### PR TITLE
fix(bin): refuse task id reuse when data directory exists

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -54,6 +54,7 @@
 # it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers
 # over copied detail) and has the crewmate add the fm-ensure-agents-md.sh
 # self-governance section when a touched project AGENTS.md lacks it.
+# Refuses claiming a task id whose data/<task-id>/ directory already exists.
 # Refuses to overwrite an existing brief.
 set -eu
 
@@ -154,6 +155,7 @@ elif [ "$MODE_SET" -eq 1 ]; then
   echo "error: --mode applies only to ship briefs; a scout delivers a report and a secondmate charter is not a delivery contract" >&2
   exit 1
 fi
+[ "${#POS[@]}" -ge 1 ] || { echo "error: task id is required" >&2; exit 1; }
 ID=${POS[0]}
 
 if [ "$KIND" = secondmate ] && [ "$HERDR_LAB" -eq 1 ]; then
@@ -163,6 +165,34 @@ fi
 
 if [ "$NO_PROJECTS" -eq 1 ] && [ "$KIND" != secondmate ]; then
   echo "error: --no-projects applies only to --secondmate charters" >&2
+  exit 1
+fi
+
+if [ -e "$DATA/$ID" ]; then
+  contents=""
+  if [ -d "$DATA/$ID" ]; then
+    entries=()
+    shopt -s nullglob dotglob
+    for entry in "$DATA/$ID"/*; do
+      entries+=("$(basename "$entry")")
+    done
+    shopt -u nullglob dotglob
+    for entry in "${entries[@]}"; do
+      if [ -n "$contents" ]; then
+        contents="$contents, $entry"
+      else
+        contents="$entry"
+      fi
+    done
+  fi
+  if [ -n "$contents" ]; then
+    contents_desc="contains: $contents"
+  elif [ -d "$DATA/$ID" ]; then
+    contents_desc="empty directory"
+  else
+    contents_desc="existing file"
+  fi
+  echo "error: task id '$ID' already exists at $DATA/$ID ($contents_desc); choose a distinct task id (e.g. '$ID-2' or mint a new one) to preserve retained history and avoid collisions" >&2
   exit 1
 fi
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -543,7 +543,7 @@ test_secondmate_directory_paths_are_absolute_and_output_is_stable() {
     "$ROOT/bin/fm-brief.sh" relative-home --secondmate --no-projects >/dev/null 2>&1
   baseline="$root/absolute-home-charter"
   cp "$brief" "$baseline"
-  rm -f "$brief"
+  rm -rf "$home/data/relative-home"
   (
     cd "$root" || exit 1
     CDPATH="$root/cdpath" FM_HOME=home FM_SECONDMATE_CHARTER=x \
@@ -559,7 +559,7 @@ test_secondmate_directory_paths_are_absolute_and_output_is_stable() {
     "$ROOT/bin/fm-brief.sh" relative-state --secondmate --no-projects >/dev/null 2>&1
   baseline="$root/absolute-state-charter"
   cp "$brief" "$baseline"
-  rm -f "$brief"
+  rm -rf "$home/data/relative-state"
   (
     cd "$root" || exit 1
     CDPATH="$root/cdpath" FM_HOME="$home" FM_STATE_OVERRIDE=state-override FM_SECONDMATE_CHARTER=x \
@@ -575,7 +575,7 @@ test_secondmate_directory_paths_are_absolute_and_output_is_stable() {
     "$ROOT/bin/fm-brief.sh" relative-data --secondmate --no-projects >/dev/null 2>&1
   baseline="$root/absolute-data-charter"
   cp "$brief" "$baseline"
-  rm -f "$brief"
+  rm -rf "$data_override/relative-data"
   (
     cd "$root" || exit 1
     CDPATH="$root/cdpath" FM_HOME="$home" FM_DATA_OVERRIDE=data-override FM_SECONDMATE_CHARTER=x \
@@ -712,6 +712,72 @@ test_scout_and_secondmate_scaffold() {
   pass "fm-brief: scout and secondmate code paths still scaffold well-formed briefs"
 }
 
+# Claiming a task id whose data/<id>/ already exists is refused and preserves retained reports.
+test_task_id_reuse_refused_and_preserves_retained_report() {
+  local home id report_path report_content err status
+  home="$TMP_ROOT/id-reuse-home"
+  mkdir -p "$home/data"
+
+  # Case 1: Existing data/<id>/ containing a retained report
+  id="vm-verify-12"
+  mkdir -p "$home/data/$id"
+  report_path="$home/data/$id/report.md"
+  report_content="Detailed verification report for earlier work. Preserved intact."
+  printf '%s\n' "$report_content" > "$report_path"
+
+  err="$home/retained-report.err"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes 2>"$err"; status=$?
+  expect_code 1 "$status" "claiming an id with an existing data/<id>/ directory must exit 1"
+  assert_grep "error: task id '$id' already exists at $home/data/$id (contains: report.md)" "$err" \
+    "refusal did not name the directory and list its retained contents"
+  assert_grep "choose a distinct task id (e.g. '$id-2' or mint a new one)" "$err" \
+    "refusal did not provide a way forward for the operator"
+
+  # Verify the retained report survives intact
+  [ -f "$report_path" ] || fail "retained report.md was removed"
+  [ "$(cat "$report_path")" = "$report_content" ] \
+    || fail "retained report.md content was modified during attempted id reuse"
+  assert_absent "$home/data/$id/brief.md" "brief.md was written despite id reuse refusal"
+
+  # Case 2: Existing data/<id>/ containing multiple artifacts (brief and report)
+  id="multi-artifact-task"
+  mkdir -p "$home/data/$id"
+  printf 'prior brief\n' > "$home/data/$id/brief.md"
+  printf 'prior report\n' > "$home/data/$id/report.md"
+  err="$home/multi-artifact.err"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --scout 2>"$err"; status=$?
+  expect_code 1 "$status" "scout scaffold with existing data/<id>/ must exit 1"
+  assert_grep "error: task id '$id' already exists at $home/data/$id (contains: brief.md, report.md)" "$err" \
+    "refusal did not list all entries in data/<id>"
+
+  # Case 3: Existing empty data/<id>/ directory
+  id="empty-dir-task"
+  mkdir -p "$home/data/$id"
+  err="$home/empty-dir.err"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode direct-PR 2>"$err"; status=$?
+  expect_code 1 "$status" "scaffold with empty existing data/<id> must exit 1"
+  assert_grep "error: task id '$id' already exists at $home/data/$id (empty directory)" "$err" \
+    "refusal did not identify empty directory"
+
+  # Case 4: Existing file at data/<id>
+  id="file-task"
+  touch "$home/data/$id"
+  err="$home/file-task.err"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode local-only 2>"$err"; status=$?
+  expect_code 1 "$status" "scaffold with existing file at data/<id> must exit 1"
+  assert_grep "error: task id '$id' already exists at $home/data/$id (existing file)" "$err" \
+    "refusal did not identify existing file"
+
+  # Case 5: Unused task id succeeds without tripping the refusal
+  id="fresh-task-unused"
+  err="$home/fresh-task.err"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>"$err"; status=$?
+  expect_code 0 "$status" "scaffold with unused task id must exit 0"
+  assert_present "$home/data/$id/brief.md" "brief was not scaffolded for unused task id"
+
+  pass "fm-brief: task id reuse is refused, reports directory contents, gives a way forward, and preserves retained artifacts"
+}
+
 test_script_parses
 test_no_heredoc_in_command_substitution
 test_help_includes_entire_header
@@ -732,3 +798,4 @@ test_secondmate_directory_paths_are_absolute_and_output_is_stable
 test_pause_verb_override_renders_all_brief_scaffolds
 test_scout_and_secondmate_load_decision_hold_policy
 test_scout_and_secondmate_scaffold
+test_task_id_reuse_refused_and_preserves_retained_report

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -1817,6 +1817,15 @@ TS
     fi
 
     pane=$(tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" -S - 2>/dev/null || true)
+    i=0
+    while [ "$i" -lt 120 ]; do
+      pane=$(tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" -S - 2>/dev/null || true)
+      if printf '%s\n' "$pane" | grep -Fq "CAPTAIN_ANSWER_$label" && printf '%s\n' "$pane" | grep -Fq "MONITOR_HANDLED_${label}_ONE"; then
+        break
+      fi
+      sleep 0.05
+      i=$((i + 1))
+    done
     [ "$(printf '%s\n' "$pane" | grep -Fc "CAPTAIN_ANSWER_$label" || true)" -eq 1 ] \
       || fail "Pi follow-up $label case rendered a duplicate captain answer"
     assert_contains "$pane" "CAPTAIN_PROMPT_$label" "Pi follow-up $label case hid the genuine captain prompt"


### PR DESCRIPTION
## Intent

Refuse task id reuse in fm-brief.sh when a data/<id> directory already exists to protect retained reports and prevent stale task instruction collisions

## What Changed
- Added a validation in `bin/fm-brief.sh` that requires a task ID and refuses brief creation if `$DATA/<id>` already exists, reporting the existing path contents and exiting with an error.
- Added tests in `tests/fm-brief.test.sh` verifying task ID reuse refusal across existing files and directories, and updated test teardowns to remove full task data directories.
- Added a retry loop in `tests/fm-calm-pi-extension.test.sh` when capturing tmux pane contents.

## Risk Assessment

✅ Low: The change cleanly refuses task ID reuse when a task data directory already exists, protecting retained artifacts with clear error reporting and thorough test coverage.

## Testing

`Executed targeted unit tests in tests/fm-brief.test.sh and performed end-to-end verification of bin/fm-brief.sh demonstrating refusal on existing data/<id> directories/files and report preservation, with evidence recorded in /tmp/no-mistakes-evidence/01M0AZQVAQWN146YANWJVWCVBY/task-id-reuse-cli-transcript.txt.`

<details>
<summary>Evidence: CLI transcript demonstrating task ID reuse refusal and retained report preservation</summary>

Source: [CLI transcript demonstrating task ID reuse refusal and retained report preservation](https://github.com/BohnBawerick/firstmate/blob/000e633025369a26dcf3ad366798251cea2e703d/.no-mistakes/evidence/fm/fm-task-id-reuse/task-id-reuse-cli-transcript.txt)

```text
=== Scenario 1: Refusing task ID reuse with existing retained report ===
[Attempting to scaffold task-101]
error: task id 'task-101' already exists at /tmp/tmp.LMGXHKvA1H/demo-home/data/task-101 (contains: report.md); choose a distinct task id (e.g. 'task-101-2' or mint a new one) to preserve retained history and avoid collisions
[Command exited non-zero as expected]
[Checking preserved report.md content:]
Original report from previous run
[Checking brief.md does not exist:]
brief.md is absent (protected)

=== Scenario 2: Refusing task ID reuse with multiple artifacts ===
[Attempting to scaffold task-102 with --scout]
error: task id 'task-102' already exists at /tmp/tmp.LMGXHKvA1H/demo-home/data/task-102 (contains: brief.md, report.md); choose a distinct task id (e.g. 'task-102-2' or mint a new one) to preserve retained history and avoid collisions
[Command exited non-zero as expected]

=== Scenario 3: Refusing task ID reuse with empty directory ===
[Attempting to scaffold task-103 with --mode direct-PR]
error: task id 'task-103' already exists at /tmp/tmp.LMGXHKvA1H/demo-home/data/task-103 (empty directory); choose a distinct task id (e.g. 'task-103-2' or mint a new one) to preserve retained history and avoid collisions
[Command exited non-zero as expected]

=== Scenario 4: Refusing task ID reuse with existing file ===
[Attempting to scaffold task-104 with --mode local-only]
error: task id 'task-104' already exists at /tmp/tmp.LMGXHKvA1H/demo-home/data/task-104 (existing file); choose a distinct task id (e.g. 'task-104-2' or mint a new one) to preserve retained history and avoid collisions
[Command exited non-zero as expected]

=== Scenario 5: Successful scaffolding with fresh/unused task ID ===
[Attempting to scaffold task-105 with --mode no-mistakes]
scaffolded: /tmp/tmp.LMGXHKvA1H/demo-home/data/task-105/brief.md (ship, mode=no-mistakes; replace {TASK})
[Command exited 0 as expected]
[Checking brief.md was created:]
brief.md successfully generated
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"e34bc88388c25cc417722c14d9490ed07cc1b320","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-brief.test.sh`
- <code>`bin/fm-brief.sh` task ID reuse refusal verification across existing retained report, multi-artifact directory, empty directory, existing file, and fresh ID creation</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
