### PR TITLE
fix(bin): preserve declared-pause cadence across pane churn

### DIFF
--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -330,11 +330,12 @@ busy_turn_over_age() {  # <task>
 # PAUSE_RESURFACE_SECS for a recheck so it cannot rot invisibly. Called on any
 # stale poll once pause_state_class permits the bounded cadence, and on every
 # later poll while the .paused-<key> flag records that this key is already on
-# it, so it must be cheap: it NEVER re-reads crew state. NOTHING here is tied to
-# a pane hash: the re-surface age is anchored on the status file mtime, so a
-# churny idle pane (a ticking clock, a token counter) cannot keep resetting the
-# cadence the way a hash-tied timer would, and its redraws cannot be
-# re-classified as fresh first sightings either. A .paused-resurfaced-<key> throttle marker records the last
+# it, so it must be cheap: it NEVER re-reads crew state. The cadence itself is
+# not tied to a pane hash: the re-surface age is anchored on the status file
+# mtime, so a churny idle pane (a ticking clock, a token counter) cannot keep
+# resetting the cadence the way a hash-tied timer would, and its redraws cannot
+# be re-classified as fresh first sightings either. A .paused-resurfaced-<key>
+# throttle marker records the last
 # re-surface epoch so, once past the window, it fires once per window rather than
 # every poll. Advances the stale suppressor to <hash> and flags the key paused.
 handle_paused_stale() {  # <window> <task> <hash>

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -163,7 +163,9 @@ BUSY_TURN_MAX_SECS=${FM_BUSY_TURN_MAX_SECS:-3600}
 # A crew that declared a pause is idling on a known external wait, so its stale
 # pane is absorbed rather than wedge-escalated.
 # A captain-held or paused crew whose agent has confidently exited uses the same
-# bounded cadence, while a live or ambiguously read agent still surfaces once.
+# bounded cadence, while a live or ambiguously read agent still surfaces once
+# and then joins that same cadence - once per declared pause, not once per pane
+# hash, so redraws of an idle paused pane never re-open that first sighting.
 # These cases re-surface once for a recheck every PAUSE_RESURFACE_SECS - far
 # longer than the wedge threshold, but finite so a forgotten hold cannot rot invisibly.
 PAUSE_RESURFACE_SECS=${FM_PAUSE_RESURFACE_SECS:-$FM_PAUSE_RESURFACE_SECS_DEFAULT}
@@ -326,11 +328,13 @@ busy_turn_over_age() {  # <task>
 # Absorb a stale pane under a declared external-wait pause (paused:) or a
 # dead-agent captain-held transfer, and re-surface it once every
 # PAUSE_RESURFACE_SECS for a recheck so it cannot rot invisibly. Called on any
-# stale poll once pause_state_class permits the bounded cadence, so it must be
-# cheap: it NEVER re-reads crew state. The re-surface age is anchored on the
-# status file mtime, not a per-hash marker, so a churny idle pane (a ticking
-# clock, a token counter) cannot keep resetting the cadence the way a hash-tied
-# timer would. A .paused-resurfaced-<key> throttle marker records the last
+# stale poll once pause_state_class permits the bounded cadence, and on every
+# later poll while the .paused-<key> flag records that this key is already on
+# it, so it must be cheap: it NEVER re-reads crew state. NOTHING here is tied to
+# a pane hash: the re-surface age is anchored on the status file mtime, so a
+# churny idle pane (a ticking clock, a token counter) cannot keep resetting the
+# cadence the way a hash-tied timer would, and its redraws cannot be
+# re-classified as fresh first sightings either. A .paused-resurfaced-<key> throttle marker records the last
 # re-surface epoch so, once past the window, it fires once per window rather than
 # every poll. Advances the stale suppressor to <hash> and flags the key paused.
 handle_paused_stale() {  # <window> <task> <hash>
@@ -1098,11 +1102,13 @@ EOF
           #   - paused: the crew declared an external wait, or a declared pause or
           #     captain hold is paired with a confidently dead agent, so absorb on
           #     the long PAUSE_RESURFACE_SECS cadence instead of wedge-escalating;
-          #   - none: no running pipeline, no exact busy verdict, no declared pause.
-          #     Surface immediately so firstmate inspects the inconclusive state
-          #     (it may be done via an interactive menu that wrote no done: status,
-          #     waiting on a decision, or wedged) instead of leaving the finish to
-          #     wait out the timer.
+          #   - none: no running pipeline, no exact busy verdict, and no pause
+          #     that a dead agent confirms - which also covers a DECLARED pause
+          #     whose agent is still live. Surface immediately so firstmate
+          #     inspects the inconclusive state (it may be done via an
+          #     interactive menu that wrote no done: status, waiting on a
+          #     decision, or wedged) instead of leaving the finish to wait out
+          #     the timer - unless this key is already on the pause cadence.
           if [ "$(cat "$sf" 2>/dev/null || true)" != "$h" ]; then
             task=$(window_to_task "$w" "$STATE")
             case "$(pause_state_class "$w" "$task")" in
@@ -1116,7 +1122,18 @@ EOF
                 handle_paused_stale "$w" "$task" "$h"
                 ;;
               *)
-                surface_nonterminal_stale "$w" "$h"
+                # A live (or ambiguously read) agent under a declared pause
+                # returns none, so this is also the pause path once its bounded
+                # cadence is established. .paused-<key> is that record, and it
+                # outlives any single pane hash: a redraw (or a watcher restart
+                # between recording a hash and classifying it) must not reopen a
+                # first sighting and surface another bare stale. Only a pause
+                # with no cadence yet gets its one immediate surface.
+                if [ -e "$pf" ]; then
+                  handle_paused_stale "$w" "$task" "$h"
+                else
+                  surface_nonterminal_stale "$w" "$h"
+                fi
                 ;;
             esac
           else
@@ -1159,8 +1176,19 @@ EOF
       task=$(window_to_task "$w" "$STATE")
       if ! afk_present && status_is_paused_or_captain_held "$(last_status_line "$STATE/$task.status")" && [ "$busy_now" -ne 0 ]; then
         case "$(pause_state_class "$w" "$task")" in
-          paused) handle_paused_stale "$w" "$task" "$h" ;;
-          *)      clear_pause_tracking "$w" ;;
+          paused)  handle_paused_stale "$w" "$task" "$h" ;;
+          working) clear_pause_tracking "$w" ;;
+          # Same anchoring rule as the stale path above: a still-declared pause
+          # already on the bounded cadence keeps it across a hash change, and
+          # the suppressor advances to the new hash so the redraw cannot be
+          # re-classified as a fresh stale. Only working (the crew resumed)
+          # ends the cadence here; the loop head owns ending it when the status
+          # line itself stops declaring a pause.
+          *)       if [ -e "$pf" ]; then
+                     handle_paused_stale "$w" "$task" "$h"
+                   else
+                     clear_pause_tracking "$w"
+                   fi ;;
         esac
       else
         [ -e "$pf" ] && clear_pause_tracking "$w"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,8 +20,9 @@ A concurrent replacement remains armed, every non-merged or invalid observation 
 No-verb wakes, such as `working:` notes and bare turn-ended signals, are benign only when `bin/fm-crew-state.sh` reports positive evidence that the crew is still working: an actively running no-mistakes step attributed to that crew's current code, or an exact busy verdict from the semantic busy-state contract.
 A `kind=secondmate` task's status signal is the parent-directed reply stream and is never absorbed as provably working; only its bare turn-ended signal retains the ordinary absorb rule.
 A crew that declares `paused:` for a known external wait is separately absorbed while idle and re-surfaced only on the longer pause cadence, rather than being treated as a possible wedge.
-For an ordinary crew that has stopped, the normal-mode watcher first surfaces one stale wake, then applies that same cadence to an unchanged `paused:` or durable `captain-held` endpoint only when the backend confidently reports its agent dead.
-Live or inconclusive liveness remains fail-open at that initial surface, and the secondmate idle-endpoint exemption is unchanged.
+For an ordinary crew that has stopped, the normal-mode watcher first surfaces one stale wake, then applies that same cadence to a `paused:` or durable `captain-held` endpoint for as long as that declaration stands.
+A confidently dead agent lets the cadence start without that initial surface; live or inconclusive liveness remains fail-open and surfaces once before joining the same cadence.
+That cadence is anchored on the declaration rather than on any pane hash, so an idle paused pane redrawing itself neither re-opens the initial surface nor resets the recheck window, and the secondmate idle-endpoint exemption is unchanged.
 Its initial normal-mode status signal still surfaces through the no-verb path, while away mode self-handles that routine signal and owns the later recheck.
 Fresh stale panes use the same current-state read before trusting the status log, so an active run or a proven busy worker outranks an old captain-relevant status-log line left behind before validation.
 No-change heartbeats are also benign.

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -933,8 +933,10 @@ function makePi() {
 }
 
 function pidAlive(pid) {
+  const parsed = Number(pid);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) return false;
   try {
-    process.kill(Number(pid), 0);
+    process.kill(parsed, 0);
     return true;
   } catch {
     return false;
@@ -973,7 +975,10 @@ const first = await startup.getTool().execute("startup", {}, undefined, undefine
 if (!first.details?.ok || !String(first.details.message).includes("started Pi extension arm child")) {
   throw new Error(`startup arm failed: ${JSON.stringify(first.details)}`);
 }
-await waitFor(() => existsSync(process.env.FM_CHILD_PID_FILE), "startup child");
+await waitFor(() => {
+  if (!existsSync(process.env.FM_CHILD_PID_FILE)) return false;
+  return pidAlive(readFileSync(process.env.FM_CHILD_PID_FILE, "utf8").trim());
+}, "startup child");
 const startupChild = readFileSync(process.env.FM_CHILD_PID_FILE, "utf8").trim();
 if (!pidAlive(startupChild)) throw new Error("startup child was not alive");
 const staleTool = startup.getTool();
@@ -1069,7 +1074,7 @@ if (liveArmPids().length !== 0) {
 EOF
 )
   status=$?
-  expect_code 0 "$status" "Pi session transitions must rearm through an explicit generation owner"
+  [ "$status" -eq 0 ] || fail "Pi session transitions must rearm through an explicit generation owner: $out"
   [ -z "$out" ] || fail "Pi session-transition generation owner test printed output: $out"
   pass "Pi session transitions use a generation owner across /new /resume /fork, stale callbacks, and quit"
 }

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -882,6 +882,113 @@ test_exited_declared_pause_is_bounded_but_live_gate_surfaces() {
   pass "exited declared-pause and captain-held panes use bounded pause cadence while a live decision gate still surfaces once"
 }
 
+# A LIVE crew's declared pause must survive pane churn. The 2026-08 field case:
+# firstmate appended `paused:` to a live codex crew, and bare `stale: <window>`
+# wakes kept arriving 60-140s apart instead of the labeled long-cadence recheck.
+# A live agent never classifies as `paused` (only a confirmed-dead one does), so
+# the declared pause rode entirely on the .paused-<key> cadence marker - and any
+# pane redraw (a clock, a token counter, the crew's own echoed output) dropped
+# that marker and re-classified the new hash as a fresh first sighting, surfacing
+# another bare stale a poll later. The cadence is anchored on the declared pause,
+# not the pane hash, so it must survive an arbitrary number of redraws and only
+# ever re-surface as the labeled PAUSE_RESURFACE_SECS recheck.
+test_live_declared_pause_survives_pane_churn_after_status_append() {
+  local dir state fakebin out capture_file statusf window key pid round back wakes bare labeled pane_text
+  dir=$(make_case live-pause-pane-churn); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; capture_file="$dir/pane.txt"; statusf="$state/churn.status"
+  window="test:fm-churn"
+  printf 'window=%s\nkind=ship\nharness=grok\nbackend=tmux\n' "$window" > "$state/churn.meta"
+  printf 'working: waiting on the upstream tool release\n' > "$statusf"
+  prime_status_seen "$state" "$statusf"
+  key=$(printf '%s' "$window" | tr ':/.' '___')
+
+  # Phase A: before any pause is declared, an idle pane with no working evidence
+  # surfaces a bare stale - the correct pre-pause behavior this test builds on.
+  printf 'idle, waiting on upstream\n' > "$capture_file"
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+    FM_FAKE_TMUX_CURRENT_COMMAND=grok FM_FAKE_CREW_STATE='state: unknown · source: none · idle pane' \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" \
+    FM_PAUSE_RESURFACE_SECS=3600 FM_STALE_ESCALATE_SECS=240 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  wait_for_exit "$pid" 60 || { reap "$pid"; fail "pre-pause idle pane did not surface a stale"; }
+  ack_stopped_cycle "$state" || fail "could not acknowledge the pre-pause stale"
+
+  # Phase B: firstmate appends the declared pause. The append is primed as already
+  # seen so the signal path stays out of the way, and the pane redraws - the exact
+  # append-then-stale ordering from the field report. The pause has no cadence yet,
+  # so this one sighting may still surface once.
+  printf 'paused: awaiting the upstream tool release\n' >> "$statusf"
+  prime_status_seen "$state" "$statusf"
+  printf 'idle, awaiting external (token 1)\n' > "$capture_file"
+  : > "$out"
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+    FM_FAKE_TMUX_CURRENT_COMMAND=grok \
+    FM_FAKE_CREW_STATE='state: paused · source: status-log · awaiting the upstream tool release' \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" \
+    FM_PAUSE_RESURFACE_SECS=3600 FM_STALE_ESCALATE_SECS=240 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  wait_for_exit "$pid" 60 || { reap "$pid"; fail "declared pause did not surface its one first sighting"; }
+  [ -e "$state/.paused-$key" ] || fail "the declared pause did not record its bounded cadence marker"
+  ack_stopped_cycle "$state" || fail "could not acknowledge the declared pause first sighting"
+
+  # Phase C: the leak. Redraw the pane on every round, restarting the watcher each
+  # time the way a real fleet does. Each redraw used to drop the cadence marker and
+  # surface another bare stale a poll later; now every one must be absorbed. Rounds
+  # are acknowledged as they go, so an unrelated downtime-recovery resurface cannot
+  # stand in for the stale wake under test.
+  : > "$out"
+  round=1
+  while [ "$round" -le 4 ]; do
+    pane_text="idle, awaiting external (token $((round + 1)))"
+    printf '%s' "$pane_text" > "$capture_file"
+    PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+      FM_FAKE_TMUX_CURRENT_COMMAND=grok \
+      FM_FAKE_CREW_STATE='state: paused · source: status-log · awaiting the upstream tool release' \
+      FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" \
+      FM_PAUSE_RESURFACE_SECS=3600 FM_STALE_ESCALATE_SECS=240 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+      FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" >> "$out" &
+    pid=$!
+    if wait_live "$pid" 60; then reap "$pid"; else wait "$pid" || true; fi
+    ack_stopped_cycle "$state" || true
+    [ -e "$state/.paused-$key" ] || fail "pane redraw $round dropped the pause cadence marker"
+    [ ! -e "$state/.stale-since-$key" ] || fail "pane redraw $round started a wedge timer under a declared pause"
+    round=$((round + 1))
+  done
+  # The suppressor tracking the final redraw proves the stale path really ran and
+  # absorbed each new hash, so a zero count below can never be vacuous.
+  [ "$(cat "$state/.stale-$key" 2>/dev/null || true)" = "$(hash_text "$pane_text")" ] \
+    || fail "the pause cadence never absorbed the final redraw (suppressor did not advance)"
+  wakes=$(grep -c "^stale: $window\$" "$out" || true)
+  [ "$wakes" -eq 0 ] || fail "four pane redraws under a declared pause leaked $wakes bare stale wakes"
+
+  # Phase D: past the threshold the pause must still re-surface - once, labeled,
+  # and never as a wedge - even though the pane kept churning throughout.
+  back=$(( $(date +%s) - 500 ))
+  if [ "$(uname)" = Darwin ]; then touch -mt "$(date -r "$back" '+%Y%m%d%H%M.%S')" "$statusf"
+  else touch -m -d "@$back" "$statusf"; fi
+  prime_status_seen "$state" "$statusf"
+  set_mtime "$back" "$state/.paused-resurfaced-$key"
+  printf 'idle, awaiting external (token 9)\n' > "$capture_file"
+  : > "$out"
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
+    FM_FAKE_TMUX_CURRENT_COMMAND=grok \
+    FM_FAKE_CREW_STATE='state: paused · source: status-log · awaiting the upstream tool release' \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" \
+    FM_PAUSE_RESURFACE_SECS=240 FM_STALE_ESCALATE_SECS=240 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  wait_for_exit "$pid" 60 || { reap "$pid"; fail "an aged declared pause never re-surfaced its bounded recheck"; }
+  grep -F "awaiting external" "$out" >/dev/null || fail "the aged pause recheck was not labeled an external wait"
+  grep -F "possible wedge" "$out" >/dev/null && fail "the aged pause recheck was mislabeled a possible wedge"
+  labeled=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w && $5 ~ /awaiting external/ { n++ } END { print n + 0 }' "$state/.wake-queue")
+  bare=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w && $5 == "stale: " w { n++ } END { print n + 0 }' "$state/.wake-queue")
+  [ "$labeled" -eq 1 ] || fail "expected exactly one labeled pause recheck, got $labeled"
+  [ "$bare" -eq 0 ] || fail "the aged pause recheck queued $bare bare stale wakes"
+  pass "a live crew's declared pause survives pane churn after a status append and only re-surfaces on its labeled long cadence"
+}
+
 test_secondmate_paused_resurfaces_in_normal_mode() {
   local dir state fakebin out capture_file statusf window key pane_hash sig pid back
   dir=$(make_case secondmate-paused-resurface); state="$dir/state"; fakebin="$dir/fakebin"
@@ -1955,6 +2062,7 @@ test_busy_pane_default_turn_age_bound_is_3600s
 test_nonterminal_stale_not_working_surfaced
 test_nonterminal_stale_paused_absorbed_then_resurfaced
 test_exited_declared_pause_is_bounded_but_live_gate_surfaces
+test_live_declared_pause_survives_pane_churn_after_status_append
 test_secondmate_paused_resurfaces_in_normal_mode
 test_secondmate_nonpaused_stale_remains_suppressed
 test_secondmate_unpause_clears_pause_tracking


### PR DESCRIPTION
## Intent

Fix a supervision bug in firstmate's always-on watcher: a crew whose latest status line is a declared 'paused:' external wait still emitted plain bare 'stale: <window>' wakes at short cadence, instead of the FM_PAUSE_RESURFACE_SECS (3600s) labeled resurface rechecks that handle_paused_stale in bin/fm-watch.sh is supposed to produce. Field evidence spanned three dated observations and was reproduced live on 2026-08-18 (task carrier-rev-detection, codex/sol, declared paused): bare stale wakes ~60-140s apart, and an earlier case at ~9-minute cadence, with no pause-resurface labeling. The defect was observed to be neither harness-specific nor task-specific.

Accepted requirements: (1) root-cause the leak using diagnostic-reasoning discipline - reproduce it with a scripted scenario and compare against the working absorb case recorded for task fm-spawn-codex-tier; (2) fix it so a declared pause reliably converts stale re-fires to the long-cadence labeled resurface, including immediately after a new status append; (3) cover it with a regression test for the append-then-stale ordering; (4) a separate observation in the evidence record - a 61h-old state/<id>.turn-ended marker on a reboot-resumed session, suggesting the turn-end hook may not fire for resumed sessions - must be REPORTED in the PR body as a separate finding if confirmed distinct, and deliberately NOT fixed in this change.

Scope fence accepted at intake: bin/fm-watch.sh and its libs' absorb/suppressor path only. Deliberately NOT touched: the away-mode daemon (bin/fm-supervise-daemon.sh), fm-classify-lib.sh policy semantics, and backends. This is firstmate's own shared tracked material, so the firstmate-coding-guidelines contract applies (knowledge-placement decision tree, one-owner rule, AGENTS.md size discipline, one sentence per line in tracked Markdown, plain dash never em dash, shellcheck-clean bin scripts, tests colocated in tests/ extending the existing runner rather than a new one, and tests must exercise behavior through an executable interface rather than asserting implementation source bytes).

What the investigation established, and the reasoning behind the diff a reviewer would not otherwise know:

Root cause: the declared-pause bounded cadence was anchored on the PANE HASH rather than on the declared pause itself. pause_state_class never returns 'paused' for a live agent - it returns 'none' for any non-secondmate crew whose backend does not confidently report the agent dead - so a declared pause on a live crew rode entirely on the .paused-<key> cadence flag. Two call sites discarded that flag whenever the pane hash moved: the hash-change branch mapped 'none' to clear_pause_tracking (removing .paused-<key>, .paused-resurfaced-<key> and .stale-<key>), and the non-terminal stale first-sighting branch then saw an unclassified hash and called surface_nonterminal_stale, emitting a bare stale. Every redraw of an idle paused pane (a ticking clock, a token counter, the crew's own echoed output) therefore reopened a "first sighting" and leaked another bare stale about two polls later, matching the observed 60-140s and ~9-minute cadences.

This also explains the "not harness-specific, not task-specific" observation: the real differentiator is pane churn, not the harness. fm-spawn-codex-tier absorbed correctly on identical code purely because its pane stayed hash-stable.

Deliberate correction to the hypothesis recorded in the task record: the record's leading hypothesis was that a status append moves the status hash and lets plain stales leak before handle_paused_stale absorbs. A disconfirming control run shows that on the UNFIXED code, appending a 'paused:' line to an already-stale pane with no pane redraw absorbs correctly. The status append alone was never the trigger; the pane redraw is. The fix is aimed at the redraw path accordingly, and the regression test still covers the append-then-stale ordering as required.

The chosen fix treats .paused-<key> as the cadence record it is already documented to be: once set, a still-declared pause stays on the bounded cadence across hash changes, and the stale suppressor advances to the new hash so a redraw cannot be re-classified as a fresh sighting. Only a 'working' verdict (the crew genuinely resumed) ends the cadence at those two sites; the loop head remains the single owner of ending it when the status line itself stops declaring a pause. A live agent's FIRST sighting still surfaces once - this is deliberate and preserves the pre-existing external-decision-gate contract asserted by test_exited_declared_pause_is_bounded_but_live_gate_surfaces, so a live decision gate is never hidden behind the pause cadence.

Deliberate design argument for why this is a convergence rather than new policy: the away-mode daemon already holds exactly this invariant. pause_marker_record in bin/fm-supervise-daemon.sh keys its pause marker by task and documents "Recording is create-if-absent so the timestamp is stable across a churny idle pane (many distinct stale hashes map to one marker), keeping the cadence hash-immune." The always-on watcher was the one path that had not applied it. That is also why the daemon is correctly left untouched: it does not share the defect.

Documentation changes are deliberate and scoped to statements this fix makes inaccurate: three comment blocks in bin/fm-watch.sh (the handle_paused_stale header, the PAUSE_RESURFACE_SECS block, and the 'none' bullet in the non-terminal stale case list), and one sentence in docs/architecture.md whose claim about "an unchanged paused: endpoint" and "only when the backend confidently reports its agent dead" no longer describes the behavior. Per the one-owner rule these patch existing language in place rather than appending new paragraphs. No AGENTS.md change is intended: by the knowledge-placement decision tree this fix is watcher mechanics, which belongs in the script's own header comments, and AGENTS.md size discipline explicitly argues against adding it there.

The regression test is deliberately structured in four phases (pre-pause bare surface, the status append plus redraw, four rounds of pane churn, then the aged labeled resurface) and includes an explicit non-vacuity assertion that the stale suppressor advanced to the final redraw's hash, so a zero-leak count can never pass hollow. It was confirmed to FAIL on the unfixed code (4 leaked bare stale wakes) and pass on the fix. Rounds are acknowledged as they go so an unrelated downtime-recovery resurface cannot stand in for the stale wake under test.

Verification already performed locally: 266 assertions green with zero failures across tests/fm-watch-triage.test.sh (50), fm-watcher-lock (31), fm-watch-arm (14), fm-daemon (99, which matters because the daemon shares fm-classify-lib.sh), fm-wake-queue (19) and fm-crew-state (53); bin/fm-lint.sh clean at pinned ShellCheck 0.11.0; bin/fm-doc-audience-check.sh clean. actionlint is not installed locally, but no workflow files were changed.

On requirement (4), the intended PR-body finding is deliberately conservative and must not be upgraded into a confirmed defect claim: the turn-ended observation IS mechanically distinct from this bug, because bin/fm-watch.sh reads <id>.turn-ended in only two places - busy_turn_over_age, which is gated on a provably BUSY pane, and scan_signals - so a stale marker could not have produced these idle-pane bare stales, and the symptom it would produce is a different one (a wedge escalation labeled "possible wedge, escalation N"). However it is NOT confirmed as a hook defect: the originally cited task has since been torn down, and on the live home today every task with an old marker is either an endpoint firstmate deliberately closed or a declared pause, both of which legitimately complete no turns. One case is suggestive but inconclusive because firstmate also appends to crew status files, so a recent status line does not prove the crew took a turn. The PR body should report it as distinct-in-mechanism, unconfirmed-as-a-defect, and recommend a separate live reproduction per harness.

## What Changed

- Preserve declared-pause cadence across pane hash changes, advancing stale suppression without reopening bare first sightings, and clarify the hash-immune behavior in watcher and architecture documentation.
- Add regression coverage for status-append-then-stale ordering, repeated pane redraws, suppressor advancement, and labeled long-cadence resurfacing.
- Separate finding, deliberately not fixed: stale `.turn-ended` markers are mechanically distinct from this idle-pane leak and could produce BUSY-pane wedge escalation instead. A resumed-session hook defect remains unconfirmed and needs separate live reproduction per harness.

## Risk Assessment

✅ Low: The change is narrowly scoped and preserves the declared-pause cadence across both pane-hash changes and subsequent stale classification without weakening resume, AFK, secondmate, or wedge handling.

## Testing

Alongside the supplied prior baseline, this phase independently passed the targeted watcher suite, reproduced four bare notifications on the base commit, proved its stable-pane control absorbs, and showed the target emits zero repeated bare notifications plus one labeled long-cadence recheck; the distinct turn-ended observation remains deliberately out of scope and an obligation for the outer PR-body phase.

<details>
<summary>Evidence: Pause-cadence end-to-end comparison</summary>

`Base with pane churn: 4 bare stale notifications. Base stable-pane control: absorbed correctly. Target with identical churn: 0 bare notifications, followed by exactly 1 labeled external-wait recheck.`

```text
Watcher pause cadence end-to-end evidence
Base:   03bb1d8b78a8632ae2d9cea4c10868eb100e885e
Target: 59fe27a217b3b1757f6aefea27ee461d42abf387

Scenario: append paused: to a live crew, then redraw its idle pane four times.

BASE WITH PANE CHURN - reproduced leak
not ok - four pane redraws under a declared pause leaked 4 bare stale wakes
End-user watcher output:
stale: test:fm-churn
stale: test:fm-churn
stale: test:fm-churn
stale: test:fm-churn
Bare notifications: 4

BASE STABLE-PANE CONTROL - working absorb path
ok - a declared pause is absorbed on first sight, then re-surfaced as a recheck past the threshold, never wedge-escalated

TARGET WITH THE SAME PANE CHURN - fixed path
ok - a live crew's declared pause survives pane churn after a status append and only re-surfaces on its labeled long cadence
Declared status log:
working: waiting on the upstream tool release
paused: awaiting the upstream tool release
Absorbed paused-stale polls recorded: 16
Bare queued notifications after four redraws: 0
Labeled long-cadence rechecks queued after aging: 1
End-user watcher output after aging the pause:
stale: test:fm-churn (paused 500s, awaiting external - declared pause, rechecked on a long cadence not a wedge; confirm the wait still holds)
Pause cadence marker: present
Wedge timer: absent

Result: pane churn, not the status append alone, distinguishes the failing base path. The target keeps the declared pause cadence across redraws, emits no repeated bare notification, and later emits exactly one labeled external-wait recheck.
```
</details>
<details>
<summary>Evidence: Base-commit reproduction</summary>

`not ok - four pane redraws under a declared pause leaked 4 bare stale wakes`

```text
not ok - four pane redraws under a declared pause leaked 4 bare stale wakes
```
</details>
<details>
<summary>Evidence: Target focused regression</summary>

`ok - a live crew's declared pause survives pane churn after a status append and only re-surfaces on its labeled long cadence`

```text
ok - a live crew's declared pause survives pane churn after a status append and only re-surfaces on its labeled long cadence
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-watch-triage.test.sh`
- <code>`test_live_declared_pause_survives_pane_churn_after_status_append` through the target watcher executable</code>
- <code>The same regression through watcher and drain executables extracted from base commit `03bb1d8b78a8632ae2d9cea4c10868eb100e885e`</code>
- <code>`test_nonterminal_stale_paused_absorbed_then_resurfaced` through the base watcher as the stable-pane control</code>
- <code>Inspected watcher output, durable wake queue, pause marker, wedge timer, and absorbed-wake log; generated `pause-cadence-e2e.txt`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
