### PR TITLE
fix(bin): spawn into a local-only project that has no origin remote

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -144,9 +144,10 @@
 #   local tip instead of refusing. Taking that path is never silent - it prints one
 #   loud NOTICE naming the project and stating that the origin freshen is skipped and
 #   that the named LOCAL default branch is the base authority, so a project that lost a
-#   remote it was meant to have is visible rather than assumed local-only. The notice
-#   reports the skip only; the clean-worktree and reset checks below still apply and
-#   can refuse afterwards.
+#   remote it was meant to have is visible rather than assumed local-only. A LOCAL
+#   default branch that cannot be resolved refuses instead, before any notice prints.
+#   The notice reports the skip only; the clean-worktree and reset checks still apply
+#   and can refuse afterwards.
 #   Only a genuinely absent remote takes that path; a configured origin that cannot
 #   be fetched still refuses exactly as above.
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -142,8 +142,11 @@
 #   genuinely be - has no remote history to be stale against, so its LOCAL default
 #   branch is the authority: the fetch is skipped and the worktree resets to that
 #   local tip instead of refusing. Taking that path is never silent - it prints one
-#   loud NOTICE naming the project and the local branch launched from, so a project
-#   that lost a remote it was meant to have is visible rather than assumed local-only.
+#   loud NOTICE naming the project and stating that the origin freshen is skipped and
+#   that the named LOCAL default branch is the base authority, so a project that lost a
+#   remote it was meant to have is visible rather than assumed local-only. The notice
+#   reports the skip only; the clean-worktree and reset checks below still apply and
+#   can refuse afterwards.
 #   Only a genuinely absent remote takes that path; a configured origin that cannot
 #   be fetched still refuses exactly as above.
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
@@ -1743,8 +1746,11 @@ validate_spawn_worktree() {  # <source> <inspect-target>
 # so any fetch or resolution failure refuses. With NO origin configured - which a
 # local-only project may genuinely be - there is no remote history to be stale
 # against, so the LOCAL default branch is authoritative and nothing needs fetching.
-# The skip is never silent: taking it prints one loud NOTICE naming the project, so
-# an operator sees a project that lost a remote it was meant to have.
+# The skip is never silent: taking it prints one loud NOTICE, so an operator sees a
+# project that lost a remote it was meant to have. The notice reports only what is
+# already true when it prints - the freshen was skipped and the local branch is the
+# base authority - because the caller's clean-worktree and reset checks run after
+# this resolution and can still refuse. The script header owns its exact mechanics.
 spawn_worktree_base_ref() {  # <worktree>
   local worktree=$1 default
   if ! git -C "$worktree" remote get-url origin >/dev/null 2>&1; then
@@ -1752,7 +1758,7 @@ spawn_worktree_base_ref() {  # <worktree>
       echo "error: could not determine the local default branch for pooled worktree '$worktree' of a project with no origin remote; refusing to launch from a potentially stale base" >&2
       return 1
     }
-    echo "NOTICE: project '$PROJ_ABS' has no origin remote configured - launching from its LOCAL default branch '$default' (pooled worktree '$worktree') without fetching, because no remote history exists to be stale against. If this project is meant to have a remote, restore it before shipping." >&2
+    echo "NOTICE: project '$PROJ_ABS' has no origin remote configured - skipping the origin freshen for pooled worktree '$worktree' and taking its LOCAL default branch '$default' as the base authority, because no remote history exists to be stale against. If this project is meant to have a remote, restore it before shipping." >&2
     printf '%s\n' "refs/heads/$default"
     return 0
   fi

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -141,8 +141,11 @@
 #   A project with NO origin remote configured - which a local-only project may
 #   genuinely be - has no remote history to be stale against, so its LOCAL default
 #   branch is the authority: the fetch is skipped and the worktree resets to that
-#   local tip instead of refusing. Only a genuinely absent remote takes that path;
-#   a configured origin that cannot be fetched still refuses exactly as above.
+#   local tip instead of refusing. Taking that path is never silent - it prints one
+#   loud NOTICE naming the project and the local branch launched from, so a project
+#   that lost a remote it was meant to have is visible rather than assumed local-only.
+#   Only a genuinely absent remote takes that path; a configured origin that cannot
+#   be fetched still refuses exactly as above.
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
@@ -1740,6 +1743,8 @@ validate_spawn_worktree() {  # <source> <inspect-target>
 # so any fetch or resolution failure refuses. With NO origin configured - which a
 # local-only project may genuinely be - there is no remote history to be stale
 # against, so the LOCAL default branch is authoritative and nothing needs fetching.
+# The skip is never silent: taking it prints one loud NOTICE naming the project, so
+# an operator sees a project that lost a remote it was meant to have.
 spawn_worktree_base_ref() {  # <worktree>
   local worktree=$1 default
   if ! git -C "$worktree" remote get-url origin >/dev/null 2>&1; then
@@ -1747,6 +1752,7 @@ spawn_worktree_base_ref() {  # <worktree>
       echo "error: could not determine the local default branch for pooled worktree '$worktree' of a project with no origin remote; refusing to launch from a potentially stale base" >&2
       return 1
     }
+    echo "NOTICE: project '$PROJ_ABS' has no origin remote configured - launching from its LOCAL default branch '$default' (pooled worktree '$worktree') without fetching, because no remote history exists to be stale against. If this project is meant to have a remote, restore it before shipping." >&2
     printf '%s\n' "refs/heads/$default"
     return 0
   fi

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -138,6 +138,11 @@
 #   origin, resolves the current remote default branch, and resets to its tip.
 #   An unreachable origin, unresolved default branch, or non-clean worktree
 #   refuses the spawn rather than risking a PR based on stale history.
+#   A project with NO origin remote configured - which a local-only project may
+#   genuinely be - has no remote history to be stale against, so its LOCAL default
+#   branch is the authority: the fetch is skipped and the worktree resets to that
+#   local tip instead of refusing. Only a genuinely absent remote takes that path;
+#   a configured origin that cannot be fetched still refuses exactly as above.
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
@@ -1727,8 +1732,24 @@ validate_spawn_worktree() {  # <source> <inspect-target>
   fi
 }
 
-freshen_spawn_worktree_base() {  # <worktree>
-  local worktree=$1 default target expected actual status
+# Resolve the authoritative base ref a fresh worktree must sit on, echoed on
+# stdout. Two authorities, kept as two branches on purpose: "no origin remote
+# configured" is not the same condition as "origin configured but unreachable",
+# and collapsing them would trade a real stale-base guard for convenience.
+# With origin configured, only the fetched remote default branch is authoritative,
+# so any fetch or resolution failure refuses. With NO origin configured - which a
+# local-only project may genuinely be - there is no remote history to be stale
+# against, so the LOCAL default branch is authoritative and nothing needs fetching.
+spawn_worktree_base_ref() {  # <worktree>
+  local worktree=$1 default
+  if ! git -C "$worktree" remote get-url origin >/dev/null 2>&1; then
+    default=$(default_branch "$worktree") || {
+      echo "error: could not determine the local default branch for pooled worktree '$worktree' of a project with no origin remote; refusing to launch from a potentially stale base" >&2
+      return 1
+    }
+    printf '%s\n' "refs/heads/$default"
+    return 0
+  fi
   if ! git -C "$worktree" fetch --quiet origin; then
     echo "error: could not fetch origin for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
     return 1
@@ -1741,11 +1762,16 @@ freshen_spawn_worktree_base() {  # <worktree>
     echo "error: could not determine origin's default branch for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
     return 1
   }
-  target="origin/$default"
   if ! git -C "$worktree" fetch --quiet origin "+refs/heads/$default:refs/remotes/origin/$default"; then
-    echo "error: could not fetch '$target' for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+    echo "error: could not fetch 'origin/$default' for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
     return 1
   fi
+  printf '%s\n' "origin/$default"
+}
+
+freshen_spawn_worktree_base() {  # <worktree>
+  local worktree=$1 target expected actual status
+  target=$(spawn_worktree_base_ref "$worktree") || return 1
   expected=$(git -C "$worktree" rev-parse --verify --quiet "$target^{commit}" 2>/dev/null) || {
     echo "error: '$target' is not a commit for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
     return 1

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -157,7 +157,7 @@ Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectab
 
 Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees for tmux, herdr, zellij, and cmux tasks, while Orca creates its own worktrees for `backend=orca`.
 For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout.
-`fm-spawn.sh` also owns the base-freshness boundary for every fresh ship and scout: no worker starts until its clean task worktree matches the fetched tip of origin's resolved default branch, and any unsafe or unverifiable base stops the spawn.
+`fm-spawn.sh` also owns the base-freshness boundary for every fresh ship and scout: no worker starts until its clean task worktree matches the tip of the project's authoritative default branch - origin's resolved default branch when a remote is configured, and the local default branch when the project genuinely has none - and any unsafe or unverifiable base stops the spawn.
 Its header owns the exact refusal mechanics, while `tests/fm-spawn-pool-base-freshen.test.sh` owns the portable regression coverage.
 
 The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -16,12 +16,17 @@
 # past the pool base, so neither verdict can be reached by accident: an
 # implementation that fetched unconditionally fails the first, and one that fell
 # back to the local branch whenever a fetch failed fails the second.
+# The remoteless skip must also be loud: these tests assert the spawn's real captured
+# output carries one NOTICE naming the project when the skip fires, and carries none
+# when an origin is configured, so an operator sees a project that lost its remote.
 set -u
 
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 SPAWN="$ROOT/bin/fm-spawn.sh"
+REMOTELESS_NOTICE='NOTICE: project'
+REMOTELESS_NOTICE_REASON='has no origin remote configured'
 TMP_ROOT=$(fm_test_tmproot fm-spawn-pool-base-freshen)
 
 make_spawn_fakebin() {
@@ -135,6 +140,19 @@ run_spawn() {
     "$SPAWN" "$id" "$PROJECT_DIR" "$@" 2>&1
 }
 
+# The skipped-fetch notice lines from a real spawn's captured output, so presence,
+# count, and contents are asserted against the notice itself rather than any other
+# line that happens to mention the project.
+remoteless_notice_lines() {  # <captured-output>
+  printf '%s\n' "$1" | grep -F "$REMOTELESS_NOTICE" || true
+}
+
+# The project path as the spawn itself renders it: the fixture root can carry a
+# redundant separator, and the spawn normalizes the argument before printing it.
+spawn_rendered_project_path() {
+  (cd "$PROJECT_DIR" && pwd)
+}
+
 test_stale_pool_base_refreshes_before_branching() {
   local rec id out status current branch_head
   id='pool-current-base-r1'
@@ -145,6 +163,10 @@ test_stale_pool_base_refreshes_before_branching() {
   status=$?
   expect_code 0 "$status" "spawn should refresh a stale pooled worktree"
   assert_contains "$out" "spawned $id" "spawn did not report success"
+  assert_not_contains "$out" "$REMOTELESS_NOTICE" \
+    "an origin-backed launch printed the no-remote skip notice"
+  assert_not_contains "$out" "$REMOTELESS_NOTICE_REASON" \
+    "an origin-backed launch claimed the project has no origin remote"
   current=$(git -C "$POOL_DIR" rev-parse origin/main)
   branch_head=$(git -C "$POOL_DIR" rev-parse HEAD)
   [ "$branch_head" = "$current" ] || fail "spawn left the pooled worktree on stale history"
@@ -207,6 +229,8 @@ test_unreachable_origin_refuses_stale_pool_base() {
   [ "$status" -ne 0 ] || fail "spawn succeeded despite an unreachable origin"
   assert_contains "$out" "could not fetch origin" \
     "spawn did not clearly refuse an unreachable origin"
+  assert_not_contains "$out" "$REMOTELESS_NOTICE" \
+    "an unreachable configured origin was reported as no remote configured"
   after=$(git -C "$POOL_DIR" rev-parse HEAD)
   [ "$after" = "$before" ] || fail "spawn changed the pooled worktree after origin became unreachable"
   [ "$after" != "$local_tip" ] \
@@ -218,7 +242,7 @@ test_unreachable_origin_refuses_stale_pool_base() {
 }
 
 test_remoteless_project_launches_from_local_default() {
-  local rec id out status local_tip pool_head
+  local rec id out status local_tip pool_head notice
   id='pool-no-remote-r6'
   rec=$(make_remoteless_case no-remote "$id")
   read_case_record "$rec"
@@ -236,16 +260,26 @@ test_remoteless_project_launches_from_local_default() {
     || fail "spawn launched a remoteless project from its stale pool base"
   assert_grep 'must survive a newly spawned branch' "$POOL_DIR/advanced-main.txt" \
     "the remoteless worktree is missing the local default branch's latest content"
+  notice=$(remoteless_notice_lines "$out")
+  [ "$(printf '%s\n' "$notice" | grep -c .)" = 1 ] \
+    || fail "the remoteless launch printed $(printf '%s\n' "$notice" | grep -c .) skip notices, not exactly one"
+  assert_contains "$notice" "$REMOTELESS_NOTICE_REASON" \
+    "the remoteless NOTICE did not say why the fetch was skipped"
+  assert_contains "$notice" "$(spawn_rendered_project_path)" \
+    "the remoteless NOTICE did not name the project path"
+  assert_contains "$notice" "$DEFAULT_BRANCH" \
+    "the remoteless NOTICE did not name the local default branch launched from"
   if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+    printf '# observed remoteless notice: %s\n' "$notice"
     printf '# observed remoteless spawn: %s\n' "$(printf '%s\n' "$out" | tail -n 1)"
     printf '# observed remoteless base: HEAD=%s local-%s=%s pool-base=%s\n' \
       "$pool_head" "$DEFAULT_BRANCH" "$local_tip" "$INITIAL_SHA"
   fi
-  pass "a project with no origin remote launches from its local default branch tip"
+  pass "a project with no origin remote launches from its local default branch tip, loudly"
 }
 
 test_remoteless_scout_launches_from_local_default() {
-  local rec id out status local_tip
+  local rec id out status local_tip notice
   id='pool-no-remote-scout-r6'
   rec=$(make_remoteless_case no-remote-scout "$id")
   read_case_record "$rec"
@@ -256,7 +290,12 @@ test_remoteless_scout_launches_from_local_default() {
   expect_code 0 "$status" "a scout should launch into a project with no origin remote"
   [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$local_tip" ] \
     || fail "the remoteless scout did not start at the local default branch tip"
-  pass "a scout into a remoteless project also starts from the local default branch tip"
+  notice=$(remoteless_notice_lines "$out")
+  [ "$(printf '%s\n' "$notice" | grep -c .)" = 1 ] \
+    || fail "a remoteless scout launch did not print exactly one skip notice"
+  assert_contains "$notice" "$(spawn_rendered_project_path)" \
+    "the remoteless scout's NOTICE did not name the project path"
+  pass "a scout into a remoteless project also starts from the local default branch tip, loudly"
 }
 
 test_remoteless_project_without_a_local_default_refuses() {
@@ -272,6 +311,8 @@ test_remoteless_project_without_a_local_default_refuses() {
     || fail "spawn succeeded with no origin remote and no resolvable local default branch"
   assert_contains "$out" "could not determine the local default branch" \
     "spawn did not clearly refuse a remoteless project with no resolvable default branch"
+  assert_not_contains "$out" "$REMOTELESS_NOTICE" \
+    "spawn announced a local-default launch it then refused"
   [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$before" ] \
     || fail "spawn moved the pooled worktree while refusing an unresolvable local default branch"
   pass "a remoteless project with no resolvable default branch still refuses"
@@ -295,6 +336,8 @@ test_direct_pr_and_scout_refresh_before_launch() {
       || fail "$contract spawn did not start at current origin/main"
     assert_grep 'must survive a newly spawned branch' "$POOL_DIR/advanced-main.txt" \
       "$contract spawn omitted advanced-main content"
+    assert_not_contains "$out" "$REMOTELESS_NOTICE" \
+      "$contract spawn printed the no-remote skip notice while origin was configured"
     if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
       printf '# observed %s spawn: %s\n' "$contract" "$(printf '%s\n' "$out" | tail -n 1)"
     fi

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -6,6 +6,16 @@
 # These tests drive the real spawn path with a fake terminal, then prove it
 # starts the worker from the fetched origin/main tip or stops when origin is
 # unreachable.
+#
+# Two conditions that look alike are held apart here, because collapsing them
+# would either strand a whole project posture or drop a real safety guard:
+#   - no origin remote CONFIGURED - a local-only project may genuinely have none,
+#     so its local default branch is the authority and the fetch has nothing to do.
+#   - origin configured but UNREACHABLE - a real stale-base risk that must refuse.
+# Both remoteless and unreachable-origin fixtures advance the LOCAL default branch
+# past the pool base, so neither verdict can be reached by accident: an
+# implementation that fetched unconditionally fails the first, and one that fell
+# back to the local branch whenever a fetch failed fails the second.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -65,6 +75,47 @@ make_case() {
   git -C "$publisher" push --quiet origin "$default"
 
   printf '%s\n' "$case_dir|$home|$project|$pool|$fakebin|$initial|$default"
+}
+
+# A project with NO origin remote at all, as a local-only project may genuinely be.
+# Its local default branch is advanced past the pooled worktree's base, so a spawn
+# that skips the refresh entirely is as visible as one that refuses.
+# Echoes the same record layout as make_case.
+make_remoteless_case() {
+  local name=$1 id=$2 default=${3:-main} case_dir home project pool fakebin initial
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  project="$case_dir/project"
+  pool="$case_dir/pool"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
+  printf 'codex\n' > "$home/config/crew-harness"
+  printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
+  touch "$home/state/.last-watcher-beat"
+
+  git init --quiet -b "$default" "$project"
+  printf 'base\n' > "$project/README.md"
+  git -C "$project" add README.md
+  git -C "$project" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial
+  initial=$(git -C "$project" rev-parse HEAD)
+  git -C "$project" worktree add --quiet --detach "$pool" "$initial"
+  advance_local_default "$project" "$initial"
+
+  printf '%s\n' "$case_dir|$home|$project|$pool|$fakebin|$initial|$default"
+}
+
+# Move the project's checked-out local default branch one commit past <base>, so a
+# pooled worktree left at <base> is genuinely stale against the local branch. This
+# is what an approved local-only merge does to a remoteless project.
+advance_local_default() {
+  local project=$1 base=$2
+  printf 'must survive a newly spawned branch\n' > "$project/advanced-main.txt"
+  git -C "$project" add advanced-main.txt
+  git -C "$project" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' \
+    commit -qm advance-local-default
+  [ "$(git -C "$project" rev-parse HEAD)" != "$base" ] \
+    || fail "fixture did not advance the local default branch past the pool base"
 }
 
 read_case_record() {
@@ -138,12 +189,18 @@ test_non_main_default_branch_refreshes_before_branching() {
 }
 
 test_unreachable_origin_refuses_stale_pool_base() {
-  local rec id out status before after
+  local rec id out status before after local_tip
   id='pool-unreachable-origin-r2'
   rec=$(make_case unreachable-origin "$id")
   read_case_record "$rec"
   git -C "$POOL_DIR" remote set-url origin "file://$CASE_DIR/missing-origin.git"
+  # Give the local default branch a usable tip too. An implementation that treated
+  # "cannot fetch" the same way it treats "no remote configured" would reset to this
+  # commit and launch, so the refusal below is proof the two paths stayed separate.
+  advance_local_default "$PROJECT_DIR" "$INITIAL_SHA"
+  local_tip=$(git -C "$PROJECT_DIR" rev-parse "refs/heads/$DEFAULT_BRANCH")
   before=$(git -C "$POOL_DIR" rev-parse HEAD)
+  [ "$local_tip" != "$before" ] || fail "fixture did not separate the local tip from the pool base"
 
   out=$(run_spawn "$id" --mode no-mistakes --yolo off)
   status=$?
@@ -152,10 +209,72 @@ test_unreachable_origin_refuses_stale_pool_base() {
     "spawn did not clearly refuse an unreachable origin"
   after=$(git -C "$POOL_DIR" rev-parse HEAD)
   [ "$after" = "$before" ] || fail "spawn changed the pooled worktree after origin became unreachable"
+  [ "$after" != "$local_tip" ] \
+    || fail "spawn fell back to the local default branch instead of refusing an unreachable origin"
   if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
     printf '# observed unreachable-origin refusal: %s\n' "$(printf '%s\n' "$out" | tail -n 1)"
   fi
-  pass "an unreachable origin refuses a potentially stale pooled worktree"
+  pass "a configured but unreachable origin refuses instead of falling back to the local branch"
+}
+
+test_remoteless_project_launches_from_local_default() {
+  local rec id out status local_tip pool_head
+  id='pool-no-remote-r6'
+  rec=$(make_remoteless_case no-remote "$id")
+  read_case_record "$rec"
+  [ -z "$(git -C "$POOL_DIR" remote)" ] || fail "fixture is not remoteless"
+  local_tip=$(git -C "$PROJECT_DIR" rev-parse "refs/heads/$DEFAULT_BRANCH")
+
+  out=$(run_spawn "$id" --mode local-only --yolo off)
+  status=$?
+  expect_code 0 "$status" "spawn should launch into a project with no origin remote"
+  assert_contains "$out" "spawned $id" "spawn did not report success without an origin remote"
+  pool_head=$(git -C "$POOL_DIR" rev-parse HEAD)
+  [ "$pool_head" = "$local_tip" ] \
+    || fail "spawn left the remoteless pooled worktree off the local default branch tip"
+  [ "$pool_head" != "$INITIAL_SHA" ] \
+    || fail "spawn launched a remoteless project from its stale pool base"
+  assert_grep 'must survive a newly spawned branch' "$POOL_DIR/advanced-main.txt" \
+    "the remoteless worktree is missing the local default branch's latest content"
+  if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+    printf '# observed remoteless spawn: %s\n' "$(printf '%s\n' "$out" | tail -n 1)"
+    printf '# observed remoteless base: HEAD=%s local-%s=%s pool-base=%s\n' \
+      "$pool_head" "$DEFAULT_BRANCH" "$local_tip" "$INITIAL_SHA"
+  fi
+  pass "a project with no origin remote launches from its local default branch tip"
+}
+
+test_remoteless_scout_launches_from_local_default() {
+  local rec id out status local_tip
+  id='pool-no-remote-scout-r6'
+  rec=$(make_remoteless_case no-remote-scout "$id")
+  read_case_record "$rec"
+  local_tip=$(git -C "$PROJECT_DIR" rev-parse "refs/heads/$DEFAULT_BRANCH")
+
+  out=$(run_spawn "$id" --scout)
+  status=$?
+  expect_code 0 "$status" "a scout should launch into a project with no origin remote"
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$local_tip" ] \
+    || fail "the remoteless scout did not start at the local default branch tip"
+  pass "a scout into a remoteless project also starts from the local default branch tip"
+}
+
+test_remoteless_project_without_a_local_default_refuses() {
+  local rec id out status before
+  id='pool-no-remote-no-default-r6'
+  rec=$(make_remoteless_case no-remote-no-default "$id" trunk)
+  read_case_record "$rec"
+  before=$(git -C "$POOL_DIR" rev-parse HEAD)
+
+  out=$(run_spawn "$id" --mode local-only --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] \
+    || fail "spawn succeeded with no origin remote and no resolvable local default branch"
+  assert_contains "$out" "could not determine the local default branch" \
+    "spawn did not clearly refuse a remoteless project with no resolvable default branch"
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$before" ] \
+    || fail "spawn moved the pooled worktree while refusing an unresolvable local default branch"
+  pass "a remoteless project with no resolvable default branch still refuses"
 }
 
 test_direct_pr_and_scout_refresh_before_launch() {
@@ -233,5 +352,8 @@ test_direct_pr_and_scout_refresh_before_launch
 test_dirty_pool_refuses_without_discarding_work
 test_unresolved_remote_default_refuses_pool
 test_unreachable_origin_refuses_stale_pool_base
+test_remoteless_project_launches_from_local_default
+test_remoteless_scout_launches_from_local_default
+test_remoteless_project_without_a_local_default_refuses
 
 echo "# all fm-spawn-pool-base-freshen tests passed"

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -19,6 +19,9 @@
 # The remoteless skip must also be loud: these tests assert the spawn's real captured
 # output carries one NOTICE naming the project when the skip fires, and carries none
 # when an origin is configured, so an operator sees a project that lost its remote.
+# That notice prints before the clean-worktree check, so it is asserted to report the
+# skipped origin freshen and the local branch taken as the base authority rather than a
+# launch the later checks may still refuse.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -27,6 +30,8 @@ set -u
 SPAWN="$ROOT/bin/fm-spawn.sh"
 REMOTELESS_NOTICE='NOTICE: project'
 REMOTELESS_NOTICE_REASON='has no origin remote configured'
+REMOTELESS_NOTICE_SKIP='skipping the origin freshen'
+REMOTELESS_NOTICE_AUTHORITY='as the base authority'
 TMP_ROOT=$(fm_test_tmproot fm-spawn-pool-base-freshen)
 
 make_spawn_fakebin() {
@@ -49,8 +54,20 @@ SH
   printf '%s\n' "$fakebin"
 }
 
+# Build a spawn case. <remote> is `origin` (the default) for an origin-backed project,
+# or `none` for a project that genuinely has no remote at all. Only the remote varies:
+# every other part of the fixture - the firstmate home layout, the project, and the
+# pooled worktree - is built here once, so a remoteless case cannot drift from an
+# origin-backed one when this fixture later grows another required file.
+# Either way the project's authoritative default branch is advanced one commit past
+# the pooled worktree's base, so a spawn that skips the refresh is as visible as one
+# that refuses. Echoes a record for read_case_record.
 make_case() {
-  local name=$1 id=$2 default=${3:-main} case_dir home project origin pool publisher fakebin initial
+  local name=$1 id=$2 default=${3:-main} remote=${4:-origin} case_dir home project origin pool publisher fakebin initial
+  case "$remote" in
+    origin|none) ;;
+    *) fail "make_case got an unknown remote '$remote'; expected 'origin' or 'none'" ;;
+  esac
   case_dir="$TMP_ROOT/$name"
   home="$case_dir/home"
   project="$case_dir/project"
@@ -68,46 +85,32 @@ make_case() {
   printf 'base\n' > "$project/README.md"
   git -C "$project" add README.md
   git -C "$project" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial
-  git clone --quiet --bare "$project" "$origin"
-  git -C "$project" remote add origin "file://$origin"
+  if [ "$remote" = origin ]; then
+    git clone --quiet --bare "$project" "$origin"
+    git -C "$project" remote add origin "file://$origin"
+  fi
   initial=$(git -C "$project" rev-parse HEAD)
   git -C "$project" worktree add --quiet --detach "$pool" "$initial"
 
-  git clone --quiet "file://$origin" "$publisher"
-  printf 'must survive a newly spawned branch\n' > "$publisher/advanced-main.txt"
-  git -C "$publisher" add advanced-main.txt
-  git -C "$publisher" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm advance-main
-  git -C "$publisher" push --quiet origin "$default"
+  if [ "$remote" = origin ]; then
+    git clone --quiet "file://$origin" "$publisher"
+    printf 'must survive a newly spawned branch\n' > "$publisher/advanced-main.txt"
+    git -C "$publisher" add advanced-main.txt
+    git -C "$publisher" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm advance-main
+    git -C "$publisher" push --quiet origin "$default"
+  else
+    [ -z "$(git -C "$project" remote)" ] || fail "$name: fixture is not remoteless"
+    advance_local_default "$project" "$initial"
+  fi
 
   printf '%s\n' "$case_dir|$home|$project|$pool|$fakebin|$initial|$default"
 }
 
 # A project with NO origin remote at all, as a local-only project may genuinely be.
-# Its local default branch is advanced past the pooled worktree's base, so a spawn
-# that skips the refresh entirely is as visible as one that refuses.
-# Echoes the same record layout as make_case.
+# Echoes the same record layout as make_case, because it is make_case.
 make_remoteless_case() {
-  local name=$1 id=$2 default=${3:-main} case_dir home project pool fakebin initial
-  case_dir="$TMP_ROOT/$name"
-  home="$case_dir/home"
-  project="$case_dir/project"
-  pool="$case_dir/pool"
-  fakebin=$(make_spawn_fakebin "$case_dir/fake")
-
-  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
-  printf 'codex\n' > "$home/config/crew-harness"
-  printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
-  touch "$home/state/.last-watcher-beat"
-
-  git init --quiet -b "$default" "$project"
-  printf 'base\n' > "$project/README.md"
-  git -C "$project" add README.md
-  git -C "$project" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial
-  initial=$(git -C "$project" rev-parse HEAD)
-  git -C "$project" worktree add --quiet --detach "$pool" "$initial"
-  advance_local_default "$project" "$initial"
-
-  printf '%s\n' "$case_dir|$home|$project|$pool|$fakebin|$initial|$default"
+  local name=$1 id=$2 default=${3:-main}
+  make_case "$name" "$id" "$default" none
 }
 
 # Move the project's checked-out local default branch one commit past <base>, so a
@@ -264,11 +267,13 @@ test_remoteless_project_launches_from_local_default() {
   [ "$(printf '%s\n' "$notice" | grep -c .)" = 1 ] \
     || fail "the remoteless launch printed $(printf '%s\n' "$notice" | grep -c .) skip notices, not exactly one"
   assert_contains "$notice" "$REMOTELESS_NOTICE_REASON" \
-    "the remoteless NOTICE did not say why the fetch was skipped"
+    "the remoteless NOTICE did not say why the origin freshen was skipped"
+  assert_contains "$notice" "$REMOTELESS_NOTICE_SKIP" \
+    "the remoteless NOTICE did not say the origin freshen was skipped"
   assert_contains "$notice" "$(spawn_rendered_project_path)" \
     "the remoteless NOTICE did not name the project path"
-  assert_contains "$notice" "$DEFAULT_BRANCH" \
-    "the remoteless NOTICE did not name the local default branch launched from"
+  assert_contains "$notice" "LOCAL default branch '$DEFAULT_BRANCH' $REMOTELESS_NOTICE_AUTHORITY" \
+    "the remoteless NOTICE did not name the local default branch it took as the base authority"
   if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
     printf '# observed remoteless notice: %s\n' "$notice"
     printf '# observed remoteless spawn: %s\n' "$(printf '%s\n' "$out" | tail -n 1)"
@@ -316,6 +321,39 @@ test_remoteless_project_without_a_local_default_refuses() {
   [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$before" ] \
     || fail "spawn moved the pooled worktree while refusing an unresolvable local default branch"
   pass "a remoteless project with no resolvable default branch still refuses"
+}
+
+# The notice fires while the base ref is being resolved, ahead of the clean-worktree
+# and reset checks, so it may only claim what is already true at that moment. A
+# remoteless spawn into a dirty pool is where that matters: the notice still prints,
+# and the spawn still refuses, so a notice that announced a launch would have lied.
+test_remoteless_notice_survives_a_later_refusal() {
+  local rec id out status before notice
+  id='pool-no-remote-dirty-r6'
+  rec=$(make_remoteless_case no-remote-dirty "$id")
+  read_case_record "$rec"
+  before=$(git -C "$POOL_DIR" rev-parse HEAD)
+  printf 'keep this local work\n' > "$POOL_DIR/uncommitted.txt"
+
+  out=$(run_spawn "$id" --mode local-only --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn succeeded into a dirty remoteless pooled worktree"
+  assert_contains "$out" "is not clean" \
+    "spawn did not clearly refuse a dirty remoteless pooled worktree"
+  assert_not_contains "$out" "spawned $id" "a refused remoteless spawn reported a launch"
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$before" ] \
+    || fail "spawn moved HEAD while refusing a dirty remoteless pooled worktree"
+  notice=$(remoteless_notice_lines "$out")
+  [ "$(printf '%s\n' "$notice" | grep -c .)" = 1 ] \
+    || fail "a refused remoteless spawn did not print exactly one skip notice"
+  assert_contains "$notice" "$REMOTELESS_NOTICE_SKIP" \
+    "the notice printed ahead of a refusal did not report the skipped origin freshen"
+  assert_contains "$notice" "$REMOTELESS_NOTICE_AUTHORITY" \
+    "the notice printed ahead of a refusal did not report the local branch as the base authority"
+  if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+    printf '# observed notice before refusal: %s\n' "$notice"
+  fi
+  pass "the remoteless notice reports only the skip, so it stays true when the spawn then refuses"
 }
 
 test_direct_pr_and_scout_refresh_before_launch() {
@@ -398,5 +436,6 @@ test_unreachable_origin_refuses_stale_pool_base
 test_remoteless_project_launches_from_local_default
 test_remoteless_scout_launches_from_local_default
 test_remoteless_project_without_a_local_default_refuses
+test_remoteless_notice_survives_a_later_refusal
 
 echo "# all fm-spawn-pool-base-freshen tests passed"

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -38,6 +38,8 @@
 #   (o) fm-pr-check rerun after HEAD moved                      -> no stale pr_head
 #   (p) fm-pr-check when local HEAD lags                        -> record remote PR head
 #   (q) no-mistakes + NO pr= recorded, PR discovered by branch  -> ALLOW  (yolo/no-CI merge)
+#   (z1) local-only project with NO remote configured + merged  -> ALLOW  (remoteless landing)
+#   (z2) local-only project with NO remote configured + unmerged -> REFUSE (remoteless safety)
 #
 # Also covers backlog teardown-lock-race: a git index.lock left in the worktree by a
 # killed crew process (bin/fm-teardown.sh's teardown_treehouse_return).
@@ -173,6 +175,34 @@ SH
   touch "$case_dir/state/.last-watcher-beat"
 
   printf '%s\n' "$case_dir"
+}
+
+# Build a case whose project has NO remote at all, as a local-only project may
+# genuinely have none. Everything else matches make_case, so the only variable
+# between this and the origin-backed cases is the absence of the remote.
+# Echoes the case dir.
+make_remoteless_case() {
+  local name=$1 case_dir
+  case_dir=$(make_case "$name")
+  git -C "$case_dir/project" worktree remove --force "$case_dir/wt"
+  rm -rf "$case_dir/project" "$case_dir/origin.git"
+  git init -q -b main "$case_dir/project"
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t \
+    commit -q --allow-empty -m "local baseline"
+  git -C "$case_dir/project" worktree add -q -b fm/task-x1 "$case_dir/wt" main
+  [ -z "$(git -C "$case_dir/project" remote)" ] || fail "$name: fixture is not remoteless"
+  printf '%s\n' "$case_dir"
+}
+
+# Land the worktree's branch on the project's local default branch through the real
+# approved-merge path, so the case proves that path works rather than simulating it.
+run_merge_local() {
+  local case_dir=$1
+  FM_ROOT_OVERRIDE="$ROOT" \
+  FM_STATE_OVERRIDE="$case_dir/state" \
+  FM_CONFIG_OVERRIDE="$case_dir/config" \
+  PATH="$case_dir/fakebin:${FM_TEARDOWN_TEST_PATH:-$PATH}" \
+    "$ROOT/bin/fm-merge-local.sh" task-x1
 }
 
 add_compatible_tasks_axi() {
@@ -651,6 +681,47 @@ test_local_only_merged_to_local_main_allows() {
   expect_code 0 "$rc" "merged-main: teardown should succeed when work is merged into local main"
   ! grep -q REFUSED "$case_dir/stderr" || fail "merged-main: teardown printed a REFUSED line"
   pass "local-only worktree with work merged into local main is torn down (no regression)"
+}
+
+test_remoteless_local_only_merged_then_torn_down() {
+  local case_dir rc out wt_head merged_head
+  case_dir=$(make_remoteless_case remoteless-merge)
+  write_meta "$case_dir" local-only ship
+  wt_commit_file "$case_dir" landed.txt "remoteless local work"
+  wt_head=$(git -C "$case_dir/wt" rev-parse HEAD)
+
+  out=$(run_merge_local "$case_dir") || fail "remoteless-merge: the approved local merge failed: $out"
+  merged_head=$(git -C "$case_dir/project" rev-parse refs/heads/main)
+  [ "$merged_head" = "$wt_head" ] \
+    || fail "remoteless-merge: local main is not at the branch head after the approved merge"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+  expect_code 0 "$rc" "remoteless-merge: teardown should accept work merged into local main"
+  ! grep -q REFUSED "$case_dir/stderr" \
+    || fail "remoteless-merge: teardown refused landed work on a project with no remote"
+  pass "a remoteless local-only project merges through the approved path and tears down"
+}
+
+test_remoteless_local_only_unpushed_still_refuses() {
+  local case_dir rc
+  case_dir=$(make_remoteless_case remoteless-unpushed)
+  write_meta "$case_dir" local-only ship
+  wt_commit_file "$case_dir" unlanded.txt "never merged anywhere"
+  # Deliberately NOT merged into local main: with no remote to fall back on, the
+  # local default branch is the only landing proof, and it does not have this work.
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "remoteless-unpushed: teardown should refuse unlanded work"
+  grep -q REFUSED "$case_dir/stderr" || fail "remoteless-unpushed: no REFUSED line in stderr"
+  assert_grep 'never merged anywhere' "$case_dir/wt/unlanded.txt" \
+    "remoteless-unpushed: teardown discarded the unlanded work it refused"
+  pass "a remoteless local-only project still refuses to discard work not on its local default branch"
 }
 
 test_no_mistakes_origin_remote_allows() {
@@ -2596,6 +2667,8 @@ test_teardown_prompts_tasks_axi_done_when_compatible
 test_teardown_manual_backend_prompts_hand_edit_even_when_tasks_axi_present
 test_local_only_truly_unpushed_refuses
 test_local_only_merged_to_local_main_allows
+test_remoteless_local_only_merged_then_torn_down
+test_remoteless_local_only_unpushed_still_refuses
 test_no_mistakes_origin_remote_allows
 test_no_mistakes_truly_unpushed_refuses
 test_local_only_force_overrides_unpushed


### PR DESCRIPTION
## Intent

A local-only project with no remote cannot be spawned into at all. Fix that.

The bug, reproduced: data/projects.md documents local-only as a posture whose project "may have no remote", and the project-management skill says the same: "A local-only project may have no remote and skips no-mistakes initialization." But bin/fm-spawn.sh's freshen_spawn_worktree_base begins with an unconditional `git -C "$worktree" fetch --quiet origin`, so a repo with no origin fails immediately with: error: could not fetch origin for pooled worktree '<path>'; refusing to launch from a potentially stale base. Reproduced 2026-08-17 spawning a ship task into a freshly created local-only project with a single commit and no remote configured. The spawn aborts before writing task metadata, so it fails cleanly - the worktree lease is released and no state/<id>.meta is left behind - but the task simply cannot start. Reproduce it independently before fixing, with a throwaway local repo, so the real thing gets fixed.

The fix: when the repository has no origin remote configured, there is no stale base possible: the local default branch IS authoritative, so the freshen step has nothing to do and must be skipped rather than treated as a failure. Detect the genuine absence of the remote, skip freshening, and continue the spawn from the local default branch.

Preserve the existing guard exactly where it still applies. If an origin remote IS configured and the fetch or default-branch resolution fails, that must keep refusing loudly as it does today - an unreachable remote is a real stale-base risk and this change must not weaken it. The distinction is "no remote configured" versus "remote configured but unreachable", and those two must not collapse into one code path.

Accepted decision (spawn-remoteless-skip-scope, already answered and applied): the remoteless skip must never be silent. Taking that path prints exactly one loud NOTICE naming the project and the local default branch launched from, so a project that lost a remote it was meant to have stays visible rather than being silently assumed local-only.

Check whether the same unconditional-remote assumption exists anywhere else on the spawn, teardown, or merge path for a remoteless local-only project, and fix what is found in the same change rather than leaving a second instance of this bug for later. bin/fm-merge-local.sh and bin/fm-teardown.sh are the obvious places to check, since teardown's landed-work test already has a documented local-only fallback for "the common case where there is no remote at all" - confirm that path genuinely works with no remote rather than assuming it does.

Acceptance criteria:
1. A ship spawn into a local-only project with no remote succeeds and the worker starts in a genuine isolated worktree on the local default branch.
2. A spawn into a project WITH a remote whose fetch fails still refuses, with its current message unchanged. Prove both halves.
3. Tests colocated in tests/ following the existing pattern, covering the no-remote skip, the remote-present-but-unreachable refusal, and whatever second instance of the assumption is found. Drive the two cases apart deliberately so neither can pass vacuously.
4. bin/fm-lint.sh passes.
5. Update whichever owner documents this behavior, per the knowledge-placement tree - the script header and --help own exact mechanics. Do not restate the contract in a second place.

Constraints: this is a narrow correctness fix. Do not restructure the spawn path, do not change the worktree pooling model, and do not relax any other guard. If an unrelated problem is found, note it in the PR description rather than fixing it. This task changes firstmate's own shared, tracked material, so the firstmate-coding-guidelines contract applies: knowledge-placement tree, one-owner rule, one sentence per line in tracked Markdown, plain dash never an em dash, shellcheck-clean bin scripts, and tests colocated in tests/ that exercise behavior through an executable interface rather than asserting implementation source bytes.

## What Changed

- `bin/fm-spawn.sh` splits base-ref resolution into a new `spawn_worktree_base_ref` helper that keeps "no origin remote configured" and "origin configured but unreachable" as separate paths: a genuinely remoteless project skips the origin fetch and takes `refs/heads/<local default>` as its base authority, while a configured-but-unfetchable origin still refuses with its existing `could not fetch origin ...` message. A remoteless project whose local default branch cannot be resolved refuses too, and the clean-worktree and reset checks still run afterwards in both cases.
- The remoteless skip is never silent: it prints exactly one `NOTICE` naming the project path, the skipped origin freshen, and the local default branch taken as the base authority. The `fm-spawn.sh` header documents these mechanics, and `docs/architecture.md`'s one-line base-freshness summary now says the authority is origin's default branch when a remote is configured and the local default branch when the project has none.
- `tests/fm-spawn-pool-base-freshen.test.sh` grows remoteless ship and scout launches, an unresolvable-local-default refusal, and a notice-before-a-later-refusal case; both the remoteless and unreachable-origin fixtures now advance the local default branch past the pool base so neither verdict can pass vacuously, and origin-backed cases assert the notice is absent. `tests/fm-teardown.test.sh` adds two cases that drive `bin/fm-merge-local.sh` and teardown against a project with no remote at all - landed work tears down, unlanded work still REFUSES - confirming that path already worked without needing a code change.

## Known limitation

A project with no origin remote whose local default branch is named something other than `main` or `master` still refuses to launch.
The shared default-branch helper (`default_branch` in `bin/fm-ff-lib.sh`) resolves only `origin/HEAD`, `main`, and `master`, so a remoteless project on, for example, a `trunk` default branch still stops with `could not determine the local default branch ... refusing to launch from a potentially stale base`.

Widening that helper was deliberately left out of scope for this change.
It is re-implemented identically in `bin/fm-merge-local.sh`, `bin/fm-teardown.sh`, `bin/fm-review-diff.sh`, `bin/fm-fleet-sync.sh`, and `bin/fm-tangle-lib.sh`, so fixing it for spawn alone would leave those callers disagreeing about what a project's default branch is - a worse defect than the one being fixed.
The failure mode if it ever bites is a loud, diagnosable refusal rather than silent wrong behaviour, and the repair is small when a real case appears.

The existing refusal is covered by `tests/fm-spawn-pool-base-freshen.test.sh`; no test pins this gap as desired behaviour.

## Note on the lint step

`bin/fm-lint.sh` passes, with ShellCheck 0.11.0 matching the pin.
The separate workflow linter `bin/fm-lint-workflows.sh` reported `actionlint not found` (exit code 127) because `actionlint` is not installed on this machine, and installing it would mean writing outside this task's worktree.
This change touches no `.github/workflows/` files, and CI installs the pinned `actionlint` itself, so workflow linting is still enforced before merge.

## Risk Assessment

✅ Low: The fix adds one narrowly guarded branch that can only intercept repo shapes which previously hard-refused (a fetch cannot succeed without a configured origin URL), keeps the unreachable-origin guard and its messages byte-identical, uses the same remote-detection idiom as teardown/merge/review, and is covered by non-vacuous tests on both halves plus the remoteless teardown/merge path.

## Testing

I reproduced the reported failure from scratch with my own harness before trusting the fix: a freshly built local-only repo with one commit and no remote, a real pooled git worktree, and the real fm-spawn.sh from base d843712 - it aborted with the documented `could not fetch origin` refusal and wrote no task metadata. The same harness against the target commit launches the ship task, prints exactly one loud NOTICE naming the project and the local default branch, and resets the pooled worktree from its stale base onto the local main tip; the companion case with an origin configured but unreachable still refuses, exit 1, with the message byte-identical to before and no fallback to the local branch, so the two conditions are demonstrably separate code paths. For the second instance of the assumption I drove the real fm-merge-local.sh and fm-teardown.sh on a remoteless project and captured the transcript: the approved local merge lands on local main with no remote present and teardown accepts, while unmerged work is still refused without being discarded. On the automated side, tests/fm-spawn-pool-base-freshen.test.sh passes at the target and fails precisely at the remoteless case when run against the pre-fix script (all pre-existing guard cases still passing), and tests/fm-teardown.test.sh passes in full. This is a CLI-only change with no rendered UI surface, so the reviewer-visible evidence is CLI transcripts rather than screenshots. I did not run bin/fm-lint.sh, which is out of scope for this phase; everything else in the acceptance criteria checked out and the worktree is clean.

<details>
<summary>Evidence: Bug reproduced against the pre-fix script (base d843712): remoteless spawn refuses, broken-origin spawn refuses</summary>

Source: [Bug reproduced against the pre-fix script (base d843712): remoteless spawn refuses, broken-origin spawn refuses](https://github.com/Scy1505/firstmate/blob/eeb831173f57d0320490aecc72983e1a044ef176/.no-mistakes/evidence/fm/fm-spawn-no-remote-2/repro-before-fix.txt)

<code>===== CASE A: local-only project, one commit, NO remote configured -&gt; must launch [BEFORE FIX (base d843712)] =====&#10;$ git -C project remote -v&#10;(no remote configured)&#10;$ fm-spawn.sh local-only-ship-a1 &lt;project&gt; --mode local-only --yolo off&#10;fatal: &#39;origin&#39; does not appear to be a git repository&#10;error: could not fetch origin for pooled worktree &#39;.../case-a-no-remote/pool&#39;; refusing to launch from a potentially stale base&#10;-- exit status: 1&#10;-- task metadata written: 0</code>

```text
### firstmate remoteless-spawn reproduction (BEFORE FIX (base d843712))
repo under test: /var/folders/qv/cm61wmnx0jz5v328bp9bclhw0000gn/T//fm-remoteless-repro/repo-base
fm-spawn.sh sha1: 22b8f2226700da9892631c0fbc050518c54af775

===== CASE A: local-only project, one commit, NO remote configured -> must launch [BEFORE FIX (base d843712)] =====
$ git -C project remote -v
  (no remote configured)
$ fm-spawn.sh local-only-ship-a1 <project> --mode local-only --yolo off
  warning: /var/folders/qv/cm61wmnx0jz5v328bp9bclhw0000gn/T//fm-remoteless-repro.5q47K7/case-a-no-remote/home/data/local-only-ship-a1/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode local-only - confirm its definition of done matches
  notice: local-only-ship-a1 ships mode=local-only while the standing posture for project is no-mistakes - less rigor than the captain's standing posture; proceed only on a current explicit captain instruction or an intake judgment you can state
  fatal: 'origin' does not appear to be a git repository
  fatal: Could not read from remote repository.
  
  Please make sure you have the correct access rights
  and the repository exists.
  error: could not fetch origin for pooled worktree '/var/folders/qv/cm61wmnx0jz5v328bp9bclhw0000gn/T//fm-remoteless-repro.5q47K7/case-a-no-remote/pool'; refusing to launch from a potentially stale base
-- exit status: 1
-- pooled worktree HEAD: before=52827b3f5e81dd206786ac94f20e2abf6a930ae3 after=52827b3f5e81dd206786ac94f20e2abf6a930ae3 local-main=f3e2a3756928de7e4d640b177b77b3ade515a6db
-- pooled worktree branch: HEAD
-- is a real separate worktree root: /private/var/folders/qv/cm61wmnx0jz5v328bp9bclhw0000gn/T/fm-remoteless-repro.5q47K7/case-a-no-remote/pool (project checkout: /var/folders/qv/cm61wmnx0jz5v328bp9bclhw0000gn/T//fm-remoteless-repro.5q47K7/case-a-no-remote/project)
-- task metadata written: 0

===== CASE B: origin CONFIGURED but unreachable -> must still refuse loudly [BEFORE FIX (base d843712)] =====
$ git -C project remote -v
  origin	file:///var/folders/qv/cm61wmnx0jz5v328bp9bclhw0000gn/T//fm-remoteless-repro.5q47K7/case-b-broken-origin/does-not-exist.git (fetch)
  origin	file:///var/folders/qv/cm61wmnx0jz5v328bp9bclhw0000gn/T//fm-remoteless-repro.5q47K7/case-b-broken-origin/does-not-exist.git (push)
$ fm-spawn.sh origin-ship-b1 <project> --mode no-mistakes --yolo off
  warning: /var/folders/qv/cm61wmnx0jz5v328bp9bclhw0000gn/T//fm-remoteless-repro.5q47K7/case-b-broken-origin/home/data/origin-ship-b1/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
  fatal: '/var/folders/qv/cm61wmnx0jz5v328bp9bclhw0000gn/T//fm-remoteless-repro.5q47K7/case-b-broken-origin/does-not-exist.git' does not appear to be a git repository
  fatal: Could not read from remote repository.
  
  Please make sure you have the correct access rights
  and the repository exists.
  error: could not fetch origin for pooled worktree '/var/folders/qv/cm61wmnx0jz5v328bp9bclhw0000gn/T//fm-remoteless-repro.5q47K7/case-b-broken-origin/pool'; refusing to launch from a potentially stale base
-- exit status: 1
-- pooled worktree HEAD: before=580278f24fc36c46540377c145662ce85fd440df after=580278f24fc36c46540377c145662ce85fd440df local-main=fbbdf2964e73124dd4d26891026f036ee98f9dc9
-- pooled worktree branch: HEAD
-- is a real separate worktree root: /private/var/folders/qv/cm61wmnx0jz5v328bp9bclhw0000gn/T/fm-remoteless-repro.5q47K7/case-b-broken-origin/pool (project checkout: /var/folders/qv/cm61wmnx0jz5v328bp9bclhw0000gn/T//fm-remoteless-repro.5q47K7/case-b-broken-origin/project)
-- task metadata written: 0
```
</details>
<details>
<summary>Evidence: Same harness after the fix: remoteless spawn launches from the local default branch with one loud NOTICE; configured-but-unreachable origin still refuses</summary>

Source: [Same harness after the fix: remoteless spawn launches from the local default branch with one loud NOTICE; configured-but-unreachable origin still refuses](https://github.com/Scy1505/firstmate/blob/eeb831173f57d0320490aecc72983e1a044ef176/.no-mistakes/evidence/fm/fm-spawn-no-remote-2/repro-after-fix.txt)

<code>===== CASE A: local-only project, one commit, NO remote configured -&gt; must launch [AFTER FIX] =====&#10;NOTICE: project &#39;.../case-a-no-remote/project&#39; has no origin remote configured - skipping the origin freshen for pooled worktree &#39;.../case-a-no-remote/pool&#39; and taking its LOCAL default branch &#39;main&#39; as the base authority, because no remote history exists to be stale against. If this project is meant to have a remote, restore it before shipping.&#10;spawned local-only-ship-a1 harness=codex kind=ship mode=local-only yolo=off window=firstmate:fm-local-only-ship-a1 worktree=.../case-a-no-remote/pool&#10;-- exit status: 0&#10;-- pooled worktree HEAD: before=0d9950f after=46e8123 local-main=46e8123&#10;-- task metadata written: 1&#10;&#10;===== CASE B: origin CONFIGURED but unreachable -&gt; must still refuse loudly =====&#10;error: could not fetch origin for pooled worktree &#39;.../case-b-broken-origin/pool&#39;; refusing to launch from a potentially stale base&#10;-- exit status: 1&#10;-- pooled worktree HEAD: before=1912b3d after=1912b3d local-main=fe97358 (no fallback to the local branch)</code>

```text
### firstmate remoteless-spawn reproduction (AFTER FIX (target 9458657))
repo under test: /Users/felipe/.no-mistakes/worktrees/4fb7eb181a3c/01M0AND48W761TMV4ZB34KDXGZ
fm-spawn.sh sha1: 45c5d9cd7c4965b32880ad8ecc413050d2dd32ac

===== CASE A: local-only project, one commit, NO remote configured -> must launch [AFTER FIX (target 9458657)] =====
$ git -C project remote -v
  (no remote configured)
$ fm-spawn.sh local-only-ship-a1 <project> --mode local-only --yolo off
  warning: /var/folders/qv/cm61wmnx0jz5v328bp9bclhw0000gn/T//fm-remoteless-repro.wHdmcR/case-a-no-remote/home/data/local-only-ship-a1/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode local-only - confirm its definition of done matches
  notice: local-only-ship-a1 ships mode=local-only while the standing posture for project is no-mistakes - less rigor than the captain's standing posture; proceed only on a current explicit captain instruction or an intake judgment you can state
  NOTICE: project '/var/folders/qv/cm61wmnx0jz5v328bp9bclhw0000gn/T/fm-remoteless-repro.wHdmcR/case-a-no-remote/project' has no origin remote configured - skipping the origin freshen for pooled worktree '/var/folders/qv/cm61wmnx0jz5v328bp9bclhw0000gn/T//fm-remoteless-repro.wHdmcR/case-a-no-remote/pool' and taking its LOCAL default branch 'main' as the base authority, because no remote history exists to be stale against. If this project is meant to have a remote, restore it before shipping.
  spawned local-only-ship-a1 harness=codex kind=ship mode=local-only yolo=off window=firstmate:fm-local-only-ship-a1 worktree=/var/folders/qv/cm61wmnx0jz5v328bp9bclhw0000gn/T//fm-remoteless-repro.wHdmcR/case-a-no-remote/pool
-- exit status: 0
-- pooled worktree HEAD: before=0d9950fb92e35af68da27f2094e30dc82a72cade after=46e8123fa266b9fdfee837787951a4bd19909d5f local-main=46e8123fa266b9fdfee837787951a4bd19909d5f
-- pooled worktree branch: HEAD
-- is a real separate worktree root: /private/var/folders/qv/cm61wmnx0jz5v328bp9bclhw0000gn/T/fm-remoteless-repro.wHdmcR/case-a-no-remote/pool (project checkout: /var/folders/qv/cm61wmnx0jz5v328bp9bclhw0000gn/T//fm-remoteless-repro.wHdmcR/case-a-no-remote/project)
-- task metadata written: 1

===== CASE B: origin CONFIGURED but unreachable -> must still refuse loudly [AFTER FIX (target 9458657)] =====
$ git -C project remote -v
  origin	file:///var/folders/qv/cm61wmnx0jz5v328bp9bclhw0000gn/T//fm-remoteless-repro.wHdmcR/case-b-broken-origin/does-not-exist.git (fetch)
  origin	file:///var/folders/qv/cm61wmnx0jz5v328bp9bclhw0000gn/T//fm-remoteless-repro.wHdmcR/case-b-broken-origin/does-not-exist.git (push)
$ fm-spawn.sh origin-ship-b1 <project> --mode no-mistakes --yolo off
  warning: /var/folders/qv/cm61wmnx0jz5v328bp9bclhw0000gn/T//fm-remoteless-repro.wHdmcR/case-b-broken-origin/home/data/origin-ship-b1/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
  fatal: '/var/folders/qv/cm61wmnx0jz5v328bp9bclhw0000gn/T//fm-remoteless-repro.wHdmcR/case-b-broken-origin/does-not-exist.git' does not appear to be a git repository
  fatal: Could not read from remote repository.
  
  Please make sure you have the correct access rights
  and the repository exists.
  error: could not fetch origin for pooled worktree '/var/folders/qv/cm61wmnx0jz5v328bp9bclhw0000gn/T//fm-remoteless-repro.wHdmcR/case-b-broken-origin/pool'; refusing to launch from a potentially stale base
-- exit status: 1
-- pooled worktree HEAD: before=1912b3dc7311f9840b4da95a76e68a383fd7aa57 after=1912b3dc7311f9840b4da95a76e68a383fd7aa57 local-main=fe97358f3ecb28df345de6b4d0c020f6b87c3e4d
-- pooled worktree branch: HEAD
-- is a real separate worktree root: /private/var/folders/qv/cm61wmnx0jz5v328bp9bclhw0000gn/T/fm-remoteless-repro.wHdmcR/case-b-broken-origin/pool (project checkout: /var/folders/qv/cm61wmnx0jz5v328bp9bclhw0000gn/T//fm-remoteless-repro.wHdmcR/case-b-broken-origin/project)
-- task metadata written: 0
```
</details>
<details>
<summary>Evidence: Independent reproduction harness (self-written, used for both the before and after runs)</summary>

Source: [Independent reproduction harness (self-written, used for both the before and after runs)](https://github.com/Scy1505/firstmate/blob/eeb831173f57d0320490aecc72983e1a044ef176/.no-mistakes/evidence/fm/fm-spawn-no-remote-2/repro-remoteless-spawn.sh)

```text
#!/usr/bin/env bash
# Independent end-to-end reproduction harness for:
#   "A local-only project with no remote cannot be spawned into at all."
#
# Written for the Test phase, deliberately NOT reusing tests/fm-spawn-pool-base-freshen.test.sh,
# so the reported bug is reproduced from scratch against the pre-fix script and then
# re-run unchanged against the fixed one.
#
# Usage: repro-remoteless-spawn.sh <path-to-firstmate-repo-root> <label>
#
# Two throwaway projects are built per run:
#   A. local-only, ONE commit, NO remote configured  -> the reported repro
#   B. origin configured but UNREACHABLE             -> the guard that must survive
#
# tmux is not installed on this machine, so the terminal is faked exactly the way
# firstmate's own suite fakes it (tmux shim + `treehouse get` no-op). Everything the
# fix touches - the git remote configuration, the pooled worktree, the fetch, the
# default-branch resolution, the reset - is real git against real repos on disk.
set -u

REPO=${1:?usage: repro-remoteless-spawn.sh <repo-root> <label>}
LABEL=${2:?usage: repro-remoteless-spawn.sh <repo-root> <label>}
SPAWN="$REPO/bin/fm-spawn.sh"
ROOT_DIR=$(mktemp -d "${TMPDIR:-/tmp}/fm-remoteless-repro.XXXXXX")

git_c() { git -c user.name='Repro' -c user.email='repro@example.invalid' "$@"; }

build_fakebin() {  # <dir>
  local fb=$1
  mkdir -p "$fb"
  cat > "$fb/tmux" <<'SH'
#!/usr/bin/env bash
set -u
case "$*" in
  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:?}"; exit 0 ;;
esac
case "${1:-}" in
  display-message) printf 'firstmate\n'; exit 0 ;;
esac
exit 0
SH
  cat > "$fb/treehouse" <<'SH'
#!/usr/bin/env bash
exit 0
SH
  chmod +x "$fb/tmux" "$fb/treehouse"
}

build_case() {  # <name> <id> <remote-kind: none|broken>
  local name=$1 id=$2 kind=$3 dir home project pool
  dir="$ROOT_DIR/$name"
  home="$dir/home"
  project="$dir/project"
  pool="$dir/pool"
  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
  printf 'codex\n' > "$home/config/crew-harness"
  printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
  touch "$home/state/.last-watcher-beat"
  build_fakebin "$dir/fakebin"

  # A freshly created local-only project: one commit, and (case A) no remote at all.
  git init --quiet -b main "$project"
  printf 'hello local-only\n' > "$project/README.md"
  git -C "$project" add README.md
  git_c -C "$project" commit -qm 'initial local-only commit'
  git -C "$project" worktree add --quiet --detach "$pool" HEAD
  if [ "$kind" = broken ]; then
    # One remote add reaches both: a linked worktree shares the project's config.
    git -C "$project" remote add origin "file://$dir/does-not-exist.git"
  fi
  # Land one more commit on the local default branch AFTER the pool worktree was
  # allocated, so the pool base is genuinely stale against the local tip. A spawn that
  # merely ignored the freshen step would leave the pool on the old base; a spawn that
  # treats the local branch as the authority resets onto this commit.
  printf 'landed after the pool was allocated\n' > "$project/landed-later.txt"
  git -C "$project" add landed-later.txt
  git_c -C "$project" commit -qm 'advance local default after pool allocation'
  printf '%s\n' "$dir|$home|$project|$pool"
}

report() {  # <heading> <dir> <home> <project> <pool> <id> ...spawn args
  local heading=$1 dir=$2 home=$3 project=$4 pool=$5 id=$6
  shift 6
  local out status head_before head_after
  head_before=$(git -C "$pool" rev-parse HEAD)
  printf '\n===== %s [%s] =====\n' "$heading" "$LABEL"
  printf '$ git -C project remote -v\n'
  git -C "$project" remote -v | sed 's/^/  /'
  [ -n "$(git -C "$project" remote)" ] || printf '  (no remote configured)\n'
  printf '$ fm-spawn.sh %s <project> %s\n' "$id" "$*"
  out=$(FM_ROOT_OVERRIDE='' FM_HOME="$home" \
    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
    FM_SPAWN_NO_GUARD=1 FM_GATE_REFUSE_BYPASS=1 TMUX="fake,1,0" FM_FAKE_PANE_PATH="$pool" \
    PATH="$dir/fakebin:$PATH" \
    "$SPAWN" "$id" "$project" "$@" 2>&1)
  status=$?
  printf '%s\n' "$out" | sed 's/^/  /'
  printf -- '-- exit status: %s\n' "$status"
  head_after=$(git -C "$pool" rev-parse HEAD)
  printf -- '-- pooled worktree HEAD: before=%s after=%s local-main=%s\n' \
    "$head_before" "$head_after" "$(git -C "$project" rev-parse refs/heads/main)"
  printf -- '-- pooled worktree branch: %s\n' "$(git -C "$pool" rev-parse --abbrev-ref HEAD)"
  printf -- '-- is a real separate worktree root: %s (project checkout: %s)\n' \
    "$(git -C "$pool" rev-parse --show-toplevel)" "$project"
  printf -- '-- task metadata written: %s\n' \
    "$(find "$home/state" -maxdepth 1 -name '*.meta' 2>/dev/null | wc -l | tr -d ' ')"
}

printf '### firstmate remoteless-spawn reproduction (%s)\n' "$LABEL"
printf 'repo under test: %s\n' "$REPO"
printf 'fm-spawn.sh sha1: %s\n' "$(shasum "$SPAWN" | awk '{print $1}')"

IFS='|' read -r A_DIR A_HOME A_PROJECT A_POOL <<EOF
$(build_case case-a-no-remote local-only-ship-a1 none)
EOF
report 'CASE A: local-only project, one commit, NO remote configured -> must launch' \
  "$A_DIR" "$A_HOME" "$A_PROJECT" "$A_POOL" local-only-ship-a1 --mode local-only --yolo off

IFS='|' read -r B_DIR B_HOME B_PROJECT B_POOL <<EOF
$(build_case case-b-broken-origin origin-ship-b1 broken)
EOF
report 'CASE B: origin CONFIGURED but unreachable -> must still refuse loudly' \
  "$B_DIR" "$B_HOME" "$B_PROJECT" "$B_POOL" origin-ship-b1 --mode no-mistakes --yolo off

rm -rf "$ROOT_DIR"
```
</details>
<details>
<summary>Evidence: New spawn coverage run against the PRE-FIX script: old guards still pass, the remoteless case fails (not vacuous)</summary>

Source: [New spawn coverage run against the PRE-FIX script: old guards still pass, the remoteless case fails (not vacuous)](https://github.com/Scy1505/firstmate/blob/eeb831173f57d0320490aecc72983e1a044ef176/.no-mistakes/evidence/fm/fm-spawn-no-remote-2/new-tests-against-prefix-spawn.txt)

<code>ok - a dirty pooled worktree is refused without discarding its local work&#10;ok - an unresolved remote default branch refuses the pooled worktree&#10;ok - a configured but unreachable origin refuses instead of falling back to the local branch&#10;not ok - spawn should launch into a project with no origin remote: expected exit 0, got 1&#10;exit=1</code>

```text
# tests/fm-spawn-pool-base-freshen.test.sh (target commit) run against the PRE-FIX bin/fm-spawn.sh (base d843712)
# proves the new coverage is not vacuous: the pre-existing guard cases still pass, the remoteless case fails
ok - a stale pooled worktree refreshes to current origin/main before a crew branch is created
ok - a stale pooled worktree resolves and refreshes a non-main default branch
ok - direct-PR ships and scouts both refresh stale pooled worktrees before launch
ok - a dirty pooled worktree is refused without discarding its local work
ok - an unresolved remote default branch refuses the pooled worktree
ok - a configured but unreachable origin refuses instead of falling back to the local branch
not ok - spawn should launch into a project with no origin remote: expected exit 0, got 1
exit=1
```
</details>
<details>
<summary>Evidence: tests/fm-spawn-pool-base-freshen.test.sh at the target commit (FM_TEST_EVIDENCE=1)</summary>

Source: [tests/fm-spawn-pool-base-freshen.test.sh at the target commit (FM_TEST_EVIDENCE=1)](https://github.com/Scy1505/firstmate/blob/eeb831173f57d0320490aecc72983e1a044ef176/.no-mistakes/evidence/fm/fm-spawn-no-remote-2/spawn-tests-after-fix.txt)

```text
# tests/fm-spawn-pool-base-freshen.test.sh at the target commit (fixed bin/fm-spawn.sh), FM_TEST_EVIDENCE=1
# observed spawn: spawned pool-current-base-r1 harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-pool-current-base-r1 worktree=/var/folders/qv/cm61wmnx0jz5v328bp9bclhw0000gn/T//fm-spawn-pool-base-freshen.tUDgJq/current-base/pool
# observed base: HEAD=bb79bd0450627b656d360ed5f88906e7994ee5a0 origin/main=bb79bd0450627b656d360ed5f88906e7994ee5a0 advanced-main=must survive a newly spawned branch
ok - a stale pooled worktree refreshes to current origin/main before a crew branch is created
ok - a stale pooled worktree resolves and refreshes a non-main default branch
# observed direct-pr spawn: spawned pool-direct-pr-r3 harness=codex kind=ship mode=direct-PR yolo=off window=firstmate:fm-pool-direct-pr-r3 worktree=/var/folders/qv/cm61wmnx0jz5v328bp9bclhw0000gn/T//fm-spawn-pool-base-freshen.tUDgJq/direct-pr/pool
# observed scout spawn: spawned pool-scout-r3 harness=codex kind=scout window=firstmate:fm-pool-scout-r3 worktree=/var/folders/qv/cm61wmnx0jz5v328bp9bclhw0000gn/T//fm-spawn-pool-base-freshen.tUDgJq/scout/pool
ok - direct-PR ships and scouts both refresh stale pooled worktrees before launch
# observed dirty refusal: error: pooled worktree '/var/folders/qv/cm61wmnx0jz5v328bp9bclhw0000gn/T//fm-spawn-pool-base-freshen.tUDgJq/dirty-refusal/pool' is not clean; refusing to discard uncommitted work while refreshing its base; preserved=keep this local work
ok - a dirty pooled worktree is refused without discarding its local work
# observed unresolved-default refusal: error: could not resolve origin's current default branch for pooled worktree '/var/folders/qv/cm61wmnx0jz5v328bp9bclhw0000gn/T//fm-spawn-pool-base-freshen.tUDgJq/unresolved-default/pool'; refusing to launch from a potentially stale base
ok - an unresolved remote default branch refuses the pooled worktree
# observed unreachable-origin refusal: error: could not fetch origin for pooled worktree '/var/folders/qv/cm61wmnx0jz5v328bp9bclhw0000gn/T//fm-spawn-pool-base-freshen.tUDgJq/unreachable-origin/pool'; refusing to launch from a potentially stale base
ok - a configured but unreachable origin refuses instead of falling back to the local branch
# observed remoteless notice: NOTICE: project '/var/folders/qv/cm61wmnx0jz5v328bp9bclhw0000gn/T/fm-spawn-pool-base-freshen.tUDgJq/no-remote/project' has no origin remote configured - skipping the origin freshen for pooled worktree '/var/folders/qv/cm61wmnx0jz5v328bp9bclhw0000gn/T//fm-spawn-pool-base-freshen.tUDgJq/no-remote/pool' and taking its LOCAL default branch 'main' as the base authority, because no remote history exists to be stale against. If this project is meant to have a remote, restore it before shipping.
# observed remoteless spawn: spawned pool-no-remote-r6 harness=codex kind=ship mode=local-only yolo=off window=firstmate:fm-pool-no-remote-r6 worktree=/var/folders/qv/cm61wmnx0jz5v328bp9bclhw0000gn/T//fm-spawn-pool-base-freshen.tUDgJq/no-remote/pool
# observed remoteless base: HEAD=46da24e29dc5b9bc96e955c8f4de1c1e89cd76b5 local-main=46da24e29dc5b9bc96e955c8f4de1c1e89cd76b5 pool-base=9cefc5b4d8292c4a22b6a7d0b9792e4ae47b846f
ok - a project with no origin remote launches from its local default branch tip, loudly
ok - a scout into a remoteless project also starts from the local default branch tip, loudly
ok - a remoteless project with no resolvable default branch still refuses
# observed notice before refusal: NOTICE: project '/var/folders/qv/cm61wmnx0jz5v328bp9bclhw0000gn/T/fm-spawn-pool-base-freshen.tUDgJq/no-remote-dirty/project' has no origin remote configured - skipping the origin freshen for pooled worktree '/var/folders/qv/cm61wmnx0jz5v328bp9bclhw0000gn/T//fm-spawn-pool-base-freshen.tUDgJq/no-remote-dirty/pool' and taking its LOCAL default branch 'main' as the base authority, because no remote history exists to be stale against. If this project is meant to have a remote, restore it before shipping.
ok - the remoteless notice reports only the skip, so it stays true when the spawn then refuses
# all fm-spawn-pool-base-freshen tests passed
exit=0
```
</details>
<details>
<summary>Evidence: Remoteless merge + teardown CLI transcript (real fm-merge-local.sh and fm-teardown.sh)</summary>

Source: [Remoteless merge + teardown CLI transcript (real fm-merge-local.sh and fm-teardown.sh)](https://github.com/Scy1505/firstmate/blob/eeb831173f57d0320490aecc72983e1a044ef176/.no-mistakes/evidence/fm/fm-spawn-no-remote-2/transcript-remoteless-merge-teardown.txt)

<code>===== CASE 1: remoteless project, work merged through the approved local path =====&#10;project remotes: (none if empty)&#10;$ fm-merge-local.sh task-x1&#10;merged fm/task-x1 into local main (00bc934 -&gt; 6d30f40) in .../evidence-remoteless-merge/project&#10;$ fm-teardown.sh (task-x1)&#10;teardown task-x1 complete (window firstmate:fm-task-x1, worktree .../wt)&#10;-- fm-teardown exit: 0 (0 = accepted the landed work)&#10;&#10;===== CASE 2: same remoteless project, work NOT merged anywhere =====&#10;[stderr] REFUSED: local-only worktree .../evidence-remoteless-unpushed/wt has work not yet merged into main and not on any remote.&#10;[stderr] commits not yet on main:&#10;[stderr] 40c4f51 add unlanded.txt&#10;-- fm-teardown exit: 1 (non-zero = refused to discard unlanded work)&#10;-- unlanded work still on disk: never merged anywhere</code>

```text
### remoteless local-only merge + teardown transcript
repo under test: /Users/felipe/.no-mistakes/worktrees/4fb7eb181a3c/01M0AND48W761TMV4ZB34KDXGZ

===== CASE 1: remoteless project, work merged through the approved local path =====
-- before merge
   project remotes: (none if empty)
   local main      : 00bc9347b93f8665eae729fbce62bd1cda0d6ab9
   task branch     : 6d30f401097effa014d45d0857b2eb0dbda85eeb
   task worktree   : present (removal is delegated to the faked treehouse)
$ fm-merge-local.sh task-x1
  merged fm/task-x1 into local main (00bc934 -> 6d30f40) in /var/folders/qv/cm61wmnx0jz5v328bp9bclhw0000gn/T//fm-teardown-tests.1SxowN/evidence-remoteless-merge/project
-- fm-merge-local exit: 0
-- after merge
   project remotes: (none if empty)
   local main      : 6d30f401097effa014d45d0857b2eb0dbda85eeb
   task branch     : 6d30f401097effa014d45d0857b2eb0dbda85eeb
   task worktree   : present (removal is delegated to the faked treehouse)
$ fm-teardown.sh (task-x1)
  teardown task-x1 complete (window firstmate:fm-task-x1, worktree /var/folders/qv/cm61wmnx0jz5v328bp9bclhw0000gn/T//fm-teardown-tests.1SxowN/evidence-remoteless-merge/wt)
  Backlog: task-x1 just finished. Run tasks-axi done task-x1 --note "local main", then run tasks-axi ready for dependency-cleared candidates, check date gates, and dispatch only work whose blockers are gone and date is due.
-- fm-teardown exit: 0 (0 = accepted the landed work)
-- after teardown
   project remotes: (none if empty)
   local main      : 6d30f401097effa014d45d0857b2eb0dbda85eeb
   task branch     : (gone)
   task worktree   : present (removal is delegated to the faked treehouse)

===== CASE 2: same remoteless project, work NOT merged anywhere =====
-- before teardown
   project remotes: (none if empty)
   local main      : bf9ece994b8369dc336799cacd41c24bbd0d21d8
   task branch     : c3ecc9eb3152570fd05e5660724dcfbd61ea95e7
   task worktree   : present (removal is delegated to the faked treehouse)
$ fm-teardown.sh (task-x1)
  [stderr] REFUSED: local-only worktree /var/folders/qv/cm61wmnx0jz5v328bp9bclhw0000gn/T//fm-teardown-tests.1SxowN/evidence-remoteless-unpushed/wt has work not yet merged into main and not on any remote.
  [stderr] commits not yet on main:
  [stderr] c3ecc9e add unlanded.txt
  [stderr] Merge the branch into local main first (bin/fm-merge-local.sh after the captain approves), or push to a fork/remote, or get the captain's explicit OK to discard, then --force.
-- fm-teardown exit: 1 (non-zero = refused to discard unlanded work)
-- after teardown
   project remotes: (none if empty)
   local main      : bf9ece994b8369dc336799cacd41c24bbd0d21d8
   task branch     : c3ecc9eb3152570fd05e5660724dcfbd61ea95e7
   task worktree   : present (removal is delegated to the faked treehouse)
-- unlanded work still on disk: never merged anywhere
```
</details>
<details>
<summary>Evidence: Transcript harness for the merge/teardown half</summary>

Source: [Transcript harness for the merge/teardown half](https://github.com/Scy1505/firstmate/blob/eeb831173f57d0320490aecc72983e1a044ef176/.no-mistakes/evidence/fm/fm-spawn-no-remote-2/transcript-remoteless-merge-teardown.sh)

```text
#!/usr/bin/env bash
# Reviewer-visible CLI transcript for the SECOND instance of the "there is always a
# remote" assumption named in the intent: the landed-work test on the merge/teardown
# path for a project with NO remote configured.
#
# It reuses the repo suite's own fixture builders (a truncated copy of
# tests/fm-teardown.test.sh, sourced with its own bottom invocation list removed), then
# drives the REAL bin/fm-merge-local.sh and bin/fm-teardown.sh and prints what an
# operator would see, instead of only reporting ok/not-ok.
#
# Usage: transcript-remoteless-merge-teardown.sh <harness.sh> <repo-root>
set -u

HARNESS=${1:?usage: transcript-remoteless-merge-teardown.sh <harness.sh> <repo-root>}
REPO=${2:?usage: transcript-remoteless-merge-teardown.sh <harness.sh> <repo-root>}

# shellcheck source=/dev/null
. "$HARNESS"

show_state() {  # <label> <case_dir>
  local label=$1 case_dir=$2
  printf -- '-- %s\n' "$label"
  printf -- '   project remotes: %s\n' "$(git -C "$case_dir/project" remote | tr '\n' ' ')(none if empty)"
  printf -- '   local main      : %s\n' "$(git -C "$case_dir/project" rev-parse refs/heads/main)"
  printf -- '   task branch     : %s\n' \
    "$(git -C "$case_dir/project" rev-parse --verify --quiet refs/heads/fm/task-x1 || echo '(gone)')"
  # The physical worktree removal is delegated to `treehouse return`, which the suite's
  # fixture fakes, so this line reports the fixture's disk state and not a teardown verdict.
  printf -- '   task worktree   : %s (removal is delegated to the faked treehouse)\n' \
    "$([ -d "$case_dir/wt" ] && echo present || echo removed)"
}

printf '### remoteless local-only merge + teardown transcript\n'
printf 'repo under test: %s\n\n' "$REPO"

printf '===== CASE 1: remoteless project, work merged through the approved local path =====\n'
c1=$(make_remoteless_case evidence-remoteless-merge)
write_meta "$c1" local-only ship
wt_commit_file "$c1" landed.txt "remoteless local work"
show_state 'before merge' "$c1"
printf '$ fm-merge-local.sh task-x1\n'
merge_out=$(run_merge_local "$c1" 2>&1); merge_rc=$?
printf '%s\n' "$merge_out" | sed 's/^/  /'
printf -- '-- fm-merge-local exit: %s\n' "$merge_rc"
show_state 'after merge' "$c1"
printf '$ fm-teardown.sh (task-x1)\n'
set +e
run_teardown "$c1" > "$c1/stdout" 2> "$c1/stderr"
td_rc=$?
set -e
sed 's/^/  /' "$c1/stdout"
sed 's/^/  [stderr] /' "$c1/stderr"
printf -- '-- fm-teardown exit: %s (0 = accepted the landed work)\n' "$td_rc"
show_state 'after teardown' "$c1"

printf '\n===== CASE 2: same remoteless project, work NOT merged anywhere =====\n'
c2=$(make_remoteless_case evidence-remoteless-unpushed)
write_meta "$c2" local-only ship
wt_commit_file "$c2" unlanded.txt "never merged anywhere"
show_state 'before teardown' "$c2"
printf '$ fm-teardown.sh (task-x1)\n'
set +e
run_teardown "$c2" > "$c2/stdout" 2> "$c2/stderr"
td_rc=$?
set -e
sed 's/^/  /' "$c2/stdout"
sed 's/^/  [stderr] /' "$c2/stderr"
printf -- '-- fm-teardown exit: %s (non-zero = refused to discard unlanded work)\n' "$td_rc"
show_state 'after teardown' "$c2"
printf -- '-- unlanded work still on disk: %s\n' \
  "$(cat "$c2/wt/unlanded.txt" 2>/dev/null || echo '(LOST)')"
```
</details>
<details>
<summary>Evidence: tests/fm-teardown.test.sh full-file result</summary>

Source: [tests/fm-teardown.test.sh full-file result](https://github.com/Scy1505/firstmate/blob/eeb831173f57d0320490aecc72983e1a044ef176/.no-mistakes/evidence/fm/fm-spawn-no-remote-2/teardown-suite-result.txt)

<code>ok - a remoteless local-only project merges through the approved path and tears down&#10;ok - a remoteless local-only project still refuses to discard work not on its local default branch&#10;EXIT=0&#10;# total ok lines: 60</code>

```text
# bash tests/fm-teardown.test.sh (full file, the smallest unit that contains the two new remoteless cases)
ok - a remoteless local-only project merges through the approved path and tears down
ok - a remoteless local-only project still refuses to discard work not on its local default branch
EXIT=0
# total ok lines: 60
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"ffe44d6bc32c5f3443c74c4eda478d3b4d0549ba","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-spawn.sh:1751` - The remoteless branch resolves the &#34;local default branch&#34; through `default_branch`, which knows only origin/HEAD, main, or master. A local-only project with no remote whose default branch is anything else (`git init -b trunk`, or a global `init.defaultBranch`) still cannot be spawned into: default_branch returns 1 and the spawn aborts with &#34;could not determine the local default branch ... refusing to launch from a potentially stale base&#34;. Confirmed against a throwaway repo (no get-url, no origin/HEAD symref, no main/master ref). The same project WITH an origin resolves trunk fine (tests/fm-spawn-pool-base-freshen.test.sh:197), so the remoteless path is strictly weaker, and tests/fm-spawn-pool-base-freshen.test.sh:301 codifies the refusal as intended. Related: consulting refs/remotes/origin/HEAD inside a branch that just proved no origin exists is semantically wrong - a leftover symref (remote dropped by editing config rather than `git remote remove`) makes the NOTICE name a branch with possibly no local ref, and the spawn then dies on the less clear &#34;&#39;refs/heads/X&#39; is not a commit&#34; after already announcing the launch. The earliest shared boundary is `default_branch` in bin/fm-ff-lib.sh, which fm-merge-local.sh, fm-teardown.sh, and fm-review-diff.sh each re-implement identically, so fixing spawn alone would desync spawn from teardown/merge. Deciding between an in-scope shared fix and a PR-description note (per the &#34;note unrelated problems&#34; constraint) is yours.
- ℹ️ `bin/fm-spawn.sh:1755` - The NOTICE is printed while resolving the base ref, before the clean-worktree check and the reset. A remoteless spawn into a dirty pooled worktree therefore prints &#34;launching from its LOCAL default branch &#39;main&#39; ...&#34; and then refuses with &#34;pooled worktree ... is not clean&#34;, announcing a launch that never happens. The change already treats this as an invariant elsewhere - tests/fm-spawn-pool-base-freshen.test.sh:314 asserts the NOTICE must not appear when the unresolvable-default case refuses - so the dirty-pool and non-commit-ref refusals are the remaining gap. Emitting the NOTICE only after the reset verifies, or rewording it to state the skip rather than the launch, closes it while preserving the exactly-one-NOTICE decision.
- ℹ️ `tests/fm-spawn-pool-base-freshen.test.sh:89` - make_remoteless_case duplicates roughly twenty lines of make_case (home layout, crew-harness, brief, watcher beat, git init, initial commit, pool worktree) instead of parameterizing it. If make_case later gains another required home file - as it did for state/.last-watcher-beat and config/crew-harness - the remoteless fixture drifts and its spawns start passing or failing for reasons unrelated to the remote. The teardown test took the better route at tests/fm-teardown.test.sh:184 (build via make_case, then strip the remote); the same shape applies here via a flag that skips the origin clone/remote-add and calls advance_local_default instead of publishing.

🔧 Fix: reword remoteless skip notice and dedupe spawn fixture
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Independent E2E repro harness (self-written, not the repo suite) run against a copy of the repo with `git show d843712:bin/fm-spawn.sh` restored: `bash repro-remoteless-spawn.sh &lt;prefix-repo&gt; &#39;BEFORE FIX&#39;` - remoteless spawn fails with `error: could not fetch origin for pooled worktree ...`, no state/&lt;id&gt;.meta written</code>
- <code>Same harness against the target worktree: `bash repro-remoteless-spawn.sh $PWD &#39;AFTER FIX&#39;` - remoteless case exits 0, prints one `NOTICE: project ... has no origin remote configured - skipping the origin freshen ... LOCAL default branch &#39;main&#39; as the base authority`, resets the pooled worktree from its stale base onto the local main tip, writes 1 task meta; broken-origin case still exits 1 with `error: could not fetch origin for pooled worktree &#39;...&#39;; refusing to launch from a potentially stale base` and pool HEAD stays off the local tip</code>
- <code>`FM_TEST_EVIDENCE=1 bash tests/fm-spawn-pool-base-freshen.test.sh` (target commit) - 10 cases pass, including `test_remoteless_project_launches_from_local_default`, `test_remoteless_scout_launches_from_local_default`, `test_remoteless_project_without_a_local_default_refuses`, `test_remoteless_notice_survives_a_later_refusal`, and `test_unreachable_origin_refuses_stale_pool_base`</code>
- <code>`bash tests/fm-spawn-pool-base-freshen.test.sh` (target test file) executed against the PRE-FIX `bin/fm-spawn.sh` - all pre-existing guard cases still pass and it fails exactly at `not ok - spawn should launch into a project with no origin remote: expected exit 0, got 1`, exit 1</code>
- <code>`bash tests/fm-teardown.test.sh` - full file, exit 0, 60 ok lines, including `test_remoteless_local_only_merged_then_torn_down` and `test_remoteless_local_only_unpushed_still_refuses`</code>
- <code>Manual CLI transcript of the merge/teardown half: `bash transcript-remoteless-merge-teardown.sh` driving real `bin/fm-merge-local.sh task-x1` then `bin/fm-teardown.sh task-x1` on a remoteless fixture (merge lands on local main, teardown exit 0) and on an unmerged remoteless fixture (`REFUSED: local-only worktree ... not yet merged into main and not on any remote`, exit 1, work preserved)</code>
- `Normalized comparison of the unreachable-origin refusal line before vs after the fix - byte-identical wording`
- <code>`git status --porcelain` - worktree clean after testing</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

