### PR TITLE
feat: add advisory model route decision foundation

### DIFF
--- a/bin/fm-route-decision.sh
+++ b/bin/fm-route-decision.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# fm-route-decision.sh - validate or inspect an advisory model route decision.
+#
+# Usage:
+#   fm-route-decision.sh validate [FILE|-]
+#   fm-route-decision.sh profile ROUTE
+#   fm-route-decision.sh schema
+#
+# The validator is deliberately advisory: it never classifies prompts, checks
+# credentials or quota, launches or replaces workers, replans failures, or
+# changes merge authority. The versioned JSON schema is the allowlist owner;
+# this script adds the deterministic cross-field checks that jq can enforce.
+set -u
+
+SELF_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ROOT=$(cd "$SELF_DIR/.." && pwd)
+SCHEMA_FILE="$ROOT/schemas/fm-route-decision.v1.json"
+
+fm_route_decision_usage() {
+  sed -n '2,12{s/^# \{0,1\}//;p;}' "$SELF"
+}
+
+fm_route_decision_die() {
+  printf 'fm-route-decision: %s\n' "$1" >&2
+  exit 1
+}
+
+[ -r "$SCHEMA_FILE" ] || fm_route_decision_die "missing route-decision schema"
+command -v jq >/dev/null 2>&1 || fm_route_decision_die "jq is required"
+
+fm_route_decision_validate() {
+  local input=${1:--} file rc
+  file=$(mktemp "${TMPDIR:-/tmp}/fm-route-decision.XXXXXX") ||
+    fm_route_decision_die "could not create an input buffer"
+  trap 'rm -f "$file"' EXIT HUP INT TERM
+  if [ "$input" = - ]; then
+    cat > "$file" || fm_route_decision_die "could not read JSON from stdin"
+  else
+    [ -f "$input" ] || fm_route_decision_die "input file does not exist: $input"
+    cat -- "$input" > "$file" || fm_route_decision_die "could not read input file: $input"
+  fi
+
+  if ! jq -e -s 'length == 1' "$file" >/dev/null 2>&1; then
+    fm_route_decision_die "malformed JSON"
+  fi
+
+  if ! jq -e -s --slurpfile contract "$SCHEMA_FILE" '
+    .[0] as $d
+    | $contract[0] as $contract
+    | if ($d | type) != "object" then false
+      elif (($d | keys_unsorted | sort) != ([
+        "confidence", "model", "override", "privacy", "provider", "reason",
+        "route", "schema", "source"
+      ] | sort)) then false
+      elif $d.schema != "fm-route-decision.v1" then false
+      elif ($d.route | type) != "string" then false
+      elif (($contract["x-route-profiles"] | has($d.route)) | not) then false
+      elif ($d.provider | type) != "string" then false
+      elif ($d.model | type) != "string" then false
+      elif ($d.confidence | type) != "number" or $d.confidence < 0 or $d.confidence > 1 then false
+      elif ($d.privacy | type) != "string" or
+        ($d.privacy != "local-only" and $d.privacy != "cloud-allowed") then false
+      elif ($d.source | type) != "string" or
+        ($d.source != "advisory" and $d.source != "explicit") then false
+      elif ($d.reason | type) != "string" or ($d.reason | length) == 0 or
+        ($d.reason | length) > 1000 then false
+      else
+        ($contract["x-route-profiles"][$d.route]) as $profile
+        | if $d.provider != $profile.provider or $d.model != $profile.model then false
+          elif (($profile.privacy | index($d.privacy)) == null) then false
+          elif ($d.route | startswith("cloud-")) and $d.privacy != "cloud-allowed" then false
+          elif $d.source == "advisory" and $d.override != null then false
+          elif $d.source == "advisory" and $d.route != "escalate" and $d.confidence < 0.5 then false
+          elif $d.source == "explicit" and ($d.override | type) != "object" then false
+          elif $d.source == "explicit" and (($d.override | keys_unsorted | sort) != ["reason", "route"]) then false
+          elif $d.source == "explicit" and ($d.override.route != $d.route) then false
+          elif $d.source == "explicit" and ($d.override.route | type) != "string" then false
+          elif $d.source == "explicit" and (($contract["x-route-profiles"] | has($d.override.route)) | not) then false
+          elif $d.source == "explicit" and (($d.override.reason | type) != "string" or
+            ($d.override.reason | length) == 0 or ($d.override.reason | length) > 1000) then false
+          else true
+          end
+      end' "$file" >/dev/null 2>&1; then
+    fm_route_decision_die "route decision violates fm-route-decision.v1"
+  fi
+
+  jq -cS . "$file"
+  rc=$?
+  trap - EXIT HUP INT TERM
+  rm -f "$file"
+  return "$rc"
+}
+
+fm_route_decision_profile() {
+  local route=${1:-}
+  [ "$#" -eq 1 ] || fm_route_decision_die "profile requires a route"
+  jq -e -cS --arg route "$route" \
+    '."x-route-profiles"[$route] // empty | . + {route: $route}' \
+    "$SCHEMA_FILE" 2>/dev/null || fm_route_decision_die "unknown route: $route"
+}
+
+case "${1:-}" in
+  validate)
+    [ "$#" -le 2 ] || fm_route_decision_die "validate accepts one file or stdin"
+    fm_route_decision_validate "${2:--}"
+    ;;
+  profile)
+    shift
+    fm_route_decision_profile "$@"
+    ;;
+  schema)
+    [ "$#" -eq 1 ] || fm_route_decision_die "schema accepts no arguments"
+    cat -- "$SCHEMA_FILE"
+    ;;
+  --help|-h)
+    fm_route_decision_usage
+    ;;
+  *)
+    fm_route_decision_usage >&2
+    exit 2
+    ;;
+esac

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -146,7 +146,7 @@ family_for_basename() {
     fm-subagent-pretool-check.test.sh|\
     fm-supervision-instructions.test.sh|fm-task-delivery.test.sh|\
     fm-tmux-submit-busy.test.sh|fm-trace-context-lib.test.sh|\
-    fm-transition-lib.test.sh|\
+    fm-transition-lib.test.sh|fm-route-decision.test.sh|\
     fm-test-run.test.sh|fm-test-isolation-proof.test.sh)
       printf '%s\n' pure-contract-unit
       ;;

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -289,6 +289,10 @@
       "audience": "operator-current"
     },
     {
+      "path": "docs/model-routing.md",
+      "audience": "operator-current"
+    },
+    {
       "path": "docs/sessionstart-nudge.md",
       "audience": "operator-current"
     },

--- a/docs/model-routing.md
+++ b/docs/model-routing.md
@@ -1,0 +1,54 @@
+# Advisory model routing
+
+Phase 1 provides a strict, versioned contract for an advisory model route decision.
+The contract is defined by [`schemas/fm-route-decision.v1.json`](../schemas/fm-route-decision.v1.json), and [`bin/fm-route-decision.sh`](../bin/fm-route-decision.sh) is the deterministic executable validator.
+
+## Opt-in behavior
+
+This feature is advisory and opt-in.
+It does not classify captain prompts, select a route automatically, launch or replace workers, replan after failures, merge changes, or install or download models.
+A caller must explicitly provide a decision to `fm-route-decision.sh validate`.
+
+Firstmate still owns privacy preflight, model catalog and authentication checks, quota checks, effort selection, worker launch, supervision, validation, and merge authority.
+A valid route decision is not evidence that a provider is authenticated, a model is available, quota exists, or a route is safe for a particular prompt.
+
+## Route profiles
+
+The allowlisted logical route profiles are:
+
+- `local-qwen-14b` uses provider class `local` and logical model `qwen-14b`.
+- `cloud-luna` uses provider class `cloud` and logical model `luna`.
+- `cloud-opus-4-8` uses provider class `cloud` and logical model `opus-4-8`.
+- `escalate` uses provider and model value `none` and requests human or higher-level handling instead of a model route.
+
+The local Qwen profile is a contract for a logical route only.
+It does not assert an Ollama provider or model identifier, and the exact local endpoint and model configuration remain operator configuration.
+The cloud profiles likewise do not encode credentials, account identity, catalog support, or quota availability.
+
+Cloud profiles require `privacy: "cloud-allowed"`.
+The local profile accepts either privacy classification because a local route does not require cloud transmission.
+Escalation is valid for either privacy classification and can carry low confidence.
+Non-escalation advisory decisions require confidence from `0.5` through `1`.
+
+## Decision validation
+
+A decision has exactly the fields `schema`, `route`, `provider`, `model`, `confidence`, `privacy`, `source`, `reason`, and `override`.
+Unknown fields, routes, provider classes, and logical model values are rejected.
+The validator also rejects malformed JSON, profile/provider/model mismatches, cloud privacy conflicts, invalid override relationships, and low-confidence non-escalation advice.
+
+Validate JSON from a file or stdin:
+
+```sh
+bin/fm-route-decision.sh validate decision.json
+printf '%s\n' '{"schema":"fm-route-decision.v1",...}' | bin/fm-route-decision.sh validate -
+```
+
+Inspect one allowlisted profile without resolving any provider endpoint:
+
+```sh
+bin/fm-route-decision.sh profile local-qwen-14b
+```
+
+An advisory decision uses `source: "advisory"` and `override: null`.
+An explicit operator decision uses `source: "explicit"` and an `override` object whose route and reason match the effective route.
+The explicit route therefore takes precedence over an advisory recommendation, while the validator still only checks the supplied result and never chooses a route.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -88,6 +88,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-config-inherit-lib.sh` | Shared primary-to-secondmate inherited local-material propagation and config-reread delivery |
 | `fm-tasks-axi-lib.sh`    | Shared backlog-backend selector and `tasks-axi` compatibility probe                  |
 | `fm-quota-axi-lib.sh`    | Shared `quota-axi` compatibility floor for the bootstrap diagnostic                  |
+| `fm-route-decision.sh`   | Validate and inspect the opt-in advisory model route decision contract               |
 | `fm-vendor-auth-probe.sh`| Run one hard-bounded, non-destructive authentication probe of a named vendor CLI and report the fact |
 | `fm-wake-drain.sh`       | Present durable watcher wakes, unread informational status lines, and OPEN DECISIONS, consume acknowledged rows through their sequence, retire only the matching recovery generation, then assert supervision health |
 | `fm-wake-lib.sh`         | Shared durable wake queue, recovery generations, portable locks, and watcher identity/health helpers |

--- a/schemas/fm-route-decision.v1.json
+++ b/schemas/fm-route-decision.v1.json
@@ -1,0 +1,254 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:firstmate:schema:fm-route-decision.v1",
+  "title": "Firstmate advisory model route decision",
+  "description": "A strict, advisory-only route decision. It records a logical route profile and never names credentials or a provider endpoint.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "route",
+    "provider",
+    "model",
+    "confidence",
+    "privacy",
+    "source",
+    "reason",
+    "override"
+  ],
+  "properties": {
+    "schema": {
+      "const": "fm-route-decision.v1"
+    },
+    "route": {
+      "type": "string",
+      "enum": [
+        "local-qwen-14b",
+        "cloud-luna",
+        "cloud-opus-4-8",
+        "escalate"
+      ]
+    },
+    "provider": {
+      "type": "string",
+      "enum": [
+        "local",
+        "cloud",
+        "none"
+      ]
+    },
+    "model": {
+      "type": "string",
+      "enum": [
+        "qwen-14b",
+        "luna",
+        "opus-4-8",
+        "none"
+      ]
+    },
+    "confidence": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "privacy": {
+      "type": "string",
+      "enum": [
+        "local-only",
+        "cloud-allowed"
+      ]
+    },
+    "source": {
+      "type": "string",
+      "enum": [
+        "advisory",
+        "explicit"
+      ]
+    },
+    "reason": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 1000
+    },
+    "override": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "route",
+            "reason"
+          ],
+          "properties": {
+            "route": {
+              "type": "string",
+              "enum": [
+                "local-qwen-14b",
+                "cloud-luna",
+                "cloud-opus-4-8",
+                "escalate"
+              ]
+            },
+            "reason": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 1000
+            }
+          }
+        }
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "route": {
+            "const": "local-qwen-14b"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "provider": {
+            "const": "local"
+          },
+          "model": {
+            "const": "qwen-14b"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "route": {
+            "const": "cloud-luna"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "provider": {
+            "const": "cloud"
+          },
+          "model": {
+            "const": "luna"
+          },
+          "privacy": {
+            "const": "cloud-allowed"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "route": {
+            "const": "cloud-opus-4-8"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "provider": {
+            "const": "cloud"
+          },
+          "model": {
+            "const": "opus-4-8"
+          },
+          "privacy": {
+            "const": "cloud-allowed"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "route": {
+            "const": "escalate"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "provider": {
+            "const": "none"
+          },
+          "model": {
+            "const": "none"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "source": {
+            "const": "advisory"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "override": {
+            "const": null
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "source": {
+            "const": "explicit"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "override": {
+            "type": "object"
+          }
+        }
+      }
+    }
+  ],
+  "x-route-profiles": {
+    "local-qwen-14b": {
+      "provider": "local",
+      "model": "qwen-14b",
+      "privacy": [
+        "local-only",
+        "cloud-allowed"
+      ],
+      "endpoint": "operator-configured"
+    },
+    "cloud-luna": {
+      "provider": "cloud",
+      "model": "luna",
+      "privacy": [
+        "cloud-allowed"
+      ]
+    },
+    "cloud-opus-4-8": {
+      "provider": "cloud",
+      "model": "opus-4-8",
+      "privacy": [
+        "cloud-allowed"
+      ]
+    },
+    "escalate": {
+      "provider": "none",
+      "model": "none",
+      "privacy": [
+        "local-only",
+        "cloud-allowed"
+      ]
+    }
+  }
+}

--- a/tests/fm-route-decision.test.sh
+++ b/tests/fm-route-decision.test.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Behavioral regressions for the strict, advisory-only model route decision contract.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+VALIDATOR="$ROOT/bin/fm-route-decision.sh"
+TMP_ROOT=$(fm_test_tmproot fm-route-decision)
+
+route_json() {
+  jq -cn --arg route "$1" --arg provider "$2" --arg model "$3" \
+    --argjson confidence "$4" --arg privacy "$5" --arg source "$6" \
+    --arg reason "$7" --argjson override "${8:-null}" '{
+      schema: "fm-route-decision.v1",
+      route: $route,
+      provider: $provider,
+      model: $model,
+      confidence: $confidence,
+      privacy: $privacy,
+      source: $source,
+      reason: $reason,
+      override: $override
+    }'
+}
+
+expect_valid() {
+  local label=$1 payload=$2 out
+  out=$(printf '%s\n' "$payload" | "$VALIDATOR" validate - 2>"$TMP_ROOT/error") \
+    || fail "$label was rejected: $(cat "$TMP_ROOT/error")"
+  printf '%s' "$out" | jq -e '.schema == "fm-route-decision.v1"' >/dev/null \
+    || fail "$label did not return the versioned decision"
+}
+
+expect_rejected() {
+  local label=$1 payload=$2
+  if printf '%s\n' "$payload" | "$VALIDATOR" validate - >"$TMP_ROOT/output" 2>"$TMP_ROOT/error"; then
+    fail "$label was accepted"
+  fi
+}
+
+test_valid_decisions() {
+  local local_decision cloud_decision
+  local_decision=$(route_json local-qwen-14b local qwen-14b 0.9 local-only advisory local-safe null)
+  cloud_decision=$(route_json cloud-opus-4-8 cloud opus-4-8 0.8 cloud-allowed advisory cloud-capable null)
+  expect_valid "local advisory decision" "$local_decision"
+  expect_valid "cloud advisory decision" "$cloud_decision"
+  pass "valid local and cloud advisory decisions are accepted"
+}
+
+test_strict_json_and_allowlists() {
+  local valid extra unknown_route unknown_provider unknown_model
+  valid=$(route_json cloud-luna cloud luna 0.8 cloud-allowed advisory cloud-safe null)
+  extra=$(printf '%s' "$valid" | jq '.unexpected = true')
+  unknown_route=$(printf '%s' "$valid" | jq '.route = "cloud-unknown"')
+  unknown_provider=$(printf '%s' "$valid" | jq '.provider = "unverified-provider"')
+  unknown_model=$(printf '%s' "$valid" | jq '.model = "unverified-model"')
+  expect_rejected "malformed JSON" '{"schema":'
+  expect_rejected "extra field" "$extra"
+  expect_rejected "unknown route" "$unknown_route"
+  expect_rejected "unknown provider" "$unknown_provider"
+  expect_rejected "unknown model" "$unknown_model"
+  pass "malformed JSON, extra fields, and unknown route values are rejected"
+}
+
+test_privacy_and_cross_field_invariants() {
+  local cloud_local local_cloud bad_local bad_cloud low
+  cloud_local=$(route_json cloud-luna cloud luna 0.8 local-only advisory privacy-conflict null)
+  local_cloud=$(route_json local-qwen-14b local qwen-14b 0.8 cloud-allowed advisory local-route-cloud-safe null)
+  bad_local=$(route_json local-qwen-14b cloud qwen-14b 0.8 local-only advisory wrong-provider null)
+  bad_cloud=$(route_json cloud-luna cloud qwen-14b 0.8 cloud-allowed advisory wrong-model null)
+  low=$(route_json cloud-luna cloud luna 0.49 cloud-allowed advisory too-uncertain null)
+  expect_rejected "cloud route with local-only privacy" "$cloud_local"
+  expect_valid "local route with cloud-allowed privacy" "$local_cloud"
+  expect_rejected "local route with cloud provider" "$bad_local"
+  expect_rejected "cloud route with local model" "$bad_cloud"
+  expect_rejected "low-confidence non-escalation" "$low"
+  pass "privacy, profile, and confidence invariants are deterministic"
+}
+
+test_escalation_and_explicit_override() {
+  local escalation explicit mismatch
+  escalation=$(route_json escalate none none 0.1 local-only advisory uncertain-escalation null)
+  explicit=$(route_json local-qwen-14b local qwen-14b 0.2 local-only explicit operator-override \
+    '{"route":"local-qwen-14b","reason":"operator requires local processing"}')
+  mismatch=$(route_json cloud-luna cloud luna 0.9 cloud-allowed explicit stale-effective-route \
+    '{"route":"local-qwen-14b","reason":"operator requires local processing"}')
+  expect_valid "escalation decision" "$escalation"
+  expect_valid "explicit local override" "$explicit"
+  expect_rejected "override that does not match the effective route" "$mismatch"
+  pass "escalation permits uncertainty and an explicit override controls the effective route"
+}
+
+test_profile_contract() {
+  local profile
+  profile=$("$VALIDATOR" profile local-qwen-14b)
+  printf '%s' "$profile" | jq -e '
+    .route == "local-qwen-14b" and
+    .provider == "local" and
+    .model == "qwen-14b" and
+    .endpoint == "operator-configured"
+  ' >/dev/null || fail "local Qwen profile lost its operator-configured endpoint contract"
+  if "$VALIDATOR" profile unknown-route >/dev/null 2>"$TMP_ROOT/error"; then
+    fail "unknown profile route was accepted"
+  fi
+  pass "allowlisted profiles preserve logical IDs without provider endpoint assumptions"
+}
+
+test_valid_decisions
+test_strict_json_and_allowlists
+test_privacy_and_cross_field_invariants
+test_escalation_and_explicit_override
+test_profile_contract


### PR DESCRIPTION
## Summary

- Add the versioned `fm-route-decision.v1` strict schema and deterministic validator for advisory model routing.
- Allowlist the local Qwen, Luna, Opus, and escalation route profiles without provider credentials, endpoint IDs, or quota claims.
- Add executable coverage for valid and malformed decisions, strict fields, allowlists, privacy and profile invariants, confidence, escalation, and explicit override precedence.
- Document the opt-in boundary and the Firstmate-owned privacy, catalog, authentication, quota, effort, launch, supervision, validation, and merge responsibilities.

This phase is advisory only.
It does not classify prompts, choose routes automatically, launch or replace workers, replan failures, merge changes, or install or download models.

## Validation

- `bin/fm-test-run.sh tests/fm-route-decision.test.sh` - passed, 5 checks.
- `bin/fm-test-run.sh --check-coverage` - passed, `FM_TEST_COVERAGE ok total=150 parallel=24 serial=114 serial_shards=4 herdr=12`.
- `bin/fm-doc-audience-check.sh` - passed, `fm-doc-audience-check: ok surfaces=70 local_links=255`.
- `bin/fm-lint.sh` - passed with ShellCheck 0.11.0 and actionlint 1.7.12; all 3 workflow files valid.
- `git diff --cached --check` - passed.

No merge has been performed.
