### PR TITLE
perf(bin): read fm_meta_get with one awk pass instead of grep|tail|cut

### DIFF
--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -335,10 +335,18 @@ fm_backend_required_tool_available() {  # <backend> <tool>
 # fm_meta_get: the LAST value of `key=` in <meta-file>, or empty (never
 # errors) if the file or key is absent. Mirrors the ad hoc `grep '^key=' |
 # tail -1 | cut -d= -f2-` snippet every fm-*.sh script used to repeat inline.
+# Implemented as a single awk pass (one subprocess) instead of the previous
+# grep | tail | cut pipeline (three subprocesses): this is one of the
+# hottest helpers in the codebase, called from every fm-*.sh script that
+# reads task metadata, so cutting two forks per call adds up across a
+# session with many tasks/hooks.
 fm_meta_get() {  # <meta-file> <key>
   local meta=$1 key=$2
   [ -f "$meta" ] || return 0
-  grep "^$key=" "$meta" 2>/dev/null | tail -1 | cut -d= -f2- || true
+  awk -v key="$key" '
+    $0 ~ "^" key "=" { line = $0 }
+    END { if (line != "") { sub("^" key "=", "", line); print line } }
+  ' "$meta" 2>/dev/null || true
 }
 
 # fm_backend_of_meta: the backend recorded in <meta-file>, defaulting to

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -526,6 +526,9 @@ test_meta_get_and_backend_of_meta() {
   [ "$(fm_meta_get "$meta" missing)" = "" ] || fail "fm_meta_get should print nothing for an absent key"
   [ "$(fm_backend_of_meta "$meta")" = tmux ] || fail "fm_backend_of_meta should default absent backend= to tmux"
 
+  printf 'window=stale\n' >> "$meta"
+  [ "$(fm_meta_get "$meta" window)" = "stale" ] || fail "fm_meta_get should return the LAST value when a key repeats"
+
   printf 'backend=tmux\n' >> "$meta"
   [ "$(fm_backend_of_meta "$meta")" = tmux ] || fail "fm_backend_of_meta should read an explicit backend=tmux"
 


### PR DESCRIPTION
## What

`fm_meta_get()` (bin/fm-backend.sh) is the single implementation point for reading a `key=value` field out of a task `.meta` file. Per its own doc comment, it consolidated an ad hoc `grep '^key=' | tail -1 | cut -d= -f2-` snippet that "every fm-*.sh script used to repeat inline" - and it is still called 85+ times across the codebase (fm-bootstrap.sh, fm-control.sh, fm-spawn.sh, fm-teardown.sh, fm-session-start.sh, fm-fleet-snapshot.sh, fm-send.sh, and more), several of which loop it once per task.

It forked 3 subprocesses per call (`grep`, `tail`, `cut`). This PR replaces that pipeline with a single `awk` pass that preserves the exact same contract (last matching `key=` line wins; strip up to and including the first `=`; empty output and success exit code when the file or key is absent) - cutting subprocess spawns for this helper by two thirds with zero behavior change.

## Why this one

Identified as part of a broader performance pass over the repo's ~150 shell scripts (polling loops, O(n²) JSON accumulation via repeated `jq` invocations, redundant `git rev-parse` calls, etc.). This change was the best impact/effort ratio: it touches the single, already-deduplicated implementation of the codebase's hottest metadata-read helper, requires no caller changes, and is a drop-in, easily verified swap.

## Verification

- Existing unit test `fm_meta_get / fm_backend_of_meta` in `tests/fm-backend.test.sh` passes unmodified.
- Added a regression case asserting last-value-wins when a key repeats in a meta file (documented behavior that wasn't previously exercised directly).
- Manually verified edge cases match old behavior byte-for-byte: normal value, empty value (`backend=`), a value containing additional `=` characters (`query=a=b=c`), and a missing key.
- Ran `tests/fm-backend.test.sh`; the one pre-existing failure (`fm-spawn.sh ... symlinked prefix`, a task-lock contention error) reproduces identically on `main` without this change, confirming it's unrelated.