### PR TITLE
fix(bin): recognize teardown work that landed under rewritten commits

### DIFF
--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1047,10 +1047,24 @@ ensure_commit_object() {
 # different ids and the revert check below could never match. It only has to be
 # consistent, since every id compared here is computed in the same repository.
 patch_id_for_commit() {
-  local commit=$1
-  git -C "$WT" show --pretty=medium --no-ext-diff --no-prefix "$commit" 2>/dev/null \
-    | git patch-id --stable 2>/dev/null \
-    | awk 'NR == 1 { print $1 }'
+  local commit=$1 tmp patch_output status
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-teardown-patch-id.XXXXXX") || return 1
+  if ! git -C "$WT" show --pretty=medium --no-ext-diff --no-prefix "$commit" > "$tmp/patch" 2>/dev/null; then
+    rm -f -- "$tmp/patch"
+    rmdir "$tmp" 2>/dev/null || true
+    return 1
+  fi
+  if ! git patch-id --stable < "$tmp/patch" > "$tmp/ids" 2>/dev/null; then
+    rm -f -- "$tmp/patch" "$tmp/ids"
+    rmdir "$tmp" 2>/dev/null || true
+    return 1
+  fi
+  patch_output=$(awk 'NR == 1 { print $1 }' "$tmp/ids")
+  status=$?
+  rm -f -- "$tmp/patch" "$tmp/ids"
+  rmdir "$tmp" 2>/dev/null || true
+  [ "$status" -eq 0 ] || return 1
+  printf '%s\n' "$patch_output"
 }
 
 # Every distinct patch id the commits <git log args...> select carry, as ONE
@@ -1061,10 +1075,104 @@ patch_id_for_commit() {
 # `git log -p` does not show) contribute nothing, which is what the reference side
 # wants: they can never prove a subject patch is present.
 patch_ids_for_log() {
-  git -C "$WT" log --format=%H --no-ext-diff --no-prefix -p "$@" 2>/dev/null \
-    | git patch-id --stable 2>/dev/null \
-    | awk 'NF { print $1 }' \
-    | sort -u
+  local tmp status
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-teardown-patch-log.XXXXXX") || return 1
+  if ! git -C "$WT" log --format=%H --no-ext-diff --no-prefix -p "$@" > "$tmp/patches" 2>/dev/null; then
+    rm -f -- "$tmp/patches"
+    rmdir "$tmp" 2>/dev/null || true
+    return 1
+  fi
+  if ! git patch-id --stable < "$tmp/patches" > "$tmp/patch-ids" 2>/dev/null; then
+    rm -f -- "$tmp/patches" "$tmp/patch-ids"
+    rmdir "$tmp" 2>/dev/null || true
+    return 1
+  fi
+  if ! awk 'NF { print $1 }' "$tmp/patch-ids" > "$tmp/ids"; then
+    rm -f -- "$tmp/patches" "$tmp/patch-ids" "$tmp/ids"
+    rmdir "$tmp" 2>/dev/null || true
+    return 1
+  fi
+  sort -u "$tmp/ids"
+  status=$?
+  rm -f -- "$tmp/patches" "$tmp/patch-ids" "$tmp/ids"
+  rmdir "$tmp" 2>/dev/null || true
+  return "$status"
+}
+
+patch_applies_to_tree() {
+  local patch=$1 tree=$2 direction=$3 tmp status
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-teardown-patch-apply.XXXXXX") || return 2
+  if ! GIT_INDEX_FILE="$tmp/index" git -C "$WT" read-tree "$tree" 2>/dev/null; then
+    rm -f -- "$tmp/index"
+    rmdir "$tmp" 2>/dev/null || true
+    return 2
+  fi
+  if [ "$direction" = reverse ]; then
+    GIT_INDEX_FILE="$tmp/index" git -C "$WT" apply --cached --check --unidiff-zero -p0 --reverse "$patch" >/dev/null 2>&1
+  else
+    GIT_INDEX_FILE="$tmp/index" git -C "$WT" apply --cached --check --unidiff-zero -p0 "$patch" >/dev/null 2>&1
+  fi
+  status=$?
+  rm -f -- "$tmp/index"
+  rmdir "$tmp" 2>/dev/null || true
+  case "$status" in
+    0) return 0 ;;
+    1) return 1 ;;
+    *) return 2 ;;
+  esac
+}
+
+patch_was_reversed_by_reference_commits() {
+  local subject=$1 reference_commits=$2 tmp parents candidate parent status
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-teardown-reverse-scan.XXXXXX") || return 2
+  if ! git -C "$WT" show --format= --binary --full-index --no-ext-diff --no-prefix "$subject" > "$tmp/patch" 2>/dev/null; then
+    rm -f -- "$tmp/patch"
+    rmdir "$tmp" 2>/dev/null || true
+    return 2
+  fi
+  while IFS= read -r candidate; do
+    [ -n "$candidate" ] || continue
+    parents=$(git -C "$WT" rev-list --parents -n 1 "$candidate" 2>/dev/null) || {
+      rm -f -- "$tmp/patch"
+      rmdir "$tmp" 2>/dev/null || true
+      return 2
+    }
+    parents=${parents#* }
+    [ "$parents" != "$candidate" ] || continue
+    for parent in $parents; do
+      patch_applies_to_tree "$tmp/patch" "$parent" reverse
+      status=$?
+      case "$status" in
+        0) ;;
+        1) continue ;;
+        *)
+          rm -f -- "$tmp/patch"
+          rmdir "$tmp" 2>/dev/null || true
+          return 2
+          ;;
+      esac
+      patch_applies_to_tree "$tmp/patch" "$candidate" forward
+      status=$?
+      case "$status" in
+        0)
+          rm -f -- "$tmp/patch"
+          rmdir "$tmp" 2>/dev/null || true
+          return 0
+          ;;
+        1) ;;
+        *)
+          rm -f -- "$tmp/patch"
+          rmdir "$tmp" 2>/dev/null || true
+          return 2
+          ;;
+      esac
+    done
+  done <<EOF
+$reference_commits
+EOF
+  rm -f -- "$tmp/patch"
+  rmdir "$tmp" 2>/dev/null || true
+  return 1
 }
 
 # The one patch-set comparison behind every landed-work patch check, so a future
@@ -1085,7 +1193,7 @@ patch_ids_for_log() {
 # commit that did touch them.
 subject_patches_are_in_reference() {
   local -a ref_args=() subject_args=() pathspecs=()
-  local past_separator=0 arg ref_ids reverted_ids subject_commits subject_paths commit patch_id path
+  local past_separator=0 arg ref_ids reverted_ids reference_commits subject_commits subject_paths commit patch_id path status
   for arg in "$@"; do
     if [ "$past_separator" = 0 ] && [ "$arg" = '::' ]; then
       past_separator=1
@@ -1100,11 +1208,7 @@ subject_patches_are_in_reference() {
   [ "${#ref_args[@]}" -gt 0 ] && [ "${#subject_args[@]}" -gt 0 ] || return 1
   subject_commits=$(git -C "$WT" log --format=%H "${subject_args[@]}" -- 2>/dev/null) || return 1
   [ -n "$subject_commits" ] || return 2
-  subject_paths=$(
-    git -C "$WT" -c core.quotePath=false log --format= --name-only "${subject_args[@]}" -- 2>/dev/null \
-      | sed '/^$/d' \
-      | sort -u
-  ) || return 1
+  subject_paths=$(git -C "$WT" -c core.quotePath=false log --format= --name-only --no-renames "${subject_args[@]}" -- 2>/dev/null) || return 1
   [ -n "$subject_paths" ] || return 1
   while IFS= read -r path; do
     [ -n "$path" ] || continue
@@ -1116,6 +1220,7 @@ EOF
   ref_ids=$(patch_ids_for_log --full-history "${ref_args[@]}" -- "${pathspecs[@]}") || return 1
   [ -n "$ref_ids" ] || return 1
   reverted_ids=$(patch_ids_for_log --full-history -R "${ref_args[@]}" -- "${pathspecs[@]}") || return 1
+  reference_commits=$(git -C "$WT" log --format=%H --full-history "${ref_args[@]}" -- "${pathspecs[@]}" 2>/dev/null) || return 1
   while IFS= read -r commit; do
     [ -n "$commit" ] || continue
     patch_id=$(patch_id_for_commit "$commit") || return 1
@@ -1124,6 +1229,9 @@ EOF
     if [ -n "$reverted_ids" ] && printf '%s\n' "$reverted_ids" | grep -qxF "$patch_id"; then
       return 1
     fi
+    patch_was_reversed_by_reference_commits "$commit" "$reference_commits"
+    status=$?
+    [ "$status" -eq 1 ] || return 1
   done <<EOF
 $subject_commits
 EOF

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1119,6 +1119,33 @@ changes_are_represented_in_tree_fail() {
   return 1
 }
 
+# The tree-representation proof behind `with-tree-proof`: is the whole
+# <pre>..<post> change still present in <tree>, at the place it landed?
+# A patch id alone cannot answer that, because a patch that landed and was then
+# reverted, partially reverted, relocated, or replaced still has its id on the
+# reference side forever.
+# Each changed path is proven on its own, by reverse-applying that path's patch
+# against a scratch index holding <tree>: reverse-apply succeeds only if <tree>
+# still contains the exact post-image lines the patch added.
+# The proof is deliberately strict in three ways a future simplification must not
+# relax.
+# It is location-preserving: `git apply` reports `Hunk #N succeeded at <line>`
+# whenever it matched at an offset, so any such line means the block was found
+# somewhere other than where it landed and the path is NOT represented (LC_ALL=C
+# pins that message to the text matched here).
+# It is terminator-aware: the per-path patch carries its `\ No newline at end of
+# file` markers and, under --binary --full-index, a literal delta for a binary
+# path, so a difference of only a trailing terminator fails the reverse-apply
+# instead of being normalized away.
+# It only ever allows on positive proof: an unreadable or empty per-path patch,
+# an unreadable scratch index, and every unexpected git failure all report "not
+# represented".
+# The one fallback arm, taken when reverse-apply fails, covers the genuine
+# superset case where <tree> kept the landed file and added unrelated lines on
+# top of it: it requires the path to be newly added by the change (absent in
+# <pre>), present as the same kind of regular blob in <post> and <tree>, textual
+# on both sides, and to have gained lines only - a single deleted line means part
+# of the landed content is gone, so it refuses.
 changes_are_represented_in_tree() {
   local pre=$1 post=$2 tree=$3 paths path tmp status pre_entry post_entry current_entry
   local post_meta current_meta post_mode post_type post_oid current_mode current_type current_oid
@@ -1320,6 +1347,13 @@ EOF
   [ "$mode" = with-tree-proof ] || return 0
   [ -n "$subject_tip" ] && [ -n "$subject_oldest" ] || return 1
   subject_base=$(git -C "$WT" rev-parse --verify "$subject_oldest^" 2>/dev/null) || return 1
+  # A subject range with an empty NET diff (a change and its revert both inside
+  # the range) has no changed path to run the per-path proof over.
+  # It is allowed only here, after the loop above already proved every subject
+  # patch - both inverse patches included - present on the reference side, and
+  # only when the reference tree still matches the subject tip over exactly those
+  # paths, so the sequence is never inferred to have landed from the empty net
+  # diff alone.
   git -C "$WT" diff --quiet --no-ext-diff --no-renames "$subject_base" "$subject_tip" -- 2>/dev/null
   status=$?
   if [ "$status" -eq 0 ]; then

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1210,6 +1210,13 @@ EOF
     IFS=$'\t' read -r current_additions current_deletions current_path <<EOF
 $current_numstat
 EOF
+    case "$current_path" in
+      '')
+        rm -f -- "$tmp/index" "$tmp/index.lock"
+        rmdir "$tmp" 2>/dev/null || true
+        return 1
+        ;;
+    esac
     case "$current_additions" in
       ''|*[!0-9]*)
         rm -f -- "$tmp/index" "$tmp/index.lock"
@@ -1256,7 +1263,7 @@ EOF
 subject_patches_are_in_reference() {
   local -a ref_args=() subject_args=() pathspecs=()
   local reference_tree=$1 past_separator=0 arg ref_ids subject_commits subject_paths commit patch_id path status
-  local subject_tip= subject_oldest= subject_base
+  local subject_tip='' subject_oldest='' subject_base
   shift
   git -C "$WT" rev-parse --verify "$reference_tree^{tree}" >/dev/null 2>&1 || return 1
   for arg in "$@"; do
@@ -1299,9 +1306,10 @@ EOF
   git -C "$WT" diff --quiet --no-ext-diff --no-renames "$subject_base" "$subject_tip" -- 2>/dev/null
   status=$?
   if [ "$status" -eq 0 ]; then
-    git -C "$WT" diff --quiet --no-ext-diff --no-renames "$subject_tip" "$reference_tree" -- \
-      "${pathspecs[@]}" 2>/dev/null
-    [ "$?" -eq 0 ] || return 1
+    if ! git -C "$WT" diff --quiet --no-ext-diff --no-renames "$subject_tip" "$reference_tree" -- \
+      "${pathspecs[@]}" 2>/dev/null; then
+      return 1
+    fi
     return 0
   fi
   [ "$status" -eq 1 ] || return 1

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1121,10 +1121,22 @@ changes_are_represented_in_tree() {
       rmdir "$tmp" 2>/dev/null || true
       return 1
     }
-    GIT_INDEX_FILE="$tmp/index" git -C "$WT" apply --cached --check --reverse -p0 "$tmp/path.patch" >/dev/null 2>&1
+    LC_ALL=C GIT_INDEX_FILE="$tmp/index" git -C "$WT" apply --cached --check --reverse --verbose -p0 \
+      "$tmp/path.patch" > /dev/null 2> "$tmp/apply-output"
     status=$?
     rm -f -- "$tmp/path.patch"
-    [ "$status" -ne 0 ] || continue
+    if [ "$status" -eq 0 ]; then
+      grep -Eq '^Hunk #[0-9]+ succeeded at ' "$tmp/apply-output"
+      status=$?
+      rm -f -- "$tmp/apply-output"
+      if [ "$status" -ne 1 ]; then
+        rm -f -- "$tmp/index" "$tmp/index.lock"
+        rmdir "$tmp" 2>/dev/null || true
+        return 1
+      fi
+      continue
+    fi
+    rm -f -- "$tmp/apply-output"
     pre_entry=$(git -C "$WT" -c core.quotePath=false ls-tree "$pre" -- ":(literal)$path" 2>/dev/null) || {
       rm -f -- "$tmp/index" "$tmp/index.lock"
       rmdir "$tmp" 2>/dev/null || true
@@ -1243,7 +1255,7 @@ EOF
 # commit that did touch them.
 subject_patches_are_in_reference() {
   local -a ref_args=() subject_args=() pathspecs=()
-  local reference_tree=$1 past_separator=0 arg ref_ids subject_commits subject_paths commit patch_id path
+  local reference_tree=$1 past_separator=0 arg ref_ids subject_commits subject_paths commit patch_id path status
   local subject_tip= subject_oldest= subject_base
   shift
   git -C "$WT" rev-parse --verify "$reference_tree^{tree}" >/dev/null 2>&1 || return 1
@@ -1284,6 +1296,10 @@ $subject_commits
 EOF
   [ -n "$subject_tip" ] && [ -n "$subject_oldest" ] || return 1
   subject_base=$(git -C "$WT" rev-parse --verify "$subject_oldest^" 2>/dev/null) || return 1
+  git -C "$WT" diff --quiet --no-ext-diff --no-renames "$subject_base" "$subject_tip" -- 2>/dev/null
+  status=$?
+  [ "$status" -ne 0 ] || return 0
+  [ "$status" -eq 1 ] || return 1
   changes_are_represented_in_tree "$subject_base" "$subject_tip" "$reference_tree"
 }
 

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1098,13 +1098,14 @@ patch_ids_for_log() {
 }
 
 changes_are_represented_in_tree() {
-  local pre=$1 post=$2 tree=$3 paths path tmp pre_entry post_entry current_entry
-  local pre_meta post_meta current_meta pre_mode post_mode current_mode pre_oid post_oid current_oid
-  local numstat current_numstat status added_file
-  paths=$(git -C "$WT" -c core.quotePath=false diff --name-only --no-renames "$pre" "$post" -- 2>/dev/null) || return 1
-  [ -n "$paths" ] || return 1
+  local pre=$1 post=$2 tree=$3 tmp status
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-teardown-current-tree.XXXXXX") || return 1
   if ! git -C "$WT" diff --binary --full-index --no-ext-diff --no-prefix --no-renames "$pre" "$post" -- > "$tmp/aggregate.patch" 2>/dev/null; then
+    rm -f -- "$tmp/aggregate.patch"
+    rmdir "$tmp" 2>/dev/null || true
+    return 1
+  fi
+  if [ ! -s "$tmp/aggregate.patch" ]; then
     rm -f -- "$tmp/aggregate.patch"
     rmdir "$tmp" 2>/dev/null || true
     return 1
@@ -1117,139 +1118,8 @@ changes_are_represented_in_tree() {
   GIT_INDEX_FILE="$tmp/index" git -C "$WT" apply --cached --check --reverse -p0 "$tmp/aggregate.patch" >/dev/null 2>&1
   status=$?
   rm -f -- "$tmp/aggregate.patch" "$tmp/index" "$tmp/index.lock"
-  if [ "$status" -eq 0 ]; then
-    rmdir "$tmp" 2>/dev/null || true
-    return 0
-  fi
-  while IFS= read -r path; do
-    [ -n "$path" ] || continue
-    pre_entry=$(git -C "$WT" -c core.quotePath=false ls-tree "$pre" -- ":(literal)$path" 2>/dev/null) || {
-      rmdir "$tmp" 2>/dev/null || true
-      return 1
-    }
-    post_entry=$(git -C "$WT" -c core.quotePath=false ls-tree "$post" -- ":(literal)$path" 2>/dev/null) || {
-      rmdir "$tmp" 2>/dev/null || true
-      return 1
-    }
-    current_entry=$(git -C "$WT" -c core.quotePath=false ls-tree "$tree" -- ":(literal)$path" 2>/dev/null) || {
-      rmdir "$tmp" 2>/dev/null || true
-      return 1
-    }
-    if [ -z "$post_entry" ]; then
-      [ -z "$current_entry" ] || {
-        rmdir "$tmp" 2>/dev/null || true
-        return 1
-      }
-      continue
-    fi
-    [ -n "$current_entry" ] || {
-      rmdir "$tmp" 2>/dev/null || true
-      return 1
-    }
-    pre_meta=${pre_entry%%$'\t'*}
-    post_meta=${post_entry%%$'\t'*}
-    current_meta=${current_entry%%$'\t'*}
-    read -r pre_mode _ pre_oid <<EOF
-$pre_meta
-EOF
-    read -r post_mode _ post_oid <<EOF
-$post_meta
-EOF
-    read -r current_mode _ current_oid <<EOF
-$current_meta
-EOF
-    [ -n "$post_oid" ] && [ -n "$current_oid" ] && [ "$post_mode" = "$current_mode" ] || {
-      rmdir "$tmp" 2>/dev/null || true
-      return 1
-    }
-    [ "$post_oid" != "$current_oid" ] || continue
-    numstat=$(git -C "$WT" diff --numstat --no-renames "$pre" "$post" -- ":(literal)$path" 2>/dev/null) || {
-      rmdir "$tmp" 2>/dev/null || true
-      return 1
-    }
-    case "$numstat" in
-      -$'\t'-$'\t'*)
-        rmdir "$tmp" 2>/dev/null || true
-        return 1
-        ;;
-    esac
-    added_file=0
-    if [ -n "$pre_oid" ]; then
-      if ! git -C "$WT" cat-file blob "$pre_oid" > "$tmp/pre" 2>/dev/null; then
-        rm -f -- "$tmp/pre"
-        rmdir "$tmp" 2>/dev/null || true
-        return 1
-      fi
-    else
-      added_file=1
-      : > "$tmp/pre"
-    fi
-    if ! git -C "$WT" cat-file blob "$post_oid" > "$tmp/post" 2>/dev/null; then
-      rm -f -- "$tmp/pre" "$tmp/post"
-      rmdir "$tmp" 2>/dev/null || true
-      return 1
-    fi
-    if ! git -C "$WT" cat-file blob "$current_oid" > "$tmp/current" 2>/dev/null; then
-      rm -f -- "$tmp/pre" "$tmp/post" "$tmp/current"
-      rmdir "$tmp" 2>/dev/null || true
-      return 1
-    fi
-    git -C "$WT" diff --no-index --numstat --no-ext-diff "$tmp/post" "$tmp/current" > "$tmp/current.numstat" 2>/dev/null
-    status=$?
-    [ "$status" -le 1 ] || {
-      rm -f -- "$tmp/pre" "$tmp/post" "$tmp/current" "$tmp/current.numstat"
-      rmdir "$tmp" 2>/dev/null || true
-      return 1
-    }
-    current_numstat=$(cat "$tmp/current.numstat") || {
-      rm -f -- "$tmp/pre" "$tmp/post" "$tmp/current" "$tmp/current.numstat"
-      rmdir "$tmp" 2>/dev/null || true
-      return 1
-    }
-    case "$current_numstat" in
-      -$'\t'-$'\t'*)
-        rm -f -- "$tmp/pre" "$tmp/post" "$tmp/current" "$tmp/current.numstat"
-        rmdir "$tmp" 2>/dev/null || true
-        return 1
-        ;;
-    esac
-    if ! awk -v added_file="$added_file" '
-      FILENAME == ARGV[1] { before[$0]++; next }
-      FILENAME == ARGV[2] { after[$0]++; next }
-      FILENAME == ARGV[3] { current[$0]++; current_lines++; next }
-      END {
-        for (line in before) {
-          if (before[line] > after[line] && current[line] > after[line]) bad = 1
-          if (before[line] != current[line]) changed = 1
-        }
-        for (line in after) {
-          added = after[line] - before[line]
-          if (added > 0) {
-            present = current[line] - before[line]
-            if (present < 0) present = 0
-            if (present > added) present = added
-            retained += present
-          }
-          if (after[line] != current[line]) changed = 1
-        }
-        for (line in current) {
-          if (current[line] != after[line]) changed = 1
-        }
-        if (!changed || bad) exit 1
-        if (added_file && retained == 0 && current_lines > 0) exit 0
-        exit 1
-      }
-    ' "$tmp/pre" "$tmp/post" "$tmp/current"; then
-      rm -f -- "$tmp/pre" "$tmp/post" "$tmp/current" "$tmp/current.numstat"
-      rmdir "$tmp" 2>/dev/null || true
-      return 1
-    fi
-    rm -f -- "$tmp/pre" "$tmp/post" "$tmp/current" "$tmp/current.numstat"
-  done <<EOF
-$paths
-EOF
   rmdir "$tmp" 2>/dev/null || true
-  return 0
+  [ "$status" -eq 0 ]
 }
 
 # The one patch-set comparison behind every landed-work patch check, so a future

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1097,21 +1097,37 @@ patch_ids_for_log() {
   return "$status"
 }
 
-commit_paths_are_represented_in_tree() {
-  local commit=$1 tree=$2 paths path tmp parent pre_entry post_entry current_entry
+changes_are_represented_in_tree() {
+  local pre=$1 post=$2 tree=$3 paths path tmp pre_entry post_entry current_entry
   local pre_meta post_meta current_meta pre_mode post_mode current_mode pre_oid post_oid current_oid
-  local numstat status
-  paths=$(git -C "$WT" -c core.quotePath=false show --format= --name-only --no-renames "$commit" -- 2>/dev/null) || return 1
+  local numstat current_numstat status added_file
+  paths=$(git -C "$WT" -c core.quotePath=false diff --name-only --no-renames "$pre" "$post" -- 2>/dev/null) || return 1
   [ -n "$paths" ] || return 1
-  parent=$(git -C "$WT" rev-parse --verify "$commit^" 2>/dev/null) || return 1
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-teardown-current-tree.XXXXXX") || return 1
+  if ! git -C "$WT" diff --binary --full-index --no-ext-diff --no-prefix --no-renames "$pre" "$post" -- > "$tmp/aggregate.patch" 2>/dev/null; then
+    rm -f -- "$tmp/aggregate.patch"
+    rmdir "$tmp" 2>/dev/null || true
+    return 1
+  fi
+  if ! GIT_INDEX_FILE="$tmp/index" git -C "$WT" read-tree "$tree" 2>/dev/null; then
+    rm -f -- "$tmp/aggregate.patch" "$tmp/index" "$tmp/index.lock"
+    rmdir "$tmp" 2>/dev/null || true
+    return 1
+  fi
+  GIT_INDEX_FILE="$tmp/index" git -C "$WT" apply --cached --check --reverse -p0 "$tmp/aggregate.patch" >/dev/null 2>&1
+  status=$?
+  rm -f -- "$tmp/aggregate.patch" "$tmp/index" "$tmp/index.lock"
+  if [ "$status" -eq 0 ]; then
+    rmdir "$tmp" 2>/dev/null || true
+    return 0
+  fi
   while IFS= read -r path; do
     [ -n "$path" ] || continue
-    pre_entry=$(git -C "$WT" -c core.quotePath=false ls-tree "$parent" -- ":(literal)$path" 2>/dev/null) || {
+    pre_entry=$(git -C "$WT" -c core.quotePath=false ls-tree "$pre" -- ":(literal)$path" 2>/dev/null) || {
       rmdir "$tmp" 2>/dev/null || true
       return 1
     }
-    post_entry=$(git -C "$WT" -c core.quotePath=false ls-tree "$commit" -- ":(literal)$path" 2>/dev/null) || {
+    post_entry=$(git -C "$WT" -c core.quotePath=false ls-tree "$post" -- ":(literal)$path" 2>/dev/null) || {
       rmdir "$tmp" 2>/dev/null || true
       return 1
     }
@@ -1147,7 +1163,7 @@ EOF
       return 1
     }
     [ "$post_oid" != "$current_oid" ] || continue
-    numstat=$(git -C "$WT" diff --numstat --no-renames "$parent" "$commit" -- ":(literal)$path" 2>/dev/null) || {
+    numstat=$(git -C "$WT" diff --numstat --no-renames "$pre" "$post" -- ":(literal)$path" 2>/dev/null) || {
       rmdir "$tmp" 2>/dev/null || true
       return 1
     }
@@ -1157,52 +1173,78 @@ EOF
         return 1
         ;;
     esac
-    if ! git -C "$WT" diff --unified=0 --no-ext-diff --no-renames "$parent" "$commit" -- ":(literal)$path" > "$tmp/original.diff" 2>/dev/null; then
-      rm -f -- "$tmp/original.diff"
-      rmdir "$tmp" 2>/dev/null || true
-      return 1
+    added_file=0
+    if [ -n "$pre_oid" ]; then
+      if ! git -C "$WT" cat-file blob "$pre_oid" > "$tmp/pre" 2>/dev/null; then
+        rm -f -- "$tmp/pre"
+        rmdir "$tmp" 2>/dev/null || true
+        return 1
+      fi
+    else
+      added_file=1
+      : > "$tmp/pre"
     fi
     if ! git -C "$WT" cat-file blob "$post_oid" > "$tmp/post" 2>/dev/null; then
-      rm -f -- "$tmp/original.diff" "$tmp/post"
+      rm -f -- "$tmp/pre" "$tmp/post"
       rmdir "$tmp" 2>/dev/null || true
       return 1
     fi
     if ! git -C "$WT" cat-file blob "$current_oid" > "$tmp/current" 2>/dev/null; then
-      rm -f -- "$tmp/original.diff" "$tmp/post" "$tmp/current"
+      rm -f -- "$tmp/pre" "$tmp/post" "$tmp/current"
       rmdir "$tmp" 2>/dev/null || true
       return 1
     fi
-    git -C "$WT" diff --no-index --unified=0 --no-ext-diff --no-prefix "$tmp/post" "$tmp/current" > "$tmp/current.diff" 2>/dev/null
+    git -C "$WT" diff --no-index --numstat --no-ext-diff "$tmp/post" "$tmp/current" > "$tmp/current.numstat" 2>/dev/null
     status=$?
     [ "$status" -le 1 ] || {
-      rm -f -- "$tmp/original.diff" "$tmp/post" "$tmp/current" "$tmp/current.diff"
+      rm -f -- "$tmp/pre" "$tmp/post" "$tmp/current" "$tmp/current.numstat"
       rmdir "$tmp" 2>/dev/null || true
       return 1
     }
-    if ! awk '
-      FNR == NR {
-        if ($0 ~ /^-/ && $0 !~ /^--- /) original_removed[substr($0, 2)] = 1
-        next
+    current_numstat=$(cat "$tmp/current.numstat") || {
+      rm -f -- "$tmp/pre" "$tmp/post" "$tmp/current" "$tmp/current.numstat"
+      rmdir "$tmp" 2>/dev/null || true
+      return 1
+    }
+    case "$current_numstat" in
+      -$'\t'-$'\t'*)
+        rm -f -- "$tmp/pre" "$tmp/post" "$tmp/current" "$tmp/current.numstat"
+        rmdir "$tmp" 2>/dev/null || true
+        return 1
+        ;;
+    esac
+    if ! awk -v added_file="$added_file" '
+      FILENAME == ARGV[1] { before[$0]++; next }
+      FILENAME == ARGV[2] { after[$0]++; next }
+      FILENAME == ARGV[3] { current[$0]++; current_lines++; next }
+      END {
+        for (line in before) {
+          if (before[line] > after[line] && current[line] > after[line]) bad = 1
+          if (before[line] != current[line]) changed = 1
+        }
+        for (line in after) {
+          added = after[line] - before[line]
+          if (added > 0) {
+            present = current[line] - before[line]
+            if (present < 0) present = 0
+            if (present > added) present = added
+            retained += present
+          }
+          if (after[line] != current[line]) changed = 1
+        }
+        for (line in current) {
+          if (current[line] != after[line]) changed = 1
+        }
+        if (!changed || bad) exit 1
+        if (added_file && retained == 0 && current_lines > 0) exit 0
+        exit 1
       }
-      function finish_hunk() {
-        if (in_hunk && removed > added) bad = 1
-        removed = 0
-        added = 0
-      }
-      /^@@ / { finish_hunk(); in_hunk = 1; next }
-      in_hunk && /^-/ && $0 !~ /^--- / { removed++; next }
-      in_hunk && /^\+/ && $0 !~ /^\+\+\+ / {
-        added++
-        if (substr($0, 2) in original_removed) bad = 1
-        next
-      }
-      END { finish_hunk(); exit bad ? 1 : 0 }
-    ' "$tmp/original.diff" "$tmp/current.diff"; then
-      rm -f -- "$tmp/original.diff" "$tmp/post" "$tmp/current" "$tmp/current.diff"
+    ' "$tmp/pre" "$tmp/post" "$tmp/current"; then
+      rm -f -- "$tmp/pre" "$tmp/post" "$tmp/current" "$tmp/current.numstat"
       rmdir "$tmp" 2>/dev/null || true
       return 1
     fi
-    rm -f -- "$tmp/original.diff" "$tmp/post" "$tmp/current" "$tmp/current.diff"
+    rm -f -- "$tmp/pre" "$tmp/post" "$tmp/current" "$tmp/current.numstat"
   done <<EOF
 $paths
 EOF
@@ -1229,6 +1271,7 @@ EOF
 subject_patches_are_in_reference() {
   local -a ref_args=() subject_args=() pathspecs=()
   local reference_tree=$1 past_separator=0 arg ref_ids subject_commits subject_paths commit patch_id path
+  local subject_tip= subject_oldest= subject_base
   shift
   git -C "$WT" rev-parse --verify "$reference_tree^{tree}" >/dev/null 2>&1 || return 1
   for arg in "$@"; do
@@ -1258,13 +1301,17 @@ EOF
   [ -n "$ref_ids" ] || return 1
   while IFS= read -r commit; do
     [ -n "$commit" ] || continue
+    [ -n "$subject_tip" ] || subject_tip=$commit
+    subject_oldest=$commit
     patch_id=$(patch_id_for_commit "$commit") || return 1
     [ -n "$patch_id" ] || return 1
     printf '%s\n' "$ref_ids" | grep -qxF "$patch_id" || return 1
-    commit_paths_are_represented_in_tree "$commit" "$reference_tree" || return 1
   done <<EOF
 $subject_commits
 EOF
+  [ -n "$subject_tip" ] && [ -n "$subject_oldest" ] || return 1
+  subject_base=$(git -C "$WT" rev-parse --verify "$subject_oldest^" 2>/dev/null) || return 1
+  changes_are_represented_in_tree "$subject_base" "$subject_tip" "$reference_tree"
 }
 
 unpushed_patches_are_in_pr_head() {

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1047,29 +1047,55 @@ patch_id_for_commit() {
     | awk 'NR == 1 { print $1 }'
 }
 
-unpushed_patches_are_in_pr_head() {
-  local pr_head=$1 current base pr_patch_ids commit patch_id unpushed
-  current=$(git -C "$WT" rev-parse --verify HEAD 2>/dev/null) || return 1
-  base=$(git -C "$WT" merge-base "$current" "$pr_head" 2>/dev/null) || return 1
-  pr_patch_ids=$(
-    git -C "$WT" log --format=%H "$base..$pr_head" -- 2>/dev/null \
+# The one patch-set comparison behind every landed-work patch check, so a future
+# fix to it can never land on only one copy. Takes the reference-side `git log`
+# arguments, the literal separator `::`, then the subject-side ones. Returns 0
+# when EVERY subject commit's patch is already present on the reference side, 2
+# when the subject side is empty so there is nothing to prove (the caller decides
+# what that means), and 1 for everything else: an unreadable git log, a reference
+# side that contributes no patch ids at all, an empty or unreadable subject patch
+# id, or any subject commit whose patch is missing.
+subject_patches_are_in_reference() {
+  local -a ref_args=() subject_args=()
+  local past_separator=0 arg ref_ids subject_commits commit patch_id
+  for arg in "$@"; do
+    if [ "$past_separator" = 0 ] && [ "$arg" = '::' ]; then
+      past_separator=1
+      continue
+    fi
+    if [ "$past_separator" = 0 ]; then
+      ref_args+=("$arg")
+    else
+      subject_args+=("$arg")
+    fi
+  done
+  [ "${#ref_args[@]}" -gt 0 ] && [ "${#subject_args[@]}" -gt 0 ] || return 1
+  subject_commits=$(git -C "$WT" log --format=%H "${subject_args[@]}" -- 2>/dev/null) || return 1
+  [ -n "$subject_commits" ] || return 2
+  ref_ids=$(
+    git -C "$WT" log --format=%H "${ref_args[@]}" -- 2>/dev/null \
       | while IFS= read -r commit; do
           patch_id_for_commit "$commit"
         done \
       | sed '/^$/d' \
       | sort -u
   ) || return 1
-  [ -n "$pr_patch_ids" ] || return 1
-  unpushed=$(git -C "$WT" log --format=%H HEAD --not --remotes -- 2>/dev/null) || return 1
-  [ -n "$unpushed" ] || return 1
+  [ -n "$ref_ids" ] || return 1
   while IFS= read -r commit; do
     [ -n "$commit" ] || continue
     patch_id=$(patch_id_for_commit "$commit") || return 1
     [ -n "$patch_id" ] || return 1
-    printf '%s\n' "$pr_patch_ids" | grep -qxF "$patch_id" || return 1
+    printf '%s\n' "$ref_ids" | grep -qxF "$patch_id" || return 1
   done <<EOF
-$unpushed
+$subject_commits
 EOF
+}
+
+unpushed_patches_are_in_pr_head() {
+  local pr_head=$1 current base
+  current=$(git -C "$WT" rev-parse --verify HEAD 2>/dev/null) || return 1
+  base=$(git -C "$WT" merge-base "$current" "$pr_head" 2>/dev/null) || return 1
+  subject_patches_are_in_reference "$base..$pr_head" :: HEAD --not --remotes
 }
 
 # Is the worktree's PR merged for local work contained in that PR? Resolves the
@@ -1146,27 +1172,11 @@ content_in_ref() {
 # inconclusive. Anything short of a complete match returns non-zero, so genuinely
 # unlanded work still refuses.
 patches_are_in_ref() {
-  local ref=$1 local_commits landed_ids commit patch_id
+  local ref=$1 status
   [ -n "$ref" ] || return 1
-  local_commits=$(git -C "$WT" log --format=%H HEAD --not "$ref" -- 2>/dev/null) || return 1
-  [ -n "$local_commits" ] || return 0
-  landed_ids=$(
-    git -C "$WT" log --format=%H "$ref" --not HEAD -- 2>/dev/null \
-      | while IFS= read -r commit; do
-          patch_id_for_commit "$commit"
-        done \
-      | sed '/^$/d' \
-      | sort -u
-  ) || return 1
-  [ -n "$landed_ids" ] || return 1
-  while IFS= read -r commit; do
-    [ -n "$commit" ] || continue
-    patch_id=$(patch_id_for_commit "$commit") || return 1
-    [ -n "$patch_id" ] || return 1
-    printf '%s\n' "$landed_ids" | grep -qxF "$patch_id" || return 1
-  done <<EOF
-$local_commits
-EOF
+  subject_patches_are_in_reference "$ref" --not HEAD :: HEAD --not "$ref"
+  status=$?
+  [ "$status" -eq 0 ] || [ "$status" -eq 2 ]
 }
 
 # Has the worktree's committed work actually LANDED, though its commits are not
@@ -1426,7 +1436,7 @@ teardown_treehouse_return() {
 }
 
 validate_worktree_teardown_safety() {
-  local dirty_raw dirty unpushed_raw unpushed DEFAULT unmerged_raw unmerged branch
+  local dirty_raw dirty unpushed_raw unpushed DEFAULT unmerged_raw unmerged branch landed_by_patch
   [ -d "$WT" ] || return 0
   [ "$FORCE" != "--force" ] || return 0
   case "$KIND" in
@@ -1468,8 +1478,16 @@ validate_worktree_teardown_safety() {
     # by the rebase that landed them, so consult patch equivalence before refusing.
     # It clears only commits it can prove are already in $DEFAULT; the uncommitted
     # check below is untouched, and anything unproven still refuses.
+    landed_by_patch=0
     if [ -n "$unmerged" ] && patches_are_in_ref "$DEFAULT"; then
       unmerged=
+      landed_by_patch=1
+    fi
+    if [ "$landed_by_patch" = 1 ] && [ -n "$dirty" ]; then
+      echo "REFUSED: local-only worktree $WT has uncommitted changes; its commits already landed in $DEFAULT." >&2
+      echo "uncommitted changes present" >&2
+      echo "Commit the uncommitted changes (or get the captain's explicit OK to discard, then --force)." >&2
+      return 1
     fi
     if [ -n "$dirty" ] || [ -n "$unmerged" ]; then
       echo "REFUSED: local-only worktree $WT has work not yet merged into $DEFAULT and not on any remote." >&2

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -11,7 +11,8 @@
 # normal ship task whose commits are not so reachable - when its PR is merged and
 # GitHub reports a PR head that contains the current local work, its content is
 # already present in the up-to-date default branch, or every commit that branch
-# cannot reach is already present there as a PATCH. This recognizes the common
+# cannot reach is already present there as a PATCH that branch has not since
+# reverted. This recognizes the common
 # squash-merge-then-delete-branch flow, where the branch's own commits live nowhere
 # on a remote yet the change is fully in main, and the rebase case, where landing
 # rewrote every commit so no reachability test can ever succeed again (see
@@ -1041,24 +1042,50 @@ ensure_commit_object() {
   git -C "$WT" cat-file -e "$commit^{commit}" 2>/dev/null
 }
 
+# --no-prefix everywhere a patch id is taken: the default a/ and b/ prefixes swap
+# places under `-R`, so a patch and its own reverse would otherwise hash to
+# different ids and the revert check below could never match. It only has to be
+# consistent, since every id compared here is computed in the same repository.
 patch_id_for_commit() {
   local commit=$1
-  git -C "$WT" show --pretty=medium --no-ext-diff "$commit" 2>/dev/null \
+  git -C "$WT" show --pretty=medium --no-ext-diff --no-prefix "$commit" 2>/dev/null \
     | git patch-id --stable 2>/dev/null \
     | awk 'NR == 1 { print $1 }'
+}
+
+# Every distinct patch id the commits <git log args...> select carry, as ONE
+# `git log -p | git patch-id` pipeline - the batching `git cherry` itself uses -
+# rather than three processes per commit, so a reference side of any length costs
+# two processes instead of growing with the default branch's history. Commits that
+# emit no diff (empty commits, and merge commits whose conflict resolution
+# `git log -p` does not show) contribute nothing, which is what the reference side
+# wants: they can never prove a subject patch is present.
+patch_ids_for_log() {
+  git -C "$WT" log --format=%H --no-ext-diff --no-prefix -p "$@" 2>/dev/null \
+    | git patch-id --stable 2>/dev/null \
+    | awk 'NF { print $1 }' \
+    | sort -u
 }
 
 # The one patch-set comparison behind every landed-work patch check, so a future
 # fix to it can never land on only one copy. Takes the reference-side `git log`
 # arguments, the literal separator `::`, then the subject-side ones. Returns 0
-# when EVERY subject commit's patch is already present on the reference side, 2
-# when the subject side is empty so there is nothing to prove (the caller decides
-# what that means), and 1 for everything else: an unreadable git log, a reference
+# when EVERY subject commit's patch is already present on the reference side and
+# none of them is undone there again, 2 when the subject side is empty so there is
+# nothing to prove (the caller decides what that means), and 1 for everything
+# else: an unreadable git log, a subject side that touches no path, a reference
 # side that contributes no patch ids at all, an empty or unreadable subject patch
-# id, or any subject commit whose patch is missing.
+# id, any subject commit whose patch is missing, or any subject patch the
+# reference side also carries in REVERSE (the landed-then-reverted case, where the
+# work is no longer present and discarding it would lose it).
+# The reference scan is bounded to the paths the subject commits touch: a commit
+# can only carry a subject commit's patch if it touches exactly those paths, so
+# this can never drop a match, and it keeps unrelated default-branch history out
+# of the comparison. --full-history keeps path limiting from simplifying away a
+# commit that did touch them.
 subject_patches_are_in_reference() {
-  local -a ref_args=() subject_args=()
-  local past_separator=0 arg ref_ids subject_commits commit patch_id
+  local -a ref_args=() subject_args=() pathspecs=()
+  local past_separator=0 arg ref_ids reverted_ids subject_commits subject_paths commit patch_id path
   for arg in "$@"; do
     if [ "$past_separator" = 0 ] && [ "$arg" = '::' ]; then
       past_separator=1
@@ -1073,20 +1100,30 @@ subject_patches_are_in_reference() {
   [ "${#ref_args[@]}" -gt 0 ] && [ "${#subject_args[@]}" -gt 0 ] || return 1
   subject_commits=$(git -C "$WT" log --format=%H "${subject_args[@]}" -- 2>/dev/null) || return 1
   [ -n "$subject_commits" ] || return 2
-  ref_ids=$(
-    git -C "$WT" log --format=%H "${ref_args[@]}" -- 2>/dev/null \
-      | while IFS= read -r commit; do
-          patch_id_for_commit "$commit"
-        done \
+  subject_paths=$(
+    git -C "$WT" -c core.quotePath=false log --format= --name-only "${subject_args[@]}" -- 2>/dev/null \
       | sed '/^$/d' \
       | sort -u
   ) || return 1
+  [ -n "$subject_paths" ] || return 1
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    pathspecs+=(":(literal)$path")
+  done <<EOF
+$subject_paths
+EOF
+  [ "${#pathspecs[@]}" -gt 0 ] || return 1
+  ref_ids=$(patch_ids_for_log --full-history "${ref_args[@]}" -- "${pathspecs[@]}") || return 1
   [ -n "$ref_ids" ] || return 1
+  reverted_ids=$(patch_ids_for_log --full-history -R "${ref_args[@]}" -- "${pathspecs[@]}") || return 1
   while IFS= read -r commit; do
     [ -n "$commit" ] || continue
     patch_id=$(patch_id_for_commit "$commit") || return 1
     [ -n "$patch_id" ] || return 1
     printf '%s\n' "$ref_ids" | grep -qxF "$patch_id" || return 1
+    if [ -n "$reverted_ids" ] && printf '%s\n' "$reverted_ids" | grep -qxF "$patch_id"; then
+      return 1
+    fi
   done <<EOF
 $subject_commits
 EOF
@@ -1169,9 +1206,10 @@ content_in_ref() {
 # Deliberately strict, so it can only ever turn a refusal into an allow on proof:
 # EVERY unreachable commit must match, an unreadable or empty patch (an empty
 # commit, or a merge commit, whose conflict resolution `git show` does not emit)
-# never counts as landed, and a ref that contributes no patches at all is
-# inconclusive. Anything short of a complete match returns non-zero, so genuinely
-# unlanded work still refuses.
+# never counts as landed, a patch <ref> carries in reverse as well (it landed and
+# was then reverted, so the work is no longer there) does not count either, and a
+# ref that contributes no patches at all is inconclusive. Anything short of a
+# complete match returns non-zero, so genuinely unlanded work still refuses.
 patches_are_in_ref() {
   local ref=$1 status
   [ -n "$ref" ] || return 1

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -17,6 +17,17 @@
 # on a remote yet the change is fully in main, and the rebase case, where landing
 # rewrote every commit so no reachability test can ever succeed again (see
 # patches_are_in_ref).
+# The merged-PR path and the default-branch patch path deliberately DIFFER, and a
+# future reader must not "unify" them.
+# The merged-PR path is patch-id containment only: every unpushed commit's patch
+# must appear in the PR head, and that is the whole test.
+# That path is already anchored by a merged PR, whose head is expected to keep
+# evolving past the local commits under review fixes and rewrites, so demanding
+# the local change still be present verbatim in the PR head's tree would refuse
+# work that genuinely landed.
+# The default-branch patch path additionally requires the tree-representation
+# proof, because nothing else there rules out a patch that landed and was then
+# reverted, partially reverted, relocated, or replaced.
 # The PR itself is resolved from the task's recorded pr= when present, or - when
 # no pr= was ever recorded (e.g. a yolo-authorized merge on a repo with no PR CI,
 # where the usual "checks green" fm-pr-check.sh trigger never fires) - by looking
@@ -1097,6 +1108,17 @@ patch_ids_for_log() {
   return "$status"
 }
 
+# The single teardown-and-refuse step every failing arm of
+# changes_are_represented_in_tree takes: remove the scratch index and its
+# directory, then report "not represented". Always returns 1, so each arm is one
+# call plus its own `return 1` and no copy of the cleanup can drift.
+changes_are_represented_in_tree_fail() {
+  local tmp=$1
+  rm -f -- "$tmp/index" "$tmp/index.lock"
+  rmdir "$tmp" 2>/dev/null || true
+  return 1
+}
+
 changes_are_represented_in_tree() {
   local pre=$1 post=$2 tree=$3 paths path tmp status pre_entry post_entry current_entry
   local post_meta current_meta post_mode post_type post_oid current_mode current_type current_oid
@@ -1105,22 +1127,21 @@ changes_are_represented_in_tree() {
   [ -n "$paths" ] || return 1
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-teardown-current-tree.XXXXXX") || return 1
   if ! GIT_INDEX_FILE="$tmp/index" git -C "$WT" read-tree "$tree" 2>/dev/null; then
-    rm -f -- "$tmp/index" "$tmp/index.lock"
-    rmdir "$tmp" 2>/dev/null || true
+    changes_are_represented_in_tree_fail "$tmp"
     return 1
   fi
   while IFS= read -r path; do
     [ -n "$path" ] || continue
     if ! git -C "$WT" diff --binary --full-index --no-ext-diff --no-prefix --no-renames "$pre" "$post" -- ":(literal)$path" > "$tmp/path.patch" 2>/dev/null; then
-      rm -f -- "$tmp/path.patch" "$tmp/index" "$tmp/index.lock"
-      rmdir "$tmp" 2>/dev/null || true
+      rm -f -- "$tmp/path.patch"
+      changes_are_represented_in_tree_fail "$tmp"
       return 1
     fi
-    [ -s "$tmp/path.patch" ] || {
-      rm -f -- "$tmp/path.patch" "$tmp/index" "$tmp/index.lock"
-      rmdir "$tmp" 2>/dev/null || true
+    if [ ! -s "$tmp/path.patch" ]; then
+      rm -f -- "$tmp/path.patch"
+      changes_are_represented_in_tree_fail "$tmp"
       return 1
-    }
+    fi
     LC_ALL=C GIT_INDEX_FILE="$tmp/index" git -C "$WT" apply --cached --check --reverse --verbose -p0 \
       "$tmp/path.patch" > /dev/null 2> "$tmp/apply-output"
     status=$?
@@ -1130,36 +1151,30 @@ changes_are_represented_in_tree() {
       status=$?
       rm -f -- "$tmp/apply-output"
       if [ "$status" -ne 1 ]; then
-        rm -f -- "$tmp/index" "$tmp/index.lock"
-        rmdir "$tmp" 2>/dev/null || true
+        changes_are_represented_in_tree_fail "$tmp"
         return 1
       fi
       continue
     fi
     rm -f -- "$tmp/apply-output"
     pre_entry=$(git -C "$WT" -c core.quotePath=false ls-tree "$pre" -- ":(literal)$path" 2>/dev/null) || {
-      rm -f -- "$tmp/index" "$tmp/index.lock"
-      rmdir "$tmp" 2>/dev/null || true
+      changes_are_represented_in_tree_fail "$tmp"
       return 1
     }
     [ -z "$pre_entry" ] || {
-      rm -f -- "$tmp/index" "$tmp/index.lock"
-      rmdir "$tmp" 2>/dev/null || true
+      changes_are_represented_in_tree_fail "$tmp"
       return 1
     }
     post_entry=$(git -C "$WT" -c core.quotePath=false ls-tree "$post" -- ":(literal)$path" 2>/dev/null) || {
-      rm -f -- "$tmp/index" "$tmp/index.lock"
-      rmdir "$tmp" 2>/dev/null || true
+      changes_are_represented_in_tree_fail "$tmp"
       return 1
     }
     current_entry=$(git -C "$WT" -c core.quotePath=false ls-tree "$tree" -- ":(literal)$path" 2>/dev/null) || {
-      rm -f -- "$tmp/index" "$tmp/index.lock"
-      rmdir "$tmp" 2>/dev/null || true
+      changes_are_represented_in_tree_fail "$tmp"
       return 1
     }
     [ -n "$post_entry" ] && [ -n "$current_entry" ] || {
-      rm -f -- "$tmp/index" "$tmp/index.lock"
-      rmdir "$tmp" 2>/dev/null || true
+      changes_are_represented_in_tree_fail "$tmp"
       return 1
     }
     post_meta=${post_entry%%$'\t'*}
@@ -1173,37 +1188,31 @@ EOF
     case "$post_mode:$post_type:$current_mode:$current_type" in
       100644:blob:100644:blob|100755:blob:100755:blob) ;;
       *)
-        rm -f -- "$tmp/index" "$tmp/index.lock"
-        rmdir "$tmp" 2>/dev/null || true
+        changes_are_represented_in_tree_fail "$tmp"
         return 1
         ;;
     esac
     [ -n "$post_oid" ] && [ -n "$current_oid" ] || {
-      rm -f -- "$tmp/index" "$tmp/index.lock"
-      rmdir "$tmp" 2>/dev/null || true
+      changes_are_represented_in_tree_fail "$tmp"
       return 1
     }
     numstat=$(git -C "$WT" diff --numstat --no-renames "$pre" "$post" -- ":(literal)$path" 2>/dev/null) || {
-      rm -f -- "$tmp/index" "$tmp/index.lock"
-      rmdir "$tmp" 2>/dev/null || true
+      changes_are_represented_in_tree_fail "$tmp"
       return 1
     }
     current_numstat=$(git -C "$WT" diff --numstat --no-renames "$post" "$tree" -- ":(literal)$path" 2>/dev/null) || {
-      rm -f -- "$tmp/index" "$tmp/index.lock"
-      rmdir "$tmp" 2>/dev/null || true
+      changes_are_represented_in_tree_fail "$tmp"
       return 1
     }
     case "$numstat" in
       -$'\t'-$'\t'*)
-        rm -f -- "$tmp/index" "$tmp/index.lock"
-        rmdir "$tmp" 2>/dev/null || true
+        changes_are_represented_in_tree_fail "$tmp"
         return 1
         ;;
     esac
     case "$current_numstat" in
       -$'\t'-$'\t'*)
-        rm -f -- "$tmp/index" "$tmp/index.lock"
-        rmdir "$tmp" 2>/dev/null || true
+        changes_are_represented_in_tree_fail "$tmp"
         return 1
         ;;
     esac
@@ -1212,28 +1221,24 @@ $current_numstat
 EOF
     case "$current_path" in
       '')
-        rm -f -- "$tmp/index" "$tmp/index.lock"
-        rmdir "$tmp" 2>/dev/null || true
+        changes_are_represented_in_tree_fail "$tmp"
         return 1
         ;;
     esac
     case "$current_additions" in
       ''|*[!0-9]*)
-        rm -f -- "$tmp/index" "$tmp/index.lock"
-        rmdir "$tmp" 2>/dev/null || true
+        changes_are_represented_in_tree_fail "$tmp"
         return 1
         ;;
     esac
     case "$current_deletions" in
       ''|*[!0-9]*)
-        rm -f -- "$tmp/index" "$tmp/index.lock"
-        rmdir "$tmp" 2>/dev/null || true
+        changes_are_represented_in_tree_fail "$tmp"
         return 1
         ;;
     esac
     if [ "$current_deletions" -ne 0 ]; then
-      rm -f -- "$tmp/index" "$tmp/index.lock"
-      rmdir "$tmp" 2>/dev/null || true
+      changes_are_represented_in_tree_fail "$tmp"
       return 1
     fi
   done <<EOF
@@ -1245,16 +1250,21 @@ EOF
 }
 
 # The one patch-set comparison behind every landed-work patch check, so a future
-# fix to it can never land on only one copy. Takes the reference-side `git log`
-# arguments, the literal separator `::`, then the subject-side ones. Returns 0
-# when EVERY subject commit's patch appeared on the reference side and every
-# changed path remains represented in its current tree, 2 when the subject side
-# is empty so there is nothing to prove (the caller decides what that means), and
-# 1 for everything
+# fix to it can never land on only one copy. Takes the proof mode
+# (`patch-ids-only` or `with-tree-proof`), the reference tree the tree proof runs
+# against, the reference-side `git log` arguments, the literal separator `::`,
+# then the subject-side ones. Returns 0 when EVERY subject commit's patch
+# appeared on the reference side and - under `with-tree-proof` only - every
+# changed path remains represented in that reference tree, 2 when the subject
+# side is empty so there is nothing to prove (the caller decides what that
+# means), and 1 for everything
 # else: an unreadable git log, a subject side that touches no path, a reference
 # side that contributes no patch ids at all, an empty or unreadable subject patch
-# id, any subject commit whose patch is missing, or any subject path whose change
-# is no longer represented in the current reference tree.
+# id, any subject commit whose patch is missing, or - under `with-tree-proof` -
+# any subject path whose change is no longer represented in the current reference
+# tree.
+# The two modes differ deliberately: see the merged-PR contract in this file's
+# header comment before unifying them.
 # The reference scan is bounded to the paths the subject commits touch: a commit
 # can only carry a subject commit's patch if it touches exactly those paths, so
 # this can never drop a match, and it keeps unrelated default-branch history out
@@ -1262,10 +1272,16 @@ EOF
 # commit that did touch them.
 subject_patches_are_in_reference() {
   local -a ref_args=() subject_args=() pathspecs=()
-  local reference_tree=$1 past_separator=0 arg ref_ids subject_commits subject_paths commit patch_id path status
+  local mode=$1 reference_tree=$2 past_separator=0 arg ref_ids subject_commits subject_paths commit patch_id path status
   local subject_tip='' subject_oldest='' subject_base
-  shift
-  git -C "$WT" rev-parse --verify "$reference_tree^{tree}" >/dev/null 2>&1 || return 1
+  shift 2
+  case "$mode" in
+    patch-ids-only|with-tree-proof) ;;
+    *) return 1 ;;
+  esac
+  if [ "$mode" = with-tree-proof ]; then
+    git -C "$WT" rev-parse --verify "$reference_tree^{tree}" >/dev/null 2>&1 || return 1
+  fi
   for arg in "$@"; do
     if [ "$past_separator" = 0 ] && [ "$arg" = '::' ]; then
       past_separator=1
@@ -1301,6 +1317,7 @@ EOF
   done <<EOF
 $subject_commits
 EOF
+  [ "$mode" = with-tree-proof ] || return 0
   [ -n "$subject_tip" ] && [ -n "$subject_oldest" ] || return 1
   subject_base=$(git -C "$WT" rev-parse --verify "$subject_oldest^" 2>/dev/null) || return 1
   git -C "$WT" diff --quiet --no-ext-diff --no-renames "$subject_base" "$subject_tip" -- 2>/dev/null
@@ -1316,11 +1333,14 @@ EOF
   changes_are_represented_in_tree "$subject_base" "$subject_tip" "$reference_tree"
 }
 
+# Patch-id containment against a merged PR's head, and nothing more: see the
+# merged-PR contract in this file's header comment for why this path deliberately
+# skips the tree-representation proof that patches_are_in_ref requires.
 unpushed_patches_are_in_pr_head() {
   local pr_head=$1 current base
   current=$(git -C "$WT" rev-parse --verify HEAD 2>/dev/null) || return 1
   base=$(git -C "$WT" merge-base "$current" "$pr_head" 2>/dev/null) || return 1
-  subject_patches_are_in_reference "$pr_head" "$base..$pr_head" :: HEAD --not --remotes
+  subject_patches_are_in_reference patch-ids-only "$pr_head" "$base..$pr_head" :: HEAD --not --remotes
 }
 
 # Is the worktree's PR merged for local work contained in that PR? Resolves the
@@ -1400,7 +1420,7 @@ content_in_ref() {
 patches_are_in_ref() {
   local ref=$1 status
   [ -n "$ref" ] || return 1
-  subject_patches_are_in_reference "$ref" "$ref" --not HEAD :: HEAD --not "$ref"
+  subject_patches_are_in_reference with-tree-proof "$ref" "$ref" --not HEAD :: HEAD --not "$ref"
   status=$?
   [ "$status" -eq 0 ] || [ "$status" -eq 2 ]
 }

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -9,10 +9,13 @@
 # reachable from any remote-tracking branch (a fork counts as a remote, so
 # upstream-contribution PRs pushed to a fork satisfy this in any mode), OR - for a
 # normal ship task whose commits are not so reachable - when its PR is merged and
-# GitHub reports a PR head that contains the current local work, or its content is
-# already present in the up-to-date default branch. This recognizes the common
+# GitHub reports a PR head that contains the current local work, its content is
+# already present in the up-to-date default branch, or every commit that branch
+# cannot reach is already present there as a PATCH. This recognizes the common
 # squash-merge-then-delete-branch flow, where the branch's own commits live nowhere
-# on a remote yet the change is fully in main.
+# on a remote yet the change is fully in main, and the rebase case, where landing
+# rewrote every commit so no reachability test can ever succeed again (see
+# patches_are_in_ref).
 # The PR itself is resolved from the task's recorded pr= when present, or - when
 # no pr= was ever recorded (e.g. a yolo-authorized merge on a repo with no PR CI,
 # where the usual "checks green" fm-pr-check.sh trigger never fires) - by looking
@@ -24,7 +27,10 @@
 # Uncommitted changes are never landed.
 # local-only projects additionally accept work merged into the local default
 # branch (firstmate performs that merge after configured approval) as a fallback
-# for the common case where there is no remote at all.
+# for the common case where there is no remote at all, by the same reachability-
+# or-patch test. That path matters most there: bin/fm-merge-local.sh is
+# fast-forward-only, so every chain landing into a moved default branch rebases
+# first and leaves its earlier nodes with rewritten commits.
 # Scout tasks (kind=scout in meta) carve out of that check: their worktree is
 # declared scratch and the report at data/<task-id>/report.md is the work
 # product. Teardown proceeds only once the report exists and the shared
@@ -1094,24 +1100,31 @@ pr_is_merged() {
   unpushed_patches_are_in_pr_head "$head"
 }
 
-# Is the branch's content already present in the up-to-date default branch? Fetches
-# first, then 3-way merges the default branch with HEAD: when HEAD introduces nothing
-# the default branch does not already contain (e.g. its change landed via squash) the
-# merged tree equals the default branch's tree. This isolates branch-only changes, so
-# unrelated commits the default branch gained past the merge-base do not count as
-# "added". Returns non-zero when inconclusive (no default ref, or a merge conflict),
-# so the caller refuses rather than guesses.
-content_in_default() {
-  local name ref default_tree merged_tree
+# The up-to-date default-branch ref to test landing against: origin's
+# remote-tracking ref after a fetch when the worktree has an origin, otherwise the
+# local default branch. Returns non-zero when neither exists, so callers stay
+# inconclusive rather than guessing.
+default_landing_ref() {
+  local name
   name=$(default_branch) || return 1
   if git -C "$WT" remote get-url origin >/dev/null 2>&1; then
     git -C "$WT" fetch --quiet origin "+refs/heads/$name:refs/remotes/origin/$name" >/dev/null 2>&1 || return 1
-    ref="refs/remotes/origin/$name"
-  elif git -C "$WT" rev-parse --quiet --verify "refs/heads/$name" >/dev/null 2>&1; then
-    ref="refs/heads/$name"
-  else
-    return 1
+    printf '%s\n' "refs/remotes/origin/$name"
+    return 0
   fi
+  git -C "$WT" rev-parse --quiet --verify "refs/heads/$name" >/dev/null 2>&1 || return 1
+  printf '%s\n' "refs/heads/$name"
+}
+
+# Is the branch's content already present in <ref>? 3-way merges that ref with
+# HEAD: when HEAD introduces nothing the ref does not already contain (e.g. its
+# change landed via squash) the merged tree equals the ref's tree. This isolates
+# branch-only changes, so unrelated commits the ref gained past the merge-base do
+# not count as "added". Returns non-zero when inconclusive (a merge conflict, or a
+# ref with no tree), so the caller refuses rather than guesses.
+content_in_ref() {
+  local ref=$1 default_tree merged_tree
+  [ -n "$ref" ] || return 1
   default_tree=$(git -C "$WT" rev-parse --quiet --verify "$ref^{tree}" 2>/dev/null) || return 1
   [ -n "$default_tree" ] || return 1
   merged_tree=$(git -C "$WT" merge-tree --write-tree "$ref" HEAD 2>/dev/null) || return 1
@@ -1119,15 +1132,55 @@ content_in_default() {
   [ "$merged_tree" = "$default_tree" ]
 }
 
+# Is every commit HEAD holds that <ref> cannot reach already present in <ref> as a
+# PATCH? This is the relationship `git cherry` reports, and it is the only one that
+# can recognize work landed under REWRITTEN commits: a rebase gives every commit a
+# new object id, so reachability alone can never be satisfied afterwards even when
+# the content is fully in. Rebasing is the normal way work lands here, because
+# bin/fm-merge-local.sh is fast-forward-only, so a second chain landing into a moved
+# default branch must rebase first.
+# Deliberately strict, so it can only ever turn a refusal into an allow on proof:
+# EVERY unreachable commit must match, an unreadable or empty patch (an empty
+# commit, or a merge commit, whose conflict resolution `git show` does not emit)
+# never counts as landed, and a ref that contributes no patches at all is
+# inconclusive. Anything short of a complete match returns non-zero, so genuinely
+# unlanded work still refuses.
+patches_are_in_ref() {
+  local ref=$1 local_commits landed_ids commit patch_id
+  [ -n "$ref" ] || return 1
+  local_commits=$(git -C "$WT" log --format=%H HEAD --not "$ref" -- 2>/dev/null) || return 1
+  [ -n "$local_commits" ] || return 0
+  landed_ids=$(
+    git -C "$WT" log --format=%H "$ref" --not HEAD -- 2>/dev/null \
+      | while IFS= read -r commit; do
+          patch_id_for_commit "$commit"
+        done \
+      | sed '/^$/d' \
+      | sort -u
+  ) || return 1
+  [ -n "$landed_ids" ] || return 1
+  while IFS= read -r commit; do
+    [ -n "$commit" ] || continue
+    patch_id=$(patch_id_for_commit "$commit") || return 1
+    [ -n "$patch_id" ] || return 1
+    printf '%s\n' "$landed_ids" | grep -qxF "$patch_id" || return 1
+  done <<EOF
+$local_commits
+EOF
+}
+
 # Has the worktree's committed work actually LANDED, though its commits are not
 # reachable from any remote-tracking branch? True when a merged PR proves the
 # current local work is contained in the PR head, OR the content is already in the
-# default branch (fallback, which also covers the no-PR and gh-error paths). False
-# only for genuinely unlanded work.
+# default branch, OR every commit the default branch cannot reach is already there
+# as a patch (the rebase case). The two default-branch fallbacks also cover the
+# no-PR and gh-error paths. False only for genuinely unlanded work.
 work_is_landed() {
-  local branch=$1
+  local branch=$1 ref
   pr_is_merged "$branch" && return 0
-  content_in_default
+  ref=$(default_landing_ref) || return 1
+  content_in_ref "$ref" && return 0
+  patches_are_in_ref "$ref"
 }
 
 backlog_refresh_reminder() {
@@ -1411,6 +1464,13 @@ validate_worktree_teardown_safety() {
       return 1
     fi
     unmerged=$(printf '%s\n' "$unmerged_raw" | head -5)
+    # Reachability alone can never recognize a branch whose commits were rewritten
+    # by the rebase that landed them, so consult patch equivalence before refusing.
+    # It clears only commits it can prove are already in $DEFAULT; the uncommitted
+    # check below is untouched, and anything unproven still refuses.
+    if [ -n "$unmerged" ] && patches_are_in_ref "$DEFAULT"; then
+      unmerged=
+    fi
     if [ -n "$dirty" ] || [ -n "$unmerged" ]; then
       echo "REFUSED: local-only worktree $WT has work not yet merged into $DEFAULT and not on any remote." >&2
       [ -n "$dirty" ] && echo "uncommitted changes present" >&2

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1100,7 +1100,7 @@ patch_ids_for_log() {
 changes_are_represented_in_tree() {
   local pre=$1 post=$2 tree=$3 paths path tmp status pre_entry post_entry current_entry
   local post_meta current_meta post_mode post_type post_oid current_mode current_type current_oid
-  local numstat current_numstat
+  local numstat current_numstat current_additions current_deletions current_path
   paths=$(git -C "$WT" -c core.quotePath=false diff --name-only --no-renames "$pre" "$post" -- 2>/dev/null) || return 1
   [ -n "$paths" ] || return 1
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-teardown-current-tree.XXXXXX") || return 1
@@ -1195,22 +1195,28 @@ EOF
         return 1
         ;;
     esac
-    if ! git -C "$WT" cat-file blob "$post_oid" > "$tmp/post" 2>/dev/null ||
-      ! git -C "$WT" cat-file blob "$current_oid" > "$tmp/current" 2>/dev/null; then
-      rm -f -- "$tmp/post" "$tmp/current" "$tmp/index" "$tmp/index.lock"
+    IFS=$'\t' read -r current_additions current_deletions current_path <<EOF
+$current_numstat
+EOF
+    case "$current_additions" in
+      ''|*[!0-9]*)
+        rm -f -- "$tmp/index" "$tmp/index.lock"
+        rmdir "$tmp" 2>/dev/null || true
+        return 1
+        ;;
+    esac
+    case "$current_deletions" in
+      ''|*[!0-9]*)
+        rm -f -- "$tmp/index" "$tmp/index.lock"
+        rmdir "$tmp" 2>/dev/null || true
+        return 1
+        ;;
+    esac
+    if [ "$current_deletions" -ne 0 ]; then
+      rm -f -- "$tmp/index" "$tmp/index.lock"
       rmdir "$tmp" 2>/dev/null || true
       return 1
     fi
-    if ! awk '
-      FILENAME == ARGV[1] { required[++required_count] = $0; next }
-      FILENAME == ARGV[2] && matched < required_count && $0 == required[matched + 1] { matched++ }
-      END { exit matched == required_count ? 0 : 1 }
-    ' "$tmp/post" "$tmp/current"; then
-      rm -f -- "$tmp/post" "$tmp/current" "$tmp/index" "$tmp/index.lock"
-      rmdir "$tmp" 2>/dev/null || true
-      return 1
-    fi
-    rm -f -- "$tmp/post" "$tmp/current"
   done <<EOF
 $paths
 EOF

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1120,6 +1120,47 @@ patch_applies_to_tree() {
   esac
 }
 
+patch_parts_are_represented_in_tree() {
+  local patch=$1 tree=$2 tmp=$3 fragment_count fragment status i
+  fragment_count=$(awk -v prefix="$tmp/fragment." '
+    BEGIN { count = 0; header_count = 0; file = "" }
+    count == 0 && $0 !~ /^@@ / { header[++header_count] = $0; next }
+    /^@@ / {
+      if (file != "") close(file)
+      count++
+      file = prefix count
+      for (i = 1; i <= header_count; i++) print header[i] > file
+      print $0 > file
+      next
+    }
+    count > 0 { print $0 > file }
+    END {
+      if (file != "") close(file)
+      print count
+    }
+  ' "$patch") || return 1
+  case "$fragment_count" in
+    0)
+      patch_applies_to_tree "$patch" "$tree" forward
+      status=$?
+      ;;
+    *[!0-9]*|'') return 1 ;;
+    *)
+      status=1
+      i=1
+      while [ "$i" -le "$fragment_count" ]; do
+        fragment="$tmp/fragment.$i"
+        [ -s "$fragment" ] || return 1
+        patch_applies_to_tree "$fragment" "$tree" forward
+        status=$?
+        [ "$status" -eq 1 ] || break
+        i=$((i + 1))
+      done
+      ;;
+  esac
+  [ "$status" -eq 1 ]
+}
+
 commit_paths_are_represented_in_tree() {
   local commit=$1 tree=$2 paths path tmp status
   paths=$(git -C "$WT" -c core.quotePath=false show --format= --name-only --no-renames "$commit" -- 2>/dev/null) || return 1
@@ -1137,21 +1178,14 @@ commit_paths_are_represented_in_tree() {
       rmdir "$tmp" 2>/dev/null || true
       return 1
     }
-    patch_applies_to_tree "$tmp/patch" "$tree" forward
+    patch_parts_are_represented_in_tree "$tmp/patch" "$tree" "$tmp"
     status=$?
-    case "$status" in
-      0)
-        rm -f -- "$tmp/patch"
-        rmdir "$tmp" 2>/dev/null || true
-        return 1
-        ;;
-      1) ;;
-      *)
-        rm -f -- "$tmp/patch"
-        rmdir "$tmp" 2>/dev/null || true
-        return 1
-        ;;
-    esac
+    rm -f -- "$tmp"/fragment.*
+    [ "$status" -eq 0 ] || {
+      rm -f -- "$tmp/patch"
+      rmdir "$tmp" 2>/dev/null || true
+      return 1
+    }
   done <<EOF
 $paths
 EOF

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1097,99 +1097,115 @@ patch_ids_for_log() {
   return "$status"
 }
 
-patch_applies_to_tree() {
-  local patch=$1 tree=$2 direction=$3 tmp status
-  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-teardown-patch-apply.XXXXXX") || return 2
-  if ! GIT_INDEX_FILE="$tmp/index" git -C "$WT" read-tree "$tree" 2>/dev/null; then
-    rm -f -- "$tmp/index"
-    rmdir "$tmp" 2>/dev/null || true
-    return 2
-  fi
-  if [ "$direction" = reverse ]; then
-    GIT_INDEX_FILE="$tmp/index" git -C "$WT" apply --cached --check --unidiff-zero -p0 --reverse "$patch" >/dev/null 2>&1
-  else
-    GIT_INDEX_FILE="$tmp/index" git -C "$WT" apply --cached --check --unidiff-zero -p0 "$patch" >/dev/null 2>&1
-  fi
-  status=$?
-  rm -f -- "$tmp/index"
-  rmdir "$tmp" 2>/dev/null || true
-  case "$status" in
-    0) return 0 ;;
-    1) return 1 ;;
-    *) return 2 ;;
-  esac
-}
-
-patch_parts_are_represented_in_tree() {
-  local patch=$1 tree=$2 tmp=$3 fragment_count fragment status i
-  fragment_count=$(awk -v prefix="$tmp/fragment." '
-    BEGIN { count = 0; header_count = 0; file = "" }
-    count == 0 && $0 !~ /^@@ / { header[++header_count] = $0; next }
-    /^@@ / {
-      if (file != "") close(file)
-      count++
-      file = prefix count
-      for (i = 1; i <= header_count; i++) print header[i] > file
-      print $0 > file
-      next
-    }
-    count > 0 { print $0 > file }
-    END {
-      if (file != "") close(file)
-      print count
-    }
-  ' "$patch") || return 1
-  case "$fragment_count" in
-    0)
-      patch_applies_to_tree "$patch" "$tree" forward
-      status=$?
-      ;;
-    *[!0-9]*|'') return 1 ;;
-    *)
-      status=1
-      i=1
-      while [ "$i" -le "$fragment_count" ]; do
-        fragment="$tmp/fragment.$i"
-        [ -s "$fragment" ] || return 1
-        patch_applies_to_tree "$fragment" "$tree" forward
-        status=$?
-        [ "$status" -eq 1 ] || break
-        i=$((i + 1))
-      done
-      ;;
-  esac
-  [ "$status" -eq 1 ]
-}
-
 commit_paths_are_represented_in_tree() {
-  local commit=$1 tree=$2 paths path tmp status
+  local commit=$1 tree=$2 paths path tmp parent pre_entry post_entry current_entry
+  local pre_meta post_meta current_meta pre_mode post_mode current_mode pre_oid post_oid current_oid
+  local numstat status
   paths=$(git -C "$WT" -c core.quotePath=false show --format= --name-only --no-renames "$commit" -- 2>/dev/null) || return 1
   [ -n "$paths" ] || return 1
+  parent=$(git -C "$WT" rev-parse --verify "$commit^" 2>/dev/null) || return 1
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-teardown-current-tree.XXXXXX") || return 1
   while IFS= read -r path; do
     [ -n "$path" ] || continue
-    if ! git -C "$WT" show --format= --binary --full-index --no-ext-diff --no-prefix --no-renames "$commit" -- ":(literal)$path" > "$tmp/patch" 2>/dev/null; then
-      rm -f -- "$tmp/patch"
+    pre_entry=$(git -C "$WT" -c core.quotePath=false ls-tree "$parent" -- ":(literal)$path" 2>/dev/null) || {
+      rmdir "$tmp" 2>/dev/null || true
+      return 1
+    }
+    post_entry=$(git -C "$WT" -c core.quotePath=false ls-tree "$commit" -- ":(literal)$path" 2>/dev/null) || {
+      rmdir "$tmp" 2>/dev/null || true
+      return 1
+    }
+    current_entry=$(git -C "$WT" -c core.quotePath=false ls-tree "$tree" -- ":(literal)$path" 2>/dev/null) || {
+      rmdir "$tmp" 2>/dev/null || true
+      return 1
+    }
+    if [ -z "$post_entry" ]; then
+      [ -z "$current_entry" ] || {
+        rmdir "$tmp" 2>/dev/null || true
+        return 1
+      }
+      continue
+    fi
+    [ -n "$current_entry" ] || {
+      rmdir "$tmp" 2>/dev/null || true
+      return 1
+    }
+    pre_meta=${pre_entry%%$'\t'*}
+    post_meta=${post_entry%%$'\t'*}
+    current_meta=${current_entry%%$'\t'*}
+    read -r pre_mode _ pre_oid <<EOF
+$pre_meta
+EOF
+    read -r post_mode _ post_oid <<EOF
+$post_meta
+EOF
+    read -r current_mode _ current_oid <<EOF
+$current_meta
+EOF
+    [ -n "$post_oid" ] && [ -n "$current_oid" ] && [ "$post_mode" = "$current_mode" ] || {
+      rmdir "$tmp" 2>/dev/null || true
+      return 1
+    }
+    [ "$post_oid" != "$current_oid" ] || continue
+    numstat=$(git -C "$WT" diff --numstat --no-renames "$parent" "$commit" -- ":(literal)$path" 2>/dev/null) || {
+      rmdir "$tmp" 2>/dev/null || true
+      return 1
+    }
+    case "$numstat" in
+      -$'\t'-$'\t'*)
+        rmdir "$tmp" 2>/dev/null || true
+        return 1
+        ;;
+    esac
+    if ! git -C "$WT" diff --unified=0 --no-ext-diff --no-renames "$parent" "$commit" -- ":(literal)$path" > "$tmp/original.diff" 2>/dev/null; then
+      rm -f -- "$tmp/original.diff"
       rmdir "$tmp" 2>/dev/null || true
       return 1
     fi
-    [ -s "$tmp/patch" ] || {
-      rm -f -- "$tmp/patch"
+    if ! git -C "$WT" cat-file blob "$post_oid" > "$tmp/post" 2>/dev/null; then
+      rm -f -- "$tmp/original.diff" "$tmp/post"
       rmdir "$tmp" 2>/dev/null || true
       return 1
-    }
-    patch_parts_are_represented_in_tree "$tmp/patch" "$tree" "$tmp"
+    fi
+    if ! git -C "$WT" cat-file blob "$current_oid" > "$tmp/current" 2>/dev/null; then
+      rm -f -- "$tmp/original.diff" "$tmp/post" "$tmp/current"
+      rmdir "$tmp" 2>/dev/null || true
+      return 1
+    fi
+    git -C "$WT" diff --no-index --unified=0 --no-ext-diff --no-prefix "$tmp/post" "$tmp/current" > "$tmp/current.diff" 2>/dev/null
     status=$?
-    rm -f -- "$tmp"/fragment.*
-    [ "$status" -eq 0 ] || {
-      rm -f -- "$tmp/patch"
+    [ "$status" -le 1 ] || {
+      rm -f -- "$tmp/original.diff" "$tmp/post" "$tmp/current" "$tmp/current.diff"
       rmdir "$tmp" 2>/dev/null || true
       return 1
     }
+    if ! awk '
+      FNR == NR {
+        if ($0 ~ /^-/ && $0 !~ /^--- /) original_removed[substr($0, 2)] = 1
+        next
+      }
+      function finish_hunk() {
+        if (in_hunk && removed > added) bad = 1
+        removed = 0
+        added = 0
+      }
+      /^@@ / { finish_hunk(); in_hunk = 1; next }
+      in_hunk && /^-/ && $0 !~ /^--- / { removed++; next }
+      in_hunk && /^\+/ && $0 !~ /^\+\+\+ / {
+        added++
+        if (substr($0, 2) in original_removed) bad = 1
+        next
+      }
+      END { finish_hunk(); exit bad ? 1 : 0 }
+    ' "$tmp/original.diff" "$tmp/current.diff"; then
+      rm -f -- "$tmp/original.diff" "$tmp/post" "$tmp/current" "$tmp/current.diff"
+      rmdir "$tmp" 2>/dev/null || true
+      return 1
+    fi
+    rm -f -- "$tmp/original.diff" "$tmp/post" "$tmp/current" "$tmp/current.diff"
   done <<EOF
 $paths
 EOF
-  rm -f -- "$tmp/patch"
   rmdir "$tmp" 2>/dev/null || true
   return 0
 }

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -22,8 +22,9 @@
 # up a merged PR whose head branch matches the worktree's branch, fetching its head
 # via refs/pull/<n>/head when the branch itself was deleted. So a missing pr= never
 # by itself causes a false refusal of landed work.
-# A gh lookup error falls back to the content check; if that is also inconclusive,
-# teardown refuses rather than risk discarding unlanded work.
+# A gh lookup error falls back to the default-branch content and patch checks; if
+# those are also inconclusive, teardown refuses rather than risk discarding
+# unlanded work.
 # Uncommitted changes are never landed.
 # local-only projects additionally accept work merged into the local default
 # branch (firstmate performs that merge after configured approval) as a fallback

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1298,7 +1298,12 @@ EOF
   subject_base=$(git -C "$WT" rev-parse --verify "$subject_oldest^" 2>/dev/null) || return 1
   git -C "$WT" diff --quiet --no-ext-diff --no-renames "$subject_base" "$subject_tip" -- 2>/dev/null
   status=$?
-  [ "$status" -ne 0 ] || return 0
+  if [ "$status" -eq 0 ]; then
+    git -C "$WT" diff --quiet --no-ext-diff --no-renames "$subject_tip" "$reference_tree" -- \
+      "${pathspecs[@]}" 2>/dev/null
+    [ "$?" -eq 0 ] || return 1
+    return 0
+  fi
   [ "$status" -eq 1 ] || return 1
   changes_are_represented_in_tree "$subject_base" "$subject_tip" "$reference_tree"
 }

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1122,57 +1122,86 @@ patch_applies_to_tree() {
   esac
 }
 
+patch_file_was_reversed_by_reference_commits() {
+  local patch=$1 reference_commits=$2 parents candidate parent status
+  while IFS= read -r candidate; do
+    [ -n "$candidate" ] || continue
+    parents=$(git -C "$WT" rev-list --parents -n 1 "$candidate" 2>/dev/null) || {
+      return 2
+    }
+    parents=${parents#* }
+    [ "$parents" != "$candidate" ] || continue
+    for parent in $parents; do
+      patch_applies_to_tree "$patch" "$parent" reverse
+      status=$?
+      case "$status" in
+        0) ;;
+        1) continue ;;
+        *) return 2 ;;
+      esac
+      patch_applies_to_tree "$patch" "$candidate" forward
+      status=$?
+      case "$status" in
+        0) return 0 ;;
+        1) ;;
+        *) return 2 ;;
+      esac
+    done
+  done <<EOF
+$reference_commits
+EOF
+  return 1
+}
+
 patch_was_reversed_by_reference_commits() {
-  local subject=$1 reference_commits=$2 tmp parents candidate parent status
+  local subject=$1 reference_commits=$2 tmp status
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-teardown-reverse-scan.XXXXXX") || return 2
   if ! git -C "$WT" show --format= --binary --full-index --no-ext-diff --no-prefix "$subject" > "$tmp/patch" 2>/dev/null; then
     rm -f -- "$tmp/patch"
     rmdir "$tmp" 2>/dev/null || true
     return 2
   fi
-  while IFS= read -r candidate; do
-    [ -n "$candidate" ] || continue
-    parents=$(git -C "$WT" rev-list --parents -n 1 "$candidate" 2>/dev/null) || {
-      rm -f -- "$tmp/patch"
-      rmdir "$tmp" 2>/dev/null || true
-      return 2
-    }
-    parents=${parents#* }
-    [ "$parents" != "$candidate" ] || continue
-    for parent in $parents; do
-      patch_applies_to_tree "$tmp/patch" "$parent" reverse
-      status=$?
-      case "$status" in
-        0) ;;
-        1) continue ;;
-        *)
-          rm -f -- "$tmp/patch"
-          rmdir "$tmp" 2>/dev/null || true
-          return 2
-          ;;
-      esac
-      patch_applies_to_tree "$tmp/patch" "$candidate" forward
-      status=$?
-      case "$status" in
-        0)
-          rm -f -- "$tmp/patch"
-          rmdir "$tmp" 2>/dev/null || true
-          return 0
-          ;;
-        1) ;;
-        *)
-          rm -f -- "$tmp/patch"
-          rmdir "$tmp" 2>/dev/null || true
-          return 2
-          ;;
-      esac
-    done
-  done <<EOF
-$reference_commits
-EOF
+  patch_file_was_reversed_by_reference_commits "$tmp/patch" "$reference_commits"
+  status=$?
   rm -f -- "$tmp/patch"
   rmdir "$tmp" 2>/dev/null || true
-  return 1
+  return "$status"
+}
+
+subject_sequence_was_reversed_by_reference_commits() {
+  local subject_commits=$1 reference_commits=$2 newest= oldest= commit base tmp status count=0
+  while IFS= read -r commit; do
+    [ -n "$commit" ] || continue
+    [ -n "$newest" ] || newest=$commit
+    oldest=$commit
+    count=$((count + 1))
+  done <<EOF
+$subject_commits
+EOF
+  [ "$count" -gt 1 ] || return 1
+  while IFS= read -r commit; do
+    [ -n "$commit" ] || continue
+    git -C "$WT" merge-base --is-ancestor "$commit" "$newest" 2>/dev/null || return 2
+  done <<EOF
+$subject_commits
+EOF
+  base=$(git -C "$WT" rev-parse --verify "$oldest^" 2>/dev/null) || return 2
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-teardown-sequence-scan.XXXXXX") || return 2
+  if ! git -C "$WT" diff --binary --full-index --no-ext-diff --no-prefix "$base" "$newest" -- > "$tmp/patch" 2>/dev/null; then
+    rm -f -- "$tmp/patch"
+    rmdir "$tmp" 2>/dev/null || true
+    return 2
+  fi
+  [ -s "$tmp/patch" ] || {
+    rm -f -- "$tmp/patch"
+    rmdir "$tmp" 2>/dev/null || true
+    return 2
+  }
+  patch_file_was_reversed_by_reference_commits "$tmp/patch" "$reference_commits"
+  status=$?
+  rm -f -- "$tmp/patch"
+  rmdir "$tmp" 2>/dev/null || true
+  return "$status"
 }
 
 # The one patch-set comparison behind every landed-work patch check, so a future
@@ -1235,6 +1264,9 @@ EOF
   done <<EOF
 $subject_commits
 EOF
+  subject_sequence_was_reversed_by_reference_commits "$subject_commits" "$reference_commits"
+  status=$?
+  [ "$status" -eq 1 ] || return 1
 }
 
 unpushed_patches_are_in_pr_head() {

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1098,28 +1098,125 @@ patch_ids_for_log() {
 }
 
 changes_are_represented_in_tree() {
-  local pre=$1 post=$2 tree=$3 tmp status
+  local pre=$1 post=$2 tree=$3 paths path tmp status pre_entry post_entry current_entry
+  local post_meta current_meta post_mode post_type post_oid current_mode current_type current_oid
+  local numstat current_numstat
+  paths=$(git -C "$WT" -c core.quotePath=false diff --name-only --no-renames "$pre" "$post" -- 2>/dev/null) || return 1
+  [ -n "$paths" ] || return 1
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-teardown-current-tree.XXXXXX") || return 1
-  if ! git -C "$WT" diff --binary --full-index --no-ext-diff --no-prefix --no-renames "$pre" "$post" -- > "$tmp/aggregate.patch" 2>/dev/null; then
-    rm -f -- "$tmp/aggregate.patch"
-    rmdir "$tmp" 2>/dev/null || true
-    return 1
-  fi
-  if [ ! -s "$tmp/aggregate.patch" ]; then
-    rm -f -- "$tmp/aggregate.patch"
-    rmdir "$tmp" 2>/dev/null || true
-    return 1
-  fi
   if ! GIT_INDEX_FILE="$tmp/index" git -C "$WT" read-tree "$tree" 2>/dev/null; then
-    rm -f -- "$tmp/aggregate.patch" "$tmp/index" "$tmp/index.lock"
+    rm -f -- "$tmp/index" "$tmp/index.lock"
     rmdir "$tmp" 2>/dev/null || true
     return 1
   fi
-  GIT_INDEX_FILE="$tmp/index" git -C "$WT" apply --cached --check --reverse -p0 "$tmp/aggregate.patch" >/dev/null 2>&1
-  status=$?
-  rm -f -- "$tmp/aggregate.patch" "$tmp/index" "$tmp/index.lock"
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    if ! git -C "$WT" diff --binary --full-index --no-ext-diff --no-prefix --no-renames "$pre" "$post" -- ":(literal)$path" > "$tmp/path.patch" 2>/dev/null; then
+      rm -f -- "$tmp/path.patch" "$tmp/index" "$tmp/index.lock"
+      rmdir "$tmp" 2>/dev/null || true
+      return 1
+    fi
+    [ -s "$tmp/path.patch" ] || {
+      rm -f -- "$tmp/path.patch" "$tmp/index" "$tmp/index.lock"
+      rmdir "$tmp" 2>/dev/null || true
+      return 1
+    }
+    GIT_INDEX_FILE="$tmp/index" git -C "$WT" apply --cached --check --reverse -p0 "$tmp/path.patch" >/dev/null 2>&1
+    status=$?
+    rm -f -- "$tmp/path.patch"
+    [ "$status" -ne 0 ] || continue
+    pre_entry=$(git -C "$WT" -c core.quotePath=false ls-tree "$pre" -- ":(literal)$path" 2>/dev/null) || {
+      rm -f -- "$tmp/index" "$tmp/index.lock"
+      rmdir "$tmp" 2>/dev/null || true
+      return 1
+    }
+    [ -z "$pre_entry" ] || {
+      rm -f -- "$tmp/index" "$tmp/index.lock"
+      rmdir "$tmp" 2>/dev/null || true
+      return 1
+    }
+    post_entry=$(git -C "$WT" -c core.quotePath=false ls-tree "$post" -- ":(literal)$path" 2>/dev/null) || {
+      rm -f -- "$tmp/index" "$tmp/index.lock"
+      rmdir "$tmp" 2>/dev/null || true
+      return 1
+    }
+    current_entry=$(git -C "$WT" -c core.quotePath=false ls-tree "$tree" -- ":(literal)$path" 2>/dev/null) || {
+      rm -f -- "$tmp/index" "$tmp/index.lock"
+      rmdir "$tmp" 2>/dev/null || true
+      return 1
+    }
+    [ -n "$post_entry" ] && [ -n "$current_entry" ] || {
+      rm -f -- "$tmp/index" "$tmp/index.lock"
+      rmdir "$tmp" 2>/dev/null || true
+      return 1
+    }
+    post_meta=${post_entry%%$'\t'*}
+    current_meta=${current_entry%%$'\t'*}
+    read -r post_mode post_type post_oid <<EOF
+$post_meta
+EOF
+    read -r current_mode current_type current_oid <<EOF
+$current_meta
+EOF
+    case "$post_mode:$post_type:$current_mode:$current_type" in
+      100644:blob:100644:blob|100755:blob:100755:blob) ;;
+      *)
+        rm -f -- "$tmp/index" "$tmp/index.lock"
+        rmdir "$tmp" 2>/dev/null || true
+        return 1
+        ;;
+    esac
+    [ -n "$post_oid" ] && [ -n "$current_oid" ] || {
+      rm -f -- "$tmp/index" "$tmp/index.lock"
+      rmdir "$tmp" 2>/dev/null || true
+      return 1
+    }
+    numstat=$(git -C "$WT" diff --numstat --no-renames "$pre" "$post" -- ":(literal)$path" 2>/dev/null) || {
+      rm -f -- "$tmp/index" "$tmp/index.lock"
+      rmdir "$tmp" 2>/dev/null || true
+      return 1
+    }
+    current_numstat=$(git -C "$WT" diff --numstat --no-renames "$post" "$tree" -- ":(literal)$path" 2>/dev/null) || {
+      rm -f -- "$tmp/index" "$tmp/index.lock"
+      rmdir "$tmp" 2>/dev/null || true
+      return 1
+    }
+    case "$numstat" in
+      -$'\t'-$'\t'*)
+        rm -f -- "$tmp/index" "$tmp/index.lock"
+        rmdir "$tmp" 2>/dev/null || true
+        return 1
+        ;;
+    esac
+    case "$current_numstat" in
+      -$'\t'-$'\t'*)
+        rm -f -- "$tmp/index" "$tmp/index.lock"
+        rmdir "$tmp" 2>/dev/null || true
+        return 1
+        ;;
+    esac
+    if ! git -C "$WT" cat-file blob "$post_oid" > "$tmp/post" 2>/dev/null ||
+      ! git -C "$WT" cat-file blob "$current_oid" > "$tmp/current" 2>/dev/null; then
+      rm -f -- "$tmp/post" "$tmp/current" "$tmp/index" "$tmp/index.lock"
+      rmdir "$tmp" 2>/dev/null || true
+      return 1
+    fi
+    if ! awk '
+      FILENAME == ARGV[1] { required[++required_count] = $0; next }
+      FILENAME == ARGV[2] && matched < required_count && $0 == required[matched + 1] { matched++ }
+      END { exit matched == required_count ? 0 : 1 }
+    ' "$tmp/post" "$tmp/current"; then
+      rm -f -- "$tmp/post" "$tmp/current" "$tmp/index" "$tmp/index.lock"
+      rmdir "$tmp" 2>/dev/null || true
+      return 1
+    fi
+    rm -f -- "$tmp/post" "$tmp/current"
+  done <<EOF
+$paths
+EOF
+  rm -f -- "$tmp/index" "$tmp/index.lock"
   rmdir "$tmp" 2>/dev/null || true
-  [ "$status" -eq 0 ]
+  return 0
 }
 
 # The one patch-set comparison behind every landed-work patch check, so a future

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1042,10 +1042,8 @@ ensure_commit_object() {
   git -C "$WT" cat-file -e "$commit^{commit}" 2>/dev/null
 }
 
-# --no-prefix everywhere a patch id is taken: the default a/ and b/ prefixes swap
-# places under `-R`, so a patch and its own reverse would otherwise hash to
-# different ids and the revert check below could never match. It only has to be
-# consistent, since every id compared here is computed in the same repository.
+# --no-prefix only has to be consistent, since every id compared here is
+# computed in the same repository.
 patch_id_for_commit() {
   local commit=$1 tmp patch_output status
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-teardown-patch-id.XXXXXX") || return 1
@@ -1122,99 +1120,57 @@ patch_applies_to_tree() {
   esac
 }
 
-patch_file_was_reversed_by_reference_commits() {
-  local patch=$1 reference_commits=$2 parents candidate parent status
-  while IFS= read -r candidate; do
-    [ -n "$candidate" ] || continue
-    parents=$(git -C "$WT" rev-list --parents -n 1 "$candidate" 2>/dev/null) || {
-      return 2
+commit_paths_are_represented_in_tree() {
+  local commit=$1 tree=$2 paths path tmp status
+  paths=$(git -C "$WT" -c core.quotePath=false show --format= --name-only --no-renames "$commit" -- 2>/dev/null) || return 1
+  [ -n "$paths" ] || return 1
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-teardown-current-tree.XXXXXX") || return 1
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    if ! git -C "$WT" show --format= --binary --full-index --no-ext-diff --no-prefix --no-renames "$commit" -- ":(literal)$path" > "$tmp/patch" 2>/dev/null; then
+      rm -f -- "$tmp/patch"
+      rmdir "$tmp" 2>/dev/null || true
+      return 1
+    fi
+    [ -s "$tmp/patch" ] || {
+      rm -f -- "$tmp/patch"
+      rmdir "$tmp" 2>/dev/null || true
+      return 1
     }
-    parents=${parents#* }
-    [ "$parents" != "$candidate" ] || continue
-    for parent in $parents; do
-      patch_applies_to_tree "$patch" "$parent" reverse
-      status=$?
-      case "$status" in
-        0) ;;
-        1) continue ;;
-        *) return 2 ;;
-      esac
-      patch_applies_to_tree "$patch" "$candidate" forward
-      status=$?
-      case "$status" in
-        0) return 0 ;;
-        1) ;;
-        *) return 2 ;;
-      esac
-    done
+    patch_applies_to_tree "$tmp/patch" "$tree" forward
+    status=$?
+    case "$status" in
+      0)
+        rm -f -- "$tmp/patch"
+        rmdir "$tmp" 2>/dev/null || true
+        return 1
+        ;;
+      1) ;;
+      *)
+        rm -f -- "$tmp/patch"
+        rmdir "$tmp" 2>/dev/null || true
+        return 1
+        ;;
+    esac
   done <<EOF
-$reference_commits
+$paths
 EOF
-  return 1
-}
-
-patch_was_reversed_by_reference_commits() {
-  local subject=$1 reference_commits=$2 tmp status
-  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-teardown-reverse-scan.XXXXXX") || return 2
-  if ! git -C "$WT" show --format= --binary --full-index --no-ext-diff --no-prefix "$subject" > "$tmp/patch" 2>/dev/null; then
-    rm -f -- "$tmp/patch"
-    rmdir "$tmp" 2>/dev/null || true
-    return 2
-  fi
-  patch_file_was_reversed_by_reference_commits "$tmp/patch" "$reference_commits"
-  status=$?
   rm -f -- "$tmp/patch"
   rmdir "$tmp" 2>/dev/null || true
-  return "$status"
-}
-
-subject_sequence_was_reversed_by_reference_commits() {
-  local subject_commits=$1 reference_commits=$2 newest= oldest= commit base tmp status count=0
-  while IFS= read -r commit; do
-    [ -n "$commit" ] || continue
-    [ -n "$newest" ] || newest=$commit
-    oldest=$commit
-    count=$((count + 1))
-  done <<EOF
-$subject_commits
-EOF
-  [ "$count" -gt 1 ] || return 1
-  while IFS= read -r commit; do
-    [ -n "$commit" ] || continue
-    git -C "$WT" merge-base --is-ancestor "$commit" "$newest" 2>/dev/null || return 2
-  done <<EOF
-$subject_commits
-EOF
-  base=$(git -C "$WT" rev-parse --verify "$oldest^" 2>/dev/null) || return 2
-  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-teardown-sequence-scan.XXXXXX") || return 2
-  if ! git -C "$WT" diff --binary --full-index --no-ext-diff --no-prefix "$base" "$newest" -- > "$tmp/patch" 2>/dev/null; then
-    rm -f -- "$tmp/patch"
-    rmdir "$tmp" 2>/dev/null || true
-    return 2
-  fi
-  [ -s "$tmp/patch" ] || {
-    rm -f -- "$tmp/patch"
-    rmdir "$tmp" 2>/dev/null || true
-    return 2
-  }
-  patch_file_was_reversed_by_reference_commits "$tmp/patch" "$reference_commits"
-  status=$?
-  rm -f -- "$tmp/patch"
-  rmdir "$tmp" 2>/dev/null || true
-  return "$status"
+  return 0
 }
 
 # The one patch-set comparison behind every landed-work patch check, so a future
 # fix to it can never land on only one copy. Takes the reference-side `git log`
 # arguments, the literal separator `::`, then the subject-side ones. Returns 0
-# when EVERY subject commit's patch is already present on the reference side and
-# none of them is undone there again, 2 when the subject side is empty so there is
-# nothing to prove (the caller decides what that means), and 1 for everything
+# when EVERY subject commit's patch appeared on the reference side and every
+# changed path remains represented in its current tree, 2 when the subject side
+# is empty so there is nothing to prove (the caller decides what that means), and
+# 1 for everything
 # else: an unreadable git log, a subject side that touches no path, a reference
 # side that contributes no patch ids at all, an empty or unreadable subject patch
-# id, any subject commit whose patch is missing, or any subject patch the
-# reference side also carries in REVERSE (the landed-then-reverted case, where the
-# work is no longer present and discarding it would lose it).
+# id, any subject commit whose patch is missing, or any subject path whose change
+# is no longer represented in the current reference tree.
 # The reference scan is bounded to the paths the subject commits touch: a commit
 # can only carry a subject commit's patch if it touches exactly those paths, so
 # this can never drop a match, and it keeps unrelated default-branch history out
@@ -1222,7 +1178,9 @@ EOF
 # commit that did touch them.
 subject_patches_are_in_reference() {
   local -a ref_args=() subject_args=() pathspecs=()
-  local past_separator=0 arg ref_ids reverted_ids reference_commits subject_commits subject_paths commit patch_id path status
+  local reference_tree=$1 past_separator=0 arg ref_ids subject_commits subject_paths commit patch_id path
+  shift
+  git -C "$WT" rev-parse --verify "$reference_tree^{tree}" >/dev/null 2>&1 || return 1
   for arg in "$@"; do
     if [ "$past_separator" = 0 ] && [ "$arg" = '::' ]; then
       past_separator=1
@@ -1248,32 +1206,22 @@ EOF
   [ "${#pathspecs[@]}" -gt 0 ] || return 1
   ref_ids=$(patch_ids_for_log --full-history "${ref_args[@]}" -- "${pathspecs[@]}") || return 1
   [ -n "$ref_ids" ] || return 1
-  reverted_ids=$(patch_ids_for_log --full-history -R "${ref_args[@]}" -- "${pathspecs[@]}") || return 1
-  reference_commits=$(git -C "$WT" log --format=%H --full-history "${ref_args[@]}" -- "${pathspecs[@]}" 2>/dev/null) || return 1
   while IFS= read -r commit; do
     [ -n "$commit" ] || continue
     patch_id=$(patch_id_for_commit "$commit") || return 1
     [ -n "$patch_id" ] || return 1
     printf '%s\n' "$ref_ids" | grep -qxF "$patch_id" || return 1
-    if [ -n "$reverted_ids" ] && printf '%s\n' "$reverted_ids" | grep -qxF "$patch_id"; then
-      return 1
-    fi
-    patch_was_reversed_by_reference_commits "$commit" "$reference_commits"
-    status=$?
-    [ "$status" -eq 1 ] || return 1
+    commit_paths_are_represented_in_tree "$commit" "$reference_tree" || return 1
   done <<EOF
 $subject_commits
 EOF
-  subject_sequence_was_reversed_by_reference_commits "$subject_commits" "$reference_commits"
-  status=$?
-  [ "$status" -eq 1 ] || return 1
 }
 
 unpushed_patches_are_in_pr_head() {
   local pr_head=$1 current base
   current=$(git -C "$WT" rev-parse --verify HEAD 2>/dev/null) || return 1
   base=$(git -C "$WT" merge-base "$current" "$pr_head" 2>/dev/null) || return 1
-  subject_patches_are_in_reference "$base..$pr_head" :: HEAD --not --remotes
+  subject_patches_are_in_reference "$pr_head" "$base..$pr_head" :: HEAD --not --remotes
 }
 
 # Is the worktree's PR merged for local work contained in that PR? Resolves the
@@ -1353,7 +1301,7 @@ content_in_ref() {
 patches_are_in_ref() {
   local ref=$1 status
   [ -n "$ref" ] || return 1
-  subject_patches_are_in_reference "$ref" --not HEAD :: HEAD --not "$ref"
+  subject_patches_are_in_reference "$ref" "$ref" --not HEAD :: HEAD --not "$ref"
   status=$?
   [ "$status" -eq 0 ] || [ "$status" -eq 2 ]
 }

--- a/docs/gitlab-merge-watch.md
+++ b/docs/gitlab-merge-watch.md
@@ -290,7 +290,7 @@ It skips only that prompt; the conditions above are what authorize the merge.
 ## Why a recorded head is not the authority
 
 `bin/fm-pr-check.sh` records `pr_head=` only for GitHub, where `gh` exposes the head commit as a selectable field.
-It is optional by design, and the other consumers already treat it that way: `bin/fm-teardown.sh` reads the head from the forge at teardown and falls back to its provider-agnostic content check, and `bin/fm-review-diff.sh` resolves the head from the remote when none is recorded.
+It is optional by design, and the other consumers already treat it that way: `bin/fm-teardown.sh` reads the head from the forge at teardown and falls back to its provider-agnostic default-branch checks, and `bin/fm-review-diff.sh` resolves the head from the remote when none is recorded.
 
 The merge path does not record one either, and deliberately does not depend on one.
 A rebase moves the head and leaves any recorded value stale, so a merge decided from metadata can verify a commit that no longer exists.

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -764,6 +764,12 @@ test_local_only_rebased_patch_landed_but_dirty_refuses() {
   grep -q REFUSED "$case_dir/stderr" || fail "rebased-dirty: no REFUSED line in stderr"
   grep -Fq "uncommitted changes present" "$case_dir/stderr" \
     || fail "rebased-dirty: refusal did not name the uncommitted changes"
+  grep -Fq "its commits already landed in" "$case_dir/stderr" \
+    || fail "rebased-dirty: refusal did not credit the commits as already landed"
+  grep -Fq "Commit the uncommitted changes" "$case_dir/stderr" \
+    || fail "rebased-dirty: refusal did not point at the uncommitted change"
+  ! grep -Eq "not yet merged into|Merge the branch into local" "$case_dir/stderr" \
+    || fail "rebased-dirty: refusal still claims the branch has unmerged work"
   pass "worktree with uncommitted changes is refused even when every commit's patch landed"
 }
 

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -5,9 +5,10 @@
 # treehouse return hard-resets the worktree. "Landed" means reachable from a remote
 # OR - for a normal ship task whose commits are not so reachable - its PR is merged
 # and GitHub reports a PR head that contains the current local work, or its content
-# is already in the up-to-date default branch.
+# is already in the up-to-date default branch, or every commit it holds is already
+# present there as a patch.
 #
-# Covers three fixes:
+# Covers four fixes:
 #   - local-only fork-remote: a fork IS a remote, so fork-pushed upstream-
 #     contribution PRs are teardown-eligible (the pre-fix code false-refused them).
 #   - squash-merge-then-delete-branch: the branch's own commits live nowhere on a
@@ -15,6 +16,12 @@
 #     main. Reachability alone false-refused this common GitHub flow; the check now
 #     recognizes a merged PR head containing the local work (or the content already
 #     in main) as landed.
+#   - rebase-rewrites-commits: a rebase gives every commit a new object id, so a
+#     branch whose content landed under rewritten commits can never satisfy a
+#     reachability test. Because bin/fm-merge-local.sh is fast-forward-only, rebasing
+#     onto a moved default branch is the normal way local-only chains land, which
+#     made this a permanent false refusal. The check now also accepts a branch whose
+#     every commit is present in the default branch as a patch.
 #   - teardown-lock-race: a killed crew process can leave a transient worktree
 #     git index.lock that blocks teardown. The return path retries on the lock
 #     error signature (even if the lock self-clears mid-check), then only removes a
@@ -38,6 +45,10 @@
 #   (o) fm-pr-check rerun after HEAD moved                      -> no stale pr_head
 #   (p) fm-pr-check when local HEAD lags                        -> record remote PR head
 #   (q) no-mistakes + NO pr= recorded, PR discovered by branch  -> ALLOW  (yolo/no-CI merge)
+#   (q1) local-only + patch landed under a rewritten commit     -> ALLOW  (rebase fix)
+#   (q2) local-only + one commit's patch absent from main       -> REFUSE (safety)
+#   (q3) local-only + every patch landed but worktree dirty     -> REFUSE (dirty wins)
+#   (q4) no-mistakes + patch landed, main edited it afterwards  -> ALLOW  (rebase fix)
 #
 # Also covers backlog teardown-lock-race: a git index.lock left in the worktree by a
 # killed crew process (bin/fm-teardown.sh's teardown_treehouse_return).
@@ -251,6 +262,44 @@ land_on_origin_main() {
   printf '%s\n' "$content" > "$tmp/$file"
   git -C "$tmp" add -- "$file"
   git -C "$tmp" -c user.email=t@t -c user.name=t commit -q -m "squash $file"
+  git -C "$tmp" push -q origin HEAD:main
+  rm -rf "$tmp"
+}
+
+# Move the project's LOCAL default branch on with an unrelated commit, then apply
+# <file>=<content> there as a fresh commit. The resulting commit carries the same
+# patch as the task branch's own commit but a different object id, which is what a
+# rebase-then-fast-forward leaves behind: the branch's commits are unreachable from
+# main while their content is fully landed. Args: case_dir file content
+land_rewritten_patch_on_local_main() {
+  local case_dir=$1 file=$2 content=$3
+  printf '%s\n' "main moved on" > "$case_dir/project/unrelated.txt"
+  git -C "$case_dir/project" add -- unrelated.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t \
+    commit -q -m "unrelated main commit"
+  printf '%s\n' "$content" > "$case_dir/project/$file"
+  git -C "$case_dir/project" add -- "$file"
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t \
+    commit -q -m "rebased: add $file"
+}
+
+# Same rewritten-commit landing, but on origin's default branch, followed by a
+# later edit of the same file. The later edit is what makes the whole-tree content
+# check inconclusive, so only patch equivalence can prove the work landed.
+# Args: case_dir file content later_content
+land_rewritten_patch_then_edit_on_origin_main() {
+  local case_dir=$1 file=$2 content=$3 later=$4 tmp
+  tmp="$case_dir/_rebased"
+  git clone -q "$case_dir/origin.git" "$tmp"
+  printf '%s\n' "main moved on" > "$tmp/unrelated.txt"
+  git -C "$tmp" add -- unrelated.txt
+  git -C "$tmp" -c user.email=t@t -c user.name=t commit -q -m "unrelated main commit"
+  printf '%s\n' "$content" > "$tmp/$file"
+  git -C "$tmp" add -- "$file"
+  git -C "$tmp" -c user.email=t@t -c user.name=t commit -q -m "rebased: add $file"
+  printf '%s\n' "$later" > "$tmp/$file"
+  git -C "$tmp" add -- "$file"
+  git -C "$tmp" -c user.email=t@t -c user.name=t commit -q -m "follow-up edit of $file"
   git -C "$tmp" push -q origin HEAD:main
   rm -rf "$tmp"
 }
@@ -651,6 +700,91 @@ test_local_only_merged_to_local_main_allows() {
   expect_code 0 "$rc" "merged-main: teardown should succeed when work is merged into local main"
   ! grep -q REFUSED "$case_dir/stderr" || fail "merged-main: teardown printed a REFUSED line"
   pass "local-only worktree with work merged into local main is torn down (no regression)"
+}
+
+test_local_only_rebased_patch_landed_allows() {
+  local case_dir rc
+  case_dir=$(make_case rebased-landed)
+  write_meta "$case_dir" local-only ship
+  wt_commit_file "$case_dir" feature.txt hello "add feature"
+  # main gained an unrelated commit, so landing this branch needed a rebase; the
+  # branch's own commit is now unreachable from main while its patch is fully there.
+  land_rewritten_patch_on_local_main "$case_dir" feature.txt hello
+  git -C "$case_dir/wt" merge-base --is-ancestor HEAD main 2>/dev/null \
+    && fail "rebased-landed: branch commit is still reachable from main; case is vacuous"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "rebased-landed: teardown should succeed when the patch landed under a rewritten commit"
+  ! grep -q REFUSED "$case_dir/stderr" || fail "rebased-landed: teardown printed a REFUSED line"
+  pass "local-only worktree whose patch landed under a rewritten commit is torn down"
+}
+
+test_local_only_rebased_patch_with_absent_commit_refuses() {
+  local case_dir rc
+  case_dir=$(make_case rebased-partial)
+  write_meta "$case_dir" local-only ship
+  wt_commit_file "$case_dir" feature.txt hello "add feature"
+  # A second commit whose patch never reaches main: patch equivalence must not
+  # excuse it just because the first commit's patch did land.
+  wt_commit_file "$case_dir" extra.txt "still here" "add extra"
+  land_rewritten_patch_on_local_main "$case_dir" feature.txt hello
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "rebased-partial: teardown should refuse"
+  grep -q REFUSED "$case_dir/stderr" || fail "rebased-partial: no REFUSED line in stderr"
+  grep -Fq "commits not yet on main" "$case_dir/stderr" \
+    || fail "rebased-partial: refusal did not name the commits still missing from main"
+  pass "local-only worktree with a commit whose patch is absent from main is refused"
+}
+
+test_local_only_rebased_patch_landed_but_dirty_refuses() {
+  local case_dir rc
+  case_dir=$(make_case rebased-dirty)
+  write_meta "$case_dir" local-only ship
+  wt_commit_file "$case_dir" feature.txt hello "add feature"
+  land_rewritten_patch_on_local_main "$case_dir" feature.txt hello
+  # Every commit's patch landed, but the worktree still holds uncommitted work.
+  printf '%s\n' "not committed anywhere" > "$case_dir/wt/scratch.txt"
+  git -C "$case_dir/wt" add -- scratch.txt
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "rebased-dirty: teardown should refuse on uncommitted changes"
+  grep -q REFUSED "$case_dir/stderr" || fail "rebased-dirty: no REFUSED line in stderr"
+  grep -Fq "uncommitted changes present" "$case_dir/stderr" \
+    || fail "rebased-dirty: refusal did not name the uncommitted changes"
+  pass "worktree with uncommitted changes is refused even when every commit's patch landed"
+}
+
+test_no_mistakes_rebased_patch_landed_after_later_edit_allows() {
+  local case_dir rc
+  case_dir=$(make_case nm-rebased-landed)
+  write_meta "$case_dir" no-mistakes ship
+  wt_commit_file "$case_dir" feature.txt hello "add feature"
+  # The patch landed on origin/main under a rewritten commit, then main edited the
+  # same file again. The whole-tree content check cannot conclude anything from
+  # that, so only patch equivalence proves the branch's work is already in.
+  land_rewritten_patch_then_edit_on_origin_main "$case_dir" feature.txt hello revised
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "nm-rebased-landed: teardown should succeed when the patch landed under a rewritten commit"
+  ! grep -q REFUSED "$case_dir/stderr" || fail "nm-rebased-landed: teardown printed a REFUSED line"
+  pass "no-mistakes worktree whose patch landed under a rewritten commit is torn down"
 }
 
 test_no_mistakes_origin_remote_allows() {
@@ -2596,6 +2730,10 @@ test_teardown_prompts_tasks_axi_done_when_compatible
 test_teardown_manual_backend_prompts_hand_edit_even_when_tasks_axi_present
 test_local_only_truly_unpushed_refuses
 test_local_only_merged_to_local_main_allows
+test_local_only_rebased_patch_landed_allows
+test_local_only_rebased_patch_with_absent_commit_refuses
+test_local_only_rebased_patch_landed_but_dirty_refuses
+test_no_mistakes_rebased_patch_landed_after_later_edit_allows
 test_no_mistakes_origin_remote_allows
 test_no_mistakes_truly_unpushed_refuses
 test_local_only_force_overrides_unpushed

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -57,6 +57,7 @@
 #   (q2i) local-only + one added line replaced                   -> REFUSE (safety)
 #   (q2j) local-only + added file fully replaced                 -> REFUSE (safety)
 #   (q2k) local-only + unrelated line appended after landing     -> ALLOW  (superset)
+#   (q2l) local-only + landed trailing newline removed            -> REFUSE (safety)
 #   (q3) local-only + every patch landed but worktree dirty     -> REFUSE (dirty wins)
 #   (q4) no-mistakes + patch landed, all its content replaced   -> REFUSE (safety)
 #   (q5) local-only + rewritten rename patch landed              -> ALLOW  (rename fix)
@@ -1171,6 +1172,46 @@ SH
   ! grep -q REFUSED "$case_dir/stderr" || fail "rebased-added-file-superset: teardown printed a REFUSED line"
   [ -e "$case_dir/treehouse-called" ] || fail "rebased-added-file-superset: teardown did not invoke worktree return"
   pass "local-only worktree whose landed file gained unrelated content is torn down"
+}
+
+test_local_only_rebased_added_file_loses_trailing_newline_refuses() {
+  local case_dir rc expected_hash actual_hash
+  case_dir=$(make_case rebased-added-file-no-newline)
+  write_meta "$case_dir" local-only ship
+
+  printf 'A\n' > "$case_dir/wt/feature.txt"
+  git -C "$case_dir/wt" add -- feature.txt
+  git -C "$case_dir/wt" -c user.email=t@t -c user.name=t commit -q -m "add feature"
+
+  printf '%s\n' moved > "$case_dir/project/unrelated.txt"
+  git -C "$case_dir/project" add -- unrelated.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "main moved"
+  printf 'A\n' > "$case_dir/project/feature.txt"
+  git -C "$case_dir/project" add -- feature.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "rewritten feature"
+  printf A > "$case_dir/project/feature.txt"
+  git -C "$case_dir/project" add -- feature.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "remove trailing newline"
+
+  cat > "$case_dir/fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+touch "$case_dir/treehouse-called"
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "rebased-added-file-no-newline: teardown should refuse"
+  grep -q REFUSED "$case_dir/stderr" || fail "rebased-added-file-no-newline: no REFUSED line in stderr"
+  [ ! -e "$case_dir/treehouse-called" ] || fail "rebased-added-file-no-newline: destructive return was invoked"
+  expected_hash=$(printf 'A\n' | git hash-object --stdin)
+  actual_hash=$(git hash-object "$case_dir/wt/feature.txt")
+  [ "$actual_hash" = "$expected_hash" ] || fail "rebased-added-file-no-newline: worktree content was discarded"
+  pass "local-only worktree whose landed trailing newline was removed is refused"
 }
 
 test_local_only_rewritten_rename_patch_landed_allows() {
@@ -3231,6 +3272,7 @@ test_local_only_rebased_added_line_partially_reverted_refuses
 test_local_only_rebased_added_line_replaced_refuses
 test_local_only_rebased_added_file_fully_replaced_refuses
 test_local_only_rebased_added_file_superset_allows
+test_local_only_rebased_added_file_loses_trailing_newline_refuses
 test_local_only_rebased_patch_landed_but_dirty_refuses
 test_no_mistakes_rebased_patch_landed_after_full_replacement_refuses
 test_local_only_rewritten_rename_patch_landed_allows

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -60,6 +60,7 @@
 #   (q2l) local-only + landed trailing newline removed            -> REFUSE (safety)
 #   (q2m) local-only + landed change relocated elsewhere          -> REFUSE (safety)
 #   (q2n) local-only + rewritten inverse sequence is net zero     -> ALLOW  (current state)
+#   (q2o) local-only + net-zero inverse later reverted             -> REFUSE (safety)
 #   (q3) local-only + every patch landed but worktree dirty     -> REFUSE (dirty wins)
 #   (q4) no-mistakes + patch landed, all its content replaced   -> REFUSE (safety)
 #   (q5) local-only + rewritten rename patch landed              -> ALLOW  (rename fix)
@@ -1078,6 +1079,54 @@ SH
   ! grep -q REFUSED "$case_dir/stderr" || fail "rebased-net-zero-sequence: teardown printed a REFUSED line"
   [ -e "$case_dir/treehouse-called" ] || fail "rebased-net-zero-sequence: teardown did not invoke worktree return"
   pass "local-only worktree whose rewritten inverse patches net to zero is torn down"
+}
+
+test_local_only_rebased_net_zero_inverse_later_reverted_refuses() {
+  local case_dir rc
+  case_dir=$(make_case rebased-net-zero-inverse-reverted)
+  write_meta "$case_dir" local-only ship
+
+  printf '%s\n' x > "$case_dir/project/shared.txt"
+  git -C "$case_dir/project" add -- shared.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "add baseline"
+  git -C "$case_dir/wt" rebase main >/dev/null
+  printf '%s\n' y > "$case_dir/wt/shared.txt"
+  git -C "$case_dir/wt" add -- shared.txt
+  git -C "$case_dir/wt" -c user.email=t@t -c user.name=t commit -q -m "change x to y"
+  printf '%s\n' x > "$case_dir/wt/shared.txt"
+  git -C "$case_dir/wt" add -- shared.txt
+  git -C "$case_dir/wt" -c user.email=t@t -c user.name=t commit -q -m "change y back to x"
+
+  printf '%s\n' moved > "$case_dir/project/unrelated.txt"
+  git -C "$case_dir/project" add -- unrelated.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "main moved"
+  printf '%s\n' y > "$case_dir/project/shared.txt"
+  git -C "$case_dir/project" add -- shared.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "rewritten x to y"
+  printf '%s\n' x > "$case_dir/project/shared.txt"
+  git -C "$case_dir/project" add -- shared.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "rewritten y back to x"
+  printf '%s\n' y > "$case_dir/project/shared.txt"
+  git -C "$case_dir/project" add -- shared.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "revert rewritten inverse"
+
+  cat > "$case_dir/fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+touch "$case_dir/treehouse-called"
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "rebased-net-zero-inverse-reverted: teardown should refuse"
+  grep -q REFUSED "$case_dir/stderr" || fail "rebased-net-zero-inverse-reverted: no REFUSED line in stderr"
+  [ ! -e "$case_dir/treehouse-called" ] || fail "rebased-net-zero-inverse-reverted: destructive return was invoked"
+  grep -Fxq x "$case_dir/wt/shared.txt" || fail "rebased-net-zero-inverse-reverted: worktree content was discarded"
+  pass "local-only net-zero worktree whose inverse was later reverted is refused"
 }
 
 test_local_only_rebased_same_file_hunk_partially_reverted_refuses() {
@@ -3373,6 +3422,7 @@ test_local_only_rebased_multifile_patch_partially_reverted_on_main_refuses
 test_local_only_rebased_patch_reverted_then_relanded_allows
 test_local_only_rebased_patch_relocated_to_identical_block_refuses
 test_local_only_rebased_inverse_sequence_with_net_zero_change_allows
+test_local_only_rebased_net_zero_inverse_later_reverted_refuses
 test_local_only_rebased_same_file_hunk_partially_reverted_refuses
 test_local_only_rebased_added_line_partially_reverted_refuses
 test_local_only_rebased_added_line_replaced_refuses

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -56,6 +56,7 @@
 #   (q2h) local-only + one added line reverted                   -> REFUSE (safety)
 #   (q2i) local-only + one added line replaced                   -> REFUSE (safety)
 #   (q2j) local-only + added file fully replaced                 -> REFUSE (safety)
+#   (q2k) local-only + unrelated line appended after landing     -> ALLOW  (superset)
 #   (q3) local-only + every patch landed but worktree dirty     -> REFUSE (dirty wins)
 #   (q4) no-mistakes + patch landed, all its content replaced   -> REFUSE (safety)
 #   (q5) local-only + rewritten rename patch landed              -> ALLOW  (rename fix)
@@ -1133,6 +1134,43 @@ SH
   grep -Fxq A "$case_dir/wt/feature.txt" || fail "rebased-added-file-replaced: worktree content was discarded"
   grep -Fxq B "$case_dir/wt/feature.txt" || fail "rebased-added-file-replaced: worktree content was discarded"
   pass "local-only worktree whose added file was fully replaced is refused"
+}
+
+test_local_only_rebased_added_file_superset_allows() {
+  local case_dir rc
+  case_dir=$(make_case rebased-added-file-superset)
+  write_meta "$case_dir" local-only ship
+
+  printf '%s\n' A > "$case_dir/wt/feature.txt"
+  git -C "$case_dir/wt" add -- feature.txt
+  git -C "$case_dir/wt" -c user.email=t@t -c user.name=t commit -q -m "add feature"
+
+  printf '%s\n' moved > "$case_dir/project/unrelated.txt"
+  git -C "$case_dir/project" add -- unrelated.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "main moved"
+  printf '%s\n' A > "$case_dir/project/feature.txt"
+  git -C "$case_dir/project" add -- feature.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "rewritten feature"
+  printf '%s\n' A B > "$case_dir/project/feature.txt"
+  git -C "$case_dir/project" add -- feature.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "append unrelated content"
+
+  cat > "$case_dir/fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+touch "$case_dir/treehouse-called"
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "rebased-added-file-superset: teardown should allow"
+  ! grep -q REFUSED "$case_dir/stderr" || fail "rebased-added-file-superset: teardown printed a REFUSED line"
+  [ -e "$case_dir/treehouse-called" ] || fail "rebased-added-file-superset: teardown did not invoke worktree return"
+  pass "local-only worktree whose landed file gained unrelated content is torn down"
 }
 
 test_local_only_rewritten_rename_patch_landed_allows() {
@@ -3192,6 +3230,7 @@ test_local_only_rebased_same_file_hunk_partially_reverted_refuses
 test_local_only_rebased_added_line_partially_reverted_refuses
 test_local_only_rebased_added_line_replaced_refuses
 test_local_only_rebased_added_file_fully_replaced_refuses
+test_local_only_rebased_added_file_superset_allows
 test_local_only_rebased_patch_landed_but_dirty_refuses
 test_no_mistakes_rebased_patch_landed_after_full_replacement_refuses
 test_local_only_rewritten_rename_patch_landed_allows

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -48,8 +48,11 @@
 #   (q1) local-only + patch landed under a rewritten commit     -> ALLOW  (rebase fix)
 #   (q2) local-only + one commit's patch absent from main       -> REFUSE (safety)
 #   (q2b) local-only + landed patch reverted on main again      -> REFUSE (safety)
+#   (q2c) local-only + combined revert on main                   -> REFUSE (safety)
 #   (q3) local-only + every patch landed but worktree dirty     -> REFUSE (dirty wins)
 #   (q4) no-mistakes + patch landed, main edited it afterwards  -> ALLOW  (rebase fix)
+#   (q5) local-only + rewritten rename patch landed              -> ALLOW  (rename fix)
+#   (q6) patch-history read fails after emitting output          -> REFUSE (fail-safe)
 #
 # Also covers backlog teardown-lock-race: a git index.lock left in the worktree by a
 # killed crew process (bin/fm-teardown.sh's teardown_treehouse_return).
@@ -315,6 +318,27 @@ land_rewritten_patch_then_edit_on_origin_main() {
   git -C "$tmp" -c user.email=t@t -c user.name=t commit -q -m "follow-up edit of $file"
   git -C "$tmp" push -q origin HEAD:main
   rm -rf "$tmp"
+}
+
+add_git_patch_log_failure() {
+  local case_dir=$1
+  cat > "$case_dir/fakebin/git" <<'SH'
+#!/usr/bin/env bash
+real=${REAL_GIT_FOR_TEST:?}
+args=("$@")
+is_log=0
+is_patch=0
+for arg in "$@"; do
+  [ "$arg" = log ] && is_log=1
+  [ "$arg" = -p ] && is_patch=1
+done
+if [ "$is_log" = 1 ] && [ "$is_patch" = 1 ]; then
+  "$real" "${args[@]}"
+  exit 86
+fi
+exec "$real" "${args[@]}"
+SH
+  chmod +x "$case_dir/fakebin/git"
 }
 
 # Override GitHub lookups to report PR 7 as merged with the supplied head.
@@ -780,6 +804,90 @@ test_local_only_rebased_patch_reverted_on_main_refuses() {
     || fail "rebased-reverted: refusal did not name the commits still missing from main"
   [ -e "$case_dir/wt/feature.txt" ] || fail "rebased-reverted: worktree work was discarded"
   pass "local-only worktree whose landed patch was reverted on main is refused"
+}
+
+test_local_only_rebased_patch_combined_revert_on_main_refuses() {
+  local case_dir rc
+  case_dir=$(make_case rebased-combined-revert)
+  write_meta "$case_dir" local-only ship
+
+  printf '%s\n' baseline > "$case_dir/project/shared.txt"
+  git -C "$case_dir/project" add -- shared.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "add baseline"
+  git -C "$case_dir/wt" rebase main >/dev/null
+
+  printf '%s\n' feature > "$case_dir/wt/shared.txt"
+  git -C "$case_dir/wt" add -- shared.txt
+  git -C "$case_dir/wt" -c user.email=t@t -c user.name=t commit -q -m "change shared feature"
+
+  printf '%s\n' moved > "$case_dir/project/unrelated.txt"
+  git -C "$case_dir/project" add -- unrelated.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "main moved"
+  printf '%s\n' feature > "$case_dir/project/shared.txt"
+  git -C "$case_dir/project" add -- shared.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "rewritten feature"
+  printf '%s\n' baseline 'unrelated retained' > "$case_dir/project/shared.txt"
+  git -C "$case_dir/project" add -- shared.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "revert feature with other work"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "rebased-combined-revert: teardown should refuse"
+  grep -q REFUSED "$case_dir/stderr" || fail "rebased-combined-revert: no REFUSED line in stderr"
+  [ -e "$case_dir/wt/shared.txt" ] || fail "rebased-combined-revert: worktree work was discarded"
+  pass "local-only worktree whose patch was reverted with other work is refused"
+}
+
+test_local_only_rewritten_rename_patch_landed_allows() {
+  local case_dir rc
+  case_dir=$(make_case rewritten-rename)
+  write_meta "$case_dir" local-only ship
+
+  printf '%s\n' payload > "$case_dir/project/old-name.txt"
+  git -C "$case_dir/project" add -- old-name.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "add rename source"
+  git -C "$case_dir/wt" rebase main >/dev/null
+  git -C "$case_dir/wt" mv old-name.txt new-name.txt
+  git -C "$case_dir/wt" -c user.email=t@t -c user.name=t commit -q -m "rename source"
+
+  printf '%s\n' moved > "$case_dir/project/unrelated.txt"
+  git -C "$case_dir/project" add -- unrelated.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "main moved"
+  git -C "$case_dir/project" mv old-name.txt new-name.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "rewritten rename"
+  git -C "$case_dir/wt" merge-base --is-ancestor HEAD main 2>/dev/null \
+    && fail "rewritten-rename: branch commit is still reachable from main"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "rewritten-rename: teardown should accept the landed rename patch"
+  ! grep -q REFUSED "$case_dir/stderr" || fail "rewritten-rename: teardown printed a REFUSED line"
+  pass "local-only worktree whose rename landed under a rewritten commit is torn down"
+}
+
+test_patch_log_failure_after_output_refuses() {
+  local case_dir rc
+  case_dir=$(make_case patch-log-failure)
+  write_meta "$case_dir" no-mistakes ship
+  wt_commit_file "$case_dir" feature.txt hello "add feature"
+  land_rewritten_patch_then_edit_on_origin_main "$case_dir" feature.txt hello revised
+  add_git_patch_log_failure "$case_dir"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "patch-log-failure: teardown should fail closed"
+  grep -q REFUSED "$case_dir/stderr" || fail "patch-log-failure: no REFUSED line in stderr"
+  [ -e "$case_dir/wt/feature.txt" ] || fail "patch-log-failure: worktree work was discarded"
+  pass "partial patch-history output cannot authorize teardown"
 }
 
 test_local_only_rebased_patch_landed_but_dirty_refuses() {
@@ -2776,8 +2884,11 @@ test_local_only_merged_to_local_main_allows
 test_local_only_rebased_patch_landed_allows
 test_local_only_rebased_patch_with_absent_commit_refuses
 test_local_only_rebased_patch_reverted_on_main_refuses
+test_local_only_rebased_patch_combined_revert_on_main_refuses
 test_local_only_rebased_patch_landed_but_dirty_refuses
 test_no_mistakes_rebased_patch_landed_after_later_edit_allows
+test_local_only_rewritten_rename_patch_landed_allows
+test_patch_log_failure_after_output_refuses
 test_no_mistakes_origin_remote_allows
 test_no_mistakes_truly_unpushed_refuses
 test_local_only_force_overrides_unpushed

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -49,6 +49,7 @@
 #   (q2) local-only + one commit's patch absent from main       -> REFUSE (safety)
 #   (q2b) local-only + landed patch reverted on main again      -> REFUSE (safety)
 #   (q2c) local-only + combined revert on main                   -> REFUSE (safety)
+#   (q2d) local-only + two landed patches jointly reverted      -> REFUSE (safety)
 #   (q3) local-only + every patch landed but worktree dirty     -> REFUSE (dirty wins)
 #   (q4) no-mistakes + patch landed, main edited it afterwards  -> ALLOW  (rebase fix)
 #   (q5) local-only + rewritten rename patch landed              -> ALLOW  (rename fix)
@@ -839,6 +840,55 @@ test_local_only_rebased_patch_combined_revert_on_main_refuses() {
   grep -q REFUSED "$case_dir/stderr" || fail "rebased-combined-revert: no REFUSED line in stderr"
   [ -e "$case_dir/wt/shared.txt" ] || fail "rebased-combined-revert: worktree work was discarded"
   pass "local-only worktree whose patch was reverted with other work is refused"
+}
+
+test_local_only_rebased_patch_sequence_jointly_reverted_on_main_refuses() {
+  local case_dir rc
+  case_dir=$(make_case rebased-sequence-reverted)
+  write_meta "$case_dir" local-only ship
+
+  printf '%s\n' x > "$case_dir/project/shared.txt"
+  git -C "$case_dir/project" add -- shared.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "add baseline"
+  git -C "$case_dir/wt" rebase main >/dev/null
+
+  printf '%s\n' y > "$case_dir/wt/shared.txt"
+  git -C "$case_dir/wt" add -- shared.txt
+  git -C "$case_dir/wt" -c user.email=t@t -c user.name=t commit -q -m "change x to y"
+  printf '%s\n' z > "$case_dir/wt/shared.txt"
+  git -C "$case_dir/wt" add -- shared.txt
+  git -C "$case_dir/wt" -c user.email=t@t -c user.name=t commit -q -m "change y to z"
+
+  printf '%s\n' moved > "$case_dir/project/unrelated.txt"
+  git -C "$case_dir/project" add -- unrelated.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "main moved"
+  printf '%s\n' y > "$case_dir/project/shared.txt"
+  git -C "$case_dir/project" add -- shared.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "rewritten x to y"
+  printf '%s\n' z > "$case_dir/project/shared.txt"
+  git -C "$case_dir/project" add -- shared.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "rewritten y to z"
+  printf '%s\n' x > "$case_dir/project/shared.txt"
+  git -C "$case_dir/project" add -- shared.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "jointly revert sequence"
+
+  cat > "$case_dir/fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+touch "$case_dir/treehouse-called"
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "rebased-sequence-reverted: teardown should refuse"
+  grep -q REFUSED "$case_dir/stderr" || fail "rebased-sequence-reverted: no REFUSED line in stderr"
+  [ ! -e "$case_dir/treehouse-called" ] || fail "rebased-sequence-reverted: destructive return was invoked"
+  [ -e "$case_dir/wt/shared.txt" ] || fail "rebased-sequence-reverted: worktree work was discarded"
+  pass "local-only worktree whose landed patch sequence was jointly reverted is refused"
 }
 
 test_local_only_rewritten_rename_patch_landed_allows() {
@@ -2885,6 +2935,7 @@ test_local_only_rebased_patch_landed_allows
 test_local_only_rebased_patch_with_absent_commit_refuses
 test_local_only_rebased_patch_reverted_on_main_refuses
 test_local_only_rebased_patch_combined_revert_on_main_refuses
+test_local_only_rebased_patch_sequence_jointly_reverted_on_main_refuses
 test_local_only_rebased_patch_landed_but_dirty_refuses
 test_no_mistakes_rebased_patch_landed_after_later_edit_allows
 test_local_only_rewritten_rename_patch_landed_allows

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -50,6 +50,8 @@
 #   (q2b) local-only + landed patch reverted on main again      -> REFUSE (safety)
 #   (q2c) local-only + combined revert on main                   -> REFUSE (safety)
 #   (q2d) local-only + two landed patches jointly reverted      -> REFUSE (safety)
+#   (q2e) local-only + one file of landed patch reverted         -> REFUSE (safety)
+#   (q2f) local-only + reverted patch re-landed                  -> ALLOW  (current state)
 #   (q3) local-only + every patch landed but worktree dirty     -> REFUSE (dirty wins)
 #   (q4) no-mistakes + patch landed, main edited it afterwards  -> ALLOW  (rebase fix)
 #   (q5) local-only + rewritten rename patch landed              -> ALLOW  (rename fix)
@@ -889,6 +891,83 @@ SH
   [ ! -e "$case_dir/treehouse-called" ] || fail "rebased-sequence-reverted: destructive return was invoked"
   [ -e "$case_dir/wt/shared.txt" ] || fail "rebased-sequence-reverted: worktree work was discarded"
   pass "local-only worktree whose landed patch sequence was jointly reverted is refused"
+}
+
+test_local_only_rebased_multifile_patch_partially_reverted_on_main_refuses() {
+  local case_dir rc
+  case_dir=$(make_case rebased-partial-revert)
+  write_meta "$case_dir" local-only ship
+
+  printf '%s\n' one > "$case_dir/wt/one.txt"
+  printf '%s\n' two > "$case_dir/wt/two.txt"
+  git -C "$case_dir/wt" add -- one.txt two.txt
+  git -C "$case_dir/wt" -c user.email=t@t -c user.name=t commit -q -m "add both files"
+
+  printf '%s\n' moved > "$case_dir/project/unrelated.txt"
+  git -C "$case_dir/project" add -- unrelated.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "main moved"
+  printf '%s\n' one > "$case_dir/project/one.txt"
+  printf '%s\n' two > "$case_dir/project/two.txt"
+  git -C "$case_dir/project" add -- one.txt two.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "rewritten add both files"
+  git -C "$case_dir/project" rm -q -- two.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "revert one file"
+
+  cat > "$case_dir/fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+touch "$case_dir/treehouse-called"
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "rebased-partial-revert: teardown should refuse"
+  grep -q REFUSED "$case_dir/stderr" || fail "rebased-partial-revert: no REFUSED line in stderr"
+  [ ! -e "$case_dir/treehouse-called" ] || fail "rebased-partial-revert: destructive return was invoked"
+  [ -e "$case_dir/wt/two.txt" ] || fail "rebased-partial-revert: worktree work was discarded"
+  pass "local-only worktree whose multi-file patch was partially reverted is refused"
+}
+
+test_local_only_rebased_patch_reverted_then_relanded_allows() {
+  local case_dir rc
+  case_dir=$(make_case rebased-relanded)
+  write_meta "$case_dir" local-only ship
+
+  printf '%s\n' x > "$case_dir/project/shared.txt"
+  git -C "$case_dir/project" add -- shared.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "add baseline"
+  git -C "$case_dir/wt" rebase main >/dev/null
+  printf '%s\n' y > "$case_dir/wt/shared.txt"
+  git -C "$case_dir/wt" add -- shared.txt
+  git -C "$case_dir/wt" -c user.email=t@t -c user.name=t commit -q -m "change x to y"
+
+  printf '%s\n' moved > "$case_dir/project/unrelated.txt"
+  git -C "$case_dir/project" add -- unrelated.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "main moved"
+  printf '%s\n' y > "$case_dir/project/shared.txt"
+  git -C "$case_dir/project" add -- shared.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "rewritten landing"
+  printf '%s\n' x > "$case_dir/project/shared.txt"
+  git -C "$case_dir/project" add -- shared.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "revert landing"
+  printf '%s\n' y > "$case_dir/project/shared.txt"
+  git -C "$case_dir/project" add -- shared.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "re-land change"
+  git -C "$case_dir/wt" merge-base --is-ancestor HEAD main 2>/dev/null \
+    && fail "rebased-relanded: branch commit is still reachable from main"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "rebased-relanded: teardown should accept the final landed state"
+  ! grep -q REFUSED "$case_dir/stderr" || fail "rebased-relanded: teardown printed a REFUSED line"
+  pass "local-only worktree whose reverted patch was re-landed is torn down"
 }
 
 test_local_only_rewritten_rename_patch_landed_allows() {
@@ -2936,6 +3015,8 @@ test_local_only_rebased_patch_with_absent_commit_refuses
 test_local_only_rebased_patch_reverted_on_main_refuses
 test_local_only_rebased_patch_combined_revert_on_main_refuses
 test_local_only_rebased_patch_sequence_jointly_reverted_on_main_refuses
+test_local_only_rebased_multifile_patch_partially_reverted_on_main_refuses
+test_local_only_rebased_patch_reverted_then_relanded_allows
 test_local_only_rebased_patch_landed_but_dirty_refuses
 test_no_mistakes_rebased_patch_landed_after_later_edit_allows
 test_local_only_rewritten_rename_patch_landed_allows

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -55,8 +55,9 @@
 #   (q2g) local-only + one same-file hunk reverted               -> REFUSE (safety)
 #   (q2h) local-only + one added line reverted                   -> REFUSE (safety)
 #   (q2i) local-only + one added line replaced                   -> REFUSE (safety)
+#   (q2j) local-only + added file fully replaced                 -> REFUSE (safety)
 #   (q3) local-only + every patch landed but worktree dirty     -> REFUSE (dirty wins)
-#   (q4) no-mistakes + patch landed, main edited it afterwards  -> ALLOW  (rebase fix)
+#   (q4) no-mistakes + patch landed, all its content replaced   -> REFUSE (safety)
 #   (q5) local-only + rewritten rename patch landed              -> ALLOW  (rename fix)
 #   (q6) patch-history read fails after emitting output          -> REFUSE (fail-safe)
 #
@@ -1095,6 +1096,45 @@ SH
   pass "local-only worktree whose added line was replaced is refused"
 }
 
+test_local_only_rebased_added_file_fully_replaced_refuses() {
+  local case_dir rc
+  case_dir=$(make_case rebased-added-file-replaced)
+  write_meta "$case_dir" local-only ship
+
+  printf '%s\n' A B > "$case_dir/wt/feature.txt"
+  git -C "$case_dir/wt" add -- feature.txt
+  git -C "$case_dir/wt" -c user.email=t@t -c user.name=t commit -q -m "add two-line feature"
+
+  printf '%s\n' moved > "$case_dir/project/unrelated.txt"
+  git -C "$case_dir/project" add -- unrelated.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "main moved"
+  printf '%s\n' A B > "$case_dir/project/feature.txt"
+  git -C "$case_dir/project" add -- feature.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "rewritten two-line feature"
+  printf '%s\n' C D > "$case_dir/project/feature.txt"
+  git -C "$case_dir/project" add -- feature.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "replace entire feature"
+
+  cat > "$case_dir/fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+touch "$case_dir/treehouse-called"
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "rebased-added-file-replaced: teardown should refuse"
+  grep -q REFUSED "$case_dir/stderr" || fail "rebased-added-file-replaced: no REFUSED line in stderr"
+  [ ! -e "$case_dir/treehouse-called" ] || fail "rebased-added-file-replaced: destructive return was invoked"
+  grep -Fxq A "$case_dir/wt/feature.txt" || fail "rebased-added-file-replaced: worktree content was discarded"
+  grep -Fxq B "$case_dir/wt/feature.txt" || fail "rebased-added-file-replaced: worktree content was discarded"
+  pass "local-only worktree whose added file was fully replaced is refused"
+}
+
 test_local_only_rewritten_rename_patch_landed_allows() {
   local case_dir rc
   case_dir=$(make_case rewritten-rename)
@@ -1172,24 +1212,30 @@ test_local_only_rebased_patch_landed_but_dirty_refuses() {
   pass "worktree with uncommitted changes is refused even when every commit's patch landed"
 }
 
-test_no_mistakes_rebased_patch_landed_after_later_edit_allows() {
+test_no_mistakes_rebased_patch_landed_after_full_replacement_refuses() {
   local case_dir rc
   case_dir=$(make_case nm-rebased-landed)
   write_meta "$case_dir" no-mistakes ship
   wt_commit_file "$case_dir" feature.txt hello "add feature"
-  # The patch landed on origin/main under a rewritten commit, then main edited the
-  # same file again. The whole-tree content check cannot conclude anything from
-  # that, so only patch equivalence proves the branch's work is already in.
   land_rewritten_patch_then_edit_on_origin_main "$case_dir" feature.txt hello revised
+
+  cat > "$case_dir/fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+touch "$case_dir/treehouse-called"
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
 
   set +e
   run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
   rc=$?
   set -e
 
-  expect_code 0 "$rc" "nm-rebased-landed: teardown should succeed when the patch landed under a rewritten commit"
-  ! grep -q REFUSED "$case_dir/stderr" || fail "nm-rebased-landed: teardown printed a REFUSED line"
-  pass "no-mistakes worktree whose patch landed under a rewritten commit is torn down"
+  expect_code 1 "$rc" "nm-rebased-landed: teardown should refuse when all subject content was replaced"
+  grep -q REFUSED "$case_dir/stderr" || fail "nm-rebased-landed: no REFUSED line in stderr"
+  [ ! -e "$case_dir/treehouse-called" ] || fail "nm-rebased-landed: destructive return was invoked"
+  grep -Fxq hello "$case_dir/wt/feature.txt" || fail "nm-rebased-landed: worktree content was discarded"
+  pass "no-mistakes worktree whose landed content was fully replaced is refused"
 }
 
 test_no_mistakes_origin_remote_allows() {
@@ -3145,8 +3191,9 @@ test_local_only_rebased_patch_reverted_then_relanded_allows
 test_local_only_rebased_same_file_hunk_partially_reverted_refuses
 test_local_only_rebased_added_line_partially_reverted_refuses
 test_local_only_rebased_added_line_replaced_refuses
+test_local_only_rebased_added_file_fully_replaced_refuses
 test_local_only_rebased_patch_landed_but_dirty_refuses
-test_no_mistakes_rebased_patch_landed_after_later_edit_allows
+test_no_mistakes_rebased_patch_landed_after_full_replacement_refuses
 test_local_only_rewritten_rename_patch_landed_allows
 test_patch_log_failure_after_output_refuses
 test_no_mistakes_origin_remote_allows

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -58,6 +58,8 @@
 #   (q2j) local-only + added file fully replaced                 -> REFUSE (safety)
 #   (q2k) local-only + unrelated line appended after landing     -> ALLOW  (superset)
 #   (q2l) local-only + landed trailing newline removed            -> REFUSE (safety)
+#   (q2m) local-only + landed change relocated elsewhere          -> REFUSE (safety)
+#   (q2n) local-only + rewritten inverse sequence is net zero     -> ALLOW  (current state)
 #   (q3) local-only + every patch landed but worktree dirty     -> REFUSE (dirty wins)
 #   (q4) no-mistakes + patch landed, all its content replaced   -> REFUSE (safety)
 #   (q5) local-only + rewritten rename patch landed              -> ALLOW  (rename fix)
@@ -974,6 +976,108 @@ test_local_only_rebased_patch_reverted_then_relanded_allows() {
   expect_code 0 "$rc" "rebased-relanded: teardown should accept the final landed state"
   ! grep -q REFUSED "$case_dir/stderr" || fail "rebased-relanded: teardown printed a REFUSED line"
   pass "local-only worktree whose reverted patch was re-landed is torn down"
+}
+
+test_local_only_rebased_patch_relocated_to_identical_block_refuses() {
+  local case_dir rc
+  case_dir=$(make_case rebased-relocated-identical-block)
+  write_meta "$case_dir" local-only ship
+
+  printf '%s\n' \
+    p1 p2 p3 p4 p5 \
+    context-one context-two context-three target context-four context-five context-six \
+    s1 s2 s3 s4 s5 s6 s7 s8 \
+    context-one context-two context-three target context-four context-five context-six \
+    z1 z2 z3 z4 z5 > "$case_dir/project/shared.txt"
+  git -C "$case_dir/project" add -- shared.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "add repeated baseline"
+  git -C "$case_dir/wt" rebase main >/dev/null
+
+  awk '$0 == "target" && !changed { print "landed"; changed = 1; next } { print }' \
+    "$case_dir/wt/shared.txt" > "$case_dir/wt/shared.next"
+  mv "$case_dir/wt/shared.next" "$case_dir/wt/shared.txt"
+  git -C "$case_dir/wt" add -- shared.txt
+  git -C "$case_dir/wt" -c user.email=t@t -c user.name=t commit -q -m "change first repeated block"
+
+  printf '%s\n' moved > "$case_dir/project/unrelated.txt"
+  git -C "$case_dir/project" add -- unrelated.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "main moved"
+  awk '$0 == "target" && !changed { print "landed"; changed = 1; next } { print }' \
+    "$case_dir/project/shared.txt" > "$case_dir/project/shared.next"
+  mv "$case_dir/project/shared.next" "$case_dir/project/shared.txt"
+  git -C "$case_dir/project" add -- shared.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "rewritten first-block landing"
+  awk '
+    $0 == "landed" && !reverted { print "target"; reverted = 1; next }
+    $0 == "target" { print "landed"; next }
+    { print }
+  ' "$case_dir/project/shared.txt" > "$case_dir/project/shared.next"
+  mv "$case_dir/project/shared.next" "$case_dir/project/shared.txt"
+  git -C "$case_dir/project" add -- shared.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "relocate landing to second block"
+
+  cat > "$case_dir/fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+touch "$case_dir/treehouse-called"
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "rebased-relocated-identical-block: teardown should refuse"
+  grep -q REFUSED "$case_dir/stderr" || fail "rebased-relocated-identical-block: no REFUSED line in stderr"
+  [ ! -e "$case_dir/treehouse-called" ] || fail "rebased-relocated-identical-block: destructive return was invoked"
+  [ "$(sed -n '9p' "$case_dir/wt/shared.txt")" = landed ] \
+    || fail "rebased-relocated-identical-block: worktree change was discarded"
+  pass "local-only worktree whose landed change moved to an identical block is refused"
+}
+
+test_local_only_rebased_inverse_sequence_with_net_zero_change_allows() {
+  local case_dir rc
+  case_dir=$(make_case rebased-net-zero-sequence)
+  write_meta "$case_dir" local-only ship
+
+  printf '%s\n' x > "$case_dir/project/shared.txt"
+  git -C "$case_dir/project" add -- shared.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "add baseline"
+  git -C "$case_dir/wt" rebase main >/dev/null
+  printf '%s\n' y > "$case_dir/wt/shared.txt"
+  git -C "$case_dir/wt" add -- shared.txt
+  git -C "$case_dir/wt" -c user.email=t@t -c user.name=t commit -q -m "change x to y"
+  printf '%s\n' x > "$case_dir/wt/shared.txt"
+  git -C "$case_dir/wt" add -- shared.txt
+  git -C "$case_dir/wt" -c user.email=t@t -c user.name=t commit -q -m "change y back to x"
+
+  printf '%s\n' moved > "$case_dir/project/unrelated.txt"
+  git -C "$case_dir/project" add -- unrelated.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "main moved"
+  printf '%s\n' y > "$case_dir/project/shared.txt"
+  git -C "$case_dir/project" add -- shared.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "rewritten x to y"
+  printf '%s\n' x > "$case_dir/project/shared.txt"
+  git -C "$case_dir/project" add -- shared.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "rewritten y back to x"
+
+  cat > "$case_dir/fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+touch "$case_dir/treehouse-called"
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "rebased-net-zero-sequence: teardown should allow"
+  ! grep -q REFUSED "$case_dir/stderr" || fail "rebased-net-zero-sequence: teardown printed a REFUSED line"
+  [ -e "$case_dir/treehouse-called" ] || fail "rebased-net-zero-sequence: teardown did not invoke worktree return"
+  pass "local-only worktree whose rewritten inverse patches net to zero is torn down"
 }
 
 test_local_only_rebased_same_file_hunk_partially_reverted_refuses() {
@@ -3267,6 +3371,8 @@ test_local_only_rebased_patch_combined_revert_on_main_refuses
 test_local_only_rebased_patch_sequence_jointly_reverted_on_main_refuses
 test_local_only_rebased_multifile_patch_partially_reverted_on_main_refuses
 test_local_only_rebased_patch_reverted_then_relanded_allows
+test_local_only_rebased_patch_relocated_to_identical_block_refuses
+test_local_only_rebased_inverse_sequence_with_net_zero_change_allows
 test_local_only_rebased_same_file_hunk_partially_reverted_refuses
 test_local_only_rebased_added_line_partially_reverted_refuses
 test_local_only_rebased_added_line_replaced_refuses

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -42,6 +42,7 @@
 #   (l) no-mistakes + stale origin/main but fetched content     -> ALLOW  (fresh fetch)
 #   (m) no-mistakes + local HEAD ancestor of merged PR head     -> ALLOW  (lagging local)
 #   (n) no-mistakes + replayed unpushed patch in merged PR head -> ALLOW  (replayed local)
+#   (n1) no-mistakes + merged PR head evolved past local commit -> ALLOW  (evolved PR head)
 #   (o) fm-pr-check rerun after HEAD moved                      -> no stale pr_head
 #   (p) fm-pr-check when local HEAD lags                        -> record remote PR head
 #   (q) no-mistakes + NO pr= recorded, PR discovered by branch  -> ALLOW  (yolo/no-CI merge)
@@ -1605,6 +1606,47 @@ test_squash_merged_pr_allows_replayed_unpushed_patch() {
   expect_code 0 "$rc" "squash-replayed-patch: teardown should succeed when unpushed local patch is in the merged PR head"
   ! grep -q REFUSED "$case_dir/stderr" || fail "squash-replayed-patch: teardown printed a REFUSED line"
   pass "squash-merged PR accepts replayed unpushed local patches contained in the PR head"
+}
+
+test_merged_pr_head_evolved_after_local_commit_allows() {
+  local case_dir rc parent_head pr_head tmp
+  case_dir=$(make_case pr-head-evolved)
+  write_meta "$case_dir" no-mistakes ship
+  # The merged-PR path is patch-id containment only, deliberately: the pipeline
+  # replays the local commit onto the PR branch and then keeps fixing it there,
+  # so the PR head's tree no longer holds the local change verbatim even though
+  # the work genuinely landed. Requiring the local change to still be present in
+  # the PR head's tree would false-refuse this.
+  wt_commit_file "$case_dir" local-parent.txt parent "local parent"
+  parent_head=$(git -C "$case_dir/wt" rev-parse HEAD)
+  git -C "$case_dir/wt" push -q origin "$parent_head:refs/heads/fm/task-x1"
+  git -C "$case_dir/project" fetch -q origin fm/task-x1
+  printf 'A\nB\n' > "$case_dir/wt/feature.txt"
+  git -C "$case_dir/wt" add -- feature.txt
+  git -C "$case_dir/wt" -c user.email=t@t -c user.name=t commit -q -m "add feature"
+  append_pr_meta_url "$case_dir"
+  tmp="$case_dir/_evolved"
+  git clone -q "$case_dir/origin.git" "$tmp"
+  printf 'A\nB\n' > "$tmp/feature.txt"
+  git -C "$tmp" add -- feature.txt
+  git -C "$tmp" -c user.email=t@t -c user.name=t commit -q -m "add feature"
+  printf 'A\nC\n' > "$tmp/feature.txt"
+  git -C "$tmp" add -- feature.txt
+  git -C "$tmp" -c user.email=t@t -c user.name=t commit -q -m "review fix on the PR branch"
+  git -C "$tmp" push -q origin HEAD:refs/heads/pr-head
+  git -C "$case_dir/project" fetch -q origin pr-head
+  rm -rf "$tmp"
+  pr_head=$(git -C "$case_dir/project" rev-parse refs/remotes/origin/pr-head)
+  add_gh_pr_merged_for_head "$case_dir" "$pr_head"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "pr-head-evolved: teardown should succeed when the merged PR head evolved past the local commit"
+  ! grep -q REFUSED "$case_dir/stderr" || fail "pr-head-evolved: teardown printed a REFUSED line"
+  pass "merged-PR path stays patch-id containment when the PR head evolved after the local commit"
 }
 
 test_merged_pr_with_later_local_commit_refuses() {
@@ -3452,6 +3494,7 @@ test_squash_merged_branch_deleted_allows
 test_squash_merged_pr_allows_when_head_ancestor_of_pr_head
 test_no_pr_recorded_discovers_merged_pr_by_branch_allows
 test_squash_merged_pr_allows_replayed_unpushed_patch
+test_merged_pr_head_evolved_after_local_commit_allows
 test_merged_pr_with_later_local_commit_refuses
 test_pr_check_does_not_refresh_stale_pr_head
 test_pr_check_records_remote_head_when_local_lags

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -54,6 +54,7 @@
 #   (q2f) local-only + reverted patch re-landed                  -> ALLOW  (current state)
 #   (q2g) local-only + one same-file hunk reverted               -> REFUSE (safety)
 #   (q2h) local-only + one added line reverted                   -> REFUSE (safety)
+#   (q2i) local-only + one added line replaced                   -> REFUSE (safety)
 #   (q3) local-only + every patch landed but worktree dirty     -> REFUSE (dirty wins)
 #   (q4) no-mistakes + patch landed, main edited it afterwards  -> ALLOW  (rebase fix)
 #   (q5) local-only + rewritten rename patch landed              -> ALLOW  (rename fix)
@@ -1054,6 +1055,44 @@ SH
   [ ! -e "$case_dir/treehouse-called" ] || fail "rebased-added-line-revert: destructive return was invoked"
   grep -Fxq B "$case_dir/wt/feature.txt" || fail "rebased-added-line-revert: worktree line was discarded"
   pass "local-only worktree whose added line was reverted is refused"
+}
+
+test_local_only_rebased_added_line_replaced_refuses() {
+  local case_dir rc
+  case_dir=$(make_case rebased-added-line-replaced)
+  write_meta "$case_dir" local-only ship
+
+  printf '%s\n' A B > "$case_dir/wt/feature.txt"
+  git -C "$case_dir/wt" add -- feature.txt
+  git -C "$case_dir/wt" -c user.email=t@t -c user.name=t commit -q -m "add two-line feature"
+
+  printf '%s\n' moved > "$case_dir/project/unrelated.txt"
+  git -C "$case_dir/project" add -- unrelated.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "main moved"
+  printf '%s\n' A B > "$case_dir/project/feature.txt"
+  git -C "$case_dir/project" add -- feature.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "rewritten two-line feature"
+  printf '%s\n' A C > "$case_dir/project/feature.txt"
+  git -C "$case_dir/project" add -- feature.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "replace added line"
+
+  cat > "$case_dir/fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+touch "$case_dir/treehouse-called"
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "rebased-added-line-replaced: teardown should refuse"
+  grep -q REFUSED "$case_dir/stderr" || fail "rebased-added-line-replaced: no REFUSED line in stderr"
+  [ ! -e "$case_dir/treehouse-called" ] || fail "rebased-added-line-replaced: destructive return was invoked"
+  grep -Fxq B "$case_dir/wt/feature.txt" || fail "rebased-added-line-replaced: worktree line was discarded"
+  pass "local-only worktree whose added line was replaced is refused"
 }
 
 test_local_only_rewritten_rename_patch_landed_allows() {
@@ -3105,6 +3144,7 @@ test_local_only_rebased_multifile_patch_partially_reverted_on_main_refuses
 test_local_only_rebased_patch_reverted_then_relanded_allows
 test_local_only_rebased_same_file_hunk_partially_reverted_refuses
 test_local_only_rebased_added_line_partially_reverted_refuses
+test_local_only_rebased_added_line_replaced_refuses
 test_local_only_rebased_patch_landed_but_dirty_refuses
 test_no_mistakes_rebased_patch_landed_after_later_edit_allows
 test_local_only_rewritten_rename_patch_landed_allows

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -52,6 +52,7 @@
 #   (q2d) local-only + two landed patches jointly reverted      -> REFUSE (safety)
 #   (q2e) local-only + one file of landed patch reverted         -> REFUSE (safety)
 #   (q2f) local-only + reverted patch re-landed                  -> ALLOW  (current state)
+#   (q2g) local-only + one same-file hunk reverted               -> REFUSE (safety)
 #   (q3) local-only + every patch landed but worktree dirty     -> REFUSE (dirty wins)
 #   (q4) no-mistakes + patch landed, main edited it afterwards  -> ALLOW  (rebase fix)
 #   (q5) local-only + rewritten rename patch landed              -> ALLOW  (rename fix)
@@ -968,6 +969,52 @@ test_local_only_rebased_patch_reverted_then_relanded_allows() {
   expect_code 0 "$rc" "rebased-relanded: teardown should accept the final landed state"
   ! grep -q REFUSED "$case_dir/stderr" || fail "rebased-relanded: teardown printed a REFUSED line"
   pass "local-only worktree whose reverted patch was re-landed is torn down"
+}
+
+test_local_only_rebased_same_file_hunk_partially_reverted_refuses() {
+  local case_dir rc
+  case_dir=$(make_case rebased-hunk-revert)
+  write_meta "$case_dir" local-only ship
+
+  printf '%s\n' a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11 a12 > "$case_dir/project/shared.txt"
+  git -C "$case_dir/project" add -- shared.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "add baseline"
+  git -C "$case_dir/wt" rebase main >/dev/null
+
+  sed -e 's/^a2$/landed-two/' -e 's/^a11$/landed-eleven/' "$case_dir/wt/shared.txt" > "$case_dir/wt/shared.next"
+  mv "$case_dir/wt/shared.next" "$case_dir/wt/shared.txt"
+  git -C "$case_dir/wt" add -- shared.txt
+  git -C "$case_dir/wt" -c user.email=t@t -c user.name=t commit -q -m "change two separated hunks"
+
+  printf '%s\n' moved > "$case_dir/project/unrelated.txt"
+  git -C "$case_dir/project" add -- unrelated.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "main moved"
+  sed -e 's/^a2$/landed-two/' -e 's/^a11$/landed-eleven/' "$case_dir/project/shared.txt" > "$case_dir/project/shared.next"
+  mv "$case_dir/project/shared.next" "$case_dir/project/shared.txt"
+  git -C "$case_dir/project" add -- shared.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "rewritten separated hunks"
+  sed 's/^landed-eleven$/a11/' "$case_dir/project/shared.txt" > "$case_dir/project/shared.next"
+  mv "$case_dir/project/shared.next" "$case_dir/project/shared.txt"
+  git -C "$case_dir/project" add -- shared.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "revert second hunk"
+
+  cat > "$case_dir/fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+touch "$case_dir/treehouse-called"
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "rebased-hunk-revert: teardown should refuse"
+  grep -q REFUSED "$case_dir/stderr" || fail "rebased-hunk-revert: no REFUSED line in stderr"
+  [ ! -e "$case_dir/treehouse-called" ] || fail "rebased-hunk-revert: destructive return was invoked"
+  grep -Fxq landed-eleven "$case_dir/wt/shared.txt" || fail "rebased-hunk-revert: worktree hunk was discarded"
+  pass "local-only worktree whose same-file patch was partially reverted is refused"
 }
 
 test_local_only_rewritten_rename_patch_landed_allows() {
@@ -3017,6 +3064,7 @@ test_local_only_rebased_patch_combined_revert_on_main_refuses
 test_local_only_rebased_patch_sequence_jointly_reverted_on_main_refuses
 test_local_only_rebased_multifile_patch_partially_reverted_on_main_refuses
 test_local_only_rebased_patch_reverted_then_relanded_allows
+test_local_only_rebased_same_file_hunk_partially_reverted_refuses
 test_local_only_rebased_patch_landed_but_dirty_refuses
 test_no_mistakes_rebased_patch_landed_after_later_edit_allows
 test_local_only_rewritten_rename_patch_landed_allows

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -53,6 +53,7 @@
 #   (q2e) local-only + one file of landed patch reverted         -> REFUSE (safety)
 #   (q2f) local-only + reverted patch re-landed                  -> ALLOW  (current state)
 #   (q2g) local-only + one same-file hunk reverted               -> REFUSE (safety)
+#   (q2h) local-only + one added line reverted                   -> REFUSE (safety)
 #   (q3) local-only + every patch landed but worktree dirty     -> REFUSE (dirty wins)
 #   (q4) no-mistakes + patch landed, main edited it afterwards  -> ALLOW  (rebase fix)
 #   (q5) local-only + rewritten rename patch landed              -> ALLOW  (rename fix)
@@ -1015,6 +1016,44 @@ SH
   [ ! -e "$case_dir/treehouse-called" ] || fail "rebased-hunk-revert: destructive return was invoked"
   grep -Fxq landed-eleven "$case_dir/wt/shared.txt" || fail "rebased-hunk-revert: worktree hunk was discarded"
   pass "local-only worktree whose same-file patch was partially reverted is refused"
+}
+
+test_local_only_rebased_added_line_partially_reverted_refuses() {
+  local case_dir rc
+  case_dir=$(make_case rebased-added-line-revert)
+  write_meta "$case_dir" local-only ship
+
+  printf '%s\n' A B > "$case_dir/wt/feature.txt"
+  git -C "$case_dir/wt" add -- feature.txt
+  git -C "$case_dir/wt" -c user.email=t@t -c user.name=t commit -q -m "add two-line feature"
+
+  printf '%s\n' moved > "$case_dir/project/unrelated.txt"
+  git -C "$case_dir/project" add -- unrelated.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "main moved"
+  printf '%s\n' A B > "$case_dir/project/feature.txt"
+  git -C "$case_dir/project" add -- feature.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "rewritten two-line feature"
+  printf '%s\n' A > "$case_dir/project/feature.txt"
+  git -C "$case_dir/project" add -- feature.txt
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -q -m "revert added line"
+
+  cat > "$case_dir/fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+touch "$case_dir/treehouse-called"
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "rebased-added-line-revert: teardown should refuse"
+  grep -q REFUSED "$case_dir/stderr" || fail "rebased-added-line-revert: no REFUSED line in stderr"
+  [ ! -e "$case_dir/treehouse-called" ] || fail "rebased-added-line-revert: destructive return was invoked"
+  grep -Fxq B "$case_dir/wt/feature.txt" || fail "rebased-added-line-revert: worktree line was discarded"
+  pass "local-only worktree whose added line was reverted is refused"
 }
 
 test_local_only_rewritten_rename_patch_landed_allows() {
@@ -3065,6 +3104,7 @@ test_local_only_rebased_patch_sequence_jointly_reverted_on_main_refuses
 test_local_only_rebased_multifile_patch_partially_reverted_on_main_refuses
 test_local_only_rebased_patch_reverted_then_relanded_allows
 test_local_only_rebased_same_file_hunk_partially_reverted_refuses
+test_local_only_rebased_added_line_partially_reverted_refuses
 test_local_only_rebased_patch_landed_but_dirty_refuses
 test_no_mistakes_rebased_patch_landed_after_later_edit_allows
 test_local_only_rewritten_rename_patch_landed_allows

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -47,6 +47,7 @@
 #   (q) no-mistakes + NO pr= recorded, PR discovered by branch  -> ALLOW  (yolo/no-CI merge)
 #   (q1) local-only + patch landed under a rewritten commit     -> ALLOW  (rebase fix)
 #   (q2) local-only + one commit's patch absent from main       -> REFUSE (safety)
+#   (q2b) local-only + landed patch reverted on main again      -> REFUSE (safety)
 #   (q3) local-only + every patch landed but worktree dirty     -> REFUSE (dirty wins)
 #   (q4) no-mistakes + patch landed, main edited it afterwards  -> ALLOW  (rebase fix)
 #
@@ -281,6 +282,18 @@ land_rewritten_patch_on_local_main() {
   git -C "$case_dir/project" add -- "$file"
   git -C "$case_dir/project" -c user.email=t@t -c user.name=t \
     commit -q -m "rebased: add $file"
+}
+
+# Same rewritten-commit landing on the LOCAL default branch, followed by a commit
+# that reverts it again. The patch is in main's history but the work is gone from
+# main's tree, so teardown must not treat the branch as landed.
+# Args: case_dir file content
+land_rewritten_patch_then_revert_on_local_main() {
+  local case_dir=$1 file=$2 content=$3
+  land_rewritten_patch_on_local_main "$case_dir" "$file" "$content"
+  git -C "$case_dir/project" rm -q -- "$file"
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t \
+    commit -q -m "revert: drop $file again"
 }
 
 # Same rewritten-commit landing, but on origin's default branch, followed by a
@@ -743,6 +756,30 @@ test_local_only_rebased_patch_with_absent_commit_refuses() {
   grep -Fq "commits not yet on main" "$case_dir/stderr" \
     || fail "rebased-partial: refusal did not name the commits still missing from main"
   pass "local-only worktree with a commit whose patch is absent from main is refused"
+}
+
+test_local_only_rebased_patch_reverted_on_main_refuses() {
+  local case_dir rc
+  case_dir=$(make_case rebased-reverted)
+  write_meta "$case_dir" local-only ship
+  wt_commit_file "$case_dir" feature.txt hello "add feature"
+  # The patch landed under a rewritten commit and main then reverted it, so the
+  # work exists nowhere but this worktree; patch equivalence must not clear it.
+  land_rewritten_patch_then_revert_on_local_main "$case_dir" feature.txt hello
+  [ ! -e "$case_dir/project/feature.txt" ] \
+    || fail "rebased-reverted: feature.txt is still in main's tree; case is vacuous"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "rebased-reverted: teardown should refuse when the landed patch was reverted"
+  grep -q REFUSED "$case_dir/stderr" || fail "rebased-reverted: no REFUSED line in stderr"
+  grep -Fq "commits not yet on main" "$case_dir/stderr" \
+    || fail "rebased-reverted: refusal did not name the commits still missing from main"
+  [ -e "$case_dir/wt/feature.txt" ] || fail "rebased-reverted: worktree work was discarded"
+  pass "local-only worktree whose landed patch was reverted on main is refused"
 }
 
 test_local_only_rebased_patch_landed_but_dirty_refuses() {
@@ -2738,6 +2775,7 @@ test_local_only_truly_unpushed_refuses
 test_local_only_merged_to_local_main_allows
 test_local_only_rebased_patch_landed_allows
 test_local_only_rebased_patch_with_absent_commit_refuses
+test_local_only_rebased_patch_reverted_on_main_refuses
 test_local_only_rebased_patch_landed_but_dirty_refuses
 test_no_mistakes_rebased_patch_landed_after_later_edit_allows
 test_no_mistakes_origin_remote_allows


### PR DESCRIPTION
## Intent

Fix a false refusal in bin/fm-teardown.sh's landed-work safety check: after a rebase, a branch whose content landed in full under rewritten commits could never be reclaimed, because the check only asked whether the branch's COMMITS were reachable from main. Rebase is the normal path here - bin/fm-merge-local.sh is fast-forward-only, so every second chain landing into a moved default branch must rebase first - so every multi-chain local-only graph ended with parent nodes that ordinary teardown could never reclaim, and the documented remedies (merge again, or --force) were both wrong for work that was not actually at risk.

The fix teaches the check about patch equivalence (the `git cherry` / patch-id relationship) so content that landed under a rewritten commit is recognised as landed, and removes the NEED for --force in this case rather than making --force easier to reach.

The safety property must NOT weaken. Teardown must still refuse genuinely unlanded work: it keeps refusing when a commit's patch is genuinely absent from main, keeps refusing on uncommitted changes regardless of patch state, and --force stays gated on explicit captain authority.

Decisions made deliberately during this work - please treat these as intended, not as mistakes:
1. Terminator-aware comparison: a difference that is only a trailing newline must NEVER read as landed. If equivalence cannot be proven including line terminators, it is NOT landed - refuse.
2. Location-preserving proof: reverse-apply must not match an identical block at the wrong location. If location cannot be established, treat as NOT landed and refuse.
3. Net-zero sequences are allowed only AFTER per-patch proof that both inverse patches genuinely landed - never inferred from an empty net diff.
4. Governing invariant: this change may turn a false "landed" into a refusal freely, but may only turn a refusal into an allow on positive proof.
5. A patch that landed and was later reverted, partially reverted, relocated, replaced, or had one hunk or one added line undone must refuse. A landed patch that main later added unrelated lines on top of (a genuine superset) may allow.
6. The reference scan is bounded to the paths the subject commits touch and batched through one `git log -p | git patch-id` pipeline, so cost does not grow with the default branch's history.

Acceptance criteria the change must meet, and the tests that must prove them genuinely distinguishing (no single implementation may pass all three by weakening the check):
- a test proves teardown allows reclaim when a branch's patch landed under a rewritten commit;
- a test proves teardown still REFUSES when the branch has a commit whose patch is not on main;
- a test proves teardown still refuses on uncommitted changes even when all commits landed.

Verified locally before this run: the full tests/fm-teardown.test.sh suite passes (78 assertions, 0 failures); bin/fm-lint.sh is clean including pinned actionlint; bin/fm-doc-audience-check.sh passes. The distinguishing property was proven empirically - the allow test fails against the pre-fix guard from origin/main, and the refuse test fails against a deliberately weakened build whose patch check returns success unconditionally.

The final commit on this branch only clears three shellcheck findings that bin/fm-lint.sh (the repo's canonical lint gate, which CI invokes directly) reported in the new code: it asserts the numstat record carries its path field, gives two locals explicit empty-string initialisers, and checks a diff's exit status directly. All three are behavior-preserving or fail-closed.

This repo is firstmate's own shared tracked material and bin/fm-teardown.sh is a safety-critical guard, so .agents/skills/firstmate-coding-guidelines/SKILL.md applies: one sentence per line in tracked Markdown, plain dashes, shellcheck-clean bin scripts, tests colocated in tests/ as <subject>.test.sh, and tests must exercise behavior through an executable interface rather than asserting implementation source bytes.

## What Changed

- `bin/fm-teardown.sh`'s landed-work check no longer relies on commit reachability alone: a new `patches_are_in_ref` arm accepts a branch when every commit the default branch cannot reach is present there as a patch (the `git cherry` / patch-id relationship), which is the only way work rewritten by a rebase can be recognized. The reference scan runs through one batched `git log -p | git patch-id` pipeline bounded to the paths the subject commits touch, and the old `content_in_default` was split into `default_landing_ref` plus a ref-parameterized `content_in_ref`.
- The patch arm allows only on positive proof: `subject_patches_are_in_reference` requires every subject patch on the reference side and then a per-path `changes_are_represented_in_tree` proof that reverse-applies each path's binary/full-index patch against a scratch index of the reference tree, rejecting hunks that matched at an offset (relocation), trailing-newline-only differences, non-blob or mode changes, and any path the tree has since deleted lines from; a net-zero subject range is allowed only after both inverse patches are individually proven and the tip tree still matches over those paths. The merged-PR path keeps its patch-id-only contract, and `validate_worktree_teardown_safety` still refuses on uncommitted changes with a distinct message when the commits did land.
- `tests/fm-teardown.test.sh` adds ~20 behavior-level cases through the teardown executable covering the rebase allow, an absent-patch refusal, dirty-worktree refusal after landing, plus reverted, partially reverted, relocated, replaced, superset, rename, net-zero and patch-history-failure variants; `docs/gitlab-merge-watch.md` updates its one-line description of teardown's fallback to name the default-branch checks.

## Risk Assessment

⚠️ Medium: A 400-line rewrite of a safety-critical destructive-action guard is large in blast radius, but every new arm is fail-closed, the loosening is gated behind a per-commit patch-id match plus a location-preserving tree-representation proof, and 20 new behavior-level tests cover the three required distinguishing criteria plus revert/relocate/replace/newline/net-zero adversarial cases — so it is safe to merge with the informational notes as follow-ups.

## Testing

Ran the subject's own suite (tests/fm-teardown.test.sh: 79 assertions, 0 failures) and then exercised bin/fm-teardown.sh directly in sandboxed repos to capture the operator-visible CLI output for each acceptance criterion: teardown now completes for a branch whose patch landed under a rewritten commit, still refuses with 'commits not yet on main' when a commit's patch is absent, and still refuses on uncommitted changes with copy that correctly credits the landed commits. Re-running the same rebase scenario against the pre-fix script from the base commit reproduces the original false REFUSED, so the fix is genuinely distinguishing rather than a weakened check; transcripts and suite results are saved as evidence and the worktree was left clean.

<details>
<summary>Evidence: Teardown CLI transcript after the fix (three acceptance scenarios)</summary>

Source: [Teardown CLI transcript after the fix (three acceptance scenarios)](https://github.com/IanQiu979/firstmate/blob/6576899eb0e046e1516382481bb0de79d7418c1a/.no-mistakes/evidence/fm/fm-teardown-false-refusal-after-rebase/teardown-cli-transcript-after-fix.txt)

<code>SCENARIO 1 (patch landed under a rewritten commit):&#10;* f58ae1b add feature&#10;| * f27dbd5 rebased: add feature.txt&#10;| * 1938898 unrelated main commit&#10;[branch commits are NOT reachable from main - rebase rewrote them]&#10;$ fm-teardown.sh task-x1&#10;teardown task-x1 complete (window firstmate:fm-task-x1, worktree .../evid-landed-rebase/wt)&#10;[exit status: 0]&#10;&#10;SCENARIO 2 (a commit&#39;s patch never landed):&#10;REFUSED: local-only worktree .../evid-unlanded-commit/wt has work not yet merged into main and not on any remote.&#10;commits not yet on main:&#10;e1ea9f4 add extra&#10;a41a0b4 add feature&#10;[exit status: 1]&#10;&#10;SCENARIO 3 (all commits landed, worktree dirty):&#10;REFUSED: local-only worktree .../evid-dirty/wt has uncommitted changes; its commits already landed in main.&#10;uncommitted changes present&#10;Commit the uncommitted changes (or get the captain&#39;s explicit OK to discard, then --force).&#10;[exit status: 1]</code>

```text

=========================================================
$ SCENARIO 1: branch content landed under a rewritten (rebased) commit -> expect ALLOW
=========================================================

--- git state (branch fm/task-x1 vs local main) ---
    * f58ae1b add feature
    | * f27dbd5 rebased: add feature.txt
    | * 1938898 unrelated main commit
    |/  
    * b605b30 origin baseline
    [branch commits are NOT reachable from main - rebase rewrote them]

=========================================================
$ fm-teardown.sh task-x1
=========================================================
teardown task-x1 complete (window firstmate:fm-task-x1, worktree /var/folders/62/t6ydhgg91f3df0jm3k2r0fh80000gp/T//fm-teardown-tests.9rGZet/evid-landed-rebase/wt)
Backlog: task-x1 just finished. Run tasks-axi done task-x1 --note "local main", then run tasks-axi ready for dependency-cleared candidates, check date gates, and dispatch only work whose blockers are gone and date is due.

[exit status: 0]

=========================================================
$ SCENARIO 2: a second commit's patch never landed on main -> expect REFUSE
=========================================================

--- git state (branch fm/task-x1 vs local main) ---
    * e1ea9f4 add extra
    * a41a0b4 add feature
    | * d25998e rebased: add feature.txt
    | * dda8f3e unrelated main commit
    |/  
    * fb1bf79 origin baseline
    [branch commits are NOT reachable from main - rebase rewrote them]

=========================================================
$ fm-teardown.sh task-x1
=========================================================
REFUSED: local-only worktree /var/folders/62/t6ydhgg91f3df0jm3k2r0fh80000gp/T//fm-teardown-tests.9rGZet/evid-unlanded-commit/wt has work not yet merged into main and not on any remote.
commits not yet on main:
e1ea9f4 add extra
a41a0b4 add feature
Merge the branch into local main first (bin/fm-merge-local.sh after the captain approves), or push to a fork/remote, or get the captain's explicit OK to discard, then --force.

[exit status: 1]

=========================================================
$ SCENARIO 3: every commit landed but the worktree is dirty -> expect REFUSE
=========================================================

--- git state (branch fm/task-x1 vs local main) ---
    * a1dd054 rebased: add feature.txt
    * 61469b2 unrelated main commit
    | * 0386f38 add feature
    |/  
    * cec1200 origin baseline
    [branch commits are NOT reachable from main - rebase rewrote them]

=========================================================
$ fm-teardown.sh task-x1
=========================================================
REFUSED: local-only worktree /var/folders/62/t6ydhgg91f3df0jm3k2r0fh80000gp/T//fm-teardown-tests.9rGZet/evid-dirty/wt has uncommitted changes; its commits already landed in main.
uncommitted changes present
Commit the uncommitted changes (or get the captain's explicit OK to discard, then --force).

[exit status: 1]
```
</details>
<details>
<summary>Evidence: Same scenarios against the pre-fix script (base commit 038d0f7) — shows the false refusal</summary>

Source: [Same scenarios against the pre-fix script (base commit 038d0f7) — shows the false refusal](https://github.com/IanQiu979/firstmate/blob/6576899eb0e046e1516382481bb0de79d7418c1a/.no-mistakes/evidence/fm/fm-teardown-false-refusal-after-rebase/teardown-cli-transcript-before-fix.txt)

<code>SCENARIO 1 (patch landed under a rewritten commit), pre-fix build:&#10;$ fm-teardown.sh task-x1&#10;REFUSED: local-only worktree .../evid-landed-rebase/wt has work not yet merged into main and not on any remote.&#10;commits not yet on main:&#10;2899557 add feature&#10;Merge the branch into local main first (bin/fm-merge-local.sh after the captain approves), or push to a fork/remote, or get the captain&#39;s explicit OK to discard, then --force.&#10;[exit status: 1]</code>

```text

=========================================================
$ SCENARIO 1: branch content landed under a rewritten (rebased) commit -> expect ALLOW
=========================================================

--- git state (branch fm/task-x1 vs local main) ---
    * 2899557 add feature
    | * 766c71a rebased: add feature.txt
    | * 0ca7ebe unrelated main commit
    |/  
    * c0ef6a6 origin baseline
    [branch commits are NOT reachable from main - rebase rewrote them]

=========================================================
$ fm-teardown.sh task-x1
=========================================================
REFUSED: local-only worktree /var/folders/62/t6ydhgg91f3df0jm3k2r0fh80000gp/T//fm-teardown-tests.Zt78CS/evid-landed-rebase/wt has work not yet merged into main and not on any remote.
commits not yet on main:
2899557 add feature
Merge the branch into local main first (bin/fm-merge-local.sh after the captain approves), or push to a fork/remote, or get the captain's explicit OK to discard, then --force.

[exit status: 1]

=========================================================
$ SCENARIO 2: a second commit's patch never landed on main -> expect REFUSE
=========================================================

--- git state (branch fm/task-x1 vs local main) ---
    * 487782c add extra
    * 79fcbee add feature
    | * 0dd0879 rebased: add feature.txt
    | * abc57b1 unrelated main commit
    |/  
    * 43f6f9f origin baseline
    [branch commits are NOT reachable from main - rebase rewrote them]

=========================================================
$ fm-teardown.sh task-x1
=========================================================
REFUSED: local-only worktree /var/folders/62/t6ydhgg91f3df0jm3k2r0fh80000gp/T//fm-teardown-tests.Zt78CS/evid-unlanded-commit/wt has work not yet merged into main and not on any remote.
commits not yet on main:
487782c add extra
79fcbee add feature
Merge the branch into local main first (bin/fm-merge-local.sh after the captain approves), or push to a fork/remote, or get the captain's explicit OK to discard, then --force.

[exit status: 1]

=========================================================
$ SCENARIO 3: every commit landed but the worktree is dirty -> expect REFUSE
=========================================================

--- git state (branch fm/task-x1 vs local main) ---
    * 9d48280 add feature
    | * ab98af9 rebased: add feature.txt
    | * f847c56 unrelated main commit
    |/  
    * 50d2f87 origin baseline
    [branch commits are NOT reachable from main - rebase rewrote them]

=========================================================
$ fm-teardown.sh task-x1
=========================================================
REFUSED: local-only worktree /var/folders/62/t6ydhgg91f3df0jm3k2r0fh80000gp/T//fm-teardown-tests.Zt78CS/evid-dirty/wt has work not yet merged into main and not on any remote.
uncommitted changes present
commits not yet on main:
9d48280 add feature
Merge the branch into local main first (bin/fm-merge-local.sh after the captain approves), or push to a fork/remote, or get the captain's explicit OK to discard, then --force.

[exit status: 1]
```
</details>
<details>
<summary>Evidence: fm-teardown suite results</summary>

Source: [fm-teardown suite results](https://github.com/IanQiu979/firstmate/blob/6576899eb0e046e1516382481bb0de79d7418c1a/.no-mistakes/evidence/fm/fm-teardown-false-refusal-after-rebase/fm-teardown-suite-results.txt)

<code>ok - local-only worktree whose patch landed under a rewritten commit is torn down&#10;ok - local-only worktree with a commit whose patch is absent from main is refused&#10;ok - worktree with uncommitted changes is refused even when every commit&#39;s patch landed&#10;ok - local-only worktree whose landed trailing newline was removed is refused&#10;ok - local-only worktree whose landed change moved to an identical block is refused&#10;ok - local-only worktree whose rewritten inverse patches net to zero is torn down&#10;...&#10;79 assertions, 0 failures (bash tests/fm-teardown.test.sh, exit 0)</code>

```text
ok - local-only worktree with HEAD on a fork remote is torn down (fix holds)
ok - teardown prompts tasks-axi backlog refresh when compatible
ok - teardown honors config/backlog-backend=manual even when tasks-axi is compatible
ok - local-only worktree with truly unpushed work is refused (safety preserved)
ok - local-only worktree with work merged into local main is torn down (no regression)
ok - local-only worktree whose patch landed under a rewritten commit is torn down
ok - local-only worktree with a commit whose patch is absent from main is refused
ok - local-only worktree whose landed patch was reverted on main is refused
ok - local-only worktree whose patch was reverted with other work is refused
ok - local-only worktree whose landed patch sequence was jointly reverted is refused
ok - local-only worktree whose multi-file patch was partially reverted is refused
ok - local-only worktree whose reverted patch was re-landed is torn down
ok - local-only worktree whose landed change moved to an identical block is refused
ok - local-only worktree whose rewritten inverse patches net to zero is torn down
ok - local-only net-zero worktree whose inverse was later reverted is refused
ok - local-only worktree whose same-file patch was partially reverted is refused
ok - local-only worktree whose added line was reverted is refused
ok - local-only worktree whose added line was replaced is refused
ok - local-only worktree whose added file was fully replaced is refused
ok - local-only worktree whose landed file gained unrelated content is torn down
ok - local-only worktree whose landed trailing newline was removed is refused
ok - worktree with uncommitted changes is refused even when every commit's patch landed
ok - no-mistakes worktree whose landed content was fully replaced is refused
ok - local-only worktree whose rename landed under a rewritten commit is torn down
ok - partial patch-history output cannot authorize teardown
ok - no-mistakes worktree with HEAD on origin is torn down (no regression)
ok - no-mistakes worktree with genuinely unlanded work is refused (safety preserved)
ok - local-only worktree with unpushed work is torn down under --force (escape hatch)
ok - teardown completes when an exact busy-state sidecar is already absent
ok - herdr teardown removes pane-owned escalation dedupe state
ok - herdr flat teardown refuses before returning the isolated copy under lock contention and the retry completes cleanly
ok - herdr flat teardown never erases records when pane presence is unparseable
ok - herdr flat teardown preflight refuses before every destructive change
ok - forced secondmate teardown preflights every Herdr child before cleanup mutation
ok - forced secondmate teardown holds every descendant lifecycle and metadata lock
ok - forced secondmate teardown retains Herdr child identity until exact pane disappearance
ok - forced teardown retains a nested secondmate home and its grandchild's Herdr identity when the grandchild close is unconfirmed
ok - herdr projection teardown retires its journal only after confirming the exact recorded pane is gone
ok - herdr projection teardown retains every record when post-close presence is unknown
ok - herdr projection teardown surfaces failed focus restoration without turning confirmed cleanup into a hard failure
ok - squash-merged + deleted-branch worktree (PR merged) is torn down (the fix)
ok - squash-merged PR accepts a local HEAD that is an ancestor of the final PR head
ok - teardown discovers a merged PR by branch name and tears down when no pr= was ever recorded
ok - squash-merged PR accepts replayed unpushed local patches contained in the PR head
ok - merged-PR path stays patch-id containment when the PR head evolved after the local commit
ok - merged PR does not allow teardown after a later local commit
ok - fm-pr-check does not refresh PR head after HEAD moves
ok - fm-pr-check records the remote PR head when the local worktree lags
ok - worktree whose content already landed in the default branch is torn down (content fallback)
ok - content fallback refreshes origin default before comparing trees
ok - dirty worktree is refused even when its committed work has landed (dirty always wins)
ok - gh lookup error with content not in default refuses (fail-safe)
ok - provably-stale worktree index.lock (old, no live holder) is cleared and teardown succeeds
ok - live-held worktree index.lock is never removed and teardown refuses
ok - lsof errors leave worktree index.lock in place and refuse teardown
ok - stale lock cleanup rechecks and refuses dirty worktree before return
ok - normal repo index.lock is resolved from the worktree and cleared when stale
ok - lock mtime read failures leave worktree index.lock in place and refuse teardown
ok - transient index.lock cleared after first failed return is retried successfully without force-remove
ok - persistent index.lock exhausts retries and refuses without force-removing the lock
ok - empty retry wait overrides use the default without aborting teardown
ok - fractional legacy retry wait remains supported without arithmetic
ok - a task's own parked no-mistakes run is aborted, not orphaned, before the worker is removed
ok - teardown refuses before reap or removal when a task-owned run remains parked
ok - a different run cannot confirm the targeted abort
ok - empty post-abort status is not accepted as confirmation
ok - the CLI's exact run-not-found signal confirms completion
ok - a parked run on another branch is never aborted by this task's teardown (ownership is precise)
ok - a task-owned autonomous running step is left alone rather than aborted
ok - a leaked descendant process rooted under the task's worktree is reaped by teardown, not left surviving
ok - a leaked descendant process rooted under the task's per-task tasktmp is reaped by teardown too
ok - missing lsof falls back to reaping the tmux pane process group
ok - an erroring lsof scan refuses teardown and preserves the task
ok - a reused pid with a different start time is never force-killed
ok - an exec change preserves birth identity and the process is reaped
ok - a process spawned during grace is reaped on a later pass
ok - persistent leaked processes refuse teardown after bounded retries
ok - a process exiting during identity lookup does not block teardown
ok - the run abort and the leaked-process reap both complete before the destructive worktree return

79 assertions, 0 failures (bash tests/fm-teardown.test.sh, exit 0)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"948e09450089583a955116d7bac298e4224205ca","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 3 infos</summary>

- ℹ️ `bin/fm-teardown.sh:1150` - Location-preserving proof rejects any hunk that reverse-applies at a non-zero offset, so the &#34;genuine superset&#34; allowance of decision 5 only actually reaches files the branch ADDED (the pre_entry-empty fallback). Concrete state I verified in a scratch repo: branch changes line 20 of f.txt; main lands the rewritten commit and a later main commit prepends one line to f.txt. `git apply --cached --check --reverse --verbose -p0` then prints &#34;Hunk #1 succeeded at 18 (offset -1 lines).&#34;, the grep at line 1150 matches, and teardown refuses even though the work is fully present in main. This is fail-closed and permitted by governing invariant 4, so it is not a defect — but it is a broader residual false-refusal surface than the header comment implies, and it is reachable in exactly the multi-chain rebase scenario this change targets (chain A edits the same file above chain B&#39;s hunk). Worth a line in the patches_are_in_ref comment so a future reader does not read decision 5 as already covered for modified files.
- ℹ️ `bin/fm-teardown.sh:1424` - The script runs under `set -eu`. Three new sites capture a deliberately-failing command&#39;s status as a bare statement rather than in a condition: `subject_patches_are_in_reference ...; status=$?` (1423-1424), `git apply --cached --check --reverse ...; status=$?` (1146-1147), and `git diff --quiet ...; status=$?` (1323-1324). These are correct today only because every entry point is evaluated inside an `if`/`&amp;&amp;` condition (`if [ -n &#34;$unmerged&#34; ] &amp;&amp; patches_are_in_ref ...` at 1728, `if ! work_is_landed ...` at 1756), which suppresses errexit for the whole call subtree. A future caller invoking `patches_are_in_ref` as a plain statement would make the script exit at the first non-zero git status instead of returning &#34;not landed&#34;. Consequence is fail-closed (teardown aborts non-zero), so this is a maintenance hazard rather than a safety hole; an inline note or `|| status=$?` idiom would make the dependency explicit.
- ℹ️ `bin/fm-teardown.sh:1199` - The `numstat` (pre-&gt;post) binary guard at 1199/1210 is unreachable as a distinct case. This arm is only entered after `[ -z &#34;$pre_entry&#34; ]` succeeded, so `pre` has no blob for the path and binary-ness of the pre-&gt;post diff is decided solely by `post`. Whenever pre-&gt;post is binary, `post` is binary, so the `current_numstat` (post-&gt;tree) binary guard at 1216 already fires. The check is harmless and fail-closed; it exists mainly to give the `numstat` local a use for SC2034. Dropping it (and the now-unused local) would remove a branch that no input can reach on its own.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-teardown.test.sh` — full subject suite for the changed script (79 ok assertions, 0 failures, exit 0)</code>
- <code>Manual CLI run of `bin/fm-teardown.sh task-x1` on a sandbox where the branch&#39;s patch landed under a rewritten commit (allow, exit 0)</code>
- <code>Manual CLI run of `bin/fm-teardown.sh task-x1` with a second commit whose patch never reached main (refuse, exit 1, names the missing commits)</code>
- <code>Manual CLI run of `bin/fm-teardown.sh task-x1` with all commits landed but staged uncommitted changes (refuse, exit 1, &#39;uncommitted changes present&#39;)</code>
- <code>Same three scenarios re-run against `git show 038d0f7:bin/fm-teardown.sh` (pre-fix) to prove the rebase case previously produced a false REFUSED</code>
- <code>`git status --porcelain` — worktree left clean, scratch harness removed</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: no lint changes needed; fm-lint.sh passes clean
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
