### PR TITLE
test: make process-event assertions deterministic

### DIFF
--- a/tests/fm-procevent.test.sh
+++ b/tests/fm-procevent.test.sh
@@ -87,6 +87,21 @@ wait_for() {  # <file> [tries]
   return 1
 }
 
+# <file> <count> [tries]: wait until <file> holds at least <count> lines. A
+# detached runner appends its execution marker after the command that started it
+# has already returned, so a caller that needs that append must wait for it
+# rather than assume a fixed settle window covered it on a loaded machine.
+wait_for_lines() {
+  local f=$1 want=$2 n=${3:-100} have
+  for _ in $(seq 1 "$n"); do
+    have=$(wc -l < "$f" 2>/dev/null | tr -d ' ')
+    case "$have" in ''|*[!0-9]*) have=0 ;; esac
+    [ "$have" -ge "$want" ] && return 0
+    sleep 0.1
+  done
+  return 1
+}
+
 hold_source_lock() {  # <source-id> <ready-file> <release-file>
   local id=$1 ready=$2 release=$3 parent=$$
   FM_HOME="$TMP_ROOT/lock-helper-home" bash -c '
@@ -146,7 +161,10 @@ sup=$(PATH="${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}" bash -c \
 assert_contains "$sup" yes "a registered source needs supervision with no task metadata"
 
 pe "$H1" reconcile >/dev/null
-sleep 0.5
+# Reconcile's replacement runner is detached, so ownership is recorded after
+# reconcile has already returned. Wait for the claim itself: a duplicate start
+# only has an owner to lose to once that claim exists.
+wait_for "$FM_PROCEVENT_CLAIM_ROOT/src-one.claim" || fail "reconcile never claimed the registered source"
 out=$(pe "$H1" start src-one)
 assert_contains "$out" "already owned" "a duplicate start loses instead of running a second child"
 
@@ -383,8 +401,16 @@ assert_contains "$out" "not-autohandled: publish-src" "failed publication did no
 assert_absent "$HPUBLISH/state/applied" "a result was applied before its wake was durably published"
 assert_absent "$HPUBLISH/state/procevent-inbox/publish-src.1.handled" "a result was acknowledged before its wake was durably published"
 rmdir "$HPUBLISH/state/.wake-queue"
+# This source's child returns instantly, so leaving it registered would have the
+# recovery reconcile below start a detached poll that races every assertion after
+# it for the source claim, the next sequence, and this home's applied record.
+# Re-announcement is proven from the durable inbox alone and needs no
+# registration, so retire it first - the same retire-before-reconcile discipline
+# the blocker-backed sources rely on - and prove no competing poll was started.
+pe_adapter "$HPUBLISH" retire publish-src >/dev/null
 out=$(pe_adapter "$HPUBLISH" reconcile)
 assert_contains "$out" "published=1" "the unpublished capture was not announced on later reconciliation"
+assert_contains "$out" "started=0" "reconcile started an always-ready poll that races the recovery assertions"
 assert_contains "$(wake_payloads "$HPUBLISH")" "procevent applying publish-src 1" "later reconciliation did not deliver the capture to a handler"
 FM_HOME="$HPUBLISH" FM_PROCEVENT_UNDER_TEST="$ROOT/bin/fm-procevent.sh" \
   "$ADAPTER_ROOT/bin/fm-procevent-applying.sh" autohandle publish-src 1 \
@@ -403,6 +429,7 @@ PE_TRACKED+=("$HSELF|self-src")
 pe_adapter "$HSELF" register selfann self-src -- /bin/echo "self announced" >/dev/null
 out=$(pe_adapter "$HSELF" start self-src 2>&1)
 assert_contains "$out" "autohandled: self-src" "the self-announcing adapter did not apply its own capture"
+assert_not_contains "$out" "not-autohandled" "the applied capture was still reported as left for the handler"
 assert_grep 'self-src 1' "$HSELF/state/applied" "the self-announcing capture was not applied"
 assert_present "$HSELF/state/procevent-inbox/self-src.1.handled" "the self-announcing application was not acknowledged"
 if [ -e "$HSELF/state/.wake-queue" ] && grep -q 'procevent selfann self-src 1' "$HSELF/state/.wake-queue"; then
@@ -795,8 +822,13 @@ sleep 0.5
 assert_absent "$ORPHAN_OVERLAP" "no replacement source starts while the crashed generation remains alive"
 case "$orphan_out" in
   *"started=1"*)
-    [ -e "$FM_PROCEVENT_CLAIM_ROOT/orphan-src.claim" ] \
+    # The replacement is detached: it records its own claim and execs its source
+    # after reconcile has already returned, so both effects must be waited for
+    # rather than snapshotted behind the settle window above.
+    wait_for "$FM_PROCEVENT_CLAIM_ROOT/orphan-src.claim" \
       || fail "a replacement runner started without recording its own claim"
+    wait_for_lines "$ORPHAN_LOG" 2 \
+      || fail "the replacement runner never started its source: $(cat "$ORPHAN_LOG")"
     [ "$(wc -l < "$ORPHAN_LOG" | tr -d ' ')" = 2 ] \
       || fail "reconcile did not start exactly one replacement source: $(cat "$ORPHAN_LOG")"
     ;;


### PR DESCRIPTION
## Intent

Fix the flaky assertion in tests/fm-procevent.test.sh and make it deterministic. The reported symptom was an intermittent "not ok - a failed self-announcing application was reported as applied (missing: not-autohandled: self-src)" that passed on rerun, was unrelated to the change under test, and had blocked unrelated PRs (it blocked the Herdr step-timeout PR #2413 and cost a stuck-crew recovery). This is the procevent-test flake and is deliberately SEPARATE from the watcher-lock flake already fixed in #2595. The task was scoped to: reproduce it in a tight loop until it flakes, pin down exactly which assertion and which timing assumption breaks, diagnose the race precisely, make it deterministic by fixing the real ordering/synchronization (wait on a condition instead of a fixed sleep; close the genuine TOCTOU), and prove it with many repeated local runs. A bare sleep-bump was ruled out as a last resort requiring justification, and weakening what the test verifies was explicitly ruled out.

WHAT THE INVESTIGATION FOUND, and why the diff is not the obvious one-liner a reviewer might expect:

1. Root cause, proven. The failure mode is NOT a wrong autohandle verdict. reconcile starts a replacement runner through detach_runner, which only forks: reconcile returns and counts the start before that runner has claimed its source or exec'd its child. With the section's always-ready /bin/echo source left registered, that detached poll steals the source claim from the very next start, so start exits early printing "already owned: self-src" and never reaches the autohandle branch that prints "not-autohandled". Proven by reverting one line of PR #2456 on this tree: the pre-fix version fails on the FIRST loop iteration with exactly the reported message and "--- output --- already owned: self-src".

2. Scope finding, deliberate and captain-informed. The exact reported assertion was ALREADY fixed on main by PR #2456 (retire-before-reconcile), merged 2026-08-16T05:41Z - one day AFTER it blocked PR #2413 (merged 2026-08-15T04:32Z). 128 full-suite runs of unmodified main at 6-8x concurrency never reproduced it. So this branch deliberately does NOT re-fix that assertion; it closes the defect CLASS that #2456 left only as a discipline comment with no enforcement, and it fixes the procevent flake that IS still live. Firstmate was told this scope finding and instructed to proceed on that basis.

3. What changed, all in tests/fm-procevent.test.sh:
- Publish-before-apply recovery section: it left its always-ready /bin/echo source registered across the recovery reconcile, so that reconcile launched a competing detached poll (measured directly: "reconciled: published=1 started=1"). That poll then raced every later assertion in the section for the source claim, the next capture sequence, and this home's state/applied record, produced a duplicate publish-src wake, and outlived the section still holding a live claim. It is now retired before that reconcile - re-announcement is proven from the durable inbox alone and needs no registration, which the src-cut section already demonstrates with no registration at all - and started=0 is now asserted so a competing poll cannot be reintroduced unnoticed. This is exactly the retire-before-reconcile discipline the self-announcing section already carries.
- Crashed-leader replacement section: this is the procevent flake still live on main. It snapshotted the replacement runner's claim file and execution log behind a fixed 0.5s settle window. On a loaded machine that window expires first, which is the CI flake behind "a replacement runner started without recording its own claim" and "reconcile did not start exactly one replacement source". Both effects are now waited for with bounded wait helpers; the exact one-replacement count assertion is preserved unchanged after the wait, so nothing is weakened. The pre-existing sleep 0.5 before the negative ORPHAN_OVERLAP assertion is intentionally left where it is: it is a settle window for a negative assertion, not the thing that flakes.
- Duplicate-start section: it slept a fixed 0.5s for reconcile's detached runner to record ownership before asserting that a second start loses to it. It now waits for that claim file instead.
- New wait_for_lines helper next to the existing wait_for, colocated in this suite the same way wait_for is.
- One assertion tightened because it could not fail as written: "autohandled: self-src" is a substring of "not-autohandled: self-src", so the applied path was accepted even when the runner reported the capture left for the handler. Added assert_not_contains "not-autohandled". This strengthens, never weakens.

4. Deliberately NOT changed: bin/. No production code is touched, on purpose. reconcile restarting an unowned registered source is its documented job and correct behavior; the always-ready /bin/echo source is a test fixture (a real source blocks). The defect is in the test's timing assumptions, not in fm-procevent.sh.

5. Evidence. Unmodified suite: 128 full runs at 6-8x concurrency produced 6 failing runs, all in the crashed-leader section. Fixed suite: 216 full runs under the same load (load average 25-50 throughout) produced zero failures. bin/fm-lint.sh clean (shellcheck 0.11.0 pinned, tests/*.sh is in its canonical file set).

Constraints honored: this touches firstmate's own shared tracked material, so firstmate-coding-guidelines was loaded and followed - one sentence per line in Markdown, plain dash never em dash, no agent co-author on the commit, tests colocated in tests/ extending the existing suite rather than a new runner, and behavior asserted through the executable runner interface rather than implementation source text.

## What Changed

- Replace fixed sleeps with bounded waits for detached runners to record claims and execution markers.
- Retire the publish-recovery source before reconciliation and assert that no competing poll starts.
- Tighten self-announcing adapter coverage to reject `not-autohandled` output on the successful path.

## Risk Assessment

✅ Low: The changes are limited to test synchronization, preserve existing behavioral assertions, and correctly wait for observable detached-runner state instead of assuming fixed timing.

## Testing

The focused process-event suite passed once through the project runner and eight more times concurrently, consistently exercising the corrected detached-runner synchronization and strengthened assertions; CLI transcripts were captured as reviewer evidence, and no visual artifact was applicable because this is a shell-test-only change.

<details>
<summary>Evidence: Focused process-event suite transcript</summary>

Source: [Focused process-event suite transcript](https://github.com/kunchenguid/firstmate/blob/ff0aa036eb5021b7f660f0cd83ac25c02598a260/.no-mistakes/evidence/fm/fm-procevent-test-flake-r1/fm-procevent-focused-run.log)

```text
FM_TEST_BEGIN 2026-08-19T09:20:21Z tests/fm-procevent.test.sh family=unclassified expected_gate_skip=none
ok - no configured source means no generated state and no process
ok - one blocking completion yields exactly one bounded normalized event
not-autohandled: direct-src (left for the handler; still unacknowledged)
ok - public start owns the process group recorded by its claim
ok - public start never claims an inherited caller process group
ok - an unhandled result survives restart and repeat drains, and only explicit acknowledgement stops its re-announcement
ok - publication cannot race a handled acknowledgement
ok - handled acknowledgement creation is private and fails safely
ok - automatic application waits for durable publication and failed publication remains recoverable
ok - a self-announcing adapter applies quietly and still publishes what it could not apply
not-autohandled: ends-src (left for the handler; still unacknowledged)
ok - an adapter-classified terminal result is captured once, announced, and retires its source automatically
not-autohandled: open-src (left for the handler; still unacknowledged)
ok - a source stays armed unless its own adapter classifies the result terminal
not-autohandled: replace-src (left for the handler; still unacknowledged)
ok - terminal retirement preserves and releases a concurrently replaced registration
ok - failed terminal retirement is fail-closed and idempotently recoverable
ok - one Send & End yields exactly one captured result, automatic retirement, and no recurring poll
ok - a drained-but-unhandled result survives a replacement session and is retired only by explicit handling, never twice
ok - pending results preserve numeric order and distinct wake identity
ok - one owner per canonical source across homes
ok - retiring a never-completing source stops its runner and its blocked child
ok - reconcile reaps a runner whose source registration is gone
not-autohandled: stale-src (left for the handler; still unacknowledged)
ok - stale-owner recovery removes abandoned output without displacing a live owner
not-autohandled: cross-home-src (left for the handler; still unacknowledged)
ok - cross-home stale recovery removes abandoned output from the old state directory
not-autohandled: race-src (left for the handler; still unacknowledged)
not-autohandled: race-src (left for the handler; still unacknowledged)
ok - concurrent stale-claim replacement starts exactly one runner
ok - a crashed runner leader never lets a live owned group be reclaimed as stale
ok - a truly dead generation with no surviving group is still safely reclaimed
ok - claim replacement cannot produce a torn ownership snapshot
ok - retirement and start share one serialized lifecycle boundary
ok - PID reuse cannot signal an unrelated process
ok - transient identity failure preserves the live source for retry
ok - bounded home sweep preflights then retires every locally owned source
ok - home sweep leaves foreign-home claims and runners untouched
ok - home sweep refuses safely until runner identity is readable
ok - healthy runtime behavior remains registration-only
ok - registration rejects unrepresentable newline arguments
ok - nonzero exit with no output stays armed and silent
ok - oversized output is bounded rather than published whole or dropped
ok - live output stays bounded and retirement reaps the whole source group
ok - invalid output bounds fail closed
ok - the adapter derives physical identity without newline path corruption
ok - source-only homes trigger the general supervision guard
ok - the adapter classifies published poll output safely
ok - the adapter owns which Lavish results end a source, and payload text cannot forge one
ok - the published interfaces state the loss limitation and claim no lossless delivery

all procevent tests passed
FM_TEST_END 2026-08-19T09:22:11Z tests/fm-procevent.test.sh exit=0 duration_ms=110110 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=110218
FM_TEST_SUMMARY_FAMILY family=unclassified count=1 duration_ms=110110 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-procevent.test.sh duration_ms=110110
real 110.49
user 15.89
sys 34.50
```
</details>
<details>
<summary>Evidence: Eight-run concurrent stress summary</summary>

Source: [Eight-run concurrent stress summary](https://github.com/kunchenguid/firstmate/blob/ff0aa036eb5021b7f660f0cd83ac25c02598a260/.no-mistakes/evidence/fm/fm-procevent-test-flake-r1/fm-procevent-repeat-summary.log)

```text
run=1 status=PASS crashed-leader=1 duplicate-start=1 publish-recovery=1 self-announcing=1
run=2 status=PASS crashed-leader=1 duplicate-start=1 publish-recovery=1 self-announcing=1
run=3 status=PASS crashed-leader=1 duplicate-start=1 publish-recovery=1 self-announcing=1
run=4 status=PASS crashed-leader=1 duplicate-start=1 publish-recovery=1 self-announcing=1
run=5 status=PASS crashed-leader=1 duplicate-start=1 publish-recovery=1 self-announcing=1
run=6 status=PASS crashed-leader=1 duplicate-start=1 publish-recovery=1 self-announcing=1
run=7 status=PASS crashed-leader=1 duplicate-start=1 publish-recovery=1 self-announcing=1
run=8 status=PASS crashed-leader=1 duplicate-start=1 publish-recovery=1 self-announcing=1
concurrent_runs=8 failed=0 elapsed_seconds=173
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"7431e85a5836abf6adbd03cc28bef1af0aef2e84","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-test-run.sh tests/fm-procevent.test.sh`
- <code>Eight concurrent executions of `bash tests/fm-procevent.test.sh`, validating crashed-leader replacement, duplicate-start ownership, publish recovery, and self-announcing behavior under load</code>
- <code>`git status --short` after testing to confirm the worktree remained clean</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
