### PR TITLE
chore: update pull request

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -185,13 +185,24 @@ The shared symptom is a healthy-looking pane with no work in progress, so each a
 | Fact | Value |
 |---|---|
 | Busy state | Owned lifecycle hooks: `UserPromptSubmit` opens a turn, while `Stop`, `StopFailure`, and `SessionEnd` close it; because Claude fires no hook for a manual interrupt, `bin/fm-control.sh interrupt` reports only delivered keys and the verified endpoint or live agent, publishes no idle event, makes no cancellation claim, and leaves adapter-observed state unchanged, so a mid-turn worker typically remains busy via `claude-hook`. |
+| Autonomy | `--permission-mode auto` (footer shows `⏵⏵ auto mode on`): Claude Code's classifier reviews every action that is not a read or an in-worktree edit instead of prompting, so a crewmate, scout, or secondmate runs unattended. It replaced `--dangerously-skip-permissions`, which Claude Code refuses outright under root (`cannot be used with root/sudo privileges`), so a root-operated fleet could not spawn on claude at all; verified 2026-08-18 on Claude Code 2.1.234, evidence in [`docs/verification/claude.md`](../../../docs/verification/claude.md). |
 | Exit command | `/exit` |
 | Interrupt | single Escape |
 | Skill invocation | `/<skill>` (e.g. `/no-mistakes`) |
 
-First launch in a fresh worktree, or first ever on a machine, may show a trust or bypass-permissions confirmation.
+First launch in a fresh worktree, or first ever on a machine, may show a trust confirmation; the bypass acceptance dialog no longer applies, and auto mode showed no acceptance dialog of its own on 2.1.234 (Claude Code documents only a one-time non-blocking notice for it).
 After every spawn, peek the pane within about 20 seconds.
 If such a dialog is showing, accept it from an active firstmate session using `FM_HOME=<this-firstmate-home> bin/fm-send.sh <window> --key Enter`, or the choice the dialog requires, unless `FM_HOME` is already set to the active firstmate home; verify the brief started processing.
+The same peek should show `⏵⏵ auto mode on` in the footer.
+Auto mode exists only for the models Claude Code lists for it (Opus 4.6 or later, Sonnet 4.6 or later, and Fable 5 at the time of writing), and a launch that names any other model, such as Haiku 4.5, starts silently in Manual mode with `⏸ manual mode on · auto mode unavailable for this model` in the footer and parks on its first permission prompt; a claude dispatch profile or `config/secondmate-harness` model token must therefore name an auto-capable model, and a `manual mode on` footer after a spawn is a launch failure to relaunch on a supported model, not a prompt to answer by hand (both footers verified 2026-08-18).
+
+Auto mode is not a full bypass, and what a worker loses is bounded and observable.
+A blocked call does not stall the worker: the model receives `Blocked by classifier` and tries an alternative, and Claude Code lists the call under `/permissions` in its Recently denied tab.
+The documented default blocks that intersect fleet work are discard-style git commands (`git reset --hard`, `git checkout -- .`, `git restore .`, `git clean -fd`, `git stash drop`), `git commit --amend` of a commit the session did not create or already pushed, force pushes, wildcard deletes under `/tmp`, merging a pull request no human approved, and launching another autonomous agent loop; the classifier is contextual rather than a fixed denylist (a session-created scratch repo's `git reset --hard` and a wildcard delete of session-created scratch were both allowed in verification), so treat these as may-be-refused, use-an-alternative, not as never-works.
+After 3 consecutive or 20 total blocks, auto mode pauses and the pane shows an ordinary permission prompt for the blocked call, where an unattended worker waits exactly as it would on a trust dialog; a claude worker that stops responding on such a prompt needs firstmate to answer it (`bin/fm-send.sh <window> --key ...`) or steer it to an allowed alternative, and repeated blocks are the signal that the task itself is asking for a blocked category (documented thresholds, not yet reproduced in a crewmate pane).
+The classifier reads user messages, tool calls, and CLAUDE.md content, never tool results, and explicit `permissions.ask` rules still prompt; firstmate's per-task settings install only hooks, never permission rules, so no fleet-owned rule forces a prompt.
+Claude Code's [permission-modes reference](https://code.claude.com/docs/en/permission-modes) owns the current block and allow lists, and `claude auto-mode defaults` prints them for the installed version.
+A claude secondmate's own spawns, PR merges, and steers all pass through the same classifier and are not yet verified under it; [`docs/verification/claude.md`](../../../docs/verification/claude.md) tracks that gap.
 
 Claude renders a predicted-next-prompt suggestion as dim/faint text inside an otherwise-empty composer after a turn completes.
 A plain `tmux capture-pane` cannot tell that ghost text apart from typed text.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1111,7 +1111,17 @@ launch_template() {
     # does NOT suppress the interactive ghost text (verified empirically), so the env
     # var is the correct control. The dim-aware composer reader in fm-tmux-lib.sh is
     # the defense-in-depth backstop for any pane this flag cannot reach.
-    claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    # --permission-mode auto is claude's supported autonomous mode: its
+    # classifier auto-approves ordinary tool calls and only refuses (or holds
+    # for a human) the calls it judges risky, so an unattended crewmate keeps
+    # working. It replaced --dangerously-skip-permissions, which claude refuses
+    # outright when the effective UID is 0 ("cannot be used with root/sudo
+    # privileges"), so a root-operated firstmate could not spawn on claude at
+    # all. auto is not a full bypass, and it exists only for the models Claude
+    # Code supports it on: any other --model starts silently in Manual mode and
+    # parks on its first prompt. The harness-adapters skill owns that model list,
+    # what a crewmate loses under auto, and how to handle a held call.
+    claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --permission-mode auto __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     codex)
       if [ "$kind" = secondmate ]; then
         printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
@@ -1131,8 +1141,8 @@ launch_template() {
     # grok (Grok Build TUI): a positional prompt starts the supervised interactive
     # session. --always-approve auto-approves every tool execution (verified: the
     # crewmate runs fully autonomously, no permission gate), which an unattended
-    # crewmate needs; it is the targeted equivalent of claude's
-    # --dangerously-skip-permissions. grok's turn-end signal does NOT ride the
+    # crewmate needs; it is grok's counterpart of the autonomous claude launch
+    # above. grok's turn-end signal does NOT ride the
     # launch command - it is a Stop-event hook installed below (global hook +
     # per-task pointer), so the template is identical for ship/scout/secondmate.
     grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -209,6 +209,7 @@ The full cmux home label also includes a short hash of the resolved `FM_ROOT` pa
 ## Harness support
 
 claude, codex, opencode, pi, pi-signed, grok, kimi, and cursor are empirically verified for crewmate and secondmate launches; [README requirements](../README.md#requirements) own the set supported for the primary session.
+The claude crewmate, scout, and secondmate template launches with `--permission-mode auto`, Claude Code's supported autonomous mode, so it starts under a root-operated primary where the bypass flag is refused; the model it names must support auto mode, and [`docs/verification/claude.md`](verification/claude.md) owns that evidence.
 A cursor secondmate or primary runs the tracked project-scope `.cursor/hooks.json` in its own home and must be launched with `--trust`, or no project hook loads; [`docs/supervision-protocols/cursor.md`](supervision-protocols/cursor.md) owns its supervision protocol.
 Cursor delivery confirmation is verified on tmux and Herdr only.
 On Zellij, cmux, and Orca a Cursor steer lands, but `fm-send` reports delivery unconfirmed and exits non-zero because their shared submit core does not consult the busy footer; [runtime backend verification](verification/runtime-backends.md#cursor-agent-cli) owns the evidence and transcript-state boundary.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -337,6 +337,10 @@
       "audience": "operator-current"
     },
     {
+      "path": "docs/verification/claude.md",
+      "audience": "maintainer-verification"
+    },
+    {
       "path": "docs/verification/dispatch-auth.md",
       "audience": "maintainer-verification"
     },

--- a/docs/examples/crew-dispatch.json
+++ b/docs/examples/crew-dispatch.json
@@ -7,8 +7,8 @@
     },
     {
       "when": "The task is a trivial mechanical edit such as a rote rename, formatting sweep, targeted typo fix, or simple file gathering.",
-      "use": { "harness": "claude", "model": "haiku", "effort": "low" },
-      "why": "Use the cheapest fast profile when the task is narrow and low ambiguity."
+      "use": { "harness": "claude", "model": "claude-sonnet-5", "effort": "low" },
+      "why": "Use the cheapest fast profile when the task is narrow and low ambiguity. A claude dispatch profile must name an auto-capable model (Opus 4.6+, Sonnet 4.6+, or Fable 5), because any other model starts silently in Manual mode under --permission-mode auto and parks a crewmate on its first permission prompt."
     },
     {
       "when": "The task is a big or ambiguous multi-file feature, a risky refactor, or work that requires holding many moving parts in mind.",

--- a/docs/verification/claude.md
+++ b/docs/verification/claude.md
@@ -1,0 +1,84 @@
+# Verification: the claude (Claude Code) autonomous launch
+
+Active empirical evidence for the `--permission-mode auto` launch in `bin/fm-spawn.sh`'s claude template.
+[`.agents/skills/harness-adapters/SKILL.md`](../../.agents/skills/harness-adapters/SKILL.md) owns the operating facts; this record owns how they were established and what is still unproven.
+
+## Subject
+
+| Field | Value |
+|---|---|
+| Version | `2.1.234 (Claude Code)` |
+| Verified | 2026-08-18 |
+| Platform | Linux x86_64, effective UID 0, herdr and tmux panes |
+| Account | Claude Max, Anthropic API path |
+
+Every command below ran as root on the same host, either from the firstmate crewmate's own pane or inside a throwaway tmux server, so no fleet home or captain configuration was touched.
+
+## Verified facts
+
+### The bypass flag is refused under root
+
+Claude Code refuses to start with `--dangerously-skip-permissions` when the effective UID is 0, before any model call:
+
+```
+$ id -u
+0
+$ claude --version
+2.1.234 (Claude Code)
+$ claude --dangerously-skip-permissions -p 'reply with the single word OK' --model claude-haiku-4-5-20251001
+--dangerously-skip-permissions cannot be used with root/sudo privileges for security reasons
+```
+
+`--permission-mode bypassPermissions` is documented as the equivalent spelling and carries the same refusal.
+
+### `--permission-mode auto` launches as root and reports auto mode
+
+Two idle interactive sessions were started in a scratch tmux server from a trusted worktree, with the crewmate's own `CLAUDECODE`, `CLAUDE_CODE_*`, `CLAUDE_PID`, and `HERDR_*` variables unset so each probe was an ordinary top-level launch:
+
+```
+$ tmux -L fmprobe new-session -d -s probe -n fable -x 170 -y 45 -c "$WT" \
+    'env -u CLAUDECODE ... CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --permission-mode auto --model claude-fable-5'
+$ tmux -L fmprobe new-window -d -t probe: -n haiku -c "$WT" \
+    'env -u CLAUDECODE ... CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --permission-mode auto --model claude-haiku-4-5-20251001'
+$ sleep 12; tmux -L fmprobe capture-pane -p -t probe:fable; tmux -L fmprobe capture-pane -p -t probe:haiku
+```
+
+Observed footers, trimmed to the mode indicator:
+
+```text
+fable:  ⏵⏵ auto mode on (shift+tab to cycle) · ← for agents                    ◈ max · /effort
+haiku:  ⏸ manual mode on · ? for shortcuts · ← for agents          auto mode unavailable for this model
+```
+
+Neither probe showed a trust dialog or an acceptance dialog in that trusted worktree.
+The Fable session honored the flag; the Haiku session started in Manual mode with no error, which is the documented silent fallback when auto mode is unavailable for the model.
+Both were exited with `/exit` and the scratch server was killed.
+
+### Ordinary crewmate work runs unattended under auto mode
+
+The crewmate that produced this record ran as root in a herdr pane under `claude --permission-mode auto --model claude-fable-5 --effort high <brief>` and completed its task without a single refused tool call: shell reads and greps, in-worktree edits through heredocs and short scripts, appends to the fleet status file outside the worktree, `git checkout -b`, `git add`, and `git commit`, `bin/fm-test-run.sh`, `bin/fm-lint.sh`, `no-mistakes doctor`, a read-only `curl` fetch, a nested `claude -p` launch, one subagent, scratch files under `/tmp`, and a scratch tmux server driven with `send-keys`.
+Two documented default-block shapes were probed deliberately against session-created scratch state and were both allowed, which shows the classifier judges context rather than matching a fixed denylist:
+
+```
+$ git init -q -b main . && git commit -q -m 'probe: initial' && echo two >> f.txt
+$ git reset --hard HEAD
+HEAD is now at caa60ed probe: initial
+$ rm -rf automode-probe* && echo 'wildcard rm ran'
+wildcard rm ran
+```
+
+### Documented reference
+
+Claude Code's [permission-modes reference](https://code.claude.com/docs/en/permission-modes) is the current owner of what auto mode blocks and allows by default, of the model and plan requirements, and of the repeated-block fallback (3 consecutive or 20 total blocks pause auto mode and resume prompting).
+`claude auto-mode defaults` prints the installed version's rule lists as JSON.
+
+## Still unproven
+
+- The repeated-block park in an unattended crewmate pane: its exact rendering, and whether `bin/fm-send.sh <window> --key Enter` resumes it the way it accepts a trust dialog.
+- A claude secondmate's own `bin/fm-spawn.sh`, `bin/fm-pr-merge.sh`, and `fm-send` steers under the classifier, whose documented defaults name unapproved PR merges and unsandboxed agent loops.
+- The one-time terminal notice Claude Code shows the first time a session starts in auto mode on a machine that has never seen it; this host had already recorded it, so the post-spawn peek in the harness-adapters skill remains the guard.
+
+## Refresh procedure
+
+Rerun the three verified-fact blocks above after upgrading Claude Code or changing the claude launch template, and update the version, date, and footers here.
+The launch string itself is pinned by `tests/fm-spawn-dispatch-profile.test.sh`, `tests/fm-secondmate-harness.test.sh`, and `tests/fm-backend-orca.test.sh`.

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -520,7 +520,7 @@ test_spawn_writes_orca_metadata_and_launches_harness() {
     "spawn should reuse the implicit terminal returned by Orca worktree creation"
   assert_contains "$(cat "$log")" $'orca\x1f''terminal'$'\x1f''send'$'\x1f''--terminal'$'\x1f''term-spawn'$'\x1f''--text'$'\x1f''export GOTMPDIR=/tmp/fm-orcaspawnz1/gotmp'$'\x1f''--enter'$'\x1f''--json' \
     "spawn did not export GOTMPDIR through the Orca terminal"
-  assert_contains "$(cat "$log")" "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions" \
+  assert_contains "$(cat "$log")" "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --permission-mode auto" \
     "spawn did not send the selected harness launch command through Orca"
   rm -rf "/tmp/fm-$id"
   pass "fm-spawn.sh --backend orca: reuses implicit terminal, records metadata, launches harness"

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -767,7 +767,7 @@ test_spawn_secondmate_harness_model_token() {
   [ "$(meta_field "$meta" model)" = opus ] || fail "model-token: meta model not opus (got '$(meta_field "$meta" model)')"
   [ "$(meta_field "$meta" effort)" = default ] || fail "model-token: meta effort not default (got '$(meta_field "$meta" effort)')"
   launch=$(cat "$launchlog")
-  assert_contains "$launch" "claude --dangerously-skip-permissions --model 'opus'" \
+  assert_contains "$launch" "claude --permission-mode auto --model 'opus'" \
     "model-token: launch did not carry --model opus"
   assert_not_contains "$launch" "--effort" "model-token: launch must not carry an --effort flag"
   pass "C3 spawn: config/secondmate-harness's model token threads --model into the launch and meta"
@@ -789,7 +789,7 @@ test_spawn_secondmate_harness_model_and_effort_tokens() {
   [ "$(meta_field "$meta" model)" = opus ] || fail "model-effort-tokens: meta model not opus"
   [ "$(meta_field "$meta" effort)" = high ] || fail "model-effort-tokens: meta effort not high (got '$(meta_field "$meta" effort)')"
   launch=$(cat "$launchlog")
-  assert_contains "$launch" "claude --dangerously-skip-permissions --model 'opus' --effort 'high'" \
+  assert_contains "$launch" "claude --permission-mode auto --model 'opus' --effort 'high'" \
     "model-effort-tokens: launch did not carry both --model opus and --effort high"
   pass "C4 spawn: config/secondmate-harness's model+effort tokens thread into the launch and meta"
 }

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -165,7 +165,7 @@ test_no_profile_keeps_claude_profile_defaults() {
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude default default
 
   launch=$(cat "$LAUNCH_LOG")
-  expected="env -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/brief.md')\""
+  expected="env -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --permission-mode auto \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/brief.md')\""
   [ "$launch" = "$expected" ] || fail "no-profile claude launch did not use the canonical launch kind"$'\n'"expected: $expected"$'\n'"actual:   $launch"
   pass "no --model/--effort records defaults and types the claude launch instructions"
 }
@@ -429,7 +429,7 @@ test_claude_threads_model_and_effort() {
   expect_code 0 "$status" "claude spawn with profile flags should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude sonnet high
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "claude --dangerously-skip-permissions --model 'sonnet' --effort 'high'" \
+  assert_contains "$launch" "claude --permission-mode auto --model 'sonnet' --effort 'high'" \
     "claude launch did not thread model and effort flags"
   assert_not_contains "$launch" "--tui-mode" "non-Pi launches must not receive Pi's TUI mode override"
   pass "claude receives --model and --effort profile flags"


### PR DESCRIPTION
## Intent

Make `claude` a launchable crewmate harness on root-operated hosts by replacing the `--dangerously-skip-permissions` launch flag with `--permission-mode auto`.

Problem: `bin/fm-spawn.sh`'s built-in `claude` launch template emitted `CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions ...`, and Claude Code refuses `--dangerously-skip-permissions` outright when the effective UID is 0 (`--dangerously-skip-permissions cannot be used with root/sudo privileges for security reasons`, reproduced on Claude Code 2.1.234), so every claude crewmate, scout, and secondmate failed to launch on a root-operated firstmate; the fleet could then spawn only on codex, and when the codex weekly quota reached 100% on 2026-08-18 it could not spawn at all. The captain authorized removing the refusal at its source with Claude Code's supported autonomous mode rather than the `IS_SANDBOX=1` workaround held on upstream PR 2455 (`fm-claude-root-sandbox-launch`).

Accepted requirements:
1. In `bin/fm-spawn.sh`, the built-in `claude` launch template passes `--permission-mode auto` and no longer passes `--dangerously-skip-permissions`; the existing model/effort flag composition and the brief encoding are unchanged. The claude template is a single kind-independent line, so the secondmate claude launch path is the same line and needs no separate treatment; the secondmate launch assertions were updated consistently.
2. A concise code comment at the template states why: `--dangerously-skip-permissions` is refused under root, and `auto` is the supported autonomous mode; mechanics stay in the script comment, not in `AGENTS.md`. The grok template's stale cross-reference to claude's bypass flag was reworded to point at the autonomous claude launch above it.
3. Every colocated test that asserts the claude launch string was updated: `tests/fm-spawn-dispatch-profile.test.sh` (canonical no-profile launch and model/effort threading), `tests/fm-secondmate-harness.test.sh` (C3/C4 secondmate model and model+effort tokens), and `tests/fm-backend-orca.test.sh` (harness launch sent through Orca); the whole `tests/` tree was grepped for the old flag. No test expectation depends on the runner's UID. Deliberately unchanged: the opt-in live guards `tests/fm-backend-herdr-smoke.test.sh` (`FM_HERDR_SMOKE_REAL_CLAUDE=1`), `tests/fm-claude-stop-autoarm-live-e2e.test.sh` (`FM_CLAUDE_LIVE_E2E=1`), and `tests/fm-sessionstart-hook-live-e2e.test.sh` still invoke a real claude with the bypass flag or `--permission-mode bypassPermissions`; they do not assert the launch template, their recorded evidence in `docs/verification/supervision.md` names those exact commands, and on a root host they fail with the same refusal, so moving them to `auto` is a separate re-verification, not part of this change. The hook verification recipes in `docs/cd-guard.md`, `docs/arm-pretool-check.md`, and `docs/subagent-guard.md` are likewise unchanged for the same reason.
4. The behavioral consequence of `auto` is established and recorded in its owners: `.agents/skills/harness-adapters/SKILL.md` (claude section: an Autonomy row, the post-spawn `auto mode on` footer check, the auto-capable model requirement whose absence silently starts Manual mode, the documented default blocks that intersect fleet work with the verified fact that the classifier is contextual rather than a fixed denylist, the 3-consecutive/20-total repeated-block prompt fallback and how firstmate handles a worker parked on it, and the still-unverified secondmate spawn/merge/steer surface), a new dated maintainer-verification record `docs/verification/claude.md` registered in `docs/documentation-audiences.json`, and one pointer sentence in `docs/configuration.md` "Harness support". Verified on this host (Claude Code 2.1.234, uid 0): the bypass flag is refused; `--permission-mode auto --model claude-fable-5` starts as root with `⏵⏵ auto mode on` and no dialog; `--permission-mode auto --model claude-haiku-4-5-20251001` starts silently in `⏸ manual mode on · auto mode unavailable for this model`, which would park an unattended worker on its first permission prompt; the crewmate that produced this change did all its ordinary work under auto without a refused tool call, including two documented default-block shapes (`git reset --hard` in a session-created scratch repo, a wildcard `rm -rf` of session-created scratch under /tmp) that the classifier allowed. No category of ordinary crewmate work was found blocked outright, so no needs-decision was raised; the model gate is the one dispatch-relevant constraint (claude dispatch profiles and `config/secondmate-harness` model tokens must name an auto-capable model). This is a deliberate behavior change for non-root fleets too: every claude worker now runs under the classifier instead of a full bypass, so a fleet whose organization disabled auto mode or whose profile pins a model without auto support would start its claude workers in Manual mode and park on the first prompt; the post-spawn footer check in the harness-adapters skill is the detection, and a plain replacement (not a UID-conditional template) was chosen because it is what the captain authorized and it keeps every test expectation independent of the runner's UID.
5. Supersession assessment for `fm-claude-root-sandbox-launch` (upstream PR 2455, held): this change supersedes it for the fleet's claude launch path. Both edit the same template line and are mutually exclusive; PR 2455 keeps bypass mode and defeats the root refusal with the undocumented `IS_SANDBOX=1` marker, which Claude Code's own docs steer away from (they recommend a non-root dev container) and which can vanish in any release, whereas `auto` is the documented, supported autonomous mode and keeps the classifier's protection for workers that read untrusted content. What PR 2455 would preserve and this change gives up: full bypass with no classifier blocks or repeated-block prompt fallback, any model including those without auto support, and no classifier latency or token overhead. Recommendation: close or withdraw PR 2455 once this lands, keeping it only as a documented fallback if a verified need for a full-bypass claude worker appears (a claude secondmate whose spawn or merge steps the classifier blocks, or a required model without auto support); that task was not closed or modified here.
6. `bin/fm-lint.sh` passed with the pinned ShellCheck 0.11.0 and actionlint 1.7.12 (installed into a scratch directory via `bin/fm-install-shellcheck.sh` and `bin/fm-install-actionlint.sh`); `bin/` stays shellcheck-clean; `bin/fm-doc-audience-check.sh` passed; `bin/fm-test-run.sh` ran the three edited suites, the `backend-dispatch` family, `tests/fm-documentation-audiences.test.sh`, and `tests/fm-lint.test.sh`. One pre-existing failure is unrelated: `tests/fm-secondmate-harness.test.sh` `test_config_reread_serializes_concurrent_pushes` ("first config push did not reach pointer delivery", a 2-second timing wait on `fm-config-push.sh`) fails identically on a pristine `main` snapshot on this host and does not touch the launch template.

Constraints: this is firstmate's own shared tracked material and follows `firstmate-coding-guidelines`; no other harness adapter changed; no permissions redesign; no production website repositories, services, systemd units, `/root/elseis-articles`, `/var/www/elseis`, or `/root/agents` were touched; the change lives only on this branch and was never applied to the primary checkout the fleet runs from.

## What Changed

Final changed paths and statuses:

```text
M	.agents/skills/harness-adapters/SKILL.md
M	bin/fm-spawn.sh
M	docs/configuration.md
M	docs/documentation-audiences.json
M	docs/examples/crew-dispatch.json
A	docs/verification/claude.md
M	tests/fm-backend-orca.test.sh
M	tests/fm-secondmate-harness.test.sh
M	tests/fm-spawn-dispatch-profile.test.sh
```

## Risk Assessment

✅ Low: The change is a well-bounded, documented flag swap with all colocated tests updated consistently, the previous model-gate finding fixed exactly as prescribed, and no remaining stale references or intent contradictions.

## Testing

Verified the launch-template change end-to-end: reviewed the diff, grepped the tree for the old flag (only deliberately-unchanged guards/recipes remain), ran the three edited suites plus the documentation-audiences suite and doc-audience check (all pass; the one secondmate failure is the documented pre-existing config-push timing test, reproduced identically at base commit 03bb1d8), and demonstrated the end-user behavior live on this host (uid 0, Claude Code 2.1.235): --dangerously-skip-permissions is refused with a clean env, while --permission-mode auto launches as root and completes a turn; the refusal only vanishes when the undocumented IS_SANDBOX marker is ambient, which fleet panes lack. The exact command the fleet types into a pane (canonical no-profile launch and model/effort threading) is pinned by the passing dispatch-profile suite. No actionable findings beyond the documented pre-existing failure.

<details>
<summary>Evidence: Live root launch probes transcript (refusal + auto acceptance, Claude Code 2.1.235)</summary>

Source: [Live root launch probes transcript (refusal + auto acceptance, Claude Code 2.1.235)](https://github.com/alvarodecamps/firstmate/blob/1204fa3e7e52bf8afed1470c9a9f9a9b713a7397/.no-mistakes/evidence/fm/fm-claude-auto-permission-mode/root-launch-probes.txt)

```text
Live probes on this host (uid 0, Claude Code 2.1.235), run by the test phase.

1) The old flag is refused under root with a clean env (the bug being fixed):

$ env -i HOME=/root PATH="$PATH" claude --dangerously-skip-permissions -p 'reply with the single word OK' --model claude-haiku-4-5-20251001
--dangerously-skip-permissions cannot be used with root/sudo privileges for security reasons

Note: the refusal did NOT fire while the ambient session env carried the
IS_SANDBOX=1 marker (the undocumented workaround upstream PR 2455 held);
fleet launch panes do not have that marker, and the refusal reproduced with
it removed. This matches the record in docs/verification/claude.md (2.1.234).

2) The new flag is accepted as root and the session runs:

$ env -u IS_SANDBOX ... claude --permission-mode auto -p 'reply with the single word OK' --model claude-fable-5
OK   (exit 0)

3) The classifier rule lists are queryable, as the harness-adapters skill
states: `claude auto-mode defaults` prints the allow/block JSON.

4) The exact command the fleet types into a pane, pinned by
tests/fm-spawn-dispatch-profile.test.sh (canonical no-profile launch):

env -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --permission-mode auto "$(<fm-operational-input.sh> encode launch-brief < brief.md)"

and with profile model/effort threading:
claude --permission-mode auto --model 'sonnet' --effort 'high'
```
</details>
<details>
<summary>Evidence: fm-secondmate-harness suite log (C3/C4 ok, pre-existing failure)</summary>

Source: [fm-secondmate-harness suite log (C3/C4 ok, pre-existing failure)](https://github.com/alvarodecamps/firstmate/blob/1204fa3e7e52bf8afed1470c9a9f9a9b713a7397/.no-mistakes/evidence/fm/fm-claude-auto-permission-mode/secondmate-suite.log)

```text
ok - A1 fm-harness.sh secondmate resolves the fallback chain; crew mode unchanged
ok - fm-harness detects only Cursor Agent CLI's exact invocation marker
ok - C1 fm-harness.sh secondmate-model/secondmate-effort resolve the optional tokens; bare harness stays empty (backward-compat)
ok - pi-signed identity: authoritative launch selection distinguishes shared wrapper ancestry
ok - harness identity: dash-leading ps command names are basename operands, not options
ok - B1 propagate_inheritable_config: copy, idempotence, convergence, absence-mirror, exclusion, no-op, skip diagnostics
ok - B2 spawn: secondmate runs the secondmate harness; its home inherits declared config
ok - B3 spawn: an absent secondmate-harness falls back to the crew harness (backward-compat)
ok - B4 spawn: no config at all -> own harness and no propagation side effects
ok - B5 spawn: an explicit per-spawn harness arg overrides config/secondmate-harness
ok - B6 spawn: an unverified resolved secondmate harness is refused (guard intact)
skip: cursor executable not resolvable in this environment, so the launch could not be built
ok - B5b spawn: FM_BACKEND wins over inherited config/backend
ok - B5c spawn: explicit --backend wins over FM_BACKEND and inherited config/backend
ok - C2 spawn: a bare harness-only secondmate-harness file launches with no model/effort flag (backward-compat)
ok - C3 spawn: config/secondmate-harness's model token threads --model into the launch and meta
ok - C4 spawn: config/secondmate-harness's model+effort tokens thread into the launch and meta
ok - C5 spawn: an explicit --model overrides config/secondmate-harness's model token; the file's effort token still applies
ok - C6 spawn: an explicit --effort overrides config/secondmate-harness's effort token; the file's model token still applies
ok - C7 spawn: an explicit --harness starts with clean model/effort defaults
ok - C8 spawn: an explicit --harness still honors explicit model/effort flags
ok - C9 spawn: secondmate launch pins supervision to its own harness
ok - C9 spawn: the harness fallback chain still resolves with no tokens; crew/scout launches are unaffected by this feature
ok - B7 bootstrap sweep pushes, re-converges, and mirrors absence; never inherits secondmate-harness
ok - B8 bootstrap sweep propagates config even when the home's tracked files are already current
ok - B9 bootstrap sweep defers new inherited config until the home ignores it
ok - B10 bootstrap sweep materializes and inherits the startup-memory default while fast-forwarding
ok - B12b backend inheritance: present values and primary absence converge exactly
ok - B12c presentation inheritance: the primary default converges on, and only an explicit opt-out propagates off
ok - B11 bootstrap sweep surfaces config propagation failures
ok - B11 bootstrap rereads completed config writes after partial propagation
ok - B12 config-push propagates via shared live discovery, reports items, rereads on change only, and does not fast-forward
ok - B13 config-push reports dirty, non-allowing, and invalid homes without failing warnings-only runs
ok - B14 config-push exits nonzero on real propagation errors
ok - B14 config-push rereads completed config writes after partial propagation
ok - B15 config reread is per-home, exact-byte, ordered, and pointer-only
ok - B16 config reread isolation, ABSENT, generation safety, send failure, and retry
ok - B20 config reread publication failures retain exact generations for retry
ok - B21 config reread instruction-write failures retain exact retry generations
ok - B21 config reread preserves exact bytes when temporary adoption also fails
not ok - first config push did not reach pointer delivery
```
</details>
<details>
<summary>Evidence: fm-backend-orca suite log (51 ok, exit 0)</summary>

Source: [fm-backend-orca suite log (51 ok, exit 0)](https://github.com/alvarodecamps/firstmate/blob/1204fa3e7e52bf8afed1470c9a9f9a9b713a7397/.no-mistakes/evidence/fm/fm-claude-auto-permission-mode/orca-suite.log)

```text
ok - fm_backend_orca_capture: parses result.terminal.tail and calls terminal read
ok - fm_backend_orca_capture: falls back to result text fields
ok - fm_backend_orca_capture: fails closed on Orca read error JSON
ok - fm_backend_orca_runtime_check: accepts reachable ready runtime
ok - fm_backend_orca_runtime_check: fails closed when runtime is not ready
ok - fm_backend_orca_send_text_submit: verifies empty composer after Enter with one bounded read
ok - fm_backend_orca_send_text_submit: a borderless claude composer confirms delivery (the missing #2029 shape)
ok - fm_backend_orca_composer_state: a stale startup banner cannot outrank the live composer row
ok - fm_backend_orca_send_text_submit: retries Enter while composer remains pending
ok - fm_backend_orca_composer_state: a slash-command popup's argument-hint placeholder still reads pending
ok - fm_backend_orca_composer_state: a bare dead-shell prompt reads unknown (unsafe-for-injection), never empty
ok - fm_backend_orca_send_text_submit: a slash-command popup's placeholder fill on Enter #1 does not short-circuit as submitted; Enter #2 is retried and lands it
ok - fm_backend_orca_send_literal: sends text without submitting
ok - fm_backend_orca_send_text_submit: reports send-failed when Orca send fails
ok - Orca send helpers: fail closed on ok:false JSON
ok - fm_backend_orca_send_key: Enter maps to empty enter, C-c maps to interrupt
ok - fm_backend_orca_send_key: refuses unsupported keys loudly
ok - fm_backend_orca_send_key: refuses Escape instead of mapping it to interrupt
ok - fm_backend_orca_kill: calls terminal close and stays best-effort
ok - fm_backend_orca_remove_worktree: refuses empty worktree ids
ok - fm_backend_orca_remove_worktree: fails closed on ok:false JSON
ok - fm_backend_orca_worktree_path: resolves an Orca worktree id to its path
ok - fm-backend dispatcher: accepts orca and routes capture through bin/backends/orca.sh
ok - fm_backend_orca_json_get: ignores undocumented terminal id shapes
ok - Orca lifecycle helpers: register repo, create worktree, create terminal, parse stable ids
ok - fm_backend_orca_worktree_create: removes created worktree when path is missing
ok - fm-spawn.sh --backend orca: preserves metadata when pathless cleanup fails
ok - fm-spawn.sh --backend orca: reuses implicit terminal, records metadata, launches harness
ok - fm-spawn.sh --backend orca --secondmate: refuses before secondmate-home mutation
ok - fm-spawn.sh --backend orca: refuses before mutation when Orca runtime is not ready
ok - fm-spawn.sh --backend orca: refuses non-isolated worktrees and closes implicit terminals
ok - fm-spawn.sh --backend orca: removes worktree when terminal creation fails
ok - fm-spawn.sh --backend orca: preserves metadata when abort cleanup fails
ok - fm-spawn.sh --backend orca: releases terminal and worktree on later aborts
error: text not submitted to term-io (delivery unconfirmed; verdict=unknown; tried meta=/tmp/fm-backend-orca-tests.jO8tP5/io-state/orcaiopathz2.meta; backend=from-meta)
ok - fm-peek/fm-send/fm-crew-state route through backend=orca metadata
ok - fm-peek/fm-crew-state: Orca read error JSON fails closed
ok - fm_backend_target_exists: Orca ok:false read JSON is not live
ok - fm-teardown.sh backend=orca: scout report gate then helper-backed worktree removal
ok - fm-teardown.sh backend=orca: scout teardown refuses id/path mismatches
ok - fm-teardown.sh backend=orca: releases terminal/worktree when path is absent
ok - fm-teardown.sh backend=orca: preserves metadata on remove ok:false JSON
ok - fm-teardown.sh backend=orca: scout report gate precedes pathless helper cleanup
ok - fm-teardown.sh backend=orca: ship teardown fails closed when worktree path is missing
ok - fm-teardown.sh backend=orca: ship teardown requires a matching Orca id path
ok - fm-teardown.sh backend=orca: ship teardown fails closed when id resolution fails
ok - fm-teardown.sh backend=orca: ship teardown refuses id/path mismatches
ok - fm-teardown.sh backend=orca: refuses missing worktree ids before cleanup
ok - fm-teardown.sh backend=orca: refuses incomplete worktree-only endpoint metadata before runtime dispatch
ok - fm-teardown.sh --force: removes Orca secondmate children through Orca
ok - fm-teardown.sh --force: refuses Orca child id/path mismatches
ok - fm-teardown.sh --force: refuses partial Orca secondmate children before runtime dispatch
```
</details>
<details>
<summary>Evidence: Base-commit snapshot secondmate suite log (same pre-existing failure)</summary>

Source: [Base-commit snapshot secondmate suite log (same pre-existing failure)](https://github.com/alvarodecamps/firstmate/blob/1204fa3e7e52bf8afed1470c9a9f9a9b713a7397/.no-mistakes/evidence/fm/fm-claude-auto-permission-mode/secondmate-base-suite.log)

```text
ok - A1 fm-harness.sh secondmate resolves the fallback chain; crew mode unchanged
ok - fm-harness detects only Cursor Agent CLI's exact invocation marker
ok - C1 fm-harness.sh secondmate-model/secondmate-effort resolve the optional tokens; bare harness stays empty (backward-compat)
ok - pi-signed identity: authoritative launch selection distinguishes shared wrapper ancestry
ok - harness identity: dash-leading ps command names are basename operands, not options
ok - B1 propagate_inheritable_config: copy, idempotence, convergence, absence-mirror, exclusion, no-op, skip diagnostics
ok - B2 spawn: secondmate runs the secondmate harness; its home inherits declared config
ok - B3 spawn: an absent secondmate-harness falls back to the crew harness (backward-compat)
ok - B4 spawn: no config at all -> own harness and no propagation side effects
ok - B5 spawn: an explicit per-spawn harness arg overrides config/secondmate-harness
ok - B6 spawn: an unverified resolved secondmate harness is refused (guard intact)
skip: cursor executable not resolvable in this environment, so the launch could not be built
ok - B5b spawn: FM_BACKEND wins over inherited config/backend
ok - B5c spawn: explicit --backend wins over FM_BACKEND and inherited config/backend
ok - C2 spawn: a bare harness-only secondmate-harness file launches with no model/effort flag (backward-compat)
ok - C3 spawn: config/secondmate-harness's model token threads --model into the launch and meta
ok - C4 spawn: config/secondmate-harness's model+effort tokens thread into the launch and meta
ok - C5 spawn: an explicit --model overrides config/secondmate-harness's model token; the file's effort token still applies
ok - C6 spawn: an explicit --effort overrides config/secondmate-harness's effort token; the file's model token still applies
ok - C7 spawn: an explicit --harness starts with clean model/effort defaults
ok - C8 spawn: an explicit --harness still honors explicit model/effort flags
ok - C9 spawn: secondmate launch pins supervision to its own harness
ok - C9 spawn: the harness fallback chain still resolves with no tokens; crew/scout launches are unaffected by this feature
ok - B7 bootstrap sweep pushes, re-converges, and mirrors absence; never inherits secondmate-harness
ok - B8 bootstrap sweep propagates config even when the home's tracked files are already current
ok - B9 bootstrap sweep defers new inherited config until the home ignores it
ok - B10 bootstrap sweep materializes and inherits the startup-memory default while fast-forwarding
ok - B12b backend inheritance: present values and primary absence converge exactly
ok - B12c presentation inheritance: the primary default converges on, and only an explicit opt-out propagates off
ok - B11 bootstrap sweep surfaces config propagation failures
ok - B11 bootstrap rereads completed config writes after partial propagation
ok - B12 config-push propagates via shared live discovery, reports items, rereads on change only, and does not fast-forward
ok - B13 config-push reports dirty, non-allowing, and invalid homes without failing warnings-only runs
ok - B14 config-push exits nonzero on real propagation errors
ok - B14 config-push rereads completed config writes after partial propagation
ok - B15 config reread is per-home, exact-byte, ordered, and pointer-only
ok - B16 config reread isolation, ABSENT, generation safety, send failure, and retry
ok - B20 config reread publication failures retain exact generations for retry
ok - B21 config reread instruction-write failures retain exact retry generations
ok - B21 config reread preserves exact bytes when temporary adoption also fails
not ok - first config push did not reach pointer delivery
```
</details>
- Outcome: ⚠️ 1 info across 1 run (11m21s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"e6750c0051bfdfd38435b2313ad8b925311c8133","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `docs/examples/crew-dispatch.json:10` - docs/examples/crew-dispatch.json:10 pins {&#34;harness&#34;: &#34;claude&#34;, &#34;model&#34;: &#34;haiku&#34;, &#34;effort&#34;: &#34;low&#34;} as a copyable dispatch profile. Under the new `--permission-mode auto` launch, this change&#39;s own verification record (docs/verification/claude.md:46-50) proves Haiku 4.5 starts silently in Manual mode (`auto mode unavailable for this model`) and parks on its first permission prompt — the exact model-gate failure the change documents (&#39;a claude dispatch profile ... must name an auto-capable model&#39;). The example is intended to be copied by crews, and its stated purpose (unattended cheapest-fast profile) no longer holds. Suggest updating the example&#39;s claude model to an auto-capable one or annotating the auto-mode constraint in the example.

🔧 Fix: Fix crew-dispatch example claude profile to auto-capable sonnet-5
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `tests/fm-secondmate-harness.test.sh:2127` - tests/fm-secondmate-harness.test.sh exits 1 on test_config_reread_serializes_concurrent_pushes (&#39;first config push did not reach pointer delivery&#39;, a 2s timing wait on fm-config-push.sh). Proven pre-existing and unrelated: the identical failure (39 ok, same not ok line) reproduces at base commit 03bb1d8 in a scratch snapshot; the test exercises config-push concurrency, not the claude launch template. Documented in the author&#39;s intent; no fix needed as part of this change.
- `git diff 03bb1d8..HEAD -- bin/fm-spawn.sh tests/ docs/ reviewed template line, comment, grok reword, and test updates`
- `grep -rn 'dangerously-skip-permissions' . — old flag remains only in deliberately-unchanged live guards (fm-claude-stop-autoarm, fm-backend-herdr-smoke, fm-sessionstart-hook) and hook recipes (cd-guard, arm-pretool-check, subagent-guard)`
- `./tests/fm-spawn-dispatch-profile.test.sh — all pass incl. canonical no-profile launch line and --model/--effort threading`
- `./tests/fm-backend-orca.test.sh — exit 0, 51 ok`
- `./tests/fm-secondmate-harness.test.sh — C3/C4 pass; single failure test_config_reread_serializes_concurrent_pushes`
- `git archive 03bb1d8 | tar -x -C /tmp/nm-base-snapshot && ./tests/fm-secondmate-harness.test.sh — identical pre-existing failure at base commit`
- `./tests/fm-documentation-audiences.test.sh — pass`
- `./bin/fm-doc-audience-check.sh — ok surfaces=70 local_links=257`
- `env -i HOME=/root PATH=$PATH claude --dangerously-skip-permissions -p ... — refusal reproduced on uid 0 with Claude Code 2.1.235`
- `env -u IS_SANDBOX ... claude --permission-mode auto -p 'reply with the single word OK' --model claude-fable-5 — accepted as root, completes turn`
- `claude auto-mode defaults — prints classifier allow/block JSON as the skill documents`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
