### PR TITLE
fix(bin): start no-mistakes validation from worker after commit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -329,7 +329,9 @@ After an autonomous merge, give the captain a one-line full-URL or local-main ou
 
 ### Validate
 
-For a no-mistakes ship, trigger validation on the same worker after its implementation commit, using the harness invocation owned by `harness-adapters`.
+For a no-mistakes ship, the same worker starts its own validation run immediately after the implementation commit and reports `done:` only with a PR.
+The worker appends a nonterminal `working:` line when that run starts, and appends `failed:` or `blocked:` if the run dies mid-pipeline, so firstmate still learns start and failure without a handoff `done:`.
+Firstmate does not send a start trigger after the implementation commit.
 The task worker that starts a no-mistakes run drives the pipeline and owns every `no-mistakes axi run` and `no-mistakes axi respond` call through the next gate or outcome.
 Firstmate never invokes `no-mistakes axi respond` for a crew-owned run.
 Once validation starts, prefer routing new requirements to follow-up work rather than expanding the current task, unless a new requirement completely invalidates the work being validated; however, the smallest downstream changes needed to keep already accepted product or engineering behavior correct, add behavioral tests where an executable contract exists, or keep documentation accurate remain within the current task even when they touch files not named at intake, and corrections required to satisfy already accepted intent are not new requirements.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -30,7 +30,9 @@
 # For ship tasks, --mode is REQUIRED and shapes the definition of done. Firstmate
 # resolves it per task at intake (AGENTS.md section 7); data/projects.md holds the
 # captain's standing posture as context, and this script never reads it:
-#   no-mistakes  implement -> /no-mistakes pipeline -> PR -> configured merge authority
+#   no-mistakes  implement -> worker starts the no-mistakes pipeline (the `no-mistakes axi`
+#                CLI, not a skill) immediately after the implementation commit -> PR ->
+#                configured merge authority
 #   direct-PR    implement -> push + open PR via gh-axi (no pipeline) -> configured merge authority
 #   local-only   implement on branch, stop and report "ready in branch" (no push/PR);
 #                the configured merge authority approves, firstmate merges to local main
@@ -362,7 +364,7 @@ Delivery contract: mode=direct-PR
 This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
 The task is complete only when committed on your branch.
 When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
-Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
+Do NOT run the no-mistakes pipeline. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
 EOF
     ;;
   local-only)
@@ -385,12 +387,13 @@ EOF
     IFS= read -r -d '' DOD <<EOF || true
 # Definition of done
 Delivery contract: mode=no-mistakes
-The task is complete only when committed on your branch.
-When you believe it is complete, append \`done: {summary}\` to the status file and stop.
-Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
+This mode is complete only when the no-mistakes pipeline has shipped a PR whose checks are green.
+When implementation is committed on your branch, start the no-mistakes pipeline yourself immediately.
+Append \`working: starting no-mistakes validation\` to the status file, then run the \`no-mistakes\` CLI on your \`PATH\`: \`no-mistakes axi run --intent "<...>"\` to start, and \`no-mistakes axi respond\` for each gate.
+Do not append \`done:\` until there is a PR.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
-Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
+Follow the guidance no-mistakes itself provides for the mechanics: \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
 When starting no-mistakes, make \`--intent\` preserve all relevant content from this brief's \`# Task\` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
 Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
 
@@ -400,7 +403,9 @@ Two firstmate-specific rules layer on top of that guidance:
   When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
 - Avoid \`--yes\`: it would silently bypass firstmate's authority check and any required captain escalation.
 
-After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
+If you cannot start or continue the run, append \`blocked: {the exact error}\` and stop, never \`done:\`.
+If the run dies mid-pipeline, append \`failed: {the exact error}\` and stop, never stay silent.
+After the run reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
 EOF
     ;;
 esac

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -256,7 +256,7 @@ test_ship_mode_is_explicit_not_registry() {
   brief="$home/data/brief-explicit-a5/brief.md"
   grep -qx "Delivery contract: mode=no-mistakes" "$brief" \
     || fail "registered direct-PR posture overrode the explicit --mode"
-  assert_grep "Firstmate will then instruct you to run /no-mistakes" "$brief" \
+  assert_grep "start the no-mistakes pipeline yourself immediately" "$brief" \
     "explicit no-mistakes brief did not render the pipeline definition of done"
 
   # An unregistered project is not a blocker either, because nothing is looked up.
@@ -352,6 +352,86 @@ test_no_mistakes_dod_wording() {
   assert_grep "firstmate's authority check" "$brief" \
     "no-mistakes DOD lost the apostrophe prose that the structural fix makes parse-safe"
   pass "fm-brief.sh: no-mistakes DOD keeps its apostrophe prose, now parse-safe"
+}
+
+# Option (b): the worker starts its own no-mistakes run the moment
+# implementation is committed. The generated brief is the worker-facing
+# contract; this test pins both directions of that change through the
+# public scaffold, not by reading fm-brief.sh source.
+# RED if the old firstmate-triggered handoff returns (either the origin/main
+# "instruct you to run" form or the later "triggers validation" /
+# "not yet validated - no PR yet" form).
+# RED if the start-your-own-run instruction disappears.
+# A silent start plus a silent mid-pipeline death is worse than the
+# supervisor round trip this removes, so start and failure reporting are
+# part of the same contract.
+test_no_mistakes_worker_starts_own_validation() {
+  local home id brief
+  home="$TMP_ROOT/self-start-home"
+  mkdir -p "$home/data"
+  id="brief-self-start-b1"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1 \
+    || fail "no-mistakes self-start brief should scaffold"
+  brief="$home/data/$id/brief.md"
+
+  # Negative: the intermediate handoff must not come back.
+  assert_no_grep "Firstmate will then instruct you to run" "$brief" \
+    "no-mistakes DOD restored the origin/main firstmate-instructs-validation handoff"
+  assert_no_grep "Firstmate then triggers validation" "$brief" \
+    "no-mistakes DOD restored the firstmate-triggers-validation handoff"
+  assert_no_grep "not yet validated - no PR yet" "$brief" \
+    "no-mistakes DOD restored a done: line with no PR"
+  assert_no_grep "When you believe it is complete, append \`done:" "$brief" \
+    "no-mistakes DOD restored the pre-PR done: {summary} stop"
+
+  # Positive: the worker must start the run itself and tell firstmate.
+  assert_grep "start the no-mistakes pipeline yourself immediately" "$brief" \
+    "no-mistakes DOD lost the start-your-own-run instruction"
+  assert_grep "working: starting no-mistakes validation" "$brief" \
+    "no-mistakes DOD lost the nonterminal working: append that tells firstmate validation started"
+  # shellcheck disable=SC2016  # single quotes are deliberate: the backticks must stay literal
+  assert_grep 'the `no-mistakes` CLI on your `PATH`' "$brief" \
+    "no-mistakes DOD did not name the CLI as the interface the worker actually has"
+  # shellcheck disable=SC2016  # single quotes are deliberate: the backticks must stay literal
+  assert_grep '`no-mistakes axi run --intent "<...>"` to start' "$brief" \
+    "no-mistakes DOD did not give the concrete run command"
+  # shellcheck disable=SC2016  # single quotes are deliberate: the backticks must stay literal
+  assert_grep '`no-mistakes axi respond` for each gate' "$brief" \
+    "no-mistakes DOD did not give the concrete gate-response command"
+  assert_grep "Do not append \`done:\` until there is a PR." "$brief" \
+    "no-mistakes DOD lost the rule that done: requires a PR"
+  assert_grep "This mode is complete only when the no-mistakes pipeline has shipped a PR whose checks are green." "$brief" \
+    "no-mistakes DOD did not bind completion to a green PR"
+  assert_grep "stop, never \`done:\`." "$brief" \
+    "no-mistakes DOD did not route an unstartable run to blocked: instead of done:"
+  assert_grep "If the run dies mid-pipeline, append \`failed:" "$brief" \
+    "no-mistakes DOD did not surface a mid-pipeline death"
+
+  # Skill form is absent in a crewmate worktree; no scaffold may instruct it.
+  for id_args in \
+    "brief-self-start-nomistakes:some-proj --mode no-mistakes" \
+    "brief-self-start-directpr:some-proj --mode direct-PR" \
+    "brief-self-start-localonly:some-proj --mode local-only" \
+    "brief-self-start-scout:some-proj --scout"; do
+    id=${id_args%%:*}
+    # shellcheck disable=SC2086  # the arg list is an intentional word split
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" ${id_args#*:} >/dev/null 2>&1 \
+      || fail "$id: scaffold exited non-zero"
+    brief="$home/data/$id/brief.md"
+    assert_no_grep "run /no-mistakes" "$brief" \
+      "$id: brief tells the worker to run a skill it cannot load"
+    assert_no_grep "invoke /no-mistakes" "$brief" \
+      "$id: brief tells the worker to invoke a skill it cannot load"
+  done
+  FM_HOME="$home" FM_SECONDMATE_CHARTER='Handle routed domain work.' \
+    "$ROOT/bin/fm-brief.sh" brief-self-start-secondmate --secondmate --no-projects >/dev/null 2>&1 \
+    || fail "secondmate charter scaffold exited non-zero"
+  assert_no_grep "run /no-mistakes" "$home/data/brief-self-start-secondmate/brief.md" \
+    "secondmate charter tells the worker to run a skill it cannot load"
+  assert_grep "Do NOT run the no-mistakes pipeline." "$home/data/brief-self-start-directpr/brief.md" \
+    "direct-PR brief lost its pipeline refusal"
+
+  pass "fm-brief.sh: no-mistakes DOD starts its own run and never emits a pre-PR done:"
 }
 
 test_ship_project_memory_wording() {
@@ -721,6 +801,7 @@ test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
+test_no_mistakes_worker_starts_own_validation
 test_ship_project_memory_wording
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path


### PR DESCRIPTION
## Intent

Remove the intermediate validation handoff from firstmate's task lifecycle, so a worker starts its own validation run the moment its implementation is committed and only reports done when there is a PR. This is option (b) from fm-brief-no-mistakes-cli, approved by the captain on 2026-08-18.

Change AGENTS.md section 7 and the generated brief text in bin/fm-brief.sh that mirrors that handoff. Keep the change to the handoff itself. Do not reopen the option (a) wording that shipped separately in fm-brief-no-mistakes-cli, and do not redesign the status protocol.

Firstmate must still learn when validation starts and when it fails, without the handoff line: a nonterminal working: append at the moment the run starts, and a failed: or blocked: if the run dies mid-pipeline.

The gate contract is unchanged: the worker still stops at an ask-user finding, prints every finding verbatim, waits for one instruction naming the finding ids, never calls no-mistakes axi respond on a finding it was not told to answer, and never passes --yes. Phrase worker-facing text in terms of what the worker must do, never in terms of what firstmate will do for it.

The working path is the no-mistakes CLI (no-mistakes axi run --intent "..."); /no-mistakes is a firstmate skill and is absent in a crewmate worktree.

Cover the generated brief's new contract with a test that goes RED if the handoff text comes back or the start-your-own-run instruction disappears, and prove both directions. Keep bin/ shellcheck-clean. Report any sabotage that stays green.

Push to fork and validate against the PR there, where CI is real. Leave any upstream PR against origin alone. There is no direct-PR fallback. If the fork's main is stale as a PR base, report that as evidence, not a failure of this task.

## What Changed

- Updated `AGENTS.md` and `bin/fm-brief.sh` to remove the intermediate firstmate handoff, instructing workers to start the `no-mistakes` CLI validation pipeline immediately after committing implementation changes.
- Updated brief templates and task lifecycle rules to append a nonterminal `working:` status line when validation begins, report `failed:` or `blocked:` on errors, and require a green PR before appending `done:`.
- Replaced `/no-mistakes` skill references with direct `no-mistakes` CLI invocations across generated briefs and added contract tests in `tests/fm-brief.test.sh` to verify self-started validation.

## Risk Assessment

✅ Low: The change cleanly removes the intermediate validation handoff in AGENTS.md and bin/fm-brief.sh in favor of worker self-start via the no-mistakes CLI, accompanied by comprehensive contract tests for the generated brief.

## Testing

Exercised end-to-end brief generation across ship (no-mistakes, direct-PR, local-only), scout, and secondmate modes, verified that no-mistakes briefs instruct the worker to start its own validation immediately via the no-mistakes CLI without intermediate pre-PR done: handoffs, verified mid-pipeline failure reporting via blocked:/failed:, confirmed absence of /no-mistakes skill references, and proved test sensitivity in both directions via mutation testing.

<details>
<summary>Evidence: Validation Report</summary>

Source: [Validation Report](https://github.com/BohnBawerick/firstmate/blob/21a0255f8ed0b4378e141ed77a0556b3a1b3016e/.no-mistakes/evidence/fm/fm-validation-self-start/validation-report.md)

```text
# Validation Report: fm/fm-validation-self-start

## Executive Summary
This validation confirms Option (b) implementation from `fm-brief-no-mistakes-cli` removing the intermediate validation handoff from Firstmate's task lifecycle.

A worker agent now:
1. Immediately starts its own validation run after its implementation commit using the `no-mistakes` CLI on PATH (`no-mistakes axi run --intent "<...>"`).
2. Appends a nonterminal `working: starting no-mistakes validation` line to the status file when the run starts.
3. Does NOT append `done:` until there is a PR whose checks are green (`done: PR {url} checks green`).
4. Appends `blocked: {the exact error}` or `failed: {the exact error}` if the run dies mid-pipeline.
5. Handles ask-user findings via `needs-decision` escalation, never answers findings itself, and avoids `--yes`.
6. Uses `no-mistakes axi` CLI commands; references to the `/no-mistakes` skill (absent in crewmate worktrees) are removed.

## Test Proofs

### 1. Behavioral Test Suite
`./tests/fm-brief.test.sh` executes end-to-end scaffolding across modes (`no-mistakes`, `direct-PR`, `local-only`, `--scout`, `--secondmate`) and validates exact behavioral contracts via `test_no_mistakes_worker_starts_own_validation`.

All 21 test assertions pass cleanly.

### 2. Mutation / Sabotage Verification (Proving Both Directions)
- **Direction 1 (Old handoff text returns):**
  When the legacy handoff text (`Firstmate will then instruct you to run /no-mistakes`) was reintroduced, `tests/fm-brief.test.sh` went RED immediately (`not ok - explicit no-mistakes brief did not render the pipeline definition of done`).
- **Direction 2 (Self-start instruction missing):**
  When the self-start instruction (`When implementation is committed on your branch, start the no-mistakes pipeline yourself immediately.`) was removed, `tests/fm-brief.test.sh` went RED immediately (`not ok - explicit no-mistakes brief did not render the pipeline definition of done`).

### 3. Generated Brief Inspection
Generated brief output for `no-mistakes` mode confirms the exact Definition of Done:
`` `markdown
# Definition of done
Delivery contract: mode=no-mistakes
This mode is complete only when the no-mistakes pipeline has shipped a PR whose checks are green.
When implementation is committed on your branch, start the no-mistakes pipeline yourself immediately.
Append `working: starting no-mistakes validation` to the status file, then run the `no-mistakes` CLI on your `PATH`: `no-mistakes axi run --intent "<...>"` to start, and `no-mistakes axi respond` for each gate.
Do not append `done:` until there is a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

If you cannot start or continue the run, append `blocked: {the exact error}` and stop, never `done:`.
If the run dies mid-pipeline, append `failed: {the exact error}` and stop, never stay silent.
After the run reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
`` `
```
</details>
<details>
<summary>Evidence: Generated Brief - no-mistakes Mode</summary>

Source: [Generated Brief - no-mistakes Mode](https://github.com/BohnBawerick/firstmate/blob/21a0255f8ed0b4378e141ed77a0556b3a1b3016e/.no-mistakes/evidence/fm/fm-validation-self-start/brief-no-mistakes.md)

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of demo-project, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/test-nomistakes`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/test-fm-brief-evidence-65442/state/test-nomistakes.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/home/paiva/.no-mistakes/worktrees/3437026af8a8/01M0B1AVKDKZA9A5DBD12CNP84/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/home/paiva/.no-mistakes/worktrees/3437026af8a8/01M0B1AVKDKZA9A5DBD12CNP84/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=no-mistakes
This mode is complete only when the no-mistakes pipeline has shipped a PR whose checks are green.
When implementation is committed on your branch, start the no-mistakes pipeline yourself immediately.
Append `working: starting no-mistakes validation` to the status file, then run the `no-mistakes` CLI on your `PATH`: `no-mistakes axi run --intent "<...>"` to start, and `no-mistakes axi respond` for each gate.
Do not append `done:` until there is a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

If you cannot start or continue the run, append `blocked: {the exact error}` and stop, never `done:`.
If the run dies mid-pipeline, append `failed: {the exact error}` and stop, never stay silent.
After the run reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Generated Brief - direct-PR Mode</summary>

Source: [Generated Brief - direct-PR Mode](https://github.com/BohnBawerick/firstmate/blob/21a0255f8ed0b4378e141ed77a0556b3a1b3016e/.no-mistakes/evidence/fm/fm-validation-self-start/brief-direct-pr.md)

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of demo-project, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/test-directpr`

# Rules
1. Never push to the default branch (push only your `fm/test-directpr` branch). Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/test-fm-brief-evidence-65442/state/test-directpr.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/home/paiva/.no-mistakes/worktrees/3437026af8a8/01M0B1AVKDKZA9A5DBD12CNP84/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/home/paiva/.no-mistakes/worktrees/3437026af8a8/01M0B1AVKDKZA9A5DBD12CNP84/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=direct-PR
This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
The task is complete only when committed on your branch.
When it is implemented and committed, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` to the status file and stop.
Do NOT run the no-mistakes pipeline. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
```
</details>
<details>
<summary>Evidence: Generated Brief - local-only Mode</summary>

Source: [Generated Brief - local-only Mode](https://github.com/BohnBawerick/firstmate/blob/21a0255f8ed0b4378e141ed77a0556b3a1b3016e/.no-mistakes/evidence/fm/fm-validation-self-start/brief-local-only.md)

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of demo-project, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/test-localonly`

# Rules
1. Never push to any remote and never open a PR. Work only on your `fm/test-localonly` branch; firstmate handles the merge into local `main`.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/test-fm-brief-evidence-65442/state/test-localonly.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/home/paiva/.no-mistakes/worktrees/3437026af8a8/01M0B1AVKDKZA9A5DBD12CNP84/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/home/paiva/.no-mistakes/worktrees/3437026af8a8/01M0B1AVKDKZA9A5DBD12CNP84/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=local-only
This task ships **local-only**: no remote, no PR, no pipeline.
The task is complete only when committed on your branch `fm/test-localonly`. Do NOT push, do NOT open a PR, do NOT merge.
Keep your branch a clean fast-forward onto the current default branch - if `main` has advanced, rebase onto it so the eventual merge stays a fast-forward.
When it is implemented and committed, append `done: ready in branch fm/test-localonly` to the status file and stop.
The configured merge authority approves the ready branch, then firstmate merges it into local `main` through the guarded fast-forward path.
```
</details>
<details>
<summary>Evidence: Test Suite Passing Output</summary>

Source: [Test Suite Passing Output](https://github.com/BohnBawerick/firstmate/blob/21a0255f8ed0b4378e141ed77a0556b3a1b3016e/.no-mistakes/evidence/fm/fm-validation-self-start/test-suite-pass-output.log)

```text
ok - fm-brief.sh: bash -n succeeds
/tmp/fm-brief.qh5YmU/heredoc-in-substitution.sh:2
ok - fm-brief.sh: no heredoc is nested inside a command substitution (Bash 3.2 parse-safe)
ok - fm-brief.sh: --help renders the complete header
ok - fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly
ok - fm-brief.sh: ship --mode is required and closed-set validated
ok - fm-brief.sh: the explicit ship mode wins over the registered posture
ok - fm-brief.sh: --yolo and scout/secondmate --mode are refused, never silently dropped
ok - fm-brief.sh: faster paths use configured authority without stacked review
ok - fm-brief.sh: no-mistakes DOD keeps its apostrophe prose, now parse-safe
ok - fm-brief.sh: no-mistakes DOD starts its own run and never emits a pre-PR done:
ok - fm-brief.sh: ship project-memory wording carries the AGENTS.md authoring bar
ok - fm-brief.sh: --herdr-lab emits the complete hard safety contract
ok - fm-brief.sh: --herdr-lab uses its quoted Firstmate-owned helper path
ok - fm-brief.sh: ship and scout scaffolds make omitted Herdr intent fail-visible
ok - fm-brief.sh: Herdr lab contract covers scouts and rejects secondmate misuse
ok - fm-brief.sh: --no-projects scaffolds a project-less charter and guards misuse
ok - fm-brief.sh: marked requests avoid generic acknowledgements and preserve material reporting
ok - fm-brief.sh: relative directory inputs ignore CDPATH, render stable absolute charter paths, or fail loudly
ok - fm-brief.sh: custom pause verb renders in every scaffold
ok - fm-brief.sh: investigation and visual-review completions load the shared decision policy
ok - fm-brief: scout and secondmate code paths still scaffold well-formed briefs
```
</details>
<details>
<summary>Evidence: Sabotage Direction 1 RED Output (Handoff Restored)</summary>

Source: [Sabotage Direction 1 RED Output (Handoff Restored)](https://github.com/BohnBawerick/firstmate/blob/21a0255f8ed0b4378e141ed77a0556b3a1b3016e/.no-mistakes/evidence/fm/fm-validation-self-start/sabotage-direction1-output.log)

```text
ok - fm-brief.sh: bash -n succeeds
/tmp/fm-brief.N3TMPb/heredoc-in-substitution.sh:2
ok - fm-brief.sh: no heredoc is nested inside a command substitution (Bash 3.2 parse-safe)
ok - fm-brief.sh: --help renders the complete header
ok - fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly
ok - fm-brief.sh: ship --mode is required and closed-set validated
not ok - explicit no-mistakes brief did not render the pipeline definition of done
```
</details>
<details>
<summary>Evidence: Sabotage Direction 2 RED Output (Self-Start Missing)</summary>

Source: [Sabotage Direction 2 RED Output (Self-Start Missing)](https://github.com/BohnBawerick/firstmate/blob/21a0255f8ed0b4378e141ed77a0556b3a1b3016e/.no-mistakes/evidence/fm/fm-validation-self-start/sabotage-direction2-output.log)

```text
ok - fm-brief.sh: bash -n succeeds
/tmp/fm-brief.ZUkoZZ/heredoc-in-substitution.sh:2
ok - fm-brief.sh: no heredoc is nested inside a command substitution (Bash 3.2 parse-safe)
ok - fm-brief.sh: --help renders the complete header
ok - fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly
ok - fm-brief.sh: ship --mode is required and closed-set validated
not ok - explicit no-mistakes brief did not render the pipeline definition of done
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"fa2f4f7a4b4ea4509b1538c6551ca8d4c709b177","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `./tests/fm-brief.test.sh`
- `bash tests/fm-ask-user-authority.test.sh`
- `bash tests/fm-gate-refuse.test.sh`
- `bash tests/fm-task-delivery.test.sh`
- `bash tests/fm-ensure-agents-md.test.sh`
- `./bin/fm-brief.sh test-nomistakes demo-project --mode no-mistakes`
- `./bin/fm-brief.sh test-directpr demo-project --mode direct-PR`
- `./bin/fm-brief.sh test-localonly demo-project --mode local-only`
- `./bin/fm-brief.sh test-scout demo-project --scout`
- `FM_SECONDMATE_CHARTER='...' ./bin/fm-brief.sh test-secondmate --secondmate --no-projects`
- <code>Dual-direction mutation testing against `bin/fm-brief.sh` to prove RED when restoring legacy handoff text or removing self-start instructions</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
