### PR TITLE
fix(bin): report unattributable crew runs as unknown

### DIFF
--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -35,6 +35,8 @@
 #      is an ancestor of the run head (pipeline fix commits advanced the run on
 #      the same line of history). Local work that advanced past the run head, or
 #      diverged from it, invalidates attribution.
+#      A run head unavailable in the worktree's object store makes correlation
+#      unattributable and reports unknown rather than a terminal run verdict.
 #      The run-step is AUTHORITATIVE: running/fixing -> working, ci -> working,
 #      awaiting_approval/fix_review -> parked (with gate findings), terminal
 #      passed/checks-passed -> done, failed/cancelled -> failed. EXCEPT: while
@@ -384,7 +386,7 @@ nm_ci_checks_state() {
 # matching row's status word (running/completed/cancelled/failed), or empty
 # when the branch has no run within FM_CREW_STATE_RUNS_LIMIT rows.
 nm_runs_status_for_branch() {  # <branch>
-  local branch=$1 out row st rest br sha
+  local branch=$1 out row st rest br sha relationship
   out=$(nm_run runs --limit "$FM_CREW_STATE_RUNS_LIMIT")
   [ -n "$out" ] || return 0
   while IFS= read -r row; do
@@ -400,11 +402,17 @@ nm_runs_status_for_branch() {  # <branch>
     if [ "$br" = "$branch" ]; then
       # Same code-identity rule as axi status: skip a same-branch row whose
       # short-sha does not match this worktree (rewritten or advanced tip).
-      if ! nm_coarse_head_matches_worktree "$sha"; then
-        continue
-      fi
-      printf '%s' "$st"
-      return 0
+      relationship=$(nm_coarse_head_relationship "$sha")
+      case "$relationship" in
+        equal|worktree-ancestor-of-run)
+          printf '%s' "$st"
+          return 0
+          ;;
+        unresolvable-*)
+          printf 'unattributable|%s|%s' "$sha" "$relationship"
+          return 0
+          ;;
+      esac
     fi
   done <<< "$out"
   return 0
@@ -414,20 +422,38 @@ nm_runs_status_for_branch() {  # <branch>
 # scratch worktree); with no branch there is no run to attribute to this crew.
 CREW_BRANCH=$(git -C "$WT" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
 
-# 0 if the active axi-status run's head field matches this worktree's code
-# identity. Branch match is a precondition (caller). Rule owned by
-# fm_nm_head_matches_worktree in bin/fm-nm-run-lib.sh.
-nm_run_head_matches_worktree() {
+# Relationship between the active axi-status run's head field and this
+# worktree's code identity. Branch match is a precondition (caller). Rule owned
+# by fm_nm_head_relationship in bin/fm-nm-run-lib.sh.
+nm_run_head_relationship() {
   local run_head
   run_head=$(strip_quotes "$(nm_field head)")
-  fm_nm_head_matches_worktree "$WT" "$run_head"
+  fm_nm_head_relationship "$WT" "$run_head"
 }
 
-# Coarse runs-list rows are "<status> <branch> <short-sha> ...". 0 if the short
-# sha for this branch row matches the worktree head under the same rules as
-# nm_run_head_matches_worktree (equal, or local is ancestor of run tip).
-nm_coarse_head_matches_worktree() {  # <short-sha>
-  fm_nm_head_matches_worktree "$WT" "$1"
+# Coarse runs-list rows are "<status> <branch> <short-sha> ...". Return the
+# relationship between that short SHA and the worktree head under the same
+# rules as nm_run_head_relationship.
+nm_coarse_head_relationship() {  # <short-sha>
+  fm_nm_head_relationship "$WT" "$1"
+}
+
+emit_unattributable_run() {  # <run-head> <relationship>
+  local run_head=$1 relationship=$2
+  case "$relationship" in
+    unresolvable-run-head)
+      emit unknown run-step \
+        "run unattributable: run head $run_head is not present in the worktree object store; ancestry cannot be computed"
+      ;;
+    unresolvable-worktree-head)
+      emit unknown run-step \
+        "run unattributable: worktree HEAD cannot be resolved; ancestry with run head $run_head cannot be computed"
+      ;;
+    *)
+      emit unknown run-step \
+        "run unattributable: ancestry between worktree HEAD and run head $run_head cannot be computed"
+      ;;
+  esac
 }
 
 HAVE_RUN=0
@@ -443,9 +469,16 @@ if [ "$KIND" = ship ] && [ -n "$CREW_BRANCH" ] && command -v no-mistakes >/dev/n
   RUN_OUT=$(nm_run axi status)
   if [ -n "$RUN_OUT" ]; then
     run_branch=$(strip_quotes "$(nm_field branch)")
-    if [ -n "$run_branch" ] && [ "$run_branch" = "$CREW_BRANCH" ] && nm_run_head_matches_worktree; then
-      HAVE_RUN=1
-    else
+    run_head=$(strip_quotes "$(nm_field head)")
+    head_relationship=missing-run-head
+    if [ -n "$run_branch" ] && [ "$run_branch" = "$CREW_BRANCH" ]; then
+      head_relationship=$(nm_run_head_relationship)
+      case "$head_relationship" in
+        equal|worktree-ancestor-of-run) HAVE_RUN=1 ;;
+        unresolvable-*) emit_unattributable_run "$run_head" "$head_relationship" ;;
+      esac
+    fi
+    if [ "$HAVE_RUN" = 0 ]; then
       # The active-or-most-recent run is for another branch, or same branch with
       # a rewritten/diverged head (the CLI is alive and answered; only the
       # attribution missed) - try the coarse fallback.
@@ -454,10 +487,19 @@ if [ "$KIND" = ship ] && [ -n "$CREW_BRANCH" ] && command -v no-mistakes >/dev/n
       # immediately with a second bounded call would just double the wait
       # for no better answer.
       COARSE_STATUS=$(nm_runs_status_for_branch "$CREW_BRANCH")
-      if [ -n "$COARSE_STATUS" ]; then
-        HAVE_RUN=1
-        RUN_SOURCE=coarse
-      fi
+      case "$COARSE_STATUS" in
+        unattributable\|*)
+          coarse_unattributable=${COARSE_STATUS#*|}
+          coarse_head=${coarse_unattributable%%|*}
+          coarse_relationship=${coarse_unattributable#*|}
+          emit_unattributable_run "$coarse_head" "$coarse_relationship"
+          ;;
+        '') ;;
+        *)
+          HAVE_RUN=1
+          RUN_SOURCE=coarse
+          ;;
+      esac
     fi
   fi
 fi

--- a/bin/fm-nm-run-lib.sh
+++ b/bin/fm-nm-run-lib.sh
@@ -55,19 +55,42 @@ fm_nm_field() {  # <toon-output> <key>
   printf '%s\n' "$1" | sed -n "s/^[[:space:]]*$2:[[:space:]]*\(.*\)/\1/p" | head -1
 }
 
-# 0 if run head $2 matches worktree $1's code identity, per the same rule
-# everywhere this attribution is needed:
+# Relationship between run head $2 and worktree $1's code identity.
+# The result distinguishes an ordinary mismatch from a relationship that Git
+# cannot compute because an object is unavailable:
 #   - missing/empty head: cannot bind; reject
 #   - equal commits (short or full SHA): match
 #   - worktree HEAD is an ancestor of run head: match (pipeline fix commits on
 #     the same history advanced the run tip past local HEAD)
 #   - run head is a strict ancestor of worktree HEAD, or diverged: no match
 #     (local work advanced outside the run, or the branch tip was rewritten)
-fm_nm_head_matches_worktree() {  # <worktree> <run_head>
-  local wt=$1 run_head=$2 local_full run_full
-  [ -n "$run_head" ] || return 1
-  local_full=$(git -C "$wt" rev-parse HEAD 2>/dev/null) || return 1
-  run_full=$(git -C "$wt" rev-parse --verify "${run_head}^{commit}" 2>/dev/null) || return 1
-  [ "$run_full" = "$local_full" ] && return 0
+#   - an unavailable head or an ancestry error: unresolvable, not a mismatch
+fm_nm_head_relationship() {  # <worktree> <run_head>
+  local wt=$1 run_head=$2 local_full run_full rc
+  [ -n "$run_head" ] || { printf 'missing-run-head'; return 0; }
+  local_full=$(git -C "$wt" rev-parse HEAD 2>/dev/null) \
+    || { printf 'unresolvable-worktree-head'; return 0; }
+  run_full=$(git -C "$wt" rev-parse --verify "${run_head}^{commit}" 2>/dev/null) \
+    || { printf 'unresolvable-run-head'; return 0; }
+  if [ "$run_full" = "$local_full" ]; then
+    printf 'equal'
+    return 0
+  fi
   git -C "$wt" merge-base --is-ancestor "$local_full" "$run_full" 2>/dev/null
+  rc=$?
+  case "$rc" in
+    0) printf 'worktree-ancestor-of-run' ;;
+    1) printf 'mismatch' ;;
+    *) printf 'unresolvable-ancestry' ;;
+  esac
+}
+
+# 0 only when fm_nm_head_relationship reports one of the two matching
+# relations. Callers that need to distinguish mismatch from an unavailable
+# object read fm_nm_head_relationship directly.
+fm_nm_head_matches_worktree() {  # <worktree> <run_head>
+  case "$(fm_nm_head_relationship "$1" "$2")" in
+    equal|worktree-ancestor-of-run) return 0 ;;
+    *) return 1 ;;
+  esac
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,10 +42,11 @@ This home's answerer close, pending-reply escalation close, and captain-held tra
 A turn-ended-only queue row omits its historical status annotation when that status file exactly matches the same seen marker.
 Any direct or remaining historical annotation prints every status line unread at the presentation cursor instead of replaying only the latest line.
 `bin/fm-crew-state.sh <id>` is the cheap current-state read for an actionable heartbeat review: it attributes a no-mistakes run, active or terminal, only when it matches the crew's branch and current code identity, then keeps that run-step authoritative even if the pane has closed.
+A same-branch run whose code-identity relationship cannot be computed reports `unknown` from `run-step` with an unattributable detail instead of a terminal verdict, and the script does not fall through to an older run.
 The script header owns the exact run-head ancestry rules.
 During no-mistakes' `ci` monitor phase, it also reads the ci step log tail because `axi status` reports both "still waiting on checks" and "checks green, waiting on merge" as `ci,running`.
 The most recent recognized ci log marker wins, so checks-green monitoring reports done while a later re-arm, failed-check, or issue marker returns the crew to working.
-Only when no matching run exists does it consult semantic busy state; exact busy reports working, exact idle permits fallback to a status-log event whose verb maps to a recognized run-state, and unknown or a dead pane stays unknown instead of trusting a stale log.
+Only when no matching or unattributable run exists does it consult semantic busy state; exact busy reports working, exact idle permits fallback to a status-log event whose verb maps to a recognized run-state, and unknown or a dead pane stays unknown instead of trusting a stale log.
 Decision-only events such as `resolved` never become current state or leak their prose into the current-state detail.
 In that status-log fallback, a declared external wait reports the distinct `paused` state with its reason.
 The semantic branch reports working only on an exact busy verdict and names the source that produced it; an unknown verdict never becomes working, never permits the status-log fallback, and never becomes a silent idle.

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -681,6 +681,8 @@ test_terminal_failed() {
   local out; out=$(run_crew_state "$d" feat-e)
   assert_contains "$out" "state: failed" "failed run -> failed"
   assert_contains "$out" "source: run-step" "failed -> run-step source"
+  assert_contains "$out" "run failed" "failed run preserves its terminal detail"
+  assert_not_contains "$out" "unattributable" "genuine failure is not an attribution refusal"
   pass "terminal failed run is authoritative"
 }
 
@@ -1367,6 +1369,73 @@ test_active_run_descendant_fix_head_remains_current() {
   pass "active run with valid descendant fix head remains current"
 }
 
+# The pipeline owns fix-round commits before they are present in the crew
+# worktree's object store. An unresolvable live run must stop attribution at
+# that newest same-branch row instead of falling through to an older terminal
+# run whose head happens to remain resolvable.
+test_absent_active_run_head_is_unattributable() {
+  reset_fakes
+  local d local_short missing_head out
+  d=$(new_case absent-active-run-head)
+  make_repo_on_branch "$d/wt" fm/feat-unattributable
+  local_short=$(git -C "$d/wt" rev-parse --short=7 HEAD)
+  missing_head=ffffffffffffffffffffffffffffffffffffffff
+  git -C "$d/wt" cat-file -e "${missing_head}^{commit}" 2>/dev/null \
+    && fail "absent-object fixture unexpectedly resolved"
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/unattributable.meta" \
+    "window=fm:fm-unattributable" \
+    "worktree=$d/wt" \
+    "kind=ship"
+  FM_FAKE_RUN_HEAD=$missing_head
+  FM_FAKE_AXI_STATUS="$(run_running fm/feat-unattributable)"
+  FM_FAKE_RUNS_LIST="$(cat <<EOF
+  running    fm/feat-unattributable ${missing_head:0:7}  2026-08-14 12:00
+  failed     fm/feat-unattributable ${local_short}  2026-08-14 11:00
+EOF
+)"
+  out=$(run_crew_state "$d" unattributable)
+  assert_contains "$out" "state: unknown" "absent active run head -> unknown"
+  assert_contains "$out" "source: run-step" "unattributable run remains the reported source"
+  assert_contains "$out" "run head ${missing_head} is not present" \
+    "unattributable detail names the unresolved run head"
+  assert_contains "$out" "ancestry cannot be computed" \
+    "unattributable detail names the unavailable relationship"
+  assert_not_contains "$out" "state: failed" \
+    "an attribution refusal must never become a terminal failure"
+  pass "absent active run head is unknown and unattributable"
+}
+
+test_absent_runs_list_head_is_unattributable() {
+  reset_fakes
+  local d local_short missing_head out
+  d=$(new_case absent-runs-list-head)
+  make_repo_on_branch "$d/wt" fm/feat-unattributable-list
+  local_short=$(git -C "$d/wt" rev-parse --short=7 HEAD)
+  missing_head=eeeeeee
+  git -C "$d/wt" cat-file -e "${missing_head}^{commit}" 2>/dev/null \
+    && fail "absent runs-list fixture unexpectedly resolved"
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/unattributable-list.meta" \
+    "window=fm:fm-unattributable-list" \
+    "worktree=$d/wt" \
+    "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)"
+  FM_FAKE_RUNS_LIST="$(cat <<EOF
+  running    fm/other-crew aaaaaaa  2026-08-14 12:05
+  running    fm/feat-unattributable-list ${missing_head}  2026-08-14 12:00
+  failed     fm/feat-unattributable-list ${local_short}  2026-08-14 11:00
+EOF
+)"
+  out=$(run_crew_state "$d" unattributable-list)
+  assert_contains "$out" "state: unknown" "absent runs-list head -> unknown"
+  assert_contains "$out" "run head ${missing_head} is not present" \
+    "runs-list refusal names the unresolved run head"
+  assert_not_contains "$out" "state: failed" \
+    "runs-list refusal must not fall through to an older terminal run"
+  pass "absent runs-list head is unknown and unattributable"
+}
+
 # Head-binding: local work that advanced past the run head invalidates the run.
 test_local_advanced_past_run_head_invalidates() {
   reset_fakes
@@ -1459,6 +1528,8 @@ test_not_provably_working_when_stopped
 test_usage_error
 test_historical_same_branch_rewritten_head_not_current
 test_active_run_descendant_fix_head_remains_current
+test_absent_active_run_head_is_unattributable
+test_absent_runs_list_head_is_unattributable
 test_local_advanced_past_run_head_invalidates
 test_missing_run_head_falls_back_to_current_state
 


### PR DESCRIPTION
## Intent

Fix the P1 fleet-state bug in upstream issue 2403 using the corrected verified analysis from issue comment 5299274609: a live no-mistakes run head may be absent from the crew worktree object store because fix-round commits are held in pipeline custody, so equality and ancestry cannot be computed. Declining attribution is correct, but fm-crew-state must report a distinct explicit unknown or unattributable verdict naming what could not be computed, never a terminal failed verdict. Genuine failed and cancelled runs whose heads can be attributed must remain failed. Follow the Firstmate shared tracked material coding guidelines and keep the change narrow. Use TDD with colocated executable behavior tests reproducing an absent run-head object and preserving a genuine failed-run regression, keep ShellCheck clean, and follow watcher classification, inactive reconciliation, fleet or session-start wording consumers so the unknown verdict remains sensible without expanding scope. Rebase before opening the PR because fm-bootstrap-missing-grade is concurrently changing bin/fm-bootstrap.sh. Drive no-mistakes through a PR with CI green, then post a PR comment containing exactly @codex review.

## What Changed

- Classify unresolved run-head relationships as `unknown` and explicitly report why crew-state attribution could not be computed.
- Prevent same-branch unattributable runs from falling through to older terminal results while preserving attributable failed and cancelled verdicts.
- Add executable regressions for absent active and runs-list head objects, plus architecture documentation for the attribution contract.

## Risk Assessment

✅ Low: Captain, the narrow change correctly distinguishes unavailable Git objects from ancestry mismatches, preserves attributable failed and cancelled outcomes, and keeps downstream unknown-state handling non-terminal.

## Testing

The supplied base reproduced the false terminal `failed` verdict, while target 71879b5 emits an explicit unattributable `unknown` verdict and preserves attributable failed runs as `failed`. Focused crew-state, watcher, inactive-reconciliation, fleet-view, and session-start behavior suites passed. Because this is a CLI-only change, reviewer-visible evidence is a CLI transcript rather than an image. Per the assigned test-phase rules, no lint or static-analysis commands were run.

<details>
<summary>Evidence: Fleet-state CLI verdict transcript</summary>

Source: [Fleet-state CLI verdict transcript](https://github.com/twilwa/firstmate/blob/8511a4a7f529f6248e9295edbc427cf25cdbce05/.no-mistakes/evidence/fm/fm-crew-state-stale-run/fm-crew-state-verdicts.txt)

<code>Scenario: live run head is absent from the crew worktree object store&#10;state: unknown · source: run-step · run unattributable: run head ffffffffffffffffffffffffffffffffffffffff is not present in the worktree object store; ancestry cannot be computed&#10;&#10;Scenario: terminal failed run head is attributable to the crew worktree&#10;state: failed · source: run-step · run failed</code>

```text
Scenario: live run head is absent from the crew worktree object store
state: unknown · source: run-step · run unattributable: run head ffffffffffffffffffffffffffffffffffffffff is not present in the worktree object store; ancestry cannot be computed

Scenario: terminal failed run head is attributable to the crew worktree
state: failed · source: run-step · run failed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"ff7ec90d794056f27a1dadebdfdeeb7dbf7f4073","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git merge-base --is-ancestor 03bb1d8b78a8632ae2d9cea4c10868eb100e885e 71879b5cb11018952d747fde50f3a743e05a2d87`
- `bash tests/fm-crew-state.test.sh`
- <code>`bash .fm-crew-state-evidence.sh &#34;$PWD/.nm-base-replay.lXhcEN&#34;` (base regression replay)</code>
- `bash .fm-crew-state-evidence.sh "$PWD" | tee /var/folders/px/0dyr9zns1jl9gmz_1sxcqyd80000gn/T/no-mistakes-evidence/01M0BHCXAWDRR7NYYBEGJ5NXS2/fm-crew-state-verdicts.txt`
- `bash tests/fm-watch-triage.test.sh`
- `bash tests/fm-inactive-reconcile.test.sh`
- `bash tests/fm-fleet-snapshot-view.test.sh`
- `bash tests/fm-session-start.test.sh`
- `git status --short --branch`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

🔧 Fix: Verify lint passes with pinned toolchain
1 warning still open:
- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
