### PR TITLE
feat(pi): add opt-in permission modes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,19 @@ jobs:
       - name: Prove complete regression partition
         run: bin/fm-test-run.sh --check-coverage
 
+  tests-pi-permission-modes:
+    name: Behavior tests (Pi permission modes)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install pinned Pi runtime
+        run: npm install --prefix "$RUNNER_TEMP/fm-pi" @earendil-works/pi-coding-agent@0.84.2
+      - name: Run mandatory permission-mode behavior tests
+        env:
+          FM_PI_PACKAGE_DIR: ${{ runner.temp }}/fm-pi/node_modules/@earendil-works/pi-coding-agent
+        run: tests/fm-permission-modes.test.sh
+
   # Two duration-balanced portable parallel shards of the Phase 2 proven-isolated
   # set only. Composition owner: bin/fm-test-run.sh (docs/fm-test-portable-shards.md).
   tests-portable-parallel-1:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Install pinned Pi runtime
         run: npm install --prefix "$RUNNER_TEMP/fm-pi" @earendil-works/pi-coding-agent@0.84.2
       - name: Run mandatory permission-mode behavior tests

--- a/.pi/extensions/fm-permission-modes.ts
+++ b/.pi/extensions/fm-permission-modes.ts
@@ -128,6 +128,7 @@ export default function (pi: ExtensionAPI): void {
   // entry and stays at the default (off). This is session-persisted state via
   // Pi's appendEntry API, not a global config file.
   pi.on("session_start", async (_event, ctx: ExtensionContext) => {
+    mode = DEFAULT_PERMISSION_MODE;
     try {
       const entries = ctx.sessionManager.getEntries();
       let restored: PermissionMode | undefined;
@@ -143,9 +144,7 @@ export default function (pi: ExtensionAPI): void {
           }
         }
       }
-      if (restored !== undefined) {
-        mode = restored;
-      }
+      mode = restored ?? DEFAULT_PERMISSION_MODE;
     } catch {
       // sessionManager may be unavailable in synthetic contexts; stay at off.
     }

--- a/.pi/extensions/fm-permission-modes.ts
+++ b/.pi/extensions/fm-permission-modes.ts
@@ -1,0 +1,154 @@
+// Firstmate's opt-in Claude Code-inspired permission-mode toggle for the Pi
+// primary. docs/permission-modes.md owns the operator-facing contract.
+//
+// Three modes, all session-scoped and off by default so Firstmate behavior is
+// preserved exactly until the captain explicitly enables one:
+//   off      - no-op gate; the existing PreToolUse seatbelts and turn-end guard
+//              run unchanged (this handler returns a no-block result).
+//   plan     - block the built-in edit and write tools and any bash command
+//              that is not genuinely read-only, while allowing read-only
+//              inspection (read, ls, grep, find, and read-only bash).
+//   confirm  - require an interactive approval before the built-in mutating
+//              file and shell tools (edit, write, and non-read-only bash); if
+//              no UI is available, refuse rather than silently permit.
+//
+// Mode state is session-persisted through Pi's supported extension state API
+// (pi.appendEntry), restored on session_start, and never written to a global
+// config file. The active mode is shown unobtrusively in the Pi footer.
+//
+// This is an advisory harness control, not an OS sandbox: Pi extensions execute
+// with the user's full privileges, and the bash read-only classifier is a
+// best-effort heuristic. The pure classification and decision logic lives in
+// ./lib/fm-permission-policy.ts and is tested by tests/fm-permission-modes.test.sh.
+//
+// Composition with the existing turn-end guard: Pi's tool_call dispatch
+// (runner.emitToolCall) runs handlers in load order and short-circuits on the
+// first {block: true}, so a no-block result from this handler lets the existing
+// PreToolUse seatbelts run afterward. Permission modes therefore never weaken
+// the existing seatbelts: a call this gate allows still passes through them, and
+// a call this gate blocks is blocked regardless. See docs/permission-modes.md.
+import type { ExtensionAPI, ExtensionContext, ToolCallEvent } from "@earendil-works/pi-coding-agent";
+import {
+  DEFAULT_PERMISSION_MODE,
+  PERMISSION_ENTRY_TYPE,
+  PERMISSION_MODES,
+  type PermissionMode,
+  decideToolCall,
+  modeStatusLabel,
+  parsePermissionModeArg,
+} from "./lib/fm-permission-policy.ts";
+
+const STATUS_KEY = "fm-permissions";
+
+type MaybeCustomPermissionEntry = {
+  type?: string;
+  customType?: string;
+  data?: { mode?: string };
+};
+
+type MaybeUiTheme = {
+  fg?: (color: string, text: string) => string;
+} | undefined;
+
+function styleWithTheme(ctx: ExtensionContext, text: string, color: string): string {
+  try {
+    const theme = ctx.ui.theme as MaybeUiTheme;
+    return theme?.fg ? theme.fg(color, text) : text;
+  } catch {
+    return text;
+  }
+}
+
+export default function (pi: ExtensionAPI): void {
+  let mode: PermissionMode = DEFAULT_PERMISSION_MODE;
+
+  function persist(): void {
+    try {
+      pi.appendEntry(PERMISSION_ENTRY_TYPE, { mode });
+    } catch {
+      // appendEntry may be unavailable in synthetic contexts; persistence is best-effort.
+    }
+  }
+
+  function updateStatus(ctx: ExtensionContext): void {
+    const label = modeStatusLabel(mode);
+    if (label === undefined) {
+      ctx.ui.setStatus(STATUS_KEY, undefined);
+      return;
+    }
+    const color = mode === "plan" ? "warning" : "accent";
+    ctx.ui.setStatus(STATUS_KEY, styleWithTheme(ctx, label, color));
+  }
+
+  function setMode(next: PermissionMode, ctx: ExtensionContext): void {
+    mode = next;
+    persist();
+    updateStatus(ctx);
+  }
+
+  pi.registerCommand("fm-permissions", {
+    description: "Set the advisory permission mode: off | plan | confirm (off by default).",
+    handler: async (args, ctx) => {
+      const trimmed = args.trim();
+      if (trimmed === "") {
+        ctx.ui.notify(`permission mode: ${mode}`, "info");
+        return;
+      }
+      const parsed = parsePermissionModeArg(trimmed);
+      if (!parsed.ok) {
+        ctx.ui.notify(parsed.error, "error");
+        return;
+      }
+      setMode(parsed.mode, ctx);
+      ctx.ui.notify(`permission mode: ${mode}`, "info");
+    },
+  });
+
+  pi.on("tool_call", async (event: ToolCallEvent, ctx: ExtensionContext) => {
+    if (mode === "off") return {};
+    const toolName = event.toolName;
+    const command =
+      toolName === "bash"
+        ? String((event.input as { command?: unknown }).command ?? "")
+        : undefined;
+    const decision = decideToolCall(mode, toolName, command, ctx.hasUI);
+    if (decision.action === "allow") return {};
+    if (decision.action === "block") {
+      return { block: true, reason: decision.reason };
+    }
+    // decision.action === "confirm": an interactive prompt is required; the
+    // pure policy already guaranteed ctx.hasUI is true on this branch, so a
+    // missing UI would have been a block instead of a silent permit.
+    const approved = await ctx.ui.confirm("fm-permissions", decision.prompt);
+    return approved ? {} : { block: true, reason: decision.denialReason };
+  });
+
+  // Restore the persisted mode on session start/resume/reload so the choice
+  // survives across Pi session replacements. A fresh session has no persisted
+  // entry and stays at the default (off). This is session-persisted state via
+  // Pi's appendEntry API, not a global config file.
+  pi.on("session_start", async (_event, ctx: ExtensionContext) => {
+    try {
+      const entries = ctx.sessionManager.getEntries();
+      let restored: PermissionMode | undefined;
+      for (const entry of entries) {
+        const custom = entry as MaybeCustomPermissionEntry;
+        if (
+          custom.type === "custom" &&
+          custom.customType === PERMISSION_ENTRY_TYPE &&
+          custom.data?.mode
+        ) {
+          if ((PERMISSION_MODES as readonly string[]).includes(custom.data.mode)) {
+            restored = custom.data.mode as PermissionMode;
+          }
+        }
+      }
+      if (restored !== undefined) {
+        mode = restored;
+      }
+    } catch {
+      // sessionManager may be unavailable in synthetic contexts; stay at off.
+    }
+    updateStatus(ctx);
+  });
+}

--- a/.pi/extensions/lib/fm-permission-policy.ts
+++ b/.pi/extensions/lib/fm-permission-policy.ts
@@ -122,7 +122,15 @@ export const DESTRUCTIVE_SHELL_PATTERNS: readonly RegExp[] = [
   /\bmount\b/i,
   /\bumount\b/i,
   /\b(vim?|nano|emacs|code|subl|micro|ed)\b/i,
+  /\bfind\b[\s\S]*\s-(delete|exec|execdir|ok|okdir|fprint|fprint0|fprintf|fls)\b/i,
+  /\bsed\b[\s\S]*\s(--in-place(?:=\S*)?|-i(?:\S*)?)\b/i,
+  /\bsort\b[\s\S]*\s(--output(?:=\S*)?|-o)\b/i,
+  /\bgit\s+(log|diff|show|blame|shortlog)[\s\S]*\s--output(?:=|\s)/i,
+  /\b(npm|pnpm)\s+audit[\s\S]*\s--fix\b/i,
+  /\bdate\b[\s\S]*\s(--set(?:=\S*)?|-s)\b/i,
 ];
+
+const UNSAFE_SHELL_SYNTAX = /[\n\r;&|`<>]|\$\(|\$\{|\\\n/;
 
 /**
  * Patterns that mark a bash command as genuinely read-only. Anchored at the
@@ -131,77 +139,16 @@ export const DESTRUCTIVE_SHELL_PATTERNS: readonly RegExp[] = [
  * of these AND no destructive pattern matches.
  */
 export const READ_ONLY_SHELL_PATTERNS: readonly RegExp[] = [
-  /^\s*cat\b/,
-  /^\s*head\b/,
-  /^\s*tail\b/,
-  /^\s*less\b/,
-  /^\s*more\b/,
-  /^\s*grep\b/,
-  /^\s*egrep\b/,
-  /^\s*fgrep\b/,
-  /^\s*rg\b/,
-  /^\s*find\b/,
-  /^\s*fd\b/,
-  /^\s*ls\b/,
-  /^\s*pwd\b/,
-  /^\s*echo\b/,
-  /^\s*printf\b/,
-  /^\s*wc\b/,
-  /^\s*sort\b/,
-  /^\s*uniq\b/,
-  /^\s*diff\b/,
-  /^\s*comm\b/,
-  /^\s*cmp\b/,
-  /^\s*file\b/,
-  /^\s*stat\b/,
-  /^\s*du\b/,
-  /^\s*df\b/,
-  /^\s*tree\b/,
-  /^\s*which\b/,
-  /^\s*whereis\b/,
-  /^\s*type\b/,
-  /^\s*command\s+-v\b/,
-  /^\s*env\b/,
-  /^\s*printenv\b/,
-  /^\s*uname\b/,
-  /^\s*whoami\b/,
-  /^\s*id\b/,
-  /^\s*date\b/,
-  /^\s*cal\b/,
-  /^\s*uptime\b/,
-  /^\s*hostname\b/,
-  /^\s*ps\b/,
-  /^\s*top\b/,
-  /^\s*htop\b/,
-  /^\s*free\b/,
-  /^\s*vmstat\b/,
-  /^\s*iostat\b/,
-  /^\s*git\s+(status|log|diff|show|blame|branch|remote|describe|rev-parse|shortlog|ls-files|ls-remote|config\s+--get|symbolic-ref)\b/i,
-  /^\s*git\s+rev-parse\b/i,
-  /^\s*npm\s+(list|ls|view|info|search|outdated|audit|ping)/i,
-  /^\s*yarn\s+(list|info|why|audit)/i,
-  /^\s*pnpm\s+(list|why|audit)/i,
-  /^\s*node\s+--version/i,
-  /^\s*node\s+-v\b/i,
-  /^\s*python3?\s+--version/i,
-  /^\s*python3?\s+-V\b/i,
-  /^\s*rustc\s+--version/i,
-  /^\s*cargo\s+--version/i,
-  /^\s*go\s+version\b/i,
-  /^\s*git\s+--version/i,
-  /^\s*jq\b/,
-  /^\s*sed\s+-n\b/,
-  /^\s*awk\b/,
-  /^\s*bash\s+--version/i,
-  /^\s*zsh\s+--version/i,
-  /^\s*realpath\b/,
-  /^\s*readlink\b/,
-  /^\s*basename\b/,
-  /^\s*dirname\b/,
-  /^\s*seq\b/,
-  /^\s*yes\s+--help/i,
-  /^\s*man\b/,
-  /^\s*help\b/,
+  /^\s*(cat|head|tail|grep|egrep|fgrep|rg|find|fd|ls|pwd|echo|printf|wc|sort|uniq|diff|comm|cmp|file|stat|du|df|tree|which|whereis|type|printenv|uname|whoami|id|date|cal|uptime|ps|free|vmstat|iostat|jq|realpath|readlink|basename|dirname|seq)(?:\s+[\s\S]*)?\s*$/,
+  /^\s*command\s+-v(?:\s+[\s\S]*)?\s*$/,
+  /^\s*git\s+(status|log|diff|show|blame|describe|rev-parse|shortlog|ls-files|ls-remote)(?:\s+[\s\S]*)?\s*$/i,
+  /^\s*git\s+branch(?:\s+(?:--list|--show-current|-a|-r|-v|-vv|--contains(?:=\S+)?|--no-contains(?:=\S+)?|--merged(?:=\S+)?|--no-merged(?:=\S+)?|--sort=\S+|--format=\S+|--color(?:=\S+)?|--no-color))*\s*$/i,
+  /^\s*git\s+remote(?:\s+(?:-v|show(?:\s+\S+)?|get-url(?:\s+--all)?\s+\S+))?\s*$/i,
+  /^\s*git\s+config\s+--get(?:-all|-regexp)?\s+\S+(?:\s+\S+)?\s*$/i,
+  /^\s*git\s+symbolic-ref(?:\s+(?:--quiet|-q|--short))*\s+\S+\s*$/i,
+  /^\s*(npm\s+(list|ls|view|info|search|outdated|audit|ping)|yarn\s+(list|info|why|audit)|pnpm\s+(list|why|audit))(?:\s+[\s\S]*)?\s*$/i,
+  /^\s*(node\s+(--version|-v)|python3?\s+(--version|-V)|rustc\s+--version|cargo\s+--version|go\s+version|git\s+--version|bash\s+--version|zsh\s+--version|yes\s+--help)\s*$/i,
+  /^\s*sed\s+-n(?:\s+[\s\S]*)?\s*$/,
 ];
 
 /**
@@ -215,6 +162,7 @@ export function isReadOnlyShellCommand(command: string | undefined): boolean {
   if (typeof command !== "string" || command.trim() === "") {
     return false;
   }
+  if (UNSAFE_SHELL_SYNTAX.test(command)) return false;
   const isDestructive = DESTRUCTIVE_SHELL_PATTERNS.some((p) => p.test(command));
   if (isDestructive) return false;
   return READ_ONLY_SHELL_PATTERNS.some((p) => p.test(command));

--- a/.pi/extensions/lib/fm-permission-policy.ts
+++ b/.pi/extensions/lib/fm-permission-policy.ts
@@ -1,0 +1,304 @@
+// Pure, side-effect-free permission-mode policy for the Firstmate Pi primary.
+//
+// Owned by .pi/extensions/fm-permission-modes.ts, which wires these decisions
+// to Pi events. Tested directly by tests/fm-permission-modes.test.sh so the
+// classification and mode logic stays decoupled from the Pi runtime.
+//
+// This is an advisory harness control, not an OS sandbox: Pi extensions execute
+// with the user's full privileges, and shell classification is a best-effort
+// heuristic because shell is Turing-complete. docs/permission-modes.md owns the
+// operator-facing contract and the advisory-only boundary.
+
+/**
+ * The three permission modes. `off` is the default and preserves Firstmate
+ * behavior exactly: the tool_call handler returns a no-op and nothing is
+ * blocked, confirmed, or displayed.
+ */
+export const PERMISSION_MODES = ["off", "plan", "confirm"] as const;
+export type PermissionMode = (typeof PERMISSION_MODES)[number];
+export const DEFAULT_PERMISSION_MODE: PermissionMode = "off";
+
+/** The custom session entry type used to persist the active mode. */
+export const PERMISSION_ENTRY_TYPE = "fm-permission-modes";
+
+/** A parsed /fm-permissions argument: either a valid mode or an error. */
+export type ParsedMode =
+  | { ok: true; mode: PermissionMode }
+  | { ok: false; error: string };
+
+const MODE_USAGE = "usage: /fm-permissions off|plan|confirm";
+
+/**
+ * Parse a single /fm-permissions argument. An empty argument is an error from
+ * the pure parser's perspective; the command handler treats a totally empty
+ * invocation as a status query instead, so it only calls this with a real token.
+ */
+export function parsePermissionModeArg(arg: string): ParsedMode {
+  const token = arg.trim();
+  if (token === "") {
+    return { ok: false, error: `missing mode argument; ${MODE_USAGE}` };
+  }
+  for (const mode of PERMISSION_MODES) {
+    if (token === mode) {
+      return { ok: true, mode };
+    }
+  }
+  return { ok: false, error: `unknown mode ${JSON.stringify(token)}; ${MODE_USAGE}` };
+}
+
+/**
+ * The mutation class of a built-in tool name. `shell` (bash) needs command
+ * inspection; the others are decided by name alone. Custom and unrecognized
+ * tool names are `neutral`: plan and confirm gate only the built-in file and
+ * shell tools named in docs/permission-modes.md, so neutral tools pass through.
+ */
+export type ToolMutationClass = "read" | "mutate" | "shell" | "neutral";
+
+const READ_ONLY_TOOLS = new Set(["read", "ls", "grep", "find"]);
+const MUTATING_TOOLS = new Set(["edit", "write"]);
+
+export function classifyToolMutation(toolName: string): ToolMutationClass {
+  if (toolName === "bash") return "shell";
+  if (READ_ONLY_TOOLS.has(toolName)) return "read";
+  if (MUTATING_TOOLS.has(toolName)) return "mutate";
+  return "neutral";
+}
+
+/**
+ * Patterns that mark a bash command as mutating anywhere in the command string.
+ * Matched against the whole command so chained, piped, or substituted mutations
+ * are caught even when the leading token looks read-only.
+ */
+export const DESTRUCTIVE_SHELL_PATTERNS: readonly RegExp[] = [
+  /\brm\b/i,
+  /\brmdir\b/i,
+  /\bunlink\b/i,
+  /\bmv\b/i,
+  /\bcp\b/i,
+  /\bmkdir\b/i,
+  /\btouch\b/i,
+  /\bchmod\b/i,
+  /\bchown\b/i,
+  /\bchgrp\b/i,
+  /\bln\b/i,
+  /\btee\b/i,
+  /\btruncate\b/i,
+  /\bdd\b/i,
+  /\bshred\b/i,
+  /\bsplit\b/i,
+  /\bcut\b/i,
+  /(^|[^<])>(?!>)/,
+  />>/,
+  /\bnpm\s+(install|uninstall|update|ci|link|publish|run\s+script)/i,
+  /\bnpx\s+/i,
+  /\byarn\s+(add|remove|install|publish|upgrade)/i,
+  /\bpnpm\s+(add|remove|install|publish)/i,
+  /\bpip3?\s+(install|uninstall)/i,
+  /\bpipx\s+(install|uninstall)/i,
+  /\buv\s+(pip\s+)?(install|uninstall)/i,
+  /\bapt(-get)?\s+(install|remove|purge|update|upgrade|dist-upgrade)/i,
+  /\bdnf\s+(install|remove|upgrade)/i,
+  /\byum\s+(install|remove|update)/i,
+  /\bbrew\s+(install|uninstall|upgrade|cask\s+install)/i,
+  /\bcargo\s+(install|uninstall|publish)/i,
+  /\bgo\s+(install|build.*-o\b)/i,
+  /\bgem\s+install\b/i,
+  /\bcomposer\s+(install|update|require|remove)/i,
+  /\bgit\s+(add|commit|push|pull|merge|rebase|reset|restore|stash|cherry-pick|revert|tag|init|clone|checkout|switch|branch\s+-[dD]|worktree\s+(add|remove|prune|repair))/i,
+  /\bsudo\b/i,
+  /\bsu\b/i,
+  /\bkill\b/i,
+  /\bpkill\b/i,
+  /\bkillall\b/i,
+  /\breboot\b/i,
+  /\bshutdown\b/i,
+  /\bhalt\b/i,
+  /\bpoweroff\b/i,
+  /\bsystemctl\s+(start|stop|restart|reload|enable|disable|mask|unmask)/i,
+  /\bservice\s+\S+\s+(start|stop|restart|reload)/i,
+  /\blaunchctl\s+(load|unload|start|stop|bootstrap)/i,
+  /\bdefaults\s+write\b/i,
+  /\bmkfs\b/i,
+  /\bmount\b/i,
+  /\bumount\b/i,
+  /\b(vim?|nano|emacs|code|subl|micro|ed)\b/i,
+];
+
+/**
+ * Patterns that mark a bash command as genuinely read-only. Anchored at the
+ * start so a mutation chained after a read-only leader is still caught by the
+ * destructive patterns above. A command is read-only only when it matches one
+ * of these AND no destructive pattern matches.
+ */
+export const READ_ONLY_SHELL_PATTERNS: readonly RegExp[] = [
+  /^\s*cat\b/,
+  /^\s*head\b/,
+  /^\s*tail\b/,
+  /^\s*less\b/,
+  /^\s*more\b/,
+  /^\s*grep\b/,
+  /^\s*egrep\b/,
+  /^\s*fgrep\b/,
+  /^\s*rg\b/,
+  /^\s*find\b/,
+  /^\s*fd\b/,
+  /^\s*ls\b/,
+  /^\s*pwd\b/,
+  /^\s*echo\b/,
+  /^\s*printf\b/,
+  /^\s*wc\b/,
+  /^\s*sort\b/,
+  /^\s*uniq\b/,
+  /^\s*diff\b/,
+  /^\s*comm\b/,
+  /^\s*cmp\b/,
+  /^\s*file\b/,
+  /^\s*stat\b/,
+  /^\s*du\b/,
+  /^\s*df\b/,
+  /^\s*tree\b/,
+  /^\s*which\b/,
+  /^\s*whereis\b/,
+  /^\s*type\b/,
+  /^\s*command\s+-v\b/,
+  /^\s*env\b/,
+  /^\s*printenv\b/,
+  /^\s*uname\b/,
+  /^\s*whoami\b/,
+  /^\s*id\b/,
+  /^\s*date\b/,
+  /^\s*cal\b/,
+  /^\s*uptime\b/,
+  /^\s*hostname\b/,
+  /^\s*ps\b/,
+  /^\s*top\b/,
+  /^\s*htop\b/,
+  /^\s*free\b/,
+  /^\s*vmstat\b/,
+  /^\s*iostat\b/,
+  /^\s*git\s+(status|log|diff|show|blame|branch|remote|describe|rev-parse|shortlog|ls-files|ls-remote|config\s+--get|symbolic-ref)\b/i,
+  /^\s*git\s+rev-parse\b/i,
+  /^\s*npm\s+(list|ls|view|info|search|outdated|audit|ping)/i,
+  /^\s*yarn\s+(list|info|why|audit)/i,
+  /^\s*pnpm\s+(list|why|audit)/i,
+  /^\s*node\s+--version/i,
+  /^\s*node\s+-v\b/i,
+  /^\s*python3?\s+--version/i,
+  /^\s*python3?\s+-V\b/i,
+  /^\s*rustc\s+--version/i,
+  /^\s*cargo\s+--version/i,
+  /^\s*go\s+version\b/i,
+  /^\s*git\s+--version/i,
+  /^\s*jq\b/,
+  /^\s*sed\s+-n\b/,
+  /^\s*awk\b/,
+  /^\s*bash\s+--version/i,
+  /^\s*zsh\s+--version/i,
+  /^\s*realpath\b/,
+  /^\s*readlink\b/,
+  /^\s*basename\b/,
+  /^\s*dirname\b/,
+  /^\s*seq\b/,
+  /^\s*yes\s+--help/i,
+  /^\s*man\b/,
+  /^\s*help\b/,
+];
+
+/**
+ * Whether a bash command is genuinely read-only. Advisory heuristic, not a
+ * sandbox: shell is Turing-complete, so this can only recognize known-safe and
+ * known-unsafe shapes. The safe direction is conservative - an unrecognized
+ * command is treated as non-read-only, so plan mode blocks it and confirm mode
+ * prompts for it rather than silently allowing a possible mutation.
+ */
+export function isReadOnlyShellCommand(command: string | undefined): boolean {
+  if (typeof command !== "string" || command.trim() === "") {
+    return false;
+  }
+  const isDestructive = DESTRUCTIVE_SHELL_PATTERNS.some((p) => p.test(command));
+  if (isDestructive) return false;
+  return READ_ONLY_SHELL_PATTERNS.some((p) => p.test(command));
+}
+
+/**
+ * A short, unobtrusive footer label for the active mode, or undefined to clear
+ * the footer. The extension styles this with the active theme before calling
+ * ctx.ui.setStatus.
+ */
+export function modeStatusLabel(mode: PermissionMode): string | undefined {
+  if (mode === "off") return undefined;
+  return `permission: ${mode}`;
+}
+
+/**
+ * A decision returned to the extension's tool_call handler. The extension
+ * translates `allow` to a no-op, `block` to a Pi block result, and `confirm` to
+ * an interactive ctx.ui.confirm prompt that itself resolves to allow or block.
+ */
+export type ToolCallDecision =
+  | { action: "allow" }
+  | { action: "block"; reason: string }
+  | { action: "confirm"; prompt: string; denialReason: string };
+
+function describeBash(command: string | undefined): string {
+  const trimmed = typeof command === "string" ? command.trim() : "";
+  if (trimmed === "") return "bash command";
+  const single = trimmed.replace(/\s+/g, " ");
+  return single.length > 120 ? `${single.slice(0, 117)}...` : single;
+}
+
+/**
+ * The complete mode decision for a tool_call. `command` is only consulted for
+ * the bash tool; other tools decide by name. `hasUI` makes noninteractive
+ * refusal a pure-function decision: confirm mode with no UI blocks a mutating
+ * call instead of silently allowing it.
+ */
+export function decideToolCall(
+  mode: PermissionMode,
+  toolName: string,
+  command: string | undefined,
+  hasUI: boolean,
+): ToolCallDecision {
+  if (mode === "off") {
+    return { action: "allow" };
+  }
+
+  const mutation = classifyToolMutation(toolName);
+
+  if (mode === "plan") {
+    if (mutation === "mutate") {
+      return {
+        action: "block",
+        reason: `plan mode blocks the ${toolName} tool; use /fm-permissions off to allow mutations`,
+      };
+    }
+    if (mutation === "shell" && !isReadOnlyShellCommand(command)) {
+      return {
+        action: "block",
+        reason: `plan mode blocks non-read-only shell; use /fm-permissions off to allow mutations. Command: ${describeBash(command)}`,
+      };
+    }
+    return { action: "allow" };
+  }
+
+  // mode === "confirm"
+  if (mutation === "mutate" || (mutation === "shell" && !isReadOnlyShellCommand(command))) {
+    if (!hasUI) {
+      const target = mutation === "shell" ? describeBash(command) : `the ${toolName} tool`;
+      return {
+        action: "block",
+        reason: `confirm mode requires interactive approval for ${target}, but no UI is available; use /fm-permissions off in noninteractive runs`,
+      };
+    }
+    const prompt =
+      mutation === "shell"
+        ? `confirm mode: allow this command?\n\n${describeBash(command)}`
+        : `confirm mode: allow the ${toolName} tool?`;
+    return {
+      action: "confirm",
+      prompt,
+      denialReason: `${toolName} denied by user in confirm mode`,
+    };
+  }
+  return { action: "allow" };
+}

--- a/.pi/extensions/lib/fm-permission-policy.ts
+++ b/.pi/extensions/lib/fm-permission-policy.ts
@@ -132,24 +132,159 @@ export const DESTRUCTIVE_SHELL_PATTERNS: readonly RegExp[] = [
 
 const UNSAFE_SHELL_SYNTAX = /[\n\r;&|`<>]|\$\(|\$\{|\\\n/;
 
-/**
- * Patterns that mark a bash command as genuinely read-only. Anchored at the
- * start so a mutation chained after a read-only leader is still caught by the
- * destructive patterns above. A command is read-only only when it matches one
- * of these AND no destructive pattern matches.
- */
-export const READ_ONLY_SHELL_PATTERNS: readonly RegExp[] = [
-  /^\s*(cat|head|tail|grep|egrep|fgrep|rg|find|fd|ls|pwd|echo|printf|wc|sort|uniq|diff|comm|cmp|file|stat|du|df|tree|which|whereis|type|printenv|uname|whoami|id|date|cal|uptime|ps|free|vmstat|iostat|jq|realpath|readlink|basename|dirname|seq)(?:\s+[\s\S]*)?\s*$/,
-  /^\s*command\s+-v(?:\s+[\s\S]*)?\s*$/,
-  /^\s*git\s+(status|log|diff|show|blame|describe|rev-parse|shortlog|ls-files|ls-remote)(?:\s+[\s\S]*)?\s*$/i,
-  /^\s*git\s+branch(?:\s+(?:--list|--show-current|-a|-r|-v|-vv|--contains(?:=\S+)?|--no-contains(?:=\S+)?|--merged(?:=\S+)?|--no-merged(?:=\S+)?|--sort=\S+|--format=\S+|--color(?:=\S+)?|--no-color))*\s*$/i,
-  /^\s*git\s+remote(?:\s+(?:-v|show(?:\s+\S+)?|get-url(?:\s+--all)?\s+\S+))?\s*$/i,
-  /^\s*git\s+config\s+--get(?:-all|-regexp)?\s+\S+(?:\s+\S+)?\s*$/i,
-  /^\s*git\s+symbolic-ref(?:\s+(?:--quiet|-q|--short))*\s+\S+\s*$/i,
-  /^\s*(npm\s+(list|ls|view|info|search|outdated|audit|ping)|yarn\s+(list|info|why|audit)|pnpm\s+(list|why|audit))(?:\s+[\s\S]*)?\s*$/i,
-  /^\s*(node\s+(--version|-v)|python3?\s+(--version|-V)|rustc\s+--version|cargo\s+--version|go\s+version|git\s+--version|bash\s+--version|zsh\s+--version|yes\s+--help)\s*$/i,
-  /^\s*sed\s+-n(?:\s+[\s\S]*)?\s*$/,
-];
+const READ_ONLY_COMMANDS = new Set([
+  "basename",
+  "cal",
+  "cat",
+  "cmp",
+  "comm",
+  "df",
+  "dirname",
+  "du",
+  "echo",
+  "egrep",
+  "fgrep",
+  "free",
+  "grep",
+  "head",
+  "id",
+  "iostat",
+  "jq",
+  "ls",
+  "printenv",
+  "ps",
+  "pwd",
+  "readlink",
+  "realpath",
+  "seq",
+  "stat",
+  "tail",
+  "type",
+  "uname",
+  "uptime",
+  "vmstat",
+  "wc",
+  "whereis",
+  "which",
+  "whoami",
+]);
+
+function parseSimpleShellWords(command: string): string[] | undefined {
+  if (UNSAFE_SHELL_SYNTAX.test(command) || command.includes("$")) return undefined;
+
+  const words: string[] = [];
+  let word = "";
+  let quote: "'" | '"' | undefined;
+  let escaped = false;
+  let started = false;
+
+  for (const character of command) {
+    if (escaped) {
+      word += character;
+      escaped = false;
+      started = true;
+      continue;
+    }
+    if (character === "\\" && quote !== "'") {
+      escaped = true;
+      started = true;
+      continue;
+    }
+    if (quote !== undefined) {
+      if (character === quote) quote = undefined;
+      else word += character;
+      started = true;
+      continue;
+    }
+    if (character === "'" || character === '"') {
+      quote = character;
+      started = true;
+      continue;
+    }
+    if (/\s/.test(character)) {
+      if (started) {
+        words.push(word);
+        word = "";
+        started = false;
+      }
+      continue;
+    }
+    word += character;
+    started = true;
+  }
+
+  if (escaped || quote !== undefined) return undefined;
+  if (started) words.push(word);
+  return words;
+}
+
+function hasOption(args: readonly string[], ...options: readonly string[]): boolean {
+  return args.some((arg) => options.some((option) => arg === option || arg.startsWith(`${option}=`)));
+}
+
+function isReadOnlyFind(args: readonly string[]): boolean {
+  return !hasOption(
+    args,
+    "-delete",
+    "-exec",
+    "-execdir",
+    "-fls",
+    "-fprint",
+    "-fprint0",
+    "-fprintf",
+    "-ok",
+    "-okdir",
+  );
+}
+
+function isReadOnlyRipgrep(args: readonly string[]): boolean {
+  return !hasOption(args, "--hostname-bin", "--pre");
+}
+
+function isReadOnlyGit(args: readonly string[]): boolean {
+  const [subcommand, ...rest] = args;
+  if (subcommand === "--version") return rest.length === 0;
+  if (["describe", "ls-files", "rev-parse", "status"].includes(subcommand ?? "")) return true;
+  if (["blame", "diff", "log", "shortlog", "show"].includes(subcommand ?? "")) {
+    return !hasOption(rest, "--ext-diff", "--output", "--textconv");
+  }
+  if (subcommand === "branch") {
+    return rest.every((arg) =>
+      /^(--list|--show-current|-a|-r|-v|-vv|--contains(?:=\S+)?|--no-contains(?:=\S+)?|--merged(?:=\S+)?|--no-merged(?:=\S+)?|--sort=\S+|--format=\S+|--color(?:=\S+)?|--no-color)$/.test(
+        arg,
+      ),
+    );
+  }
+  if (subcommand === "remote") {
+    return (
+      rest.length === 0 ||
+      (rest.length === 1 && rest[0] === "-v") ||
+      (rest[0] === "show" && rest.length <= 2) ||
+      (rest[0] === "get-url" && rest.length >= 2 && rest.length <= 3 && rest[1] === "--all") ||
+      (rest[0] === "get-url" && rest.length === 2)
+    );
+  }
+  if (subcommand === "config") {
+    return rest.length >= 2 && rest.length <= 3 && /^--get(?:-all|-regexp)?$/.test(rest[0] ?? "");
+  }
+  if (subcommand === "symbolic-ref") {
+    const references = rest.filter((arg) => !["--quiet", "-q", "--short"].includes(arg));
+    return references.length === 1;
+  }
+  return false;
+}
+
+function hasExactVersionArgs(command: string, args: readonly string[]): boolean {
+  if (["bash", "cargo", "rustc", "zsh"].includes(command)) {
+    return args.length === 1 && args[0] === "--version";
+  }
+  if (command === "go") return args.length === 1 && args[0] === "version";
+  if (command === "node") return args.length === 1 && ["--version", "-v"].includes(args[0] ?? "");
+  if (/^python3?$/.test(command)) {
+    return args.length === 1 && ["--version", "-V"].includes(args[0] ?? "");
+  }
+  return false;
+}
 
 /**
  * Whether a bash command is genuinely read-only. Advisory heuristic, not a
@@ -162,10 +297,17 @@ export function isReadOnlyShellCommand(command: string | undefined): boolean {
   if (typeof command !== "string" || command.trim() === "") {
     return false;
   }
-  if (UNSAFE_SHELL_SYNTAX.test(command)) return false;
   const isDestructive = DESTRUCTIVE_SHELL_PATTERNS.some((p) => p.test(command));
   if (isDestructive) return false;
-  return READ_ONLY_SHELL_PATTERNS.some((p) => p.test(command));
+  const words = parseSimpleShellWords(command);
+  if (words === undefined || words.length === 0) return false;
+  const [executable, ...args] = words;
+  if (READ_ONLY_COMMANDS.has(executable ?? "")) return true;
+  if (executable === "command") return args.length >= 2 && args[0] === "-v";
+  if (executable === "find") return isReadOnlyFind(args);
+  if (executable === "rg") return isReadOnlyRipgrep(args);
+  if (executable === "git") return isReadOnlyGit(args);
+  return hasExactVersionArgs(executable ?? "", args);
 }
 
 /**

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Firstmate's skills live in two separate places with different audiences:
 - [docs/remote-secondmates.md](docs/remote-secondmates.md) - current setup, routing, transfer, recovery, and safety behavior for whole-home remote second mates.
 - [docs/calm.md](docs/calm.md) - current Pi `/calm` behavior and supported presentation limits.
 - [docs/voice-relay.md](docs/voice-relay.md) - the optional spoken interface: setup on both machines, measured round-trip cost, what a spoken answer may read, and what this build does not do yet.
+- [docs/permission-modes.md](docs/permission-modes.md) - optional Pi `/fm-permissions` modes, session state, and advisory safety limits.
 - [docs/wedge-alarm.md](docs/wedge-alarm.md) - configure the active alert for an away-mode escalation delivery that gets stuck.
 - [docs/tmux-backend.md](docs/tmux-backend.md) - current setup and limits for the tmux reference backend.
 - [docs/herdr-backend.md](docs/herdr-backend.md) - current setup, safety boundaries, and limits for the experimental Herdr backend.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -237,6 +237,10 @@
       "audience": "operator-current"
     },
     {
+      "path": "docs/permission-modes.md",
+      "audience": "operator-current"
+    },
+    {
       "path": "docs/cd-guard.md",
       "audience": "maintainer-architecture"
     },

--- a/docs/permission-modes.md
+++ b/docs/permission-modes.md
@@ -1,0 +1,60 @@
+# Pi permission modes
+
+Permission modes are an opt-in, session-scoped advisory harness control for the Firstmate Pi primary.
+They are off by default and change nothing until a mode is explicitly enabled, so Firstmate behavior is preserved exactly when off.
+The active mode is session-persisted through Pi supported extension state, restored on session resume and reload, and never written to a global config file.
+
+This is an advisory harness control, not an OS sandbox.
+Pi extensions execute with the user full privileges, and the bash read-only classifier is a best-effort heuristic because shell is Turing-complete.
+Use it to reduce accidental mutations during interactive exploration, not to enforce a security boundary.
+
+## Modes
+
+- `off` - the default; no call is blocked or confirmed, and the existing PreToolUse seatbelts and turn-end guard run unchanged.
+- `plan` - block the built-in `edit` and `write` tools and any `bash` command that is not genuinely read-only, while allowing read-only inspection (`read`, `ls`, `grep`, `find`, and read-only `bash`).
+- `confirm` - require an interactive approval before the built-in mutating file and shell tools (`edit`, `write`, and non-read-only `bash`); if no UI is available, refuse the call rather than silently permit it.
+
+## Command
+
+```
+/fm-permissions off|plan|confirm
+```
+
+A bare `/fm-permissions` reports the active mode.
+Unknown or missing arguments notify an error and leave the mode unchanged.
+The mode name is case-sensitive and leading or trailing whitespace is trimmed.
+
+## State and display
+
+The active mode is stored through Pi `appendEntry` extension state, not a config file.
+A fresh session starts `off`; a resumed or reloaded session restores the last persisted mode.
+Malformed persisted entries are ignored, so a stale or hand-edited session never restores an invalid mode.
+While a mode is active, a short label is shown unobtrusively in the Pi footer; `off` clears it.
+
+## Bash read-only classification
+
+`plan` and `confirm` consult a pure read-only classifier for `bash` commands.
+A command is read-only only when it matches a known read-only pattern (such as `ls`, `cat`, `grep`, `rg`, `git status`, `git log`) and no known mutating pattern matches anywhere in the command, so chained, piped, redirected, or substituted mutations are caught even when the leading token looks read-only.
+An unrecognized command defaults to non-read-only, so `plan` blocks it and `confirm` prompts for it rather than silently allowing a possible mutation.
+The patterns are intentionally conservative; operators who need an unrecognized read-only command in `plan` mode can toggle `off` for that turn.
+
+## Composition with existing seatbelts
+
+Permission modes are an additive gate and never weaken the existing PreToolUse seatbelts or turn-end guard.
+Pi runs `tool_call` handlers in load order and short-circuits on the first block, and a no-block decision from this extension lets the existing seatbelts run afterward.
+A call this gate allows therefore still passes through the existing `cd`-guard and watcher-arm seatbelts, and a call this gate blocks is blocked regardless.
+Approval in `confirm` mode approves only this permission gate; it does not bypass those seatbelts.
+See [`arm-pretool-check.md`](arm-pretool-check.md), [`cd-guard.md`](cd-guard.md), and [`turnend-guard.md`](turnend-guard.md) for the existing seatbelts.
+
+## Scope and limits
+
+Only the built-in `edit`, `write`, and `bash` tools are gated; custom tools and other built-in tools pass through, because permission modes gate the built-in mutating file and shell tools named above.
+JARVIS remains the only semantic authority; this extension adds no delegation and no second LLM planner.
+The pure classification and decision logic lives in `.pi/extensions/lib/fm-permission-policy.ts` and the wiring in `.pi/extensions/fm-permission-modes.ts`.
+
+## Regression entry points
+
+```sh
+tests/fm-permission-modes.test.sh
+tests/fm-pi-primary-types.test.sh
+```

--- a/docs/permission-modes.md
+++ b/docs/permission-modes.md
@@ -2,10 +2,10 @@
 
 Permission modes are an opt-in, session-scoped advisory harness control for the Firstmate Pi primary.
 They are off by default and change nothing until a mode is explicitly enabled, so Firstmate behavior is preserved exactly when off.
-The active mode is session-persisted through Pi supported extension state, restored on session resume and reload, and never written to a global config file.
+The active mode is session-persisted through Pi's supported extension state, restored on session resume and reload, and never written to a global config file.
 
 This is an advisory harness control, not an OS sandbox.
-Pi extensions execute with the user full privileges, and the bash read-only classifier is a best-effort heuristic because shell is Turing-complete.
+Pi extensions execute with the user's full privileges, and the bash read-only classifier is a best-effort heuristic because shell is Turing-complete.
 Use it to reduce accidental mutations during interactive exploration, not to enforce a security boundary.
 
 ## Modes
@@ -21,7 +21,7 @@ Use it to reduce accidental mutations during interactive exploration, not to enf
 ```
 
 A bare `/fm-permissions` reports the active mode.
-Unknown or missing arguments notify an error and leave the mode unchanged.
+Unknown arguments notify an error and leave the mode unchanged.
 The mode name is case-sensitive and leading or trailing whitespace is trimmed.
 
 ## State and display

--- a/tests/fm-permission-modes.test.sh
+++ b/tests/fm-permission-modes.test.sh
@@ -97,7 +97,7 @@ check(policy.classifyToolMutation("fm_watch_arm_pi") === "neutral", "watcher too
 for (const ok of ["ls -la", "git status", "git log --oneline", "cat README.md", "rg TODO .", "grep -r foo .", "find . -name '*.ts'", "echo hello", "node --version", "jq '.x' f.json", "ps aux"]) {
   check(policy.isReadOnlyShellCommand(ok), `read-only command blocked: ${ok}`);
 }
-for (const bad of ["rm file", "rm -rf /", "git push", "git commit -m x", "echo hi; rm x", "cat f > /etc/passwd", "mkdir d", "chmod 777 .", "sudo ls", "npm install pkg", "vim file", "echo hi > f", "git checkout -b branch"]) {
+for (const bad of ["rm file", "rm -rf /", "git push", "git commit -m x", "echo hi; rm x", "cat f > /etc/passwd", "mkdir d", "chmod 777 .", "sudo ls", "npm install pkg", "vim file", "echo hi > f", "git checkout -b branch", "find . -delete", "find . -exec touch {} ;", "git branch new", "git remote add origin x", "ls; python -c \"open('x','w').write('x')\"", "git status && touch x", "sed -n -i file", "sort input -o output", "npm audit --fix"]) {
   check(!policy.isReadOnlyShellCommand(bad), `mutating command allowed: ${bad}`);
 }
 check(!policy.isReadOnlyShellCommand("totallyUnknownCmd --flag"), "unknown command allowed (must default to non-read-only)");
@@ -428,7 +428,6 @@ await sessionStart({ type: "session_start", reason: "resume" }, restoredCtx);
 }
 
 // Malformed persisted mode is ignored, leaving the mode at off after a reset.
-await commands["fm-permissions"].handler("off", ctx);
 const freshCtx = mkCtx([{ type: "custom", customType: "fm-permission-modes", data: { mode: "bogus" } }]);
 await sessionStart({ type: "session_start", reason: "startup" }, freshCtx);
 {
@@ -437,7 +436,8 @@ await sessionStart({ type: "session_start", reason: "startup" }, freshCtx);
   if (r && r.block) throw new Error(`malformed persisted mode restored a blocking mode: ${JSON.stringify(r)}`);
 }
 
-// A fresh session with no entries stays off.
+// A fresh session with no entries resets a previously restored mode to off.
+await sessionStart({ type: "session_start", reason: "resume" }, restoredCtx);
 const emptyCtx = mkCtx([]);
 await sessionStart({ type: "session_start", reason: "new" }, emptyCtx);
 {

--- a/tests/fm-permission-modes.test.sh
+++ b/tests/fm-permission-modes.test.sh
@@ -94,10 +94,10 @@ check(policy.classifyToolMutation("custom_thing") === "neutral", "custom tool no
 check(policy.classifyToolMutation("fm_watch_arm_pi") === "neutral", "watcher tool not neutral");
 
 // isReadOnlyShellCommand: genuinely read-only, clearly mutating, chained, and unknown.
-for (const ok of ["ls -la", "git status", "git log --oneline", "cat README.md", "rg TODO .", "grep -r foo .", "find . -name '*.ts'", "echo hello", "node --version", "jq '.x' f.json", "ps aux"]) {
+for (const ok of ["ls -la", "git status", "git log --oneline", "cat README.md", "head -20 README.md", "tail -20 README.md", "wc -l README.md", "rg TODO .", "grep -r foo .", "find . -name '*.ts'", "echo hello", "node --version", "jq '.x' f.json", "ps aux"]) {
   check(policy.isReadOnlyShellCommand(ok), `read-only command blocked: ${ok}`);
 }
-for (const bad of ["rm file", "rm -rf /", "git push", "git commit -m x", "echo hi; rm x", "cat f > /etc/passwd", "mkdir d", "chmod 777 .", "sudo ls", "npm install pkg", "vim file", "echo hi > f", "git checkout -b branch", "find . -delete", "find . -exec touch {} ;", "git branch new", "git remote add origin x", "ls; python -c \"open('x','w').write('x')\"", "git status && touch x", "sed -n -i file", "sort input -o output", "npm audit --fix"]) {
+for (const bad of ["rm file", "rm -rf /", "git push", "git commit -m x", "echo hi; rm x", "cat f > /etc/passwd", "mkdir d", "chmod 777 .", "sudo ls", "npm install pkg", "vim file", "echo hi > f", "git checkout -b branch", "find . -delete", "find . -exec touch {} +", "find . -execdir touch {} +", "fd -x ./mutator", "rg --pre ./mutator pattern .", "rg --hostname-bin ./mutator pattern .", "git branch new", "git remote add origin x", "git log --output=out", "git diff --ext-diff", "ls; python -c \"open('x','w').write('x')\"", "git status && touch x", "sed -n 'w out' input", "sed -n 'W out' input", "sed -n -i file", "sort input -o output", "sort input -ooutput", "date -s @0", "date -s@0", "awk 'BEGIN { system(\"touch x\") }'", "npm audit --fix"]) {
   check(!policy.isReadOnlyShellCommand(bad), `mutating command allowed: ${bad}`);
 }
 check(!policy.isReadOnlyShellCommand("totallyUnknownCmd --flag"), "unknown command allowed (must default to non-read-only)");
@@ -225,6 +225,11 @@ await expectBlock("bash", { command: "git push" }, "git-push");
 await expectBlock("bash", { command: "echo hi; rm x" }, "chained-rm");
 await expectBlock("bash", { command: "cat f > /etc/passwd" }, "redirect");
 await expectBlock("bash", { command: "npm install pkg" }, "npm-install");
+await expectBlock("bash", { command: "sed -n 'w out' input" }, "sed-write");
+await expectBlock("bash", { command: "fd -x ./mutator" }, "fd-exec");
+await expectBlock("bash", { command: "sort input -ooutput" }, "sort-output");
+await expectBlock("bash", { command: "date -s@0" }, "date-set");
+await expectBlock("bash", { command: "awk 'BEGIN { system(\"touch x\") }'" }, "awk-system");
 JS
 )
   status=$?

--- a/tests/fm-permission-modes.test.sh
+++ b/tests/fm-permission-modes.test.sh
@@ -1,0 +1,550 @@
+#!/usr/bin/env bash
+# Behavioral tests for the opt-in Pi permission-mode extension
+# (.pi/extensions/fm-permission-modes.ts + .pi/extensions/lib/fm-permission-policy.ts).
+#
+# Covers default-off compatibility, read-only plan calls, blocked mutation,
+# confirm allow/deny, noninteractive refusal, malformed command arguments,
+# session-persisted state round-trip, and the additive-composition guarantee
+# (a no-block decision lets the existing PreToolUse seatbelts run; a block
+# short-circuits before them) proven against the real Pi ExtensionRunner.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+EXT="$ROOT/.pi/extensions/fm-permission-modes.ts"
+POLICY="$ROOT/.pi/extensions/lib/fm-permission-policy.ts"
+PI_PACKAGE_DIR=${FM_PI_PACKAGE_DIR:-"$(npm root -g 2>/dev/null)/@earendil-works/pi-coding-agent"}
+TMP_ROOT=$(fm_test_tmproot fm-permission-modes)
+FIXTURE="$TMP_ROOT/fixture"
+
+cleanup() {
+  fm_test_cleanup
+}
+trap cleanup EXIT
+
+build_fixture() {
+  mkdir -p \
+    "$FIXTURE/lib" \
+    "$FIXTURE/node_modules/@earendil-works" \
+    "$FIXTURE/node_modules/@types"
+  cp "$EXT" "$FIXTURE/fm-permission-modes.ts"
+  cp "$POLICY" "$FIXTURE/lib/fm-permission-policy.ts"
+  ln -s "$PI_PACKAGE_DIR" "$FIXTURE/node_modules/@earendil-works/pi-coding-agent"
+  ln -s "$PI_PACKAGE_DIR/node_modules/@earendil-works/pi-tui" "$FIXTURE/node_modules/@earendil-works/pi-tui"
+  ln -s "$PI_PACKAGE_DIR/node_modules/typebox" "$FIXTURE/node_modules/typebox"
+  ln -s "$PI_PACKAGE_DIR/node_modules/@types/node" "$FIXTURE/node_modules/@types/node"
+  printf '%s\n' '{"type":"module"}' >"$FIXTURE/package.json"
+}
+
+node_guard() {
+  if ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
+    echo "skip: node or npm not found for Pi permission-modes test"
+    return 1
+  fi
+  if [ ! -f "$PI_PACKAGE_DIR/package.json" ]; then
+    echo "skip: installed @earendil-works/pi-coding-agent package not found"
+    return 1
+  fi
+  return 0
+}
+
+run_node() {
+  # Run a node --input-type=module heredoc against the fixture. $1 is the heredoc
+  # body passed on stdin; the fixture dir is the cwd so relative .ts imports resolve.
+  (cd "$FIXTURE" && EXT="$FIXTURE/fm-permission-modes.ts" \
+    POLICY="$FIXTURE/lib/fm-permission-policy.ts" \
+    PI_PACKAGE_DIR="$PI_PACKAGE_DIR" \
+    node --input-type=module) 2>&1
+}
+
+test_pure_policy() {
+  local out status
+  node_guard || return 0
+  out=$(run_node <<'JS'
+import { pathToFileURL } from "node:url";
+const policy = await import(`${pathToFileURL(process.env.POLICY).href}?pure=${Date.now()}`);
+
+function check(cond, msg) {
+  if (!cond) throw new Error(msg);
+}
+
+// parsePermissionModeArg: valid modes, missing, unknown, and case sensitivity.
+for (const m of ["off", "plan", "confirm"]) {
+  const r = policy.parsePermissionModeArg(m);
+  check(r.ok && r.mode === m, `parsePermissionModeArg(${m}) failed`);
+}
+check(!policy.parsePermissionModeArg("").ok, "empty arg parsed as ok");
+check(!policy.parsePermissionModeArg("bogus").ok, "unknown arg parsed as ok");
+check(!policy.parsePermissionModeArg("PLAN").ok, "uppercase accepted (must be case-sensitive)");
+{
+  const spaced = policy.parsePermissionModeArg("  plan  ");
+  check(spaced.ok && spaced.mode === "plan", "leading/trailing whitespace not trimmed");
+}
+
+// classifyToolMutation: built-in tools and neutral custom tools.
+check(policy.classifyToolMutation("edit") === "mutate", "edit classified wrong");
+check(policy.classifyToolMutation("write") === "mutate", "write classified wrong");
+check(policy.classifyToolMutation("bash") === "shell", "bash classified wrong");
+check(policy.classifyToolMutation("read") === "read", "read classified wrong");
+for (const t of ["ls", "grep", "find"]) {
+  check(policy.classifyToolMutation(t) === "read", `${t} classified wrong`);
+}
+check(policy.classifyToolMutation("custom_thing") === "neutral", "custom tool not neutral");
+check(policy.classifyToolMutation("fm_watch_arm_pi") === "neutral", "watcher tool not neutral");
+
+// isReadOnlyShellCommand: genuinely read-only, clearly mutating, chained, and unknown.
+for (const ok of ["ls -la", "git status", "git log --oneline", "cat README.md", "rg TODO .", "grep -r foo .", "find . -name '*.ts'", "echo hello", "node --version", "jq '.x' f.json", "ps aux"]) {
+  check(policy.isReadOnlyShellCommand(ok), `read-only command blocked: ${ok}`);
+}
+for (const bad of ["rm file", "rm -rf /", "git push", "git commit -m x", "echo hi; rm x", "cat f > /etc/passwd", "mkdir d", "chmod 777 .", "sudo ls", "npm install pkg", "vim file", "echo hi > f", "git checkout -b branch"]) {
+  check(!policy.isReadOnlyShellCommand(bad), `mutating command allowed: ${bad}`);
+}
+check(!policy.isReadOnlyShellCommand("totallyUnknownCmd --flag"), "unknown command allowed (must default to non-read-only)");
+check(!policy.isReadOnlyShellCommand(""), "empty command classified read-only");
+check(!policy.isReadOnlyShellCommand(undefined), "undefined command classified read-only");
+
+// decideToolCall: off allows everything; plan blocks mutation and non-read-only shell;
+// confirm prompts for mutation when UI exists and blocks when it does not.
+check(policy.decideToolCall("off", "edit", undefined, true).action === "allow", "off blocked edit");
+check(policy.decideToolCall("off", "bash", "rm -rf /", true).action === "allow", "off blocked mutating bash");
+check(policy.decideToolCall("plan", "edit", undefined, true).action === "block", "plan allowed edit");
+check(policy.decideToolCall("plan", "write", undefined, true).action === "block", "plan allowed write");
+check(policy.decideToolCall("plan", "read", undefined, true).action === "allow", "plan blocked read");
+check(policy.decideToolCall("plan", "bash", "ls", true).action === "allow", "plan blocked read-only bash");
+check(policy.decideToolCall("plan", "bash", "rm x", true).action === "block", "plan allowed mutating bash");
+check(policy.decideToolCall("plan", "bash", "git status", true).action === "allow", "plan blocked git status");
+check(policy.decideToolCall("plan", "custom_thing", undefined, true).action === "allow", "plan gated a neutral custom tool");
+
+const cEditUI = policy.decideToolCall("confirm", "edit", undefined, true);
+check(cEditUI.action === "confirm", "confirm did not prompt for edit with UI");
+const cEditNoUI = policy.decideToolCall("confirm", "edit", undefined, false);
+check(cEditNoUI.action === "block", "confirm did not refuse edit without UI (noninteractive refusal)");
+const cBashRO = policy.decideToolCall("confirm", "bash", "ls", true);
+check(cBashRO.action === "allow", "confirm prompted for read-only bash");
+const cBashMutUI = policy.decideToolCall("confirm", "bash", "rm x", true);
+check(cBashMutUI.action === "confirm", "confirm did not prompt for mutating bash");
+const cBashMutNoUI = policy.decideToolCall("confirm", "bash", "rm x", false);
+check(cBashMutNoUI.action === "block", "confirm allowed mutating bash without UI");
+check(policy.decideToolCall("confirm", "read", undefined, false).action === "allow", "confirm refused a read-only tool without UI");
+
+// modeStatusLabel: off clears the footer; plan/confirm label themselves.
+check(policy.modeStatusLabel("off") === undefined, "off produced a footer label");
+check(policy.modeStatusLabel("plan") === "permission: plan", "plan label wrong");
+check(policy.modeStatusLabel("confirm") === "permission: confirm", "confirm label wrong");
+JS
+)
+  status=$?
+  [ "$status" -eq 0 ] || fail "pure policy checks failed: $out"
+  [ -z "$out" ] || fail "pure policy test printed output: $out"
+  pass "pure policy: parsing, tool classification, read-only shell, and mode decisions (including noninteractive refusal)"
+}
+
+test_default_off_compatibility() {
+  local out status
+  node_guard || return 0
+  out=$(run_node <<'JS'
+import { pathToFileURL } from "node:url";
+const ext = await import(`${pathToFileURL(process.env.EXT).href}?off=${Date.now()}`);
+const handlers = new Map();
+const pi = {
+  events: { emit() {}, on() {} },
+  on(ev, h) { const a = handlers.get(ev) || []; a.push(h); handlers.set(ev, a); },
+  registerCommand() {},
+  appendEntry() {},
+};
+ext.default(pi);
+const toolCall = handlers.get("tool_call")[0];
+const ctx = {
+  hasUI: true,
+  ui: { notify() {}, setStatus() {}, confirm: async () => true, theme: { fg: (_c, t) => t } },
+  sessionManager: { getEntries: () => [] },
+};
+// Off is the default and must not block any tool, including mutating ones.
+for (const [name, input] of [
+  ["edit", { path: "f", edits: [] }],
+  ["write", { path: "f", content: "x" }],
+  ["read", { path: "f" }],
+  ["bash", { command: "rm -rf /tmp/anything" }],
+  ["bash", { command: "git push" }],
+  ["custom_tool", { x: 1 }],
+]) {
+  const r = await toolCall({ type: "tool_call", toolName: name, toolCallId: name, input }, ctx);
+  if (r && r.block) throw new Error(`off mode blocked ${name}: ${JSON.stringify(r)}`);
+}
+JS
+)
+  status=$?
+  [ "$status" -eq 0 ] || fail "default-off compatibility failed: $out"
+  [ -z "$out" ] || fail "default-off test printed output: $out"
+  pass "off mode preserves behavior: edit, write, read, mutating bash, and custom tools all pass unblocked"
+}
+
+test_plan_readonly_allowed_and_mutation_blocked() {
+  local out status
+  node_guard || return 0
+  out=$(run_node <<'JS'
+import { pathToFileURL } from "node:url";
+const ext = await import(`${pathToFileURL(process.env.EXT).href}?plan=${Date.now()}`);
+const handlers = new Map();
+const commands = {};
+const pi = {
+  events: { emit() {}, on() {} },
+  on(ev, h) { const a = handlers.get(ev) || []; a.push(h); handlers.set(ev, a); },
+  registerCommand(name, opts) { commands[name] = opts; },
+  appendEntry() {},
+};
+ext.default(pi);
+const ctx = {
+  hasUI: true,
+  ui: { notify() {}, setStatus() {}, confirm: async () => true, theme: { fg: (_c, t) => t } },
+  sessionManager: { getEntries: () => [] },
+};
+await commands["fm-permissions"].handler("plan", ctx);
+const toolCall = handlers.get("tool_call")[0];
+async function expectAllow(name, input, label) {
+  const r = await toolCall({ type: "tool_call", toolName: name, toolCallId: label, input }, ctx);
+  if (r && r.block) throw new Error(`plan blocked a read-only call ${label}: ${JSON.stringify(r)}`);
+}
+async function expectBlock(name, input, label) {
+  const r = await toolCall({ type: "tool_call", toolName: name, toolCallId: label, input }, ctx);
+  if (!r || !r.block) throw new Error(`plan allowed a mutation ${label}: ${JSON.stringify(r)}`);
+}
+// Genuinely read-only inspection is allowed.
+await expectAllow("read", { path: "f" }, "read");
+await expectAllow("ls", { path: "." }, "ls");
+await expectAllow("grep", { pattern: "x", path: "." }, "grep");
+await expectAllow("bash", { command: "git status" }, "git-status");
+await expectAllow("bash", { command: "cat README.md" }, "cat");
+await expectAllow("bash", { command: "rg TODO ." }, "rg");
+// Mutations are blocked, including chained and redirected ones.
+await expectBlock("edit", { path: "f", edits: [] }, "edit");
+await expectBlock("write", { path: "f", content: "x" }, "write");
+await expectBlock("bash", { command: "rm file" }, "rm");
+await expectBlock("bash", { command: "git push" }, "git-push");
+await expectBlock("bash", { command: "echo hi; rm x" }, "chained-rm");
+await expectBlock("bash", { command: "cat f > /etc/passwd" }, "redirect");
+await expectBlock("bash", { command: "npm install pkg" }, "npm-install");
+JS
+)
+  status=$?
+  [ "$status" -eq 0 ] || fail "plan mode checks failed: $out"
+  [ -z "$out" ] || fail "plan mode test printed output: $out"
+  pass "plan mode allows read-only inspection (read, ls, grep, git status, cat, rg) and blocks edit, write, and mutating/chained/redirected bash"
+}
+
+test_confirm_allow_deny_and_noninteractive_refusal() {
+  local out status
+  node_guard || return 0
+  out=$(run_node <<'JS'
+import { pathToFileURL } from "node:url";
+const ext = await import(`${pathToFileURL(process.env.EXT).href}?confirm=${Date.now()}`);
+const handlers = new Map();
+const commands = {};
+const pi = {
+  events: { emit() {}, on() {} },
+  on(ev, h) { const a = handlers.get(ev) || []; a.push(h); handlers.set(ev, a); },
+  registerCommand(name, opts) { commands[name] = opts; },
+  appendEntry() {},
+};
+ext.default(pi);
+let nextConfirm = false;
+let confirmCalls = 0;
+const ctxInteractive = {
+  hasUI: true,
+  ui: {
+    notify() {},
+    setStatus() {},
+    confirm: async () => { confirmCalls += 1; return nextConfirm; },
+    theme: { fg: (_c, t) => t },
+  },
+  sessionManager: { getEntries: () => [] },
+};
+const ctxHeadless = { hasUI: false, ui: { notify() {}, setStatus() {}, confirm: async () => { throw new Error("confirm must not be called headless"); }, theme: { fg: (_c, t) => t } }, sessionManager: { getEntries: () => [] } };
+await commands["fm-permissions"].handler("confirm", ctxInteractive);
+const toolCall = handlers.get("tool_call")[0];
+
+// Allow path: user approves a mutating tool.
+nextConfirm = true; confirmCalls = 0;
+let r = await toolCall({ type: "tool_call", toolName: "edit", toolCallId: "e1", input: { path: "f", edits: [] } }, ctxInteractive);
+if (r && r.block) throw new Error(`confirm denied edit despite approval: ${JSON.stringify(r)}`);
+if (confirmCalls !== 1) throw new Error(`confirm called ${confirmCalls}x for edit (expected 1)`);
+
+// Deny path: user rejects a mutating tool.
+nextConfirm = false; confirmCalls = 0;
+r = await toolCall({ type: "tool_call", toolName: "edit", toolCallId: "e2", input: { path: "f", edits: [] } }, ctxInteractive);
+if (!r || !r.block) throw new Error(`confirm allowed edit despite denial: ${JSON.stringify(r)}`);
+if (confirmCalls !== 1) throw new Error(`confirm called ${confirmCalls}x for denied edit (expected 1)`);
+
+// Mutating bash prompts and respects the answer.
+nextConfirm = true; confirmCalls = 0;
+r = await toolCall({ type: "tool_call", toolName: "bash", toolCallId: "b1", input: { command: "rm x" } }, ctxInteractive);
+if (r && r.block) throw new Error(`confirm denied mutating bash despite approval: ${JSON.stringify(r)}`);
+if (confirmCalls !== 1) throw new Error(`confirm called ${confirmCalls}x for mutating bash (expected 1)`);
+
+// Read-only bash is not prompted.
+nextConfirm = false; confirmCalls = 0;
+r = await toolCall({ type: "tool_call", toolName: "bash", toolCallId: "b2", input: { command: "ls" } }, ctxInteractive);
+if (r && r.block) throw new Error(`confirm blocked read-only bash: ${JSON.stringify(r)}`);
+if (confirmCalls !== 0) throw new Error(`confirm prompted for read-only bash ${confirmCalls}x`);
+
+// Noninteractive refusal: no UI must block a mutating call rather than permit it.
+r = await toolCall({ type: "tool_call", toolName: "edit", toolCallId: "e3", input: { path: "f", edits: [] } }, ctxHeadless);
+if (!r || !r.block) throw new Error(`headless confirm allowed edit (must refuse): ${JSON.stringify(r)}`);
+r = await toolCall({ type: "tool_call", toolName: "bash", toolCallId: "b3", input: { command: "rm x" } }, ctxHeadless);
+if (!r || !r.block) throw new Error(`headless confirm allowed mutating bash (must refuse): ${JSON.stringify(r)}`);
+// Read-only tools still pass headless.
+r = await toolCall({ type: "tool_call", toolName: "read", toolCallId: "r1", input: { path: "f" } }, ctxHeadless);
+if (r && r.block) throw new Error(`headless confirm blocked read: ${JSON.stringify(r)}`);
+JS
+)
+  status=$?
+  [ "$status" -eq 0 ] || fail "confirm allow/deny/refusal checks failed: $out"
+  [ -z "$out" ] || fail "confirm test printed output: $out"
+  pass "confirm mode prompts mutating tools (allow/deny), skips read-only bash, and refuses mutating calls without a UI"
+}
+
+test_malformed_command_arguments() {
+  local out status
+  node_guard || return 0
+  out=$(run_node <<'JS'
+import { pathToFileURL } from "node:url";
+const ext = await import(`${pathToFileURL(process.env.EXT).href}?cmd=${Date.now()}`);
+const handlers = new Map();
+const commands = {};
+const pi = {
+  events: { emit() {}, on() {} },
+  on(ev, h) { const a = handlers.get(ev) || []; a.push(h); handlers.set(ev, a); },
+  registerCommand(name, opts) { commands[name] = opts; },
+  appendEntry() {},
+};
+ext.default(pi);
+const notifications = [];
+const ctx = {
+  hasUI: true,
+  ui: { notify: (m, t) => notifications.push({ m, t }), setStatus() {}, confirm: async () => true, theme: { fg: (_c, t) => t } },
+  sessionManager: { getEntries: () => [] },
+};
+const toolCall = handlers.get("tool_call")[0];
+const cmd = commands["fm-permissions"];
+
+// Empty invocation is a status query, not an error; mode stays off and nothing is blocked.
+notifications.length = 0;
+await cmd.handler("", ctx);
+if (notifications.length !== 1 || notifications[0].t !== "info") throw new Error(`empty invocation did not notify status: ${JSON.stringify(notifications)}`);
+if (!notifications[0].m.includes("off")) throw new Error(`status did not report off: ${notifications[0].m}`);
+const r = await toolCall({ type: "tool_call", toolName: "edit", toolCallId: "e", input: { path: "f", edits: [] } }, ctx);
+if (r && r.block) throw new Error(`status query changed mode and blocked edit: ${JSON.stringify(r)}`);
+
+// Malformed argument notifies an error and leaves the mode unchanged.
+notifications.length = 0;
+await cmd.handler("bogus", ctx);
+if (notifications.length !== 1 || notifications[0].t !== "error") throw new Error(`bogus arg did not notify error: ${JSON.stringify(notifications)}`);
+if (!/usage|unknown mode/i.test(notifications[0].m)) throw new Error(`error message did not guide usage: ${notifications[0].m}`);
+const r2 = await toolCall({ type: "tool_call", toolName: "edit", toolCallId: "e2", input: { path: "f", edits: [] } }, ctx);
+if (r2 && r2.block) throw new Error(`bogus arg changed mode to a blocking one: ${JSON.stringify(r2)}`);
+
+// Case sensitivity: PLAN is not accepted.
+notifications.length = 0;
+await cmd.handler("PLAN", ctx);
+if (notifications[0].t !== "error") throw new Error(`uppercase PLAN accepted: ${JSON.stringify(notifications)}`);
+const r3 = await toolCall({ type: "tool_call", toolName: "edit", toolCallId: "e3", input: { path: "f", edits: [] } }, ctx);
+if (r3 && r3.block) throw new Error(`uppercase PLAN changed mode: ${JSON.stringify(r3)}`);
+
+// Valid modes round-trip and take effect.
+await cmd.handler("plan", ctx);
+const r4 = await toolCall({ type: "tool_call", toolName: "edit", toolCallId: "e4", input: { path: "f", edits: [] } }, ctx);
+if (!r4 || !r4.block) throw new Error(`plan did not take effect after valid arg: ${JSON.stringify(r4)}`);
+await cmd.handler("off", ctx);
+const r5 = await toolCall({ type: "tool_call", toolName: "edit", toolCallId: "e5", input: { path: "f", edits: [] } }, ctx);
+if (r5 && r5.block) throw new Error(`off did not restore behavior after valid arg: ${JSON.stringify(r5)}`);
+
+// Trailing whitespace is trimmed and accepted.
+await cmd.handler("  plan  ", ctx);
+const r6 = await toolCall({ type: "tool_call", toolName: "edit", toolCallId: "e6", input: { path: "f", edits: [] } }, ctx);
+if (!r6 || !r6.block) throw new Error(`trailing-whitespace plan did not take effect: ${JSON.stringify(r6)}`);
+JS
+)
+  status=$?
+  [ "$status" -eq 0 ] || fail "malformed command argument checks failed: $out"
+  [ -z "$out" ] || fail "malformed command test printed output: $out"
+  pass "command handles empty (status), malformed (error, mode unchanged), case sensitivity, trailing whitespace, and valid round-trips"
+}
+
+test_session_persisted_state_roundtrip() {
+  local out status
+  node_guard || return 0
+  out=$(run_node <<'JS'
+import { pathToFileURL } from "node:url";
+const ext = await import(`${pathToFileURL(process.env.EXT).href}?persist=${Date.now()}`);
+const handlers = new Map();
+const commands = {};
+const appended = [];
+const pi = {
+  events: { emit() {}, on() {} },
+  on(ev, h) { const a = handlers.get(ev) || []; a.push(h); handlers.set(ev, a); },
+  registerCommand(name, opts) { commands[name] = opts; },
+  appendEntry(customType, data) { appended.push({ customType, data }); },
+};
+ext.default(pi);
+const ctx = {
+  hasUI: true,
+  ui: { notify() {}, setStatus() {}, confirm: async () => true, theme: { fg: (_c, t) => t } },
+  sessionManager: { getEntries: () => [] },
+};
+await commands["fm-permissions"].handler("plan", ctx);
+if (appended.length !== 1 || appended[0].customType !== "fm-permission-modes" || appended[0].data?.mode !== "plan") {
+  throw new Error(`appendEntry did not persist plan mode: ${JSON.stringify(appended)}`);
+}
+await commands["fm-permissions"].handler("confirm", ctx);
+if (appended[appended.length - 1].data?.mode !== "confirm") {
+  throw new Error(`appendEntry did not persist confirm mode: ${JSON.stringify(appended)}`);
+}
+
+const sessionStart = handlers.get("session_start")[0];
+const toolCall = handlers.get("tool_call")[0];
+const mkCtx = (entries) => ({
+  hasUI: true,
+  ui: { notify() {}, setStatus() {}, confirm: async () => true, theme: { fg: (_c, t) => t } },
+  sessionManager: { getEntries: () => entries },
+});
+const fireEdit = async (ctx) => toolCall({ type: "tool_call", toolName: "edit", toolCallId: "e", input: { path: "f", edits: [] } }, ctx);
+
+// Reset to off first, so the restore below is what sets the mode.
+await commands["fm-permissions"].handler("off", ctx);
+
+// session_start restores the last valid persisted mode (confirm) from Pi session entries.
+// Confirm mode is proven by noninteractive refusal: a headless mutating call must be
+// refused, proving the mode was restored from entries rather than left at off.
+const restoredCtx = mkCtx([
+  { type: "custom", customType: "fm-permission-modes", data: { mode: "plan" } },
+  { type: "custom", customType: "fm-permission-modes", data: { mode: "confirm" } },
+]);
+await sessionStart({ type: "session_start", reason: "resume" }, restoredCtx);
+{
+  const headless = { ...restoredCtx, hasUI: false };
+  const r = await fireEdit(headless);
+  if (!r || !r.block) throw new Error(`session_start did not restore confirm mode (headless edit not refused): ${JSON.stringify(r)}`);
+}
+
+// Malformed persisted mode is ignored, leaving the mode at off after a reset.
+await commands["fm-permissions"].handler("off", ctx);
+const freshCtx = mkCtx([{ type: "custom", customType: "fm-permission-modes", data: { mode: "bogus" } }]);
+await sessionStart({ type: "session_start", reason: "startup" }, freshCtx);
+{
+  const headless = { ...freshCtx, hasUI: false };
+  const r = await fireEdit(headless);
+  if (r && r.block) throw new Error(`malformed persisted mode restored a blocking mode: ${JSON.stringify(r)}`);
+}
+
+// A fresh session with no entries stays off.
+const emptyCtx = mkCtx([]);
+await sessionStart({ type: "session_start", reason: "new" }, emptyCtx);
+{
+  const headless = { ...emptyCtx, hasUI: false };
+  const r = await fireEdit(headless);
+  if (r && r.block) throw new Error(`fresh session did not start off: ${JSON.stringify(r)}`);
+}
+JS
+)
+  status=$?
+  [ "$status" -eq 0 ] || fail "session-persisted state round-trip failed: $out"
+  [ -z "$out" ] || fail "persistence test printed output: $out"
+  pass "mode state persists via appendEntry, restores on session_start (last valid entry), ignores malformed entries, and defaults to off on a fresh session"
+}
+
+test_additive_composition_with_real_runner() {
+  local out status
+  node_guard || return 0
+  out=$(run_node <<'JS'
+import { pathToFileURL } from "node:url";
+const packageRoot = process.env.PI_PACKAGE_DIR;
+const { ExtensionRunner } = await import(pathToFileURL(`${packageRoot}/dist/core/extensions/runner.js`).href);
+
+// Load the real permission-mode extension to register its real tool_call handler.
+const ext = await import(`${pathToFileURL(process.env.EXT).href}?compose=${Date.now()}`);
+const myHandlers = new Map();
+const commands = {};
+const pi = {
+  events: { emit() {}, on() {} },
+  on(ev, h) { const a = myHandlers.get(ev) || []; a.push(h); myHandlers.set(ev, a); },
+  registerCommand(name, opts) { commands[name] = opts; },
+  appendEntry() {},
+};
+ext.default(pi);
+
+// A second "seatbelt" handler stands in for the existing turn-end guard
+// PreToolUse checks. It records that it ran and never blocks on its own.
+let seatbeltRan = false;
+const seatbelt = async (_event, _ctx) => { seatbeltRan = true; return {}; };
+
+// Build two fake Extension objects the way the Pi loader does: a handlers Map.
+const mine = { handlers: myHandlers };
+const seat = { handlers: new Map([["tool_call", [seatbelt]]]) };
+const runtime = {
+  flagValues: new Map(),
+  pendingProviderRegistrations: [],
+  pendingNativeProviderRegistrations: [],
+  invalidate() {},
+  assertActive() {},
+  trackEventBusSubscription(fn) { return fn; },
+  getThinkingLevel: () => "off",
+  registerProvider() {},
+  registerNativeProvider() {},
+  unregisterProvider() {},
+};
+const runner = new ExtensionRunner([mine, seat], runtime, process.cwd(), { getEntries: () => [] }, { registerProvider() {} });
+runner.uiContext = { notify() {}, setStatus() {}, confirm: async () => true, theme: { fg: (_c, t) => t } };
+
+async function fire(toolName, input) {
+  seatbeltRan = false;
+  const result = await runner.emitToolCall({ type: "tool_call", toolName, toolCallId: toolName, input });
+  return { result, seatbeltRan };
+}
+
+// Off (default): a no-block decision must let the seatbelt run (additive, no weakening).
+let obs = await fire("edit", { path: "f", edits: [] });
+if (obs.result && obs.result.block) throw new Error(`off blocked edit: ${JSON.stringify(obs.result)}`);
+if (!obs.seatbeltRan) throw new Error("off short-circuited the seatbelt (weakened the existing gate)");
+
+// Plan mode, edit: a block short-circuits, so the seatbelt never runs.
+await commands["fm-permissions"].handler("plan", { ui: runner.uiContext, hasUI: true, sessionManager: { getEntries: () => [] } });
+obs = await fire("edit", { path: "f", edits: [] });
+if (!obs.result || !obs.result.block) throw new Error(`plan did not block edit: ${JSON.stringify(obs.result)}`);
+if (obs.seatbeltRan) throw new Error("plan block let the seatbelt run anyway (should short-circuit)");
+
+// Plan mode, read-only bash: a no-block decision lets the seatbelt run.
+obs = await fire("bash", { command: "ls -la" });
+if (obs.result && obs.result.block) throw new Error(`plan blocked read-only bash: ${JSON.stringify(obs.result)}`);
+if (!obs.seatbeltRan) throw new Error("plan read-only bash short-circuited the seatbelt");
+
+// Confirm mode, approved mutating call: the no-block decision lets the seatbelt
+// run, proving approval never bypasses the existing PreToolUse seatbelts.
+await commands["fm-permissions"].handler("confirm", { ui: runner.uiContext, hasUI: true, sessionManager: { getEntries: () => [] } });
+runner.uiContext = { notify() {}, setStatus() {}, confirm: async () => true, theme: { fg: (_c, t) => t } };
+obs = await fire("edit", { path: "f", edits: [] });
+if (obs.result && obs.result.block) throw new Error(`confirm denied approved edit: ${JSON.stringify(obs.result)}`);
+if (!obs.seatbeltRan) throw new Error("confirm approval bypassed the seatbelt (weakened the existing gate)");
+
+// Confirm mode, denied mutating call: a block short-circuits before the seatbelt.
+runner.uiContext = { notify() {}, setStatus() {}, confirm: async () => false, theme: { fg: (_c, t) => t } };
+obs = await fire("edit", { path: "f", edits: [] });
+if (!obs.result || !obs.result.block) throw new Error(`confirm allowed denied edit: ${JSON.stringify(obs.result)}`);
+if (obs.seatbeltRan) throw new Error("confirm denial let the seatbelt run anyway (should short-circuit)");
+JS
+)
+  status=$?
+  [ "$status" -eq 0 ] || fail "additive composition proof failed: $out"
+  [ -z "$out" ] || fail "composition test printed output: $out"
+  pass "additive composition (real Pi runner): off and approved calls let the seatbelt run; plan and denied calls short-circuit before it - permission modes never weaken the existing seatbelts"
+}
+
+build_fixture
+
+test_pure_policy
+test_default_off_compatibility
+test_plan_readonly_allowed_and_mutation_blocked
+test_confirm_allow_deny_and_noninteractive_refusal
+test_malformed_command_arguments
+test_session_persisted_state_roundtrip
+test_additive_composition_with_real_runner

--- a/tests/fm-pi-primary-types.test.sh
+++ b/tests/fm-pi-primary-types.test.sh
@@ -27,6 +27,7 @@ trap cleanup EXIT
 
 mkdir -p "$TMP_ROOT/lib" "$TMP_ROOT/node_modules/@earendil-works" "$TMP_ROOT/node_modules/@types"
 cp "$ROOT/.pi/extensions/fm-calm.ts" "$TMP_ROOT/fm-calm.ts"
+cp "$ROOT/.pi/extensions/fm-permission-modes.ts" "$TMP_ROOT/fm-permission-modes.ts"
 cp "$ROOT/.pi/extensions/fm-primary-pi-watch.ts" "$TMP_ROOT/fm-primary-pi-watch.ts"
 cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$TMP_ROOT/fm-primary-turnend-guard.ts"
 cp "$ROOT/.pi/extensions/lib/fm-calm-assistant-layout.ts" "$TMP_ROOT/lib/fm-calm-assistant-layout.ts"
@@ -34,6 +35,7 @@ cp "$ROOT/.pi/extensions/lib/fm-calm-operational-user-layout.ts" "$TMP_ROOT/lib/
 cp "$ROOT/.pi/extensions/lib/fm-calm-visibility.ts" "$TMP_ROOT/lib/fm-calm-visibility.ts"
 cp "$ROOT/.pi/extensions/lib/fm-calm-working-ship.ts" "$TMP_ROOT/lib/fm-calm-working-ship.ts"
 cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" "$TMP_ROOT/lib/fm-operational-input.ts"
+cp "$ROOT/.pi/extensions/lib/fm-permission-policy.ts" "$TMP_ROOT/lib/fm-permission-policy.ts"
 ln -s "$PI_PACKAGE_DIR" "$TMP_ROOT/node_modules/@earendil-works/pi-coding-agent"
 ln -s "$PI_PACKAGE_DIR/node_modules/@earendil-works/pi-tui" "$TMP_ROOT/node_modules/@earendil-works/pi-tui"
 ln -s "$PI_PACKAGE_DIR/node_modules/typebox" "$TMP_ROOT/node_modules/typebox"


### PR DESCRIPTION
## Intent

Implement a clean-room, opt-in Claude Code-inspired permission-mode vertical slice for the Firstmate Pi primary, using only public Pi documentation and observable behavior (no leaked or proprietary Anthropic material).

Build an optional Pi extension (.pi/extensions/fm-permission-modes.ts) that defaults to no behavioral change and exposes /fm-permissions off|plan|confirm. off (the default) preserves current Firstmate behavior exactly. plan blocks the built-in edit and write tools and any non-read-only bash command while allowing genuinely read-only inspection (read, ls, grep, find, and read-only bash). confirm requires an interactive approval before the mutating built-in file and shell tools (edit, write, and non-read-only bash); if no UI is available, refuse rather than silently permit. Read-only bash and read-only tools are not prompted in confirm mode.

Mode state is session-persisted through Pi supported extension state (pi.appendEntry), restored on session resume and reload, fresh sessions start off, and it is never written to a global config file. The active mode shows unobtrusively in the Pi footer (cleared when off). No delegation or second LLM planner is added. Operator documentation (docs/permission-modes.md) states plainly that this is an advisory harness control, not an OS sandbox, because Pi extensions execute with user privileges.

Decisions and tradeoffs: pure command classification and mode decisions are factored into a testable module (.pi/extensions/lib/fm-permission-policy.ts) with a conservative bash read-only classifier (allowlist of known read-only commands plus a blocklist of mutating patterns matched anywhere, defaulting unrecognized commands to non-read-only so plan blocks and confirm prompts rather than silently allowing a possible mutation). The gate is additive and never weakens the existing PreToolUse seatbelts or turn-end guard: a no-block decision returns the same empty no-block result shape the existing turnend-guard uses so Pi runs the existing seatbelts afterward, and a block short-circuits before them; approval in confirm approves only this gate and does not bypass those seatbelts. Only the built-in edit, write, and bash tools are gated; custom tools pass through. The extension is scoped to Pi and does not touch the existing watcher or turn-end semantics or other adapters.

Behavioral tests (tests/fm-permission-modes.test.sh) cover default-off compatibility, read-only plan calls, blocked mutation, confirm allow and deny, noninteractive refusal, and malformed command arguments, plus session-persisted state round-trip and an end-to-end proof against the real Pi ExtensionRunner that the gate is additive and never weakens the existing seatbelts. The new TypeScript files are added to the strict no-emit typecheck (tests/fm-pi-primary-types.test.sh). bin/fm-lint.sh and bin/fm-doc-audience-check.sh must pass.

## What Changed

- Add opt-in `/fm-permissions off|plan|confirm` controls for Pi with session persistence, footer status, and default-off compatibility.
- Gate mutating built-in tools using conservative shell-command classification, interactive confirmation, and fail-closed headless behavior without bypassing existing seatbelts.
- Document the advisory safety boundary and add behavioral, typecheck, and pinned-runtime CI coverage.

## Risk Assessment

✅ Low: Captain, the change is well-bounded and the prior classifier, session-state, and mandatory-test defects are now resolved without introducing new material source risks.

## Testing

No baseline test output was supplied; targeted tests passed against Pi 0.84.2, including the real ExtensionRunner additive-seatbelt proof, and the interaction transcript directly demonstrates footer, persistence, prompt, allow, and refusal behavior. No screenshot was captured because this is a terminal Pi extension and the deterministic harness exercised its actual UI API without requiring a credentialed interactive model session; exact displayed status and prompt values are preserved in the JSON artifact. Per phase rules, linting, typechecking/static analysis, and the full suite were not run.

<details>
<summary>Evidence: Permission-mode interaction transcript</summary>

```text
{
  "freshSession": {
    "footer": { "key": "fm-permissions", "value": null },
    "offEdit": { "blocked": false, "result": {} }
  },
  "plan": {
    "footer": { "key": "fm-permissions", "value": "permission: plan" },
    "persisted": { "customType": "fm-permission-modes", "data": { "mode": "plan" } },
    "readOnlyGitStatus": { "blocked": false, "result": {} },
    "mutationTouch": {
      "blocked": true,
      "reason": "plan mode blocks non-read-only shell; use /fm-permissions off to allow mutations. Command: touch demo.txt"
    },
    "customTool": { "blocked": false, "result": {} }
  },
  "confirm": {
    "footer": { "key": "fm-permissions", "value": "permission: confirm" },
    "deniedWrite": { "blocked": true, "reason": "write denied by user in confirm mode" },
    "approvedWrite": { "blocked": false, "result": {} },
    "headlessEdit": {
      "blocked": true,
      "reason": "confirm mode requires interactive approval for the edit tool, but no UI is available; use /fm-permissions off in noninteractive runs"
    },
    "prompts": [
      { "title": "fm-permissions", "prompt": "confirm mode: allow the write tool?" },
      { "title": "fm-permissions", "prompt": "confirm mode: allow the write tool?" }
    ]
  },
  "resumedSession": {
    "footer": { "key": "fm-permissions", "value": "permission: plan" },
    "edit": {
      "blocked": true,
      "reason": "plan mode blocks the edit tool; use /fm-permissions off to allow mutations"
    }
  },
  "notifications": [
    { "message": "permission mode: plan", "level": "info" },
    { "message": "permission mode: confirm", "level": "info" }
  ]
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (2) ✅</summary>

- 🚨 `.pi/extensions/lib/fm-permission-policy.ts:220` - Required intent says the classifier must default unrecognized commands to non-read-only and plan must block every non-read-only bash command. This returns true when only the command prefix matches the allowlist, so mutations such as `find . -delete`, `git branch new`, or `ls; python -c &#34;open(&#39;x&#39;,&#39;w&#39;).write(&#39;x&#39;)&#34;` bypass plan and receive no confirm prompt. Validate the complete command and mutating flags at `isReadOnlyShellCommand`, rather than relying on a leading-command match plus an incomplete blocklist.
- 🚨 `.pi/extensions/fm-permission-modes.ts:146` - Required intent says fresh sessions start off. After plan/confirm is selected, a Pi `session_start` for `/new` with no persisted entry leaves `restored` undefined and never resets `mode`, so the previous session&#39;s mode leaks into the fresh session. Reset to `DEFAULT_PERMISSION_MODE` before restoring entries, or assign `mode = restored ?? DEFAULT_PERMISSION_MODE`.
- 🚨 `tests/fm-permission-modes.test.sh:63` - Required intent calls for behavioral coverage and an end-to-end proof against the real Pi ExtensionRunner. Every test uses `node_guard || return 0`, so when the globally installed Pi package is absent the entire new suite prints skips and exits successfully; the repository CI lane installs tasks-axi but not Pi. Make the required suite fail when Pi is unavailable or provision a pinned Pi package in its CI lane so these assertions actually execute.

🔧 Fix: Harden permission modes and require pinned Pi tests
1 error still open:
- 🚨 `.pi/extensions/lib/fm-permission-policy.ts:142` - Required criterion says “plan blocks ... any non-read-only bash command” and unrecognized commands must default to non-read-only. The revised allowlist still accepts unrestricted arguments: `sed -n &#39;w out&#39; input` writes `out`, `fd -x ./mutator` executes a program, and attached mutating flags such as `sort input -ooutput` or `date -s@0` evade the blocklist. These calls bypass both plan blocking and confirm prompting. At `isReadOnlyShellCommand`, validate each allowed command’s complete argv/options or remove commands with write/exec capabilities instead of relying on an incomplete mutation blocklist.

🔧 Fix: Validate complete shell argv before read-only approval
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `Inspected the target diff and focused permission-mode test surface against the authoritative intent.`
- <code>Installed CI-pinned Pi 0.84.2 into a disposable worktree directory, then ran `FM_PI_PACKAGE_DIR=&#34;$PWD/.tmp-no-mistakes/pi/node_modules/@earendil-works/pi-coding-agent&#34; tests/fm-permission-modes.test.sh`.</code>
- <code>Ran a `node --input-type=module` interaction harness against the real extension, exercising fresh-session off behavior, plan read/mutation decisions, custom-tool passthrough, confirm allow/deny, headless refusal, footer state, persistence, and resume restoration.</code>
- `Validated the generated JSON evidence structure, removed the disposable Pi installation, and confirmed the worktree remained clean.`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
