### PR TITLE
fix: route in-scope state reads to secondmates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,6 +263,8 @@ Proceed on one confident match while naming the project in plain language; ask o
 Route by the nature of the work against each registered secondmate scope, not by a non-exclusive clone list.
 Keep `local-only` work in the main home.
 Send in-scope work to the fitting secondmate unless it is blocked or the captain explicitly redirects it; do not read the secondmate's chat because marked routed replies return through its status or referenced document.
+Reading, polling, and verifying state inside a registered scope is in-scope work and routes the same way; ownership decides, not size, and being quick to check it yourself is not an exemption.
+An empty secondmate queue is healthy, but firstmate hand-working a scope a registered secondmate owns is a routing failure, never a cue for that secondmate to self-start.
 If no secondmate scope fits, use the main home or discuss creating an appropriate persistent secondmate.
 For one-off or infrequent operational work, start with the simplest direct end-to-end path.
 Do not build wrappers, control planes, policy layers, custom verifiers, or automation unless the direct path exposes a concrete blocker or repeated need that justifies the added machinery.


### PR DESCRIPTION
## Intent

Close a real gap in AGENTS.md's secondmate routing rule: it says to route in-scope WORK to the fitting secondmate, but nothing tells a firstmate that reading and verifying state inside a secondmate's scope IS work. So a supervisor routes implementation correctly and quietly keeps every state lookup, because each one feels like looking rather than delegating.

Evidence this comes from: on 2026-08-19 a fleet's firstmate spent a full day hand-polling pull-request state (heads, checks, mergeability, reviewer lists, comment contents) across two repositories. Two registered secondmates existed whose charters covered exactly that: one for continuous review intake, one holding a durable inventory of fleet-authored open-source pull requests. Both sat idle while their own scope was worked by hand. The cost was not only wasted capacity: firstmate sampled three pull requests itself, concluded a CI shard had changed state, and reported that to the captain. A crewmate later pulled the full 157-run population and disproved it, and disproved firstmate's correction too. The supervisor doing its own investigation is how a false premise reached the captain. The existing rule was not violated; it simply does not say that a lookup counts.

What to change: in AGENTS.md section 7, in the intake-and-authority routing paragraph that currently reads "Send in-scope work to the fitting secondmate unless it is blocked or the captain explicitly redirects it", add the missing half.

The rule to express, in that section's voice and as briefly as it can be said:
- Reading, polling and verifying state that falls inside a registered secondmate's scope is in-scope work and routes like any other; being quick is not an exemption, and ownership rather than size decides.
- A secondmate idling with an empty queue is healthy, but a secondmate idling while firstmate works its scope by hand is a routing failure.

Preserve the existing idle-by-default contract exactly. Section 6 states that a secondmate is idle by default, acts only on routed work, and that an empty queue never authorizes self-directed work. The addition must not weaken that or read as licence for a secondmate to go looking for things to do; the failure being fixed is firstmate not routing, never a secondmate not self-starting. If wording could be read either way, it must be rewritten. Specifically accepted requirement: neither sentence may be readable as licence for a secondmate to self-start looking for work by someone who has not read the task brief.

Constraints: AGENTS.md is always-loaded for every session of every Firstmate user, so every byte is paid continuously. This is a two-sentence change at most. Do not add a section, do not restate the routing rule around it, and do not add examples; the surrounding text already carries the context. Follow the firstmate-coding-guidelines skill for firstmate's shared tracked material.

Scaffolded from upstream/main because this belongs to every Firstmate user, not just one fleet: it is a general supervisor failure mode, not a local preference. Do not bundle any unrelated fork divergence into the pull request.

Definition of done: the change lands through the normal validation path with a pull request against official upstream, and the commit message states the concrete failure it prevents rather than describing the edit.

## What Changed

- Classify reading, polling, and verifying state within a registered secondmate scope as routable in-scope work, regardless of task size or speed.
- Define firstmate hand-working an owned scope as a routing failure while preserving empty-queue idling and prohibiting secondmates from self-starting.

## Risk Assessment

✅ Low: The change is limited to two clear routing sentences that satisfy the stated intent, preserve secondmates’ idle-by-default behavior, and introduce no unrelated changes.

## Testing

Baseline diff and commit checks found the target directly atop base with only two AGENTS.md insertions; no repository automated test semantically exercises instruction interpretation, so after resolving an isolated-profile 401 by retrying with the authenticated ephemeral profile, a live read-only Codex session passed both end-user routing scenarios and produced the attached CLI transcript, with final checks confirming a clean worktree; no screenshot applies to this non-UI agent contract.

<details>
<summary>Evidence: Live read-only Codex routing scenarios</summary>

<code>1. ROUTE_TO_REVIEW_INTAKE — Captain, PR reading and verification belong to that secondmate’s registered scope; task size is irrelevant.&#10;2. WAIT_FOR_ROUTED_WORK — An idle secondmate acts only on routed work and never self-starts polling.</code>

```text
1. ROUTE_TO_REVIEW_INTAKE — Captain, PR reading and verification belong to that secondmate’s registered scope; task size is irrelevant.
2. WAIT_FOR_ROUTED_WORK — An idle secondmate acts only on routed work and never self-starts polling.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --stat`, `git diff --name-status`, and `git diff --unified=12 b57c4d6e…47e74970 -- AGENTS.md`</code>
- `Read AGENTS.md sections 6–7, the documentation audience classification, and target commit message`
- <code>Searched `tests/` for existing semantic coverage of AGENTS.md secondmate routing</code>
- <code>`codex exec --ephemeral --ignore-user-config --ignore-rules -s read-only …` (initial setup attempt failed with HTTP 401 before model execution)</code>
- <code>`codex exec --ephemeral --ignore-rules -s read-only …` with paired quick-lookup and empty-queue scenarios</code>
- `Final assertions verified target parent/base identity, the sole two-line AGENTS.md diff, expected live decisions, evidence presence, and a clean worktree`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
