### PR TITLE
fix(bin): compare directory identity, not path spelling, when resolving a spawn worktree

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1688,18 +1688,33 @@ BRIEF_REAL="$BRIEF_DIR_REAL/$(basename "$BRIEF")"
 # still-symlinked PROJ_ABS can misfire both ways: false-negative (the poll
 # below never notices the pane left the project) or false-positive (the
 # isolation guard refuses a spawn that never actually tangled). Canonicalize
-# once here so every downstream comparison uses the same physical form
-# (docs/herdr-backend.md "Known gaps").
+# once here so the project is named in the same physical form the backends
+# report (docs/herdr-backend.md "Known gaps").
 PROJ_ABS_REAL=$(cd "$PROJ_ABS" 2>/dev/null && pwd -P) || PROJ_ABS_REAL="$PROJ_ABS"
 
-real_path_or_raw() {  # <path>
-  local path=$1 real
-  if real=$(cd "$path" 2>/dev/null && pwd -P); then
-    printf '%s\n' "$real"
-  else
-    printf '%s\n' "$path"
-  fi
-}
+# Canonicalizing is still not enough to decide "is this the same directory?" by
+# string comparison, because a path spelling is not a directory identity. On a
+# case-insensitive volume - the macOS default - .../Code/firstmate and
+# .../code/firstmate are ONE directory, and bash's `pwd -P` resolves symlinks
+# but PRESERVES whichever case the caller cd'd with (zsh canonicalizes instead,
+# which is why a zsh spot-check misses this entirely). Meanwhile every backend's
+# pane-path read and `git rev-parse --show-toplevel` report the canonical case.
+# Comparing those spellings as strings broke the chain below in both directions:
+# the settle loop read the pane's canonical-case PROJECT path as "the pane
+# already left the project" and recorded the primary checkout as the worktree,
+# and the isolation guard compared the same two spellings and passed instead of
+# refusing. Device+inode is the filesystem's own answer: equal for every
+# spelling that reaches one directory, never equal for two distinct ones.
+# Prints empty, and still succeeds so `set -e` callers stay simple, when the
+# path is unreadable; every caller treats empty as "cannot prove it", which
+# waits or refuses rather than assuming isolation.
+if [ "$(uname -s 2>/dev/null || true)" = Darwin ]; then
+  path_identity() { [ -n "${1:-}" ] || return 0; stat -f '%d:%i' "$1" 2>/dev/null || true; }
+else
+  path_identity() { [ -n "${1:-}" ] || return 0; stat -c '%d:%i' "$1" 2>/dev/null || true; }
+fi
+
+PROJ_ABS_ID=$(path_identity "$PROJ_ABS_REAL")
 
 # Session-provider container-ensure + task creation. tmux stays exactly as P1
 # left it (same session-name / new-window sequence, see bin/backends/tmux.sh);
@@ -1709,19 +1724,20 @@ real_path_or_raw() {  # <path>
 # herdr-sm-spaces-k4). Both branches converge on the same $T ("target") string
 # that every downstream operation (send/capture/kill) already treats as opaque
 # per-backend routing (fm_backend_resolve_selector).
+
+# Refuses unless WT is provably the top-level of a worktree that is NOT the
+# project. Both comparisons are directory identities, not path strings: the
+# spelling WT arrived in comes from a backend's pane read while wt_top comes
+# from git, so two spellings of one directory must not read as two directories
+# (and vice versa). An identity that cannot be read at all stays empty and
+# refuses, because isolation unproven is isolation refused.
 validate_spawn_worktree() {  # <source> <inspect-target>
-  local source=$1 inspect_target=$2 wt_real proj_real wt_top wt_top_real
-  wt_real=
-  if ! wt_real=$(cd "$WT" 2>/dev/null && pwd -P); then
-    wt_real=
-  fi
-  proj_real=$PROJ_ABS_REAL
+  local source=$1 inspect_target=$2 wt_id wt_top wt_top_id
+  wt_id=$(path_identity "$WT")
   wt_top=$(git -C "$WT" rev-parse --show-toplevel 2>/dev/null || true)
-  wt_top_real=
-  if ! wt_top_real=$(cd "$wt_top" 2>/dev/null && pwd -P); then
-    wt_top_real=
-  fi
-  if [ -z "$wt_real" ] || [ -z "$wt_top_real" ] || [ "$wt_real" != "$wt_top_real" ] || [ "$wt_real" = "$proj_real" ]; then
+  wt_top_id=$(path_identity "$wt_top")
+  if [ -z "$wt_id" ] || [ -z "$wt_top_id" ] || [ -z "$PROJ_ABS_ID" ] \
+    || [ "$wt_id" != "$wt_top_id" ] || [ "$wt_id" = "$PROJ_ABS_ID" ]; then
     echo "error: $source did not yield an isolated worktree (resolved '$WT'; worktree root '${wt_top:-none}'; primary '$PROJ_ABS'); refusing to launch to avoid tangling the primary checkout. Inspect target $inspect_target" >&2
     exit 1
   fi
@@ -2198,15 +2214,20 @@ if [ "$RELAUNCH" -eq 1 ]; then
   # No worktree is acquired: the recorded one is reused as-is. What must be
   # proven instead is that the adopted endpoint's shell is actually sitting in
   # that worktree, so the replacement agent starts where the work is rather
-  # than wherever the pane happened to drift.
-  relaunch_wt_real=$(real_path_or_raw "$WT")
+  # than wherever the pane happened to drift. Same directory identity, not the
+  # same path string: the pane reports the canonical spelling while the recorded
+  # worktree carries whatever spelling the original spawn wrote, so comparing
+  # strings would refuse a relaunch into the very worktree holding the work.
+  relaunch_wt_id=$(path_identity "$WT")
   relaunch_seen=
+  relaunch_seen_id=
   for _ in $(seq 1 10); do
     relaunch_seen=$(spawn_current_path "$WT_TARGET" || true)
-    [ -z "$relaunch_seen" ] || [ "$(real_path_or_raw "$relaunch_seen")" != "$relaunch_wt_real" ] || break
+    relaunch_seen_id=$(path_identity "$relaunch_seen")
+    [ -z "$relaunch_wt_id" ] || [ -z "$relaunch_seen_id" ] || [ "$relaunch_seen_id" != "$relaunch_wt_id" ] || break
     sleep 0.5
   done
-  if [ -z "$relaunch_seen" ] || [ "$(real_path_or_raw "$relaunch_seen")" != "$relaunch_wt_real" ]; then
+  if [ -z "$relaunch_wt_id" ] || [ -z "$relaunch_seen_id" ] || [ "$relaunch_seen_id" != "$relaunch_wt_id" ]; then
     echo "error: task $ID's endpoint is in '${relaunch_seen:-unknown}', not its recorded worktree '$WT'; refusing to relaunch an agent outside the copy holding its work" >&2
     exit 1
   fi
@@ -2219,35 +2240,38 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   # automatic-rename slips through), display-message -t <bad-name> falls back to the
   # active client's window, which would misread firstmate's OWN pane path as the
   # worktree and tangle a hook into the primary checkout. The window id never lies.
-  # Compare against PROJ_ABS_REAL (physical), not PROJ_ABS: a symlinked project
-  # prefix would otherwise make the pane's OS-level cwd read differ from
-  # PROJ_ABS on the very first poll, before the pane has actually moved.
+  # Compare by directory identity (PROJ_ABS_ID), not by path string: the pane
+  # reports its cwd in the canonical spelling the OS holds, while PROJ_ABS came
+  # from however firstmate addressed the project. A symlinked prefix or a
+  # different case in that spelling would otherwise make the very first poll -
+  # taken before the pane has moved at all - read as "already left the project",
+  # which is exactly how a spawn came to record the PRIMARY CHECKOUT as the
+  # worktree. One identity covers both.
   #
-  # A single read that already differs from PROJ_ABS_REAL is not proof the pane
-  # settled there: on some tmux/WSL setups a brand-new window's pane_current_path
-  # transiently reports an unrelated stale path (seen live as another real git
-  # checkout entirely) before the shell catches up with treehouse get's cd. That
-  # stale path still passes the PROJ_ABS_REAL comparison and validate_spawn_worktree
-  # below (it resolves to a real, distinct worktree top-level too), so accepting it
-  # on one read alone silently records the wrong worktree= in state/<id>.meta. Require
-  # two consecutive reads to agree on the same non-project path before accepting it;
-  # a mismatch just becomes the new candidate rather than resetting the wait, so a
-  # pane that is already settled by the first real read only costs the one existing
-  # inter-poll sleep as confirmation, not a whole extra cycle on top.
+  # A single read that is genuinely outside the project is still not proof the
+  # pane settled there: on some tmux/WSL setups a brand-new window's
+  # pane_current_path transiently reports an unrelated stale path (seen live as
+  # another real git checkout entirely) before the shell catches up with
+  # treehouse get's cd. That stale path resolves to a real, distinct worktree
+  # top-level too, so it passes validate_spawn_worktree below, and accepting it
+  # on one read alone silently records the wrong worktree= in state/<id>.meta.
+  # Require two consecutive reads to agree on the same non-project directory
+  # before accepting it; a mismatch just becomes the new candidate rather than
+  # resetting the wait, so a pane that is already settled by the first real read
+  # only costs the one existing inter-poll sleep as confirmation, not a whole
+  # extra cycle on top. A read whose identity cannot be taken at all is not a
+  # settled directory, so it keeps the loop waiting rather than becoming a
+  # candidate that the guard would only have to refuse later.
   candidate=""
   for _ in $(seq 1 60); do
     p=$(spawn_current_path "$WT_TARGET" || true)
-    if [ -n "$p" ]; then
-      p_real=$(real_path_or_raw "$p")
-      if [ "$p_real" != "$PROJ_ABS_REAL" ]; then
-        if [ -n "$candidate" ] && [ "$p_real" = "$candidate" ]; then
-          WT="$p"
-          break
-        fi
-        candidate="$p_real"
-      else
-        candidate=""
+    p_id=$(path_identity "$p")
+    if [ -n "$p_id" ] && [ "$p_id" != "$PROJ_ABS_ID" ]; then
+      if [ -n "$candidate" ] && [ "$p_id" = "$candidate" ]; then
+        WT="$p"
+        break
       fi
+      candidate="$p_id"
     else
       candidate=""
     fi

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -201,6 +201,7 @@ family_for_basename() {
     fm-herdr-session-cleanup.test.sh|fm-send-resolve-key.test.sh|fm-send-strict.test.sh|fm-spawn-batch.test.sh|\
     fm-spawn-dispatch-profile.test.sh|\
     fm-trace-context-spawn.test.sh|fm-spawn-worktree-settle.test.sh|\
+    fm-spawn-path-case.test.sh|\
     fm-teardown-endpoint-safety.test.sh)
       printf '%s\n' backend-dispatch
       ;;

--- a/tests/fm-spawn-path-case.test.sh
+++ b/tests/fm-spawn-path-case.test.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# Regression test for fm-spawn.sh's directory comparisons when one directory is
+# reachable under more than one spelling (bin/fm-spawn.sh: the treehouse-get
+# settle loop and validate_spawn_worktree).
+#
+# macOS volumes are case-insensitive by default, so /a/Code/x and /a/code/x are
+# ONE directory. bash's `pwd -P` resolves symlinks but preserves whatever case
+# the caller cd'd with, while every backend's pane-path read and
+# `git rev-parse --show-toplevel` report the canonical case. Comparing those as
+# strings made two spellings of one directory look like two directories, and
+# broke the spawn chain in both directions:
+#
+#   - The settle loop read the pane's canonical-case PROJECT path as "the pane
+#     already left the project", accepted it, and recorded the PRIMARY CHECKOUT
+#     as worktree= in state/<id>.meta - the exact tangle the loop exists to
+#     prevent. validate_spawn_worktree then compared the same two spellings and
+#     passed instead of refusing.
+#   - Read the other way, a legitimate worktree reported under a non-canonical
+#     spelling failed the guard's own wt/wt-top check, refusing a spawn that
+#     never tangled anything.
+#
+# Both directions are pinned below, together with the guard's refusal on a path
+# it cannot prove is an isolated worktree, so no future change can buy the first
+# two by making the guard lenient.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=$(fm_test_tmproot fm-spawn-path-case)
+
+# Filesystem identity of a directory: equal for every spelling that reaches one
+# directory. The assertions below compare recorded paths this way rather than as
+# strings, because the meta may legitimately record any spelling of the right
+# directory - only which directory it names is under test.
+if [ "$(uname -s 2>/dev/null || true)" = Darwin ]; then
+  dir_identity() { stat -f '%d:%i' "$1" 2>/dev/null || true; }
+else
+  dir_identity() { stat -c '%d:%i' "$1" 2>/dev/null || true; }
+fi
+
+# lower_case_component <path> <mixed-case-component>: the same path with that one
+# component lowercased, leaving every other byte untouched.
+lower_case_component() {
+  local path=$1 component=$2 lowered
+  lowered=$(printf '%s' "$component" | tr '[:upper:]' '[:lower:]')
+  printf '%s\n' "${path//$component/$lowered}"
+}
+
+# This whole file is about a case-INSENSITIVE filesystem. On a case-sensitive one
+# the two spellings are genuinely two directories and there is no bug to pin, so
+# skip loudly rather than passing vacuously.
+mkdir -p "$TMP_ROOT/CaseProbe"
+if [ -z "$(dir_identity "$TMP_ROOT/CaseProbe")" ] ||
+  [ "$(dir_identity "$TMP_ROOT/CaseProbe")" != "$(dir_identity "$TMP_ROOT/caseprobe")" ]; then
+  echo "skip: ${TMPDIR:-/tmp} is a case-sensitive filesystem; the path-case tangle cannot occur here"
+  exit 0
+fi
+
+# make_case_fakebin <dir>: a fake tmux whose `#{pane_current_path}` query walks a
+# scripted sequence of paths, one per line, repeating the last line forever. The
+# sequence is how each case below stages what the pane reports and when.
+make_case_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*)
+    seqfile="${FM_FAKE_PANE_SEQUENCE:?FM_FAKE_PANE_SEQUENCE unset}"
+    countfile="${FM_FAKE_PANE_COUNTFILE:?FM_FAKE_PANE_COUNTFILE unset}"
+    n=0
+    [ -f "$countfile" ] && n=$(cat "$countfile")
+    n=$((n + 1))
+    printf '%s\n' "$n" > "$countfile"
+    total=$(wc -l < "$seqfile" | tr -d ' ')
+    [ "$n" -le "$total" ] || n=$total
+    sed -n "${n}p" "$seqfile"
+    exit 0
+    ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  has-session|new-session|new-window|kill-window) exit 0 ;;
+  send-keys) exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse
+  printf '%s\n' "$fakebin"
+}
+
+# make_case_home <name> <id>: a firstmate home plus a project with one real
+# worktree, both under a deliberately mixed-case directory component so each case
+# can address them under a second, lowercased spelling of the same directories.
+# Sets CASE_DIR / HOME_DIR / PROJ_DIR / WT_DIR / FAKEBIN_DIR / SEQFILE /
+# COUNTFILE, and the ALT_* spellings that reach the very same directories.
+make_case_home() {
+  local name=$1 id=$2
+  CASE_DIR="$TMP_ROOT/CaseSpawn-$name"
+  HOME_DIR="$CASE_DIR/home"
+  PROJ_DIR="$CASE_DIR/project"
+  WT_DIR="$CASE_DIR/wt"
+  SEQFILE="$CASE_DIR/pane-sequence"
+  COUNTFILE="$CASE_DIR/pane-call-count"
+  mkdir -p "$HOME_DIR/data" "$HOME_DIR/projects" "$HOME_DIR/state" "$HOME_DIR/config"
+  printf 'codex\n' > "$HOME_DIR/config/crew-harness"
+  fm_git_worktree "$PROJ_DIR" "$WT_DIR" "wt-$name"
+  mkdir -p "$HOME_DIR/data/$id"
+  printf 'brief for %s\n' "$id" > "$HOME_DIR/data/$id/brief.md"
+  touch "$HOME_DIR/state/.last-watcher-beat"
+  FAKEBIN_DIR=$(make_case_fakebin "$CASE_DIR/fake")
+  ALT_PROJ_DIR=$(lower_case_component "$PROJ_DIR" "CaseSpawn-$name")
+  ALT_WT_DIR=$(lower_case_component "$WT_DIR" "CaseSpawn-$name")
+  # The alternate spellings must reach the very same directories, or every case
+  # below would be testing two unrelated paths instead of one path twice.
+  [ -n "$(dir_identity "$PROJ_DIR")" ] && [ "$(dir_identity "$PROJ_DIR")" = "$(dir_identity "$ALT_PROJ_DIR")" ] ||
+    fail "fixture: '$ALT_PROJ_DIR' does not reach the same directory as '$PROJ_DIR'"
+  [ -n "$(dir_identity "$WT_DIR")" ] && [ "$(dir_identity "$WT_DIR")" = "$(dir_identity "$ALT_WT_DIR")" ] ||
+    fail "fixture: '$ALT_WT_DIR' does not reach the same directory as '$WT_DIR'"
+}
+
+# stage_pane_sequence <path> ...: what the pane reports, one read per argument,
+# with the last one repeating for the rest of the settle loop.
+stage_pane_sequence() {
+  local path
+  : > "$SEQFILE"
+  for path in "$@"; do
+    printf '%s\n' "$path" >> "$SEQFILE"
+  done
+  : > "$COUNTFILE"
+}
+
+# run_case_spawn <id> <project-arg>: spawn <id> against the project addressed
+# exactly as given, so a case can hand fm-spawn a non-canonical spelling.
+run_case_spawn() {
+  local id=$1 project_arg=$2
+  FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
+    FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+    FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
+    FM_FAKE_PANE_SEQUENCE="$SEQFILE" FM_FAKE_PANE_COUNTFILE="$COUNTFILE" \
+    PATH="$FAKEBIN_DIR:$PATH" \
+    "$SPAWN" "$id" "$project_arg" --mode no-mistakes --yolo off 2>&1
+}
+
+# recorded_worktree <id>: the worktree= value fm-spawn wrote to state/<id>.meta.
+recorded_worktree() {
+  sed -n 's/^worktree=//p' "$HOME_DIR/state/$1.meta" 2>/dev/null | head -n 1
+}
+
+# The incident itself. firstmate reaches the project under a non-canonical
+# spelling, so fm-spawn's own project path carries that spelling, while the pane
+# reports the canonical one until `treehouse get` lands. Those are the same
+# directory, so the settle loop must keep waiting for the real worktree rather
+# than accepting the project as one - and the recorded worktree must be the
+# isolated worktree, never the primary checkout.
+test_project_under_another_spelling_is_not_recorded_as_the_worktree() {
+  local id out status recorded
+  id="path-case-primary-c1"
+  make_case_home primary "$id"
+  # Four reads still inside the project (canonical spelling), then the worktree.
+  stage_pane_sequence "$PROJ_DIR" "$PROJ_DIR" "$PROJ_DIR" "$PROJ_DIR" "$WT_DIR"
+
+  out=$(run_case_spawn "$id" "$ALT_PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "spawn should succeed once the pane reaches the real worktree"
+  assert_contains "$out" "spawned $id" "spawn did not report success"
+
+  recorded=$(recorded_worktree "$id")
+  [ -n "$recorded" ] || fail "no worktree= recorded in state/$id.meta"
+  [ "$(dir_identity "$recorded")" != "$(dir_identity "$PROJ_DIR")" ] ||
+    fail "meta recorded the PRIMARY CHECKOUT as the worktree ('$recorded'); the project reached under another spelling was mistaken for an isolated worktree"
+  [ "$(dir_identity "$recorded")" = "$(dir_identity "$WT_DIR")" ] ||
+    fail "meta recorded '$recorded', which is not the isolated worktree '$WT_DIR'"
+  pass "the project reached under another spelling is not accepted as the worktree"
+}
+
+# The same comparison read the other way. The pane reports the real worktree
+# under a non-canonical spelling while git reports its canonical top-level; that
+# is one directory, so the isolation guard must accept it instead of refusing a
+# spawn that never tangled anything.
+test_worktree_under_another_spelling_is_still_accepted() {
+  local id out status recorded
+  id="path-case-worktree-c2"
+  make_case_home worktree "$id"
+  stage_pane_sequence "$PROJ_DIR" "$ALT_WT_DIR"
+
+  out=$(run_case_spawn "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "spawn should accept the real worktree reported under another spelling, got: $out"
+  assert_contains "$out" "spawned $id" "spawn did not report success"
+
+  recorded=$(recorded_worktree "$id")
+  [ "$(dir_identity "$recorded")" = "$(dir_identity "$WT_DIR")" ] ||
+    fail "meta recorded '$recorded', which is not the isolated worktree '$WT_DIR'"
+  pass "the real worktree reported under another spelling is still accepted"
+}
+
+# The refusal itself must survive the fix. A path inside the project is not the
+# top-level of any worktree, so the guard cannot prove isolation and must refuse
+# loudly rather than launch - the same refusal, now decided on directory identity
+# instead of string spelling.
+test_guard_still_refuses_a_path_that_is_not_a_worktree_root() {
+  local id out status
+  id="path-case-refuse-c3"
+  make_case_home refuse "$id"
+  mkdir -p "$PROJ_DIR/nested"
+  stage_pane_sequence "$PROJ_DIR" "$PROJ_DIR/nested"
+
+  out=$(run_case_spawn "$id" "$ALT_PROJ_DIR")
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn should refuse a path that is not a worktree root, got exit 0: $out"
+  assert_contains "$out" "did not yield an isolated worktree" \
+    "refusal did not name the isolation failure"
+  assert_absent "$HOME_DIR/state/$id.meta" \
+    "a refused spawn must not record task metadata"
+  pass "the isolation guard still refuses a path it cannot prove is a worktree root"
+}
+
+test_project_under_another_spelling_is_not_recorded_as_the_worktree
+test_worktree_under_another_spelling_is_still_accepted
+test_guard_still_refuses_a_path_that_is_not_a_worktree_root
+
+echo "# all fm-spawn-path-case tests passed"


### PR DESCRIPTION
## Intent

The developer (as firstmate, delegating to a crewmate) directed a fix for a path-comparison bug in bin/fm-spawn.sh where two differently-cased spellings of the same working directory (e.g. on a case-insensitive filesystem) could cause fm-spawn.sh to silently launch a crewmate in the primary firstmate checkout instead of an isolated worktree. The diagnosis was already complete: string comparisons of paths in the FM_ROOT resolution, the treehouse wait loop, and the isolation guard all needed to be replaced with device+inode comparisons (via stat) so that two spellings of the same real directory compare equal, without weakening the guard's hard-refusal behavior when isolation can't be proven. The developer required a regression test simulating a differently-cased cwd to prove the fix, required the crewmate to verify isolation in its own disposable worktree before touching anything, and mandated the standard firstmate delivery workflow: branch creation, no-mistakes validation pipeline with gated fix/review responses (never self-applying fixes or committing during an active validation run), and status reporting only at meaningful phase changes. The crewmate additionally found and fixed a second, opposite-direction bug in the same comparison chain (false refusal of legitimate spawns) and added a corresponding pinned test, then began running the /no-mistakes validation pipeline, which is still in progress in the transcript.

## What Changed

- Replaced string comparisons of canonicalized paths in `bin/fm-spawn.sh` with device+inode identity checks (`path_identity`, using `stat -f`/`stat -c`) across the project-path resolution, the treehouse settle-wait loop, the isolation guard (`validate_spawn_worktree`), and the relaunch pane-settle check, so two differently-cased spellings of the same directory (e.g. on a case-insensitive filesystem) are recognized as one directory instead of two.
- Preserved fail-refuse behavior: an unreadable or empty identity is treated as unproven isolation, which still waits or refuses rather than assuming success.
- Added `tests/fm-spawn-path-case.test.sh` covering the primary-checkout-recorded-as-worktree case, the worktree-under-alt-spelling acceptance case, and the guard's continued refusal of a non-worktree-root path, and registered it in `bin/fm-test-run.sh`'s `backend-dispatch` test family.

## Risk Assessment

✅ Low: The change replaces string-based path comparisons with device+inode identity comparisons (via a new path_identity helper) at exactly the three call sites the bug report identified, preserves fail-closed behavior when identity can't be proven (empty stat output never matches), removes the now-dead real_path_or_raw helper with no leftover references, passes shellcheck and bash -n cleanly, and ships a well-constructed regression test (skips gracefully on case-sensitive filesystems, pins both directions of the bug plus the guard's legitimate refusal case) that was correctly registered in the test runner's family list.

## Testing

Verified the fix by running the new regression test against both the target and base commits: it fails on base (reproducing the exact case-spelling tangle bug where the primary checkout gets recorded as the isolated worktree) and passes cleanly on target, and the full backend-dispatch test family shows no regressions beyond one pre-existing, environment-only failure (missing `tasks-axi` binary) reproduced identically on the base commit.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-spawn-path-case.test.sh` on target commit f76e50a — all 3 pinned cases pass (project-under-alt-spelling not recorded as worktree; worktree-under-alt-spelling still accepted; guard still refuses a non-worktree-root path)</code>
- <code>`bash tests/fm-spawn-path-case.test.sh` on base commit f242264 (via a detached temp worktree, cleaned up afterward) — fails exactly as expected, reproducing the primary-checkout-recorded-as-worktree bug the fix addresses</code>
- <code>`bin/fm-test-run.sh --family backend-dispatch` (15 test files including fm-spawn-path-case.test.sh and the related fm-spawn-worktree-settle.test.sh) — 14/15 pass; one unrelated pre-existing failure in fm-backend.test.sh&#39;s legacy teardown fixture, traced to a missing `tasks-axi` binary and reproduced identically on the base commit</code>
- <code>`bash tests/fm-backend.test.sh` standalone — confirmed the pre-existing &#39;symlinked prefix does not trip the isolation guard&#39; case (adjacent path-identity behavior) still passes, and confirmed the one failing case is environment-only (tasks-axi absent), not code-related</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Lint** - skipped</summary>

- ⚠️ linter found issues (exit code 127)

🔧 Fix: No lint fix needed; ShellCheck clean, actionlint missing is pre-existing env gap
1 warning still open:
- ⚠️ linter found issues (exit code 127)

🔧 Fix: No lint fix needed; ShellCheck clean, actionlint absence is pre-existing env gap
1 warning still open:
- ⚠️ linter found issues (exit code 127)

🔧 Fix: No lint fixes needed; ShellCheck clean, actionlint absence is a pre-existing sandbox gap
1 warning still open:
- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
