### PR TITLE
feat(cursor): enable optimized auto worker dispatch

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -131,7 +131,7 @@ The supported launch-profile flags below are verified locally; each row records 
 | pi / pi-signed | `--model <model>` | `--thinking <low\|medium\|high\|xhigh\|max>` | Verified 2026-07-27 on Pi and pi-signed 0.82.0. Both expose the same accepted thinking levels and completed the same model-qualified max-thinking smoke. |
 | opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |
 | kimi | `--model <model>` | none | Verified 2026-07-25 on Kimi Code CLI 0.29.1. |
-| cursor | `--model <model>` | none | Verified 2026-08-11 on Cursor Agent CLI 2026.08.11-e8db854. No effort flag exists, so firstmate records the requested effort in task metadata and omits it from the launch. Validate ids against `cursor-agent --list-models` rather than assuming a low/medium/high family: the live catalog carries only `-high` Grok ids. |
+| cursor | `--model <model>` | none | Verified on Cursor Agent CLI; the cursor section owns model validation, including the parameterized auto exception, and no separate effort flag exists. |
 | muse | `--model <model>` | `--reasoning-effort <low\|medium\|high\|xhigh>`, and `ultra` only for an explicit `max` | Verified 2026-08-05 on Muse Code 0.1.0-R708.1. The flag accepts `none\|minimal\|low\|medium\|high\|xhigh\|ultra` and defaults to `high`. `ultra` is muse's max-class level, so it is reachable only through an explicit captain `max`, never from the generic fallback; `none` and `minimal` sit below the shared vocabulary and stay unreachable. |
 
 The concrete `harness` field owns adapter identity independently of the model provider: `harness=pi` with `model=xai/grok-*` is Pi using xAI, not `harness=grok`, and does not require Grok CLI login; `harness=grok` remains the standalone Grok Build CLI adapter.
@@ -151,7 +151,7 @@ Use the discovery surface in the current authenticated environment because suppo
 | pi / pi-signed | Run the selected executable as `<executable> --list-models [search]`; Pi's installed `docs/models.md` owns how built-in, extension-registered, and custom provider/model entries reach that list. |
 | grok | Run `grok models`, which lists the models available to the current Grok installation and account. |
 | kimi | Run `kimi provider list --json`, which lists the current provider and model configuration. |
-| cursor | Run `cursor-agent --list-models` (or the legacy `agent --list-models`), which lists the ids available to the current Cursor account. `cursor` is not the CLI name. |
+| cursor | Run `cursor-agent --list-models` (or the legacy `agent --list-models`) and apply the parameterized auto exception owned by the cursor section; `cursor` is not the CLI name. |
 
 For an unfamiliar harness or model namespace, establish support and provider identity from that harness's authoritative CLI help, model listing, or current documentation rather than guessing from a name or prefix.
 A listing that reaches the account and does not contain the model is concrete evidence the model is unsupported: block that candidate and quote the result.
@@ -159,7 +159,7 @@ A discovery surface you could not reach establishes nothing; report that as unce
 
 When a requested effort value is outside the harness-specific accepted set, `fm-spawn` records the requested `effort=` in meta but emits no effort flag for that harness.
 This preserves launch success instead of passing a known-bad value.
-For Cursor, select the intended reasoning class through a model id the account's own `--list-models` actually returns, and leave the separate effort axis unset.
+For Cursor, follow the cursor section's model-validation contract and leave the separate effort axis unset.
 
 ## no-mistakes skill invocation
 
@@ -371,7 +371,7 @@ Do not confuse `harness=cursor` using a `cursor-grok-4.5-*` model with `harness=
 |---|---|
 | Binary | Resolved through `fm_cursor_resolve_binary` (bin/fm-cursor-lib.sh). `cursor` is NOT the CLI: the installed names are `cursor-agent` and the legacy alias `agent`, both symlinked into `~/.local/share/cursor-agent/versions/<version>/cursor-agent`. The STABLE launcher is used, never the versioned target, which the CLI replaces on its own auto-update. |
 | Launch | A positional prompt with `--trust`, `--yolo`, `--model <model>` when selected, and `--workspace <absolute-task-worktree>`, behind `env -u` of the foreign primary markers. |
-| Models | Validate against `cursor-agent --list-models` for the current account rather than a fixed list; that list has already drifted once. The live catalog contains only `-high` Grok ids (`cursor-grok-4.5-high`, `cursor-grok-4.5-high-fast`) and several `xhigh` ids, so an assumed low/medium Grok id is invalid. |
+| Models | The model-validation and auto-optimization contract immediately below owns this behavior. |
 | Busy state | Its own per-conversation transcript, folded on demand by `bin/fm-busy-lib.sh` (source `cursor-transcript`). Each turn is bracketed by a `role:user` open and a typed `turn_ended` close covering `success` and `aborted`, so unlike Claude's `Stop` hook this source covers manual interruption. Nothing is armed and no record is ever seeded. Backend-agnostic, and confirmed identical on tmux and Herdr. |
 | Exit command | `/exit` |
 | Interrupt | Single Escape. The composer returns to its placeholder rather than the cancelled prompt, so NO clear key is needed (unlike muse). `bin/fm-control-lib.sh` claims no cancellation acknowledgement: the aborted transcript close appeared within seconds in some runs and not within twenty in others. |
@@ -384,6 +384,14 @@ Do not confuse `harness=cursor` using a `cursor-grok-4.5-*` model with `harness=
 | Composer | A BARE row whose prompt glyph is `→` (U+2192); no border. Idle placeholders are `Plan, search, build anything` fresh and `Add a follow-up` after a turn, drawn de-emphasised so a styled capture separates them from real typed text. |
 | Primary hooks | Tracked project-scope `.cursor/hooks.json` registers `stop`, `sessionStart`, and two `preToolUse` seatbelts, all anchored through `$CURSOR_PROJECT_DIR`. Cursor ALSO loads `<project>/.claude/settings.json`, so the tracked Claude entries stand down on a Cursor-delivered payload; `docs/turnend-guard.md` owns that predicate. |
 | Primary limits | `stop` does not fire in headless `cursor-agent -p`. `preCompact` is deliberately unregistered because it cannot inject context, so a Cursor primary does not re-emit its digest after a compaction; that surface is deferred to a follow-up. Project hooks need `--trust`. |
+
+**Cursor model validation and auto optimization.**
+Validate ordinary model ids against `cursor-agent --list-models` for the current account because that catalog has already drifted.
+Cursor's catalog still reports only plain `auto` even though the account accepts the parameterized auto optimization ids below, so `fm_cursor_catalog_has_model` treats that plain entry as evidence for exactly those ids and continues to reject unknown ids.
+The standing worker default is Auto Balance, which maps to `auto-smart[optimize_for=balanced]`.
+An explicit per-task captain override named `cost` maps to `auto-smart[optimize_for=cost]`.
+An explicit per-task captain override named `intelligence` maps to `auto-smart[optimize_for=intelligence]`.
+Never infer Cost or Intelligence from task difficulty because only those named overrides select them.
 
 **Detection ordering is load-bearing.**
 Cursor does NOT clear an inherited `CLAUDECODE`, so a cursor worker under a claude primary carries both markers and whichever is tested first wins.

--- a/bin/fm-cursor-lib.sh
+++ b/bin/fm-cursor-lib.sh
@@ -129,6 +129,9 @@ fm_cursor_catalog_has_model() {  # <model>
   local wanted=$1
   awk -v wanted="$wanted" '
     BEGIN { ansi = sprintf("%c\\[[0-9;]*[A-Za-z]", 27) }
+    function is_parameterized_auto(model) {
+      return model ~ /^auto-smart\[optimize_for=(balanced|cost|intelligence)\]$/
+    }
     {
       line = $0
       gsub(ansi, "", line)
@@ -137,7 +140,7 @@ fm_cursor_catalog_has_model() {  # <model>
       id = substr(line, 1, separator - 1)
       sub(/^[[:space:]]+/, "", id)
       sub(/[[:space:]]+$/, "", id)
-      if (id == wanted) found = 1
+      if (id == wanted || (id == "auto" && is_parameterized_auto(wanted))) found = 1
     }
     END { exit found ? 0 : 1 }
   '

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -556,17 +556,41 @@ test_cursor_threads_model_workspace_and_omits_effort_axis() {
   pass "cursor receives its model-qualified reasoning class and exact task workspace"
 }
 
+test_cursor_accepts_parameterized_auto_from_plain_auto_catalog() {
+  local optimize_for model rec id out status launch
+
+  for optimize_for in balanced cost intelligence; do
+    model="auto-smart[optimize_for=$optimize_for]"
+    id="profile-cursor-auto-$optimize_for"
+    rec=$(make_spawn_case "$id" cursor "$id")
+    read_case_record "$rec"
+
+    FM_TEST_CURSOR_MODELS='Available models\nauto - Auto' \
+      out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+        --model "$model")
+    status=$?
+    expect_code 0 "$status" "cursor spawn should accept the $optimize_for auto optimization"
+    launch=$(cat "$LAUNCH_LOG")
+    assert_contains "$launch" "--model '$model'" \
+      "cursor launch did not preserve the $optimize_for auto optimization"
+    assert_meta_profile "$HOME_DIR/state/$id.meta" cursor "$model" default
+  done
+
+  pass "cursor accepts every supported auto optimization from its plain auto catalog entry"
+}
+
 test_cursor_refuses_model_absent_from_live_catalog() {
   local rec id out status
   id=profile-cursor-unsupported-z6d
   rec=$(make_spawn_case profile-cursor-unsupported cursor "$id")
   read_case_record "$rec"
 
-  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
-    --model cursor-grok-4.5)
+  FM_TEST_CURSOR_MODELS='Available models\nauto - Auto' \
+    out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+      --model cursor-junk-model)
   status=$?
   expect_code 1 "$status" "cursor spawn should refuse a model absent from a successful catalog"
-  assert_contains "$out" "Cursor model 'cursor-grok-4.5' is not available" \
+  assert_contains "$out" "Cursor model 'cursor-junk-model' is not available" \
     "cursor model refusal did not identify the unavailable model"
   assert_contains "$out" "--list-models" \
     "cursor model refusal did not tell the caller how to find valid ids"
@@ -844,6 +868,7 @@ test_grok_threads_model_and_reasoning_effort
 test_grok_omits_invalid_max_reasoning_effort
 test_grok_omits_invalid_xhigh_reasoning_effort
 test_cursor_threads_model_workspace_and_omits_effort_axis
+test_cursor_accepts_parameterized_auto_from_plain_auto_catalog
 test_cursor_refuses_model_absent_from_live_catalog
 test_cursor_failed_catalog_probe_does_not_block_spawn
 test_opencode_threads_model_and_ignores_effort_axis


### PR DESCRIPTION
## Summary
- accept Cursor's balanced, cost, and intelligence parameterized auto models when the live catalog exposes plain `auto`
- preserve live-catalog rejection for unknown model ids
- document Auto Balance as the standing default and require explicit named overrides for Cost or Intelligence

## Test plan
- [x] `bash tests/fm-spawn-dispatch-profile.test.sh`
- [x] `bin/fm-lint.sh bin/fm-cursor-lib.sh tests/fm-spawn-dispatch-profile.test.sh`
- [x] `bin/fm-doc-audience-check.sh`
- [x] `git diff --check`

## Notes
- The full no-argument lint reached the workflow check but could not run it because actionlint 1.7.12 is not installed; no workflow files changed.