### PR TITLE
fix(ci): exempt release-please PRs from no-mistakes gate

### DIFF
--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -50,9 +50,9 @@ jobs:
           # them. Identify them by what release-please itself produces: a branch
           # under its own reserved prefix, pushed to THIS repository, carrying the
           # generated Release Please footer in the body. Requiring all three keeps
-          # a hand-written PR from claiming the exemption with a borrowed branch
-          # name or a copied body, because only a writer to this repository can
-          # create the branch here and only release-please writes that body.
+          # an untrusted fork from claiming the exemption with a borrowed branch
+          # name or copied body, while avoiding a blanket exemption for the human
+          # identity whose token release-please uses.
           release_please_branch=no
           case "${PR_HEAD_REF:-}" in
             release-please--* | release-please/*) release_please_branch=yes ;;

--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -19,21 +19,52 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Every exemption lives in the step script below, never in a job-level `if`,
+  # so the whole decision is one executable contract that tests can run.
   check:
     name: PR must be raised via no-mistakes
     runs-on: ubuntu-latest
-    if: >-
-      github.event.pull_request.user.login != 'github-actions[bot]' &&
-      github.event.pull_request.user.login != 'dependabot[bot]'
     steps:
       - name: Verify no-mistakes signature in PR body
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
         run: |
           set -eu
           marker='Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)'
+          release_please_marker='This PR was generated with [Release Please](https://github.com/googleapis/release-please)'
+
+          case "${PR_AUTHOR:-}" in
+            'github-actions[bot]' | 'dependabot[bot]')
+              echo "PR #${PR_NUMBER} was raised by ${PR_AUTHOR}; automation is exempt."
+              exit 0
+              ;;
+          esac
+
+          # release-please release PRs are automation even when a personal access
+          # token makes them look human-authored, so author login cannot identify
+          # them. Identify them by what release-please itself produces: a branch
+          # under its own reserved prefix, pushed to THIS repository, carrying the
+          # generated Release Please footer in the body. Requiring all three keeps
+          # a hand-written PR from claiming the exemption with a borrowed branch
+          # name or a copied body, because only a writer to this repository can
+          # create the branch here and only release-please writes that body.
+          release_please_branch=no
+          case "${PR_HEAD_REF:-}" in
+            release-please--* | release-please/*) release_please_branch=yes ;;
+          esac
+          if [ "$release_please_branch" = yes ] &&
+            [ -n "${BASE_REPO:-}" ] &&
+            [ "${PR_HEAD_REPO:-}" = "${BASE_REPO:-}" ] &&
+            printf '%s' "${PR_BODY:-}" | grep -qF -- "$release_please_marker"; then
+            echo "PR #${PR_NUMBER} is a release-please release PR (${PR_HEAD_REF}); release automation is exempt."
+            exit 0
+          fi
+
           if printf '%s' "${PR_BODY:-}" | grep -qF -- "$marker"; then
             echo "Found no-mistakes signature in PR #${PR_NUMBER} body."
             exit 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,8 @@ Pushing through it runs an AI-driven review/test/lint pipeline in an isolated wo
 
 A GitHub Actions check (`Require no-mistakes`) runs on PRs targeting `main` and fails if the body is missing the deterministic signature that no-mistakes writes.
 It evaluates every PR opening and body edit independently, so a later edit cannot replace an earlier pending compliance check.
-GitHub Actions and Dependabot are exempt so their automation keeps working, but regular contributor PRs without the signature will not be reviewed or merged.
+GitHub Actions, Dependabot, and release-please release automation are exempt so their automation keeps working, but regular contributor PRs without the signature will not be reviewed or merged.
+The [`Require no-mistakes` workflow](.github/workflows/no-mistakes-required.yml) owns the exact automation-classification contract.
 
 ## Workflow
 

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -141,6 +141,7 @@ family_for_basename() {
     fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
     fm-kimi-harness.test.sh|fm-muse-harness.test.sh|fm-herdr-lab.test.sh|fm-lint.test.sh|\
     fm-lint-workflows.test.sh|\
+    fm-no-mistakes-required-workflow.test.sh|\
     fm-operational-input.test.sh|fm-pi-primary-types.test.sh|\
     fm-send-popup-settle.test.sh|fm-send-settle.test.sh|\
     fm-subagent-pretool-check.test.sh|\

--- a/tests/fm-no-mistakes-required-workflow.test.sh
+++ b/tests/fm-no-mistakes-required-workflow.test.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1091,SC2016
+# Gate contract of .github/workflows/no-mistakes-required.yml.
+#
+# The check must exempt automation that cannot use the no-mistakes pipeline
+# while still failing an ordinary human PR that lacks the pipeline signature.
+# release-please opens its release PRs under a personal access token, so the
+# author login reads as the repository owner and the bot exemptions never
+# matched; every release needed a manual owner override (kunchenguid/sshhip#293
+# is a real release PR that failed this check).
+#
+# The workflow is copied verbatim into consumer repositories, so the decision
+# cannot move into a helper script. It lives in one shell step instead, and this
+# test loads the workflow through a real YAML parser and executes that step's
+# script with the environment GitHub would supply. It never asserts workflow
+# source text.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+WORKFLOW="$ROOT/.github/workflows/no-mistakes-required.yml"
+
+command -v ruby >/dev/null 2>&1 \
+  || fail "ruby is required to parse .github/workflows/no-mistakes-required.yml as YAML"
+
+# Exact body of a real release-please release PR (kunchenguid/sshhip#293).
+RELEASE_PLEASE_BODY=':robot: I have created a release *beep* *boop*
+---
+
+
+## [1.22.0](https://github.com/kunchenguid/sshhip/compare/sshhip-v1.21.1...sshhip-v1.22.0) (2026-08-18)
+
+
+### Features
+
+* **ios:** support OSC 8 terminal hyperlinks
+
+---
+This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).'
+
+NO_MISTAKES_BODY='## Summary
+
+Something useful.
+
+## Pipeline
+
+Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)'
+
+HUMAN_BODY='## Summary
+
+Hand-written change with no pipeline behind it.'
+
+TMP_ROOT=$(fm_test_tmproot fm-nm-required-workflow)
+GATE="$TMP_ROOT/gate.sh"
+
+extract_gate_script() {
+  ruby -ryaml -e '
+doc = YAML.load_file(ARGV[0])
+job = doc.fetch("jobs").fetch("check")
+if job.key?("if")
+  raise "job-level `if` gating: the exemption decision must stay in the executable step"
+end
+steps = job.fetch("steps")
+raise "expected exactly one gate step, got #{steps.length}" unless steps.length == 1
+print steps.fetch(0).fetch("run")
+' "$WORKFLOW"
+}
+
+extract_gate_script > "$GATE" \
+  || fail "could not load the gate step from $WORKFLOW"
+chmod +x "$GATE"
+
+# Runs the gate exactly as the workflow step would, with GitHub's environment.
+# Usage: run_gate <author> <head_ref> <head_repo> <body>
+run_gate() {
+  local author=$1 head_ref=$2 head_repo=$3 body=$4
+  GATE_RC=0
+  GATE_OUT=$(
+    PR_BODY="$body" \
+    PR_AUTHOR="$author" \
+    PR_NUMBER=4242 \
+    PR_HEAD_REF="$head_ref" \
+    PR_HEAD_REPO="$head_repo" \
+    BASE_REPO=kunchenguid/firstmate \
+      bash "$GATE" 2>&1
+  ) || GATE_RC=$?
+}
+
+test_release_please_pr_is_exempt() {
+  run_gate kunchenguid \
+    release-please--branches--main--components--sshhip \
+    kunchenguid/firstmate \
+    "$RELEASE_PLEASE_BODY"
+  [ "$GATE_RC" -eq 0 ] \
+    || fail "release-please release PR must pass without an owner override"$'\n'"$GATE_OUT"
+  assert_contains "$GATE_OUT" "release-please release PR" \
+    "gate did not report why the release PR was exempt"
+  pass "a release-please release PR passes without the no-mistakes signature"
+}
+
+test_legacy_release_please_branch_is_exempt() {
+  run_gate kunchenguid \
+    release-please/branches/main \
+    kunchenguid/firstmate \
+    "$RELEASE_PLEASE_BODY"
+  [ "$GATE_RC" -eq 0 ] \
+    || fail "release-please's slash branch layout must also be exempt"$'\n'"$GATE_OUT"
+  pass "the older release-please branch layout is exempt too"
+}
+
+test_human_pr_without_signature_still_fails() {
+  run_gate kunchenguid feature/manual-edit kunchenguid/firstmate "$HUMAN_BODY"
+  [ "$GATE_RC" -ne 0 ] \
+    || fail "a human PR without the no-mistakes signature must still fail"$'\n'"$GATE_OUT"
+  assert_contains "$GATE_OUT" "not raised through no-mistakes" \
+    "failure did not explain the missing pipeline signature"
+  pass "a human PR without the pipeline signature still fails"
+}
+
+test_human_pr_with_signature_passes() {
+  run_gate kunchenguid fm/some-task kunchenguid/firstmate "$NO_MISTAKES_BODY"
+  [ "$GATE_RC" -eq 0 ] \
+    || fail "a PR carrying the no-mistakes signature must pass"$'\n'"$GATE_OUT"
+  pass "a PR carrying the no-mistakes signature passes"
+}
+
+test_release_please_branch_name_alone_is_not_enough() {
+  # A contributor cannot borrow the exemption by naming a branch after
+  # release-please: the generated release body must be there too.
+  run_gate kunchenguid \
+    release-please--branches--main--components--sneaky \
+    kunchenguid/firstmate \
+    "$HUMAN_BODY"
+  [ "$GATE_RC" -ne 0 ] \
+    || fail "a release-please branch name alone must not grant the exemption"$'\n'"$GATE_OUT"
+  pass "a release-please-shaped branch name alone does not grant the exemption"
+}
+
+test_release_please_body_from_a_fork_is_not_enough() {
+  # Only a writer to this repository can push a release-please branch here, so
+  # a fork copying the generated body must not be exempt.
+  run_gate someone \
+    release-please--branches--main--components--sshhip \
+    someone/firstmate \
+    "$RELEASE_PLEASE_BODY"
+  [ "$GATE_RC" -ne 0 ] \
+    || fail "a fork copying a release-please body must not be exempt"$'\n'"$GATE_OUT"
+  pass "a fork copying a release-please body is not exempt"
+}
+
+test_bot_authors_remain_exempt() {
+  local author
+  for author in 'github-actions[bot]' 'dependabot[bot]'; do
+    run_gate "$author" "dependabot/npm_and_yarn/x" kunchenguid/firstmate "$HUMAN_BODY"
+    [ "$GATE_RC" -eq 0 ] \
+      || fail "$author must stay exempt"$'\n'"$GATE_OUT"
+  done
+  pass "the existing bot author exemptions still hold"
+}
+
+test_release_please_pr_is_exempt
+test_legacy_release_please_branch_is_exempt
+test_human_pr_without_signature_still_fails
+test_human_pr_with_signature_passes
+test_release_please_branch_name_alone_is_not_enough
+test_release_please_body_from_a_fork_is_not_enough
+test_bot_authors_remain_exempt


### PR DESCRIPTION
## Intent

Exempt release-please's own release PRs from firstmate's required no-mistakes enforcement check (.github/workflows/no-mistakes-required.yml).

Problem: the workflow requires every PR to main to carry the no-mistakes pipeline signature in its body, exempting only github-actions[bot] and dependabot[bot]. release-please now authors its release PRs under the kunchenguid identity via a personal access token, not the exempt bot, so automated release PRs FAIL the required check and need a manual owner override on every release. This was reproduced first, as the brief required: kunchenguid/sshhip PR #293 ('chore(main): release sshhip 1.22.0', head branch release-please--branches--main--components--sshhip, user kunchenguid) has check run 'PR must be raised via no-mistakes' with conclusion failure; running the pre-fix step script locally with that PR's environment also exits 1.

CRITICAL DESIGN CONSTRAINT stated by the requester: do NOT exempt the kunchenguid human identity broadly, because that would also exempt the captain's own hand-authored PRs and defeat the gate. The release PRs must be identified by a reliable release-please-specific signal determined from how release-please actually opens these PRs.

Deliberate decisions made while doing the work:
- Exempt only when THREE release-please facts hold together: (1) head branch under release-please's reserved prefix (release-please--* for the current manifest layout, plus release-please/* for the older layout), (2) the head repository equals the base repository, so a fork can never claim it, and (3) the generated 'This PR was generated with [Release Please](https://github.com/googleapis/release-please)' footer is present in the PR body. Requiring all three means a hand-written human PR cannot claim the exemption with a borrowed branch name or a copied body, since only a writer to the repository can push that branch here.
- Deliberately did NOT use the release-please label (autorelease: pending): release-please labels the PR after creating it, so an 'opened' event can race the label and make the gate flaky. Author login is deliberately not used at all for release PRs.
- Deliberately moved the existing github-actions[bot] / dependabot[bot] exemptions out of the job-level 'if' expression into the same step shell script, so the whole exemption decision is one executable contract in one place rather than split between a GitHub expression and a script. Consequence: exempt bot PRs now report a successful check instead of a skipped one, which is equivalent or better for a required check.
- The workflow is a shared template copied verbatim into consumer repositories (SSHHIP carries a byte-verbatim copy), so the decision deliberately stays inline in the workflow and must NOT be factored out into a bin/ helper script that consumers would also have to copy, and that PR-head content could tamper with.

Test: tests/fm-no-mistakes-required-workflow.test.sh loads the workflow through a real YAML parser (ruby/psych, the same approach tests/fm-test-run.test.sh already uses for ci.yml) and EXECUTES the extracted step script with the environment GitHub supplies, asserting observable exit status and output - it never asserts workflow source text. Cases: a real release-please release PR (using the exact body of sshhip#293) is exempt; the older release-please branch layout is exempt; both bot authors stay exempt; a human PR without the pipeline signature still FAILS; a release-please-shaped branch name alone without the generated body FAILS; a fork copying a release-please body FAILS. It also asserts, through the parsed semantic model, that the job carries no job-level 'if', so the decision cannot silently move back out of the executable step and escape the test. The new test is classified into the pure-contract-unit family in bin/fm-test-run.sh; it was deliberately NOT added to the proven-isolated set, which requires a new concurrent isolation proof archive.

Acceptance criteria from the requester: a release-please release PR passes without an owner override; a non-exempt human PR to main without the no-mistakes signature still fails; the failure was reproduced first; a test asserts both the exemption and the still-fails-for-humans behavior; the change stays adoptable by consumer repositories and the PR notes that consumers carrying a verbatim copy (SSHHIP) must re-sync this workflow.

## What Changed

- Exempt same-repository release-please PRs only when their reserved branch prefix and generated footer both match, while unsigned human and fork PRs still fail.
- Move existing GitHub Actions and Dependabot exemptions into the executable gate script so exempt automation reports success.
- Add parser-backed contract coverage and documentation for the exemption; consumers with verbatim workflow copies, including SSHHIP, must re-sync the workflow.

## Risk Assessment

✅ Low: The change is narrowly scoped and the three-factor release-please exemption preserves failure behavior for ordinary unsigned human and fork PRs while retaining existing bot exemptions.

## Testing

Inspected the workflow change, ran its focused executable contract test directly and through the classified test runner, then captured an end-user-style CI transcript proving the pre-fix failure, successful release-please exemption, and continued rejection of unsigned human and fork PRs; all checks behaved as intended and the worktree remained clean.

<details>
<summary>Evidence: Required-check behavior before and after the release-please exemption</summary>

Source: [Required-check behavior before and after the release-please exemption](https://github.com/kunchenguid/firstmate/blob/17fc531fd676990a1a7fc7ea8ed688fc79bc88f3/.no-mistakes/evidence/fm/nm-required-exempt-release-please-r1/no-mistakes-required-behavior.txt)

```text
No-mistakes required-check behavior transcript
Scripts were parsed from workflow YAML with Ruby Psych and executed with pull-request environment variables.

=== PRE-FIX: real release-please-shaped PR is rejected ===
exit_status=1
::error::This PR was not raised through no-mistakes.

Contributions to this repository must be submitted via 'git push no-mistakes'.
That pipeline runs the required review/test/lint/CI steps and writes a
deterministic '## Pipeline' section into the PR body containing:

    Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

See CONTRIBUTING.md for setup and the full workflow.

PR author: kunchenguid

=== FIXED: same release-please-shaped PR is exempt ===
exit_status=0
PR #293 is a release-please release PR (release-please--branches--main--components--sshhip); release automation is exempt.

=== FIXED: ordinary human PR remains rejected ===
exit_status=1
::error::This PR was not raised through no-mistakes.

Contributions to this repository must be submitted via 'git push no-mistakes'.
That pipeline runs the required review/test/lint/CI steps and writes a
deterministic '## Pipeline' section into the PR body containing:

    Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

See CONTRIBUTING.md for setup and the full workflow.

PR author: kunchenguid

=== FIXED: fork cannot claim release exemption ===
exit_status=1
::error::This PR was not raised through no-mistakes.

Contributions to this repository must be submitted via 'git push no-mistakes'.
That pipeline runs the required review/test/lint/CI steps and writes a
deterministic '## Pipeline' section into the PR body containing:

    Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

See CONTRIBUTING.md for setup and the full workflow.

PR author: someone
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"acdf98aaa051c5f20d8c1fdf7408cff41fff66e6","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff 03bb1d8b78a8632ae2d9cea4c10868eb100e885e..607f5d52051b2f65a3d87a9a7472daf44fd3d2a4`.</code>
- `bash tests/fm-no-mistakes-required-workflow.test.sh`
- `bin/fm-test-run.sh tests/fm-no-mistakes-required-workflow.test.sh`
- `Parsed the pre-fix and fixed workflow scripts with Ruby Psych and executed them using release-please, ordinary-human, and fork PR environments; confirmed pre-fix rejection, fixed exemption, and retained rejection safeguards.`
- <code>`git status --short` confirmed testing left the worktree clean.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
