### PR TITLE
feat(bin): reclaim Next.js build output from pooled copies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -363,6 +363,7 @@ Tear down a ship task only after landing is confirmed.
 A teardown refusal for uncommitted or unlanded work is a stop-and-investigate result, never an obstacle to bypass.
 Never force teardown without explicit discard authority.
 After successful teardown, record completion, retain only the configured recent Done history, and re-evaluate queued work whose blockers and time gates have cleared.
+Teardown reclaims a finished copy's Next.js build output on its own; run `bin/fm-next-cache-sweep.sh` only when disk space must be recovered from copies already idle in the pool, and read its header before doing so.
 
 A secondmate is persistent and an empty queue is healthy.
 Retire one only on an explicit captain or main-firstmate decision, after loading `secondmate-provisioning`; its home must contain no work under way, and forced discard still requires explicit captain authority.

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -588,6 +588,33 @@ fm_backend_expected_label_of_selector() {  # <raw-target> <state-dir>
   return 0
 }
 
+# Source one adapter file, at most once per shell, failing rather than exiting
+# when it is missing.
+#
+# Stock macOS Bash 3.2 - what /usr/bin/env bash resolves to on the machines this
+# fleet runs on - terminates the whole shell when `.` cannot find its file, and
+# does so with status 0. It ignores both the `|| return 1` written beside the
+# source and the `if !` the caller wrapped the call in. A missing adapter would
+# therefore end fm-teardown.sh mid-run while reporting success, so the caller
+# records a task as cleaned up when nothing was cleaned up and the safety
+# refusal it was about to print never appears. Bash 5 returns 1 as written,
+# which is why CI's Linux lanes never saw it. Testing the file first makes the
+# missing adapter a refusable error on every supported Bash.
+# The guard is read and written through eval because this file is also sourced
+# from zsh, where bash's ${!var} indirection and printf -v mean something else
+# or nothing at all. Guard names are literals from this file's own call sites.
+# Verified 2026-08-18 against GNU bash 3.2.57(1)-release (arm64-apple-darwin25)
+# and pinned by tests/fm-backend.test.sh.
+fm_backend_source_adapter_once() {  # <guard-var> <adapter-file>
+  local guard=$1 file=$2 loaded
+  eval "loaded=\${$guard:-}"
+  [ -z "$loaded" ] || return 0
+  [ -r "$file" ] || return 1
+  # shellcheck source=/dev/null
+  . "$file" || return 1
+  eval "$guard=1"
+}
+
 # fm_backend_source: source the named backend's adapter file, once per shell.
 # Each adapter is an independently linted canonical root. The /dev/null source
 # boundaries keep runtime dispatch from importing all five adapter ASTs into
@@ -597,39 +624,19 @@ fm_backend_source() {  # <name>
   fm_backend_validate "$name" || return 1
   case "$name" in
     tmux)
-      if [ -z "${_FM_BACKEND_TMUX_SOURCED:-}" ]; then
-        # shellcheck source=/dev/null
-        . "$FM_BACKEND_LIB_DIR/backends/tmux.sh" || return 1
-        _FM_BACKEND_TMUX_SOURCED=1
-      fi
+      fm_backend_source_adapter_once _FM_BACKEND_TMUX_SOURCED "$FM_BACKEND_LIB_DIR/backends/tmux.sh" || return 1
       ;;
     herdr)
-      if [ -z "${_FM_BACKEND_HERDR_SOURCED:-}" ]; then
-        # shellcheck source=/dev/null
-        . "$FM_BACKEND_LIB_DIR/backends/herdr.sh" || return 1
-        _FM_BACKEND_HERDR_SOURCED=1
-      fi
+      fm_backend_source_adapter_once _FM_BACKEND_HERDR_SOURCED "$FM_BACKEND_LIB_DIR/backends/herdr.sh" || return 1
       ;;
     zellij)
-      if [ -z "${_FM_BACKEND_ZELLIJ_SOURCED:-}" ]; then
-        # shellcheck source=/dev/null
-        . "$FM_BACKEND_LIB_DIR/backends/zellij.sh" || return 1
-        _FM_BACKEND_ZELLIJ_SOURCED=1
-      fi
+      fm_backend_source_adapter_once _FM_BACKEND_ZELLIJ_SOURCED "$FM_BACKEND_LIB_DIR/backends/zellij.sh" || return 1
       ;;
     orca)
-      if [ -z "${_FM_BACKEND_ORCA_SOURCED:-}" ]; then
-        # shellcheck source=/dev/null
-        . "$FM_BACKEND_LIB_DIR/backends/orca.sh" || return 1
-        _FM_BACKEND_ORCA_SOURCED=1
-      fi
+      fm_backend_source_adapter_once _FM_BACKEND_ORCA_SOURCED "$FM_BACKEND_LIB_DIR/backends/orca.sh" || return 1
       ;;
     cmux)
-      if [ -z "${_FM_BACKEND_CMUX_SOURCED:-}" ]; then
-        # shellcheck source=/dev/null
-        . "$FM_BACKEND_LIB_DIR/backends/cmux.sh" || return 1
-        _FM_BACKEND_CMUX_SOURCED=1
-      fi
+      fm_backend_source_adapter_once _FM_BACKEND_CMUX_SOURCED "$FM_BACKEND_LIB_DIR/backends/cmux.sh" || return 1
       ;;
   esac
 }

--- a/bin/fm-next-cache-lib.sh
+++ b/bin/fm-next-cache-lib.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# Shared discovery and removal of Next.js build output inside a task worktree.
+#
+# Why this exists: a pooled worktree returns to the pool carrying its Next.js
+# build output, and nothing ever removes it. Measured 2026-08-18: one idle
+# Artemis copy held a 15 GB packages/frontend/.next on a volume with 11 GB free;
+# removing that one directory took free space to 27 GB. An earlier sweep on
+# 2026-08-07 found ~25.6 GB of it spread across eight copies. The output
+# regenerates from source on the next build, so it is the largest reclaim in the
+# pool that costs nothing to give up.
+#
+# Sourced by bin/fm-teardown.sh (which reclaims a copy before returning it) and
+# bin/fm-next-cache-sweep.sh (which reclaims copies already sitting idle in the
+# pool). Both get the same discovery rule from here, so "what counts as
+# reclaimable" is stated once.
+#
+# WHAT IS RECLAIMED. Exactly directories named .next that pass BOTH proofs:
+#   1. git ignores the directory in the repo that contains it
+#      (`git check-ignore`). Tracked content can never match, so no source, no
+#      git data, and no committed fixture is reachable by this rule.
+#   2. its parent is a Next.js app root: a next.config.{js,cjs,mjs,ts,cts,mts}
+#      sits beside it, or the parent's package.json names `next`. This is what
+#      makes the claim "regenerable build output" true rather than assumed - a
+#      gitignored directory that merely happens to be called .next is left alone.
+# Nothing else is ever removed. node_modules, source, and git data are out of
+# scope by construction, not by exclusion list: the walk prunes node_modules and
+# .git outright, and neither could pass proof 2 anyway.
+#
+# OTHER CACHES WERE MEASURED AND DELIBERATELY LEFT OUT. Surveying the whole pool
+# on 2026-08-18 turned up one other large gitignored directory: a project's .tmp
+# scratch root, ~8.7 GB across the copies, holding audit output, coverage JSON,
+# browser recordings, and review artifacts. That is agent work product, not build
+# output - nothing regenerates it - so it is not this rule's business, and the
+# same goes for a `dist` (~102 MB pooled, and tracked in some projects). Every
+# other candidate measured zero: .turbo, .cache, .parcel-cache, .vite, .output.
+# Widening this rule by pattern would trade a large, provably safe reclaim for a
+# small, unprovable one; add a directory only by naming it and its measured size.
+#
+# Next.js documents .next as the build output directory (`distDir` defaults to
+# '.next') and clears it itself on every production build (`cleanDistDir`
+# defaults to true, preserving only .next/cache). Removing it is therefore the
+# same operation the framework already performs on itself, one build earlier.
+# A project that sets a custom `distDir` is deliberately NOT discovered: reading
+# a build config to decide what to delete would make the deletion set depend on
+# untrusted project code. Such a project keeps its cache until someone names the
+# directory, which is the safe direction to be wrong in.
+#
+# The walk prunes node_modules and .git, and stops descending at each .next it
+# finds, so a nested .next under .next/standalone is reclaimed with its parent
+# rather than counted twice. Measured cost on the largest live Artemis copy
+# (5.1 GB of loose scratch, full node_modules): 214 ms.
+#
+# This library never decides WHETHER a worktree may be touched. Teardown proves
+# that through its own landed-work checks; the sweep proves it through pool
+# lease state, task records, and a clean tree. Sourcing this file grants no
+# authority to remove anything.
+
+# Bytes-to-human, matching the units du -h prints, so a reclaim line reads the
+# same as what an operator would have measured by hand.
+fm_next_cache_human_kb() {  # <kilobytes>
+  local kb=${1:-0}
+  if [ "$kb" -lt 1024 ]; then
+    printf '%dK\n' "$kb"
+  elif [ "$kb" -lt 1048576 ]; then
+    awk -v k="$kb" 'BEGIN { printf "%.1fM\n", k / 1024 }'
+  else
+    awk -v k="$kb" 'BEGIN { printf "%.1fG\n", k / 1048576 }'
+  fi
+}
+
+# Size of <dir> in kilobytes, or 0 when it cannot be measured. Reporting must
+# never be the thing that fails a reclaim, so an unreadable size is not an error.
+fm_next_cache_size_kb() {  # <dir>
+  local dir=$1 kb
+  kb=$(du -sk -- "$dir" 2>/dev/null | awk 'NR == 1 { print $1 }') || kb=
+  case "$kb" in
+    ''|*[!0-9]*) printf '0\n' ;;
+    *) printf '%s\n' "$kb" ;;
+  esac
+}
+
+# Is <parent> a Next.js app root? See proof 2 in the header.
+fm_next_cache_parent_is_next_app() {  # <parent-dir>
+  local parent=$1 ext
+  for ext in js cjs mjs ts cts mts; do
+    [ -f "$parent/next.config.$ext" ] && return 0
+  done
+  [ -f "$parent/package.json" ] || return 1
+  grep -Eq '"next"[[:space:]]*:' "$parent/package.json" 2>/dev/null
+}
+
+# Does <dir> pass both proofs, as a real directory inside repo <root>?
+fm_next_cache_is_build_output() {  # <repo-root> <dir>
+  local root=$1 dir=$2 real parent
+  [ -d "$dir" ] || return 1
+  # A symlink is never removed: the target may live outside the worktree
+  # entirely, and rm -rf on it would follow the operator's intent nowhere good.
+  if [ -L "$dir" ]; then return 1; fi
+  real=$(CDPATH='' cd -- "$dir" 2>/dev/null && pwd -P) || return 1
+  # Containment: only ever a path physically under the worktree we were given.
+  case "$real" in
+    "$root"/*) ;;
+    *) return 1 ;;
+  esac
+  git -C "$root" check-ignore -q -- "$real" 2>/dev/null || return 1
+  parent=$(dirname -- "$real")
+  fm_next_cache_parent_is_next_app "$parent"
+}
+
+# Print each reclaimable Next.js build-output directory in <worktree>, one
+# absolute path per line. Prints nothing (exit 0) when the worktree is missing,
+# is not a git repo, or holds none.
+fm_next_cache_dirs() {  # <worktree>
+  local wt=$1 root dir
+  root=$(CDPATH='' cd -- "$wt" 2>/dev/null && pwd -P) || return 0
+  git -C "$root" rev-parse --git-dir >/dev/null 2>&1 || return 0
+  while IFS= read -r dir; do
+    [ -n "$dir" ] || continue
+    fm_next_cache_is_build_output "$root" "$dir" || continue
+    printf '%s\n' "$dir"
+  done < <(find "$root" \( -name node_modules -o -name .git \) -prune -o \
+    -type d -name .next -print -prune 2>/dev/null)
+}
+
+# Total kilobytes <worktree> holds, without printing or removing anything.
+# Sets FM_NEXT_CACHE_TOTAL_KB and prints it.
+fm_next_cache_total_kb() {  # <worktree>
+  local wt=$1 dir
+  FM_NEXT_CACHE_TOTAL_KB=0
+  while IFS= read -r dir; do
+    [ -n "$dir" ] || continue
+    FM_NEXT_CACHE_TOTAL_KB=$(( FM_NEXT_CACHE_TOTAL_KB + $(fm_next_cache_size_kb "$dir") ))
+  done < <(fm_next_cache_dirs "$wt")
+  printf '%s\n' "$FM_NEXT_CACHE_TOTAL_KB"
+}
+
+# Report what <worktree> holds without removing anything. One line per
+# directory; nothing when there is none. Sets FM_NEXT_CACHE_TOTAL_KB.
+fm_next_cache_report() {  # <worktree> <label>
+  local wt=$1 label=$2 dir kb
+  FM_NEXT_CACHE_TOTAL_KB=0
+  while IFS= read -r dir; do
+    [ -n "$dir" ] || continue
+    kb=$(fm_next_cache_size_kb "$dir")
+    FM_NEXT_CACHE_TOTAL_KB=$(( FM_NEXT_CACHE_TOTAL_KB + kb ))
+    printf '%s: would reclaim %s from %s\n' "$label" "$(fm_next_cache_human_kb "$kb")" "$dir"
+  done < <(fm_next_cache_dirs "$wt")
+}
+
+# Remove every reclaimable directory in <worktree>, printing one line each with
+# the space it gave back. Silent when there is nothing to reclaim, so a caller
+# that runs this on every teardown stays quiet on projects that never build.
+# Sets FM_NEXT_CACHE_TOTAL_KB to the reclaimed total.
+# Returns non-zero if any removal failed, having reported which - a failed
+# reclaim is worth seeing, but it is never a reason to fail the caller's own
+# work, so callers report it rather than abort on it.
+fm_next_cache_reclaim() {  # <worktree> <label>
+  local wt=$1 label=$2 dir kb rc=0
+  FM_NEXT_CACHE_TOTAL_KB=0
+  while IFS= read -r dir; do
+    [ -n "$dir" ] || continue
+    kb=$(fm_next_cache_size_kb "$dir")
+    if rm -rf -- "$dir" 2>/dev/null && [ ! -e "$dir" ]; then
+      FM_NEXT_CACHE_TOTAL_KB=$(( FM_NEXT_CACHE_TOTAL_KB + kb ))
+      printf '%s: reclaimed %s of Next.js build output from %s\n' \
+        "$label" "$(fm_next_cache_human_kb "$kb")" "$dir"
+    else
+      printf '%s: could not remove Next.js build output at %s\n' "$label" "$dir" >&2
+      rc=1
+    fi
+  done < <(fm_next_cache_dirs "$wt")
+  return "$rc"
+}

--- a/bin/fm-next-cache-lib.sh
+++ b/bin/fm-next-cache-lib.sh
@@ -58,93 +58,194 @@
 # Bytes-to-human, matching the units du -h prints, so a reclaim line reads the
 # same as what an operator would have measured by hand.
 fm_next_cache_human_kb() {  # <kilobytes>
-  local kb=${1:-0}
+  local kb=${1:-} tenths
+  case "$kb" in ''|*[!0-9]*) return 1 ;; esac
+  kb=$((10#$kb))
   if [ "$kb" -lt 1024 ]; then
     printf '%dK\n' "$kb"
   elif [ "$kb" -lt 1048576 ]; then
-    awk -v k="$kb" 'BEGIN { printf "%.1fM\n", k / 1024 }'
+    tenths=$(( (kb * 10 + 512) / 1024 ))
+    printf '%d.%dM\n' "$(( tenths / 10 ))" "$(( tenths % 10 ))"
   else
-    awk -v k="$kb" 'BEGIN { printf "%.1fG\n", k / 1048576 }'
+    tenths=$(( (kb * 10 + 524288) / 1048576 ))
+    printf '%d.%dG\n' "$(( tenths / 10 ))" "$(( tenths % 10 ))"
   fi
 }
 
-# Size of <dir> in kilobytes, or 0 when it cannot be measured. Reporting must
-# never be the thing that fails a reclaim, so an unreadable size is not an error.
+# Size of <dir> in kilobytes. An unreadable or malformed measurement is not zero.
 fm_next_cache_size_kb() {  # <dir>
-  local dir=$1 kb
-  kb=$(du -sk -- "$dir" 2>/dev/null | awk 'NR == 1 { print $1 }') || kb=
-  case "$kb" in
-    ''|*[!0-9]*) printf '0\n' ;;
-    *) printf '%s\n' "$kb" ;;
+  local dir=$1 output kb rest
+  output=$(du -sk -- "$dir" 2>/dev/null) || return 1
+  kb=${output%%[!0-9]*}
+  case "$kb" in ''|*[!0-9]*) return 1 ;; esac
+  rest=${output#"$kb"}
+  case "$rest" in
+    $'\t'*|' '*) ;;
+    *) return 1 ;;
   esac
+  printf '%s\n' "$kb"
 }
 
 # Is <parent> a Next.js app root? See proof 2 in the header.
 fm_next_cache_parent_is_next_app() {  # <parent-dir>
-  local parent=$1 ext
+  local parent=$1 ext grep_status
   for ext in js cjs mjs ts cts mts; do
     [ -f "$parent/next.config.$ext" ] && return 0
   done
   [ -f "$parent/package.json" ] || return 1
-  grep -Eq '"next"[[:space:]]*:' "$parent/package.json" 2>/dev/null
+  if grep -Eq '"next"[[:space:]]*:' "$parent/package.json" 2>/dev/null; then
+    return 0
+  else
+    grep_status=$?
+  fi
+  [ "$grep_status" -eq 1 ] && return 1
+  return 2
 }
 
 # Does <dir> pass both proofs, as a real directory inside repo <root>?
 fm_next_cache_is_build_output() {  # <repo-root> <dir>
-  local root=$1 dir=$2 real parent
+  local root=$1 dir=$2 real parent ignore_status app_status
+  if [ ! -e "$dir" ] && [ ! -L "$dir" ]; then return 2; fi
   [ -d "$dir" ] || return 1
   # A symlink is never removed: the target may live outside the worktree
   # entirely, and rm -rf on it would follow the operator's intent nowhere good.
   if [ -L "$dir" ]; then return 1; fi
-  real=$(CDPATH='' cd -- "$dir" 2>/dev/null && pwd -P) || return 1
+  real=$(CDPATH='' cd -- "$dir" 2>/dev/null && pwd -P) || return 2
   # Containment: only ever a path physically under the worktree we were given.
   case "$real" in
     "$root"/*) ;;
-    *) return 1 ;;
+    *) return 2 ;;
   esac
-  git -C "$root" check-ignore -q -- "$real" 2>/dev/null || return 1
-  parent=$(dirname -- "$real")
-  fm_next_cache_parent_is_next_app "$parent"
+  if git -C "$root" check-ignore -q -- "$real" 2>/dev/null; then
+    ignore_status=0
+  else
+    ignore_status=$?
+  fi
+  [ "$ignore_status" -eq 1 ] && return 1
+  [ "$ignore_status" -eq 0 ] || return 2
+  parent=${real%/*}
+  if fm_next_cache_parent_is_next_app "$parent"; then
+    return 0
+  else
+    app_status=$?
+  fi
+  [ "$app_status" -eq 1 ] && return 1
+  return 2
+}
+
+FM_NEXT_CACHE_PLAN=
+FM_NEXT_CACHE_TOTAL_KB=0
+FM_NEXT_CACHE_INSPECTION_ERROR=
+
+fm_next_cache_inspect() {  # <worktree>
+  local wt=$1 root tmp dir candidate_status kb record rc=0
+  FM_NEXT_CACHE_PLAN=
+  FM_NEXT_CACHE_TOTAL_KB=0
+  FM_NEXT_CACHE_INSPECTION_ERROR=
+  if ! root=$(CDPATH='' cd -- "$wt" 2>/dev/null && pwd -P); then
+    FM_NEXT_CACHE_INSPECTION_ERROR="cannot enter worktree: $wt"
+    return 1
+  fi
+  if ! git -C "$root" rev-parse --git-dir >/dev/null 2>&1; then
+    FM_NEXT_CACHE_INSPECTION_ERROR="not an inspectable git worktree: $wt"
+    return 1
+  fi
+  if ! tmp=$(umask 077; mktemp "${TMPDIR:-/tmp}/fm-next-cache-find.XXXXXX" 2>/dev/null); then
+    FM_NEXT_CACHE_INSPECTION_ERROR="cannot stage build-output discovery for: $wt"
+    return 1
+  fi
+  if ! find "$root" \( -name node_modules -o -name .git \) -prune -o \
+    -type d -name .next -print0 -prune > "$tmp" 2>/dev/null; then
+    FM_NEXT_CACHE_INSPECTION_ERROR="cannot walk worktree for build output: $wt"
+    rc=1
+  fi
+  if [ "$rc" -eq 0 ]; then
+    while IFS= read -r -d '' dir; do
+      case "$dir" in
+        ''|*$'\t'*|*$'\r'*|*$'\n'*)
+          FM_NEXT_CACHE_INSPECTION_ERROR="unsafe build-output path in worktree: $wt"
+          rc=1
+          break
+          ;;
+      esac
+      if fm_next_cache_is_build_output "$root" "$dir"; then
+        candidate_status=0
+      else
+        candidate_status=$?
+      fi
+      case "$candidate_status" in
+        0)
+          if ! kb=$(fm_next_cache_size_kb "$dir"); then
+            FM_NEXT_CACHE_INSPECTION_ERROR="cannot measure build output at: $dir"
+            rc=1
+            break
+          fi
+          record="$kb"$'\t'"$dir"
+          if [ -n "$FM_NEXT_CACHE_PLAN" ]; then
+            FM_NEXT_CACHE_PLAN="$FM_NEXT_CACHE_PLAN"$'\n'"$record"
+          else
+            FM_NEXT_CACHE_PLAN=$record
+          fi
+          FM_NEXT_CACHE_TOTAL_KB=$(( FM_NEXT_CACHE_TOTAL_KB + kb ))
+          ;;
+        1) ;;
+        *)
+          FM_NEXT_CACHE_INSPECTION_ERROR="cannot establish build-output eligibility at: $dir"
+          rc=1
+          break
+          ;;
+      esac
+    done < "$tmp"
+  fi
+  if ! rm -f -- "$tmp"; then
+    FM_NEXT_CACHE_INSPECTION_ERROR="cannot clear build-output discovery state for: $wt"
+    rc=1
+  fi
+  if [ "$rc" -ne 0 ]; then
+    FM_NEXT_CACHE_PLAN=
+    FM_NEXT_CACHE_TOTAL_KB=0
+    return 1
+  fi
+  return 0
 }
 
 # Print each reclaimable Next.js build-output directory in <worktree>, one
-# absolute path per line. Prints nothing (exit 0) when the worktree is missing,
-# is not a git repo, or holds none.
+# absolute path per line. An incomplete inspection returns non-zero.
 fm_next_cache_dirs() {  # <worktree>
-  local wt=$1 root dir
-  root=$(CDPATH='' cd -- "$wt" 2>/dev/null && pwd -P) || return 0
-  git -C "$root" rev-parse --git-dir >/dev/null 2>&1 || return 0
-  while IFS= read -r dir; do
-    [ -n "$dir" ] || continue
-    fm_next_cache_is_build_output "$root" "$dir" || continue
-    printf '%s\n' "$dir"
-  done < <(find "$root" \( -name node_modules -o -name .git \) -prune -o \
-    -type d -name .next -print -prune 2>/dev/null)
+  local wt=$1 dir
+  fm_next_cache_inspect "$wt" || return 1
+  while IFS=$'\t' read -r _ dir; do
+    [ -n "$dir" ] && printf '%s\n' "$dir"
+  done <<EOT
+$FM_NEXT_CACHE_PLAN
+EOT
 }
 
 # Total kilobytes <worktree> holds, without printing or removing anything.
 # Sets FM_NEXT_CACHE_TOTAL_KB and prints it.
 fm_next_cache_total_kb() {  # <worktree>
-  local wt=$1 dir
-  FM_NEXT_CACHE_TOTAL_KB=0
-  while IFS= read -r dir; do
-    [ -n "$dir" ] || continue
-    FM_NEXT_CACHE_TOTAL_KB=$(( FM_NEXT_CACHE_TOTAL_KB + $(fm_next_cache_size_kb "$dir") ))
-  done < <(fm_next_cache_dirs "$wt")
+  local wt=$1
+  fm_next_cache_inspect "$wt" || return 1
   printf '%s\n' "$FM_NEXT_CACHE_TOTAL_KB"
 }
 
 # Report what <worktree> holds without removing anything. One line per
 # directory; nothing when there is none. Sets FM_NEXT_CACHE_TOTAL_KB.
 fm_next_cache_report() {  # <worktree> <label>
-  local wt=$1 label=$2 dir kb
-  FM_NEXT_CACHE_TOTAL_KB=0
-  while IFS= read -r dir; do
-    [ -n "$dir" ] || continue
-    kb=$(fm_next_cache_size_kb "$dir")
-    FM_NEXT_CACHE_TOTAL_KB=$(( FM_NEXT_CACHE_TOTAL_KB + kb ))
-    printf '%s: would reclaim %s from %s\n' "$label" "$(fm_next_cache_human_kb "$kb")" "$dir"
-  done < <(fm_next_cache_dirs "$wt")
+  local wt=$1 label=$2 dir kb human
+  if ! fm_next_cache_inspect "$wt"; then
+    printf '%s: could not inspect Next.js build output (%s)\n' \
+      "$label" "$FM_NEXT_CACHE_INSPECTION_ERROR" >&2
+    return 1
+  fi
+  while IFS=$'\t' read -r kb dir; do
+    if [ -n "$dir" ]; then
+      human=$(fm_next_cache_human_kb "$kb") || return 1
+      printf '%s: would reclaim %s from %s\n' "$label" "$human" "$dir"
+    fi
+  done <<EOT
+$FM_NEXT_CACHE_PLAN
+EOT
 }
 
 # Remove every reclaimable directory in <worktree>, printing one line each with
@@ -155,19 +256,28 @@ fm_next_cache_report() {  # <worktree> <label>
 # reclaim is worth seeing, but it is never a reason to fail the caller's own
 # work, so callers report it rather than abort on it.
 fm_next_cache_reclaim() {  # <worktree> <label>
-  local wt=$1 label=$2 dir kb rc=0
+  local wt=$1 label=$2 dir kb human rc=0 plan
+  if ! fm_next_cache_inspect "$wt"; then
+    printf '%s: could not inspect Next.js build output (%s)\n' \
+      "$label" "$FM_NEXT_CACHE_INSPECTION_ERROR" >&2
+    return 1
+  fi
+  plan=$FM_NEXT_CACHE_PLAN
   FM_NEXT_CACHE_TOTAL_KB=0
-  while IFS= read -r dir; do
-    [ -n "$dir" ] || continue
-    kb=$(fm_next_cache_size_kb "$dir")
-    if rm -rf -- "$dir" 2>/dev/null && [ ! -e "$dir" ]; then
-      FM_NEXT_CACHE_TOTAL_KB=$(( FM_NEXT_CACHE_TOTAL_KB + kb ))
-      printf '%s: reclaimed %s of Next.js build output from %s\n' \
-        "$label" "$(fm_next_cache_human_kb "$kb")" "$dir"
-    else
-      printf '%s: could not remove Next.js build output at %s\n' "$label" "$dir" >&2
-      rc=1
+  while IFS=$'\t' read -r kb dir; do
+    if [ -n "$dir" ]; then
+      human=$(fm_next_cache_human_kb "$kb") || return 1
+      if rm -rf -- "$dir" 2>/dev/null && [ ! -e "$dir" ] && [ ! -L "$dir" ]; then
+        FM_NEXT_CACHE_TOTAL_KB=$(( FM_NEXT_CACHE_TOTAL_KB + kb ))
+        printf '%s: reclaimed %s of Next.js build output from %s\n' \
+          "$label" "$human" "$dir"
+      else
+        printf '%s: could not remove Next.js build output at %s\n' "$label" "$dir" >&2
+        rc=1
+      fi
     fi
-  done < <(fm_next_cache_dirs "$wt")
+  done <<EOT
+$plan
+EOT
   return "$rc"
 }

--- a/bin/fm-next-cache-sweep.sh
+++ b/bin/fm-next-cache-sweep.sh
@@ -52,17 +52,34 @@
 # pool lookup failed (already reported), 2 on a usage or environment error.
 set -u
 
-SCRIPT_DIR=$(CDPATH='' cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
-FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd -P)}"
+case "${BASH_SOURCE[0]}" in
+  */*) script_parent=${BASH_SOURCE[0]%/*} ;;
+  *) script_parent=. ;;
+esac
+if ! SCRIPT_DIR=$(CDPATH='' cd -- "$script_parent" 2>/dev/null && pwd -P); then
+  printf 'fm-next-cache-sweep: cannot resolve the script directory\n' >&2
+  exit 2
+fi
+if [ -n "${FM_ROOT_OVERRIDE:-}" ]; then
+  FM_ROOT=$FM_ROOT_OVERRIDE
+elif ! FM_ROOT=$(CDPATH='' cd -- "$SCRIPT_DIR/.." 2>/dev/null && pwd -P); then
+  printf 'fm-next-cache-sweep: cannot resolve the firstmate root\n' >&2
+  exit 2
+fi
 FM_HOME="${FM_HOME:-$FM_ROOT}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 PROJECTS="${FM_PROJECTS_OVERRIDE:-$FM_HOME/projects}"
 
+if [ ! -r "$SCRIPT_DIR/fm-next-cache-lib.sh" ] \
+  || [ ! -r "$SCRIPT_DIR/fm-secondmate-registry-lib.sh" ]; then
+  printf 'fm-next-cache-sweep: required libraries are unreadable\n' >&2
+  exit 2
+fi
 # shellcheck source=bin/fm-next-cache-lib.sh
-. "$SCRIPT_DIR/fm-next-cache-lib.sh"
+. "$SCRIPT_DIR/fm-next-cache-lib.sh" || exit 2
 # shellcheck source=bin/fm-secondmate-registry-lib.sh
-. "$SCRIPT_DIR/fm-secondmate-registry-lib.sh"
+. "$SCRIPT_DIR/fm-secondmate-registry-lib.sh" || exit 2
 
 sweep_die() { printf 'fm-next-cache-sweep: %s\n' "$1" >&2; exit 2; }
 
@@ -115,20 +132,107 @@ sweep_resolve_directory() {
 }
 
 sweep_path_identity() {  # <path>
-  local resolved
+  local resolved platform identity device inode
   resolved=$(CDPATH='' cd -- "$1" 2>/dev/null && pwd -P) || return 1
-  if [ "$(uname)" = Darwin ]; then
-    stat -L -f '%d:%i' "$resolved" 2>/dev/null
+  platform=$(uname 2>/dev/null) || return 1
+  if [ "$platform" = Darwin ]; then
+    identity=$(stat -L -f '%d:%i' "$resolved" 2>/dev/null) || return 1
   else
-    stat -L -c '%d:%i' "$resolved" 2>/dev/null
+    identity=$(stat -L -c '%d:%i' "$resolved" 2>/dev/null) || return 1
   fi
+  device=${identity%%:*}
+  inode=${identity#*:}
+  [ "$device:$inode" = "$identity" ] || return 1
+  case "$device$inode" in ''|*[!0-9]*) return 1 ;; esac
+  printf '%s\n' "$identity"
+}
+
+sweep_read_text_file() {  # <path>
+  python3 - "$1" <<'PY'
+import os, stat, sys
+
+flags = os.O_RDONLY
+if hasattr(os, "O_NOFOLLOW"):
+    flags |= os.O_NOFOLLOW
+try:
+    fd = os.open(sys.argv[1], flags)
+    try:
+        if not stat.S_ISREG(os.fstat(fd).st_mode):
+            raise OSError()
+        chunks = []
+        while True:
+            chunk = os.read(fd, 65536)
+            if not chunk:
+                break
+            chunks.append(chunk)
+    finally:
+        os.close(fd)
+except OSError:
+    sys.exit(1)
+data = b"".join(chunks)
+if b"\0" in data:
+    sys.exit(1)
+sys.stdout.buffer.write(data)
+PY
+}
+
+sweep_task_meta_files() {  # <state-dir>
+  python3 - "$1" <<'PY'
+import os, sys
+
+try:
+    entries = list(os.scandir(sys.argv[1]))
+except OSError:
+    sys.exit(1)
+paths = []
+for entry in entries:
+    if entry.name.endswith(".meta"):
+        path = entry.path
+        if any(c in path for c in "\t\r\n"):
+            sys.exit(1)
+        paths.append(path)
+for path in sorted(paths):
+    print(path)
+PY
+}
+
+sweep_project_directories() {  # <projects-dir>
+  python3 - "$1" <<'PY'
+import os, sys
+
+try:
+    entries = list(os.scandir(sys.argv[1]))
+except OSError:
+    sys.exit(1)
+paths = []
+for entry in entries:
+    try:
+        is_dir = entry.is_dir()
+    except OSError:
+        sys.exit(1)
+    if is_dir:
+        path = entry.path
+        if any(c in path for c in "\t\r\n"):
+            sys.exit(1)
+        paths.append(path)
+for path in sorted(paths):
+    print(path)
+PY
 }
 
 sweep_task_record_state_dirs() {
-  local registry="$DATA/secondmates.md" registry_contents line home resolved_home
-  TASK_STATE_DIRS=$STATE
-  if [ ! -f "$registry" ] || [ -L "$registry" ] || [ ! -r "$registry" ] \
-    || ! registry_contents=$(cat "$registry" 2>/dev/null); then
+  local registry="$DATA/secondmates.md" registry_contents line home resolved_home resolved_state
+  if ! resolved_state=$(sweep_resolve_directory "$STATE"); then
+    sweep_incomplete "cannot resolve task state directory: $STATE"
+    return
+  fi
+  case "$resolved_state" in *$'\t'*|*$'\r'*|*$'\n'*)
+    sweep_incomplete "unsafe task state directory: $STATE"
+    return
+    ;;
+  esac
+  TASK_STATE_DIRS=$resolved_state
+  if ! registry_contents=$(sweep_read_text_file "$registry"); then
     sweep_incomplete "cannot read secondmate registry: $registry"
     return
   fi
@@ -141,6 +245,11 @@ sweep_task_record_state_dirs() {
         fi
         if [ "$SECONDMATE_REGISTRY_REMOTE" -eq 0 ]; then
           home=$SECONDMATE_REGISTRY_HOME
+          case "$home" in *$'\t'*|*$'\r'*|*$'\n'*)
+            sweep_incomplete "unsafe registered local secondmate home: $home"
+            return
+            ;;
+          esac
           case "$home" in
             /*) ;;
             *)
@@ -152,6 +261,11 @@ sweep_task_record_state_dirs() {
             sweep_incomplete "cannot resolve registered local secondmate home: $home"
             return
           fi
+          case "$resolved_home" in *$'\t'*|*$'\r'*|*$'\n'*)
+            sweep_incomplete "unsafe resolved local secondmate home: $home"
+            return
+            ;;
+          esac
           TASK_STATE_DIRS="$TASK_STATE_DIRS"$'\n'"$resolved_home/state"
         fi
         ;;
@@ -164,7 +278,8 @@ EOT
 TASK_WORKTREES=
 TASK_WORKTREE_IDENTITIES=
 sweep_load_task_worktrees() {
-  local state_dir meta meta_contents worktree kind remote_host identity
+  local state_dir metas meta meta_contents worktree kind remote_host identity line
+  local seen_worktree seen_kind seen_remote_host
   TASK_WORKTREES=
   TASK_WORKTREE_IDENTITIES=
   sweep_task_record_state_dirs || return 1
@@ -177,18 +292,54 @@ sweep_load_task_worktrees() {
       sweep_incomplete "cannot read task state directory: $state_dir"
       return
     fi
-    for meta in "$state_dir"/*.meta; do
-      if [ -e "$meta" ] || [ -L "$meta" ]; then
-        if [ ! -f "$meta" ] || [ -L "$meta" ] || [ ! -r "$meta" ] \
-          || ! meta_contents=$(cat "$meta" 2>/dev/null); then
+    if ! metas=$(sweep_task_meta_files "$state_dir"); then
+      sweep_incomplete "cannot enumerate task metadata in: $state_dir"
+      return
+    fi
+    while IFS= read -r meta; do
+      if [ -n "$meta" ]; then
+        if ! meta_contents=$(sweep_read_text_file "$meta"); then
           sweep_incomplete "cannot read task metadata: $meta"
           return
         fi
-        worktree=$(printf '%s\n' "$meta_contents" | sed -n 's/^worktree=//p')
-        kind=$(printf '%s\n' "$meta_contents" | sed -n 's/^kind=//p')
-        remote_host=$(printf '%s\n' "$meta_contents" | sed -n 's/^remote_host=//p')
+        worktree=
+        kind=
+        remote_host=
+        seen_worktree=0
+        seen_kind=0
+        seen_remote_host=0
+        while IFS= read -r line || [ -n "$line" ]; do
+          case "$line" in
+            worktree=*)
+              [ "$seen_worktree" -eq 0 ] || {
+                sweep_incomplete "task metadata has duplicate worktree fields: $meta"
+                return
+              }
+              worktree=${line#worktree=}
+              seen_worktree=1
+              ;;
+            kind=*)
+              [ "$seen_kind" -eq 0 ] || {
+                sweep_incomplete "task metadata has duplicate kind fields: $meta"
+                return
+              }
+              kind=${line#kind=}
+              seen_kind=1
+              ;;
+            remote_host=*)
+              [ "$seen_remote_host" -eq 0 ] || {
+                sweep_incomplete "task metadata has duplicate remote_host fields: $meta"
+                return
+              }
+              remote_host=${line#remote_host=}
+              seen_remote_host=1
+              ;;
+          esac
+        done <<EOT
+$meta_contents
+EOT
         case "$worktree" in
-          ''|*$'\n'*)
+          ''|*$'\t'*|*$'\r'*|*$'\n'*)
             sweep_incomplete "task metadata has no single worktree: $meta"
             return
             ;;
@@ -199,7 +350,7 @@ sweep_load_task_worktrees() {
             ;;
         esac
         case "$kind$remote_host" in
-          *$'\n'*)
+          *$'\t'*|*$'\r'*|*$'\n'*)
             sweep_incomplete "task metadata has ambiguous placement: $meta"
             return
             ;;
@@ -223,7 +374,9 @@ sweep_load_task_worktrees() {
           fi
         fi
       fi
-    done
+    done <<EOT
+$metas
+EOT
   done <<EOT
 $TASK_STATE_DIRS
 EOT
@@ -231,14 +384,21 @@ EOT
 
 # Does any task record name <path> as its worktree?
 sweep_task_owns() {  # <path>
-  local path=$1 path_identity
-  if [ -n "$TASK_WORKTREES" ] && printf '%s\n' "$TASK_WORKTREES" | grep -Fxq -- "$path"; then
-    return 0
+  local path=$1 path_identity recorded
+  if [ -n "$TASK_WORKTREES" ]; then
+    while IFS= read -r recorded; do
+      [ "$recorded" = "$path" ] && return 0
+    done <<EOT
+$TASK_WORKTREES
+EOT
   fi
   path_identity=$(sweep_path_identity "$path") || return 2
-  if [ -n "$TASK_WORKTREE_IDENTITIES" ] \
-    && printf '%s\n' "$TASK_WORKTREE_IDENTITIES" | grep -Fxq -- "$path_identity"; then
-    return 0
+  if [ -n "$TASK_WORKTREE_IDENTITIES" ]; then
+    while IFS= read -r recorded; do
+      [ "$recorded" = "$path_identity" ] && return 0
+    done <<EOT
+$TASK_WORKTREE_IDENTITIES
+EOT
   fi
   return 1
 }
@@ -247,9 +407,14 @@ sweep_task_owns() {  # <path>
 # treehouse resolves the pool from the working directory, and reading pool
 # status changes nothing in the clone.
 sweep_pool_entries() {  # <project-dir>
-  local raw
-  raw=$(cd "$1" && treehouse status --json 2>/dev/null) || return 1
-  printf '%s\n' "$raw" | python3 -c '
+  local tmp parse_status=0
+  tmp=$(umask 077; mktemp "${TMPDIR:-/tmp}/fm-next-cache-pool.XXXXXX" 2>/dev/null) \
+    || return 1
+  if ! (cd "$1" && treehouse status --json > "$tmp" 2>/dev/null); then
+    rm -f -- "$tmp" || true
+    return 1
+  fi
+  python3 - "$tmp" <<'PY' || parse_status=$?
 import json, sys
 
 # Anything this cannot read as a list of pool entries exits non-zero, so the
@@ -257,11 +422,15 @@ import json, sys
 # unparseable pool is not an empty pool, and it is certainly not a pool of
 # unowned copies.
 try:
-    pool = json.load(sys.stdin)
-except ValueError:
+    raw = open(sys.argv[1], "rb").read()
+    if b"\0" in raw:
+        raise ValueError()
+    pool = json.loads(raw.decode("utf-8"))
+except (OSError, UnicodeError, ValueError):
     sys.exit(1)
 if not isinstance(pool, list):
     sys.exit(1)
+rows = []
 for entry in pool:
     if not isinstance(entry, dict):
         sys.exit(1)
@@ -271,68 +440,87 @@ for entry in pool:
         sys.exit(1)
     if not isinstance(path, str) or not path or not path.startswith("/"):
         sys.exit(1)
-    if any(c in status or c in path for c in "\t\r\n"):
+    if any(c in status or c in path for c in "\0\t\r\n"):
         sys.exit(1)
+    rows.append((status, path))
+for status, path in rows:
     print("%s\t%s" % (status, path))
-'
+PY
+  if ! rm -f -- "$tmp"; then return 1; fi
+  return "$parse_status"
 }
 
-# Why <worktree> may not be swept, printed as "<class><tab><reason>"; empty when
-# it may be. `owned` is a complete answer for that copy. `undetermined` makes
-# the project's preflight incomplete, so none of that project's copies may be
-# touched.
+# Classify why <worktree> may not be swept in SWEEP_OWNER_CLASS and
+# SWEEP_OWNER_REASON. `owned` is a complete answer; `undetermined` makes the
+# project's preflight incomplete.
 sweep_unowned_reason() {  # <status> <worktree>
   local status=$1 wt=$2 task_ownership
+  SWEEP_OWNER_CLASS=free
+  SWEEP_OWNER_REASON=
   # Only the pool's own word for "available" clears this check. Any other
   # value - in-use, a status this version of treehouse does not print, or none
   # at all - means ownership was not established, which is not the same as
   # establishing that there is no owner.
   if [ "$status" = in-use ]; then
-    printf 'owned\tin use by the pool\n'
+    SWEEP_OWNER_CLASS=owned
+    SWEEP_OWNER_REASON="in use by the pool"
     return 0
   fi
   if [ "$status" != available ]; then
-    printf 'undetermined\tthe pool did not report it available\n'
+    SWEEP_OWNER_CLASS=undetermined
+    SWEEP_OWNER_REASON="the pool did not report it available"
     return 0
   fi
   sweep_task_owns "$wt"
   task_ownership=$?
   case "$task_ownership" in
     0)
-      printf 'owned\tstill claimed by a task record\n'
+      SWEEP_OWNER_CLASS=owned
+      SWEEP_OWNER_REASON="still claimed by a task record"
       return 0
       ;;
     2)
-      printf 'undetermined\tcannot compare it with task-record worktrees\n'
+      SWEEP_OWNER_CLASS=undetermined
+      SWEEP_OWNER_REASON="cannot compare it with task-record worktrees"
       return 0
       ;;
   esac
   if ! git -C "$wt" rev-parse --git-dir >/dev/null 2>&1; then
-    printf 'undetermined\tnot an inspectable git worktree\n'
+    SWEEP_OWNER_CLASS=undetermined
+    SWEEP_OWNER_REASON="not an inspectable git worktree"
     return 0
   fi
   local dirty stashes
   if ! dirty=$(git -C "$wt" status --porcelain 2>/dev/null); then
-    printf 'undetermined\tcannot inspect it for uncommitted changes\n'
+    SWEEP_OWNER_CLASS=undetermined
+    SWEEP_OWNER_REASON="cannot inspect it for uncommitted changes"
     return 0
   fi
   if [ -n "$dirty" ]; then
-    printf 'owned\thas uncommitted changes\n'
+    SWEEP_OWNER_CLASS=owned
+    SWEEP_OWNER_REASON="has uncommitted changes"
     return 0
   fi
   if ! stashes=$(git -C "$wt" stash list 2>/dev/null); then
-    printf 'undetermined\tcannot inspect it for stashes\n'
+    SWEEP_OWNER_CLASS=undetermined
+    SWEEP_OWNER_REASON="cannot inspect it for stashes"
     return 0
   fi
   if [ -n "$stashes" ]; then
-    printf 'owned\thas stashed work\n'
+    SWEEP_OWNER_CLASS=owned
+    SWEEP_OWNER_REASON="has stashed work"
     return 0
   fi
-  printf '\n'
+  return 0
 }
 
+SWEEP_PROJECT_PLAN=
+SWEEP_PROJECT_INSPECTED=0
 sweep_project_plan() {  # <entries>
-  local entries=$1 status wt verdict class reason plan='' record
+  local entries=$1 status wt record pool_identity recorded_identity
+  local pool_identities=
+  SWEEP_PROJECT_PLAN=
+  SWEEP_PROJECT_INSPECTED=0
   while IFS=$'\t' read -r status wt; do
     if [ -n "$status$wt" ]; then
       if [ -z "$status" ] || [ -z "$wt" ]; then
@@ -343,46 +531,69 @@ sweep_project_plan() {  # <entries>
         sweep_incomplete "pool worktree is not an inspectable directory: $wt"
         return
       fi
-      verdict=$(sweep_unowned_reason "$status" "$wt")
-      if [ -n "$verdict" ]; then
-        class=${verdict%%	*}
-        reason=${verdict#*	}
-        if [ "$class" = undetermined ]; then
-          sweep_incomplete "$wt could not be assessed ($reason)"
-          return
-        fi
-        record="owned"$'\t'"$reason"$'\t'"$wt"
-      else
-        record="free"$'\t'"-"$'\t'"$wt"
+      if ! pool_identity=$(sweep_path_identity "$wt"); then
+        sweep_incomplete "pool worktree identity cannot be established: $wt"
+        return
       fi
-      if [ -n "$plan" ]; then
-        plan="$plan"$'\n'"$record"
+      if [ -n "$pool_identities" ]; then
+        while IFS= read -r recorded_identity; do
+          if [ "$recorded_identity" = "$pool_identity" ]; then
+            sweep_incomplete "pool entries name a duplicate filesystem copy: $wt"
+            return
+          fi
+        done <<EOT
+$pool_identities
+EOT
+        pool_identities="$pool_identities"$'\n'"$pool_identity"
       else
-        plan=$record
+        pool_identities=$pool_identity
+      fi
+      sweep_unowned_reason "$status" "$wt"
+      if [ "$SWEEP_OWNER_CLASS" = undetermined ]; then
+        sweep_incomplete "$wt could not be assessed ($SWEEP_OWNER_REASON)"
+        return
+      fi
+      if ! fm_next_cache_inspect "$wt"; then
+        sweep_incomplete "$wt build output could not be inspected ($FM_NEXT_CACHE_INSPECTION_ERROR)"
+        return
+      fi
+      SWEEP_PROJECT_INSPECTED=$(( SWEEP_PROJECT_INSPECTED + 1 ))
+      if [ "$SWEEP_OWNER_CLASS" = owned ]; then
+        record="owned"$'\t'"$SWEEP_OWNER_REASON"$'\t'"$FM_NEXT_CACHE_TOTAL_KB"$'\t'"$wt"
+      else
+        record="free"$'\t'"-"$'\t'"$FM_NEXT_CACHE_TOTAL_KB"$'\t'"$wt"
+      fi
+      if [ -n "$SWEEP_PROJECT_PLAN" ]; then
+        SWEEP_PROJECT_PLAN="$SWEEP_PROJECT_PLAN"$'\n'"$record"
+      else
+        SWEEP_PROJECT_PLAN=$record
       fi
     fi
   done <<EOT
 $entries
 EOT
-  printf '%s\n' "$plan"
 }
 
 sweep_apply_project_plan() {  # <plan>
-  local plan=$1 action reason wt
-  while IFS=$'\t' read -r action reason wt; do
+  local plan=$1 action reason planned_kb wt apply_status
+  while IFS=$'\t' read -r action reason planned_kb wt; do
     if [ -n "$action" ]; then
       if [ "$action" = owned ]; then
-        fm_next_cache_total_kb "$wt" >/dev/null
-        if [ "$FM_NEXT_CACHE_TOTAL_KB" -gt 0 ]; then
+        if [ "$planned_kb" -gt 0 ]; then
           printf 'sweep: skipped %s (%s), holding %s\n' \
-            "$wt" "$reason" "$(fm_next_cache_human_kb "$FM_NEXT_CACHE_TOTAL_KB")"
+            "$wt" "$reason" "$(fm_next_cache_human_kb "$planned_kb")"
           SKIPPED=$(( SKIPPED + 1 ))
         fi
       else
+        apply_status=0
         if [ "$DRY_RUN" = 1 ]; then
-          fm_next_cache_report "$wt" "sweep" || RC=1
+          fm_next_cache_report "$wt" "sweep" || apply_status=$?
         else
-          fm_next_cache_reclaim "$wt" "sweep" || RC=1
+          fm_next_cache_reclaim "$wt" "sweep" || apply_status=$?
+        fi
+        if [ "$apply_status" -ne 0 ]; then
+          RC=1
+          FAILED=$(( FAILED + 1 ))
         fi
         if [ "$FM_NEXT_CACHE_TOTAL_KB" -gt 0 ]; then
           TOTAL_KB=$(( TOTAL_KB + FM_NEXT_CACHE_TOTAL_KB ))
@@ -396,33 +607,40 @@ EOT
 }
 
 sweep_project() {  # <project>
-  local project=$1 project_real entries plan
+  local project=$1 project_real entries
+  SWEEP_PROJECT_INSPECTED=0
+  SWEEP_PROJECT_COMPLETE=0
   if ! project_real=$(sweep_resolve_directory "$project"); then
     sweep_incomplete "cannot enter project: $project"
+    return
+  fi
+  if ! git -C "$project_real" rev-parse --git-dir >/dev/null 2>&1; then
+    sweep_incomplete "cannot inspect project Git metadata: $project_real"
     return
   fi
   if ! entries=$(sweep_pool_entries "$project_real"); then
     sweep_incomplete "cannot read the worktree pool for $project_real"
     return
   fi
-  if ! plan=$(sweep_project_plan "$entries"); then
+  if ! sweep_project_plan "$entries"; then
     return 1
   fi
-  sweep_apply_project_plan "$plan"
+  sweep_apply_project_plan "$SWEEP_PROJECT_PLAN"
+  SWEEP_PROJECT_COMPLETE=1
 }
 
 if [ "${#PROJECT_ARGS[@]}" -gt 0 ]; then
   TARGETS=("${PROJECT_ARGS[@]}")
 else
   TARGETS=()
-  for dir in "$PROJECTS"/*/; do
-    if [ -d "$dir" ]; then
-      dir=${dir%/}
-      if git -C "$dir" rev-parse --git-dir >/dev/null 2>&1; then
-        TARGETS+=("$dir")
-      fi
-    fi
-  done
+  if ! project_dirs=$(sweep_project_directories "$PROJECTS"); then
+    sweep_die "cannot enumerate project clones under $PROJECTS"
+  fi
+  while IFS= read -r dir; do
+    [ -n "$dir" ] && TARGETS+=("$dir")
+  done <<EOT
+$project_dirs
+EOT
 fi
 
 [ "${#TARGETS[@]}" -gt 0 ] || sweep_die "no project clones to sweep under $PROJECTS"
@@ -434,10 +652,18 @@ TOTAL_KB=0
 RECLAIMED=0
 SKIPPED=0
 INCOMPLETE=0
+INSPECTED=0
+FAILED=0
+COMPLETE_PROJECTS=0
 for project in "${TARGETS[@]}"; do
-  if ! sweep_project "$project"; then
+  sweep_project "$project"
+  project_status=$?
+  INSPECTED=$(( INSPECTED + SWEEP_PROJECT_INSPECTED ))
+  if [ "$project_status" -ne 0 ]; then
     RC=1
     INCOMPLETE=$(( INCOMPLETE + 1 ))
+  elif [ "$SWEEP_PROJECT_COMPLETE" -eq 1 ]; then
+    COMPLETE_PROJECTS=$(( COMPLETE_PROJECTS + 1 ))
   fi
 done
 
@@ -454,21 +680,38 @@ if [ "$INCOMPLETE" -gt 0 ]; then
   INCOMPLETE_NOTE="; $(sweep_projects "$INCOMPLETE") could not be inspected"
 fi
 
+FAILED_NOTE=
+if [ "$FAILED" -gt 0 ]; then
+  FAILED_NOTE="; $(sweep_copies "$FAILED") could not be processed"
+fi
+
 if [ "$RECLAIMED" -eq 0 ]; then
-  if [ "$SKIPPED" -gt 0 ]; then
+  if [ "$FAILED" -gt 0 ]; then
+    printf 'sweep: reclamation incomplete%s%s\n' "$FAILED_NOTE" "$INCOMPLETE_NOTE"
+  elif [ "$SKIPPED" -gt 0 ]; then
     printf 'sweep: nothing to reclaim; %s were skipped as owned (listed above)%s\n' \
       "$(sweep_copies "$SKIPPED")" "$INCOMPLETE_NOTE"
   elif [ "$INCOMPLETE" -gt 0 ]; then
-    printf 'sweep: nothing to reclaim in inspected projects%s\n' "$INCOMPLETE_NOTE"
+    if [ "$INSPECTED" -eq 0 ]; then
+      printf 'sweep: no copy was completely inspected%s\n' "$INCOMPLETE_NOTE"
+    else
+      printf 'sweep: nothing to reclaim in %s%s\n' \
+        "$(sweep_copies "$INSPECTED")" "$INCOMPLETE_NOTE"
+    fi
+  elif [ "$INSPECTED" -eq 0 ]; then
+    printf 'sweep: nothing to reclaim; %s contained no copies\n' \
+      "$(sweep_projects "$COMPLETE_PROJECTS")"
   else
     printf 'sweep: nothing to reclaim; no idle copy holds Next.js build output\n'
   fi
 elif [ "$DRY_RUN" = 1 ]; then
-  printf 'sweep: would reclaim %s from %s%s\n' \
-    "$(fm_next_cache_human_kb "$TOTAL_KB")" "$(sweep_copies "$RECLAIMED")" "$INCOMPLETE_NOTE"
+  printf 'sweep: would reclaim %s from %s%s%s\n' \
+    "$(fm_next_cache_human_kb "$TOTAL_KB")" "$(sweep_copies "$RECLAIMED")" \
+    "$FAILED_NOTE" "$INCOMPLETE_NOTE"
 else
-  printf 'sweep: reclaimed %s from %s%s\n' \
-    "$(fm_next_cache_human_kb "$TOTAL_KB")" "$(sweep_copies "$RECLAIMED")" "$INCOMPLETE_NOTE"
+  printf 'sweep: reclaimed %s from %s%s%s\n' \
+    "$(fm_next_cache_human_kb "$TOTAL_KB")" "$(sweep_copies "$RECLAIMED")" \
+    "$FAILED_NOTE" "$INCOMPLETE_NOTE"
 fi
 
 exit "$RC"

--- a/bin/fm-next-cache-sweep.sh
+++ b/bin/fm-next-cache-sweep.sh
@@ -67,176 +67,204 @@
 # boundary, and summary selector. That input-oriented trace includes implicit
 # omission paths that a syntax search for `continue` cannot find.
 #
-# Every verdict below carries both the observation it rests on and its falsifier.
-# A falsifier states the exact condition that would make the direction unsafe;
-# it is not a claim that a command name alone proves the needed property.
+# Every verdict below carries both the observation it rests on and a concrete
+# falsifier: a case that could satisfy the named check while still violating the
+# property that check is meant to establish. Restating the check as "a non-X"
+# is not evidence that the check establishes the broader property.
 #
 # Sweep entry and global ownership inputs:
 # - `bin/fm-next-cache-sweep.sh: startup -> BASH_SOURCE, FM_* overrides, cd,
 #   readable library predicates, and source`. Checked: every failed directory
 #   command substitution is tested, both library paths must pass `-r`, and a
-#   nonzero source status exits 2 before deletion authority exists. Falsifier:
-#   any failed resolution or library load reaches argument processing with exit 0.
+#   nonzero source status exits before target construction. Falsifier: an
+#   override whose parent cannot be searched, or a readable library whose source
+#   command returns nonzero, reaches target construction with deletion authority.
 # - `bin/fm-next-cache-sweep.sh: argument loops -> "$@"`. Checked: the option
 #   case accepts only `--dry-run`, rejects every other dash-prefixed value with
-#   exit 2, and retains non-options verbatim for the project-root proof. Converted
-#   wrong verdict: repository reachability alone was insufficient; every retained
-#   path must now physically equal its `--show-toplevel`. Falsifier: an explicit
-#   subdirectory reaches pool lookup or weakens the clone-exclusion comparison.
+#   exit 2, and retains non-options verbatim. Falsifier: `--unknown` is retained
+#   as a project, or `-- /path` loses the literal project path before validation.
+# - `bin/fm-next-cache-sweep.sh: target construction -> PROJECT_ARGS,
+#   sweep_project_directories, and TARGETS`. Checked: today both sources become
+#   indistinguishable plain paths. Wrong verdict found here: a valid explicit
+#   project therefore inherits the deletion authority intended only for default
+#   discovery. Required: every target carries its origin-derived authority and
+#   only a positively `reclaim`-eligible target may reach removal. Falsifier: an
+#   explicit primary-clone argument with one available clean pool copy removes
+#   that copy instead of recording a report-only terminal verdict.
 # - `bin/fm-next-cache-sweep.sh: command preflight -> command -v treehouse and
 #   python3`. Checked: absence exits 2, while every later invocation separately
-#   checks the command's status. Falsifier: a missing command falls through, or a
-#   found command's later nonzero status is normalized to usable output.
+#   checks the command's status. Falsifier: a treehouse shim is found, emits valid
+#   `available` JSON, then exits 1, yet its row reaches candidate planning.
 # - `bin/fm-next-cache-sweep.sh: sweep_task_record_state_dirs ->
 #   sweep_resolve_directory "$STATE"`. Checked: physical resolution requires a
 #   searchable directory and failure propagates through the checked loader to
-#   `sweep_die`. Falsifier: an absent or unresolvable primary state directory
-#   contributes an empty ownership set.
+#   `sweep_die`. Falsifier: `$STATE` is a dangling symlink and the sweep proceeds
+#   with an empty primary task-record set.
 # - `bin/fm-next-cache-sweep.sh: sweep_task_record_state_dirs ->
 #   sweep_read_text_file "$DATA/secondmates.md"`. Checked: the reader requires a
 #   regular non-symlink, stages a complete byte-for-byte read, rejects NUL, and
 #   propagates failure globally; the absent, unreadable, and NUL tests exercise
-#   those branches. Falsifier: any registry read failure yields empty registry
-#   text and task enumeration continues.
+#   those branches. Falsifier: the registry yields one complete local record and
+#   then an I/O error, but that partial prefix is accepted as the full registry.
 # - `bin/fm-next-cache-sweep.sh: sweep_task_record_state_dirs -> registry line
 #   loop and secondmate_registry_parse_line`. Checked: every registry record is
 #   defined by the shared parser's `- ` prefix; such a line must parse, local
 #   homes must be absolute and physically resolvable, and remote records are
 #   excluded by their explicit placement flag because they cannot own this host's
-#   pool. Falsifier: a parser-recognized local record can be ignored, or a remote
-#   record can name a worktree in this machine's pool.
+#   pool. Falsifier: a syntactically valid local record with `home: ../mate` is
+#   treated as an absent home and contributes no task records.
 # - `bin/fm-next-cache-sweep.sh: sweep_load_task_worktrees -> state directory
 #   predicates and sweep_task_meta_files`. Checked: `-d`, `-r`, and `-x` precede
 #   a Python `os.scandir` whose exceptions and unsafe names are nonzero, and every
-#   nonzero status aborts the global loader. Falsifier: a missing, unreadable, or
-#   partially scanned state directory is represented as containing no metadata.
+#   nonzero status aborts the global loader. Falsifier: a state directory lists
+#   one `.meta` entry, then enumeration fails on another entry, but the first-only
+#   list is accepted as complete.
 # - `bin/fm-next-cache-sweep.sh: sweep_load_task_worktrees ->
 #   sweep_read_text_file "$meta" and metadata field loop`. Checked: the same
 #   complete reader rejects NUL, and one shell pass rejects duplicate, missing,
 #   non-absolute, or invalid-placement fields before appending a worktree. This
-#   replaced unchecked `sed` substitutions. Falsifier: any failed metadata read
-#   or parse omits its owner while enumeration still succeeds.
+#   replaced unchecked `sed` substitutions. Falsifier: metadata contains two
+#   `worktree=` fields, the second naming the candidate, and last-value parsing
+#   silently omits or replaces that owner.
 # - `bin/fm-next-cache-sweep.sh: sweep_path_identity -> cd, uname, and stat -L`.
 #   Checked: `cd && pwd -P` resolves the referent, `stat -L` follows a final
 #   symlink on both probed platforms, and empty or non-numeric device/inode output
 #   is rejected; identity-failure and symlink tests exercise the boundary.
-#   Falsifier: a broken/unresolved referent or malformed stat answer is treated as
-#   a distinct, usable identity.
+#   Falsifier: a final symlink to a recorded worktree is compared by the link's
+#   own inode, or a broken final symlink is accepted as a distinct candidate.
 # - `bin/fm-next-cache-sweep.sh: sweep_task_owns -> recorded paths and identities`.
-#   Checked: `grep` status 0 is an exact match, 1 is the only accepted no-match,
-#   and every other status is undetermined; resolved device/inode equality catches
-#   alternate spellings. Falsifier: a comparison error or unresolved extant path
-#   is accepted as proof that no task owns the candidate.
+#   Checked: shell equality catches the exact spelling and resolved device/inode
+#   equality catches symlinked prefixes and case aliases. Falsifier: metadata
+#   names `/alias/pool/1` while the pool names `/real/pool/1`, both resolve to the
+#   same directory, and the candidate is classified unowned.
 #
 # Project discovery, pool, and candidate inputs:
 # - `bin/fm-next-cache-sweep.sh: sweep_project_directories -> os.scandir and
 #   entry.is_dir`. Checked: Python stages the complete immediate directory set,
 #   rejects unsafe paths, and turns enumeration or entry-type exceptions into a
 #   checked nonzero status; the unreadable-Git discovery test then preserves each
-#   announced project for project-scoped refusal. Falsifier: a directory-entry
-#   failure silently removes a project from the requested target set.
+#   announced project for project-scoped refusal. Falsifier: `entry.is_dir()`
+#   raises for one project while another is readable, and only the readable one
+#   reaches the target list and clean summary.
 # - `bin/fm-next-cache-sweep.sh: sweep_project -> sweep_resolve_directory and Git
 #   project queries`. Checked: physical entry and `git rev-parse --show-toplevel`
-#   must both succeed, the answer must be safe and physically resolvable, and its
-#   physical path must equal the resolved argument before pool lookup. This
-#   converts the wrong `--git-dir` verdict observed from `bin/`. Falsifier: any
-#   non-root argument supplies the project identity used by candidate provenance.
+#   must succeed and the physical top level must equal the argument. Wrong verdict
+#   found here: root equality proves a worktree root, not the primary clone.
+#   Required: `--absolute-git-dir` and absolute `--git-common-dir` must resolve to
+#   the same directory before a target can anchor provenance. Falsifier: an
+#   explicit linked-worktree root passes top-level equality, then a pool row naming
+#   the primary clone passes the distinct-project comparison and reaches removal.
 # - `bin/fm-next-cache-sweep.sh: sweep_pool_entries -> mktemp, treehouse status
 #   --json, staged-file read, JSON decode, and temp removal`. Checked: treehouse's
 #   status is captured before parsing, the file is decoded strictly as UTF-8 JSON,
 #   and staging, parse, top-level-shape, or cleanup failure returns nonzero before
-#   a plan exists. Falsifier: a failed or partial pool lookup supplies any
-#   candidate or is summarized as an empty pool.
+#   a plan exists. Falsifier: treehouse writes a complete first row and exits 1
+#   before its second row, but the first row is planned as a complete pool.
+# - `bin/fm-next-cache-sweep.sh: sweep_pool_entries -> JSON object decoding`.
+#   Checked: today `json.loads` silently keeps the last duplicate key. Wrong
+#   verdict found here: syntactically decoded JSON is not necessarily unambiguous
+#   lease evidence. Required: reject duplicate keys at every object before any row
+#   is emitted. Falsifier: one entry contains `"status":"in-use"` followed by
+#   `"status":"available"`, and last-value decoding authorizes deletion.
 # - `bin/fm-next-cache-sweep.sh: sweep_pool_entries -> status and path fields`.
 #   Checked: Python requires both fields to be nonempty strings, the path to be
 #   absolute, and rejects NUL, tab, CR, and LF before emitting tab-delimited rows;
-#   malformed-field and NUL tests exercise the boundary. Falsifier: shell capture
-#   can normalize an unvalidated field into `available` or a different path.
+#   malformed-field and NUL tests exercise the boundary. Falsifier: JSON status
+#   `avail\u0000able` crosses command substitution as `available` and reaches the
+#   exact-status check.
 # - `bin/fm-next-cache-sweep.sh: sweep_project_plan -> pool directory predicate,
 #   sweep_path_identity, and duplicate identity scan`. Checked: `-d` is required,
 #   physical device/inode identity is mandatory, and repeated identity produces
 #   an undetermined assessment. The complete pool listing is counted before any
-#   assessment begins. Falsifier: an absent/unresolvable path or alias duplicate
-#   authorizes deletion, or an early exit can hide a later announced candidate.
+#   assessment begins. Falsifier: two different pool strings resolve to the same
+#   inode and are each applied, or a nonexistent first path prevents a valid later
+#   path from receiving a terminal verdict.
 # - `bin/fm-next-cache-sweep.sh: sweep_pool_worktree_provenance -> candidate root,
 #   project worktree registry, and project-clone exclusion`. Checked: candidate
 #   `--show-toplevel` must physically equal the candidate, the candidate identity
 #   must appear exactly once in `git worktree list --porcelain -z`, and it must
-#   differ from the supplied project identity. The supplied identity is now first
-#   proven to be the project root, converting the earlier wrong evidence chain.
-#   Falsifier: either root proof can be bypassed, or the linked-worktree registry
-#   can be incomplete while verification succeeds.
+#   differ from the supplied project identity. Wrong evidence chain: the supplied
+#   identity was proven only to be a root; the primary-clone proof above is also
+#   required. Falsifier: the pool names a child of a live registered worktree and
+#   Git reachability is mistaken for root identity, or a linked project argument
+#   makes the actual primary clone look like a distinct registered candidate.
 # - `bin/fm-next-cache-sweep.sh: sweep_unowned_reason -> pool status`. Checked:
 #   only byte-exact `available` proceeds, `in-use` records ownership, and every
-#   other value records undetermined. Falsifier: any unknown or malformed status
-#   reaches clean-tree inspection as though availability were proven.
+#   other value records undetermined. Falsifier: `available ` or `AVAILABLE`
+#   reaches clean-tree inspection as if it were byte-exact `available`.
 # - `bin/fm-next-cache-sweep.sh: sweep_unowned_reason -> git status --porcelain
 #   and git stash list`. Checked: each command substitution is status-checked,
 #   nonempty status or stash output records ownership, and failure records
-#   undetermined. Falsifier: Git failure or returned work is classified free.
+#   undetermined. Falsifier: `git status` prints an empty-looking result then exits
+#   1, or `git stash list` prints a stash then exits 1, and the copy is classified
+#   free from the captured text alone.
 # - `bin/fm-next-cache-sweep.sh: sweep_project_plan -> fm_next_cache_inspect and
 #   FM_NEXT_CACHE_* outputs`. Checked: the inspection status is checked before
 #   size and plan values are consumed, so failed discovery, eligibility, or
 #   measurement produces an undetermined assessment. Every candidate is assessed
-#   before project refusal is applied. Falsifier: incomplete inspection supplies
-#   a zero-size/free row or prevents a later announced path receiving an assessment.
+#   before project refusal is applied. Falsifier: `find` reports one `.next` then
+#   exits 1 and that partial measurement becomes a free row, or the failure stops
+#   a later announced pool path from being assessed.
 #
 # Shared build-output discovery and removal inputs:
 # - `bin/fm-next-cache-lib.sh: fm_next_cache_size_kb -> du -sk`. Checked: only a
 #   zero-status command with leading decimal digits followed by a separator is
 #   emitted; failure and malformed output are nonzero, as the size-failure test
-#   observes. Falsifier: failed or malformed measurement becomes numeric zero.
+#   observes. Falsifier: `du` prints `0\t/path` then exits 1 and the directory is
+#   reported as measured empty.
 # - `bin/fm-next-cache-lib.sh: fm_next_cache_parent_is_next_app -> next.config.*
 #   and package.json predicates plus grep`. Checked: a regular config is positive,
 #   absent files or grep status 1 are negative, and every other grep status is
 #   undetermined. A negative cannot authorize deletion because callers require
-#   positive app evidence. Falsifier: an inspection error returns the same status
-#   as a proven app and lets the directory qualify.
+#   positive app evidence. Falsifier: package.json cannot be read and grep exits 2,
+#   but that status is returned as the same zero used for a matched `"next"` key.
 # - `bin/fm-next-cache-lib.sh: fm_next_cache_is_build_output -> path existence,
 #   directory and symlink predicates, physical resolution, containment, git
 #   check-ignore, and app-root result`. Checked: only a real nonsymlink directory
 #   physically below the supplied root with check-ignore status 0 and app status
-#   0 qualifies; proven negatives return 1 and failures return 2. Falsifier: any
-#   unresolved, external, symlinked, unignored, or unproven-app path returns 0.
+#   0 qualifies; proven negatives return 1 and failures return 2. Falsifier: an
+#   ignored `.next` symlink points outside the worktree, or `git check-ignore`
+#   exits 128, and the candidate still returns the qualifying status 0.
 # - `bin/fm-next-cache-lib.sh: fm_next_cache_inspect -> worktree cd and git
 #   rev-parse --git-dir`. Checked: entry and Git failure set a named inspection
 #   error and return nonzero; `--git-dir` is needed here only to prove a repository
 #   is reachable because the sweep separately proves candidate-root provenance
-#   and teardown supplies its task worktree. Falsifier: this library answer is
-#   itself used to prove that an arbitrary caller path is a worktree root.
+#   and teardown supplies its task worktree. Falsifier: a caller passes a repository
+#   child directory, `--git-dir` succeeds there, and that answer alone grants the
+#   caller authority to remove the child's build output.
 # - `bin/fm-next-cache-lib.sh: fm_next_cache_inspect -> mktemp, find -print0,
 #   NUL-delimited read, and temp removal`. Checked: the complete `find` status is
 #   captured before parsing, documented `-print0` records are path-validated, and
 #   any staging, walk, eligibility, measurement, or cleanup failure clears the
-#   accumulated plan and returns nonzero. Falsifier: a successful `find -print0`
-#   violates its NUL-record contract, or any checked nonzero path leaves a partial
-#   plan usable by report or reclaim.
+#   accumulated plan and returns nonzero. Falsifier: `find` emits one complete NUL
+#   record then exits 1, yet that partial plan remains usable by report or reclaim.
 # - `bin/fm-next-cache-lib.sh: fm_next_cache_report and fm_next_cache_reclaim ->
 #   plan rows and fm_next_cache_human_kb`. Checked: only inspect-generated numeric
 #   size/path rows reach formatting, and repeated inspection or numeric validation
-#   failure returns nonzero to the sweep. Falsifier: malformed plan data prints a
-#   success or contributes a total.
+#   failure returns nonzero to the sweep. Falsifier: an internally corrupted plan
+#   row contains `bogus\t/path` and still prints success or contributes bytes.
 # - `bin/fm-next-cache-lib.sh: fm_next_cache_reclaim -> rm -rf and post-removal
 #   existence predicates`. Checked: bytes are added only after `rm` status 0 and
 #   both `-e` and `-L` confirm absence; otherwise the exact path is reported and
-#   status is nonzero. Falsifier: a remaining directory or link contributes
-#   reclaimed bytes or a successful outcome.
+#   status is nonzero. Falsifier: `rm` returns 0 while a dangling symlink remains
+#   at the path, and its measured bytes are counted as reclaimed.
 #
 # Outcome and summary inputs:
 # - `bin/fm-next-cache-sweep.sh: sweep_apply_project_plan -> report or reclaim
-#   status and FM_NEXT_CACHE_TOTAL_KB`. Checked: both dry-run and removal statuses
-#   are captured and routed through the one terminal-verdict recorder; failed
-#   paths become named `failed` verdicts and only ledger-recorded measured work
-#   contributes totals. Falsifier: an apply result changes a summary counter
-#   without first appending exactly one candidate verdict.
+#   status, target authority, and FM_NEXT_CACHE_TOTAL_KB`. Checked: today dry-run
+#   and removal statuses are captured, but target origin is already lost. Required:
+#   exact per-target `reclaim` eligibility chooses removal; explicit and missing
+#   eligibility choose reporting and a distinct terminal verdict. Falsifier: an
+#   explicit target's free candidate calls `fm_next_cache_reclaim`, or its report
+#   is recorded and summarized as reclaimed.
 # - `bin/fm-next-cache-sweep.sh: sweep_project_plan, sweep_project, project loop,
 #   and final summary -> announced candidates and final verdicts`. Checked: project
 #   plans remain atomic, the complete pool list announces indexed candidates
-#   before assessment, and one ledger records `reclaimed`, `skipped-as-owned`,
-#   `undetermined`, `refused`, or `failed`. Per-project reconciliation proves each
-#   index occurs once; run reconciliation gates every clean summary. This converts
-#   the wrong early-return verdict. Falsifier: an announced index has zero or two
-#   terminal records, or any summary counter changes outside the ledger recorder.
+#   before assessment, and one ledger records each terminal outcome. Per-project
+#   reconciliation proves each index occurs once; run reconciliation gates every
+#   clean summary. Falsifier: a three-row pool has an invalid first row and valid
+#   later rows, but either later index has no verdict, or a discarded row still
+#   increments the clean inspected count outside the ledger.
 set -u
 
 case "${BASH_SOURCE[0]}" in

--- a/bin/fm-next-cache-sweep.sh
+++ b/bin/fm-next-cache-sweep.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# Reclaim Next.js build output from pooled worktrees that nobody is using.
+#
+# Teardown (bin/fm-teardown.sh) reclaims a copy on the way back to the pool, so
+# this sweep exists for the copies that were returned before that shipped, and
+# for a copy whose task record is gone. It is a command a human or firstmate
+# runs; there is deliberately no daemon, watcher, schedule, or disk-pressure
+# trigger behind it.
+#
+# Usage: fm-next-cache-sweep.sh [--dry-run] [<project-dir>...]
+#   --dry-run   report what would be reclaimed and remove nothing.
+#   <project-dir>...  sweep these project clones' pools instead of every clone
+#                     under $FM_HOME/projects.
+#
+# WHAT IT TOUCHES. Only pooled task copies, and only the Next.js build output
+# inside them - bin/fm-next-cache-lib.sh's header owns that discovery rule and
+# the reason it can never reach source, node_modules, or git data. The project
+# clone itself is never swept: firstmate reads its clones and only crewmates
+# change them, and a clone is where nothing builds anyway.
+#
+# A COPY MUST BE PROVEN UNOWNED, all four, or it is skipped:
+#   1. treehouse reports it `available`. A live dev server rewrites the build
+#      output the moment you delete it, and deleting mid-build is worse than
+#      leaving it alone, so a leased copy is out of scope no matter how idle it
+#      looks. The pool is shared across firstmate homes and treehouse's lease is
+#      the only ownership signal that spans all of them, which is why it comes
+#      first rather than last.
+#   2. No task record names it. This home's state/*.meta plus every registered
+#      secondmate home's, so a copy owned by a task in another home is skipped
+#      even if its lease was somehow released.
+#   3. The tree is clean. Uncommitted work is unlanded work.
+#   4. There are no stashes. A stash is unlanded work that a clean tree does not
+#      show, and nobody is watching an idle copy to notice it disappear.
+# Checks 3 and 4 read git and change nothing. A copy that fails any check keeps
+# its build output; the sweep says which check failed and moves on.
+#
+# It reports every copy it reclaimed, with the space each gave back and a total,
+# and says plainly when it found nothing - a cleanup that prints nothing is
+# indistinguishable from one that did nothing.
+#
+# Exit status is 0 when the sweep completed, 1 when a removal or a project's
+# pool lookup failed (already reported), 2 on a usage or environment error.
+set -u
+
+SCRIPT_DIR=$(CDPATH='' cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd -P)}"
+FM_HOME="${FM_HOME:-$FM_ROOT}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+PROJECTS="${FM_PROJECTS_OVERRIDE:-$FM_HOME/projects}"
+
+# shellcheck source=bin/fm-next-cache-lib.sh
+. "$SCRIPT_DIR/fm-next-cache-lib.sh"
+# shellcheck source=bin/fm-secondmate-registry-lib.sh
+. "$SCRIPT_DIR/fm-secondmate-registry-lib.sh"
+
+sweep_die() { printf 'fm-next-cache-sweep: %s\n' "$1" >&2; exit 2; }
+
+sweep_usage() {
+  cat <<'TXT'
+Usage: fm-next-cache-sweep.sh [--dry-run] [<project-dir>...]
+
+Reclaim Next.js build output from pooled task copies that nobody is using.
+With no project directory, sweeps every project clone under $FM_HOME/projects.
+
+  --dry-run   report what would be reclaimed and remove nothing.
+
+A copy is swept only when the pool reports it available, no task record in this
+home or a registered secondmate home names it, its tree is clean, and it holds
+no stashes. Anything else is skipped and reported. Read this script's header for
+the full rule, and bin/fm-next-cache-lib.sh's for what counts as build output.
+TXT
+}
+
+DRY_RUN=0
+PROJECT_ARGS=()
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1; shift ;;
+    -h|--help) sweep_usage; exit 0 ;;
+    --) shift; break ;;
+    -*) sweep_die "unknown option: $1 (see --help)" ;;
+    *) PROJECT_ARGS+=("$1"); shift ;;
+  esac
+done
+while [ "$#" -gt 0 ]; do PROJECT_ARGS+=("$1"); shift; done
+
+command -v treehouse >/dev/null 2>&1 \
+  || sweep_die "treehouse is not installed; the pool's lease state is the sweep's first ownership proof and cannot be guessed"
+command -v python3 >/dev/null 2>&1 \
+  || sweep_die "python3 is not installed; it reads the pool's JSON status"
+
+# Every state directory whose task records could own a pooled copy: this home's
+# plus every locally registered secondmate's. A remote secondmate's home lives on
+# another machine and cannot hold this machine's pool, so it is not consulted.
+sweep_task_record_state_dirs() {
+  local registry="$DATA/secondmates.md" line home
+  printf '%s\n' "$STATE"
+  [ -f "$registry" ] || return 0
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in '- '*) ;; *) continue ;; esac
+    secondmate_registry_parse_line "$line" || continue
+    if [ "$SECONDMATE_REGISTRY_REMOTE" -eq 1 ]; then continue; fi
+    home=$SECONDMATE_REGISTRY_HOME
+    [ -n "$home" ] || continue
+    printf '%s/state\n' "$home"
+  done < "$registry"
+}
+
+TASK_WORKTREES=
+sweep_load_task_worktrees() {
+  local state_dir meta
+  TASK_WORKTREES=$(
+    while IFS= read -r state_dir; do
+      [ -d "$state_dir" ] || continue
+      for meta in "$state_dir"/*.meta; do
+        [ -f "$meta" ] || continue
+        sed -n 's/^worktree=//p' "$meta"
+      done
+    done < <(sweep_task_record_state_dirs)
+  )
+}
+
+# Does any task record name <path> as its worktree?
+sweep_task_owns() {  # <path>
+  local path=$1
+  [ -n "$TASK_WORKTREES" ] || return 1
+  printf '%s\n' "$TASK_WORKTREES" | grep -Fxq -- "$path"
+}
+
+# Print "<status>\t<path>" for every worktree in <project-dir>'s pool.
+# treehouse resolves the pool from the working directory, and reading pool
+# status changes nothing in the clone.
+sweep_pool_entries() {  # <project-dir>
+  ( cd "$1" && treehouse status --json 2>/dev/null ) | python3 -c '
+import json, sys
+
+try:
+    pool = json.load(sys.stdin)
+except ValueError:
+    sys.exit(1)
+for entry in pool:
+    status = entry.get("status") or ""
+    path = entry.get("path") or ""
+    if path:
+        print("%s\t%s" % (status, path))
+'
+}
+
+# Why <worktree> may not be swept, printed as a short reason; empty when it may.
+sweep_unowned_reason() {  # <status> <worktree>
+  local status=$1 wt=$2
+  if [ "$status" != available ]; then
+    printf 'in use by the pool\n'
+    return 0
+  fi
+  if sweep_task_owns "$wt"; then
+    printf 'still claimed by a task record\n'
+    return 0
+  fi
+  if ! git -C "$wt" rev-parse --git-dir >/dev/null 2>&1; then
+    printf 'not an inspectable git worktree\n'
+    return 0
+  fi
+  local dirty stashes
+  if ! dirty=$(git -C "$wt" status --porcelain 2>/dev/null); then
+    printf 'cannot inspect it for uncommitted changes\n'
+    return 0
+  fi
+  if [ -n "$dirty" ]; then
+    printf 'has uncommitted changes\n'
+    return 0
+  fi
+  if ! stashes=$(git -C "$wt" stash list 2>/dev/null); then
+    printf 'cannot inspect it for stashes\n'
+    return 0
+  fi
+  if [ -n "$stashes" ]; then
+    printf 'has stashed work\n'
+    return 0
+  fi
+  printf '\n'
+}
+
+if [ "${#PROJECT_ARGS[@]}" -gt 0 ]; then
+  TARGETS=("${PROJECT_ARGS[@]}")
+else
+  TARGETS=()
+  for dir in "$PROJECTS"/*/; do
+    [ -d "$dir" ] || continue
+    dir=${dir%/}
+    git -C "$dir" rev-parse --git-dir >/dev/null 2>&1 || continue
+    TARGETS+=("$dir")
+  done
+fi
+
+[ "${#TARGETS[@]}" -gt 0 ] || sweep_die "no project clones to sweep under $PROJECTS"
+
+sweep_load_task_worktrees
+
+RC=0
+TOTAL_KB=0
+RECLAIMED=0
+SKIPPED=0
+for project in "${TARGETS[@]}"; do
+  if ! project_real=$(CDPATH='' cd -- "$project" 2>/dev/null && pwd -P); then
+    printf 'sweep: cannot enter project %s\n' "$project" >&2
+    RC=1
+    continue
+  fi
+  if ! entries=$(sweep_pool_entries "$project_real"); then
+    printf 'sweep: cannot read the worktree pool for %s\n' "$project_real" >&2
+    RC=1
+    continue
+  fi
+  while IFS=$'\t' read -r status wt; do
+    [ -n "$wt" ] || continue
+    [ -d "$wt" ] || continue
+    reason=$(sweep_unowned_reason "$status" "$wt")
+    if [ -n "$reason" ]; then
+      # Only worth a line when there was something to reclaim; an idle copy that
+      # never built anything is not news.
+      fm_next_cache_total_kb "$wt" >/dev/null
+      if [ "$FM_NEXT_CACHE_TOTAL_KB" -gt 0 ]; then
+        printf 'sweep: skipped %s (%s), holding %s\n' \
+          "$wt" "$reason" "$(fm_next_cache_human_kb "$FM_NEXT_CACHE_TOTAL_KB")"
+        SKIPPED=$(( SKIPPED + 1 ))
+      fi
+      continue
+    fi
+    if [ "$DRY_RUN" = 1 ]; then
+      fm_next_cache_report "$wt" "sweep" || RC=1
+    else
+      fm_next_cache_reclaim "$wt" "sweep" || RC=1
+    fi
+    if [ "$FM_NEXT_CACHE_TOTAL_KB" -gt 0 ]; then
+      TOTAL_KB=$(( TOTAL_KB + FM_NEXT_CACHE_TOTAL_KB ))
+      RECLAIMED=$(( RECLAIMED + 1 ))
+    fi
+  done <<EOT
+$entries
+EOT
+done
+
+sweep_copies() {  # <count>
+  if [ "$1" -eq 1 ]; then printf '1 copy\n'; else printf '%d copies\n' "$1"; fi
+}
+
+if [ "$RECLAIMED" -eq 0 ]; then
+  if [ "$SKIPPED" -gt 0 ]; then
+    printf 'sweep: nothing to reclaim; %s still hold build output but are in use or hold unlanded work\n' \
+      "$(sweep_copies "$SKIPPED")"
+  else
+    printf 'sweep: nothing to reclaim; no idle copy holds Next.js build output\n'
+  fi
+elif [ "$DRY_RUN" = 1 ]; then
+  printf 'sweep: would reclaim %s from %s\n' \
+    "$(fm_next_cache_human_kb "$TOTAL_KB")" "$(sweep_copies "$RECLAIMED")"
+else
+  printf 'sweep: reclaimed %s from %s\n' \
+    "$(fm_next_cache_human_kb "$TOTAL_KB")" "$(sweep_copies "$RECLAIMED")"
+fi
+
+exit "$RC"

--- a/bin/fm-next-cache-sweep.sh
+++ b/bin/fm-next-cache-sweep.sh
@@ -61,135 +61,182 @@
 #
 # Each source site is identified by file, function, and the exact statement or
 # command that reads it rather than by a numeric line that this inventory itself
-# would immediately invalidate.
-# The inventory was built by tracing every external command and its status,
-# every command substitution, every filesystem predicate and directory entry,
-# every file-content parser, every environment or CLI value, every Python to
-# shell boundary, and every value that selects or qualifies the final summary.
-# That input-oriented trace includes implicit omission paths that a syntax search
-# for `continue` cannot find, so every value entering either script is accounted
-# for whether its failure direction was already safe or required conversion.
+# would immediately invalidate. The inventory was built by tracing every
+# external command and status, command substitution, filesystem predicate and
+# directory entry, file parser, environment or CLI value, Python-to-shell
+# boundary, and summary selector. That input-oriented trace includes implicit
+# omission paths that a syntax search for `continue` cannot find.
+#
+# Every verdict below carries both the observation it rests on and its falsifier.
+# A falsifier states the exact condition that would make the direction unsafe;
+# it is not a claim that a command name alone proves the needed property.
 #
 # Sweep entry and global ownership inputs:
 # - `bin/fm-next-cache-sweep.sh: startup -> BASH_SOURCE, FM_* overrides, cd,
-#   readable library predicates, and source`: resolution, readability, or source
-#   failure currently exits 2, which is the required global refusal.
-# - `bin/fm-next-cache-sweep.sh: argument loops -> "$@"`: an unknown option
-#   currently exits 2 and explicit project paths are retained for checked project
-#   resolution, which is the required direction.
+#   readable library predicates, and source`. Checked: every failed directory
+#   command substitution is tested, both library paths must pass `-r`, and a
+#   nonzero source status exits 2 before deletion authority exists. Falsifier:
+#   any failed resolution or library load reaches argument processing with exit 0.
+# - `bin/fm-next-cache-sweep.sh: argument loops -> "$@"`. Checked: the option
+#   case accepts only `--dry-run`, rejects every other dash-prefixed value with
+#   exit 2, and retains non-options verbatim. Re-derived wrong verdict: retention
+#   plus later `git rev-parse --git-dir` proves only that a repository is reachable,
+#   not that an explicit path is its root. Falsifier: an explicit subdirectory is
+#   accepted as the project clone and weakens the clone-exclusion comparison.
 # - `bin/fm-next-cache-sweep.sh: command preflight -> command -v treehouse and
-#   python3`: absence currently exits 2, which is the required global refusal.
+#   python3`. Checked: absence exits 2, while every later invocation separately
+#   checks the command's status. Falsifier: a missing command falls through, or a
+#   found command's later nonzero status is normalized to usable output.
 # - `bin/fm-next-cache-sweep.sh: sweep_task_record_state_dirs ->
-#   sweep_resolve_directory "$STATE"`: an absent or unresolvable primary state
-#   directory currently refuses globally, which is required.
+#   sweep_resolve_directory "$STATE"`. Checked: physical resolution requires a
+#   searchable directory and failure propagates through the checked loader to
+#   `sweep_die`. Falsifier: an absent or unresolvable primary state directory
+#   contributes an empty ownership set.
 # - `bin/fm-next-cache-sweep.sh: sweep_task_record_state_dirs ->
-#   sweep_read_text_file "$DATA/secondmates.md"`: a missing, non-regular,
-#   symlinked, unreadable, or NUL-bearing registry currently refuses globally,
-#   which is required.
+#   sweep_read_text_file "$DATA/secondmates.md"`. Checked: the reader requires a
+#   regular non-symlink, stages a complete byte-for-byte read, rejects NUL, and
+#   propagates failure globally; the absent, unreadable, and NUL tests exercise
+#   those branches. Falsifier: any registry read failure yields empty registry
+#   text and task enumeration continues.
 # - `bin/fm-next-cache-sweep.sh: sweep_task_record_state_dirs -> registry line
-#   loop and secondmate_registry_parse_line`: a malformed local record, unsafe
-#   field, non-absolute home, or unresolvable home currently refuses globally;
-#   remote homes are deliberately excluded because they cannot own this host's
-#   pool, which is the required scope.
+#   loop and secondmate_registry_parse_line`. Checked: every registry record is
+#   defined by the shared parser's `- ` prefix; such a line must parse, local
+#   homes must be absolute and physically resolvable, and remote records are
+#   excluded by their explicit placement flag because they cannot own this host's
+#   pool. Falsifier: a parser-recognized local record can be ignored, or a remote
+#   record can name a worktree in this machine's pool.
 # - `bin/fm-next-cache-sweep.sh: sweep_load_task_worktrees -> state directory
-#   predicates and sweep_task_meta_files`: absent, unreadable, unsearchable, or
-#   unscannable state directories and unsafe metadata names currently refuse
-#   globally, which is required.
+#   predicates and sweep_task_meta_files`. Checked: `-d`, `-r`, and `-x` precede
+#   a Python `os.scandir` whose exceptions and unsafe names are nonzero, and every
+#   nonzero status aborts the global loader. Falsifier: a missing, unreadable, or
+#   partially scanned state directory is represented as containing no metadata.
 # - `bin/fm-next-cache-sweep.sh: sweep_load_task_worktrees ->
-#   sweep_read_text_file "$meta" and metadata field loop`: unreadable,
-#   NUL-bearing, duplicate, missing, non-absolute, or invalid-placement metadata
-#   currently refuses globally, which is required.
-#   The earlier `sed -n` field extraction discarded parse status and could omit
-#   an owner; the checked single-pass parser is the required converted behavior.
-# - `bin/fm-next-cache-sweep.sh: sweep_path_identity -> cd, uname, and stat -L`:
-#   an unresolvable referent, platform lookup failure, stat failure, empty output,
-#   or malformed device and inode currently refuses the relevant scope, which is
-#   required.
-# - `bin/fm-next-cache-sweep.sh: sweep_task_owns -> recorded paths and identities`:
-#   exact path or device-inode equality proves ownership, a complete mismatch
-#   proves no recorded owner, and candidate identity failure returns undetermined,
-#   which is the required three-way result.
+#   sweep_read_text_file "$meta" and metadata field loop`. Checked: the same
+#   complete reader rejects NUL, and one shell pass rejects duplicate, missing,
+#   non-absolute, or invalid-placement fields before appending a worktree. This
+#   replaced unchecked `sed` substitutions. Falsifier: any failed metadata read
+#   or parse omits its owner while enumeration still succeeds.
+# - `bin/fm-next-cache-sweep.sh: sweep_path_identity -> cd, uname, and stat -L`.
+#   Checked: `cd && pwd -P` resolves the referent, `stat -L` follows a final
+#   symlink on both probed platforms, and empty or non-numeric device/inode output
+#   is rejected; identity-failure and symlink tests exercise the boundary.
+#   Falsifier: a broken/unresolved referent or malformed stat answer is treated as
+#   a distinct, usable identity.
+# - `bin/fm-next-cache-sweep.sh: sweep_task_owns -> recorded paths and identities`.
+#   Checked: `grep` status 0 is an exact match, 1 is the only accepted no-match,
+#   and every other status is undetermined; resolved device/inode equality catches
+#   alternate spellings. Falsifier: a comparison error or unresolved extant path
+#   is accepted as proof that no task owns the candidate.
 #
 # Project discovery, pool, and candidate inputs:
 # - `bin/fm-next-cache-sweep.sh: sweep_project_directories -> os.scandir and
-#   entry.is_dir`: enumeration, entry-type, or unsafe-path failure currently exits
-#   2 instead of silently dropping a project, which is the required global refusal.
-# - `bin/fm-next-cache-sweep.sh: sweep_project -> sweep_resolve_directory and
-#   git rev-parse --git-dir`: an unenterable project or unreadable Git answer
-#   currently refuses that project, which is required.
+#   entry.is_dir`. Checked: Python stages the complete immediate directory set,
+#   rejects unsafe paths, and turns enumeration or entry-type exceptions into a
+#   checked nonzero status; the unreadable-Git discovery test then preserves each
+#   announced project for project-scoped refusal. Falsifier: a directory-entry
+#   failure silently removes a project from the requested target set.
+# - `bin/fm-next-cache-sweep.sh: sweep_project -> sweep_resolve_directory and Git
+#   project queries`. Checked: physical entry and `git rev-parse --git-dir` errors
+#   already refuse the project. Re-derived wrong verdict: `--git-dir` succeeds in
+#   a repository child, as observed from `bin/`, so it does not prove that the
+#   resolved argument equals `git rev-parse --show-toplevel`. Falsifier: the
+#   project clone can be returned by the pool while the comparison anchor remains
+#   an explicit child path.
 # - `bin/fm-next-cache-sweep.sh: sweep_pool_entries -> mktemp, treehouse status
-#   --json, staged-file read, JSON decode, and temp removal`: command failure,
-#   malformed encoding or JSON, NUL, wrong top-level shape, or staging failure
-#   currently refuses that project atomically, which is required.
-# - `bin/fm-next-cache-sweep.sh: sweep_pool_entries -> status and path fields`:
-#   missing, non-string, empty, non-absolute, NUL-bearing, tab-bearing, or
-#   newline-bearing fields currently refuse the project before shell parsing,
-#   which is required at the Python to shell boundary.
+#   --json, staged-file read, JSON decode, and temp removal`. Checked: treehouse's
+#   status is captured before parsing, the file is decoded strictly as UTF-8 JSON,
+#   and staging, parse, top-level-shape, or cleanup failure returns nonzero before
+#   a plan exists. Falsifier: a failed or partial pool lookup supplies any
+#   candidate or is summarized as an empty pool.
+# - `bin/fm-next-cache-sweep.sh: sweep_pool_entries -> status and path fields`.
+#   Checked: Python requires both fields to be nonempty strings, the path to be
+#   absolute, and rejects NUL, tab, CR, and LF before emitting tab-delimited rows;
+#   malformed-field and NUL tests exercise the boundary. Falsifier: shell capture
+#   can normalize an unvalidated field into `available` or a different path.
 # - `bin/fm-next-cache-sweep.sh: sweep_project_plan -> pool directory predicate,
-#   sweep_path_identity, and duplicate identity scan`: an absent or unresolvable
-#   path or duplicate filesystem copy currently refuses the project, which is
-#   required.
-# - `bin/fm-next-cache-sweep.sh: sweep_project_plan and sweep_unowned_reason ->
-#   candidate provenance`: today any repository directory passes because
-#   `git rev-parse --git-dir` answers in the project clone and in child directories.
-#   The contract requires positive proof that the candidate is the root of a
-#   linked worktree registered to this project and is not the project clone.
-# - `bin/fm-next-cache-sweep.sh: sweep_unowned_reason -> pool status`: only the
-#   exact `available` value can proceed, `in-use` is a proven owner, and every
-#   other value is undetermined, which is the required direction.
+#   sweep_path_identity, and duplicate identity scan`. Checked: `-d` is required,
+#   physical device/inode identity is mandatory, and repeated identity refuses
+#   the atomic project. Falsifier: an absent/unresolvable path or alias duplicate
+#   authorizes deletion, or refusal leaves any announced path without a verdict.
+# - `bin/fm-next-cache-sweep.sh: sweep_pool_worktree_provenance -> candidate root,
+#   project worktree registry, and project-clone exclusion`. Checked: candidate
+#   `--show-toplevel` must physically equal the candidate, the candidate identity
+#   must appear exactly once in `git worktree list --porcelain -z`, and it must
+#   differ from the supplied project identity. Re-derived wrong evidence chain:
+#   these predicates exclude the clone only when the supplied project is itself
+#   proven to be the project root. Falsifier: an explicit project child makes the
+#   actual clone identity differ from the comparison anchor and pass provenance.
+# - `bin/fm-next-cache-sweep.sh: sweep_unowned_reason -> pool status`. Checked:
+#   only byte-exact `available` proceeds, `in-use` records ownership, and every
+#   other value records undetermined. Falsifier: any unknown or malformed status
+#   reaches clean-tree inspection as though availability were proven.
 # - `bin/fm-next-cache-sweep.sh: sweep_unowned_reason -> git status --porcelain
-#   and git stash list`: command failure is undetermined and non-empty output is
-#   owned, which is the required fail-closed direction.
+#   and git stash list`. Checked: each command substitution is status-checked,
+#   nonempty status or stash output records ownership, and failure records
+#   undetermined. Falsifier: Git failure or returned work is classified free.
 # - `bin/fm-next-cache-sweep.sh: sweep_project_plan -> fm_next_cache_inspect and
-#   FM_NEXT_CACHE_* outputs`: failed discovery, eligibility, or measurement
-#   refuses the project and a completed result becomes an owned or free plan row,
-#   which is the required project-atomic boundary.
+#   FM_NEXT_CACHE_* outputs`. Checked: the inspection status is checked before
+#   size and plan values are consumed, so failed discovery, eligibility, or
+#   measurement refuses application. Falsifier: incomplete inspection supplies a
+#   zero-size or free row, or an early refusal prevents later pool paths receiving
+#   final verdicts; the latter is the reporting defect being converted.
 #
 # Shared build-output discovery and removal inputs:
-# - `bin/fm-next-cache-lib.sh: fm_next_cache_size_kb -> du -sk`: command failure
-#   or malformed output currently returns nonzero, which is required.
-#   The earlier implementation normalized failed measurement to zero and could
-#   report unmeasured output as absent; that unsafe direction has been converted.
+# - `bin/fm-next-cache-lib.sh: fm_next_cache_size_kb -> du -sk`. Checked: only a
+#   zero-status command with leading decimal digits followed by a separator is
+#   emitted; failure and malformed output are nonzero, as the size-failure test
+#   observes. Falsifier: failed or malformed measurement becomes numeric zero.
 # - `bin/fm-next-cache-lib.sh: fm_next_cache_parent_is_next_app -> next.config.*
-#   and package.json predicates plus grep`: absent app evidence is a safe negative,
-#   a grep match is positive, and a grep error is undetermined, which is required.
+#   and package.json predicates plus grep`. Checked: a regular config is positive,
+#   absent files or grep status 1 are negative, and every other grep status is
+#   undetermined. A negative cannot authorize deletion because callers require
+#   positive app evidence. Falsifier: an inspection error returns the same status
+#   as a proven app and lets the directory qualify.
 # - `bin/fm-next-cache-lib.sh: fm_next_cache_is_build_output -> path existence,
 #   directory and symlink predicates, physical resolution, containment, git
-#   check-ignore, and app-root result`: a proven non-candidate is retained while
-#   missing evidence or command failure is undetermined, which is required.
+#   check-ignore, and app-root result`. Checked: only a real nonsymlink directory
+#   physically below the supplied root with check-ignore status 0 and app status
+#   0 qualifies; proven negatives return 1 and failures return 2. Falsifier: any
+#   unresolved, external, symlinked, unignored, or unproven-app path returns 0.
 # - `bin/fm-next-cache-lib.sh: fm_next_cache_inspect -> worktree cd and git
-#   rev-parse --git-dir`: entry or Git failure currently returns an inspection
-#   error, which is required.
-#   The earlier `fm_next_cache_dirs` returned success with no output for these
-#   failures and could report an unreadable copy as empty; that has been converted.
+#   rev-parse --git-dir`. Checked: entry and Git failure set a named inspection
+#   error and return nonzero; `--git-dir` is needed here only to prove a repository
+#   is reachable because the sweep separately proves candidate-root provenance
+#   and teardown supplies its task worktree. Falsifier: this library answer is
+#   itself used to prove that an arbitrary caller path is a worktree root.
 # - `bin/fm-next-cache-lib.sh: fm_next_cache_inspect -> mktemp, find -print0,
-#   NUL-delimited read, and temp removal`: staging, traversal, unsafe-path, read,
-#   or cleanup failure currently discards the plan and returns nonzero, which is
-#   required.
-#   The earlier process-substitution walk discarded `find` status and could emit
-#   a partial directory set; staged checked traversal is the converted behavior.
+#   NUL-delimited read, and temp removal`. Checked: the complete `find` status is
+#   captured before parsing, documented `-print0` records are path-validated, and
+#   any staging, walk, eligibility, measurement, or cleanup failure clears the
+#   accumulated plan and returns nonzero. Falsifier: a successful `find -print0`
+#   violates its NUL-record contract, or any checked nonzero path leaves a partial
+#   plan usable by report or reclaim.
 # - `bin/fm-next-cache-lib.sh: fm_next_cache_report and fm_next_cache_reclaim ->
-#   plan rows and fm_next_cache_human_kb`: malformed formatting or a repeated
-#   inspection failure returns nonzero, which is required.
+#   plan rows and fm_next_cache_human_kb`. Checked: only inspect-generated numeric
+#   size/path rows reach formatting, and repeated inspection or numeric validation
+#   failure returns nonzero to the sweep. Falsifier: malformed plan data prints a
+#   success or contributes a total.
 # - `bin/fm-next-cache-lib.sh: fm_next_cache_reclaim -> rm -rf and post-removal
-#   existence predicates`: failed or incomplete removal is reported and returns
-#   nonzero while successful removal alone contributes reclaimed bytes, which is
-#   required.
+#   existence predicates`. Checked: bytes are added only after `rm` status 0 and
+#   both `-e` and `-L` confirm absence; otherwise the exact path is reported and
+#   status is nonzero. Falsifier: a remaining directory or link contributes
+#   reclaimed bytes or a successful outcome.
 #
 # Outcome and summary inputs:
 # - `bin/fm-next-cache-sweep.sh: sweep_apply_project_plan -> report or reclaim
-#   status and FM_NEXT_CACHE_TOTAL_KB`: failures currently become named failed
-#   outcomes and successful measured work contributes totals, which is required.
-#   The earlier dry-run and removal branches only changed exit status, allowing
-#   all-zero counters to select a clean summary; named failure outcomes are the
-#   required converted behavior.
+#   status and FM_NEXT_CACHE_TOTAL_KB`. Checked: both dry-run and removal statuses
+#   are captured, failed paths increment the failure outcome, and only successful
+#   measured work contributes bytes. Falsifier: an apply failure has no named
+#   final outcome or permits a complete summary.
 # - `bin/fm-next-cache-sweep.sh: sweep_project_plan, sweep_project, project loop,
-#   and final summary -> project completeness and copy verdicts`: today a copy
-#   inspected before a later project refusal still increments the run's inspected
-#   count even though its discarded plan produced no outcome.
-#   The contract requires only fully applied project verdicts to enter run totals,
-#   and it makes every clean `nothing to reclaim` sentence unreachable unless
-#   every requested project completed and every returned copy has a final verdict.
+#   and final summary -> announced candidates and final verdicts`. Checked: project
+#   plans are atomic and only completed projects currently enter run totals.
+#   Re-derived wrong verdict: `sweep_project_plan` returns on its first failed
+#   candidate, so later paths from the already complete pool listing have no
+#   verdict at all. Falsifier: announced-candidate count can differ from final-
+#   verdict count while the omission is not reported. The required conversion is
+#   a single candidate ledger, exactly one terminal verdict per announced path,
+#   and reconciliation before any clean summary is reachable.
 set -u
 
 case "${BASH_SOURCE[0]}" in

--- a/bin/fm-next-cache-sweep.sh
+++ b/bin/fm-next-cache-sweep.sh
@@ -50,6 +50,146 @@
 #
 # Exit status is 0 when the sweep completed, 1 when a removal or a project's
 # pool lookup failed (already reported), 2 on a usage or environment error.
+#
+# INPUT COMPLETENESS INVENTORY
+#
+# The contract for every item below is that an absent, unreadable, malformed,
+# ambiguous, or incomplete ownership input cannot produce a determinate answer.
+# A global input refuses the sweep, a project input refuses that project before
+# its plan is applied, and a copy input prevents that copy from authorizing any
+# deletion while also making its project incomplete.
+#
+# Each source site is identified by file, function, and the exact statement or
+# command that reads it rather than by a numeric line that this inventory itself
+# would immediately invalidate.
+# The inventory was built by tracing every external command and its status,
+# every command substitution, every filesystem predicate and directory entry,
+# every file-content parser, every environment or CLI value, every Python to
+# shell boundary, and every value that selects or qualifies the final summary.
+# That input-oriented trace includes implicit omission paths that a syntax search
+# for `continue` cannot find, so every value entering either script is accounted
+# for whether its failure direction was already safe or required conversion.
+#
+# Sweep entry and global ownership inputs:
+# - `bin/fm-next-cache-sweep.sh: startup -> BASH_SOURCE, FM_* overrides, cd,
+#   readable library predicates, and source`: resolution, readability, or source
+#   failure currently exits 2, which is the required global refusal.
+# - `bin/fm-next-cache-sweep.sh: argument loops -> "$@"`: an unknown option
+#   currently exits 2 and explicit project paths are retained for checked project
+#   resolution, which is the required direction.
+# - `bin/fm-next-cache-sweep.sh: command preflight -> command -v treehouse and
+#   python3`: absence currently exits 2, which is the required global refusal.
+# - `bin/fm-next-cache-sweep.sh: sweep_task_record_state_dirs ->
+#   sweep_resolve_directory "$STATE"`: an absent or unresolvable primary state
+#   directory currently refuses globally, which is required.
+# - `bin/fm-next-cache-sweep.sh: sweep_task_record_state_dirs ->
+#   sweep_read_text_file "$DATA/secondmates.md"`: a missing, non-regular,
+#   symlinked, unreadable, or NUL-bearing registry currently refuses globally,
+#   which is required.
+# - `bin/fm-next-cache-sweep.sh: sweep_task_record_state_dirs -> registry line
+#   loop and secondmate_registry_parse_line`: a malformed local record, unsafe
+#   field, non-absolute home, or unresolvable home currently refuses globally;
+#   remote homes are deliberately excluded because they cannot own this host's
+#   pool, which is the required scope.
+# - `bin/fm-next-cache-sweep.sh: sweep_load_task_worktrees -> state directory
+#   predicates and sweep_task_meta_files`: absent, unreadable, unsearchable, or
+#   unscannable state directories and unsafe metadata names currently refuse
+#   globally, which is required.
+# - `bin/fm-next-cache-sweep.sh: sweep_load_task_worktrees ->
+#   sweep_read_text_file "$meta" and metadata field loop`: unreadable,
+#   NUL-bearing, duplicate, missing, non-absolute, or invalid-placement metadata
+#   currently refuses globally, which is required.
+#   The earlier `sed -n` field extraction discarded parse status and could omit
+#   an owner; the checked single-pass parser is the required converted behavior.
+# - `bin/fm-next-cache-sweep.sh: sweep_path_identity -> cd, uname, and stat -L`:
+#   an unresolvable referent, platform lookup failure, stat failure, empty output,
+#   or malformed device and inode currently refuses the relevant scope, which is
+#   required.
+# - `bin/fm-next-cache-sweep.sh: sweep_task_owns -> recorded paths and identities`:
+#   exact path or device-inode equality proves ownership, a complete mismatch
+#   proves no recorded owner, and candidate identity failure returns undetermined,
+#   which is the required three-way result.
+#
+# Project discovery, pool, and candidate inputs:
+# - `bin/fm-next-cache-sweep.sh: sweep_project_directories -> os.scandir and
+#   entry.is_dir`: enumeration, entry-type, or unsafe-path failure currently exits
+#   2 instead of silently dropping a project, which is the required global refusal.
+# - `bin/fm-next-cache-sweep.sh: sweep_project -> sweep_resolve_directory and
+#   git rev-parse --git-dir`: an unenterable project or unreadable Git answer
+#   currently refuses that project, which is required.
+# - `bin/fm-next-cache-sweep.sh: sweep_pool_entries -> mktemp, treehouse status
+#   --json, staged-file read, JSON decode, and temp removal`: command failure,
+#   malformed encoding or JSON, NUL, wrong top-level shape, or staging failure
+#   currently refuses that project atomically, which is required.
+# - `bin/fm-next-cache-sweep.sh: sweep_pool_entries -> status and path fields`:
+#   missing, non-string, empty, non-absolute, NUL-bearing, tab-bearing, or
+#   newline-bearing fields currently refuse the project before shell parsing,
+#   which is required at the Python to shell boundary.
+# - `bin/fm-next-cache-sweep.sh: sweep_project_plan -> pool directory predicate,
+#   sweep_path_identity, and duplicate identity scan`: an absent or unresolvable
+#   path or duplicate filesystem copy currently refuses the project, which is
+#   required.
+# - `bin/fm-next-cache-sweep.sh: sweep_project_plan and sweep_unowned_reason ->
+#   candidate provenance`: today any repository directory passes because
+#   `git rev-parse --git-dir` answers in the project clone and in child directories.
+#   The contract requires positive proof that the candidate is the root of a
+#   linked worktree registered to this project and is not the project clone.
+# - `bin/fm-next-cache-sweep.sh: sweep_unowned_reason -> pool status`: only the
+#   exact `available` value can proceed, `in-use` is a proven owner, and every
+#   other value is undetermined, which is the required direction.
+# - `bin/fm-next-cache-sweep.sh: sweep_unowned_reason -> git status --porcelain
+#   and git stash list`: command failure is undetermined and non-empty output is
+#   owned, which is the required fail-closed direction.
+# - `bin/fm-next-cache-sweep.sh: sweep_project_plan -> fm_next_cache_inspect and
+#   FM_NEXT_CACHE_* outputs`: failed discovery, eligibility, or measurement
+#   refuses the project and a completed result becomes an owned or free plan row,
+#   which is the required project-atomic boundary.
+#
+# Shared build-output discovery and removal inputs:
+# - `bin/fm-next-cache-lib.sh: fm_next_cache_size_kb -> du -sk`: command failure
+#   or malformed output currently returns nonzero, which is required.
+#   The earlier implementation normalized failed measurement to zero and could
+#   report unmeasured output as absent; that unsafe direction has been converted.
+# - `bin/fm-next-cache-lib.sh: fm_next_cache_parent_is_next_app -> next.config.*
+#   and package.json predicates plus grep`: absent app evidence is a safe negative,
+#   a grep match is positive, and a grep error is undetermined, which is required.
+# - `bin/fm-next-cache-lib.sh: fm_next_cache_is_build_output -> path existence,
+#   directory and symlink predicates, physical resolution, containment, git
+#   check-ignore, and app-root result`: a proven non-candidate is retained while
+#   missing evidence or command failure is undetermined, which is required.
+# - `bin/fm-next-cache-lib.sh: fm_next_cache_inspect -> worktree cd and git
+#   rev-parse --git-dir`: entry or Git failure currently returns an inspection
+#   error, which is required.
+#   The earlier `fm_next_cache_dirs` returned success with no output for these
+#   failures and could report an unreadable copy as empty; that has been converted.
+# - `bin/fm-next-cache-lib.sh: fm_next_cache_inspect -> mktemp, find -print0,
+#   NUL-delimited read, and temp removal`: staging, traversal, unsafe-path, read,
+#   or cleanup failure currently discards the plan and returns nonzero, which is
+#   required.
+#   The earlier process-substitution walk discarded `find` status and could emit
+#   a partial directory set; staged checked traversal is the converted behavior.
+# - `bin/fm-next-cache-lib.sh: fm_next_cache_report and fm_next_cache_reclaim ->
+#   plan rows and fm_next_cache_human_kb`: malformed formatting or a repeated
+#   inspection failure returns nonzero, which is required.
+# - `bin/fm-next-cache-lib.sh: fm_next_cache_reclaim -> rm -rf and post-removal
+#   existence predicates`: failed or incomplete removal is reported and returns
+#   nonzero while successful removal alone contributes reclaimed bytes, which is
+#   required.
+#
+# Outcome and summary inputs:
+# - `bin/fm-next-cache-sweep.sh: sweep_apply_project_plan -> report or reclaim
+#   status and FM_NEXT_CACHE_TOTAL_KB`: failures currently become named failed
+#   outcomes and successful measured work contributes totals, which is required.
+#   The earlier dry-run and removal branches only changed exit status, allowing
+#   all-zero counters to select a clean summary; named failure outcomes are the
+#   required converted behavior.
+# - `bin/fm-next-cache-sweep.sh: sweep_project_plan, sweep_project, project loop,
+#   and final summary -> project completeness and copy verdicts`: today a copy
+#   inspected before a later project refusal still increments the run's inspected
+#   count even though its discarded plan produced no outcome.
+#   The contract requires only fully applied project verdicts to enter run totals,
+#   and it makes every clean `nothing to reclaim` sentence unreachable unless
+#   every requested project completed and every returned copy has a final verdict.
 set -u
 
 case "${BASH_SOURCE[0]}" in

--- a/bin/fm-next-cache-sweep.sh
+++ b/bin/fm-next-cache-sweep.sh
@@ -103,46 +103,99 @@ command -v python3 >/dev/null 2>&1 \
 # Every state directory whose task records could own a pooled copy: this home's
 # plus every locally registered secondmate's. A remote secondmate's home lives on
 # another machine and cannot hold this machine's pool, so it is not consulted.
+TASK_STATE_DIRS=
+TASK_RECORD_ERROR=
 sweep_task_record_state_dirs() {
-  local registry="$DATA/secondmates.md" line home
-  printf '%s\n' "$STATE"
-  [ -f "$registry" ] || return 0
+  local registry="$DATA/secondmates.md" registry_contents line home
+  TASK_STATE_DIRS=$STATE
+  if [ ! -e "$registry" ] && [ ! -L "$registry" ]; then return 0; fi
+  if [ ! -f "$registry" ] || ! registry_contents=$(cat "$registry" 2>/dev/null); then
+    TASK_RECORD_ERROR="cannot read secondmate registry: $registry"
+    return 1
+  fi
   while IFS= read -r line || [ -n "$line" ]; do
     case "$line" in '- '*) ;; *) continue ;; esac
-    secondmate_registry_parse_line "$line" || continue
+    if ! secondmate_registry_parse_line "$line"; then
+      TASK_RECORD_ERROR="malformed secondmate registry entry in $registry: $line"
+      return 1
+    fi
     if [ "$SECONDMATE_REGISTRY_REMOTE" -eq 1 ]; then continue; fi
     home=$SECONDMATE_REGISTRY_HOME
-    [ -n "$home" ] || continue
-    printf '%s/state\n' "$home"
-  done < "$registry"
+    if [ ! -e "$home" ] && [ ! -L "$home" ]; then
+      printf 'sweep: registered local secondmate home is absent: %s; no local task records to inspect\n' \
+        "$home" >&2
+      continue
+    fi
+    TASK_STATE_DIRS="$TASK_STATE_DIRS"$'\n'"$home/state"
+  done <<EOT
+$registry_contents
+EOT
 }
 
 TASK_WORKTREES=
 sweep_load_task_worktrees() {
-  local state_dir meta
-  TASK_WORKTREES=$(
-    while IFS= read -r state_dir; do
-      [ -d "$state_dir" ] || continue
-      for meta in "$state_dir"/*.meta; do
-        [ -f "$meta" ] || continue
-        sed -n 's/^worktree=//p' "$meta"
-      done
-    done < <(sweep_task_record_state_dirs)
-  )
+  local state_dir meta worktrees
+  TASK_WORKTREES=
+  TASK_RECORD_ERROR=
+  sweep_task_record_state_dirs || return 1
+  while IFS= read -r state_dir; do
+    [ -n "$state_dir" ] || continue
+    if [ ! -d "$state_dir" ] || [ ! -r "$state_dir" ] || [ ! -x "$state_dir" ]; then
+      TASK_RECORD_ERROR="cannot read task state directory: $state_dir"
+      return 1
+    fi
+    for meta in "$state_dir"/*.meta; do
+      if [ ! -e "$meta" ] && [ ! -L "$meta" ]; then continue; fi
+      if [ ! -f "$meta" ] || ! worktrees=$(sed -n 's/^worktree=//p' "$meta" 2>/dev/null); then
+        TASK_RECORD_ERROR="cannot read task metadata: $meta"
+        return 1
+      fi
+      [ -n "$worktrees" ] || continue
+      if [ -n "$TASK_WORKTREES" ]; then
+        TASK_WORKTREES="$TASK_WORKTREES"$'\n'"$worktrees"
+      else
+        TASK_WORKTREES=$worktrees
+      fi
+    done
+  done <<EOT
+$TASK_STATE_DIRS
+EOT
+}
+
+sweep_path_identity() {  # <path>
+  if [ "$(uname)" = Darwin ]; then
+    stat -f '%d:%i' "$1" 2>/dev/null
+  else
+    stat -c '%d:%i' "$1" 2>/dev/null
+  fi
 }
 
 # Does any task record name <path> as its worktree?
 sweep_task_owns() {  # <path>
-  local path=$1
+  local path=$1 path_identity recorded recorded_identity
+  if [ -n "$TASK_WORKTREES" ] && printf '%s\n' "$TASK_WORKTREES" | grep -Fxq -- "$path"; then
+    return 0
+  fi
+  path_identity=$(sweep_path_identity "$path") || return 2
   [ -n "$TASK_WORKTREES" ] || return 1
-  printf '%s\n' "$TASK_WORKTREES" | grep -Fxq -- "$path"
+  while IFS= read -r recorded; do
+    [ -n "$recorded" ] || continue
+    if [ ! -e "$recorded" ] && [ ! -L "$recorded" ]; then continue; fi
+    recorded_identity=$(sweep_path_identity "$recorded") || return 2
+    if [ "$recorded_identity" = "$path_identity" ]; then return 0; fi
+  done <<EOT
+$TASK_WORKTREES
+EOT
+  return 1
 }
 
 # Print "<status>\t<path>" for every worktree in <project-dir>'s pool.
 # treehouse resolves the pool from the working directory, and reading pool
 # status changes nothing in the clone.
 sweep_pool_entries() {  # <project-dir>
-  ( cd "$1" && treehouse status --json 2>/dev/null ) | python3 -c '
+  local raw
+  raw=$(cd "$1" && treehouse status --json 2>/dev/null) || return 1
+  printf '%s\n' "$raw" | python3 -c '
 import json, sys
 
 # Anything this cannot read as a list of pool entries exits non-zero, so the
@@ -172,7 +225,7 @@ for entry in pool:
 # because the same broken inspection that hides its owner also hides how much it
 # is holding, and a silent skip there would read as "nothing here".
 sweep_unowned_reason() {  # <status> <worktree>
-  local status=$1 wt=$2
+  local status=$1 wt=$2 task_ownership
   # Only the pool's own word for "available" clears this check. Any other
   # value - in-use, a status this version of treehouse does not print, or none
   # at all - means ownership was not established, which is not the same as
@@ -185,10 +238,18 @@ sweep_unowned_reason() {  # <status> <worktree>
     printf 'undetermined\tthe pool did not report it available\n'
     return 0
   fi
-  if sweep_task_owns "$wt"; then
-    printf 'owned\tstill claimed by a task record\n'
-    return 0
-  fi
+  sweep_task_owns "$wt"
+  task_ownership=$?
+  case "$task_ownership" in
+    0)
+      printf 'owned\tstill claimed by a task record\n'
+      return 0
+      ;;
+    2)
+      printf 'undetermined\tcannot compare it with task-record worktrees\n'
+      return 0
+      ;;
+  esac
   if ! git -C "$wt" rev-parse --git-dir >/dev/null 2>&1; then
     printf 'undetermined\tnot an inspectable git worktree\n'
     return 0
@@ -227,21 +288,24 @@ fi
 
 [ "${#TARGETS[@]}" -gt 0 ] || sweep_die "no project clones to sweep under $PROJECTS"
 
-sweep_load_task_worktrees
+sweep_load_task_worktrees || sweep_die "$TASK_RECORD_ERROR"
 
 RC=0
 TOTAL_KB=0
 RECLAIMED=0
 SKIPPED=0
+INCOMPLETE=0
 for project in "${TARGETS[@]}"; do
   if ! project_real=$(CDPATH='' cd -- "$project" 2>/dev/null && pwd -P); then
     printf 'sweep: cannot enter project %s\n' "$project" >&2
     RC=1
+    INCOMPLETE=$(( INCOMPLETE + 1 ))
     continue
   fi
   if ! entries=$(sweep_pool_entries "$project_real"); then
     printf 'sweep: cannot read the worktree pool for %s\n' "$project_real" >&2
     RC=1
+    INCOMPLETE=$(( INCOMPLETE + 1 ))
     continue
   fi
   while IFS=$'\t' read -r status wt; do
@@ -284,19 +348,30 @@ sweep_copies() {  # <count>
   if [ "$1" -eq 1 ]; then printf '1 copy\n'; else printf '%d copies\n' "$1"; fi
 }
 
+sweep_projects() {  # <count>
+  if [ "$1" -eq 1 ]; then printf '1 project\n'; else printf '%d projects\n' "$1"; fi
+}
+
+INCOMPLETE_NOTE=
+if [ "$INCOMPLETE" -gt 0 ]; then
+  INCOMPLETE_NOTE="; $(sweep_projects "$INCOMPLETE") could not be inspected"
+fi
+
 if [ "$RECLAIMED" -eq 0 ]; then
   if [ "$SKIPPED" -gt 0 ]; then
-    printf 'sweep: nothing to reclaim; %s were skipped as owned or unassessable (listed above)\n' \
-      "$(sweep_copies "$SKIPPED")"
+    printf 'sweep: nothing to reclaim; %s were skipped as owned or unassessable (listed above)%s\n' \
+      "$(sweep_copies "$SKIPPED")" "$INCOMPLETE_NOTE"
+  elif [ "$INCOMPLETE" -gt 0 ]; then
+    printf 'sweep: nothing to reclaim in inspected projects%s\n' "$INCOMPLETE_NOTE"
   else
     printf 'sweep: nothing to reclaim; no idle copy holds Next.js build output\n'
   fi
 elif [ "$DRY_RUN" = 1 ]; then
-  printf 'sweep: would reclaim %s from %s\n' \
-    "$(fm_next_cache_human_kb "$TOTAL_KB")" "$(sweep_copies "$RECLAIMED")"
+  printf 'sweep: would reclaim %s from %s%s\n' \
+    "$(fm_next_cache_human_kb "$TOTAL_KB")" "$(sweep_copies "$RECLAIMED")" "$INCOMPLETE_NOTE"
 else
-  printf 'sweep: reclaimed %s from %s\n' \
-    "$(fm_next_cache_human_kb "$TOTAL_KB")" "$(sweep_copies "$RECLAIMED")"
+  printf 'sweep: reclaimed %s from %s%s\n' \
+    "$(fm_next_cache_human_kb "$TOTAL_KB")" "$(sweep_copies "$RECLAIMED")" "$INCOMPLETE_NOTE"
 fi
 
 exit "$RC"

--- a/bin/fm-next-cache-sweep.sh
+++ b/bin/fm-next-cache-sweep.sh
@@ -590,6 +590,88 @@ PY
   return "$parse_status"
 }
 
+sweep_pool_worktree_provenance() {  # <project-dir> <worktree>
+  local project=$1 wt=$2 wt_real top top_real tmp verify_status=0
+  SWEEP_POOL_PROVENANCE_REASON=
+  if ! wt_real=$(sweep_resolve_directory "$wt"); then
+    SWEEP_POOL_PROVENANCE_REASON="not an inspectable git worktree"
+    return 1
+  fi
+  if ! top=$(git -C "$wt_real" rev-parse --show-toplevel 2>/dev/null); then
+    SWEEP_POOL_PROVENANCE_REASON="not an inspectable git worktree"
+    return 1
+  fi
+  case "$top" in
+    ''|*$'\t'*|*$'\r'*|*$'\n'*)
+      SWEEP_POOL_PROVENANCE_REASON="worktree root is malformed"
+      return 1
+      ;;
+  esac
+  if ! top_real=$(sweep_resolve_directory "$top"); then
+    SWEEP_POOL_PROVENANCE_REASON="worktree root cannot be resolved"
+    return 1
+  fi
+  if [ "$top_real" != "$wt_real" ]; then
+    SWEEP_POOL_PROVENANCE_REASON="pool path is not a worktree root"
+    return 1
+  fi
+  if ! tmp=$(umask 077; mktemp "${TMPDIR:-/tmp}/fm-next-cache-worktrees.XXXXXX" 2>/dev/null); then
+    SWEEP_POOL_PROVENANCE_REASON="cannot stage the project's worktree registry"
+    return 1
+  fi
+  if ! git -C "$project" worktree list --porcelain -z > "$tmp" 2>/dev/null; then
+    rm -f -- "$tmp" || true
+    SWEEP_POOL_PROVENANCE_REASON="cannot read the project's worktree registry"
+    return 1
+  fi
+  python3 - "$tmp" "$wt_real" "$project" <<'PY' || verify_status=$?
+import os, sys
+
+try:
+    raw = open(sys.argv[1], "rb").read()
+    candidate = os.stat(sys.argv[2])
+    project = os.stat(sys.argv[3])
+except OSError:
+    sys.exit(1)
+candidate_id = (candidate.st_dev, candidate.st_ino)
+project_id = (project.st_dev, project.st_ino)
+if candidate_id == project_id or not raw.endswith(b"\0\0"):
+    sys.exit(1)
+records = raw[:-2].split(b"\0\0")
+if not records or any(not record for record in records):
+    sys.exit(1)
+seen = set()
+matches = 0
+for record in records:
+    fields = record.split(b"\0")
+    worktrees = [field[len(b"worktree "):] for field in fields
+                 if field.startswith(b"worktree ")]
+    if len(worktrees) != 1 or not worktrees[0] or fields[0] != b"worktree " + worktrees[0]:
+        sys.exit(1)
+    try:
+        info = os.stat(worktrees[0])
+    except OSError:
+        sys.exit(1)
+    identity = (info.st_dev, info.st_ino)
+    if identity in seen:
+        sys.exit(1)
+    seen.add(identity)
+    if identity == candidate_id:
+        matches += 1
+if matches != 1:
+    sys.exit(1)
+PY
+  if ! rm -f -- "$tmp"; then
+    SWEEP_POOL_PROVENANCE_REASON="cannot clear the project's worktree registry state"
+    return 1
+  fi
+  if [ "$verify_status" -ne 0 ]; then
+    SWEEP_POOL_PROVENANCE_REASON="not a linked worktree registered to this project"
+    return 1
+  fi
+  return 0
+}
+
 # Classify why <worktree> may not be swept in SWEEP_OWNER_CLASS and
 # SWEEP_OWNER_REASON. `owned` is a complete answer; `undetermined` makes the
 # project's preflight incomplete.
@@ -656,8 +738,9 @@ sweep_unowned_reason() {  # <status> <worktree>
 
 SWEEP_PROJECT_PLAN=
 SWEEP_PROJECT_INSPECTED=0
-sweep_project_plan() {  # <entries>
-  local entries=$1 status wt record pool_identity recorded_identity
+sweep_project_plan() {  # <project> <entries>
+  local project=$1 entries=$2 status wt record pool_identity recorded_identity
+  local inspected=0
   local pool_identities=
   SWEEP_PROJECT_PLAN=
   SWEEP_PROJECT_INSPECTED=0
@@ -673,6 +756,10 @@ sweep_project_plan() {  # <entries>
       fi
       if ! pool_identity=$(sweep_path_identity "$wt"); then
         sweep_incomplete "pool worktree identity cannot be established: $wt"
+        return
+      fi
+      if ! sweep_pool_worktree_provenance "$project" "$wt"; then
+        sweep_incomplete "$wt pool provenance could not be established ($SWEEP_POOL_PROVENANCE_REASON)"
         return
       fi
       if [ -n "$pool_identities" ]; then
@@ -697,7 +784,7 @@ EOT
         sweep_incomplete "$wt build output could not be inspected ($FM_NEXT_CACHE_INSPECTION_ERROR)"
         return
       fi
-      SWEEP_PROJECT_INSPECTED=$(( SWEEP_PROJECT_INSPECTED + 1 ))
+      inspected=$(( inspected + 1 ))
       if [ "$SWEEP_OWNER_CLASS" = owned ]; then
         record="owned"$'\t'"$SWEEP_OWNER_REASON"$'\t'"$FM_NEXT_CACHE_TOTAL_KB"$'\t'"$wt"
       else
@@ -712,6 +799,7 @@ EOT
   done <<EOT
 $entries
 EOT
+  SWEEP_PROJECT_INSPECTED=$inspected
 }
 
 sweep_apply_project_plan() {  # <plan>
@@ -762,7 +850,7 @@ sweep_project() {  # <project>
     sweep_incomplete "cannot read the worktree pool for $project_real"
     return
   fi
-  if ! sweep_project_plan "$entries"; then
+  if ! sweep_project_plan "$project_real" "$entries"; then
     return 1
   fi
   sweep_apply_project_plan "$SWEEP_PROJECT_PLAN"
@@ -798,12 +886,15 @@ COMPLETE_PROJECTS=0
 for project in "${TARGETS[@]}"; do
   sweep_project "$project"
   project_status=$?
-  INSPECTED=$(( INSPECTED + SWEEP_PROJECT_INSPECTED ))
   if [ "$project_status" -ne 0 ]; then
     RC=1
     INCOMPLETE=$(( INCOMPLETE + 1 ))
   elif [ "$SWEEP_PROJECT_COMPLETE" -eq 1 ]; then
+    INSPECTED=$(( INSPECTED + SWEEP_PROJECT_INSPECTED ))
     COMPLETE_PROJECTS=$(( COMPLETE_PROJECTS + 1 ))
+  else
+    RC=1
+    INCOMPLETE=$(( INCOMPLETE + 1 ))
   fi
 done
 
@@ -825,19 +916,28 @@ if [ "$FAILED" -gt 0 ]; then
   FAILED_NOTE="; $(sweep_copies "$FAILED") could not be processed"
 fi
 
-if [ "$RECLAIMED" -eq 0 ]; then
-  if [ "$FAILED" -gt 0 ]; then
+RUN_COMPLETE=0
+if [ "$INCOMPLETE" -eq 0 ] && [ "$FAILED" -eq 0 ] \
+  && [ "$COMPLETE_PROJECTS" -eq "${#TARGETS[@]}" ]; then
+  RUN_COMPLETE=1
+fi
+
+if [ "$RUN_COMPLETE" -eq 0 ]; then
+  if [ "$DRY_RUN" = 1 ] && [ "$RECLAIMED" -gt 0 ]; then
+    printf 'sweep: would reclaim %s from %s, but inspection was incomplete%s%s\n' \
+      "$(fm_next_cache_human_kb "$TOTAL_KB")" "$(sweep_copies "$RECLAIMED")" \
+      "$FAILED_NOTE" "$INCOMPLETE_NOTE"
+  elif [ "$RECLAIMED" -gt 0 ]; then
+    printf 'sweep: reclaimed %s from %s, but processing was incomplete%s%s\n' \
+      "$(fm_next_cache_human_kb "$TOTAL_KB")" "$(sweep_copies "$RECLAIMED")" \
+      "$FAILED_NOTE" "$INCOMPLETE_NOTE"
+  else
     printf 'sweep: reclamation incomplete%s%s\n' "$FAILED_NOTE" "$INCOMPLETE_NOTE"
-  elif [ "$SKIPPED" -gt 0 ]; then
+  fi
+elif [ "$RECLAIMED" -eq 0 ]; then
+  if [ "$SKIPPED" -gt 0 ]; then
     printf 'sweep: nothing to reclaim; %s were skipped as owned (listed above)%s\n' \
       "$(sweep_copies "$SKIPPED")" "$INCOMPLETE_NOTE"
-  elif [ "$INCOMPLETE" -gt 0 ]; then
-    if [ "$INSPECTED" -eq 0 ]; then
-      printf 'sweep: no copy was completely inspected%s\n' "$INCOMPLETE_NOTE"
-    else
-      printf 'sweep: nothing to reclaim in %s%s\n' \
-        "$(sweep_copies "$INSPECTED")" "$INCOMPLETE_NOTE"
-    fi
   elif [ "$INSPECTED" -eq 0 ]; then
     printf 'sweep: nothing to reclaim; %s contained no copies\n' \
       "$(sweep_projects "$COMPLETE_PROJECTS")"

--- a/bin/fm-next-cache-sweep.sh
+++ b/bin/fm-next-cache-sweep.sh
@@ -9,8 +9,8 @@
 #
 # Usage: fm-next-cache-sweep.sh [--dry-run] [<project-dir>...]
 #   --dry-run   report what would be reclaimed and remove nothing.
-#   <project-dir>...  sweep these project clones' pools instead of every clone
-#                     under $FM_HOME/projects.
+#   <project-dir>...  inspect and report these project clones' pools without
+#                     deleting; default discovery retains reclamation authority.
 #
 # WHAT IT TOUCHES. Only pooled task copies, and only the Next.js build output
 # inside them - bin/fm-next-cache-lib.sh's header owns that discovery rule and
@@ -84,13 +84,13 @@
 #   exit 2, and retains non-options verbatim. Falsifier: `--unknown` is retained
 #   as a project, or `-- /path` loses the literal project path before validation.
 # - `bin/fm-next-cache-sweep.sh: target construction -> PROJECT_ARGS,
-#   sweep_project_directories, and TARGETS`. Checked: today both sources become
-#   indistinguishable plain paths. Wrong verdict found here: a valid explicit
-#   project therefore inherits the deletion authority intended only for default
-#   discovery. Required: every target carries its origin-derived authority and
-#   only a positively `reclaim`-eligible target may reach removal. Falsifier: an
-#   explicit primary-clone argument with one available clean pool copy removes
-#   that copy instead of recording a report-only terminal verdict.
+#   sweep_project_directories, and TARGETS`. Checked: each target record carries
+#   `report-only` for explicit paths or `reclaim` only for default discovery;
+#   a record with missing authority also reports instead of deleting.
+#   Converted wrong verdict: plain target paths had erased the origin needed to
+#   withhold deletion. Falsifier: an explicit primary-clone argument with one
+#   available clean pool copy removes that copy instead of recording a report-only
+#   terminal verdict.
 # - `bin/fm-next-cache-sweep.sh: command preflight -> command -v treehouse and
 #   python3`. Checked: absence exits 2, while every later invocation separately
 #   checks the command's status. Falsifier: a treehouse shim is found, emits valid
@@ -148,12 +148,12 @@
 #   reaches the target list and clean summary.
 # - `bin/fm-next-cache-sweep.sh: sweep_project -> sweep_resolve_directory and Git
 #   project queries`. Checked: physical entry and `git rev-parse --show-toplevel`
-#   must succeed and the physical top level must equal the argument. Wrong verdict
-#   found here: root equality proves a worktree root, not the primary clone.
-#   Required: `--absolute-git-dir` and absolute `--git-common-dir` must resolve to
-#   the same directory before a target can anchor provenance. Falsifier: an
-#   explicit linked-worktree root passes top-level equality, then a pool row naming
-#   the primary clone passes the distinct-project comparison and reaches removal.
+#   must succeed and the physical top level must equal the argument; resolved
+#   `--absolute-git-dir` and absolute `--git-common-dir` must also be identical.
+#   Converted wrong verdict: root equality had proven a worktree root, not the
+#   primary clone. Falsifier: an explicit linked-worktree root passes top-level
+#   equality, then a pool row naming the primary clone passes the distinct-project
+#   comparison and reaches removal.
 # - `bin/fm-next-cache-sweep.sh: sweep_pool_entries -> mktemp, treehouse status
 #   --json, staged-file read, JSON decode, and temp removal`. Checked: treehouse's
 #   status is captured before parsing, the file is decoded strictly as UTF-8 JSON,
@@ -161,11 +161,11 @@
 #   a plan exists. Falsifier: treehouse writes a complete first row and exits 1
 #   before its second row, but the first row is planned as a complete pool.
 # - `bin/fm-next-cache-sweep.sh: sweep_pool_entries -> JSON object decoding`.
-#   Checked: today `json.loads` silently keeps the last duplicate key. Wrong
-#   verdict found here: syntactically decoded JSON is not necessarily unambiguous
-#   lease evidence. Required: reject duplicate keys at every object before any row
-#   is emitted. Falsifier: one entry contains `"status":"in-use"` followed by
-#   `"status":"available"`, and last-value decoding authorizes deletion.
+#   Checked: an object-pairs hook now rejects every repeated key before a decoded
+#   object or candidate row exists. Converted wrong verdict: syntactically decoded
+#   JSON had not guaranteed unambiguous lease evidence. Falsifier: one entry
+#   contains `"status":"in-use"` followed by `"status":"available"`, and
+#   last-value decoding authorizes deletion.
 # - `bin/fm-next-cache-sweep.sh: sweep_pool_entries -> status and path fields`.
 #   Checked: Python requires both fields to be nonempty strings, the path to be
 #   absolute, and rejects NUL, tab, CR, and LF before emitting tab-delimited rows;
@@ -184,10 +184,11 @@
 #   `--show-toplevel` must physically equal the candidate, the candidate identity
 #   must appear exactly once in `git worktree list --porcelain -z`, and it must
 #   differ from the supplied project identity. Wrong evidence chain: the supplied
-#   identity was proven only to be a root; the primary-clone proof above is also
-#   required. Falsifier: the pool names a child of a live registered worktree and
-#   Git reachability is mistaken for root identity, or a linked project argument
-#   makes the actual primary clone look like a distinct registered candidate.
+#   identity was previously proven only to be a root; it now passes the independent
+#   primary-clone proof above first. Falsifier: the pool names a child of a live
+#   registered worktree and Git reachability is mistaken for root identity, or a
+#   linked project argument makes the actual primary clone look like a distinct
+#   registered candidate.
 # - `bin/fm-next-cache-sweep.sh: sweep_unowned_reason -> pool status`. Checked:
 #   only byte-exact `available` proceeds, `in-use` records ownership, and every
 #   other value records undetermined. Falsifier: `available ` or `AVAILABLE`
@@ -251,12 +252,12 @@
 #
 # Outcome and summary inputs:
 # - `bin/fm-next-cache-sweep.sh: sweep_apply_project_plan -> report or reclaim
-#   status, target authority, and FM_NEXT_CACHE_TOTAL_KB`. Checked: today dry-run
-#   and removal statuses are captured, but target origin is already lost. Required:
-#   exact per-target `reclaim` eligibility chooses removal; explicit and missing
-#   eligibility choose reporting and a distinct terminal verdict. Falsifier: an
-#   explicit target's free candidate calls `fm_next_cache_reclaim`, or its report
-#   is recorded and summarized as reclaimed.
+#   status, target authority, and FM_NEXT_CACHE_TOTAL_KB`. Checked: exact per-target
+#   `reclaim` eligibility chooses removal; explicit and missing eligibility choose
+#   reporting and a distinct terminal verdict. Converted wrong verdict: apply had
+#   received a plain path after target origin was lost. Falsifier: an explicit
+#   target's free candidate calls `fm_next_cache_reclaim`, or its report is recorded
+#   and summarized as reclaimed.
 # - `bin/fm-next-cache-sweep.sh: sweep_project_plan, sweep_project, project loop,
 #   and final summary -> announced candidates and final verdicts`. Checked: project
 #   plans remain atomic, the complete pool list announces indexed candidates
@@ -309,6 +310,7 @@ Usage: fm-next-cache-sweep.sh [--dry-run] [<project-dir>...]
 
 Reclaim Next.js build output from pooled task copies that nobody is using.
 With no project directory, sweeps every project clone under $FM_HOME/projects.
+Explicit project directories are inspected and reported without deleting.
 
   --dry-run   report what would be reclaimed and remove nothing.
 
@@ -360,6 +362,21 @@ sweep_path_identity() {  # <path>
   [ "$device:$inode" = "$identity" ] || return 1
   case "$device$inode" in ''|*[!0-9]*) return 1 ;; esac
   printf '%s\n' "$identity"
+}
+
+sweep_project_is_primary_worktree() {  # <path>
+  local project=$1 git_dir common_dir git_dir_real common_dir_real
+  git_dir=$(git -C "$project" rev-parse --absolute-git-dir 2>/dev/null) \
+    || return 1
+  common_dir=$(git -C "$project" \
+    rev-parse --path-format=absolute --git-common-dir 2>/dev/null) \
+    || return 1
+  case "$git_dir$common_dir" in
+    *$'\t'*|*$'\r'*|*$'\n'*) return 1 ;;
+  esac
+  git_dir_real=$(sweep_resolve_directory "$git_dir") || return 1
+  common_dir_real=$(sweep_resolve_directory "$common_dir") || return 1
+  [ "$git_dir_real" = "$common_dir_real" ]
 }
 
 sweep_read_text_file() {  # <path>
@@ -632,6 +649,14 @@ sweep_pool_entries() {  # <project-dir>
   python3 - "$tmp" <<'PY' || parse_status=$?
 import json, sys
 
+def unique_object(pairs):
+    value = {}
+    for key, item in pairs:
+        if key in value:
+            raise ValueError()
+        value[key] = item
+    return value
+
 # Anything this cannot read as a list of pool entries exits non-zero, so the
 # caller reports the project as unreadable and sweeps none of its copies. An
 # unparseable pool is not an empty pool, and it is certainly not a pool of
@@ -640,7 +665,7 @@ try:
     raw = open(sys.argv[1], "rb").read()
     if b"\0" in raw:
         raise ValueError()
-    pool = json.loads(raw.decode("utf-8"))
+    pool = json.loads(raw.decode("utf-8"), object_pairs_hook=unique_object)
 except (OSError, UnicodeError, ValueError):
     sys.exit(1)
 if not isinstance(pool, list):
@@ -837,14 +862,18 @@ sweep_record_candidate_verdict() {  # <project> <candidate-id> <verdict> <reason
   local recorded_id record human
   case "$candidate_id" in ''|*[!0-9]*) return 1 ;; esac
   case "$verdict" in
-    reclaimed|skipped-as-owned|undetermined|refused|failed) ;;
+    reclaimed|reported|skipped-as-owned|undetermined|refused|failed) ;;
     *) return 1 ;;
   esac
   case "$kb" in -) ;; ''|*[!0-9]*) return 1 ;; esac
   case "$project$reason$wt" in *$'\t'*|*$'\r'*|*$'\n'*) return 1 ;; esac
-  if [ "$verdict" = skipped-as-owned ] && [ "$kb" -gt 0 ]; then
-    human=$(fm_next_cache_human_kb "$kb") || return 1
-  fi
+  case "$verdict" in
+    reported|skipped-as-owned)
+      if [ "$kb" -gt 0 ]; then
+        human=$(fm_next_cache_human_kb "$kb") || return 1
+      fi
+      ;;
+  esac
   if [ -n "$SWEEP_PROJECT_VERDICT_IDS" ]; then
     while IFS= read -r recorded_id; do
       [ "$recorded_id" = "$candidate_id" ] && return 1
@@ -865,6 +894,15 @@ EOT
   CANDIDATE_VERDICTS=$(( CANDIDATE_VERDICTS + 1 ))
   case "$verdict" in
     reclaimed) ;;
+    reported)
+      if [ "$kb" -gt 0 ]; then
+        printf 'sweep: report-only %s (%s), holding %s\n' \
+          "$wt" "$reason" "$human"
+      else
+        printf 'sweep: report-only %s (%s), no Next.js build output\n' \
+          "$wt" "$reason"
+      fi
+      ;;
     skipped-as-owned)
       if [ "$kb" -gt 0 ]; then
         printf 'sweep: skipped-as-owned %s (%s), holding %s\n' \
@@ -887,6 +925,9 @@ sweep_summarize_candidate_ledger() {
   local project candidate_id verdict reason kb wt rows=0
   TOTAL_KB=0
   RECLAIMED=0
+  REPORTED=0
+  REPORTED_KB=0
+  REPORT_ONLY_INSPECTED=0
   SKIPPED=0
   INSPECTED=0
   FAILED=0
@@ -903,6 +944,15 @@ sweep_summarize_candidate_ledger() {
           if [ "$kb" -gt 0 ]; then
             TOTAL_KB=$(( TOTAL_KB + kb ))
             RECLAIMED=$(( RECLAIMED + 1 ))
+          fi
+          ;;
+        reported)
+          [ "$kb" = - ] && return 1
+          INSPECTED=$(( INSPECTED + 1 ))
+          REPORT_ONLY_INSPECTED=$(( REPORT_ONLY_INSPECTED + 1 ))
+          if [ "$kb" -gt 0 ]; then
+            REPORTED_KB=$(( REPORTED_KB + kb ))
+            REPORTED=$(( REPORTED + 1 ))
           fi
           ;;
         skipped-as-owned)
@@ -1060,12 +1110,34 @@ EOT
   fi
 }
 
-sweep_apply_project_plan() {  # <project> <plan>
-  local project=$1 plan=$2 candidate_id action reason planned_kb wt apply_status
-  local record_error=0
+sweep_apply_project_plan() {  # <project> <plan> <authority>
+  local project=$1 plan=$2 authority=$3 candidate_id action reason planned_kb wt
+  local apply_status report_reason record_error=0
   while IFS=$'\t' read -r candidate_id action reason planned_kb wt; do
     if [ -n "$candidate_id" ]; then
-      if [ "$action" = owned ]; then
+      if [ "$authority" != reclaim ]; then
+        apply_status=0
+        fm_next_cache_report "$wt" "sweep" || apply_status=$?
+        if [ "$authority" = report-only ]; then
+          report_reason="operator-supplied project is report-only"
+        else
+          report_reason="target has no deletion eligibility"
+        fi
+        if [ "$action" = owned ]; then
+          report_reason="$report_reason; $reason"
+        fi
+        if [ "$apply_status" -ne 0 ]; then
+          sweep_record_candidate_verdict \
+            "$project" "$candidate_id" failed \
+            "report-only build output could not be processed" 0 "$wt" \
+            || record_error=1
+        else
+          sweep_record_candidate_verdict \
+            "$project" "$candidate_id" reported \
+            "$report_reason" "$FM_NEXT_CACHE_TOTAL_KB" "$wt" \
+            || record_error=1
+        fi
+      elif [ "$action" = owned ]; then
         sweep_record_candidate_verdict \
           "$project" "$candidate_id" skipped-as-owned "$reason" "$planned_kb" "$wt" \
           || record_error=1
@@ -1098,8 +1170,8 @@ EOT
   [ "$record_error" -eq 0 ]
 }
 
-sweep_project() {  # <project>
-  local project=$1 project_real project_top project_top_real entries
+sweep_project() {  # <project> <authority>
+  local project=$1 authority=${2:-} project_real project_top project_top_real entries
   SWEEP_PROJECT_ANNOUNCED=0
   SWEEP_PROJECT_ASSESSED=0
   SWEEP_PROJECT_VERDICTS=0
@@ -1127,6 +1199,10 @@ sweep_project() {  # <project>
     sweep_incomplete "project path is not a project root: $project_real"
     return
   fi
+  if ! sweep_project_is_primary_worktree "$project_real"; then
+    sweep_incomplete "project path is not the primary project clone: $project_real"
+    return
+  fi
   if ! entries=$(sweep_pool_entries "$project_real"); then
     sweep_incomplete "cannot read the worktree pool for $project_real"
     return
@@ -1134,7 +1210,8 @@ sweep_project() {  # <project>
   if ! sweep_project_plan "$project_real" "$entries"; then
     return 1
   fi
-  if ! sweep_apply_project_plan "$project_real" "$SWEEP_PROJECT_PLAN"; then
+  if ! sweep_apply_project_plan \
+    "$project_real" "$SWEEP_PROJECT_PLAN" "$authority"; then
     sweep_reconcile_project_verdicts "$project_real" || true
     sweep_incomplete "candidate verdict could not be recorded for $project_real"
     return
@@ -1143,15 +1220,24 @@ sweep_project() {  # <project>
   SWEEP_PROJECT_COMPLETE=1
 }
 
+TARGETS=()
+sweep_add_target() {  # <path> [<origin>]
+  local path=$1 origin=${2:-} authority=report-only
+  case "$path" in *$'\t'*|*$'\r'*|*$'\n'*) sweep_die "unsafe project target" ;; esac
+  [ "$origin" = default-discovery ] && authority=reclaim
+  TARGETS+=("$authority"$'\t'"$path")
+}
+
 if [ "${#PROJECT_ARGS[@]}" -gt 0 ]; then
-  TARGETS=("${PROJECT_ARGS[@]}")
+  for project in "${PROJECT_ARGS[@]}"; do
+    sweep_add_target "$project" explicit
+  done
 else
-  TARGETS=()
   if ! project_dirs=$(sweep_project_directories "$PROJECTS"); then
     sweep_die "cannot enumerate project clones under $PROJECTS"
   fi
   while IFS= read -r dir; do
-    [ -n "$dir" ] && TARGETS+=("$dir")
+    [ -n "$dir" ] && sweep_add_target "$dir" default-discovery
   done <<EOT
 $project_dirs
 EOT
@@ -1169,21 +1255,38 @@ INCOMPLETE=0
 INSPECTED=0
 FAILED=0
 COMPLETE_PROJECTS=0
+REPORT_ONLY_PROJECTS=0
 CANDIDATE_LEDGER=
 CANDIDATE_ANNOUNCED=0
 CANDIDATE_VERDICTS=0
-for project in "${TARGETS[@]}"; do
-  sweep_project "$project"
+target_index=0
+while [ "$target_index" -lt "${#TARGETS[@]}" ]; do
+  target=${TARGETS[$target_index]}
+  case "$target" in
+    *$'\t'*)
+      authority=${target%%$'\t'*}
+      project=${target#*$'\t'}
+      ;;
+    *)
+      authority=
+      project=$target
+      ;;
+  esac
+  sweep_project "$project" "$authority"
   project_status=$?
   if [ "$project_status" -ne 0 ]; then
     RC=1
     INCOMPLETE=$(( INCOMPLETE + 1 ))
   elif [ "$SWEEP_PROJECT_COMPLETE" -eq 1 ]; then
     COMPLETE_PROJECTS=$(( COMPLETE_PROJECTS + 1 ))
+    if [ "$authority" != reclaim ]; then
+      REPORT_ONLY_PROJECTS=$(( REPORT_ONLY_PROJECTS + 1 ))
+    fi
   else
     RC=1
     INCOMPLETE=$(( INCOMPLETE + 1 ))
   fi
+  target_index=$(( target_index + 1 ))
 done
 
 LEDGER_INCOMPLETE=0
@@ -1221,6 +1324,15 @@ if [ "$FAILED" -gt 0 ]; then
   FAILED_NOTE="; $(sweep_copies "$FAILED") could not be processed"
 fi
 
+REPORT_ONLY_NOTE=
+if [ "$REPORTED" -gt 0 ]; then
+  REPORT_ONLY_NOTE="; report-only inspection found $(fm_next_cache_human_kb "$REPORTED_KB") in $(sweep_copies "$REPORTED")"
+elif [ "$REPORT_ONLY_INSPECTED" -gt 0 ]; then
+  REPORT_ONLY_NOTE="; report-only inspection completed for $(sweep_copies "$REPORT_ONLY_INSPECTED")"
+elif [ "$REPORT_ONLY_PROJECTS" -gt 0 ]; then
+  REPORT_ONLY_NOTE="; report-only inspection completed for $(sweep_projects "$REPORT_ONLY_PROJECTS")"
+fi
+
 RUN_COMPLETE=0
 if [ "$INCOMPLETE" -eq 0 ] && [ "$FAILED" -eq 0 ] \
   && [ "$LEDGER_INCOMPLETE" -eq 0 ] \
@@ -1230,18 +1342,30 @@ fi
 
 if [ "$RUN_COMPLETE" -eq 0 ]; then
   if [ "$DRY_RUN" = 1 ] && [ "$RECLAIMED" -gt 0 ]; then
-    printf 'sweep: would reclaim %s from %s, but inspection was incomplete%s%s\n' \
+    printf 'sweep: would reclaim %s from %s, but inspection was incomplete%s%s%s\n' \
       "$(fm_next_cache_human_kb "$TOTAL_KB")" "$(sweep_copies "$RECLAIMED")" \
-      "$FAILED_NOTE" "$INCOMPLETE_NOTE"
+      "$FAILED_NOTE" "$INCOMPLETE_NOTE" "$REPORT_ONLY_NOTE"
   elif [ "$RECLAIMED" -gt 0 ]; then
-    printf 'sweep: reclaimed %s from %s, but processing was incomplete%s%s\n' \
+    printf 'sweep: reclaimed %s from %s, but processing was incomplete%s%s%s\n' \
       "$(fm_next_cache_human_kb "$TOTAL_KB")" "$(sweep_copies "$RECLAIMED")" \
-      "$FAILED_NOTE" "$INCOMPLETE_NOTE"
+      "$FAILED_NOTE" "$INCOMPLETE_NOTE" "$REPORT_ONLY_NOTE"
   else
-    printf 'sweep: reclamation incomplete%s%s\n' "$FAILED_NOTE" "$INCOMPLETE_NOTE"
+    printf 'sweep: reclamation incomplete%s%s%s\n' \
+      "$FAILED_NOTE" "$INCOMPLETE_NOTE" "$REPORT_ONLY_NOTE"
   fi
 elif [ "$RECLAIMED" -eq 0 ]; then
-  if [ "$SKIPPED" -gt 0 ]; then
+  if [ "$REPORT_ONLY_PROJECTS" -gt 0 ]; then
+    if [ "$REPORTED" -gt 0 ]; then
+      printf 'sweep: report-only inspection found %s in %s; nothing was reclaimed\n' \
+        "$(fm_next_cache_human_kb "$REPORTED_KB")" "$(sweep_copies "$REPORTED")"
+    elif [ "$REPORT_ONLY_INSPECTED" -gt 0 ]; then
+      printf 'sweep: report-only inspection found no Next.js build output in %s; nothing was reclaimed\n' \
+        "$(sweep_copies "$REPORT_ONLY_INSPECTED")"
+    else
+      printf 'sweep: report-only inspection complete; %s contained no copies; nothing was reclaimed\n' \
+        "$(sweep_projects "$REPORT_ONLY_PROJECTS")"
+    fi
+  elif [ "$SKIPPED" -gt 0 ]; then
     printf 'sweep: nothing to reclaim; %s were skipped as owned (listed above)%s\n' \
       "$(sweep_copies "$SKIPPED")" "$INCOMPLETE_NOTE"
   elif [ "$INSPECTED" -eq 0 ]; then
@@ -1251,13 +1375,13 @@ elif [ "$RECLAIMED" -eq 0 ]; then
     printf 'sweep: nothing to reclaim; no idle copy holds Next.js build output\n'
   fi
 elif [ "$DRY_RUN" = 1 ]; then
-  printf 'sweep: would reclaim %s from %s%s%s\n' \
+  printf 'sweep: would reclaim %s from %s%s%s%s\n' \
     "$(fm_next_cache_human_kb "$TOTAL_KB")" "$(sweep_copies "$RECLAIMED")" \
-    "$FAILED_NOTE" "$INCOMPLETE_NOTE"
+    "$FAILED_NOTE" "$INCOMPLETE_NOTE" "$REPORT_ONLY_NOTE"
 else
-  printf 'sweep: reclaimed %s from %s%s%s\n' \
+  printf 'sweep: reclaimed %s from %s%s%s%s\n' \
     "$(fm_next_cache_human_kb "$TOTAL_KB")" "$(sweep_copies "$RECLAIMED")" \
-    "$FAILED_NOTE" "$INCOMPLETE_NOTE"
+    "$FAILED_NOTE" "$INCOMPLETE_NOTE" "$REPORT_ONLY_NOTE"
 fi
 
 exit "$RC"

--- a/bin/fm-next-cache-sweep.sh
+++ b/bin/fm-next-cache-sweep.sh
@@ -31,11 +31,11 @@
 #   3. The tree is clean. Uncommitted work is unlanded work.
 #   4. There are no stashes. A stash is unlanded work that a clean tree does not
 #      show, and nobody is watching an idle copy to notice it disappear.
-# Checks 3 and 4 read git and change nothing. A copy that fails any check keeps
-# its build output; the sweep says which check failed and moves on. Every check
-# treats "could not determine" as "owned": an unreadable pool, an unparseable
-# status, a path that is not an inspectable git worktree, or a git command that
-# fails all skip the copy rather than assume it is free.
+# Checks 3 and 4 read git and change nothing. A copy with a proven owner keeps
+# its build output and is reported. An ownership input that is absent,
+# unreadable, malformed, or incomplete refuses reclamation at that input's
+# scope: task-record enumeration refuses the whole sweep, and pool or worktree
+# inspection refuses that project before any of its copies are touched.
 #
 # One race is left open deliberately. A copy can be leased in the moment between
 # the pool reporting it available and the removal running. Closing that would
@@ -66,6 +66,11 @@ PROJECTS="${FM_PROJECTS_OVERRIDE:-$FM_HOME/projects}"
 
 sweep_die() { printf 'fm-next-cache-sweep: %s\n' "$1" >&2; exit 2; }
 
+sweep_incomplete() {
+  printf 'sweep: incomplete ownership input: %s; reclamation refused\n' "$1" >&2
+  return 1
+}
+
 sweep_usage() {
   cat <<'TXT'
 Usage: fm-next-cache-sweep.sh [--dry-run] [<project-dir>...]
@@ -77,8 +82,9 @@ With no project directory, sweeps every project clone under $FM_HOME/projects.
 
 A copy is swept only when the pool reports it available, no task record in this
 home or a registered secondmate home names it, its tree is clean, and it holds
-no stashes. Anything else is skipped and reported. Read this script's header for
-the full rule, and bin/fm-next-cache-lib.sh's for what counts as build output.
+no stashes. Proven owners are skipped and reported; incomplete ownership input
+refuses its whole scope. Read this script's header for the full rule, and
+bin/fm-next-cache-lib.sh's for what counts as build output.
 TXT
 }
 
@@ -104,57 +110,118 @@ command -v python3 >/dev/null 2>&1 \
 # plus every locally registered secondmate's. A remote secondmate's home lives on
 # another machine and cannot hold this machine's pool, so it is not consulted.
 TASK_STATE_DIRS=
-TASK_RECORD_ERROR=
+sweep_resolve_directory() {
+  CDPATH='' cd -- "$1" 2>/dev/null && pwd -P
+}
+
+sweep_path_identity() {  # <path>
+  local resolved
+  resolved=$(CDPATH='' cd -- "$1" 2>/dev/null && pwd -P) || return 1
+  if [ "$(uname)" = Darwin ]; then
+    stat -L -f '%d:%i' "$resolved" 2>/dev/null
+  else
+    stat -L -c '%d:%i' "$resolved" 2>/dev/null
+  fi
+}
+
 sweep_task_record_state_dirs() {
-  local registry="$DATA/secondmates.md" registry_contents line home
+  local registry="$DATA/secondmates.md" registry_contents line home resolved_home
   TASK_STATE_DIRS=$STATE
-  if [ ! -e "$registry" ] && [ ! -L "$registry" ]; then return 0; fi
-  if [ ! -f "$registry" ] || ! registry_contents=$(cat "$registry" 2>/dev/null); then
-    TASK_RECORD_ERROR="cannot read secondmate registry: $registry"
-    return 1
+  if [ ! -f "$registry" ] || [ -L "$registry" ] || [ ! -r "$registry" ] \
+    || ! registry_contents=$(cat "$registry" 2>/dev/null); then
+    sweep_incomplete "cannot read secondmate registry: $registry"
+    return
   fi
   while IFS= read -r line || [ -n "$line" ]; do
-    case "$line" in '- '*) ;; *) continue ;; esac
-    if ! secondmate_registry_parse_line "$line"; then
-      TASK_RECORD_ERROR="malformed secondmate registry entry in $registry: $line"
-      return 1
-    fi
-    if [ "$SECONDMATE_REGISTRY_REMOTE" -eq 1 ]; then continue; fi
-    home=$SECONDMATE_REGISTRY_HOME
-    if [ ! -e "$home" ] && [ ! -L "$home" ]; then
-      printf 'sweep: registered local secondmate home is absent: %s; no local task records to inspect\n' \
-        "$home" >&2
-      continue
-    fi
-    TASK_STATE_DIRS="$TASK_STATE_DIRS"$'\n'"$home/state"
+    case "$line" in
+      '- '*)
+        if ! secondmate_registry_parse_line "$line"; then
+          sweep_incomplete "malformed secondmate registry entry in $registry: $line"
+          return
+        fi
+        if [ "$SECONDMATE_REGISTRY_REMOTE" -eq 0 ]; then
+          home=$SECONDMATE_REGISTRY_HOME
+          case "$home" in
+            /*) ;;
+            *)
+              sweep_incomplete "unsafe non-absolute secondmate home: $home"
+              return
+              ;;
+          esac
+          if ! resolved_home=$(sweep_resolve_directory "$home"); then
+            sweep_incomplete "cannot resolve registered local secondmate home: $home"
+            return
+          fi
+          TASK_STATE_DIRS="$TASK_STATE_DIRS"$'\n'"$resolved_home/state"
+        fi
+        ;;
+    esac
   done <<EOT
 $registry_contents
 EOT
 }
 
 TASK_WORKTREES=
+TASK_WORKTREE_IDENTITIES=
 sweep_load_task_worktrees() {
-  local state_dir meta worktrees
+  local state_dir meta meta_contents worktree kind remote_host identity
   TASK_WORKTREES=
-  TASK_RECORD_ERROR=
+  TASK_WORKTREE_IDENTITIES=
   sweep_task_record_state_dirs || return 1
   while IFS= read -r state_dir; do
-    [ -n "$state_dir" ] || continue
+    if [ -z "$state_dir" ]; then
+      sweep_incomplete "task state directory enumeration returned an empty path"
+      return
+    fi
     if [ ! -d "$state_dir" ] || [ ! -r "$state_dir" ] || [ ! -x "$state_dir" ]; then
-      TASK_RECORD_ERROR="cannot read task state directory: $state_dir"
-      return 1
+      sweep_incomplete "cannot read task state directory: $state_dir"
+      return
     fi
     for meta in "$state_dir"/*.meta; do
-      if [ ! -e "$meta" ] && [ ! -L "$meta" ]; then continue; fi
-      if [ ! -f "$meta" ] || ! worktrees=$(sed -n 's/^worktree=//p' "$meta" 2>/dev/null); then
-        TASK_RECORD_ERROR="cannot read task metadata: $meta"
-        return 1
-      fi
-      [ -n "$worktrees" ] || continue
-      if [ -n "$TASK_WORKTREES" ]; then
-        TASK_WORKTREES="$TASK_WORKTREES"$'\n'"$worktrees"
-      else
-        TASK_WORKTREES=$worktrees
+      if [ -e "$meta" ] || [ -L "$meta" ]; then
+        if [ ! -f "$meta" ] || [ -L "$meta" ] || [ ! -r "$meta" ] \
+          || ! meta_contents=$(cat "$meta" 2>/dev/null); then
+          sweep_incomplete "cannot read task metadata: $meta"
+          return
+        fi
+        worktree=$(printf '%s\n' "$meta_contents" | sed -n 's/^worktree=//p')
+        kind=$(printf '%s\n' "$meta_contents" | sed -n 's/^kind=//p')
+        remote_host=$(printf '%s\n' "$meta_contents" | sed -n 's/^remote_host=//p')
+        case "$worktree" in
+          ''|*$'\n'*)
+            sweep_incomplete "task metadata has no single worktree: $meta"
+            return
+            ;;
+          /*) ;;
+          *)
+            sweep_incomplete "task metadata has a non-absolute worktree: $meta ($worktree)"
+            return
+            ;;
+        esac
+        case "$kind$remote_host" in
+          *$'\n'*)
+            sweep_incomplete "task metadata has ambiguous placement: $meta"
+            return
+            ;;
+        esac
+        if [ -n "$remote_host" ]; then
+          if [ "$kind" != secondmate ]; then
+            sweep_incomplete "task metadata has an invalid remote placement: $meta"
+            return
+          fi
+        else
+          if ! identity=$(sweep_path_identity "$worktree"); then
+            sweep_incomplete "cannot resolve task-record worktree: $worktree"
+            return
+          fi
+          if [ -n "$TASK_WORKTREES" ]; then
+            TASK_WORKTREES="$TASK_WORKTREES"$'\n'"$worktree"
+            TASK_WORKTREE_IDENTITIES="$TASK_WORKTREE_IDENTITIES"$'\n'"$identity"
+          else
+            TASK_WORKTREES=$worktree
+            TASK_WORKTREE_IDENTITIES=$identity
+          fi
+        fi
       fi
     done
   done <<EOT
@@ -162,30 +229,17 @@ $TASK_STATE_DIRS
 EOT
 }
 
-sweep_path_identity() {  # <path>
-  if [ "$(uname)" = Darwin ]; then
-    stat -f '%d:%i' "$1" 2>/dev/null
-  else
-    stat -c '%d:%i' "$1" 2>/dev/null
-  fi
-}
-
 # Does any task record name <path> as its worktree?
 sweep_task_owns() {  # <path>
-  local path=$1 path_identity recorded recorded_identity
+  local path=$1 path_identity
   if [ -n "$TASK_WORKTREES" ] && printf '%s\n' "$TASK_WORKTREES" | grep -Fxq -- "$path"; then
     return 0
   fi
   path_identity=$(sweep_path_identity "$path") || return 2
-  [ -n "$TASK_WORKTREES" ] || return 1
-  while IFS= read -r recorded; do
-    [ -n "$recorded" ] || continue
-    if [ ! -e "$recorded" ] && [ ! -L "$recorded" ]; then continue; fi
-    recorded_identity=$(sweep_path_identity "$recorded") || return 2
-    if [ "$recorded_identity" = "$path_identity" ]; then return 0; fi
-  done <<EOT
-$TASK_WORKTREES
-EOT
+  if [ -n "$TASK_WORKTREE_IDENTITIES" ] \
+    && printf '%s\n' "$TASK_WORKTREE_IDENTITIES" | grep -Fxq -- "$path_identity"; then
+    return 0
+  fi
   return 1
 }
 
@@ -211,19 +265,22 @@ if not isinstance(pool, list):
 for entry in pool:
     if not isinstance(entry, dict):
         sys.exit(1)
-    status = entry.get("status") or ""
-    path = entry.get("path") or ""
-    if path:
-        print("%s\t%s" % (status, path))
+    status = entry.get("status")
+    path = entry.get("path")
+    if not isinstance(status, str) or not status:
+        sys.exit(1)
+    if not isinstance(path, str) or not path or not path.startswith("/"):
+        sys.exit(1)
+    if any(c in status or c in path for c in "\t\r\n"):
+        sys.exit(1)
+    print("%s\t%s" % (status, path))
 '
 }
 
 # Why <worktree> may not be swept, printed as "<class><tab><reason>"; empty when
-# it may be. The class separates a copy shown to have an owner (`owned`) from
-# one whose ownership could not be established at all (`undetermined`). Both
-# skip, but they are reported differently: an undetermined copy is always named,
-# because the same broken inspection that hides its owner also hides how much it
-# is holding, and a silent skip there would read as "nothing here".
+# it may be. `owned` is a complete answer for that copy. `undetermined` makes
+# the project's preflight incomplete, so none of that project's copies may be
+# touched.
 sweep_unowned_reason() {  # <status> <worktree>
   local status=$1 wt=$2 task_ownership
   # Only the pool's own word for "available" clears this check. Any other
@@ -274,21 +331,103 @@ sweep_unowned_reason() {  # <status> <worktree>
   printf '\n'
 }
 
+sweep_project_plan() {  # <entries>
+  local entries=$1 status wt verdict class reason plan='' record
+  while IFS=$'\t' read -r status wt; do
+    if [ -n "$status$wt" ]; then
+      if [ -z "$status" ] || [ -z "$wt" ]; then
+        sweep_incomplete "pool entry did not yield a complete status and path"
+        return
+      fi
+      if [ ! -d "$wt" ]; then
+        sweep_incomplete "pool worktree is not an inspectable directory: $wt"
+        return
+      fi
+      verdict=$(sweep_unowned_reason "$status" "$wt")
+      if [ -n "$verdict" ]; then
+        class=${verdict%%	*}
+        reason=${verdict#*	}
+        if [ "$class" = undetermined ]; then
+          sweep_incomplete "$wt could not be assessed ($reason)"
+          return
+        fi
+        record="owned"$'\t'"$reason"$'\t'"$wt"
+      else
+        record="free"$'\t'"-"$'\t'"$wt"
+      fi
+      if [ -n "$plan" ]; then
+        plan="$plan"$'\n'"$record"
+      else
+        plan=$record
+      fi
+    fi
+  done <<EOT
+$entries
+EOT
+  printf '%s\n' "$plan"
+}
+
+sweep_apply_project_plan() {  # <plan>
+  local plan=$1 action reason wt
+  while IFS=$'\t' read -r action reason wt; do
+    if [ -n "$action" ]; then
+      if [ "$action" = owned ]; then
+        fm_next_cache_total_kb "$wt" >/dev/null
+        if [ "$FM_NEXT_CACHE_TOTAL_KB" -gt 0 ]; then
+          printf 'sweep: skipped %s (%s), holding %s\n' \
+            "$wt" "$reason" "$(fm_next_cache_human_kb "$FM_NEXT_CACHE_TOTAL_KB")"
+          SKIPPED=$(( SKIPPED + 1 ))
+        fi
+      else
+        if [ "$DRY_RUN" = 1 ]; then
+          fm_next_cache_report "$wt" "sweep" || RC=1
+        else
+          fm_next_cache_reclaim "$wt" "sweep" || RC=1
+        fi
+        if [ "$FM_NEXT_CACHE_TOTAL_KB" -gt 0 ]; then
+          TOTAL_KB=$(( TOTAL_KB + FM_NEXT_CACHE_TOTAL_KB ))
+          RECLAIMED=$(( RECLAIMED + 1 ))
+        fi
+      fi
+    fi
+  done <<EOT
+$plan
+EOT
+}
+
+sweep_project() {  # <project>
+  local project=$1 project_real entries plan
+  if ! project_real=$(sweep_resolve_directory "$project"); then
+    sweep_incomplete "cannot enter project: $project"
+    return
+  fi
+  if ! entries=$(sweep_pool_entries "$project_real"); then
+    sweep_incomplete "cannot read the worktree pool for $project_real"
+    return
+  fi
+  if ! plan=$(sweep_project_plan "$entries"); then
+    return 1
+  fi
+  sweep_apply_project_plan "$plan"
+}
+
 if [ "${#PROJECT_ARGS[@]}" -gt 0 ]; then
   TARGETS=("${PROJECT_ARGS[@]}")
 else
   TARGETS=()
   for dir in "$PROJECTS"/*/; do
-    [ -d "$dir" ] || continue
-    dir=${dir%/}
-    git -C "$dir" rev-parse --git-dir >/dev/null 2>&1 || continue
-    TARGETS+=("$dir")
+    if [ -d "$dir" ]; then
+      dir=${dir%/}
+      if git -C "$dir" rev-parse --git-dir >/dev/null 2>&1; then
+        TARGETS+=("$dir")
+      fi
+    fi
   done
 fi
 
 [ "${#TARGETS[@]}" -gt 0 ] || sweep_die "no project clones to sweep under $PROJECTS"
 
-sweep_load_task_worktrees || sweep_die "$TASK_RECORD_ERROR"
+sweep_load_task_worktrees || sweep_die "task-record ownership inputs are incomplete"
 
 RC=0
 TOTAL_KB=0
@@ -296,52 +435,10 @@ RECLAIMED=0
 SKIPPED=0
 INCOMPLETE=0
 for project in "${TARGETS[@]}"; do
-  if ! project_real=$(CDPATH='' cd -- "$project" 2>/dev/null && pwd -P); then
-    printf 'sweep: cannot enter project %s\n' "$project" >&2
+  if ! sweep_project "$project"; then
     RC=1
     INCOMPLETE=$(( INCOMPLETE + 1 ))
-    continue
   fi
-  if ! entries=$(sweep_pool_entries "$project_real"); then
-    printf 'sweep: cannot read the worktree pool for %s\n' "$project_real" >&2
-    RC=1
-    INCOMPLETE=$(( INCOMPLETE + 1 ))
-    continue
-  fi
-  while IFS=$'\t' read -r status wt; do
-    [ -n "$wt" ] || continue
-    [ -d "$wt" ] || continue
-    verdict=$(sweep_unowned_reason "$status" "$wt")
-    if [ -n "$verdict" ]; then
-      class=${verdict%%	*}
-      reason=${verdict#*	}
-      fm_next_cache_total_kb "$wt" >/dev/null
-      if [ "$class" = undetermined ]; then
-        # Always named: the failed inspection that hid the owner also hid the
-        # size, so "holding 0" here means "could not measure", not "empty".
-        printf 'sweep: skipped %s (%s); its contents could not be assessed\n' "$wt" "$reason"
-        SKIPPED=$(( SKIPPED + 1 ))
-      elif [ "$FM_NEXT_CACHE_TOTAL_KB" -gt 0 ]; then
-        # An owned copy is worth a line only when it is actually holding
-        # something; an idle copy that never built anything is not news.
-        printf 'sweep: skipped %s (%s), holding %s\n' \
-          "$wt" "$reason" "$(fm_next_cache_human_kb "$FM_NEXT_CACHE_TOTAL_KB")"
-        SKIPPED=$(( SKIPPED + 1 ))
-      fi
-      continue
-    fi
-    if [ "$DRY_RUN" = 1 ]; then
-      fm_next_cache_report "$wt" "sweep" || RC=1
-    else
-      fm_next_cache_reclaim "$wt" "sweep" || RC=1
-    fi
-    if [ "$FM_NEXT_CACHE_TOTAL_KB" -gt 0 ]; then
-      TOTAL_KB=$(( TOTAL_KB + FM_NEXT_CACHE_TOTAL_KB ))
-      RECLAIMED=$(( RECLAIMED + 1 ))
-    fi
-  done <<EOT
-$entries
-EOT
 done
 
 sweep_copies() {  # <count>
@@ -359,7 +456,7 @@ fi
 
 if [ "$RECLAIMED" -eq 0 ]; then
   if [ "$SKIPPED" -gt 0 ]; then
-    printf 'sweep: nothing to reclaim; %s were skipped as owned or unassessable (listed above)%s\n' \
+    printf 'sweep: nothing to reclaim; %s were skipped as owned (listed above)%s\n' \
       "$(sweep_copies "$SKIPPED")" "$INCOMPLETE_NOTE"
   elif [ "$INCOMPLETE" -gt 0 ]; then
     printf 'sweep: nothing to reclaim in inspected projects%s\n' "$INCOMPLETE_NOTE"

--- a/bin/fm-next-cache-sweep.sh
+++ b/bin/fm-next-cache-sweep.sh
@@ -79,10 +79,10 @@
 #   any failed resolution or library load reaches argument processing with exit 0.
 # - `bin/fm-next-cache-sweep.sh: argument loops -> "$@"`. Checked: the option
 #   case accepts only `--dry-run`, rejects every other dash-prefixed value with
-#   exit 2, and retains non-options verbatim. Re-derived wrong verdict: retention
-#   plus later `git rev-parse --git-dir` proves only that a repository is reachable,
-#   not that an explicit path is its root. Falsifier: an explicit subdirectory is
-#   accepted as the project clone and weakens the clone-exclusion comparison.
+#   exit 2, and retains non-options verbatim for the project-root proof. Converted
+#   wrong verdict: repository reachability alone was insufficient; every retained
+#   path must now physically equal its `--show-toplevel`. Falsifier: an explicit
+#   subdirectory reaches pool lookup or weakens the clone-exclusion comparison.
 # - `bin/fm-next-cache-sweep.sh: command preflight -> command -v treehouse and
 #   python3`. Checked: absence exits 2, while every later invocation separately
 #   checks the command's status. Falsifier: a missing command falls through, or a
@@ -136,12 +136,11 @@
 #   announced project for project-scoped refusal. Falsifier: a directory-entry
 #   failure silently removes a project from the requested target set.
 # - `bin/fm-next-cache-sweep.sh: sweep_project -> sweep_resolve_directory and Git
-#   project queries`. Checked: physical entry and `git rev-parse --git-dir` errors
-#   already refuse the project. Re-derived wrong verdict: `--git-dir` succeeds in
-#   a repository child, as observed from `bin/`, so it does not prove that the
-#   resolved argument equals `git rev-parse --show-toplevel`. Falsifier: the
-#   project clone can be returned by the pool while the comparison anchor remains
-#   an explicit child path.
+#   project queries`. Checked: physical entry and `git rev-parse --show-toplevel`
+#   must both succeed, the answer must be safe and physically resolvable, and its
+#   physical path must equal the resolved argument before pool lookup. This
+#   converts the wrong `--git-dir` verdict observed from `bin/`. Falsifier: any
+#   non-root argument supplies the project identity used by candidate provenance.
 # - `bin/fm-next-cache-sweep.sh: sweep_pool_entries -> mktemp, treehouse status
 #   --json, staged-file read, JSON decode, and temp removal`. Checked: treehouse's
 #   status is captured before parsing, the file is decoded strictly as UTF-8 JSON,
@@ -155,17 +154,18 @@
 #   can normalize an unvalidated field into `available` or a different path.
 # - `bin/fm-next-cache-sweep.sh: sweep_project_plan -> pool directory predicate,
 #   sweep_path_identity, and duplicate identity scan`. Checked: `-d` is required,
-#   physical device/inode identity is mandatory, and repeated identity refuses
-#   the atomic project. Falsifier: an absent/unresolvable path or alias duplicate
-#   authorizes deletion, or refusal leaves any announced path without a verdict.
+#   physical device/inode identity is mandatory, and repeated identity produces
+#   an undetermined assessment. The complete pool listing is counted before any
+#   assessment begins. Falsifier: an absent/unresolvable path or alias duplicate
+#   authorizes deletion, or an early exit can hide a later announced candidate.
 # - `bin/fm-next-cache-sweep.sh: sweep_pool_worktree_provenance -> candidate root,
 #   project worktree registry, and project-clone exclusion`. Checked: candidate
 #   `--show-toplevel` must physically equal the candidate, the candidate identity
 #   must appear exactly once in `git worktree list --porcelain -z`, and it must
-#   differ from the supplied project identity. Re-derived wrong evidence chain:
-#   these predicates exclude the clone only when the supplied project is itself
-#   proven to be the project root. Falsifier: an explicit project child makes the
-#   actual clone identity differ from the comparison anchor and pass provenance.
+#   differ from the supplied project identity. The supplied identity is now first
+#   proven to be the project root, converting the earlier wrong evidence chain.
+#   Falsifier: either root proof can be bypassed, or the linked-worktree registry
+#   can be incomplete while verification succeeds.
 # - `bin/fm-next-cache-sweep.sh: sweep_unowned_reason -> pool status`. Checked:
 #   only byte-exact `available` proceeds, `in-use` records ownership, and every
 #   other value records undetermined. Falsifier: any unknown or malformed status
@@ -177,9 +177,9 @@
 # - `bin/fm-next-cache-sweep.sh: sweep_project_plan -> fm_next_cache_inspect and
 #   FM_NEXT_CACHE_* outputs`. Checked: the inspection status is checked before
 #   size and plan values are consumed, so failed discovery, eligibility, or
-#   measurement refuses application. Falsifier: incomplete inspection supplies a
-#   zero-size or free row, or an early refusal prevents later pool paths receiving
-#   final verdicts; the latter is the reporting defect being converted.
+#   measurement produces an undetermined assessment. Every candidate is assessed
+#   before project refusal is applied. Falsifier: incomplete inspection supplies
+#   a zero-size/free row or prevents a later announced path receiving an assessment.
 #
 # Shared build-output discovery and removal inputs:
 # - `bin/fm-next-cache-lib.sh: fm_next_cache_size_kb -> du -sk`. Checked: only a
@@ -225,18 +225,18 @@
 # Outcome and summary inputs:
 # - `bin/fm-next-cache-sweep.sh: sweep_apply_project_plan -> report or reclaim
 #   status and FM_NEXT_CACHE_TOTAL_KB`. Checked: both dry-run and removal statuses
-#   are captured, failed paths increment the failure outcome, and only successful
-#   measured work contributes bytes. Falsifier: an apply failure has no named
-#   final outcome or permits a complete summary.
+#   are captured and routed through the one terminal-verdict recorder; failed
+#   paths become named `failed` verdicts and only ledger-recorded measured work
+#   contributes totals. Falsifier: an apply result changes a summary counter
+#   without first appending exactly one candidate verdict.
 # - `bin/fm-next-cache-sweep.sh: sweep_project_plan, sweep_project, project loop,
 #   and final summary -> announced candidates and final verdicts`. Checked: project
-#   plans are atomic and only completed projects currently enter run totals.
-#   Re-derived wrong verdict: `sweep_project_plan` returns on its first failed
-#   candidate, so later paths from the already complete pool listing have no
-#   verdict at all. Falsifier: announced-candidate count can differ from final-
-#   verdict count while the omission is not reported. The required conversion is
-#   a single candidate ledger, exactly one terminal verdict per announced path,
-#   and reconciliation before any clean summary is reachable.
+#   plans remain atomic, the complete pool list announces indexed candidates
+#   before assessment, and one ledger records `reclaimed`, `skipped-as-owned`,
+#   `undetermined`, `refused`, or `failed`. Per-project reconciliation proves each
+#   index occurs once; run reconciliation gates every clean summary. This converts
+#   the wrong early-return verdict. Falsifier: an announced index has zero or two
+#   terminal records, or any summary counter changes outside the ledger recorder.
 set -u
 
 case "${BASH_SOURCE[0]}" in
@@ -784,82 +784,264 @@ sweep_unowned_reason() {  # <status> <worktree>
 }
 
 SWEEP_PROJECT_PLAN=
-SWEEP_PROJECT_INSPECTED=0
+SWEEP_PROJECT_ANNOUNCED=0
+SWEEP_PROJECT_ASSESSED=0
+SWEEP_PROJECT_VERDICTS=0
+SWEEP_PROJECT_VERDICT_IDS=
+
+sweep_add_project_assessment() {  # <candidate-id> <action> <reason> <kb> <worktree>
+  local candidate_id=$1 action=$2 reason=$3 kb=$4 wt=$5 record
+  case "$candidate_id" in ''|*[!0-9]*) return 1 ;; esac
+  case "$action" in owned|free|undetermined) ;; *) return 1 ;; esac
+  case "$kb" in -) ;; ''|*[!0-9]*) return 1 ;; esac
+  case "$reason$wt" in *$'\t'*|*$'\r'*|*$'\n'*) return 1 ;; esac
+  record="$candidate_id"$'\t'"$action"$'\t'"$reason"$'\t'"$kb"$'\t'"$wt"
+  if [ -n "$SWEEP_PROJECT_PLAN" ]; then
+    SWEEP_PROJECT_PLAN="$SWEEP_PROJECT_PLAN"$'\n'"$record"
+  else
+    SWEEP_PROJECT_PLAN=$record
+  fi
+  SWEEP_PROJECT_ASSESSED=$(( SWEEP_PROJECT_ASSESSED + 1 ))
+}
+
+sweep_record_candidate_verdict() {  # <project> <candidate-id> <verdict> <reason> <kb> <worktree>
+  local project=$1 candidate_id=$2 verdict=$3 reason=$4 kb=$5 wt=$6
+  local recorded_id record human
+  case "$candidate_id" in ''|*[!0-9]*) return 1 ;; esac
+  case "$verdict" in
+    reclaimed|skipped-as-owned|undetermined|refused|failed) ;;
+    *) return 1 ;;
+  esac
+  case "$kb" in -) ;; ''|*[!0-9]*) return 1 ;; esac
+  case "$project$reason$wt" in *$'\t'*|*$'\r'*|*$'\n'*) return 1 ;; esac
+  if [ "$verdict" = skipped-as-owned ] && [ "$kb" -gt 0 ]; then
+    human=$(fm_next_cache_human_kb "$kb") || return 1
+  fi
+  if [ -n "$SWEEP_PROJECT_VERDICT_IDS" ]; then
+    while IFS= read -r recorded_id; do
+      [ "$recorded_id" = "$candidate_id" ] && return 1
+    done <<EOT
+$SWEEP_PROJECT_VERDICT_IDS
+EOT
+    SWEEP_PROJECT_VERDICT_IDS="$SWEEP_PROJECT_VERDICT_IDS"$'\n'"$candidate_id"
+  else
+    SWEEP_PROJECT_VERDICT_IDS=$candidate_id
+  fi
+  record="$project"$'\t'"$candidate_id"$'\t'"$verdict"$'\t'"$reason"$'\t'"$kb"$'\t'"$wt"
+  if [ -n "$CANDIDATE_LEDGER" ]; then
+    CANDIDATE_LEDGER="$CANDIDATE_LEDGER"$'\n'"$record"
+  else
+    CANDIDATE_LEDGER=$record
+  fi
+  SWEEP_PROJECT_VERDICTS=$(( SWEEP_PROJECT_VERDICTS + 1 ))
+  CANDIDATE_VERDICTS=$(( CANDIDATE_VERDICTS + 1 ))
+  case "$verdict" in
+    reclaimed) ;;
+    skipped-as-owned)
+      if [ "$kb" -gt 0 ]; then
+        printf 'sweep: skipped-as-owned %s (%s), holding %s\n' \
+          "$wt" "$reason" "$human"
+      fi
+      ;;
+    undetermined)
+      printf 'sweep: undetermined %s (%s)\n' "$wt" "$reason" >&2
+      ;;
+    refused)
+      printf 'sweep: refused %s (%s)\n' "$wt" "$reason" >&2
+      ;;
+    failed)
+      printf 'sweep: failed %s (%s)\n' "$wt" "$reason" >&2
+      ;;
+  esac
+}
+
+sweep_summarize_candidate_ledger() {
+  local project candidate_id verdict reason kb wt rows=0
+  TOTAL_KB=0
+  RECLAIMED=0
+  SKIPPED=0
+  INSPECTED=0
+  FAILED=0
+  if [ -n "$CANDIDATE_LEDGER" ]; then
+    while IFS=$'\t' read -r project candidate_id verdict reason kb wt; do
+      case "$project$reason$wt" in *$'\t'*|*$'\r'*|*$'\n'*) return 1 ;; esac
+      case "$candidate_id" in ''|*[!0-9]*) return 1 ;; esac
+      case "$kb" in -) ;; ''|*[!0-9]*) return 1 ;; esac
+      rows=$(( rows + 1 ))
+      case "$verdict" in
+        reclaimed)
+          [ "$kb" = - ] && return 1
+          INSPECTED=$(( INSPECTED + 1 ))
+          if [ "$kb" -gt 0 ]; then
+            TOTAL_KB=$(( TOTAL_KB + kb ))
+            RECLAIMED=$(( RECLAIMED + 1 ))
+          fi
+          ;;
+        skipped-as-owned)
+          [ "$kb" = - ] && return 1
+          INSPECTED=$(( INSPECTED + 1 ))
+          [ "$kb" -gt 0 ] && SKIPPED=$(( SKIPPED + 1 ))
+          ;;
+        undetermined|refused)
+          ;;
+        failed)
+          [ "$kb" = - ] && return 1
+          INSPECTED=$(( INSPECTED + 1 ))
+          FAILED=$(( FAILED + 1 ))
+          if [ "$kb" -gt 0 ]; then
+            TOTAL_KB=$(( TOTAL_KB + kb ))
+            RECLAIMED=$(( RECLAIMED + 1 ))
+          fi
+          ;;
+        *) return 1 ;;
+      esac
+    done <<EOT
+$CANDIDATE_LEDGER
+EOT
+  fi
+  [ "$rows" -eq "$CANDIDATE_VERDICTS" ]
+}
+
+sweep_reconcile_project_verdicts() {  # <project>
+  local project=$1 expected recorded matches
+  if [ "$SWEEP_PROJECT_VERDICTS" -ne "$SWEEP_PROJECT_ANNOUNCED" ]; then
+    sweep_incomplete "candidate verdict reconciliation failed for $project ($SWEEP_PROJECT_ANNOUNCED announced, $SWEEP_PROJECT_VERDICTS recorded)"
+    return
+  fi
+  expected=1
+  while [ "$expected" -le "$SWEEP_PROJECT_ANNOUNCED" ]; do
+    matches=0
+    if [ -n "$SWEEP_PROJECT_VERDICT_IDS" ]; then
+      while IFS= read -r recorded; do
+        [ "$recorded" = "$expected" ] && matches=$(( matches + 1 ))
+      done <<EOT
+$SWEEP_PROJECT_VERDICT_IDS
+EOT
+    fi
+    if [ "$matches" -ne 1 ]; then
+      sweep_incomplete "candidate verdict reconciliation failed for $project (candidate $expected has $matches verdicts)"
+      return
+    fi
+    expected=$(( expected + 1 ))
+  done
+}
+
 sweep_project_plan() {  # <project> <entries>
-  local project=$1 entries=$2 status wt record pool_identity recorded_identity
-  local inspected=0
+  local project=$1 entries=$2 status wt pool_identity recorded_identity
+  local candidate_id=0 action reason kb duplicate record_error=0 project_refused=0
   local pool_identities=
   SWEEP_PROJECT_PLAN=
-  SWEEP_PROJECT_INSPECTED=0
+  SWEEP_PROJECT_ANNOUNCED=0
+  SWEEP_PROJECT_ASSESSED=0
+  SWEEP_PROJECT_VERDICTS=0
+  SWEEP_PROJECT_VERDICT_IDS=
   while IFS=$'\t' read -r status wt; do
     if [ -n "$status$wt" ]; then
-      if [ -z "$status" ] || [ -z "$wt" ]; then
-        sweep_incomplete "pool entry did not yield a complete status and path"
-        return
-      fi
-      if [ ! -d "$wt" ]; then
-        sweep_incomplete "pool worktree is not an inspectable directory: $wt"
-        return
-      fi
-      if ! pool_identity=$(sweep_path_identity "$wt"); then
-        sweep_incomplete "pool worktree identity cannot be established: $wt"
-        return
-      fi
-      if ! sweep_pool_worktree_provenance "$project" "$wt"; then
-        sweep_incomplete "$wt pool provenance could not be established ($SWEEP_POOL_PROVENANCE_REASON)"
-        return
-      fi
-      if [ -n "$pool_identities" ]; then
-        while IFS= read -r recorded_identity; do
-          if [ "$recorded_identity" = "$pool_identity" ]; then
-            sweep_incomplete "pool entries name a duplicate filesystem copy: $wt"
-            return
-          fi
-        done <<EOT
-$pool_identities
-EOT
-        pool_identities="$pool_identities"$'\n'"$pool_identity"
-      else
-        pool_identities=$pool_identity
-      fi
-      sweep_unowned_reason "$status" "$wt"
-      if [ "$SWEEP_OWNER_CLASS" = undetermined ]; then
-        sweep_incomplete "$wt could not be assessed ($SWEEP_OWNER_REASON)"
-        return
-      fi
-      if ! fm_next_cache_inspect "$wt"; then
-        sweep_incomplete "$wt build output could not be inspected ($FM_NEXT_CACHE_INSPECTION_ERROR)"
-        return
-      fi
-      inspected=$(( inspected + 1 ))
-      if [ "$SWEEP_OWNER_CLASS" = owned ]; then
-        record="owned"$'\t'"$SWEEP_OWNER_REASON"$'\t'"$FM_NEXT_CACHE_TOTAL_KB"$'\t'"$wt"
-      else
-        record="free"$'\t'"-"$'\t'"$FM_NEXT_CACHE_TOTAL_KB"$'\t'"$wt"
-      fi
-      if [ -n "$SWEEP_PROJECT_PLAN" ]; then
-        SWEEP_PROJECT_PLAN="$SWEEP_PROJECT_PLAN"$'\n'"$record"
-      else
-        SWEEP_PROJECT_PLAN=$record
-      fi
+      SWEEP_PROJECT_ANNOUNCED=$(( SWEEP_PROJECT_ANNOUNCED + 1 ))
+      CANDIDATE_ANNOUNCED=$(( CANDIDATE_ANNOUNCED + 1 ))
     fi
   done <<EOT
 $entries
 EOT
-  SWEEP_PROJECT_INSPECTED=$inspected
+  while IFS=$'\t' read -r status wt; do
+    if [ -n "$status$wt" ]; then
+      candidate_id=$(( candidate_id + 1 ))
+      action=undetermined
+      reason=
+      kb=-
+      if [ -z "$status" ] || [ -z "$wt" ]; then
+        reason="pool entry did not yield a complete status and path"
+      elif [ ! -d "$wt" ]; then
+        reason="pool worktree is not an inspectable directory"
+      elif ! pool_identity=$(sweep_path_identity "$wt"); then
+        reason="pool worktree identity cannot be established"
+      elif ! sweep_pool_worktree_provenance "$project" "$wt"; then
+        reason="pool provenance could not be established: $SWEEP_POOL_PROVENANCE_REASON"
+      else
+        duplicate=0
+        if [ -n "$pool_identities" ]; then
+          while IFS= read -r recorded_identity; do
+            [ "$recorded_identity" = "$pool_identity" ] && duplicate=1
+          done <<EOT
+$pool_identities
+EOT
+        fi
+        if [ "$duplicate" -eq 1 ]; then
+          reason="pool entries name a duplicate filesystem copy"
+        else
+          if [ -n "$pool_identities" ]; then
+            pool_identities="$pool_identities"$'\n'"$pool_identity"
+          else
+            pool_identities=$pool_identity
+          fi
+          sweep_unowned_reason "$status" "$wt"
+          if [ "$SWEEP_OWNER_CLASS" = undetermined ]; then
+            reason=$SWEEP_OWNER_REASON
+          elif ! fm_next_cache_inspect "$wt"; then
+            reason="build output could not be inspected: $FM_NEXT_CACHE_INSPECTION_ERROR"
+          else
+            kb=$FM_NEXT_CACHE_TOTAL_KB
+            if [ "$SWEEP_OWNER_CLASS" = owned ]; then
+              action=owned
+              reason=$SWEEP_OWNER_REASON
+            else
+              action=free
+              reason=-
+            fi
+          fi
+        fi
+      fi
+      if ! sweep_add_project_assessment \
+        "$candidate_id" "$action" "$reason" "$kb" "$wt"; then
+        record_error=1
+      fi
+      [ "$action" = undetermined ] && project_refused=1
+    fi
+  done <<EOT
+$entries
+EOT
+  if [ "$record_error" -ne 0 ] \
+    || [ "$SWEEP_PROJECT_ASSESSED" -ne "$SWEEP_PROJECT_ANNOUNCED" ]; then
+    sweep_incomplete "candidate assessment reconciliation failed for $project ($SWEEP_PROJECT_ANNOUNCED announced, $SWEEP_PROJECT_ASSESSED assessed)"
+    return
+  fi
+  if [ "$project_refused" -eq 1 ]; then
+    while IFS=$'\t' read -r candidate_id action reason kb wt; do
+      if [ -n "$candidate_id" ]; then
+        if [ "$action" = undetermined ]; then
+          sweep_record_candidate_verdict \
+            "$project" "$candidate_id" undetermined "$reason" "$kb" "$wt" \
+            || record_error=1
+        else
+          sweep_record_candidate_verdict \
+            "$project" "$candidate_id" refused \
+            "another pool candidate made project preflight incomplete" "$kb" "$wt" \
+            || record_error=1
+        fi
+      fi
+    done <<EOT
+$SWEEP_PROJECT_PLAN
+EOT
+    if [ "$record_error" -ne 0 ]; then
+      sweep_incomplete "candidate verdict could not be recorded for $project"
+      return
+    fi
+    sweep_reconcile_project_verdicts "$project" || return 1
+    sweep_incomplete "one or more announced pool candidates could not be fully assessed for $project"
+    return
+  fi
 }
 
-sweep_apply_project_plan() {  # <plan>
-  local plan=$1 action reason planned_kb wt apply_status
-  while IFS=$'\t' read -r action reason planned_kb wt; do
-    if [ -n "$action" ]; then
+sweep_apply_project_plan() {  # <project> <plan>
+  local project=$1 plan=$2 candidate_id action reason planned_kb wt apply_status
+  local record_error=0
+  while IFS=$'\t' read -r candidate_id action reason planned_kb wt; do
+    if [ -n "$candidate_id" ]; then
       if [ "$action" = owned ]; then
-        if [ "$planned_kb" -gt 0 ]; then
-          printf 'sweep: skipped %s (%s), holding %s\n' \
-            "$wt" "$reason" "$(fm_next_cache_human_kb "$planned_kb")"
-          SKIPPED=$(( SKIPPED + 1 ))
-        fi
-      else
+        sweep_record_candidate_verdict \
+          "$project" "$candidate_id" skipped-as-owned "$reason" "$planned_kb" "$wt" \
+          || record_error=1
+      elif [ "$action" = free ]; then
         apply_status=0
         if [ "$DRY_RUN" = 1 ]; then
           fm_next_cache_report "$wt" "sweep" || apply_status=$?
@@ -867,30 +1049,54 @@ sweep_apply_project_plan() {  # <plan>
           fm_next_cache_reclaim "$wt" "sweep" || apply_status=$?
         fi
         if [ "$apply_status" -ne 0 ]; then
-          RC=1
-          FAILED=$(( FAILED + 1 ))
+          sweep_record_candidate_verdict \
+            "$project" "$candidate_id" failed \
+            "build output could not be processed" "$FM_NEXT_CACHE_TOTAL_KB" "$wt" \
+            || record_error=1
+        else
+          sweep_record_candidate_verdict \
+            "$project" "$candidate_id" reclaimed - "$FM_NEXT_CACHE_TOTAL_KB" "$wt" \
+            || record_error=1
         fi
-        if [ "$FM_NEXT_CACHE_TOTAL_KB" -gt 0 ]; then
-          TOTAL_KB=$(( TOTAL_KB + FM_NEXT_CACHE_TOTAL_KB ))
-          RECLAIMED=$(( RECLAIMED + 1 ))
-        fi
+      else
+        sweep_record_candidate_verdict \
+          "$project" "$candidate_id" failed "candidate plan is invalid" 0 "$wt" \
+          || record_error=1
       fi
     fi
   done <<EOT
 $plan
 EOT
+  [ "$record_error" -eq 0 ]
 }
 
 sweep_project() {  # <project>
-  local project=$1 project_real entries
-  SWEEP_PROJECT_INSPECTED=0
+  local project=$1 project_real project_top project_top_real entries
+  SWEEP_PROJECT_ANNOUNCED=0
+  SWEEP_PROJECT_ASSESSED=0
+  SWEEP_PROJECT_VERDICTS=0
+  SWEEP_PROJECT_VERDICT_IDS=
   SWEEP_PROJECT_COMPLETE=0
   if ! project_real=$(sweep_resolve_directory "$project"); then
     sweep_incomplete "cannot enter project: $project"
     return
   fi
-  if ! git -C "$project_real" rev-parse --git-dir >/dev/null 2>&1; then
+  if ! project_top=$(git -C "$project_real" rev-parse --show-toplevel 2>/dev/null); then
     sweep_incomplete "cannot inspect project Git metadata: $project_real"
+    return
+  fi
+  case "$project_top" in
+    ''|*$'\t'*|*$'\r'*|*$'\n'*)
+      sweep_incomplete "project root is malformed for: $project_real"
+      return
+      ;;
+  esac
+  if ! project_top_real=$(sweep_resolve_directory "$project_top"); then
+    sweep_incomplete "cannot resolve project root for: $project_real"
+    return
+  fi
+  if [ "$project_top_real" != "$project_real" ]; then
+    sweep_incomplete "project path is not a project root: $project_real"
     return
   fi
   if ! entries=$(sweep_pool_entries "$project_real"); then
@@ -900,7 +1106,12 @@ sweep_project() {  # <project>
   if ! sweep_project_plan "$project_real" "$entries"; then
     return 1
   fi
-  sweep_apply_project_plan "$SWEEP_PROJECT_PLAN"
+  if ! sweep_apply_project_plan "$project_real" "$SWEEP_PROJECT_PLAN"; then
+    sweep_reconcile_project_verdicts "$project_real" || true
+    sweep_incomplete "candidate verdict could not be recorded for $project_real"
+    return
+  fi
+  sweep_reconcile_project_verdicts "$project_real" || return 1
   SWEEP_PROJECT_COMPLETE=1
 }
 
@@ -930,6 +1141,9 @@ INCOMPLETE=0
 INSPECTED=0
 FAILED=0
 COMPLETE_PROJECTS=0
+CANDIDATE_LEDGER=
+CANDIDATE_ANNOUNCED=0
+CANDIDATE_VERDICTS=0
 for project in "${TARGETS[@]}"; do
   sweep_project "$project"
   project_status=$?
@@ -937,13 +1151,26 @@ for project in "${TARGETS[@]}"; do
     RC=1
     INCOMPLETE=$(( INCOMPLETE + 1 ))
   elif [ "$SWEEP_PROJECT_COMPLETE" -eq 1 ]; then
-    INSPECTED=$(( INSPECTED + SWEEP_PROJECT_INSPECTED ))
     COMPLETE_PROJECTS=$(( COMPLETE_PROJECTS + 1 ))
   else
     RC=1
     INCOMPLETE=$(( INCOMPLETE + 1 ))
   fi
 done
+
+LEDGER_INCOMPLETE=0
+if ! sweep_summarize_candidate_ledger; then
+  printf 'sweep: incomplete candidate verdict ledger: malformed terminal record\n' >&2
+  RC=1
+  LEDGER_INCOMPLETE=1
+fi
+if [ "$CANDIDATE_VERDICTS" -ne "$CANDIDATE_ANNOUNCED" ]; then
+  printf 'sweep: incomplete candidate verdict ledger: %d announced, %d recorded\n' \
+    "$CANDIDATE_ANNOUNCED" "$CANDIDATE_VERDICTS" >&2
+  RC=1
+  LEDGER_INCOMPLETE=1
+fi
+if [ "$FAILED" -gt 0 ]; then RC=1; fi
 
 sweep_copies() {  # <count>
   if [ "$1" -eq 1 ]; then printf '1 copy\n'; else printf '%d copies\n' "$1"; fi
@@ -957,6 +1184,9 @@ INCOMPLETE_NOTE=
 if [ "$INCOMPLETE" -gt 0 ]; then
   INCOMPLETE_NOTE="; $(sweep_projects "$INCOMPLETE") could not be inspected"
 fi
+if [ "$LEDGER_INCOMPLETE" -ne 0 ]; then
+  INCOMPLETE_NOTE="$INCOMPLETE_NOTE; candidate verdicts were incomplete ($CANDIDATE_ANNOUNCED announced, $CANDIDATE_VERDICTS recorded)"
+fi
 
 FAILED_NOTE=
 if [ "$FAILED" -gt 0 ]; then
@@ -965,6 +1195,7 @@ fi
 
 RUN_COMPLETE=0
 if [ "$INCOMPLETE" -eq 0 ] && [ "$FAILED" -eq 0 ] \
+  && [ "$LEDGER_INCOMPLETE" -eq 0 ] \
   && [ "$COMPLETE_PROJECTS" -eq "${#TARGETS[@]}" ]; then
   RUN_COMPLETE=1
 fi

--- a/bin/fm-next-cache-sweep.sh
+++ b/bin/fm-next-cache-sweep.sh
@@ -32,7 +32,17 @@
 #   4. There are no stashes. A stash is unlanded work that a clean tree does not
 #      show, and nobody is watching an idle copy to notice it disappear.
 # Checks 3 and 4 read git and change nothing. A copy that fails any check keeps
-# its build output; the sweep says which check failed and moves on.
+# its build output; the sweep says which check failed and moves on. Every check
+# treats "could not determine" as "owned": an unreadable pool, an unparseable
+# status, a path that is not an inspectable git worktree, or a git command that
+# fails all skip the copy rather than assume it is free.
+#
+# One race is left open deliberately. A copy can be leased in the moment between
+# the pool reporting it available and the removal running. Closing that would
+# need a lease this tool does not own, and the consequence is bounded: the copy
+# was leased to start fresh work, so it loses build output it was about to
+# regenerate anyway - the same directory `next build` clears at the start of
+# every production build. Losing that race costs a rebuild, not work.
 #
 # It reports every copy it reclaimed, with the space each gave back and a total,
 # and says plainly when it found nothing - a cleanup that prints nothing is
@@ -135,11 +145,19 @@ sweep_pool_entries() {  # <project-dir>
   ( cd "$1" && treehouse status --json 2>/dev/null ) | python3 -c '
 import json, sys
 
+# Anything this cannot read as a list of pool entries exits non-zero, so the
+# caller reports the project as unreadable and sweeps none of its copies. An
+# unparseable pool is not an empty pool, and it is certainly not a pool of
+# unowned copies.
 try:
     pool = json.load(sys.stdin)
 except ValueError:
     sys.exit(1)
+if not isinstance(pool, list):
+    sys.exit(1)
 for entry in pool:
+    if not isinstance(entry, dict):
+        sys.exit(1)
     status = entry.get("status") or ""
     path = entry.get("path") or ""
     if path:
@@ -147,36 +165,49 @@ for entry in pool:
 '
 }
 
-# Why <worktree> may not be swept, printed as a short reason; empty when it may.
+# Why <worktree> may not be swept, printed as "<class><tab><reason>"; empty when
+# it may be. The class separates a copy shown to have an owner (`owned`) from
+# one whose ownership could not be established at all (`undetermined`). Both
+# skip, but they are reported differently: an undetermined copy is always named,
+# because the same broken inspection that hides its owner also hides how much it
+# is holding, and a silent skip there would read as "nothing here".
 sweep_unowned_reason() {  # <status> <worktree>
   local status=$1 wt=$2
+  # Only the pool's own word for "available" clears this check. Any other
+  # value - in-use, a status this version of treehouse does not print, or none
+  # at all - means ownership was not established, which is not the same as
+  # establishing that there is no owner.
+  if [ "$status" = in-use ]; then
+    printf 'owned\tin use by the pool\n'
+    return 0
+  fi
   if [ "$status" != available ]; then
-    printf 'in use by the pool\n'
+    printf 'undetermined\tthe pool did not report it available\n'
     return 0
   fi
   if sweep_task_owns "$wt"; then
-    printf 'still claimed by a task record\n'
+    printf 'owned\tstill claimed by a task record\n'
     return 0
   fi
   if ! git -C "$wt" rev-parse --git-dir >/dev/null 2>&1; then
-    printf 'not an inspectable git worktree\n'
+    printf 'undetermined\tnot an inspectable git worktree\n'
     return 0
   fi
   local dirty stashes
   if ! dirty=$(git -C "$wt" status --porcelain 2>/dev/null); then
-    printf 'cannot inspect it for uncommitted changes\n'
+    printf 'undetermined\tcannot inspect it for uncommitted changes\n'
     return 0
   fi
   if [ -n "$dirty" ]; then
-    printf 'has uncommitted changes\n'
+    printf 'owned\thas uncommitted changes\n'
     return 0
   fi
   if ! stashes=$(git -C "$wt" stash list 2>/dev/null); then
-    printf 'cannot inspect it for stashes\n'
+    printf 'undetermined\tcannot inspect it for stashes\n'
     return 0
   fi
   if [ -n "$stashes" ]; then
-    printf 'has stashed work\n'
+    printf 'owned\thas stashed work\n'
     return 0
   fi
   printf '\n'
@@ -216,12 +247,19 @@ for project in "${TARGETS[@]}"; do
   while IFS=$'\t' read -r status wt; do
     [ -n "$wt" ] || continue
     [ -d "$wt" ] || continue
-    reason=$(sweep_unowned_reason "$status" "$wt")
-    if [ -n "$reason" ]; then
-      # Only worth a line when there was something to reclaim; an idle copy that
-      # never built anything is not news.
+    verdict=$(sweep_unowned_reason "$status" "$wt")
+    if [ -n "$verdict" ]; then
+      class=${verdict%%	*}
+      reason=${verdict#*	}
       fm_next_cache_total_kb "$wt" >/dev/null
-      if [ "$FM_NEXT_CACHE_TOTAL_KB" -gt 0 ]; then
+      if [ "$class" = undetermined ]; then
+        # Always named: the failed inspection that hid the owner also hid the
+        # size, so "holding 0" here means "could not measure", not "empty".
+        printf 'sweep: skipped %s (%s); its contents could not be assessed\n' "$wt" "$reason"
+        SKIPPED=$(( SKIPPED + 1 ))
+      elif [ "$FM_NEXT_CACHE_TOTAL_KB" -gt 0 ]; then
+        # An owned copy is worth a line only when it is actually holding
+        # something; an idle copy that never built anything is not news.
         printf 'sweep: skipped %s (%s), holding %s\n' \
           "$wt" "$reason" "$(fm_next_cache_human_kb "$FM_NEXT_CACHE_TOTAL_KB")"
         SKIPPED=$(( SKIPPED + 1 ))
@@ -248,7 +286,7 @@ sweep_copies() {  # <count>
 
 if [ "$RECLAIMED" -eq 0 ]; then
   if [ "$SKIPPED" -gt 0 ]; then
-    printf 'sweep: nothing to reclaim; %s still hold build output but are in use or hold unlanded work\n' \
+    printf 'sweep: nothing to reclaim; %s were skipped as owned or unassessable (listed above)\n' \
       "$(sweep_copies "$SKIPPED")"
   else
     printf 'sweep: nothing to reclaim; no idle copy holds Next.js build output\n'

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -133,6 +133,19 @@
 #     root still exists, so the account's healthy LaunchAgent worker and every
 #     live remote secondmate worker are out of scope. Best effort: a sweep
 #     failure never blocks this teardown.
+#   Fix 4 - reclaim the copy's Next.js build output before it returns to the
+#     pool. `treehouse return` resets tracked content and leaves gitignored
+#     build output where it is, so a finished copy goes back to the pool still
+#     holding it and nothing ever removes it (measured 2026-08-18: 15 GB in one
+#     idle Artemis copy on a volume with 11 GB free; ~25.6 GB across eight
+#     copies on 2026-08-07). This runs after every unlanded-work refusal has
+#     passed and after the worktree's processes are reaped, so nothing is still
+#     writing it. bin/fm-next-cache-lib.sh owns exactly what qualifies and why
+#     it can never reach source, node_modules, or git data. Best effort and
+#     silent when there is nothing to reclaim: the output regenerates from
+#     source, so it is never the work product a refusal is protecting.
+#     bin/fm-next-cache-sweep.sh is the matching entry point for copies already
+#     sitting idle in the pool.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -168,6 +181,8 @@ SUB_HOME_PARENT_MARKER=".fm-secondmate-parent"
 . "$SCRIPT_DIR/fm-wake-lib.sh"
 # shellcheck source=bin/fm-nm-run-lib.sh
 . "$SCRIPT_DIR/fm-nm-run-lib.sh"
+# shellcheck source=bin/fm-next-cache-lib.sh
+. "$SCRIPT_DIR/fm-next-cache-lib.sh"
 if [ "$#" -lt 1 ] || ! fm_task_id_path_safe "$1"; then
   echo "error: invalid teardown request" >&2
   exit 2
@@ -2436,6 +2451,15 @@ elif [ -d "$WT" ] && [ "$KIND" != secondmate ]; then
   # Remove our hook file so a reused pool worktree cannot fire signals for a dead task.
   rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" \
     "$WT/.fm-grok-turnend" "$WT/.fm-kimi-turnend"
+  # Fix 4 (see script header): reclaim this copy's Next.js build output. Every
+  # unlanded-work refusal has already passed and the worktree's processes are
+  # already reaped, so nothing here is still being written. treehouse return
+  # resets tracked content but leaves gitignored output alone, so without this
+  # the copy goes back to the pool carrying gigabytes nobody will use again.
+  # Never fatal: the build output is not the work product, and failing a
+  # completed teardown over a directory that regenerates would be the wrong
+  # trade. bin/fm-next-cache-lib.sh owns what is removed and why.
+  fm_next_cache_reclaim "$WT" "teardown" || true
   # Kills remaining processes in the worktree (including the agent), resets, returns
   # to pool. treehouse resolves the pool from the working directory, so run it from
   # the project. teardown_treehouse_return tolerates transient and stale git locks

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -107,7 +107,9 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-pr-check.sh`         | Record validated `pr=` and `pr_head=` values, then atomically arm a static merge poll |
 | `fm-pr-merge.sh`         | Record PR metadata, then merge a task's canonical full GitHub URL                    |
 | `fm-promote.sh`          | Promote a scout task in place to a protected ship task with an explicit delivery mode |
-| `fm-teardown.sh`         | Fail-closed teardown: return landed ship worktrees, require completed scout deliverables, retire secondmate homes |
+| `fm-next-cache-lib.sh`   | Shared proof and reclamation of regenerable Next.js `.next` output inside task worktrees |
+| `fm-next-cache-sweep.sh` | Report or reclaim eligible Next.js build output from proven-unowned pooled copies |
+| `fm-teardown.sh`         | Fail-closed teardown of landed ships, completed scouts, and secondmate homes, reclaiming finished-copy Next.js output before pool return |
 | `fm-harness.sh`          | Detect the running harness and resolve crew or secondmate harness, model, and effort |
 | `fm-lock.sh`             | Per-home firstmate session lock                                                      |
 | `fm-x-lib.sh`            | Shared Relay config, relay, and reply-threading helpers                              |

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -503,6 +503,39 @@ test_backend_source_shell_portable() {
   pass "bash: fm_backend_source recognizes known backends and rejects unknown ones"
 }
 
+test_backend_source_missing_adapter_is_refusable() {
+  local root out rc backend
+  # A missing adapter file must reach the caller as a failed call it can refuse
+  # on - not as the death of the calling shell. Stock macOS Bash 3.2 terminates
+  # the whole shell (with status 0) when `.` cannot find its file, ignoring both
+  # the `|| return 1` and the `if !` around it, which silently turned
+  # fm-teardown.sh's herdr preflight refusal into a reported success. Bash 5
+  # returns 1 as written, so this case only ever fails on the stock macOS Bash
+  # the fleet actually runs on.
+  root="$TMP_ROOT/missing-adapter"
+  rm -rf "$root"
+  mkdir -p "$root"
+  cp -R "$ROOT/bin" "$root/bin"
+  for backend in tmux herdr zellij orca cmux; do
+    rm -f "$root/bin/backends/$backend.sh"
+  done
+  for backend in tmux herdr zellij orca cmux; do
+    rc=0
+    out=$(bash -c "
+      set -eu
+      . '$root/bin/fm-backend.sh'
+      if fm_backend_source $backend; then echo LOADED; else echo REFUSED; fi
+      echo CALLER-SURVIVED
+    " 2>/dev/null) || rc=$?
+    expect_code 0 "$rc" "fm_backend_source $backend: the caller should keep control"
+    assert_contains "$out" "REFUSED" \
+      "fm_backend_source $backend: a missing adapter must be a failed call, not a load"
+    assert_contains "$out" "CALLER-SURVIVED" \
+      "fm_backend_source $backend: a missing adapter must not terminate the calling shell"
+  done
+  pass "fm_backend_source: a missing adapter fails the call instead of killing the caller"
+}
+
 test_backend_validate_spawn_accepts_orca() {
   local out
   fm_backend_validate_spawn tmux 2>/dev/null || fail "fm_backend_validate_spawn should accept tmux"
@@ -1126,6 +1159,7 @@ test_backend_name_autodetect_notice
 test_backend_name_explicit_beats_detection
 test_backend_validate_refuses_unknown
 test_backend_source_shell_portable
+test_backend_source_missing_adapter_is_refusable
 test_backend_validate_spawn_accepts_orca
 test_meta_get_and_backend_of_meta
 test_resolve_selector_three_forms

--- a/tests/fm-gotmp.test.sh
+++ b/tests/fm-gotmp.test.sh
@@ -58,7 +58,10 @@ make_fake_root() {
   ln -s "$ROOT/bin/backends/tmux.sh" "$fake/bin/backends/tmux.sh"
   ln -s "$ROOT/bin/fm-tmux-lib.sh" "$fake/bin/fm-tmux-lib.sh"
   ln -s "$ROOT/bin/fm-composer-lib.sh" "$fake/bin/fm-composer-lib.sh"
+  ln -s "$ROOT/bin/fm-cursor-lib.sh" "$fake/bin/fm-cursor-lib.sh"
+  ln -s "$ROOT/bin/fm-session-lock-lib.sh" "$fake/bin/fm-session-lock-lib.sh"
   ln -s "$ROOT/bin/fm-nm-run-lib.sh" "$fake/bin/fm-nm-run-lib.sh"
+  ln -s "$ROOT/bin/fm-next-cache-lib.sh" "$fake/bin/fm-next-cache-lib.sh"
   # fm-lock-lib.sh: teardown sources it for the shared lock-staleness proof.
   ln -s "$ROOT/bin/fm-lock-lib.sh" "$fake/bin/fm-lock-lib.sh"
   # Lifecycle serialization, status presentation retirement, and shared adapter
@@ -139,7 +142,10 @@ test_teardown_skips_gracefully_without_tasktmp() {
   ln -s "$ROOT/bin/backends/tmux.sh" "$fake/bin/backends/tmux.sh"
   ln -s "$ROOT/bin/fm-tmux-lib.sh" "$fake/bin/fm-tmux-lib.sh"
   ln -s "$ROOT/bin/fm-composer-lib.sh" "$fake/bin/fm-composer-lib.sh"
+  ln -s "$ROOT/bin/fm-cursor-lib.sh" "$fake/bin/fm-cursor-lib.sh"
+  ln -s "$ROOT/bin/fm-session-lock-lib.sh" "$fake/bin/fm-session-lock-lib.sh"
   ln -s "$ROOT/bin/fm-nm-run-lib.sh" "$fake/bin/fm-nm-run-lib.sh"
+  ln -s "$ROOT/bin/fm-next-cache-lib.sh" "$fake/bin/fm-next-cache-lib.sh"
   ln -s "$ROOT/bin/fm-lock-lib.sh" "$fake/bin/fm-lock-lib.sh"
   ln -s "$ROOT/bin/fm-control-lib.sh" "$fake/bin/fm-control-lib.sh"
   ln -s "$ROOT/bin/fm-classify-lib.sh" "$fake/bin/fm-classify-lib.sh"

--- a/tests/fm-next-cache-sweep.test.sh
+++ b/tests/fm-next-cache-sweep.test.sh
@@ -884,7 +884,60 @@ SH
     "nondirectory-pool-entry: project preflight must precede every deletion"
   assert_contains "$out" "$case_dir/pool/not-a-directory" \
     "nondirectory-pool-entry: the refusal must name the invalid path"
+  assert_not_contains "$out" "nothing to reclaim" \
+    "nondirectory-pool-entry: a discarded plan is not a completed empty inspection"
   pass "a nondirectory pool entry refuses its project before any deletion"
+}
+
+test_sweep_refuses_pool_entry_for_live_copy_child() {
+  local case_dir wt child out rc
+  case_dir=$(make_case live-copy-child)
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  child="$wt/packages/frontend"
+  fm_write_meta "$case_dir/state/task-x1.meta" \
+    "endpoint_task_id=task-x1" "worktree=$wt" "project=$case_dir/projects/app" \
+    "kind=ship" "mode=no-mistakes"
+  cat > "$case_dir/fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+printf '[{"status":"available","path":"%s/1/packages/frontend"}]\n' \
+  "$FM_FAKE_POOL_DIR"
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+
+  set +e
+  out=$(run_sweep "$case_dir" 2>&1); rc=$?
+  set -e
+
+  expect_code 1 "$rc" "live-copy-child: an interior repository path must refuse"
+  assert_present "$child/.next" \
+    "live-copy-child: a pool path inside a live task copy must never authorize deletion"
+  assert_contains "$out" "$child" \
+    "live-copy-child: the unproved pool path must be named"
+  pass "a live copy child cannot masquerade as a pooled worktree"
+}
+
+test_sweep_refuses_pool_entry_for_project_clone() {
+  local case_dir clone out rc
+  case_dir=$(make_case project-clone-entry)
+  clone="$case_dir/projects/app"
+  add_next_app "$clone" packages/frontend
+  cat > "$case_dir/fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+printf '[{"status":"available","path":"%s"}]\n' "$FM_FAKE_PROJECT_CLONE"
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+
+  set +e
+  out=$(FM_FAKE_PROJECT_CLONE="$clone" run_sweep "$case_dir" 2>&1); rc=$?
+  set -e
+
+  expect_code 1 "$rc" "project-clone-entry: the project clone is not a pool copy"
+  assert_present "$clone/packages/frontend/.next" \
+    "project-clone-entry: the sweep must never delete from the project clone"
+  assert_contains "$out" "$clone" \
+    "project-clone-entry: the unproved pool path must be named"
+  pass "the project clone cannot masquerade as a pooled worktree"
 }
 
 test_sweep_reports_incomplete_project_count() {
@@ -1555,8 +1608,24 @@ test_teardown_stays_quiet_without_build_output() {
   pass "teardown says nothing about reclamation when there is nothing to reclaim"
 }
 
+test_unknown_test_selector_fails() {
+  local out rc
+
+  set +e
+  out=$(FM_NEXT_CACHE_TEST=test_selector_that_does_not_exist \
+    /bin/bash "$ROOT/tests/fm-next-cache-sweep.test.sh" 2>&1); rc=$?
+  set -e
+
+  expect_code 1 "$rc" "unknown-selector: an unmatched selector must fail"
+  assert_contains "$out" "test_selector_that_does_not_exist" \
+    "unknown-selector: the unmatched selector must be named"
+  pass "an unknown test selector cannot produce a vacuous pass"
+}
+
+FM_NEXT_CACHE_TEST_MATCHED=0
 run_next_cache_test() {
   if [ -z "${FM_NEXT_CACHE_TEST:-}" ] || [ "$FM_NEXT_CACHE_TEST" = "$1" ]; then
+    FM_NEXT_CACHE_TEST_MATCHED=1
     "$1"
   fi
 }
@@ -1593,6 +1662,8 @@ run_next_cache_test test_sweep_refuses_nul_pool_status
 run_next_cache_test test_sweep_refuses_conflicting_alias_pool_entries
 run_next_cache_test test_sweep_refuses_pathless_pool_entry_atomically
 run_next_cache_test test_sweep_refuses_nondirectory_pool_entry_atomically
+run_next_cache_test test_sweep_refuses_pool_entry_for_live_copy_child
+run_next_cache_test test_sweep_refuses_pool_entry_for_project_clone
 run_next_cache_test test_sweep_reports_incomplete_project_count
 run_next_cache_test test_sweep_refuses_without_treehouse
 run_next_cache_test test_sweep_refuses_uninspectable_worktree_project
@@ -1616,3 +1687,8 @@ run_next_cache_test test_teardown_reclaims_before_returning_the_copy
 run_next_cache_test test_teardown_reclaims_only_after_the_copy_is_quiet
 run_next_cache_test test_teardown_refusal_keeps_the_copy_intact
 run_next_cache_test test_teardown_stays_quiet_without_build_output
+run_next_cache_test test_unknown_test_selector_fails
+
+if [ -n "${FM_NEXT_CACHE_TEST:-}" ] && [ "$FM_NEXT_CACHE_TEST_MATCHED" -eq 0 ]; then
+  fail "unknown FM_NEXT_CACHE_TEST selector: $FM_NEXT_CACHE_TEST"
+fi

--- a/tests/fm-next-cache-sweep.test.sh
+++ b/tests/fm-next-cache-sweep.test.sh
@@ -52,6 +52,7 @@ make_case() {
   case_dir="$TMP_ROOT/$name"
   mkdir -p "$case_dir/state" "$case_dir/config" "$case_dir/data" \
     "$case_dir/projects" "$case_dir/fakebin" "$case_dir/pool"
+  : > "$case_dir/data/secondmates.md"
 
   git init -q --bare "$case_dir/origin.git"
   git -C "$case_dir/origin.git" symbolic-ref HEAD refs/heads/main
@@ -274,15 +275,15 @@ test_sweep_skips_stashed_copy() {
   pass "sweep never touches a copy holding stashed work"
 }
 
-# --- sweep: ownership that cannot be determined counts as owned --------------
+# --- sweep: incomplete ownership refuses its whole scope ---------------------
 #
 # The reclaim is a deletion, so the interesting question is not what happens
 # when the proof succeeds - it is what happens when the proof cannot be made.
 # Each case below breaks one input the sweep relies on and asserts the build
-# output SURVIVES, because "could not determine" must read as "owned".
+# output SURVIVES, because incomplete evidence can never authorize deletion.
 
-test_sweep_skips_copy_with_unknown_pool_status() {
-  local case_dir wt out
+test_sweep_refuses_project_with_unknown_pool_status() {
+  local case_dir wt out rc
   case_dir=$(make_case unknown-status)
   install_treehouse_stub "$case_dir"
   wt=$(add_pool_worktree "$case_dir" 1)
@@ -291,13 +292,17 @@ test_sweep_skips_copy_with_unknown_pool_status() {
   # proven free, even though it is not the familiar `in-use` either.
   printf '1 reserved-by-something-new\n' > "$case_dir/pool-status"
 
-  out=$(run_sweep "$case_dir" 2>&1)
+  set +e
+  out=$(run_sweep "$case_dir" 2>&1); rc=$?
+  set -e
 
   assert_present "$wt/packages/frontend/.next" \
     "unknown-status: an unrecognized pool status is not proof the copy is free"
+  expect_code 1 "$rc" \
+    "unknown-status: incomplete pool ownership must refuse the project"
   assert_contains "$out" "the pool did not report it available" \
     "unknown-status: the skip reason must name what was not established"
-  pass "an unrecognized pool status keeps the copy out of scope"
+  pass "an unrecognized pool status refuses the whole project"
 }
 
 test_sweep_skips_whole_project_when_pool_is_unreadable() {
@@ -426,7 +431,7 @@ test_sweep_refuses_malformed_secondmate_registry() {
   pass "a malformed secondmate record refuses the whole sweep"
 }
 
-test_sweep_allows_absent_secondmate_home() {
+test_sweep_refuses_absent_secondmate_home() {
   local case_dir wt out rc absent
   case_dir=$(make_case absent-secondmate-home)
   install_treehouse_stub "$case_dir"
@@ -441,13 +446,84 @@ test_sweep_allows_absent_secondmate_home() {
   out=$(run_sweep "$case_dir" 2>&1); rc=$?
   set -e
 
-  expect_code 0 "$rc" \
-    "absent-secondmate-home: a home absent from this machine contributes no local records"
-  assert_absent "$wt/packages/frontend/.next" \
-    "absent-secondmate-home: a provably absent home must not block a safe reclaim"
+  expect_code 2 "$rc" \
+    "absent-secondmate-home: an absent ownership source must refuse the sweep"
+  assert_present "$wt/packages/frontend/.next" \
+    "absent-secondmate-home: strict completeness must preserve the build output"
   assert_contains "$out" "$absent" \
-    "absent-secondmate-home: omitting an absent home must be reported explicitly"
-  pass "an absent registered local home is reported and does not block the sweep"
+    "absent-secondmate-home: the refusal must name the absent home"
+  pass "an absent registered local home refuses the whole sweep"
+}
+
+test_sweep_refuses_relative_secondmate_home() {
+  local case_dir wt out rc
+  case_dir=$(make_case relative-secondmate-home)
+  install_treehouse_stub "$case_dir"
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  printf '1 available\n' > "$case_dir/pool-status"
+  printf '%s\n' \
+    '- helper - Helps. (home: relative-home; scope: things; projects: app; added 2026-08-18)' \
+    > "$case_dir/data/secondmates.md"
+
+  set +e
+  out=$(run_sweep "$case_dir" 2>&1); rc=$?
+  set -e
+
+  expect_code 2 "$rc" \
+    "relative-secondmate-home: an unsafe ownership source must refuse the sweep"
+  assert_present "$wt/packages/frontend/.next" \
+    "relative-secondmate-home: an unresolved registry home must prevent deletion"
+  assert_contains "$out" "relative-home" \
+    "relative-secondmate-home: the refusal must name the unsafe home"
+  pass "a relative registered local home refuses the whole sweep"
+}
+
+test_sweep_refuses_unreadable_secondmate_registry() {
+  local case_dir wt out rc registry
+  case_dir=$(make_case unreadable-secondmate-registry)
+  install_treehouse_stub "$case_dir"
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  printf '1 available\n' > "$case_dir/pool-status"
+  registry="$case_dir/data/secondmates.md"
+  chmod 000 "$registry"
+
+  set +e
+  out=$(run_sweep "$case_dir" 2>&1); rc=$?
+  set -e
+  chmod 600 "$registry"
+
+  expect_code 2 "$rc" \
+    "unreadable-secondmate-registry: unreadable global ownership must refuse the sweep"
+  assert_present "$wt/packages/frontend/.next" \
+    "unreadable-secondmate-registry: unreadable ownership must prevent deletion"
+  assert_contains "$out" "$registry" \
+    "unreadable-secondmate-registry: the refusal must name the registry"
+  pass "an unreadable secondmate registry refuses the whole sweep"
+}
+
+test_sweep_refuses_absent_secondmate_registry() {
+  local case_dir wt out rc registry
+  case_dir=$(make_case absent-secondmate-registry)
+  install_treehouse_stub "$case_dir"
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  printf '1 available\n' > "$case_dir/pool-status"
+  registry="$case_dir/data/secondmates.md"
+  rm -f "$registry"
+
+  set +e
+  out=$(run_sweep "$case_dir" 2>&1); rc=$?
+  set -e
+
+  expect_code 2 "$rc" \
+    "absent-secondmate-registry: absent global ownership must refuse the sweep"
+  assert_present "$wt/packages/frontend/.next" \
+    "absent-secondmate-registry: absent ownership input must prevent deletion"
+  assert_contains "$out" "$registry" \
+    "absent-secondmate-registry: the refusal must name the missing registry"
+  pass "an absent secondmate registry refuses the whole sweep"
 }
 
 test_sweep_skips_symlink_aliased_task_worktree() {
@@ -470,6 +546,54 @@ test_sweep_skips_symlink_aliased_task_worktree() {
   assert_contains "$out" "still claimed by a task record" \
     "symlink-task-alias: the filesystem identity match must be reported as owned"
   pass "task ownership follows filesystem identity through a symlinked prefix"
+}
+
+test_sweep_skips_final_symlink_aliased_task_worktree() {
+  local case_dir wt out alias
+  case_dir=$(make_case final-symlink-task-alias)
+  install_treehouse_stub "$case_dir"
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  printf '1 available\n' > "$case_dir/pool-status"
+  alias="$case_dir/task-worktree-link"
+  ln -s "$wt" "$alias"
+  fm_write_meta "$case_dir/state/task-x1.meta" \
+    "endpoint_task_id=task-x1" "worktree=$alias" \
+    "project=$case_dir/projects/app" "kind=ship" "mode=no-mistakes"
+
+  out=$(run_sweep "$case_dir" 2>&1)
+
+  assert_present "$wt/packages/frontend/.next" \
+    "final-symlink-task-alias: task ownership must follow the final symlink"
+  assert_contains "$out" "still claimed by a task record" \
+    "final-symlink-task-alias: resolved filesystem identity must be reported as owned"
+  pass "task ownership resolves a final symlink to its worktree"
+}
+
+test_sweep_refuses_broken_task_worktree_symlink() {
+  local case_dir wt out rc alias
+  case_dir=$(make_case broken-task-worktree-link)
+  install_treehouse_stub "$case_dir"
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  printf '1 available\n' > "$case_dir/pool-status"
+  alias="$case_dir/broken-task-worktree-link"
+  ln -s "$case_dir/missing-task-worktree" "$alias"
+  fm_write_meta "$case_dir/state/task-x1.meta" \
+    "endpoint_task_id=task-x1" "worktree=$alias" \
+    "project=$case_dir/projects/app" "kind=ship" "mode=no-mistakes"
+
+  set +e
+  out=$(run_sweep "$case_dir" 2>&1); rc=$?
+  set -e
+
+  expect_code 2 "$rc" \
+    "broken-task-worktree-link: unresolved global task identity must refuse the sweep"
+  assert_present "$wt/packages/frontend/.next" \
+    "broken-task-worktree-link: unresolved task identity must prevent deletion"
+  assert_contains "$out" "$alias" \
+    "broken-task-worktree-link: the refusal must name the unresolved task path"
+  pass "a broken task-worktree symlink refuses the whole sweep"
 }
 
 test_sweep_skips_case_aliased_task_worktree() {
@@ -497,8 +621,8 @@ test_sweep_skips_case_aliased_task_worktree() {
   pass "task ownership follows filesystem identity across case aliases"
 }
 
-test_sweep_skips_when_candidate_identity_is_unreadable() {
-  local case_dir wt out real_stat
+test_sweep_refuses_when_candidate_identity_is_unreadable() {
+  local case_dir wt out rc real_stat
   case_dir=$(make_case candidate-identity-unreadable)
   install_treehouse_stub "$case_dir"
   install_stat_failure_stub "$case_dir"
@@ -507,18 +631,22 @@ test_sweep_skips_when_candidate_identity_is_unreadable() {
   printf '1 available\n' > "$case_dir/pool-status"
   real_stat=$(command -v stat)
 
+  set +e
   out=$(FM_REAL_STAT="$real_stat" FM_FAKE_STAT_FAIL="$wt" \
-    run_sweep "$case_dir" 2>&1)
+    run_sweep "$case_dir" 2>&1); rc=$?
+  set -e
 
   assert_present "$wt/packages/frontend/.next" \
     "candidate-identity-unreadable: unresolved candidate identity must prevent deletion"
-  assert_contains "$out" "could not be assessed" \
-    "candidate-identity-unreadable: unresolved ownership must be reported as unknown"
-  pass "an unreadable candidate identity is never treated as unowned"
+  expect_code 1 "$rc" \
+    "candidate-identity-unreadable: incomplete project ownership must return nonzero"
+  assert_contains "$out" "$wt" \
+    "candidate-identity-unreadable: the refusal must name the candidate"
+  pass "an unreadable candidate identity refuses the whole project"
 }
 
-test_sweep_skips_when_recorded_identity_is_unreadable() {
-  local case_dir wt out alias real_stat
+test_sweep_refuses_when_recorded_identity_is_unreadable() {
+  local case_dir wt out rc alias real_stat
   case_dir=$(make_case recorded-identity-unreadable)
   install_treehouse_stub "$case_dir"
   install_stat_failure_stub "$case_dir"
@@ -532,14 +660,68 @@ test_sweep_skips_when_recorded_identity_is_unreadable() {
     "project=$case_dir/projects/app" "kind=ship" "mode=no-mistakes"
   real_stat=$(command -v stat)
 
-  out=$(FM_REAL_STAT="$real_stat" FM_FAKE_STAT_FAIL="$alias/1" \
-    run_sweep "$case_dir" 2>&1)
+  set +e
+  out=$(FM_REAL_STAT="$real_stat" FM_FAKE_STAT_FAIL="$wt" \
+    run_sweep "$case_dir" 2>&1); rc=$?
+  set -e
 
   assert_present "$wt/packages/frontend/.next" \
     "recorded-identity-unreadable: unresolved recorded identity must prevent deletion"
-  assert_contains "$out" "could not be assessed" \
-    "recorded-identity-unreadable: unresolved ownership must be reported as unknown"
-  pass "an unreadable existing task path is treated as a possible owner"
+  expect_code 2 "$rc" \
+    "recorded-identity-unreadable: incomplete global ownership must refuse the sweep"
+  assert_contains "$out" "$alias/1" \
+    "recorded-identity-unreadable: the refusal must name the recorded path"
+  pass "an unreadable existing task path refuses the whole sweep"
+}
+
+test_sweep_refuses_pathless_pool_entry_atomically() {
+  local case_dir wt out rc
+  case_dir=$(make_case pathless-pool-entry)
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  cat > "$case_dir/fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+printf '[{"status":"available","path":"%s/1"},{"status":"available"}]\n' \
+  "$FM_FAKE_POOL_DIR"
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+
+  set +e
+  out=$(run_sweep "$case_dir" 2>&1); rc=$?
+  set -e
+
+  expect_code 1 "$rc" "pathless-pool-entry: incomplete pool input must return nonzero"
+  assert_present "$wt/packages/frontend/.next" \
+    "pathless-pool-entry: no earlier entry may be reclaimed from an incomplete pool"
+  assert_contains "$out" "worktree pool" \
+    "pathless-pool-entry: the incomplete pool must be reported"
+  pass "a pathless pool entry refuses its project before any deletion"
+}
+
+test_sweep_refuses_nondirectory_pool_entry_atomically() {
+  local case_dir wt out rc
+  case_dir=$(make_case nondirectory-pool-entry)
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  printf 'not a directory\n' > "$case_dir/pool/not-a-directory"
+  cat > "$case_dir/fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+printf '[{"status":"available","path":"%s/1"},{"status":"available","path":"%s/not-a-directory"}]\n' \
+  "$FM_FAKE_POOL_DIR" "$FM_FAKE_POOL_DIR"
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+
+  set +e
+  out=$(run_sweep "$case_dir" 2>&1); rc=$?
+  set -e
+
+  expect_code 1 "$rc" \
+    "nondirectory-pool-entry: an uninspectable pool path must return nonzero"
+  assert_present "$wt/packages/frontend/.next" \
+    "nondirectory-pool-entry: project preflight must precede every deletion"
+  assert_contains "$out" "$case_dir/pool/not-a-directory" \
+    "nondirectory-pool-entry: the refusal must name the invalid path"
+  pass "a nondirectory pool entry refuses its project before any deletion"
 }
 
 test_sweep_reports_incomplete_project_count() {
@@ -599,8 +781,8 @@ test_sweep_refuses_without_treehouse() {
   pass "the sweep refuses outright when the pool's lease cannot be consulted"
 }
 
-test_sweep_skips_uninspectable_worktree() {
-  local case_dir wt out
+test_sweep_refuses_uninspectable_worktree_project() {
+  local case_dir wt out rc
   case_dir=$(make_case uninspectable)
   install_treehouse_stub "$case_dir"
   wt=$(add_pool_worktree "$case_dir" 1)
@@ -611,19 +793,23 @@ test_sweep_skips_uninspectable_worktree() {
   rm -rf "$wt/.git"
   printf '1 available\n' > "$case_dir/pool-status"
 
-  out=$(run_sweep "$case_dir" 2>&1)
+  set +e
+  out=$(run_sweep "$case_dir" 2>&1); rc=$?
+  set -e
 
   assert_present "$wt/packages/frontend/.next" \
     "uninspectable: a path git cannot inspect must keep its build output"
+  expect_code 1 "$rc" \
+    "uninspectable: incomplete project ownership must return nonzero"
   assert_contains "$out" "not an inspectable git worktree" \
-    "uninspectable: the skip reason must be reported"
-  assert_contains "$out" "could not be assessed" \
-    "uninspectable: a copy that cannot be assessed must be named, not passed over silently"
-  pass "a copy git cannot inspect is never swept"
+    "uninspectable: the refusal reason must be reported"
+  assert_contains "$out" "$wt" \
+    "uninspectable: the refused copy must be named"
+  pass "a copy git cannot inspect refuses the whole project"
 }
 
-test_sweep_skips_when_git_inspection_fails() {
-  local case_dir wt out gitdir
+test_sweep_refuses_project_when_git_inspection_fails() {
+  local case_dir wt out rc gitdir
   case_dir=$(make_case git-failing)
   install_treehouse_stub "$case_dir"
   wt=$(add_pool_worktree "$case_dir" 1)
@@ -637,15 +823,19 @@ test_sweep_skips_when_git_inspection_fails() {
   printf 'not an index\n' > "$gitdir/index"
   printf '1 available\n' > "$case_dir/pool-status"
 
-  out=$(run_sweep "$case_dir" 2>&1)
+  set +e
+  out=$(run_sweep "$case_dir" 2>&1); rc=$?
+  set -e
 
   assert_present "$wt/packages/frontend/.next" \
     "git-failing: an unanswerable clean-tree check must keep the build output"
+  expect_code 1 "$rc" \
+    "git-failing: incomplete project ownership must return nonzero"
   assert_contains "$out" "cannot inspect it" \
-    "git-failing: the skip reason must say the inspection failed"
-  assert_contains "$out" "could not be assessed" \
-    "git-failing: a copy that cannot be assessed must be named, not passed over silently"
-  pass "a copy whose git state cannot be read is never swept"
+    "git-failing: the refusal reason must say the inspection failed"
+  assert_contains "$out" "$wt" \
+    "git-failing: the refused copy must be named"
+  pass "an unreadable git state refuses the whole project"
 }
 
 # --- discovery rule: only regenerable Next.js build output -------------------
@@ -907,21 +1097,28 @@ test_sweep_skips_copy_claimed_by_task_record
 test_sweep_skips_copy_claimed_by_secondmate_task_record
 test_sweep_skips_dirty_copy
 test_sweep_skips_stashed_copy
-test_sweep_skips_copy_with_unknown_pool_status
+test_sweep_refuses_project_with_unknown_pool_status
 test_sweep_skips_whole_project_when_pool_is_unreadable
 test_sweep_skips_project_when_pool_lookup_fails
 test_sweep_skips_project_when_pool_prints_json_then_fails
 test_sweep_refuses_unreadable_secondmate_state
 test_sweep_refuses_malformed_secondmate_registry
-test_sweep_allows_absent_secondmate_home
+test_sweep_refuses_absent_secondmate_home
+test_sweep_refuses_relative_secondmate_home
+test_sweep_refuses_unreadable_secondmate_registry
+test_sweep_refuses_absent_secondmate_registry
 test_sweep_skips_symlink_aliased_task_worktree
+test_sweep_skips_final_symlink_aliased_task_worktree
+test_sweep_refuses_broken_task_worktree_symlink
 test_sweep_skips_case_aliased_task_worktree
-test_sweep_skips_when_candidate_identity_is_unreadable
-test_sweep_skips_when_recorded_identity_is_unreadable
+test_sweep_refuses_when_candidate_identity_is_unreadable
+test_sweep_refuses_when_recorded_identity_is_unreadable
+test_sweep_refuses_pathless_pool_entry_atomically
+test_sweep_refuses_nondirectory_pool_entry_atomically
 test_sweep_reports_incomplete_project_count
 test_sweep_refuses_without_treehouse
-test_sweep_skips_uninspectable_worktree
-test_sweep_skips_when_git_inspection_fails
+test_sweep_refuses_uninspectable_worktree_project
+test_sweep_refuses_project_when_git_inspection_fails
 test_sweep_leaves_tracked_next_directory
 test_sweep_leaves_ignored_next_outside_a_next_app
 test_sweep_leaves_node_modules_and_source

--- a/tests/fm-next-cache-sweep.test.sh
+++ b/tests/fm-next-cache-sweep.test.sh
@@ -940,6 +940,107 @@ SH
   pass "the project clone cannot masquerade as a pooled worktree"
 }
 
+test_sweep_refuses_explicit_project_subdirectory() {
+  local case_dir clone child out rc
+  case_dir=$(make_case explicit-project-subdirectory)
+  clone="$case_dir/projects/app"
+  add_next_app "$clone" packages/frontend
+  child="$clone/packages/frontend"
+  cat > "$case_dir/fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+printf '[{"status":"available","path":"%s"}]\n' "$FM_FAKE_PROJECT_CLONE"
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+
+  set +e
+  out=$(FM_FAKE_PROJECT_CLONE="$clone" run_sweep "$case_dir" "$child" 2>&1); rc=$?
+  set -e
+
+  expect_code 1 "$rc" \
+    "explicit-project-subdirectory: an explicit child is not a project clone root"
+  assert_present "$child/.next" \
+    "explicit-project-subdirectory: a child argument must not weaken clone exclusion"
+  assert_contains "$out" "$child" \
+    "explicit-project-subdirectory: the rejected project argument must be named"
+  assert_contains "$out" "project root" \
+    "explicit-project-subdirectory: the missing root proof must be reported"
+  pass "an explicit project subdirectory cannot anchor clone provenance"
+}
+
+test_sweep_refusal_records_later_candidate_verdicts() {
+  local case_dir wt1 wt2 invalid out rc
+  case_dir=$(make_case later-candidate-verdicts)
+  wt1=$(add_pool_worktree "$case_dir" 1)
+  wt2=$(add_pool_worktree "$case_dir" 2)
+  add_next_app "$wt1" packages/one
+  add_next_app "$wt2" packages/two
+  invalid="$case_dir/pool/not-a-directory"
+  printf 'not a directory\n' > "$invalid"
+  cat > "$case_dir/fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+printf '[{"status":"available","path":"%s/not-a-directory"},' "$FM_FAKE_POOL_DIR"
+printf '{"status":"available","path":"%s/1"},' "$FM_FAKE_POOL_DIR"
+printf '{"status":"available","path":"%s/2"}]\n' "$FM_FAKE_POOL_DIR"
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+
+  set +e
+  out=$(run_sweep "$case_dir" 2>&1); rc=$?
+  set -e
+
+  expect_code 1 "$rc" \
+    "later-candidate-verdicts: one uninspectable candidate must refuse the project"
+  assert_present "$wt1/packages/one/.next" \
+    "later-candidate-verdicts: atomic refusal must preserve the first later copy"
+  assert_present "$wt2/packages/two/.next" \
+    "later-candidate-verdicts: atomic refusal must preserve the second later copy"
+  assert_contains "$out" "sweep: undetermined $invalid" \
+    "later-candidate-verdicts: the failing candidate needs a terminal verdict"
+  assert_contains "$out" "sweep: refused $wt1" \
+    "later-candidate-verdicts: the first later candidate needs a terminal verdict"
+  assert_contains "$out" "sweep: refused $wt2" \
+    "later-candidate-verdicts: the second later candidate needs a terminal verdict"
+  pass "project refusal records a verdict for every later candidate"
+}
+
+test_sweep_reconciles_every_announced_candidate() {
+  local case_dir wt1 wt2 invalid out rc verdict_count
+  case_dir=$(make_case candidate-ledger-reconciliation)
+  wt1=$(add_pool_worktree "$case_dir" 1)
+  wt2=$(add_pool_worktree "$case_dir" 2)
+  add_next_app "$wt1" packages/one
+  add_next_app "$wt2" packages/two
+  invalid="$case_dir/pool/not-a-directory"
+  printf 'not a directory\n' > "$invalid"
+  cat > "$case_dir/fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+printf '[{"status":"available","path":"%s/1"},' "$FM_FAKE_POOL_DIR"
+printf '{"status":"available","path":"%s/not-a-directory"},' "$FM_FAKE_POOL_DIR"
+printf '{"status":"available","path":"%s/2"}]\n' "$FM_FAKE_POOL_DIR"
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+
+  set +e
+  out=$(run_sweep "$case_dir" 2>&1); rc=$?
+  set -e
+
+  expect_code 1 "$rc" \
+    "candidate-ledger-reconciliation: an incomplete candidate must refuse the project"
+  verdict_count=$(printf '%s\n' "$out" \
+    | grep -Ec '^sweep: (reclaimed|skipped-as-owned|undetermined|refused|failed) ' || true)
+  [ "$verdict_count" -eq 3 ] \
+    || fail "candidate-ledger-reconciliation: expected 3 terminal verdicts, got $verdict_count"$'\n'"$out"
+  assert_contains "$out" "sweep: refused $wt1" \
+    "candidate-ledger-reconciliation: a discarded earlier plan row needs a verdict"
+  assert_contains "$out" "sweep: undetermined $invalid" \
+    "candidate-ledger-reconciliation: the incomplete candidate needs a verdict"
+  assert_contains "$out" "sweep: refused $wt2" \
+    "candidate-ledger-reconciliation: an unprocessed later candidate needs a verdict"
+  assert_not_contains "$out" "nothing to reclaim" \
+    "candidate-ledger-reconciliation: an unreconciled run cannot claim completeness"
+  pass "the candidate ledger reconciles every announced pool path"
+}
+
 test_sweep_reports_incomplete_project_count() {
   local case_dir out rc
   case_dir=$(make_case incomplete-summary)
@@ -1664,6 +1765,9 @@ run_next_cache_test test_sweep_refuses_pathless_pool_entry_atomically
 run_next_cache_test test_sweep_refuses_nondirectory_pool_entry_atomically
 run_next_cache_test test_sweep_refuses_pool_entry_for_live_copy_child
 run_next_cache_test test_sweep_refuses_pool_entry_for_project_clone
+run_next_cache_test test_sweep_refuses_explicit_project_subdirectory
+run_next_cache_test test_sweep_refusal_records_later_candidate_verdicts
+run_next_cache_test test_sweep_reconciles_every_announced_candidate
 run_next_cache_test test_sweep_reports_incomplete_project_count
 run_next_cache_test test_sweep_refuses_without_treehouse
 run_next_cache_test test_sweep_refuses_uninspectable_worktree_project

--- a/tests/fm-next-cache-sweep.test.sh
+++ b/tests/fm-next-cache-sweep.test.sh
@@ -114,6 +114,18 @@ SH
   chmod +x "$case_dir/fakebin/stat"
 }
 
+install_stat_empty_stub() {  # <case-dir>
+  local case_dir=$1
+  cat > "$case_dir/fakebin/stat" <<'SH'
+#!/usr/bin/env bash
+last=
+for arg in "$@"; do last=$arg; done
+if [ "$last" = "${FM_FAKE_STAT_EMPTY:-}" ]; then exit 0; fi
+exec "$FM_REAL_STAT" "$@"
+SH
+  chmod +x "$case_dir/fakebin/stat"
+}
+
 run_sweep() {  # <case-dir> [args...]
   local case_dir=$1; shift
   FM_HOME="$case_dir" \
@@ -674,6 +686,157 @@ test_sweep_refuses_when_recorded_identity_is_unreadable() {
   pass "an unreadable existing task path refuses the whole sweep"
 }
 
+test_sweep_preserves_task_owner_when_grep_fails() {
+  local case_dir wt out real_grep
+  case_dir=$(make_case task-owner-grep-failure)
+  install_treehouse_stub "$case_dir"
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  printf '1 available\n' > "$case_dir/pool-status"
+  fm_write_meta "$case_dir/state/task-x1.meta" \
+    "endpoint_task_id=task-x1" "worktree=$wt" "project=$case_dir/projects/app" \
+    "kind=ship" "mode=no-mistakes"
+  real_grep=$(command -v grep)
+  cat > "$case_dir/fakebin/grep" <<'SH'
+#!/usr/bin/env bash
+for arg in "$@"; do
+  if [ "$arg" = -Fxq ]; then exit 2; fi
+done
+exec "$FM_REAL_GREP" "$@"
+SH
+  chmod +x "$case_dir/fakebin/grep"
+
+  out=$(FM_REAL_GREP="$real_grep" run_sweep "$case_dir" 2>&1)
+
+  assert_present "$wt/packages/frontend/.next" \
+    "task-owner-grep-failure: a failed comparison tool must not erase task ownership"
+  assert_contains "$out" "still claimed by a task record" \
+    "task-owner-grep-failure: exact task ownership must remain determinate"
+  pass "task ownership cannot become a no-match when grep fails"
+}
+
+test_sweep_refuses_empty_candidate_identity() {
+  local case_dir wt out rc real_stat
+  case_dir=$(make_case empty-candidate-identity)
+  install_treehouse_stub "$case_dir"
+  install_stat_empty_stub "$case_dir"
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  printf '1 available\n' > "$case_dir/pool-status"
+  real_stat=$(command -v stat)
+
+  set +e
+  out=$(FM_REAL_STAT="$real_stat" FM_FAKE_STAT_EMPTY="$wt" \
+    run_sweep "$case_dir" 2>&1); rc=$?
+  set -e
+
+  expect_code 1 "$rc" "empty-candidate-identity: empty identity output must be incomplete"
+  assert_present "$wt/packages/frontend/.next" \
+    "empty-candidate-identity: empty stat output must not prove the copy unowned"
+  assert_contains "$out" "$wt" \
+    "empty-candidate-identity: the incomplete candidate must be named"
+  pass "empty filesystem identity output refuses the project"
+}
+
+test_sweep_refuses_nul_task_metadata() {
+  local case_dir wt out rc meta
+  case_dir=$(make_case nul-task-metadata)
+  install_treehouse_stub "$case_dir"
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  printf '1 available\n' > "$case_dir/pool-status"
+  meta="$case_dir/state/task-x1.meta"
+  {
+    printf 'endpoint_task_id=task-x1\nworktree=%s\nkind=secondmate\n' "$wt"
+    printf 'remote_host=helper\0\n'
+  } > "$meta"
+
+  set +e
+  out=$(run_sweep "$case_dir" 2>&1); rc=$?
+  set -e
+
+  expect_code 2 "$rc" "nul-task-metadata: malformed global ownership must refuse"
+  assert_present "$wt/packages/frontend/.next" \
+    "nul-task-metadata: NUL normalization must not hide a local task owner"
+  assert_contains "$out" "$meta" \
+    "nul-task-metadata: the malformed ownership file must be named"
+  pass "NUL-bearing task metadata refuses the whole sweep"
+}
+
+test_sweep_refuses_nul_secondmate_registry() {
+  local case_dir wt out rc registry
+  case_dir=$(make_case nul-secondmate-registry)
+  install_treehouse_stub "$case_dir"
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  printf '1 available\n' > "$case_dir/pool-status"
+  registry="$case_dir/data/secondmates.md"
+  printf 'registry\0record\n' > "$registry"
+
+  set +e
+  out=$(run_sweep "$case_dir" 2>&1); rc=$?
+  set -e
+
+  expect_code 2 "$rc" "nul-secondmate-registry: malformed global ownership must refuse"
+  assert_present "$wt/packages/frontend/.next" \
+    "nul-secondmate-registry: an incompletely readable registry must prevent deletion"
+  assert_contains "$out" "$registry" \
+    "nul-secondmate-registry: the malformed registry must be named"
+  pass "a NUL-bearing secondmate registry refuses the whole sweep"
+}
+
+test_sweep_refuses_nul_pool_status() {
+  local case_dir wt out rc
+  case_dir=$(make_case nul-pool-status)
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  cat > "$case_dir/fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+python3 - "$FM_FAKE_POOL_DIR" <<'PY'
+import json, sys
+print(json.dumps([{"status": "avail\x00able", "path": sys.argv[1] + "/1"}]))
+PY
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+
+  set +e
+  out=$(run_sweep "$case_dir" 2>&1); rc=$?
+  set -e
+
+  expect_code 1 "$rc" "nul-pool-status: malformed pool input must return nonzero"
+  assert_present "$wt/packages/frontend/.next" \
+    "nul-pool-status: NUL normalization must not forge available status"
+  assert_contains "$out" "worktree pool" \
+    "nul-pool-status: the malformed pool must be reported"
+  pass "a NUL-bearing pool field cannot forge availability"
+}
+
+test_sweep_refuses_conflicting_alias_pool_entries() {
+  local case_dir wt alias out rc
+  case_dir=$(make_case conflicting-alias-pool-entries)
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  alias="$case_dir/pool-copy-alias"
+  ln -s "$wt" "$alias"
+  cat > "$case_dir/fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+printf '[{"status":"in-use","path":"%s/1"},{"status":"available","path":"%s"}]\n' \
+  "$FM_FAKE_POOL_DIR" "$FM_FAKE_POOL_ALIAS"
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+
+  set +e
+  out=$(FM_FAKE_POOL_ALIAS="$alias" run_sweep "$case_dir" 2>&1); rc=$?
+  set -e
+
+  expect_code 1 "$rc" "conflicting-alias-pool-entries: ambiguous pool input must refuse"
+  assert_present "$wt/packages/frontend/.next" \
+    "conflicting-alias-pool-entries: available alias must not override an in-use copy"
+  assert_contains "$out" "duplicate filesystem copy" \
+    "conflicting-alias-pool-entries: the pool collision must be named"
+  pass "conflicting pool aliases refuse the project atomically"
+}
+
 test_sweep_refuses_pathless_pool_entry_atomically() {
   local case_dir wt out rc
   case_dir=$(make_case pathless-pool-entry)
@@ -836,6 +999,309 @@ test_sweep_refuses_project_when_git_inspection_fails() {
   assert_contains "$out" "$wt" \
     "git-failing: the refused copy must be named"
   pass "an unreadable git state refuses the whole project"
+}
+
+test_sweep_refuses_implicit_project_with_unreadable_git_metadata() {
+  local case_dir out rc broken
+  case_dir=$(make_case implicit-project-git-failure)
+  broken="$case_dir/projects/broken"
+  mkdir -p "$broken/.git"
+  cat > "$case_dir/fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+printf '[]\n'
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+
+  set +e
+  out=$(run_sweep "$case_dir" 2>&1); rc=$?
+  set -e
+
+  expect_code 1 "$rc" \
+    "implicit-project-git-failure: an uninspectable discovered project must count"
+  assert_not_contains "$out" "no idle copy holds Next.js build output" \
+    "implicit-project-git-failure: silently omitted projects make the clean claim false"
+  assert_contains "$out" "$broken" \
+    "implicit-project-git-failure: the uninspectable project must be named"
+  pass "implicit discovery records projects whose Git metadata is uninspectable"
+}
+
+test_sweep_refuses_when_build_output_walk_fails() {
+  local case_dir wt out rc real_find
+  case_dir=$(make_case build-output-walk-failure)
+  install_treehouse_stub "$case_dir"
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  printf '1 available\n' > "$case_dir/pool-status"
+  real_find=$(command -v find)
+  cat > "$case_dir/fakebin/find" <<'SH'
+#!/usr/bin/env bash
+if [ "$1" = "$FM_FAKE_FIND_ROOT" ]; then
+  for arg in "$@"; do
+    if [ "$arg" = -print0 ]; then
+      printf '%s\0' "$FM_FAKE_FIND_PATH"
+      exit 1
+    fi
+  done
+  printf '%s\n' "$FM_FAKE_FIND_PATH"
+  exit 1
+fi
+exec "$FM_REAL_FIND" "$@"
+SH
+  chmod +x "$case_dir/fakebin/find"
+
+  set +e
+  out=$(FM_REAL_FIND="$real_find" FM_FAKE_FIND_ROOT="$wt" \
+    FM_FAKE_FIND_PATH="$wt/packages/frontend/.next" \
+    run_sweep "$case_dir" 2>&1); rc=$?
+  set -e
+
+  expect_code 1 "$rc" "build-output-walk-failure: a partial walk must be incomplete"
+  assert_present "$wt/packages/frontend/.next" \
+    "build-output-walk-failure: partial discovery must precede no deletion"
+  assert_contains "$out" "$wt" \
+    "build-output-walk-failure: the incompletely walked copy must be named"
+  pass "a partial build-output walk refuses the project atomically"
+}
+
+test_sweep_refuses_when_build_output_size_fails() {
+  local case_dir wt out rc real_du
+  case_dir=$(make_case build-output-size-failure)
+  install_treehouse_stub "$case_dir"
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  printf '1 available\n' > "$case_dir/pool-status"
+  real_du=$(command -v du)
+  cat > "$case_dir/fakebin/du" <<'SH'
+#!/usr/bin/env bash
+last=
+for arg in "$@"; do last=$arg; done
+if [ "$last" = "$FM_FAKE_DU_PATH" ]; then exit 1; fi
+exec "$FM_REAL_DU" "$@"
+SH
+  chmod +x "$case_dir/fakebin/du"
+
+  set +e
+  out=$(FM_REAL_DU="$real_du" FM_FAKE_DU_PATH="$wt/packages/frontend/.next" \
+    run_sweep "$case_dir" 2>&1); rc=$?
+  set -e
+
+  expect_code 1 "$rc" "build-output-size-failure: an unmeasurable cache must be incomplete"
+  assert_present "$wt/packages/frontend/.next" \
+    "build-output-size-failure: failed measurement must not normalize to empty"
+  assert_contains "$out" "$wt" \
+    "build-output-size-failure: the unmeasurable copy must be named"
+  pass "an unmeasurable build-output directory refuses the project"
+}
+
+test_sweep_refuses_when_package_inspection_fails() {
+  local case_dir wt app out rc real_grep
+  case_dir=$(make_case package-inspection-failure)
+  install_treehouse_stub "$case_dir"
+  wt=$(add_pool_worktree "$case_dir" 1)
+  app="$wt/packages/frontend"
+  mkdir -p "$app/.next"
+  printf '{"dependencies":{"next":"16.3.0"}}\n' > "$app/package.json"
+  printf 'build\n' > "$app/.next/BUILD_ID"
+  printf 'packages/frontend/.next\n' >> "$wt/.gitignore"
+  git -C "$wt" add -A >/dev/null 2>&1
+  git -C "$wt" -c commit.gpgsign=false -c user.email=t@t -c user.name=t \
+    commit -qm "package-only next app"
+  printf '1 available\n' > "$case_dir/pool-status"
+  real_grep=$(command -v grep)
+  cat > "$case_dir/fakebin/grep" <<'SH'
+#!/usr/bin/env bash
+last=
+for arg in "$@"; do last=$arg; done
+if [ "$last" = "$FM_FAKE_GREP_PATH" ]; then exit 2; fi
+exec "$FM_REAL_GREP" "$@"
+SH
+  chmod +x "$case_dir/fakebin/grep"
+
+  set +e
+  out=$(FM_REAL_GREP="$real_grep" FM_FAKE_GREP_PATH="$app/package.json" \
+    run_sweep "$case_dir" 2>&1); rc=$?
+  set -e
+
+  expect_code 1 "$rc" "package-inspection-failure: failed app proof must be incomplete"
+  assert_present "$app/.next" \
+    "package-inspection-failure: a failed app proof must not read as not-an-app"
+  assert_contains "$out" "$wt" \
+    "package-inspection-failure: the incompletely inspected copy must be named"
+  pass "a failed package inspection refuses the project"
+}
+
+test_sweep_refuses_when_gitignore_inspection_fails() {
+  local case_dir wt out rc real_git
+  case_dir=$(make_case gitignore-inspection-failure)
+  install_treehouse_stub "$case_dir"
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  printf '1 available\n' > "$case_dir/pool-status"
+  real_git=$(command -v git)
+  cat > "$case_dir/fakebin/git" <<'SH'
+#!/usr/bin/env bash
+for arg in "$@"; do
+  if [ "$arg" = check-ignore ]; then exit 2; fi
+done
+exec "$FM_REAL_GIT" "$@"
+SH
+  chmod +x "$case_dir/fakebin/git"
+
+  set +e
+  out=$(FM_REAL_GIT="$real_git" run_sweep "$case_dir" 2>&1); rc=$?
+  set -e
+
+  expect_code 1 "$rc" "gitignore-inspection-failure: failed ignore proof must be incomplete"
+  assert_present "$wt/packages/frontend/.next" \
+    "gitignore-inspection-failure: a Git error must not read as not ignored"
+  assert_contains "$out" "$wt" \
+    "gitignore-inspection-failure: the incompletely inspected copy must be named"
+  pass "a failed gitignore inspection refuses the project"
+}
+
+test_sweep_refuses_worktree_that_becomes_unenterable() {
+  local case_dir wt out rc real_git
+  case_dir=$(make_case worktree-becomes-unenterable)
+  install_treehouse_stub "$case_dir"
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  printf '1 available\n' > "$case_dir/pool-status"
+  real_git=$(command -v git)
+  cat > "$case_dir/fakebin/git" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = -C ] && [ "${2:-}" = "$FM_FAKE_UNENTERABLE_WT" ] \
+  && [ "${3:-}" = stash ] && [ "${4:-}" = list ]; then
+  "$FM_REAL_GIT" "$@"
+  rc=$?
+  chmod 000 "$FM_FAKE_UNENTERABLE_WT"
+  exit "$rc"
+fi
+exec "$FM_REAL_GIT" "$@"
+SH
+  chmod +x "$case_dir/fakebin/git"
+
+  set +e
+  out=$(FM_REAL_GIT="$real_git" FM_FAKE_UNENTERABLE_WT="$wt" \
+    run_sweep "$case_dir" 2>&1); rc=$?
+  set -e
+  chmod 700 "$wt"
+
+  expect_code 1 "$rc" "worktree-becomes-unenterable: failed entry must be incomplete"
+  assert_present "$wt/packages/frontend/.next" \
+    "worktree-becomes-unenterable: failed entry must not read as no build output"
+  assert_not_contains "$out" "no idle copy holds Next.js build output" \
+    "worktree-becomes-unenterable: no inspected copy means no clean empty claim"
+  pass "a worktree that cannot be entered is reported as incomplete"
+}
+
+test_sweep_reports_human_size_without_awk() {
+  local case_dir wt out real_awk
+  case_dir=$(make_case human-size-without-awk)
+  install_treehouse_stub "$case_dir"
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  head -c 2097152 /dev/zero > "$wt/packages/frontend/.next/static/large.js"
+  printf '1 available\n' > "$case_dir/pool-status"
+  real_awk=$(command -v awk)
+  cat > "$case_dir/fakebin/awk" <<'SH'
+#!/usr/bin/env bash
+for arg in "$@"; do
+  if [ "$arg" = -v ]; then exit 2; fi
+done
+exec "$FM_REAL_AWK" "$@"
+SH
+  chmod +x "$case_dir/fakebin/awk"
+
+  out=$(FM_REAL_AWK="$real_awk" run_sweep "$case_dir" 2>&1)
+
+  assert_absent "$wt/packages/frontend/.next" \
+    "human-size-without-awk: healthy build output must still be reclaimed"
+  assert_not_contains "$out" "reclaimed  of Next.js build output" \
+    "human-size-without-awk: a formatter failure must not erase the reported size"
+  pass "human-readable reclaim sizes do not depend on an unchecked formatter"
+}
+
+test_sweep_records_failed_removal() {
+  local case_dir wt out rc real_rm
+  case_dir=$(make_case failed-removal)
+  install_treehouse_stub "$case_dir"
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  printf '1 available\n' > "$case_dir/pool-status"
+  real_rm=$(command -v rm)
+  cat > "$case_dir/fakebin/rm" <<'SH'
+#!/usr/bin/env bash
+last=
+for arg in "$@"; do last=$arg; done
+if [ "$last" = "$FM_FAKE_RM_PATH" ]; then exit 1; fi
+exec "$FM_REAL_RM" "$@"
+SH
+  chmod +x "$case_dir/fakebin/rm"
+
+  set +e
+  out=$(FM_REAL_RM="$real_rm" FM_FAKE_RM_PATH="$wt/packages/frontend/.next" \
+    run_sweep "$case_dir" 2>&1); rc=$?
+  set -e
+
+  expect_code 1 "$rc" "failed-removal: a failed deletion must return nonzero"
+  assert_present "$wt/packages/frontend/.next" \
+    "failed-removal: failed deletion must leave the directory present"
+  assert_not_contains "$out" "no idle copy holds Next.js build output" \
+    "failed-removal: a retained cache makes the clean empty claim false"
+  assert_contains "$out" "could not be processed" \
+    "failed-removal: the summary must count the failed copy"
+  pass "a failed removal is a named summary outcome"
+}
+
+test_sweep_records_dry_run_inspection_failure() {
+  local case_dir wt out rc real_find counter
+  case_dir=$(make_case dry-run-inspection-failure)
+  install_treehouse_stub "$case_dir"
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  printf '1 available\n' > "$case_dir/pool-status"
+  real_find=$(command -v find)
+  counter="$case_dir/find-count"
+  cat > "$case_dir/fakebin/find" <<'SH'
+#!/usr/bin/env bash
+count=0
+if [ -f "$FM_FAKE_FIND_COUNT" ]; then count=$(sed -n '1p' "$FM_FAKE_FIND_COUNT"); fi
+count=$(( count + 1 ))
+printf '%s\n' "$count" > "$FM_FAKE_FIND_COUNT"
+if [ "$count" -gt 1 ]; then exit 1; fi
+exec "$FM_REAL_FIND" "$@"
+SH
+  chmod +x "$case_dir/fakebin/find"
+
+  set +e
+  out=$(FM_REAL_FIND="$real_find" FM_FAKE_FIND_COUNT="$counter" \
+    run_sweep "$case_dir" --dry-run 2>&1); rc=$?
+  set -e
+
+  expect_code 1 "$rc" "dry-run-inspection-failure: a failed report must return nonzero"
+  assert_present "$wt/packages/frontend/.next" \
+    "dry-run-inspection-failure: dry run must leave build output present"
+  assert_contains "$out" "could not be processed" \
+    "dry-run-inspection-failure: the summary must count the failed report"
+  pass "a dry-run report failure is a named summary outcome"
+}
+
+test_sweep_distinguishes_empty_pool_from_uninspected_copy() {
+  local case_dir out
+  case_dir=$(make_case empty-pool)
+  cat > "$case_dir/fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+printf '[]\n'
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+
+  out=$(run_sweep "$case_dir" 2>&1)
+
+  assert_not_contains "$out" "no idle copy holds Next.js build output" \
+    "empty-pool: zero inspected copies must not select the copy-level clean claim"
+  assert_contains "$out" "contained no copies" \
+    "empty-pool: a completely read empty pool must get its own determinate summary"
+  pass "an empty pool is distinct from a copy that could not be inspected"
 }
 
 # --- discovery rule: only regenerable Next.js build output -------------------
@@ -1089,42 +1555,64 @@ test_teardown_stays_quiet_without_build_output() {
   pass "teardown says nothing about reclamation when there is nothing to reclaim"
 }
 
-test_sweep_reclaims_available_copy
-test_sweep_reports_nothing_found
-test_sweep_dry_run_removes_nothing
-test_sweep_skips_in_use_copy
-test_sweep_skips_copy_claimed_by_task_record
-test_sweep_skips_copy_claimed_by_secondmate_task_record
-test_sweep_skips_dirty_copy
-test_sweep_skips_stashed_copy
-test_sweep_refuses_project_with_unknown_pool_status
-test_sweep_skips_whole_project_when_pool_is_unreadable
-test_sweep_skips_project_when_pool_lookup_fails
-test_sweep_skips_project_when_pool_prints_json_then_fails
-test_sweep_refuses_unreadable_secondmate_state
-test_sweep_refuses_malformed_secondmate_registry
-test_sweep_refuses_absent_secondmate_home
-test_sweep_refuses_relative_secondmate_home
-test_sweep_refuses_unreadable_secondmate_registry
-test_sweep_refuses_absent_secondmate_registry
-test_sweep_skips_symlink_aliased_task_worktree
-test_sweep_skips_final_symlink_aliased_task_worktree
-test_sweep_refuses_broken_task_worktree_symlink
-test_sweep_skips_case_aliased_task_worktree
-test_sweep_refuses_when_candidate_identity_is_unreadable
-test_sweep_refuses_when_recorded_identity_is_unreadable
-test_sweep_refuses_pathless_pool_entry_atomically
-test_sweep_refuses_nondirectory_pool_entry_atomically
-test_sweep_reports_incomplete_project_count
-test_sweep_refuses_without_treehouse
-test_sweep_refuses_uninspectable_worktree_project
-test_sweep_refuses_project_when_git_inspection_fails
-test_sweep_leaves_tracked_next_directory
-test_sweep_leaves_ignored_next_outside_a_next_app
-test_sweep_leaves_node_modules_and_source
-test_sweep_reclaims_nested_build_output_once
-test_sweep_never_sweeps_the_project_clone
-test_teardown_reclaims_before_returning_the_copy
-test_teardown_reclaims_only_after_the_copy_is_quiet
-test_teardown_refusal_keeps_the_copy_intact
-test_teardown_stays_quiet_without_build_output
+run_next_cache_test() {
+  if [ -z "${FM_NEXT_CACHE_TEST:-}" ] || [ "$FM_NEXT_CACHE_TEST" = "$1" ]; then
+    "$1"
+  fi
+}
+
+run_next_cache_test test_sweep_reclaims_available_copy
+run_next_cache_test test_sweep_reports_nothing_found
+run_next_cache_test test_sweep_dry_run_removes_nothing
+run_next_cache_test test_sweep_skips_in_use_copy
+run_next_cache_test test_sweep_skips_copy_claimed_by_task_record
+run_next_cache_test test_sweep_skips_copy_claimed_by_secondmate_task_record
+run_next_cache_test test_sweep_skips_dirty_copy
+run_next_cache_test test_sweep_skips_stashed_copy
+run_next_cache_test test_sweep_refuses_project_with_unknown_pool_status
+run_next_cache_test test_sweep_skips_whole_project_when_pool_is_unreadable
+run_next_cache_test test_sweep_skips_project_when_pool_lookup_fails
+run_next_cache_test test_sweep_skips_project_when_pool_prints_json_then_fails
+run_next_cache_test test_sweep_refuses_unreadable_secondmate_state
+run_next_cache_test test_sweep_refuses_malformed_secondmate_registry
+run_next_cache_test test_sweep_refuses_absent_secondmate_home
+run_next_cache_test test_sweep_refuses_relative_secondmate_home
+run_next_cache_test test_sweep_refuses_unreadable_secondmate_registry
+run_next_cache_test test_sweep_refuses_absent_secondmate_registry
+run_next_cache_test test_sweep_skips_symlink_aliased_task_worktree
+run_next_cache_test test_sweep_skips_final_symlink_aliased_task_worktree
+run_next_cache_test test_sweep_refuses_broken_task_worktree_symlink
+run_next_cache_test test_sweep_skips_case_aliased_task_worktree
+run_next_cache_test test_sweep_refuses_when_candidate_identity_is_unreadable
+run_next_cache_test test_sweep_refuses_when_recorded_identity_is_unreadable
+run_next_cache_test test_sweep_preserves_task_owner_when_grep_fails
+run_next_cache_test test_sweep_refuses_empty_candidate_identity
+run_next_cache_test test_sweep_refuses_nul_task_metadata
+run_next_cache_test test_sweep_refuses_nul_secondmate_registry
+run_next_cache_test test_sweep_refuses_nul_pool_status
+run_next_cache_test test_sweep_refuses_conflicting_alias_pool_entries
+run_next_cache_test test_sweep_refuses_pathless_pool_entry_atomically
+run_next_cache_test test_sweep_refuses_nondirectory_pool_entry_atomically
+run_next_cache_test test_sweep_reports_incomplete_project_count
+run_next_cache_test test_sweep_refuses_without_treehouse
+run_next_cache_test test_sweep_refuses_uninspectable_worktree_project
+run_next_cache_test test_sweep_refuses_project_when_git_inspection_fails
+run_next_cache_test test_sweep_refuses_implicit_project_with_unreadable_git_metadata
+run_next_cache_test test_sweep_refuses_when_build_output_walk_fails
+run_next_cache_test test_sweep_refuses_when_build_output_size_fails
+run_next_cache_test test_sweep_refuses_when_package_inspection_fails
+run_next_cache_test test_sweep_refuses_when_gitignore_inspection_fails
+run_next_cache_test test_sweep_refuses_worktree_that_becomes_unenterable
+run_next_cache_test test_sweep_reports_human_size_without_awk
+run_next_cache_test test_sweep_records_failed_removal
+run_next_cache_test test_sweep_records_dry_run_inspection_failure
+run_next_cache_test test_sweep_distinguishes_empty_pool_from_uninspected_copy
+run_next_cache_test test_sweep_leaves_tracked_next_directory
+run_next_cache_test test_sweep_leaves_ignored_next_outside_a_next_app
+run_next_cache_test test_sweep_leaves_node_modules_and_source
+run_next_cache_test test_sweep_reclaims_nested_build_output_once
+run_next_cache_test test_sweep_never_sweeps_the_project_clone
+run_next_cache_test test_teardown_reclaims_before_returning_the_copy
+run_next_cache_test test_teardown_reclaims_only_after_the_copy_is_quiet
+run_next_cache_test test_teardown_refusal_keeps_the_copy_intact
+run_next_cache_test test_teardown_stays_quiet_without_build_output

--- a/tests/fm-next-cache-sweep.test.sh
+++ b/tests/fm-next-cache-sweep.test.sh
@@ -21,6 +21,9 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 fm_git_identity fmtest fmtest@example.invalid
 
+# Fixture commits pass -c commit.gpgsign=false explicitly rather than relying on
+# the harness to neutralize it, so a host that signs commits by default cannot
+# make these cases depend on a personal signing key.
 SWEEP="$ROOT/bin/fm-next-cache-sweep.sh"
 TEARDOWN="$ROOT/bin/fm-teardown.sh"
 TMP_ROOT=$(fm_test_tmproot fm-next-cache-sweep)
@@ -39,7 +42,7 @@ add_next_app() {
   head -c 4096 /dev/zero > "$app/.next/static/chunk.js"
   printf '%s/.next\n' "$sub" >> "$wt/.gitignore"
   git -C "$wt" add -A >/dev/null 2>&1
-  git -C "$wt" -c user.email=t@t -c user.name=t commit -qm "next app at $sub"
+  git -C "$wt" -c commit.gpgsign=false -c user.email=t@t -c user.name=t commit -qm "next app at $sub"
 }
 
 # A firstmate home with a project clone, a fake treehouse pool, and a fakebin.
@@ -55,7 +58,7 @@ make_case() {
   git clone -q "$case_dir/origin.git" "$case_dir/_seed" 2>/dev/null
   printf '# app\n' > "$case_dir/_seed/README.md"
   git -C "$case_dir/_seed" add README.md
-  git -C "$case_dir/_seed" -c user.email=t@t -c user.name=t \
+  git -C "$case_dir/_seed" -c commit.gpgsign=false -c user.email=t@t -c user.name=t \
     commit -qm "origin baseline"
   git -C "$case_dir/_seed" push -q origin main
   rm -rf "$case_dir/_seed"
@@ -248,7 +251,7 @@ test_sweep_skips_stashed_copy() {
   wt=$(add_pool_worktree "$case_dir" 1)
   add_next_app "$wt" packages/frontend
   printf 'work in progress\n' >> "$wt/README.md"
-  git -C "$wt" -c user.email=t@t -c user.name=t stash -q
+  git -C "$wt" -c commit.gpgsign=false -c user.email=t@t -c user.name=t stash -q
   printf '1 available\n' > "$case_dir/pool-status"
 
   out=$(run_sweep "$case_dir" 2>&1)
@@ -428,7 +431,7 @@ test_sweep_leaves_tracked_next_directory() {
   printf 'export default {}\n' > "$wt/packages/frontend/next.config.ts"
   printf 'checked in\n' > "$wt/packages/frontend/.next/fixture.txt"
   git -C "$wt" add -A >/dev/null 2>&1
-  git -C "$wt" -c user.email=t@t -c user.name=t commit -qm "tracked .next fixture"
+  git -C "$wt" -c commit.gpgsign=false -c user.email=t@t -c user.name=t commit -qm "tracked .next fixture"
   printf '1 available\n' > "$case_dir/pool-status"
 
   out=$(run_sweep "$case_dir" 2>&1)
@@ -450,7 +453,7 @@ test_sweep_leaves_ignored_next_outside_a_next_app() {
   printf 'irreplaceable\n' > "$wt/notes/.next/keep.txt"
   printf 'notes/.next\n' >> "$wt/.gitignore"
   git -C "$wt" add -A >/dev/null 2>&1
-  git -C "$wt" -c user.email=t@t -c user.name=t commit -qm "ignored non-app .next"
+  git -C "$wt" -c commit.gpgsign=false -c user.email=t@t -c user.name=t commit -qm "ignored non-app .next"
   printf '1 available\n' > "$case_dir/pool-status"
 
   out=$(run_sweep "$case_dir" 2>&1)
@@ -473,7 +476,7 @@ test_sweep_leaves_node_modules_and_source() {
   printf 'export default {}\n' > "$wt/node_modules/some-pkg/next.config.js"
   printf 'node_modules\n' >> "$wt/.gitignore"
   git -C "$wt" add -A >/dev/null 2>&1
-  git -C "$wt" -c user.email=t@t -c user.name=t commit -qm "ignore node_modules"
+  git -C "$wt" -c commit.gpgsign=false -c user.email=t@t -c user.name=t commit -qm "ignore node_modules"
   printf '1 available\n' > "$case_dir/pool-status"
 
   out=$(run_sweep "$case_dir" 2>&1)
@@ -533,7 +536,7 @@ make_teardown_case() {  # <name>
   git init -q --bare "$dir/origin.git"
   git -C "$dir/origin.git" symbolic-ref HEAD refs/heads/main
   git clone -q "$dir/origin.git" "$dir/_seed" 2>/dev/null
-  git -C "$dir/_seed" -c user.email=t@t -c user.name=t commit -q --allow-empty -m base
+  git -C "$dir/_seed" -c commit.gpgsign=false -c user.email=t@t -c user.name=t commit -q --allow-empty -m base
   git -C "$dir/_seed" push -q origin main
   rm -rf "$dir/_seed"
   git clone -q "$dir/origin.git" "$dir/project"
@@ -636,7 +639,7 @@ test_teardown_refusal_keeps_the_copy_intact() {
   case_dir=$(make_teardown_case teardown-refuse)
   add_next_app "$case_dir/wt" packages/frontend
   # Unlanded commit: teardown must refuse, and refusing means changing nothing.
-  git -C "$case_dir/wt" -c user.email=t@t -c user.name=t \
+  git -C "$case_dir/wt" -c commit.gpgsign=false -c user.email=t@t -c user.name=t \
     commit -q --allow-empty -m "unlanded work"
 
   set +e

--- a/tests/fm-next-cache-sweep.test.sh
+++ b/tests/fm-next-cache-sweep.test.sh
@@ -161,6 +161,31 @@ test_sweep_reclaims_available_copy() {
   pass "sweep reclaims Next.js build output from an available, unowned copy"
 }
 
+test_sweep_reports_explicit_project_without_deleting() {
+  local case_dir wt project out rc
+  case_dir=$(make_case explicit-project-report-only)
+  install_treehouse_stub "$case_dir"
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  printf '1 available\n' > "$case_dir/pool-status"
+  project="$case_dir/projects/app"
+
+  set +e
+  out=$(run_sweep "$case_dir" "$project" 2>&1); rc=$?
+  set -e
+
+  expect_code 0 "$rc" "explicit-project-report-only: inspection should succeed"
+  assert_present "$wt/packages/frontend/.next" \
+    "explicit-project-report-only: an operator-supplied target must not delete"
+  assert_contains "$out" "$wt/packages/frontend/.next" \
+    "explicit-project-report-only: the discovered build output must be reported"
+  assert_contains "$out" "report-only" \
+    "explicit-project-report-only: output must distinguish the non-deleting path"
+  assert_not_contains "$out" "sweep: reclaimed" \
+    "explicit-project-report-only: reported bytes must not count as reclaimed"
+  pass "an explicit project target is inspected without deletion authority"
+}
+
 test_sweep_reports_nothing_found() {
   local case_dir out
   case_dir=$(make_case empty)
@@ -811,6 +836,30 @@ SH
   pass "a NUL-bearing pool field cannot forge availability"
 }
 
+test_sweep_refuses_duplicate_pool_fields() {
+  local case_dir wt out rc
+  case_dir=$(make_case duplicate-pool-fields)
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  cat > "$case_dir/fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+printf '[{"status":"in-use","status":"available","path":"%s/1"}]\n' \
+  "$FM_FAKE_POOL_DIR"
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+
+  set +e
+  out=$(run_sweep "$case_dir" 2>&1); rc=$?
+  set -e
+
+  expect_code 1 "$rc" "duplicate-pool-fields: ambiguous lease evidence must refuse"
+  assert_present "$wt/packages/frontend/.next" \
+    "duplicate-pool-fields: last-value parsing must not forge availability"
+  assert_contains "$out" "worktree pool" \
+    "duplicate-pool-fields: the ambiguous pool must be reported"
+  pass "duplicate pool fields cannot forge availability"
+}
+
 test_sweep_refuses_conflicting_alias_pool_entries() {
   local case_dir wt alias out rc
   case_dir=$(make_case conflicting-alias-pool-entries)
@@ -940,6 +989,35 @@ SH
   pass "the project clone cannot masquerade as a pooled worktree"
 }
 
+test_sweep_refuses_discovered_linked_worktree_as_project_clone() {
+  local case_dir primary linked out rc
+  case_dir=$(make_case discovered-linked-project)
+  primary="$case_dir/primary"
+  linked="$case_dir/projects/app"
+  mv "$linked" "$primary"
+  git -C "$primary" worktree add -q -b fm/discovered-linked-project "$linked" main
+  add_next_app "$primary" packages/frontend
+  cat > "$case_dir/fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+printf '[{"status":"available","path":"%s"}]\n' "$FM_FAKE_PRIMARY_PROJECT"
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+
+  set +e
+  out=$(FM_FAKE_PRIMARY_PROJECT="$primary" run_sweep "$case_dir" 2>&1); rc=$?
+  set -e
+
+  expect_code 1 "$rc" \
+    "discovered-linked-project: a deleting target must be the primary clone"
+  assert_present "$primary/packages/frontend/.next" \
+    "discovered-linked-project: the primary clone must never become a pool candidate"
+  assert_contains "$out" "$linked" \
+    "discovered-linked-project: the rejected discovered target must be named"
+  assert_contains "$out" "primary" \
+    "discovered-linked-project: the failed clone-identity proof must be reported"
+  pass "default discovery rejects a linked worktree as the project clone"
+}
+
 test_sweep_refuses_explicit_project_subdirectory() {
   local case_dir clone child out rc
   case_dir=$(make_case explicit-project-subdirectory)
@@ -1027,7 +1105,7 @@ SH
   expect_code 1 "$rc" \
     "candidate-ledger-reconciliation: an incomplete candidate must refuse the project"
   verdict_count=$(printf '%s\n' "$out" \
-    | grep -Ec '^sweep: (reclaimed|skipped-as-owned|undetermined|refused|failed) ' || true)
+    | grep -Ec '^sweep: (reclaimed|report-only|skipped-as-owned|undetermined|refused|failed) ' || true)
   [ "$verdict_count" -eq 3 ] \
     || fail "candidate-ledger-reconciliation: expected 3 terminal verdicts, got $verdict_count"$'\n'"$out"
   assert_contains "$out" "sweep: refused $wt1" \
@@ -1732,6 +1810,7 @@ run_next_cache_test() {
 }
 
 run_next_cache_test test_sweep_reclaims_available_copy
+run_next_cache_test test_sweep_reports_explicit_project_without_deleting
 run_next_cache_test test_sweep_reports_nothing_found
 run_next_cache_test test_sweep_dry_run_removes_nothing
 run_next_cache_test test_sweep_skips_in_use_copy
@@ -1760,11 +1839,13 @@ run_next_cache_test test_sweep_refuses_empty_candidate_identity
 run_next_cache_test test_sweep_refuses_nul_task_metadata
 run_next_cache_test test_sweep_refuses_nul_secondmate_registry
 run_next_cache_test test_sweep_refuses_nul_pool_status
+run_next_cache_test test_sweep_refuses_duplicate_pool_fields
 run_next_cache_test test_sweep_refuses_conflicting_alias_pool_entries
 run_next_cache_test test_sweep_refuses_pathless_pool_entry_atomically
 run_next_cache_test test_sweep_refuses_nondirectory_pool_entry_atomically
 run_next_cache_test test_sweep_refuses_pool_entry_for_live_copy_child
 run_next_cache_test test_sweep_refuses_pool_entry_for_project_clone
+run_next_cache_test test_sweep_refuses_discovered_linked_worktree_as_project_clone
 run_next_cache_test test_sweep_refuses_explicit_project_subdirectory
 run_next_cache_test test_sweep_refusal_records_later_candidate_verdicts
 run_next_cache_test test_sweep_reconciles_every_announced_candidate

--- a/tests/fm-next-cache-sweep.test.sh
+++ b/tests/fm-next-cache-sweep.test.sh
@@ -1,0 +1,476 @@
+#!/usr/bin/env bash
+# Behavior tests for Next.js build-cache reclamation.
+#
+# The leak this pins: a pooled task copy returns to the pool still holding its
+# Next.js build output. `treehouse return` resets tracked content and leaves
+# gitignored output alone, so nothing ever removes it and it accumulates copy by
+# copy until the volume fills. Measured 2026-08-18: 15 GB in one idle Artemis
+# copy on a volume with 11 GB free.
+#
+# Two surfaces, one discovery rule (bin/fm-next-cache-lib.sh):
+#   bin/fm-teardown.sh          reclaims a copy on its way back to the pool.
+#   bin/fm-next-cache-sweep.sh  reclaims copies already sitting idle in it.
+#
+# The cases that matter most are the refusals. A live dev server rewrites the
+# output the moment it is deleted, and deleting mid-build is worse than leaving
+# it alone, so every ownership proof gets its own case asserting the directory
+# SURVIVES.
+set -u
+
+# shellcheck source=tests/lib.sh disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+fm_git_identity fmtest fmtest@example.invalid
+
+SWEEP="$ROOT/bin/fm-next-cache-sweep.sh"
+TEARDOWN="$ROOT/bin/fm-teardown.sh"
+TMP_ROOT=$(fm_test_tmproot fm-next-cache-sweep)
+TMP_ROOT=$(cd "$TMP_ROOT" && pwd -P)
+
+# --- fixture builders -------------------------------------------------------
+
+# Give <worktree> a Next.js app at <subpath> holding build output, and make that
+# output gitignored the way a real project does. Args: worktree subpath
+add_next_app() {
+  local wt=$1 sub=$2 app="$1/$2"
+  mkdir -p "$app/.next/server" "$app/.next/static"
+  printf 'export default {}\n' > "$app/next.config.ts"
+  printf '{"name":"app","dependencies":{"next":"16.3.0"}}\n' > "$app/package.json"
+  printf 'build-id\n' > "$app/.next/BUILD_ID"
+  head -c 4096 /dev/zero > "$app/.next/static/chunk.js"
+  printf '%s/.next\n' "$sub" >> "$wt/.gitignore"
+  git -C "$wt" add -A >/dev/null 2>&1
+  git -C "$wt" -c user.email=t@t -c user.name=t commit -qm "next app at $sub"
+}
+
+# A firstmate home with a project clone, a fake treehouse pool, and a fakebin.
+# Echoes the case dir. Args: name
+make_case() {
+  local name=$1 case_dir
+  case_dir="$TMP_ROOT/$name"
+  mkdir -p "$case_dir/state" "$case_dir/config" "$case_dir/data" \
+    "$case_dir/projects" "$case_dir/fakebin" "$case_dir/pool"
+
+  git init -q --bare "$case_dir/origin.git"
+  git -C "$case_dir/origin.git" symbolic-ref HEAD refs/heads/main
+  git clone -q "$case_dir/origin.git" "$case_dir/_seed" 2>/dev/null
+  printf '# app\n' > "$case_dir/_seed/README.md"
+  git -C "$case_dir/_seed" add README.md
+  git -C "$case_dir/_seed" -c user.email=t@t -c user.name=t \
+    commit -qm "origin baseline"
+  git -C "$case_dir/_seed" push -q origin main
+  rm -rf "$case_dir/_seed"
+  git clone -q "$case_dir/origin.git" "$case_dir/projects/app"
+  git -C "$case_dir/projects/app" remote set-head origin main 2>/dev/null || true
+
+  printf '%s\n' "$case_dir"
+}
+
+# Add a pool worktree named <n> to <case_dir>, on branch fm/task-<n>.
+# Echoes its path. Args: case_dir n
+add_pool_worktree() {  # <case-dir> <n>
+  local case_dir=$1 n=$2 wt="$1/pool/$2"
+  git -C "$case_dir/projects/app" worktree add -q -b "fm/task-$n" "$wt" main
+  printf '%s\n' "$wt"
+}
+
+# Install a treehouse stub whose `status --json` answers the pool description in
+# $case_dir/pool-status (lines of "<name> <status>"). `return --force` succeeds.
+install_treehouse_stub() {  # <case-dir>
+  local case_dir=$1
+  cat > "$case_dir/fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = status ]; then
+  python3 - "$FM_FAKE_POOL_STATUS" "$FM_FAKE_POOL_DIR" <<'PY'
+import json, sys
+entries = []
+with open(sys.argv[1]) as handle:
+    for line in handle:
+        line = line.split()
+        if len(line) == 2:
+            entries.append({"name": line[0], "status": line[1],
+                            "path": "%s/%s" % (sys.argv[2], line[0])})
+print(json.dumps(entries))
+PY
+  exit 0
+fi
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+}
+
+run_sweep() {  # <case-dir> [args...]
+  local case_dir=$1; shift
+  FM_HOME="$case_dir" \
+  FM_STATE_OVERRIDE="$case_dir/state" \
+  FM_DATA_OVERRIDE="$case_dir/data" \
+  FM_PROJECTS_OVERRIDE="$case_dir/projects" \
+  FM_FAKE_POOL_STATUS="$case_dir/pool-status" \
+  FM_FAKE_POOL_DIR="$case_dir/pool" \
+  PATH="$case_dir/fakebin:$PATH" \
+    "$SWEEP" "$@"
+}
+
+# --- sweep: it reclaims a genuinely unowned copy -----------------------------
+
+test_sweep_reclaims_available_copy() {
+  local case_dir wt out rc
+  case_dir=$(make_case reclaim)
+  install_treehouse_stub "$case_dir"
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  printf '1 available\n' > "$case_dir/pool-status"
+
+  set +e
+  out=$(run_sweep "$case_dir" 2>&1); rc=$?
+  set -e
+
+  expect_code 0 "$rc" "reclaim: sweep should succeed"
+  assert_absent "$wt/packages/frontend/.next" "reclaim: build output should be gone"
+  assert_present "$wt/packages/frontend/next.config.ts" "reclaim: source must survive"
+  assert_present "$wt/README.md" "reclaim: tracked content must survive"
+  assert_contains "$out" "reclaimed" "reclaim: sweep must report what it reclaimed"
+  assert_contains "$out" "$wt/packages/frontend/.next" "reclaim: report must name the directory"
+  pass "sweep reclaims Next.js build output from an available, unowned copy"
+}
+
+test_sweep_reports_nothing_found() {
+  local case_dir out
+  case_dir=$(make_case empty)
+  install_treehouse_stub "$case_dir"
+  add_pool_worktree "$case_dir" 1 >/dev/null
+  printf '1 available\n' > "$case_dir/pool-status"
+
+  out=$(run_sweep "$case_dir" 2>&1)
+
+  assert_contains "$out" "nothing to reclaim" \
+    "empty: a sweep that found nothing must say so rather than print nothing"
+  pass "sweep reports plainly when no idle copy holds build output"
+}
+
+test_sweep_dry_run_removes_nothing() {
+  local case_dir wt out
+  case_dir=$(make_case dry-run)
+  install_treehouse_stub "$case_dir"
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  printf '1 available\n' > "$case_dir/pool-status"
+
+  out=$(run_sweep "$case_dir" --dry-run 2>&1)
+
+  assert_present "$wt/packages/frontend/.next" "dry-run: build output must survive"
+  assert_contains "$out" "would reclaim" "dry-run: must report what it would reclaim"
+  pass "--dry-run reports the reclaim without performing it"
+}
+
+# --- sweep: every ownership proof refuses ------------------------------------
+
+test_sweep_skips_in_use_copy() {
+  local case_dir wt out
+  case_dir=$(make_case in-use)
+  install_treehouse_stub "$case_dir"
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  printf '1 in-use\n' > "$case_dir/pool-status"
+
+  out=$(run_sweep "$case_dir" 2>&1)
+
+  assert_present "$wt/packages/frontend/.next" \
+    "in-use: a leased copy may be mid-build; its output must survive"
+  assert_contains "$out" "in use by the pool" "in-use: the skip reason must be reported"
+  pass "sweep never touches a copy the pool still reports in use"
+}
+
+test_sweep_skips_copy_claimed_by_task_record() {
+  local case_dir wt out
+  case_dir=$(make_case claimed)
+  install_treehouse_stub "$case_dir"
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  printf '1 available\n' > "$case_dir/pool-status"
+  fm_write_meta "$case_dir/state/task-x1.meta" \
+    "endpoint_task_id=task-x1" "worktree=$wt" "project=$case_dir/projects/app" \
+    "kind=ship" "mode=no-mistakes"
+
+  out=$(run_sweep "$case_dir" 2>&1)
+
+  assert_present "$wt/packages/frontend/.next" \
+    "claimed: a copy a task still records must keep its output"
+  assert_contains "$out" "still claimed by a task record" "claimed: reason must be reported"
+  pass "sweep never touches a copy a task record still claims"
+}
+
+test_sweep_skips_copy_claimed_by_secondmate_task_record() {
+  local case_dir wt out sub
+  case_dir=$(make_case claimed-secondmate)
+  install_treehouse_stub "$case_dir"
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  printf '1 available\n' > "$case_dir/pool-status"
+  # The pool is shared across firstmate homes, so a copy owned by another home's
+  # task must be as untouchable as one owned by this home's.
+  sub="$case_dir/secondmate"
+  mkdir -p "$sub/state"
+  fm_write_meta "$sub/state/task-s1.meta" \
+    "endpoint_task_id=task-s1" "worktree=$wt" "kind=ship" "mode=no-mistakes"
+  printf -- '- helper - Helps. (home: %s; scope: things; projects: app; added 2026-08-18)\n' \
+    "$sub" > "$case_dir/data/secondmates.md"
+
+  out=$(run_sweep "$case_dir" 2>&1)
+
+  assert_present "$wt/packages/frontend/.next" \
+    "claimed-secondmate: another home's task record must protect the copy"
+  assert_contains "$out" "still claimed by a task record" \
+    "claimed-secondmate: reason must be reported"
+  pass "sweep honours task records in registered secondmate homes"
+}
+
+test_sweep_skips_dirty_copy() {
+  local case_dir wt out
+  case_dir=$(make_case dirty)
+  install_treehouse_stub "$case_dir"
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  printf 'unfinished\n' > "$wt/packages/frontend/edit.ts"
+  printf '1 available\n' > "$case_dir/pool-status"
+
+  out=$(run_sweep "$case_dir" 2>&1)
+
+  assert_present "$wt/packages/frontend/.next" \
+    "dirty: uncommitted work means the copy is not finished with"
+  assert_contains "$out" "has uncommitted changes" "dirty: reason must be reported"
+  pass "sweep never touches a copy with uncommitted changes"
+}
+
+test_sweep_skips_stashed_copy() {
+  local case_dir wt out
+  case_dir=$(make_case stashed)
+  install_treehouse_stub "$case_dir"
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  printf 'work in progress\n' >> "$wt/README.md"
+  git -C "$wt" -c user.email=t@t -c user.name=t stash -q
+  printf '1 available\n' > "$case_dir/pool-status"
+
+  out=$(run_sweep "$case_dir" 2>&1)
+
+  assert_present "$wt/packages/frontend/.next" \
+    "stashed: a stash is unlanded work a clean tree does not show"
+  assert_contains "$out" "has stashed work" "stashed: reason must be reported"
+  pass "sweep never touches a copy holding stashed work"
+}
+
+# --- discovery rule: only regenerable Next.js build output -------------------
+
+test_sweep_leaves_tracked_next_directory() {
+  local case_dir wt out
+  case_dir=$(make_case tracked)
+  install_treehouse_stub "$case_dir"
+  wt=$(add_pool_worktree "$case_dir" 1)
+  # A committed .next beside a real Next app: tracked content is never build
+  # output, so gitignore status - not the name - decides.
+  mkdir -p "$wt/packages/frontend/.next"
+  printf 'export default {}\n' > "$wt/packages/frontend/next.config.ts"
+  printf 'checked in\n' > "$wt/packages/frontend/.next/fixture.txt"
+  git -C "$wt" add -A >/dev/null 2>&1
+  git -C "$wt" -c user.email=t@t -c user.name=t commit -qm "tracked .next fixture"
+  printf '1 available\n' > "$case_dir/pool-status"
+
+  out=$(run_sweep "$case_dir" 2>&1)
+
+  assert_present "$wt/packages/frontend/.next/fixture.txt" \
+    "tracked: a tracked .next is not build output and must survive"
+  assert_contains "$out" "nothing to reclaim" "tracked: nothing should have been reclaimed"
+  pass "a tracked .next directory is never treated as build output"
+}
+
+test_sweep_leaves_ignored_next_outside_a_next_app() {
+  local case_dir wt out
+  case_dir=$(make_case not-an-app)
+  install_treehouse_stub "$case_dir"
+  wt=$(add_pool_worktree "$case_dir" 1)
+  # Gitignored and named .next, but nothing here is a Next.js app, so it is not
+  # provably regenerable and the sweep must leave it alone.
+  mkdir -p "$wt/notes/.next"
+  printf 'irreplaceable\n' > "$wt/notes/.next/keep.txt"
+  printf 'notes/.next\n' >> "$wt/.gitignore"
+  git -C "$wt" add -A >/dev/null 2>&1
+  git -C "$wt" -c user.email=t@t -c user.name=t commit -qm "ignored non-app .next"
+  printf '1 available\n' > "$case_dir/pool-status"
+
+  out=$(run_sweep "$case_dir" 2>&1)
+
+  assert_present "$wt/notes/.next/keep.txt" \
+    "not-an-app: an ignored .next outside a Next.js app must survive"
+  assert_contains "$out" "nothing to reclaim" "not-an-app: nothing should have been reclaimed"
+  pass "an ignored .next that is not Next.js build output is left alone"
+}
+
+test_sweep_leaves_node_modules_and_source() {
+  local case_dir wt out
+  case_dir=$(make_case node-modules)
+  install_treehouse_stub "$case_dir"
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  # A gitignored node_modules holding a package that itself ships a .next.
+  mkdir -p "$wt/node_modules/some-pkg/.next"
+  printf 'vendored\n' > "$wt/node_modules/some-pkg/.next/vendor.js"
+  printf 'export default {}\n' > "$wt/node_modules/some-pkg/next.config.js"
+  printf 'node_modules\n' >> "$wt/.gitignore"
+  git -C "$wt" add -A >/dev/null 2>&1
+  git -C "$wt" -c user.email=t@t -c user.name=t commit -qm "ignore node_modules"
+  printf '1 available\n' > "$case_dir/pool-status"
+
+  out=$(run_sweep "$case_dir" 2>&1)
+
+  assert_absent "$wt/packages/frontend/.next" "node-modules: the app's output should be reclaimed"
+  assert_present "$wt/node_modules/some-pkg/.next/vendor.js" \
+    "node-modules: nothing inside node_modules may be removed"
+  assert_present "$wt/.git" "node-modules: git data must survive"
+  pass "node_modules and git data are out of reach of the discovery walk"
+}
+
+test_sweep_reclaims_nested_build_output_once() {
+  local case_dir wt out
+  case_dir=$(make_case nested)
+  install_treehouse_stub "$case_dir"
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  # Next's standalone output nests a second .next inside the first. It must go
+  # with its parent, counted once, not walked into and reported twice.
+  mkdir -p "$wt/packages/frontend/.next/standalone/packages/frontend/.next"
+  printf 'export default {}\n' \
+    > "$wt/packages/frontend/.next/standalone/packages/frontend/next.config.ts"
+  printf '1 available\n' > "$case_dir/pool-status"
+
+  out=$(run_sweep "$case_dir" 2>&1)
+
+  assert_absent "$wt/packages/frontend/.next" "nested: the whole tree should be gone"
+  [ "$(printf '%s\n' "$out" | grep -c 'of Next.js build output from ')" = 1 ] \
+    || fail "nested: a nested .next must be reclaimed with its parent, reported once"$'\n'"$out"
+  pass "a nested standalone .next is reclaimed with its parent and reported once"
+}
+
+test_sweep_never_sweeps_the_project_clone() {
+  local case_dir out
+  case_dir=$(make_case clone)
+  install_treehouse_stub "$case_dir"
+  add_pool_worktree "$case_dir" 1 >/dev/null
+  add_next_app "$case_dir/projects/app" packages/frontend
+  printf '1 available\n' > "$case_dir/pool-status"
+
+  out=$(run_sweep "$case_dir" 2>&1)
+
+  assert_present "$case_dir/projects/app/packages/frontend/.next" \
+    "clone: firstmate reads its project clones; the sweep must not write to them"
+  pass "the sweep reclaims from pooled copies only, never the project clone"
+}
+
+# --- teardown: the copy is reclaimed on its way back to the pool -------------
+
+# A minimal teardown sandbox: project clone, task worktree, stubs.
+make_teardown_case() {  # <name>
+  local case_dir=$1 dir
+  dir="$TMP_ROOT/$case_dir"
+  mkdir -p "$dir/state" "$dir/config" "$dir/fakebin"
+  fm_fake_exit0 "$dir/fakebin" treehouse tmux gh gh-axi no-mistakes tasks-axi
+
+  git init -q --bare "$dir/origin.git"
+  git -C "$dir/origin.git" symbolic-ref HEAD refs/heads/main
+  git clone -q "$dir/origin.git" "$dir/_seed" 2>/dev/null
+  git -C "$dir/_seed" -c user.email=t@t -c user.name=t commit -q --allow-empty -m base
+  git -C "$dir/_seed" push -q origin main
+  rm -rf "$dir/_seed"
+  git clone -q "$dir/origin.git" "$dir/project"
+  git -C "$dir/project" remote set-head origin main 2>/dev/null || true
+  git -C "$dir/project" worktree add -q -b fm/task-x1 "$dir/wt" main
+  touch "$dir/state/.last-watcher-beat"
+
+  fm_write_meta "$dir/state/task-x1.meta" \
+    "window=firstmate:fm-task-x1" \
+    "endpoint_task_id=task-x1" \
+    "worktree=$dir/wt" \
+    "project=$dir/project" \
+    "kind=ship" \
+    "mode=no-mistakes"
+
+  printf '%s\n' "$dir"
+}
+
+run_teardown() {  # <case-dir> [args...]
+  local case_dir=$1; shift
+  FM_ROOT_OVERRIDE="$ROOT" \
+  FM_STATE_OVERRIDE="$case_dir/state" \
+  FM_CONFIG_OVERRIDE="$case_dir/config" \
+  PATH="$case_dir/fakebin:$PATH" \
+    "$TEARDOWN" task-x1 "$@"
+}
+
+test_teardown_reclaims_before_returning_the_copy() {
+  local case_dir out rc
+  case_dir=$(make_teardown_case teardown-reclaim)
+  add_next_app "$case_dir/wt" packages/frontend
+  git -C "$case_dir/wt" push -q origin fm/task-x1
+  git -C "$case_dir/project" fetch -q origin
+
+  set +e
+  out=$(run_teardown "$case_dir" 2>&1); rc=$?
+  set -e
+
+  expect_code 0 "$rc" "teardown-reclaim: teardown should succeed"
+  assert_absent "$case_dir/wt/packages/frontend/.next" \
+    "teardown-reclaim: the copy must not return to the pool holding build output"
+  assert_contains "$out" "reclaimed" "teardown-reclaim: teardown must report the reclaim"
+  pass "teardown reclaims Next.js build output before returning the copy to the pool"
+}
+
+test_teardown_refusal_keeps_the_copy_intact() {
+  local case_dir out rc
+  case_dir=$(make_teardown_case teardown-refuse)
+  add_next_app "$case_dir/wt" packages/frontend
+  # Unlanded commit: teardown must refuse, and refusing means changing nothing.
+  git -C "$case_dir/wt" -c user.email=t@t -c user.name=t \
+    commit -q --allow-empty -m "unlanded work"
+
+  set +e
+  out=$(run_teardown "$case_dir" 2>&1); rc=$?
+  set -e
+
+  expect_code 1 "$rc" "teardown-refuse: teardown should refuse unlanded work"
+  assert_contains "$out" "REFUSED" "teardown-refuse: the refusal must be reported"
+  assert_present "$case_dir/wt/packages/frontend/.next" \
+    "teardown-refuse: a refused teardown must leave the copy exactly as it was"
+  pass "a refused teardown reclaims nothing"
+}
+
+test_teardown_stays_quiet_without_build_output() {
+  local case_dir out rc
+  case_dir=$(make_teardown_case teardown-quiet)
+  git -C "$case_dir/wt" push -q origin fm/task-x1
+  git -C "$case_dir/project" fetch -q origin
+
+  set +e
+  out=$(run_teardown "$case_dir" 2>&1); rc=$?
+  set -e
+
+  expect_code 0 "$rc" "teardown-quiet: teardown should succeed"
+  assert_not_contains "$out" "reclaimed" \
+    "teardown-quiet: a project that never builds must not get a reclaim line"
+  pass "teardown says nothing about reclamation when there is nothing to reclaim"
+}
+
+test_sweep_reclaims_available_copy
+test_sweep_reports_nothing_found
+test_sweep_dry_run_removes_nothing
+test_sweep_skips_in_use_copy
+test_sweep_skips_copy_claimed_by_task_record
+test_sweep_skips_copy_claimed_by_secondmate_task_record
+test_sweep_skips_dirty_copy
+test_sweep_skips_stashed_copy
+test_sweep_leaves_tracked_next_directory
+test_sweep_leaves_ignored_next_outside_a_next_app
+test_sweep_leaves_node_modules_and_source
+test_sweep_reclaims_nested_build_output_once
+test_sweep_never_sweeps_the_project_clone
+test_teardown_reclaims_before_returning_the_copy
+test_teardown_refusal_keeps_the_copy_intact
+test_teardown_stays_quiet_without_build_output

--- a/tests/fm-next-cache-sweep.test.sh
+++ b/tests/fm-next-cache-sweep.test.sh
@@ -101,6 +101,18 @@ SH
   chmod +x "$case_dir/fakebin/treehouse"
 }
 
+install_stat_failure_stub() {  # <case-dir>
+  local case_dir=$1
+  cat > "$case_dir/fakebin/stat" <<'SH'
+#!/usr/bin/env bash
+last=
+for arg in "$@"; do last=$arg; done
+if [ "$last" = "${FM_FAKE_STAT_FAIL:-}" ]; then exit 1; fi
+exec "$FM_REAL_STAT" "$@"
+SH
+  chmod +x "$case_dir/fakebin/stat"
+}
+
 run_sweep() {  # <case-dir> [args...]
   local case_dir=$1; shift
   FM_HOME="$case_dir" \
@@ -336,6 +348,224 @@ SH
     "pool-failing: a failed pool lookup must leave every copy alone"
   [ "$rc" -ne 0 ] || fail "pool-failing: a failed pool lookup must not report a clean sweep"
   pass "a failing pool lookup sweeps nothing in that project"
+}
+
+test_sweep_skips_project_when_pool_prints_json_then_fails() {
+  local case_dir wt out rc
+  case_dir=$(make_case pool-json-then-failing)
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  cat > "$case_dir/fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+printf '[{"name":"1","status":"available","path":"%s/1"}]\n' "$FM_FAKE_POOL_DIR"
+exit 1
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+
+  set +e
+  out=$(run_sweep "$case_dir" 2>&1); rc=$?
+  set -e
+
+  assert_present "$wt/packages/frontend/.next" \
+    "pool-json-then-failing: a failed authoritative lookup must leave every copy alone"
+  [ "$rc" -ne 0 ] \
+    || fail "pool-json-then-failing: a failed lookup must not report a clean sweep"
+  assert_contains "$out" "cannot read the worktree pool" \
+    "pool-json-then-failing: the failed lookup must be reported"
+  pass "valid pool JSON cannot mask a failed treehouse lookup"
+}
+
+test_sweep_refuses_unreadable_secondmate_state() {
+  local case_dir wt out rc sub
+  case_dir=$(make_case unreadable-secondmate-state)
+  install_treehouse_stub "$case_dir"
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  printf '1 available\n' > "$case_dir/pool-status"
+  sub="$case_dir/secondmate"
+  mkdir -p "$sub/state"
+  fm_write_meta "$sub/state/task-s1.meta" \
+    "endpoint_task_id=task-s1" "worktree=$wt" "kind=ship" "mode=no-mistakes"
+  printf -- '- helper - Helps. (home: %s; scope: things; projects: app; added 2026-08-18)\n' \
+    "$sub" > "$case_dir/data/secondmates.md"
+  chmod 000 "$sub/state"
+
+  set +e
+  out=$(run_sweep "$case_dir" 2>&1); rc=$?
+  set -e
+  chmod 700 "$sub/state"
+
+  assert_present "$wt/packages/frontend/.next" \
+    "unreadable-secondmate-state: unbounded task ownership must prevent every deletion"
+  expect_code 2 "$rc" \
+    "unreadable-secondmate-state: an unreadable task-record source must refuse the sweep"
+  assert_contains "$out" "$sub/state" \
+    "unreadable-secondmate-state: the refusal must name the unreadable state directory"
+  pass "an unreadable registered state directory refuses the whole sweep"
+}
+
+test_sweep_refuses_malformed_secondmate_registry() {
+  local case_dir wt out rc
+  case_dir=$(make_case malformed-secondmate-registry)
+  install_treehouse_stub "$case_dir"
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  printf '1 available\n' > "$case_dir/pool-status"
+  printf '%s\n' '- helper - malformed registry entry' > "$case_dir/data/secondmates.md"
+
+  set +e
+  out=$(run_sweep "$case_dir" 2>&1); rc=$?
+  set -e
+
+  assert_present "$wt/packages/frontend/.next" \
+    "malformed-secondmate-registry: unbounded task ownership must prevent every deletion"
+  expect_code 2 "$rc" \
+    "malformed-secondmate-registry: malformed ownership input must refuse the sweep"
+  assert_contains "$out" "$case_dir/data/secondmates.md" \
+    "malformed-secondmate-registry: the refusal must name the malformed registry"
+  pass "a malformed secondmate record refuses the whole sweep"
+}
+
+test_sweep_allows_absent_secondmate_home() {
+  local case_dir wt out rc absent
+  case_dir=$(make_case absent-secondmate-home)
+  install_treehouse_stub "$case_dir"
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  printf '1 available\n' > "$case_dir/pool-status"
+  absent="$case_dir/absent-secondmate"
+  printf -- '- helper - Helps. (home: %s; scope: things; projects: app; added 2026-08-18)\n' \
+    "$absent" > "$case_dir/data/secondmates.md"
+
+  set +e
+  out=$(run_sweep "$case_dir" 2>&1); rc=$?
+  set -e
+
+  expect_code 0 "$rc" \
+    "absent-secondmate-home: a home absent from this machine contributes no local records"
+  assert_absent "$wt/packages/frontend/.next" \
+    "absent-secondmate-home: a provably absent home must not block a safe reclaim"
+  assert_contains "$out" "$absent" \
+    "absent-secondmate-home: omitting an absent home must be reported explicitly"
+  pass "an absent registered local home is reported and does not block the sweep"
+}
+
+test_sweep_skips_symlink_aliased_task_worktree() {
+  local case_dir wt out alias
+  case_dir=$(make_case symlink-task-alias)
+  install_treehouse_stub "$case_dir"
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  printf '1 available\n' > "$case_dir/pool-status"
+  alias="$case_dir/pool-alias"
+  ln -s "$case_dir/pool" "$alias"
+  fm_write_meta "$case_dir/state/task-x1.meta" \
+    "endpoint_task_id=task-x1" "worktree=$alias/1" \
+    "project=$case_dir/projects/app" "kind=ship" "mode=no-mistakes"
+
+  out=$(run_sweep "$case_dir" 2>&1)
+
+  assert_present "$wt/packages/frontend/.next" \
+    "symlink-task-alias: an aliased task path must protect the same worktree"
+  assert_contains "$out" "still claimed by a task record" \
+    "symlink-task-alias: the filesystem identity match must be reported as owned"
+  pass "task ownership follows filesystem identity through a symlinked prefix"
+}
+
+test_sweep_skips_case_aliased_task_worktree() {
+  local case_dir wt out alias
+  case_dir=$(make_case case-task-alias)
+  install_treehouse_stub "$case_dir"
+  wt=$(add_pool_worktree "$case_dir" 1)
+  if [ ! -d "$case_dir/POOL/1" ]; then
+    pass "SKIP (case-sensitive filesystem): case-aliased task ownership"
+    return 0
+  fi
+  add_next_app "$wt" packages/frontend
+  printf '1 available\n' > "$case_dir/pool-status"
+  alias="$case_dir/POOL/1"
+  fm_write_meta "$case_dir/state/task-x1.meta" \
+    "endpoint_task_id=task-x1" "worktree=$alias" \
+    "project=$case_dir/projects/app" "kind=ship" "mode=no-mistakes"
+
+  out=$(run_sweep "$case_dir" 2>&1)
+
+  assert_present "$wt/packages/frontend/.next" \
+    "case-task-alias: differently cased spelling must protect the same worktree"
+  assert_contains "$out" "still claimed by a task record" \
+    "case-task-alias: the filesystem identity match must be reported as owned"
+  pass "task ownership follows filesystem identity across case aliases"
+}
+
+test_sweep_skips_when_candidate_identity_is_unreadable() {
+  local case_dir wt out real_stat
+  case_dir=$(make_case candidate-identity-unreadable)
+  install_treehouse_stub "$case_dir"
+  install_stat_failure_stub "$case_dir"
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  printf '1 available\n' > "$case_dir/pool-status"
+  real_stat=$(command -v stat)
+
+  out=$(FM_REAL_STAT="$real_stat" FM_FAKE_STAT_FAIL="$wt" \
+    run_sweep "$case_dir" 2>&1)
+
+  assert_present "$wt/packages/frontend/.next" \
+    "candidate-identity-unreadable: unresolved candidate identity must prevent deletion"
+  assert_contains "$out" "could not be assessed" \
+    "candidate-identity-unreadable: unresolved ownership must be reported as unknown"
+  pass "an unreadable candidate identity is never treated as unowned"
+}
+
+test_sweep_skips_when_recorded_identity_is_unreadable() {
+  local case_dir wt out alias real_stat
+  case_dir=$(make_case recorded-identity-unreadable)
+  install_treehouse_stub "$case_dir"
+  install_stat_failure_stub "$case_dir"
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  printf '1 available\n' > "$case_dir/pool-status"
+  alias="$case_dir/pool-alias"
+  ln -s "$case_dir/pool" "$alias"
+  fm_write_meta "$case_dir/state/task-x1.meta" \
+    "endpoint_task_id=task-x1" "worktree=$alias/1" \
+    "project=$case_dir/projects/app" "kind=ship" "mode=no-mistakes"
+  real_stat=$(command -v stat)
+
+  out=$(FM_REAL_STAT="$real_stat" FM_FAKE_STAT_FAIL="$alias/1" \
+    run_sweep "$case_dir" 2>&1)
+
+  assert_present "$wt/packages/frontend/.next" \
+    "recorded-identity-unreadable: unresolved recorded identity must prevent deletion"
+  assert_contains "$out" "could not be assessed" \
+    "recorded-identity-unreadable: unresolved ownership must be reported as unknown"
+  pass "an unreadable existing task path is treated as a possible owner"
+}
+
+test_sweep_reports_incomplete_project_count() {
+  local case_dir out rc
+  case_dir=$(make_case incomplete-summary)
+  git clone -q "$case_dir/origin.git" "$case_dir/projects/empty"
+  cat > "$case_dir/fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+if [ "$(basename "$PWD")" = app ]; then exit 1; fi
+printf '[]\n'
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+
+  set +e
+  out=$(run_sweep "$case_dir" \
+    "$case_dir/projects/app" "$case_dir/projects/empty" 2>&1); rc=$?
+  set -e
+
+  expect_code 1 "$rc" "incomplete-summary: a partial sweep must return nonzero"
+  assert_not_contains "$out" "no idle copy holds Next.js build output" \
+    "incomplete-summary: unreadable projects make the absolute empty claim false"
+  assert_contains "$out" "1 project" \
+    "incomplete-summary: the summary must count projects that could not be inspected"
+  assert_contains "$out" "could not be inspected" \
+    "incomplete-summary: the summary must state that the result is incomplete"
+  pass "an incomplete sweep qualifies its summary with the unreadable project count"
 }
 
 test_sweep_refuses_without_treehouse() {
@@ -680,6 +910,15 @@ test_sweep_skips_stashed_copy
 test_sweep_skips_copy_with_unknown_pool_status
 test_sweep_skips_whole_project_when_pool_is_unreadable
 test_sweep_skips_project_when_pool_lookup_fails
+test_sweep_skips_project_when_pool_prints_json_then_fails
+test_sweep_refuses_unreadable_secondmate_state
+test_sweep_refuses_malformed_secondmate_registry
+test_sweep_allows_absent_secondmate_home
+test_sweep_skips_symlink_aliased_task_worktree
+test_sweep_skips_case_aliased_task_worktree
+test_sweep_skips_when_candidate_identity_is_unreadable
+test_sweep_skips_when_recorded_identity_is_unreadable
+test_sweep_reports_incomplete_project_count
 test_sweep_refuses_without_treehouse
 test_sweep_skips_uninspectable_worktree
 test_sweep_skips_when_git_inspection_fails

--- a/tests/fm-next-cache-sweep.test.sh
+++ b/tests/fm-next-cache-sweep.test.sh
@@ -259,6 +259,162 @@ test_sweep_skips_stashed_copy() {
   pass "sweep never touches a copy holding stashed work"
 }
 
+# --- sweep: ownership that cannot be determined counts as owned --------------
+#
+# The reclaim is a deletion, so the interesting question is not what happens
+# when the proof succeeds - it is what happens when the proof cannot be made.
+# Each case below breaks one input the sweep relies on and asserts the build
+# output SURVIVES, because "could not determine" must read as "owned".
+
+test_sweep_skips_copy_with_unknown_pool_status() {
+  local case_dir wt out
+  case_dir=$(make_case unknown-status)
+  install_treehouse_stub "$case_dir"
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  # A status this version of the sweep does not know: not `available`, so not
+  # proven free, even though it is not the familiar `in-use` either.
+  printf '1 reserved-by-something-new\n' > "$case_dir/pool-status"
+
+  out=$(run_sweep "$case_dir" 2>&1)
+
+  assert_present "$wt/packages/frontend/.next" \
+    "unknown-status: an unrecognized pool status is not proof the copy is free"
+  assert_contains "$out" "the pool did not report it available" \
+    "unknown-status: the skip reason must name what was not established"
+  pass "an unrecognized pool status keeps the copy out of scope"
+}
+
+test_sweep_skips_whole_project_when_pool_is_unreadable() {
+  local case_dir wt out rc
+  case_dir=$(make_case pool-unreadable)
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  # treehouse answers `status --json` with something that is not pool JSON. An
+  # unparseable pool is not an empty pool and is certainly not a pool of
+  # unowned copies, so no copy in this project may be swept.
+  cat > "$case_dir/fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = status ]; then printf 'panic: pool state corrupt
+'; exit 0; fi
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+
+  set +e
+  out=$(run_sweep "$case_dir" 2>&1); rc=$?
+  set -e
+
+  assert_present "$wt/packages/frontend/.next" \
+    "pool-unreadable: an unreadable pool must leave every copy alone"
+  assert_contains "$out" "cannot read the worktree pool" \
+    "pool-unreadable: the sweep must report the project it could not read"
+  [ "$rc" -ne 0 ] || fail "pool-unreadable: an unreadable pool must not report a clean sweep"
+  pass "an unreadable pool sweeps nothing in that project and reports it"
+}
+
+test_sweep_skips_project_when_pool_lookup_fails() {
+  local case_dir wt out rc
+  case_dir=$(make_case pool-failing)
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  cat > "$case_dir/fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+echo "treehouse: cannot open pool" >&2
+exit 1
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+
+  set +e
+  out=$(run_sweep "$case_dir" 2>&1); rc=$?
+  set -e
+
+  assert_present "$wt/packages/frontend/.next" \
+    "pool-failing: a failed pool lookup must leave every copy alone"
+  [ "$rc" -ne 0 ] || fail "pool-failing: a failed pool lookup must not report a clean sweep"
+  pass "a failing pool lookup sweeps nothing in that project"
+}
+
+test_sweep_refuses_without_treehouse() {
+  local case_dir wt out rc path_dir cmd resolved
+  case_dir=$(make_case no-treehouse)
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  printf '1 available\n' > "$case_dir/pool-status"
+  # A PATH with the ordinary tools but no treehouse at all: without the pool's
+  # lease there is no ownership signal that spans firstmate homes, so the sweep
+  # must refuse rather than fall back to the checks it can still make.
+  path_dir="$case_dir/path-without-treehouse"
+  mkdir -p "$path_dir"
+  for cmd in awk basename bash cat chmod cut dirname du env find git grep head mkdir \
+    printf python3 readlink rm sed sort stat tail tr wc; do
+    resolved=$(command -v "$cmd" 2>/dev/null) || continue
+    case "$resolved" in /*) ln -sf "$resolved" "$path_dir/$cmd" ;; esac
+  done
+
+  set +e
+  out=$(FM_HOME="$case_dir" FM_STATE_OVERRIDE="$case_dir/state" \
+    FM_DATA_OVERRIDE="$case_dir/data" FM_PROJECTS_OVERRIDE="$case_dir/projects" \
+    PATH="$path_dir" "$SWEEP" 2>&1); rc=$?
+  set -e
+
+  assert_present "$wt/packages/frontend/.next" \
+    "no-treehouse: without the pool's lease the sweep must remove nothing"
+  expect_code 2 "$rc" "no-treehouse: a missing ownership signal is an environment error"
+  assert_contains "$out" "treehouse is not installed" \
+    "no-treehouse: the refusal must name the missing requirement"
+  pass "the sweep refuses outright when the pool's lease cannot be consulted"
+}
+
+test_sweep_skips_uninspectable_worktree() {
+  local case_dir wt out
+  case_dir=$(make_case uninspectable)
+  install_treehouse_stub "$case_dir"
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  # The pool still names this path, but it is no longer a git worktree, so the
+  # clean-tree and stash proofs cannot be made at all.
+  rm -f "$wt/.git"
+  rm -rf "$wt/.git"
+  printf '1 available\n' > "$case_dir/pool-status"
+
+  out=$(run_sweep "$case_dir" 2>&1)
+
+  assert_present "$wt/packages/frontend/.next" \
+    "uninspectable: a path git cannot inspect must keep its build output"
+  assert_contains "$out" "not an inspectable git worktree" \
+    "uninspectable: the skip reason must be reported"
+  assert_contains "$out" "could not be assessed" \
+    "uninspectable: a copy that cannot be assessed must be named, not passed over silently"
+  pass "a copy git cannot inspect is never swept"
+}
+
+test_sweep_skips_when_git_inspection_fails() {
+  local case_dir wt out gitdir
+  case_dir=$(make_case git-failing)
+  install_treehouse_stub "$case_dir"
+  wt=$(add_pool_worktree "$case_dir" 1)
+  add_next_app "$wt" packages/frontend
+  # The worktree still looks like a repo, but its object store is gone, so
+  # `git status` cannot answer whether there is uncommitted work. Unknown is
+  # not clean.
+  gitdir=$(git -C "$wt" rev-parse --git-dir)
+  gitdir=$(cd "$wt" && cd "$gitdir" && pwd -P)
+  mv "$gitdir/index" "$gitdir/index.moved" 2>/dev/null || true
+  printf 'not an index\n' > "$gitdir/index"
+  printf '1 available\n' > "$case_dir/pool-status"
+
+  out=$(run_sweep "$case_dir" 2>&1)
+
+  assert_present "$wt/packages/frontend/.next" \
+    "git-failing: an unanswerable clean-tree check must keep the build output"
+  assert_contains "$out" "cannot inspect it" \
+    "git-failing: the skip reason must say the inspection failed"
+  assert_contains "$out" "could not be assessed" \
+    "git-failing: a copy that cannot be assessed must be named, not passed over silently"
+  pass "a copy whose git state cannot be read is never swept"
+}
+
 # --- discovery rule: only regenerable Next.js build output -------------------
 
 test_sweep_leaves_tracked_next_directory() {
@@ -423,6 +579,58 @@ test_teardown_reclaims_before_returning_the_copy() {
   pass "teardown reclaims Next.js build output before returning the copy to the pool"
 }
 
+test_teardown_reclaims_only_after_the_copy_is_quiet() {
+  local case_dir out rc pid order
+  case_dir=$(make_teardown_case teardown-order)
+  add_next_app "$case_dir/wt" packages/frontend
+  git -C "$case_dir/wt" push -q origin fm/task-x1
+  git -C "$case_dir/project" fetch -q origin
+  order="$case_dir/order.log"
+
+  # Teardown's answer to "what if the copy is not really finished with" is
+  # ordering: the reclaim runs after every unlanded-work refusal has passed AND
+  # after the worktree's processes are reaped, so nothing can still be writing
+  # the directory it removes. This stub stands where the pool return happens -
+  # the step right after the reclaim - and records what was true by then.
+  cat > "$case_dir/fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+if [ -e "$case_dir/wt/packages/frontend/.next" ]; then
+  printf 'build-output-still-present\n' >> "$order"
+else
+  printf 'build-output-already-reclaimed\n' >> "$order"
+fi
+if kill -0 "\$(cat "$case_dir/sleeper.pid" 2>/dev/null || echo 0)" 2>/dev/null; then
+  printf 'worktree-process-still-alive\n' >> "$order"
+else
+  printf 'worktree-process-already-reaped\n' >> "$order"
+fi
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+
+  # A live process whose working directory is the copy - exactly what teardown's
+  # reap exists to clear, and exactly what would still be writing the build
+  # output if the reclaim ran too early.
+  ( cd "$case_dir/wt" && exec sleep 300 ) &
+  pid=$!
+  disown 2>/dev/null || true
+  printf '%s\n' "$pid" > "$case_dir/sleeper.pid"
+  sleep 0.3
+  kill -0 "$pid" 2>/dev/null || fail "teardown-order: setup sleeper did not start"
+
+  set +e
+  out=$(run_teardown "$case_dir" 2>&1); rc=$?
+  set -e
+  kill -KILL "$pid" 2>/dev/null || true
+
+  expect_code 0 "$rc" "teardown-order: teardown should succeed"
+  assert_grep "build-output-already-reclaimed" "$order" \
+    "teardown-order: the reclaim must happen before the copy returns to the pool"
+  assert_grep "worktree-process-already-reaped" "$order" \
+    "teardown-order: nothing may still be running in the copy when its output is removed"
+  pass "teardown reclaims only after the copy's processes are reaped and before it returns"
+}
+
 test_teardown_refusal_keeps_the_copy_intact() {
   local case_dir out rc
   case_dir=$(make_teardown_case teardown-refuse)
@@ -466,11 +674,18 @@ test_sweep_skips_copy_claimed_by_task_record
 test_sweep_skips_copy_claimed_by_secondmate_task_record
 test_sweep_skips_dirty_copy
 test_sweep_skips_stashed_copy
+test_sweep_skips_copy_with_unknown_pool_status
+test_sweep_skips_whole_project_when_pool_is_unreadable
+test_sweep_skips_project_when_pool_lookup_fails
+test_sweep_refuses_without_treehouse
+test_sweep_skips_uninspectable_worktree
+test_sweep_skips_when_git_inspection_fails
 test_sweep_leaves_tracked_next_directory
 test_sweep_leaves_ignored_next_outside_a_next_app
 test_sweep_leaves_node_modules_and_source
 test_sweep_reclaims_nested_build_output_once
 test_sweep_never_sweeps_the_project_clone
 test_teardown_reclaims_before_returning_the_copy
+test_teardown_reclaims_only_after_the_copy_is_quiet
 test_teardown_refusal_keeps_the_copy_intact
 test_teardown_stays_quiet_without_build_output


### PR DESCRIPTION
## Intent

Make Next.js build-cache reclamation structural instead of something noticed only when the disk fills.

Why now, with measured numbers: on 2026-08-18 one idle Artemis copy held a 15 GB packages/frontend/.next on a volume with 11 GB free; reclaiming that single directory took free space to 27 GB. A 2026-08-07 measurement found ~25.6 GB spread across eight copies. This is pure build output that regenerates, so it is the largest low-risk reclaim available, and it keeps coming back because nothing removes it.

Two pieces were asked for, and only two:
1. Teardown removes the copy's .next before returning it to the pool. That is where the problem is created: a copy goes back to the pool carrying gigabytes nobody will ever use again.
2. A way to sweep idle copies without disturbing a live one.

Explicit constraints the user set:
- NEVER delete from a copy whose task is running. A dev server holding that directory will simply rewrite it, and removing it mid-build is worse than leaving it alone. A copy must be PROVEN unowned before it is touched: no owning task record, plus the same clean-tree and stash checks teardown already makes.
- Report what was reclaimed rather than sweeping silently. A cleanup that says nothing is indistinguishable from one that did nothing, and the operator needs to know where the space went.
- Refuse by shape: do NOT build a daemon, a watcher, a scheduler, or a disk-pressure monitor. The direct path is teardown doing its job plus one sweep entry point a human or firstmate can run. Extra machinery is only justified by naming a concrete blocker in the direct path first. This is a deliberate architectural exclusion, not an oversight.
- Do NOT delete anything that is not regenerable build output. Never node_modules, never source, never git data. .next is the target. Other caches worth including must be NAMED with their measured size rather than folded in by pattern.

Decisions and tradeoffs made while doing the work, which a reviewer reading only the diff would not know:

- One discovery rule lives in bin/fm-next-cache-lib.sh and is shared by both surfaces so "what counts as reclaimable" is stated once. A directory qualifies only if it is named .next AND git ignores it AND its parent is a Next.js app root (next.config.* beside it, or a package.json naming next). Both proofs are deliberate: gitignore status means tracked content can never match, and the app-root proof is what makes "regenerable build output" true rather than assumed, so a gitignored directory that merely happens to be called .next is left alone.
- Verified against current Next.js documentation: distDir defaults to '.next', and cleanDistDir defaults to true, so next build already clears that directory itself on every production build, preserving only .next/cache. Removing it is the same operation the framework performs one build earlier.
- A project with a custom distDir is deliberately NOT discovered. Reading a build config to decide what to delete would make the deletion set depend on untrusted project code. Such a project keeps its cache until someone names the directory. This is the safe direction to be wrong in, and is an intentional gap, not a bug.
- Other caches were measured and deliberately left out rather than swept by pattern, as the user required: a project's .tmp scratch root at ~8.7 GB pooled holds audit output, coverage JSON, browser recordings, and review artifacts - agent work product that nothing regenerates, so it is out of scope. A dist directory measured ~102 MB pooled and is tracked in some projects. .turbo, .cache, .parcel-cache, .vite, and .output all measured zero.
- The sweep requires FOUR independent proofs before touching a copy: the pool reports it available, no task record in this home or any locally registered secondmate home names it as its worktree, its tree is clean, and it has no stashes. The pool lease is checked first on purpose: the worktree pool is shared across firstmate homes (verified: two different clones resolve to the same pool), so treehouse's lease is the only ownership signal that spans all of them. The stash check is an addition beyond what teardown does today, because a stash is unlanded work a clean tree does not show and nobody is watching an idle copy to notice it disappear.
- Every "could not determine" outcome is treated as "owned": an unreadable or unparseable pool, an unrecognized pool status, a path that is not an inspectable git worktree, or a git command that fails all skip the copy. A missing treehouse makes the whole sweep refuse with exit 2 rather than fall back to the checks it can still make.
- A copy whose ownership could not be established is ALWAYS reported by name, even though its size cannot be measured, because the same broken inspection that hides its owner also hides how much it is holding; a size-gated skip line would pass such a copy over in silence.
- One race is left open deliberately and documented in the script header: a copy can be leased between the pool reporting it available and the removal running. Closing it would need a lease this tool does not own, and the consequence is bounded - the copy was leased to start fresh work, so it loses output it was about to regenerate anyway. Losing that race costs a rebuild, not work.
- The sweep never touches the project clone under projects/, only pooled copies. Firstmate reads its clones and only crewmates change them, and measurement confirmed the clones hold no build output anyway.
- Teardown's reclaim runs after every unlanded-work refusal has passed and after the worktree's processes are reaped, so nothing can still be writing the directory it removes, and it is never fatal: the output regenerates from source, so it is never the work product a refusal protects. A test pins that ordering and fails if the reclaim is moved after the pool return.

A later user requirement, accepted and implemented: because the change makes teardown DELETE something before returning a copy, the tests must cover a copy that IS owned and a copy whose ownership CANNOT be determined, not just the clean case. Both are now covered - five owned cases and six cannot-determine cases, each asserting the build output survives.

One unrelated pre-existing bug was found and fixed in a separate commit, deliberately included rather than left broken: on stock macOS Bash 3.2 (what /usr/bin/env bash resolves to on the machines this fleet runs on), `.` on a missing file terminates the whole shell with status 0, ignoring both the `|| return 1` beside the source and the enclosing `if !`. A missing backend adapter therefore ended fm-teardown.sh mid-run while REPORTING SUCCESS, so a caller records a task as cleaned up when nothing was cleaned up and the safety refusal never prints. Bash 5 returns 1 as written, which is why the Linux CI lanes never saw it and tests/fm-teardown.test.sh's herdr preflight case failed only locally. fm_backend_source now tests the adapter file before sourcing it, through one helper the five backends share; the guard is read and written with eval because that file is also sourced from zsh, where ${!var} and printf -v do not mean what they mean in bash. A new case in tests/fm-backend.test.sh fails without the fix.

Three other pre-existing local test failures were investigated and deliberately NOT fixed, because they are host-environment limitations rather than code defects and would pass on CI's Linux runners: tests/fm-kimi-harness.test.sh (python3 on PATH is 3.8.20, and tomllib needs 3.11+), tests/fm-muse-harness.test.sh (macOS SIGKILLs a copied system bash, so the ancestry fixture cannot launch - verified rc=137), and tests/fm-composer-lib.test.sh (half-block glyph matching under Bash 3.2's weak multibyte support). Fixing three more unrelated subsystems would have expanded this task well past its scope.

RE-SCAFFOLD, 2026-08-18: this branch was re-created from upstream/main on the captain's explicit ruling and the work cherry-picked across unchanged. The first attempt was branched from the fork's main, so its rebase gate correctly warned that 35 unrelated fork commits (78 files) would enter the upstream pull request. The captain ruled to make that gate's premise true rather than approve or skip it, and this branch is the result: it now carries exactly four commits relative to upstream/main and nothing else. The carried patch was verified byte-identical to the pre-re-scaffold work - the only difference between the two diffs is one AGENTS.md hunk header line number, because upstream's AGENTS.md is longer than the fork's; the inserted line lands in the same paragraph, under the same anchor sentence.

A fourth commit was added during the re-scaffold and is part of this change: the suite's fixture commits inherited the host's commit.gpgsign setting, which on the upstream base made them fail to write a commit object and killed the script with exit 128 before its first assertion - a crash that prints no "not ok" line and therefore reads as a pass to anything counting failures. Every fixture git invocation now passes -c commit.gpgsign=false explicitly, so these cases depend on no personal signing key and no ambient harness setting.

Deliberately NOT included, because it would import unrelated fork divergence into an upstream pull request: upstream's tests/lib.sh has no commit.gpgsign guard, while the fork's does. On a host that signs commits by default, pristine upstream/main already fails tests/fm-teardown.test.sh (exit 128) and tests/fm-backend.test.sh (exit 1) for that reason alone, before any change here. Those are pre-existing upstream host-environment failures, verified against a clean upstream/main checkout, and fixing them belongs in its own change rather than being folded in here.

## What Changed

- Add shared `.next` eligibility checks and a sweep command that reports or reclaims build output only from available, proven-unowned pooled copies, failing closed when ownership cannot be established.
- Reclaim qualifying Next.js build output during teardown before returning completed copies to the pool, with dry-run support, explicit outcome reporting, documentation, and comprehensive safety coverage.
- Make missing backend adapters return a refusable error instead of terminating callers on stock macOS Bash.

## Risk Assessment

✅ Low: Captain, the changes now fail closed: explicit targets are report-only, deleting targets require primary-worktree identity, and duplicate pool fields are rejected.

## Testing

The focused cache and backend suites passed on macOS Bash 3.2 after neutralizing the documented ambient signing setting for the backend retry; direct CLI transcripts demonstrate reported idle reclamation, teardown reclamation, source preservation, live-copy protection, and fail-closed unknown ownership.

<details>
<summary>Evidence: Cache sweep CLI evidence</summary>

<code>Dry-run preserved output; reclaim removed only `.next`; in-use and undetermined copies preserved output and were reported.</code>

```text
OPERATOR CHECK 1: dry-run on an available, unowned pooled copy
sweep: would reclaim 8K from /private/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/fm-next-cache-sweep.3OKyh7/cli-evidence/pool/1/packages/frontend/.next
sweep: would reclaim 8K from 1 copy
RESULT: build output still exists after dry-run

OPERATOR CHECK 2: reclaim the same idle pooled copy
sweep: reclaimed 8K of Next.js build output from /private/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/fm-next-cache-sweep.3OKyh7/cli-evidence/pool/1/packages/frontend/.next
sweep: reclaimed 8K from 1 copy
RESULT: build output removed; Next.js config and tracked source remain

OPERATOR CHECK 3: pool reports the copy in use
sweep: skipped-as-owned /private/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/fm-next-cache-sweep.3OKyh7/cli-evidence/pool/1 (in use by the pool), holding 4K
sweep: nothing to reclaim; 1 copy were skipped as owned (listed above)
RESULT: live copy build output preserved

OPERATOR CHECK 4: ownership cannot be determined
sweep: undetermined /private/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/fm-next-cache-sweep.3OKyh7/cli-evidence/pool/1 (the pool did not report it available)
sweep: incomplete ownership input: one or more announced pool candidates could not be fully assessed for /private/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/fm-next-cache-sweep.3OKyh7/cli-evidence/projects/app; reclamation refused
sweep: reclamation incomplete; 1 project could not be inspected
RESULT: exit=1; build_output_preserved=yes
```
</details>
<details>
<summary>Evidence: Teardown CLI evidence</summary>

<code>Teardown reported reclaim, exited successfully, removed `.next`, and preserved tracked Next.js source.</code>

```text
OPERATOR CHECK: tear down a landed task copy holding Next.js build output
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no live watcher process holds this home lock (last beat: 0s ago).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  repair missing watcher supervision according to the session-start block for this harness; do not use shell &.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
teardown: reclaimed 8K of Next.js build output from /private/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/fm-next-cache-sweep.yiqbrg/teardown-cli-evidence/wt/packages/frontend/.next
/private/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/fm-next-cache-sweep.yiqbrg/teardown-cli-evidence/project: already current
teardown task-x1 complete (window firstmate:fm-task-x1, worktree /private/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/fm-next-cache-sweep.yiqbrg/teardown-cli-evidence/wt)
Backlog: task-x1 just finished. Update data/backlog.md - move task-x1 to Done, keep Done to the 10 most recent, then re-scan Queued and dispatch only work whose blockers are gone and date is due.
RESULT: exit=0; build_output_removed=yes; tracked_next_source_preserved=yes
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 5 issues found → auto-fixed (6) ✅</summary>

- 🚨 `bin/fm-next-cache-lib.sh:105` - “Never delete anything that is not regenerable build output” is contradicted by checking only whether the `.next` directory itself is ignored. Git does not track directories, so an ignored `.next` can contain force-added tracked descendants; line 163 then deletes them, and a later failed pool return leaves tracked content missing. Reject candidates when `git ls-files` reports any descendant, treating inspection failure as non-reclaimable.
- 🚨 `bin/fm-next-cache-sweep.sh:145` - “Every ‘could not determine’ outcome is treated as ‘owned’” is contradicted by this pipeline. Without `pipefail`, `treehouse status` may emit valid JSON and exit nonzero while Python exits 0, allowing an `available` entry to reach deletion despite a failed authoritative pool lookup. Capture and check treehouse’s status before parsing, or protect the pipeline with pipefail.
- 🚨 `bin/fm-next-cache-sweep.sh:123` - “A copy must be PROVEN unowned: no owning task record” is contradicted by silently skipping missing state directories, malformed registry entries, and failed metadata reads; the caller also ignores loader failure. An unreadable registered-secondmate record can therefore be omitted and its available, clean copy swept. Make task-record enumeration an all-or-nothing proof and refuse when any local registry or candidate metadata cannot be read.
- 🚨 `bin/fm-next-cache-sweep.sh:138` - The required “no owning task record names it as its worktree” proof uses literal `grep -Fx` path equality. On case-insensitive macOS, differently-cased paths can identify the same directory but fail this comparison; if its lease is available or released, the remaining checks pass and a live task’s cache can be removed. Compare filesystem identity, such as device and inode, at this boundary.
- ⚠️ `bin/fm-next-cache-sweep.sh:292` - After a project’s pool lookup fails, `RC` changes but no incomplete/unknown count is recorded, so the final output can still assert “no idle copy holds Next.js build output.” That contradicts the requested honest reporting because the sweep could not establish that fact. Track incomplete projects and report an incomplete sweep instead.

🔧 Fix: Captain: fail closed on uncertain cache ownership
4 issues (2 errors, 2 warnings) still open:
- 🚨 `bin/fm-next-cache-sweep.sh:167` - “No task record ... names it as its worktree” remains bypassable because `stat` does not follow a final symlink by default. If metadata names `/pool/link` and treehouse reports its target, the literal paths and lstat inodes differ, so an available, clean copy reaches deletion; a broken final symlink also returns its own inode instead of the required unknown result. Make this boundary compare resolved referents and return undetermined when a final symlink cannot be resolved.
- 🚨 `bin/fm-next-cache-sweep.sh:124` - The all-or-nothing task-record proof still accepts a syntactically parseable but non-absolute local `home:` and then treats it as absent relative to the caller’s current directory. The shared registry contract rejects such homes as unsafe; here the intended home’s task records can be omitted and its copy swept. Before the absence exception, reject any local home that is not an absolute, resolvable registry path.
- ⚠️ `bin/fm-next-cache-sweep.sh:216` - “An unreadable or unparseable pool ... skips the copy” is contradicted by silently dropping dictionary entries with no usable `path`. A status-0 response containing such an entry is accepted as a complete pool and can produce the absolute “no idle copy” summary. Treat a missing or non-string path as a malformed pool and make the whole project incomplete.
- ⚠️ `bin/fm-next-cache-sweep.sh:313` - “A copy whose ownership could not be established is ALWAYS reported by name” is contradicted by `[ -d &#34;$wt&#34; ] || continue`. A named pool entry whose path is missing or inaccessible disappears silently instead of being reported as undetermined. Pass it through the ownership verdict so identity failure produces the existing named skip line.

🔧 Fix: Captain: fail closed on incomplete cache ownership
4 issues (2 errors, 2 warnings) still open:
- 🚨 `bin/fm-next-cache-sweep.sh:235` - The required rule that an incomplete ownership check must refuse is still bypassable: both `grep` comparisons treat every nonzero status as “no match.” If `grep` is unavailable or exits 2, an exact task-owned copy can be classified free and reclaimed. Distinguish no-match (1) from inspection failure and return the undetermined verdict on the latter.
- 🚨 `bin/fm-next-cache-sweep.sh:274` - The malformed-pool refusal does not reject NUL characters. Python accepts fields such as `avail\u0000able`, but Bash command substitution cannot represent NUL and can collapse that value to `available`, authorizing deletion without the pool’s exact availability proof. Reject NUL before emitting the line protocol.
- ⚠️ `bin/fm-next-cache-sweep.sh:421` - The captain’s requirement that no silent set-narrowing survive remains contradicted: the old `git ... || continue` was only rewritten as a nested `if`. With one readable project and one project directory whose Git metadata cannot be inspected, the latter disappears from `TARGETS` and the sweep can still claim completeness. Record that directory as an incomplete project or refuse discovery.
- ⚠️ `bin/fm-next-cache-sweep.sh:464` - If every attempted removal fails, `RC` becomes 1 but `RECLAIMED`, `SKIPPED`, and `INCOMPLETE` remain zero, so the final summary falsely says no idle copy holds build output even though the failed directory remains. Track removal failures and qualify the summary accordingly.

🔧 Fix: Captain: fail closed across cache ownership inputs
3 issues (2 errors, 1 warning) still open:
- 🚨 `bin/fm-next-cache-sweep.sh:530` - The required “sweep never touches the project clone” and task-record ownership proofs are not established by `[ -d &#34;$wt&#34; ]` plus inode identity. `git rev-parse --git-dir` also succeeds for repository subdirectories: a pool response naming the project clone deletes its `.next`, while naming a live copy’s child directory bypasses the task record for its root. Captain, this is the same completeness class after the promised exhaustive enumeration, so the stated boundary calls for removing sweep deletion authority rather than another local patch.
- 🚨 `bin/fm-next-cache-sweep.sh:698` - A valid free copy can be inspected and planned before a later malformed entry refuses the project. The plan is then discarded without reporting that copy, but `INSPECTED` remains incremented and the summary says “nothing to reclaim in 1 copy” even though its `.next` remains. This contradicts the required honest summary and “ALWAYS reported by name” rule; keep project refusal atomic but treat discarded plans as incomplete, not empty.
- ⚠️ `tests/fm-next-cache-sweep.test.sh:1559` - If `FM_NEXT_CACHE_TEST` contains a misspelled or removed test name, every wrapper invocation silently skips and the suite exits successfully without running an assertion. Track whether the selector matched and fail when it did not, so targeted RED/green evidence cannot be vacuous.

🔧 Fix: Captain: prove pool provenance and honest sweep outcomes
2 errors still open:
- 🚨 `bin/fm-next-cache-sweep.sh:845` - The required positive proof that a candidate “must not be the project clone” remains bypassable. `sweep_project` accepts an explicit project subdirectory because `git rev-parse --git-dir` succeeds there; provenance then compares the candidate clone root against that subdirectory rather than the actual project root. Thus a pool response naming the clone can pass the worktree-root/registry checks and have its `.next` deleted. Require the project argument itself to equal its resolved `--show-toplevel` before pool lookup, or derive the primary clone identity independently. This also disproves the header inventory’s claim that every relevant input was accounted for; under the captain’s stated boundary, deletion authority should be reconsidered rather than applying another local patch.
- 🚨 `bin/fm-next-cache-sweep.sh:763` - The requirement that a copy whose ownership cannot be established is “ALWAYS reported by name” is contradicted by returning on the first failed candidate preflight. If a complete pool listing contains an invalid first entry followed by other named copies, those later copies receive no verdict and are never reported, although the whole project is refused. Preserve atomic refusal, but evaluate or explicitly report every remaining pool entry as refused before returning.

🔧 Fix: Correct wrong root verdict and reconcile cache candidates
2 errors still open:
- 🚨 `bin/fm-next-cache-sweep.sh:1098` - The required guarantee that “the sweep never touches the project clone” remains bypassable when an explicit argument is another linked-worktree root. Such a path equals its own `--show-toplevel`, so it passes here; provenance then treats that linked worktree—not the repository’s primary worktree—as the clone to exclude. If the pool response names the real primary clone, it is a distinct registered root and can reach deletion. Prove the supplied project is the primary worktree or derive the primary identity independently. This is the same destructive causal theme after multiple fixes, so I recommend withholding sweep deletion authority until that boundary is proven.
- 🚨 `bin/fm-next-cache-sweep.sh:615` - The requirement that ambiguous pool input refuse reclamation is contradicted by parsing JSON with Python’s default duplicate-key behavior. A response such as `{&#34;status&#34;:&#34;in-use&#34;,&#34;status&#34;:&#34;available&#34;,&#34;path&#34;:&#34;…&#34;}` is accepted with the last status winning, allowing conflicting authoritative lease evidence to become `available`. Reject duplicate object keys during JSON decoding before emitting any candidate rows; otherwise a malformed pool can still authorize deletion.

🔧 Fix: Correct authority verdicts and reject duplicate pool fields
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `/bin/bash tests/fm-next-cache-sweep.test.sh`
- <code>`/bin/bash tests/fm-backend.test.sh` — relevant adapter case passed; later encountered the known ambient GPG-signing fixture issue</code>
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false /bin/bash tests/fm-backend.test.sh`
- <code>Controlled `bin/fm-next-cache-sweep.sh --dry-run` and reclaim checks against an available, unowned pooled copy</code>
- <code>Controlled sweep checks with pool status `in-use` and unknown, verifying `.next` survived</code>
- <code>Controlled `bin/fm-teardown.sh task-x1` check for a landed copy holding `.next`</code>
- <code>`git status --short` and evidence-file integrity checks</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
