### PR TITLE
fix: allow firstmate tasks to land into authoritative local main on forks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ Shared tracked material is `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.
 When any crewmate is live, delegate changes to shared tracked material rather than competing with supervision; when the fleet is empty, firstmate may change it directly.
 This repo is a shared template, while `.env`, `data/`, `state/`, `config/`, `projects/`, and `.no-mistakes/` are captain-private and gitignored.
 Ship shared tracked changes through this repo's no-mistakes pipeline and PR path, with the same merge authority as any other project.
+Firstmate repo tasks land into this home's local `main` via `bin/fm-merge-local.sh` once approved, while the outward-facing PR to upstream remains open.
 Never add an agent name as a commit co-author.
 
 ## 2. Layout and state
@@ -324,7 +325,7 @@ Complexity alone is not expansion: a difficult correction genuinely required by 
 Before deciding any ask-user finding, load `ask-user-authority`; the implementation worker never answers its own finding.
 Never merge a red PR.
 Without a current explicit captain instruction that states the concrete merge, that default stands, and standing `yolo` cannot authorize a red merge; section 1 owns when such an instruction overrides a Firstmate-written standing rule within its exact scope.
-Use `bin/fm-pr-merge.sh` for every task PR merge so merge metadata is recorded, and use `bin/fm-merge-local.sh` for approved local-only landing; never call a lower-level merge command around their guards.
+Use `bin/fm-pr-merge.sh` for every task PR merge on remote-authoritative projects so merge metadata is recorded, and use `bin/fm-merge-local.sh` for approved local-only landing and for Firstmate's own local-authoritative repository; never call a lower-level merge command around their guards.
 After an autonomous merge, give the captain a one-line full-URL or local-main outcome.
 
 ### Validate

--- a/bin/fm-fleet-sync.sh
+++ b/bin/fm-fleet-sync.sh
@@ -304,6 +304,13 @@ sync_project() {
     echo "$label: skipped: not a git repo"
     return 0
   fi
+  proj_real=$(cd "$PROJ" 2>/dev/null && pwd -P || printf '%s\n' "$PROJ")
+  root_real=$(cd "$FM_ROOT" 2>/dev/null && pwd -P || printf '%s\n' "$FM_ROOT")
+  home_real=$(cd "$FM_HOME" 2>/dev/null && pwd -P || printf '%s\n' "$FM_HOME")
+  if [ "$proj_real" = "$root_real" ] || [ "$proj_real" = "$home_real" ]; then
+    echo "$label: skipped: firstmate home (upstream sync is manual)"
+    return 0
+  fi
   mode_line=$("$FM_ROOT/bin/fm-project-mode.sh" "$label" 2>/dev/null || echo "no-mistakes off")
   mode=${mode_line%% *}
   if [ "$mode" = "local-only" ]; then

--- a/bin/fm-fleet-sync.sh
+++ b/bin/fm-fleet-sync.sh
@@ -11,8 +11,8 @@
 # is left untouched and reported as a quantified, loud "STUCK: ... N commits behind
 # ... - needs attention" warning rather than a quiet drift. Nothing is ever forced,
 # stashed, or discarded.
-# Still skips (benignly) local-only/no-origin projects, missing remotes/branches,
-# and fetch failures.
+# Still skips (benignly) local-only/no-origin projects, Firstmate's own home directory,
+# missing remotes/branches, and fetch failures.
 # Pruning never deletes the checked-out branch or a branch that still has a
 # worktree, so it cannot discard unlanded work; set FM_FLEET_PRUNE=0 to disable it.
 # When the fetch fails on an orphaned .git/packed-refs.lock (left by a ref rewrite

--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
-# Perform the approved local merge for a local-only ship task: fast-forward the
-# project's default branch to the crewmate's fm/<id> branch.
+# Perform the approved local merge for a local-only ship task or Firstmate's own
+# repository: fast-forward the project's default branch to the crewmate's fm/<id> branch.
 #
 # This is firstmate's merge gate-action (the captain's merge authority applied
 # locally instead of via a GitHub PR). It is the one sanctioned exception to hard
 # rule #1 "never run state-changing git in projects/", and it is narrow: it only
-# runs for mode=local-only tasks, only after the captain approves (or yolo=on
-# auto-approves), and only as a clean fast-forward - it refuses a diverged branch
-# and tells you to have the crewmate rebase. See AGENTS.md prime directives,
-# project management, and task lifecycle.
+# runs for mode=local-only tasks and for Firstmate's own repository in any mode,
+# only after the captain approves (or yolo=on auto-approves), and only as a clean
+# fast-forward - it refuses a diverged branch and tells you to have the crewmate
+# rebase. See AGENTS.md prime directives, project management, and task lifecycle.
 # Usage: fm-merge-local.sh <task-id>
 set -eu
 

--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -23,7 +23,27 @@ META="$STATE/$ID.meta"
 
 PROJ=$(grep '^project=' "$META" | cut -d= -f2-)
 MODE=$(grep '^mode=' "$META" | cut -d= -f2- || true)
-[ "$MODE" = local-only ] || { echo "error: task $ID is mode=$MODE, not local-only; merge PR tasks with bin/fm-pr-merge.sh <id> <PR url> after approval" >&2; exit 1; }
+
+canonical_dir() {
+  local target=$1
+  ( cd "$target" 2>/dev/null && pwd -P ) || printf '%s\n' "$target"
+}
+
+is_firstmate_repo() {
+  local proj_real root_real home_real
+  proj_real=$(canonical_dir "$PROJ")
+  root_real=$(canonical_dir "$FM_ROOT")
+  home_real=$(canonical_dir "$FM_HOME")
+  [ "$proj_real" = "$root_real" ] || [ "$proj_real" = "$home_real" ]
+}
+
+if [ "$MODE" != "local-only" ] && ! is_firstmate_repo; then
+  echo "error: task $ID is mode=$MODE on $PROJ, not local-only; merge PR tasks with bin/fm-pr-merge.sh <id> <PR url> after approval" >&2
+  exit 1
+fi
+
+[ -n "$PROJ" ] && [ -d "$PROJ" ] || { echo "error: project directory '$PROJ' does not exist" >&2; exit 1; }
+git -C "$PROJ" rev-parse --is-inside-work-tree >/dev/null 2>&1 || { echo "error: '$PROJ' is not a git repository" >&2; exit 1; }
 
 default_branch() {
   local ref branch

--- a/bin/fm-pr-merge.sh
+++ b/bin/fm-pr-merge.sh
@@ -82,3 +82,13 @@ if ! caller_has_merge_method "$@"; then
 fi
 
 gh-axi pr merge "$PR_NUMBER" --repo "$PR_OWNER/$PR_REPO" "${merge_args[@]+"${merge_args[@]}"}" "$@"
+
+PROJ=$(grep '^project=' "$META" | cut -d= -f2- || true)
+if [ -n "$PROJ" ] && [ -d "$PROJ" ]; then
+  proj_real=$(cd "$PROJ" 2>/dev/null && pwd -P || printf '%s\n' "$PROJ")
+  root_real=$(cd "$FM_ROOT" 2>/dev/null && pwd -P || printf '%s\n' "$FM_ROOT")
+  home_real=$(cd "$FM_HOME" 2>/dev/null && pwd -P || printf '%s\n' "$FM_HOME")
+  if [ "$proj_real" = "$root_real" ] || [ "$proj_real" = "$home_real" ]; then
+    "$SCRIPT_DIR/fm-merge-local.sh" "$ID"
+  fi
+fi

--- a/bin/fm-pr-merge.sh
+++ b/bin/fm-pr-merge.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Merge a task's PR after recording pr= and any available pr_head= through
 # bin/fm-pr-check.sh, so teardown can verify landed work after squash merges.
+# For Firstmate's own repository, also fast-forwards local main via fm-merge-local.sh.
 # The full canonical GitHub PR URL is parsed by bin/fm-pr-lib.sh and the derived
 # owner/repository and PR number are passed to gh-axi as separate arguments.
 #

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -22,9 +22,9 @@
 # A gh lookup error falls back to the content check; if that is also inconclusive,
 # teardown refuses rather than risk discarding unlanded work.
 # Uncommitted changes are never landed.
-# local-only projects additionally accept work merged into the local default
-# branch (firstmate performs that merge after configured approval) as a fallback
-# for the common case where there is no remote at all.
+# Work merged into the local default branch (such as local-only projects or
+# Firstmate's own local repository after approved fast-forward) is additionally
+# accepted as landed.
 # Scout tasks (kind=scout in meta) carve out of that check: their worktree is
 # declared scratch and the report at data/<task-id>/report.md is the work
 # product. Teardown proceeds only once the report exists and the shared

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -881,6 +881,20 @@ content_in_default() {
   [ "$merged_tree" = "$default_tree" ]
 }
 
+content_in_local_default() {
+  local name default_tree merged_tree
+  name=$(default_branch) || return 1
+  git -C "$WT" rev-parse --quiet --verify "refs/heads/$name" >/dev/null 2>&1 || return 1
+  if git -C "$WT" merge-base --is-ancestor HEAD "refs/heads/$name" 2>/dev/null; then
+    return 0
+  fi
+  default_tree=$(git -C "$WT" rev-parse --quiet --verify "refs/heads/$name^{tree}" 2>/dev/null) || return 1
+  [ -n "$default_tree" ] || return 1
+  merged_tree=$(git -C "$WT" merge-tree --write-tree "refs/heads/$name" HEAD 2>/dev/null) || return 1
+  merged_tree=$(printf '%s\n' "$merged_tree" | head -1)
+  [ "$merged_tree" = "$default_tree" ]
+}
+
 # Has the worktree's committed work actually LANDED, though its commits are not
 # reachable from any remote-tracking branch? True when a merged PR proves the
 # current local work is contained in the PR head, OR the content is already in the
@@ -889,7 +903,8 @@ content_in_default() {
 work_is_landed() {
   local branch=$1
   pr_is_merged "$branch" && return 0
-  content_in_default
+  content_in_default && return 0
+  content_in_local_default
 }
 
 backlog_refresh_reminder() {

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -204,7 +204,7 @@ family_for_basename() {
     fm-teardown-endpoint-safety.test.sh)
       printf '%s\n' backend-dispatch
       ;;
-    fm-pr-check-security.test.sh|fm-pr-merge.test.sh|fm-review-diff.test.sh|\
+    fm-pr-check-security.test.sh|fm-pr-merge.test.sh|fm-merge-local.test.sh|fm-review-diff.test.sh|\
     fm-teardown.test.sh|fm-x-mode.test.sh)
       printf '%s\n' pr-forge
       ;;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -247,6 +247,7 @@ When a selected delivery path calls for a diff, `bin/fm-review-diff.sh` refreshe
 Where a no-mistakes pipeline stores evidence in the repo, it publishes that PR-viewable validation evidence to an orphan evidence branch that shares no history with code branches, so it never enters the crew branch or the default branch.
 This repo uses that setting, and its own `.no-mistakes/` directory remains local state that stays gitignored and is rejected by CI if tracked; [`configuration.md`](configuration.md) owns the setting.
 PR-based task merges go through `bin/fm-pr-merge.sh`, which records `pr=` and any available `pr_head=` through `bin/fm-pr-check.sh` before calling `gh-axi pr merge`.
+`local-only` tasks and Firstmate's own repository tasks land into the local default branch through `bin/fm-merge-local.sh`.
 The helper requires a full `https://github.com/<owner>/<repo>/pull/<n>` URL, invokes `gh-axi pr merge <n> --repo <owner>/<repo>`, defaults to `--squash`, preserves explicit merge-method flags, and rejects malformed URLs or repo override flags before recording merge state; a well-formed GitLab merge request URL (see [docs/gitlab-merge-watch.md](gitlab-merge-watch.md)) is refused too, explicitly, rather than sent to the wrong forge.
 Teardown is fail-closed for ship worktrees: dirty worktrees refuse, and committed work must be landed before the worktree is returned.
 [`bin/fm-teardown.sh`](../bin/fm-teardown.sh)'s header owns the landed-work proofs, PR-discovery fallback, and stale-lock recovery procedure.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -341,6 +341,10 @@
       "audience": "maintainer-verification"
     },
     {
+      "path": "docs/verification/fork-reconciliation.md",
+      "audience": "maintainer-verification"
+    },
+    {
       "path": "docs/verification/muse.md",
       "audience": "maintainer-verification"
     },

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -60,7 +60,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `backends/cmux.sh`       | Experimental cmux session-provider adapter                                           |
 | `fm-config-push.sh`      | Push declared inherited local material to live local or remote secondmates and send the placement-specific config reread when changed |
 | `fm-project-mode.sh`     | Resolve a project's registered delivery posture from `data/projects.md` for fleet sync and home seeding |
-| `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval            |
+| `fm-merge-local.sh`      | Fast-forward a `local-only` project or Firstmate's own repository local default branch after approval |
 | `fm-review-diff.sh`      | Review a crewmate branch or resolved PR head against the authoritative base          |
 | `fm-marker-lib.sh`       | Compatibility entry point for the from-firstmate carrier owned by `fm-operational-input.sh` |
 | `fm-pending-reply-lib.sh` | Parent-owned secondmate pending-reply expectations, recovery, and keyed escalation lifecycle |

--- a/docs/verification/fork-reconciliation.md
+++ b/docs/verification/fork-reconciliation.md
@@ -1,0 +1,78 @@
+# Fork Reconciliation Plan and Delivery Analysis
+
+This document records the empirical evidence and reconciliation plan for Firstmate's fork repository and delivery path.
+
+## Background and remotes
+
+This Firstmate home operates as a fork where local `main` is authoritative for the fleet.
+The repository has three remotes:
+
+- `origin` (`github.com/kunchenguid/firstmate`): upstream repository.
+- `fork` (`github.com/BohnBawerick/firstmate`): the captain's fork repository.
+- `no-mistakes` (`/home/paiva/.no-mistakes/repos/3437026af8a8.git`): local bare gate repository.
+
+## Evidence measured on 2026-08-19
+
+The commit state measured across remotes and local heads:
+
+- `local main` = `7e09a25`
+- `fork/main` = `2114a72`
+- `origin/main` = `d843712`
+- `git log fork/main..main` = 72 commits
+- `git log main..fork/main` = 1 commit (`2114a72`)
+
+Commit `2114a72` is titled `fix(bin): distinguish unreadable away-mode panes from gone ones (#1)`.
+It merged PR #1 on `BohnBawerick/firstmate` with `--squash`.
+The PR branch was `fm/fm-stale-unreadable-vs-gone` (commit `0a5674532515ed848b5b37b2d8ff30975b157758`).
+Because `fork/main` was stale at commit `96876db`, GitHub squashed all 72 missing commits plus the task fix into commit `2114a72`.
+Local `main` never received the fix.
+
+## Content verification of commit 2114a72
+
+We evaluated whether the fix in `2114a72` is present in local `main`.
+
+### 1. Patch ID comparison
+
+The patch ID of the underlying task commit `0a56745` was computed using `git patch-id --stable`:
+
+```
+8c93cd1f61da926d3e72ef10865ff274184d127c 0a5674532515ed848b5b37b2d8ff30975b157758
+```
+
+Searching `git log -p main | git patch-id --stable` for this patch ID produces zero matches.
+
+### 2. Range diff comparison
+
+Running `git range-diff 0a56745~1..0a56745 main~15..main` shows commit `0a56745` has no equivalent commit on `main`.
+
+### 3. Direct file comparison
+
+The 5 files modified by `0a56745` were inspected directly against `local main`:
+
+- `.agents/skills/afk/SKILL.md`: missing the specification that unreadable endpoints are surfaced rather than dropped during away mode.
+- `bin/fm-supervise-daemon.sh`: missing `stale_window_recheck`, capture retries, and the gone versus unreadable pane classification.
+- `docs/architecture.md`: missing the gone versus unreadable pane architecture note.
+- `docs/configuration.md`: missing `FM_STALE_CAPTURE_RETRIES` and `FM_STALE_CAPTURE_RETRY_SLEEP` documentation.
+- `tests/fm-daemon.test.sh`: missing the test cases covering gone, unreadable-present, retry-then-ordinary, and dead-is-not-gone behaviors.
+
+### Verdict
+
+The fix in `2114a72` is completely missing in `local main`.
+
+## Minimum safe path to bring the fix into local main
+
+1. A worker creates a branch from current `local main`.
+2. Cherry-pick commit `0a56745` from branch `fm/fm-stale-unreadable-vs-gone`.
+3. Resolve minor conflicts in `bin/fm-supervise-daemon.sh` and `docs/configuration.md` from intervening commits (`e85be9e`, `416c0d3`).
+4. Run `tests/fm-daemon.test.sh` to confirm all tests pass.
+5. Fast-forward merge the branch into `local main` using `bin/fm-merge-local.sh`.
+
+## Plan for fork/main
+
+To ensure future PRs have a truthful base:
+
+1. `fork/main` should be reset to match `local main` exactly.
+2. What is preserved: all 72 local commits, the full history, and the exact tree running in the fleet.
+3. What is lost: the single squash commit `2114a72` on `fork/main` (the underlying commit `0a56745` is preserved in local branch `fm/fm-stale-unreadable-vs-gone` and upstream PR 2587).
+4. Force push requirement: YES. Because `fork/main` and `local main` have diverged histories, aligning `fork/main` to `local main` requires `git push --force-with-lease fork main:main`. This is a deliberate operational decision for Firstmate.
+5. Consequence: future PRs opened against `fork/main` will have a truthful base, CI will test against the exact fleet codebase, and PR diffs will only show the task's changes.

--- a/tests/fm-fleet-sync.test.sh
+++ b/tests/fm-fleet-sync.test.sh
@@ -370,6 +370,17 @@ test_local_only_skipped() {
   pass "local-only clone is skipped (benign), not flagged STUCK"
 }
 
+test_firstmate_home_skipped() {
+  local home out
+  home=$(new_home)
+  git init -q "$home"
+  out=$(run_sync "$home" "$home")
+
+  assert_contains "$out" "skipped: firstmate home (upstream sync is manual)" "firstmate home is skipped"
+  assert_not_contains "$out" "STUCK" "firstmate home skip is not escalated to STUCK"
+  pass "firstmate home is skipped (manual sync), not flagged STUCK"
+}
+
 test_single_project_by_bare_name_resolves() {
   local home out
   home=$(new_home)
@@ -613,6 +624,7 @@ test_on_default_clean_behind_fast_forwards
 test_already_current_unchanged
 test_no_origin_skipped
 test_local_only_skipped
+test_firstmate_home_skipped
 test_single_project_by_bare_name_resolves
 test_single_project_by_bare_name_ignores_cwd_shadow
 test_single_project_by_projects_relative_name_resolves

--- a/tests/fm-merge-local.test.sh
+++ b/tests/fm-merge-local.test.sh
@@ -1,0 +1,411 @@
+#!/usr/bin/env bash
+# Tests for bin/fm-merge-local.sh: fast-forwards the local default branch to the
+# crewmate's fm/<id> branch for local-only projects and for Firstmate's own
+# repository (where local main is authoritative).
+#
+# Matrix:
+#   (a) fast-forwards a clean local-only project branch
+#   (b) fast-forwards a no-mistakes task on Firstmate's own repository (FM_ROOT)
+#   (c) fast-forwards a direct-PR task on Firstmate's own repository (FM_ROOT)
+#   (d) refuses a no-mistakes task on an ordinary project (not local-only)
+#   (e) refuses a direct-PR task on an ordinary project (not local-only)
+#   (f) refuses when task meta is missing
+#   (g) refuses when project directory does not exist or is not a git repo
+#   (h) refuses when branch fm/<id> does not exist
+#   (i) refuses when project checkout is not on its default branch
+#   (j) refuses when project checkout is dirty
+#   (k) refuses when branch has diverged (not a fast-forward)
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+fm_git_identity fmtest fmtest@example.invalid
+
+MERGE_LOCAL="$ROOT/bin/fm-merge-local.sh"
+TMP_ROOT=$(fm_test_tmproot fm-merge-local-tests)
+
+make_repo() {
+  local dir=$1 default=${2:-main}
+  mkdir -p "$dir"
+  git -C "$dir" init --quiet --initial-branch="$default"
+  echo "initial" > "$dir/file.txt"
+  git -C "$dir" add file.txt
+  git -C "$dir" commit --quiet -m "initial commit"
+}
+
+test_fast_forward_local_only_project() {
+  local case_dir proj_dir state_dir rc before after
+  case_dir="$TMP_ROOT/local-only-clean"
+  proj_dir="$case_dir/projects/myproj"
+  state_dir="$case_dir/state"
+  mkdir -p "$state_dir"
+  make_repo "$proj_dir" main
+
+  git -C "$proj_dir" checkout -b fm/task-loc1 --quiet
+  echo "feature" >> "$proj_dir/file.txt"
+  git -C "$proj_dir" commit --quiet -am "feature commit"
+  git -C "$proj_dir" checkout main --quiet
+
+  fm_write_meta "$state_dir/task-loc1.meta" \
+    "window=fm-task-loc1" \
+    "worktree=$case_dir/wt" \
+    "project=$proj_dir" \
+    "kind=ship" \
+    "mode=local-only"
+
+  before=$(git -C "$proj_dir" rev-parse HEAD)
+
+  set +e
+  FM_ROOT_OVERRIDE="$case_dir/fmroot" \
+  FM_HOME="$case_dir/fmroot" \
+  FM_STATE_OVERRIDE="$state_dir" \
+    "$MERGE_LOCAL" task-loc1 > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "local-only: fm-merge-local should succeed"
+  after=$(git -C "$proj_dir" rev-parse HEAD)
+  [ "$before" != "$after" ] || fail "local-only: default branch was not advanced"
+  assert_grep "merged fm/task-loc1 into local main" "$case_dir/stdout" \
+    "local-only: success message was not printed"
+  pass "fm-merge-local fast-forwards a clean local-only project branch"
+}
+
+test_fast_forward_no_mistakes_firstmate_repo() {
+  local case_dir fm_root state_dir rc before after
+  case_dir="$TMP_ROOT/fm-no-mistakes"
+  fm_root="$case_dir/firstmate"
+  state_dir="$case_dir/state"
+  mkdir -p "$state_dir"
+  make_repo "$fm_root" main
+
+  git -C "$fm_root" checkout -b fm/task-fm1 --quiet
+  echo "firstmate feature" >> "$fm_root/file.txt"
+  git -C "$fm_root" commit --quiet -am "firstmate fix"
+  git -C "$fm_root" checkout main --quiet
+
+  fm_write_meta "$state_dir/task-fm1.meta" \
+    "window=fm-task-fm1" \
+    "worktree=$case_dir/wt" \
+    "project=$fm_root" \
+    "kind=ship" \
+    "mode=no-mistakes"
+
+  before=$(git -C "$fm_root" rev-parse HEAD)
+
+  set +e
+  FM_ROOT_OVERRIDE="$fm_root" \
+  FM_HOME="$fm_root" \
+  FM_STATE_OVERRIDE="$state_dir" \
+    "$MERGE_LOCAL" task-fm1 > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "firstmate no-mistakes: fm-merge-local should succeed"
+  after=$(git -C "$fm_root" rev-parse HEAD)
+  [ "$before" != "$after" ] || fail "firstmate no-mistakes: default branch was not advanced"
+  assert_grep "merged fm/task-fm1 into local main" "$case_dir/stdout" \
+    "firstmate no-mistakes: success message was not printed"
+  pass "fm-merge-local fast-forwards a no-mistakes task on Firstmate's own repository"
+}
+
+test_fast_forward_direct_pr_firstmate_repo() {
+  local case_dir fm_root state_dir rc before after
+  case_dir="$TMP_ROOT/fm-direct-pr"
+  fm_root="$case_dir/firstmate"
+  state_dir="$case_dir/state"
+  mkdir -p "$state_dir"
+  make_repo "$fm_root" main
+
+  git -C "$fm_root" checkout -b fm/task-fm2 --quiet
+  echo "direct PR fix" >> "$fm_root/file.txt"
+  git -C "$fm_root" commit --quiet -am "direct pr fix"
+  git -C "$fm_root" checkout main --quiet
+
+  fm_write_meta "$state_dir/task-fm2.meta" \
+    "window=fm-task-fm2" \
+    "worktree=$case_dir/wt" \
+    "project=$fm_root" \
+    "kind=ship" \
+    "mode=direct-PR"
+
+  before=$(git -C "$fm_root" rev-parse HEAD)
+
+  set +e
+  FM_ROOT_OVERRIDE="$fm_root" \
+  FM_HOME="$fm_root" \
+  FM_STATE_OVERRIDE="$state_dir" \
+    "$MERGE_LOCAL" task-fm2 > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "firstmate direct-PR: fm-merge-local should succeed"
+  after=$(git -C "$fm_root" rev-parse HEAD)
+  [ "$before" != "$after" ] || fail "firstmate direct-PR: default branch was not advanced"
+  assert_grep "merged fm/task-fm2 into local main" "$case_dir/stdout" \
+    "firstmate direct-PR: success message was not printed"
+  pass "fm-merge-local fast-forwards a direct-PR task on Firstmate's own repository"
+}
+
+test_refuses_no_mistakes_ordinary_project() {
+  local case_dir proj_dir state_dir rc
+  case_dir="$TMP_ROOT/ordinary-no-mistakes"
+  proj_dir="$case_dir/projects/otherproj"
+  state_dir="$case_dir/state"
+  mkdir -p "$state_dir"
+  make_repo "$proj_dir" main
+
+  git -C "$proj_dir" checkout -b fm/task-ord1 --quiet
+  echo "change" >> "$proj_dir/file.txt"
+  git -C "$proj_dir" commit --quiet -am "change"
+  git -C "$proj_dir" checkout main --quiet
+
+  fm_write_meta "$state_dir/task-ord1.meta" \
+    "window=fm-task-ord1" \
+    "worktree=$case_dir/wt" \
+    "project=$proj_dir" \
+    "kind=ship" \
+    "mode=no-mistakes"
+
+  set +e
+  FM_ROOT_OVERRIDE="$case_dir/fmroot" \
+  FM_HOME="$case_dir/fmroot" \
+  FM_STATE_OVERRIDE="$state_dir" \
+    "$MERGE_LOCAL" task-ord1 > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "ordinary no-mistakes: fm-merge-local should refuse"
+  assert_grep "is mode=no-mistakes on $proj_dir, not local-only; merge PR tasks with bin/fm-pr-merge.sh" "$case_dir/stderr" \
+    "ordinary no-mistakes: refusal did not explain mode"
+  pass "fm-merge-local refuses a no-mistakes task on an ordinary project"
+}
+
+test_refuses_direct_pr_ordinary_project() {
+  local case_dir proj_dir state_dir rc
+  case_dir="$TMP_ROOT/ordinary-direct-pr"
+  proj_dir="$case_dir/projects/otherproj2"
+  state_dir="$case_dir/state"
+  mkdir -p "$state_dir"
+  make_repo "$proj_dir" main
+
+  git -C "$proj_dir" checkout -b fm/task-ord2 --quiet
+  echo "change" >> "$proj_dir/file.txt"
+  git -C "$proj_dir" commit --quiet -am "change"
+  git -C "$proj_dir" checkout main --quiet
+
+  fm_write_meta "$state_dir/task-ord2.meta" \
+    "window=fm-task-ord2" \
+    "worktree=$case_dir/wt" \
+    "project=$proj_dir" \
+    "kind=ship" \
+    "mode=direct-PR"
+
+  set +e
+  FM_ROOT_OVERRIDE="$case_dir/fmroot" \
+  FM_HOME="$case_dir/fmroot" \
+  FM_STATE_OVERRIDE="$state_dir" \
+    "$MERGE_LOCAL" task-ord2 > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "ordinary direct-PR: fm-merge-local should refuse"
+  assert_grep "is mode=direct-PR on $proj_dir, not local-only; merge PR tasks with bin/fm-pr-merge.sh" "$case_dir/stderr" \
+    "ordinary direct-PR: refusal did not explain mode"
+  pass "fm-merge-local refuses a direct-PR task on an ordinary project"
+}
+
+test_refuses_missing_meta() {
+  local case_dir state_dir rc
+  case_dir="$TMP_ROOT/missing-meta"
+  state_dir="$case_dir/state"
+  mkdir -p "$state_dir"
+
+  set +e
+  FM_ROOT_OVERRIDE="$case_dir/fmroot" \
+  FM_HOME="$case_dir/fmroot" \
+  FM_STATE_OVERRIDE="$state_dir" \
+    "$MERGE_LOCAL" missing-task > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "missing-meta: fm-merge-local should refuse"
+  assert_grep "error: no meta for task missing-task" "$case_dir/stderr" \
+    "missing-meta: refusal did not explain missing meta"
+  pass "fm-merge-local refuses when task meta is missing"
+}
+
+test_refuses_missing_project() {
+  local case_dir state_dir rc
+  case_dir="$TMP_ROOT/missing-proj"
+  state_dir="$case_dir/state"
+  mkdir -p "$state_dir"
+
+  fm_write_meta "$state_dir/task-missproj.meta" \
+    "window=fm-task-missproj" \
+    "worktree=$case_dir/wt" \
+    "project=$case_dir/nonexistent" \
+    "kind=ship" \
+    "mode=local-only"
+
+  set +e
+  FM_ROOT_OVERRIDE="$case_dir/fmroot" \
+  FM_HOME="$case_dir/fmroot" \
+  FM_STATE_OVERRIDE="$state_dir" \
+    "$MERGE_LOCAL" task-missproj > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "missing-proj: fm-merge-local should refuse"
+  assert_grep "project directory '$case_dir/nonexistent' does not exist" "$case_dir/stderr" \
+    "missing-proj: refusal did not explain missing project"
+  pass "fm-merge-local refuses when project directory does not exist"
+}
+
+test_refuses_missing_branch() {
+  local case_dir proj_dir state_dir rc
+  case_dir="$TMP_ROOT/missing-branch"
+  proj_dir="$case_dir/projects/myproj"
+  state_dir="$case_dir/state"
+  mkdir -p "$state_dir"
+  make_repo "$proj_dir" main
+
+  fm_write_meta "$state_dir/task-nobranch.meta" \
+    "window=fm-task-nobranch" \
+    "worktree=$case_dir/wt" \
+    "project=$proj_dir" \
+    "kind=ship" \
+    "mode=local-only"
+
+  set +e
+  FM_ROOT_OVERRIDE="$case_dir/fmroot" \
+  FM_HOME="$case_dir/fmroot" \
+  FM_STATE_OVERRIDE="$state_dir" \
+    "$MERGE_LOCAL" task-nobranch > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "missing-branch: fm-merge-local should refuse"
+  assert_grep "branch fm/task-nobranch does not exist in $proj_dir" "$case_dir/stderr" \
+    "missing-branch: refusal did not explain missing branch"
+  pass "fm-merge-local refuses when branch fm/<id> does not exist"
+}
+
+test_refuses_dirty_project() {
+  local case_dir proj_dir state_dir rc
+  case_dir="$TMP_ROOT/dirty-proj"
+  proj_dir="$case_dir/projects/myproj"
+  state_dir="$case_dir/state"
+  mkdir -p "$state_dir"
+  make_repo "$proj_dir" main
+
+  git -C "$proj_dir" checkout -b fm/task-dirty --quiet
+  echo "change" >> "$proj_dir/file.txt"
+  git -C "$proj_dir" commit --quiet -am "change"
+  git -C "$proj_dir" checkout main --quiet
+  echo "uncommitted edit" >> "$proj_dir/file.txt"
+
+  fm_write_meta "$state_dir/task-dirty.meta" \
+    "window=fm-task-dirty" \
+    "worktree=$case_dir/wt" \
+    "project=$proj_dir" \
+    "kind=ship" \
+    "mode=local-only"
+
+  set +e
+  FM_ROOT_OVERRIDE="$case_dir/fmroot" \
+  FM_HOME="$case_dir/fmroot" \
+  FM_STATE_OVERRIDE="$state_dir" \
+    "$MERGE_LOCAL" task-dirty > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "dirty-proj: fm-merge-local should refuse"
+  assert_grep "has a dirty working tree; refusing to merge into it" "$case_dir/stderr" \
+    "dirty-proj: refusal did not explain dirty working tree"
+  pass "fm-merge-local refuses when project checkout is dirty"
+}
+
+test_refuses_off_default_project() {
+  local case_dir proj_dir state_dir rc
+  case_dir="$TMP_ROOT/off-default-proj"
+  proj_dir="$case_dir/projects/myproj"
+  state_dir="$case_dir/state"
+  mkdir -p "$state_dir"
+  make_repo "$proj_dir" main
+
+  git -C "$proj_dir" checkout -b other-branch --quiet
+  git -C "$proj_dir" checkout -b fm/task-offdef --quiet
+  echo "change" >> "$proj_dir/file.txt"
+  git -C "$proj_dir" commit --quiet -am "change"
+  git -C "$proj_dir" checkout other-branch --quiet
+
+  fm_write_meta "$state_dir/task-offdef.meta" \
+    "window=fm-task-offdef" \
+    "worktree=$case_dir/wt" \
+    "project=$proj_dir" \
+    "kind=ship" \
+    "mode=local-only"
+
+  set +e
+  FM_ROOT_OVERRIDE="$case_dir/fmroot" \
+  FM_HOME="$case_dir/fmroot" \
+  FM_STATE_OVERRIDE="$state_dir" \
+    "$MERGE_LOCAL" task-offdef > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "off-default: fm-merge-local should refuse"
+  assert_grep "expected default branch 'main'; cannot merge safely" "$case_dir/stderr" \
+    "off-default: refusal did not explain non-default branch"
+  pass "fm-merge-local refuses when project checkout is not on its default branch"
+}
+
+test_refuses_diverged_branch() {
+  local case_dir proj_dir state_dir rc
+  case_dir="$TMP_ROOT/diverged-branch"
+  proj_dir="$case_dir/projects/myproj"
+  state_dir="$case_dir/state"
+  mkdir -p "$state_dir"
+  make_repo "$proj_dir" main
+
+  git -C "$proj_dir" checkout -b fm/task-div --quiet
+  echo "task change" >> "$proj_dir/file.txt"
+  git -C "$proj_dir" commit --quiet -am "task change"
+  git -C "$proj_dir" checkout main --quiet
+  echo "competing change" >> "$proj_dir/other.txt"
+  git -C "$proj_dir" add other.txt
+  git -C "$proj_dir" commit --quiet -m "competing change on main"
+
+  fm_write_meta "$state_dir/task-div.meta" \
+    "window=fm-task-div" \
+    "worktree=$case_dir/wt" \
+    "project=$proj_dir" \
+    "kind=ship" \
+    "mode=local-only"
+
+  set +e
+  FM_ROOT_OVERRIDE="$case_dir/fmroot" \
+  FM_HOME="$case_dir/fmroot" \
+  FM_STATE_OVERRIDE="$state_dir" \
+    "$MERGE_LOCAL" task-div > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "diverged-branch: fm-merge-local should refuse"
+  assert_grep "REFUSED: fm/task-div is not a fast-forward of main (it has diverged)" "$case_dir/stderr" \
+    "diverged-branch: refusal did not explain divergence"
+  pass "fm-merge-local refuses when branch has diverged (not a fast-forward)"
+}
+
+test_fast_forward_local_only_project
+test_fast_forward_no_mistakes_firstmate_repo
+test_fast_forward_direct_pr_firstmate_repo
+test_refuses_no_mistakes_ordinary_project
+test_refuses_direct_pr_ordinary_project
+test_refuses_missing_meta
+test_refuses_missing_project
+test_refuses_missing_branch
+test_refuses_dirty_project
+test_refuses_off_default_project
+test_refuses_diverged_branch

--- a/tests/fm-pr-merge.test.sh
+++ b/tests/fm-pr-merge.test.sh
@@ -301,6 +301,51 @@ test_parses_pr_url_for_gh_axi() {
   pass "fm-pr-merge parses a GitHub PR URL into gh-axi number and --repo arguments"
 }
 
+test_merges_firstmate_repo_locally() {
+  local case_dir fm_root state_dir rc before after
+  case_dir="$TMP_ROOT/fm-pr-merge-local"
+  fm_root="$case_dir/firstmate"
+  state_dir="$case_dir/state"
+  mkdir -p "$state_dir" "$case_dir/fakebin"
+  git init --quiet --initial-branch=main "$fm_root"
+  echo "init" > "$fm_root/file.txt"
+  git -C "$fm_root" add file.txt
+  git -C "$fm_root" commit --quiet -m "init"
+  git -C "$fm_root" checkout -b fm/task-fmpr --quiet
+  echo "pr fix" >> "$fm_root/file.txt"
+  git -C "$fm_root" commit --quiet -am "pr fix"
+  git -C "$fm_root" checkout main --quiet
+
+  fm_write_meta "$state_dir/task-fmpr.meta" \
+    "window=fm-task-fmpr" \
+    "worktree=$case_dir/wt" \
+    "project=$fm_root" \
+    "kind=ship" \
+    "mode=no-mistakes"
+
+  add_gh_mocks "$case_dir" aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  : > "$case_dir/gh-axi.log"
+  before=$(git -C "$fm_root" rev-parse HEAD)
+
+  set +e
+  FM_ROOT_OVERRIDE="$fm_root" \
+  FM_HOME="$fm_root" \
+  FM_STATE_OVERRIDE="$state_dir" \
+  FM_TEST_GH_AXI_LOG="$case_dir/gh-axi.log" \
+  PATH="$case_dir/fakebin:$PATH" \
+    "$PR_MERGE" task-fmpr https://github.com/example/firstmate/pull/42 \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "fm-pr-merge-local: fm-pr-merge should succeed"
+  after=$(git -C "$fm_root" rev-parse HEAD)
+  [ "$before" != "$after" ] || fail "fm-pr-merge-local: local main was not advanced after remote merge"
+  assert_grep "merged fm/task-fmpr into local main" "$case_dir/stdout" \
+    "fm-pr-merge-local: local fast-forward output was not printed"
+  pass "fm-pr-merge fast-forwards local main when project is Firstmate's own repository"
+}
+
 test_records_pr_and_head_before_merging
 test_merge_failure_propagates_after_recording
 test_extra_merge_args_forwarded
@@ -311,3 +356,4 @@ test_repo_override_args_refuse_before_recording
 test_explicit_merge_method_not_overridden
 test_method_equals_merge_method_not_overridden
 test_parses_pr_url_for_gh_axi
+test_merges_firstmate_repo_locally

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -692,6 +692,25 @@ test_no_mistakes_truly_unpushed_refuses() {
   pass "no-mistakes worktree with genuinely unlanded work is refused (safety preserved)"
 }
 
+test_no_mistakes_merged_into_local_main_allows() {
+  local case_dir rc wt_head
+  case_dir=$(make_case nm-merged-local-main)
+  write_meta "$case_dir" no-mistakes ship
+  wt_commit_file "$case_dir" feature.txt hello "firstmate local fix"
+  wt_head=$(git -C "$case_dir/wt" rev-parse HEAD)
+  # Advance local main (as fm-merge-local.sh does), leaving origin/main untouched
+  git -C "$case_dir/project" update-ref refs/heads/main "$wt_head"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "nm-merged-local-main: teardown should succeed when work is in local main"
+  ! grep -q REFUSED "$case_dir/stderr" || fail "nm-merged-local-main: teardown printed a REFUSED line"
+  pass "no-mistakes worktree with work merged into local main is torn down"
+}
+
 test_squash_merged_branch_deleted_allows() {
   local case_dir rc pr_head
   case_dir=$(make_case squash-merged)
@@ -2597,6 +2616,7 @@ test_teardown_manual_backend_prompts_hand_edit_even_when_tasks_axi_present
 test_local_only_truly_unpushed_refuses
 test_local_only_merged_to_local_main_allows
 test_no_mistakes_origin_remote_allows
+test_no_mistakes_merged_into_local_main_allows
 test_no_mistakes_truly_unpushed_refuses
 test_local_only_force_overrides_unpushed
 test_teardown_missing_busy_sidecar_completes


### PR DESCRIPTION
## Intent

Fix Firstmate's delivery path on a fork repository so firstmate tasks land into authoritative local main via bin/fm-merge-local.sh and bin/fm-pr-merge.sh, teach bin/fm-fleet-sync.sh to skip firstmate home gracefully, teach bin/fm-teardown.sh to recognize work landed in the local default branch, provide fork reconciliation plan and empirical evidence in docs/verification/fork-reconciliation.md, and add test coverage.

## What Changed
- Updated `bin/fm-merge-local.sh` and `bin/fm-pr-merge.sh` to allow approved Firstmate repository tasks to fast-forward into the authoritative local `main` branch.
- Updated `bin/fm-fleet-sync.sh` to gracefully skip Firstmate's home directory during sync and updated `bin/fm-teardown.sh` to recognize work landed in the local default branch.
- Added regression test suites across `tests/fm-merge-local.test.sh`, `tests/fm-pr-merge.test.sh`, `tests/fm-fleet-sync.test.sh`, and `tests/fm-teardown.test.sh`, alongside fork reconciliation documentation in `docs/verification/fork-reconciliation.md`.

## Risk Assessment

✅ Low: The changes cleanly implement local landing for Firstmate tasks on fork repositories, skip Firstmate home in fleet sync, allow teardown for local default branch merges, and provide thorough documentation and behavioral test coverage.

## Testing

Validated the fork delivery fix across 5 targeted test suites (50+ individual test assertions) and an end-to-end multi-scenario CLI verification transcript proving: (1) Firstmate tasks land into local authoritative main via fm-merge-local.sh even when mode=no-mistakes, (2) fm-pr-merge.sh triggers local fast-forward for Firstmate repo tasks after remote PR merge, (3) fm-fleet-sync.sh skips Firstmate home gracefully without STUCK escalation, (4) fm-teardown.sh recognizes content landed in the local default branch and allows clean teardown, (5) non-Firstmate mode=no-mistakes tasks remain guarded and refused, and (6) fork reconciliation documentation is properly classified in docs/documentation-audiences.json. All automated tests and end-to-end checks passed.

<details>
<summary>Evidence: End-to-End Fork Delivery Verification Transcript</summary>

Source: [End-to-End Fork Delivery Verification Transcript](https://github.com/BohnBawerick/firstmate/blob/7b8cc59076717a6aa0c10c58088ffdda0d666f29/.no-mistakes/evidence/fm/fm-fork-main-stale/e2e-verification-transcript.txt)

```text
================================================================================
Firstmate Fork Delivery Path End-to-End Verification Transcript
Commit: 28e0329d8cb52a3815e832d1d7e71baca881621d
Date: 2026-08-18 19:31:09Z
================================================================================

=== Scenario 1: fm-fleet-sync Skips Firstmate Home Gracefully ===
Command: bin/fm-fleet-sync.sh "/home/paiva/.no-mistakes/worktrees/3437026af8a8/01M0B5586CYW8M67MY31E6CNYH"
/home/paiva/.no-mistakes/worktrees/3437026af8a8/01M0B5586CYW8M67MY31E6CNYH: skipped: firstmate home (upstream sync is manual)
Exit code: 0

=== Scenario 2: fm-merge-local Lands Firstmate Tasks (mode=no-mistakes) ===
Task metadata:
id=task-fm-delivery-01
project=/tmp/fm-evidence-run.TXYQ9v/firstmate-home
mode=no-mistakes
kind=crewmate
branch=fm/task-fm-delivery-01
Before merge, main is at: e78dc26
Executing fm-merge-local.sh...
merged fm/task-fm-delivery-01 into local main (e78dc26 -> 85ed28c) in /tmp/fm-evidence-run.TXYQ9v/firstmate-home
After merge, main is at: 85ed28c
Main commit message: feat: landing fix

=== Scenario 3: fm-pr-merge Merges PR and Fast-Forwards Local Main for Firstmate ===
Executing fm-pr-merge.sh for Firstmate task task-fm-pr-02...
armed: state/task-fm-pr-02.check.sh
MOCK gh-axi invoked: pr merge 99 --repo BohnBawerick/firstmate --squash
merged fm/task-fm-pr-02 into local main (85ed28c -> c2beb85) in /tmp/fm-evidence-run.TXYQ9v/firstmate-home
After fm-pr-merge, local main is at: c2beb85
Main commit message: feat: remote PR fix

=== Scenario 4: fm-teardown Recognizes Content Landed in Local Main ===
Worktree exists before teardown: YES
Executing fm-teardown.sh...
/tmp/fm-evidence-run.TXYQ9v/firstmate-home: skipped: firstmate home (upstream sync is manual)
teardown task-fm-td-03 complete (window firstmate:fm-task-fm-td-03, worktree /tmp/fm-evidence-run.TXYQ9v/wt-task-fm-td-03)
Backlog: task-fm-td-03 just finished. Run tasks-axi done task-fm-td-03 --pr PR_URL, then run tasks-axi ready for dependency-cleared candidates, check date gates, and dispatch only work whose blockers are gone and date is due.
Teardown exit code: 0
Worktree exists after teardown: NO

=== Scenario 5: Guard Safety - Refusal on Ordinary Project with mode=no-mistakes ===
Attempting fm-merge-local on ordinary project with mode=no-mistakes (expected error):
WARNING: watcher still down (same stale episode; last beat: never, grace 300s) - full banner already printed this episode.
error: task task-other-04 is mode=no-mistakes on /tmp/fm-evidence-run.TXYQ9v/other-repo, not local-only; merge PR tasks with bin/fm-pr-merge.sh <id> <PR url> after approval
Guard exit code: 1 (expected non-zero refusal)

================================================================================
All verification scenarios passed successfully.
================================================================================
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"216e1876568774c873927d38cf70eda80504a74a","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `./bin/fm-test-run.sh tests/fm-merge-local.test.sh tests/fm-pr-merge.test.sh tests/fm-fleet-sync.test.sh tests/fm-teardown.test.sh tests/fm-documentation-audiences.test.sh`
- `./bin/fm-test-run.sh --check-coverage`
- `./bin/fm-test-run.sh tests/fm-test-isolation-proof.test.sh`
- <code>End-to-end verification of `bin/fm-fleet-sync.sh` skipping Firstmate home repository gracefully</code>
- <code>End-to-end verification of `bin/fm-merge-local.sh` fast-forwarding Firstmate repo tasks with `mode=no-mistakes`</code>
- <code>End-to-end verification of `bin/fm-pr-merge.sh` merging remote PR and automatically fast-forwarding local main for Firstmate repository</code>
- <code>End-to-end verification of `bin/fm-teardown.sh` recognizing work landed into local default branch</code>
- <code>End-to-end verification of `bin/fm-merge-local.sh` guard safety refusing non-Firstmate `mode=no-mistakes` tasks</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
