### PR TITLE
feat(bin): add guarded user-skill canonicalization command

### DIFF
--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -146,7 +146,7 @@ family_for_basename() {
     fm-subagent-pretool-check.test.sh|\
     fm-supervision-instructions.test.sh|fm-task-delivery.test.sh|\
     fm-tmux-submit-busy.test.sh|fm-trace-context-lib.test.sh|\
-    fm-transition-lib.test.sh|\
+    fm-transition-lib.test.sh|fm-user-skill-sync.test.sh|\
     fm-test-run.test.sh|fm-test-isolation-proof.test.sh)
       printf '%s\n' pure-contract-unit
       ;;

--- a/bin/fm-user-skill-sync.sh
+++ b/bin/fm-user-skill-sync.sh
@@ -12,7 +12,8 @@
 # broken link, special file, malformed skill directory, unexpected root entry,
 # overlapping managed roots, or ambiguous tree refuses the whole run before any
 # mutation. Skill trees may contain directories and regular files only and must
-# include SKILL.md. Managed roots are compared by filesystem identity rather than
+# include SKILL.md. A duplicate is verified only when its tree matches the
+# retained copy in structure, bytes, and permission bits. Managed roots are compared by filesystem identity rather than
 # path spelling, so a case-insensitive volume or an aliased path cannot present
 # one directory under two ownership roles.
 #
@@ -135,8 +136,35 @@ PI="$HOME/.pi/agent/skills"
 # whole-root link to the canonical store is a supported input this run converges
 # rather than an ownership collision. GNU stat is probed before BSD stat because
 # BSD's -f prints inode fields while GNU's -f prints filesystem fields.
+if stat -c '%d:%i' / >/dev/null 2>&1; then
+  STAT_IDENTITY_FORMAT='-c'
+  STAT_IDENTITY_SPEC='%d:%i'
+  STAT_MODE_SPEC='%a %n'
+elif stat -f '%d:%i' / >/dev/null 2>&1; then
+  STAT_IDENTITY_FORMAT='-f'
+  STAT_IDENTITY_SPEC='%d:%i'
+  STAT_MODE_SPEC='%Lp %N'
+else
+  die "stat does not report device, inode, and permission fields"
+fi
+
 path_identity() {
-  stat -c '%d:%i' "$1" 2>/dev/null || stat -f '%d:%i' "$1" 2>/dev/null
+  stat "$STAT_IDENTITY_FORMAT" "$STAT_IDENTITY_SPEC" "$1" 2>/dev/null
+}
+
+# Identity of a path and of every existing ancestor above it, so containment is
+# answered from one precomputed chain instead of re-walking per comparison.
+path_identity_chain() {
+  local probe=$1 id
+  while :; do
+    if [ -e "$probe" ] || [ -L "$probe" ]; then
+      id=$(path_identity "$probe") || id=
+      [ -z "$id" ] || printf '%s\n' "$id"
+    fi
+    [ "$probe" != / ] || break
+    probe=${probe%/*}
+    [ -n "$probe" ] || probe=/
+  done
 }
 
 nearest_existing_ancestor() {
@@ -162,18 +190,21 @@ unresolved_suffix() {
   printf '\n'
 }
 
-path_contains_identity() {
-  local probe=$1 wanted=$2 id
-  while :; do
-    if [ -e "$probe" ] || [ -L "$probe" ]; then
-      id=$(path_identity "$probe") || id=
-      [ -z "$id" ] || [ "$id" != "$wanted" ] || return 0
-    fi
-    [ "$probe" != / ] || break
-    probe=${probe%/*}
-    [ -n "$probe" ] || probe=/
-  done
+chain_contains_identity() {
+  local chain=$1 wanted=$2
+  [ -n "$wanted" ] || return 1
+  case "
+$chain
+" in
+    *"
+$wanted
+"*) return 0 ;;
+  esac
   return 1
+}
+
+path_contains_identity() {
+  chain_contains_identity "$(path_identity_chain "$1")" "$2"
 }
 
 path_self_identity() {
@@ -200,32 +231,56 @@ managed_root_for_role() {
     *) die "internal error: unknown managed root role $1" ;;
   esac
 }
-for role_a in $MANAGED_ROLES; do
-  root_a=$(managed_root_for_role "$role_a")
-  self_a=$(path_self_identity "$root_a")
-  anchor_a=$(path_identity "$(nearest_existing_ancestor "$root_a")") \
-    || die "cannot resolve managed skill root ancestor: $root_a"
-  [ -n "$anchor_a" ] || die "cannot resolve managed skill root ancestor: $root_a"
-  suffix_a=$(unresolved_suffix "$root_a")
-  for role_b in $MANAGED_ROLES; do
-    [ "$role_a" != "$role_b" ] || continue
-    root_b=$(managed_root_for_role "$role_b")
-    self_b=$(path_self_identity "$root_b")
-    if [ -n "$self_a" ] && [ "$self_a" = "$self_b" ]; then
+ROLE_NAME=()
+ROLE_PATH=()
+ROLE_SELF=()
+ROLE_CHAIN=()
+ROLE_ANCHOR=()
+ROLE_SUFFIX=()
+for role in $MANAGED_ROLES; do
+  role_root=$(managed_root_for_role "$role")
+  role_anchor=$(path_identity "$(nearest_existing_ancestor "$role_root")") || role_anchor=
+  [ -n "$role_anchor" ] || die "cannot resolve managed skill root ancestor: $role_root"
+  ROLE_NAME+=("$role")
+  ROLE_PATH+=("$role_root")
+  ROLE_SELF+=("$(path_self_identity "$role_root")")
+  ROLE_CHAIN+=("$(path_identity_chain "$role_root")")
+  ROLE_ANCHOR+=("$role_anchor")
+  ROLE_SUFFIX+=("$(unresolved_suffix "$role_root")")
+done
+
+role_count=${#ROLE_NAME[@]}
+index_a=0
+while [ "$index_a" -lt "$role_count" ]; do
+  index_b=0
+  while [ "$index_b" -lt "$role_count" ]; do
+    if [ "$index_a" -eq "$index_b" ]; then
+      index_b=$((index_b + 1))
+      continue
+    fi
+    role_a=${ROLE_NAME[$index_a]}
+    role_b=${ROLE_NAME[$index_b]}
+    root_a=${ROLE_PATH[$index_a]}
+    root_b=${ROLE_PATH[$index_b]}
+    self_a=${ROLE_SELF[$index_a]}
+    if [ -n "$self_a" ] && [ "$self_a" = "${ROLE_SELF[$index_b]}" ]; then
       die "managed skill roots $role_a and $role_b are the same directory: $root_a and $root_b"
     fi
-    if [ -n "$self_a" ] && path_contains_identity "$root_b" "$self_a"; then
+    if chain_contains_identity "${ROLE_CHAIN[$index_b]}" "$self_a"; then
       die "managed skill root $role_b is nested inside $role_a: $root_b"
     fi
-    anchor_b=$(path_identity "$(nearest_existing_ancestor "$root_b")") || anchor_b=
-    if [ -n "$anchor_b" ] && [ "$anchor_a" = "$anchor_b" ]; then
-      [ "$suffix_a" != "$(unresolved_suffix "$root_b")" ] \
+    if [ "${ROLE_ANCHOR[$index_a]}" = "${ROLE_ANCHOR[$index_b]}" ]; then
+      suffix_a=${ROLE_SUFFIX[$index_a]}
+      suffix_b=${ROLE_SUFFIX[$index_b]}
+      [ "$suffix_a" != "$suffix_b" ] \
         || die "managed skill roots $role_a and $role_b resolve to the same directory: $root_a and $root_b"
-      case "$(unresolved_suffix "$root_b")" in
+      case "$suffix_b" in
         "$suffix_a"/*) die "managed skill root $role_b is nested inside $role_a: $root_b" ;;
       esac
     fi
+    index_b=$((index_b + 1))
   done
+  index_a=$((index_a + 1))
 done
 
 for parent in \
@@ -254,6 +309,27 @@ PLAN="$TMP/plan"
 : > "$INVENTORY"
 : > "$ROOT_LINKS"
 : > "$PLAN"
+
+# A verified duplicate must match the retained tree in structure, bytes, and
+# permission bits, otherwise removing it would silently drop the only copy that
+# carries an executable helper script.
+tree_mode_listing() {
+  local tree=$1
+  find -P "$tree" \( -type d -o -type f \) -exec stat "$STAT_IDENTITY_FORMAT" "$STAT_MODE_SPEC" {} + 2>/dev/null \
+    | awk -v prefix="$tree" '{
+        mode = $1
+        sub(/^[^ ]* /, "")
+        if (index($0, prefix) == 1) { $0 = substr($0, length(prefix) + 1) }
+        print mode " " $0
+      }' \
+    | LC_ALL=C sort
+}
+
+trees_equivalent() {
+  local a=$1 b=$2
+  diff -qr "$a" "$b" >/dev/null 2>&1 || return 1
+  [ "$(tree_mode_listing "$a")" = "$(tree_mode_listing "$b")" ]
+}
 
 validate_skill_tree() {
   local skill=$1 bad
@@ -363,7 +439,7 @@ while IFS= read -r name; do
   while IFS=$'\t' read -r inv_name kind path role; do
     [ "$inv_name" = "$name" ] || continue
     if [ "$kind" = real ] && [ "$path" != "$baseline" ]; then
-      diff -qr "$baseline" "$path" >/dev/null 2>&1 || die "conflicting skill trees for '$name': $baseline and $path"
+      trees_equivalent "$baseline" "$path" || die "conflicting skill trees for '$name': $baseline and $path"
     fi
   done < "$INVENTORY"
 
@@ -425,7 +501,7 @@ remove_verified_duplicate() {
     verify_link_to_canonical "$path" "$name"
   elif [ -d "$path" ]; then
     validate_skill_tree "$path"
-    diff -qr "$canonical" "$path" >/dev/null 2>&1 || die "duplicate changed after preflight: $path"
+    trees_equivalent "$canonical" "$path" || die "duplicate changed after preflight: $path"
   else
     die "duplicate changed type after preflight: $path"
   fi

--- a/bin/fm-user-skill-sync.sh
+++ b/bin/fm-user-skill-sync.sh
@@ -102,10 +102,20 @@ case "$HOME" in /*) ;; *) die "HOME must be absolute: $HOME" ;; esac
 case "/$HOME/" in */../*|*/./*) die "HOME contains traversal components: $HOME" ;; esac
 case "$HOME" in *$'\n'*|*$'\r'*|*$'\t'*) die "HOME must not contain control characters" ;; esac
 HOME=$(cd "$HOME" && pwd -P)
-CODEX_ROOT=${CODEX_HOME:-$HOME/.codex}
-while case "$CODEX_ROOT" in *'//'*) true ;; *) false ;; esac; do
-  CODEX_ROOT=${CODEX_ROOT//\/\//\/}
-done
+# Separator spelling must never reach path construction: relative_path splits on
+# every component, so a duplicate or trailing slash would emit a wrong link.
+normalize_absolute_path() {
+  local path=$1
+  while case "$path" in *'//'*) true ;; *) false ;; esac; do
+    path=${path//\/\//\/}
+  done
+  while [ "$path" != / ] && [ "$path" != "${path%/}" ]; do
+    path=${path%/}
+  done
+  printf '%s\n' "$path"
+}
+
+CODEX_ROOT=$(normalize_absolute_path "${CODEX_HOME:-$HOME/.codex}")
 case "$CODEX_ROOT" in /*) ;; *) die "CODEX_HOME must be absolute: $CODEX_ROOT" ;; esac
 case "/$CODEX_ROOT/" in */../*|*/./*) die "CODEX_HOME contains traversal components: $CODEX_ROOT" ;; esac
 case "$CODEX_ROOT" in *$'\n'*|*$'\r'*|*$'\t'*) die "CODEX_HOME must not contain control characters" ;; esac
@@ -123,7 +133,9 @@ physicalize_path() {
   physical=$(cd "$probe" && pwd -P) || die "cannot resolve CODEX_HOME ancestor: $probe"
   printf '%s%s\n' "$physical" "$suffix"
 }
-CODEX_ROOT=$(physicalize_path "$CODEX_ROOT")
+CODEX_ROOT=$(normalize_absolute_path "$(physicalize_path "$CODEX_ROOT")")
+case "$CODEX_ROOT" in /*) ;; *) die "CODEX_HOME must resolve to an absolute path: $CODEX_ROOT" ;; esac
+[ "$CODEX_ROOT" != / ] || die "CODEX_HOME must not be the filesystem root"
 
 CANON="$HOME/.agents/skills"
 CLAUDE="$HOME/.claude/skills"
@@ -309,6 +321,7 @@ trap 'rm -rf "$TMP"' EXIT INT TERM
 INVENTORY="$TMP/inventory"
 ROOT_LINKS="$TMP/root-links"
 PLAN="$TMP/plan"
+TREE_NAMES="$TMP/tree-names"
 : > "$INVENTORY"
 : > "$ROOT_LINKS"
 : > "$PLAN"
@@ -349,7 +362,8 @@ validate_skill_tree() {
   [ -f "$skill/SKILL.md" ] && [ ! -L "$skill/SKILL.md" ] || die "skill lacks a regular SKILL.md: $skill"
   bad=$(find -P "$skill" ! -type d ! -type f -print -quit 2>/dev/null) || die "cannot inspect skill tree: $skill"
   [ -z "$bad" ] || die "skill tree contains a link or special entry: $bad"
-  control=$(LC_ALL=C find -P "$skill" -print0 | LC_ALL=C tr -d '\000' | LC_ALL=C tr -dc '[:cntrl:]' | wc -c) \
+  LC_ALL=C find -P "$skill" -print0 > "$TREE_NAMES" || die "cannot inspect skill tree names: $skill"
+  control=$(LC_ALL=C tr -d '\000' < "$TREE_NAMES" | LC_ALL=C tr -dc '[:cntrl:]' | wc -c) \
     || die "cannot inspect skill tree names: $skill"
   [ "$control" -eq 0 ] || die "skill tree contains a control character in a nested name: $skill"
 }

--- a/bin/fm-user-skill-sync.sh
+++ b/bin/fm-user-skill-sync.sh
@@ -135,7 +135,8 @@ physicalize_path() {
   physical=$(cd "$probe" && pwd -P) || die "cannot resolve CODEX_HOME ancestor: $probe"
   printf '%s%s\n' "$physical" "$suffix"
 }
-CODEX_ROOT=$(normalize_absolute_path "$(physicalize_path "$CODEX_ROOT")")
+CODEX_ROOT=$(physicalize_path "$CODEX_ROOT")
+CODEX_ROOT=$(normalize_absolute_path "$CODEX_ROOT")
 case "$CODEX_ROOT" in /*) ;; *) die "CODEX_HOME must resolve to an absolute path: $CODEX_ROOT" ;; esac
 [ "$CODEX_ROOT" != / ] || die "CODEX_HOME must not be the filesystem root"
 
@@ -321,7 +322,22 @@ for managed in "$CANON" "$CLAUDE" "$CODEX" "$GEMINI" "$OPENCODE_CONFIG" "$OPENCO
 done
 
 TMP=$(mktemp -d "${TMPDIR:-/tmp}/fm-user-skill-sync.XXXXXX") || die "cannot create preflight workspace"
-trap 'rm -rf "$TMP"' EXIT INT TERM
+cleanup_workspace() {
+  rm -rf "$TMP"
+}
+
+# A signal handler that only cleans up would let the interrupted apply loop run
+# to completion and report success, so INT and TERM exit with their conventional
+# statuses instead.
+interrupted() {
+  cleanup_workspace
+  printf 'error: interrupted by %s; any earlier planned changes remain applied\n' "$1" >&2
+  exit "$2"
+}
+
+trap cleanup_workspace EXIT
+trap 'interrupted SIGINT 130' INT
+trap 'interrupted SIGTERM 143' TERM
 INVENTORY="$TMP/inventory"
 ROOT_LINKS="$TMP/root-links"
 PLAN="$TMP/plan"

--- a/bin/fm-user-skill-sync.sh
+++ b/bin/fm-user-skill-sync.sh
@@ -1,0 +1,345 @@
+#!/usr/bin/env bash
+# Converge user-installed skills into one canonical cross-harness layout.
+#
+# The canonical content store is $HOME/.agents/skills. Claude Code and Codex
+# receive relative per-skill links in their user skill roots. Gemini, OpenCode,
+# and Pi discover the canonical store natively, so verified duplicates in their
+# legacy user roots are removed. Codex's vendor-owned skills/.system entry and
+# plugin installations are never inspected or changed.
+#
+# Every local run performs a complete read-only preflight before acting. Dry-run
+# is the default; --apply is the only mutation switch. A conflict, unsafe or
+# broken link, special file, malformed skill directory, unexpected root entry,
+# or ambiguous tree refuses the whole run before any mutation. Skill trees may
+# contain directories and regular files only and must include SKILL.md.
+#
+# Remote operation is routed only through a registered remote secondmate record
+# and bin/fm-on.sh, which binds the configured SSH host, code root, and remote
+# home without fallback. It executes this same tracked script in the remote
+# account. Plugin distribution remains a separate operation.
+#
+# Usage:
+#   fm-user-skill-sync.sh [--dry-run|--apply]
+#   fm-user-skill-sync.sh --remote <secondmate-id|ssh-alias> [--dry-run|--apply]
+#
+# Environment:
+#   HOME        Absolute user home whose skill roots are reconciled.
+#   CODEX_HOME  Optional absolute Codex home (default: $HOME/.codex).
+#
+# Managed user roots:
+#   $HOME/.agents/skills                 canonical content
+#   $HOME/.claude/skills                 relative links
+#   ${CODEX_HOME:-$HOME/.codex}/skills   relative links; .system preserved
+#   $HOME/.gemini/skills                 duplicate cleanup only
+#   $HOME/.config/opencode/skills        duplicate cleanup only
+#   $HOME/.opencode/skills               duplicate cleanup only
+#   $HOME/.pi/agent/skills               duplicate cleanup only
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+MODE=dry-run
+ACTION_SET=0
+REMOTE=
+
+usage() {
+  sed -n '2,/^set -eu$/p' "$0" | sed '/^set -eu$/d; s/^# \{0,1\}//'
+}
+
+die() {
+  printf 'error: %s\n' "$1" >&2
+  exit 1
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dry-run)
+      [ "$ACTION_SET" -eq 0 ] || die "choose exactly one of --dry-run or --apply"
+      MODE=dry-run
+      ACTION_SET=1
+      ;;
+    --apply)
+      [ "$ACTION_SET" -eq 0 ] || die "choose exactly one of --dry-run or --apply"
+      MODE=apply
+      ACTION_SET=1
+      ;;
+    --remote)
+      [ "$#" -ge 2 ] || die "--remote requires a registered secondmate id or SSH alias"
+      [ -z "$REMOTE" ] || die "--remote may be specified only once"
+      REMOTE=$2
+      shift
+      ;;
+    --help|-h) usage; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+  shift
+done
+
+if [ -n "$REMOTE" ]; then
+  case "$REMOTE" in ''|-*|*[!A-Za-z0-9._-]*) die "unsafe remote route: $REMOTE" ;; esac
+  if [ "$MODE" = apply ]; then
+    exec "$SCRIPT_DIR/fm-on.sh" "$REMOTE" fm-user-skill-sync.sh --apply
+  fi
+  exec "$SCRIPT_DIR/fm-on.sh" "$REMOTE" fm-user-skill-sync.sh --dry-run
+fi
+
+[ -n "${HOME:-}" ] || die "HOME is required"
+case "$HOME" in /*) ;; *) die "HOME must be absolute: $HOME" ;; esac
+[ -d "$HOME" ] && [ ! -L "$HOME" ] || die "HOME must be a real directory: $HOME"
+case "/$HOME/" in */../*|*/./*) die "HOME contains traversal components: $HOME" ;; esac
+case "$HOME" in *$'\n'*|*$'\r'*|*$'\t'*) die "HOME must not contain control characters" ;; esac
+HOME=$(cd "$HOME" && pwd -P)
+CODEX_ROOT=${CODEX_HOME:-$HOME/.codex}
+while case "$CODEX_ROOT" in *'//'*) true ;; *) false ;; esac; do
+  CODEX_ROOT=${CODEX_ROOT//\/\//\/}
+done
+case "$CODEX_ROOT" in /*) ;; *) die "CODEX_HOME must be absolute: $CODEX_ROOT" ;; esac
+case "/$CODEX_ROOT/" in */../*|*/./*) die "CODEX_HOME contains traversal components: $CODEX_ROOT" ;; esac
+case "$CODEX_ROOT" in *$'\n'*|*$'\r'*|*$'\t'*) die "CODEX_HOME must not contain control characters" ;; esac
+
+physicalize_path() {
+  local probe=$1 suffix='' base parent physical
+  while [ ! -e "$probe" ] && [ ! -L "$probe" ]; do
+    base=${probe##*/}
+    parent=${probe%/*}
+    [ -n "$parent" ] || parent=/
+    suffix="/$base$suffix"
+    probe=$parent
+  done
+  [ -d "$probe" ] || die "existing CODEX_HOME ancestor is not a directory: $probe"
+  physical=$(cd "$probe" && pwd -P) || die "cannot resolve CODEX_HOME ancestor: $probe"
+  printf '%s%s\n' "$physical" "$suffix"
+}
+CODEX_ROOT=$(physicalize_path "$CODEX_ROOT")
+
+CANON="$HOME/.agents/skills"
+CLAUDE="$HOME/.claude/skills"
+CODEX="$CODEX_ROOT/skills"
+GEMINI="$HOME/.gemini/skills"
+OPENCODE_CONFIG="$HOME/.config/opencode/skills"
+OPENCODE_LEGACY="$HOME/.opencode/skills"
+PI="$HOME/.pi/agent/skills"
+
+for parent in \
+  "$HOME/.agents" "$HOME/.claude" "$HOME/.gemini" "$HOME/.config" \
+  "$HOME/.config/opencode" "$HOME/.opencode" "$HOME/.pi" "$HOME/.pi/agent" \
+  "$CODEX_ROOT"; do
+  [ ! -L "$parent" ] || die "managed skill parent must not be a link: $parent"
+  [ ! -e "$parent" ] || [ -d "$parent" ] || die "managed skill parent is not a directory: $parent"
+done
+
+# The operator command owns user homes only. Refuse a synthetic HOME or
+# CODEX_HOME that points its managed roots into this repository.
+for managed in "$CANON" "$CLAUDE" "$CODEX" "$GEMINI" "$OPENCODE_CONFIG" "$OPENCODE_LEGACY" "$PI"; do
+  case "$managed/" in "$ROOT/"*) die "managed user root overlaps the Firstmate repository: $managed" ;; esac
+done
+
+TMP=$(mktemp -d "${TMPDIR:-/tmp}/fm-user-skill-sync.XXXXXX") || die "cannot create preflight workspace"
+trap 'rm -rf "$TMP"' EXIT INT TERM
+INVENTORY="$TMP/inventory"
+ROOT_LINKS="$TMP/root-links"
+PLAN="$TMP/plan"
+: > "$INVENTORY"
+: > "$ROOT_LINKS"
+: > "$PLAN"
+
+validate_skill_tree() {
+  local skill=$1 bad
+  [ -f "$skill/SKILL.md" ] && [ ! -L "$skill/SKILL.md" ] || die "skill lacks a regular SKILL.md: $skill"
+  bad=$(find -P "$skill" ! -type d ! -type f -print -quit 2>/dev/null) || die "cannot inspect skill tree: $skill"
+  [ -z "$bad" ] || die "skill tree contains a link or special entry: $bad"
+}
+
+physical_dir() {
+  (cd "$1" 2>/dev/null && pwd -P)
+}
+
+verify_link_to_canonical() {
+  local path=$1 name=$2 resolved expected
+  [ -e "$path" ] || die "broken skill link: $path"
+  [ -d "$path" ] || die "skill link does not resolve to a directory: $path"
+  resolved=$(physical_dir "$path") || die "cannot resolve skill link: $path"
+  expected=$(physical_dir "$CANON/$name") || die "skill link has no established canonical target: $path"
+  [ "$resolved" = "$expected" ] || die "unsafe skill link points outside the canonical store: $path"
+}
+
+scan_root() {
+  local role=$1 root=$2 entry name resolved expected
+  if [ -L "$root" ]; then
+    [ "$role" != canonical ] || die "canonical skill root must be a real directory: $root"
+    [ -e "$root" ] || die "broken managed skill root link: $root"
+    resolved=$(physical_dir "$root") || die "cannot resolve managed skill root link: $root"
+    expected=$(physical_dir "$CANON") || die "managed root link has no established canonical store: $root"
+    [ "$resolved" = "$expected" ] || die "unsafe managed skill root link points outside the canonical store: $root"
+    printf '%s\t%s\n' "$role" "$root" >> "$ROOT_LINKS"
+    return 0
+  fi
+  [ ! -e "$root" ] || [ -d "$root" ] || die "managed skill root is not a directory: $root"
+  [ -d "$root" ] || return 0
+  for entry in "$root"/* "$root"/.[!.]* "$root"/..?*; do
+    [ -e "$entry" ] || [ -L "$entry" ] || continue
+    name=${entry##*/}
+    [ "$name" = .system ] && [ "$role" = codex ] && continue
+    case "$name" in ''|.|..|*[!A-Za-z0-9._-]*) die "unexpected entry name in managed skill root: $entry" ;; esac
+    if [ -L "$entry" ]; then
+      [ "$role" != canonical ] || die "canonical skill entry must not be a link: $entry"
+      verify_link_to_canonical "$entry" "$name"
+      printf '%s\tlink\t%s\t%s\n' "$name" "$entry" "$role" >> "$INVENTORY"
+    elif [ -d "$entry" ]; then
+      validate_skill_tree "$entry"
+      printf '%s\treal\t%s\t%s\n' "$name" "$entry" "$role" >> "$INVENTORY"
+    else
+      die "unexpected entry in managed skill root: $entry"
+    fi
+  done
+}
+
+scan_root canonical "$CANON"
+scan_root claude "$CLAUDE"
+scan_root codex "$CODEX"
+scan_root gemini "$GEMINI"
+scan_root opencode "$OPENCODE_CONFIG"
+scan_root opencode "$OPENCODE_LEGACY"
+scan_root pi "$PI"
+
+relative_path() {
+  local from=${1#/} to=${2#/} first_from first_to up=
+  while [ -n "$from" ] && [ -n "$to" ]; do
+    first_from=${from%%/*}
+    first_to=${to%%/*}
+    [ "$first_from" = "$first_to" ] || break
+    if [ "$from" = "$first_from" ]; then from=; else from=${from#*/}; fi
+    if [ "$to" = "$first_to" ]; then to=; else to=${to#*/}; fi
+  done
+  while [ -n "$from" ]; do
+    first_from=${from%%/*}
+    up="${up}../"
+    if [ "$from" = "$first_from" ]; then from=; else from=${from#*/}; fi
+  done
+  printf '%s%s\n' "$up" "$to"
+}
+
+plan() {
+  printf '%s\t%s\t%s\n' "$1" "$2" "${3:-}" >> "$PLAN"
+}
+
+# Replace only whole-root links already proven to resolve to the canonical
+# store. Link-based native roots are removed; Claude and Codex become real roots
+# containing the required relative per-skill links.
+while IFS=$'\t' read -r role root; do
+  [ -n "$root" ] || continue
+  plan unlink-root "$root"
+  case "$role" in claude|codex) plan mkdir "$root" ;; esac
+done < "$ROOT_LINKS"
+
+# Root creation is part of convergence even for an empty skill collection.
+[ -d "$CANON" ] || plan mkdir "$CANON"
+[ -d "$CLAUDE" ] || [ -L "$CLAUDE" ] || plan mkdir "$CLAUDE"
+[ -d "$CODEX" ] || [ -L "$CODEX" ] || plan mkdir "$CODEX"
+
+cut -f1 "$INVENTORY" | LC_ALL=C sort -u > "$TMP/names"
+while IFS= read -r name; do
+  [ -n "$name" ] || continue
+  canonical=$(awk -F '\t' -v n="$name" '$1==n && $4=="canonical" {print $3; exit}' "$INVENTORY")
+  baseline=$canonical
+  if [ -z "$baseline" ]; then
+    baseline=$(awk -F '\t' -v n="$name" '$1==n && $2=="real" {print $3; exit}' "$INVENTORY")
+    [ -n "$baseline" ] || die "skill has links but no real owned copy: $name"
+    plan copy "$baseline" "$CANON/$name"
+  fi
+
+  while IFS=$'\t' read -r inv_name kind path role; do
+    [ "$inv_name" = "$name" ] || continue
+    if [ "$kind" = real ] && [ "$path" != "$baseline" ]; then
+      diff -qr "$baseline" "$path" >/dev/null 2>&1 || die "conflicting skill trees for '$name': $baseline and $path"
+    fi
+  done < "$INVENTORY"
+
+  while IFS=$'\t' read -r inv_name kind path role; do
+    [ "$inv_name" = "$name" ] || continue
+    [ "$role" != canonical ] || continue
+    case "$role" in
+      claude|codex)
+        target="$CANON/$name"
+        rel=$(relative_path "${path%/*}" "$target")
+        if [ "$kind" = link ] && [ "$(readlink "$path")" = "$rel" ]; then
+          continue
+        fi
+        plan remove "$path"
+        plan link "$rel" "$path"
+        ;;
+      gemini|opencode|pi)
+        plan remove "$path"
+        ;;
+      *) die "internal error: unknown skill-root role $role" ;;
+    esac
+  done < "$INVENTORY"
+
+  if ! awk -F '\t' -v n="$name" '$1==n && $4=="claude" {found=1} END {exit !found}' "$INVENTORY"; then
+    plan link "$(relative_path "$CLAUDE" "$CANON/$name")" "$CLAUDE/$name"
+  fi
+  if ! awk -F '\t' -v n="$name" '$1==n && $4=="codex" {found=1} END {exit !found}' "$INVENTORY"; then
+    plan link "$(relative_path "$CODEX" "$CANON/$name")" "$CODEX/$name"
+  fi
+done < "$TMP/names"
+
+if [ ! -s "$PLAN" ]; then
+  printf 'user skills already converged; no changes\n'
+  exit 0
+fi
+
+if [ "$MODE" = dry-run ]; then
+  printf 'DRY RUN - no changes made\n'
+else
+  printf 'APPLY\n'
+fi
+while IFS=$'\t' read -r action first second; do
+  case "$action" in
+    mkdir) printf '%s %s\n' "$action" "$first" ;;
+    copy) printf '%s %s -> %s\n' "$action" "$first" "$second" ;;
+    remove|unlink-root) printf '%s %s\n' "$action" "$first" ;;
+    link) printf '%s -> %s\n' "$second" "$first" ;;
+  esac
+done < "$PLAN"
+
+[ "$MODE" = apply ] || exit 0
+
+remove_verified_duplicate() {
+  local path=$1 name canonical
+  name=${path##*/}
+  canonical="$CANON/$name"
+  [ -d "$canonical" ] && [ ! -L "$canonical" ] || die "canonical skill changed after preflight: $canonical"
+  if [ -L "$path" ]; then
+    verify_link_to_canonical "$path" "$name"
+  elif [ -d "$path" ]; then
+    validate_skill_tree "$path"
+    diff -qr "$canonical" "$path" >/dev/null 2>&1 || die "duplicate changed after preflight: $path"
+  else
+    die "duplicate changed type after preflight: $path"
+  fi
+  rm -rf "$path"
+}
+
+while IFS=$'\t' read -r action first second; do
+  case "$action" in
+    mkdir) mkdir -p "$first" ;;
+    copy)
+      [ ! -e "$second" ] && [ ! -L "$second" ] || die "destination appeared after preflight: $second"
+      mkdir -p "${second%/*}"
+      cp -R "$first" "$second"
+      ;;
+    remove) remove_verified_duplicate "$first" ;;
+    unlink-root)
+      [ -L "$first" ] && [ -e "$first" ] || die "managed root link changed after preflight: $first"
+      [ "$(physical_dir "$first")" = "$(physical_dir "$CANON")" ] \
+        || die "managed root link changed target after preflight: $first"
+      rm "$first"
+      ;;
+    link)
+      [ ! -e "$second" ] && [ ! -L "$second" ] || die "link destination appeared after preflight: $second"
+      ln -s "$first" "$second"
+      ;;
+    *) die "internal error: unknown planned action $action" ;;
+  esac
+done < "$PLAN"
+printf 'user skills converged\n'

--- a/bin/fm-user-skill-sync.sh
+++ b/bin/fm-user-skill-sync.sh
@@ -10,8 +10,15 @@
 # Every local run performs a complete read-only preflight before acting. Dry-run
 # is the default; --apply is the only mutation switch. A conflict, unsafe or
 # broken link, special file, malformed skill directory, unexpected root entry,
-# or ambiguous tree refuses the whole run before any mutation. Skill trees may
-# contain directories and regular files only and must include SKILL.md.
+# overlapping managed roots, or ambiguous tree refuses the whole run before any
+# mutation. Skill trees may contain directories and regular files only and must
+# include SKILL.md.
+#
+# Preflight refusal is total: nothing is mutated. Once --apply begins executing
+# the accepted plan, each step is re-verified against the live filesystem and a
+# step that no longer matches the plan stops the run there, leaving the earlier
+# steps applied. Each step is individually safe and convergent, so rerunning the
+# command after resolving the interference replans from the current state.
 #
 # Remote operation is routed only through a registered remote secondmate record
 # and bin/fm-on.sh, which binds the configured SSH host, code root, and remote
@@ -119,6 +126,34 @@ GEMINI="$HOME/.gemini/skills"
 OPENCODE_CONFIG="$HOME/.config/opencode/skills"
 OPENCODE_LEGACY="$HOME/.opencode/skills"
 PI="$HOME/.pi/agent/skills"
+
+# Each managed root must be a distinct, non-overlapping path, otherwise one root
+# would be scanned under two ownership roles and planned against itself.
+MANAGED_ROLES="canonical claude codex gemini opencode-config opencode-legacy pi"
+managed_root_for_role() {
+  case $1 in
+    canonical) printf '%s\n' "$CANON" ;;
+    claude) printf '%s\n' "$CLAUDE" ;;
+    codex) printf '%s\n' "$CODEX" ;;
+    gemini) printf '%s\n' "$GEMINI" ;;
+    opencode-config) printf '%s\n' "$OPENCODE_CONFIG" ;;
+    opencode-legacy) printf '%s\n' "$OPENCODE_LEGACY" ;;
+    pi) printf '%s\n' "$PI" ;;
+    *) die "internal error: unknown managed root role $1" ;;
+  esac
+}
+for role_a in $MANAGED_ROLES; do
+  for role_b in $MANAGED_ROLES; do
+    [ "$role_a" != "$role_b" ] || continue
+    root_a=$(managed_root_for_role "$role_a")
+    root_b=$(managed_root_for_role "$role_b")
+    [ "$root_a" != "$root_b" ] \
+      || die "managed skill roots $role_a and $role_b resolve to the same path: $root_a"
+    case "$root_b/" in
+      "$root_a"/*) die "managed skill root $role_b is nested inside $role_a: $root_b" ;;
+    esac
+  done
+done
 
 for parent in \
   "$HOME/.agents" "$HOME/.claude" "$HOME/.gemini" "$HOME/.config" \
@@ -298,7 +333,7 @@ while IFS=$'\t' read -r action first second; do
     mkdir) printf '%s %s\n' "$action" "$first" ;;
     copy) printf '%s %s -> %s\n' "$action" "$first" "$second" ;;
     remove|unlink-root) printf '%s %s\n' "$action" "$first" ;;
-    link) printf '%s -> %s\n' "$second" "$first" ;;
+    link) printf 'link %s -> %s\n' "$second" "$first" ;;
   esac
 done < "$PLAN"
 

--- a/bin/fm-user-skill-sync.sh
+++ b/bin/fm-user-skill-sync.sh
@@ -12,7 +12,9 @@
 # broken link, special file, malformed skill directory, unexpected root entry,
 # overlapping managed roots, or ambiguous tree refuses the whole run before any
 # mutation. Skill trees may contain directories and regular files only and must
-# include SKILL.md.
+# include SKILL.md. Managed roots are compared by filesystem identity rather than
+# path spelling, so a case-insensitive volume or an aliased path cannot present
+# one directory under two ownership roles.
 #
 # Preflight refusal is total: nothing is mutated. Once --apply begins executing
 # the accepted plan, each step is re-verified against the live filesystem and a
@@ -127,8 +129,64 @@ OPENCODE_CONFIG="$HOME/.config/opencode/skills"
 OPENCODE_LEGACY="$HOME/.opencode/skills"
 PI="$HOME/.pi/agent/skills"
 
-# Each managed root must be a distinct, non-overlapping path, otherwise one root
-# would be scanned under two ownership roles and planned against itself.
+# Ownership boundaries compare filesystem identity rather than path spelling, so
+# a case-insensitive volume or an aliased path cannot present one directory
+# under two managed roles. Identity is taken without dereferencing, because a
+# whole-root link to the canonical store is a supported input this run converges
+# rather than an ownership collision. GNU stat is probed before BSD stat because
+# BSD's -f prints inode fields while GNU's -f prints filesystem fields.
+path_identity() {
+  stat -c '%d:%i' "$1" 2>/dev/null || stat -f '%d:%i' "$1" 2>/dev/null
+}
+
+nearest_existing_ancestor() {
+  local probe=$1
+  while [ ! -e "$probe" ] && [ ! -L "$probe" ]; do
+    probe=${probe%/*}
+    [ -n "$probe" ] || probe=/
+  done
+  printf '%s\n' "$probe"
+}
+
+# Remaining components below the nearest existing ancestor, compared without
+# case so two roots that would collide once created are refused in advance.
+unresolved_suffix() {
+  local probe=$1 anchor suffix
+  anchor=$(nearest_existing_ancestor "$probe")
+  if [ "$anchor" = "$probe" ]; then
+    printf '\n'
+    return 0
+  fi
+  if [ "$anchor" = / ]; then suffix=$probe; else suffix=${probe#"$anchor"}; fi
+  printf '%s' "$suffix" | tr '[:upper:]' '[:lower:]'
+  printf '\n'
+}
+
+path_contains_identity() {
+  local probe=$1 wanted=$2 id
+  while :; do
+    if [ -e "$probe" ] || [ -L "$probe" ]; then
+      id=$(path_identity "$probe") || id=
+      [ -z "$id" ] || [ "$id" != "$wanted" ] || return 0
+    fi
+    [ "$probe" != / ] || break
+    probe=${probe%/*}
+    [ -n "$probe" ] || probe=/
+  done
+  return 1
+}
+
+path_self_identity() {
+  local path=$1 id
+  if [ -e "$path" ] || [ -L "$path" ]; then
+    id=$(path_identity "$path") || id=
+    [ -n "$id" ] || die "cannot resolve managed skill path identity: $path"
+    printf '%s\n' "$id"
+  fi
+}
+
+# Each managed root must be a distinct, non-overlapping directory, otherwise one
+# root would be scanned under two ownership roles and planned against itself.
 MANAGED_ROLES="canonical claude codex gemini opencode-config opencode-legacy pi"
 managed_root_for_role() {
   case $1 in
@@ -143,15 +201,30 @@ managed_root_for_role() {
   esac
 }
 for role_a in $MANAGED_ROLES; do
+  root_a=$(managed_root_for_role "$role_a")
+  self_a=$(path_self_identity "$root_a")
+  anchor_a=$(path_identity "$(nearest_existing_ancestor "$root_a")") \
+    || die "cannot resolve managed skill root ancestor: $root_a"
+  [ -n "$anchor_a" ] || die "cannot resolve managed skill root ancestor: $root_a"
+  suffix_a=$(unresolved_suffix "$root_a")
   for role_b in $MANAGED_ROLES; do
     [ "$role_a" != "$role_b" ] || continue
-    root_a=$(managed_root_for_role "$role_a")
     root_b=$(managed_root_for_role "$role_b")
-    [ "$root_a" != "$root_b" ] \
-      || die "managed skill roots $role_a and $role_b resolve to the same path: $root_a"
-    case "$root_b/" in
-      "$root_a"/*) die "managed skill root $role_b is nested inside $role_a: $root_b" ;;
-    esac
+    self_b=$(path_self_identity "$root_b")
+    if [ -n "$self_a" ] && [ "$self_a" = "$self_b" ]; then
+      die "managed skill roots $role_a and $role_b are the same directory: $root_a and $root_b"
+    fi
+    if [ -n "$self_a" ] && path_contains_identity "$root_b" "$self_a"; then
+      die "managed skill root $role_b is nested inside $role_a: $root_b"
+    fi
+    anchor_b=$(path_identity "$(nearest_existing_ancestor "$root_b")") || anchor_b=
+    if [ -n "$anchor_b" ] && [ "$anchor_a" = "$anchor_b" ]; then
+      [ "$suffix_a" != "$(unresolved_suffix "$root_b")" ] \
+        || die "managed skill roots $role_a and $role_b resolve to the same directory: $root_a and $root_b"
+      case "$(unresolved_suffix "$root_b")" in
+        "$suffix_a"/*) die "managed skill root $role_b is nested inside $role_a: $root_b" ;;
+      esac
+    fi
   done
 done
 
@@ -165,8 +238,12 @@ done
 
 # The operator command owns user homes only. Refuse a synthetic HOME or
 # CODEX_HOME that points its managed roots into this repository.
+ROOT_IDENTITY=$(path_identity "$ROOT") || die "cannot resolve the Firstmate repository root: $ROOT"
+[ -n "$ROOT_IDENTITY" ] || die "cannot resolve the Firstmate repository root: $ROOT"
 for managed in "$CANON" "$CLAUDE" "$CODEX" "$GEMINI" "$OPENCODE_CONFIG" "$OPENCODE_LEGACY" "$PI"; do
-  case "$managed/" in "$ROOT/"*) die "managed user root overlaps the Firstmate repository: $managed" ;; esac
+  if path_contains_identity "$managed" "$ROOT_IDENTITY"; then
+    die "managed user root overlaps the Firstmate repository: $managed"
+  fi
 done
 
 TMP=$(mktemp -d "${TMPDIR:-/tmp}/fm-user-skill-sync.XXXXXX") || die "cannot create preflight workspace"

--- a/bin/fm-user-skill-sync.sh
+++ b/bin/fm-user-skill-sync.sh
@@ -328,10 +328,16 @@ cleanup_workspace() {
 
 # A signal handler that only cleans up would let the interrupted apply loop run
 # to completion and report success, so INT and TERM exit with their conventional
-# statuses instead.
+# statuses instead. The trap covers the read-only preflight too, so the
+# diagnosis reports mutation only once a planned step has actually begun.
+MUTATION_STARTED=0
 interrupted() {
   cleanup_workspace
-  printf 'error: interrupted by %s; any earlier planned changes remain applied\n' "$1" >&2
+  if [ "$MUTATION_STARTED" -eq 0 ]; then
+    printf 'error: interrupted by %s before any planned change began; nothing was mutated\n' "$1" >&2
+  else
+    printf 'error: interrupted by %s; earlier planned changes may already be applied\n' "$1" >&2
+  fi
   exit "$2"
 }
 
@@ -596,6 +602,7 @@ remove_verified_duplicate() {
 }
 
 while IFS=$'\t' read -r action first second; do
+  MUTATION_STARTED=1
   case "$action" in
     mkdir) mkdir -p "$first" ;;
     copy)

--- a/bin/fm-user-skill-sync.sh
+++ b/bin/fm-user-skill-sync.sh
@@ -12,10 +12,13 @@
 # broken link, special file, malformed skill directory, unexpected root entry,
 # overlapping managed roots, or ambiguous tree refuses the whole run before any
 # mutation. Skill trees may contain directories and regular files only and must
-# include SKILL.md. A duplicate is verified only when its tree matches the
-# retained copy in structure, bytes, and permission bits. Managed roots are compared by filesystem identity rather than
-# path spelling, so a case-insensitive volume or an aliased path cannot present
-# one directory under two ownership roles.
+# include SKILL.md, and no nested name may carry a control character. A
+# duplicate is verified only when its tree matches the retained copy in
+# structure, bytes, and permission bits, and the canonical copy is established
+# mode-faithfully so that proof holds under any umask. Managed roots are
+# compared by filesystem identity rather than path spelling, so a
+# case-insensitive volume or an aliased path cannot present one directory under
+# two ownership roles.
 #
 # Preflight refusal is total: nothing is mutated. Once --apply begins executing
 # the accepted plan, each step is re-verified against the live filesystem and a
@@ -312,10 +315,15 @@ PLAN="$TMP/plan"
 
 # A verified duplicate must match the retained tree in structure, bytes, and
 # permission bits, otherwise removing it would silently drop the only copy that
-# carries an executable helper script.
+# carries an executable helper script. The listing is line-oriented, so skill
+# trees carrying a control character in any nested name are refused by
+# validate_skill_tree before this proof is trusted.
 tree_mode_listing() {
-  local tree=$1
-  find -P "$tree" \( -type d -o -type f \) -exec stat "$STAT_IDENTITY_FORMAT" "$STAT_MODE_SPEC" {} + 2>/dev/null \
+  local tree=$1 raw
+  raw=$(find -P "$tree" \( -type d -o -type f \) -exec stat "$STAT_IDENTITY_FORMAT" "$STAT_MODE_SPEC" {} +) \
+    || return 1
+  [ -n "$raw" ] || return 1
+  printf '%s\n' "$raw" \
     | awk -v prefix="$tree" '{
         mode = $1
         sub(/^[^ ]* /, "")
@@ -325,17 +333,25 @@ tree_mode_listing() {
     | LC_ALL=C sort
 }
 
+# Fails closed: an unreadable tree, a failing stat, or an empty listing refuses
+# the equality that would otherwise authorize removing the last copy.
 trees_equivalent() {
-  local a=$1 b=$2
+  local a=$1 b=$2 listing_a listing_b
   diff -qr "$a" "$b" >/dev/null 2>&1 || return 1
-  [ "$(tree_mode_listing "$a")" = "$(tree_mode_listing "$b")" ]
+  listing_a=$(tree_mode_listing "$a") || return 1
+  listing_b=$(tree_mode_listing "$b") || return 1
+  [ -n "$listing_a" ] && [ -n "$listing_b" ] || return 1
+  [ "$listing_a" = "$listing_b" ]
 }
 
 validate_skill_tree() {
-  local skill=$1 bad
+  local skill=$1 bad control
   [ -f "$skill/SKILL.md" ] && [ ! -L "$skill/SKILL.md" ] || die "skill lacks a regular SKILL.md: $skill"
   bad=$(find -P "$skill" ! -type d ! -type f -print -quit 2>/dev/null) || die "cannot inspect skill tree: $skill"
   [ -z "$bad" ] || die "skill tree contains a link or special entry: $bad"
+  control=$(LC_ALL=C find -P "$skill" -print0 | LC_ALL=C tr -d '\000' | LC_ALL=C tr -dc '[:cntrl:]' | wc -c) \
+    || die "cannot inspect skill tree names: $skill"
+  [ "$control" -eq 0 ] || die "skill tree contains a control character in a nested name: $skill"
 }
 
 physical_dir() {
@@ -514,7 +530,7 @@ while IFS=$'\t' read -r action first second; do
     copy)
       [ ! -e "$second" ] && [ ! -L "$second" ] || die "destination appeared after preflight: $second"
       mkdir -p "${second%/*}"
-      cp -R "$first" "$second"
+      cp -Rp "$first" "$second"
       ;;
     remove) remove_verified_duplicate "$first" ;;
     unlink-root)

--- a/bin/fm-user-skill-sync.sh
+++ b/bin/fm-user-skill-sync.sh
@@ -11,8 +11,10 @@
 # is the default; --apply is the only mutation switch. A conflict, unsafe or
 # broken link, special file, malformed skill directory, unexpected root entry,
 # overlapping managed roots, or ambiguous tree refuses the whole run before any
-# mutation. Skill trees may contain directories and regular files only and must
-# include SKILL.md, and no nested name may carry a control character. A
+# mutation. An existing managed root that cannot be listed is refused rather
+# than read as empty, so convergence is never claimed for a root this run could
+# not inspect. Skill trees may contain directories and regular files only and
+# must include SKILL.md, and no nested name may carry a control character. A
 # duplicate is verified only when its tree matches the retained copy in
 # structure, bytes, and permission bits, and the canonical copy is established
 # mode-faithfully so that proof holds under any umask. Managed roots are
@@ -304,6 +306,8 @@ for parent in \
   "$CODEX_ROOT"; do
   [ ! -L "$parent" ] || die "managed skill parent must not be a link: $parent"
   [ ! -e "$parent" ] || [ -d "$parent" ] || die "managed skill parent is not a directory: $parent"
+  [ ! -d "$parent" ] || { [ -r "$parent" ] && [ -x "$parent" ]; } \
+    || die "cannot inspect managed skill parent; fix its permissions and rerun: $parent"
 done
 
 # The operator command owns user homes only. Refuse a synthetic HOME or
@@ -341,20 +345,53 @@ tree_mode_listing() {
         mode = $1
         sub(/^[^ ]* /, "")
         if (index($0, prefix) == 1) { $0 = substr($0, length(prefix) + 1) }
-        print mode " " $0
+        if ($0 == "") { $0 = "." }
+        print $0 "\t" mode
       }' \
     | LC_ALL=C sort
 }
 
+# The two listings hold the same paths in the same order because diff -qr has
+# already proven the structures match, so the first differing line names the
+# entry whose permission bits disagree.
+mode_mismatch_summary() {
+  printf '%s\n' "$1" > "$TMP/mode-a"
+  printf '%s\n' "$2" > "$TMP/mode-b"
+  awk -F '\t' '
+    NR == FNR { path[FNR] = $1; mode[FNR] = $2; next }
+    $2 != mode[FNR] { printf "%s (%s vs %s)\n", path[FNR], mode[FNR], $2; exit }
+  ' "$TMP/mode-a" "$TMP/mode-b"
+}
+
 # Fails closed: an unreadable tree, a failing stat, or an empty listing refuses
 # the equality that would otherwise authorize removing the last copy.
+# TREE_DIFFERENCE carries the reason so the caller can name what actually
+# differs instead of reporting every mismatch as a content conflict.
+TREE_DIFFERENCE=
 trees_equivalent() {
-  local a=$1 b=$2 listing_a listing_b
-  diff -qr "$a" "$b" >/dev/null 2>&1 || return 1
-  listing_a=$(tree_mode_listing "$a") || return 1
-  listing_b=$(tree_mode_listing "$b") || return 1
-  [ -n "$listing_a" ] && [ -n "$listing_b" ] || return 1
-  [ "$listing_a" = "$listing_b" ]
+  local a=$1 b=$2 listing_a listing_b mismatch
+  TREE_DIFFERENCE=
+  if ! diff -qr "$a" "$b" >/dev/null 2>&1; then
+    TREE_DIFFERENCE='tree structure or file contents differ'
+    return 1
+  fi
+  if ! listing_a=$(tree_mode_listing "$a"); then
+    TREE_DIFFERENCE="cannot inspect permission bits under $a"
+    return 1
+  fi
+  if ! listing_b=$(tree_mode_listing "$b"); then
+    TREE_DIFFERENCE="cannot inspect permission bits under $b"
+    return 1
+  fi
+  if [ -z "$listing_a" ] || [ -z "$listing_b" ]; then
+    TREE_DIFFERENCE='permission-bit inspection returned nothing'
+    return 1
+  fi
+  [ "$listing_a" != "$listing_b" ] || return 0
+  mismatch=$(mode_mismatch_summary "$listing_a" "$listing_b")
+  [ -n "$mismatch" ] || mismatch='listings disagree'
+  TREE_DIFFERENCE="permission bits differ: $mismatch"
+  return 1
 }
 
 validate_skill_tree() {
@@ -394,6 +431,8 @@ scan_root() {
   fi
   [ ! -e "$root" ] || [ -d "$root" ] || die "managed skill root is not a directory: $root"
   [ -d "$root" ] || return 0
+  { [ -r "$root" ] && [ -x "$root" ] && ls -A -- "$root" >/dev/null 2>&1; } \
+    || die "cannot inspect managed skill root; fix its permissions and rerun: $root"
   for entry in "$root"/* "$root"/.[!.]* "$root"/..?*; do
     [ -e "$entry" ] || [ -L "$entry" ] || continue
     name=${entry##*/}
@@ -469,7 +508,8 @@ while IFS= read -r name; do
   while IFS=$'\t' read -r inv_name kind path role; do
     [ "$inv_name" = "$name" ] || continue
     if [ "$kind" = real ] && [ "$path" != "$baseline" ]; then
-      trees_equivalent "$baseline" "$path" || die "conflicting skill trees for '$name': $baseline and $path"
+      trees_equivalent "$baseline" "$path" \
+        || die "conflicting skill trees for '$name' ($TREE_DIFFERENCE): $baseline and $path"
     fi
   done < "$INVENTORY"
 
@@ -531,7 +571,8 @@ remove_verified_duplicate() {
     verify_link_to_canonical "$path" "$name"
   elif [ -d "$path" ]; then
     validate_skill_tree "$path"
-    trees_equivalent "$canonical" "$path" || die "duplicate changed after preflight: $path"
+    trees_equivalent "$canonical" "$path" \
+      || die "duplicate changed after preflight ($TREE_DIFFERENCE): $path"
   else
     die "duplicate changed type after preflight: $path"
   fi

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -289,6 +289,29 @@ Malformed JSON, an empty or malformed rule/default array, an unverified harness,
 While the file remains present, no crewmate or scout spawn may proceed without an explicit resolved harness; malformed configuration must be reported and corrected rather than selected around.
 Secondmate homes inherit this file from the primary, so a secondmate's own crewmates apply the same dispatch profile behavior.
 
+## User skill layout
+
+User-installed skill content is canonical in `$HOME/.agents/skills`.
+Claude Code and Codex receive relative per-skill links, while Gemini, OpenCode, and Pi use their native canonical-store discovery without duplicate per-harness copies.
+Codex's `.system` skills and every harness's plugin installation remain outside this operation.
+The command's header and `--help` are the authoritative owner of managed roots, conflict checks, and mutation mechanics.
+
+Preview local convergence, then apply the reviewed plan explicitly:
+
+```sh
+bin/fm-user-skill-sync.sh
+bin/fm-user-skill-sync.sh --apply
+```
+
+Use a registered remote secondmate route for the remote Mac; this preserves the configured SSH host and remote home rather than selecting another home:
+
+```sh
+bin/fm-user-skill-sync.sh --remote <secondmate-id-or-ssh-alias>
+bin/fm-user-skill-sync.sh --remote <secondmate-id-or-ssh-alias> --apply
+```
+
+The current Codex link verification boundary and its non-invasive test command are recorded in [`docs/verification/user-skills.md`](verification/user-skills.md).
+
 ## Toolchain
 
 On session start the first mate detects what its required toolchain is missing or too old and lists each problem with either an exact install command or manual instructions.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -369,6 +369,10 @@
       "audience": "maintainer-verification"
     },
     {
+      "path": "docs/verification/user-skills.md",
+      "audience": "maintainer-verification"
+    },
+    {
       "path": "docs/watcher-continuity.md",
       "audience": "operator-current"
     },

--- a/docs/remote-secondmates.md
+++ b/docs/remote-secondmates.md
@@ -229,7 +229,7 @@ Retirement is executed on the configured host and refuses while the remote home 
 It closes only the retiring secondmate's panes or `2ndmate-<id>` workspace in `fm-remote`; it never stops the shared session or removes a sibling secondmate's workspace or panes.
 SSH exit 255 preserves both the route and local records because completion is unknown.
 `--force` remains the explicit discard path and requires the same captain authority as local secondmate discard.
-No generic remote delete or write surface exists: remote writes are confined to inherited allowlist files and backlog handoff scratch files, and remote home removal is reachable only through guarded secondmate retirement.
+No generic remote delete or write surface exists: remote writes are confined to inherited allowlist files, backlog handoff scratch files, and the explicitly routed user-skill convergence described under [user skill layout](configuration.md#user-skill-layout), which still defaults to a read-only plan and requires `--apply`; remote home removal is reachable only through guarded secondmate retirement.
 
 ## Verification
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -18,6 +18,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-fleet-view.sh`       | Render the fleet snapshot as a human Markdown view                                   |
 | `fm-bearings-snapshot.sh` | Project the fleet snapshot to the compact TOON bearings view; local-only unless `--include-prs` |
 | `fm-update.sh`           | Fast-forward-only self-update of firstmate and local or remote secondmate homes       |
+| `fm-user-skill-sync.sh`  | Preview or apply guarded user-skill canonicalization locally or through a registered remote route |
 | `fm-on.sh`               | Execute one tracked Firstmate command in a configured remote secondmate home, using its job worker except for the doctor bootstrap |
 | `fm-remote-job-lib.sh`   | Shared bounded remote job queue, worker readiness, LaunchAgent contract, and filesystem-composed PATH |
 | `fm-remote-job-worker.sh` | Long-lived remote queue worker for tracked `fm-*.sh` commands in the account runtime |

--- a/docs/verification/user-skills.md
+++ b/docs/verification/user-skills.md
@@ -34,7 +34,7 @@ ok - a control character in a nested skill name refuses before mutation
 ok - odd CODEX_HOME separator spelling still links correctly and converges
 ok - an unreadable managed root refuses instead of claiming convergence
 ok - a permission-bit-only difference is diagnosed as such
-ok - an interrupted apply stops with a nonzero status instead of claiming success
+ok - an interrupted apply stops at the signal instead of finishing the plan
 ok - an unresolvable CODEX_HOME reports exactly one cause
 ok - remote invocation binds the registered host and forwards explicit apply
 ```

--- a/docs/verification/user-skills.md
+++ b/docs/verification/user-skills.md
@@ -5,7 +5,7 @@ This record owns the current empirical verification boundary.
 
 ## Isolated filesystem verification
 
-On 2026-08-20, the focused temporary-home suite exercised canonicalization, relative Claude and Codex links, verified whole-root link conversion, duplicate removal under default and restrictive umasks, byte and permission-bit conflict refusal, control-character name refusal, CODEX_HOME separator normalization, unreadable-root refusal, permission-bit conflict diagnosis, interrupted-apply termination, interrupted-preflight no-mutation reporting, `.system` preservation, default dry-run behavior, idempotence, unsafe-entry refusal, colliding, nested, and aliased managed-root refusal, and registered-remote command construction.
+On 2026-08-20, the focused temporary-home suite exercised canonicalization, relative Claude and Codex links, verified whole-root link conversion, duplicate removal under default and restrictive umasks, byte and permission-bit conflict refusal, control-character name refusal, CODEX_HOME separator normalization, unreadable-root refusal, permission-bit conflict diagnosis, interrupted-apply termination, interrupted-preflight no-mutation reporting, `.system` preservation, default dry-run behavior, idempotence, unsafe-entry refusal, colliding, nested, and aliased managed-root refusal, registered-remote command construction, exact host, root, and home binding for each registered route, and ambiguous-alias refusal before any transport is opened.
 
 Command:
 
@@ -37,7 +37,9 @@ ok - a permission-bit-only difference is diagnosed as such
 ok - an interrupted apply stops at the signal instead of finishing the plan
 ok - an interrupted read-only run reports that nothing was mutated
 ok - an unresolvable CODEX_HOME reports exactly one cause
-ok - remote invocation binds the registered host and forwards explicit apply
+ok - remote invocation binds exactly the selected record's host, root, and home
+ok - each registered record binds its own host, root, and home
+ok - an ambiguous host alias refuses instead of selecting a host
 ```
 
 The Codex probe creates one isolated skill under a temporary `CODEX_HOME`, verifies that its relative link resolves to the canonical tree, and reads `SKILL.md` through that link.

--- a/docs/verification/user-skills.md
+++ b/docs/verification/user-skills.md
@@ -5,7 +5,7 @@ This record owns the current empirical verification boundary.
 
 ## Isolated filesystem verification
 
-On 2026-08-20, the focused temporary-home suite exercised canonicalization, relative Claude and Codex links, verified whole-root link conversion, duplicate removal under default and restrictive umasks, byte and permission-bit conflict refusal, control-character name refusal, CODEX_HOME separator normalization, unreadable-root refusal, permission-bit conflict diagnosis, interrupted-apply termination, `.system` preservation, default dry-run behavior, idempotence, unsafe-entry refusal, colliding, nested, and aliased managed-root refusal, and registered-remote command construction.
+On 2026-08-20, the focused temporary-home suite exercised canonicalization, relative Claude and Codex links, verified whole-root link conversion, duplicate removal under default and restrictive umasks, byte and permission-bit conflict refusal, control-character name refusal, CODEX_HOME separator normalization, unreadable-root refusal, permission-bit conflict diagnosis, interrupted-apply termination, interrupted-preflight no-mutation reporting, `.system` preservation, default dry-run behavior, idempotence, unsafe-entry refusal, colliding, nested, and aliased managed-root refusal, and registered-remote command construction.
 
 Command:
 
@@ -35,6 +35,7 @@ ok - odd CODEX_HOME separator spelling still links correctly and converges
 ok - an unreadable managed root refuses instead of claiming convergence
 ok - a permission-bit-only difference is diagnosed as such
 ok - an interrupted apply stops at the signal instead of finishing the plan
+ok - an interrupted read-only run reports that nothing was mutated
 ok - an unresolvable CODEX_HOME reports exactly one cause
 ok - remote invocation binds the registered host and forwards explicit apply
 ```

--- a/docs/verification/user-skills.md
+++ b/docs/verification/user-skills.md
@@ -5,7 +5,7 @@ This record owns the current empirical verification boundary.
 
 ## Isolated filesystem verification
 
-On 2026-08-20, the focused temporary-home suite exercised canonicalization, relative Claude and Codex links, verified whole-root link conversion, duplicate removal under default and restrictive umasks, byte and permission-bit conflict refusal, control-character name refusal, `.system` preservation, default dry-run behavior, idempotence, unsafe-entry refusal, colliding, nested, and aliased managed-root refusal, and registered-remote command construction.
+On 2026-08-20, the focused temporary-home suite exercised canonicalization, relative Claude and Codex links, verified whole-root link conversion, duplicate removal under default and restrictive umasks, byte and permission-bit conflict refusal, control-character name refusal, CODEX_HOME separator normalization, `.system` preservation, default dry-run behavior, idempotence, unsafe-entry refusal, colliding, nested, and aliased managed-root refusal, and registered-remote command construction.
 
 Command:
 
@@ -31,6 +31,7 @@ ok - migration preserves executable skill scripts
 ok - migration preserves source modes and converges under a default umask
 ok - migration converges under a restrictive umask
 ok - a control character in a nested skill name refuses before mutation
+ok - odd CODEX_HOME separator spelling still links correctly and converges
 ok - remote invocation binds the registered host and forwards explicit apply
 ```
 

--- a/docs/verification/user-skills.md
+++ b/docs/verification/user-skills.md
@@ -5,7 +5,7 @@ This record owns the current empirical verification boundary.
 
 ## Isolated filesystem verification
 
-On 2026-08-20, the focused temporary-home suite exercised canonicalization, relative Claude and Codex links, verified whole-root link conversion, duplicate removal under default and restrictive umasks, byte and permission-bit conflict refusal, control-character name refusal, CODEX_HOME separator normalization, `.system` preservation, default dry-run behavior, idempotence, unsafe-entry refusal, colliding, nested, and aliased managed-root refusal, and registered-remote command construction.
+On 2026-08-20, the focused temporary-home suite exercised canonicalization, relative Claude and Codex links, verified whole-root link conversion, duplicate removal under default and restrictive umasks, byte and permission-bit conflict refusal, control-character name refusal, CODEX_HOME separator normalization, unreadable-root refusal, permission-bit conflict diagnosis, `.system` preservation, default dry-run behavior, idempotence, unsafe-entry refusal, colliding, nested, and aliased managed-root refusal, and registered-remote command construction.
 
 Command:
 
@@ -32,6 +32,8 @@ ok - migration preserves source modes and converges under a default umask
 ok - migration converges under a restrictive umask
 ok - a control character in a nested skill name refuses before mutation
 ok - odd CODEX_HOME separator spelling still links correctly and converges
+ok - an unreadable managed root refuses instead of claiming convergence
+ok - a permission-bit-only difference is diagnosed as such
 ok - remote invocation binds the registered host and forwards explicit apply
 ```
 

--- a/docs/verification/user-skills.md
+++ b/docs/verification/user-skills.md
@@ -5,7 +5,7 @@ This record owns the current empirical verification boundary.
 
 ## Isolated filesystem verification
 
-On 2026-08-20, the focused temporary-home suite exercised canonicalization, relative Claude and Codex links, verified whole-root link conversion, duplicate removal under default and restrictive umasks, byte and permission-bit conflict refusal, control-character name refusal, CODEX_HOME separator normalization, unreadable-root refusal, permission-bit conflict diagnosis, `.system` preservation, default dry-run behavior, idempotence, unsafe-entry refusal, colliding, nested, and aliased managed-root refusal, and registered-remote command construction.
+On 2026-08-20, the focused temporary-home suite exercised canonicalization, relative Claude and Codex links, verified whole-root link conversion, duplicate removal under default and restrictive umasks, byte and permission-bit conflict refusal, control-character name refusal, CODEX_HOME separator normalization, unreadable-root refusal, permission-bit conflict diagnosis, interrupted-apply termination, `.system` preservation, default dry-run behavior, idempotence, unsafe-entry refusal, colliding, nested, and aliased managed-root refusal, and registered-remote command construction.
 
 Command:
 
@@ -34,6 +34,8 @@ ok - a control character in a nested skill name refuses before mutation
 ok - odd CODEX_HOME separator spelling still links correctly and converges
 ok - an unreadable managed root refuses instead of claiming convergence
 ok - a permission-bit-only difference is diagnosed as such
+ok - an interrupted apply stops with a nonzero status instead of claiming success
+ok - an unresolvable CODEX_HOME reports exactly one cause
 ok - remote invocation binds the registered host and forwards explicit apply
 ```
 

--- a/docs/verification/user-skills.md
+++ b/docs/verification/user-skills.md
@@ -5,7 +5,7 @@ This record owns the current empirical verification boundary.
 
 ## Isolated filesystem verification
 
-On 2026-08-20, the focused temporary-home suite exercised canonicalization, relative Claude and Codex links, verified whole-root link conversion, duplicate removal, byte and permission-bit conflict refusal, `.system` preservation, default dry-run behavior, idempotence, unsafe-entry refusal, colliding, nested, and aliased managed-root refusal, and registered-remote command construction.
+On 2026-08-20, the focused temporary-home suite exercised canonicalization, relative Claude and Codex links, verified whole-root link conversion, duplicate removal under default and restrictive umasks, byte and permission-bit conflict refusal, control-character name refusal, `.system` preservation, default dry-run behavior, idempotence, unsafe-entry refusal, colliding, nested, and aliased managed-root refusal, and registered-remote command construction.
 
 Command:
 
@@ -28,10 +28,13 @@ ok - colliding or nested managed roots refuse before any mutation
 ok - aliased managed roots that name one directory refuse before any mutation
 ok - duplicate removal proves permission bits as well as bytes
 ok - migration preserves executable skill scripts
+ok - migration preserves source modes and converges under a default umask
+ok - migration converges under a restrictive umask
+ok - a control character in a nested skill name refuses before mutation
 ok - remote invocation binds the registered host and forwards explicit apply
 ```
 
 The Codex probe creates one isolated skill under a temporary `CODEX_HOME`, verifies that its relative link resolves to the canonical tree, and reads `SKILL.md` through that link.
 No live Codex process was started because doing so could create account configuration or session state in the captain's environment.
 Codex discovery through a live authenticated process therefore remains unverified.
-The operator command remains conservative: it defaults to a complete read-only plan, requires explicit `--apply`, refuses links it cannot prove target an existing canonical skill, removes a duplicate only when its tree matches the retained copy in structure, bytes, and permission bits, refuses before any mutation when two managed roots resolve to the same or a nested directory by filesystem identity rather than path spelling, and never inspects or changes `.system`.
+The operator command remains conservative: it defaults to a complete read-only plan, requires explicit `--apply`, refuses links it cannot prove target an existing canonical skill, removes a duplicate only when its tree matches the retained copy in structure, bytes, and permission bits, establishes the canonical copy mode-faithfully so that proof holds under any umask, fails that proof closed when a tree cannot be inspected, refuses before any mutation when two managed roots resolve to the same or a nested directory by filesystem identity rather than path spelling, and never inspects or changes `.system`.

--- a/docs/verification/user-skills.md
+++ b/docs/verification/user-skills.md
@@ -5,7 +5,7 @@ This record owns the current empirical verification boundary.
 
 ## Isolated filesystem verification
 
-On 2026-08-20, the focused temporary-home suite exercised canonicalization, relative Claude and Codex links, verified whole-root link conversion, duplicate removal, conflict refusal, `.system` preservation, default dry-run behavior, idempotence, unsafe-entry refusal, colliding, nested, and aliased managed-root refusal, and registered-remote command construction.
+On 2026-08-20, the focused temporary-home suite exercised canonicalization, relative Claude and Codex links, verified whole-root link conversion, duplicate removal, byte and permission-bit conflict refusal, `.system` preservation, default dry-run behavior, idempotence, unsafe-entry refusal, colliding, nested, and aliased managed-root refusal, and registered-remote command construction.
 
 Command:
 
@@ -26,10 +26,12 @@ ok - verified whole-root canonical links converge without touching their target
 ok - isolated Codex per-skill link resolves and exposes SKILL.md
 ok - colliding or nested managed roots refuse before any mutation
 ok - aliased managed roots that name one directory refuse before any mutation
+ok - duplicate removal proves permission bits as well as bytes
+ok - migration preserves executable skill scripts
 ok - remote invocation binds the registered host and forwards explicit apply
 ```
 
 The Codex probe creates one isolated skill under a temporary `CODEX_HOME`, verifies that its relative link resolves to the canonical tree, and reads `SKILL.md` through that link.
 No live Codex process was started because doing so could create account configuration or session state in the captain's environment.
 Codex discovery through a live authenticated process therefore remains unverified.
-The operator command remains conservative: it defaults to a complete read-only plan, requires explicit `--apply`, refuses links it cannot prove target an existing canonical skill, refuses before any mutation when two managed roots resolve to the same or a nested directory by filesystem identity rather than path spelling, and never inspects or changes `.system`.
+The operator command remains conservative: it defaults to a complete read-only plan, requires explicit `--apply`, refuses links it cannot prove target an existing canonical skill, removes a duplicate only when its tree matches the retained copy in structure, bytes, and permission bits, refuses before any mutation when two managed roots resolve to the same or a nested directory by filesystem identity rather than path spelling, and never inspects or changes `.system`.

--- a/docs/verification/user-skills.md
+++ b/docs/verification/user-skills.md
@@ -5,7 +5,7 @@ This record owns the current empirical verification boundary.
 
 ## Isolated filesystem verification
 
-On 2026-08-20, the focused temporary-home suite exercised canonicalization, relative Claude and Codex links, verified whole-root link conversion, duplicate removal, conflict refusal, `.system` preservation, default dry-run behavior, idempotence, unsafe-entry refusal, and registered-remote command construction.
+On 2026-08-20, the focused temporary-home suite exercised canonicalization, relative Claude and Codex links, verified whole-root link conversion, duplicate removal, conflict refusal, `.system` preservation, default dry-run behavior, idempotence, unsafe-entry refusal, colliding and nested managed-root refusal, and registered-remote command construction.
 
 Command:
 
@@ -24,10 +24,11 @@ ok - Codex vendor-managed .system is preserved
 ok - broken links and unexpected entries refuse conservatively
 ok - verified whole-root canonical links converge without touching their target
 ok - isolated Codex per-skill link resolves and exposes SKILL.md
+ok - colliding or nested managed roots refuse before any mutation
 ok - remote invocation binds the registered host and forwards explicit apply
 ```
 
 The Codex probe creates one isolated skill under a temporary `CODEX_HOME`, verifies that its relative link resolves to the canonical tree, and reads `SKILL.md` through that link.
 No live Codex process was started because doing so could create account configuration or session state in the captain's environment.
 Codex discovery through a live authenticated process therefore remains unverified.
-The operator command remains conservative: it defaults to a complete read-only plan, requires explicit `--apply`, refuses links it cannot prove target an existing canonical skill, and never inspects or changes `.system`.
+The operator command remains conservative: it defaults to a complete read-only plan, requires explicit `--apply`, refuses links it cannot prove target an existing canonical skill, refuses before any mutation when two managed roots resolve to the same or a nested path, and never inspects or changes `.system`.

--- a/docs/verification/user-skills.md
+++ b/docs/verification/user-skills.md
@@ -1,0 +1,33 @@
+# User skill layout verification
+
+[`bin/fm-user-skill-sync.sh`](../../bin/fm-user-skill-sync.sh) owns the operating contract, and [`docs/configuration.md`](../configuration.md#user-skill-layout) owns concise operator usage.
+This record owns the current empirical verification boundary.
+
+## Isolated filesystem verification
+
+On 2026-08-20, the focused temporary-home suite exercised canonicalization, relative Claude and Codex links, verified whole-root link conversion, duplicate removal, conflict refusal, `.system` preservation, default dry-run behavior, idempotence, unsafe-entry refusal, and registered-remote command construction.
+
+Command:
+
+```sh
+tests/fm-user-skill-sync.test.sh
+```
+
+Output:
+
+```text
+ok - real user skill migrates to canonical content with relative harness links
+ok - verified duplicate removal is idempotent
+ok - byte-different skill trees refuse before mutation
+ok - dry-run is the mutation-free default
+ok - Codex vendor-managed .system is preserved
+ok - broken links and unexpected entries refuse conservatively
+ok - verified whole-root canonical links converge without touching their target
+ok - isolated Codex per-skill link resolves and exposes SKILL.md
+ok - remote invocation binds the registered host and forwards explicit apply
+```
+
+The Codex probe creates one isolated skill under a temporary `CODEX_HOME`, verifies that its relative link resolves to the canonical tree, and reads `SKILL.md` through that link.
+No live Codex process was started because doing so could create account configuration or session state in the captain's environment.
+Codex discovery through a live authenticated process therefore remains unverified.
+The operator command remains conservative: it defaults to a complete read-only plan, requires explicit `--apply`, refuses links it cannot prove target an existing canonical skill, and never inspects or changes `.system`.

--- a/docs/verification/user-skills.md
+++ b/docs/verification/user-skills.md
@@ -5,7 +5,7 @@ This record owns the current empirical verification boundary.
 
 ## Isolated filesystem verification
 
-On 2026-08-20, the focused temporary-home suite exercised canonicalization, relative Claude and Codex links, verified whole-root link conversion, duplicate removal, conflict refusal, `.system` preservation, default dry-run behavior, idempotence, unsafe-entry refusal, colliding and nested managed-root refusal, and registered-remote command construction.
+On 2026-08-20, the focused temporary-home suite exercised canonicalization, relative Claude and Codex links, verified whole-root link conversion, duplicate removal, conflict refusal, `.system` preservation, default dry-run behavior, idempotence, unsafe-entry refusal, colliding, nested, and aliased managed-root refusal, and registered-remote command construction.
 
 Command:
 
@@ -25,10 +25,11 @@ ok - broken links and unexpected entries refuse conservatively
 ok - verified whole-root canonical links converge without touching their target
 ok - isolated Codex per-skill link resolves and exposes SKILL.md
 ok - colliding or nested managed roots refuse before any mutation
+ok - aliased managed roots that name one directory refuse before any mutation
 ok - remote invocation binds the registered host and forwards explicit apply
 ```
 
 The Codex probe creates one isolated skill under a temporary `CODEX_HOME`, verifies that its relative link resolves to the canonical tree, and reads `SKILL.md` through that link.
 No live Codex process was started because doing so could create account configuration or session state in the captain's environment.
 Codex discovery through a live authenticated process therefore remains unverified.
-The operator command remains conservative: it defaults to a complete read-only plan, requires explicit `--apply`, refuses links it cannot prove target an existing canonical skill, refuses before any mutation when two managed roots resolve to the same or a nested path, and never inspects or changes `.system`.
+The operator command remains conservative: it defaults to a complete read-only plan, requires explicit `--apply`, refuses links it cannot prove target an existing canonical skill, refuses before any mutation when two managed roots resolve to the same or a nested directory by filesystem identity rather than path spelling, and never inspects or changes `.system`.

--- a/tests/fm-user-skill-sync.test.sh
+++ b/tests/fm-user-skill-sync.test.sh
@@ -372,6 +372,57 @@ test_codex_home_separator_spelling_converges() {
   pass "odd CODEX_HOME separator spelling still links correctly and converges"
 }
 
+test_unreadable_managed_root_refuses() {
+  local home out rc
+  if [ "$(id -u)" -eq 0 ]; then
+    pass "unreadable managed roots refuse (skipped: running as root bypasses permissions)"
+    return 0
+  fi
+
+  home=$(new_home)
+  make_skill "$home/.agents/skills" alpha body
+  make_skill "$home/.gemini/skills" alpha body
+  chmod 000 "$home/.gemini/skills"
+  set +e
+  out=$(run_sync "$home" --apply 2>&1)
+  rc=$?
+  set -e
+  chmod 755 "$home/.gemini/skills"
+  [ "$rc" -ne 0 ] || fail "unreadable managed skill root was reported as converged"
+  assert_contains "$out" "cannot inspect managed skill root" "unreadable root refusal lacked diagnosis"
+  [ -d "$home/.gemini/skills/alpha" ] || fail "refused run mutated the unreadable root"
+
+  home=$(new_home)
+  make_skill "$home/.agents/skills" alpha body
+  make_skill "$home/.gemini/skills" alpha body
+  chmod 000 "$home/.gemini"
+  set +e
+  out=$(run_sync "$home" --apply 2>&1)
+  rc=$?
+  set -e
+  chmod 755 "$home/.gemini"
+  [ "$rc" -ne 0 ] || fail "unreadable managed skill parent was reported as converged"
+  assert_contains "$out" "cannot inspect managed skill parent" "unreadable parent refusal lacked diagnosis"
+  [ -d "$home/.gemini/skills/alpha" ] || fail "refused run mutated the unreadable parent tree"
+  pass "an unreadable managed root refuses instead of claiming convergence"
+}
+
+test_mode_only_difference_names_permission_bits() {
+  local home out
+  home=$(new_home)
+  make_skill "$home/.agents/skills" alpha body
+  make_skill "$home/.gemini/skills" alpha body
+  chmod 700 "$home/.gemini/skills/alpha/sub"
+
+  out=$(expect_failure "$home" "mode-only difference" --apply)
+
+  assert_contains "$out" "permission bits differ" "mode-only refusal did not name permission bits"
+  assert_contains "$out" "/sub" "mode-only refusal did not name the differing entry"
+  assert_contains "$out" "700" "mode-only refusal did not report the differing modes"
+  [ -d "$home/.gemini/skills/alpha" ] || fail "refused run mutated the differing duplicate"
+  pass "a permission-bit-only difference is diagnosed as such"
+}
+
 test_remote_routes_through_registered_home() {
   local home fakebin argv encoded decoded home_encoded remote_home
   home=$(new_home)
@@ -420,4 +471,6 @@ test_non_default_modes_migrate_and_converge
 test_restrictive_umask_migration_converges
 test_control_character_nested_name_refuses
 test_codex_home_separator_spelling_converges
+test_unreadable_managed_root_refuses
+test_mode_only_difference_names_permission_bits
 test_remote_routes_through_registered_home

--- a/tests/fm-user-skill-sync.test.sh
+++ b/tests/fm-user-skill-sync.test.sh
@@ -542,36 +542,90 @@ test_unresolvable_codex_home_reports_one_cause() {
   pass "an unresolvable CODEX_HOME reports exactly one cause"
 }
 
-test_remote_routes_through_registered_home() {
-  local home fakebin argv encoded decoded home_encoded remote_home
-  home=$(new_home)
+remote_registry_home() {
+  local home=$1
   mkdir -p "$home/data"
   cat > "$home/data/secondmates.md" <<EOF
 - mac - registered Mac (host: remote-mac; root: /remote/firstmate; home: /remote/firstmate-home; scope: user tools; projects: ; added 2026-08-20)
+- studio - registered studio Mac (host: studio-mac; root: /studio/firstmate; home: /studio/firstmate-home; scope: user tools; projects: ; added 2026-08-20)
+- studio-standby - standby account on the studio Mac (host: studio-mac; root: /studio/firstmate-standby; home: /studio/standby-home; scope: user tools; projects: ; added 2026-08-20)
 EOF
+}
+
+remote_ssh_stub() {
+  local home=$1 fakebin
   fakebin=$(fm_fakebin "$home")
   cat > "$fakebin/ssh" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$@" > "${SSH_ARGV:?}"
 SH
   chmod +x "$fakebin/ssh"
+  printf '%s\n' "$fakebin/ssh"
+}
+
+decode_b64() {
+  printf '%s' "$1" | base64 --decode 2>/dev/null || printf '%s' "$1" | base64 -D
+}
+
+test_remote_routes_through_registered_home() {
+  local home ssh_bin argv decoded remote_root remote_home
+  home=$(new_home)
+  remote_registry_home "$home"
+  ssh_bin=$(remote_ssh_stub "$home")
   argv="$home/ssh.argv"
 
-  HOME="$home" FM_HOME="$home" FM_SSH_BIN="$fakebin/ssh" SSH_ARGV="$argv" \
+  HOME="$home" FM_HOME="$home" FM_SSH_BIN="$ssh_bin" SSH_ARGV="$argv" \
     "$SCRIPT" --remote mac --apply
 
   assert_grep 'remote-mac' "$argv" "remote operation did not use the registered SSH host"
-  home_encoded=$(tail -n 2 "$argv" | head -n 1)
-  remote_home=$(printf '%s' "$home_encoded" | base64 --decode 2>/dev/null \
-    || printf '%s' "$home_encoded" | base64 -D)
+  remote_root=$(decode_b64 "$(tail -n 3 "$argv" | head -n 1)")
+  remote_home=$(decode_b64 "$(tail -n 2 "$argv" | head -n 1)")
+  [ "$remote_root" = /remote/firstmate ] || fail "remote operation changed the registered root: $remote_root"
   [ "$remote_home" = /remote/firstmate-home ] || fail "remote operation changed the registered home: $remote_home"
-  encoded=$(tail -n 1 "$argv")
-  decoded=$(printf '%s' "$encoded" | base64 --decode 2>/dev/null | tr '\0' '\n' \
-    || printf '%s' "$encoded" | base64 -D | tr '\0' '\n')
+  decoded=$(decode_b64 "$(tail -n 1 "$argv")" | tr '\0' '\n')
   assert_contains "$decoded" "fm-user-skill-sync.sh" "remote argv omitted the authoritative command"
   assert_contains "$decoded" "--apply" "remote argv lost explicit apply intent"
-  assert_not_contains "$(cat "$argv")" "different-host" "remote route changed hosts"
-  pass "remote invocation binds the registered host and forwards explicit apply"
+  assert_not_contains "$(cat "$argv")" "studio-mac" "remote route reached another registered host"
+  assert_not_contains "$remote_home" "studio" "remote route bound another registered home"
+  pass "remote invocation binds exactly the selected record's host, root, and home"
+}
+
+test_remote_second_record_binds_its_own_placement() {
+  local home ssh_bin argv remote_root remote_home
+  home=$(new_home)
+  remote_registry_home "$home"
+  ssh_bin=$(remote_ssh_stub "$home")
+  argv="$home/ssh.argv"
+
+  HOME="$home" FM_HOME="$home" FM_SSH_BIN="$ssh_bin" SSH_ARGV="$argv" \
+    "$SCRIPT" --remote studio --dry-run
+
+  assert_grep 'studio-mac' "$argv" "selecting the second record did not use its own SSH host"
+  assert_not_contains "$(cat "$argv")" "remote-mac" "selecting the second record reached the first host"
+  remote_root=$(decode_b64 "$(tail -n 3 "$argv" | head -n 1)")
+  remote_home=$(decode_b64 "$(tail -n 2 "$argv" | head -n 1)")
+  [ "$remote_root" = /studio/firstmate ] || fail "second record bound root $remote_root"
+  [ "$remote_home" = /studio/firstmate-home ] || fail "second record bound home $remote_home"
+  pass "each registered record binds its own host, root, and home"
+}
+
+test_remote_ambiguous_alias_refuses_without_transport() {
+  local home ssh_bin argv out rc
+  home=$(new_home)
+  remote_registry_home "$home"
+  ssh_bin=$(remote_ssh_stub "$home")
+  argv="$home/ssh.argv"
+
+  set +e
+  out=$(HOME="$home" FM_HOME="$home" FM_SSH_BIN="$ssh_bin" SSH_ARGV="$argv" \
+    "$SCRIPT" --remote studio-mac --apply 2>&1)
+  rc=$?
+  set -e
+
+  [ "$rc" -ne 0 ] || fail "an ambiguous host alias was accepted"
+  assert_contains "$out" "ambiguous" "ambiguous alias refusal did not name the ambiguity"
+  [ ! -e "$argv" ] || fail "ambiguous alias still opened a remote transport"
+  pass "an ambiguous host alias refuses instead of selecting a host"
 }
 
 test_canonicalizes_and_links
@@ -596,3 +650,5 @@ test_interrupt_stops_apply
 test_interrupt_during_preflight_reports_no_mutation
 test_unresolvable_codex_home_reports_one_cause
 test_remote_routes_through_registered_home
+test_remote_second_record_binds_its_own_placement
+test_remote_ambiguous_alias_refuses_without_transport

--- a/tests/fm-user-skill-sync.test.sh
+++ b/tests/fm-user-skill-sync.test.sh
@@ -175,6 +175,36 @@ test_codex_relative_link_resolves_in_isolated_home() {
   pass "isolated Codex per-skill link resolves and exposes SKILL.md"
 }
 
+test_colliding_managed_roots_refuse() {
+  local home out rc
+  home=$(new_home)
+  make_skill "$home/.agents/skills" alpha body
+
+  set +e
+  out=$(HOME="$home" CODEX_HOME="$home/.agents" "$SCRIPT" 2>&1)
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "colliding Codex and canonical roots were not refused"
+  assert_contains "$out" "resolve to the same path" "collision refusal lacked diagnosis"
+
+  set +e
+  out=$(HOME="$home" CODEX_HOME="$home/.agents" "$SCRIPT" --apply 2>&1)
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "colliding roots were applied"
+  [ -f "$home/.agents/skills/alpha/SKILL.md" ] || fail "colliding apply destroyed the canonical skill"
+  [ ! -L "$home/.agents/skills/alpha" ] || fail "colliding apply replaced the canonical skill with a link"
+
+  set +e
+  out=$(HOME="$home" CODEX_HOME="$home/.agents/skills" "$SCRIPT" --apply 2>&1)
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "nested Codex root inside the canonical root was applied"
+  assert_contains "$out" "nested inside" "nested-root refusal lacked diagnosis"
+  [ -f "$home/.agents/skills/alpha/SKILL.md" ] || fail "nested apply destroyed the canonical skill"
+  pass "colliding or nested managed roots refuse before any mutation"
+}
+
 test_remote_routes_through_registered_home() {
   local home fakebin argv encoded decoded home_encoded remote_home
   home=$(new_home)
@@ -215,4 +245,5 @@ test_codex_system_preserved
 test_links_and_unexpected_entries_refuse
 test_safe_whole_root_links_converge
 test_codex_relative_link_resolves_in_isolated_home
+test_colliding_managed_roots_refuse
 test_remote_routes_through_registered_home

--- a/tests/fm-user-skill-sync.test.sh
+++ b/tests/fm-user-skill-sync.test.sh
@@ -423,35 +423,42 @@ test_mode_only_difference_names_permission_bits() {
   pass "a permission-bit-only difference is diagnosed as such"
 }
 
+# The apply loop is paused deterministically by shadowing `cp` with a stub that
+# blocks after the canonical copy is planned, so the signal is always delivered
+# mid-plan rather than racing the run to completion. Bash defers the trap until
+# the foreground child returns, so the stub is released after signalling.
 test_interrupt_stops_apply() {
-  local home out pid rc i waited
+  local home out pid rc fakebin waited
   home=$(new_home)
-  i=0
-  while [ "$i" -lt 60 ]; do
-    make_skill "$home/.gemini/skills" "skill$i" body
-    i=$((i + 1))
-  done
+  make_skill "$home/.gemini/skills" alpha body
   out="$home/apply.out"
+  fakebin=$(fm_fakebin "$home")
+  cat > "$fakebin/cp" <<'SH'
+#!/usr/bin/env bash
+: > "${COPY_STARTED:?}"
+waited=0
+while [ ! -e "${COPY_RELEASE:?}" ] && [ "$waited" -lt 600 ]; do
+  sleep 0.1
+  waited=$((waited + 1))
+done
+exec /bin/cp "$@"
+SH
+  chmod +x "$fakebin/cp"
 
-  HOME="$home" CODEX_HOME="$home/.codex" "$SCRIPT" --apply > "$out" 2>&1 &
+  PATH="$fakebin:$PATH" COPY_STARTED="$home/copy.started" COPY_RELEASE="$home/copy.release" \
+    HOME="$home" CODEX_HOME="$home/.codex" "$SCRIPT" --apply > "$out" 2>&1 &
   pid=$!
+
   waited=0
-  while [ "$waited" -lt 400 ]; do
-    grep -q '^APPLY$' "$out" 2>/dev/null && break
-    kill -0 "$pid" 2>/dev/null || break
-    sleep 0.05
+  while [ ! -e "$home/copy.started" ]; do
+    kill -0 "$pid" 2>/dev/null || fail "apply exited before reaching the canonical copy"
+    [ "$waited" -lt 600 ] || fail "apply never reached the canonical copy"
+    sleep 0.1
     waited=$((waited + 1))
   done
 
-  if ! kill -0 "$pid" 2>/dev/null; then
-    set +e
-    wait "$pid"
-    set -e
-    pass "interrupted apply exits nonzero (skipped: run finished before the signal landed)"
-    return 0
-  fi
-
-  kill -TERM "$pid" 2>/dev/null || true
+  kill -TERM "$pid" || fail "apply was no longer running when the signal was sent"
+  : > "$home/copy.release"
   set +e
   wait "$pid"
   rc=$?
@@ -460,7 +467,10 @@ test_interrupt_stops_apply() {
   [ "$rc" -eq 143 ] || fail "interrupted apply exited $rc instead of 143"
   assert_contains "$(cat "$out")" "interrupted by SIGTERM" "interrupted apply lacked an interruption diagnosis"
   assert_not_contains "$(cat "$out")" "user skills converged" "interrupted apply still claimed convergence"
-  pass "an interrupted apply stops with a nonzero status instead of claiming success"
+  [ -f "$home/.agents/skills/alpha/SKILL.md" ] || fail "the copy that was in flight did not complete"
+  [ -d "$home/.gemini/skills/alpha" ] || fail "the interrupted apply kept executing later plan steps"
+  [ ! -e "$home/.claude/skills/alpha" ] || fail "the interrupted apply kept linking after the signal"
+  pass "an interrupted apply stops at the signal instead of finishing the plan"
 }
 
 test_unresolvable_codex_home_reports_one_cause() {

--- a/tests/fm-user-skill-sync.test.sh
+++ b/tests/fm-user-skill-sync.test.sh
@@ -287,6 +287,63 @@ test_executable_skill_script_survives_migration() {
   pass "migration preserves executable skill scripts"
 }
 
+entry_mode() {
+  stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null
+}
+
+test_non_default_modes_migrate_and_converge() {
+  local home first second
+  home=$(new_home)
+  mkdir -p "$home/.gemini/skills/alpha/scripts"
+  printf '%s\n' body > "$home/.gemini/skills/alpha/SKILL.md"
+  printf '%s\n' 'echo hi' > "$home/.gemini/skills/alpha/scripts/run.sh"
+  chmod 664 "$home/.gemini/skills/alpha/scripts/run.sh"
+  chmod 775 "$home/.gemini/skills/alpha/scripts"
+
+  first=$(umask 022; run_sync "$home" --apply)
+
+  assert_contains "$first" "user skills converged" "migration of non-default modes did not converge"
+  [ "$(entry_mode "$home/.agents/skills/alpha/scripts/run.sh")" = 664 ] \
+    || fail "canonical copy did not preserve the source file mode"
+  [ "$(entry_mode "$home/.agents/skills/alpha/scripts")" = 775 ] \
+    || fail "canonical copy did not preserve the source directory mode"
+  [ ! -e "$home/.gemini/skills/alpha" ] || fail "migrated Gemini source was not removed"
+  second=$(run_sync "$home" --apply)
+  [ "$second" = "user skills already converged; no changes" ] \
+    || fail "rerun after migration did not converge: $second"
+  pass "migration preserves source modes and converges under a default umask"
+}
+
+test_restrictive_umask_migration_converges() {
+  local home first
+  home=$(new_home)
+  make_skill "$home/.opencode/skills" beta body
+
+  first=$(umask 077; run_sync "$home" --apply)
+
+  assert_contains "$first" "user skills converged" "migration under a restrictive umask did not converge"
+  [ -f "$home/.agents/skills/beta/SKILL.md" ] || fail "canonical skill was not established under umask 077"
+  [ ! -e "$home/.opencode/skills/beta" ] || fail "migrated OpenCode source was not removed"
+  pass "migration converges under a restrictive umask"
+}
+
+test_control_character_nested_name_refuses() {
+  local home out nested
+  home=$(new_home)
+  make_skill "$home/.agents/skills" alpha body
+  nested=$(printf 'note\nname.txt')
+  printf '%s\n' text > "$home/.agents/skills/alpha/$nested" 2>/dev/null || {
+    pass "control-character nested names are unsupported by this filesystem (skipped)"
+    return 0
+  }
+
+  out=$(expect_failure "$home" "control-character nested name" --apply)
+
+  assert_contains "$out" "control character" "control-character refusal lacked diagnosis"
+  [ -f "$home/.agents/skills/alpha/SKILL.md" ] || fail "refused run mutated the canonical skill"
+  pass "a control character in a nested skill name refuses before mutation"
+}
+
 test_remote_routes_through_registered_home() {
   local home fakebin argv encoded decoded home_encoded remote_home
   home=$(new_home)
@@ -331,4 +388,7 @@ test_colliding_managed_roots_refuse
 test_aliased_managed_roots_refuse
 test_mode_differing_duplicate_refuses
 test_executable_skill_script_survives_migration
+test_non_default_modes_migrate_and_converge
+test_restrictive_umask_migration_converges
+test_control_character_nested_name_refuses
 test_remote_routes_through_registered_home

--- a/tests/fm-user-skill-sync.test.sh
+++ b/tests/fm-user-skill-sync.test.sh
@@ -245,6 +245,48 @@ test_aliased_managed_roots_refuse() {
   pass "aliased managed roots that name one directory refuse before any mutation"
 }
 
+make_script_skill() {
+  local root=$1 name=$2 mode=$3
+  mkdir -p "$root/$name/scripts"
+  printf '%s\n' body > "$root/$name/SKILL.md"
+  printf '%s\n' 'echo hi' > "$root/$name/scripts/run.sh"
+  chmod "$mode" "$root/$name/scripts/run.sh"
+}
+
+test_mode_differing_duplicate_refuses() {
+  local home out second
+  home=$(new_home)
+  make_script_skill "$home/.agents/skills" alpha 644
+  make_script_skill "$home/.pi/agent/skills" alpha 755
+
+  out=$(expect_failure "$home" "mode-differing duplicate" --apply)
+
+  assert_contains "$out" "conflicting skill trees" "mode-difference refusal lacked diagnosis"
+  [ -x "$home/.pi/agent/skills/alpha/scripts/run.sh" ] \
+    || fail "executable duplicate was removed despite differing from the canonical copy"
+  [ ! -x "$home/.agents/skills/alpha/scripts/run.sh" ] || fail "canonical script mode changed"
+
+  chmod 644 "$home/.pi/agent/skills/alpha/scripts/run.sh"
+  second=$(run_sync "$home" --apply)
+  [ ! -e "$home/.pi/agent/skills/alpha" ] || fail "mode-identical duplicate was not removed"
+  assert_contains "$second" "user skills converged" "mode-identical duplicate did not converge"
+  pass "duplicate removal proves permission bits as well as bytes"
+}
+
+test_executable_skill_script_survives_migration() {
+  local home
+  home=$(new_home)
+  make_script_skill "$home/.gemini/skills" alpha 755
+
+  run_sync "$home" --apply >/dev/null
+
+  [ -x "$home/.agents/skills/alpha/scripts/run.sh" ] \
+    || fail "migration dropped the executable bit on a skill script"
+  [ -x "$home/.claude/skills/alpha/scripts/run.sh" ] \
+    || fail "executable script is not executable through the Claude link"
+  pass "migration preserves executable skill scripts"
+}
+
 test_remote_routes_through_registered_home() {
   local home fakebin argv encoded decoded home_encoded remote_home
   home=$(new_home)
@@ -287,4 +329,6 @@ test_safe_whole_root_links_converge
 test_codex_relative_link_resolves_in_isolated_home
 test_colliding_managed_roots_refuse
 test_aliased_managed_roots_refuse
+test_mode_differing_duplicate_refuses
+test_executable_skill_script_survives_migration
 test_remote_routes_through_registered_home

--- a/tests/fm-user-skill-sync.test.sh
+++ b/tests/fm-user-skill-sync.test.sh
@@ -423,6 +423,66 @@ test_mode_only_difference_names_permission_bits() {
   pass "a permission-bit-only difference is diagnosed as such"
 }
 
+test_interrupt_stops_apply() {
+  local home out pid rc i waited
+  home=$(new_home)
+  i=0
+  while [ "$i" -lt 60 ]; do
+    make_skill "$home/.gemini/skills" "skill$i" body
+    i=$((i + 1))
+  done
+  out="$home/apply.out"
+
+  HOME="$home" CODEX_HOME="$home/.codex" "$SCRIPT" --apply > "$out" 2>&1 &
+  pid=$!
+  waited=0
+  while [ "$waited" -lt 400 ]; do
+    grep -q '^APPLY$' "$out" 2>/dev/null && break
+    kill -0 "$pid" 2>/dev/null || break
+    sleep 0.05
+    waited=$((waited + 1))
+  done
+
+  if ! kill -0 "$pid" 2>/dev/null; then
+    set +e
+    wait "$pid"
+    set -e
+    pass "interrupted apply exits nonzero (skipped: run finished before the signal landed)"
+    return 0
+  fi
+
+  kill -TERM "$pid" 2>/dev/null || true
+  set +e
+  wait "$pid"
+  rc=$?
+  set -e
+
+  [ "$rc" -eq 143 ] || fail "interrupted apply exited $rc instead of 143"
+  assert_contains "$(cat "$out")" "interrupted by SIGTERM" "interrupted apply lacked an interruption diagnosis"
+  assert_not_contains "$(cat "$out")" "user skills converged" "interrupted apply still claimed convergence"
+  pass "an interrupted apply stops with a nonzero status instead of claiming success"
+}
+
+test_unresolvable_codex_home_reports_one_cause() {
+  local home out errors rc
+  home=$(new_home)
+  printf '%s\n' text > "$home/afile"
+
+  set +e
+  out=$(HOME="$home" CODEX_HOME="$home/afile" "$SCRIPT" 2>&1)
+  rc=$?
+  set -e
+
+  [ "$rc" -ne 0 ] || fail "CODEX_HOME pointing at a regular file was accepted"
+  assert_contains "$out" "existing CODEX_HOME ancestor is not a directory" \
+    "unresolvable CODEX_HOME refusal lacked its cause"
+  assert_not_contains "$out" "must resolve to an absolute path" \
+    "unresolvable CODEX_HOME emitted a cascading empty-path error"
+  errors=$(printf '%s\n' "$out" | grep -c '^error:')
+  [ "$errors" -eq 1 ] || fail "unresolvable CODEX_HOME reported $errors errors instead of one"
+  pass "an unresolvable CODEX_HOME reports exactly one cause"
+}
+
 test_remote_routes_through_registered_home() {
   local home fakebin argv encoded decoded home_encoded remote_home
   home=$(new_home)
@@ -473,4 +533,6 @@ test_control_character_nested_name_refuses
 test_codex_home_separator_spelling_converges
 test_unreadable_managed_root_refuses
 test_mode_only_difference_names_permission_bits
+test_interrupt_stops_apply
+test_unresolvable_codex_home_reports_one_cause
 test_remote_routes_through_registered_home

--- a/tests/fm-user-skill-sync.test.sh
+++ b/tests/fm-user-skill-sync.test.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# Behavior tests for the user-skill canonicalization command.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-user-skill-sync)
+SCRIPT="$ROOT/bin/fm-user-skill-sync.sh"
+new_home() {
+  mktemp -d "$TMP_ROOT/home.XXXXXX"
+}
+
+make_skill() {
+  local root=$1 name=$2 body=$3
+  mkdir -p "$root/$name/sub"
+  printf '%s\n' "$body" > "$root/$name/SKILL.md"
+  printf '%s\n' asset > "$root/$name/sub/asset.txt"
+}
+
+run_sync() {
+  local home=$1
+  shift
+  HOME="$home" CODEX_HOME="$home/.codex" "$SCRIPT" "$@"
+}
+
+expect_failure() {
+  local home=$1 message=$2
+  shift 2
+  local out rc
+  set +e
+  out=$(run_sync "$home" "$@" 2>&1)
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "$message: command unexpectedly succeeded"
+  printf '%s\n' "$out"
+}
+
+test_canonicalizes_and_links() {
+  local home out
+  home=$(new_home)
+  make_skill "$home/.gemini/skills" alpha content
+
+  out=$(run_sync "$home" --apply)
+
+  [ -f "$home/.agents/skills/alpha/SKILL.md" ] || fail "canonical skill was not established"
+  [ ! -e "$home/.gemini/skills/alpha" ] || fail "verified Gemini duplicate remained"
+  [ -L "$home/.claude/skills/alpha" ] || fail "Claude per-skill link missing"
+  [ "$(readlink "$home/.claude/skills/alpha")" = '../../.agents/skills/alpha' ] \
+    || fail "Claude link is not the expected relative target"
+  [ -L "$home/.codex/skills/alpha" ] || fail "Codex per-skill link missing"
+  [ "$(readlink "$home/.codex/skills/alpha")" = '../../.agents/skills/alpha' ] \
+    || fail "Codex link is not the expected relative target"
+  assert_contains "$out" "user skills converged" "apply did not report convergence"
+  pass "real user skill migrates to canonical content with relative harness links"
+}
+
+test_duplicate_removal_and_idempotence() {
+  local home first second
+  home=$(new_home)
+  make_skill "$home/.agents/skills" alpha same
+  make_skill "$home/.pi/agent/skills" alpha same
+  make_skill "$home/.config/opencode/skills" alpha same
+
+  first=$(run_sync "$home" --apply)
+  [ ! -e "$home/.pi/agent/skills/alpha" ] || fail "Pi duplicate remained"
+  [ ! -e "$home/.config/opencode/skills/alpha" ] || fail "OpenCode duplicate remained"
+  second=$(run_sync "$home" --apply)
+  assert_contains "$first" "remove" "first apply omitted duplicate-removal plan"
+  [ "$second" = "user skills already converged; no changes" ] \
+    || fail "second apply did not converge to no changes: $second"
+  pass "verified duplicate removal is idempotent"
+}
+
+test_conflict_refuses_without_mutation() {
+  local home out before
+  home=$(new_home)
+  make_skill "$home/.agents/skills" alpha canonical
+  make_skill "$home/.claude/skills" alpha conflicting
+  before=$(cat "$home/.claude/skills/alpha/SKILL.md")
+
+  out=$(expect_failure "$home" "conflicting trees")
+
+  assert_contains "$out" "conflicting skill trees" "conflict refusal lacked diagnosis"
+  [ -d "$home/.claude/skills/alpha" ] || fail "conflicting source was mutated"
+  [ "$(cat "$home/.claude/skills/alpha/SKILL.md")" = "$before" ] || fail "conflicting source content changed"
+  [ ! -e "$home/.codex/skills/alpha" ] || fail "preflight conflict allowed partial Codex mutation"
+  pass "byte-different skill trees refuse before mutation"
+}
+
+test_dry_run_changes_nothing() {
+  local home out
+  home=$(new_home)
+  make_skill "$home/.opencode/skills" beta body
+
+  out=$(run_sync "$home")
+
+  assert_contains "$out" "DRY RUN - no changes made" "default run was not visibly dry"
+  [ -d "$home/.opencode/skills/beta" ] || fail "dry-run removed source"
+  [ ! -e "$home/.agents" ] || fail "dry-run created canonical root"
+  [ ! -e "$home/.claude" ] || fail "dry-run created Claude root"
+  [ ! -e "$home/.codex" ] || fail "dry-run created Codex root"
+  pass "dry-run is the mutation-free default"
+}
+
+test_codex_system_preserved() {
+  local home before
+  home=$(new_home)
+  mkdir -p "$home/.codex/skills/.system"
+  printf '%s\n' vendor > "$home/.codex/skills/.system/owned.txt"
+  before=$(cat "$home/.codex/skills/.system/owned.txt")
+  make_skill "$home/.agents/skills" alpha body
+
+  run_sync "$home" --apply >/dev/null
+
+  [ "$(cat "$home/.codex/skills/.system/owned.txt")" = "$before" ] || fail "Codex .system content changed"
+  [ -L "$home/.codex/skills/alpha" ] || fail "Codex user link was not created beside .system"
+  pass "Codex vendor-managed .system is preserved"
+}
+
+test_links_and_unexpected_entries_refuse() {
+  local home out
+  home=$(new_home)
+  mkdir -p "$home/.agents/skills/alpha"
+  printf '%s\n' body > "$home/.agents/skills/alpha/SKILL.md"
+  ln -s missing "$home/.claude/skills" 2>/dev/null || {
+    mkdir -p "$home/.claude"
+    ln -s missing "$home/.claude/skills"
+  }
+  out=$(expect_failure "$home" "broken root link")
+  assert_contains "$out" "broken managed skill root link" "broken root link refusal lacked diagnosis"
+
+  home=$(new_home)
+  make_skill "$home/.agents/skills" alpha body
+  make_skill "$home/outside" alpha body
+  mkdir -p "$home/.claude/skills"
+  ln -s "$home/outside/alpha" "$home/.claude/skills/alpha"
+  out=$(expect_failure "$home" "unsafe per-skill link")
+  assert_contains "$out" "unsafe skill link points outside" "unsafe per-skill link refusal lacked diagnosis"
+
+  home=$(new_home)
+  mkdir -p "$home/.agents/skills"
+  printf '%s\n' surprise > "$home/.agents/skills/README.txt"
+  out=$(expect_failure "$home" "unexpected root file")
+  assert_contains "$out" "unexpected entry" "unexpected-entry refusal lacked diagnosis"
+  pass "broken links and unexpected entries refuse conservatively"
+}
+
+test_safe_whole_root_links_converge() {
+  local home
+  home=$(new_home)
+  make_skill "$home/.agents/skills" alpha body
+  mkdir -p "$home/.claude" "$home/.pi/agent"
+  ln -s ../.agents/skills "$home/.claude/skills"
+  ln -s ../../.agents/skills "$home/.pi/agent/skills"
+
+  run_sync "$home" --apply >/dev/null
+
+  [ -d "$home/.claude/skills" ] && [ ! -L "$home/.claude/skills" ] \
+    || fail "safe Claude whole-root link did not become a real per-skill root"
+  [ -L "$home/.claude/skills/alpha" ] || fail "Claude per-skill link missing after root conversion"
+  [ ! -e "$home/.pi/agent/skills" ] || fail "native Pi whole-root duplicate link remained"
+  pass "verified whole-root canonical links converge without touching their target"
+}
+
+test_codex_relative_link_resolves_in_isolated_home() {
+  local home resolved expected
+  home=$(new_home)
+  make_skill "$home/.agents/skills" probe body
+  run_sync "$home" --apply >/dev/null
+  resolved=$(cd "$home/.codex/skills/probe" && pwd -P)
+  expected=$(cd "$home/.agents/skills/probe" && pwd -P)
+  [ "$resolved" = "$expected" ] || fail "isolated Codex link does not resolve to canonical skill"
+  [ -f "$home/.codex/skills/probe/SKILL.md" ] || fail "SKILL.md is unreadable through isolated Codex link"
+  pass "isolated Codex per-skill link resolves and exposes SKILL.md"
+}
+
+test_remote_routes_through_registered_home() {
+  local home fakebin argv encoded decoded home_encoded remote_home
+  home=$(new_home)
+  mkdir -p "$home/data"
+  cat > "$home/data/secondmates.md" <<EOF
+- mac - registered Mac (host: remote-mac; root: /remote/firstmate; home: /remote/firstmate-home; scope: user tools; projects: ; added 2026-08-20)
+EOF
+  fakebin=$(fm_fakebin "$home")
+  cat > "$fakebin/ssh" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "${SSH_ARGV:?}"
+SH
+  chmod +x "$fakebin/ssh"
+  argv="$home/ssh.argv"
+
+  HOME="$home" FM_HOME="$home" FM_SSH_BIN="$fakebin/ssh" SSH_ARGV="$argv" \
+    "$SCRIPT" --remote mac --apply
+
+  assert_grep 'remote-mac' "$argv" "remote operation did not use the registered SSH host"
+  home_encoded=$(tail -n 2 "$argv" | head -n 1)
+  remote_home=$(printf '%s' "$home_encoded" | base64 --decode 2>/dev/null \
+    || printf '%s' "$home_encoded" | base64 -D)
+  [ "$remote_home" = /remote/firstmate-home ] || fail "remote operation changed the registered home: $remote_home"
+  encoded=$(tail -n 1 "$argv")
+  decoded=$(printf '%s' "$encoded" | base64 --decode 2>/dev/null | tr '\0' '\n' \
+    || printf '%s' "$encoded" | base64 -D | tr '\0' '\n')
+  assert_contains "$decoded" "fm-user-skill-sync.sh" "remote argv omitted the authoritative command"
+  assert_contains "$decoded" "--apply" "remote argv lost explicit apply intent"
+  assert_not_contains "$(cat "$argv")" "different-host" "remote route changed hosts"
+  pass "remote invocation binds the registered host and forwards explicit apply"
+}
+
+test_canonicalizes_and_links
+test_duplicate_removal_and_idempotence
+test_conflict_refuses_without_mutation
+test_dry_run_changes_nothing
+test_codex_system_preserved
+test_links_and_unexpected_entries_refuse
+test_safe_whole_root_links_converge
+test_codex_relative_link_resolves_in_isolated_home
+test_remote_routes_through_registered_home

--- a/tests/fm-user-skill-sync.test.sh
+++ b/tests/fm-user-skill-sync.test.sh
@@ -423,6 +423,23 @@ test_mode_only_difference_names_permission_bits() {
   pass "a permission-bit-only difference is diagnosed as such"
 }
 
+# Shadows one external command with a stub that announces itself and blocks
+# until the test releases it, giving a deterministic pause point inside the run.
+make_blocking_stub() {
+  local fakebin=$1 name=$2 real=$3
+  cat > "$fakebin/$name" <<SH
+#!/usr/bin/env bash
+: > "\${STUB_STARTED:?}"
+waited=0
+while [ ! -e "\${STUB_RELEASE:?}" ] && [ "\$waited" -lt 600 ]; do
+  sleep 0.1
+  waited=\$((waited + 1))
+done
+exec $real "\$@"
+SH
+  chmod +x "$fakebin/$name"
+}
+
 # The apply loop is paused deterministically by shadowing `cp` with a stub that
 # blocks after the canonical copy is planned, so the signal is always delivered
 # mid-plan rather than racing the run to completion. Bash defers the trap until
@@ -433,24 +450,14 @@ test_interrupt_stops_apply() {
   make_skill "$home/.gemini/skills" alpha body
   out="$home/apply.out"
   fakebin=$(fm_fakebin "$home")
-  cat > "$fakebin/cp" <<'SH'
-#!/usr/bin/env bash
-: > "${COPY_STARTED:?}"
-waited=0
-while [ ! -e "${COPY_RELEASE:?}" ] && [ "$waited" -lt 600 ]; do
-  sleep 0.1
-  waited=$((waited + 1))
-done
-exec /bin/cp "$@"
-SH
-  chmod +x "$fakebin/cp"
+  make_blocking_stub "$fakebin" cp /bin/cp
 
-  PATH="$fakebin:$PATH" COPY_STARTED="$home/copy.started" COPY_RELEASE="$home/copy.release" \
+  PATH="$fakebin:$PATH" STUB_STARTED="$home/stub.started" STUB_RELEASE="$home/stub.release" \
     HOME="$home" CODEX_HOME="$home/.codex" "$SCRIPT" --apply > "$out" 2>&1 &
   pid=$!
 
   waited=0
-  while [ ! -e "$home/copy.started" ]; do
+  while [ ! -e "$home/stub.started" ]; do
     kill -0 "$pid" 2>/dev/null || fail "apply exited before reaching the canonical copy"
     [ "$waited" -lt 600 ] || fail "apply never reached the canonical copy"
     sleep 0.1
@@ -458,7 +465,7 @@ SH
   done
 
   kill -TERM "$pid" || fail "apply was no longer running when the signal was sent"
-  : > "$home/copy.release"
+  : > "$home/stub.release"
   set +e
   wait "$pid"
   rc=$?
@@ -466,11 +473,53 @@ SH
 
   [ "$rc" -eq 143 ] || fail "interrupted apply exited $rc instead of 143"
   assert_contains "$(cat "$out")" "interrupted by SIGTERM" "interrupted apply lacked an interruption diagnosis"
+  assert_contains "$(cat "$out")" "may already be applied" \
+    "mid-apply interruption did not report that changes may be applied"
   assert_not_contains "$(cat "$out")" "user skills converged" "interrupted apply still claimed convergence"
   [ -f "$home/.agents/skills/alpha/SKILL.md" ] || fail "the copy that was in flight did not complete"
   [ -d "$home/.gemini/skills/alpha" ] || fail "the interrupted apply kept executing later plan steps"
   [ ! -e "$home/.claude/skills/alpha" ] || fail "the interrupted apply kept linking after the signal"
   pass "an interrupted apply stops at the signal instead of finishing the plan"
+}
+
+test_interrupt_during_preflight_reports_no_mutation() {
+  local home out pid rc fakebin waited real_diff
+  home=$(new_home)
+  make_skill "$home/.agents/skills" alpha body
+  make_skill "$home/.gemini/skills" alpha body
+  out="$home/dryrun.out"
+  fakebin=$(fm_fakebin "$home")
+  real_diff=$(command -v diff)
+  make_blocking_stub "$fakebin" diff "$real_diff"
+
+  PATH="$fakebin:$PATH" STUB_STARTED="$home/stub.started" STUB_RELEASE="$home/stub.release" \
+    HOME="$home" CODEX_HOME="$home/.codex" "$SCRIPT" > "$out" 2>&1 &
+  pid=$!
+
+  waited=0
+  while [ ! -e "$home/stub.started" ]; do
+    kill -0 "$pid" 2>/dev/null || fail "dry run exited before reaching the preflight comparison"
+    [ "$waited" -lt 600 ] || fail "dry run never reached the preflight comparison"
+    sleep 0.1
+    waited=$((waited + 1))
+  done
+
+  kill -TERM "$pid" || fail "dry run was no longer running when the signal was sent"
+  : > "$home/stub.release"
+  set +e
+  wait "$pid"
+  rc=$?
+  set -e
+
+  [ "$rc" -eq 143 ] || fail "interrupted dry run exited $rc instead of 143"
+  assert_contains "$(cat "$out")" "before any planned change began" \
+    "preflight interruption did not report that nothing was mutated"
+  assert_not_contains "$(cat "$out")" "may already be applied" \
+    "preflight interruption wrongly claimed applied changes"
+  [ -f "$home/.agents/skills/alpha/SKILL.md" ] || fail "interrupted dry run mutated the canonical skill"
+  [ -d "$home/.gemini/skills/alpha" ] || fail "interrupted dry run removed the duplicate"
+  [ ! -e "$home/.claude" ] || fail "interrupted dry run created a managed root"
+  pass "an interrupted read-only run reports that nothing was mutated"
 }
 
 test_unresolvable_codex_home_reports_one_cause() {
@@ -544,5 +593,6 @@ test_codex_home_separator_spelling_converges
 test_unreadable_managed_root_refuses
 test_mode_only_difference_names_permission_bits
 test_interrupt_stops_apply
+test_interrupt_during_preflight_reports_no_mutation
 test_unresolvable_codex_home_reports_one_cause
 test_remote_routes_through_registered_home

--- a/tests/fm-user-skill-sync.test.sh
+++ b/tests/fm-user-skill-sync.test.sh
@@ -344,6 +344,34 @@ test_control_character_nested_name_refuses() {
   pass "a control character in a nested skill name refuses before mutation"
 }
 
+test_codex_home_separator_spelling_converges() {
+  local home resolved expected second
+  home=$(new_home)
+  make_skill "$home/.agents/skills" alpha body
+
+  HOME="$home" CODEX_HOME="$home/.codex/" "$SCRIPT" --apply >/dev/null
+
+  [ -L "$home/.codex/skills/alpha" ] || fail "trailing-slash CODEX_HOME did not create the Codex link"
+  resolved=$(cd "$home/.codex/skills/alpha" 2>/dev/null && pwd -P) \
+    || fail "trailing-slash CODEX_HOME produced a link that does not resolve"
+  expected=$(cd "$home/.agents/skills/alpha" && pwd -P)
+  [ "$resolved" = "$expected" ] || fail "Codex link resolves outside the canonical store: $resolved"
+  [ -f "$home/.codex/skills/alpha/SKILL.md" ] || fail "SKILL.md is unreadable through the Codex link"
+
+  second=$(run_sync "$home" --apply)
+  [ "$second" = "user skills already converged; no changes" ] \
+    || fail "canonically spelled rerun did not converge: $second"
+
+  home=$(new_home)
+  make_skill "$home/.agents/skills" alpha body
+  HOME="$home" CODEX_HOME="$home//.codex//" "$SCRIPT" --apply >/dev/null
+  resolved=$(cd "$home/.codex/skills/alpha" 2>/dev/null && pwd -P) \
+    || fail "repeated-separator CODEX_HOME produced a link that does not resolve"
+  [ "$resolved" = "$(cd "$home/.agents/skills/alpha" && pwd -P)" ] \
+    || fail "repeated-separator CODEX_HOME resolves outside the canonical store"
+  pass "odd CODEX_HOME separator spelling still links correctly and converges"
+}
+
 test_remote_routes_through_registered_home() {
   local home fakebin argv encoded decoded home_encoded remote_home
   home=$(new_home)
@@ -391,4 +419,5 @@ test_executable_skill_script_survives_migration
 test_non_default_modes_migrate_and_converge
 test_restrictive_umask_migration_converges
 test_control_character_nested_name_refuses
+test_codex_home_separator_spelling_converges
 test_remote_routes_through_registered_home

--- a/tests/fm-user-skill-sync.test.sh
+++ b/tests/fm-user-skill-sync.test.sh
@@ -185,7 +185,7 @@ test_colliding_managed_roots_refuse() {
   rc=$?
   set -e
   [ "$rc" -ne 0 ] || fail "colliding Codex and canonical roots were not refused"
-  assert_contains "$out" "resolve to the same path" "collision refusal lacked diagnosis"
+  assert_contains "$out" "same directory" "collision refusal lacked diagnosis"
 
   set +e
   out=$(HOME="$home" CODEX_HOME="$home/.agents" "$SCRIPT" --apply 2>&1)
@@ -203,6 +203,46 @@ test_colliding_managed_roots_refuse() {
   assert_contains "$out" "nested inside" "nested-root refusal lacked diagnosis"
   [ -f "$home/.agents/skills/alpha/SKILL.md" ] || fail "nested apply destroyed the canonical skill"
   pass "colliding or nested managed roots refuse before any mutation"
+}
+
+# A managed root that differs only in spelling still names one directory on a
+# case-insensitive volume, which is the captain's default macOS filesystem.
+filesystem_is_case_insensitive() {
+  local probe=$1
+  mkdir -p "$probe/casefold"
+  [ -d "$probe/CASEFOLD" ]
+}
+
+test_aliased_managed_roots_refuse() {
+  local home out rc probe
+  home=$(new_home)
+
+  set +e
+  out=$(HOME="$home" CODEX_HOME="$home/.Agents" "$SCRIPT" 2>&1)
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "case-variant Codex root was not refused before the roots existed"
+  assert_contains "$out" "same directory" "case-variant refusal lacked diagnosis"
+  [ ! -e "$home/.agents" ] || fail "refused run created the canonical root"
+
+  probe=$(new_home)
+  if ! filesystem_is_case_insensitive "$probe"; then
+    pass "case-variant managed roots refuse before creation (case-sensitive volume: alias case skipped)"
+    return 0
+  fi
+
+  home=$(new_home)
+  make_skill "$home/.agents/skills" alpha body
+
+  set +e
+  out=$(HOME="$home" CODEX_HOME="$home/.Agents" "$SCRIPT" --apply 2>&1)
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "case-variant Codex root aliasing the canonical store was applied"
+  assert_contains "$out" "same directory" "aliased-root refusal lacked diagnosis"
+  [ -f "$home/.agents/skills/alpha/SKILL.md" ] || fail "aliased apply destroyed the canonical skill"
+  [ ! -L "$home/.agents/skills/alpha" ] || fail "aliased apply replaced the canonical skill with a link"
+  pass "aliased managed roots that name one directory refuse before any mutation"
 }
 
 test_remote_routes_through_registered_home() {
@@ -246,4 +286,5 @@ test_links_and_unexpected_entries_refuse
 test_safe_whole_root_links_converge
 test_codex_relative_link_resolves_in_isolated_home
 test_colliding_managed_roots_refuse
+test_aliased_managed_roots_refuse
 test_remote_routes_through_registered_home


### PR DESCRIPTION
## Intent

Implement the captain-approved canonical user-skill layout and synchronization tool for Firstmate. Add an idempotent operator command with clear help that defaults to dry-run and requires explicit apply. Canonical user-installed skills under $HOME/.agents/skills; create relative per-skill links for Claude under $HOME/.claude/skills and Codex under ${CODEX_HOME:-$HOME/.codex}/skills; remove only verified duplicate user-skill copies or links from Gemini, OpenCode, and Pi roots because they discover the canonical store natively. Migrate or reconcile real skill directories only when trees are byte-identical or no canonical copy exists, and refuse before mutation on conflicts, broken or unsafe links, unexpected entries, special files, or ambiguous ownership. Never touch Codex skills/.system, Firstmate repository-internal .agents/skills, public skills/, Claude plugins or caches, project clones, unrelated home files, or additional skills/plugins. Support the registered remote Mac through an explicit guarded registered route that runs the same checks and cannot silently select another host or home; keep plugin distribution separate. Include executable temporary-home tests for canonicalization, relative links, duplicate removal, conflict refusal, .system preservation, dry-run, idempotence, safe and unsafe links, and remote command construction/home binding. Add concise operator documentation with exact local and remote dry-run/apply examples. Do not run migration against the captain's real local or remote roots. Verify one Codex link in an isolated temporary home; because a live authenticated Codex discovery check could mutate captain environment state, record that limitation and keep application conservative. Keep the full operational contract authoritative in the script header/help, with supporting usage in the appropriate operator documentation rather than AGENTS.md.

## What Changed

- Added `bin/fm-user-skill-sync.sh`, an operator command that converges user-installed skills on the canonical `$HOME/.agents/skills` store: it creates relative per-skill links for Claude and `${CODEX_HOME:-$HOME/.codex}`, removes only verified duplicate copies from the Gemini, OpenCode, and Pi roots, preserves Codex `skills/.system` and plugin installs, defaults to a complete read-only plan with `--apply` as the only mutation switch, and refuses the whole run before mutating on conflicts, unsafe or broken links, unexpected entries, unreadable roots, or managed roots that resolve to the same or a nested directory by filesystem identity. `--remote <secondmate-id|ssh-alias>` routes through a registered secondmate record and `bin/fm-on.sh`, binding the configured host, code root, and remote home with no fallback, and refusing ambiguous aliases before opening a transport.
- Added `tests/fm-user-skill-sync.test.sh` (24 temporary-home cases) covering canonicalization, relative and whole-root links, duplicate removal under default and restrictive umasks, byte and permission-bit conflict refusal, control-character and `CODEX_HOME` separator handling, dry-run, idempotence, `.system` preservation, interrupted apply and preflight reporting, managed-root collision refusal, and remote command construction/home binding; registered the suite in `bin/fm-test-run.sh` under `pure-contract-unit`.
- Documented the layout and exact local/remote dry-run and apply examples in `docs/configuration.md`, listed the script in `docs/scripts.md`, added `docs/verification/user-skills.md` recording the isolated-Codex-link verification and the unverified live-discovery boundary, and corrected the `docs/remote-secondmates.md` remote-write-surface claim to include this routed operation.

## Risk Assessment

✅ Low: The fix rounds only replaced a vacuous test assertion with genuine multi-record host/root/home binding and ambiguity-refusal coverage and refreshed a verification transcript to match the suite exactly; no production behavior changed and the underlying sync command remains fail-closed with a total preflight before any mutation.

## Testing

I ran the focused temporary-home suite for the new command (all 24 cases pass) and then exercised the command the way an operator would, in a disposable HOME: help, dry-run default that changed nothing, explicit apply that canonicalized a real skill tree into $HOME/.agents/skills with relative Claude and Codex links, removal of the verified Gemini and Pi duplicates, Codex .system left untouched, a second apply reporting already-converged, a byte-conflict refusing with both trees intact, and the registered remote route binding exactly one record's host/root/home under a stubbed ssh while an ambiguous alias refused before any transport opened. Everything ran against sandbox roots only — the captain's real local and remote skill roots were never touched, and live authenticated Codex discovery remains unverified as the change's own verification record states. The captured CLI transcript is the reviewer-visible artifact; the change is CLI-only, so there is no UI surface to screenshot. The working tree is clean of test byproducts.

<details>
<summary>Evidence: Operator CLI transcript: canonicalization, links, duplicate removal, .system preservation, dry-run/apply/idempotence, conflict refusal, remote binding</summary>

Source: [Operator CLI transcript: canonicalization, links, duplicate removal, .system preservation, dry-run/apply/idempotence, conflict refusal, remote binding](https://github.com/timoconnellaus/firstmate/blob/42a35e4912e3f4d46005f95f5750fcb7bf91f372/.no-mistakes/evidence/fm/firstmate-skill-canonical-store-sync-i9/user-skill-sync-operator-transcript.txt)

```text
### Isolated operator sandbox HOME=/var/folders/5m/kfvhd_k5671cqk7cdj6t08540000gn/T//fm-usk-demo.avnroD/home (captain's real HOME is never used)

### Seeded layout before any run
./.codex
./.codex/skills
./.codex/skills/.system
./.codex/skills/.system/vendor
./.gemini
./.gemini/skills
./.gemini/skills/alpha
./.gemini/skills/alpha/SKILL.md
./.gemini/skills/alpha/sub
./.pi
./.pi/agent
./.pi/agent/skills
./.pi/agent/skills/alpha

############ 1. Help / operating contract ############

$ /Users/tim/.no-mistakes/worktrees/832fb889ab00/01M0EG441CN960PFMP8TRFA69S/bin/fm-user-skill-sync.sh --help
Converge user-installed skills into one canonical cross-harness layout.

The canonical content store is $HOME/.agents/skills. Claude Code and Codex
receive relative per-skill links in their user skill roots. Gemini, OpenCode,
and Pi discover the canonical store natively, so verified duplicates in their
legacy user roots are removed. Codex's vendor-owned skills/.system entry and
plugin installations are never inspected or changed.

Every local run performs a complete read-only preflight before acting. Dry-run
is the default; --apply is the only mutation switch. A conflict, unsafe or
broken link, special file, malformed skill directory, unexpected root entry,
overlapping managed roots, or ambiguous tree refuses the whole run before any
mutation. An existing managed root that cannot be listed is refused rather
than read as empty, so convergence is never claimed for a root this run could
not inspect. Skill trees may contain directories and regular files only and
must include SKILL.md, and no nested name may carry a control character. A
duplicate is verified only when its tree matches the retained copy in
structure, bytes, and permission bits, and the canonical copy is established
mode-faithfully so that proof holds under any umask. Managed roots are
compared by filesystem identity rather than path spelling, so a
case-insensitive volume or an aliased path cannot present one directory under
two ownership roles.

Preflight refusal is total: nothing is mutated. Once --apply begins executing
the accepted plan, each step is re-verified against the live filesystem and a
step that no longer matches the plan stops the run there, leaving the earlier
steps applied. Each step is individually safe and convergent, so rerunning the
command after resolving the interference replans from the current state.

Remote operation is routed only through a registered remote secondmate record
and bin/fm-on.sh, which binds the configured SSH host, code root, and remote
home without fallback. It executes this same tracked script in the remote
account. Plugin distribution remains a separate operation.

Usage:
  fm-user-skill-sync.sh [--dry-run|--apply]
  fm-user-skill-sync.sh --remote <secondmate-id|ssh-alias> [--dry-run|--apply]

Environment:
  HOME        Absolute user home whose skill roots are reconciled.
  CODEX_HOME  Optional absolute Codex home (default: $HOME/.codex).

Managed user roots:
  $HOME/.agents/skills                 canonical content
  $HOME/.claude/skills                 relative links
  ${CODEX_HOME:-$HOME/.codex}/skills   relative links; .system preserved
  $HOME/.gemini/skills                 duplicate cleanup only
  $HOME/.config/opencode/skills        duplicate cleanup only
  $HOME/.opencode/skills               duplicate cleanup only
  $HOME/.pi/agent/skills               duplicate cleanup only
[exit 0]

############ 2. Default is dry-run (docs: bin/fm-user-skill-sync.sh) ############

$ /Users/tim/.no-mistakes/worktrees/832fb889ab00/01M0EG441CN960PFMP8TRFA69S/bin/fm-user-skill-sync.sh
DRY RUN - no changes made
mkdir /private/var/folders/5m/kfvhd_k5671cqk7cdj6t08540000gn/T/fm-usk-demo.avnroD/home/.agents/skills
mkdir /private/var/folders/5m/kfvhd_k5671cqk7cdj6t08540000gn/T/fm-usk-demo.avnroD/home/.claude/skills
copy /private/var/folders/5m/kfvhd_k5671cqk7cdj6t08540000gn/T/fm-usk-demo.avnroD/home/.gemini/skills/alpha -> /private/var/folders/5m/kfvhd_k5671cqk7cdj6t08540000gn/T/fm-usk-demo.avnroD/home/.agents/skills/alpha
remove /private/var/folders/5m/kfvhd_k5671cqk7cdj6t08540000gn/T/fm-usk-demo.avnroD/home/.gemini/skills/alpha
remove /private/var/folders/5m/kfvhd_k5671cqk7cdj6t08540000gn/T/fm-usk-demo.avnroD/home/.pi/agent/skills/alpha
link /private/var/folders/5m/kfvhd_k5671cqk7cdj6t08540000gn/T/fm-usk-demo.avnroD/home/.claude/skills/alpha -> ../../.agents/skills/alpha
link /private/var/folders/5m/kfvhd_k5671cqk7cdj6t08540000gn/T/fm-usk-demo.avnroD/home/.codex/skills/alpha -> ../../.agents/skills/alpha
[exit 0]
--- filesystem after default run (unchanged?) ---
./.codex
./.codex/skills
./.codex/skills/.system
./.codex/skills/.system/vendor
./.gemini
./.gemini/skills
./.gemini/skills/alpha
./.gemini/skills/alpha/SKILL.md
./.gemini/skills/alpha/sub
./.pi
./.pi/agent
./.pi/agent/skills
./.pi/agent/skills/alpha

############ 3. Explicit apply (docs: bin/fm-user-skill-sync.sh --apply) ############

$ /Users/tim/.no-mistakes/worktrees/832fb889ab00/01M0EG441CN960PFMP8TRFA69S/bin/fm-user-skill-sync.sh --apply
APPLY
mkdir /private/var/folders/5m/kfvhd_k5671cqk7cdj6t08540000gn/T/fm-usk-demo.avnroD/home/.agents/skills
mkdir /private/var/folders/5m/kfvhd_k5671cqk7cdj6t08540000gn/T/fm-usk-demo.avnroD/home/.claude/skills
copy /private/var/folders/5m/kfvhd_k5671cqk7cdj6t08540000gn/T/fm-usk-demo.avnroD/home/.gemini/skills/alpha -> /private/var/folders/5m/kfvhd_k5671cqk7cdj6t08540000gn/T/fm-usk-demo.avnroD/home/.agents/skills/alpha
remove /private/var/folders/5m/kfvhd_k5671cqk7cdj6t08540000gn/T/fm-usk-demo.avnroD/home/.gemini/skills/alpha
remove /private/var/folders/5m/kfvhd_k5671cqk7cdj6t08540000gn/T/fm-usk-demo.avnroD/home/.pi/agent/skills/alpha
link /private/var/folders/5m/kfvhd_k5671cqk7cdj6t08540000gn/T/fm-usk-demo.avnroD/home/.claude/skills/alpha -> ../../.agents/skills/alpha
link /private/var/folders/5m/kfvhd_k5671cqk7cdj6t08540000gn/T/fm-usk-demo.avnroD/home/.codex/skills/alpha -> ../../.agents/skills/alpha
user skills converged
[exit 0]
--- canonical store + relative links ---
./.agents
./.agents/skills
./.agents/skills/alpha
./.agents/skills/alpha/SKILL.md
./.agents/skills/alpha/sub
./.claude
./.claude/skills
./.claude/skills/alpha
./.codex
./.codex/skills
./.codex/skills/.system
./.codex/skills/.system/vendor
./.codex/skills/alpha
./.gemini
./.gemini/skills
./.pi
./.pi/agent
./.pi/agent/skills
claude link -> ../../.agents/skills/alpha
codex  link -> ../../.agents/skills/alpha
read SKILL.md through the codex relative link: alpha skill
codex .system preserved: vendor-owned

############ 4. Idempotence: re-run apply ############

$ /Users/tim/.no-mistakes/worktrees/832fb889ab00/01M0EG441CN960PFMP8TRFA69S/bin/fm-user-skill-sync.sh --apply
user skills already converged; no changes
[exit 0]

############ 5. Conflict refuses before mutation ############

$ /Users/tim/.no-mistakes/worktrees/832fb889ab00/01M0EG441CN960PFMP8TRFA69S/bin/fm-user-skill-sync.sh --apply
error: conflicting skill trees for 'beta' (tree structure or file contents differ): /private/var/folders/5m/kfvhd_k5671cqk7cdj6t08540000gn/T/fm-usk-demo.avnroD/home/.agents/skills/beta and /private/var/folders/5m/kfvhd_k5671cqk7cdj6t08540000gn/T/fm-usk-demo.avnroD/home/.gemini/skills/beta
[exit 1]
gemini beta still present after refusal: gemini beta
canonical beta untouched: canonical beta DIFFERENT

############ 6. Registered remote route (stubbed ssh, no real host contacted) ############

$ bin/fm-user-skill-sync.sh --remote mac   (dry-run default)
[exit 0]
--- ssh invocation captured ---
-o
bound remote host : remote-mac
bound remote root : /remote/firstmate
bound remote home : /remote/firstmate-home
remote command    : fm-user-skill-sync.sh --dry-run 
mentions other host studio-mac? 0

$ bin/fm-user-skill-sync.sh --remote studio-mac --apply   (ambiguous alias)
error: remote route 'studio-mac' is ambiguous across 2 configured secondmates; use a secondmate id
[exit 1]
transport opened? no - refused before contacting any host

### Sandbox: /var/folders/5m/kfvhd_k5671cqk7cdj6t08540000gn/T//fm-usk-demo.avnroD (captain's real ~/.agents, ~/.claude, ~/.codex untouched)
```
</details>
<details>
<summary>Evidence: Key end-state after --apply in the isolated home</summary>

```text
$ fm-user-skill-sync.sh --apply
APPLY
mkdir <HOME>/.agents/skills
mkdir <HOME>/.claude/skills
copy <HOME>/.gemini/skills/alpha -> <HOME>/.agents/skills/alpha
remove <HOME>/.gemini/skills/alpha
remove <HOME>/.pi/agent/skills/alpha
link <HOME>/.claude/skills/alpha -> ../../.agents/skills/alpha
link <HOME>/.codex/skills/alpha -> ../../.agents/skills/alpha
user skills converged

claude link -> ../../.agents/skills/alpha
codex link -> ../../.agents/skills/alpha
read SKILL.md through the codex relative link: alpha skill
codex .system preserved: vendor-owned

$ fm-user-skill-sync.sh --apply (re-run)
user skills already converged; no changes

$ fm-user-skill-sync.sh --apply (byte-different beta)
error: conflicting skill trees for 'beta' (tree structure or file contents differ): ...
[exit 1] both trees intact

$ fm-user-skill-sync.sh --remote mac
bound remote host : remote-mac
bound remote root : /remote/firstmate
bound remote home : /remote/firstmate-home
remote command : fm-user-skill-sync.sh --dry-run
mentions other host studio-mac? 0

$ fm-user-skill-sync.sh --remote studio-mac --apply
error: remote route 'studio-mac' is ambiguous across 2 configured secondmates; use a secondmate id
transport opened? no - refused before contacting any host
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"2c0bcec0281010ec7f6e02d00e7e1be0262c0a88","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 4 issues found → auto-fixed (2) ✅</summary>

- ⚠️ `docs/configuration.md:306` - The remote route reconciles the remote SSH *account* home, not the registered `home:` field, but the docs and the test describe it as the registered home. `bin/fm-on.sh` forwards the record&#39;s `home:` as `HOME_B64`, and `bin/fm-remote-entrypoint.sh:101-102` explicitly does `unset HOME` and derives `ACCOUNT_HOME=$(cd ~ &amp;&amp; pwd -P)`; the worker then runs the child with `HOME=$account_home` and `FM_HOME=$home` (bin/fm-remote-job-worker.sh:594-595). So `$HOME/.agents/skills` remotely means the SSH login account&#39;s home, while the record&#39;s `home:` (a Firstmate home, required by the entrypoint to be *disjoint* from the code root) is never read by this script. docs/configuration.md:306 says the route &#34;preserves the configured SSH host and remote home rather than selecting another home&#34;, and tests/fm-user-skill-sync.test.sh:567 asserts the forwarded value equals `/remote/firstmate-home` under the message &#34;remote operation changed the registered home&#34; — both imply the registered home is the sync target. Behavior is deterministic and cannot silently pick another host, so the intent constraint is met, but the operator-facing claim and the test&#39;s stated meaning should say the reconciled roots come from the remote account home.
- ⚠️ `bin/fm-user-skill-sync.sh:96` - A remote apply cannot honor a non-default `CODEX_HOME` on the remote Mac, yet still reports convergence. The remote route execs `fm-on.sh &lt;route&gt; fm-user-skill-sync.sh --apply`, and the remote child is launched under `/usr/bin/env -i` with only PATH/HOME/FM_HOME/FM_ROOT_OVERRIDE (bin/fm-remote-job-worker.sh:591-597). `CODEX_HOME` is therefore always unset remotely, so `CODEX_ROOT` falls back to `$HOME/.codex` (line 120). If the remote account sets `CODEX_HOME` in its shell profile, the run creates per-skill links under an unused `~/.codex/skills`, leaves the real Codex skills root unscanned and unreconciled, and prints &#34;user skills converged&#34;. Either document this as an explicit remote limitation alongside the Codex-discovery limitation already recorded in docs/verification/user-skills.md, or add a guarded way to bind the remote Codex root.
- ⚠️ `bin/fm-user-skill-sync.sh:471` - Any non-directory dotfile sitting directly in a managed skill root refuses the entire run, and `.DS_Store` is very likely to be present on the captain&#39;s macOS roots. The glob at line 458 picks up `.DS_Store`; its name passes the charset check at line 462 (only `[A-Za-z0-9._-]`), it is neither a link nor a directory, so line 471 dies with &#34;unexpected entry in managed skill root&#34;. This fails closed and matches the intent&#39;s &#34;refuse on unexpected entries&#34;, so it is safe — but it makes the command unrunnable on a Finder-visited `~/.claude/skills` or `~/.agents/skills` until the operator manually removes the file, and the diagnostic does not say that removing it is the resolution. The same file nested inside one copy of a skill tree also turns an otherwise byte-identical duplicate into a &#34;conflicting skill trees&#34; refusal. Consider either ignoring `.DS_Store` explicitly or extending the diagnostic with the remediation.
- ℹ️ `tests/fm-user-skill-sync.test.sh:573` - `assert_not_contains &#34;$(cat &#34;$argv&#34;)&#34; &#34;different-host&#34;` cannot fail: no code path anywhere emits the literal string `different-host`, so the assertion proves nothing about host binding. The real host-binding proof is the `assert_grep &#39;remote-mac&#39;` on line 563. To actually cover &#34;cannot silently select another host&#34;, register a second remote record with a different host and assert the run either selects `remote-mac` or refuses as ambiguous, rather than asserting the absence of a string that never appears.

🔧 Fix: Prove remote route host/home binding and ambiguity refusal
2 issues (1 warning, 1 info) still open:
- ⚠️ `docs/verification/user-skills.md:40` - The recorded verification output is stale relative to the suite it claims to record. tests/fm-user-skill-sync.test.sh now invokes 24 tests (lines 631-654), but the fenced output block lists only 22 ok lines: it omits test_remote_second_record_binds_its_own_placement (&#34;each registered record binds its own host, root, and home&#34;) and test_remote_ambiguous_alias_refuses_without_transport (&#34;an ambiguous host alias refuses instead of selecting a host&#34;), both added by commit eda1513. Line 40 also records `ok - remote invocation binds the registered host and forwards explicit apply`, a label the suite no longer emits — tests/fm-user-skill-sync.test.sh:590 now passes with &#34;remote invocation binds exactly the selected record&#39;s host, root, and home&#34;. The prose summary at line 8 similarly ends at &#34;registered-remote command construction&#34; and does not cover the host/root/home binding or ambiguity refusal this record is meant to attest. This file is the maintainer-verification evidence record for the change, so an out-of-date transcript misstates what was actually observed. Refresh the output block and the summary sentence to the current 24 pass lines.
- ℹ️ `bin/fm-user-skill-sync.sh:207` - unresolved_suffix lowercases the unresolved path suffix unconditionally, so on a case-sensitive filesystem two managed roots that differ only in case are refused at line 294 with &#34;managed skill roots canonical and codex resolve to the same directory&#34; even though they are genuinely distinct directories there. tests/fm-user-skill-sync.test.sh:216-226 asserts this refusal before the case-insensitivity probe, so the wording is encoded as expected behavior on every platform. This is a deliberate fail-closed choice for the captain&#39;s case-insensitive macOS volume and is only reachable through a hand-set case-variant CODEX_HOME, so the safety property holds; only the diagnostic claims more than was proven on case-sensitive volumes. Noted as a tradeoff, not a defect requiring change.

🔧 Fix: Refresh user-skill verification record to current suite output
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`./bin/fm-test-run.sh tests/fm-user-skill-sync.test.sh` — 24 behavior cases, all ok, exit 0</code>
- <code>Manual operator walkthrough in a throwaway `HOME` (`mktemp -d`): seeded Gemini + Pi duplicate skills and a Codex `skills/.system/vendor` entry, then ran `fm-user-skill-sync.sh --help`, bare (dry-run), `--apply`, and `--apply` again</code>
- <code>Verified post-apply filesystem state: canonical `$HOME/.agents/skills/alpha`, `readlink $HOME/.claude/skills/alpha` and `$HOME/.codex/skills/alpha` both `../../.agents/skills/alpha`, `cat` of `SKILL.md` read through the Codex relative link, `.system/vendor/SKILL.md` intact, Gemini/Pi copies removed</code>
- <code>Conflict path: introduced a byte-different `beta` in `.agents/skills` vs `.gemini/skills`, ran `--apply`, confirmed exit 1 and both trees unmodified</code>
- <code>Remote route with a stubbed `ssh` and a fixture secondmate registry: `--remote mac` (dry-run default) bound host `remote-mac`, root `/remote/firstmate`, home `/remote/firstmate-home` and carried `fm-user-skill-sync.sh --dry-run`, with zero references to the other registered host; `--remote studio-mac --apply` refused as ambiguous and opened no transport</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/configuration.md:294` - docs/configuration.md#user-skill-layout enumerates Claude Code, Codex, Gemini, OpenCode, and Pi, while .agents/skills/harness-adapters/SKILL.md separately records that Cursor also discovers user-level skills. The configuration section makes no exhaustiveness claim, so nothing is factually wrong today, but a reader may infer the list covers every skill-discovering harness. Worth a follow-up decision on whether Cursor is intentionally unmanaged and, if so, saying so in the script header (the contract owner) rather than duplicating harness inventories in configuration.md.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
