### PR TITLE
fix(composer): find the input row when furniture is drawn below it

### DIFF
--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -66,7 +66,18 @@
 #                identity reporting an idle/done/blocked pi (herdr `agent
 #                get`; the tmux foreground-process probe), because a blank
 #                region between two transcript rules is otherwise exactly the
-#                strict rule's unidentifiable blank row.
+#                strict rule's unidentifiable blank row. The pair must ENCLOSE
+#                at least one row: two adjacent rules are a divider.
+#
+# SHAPES DRAWN BELOW THE COMPOSER (task fm-composer-odczyt-herdr): the
+# cursorless ranking takes the bottom-most shape, so anything a terminal draws
+# UNDER the input row - an operator's multi-row status bar, a footer, a pair of
+# transcript rules - can outrank the real composer and hide it. `separated` is
+# the shape that forges most easily, being nothing but two rules, and it is
+# also the only shape identity can refute. _fm_composer_cursorless_pi_decides
+# asks whether the pi rules DECIDE the selection and, if they do, spends the
+# lazy identity probe: an agent proven not to be pi drops them, and every other
+# answer keeps them exactly as strict. Nothing else in the ranking relaxes.
 #
 # THE SAFETY RULE for glyphs: a bare shell prompt glyph (`>` `$` `%` `#`) -
 # what a pane shows once its agent has exited to a plain login shell - is a
@@ -639,7 +650,11 @@ _fm_composer_scan_screen() {  # <plain-screen> <cursor-or-empty> [extract-wrap]
         FM_COMPOSER_SCAN_PI_PAIR_FOUND=1
         FM_COMPOSER_SCAN_PI_OPEN=$pi_open
         FM_COMPOSER_SCAN_PI_CLOSE=$row
-        if [ "$pi_lines" -le "$pi_max" ]; then
+        # A pair must ENCLOSE at least one row to hold an input row at all:
+        # two adjacent rules are a divider, not a composer, and a zero-height
+        # region trivially satisfies every content check below it, which read
+        # `empty` and authorized injection into a region with nowhere to type.
+        if [ "$pi_lines" -ge 1 ] && [ "$pi_lines" -le "$pi_max" ]; then
           FM_COMPOSER_SCAN_PI_PAIR_VALID=1
         else
           FM_COMPOSER_SCAN_PI_PAIR_VALID=0
@@ -1023,8 +1038,13 @@ _fm_composer_leftbar_floor_row() {  # <trimmed-row>
   [ -z "${blocks//▀/}" ]
 }
 
+# _fm_composer_select_cursorless <plain-screen> [pi-enabled]
+# <pi-enabled> defaults to 1. Passing 0 removes pi's separated-pair candidate
+# and its lone-separator staleness rule from the ranking; only a caller holding
+# positive identity proof that this pane's live agent is NOT pi may do so (see
+# _fm_composer_cursorless_pi_decides).
 _fm_composer_select_cursorless() {
-  local plain=$1 generic=-1 next boundary raw trimmed
+  local plain=$1 pi_enabled=${2:-1} generic=-1 next boundary raw trimmed
   FM_COMPOSER_SELECTED_KIND=
   FM_COMPOSER_SELECTED_FIRST=-1
   FM_COMPOSER_SELECTED_LAST=-1
@@ -1052,7 +1072,7 @@ _fm_composer_select_cursorless() {
     FM_COMPOSER_SELECTED_KIND=
     return 1
   fi
-  if [ "$FM_COMPOSER_SCAN_PI_PAIR_FOUND" = 1 ] \
+  if [ "$pi_enabled" = 1 ] && [ "$FM_COMPOSER_SCAN_PI_PAIR_FOUND" = 1 ] \
      && [ "$FM_COMPOSER_SCAN_PI_CLOSE" -gt "$generic" ] \
      && [ "$generic" -lt "$FM_COMPOSER_SCAN_PI_OPEN" ]; then
     generic=$FM_COMPOSER_SCAN_PI_CLOSE
@@ -1060,7 +1080,7 @@ _fm_composer_select_cursorless() {
     FM_COMPOSER_SELECTED_FIRST=$((FM_COMPOSER_SCAN_PI_OPEN + 1))
     FM_COMPOSER_SELECTED_LAST=$((FM_COMPOSER_SCAN_PI_CLOSE - 1))
   fi
-  if [ "$FM_COMPOSER_SCAN_PI_PAIR_FOUND" = 0 ] \
+  if [ "$pi_enabled" = 1 ] && [ "$FM_COMPOSER_SCAN_PI_PAIR_FOUND" = 0 ] \
      && [ "$FM_COMPOSER_SCAN_PI_LAST_SEPARATOR" -gt "$generic" ]; then
     FM_COMPOSER_SELECTED_KIND=
     return 1
@@ -1107,6 +1127,37 @@ _fm_composer_select_cursorless() {
   [ -n "$FM_COMPOSER_SELECTED_KIND" ]
 }
 
+# _fm_composer_cursorless_pi_decides: 0 when pi's separated-pair candidate and
+# its lone-separator staleness rule are what DECIDE the cursorless selection -
+# that is, when suppressing them would select a different shape (or would
+# succeed where the pi rules refuse). Only then is an identity probe worth its
+# cost, so the lazy-probe contract is preserved.
+#
+# WHY THIS EXISTS (task fm-composer-odczyt-herdr, 2026-08-19): pi's shape is a
+# region between two solid `─` rules, which is not self-proving - that is
+# exactly why _fm_composer_pi_verdict demands identity. Anything a terminal
+# draws BELOW the composer can forge it: a fleet operator's own multi-row
+# status bar draws rule-separated rows under claude's input row, the
+# bottom-most-shape rule then ranked that forged pair above the real bare `❯`
+# composer, and every read of every pane on that machine returned `unknown` -
+# 196 consecutive away-mode escalations deferred over 4229 s with the work
+# already finished. Leaves _fm_composer_select_cursorless's ranking alone; it
+# only asks whether the ranking hinged on the one shape identity can refute.
+_fm_composer_cursorless_pi_decides() {  # <plain-screen>
+  local plain=$1 with_pi='' without_pi=''
+  if [ "$FM_COMPOSER_SCAN_PI_PAIR_FOUND" != 1 ] \
+     && [ "$FM_COMPOSER_SCAN_PI_LAST_SEPARATOR" -lt 0 ]; then
+    return 1
+  fi
+  _fm_composer_select_cursorless "$plain" 1 && with_pi=ok
+  with_pi="$with_pi:$FM_COMPOSER_SELECTED_KIND:$FM_COMPOSER_SELECTED_FIRST"
+  with_pi="$with_pi:$FM_COMPOSER_SELECTED_LAST:$FM_COMPOSER_SELECTED_AMBIG"
+  _fm_composer_select_cursorless "$plain" 0 && without_pi=ok
+  without_pi="$without_pi:$FM_COMPOSER_SELECTED_KIND:$FM_COMPOSER_SELECTED_FIRST"
+  without_pi="$without_pi:$FM_COMPOSER_SELECTED_LAST:$FM_COMPOSER_SELECTED_AMBIG"
+  [ "$with_pi" != "$without_pi" ]
+}
+
 fm_composer_extract_selected_content() {  # <caps> <screen>
   local caps=$1 screen=$2 styled=0 kv plain row raw content glyph joined='' footer_re prompt_row=-1
   local leading_blank=1 placeholder_position=0 prompt_is_shell=0
@@ -1118,7 +1169,7 @@ $caps
 EOF
   plain=$(printf '%s\n' "$screen" | fm_composer_strip_ansi)
   _fm_composer_scan_screen "$plain" '' 1
-  _fm_composer_select_cursorless "$plain" || return 1
+  _fm_composer_select_cursorless "$plain" 1 || return 1
   row=$FM_COMPOSER_SELECTED_FIRST
   while [ "$row" -le "$FM_COMPOSER_SELECTED_LAST" ]; do
     raw=$(_fm_composer_screen_row "$row" "$screen")
@@ -1258,7 +1309,28 @@ EOF
   # No cursor: the bottom-most shape wins, with the pi-separator staleness
   # rules layered on (a live pi composer pair below the generic candidate
   # proves that candidate stale).
-  if ! _fm_composer_select_cursorless "$plain"; then
+  #
+  # Those pi rules rank a NON-self-proving shape - a region between two solid
+  # rules - above shapes that carry their own container proof, so any status
+  # bar, footer, or transcript rule drawn below the real composer can forge
+  # one and hide the input row. When they are what decides the selection, the
+  # same identity probe that already gates pi's verdict decides whether they
+  # are real: a live agent proven NOT to be pi means this pane has no pi
+  # composer at all, so the forged pair drops out and the input row above it
+  # is found. Nothing else relaxes - an unfetched identity still asks for the
+  # probe, and no identity capability, an absent probe, or a live pi all keep
+  # the pi rules exactly as strict as before.
+  local pi_enabled=1
+  if [ "$has_identity" = 1 ] && _fm_composer_cursorless_pi_decides "$plain"; then
+    if [ -z "$identity" ]; then
+      printf 'need-identity'
+      return 0
+    fi
+    if [ "$identity" != probe-absent ] && [ "${identity%%$'\t'*}" != pi ]; then
+      pi_enabled=0
+    fi
+  fi
+  if ! _fm_composer_select_cursorless "$plain" "$pi_enabled"; then
     printf 'unknown'
     return 0
   fi
@@ -1274,7 +1346,7 @@ EOF
       if [ "$FM_COMPOSER_SELECTED_LAST" -gt "$FM_COMPOSER_SELECTED_FIRST" ]; then
         _fm_composer_classify_bare_wrap "$screen" "$styled" \
           "$FM_COMPOSER_SELECTED_FIRST" "$FM_COMPOSER_SELECTED_LAST"
-      elif [ "$FM_COMPOSER_SCAN_PI_PAIR_FOUND" = 1 ] \
+      elif [ "$pi_enabled" = 1 ] && [ "$FM_COMPOSER_SCAN_PI_PAIR_FOUND" = 1 ] \
          && [ "$FM_COMPOSER_SCAN_BARE_ROW" -gt "$FM_COMPOSER_SCAN_PI_OPEN" ] \
          && [ "$FM_COMPOSER_SCAN_BARE_ROW" -lt "$FM_COMPOSER_SCAN_PI_CLOSE" ]; then
         _fm_composer_classify_bare_pi_overlap "$screen" "$styled" "$has_identity" "$identity" \

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -159,6 +159,7 @@ family_for_basename() {
       printf '%s\n' watcher-wake-lock
       ;;
     fm-afk-inject-herdr-e2e.test.sh|fm-afk-launch.test.sh|fm-backend-autodetect-smoke.test.sh|\
+    fm-composer-statusbar-herdr-e2e.test.sh|\
     fm-backend-herdr-eventwait-smoke.test.sh|fm-backend-herdr-presentation-e2e.test.sh|\
     fm-backend-herdr-launcher-workspace-e2e.test.sh|\
     fm-backend-herdr-prune-safety-e2e.test.sh|fm-backend-herdr-respawn-idem-e2e.test.sh|\

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -161,6 +161,18 @@ fm_tmux_composer_state() {  # <target> -> empty|pending|pending-unproven|unknown
   # harness is untouched.
   if [ "$verdict" = unknown ] && fm_tmux_pane_is_cursor "$target"; then
     verdict=$(fm_composer_classify_screen "$(fm_tmux_composer_caps)" "$pane" '')
+    # The cursorless read is identity-capable too, so it can ask for the same
+    # lazy probe the cursor read above asks for; the sentinel must never leave
+    # this adapter. Reuse an identity already fetched rather than probing twice.
+    if [ "$verdict" = need-identity ]; then
+      if [ -z "${identity:-}" ]; then
+        if ! identity=$(fm_tmux_composer_identity "$target") || [ -z "$identity" ]; then
+          identity=probe-absent
+        fi
+      fi
+      verdict=$(fm_composer_classify_screen "$(fm_tmux_composer_caps)" "$pane" '' "$identity")
+      [ "$verdict" != need-identity ] || verdict=unknown
+    fi
   fi
   printf '%s' "$verdict"
 }

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -205,6 +205,47 @@ Cursor is deliberately outside this cursor-anchored empty-composer matrix becaus
 
 `zellij action dump-screen --pane-id <id> --ansi` was verified at zellij 0.44.0 to preserve ANSI styling (real Claude Code rendered inside a zellij pane dumped `ESC[m` `❯` U+00A0 for its idle composer row), which is the capability the zellij composer classifier reads.
 
+### Furniture drawn below the composer
+
+The cursorless ranking takes the bottom-most shape, so anything drawn UNDER the input row competes with the real composer.
+This was measured on 2026-08-19 against herdr 0.7.5 and Claude Code 2.1.235 on Linux x86_64, on an operator machine whose shell renders a 12-row status bar below Claude's input row; two of those rows are adjacent solid rules, which forge pi's separated shape.
+Every live pane on that machine, five of five, read `unknown` before the fix and `empty` after it, with no other change to the panes:
+
+```sh
+. bin/fm-backend.sh
+herdr pane list | jq -r '.result.panes[].pane_id' \
+  | while read -r p; do printf '%s %s\n' "$p" "$(fm_backend_composer_state herdr "default:$p")"; done
+```
+
+```text
+before: default:wT:p2 unknown   default:wT:p1F unknown  default:wT:p1G unknown  default:wT:p1H unknown  default:wT:p1J unknown
+after:  default:wT:p2 empty     default:wT:p1F empty    default:wT:p1G empty    default:wT:p1H empty    default:wT:p1J empty
+```
+
+The portable half of this guarantee, including the byte-level status-bar fixture, the five injection gates it must not buy its verdict with, and the zero-height separator pair, is pinned by `tests/fm-composer-lib.test.sh`.
+Rerun the command above on any machine whose terminal draws its own furniture below a harness's input row; a pane reading `unknown` there is this defect, not a busy pane.
+The Cursor-specific cursorless fallback re-reads the same pane through that identity-capable path, so it resolves the identity probe itself rather than returning the classifier's internal request for one; `tests/fm-composer-ghost.test.sh` pins that its verdict is always one of the four public verdicts.
+
+The separated shape now also requires the pair to enclose at least one row, so two adjacent rules cannot prove a composer.
+The live guard was rerun on 2026-08-19 on Linux x86_64 with tmux 3.4 to confirm that tightening against the real shapes, from an UNTRUSTED worktree:
+
+```sh
+FM_COMPOSER_MATRIX_LIVE=1 tests/fm-composer-matrix-live-e2e.test.sh
+```
+
+```text
+ok - claude (2.1.235 (Claude Code)): real idle composer classifies empty
+not ok - codex (codex-cli 0.141.0): idle composer never classified empty (last verdict: unknown)
+ok - opencode (1.16.2): real idle composer classifies empty
+ok - pi (0.84.1): real idle composer classifies empty
+not ok - kimi (kimi, version 1.44.0): idle composer never classified empty (last verdict: unknown)
+ok - strict posture live: a blank shell row classifies unknown and injection defers
+```
+
+Pi's real separated composer still reaches `empty`, which is the shape the enclosed-row requirement had to preserve.
+The two refusals are environment and vendor state, not classifier drift, and both reproduce identically on the unchanged classifier: Codex parked on the untrusted-worktree trust dialog, which the guard correctly treats as an unreadable composer, and Kimi 1.44.0 no longer draws the bordered `│ > │` box this matrix records, drawing a titled `── input ──` rule above its input rows and a plain rule below instead - a shape the catalogue does not yet carry.
+Rerun this guard from a trusted checkout, and refresh Kimi's entry once its current shape is taught to the catalogue.
+
 ## Herdr
 
 The compatibility floor is protocol 14.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -246,6 +246,25 @@ Pi's real separated composer still reaches `empty`, which is the shape the enclo
 The two refusals are environment and vendor state, not classifier drift, and both reproduce identically on the unchanged classifier: Codex parked on the untrusted-worktree trust dialog, which the guard correctly treats as an unreadable composer, and Kimi 1.44.0 no longer draws the bordered `│ > │` box this matrix records, drawing a titled `── input ──` rule above its input rows and a plain rule below instead - a shape the catalogue does not yet carry.
 Rerun this guard from a trusted checkout, and refresh Kimi's entry once its current shape is taught to the catalogue.
 
+A readable composer is not the same guarantee as a delivered escalation, so the delivery path itself is pinned end to end against real Herdr by `tests/fm-composer-statusbar-herdr-e2e.test.sh` (`real-herdr-gated`), which draws the same 13-row status bar under a bare agent-glyph composer in an isolated `fm-herdr-lab.sh` session:
+
+```sh
+FM_COMPOSER_STATUSBAR_E2E=1 tests/fm-composer-statusbar-herdr-e2e.test.sh
+```
+
+Measured on 2026-08-19 with herdr 0.7.5, running the identical scenario against the classifier before and after the fix:
+
+| observation | before | after |
+| --- | --- | --- |
+| composer verdict on the idle pane | `unknown` | `empty` |
+| away-mode escalation delivered within 30 s | no | yes |
+| daemon deferrals recording an unreadable composer | 14 | 0 |
+| max-defer wedge alarm raised | yes | no |
+| `fm-send` exit status for a steer that did reach the pane | 1 | 0 |
+
+The `fm-send` row needs a mid-turn pane to be meaningful: Herdr confirms a submit from native agent-state whenever the pre-Enter baseline is legibly idle and falls back to reading the composer only when it is not, so the guard reports the pane working before steering it.
+The same run also asserts that real typed text under that status bar still reads `pending`, that the away daemon holds its escalation back rather than typing over it, and that the held escalation arrives as its own submission once the pane goes idle.
+
 ## Herdr
 
 The compatibility floor is protocol 14.

--- a/tests/fm-composer-ghost.test.sh
+++ b/tests/fm-composer-ghost.test.sh
@@ -655,6 +655,44 @@ test_non_bordered_interior_edges_are_pending() {
   pass "fm_tmux_composer_state: interior edge glyphs retain non-bordered fallback"
 }
 
+test_cursor_fallback_never_leaks_the_identity_sentinel() {
+  # The Cursor reclassification re-reads the pane CURSORLESSLY, and that read
+  # is identity-capable, so it can ask for the lazy identity probe exactly as
+  # the cursor-anchored read above it does. `need-identity` is an internal
+  # sentinel that must never leave an adapter: a caller comparing the verdict
+  # to `empty` would defer forever, and one comparing it to `unknown` would
+  # miss a real refusal. Reachable whenever anything below the composer forges
+  # a separator pair - a terminal's own status bar, a footer, two rules.
+  local dir fb capture out nbsp rule
+  dir="$TMP_ROOT/cursor-fallback-sentinel"; mkdir -p "$dir"
+  fb=$(make_fake_tmux "$dir")
+  capture="$dir/styled.txt"
+  nbsp=$(printf '\302\240')
+  rule='────────────────────────'
+  # A composer with a status bar under it, whose two adjacent rules forge the
+  # separated shape. The cursor is parked below the footer, as Cursor parks it.
+  printf '%s\n→%s\n%s\n  PWD: repo\n  %s\n  %s\n  footer text\n' \
+    "$rule" "$nbsp" "$rule" "$rule" "$rule" > "$capture"
+  # Stub Cursor's process identity: this test is about the verdict domain of
+  # the reclassification branch, not about detecting Cursor.
+  # shellcheck disable=SC2329 # Overrides the sourced library's definition; the
+  # library body under test invokes it.
+  fm_tmux_pane_is_cursor() { return 0; }
+  out=$(PATH="$fb:$PATH" FM_FAKE_STYLED="$capture" FM_FAKE_CY=6 \
+    fm_tmux_composer_state "fakepane")
+  unset -f fm_tmux_pane_is_cursor
+  # shellcheck source=/dev/null
+  . "$LIB"
+  case "$out" in
+    empty|pending|pending-unproven|unknown) ;;
+    *) fail "the Cursor reclassification leaked '$out' out of the adapter" ;;
+  esac
+  # With no identity available the pi rules stay strict, so this defers.
+  [ "$out" = unknown ] \
+    || fail "an unprovable forged pair under a Cursor composer must defer, got '$out'"
+  pass "fm_tmux_composer_state: the Cursor reclassification resolves identity instead of leaking the sentinel"
+}
+
 # --- fm-peek.sh stays escape-free (LLM-facing path) -------------------------
 
 test_peek_output_is_escape_free() {
@@ -713,4 +751,5 @@ test_absent_tmux_identity_keeps_enclosed_bare_verdict
 test_legitimate_empty_routes_remain_empty
 test_non_bordered_composer_uses_compatibility_fallback
 test_non_bordered_interior_edges_are_pending
+test_cursor_fallback_never_leaks_the_identity_sentinel
 test_peek_output_is_escape_free

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -384,6 +384,133 @@ test_matrix_kimi_bordered_shell_glyph_box() {
   pass "matrix: kimi's bordered shell-glyph box reads empty through the shared owner (spawn's fourth copy retired)"
 }
 
+# --- Furniture drawn BELOW the composer -------------------------------------
+#
+# STATUS_BAR_ROWS reproduces a real herdr capture of an idle claude 2.1.235
+# pane on an operator machine whose shell renders a 12-row status bar UNDER
+# claude's input row (task fm-composer-odczyt-herdr, 2026-08-19). Two of those
+# rows are adjacent solid rules, which forge exactly the shape pi's separated
+# composer is made of. Ranking that forged pair as the bottom-most shape hid
+# the real agent-glyph composer above it, so EVERY pane on that machine read
+# `unknown`: 196 consecutive away-mode escalations deferred over 4229 s with
+# the work already finished, and every steer's Enter left unconfirmed.
+STATUS_BAR_RULE='────────────────────────────────────────'
+STATUS_BAR_ROWS=$'  BLAKE OS │ CC: 2.1.235 │ RZESZOW, 18  07:09  14C\n'
+STATUS_BAR_ROWS+=$'  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄\n'
+STATUS_BAR_ROWS+=$'  PWD: _firstmate\n'
+STATUS_BAR_ROWS+="  $STATUS_BAR_RULE"$'\n'
+STATUS_BAR_ROWS+=$'  CONTEXT: ⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁ 12%\n'
+STATUS_BAR_ROWS+=$'  ········································\n'
+STATUS_BAR_ROWS+="  $STATUS_BAR_RULE"$'\n'
+STATUS_BAR_ROWS+=$'  USE: 5HR: 61% ↻TODAY@0710 │ WEEK: 65% (SUB/API)\n'
+# The two adjacent rules the outage turned on: a divider pair, not a composer.
+STATUS_BAR_ROWS+="  $STATUS_BAR_RULE"$'\n'
+STATUS_BAR_ROWS+="  $STATUS_BAR_RULE"$'\n'
+STATUS_BAR_ROWS+=$'  "There is no next time. It is now or never." -Celestine Chua\n'
+STATUS_BAR_ROWS+=$'  bypass permissions on (shift+tab to cycle) - for agents'
+
+# status_bar_screen <composer-row>: the captured screen with <composer-row>
+# standing where claude drew its input row.
+status_bar_screen() {  # <composer-row>
+  printf '%s\n%s\n%s\n%s\n%s\n%s' \
+    'transcript line' 'more transcript' "$STATUS_BAR_RULE" "$1" "$STATUS_BAR_RULE" \
+    "$STATUS_BAR_ROWS"
+}
+
+test_status_bar_below_composer_does_not_hide_it() {
+  local screen typed claude_working claude_idle pi_idle out
+  screen=$(status_bar_screen "❯$NBSP")
+  typed=$(status_bar_screen "❯ fix the flaky test")
+  claude_working=$(printf 'claude\tworking'); claude_idle=$(printf 'claude\tidle')
+  pi_idle=$(printf 'pi\tidle')
+  # NON-VACUOUSNESS: the forged pair really is what decides this screen, so
+  # the classifier spends the lazy identity probe on it. If this stops being
+  # `need-identity` the fixture no longer reproduces the outage and every
+  # assertion below would pass for the wrong reason.
+  out=$(fm_composer_classify_screen "$CAPS_STYLED" "$screen")
+  [ "$out" = need-identity ] \
+    || fail "the forged pair must be what decides this screen (expected need-identity, got '$out')"
+  # THE FIX: a live agent proven NOT to be pi means this pane has no pi
+  # composer, so the forged pair drops out and the real input row is found.
+  assert_screen "idle claude under a status bar" empty "$CAPS_STYLED" "$screen" '' "$claude_working"
+  assert_screen "idle claude under a status bar (idle)" empty "$CAPS_STYLED" "$screen" '' "$claude_idle"
+  # The same defect left every steer's Enter unconfirmed: real typed text
+  # under the status bar read `unknown`, so no retry could ever be earned.
+  assert_screen "typed text under a status bar" pending "$CAPS_STYLED" "$typed" '' "$claude_working"
+  # NOTHING ELSE RELAXES. Each of these read `unknown` before the fix and must
+  # keep reading `unknown`: only POSITIVE identity proof moves the verdict.
+  assert_screen "status bar without an identity probe result" unknown \
+    "$CAPS_STYLED" "$screen" '' probe-absent
+  assert_screen "status bar on an identity-less styled backend" unknown \
+    "$CAPS_STYLED_NOID" "$screen"
+  assert_screen "status bar on a plain backend" unknown "$CAPS_PLAIN" "$screen"
+  # A live pi keeps the pi rules exactly as they were: the pair still outranks
+  # everything above it, and a zero-height pair proves nothing.
+  assert_screen "live pi still owns its separator pair" unknown \
+    "$CAPS_STYLED" "$screen" '' "$pi_idle"
+  pass "matrix: a status bar drawn below the composer no longer hides the input row"
+}
+
+test_status_bar_preserves_the_safety_gates() {
+  # The gates this fix must not buy its verdict with. Each screen carries the
+  # SAME status bar and the SAME proven-non-pi identity that turns the fixture
+  # above into `empty`; every one of them must still refuse.
+  local claude_working out screen
+  claude_working=$(printf 'claude\tworking')
+  # 1. A dead shell below the composer: the agent exited and its prompt row is
+  #    the only live input on the pane. Injecting here types into a shell.
+  screen=$(status_bar_screen "❯$NBSP")$'\n$ '
+  out=$(fm_composer_classify_screen "$CAPS_STYLED" "$screen" '' "$claude_working")
+  [ "$out" != empty ] \
+    || fail "a dead shell below a status-bar composer must never read empty"
+  # 2. A modal dialog drawn over the pane: an unclosed box below the composer
+  #    is a screen that is not the composer's to accept text.
+  screen=$(status_bar_screen "❯$NBSP")$'\n  ╭────────────────╮\n  │ Do you trust   │'
+  out=$(fm_composer_classify_screen "$CAPS_STYLED" "$screen" '' "$claude_working")
+  [ "$out" != empty ] \
+    || fail "an unclosed modal below a status-bar composer must never read empty"
+  # 3. A mid-redraw pane: the composer row itself has not been drawn yet, so
+  #    the only candidate is a blank unidentified row (the strict rule).
+  screen=$(status_bar_screen '')
+  out=$(fm_composer_classify_screen "$CAPS_STYLED" "$screen" '' "$claude_working")
+  [ "$out" != empty ] \
+    || fail "a blank unidentified row under a status bar must never read empty"
+  # 4. An unidentified text row where the composer should be: no container
+  #    proof at all, status bar or not.
+  screen=$(status_bar_screen 'Applying edit to bin/fm-composer-lib.sh')
+  out=$(fm_composer_classify_screen "$CAPS_STYLED" "$screen" '' "$claude_working")
+  [ "$out" != empty ] \
+    || fail "an unidentified row under a status bar must never read empty"
+  # 5. A bare SHELL glyph where the composer should be: the dead-shell rule
+  #    holds under a status bar exactly as it does without one.
+  screen=$(status_bar_screen '$ ')
+  out=$(fm_composer_classify_screen "$CAPS_STYLED" "$screen" '' "$claude_working")
+  [ "$out" != empty ] \
+    || fail "a bare shell glyph under a status bar must never read empty"
+  pass "strict posture: the status-bar fix buys nothing from the injection gates"
+}
+
+test_zero_height_separator_pair_proves_nothing() {
+  # A pi pair that encloses NO row cannot hold an input row, yet every content
+  # check over an empty range trivially succeeded, so an idle pi identity read
+  # it `empty` and authorized injection into a region with nowhere to type.
+  # Any two adjacent rules - a status bar's divider, a transcript rule meeting
+  # a footer rule - forge one.
+  local adjacent real pi_idle
+  pi_idle=$(printf 'pi\tidle')
+  adjacent=$'transcript\n────────────────────────\n────────────────────────\n footer'
+  assert_screen "adjacent rules are a divider, not a composer" unknown \
+    "$CAPS_STYLED" "$adjacent" '' "$pi_idle"
+  assert_screen "adjacent rules on tmux" unknown "$CAPS_TMUX" "$adjacent" 2 "$pi_idle"
+  # NON-VACUOUSNESS: the SAME pair with one row between the rules is pi's real
+  # composer and still reads empty, so the refusal above is about the missing
+  # row and not about the fixture drifting out of the pi shape.
+  real=$'transcript\n────────────────────────\n\n────────────────────────\n footer'
+  assert_screen "one enclosed row is still pi's composer" empty \
+    "$CAPS_STYLED" "$real" '' "$pi_idle"
+  pass "strict posture: a zero-height separator pair is never positive container proof"
+}
+
 test_matrix_claude_inside_zellij_ansi_dump() {
   # Real claude captured through `zellij action dump-screen --ansi`
   # (capability established by the audit): `ESC[m` `❯` U+00A0.
@@ -617,6 +744,9 @@ test_matrix_opencode_leftbar_signals
 test_matrix_grok_titled_bottom_border
 test_matrix_kimi_bordered_shell_glyph_box
 test_matrix_claude_inside_zellij_ansi_dump
+test_status_bar_below_composer_does_not_hide_it
+test_status_bar_preserves_the_safety_gates
+test_zero_height_separator_pair_proves_nothing
 test_strict_blank_row_divergence
 test_bare_wrap_region_classifies
 test_contiguous_transcript_reanchors_on_live_prompt

--- a/tests/fm-composer-statusbar-herdr-e2e.test.sh
+++ b/tests/fm-composer-statusbar-herdr-e2e.test.sh
@@ -1,0 +1,345 @@
+#!/usr/bin/env bash
+# tests/fm-composer-statusbar-herdr-e2e.test.sh - the real-Herdr end-to-end
+# guard for the 2026-08-19 night-supervision outage (task
+# fm-composer-odczyt-herdr).
+#
+# The classifier half of that outage is pinned portably by
+# tests/fm-composer-lib.test.sh. This guard proves the half a screen fixture
+# cannot: that an escalation is actually DELIVERED and CONFIRMED, and that a
+# steer's Enter is confirmed without anyone re-sending it by hand, against a
+# real pane whose terminal draws a multi-row status bar UNDER the input row.
+# That is what failed for 4229 s with the work already finished: the composer
+# read `unknown`, so the away-mode daemon refused to deliver 196 times running
+# and every fm-send reported its Enter unconfirmed.
+#
+# The supervisor pane is a deterministic bash loop, not a harness binary, for
+# the same reason tests/fm-afk-inject-herdr-e2e.test.sh uses one: this test
+# asserts on submitted CONTENT, not on pane appearance, and the loop can draw
+# the exact outage geometry on demand. It draws the bare agent-glyph composer
+# row and then, BELOW it, a 13-row status bar carrying two adjacent solid
+# rules - the shape that forged pi's separated composer and outranked the real
+# input row. It registers as a real Herdr agent and reports an idle/working/
+# idle cycle around each submission, because Herdr submit confirmation is
+# native agent-state, not composer text (docs/herdr-backend.md "Native
+# agent-state submit confirmation").
+#
+# Herdr isolation: every lifecycle action and every task-specific Herdr call
+# goes through bin/fm-herdr-lab.sh in a named non-`default` lab session, and a
+# PATH shim routes the production adapter's own calls through the same helper,
+# so nothing here can reach the captain's running `default` session.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+if [ "${FM_COMPOSER_STATUSBAR_E2E:-0}" != 1 ]; then
+  echo "skip: set FM_COMPOSER_STATUSBAR_E2E=1 to run the real-Herdr status-bar delivery regression"
+  exit 0
+fi
+for tool in herdr jq; do
+  command -v "$tool" >/dev/null 2>&1 || { echo "skip: $tool not found"; exit 0; }
+done
+
+# shellcheck source=/dev/null
+. "$ROOT/tests/herdr-test-safety.sh"
+herdr_forget_inherited_pane
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-supervise-daemon.sh"
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-backend.sh"
+fm_backend_source herdr || fail "fm_backend_source herdr failed"
+
+LAB_HELPER=${HERDR_LAB_HELPER:-$ROOT/bin/fm-herdr-lab.sh}
+SESSION=$("$LAB_HELPER" name fm-composer-statusbar)
+TMP_ROOT=$(fm_test_tmproot fm-composer-statusbar-e2e)
+HOME_DIR="$TMP_ROOT/home"
+STATE="$HOME_DIR/state"
+PROJECT="$TMP_ROOT/project"
+FAKEBIN="$TMP_ROOT/fakebin"
+LOG_FILE="$TMP_ROOT/submitted.log"
+ORIGINAL_PATH=$PATH
+DAEMON_PID=
+PANE=
+TARGET=
+
+cleanup() {
+  local rc=$?
+  trap - EXIT
+  if [ -n "${DAEMON_PID:-}" ]; then
+    afk_exit "$STATE" 2>/dev/null || true
+    kill "$DAEMON_PID" 2>/dev/null || true
+    wait "$DAEMON_PID" 2>/dev/null || true
+  fi
+  if ! "$LAB_HELPER" teardown "$SESSION"; then
+    rc=1
+  fi
+  rm -rf "$TMP_ROOT"
+  exit "$rc"
+}
+trap cleanup EXIT
+"$LAB_HELPER" provision "$SESSION"
+
+mkdir -p "$HOME_DIR"/{state,data,config,projects} "$PROJECT" "$FAKEBIN"
+: > "$LOG_FILE"
+
+# Route the production adapter's own Herdr calls through the guarded helper:
+# the shim strips only the adapter's validated trailing --session pair and
+# refuses anything scoped to another session, then the helper re-appends it.
+cat > "$FAKEBIN/herdr" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+helper='$LAB_HELPER'
+session='$SESSION'
+real_path='$ORIGINAL_PATH'
+args=("\$@")
+n=\${#args[@]}
+if [ "\$n" -ge 2 ] && [ "\${args[\$((n-2))]}" = --session ]; then
+  [ "\${args[\$((n-1))]}" = "\$session" ] || { echo 'wrapper refused foreign session' >&2; exit 97; }
+  args=("\${args[@]:0:\$((n-2))}")
+else
+  [ "\${HERDR_SESSION:-}" = "\$session" ] || { echo 'wrapper requires isolated session' >&2; exit 98; }
+fi
+PATH="\$real_path" exec "\$helper" run "\$session" "\${args[@]}"
+EOF
+chmod +x "$FAKEBIN/herdr"
+
+lab() { PATH="$ORIGINAL_PATH" "$LAB_HELPER" run "$SESSION" "$@"; }
+
+# --- the supervisor pane ----------------------------------------------------
+
+PANE=$(lab workspace create --cwd "$PROJECT" --label fm-statusbar-supervisor --no-focus \
+  | jq -r '.result.root_pane.pane_id')
+[ -n "$PANE" ] && [ "$PANE" != null ] || fail "the lab workspace did not return a root pane id"
+TARGET="$SESSION:$PANE"
+
+# Herdr can return a created pane before its shell is ready to accept Enter, so
+# require a stable shell-owned foreground before launching the fixture.
+ready=false
+for _ in $(seq 1 100); do
+  if lab pane process-info --pane "$PANE" 2>/dev/null | jq -e '
+    .result.process_info as $p
+    | ($p.foreground_processes | length == 1)
+      and ($p.foreground_processes[0].pid == $p.shell_pid)' >/dev/null 2>&1; then
+    ready=true
+    break
+  fi
+  sleep 0.2
+done
+[ "$ready" = true ] || fail "the lab supervisor pane's shell never became ready"
+
+LOOP_SCRIPT="$TMP_ROOT/statusbar-loop.sh"
+cat > "$LOOP_SCRIPT" <<LOOP
+#!/usr/bin/env bash
+# Draws the outage geometry: a bare agent-glyph composer row with a status bar
+# BELOW it. Two of the bar's rows are adjacent solid rules, which is exactly
+# the separated shape; the cursor is returned to the composer row with a
+# RELATIVE move, so the block stays correct even when drawing the bar scrolls
+# the pane.
+MARK=\$'\xE2\x81\xA3'
+LOG="\$1"
+HELPER='$LAB_HELPER'
+SESSION='$SESSION'
+PANE='$PANE'
+report_agent_state() {  # <idle|working>
+  "\$HELPER" run "\$SESSION" pane report-agent "\$PANE" \
+    --source fm-test-supervisor --agent fm-test-supervisor --state "\$1" >/dev/null 2>&1
+}
+BAR=(
+'────────────────────────────────────────'
+'  BLAKE OS | CC: 2.1.235 | RZESZOW, 19'
+'  ┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄'
+'  PWD: lab'
+'  ────────────────────────────────────────'
+'  CONTEXT: 12%'
+'  ········································'
+'  ────────────────────────────────────────'
+'  USE: 5HR: 61% | WEEK: 65% (SUB/API)'
+'  ────────────────────────────────────────'
+'  ────────────────────────────────────────'
+'  "There is no next time." -Celestine Chua'
+'  bypass permissions on (shift+tab to cycle)'
+)
+OLD_STTY=\$(stty -g 2>/dev/null || true)
+[ -z "\$OLD_STTY" ] || stty -echo -icanon min 1 time 0 2>/dev/null || true
+cleanup() { [ -z "\$OLD_STTY" ] || stty "\$OLD_STTY" 2>/dev/null || true; }
+trap cleanup EXIT INT TERM
+report_agent_state idle
+
+_buf=
+redraw() {
+  local avail=40 shown tail_n row
+  if [ "\${#_buf}" -gt "\$avail" ]; then
+    tail_n=\$((avail - 3))
+    shown="...\${_buf: -\$tail_n}"
+  else
+    shown="\$_buf"
+  fi
+  printf '\r\033[K❯ %s' "\$shown"
+  for row in "\${BAR[@]}"; do printf '\n\033[K%s' "\$row"; done
+  printf '\033[J'
+  printf '\033[%dA\r\033[K❯ %s' "\${#BAR[@]}" "\$shown"
+}
+submit_line() {
+  local _line=\$_buf _c _hex
+  if [ "\${_line:0:1}" = "\$MARK" ]; then _c="injection"; else _c="user"; fi
+  _hex=\$(printf '%s' "\$_line" | od -An -tx1 | tr -d ' \n')
+  printf '%s\t%s\t%s\n' "\$_hex" "\$_line" "\$_c" >> "\$LOG"
+  _buf=
+  printf '\r\033[K\n'
+  redraw
+  report_agent_state working
+  sleep 0.6
+  report_agent_state idle
+}
+
+redraw
+while IFS= read -r -n 1 _ch; do
+  if [ -z "\$_ch" ]; then submit_line; continue; fi
+  case "\$_ch" in
+    \$'\r'|\$'\n') submit_line ;;
+    \$'\177'|\$'\b') _buf=\${_buf%?}; redraw ;;
+    *) _buf="\${_buf}\${_ch}"; redraw ;;
+  esac
+done
+LOOP
+chmod +x "$LOOP_SCRIPT"
+
+PATH="$FAKEBIN:$ORIGINAL_PATH" HERDR_SESSION="$SESSION" \
+  fm_backend_herdr_send_text_line "$TARGET" "bash '$LOOP_SCRIPT' '$LOG_FILE'" \
+  || fail "could not start the status-bar supervisor loop in the lab pane"
+sleep 2
+
+# --- 1. the classifier, live on the outage geometry -------------------------
+
+verdict=$(PATH="$FAKEBIN:$ORIGINAL_PATH" HERDR_SESSION="$SESSION" \
+  fm_backend_composer_state herdr "$TARGET")
+[ "$verdict" = empty ] \
+  || fail "an idle composer with a status bar drawn below it must classify empty, got '$verdict'"
+pass "live herdr: an idle composer under a 13-row status bar classifies empty"
+
+# --- 2. fm-send confirms its own Enter --------------------------------------
+# The outage's second symptom: the text landed in the composer but the submit
+# read-back never confirmed, so every steer had to be finished by hand with
+# `herdr pane send-keys <pane> Enter`. Exit 3 is fm-send's own code for that.
+#
+# The pane is put MID-TURN first, on purpose. Herdr confirms a submit from
+# native agent-state when the pre-Enter baseline is legibly idle, and only
+# falls back to reading the composer when it is not - so a pane that is idle
+# when the steer arrives never exercises this defect at all. The pane firstmate
+# was steering that night was a working agent, which is exactly the case that
+# falls back to the composer read and got `unknown`.
+lab pane report-agent "$PANE" --source fm-test-supervisor \
+  --agent fm-test-supervisor --state working >/dev/null
+
+cat > "$STATE/steer-task.meta" <<EOF
+window=$TARGET
+backend=herdr
+kind=ship
+mode=no-mistakes
+worktree=$PROJECT
+project=synthetic-project
+EOF
+
+send_rc=0
+PATH="$FAKEBIN:$ORIGINAL_PATH" HERDR_SESSION="$SESSION" \
+  FM_HOME="$HOME_DIR" FM_ROOT_OVERRIDE="$HOME_DIR" \
+  "$ROOT/bin/fm-send.sh" steer-task "steer under the status bar" \
+  >"$TMP_ROOT/send.out" 2>"$TMP_ROOT/send.err" || send_rc=$?
+sleep 1
+# The line reaching the pane is not the point: it reached the pane during the
+# outage too. The point is that fm-send can now SEE that it did, so the caller
+# is not left re-sending Enter by hand over an instruction that already landed.
+grep -qF 'steer under the status bar' "$LOG_FILE" \
+  || fail "the steer never reached the pane at all (exit $send_rc): $(tail -1 "$TMP_ROOT/send.err")"
+[ "$send_rc" -eq 0 ] \
+  || fail "the steer landed but fm-send reported it undelivered (exit $send_rc): $(tail -1 "$TMP_ROOT/send.err")"
+pass "live herdr: fm-send confirms its own submit under the status bar, with no hand-sent Enter"
+
+# --- 3. the away-mode cycle: delivered AND confirmed ------------------------
+
+: > "$LOG_FILE"
+afk_enter "$STATE"
+PATH="$FAKEBIN:$ORIGINAL_PATH" \
+HERDR_SESSION="$SESSION" \
+FM_STATE_OVERRIDE="$STATE" \
+FM_SUPERVISOR_BACKEND=herdr \
+FM_SUPERVISOR_TARGET="$TARGET" \
+FM_ESCALATE_BATCH_SECS=0 \
+FM_HOUSEKEEPING_TICK=1 \
+FM_POLL=1 \
+FM_SIGNAL_GRACE=1 \
+FM_HEARTBEAT=999999 \
+FM_CHECK_INTERVAL=999999 \
+FM_MAX_DEFER_SECS=20 \
+FM_INJECT_CONFIRM_SLEEP=0.5 \
+FM_INJECT_CONFIRM_RETRIES=6 \
+FM_STALE_ESCALATE_SECS=999999 \
+  nohup "$ROOT/bin/fm-supervise-daemon.sh" >"$TMP_ROOT/daemon.out" 2>"$TMP_ROOT/daemon.err" &
+DAEMON_PID=$!
+started=false
+for _ in $(seq 1 40); do
+  if grep -q 'backend=herdr' "$STATE/.supervise-daemon.log" 2>/dev/null; then started=true; break; fi
+  kill -0 "$DAEMON_PID" 2>/dev/null || break
+  sleep 0.25
+done
+[ "$started" = true ] || fail "the away daemon never recorded backend=herdr: $(cat "$TMP_ROOT/daemon.err")"
+
+echo "done: PR https://example.test/pr/900" > "$STATE/fake-c1.status"
+delivered=false
+for _ in $(seq 1 40); do
+  grep -q 'Supervisor escalate' "$LOG_FILE" && { delivered=true; break; }
+  sleep 0.5
+done
+[ "$delivered" = true ] \
+  || fail "the escalation was never delivered under the status bar; daemon log: $(tail -5 "$STATE/.supervise-daemon.log" 2>/dev/null)"
+marker_count=$(awk -F '\t' '{ hex=$1; count += gsub(/e281a3/, "", hex) } END { print count + 0 }' "$LOG_FILE")
+[ "$marker_count" -eq 1 ] \
+  || fail "expected exactly one delivered escalation, got $marker_count (duplicate or lost)"
+digest_line=$(grep 'Supervisor escalate' "$LOG_FILE" | head -1)
+case "$digest_line" in
+  *injection) ;;
+  *) fail "the delivered escalation was misclassified (expected injection): $digest_line" ;;
+esac
+[ ! -s "$STATE/.subsuper-inject-wedged" ] \
+  || fail "the daemon raised the wedge alarm even though the composer was readable"
+pass "live herdr: an away-mode escalation is delivered and confirmed exactly once under the status bar"
+
+# --- 4. the injection gate, live under the same status bar ------------------
+# The fix must not have bought delivery by declaring the pane empty: real typed
+# text under the SAME status bar must still hold the next escalation back.
+
+: > "$LOG_FILE"
+PATH="$FAKEBIN:$ORIGINAL_PATH" HERDR_SESSION="$SESSION" \
+  fm_backend_herdr_send_literal "$TARGET" "captain half-written sentence"
+sleep 1
+verdict=$(PATH="$FAKEBIN:$ORIGINAL_PATH" HERDR_SESSION="$SESSION" \
+  fm_backend_composer_state herdr "$TARGET")
+[ "$verdict" = pending ] \
+  || fail "real typed text under the status bar must read pending, got '$verdict'"
+echo "needs-decision: pick A or B" > "$STATE/fake-c2.status"
+sleep 10
+if grep -q 'Supervisor escalate' "$LOG_FILE"; then
+  fail "the daemon injected over the captain's half-written sentence"
+fi
+PATH="$FAKEBIN:$ORIGINAL_PATH" HERDR_SESSION="$SESSION" \
+  fm_backend_herdr_send_key "$TARGET" Enter
+sleep 1
+for _ in $(seq 1 40); do
+  grep -q 'Supervisor escalate' "$LOG_FILE" && break
+  sleep 0.5
+done
+grep -qF 'captain half-written sentence' "$LOG_FILE" \
+  || fail "the captain's own line was lost instead of submitted"
+grep -q 'Supervisor escalate' "$LOG_FILE" \
+  || fail "the held escalation never arrived after the composer went idle"
+if grep -q 'captain half-written sentence.*Supervisor escalate' "$LOG_FILE" \
+   || grep -q 'Supervisor escalate.*captain half-written sentence' "$LOG_FILE"; then
+  fail "the captain's line and the escalation were merged into one submission"
+fi
+pass "live herdr: the injection gate still holds over real typed text under the status bar"
+
+afk_exit "$STATE" 2>/dev/null || true
+kill "$DAEMON_PID" 2>/dev/null || true
+wait "$DAEMON_PID" 2>/dev/null || true
+DAEMON_PID=
+echo "# all fm-composer-statusbar-herdr-e2e tests passed"


### PR DESCRIPTION
## The defect

The cursorless composer ranking takes the bottom-most shape, so anything a terminal draws UNDER the input row competes with the real composer.
Pi's `separated` shape is nothing but a region between two solid rules, so a status bar, a footer, or two transcript rules forge one trivially - and it outranked the real bare agent-glyph composer above it.

On a machine whose shell renders a 12-row status bar below Claude's input row, every pane read `unknown`.
Two consequences, both measured:

- The away-mode daemon refused to deliver 196 consecutive times over 4229 s with the work already finished.
- `fm-send` reported every steer's Enter unconfirmed, because real typed text under the same status bar also read `unknown` instead of `pending`.

## The fix

`separated` is the only shape identity can refute, and its verdict is already identity-gated.
The cursorless path now asks whether the pi rules DECIDE the selection and, when they do, spends the same lazy identity probe it already had: an agent proven not to be pi has no pi composer, so the forged pair drops out and the input row above it is found.

Only positive identity proof moves a verdict.
No identity capability, an unfetched identity, an absent probe, and a live pi all keep the pi rules exactly as strict as before, so the identity-less backends see no behavior change at all.

Two adjacent rules now also fail the shape outright: a pair that encloses no row cannot hold an input row, yet every content check over that empty range trivially succeeded and read `empty`.

The tmux Cursor reclassification re-reads its pane through the same identity-capable cursorless path, so it now resolves the probe itself instead of letting the classifier's internal identity request escape the adapter - reachable today whenever anything below the composer forges a pair.

## The gates are untouched, and there is a test that says so

Against the same status-bar screen and the same proven-non-pi identity that turns it into `empty`, each of these must still refuse, and does: a dead shell below the composer, an unclosed modal, a mid-redraw pane whose composer row is not drawn yet, an unidentified text row, and a bare shell glyph.

## Evidence

Portable regressions in `tests/fm-composer-lib.test.sh` and `tests/fm-composer-ghost.test.sh`; both new regressions fail against the unchanged classifier.

Live, herdr 0.7.5 with Claude Code 2.1.235: five of five real panes read `unknown` before and `empty` after, with no other change to the panes.

End to end against real Herdr in an isolated `fm-herdr-lab.sh` session (`tests/fm-composer-statusbar-herdr-e2e.test.sh`, `real-herdr-gated`), same scenario run against the classifier before and after:

| observation | before | after |
| --- | --- | --- |
| composer verdict on the idle pane | `unknown` | `empty` |
| away-mode escalation delivered within 30 s | no | yes |
| daemon deferrals recording an unreadable composer | 14 | 0 |
| max-defer wedge alarm raised | yes | no |
| `fm-send` exit status for a steer that did reach the pane | 1 | 0 |

That last row is the hand-sent-Enter workaround in one number: the text reached the pane in both runs, but only after the fix can `fm-send` see that it did.
The guard reports the pane mid-turn on purpose, because Herdr confirms a submit from native agent-state whenever the pre-Enter baseline is legibly idle and falls back to the composer read only when it is not.

A fourth leg keeps the fix honest: real typed text under that same status bar still reads `pending`, the daemon holds its escalation back rather than typing over the half-written line, and the held escalation arrives as its own separate submission once the pane goes idle.

The live composer matrix was rerun on Linux to confirm the enclosed-row requirement against real shapes; Pi's real separated composer still reaches `empty`.
Dated results are in `docs/verification/runtime-backends.md`.

## Noted, not fixed here

Kimi 1.44.0 no longer draws the bordered `│ > │` composer this repo's matrix records - it draws a titled `── input ──` rule above its input rows and a plain rule below - so it classifies `unknown`, identically before and after this change.
