### PR TITLE
feat(bin): support named base branches for pooled spawns

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -49,7 +49,8 @@
 # a no-mistakes PR after first green, and reconfirm CI. A direct-PR brief opens
 # with gh-axi pr create --base <branch>. A local-only brief records that same
 # base as the landing target that bin/fm-merge-local.sh reads. A scout brief
-# only records the freshen base. --secondmate refuses the flag.
+# records the freshen base as the same `Base branch contract:` line spawn
+# reads from Definition of done. --secondmate refuses the flag.
 # --branch-name <name> replaces every generated `fm/<task-id>` crew branch
 # (checkout command, push-rule text, local-only done line) with that name.
 # The name must pass `git check-ref-format --branch`. When omitted, scaffolds
@@ -409,7 +410,7 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 $HERDR_SECTION
 
 # Setup
-You are in a disposable git worktree of $REPO, $SETUP_HEAD.$BASE_BRANCH_CONTRACT
+You are in a disposable git worktree of $REPO, $SETUP_HEAD.
 This is a SCOUT task: the deliverable is a written report, not a PR.
 The worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
 The report is the only thing that survives, so anything worth keeping must be in it.
@@ -445,7 +446,7 @@ The report must stand alone: what you did, what you found, the evidence (command
 If your deliverable is a visual artifact the captain will review and iterate on, you may host the Lavish review loop yourself (poll, revise, re-serve, staying alive) instead of handing it back to firstmate.
 Before reporting done, read and follow \`$FM_ROOT/.agents/skills/captain-hold-lifecycle/SKILL.md\` and pass its shared completion gate for the report and any visual review.
 When the report is complete, append \`done: {one-line conclusion}\` to the status file and stop.
-If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.
+If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.$BASE_BRANCH_CONTRACT
 EOF
 echo "scaffolded: $BRIEF (scout; replace {TASK})"
 exit 0

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -6,8 +6,8 @@
 # description, acceptance criteria, and context, and may adjust other sections
 # when the task genuinely deviates (e.g. working an existing external PR instead
 # of shipping a new one).
-# Usage: fm-brief.sh <task-id> <repo-name> --mode <no-mistakes|direct-PR|local-only> [--herdr-lab]
-#        fm-brief.sh <task-id> <repo-name> --scout [--herdr-lab]
+# Usage: fm-brief.sh <task-id> <repo-name> --mode <no-mistakes|direct-PR|local-only> [--herdr-lab] [--base-branch <branch>] [--branch-name <name>]
+#        fm-brief.sh <task-id> <repo-name> --scout [--herdr-lab] [--base-branch <branch>] [--branch-name <name>]
 #        fm-brief.sh <task-id> --secondmate {<project>...|--no-projects}
 #   --scout writes the scout contract instead: the deliverable is a report at
 #   data/<task-id>/report.md (no branch, no push, no PR) and the worktree is scratch.
@@ -43,6 +43,22 @@
 # Ship briefs begin with a worktree-isolation assertion before the branch step.
 # --mode is refused on scout and secondmate scaffolds: a scout's deliverable is a
 # report rather than a merge, and a charter is not a delivery contract.
+# --base-branch <branch> writes the worker-facing steps for the sequence owned
+# by bin/fm-spawn.sh's header: freshen from that branch, ship normally, retarget
+# a no-mistakes PR after first green, and reconfirm CI. A direct-PR brief opens
+# with gh-axi pr create --base <branch>; a local-only or scout brief only records
+# the freshen base. --secondmate refuses the flag.
+# --branch-name <name> replaces every generated `fm/<task-id>` crew branch
+# (checkout command, push-rule text, local-only done line) with that name.
+# The name must pass `git check-ref-format --branch`. When omitted, scaffolds
+# still use `fm/<task-id>` exactly as today. --secondmate refuses the flag.
+# A custom name is recorded as `Crew branch: branch=<name>` on ship briefs.
+# Other scripts that reconstruct `fm/<id>` instead of reading a recorded branch:
+# bin/fm-merge-local.sh (local-only merge looks up `fm/<id>`), bin/fm-promote.sh
+# (next-step hint tells the scout to create `fm/<id>`), and
+# bin/fm-review-diff.sh (prefers `fm/<id>`, then falls back to the worktree HEAD).
+# bin/fm-spawn.sh, bin/fm-teardown.sh, bin/fm-control.sh, and
+# bin/fm-crew-state.sh do not reconstruct that pattern.
 # There is no --yolo flag here. The worker never owns merge decisions, so yolo is
 # a spawn-time and firstmate-side input only (AGENTS.md section 7).
 # Every scaffold's status protocol distinguishes the configured
@@ -111,6 +127,10 @@ HERDR_LAB=0
 NO_PROJECTS=0
 MODE=
 MODE_SET=0
+BASE_BRANCH=
+BASE_BRANCH_SET=0
+BRANCH_NAME=
+BRANCH_NAME_SET=0
 POS=()
 want_value=
 for a in "$@"; do
@@ -120,6 +140,8 @@ for a in "$@"; do
     esac
     case "$want_value" in
       mode) MODE=$a; MODE_SET=1 ;;
+      'base-branch') BASE_BRANCH=$a; BASE_BRANCH_SET=1 ;;
+      'branch-name') BRANCH_NAME=$a; BRANCH_NAME_SET=1 ;;
       *) echo "error: internal parser state for --$want_value" >&2; exit 1 ;;
     esac
     want_value=
@@ -132,6 +154,10 @@ for a in "$@"; do
     --no-projects) NO_PROJECTS=1 ;;
     --mode) want_value=mode ;;
     --mode=*) MODE=${a#--mode=}; MODE_SET=1 ;;
+    --base-branch) want_value='base-branch' ;;
+    --base-branch=*) BASE_BRANCH=${a#--base-branch=}; BASE_BRANCH_SET=1 ;;
+    --branch-name) want_value='branch-name' ;;
+    --branch-name=*) BRANCH_NAME=${a#--branch-name=}; BRANCH_NAME_SET=1 ;;
     # yolo never reaches the worker: it is firstmate's merge authority, not a
     # brief input. Refuse it loudly so it is never silently dropped here and then
     # believed to have been recorded.
@@ -140,6 +166,8 @@ for a in "$@"; do
   esac
 done
 [ -z "$want_value" ] || { echo "error: --$want_value requires a value" >&2; exit 1; }
+[ "$BASE_BRANCH_SET" -eq 0 ] || [ -n "$BASE_BRANCH" ] || { echo "error: --base-branch requires a non-empty value" >&2; exit 1; }
+[ "$BRANCH_NAME_SET" -eq 0 ] || [ -n "$BRANCH_NAME" ] || { echo "error: --branch-name requires a non-empty value" >&2; exit 1; }
 
 # Ship delivery mode is an explicit per-task decision (AGENTS.md section 7). A
 # missing or invalid value stops the scaffold rather than silently defaulting.
@@ -159,7 +187,31 @@ elif [ "$MODE_SET" -eq 1 ]; then
   echo "error: --mode applies only to ship briefs; a scout delivers a report and a secondmate charter is not a delivery contract" >&2
   exit 1
 fi
+if [ "$KIND" = secondmate ] && [ "$BASE_BRANCH_SET" -eq 1 ]; then
+  echo "error: --base-branch applies only to ship and scout briefs; a secondmate already owns its home" >&2
+  exit 1
+fi
+if [ "$KIND" = secondmate ] && [ "$BRANCH_NAME_SET" -eq 1 ]; then
+  echo "error: --branch-name applies only to ship and scout briefs; a secondmate already owns its home" >&2
+  exit 1
+fi
+if [ "$BASE_BRANCH_SET" -eq 1 ]; then
+  git check-ref-format --branch "$BASE_BRANCH" >/dev/null 2>&1 || {
+    echo "error: --base-branch is not a usable git branch name: $BASE_BRANCH" >&2
+    exit 1
+  }
+fi
+if [ "$BRANCH_NAME_SET" -eq 1 ]; then
+  git check-ref-format --branch "$BRANCH_NAME" >/dev/null 2>&1 || {
+    echo "error: --branch-name is not a usable git branch name: $BRANCH_NAME" >&2
+    exit 1
+  }
+fi
 ID=${POS[0]}
+CREW_BRANCH="fm/$ID"
+if [ "$BRANCH_NAME_SET" -eq 1 ]; then
+  CREW_BRANCH=$BRANCH_NAME
+fi
 
 if [ "$KIND" = secondmate ] && [ "$HERDR_LAB" -eq 1 ]; then
   echo "error: --herdr-lab applies only to crewmate ship or scout briefs" >&2
@@ -183,6 +235,16 @@ shell_quote() {
 
 STATUS_FILE=$(shell_quote "$STATE/$ID.status")
 INBOX_DIR=$(shell_quote "$STATE/$ID.inbox")
+BASE_BRANCH_COMMAND=$BASE_BRANCH
+CREW_BRANCH_COMMAND=$CREW_BRANCH
+BASE_BRANCH_CONTRACT=
+if [ "$BASE_BRANCH_SET" -eq 1 ]; then
+  BASE_BRANCH_COMMAND=$(shell_quote "$BASE_BRANCH")
+  BASE_BRANCH_CONTRACT=$'\nBase branch contract: base_branch='$BASE_BRANCH
+fi
+if [ "$BRANCH_NAME_SET" -eq 1 ]; then
+  CREW_BRANCH_COMMAND=$(shell_quote "$CREW_BRANCH")
+fi
 
 # The receive-and-ack half of the steering-inbox contract, included in every
 # scaffold kind. The record format, doorbell line, and re-ring ladder are
@@ -289,6 +351,12 @@ fi
 
 REPO=${POS[1]}
 
+if [ -n "$BASE_BRANCH" ]; then
+  SETUP_HEAD="at a detached HEAD on \`$BASE_BRANCH\`"
+else
+  SETUP_HEAD="at a detached HEAD on a clean default branch"
+fi
+
 if [ "$HERDR_LAB" -eq 1 ]; then
 HERDR_LAB_HELPER=$(shell_quote "$FM_ROOT/bin/fm-herdr-lab.sh")
 # shellcheck disable=SC2016  # single quotes are deliberate: these lines are literal brief text whose backtick-wrapped $(...) and "$HERDR_LAB_SESSION" snippets must reach the reading agent verbatim, not expand at scaffold time; only the '"$VAR"' break-outs interpolate.
@@ -331,7 +399,7 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 $HERDR_SECTION
 
 # Setup
-You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.
+You are in a disposable git worktree of $REPO, $SETUP_HEAD.$BASE_BRANCH_CONTRACT
 This is a SCOUT task: the deliverable is a written report, not a PR.
 The worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
 The report is the only thing that survives, so anything worth keeping must be in it.
@@ -381,11 +449,11 @@ fi
 case "$MODE" in
   direct-PR)
     SETUP2=""
-    RULE1='1. Never push to the default branch (push only your `fm/'"$ID"'` branch). Never merge a PR.'
+    RULE1='1. Never push to the default branch (push only your `'"$CREW_BRANCH"'` branch). Never merge a PR.'
     ;;
   local-only)
     SETUP2=""
-    RULE1="1. Never push to any remote and never open a PR. Work only on your \`fm/$ID\` branch; firstmate handles the merge into local \`main\`."
+    RULE1="1. Never push to any remote and never open a PR. Work only on your \`$CREW_BRANCH\` branch; firstmate handles the merge into local \`main\`."
     ;;
   *)  # no-mistakes
     SETUP2="
@@ -393,7 +461,13 @@ case "$MODE" in
     RULE1='1. Never push to the default branch. Never merge a PR.'
     ;;
 esac
-DOD=$(fm_dod_block "$MODE" "$ID") || exit 1
+DOD=$(fm_dod_block "$MODE" "$ID" "$CREW_BRANCH" "$BASE_BRANCH") || exit 1
+if [ -n "$BASE_BRANCH" ]; then
+  DOD="${DOD}"$'\n'"Base branch contract: base_branch=$BASE_BRANCH"
+fi
+if [ "$BRANCH_NAME_SET" -eq 1 ]; then
+  DOD="${DOD}"$'\n'"Crew branch: branch=$CREW_BRANCH"
+fi
 
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
@@ -404,13 +478,13 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 $HERDR_SECTION
 
 # Setup
-You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.
+You are in a disposable git worktree of $REPO, $SETUP_HEAD.
 
 **Verify isolation before anything else.** Run \`pwd -P\` and \`git rev-parse --show-toplevel\`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
 The path check is authoritative: \`git rev-parse --git-dir\` and \`git rev-parse --git-common-dir\` can help inspect the repo, but they do not prove you are outside the primary checkout.
 If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append \`blocked: launched in primary checkout, not an isolated worktree\` to the status file and stop.
 
-1. First action: create your branch: \`git checkout -b fm/$ID\`$SETUP2
+1. First action: create your branch: \`git checkout -b $CREW_BRANCH_COMMAND\`$SETUP2
 
 # Rules
 $RULE1

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -33,7 +33,8 @@
 #   no-mistakes  implement -> /no-mistakes pipeline -> PR -> configured merge authority
 #   direct-PR    implement -> push + open PR via gh-axi (no pipeline) -> configured merge authority
 #   local-only   implement on branch, stop and report "ready in branch" (no push/PR);
-#                the configured merge authority approves, firstmate merges to local main
+#                the configured merge authority approves, firstmate merges to the
+#                recorded base or, when none is recorded, to local main
 # no-mistakes-prod-only is a registry policy, not a task mode; resolve it to one of
 # the three concrete modes at intake before calling this script.
 # The generated ship brief records the chosen mode as a fixed machine-readable
@@ -46,8 +47,9 @@
 # --base-branch <branch> writes the worker-facing steps for the sequence owned
 # by bin/fm-spawn.sh's header: freshen from that branch, ship normally, retarget
 # a no-mistakes PR after first green, and reconfirm CI. A direct-PR brief opens
-# with gh-axi pr create --base <branch>; a local-only or scout brief only records
-# the freshen base. --secondmate refuses the flag.
+# with gh-axi pr create --base <branch>. A local-only brief records that same
+# base as the landing target that bin/fm-merge-local.sh reads. A scout brief
+# only records the freshen base. --secondmate refuses the flag.
 # --branch-name <name> replaces every generated `fm/<task-id>` crew branch
 # (checkout command, push-rule text, local-only done line) with that name.
 # The name must pass `git check-ref-format --branch`. When omitted, scaffolds
@@ -453,7 +455,11 @@ case "$MODE" in
     ;;
   local-only)
     SETUP2=""
-    RULE1="1. Never push to any remote and never open a PR. Work only on your \`$CREW_BRANCH\` branch; firstmate handles the merge into local \`main\`."
+    if [ -n "$BASE_BRANCH" ]; then
+      RULE1="1. Never push to any remote and never open a PR. Work only on your \`$CREW_BRANCH\` branch; firstmate handles the merge into local \`$BASE_BRANCH\`."
+    else
+      RULE1="1. Never push to any remote and never open a PR. Work only on your \`$CREW_BRANCH\` branch; firstmate handles the merge into local \`main\`."
+    fi
     ;;
   *)  # no-mistakes
     SETUP2="

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -54,9 +54,10 @@
 # (checkout command, push-rule text, local-only done line) with that name.
 # The name must pass `git check-ref-format --branch`. When omitted, scaffolds
 # still use `fm/<task-id>` exactly as today. --secondmate refuses the flag.
-# --branch-name and --base-branch cannot name the same branch: the scaffold
-# checks out the base, so an identical crew branch would make `git checkout -b`
-# fail on the worker's first action.
+# The resolved crew branch (an explicit --branch-name, or fm/<task-id> when
+# that flag is omitted) and --base-branch cannot name the same branch: the
+# scaffold checks out the base, so an identical crew branch would make
+# `git checkout -b` fail on the worker's first action.
 # A custom name is recorded as `Crew branch: branch=<name>` on ship briefs.
 # bin/fm-merge-local.sh reads that recorded line and falls back to `fm/<id>`
 # only when it is absent. Other scripts that still reconstruct `fm/<id>`:
@@ -212,14 +213,14 @@ if [ "$BRANCH_NAME_SET" -eq 1 ]; then
     exit 1
   }
 fi
-if [ "$BASE_BRANCH_SET" -eq 1 ] && [ "$BRANCH_NAME_SET" -eq 1 ] && [ "$BASE_BRANCH" = "$BRANCH_NAME" ]; then
-  echo "error: --branch-name and --base-branch cannot name the same branch ($BRANCH_NAME): the scaffold checks out the base, so the worker cannot create a crew branch with the same name" >&2
-  exit 1
-fi
 ID=${POS[0]}
 CREW_BRANCH="fm/$ID"
 if [ "$BRANCH_NAME_SET" -eq 1 ]; then
   CREW_BRANCH=$BRANCH_NAME
+fi
+if [ "$BASE_BRANCH_SET" -eq 1 ] && [ "$BASE_BRANCH" = "$CREW_BRANCH" ]; then
+  echo "error: --base-branch cannot be the crew branch ($CREW_BRANCH): the scaffold checks out the base, so the worker cannot create a crew branch with the same name" >&2
+  exit 1
 fi
 
 if [ "$KIND" = secondmate ] && [ "$HERDR_LAB" -eq 1 ]; then

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -53,9 +53,9 @@
 # The name must pass `git check-ref-format --branch`. When omitted, scaffolds
 # still use `fm/<task-id>` exactly as today. --secondmate refuses the flag.
 # A custom name is recorded as `Crew branch: branch=<name>` on ship briefs.
-# Other scripts that reconstruct `fm/<id>` instead of reading a recorded branch:
-# bin/fm-merge-local.sh (local-only merge looks up `fm/<id>`), bin/fm-promote.sh
-# (next-step hint tells the scout to create `fm/<id>`), and
+# bin/fm-merge-local.sh reads that recorded line and falls back to `fm/<id>`
+# only when it is absent. Other scripts that still reconstruct `fm/<id>`:
+# bin/fm-promote.sh (next-step hint tells the scout to create `fm/<id>`), and
 # bin/fm-review-diff.sh (prefers `fm/<id>`, then falls back to the worktree HEAD).
 # bin/fm-spawn.sh, bin/fm-teardown.sh, bin/fm-control.sh, and
 # bin/fm-crew-state.sh do not reconstruct that pattern.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -66,6 +66,15 @@
 # bin/fm-review-diff.sh (prefers `fm/<id>`, then falls back to the worktree HEAD).
 # bin/fm-spawn.sh, bin/fm-teardown.sh, bin/fm-control.sh, and
 # bin/fm-crew-state.sh do not reconstruct that pattern.
+# After the generated Definition of done, every ship and scout scaffold writes
+# the exact line `Scaffold bound: generated`. bin/fm-spawn.sh and
+# bin/fm-merge-local.sh treat the first such line as the end of generated
+# scaffold: only an fm-control relaunch marker after that line is a structural
+# cutoff. A progress note that copies `# Setup` and the disposable-worktree
+# line therefore cannot move the bound. Briefs scaffolded before this line
+# keep the older Setup-pair fallback in those readers. A {TASK} body that
+# copies the Definition of done and this exact line can still hide later
+# generated contracts; that residual is accepted.
 # There is no --yolo flag here. The worker never owns merge decisions, so yolo is
 # a spawn-time and firstmate-side input only (AGENTS.md section 7).
 # Every scaffold's status protocol distinguishes the configured
@@ -447,6 +456,8 @@ If your deliverable is a visual artifact the captain will review and iterate on,
 Before reporting done, read and follow \`$FM_ROOT/.agents/skills/captain-hold-lifecycle/SKILL.md\` and pass its shared completion gate for the report and any visual review.
 When the report is complete, append \`done: {one-line conclusion}\` to the status file and stop.
 If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.$BASE_BRANCH_CONTRACT
+
+Scaffold bound: generated
 EOF
 echo "scaffolded: $BRIEF (scout; replace {TASK})"
 exit 0
@@ -537,5 +548,7 @@ If you touch a project \`AGENTS.md\` that lacks \`## Maintaining this file\`, ad
 Keep it proportionate: skip \`AGENTS.md\` edits for trivial tasks that produced no durable project knowledge.
 
 $DOD
+
+Scaffold bound: generated
 EOF
 echo "scaffolded: $BRIEF (ship, mode=$MODE; replace {TASK})"

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -54,6 +54,9 @@
 # (checkout command, push-rule text, local-only done line) with that name.
 # The name must pass `git check-ref-format --branch`. When omitted, scaffolds
 # still use `fm/<task-id>` exactly as today. --secondmate refuses the flag.
+# --branch-name and --base-branch cannot name the same branch: the scaffold
+# checks out the base, so an identical crew branch would make `git checkout -b`
+# fail on the worker's first action.
 # A custom name is recorded as `Crew branch: branch=<name>` on ship briefs.
 # bin/fm-merge-local.sh reads that recorded line and falls back to `fm/<id>`
 # only when it is absent. Other scripts that still reconstruct `fm/<id>`:
@@ -208,6 +211,10 @@ if [ "$BRANCH_NAME_SET" -eq 1 ]; then
     echo "error: --branch-name is not a usable git branch name: $BRANCH_NAME" >&2
     exit 1
   }
+fi
+if [ "$BASE_BRANCH_SET" -eq 1 ] && [ "$BRANCH_NAME_SET" -eq 1 ] && [ "$BASE_BRANCH" = "$BRANCH_NAME" ]; then
+  echo "error: --branch-name and --base-branch cannot name the same branch ($BRANCH_NAME): the scaffold checks out the base, so the worker cannot create a crew branch with the same name" >&2
+  exit 1
 fi
 ID=${POS[0]}
 CREW_BRANCH="fm/$ID"

--- a/bin/fm-dod-lib.sh
+++ b/bin/fm-dod-lib.sh
@@ -5,19 +5,45 @@
 # receives. Both paths must hand the worker the same contract: a promoted
 # no-mistakes worker that never received the ask-user escalation rule or the
 # `--yes` ban is the exact delivery hole this single owner exists to close.
-# fm_dod_block <no-mistakes|direct-PR|local-only> <task-id> prints the block on
-# stdout with no trailing blank line. The caller validates the mode; an unknown
-# mode is refused rather than silently rendered as the pipeline contract.
+# fm_dod_block <no-mistakes|direct-PR|local-only> <task-id> [crew-branch] [base-branch]
+# prints the block on stdout with no trailing blank line. The caller validates
+# the mode; an unknown mode is refused rather than silently rendered as the
+# pipeline contract. An omitted crew-branch keeps `fm/<task-id>`. An omitted
+# base-branch keeps the historical default-branch wording; a named base changes
+# the direct-PR create command and the no-mistakes post-green retarget steps.
 # The block opens with the fixed machine-readable "Delivery contract: mode=<mode>"
 # line that bin/fm-spawn.sh checks a ship brief against.
 # Every heredoc here stays outside a command substitution: `VAR=$(cat <<EOF ...)`
 # breaks parsing of the whole file on Bash 3.2 (tests/fm-brief.test.sh).
 
-fm_dod_block() {  # <mode> <task-id>
+fm_dod_shell_quote() {
+  printf "'"
+  printf '%s' "$1" | sed "s/'/'\\\\''/g"
+  printf "'"
+}
+
+fm_dod_block() {  # <mode> <task-id> [crew-branch] [base-branch]
   local mode=$1 id=$2
+  local crew_branch=${3:-}
+  local base_branch=${4:-}
+  local base_command
+  [ -n "$crew_branch" ] || crew_branch="fm/$id"
+  if [ -n "$base_branch" ]; then
+    base_command=$(fm_dod_shell_quote "$base_branch")
+  fi
   case "$mode" in
     direct-PR)
-      cat <<EOF
+      if [ -n "$base_branch" ]; then
+        cat <<EOF
+# Definition of done
+Delivery contract: mode=direct-PR
+This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
+The task is complete only when committed on your branch.
+When it is implemented and committed, push your branch and open a PR with \`gh-axi pr create --base $base_command\`, then append \`done: PR {url}\` to the status file and stop.
+Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
+EOF
+      else
+        cat <<EOF
 # Definition of done
 Delivery contract: mode=direct-PR
 This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
@@ -25,20 +51,48 @@ The task is complete only when committed on your branch.
 When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
 Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
 EOF
+      fi
       ;;
     local-only)
       cat <<EOF
 # Definition of done
 Delivery contract: mode=local-only
 This task ships **local-only**: no remote, no PR, no pipeline.
-The task is complete only when committed on your branch \`fm/$id\`. Do NOT push, do NOT open a PR, do NOT merge.
+The task is complete only when committed on your branch \`$crew_branch\`. Do NOT push, do NOT open a PR, do NOT merge.
 Keep your branch a clean fast-forward onto the current default branch - if \`main\` has advanced, rebase onto it so the eventual merge stays a fast-forward.
-When it is implemented and committed, append \`done: ready in branch fm/$id\` to the status file and stop.
+When it is implemented and committed, append \`done: ready in branch $crew_branch\` to the status file and stop.
 The configured merge authority approves the ready branch, then firstmate merges it into local \`main\` through the guarded fast-forward path.
 EOF
       ;;
     no-mistakes)
-      cat <<EOF
+      if [ -n "$base_branch" ]; then
+        cat <<EOF
+# Definition of done
+Delivery contract: mode=no-mistakes
+The task is complete only when committed on your branch.
+When you believe it is complete, append \`done: {summary}\` to the status file and stop.
+Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
+
+You drive no-mistakes by responding to its gates, not by implementing fixes.
+Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
+When starting no-mistakes, make \`--intent\` preserve all relevant content from this brief's \`# Task\` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
+Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
+
+Two firstmate-specific rules layer on top of that guidance:
+- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
+  Firstmate applies \`ask-user-authority\` and obtains any required captain decision.
+  When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
+- NEVER pass \`--yes\` (or \`-y\`) to \`no-mistakes axi run\` or \`no-mistakes axi respond\`. It is banned fleet-wide.
+  It auto-resolves every gate including ask-user findings with no escalation, and answering your own ask-user finding is a hard rule violation.
+
+Run /no-mistakes completely normally: push, PR against the repo default branch, CI to green. Do not pass --skip pr and do not change no-mistakes PR-target settings.
+After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), do not report done yet.
+Retarget the open PR with \`gh pr edit <number> --base $base_command\` (the recorded base_branch value; bin/fm-spawn.sh owns this sequence).
+Then poll \`gh-axi pr checks <number>\` until checks are green against that base (zero pending, zero failed). Do not trust the pre-retarget green, and do not treat "0 checks configured" as green unless that is this repo's trusted no-CI case.
+Only then append \`done: PR {url} checks green\` and stop. You are finished.
+EOF
+      else
+        cat <<EOF
 # Definition of done
 Delivery contract: mode=no-mistakes
 The task is complete only when committed on your branch.
@@ -59,6 +113,7 @@ Two firstmate-specific rules layer on top of that guidance:
 
 After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
 EOF
+      fi
       ;;
     *)
       echo "error: fm_dod_block: unknown delivery mode '$mode'" >&2

--- a/bin/fm-dod-lib.sh
+++ b/bin/fm-dod-lib.sh
@@ -10,7 +10,8 @@
 # the mode; an unknown mode is refused rather than silently rendered as the
 # pipeline contract. An omitted crew-branch keeps `fm/<task-id>`. An omitted
 # base-branch keeps the historical default-branch wording; a named base changes
-# the direct-PR create command and the no-mistakes post-green retarget steps.
+# the direct-PR create command, the local-only landing target, and the
+# no-mistakes post-green retarget steps.
 # The block opens with the fixed machine-readable "Delivery contract: mode=<mode>"
 # line that bin/fm-spawn.sh checks a ship brief against.
 # Every heredoc here stays outside a command substitution: `VAR=$(cat <<EOF ...)`
@@ -54,7 +55,18 @@ EOF
       fi
       ;;
     local-only)
-      cat <<EOF
+      if [ -n "$base_branch" ]; then
+        cat <<EOF
+# Definition of done
+Delivery contract: mode=local-only
+This task ships **local-only**: no remote, no PR, no pipeline.
+The task is complete only when committed on your branch \`$crew_branch\`. Do NOT push, do NOT open a PR, do NOT merge.
+Keep your branch a clean fast-forward onto \`$base_branch\` - if that base has advanced, rebase onto it so the eventual merge stays a fast-forward.
+When it is implemented and committed, append \`done: ready in branch $crew_branch\` to the status file and stop.
+The configured merge authority approves the ready branch, then firstmate merges it into local \`$base_branch\` through the guarded fast-forward path.
+EOF
+      else
+        cat <<EOF
 # Definition of done
 Delivery contract: mode=local-only
 This task ships **local-only**: no remote, no PR, no pipeline.
@@ -63,6 +75,7 @@ Keep your branch a clean fast-forward onto the current default branch - if \`mai
 When it is implemented and committed, append \`done: ready in branch $crew_branch\` to the status file and stop.
 The configured merge authority approves the ready branch, then firstmate merges it into local \`main\` through the guarded fast-forward path.
 EOF
+      fi
       ;;
     no-mistakes)
       if [ -n "$base_branch" ]; then

--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 # Perform the approved local merge for a local-only ship task: fast-forward the
-# project's default branch to the crewmate's fm/<id> branch.
+# project's default branch to the crewmate's recorded branch.
+# The recorded name is `Crew branch: branch=<name>` in data/<id>/brief.md
+# (written by bin/fm-brief.sh --branch-name). When that line is absent, this
+# script still uses fm/<id>, so omitted --branch-name stays identical to today.
+# An invalid recorded name refuses rather than falling back to fm/<id>.
 #
 # This is firstmate's merge gate-action (the captain's merge authority applied
 # locally instead of via a GitHub PR). It is the one sanctioned exception to hard
@@ -16,6 +20,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 "$FM_ROOT/bin/fm-guard.sh" || true
 # Role partition: landing local-only work is MAIN-owned; the Pi supervision
 # branch reports readiness and never lands (contract: bin/fm-lease-lib.sh;
@@ -47,7 +52,18 @@ default_branch() {
   return 1
 }
 
+BRIEF="$DATA/$ID/brief.md"
 BRANCH="fm/$ID"
+if [ -f "$BRIEF" ]; then
+  recorded_branch=$(sed -n 's/^Crew branch: branch=//p' "$BRIEF" | head -n 1)
+  if [ -n "$recorded_branch" ]; then
+    git check-ref-format --branch "$recorded_branch" >/dev/null 2>&1 || {
+      echo "error: $BRIEF records an invalid crew branch: $recorded_branch" >&2
+      exit 1
+    }
+    BRANCH=$recorded_branch
+  fi
+fi
 git -C "$PROJ" rev-parse --verify --quiet "refs/heads/$BRANCH" >/dev/null || { echo "error: branch $BRANCH does not exist in $PROJ" >&2; exit 1; }
 
 DEFAULT=$(default_branch) || { echo "error: cannot determine default branch for $PROJ; expected origin/HEAD, main, or master" >&2; exit 1; }

--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -9,7 +9,9 @@
 # phrase. Both lookups read only the generated contract region: the last
 # `# Definition of done` before an fm-control relaunch marker when that section
 # exists, otherwise the brief prefix before that marker so older one-line
-# records keep working. A relaunch progress note is never scanned. When the
+# records keep working. A marker copied into replaceable {TASK} text does not
+# count: it still sits before the generated Setup line. A relaunch progress
+# note is never scanned. When the
 # crew-branch line is absent from that region, this
 # script still uses fm/<id>. When the base-branch line is absent, it still
 # lands on the project's default branch. Omitted flags therefore stay
@@ -63,15 +65,23 @@ default_branch() {
 
 # Generated contracts live in the last `# Definition of done` before an
 # fm-control relaunch marker. Truncation anchors on the exact generated marker
-# (`## Progress note (ISO-timestamp)` followed by `This task was relaunched.`),
-# not on heading text alone, so task-authored progress-note prose cannot hide
-# the generated section.
+# (`## Progress note (ISO-timestamp)` followed by `This task was relaunched.`)
+# only when that marker is not followed by the generated Setup line
+# (`You are in a disposable git worktree of `). A copy inside replaceable
+# {TASK} text therefore cannot hide the generated section, while a real
+# fm-control append after Setup still ends the scan. Heading text alone is
+# not a boundary.
 brief_dod_section() {
   awk '
-    BEGIN { pending_relaunch=0 }
+    FNR==NR {
+      if ($0 ~ /^You are in a disposable git worktree of /) last_setup=FNR
+      next
+    }
     pending_relaunch && /^[[:space:]]*$/ { next }
     pending_relaunch {
-      if ($0 ~ /^This task was relaunched\./) { exit }
+      if ($0 ~ /^This task was relaunched\./) {
+        if (!last_setup || FNR > last_setup) exit
+      }
       pending_relaunch=0
     }
     /^## Progress note \([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z\)$/ {
@@ -82,17 +92,23 @@ brief_dod_section() {
     /^#{1,6}[[:space:]]/ { grab=0; next }
     grab { buf = buf $0 ORS }
     END { printf "%s", buf }
-  ' "$1"
+  ' "$1" "$1"
 }
 
-# Brief body before the first fm-control relaunch marker. Progress notes after
-# that marker are untrusted free text for contract lookup.
+# Brief body before the first fm-control relaunch marker that is not followed
+# by generated Setup. Progress notes after that marker are untrusted free
+# text for contract lookup.
 brief_truncated_prefix() {
   awk '
-    BEGIN { pending_relaunch=0 }
+    FNR==NR {
+      if ($0 ~ /^You are in a disposable git worktree of /) last_setup=FNR
+      next
+    }
     pending_relaunch && /^[[:space:]]*$/ { next }
     pending_relaunch {
-      if ($0 ~ /^This task was relaunched\./) { exit }
+      if ($0 ~ /^This task was relaunched\./) {
+        if (!last_setup || FNR > last_setup) exit
+      }
       pending_relaunch=0
     }
     /^## Progress note \([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z\)$/ {
@@ -100,7 +116,7 @@ brief_truncated_prefix() {
       next
     }
     { print }
-  ' "$1"
+  ' "$1" "$1"
 }
 
 brief_contract_region_nonempty() {

--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
 # Perform the approved local merge for a local-only ship task: fast-forward the
-# project's default branch to the crewmate's recorded branch.
-# The recorded name is `Crew branch: branch=<name>` in data/<id>/brief.md
-# (written by bin/fm-brief.sh --branch-name). The last matching line wins,
-# because the generated contract is appended after free-form {TASK} text that
-# may mention the same phrase. When that line is absent, this script still
-# uses fm/<id>, so omitted --branch-name stays identical to today.
-# An invalid recorded name refuses rather than falling back to fm/<id>.
+# landing branch to the crewmate's recorded branch.
+# The crew branch is `Crew branch: branch=<name>` in data/<id>/brief.md
+# (written by bin/fm-brief.sh --branch-name). The landing branch is
+# `Base branch contract: base_branch=<branch>` in that same brief (written by
+# --base-branch). For both lines the last match wins, because the generated
+# contract is appended after free-form {TASK} text that may mention the same
+# phrase. When the crew-branch line is absent, this script still uses fm/<id>.
+# When the base-branch line is absent, it still lands on the project's default
+# branch. Omitted flags therefore stay identical to today. An invalid recorded
+# name refuses rather than falling back.
 #
 # This is firstmate's merge gate-action (the captain's merge authority applied
 # locally instead of via a GitHub PR). It is the one sanctioned exception to hard
@@ -69,24 +72,45 @@ fi
 git -C "$PROJ" rev-parse --verify --quiet "refs/heads/$BRANCH" >/dev/null || { echo "error: branch $BRANCH does not exist in $PROJ" >&2; exit 1; }
 
 DEFAULT=$(default_branch) || { echo "error: cannot determine default branch for $PROJ; expected origin/HEAD, main, or master" >&2; exit 1; }
+TARGET=$DEFAULT
+if [ -f "$BRIEF" ]; then
+  recorded_base=$(sed -n 's/^Base branch contract: base_branch=//p' "$BRIEF" | tail -n 1)
+  if [ -n "$recorded_base" ]; then
+    git check-ref-format --branch "$recorded_base" >/dev/null 2>&1 || {
+      echo "error: $BRIEF records an invalid base branch: $recorded_base" >&2
+      exit 1
+    }
+    TARGET=$recorded_base
+  fi
+fi
+git -C "$PROJ" rev-parse --verify --quiet "refs/heads/$TARGET" >/dev/null || { echo "error: landing branch $TARGET does not exist in $PROJ" >&2; exit 1; }
 
-# The project's main checkout must be on its default branch and clean, so the
-# fast-forward lands predictably (firstmate never writes here otherwise).
+# The project's main checkout must stay on its default branch unless it is
+# already on the landing target. firstmate never writes here otherwise.
 cur=$(git -C "$PROJ" symbolic-ref --short HEAD 2>/dev/null || echo "")
-[ "$cur" = "$DEFAULT" ] || { echo "error: $PROJ is on '$cur', expected default branch '$DEFAULT'; cannot merge safely" >&2; exit 1; }
+if [ "$cur" != "$DEFAULT" ] && [ "$cur" != "$TARGET" ]; then
+  echo "error: $PROJ is on '$cur', expected default branch '$DEFAULT' or landing branch '$TARGET'; cannot merge safely" >&2
+  exit 1
+fi
 if [ -n "$(git -C "$PROJ" status --porcelain 2>/dev/null | head -1)" ]; then
   echo "error: $PROJ has a dirty working tree; refusing to merge into it" >&2
   exit 1
 fi
 
-# Clean fast-forward only: DEFAULT must be an ancestor of BRANCH.
-if ! git -C "$PROJ" merge-base --is-ancestor "$DEFAULT" "$BRANCH"; then
-  echo "REFUSED: $BRANCH is not a fast-forward of $DEFAULT (it has diverged)." >&2
-  echo "Have the crewmate rebase $BRANCH onto $DEFAULT, then retry." >&2
+# Clean fast-forward only: TARGET must be an ancestor of BRANCH.
+if ! git -C "$PROJ" merge-base --is-ancestor "$TARGET" "$BRANCH"; then
+  echo "REFUSED: $BRANCH is not a fast-forward of $TARGET (it has diverged)." >&2
+  echo "Have the crewmate rebase $BRANCH onto $TARGET, then retry." >&2
   exit 1
 fi
 
-before=$(git -C "$PROJ" rev-parse --short "$DEFAULT")
-git -C "$PROJ" merge --ff-only "$BRANCH" >/dev/null
-after=$(git -C "$PROJ" rev-parse --short "$DEFAULT")
-echo "merged $BRANCH into local $DEFAULT ($before -> $after) in $PROJ"
+before=$(git -C "$PROJ" rev-parse --short "$TARGET")
+if [ "$cur" = "$TARGET" ]; then
+  git -C "$PROJ" merge --ff-only "$BRANCH" >/dev/null
+else
+  # Stay on the default checkout and fast-forward the named base in place.
+  git -C "$PROJ" update-ref -m "fm-merge-local: fast-forward $TARGET to $BRANCH" \
+    "refs/heads/$TARGET" "$(git -C "$PROJ" rev-parse "$BRANCH")" "$(git -C "$PROJ" rev-parse "$TARGET")"
+fi
+after=$(git -C "$PROJ" rev-parse --short "$TARGET")
+echo "merged $BRANCH into local $TARGET ($before -> $after) in $PROJ"

--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -2,8 +2,10 @@
 # Perform the approved local merge for a local-only ship task: fast-forward the
 # project's default branch to the crewmate's recorded branch.
 # The recorded name is `Crew branch: branch=<name>` in data/<id>/brief.md
-# (written by bin/fm-brief.sh --branch-name). When that line is absent, this
-# script still uses fm/<id>, so omitted --branch-name stays identical to today.
+# (written by bin/fm-brief.sh --branch-name). The last matching line wins,
+# because the generated contract is appended after free-form {TASK} text that
+# may mention the same phrase. When that line is absent, this script still
+# uses fm/<id>, so omitted --branch-name stays identical to today.
 # An invalid recorded name refuses rather than falling back to fm/<id>.
 #
 # This is firstmate's merge gate-action (the captain's merge authority applied
@@ -55,7 +57,7 @@ default_branch() {
 BRIEF="$DATA/$ID/brief.md"
 BRANCH="fm/$ID"
 if [ -f "$BRIEF" ]; then
-  recorded_branch=$(sed -n 's/^Crew branch: branch=//p' "$BRIEF" | head -n 1)
+  recorded_branch=$(sed -n 's/^Crew branch: branch=//p' "$BRIEF" | tail -n 1)
   if [ -n "$recorded_branch" ]; then
     git check-ref-format --branch "$recorded_branch" >/dev/null 2>&1 || {
       echo "error: $BRIEF records an invalid crew branch: $recorded_branch" >&2

--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -6,10 +6,13 @@
 # `Base branch contract: base_branch=<branch>` in that same brief (written by
 # --base-branch). For both lines the last match wins, because the generated
 # contract is appended after free-form {TASK} text that may mention the same
-# phrase. When the crew-branch line is absent, this script still uses fm/<id>.
-# When the base-branch line is absent, it still lands on the project's default
-# branch. Omitted flags therefore stay identical to today. An invalid recorded
-# name refuses rather than falling back.
+# phrase. Both lookups read the `# Definition of done` section so a later
+# relaunch progress note cannot override the generated contract; if that
+# section is missing, the last matching line in the brief still wins so older
+# one-line records keep working. When the crew-branch line is absent, this
+# script still uses fm/<id>. When the base-branch line is absent, it still
+# lands on the project's default branch. Omitted flags therefore stay
+# identical to today. An invalid recorded name refuses rather than falling back.
 #
 # This is firstmate's merge gate-action (the captain's merge authority applied
 # locally instead of via a GitHub PR). It is the one sanctioned exception to hard
@@ -57,10 +60,31 @@ default_branch() {
   return 1
 }
 
+# Generated contracts live in `# Definition of done`. Stop at the next heading
+# so a relaunch `## Progress note` cannot override them. A brief with no DOD
+# section (older one-line records) falls back to the whole file.
+brief_dod_section() {
+  awk '
+    /^# Definition of done[[:space:]]*$/ { grab=1; next }
+    /^#{1,6}[[:space:]]/ { if (grab) exit }
+    grab { print }
+  ' "$1"
+}
+
+brief_last_contract() {
+  local file=$1 prefix=$2 section value
+  section=$(brief_dod_section "$file")
+  value=$(printf '%s\n' "$section" | sed -n "s/^${prefix}//p" | tail -n 1)
+  if [ -z "$value" ]; then
+    value=$(sed -n "s/^${prefix}//p" "$file" | tail -n 1)
+  fi
+  printf '%s' "$value"
+}
+
 BRIEF="$DATA/$ID/brief.md"
 BRANCH="fm/$ID"
 if [ -f "$BRIEF" ]; then
-  recorded_branch=$(sed -n 's/^Crew branch: branch=//p' "$BRIEF" | tail -n 1)
+  recorded_branch=$(brief_last_contract "$BRIEF" 'Crew branch: branch=')
   if [ -n "$recorded_branch" ]; then
     git check-ref-format --branch "$recorded_branch" >/dev/null 2>&1 || {
       echo "error: $BRIEF records an invalid crew branch: $recorded_branch" >&2
@@ -74,7 +98,7 @@ git -C "$PROJ" rev-parse --verify --quiet "refs/heads/$BRANCH" >/dev/null || { e
 DEFAULT=$(default_branch) || { echo "error: cannot determine default branch for $PROJ; expected origin/HEAD, main, or master" >&2; exit 1; }
 TARGET=$DEFAULT
 if [ -f "$BRIEF" ]; then
-  recorded_base=$(sed -n 's/^Base branch contract: base_branch=//p' "$BRIEF" | tail -n 1)
+  recorded_base=$(brief_last_contract "$BRIEF" 'Base branch contract: base_branch=')
   if [ -n "$recorded_base" ]; then
     git check-ref-format --branch "$recorded_base" >/dev/null 2>&1 || {
       echo "error: $BRIEF records an invalid base branch: $recorded_base" >&2

--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -6,10 +6,11 @@
 # `Base branch contract: base_branch=<branch>` in that same brief (written by
 # --base-branch). For both lines the last match wins, because the generated
 # contract is appended after free-form {TASK} text that may mention the same
-# phrase. Both lookups read the `# Definition of done` section so a later
-# relaunch progress note cannot override the generated contract; if that
-# section is missing, the last matching line in the brief still wins so older
-# one-line records keep working. When the crew-branch line is absent, this
+# phrase. Both lookups read only the generated contract region: the last
+# `# Definition of done` before an fm-control relaunch marker when that section
+# exists, otherwise the brief prefix before that marker so older one-line
+# records keep working. A relaunch progress note is never scanned. When the
+# crew-branch line is absent from that region, this
 # script still uses fm/<id>. When the base-branch line is absent, it still
 # lands on the project's default branch. Omitted flags therefore stay
 # identical to today. An invalid recorded name refuses rather than falling back.
@@ -60,13 +61,23 @@ default_branch() {
   return 1
 }
 
-# Generated contracts live in the last `# Definition of done` before a relaunch
-# `## Progress note`. The last heading wins so replaceable task text cannot
-# hide the generated section with its own copy. A brief with no DOD section
-# (older one-line records) falls back to the whole file.
+# Generated contracts live in the last `# Definition of done` before an
+# fm-control relaunch marker. Truncation anchors on the exact generated marker
+# (`## Progress note (ISO-timestamp)` followed by `This task was relaunched.`),
+# not on heading text alone, so task-authored progress-note prose cannot hide
+# the generated section.
 brief_dod_section() {
   awk '
-    /^## Progress note/ { exit }
+    BEGIN { pending_relaunch=0 }
+    pending_relaunch && /^[[:space:]]*$/ { next }
+    pending_relaunch {
+      if ($0 ~ /^This task was relaunched\./) { exit }
+      pending_relaunch=0
+    }
+    /^## Progress note \([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z\)$/ {
+      pending_relaunch=1
+      next
+    }
     /^# Definition of done[[:space:]]*$/ { grab=1; buf=""; next }
     /^#{1,6}[[:space:]]/ { grab=0; next }
     grab { buf = buf $0 ORS }
@@ -74,13 +85,38 @@ brief_dod_section() {
   ' "$1"
 }
 
+# Brief body before the first fm-control relaunch marker. Progress notes after
+# that marker are untrusted free text for contract lookup.
+brief_truncated_prefix() {
+  awk '
+    BEGIN { pending_relaunch=0 }
+    pending_relaunch && /^[[:space:]]*$/ { next }
+    pending_relaunch {
+      if ($0 ~ /^This task was relaunched\./) { exit }
+      pending_relaunch=0
+    }
+    /^## Progress note \([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z\)$/ {
+      pending_relaunch=1
+      next
+    }
+    { print }
+  ' "$1"
+}
+
+brief_contract_region_nonempty() {
+  local region=$1
+  [ -n "$(printf '%s' "$region" | sed '/^[[:space:]]*$/d' | head -n 1)" ]
+}
+
 brief_last_contract() {
-  local file=$1 prefix=$2 section value
+  local file=$1 prefix=$2 section region value
   section=$(brief_dod_section "$file")
-  value=$(printf '%s\n' "$section" | sed -n "s/^${prefix}//p" | tail -n 1)
-  if [ -z "$value" ]; then
-    value=$(sed -n "s/^${prefix}//p" "$file" | tail -n 1)
+  if brief_contract_region_nonempty "$section"; then
+    region=$section
+  else
+    region=$(brief_truncated_prefix "$file")
   fi
+  value=$(printf '%s\n' "$region" | sed -n "s/^${prefix}//p" | tail -n 1)
   printf '%s' "$value"
 }
 

--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -10,8 +10,9 @@
 # `# Definition of done` before an fm-control relaunch marker when that section
 # exists, otherwise the brief prefix before that marker so older one-line
 # records keep working. A marker copied into replaceable {TASK} text does not
-# count: it still sits before the generated Setup pair. A relaunch progress
-# note is never scanned. When the
+# count: it still sits before the first `Scaffold bound: generated` line, or
+# before the generated Setup pair on older briefs that lack that line. A
+# relaunch progress note is never scanned. When the
 # crew-branch line is absent from that region, this
 # script still uses fm/<id>. When the base-branch line is absent, it still
 # lands on the project's default branch. Omitted flags therefore stay
@@ -66,14 +67,16 @@ default_branch() {
 # Generated contracts live in the last `# Definition of done` before an
 # fm-control relaunch marker. Truncation anchors on the exact generated marker
 # (`## Progress note (ISO-timestamp)` followed by `This task was relaunched.`)
-# only when that marker is not followed by a generated Setup pair
-# (`# Setup` then `You are in a disposable git worktree of `). A copy of
-# the marker or the worktree line alone therefore cannot hide or extend
-# the generated section, while a real fm-control append after Setup still
-# ends the scan. Heading text alone is not a boundary.
+# only when that marker sits after the first `Scaffold bound: generated` line
+# written by bin/fm-brief.sh. A progress note that copies `# Setup` and the
+# disposable-worktree line therefore cannot move the bound. Briefs without
+# that line keep the older rule: the marker is structural only when it is
+# not followed by a generated Setup pair (`# Setup` then `You are in a
+# disposable git worktree of `). Heading text alone is not a boundary.
 brief_dod_section() {
   awk '
     FNR==NR {
+      if (!scaffold_end && $0 == "Scaffold bound: generated") scaffold_end=FNR
       if (pending_setup && /^[[:space:]]*$/) next
       if (pending_setup) {
         if ($0 ~ /^You are in a disposable git worktree of /) last_setup=FNR
@@ -86,7 +89,11 @@ brief_dod_section() {
     pending_relaunch && /^[[:space:]]*$/ { next }
     pending_relaunch {
       if ($0 ~ /^This task was relaunched\./) {
-        if (!last_setup || FNR > last_setup) exit
+        if (scaffold_end) {
+          if (FNR > scaffold_end) exit
+        } else if (!last_setup || FNR > last_setup) {
+          exit
+        }
       }
       pending_relaunch=0
     }
@@ -101,12 +108,13 @@ brief_dod_section() {
   ' "$1" "$1"
 }
 
-# Brief body before the first fm-control relaunch marker that is not followed
-# by generated Setup. Progress notes after that marker are untrusted free
-# text for contract lookup.
+# Brief body before the first fm-control relaunch marker after the generated
+# scaffold bound (or, on older briefs, after generated Setup). Progress notes
+# after that marker are untrusted free text for contract lookup.
 brief_truncated_prefix() {
   awk '
     FNR==NR {
+      if (!scaffold_end && $0 == "Scaffold bound: generated") scaffold_end=FNR
       if (pending_setup && /^[[:space:]]*$/) next
       if (pending_setup) {
         if ($0 ~ /^You are in a disposable git worktree of /) last_setup=FNR
@@ -119,7 +127,11 @@ brief_truncated_prefix() {
     pending_relaunch && /^[[:space:]]*$/ { next }
     pending_relaunch {
       if ($0 ~ /^This task was relaunched\./) {
-        if (!last_setup || FNR > last_setup) exit
+        if (scaffold_end) {
+          if (FNR > scaffold_end) exit
+        } else if (!last_setup || FNR > last_setup) {
+          exit
+        }
       }
       pending_relaunch=0
     }

--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -10,7 +10,7 @@
 # `# Definition of done` before an fm-control relaunch marker when that section
 # exists, otherwise the brief prefix before that marker so older one-line
 # records keep working. A marker copied into replaceable {TASK} text does not
-# count: it still sits before the generated Setup line. A relaunch progress
+# count: it still sits before the generated Setup pair. A relaunch progress
 # note is never scanned. When the
 # crew-branch line is absent from that region, this
 # script still uses fm/<id>. When the base-branch line is absent, it still
@@ -66,15 +66,21 @@ default_branch() {
 # Generated contracts live in the last `# Definition of done` before an
 # fm-control relaunch marker. Truncation anchors on the exact generated marker
 # (`## Progress note (ISO-timestamp)` followed by `This task was relaunched.`)
-# only when that marker is not followed by the generated Setup line
-# (`You are in a disposable git worktree of `). A copy inside replaceable
-# {TASK} text therefore cannot hide the generated section, while a real
-# fm-control append after Setup still ends the scan. Heading text alone is
-# not a boundary.
+# only when that marker is not followed by a generated Setup pair
+# (`# Setup` then `You are in a disposable git worktree of `). A copy of
+# the marker or the worktree line alone therefore cannot hide or extend
+# the generated section, while a real fm-control append after Setup still
+# ends the scan. Heading text alone is not a boundary.
 brief_dod_section() {
   awk '
     FNR==NR {
-      if ($0 ~ /^You are in a disposable git worktree of /) last_setup=FNR
+      if (pending_setup && /^[[:space:]]*$/) next
+      if (pending_setup) {
+        if ($0 ~ /^You are in a disposable git worktree of /) last_setup=FNR
+        pending_setup=0
+        next
+      }
+      if ($0 ~ /^# Setup[[:space:]]*$/) pending_setup=1
       next
     }
     pending_relaunch && /^[[:space:]]*$/ { next }
@@ -101,7 +107,13 @@ brief_dod_section() {
 brief_truncated_prefix() {
   awk '
     FNR==NR {
-      if ($0 ~ /^You are in a disposable git worktree of /) last_setup=FNR
+      if (pending_setup && /^[[:space:]]*$/) next
+      if (pending_setup) {
+        if ($0 ~ /^You are in a disposable git worktree of /) last_setup=FNR
+        pending_setup=0
+        next
+      }
+      if ($0 ~ /^# Setup[[:space:]]*$/) pending_setup=1
       next
     }
     pending_relaunch && /^[[:space:]]*$/ { next }

--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -60,14 +60,17 @@ default_branch() {
   return 1
 }
 
-# Generated contracts live in `# Definition of done`. Stop at the next heading
-# so a relaunch `## Progress note` cannot override them. A brief with no DOD
-# section (older one-line records) falls back to the whole file.
+# Generated contracts live in the last `# Definition of done` before a relaunch
+# `## Progress note`. The last heading wins so replaceable task text cannot
+# hide the generated section with its own copy. A brief with no DOD section
+# (older one-line records) falls back to the whole file.
 brief_dod_section() {
   awk '
-    /^# Definition of done[[:space:]]*$/ { grab=1; next }
-    /^#{1,6}[[:space:]]/ { if (grab) exit }
-    grab { print }
+    /^## Progress note/ { exit }
+    /^# Definition of done[[:space:]]*$/ { grab=1; buf=""; next }
+    /^#{1,6}[[:space:]]/ { grab=0; next }
+    grab { buf = buf $0 ORS }
+    END { printf "%s", buf }
   ' "$1"
 }
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Spawn a direct report: a crewmate in a treehouse or Orca worktree, or a
 # secondmate in its isolated firstmate home.
-# Usage: fm-spawn.sh <task-id> <project-dir> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>]
-#        fm-spawn.sh <task-id> <project-dir> --scout [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>]
+# Usage: fm-spawn.sh <task-id> <project-dir> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] [--base-branch <branch>]
+#        fm-spawn.sh <task-id> <project-dir> --scout [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] [--base-branch <branch>]
 #        fm-spawn.sh <task-id> [<firstmate-home>] [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] --secondmate
 #   --mode and --yolo are this task's delivery contract, REQUIRED for every ship
 #   spawn and refused on --scout and --secondmate spawns. Firstmate resolves both
@@ -147,11 +147,37 @@
 #   containment test reads local refs only and never fetches, so this gate stays
 #   usable offline; a stale remote-tracking ref can therefore make an unpushed
 #   commit look contained, which is exactly why no remedy command is printed.
+#   --base-branch <branch> keeps that same pooled-worktree path and instead
+#   resets to the named branch: origin/<branch> when origin has it, otherwise
+#   the local branch. A name that exists on neither refuses immediately and
+#   never falls back to the remote default. A ref-specific fetch that fails
+#   for any reason other than confirmed remote absence also refuses, rather
+#   than treating an unverifiable remote as missing and falling back to local.
+#   The spawn records base_branch=<branch> in state/<id>.meta only when the
+#   flag is set. no-mistakes axi run has no PR-base flag and no documented
+#   yaml key for the PR target; it opens against the repo default.
+#   A no-mistakes ship therefore still runs the pipeline completely normally:
+#   push, PR against the repo default branch, and CI monitored to green, with
+#   no --skip pr and no PR-target change to no-mistakes itself. After that
+#   first green, retarget with raw `gh pr edit <number> --base <branch>` using
+#   the recorded base_branch value, because installed `gh-axi pr edit` has no
+#   `--base` support. Then poll `gh-axi pr checks <number>` until checks are
+#   green against the new base (zero pending, zero failed). Do not treat the
+#   pre-retarget green as done, and do not treat "0 checks configured" as
+#   green unless that is this repo's trusted no-CI case. A direct-PR ship
+#   opens with `gh-axi pr create --base <branch>` instead of retargeting.
+#   Scaffold the matching brief with the same flag so the worker sees those
+#   steps (bin/fm-brief.sh). When the flag is omitted, freshen and the
+#   generated meta stay identical to today.
+#   --relaunch, --secondmate, and backend=orca refuse the flag. Relaunch also
+#   skips the brief/flag agreement check and preserves any recorded
+#   base_branch= already in state/<id>.meta, because it reuses the existing
+#   worktree and does not freshen.
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
 #   source of truth; shared --scout/--harness/--model/--effort/--backend/--mode/--yolo
-#   applies to every pair. A ship batch therefore carries one delivery contract, and each
+#   --base-branch applies to every pair. A ship batch therefore carries one delivery contract, and each
 #   pair still checks it against its own brief; a batch spanning modes is two invocations.
 #   If config/crew-dispatch.json exists, shared --harness is required for crewmate
 #   and scout batches. The loop lives here, in bash, so callers never hand-write a
@@ -318,6 +344,7 @@ BACKEND_ARG=
 MODE=
 YOLO=
 TRACEPARENT_ARG=
+BASE_BRANCH=
 HARNESS_SET=0
 MODEL_SET=0
 EFFORT_SET=0
@@ -325,6 +352,7 @@ BACKEND_SET=0
 MODE_SET=0
 YOLO_SET=0
 TRACEPARENT_SET=0
+BASE_BRANCH_SET=0
 RELAUNCH=0
 POS=()
 want_value=
@@ -341,6 +369,7 @@ for a in "$@"; do
       mode) MODE=$a; MODE_SET=1 ;;
       yolo) YOLO=$a; YOLO_SET=1 ;;
       traceparent) TRACEPARENT_ARG=$a; TRACEPARENT_SET=1 ;;
+      'base-branch') BASE_BRANCH=$a; BASE_BRANCH_SET=1 ;;
       *) echo "error: internal parser state for --$want_value" >&2; exit 1 ;;
     esac
     want_value=
@@ -364,6 +393,8 @@ for a in "$@"; do
     --yolo=*) YOLO=${a#--yolo=}; YOLO_SET=1 ;;
     --traceparent) want_value=traceparent ;;
     --traceparent=*) TRACEPARENT_ARG=${a#--traceparent=}; TRACEPARENT_SET=1 ;;
+    --base-branch) want_value='base-branch' ;;
+    --base-branch=*) BASE_BRANCH=${a#--base-branch=}; BASE_BRANCH_SET=1 ;;
     *) POS+=("$a") ;;
   esac
 done
@@ -375,6 +406,7 @@ done
 [ "$MODE_SET" -eq 0 ] || [ -n "$MODE" ] || { echo "error: --mode requires a non-empty value" >&2; exit 1; }
 [ "$YOLO_SET" -eq 0 ] || [ -n "$YOLO" ] || { echo "error: --yolo requires a non-empty value" >&2; exit 1; }
 [ "$TRACEPARENT_SET" -eq 0 ] || [ -n "$TRACEPARENT_ARG" ] || { echo "error: --traceparent requires a non-empty value" >&2; exit 1; }
+[ "$BASE_BRANCH_SET" -eq 0 ] || [ -n "$BASE_BRANCH" ] || { echo "error: --base-branch requires a non-empty value" >&2; exit 1; }
 # A parent-delivered carrier replaces this home's own resolution, so it is
 # refused unless it is a secondmate spawn carrying a strictly valid W3C value.
 # Nothing else may reach the pane's TRACEPARENT export.
@@ -402,6 +434,7 @@ if [ "$RELAUNCH" -eq 1 ]; then
   [ "$KIND_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded kind; --scout/--secondmate cannot override it" >&2; exit 1; }
   [ "$MODE_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded delivery mode; --mode cannot override it" >&2; exit 1; }
   [ "$YOLO_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded yolo posture; --yolo cannot override it" >&2; exit 1; }
+  [ "$BASE_BRANCH_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded worktree; --base-branch cannot override it" >&2; exit 1; }
 else
   # Delivery contract (AGENTS.md section 7). A ship task's mode and yolo are
   # firstmate's per-task decision, so they are required and closed-set validated
@@ -437,6 +470,15 @@ else
       exit 1
     }
   fi
+fi
+
+if [ "$KIND" = secondmate ] && [ "$BASE_BRANCH_SET" -eq 1 ]; then
+  echo "error: --base-branch applies only to ship and scout spawns; a secondmate already owns its home" >&2
+  exit 1
+fi
+if [ "$BASE_BRANCH_SET" -eq 1 ] && ! git check-ref-format --branch "$BASE_BRANCH" >/dev/null 2>&1; then
+  echo "error: --base-branch is not a usable git branch name: $BASE_BRANCH" >&2
+  exit 1
 fi
 
 spawn_remote_secondmate() {
@@ -949,6 +991,7 @@ if [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart" ] && case "$idpart" in *
   # spanning several modes is two invocations rather than a silent mixed dispatch.
   [ "$MODE_SET" -eq 0 ] || shared_args+=(--mode "$MODE")
   [ "$YOLO_SET" -eq 0 ] || shared_args+=(--yolo "$YOLO")
+  [ "$BASE_BRANCH_SET" -eq 0 ] || shared_args+=(--base-branch "$BASE_BRANCH")
   for pair in "${POS[@]}"; do
     case "$pair" in
       *=*) : ;;
@@ -1058,6 +1101,10 @@ if [ "$RELAUNCH" -eq 0 ]; then
     BACKEND=$BACKEND_ARG
   else
     BACKEND=$(fm_backend_name)
+  fi
+  if [ "$BACKEND" = orca ] && [ "$BASE_BRANCH_SET" -eq 1 ]; then
+    echo "error: --base-branch cannot be combined with backend=orca; Orca already owns the task worktree" >&2
+    exit 1
   fi
   fm_backend_validate_spawn "$BACKEND" || exit 1
   fm_backend_source "$BACKEND" || exit 1
@@ -1780,6 +1827,7 @@ delivery_rigor_rank() {  # <mode> -> 3 (most rigor) .. 1 (least); 0 = not a task
 # fm-brief.sh records a ship brief's mode as a fixed "Delivery contract: mode=<mode>"
 # line. A spawn that disagrees would launch a worker whose instructions and whose
 # recorded task delivery differ, which is the exact drift this contract prevents.
+BRIEF_BASE_BRANCH=$(sed -n 's/^Base branch contract: base_branch=\([^ ]*\).*$/\1/p' "$BRIEF" | head -n 1)
 if [ "$KIND" = ship ]; then
   PROJ_NAME=$(basename "$PROJ_ABS")
   BRIEF_MODE=$(sed -n 's/^Delivery contract: mode=\([^ ]*\).*$/\1/p' "$BRIEF" | head -n 1)
@@ -1798,6 +1846,15 @@ if [ "$KIND" = ship ]; then
   if [ -n "$STANDING_MODE" ] && [ "$STANDING_MODE" != no-mistakes-prod-only ] \
      && [ "$(delivery_rigor_rank "$MODE")" -lt "$(delivery_rigor_rank "$STANDING_MODE")" ]; then
     echo "notice: $ID ships mode=$MODE while the standing posture for $PROJ_NAME is $STANDING_MODE - less rigor than the captain's standing posture; proceed only on a current explicit captain instruction or an intake judgment you can state" >&2
+  fi
+fi
+# Relaunch reuses the recorded worktree and refuses --base-branch, so it must
+# not require the flag to match a brief contract that a fresh spawn already
+# applied. Fresh ship and scout spawns still refuse a mismatch.
+if [ "$RELAUNCH" -eq 0 ] && { [ "$KIND" = ship ] || [ "$KIND" = scout ]; }; then
+  if [ "$BRIEF_BASE_BRANCH" != "$BASE_BRANCH" ]; then
+    echo "error: base-branch mismatch for $ID: the brief says base_branch=${BRIEF_BASE_BRANCH:-<omitted>} but this spawn passed --base-branch ${BASE_BRANCH:-<omitted>}; correct the flag or re-scaffold the brief so the worker's instructions and the task record agree" >&2
+    exit 1
   fi
 fi
 
@@ -1893,23 +1950,49 @@ EOF
 }
 
 freshen_spawn_worktree_base() {  # <worktree>
-  local worktree=$1 default target expected actual status
+  local worktree=$1 default target expected actual status remote_status
   if ! git -C "$worktree" fetch --quiet origin; then
     echo "error: could not fetch origin for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
     return 1
   fi
-  if ! git -C "$worktree" remote set-head origin --auto >/dev/null 2>&1; then
-    echo "error: could not resolve origin's current default branch for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
-    return 1
-  fi
-  default=$(default_branch "$worktree") || {
-    echo "error: could not determine origin's default branch for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
-    return 1
-  }
-  target="origin/$default"
-  if ! git -C "$worktree" fetch --quiet origin "+refs/heads/$default:refs/remotes/origin/$default"; then
-    echo "error: could not fetch '$target' for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
-    return 1
+  if [ -n "${BASE_BRANCH:-}" ]; then
+    remote_status=0
+    git -C "$worktree" ls-remote --exit-code --heads origin "refs/heads/$BASE_BRANCH" >/dev/null 2>&1 || remote_status=$?
+    case "$remote_status" in
+      0)
+        if ! git -C "$worktree" fetch --quiet origin "+refs/heads/${BASE_BRANCH}:refs/remotes/origin/${BASE_BRANCH}"; then
+          echo "error: could not fetch 'origin/$BASE_BRANCH' for pooled worktree '$worktree'; refusing to launch from an unverifiable base" >&2
+          return 1
+        fi
+        target="origin/$BASE_BRANCH"
+        ;;
+      2)
+        if git -C "$worktree" show-ref --verify --quiet "refs/heads/$BASE_BRANCH"; then
+          target="$BASE_BRANCH"
+        else
+          echo "error: --base-branch '$BASE_BRANCH' does not exist locally or on origin for pooled worktree '$worktree'; refusing to fall back to the default branch" >&2
+          return 1
+        fi
+        ;;
+      *)
+        echo "error: could not determine whether 'origin/$BASE_BRANCH' exists for pooled worktree '$worktree'; refusing to launch from an unverifiable base" >&2
+        return 1
+        ;;
+    esac
+  else
+    if ! git -C "$worktree" remote set-head origin --auto >/dev/null 2>&1; then
+      echo "error: could not resolve origin's current default branch for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+      return 1
+    fi
+    default=$(default_branch "$worktree") || {
+      echo "error: could not determine origin's default branch for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+      return 1
+    }
+    target="origin/$default"
+    if ! git -C "$worktree" fetch --quiet origin "+refs/heads/$default:refs/remotes/origin/$default"; then
+      echo "error: could not fetch '$target' for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+      return 1
+    fi
   fi
   expected=$(git -C "$worktree" rev-parse --verify --quiet "$target^{commit}" 2>/dev/null) || {
     echo "error: '$target' is not a commit for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
@@ -2861,6 +2944,7 @@ preserve_relaunch_meta() {
   echo "kind=$KIND"
   [ -z "$MODE" ] || echo "mode=$MODE"
   [ -z "$YOLO" ] || echo "yolo=$YOLO"
+  [ -z "${BASE_BRANCH:-}" ] || echo "base_branch=$BASE_BRANCH"
   echo "tasktmp=$TASK_TMP"
   echo "model=${MODEL:-default}"
   echo "effort=${EFFORT:-default}"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1833,16 +1833,23 @@ delivery_rigor_rank() {  # <mode> -> 3 (most rigor) .. 1 (least); 0 = not a task
 # relaunch marker wins: generated contracts are appended after {TASK} text that
 # may mention the same phrases or headings, and a later progress note must not
 # override them. Truncation anchors on the exact generated marker (`## Progress
-# note (ISO-timestamp)` followed by `This task was relaunched.`), not on heading
-# text alone. When that section is missing, older one-line records are read
-# from the brief prefix before that marker only. bin/fm-merge-local.sh uses
-# the same rule for landing.
+# note (ISO-timestamp)` followed by `This task was relaunched.`) only when that
+# marker is not followed by the generated Setup line (`You are in a disposable
+# git worktree of `). A copy inside replaceable {TASK} text therefore cannot
+# hide the generated section. Heading text alone is not a boundary. When that
+# section is missing, older one-line records are read from the brief prefix
+# before that marker only. bin/fm-merge-local.sh uses the same rule for landing.
 brief_dod_section() {
   awk '
-    BEGIN { pending_relaunch=0 }
+    FNR==NR {
+      if ($0 ~ /^You are in a disposable git worktree of /) last_setup=FNR
+      next
+    }
     pending_relaunch && /^[[:space:]]*$/ { next }
     pending_relaunch {
-      if ($0 ~ /^This task was relaunched\./) { exit }
+      if ($0 ~ /^This task was relaunched\./) {
+        if (!last_setup || FNR > last_setup) exit
+      }
       pending_relaunch=0
     }
     /^## Progress note \([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z\)$/ {
@@ -1853,15 +1860,20 @@ brief_dod_section() {
     /^#{1,6}[[:space:]]/ { grab=0; next }
     grab { buf = buf $0 ORS }
     END { printf "%s", buf }
-  ' "$1"
+  ' "$1" "$1"
 }
 
 brief_truncated_prefix() {
   awk '
-    BEGIN { pending_relaunch=0 }
+    FNR==NR {
+      if ($0 ~ /^You are in a disposable git worktree of /) last_setup=FNR
+      next
+    }
     pending_relaunch && /^[[:space:]]*$/ { next }
     pending_relaunch {
-      if ($0 ~ /^This task was relaunched\./) { exit }
+      if ($0 ~ /^This task was relaunched\./) {
+        if (!last_setup || FNR > last_setup) exit
+      }
       pending_relaunch=0
     }
     /^## Progress note \([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z\)$/ {
@@ -1869,7 +1881,7 @@ brief_truncated_prefix() {
       next
     }
     { print }
-  ' "$1"
+  ' "$1" "$1"
 }
 
 brief_contract_region_nonempty() {

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -166,6 +166,8 @@
 #   pre-retarget green as done, and do not treat "0 checks configured" as
 #   green unless that is this repo's trusted no-CI case. A direct-PR ship
 #   opens with `gh-axi pr create --base <branch>` instead of retargeting.
+#   A local-only ship still freshens from that branch; landing against it is
+#   owned by bin/fm-merge-local.sh.
 #   Scaffold the matching brief with the same flag so the worker sees those
 #   steps (bin/fm-brief.sh). When the flag is omitted, freshen and the
 #   generated meta stay identical to today.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1834,15 +1834,18 @@ delivery_rigor_rank() {  # <mode> -> 3 (most rigor) .. 1 (least); 0 = not a task
 # may mention the same phrases or headings, and a later progress note must not
 # override them. Truncation anchors on the exact generated marker (`## Progress
 # note (ISO-timestamp)` followed by `This task was relaunched.`) only when that
-# marker is not followed by a generated Setup pair (`# Setup` then `You are in
-# a disposable git worktree of `). A copy of the marker or the worktree line
-# alone therefore cannot hide or extend the generated section. Heading text
-# alone is not a boundary. When that
+# marker sits after the first `Scaffold bound: generated` line written by
+# bin/fm-brief.sh. A progress note that copies `# Setup` and the disposable
+# worktree line therefore cannot move the bound. Briefs without that line keep
+# the older rule: the marker is structural only when it is not followed by a
+# generated Setup pair (`# Setup` then `You are in a disposable git worktree
+# of `). Heading text alone is not a boundary. When that
 # section is missing, older one-line records are read from the brief prefix
 # before that marker only. bin/fm-merge-local.sh uses the same rule for landing.
 brief_dod_section() {
   awk '
     FNR==NR {
+      if (!scaffold_end && $0 == "Scaffold bound: generated") scaffold_end=FNR
       if (pending_setup && /^[[:space:]]*$/) next
       if (pending_setup) {
         if ($0 ~ /^You are in a disposable git worktree of /) last_setup=FNR
@@ -1855,7 +1858,11 @@ brief_dod_section() {
     pending_relaunch && /^[[:space:]]*$/ { next }
     pending_relaunch {
       if ($0 ~ /^This task was relaunched\./) {
-        if (!last_setup || FNR > last_setup) exit
+        if (scaffold_end) {
+          if (FNR > scaffold_end) exit
+        } else if (!last_setup || FNR > last_setup) {
+          exit
+        }
       }
       pending_relaunch=0
     }
@@ -1873,6 +1880,7 @@ brief_dod_section() {
 brief_truncated_prefix() {
   awk '
     FNR==NR {
+      if (!scaffold_end && $0 == "Scaffold bound: generated") scaffold_end=FNR
       if (pending_setup && /^[[:space:]]*$/) next
       if (pending_setup) {
         if ($0 ~ /^You are in a disposable git worktree of /) last_setup=FNR
@@ -1885,7 +1893,11 @@ brief_truncated_prefix() {
     pending_relaunch && /^[[:space:]]*$/ { next }
     pending_relaunch {
       if ($0 ~ /^This task was relaunched\./) {
-        if (!last_setup || FNR > last_setup) exit
+        if (scaffold_end) {
+          if (FNR > scaffold_end) exit
+        } else if (!last_setup || FNR > last_setup) {
+          exit
+        }
       }
       pending_relaunch=0
     }

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1829,16 +1829,19 @@ delivery_rigor_rank() {  # <mode> -> 3 (most rigor) .. 1 (least); 0 = not a task
 # fm-brief.sh records a ship brief's mode as a fixed "Delivery contract: mode=<mode>"
 # line. A spawn that disagrees would launch a worker whose instructions and whose
 # recorded task delivery differ, which is the exact drift this contract prevents.
-# Last matching line in `# Definition of done` wins: generated contracts are
-# appended after {TASK} text that may mention the same phrase, and a later
-# relaunch `## Progress note` must not override them. If that section is
-# missing, the last matching line in the brief still wins. bin/fm-merge-local.sh
-# uses the same rule for landing.
+# Last matching line in the last `# Definition of done` before a relaunch
+# `## Progress note` wins: generated contracts are appended after {TASK} text
+# that may mention the same phrase or even copy the heading, and a later
+# progress note must not override them. If that section is missing, the last
+# matching line in the brief still wins. bin/fm-merge-local.sh uses the same
+# rule for landing.
 brief_dod_section() {
   awk '
-    /^# Definition of done[[:space:]]*$/ { grab=1; next }
-    /^#{1,6}[[:space:]]/ { if (grab) exit }
-    grab { print }
+    /^## Progress note/ { exit }
+    /^# Definition of done[[:space:]]*$/ { grab=1; buf=""; next }
+    /^#{1,6}[[:space:]]/ { grab=0; next }
+    grab { buf = buf $0 ORS }
+    END { printf "%s", buf }
   ' "$1"
 }
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1829,10 +1829,12 @@ delivery_rigor_rank() {  # <mode> -> 3 (most rigor) .. 1 (least); 0 = not a task
 # fm-brief.sh records a ship brief's mode as a fixed "Delivery contract: mode=<mode>"
 # line. A spawn that disagrees would launch a worker whose instructions and whose
 # recorded task delivery differ, which is the exact drift this contract prevents.
-BRIEF_BASE_BRANCH=$(sed -n 's/^Base branch contract: base_branch=\([^ ]*\).*$/\1/p' "$BRIEF" | head -n 1)
+# Last matching line wins: generated contracts are appended after {TASK} text
+# that may mention the same phrase. bin/fm-merge-local.sh uses the same rule.
+BRIEF_BASE_BRANCH=$(sed -n 's/^Base branch contract: base_branch=\([^ ]*\).*$/\1/p' "$BRIEF" | tail -n 1)
 if [ "$KIND" = ship ]; then
   PROJ_NAME=$(basename "$PROJ_ABS")
-  BRIEF_MODE=$(sed -n 's/^Delivery contract: mode=\([^ ]*\).*$/\1/p' "$BRIEF" | head -n 1)
+  BRIEF_MODE=$(sed -n 's/^Delivery contract: mode=\([^ ]*\).*$/\1/p' "$BRIEF" | tail -n 1)
   if [ -z "$BRIEF_MODE" ]; then
     echo "warning: $BRIEF records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode $MODE - confirm its definition of done matches" >&2
   elif [ "$BRIEF_MODE" != "$MODE" ]; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1834,15 +1834,22 @@ delivery_rigor_rank() {  # <mode> -> 3 (most rigor) .. 1 (least); 0 = not a task
 # may mention the same phrases or headings, and a later progress note must not
 # override them. Truncation anchors on the exact generated marker (`## Progress
 # note (ISO-timestamp)` followed by `This task was relaunched.`) only when that
-# marker is not followed by the generated Setup line (`You are in a disposable
-# git worktree of `). A copy inside replaceable {TASK} text therefore cannot
-# hide the generated section. Heading text alone is not a boundary. When that
+# marker is not followed by a generated Setup pair (`# Setup` then `You are in
+# a disposable git worktree of `). A copy of the marker or the worktree line
+# alone therefore cannot hide or extend the generated section. Heading text
+# alone is not a boundary. When that
 # section is missing, older one-line records are read from the brief prefix
 # before that marker only. bin/fm-merge-local.sh uses the same rule for landing.
 brief_dod_section() {
   awk '
     FNR==NR {
-      if ($0 ~ /^You are in a disposable git worktree of /) last_setup=FNR
+      if (pending_setup && /^[[:space:]]*$/) next
+      if (pending_setup) {
+        if ($0 ~ /^You are in a disposable git worktree of /) last_setup=FNR
+        pending_setup=0
+        next
+      }
+      if ($0 ~ /^# Setup[[:space:]]*$/) pending_setup=1
       next
     }
     pending_relaunch && /^[[:space:]]*$/ { next }
@@ -1866,7 +1873,13 @@ brief_dod_section() {
 brief_truncated_prefix() {
   awk '
     FNR==NR {
-      if ($0 ~ /^You are in a disposable git worktree of /) last_setup=FNR
+      if (pending_setup && /^[[:space:]]*$/) next
+      if (pending_setup) {
+        if ($0 ~ /^You are in a disposable git worktree of /) last_setup=FNR
+        pending_setup=0
+        next
+      }
+      if ($0 ~ /^# Setup[[:space:]]*$/) pending_setup=1
       next
     }
     pending_relaunch && /^[[:space:]]*$/ { next }

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1829,15 +1829,26 @@ delivery_rigor_rank() {  # <mode> -> 3 (most rigor) .. 1 (least); 0 = not a task
 # fm-brief.sh records a ship brief's mode as a fixed "Delivery contract: mode=<mode>"
 # line. A spawn that disagrees would launch a worker whose instructions and whose
 # recorded task delivery differ, which is the exact drift this contract prevents.
-# Last matching line in the last `# Definition of done` before a relaunch
-# `## Progress note` wins: generated contracts are appended after {TASK} text
-# that may mention the same phrase or even copy the heading, and a later
-# progress note must not override them. If that section is missing, the last
-# matching line in the brief still wins. bin/fm-merge-local.sh uses the same
-# rule for landing.
+# Last matching line in the last `# Definition of done` before an fm-control
+# relaunch marker wins: generated contracts are appended after {TASK} text that
+# may mention the same phrases or headings, and a later progress note must not
+# override them. Truncation anchors on the exact generated marker (`## Progress
+# note (ISO-timestamp)` followed by `This task was relaunched.`), not on heading
+# text alone. When that section is missing, older one-line records are read
+# from the brief prefix before that marker only. bin/fm-merge-local.sh uses
+# the same rule for landing.
 brief_dod_section() {
   awk '
-    /^## Progress note/ { exit }
+    BEGIN { pending_relaunch=0 }
+    pending_relaunch && /^[[:space:]]*$/ { next }
+    pending_relaunch {
+      if ($0 ~ /^This task was relaunched\./) { exit }
+      pending_relaunch=0
+    }
+    /^## Progress note \([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z\)$/ {
+      pending_relaunch=1
+      next
+    }
     /^# Definition of done[[:space:]]*$/ { grab=1; buf=""; next }
     /^#{1,6}[[:space:]]/ { grab=0; next }
     grab { buf = buf $0 ORS }
@@ -1845,13 +1856,36 @@ brief_dod_section() {
   ' "$1"
 }
 
+brief_truncated_prefix() {
+  awk '
+    BEGIN { pending_relaunch=0 }
+    pending_relaunch && /^[[:space:]]*$/ { next }
+    pending_relaunch {
+      if ($0 ~ /^This task was relaunched\./) { exit }
+      pending_relaunch=0
+    }
+    /^## Progress note \([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z\)$/ {
+      pending_relaunch=1
+      next
+    }
+    { print }
+  ' "$1"
+}
+
+brief_contract_region_nonempty() {
+  local region=$1
+  [ -n "$(printf '%s' "$region" | sed '/^[[:space:]]*$/d' | head -n 1)" ]
+}
+
 brief_last_contract_word() {
-  local file=$1 prefix=$2 section value
+  local file=$1 prefix=$2 section region value
   section=$(brief_dod_section "$file")
-  value=$(printf '%s\n' "$section" | sed -n "s/^${prefix}\([^ ]*\).*$/\1/p" | tail -n 1)
-  if [ -z "$value" ]; then
-    value=$(sed -n "s/^${prefix}\([^ ]*\).*$/\1/p" "$file" | tail -n 1)
+  if brief_contract_region_nonempty "$section"; then
+    region=$section
+  else
+    region=$(brief_truncated_prefix "$file")
   fi
+  value=$(printf '%s\n' "$region" | sed -n "s/^${prefix}\([^ ]*\).*$/\1/p" | tail -n 1)
   printf '%s' "$value"
 }
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1829,12 +1829,33 @@ delivery_rigor_rank() {  # <mode> -> 3 (most rigor) .. 1 (least); 0 = not a task
 # fm-brief.sh records a ship brief's mode as a fixed "Delivery contract: mode=<mode>"
 # line. A spawn that disagrees would launch a worker whose instructions and whose
 # recorded task delivery differ, which is the exact drift this contract prevents.
-# Last matching line wins: generated contracts are appended after {TASK} text
-# that may mention the same phrase. bin/fm-merge-local.sh uses the same rule.
-BRIEF_BASE_BRANCH=$(sed -n 's/^Base branch contract: base_branch=\([^ ]*\).*$/\1/p' "$BRIEF" | tail -n 1)
+# Last matching line in `# Definition of done` wins: generated contracts are
+# appended after {TASK} text that may mention the same phrase, and a later
+# relaunch `## Progress note` must not override them. If that section is
+# missing, the last matching line in the brief still wins. bin/fm-merge-local.sh
+# uses the same rule for landing.
+brief_dod_section() {
+  awk '
+    /^# Definition of done[[:space:]]*$/ { grab=1; next }
+    /^#{1,6}[[:space:]]/ { if (grab) exit }
+    grab { print }
+  ' "$1"
+}
+
+brief_last_contract_word() {
+  local file=$1 prefix=$2 section value
+  section=$(brief_dod_section "$file")
+  value=$(printf '%s\n' "$section" | sed -n "s/^${prefix}\([^ ]*\).*$/\1/p" | tail -n 1)
+  if [ -z "$value" ]; then
+    value=$(sed -n "s/^${prefix}\([^ ]*\).*$/\1/p" "$file" | tail -n 1)
+  fi
+  printf '%s' "$value"
+}
+
+BRIEF_BASE_BRANCH=$(brief_last_contract_word "$BRIEF" 'Base branch contract: base_branch=')
 if [ "$KIND" = ship ]; then
   PROJ_NAME=$(basename "$PROJ_ABS")
-  BRIEF_MODE=$(sed -n 's/^Delivery contract: mode=\([^ ]*\).*$/\1/p' "$BRIEF" | tail -n 1)
+  BRIEF_MODE=$(brief_last_contract_word "$BRIEF" 'Delivery contract: mode=')
   if [ -z "$BRIEF_MODE" ]; then
     echo "warning: $BRIEF records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode $MODE - confirm its definition of done matches" >&2
   elif [ "$BRIEF_MODE" != "$MODE" ]; then

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -194,7 +194,7 @@ Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectab
 
 Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees for tmux, herdr, zellij, and cmux tasks, while Orca creates its own worktrees for `backend=orca`.
 For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout.
-`fm-spawn.sh` also owns the base-freshness boundary for every fresh ship and scout: no worker starts until its clean task worktree matches the fetched tip of origin's resolved default branch, and any unsafe or unverifiable base stops the spawn.
+`fm-spawn.sh` also owns the base-freshness boundary for every fresh ship and scout: no worker starts until its clean task worktree matches the fetched tip of origin's resolved default branch, or of `--base-branch` when that flag is set, and any unsafe or unverifiable base stops the spawn.
 Its header owns the exact refusal mechanics, while `tests/fm-spawn-pool-base-freshen.test.sh` owns the portable regression coverage.
 
 The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -65,7 +65,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `backends/cmux.sh`       | Experimental cmux session-provider adapter                                           |
 | `fm-config-push.sh`      | Push declared inherited local material to live local or remote secondmates and send the placement-specific config reread when changed |
 | `fm-project-mode.sh`     | Resolve a project's registered delivery posture from `data/projects.md` for fleet sync and home seeding |
-| `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval            |
+| `fm-merge-local.sh`      | Fast-forward a `local-only` project's recorded base, or its local default branch when none is recorded, after approval |
 | `fm-review-diff.sh`      | Review a crewmate branch or resolved PR head against the authoritative base          |
 | `fm-marker-lib.sh`       | Compatibility entry point for the from-firstmate carrier owned by `fm-operational-input.sh` |
 | `fm-task-inbox-lib.sh`   | Single owner of durable steering-inbox records, acknowledgement, doorbells, and the delivery-attempt ladder |

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -286,8 +286,14 @@ yolo on a ship brief|brief-refused-b1 some-proj --mode direct-PR --yolo on|--yol
 yolo=value form on a ship brief|brief-refused-b2 some-proj --mode direct-PR --yolo=off|--yolo is not a brief input
 mode on a scout brief|brief-refused-b3 some-proj --scout --mode direct-PR|--mode applies only to ship briefs
 mode on a secondmate charter|brief-refused-b4 --secondmate --no-projects --mode no-mistakes|--mode applies only to ship briefs
+base-branch on a secondmate charter|brief-refused-b5 --secondmate --no-projects --base-branch develop|--base-branch applies only to ship and scout briefs
+empty base-branch value|brief-refused-b6 some-proj --mode no-mistakes --base-branch=|--base-branch requires a non-empty value
+invalid base-branch name|brief-refused-b7 some-proj --mode no-mistakes --base-branch bad..name|--base-branch is not a usable git branch name
+branch-name on a secondmate charter|brief-refused-b8 --secondmate --no-projects --branch-name feature/x|--branch-name applies only to ship and scout briefs
+empty branch-name value|brief-refused-b9 some-proj --mode no-mistakes --branch-name=|--branch-name requires a non-empty value
+invalid branch-name|brief-refused-b10 some-proj --mode no-mistakes --branch-name bad..name|--branch-name is not a usable git branch name
 ROWS
-  pass "fm-brief.sh: --yolo and scout/secondmate --mode are refused, never silently dropped"
+  pass "fm-brief.sh: --yolo, scout/secondmate --mode, and misplaced --base-branch/--branch-name are refused, never silently dropped"
 }
 
 test_faster_paths_use_configured_authority_without_stacked_review() {
@@ -762,6 +768,149 @@ test_scout_and_secondmate_scaffold() {
   pass "fm-brief: scout and secondmate code paths still scaffold well-formed briefs"
 }
 
+# --base-branch is the worker-facing form of the spawn header's
+# retarget-after-green sequence. Without the flag, existing DOD wording stays
+# unchanged. With it, no-mistakes retargets after first green and reconfirms CI;
+# direct-PR opens against the named base; scout only records the freshen base.
+test_base_branch_worker_steps() {
+  local home brief
+  home="$TMP_ROOT/base-branch-brief-home"
+  mkdir -p "$home/data"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-base-nm-omit some-proj --mode no-mistakes >/dev/null 2>&1 \
+    || fail "omitted --base-branch no-mistakes brief should scaffold"
+  brief="$home/data/brief-base-nm-omit/brief.md"
+  assert_grep "After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished." "$brief" \
+    "omitted --base-branch must keep the historical no-mistakes done line"
+  assert_no_grep "gh pr edit" "$brief" \
+    "omitted --base-branch no-mistakes brief must not retarget the PR"
+  assert_no_grep "Base branch contract: base_branch=" "$brief" \
+    "omitted --base-branch no-mistakes brief must not add a base contract"
+  assert_grep "at a detached HEAD on a clean default branch" "$brief" \
+    "omitted --base-branch must keep the default-branch setup line"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-base-nm-on some-proj --mode no-mistakes --base-branch develop >/dev/null 2>&1 \
+    || fail "--base-branch no-mistakes brief should scaffold"
+  brief="$home/data/brief-base-nm-on/brief.md"
+  assert_grep "at a detached HEAD on \`develop\`" "$brief" \
+    "--base-branch no-mistakes brief must name the freshen base in Setup"
+  assert_grep "Do not pass --skip pr" "$brief" \
+    "--base-branch no-mistakes brief must keep the pipeline running normally"
+  assert_grep "Base branch contract: base_branch=develop" "$brief" \
+    "--base-branch no-mistakes brief must record its PR target contract"
+  assert_grep "gh pr edit <number> --base 'develop'" "$brief" \
+    "--base-branch no-mistakes brief must retarget after first green"
+  assert_grep "gh-axi pr checks <number>" "$brief" \
+    "--base-branch no-mistakes brief must reconfirm CI after retarget"
+  assert_grep "Do not trust the pre-retarget green" "$brief" \
+    "--base-branch no-mistakes brief must not treat the first green as done"
+  assert_no_grep "After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\`" "$brief" \
+    "--base-branch no-mistakes brief must not keep the immediate-done line"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-base-dpr-omit some-proj --mode direct-PR >/dev/null 2>&1 \
+    || fail "omitted --base-branch direct-PR brief should scaffold"
+  brief="$home/data/brief-base-dpr-omit/brief.md"
+  assert_grep "open a PR with \`gh-axi\`" "$brief" \
+    "omitted --base-branch must keep the historical direct-PR create line"
+  assert_no_grep "gh-axi pr create --base" "$brief" \
+    "omitted --base-branch direct-PR brief must not pin a create base"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-base-dpr-on some-proj --mode direct-PR --base-branch develop >/dev/null 2>&1 \
+    || fail "--base-branch direct-PR brief should scaffold"
+  brief="$home/data/brief-base-dpr-on/brief.md"
+  assert_grep "gh-axi pr create --base 'develop'" "$brief" \
+    "--base-branch direct-PR brief must open against the named base"
+  assert_no_grep "gh-axi pr edit" "$brief" \
+    "direct-PR --base-branch must open against the named base instead of retargeting"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-base-scout-on some-proj --scout --base-branch develop >/dev/null 2>&1 \
+    || fail "--base-branch scout brief should scaffold"
+  brief="$home/data/brief-base-scout-on/brief.md"
+  assert_grep "at a detached HEAD on \`develop\`" "$brief" \
+    "--base-branch scout brief must name the freshen base in Setup"
+  assert_grep "Base branch contract: base_branch=develop" "$brief" \
+    "--base-branch scout brief must record its freshen base contract"
+  assert_no_grep "gh-axi pr edit" "$brief" \
+    "scout --base-branch must not add a PR retarget step"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-base-shell some-proj --mode no-mistakes --base-branch 'topic;id' >/dev/null 2>&1 \
+    || fail "shell-metacharacter --base-branch brief should scaffold"
+  brief="$home/data/brief-base-shell/brief.md"
+  assert_grep "gh pr edit <number> --base 'topic;id'" "$brief" \
+    "--base-branch must quote shell metacharacters in the retarget command"
+  assert_grep "Base branch contract: base_branch=topic;id" "$brief" \
+    "--base-branch must preserve the raw value in its contract line"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-base-shell-dpr some-proj --mode direct-PR --base-branch 'topic;id' >/dev/null 2>&1 \
+    || fail "shell-metacharacter direct-PR --base-branch brief should scaffold"
+  brief="$home/data/brief-base-shell-dpr/brief.md"
+  assert_grep "gh-axi pr create --base 'topic;id'" "$brief" \
+    "--base-branch must quote shell metacharacters in the create command"
+  pass "fm-brief.sh: --base-branch writes retarget-after-green steps only when set"
+}
+
+# --branch-name replaces every generated fm/<id> crew branch. Omitted keeps
+# today's exact fm/<id> wording and does not write a Crew branch contract line.
+test_branch_name_worker_steps() {
+  local home brief
+  home="$TMP_ROOT/branch-name-brief-home"
+  mkdir -p "$home/data"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-bn-omit some-proj --mode no-mistakes >/dev/null 2>&1 \
+    || fail "omitted --branch-name no-mistakes brief should scaffold"
+  brief="$home/data/brief-bn-omit/brief.md"
+  assert_grep "git checkout -b fm/brief-bn-omit" "$brief" \
+    "omitted --branch-name must keep the historical fm/<id> checkout command"
+  assert_no_grep "Crew branch: branch=" "$brief" \
+    "omitted --branch-name must not write a Crew branch contract line"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-bn-on some-proj --mode no-mistakes --branch-name feature/TD-131-visual-dom-editor >/dev/null 2>&1 \
+    || fail "--branch-name no-mistakes brief should scaffold"
+  brief="$home/data/brief-bn-on/brief.md"
+  assert_grep "git checkout -b 'feature/TD-131-visual-dom-editor'" "$brief" \
+    "--branch-name must replace the checkout command"
+  assert_grep "Crew branch: branch=feature/TD-131-visual-dom-editor" "$brief" \
+    "--branch-name must record the crew branch contract"
+  assert_no_grep "git checkout -b fm/brief-bn-on" "$brief" \
+    "--branch-name must not keep the default fm/<id> checkout command"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-bn-shell some-proj --mode no-mistakes --branch-name 'topic;id' >/dev/null 2>&1 \
+    || fail "shell-metacharacter --branch-name brief should scaffold"
+  brief="$home/data/brief-bn-shell/brief.md"
+  assert_grep "git checkout -b 'topic;id'" "$brief" \
+    "--branch-name must quote shell metacharacters in the checkout command"
+  assert_grep "Crew branch: branch=topic;id" "$brief" \
+    "--branch-name must preserve the raw value in its contract line"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-bn-dpr some-proj --mode direct-PR --branch-name feature/TD-131-visual-dom-editor >/dev/null 2>&1 \
+    || fail "--branch-name direct-PR brief should scaffold"
+  brief="$home/data/brief-bn-dpr/brief.md"
+  assert_grep "push only your \`feature/TD-131-visual-dom-editor\` branch" "$brief" \
+    "--branch-name must replace the direct-PR push-rule branch"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-bn-local-omit some-proj --mode local-only >/dev/null 2>&1 \
+    || fail "omitted --branch-name local-only brief should scaffold"
+  brief="$home/data/brief-bn-local-omit/brief.md"
+  assert_grep "done: ready in branch fm/brief-bn-local-omit" "$brief" \
+    "omitted --branch-name must keep the historical local-only done line"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-bn-local-on some-proj --mode local-only --branch-name feature/TD-131-visual-dom-editor >/dev/null 2>&1 \
+    || fail "--branch-name local-only brief should scaffold"
+  brief="$home/data/brief-bn-local-on/brief.md"
+  assert_grep "done: ready in branch feature/TD-131-visual-dom-editor" "$brief" \
+    "--branch-name must replace the local-only done line"
+  assert_grep "Work only on your \`feature/TD-131-visual-dom-editor\` branch" "$brief" \
+    "--branch-name must replace the local-only push-rule branch"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-bn-scout some-proj --scout --branch-name feature/TD-131-visual-dom-editor >/dev/null 2>&1 \
+    || fail "--branch-name scout brief should scaffold"
+  brief="$home/data/brief-bn-scout/brief.md"
+  assert_present "$brief" "scout --branch-name brief was not scaffolded"
+  assert_no_grep "git checkout -b" "$brief" \
+    "scout briefs must not invent a checkout command when --branch-name is set"
+  pass "fm-brief.sh: --branch-name replaces generated fm/<id> crew branches only when set"
+}
+
 test_script_parses
 test_no_heredoc_in_command_substitution
 test_help_includes_entire_header
@@ -783,3 +932,5 @@ test_secondmate_directory_paths_are_absolute_and_output_is_stable
 test_pause_verb_override_renders_all_brief_scaffolds
 test_scout_and_secondmate_load_decision_hold_policy
 test_scout_and_secondmate_scaffold
+test_base_branch_worker_steps
+test_branch_name_worker_steps

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -857,6 +857,15 @@ test_base_branch_worker_steps() {
     "--base-branch scout brief must name the freshen base in Setup"
   assert_grep "Base branch contract: base_branch=develop" "$brief" \
     "--base-branch scout brief must record its freshen base contract"
+  awk '
+    /^# Definition of done[[:space:]]*$/ { dod=1 }
+    /^Base branch contract: base_branch=develop$/ {
+      found=1
+      if (!dod) exit 2
+    }
+    END { if (!found) exit 1 }
+  ' "$brief" \
+    || fail "--base-branch scout brief must record its contract in Definition of done"
   assert_no_grep "gh-axi pr edit" "$brief" \
     "scout --base-branch must not add a PR retarget step"
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -292,7 +292,8 @@ invalid base-branch name|brief-refused-b7 some-proj --mode no-mistakes --base-br
 branch-name on a secondmate charter|brief-refused-b8 --secondmate --no-projects --branch-name feature/x|--branch-name applies only to ship and scout briefs
 empty branch-name value|brief-refused-b9 some-proj --mode no-mistakes --branch-name=|--branch-name requires a non-empty value
 invalid branch-name|brief-refused-b10 some-proj --mode no-mistakes --branch-name bad..name|--branch-name is not a usable git branch name
-identical base and crew branch|brief-refused-b11 some-proj --mode no-mistakes --base-branch feature/x --branch-name feature/x|--branch-name and --base-branch cannot name the same branch
+identical base and crew branch|brief-refused-b11 some-proj --mode no-mistakes --base-branch feature/x --branch-name feature/x|--base-branch cannot be the crew branch
+default crew branch equals base-branch|brief-refused-b12 some-proj --mode no-mistakes --base-branch fm/brief-refused-b12|--base-branch cannot be the crew branch
 ROWS
   pass "fm-brief.sh: --yolo, scout/secondmate --mode, and misplaced --base-branch/--branch-name are refused, never silently dropped"
 }

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -771,7 +771,8 @@ test_scout_and_secondmate_scaffold() {
 # --base-branch is the worker-facing form of the spawn header's
 # retarget-after-green sequence. Without the flag, existing DOD wording stays
 # unchanged. With it, no-mistakes retargets after first green and reconfirms CI;
-# direct-PR opens against the named base; scout only records the freshen base.
+# direct-PR opens against the named base; local-only lands on the named base;
+# scout only records the freshen base.
 test_base_branch_worker_steps() {
   local home brief
   home="$TMP_ROOT/base-branch-brief-home"
@@ -822,6 +823,30 @@ test_base_branch_worker_steps() {
     "--base-branch direct-PR brief must open against the named base"
   assert_no_grep "gh-axi pr edit" "$brief" \
     "direct-PR --base-branch must open against the named base instead of retargeting"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-base-local-omit some-proj --mode local-only >/dev/null 2>&1 \
+    || fail "omitted --base-branch local-only brief should scaffold"
+  brief="$home/data/brief-base-local-omit/brief.md"
+  assert_grep "firstmate merges it into local \`main\` through the guarded fast-forward path." "$brief" \
+    "omitted --base-branch must keep the historical local-only landing line"
+  assert_grep "Keep your branch a clean fast-forward onto the current default branch" "$brief" \
+    "omitted --base-branch must keep the historical local-only rebase line"
+  assert_no_grep "Base branch contract: base_branch=" "$brief" \
+    "omitted --base-branch local-only brief must not add a base contract"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-base-local-on some-proj --mode local-only --base-branch develop >/dev/null 2>&1 \
+    || fail "--base-branch local-only brief should scaffold"
+  brief="$home/data/brief-base-local-on/brief.md"
+  assert_grep "Keep your branch a clean fast-forward onto \`develop\`" "$brief" \
+    "--base-branch local-only brief must rebase onto the named base"
+  assert_grep "firstmate merges it into local \`develop\` through the guarded fast-forward path." "$brief" \
+    "--base-branch local-only brief must land on the named base"
+  assert_grep "Base branch contract: base_branch=develop" "$brief" \
+    "--base-branch local-only brief must record its landing-base contract"
+  assert_no_grep "fast-forward onto the current default branch" "$brief" \
+    "--base-branch local-only brief must not keep the default-branch rebase line"
+  assert_no_grep "merges it into local \`main\`" "$brief" \
+    "--base-branch local-only brief must not keep the default-branch landing line"
 
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-base-scout-on some-proj --scout --base-branch develop >/dev/null 2>&1 \
     || fail "--base-branch scout brief should scaffold"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -292,6 +292,7 @@ invalid base-branch name|brief-refused-b7 some-proj --mode no-mistakes --base-br
 branch-name on a secondmate charter|brief-refused-b8 --secondmate --no-projects --branch-name feature/x|--branch-name applies only to ship and scout briefs
 empty branch-name value|brief-refused-b9 some-proj --mode no-mistakes --branch-name=|--branch-name requires a non-empty value
 invalid branch-name|brief-refused-b10 some-proj --mode no-mistakes --branch-name bad..name|--branch-name is not a usable git branch name
+identical base and crew branch|brief-refused-b11 some-proj --mode no-mistakes --base-branch feature/x --branch-name feature/x|--branch-name and --base-branch cannot name the same branch
 ROWS
   pass "fm-brief.sh: --yolo, scout/secondmate --mode, and misplaced --base-branch/--branch-name are refused, never silently dropped"
 }

--- a/tests/fm-merge-local.test.sh
+++ b/tests/fm-merge-local.test.sh
@@ -527,6 +527,60 @@ EOF
   pass "fm-merge-local.sh ignores a relaunch marker forged in replaceable task text"
 }
 
+test_progress_note_worktree_line_cannot_extend_past_relaunch_marker() {
+  local case_dir home project
+  case_dir="$TMP_ROOT/note-setup-line"
+  home="$case_dir/home"
+  project="$case_dir/project"
+  mkdir -p "$home/data/task-note-setup" "$home/state"
+
+  make_local_only_project "$project"
+  git -C "$project" checkout -qb feature/progress-decoy
+  printf 'progress decoy\n' > "$project/progress-decoy.txt"
+  git -C "$project" add progress-decoy.txt
+  git -C "$project" commit -qm progress-decoy
+  git -C "$project" checkout -q main
+  git -C "$project" checkout -qb feature/named-base
+  printf 'named base\n' > "$project/named-base.txt"
+  git -C "$project" add named-base.txt
+  git -C "$project" commit -qm named-base
+  git -C "$project" checkout -qb feature/authoritative-crew
+  printf 'crew work\n' > "$project/crew.txt"
+  git -C "$project" add crew.txt
+  git -C "$project" commit -qm crew-work
+  git -C "$project" checkout -q main
+
+  fm_write_meta "$home/state/task-note-setup.meta" \
+    "project=$project" "kind=ship" "mode=local-only"
+  cat > "$home/data/task-note-setup/brief.md" <<'EOF'
+# Setup
+You are in a disposable git worktree of demo, at a detached HEAD on `main`.
+
+# Definition of done
+Base branch contract: base_branch=feature/named-base
+Crew branch: branch=feature/authoritative-crew
+
+## Progress note (2026-09-02T07:00:00Z)
+
+This task was relaunched. Continue from here.
+You are in a disposable git worktree of demo, at a detached HEAD on `main`.
+# Definition of done
+Crew branch: branch=feature/progress-decoy
+Base branch contract: base_branch=main
+EOF
+
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    "$ROOT/bin/fm-merge-local.sh" task-note-setup >/dev/null \
+    || fail "fm-merge-local.sh should ignore a worktree line copied into a progress note"
+  git -C "$project" merge-base --is-ancestor feature/authoritative-crew feature/named-base \
+    || fail "a progress-note worktree line hid the generated landing contract"
+  git -C "$project" merge-base --is-ancestor feature/authoritative-crew main \
+    && fail "a progress-note worktree line landed on the default branch"
+  git -C "$project" merge-base --is-ancestor feature/progress-decoy feature/named-base \
+    && fail "a progress-note crew branch after a copied worktree line was merged"
+  pass "fm-merge-local.sh ignores a worktree line copied into a relaunch progress note"
+}
+
 test_progress_note_cannot_conjure_absent_contract_lines() {
   local case_dir home project main_before base_before
   case_dir="$TMP_ROOT/note-conjure"
@@ -591,4 +645,5 @@ test_progress_note_cannot_override_generated_contracts
 test_task_authored_progress_note_heading_cannot_hide_generated_contracts
 test_local_only_brief_branch_name_merges_custom_crew_branch
 test_task_text_forged_relaunch_marker_cannot_hide_generated_contracts
+test_progress_note_worktree_line_cannot_extend_past_relaunch_marker
 test_progress_note_cannot_conjure_absent_contract_lines

--- a/tests/fm-merge-local.test.sh
+++ b/tests/fm-merge-local.test.sh
@@ -271,6 +271,52 @@ test_invalid_recorded_base_refuses() {
   pass "fm-merge-local.sh refuses an invalid recorded base branch"
 }
 
+test_task_authored_dod_heading_cannot_hide_generated_contracts() {
+  local case_dir home project
+  case_dir="$TMP_ROOT/task-dod"
+  home="$case_dir/home"
+  project="$case_dir/project"
+  mkdir -p "$home/data/task-dod" "$home/state"
+
+  make_local_only_project "$project"
+  git -C "$project" checkout -qb feature/task-decoy
+  printf 'task decoy\n' > "$project/task-decoy.txt"
+  git -C "$project" add task-decoy.txt
+  git -C "$project" commit -qm task-decoy
+  git -C "$project" checkout -q main
+  git -C "$project" checkout -qb feature/named-base
+  printf 'named base\n' > "$project/named-base.txt"
+  git -C "$project" add named-base.txt
+  git -C "$project" commit -qm named-base
+  git -C "$project" checkout -qb feature/authoritative-crew
+  printf 'crew work\n' > "$project/crew.txt"
+  git -C "$project" add crew.txt
+  git -C "$project" commit -qm crew-work
+  git -C "$project" checkout -q main
+
+  fm_write_meta "$home/state/task-dod.meta" \
+    "project=$project" "kind=ship" "mode=local-only"
+  cat > "$home/data/task-dod/brief.md" <<'EOF'
+# Task
+# Definition of done
+Base branch contract: base_branch=main
+Crew branch: branch=feature/task-decoy
+
+# Definition of done
+Base branch contract: base_branch=feature/named-base
+Crew branch: branch=feature/authoritative-crew
+EOF
+
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    "$ROOT/bin/fm-merge-local.sh" task-dod >/dev/null \
+    || fail "fm-merge-local.sh should read the last generated Definition of done"
+  git -C "$project" merge-base --is-ancestor feature/authoritative-crew feature/named-base \
+    || fail "a task-authored Definition of done hid the generated landing contract"
+  git -C "$project" merge-base --is-ancestor feature/authoritative-crew main \
+    && fail "a task-authored Definition of done landed on the default branch"
+  pass "fm-merge-local.sh uses the last Definition of done, not a task-authored copy"
+}
+
 test_progress_note_cannot_override_generated_contracts() {
   local case_dir home project
   case_dir="$TMP_ROOT/progress-note"
@@ -327,4 +373,5 @@ test_last_crew_branch_line_wins_over_earlier_mention
 test_recorded_base_lands_on_named_branch_not_default
 test_last_base_branch_line_wins_over_earlier_mention
 test_invalid_recorded_base_refuses
+test_task_authored_dod_heading_cannot_hide_generated_contracts
 test_progress_note_cannot_override_generated_contracts

--- a/tests/fm-merge-local.test.sh
+++ b/tests/fm-merge-local.test.sh
@@ -366,6 +366,149 @@ EOF
   pass "fm-merge-local.sh ignores contract lines appended in a relaunch progress note"
 }
 
+test_task_authored_progress_note_heading_cannot_hide_generated_contracts() {
+  local case_dir home project
+  case_dir="$TMP_ROOT/task-progress-heading"
+  home="$case_dir/home"
+  project="$case_dir/project"
+  mkdir -p "$home/data/task-progress-heading" "$home/state"
+
+  make_local_only_project "$project"
+  git -C "$project" checkout -qb feature/progress-decoy
+  printf 'progress decoy\n' > "$project/progress-decoy.txt"
+  git -C "$project" add progress-decoy.txt
+  git -C "$project" commit -qm progress-decoy
+  git -C "$project" checkout -q main
+  git -C "$project" checkout -qb feature/named-base
+  printf 'named base\n' > "$project/named-base.txt"
+  git -C "$project" add named-base.txt
+  git -C "$project" commit -qm named-base
+  git -C "$project" checkout -qb feature/authoritative-crew
+  printf 'crew work\n' > "$project/crew.txt"
+  git -C "$project" add crew.txt
+  git -C "$project" commit -qm crew-work
+  git -C "$project" checkout -q main
+
+  fm_write_meta "$home/state/task-progress-heading.meta" \
+    "project=$project" "kind=ship" "mode=local-only"
+  cat > "$home/data/task-progress-heading/brief.md" <<'EOF'
+# Task
+## Progress note
+The captain described a progress note in task prose.
+
+# Definition of done
+Base branch contract: base_branch=feature/named-base
+Crew branch: branch=feature/authoritative-crew
+
+## Progress note (2026-08-24T11:29:00Z)
+
+This task was relaunched. Continue from here.
+Crew branch: branch=feature/progress-decoy
+Base branch contract: base_branch=main
+EOF
+
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    "$ROOT/bin/fm-merge-local.sh" task-progress-heading >/dev/null \
+    || fail "fm-merge-local.sh should ignore a task-authored progress-note heading"
+  git -C "$project" merge-base --is-ancestor feature/authoritative-crew feature/named-base \
+    || fail "a task-authored progress-note heading hid the generated landing contract"
+  git -C "$project" merge-base --is-ancestor feature/authoritative-crew main \
+    && fail "a relaunch progress-note decoy landed on the default branch"
+  git -C "$project" merge-base --is-ancestor feature/progress-decoy feature/named-base \
+    && fail "a relaunch progress-note crew branch was merged instead of the generated contract"
+  pass "fm-merge-local.sh anchors truncation on the fm-control relaunch marker, not heading text alone"
+}
+
+test_local_only_brief_branch_name_merges_custom_crew_branch() {
+  local case_dir home project brief
+  case_dir="$TMP_ROOT/brief-branch-name"
+  home="$case_dir/home"
+  project="$case_dir/project"
+  mkdir -p "$home/data/task-brief-bn" "$home/state"
+
+  make_local_only_project "$project"
+  git -C "$project" checkout -qb feature/TD-131-visual-dom-editor
+  printf 'custom scaffold work\n' > "$project/custom-scaffold.txt"
+  git -C "$project" add custom-scaffold.txt
+  git -C "$project" commit -qm custom-scaffold
+  git -C "$project" checkout -qb "fm/task-brief-bn"
+  printf 'stale fm id branch\n' > "$project/stale-fm-id.txt"
+  git -C "$project" add stale-fm-id.txt
+  git -C "$project" commit -qm stale-fm-id
+  git -C "$project" checkout -q main
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" task-brief-bn test-proj \
+    --mode local-only --branch-name feature/TD-131-visual-dom-editor >/dev/null \
+    || fail "fm-brief.sh could not scaffold a local-only --branch-name brief"
+  brief="$home/data/task-brief-bn/brief.md"
+  assert_grep 'Crew branch: branch=feature/TD-131-visual-dom-editor' "$brief" \
+    "local-only --branch-name brief did not record the crew branch contract"
+
+  fm_write_meta "$home/state/task-brief-bn.meta" \
+    "project=$project" "kind=ship" "mode=local-only"
+
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    "$ROOT/bin/fm-merge-local.sh" task-brief-bn >/dev/null \
+    || fail "fm-merge-local.sh should merge a scaffolded local-only custom crew branch"
+  git -C "$project" merge-base --is-ancestor feature/TD-131-visual-dom-editor main \
+    || fail "scaffolded local-only custom crew branch was not merged into main"
+  git -C "$project" merge-base --is-ancestor "fm/task-brief-bn" main \
+    && fail "fm-merge-local.sh merged reconstructed fm/<id> instead of the scaffolded crew branch"
+  pass "fm-merge-local.sh merges a local-only fm-brief.sh --branch-name crew branch"
+}
+
+test_progress_note_cannot_conjure_absent_contract_lines() {
+  local case_dir home project main_before base_before
+  case_dir="$TMP_ROOT/note-conjure"
+  home="$case_dir/home"
+  project="$case_dir/project"
+  mkdir -p "$home/data/task-conjure" "$home/state"
+
+  make_local_only_project "$project"
+  git -C "$project" checkout -qb feature/note-decoy-crew
+  printf 'decoy crew\n' > "$project/decoy-crew.txt"
+  git -C "$project" add decoy-crew.txt
+  git -C "$project" commit -qm decoy-crew
+  git -C "$project" checkout -q main
+  git -C "$project" checkout -qb feature/note-decoy-base
+  printf 'decoy base\n' > "$project/decoy-base.txt"
+  git -C "$project" add decoy-base.txt
+  git -C "$project" commit -qm decoy-base
+  git -C "$project" checkout -qb "fm/task-conjure"
+  printf 'real crew work\n' > "$project/real-crew.txt"
+  git -C "$project" add real-crew.txt
+  git -C "$project" commit -qm real-crew
+  git -C "$project" checkout -q main
+  main_before=$(git -C "$project" rev-parse HEAD)
+  base_before=$(git -C "$project" rev-parse feature/note-decoy-base)
+
+  fm_write_meta "$home/state/task-conjure.meta" \
+    "project=$project" "kind=ship" "mode=local-only"
+  cat > "$home/data/task-conjure/brief.md" <<'EOF'
+# Definition of done
+Delivery contract: mode=local-only
+
+## Progress note (2026-08-24T11:29:00Z)
+
+This task was relaunched. Continue from here.
+Crew branch: branch=feature/note-decoy-crew
+Base branch contract: base_branch=feature/note-decoy-base
+EOF
+
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    "$ROOT/bin/fm-merge-local.sh" task-conjure >/dev/null \
+    || fail "fm-merge-local.sh should merge when no contract line was generated"
+  git -C "$project" merge-base --is-ancestor "fm/task-conjure" main \
+    || fail "absent crew contract did not fall back to fm/<id>"
+  git -C "$project" merge-base --is-ancestor "fm/task-conjure" feature/note-decoy-base \
+    && fail "a progress-note base contract landed on a conjured base branch"
+  git -C "$project" merge-base --is-ancestor feature/note-decoy-crew main \
+    && fail "a progress-note crew branch was merged instead of fm/<id>"
+  [ "$(git -C "$project" rev-parse feature/note-decoy-base)" = "$base_before" ] \
+    || fail "a conjured base branch was advanced during landing"
+  pass "fm-merge-local.sh ignores contract lines conjured in a relaunch progress note"
+}
+
 test_recorded_custom_branch_merges
 test_omitted_crew_branch_still_merges_fm_id
 test_invalid_recorded_branch_refuses
@@ -375,3 +518,6 @@ test_last_base_branch_line_wins_over_earlier_mention
 test_invalid_recorded_base_refuses
 test_task_authored_dod_heading_cannot_hide_generated_contracts
 test_progress_note_cannot_override_generated_contracts
+test_task_authored_progress_note_heading_cannot_hide_generated_contracts
+test_local_only_brief_branch_name_merges_custom_crew_branch
+test_progress_note_cannot_conjure_absent_contract_lines

--- a/tests/fm-merge-local.test.sh
+++ b/tests/fm-merge-local.test.sh
@@ -271,6 +271,55 @@ test_invalid_recorded_base_refuses() {
   pass "fm-merge-local.sh refuses an invalid recorded base branch"
 }
 
+test_progress_note_cannot_override_generated_contracts() {
+  local case_dir home project
+  case_dir="$TMP_ROOT/progress-note"
+  home="$case_dir/home"
+  project="$case_dir/project"
+  mkdir -p "$home/data/task-progress" "$home/state"
+
+  make_local_only_project "$project"
+  git -C "$project" checkout -qb feature/progress-decoy
+  printf 'progress decoy\n' > "$project/progress-decoy.txt"
+  git -C "$project" add progress-decoy.txt
+  git -C "$project" commit -qm progress-decoy
+  git -C "$project" checkout -q main
+  git -C "$project" checkout -qb feature/named-base
+  printf 'named base\n' > "$project/named-base.txt"
+  git -C "$project" add named-base.txt
+  git -C "$project" commit -qm named-base
+  git -C "$project" checkout -qb feature/authoritative-crew
+  printf 'crew work\n' > "$project/crew.txt"
+  git -C "$project" add crew.txt
+  git -C "$project" commit -qm crew-work
+  git -C "$project" checkout -q main
+
+  fm_write_meta "$home/state/task-progress.meta" \
+    "project=$project" "kind=ship" "mode=local-only"
+  cat > "$home/data/task-progress/brief.md" <<'EOF'
+# Definition of done
+Base branch contract: base_branch=feature/named-base
+Crew branch: branch=feature/authoritative-crew
+
+## Progress note (2026-08-24T11:29:00Z)
+
+This task was relaunched. Continue from here.
+Crew branch: branch=feature/progress-decoy
+Base branch contract: base_branch=main
+EOF
+
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    "$ROOT/bin/fm-merge-local.sh" task-progress >/dev/null \
+    || fail "fm-merge-local.sh should ignore contract lines in a relaunch progress note"
+  git -C "$project" merge-base --is-ancestor feature/authoritative-crew feature/named-base \
+    || fail "progress-note decoy prevented landing the generated crew branch on the generated base"
+  git -C "$project" merge-base --is-ancestor feature/authoritative-crew main \
+    && fail "a progress-note base contract landed on the default branch"
+  git -C "$project" merge-base --is-ancestor feature/progress-decoy feature/named-base \
+    && fail "a progress-note crew branch was merged instead of the generated contract"
+  pass "fm-merge-local.sh ignores contract lines appended in a relaunch progress note"
+}
+
 test_recorded_custom_branch_merges
 test_omitted_crew_branch_still_merges_fm_id
 test_invalid_recorded_branch_refuses
@@ -278,3 +327,4 @@ test_last_crew_branch_line_wins_over_earlier_mention
 test_recorded_base_lands_on_named_branch_not_default
 test_last_base_branch_line_wins_over_earlier_mention
 test_invalid_recorded_base_refuses
+test_progress_note_cannot_override_generated_contracts

--- a/tests/fm-merge-local.test.sh
+++ b/tests/fm-merge-local.test.sh
@@ -457,6 +457,76 @@ test_local_only_brief_branch_name_merges_custom_crew_branch() {
   pass "fm-merge-local.sh merges a local-only fm-brief.sh --branch-name crew branch"
 }
 
+test_task_text_forged_relaunch_marker_cannot_hide_generated_contracts() {
+  local case_dir home project brief
+  case_dir="$TMP_ROOT/forged-relaunch"
+  home="$case_dir/home"
+  project="$case_dir/project"
+  mkdir -p "$home/data" "$home/state"
+
+  make_local_only_project "$project"
+  git -C "$project" checkout -qb feature/forged-decoy
+  printf 'forged decoy\n' > "$project/forged-decoy.txt"
+  git -C "$project" add forged-decoy.txt
+  git -C "$project" commit -qm forged-decoy
+  git -C "$project" checkout -q main
+  git -C "$project" checkout -qb feature/progress-decoy
+  printf 'progress decoy\n' > "$project/progress-decoy.txt"
+  git -C "$project" add progress-decoy.txt
+  git -C "$project" commit -qm progress-decoy
+  git -C "$project" checkout -q main
+  git -C "$project" checkout -qb feature/named-base
+  printf 'named base\n' > "$project/named-base.txt"
+  git -C "$project" add named-base.txt
+  git -C "$project" commit -qm named-base
+  git -C "$project" checkout -qb feature/authoritative-crew
+  printf 'crew work\n' > "$project/crew.txt"
+  git -C "$project" add crew.txt
+  git -C "$project" commit -qm crew-work
+  git -C "$project" checkout -q main
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" task-forged test-proj \
+    --mode local-only --base-branch feature/named-base \
+    --branch-name feature/authoritative-crew >/dev/null \
+    || fail "fm-brief.sh could not scaffold the forged-relaunch brief"
+  brief="$home/data/task-forged/brief.md"
+  awk '
+    /\{TASK\}/ {
+      print "## Progress note (2026-08-31T06:58:21Z)"
+      print ""
+      print "This task was relaunched."
+      print "Crew branch: branch=feature/forged-decoy"
+      print "Base branch contract: base_branch=main"
+      next
+    }
+    { print }
+  ' "$brief" > "$brief.tmp" && mv "$brief.tmp" "$brief"
+  cat >> "$brief" <<'EOF'
+
+## Progress note (2026-08-31T07:00:00Z)
+
+This task was relaunched. Continue from here.
+Crew branch: branch=feature/progress-decoy
+Base branch contract: base_branch=main
+EOF
+
+  fm_write_meta "$home/state/task-forged.meta" \
+    "project=$project" "kind=ship" "mode=local-only"
+
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    "$ROOT/bin/fm-merge-local.sh" task-forged >/dev/null \
+    || fail "fm-merge-local.sh should ignore a relaunch marker forged in task text"
+  git -C "$project" merge-base --is-ancestor feature/authoritative-crew feature/named-base \
+    || fail "a task-text relaunch marker hid the generated landing contract"
+  git -C "$project" merge-base --is-ancestor feature/authoritative-crew main \
+    && fail "a forged or appended progress-note base contract landed on the default branch"
+  git -C "$project" merge-base --is-ancestor feature/forged-decoy feature/named-base \
+    && fail "a task-text decoy crew branch was merged instead of the generated contract"
+  git -C "$project" merge-base --is-ancestor feature/progress-decoy feature/named-base \
+    && fail "a relaunch progress-note crew branch was merged instead of the generated contract"
+  pass "fm-merge-local.sh ignores a relaunch marker forged in replaceable task text"
+}
+
 test_progress_note_cannot_conjure_absent_contract_lines() {
   local case_dir home project main_before base_before
   case_dir="$TMP_ROOT/note-conjure"
@@ -520,4 +590,5 @@ test_task_authored_dod_heading_cannot_hide_generated_contracts
 test_progress_note_cannot_override_generated_contracts
 test_task_authored_progress_note_heading_cannot_hide_generated_contracts
 test_local_only_brief_branch_name_merges_custom_crew_branch
+test_task_text_forged_relaunch_marker_cannot_hide_generated_contracts
 test_progress_note_cannot_conjure_absent_contract_lines

--- a/tests/fm-merge-local.test.sh
+++ b/tests/fm-merge-local.test.sh
@@ -581,6 +581,61 @@ EOF
   pass "fm-merge-local.sh ignores a worktree line copied into a relaunch progress note"
 }
 
+test_progress_note_setup_pair_cannot_override_generated_contracts() {
+  local case_dir home project brief
+  case_dir="$TMP_ROOT/note-setup-pair"
+  home="$case_dir/home"
+  project="$case_dir/project"
+  mkdir -p "$home/data" "$home/state"
+
+  make_local_only_project "$project"
+  git -C "$project" checkout -qb feature/progress-decoy
+  printf 'progress decoy\n' > "$project/progress-decoy.txt"
+  git -C "$project" add progress-decoy.txt
+  git -C "$project" commit -qm progress-decoy
+  git -C "$project" checkout -q main
+  git -C "$project" checkout -qb feature/named-base
+  printf 'named base\n' > "$project/named-base.txt"
+  git -C "$project" add named-base.txt
+  git -C "$project" commit -qm named-base
+  git -C "$project" checkout -qb feature/authoritative-crew
+  printf 'crew work\n' > "$project/crew.txt"
+  git -C "$project" add crew.txt
+  git -C "$project" commit -qm crew-work
+  git -C "$project" checkout -q main
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" task-note-pair test-proj \
+    --mode local-only --base-branch feature/named-base \
+    --branch-name feature/authoritative-crew >/dev/null \
+    || fail "fm-brief.sh could not scaffold the setup-pair progress-note brief"
+  brief="$home/data/task-note-pair/brief.md"
+  cat >> "$brief" <<'EOF'
+
+## Progress note (2026-09-02T11:00:00Z)
+
+This task was relaunched. Continue from here.
+# Setup
+You are in a disposable git worktree of test-proj, at a detached HEAD on `feature/named-base`.
+# Definition of done
+Crew branch: branch=feature/progress-decoy
+Base branch contract: base_branch=main
+EOF
+
+  fm_write_meta "$home/state/task-note-pair.meta" \
+    "project=$project" "kind=ship" "mode=local-only"
+
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    "$ROOT/bin/fm-merge-local.sh" task-note-pair >/dev/null \
+    || fail "fm-merge-local.sh should ignore a Setup pair copied into a progress note"
+  git -C "$project" merge-base --is-ancestor feature/authoritative-crew feature/named-base \
+    || fail "a progress-note Setup pair hid the generated landing contract"
+  git -C "$project" merge-base --is-ancestor feature/authoritative-crew main \
+    && fail "a progress-note Setup pair landed on the default branch"
+  git -C "$project" merge-base --is-ancestor feature/progress-decoy feature/named-base \
+    && fail "a progress-note crew branch after a copied Setup pair was merged"
+  pass "fm-merge-local.sh ignores a Setup pair copied into a relaunch progress note"
+}
+
 test_progress_note_cannot_conjure_absent_contract_lines() {
   local case_dir home project main_before base_before
   case_dir="$TMP_ROOT/note-conjure"
@@ -646,4 +701,5 @@ test_task_authored_progress_note_heading_cannot_hide_generated_contracts
 test_local_only_brief_branch_name_merges_custom_crew_branch
 test_task_text_forged_relaunch_marker_cannot_hide_generated_contracts
 test_progress_note_worktree_line_cannot_extend_past_relaunch_marker
+test_progress_note_setup_pair_cannot_override_generated_contracts
 test_progress_note_cannot_conjure_absent_contract_lines

--- a/tests/fm-merge-local.test.sh
+++ b/tests/fm-merge-local.test.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Behavior tests for bin/fm-merge-local.sh.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-merge-local)
+fm_git_identity fmtest fmtest@example.invalid
+
+make_local_only_project() {
+  local project=$1
+  mkdir -p "$project"
+  git -C "$project" init -q -b main
+  printf 'base\n' > "$project/base.txt"
+  git -C "$project" add base.txt
+  git -C "$project" commit -qm base
+}
+
+test_recorded_custom_branch_merges() {
+  local case_dir home project before after
+  case_dir="$TMP_ROOT/custom-branch"
+  home="$case_dir/home"
+  project="$case_dir/project"
+  mkdir -p "$home/data/task-custom" "$home/state"
+
+  make_local_only_project "$project"
+  git -C "$project" checkout -qb feature/custom-task
+  printf 'custom work\n' > "$project/custom.txt"
+  git -C "$project" add custom.txt
+  git -C "$project" commit -qm custom
+  git -C "$project" checkout -qb "fm/task-custom"
+  printf 'stale reconstructed branch\n' > "$project/stale.txt"
+  git -C "$project" add stale.txt
+  git -C "$project" commit -qm stale-fm-id
+  git -C "$project" checkout -q main
+  before=$(git -C "$project" rev-parse HEAD)
+
+  fm_write_meta "$home/state/task-custom.meta" \
+    "project=$project" "kind=ship" "mode=local-only"
+  printf '%s\n' 'Crew branch: branch=feature/custom-task' > "$home/data/task-custom/brief.md"
+
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    "$ROOT/bin/fm-merge-local.sh" task-custom >/dev/null \
+    || fail "fm-merge-local.sh should merge the branch recorded by fm-brief.sh"
+  after=$(git -C "$project" rev-parse HEAD)
+  [ "$after" != "$before" ] || fail "local default branch did not advance to the recorded custom branch"
+  git -C "$project" merge-base --is-ancestor feature/custom-task main \
+    || fail "recorded custom branch was not fast-forwarded into local main"
+  git -C "$project" merge-base --is-ancestor "fm/task-custom" main \
+    && fail "fm-merge-local.sh merged reconstructed fm/<id> instead of the recorded branch"
+  pass "fm-merge-local.sh merges a local-only brief's recorded custom branch"
+}
+
+test_omitted_crew_branch_still_merges_fm_id() {
+  local case_dir home project after
+  case_dir="$TMP_ROOT/default-branch"
+  home="$case_dir/home"
+  project="$case_dir/project"
+  mkdir -p "$home/data/task-default" "$home/state"
+
+  make_local_only_project "$project"
+  git -C "$project" checkout -qb "fm/task-default"
+  printf 'default work\n' > "$project/default.txt"
+  git -C "$project" add default.txt
+  git -C "$project" commit -qm default-fm-id
+  git -C "$project" checkout -q main
+
+  fm_write_meta "$home/state/task-default.meta" \
+    "project=$project" "kind=ship" "mode=local-only"
+  printf '%s\n' 'Delivery contract: mode=local-only' > "$home/data/task-default/brief.md"
+
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    "$ROOT/bin/fm-merge-local.sh" task-default >/dev/null \
+    || fail "fm-merge-local.sh should keep fm/<id> when no crew branch is recorded"
+  after=$(git -C "$project" rev-parse HEAD)
+  git -C "$project" merge-base --is-ancestor "fm/task-default" main \
+    || fail "omitted crew-branch line did not merge fm/<id>"
+  [ "$after" = "$(git -C "$project" rev-parse fm/task-default)" ] \
+    || fail "omitted crew-branch merge did not land on the fm/<id> tip"
+  pass "fm-merge-local.sh still merges fm/<id> when no crew branch is recorded"
+}
+
+test_invalid_recorded_branch_refuses() {
+  local case_dir home project out status before
+  case_dir="$TMP_ROOT/invalid-branch"
+  home="$case_dir/home"
+  project="$case_dir/project"
+  mkdir -p "$home/data/task-bad" "$home/state"
+
+  make_local_only_project "$project"
+  git -C "$project" checkout -qb "fm/task-bad"
+  printf 'should not merge\n' > "$project/bad.txt"
+  git -C "$project" add bad.txt
+  git -C "$project" commit -qm should-not-merge
+  git -C "$project" checkout -q main
+  before=$(git -C "$project" rev-parse HEAD)
+
+  fm_write_meta "$home/state/task-bad.meta" \
+    "project=$project" "kind=ship" "mode=local-only"
+  printf '%s\n' 'Crew branch: branch=bad..name' > "$home/data/task-bad/brief.md"
+
+  out=$(FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    "$ROOT/bin/fm-merge-local.sh" task-bad 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "fm-merge-local.sh accepted an invalid recorded crew branch"
+  assert_contains "$out" "records an invalid crew branch" \
+    "invalid recorded crew branch did not refuse clearly"
+  [ "$(git -C "$project" rev-parse HEAD)" = "$before" ] \
+    || fail "invalid recorded crew branch still moved local main"
+  pass "fm-merge-local.sh refuses an invalid recorded crew branch"
+}
+
+test_recorded_custom_branch_merges
+test_omitted_crew_branch_still_merges_fm_id
+test_invalid_recorded_branch_refuses

--- a/tests/fm-merge-local.test.sh
+++ b/tests/fm-merge-local.test.sh
@@ -153,7 +153,128 @@ EOF
   pass "fm-merge-local.sh uses the last Crew branch line, not an earlier mention"
 }
 
+test_recorded_base_lands_on_named_branch_not_default() {
+  local case_dir home project main_before base_before
+  case_dir="$TMP_ROOT/named-base"
+  home="$case_dir/home"
+  project="$case_dir/project"
+  mkdir -p "$home/data/task-named-base" "$home/state"
+
+  make_local_only_project "$project"
+  git -C "$project" checkout -qb feature/named-base
+  printf 'named base\n' > "$project/named-base.txt"
+  git -C "$project" add named-base.txt
+  git -C "$project" commit -qm named-base
+  git -C "$project" checkout -qb "fm/task-named-base"
+  printf 'crew work\n' > "$project/crew.txt"
+  git -C "$project" add crew.txt
+  git -C "$project" commit -qm crew-work
+  git -C "$project" checkout -q main
+  main_before=$(git -C "$project" rev-parse HEAD)
+  base_before=$(git -C "$project" rev-parse feature/named-base)
+
+  fm_write_meta "$home/state/task-named-base.meta" \
+    "project=$project" "kind=ship" "mode=local-only"
+  cat > "$home/data/task-named-base/brief.md" <<'EOF'
+Delivery contract: mode=local-only
+Base branch contract: base_branch=feature/named-base
+EOF
+
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    "$ROOT/bin/fm-merge-local.sh" task-named-base >/dev/null \
+    || fail "fm-merge-local.sh should land a named-base local-only ship on the recorded base"
+  [ "$(git -C "$project" rev-parse HEAD)" = "$main_before" ] \
+    || fail "named-base landing moved the default branch"
+  [ "$(git -C "$project" symbolic-ref --short HEAD)" = main ] \
+    || fail "named-base landing left the default checkout"
+  git -C "$project" merge-base --is-ancestor "fm/task-named-base" feature/named-base \
+    || fail "named-base landing did not fast-forward the recorded base"
+  [ "$(git -C "$project" rev-parse feature/named-base)" != "$base_before" ] \
+    || fail "recorded base did not advance to the crew branch"
+  [ "$(git -C "$project" rev-parse feature/named-base)" = "$(git -C "$project" rev-parse fm/task-named-base)" ] \
+    || fail "recorded base did not land on the crew branch tip"
+  pass "fm-merge-local.sh lands a named-base local-only ship on the recorded base, not default"
+}
+
+test_last_base_branch_line_wins_over_earlier_mention() {
+  local case_dir home project
+  case_dir="$TMP_ROOT/last-base-wins"
+  home="$case_dir/home"
+  project="$case_dir/project"
+  mkdir -p "$home/data/task-last-base" "$home/state"
+
+  make_local_only_project "$project"
+  git -C "$project" checkout -qb feature/decoy-base
+  printf 'decoy base\n' > "$project/decoy-base.txt"
+  git -C "$project" add decoy-base.txt
+  git -C "$project" commit -qm decoy-base
+  git -C "$project" checkout -q main
+  git -C "$project" checkout -qb feature/authoritative-base
+  printf 'authoritative base\n' > "$project/authoritative-base.txt"
+  git -C "$project" add authoritative-base.txt
+  git -C "$project" commit -qm authoritative-base
+  git -C "$project" checkout -qb "fm/task-last-base"
+  printf 'crew work\n' > "$project/crew.txt"
+  git -C "$project" add crew.txt
+  git -C "$project" commit -qm crew-on-authoritative-base
+  git -C "$project" checkout -q main
+
+  fm_write_meta "$home/state/task-last-base.meta" \
+    "project=$project" "kind=ship" "mode=local-only"
+  cat > "$home/data/task-last-base/brief.md" <<'EOF'
+# Task
+Base branch contract: base_branch=feature/decoy-base
+
+# Definition of done
+Base branch contract: base_branch=feature/authoritative-base
+EOF
+
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    "$ROOT/bin/fm-merge-local.sh" task-last-base >/dev/null \
+    || fail "fm-merge-local.sh should land on the last recorded base branch"
+  git -C "$project" merge-base --is-ancestor "fm/task-last-base" feature/authoritative-base \
+    || fail "last Base branch line was not the landing target"
+  git -C "$project" merge-base --is-ancestor "fm/task-last-base" feature/decoy-base \
+    && fail "an earlier Base branch mention was landed instead of the last line"
+  git -C "$project" merge-base --is-ancestor "fm/task-last-base" main \
+    && fail "named-base landing still advanced the default branch"
+  pass "fm-merge-local.sh uses the last Base branch line, not an earlier mention"
+}
+
+test_invalid_recorded_base_refuses() {
+  local case_dir home project out status before
+  case_dir="$TMP_ROOT/invalid-base"
+  home="$case_dir/home"
+  project="$case_dir/project"
+  mkdir -p "$home/data/task-bad-base" "$home/state"
+
+  make_local_only_project "$project"
+  git -C "$project" checkout -qb "fm/task-bad-base"
+  printf 'should not merge\n' > "$project/bad.txt"
+  git -C "$project" add bad.txt
+  git -C "$project" commit -qm should-not-merge
+  git -C "$project" checkout -q main
+  before=$(git -C "$project" rev-parse HEAD)
+
+  fm_write_meta "$home/state/task-bad-base.meta" \
+    "project=$project" "kind=ship" "mode=local-only"
+  printf '%s\n' 'Base branch contract: base_branch=bad..name' > "$home/data/task-bad-base/brief.md"
+
+  out=$(FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    "$ROOT/bin/fm-merge-local.sh" task-bad-base 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "fm-merge-local.sh accepted an invalid recorded base branch"
+  assert_contains "$out" "records an invalid base branch" \
+    "invalid recorded base branch did not refuse clearly"
+  [ "$(git -C "$project" rev-parse HEAD)" = "$before" ] \
+    || fail "invalid recorded base branch still moved local main"
+  pass "fm-merge-local.sh refuses an invalid recorded base branch"
+}
+
 test_recorded_custom_branch_merges
 test_omitted_crew_branch_still_merges_fm_id
 test_invalid_recorded_branch_refuses
 test_last_crew_branch_line_wins_over_earlier_mention
+test_recorded_base_lands_on_named_branch_not_default
+test_last_base_branch_line_wins_over_earlier_mention
+test_invalid_recorded_base_refuses

--- a/tests/fm-merge-local.test.sh
+++ b/tests/fm-merge-local.test.sh
@@ -111,6 +111,49 @@ test_invalid_recorded_branch_refuses() {
   pass "fm-merge-local.sh refuses an invalid recorded crew branch"
 }
 
+test_last_crew_branch_line_wins_over_earlier_mention() {
+  local case_dir home project after
+  case_dir="$TMP_ROOT/last-line-wins"
+  home="$case_dir/home"
+  project="$case_dir/project"
+  mkdir -p "$home/data/task-last" "$home/state"
+
+  make_local_only_project "$project"
+  git -C "$project" checkout -qb feature/decoy-first
+  printf 'decoy\n' > "$project/decoy.txt"
+  git -C "$project" add decoy.txt
+  git -C "$project" commit -qm decoy-first
+  git -C "$project" checkout -q main
+  git -C "$project" checkout -qb feature/authoritative-last
+  printf 'authoritative\n' > "$project/authoritative.txt"
+  git -C "$project" add authoritative.txt
+  git -C "$project" commit -qm authoritative-last
+  git -C "$project" checkout -q main
+
+  fm_write_meta "$home/state/task-last.meta" \
+    "project=$project" "kind=ship" "mode=local-only"
+  cat > "$home/data/task-last/brief.md" <<'EOF'
+# Task
+Crew branch: branch=feature/decoy-first
+
+# Definition of done
+Crew branch: branch=feature/authoritative-last
+EOF
+
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    "$ROOT/bin/fm-merge-local.sh" task-last >/dev/null \
+    || fail "fm-merge-local.sh should merge the last recorded crew branch"
+  after=$(git -C "$project" rev-parse HEAD)
+  git -C "$project" merge-base --is-ancestor feature/authoritative-last main \
+    || fail "last Crew branch line was not merged"
+  git -C "$project" merge-base --is-ancestor feature/decoy-first main \
+    && fail "an earlier Crew branch mention was merged instead of the last line"
+  [ "$after" = "$(git -C "$project" rev-parse feature/authoritative-last)" ] \
+    || fail "merge did not land on the last recorded crew branch tip"
+  pass "fm-merge-local.sh uses the last Crew branch line, not an earlier mention"
+}
+
 test_recorded_custom_branch_merges
 test_omitted_crew_branch_still_merges_fm_id
 test_invalid_recorded_branch_refuses
+test_last_crew_branch_line_wins_over_earlier_mention

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -59,6 +59,37 @@ run_spawn() {
     "$id" "$PROJECT_DIR" "$@"
 }
 
+scaffold_ship_brief() {
+  local id=$1 mode=$2 base_branch=${3:-}
+  local -a args=("$id" test-project --mode "$mode")
+  [ -z "$base_branch" ] || args+=(--base-branch "$base_branch")
+  rm -f "$HOME_DIR/data/$id/brief.md"
+  FM_HOME="$HOME_DIR" "$ROOT/bin/fm-brief.sh" "${args[@]}" >/dev/null \
+    || fail "fm-brief.sh could not scaffold the $id ship brief"
+}
+
+scaffold_scout_brief() {
+  local id=$1 base_branch=${2:-}
+  local -a args=("$id" test-project --scout)
+  [ -z "$base_branch" ] || args+=(--base-branch "$base_branch")
+  rm -f "$HOME_DIR/data/$id/brief.md"
+  FM_HOME="$HOME_DIR" "$ROOT/bin/fm-brief.sh" "${args[@]}" >/dev/null \
+    || fail "fm-brief.sh could not scaffold the scout brief"
+}
+
+fail_named_ref_fetch() {
+  local fakebin=$1 branch=$2 real_git
+  real_git=$(command -v git)
+  cat > "$fakebin/git" <<EOF
+#!/usr/bin/env bash
+for arg in "\$@"; do
+  [ "\$arg" != "+refs/heads/$branch:refs/remotes/origin/$branch" ] || exit 1
+done
+exec "$real_git" "\$@"
+EOF
+  chmod +x "$fakebin/git"
+}
+
 test_stale_pool_base_refreshes_before_branching() {
   local rec id out status current branch_head
   id='pool-current-base-r1'
@@ -425,6 +456,179 @@ test_stale_pin_beside_other_dirt_reports_one_verdict() {
   pass "a stale pin beside other dirt yields the conservative refusal alone, with no stale-pin line"
 }
 
+test_base_branch_resets_to_named_origin_tip() {
+  local rec id out status current_main current_develop branch_head
+  id='pool-base-branch-origin-r6'
+  rec=$(make_case base-branch-origin "$id")
+  read_case_record "$rec"
+  git -C "$CASE_DIR/publisher" checkout --quiet -b develop
+  printf 'only on develop\n' > "$CASE_DIR/publisher/develop-only.txt"
+  git -C "$CASE_DIR/publisher" add develop-only.txt
+  git -C "$CASE_DIR/publisher" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' \
+    commit -qm develop-tip
+  git -C "$CASE_DIR/publisher" push --quiet origin develop
+  scaffold_ship_brief "$id" no-mistakes develop
+
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off --base-branch develop)
+  status=$?
+  expect_code 0 "$status" "spawn --base-branch should refresh to the named origin tip"
+  current_main=$(git -C "$POOL_DIR" rev-parse origin/main)
+  current_develop=$(git -C "$POOL_DIR" rev-parse origin/develop)
+  branch_head=$(git -C "$POOL_DIR" rev-parse HEAD)
+  [ "$branch_head" = "$current_develop" ] || fail "spawn --base-branch develop did not reset to origin/develop"
+  [ "$branch_head" != "$current_main" ] || fail "spawn --base-branch develop reset to origin/main"
+  assert_grep 'only on develop' "$POOL_DIR/develop-only.txt" \
+    "spawn --base-branch develop omitted the named-branch tip content"
+  assert_grep 'base_branch=develop' "$HOME_DIR/state/$id.meta" \
+    "spawn --base-branch did not record base_branch= for PR targeting"
+  pass "spawn --base-branch resets the pooled worktree to the named origin tip"
+}
+
+test_absent_base_branch_leaves_default_freshen_and_meta() {
+  local rec id out status current meta
+  id='pool-base-branch-absent-r6'
+  rec=$(make_case base-branch-absent "$id")
+  read_case_record "$rec"
+
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off)
+  status=$?
+  expect_code 0 "$status" "spawn without --base-branch should keep today's default freshen"
+  current=$(git -C "$POOL_DIR" rev-parse origin/main)
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$current" ] \
+    || fail "spawn without --base-branch did not reset to origin/main"
+  meta=$HOME_DIR/state/$id.meta
+  assert_no_grep 'base_branch=' "$meta" \
+    "spawn without --base-branch recorded a PR-target base_branch="
+  pass "omitting --base-branch keeps default-branch freshen and does not record a PR target"
+}
+
+test_base_branch_uses_local_branch_when_origin_lacks_it() {
+  local rec id out status local_sha
+  id='pool-base-branch-local-r6'
+  rec=$(make_case base-branch-local "$id")
+  read_case_record "$rec"
+  git -C "$POOL_DIR" checkout --quiet -B local-only
+  printf 'only local\n' > "$POOL_DIR/local-only.txt"
+  git -C "$POOL_DIR" add local-only.txt
+  git -C "$POOL_DIR" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' \
+    commit -qm local-only
+  local_sha=$(git -C "$POOL_DIR" rev-parse HEAD)
+  git -C "$POOL_DIR" checkout --quiet --detach "$INITIAL_SHA"
+  scaffold_ship_brief "$id" no-mistakes local-only
+
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off --base-branch local-only)
+  status=$?
+  expect_code 0 "$status" "spawn --base-branch should use a local branch when origin lacks it"
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$local_sha" ] \
+    || fail "spawn --base-branch local-only did not reset to the local branch tip"
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" != "$(git -C "$POOL_DIR" rev-parse origin/main)" ] \
+    || fail "spawn --base-branch local-only fell back to origin/main"
+  pass "spawn --base-branch uses a local branch when origin lacks it"
+}
+
+test_base_branch_ref_fetch_failure_refuses_local_fallback() {
+  local rec id out status before
+  id='pool-base-branch-fetch-failure-r6'
+  rec=$(make_case base-branch-fetch-failure "$id")
+  read_case_record "$rec"
+  git -C "$CASE_DIR/publisher" checkout --quiet -b develop
+  printf 'remote develop\n' > "$CASE_DIR/publisher/remote-develop.txt"
+  git -C "$CASE_DIR/publisher" add remote-develop.txt
+  git -C "$CASE_DIR/publisher" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' \
+    commit -qm remote-develop
+  git -C "$CASE_DIR/publisher" push --quiet origin develop
+  git -C "$POOL_DIR" checkout --quiet -B develop "$INITIAL_SHA"
+  printf 'local develop\n' > "$POOL_DIR/local-develop.txt"
+  git -C "$POOL_DIR" add local-develop.txt
+  git -C "$POOL_DIR" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' \
+    commit -qm local-develop
+  git -C "$POOL_DIR" checkout --quiet --detach "$INITIAL_SHA"
+  scaffold_ship_brief "$id" no-mistakes develop
+  fail_named_ref_fetch "$FAKEBIN_DIR" develop
+  before=$(git -C "$POOL_DIR" rev-parse HEAD)
+
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off --base-branch develop)
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn fell back to local develop after its remote ref fetch failed"
+  assert_contains "$out" "could not fetch 'origin/develop'" \
+    "spawn did not clearly refuse an unverifiable remote base"
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$before" ] \
+    || fail "spawn changed the pooled worktree after a remote ref fetch failure"
+  pass "a failed remote base fetch refuses instead of falling back to local"
+}
+
+test_missing_base_branch_refuses_without_default_fallback() {
+  local rec id out status before
+  id='pool-base-branch-missing-r6'
+  rec=$(make_case base-branch-missing "$id")
+  read_case_record "$rec"
+  scaffold_ship_brief "$id" no-mistakes no-such-branch
+  before=$(git -C "$POOL_DIR" rev-parse HEAD)
+
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off --base-branch no-such-branch)
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn succeeded with a nonexistent --base-branch"
+  assert_contains "$out" "does not exist locally or on origin" \
+    "spawn did not clearly refuse a missing --base-branch"
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$before" ] \
+    || fail "spawn moved HEAD after refusing a missing --base-branch"
+  pass "a nonexistent --base-branch refuses without falling back to the default"
+}
+
+test_base_branch_refused_on_relaunch_secondmate_and_orca() {
+  local rec id out status
+  id='pool-base-branch-refuse-r6'
+  rec=$(make_case base-branch-refuse "$id")
+  read_case_record "$rec"
+  scaffold_ship_brief "$id" no-mistakes develop
+
+  out=$(run_spawn "$id" --relaunch --base-branch develop)
+  status=$?
+  [ "$status" -ne 0 ] || fail "--relaunch accepted --base-branch"
+  assert_contains "$out" "--relaunch reuses the task's recorded worktree" \
+    "--relaunch did not refuse --base-branch"
+
+  out=$(run_spawn "$id" --secondmate --base-branch develop)
+  status=$?
+  [ "$status" -ne 0 ] || fail "--secondmate accepted --base-branch"
+  assert_contains "$out" "applies only to ship and scout" \
+    "--secondmate did not refuse --base-branch"
+
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off --backend orca --base-branch develop)
+  status=$?
+  [ "$status" -ne 0 ] || fail "backend=orca accepted --base-branch"
+  assert_contains "$out" "cannot be combined with backend=orca" \
+    "backend=orca did not refuse --base-branch"
+  pass "--relaunch, --secondmate, and backend=orca refuse --base-branch"
+}
+
+test_base_branch_contract_refuses_mismatch() {
+  local rec id out status before kind
+  for kind in ship scout; do
+    id="pool-base-branch-contract-${kind}-r7"
+    rec=$(make_case "base-branch-contract-$kind" "$id")
+    read_case_record "$rec"
+    if [ "$kind" = ship ]; then
+      scaffold_ship_brief "$id" no-mistakes develop
+      before=$(git -C "$POOL_DIR" rev-parse HEAD)
+      out=$(run_spawn "$id" --mode no-mistakes --yolo off --base-branch release)
+    else
+      scaffold_scout_brief "$id" develop
+      before=$(git -C "$POOL_DIR" rev-parse HEAD)
+      out=$(run_spawn "$id" --scout --base-branch release)
+    fi
+    status=$?
+    [ "$status" -ne 0 ] || fail "$kind spawn accepted a --base-branch that disagrees with its generated brief"
+    assert_contains "$out" "base-branch mismatch" \
+      "$kind spawn did not clearly refuse a base-branch contract mismatch"
+    [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$before" ] \
+      || fail "$kind spawn changed the pooled worktree after a base-branch contract mismatch"
+    assert_absent "$HOME_DIR/state/$id.meta" \
+      "$kind spawn recorded metadata after a base-branch contract mismatch"
+  done
+  pass "ship and scout base contracts refuse conflicting spawn flags"
+}
+
 test_stale_pool_base_refreshes_before_branching
 test_non_main_default_branch_refreshes_before_branching
 test_direct_pr_and_scout_refresh_before_launch
@@ -436,5 +640,12 @@ test_unpushed_submodule_commit_is_still_uncommitted_work
 test_work_inside_submodule_is_still_uncommitted_work
 test_stale_pin_carrying_real_work_is_not_called_stale
 test_stale_pin_beside_other_dirt_reports_one_verdict
+test_base_branch_resets_to_named_origin_tip
+test_absent_base_branch_leaves_default_freshen_and_meta
+test_base_branch_uses_local_branch_when_origin_lacks_it
+test_base_branch_ref_fetch_failure_refuses_local_fallback
+test_missing_base_branch_refuses_without_default_fallback
+test_base_branch_refused_on_relaunch_secondmate_and_orca
+test_base_branch_contract_refuses_mismatch
 
 echo "# all fm-spawn-pool-base-freshen tests passed"

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -629,6 +629,37 @@ test_base_branch_contract_refuses_mismatch() {
   pass "ship and scout base contracts refuse conflicting spawn flags"
 }
 
+test_base_branch_contract_uses_last_line() {
+  local rec id brief out status
+  id='pool-base-branch-last-line-r8'
+  rec=$(make_case base-branch-last-line "$id")
+  read_case_record "$rec"
+  git -C "$CASE_DIR/publisher" checkout --quiet -b develop
+  printf 'only on develop\n' > "$CASE_DIR/publisher/develop-only.txt"
+  git -C "$CASE_DIR/publisher" add develop-only.txt
+  git -C "$CASE_DIR/publisher" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' \
+    commit -qm develop-tip
+  git -C "$CASE_DIR/publisher" push --quiet origin develop
+  scaffold_ship_brief "$id" no-mistakes develop
+  brief="$HOME_DIR/data/$id/brief.md"
+  awk '
+    /^# Task$/ {
+      print
+      print "Base branch contract: base_branch=release"
+      next
+    }
+    { print }
+  ' "$brief" > "$brief.tmp" && mv "$brief.tmp" "$brief"
+
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off --base-branch develop)
+  status=$?
+  expect_code 0 "$status" "spawn --base-branch should honor the last generated base contract"
+  assert_contains "$out" "spawned $id" "spawn did not report success after an earlier decoy base line"
+  assert_grep 'base_branch=develop' "$HOME_DIR/state/$id.meta" \
+    "spawn treated an earlier Base branch mention as the contract"
+  pass "ship base-contract agreement uses the last Base branch line"
+}
+
 test_stale_pool_base_refreshes_before_branching
 test_non_main_default_branch_refreshes_before_branching
 test_direct_pr_and_scout_refresh_before_launch
@@ -647,5 +678,6 @@ test_base_branch_ref_fetch_failure_refuses_local_fallback
 test_missing_base_branch_refuses_without_default_fallback
 test_base_branch_refused_on_relaunch_secondmate_and_orca
 test_base_branch_contract_refuses_mismatch
+test_base_branch_contract_uses_last_line
 
 echo "# all fm-spawn-pool-base-freshen tests passed"

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -660,6 +660,37 @@ test_base_branch_contract_uses_last_line() {
   pass "ship base-contract agreement uses the last Base branch line"
 }
 
+test_base_branch_contract_ignores_progress_note() {
+  local rec id brief out status
+  id='pool-base-branch-progress-note-r8'
+  rec=$(make_case base-branch-progress-note "$id")
+  read_case_record "$rec"
+  git -C "$CASE_DIR/publisher" checkout --quiet -b develop
+  printf 'only on develop\n' > "$CASE_DIR/publisher/develop-only.txt"
+  git -C "$CASE_DIR/publisher" add develop-only.txt
+  git -C "$CASE_DIR/publisher" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' \
+    commit -qm develop-tip
+  git -C "$CASE_DIR/publisher" push --quiet origin develop
+  scaffold_ship_brief "$id" no-mistakes develop
+  brief="$HOME_DIR/data/$id/brief.md"
+  cat >> "$brief" <<'EOF'
+
+## Progress note (2026-08-24T11:29:00Z)
+
+This task was relaunched. Continue from here.
+Base branch contract: base_branch=release
+Delivery contract: mode=local-only
+EOF
+
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off --base-branch develop)
+  status=$?
+  expect_code 0 "$status" "spawn should ignore contract lines in a relaunch progress note"
+  assert_contains "$out" "spawned $id" "spawn did not report success after a progress-note decoy"
+  assert_grep 'base_branch=develop' "$HOME_DIR/state/$id.meta" \
+    "spawn treated a progress-note Base branch line as the contract"
+  pass "ship base-contract agreement ignores a relaunch progress note"
+}
+
 test_stale_pool_base_refreshes_before_branching
 test_non_main_default_branch_refreshes_before_branching
 test_direct_pr_and_scout_refresh_before_launch
@@ -679,5 +710,6 @@ test_missing_base_branch_refuses_without_default_fallback
 test_base_branch_refused_on_relaunch_secondmate_and_orca
 test_base_branch_contract_refuses_mismatch
 test_base_branch_contract_uses_last_line
+test_base_branch_contract_ignores_progress_note
 
 echo "# all fm-spawn-pool-base-freshen tests passed"

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -724,6 +724,102 @@ EOF
   pass "ship base-contract agreement ignores a relaunch progress note"
 }
 
+test_base_branch_contract_ignores_task_authored_progress_note_heading() {
+  local rec id brief out status
+  id='pool-base-branch-task-progress-r9'
+  rec=$(make_case base-branch-task-progress "$id")
+  read_case_record "$rec"
+  git -C "$CASE_DIR/publisher" checkout --quiet -b develop
+  printf 'only on develop\n' > "$CASE_DIR/publisher/develop-only.txt"
+  git -C "$CASE_DIR/publisher" add develop-only.txt
+  git -C "$CASE_DIR/publisher" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' \
+    commit -qm develop-tip
+  git -C "$CASE_DIR/publisher" push --quiet origin develop
+  scaffold_ship_brief "$id" no-mistakes develop
+  brief="$HOME_DIR/data/$id/brief.md"
+  awk '
+    /^# Task$/ {
+      print
+      print "## Progress note"
+      print "The captain described a progress note in task prose."
+      print
+      next
+    }
+    { print }
+  ' "$brief" > "$brief.tmp" && mv "$brief.tmp" "$brief"
+  cat >> "$brief" <<'EOF'
+
+## Progress note (2026-08-24T11:29:00Z)
+
+This task was relaunched. Continue from here.
+Base branch contract: base_branch=release
+Delivery contract: mode=local-only
+EOF
+
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off --base-branch develop)
+  status=$?
+  expect_code 0 "$status" "spawn should ignore a task-authored progress-note heading"
+  assert_contains "$out" "spawned $id" "spawn did not report success after a task-authored progress-note heading"
+  assert_grep 'base_branch=develop' "$HOME_DIR/state/$id.meta" \
+    "spawn treated a relaunch progress-note line as the contract after a task-authored heading"
+  pass "ship base-contract agreement anchors truncation on the fm-control relaunch marker"
+}
+
+test_base_contract_ignores_note_when_contract_line_absent() {
+  local rec id brief out status
+  id='pool-base-branch-note-conjure-r9'
+  rec=$(make_case base-branch-note-conjure "$id")
+  read_case_record "$rec"
+  scaffold_ship_brief "$id" no-mistakes
+  brief="$HOME_DIR/data/$id/brief.md"
+  cat >> "$brief" <<'EOF'
+
+## Progress note (2026-08-24T11:29:00Z)
+
+This task was relaunched. Continue from here.
+Base branch contract: base_branch=release
+Delivery contract: mode=local-only
+EOF
+
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off)
+  status=$?
+  expect_code 0 "$status" "spawn should ignore a conjured base contract in a progress note"
+  assert_contains "$out" "spawned $id" "spawn did not report success after a conjured base contract"
+  assert_no_grep 'base_branch=' "$HOME_DIR/state/$id.meta" \
+    "spawn recorded a base_branch conjured by a progress note"
+  pass "ship spawn ignores a base contract conjured in a relaunch progress note"
+}
+
+test_base_contract_refuses_flag_matching_conjured_note_not_generated() {
+  local rec id brief out status
+  id='pool-base-branch-note-flag-r9'
+  rec=$(make_case base-branch-note-flag "$id")
+  read_case_record "$rec"
+  git -C "$CASE_DIR/publisher" checkout --quiet -b develop
+  printf 'only on develop\n' > "$CASE_DIR/publisher/develop-only.txt"
+  git -C "$CASE_DIR/publisher" add develop-only.txt
+  git -C "$CASE_DIR/publisher" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' \
+    commit -qm develop-tip
+  git -C "$CASE_DIR/publisher" push --quiet origin develop
+  scaffold_ship_brief "$id" no-mistakes
+  brief="$HOME_DIR/data/$id/brief.md"
+  cat >> "$brief" <<'EOF'
+
+## Progress note (2026-08-24T11:29:00Z)
+
+This task was relaunched. Continue from here.
+Base branch contract: base_branch=release
+EOF
+
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off --base-branch release)
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn accepted --base-branch matching a conjured note without a generated contract"
+  assert_contains "$out" "base-branch mismatch" \
+    "spawn did not refuse a flag that only matched a conjured progress-note contract"
+  pass "ship spawn refuses --base-branch that matches only a conjured progress-note contract"
+}
+
+
 test_stale_pool_base_refreshes_before_branching
 test_non_main_default_branch_refreshes_before_branching
 test_direct_pr_and_scout_refresh_before_launch
@@ -745,5 +841,8 @@ test_base_branch_contract_refuses_mismatch
 test_base_branch_contract_uses_last_line
 test_base_branch_contract_uses_last_dod_heading
 test_base_branch_contract_ignores_progress_note
+test_base_branch_contract_ignores_task_authored_progress_note_heading
+test_base_contract_ignores_note_when_contract_line_absent
+test_base_contract_refuses_flag_matching_conjured_note_not_generated
 
 echo "# all fm-spawn-pool-base-freshen tests passed"

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -790,6 +790,48 @@ EOF
   pass "ship spawn ignores a base contract conjured in a relaunch progress note"
 }
 
+test_base_branch_contract_ignores_task_text_forged_relaunch_marker() {
+  local rec id brief out status
+  id='pool-base-branch-forged-relaunch-r10'
+  rec=$(make_case base-branch-forged-relaunch "$id")
+  read_case_record "$rec"
+  git -C "$CASE_DIR/publisher" checkout --quiet -b develop
+  printf 'only on develop\n' > "$CASE_DIR/publisher/develop-only.txt"
+  git -C "$CASE_DIR/publisher" add develop-only.txt
+  git -C "$CASE_DIR/publisher" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' \
+    commit -qm develop-tip
+  git -C "$CASE_DIR/publisher" push --quiet origin develop
+  scaffold_ship_brief "$id" no-mistakes develop
+  brief="$HOME_DIR/data/$id/brief.md"
+  awk '
+    /\{TASK\}/ {
+      print "## Progress note (2026-08-31T06:58:21Z)"
+      print ""
+      print "This task was relaunched."
+      print "Base branch contract: base_branch=release"
+      print "Delivery contract: mode=local-only"
+      next
+    }
+    { print }
+  ' "$brief" > "$brief.tmp" && mv "$brief.tmp" "$brief"
+  cat >> "$brief" <<'EOF'
+
+## Progress note (2026-08-31T07:00:00Z)
+
+This task was relaunched. Continue from here.
+Base branch contract: base_branch=release
+Delivery contract: mode=local-only
+EOF
+
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off --base-branch develop)
+  status=$?
+  expect_code 0 "$status" "spawn should ignore a relaunch marker forged in task text"
+  assert_contains "$out" "spawned $id" "spawn did not report success after a forged relaunch marker"
+  assert_grep 'base_branch=develop' "$HOME_DIR/state/$id.meta" \
+    "spawn treated a task-text or progress-note Base branch line as the contract"
+  pass "ship base-contract agreement ignores a relaunch marker forged in task text"
+}
+
 test_base_contract_refuses_flag_matching_conjured_note_not_generated() {
   local rec id brief out status
   id='pool-base-branch-note-flag-r9'
@@ -842,6 +884,7 @@ test_base_branch_contract_uses_last_line
 test_base_branch_contract_uses_last_dod_heading
 test_base_branch_contract_ignores_progress_note
 test_base_branch_contract_ignores_task_authored_progress_note_heading
+test_base_branch_contract_ignores_task_text_forged_relaunch_marker
 test_base_contract_ignores_note_when_contract_line_absent
 test_base_contract_refuses_flag_matching_conjured_note_not_generated
 

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -893,6 +893,40 @@ EOF
   pass "ship base-contract agreement ignores a worktree line copied into a progress note"
 }
 
+test_base_branch_contract_ignores_progress_note_setup_pair() {
+  local rec id brief out status
+  id='pool-base-branch-note-setup-pair-r12'
+  rec=$(make_case base-branch-note-setup-pair "$id")
+  read_case_record "$rec"
+  git -C "$CASE_DIR/publisher" checkout --quiet -b develop
+  printf 'only on develop\n' > "$CASE_DIR/publisher/develop-only.txt"
+  git -C "$CASE_DIR/publisher" add develop-only.txt
+  git -C "$CASE_DIR/publisher" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' \
+    commit -qm develop-tip
+  git -C "$CASE_DIR/publisher" push --quiet origin develop
+  scaffold_ship_brief "$id" no-mistakes develop
+  brief="$HOME_DIR/data/$id/brief.md"
+  cat >> "$brief" <<'EOF'
+
+## Progress note (2026-09-02T11:00:00Z)
+
+This task was relaunched. Continue from here.
+# Setup
+You are in a disposable git worktree of test-project, at a detached HEAD on `develop`.
+# Definition of done
+Base branch contract: base_branch=release
+Delivery contract: mode=local-only
+EOF
+
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off --base-branch develop)
+  status=$?
+  expect_code 0 "$status" "spawn should ignore a Setup pair copied into a progress note"
+  assert_contains "$out" "spawned $id" "spawn did not report success after a progress-note Setup pair"
+  assert_grep 'base_branch=develop' "$HOME_DIR/state/$id.meta" \
+    "spawn treated a progress-note contract after a copied Setup pair as authoritative"
+  pass "ship base-contract agreement ignores a Setup pair copied into a progress note"
+}
+
 test_base_contract_refuses_flag_matching_conjured_note_not_generated() {
   local rec id brief out status
   id='pool-base-branch-note-flag-r9'
@@ -948,6 +982,7 @@ test_base_branch_contract_ignores_progress_note
 test_base_branch_contract_ignores_task_authored_progress_note_heading
 test_base_branch_contract_ignores_task_text_forged_relaunch_marker
 test_base_branch_contract_ignores_progress_note_worktree_line
+test_base_branch_contract_ignores_progress_note_setup_pair
 test_base_contract_ignores_note_when_contract_line_absent
 test_base_contract_refuses_flag_matching_conjured_note_not_generated
 

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -860,6 +860,39 @@ EOF
   pass "ship base-contract agreement ignores a relaunch marker forged in task text"
 }
 
+test_base_branch_contract_ignores_progress_note_worktree_line() {
+  local rec id brief out status
+  id='pool-base-branch-note-setup-r11'
+  rec=$(make_case base-branch-note-setup "$id")
+  read_case_record "$rec"
+  git -C "$CASE_DIR/publisher" checkout --quiet -b develop
+  printf 'only on develop\n' > "$CASE_DIR/publisher/develop-only.txt"
+  git -C "$CASE_DIR/publisher" add develop-only.txt
+  git -C "$CASE_DIR/publisher" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' \
+    commit -qm develop-tip
+  git -C "$CASE_DIR/publisher" push --quiet origin develop
+  scaffold_ship_brief "$id" no-mistakes develop
+  brief="$HOME_DIR/data/$id/brief.md"
+  cat >> "$brief" <<'EOF'
+
+## Progress note (2026-09-02T07:00:00Z)
+
+This task was relaunched. Continue from here.
+You are in a disposable git worktree of test-project, at a detached HEAD on `develop`.
+# Definition of done
+Base branch contract: base_branch=release
+Delivery contract: mode=local-only
+EOF
+
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off --base-branch develop)
+  status=$?
+  expect_code 0 "$status" "spawn should ignore a worktree line copied into a progress note"
+  assert_contains "$out" "spawned $id" "spawn did not report success after a progress-note worktree line"
+  assert_grep 'base_branch=develop' "$HOME_DIR/state/$id.meta" \
+    "spawn treated a progress-note contract after a copied worktree line as authoritative"
+  pass "ship base-contract agreement ignores a worktree line copied into a progress note"
+}
+
 test_base_contract_refuses_flag_matching_conjured_note_not_generated() {
   local rec id brief out status
   id='pool-base-branch-note-flag-r9'
@@ -914,6 +947,7 @@ test_base_branch_contract_uses_last_dod_heading
 test_base_branch_contract_ignores_progress_note
 test_base_branch_contract_ignores_task_authored_progress_note_heading
 test_base_branch_contract_ignores_task_text_forged_relaunch_marker
+test_base_branch_contract_ignores_progress_note_worktree_line
 test_base_contract_ignores_note_when_contract_line_absent
 test_base_contract_refuses_flag_matching_conjured_note_not_generated
 

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -629,6 +629,34 @@ test_base_branch_contract_refuses_mismatch() {
   pass "ship and scout base contracts refuse conflicting spawn flags"
 }
 
+test_scout_base_branch_contract_agrees_and_records() {
+  local rec id out status current_develop current_main
+  id='pool-scout-base-branch-agree-r10'
+  rec=$(make_case scout-base-branch-agree "$id")
+  read_case_record "$rec"
+  git -C "$CASE_DIR/publisher" checkout --quiet -b develop
+  printf 'only on develop\n' > "$CASE_DIR/publisher/develop-only.txt"
+  git -C "$CASE_DIR/publisher" add develop-only.txt
+  git -C "$CASE_DIR/publisher" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' \
+    commit -qm develop-tip
+  git -C "$CASE_DIR/publisher" push --quiet origin develop
+  scaffold_scout_brief "$id" develop
+
+  out=$(run_spawn "$id" --scout --base-branch develop)
+  status=$?
+  expect_code 0 "$status" "scout spawn --base-branch should accept a matching generated contract"
+  assert_contains "$out" "spawned $id" "scout spawn did not report success with a matching base contract"
+  current_develop=$(git -C "$POOL_DIR" rev-parse origin/develop)
+  current_main=$(git -C "$POOL_DIR" rev-parse origin/main)
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$current_develop" ] \
+    || fail "scout spawn --base-branch develop did not refresh to origin/develop"
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" != "$current_main" ] \
+    || fail "scout spawn --base-branch develop refreshed to origin/main"
+  assert_grep 'base_branch=develop' "$HOME_DIR/state/$id.meta" \
+    "scout spawn did not record the named analysis base"
+  pass "scout spawn honors a matching --base-branch contract from Definition of done"
+}
+
 test_base_branch_contract_uses_last_line() {
   local rec id brief out status
   id='pool-base-branch-last-line-r8'
@@ -880,6 +908,7 @@ test_base_branch_ref_fetch_failure_refuses_local_fallback
 test_missing_base_branch_refuses_without_default_fallback
 test_base_branch_refused_on_relaunch_secondmate_and_orca
 test_base_branch_contract_refuses_mismatch
+test_scout_base_branch_contract_agrees_and_records
 test_base_branch_contract_uses_last_line
 test_base_branch_contract_uses_last_dod_heading
 test_base_branch_contract_ignores_progress_note

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -660,6 +660,39 @@ test_base_branch_contract_uses_last_line() {
   pass "ship base-contract agreement uses the last Base branch line"
 }
 
+test_base_branch_contract_uses_last_dod_heading() {
+  local rec id brief out status
+  id='pool-base-branch-last-dod-r8'
+  rec=$(make_case base-branch-last-dod "$id")
+  read_case_record "$rec"
+  git -C "$CASE_DIR/publisher" checkout --quiet -b develop
+  printf 'only on develop\n' > "$CASE_DIR/publisher/develop-only.txt"
+  git -C "$CASE_DIR/publisher" add develop-only.txt
+  git -C "$CASE_DIR/publisher" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' \
+    commit -qm develop-tip
+  git -C "$CASE_DIR/publisher" push --quiet origin develop
+  scaffold_ship_brief "$id" no-mistakes develop
+  brief="$HOME_DIR/data/$id/brief.md"
+  awk '
+    /^# Task$/ {
+      print
+      print "# Definition of done"
+      print "Base branch contract: base_branch=release"
+      print "Delivery contract: mode=local-only"
+      next
+    }
+    { print }
+  ' "$brief" > "$brief.tmp" && mv "$brief.tmp" "$brief"
+
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off --base-branch develop)
+  status=$?
+  expect_code 0 "$status" "spawn should honor the last generated Definition of done"
+  assert_contains "$out" "spawned $id" "spawn did not report success after a task-authored Definition of done"
+  assert_grep 'base_branch=develop' "$HOME_DIR/state/$id.meta" \
+    "spawn treated a task-authored Definition of done as the contract"
+  pass "ship base-contract agreement uses the last Definition of done heading"
+}
+
 test_base_branch_contract_ignores_progress_note() {
   local rec id brief out status
   id='pool-base-branch-progress-note-r8'
@@ -710,6 +743,7 @@ test_missing_base_branch_refuses_without_default_fallback
 test_base_branch_refused_on_relaunch_secondmate_and_orca
 test_base_branch_contract_refuses_mismatch
 test_base_branch_contract_uses_last_line
+test_base_branch_contract_uses_last_dod_heading
 test_base_branch_contract_ignores_progress_note
 
 echo "# all fm-spawn-pool-base-freshen tests passed"


### PR DESCRIPTION
## Intent

Give firstmate an additive --base-branch on fm-spawn.sh for existing pooled treehouse worktrees: freshen/reset to that named branch tip (origin/<branch> if present, else the local branch; refuse if missing; no silent fallback to the remote default; refuse an unverifiable ref-specific fetch instead of treating it as remote absence). Record base_branch=<branch> in task meta only when the flag is set. --relaunch, --secondmate, and backend=orca refuse the flag. Do not change fm-teardown.sh, fm-control.sh, or validate_spawn_worktree. Do not add wtnew worktree provisioning, teardown, or process-reap behavior; that earlier design was cancelled and must not return.

For the eventual PR, do not change no-mistakes itself and do not use --skip pr. A no-mistakes ship must run the pipeline completely normally: push, PR against the repo default branch, CI monitored to green. After that first green, retarget the PR with raw `gh pr edit <number> --base <branch>` (installed gh-axi pr edit has no --base; keep gh-axi for every other GitHub operation), then wait and confirm CI is green again against the real target; do not trust the pre-retarget green. A direct-PR ship opens with gh-axi pr create --base <branch>. Document this exact sequence in fm-spawn.sh's header. Scaffold the matching worker-facing steps from fm-brief.sh --base-branch. When the flag is omitted, freshen, generated meta, and generated briefs stay identical to today.

Also accepted on the same change: optional --branch-name on fm-brief.sh so ship and scout scaffolds use that name everywhere the scaffold currently hardcodes fm/<task-id>. Validate with git check-ref-format --branch. When omitted, generated briefs stay identical to today. Note other scripts that still reconstruct fm/<id>. Shell-quote generated executable branch snippets.

This run's delivery job is to push the already-validated head through the gate to the recorded fork (https://github.com/lakshyads/firstmate.git) and let the PR step write a genuine no-mistakes ## Pipeline section (the marker "Updates from git push no-mistakes"). Update existing PR https://github.com/kunchenguid/firstmate/pull/2622 if that works, or open a fresh cross-repo PR from the fork; either is fine. Do not hand-stamp the signature. Do not merge.

Tests must exercise real executables and public behavior; never assert implementation source text.

## What Changed

- Added verified `--base-branch` freshening for pooled ship and scout worktrees, with metadata recording and refusal paths for unsupported or unverifiable cases.
- Extended worker briefs with base-branch delivery steps and validated, shell-quoted custom `--branch-name` scaffolding.
- Updated architecture documentation and executable regression coverage for the new spawn and brief behavior.

## Risk Assessment

✅ Low: The requested behavior is implemented within the affected spawn and brief paths, with omitted-flag compatibility and relevant failure paths covered by reviewed executable tests.

## Testing

Exercised real spawn and brief executables with isolated Git remotes and pooled worktrees: named-origin and local base selection, stale refresh, missing/unverifiable ref refusals, dirty-worktree preservation, incompatible mode refusals, metadata/brief contracts, quoted custom branches, and omitted-flag compatibility. The generated brief artifact shows the user-facing retarget-after-green sequence and custom branch command; all focused tests passed.

<details>
<summary>Evidence: Pooled-worktree base-branch E2E transcript</summary>

Source: [Pooled-worktree base-branch E2E transcript](https://github.com/lakshyads/firstmate/blob/0e9cdbe4f0fca84fa377a6a6a20ab549b1fe2f50/.no-mistakes/evidence/fm/fm-spawn-project-worktree-convention-v2/fm-spawn-base-branch-e2e.txt)

```text
# observed spawn: spawned pool-current-base-r1 harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-pool-current-base-r1 worktree=/var/folders/9_/lqnhn5_j6vz053wzxq2mk9rm0000gn/T//fm-spawn-pool-base-freshen.VkwbnK/current-base/pool
# observed base: HEAD=833579bd7be737afd98f9864bac22365f8c1ef4a origin/main=833579bd7be737afd98f9864bac22365f8c1ef4a advanced-main=must survive a newly spawned branch
ok - a stale pooled worktree refreshes to current origin/main before a crew branch is created
ok - a stale pooled worktree resolves and refreshes a non-main default branch
# observed direct-pr spawn: spawned pool-direct-pr-r3 harness=codex kind=ship mode=direct-PR yolo=off window=firstmate:fm-pool-direct-pr-r3 worktree=/var/folders/9_/lqnhn5_j6vz053wzxq2mk9rm0000gn/T//fm-spawn-pool-base-freshen.VkwbnK/direct-pr/pool
# observed scout spawn: spawned pool-scout-r3 harness=codex kind=scout window=firstmate:fm-pool-scout-r3 worktree=/var/folders/9_/lqnhn5_j6vz053wzxq2mk9rm0000gn/T//fm-spawn-pool-base-freshen.VkwbnK/scout/pool
ok - direct-PR ships and scouts both refresh stale pooled worktrees before launch
# observed dirty refusal: error: pooled worktree '/var/folders/9_/lqnhn5_j6vz053wzxq2mk9rm0000gn/T//fm-spawn-pool-base-freshen.VkwbnK/dirty-refusal/pool' is not clean; refusing to discard uncommitted work while refreshing its base; preserved=keep this local work
ok - a dirty pooled worktree is refused without discarding its local work
# observed unresolved-default refusal: error: could not resolve origin's current default branch for pooled worktree '/var/folders/9_/lqnhn5_j6vz053wzxq2mk9rm0000gn/T//fm-spawn-pool-base-freshen.VkwbnK/unresolved-default/pool'; refusing to launch from a potentially stale base
ok - an unresolved remote default branch refuses the pooled worktree
# observed unreachable-origin refusal: error: could not fetch origin for pooled worktree '/var/folders/9_/lqnhn5_j6vz053wzxq2mk9rm0000gn/T//fm-spawn-pool-base-freshen.VkwbnK/unreachable-origin/pool'; refusing to launch from a potentially stale base
ok - an unreachable origin refuses a potentially stale pooled worktree
ok - spawn --base-branch resets the pooled worktree to the named origin tip
ok - omitting --base-branch keeps default-branch freshen and does not record a PR target
ok - spawn --base-branch uses a local branch when origin lacks it
ok - a failed remote base fetch refuses instead of falling back to local
ok - a nonexistent --base-branch refuses without falling back to the default
ok - --relaunch, --secondmate, and backend=orca refuse --base-branch
ok - ship and scout base contracts refuse conflicting spawn flags
# all fm-spawn-pool-base-freshen tests passed
```
</details>
<details>
<summary>Evidence: Generated worker brief with base and branch contracts</summary>

Source: [Generated worker brief with base and branch contracts](https://github.com/lakshyads/firstmate/blob/0e9cdbe4f0fca84fa377a6a6a20ab549b1fe2f50/.no-mistakes/evidence/fm/fm-spawn-project-worktree-convention-v2/generated-brief-base-and-branch.md)

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of firstmate, at a detached HEAD on `release/2026-q3`.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b 'feature/worker-base-branch'`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/9_/lqnhn5_j6vz053wzxq2mk9rm0000gn/T/no-mistakes-evidence/01M0FEQVEPCJW32MTX8B1QR4S3/generated-brief-home/state/e2e-base-branch-demo.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/lakshyadevsingh/.no-mistakes/worktrees/3980b3023422/01M0FEQVEPCJW32MTX8B1QR4S3/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/lakshyadevsingh/.no-mistakes/worktrees/3980b3023422/01M0FEQVEPCJW32MTX8B1QR4S3/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=no-mistakes
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

Run /no-mistakes completely normally: push, PR against the repo default branch, CI to green. Do not pass --skip pr and do not change no-mistakes PR-target settings.
After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), do not report done yet.
Retarget the open PR with `gh pr edit <number> --base 'release/2026-q3'` (the recorded base_branch value; bin/fm-spawn.sh owns this sequence).
Then poll `gh-axi pr checks <number>` until checks are green against that base (zero pending, zero failed). Do not trust the pre-retarget green, and do not treat "0 checks configured" as green unless that is this repo's trusted no-CI case.
Only then append `done: PR {url} checks green` and stop. You are finished.
Base branch contract: base_branch=release/2026-q3
Crew branch: branch=feature/worker-base-branch
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"d798af1b00fe9e138f07bf0f0012809ef263de5d","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-spawn.sh:1699` - The new brief/spawn base agreement is enforced only for ship tasks. A scout brief scaffolded with `--base-branch develop` can be spawned with `--scout --base-branch release`; spawn resets the worktree to `release` while the worker-facing Setup still states `develop`. Emit the same machine-readable base contract for scouts and validate it before freshening, so the stated and actual analysis base cannot diverge.

🔧 Fix: Enforce named-base contracts for scout spawns
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --check 1cb900c28faf23fe23c9bb54e63f7c3b436ea096 d798af1b00fe9e138f07bf0f0012809ef263de5d`
- `FM_TEST_EVIDENCE=1 bash tests/fm-spawn-pool-base-freshen.test.sh`
- `bash tests/fm-brief.test.sh`
- `FM_HOME=<evidence home> bin/fm-brief.sh e2e-base-branch-demo firstmate --mode no-mistakes --base-branch release/2026-q3 --branch-name feature/worker-base-branch`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
