### PR TITLE
fix(backends): accept Orca's composite worktree id in endpoint validation

### DIFF
--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -383,6 +383,29 @@ fm_backend_endpoint_atom_valid() {  # <value>
   esac
 }
 
+# Orca records its worktree endpoint either as a bare id or as the composite
+# <repo-id>::<absolute-path> that `orca worktree` accepts, whose path component
+# the generic atom charset cannot express.
+fm_backend_orca_worktree_id_valid() {  # <value>
+  local repo_id path
+  case "$1" in
+    *::*::*) return 1 ;;
+    *::*)
+      repo_id=${1%%::*}
+      path=${1#*::}
+      fm_backend_endpoint_atom_valid "$repo_id" || return 1
+      case "$path" in
+        /*) ;;
+        *) return 1 ;;
+      esac
+      case "$path" in
+        *[[:cntrl:]]*) return 1 ;;
+      esac
+      ;;
+    *) fm_backend_endpoint_atom_valid "$1" || return 1 ;;
+  esac
+}
+
 fm_backend_validate_task_endpoint() {  # <meta-file> <task-id>
   local meta=$1 id=$2 backend_count backend window worktree project binding_count binding
   local session pane recorded_session workspace tab terminal worktree_id surface
@@ -503,7 +526,7 @@ fm_backend_validate_task_endpoint() {  # <meta-file> <task-id>
       }
       if [ "$window" != "fm-$id" ] \
         || ! fm_backend_endpoint_atom_valid "$terminal" \
-        || ! fm_backend_endpoint_atom_valid "$worktree_id"; then
+        || ! fm_backend_orca_worktree_id_valid "$worktree_id"; then
         echo "REFUSED: Orca endpoint metadata for task $id is malformed or inconsistent; preserving task state." >&2
         return 1
       fi

--- a/docs/orca-backend.md
+++ b/docs/orca-backend.md
@@ -36,12 +36,13 @@ The normal isolation and unlanded-work refusal rules still apply.
 backend=orca
 window=fm-<id>
 terminal=<orca terminal handle>
-orca_worktree_id=<orca worktree id>
+orca_worktree_id=<orca repo id>::<absolute Orca worktree path>
 worktree=<absolute Orca worktree path>
 ```
 
 `window=` remains the caller-facing Firstmate alias.
 `terminal=` and `orca_worktree_id=` are the backend authority used by operation and cleanup paths.
+Orca's own worktree id is the composite `<repo id>::<absolute path>` it returns and accepts back as `id:<value>`, so Firstmate records and replays it verbatim.
 
 ## Current lifecycle and safety
 

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -825,6 +825,40 @@ test_scout_teardown_removes_orca_worktree_via_helper() {
   pass "fm-teardown.sh backend=orca: scout report gate then helper-backed worktree removal"
 }
 
+test_scout_teardown_removes_orca_composite_worktree_id() {
+  local proj wt data state config id out rc neutral wtid
+  id="orcacompositez7"
+  proj="$TMP_ROOT/composite-project"
+  wt="$TMP_ROOT/composite-wt"
+  data="$TMP_ROOT/composite-data"
+  state="$TMP_ROOT/composite-state"
+  config="$TMP_ROOT/composite-config"
+  fm_git_worktree "$proj" "$wt" "fm/$id"
+  mkdir -p "$data/$id" "$state" "$config"
+  printf 'report\n' > "$data/$id/report.md"
+  touch "$state/.last-watcher-beat"
+  wtid="1fa7dc1c-907a-405d-b332-0eb09b4e7cf6::$wt"
+  fm_write_meta "$state/$id.meta" \
+    "window=fm-$id" "endpoint_task_id=$id" "terminal=term_composite" "worktree=$wt" "project=$proj" \
+    "harness=claude" "kind=scout" "mode=no-mistakes" "yolo=off" \
+    "backend=orca" "orca_worktree_id=$wtid" \
+    "decisions_reviewed=1" "decision_keys="
+  orca_case composite
+  printf '{"ok":true,"result":{"worktree":{"id":"%s","path":"%s"}}}\n' "$wtid" "$wt" > "$RESP/1.out"
+  neutral=$(neutral_fm_root "$CASE_DIR/neutral")
+  set +e
+  out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
+    FM_ROOT_OVERRIDE="$neutral" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
+    "$ROOT/bin/fm-teardown.sh" "$id" 2>&1 )
+  rc=$?
+  set -e
+  expect_code 0 "$rc" "Orca teardown should accept a composite repo-id::path worktree id"$'\n'"$out"
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f'"id:$wtid"$'\x1f''--force'$'\x1f''--json' \
+    "teardown did not remove the composite Orca worktree id verbatim"
+  assert_absent "$state/$id.meta" "teardown should remove task metadata"
+  pass "fm-teardown.sh backend=orca: a composite repo-id::path worktree id no longer blocks cleanup"
+}
+
 test_scout_teardown_refuses_orca_id_path_mismatch() {
   local proj wt other_wt data state config id out rc neutral
   id="orcascoutmismatchz5"
@@ -1335,6 +1369,7 @@ test_peek_send_and_crew_state_route_through_orca_meta
 test_peek_and_crew_state_fail_closed_on_orca_error_json
 test_target_exists_rejects_orca_error_json
 test_scout_teardown_removes_orca_worktree_via_helper
+test_scout_teardown_removes_orca_composite_worktree_id
 test_scout_teardown_refuses_orca_id_path_mismatch
 test_teardown_removes_orca_worktree_when_path_missing
 test_teardown_preserves_metadata_when_orca_remove_error_json

--- a/tests/fm-teardown-endpoint-safety.test.sh
+++ b/tests/fm-teardown-endpoint-safety.test.sh
@@ -365,10 +365,59 @@ SH
   pass "fm-teardown: exact tmux cleanup preserves invalid and prefix-matched neighbors while removing only the recorded target"
 }
 
+test_orca_composite_worktree_id_validates() {
+  local dir id rc out
+  dir=$(make_case orca-composite)
+  # shellcheck source=/dev/null
+  . "$ROOT/bin/fm-backend.sh"
+
+  id=orca-composite-task
+  fm_write_meta "$dir/home/state/$id.meta" \
+    "window=fm-$id" "endpoint_task_id=$id" "terminal=term_b3fa7d74-8085-472c-9dac-d65b6e5e5dce" \
+    "worktree=$dir/worktree" "project=$dir/project" "backend=orca" \
+    "orca_worktree_id=1fa7dc1c-907a-405d-b332-0eb09b4e7cf6::$dir/worktree"
+  fm_backend_validate_task_endpoint "$dir/home/state/$id.meta" "$id" \
+    || fail "Orca endpoint with a composite worktree id refused"
+  [ "$FM_BACKEND_VALIDATED_BACKEND" = orca ] \
+    || fail "composite Orca record validated as the wrong backend"
+  [ "$FM_BACKEND_VALIDATED_TARGET" = term_b3fa7d74-8085-472c-9dac-d65b6e5e5dce ] \
+    || fail "composite Orca validation did not select its terminal"
+
+  for value in \
+    "repo::relative/path" \
+    "repo::a::/abs/path" \
+    "::/abs/path" \
+    "repo::" \
+    "repo/id::/abs/path" \
+    "repo/id" \
+    "repo:id" \
+    "$(printf 'repo::/abs/pa\tth')" \
+    "$(printf 'repo::/abs/pa\rth')" \
+    "$(printf 'repo::/abs/pa\ath')"; do
+    id=orca-bad
+    fm_write_meta "$dir/home/state/$id.meta" \
+      "window=fm-$id" "endpoint_task_id=$id" "terminal=term-7" \
+      "worktree=$dir/worktree" "project=$dir/project" "backend=orca" \
+      "orca_worktree_id=$value"
+    set +e
+    out=$(fm_backend_validate_task_endpoint "$dir/home/state/$id.meta" "$id" 2>&1)
+    rc=$?
+    set -e
+    [ "$rc" -ne 0 ] \
+      || fail "malformed Orca worktree id accepted: $(printf '%q' "$value")"
+    case "$out" in
+      *"preserving task state"*) ;;
+      *) fail "malformed Orca worktree id refusal did not preserve task state: $(printf '%q' "$value")" ;;
+    esac
+  done
+  pass "cleanup identity: composite Orca worktree ids validate while malformed ones refuse"
+}
+
 test_invalid_endpoint_records_refuse_before_mutation
 test_control_lock_contention_refuses_before_mutation
 test_metadata_lock_serializes_destructive_cleanup
 test_supported_backend_endpoint_records_validate
+test_orca_composite_worktree_id_validates
 test_tmux_empty_target_refuses_without_invocation
 test_recorded_process_identity_cleanup_is_exact
 test_isolated_tmux_invalid_and_valid_cleanup


### PR DESCRIPTION
**TL;DR:** Cleaning up or controlling a task that ran through Orca no longer gets refused, so finished tasks stop piling up as stale working copies.

## The problem

Before Firstmate cleans up a task or interrupts it, it checks the task's saved record to be sure it is acting on the right thing. That check only allowed a narrow set of characters in the saved worktree id.

Orca's worktree id does not fit in that set. Orca identifies a worktree as its repo id, two colons, then the full path, like `1fa7dc1c-...::/Users/glen/orca/workspaces/platform/fm-my-task`. So the check rejected the record and refused, every time, for every task run through Orca.

The visible result: cleanup refused to run, and finished Orca tasks left their working copies behind. Interrupting, exiting, or relaunching an Orca task was blocked the same way.

## The solution

The identity check now understands Orca's two-part id: a repo id, then `::`, then an absolute path.

- Records that use Orca's real id format pass, so cleanup and control work on them.
- Bad values are still rejected: a missing half, a second `::`, a relative path, or control characters.
- Plain single-part ids still pass, so older records keep working.
- No other runtime's checks changed.

## Before / after

```mermaid
flowchart LR
  subgraph BEFORE["BEFORE: every Orca task refused"]
    direction TB
    B1["Task record<br/>repoid::/abs/path"] --> B2{"Identity check<br/>letters, digits, . _ @ % + - only"}
    B2 -->|colon and slash rejected| B3["Refused<br/>cleanup and control blocked"]
  end
  subgraph AFTER["AFTER: real ids pass, bad ones still refuse"]
    direction TB
    A1["Task record<br/>repoid::/abs/path"] --> A2{"Identity check<br/>knows Orca's two-part id"}
    A2 -->|valid| A3["Proceeds<br/>cleanup and control work"]
    A2 -->|malformed| A4["Refused<br/>empty half, double colons,<br/>relative path, control chars"]
  end
  BEFORE ~~~ AFTER
  classDef bad  fill:#fde2e2,stroke:#c0392b,stroke-width:2px,color:#5a1212;
  classDef good fill:#e2f0d9,stroke:#1e7a3c,stroke-width:2px,color:#14401f;
  class B3,A4 bad;
  class A3 good;
```

## What this unblocks, and what it does not

This clears the way to clean up stale Orca task records and their working copies across the fleet.

It does not clear all of them. Some older Orca records are separately missing the fields that name their terminal, and those still refuse for that different reason. Repairing those records is a separate job and is deliberately not in this change.

## How this was validated

Reproduced against a live Orca task record: the identity check refused it on the current main branch, and accepts it with this change, returning the right runtime and terminal.

Checked the id format against the real Orca CLI rather than assuming it. `orca worktree show --worktree "id:<repo-id>::<path>" --json` resolves and returns that same two-part string as the worktree's own id, which confirms Firstmate should store and replay it as-is, and that the removal call will accept it.

New tests cover the behaviour through the executable interface: the two-part id validates and selects the right terminal, ten malformed shapes each refuse while preserving the task record, and an end-to-end cleanup run asserts the two-part id reaches `orca worktree rm` unchanged and the record is removed.

<details>
<summary>Technical detail (for reviewers)</summary>

`bin/fm-backend.sh` gains `fm_backend_orca_worktree_id_valid`, called from the single existing `orca)` branch of `fm_backend_validate_task_endpoint`. The existing owner is patched rather than adding a second validation path.

It accepts either a bare atom (delegating to `fm_backend_endpoint_atom_valid`, so legacy records and existing fixtures are unaffected) or exactly one `::` separating a valid atom repo id from an absolute path with no `[[:cntrl:]]` characters. A second `::` is rejected so the parse stays unambiguous.

A reference patch supplied with this work required `::` and rejected bare ids. That was changed deliberately: requiring it would have broken existing test fixtures and any record holding a bare Orca worktree id.

Callers of `fm_backend_validate_task_endpoint` are `bin/fm-teardown.sh`, `bin/fm-control.sh`, `bin/fm-spawn.sh --relaunch`, and `bin/fm-remote-secondmate-control.sh`. `fm-send.sh`, `fm-peek.sh`, and `fm-crew-state.sh` do not call it and were never blocked by this defect.

Considered and rejected: cross-checking the id's path component against the record's `worktree=` field. It matches in all 21 live Orca records, but the two can legitimately diverge through symlink resolution on macOS (`/tmp` vs `/private/tmp`), and a false refusal would re-break cleanup. Out of scope for a charset fix.

A literal newline or carriage return cannot survive the record's line format, so the negative tests cover the control characters that can appear on one line (tab, CR, BEL) alongside relative paths, empty atoms, double `::`, and bare values containing `/` or `:`.

Tests live in `tests/fm-teardown-endpoint-safety.test.sh` (validation and refusals) and `tests/fm-backend-orca.test.sh` (end-to-end cleanup). `docs/orca-backend.md` is corrected in the same change: its `orca_worktree_id=<orca worktree id>` placeholder hid the two-part shape and is what led to the original assumption.

</details>
