### PR TITLE
fix(startup-memory): measure symlinked memory files instead of refusing them

### DIFF
--- a/bin/fm-startup-memory-budget-lib.sh
+++ b/bin/fm-startup-memory-budget-lib.sh
@@ -15,6 +15,8 @@ FM_STARTUP_MEMORY_BUDGET_VALUE=""
 FM_STARTUP_MEMORY_MEASURE_BYTES=""
 FM_STARTUP_MEMORY_MEASURE_TOKENS=""
 FM_STARTUP_MEMORY_MEASURE_PRESENCE=""
+# Bounded symlink walk depth; the kernel refuses deeper chains anyway.
+FM_STARTUP_MEMORY_SYMLINK_MAX_HOPS="40"
 
 fm_startup_memory_budget_fail() {
   FM_STARTUP_MEMORY_BUDGET_ERROR=$1
@@ -160,10 +162,43 @@ fm_startup_memory_estimated_tokens_for_bytes() {
   printf '%s\n' "$tokens"
 }
 
+# fm_startup_memory_symlink_resolves <path>
+# Succeeds when <path> is not a symlink, or when its symlink chain terminates
+# within FM_STARTUP_MEMORY_SYMLINK_MAX_HOPS hops.  A cyclic chain never
+# terminates, so the walk is bounded and returns a refusal instead of hanging
+# or leaking a kernel loop error out of a later read.  The bound matches the
+# depth the kernel itself refuses, so no chain a session could actually read is
+# rejected here.
+fm_startup_memory_symlink_resolves() {
+  local current=$1 hops=0 target dir
+  while [ -L "$current" ]; do
+    hops=$((hops + 1))
+    if [ "$hops" -gt "$FM_STARTUP_MEMORY_SYMLINK_MAX_HOPS" ]; then
+      return 1
+    fi
+    target=$(readlink "$current" 2>/dev/null) || return 1
+    case "$target" in
+      /*) current=$target ;;
+      *)
+        case "$current" in
+          */*) dir=${current%/*} ;;
+          *) dir=. ;;
+        esac
+        current="$dir/$target"
+        ;;
+    esac
+  done
+  return 0
+}
+
 # fm_startup_memory_measure_file <path>
-# Prints "<bytes> <estimated-tokens> <present|absent>".  Memory files must be
-# ordinary files when present so a measurement never follows a symlink or reads
-# a special file.
+# Prints "<bytes> <estimated-tokens> <present|absent>".  A session loads what a
+# memory path actually resolves to, so a symlink to an ordinary file is
+# measured through the link rather than refused: refusing it left a home whose
+# memory is injected anyway with no budget accounting at all.  Reading a
+# special file is still refused, because [ -f ] follows the link and holds only
+# for a regular target, and a broken or cyclic link is a named error rather
+# than a silent zero.
 fm_startup_memory_measure_file() {
   local path=$1 bytes tokens
   FM_STARTUP_MEMORY_MEASURE_BYTES=""
@@ -176,7 +211,17 @@ fm_startup_memory_measure_file() {
     printf '0 0 absent\n'
     return 0
   fi
-  if [ -L "$path" ] || [ ! -f "$path" ]; then
+  if [ -L "$path" ]; then
+    if ! fm_startup_memory_symlink_resolves "$path"; then
+      fm_startup_memory_budget_fail "memory file symlink does not resolve, its chain loops or exceeds $FM_STARTUP_MEMORY_SYMLINK_MAX_HOPS hops: $path"
+      return 1
+    fi
+    if [ ! -e "$path" ]; then
+      fm_startup_memory_budget_fail "memory file is a broken symlink: $path"
+      return 1
+    fi
+  fi
+  if [ ! -f "$path" ]; then
     fm_startup_memory_budget_fail "memory file is not an ordinary regular file: $path"
     return 1
   fi

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -159,6 +159,8 @@ The file must be one positive base-10 integer followed by exactly one newline in
 Malformed, multi-line, symlinked, hardlinked, special, or otherwise unsafe values are rejected rather than treated as a default.
 Use `bin/fm-startup-memory-budget.sh read` to validate and print the effective value, or `bin/fm-startup-memory-budget.sh report` to account for the three files.
 The stable local estimate is `ceil(UTF-8 bytes / 3)` per file, a conservative portable approximation rather than a provider-exact tokenizer.
+A memory file that is a symlink to an ordinary file is measured through the link, because that target's bytes are what a session actually loads; this is the shape a firstmate home embedded in an existing notes vault uses when the vault owns the captain preferences.
+A broken link, a looping link, and a directory or special-file target are each refused by their own named reason instead of being counted as an empty file.
 An inherited `data/captain-shared.md` counts in a secondmate's total but remains primary-owned and read-only there.
 The internal [`/stow` skill](../.agents/skills/stow/SKILL.md) owns curation and its automatic secondmate cascade, which accounts every home against this same per-home allowance separately rather than against a fleet total.
 The helper's header owns exact parsing, publication, and report output mechanics.

--- a/tests/fm-startup-memory-budget.test.sh
+++ b/tests/fm-startup-memory-budget.test.sh
@@ -190,7 +190,7 @@ test_budget_accounting_reports_all_three_files_and_safe_failure() {
   assert_contains "$out" 'budget_status=over-budget' "report did not surface an over-budget total"
 
   outside="$TMP_ROOT/accounting-outside"
-  printf 'outside\n' > "$outside"
+  mkdir -p "$outside"
   rm -f "$home/data/captain.md"
   ln -s "$outside" "$home/data/captain.md"
   set +e
@@ -200,8 +200,133 @@ test_budget_accounting_reports_all_three_files_and_safe_failure() {
   expect_code 2 "$rc" "unsafe memory input should fail the accounting command"
   assert_contains "$out" 'memory file is not an ordinary regular file' \
     "accounting failure did not identify the unsafe memory file"
-  [ "$(<"$outside")" = outside ] || fail "accounting failure changed a symlink target"
+  [ -d "$outside" ] || fail "accounting failure changed a symlink target"
   pass "budget accounting sums the three startup files and reports safe failures"
+}
+
+# Runs the accounting command under a wall-clock bound where one is available,
+# so a hanging read (a FIFO) or an unbounded walk (a symlink cycle) fails the
+# test instead of wedging the suite.
+run_report_bounded() {
+  local home=$1
+  if command -v timeout >/dev/null 2>&1; then
+    FM_HOME="$home" timeout 20 "$BUDGET" report 2>&1
+    return $?
+  fi
+  FM_HOME="$home" "$BUDGET" report 2>&1
+}
+
+expect_report_failure() {
+  local home=$1 expected=$2 label=$3 out rc
+  set +e
+  out=$(run_report_bounded "$home")
+  rc=$?
+  set -e
+  expect_code 2 "$rc" "$label should fail the accounting command"
+  assert_contains "$out" "$expected" "$label did not name its own reason"
+  assert_not_contains "$out" 'total_estimated_tokens=' \
+    "$label reported a total despite an unusable memory file"
+}
+
+test_memory_measurement_follows_symlinks_and_refuses_unusable_targets() {
+  local home target out regular_line
+  home="$TMP_ROOT/symlink-home"
+  mkdir -p "$home/config" "$home/data" "$TMP_ROOT/symlink-outside"
+  printf '9000\n' > "$home/config/startup-memory-budget"
+  printf 'learn\n' > "$home/data/learnings.md"
+
+  # A plain regular file must account byte for byte exactly as before.
+  target="$TMP_ROOT/symlink-outside/captain.md"
+  printf 'captain memory here\n' > "$target"
+  cp "$target" "$home/data/captain.md"
+  out=$(run_report_bounded "$home") || fail "regular memory file failed the accounting command"
+  regular_line='file=data/captain.md bytes=20 estimated_tokens=7 status=present'
+  assert_contains "$out" "$regular_line" "regular memory file was not accounted byte for byte"
+  assert_contains "$out" 'file=data/learnings.md bytes=6 estimated_tokens=2 status=present' \
+    "regular-file run did not account the remaining memory files"
+  assert_contains "$out" 'total_estimated_tokens=9' "regular-file run did not total its files"
+
+  # A symlink to that same regular file must produce the identical accounting:
+  # a session loads the target's bytes, so the budget must count them.
+  rm -f "$home/data/captain.md"
+  ln -s "$target" "$home/data/captain.md"
+  out=$(run_report_bounded "$home") || fail "symlinked memory file was refused instead of measured"
+  assert_contains "$out" "$regular_line" \
+    "symlinked memory file was not measured as its target's exact bytes"
+  assert_contains "$out" 'total_estimated_tokens=9' \
+    "symlinked memory file did not contribute to the accounted total"
+  [ "$(<"$target")" = 'captain memory here' ] || fail "measuring through a symlink changed its target"
+
+  # A relative link, the shape an in-vault home actually uses, resolves too.
+  rm -f "$home/data/captain.md"
+  ln -s ../../symlink-outside/captain.md "$home/data/captain.md"
+  out=$(run_report_bounded "$home") || fail "relative symlinked memory file was refused"
+  assert_contains "$out" "$regular_line" "relative symlinked memory file measured the wrong bytes"
+
+  # A chain of links to a regular file is still a regular file to read.
+  rm -f "$home/data/captain.md"
+  ln -s "$target" "$TMP_ROOT/symlink-outside/hop.md"
+  ln -s "$TMP_ROOT/symlink-outside/hop.md" "$home/data/captain.md"
+  out=$(run_report_bounded "$home") || fail "symlink chain to a regular file was refused"
+  assert_contains "$out" "$regular_line" "symlink chain measured the wrong bytes"
+
+  # A broken link is an error with its own reason, never a present zero-byte
+  # file and never the generic not-a-regular-file sentence.
+  rm -f "$home/data/captain.md"
+  ln -s "$TMP_ROOT/symlink-outside/no-such-file.md" "$home/data/captain.md"
+  expect_report_failure "$home" 'memory file is a broken symlink' 'a broken memory symlink'
+  set +e
+  out=$(run_report_bounded "$home")
+  set -e
+  assert_not_contains "$out" 'file=data/captain.md bytes=0' \
+    "a broken memory symlink was reported as an empty present file"
+  assert_not_contains "$out" 'status=absent' \
+    "a broken memory symlink was reported as an absent file"
+
+  # Special and directory targets keep being refused: [ -f ] follows the link
+  # and holds only for a regular target.
+  rm -f "$home/data/captain.md"
+  ln -s "$TMP_ROOT/symlink-outside" "$home/data/captain.md"
+  expect_report_failure "$home" 'memory file is not an ordinary regular file' \
+    'a memory symlink to a directory'
+
+  rm -f "$home/data/captain.md"
+  mkfifo "$TMP_ROOT/symlink-outside/fifo" 2>/dev/null \
+    || fail "could not create the FIFO this case needs"
+  ln -s "$TMP_ROOT/symlink-outside/fifo" "$home/data/captain.md"
+  expect_report_failure "$home" 'memory file is not an ordinary regular file' \
+    'a memory symlink to a FIFO'
+  rm -f "$TMP_ROOT/symlink-outside/fifo"
+
+  # A cycle bounces with its own reason rather than hanging or leaking a shell
+  # error about too many levels of symbolic links.
+  rm -f "$home/data/captain.md"
+  ln -s "$TMP_ROOT/symlink-outside/loop-b.md" "$TMP_ROOT/symlink-outside/loop-a.md"
+  ln -s "$TMP_ROOT/symlink-outside/loop-a.md" "$TMP_ROOT/symlink-outside/loop-b.md"
+  ln -s "$TMP_ROOT/symlink-outside/loop-a.md" "$home/data/captain.md"
+  expect_report_failure "$home" 'memory file symlink does not resolve, its chain loops' \
+    'a looping memory symlink'
+  set +e
+  out=$(run_report_bounded "$home")
+  set -e
+  assert_not_contains "$out" 'Too many levels' \
+    "a looping memory symlink leaked a raw system error"
+  assert_not_contains "$out" 'zbyt wiele' \
+    "a looping memory symlink leaked a raw localized system error"
+
+  # A self-referential link is the same refusal, not an infinite walk.
+  rm -f "$home/data/captain.md"
+  ln -s captain.md "$home/data/captain.md"
+  expect_report_failure "$home" 'memory file symlink does not resolve, its chain loops' \
+    'a self-referential memory symlink'
+
+  # An absent path is still plain absence, not an error.
+  rm -f "$home/data/captain.md"
+  out=$(run_report_bounded "$home") || fail "an absent memory file failed the accounting command"
+  assert_contains "$out" 'file=data/captain.md bytes=0 estimated_tokens=0 status=absent' \
+    "an absent memory file stopped being reported as absent"
+  assert_contains "$out" 'total_estimated_tokens=2' "absent accounting did not total the present files"
+  pass "memory accounting measures symlinked files and names broken, special, and looping targets"
 }
 
 new_propagation_world() {
@@ -320,6 +445,7 @@ test_primary_budget_converges_with_exact_reread_and_safe_failures() {
 test_primary_bootstrap_materializes_visible_default
 test_safe_parser_rejects_ambiguous_and_unsafe_values
 test_budget_accounting_reports_all_three_files_and_safe_failure
+test_memory_measurement_follows_symlinks_and_refuses_unusable_targets
 test_primary_budget_converges_with_exact_reread_and_safe_failures
 
 echo '# all fm-startup-memory-budget tests passed'


### PR DESCRIPTION
## The defect

`fm_startup_memory_measure_file` refuses any symlinked path. A home whose `data/captain.md` is a symlink into an existing notes vault therefore gets **no budget accounting at all**: the report aborts before a single file is counted, while that same file still enters every session's context. The guard was silent exactly where it was needed.

Concrete case: a firstmate home embedded in a personal vault keeps `data/captain.md` as a symlink to the vault's own captain file, because the vault is the source of truth and several vault scripts read it. `bin/fm-startup-memory-budget.sh report` then exits with `memory file is not an ordinary regular file` and reports nothing.

## The change

A symlink whose target is an ordinary file is measured through the link, because those are the bytes a session actually loads.

Special-file protection is unchanged: `[ -f ]` already follows the link and holds only for a regular target, so directories, FIFOs, devices and sockets still bounce with their own refusal.

Broken and cyclic links no longer share one generic sentence:
- a broken link is named as a broken symlink, never as a present zero-byte file;
- a cycle is refused through a bounded chain walk, so it neither hangs nor leaks a raw kernel loop error.

Regular files and absent paths behave byte for byte as before.

## Evidence

Live report in the vault-linked home now totals 7480/7500 estimated tokens instead of aborting.

7 new cases in `tests/fm-startup-memory-budget.test.sh` cover: symlink to a regular file, symlink to a directory, symlink to a FIFO, broken symlink, self-referential symlink, two-link cycle, and an unchanged regular-file baseline. Lint clean.

Two pre-existing failures in `tests/fm-on.test.sh` and `tests/fm-remote-job-orphan-reap.test.sh` reproduce identically on a clean base without this commit, so they are unrelated to this change.
