### PR TITLE
fix(bin): stop claude spawn from overwriting a project's .claude/settings.local.json

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -184,6 +184,7 @@ The shared symptom is a healthy-looking pane with no work in progress, so each a
 
 | Fact | Value |
 |---|---|
+| Crew hook delivery | `claude --settings <state/<id>.claude-settings.json>`, never a file inside the worktree. Claude merges those hooks with the project's own settings instead of replacing them (live-verified 2026-08-20 on 2.1.237; [`supervision.md`](../../../docs/verification/supervision.md) owns the evidence and refresh command). |
 | Busy state | Owned lifecycle hooks: `UserPromptSubmit` opens a turn, while `Stop`, `StopFailure`, and `SessionEnd` close it; because Claude fires no hook for a manual interrupt, `bin/fm-control.sh interrupt` reports only delivered keys and the verified endpoint or live agent, publishes no idle event, makes no cancellation claim, and leaves adapter-observed state unchanged, so a mid-turn worker typically remains busy via `claude-hook`. |
 | Exit command | `/exit` |
 | Interrupt | single Escape |
@@ -203,7 +204,7 @@ That styled capture is internal to the boolean detector only.
 `fm-peek` and every other human or LLM-facing capture path stays plain `tmux capture-pane` with no escape codes.
 
 **Primary-session guard fact (verified 2026-07-04, Claude Code 2.1.201; preserved 2026-07-08, Claude Code 2.1.204; Stop-owned auto-arm revalidated 2026-07-24, Claude Code 2.1.219).**
-This is separate from the per-task crewmate turn-end hook above (that one just `touch`es a marker file in a task's own `.claude/settings.local.json`).
+This is separate from the per-task crewmate turn-end hook above, which `touch`es a marker file from hooks `fm-spawn` hands the worker through `claude --settings <state/<id>.claude-settings.json>`; firstmate writes no claude settings file into a worktree, so a project's own `.claude/settings.local.json` is never touched.
 The firstmate PRIMARY's own `.claude/settings.json` registers two Stop hooks: `bin/fm-turnend-guard.sh --claude` and the Stop-owned auto-arm `bin/fm-claude-stop-autoarm.sh` (`asyncRewake: true`, `timeout: 28800`), and exiting the guard with status 2 plus stderr reliably forces the model to continue.
 Claude Code's stdin payload to a Stop hook carries a `stop_hook_active` boolean that is `true` when the current stop attempt follows ANY stop-hook-driven continuation, including `asyncRewake` rewakes; the primary guard therefore ignores it in `--claude` mode and uses the cooperative claim/epoch check plus a bounded re-block budget instead, while the codex-mode default still treats it as a one-block loop guard.
 A project-level `.claude/settings.json` only takes effect when Claude Code's project root is that exact directory - it does not walk up from a subdirectory looking for one, so firstmate launches the primary from the repo root.
@@ -528,7 +529,7 @@ Both halves of the fold are trusted with no opt-in: an open run reads `busy`, a 
 
 muse fans out to its own sub-agents, but worktree isolation is per-child and opt-in: `--subagent-worktree-isolation` is a compatibility flag whose capability "defaults on" while "omission stays shared", and no nested git worktree appeared in any verified lab run.
 Firstmate deliberately does NOT exclude any muse path from `fm-teardown.sh`'s uncommitted-work check.
-Firstmate writes `.claude/settings.local.json` itself, which is why that path is excluded for claude; it does not write muse's, so a nested muse worktree or leftover scratch is the agent's own work product and MUST be able to refuse teardown.
+Firstmate writes no harness file into a worktree for claude either - its hooks ride `--settings` from `state/` - so nothing under `.claude/` is excluded from that check any more; a nested muse worktree or leftover scratch is likewise the agent's own work product and MUST be able to refuse teardown.
 A teardown refusal naming muse scratch is therefore correct behavior: inspect it rather than forcing past it.
 
 ### Maturity caveats

--- a/bin/fm-control-lib.sh
+++ b/bin/fm-control-lib.sh
@@ -204,7 +204,7 @@ fm_control_harness_wiring_paths() {  # <harness> <worktree> <state-dir> <id>
   local harness=${1-} wt=${2-} state=${3-} id=${4-}
   [ -n "$wt" ] && [ -n "$state" ] && [ -n "$id" ] || return 1
   case "$harness" in
-    claude) printf '%s\n' "$wt/.claude/settings.local.json" ;;
+    claude) printf '%s\n' "$state/$id.claude-settings.json" ;;
     opencode) printf '%s\n' "$wt/.opencode/plugins/fm-busy-state.js" ;;
     pi|pi-signed) printf '%s\n' "$state/$id.pi-ext.ts" ;;
     grok)

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -161,7 +161,11 @@
 #     __OPINPUT__   absolute path to the canonical operational-input encoder
 #     __WORKTREE__  absolute path to the task worktree
 #     __CURSORBIN__ resolved, cursor-verified executable for a cursor launch
+#     __CLAUDESETTINGS__ absolute path to state/<id>.claude-settings.json for a claude crewmate or scout
 # Verified per-harness turn-end hooks are installed automatically where enabled; some live outside the worktree.
+# claude uses state/<id>.claude-settings.json handed to the launch through --settings,
+# so no file is written into the worktree; claude merges those hooks with the
+# project's own settings instead of replacing them.
 # Kimi uses one surgically installed Firstmate region in $HOME/.kimi-code/config.toml,
 # a firstmate-owned global hook and registry, and a gitignored per-task pointer.
 # grok uses a firstmate-owned global hook under ${GROK_HOME:-$HOME/.grok}/hooks
@@ -1111,7 +1115,18 @@ launch_template() {
     # does NOT suppress the interactive ghost text (verified empirically), so the env
     # var is the correct control. The dim-aware composer reader in fm-tmux-lib.sh is
     # the defense-in-depth backstop for any pane this flag cannot reach.
-    claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    # --settings carries the semantic busy-state hooks from a firstmate-owned file
+    # in state/, so nothing is ever written inside the worktree - the same
+    # keep-it-out-of-the-project reasoning grok, kimi, and pi already follow.
+    # Claude merges --settings hooks with the project's own settings rather than
+    # replacing them, so a project's committed hooks keep firing (verified below).
+    # A secondmate arms no busy contract, so no settings file exists for it and the
+    # flag is omitted rather than pointed at a missing path.
+    claude)
+      printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions '
+      [ "$kind" = secondmate ] || printf '%s' '--settings __CLAUDESETTINGS__ '
+      printf '%s' '__MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+      ;;
     codex)
       if [ "$kind" = secondmate ]; then
         printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
@@ -2348,17 +2363,24 @@ if [ "$KIND" != secondmate ]; then
       # the turn-ended NOTIFICATION touch for the watcher. Every
       # hook command tolerates a refused event (|| true) so a stale-gen writer
       # can never break Claude's own lifecycle.
-      mkdir -p "$WT/.claude"
+      #
+      # The settings file lives in state/, NOT in the worktree. A worktree write
+      # would have to land on .claude/settings.local.json, a path the PROJECT owns
+      # and frequently tracks; firstmate wrote it wholesale, destroying the
+      # project's own settings for the life of the task and leaving a tracked file
+      # permanently modified, which then blocked teardown. --settings is Claude's
+      # own supported way to load additional settings from an arbitrary path, and
+      # its hooks merge with (never replace) the project's own.
+      claude_settings="$STATE_REAL/$ID.claude-settings.json"
       busy_cmd_prefix="$(shell_quote "$FM_ROOT/bin/fm-busy-event.sh") apply $(shell_quote "$STATE_REAL") $(shell_quote "$ID")"
       busy_suffix="--gen $(shell_quote "$BUSY_GEN") --source claude-hook"
       j_submit=$(json_escape "$busy_cmd_prefix busy $busy_suffix --event user-prompt-submit 2>/dev/null || true")
       j_stop=$(json_escape "touch $(shell_quote "$TURNEND"); $busy_cmd_prefix idle $busy_suffix --event stop 2>/dev/null || true")
       j_stopfail=$(json_escape "$busy_cmd_prefix idle $busy_suffix --event stop-failure 2>/dev/null || true")
       j_sessionend=$(json_escape "$busy_cmd_prefix idle $busy_suffix --event session-end 2>/dev/null || true")
-      cat > "$WT/.claude/settings.local.json" <<EOF
+      cat > "$claude_settings" <<EOF
 {"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"$j_submit"}]}],"Stop":[{"hooks":[{"type":"command","command":"$j_stop"}]}],"StopFailure":[{"hooks":[{"type":"command","command":"$j_stopfail"}]}],"SessionEnd":[{"hooks":[{"type":"command","command":"$j_sessionend"}]}]}}
 EOF
-      exclude_path '.claude/settings.local.json'
       ;;
     opencode*)
       mkdir -p "$WT/.opencode/plugins"
@@ -2708,6 +2730,7 @@ fi
 sq_brief=$(shell_quote "$BRIEF")
 sq_turnend=$(shell_quote "$TURNEND")
 sq_piext=$(shell_quote "$STATE/$ID.pi-ext.ts")
+sq_claudesettings=$(shell_quote "$STATE_REAL/$ID.claude-settings.json")
 sq_piturnend=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-turnend-guard.ts")
 sq_piwatch=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts")
 sq_opinput=$(shell_quote "$FM_ROOT/bin/fm-operational-input.sh")
@@ -2719,6 +2742,7 @@ LAUNCH=${LAUNCH//__EFFORTFLAG__/$EFFORTFLAG}
 LAUNCH=${LAUNCH//__BRIEF__/$sq_brief}
 LAUNCH=${LAUNCH//__TURNEND__/$sq_turnend}
 LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}
+LAUNCH=${LAUNCH//__CLAUDESETTINGS__/$sq_claudesettings}
 LAUNCH=${LAUNCH//__PITURNEND__/$sq_piturnend}
 LAUNCH=${LAUNCH//__PIWATCH__/$sq_piwatch}
 LAUNCH=${LAUNCH//__OPINPUT__/$sq_opinput}

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1134,6 +1134,21 @@ teardown_treehouse_return() {
   return 1
 }
 
+# One-time migration: before 2026-08-20 the claude spawn wrote its hooks into
+# <worktree>/.claude/settings.local.json and excluded that path in the repo's
+# info/exclude, so a leftover from a task already under way at update time stays
+# invisible to git status and its stale hooks would fire for the NEXT task in a
+# pooled worktree. Remove ONLY a file firstmate provably wrote: untracked, and
+# carrying firstmate's own busy-event command. A tracked or project-authored file
+# is never touched - that path belongs to the project.
+remove_legacy_claude_settings() {  # <worktree>
+  local wt=$1 f="$1/.claude/settings.local.json"
+  [ -f "$f" ] || return 0
+  git -C "$wt" ls-files --error-unmatch -- .claude/settings.local.json >/dev/null 2>&1 && return 0
+  grep -q 'fm-busy-event.sh' "$f" 2>/dev/null || return 0
+  rm -f "$f"
+}
+
 validate_worktree_teardown_safety() {
   local dirty_raw dirty unpushed_raw unpushed DEFAULT unmerged_raw unmerged branch
   [ -d "$WT" ] || return 0
@@ -1150,7 +1165,11 @@ validate_worktree_teardown_safety() {
     echo "Restore the git index state, or get the captain's explicit OK to discard, then --force." >&2
     return 1
   fi
-  dirty=$(printf '%s\n' "$dirty_raw" | grep -vE '^\?\? (\.claude/|\.fm-(grok|kimi)-turnend$)' | head -1 || true)
+  # Only firstmate's OWN per-task worktree artifacts are ignored. .claude/ is
+  # deliberately NOT among them: firstmate writes no claude file into a worktree
+  # (its hooks ride --settings from state/), so anything there is the project's or
+  # the worker's and must be able to refuse teardown.
+  dirty=$(printf '%s\n' "$dirty_raw" | grep -vE '^\?\? \.fm-(grok|kimi)-turnend$' | head -1 || true)
 
   if ! unpushed_raw=$(git -C "$WT" log --oneline HEAD --not --remotes -- 2>/dev/null); then
     if worktree_safety_blocked_by_lock "commits not on a remote"; then
@@ -2226,13 +2245,15 @@ cleanup_firstmate_home_children() {
     elif [ "$child_backend" = orca ]; then
       if [ -n "$child_wt" ] && [ -d "$child_wt" ]; then
         validate_child_worktree_for_removal "$child_wt" "$child_proj" >/dev/null || return 1
-        rm -f "$child_wt/.claude/settings.local.json" "$child_wt/.opencode/plugins/fm-turn-end.js" \
+        remove_legacy_claude_settings "$child_wt"
+        rm -f "$child_wt/.opencode/plugins/fm-turn-end.js" \
           "$child_wt/.fm-grok-turnend" "$child_wt/.fm-kimi-turnend"
       fi
       fm_backend_remove_worktree "$child_backend" "$child_orca_worktree_id" || return 1
     elif [ -n "$child_wt" ] && [ -d "$child_wt" ]; then
       validate_child_worktree_for_removal "$child_wt" "$child_proj" >/dev/null || return 1
-      rm -f "$child_wt/.claude/settings.local.json" "$child_wt/.opencode/plugins/fm-turn-end.js" \
+      remove_legacy_claude_settings "$child_wt"
+      rm -f "$child_wt/.opencode/plugins/fm-turn-end.js" \
         "$child_wt/.opencode/plugins/fm-busy-state.js" \
         "$child_wt/.fm-grok-turnend" "$child_wt/.fm-kimi-turnend"
       if [ -n "$child_proj" ] && [ -d "$child_proj" ] && command -v treehouse >/dev/null 2>&1; then
@@ -2260,6 +2281,7 @@ cleanup_firstmate_home_children() {
     status_retire_presentation_task "$sub_state" "$child_id" || return 1
     rm -f "$sub_state/$child_id.turn-ended" \
       "$sub_state/$child_id.meta" "$sub_state/$child_id.pi-ext.ts" \
+      "$sub_state/$child_id.claude-settings.json" \
       "$sub_state/$child_id.grok-turnend-token" "$sub_state/$child_id.kimi-turnend-token" \
       "$sub_state/$child_id.muse-session" "$sub_state/$child_id.muse-session-current" \
       "$sub_state/$child_id.cursor-session"
@@ -2420,7 +2442,8 @@ if [ "$BACKEND" = orca ] && [ "$KIND" != secondmate ]; then
         git -C "$WT" branch -D "$branch" >/dev/null 2>&1 || true
       fi
     fi
-    rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" \
+    remove_legacy_claude_settings "$WT"
+    rm -f "$WT/.opencode/plugins/fm-turn-end.js" \
       "$WT/.opencode/plugins/fm-busy-state.js" \
       "$WT/.fm-grok-turnend" "$WT/.fm-kimi-turnend"
   fi
@@ -2434,7 +2457,8 @@ elif [ -d "$WT" ] && [ "$KIND" != secondmate ]; then
     fi
   fi
   # Remove our hook file so a reused pool worktree cannot fire signals for a dead task.
-  rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" \
+  remove_legacy_claude_settings "$WT"
+  rm -f "$WT/.opencode/plugins/fm-turn-end.js" \
     "$WT/.fm-grok-turnend" "$WT/.fm-kimi-turnend"
   # Kills remaining processes in the worktree (including the agent), resets, returns
   # to pool. treehouse resolves the pool from the working directory, so run it from
@@ -2539,7 +2563,8 @@ remove_pr_poll_artifacts "$STATE" "$ID" || exit 1
 retire_busy_state "$STATE" "$ID" "$BUSY_GEN" || exit 1
 status_retire_presentation_task "$STATE" "$ID" || exit 1
 rm -f "$STATE/$ID.turn-ended" "$STATE/$ID.meta" \
-  "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token" \
+  "$STATE/$ID.pi-ext.ts" "$STATE/$ID.claude-settings.json" \
+  "$STATE/$ID.grok-turnend-token" \
   "$STATE/$ID.kimi-turnend-token" "$STATE/$ID.muse-session" \
   "$STATE/$ID.muse-session-current" "$STATE/$ID.cursor-session" \
   "$STATE/$ID.control-relaunch" "$STATE/$ID.control-relaunch.meta-prior" \

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -187,7 +187,7 @@ family_for_basename() {
     fm-cmux-claude-composer-live-e2e.test.sh|\
     fm-composer-matrix-live-e2e.test.sh|\
     fm-codex-continuity-live-e2e.test.sh|fm-grok-continuity-live-e2e.test.sh|\
-    fm-cursor-primary-live-e2e.test.sh|\
+    fm-cursor-primary-live-e2e.test.sh|fm-claude-settings-live-e2e.test.sh|\
     fm-grok-stop-live-e2e.test.sh|fm-harness-liveness-drift-live-e2e.test.sh|\
     fm-muse-signals-live-e2e.test.sh|\
     fm-herdr-version-floor-live-e2e.test.sh|\
@@ -949,7 +949,15 @@ families_for_changed_path() {
       printf '%s\n' pure-contract-unit
       printf '%s\n' live-harness-optin
       ;;
-    bin/fm-spawn.sh|bin/fm-send.sh|bin/fm-harness.sh|\
+    bin/fm-spawn.sh)
+      # The claude branch rests on a vendor CLI fact - that --settings loads hooks
+      # from outside the workspace and merges them with the project's own - so a
+      # spawn change re-selects the live guard alongside the portable families.
+      printf '%s\n' backend-dispatch
+      printf '%s\n' pure-contract-unit
+      printf '%s\n' live-harness-optin
+      ;;
+    bin/fm-send.sh|bin/fm-harness.sh|\
     bin/fm-peek.sh|bin/fm-composer*)
       printf '%s\n' backend-dispatch
       printf '%s\n' pure-contract-unit

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -211,6 +211,9 @@ Hooks from `--settings` are therefore MERGED with the project's own rather than 
 
 This replaces the pre-2026-08-20 behavior, where the spawn wrote `<worktree>/.claude/settings.local.json` wholesale.
 On a project that tracks that path, the spawn destroyed its committed contents for the life of the task and left the tracked file permanently modified, which then blocked `bin/fm-teardown.sh` and re-escalated the finished task on every watcher pass.
+`bin/fm-teardown.sh` removes a leftover pre-fix file only when it is untracked AND carries firstmate's own `fm-busy-event.sh` command, so a tracked or project-authored file is never touched.
+One residue is deliberately left: the old spawn also appended `.claude/settings.local.json` to each project's shared `.git/info/exclude`, which outlives teardown and keeps a project's OWN untracked settings file hidden from `git status` repo-wide.
+It is not auto-removed because nothing proves firstmate rather than the operator wrote a given exclude line; remove it by hand if that repo needs its settings file visible.
 
 Refresh command, opt-in and self-skipping, which fails naming the installed version:
 

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -197,6 +197,27 @@ In this 2026-07-28 Codex 0.145.0 semantic-busy probe, Firstmate-written lifecycl
 Codex also exposes no `StopFailure` hook, so an API-error turn end would need separate coverage even after hook discovery works.
 The app-server protocol schema does define the required lifecycle (`turn/started`, plus a `turn/completed` status of `completed`, `interrupted`, `failed`, or `inProgress`), so the gate is a reachability problem rather than a protocol gap.
 
+### Claude hooks load from outside the workspace, 2026-08-20
+
+Claude's per-task busy hooks are delivered through `claude --settings <file>` and live in `state/<id>.claude-settings.json`, so `fm-spawn` writes nothing into the project worktree.
+Verified on 2026-08-20 against Claude Code 2.1.237 in a throwaway workspace holding its own `.claude/settings.local.json` with a `Stop` hook of its own.
+
+```sh
+claude --dangerously-skip-permissions --settings /tmp/fmprobe-external.json -p "say hi"
+```
+
+All three markers were created: the project `Stop` hook, and the `Stop` and `UserPromptSubmit` hooks supplied only through `--settings`.
+Hooks from `--settings` are therefore MERGED with the project's own rather than replacing them, and the project's settings file was byte-identical after the run.
+
+This replaces the pre-2026-08-20 behavior, where the spawn wrote `<worktree>/.claude/settings.local.json` wholesale.
+On a project that tracks that path, the spawn destroyed its committed contents for the life of the task and left the tracked file permanently modified, which then blocked `bin/fm-teardown.sh` and re-escalated the finished task on every watcher pass.
+
+Refresh command, opt-in and self-skipping, which fails naming the installed version:
+
+```sh
+FM_CLAUDE_SETTINGS_LIVE_E2E=1 tests/fm-claude-settings-live-e2e.test.sh
+```
+
 Deterministic entry points:
 
 ```sh

--- a/tests/fm-busy-adapter-wiring.test.sh
+++ b/tests/fm-busy-adapter-wiring.test.sh
@@ -30,7 +30,10 @@ esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
   list-windows) exit 0 ;;
-  has-session|new-session|new-window|kill-window|send-keys) exit 0 ;;
+  send-keys)
+    [ -z "${FM_FAKE_TMUX_LOG:-}" ] || printf '%s\n' "$*" >> "$FM_FAKE_TMUX_LOG"
+    exit 0 ;;
+  has-session|new-session|new-window|kill-window) exit 0 ;;
 esac
 exit 0
 SH
@@ -263,7 +266,7 @@ test_claude_hooks_semantic_lifecycle() {
   out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id" "$PROJ_DIR")
   expect_code 0 $? "claude spawn should succeed: $out"
   state="$HOME_DIR/state"
-  settings="$WT_DIR/.claude/settings.local.json"
+  settings="$state/$id.claude-settings.json"
   assert_present "$settings" "claude spawn did not write hook settings"
   jq -e . "$settings" >/dev/null || fail "claude hook settings are not valid JSON"
   for ev in UserPromptSubmit Stop StopFailure SessionEnd; do
@@ -301,13 +304,65 @@ test_claude_hooks_stale_incarnation_harmless() {
   out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id" "$PROJ_DIR")
   expect_code 0 $? "claude spawn should succeed: $out"
   state="$HOME_DIR/state"
-  settings="$WT_DIR/.claude/settings.local.json"
+  settings="$state/$id.claude-settings.json"
   "$ROOT/bin/fm-busy-event.sh" arm "$state" "$id" >/dev/null
   run_claude_hook "$settings" UserPromptSubmit \
     || fail "a stale-gen hook must still exit 0 so Claude's lifecycle is never broken"
   out=$(classify claude "$id" "$state")
   [ "$out" = "busy fm-spawn" ] || fail "a stale-gen hook event must not change state, got '$out'"
   pass "claude hook events from a superseded incarnation are rejected without breaking the hook"
+}
+
+# Regression (observed 2026-08-20 on a real project): the claude branch used to
+# write <worktree>/.claude/settings.local.json WHOLESALE. On a project that tracks
+# that file, the spawn destroyed its committed contents for the life of the task
+# and left the tracked file permanently modified, which then blocked teardown and
+# produced an endless stale-wake loop. firstmate now writes no file into the
+# worktree at all: the hooks ride claude's own --settings flag from state/.
+test_claude_spawn_never_touches_the_projects_settings() {
+  local rec id=busy-cl-3 out state settings tracked before after launch_log
+  rec=$(make_spawn_case claude-project-settings claude "$id")
+  read_case_record "$rec"
+
+  # A project that TRACKS .claude/settings.local.json with real content, landed on
+  # the default branch so the spawn's base refresh brings it into the worktree.
+  mkdir -p "$PROJ_DIR/.claude"
+  cat > "$PROJ_DIR/.claude/settings.local.json" <<'JSON'
+{"env":{"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS":"1"},"permissions":{"allow":["Bash(npm test)"]},"enabledPlugins":{"context7":true}}
+JSON
+  git -C "$PROJ_DIR" add -f .claude/settings.local.json
+  git -C "$PROJ_DIR" -c user.email=t@t -c user.name=t commit -q -m "project settings"
+  git -C "$PROJ_DIR" push -q origin HEAD
+  before=$(cat "$PROJ_DIR/.claude/settings.local.json")
+  tracked="$WT_DIR/.claude/settings.local.json"
+
+  launch_log="$CASE_DIR/launch.log"
+  out=$(FM_FAKE_TMUX_LOG="$launch_log" run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id" "$PROJ_DIR")
+  expect_code 0 $? "claude spawn should succeed: $out"
+  state="$HOME_DIR/state"
+
+  assert_present "$tracked" "the project's tracked settings must be present in the worktree"
+  after=$(cat "$tracked")
+  [ "$after" = "$before" ] \
+    || fail "the project's tracked settings must survive the spawn byte for byte, got: $after"
+  [ -z "$(git -C "$WT_DIR" status --porcelain)" ] \
+    || fail "the spawn must leave the worktree clean, got: $(git -C "$WT_DIR" status --porcelain)"
+  [ ! -e "$WT_DIR/.claude/settings.json" ] \
+    || fail "the spawn must not write any other claude settings file into the worktree"
+
+  # The hooks are armed all the same, from a firstmate-owned file outside the worktree.
+  settings="$state/$id.claude-settings.json"
+  assert_present "$settings" "claude spawn did not write its own hook settings into state/"
+  assert_grep "--settings '$(cd "$state" && pwd -P)/$id.claude-settings.json'" "$launch_log" \
+    "the launch command must load the hooks through claude's own --settings flag"
+  assert_no_grep "$WT_DIR/.claude" "$launch_log" \
+    "the launch command must not reference any claude settings inside the worktree"
+  rm -f "$state/$id.turn-ended"
+  run_claude_hook "$settings" Stop || fail "Stop hook command failed"
+  [ -f "$state/$id.turn-ended" ] || fail "the out-of-worktree hook no longer touches the marker"
+  out=$(classify claude "$id" "$state")
+  [ "$out" = "idle claude-hook" ] || fail "Stop must classify 'idle claude-hook', got '$out'"
+  pass "a claude spawn arms its hooks without writing anything into the project worktree"
 }
 
 test_codex_unverified_until_a_semantic_source_exists() {
@@ -349,6 +404,7 @@ test_kimi_and_grok_install_no_unverified_wiring
 test_opencode_plugin_semantic_lifecycle
 test_claude_hooks_semantic_lifecycle
 test_claude_hooks_stale_incarnation_harmless
+test_claude_spawn_never_touches_the_projects_settings
 test_codex_unverified_until_a_semantic_source_exists
 
 echo "all fm-busy-adapter-wiring tests passed"

--- a/tests/fm-claude-settings-live-e2e.test.sh
+++ b/tests/fm-claude-settings-live-e2e.test.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Opt-in live guard for the one vendor fact bin/fm-spawn.sh's claude branch rests on:
+# `claude --settings <file>` loads hooks from a path OUTSIDE the workspace, and those
+# hooks are MERGED with the project's own settings rather than replacing them.
+#
+# That is what lets firstmate arm per-task busy-state hooks without writing anything
+# into the project worktree. A stub claude could only echo the assumption back, so
+# this exercises the installed binary for real and fails naming its version.
+set -u
+
+if [ "${FM_CLAUDE_SETTINGS_LIVE_E2E:-0}" != 1 ]; then
+  echo "skip: set FM_CLAUDE_SETTINGS_LIVE_E2E=1 to run the live claude --settings guard"
+  exit 0
+fi
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+command -v claude >/dev/null 2>&1 || fail "claude not found; this guard requires the installed binary"
+CLAUDE_VERSION=$(claude --version 2>/dev/null | head -1)
+[ -n "$CLAUDE_VERSION" ] || fail "installed claude did not answer --version"
+
+LAB=$(fm_test_tmproot fm-claude-settings-live)
+WORKSPACE="$LAB/workspace"
+mkdir -p "$WORKSPACE/.claude"
+git -C "$LAB" init -q "$WORKSPACE"
+
+# The project's own committed settings, with content firstmate must never touch and
+# a hook of its own that must keep firing.
+cat > "$WORKSPACE/.claude/settings.local.json" <<JSON
+{"env":{"FM_LIVE_PROJECT_KEY":"kept"},
+ "hooks":{"Stop":[{"hooks":[{"type":"command","command":"touch '$LAB/project-stop'"}]}]}}
+JSON
+PROJECT_BEFORE=$(cat "$WORKSPACE/.claude/settings.local.json")
+
+# Firstmate's own settings, shaped like the file bin/fm-spawn.sh writes into state/.
+cat > "$LAB/fm-settings.json" <<JSON
+{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"touch '$LAB/fm-submit'"}]}],
+          "Stop":[{"hooks":[{"type":"command","command":"touch '$LAB/fm-stop'"}]}]}}
+JSON
+
+( cd "$WORKSPACE" && claude --dangerously-skip-permissions \
+    --settings "$LAB/fm-settings.json" -p "reply with the single word ok" ) \
+  > "$LAB/out" 2> "$LAB/err" < /dev/null \
+  || fail "claude $CLAUDE_VERSION refused the --settings launch: $(cat "$LAB/err")"
+
+[ -e "$LAB/fm-submit" ] \
+  || fail "claude $CLAUDE_VERSION did not fire the UserPromptSubmit hook supplied through --settings"
+[ -e "$LAB/fm-stop" ] \
+  || fail "claude $CLAUDE_VERSION did not fire the Stop hook supplied through --settings"
+[ -e "$LAB/project-stop" ] \
+  || fail "claude $CLAUDE_VERSION let --settings REPLACE the project's own hooks instead of merging them"
+[ "$(cat "$WORKSPACE/.claude/settings.local.json")" = "$PROJECT_BEFORE" ] \
+  || fail "claude $CLAUDE_VERSION rewrote the project's settings file during the run"
+
+pass "claude $CLAUDE_VERSION loads --settings hooks from outside the workspace and merges them with the project's own"
+echo "all fm-claude-settings-live-e2e tests passed"

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -414,15 +414,15 @@ test_harness_switch_moves_the_record_and_clears_prior_wiring() {
   local dir out rc
   dir=$(new_case switch rl4)
   add_ship_task "$dir" rl4 claude
-  # Wiring the previous claude incarnation left in the worktree.
-  mkdir -p "$dir/wt/.claude"
-  printf '{"hooks":{}}\n' > "$dir/wt/.claude/settings.local.json"
+  # Wiring the previous claude incarnation left behind. It lives in state/, never
+  # in the worktree - firstmate writes no claude file into a project checkout.
+  printf '{"hooks":{}}\n' > "$dir/home/state/rl4.claude-settings.json"
   printf 'codex' > "$dir/fake/becomes"
   out=$(run_control "$dir" rl4 relaunch --harness codex --note "switching runtime"); rc=$?
   expect_code 0 "$rc" "a harness switch should succeed"$'\n'"$out"
   assert_contains "$out" "harness=codex from=claude" "the outcome should name both harnesses"
   [ "$(meta_field "$dir" rl4 harness)" = codex ] || fail "the record should follow the switch"
-  [ ! -e "$dir/wt/.claude/settings.local.json" ] \
+  [ ! -e "$dir/home/state/rl4.claude-settings.json" ] \
     || fail "the previous harness's per-task wiring must be cleared on a switch"
   assert_grep "codex" "$dir/fake/literal" "the replacement launch should be the new harness"
   [ "$(journal_field "$dir" rl4 from_harness)" = claude ] || fail "the journal should record the origin harness"
@@ -561,8 +561,7 @@ test_wiring_removal_failure_refuses_before_replacement_arm() {
   local dir hook out rc real_rm
   dir=$(new_case wiring-failure rl29)
   add_ship_task "$dir" rl29 claude
-  hook="$dir/wt/.claude/settings.local.json"
-  mkdir -p "${hook%/*}"
+  hook="$dir/home/state/rl29.claude-settings.json"
   printf '{}\n' > "$hook"
   real_rm=$(command -v rm)
   make_rm_failure_stub "$dir"
@@ -1034,7 +1033,7 @@ test_prepublication_abort_retires_replacement_wiring_and_busy_state() {
   expect_code 1 "$rc" "a failed metadata publication should fail closed"$'\n'"$out"
   [ "$(meta_field "$dir" rl28 harness)" = claude ] \
     || fail "a failed publication should retain the prior durable record"
-  [ ! -e "$dir/wt/.claude/settings.local.json" ] \
+  [ ! -e "$dir/home/state/rl28.claude-settings.json" ] \
     || fail "an aborted replacement should remove its harness wiring"
   [ ! -e "$dir/home/state/rl28.busy-gen" ] \
     || fail "an aborted replacement should retire its busy generation"

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -165,7 +165,9 @@ test_no_profile_keeps_claude_profile_defaults() {
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude default default
 
   launch=$(cat "$LAUNCH_LOG")
-  expected="env -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/brief.md')\""
+  # The per-task busy hooks ride --settings from state/, so no file is written into
+  # the worktree (bin/fm-spawn.sh's claude branch).
+  expected="env -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions --settings '$(cd "$HOME_DIR/state" && pwd -P)/$id.claude-settings.json' \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/brief.md')\""
   [ "$launch" = "$expected" ] || fail "no-profile claude launch did not use the canonical launch kind"$'\n'"expected: $expected"$'\n'"actual:   $launch"
   pass "no --model/--effort records defaults and types the claude launch instructions"
 }
@@ -429,8 +431,8 @@ test_claude_threads_model_and_effort() {
   expect_code 0 "$status" "claude spawn with profile flags should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude sonnet high
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "claude --dangerously-skip-permissions --model 'sonnet' --effort 'high'" \
-    "claude launch did not thread model and effort flags"
+  assert_contains "$launch" "--settings '$(cd "$HOME_DIR/state" && pwd -P)/$id.claude-settings.json' --model 'sonnet' --effort 'high'" \
+    "claude launch did not thread model and effort flags after its out-of-worktree hook settings"
   assert_not_contains "$launch" "--tui-mode" "non-Pi launches must not receive Pi's TUI mode override"
   pass "claude receives --model and --effort profile flags"
 }

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -931,6 +931,95 @@ test_dirty_worktree_refuses() {
   pass "dirty worktree is refused even when its committed work has landed (dirty always wins)"
 }
 
+# Regression (observed 2026-08-20 on a real project): the claude spawn used to
+# write <worktree>/.claude/settings.local.json wholesale, and teardown used to
+# `rm -f` that same path while its dirty check ignored everything untracked under
+# .claude/. Both halves treated a PROJECT-owned path as firstmate's own. firstmate
+# now writes nothing into the worktree for claude, so teardown must leave .claude/
+# exactly as it found it - and anything untracked there is the project's or the
+# worker's work and must be able to refuse teardown like any other dirty file.
+test_teardown_leaves_the_projects_claude_settings_alone() {
+  local case_dir rc before after
+  case_dir=$(make_case claude-settings-kept)
+  write_meta "$case_dir" no-mistakes ship
+  fm_write_meta "$case_dir/state/task-x1.meta" \
+    "window=firstmate:fm-task-x1" "endpoint_task_id=task-x1" \
+    "worktree=$case_dir/wt" "project=$case_dir/project" \
+    "kind=ship" "mode=no-mistakes" "harness=claude"
+  mkdir -p "$case_dir/wt/.claude"
+  printf '%s\n' '{"permissions":{"allow":["Bash(npm test)"]}}' \
+    > "$case_dir/wt/.claude/settings.local.json"
+  git -C "$case_dir/wt" add -f -- .claude/settings.local.json
+  git -C "$case_dir/wt" -c user.email=t@t -c user.name=t commit -q -m "project settings"
+  before=$(cat "$case_dir/wt/.claude/settings.local.json")
+  # Land the branch content so the safety check allows teardown.
+  git -C "$case_dir/wt" push -q origin HEAD:main
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "claude-settings-kept: teardown should allow landed work"$'\n'"$(cat "$case_dir/stderr")"
+  [ -f "$case_dir/wt/.claude/settings.local.json" ] \
+    || fail "claude-settings-kept: teardown deleted the project's own settings file"
+  after=$(cat "$case_dir/wt/.claude/settings.local.json")
+  [ "$after" = "$before" ] \
+    || fail "claude-settings-kept: teardown rewrote the project's settings, got: $after"
+  pass "teardown leaves a project's tracked .claude/settings.local.json exactly as it found it"
+}
+
+test_untracked_claude_file_refuses_teardown() {
+  local case_dir rc
+  case_dir=$(make_case claude-untracked-dirty)
+  write_meta "$case_dir" no-mistakes ship
+  wt_commit_file "$case_dir" feature.txt hello "add feature"
+  git -C "$case_dir/wt" push -q origin HEAD:main
+  # A file the WORKER wrote under .claude/, not firstmate's own wiring.
+  mkdir -p "$case_dir/wt/.claude/agents"
+  printf '%s\n' 'reviewer agent' > "$case_dir/wt/.claude/agents/reviewer.md"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "claude-untracked-dirty: an untracked .claude/ file is not firstmate's to discard"
+  grep -q "uncommitted changes" "$case_dir/stderr" \
+    || fail "claude-untracked-dirty: refusal did not cite uncommitted changes"
+  pass "an untracked file under .claude/ refuses teardown instead of being silently discarded"
+}
+
+test_legacy_firstmate_claude_leftover_is_removed() {
+  local case_dir rc
+  case_dir=$(make_case claude-legacy-leftover)
+  write_meta "$case_dir" no-mistakes ship
+  wt_commit_file "$case_dir" feature.txt hello "add feature"
+  git -C "$case_dir/wt" push -q origin HEAD:main
+  # Exactly what a pre-2026-08-20 claude spawn left behind: firstmate's own hooks,
+  # untracked and hidden from git status by the exclude entry that spawn also wrote.
+  mkdir -p "$case_dir/wt/.claude"
+  printf '%s\n' '{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"/x/bin/fm-busy-event.sh apply /s id idle"}]}]}}' \
+    > "$case_dir/wt/.claude/settings.local.json"
+  mkdir -p "$case_dir/project/.git/info"
+  printf '%s\n' '.claude/settings.local.json' >> "$case_dir/project/.git/info/exclude"
+  # A project file next to it, which teardown must not touch.
+  printf '%s\n' 'keep me' > "$case_dir/wt/.claude/project-note.md"
+  printf '%s\n' '.claude/project-note.md' >> "$case_dir/project/.git/info/exclude"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "claude-legacy-leftover: teardown should allow landed work"$'\n'"$(cat "$case_dir/stderr")"
+  [ ! -e "$case_dir/wt/.claude/settings.local.json" ] \
+    || fail "claude-legacy-leftover: firstmate's own pre-fix hook file must not survive teardown"
+  [ -f "$case_dir/wt/.claude/project-note.md" ] \
+    || fail "claude-legacy-leftover: teardown removed a file firstmate never wrote"
+  pass "teardown removes only the pre-fix hook file firstmate itself wrote under .claude/"
+}
+
 test_gh_error_and_content_absent_refuses() {
   local case_dir rc
   case_dir=$(make_case gh-error)
@@ -2621,6 +2710,9 @@ test_pr_check_records_remote_head_when_local_lags
 test_content_in_default_fallback_allows
 test_content_fallback_refreshes_stale_origin_ref
 test_dirty_worktree_refuses
+test_teardown_leaves_the_projects_claude_settings_alone
+test_untracked_claude_file_refuses_teardown
+test_legacy_firstmate_claude_leftover_is_removed
 test_gh_error_and_content_absent_refuses
 test_stale_index_lock_cleared_and_teardown_succeeds
 test_live_index_lock_is_never_removed_and_teardown_refuses


### PR DESCRIPTION
## Intent

Stop firstmate from destroying a project's tracked .claude/settings.local.json.

The defect, observed 2026-08-20: spawning a Claude crewmate writes the busy-event hooks into <worktree>/.claude/settings.local.json, and it writes the file WHOLESALE. On the cosmic-show-hub project that file is TRACKED and had real content: a CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS env entry, a permissions.allow list, and an enabledPlugins entry for context7. The spawn replaced all of it with just the hooks block. Two consequences, both real: (1) the project's committed settings are silently destroyed in that worktree for the life of the task; (2) because the file is tracked, every spawn leaves the worktree permanently dirty, which then blocks fm-teardown.sh after the work has merged, producing an endless stale-wake loop where the watcher re-escalated the finished task every few minutes until it was cleared by hand.

What to build: firstmate must be able to install its hooks without destroying content it does not own. Two acceptable designs were named: (a) merge firstmate's hooks into the existing file, preserving every key firstmate does not own, and restore the original on teardown, safe when the file is absent, present-and-empty, malformed, or read-only; or (b) follow the existing Grok/Kimi precedent and keep the hooks outside the worktree entirely so no project file is touched at all, which removes the whole class of bug rather than mitigating it. The choice had to be argued from what Claude Code actually supports, not from preference. Whatever was built, teardown must leave the worktree exactly as it found it, because the pooled-worktree contract depends on it. The task also required checking whether the same wholesale-write pattern exists anywhere else in the spawn path for any harness, and reporting what was found.

Decisions made while doing the work, which a reviewer reading only the diff would not know:

Design chosen: option (b), hooks outside the worktree, argued from a live probe rather than preference. Claude Code's documented flag loads additional settings from an arbitrary path. Verified live on Claude Code 2.1.237 in a throwaway workspace that had its own .claude/settings.local.json with a Stop hook: running created all three marker files - the project's own Stop hook, plus the Stop and UserPromptSubmit hooks supplied only through --settings. So --settings MERGES with the project's settings rather than replacing them. That makes the merge-into-the-file design strictly worse: it would still touch a project file, still need restore-on-teardown, still need absent/empty/malformed/read-only handling, and would still leave a tracked file dirty mid-task. Firstmate now writes zero files into the worktree for claude, matching what grok, kimi and pi already do.

Root cause was deliberately fixed in all three places it manifested, not just the reported one: (1) bin/fm-spawn.sh's claude branch now writes state/<id>.claude-settings.json and passes it via --settings, dropping the mkdir -p "$WT/.claude" and the .git/info/exclude entry; (2) bin/fm-teardown.sh no longer rm -f's <worktree>/.claude/settings.local.json at any of its four cleanup sites - that rm was unconditional and ran for EVERY harness, not just claude; (3) teardown's dirty check previously filtered '^?? \.claude/', which silently discarded any untracked file a worker wrote anywhere under .claude/. That exclusion is now removed entirely, so anything under .claude/ belongs to the project or the worker and can refuse teardown like any other dirty file. The reported symptom came from the tracked case: git status shows ' M', which never matched '^?? ', so teardown refused and the watcher re-escalated forever.

Deliberate scope decisions: a one-time migration helper remove_legacy_claude_settings was added to teardown, because a task already under way at update time still has firstmate's pre-fix file sitting in its worktree, hidden from git status by the exclude entry the old spawn also wrote, and its stale hooks would then fire for the next task in a pooled worktree. It removes the file ONLY when it is untracked AND contains firstmate's own fm-busy-event.sh command, so a tracked or project-authored file is provably never touched. A per-spawn Usage: claude [options] [command] [prompt]

Claude Code - starts an interactive session by default, use -p/--print for
non-interactive output

Arguments:
prompt Your prompt

Options:
--add-dir <directories...> Additional directories to allow tool
access to
--agent <agent> Agent for the current session. Overrides
the 'agent' setting.
--agents <json> JSON object defining custom agents (e.g.
'{"reviewer": {"description": "Reviews
code", "prompt": "You are a code
reviewer"}}')
--allow-dangerously-skip-permissions Enable bypassing all permission checks
as an option, without it being enabled
by default. Recommended only for
sandboxes with no internet access.
--allowedTools, --allowed-tools <tools...>
Comma or space-separated list of tool names to allow (e.g. "Bash(git *)
Edit")
--append-system-prompt <prompt> Append a system prompt to the default
system prompt
--autocompact <auto|tokens> Auto-compact window size (auto, or
100k–1M tokens)
--ax-screen-reader Render screen-reader friendly output
(flat text, no decorative borders or
animations).
--bg, --background Start the session as a background agent
and return immediately (manage with
`claude agents`)
--bare Minimal mode: skip hooks, LSP, plugin
sync, attribution, auto-memory,
background prefetches, keychain reads,
and CLAUDE.md auto-discovery. Sets
CLAUDE_CODE_SIMPLE=1. Anthropic auth is
strictly ANTHROPIC_API_KEY or
apiKeyHelper via --settings (OAuth and
keychain are never read). 3P providers
(Bedrock/Vertex/Foundry) use their own
credentials. Skills still resolve via
/skill-name. Explicitly provide context
via: --system-prompt[-file],
--append-system-prompt[-file], --add-dir
(CLAUDE.md dirs), --mcp-config,
--settings, --agents, --plugin-dir.
--betas <betas...> Beta headers to include in API requests
(API key users only)
--brief Enable SendUserMessage tool for
agent-to-user communication
--chrome Enable Claude in Chrome integration
--cloud [description|session_id|url] Create a cloud session with the given
description, or attach to an existing
one by session ID or claude.ai/code URL
-c, --continue Continue the most recent conversation in
the current directory
--dangerously-skip-permissions Bypass all permission checks.
Recommended only for sandboxes with no
internet access.
-d, --debug [filter] Enable debug mode with optional category
filtering (e.g., "api,hooks" or
"!1p,!file")
--debug-file <path> Write debug logs to a specific file path
(implicitly enables debug mode)
--disable-slash-commands Disable all skills
--disallowedTools, --disallowed-tools <tools...>
Comma or space-separated list of tool names to deny (e.g. "Bash(git *)
Edit")
--effort <level> Effort level for the current session
(low, medium, high, xhigh, max)
--environment <environment_id> Create a new cloud session that runs on
the given self-hosted environment
(ccpool_...).
--exclude-dynamic-system-prompt-sections
Move per-machine sections (cwd, env info, memory paths, git status) from
the system prompt into the first user message. Improves cross-user
prompt-cache reuse. Only applies with the default system prompt (ignored
with --system-prompt). (default: false)
--fallback-model <model> Enable automatic fallback to specified
model(s) when the default model is
overloaded or not available. Accepts a
comma-separated list to try each in
order. Re-tries the primary at the start
of each user turn. (only works with
--print)
--file <specs...> File resources to download at startup.
Format: file_id:relative_path (e.g.,
--file file_abc:doc.txt
file_def:img.png)
--fork-session When resuming, create a new session ID
instead of reusing the original (use
with --resume or --continue)
--forward-subagent-text Forward subagent text and thinking
blocks as assistant/user messages with
parent_tool_use_id set (only works with
--print and --output-format=stream-json)
--from-pr [value] Resume a session linked to a PR by PR
number/URL, or open interactive picker
with optional search term
-h, --help Display help for command
--ide Automatically connect to IDE on startup
if exactly one valid IDE is available
--include-hook-events Include all hook lifecycle events in the
output stream (only works with
--output-format=stream-json)
--include-partial-messages Include partial message chunks as they
arrive (only works with --print and
--output-format=stream-json)
--input-format <format> Input format (only works with --print):
"text" (default), or "stream-json"
(realtime streaming input) (choices:
"text", "stream-json")
--json-schema <schema> JSON Schema for structured output
validation. Example:
{"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}
--max-budget-usd <amount> Maximum dollar amount to spend on API
calls (only works with --print)
--mcp-config <configs...> Load MCP servers from JSON files or
strings (space-separated)
--model <model> Model for the current session. Provide
an alias for the latest model (e.g.
'fable', 'opus', or 'sonnet') or a
model's full name (e.g.
'claude-fable-5').
-n, --name <name> Set a display name for this session
(shown in the prompt box, /resume
picker, and terminal title)
--no-chrome Disable Claude in Chrome integration
--no-session-persistence Disable session persistence - sessions
will not be saved to disk and cannot be
resumed (only works with --print)
--output-format <format> Output format (only works with --print):
"text" (default), "json" (single
result), or "stream-json" (realtime
streaming) (choices: "text", "json",
"stream-json")
--permission-mode <mode> Permission mode to use for the session
(choices: "acceptEdits", "auto",
"bypassPermissions", "manual",
"dontAsk", "plan")
--plugin-dir <path> Load a plugin from a directory or .zip
for this session only (repeatable:
--plugin-dir A --plugin-dir B.zip)
(default: [])
--plugin-url <url> Fetch a plugin .zip from a URL for this
session only (repeatable: --plugin-url A
--plugin-url B) (default: [])
-p, --print Print response and exit (useful for
pipes). Note: The workspace trust dialog
is skipped when Claude is run in
non-interactive mode (via -p, or when
stdout is not a TTY, e.g. piped or
redirected output). Only use this in
directories you trust. Settings files
that fail validation are silently
ignored in this mode (no error dialog is
shown).
--prompt-suggestions [value] Enable prompt suggestions. In print/SDK
mode, emits a prompt_suggestion message
after each turn with a predicted next
user prompt (choices: "true", "false",
"1", "0", "yes", "no", "on", "off",
preset: "true")
--remote-control [name] Start an interactive session with Remote
Control enabled (optionally named)
--remote-control-session-name-prefix <prefix>
Prefix for auto-generated Remote Control session names (default: hostname)
--replay-user-messages Re-emit user messages from stdin back on
stdout for acknowledgment (only works
with --input-format=stream-json and
--output-format=stream-json)
-r, --resume [value] Resume a conversation by session ID, or
open interactive picker with optional
search term
--safe-mode Start with all customizations
(CLAUDE.md, skills, plugins, hooks, MCP
servers, custom commands and agents,
output styles, workflows, custom themes,
keybindings, and more) disabled — useful
for troubleshooting a broken
configuration. Admin-managed (policy)
settings still apply. Auth, model
selection, built-in tools, and
permissions work normally. Sets
CLAUDE_CODE_SAFE_MODE=1.
--session-id <uuid> Use a specific session ID for the
conversation (must be a valid UUID)
--setting-sources <sources> Comma-separated list of setting sources
to load (user, project, local).
--settings <file-or-json> Path to a settings JSON file or a JSON
string to load additional settings from
--strict-mcp-config Only use MCP servers from --mcp-config,
ignoring all other MCP configurations
--system-prompt <prompt> System prompt to use for the session
--teleport [session] Resume a teleport session, optionally
specify session ID
--tmux Create a tmux session for the worktree
(requires --worktree). Uses iTerm2
native panes when available; use
--tmux=classic for traditional tmux.
--tools <tools...> Specify the list of available tools from
the built-in set. Use "" to disable all
tools, "default" to use all tools, or
specify tool names (e.g.
"Bash,Edit,Read").
--verbose Override verbose mode setting from
config
-v, --version Output the version number
-w, --worktree [name] Create a new git worktree for this
session (optionally specify a name)

Commands:
agents [options] Manage background agents
auth Manage authentication
auto-mode Inspect or reset auto mode classifier
configuration
doctor Check the health of your Claude Code
installation. Reads settings files in
the current directory without a trust
prompt. For a full checkup that can also
fix issues, run /doctor in a session.
gateway [options] Run the enterprise auth/telemetry
gateway
import [options] [source] Import config from another AI coding
agent into Claude Code
install [options] [target] Install Claude Code native build. Use
[target] to specify version (stable,
latest, or specific version)
mcp Configure and manage MCP servers
plugin|plugins Manage Claude Code plugins
project Manage Claude Code project state
setup-token Set up a long-lived authentication token
(requires Claude subscription)
ultrareview [options] [target] Run a cloud-hosted multi-agent code
review of the current branch (or a PR
number / base branch) and print the
findings
update|upgrade Check for updates and install if
available probe for --settings was written and then deliberately REMOVED: an unsupported flag makes claude refuse to start, so the spawn readiness gate already fails loudly, and the probe would have added a subprocess per spawn plus a second place to keep in sync. Secondmates arm no busy contract, so the launch template omits --settings for kind=secondmate rather than pointing it at a file that does not exist.

Verification, following firstmate's own harness-dependent-check rule that a vendor-emitted fact must be proven end to end against the real harness and not against a stub: a new opt-in live guard tests/fm-claude-settings-live-e2e.test.sh (gated on FM_CLAUDE_SETTINGS_LIVE_E2E=1, self-skipping) exercises the installed binary and fails naming its version, and bin/fm-spawn.sh was added to the live-harness-optin family in bin/fm-test-run.sh so a spawn change re-selects it. The dated evidence and the refresh command are recorded in docs/verification/supervision.md.

Regression tests cover both directions as required: in tests/fm-busy-adapter-wiring.test.sh a project that tracks .claude/settings.local.json with real content (landed on the default branch so the spawn's base refresh brings it in) survives a real fm-spawn byte for byte with git status empty, the launch command carries --settings pointing outside the worktree, and the hooks still drive the busy classifier. In tests/fm-teardown.test.sh: the tracked file survives teardown unchanged; an untracked file under .claude/ now refuses teardown instead of being silently discarded; and a pre-fix firstmate leftover is removed while a neighbouring project file under .claude/ is not.

Audit result for the 'does this exist elsewhere' requirement: no other harness has this flaw. opencode, grok, kimi, muse, cursor and pi all write either firstmate-named files (.fm-grok-turnend, .fm-kimi-turnend, fm-busy-state.js) or nothing inside the worktree at all; kimi's $HOME/.kimi-code/config.toml edit is genuinely marker-delimited and atomic. One unrelated observation not fixed here: grok writes ~/.grok/hooks/fm-turn-end.{sh,json} non-atomically on every spawn without the validation guard kimi has.

Known caveat deliberately not addressed: the old exclude_path call appended '.claude/settings.local.json' to each project's SHARED .git/info/exclude, which outlives teardown and hides a project's own untracked settings file from git status repo-wide. It is not auto-removed because there is no way to prove firstmate wrote a given exclude line rather than the operator.

Pre-existing test failures on this machine, present on the untouched base commit and unrelated to this change, deliberately left alone rather than reaching into firstmate's herdr/secondmate safety code: fm-teardown's herdr-child-preflight case (herdr 0.8.0 installed), fm-secondmate-harness's crew-harness sweep case, and fm-test-run's ruby-missing YAML check. bin/fm-lint.sh passes; actionlint is not installed locally so workflow lint was skipped there.

Firstmate repo conventions that were followed and should not be flagged as omissions: knowledge was routed per the firstmate-coding-guidelines placement tree, so exact mechanics live in bin/fm-spawn.sh's own header rather than in AGENTS.md, situational adapter facts live in the harness-adapters skill, and dated empirical evidence lives in docs/verification/supervision.md; AGENTS.md was deliberately left unchanged because this change adds no always-loaded contract. bin/fm-doc-audience-check.sh passes.

## What Changed

- `bin/fm-spawn.sh` now writes the claude busy-event hooks to `state/<id>.claude-settings.json` and passes it via `claude --settings` (omitted for `kind=secondmate`, which arms no busy contract), instead of writing `<worktree>/.claude/settings.local.json` wholesale and adding a `.git/info/exclude` entry; `fm-control-lib.sh` reports the new state path as the claude wiring path.
- `bin/fm-teardown.sh` no longer `rm -f`s `<worktree>/.claude/settings.local.json` at its four cleanup sites, drops the `'^?? \.claude/'` exclusion from the dirty-worktree check so anything under `.claude/` can refuse teardown, cleans up the new state file, and adds `remove_legacy_claude_settings` to delete a pre-fix leftover only when it is untracked and contains firstmate's own `fm-busy-event.sh` command.
- Tests and docs: new opt-in live guard `tests/fm-claude-settings-live-e2e.test.sh` (gated on `FM_CLAUDE_SETTINGS_LIVE_E2E=1`) wired into the `live-harness-optin` family for `bin/fm-spawn.sh` changes; `fm-busy-adapter-wiring` asserts a tracked project settings file survives a real spawn byte for byte with `--settings` pointing outside the worktree; `fm-teardown` covers survival of a tracked file, refusal on an untracked `.claude/` file, and legacy-leftover removal; evidence recorded in `docs/verification/supervision.md` and the harness-adapters skill.

## Risk Assessment

✅ Low: Well-bounded fix that removes the worktree write entirely rather than mitigating it, root-caused at all four teardown sites plus the dirty-check filter, with both-direction regression tests and a gated live guard for the one vendor fact it rests on; no reachable path back to the reported failure was found.

## Testing

Ran the targeted regression tests for the spawn and teardown halves plus the two other touched suites (all pass), proved both new regressions fail on the base commit and pass on the target, exercised the opt-in live guard against the installed claude 2.1.237 to confirm --settings hooks fire and merge rather than replace, and captured a CLI transcript of a real fm-spawn showing a project's tracked .claude/settings.local.json surviving byte for byte with a clean worktree, contrasted against the same run on the base commit where the file is overwritten and left modified. One failing teardown case (content-landed) reproduces identically on the untouched base commit and is unrelated to this change; no visual artifact applies since the surface is a shell CLI and its on-disk state.

<details>
<summary>Evidence: fm-spawn transcript after the fix: project settings preserved, worktree clean, hooks outside the worktree</summary>

Source: [fm-spawn transcript after the fix: project settings preserved, worktree clean, hooks outside the worktree](https://github.com/doitdigital0495/firstmate/blob/ff942f16ebc0c39a096056f9dc17f9f8b2c5fd60/.no-mistakes/evidence/fm/fm-settings-clobber/spawn-preserves-project-settings.txt)

<code>== worktree .claude/settings.local.json (after spawn) ==&#10;{&#34;env&#34;:{&#34;CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS&#34;:&#34;1&#34;},&#34;permissions&#34;:{&#34;allow&#34;:[&#34;Bash(npm test)&#34;]},&#34;enabledPlugins&#34;:{&#34;context7&#34;:true}}&#10;&#10;== git status --porcelain in the task worktree (after spawn) ==&#10;(empty above == worktree clean)&#10;&#10;== claude launch command recorded by the fake tmux ==&#10;--settings&#10;&#39;.../home/state/demo-claude.claude-settings.json&#39;&#10;&#10;== busy classifier driven by those out-of-worktree hooks ==&#10;after arm: busy fm-spawn&#10;after UserPromptSubmit: busy claude-hook&#10;after Stop: idle claude-hook</code>

```text
== project's committed .claude/settings.local.json (before spawn) ==
{"env":{"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS":"1"},"permissions":{"allow":["Bash(npm test)"]},"enabledPlugins":{"context7":true}}

== running: bin/fm-spawn.sh (harness=claude) ==
   warning: /tmp/fm-busy-adapter-wiring.OnYbpY/demo-project-settings/home/data/demo-claude/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
   spawned demo-claude harness=claude kind=ship mode=no-mistakes yolo=off window=firstmate:fm-demo-claude worktree=/tmp/fm-busy-adapter-wiring.OnYbpY/demo-project-settings/wt

== worktree .claude/settings.local.json (after spawn) ==
{"env":{"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS":"1"},"permissions":{"allow":["Bash(npm test)"]},"enabledPlugins":{"context7":true}}

== git status --porcelain in the task worktree (after spawn) ==
   (empty above == worktree clean)

== ls of worktree .claude/ ==
   settings.local.json

== claude launch command recorded by the fake tmux ==
   --settings
   '/tmp/fm-busy-adapter-wiring.OnYbpY/demo-project-settings/home/state/demo-claude.claude-settings.json'

== firstmate's own hooks, outside the worktree (demo-claude.claude-settings.json) ==
   {"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"'/home/daan/.no-mistakes/worktrees/cf62ac6bfd91/01M0FG77WJX1NVD09T3596T0YR/bin/fm-busy-event.sh' apply '/tmp/fm-busy-adapter-wiring.OnYbpY/demo-project-settings/home/state' 'demo-claude' busy --gen 'g1787227407.3334413.14081' --source claude-hook --event user-prompt-submit 2>/dev/null || true"}]}],"Stop":[{"hooks":[{"type":"command","command":"touch '/tmp/fm-busy-adapter-wiring.OnYbpY/demo-project-settings/home/state/demo-claude.turn-ended'; '/home/daan/.no-mistakes/worktrees/cf62ac6bfd91/01M0FG77WJX1NVD09T3596T0YR/bin/fm-busy-event.sh' apply '/tmp/fm-busy-adapter-wiring.OnYbpY/demo-project-settings/home/state' 'demo-claude' idle --gen 'g1787227407.3334413.14081' --source claude-hook --event stop 2>/dev/null || true"}]}],"StopFailure":[{"hooks":[{"type":"command","command":"'/home/daan/.no-mistakes/worktrees/cf62ac6bfd91/01M0FG77WJX1NVD09T3596T0YR/bin/fm-busy-event.sh' apply '/tmp/fm-busy-adapter-wiring.OnYbpY/demo-project-settings/home/state' 'demo-claude' idle --gen 'g1787227407.3334413.14081' --source claude-hook --event stop-failure 2>/dev/null || true"}]}],"SessionEnd":[{"hooks":[{"type":"command","command":"'/home/daan/.no-mistakes/worktrees/cf62ac6bfd91/01M0FG77WJX1NVD09T3596T0YR/bin/fm-busy-event.sh' apply '/tmp/fm-busy-adapter-wiring.OnYbpY/demo-project-settings/home/state' 'demo-claude' idle --gen 'g1787227407.3334413.14081' --source claude-hook --event session-end 2>/dev/null || true"}]}]}}

== busy classifier driven by those out-of-worktree hooks ==
   after arm:            busy fm-spawn
   after UserPromptSubmit: busy claude-hook
   after Stop:             idle claude-hook
```
</details>
<details>
<summary>Evidence: Same fm-spawn on the base commit: project settings destroyed, worktree left dirty</summary>

Source: [Same fm-spawn on the base commit: project settings destroyed, worktree left dirty](https://github.com/doitdigital0495/firstmate/blob/ff942f16ebc0c39a096056f9dc17f9f8b2c5fd60/.no-mistakes/evidence/fm/fm-settings-clobber/spawn-BEFORE-fix-destroys-settings.txt)

<code>== worktree .claude/settings.local.json (after spawn) ==&#10;{&#34;hooks&#34;:{&#34;UserPromptSubmit&#34;:[...fm-busy-event.sh...]}} &lt;- project&#39;s env/permissions/enabledPlugins gone&#10;&#10;== git status --porcelain in the task worktree (after spawn) ==&#10;M .claude/settings.local.json</code>

```text
== project's committed .claude/settings.local.json (before spawn) ==
{"env":{"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS":"1"},"permissions":{"allow":["Bash(npm test)"]},"enabledPlugins":{"context7":true}}

== running: bin/fm-spawn.sh (harness=claude) ==
   warning: /tmp/fm-busy-adapter-wiring.9pPYXC/demo-project-settings/home/data/demo-claude/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
   spawned demo-claude harness=claude kind=ship mode=no-mistakes yolo=off window=firstmate:fm-demo-claude worktree=/tmp/fm-busy-adapter-wiring.9pPYXC/demo-project-settings/wt

== worktree .claude/settings.local.json (after spawn) ==
{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"'/tmp/fmbase2/bin/fm-busy-event.sh' apply '/tmp/fm-busy-adapter-wiring.9pPYXC/demo-project-settings/home/state' 'demo-claude' busy --gen 'g1787227416.3339461.8458' --source claude-hook --event user-prompt-submit 2>/dev/null || true"}]}],"Stop":[{"hooks":[{"type":"command","command":"touch '/tmp/fm-busy-adapter-wiring.9pPYXC/demo-project-settings/home/state/demo-claude.turn-ended'; '/tmp/fmbase2/bin/fm-busy-event.sh' apply '/tmp/fm-busy-adapter-wiring.9pPYXC/demo-project-settings/home/state' 'demo-claude' idle --gen 'g1787227416.3339461.8458' --source claude-hook --event stop 2>/dev/null || true"}]}],"StopFailure":[{"hooks":[{"type":"command","command":"'/tmp/fmbase2/bin/fm-busy-event.sh' apply '/tmp/fm-busy-adapter-wiring.9pPYXC/demo-project-settings/home/state' 'demo-claude' idle --gen 'g1787227416.3339461.8458' --source claude-hook --event stop-failure 2>/dev/null || true"}]}],"SessionEnd":[{"hooks":[{"type":"command","command":"'/tmp/fmbase2/bin/fm-busy-event.sh' apply '/tmp/fm-busy-adapter-wiring.9pPYXC/demo-project-settings/home/state' 'demo-claude' idle --gen 'g1787227416.3339461.8458' --source claude-hook --event session-end 2>/dev/null || true"}]}]}}

== git status --porcelain in the task worktree (after spawn) ==
    M .claude/settings.local.json
   (empty above == worktree clean)

== ls of worktree .claude/ ==
   settings.local.json

== claude launch command recorded by the fake tmux ==

== firstmate's own hooks, outside the worktree (demo-claude.claude-settings.json) ==
sed: can't read /tmp/fm-busy-adapter-wiring.9pPYXC/demo-project-settings/home/state/demo-claude.claude-settings.json: No such file or directory

== busy classifier driven by those out-of-worktree hooks ==
   after arm:            busy fm-spawn
jq: error: Could not open file /tmp/fm-busy-adapter-wiring.9pPYXC/demo-project-settings/home/state/demo-claude.claude-settings.json: No such file or directory
not ok - no UserPromptSubmit hook command in /tmp/fm-busy-adapter-wiring.9pPYXC/demo-project-settings/home/state/demo-claude.claude-settings.json
```
</details>
<details>
<summary>Evidence: Live claude 2.1.237 --settings merge guard</summary>

Source: [Live claude 2.1.237 --settings merge guard](https://github.com/doitdigital0495/firstmate/blob/ff942f16ebc0c39a096056f9dc17f9f8b2c5fd60/.no-mistakes/evidence/fm/fm-settings-clobber/claude-settings-live-e2e.txt)

<code>ok - claude 2.1.237 (Claude Code) loads --settings hooks from outside the workspace and merges them with the project&#39;s own&#10;all fm-claude-settings-live-e2e tests passed</code>

```text
ok - claude 2.1.237 (Claude Code) loads --settings hooks from outside the workspace and merges them with the project's own
all fm-claude-settings-live-e2e tests passed
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (10m13s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"31f7c7d9158f991c1d6a7d3fa49ade264a38d133","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `bin/fm-spawn.sh:1125` - Busy-state hooks are now bound to the launch invocation (--settings) instead of a file Claude auto-discovers in the worktree. Firstmate&#39;s own paths are covered (fm-spawn --relaunch regenerates the launch; there is no auto-resume path that types a bare `claude`), but if a worker or operator restarts Claude in the pane by hand (`claude`, `claude --continue`), the UserPromptSubmit/Stop/StopFailure/SessionEnd hooks are silently absent, so the busy record can stay stuck at its last value and the watcher gets no wake. Pre-fix the worktree file survived any restart. Worth one line in the harness-adapters skill&#39;s claude row.
- ℹ️ `bin/fm-teardown.sh:1168` - The new comment states that anything under .claude/ can now refuse teardown like any other dirty file. On any project a pre-fix firstmate ever spawned into, the old `exclude_path &#39;.claude/settings.local.json&#39;` line is still in the project&#39;s shared .git/info/exclude and outlives teardown, so git status hides that one path repo-wide and it cannot refuse teardown there. The intent explicitly records this as a known caveat deliberately not addressed (no way to prove firstmate rather than the operator wrote a given exclude line), so this is a note on the residual scope, not a request to change the code.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `tests/fm-teardown.test.sh:885` - Pre-existing failure in tests/fm-teardown.test.sh case `content-landed: teardown should succeed when content is already in the default branch` (expected exit 0, got 1). Verified identical on the untouched base commit 1cb900c (run from an extracted base tree), so it is not caused by this change. It matters here only because the suite aborts on first failure, so the three new .claude/ teardown cases never execute in a plain full-file run; I ran them via a trimmed copy of the same script instead.
- <code>`bin/fm-test-run.sh tests/fm-busy-adapter-wiring.test.sh` (includes new case `a claude spawn arms its hooks without writing anything into the project worktree`) - pass</code>
- <code>Fail-before check: same new wiring test file run against the base commit tree (git archive 1cb900c) - fails with `claude spawn did not write hook settings`</code>
- <code>New teardown cases `test_teardown_leaves_the_projects_claude_settings_alone`, `test_untracked_claude_file_refuses_teardown`, `test_legacy_firstmate_claude_leftover_is_removed` run via a trimmed copy of tests/fm-teardown.test.sh - all pass</code>
- <code>Fail-before check: same three cases against base bin/fm-teardown.sh - fails with `teardown deleted the project&#39;s own settings file`</code>
- <code>`FM_CLAUDE_SETTINGS_LIVE_E2E=1 bash tests/fm-claude-settings-live-e2e.test.sh` against installed claude 2.1.237 - pass (hooks fire and merge, project file unchanged)</code>
- <code>Manual evidence demo: real `bin/fm-spawn.sh` (harness=claude) on a sandbox project tracking .claude/settings.local.json, capturing file before/after, `git status --porcelain`, the recorded launch command, and the busy classifier transitions; same demo replayed against the base commit for contrast</code>
- <code>`bin/fm-test-run.sh tests/fm-control-relaunch.test.sh tests/fm-spawn-dispatch-profile.test.sh` - pass</code>
- <code>`bin/fm-test-run.sh --list --family live-harness-optin` and `--list --changed --base 1cb900c` - the new live guard is in the opt-in family and a spawn change re-selects it; `--check-coverage` reports FM_TEST_COVERAGE ok</code>
- <code>`bash tests/fm-teardown.test.sh` on the base commit tree - reproduces the same `content-landed` failure, confirming it is pre-existing</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/configuration.md:243` - docs/configuration.md&#39;s operator-facing per-harness hook-install paragraph (lines ~243-249) names grok, Kimi, and Pi but has no claude line, so an operator reading it cannot see that claude&#39;s crew hooks now ride `--settings` from `state/&lt;id&gt;.claude-settings.json`. Not stale (it never described claude), so left unchanged under scope discipline; a follow-up could add one sentence there pointing at the harness-adapters skill.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
