### PR TITLE
feat(skills): add arxiv-niche-expert skill for persistent evidence-backed niche experts

### DIFF
--- a/.agents/skills/arxiv-niche-expert/SKILL.md
+++ b/.agents/skills/arxiv-niche-expert/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: arxiv-niche-expert
+description: >-
+  Build a persistent, evidence-backed niche expert from a topic, claim, or opinion.
+  Load when the captain asks to turn a subject, claim, or opinion into an evidence-backed expert that ingests papers (default 20, deep 50) and stays available for discussion, run by a scout (one-off briefing) or a persistent secondmate (ongoing expert).
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# arxiv-niche-expert
+
+Turn a topic, claim, or opinion into a persistent, evidence-backed niche expert.
+The expert ingests papers, ranks them by relevance and citations, and answers ongoing questions with cited evidence.
+
+This skill reuses existing substrates and is grounded in two scouts: `data/arxiv-skill-market/report.md` (reuse-first build; no existing tool offers a persistent per-niche expert or the 20/50 ingest modes) and `data/free-paper-sources/report.md` (free source set and the pluggable adapter model).
+
+## Invocation
+
+The captain gives a subject and a mode, and firstmate runs this skill through a scout or a secondmate.
+
+- `topic` / `claim` / `opinion` - the subject or thesis to investigate.
+- `mode` - `default` ingests `paper_count=20`; `deep` ingests `paper_count=50`.
+- `sources` - optional ordered override of source adapters (defaults below).
+
+Run the skill as a scout for a one-off evidence briefing, or as a persistent secondmate for ongoing Q&A.
+
+## Parameters
+
+`paper_count` and `sources` are parameters, not constants; 20 and 50 are defaults only.
+
+- `paper_count` (int) - cap on ingested papers after ranking; default 20, deep 50.
+- `sources` (list of adapter ids) - ordered search/resolver adapters; default v1 set below.
+- `topic` / `claim` / `opinion` (string) - the subject the expert covers.
+
+## Workflow
+
+Follow the pipeline in order, one stage per step.
+
+1. Search the enabled `sources` for the subject query.
+2. Download the candidate papers through the substrate's read tools.
+3. Extract title, authors, abstract, and key sections from each paper.
+4. Dedupe records by `doi`, then by normalized `title` + `authors`.
+5. Rank the survivors by relevance, citations, and recency, with provenance.
+6. Cap the ranked set to `paper_count`.
+7. Synthesize an evidence-backed briefing with inline citations.
+8. Seed a per-niche secondmate home for ongoing Q&A (see charter template).
+
+For a one-off briefing, run steps 1-7 as a scout and stop at the report.
+For an ongoing expert, run step 8 to seed the persistent secondmate.
+
+## Reusable substrates (do not reinvent)
+
+Use a mature search/download/read substrate; never build PDF parsing or LaTeX extraction yourself.
+
+- `arxiv-mcp-server` (Apache-2.0 MCP server) - tools `search_papers`, `download_paper`, `read_paper` (bounded), `list_paper_latex_sections`, `get_paper_latex_section`, `citation_graph`, `semantic_search`; bundled prompts `literature_review`, `deep-paper-analysis`, `literature-synthesis`.
+  Reach it from any MCP-aware runtime (Pi/Codex/Claude).
+- `pi-arxiv` (MIT Pi extension) - `arxiv_search`, `arxiv_paper`, `arxiv_fetch2md` (Markdown via arxiv2md).
+  Install with `pi install npm:@wienerberliner/pi-arxiv`.
+- `paper-qa` (Apache-2.0) - citation-grounded RAG over PDFs; `pqa ask "..."` or the library API returns answers with inline citations such as `Author2011 pages 1-2`.
+  Use it for the persistent expert's evidence-first discussion grounding.
+
+The `arxiv-skill-market` scout recommends this reuse-first build over forking: the mechanics are licensed and maintained, while the persistent-expert behavior and 20/50 modes are the novel layer to add.
+
+## Pluggable source adapters
+
+Model sources as adapters so each per-niche expert tunes coverage without code changes.
+`free-paper-sources` defines this model and the v1 set.
+
+Each adapter declares the following fields:
+
+- `endpoint` (URL) - the source's API base.
+- `auth` (`none` | `email` | `api_key`) - use the matching value.
+- `rate_limit` (calls/sec or calls/day) - honor it; add backoff.
+- `quality` tag (`peer_reviewed` | `preprint` | `mixed`) - set per source.
+- `dedup_key` - prefer `doi`; fall back to normalized `title` + `authors`.
+- `normalize()` - map the source's record to the common schema below.
+
+Common record schema:
+
+```json
+{
+  "title": "...",
+  "authors": ["..."],
+  "abstract": "...",
+  "url": "...",
+  "pdf_url": "...",
+  "doi": "...",
+  "year": 2026,
+  "citations": 42,
+  "source": "openalex",
+  "quality": "peer_reviewed"
+}
+```
+
+v1 default adapters (ordered):
+
+- `openalex` - backbone across all fields; free, no key at 20/50 scale; returns OA PDF links, citations, and concepts.
+  Endpoint `https://api.openalex.org/works`.
+- `semantic_scholar` - relevance/abstract/embedding layer; strong in CS/AI/bio.
+  Endpoint `https://api.semanticscholar.org/graph/v1/paper/search`; shared-rate-limit caveat, add backoff.
+- `europe_pmc` - biomedical/life-sciences depth: peer-reviewed plus 6.5M OA full text and a citation network.
+  Endpoint `https://www.ebi.ac.uk/europepmc/webservices/rest/search`.
+- `biorxiv_medrxiv` - newest biomedical/clinical preprints, before peer review.
+  Endpoint `https://api.biorxiv.org/details/{server}/{interval}/{cursor}/json`.
+- `unpaywall` - optional PDF resolver; given DOIs from the searchers, return the best free PDF URL.
+  Endpoint `https://api.unpaywall.org/v2/{DOI}`; requires `email` param; 100,000 calls/day.
+- `crossref` - internal dedup/metadata backbone only, not a user-facing searcher; most reliable DOI authority.
+  Endpoint `https://api.crossref.org/works`.
+
+Per-niche experts override `sources` and `paper_count` by config: a molecular-biology expert may enable `europe_pmc` and `biorxiv_medrxiv` and drop the rest; a CS expert may lean on `semantic_scholar` and skip the biomedical sources.
+No code change is needed.
+
+## Evidence-first synthesis
+
+Enforce evidence-first output in the briefing and in every ongoing answer.
+
+- Separate established findings from tentative claims.
+- Cite each claim inline with its source (DOI or title plus adapter).
+- Surface license and quality tags when the source provides them.
+- Rank by relevance, citations, and recency with provenance; do not present preprints as peer-reviewed.
+- Use `paper-qa` prompts to ground answers in retrieved text rather than model memory.
+
+## Per-niche secondmate charter (persistent expert)
+
+After the briefing, seed a persistent secondmate home for ongoing Q&A.
+The secondmate is idle by default and acts only when firstmate routes a topic to it.
+Use `bin/fm-brief.sh <niche-id> --secondmate --no-projects`, fill the charter with `FM_SECONDMATE_CHARTER` and `FM_SECONDMATE_SCOPE`, then `bin/fm-home-seed.sh <niche-id> - --no-projects`.
+See `secondmate-provisioning` for the full seed and launch contract.
+
+Example charter and scope:
+
+```sh
+export FM_SECONDMATE_CHARTER='You are the persistent evidence-backed expert for <niche>. You ingested <paper_count> papers from <sources> on <date>. Answer ongoing questions about this niche with cited evidence, separating established findings from tentative claims, and surface license/quality when available. You are idle until firstmate routes a topic to you. Do not invent papers; cite only the ingested set and named external sources.'
+export FM_SECONDMATE_SCOPE='Ongoing evidence-backed Q&A about <niche>: follow-up questions, claims to verify, and literature gaps, using the ingested paper set plus the named free sources.'
+```
+
+## Routing from main firstmate
+
+When the captain asks an ongoing question about the niche, route it to the secondmate by scope (per `data/secondmates.md` and `secondmate-provisioning`).
+The secondmate answers with cited evidence and stays available; it never initiates work on its own.
+For a one-off briefing only, run the skill as a scout and stop after the report.
+
+## Examples
+
+Default vs deep for the same subject:
+
+```text
+Captain: "Build me an expert on retrieval-augmented retrieval, default mode."
+→ sources = v1 default set, paper_count = 20, scout briefing then optional secondmate seed.
+
+Captain: "Same topic, deep dive."
+→ paper_count = 50, same sources, deeper ingest before the briefing.
+```
+
+Biomedical vs CS niche with different sources:
+
+```text
+Captain: "Expert on mRNA vaccine delivery, biomedical."
+→ sources = [openalex, semantic_scholar, europe_pmc, biorxiv_medrxiv, unpaywall], paper_count = 20.
+
+Captain: "Expert on transformer attention variants, CS."
+→ sources = [openalex, semantic_scholar, unpaywall], paper_count = 20 (drop europe_pmc and biorxiv_medrxiv).
+```
+
+## References
+
+- `data/arxiv-skill-market/report.md` - reuse-first build recommendation; `arxiv-mcp-server` / `pi-arxiv` substrates; `paper-qa` evidence layer; no existing persistent-expert tool.
+- `data/free-paper-sources/report.md` - v1 source set (OpenAlex, Semantic Scholar, Europe PMC, bioRxiv/medRxiv, Unpaywall) and the pluggable adapter model.
+- `secondmate-provisioning` - secondmate charter, seed, and routing contract.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -537,6 +537,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the Relay configuration blocker, on a `public-followup ...` `check:` wake or a startup-surfaced public commitment, and on any milestone or terminal wake for a Relay-linked task before posting its completion follow-up; relevant only when Relay is on.
 - `firstmate-codexapp` - load before coordinating a visible Codex Desktop thread, evaluating a Codex App backend request, or reconciling Codex Desktop host-tool smoke evidence for Firstmate work.
 - `firstmate-coding-guidelines` - load before changing firstmate's shared, tracked material, as defined by section 1's list, whether editing directly or briefing a crewmate for a firstmate-repo task.
+- `arxiv-niche-expert` - load when the captain asks to turn a topic, claim, or opinion into a persistent, evidence-backed niche expert that ingests papers (default 20, deep 50) and stays available for discussion, run by a scout or a persistent secondmate.
 
 ## 14. Relay
 

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -117,6 +117,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/arxiv-niche-expert/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/ask-user-authority/SKILL.md",
       "audience": "agent-runtime"
     },


### PR DESCRIPTION
## Intent

Build the reusable firstmate skill .agents/skills/arxiv-niche-expert/SKILL.md that turns a topic/claim/opinion into a persistent, evidence-backed niche expert. Invocation: captain gives topic/claim/opinion plus a mode flag (default ingests 20 papers, deep ingests 50) and an optional sources override; the skill runs as a scout (one-off briefing) or a persistent per-niche secondmate (ongoing expert). Workflow: search -> download -> extract -> dedupe by DOI/title -> relevance/citation ranking -> cap to paper_count -> synthesize an evidence-backed cited briefing -> seed a per-niche secondmate home for ongoing Q&A. Reuse substrates (do not reinvent PDF parsing): arxiv-mcp-server tools (search_papers, download_paper, read_paper, LaTeX sections) or pi-arxiv (arxiv_search/arxiv_fetch2md), and paper-qa prompts for citation grounding. Define pluggable source adapters with endpoint/auth/rate_limit/quality/dedup_key/normalize() mapping to a common record {title, authors, abstract, url, pdf_url, doi, year, citations, source, quality}; v1 defaults: OpenAlex (backbone), Semantic Scholar (ranking), Europe PMC (biomed), bioRxiv/medRxiv (newest preprints), Unpaywall resolver, Crossref dedup backbone. Enforce evidence-first synthesis: separate established findings from tentative claims, cite sources, surface license/quality. Include a charter template for the persistent per-niche secondmate (idle by default, routed only) with example FM_SECONDMATE_CHARTER/FM_SECONDMATE_SCOPE and routing from main firstmate, plus 2-3 usage examples (default vs deep; biomedical vs CS with different sources). paper_count and sources are parameters (20/50 are defaults only), never hard-coded constants. The skill must reference both scout reports (data/arxiv-skill-market/report.md and data/free-paper-sources/report.md) and their recommended source/substrate choices. Keep concise, one task per sentence, ASD-STE100 for captain-faced text, code identifiers unchanged. Shared tracked changes go through the PR path; firstmate-coding-guidelines was loaded before editing shared material.

## What Changed
- Added `.agents/skills/arxiv-niche-expert/SKILL.md` defining a persistent evidence-backed niche expert pipeline (search → download → extract → dedupe by DOI/title → rank by relevance/citations/recency → cap to `paper_count` → synthesize cited briefing → seed per-niche secondmate), parameterized `paper_count` (default 20, deep 50) and `sources`, pluggable source adapters (OpenAlex, Semantic Scholar, Europe PMC, bioRxiv/medRxiv, Unpaywall resolver, Crossref dedup backbone) mapping to a common record, reuse of `arxiv-mcp-server`/`pi-arxiv`/`paper-qa` substrates, evidence-first synthesis, and a persistent secondmate charter template with routing and usage examples.
- Registered the skill trigger in `AGENTS.md` and classified `.agents/skills/arxiv-niche-expert/SKILL.md` as `agent-runtime` in `docs/documentation-audiences.json`.

## Risk Assessment

✅ Low: Addition is documentation-only (new internal skill plus trigger and audience inventory entry) with no executable code, no hard-coded paper_count/sources constants, and full coverage of the required workflow, adapters, substrates, evidence-first synthesis, and secondmate charter.

## Testing

Validated the arxiv-niche-expert declarative skill end-to-end: semantic behavioral checks confirm invocation (topic/claim/opinion + default 20/deep 50 + sources override + scout/secondmate), 8-stage workflow, reuse-first substrates, pluggable adapters with common record, evidence-first synthesis, idle-by-default secondmate charter with routing, and examples; audience checker and documentation-audience suite both pass; rendered HTML and CLI transcripts captured as reviewer-visible evidence — all checks green.

<details>
<summary>Evidence: behavioral semantic validation — all 18 contract checks</summary>

Source: [behavioral semantic validation — all 18 contract checks](https://github.com/akashvacher/firstmate/blob/f3858007c05ad36f827d437ad265b3b8312a4141/.no-mistakes/evidence/fm/arxiv-niche-expert/behavioral-validation.log)

```text
PASS: frontmatter contract: name, user-invocable, internal correct
PASS: description covers topic/claim, 20/50, scout/secondmate
PASS: sections present: ['Invocation', 'Parameters', 'Workflow', 'Reusable substrates (do not reinvent)', 'Pluggable source adapters', 'Evidence-first synthesis', 'Per-niche secondmate charter (persistent expert)', 'Routing from main firstmate', 'Examples', 'References']
PASS: Invocation contract: topic/claim/opinion + default 20 / deep 50 + sources override + scout/secondmate
PASS: Parameters contract: paper_count and sources are parameters, 20/50 defaults only
PASS: Workflow pipeline: 8 ordered steps validated (search->download->extract->dedupe->rank->cap->synthesize->seed)
PASS: Workflow branching: scout one-off vs persistent secondmate
PASS: Reusable substrates: arxiv-mcp-server (search_papers etc), pi-arxiv, paper-qa, reuse-first
PASS: Scout reference present
PASS: Adapter fields: endpoint/auth/rate_limit/quality/dedup_key/normalize()
PASS: Common record schema: title/authors/abstract/url/pdf_url/doi/year/citations/source/quality
PASS: v1 adapters: openalex, semantic_scholar, europe_pmc, biorxiv_medrxiv, unpaywall, crossref
PASS: Adapter endpoints validated
PASS: Quality tags peer_reviewed/preprint/mixed
PASS: Evidence-first synthesis: separate established/tentative, cite, license/quality, ranking, paper-qa grounding
PASS: Secondmate charter: idle by default, FM_SECONDMATE_CHARTER/SCOPE, seed commands, provisioning reference
PASS: Routing: main firstmate routes by scope to secondmate
PASS: Examples: default vs deep (20/50) and biomedical vs CS with source overrides
PASS: References: both scout reports + substrates/sources
PASS: AGENTS.md trigger pointer present
PASS: Inventory classification: agent-runtime
PASS: Conciseness check passed (heuristic)
PASS: No hard-coded constants: cap references paper_count param

ALL CHECKS PASSED - skill satisfies user intent declarative contract
```
</details>
<details>
<summary>Evidence: captain invocation simulation transcript (default vs deep, biomedical vs CS)</summary>

Source: [captain invocation simulation transcript (default vs deep, biomedical vs CS)](https://github.com/akashvacher/firstmate/blob/f3858007c05ad36f827d437ad265b3b8312a4141/.no-mistakes/evidence/fm/arxiv-niche-expert/captain-invocation-transcript.log)

```text
=== Captain invocation simulation for arxiv-niche-expert skill ===

Skill location: .agents/skills/arxiv-niche-expert/SKILL.md
-rw-r--r--@ 1 avacher  staff   8.7K Aug 20 02:07 .agents/skills/arxiv-niche-expert/SKILL.md

--- Frontmatter contract ---
---
name: arxiv-niche-expert
description: >-
  Build a persistent, evidence-backed niche expert from a topic, claim, or opinion.
  Load when the captain asks to turn a subject, claim, or opinion into an evidence-backed expert that ingests papers (default 20, deep 50) and stays available for discussion, run by a scout (one-off briefing) or a persistent secondmate (ongoing expert).
user-invocable: false
metadata:
  internal: true
---


--- Invocation triggers (AGENTS.md) ---
540:- `arxiv-niche-expert` - load when the captain asks to turn a topic, claim, or opinion into a persistent, evidence-backed niche expert that ingests papers (default 20, deep 50) and stays available for discussion, run by a scout or a persistent secondmate.

--- Paper_count and sources are parameters (not constants) ---
16:This skill reuses existing substrates and is grounded in two scouts: `data/arxiv-skill-market/report.md` (reuse-first build; no existing tool offers a persistent per-niche expert or the 20/50 ingest modes) and `data/free-paper-sources/report.md` (free source set and the pluggable adapter model).
23:- `mode` - `default` ingests `paper_count=20`; `deep` ingests `paper_count=50`.
24:- `sources` - optional ordered override of source adapters (defaults below).
30:`paper_count` and `sources` are parameters, not constants; 20 and 50 are defaults only.
32:- `paper_count` (int) - cap on ingested papers after ranking; default 20, deep 50.
33:- `sources` (list of adapter ids) - ordered search/resolver adapters; default v1 set below.
40:1. Search the enabled `sources` for the subject query.
45:6. Cap the ranked set to `paper_count`.
67:Model sources as adapters so each per-niche expert tunes coverage without code changes.
68:`free-paper-sources` defines this model and the v1 set.
111:Per-niche experts override `sources` and `paper_count` by config: a molecular-biology expert may enable `europe_pmc` and `biorxiv_medrxiv` and drop the rest; a CS expert may lean on `semantic_scholar` and skip the biomedical sources.
134:export FM_SECONDMATE_CHARTER='You are the persistent evidence-backed expert for <niche>. You ingested <paper_count> papers from <sources> on <date>. Answer ongoing questions about this niche with cited evidence, separating established findings from tentative claims, and surface license/quality when available. You are idle until firstmate routes a topic to you. Do not invent papers; cite only the ingested set and named external sources.'
135:export FM_SECONDMATE_SCOPE='Ongoing evidence-backed Q&A about <niche>: follow-up questions, claims to verify, and literature gaps, using the ingested paper set plus the named free sources.'
150:→ sources = v1 default set, paper_count = 20, scout briefing then optional secondmate seed.
153:→ paper_count = 50, same sources, deeper ingest before the briefing.
156:Biomedical vs CS niche with different sources:
160:→ sources = [openalex, semantic_scholar, europe_pmc, biorxiv_medrxiv, unpaywall], paper_count = 20.
163:→ sources = [openalex, semantic_scholar, unpaywall], paper_count = 20 (drop europe_pmc and biorxiv_medrxiv).
169:- `data/free-paper-sources/report.md` - v1 source set (OpenAlex, Semantic Scholar, Europe PMC, bioRxiv/medRxiv, Unpaywall) and the pluggable adapter model.

--- Workflow: 8 steps ---
40:1. Search the enabled `sources` for the subject query.
41:2. Download the candidate papers through the substrate's read tools.
42:3. Extract title, authors, abstract, and key sections from each paper.
43:4. Dedupe records by `doi`, then by normalized `title` + `authors`.
44:5. Rank the survivors by relevance, citations, and recency, with provenance.
45:6. Cap the ranked set to `paper_count`.
46:7. Synthesize an evidence-backed briefing with inline citations.
47:8. Seed a per-niche secondmate home for ongoing Q&A (see charter template).

--- Default vs Deep examples ---
`` `text
Captain: "Build me an expert on retrieval-augmented retrieval, default mode."
→ sources = v1 default set, paper_count = 20, scout briefing then optional secondmate seed.

Captain: "Same topic, deep dive."
→ paper_count = 50, same sources, deeper ingest before the briefing.
`` `

--
`` `text
Captain: "Expert on mRNA vaccine delivery, biomedical."
→ sources = [openalex, semantic_scholar, europe_pmc, biorxiv_medrxiv, unpaywall], paper_count = 20.

Captain: "Expert on transformer attention variants, CS."
→ sources = [openalex, semantic_scholar, unpaywall], paper_count = 20 (drop europe_pmc and biorxiv_medrxiv).
`` `


--- End-to-end simulated captain flows ---
Captain: "Build me an expert on retrieval-augmented generation, default mode."
 -> Routed to scout: search -> download -> extract -> dedupe -> rank -> cap to paper_count=20 -> briefing -> optional secondmate seed

Captain: "Same topic, deep dive."
 -> paper_count=50, same sources, deeper ingest

Captain: "Expert on mRNA vaccine delivery, biomedical."
 -> sources = [openalex, semantic_scholar, europe_pmc, biorxiv_medrxiv, unpaywall] (biomedical depth)

Captain: "Expert on transformer attention variants, CS."
 -> sources = [openalex, semantic_scholar, unpaywall] (drop europe_pmc and biorxiv_medrxiv)

=== Audience inventory validation ===
fm-doc-audience-check: ok surfaces=70 local_links=253

=== Behavioral semantic validation ===
PASS: Workflow pipeline: 8 ordered steps validated (search->download->extract->dedupe->rank->cap->synthesize->seed)
PASS: Workflow branching: scout one-off vs persistent secondmate
PASS: Reusable substrates: arxiv-mcp-server (search_papers etc), pi-arxiv, paper-qa, reuse-first
PASS: Scout reference present
PASS: Adapter fields: endpoint/auth/rate_limit/quality/dedup_key/normalize()
PASS: Common record schema: title/authors/abstract/url/pdf_url/doi/year/citations/source/quality
PASS: v1 adapters: openalex, semantic_scholar, europe_pmc, biorxiv_medrxiv, unpaywall, crossref
PASS: Adapter endpoints validated
PASS: Quality tags peer_reviewed/preprint/mixed
PASS: Evidence-first synthesis: separate established/tentative, cite, license/quality, ranking, paper-qa grounding
PASS: Secondmate charter: idle by default, FM_SECONDMATE_CHARTER/SCOPE, seed commands, provisioning reference
PASS: Routing: main firstmate routes by scope to secondmate
PASS: Examples: default vs deep (20/50) and biomedical vs CS with source overrides
PASS: References: both scout reports + substrates/sources
PASS: AGENTS.md trigger pointer present
PASS: Inventory classification: agent-runtime
PASS: Conciseness check passed (heuristic)
PASS: No hard-coded constants: cap references paper_count param

ALL CHECKS PASSED - skill satisfies user intent declarative contract
```
</details>
<details>
<summary>Evidence: fm-doc-audience-check output</summary>

Source: [fm-doc-audience-check output](https://github.com/akashvacher/firstmate/blob/f3858007c05ad36f827d437ad265b3b8312a4141/.no-mistakes/evidence/fm/arxiv-niche-expert/fm-doc-audience-check.log)

```text
fm-doc-audience-check: ok surfaces=70 local_links=253
```
</details>
<details>
<summary>Evidence: fm-documentation-audiences test suite output</summary>

Source: [fm-documentation-audiences test suite output](https://github.com/akashvacher/firstmate/blob/f3858007c05ad36f827d437ad265b3b8312a4141/.no-mistakes/evidence/fm/arxiv-niche-expert/fm-documentation-audiences-test.log)

```text
ok - documentation inventory classifies every maintained prose surface exactly once
ok - classification, setup routing, and maintained-prose scope fail safely
ok - required documentation owner pointers cannot silently disappear
ok - local links resolve while dates, versions, commands, and incident prose remain semantically reviewed
```
</details>
<details>
<summary>Evidence: rendered skill — captain-facing HTML (visual evidence of prose surface)</summary>

Source: [rendered skill — captain-facing HTML (visual evidence of prose surface)](https://github.com/akashvacher/firstmate/blob/f3858007c05ad36f827d437ad265b3b8312a4141/.no-mistakes/evidence/fm/arxiv-niche-expert/skill-rendered.html)

```text
<!doctype html>
<html lang="en"><head><meta charset="utf-8"><title>arxiv-niche-expert — SKILL.md</title>
<meta name="viewport" content="width=device-width, initial-scale=1">
<style>
:root{ --blue:#3182ce; --gray:#718096; --bg:#f7fafc; }
body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif; max-width:880px; margin:0 auto; padding:40px 24px; line-height:1.65; color:#1a202c; background:white}
h1{font-size:28px; border-bottom:2px solid #e2e8f0; padding-bottom:10px; margin-top:0}
h2{font-size:20px; color:#2d3748; border-left:4px solid var(--blue); padding-left:12px; margin-top:36px}
code{background:#edf2f7; padding:1px 5px; border-radius:4px; font-size:88%; font-family:SFMono-Regular,Consolas,Monaco,monospace}
pre{background:#1a202c; color:#e2e8f0; padding:16px; border-radius:8px; overflow:auto; line-height:1.5; font-size:13px}
pre code{background:transparent; color:inherit; padding:0}
ul,ol{padding-left:24px}
li{margin:4px 0}
p{margin:8px 0}
hr{border:none; border-top:1px solid #e2e8f0; margin:32px 0}
.badge{display:inline-block; background:#ebf8ff; color:#2b6cb0; padding:2px 8px; border-radius:12px; font-size:12px; font-weight:600}
.meta{color:var(--gray); font-size:13px}
a{color:var(--blue)}
</style>
</head><body>
<div class="meta"><span class="badge">SKILL</span> .agents/skills/arxiv-niche-expert/SKILL.md &middot; agent-runtime &middot; internal</div>


<h1>arxiv-niche-expert</h1>

<p>Turn a topic, claim, or opinion into a persistent, evidence-backed niche expert.</p>
<p>The expert ingests papers, ranks them by relevance and citations, and answers ongoing questions with cited evidence.</p>

<p>This skill reuses existing substrates and is grounded in two scouts: <code>data/arxiv-skill-market/report.md</code> (reuse-first build; no existing tool offers a persistent per-niche expert or the 20/50 ingest modes) and <code>data/free-paper-sources/report.md</code> (free source set and the pluggable adapter model).</p>

<h2>Invocation</h2>

<p>The captain gives a subject and a mode, and firstmate runs this skill through a scout or a secondmate.</p>

<ul>
<li><code>topic</code> / <code>claim</code> / <code>opinion</code> - the subject or thesis to investigate.</li>
<li><code>mode</code> - <code>default</code> ingests <code>paper_count=20</code>; <code>deep</code> ingests <code>paper_count=50</code>.</li>
<li><code>sources</code> - optional ordered override of source adapters (defaults below).</li>

</ul>
<p>Run the skill as a scout for a one-off evidence briefing, or as a persistent secondmate for ongoing Q&amp;A.</p>

<h2>Parameters</h2>

<p><code>paper_count</code> and <code>sources</code> are parameters, not constants; 20 and 50 are defaults only.</p>

<ul>
<li><code>paper_count</code> (int) - cap on ingested papers after ranking; default 20, deep 50.</li>
<li><code>sources</code> (list of adapter ids) - ordered search/resolver adapters; default v1 set below.</li>
<li><code>topic</code> / <code>claim</code> / <code>opinion</code> (string) - the subject the expert covers.</li>

</ul>
<h2>Workflow</h2>

<p>Follow the pipeline in order, one stage per step.</p>

<ol>
<li>Search the enabled <code>sources</code> for the subject query.</li>
<li>Download the candidate papers through the substrate&#x27;s read tools.</li>
<ol>
<li>Extract title, authors, abstract, and key sections from each paper.</li>
<li>Dedupe records by <code>doi</code>, then by normalized <code>title</code> + <code>authors</code>.</li>
<ol>
<li>Rank the survivors by relevance, citations, and recency, with provenance.</li>
<li>Cap the ranked set to <code>paper_count</code>.</li>
<ol>
<li>Synthesize an evidence-backed briefing with inline citations.</li>
<li>Seed a per-niche secondmate home for ongoing Q&amp;A (see charter template).</li>

<p>For a one-off briefing, run steps 1-7 as a scout and stop at the report.</p>
<p>For an ongoing expert, run step 8 to seed the persistent secondmate.</p>

<h2>Reusable substrates (do not reinvent)</h2>

<p>Use a mature search/download/read substrate; never build PDF parsing or LaTeX extraction yourself.</p>

<ul>
<li><code>arxiv-mcp-server</code> (Apache-2.0 MCP server) - tools <code>search_papers</code>, <code>download_paper</code>, <code>read_paper</code> (bounded), <code>list_paper_latex_sections</code>, <code>get_paper_latex_section</code>, <code>citation_graph</code>, <code>semantic_search</code>; bundled prompts <code>literature_review</code>, <code>deep-paper-analysis</code>, <code>literature-synthesis</code>.</li>
</ul>
<p>  Reach it from any MCP-aware runtime (Pi/Codex/Claude).</p>
<ul>
<li><code>pi-arxiv</code> (MIT Pi extension) - <code>arxiv_search</code>, <code>arxiv_paper</code>, <code>arxiv_fetch2md</code> (Markdown via arxiv2md).</li>
</ul>
<p>  Install with <code>pi install npm:@wienerberliner/pi-arxiv</code>.</p>
<ul>
<li><code>paper-qa</code> (Apache-2.0) - citation-grounded RAG over PDFs; <code>pqa ask &quot;...&quot;</code> or the library API returns answers with inline citations such as <code>Author2011 pages 1-2</code>.</li>
</ul>
<p>  Use it for the persistent expert&#x27;s evidence-first discussion grounding.</p>

<p>The <code>arxiv-skill-market</code> scout recommends this reuse-first build over forking: the mechanics are licensed and maintained, while the persistent-expert behavior and 20/50 modes are the novel layer to add.</p>

<h2>Pluggable source adapters</h2>

<p>Model sources as adapters so each per-niche expert tunes coverage without code changes.</p>
<p><code>free-paper-sources</code> defines this model and the v1 set.</p>

<p>Each adapter declares the following fields:</p>

<ul>
<li><code>endpoint</code> (URL) - the source&#x27;s API base.</li>
<li><code>auth</code> (<code>none</code> | <code>email</code> | <code>api_key</code>) - use the matching value.</li>
<li><code>rate_limit</code> (calls/sec or calls/day) - honor it; add backoff.</li>
<li><code>quality</code> tag (<code>peer_reviewed</code> | <code>preprint</code> | <code>mixed</code>) - set per source.</li>
<li><code>dedup_key</code> - prefer <code>doi</code>; fall back to normalized <code>title</code> + <code>authors</code>.</li>
<li><code>normalize()</code> - map the source&#x27;s record to the common schema below.</li>

</ul>
<p>Common record schema:</p>

<pre><code>{
  &quot;title&quot;: &quot;...&quot;,
  &quot;authors&quot;: [&quot;...&quot;],
  &quot;abstract&quot;: &quot;...&quot;,
  &quot;url&quot;: &quot;...&quot;,
  &quot;pdf_url&quot;: &quot;...&quot;,
  &quot;doi&quot;: &quot;...&quot;,
  &quot;year&quot;: 2026,
  &quot;citations&quot;: 42,
  &quot;source&quot;: &quot;openalex&quot;,
  &quot;quality&quot;: &quot;peer_reviewed&quot;
}</code></pre>

<p>v1 default adapters (ordered):</p>

<ul>
<li><code>openalex</code> - backbone across all fields; free, no key at 20/50 scale; returns OA PDF links, citations, and concepts.</li>
</ul>
<p>  Endpoint <code>https://api.openalex.org/works</code>.</p>
<ul>
<li><code>semantic_scholar</code> - relevance/abstract/embedding layer; strong in CS/AI/bio.</li>
</ul>
<p>  Endpoint <code>https://api.semanticscholar.org/graph/v1/paper/search</code>; shared-rate-limit caveat, add backoff.</p>
<ul>
<li><code>europe_pmc</code> - biomedical/life-sciences depth: peer-reviewed plus 6.5M OA full text and a citation network.</li>
</ul>
<p>  Endpoint <code>https://www.ebi.ac.uk/europepmc/webservices/rest/search</code>.</p>
<ul>
<li><code>biorxiv_medrxiv</code> - newest biomedical/clinical preprints, before peer review.</li>
</ul>
<p>  Endpoint <code>https://api.biorxiv.org/details/{server}/{interval}/{cursor}/json</code>.</p>
<ul>
<li><code>unpaywall</code> - optional PDF resolver; given DOIs from the searchers, return the best free PDF URL.</li>
</ul>
<p>  Endpoint <code>https://api.unpaywall.org/v2/{DOI}</code>; requires <code>email</code> param; 100,000 calls/day.</p>
<ul>
<li><code>crossref</code> - internal dedup/metadata backbone only, not a user-facing searcher; most reliable DOI authority.</li>
</ul>
<p>  Endpoint <code>https://api.crossref.org/works</code>.</p>

<p>Per-niche experts override <code>sources</code> and <code>paper_count</code> by config: a molecular-biology expert may enable <code>europe_pmc</code> and <code>biorxiv_medrxiv</code> and drop the rest; a CS expert may lean on <code>semantic_scholar</code> and skip the biomedical sources.</p>
<p>No code change is needed.</p>

<h2>Evidence-first synthesis</h2>

<p>Enforce evidence-first output in the briefing and in every ongoing answer.</p>

<ul>
<li>Separate established findings from tentative claims.</li>
<li>Cite each claim inline with its source (DOI or title plus adapter).</li>
<li>Surface license and quality tags when the source provides them.</li>
<li>Rank by relevance, citations, and recency with provenance; do not present preprints as peer-reviewed.</li>
<li>Use <code>paper-qa</code> prompts to ground answers in retrieved text rather than model memory.</li>

</ul>
<h2>Per-niche secondmate charter (persistent expert)</h2>

<p>After the briefing, seed a persistent secondmate home for ongoing Q&amp;A.</p>
<p>The secondmate is idle by default and acts only when firstmate routes a topic to it.</p>
<p>Use <code>bin/fm-brief.sh &lt;niche-id&gt; --secondmate --no-projects</code>, fill the charter with <code>FM_SECONDMATE_CHARTER</code> and <code>FM_SECONDMATE_SCOPE</code>, then <code>bin/fm-home-seed.sh &lt;niche-id&gt; - --no-projects</code>.</p>
<p>See <code>secondmate-provisioning</code> for the full seed and launch contract.</p>

<p>Example charter and scope:</p>

<pre><code>export FM_SECONDMATE_CHARTER=&#x27;You are the persistent evidence-backed expert for &lt;niche&gt;. You ingested &lt;paper_count&gt; papers from &lt;sources&gt; on &lt;date&gt;. Answer ongoing questions about this niche with cited evidence, separating established findings from tentative claims, and surface license/quality when available. You are idle until firstmate routes a topic to you. Do not invent papers; cite only the ingested set and named external sources.&#x27;
export FM_SECONDMATE_SCOPE=&#x27;Ongoing evidence-backed Q&amp;A about &lt;niche&gt;: follow-up questions, claims to verify, and literature gaps, using the ingested paper set plus the named free sources.&#x27;</code></pre>

<h2>Routing from main firstmate</h2>

<p>When the captain asks an ongoing question about the niche, route it to the secondmate by scope (per <code>data/secondmates.md</code> and <code>secondmate-provisioning</code>).</p>
<p>The secondmate answers with cited evidence and stays available; it never initiates work on its own.</p>
<p>For a one-off briefing only, run the skill as a scout and stop after the report.</p>

<h2>Examples</h2>

<p>Default vs deep for the same subject:</p>

<pre><code>Captain: &quot;Build me an expert on retrieval-augmented retrieval, default mode.&quot;
→ sources = v1 default set, paper_count = 20, scout briefing then optional secondmate seed.

Captain: &quot;Same topic, deep dive.&quot;
→ paper_count = 50, same sources, deeper ingest before the briefing.</code></pre>

<p>Biomedical vs CS niche with different sources:</p>

<pre><code>Captain: &quot;Expert on mRNA vaccine delivery, biomedical.&quot;
→ sources = [openalex, semantic_scholar, europe_pmc, biorxiv_medrxiv, unpaywall], paper_count = 20.

Captain: &quot;Expert on transformer attention variants, CS.&quot;
→ sources = [openalex, semantic_scholar, unpaywall], paper_count = 20 (drop europe_pmc and biorxiv_medrxiv).</code></pre>

<h2>References</h2>

<ul>
<li><code>data/arxiv-skill-market/report.md</code> - reuse-first build recommendation; <code>arxiv-mcp-server</code> / <code>pi-arxiv</code> substrates; <code>paper-qa</code> evidence layer; no existing persistent-expert tool.</li>
<li><code>data/free-paper-sources/report.md</code> - v1 source set (OpenAlex, Semantic Scholar, Europe PMC, bioRxiv/medRxiv, Unpaywall) and the pluggable adapter model.</li>
<li><code>secondmate-provisioning</code> - secondmate charter, seed, and routing contract.</li>
</ul></ol>
<hr><p class="meta">Rendered from <code>.agents/skills/arxiv-niche-expert/SKILL.md</code> &mdash; this is the captain-facing evidence-backed expert skill. Default 20 papers, deep 50, pluggable sources, persistent secondmate.</p>
</body></html>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"682ea94cbbc9258afca72fdb35b4bfedfea41b89","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bin/fm-doc-audience-check.sh` — inventory ok surfaces=70 local_links=253</code>
- <code>`tests/fm-documentation-audiences.test.sh` — duplicate/setup/pointer/link checks</code>
- <code>`python3 /tmp/skill_behavioral_check.py` — semantic contract validation: frontmatter, invocation, parameters, 8-step workflow, reusable substrates (arxiv-mcp-server/pi-arxiv/paper-qa), pluggable adapters with endpoint/auth/rate_limit/quality/dedup_key/normalize() + common record schema, v1 defaults, evidence-first synthesis, secondmate charter with FM_SECONDMATE_CHARTER/SCOPE and routing, examples (default 20 vs deep 50 and biomedical vs CS), references to both scout reports, AGENTS.md trigger and paper_count/sources parameterization</code>
- <code>`bash /tmp/captain_invocation_demo.sh` — end-to-end captain flows (default/deep/biomedical/CS) transcript</code>
- <code>`skill-rendered.html` — rendered HTML artifact of the captain-facing skill</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
