### PR TITLE
fix(calm): gate loud thinking-field check to active hides and harden restore

### DIFF
--- a/.pi/extensions/lib/fm-calm-assistant-layout.ts
+++ b/.pi/extensions/lib/fm-calm-assistant-layout.ts
@@ -2,9 +2,11 @@
 // updateContent method. installCalmAssistantLayout() probes that exact method and throws
 // if it is missing; fm-calm.ts catches that and skips only this adapter with a diagnostic
 // instead of blocking Calm or Pi. The patched method likewise checks the private
-// hiddenThinkingLabel/hideThinkingBlock fields it reads and throws at render time if a Pi
-// upgrade renames them: that failure is deliberately loud rather than degraded, because a
-// renamed field would silently regress the hidden-block gaps.
+// hiddenThinkingLabel/hideThinkingBlock fields, but only on renders where Calm is actively
+// hiding thinking — the only case that reads them — and throws at render time if a Pi
+// upgrade renames them: deliberately loud there, because a renamed field would silently
+// regress the hidden-block gaps. Renders with Calm presentation off and stock export
+// renders never read the fields and are never affected by the check.
 // This layout removes collapsed thinking and the mid-turn assistant text blocks
 // classified as "assistant-working-note" from a shallow presentation copy. The message
 // itself, model context, session storage, and export rendering are never touched.
@@ -73,15 +75,15 @@ export function installCalmAssistantLayout(): void {
     message: AssistantMessage,
   ): void {
     const state = this as unknown as AssistantMessagePresentationState;
-    if (typeof state.hiddenThinkingLabel !== "string" || typeof state.hideThinkingBlock !== "boolean") {
-      throw new Error(
-        "Firstmate Calm requires AssistantMessageComponent.hiddenThinkingLabel and hideThinkingBlock",
-      );
+    let hideThinking = false;
+    if (patch.hidesThinking()) {
+      if (typeof state.hiddenThinkingLabel !== "string" || typeof state.hideThinkingBlock !== "boolean") {
+        throw new Error(
+          "Firstmate Calm requires AssistantMessageComponent.hiddenThinkingLabel and hideThinkingBlock",
+        );
+      }
+      hideThinking = state.hiddenThinkingLabel === "" && state.hideThinkingBlock;
     }
-    const hideThinking =
-      state.hiddenThinkingLabel === "" &&
-      state.hideThinkingBlock &&
-      patch.hidesThinking();
     const hideWorkingNote =
       patch.hidesWorkingNote() && isMidTurnAssistantMessage(message);
     const presentationMessage =

--- a/.pi/extensions/lib/fm-calm-assistant-layout.ts
+++ b/.pi/extensions/lib/fm-calm-assistant-layout.ts
@@ -1,7 +1,10 @@
 // Verified against Pi 0.81.1 and 0.82.0, which export AssistantMessageComponent with an
 // updateContent method. installCalmAssistantLayout() probes that exact method and throws
 // if it is missing; fm-calm.ts catches that and skips only this adapter with a diagnostic
-// instead of blocking Calm or Pi.
+// instead of blocking Calm or Pi. The patched method likewise checks the private
+// hiddenThinkingLabel/hideThinkingBlock fields it reads and throws at render time if a Pi
+// upgrade renames them: that failure is deliberately loud rather than degraded, because a
+// renamed field would silently regress the hidden-block gaps.
 // This layout removes collapsed thinking and the mid-turn assistant text blocks
 // classified as "assistant-working-note" from a shallow presentation copy. The message
 // itself, model context, session storage, and export rendering are never touched.

--- a/.pi/extensions/lib/fm-calm-assistant-layout.ts
+++ b/.pi/extensions/lib/fm-calm-assistant-layout.ts
@@ -70,6 +70,11 @@ export function installCalmAssistantLayout(): void {
     message: AssistantMessage,
   ): void {
     const state = this as unknown as AssistantMessagePresentationState;
+    if (typeof state.hiddenThinkingLabel !== "string" || typeof state.hideThinkingBlock !== "boolean") {
+      throw new Error(
+        "Firstmate Calm requires AssistantMessageComponent.hiddenThinkingLabel and hideThinkingBlock",
+      );
+    }
     const hideThinking =
       state.hiddenThinkingLabel === "" &&
       state.hideThinkingBlock &&
@@ -88,8 +93,11 @@ export function installCalmAssistantLayout(): void {
           }
         : message;
 
-    originalUpdateContent.call(this, presentationMessage);
-    if (presentationMessage !== message) state.lastMessage = message;
+    try {
+      originalUpdateContent.call(this, presentationMessage);
+    } finally {
+      if (presentationMessage !== message) state.lastMessage = message;
+    }
   };
 
   registry[CALM_ASSISTANT_LAYOUT_PATCH] = patch;

--- a/.pi/extensions/lib/fm-calm-assistant-layout.ts
+++ b/.pi/extensions/lib/fm-calm-assistant-layout.ts
@@ -3,7 +3,7 @@
 // if it is missing; fm-calm.ts catches that and skips only this adapter with a diagnostic
 // instead of blocking Calm or Pi. The patched method likewise checks the private
 // hiddenThinkingLabel/hideThinkingBlock fields, but only on renders where Calm is actively
-// hiding thinking — the only case that reads them — and throws at render time if a Pi
+// hiding thinking - the only case that reads them - and throws at render time if a Pi
 // upgrade renames them: deliberately loud there, because a renamed field would silently
 // regress the hidden-block gaps. Renders with Calm presentation off and stock export
 // renders never read the fields and are never affected by the check.

--- a/docs/calm.md
+++ b/docs/calm.md
@@ -36,7 +36,8 @@ These are supported-API boundaries rather than hidden-content failures.
 Calm has no numeric Pi version minimum or maximum and never refuses Pi solely because its version is newer than a previously verified version.
 The collapsed-thinking and operational-user-row presentation adapters probe the exact Pi API seam they patch when Calm loads.
 If Pi removes one of those seams, Calm logs a diagnostic naming the unavailable adapter and skips only that adapter; `/calm`, the other adapter, and unrelated Pi extensions remain available.
-The collapsed-thinking adapter additionally checks the private Pi thinking-presentation fields only on renders where Calm is actively hiding thinking — the only case that reads them — and fails loudly, naming the fields, if a Pi upgrade renames them, because a silent mismatch would regress the hidden-block spacing instead of surfacing the incompatibility. Renders with Calm presentation off and stock export renders never read those fields and are unaffected by the check.
+The collapsed-thinking adapter additionally checks the private Pi thinking-presentation fields only on renders where Calm is actively hiding thinking - the only case that reads them - and fails loudly, naming the fields, if a Pi upgrade renames them, because a silent mismatch would regress the hidden-block spacing instead of surfacing the incompatibility.
+Renders with Calm presentation off and stock export renders never read those fields and are unaffected by the check.
 
 Calm's built-in tool presentation (`bash`, `read`, `edit`, `write`, `grep`, `find`, `ls`) shares Pi's single, unmerged override slot per name with any other extension that overrides the same tool.
 While the persisted Calm preference is off, Calm registers none of those overrides and therefore contests no built-in tool name.

--- a/docs/calm.md
+++ b/docs/calm.md
@@ -36,7 +36,7 @@ These are supported-API boundaries rather than hidden-content failures.
 Calm has no numeric Pi version minimum or maximum and never refuses Pi solely because its version is newer than a previously verified version.
 The collapsed-thinking and operational-user-row presentation adapters probe the exact Pi API seam they patch when Calm loads.
 If Pi removes one of those seams, Calm logs a diagnostic naming the unavailable adapter and skips only that adapter; `/calm`, the other adapter, and unrelated Pi extensions remain available.
-The collapsed-thinking adapter additionally checks the private Pi thinking-presentation fields it reads on every render and fails loudly, naming the fields, if a Pi upgrade renames them, because a silent mismatch would regress the hidden-block spacing instead of surfacing the incompatibility.
+The collapsed-thinking adapter additionally checks the private Pi thinking-presentation fields only on renders where Calm is actively hiding thinking — the only case that reads them — and fails loudly, naming the fields, if a Pi upgrade renames them, because a silent mismatch would regress the hidden-block spacing instead of surfacing the incompatibility. Renders with Calm presentation off and stock export renders never read those fields and are unaffected by the check.
 
 Calm's built-in tool presentation (`bash`, `read`, `edit`, `write`, `grep`, `find`, `ls`) shares Pi's single, unmerged override slot per name with any other extension that overrides the same tool.
 While the persisted Calm preference is off, Calm registers none of those overrides and therefore contests no built-in tool name.

--- a/docs/calm.md
+++ b/docs/calm.md
@@ -36,6 +36,7 @@ These are supported-API boundaries rather than hidden-content failures.
 Calm has no numeric Pi version minimum or maximum and never refuses Pi solely because its version is newer than a previously verified version.
 The collapsed-thinking and operational-user-row presentation adapters probe the exact Pi API seam they patch when Calm loads.
 If Pi removes one of those seams, Calm logs a diagnostic naming the unavailable adapter and skips only that adapter; `/calm`, the other adapter, and unrelated Pi extensions remain available.
+The collapsed-thinking adapter additionally checks the private Pi thinking-presentation fields it reads on every render and fails loudly, naming the fields, if a Pi upgrade renames them, because a silent mismatch would regress the hidden-block spacing instead of surfacing the incompatibility.
 
 Calm's built-in tool presentation (`bash`, `read`, `edit`, `write`, `grep`, `find`, `ls`) shares Pi's single, unmerged override slot per name with any other extension that overrides the same tool.
 While the persisted Calm preference is off, Calm registers none of those overrides and therefore contests no built-in tool name.

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -2237,10 +2237,13 @@ TS
 
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l '/reload'
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
-  # The reload banner is transient and can repaint faster than a poll catches it, so
-  # accept the settled final text without depending on ever observing the banner.
-  wait_for_geometry_text "$snapshot" "CALM_GEOMETRY_FINAL" \
-    || fail "Pi Calm hidden-block geometry E2E did not complete the /reload viewport transition"
+  # The in-progress "Reloading ... files..." banner is transient and CALM_GEOMETRY_FINAL
+  # is already on-screen, so neither is a barrier. The past-tense completion banner is
+  # absent before /reload and persists in the transcript once the reload finishes, so
+  # it is a real positive synchronization signal; keystrokes sent during the reload are
+  # dropped by Pi's input teardown, so a probe command cannot serve as the marker.
+  wait_for_geometry_text "$snapshot" "Reloaded keybindings, extensions, skills, prompts, themes, and context files" \
+    || fail "Pi Calm hidden-block geometry E2E never rendered the /reload completion banner"
   sleep "$GEOMETRY_RELOAD_SETTLE_SECONDS"
   capture_geometry_viewport "$snapshot"
   assert_geometry_gap "$snapshot" "reloaded native Calm transcript"

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -406,7 +406,7 @@ JS
 }
 
 test_calm_assistant_layout_field_check_and_restore() {
-  local fixture out status
+  local fixture out output_file status
   if ! command -v node >/dev/null 2>&1; then
     echo "skip: node not found for Pi calm assistant-layout field-check test"
     return 0
@@ -430,7 +430,10 @@ test_calm_assistant_layout_field_check_and_restore() {
     '}' \
     >"$fixture/project/node_modules/@earendil-works/pi-coding-agent/index.js"
 
-  out=$(cd "$fixture/project" && node --input-type=module 2>&1 <<'JS'
+  # Redirect to a file instead of capturing via $(...): stock macOS Bash 3.2 cannot
+  # parse a heredoc body inside command substitution.
+  output_file="$fixture/node-output"
+  (cd "$fixture/project" && node --input-type=module) >"$output_file" 2>&1 <<'JS'
 const pkg = await import("@earendil-works/pi-coding-agent");
 const { AssistantMessageComponent } = pkg;
 
@@ -513,8 +516,8 @@ assistant.installCalmAssistantLayout();
   }
 }
 JS
-)
   status=$?
+  out=$(cat "$output_file")
   [ "$status" -eq 0 ] || fail "Pi calm assistant-layout field-check and restore-on-throw path failed: $out"
   [ -z "$out" ] || fail "Pi calm assistant-layout field-check test printed output: $out"
   pass "the collapsed-thinking adapter fails loudly on a renamed hiddenThinkingLabel/hideThinkingBlock field only while Calm actively hides thinking, renders untouched when Calm is off or during stock export, and restores lastMessage even when the original updateContent throws mid-render"

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -17,6 +17,9 @@ PI_OPERATIONAL_INPUT="$ROOT/.pi/extensions/lib/fm-operational-input.ts"
 PI_PACKAGE_DIR=${FM_PI_PACKAGE_DIR:-"$(npm root -g 2>/dev/null)/@earendil-works/pi-coding-agent"}
 TMUX_SOCKET="fm-calm-$$"
 TMUX_SESSION="fm-calm-e2e"
+# Grace period after /reload's final text reappears, so the geometry assertion reads a
+# settled repaint instead of a still-reflowing one.
+GEOMETRY_RELOAD_SETTLE_SECONDS=2
 # Verified against Pi 0.81.1 and 0.82.0 (docs/calm-mode-feasibility.md). This is
 # known-good evidence, not a support ceiling: the fixtures below run against whatever
 # Pi is actually installed, and record_pi_version_evidence never rejects a newer
@@ -69,6 +72,54 @@ find_chrome() {
     fi
   done
   return 1
+}
+
+start_geometry_pi() {
+  local project=$1 home=$2 config=$3 session_arg=$4
+  tmux -L "$TMUX_SOCKET" kill-session -t "$TMUX_SESSION" 2>/dev/null || true
+  tmux -L "$TMUX_SOCKET" new-session -d -s "$TMUX_SESSION" -x 100 -y 44 \
+    "cd '$project' && env FM_HOME='$home' PI_CODING_AGENT_DIR='$config' PI_OFFLINE=1 pi --approve --no-context-files --no-prompt-templates --no-extensions -e ./.pi/extensions/fm-calm.ts -e ./geometry-provider.ts $session_arg; rc=\$?; printf '\nPI_EXIT=%s\n' \"\$rc\"; sleep 20"
+}
+
+capture_geometry_viewport() {
+  local file=$1
+  tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" >"$file" 2>/dev/null
+}
+
+wait_for_geometry_text() {
+  local file=$1 text=$2 attempt=0
+  while [ "$attempt" -lt 120 ]; do
+    capture_geometry_viewport "$file" || true
+    grep -Fq "$text" "$file" 2>/dev/null && return 0
+    sleep 0.05
+    attempt=$((attempt + 1))
+  done
+  return 1
+}
+
+# Shared wait-until-absent: proves a repaint actually happened (the prior
+# content is gone) instead of racing a short-lived transient banner against a
+# 10ms poll, which can repaint and vanish between two polls.
+wait_for_geometry_absence() {
+  local file=$1 text=$2 attempt=0
+  while [ "$attempt" -lt 120 ]; do
+    capture_geometry_viewport "$file" || true
+    grep -Fq "$text" "$file" 2>/dev/null || return 0
+    sleep 0.05
+    attempt=$((attempt + 1))
+  done
+  return 1
+}
+
+assert_geometry_gap() {
+  local file=$1 label=$2 skill_line final_line gap
+  skill_line=$(grep -n -m1 '\[skill\] ahoy' "$file" | cut -d: -f1)
+  final_line=$(grep -n -m1 'CALM_GEOMETRY_FINAL' "$file" | cut -d: -f1)
+  [ -n "$skill_line" ] && [ -n "$final_line" ] \
+    || fail "$label did not render the collapsed skill row and final assistant response"
+  gap=$((final_line - skill_line - 1))
+  [ "$gap" -eq 2 ] \
+    || fail "$label left $gap rows between the collapsed skill row and final response instead of the two standard visible-row separators"
 }
 
 test_home_resolution() {
@@ -352,6 +403,92 @@ JS
   [ "$status" -eq 0 ] || fail "Pi calm missing-adapter-export path failed: $out"
   [ -z "$out" ] || fail "Pi calm missing-adapter-export test printed output: $out"
   pass "missing Pi presentation class exports reach the independent adapter degradation path"
+}
+
+test_calm_assistant_layout_field_check_and_restore() {
+  local fixture out status
+  if ! command -v node >/dev/null 2>&1; then
+    echo "skip: node not found for Pi calm assistant-layout field-check test"
+    return 0
+  fi
+
+  fixture="$TMP_ROOT/assistant-layout-field-check"
+  mkdir -p \
+    "$fixture/project/.pi/extensions/lib" \
+    "$fixture/project/node_modules/@earendil-works/pi-coding-agent"
+  cp "$ASSISTANT_LAYOUT" "$fixture/project/.pi/extensions/lib/fm-calm-assistant-layout.ts"
+  cp "$VISIBILITY" "$fixture/project/.pi/extensions/lib/fm-calm-visibility.ts"
+  printf '%s\n' '{"type":"module"}' >"$fixture/project/package.json"
+  printf '%s\n' \
+    '{"name":"@earendil-works/pi-coding-agent","type":"module","exports":"./index.js"}' \
+    >"$fixture/project/node_modules/@earendil-works/pi-coding-agent/package.json"
+  printf '%s\n' \
+    'export function getMarkdownTheme() { return {}; }' \
+    'export class UserMessageComponent {}' \
+    'export class AssistantMessageComponent {' \
+    '  updateContent(message) { this.rendered = message; }' \
+    '}' \
+    >"$fixture/project/node_modules/@earendil-works/pi-coding-agent/index.js"
+
+  out=$(cd "$fixture/project" && node --input-type=module 2>&1 <<'JS'
+const pkg = await import("@earendil-works/pi-coding-agent");
+const { AssistantMessageComponent } = pkg;
+
+// A throwing original stands in for a Pi upgrade whose updateContent fails mid-render;
+// the patch must still restore lastMessage instead of losing the original thinking content.
+let originalCalls = 0;
+AssistantMessageComponent.prototype.updateContent = function () {
+  originalCalls++;
+  throw new Error("boom-from-original-updateContent");
+};
+
+const assistant = await import("./.pi/extensions/lib/fm-calm-assistant-layout.ts");
+const visibility = await import("./.pi/extensions/lib/fm-calm-visibility.ts");
+assistant.installCalmAssistantLayout();
+
+{
+  const instance = Object.create(AssistantMessageComponent.prototype);
+  let reason;
+  try {
+    instance.updateContent({ stopReason: "endTurn", content: [] });
+  } catch (error) {
+    reason = error instanceof Error ? error.message : String(error);
+  }
+  if (!reason?.includes("hiddenThinkingLabel") || !reason.includes("hideThinkingBlock")) {
+    throw new Error(
+      `an instance missing hiddenThinkingLabel/hideThinkingBlock did not fail loudly naming both fields: ${String(reason)}`,
+    );
+  }
+  if (originalCalls !== 0) {
+    throw new Error("the missing-field check ran after calling the original updateContent instead of before");
+  }
+}
+
+{
+  visibility.setCalmPresentation(true);
+  const instance = Object.create(AssistantMessageComponent.prototype);
+  instance.hiddenThinkingLabel = "";
+  instance.hideThinkingBlock = true;
+  const original = { stopReason: "endTurn", content: [{ type: "thinking", text: "secret" }] };
+  let threw = false;
+  try {
+    instance.updateContent(original);
+  } catch {
+    threw = true;
+  }
+  if (!threw) {
+    throw new Error("fixture precondition failed: the original updateContent did not throw");
+  }
+  if (instance.lastMessage !== original) {
+    throw new Error("a mid-render throw from the original updateContent left lastMessage unrestored");
+  }
+}
+JS
+)
+  status=$?
+  [ "$status" -eq 0 ] || fail "Pi calm assistant-layout field-check and restore-on-throw path failed: $out"
+  [ -z "$out" ] || fail "Pi calm assistant-layout field-check test printed output: $out"
+  pass "the collapsed-thinking adapter fails loudly on a renamed hiddenThinkingLabel/hideThinkingBlock field and restores lastMessage even when the original updateContent throws mid-render"
 }
 
 test_builtin_gate_load_time() {
@@ -2072,56 +2209,7 @@ export default function (pi: ExtensionAPI): void {
 }
 TS
 
-  start_geometry_pi() {
-    local session_arg=$1
-    tmux -L "$TMUX_SOCKET" kill-session -t "$TMUX_SESSION" 2>/dev/null || true
-    tmux -L "$TMUX_SOCKET" new-session -d -s "$TMUX_SESSION" -x 100 -y 44 \
-      "cd '$project' && env FM_HOME='$home' PI_CODING_AGENT_DIR='$config' PI_OFFLINE=1 pi --approve --no-context-files --no-prompt-templates --no-extensions -e ./.pi/extensions/fm-calm.ts -e ./geometry-provider.ts $session_arg; rc=\$?; printf '\nPI_EXIT=%s\n' \"\$rc\"; sleep 20"
-  }
-
-  capture_geometry_viewport() {
-    local file=$1
-    tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" >"$file" 2>/dev/null
-  }
-
-  wait_for_geometry_text() {
-    local file=$1 text=$2 attempt=0
-    while [ "$attempt" -lt 120 ]; do
-      capture_geometry_viewport "$file" || true
-      grep -Fq "$text" "$file" 2>/dev/null && return 0
-      sleep 0.05
-      attempt=$((attempt + 1))
-    done
-    return 1
-  }
-
-  wait_for_geometry_transition() {
-    local file=$1 transient_text=$2 final_text=$3 attempt=0 saw_transient=0
-    while [ "$attempt" -lt 600 ]; do
-      capture_geometry_viewport "$file" || true
-      if grep -Fq "$transient_text" "$file" 2>/dev/null; then
-        saw_transient=1
-      elif [ "$saw_transient" -eq 1 ] && grep -Fq "$final_text" "$file" 2>/dev/null; then
-        return 0
-      fi
-      sleep 0.01
-      attempt=$((attempt + 1))
-    done
-    return 1
-  }
-
-  assert_geometry_gap() {
-    local file=$1 label=$2
-    skill_line=$(grep -n -m1 '\[skill\] ahoy' "$file" | cut -d: -f1)
-    final_line=$(grep -n -m1 'CALM_GEOMETRY_FINAL' "$file" | cut -d: -f1)
-    [ -n "$skill_line" ] && [ -n "$final_line" ] \
-      || fail "$label did not render the collapsed skill row and final assistant response"
-    gap=$((final_line - skill_line - 1))
-    [ "$gap" -eq 2 ] \
-      || fail "$label left $gap rows between the collapsed skill row and final response instead of the two standard visible-row separators"
-  }
-
-  start_geometry_pi "--session-dir '$sessions'"
+  start_geometry_pi "$project" "$home" "$config" "--session-dir '$sessions'"
   wait_for_geometry_text "$snapshot" "geometry-provider.ts" \
     || fail "Pi Calm hidden-block geometry E2E did not reach the ready composer"
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l '/calm-geometry-e2e'
@@ -2131,13 +2219,8 @@ TS
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
   wait_for_geometry_text "$snapshot" "visible row two" \
     || fail "Pi Calm hidden-block geometry E2E did not complete the /skill:ahoy turn"
-  i=0
-  while [ "$i" -lt 120 ]; do
-    capture_geometry_viewport "$snapshot"
-    tail -12 "$snapshot" | grep -Fq "Working..." || break
-    sleep 0.05
-    i=$((i + 1))
-  done
+  wait_for_geometry_absence "$snapshot" "Working..." \
+    || fail "Pi Calm hidden-block geometry E2E left the working indicator visible"
   assert_contains "$(cat "$snapshot")" "[skill] ahoy" "Calm hid the collapsed skill header"
   assert_contains "$(cat "$snapshot")" "CALM_GEOMETRY_FINAL" "Calm hid the final assistant response"
   assert_not_contains "$(cat "$snapshot")" "Thinking..." "Calm left a collapsed thinking label visible"
@@ -2154,11 +2237,12 @@ TS
 
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l '/reload'
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
-  wait_for_geometry_transition \
-    "$snapshot" \
-    "Reloading keybindings, extensions, skills, prompts, themes, and context files..." \
-    "CALM_GEOMETRY_FINAL" \
+  # The reload banner is transient and can repaint faster than a poll catches it, so
+  # accept the settled final text without depending on ever observing the banner.
+  wait_for_geometry_text "$snapshot" "CALM_GEOMETRY_FINAL" \
     || fail "Pi Calm hidden-block geometry E2E did not complete the /reload viewport transition"
+  sleep "$GEOMETRY_RELOAD_SETTLE_SECONDS"
+  capture_geometry_viewport "$snapshot"
   assert_geometry_gap "$snapshot" "reloaded native Calm transcript"
 
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" C-t
@@ -2166,14 +2250,8 @@ TS
     || fail "thinking expansion did not restore Calm-hidden reasoning"
   assert_not_contains "$(cat "$expanded_snapshot")" "probe-one.txt" "thinking expansion restored Calm-hidden tool rows"
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" C-t
-  i=0
-  while [ "$i" -lt 120 ]; do
-    capture_geometry_viewport "$snapshot"
-    grep -Fq "CALM_GEOMETRY_THINKING_ONE" "$snapshot" || break
-    sleep 0.05
-    i=$((i + 1))
-  done
-  assert_not_contains "$(cat "$snapshot")" "CALM_GEOMETRY_THINKING_ONE" "collapsing thinking restored hidden-row output"
+  wait_for_geometry_absence "$snapshot" "CALM_GEOMETRY_THINKING_ONE" \
+    || fail "collapsing thinking restored hidden-row output"
   assert_geometry_gap "$snapshot" "re-collapsed native Calm transcript"
 
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" -l '/calm'
@@ -2198,7 +2276,7 @@ TS
   tmux -L "$TMUX_SOCKET" send-keys -t "$TMUX_SESSION" Enter
   sleep 0.2
   tmux -L "$TMUX_SOCKET" kill-session -t "$TMUX_SESSION" 2>/dev/null || true
-  start_geometry_pi "--session '$session_file'"
+  start_geometry_pi "$project" "$home" "$config" "--session '$session_file'"
   wait_for_geometry_text "$restarted_snapshot" "visible row two" \
     || fail "Pi did not restore the Calm hidden-block geometry session"
   assert_not_contains "$(cat "$restarted_snapshot")" "Thinking..." "restart restored a collapsed thinking label under Calm"
@@ -3957,6 +4035,7 @@ test_home_resolution
 test_pi_compat_no_upper_bound
 test_pi_compat_degraded_adapter
 test_pi_compat_missing_adapter_exports
+test_calm_assistant_layout_field_check_and_restore
 test_builtin_gate_load_time
 test_calm_activation_collision_and_regression_bound
 test_rendering_and_session_lifecycle

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -434,12 +434,16 @@ test_calm_assistant_layout_field_check_and_restore() {
 const pkg = await import("@earendil-works/pi-coding-agent");
 const { AssistantMessageComponent } = pkg;
 
-// A throwing original stands in for a Pi upgrade whose updateContent fails mid-render;
-// the patch must still restore lastMessage instead of losing the original thinking content.
+// A switchable original stands in for Pi's updateContent: recording mode proves the
+// field check stays out of renders that never read the fields, and throwing mode stands
+// in for a Pi upgrade whose updateContent fails mid-render, where the patch must still
+// restore lastMessage instead of losing the original thinking content.
 let originalCalls = 0;
-AssistantMessageComponent.prototype.updateContent = function () {
+let originalThrows = true;
+AssistantMessageComponent.prototype.updateContent = function (message) {
   originalCalls++;
-  throw new Error("boom-from-original-updateContent");
+  if (originalThrows) throw new Error("boom-from-original-updateContent");
+  this.rendered = message;
 };
 
 const assistant = await import("./.pi/extensions/lib/fm-calm-assistant-layout.ts");
@@ -447,6 +451,7 @@ const visibility = await import("./.pi/extensions/lib/fm-calm-visibility.ts");
 assistant.installCalmAssistantLayout();
 
 {
+  visibility.setCalmPresentation(true);
   const instance = Object.create(AssistantMessageComponent.prototype);
   let reason;
   try {
@@ -456,7 +461,7 @@ assistant.installCalmAssistantLayout();
   }
   if (!reason?.includes("hiddenThinkingLabel") || !reason.includes("hideThinkingBlock")) {
     throw new Error(
-      `an instance missing hiddenThinkingLabel/hideThinkingBlock did not fail loudly naming both fields: ${String(reason)}`,
+      `with Calm hiding thinking, an instance missing hiddenThinkingLabel/hideThinkingBlock did not fail loudly naming both fields: ${String(reason)}`,
     );
   }
   if (originalCalls !== 0) {
@@ -465,6 +470,30 @@ assistant.installCalmAssistantLayout();
 }
 
 {
+  visibility.setCalmPresentation(false);
+  originalThrows = false;
+  const instance = Object.create(AssistantMessageComponent.prototype);
+  const message = { stopReason: "endTurn", content: [] };
+  instance.updateContent(message);
+  if (originalCalls !== 1 || instance.rendered !== message) {
+    throw new Error("with Calm presentation off, a field-missing instance did not render through the original updateContent");
+  }
+}
+
+{
+  visibility.setCalmPresentation(true);
+  visibility.setCalmStockExportRendering(true);
+  const instance = Object.create(AssistantMessageComponent.prototype);
+  const message = { stopReason: "endTurn", content: [] };
+  instance.updateContent(message);
+  visibility.setCalmStockExportRendering(false);
+  if (originalCalls !== 2 || instance.rendered !== message) {
+    throw new Error("during stock export rendering, a field-missing instance did not render through the original updateContent");
+  }
+}
+
+{
+  originalThrows = true;
   visibility.setCalmPresentation(true);
   const instance = Object.create(AssistantMessageComponent.prototype);
   instance.hiddenThinkingLabel = "";
@@ -488,7 +517,7 @@ JS
   status=$?
   [ "$status" -eq 0 ] || fail "Pi calm assistant-layout field-check and restore-on-throw path failed: $out"
   [ -z "$out" ] || fail "Pi calm assistant-layout field-check test printed output: $out"
-  pass "the collapsed-thinking adapter fails loudly on a renamed hiddenThinkingLabel/hideThinkingBlock field and restores lastMessage even when the original updateContent throws mid-render"
+  pass "the collapsed-thinking adapter fails loudly on a renamed hiddenThinkingLabel/hideThinkingBlock field only while Calm actively hides thinking, renders untouched when Calm is off or during stock export, and restores lastMessage even when the original updateContent throws mid-render"
 }
 
 test_builtin_gate_load_time() {


### PR DESCRIPTION
## Intent

The developer was working in the firstmate repo to implement four verified code-review findings on commit 6b0d21d with the smallest correct diffs: adding a loud existence check for the private Pi adapter fields hiddenThinkingLabel and hideThinkingBlock in .pi/extensions/lib/fm-calm-assistant-layout.ts, making the lastMessage restore robust if updateContent throws mid-render, removing a 10ms polling race in the geometry E2E test's reload-transition wait, and consolidating five nested duplicated shell test helpers into top-level ones. Explicit constraints included loading the firstmate-coding-guidelines skill first, following repo style (one sentence per line, plain dashes, shellcheck-clean scripts, colocated tests, no agent co-author), running the full test suite and shellcheck, and delivering through the no-mistakes validation pipeline to a PR without hand-fixing findings during a run. When the pipeline's reviewer flagged that the test fix relied on a fixed sleep, the developer (via the captain's decision) required a real positive post-reload synchronization signal that cannot match stale content, with a bounded timeout that fails loudly rather than passing vacuously. A later review finding led to a further decision to gate the field-existence check so it only throws when Calm is actively hiding thinking, keeping rendering unaffected for Calm-off and export paths, with updated comments, docs/calm.md, and tests proving both behaviors. Delivery was rerouted through a fork (juangedaan/firstmate) after push permission to the upstream repo was denied, with the goal of an open upstream PR with green CI.

## What Changed
- The Calm assistant-layout adapter now validates Pi's private `hiddenThinkingLabel`/`hideThinkingBlock` fields and throws a named error if a Pi upgrade renames them — but only on renders where Calm is actively hiding thinking; Calm-off and stock export renders never read the fields and are unaffected. `state.lastMessage` restoration was moved into a `finally` block so it survives an `updateContent` throw mid-render.
- The geometry E2E test's post-reload wait now synchronizes on the persistent "Reloaded ..." completion banner instead of a 10ms polling race, and five nested duplicated shell test helpers were consolidated into top-level ones (`start_geometry_pi`, `wait_for_geometry_text`, `wait_for_geometry_absence`, `assert_geometry_gap`). A new colocated test covers the gated field check and the throw-path restore.
- docs/calm.md documents the loud field-check failure mode and its scoping in the Calm compatibility contract.

The pipeline passed intent, rebase, test, document, lint, and push checks; review left two informational notes (a two-sentence doc line and a residual fixed settle sleep after the banner sync, an accepted flake-vs-staleness tradeoff).

## Risk Assessment

✅ Low: Small, well-bounded change implementing four reviewed findings: the gated field check and try/finally restore are verified correct against the visibility module's semantics, the new fixture test covers all four behavior branches, the consolidated shell helpers are correctly parameterized with no dangling references, and shellcheck is clean — the only findings are a docs line-style nit and an acknowledged, loud-failing test-timing tradeoff.

## Testing

Ran the two tests colocated with the change — the new field-check/restore unit test and the full hidden-block geometry E2E against real Pi 0.84.2 in tmux — both pass; captured the actual post-reload terminal viewport (completion banner + correct 2-row geometry, the end-user TUI surface) and a CLI transcript demonstrating the loud field-check error fires only while Calm actively hides thinking. The TUI evidence is a tmux capture-pane text transcript because the product surface is a terminal UI, so pane text is the rendered surface; no browser/pixel surface exists to screenshot.

<details>
<summary>Evidence: Post-/reload TUI viewport: persistent &#39;Reloaded ...&#39; completion banner with correct 2-row hidden-block geometry</summary>

<code>[skill] ahoy (ctrl+o to expand)&#10;&#10;&#10;CALM_GEOMETRY_FINAL&#10;&#10;- visible row one&#10;- visible row two&#10;&#10;Reloaded keybindings, extensions, skills, prompts, themes, and context files</code>

```text

 pi v0.84.2
 escape interrupt · ctrl+c/ctrl+d clear/exit · / commands · ! bash · ctrl+o more
 Press ctrl+o to show full startup help and loaded resources.

 Pi can explain its own features and look up its docs. Ask it how to use or extend Pi.

[Skills]
  ahoy, no-mistakes

[Extensions]
  fm-calm.ts, geometry-provider.ts


 [skill] ahoy (ctrl+o to expand)


 CALM_GEOMETRY_FINAL

 - visible row one
 - visible row two

 Reloaded keybindings, extensions, skills, prompts, themes, and context files

────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────
/tmp/fm-calm-pi-extension.6GfKzw/geometry-project (main)
↑4.7k ↓50 R2.1k W4.7k CH30.1% 87.3%/4.1k (auto)           (calm-geometry-e2e) deterministic • medium
```
</details>
<details>
<summary>Evidence: Gated field-check demo: loud error only while Calm hides thinking; Calm-off and export renders untouched</summary>

<code>Calm ON (hiding thinking) -&gt; throws loudly:&#10;Firstmate Calm requires AssistantMessageComponent.hiddenThinkingLabel and hideThinkingBlock&#10;Calm OFF -&gt; renders normally, fields never read&#10;Stock export (Calm ON) -&gt; renders normally, fields never read</code>

```text
Calm ON  (hiding thinking)  -> throws loudly:
           Firstmate Calm requires AssistantMessageComponent.hiddenThinkingLabel and hideThinkingBlock
Calm OFF                    -> renders normally, fields never read
Stock export (Calm ON)      -> renders normally, fields never read
```
</details>
<details>
<summary>Evidence: Focused test run: both targeted tests pass against Pi 0.84.2</summary>

```text
ok - the collapsed-thinking adapter fails loudly on a renamed hiddenThinkingLabel/hideThinkingBlock field only while Calm actively hides thinking, renders untouched when Calm is off or during stock export, and restores lastMessage even when the original updateContent throws mid-render
ok - Pi Calm native /skill:ahoy geometry keeps every collapsed thinking and tool block at zero height while preserving expansion, history, restart, and Calm-off rendering
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `docs/calm.md:39` - The added compatibility-contract line contains two sentences on a single line, breaking the one-sentence-per-line convention used throughout docs/calm.md (and stated as an explicit repo constraint). Split &#39;Renders with Calm presentation off and stock export renders never read those fields and are unaffected by the check.&#39; onto its own line.
- ℹ️ `tests/fm-calm-pi-extension.test.sh:2276` - The post-reload geometry assertion still uses a fixed 2s settle sleep (GEOMETRY_RELOAD_SETTLE_SECONDS) after the completion-banner wait, then a single capture. This is a deliberate, commented grace period after a real positive sync signal, and an undersized sleep on a slow machine can only cause a loud failure (never a vacuous pass) — polling the gap instead would risk matching stale pre-reload content, which also shows the expected 2-row gap. Acceptable tradeoff; noting it as residual flake surface on slow CI.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`test_calm_assistant_layout_field_check_and_restore` (new colocated test in tests/fm-calm-pi-extension.test.sh) via a focused runner — passes</code>
- <code>`test_hidden_block_geometry_e2e` (full TUI E2E in tmux against installed Pi 0.84.2, exercising the new reload completion-banner sync, the consolidated top-level geometry helpers, and both wait_for_geometry_absence call sites) — passes</code>
- `Manual CLI demo: renamed private fields throw the named error only while Calm actively hides thinking; Calm-off and stock-export renders proceed untouched`
- `Captured the post-reload tmux viewport showing the persistent 'Reloaded ...' completion banner and the asserted 2-row gap between the collapsed skill row and CALM_GEOMETRY_FINAL`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
