### PR TITLE
fix(bin): stop passing document-sized JSON to jq through argv

### DIFF
--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -69,6 +69,9 @@ FLEET="$SCRIPT_DIR/fm-fleet-snapshot.sh"
 # shellcheck source=bin/fm-timeout-lib.sh
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/fm-timeout-lib.sh"
+# shellcheck source=bin/fm-jq-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-jq-lib.sh"  # fm_jq_docs: document-sized JSON never goes through argv
 
 # Bounds (overridable for tests / large fleets).
 FM_BEARINGS_LANDED=${FM_BEARINGS_LANDED:-6}
@@ -258,7 +261,8 @@ EOF
       cnt=$(printf '%s' "$repo_rows" | jq 'length')
       [ "$returned" -gt "$FM_BEARINGS_PR_LIMIT" ] && ncapped=$((ncapped + 1))
       npr=$((npr + cnt))
-      rows=$(jq -n --argjson a "$rows" --argjson b "$repo_rows" '$a + $b')
+      # shellcheck disable=SC2016 # The filter's $ bindings belong to jq, not the shell.
+      rows=$(fm_jq_docs a "$rows" b "$repo_rows" -- -n '$a + $b')
     done
     PR_REPOS_SHOWN=$nrepos
     PR_ROWS_CAPPED=$ncapped
@@ -282,7 +286,11 @@ case "$BEARINGS_TODAY" in
   [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]) : ;;
   *) BEARINGS_TODAY=$(date -u +%Y-%m-%d) ;;
 esac
-MODEL=$(printf '%s' "$SNAP" | jq \
+# The canonical snapshot and the discovered PR rows are both content-sized, so
+# both reach jq through fm_jq_docs rather than argv or a second stdin; the filter
+# opens with `$snap |` so its body still reads the snapshot as `.`.
+# shellcheck disable=SC2016 # The filter's $ bindings belong to jq, not the shell.
+MODEL=$(fm_jq_docs snap "$SNAP" candidate_prs "$CANDIDATE_PRS" -- -n \
   --arg home "$HOME_LABEL" \
   --arg now "$NOW" \
   --arg today "$BEARINGS_TODAY" \
@@ -309,8 +317,8 @@ MODEL=$(printf '%s' "$SNAP" | jq \
   --argjson pr_repos_total "$PR_REPOS_TOTAL" \
   --argjson pr_repos_shown "$PR_REPOS_SHOWN" \
   --argjson pr_rows_capped "$PR_ROWS_CAPPED" \
-  --argjson pr_rows_min_total "$PR_ROWS_MIN_TOTAL" \
-  --argjson candidate_prs "$CANDIDATE_PRS" '
+  --argjson pr_rows_min_total "$PR_ROWS_MIN_TOTAL" '
+  $snap |
   def trunc($n): if . == null then null else
     (tostring | gsub("\\s+"; " ") | if (length > $n) then (.[:$n] + "…") else . end) end;
   def round_robin_landed($n):

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -155,6 +155,9 @@ validate_positive_bound FM_SNAPSHOT_REGISTRY_TIMEOUT "$FM_SNAPSHOT_REGISTRY_TIME
 # shellcheck source=bin/fm-timeout-lib.sh
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/fm-timeout-lib.sh"  # fm_run_timed: the shared hard bound
+# shellcheck source=bin/fm-jq-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-jq-lib.sh"  # fm_jq_docs: document-sized JSON never goes through argv
 
 usage() {
   cat <<'EOF'
@@ -552,7 +555,9 @@ task_json_lines() {
       home_json=$(jq -n '{path:null,present:false}')
     fi
 
-    jq -n \
+    # shellcheck disable=SC2016 # The filter's $ bindings belong to jq, not the shell.
+    fm_jq_docs current_state "$current_json" status_log "$status_json" \
+      open_decisions "$open_decisions_json" -- -n \
       --arg id "$id" \
       --arg kind "$kind" \
       --arg harness "$harness" \
@@ -571,14 +576,11 @@ task_json_lines() {
       --arg agent_alive "$agent_alive" \
       --arg observed_at "$SNAPSHOT_NOW" \
       --arg last_event_raw "$last_event_raw" \
-      --argjson current_state "$current_json" \
       --argjson meta_path "$meta_json" \
-      --argjson status_log "$status_json" \
       --argjson report "$report_json" \
       --argjson worktree_path "$worktree_json" \
       --argjson home_path "$home_json" \
       --argjson endpoint_exists "$endpoint_exists" \
-      --argjson open_decisions "$open_decisions_json" \
       --argjson pending_decision "$(bool_json "$pending_decision")" \
       --argjson blocked_event "$(bool_json "$blocked_event")" \
       --argjson report_present "$(bool_json "$report_present")" \
@@ -632,9 +634,8 @@ task_json_lines() {
 # Meta inventory remains the sole source of live workers; this object only
 # discloses backlog↔task inconsistency for renderers (Bearings omitted/gates).
 main_inventory_json() {  # <backlog-json> <tasks-json>
-  jq -n \
-    --argjson backlog "$1" \
-    --argjson tasks "$2" '
+  # shellcheck disable=SC2016 # The filter's $ bindings belong to jq, not the shell.
+  fm_jq_docs backlog "$1" tasks "$2" -- -n '
     ([ $backlog.records[]?
        | select((.state == "in_flight" or .state == "queued") and (.structured | not)) ]) as $unstructured_current
     | ([ $backlog.records[]?
@@ -660,15 +661,14 @@ main_inventory_json() {  # <backlog-json> <tasks-json>
 # This mode never reads parent events or terminal text and never aggregates
 # nested secondmates.
 secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
-  jq -n \
+  # shellcheck disable=SC2016 # The filter's $ bindings belong to jq, not the shell.
+  fm_jq_docs backlog "$1" tasks "$2" -- -n \
     --arg generated "$SNAPSHOT_NOW" \
     --arg home "$FM_HOME" \
     --argjson child_n "$FM_SNAPSHOT_SECONDMATE_CHILDREN" \
     --argjson queued_n "$FM_SNAPSHOT_SECONDMATE_QUEUED" \
     --argjson decisions_n "$FM_SNAPSHOT_SECONDMATE_DECISIONS" \
-    --argjson landed_n "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" \
-    --argjson backlog "$1" \
-    --argjson tasks "$2" '
+    --argjson landed_n "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" '
     def trunc($n):
       tostring | gsub("\\s+"; " ")
       | if length > $n then .[:$n] + "…" else . end;
@@ -1079,7 +1079,8 @@ terminal_evidence_json() {  # <parent-task-json> <event-note> <evidence-contradi
 }
 
 parent_evidence_reconciliation_json() {  # <summary-json> <activities-json> <decisions-json>
-  jq -n --argjson summary "$1" --argjson activities "$2" --argjson decisions "$3" '
+  # shellcheck disable=SC2016 # The filter's $ bindings belong to jq, not the shell.
+  fm_jq_docs summary "$1" activities "$2" decisions "$3" -- -n '
     def keyed: . != null and . != "" and . != "default";
     def result($e; $matches; $complete; $surface):
       $e + {
@@ -1144,7 +1145,8 @@ secondmate_current_json() {  # <parent-tasks-json>
   local activity_scan activities decisions reconciliation provenance freshness reason summary summary_rc summary_bytes summary_valid summary_reason summary_invalidity state current_reason terminal terminal_contradiction contradiction
   local records='[]' seen_homes=''
   registry=$(registry_secondmates_json) || return 1
-  union=$(jq -n --argjson registry "$registry" --argjson tasks "$tasks" '
+  # shellcheck disable=SC2016 # The filter's $ bindings belong to jq, not the shell.
+  union=$(fm_jq_docs registry "$registry" tasks "$tasks" -- -n '
     ($registry.records // []) as $registered
     | (($registered | map(.id)) // []) as $registered_ids
     | ([ $registered[] as $r
@@ -1283,11 +1285,12 @@ secondmate_current_json() {  # <parent-tasks-json>
           '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"not-collected",reason:"no useful contradiction check",lines:0,bytes:0,event_note_seen:false,contradiction:false}')
       fi
       if printf '%s' "$terminal" | jq -e '.contradiction == true' >/dev/null; then contradiction=true; fi
-      record=$(jq -n \
+      # shellcheck disable=SC2016 # The filter's $ bindings belong to jq, not the shell.
+      record=$(fm_jq_docs summary "$summary" decisions "$decisions" activities "$activities" \
+        activity_scan "$activity_scan" reconciliation "$reconciliation" terminal "$terminal" -- -n \
         --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg state "$state" --arg current_reason "$current_reason" --arg observed "$SNAPSHOT_NOW" \
-        --argjson registered "$registered" --argjson summary "$summary" --argjson summary_valid "$summary_valid" --argjson decisions "$decisions" \
-        --argjson activities "$activities" --argjson activity_scan "$activity_scan" \
-        --argjson reconciliation "$reconciliation" --argjson terminal "$terminal" --argjson contradiction "$contradiction" \
+        --argjson registered "$registered" --argjson summary_valid "$summary_valid" \
+        --argjson contradiction "$contradiction" \
         --arg event_raw "$event_raw" --arg event_note "$event_note" --argjson event_age "$event_age" '
         {id:$id,home:$home,host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
          current:{state:$state,reason:($current_reason | if . == "" then null else . end)},invalidity:$summary.invalidity,
@@ -1313,11 +1316,12 @@ secondmate_current_json() {  # <parent-tasks-json>
         terminal=$(jq -n --arg observed "$SNAPSHOT_NOW" \
           '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"not-collected",reason:"no parent event to compare",lines:0,bytes:0,event_note_seen:false,contradiction:false}')
       fi
-      record=$(jq -n \
+      # shellcheck disable=SC2016 # The filter's $ bindings belong to jq, not the shell.
+      record=$(fm_jq_docs activities "$activities" activity_scan "$activity_scan" \
+        decisions "$decisions" terminal "$terminal" -- -n \
         --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg reason "$reason" --arg observed "$SNAPSHOT_NOW" \
         --arg provenance "$provenance" --arg freshness "$freshness" --arg event_raw "$event_raw" --arg event_note "$event_note" \
-        --argjson registered "$registered" --argjson event_age "$event_age" --argjson activities "$activities" --argjson activity_scan "$activity_scan" \
-        --argjson decisions "$decisions" --argjson terminal "$terminal" '
+        --argjson registered "$registered" --argjson event_age "$event_age" '
         {id:$id,home:($home | if . == "" then null else . end),host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
          current:{state:"unknown",reason:$reason},invalidity:null,
          provenance:{selected:$provenance,structured_home:($home | if . == "" then null else . end),parent_event_role:"fallback-only-not-current"},
@@ -1326,13 +1330,13 @@ secondmate_current_json() {  # <parent-tasks-json>
          parent_event:{raw:$event_raw,note:$event_note,age_seconds:$event_age,open_activities:$activities,open_decisions:$decisions,activity_scan:$activity_scan},
          terminal_evidence:$terminal,contradiction:false}')
     fi
-    records=$(jq -n --argjson records "$records" --argjson record "$record" '$records + [$record]')
+    # shellcheck disable=SC2016 # The filter's $ bindings belong to jq, not the shell.
+    records=$(fm_jq_docs records "$records" record "$record" -- -n '$records + [$record]')
   done <<EOF
 $rows
 EOF
-  jq -n \
-    --argjson registry "$(printf '%s' "$union" | jq '.registry')" \
-    --argjson records "$records" \
+  # shellcheck disable=SC2016 # The filter's $ bindings belong to jq, not the shell.
+  fm_jq_docs registry "$(printf '%s' "$union" | jq '.registry')" records "$records" -- -n \
     --argjson total_registered "$total_registered" \
     --argjson total "$total" \
     --argjson shown "$shown" \
@@ -1341,7 +1345,8 @@ EOF
 }
 
 secondmate_landed_from_current_json() {  # <secondmate-current-json>
-  jq -n --argjson current "$1" '
+  # shellcheck disable=SC2016 # The filter's $ bindings belong to jq, not the shell.
+  fm_jq_docs current "$1" -- -n '
     {records:[ $current.records[]
       | select(.provenance.selected == "structured-home") as $mate
       | $mate.landed[]
@@ -1390,7 +1395,10 @@ SECONDMATE_CURRENT_JSON=$(secondmate_current_json "$TASKS_JSON") \
 SECONDMATE_LANDED_JSON=$(secondmate_landed_from_current_json "$SECONDMATE_CURRENT_JSON") \
   || { echo "fm-fleet-snapshot: secondmate landed projection failed" >&2; exit 1; }
 
-jq -n \
+# shellcheck disable=SC2016 # The filter's $ bindings belong to jq, not the shell.
+fm_jq_docs backlog "$BACKLOG_JSON" tasks "$TASKS_JSON" \
+  main_inventory "$MAIN_INVENTORY_JSON" scout_reports "$SCOUT_REPORTS_JSON" \
+  secondmate_current "$SECONDMATE_CURRENT_JSON" secondmate_landed "$SECONDMATE_LANDED_JSON" -- -n \
   --arg generated "$SNAPSHOT_NOW" \
   --arg fm_home "$FM_HOME" \
   --arg fm_root "$FM_ROOT" \
@@ -1398,12 +1406,6 @@ jq -n \
   --arg data "$DATA" \
   --arg config "$CONFIG" \
   --arg projects "$PROJECTS" \
-  --argjson backlog "$BACKLOG_JSON" \
-  --argjson tasks "$TASKS_JSON" \
-  --argjson main_inventory "$MAIN_INVENTORY_JSON" \
-  --argjson scout_reports "$SCOUT_REPORTS_JSON" \
-  --argjson secondmate_current "$SECONDMATE_CURRENT_JSON" \
-  --argjson secondmate_landed "$SECONDMATE_LANDED_JSON" \
   'def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
    def task_by_id($id): ($tasks[]? | select(.id == $id) | .) // null;
    def report_kind($id): (task_by_id($id).kind // backlog_by_id($id).kind // "scout");

--- a/bin/fm-jq-lib.sh
+++ b/bin/fm-jq-lib.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# fm-jq-lib.sh - the single owner of passing document-sized JSON to jq.
+#
+# Sourced, never executed.
+#
+# jq binds --argjson and --arg values through argv, and Linux caps a SINGLE
+# argv string at MAX_ARG_STRLEN (128 KiB) independently of the far larger total
+# ARG_MAX, so a document-sized value passed that way makes jq die with E2BIG the
+# moment the document outgrows that one cap. The failure is total rather than
+# degraded: the whole command aborts, so a home whose backlog, task set, or
+# cross-home aggregate crosses the threshold loses the command entirely.
+#
+#   fm_jq_docs <name> <json> [<name> <json>]... -- <jq-arg>...
+#       Streams each document in on jq's own input and binds it to $<name>, then
+#       runs jq with the remaining arguments. The last jq argument is the filter,
+#       and this prefixes the bindings onto it, so a filter body reading
+#       $backlog is unchanged from its --argjson form. Callers pass -n, because
+#       the documents occupy jq's input stream. Exit status and stdout are jq's;
+#       a caller error returns 2 before jq runs.
+#
+# The rule this exists to hold: argv carries only values with a fixed structural
+# bound - scalars, booleans, and {path,present} objects - while every value whose
+# size follows file, log, backlog, or fleet content goes through fm_jq_docs.
+set -u
+
+fm_jq_docs() {
+  local names=() docs=() prefix='' i last args
+  while [ "$#" -gt 0 ] && [ "$1" != '--' ]; do
+    if [ "$#" -lt 2 ]; then
+      echo "fm-jq-lib: fm_jq_docs got no value for document '$1'" >&2
+      return 2
+    fi
+    names[${#names[@]}]=$1
+    docs[${#docs[@]}]=$2
+    shift 2
+  done
+  if [ "${1:-}" != '--' ] || [ "${#names[@]}" -eq 0 ] || [ "$#" -lt 2 ]; then
+    echo "fm-jq-lib: fm_jq_docs needs at least one document and -- <jq-arg>..." >&2
+    return 2
+  fi
+  shift
+  i=0
+  while [ "$i" -lt "${#names[@]}" ]; do
+    prefix="$prefix(\$fm_jq_docs[$i]) as \$${names[$i]} | "
+    i=$((i + 1))
+  done
+  args=("$@")
+  last=$((${#args[@]} - 1))
+  args[last]="[inputs] as \$fm_jq_docs | $prefix${args[last]}"
+  printf '%s\n' "${docs[@]}" | jq "${args[@]}"
+}

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -954,7 +954,8 @@ families_for_changed_path() {
       printf '%s\n' backend-dispatch
       printf '%s\n' pure-contract-unit
       ;;
-    bin/fm-bearings-snapshot.sh|bin/fm-fleet-snapshot.sh|bin/fm-fleet-view.sh)
+    bin/fm-bearings-snapshot.sh|bin/fm-fleet-snapshot.sh|bin/fm-fleet-view.sh|\
+    bin/fm-jq-lib.sh)
       printf '%s\n' snapshot-bearings
       ;;
     bin/fm-install-herdr.sh|bin/fm-install-treehouse.sh|bin/fm-herdr-ci-cleanup.sh)

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -83,6 +83,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-nm-run-lib.sh`       | Shared branch-and-code-identity attribution for no-mistakes runs                    |
 | `fm-tangle-lib.sh`       | Shared default-branch resolution and primary-checkout tangle classification          |
 | `fm-timeout-lib.sh`      | Single owner of hard-bounded command execution and its fallback watchdog |
+| `fm-jq-lib.sh`           | Single owner of handing document-sized JSON to jq without crossing the platform argv cap |
 | `fm-timing-lib.sh`       | Single owner of the deferred network stage's per-step elapsed-time records, inert unless a run asks for them |
 | `fm-supervision-lib.sh`  | Shared in-flight-work-without-fresh-watcher-beacon predicate                         |
 | `fm-ff-lib.sh`           | Shared guarded fast-forward helper for origin pulls and local secondmate syncs       |

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -216,6 +216,31 @@ EOF
 
 # This is the Domain Alpha failure shape exactly: the structured home says Phase 7 is Done
 # and no child is active, so the stale parent event must never become Underway.
+# /bearings is the captain-facing command over the canonical snapshot, so a
+# backlog whose encoding passes the platform's single-argv cap must still
+# produce a projection. Before the fix this was not a smaller report: the
+# snapshot aborted with E2BIG and bearings returned nothing at all.
+test_oversized_backlog_still_renders_bearings() {
+  local home fakebin limit expected toon json
+  limit=$(fm_argv_string_limit) || {
+    echo "skip: this platform accepts a 256 KiB argv string; the cap cannot be crossed cheaply here"
+    return 0
+  }
+  home=$(make_home oversized-backlog)
+  fakebin=$(make_fakebin "$home")
+  fm_write_oversized_backlog "$home/data/backlog.md" $((limit * 2 / 5))
+  expected=$(grep -c '^- \[ \] queued-' "$home/data/backlog.md")
+  toon=$(run "$home" "$fakebin") \
+    || fail "bearings must survive a backlog whose encoding passes the ${limit}-byte argv cap"
+  assert_contains "$toon" "schema: fm-bearings.v1" "oversized-backlog bearings lost its schema line"
+  json=$(run "$home" "$fakebin" --json --all-queued) \
+    || fail "bearings --json must survive the same oversized backlog"
+  printf '%s' "$json" | jq -e --argjson n "$expected" '
+    .schema == "fm-bearings.v1" and (.gates | length) == $n
+  ' >/dev/null || fail "oversized-backlog bearings dropped queued work: $(printf '%s' "$json" | head -c 400)"
+  pass "bearings still renders when the backlog passes the platform argv cap"
+}
+
 test_domain_alpha_stale_parent_event_does_not_become_current_work() {
   local home mate fakebin json canonical
   home=$(make_home domain-alpha-parent)
@@ -1940,6 +1965,7 @@ EOF
   pass "main and secondmate captain actionability use the same blocker readiness"
 }
 
+test_oversized_backlog_still_renders_bearings
 test_domain_alpha_stale_parent_event_does_not_become_current_work
 test_gnu_stat_uses_file_formats_without_bsd_fallback_pollution
 test_parent_activity_evidence_is_bounded_and_disclosed

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -799,8 +799,44 @@ test_parked_scout_decision_stays_pending() {
   pass "a scout still parked at a decision stays pending (terminal clear does not over-fire)"
 }
 
+# A home whose backlog outgrows the platform's single-argv cap must still get a
+# complete snapshot. The canonical JSON is what bearings and the classifier
+# consume, and the failure this guards is total rather than degraded: once the
+# encoded backlog crosses the cap, every jq call handed the whole document
+# through argv dies with E2BIG and the command produces nothing at all.
+test_oversized_backlog_survives_argv_cap() {
+  local home limit expected encoded out summary
+  limit=$(fm_argv_string_limit) || {
+    echo "skip: this platform accepts a 256 KiB argv string; the cap cannot be crossed cheaply here"
+    return 0
+  }
+  home=$(make_home oversized-backlog)
+  fm_write_oversized_backlog "$home/data/backlog.md" $((limit * 2 / 5))
+  expected=$(grep -c '^- \[ \] queued-' "$home/data/backlog.md")
+  out=$(FM_HOME="$home" "$SNAPSHOT" --json) \
+    || fail "snapshot must survive a backlog whose encoding passes the ${limit}-byte argv cap"
+  encoded=$(printf '%s' "$out" | jq -c '.backlog' | LC_ALL=C wc -c | tr -d ' ')
+  [ "$encoded" -gt "$limit" ] \
+    || fail "fixture went vacuous: encoded backlog is $encoded bytes, not past the $limit-byte cap"
+  printf '%s' "$out" | jq -e --argjson n "$expected" '
+    .schema == "fm-fleet-snapshot.v1"
+      and .backlog.present == true
+      and (.backlog.records | length) == $n
+      and ([.backlog.records[] | select(.structured)] | length) == $n
+      and .main_inventory.valid == true
+      and .main_inventory.unstructured_current_count == 0
+  ' >/dev/null || fail "oversized-backlog snapshot lost records or inventory validity"
+  summary=$(FM_HOME="$home" "$SNAPSHOT" --secondmate-home-summary) \
+    || fail "the secondmate home summary must survive the same oversized backlog"
+  printf '%s' "$summary" | jq -e --argjson n "$expected" '
+    .schema == "fm-secondmate-home-summary.v1" and (.queued | length) > 0 and (.counts.queued) == $n
+  ' >/dev/null || fail "oversized-backlog home summary is not the documented contract: $summary"
+  pass "a backlog past the platform argv cap still yields a complete snapshot and home summary"
+}
+
 test_empty_fleet_json
 test_fixture_snapshot_json
+test_oversized_backlog_survives_argv_cap
 test_main_inventory_orphan_and_unstructured_disclosure
 test_normalized_roles_and_plural_blocker_readiness
 test_event_hints_follow_reconciled_current_state

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -260,6 +260,56 @@ fm_write_secondmate_meta() {
     "projects=$projects"
 }
 
+# --- platform argv limits ---------------------------------------------------
+#
+# execve refuses an argv string past a per-platform cap, so any command that
+# hands a whole JSON document to a child through --argjson dies with E2BIG once
+# that document outgrows the cap. Linux caps a SINGLE argv string at
+# MAX_ARG_STRLEN (128 KiB) independently of the far larger total ARG_MAX; other
+# platforms bound the total instead. Tests that must build an over-the-cap
+# document probe the running platform rather than pinning a constant, because a
+# pinned constant is exactly how such a test goes quietly vacuous.
+
+# fm_argv_string_limit [ceiling]: print this platform's single-argv cap in
+# bytes, resolved to within 4 KiB by bisecting real execs. A string of the
+# printed size is refused; anything comfortably under it is accepted. Prints
+# nothing and returns 1 when the platform accepts <ceiling> bytes (default
+# 262144), which means a caller cannot build an over-the-cap fixture cheaply
+# here and should skip rather than assert nothing.
+fm_argv_string_limit() {
+  local ceiling=${1:-262144} lo=0 hi mid s
+  printf -v s '%*s' "$ceiling" ''
+  if /usr/bin/env true "$s" 2>/dev/null; then
+    return 1
+  fi
+  hi=$ceiling
+  while [ $((hi - lo)) -gt 4096 ]; do
+    mid=$(((lo + hi) / 2))
+    printf -v s '%*s' "$mid" ''
+    if /usr/bin/env true "$s" 2>/dev/null; then lo=$mid; else hi=$mid; fi
+  done
+  printf '%s\n' "$hi"
+}
+
+# fm_write_oversized_backlog <file> <markdown-bytes>: write a canonical backlog
+# whose Queued section holds enough structured rows to reach roughly the
+# requested markdown size. The snapshot's JSON encoding of that backlog is
+# several times larger again, which is the document the argv cap applies to;
+# callers assert the encoded size themselves so the fixture cannot go vacuous.
+fm_write_oversized_backlog() {
+  local file=$1 target=$2 i=1 written=0 line
+  {
+    printf '## In flight\n\n## Queued\n'
+    while [ "$written" -lt "$target" ]; do
+      line=$(printf -- '- [ ] queued-%05d - Queued item %s carrying a long enough title that the encoded backlog outgrows the platform argv cap (repo: alpha) (kind: ship)' "$i" "$i")
+      printf '%s\n' "$line"
+      written=$((written + ${#line} + 1))
+      i=$((i + 1))
+    done
+    printf '\n## Done\n'
+  } > "$file"
+}
+
 # --- common assertions ------------------------------------------------------
 
 # assert_contains <haystack> <needle> <msg>


### PR DESCRIPTION
## Intent

Bearings is completely dead in a home whose backlog has grown large enough: bin/fm-bearings-snapshot.sh aborts with "bin/fm-fleet-snapshot.sh: line 611: .../jq: Argument list too long" followed by "fm-fleet-snapshot: main inventory summary failed". The goal is to make Bearings work again in such a home, and to make the whole class of failure impossible rather than patching the one line that happened to blow up first.

Measured cause: main_inventory_json() in bin/fm-fleet-snapshot.sh received the whole backlog JSON and the whole tasks JSON and passed each as a single jq --argjson command-line argument. This is NOT the total-argument-list limit. Linux caps a SINGLE argv string at MAX_ARG_STRLEN (131072 bytes) independently of ARG_MAX (2097152 on this machine), so execve refuses the call once one document crosses 128 KiB. The affected home's data/backlog.md is 80215 bytes across 60 items and its JSON encoding has crossed that threshold. Trimming the backlog is explicitly NOT the fix and must not be proposed as one: any home whose backlog grows past the threshold loses Bearings entirely, and the failure is total rather than degraded.

Deliberate decisions made while doing the work, which a reviewer reading only the diff would not know:

1. The fix is to stop passing document-sized JSON through argv anywhere in these scripts. The chosen technique streams each document in on jq's own input under `jq -n` and binds it with `[inputs] as $fm_jq_docs | ($fm_jq_docs[i]) as $name | <original filter body unchanged>`. This was chosen over --slurpfile/--rawfile from temporary files because it needs no temp files, no cleanup, and no changes to any filter body, which is what makes the output contract provably unchanged.

2. A new sourced library bin/fm-jq-lib.sh was introduced as the single owner of the technique and of the rationale, rather than repeating the pattern inline at thirteen call sites in two scripts. Its header states the rule the repo should hold going forward: argv carries only values with a fixed structural bound (scalars, booleans, {path,present} objects), while every value whose size follows file, log, backlog, or fleet content goes through fm_jq_docs. This follows the repo's one-owner rule from the firstmate-coding-guidelines skill, and the library is registered in docs/scripts.md and routed to the snapshot-bearings test lane in bin/fm-test-run.sh.

3. The brief required auditing the whole script rather than patching only the failing line, and naming every instance found. Eleven document-sized --argjson sites were found in bin/fm-fleet-snapshot.sh: the per-task record's current_state, status_log and open_decisions in task_json_lines; main_inventory_json (the reported failure); secondmate_home_summary_json; parent_evidence_reconciliation_json; the registry/tasks union in secondmate_current_json; the structured-home secondmate record; the parent-event-fallback secondmate record; the records accumulator; the secondmate_current result assembly; secondmate_landed_from_current_json; and the final top-level assembly. Two more of the same class were found in bin/fm-bearings-snapshot.sh: the per-repo PR rows accumulator and candidate_prs, both reachable at default caps once FM_BEARINGS_PR_LIMIT is raised or --all-pr-repos is passed, which the script's own help invites. All thirteen were converted. Every remaining --argjson in both scripts was checked and carries a scalar, a boolean, or a {path,present} object bounded by PATH_MAX, so they stay on argv deliberately.

4. The bearings MODEL projection previously piped $SNAP into jq as the filter's input. Since fm_jq_docs also uses stdin, that call now passes the snapshot as a named document and opens the filter with `$snap |` so the filter body still reads the snapshot as `.`. That `expr | def f: ...; body` form was verified to parse in jq before committing to the approach.

5. Output equivalence was treated as a proof obligation, not an assertion, because --json is a documented machine-readable contract that Bearings and the classifier consume. A realistic fixture was built (ship task with a PR, scout task with a report, cmux task with a missing worktree, and a registered structured secondmate home outside the parent home with its own backlog, meta and landed item, so the structured-home path with reconciliation, terminal evidence and the landed roll-up is exercised rather than the parent-event fallback). All seven output modes were compared byte-for-byte before and after: fm-fleet-snapshot --json, fm-fleet-snapshot --secondmate-home-summary, and bearings default TOON, --json, --include-prs --json, --all-landed --json, and --fields bodies,paths,actions,endpoints --json. All were byte-identical.

6. Regression tests were required to fail against the unfixed tree, and they do: copied into a `git archive HEAD` tree of the pre-fix code, both new tests fail. They test through the executable interface only and never assert implementation source bytes. tests/lib.sh gains two shared helpers. fm_argv_string_limit bisects real execs to resolve the running platform's single-argv cap rather than pinning 131072, because a pinned constant is exactly how such a test goes quietly vacuous on a platform that bounds the total instead; it returns 1 and the tests skip where the platform accepts a 256 KiB argv string. fm_write_oversized_backlog builds the fixture. Backlog parsing is quadratic in markdown bytes, so rather than making the markdown itself exceed the cap (roughly 25s of CPU), the fixture exploits the roughly 5x markdown-to-JSON inflation: markdown of limit*2/5 yields an encoded backlog of about 281 KB, over twice the cap, in about 3s of CPU. Each test asserts the encoded size exceeds the measured cap so the fixture cannot silently go vacuous, then asserts the full documented contract survives (schema, record count, structured count, main_inventory validity, the secondmate home summary counts, and the bearings gates).

7. Per-call-site `# shellcheck disable=SC2016` directives with a rationale were added at each fm_jq_docs call. ShellCheck special-cases a literal `jq` command but not a wrapper function, so it flags the single-quoted $ in every filter. This follows the repo's existing convention of per-site directives carrying a reason; the two scripts were confirmed shellcheck-clean before and after.

Verification status to report honestly rather than overstate: bin/fm-lint.sh's ShellCheck half (pinned 0.11.0) is clean; its workflow-lint half did NOT run because actionlint is absent from this environment, so that half must be reported as unrun rather than as passed, and no workflow files were changed. Two test-suite failures were reproduced on a pristine origin/main archive and are pre-existing environment problems not caused by this change: tests/fm-test-run.test.sh exits 1 with "comm: file 2 is not in sorted order", and tests/fm-lint.test.sh exits 1 with "not ok - changed-mode lint run failed" because actionlint is absent. The two touched suites pass on the fixed tree: tests/fm-fleet-snapshot-view.test.sh 16 ok exit 0, tests/fm-bearings-snapshot.test.sh 42 ok exit 0.

Repo constraints that were followed and should not be "corrected": one sentence per line in tracked Markdown, plain dash and never an em dash, no agent name as commit co-author, tests colocated in tests/ as <subject>.test.sh extending the existing runners rather than inventing a new one.

## What Changed

- Added `bin/fm-jq-lib.sh`, a shared library that streams document-sized JSON (backlog, tasks, fleet content) into `jq -n` via stdin using an `[inputs] as $fm_jq_docs` binding, instead of passing it as a single `--argjson` command-line argument that can exceed Linux's per-argv `MAX_ARG_STRLEN` cap.
- Converted all thirteen document-sized `--argjson` call sites to the new streaming technique: eleven in `bin/fm-fleet-snapshot.sh` (including `main_inventory_json`, `task_json_lines`, `secondmate_home_summary_json`, `parent_evidence_reconciliation_json`, and the secondmate/records assembly paths) and two in `bin/fm-bearings-snapshot.sh` (the per-repo PR rows accumulator and `candidate_prs`); scalar/boolean/`{path,present}` argv usages were left unchanged as they carry no unbounded size.
- Registered `bin/fm-jq-lib.sh` in `docs/scripts.md` and routed it into the snapshot/bearings test lane in `bin/fm-test-run.sh`.
- Added regression tests (`tests/fm-fleet-snapshot-view.test.sh`, `tests/fm-bearings-snapshot.test.sh`) plus shared helpers in `tests/lib.sh` (`fm_argv_string_limit`, `fm_write_oversized_backlog`) that build an oversized-backlog fixture and assert the fleet snapshot and bearings gates still succeed past the previous argv cap.

## Risk Assessment

✅ Low: The fix is well-scoped and technically verified: fm_jq_docs streams documents via jq's own stdin parser (which correctly handles multi-line pretty-printed JSON since jq tokenizes rather than line-splits), all 13 claimed --argjson call sites across both scripts were confirmed converted with the filter consistently the last positional argument (so the prefix-binding injection is correct at every site), remaining --argjson/--arg sites were confirmed to carry only scalars/booleans/bounded paths, and I independently reproduced both the original E2BIG failure and the fix's success via direct testing of fm_jq_docs against the old --argjson pattern with an oversized document.

## Testing

Ran both test suites the change touches: fm-fleet-snapshot-view.test.sh (16/16) and fm-bearings-snapshot.test.sh (42/42), both exit 0, including the two new regression tests that reproduce the exact reported failure — a backlog whose JSON encoding crosses the platform's single-argv cap — through the real fm-fleet-snapshot.sh and fm-bearings-snapshot.sh executable interfaces, confirming the fm_jq_docs fix restores the documented output contract instead of aborting with E2BIG.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-fleet-snapshot-view.test.sh (16/16 ok, exit 0, includes test_oversized_backlog_survives_argv_cap)`
- `bash tests/fm-bearings-snapshot.test.sh (42/42 ok, exit 0, includes test_oversized_backlog_still_renders_bearings)`
- `git diff 03bb1d8..7e13009 -- bin/fm-jq-lib.sh tests/lib.sh tests/fm-fleet-snapshot-view.test.sh tests/fm-bearings-snapshot.test.sh (reviewed the fm_jq_docs stdin-streaming technique and the two new argv-cap regression tests)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Lint** - skipped</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
