### PR TITLE
fix: fail closed on missing teardown dependencies

### DIFF
--- a/bin/backends/cmux.sh
+++ b/bin/backends/cmux.sh
@@ -111,12 +111,14 @@ FM_BACKEND_CMUX_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-${FM_ROOT:-$FM_BACKEND_CMUX_ROOT}}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 
+[ -r "$FM_BACKEND_CMUX_ROOT/bin/fm-backend-hometag-lib.sh" ] || { printf '%s: missing required library: %s\n' "${BASH_SOURCE[0]}" "$FM_BACKEND_CMUX_ROOT/bin/fm-backend-hometag-lib.sh" >&2; exit 1; }
 # shellcheck source=bin/fm-backend-hometag-lib.sh
 . "$FM_BACKEND_CMUX_ROOT/bin/fm-backend-hometag-lib.sh"
 
 # Shared composer-content classifier (empty|pending|unknown, and the fleet-wide
 # dead-shell-vs-agent-composer rule). Owned by bin/fm-composer-lib.sh, reused by
 # every backend so the decision cannot drift.
+[ -r "$FM_BACKEND_CMUX_ROOT/bin/fm-composer-lib.sh" ] || { printf '%s: missing required library: %s\n' "${BASH_SOURCE[0]}" "$FM_BACKEND_CMUX_ROOT/bin/fm-composer-lib.sh" >&2; exit 1; }
 # shellcheck source=bin/fm-composer-lib.sh
 . "$FM_BACKEND_CMUX_ROOT/bin/fm-composer-lib.sh"
 

--- a/bin/backends/cmux.sh
+++ b/bin/backends/cmux.sh
@@ -107,7 +107,7 @@
 # sourcing fm-backend.sh (which sources this file); this exists only so this
 # file's own unit tests, which source it directly, resolve sanely. Mirrors
 # bin/backends/zellij.sh's identical fallback.
-FM_BACKEND_CMUX_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FM_BACKEND_CMUX_ROOT="${FM_BACKEND_DEFAULT_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
 FM_ROOT="${FM_ROOT_OVERRIDE:-${FM_ROOT:-$FM_BACKEND_CMUX_ROOT}}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -68,7 +68,7 @@
 # default (the firstmate repo root - never a secondmate home, so
 # fm_backend_herdr_workspace_label falls through to "firstmate" exactly like
 # pre-P3 behavior when a test does not care about home-specific labeling).
-FM_BACKEND_HERDR_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FM_BACKEND_HERDR_ROOT="${FM_BACKEND_DEFAULT_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
 FM_ROOT="${FM_ROOT_OVERRIDE:-${FM_ROOT:-$FM_BACKEND_HERDR_ROOT}}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -75,6 +75,7 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 # Shared composer-content classifier (empty|pending|unknown, and the fleet-wide
 # dead-shell-vs-agent-composer rule). Owned by bin/fm-composer-lib.sh, reused by
 # every backend so the decision cannot drift.
+[ -r "$FM_BACKEND_HERDR_ROOT/bin/fm-composer-lib.sh" ] || { printf '%s: missing required library: %s\n' "${BASH_SOURCE[0]}" "$FM_BACKEND_HERDR_ROOT/bin/fm-composer-lib.sh" >&2; exit 1; }
 # shellcheck source=bin/fm-composer-lib.sh
 . "$FM_BACKEND_HERDR_ROOT/bin/fm-composer-lib.sh"
 
@@ -83,6 +84,7 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 # subscriber (fm_backend_herdr_wait_transition) normalizes every
 # pane.agent_status_changed edge through fm_transition_record and routes it
 # through fm_transition_policy - it never re-encodes the mapping.
+[ -r "$FM_BACKEND_HERDR_ROOT/bin/fm-transition-lib.sh" ] || { printf '%s: missing required library: %s\n' "${BASH_SOURCE[0]}" "$FM_BACKEND_HERDR_ROOT/bin/fm-transition-lib.sh" >&2; exit 1; }
 # shellcheck source=bin/fm-transition-lib.sh
 . "$FM_BACKEND_HERDR_ROOT/bin/fm-transition-lib.sh"
 
@@ -2863,6 +2865,7 @@ fm_backend_herdr_kill() {  # <target>
   local session=$FM_BACKEND_HERDR_SESSION pane=$FM_BACKEND_HERDR_PANE
   local lock_path attempt=0 lock_held=0
   if ! declare -F fm_lock_try_acquire >/dev/null 2>&1; then
+    [ -r "$FM_BACKEND_HERDR_ROOT/bin/fm-wake-lib.sh" ] || { printf '%s: missing required library: %s\n' "${BASH_SOURCE[0]}" "$FM_BACKEND_HERDR_ROOT/bin/fm-wake-lib.sh" >&2; exit 1; }
     # shellcheck source=bin/fm-wake-lib.sh
     . "$FM_BACKEND_HERDR_ROOT/bin/fm-wake-lib.sh"
   fi

--- a/bin/backends/orca.sh
+++ b/bin/backends/orca.sh
@@ -9,6 +9,7 @@
 # Shared composer-content classifier (empty|pending|unknown, and the fleet-wide
 # dead-shell-vs-agent-composer rule). Owned by bin/fm-composer-lib.sh, reused by
 # every backend so the decision cannot drift.
+[ -r "$(dirname -- "${BASH_SOURCE[0]}")/../fm-composer-lib.sh" ] || { printf '%s: missing required library: %s\n' "${BASH_SOURCE[0]}" "$(dirname -- "${BASH_SOURCE[0]}")/../fm-composer-lib.sh" >&2; exit 1; }
 # shellcheck source=bin/fm-composer-lib.sh
 . "$(dirname -- "${BASH_SOURCE[0]}")/../fm-composer-lib.sh"
 

--- a/bin/backends/orca.sh
+++ b/bin/backends/orca.sh
@@ -9,9 +9,10 @@
 # Shared composer-content classifier (empty|pending|unknown, and the fleet-wide
 # dead-shell-vs-agent-composer rule). Owned by bin/fm-composer-lib.sh, reused by
 # every backend so the decision cannot drift.
-[ -r "$(dirname -- "${BASH_SOURCE[0]}")/../fm-composer-lib.sh" ] || { printf '%s: missing required library: %s\n' "${BASH_SOURCE[0]}" "$(dirname -- "${BASH_SOURCE[0]}")/../fm-composer-lib.sh" >&2; exit 1; }
+_FM_BACKEND_ORCA_LIB_DIR="${FM_BACKEND_LIB_DIR:-$(cd "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)}"
+[ -r "$_FM_BACKEND_ORCA_LIB_DIR/fm-composer-lib.sh" ] || { printf '%s: missing required library: %s\n' "${BASH_SOURCE[0]}" "$_FM_BACKEND_ORCA_LIB_DIR/fm-composer-lib.sh" >&2; exit 1; }
 # shellcheck source=bin/fm-composer-lib.sh
-. "$(dirname -- "${BASH_SOURCE[0]}")/../fm-composer-lib.sh"
+. "$_FM_BACKEND_ORCA_LIB_DIR/fm-composer-lib.sh"
 
 fm_backend_orca_tool_check() {
   command -v orca >/dev/null 2>&1 || { echo "error: backend=orca selected but the 'orca' CLI is not installed" >&2; return 1; }

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -18,10 +18,13 @@
 # (bin/fm-supervise-daemon.sh); this adapter sources that file and re-exports
 # its submit core under the backend's naming convention rather than
 # duplicating it, so the two consumers cannot drift apart.
+[ -r "$FM_BACKEND_LIB_DIR/fm-tmux-lib.sh" ] || { printf '%s: missing required library: %s\n' "${BASH_SOURCE[0]}" "$FM_BACKEND_LIB_DIR/fm-tmux-lib.sh" >&2; exit 1; }
 # shellcheck source=bin/fm-tmux-lib.sh
 . "$FM_BACKEND_LIB_DIR/fm-tmux-lib.sh"
+[ -r "$FM_BACKEND_LIB_DIR/fm-session-lock-lib.sh" ] || { printf '%s: missing required library: %s\n' "${BASH_SOURCE[0]}" "$FM_BACKEND_LIB_DIR/fm-session-lock-lib.sh" >&2; exit 1; }
 # shellcheck source=bin/fm-session-lock-lib.sh
 . "$FM_BACKEND_LIB_DIR/fm-session-lock-lib.sh"
+[ -r "$FM_BACKEND_LIB_DIR/fm-cursor-lib.sh" ] || { printf '%s: missing required library: %s\n' "${BASH_SOURCE[0]}" "$FM_BACKEND_LIB_DIR/fm-cursor-lib.sh" >&2; exit 1; }
 # shellcheck source=bin/fm-cursor-lib.sh
 . "$FM_BACKEND_LIB_DIR/fm-cursor-lib.sh"
 

--- a/bin/backends/zellij.sh
+++ b/bin/backends/zellij.sh
@@ -116,11 +116,13 @@ FM_BACKEND_ZELLIJ_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-${FM_ROOT:-$FM_BACKEND_ZELLIJ_ROOT}}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 
+[ -r "$FM_BACKEND_ZELLIJ_ROOT/bin/fm-backend-hometag-lib.sh" ] || { printf '%s: missing required library: %s\n' "${BASH_SOURCE[0]}" "$FM_BACKEND_ZELLIJ_ROOT/bin/fm-backend-hometag-lib.sh" >&2; exit 1; }
 # shellcheck source=bin/fm-backend-hometag-lib.sh
 . "$FM_BACKEND_ZELLIJ_ROOT/bin/fm-backend-hometag-lib.sh"
 
 # Shared composer classification (the fleet-wide shape catalogue and verdict
 # owner; this adapter contributes only capture and capability facts).
+[ -r "$FM_BACKEND_ZELLIJ_ROOT/bin/fm-composer-lib.sh" ] || { printf '%s: missing required library: %s\n' "${BASH_SOURCE[0]}" "$FM_BACKEND_ZELLIJ_ROOT/bin/fm-composer-lib.sh" >&2; exit 1; }
 # shellcheck source=bin/fm-composer-lib.sh
 . "$FM_BACKEND_ZELLIJ_ROOT/bin/fm-composer-lib.sh"
 

--- a/bin/backends/zellij.sh
+++ b/bin/backends/zellij.sh
@@ -112,7 +112,7 @@
 # has no per-home CONTAINER split (one shared session for every home), but
 # FM_HOME/FM_ROOT now also feed fm_backend_zellij_home_label's tab-title tag
 # below.
-FM_BACKEND_ZELLIJ_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FM_BACKEND_ZELLIJ_ROOT="${FM_BACKEND_DEFAULT_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
 FM_ROOT="${FM_ROOT_OVERRIDE:-${FM_ROOT:-$FM_BACKEND_ZELLIJ_ROOT}}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -588,6 +588,33 @@ fm_backend_expected_label_of_selector() {  # <raw-target> <state-dir>
   return 0
 }
 
+# Source one adapter file, at most once per shell, failing rather than exiting
+# when it is missing.
+#
+# Stock macOS Bash 3.2 - what /usr/bin/env bash resolves to on the machines this
+# fleet runs on - terminates the whole shell when `.` cannot find its file, and
+# does so with status 0. It ignores both the `|| return 1` written beside the
+# source and the `if !` the caller wrapped the call in. A missing adapter would
+# therefore end fm-teardown.sh mid-run while reporting success, so the caller
+# records a task as cleaned up when nothing was cleaned up and the safety
+# refusal it was about to print never appears. Bash 5 returns 1 as written,
+# which is why CI's Linux lanes never saw it. Testing the file first makes the
+# missing adapter a refusable error on every supported Bash.
+# The guard is read and written through eval because this file is also sourced
+# from zsh, where bash's ${!var} indirection and printf -v mean something else
+# or nothing at all. Guard names are literals from this file's own call sites.
+# Verified 2026-08-18 against GNU bash 3.2.57(1)-release (arm64-apple-darwin25)
+# and pinned by tests/fm-backend.test.sh.
+fm_backend_source_adapter_once() {  # <guard-var> <adapter-file>
+  local guard=$1 file=$2 loaded
+  eval "loaded=\${$guard:-}"
+  [ -z "$loaded" ] || return 0
+  [ -r "$file" ] || return 1
+  # shellcheck source=/dev/null
+  . "$file" || return 1
+  eval "$guard=1"
+}
+
 # fm_backend_source: source the named backend's adapter file, once per shell.
 # Each adapter is an independently linted canonical root. The /dev/null source
 # boundaries keep runtime dispatch from importing all five adapter ASTs into
@@ -597,39 +624,19 @@ fm_backend_source() {  # <name>
   fm_backend_validate "$name" || return 1
   case "$name" in
     tmux)
-      if [ -z "${_FM_BACKEND_TMUX_SOURCED:-}" ]; then
-        # shellcheck source=/dev/null
-        . "$FM_BACKEND_LIB_DIR/backends/tmux.sh" || return 1
-        _FM_BACKEND_TMUX_SOURCED=1
-      fi
+      fm_backend_source_adapter_once _FM_BACKEND_TMUX_SOURCED "$FM_BACKEND_LIB_DIR/backends/tmux.sh" || return 1
       ;;
     herdr)
-      if [ -z "${_FM_BACKEND_HERDR_SOURCED:-}" ]; then
-        # shellcheck source=/dev/null
-        . "$FM_BACKEND_LIB_DIR/backends/herdr.sh" || return 1
-        _FM_BACKEND_HERDR_SOURCED=1
-      fi
+      fm_backend_source_adapter_once _FM_BACKEND_HERDR_SOURCED "$FM_BACKEND_LIB_DIR/backends/herdr.sh" || return 1
       ;;
     zellij)
-      if [ -z "${_FM_BACKEND_ZELLIJ_SOURCED:-}" ]; then
-        # shellcheck source=/dev/null
-        . "$FM_BACKEND_LIB_DIR/backends/zellij.sh" || return 1
-        _FM_BACKEND_ZELLIJ_SOURCED=1
-      fi
+      fm_backend_source_adapter_once _FM_BACKEND_ZELLIJ_SOURCED "$FM_BACKEND_LIB_DIR/backends/zellij.sh" || return 1
       ;;
     orca)
-      if [ -z "${_FM_BACKEND_ORCA_SOURCED:-}" ]; then
-        # shellcheck source=/dev/null
-        . "$FM_BACKEND_LIB_DIR/backends/orca.sh" || return 1
-        _FM_BACKEND_ORCA_SOURCED=1
-      fi
+      fm_backend_source_adapter_once _FM_BACKEND_ORCA_SOURCED "$FM_BACKEND_LIB_DIR/backends/orca.sh" || return 1
       ;;
     cmux)
-      if [ -z "${_FM_BACKEND_CMUX_SOURCED:-}" ]; then
-        # shellcheck source=/dev/null
-        . "$FM_BACKEND_LIB_DIR/backends/cmux.sh" || return 1
-        _FM_BACKEND_CMUX_SOURCED=1
-      fi
+      fm_backend_source_adapter_once _FM_BACKEND_CMUX_SOURCED "$FM_BACKEND_LIB_DIR/backends/cmux.sh" || return 1
       ;;
   esac
 }

--- a/bin/fm-public-followup-lib.sh
+++ b/bin/fm-public-followup-lib.sh
@@ -54,6 +54,7 @@
 # those remain that file's contract and are not restated here.
 
 _FM_PF_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null)" || _FM_PF_LIB_DIR="."
+[ -r "$_FM_PF_LIB_DIR/fm-x-lib.sh" ] || { printf '%s: missing required library: %s\n' "${BASH_SOURCE[0]}" "$_FM_PF_LIB_DIR/fm-x-lib.sh" >&2; exit 1; }
 # shellcheck source=bin/fm-x-lib.sh
 . "$_FM_PF_LIB_DIR/fm-x-lib.sh"
 

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -13,6 +13,7 @@
 # cursor-agent and the far-too-generic legacy alias `agent`, and it runs as a
 # bundled node script. bin/fm-cursor-lib.sh is the fleet's single owner of that
 # decision, so this file delegates to it rather than widening the name match.
+[ -r "$(dirname -- "${BASH_SOURCE[0]}")/fm-cursor-lib.sh" ] || { printf '%s: missing required library: %s\n' "${BASH_SOURCE[0]}" "$(dirname -- "${BASH_SOURCE[0]}")/fm-cursor-lib.sh" >&2; exit 1; }
 # shellcheck source=bin/fm-cursor-lib.sh
 . "$(dirname -- "${BASH_SOURCE[0]}")/fm-cursor-lib.sh"
 

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -13,9 +13,10 @@
 # cursor-agent and the far-too-generic legacy alias `agent`, and it runs as a
 # bundled node script. bin/fm-cursor-lib.sh is the fleet's single owner of that
 # decision, so this file delegates to it rather than widening the name match.
-[ -r "$(dirname -- "${BASH_SOURCE[0]}")/fm-cursor-lib.sh" ] || { printf '%s: missing required library: %s\n' "${BASH_SOURCE[0]}" "$(dirname -- "${BASH_SOURCE[0]}")/fm-cursor-lib.sh" >&2; exit 1; }
+_FM_SESSION_LOCK_LIB_DIR="${FM_BACKEND_LIB_DIR:-$(cd "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)}"
+[ -r "$_FM_SESSION_LOCK_LIB_DIR/fm-cursor-lib.sh" ] || { printf '%s: missing required library: %s\n' "${BASH_SOURCE[0]}" "$_FM_SESSION_LOCK_LIB_DIR/fm-cursor-lib.sh" >&2; exit 1; }
 # shellcheck source=bin/fm-cursor-lib.sh
-. "$(dirname -- "${BASH_SOURCE[0]}")/fm-cursor-lib.sh"
+. "$_FM_SESSION_LOCK_LIB_DIR/fm-cursor-lib.sh"
 
 # Known harness command names; extend when a new adapter is verified.
 FM_HARNESS_RE='claude|codex|opencode|grok|kimi|^pi$|^pi-signed$'

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -2163,7 +2163,23 @@ $session	$lock_path"
   return 1
 }
 
-preflight_firstmate_home_herdr_children() {  # <home>
+teardown_backend_preflight() {  # <backend> <task-id> <home>
+  local backend=$1 task_id=$2 home=$3
+  if (
+    unset FM_ROOT_OVERRIDE
+    unset _FM_BACKEND_TMUX_SOURCED _FM_BACKEND_HERDR_SOURCED _FM_BACKEND_ZELLIJ_SOURCED
+    unset _FM_BACKEND_ORCA_SOURCED _FM_BACKEND_CMUX_SOURCED
+    FM_HOME=$home
+    FM_ROOT=$home
+    fm_backend_source "$backend"
+  ); then
+    return 0
+  fi
+  echo "REFUSED: backend '$backend' required by task $task_id cannot be loaded; nothing was changed - restore its adapter and required libraries, then rerun teardown" >&2
+  return 1
+}
+
+preflight_firstmate_home_backend_children() {  # <home>
   local home=$1 sub_state child_meta child_id child_backend child_target child_kind child_home child_wt
   sub_state="$home/state"
   [ -d "$sub_state" ] || return 0
@@ -2173,6 +2189,7 @@ preflight_firstmate_home_herdr_children() {  # <home>
     fm_backend_validate_task_endpoint "$child_meta" "$child_id" || return 1
     child_backend=$FM_BACKEND_VALIDATED_BACKEND
     child_target=$FM_BACKEND_VALIDATED_TARGET
+    teardown_backend_preflight "$child_backend" "$child_id" "$home" || return 1
     if [ "$child_backend" = herdr ]; then
       teardown_herdr_preflight_target "$child_target" "$child_id" || return 1
     fi
@@ -2182,7 +2199,7 @@ preflight_firstmate_home_herdr_children() {  # <home>
       child_wt=$(meta_value "$child_meta" worktree)
       child_home=$(meta_value "$child_meta" home)
       [ -n "$child_home" ] || child_home=$child_wt
-      preflight_firstmate_home_herdr_children "$child_home" || return 1
+      preflight_firstmate_home_backend_children "$child_home" || return 1
     fi
   done
 }
@@ -2293,6 +2310,7 @@ remove_secondmate_registry_entry() {
 }
 
 validate_pr_poll_cleanup "$STATE" "$ID" || exit 1
+teardown_backend_preflight "$BACKEND" "$ID" "$FM_HOME" || exit 1
 
 if [ "$KIND" = secondmate ]; then
   [ -n "$HOME_PATH" ] || HOME_PATH=$WT
@@ -2304,7 +2322,7 @@ if [ "$KIND" = secondmate ]; then
     if [ "$BACKEND" = herdr ]; then
       teardown_herdr_preflight_target "$T" "$ID" || exit 1
     fi
-    preflight_firstmate_home_herdr_children "$HOME_PATH" || exit 1
+    preflight_firstmate_home_backend_children "$HOME_PATH" || exit 1
   fi
 fi
 

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -2173,9 +2173,7 @@ teardown_backend_preflight() {  # <backend> <task-id> <home>
     unset FM_ROOT_OVERRIDE
     unset _FM_BACKEND_TMUX_SOURCED _FM_BACKEND_HERDR_SOURCED _FM_BACKEND_ZELLIJ_SOURCED
     unset _FM_BACKEND_ORCA_SOURCED _FM_BACKEND_CMUX_SOURCED
-    FM_HOME=$home
-    FM_ROOT=$home
-    fm_backend_source "$backend"
+    FM_HOME=$home FM_ROOT=$home fm_backend_source "$backend"
   ); then
     return 0
   fi

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -144,28 +144,40 @@ CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 SECONDMATE_REG="$DATA/secondmates.md"
 SUB_HOME_MARKER=".fm-secondmate-home"
 SUB_HOME_PARENT_MARKER=".fm-secondmate-parent"
+[ -r "$SCRIPT_DIR/fm-tasks-axi-lib.sh" ] || { printf '%s: missing required library: %s\n' "${BASH_SOURCE[0]}" "$SCRIPT_DIR/fm-tasks-axi-lib.sh" >&2; exit 1; }
 # shellcheck source=bin/fm-tasks-axi-lib.sh
 . "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
+[ -r "$SCRIPT_DIR/fm-backend.sh" ] || { printf '%s: missing required library: %s\n' "${BASH_SOURCE[0]}" "$SCRIPT_DIR/fm-backend.sh" >&2; exit 1; }
 # shellcheck source=bin/fm-backend.sh
 . "$SCRIPT_DIR/fm-backend.sh"
+[ -r "$SCRIPT_DIR/fm-control-lib.sh" ] || { printf '%s: missing required library: %s\n' "${BASH_SOURCE[0]}" "$SCRIPT_DIR/fm-control-lib.sh" >&2; exit 1; }
 # shellcheck source=bin/fm-control-lib.sh
 . "$SCRIPT_DIR/fm-control-lib.sh"
+[ -r "$SCRIPT_DIR/fm-lock-lib.sh" ] || { printf '%s: missing required library: %s\n' "${BASH_SOURCE[0]}" "$SCRIPT_DIR/fm-lock-lib.sh" >&2; exit 1; }
 # shellcheck source=bin/fm-lock-lib.sh
 . "$SCRIPT_DIR/fm-lock-lib.sh"
+[ -r "$SCRIPT_DIR/fm-classify-lib.sh" ] || { printf '%s: missing required library: %s\n' "${BASH_SOURCE[0]}" "$SCRIPT_DIR/fm-classify-lib.sh" >&2; exit 1; }
 # shellcheck source=bin/fm-classify-lib.sh
 . "$SCRIPT_DIR/fm-classify-lib.sh"
+[ -r "$SCRIPT_DIR/fm-gate-refuse-lib.sh" ] || { printf '%s: missing required library: %s\n' "${BASH_SOURCE[0]}" "$SCRIPT_DIR/fm-gate-refuse-lib.sh" >&2; exit 1; }
 # shellcheck source=bin/fm-gate-refuse-lib.sh
 . "$SCRIPT_DIR/fm-gate-refuse-lib.sh"
+[ -r "$SCRIPT_DIR/fm-pr-lib.sh" ] || { printf '%s: missing required library: %s\n' "${BASH_SOURCE[0]}" "$SCRIPT_DIR/fm-pr-lib.sh" >&2; exit 1; }
 # shellcheck source=bin/fm-pr-lib.sh
 . "$SCRIPT_DIR/fm-pr-lib.sh"
+[ -r "$SCRIPT_DIR/fm-public-followup-lib.sh" ] || { printf '%s: missing required library: %s\n' "${BASH_SOURCE[0]}" "$SCRIPT_DIR/fm-public-followup-lib.sh" >&2; exit 1; }
 # shellcheck source=bin/fm-public-followup-lib.sh
 . "$SCRIPT_DIR/fm-public-followup-lib.sh"
+[ -r "$SCRIPT_DIR/fm-secondmate-registry-lib.sh" ] || { printf '%s: missing required library: %s\n' "${BASH_SOURCE[0]}" "$SCRIPT_DIR/fm-secondmate-registry-lib.sh" >&2; exit 1; }
 # shellcheck source=bin/fm-secondmate-registry-lib.sh
 . "$SCRIPT_DIR/fm-secondmate-registry-lib.sh"
+[ -r "$SCRIPT_DIR/fm-secondmate-parent-lib.sh" ] || { printf '%s: missing required library: %s\n' "${BASH_SOURCE[0]}" "$SCRIPT_DIR/fm-secondmate-parent-lib.sh" >&2; exit 1; }
 # shellcheck source=bin/fm-secondmate-parent-lib.sh
 . "$SCRIPT_DIR/fm-secondmate-parent-lib.sh"
+[ -r "$SCRIPT_DIR/fm-wake-lib.sh" ] || { printf '%s: missing required library: %s\n' "${BASH_SOURCE[0]}" "$SCRIPT_DIR/fm-wake-lib.sh" >&2; exit 1; }
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
+[ -r "$SCRIPT_DIR/fm-nm-run-lib.sh" ] || { printf '%s: missing required library: %s\n' "${BASH_SOURCE[0]}" "$SCRIPT_DIR/fm-nm-run-lib.sh" >&2; exit 1; }
 # shellcheck source=bin/fm-nm-run-lib.sh
 . "$SCRIPT_DIR/fm-nm-run-lib.sh"
 if [ "$#" -lt 1 ] || ! fm_task_id_path_safe "$1"; then
@@ -174,6 +186,7 @@ if [ "$#" -lt 1 ] || ! fm_task_id_path_safe "$1"; then
 fi
 ID=$1
 FORCE=${2:-}
+[ -r "$SCRIPT_DIR/fm-wake-lib.sh" ] || { printf '%s: missing required library: %s\n' "${BASH_SOURCE[0]}" "$SCRIPT_DIR/fm-wake-lib.sh" >&2; exit 1; }
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
 CONTROL_LOCK="$STATE/.control-$ID.lock"
@@ -2081,6 +2094,7 @@ teardown_herdr_require_prerequisites() {  # <task-id>
     fi
   done
   if ! declare -F fm_lock_try_acquire >/dev/null 2>&1; then
+    [ -r "$SCRIPT_DIR/fm-wake-lib.sh" ] || { printf '%s: missing required library: %s\n' "${BASH_SOURCE[0]}" "$SCRIPT_DIR/fm-wake-lib.sh" >&2; exit 1; }
     # shellcheck source=bin/fm-wake-lib.sh
     . "$SCRIPT_DIR/fm-wake-lib.sh"
   fi

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -54,6 +54,10 @@
 # the retired home. Removing a leased home releases its durable treehouse lease so the pool slot is freed,
 # never left leased forever. If the treehouse return fails, teardown leaves the
 # leased home and state in place instead of hiding a still-held lease.
+# Before any destructive change, teardown must load the task's recorded backend
+# adapter and its required sibling libraries. A missing or unreadable file
+# produces a named, non-zero refusal with the task state intact. Forced
+# secondmate teardown applies the same preflight recursively to every descendant.
 # Usage: fm-teardown.sh <task-id> [--force]
 #   --force skips ordinary-task dirty and landed-work checks, skips scout report
 #   checks, and discards secondmate child work for kind=secondmate. Only use it

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -41,12 +41,13 @@
 # probe, and the capability descriptor - plus the busy detection and submit
 # cores that consume the shared verdict.
 
-[ -r "$(dirname -- "${BASH_SOURCE[0]}")/fm-composer-lib.sh" ] || { printf '%s: missing required library: %s\n' "${BASH_SOURCE[0]}" "$(dirname -- "${BASH_SOURCE[0]}")/fm-composer-lib.sh" >&2; exit 1; }
+_FM_TMUX_LIB_DIR="${FM_BACKEND_LIB_DIR:-$(cd "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)}"
+[ -r "$_FM_TMUX_LIB_DIR/fm-composer-lib.sh" ] || { printf '%s: missing required library: %s\n' "${BASH_SOURCE[0]}" "$_FM_TMUX_LIB_DIR/fm-composer-lib.sh" >&2; exit 1; }
 # shellcheck source=bin/fm-composer-lib.sh
-. "$(dirname -- "${BASH_SOURCE[0]}")/fm-composer-lib.sh"
-[ -r "$(dirname -- "${BASH_SOURCE[0]}")/fm-cursor-lib.sh" ] || { printf '%s: missing required library: %s\n' "${BASH_SOURCE[0]}" "$(dirname -- "${BASH_SOURCE[0]}")/fm-cursor-lib.sh" >&2; exit 1; }
+. "$_FM_TMUX_LIB_DIR/fm-composer-lib.sh"
+[ -r "$_FM_TMUX_LIB_DIR/fm-cursor-lib.sh" ] || { printf '%s: missing required library: %s\n' "${BASH_SOURCE[0]}" "$_FM_TMUX_LIB_DIR/fm-cursor-lib.sh" >&2; exit 1; }
 # shellcheck source=bin/fm-cursor-lib.sh
-. "$(dirname -- "${BASH_SOURCE[0]}")/fm-cursor-lib.sh"
+. "$_FM_TMUX_LIB_DIR/fm-cursor-lib.sh"
 
 
 # fm_tmux_strip_ghost: thin adapter over the shared, fleet-wide ghost extractor

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -41,8 +41,10 @@
 # probe, and the capability descriptor - plus the busy detection and submit
 # cores that consume the shared verdict.
 
+[ -r "$(dirname -- "${BASH_SOURCE[0]}")/fm-composer-lib.sh" ] || { printf '%s: missing required library: %s\n' "${BASH_SOURCE[0]}" "$(dirname -- "${BASH_SOURCE[0]}")/fm-composer-lib.sh" >&2; exit 1; }
 # shellcheck source=bin/fm-composer-lib.sh
 . "$(dirname -- "${BASH_SOURCE[0]}")/fm-composer-lib.sh"
+[ -r "$(dirname -- "${BASH_SOURCE[0]}")/fm-cursor-lib.sh" ] || { printf '%s: missing required library: %s\n' "${BASH_SOURCE[0]}" "$(dirname -- "${BASH_SOURCE[0]}")/fm-cursor-lib.sh" >&2; exit 1; }
 # shellcheck source=bin/fm-cursor-lib.sh
 . "$(dirname -- "${BASH_SOURCE[0]}")/fm-cursor-lib.sh"
 

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -503,6 +503,39 @@ test_backend_source_shell_portable() {
   pass "bash: fm_backend_source recognizes known backends and rejects unknown ones"
 }
 
+test_backend_source_missing_adapter_is_refusable() {
+  local root out rc backend
+  # A missing adapter file must reach the caller as a failed call it can refuse
+  # on - not as the death of the calling shell. Stock macOS Bash 3.2 terminates
+  # the whole shell (with status 0) when `.` cannot find its file, ignoring both
+  # the `|| return 1` and the `if !` around it, which silently turned
+  # fm-teardown.sh's herdr preflight refusal into a reported success. Bash 5
+  # returns 1 as written, so this case only ever fails on the stock macOS Bash
+  # the fleet actually runs on.
+  root="$TMP_ROOT/missing-adapter"
+  rm -rf "$root"
+  mkdir -p "$root"
+  cp -R "$ROOT/bin" "$root/bin"
+  for backend in tmux herdr zellij orca cmux; do
+    rm -f "$root/bin/backends/$backend.sh"
+  done
+  for backend in tmux herdr zellij orca cmux; do
+    rc=0
+    out=$(bash -c "
+      set -eu
+      . '$root/bin/fm-backend.sh'
+      if fm_backend_source $backend; then echo LOADED; else echo REFUSED; fi
+      echo CALLER-SURVIVED
+    " 2>/dev/null) || rc=$?
+    expect_code 0 "$rc" "fm_backend_source $backend: the caller should keep control"
+    assert_contains "$out" "REFUSED" \
+      "fm_backend_source $backend: a missing adapter must be a failed call, not a load"
+    assert_contains "$out" "CALLER-SURVIVED" \
+      "fm_backend_source $backend: a missing adapter must not terminate the calling shell"
+  done
+  pass "fm_backend_source: a missing adapter fails the call instead of killing the caller"
+}
+
 test_backend_validate_spawn_accepts_orca() {
   local out
   fm_backend_validate_spawn tmux 2>/dev/null || fail "fm_backend_validate_spawn should accept tmux"
@@ -1126,6 +1159,7 @@ test_backend_name_autodetect_notice
 test_backend_name_explicit_beats_detection
 test_backend_validate_refuses_unknown
 test_backend_source_shell_portable
+test_backend_source_missing_adapter_is_refusable
 test_backend_validate_spawn_accepts_orca
 test_meta_get_and_backend_of_meta
 test_resolve_selector_three_forms

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -479,17 +479,19 @@ test_backend_validate_refuses_unknown() {
 }
 
 test_backend_source_shell_portable() {
-  local out status
+  local out status backend
   # zsh does not word-split unquoted expansions; sourcing fm-backend.sh from
   # an interactive zsh session must still recognize known backend names.
   if command -v zsh >/dev/null 2>&1; then
-    zsh -c "cd '$ROOT' && source bin/fm-backend.sh && fm_backend_source herdr && whence -w fm_backend_herdr_capture >/dev/null" 2>/dev/null \
-      || fail "zsh: fm_backend_source herdr should load the adapter when sourced"
+    for backend in tmux herdr zellij orca cmux; do
+      zsh -c "cd '$ROOT' && source bin/fm-backend.sh && fm_backend_source $backend && whence -w fm_backend_${backend}_capture >/dev/null" 2>/dev/null \
+        || fail "zsh: fm_backend_source $backend should load the adapter when sourced"
+    done
     out=$(zsh -c "cd '$ROOT' && source bin/fm-backend.sh && fm_backend_source bogus" 2>&1) \
       && fail "zsh: fm_backend_source bogus should fail"
     assert_contains "$out" "unknown backend 'bogus'" \
       "zsh: fm_backend_source did not reject bogus with the expected error"
-    pass "zsh: fm_backend_source recognizes known backends and rejects unknown ones"
+    pass "zsh: fm_backend_source loads every known backend and rejects unknown ones"
   else
     pass "zsh: shell-portable backend matching skipped (zsh not found)"
   fi

--- a/tests/fm-gotmp.test.sh
+++ b/tests/fm-gotmp.test.sh
@@ -58,6 +58,10 @@ make_fake_root() {
   ln -s "$ROOT/bin/backends/tmux.sh" "$fake/bin/backends/tmux.sh"
   ln -s "$ROOT/bin/fm-tmux-lib.sh" "$fake/bin/fm-tmux-lib.sh"
   ln -s "$ROOT/bin/fm-composer-lib.sh" "$fake/bin/fm-composer-lib.sh"
+  # backends/tmux.sh sources both of these at its top level, so a fake root
+  # without them makes teardown die inside fm_backend_kill.
+  ln -s "$ROOT/bin/fm-session-lock-lib.sh" "$fake/bin/fm-session-lock-lib.sh"
+  ln -s "$ROOT/bin/fm-cursor-lib.sh" "$fake/bin/fm-cursor-lib.sh"
   ln -s "$ROOT/bin/fm-nm-run-lib.sh" "$fake/bin/fm-nm-run-lib.sh"
   # fm-lock-lib.sh: teardown sources it for the shared lock-staleness proof.
   ln -s "$ROOT/bin/fm-lock-lib.sh" "$fake/bin/fm-lock-lib.sh"
@@ -139,6 +143,10 @@ test_teardown_skips_gracefully_without_tasktmp() {
   ln -s "$ROOT/bin/backends/tmux.sh" "$fake/bin/backends/tmux.sh"
   ln -s "$ROOT/bin/fm-tmux-lib.sh" "$fake/bin/fm-tmux-lib.sh"
   ln -s "$ROOT/bin/fm-composer-lib.sh" "$fake/bin/fm-composer-lib.sh"
+  # backends/tmux.sh sources both of these at its top level, so a fake root
+  # without them makes teardown die inside fm_backend_kill.
+  ln -s "$ROOT/bin/fm-session-lock-lib.sh" "$fake/bin/fm-session-lock-lib.sh"
+  ln -s "$ROOT/bin/fm-cursor-lib.sh" "$fake/bin/fm-cursor-lib.sh"
   ln -s "$ROOT/bin/fm-nm-run-lib.sh" "$fake/bin/fm-nm-run-lib.sh"
   ln -s "$ROOT/bin/fm-lock-lib.sh" "$fake/bin/fm-lock-lib.sh"
   ln -s "$ROOT/bin/fm-control-lib.sh" "$fake/bin/fm-control-lib.sh"
@@ -198,6 +206,51 @@ test_teardown_skips_gracefully_when_dir_missing() {
   pass "fm-teardown skips gracefully when tasktmp= points to a nonexistent dir"
 }
 
+# A missing sibling library must fail LOUDLY, never silently.
+#
+# Stock macOS Bash 3.2 terminates the whole script when `.` cannot find its file,
+# and does so with status 0. Teardown therefore used to die partway - after the
+# safety checks, before removing the tasktmp - while reporting success to its
+# caller, which then recorded the task as cleaned up. Bash 5 returns 1 instead,
+# so this only ever bit on the Bash that macOS ships by default. The guard beside
+# each source turns that into a named, non-zero refusal on every Bash.
+test_teardown_refuses_loudly_when_a_library_is_missing() {
+  local id=td-miss-z2
+  local task_tmp="$TMP_ROOT/fm-$id"
+  mkdir -p "$task_tmp/gotmp"
+  local fake err rc
+  fake=$(make_fake_root "$id" "$task_tmp")
+  # Remove a library fm-teardown.sh sources directly at top level. A library
+  # reached through a best-effort call site would refuse just as loudly, but that
+  # site discards stderr, so this one keeps the diagnostic observable.
+  rm -f "$fake/bin/fm-nm-run-lib.sh"
+  err="$fake/refusal.err"
+  rc=0
+  FM_HOME="$fake" bash "$fake/bin/fm-teardown.sh" "$id" >/dev/null 2>"$err" || rc=$?
+  [ "$rc" -ne 0 ] \
+    || fail "teardown reported success with a missing library (silent truncation, rc=$rc)"
+  grep -q "missing required library" "$err" \
+    || fail "teardown did not name the missing library"$'\n'"$(cat "$err")"
+  pass "fm-teardown refuses loudly when a sourced library is missing"
+}
+
+test_zellij_destructive_path_refuses_loudly_when_a_sibling_is_missing() {
+  local fake="$TMP_ROOT/zellij-missing-sibling"
+  local fake_abs err rc=0
+  mkdir -p "$fake/bin/backends"
+  fake_abs=$(cd "$fake" && pwd)
+  err="$fake/refusal.err"
+  ln -s "$ROOT/bin/backends/zellij.sh" "$fake/bin/backends/zellij.sh"
+  FM_HOME="$fake" bash -c ". '$fake/bin/backends/zellij.sh'" 2>"$err" || rc=$?
+  [ "$rc" -ne 0 ] \
+    || fail "zellij adapter reported success with a missing destructive-path sibling (rc=$rc)"
+  grep -Fq "missing required library: $fake_abs/bin/fm-backend-hometag-lib.sh" "$err" \
+    || fail "zellij adapter did not name the missing destructive-path sibling"$'\n'"$(cat "$err")"
+  pass "zellij adapter refuses loudly when a destructive-path sibling is missing"
+}
+
 test_teardown_removes_tasktmp_dir
 test_teardown_skips_gracefully_without_tasktmp
 test_teardown_skips_gracefully_when_dir_missing
+test_teardown_refuses_loudly_when_a_library_is_missing
+test_zellij_destructive_path_refuses_loudly_when_a_sibling_is_missing

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -1587,6 +1587,146 @@ test_herdr_flat_teardown_preflight_refuses_before_changes() {
   pass "herdr flat teardown preflight refuses before every destructive change"
 }
 
+test_backend_preflight_refuses_before_parent_cleanup() {
+  local case_dir task_tmp test_root teardown_bin treehouse_log kill_log rc
+  case_dir=$(make_case backend-preflight-parent)
+  task_tmp="$case_dir/tasktmp"
+  mkdir -p "$task_tmp"
+  write_meta "$case_dir" local-only ship
+  printf '%s\n' "tasktmp=$task_tmp" >> "$case_dir/state/task-x1.meta"
+  test_root="$case_dir/test-root"
+  mkdir -p "$test_root"
+  cp -R "$ROOT/bin" "$test_root/bin"
+  rm -f "$test_root/bin/backends/tmux.sh"
+  teardown_bin="$test_root/bin/fm-teardown.sh"
+  treehouse_log="$case_dir/treehouse.log"
+  kill_log="$case_dir/kill.log"
+  : > "$treehouse_log"
+  : > "$kill_log"
+  cat > "$case_dir/fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$treehouse_log"
+exit 0
+SH
+  cat > "$case_dir/fakebin/tmux" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$kill_log"
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/treehouse" "$case_dir/fakebin/tmux"
+
+  rc=0
+  FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$case_dir/state" FM_CONFIG_OVERRIDE="$case_dir/config" \
+    PATH="$case_dir/fakebin:$PATH" \
+    "$teardown_bin" task-x1 --force > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
+  [ "$rc" -ne 0 ] || fail "backend-preflight-parent: teardown reported success without the tmux adapter"
+  assert_grep "backend 'tmux' required by task task-x1 cannot be loaded" "$case_dir/stderr" \
+    "backend-preflight-parent: refusal did not name the unloadable backend"
+  [ -d "$case_dir/wt" ] || fail "backend-preflight-parent: refusal returned the worktree"
+  [ -d "$task_tmp" ] || fail "backend-preflight-parent: refusal removed the task temp directory"
+  [ -e "$case_dir/state/task-x1.meta" ] || fail "backend-preflight-parent: refusal removed task metadata"
+  [ ! -s "$treehouse_log" ] || fail "backend-preflight-parent: refusal invoked treehouse return"
+  [ ! -s "$kill_log" ] || fail "backend-preflight-parent: refusal attempted endpoint cleanup"
+  pass "teardown preflights its backend before parent cleanup"
+}
+
+configure_secondmate_with_zellij_child() {  # <case-dir>
+  local case_dir=$1 home="$1/secondmate-home"
+  mkdir -p "$home/state" "$home/data" "$home/config" "$home/projects"
+  printf '%s\n' task-x1 > "$home/.fm-secondmate-home"
+  printf '%s\n' "home=$home" >> "$case_dir/state/task-x1.meta"
+  fm_write_meta "$home/state/child-zellij.meta" \
+    "window=firstmate:42" \
+    "endpoint_task_id=child-zellij" \
+    "worktree=$case_dir/wt" \
+    "project=$case_dir/project" \
+    "kind=ship" \
+    "mode=local-only" \
+    "backend=zellij" \
+    "zellij_session=firstmate" \
+    "zellij_tab_id=7" \
+    "zellij_pane_id=42"
+  : > "$home/state/child-zellij.status"
+  : > "$home/state/child-zellij.turn-ended"
+}
+
+test_backend_preflight_refuses_before_descendant_cleanup() {
+  local case_dir home test_root teardown_bin treehouse_log kill_log rc
+  case_dir=$(make_case backend-preflight-descendant)
+  write_meta "$case_dir" local-only secondmate
+  configure_secondmate_with_zellij_child "$case_dir"
+  home="$case_dir/secondmate-home"
+  test_root="$case_dir/test-root"
+  mkdir -p "$test_root"
+  cp -R "$ROOT/bin" "$test_root/bin"
+  rm -f "$test_root/bin/fm-backend-hometag-lib.sh"
+  teardown_bin="$test_root/bin/fm-teardown.sh"
+  treehouse_log="$case_dir/treehouse.log"
+  kill_log="$case_dir/kill.log"
+  : > "$treehouse_log"
+  : > "$kill_log"
+  cat > "$case_dir/fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$treehouse_log"
+exit 0
+SH
+  cat > "$case_dir/fakebin/zellij" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$kill_log"
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/treehouse" "$case_dir/fakebin/zellij"
+
+  rc=0
+  FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$case_dir/state" FM_CONFIG_OVERRIDE="$case_dir/config" \
+    PATH="$case_dir/fakebin:$PATH" \
+    "$teardown_bin" task-x1 --force > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
+  [ "$rc" -ne 0 ] || fail "backend-preflight-descendant: teardown reported success without a child backend library"
+  assert_grep "backend 'zellij' required by task child-zellij cannot be loaded" "$case_dir/stderr" \
+    "backend-preflight-descendant: refusal did not name the child's unloadable backend"
+  [ -e "$case_dir/state/task-x1.meta" ] || fail "backend-preflight-descendant: refusal removed parent metadata"
+  [ -d "$home" ] || fail "backend-preflight-descendant: refusal removed the secondmate home"
+  [ -e "$home/state/child-zellij.meta" ] || fail "backend-preflight-descendant: refusal removed child metadata"
+  [ -e "$home/state/child-zellij.status" ] || fail "backend-preflight-descendant: refusal removed child status"
+  [ ! -s "$treehouse_log" ] || fail "backend-preflight-descendant: refusal returned a worktree"
+  [ ! -s "$kill_log" ] || fail "backend-preflight-descendant: refusal attempted child endpoint cleanup"
+  pass "forced teardown preflights descendant backends before cleanup"
+}
+
+test_backend_kill_failure_remains_best_effort() {
+  local case_dir task_tmp treehouse_log kill_log rc
+  case_dir=$(make_case backend-kill-best-effort)
+  task_tmp="$case_dir/tasktmp"
+  mkdir -p "$task_tmp"
+  write_meta "$case_dir" local-only ship
+  printf '%s\n' "tasktmp=$task_tmp" >> "$case_dir/state/task-x1.meta"
+  treehouse_log="$case_dir/treehouse.log"
+  kill_log="$case_dir/kill.log"
+  : > "$treehouse_log"
+  : > "$kill_log"
+  cat > "$case_dir/fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$treehouse_log"
+exit 0
+SH
+  cat > "$case_dir/fakebin/tmux" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$kill_log"
+[ "\${1:-}" != kill-window ]
+SH
+  chmod +x "$case_dir/fakebin/treehouse" "$case_dir/fakebin/tmux"
+
+  rc=0
+  run_teardown "$case_dir" --force > "$case_dir/stdout" 2> "$case_dir/stderr" || rc=$?
+  expect_code 0 "$rc" "backend-kill-best-effort: an ordinary endpoint kill failure must remain non-fatal"
+  assert_grep 'kill-window ' "$kill_log" \
+    "backend-kill-best-effort: the fixture did not exercise endpoint cleanup"
+  [ -s "$treehouse_log" ] || fail "backend-kill-best-effort: teardown did not return the worktree"
+  [ ! -d "$task_tmp" ] || fail "backend-kill-best-effort: teardown retained the task temp directory"
+  [ ! -e "$case_dir/state/task-x1.meta" ] || fail "backend-kill-best-effort: teardown retained task metadata"
+  pass "ordinary endpoint kill failures remain best-effort"
+}
+
 configure_secondmate_with_herdr_child() {  # <case-dir>
   local case_dir=$1 home="$1/secondmate-home"
   mkdir -p "$home/state" "$home/data" "$home/config" "$home/projects"
@@ -2604,6 +2744,9 @@ test_herdr_teardown_clears_escalation_marker
 test_herdr_flat_teardown_refuses_orphaning_records_then_retry_completes
 test_herdr_flat_teardown_refuses_records_on_unparseable_presence
 test_herdr_flat_teardown_preflight_refuses_before_changes
+test_backend_preflight_refuses_before_parent_cleanup
+test_backend_preflight_refuses_before_descendant_cleanup
+test_backend_kill_failure_remains_best_effort
 test_forced_secondmate_herdr_child_preflight_refuses_before_changes
 test_forced_secondmate_teardown_holds_descendant_lifecycle_locks
 test_forced_secondmate_herdr_child_retains_records_when_close_unconfirmed


### PR DESCRIPTION
## Intent

Close one defect class upstream: sourcing a missing sibling library can end a script silently and successfully on the Bash that macOS ships by default, so any Firstmate user on a stock Mac is exposed wherever a script sources a sibling.

THE HAZARD, which is the point of this change. On GNU bash 3.2.57 - what /usr/bin/env bash resolves to on stock macOS - the `.` builtin on a file it cannot find terminates the whole script and does so with status 0. It ignores both a `|| return 1` written beside the source and an enclosing `if !`. Bash 5 returns 1 as written, which is why this repository's Linux CI lanes have never seen it. The consequence is a script that dies partway through while reporting success to its caller. That is worse than a crash: a caller records the work as done.

TWO CALL SITES, each with its own failing-test evidence.
1. fm_backend_source loading a backend adapter. A missing adapter file ended fm-teardown.sh mid-run while reporting success, so the caller recorded a task as cleaned up when nothing was cleaned up and the safety refusal never printed. tests/fm-teardown.test.sh's herdr preflight case failed only on macOS.
2. The teardown chain's own sibling sources. bin/backends/tmux.sh sources fm-session-lock-lib.sh and fm-cursor-lib.sh at its top level, and tests/fm-gotmp.test.sh builds a fake FM_ROOT that symlinked neither. Teardown therefore died inside fm_backend_kill and exited 0 with the task's temp directory still on disk. That test fails on macOS against this repository's own main today, before any change here.

These are the SAME defect at two call sites, which is why they ship as one change rather than two isolated line fixes. Diagnosis order matters for review: the second was found by tracing an unexplained CI failure to its exit point, where teardown returned status 0 with the tasktmp still present.

WHAT THIS CLOSES, stated precisely rather than generously. Every sibling source on the teardown chain now fails closed: 20 sites across fm-teardown.sh (14), bin/backends/tmux.sh (3), bin/fm-tmux-lib.sh (2) and bin/backends/orca.sh (1), each testing the file is readable and refusing by name if it is not. The repository has 216 such sibling-source sites across 69 files; this change closes the chain that demonstrably fails and that owns destructive cleanup, and the remaining sites share the hazard and are deliberately not touched here. The value to a reviewer is knowing which class is closed and where the boundary is, not a claim that all sourcing is now safe.

IMPLEMENTATION NOTES A REVIEWER WOULD NOT GUESS. The adapter guard reads and writes its once-only flag through eval rather than bash's ${!var} indirection or printf -v, because bin/fm-backend.sh is also sourced from zsh, where those constructs mean something else or nothing at all; tests/fm-backend.test.sh already exercises the zsh path and fails otherwise. Each inline guard is placed ABOVE the `# shellcheck source=` directive rather than between it and the source, because that directive must stay adjacent to the source line or shellcheck stops following the file.

TESTS. tests/fm-gotmp.test.sh gains the two missing symlinks so its fake root matches reality, and a new case asserting that a missing library produces a named non-zero refusal rather than a silent success. That case is not vacuous: with the guards removed the script dies with bash's own "No such file or directory" and never names what was missing, so the case fails. The case removes a library fm-teardown.sh sources directly at top level, because a library reached through a best-effort call site refuses just as loudly but that site discards stderr, which would hide the diagnostic being asserted.

PRE-EXISTING FAILURES, not introduced here. On a host whose git signs commits by default, tests/fm-backend.test.sh and tests/fm-teardown.test.sh already fail against this branch's exact base (b57c4d6) - verified on a pristine checkout of it - because tests/lib.sh does not neutralise commit.gpgsign for fixture commits. Those failures are unrelated to this change and are not addressed here.

SCOPE. This is one general fix carved out of a larger local change at the captain's direction, so each separable thing is judged as what it is. It carries nothing project-specific.

CHAIN CLOSURE, after review. The first version of this change guarded only the sites a syntax-pattern enumeration could see, and claimed the teardown chain was closed when it was not. That claim is corrected: enumeration is now by the sourcing act with shape-independent target extraction, transitively closed from fm-teardown.sh and all five backend adapters, because teardown dispatches whichever backend the task recorded. The reachable chain is 25 files and 29 sibling-source sites; all 29 now fail closed. The repository has 251 such sites across 85 files measured the same way, and the ones outside the reachable teardown chain are deliberately untouched and stated as such.

RECOVERY NOTE, for accuracy about this branch's history. A previous run of this pipeline applied the chain-closure work correctly but committed it as a sibling of the submitted head rather than a descendant, and the pipeline refused to proceed rather than lose the reviewed change - the protection worked as designed. The prior head is preserved locally as tag fm-bash32-preabort-03a7738; the current head strictly contains it, verified as 25 insertions and zero deletions, so nothing from it was dropped. No history was rewritten out-of-band by hand.

## What Changed

- Make once-only backend adapter loading fail safely when adapter files are unreadable, preserving Bash 3.2 caller control and zsh compatibility.
- Guard teardown-chain sibling libraries and preflight parent and forced-descendant backends before destructive cleanup, returning named non-zero refusals while preserving task state.
- Add regression coverage for missing adapters and libraries, recursive backend preflight, zsh loading, and best-effort endpoint-kill behavior.

## Risk Assessment

✅ Low: The change is fail-closed, covers the complete reachable teardown sourcing chain, and preflights parent and descendant backends before destructive cleanup without altering best-effort endpoint-kill behavior.

## Testing

On stock macOS Bash 3.2.57, targeted backend, temp-cleanup, and teardown validation now succeeds with commit signing neutralized for fixtures; an initial zsh regression was reproduced, fixed test-first, and reverified, while two CLI transcripts directly demonstrate non-zero named refusals with cleanup state preserved and a final audit confirms all 29 reachable source sites are guarded.

<details>
<summary>Evidence: Stock macOS Bash missing-adapter refusal</summary>

<code>GNU bash 3.2.57&#10;exit_status=1&#10;REFUSED: backend &#39;tmux&#39; required by task evidence-task cannot be loaded&#10;tasktmp_preserved=yes&#10;metadata_preserved=yes</code>

```text
$ /bin/bash --version
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)
$ FM_HOME=<fixture> /bin/bash <fixture>/bin/fm-teardown.sh evidence-task --force
exit_status=1
stderr:
REFUSED: backend 'tmux' required by task evidence-task cannot be loaded; nothing was changed - restore its adapter and required libraries, then rerun teardown
tasktmp_preserved=yes
metadata_preserved=yes
```
</details>
<details>
<summary>Evidence: Stock macOS Bash missing-sibling refusal</summary>

<code>GNU bash 3.2.57&#10;exit_status=1&#10;missing required library: &lt;fixture&gt;/bin/fm-nm-run-lib.sh&#10;tasktmp_preserved=yes&#10;metadata_preserved=yes</code>

```text
$ /bin/bash --version
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)
$ FM_HOME=<fixture> /bin/bash <fixture>/bin/fm-teardown.sh evidence-task --force
exit_status=1
stderr:
<fixture>/bin/fm-teardown.sh: missing required library: <fixture>/bin/fm-nm-run-lib.sh
tasktmp_preserved=yes
metadata_preserved=yes
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Confirmed target `87cf89d36fbaf206005763ebc185f20bd949429c` and GNU Bash 3.2.57.</code>
- <code>Initial targeted run: `env GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false bin/fm-test-run.sh tests/fm-backend.test.sh tests/fm-gotmp.test.sh tests/fm-teardown.test.sh`; exposed the zsh regression while both cleanup suites completed successfully.</code>
- <code>RED/GREEN verification: `env GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false bin/fm-test-run.sh tests/fm-backend.test.sh`; failed before the correction and exited 0 afterward, exercising all five adapters through zsh plus Bash 3.2 missing-adapter handling.</code>
- <code>Final cleanup verification: `env GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false bin/fm-test-run.sh tests/fm-gotmp.test.sh tests/fm-teardown.test.sh`; exited 0 against the final files.</code>
- <code>Manual `/bin/bash` teardown with a missing tmux adapter returned 1, named the backend, and preserved task temp data and metadata.</code>
- <code>Manual `/bin/bash` teardown with a missing sibling library returned 1, named the missing file, and preserved task temp data and metadata.</code>
- `Audited the reachable sourcing acts: 29 sites across the nine sourcing owners, with 0 invalid guard/directive/source triplets.`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Fix backend preflight ShellCheck scope warnings
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
