### PR TITLE
fix: require whole-task completion in crew briefs

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -181,11 +181,11 @@ STATUS_FILE=$(shell_quote "$STATE/$ID.status")
 IFS= read -r -d '' COMPLETION_CONTRACT <<'EOF' || true
 Keep working until every part of the assigned task is delivered.
 A turn ending, a natural pause, or one completed sub-part is not a checkpoint to await instruction.
-Stop only for genuine completion, a genuine blocker, or a decision genuinely above your authority.
-`done:` means every stated requirement is met.
+Hand work back only at a gate defined under Definition of done, a genuine blocker, or a decision genuinely above your authority.
+The final `done:` gate under Definition of done is the whole-task completion claim: every stated requirement met. An earlier gate defined there claims only what that gate itself defines.
 Candid partial-work reporting is `blocked:` or `needs-decision:`, never `done:`.
-Before `done:`, re-read the task, confirm every requirement, verify the requested deliverable exists where requested and survives teardown, and re-run the applicable project gate with its real exit status.
-State anything not done and why; if a required item is missing, do not append `done:`.
+Before any `done:`, re-read the task, confirm every requirement that gate covers, verify the requested deliverable exists where requested and survives teardown, and re-run the applicable project checks with their real exit status.
+State anything not done and why; if a required item that gate covers is missing, do not append `done:`.
 EOF
 COMPLETION_CONTRACT=${COMPLETION_CONTRACT%$'\n'}
 
@@ -263,6 +263,7 @@ Routine internal supervision, heartbeats, retries, and crewmate churn stay insid
 # Definition of done
 $COMPLETION_CONTRACT
 
+For routed work, that gate is the correlated status line you return through the escalation path above: passing it returns you to the idle state below and never ends your session.
 You are persistent by default. Do not exit just because your queue is empty.
 On startup and restart, run normal firstmate bootstrap and recovery through \`bin/fm-session-start.sh\` for your own home, but only to RECONCILE work that is already yours: in-flight crewmates, tracked backlog items, and durable watches recorded in this home.
 When you have no assigned or in-flight work after that reconciliation, go idle and wait silently for the main firstmate to route you a task.
@@ -399,8 +400,10 @@ EOF
     IFS= read -r -d '' DOD <<EOF || true
 # Definition of done
 Delivery contract: mode=no-mistakes
+This mode has two gates under this section: an implementation-ready handoff, then the final whole-task gate once CI is green.
 The task is complete only when committed on your branch.
 When you believe it is complete, append \`done: {summary}\` to the status file and stop.
+That first \`done:\` is this mode's defined handoff gate, not the whole-task claim: it asserts every stated requirement is implemented and committed here, with validation, the PR, and green CI still ahead of you.
 Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
@@ -414,7 +417,7 @@ Two firstmate-specific rules layer on top of that guidance:
   When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
 - Avoid \`--yes\`: it would silently bypass firstmate's authority check and any required captain escalation.
 
-After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
+After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. That is this mode's final gate and its whole-task completion claim. You are finished.
 EOF
     ;;
 esac

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -49,11 +49,11 @@
 # declared-external-wait verb (FM_CLASSIFY_PAUSED_VERB, default "paused") from
 # "blocked:": pause for a known external wait expected to clear on its own,
 # blocked when firstmate must act.
-# Every scaffold ends with the shared completion contract: keep working until the
+# Every scaffold carries the shared completion contract: keep working until the
 # assigned task is delivered, hand back only at a gate defined under Definition of
-# done, never claim "done:" for work still partial for the gate being claimed (use
-# the fitting non-done state instead), and pass a re-read, deliverable, and
-# project-checks self-check before any "done:".
+# done or a state the scaffold's status protocol defines, never claim "done:" for
+# work still partial for the gate being claimed, and pass a re-read, deliverable,
+# and project-checks self-check before any "done:".
 # Ship tasks include a project-memory section so durable project-intrinsic
 # learnings can be committed to AGENTS.md through the project's delivery path;
 # it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers
@@ -186,7 +186,7 @@ STATUS_FILE=$(shell_quote "$STATE/$ID.status")
 IFS= read -r -d '' COMPLETION_CONTRACT <<'EOF' || true
 Keep working until every part of the assigned task is delivered.
 A turn ending, a natural pause, or one completed sub-part is not a checkpoint to await instruction.
-Hand work back only at a gate defined under Definition of done, a genuine blocker, or a decision genuinely above your authority.
+Hand work back only at a gate defined under Definition of done or a state the status protocol above defines: a genuine blocker, a decision genuinely above your authority, a declared external wait, or a failure.
 The final `done:` gate under Definition of done is the whole-task completion claim: every stated requirement met. An earlier gate defined there claims only what that gate itself defines.
 Work still partial for the gate you are claiming is never `done:`: use the fitting non-done state from the status protocol above (`blocked:` or `needs-decision:` when you need help or a decision above your authority, `{PAUSED_VERB}:` for a declared external wait, `failed:` when it cannot be finished). Describing the gap candidly does not make it `done:`.
 Before any `done:`, re-read the task, confirm every requirement that gate covers, verify the requested deliverable exists where requested and survives teardown, and re-run the applicable project checks with their real exit status.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -49,6 +49,11 @@
 # declared-external-wait verb (FM_CLASSIFY_PAUSED_VERB, default "paused") from
 # "blocked:": pause for a known external wait expected to clear on its own,
 # blocked when firstmate must act.
+# Every scaffold ends with the shared completion contract: keep working until the
+# assigned task is delivered, hand back only at a gate defined under Definition of
+# done, never claim "done:" for work still partial for the gate being claimed (use
+# the fitting non-done state instead), and pass a re-read, deliverable, and
+# project-checks self-check before any "done:".
 # Ship tasks include a project-memory section so durable project-intrinsic
 # learnings can be committed to AGENTS.md through the project's delivery path;
 # it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers
@@ -183,11 +188,12 @@ Keep working until every part of the assigned task is delivered.
 A turn ending, a natural pause, or one completed sub-part is not a checkpoint to await instruction.
 Hand work back only at a gate defined under Definition of done, a genuine blocker, or a decision genuinely above your authority.
 The final `done:` gate under Definition of done is the whole-task completion claim: every stated requirement met. An earlier gate defined there claims only what that gate itself defines.
-Work still partial for the gate you are claiming is `blocked:` or `needs-decision:`, never `done:`; describing the gap candidly does not make it `done:`.
+Work still partial for the gate you are claiming is never `done:`: use the fitting non-done state from the status protocol above (`blocked:` or `needs-decision:` when you need help or a decision above your authority, `{PAUSED_VERB}:` for a declared external wait, `failed:` when it cannot be finished). Describing the gap candidly does not make it `done:`.
 Before any `done:`, re-read the task, confirm every requirement that gate covers, verify the requested deliverable exists where requested and survives teardown, and re-run the applicable project checks with their real exit status.
 State anything not done and why; if a required item that gate covers is missing, do not append `done:`.
 EOF
 COMPLETION_CONTRACT=${COMPLETION_CONTRACT%$'\n'}
+COMPLETION_CONTRACT=${COMPLETION_CONTRACT//\{PAUSED_VERB\}/$PAUSED_VERB}
 
 if [ "$KIND" = secondmate ]; then
 SECONDMATE_PROJECTS=""

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -183,7 +183,7 @@ Keep working until every part of the assigned task is delivered.
 A turn ending, a natural pause, or one completed sub-part is not a checkpoint to await instruction.
 Hand work back only at a gate defined under Definition of done, a genuine blocker, or a decision genuinely above your authority.
 The final `done:` gate under Definition of done is the whole-task completion claim: every stated requirement met. An earlier gate defined there claims only what that gate itself defines.
-Candid partial-work reporting is `blocked:` or `needs-decision:`, never `done:`.
+Work still partial for the gate you are claiming is `blocked:` or `needs-decision:`, never `done:`; describing the gap candidly does not make it `done:`.
 Before any `done:`, re-read the task, confirm every requirement that gate covers, verify the requested deliverable exists where requested and survives teardown, and re-run the applicable project checks with their real exit status.
 State anything not done and why; if a required item that gate covers is missing, do not append `done:`.
 EOF

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -178,6 +178,17 @@ shell_quote() {
 
 STATUS_FILE=$(shell_quote "$STATE/$ID.status")
 
+IFS= read -r -d '' COMPLETION_CONTRACT <<'EOF' || true
+Keep working until every part of the assigned task is delivered.
+A turn ending, a natural pause, or one completed sub-part is not a checkpoint to await instruction.
+Stop only for genuine completion, a genuine blocker, or a decision genuinely above your authority.
+`done:` means every stated requirement is met.
+Candid partial-work reporting is `blocked:` or `needs-decision:`, never `done:`.
+Before `done:`, re-read the task, confirm every requirement, verify the requested deliverable exists where requested and survives teardown, and re-run the applicable project gate with its real exit status.
+State anything not done and why; if a required item is missing, do not append `done:`.
+EOF
+COMPLETION_CONTRACT=${COMPLETION_CONTRACT%$'\n'}
+
 if [ "$KIND" = secondmate ]; then
 SECONDMATE_PROJECTS=""
 idx=1
@@ -250,6 +261,8 @@ The main firstmate's answer normally writes that closing line at answer time; wh
 Routine internal supervision, heartbeats, retries, and crewmate churn stay inside your own home and must not touch that status file.
 
 # Definition of done
+$COMPLETION_CONTRACT
+
 You are persistent by default. Do not exit just because your queue is empty.
 On startup and restart, run normal firstmate bootstrap and recovery through \`bin/fm-session-start.sh\` for your own home, but only to RECONCILE work that is already yours: in-flight crewmates, tracked backlog items, and durable watches recorded in this home.
 When you have no assigned or in-flight work after that reconciliation, go idle and wait silently for the main firstmate to route you a task.
@@ -341,6 +354,7 @@ Write your findings to \`$DATA/$ID/report.md\`.
 The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
 If your deliverable is a visual artifact the captain will review and iterate on, you may host the Lavish review loop yourself (poll, revise, re-serve, staying alive) instead of handing it back to firstmate.
 Before reporting done, read and follow \`$FM_ROOT/.agents/skills/decision-hold-lifecycle/SKILL.md\` and pass its shared completion gate for the report and any visual review.
+$COMPLETION_CONTRACT
 When the report is complete, append \`done: {one-line conclusion}\` to the status file and stop.
 If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.
 EOF
@@ -461,5 +475,7 @@ If you touch a project \`AGENTS.md\` that lacks \`## Maintaining this file\`, ad
 Keep it proportionate: skip \`AGENTS.md\` edits for trivial tasks that produced no durable project knowledge.
 
 $DOD
+
+$COMPLETION_CONTRACT
 EOF
 echo "scaffolded: $BRIEF (ship, mode=$MODE; replace {TASK})"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -251,8 +251,8 @@ test_completion_contract_covers_every_variant() {
       "$kind brief lets a worker hand work back outside a defined gate"
     assert_grep "The final \`done:\` gate under Definition of done is the whole-task completion claim: every stated requirement met." "$brief" \
       "$kind brief does not define the final done gate as whole-task completion"
-    assert_grep "Candid partial-work reporting is \`blocked:\` or \`needs-decision:\`, never \`done:\`." "$brief" \
-      "$kind brief permits candid partial work to claim done"
+    assert_grep "Work still partial for the gate you are claiming is \`blocked:\` or \`needs-decision:\`, never \`done:\`; describing the gap candidly does not make it \`done:\`." "$brief" \
+      "$kind brief permits candid partial work to claim done for the gate it is claiming"
     assert_grep "Before any \`done:\`, re-read the task, confirm every requirement that gate covers, verify the requested deliverable exists where requested and survives teardown, and re-run the applicable project checks with their real exit status." "$brief" \
       "$kind brief missing the mandatory completion self-check"
     assert_grep "State anything not done and why; if a required item that gate covers is missing, do not append \`done:\`." "$brief" \
@@ -281,6 +281,10 @@ test_mode_defined_gates_survive_the_completion_contract() {
     "no-mistakes brief lets the contract suppress its implementation-ready handoff"
   assert_grep "That is this mode's final gate and its whole-task completion claim." "$brief" \
     "no-mistakes brief does not mark the CI-green done as its final gate"
+  assert_grep "An earlier gate defined there claims only what that gate itself defines." "$brief" \
+    "no-mistakes brief does not scope an intermediate gate to what that gate defines"
+  assert_no_grep "Candid partial-work reporting" "$brief" \
+    "no-mistakes brief bans partial work unconditionally, contradicting its intermediate handoff gate"
 
   out=$(FM_HOME="$home" "$ROOT/bin/fm-brief.sh" gates-secondmate --secondmate --no-projects 2>&1); status=$?
   expect_code 0 "$status" "fm-brief.sh gates-secondmate --secondmate should exit 0 (got: $out)"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -247,8 +247,8 @@ test_completion_contract_covers_every_variant() {
       "$kind brief missing the whole-task autonomy contract"
     assert_grep "A turn ending, a natural pause, or one completed sub-part is not a checkpoint to await instruction." "$brief" \
       "$kind brief lets a worker stop at a natural pause"
-    assert_grep "Hand work back only at a gate defined under Definition of done, a genuine blocker, or a decision genuinely above your authority." "$brief" \
-      "$kind brief lets a worker hand work back outside a defined gate"
+    assert_grep "Hand work back only at a gate defined under Definition of done or a state the status protocol above defines: a genuine blocker, a decision genuinely above your authority, a declared external wait, or a failure." "$brief" \
+      "$kind brief lets a worker hand work back outside a defined gate, or drops a state its status protocol defines"
     assert_grep "The final \`done:\` gate under Definition of done is the whole-task completion claim: every stated requirement met." "$brief" \
       "$kind brief does not define the final done gate as whole-task completion"
     assert_grep "Work still partial for the gate you are claiming is never \`done:\`: use the fitting non-done state from the status protocol above (\`blocked:\` or \`needs-decision:\` when you need help or a decision above your authority, \`paused:\` for a declared external wait, \`failed:\` when it cannot be finished). Describing the gap candidly does not make it \`done:\`." "$brief" \

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -251,8 +251,10 @@ test_completion_contract_covers_every_variant() {
       "$kind brief lets a worker hand work back outside a defined gate"
     assert_grep "The final \`done:\` gate under Definition of done is the whole-task completion claim: every stated requirement met." "$brief" \
       "$kind brief does not define the final done gate as whole-task completion"
-    assert_grep "Work still partial for the gate you are claiming is \`blocked:\` or \`needs-decision:\`, never \`done:\`; describing the gap candidly does not make it \`done:\`." "$brief" \
-      "$kind brief permits candid partial work to claim done for the gate it is claiming"
+    assert_grep "Work still partial for the gate you are claiming is never \`done:\`: use the fitting non-done state from the status protocol above (\`blocked:\` or \`needs-decision:\` when you need help or a decision above your authority, \`paused:\` for a declared external wait, \`failed:\` when it cannot be finished). Describing the gap candidly does not make it \`done:\`." "$brief" \
+      "$kind brief permits candid partial work to claim done, or contradicts its own status protocol"
+    assert_no_grep "{PAUSED_VERB}" "$brief" \
+      "$kind brief leaked the unsubstituted pause-verb placeholder"
     assert_grep "Before any \`done:\`, re-read the task, confirm every requirement that gate covers, verify the requested deliverable exists where requested and survives teardown, and re-run the applicable project checks with their real exit status." "$brief" \
       "$kind brief missing the mandatory completion self-check"
     assert_grep "State anything not done and why; if a required item that gate covers is missing, do not append \`done:\`." "$brief" \
@@ -283,8 +285,10 @@ test_mode_defined_gates_survive_the_completion_contract() {
     "no-mistakes brief does not mark the CI-green done as its final gate"
   assert_grep "An earlier gate defined there claims only what that gate itself defines." "$brief" \
     "no-mistakes brief does not scope an intermediate gate to what that gate defines"
-  assert_no_grep "Candid partial-work reporting" "$brief" \
-    "no-mistakes brief bans partial work unconditionally, contradicting its intermediate handoff gate"
+  assert_grep "append \`done: {summary}\` to the status file and stop" "$brief" \
+    "no-mistakes brief no longer instructs its implementation-ready handoff done line"
+  assert_grep "append \`done: PR {url} checks green\` and stop" "$brief" \
+    "no-mistakes brief no longer instructs its final CI-green done line"
 
   out=$(FM_HOME="$home" "$ROOT/bin/fm-brief.sh" gates-secondmate --secondmate --no-projects 2>&1); status=$?
   expect_code 0 "$status" "fm-brief.sh gates-secondmate --secondmate should exit 0 (got: $out)"
@@ -743,6 +747,11 @@ test_pause_verb_override_renders_all_brief_scaffolds() {
     # shellcheck disable=SC2016 # Literal backticks and braces must remain unexpanded.
     assert_no_grep '`paused: {why}`' "$brief" \
       "$kind brief still instructs the default paused status"
+    # shellcheck disable=SC2016 # Literal backticks must remain unexpanded.
+    assert_grep '`awaiting:` for a declared external wait' "$brief" \
+      "$kind brief completion contract did not route a declared external wait to the configured pause verb"
+    assert_no_grep '{PAUSED_VERB}' "$brief" \
+      "$kind brief leaked the unsubstituted pause-verb placeholder"
     assert_grep 'a blocker or wait clears' "$brief" \
       "$kind brief did not require durable resolution when a blocker clears"
     assert_grep 'even when the answer is what started that work' "$brief" \

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -217,6 +217,46 @@ test_ship_modes_generate_clean_briefs() {
   pass "fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly"
 }
 
+# A terminal `done:` is a completion claim, not a truthful checkpoint for a
+# partially completed task.  Every worker-facing variant must carry the same
+# concise autonomy, completion, and self-check contract.
+test_completion_contract_covers_every_variant() {
+  local home id brief kind mode
+  home="$TMP_ROOT/completion-contract-home"
+  mkdir -p "$home/data"
+
+  for kind in no-mistakes direct-PR local-only scout secondmate; do
+    id="brief-completion-$kind"
+    case "$kind" in
+      scout)
+        FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --scout >/dev/null 2>&1
+        ;;
+      secondmate)
+        FM_HOME="$home" FM_SECONDMATE_CHARTER='Handle routed work.' \
+          "$ROOT/bin/fm-brief.sh" "$id" --secondmate --no-projects >/dev/null 2>&1
+        ;;
+      *)
+        mode=$kind
+        FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode "$mode" >/dev/null 2>&1
+        ;;
+    esac
+    brief="$home/data/$id/brief.md"
+    assert_grep "Keep working until every part of the assigned task is delivered." "$brief" \
+      "$kind brief missing the whole-task autonomy contract"
+    assert_grep "A turn ending, a natural pause, or one completed sub-part is not a checkpoint to await instruction." "$brief" \
+      "$kind brief lets a worker stop at a natural pause"
+    assert_grep "\`done:\` means every stated requirement is met." "$brief" \
+      "$kind brief does not define done as whole-task completion"
+    assert_grep "Candid partial-work reporting is \`blocked:\` or \`needs-decision:\`, never \`done:\`." "$brief" \
+      "$kind brief permits candid partial work to claim done"
+    assert_grep "Before \`done:\`, re-read the task, confirm every requirement, verify the requested deliverable exists where requested and survives teardown, and re-run the applicable project gate with its real exit status." "$brief" \
+      "$kind brief missing the mandatory completion self-check"
+    assert_grep "State anything not done and why; if a required item is missing, do not append \`done:\`." "$brief" \
+      "$kind brief does not make missing required work nonterminal"
+  done
+  pass "fm-brief.sh: completion contract covers ship, scout, and charter variants"
+}
+
 # A ship task's delivery mode is firstmate's per-task decision, so a missing or
 # unusable value must stop the scaffold instead of silently defaulting. The
 # no-mistakes-prod-only row is the conditional registry policy: it is never a task
@@ -716,6 +756,7 @@ test_script_parses
 test_no_heredoc_in_command_substitution
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
+test_completion_contract_covers_every_variant
 test_ship_mode_is_required_and_closed_set
 test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -221,7 +221,7 @@ test_ship_modes_generate_clean_briefs() {
 # partially completed task.  Every worker-facing variant must carry the same
 # concise autonomy, completion, and self-check contract.
 test_completion_contract_covers_every_variant() {
-  local home id brief kind mode
+  local home id brief kind mode status out
   home="$TMP_ROOT/completion-contract-home"
   mkdir -p "$home/data"
 
@@ -229,32 +229,68 @@ test_completion_contract_covers_every_variant() {
     id="brief-completion-$kind"
     case "$kind" in
       scout)
-        FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --scout >/dev/null 2>&1
+        out=$(FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --scout 2>&1); status=$?
         ;;
       secondmate)
-        FM_HOME="$home" FM_SECONDMATE_CHARTER='Handle routed work.' \
-          "$ROOT/bin/fm-brief.sh" "$id" --secondmate --no-projects >/dev/null 2>&1
+        out=$(FM_HOME="$home" FM_SECONDMATE_CHARTER='Handle routed work.' \
+          "$ROOT/bin/fm-brief.sh" "$id" --secondmate --no-projects 2>&1); status=$?
         ;;
       *)
         mode=$kind
-        FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode "$mode" >/dev/null 2>&1
+        out=$(FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode "$mode" 2>&1); status=$?
         ;;
     esac
+    expect_code 0 "$status" "fm-brief.sh $id ($kind) should scaffold successfully (got: $out)"
     brief="$home/data/$id/brief.md"
+    assert_present "$brief" "$kind: brief was not scaffolded"
     assert_grep "Keep working until every part of the assigned task is delivered." "$brief" \
       "$kind brief missing the whole-task autonomy contract"
     assert_grep "A turn ending, a natural pause, or one completed sub-part is not a checkpoint to await instruction." "$brief" \
       "$kind brief lets a worker stop at a natural pause"
-    assert_grep "\`done:\` means every stated requirement is met." "$brief" \
-      "$kind brief does not define done as whole-task completion"
+    assert_grep "Hand work back only at a gate defined under Definition of done, a genuine blocker, or a decision genuinely above your authority." "$brief" \
+      "$kind brief lets a worker hand work back outside a defined gate"
+    assert_grep "The final \`done:\` gate under Definition of done is the whole-task completion claim: every stated requirement met." "$brief" \
+      "$kind brief does not define the final done gate as whole-task completion"
     assert_grep "Candid partial-work reporting is \`blocked:\` or \`needs-decision:\`, never \`done:\`." "$brief" \
       "$kind brief permits candid partial work to claim done"
-    assert_grep "Before \`done:\`, re-read the task, confirm every requirement, verify the requested deliverable exists where requested and survives teardown, and re-run the applicable project gate with its real exit status." "$brief" \
+    assert_grep "Before any \`done:\`, re-read the task, confirm every requirement that gate covers, verify the requested deliverable exists where requested and survives teardown, and re-run the applicable project checks with their real exit status." "$brief" \
       "$kind brief missing the mandatory completion self-check"
-    assert_grep "State anything not done and why; if a required item is missing, do not append \`done:\`." "$brief" \
+    assert_grep "State anything not done and why; if a required item that gate covers is missing, do not append \`done:\`." "$brief" \
       "$kind brief does not make missing required work nonterminal"
+    assert_no_grep "EOF" "$brief" "$kind: brief leaked a heredoc EOF marker (unterminated heredoc)"
   done
   pass "fm-brief.sh: completion contract covers ship, scout, and charter variants"
+}
+
+# The contract must not override a delivery mode's own multi-gate protocol. The
+# no-mistakes mode hands off to firstmate at an implementation-ready `done:`
+# before the PR and green CI exist, and the persistent secondmate returns to
+# idle after routed work instead of exiting - both must survive the contract.
+test_mode_defined_gates_survive_the_completion_contract() {
+  local home brief status out
+  home="$TMP_ROOT/mode-gates-home"
+  mkdir -p "$home/data"
+
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-brief.sh" gates-nomistakes some-proj --mode no-mistakes 2>&1); status=$?
+  expect_code 0 "$status" "fm-brief.sh gates-nomistakes --mode no-mistakes should exit 0 (got: $out)"
+  brief="$home/data/gates-nomistakes/brief.md"
+  assert_present "$brief" "no-mistakes gate brief was not scaffolded"
+  assert_grep "This mode has two gates under this section: an implementation-ready handoff, then the final whole-task gate once CI is green." "$brief" \
+    "no-mistakes brief does not declare its two done gates"
+  assert_grep "That first \`done:\` is this mode's defined handoff gate, not the whole-task claim" "$brief" \
+    "no-mistakes brief lets the contract suppress its implementation-ready handoff"
+  assert_grep "That is this mode's final gate and its whole-task completion claim." "$brief" \
+    "no-mistakes brief does not mark the CI-green done as its final gate"
+
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-brief.sh" gates-secondmate --secondmate --no-projects 2>&1); status=$?
+  expect_code 0 "$status" "fm-brief.sh gates-secondmate --secondmate should exit 0 (got: $out)"
+  brief="$home/data/gates-secondmate/brief.md"
+  assert_present "$brief" "secondmate gate brief was not scaffolded"
+  assert_grep "passing it returns you to the idle state below and never ends your session" "$brief" \
+    "secondmate charter lets a completed routed task end the persistent session"
+  assert_grep "You are persistent by default. Do not exit just because your queue is empty." "$brief" \
+    "secondmate charter lost its persistence rule"
+  pass "fm-brief.sh: mode-defined done gates and secondmate persistence survive the contract"
 }
 
 # A ship task's delivery mode is firstmate's per-task decision, so a missing or
@@ -757,6 +793,7 @@ test_no_heredoc_in_command_substitution
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
 test_completion_contract_covers_every_variant
+test_mode_defined_gates_survive_the_completion_contract
 test_ship_mode_is_required_and_closed_set
 test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply


### PR DESCRIPTION
## Summary
- add a shared, gate-aware completion and self-check contract to ship, scout, and secondmate briefs
- preserve no-mistakes handoff versus final completion gates, pause/failed status semantics, and secondmate persistence
- extend executable emitted-brief regression coverage for every variant

## Validation
- no-mistakes review, test, documentation, and lint stages passed
- `bin/fm-lint.sh` passes with actionlint 1.7.12

The upstream push step was intentionally replaced with the normal fork workflow; this PR is from `alior88:fm/fm-brief-completion-and-selfqa-c1`.