### PR TITLE
Refuse agent co-author trailers in briefs and at merge time

### DIFF
--- a/bin/fm-agent-coauthor-lib.sh
+++ b/bin/fm-agent-coauthor-lib.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Shared guard: refuse a merge whose commits carry a "Co-authored-by:" (or
+# "Co-Authored-By:") trailer naming an AI agent, so the trailer is caught
+# before it lands on a project's default branch rather than found after.
+# This is a mechanical string check, not history rewriting: it never edits or
+# strips a commit, it only decides whether the caller may proceed with a merge.
+#
+# Source this file, then pipe the candidate commit messages (one commit's full
+# message per call is fine, or all of them concatenated) to:
+#   fm_agent_coauthor_scan <<<"$commit_messages"
+# It prints each offending trailer line to stderr and returns 1 if any is
+# found, or returns 0 silently otherwise.
+
+FM_AGENT_COAUTHOR_PATTERN='^(co-authored-by|co-author):.*(claude|anthropic|chatgpt|openai|copilot|codex|gemini|cursor-agent|noreply@anthropic\.com|noreply@openai\.com)'
+
+fm_agent_coauthor_scan() {
+  local hits line
+  hits=$(grep -Eio "$FM_AGENT_COAUTHOR_PATTERN" || true)
+  [ -z "$hits" ] && return 0
+  echo "error: commit(s) carry an agent co-author trailer, which is never allowed:" >&2
+  while IFS= read -r line; do
+    echo "  $line" >&2
+  done <<<"$hits"
+  return 1
+}

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -335,6 +335,9 @@ The report is the only thing that survives, so anything worth keeping must be in
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+8. Never add an agent or AI name as a commit author or co-author (e.g. a \`Co-authored-by:\` trailer
+   naming an assistant). If your tool defaults to adding one, override that default and commit
+   without it - this applies to every commit you make, including scratch commits.
 
 # Definition of done
 Write your findings to \`$DATA/$ID/report.md\`.
@@ -452,6 +455,9 @@ $RULE1
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+8. Never add an agent or AI name as a commit author or co-author (e.g. a \`Co-authored-by:\` trailer
+   naming an assistant). If your tool defaults to adding one, override that default and commit
+   without it - this applies to every commit you make, including scratch commits.
 
 # Project memory
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.

--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -7,7 +7,9 @@
 # rule #1 "never run state-changing git in projects/", and it is narrow: it only
 # runs for mode=local-only tasks, only after the captain approves (or yolo=on
 # auto-approves), and only as a clean fast-forward - it refuses a diverged branch
-# and tells you to have the crewmate rebase. See AGENTS.md prime directives,
+# and tells you to have the crewmate rebase. It also refuses if any commit
+# being merged carries an agent co-author trailer (see
+# bin/fm-agent-coauthor-lib.sh). See AGENTS.md prime directives,
 # project management, and task lifecycle.
 # Usage: fm-merge-local.sh <task-id>
 set -eu
@@ -16,6 +18,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+# shellcheck source=bin/fm-agent-coauthor-lib.sh
+. "$SCRIPT_DIR/fm-agent-coauthor-lib.sh"
 "$FM_ROOT/bin/fm-guard.sh" || true
 ID=${1:?usage: fm-merge-local.sh <task-id>}
 META="$STATE/$ID.meta"
@@ -59,6 +63,11 @@ fi
 if ! git -C "$PROJ" merge-base --is-ancestor "$DEFAULT" "$BRANCH"; then
   echo "REFUSED: $BRANCH is not a fast-forward of $DEFAULT (it has diverged)." >&2
   echo "Have the crewmate rebase $BRANCH onto $DEFAULT, then retry." >&2
+  exit 1
+fi
+
+if ! git -C "$PROJ" log --format=%B "$DEFAULT..$BRANCH" | fm_agent_coauthor_scan; then
+  echo "REFUSED: fix the commit(s) on $BRANCH (e.g. amend/rebase) and retry." >&2
   exit 1
 fi
 

--- a/bin/fm-pr-merge.sh
+++ b/bin/fm-pr-merge.sh
@@ -4,6 +4,9 @@
 # The full canonical GitHub PR URL is parsed by bin/fm-pr-lib.sh and the derived
 # owner/repository and PR number are passed to gh-axi as separate arguments.
 #
+# Refuses to merge if any PR commit carries an agent co-author trailer (see
+# bin/fm-agent-coauthor-lib.sh); fix the branch and retry rather than bypassing.
+#
 # Merge method defaults to --squash when the caller passes none of --squash,
 # --merge, --rebase, or --method after the optional -- separator. Extra args
 # must not include --repo or -R because the repository comes only from the URL.
@@ -17,6 +20,8 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 
 # shellcheck source=bin/fm-pr-lib.sh
 . "$SCRIPT_DIR/fm-pr-lib.sh"
+# shellcheck source=bin/fm-agent-coauthor-lib.sh
+. "$SCRIPT_DIR/fm-agent-coauthor-lib.sh"
 
 if [ "$#" -lt 2 ]; then
   echo "error: invalid PR merge request" >&2
@@ -75,6 +80,12 @@ grep -qxF "pr=$URL" "$META" || {
   echo "error: PR metadata recording failed" >&2
   exit 1
 }
+
+if ! gh-axi api "repos/$PR_OWNER/$PR_REPO/pulls/$PR_NUMBER/commits" --jq '.[].commit.message' \
+    | fm_agent_coauthor_scan; then
+  echo "REFUSED: fix the offending commit(s) on the PR branch (e.g. amend/rebase and force-push) and retry." >&2
+  exit 1
+fi
 
 merge_args=()
 if ! caller_has_merge_method "$@"; then

--- a/tests/fm-agent-coauthor-lib.test.sh
+++ b/tests/fm-agent-coauthor-lib.test.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Tests for bin/fm-agent-coauthor-lib.sh: the shared scan that fm-pr-merge.sh
+# and fm-merge-local.sh both use to refuse a merge whose commits carry a
+# "Co-authored-by:" trailer naming an AI agent.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+# shellcheck source=bin/fm-agent-coauthor-lib.sh
+. "$ROOT/bin/fm-agent-coauthor-lib.sh"
+
+if printf 'fix: do a thing\n\nSome unrelated body text.\n' | fm_agent_coauthor_scan; then
+  pass "fm-agent-coauthor-lib: a commit with no co-author trailer is allowed"
+else
+  fail "fm-agent-coauthor-lib: a commit with no co-author trailer is allowed"
+fi
+
+if printf 'feat: add x\n\nCo-authored-by: Jane Doe <jane@example.com>\n' | fm_agent_coauthor_scan; then
+  pass "fm-agent-coauthor-lib: a human co-author trailer is allowed"
+else
+  fail "fm-agent-coauthor-lib: a human co-author trailer is allowed"
+fi
+
+if printf 'feat: add x\n\nCo-authored-by: Claude Sonnet 5 <noreply@anthropic.com>\n' | fm_agent_coauthor_scan 2>/dev/null; then
+  fail "fm-agent-coauthor-lib: a Claude co-author trailer is refused"
+else
+  pass "fm-agent-coauthor-lib: a Claude co-author trailer is refused"
+fi
+
+if printf 'fix: y\n\nCo-Authored-By: some-bot <noreply@openai.com>\n' | fm_agent_coauthor_scan 2>/dev/null; then
+  fail "fm-agent-coauthor-lib: case-varied trailer and an OpenAI address are still caught"
+else
+  pass "fm-agent-coauthor-lib: case-varied trailer and an OpenAI address are still caught"
+fi
+
+if printf 'fix: multi\n\nCo-authored-by: Jane Doe <jane@example.com>\nCo-authored-by: Codex <codex@example.com>\n' \
+    | fm_agent_coauthor_scan 2>/dev/null; then
+  fail "fm-agent-coauthor-lib: one offending trailer among several is still caught"
+else
+  pass "fm-agent-coauthor-lib: one offending trailer among several is still caught"
+fi

--- a/tests/fm-merge-local.test.sh
+++ b/tests/fm-merge-local.test.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Tests for bin/fm-merge-local.sh's agent-co-author guard: a local-only merge
+# must be refused, without touching the default branch, when any commit being
+# merged carries a "Co-authored-by:" trailer naming an AI agent.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+fm_git_identity fmtest fmtest@example.invalid
+
+MERGE_LOCAL="$ROOT/bin/fm-merge-local.sh"
+TMP_ROOT=$(fm_test_tmproot fm-merge-local-tests)
+
+# make_case <name>: a project repo on branch "main" with one commit, plus a
+# task branch fm/task-x1 with one additional commit whose message is passed
+# in. Meta records mode=local-only. Echoes the case dir.
+make_case() {
+  local name=$1 body=$2 case_dir proj
+  case_dir="$TMP_ROOT/$name"
+  proj="$case_dir/project"
+  mkdir -p "$case_dir/state" "$proj"
+  git -C "$proj" init -q -b main
+  git -C "$proj" commit -q --allow-empty -m initial
+  git -C "$proj" checkout -q -b fm/task-x1
+  git -C "$proj" commit -q --allow-empty -m "$body"
+  git -C "$proj" checkout -q main
+  fm_write_meta "$case_dir/state/task-x1.meta" \
+    "project=$proj" \
+    "kind=ship" \
+    "mode=local-only"
+  printf '%s\n' "$case_dir"
+}
+
+run_merge_local() {
+  local case_dir=$1
+  FM_ROOT_OVERRIDE="$ROOT" \
+  FM_STATE_OVERRIDE="$case_dir/state" \
+    "$MERGE_LOCAL" task-x1
+}
+
+# (a) refuses and does not fast-forward when the task branch carries an agent
+# co-author trailer.
+case_dir=$(make_case agent-trailer "fix: add x
+
+Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>")
+before_head=$(git -C "$case_dir/project" rev-parse main)
+task_head=$(git -C "$case_dir/project" rev-parse fm/task-x1)
+[ "$before_head" != "$task_head" ] || fail "fm-merge-local: test setup did not actually diverge main from the task branch"
+out=$(run_merge_local "$case_dir" 2>&1)
+rc=$?
+expect_code 1 "$rc" "fm-merge-local refuses a task branch with an agent co-author trailer"
+assert_contains "$out" "agent co-author trailer" "fm-merge-local refuses a task branch with an agent co-author trailer"
+main_head=$(git -C "$case_dir/project" rev-parse main)
+[ "$main_head" = "$before_head" ] || fail "fm-merge-local: refused merge must not move main"
+pass "fm-merge-local refuses a task branch with an agent co-author trailer"
+
+# (b) a clean task branch with no offending trailer still merges normally.
+case_dir=$(make_case clean "fix: add y")
+out=$(run_merge_local "$case_dir" 2>&1)
+rc=$?
+expect_code 0 "$rc" "fm-merge-local merges a clean task branch: $out"
+main_head=$(git -C "$case_dir/project" rev-parse main)
+task_head=$(git -C "$case_dir/project" rev-parse fm/task-x1)
+[ "$main_head" = "$task_head" ] || fail "fm-merge-local: clean merge did not fast-forward main to the task branch"
+pass "fm-merge-local merges a clean task branch"


### PR DESCRIPTION
## Summary
- Merged commits on deeplabs `main` picked up `Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>` trailers, which the AGENTS.md style rule forbids. Investigation traced this to the underlying coding tool's own default git-commit-message convention, not anything in the crewmate brief itself.
- Adds an explicit rule 8 to both the ship and scout brief scaffolds in `bin/fm-brief.sh`, telling the crewmate to override that default and never add an agent/AI co-author trailer, including on scratch commits.
- Adds a shared mechanical guard, `bin/fm-agent-coauthor-lib.sh`, and wires it into both merge paths (`bin/fm-pr-merge.sh`, `bin/fm-merge-local.sh`) so a merge is refused - before it lands - if any commit in the range carries a `Co-authored-by:`/`Co-Authored-By:` trailer naming a known AI agent (by name token or automated noreply address).
- Scope: the guard applies to every project's delivery path, not just firstmate's own repo, since the underlying cause (a harness-level commit default) is not project-specific.

## Test plan
- [x] `bin/fm-lint.sh` (shellcheck) passes clean on all touched/new scripts
- [x] `tests/fm-agent-coauthor-lib.test.sh` (new): scan correctly allows clean/human trailers and blocks Claude/OpenAI-style and mixed trailers
- [x] `tests/fm-merge-local.test.sh` (new): end-to-end against a real git repo - refuses and leaves `main` untouched when the task branch carries an agent trailer; merges cleanly otherwise
- [x] `tests/fm-pr-merge.test.sh` and `tests/fm-brief.test.sh` (existing) still pass unmodified against the updated scripts
- [x] Manually verified the guard against a real `git log` range and a live commit