### PR TITLE
feat: progressively disclose and safely replace crewmate briefs

### DIFF
--- a/.agents/skills/secondmate-provisioning/SKILL.md
+++ b/.agents/skills/secondmate-provisioning/SKILL.md
@@ -55,7 +55,7 @@ If you scaffold without `FM_SECONDMATE_CHARTER`, replace the `{TASK}` placeholde
 Pass `--no-projects` instead of a project list to scaffold a project-less charter for a domain whose subject is the firstmate repo itself, whose home is a firstmate worktree and whose crews take pooled worktrees of the same repo.
 `--no-projects` is mutually exclusive with a project list, and omitting both still fails loudly, so an accidental omission is never mistaken for a deliberate project-less seed.
 Re-seeding a populated home as project-less is refused non-destructively when the home contains project clones or `data/projects.md` entries.
-Retire or clean that home first, and re-scaffold a stale project-bearing charter with `--no-projects` before seeding.
+Retire or clean that home first, then use the scaffold's documented `--replace` path with `--no-projects` to replace a stale project-bearing charter before seeding.
 Keep custom charter text focused on the persistent responsibility, available project clones, and genuinely domain-specific hard rules.
 The scaffolded charter, later copied to `data/charter.md`, owns the standard lifecycle and escalation wording.
 Preserve the generated charter sections unless the domain genuinely needs a hard rule.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -497,7 +497,7 @@ Preserve durable structured identifiers, dependencies, and completion artifact l
 
 ## 11. Crewmate briefs
 
-`bin/fm-brief.sh` and its help own scaffold syntax, generated variants, status protocol, delivery-mode definitions of done, and exact safety mechanics.
+`bin/fm-brief.sh` and its help own scaffold syntax, generated variants, and exact safety mechanics; [`docs/crew-reference.md`](docs/crew-reference.md) owns conditional crewmate contracts loaded at the scaffold's named triggers.
 Use its scaffold as the contract, then replace every `{TASK}` placeholder with a clear task description, acceptance criteria, constraints, and necessary context before dispatch or seeding.
 Keep additions task-specific rather than repeating lifecycle instructions, and alter generated sections only when the task genuinely differs from the standard shape.
 

--- a/bin/fm-brief-lib.sh
+++ b/bin/fm-brief-lib.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+fm_brief_publication_lock_path() {
+  printf '%s/.brief-%s.lock\n' "$1" "$2"
+}
+
+fm_brief_replace_staged() {
+  case "${OSTYPE:-}" in
+    darwin*)
+      perl -e 'rename($ARGV[0], $ARGV[1]) or die "error: cannot replace $ARGV[1]: $!\n"' -- "$1" "$2" || return 1
+      ;;
+    linux*) mv -fT -- "$1" "$2" ;;
+    *) echo "error: unsupported platform for no-follow brief replacement: ${OSTYPE:-unknown}" >&2; return 1 ;;
+  esac
+}
+
+fm_brief_snapshot() {
+  local source=$1 destination=$2 dir base staged
+  [ -f "$source" ] || {
+    echo "error: brief snapshot source is not a regular file: $source" >&2
+    return 1
+  }
+  dir=${destination%/*}
+  base=${destination##*/}
+  [ -d "$dir" ] || {
+    echo "error: brief snapshot directory is unavailable: $dir" >&2
+    return 1
+  }
+  staged=$(mktemp "$dir/.$base.XXXXXX") || return 1
+  if ! cp -p -- "$source" "$staged"; then
+    rm -f -- "$staged"
+    return 1
+  fi
+  if ! fm_brief_replace_staged "$staged" "$destination"; then
+    rm -f -- "$staged"
+    return 1
+  fi
+}

--- a/bin/fm-brief-lib.sh
+++ b/bin/fm-brief-lib.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# shellcheck disable=SC2034 # Read by scripts that source this library.
+FM_BRIEF_SCAFFOLD_MARKER='<!-- firstmate:generated-brief-scaffold:v1 -->'
+
 fm_brief_publication_lock_path() {
   printf '%s/.brief-%s.lock\n' "$1" "$2"
 }
@@ -14,16 +17,16 @@ fm_brief_replace_staged() {
   esac
 }
 
-fm_brief_snapshot() {
+fm_brief_copy_atomic() {
   local source=$1 destination=$2 dir base staged
-  [ -f "$source" ] || {
-    echo "error: brief snapshot source is not a regular file: $source" >&2
+  [ -f "$source" ] && [ ! -L "$source" ] || {
+    echo "error: brief publication source is not a regular file: $source" >&2
     return 1
   }
   dir=${destination%/*}
   base=${destination##*/}
   [ -d "$dir" ] || {
-    echo "error: brief snapshot directory is unavailable: $dir" >&2
+    echo "error: brief publication directory is unavailable: $dir" >&2
     return 1
   }
   staged=$(mktemp "$dir/.$base.XXXXXX") || return 1
@@ -35,4 +38,39 @@ fm_brief_snapshot() {
     rm -f -- "$staged"
     return 1
   fi
+}
+
+fm_brief_snapshot() {
+  fm_brief_copy_atomic "$@"
+}
+
+fm_brief_copy_locked() {
+  local state=$1 id=$2 source=$3 destination=$4 lock status=0
+  lock=$(fm_brief_publication_lock_path "$state" "$id") || return 1
+  fm_lock_acquire_wait "$lock" || return 1
+  fm_brief_copy_atomic "$source" "$destination" || status=$?
+  fm_lock_release "$lock" || {
+    [ "$status" -ne 0 ] || status=1
+  }
+  return "$status"
+}
+
+fm_brief_restore_if_matches_locked() {
+  local state=$1 id=$2 expected=$3 replacement=$4 destination=$5 lock status=0
+  lock=$(fm_brief_publication_lock_path "$state" "$id") || return 1
+  fm_lock_acquire_wait "$lock" || return 1
+  if [ -f "$destination" ] && [ ! -L "$destination" ] \
+     && cmp -s "$expected" "$destination"; then
+    if [ -n "$replacement" ]; then
+      fm_brief_copy_atomic "$replacement" "$destination" || status=$?
+    else
+      rm -f -- "$destination" || status=$?
+    fi
+  else
+    status=2
+  fi
+  fm_lock_release "$lock" || {
+    [ "$status" -ne 0 ] || status=1
+  }
+  return "$status"
 }

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -218,7 +218,7 @@ BRIEF="$DATA/$ID/brief.md"
 # governs, so the worker follows whichever copy it read last. --replace is the
 # supported path, and it archives the superseded brief instead of destroying the
 # filled-in task text that made hand-editing look safer than regenerating.
-mkdir -p "$DATA/$ID"
+mkdir -p "$DATA/$ID" "$STATE"
 STAGE_DIR=$(mktemp -d "$DATA/$ID/.brief-stage.XXXXXX")
 STAGED="$STAGE_DIR/brief.md"
 ARCHIVE_STAGED=
@@ -280,6 +280,7 @@ shell_quote() {
 }
 
 STATUS_FILE=$(shell_quote "$STATE/$ID.status")
+printf '%s\n\n' "$FM_BRIEF_SCAFFOLD_MARKER" > "$STAGED"
 
 if [ "$KIND" = secondmate ]; then
 SECONDMATE_CHARTER=${FM_SECONDMATE_CHARTER:-"{TASK}"}
@@ -291,7 +292,7 @@ else
   PROJECT_CLONES_BODY=$(printf '%s\n' "$SECONDMATE_PROJECTS" | tr ' ' '\n' | sed 's/^/- /')
   PROJECT_CLONES_NOTE="The projects above are local clones for work you supervise; they are not an exclusive ownership claim."
 fi
-cat > "$STAGED" <<EOF
+cat >> "$STAGED" <<EOF
 You are a persistent second mate managed by the main firstmate. Work on your own; do not wait for a human.
 
 # Charter
@@ -423,7 +424,7 @@ EOF
 WAIT_SECTION=${WAIT_SECTION%$'\n'}
 
 if [ "$KIND" = scout ]; then
-cat > "$STAGED" <<EOF
+cat >> "$STAGED" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
 
 # Task
@@ -528,7 +529,7 @@ esac
 # briefs stay byte-identical to the historical Bash 5 output.
 DOD=${DOD%$'\n'}
 
-cat > "$STAGED" <<EOF
+cat >> "$STAGED" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
 
 # Task

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -86,6 +86,8 @@ esac
 . "$SCRIPT_DIR/fm-marker-lib.sh"
 # shellcheck source=bin/fm-classify-lib.sh
 . "$SCRIPT_DIR/fm-classify-lib.sh"
+# shellcheck source=bin/fm-pr-lib.sh
+. "$SCRIPT_DIR/fm-pr-lib.sh"
 PAUSED_VERB=${FM_CLASSIFY_PAUSED_VERB:-$FM_CLASSIFY_PAUSED_VERB_DEFAULT}
 
 resolve_directory_input() {
@@ -168,7 +170,8 @@ elif [ "$MODE_SET" -eq 1 ]; then
   echo "error: --mode applies only to ship briefs; a scout delivers a report and a secondmate charter is not a delivery contract" >&2
   exit 1
 fi
-ID=${POS[0]}
+ID=${POS[0]:-}
+fm_task_id_creation_valid "$ID" || { echo "error: invalid task id" >&2; exit 2; }
 
 if [ "$KIND" = secondmate ] && [ "$HERDR_LAB" -eq 1 ]; then
   echo "error: --herdr-lab applies only to crewmate ship or scout briefs" >&2
@@ -180,6 +183,27 @@ if [ "$NO_PROJECTS" -eq 1 ] && [ "$KIND" != secondmate ]; then
   exit 1
 fi
 
+SECONDMATE_PROJECTS=
+REPO=
+if [ "$KIND" = secondmate ]; then
+  idx=1
+  while [ "$idx" -lt "${#POS[@]}" ]; do
+    SECONDMATE_PROJECTS="${SECONDMATE_PROJECTS}${SECONDMATE_PROJECTS:+ }${POS[$idx]}"
+    idx=$((idx + 1))
+  done
+  if [ "$NO_PROJECTS" -eq 1 ]; then
+    [ -z "$SECONDMATE_PROJECTS" ] || { echo "error: --no-projects cannot be combined with a project list" >&2; exit 1; }
+  else
+    [ -n "$SECONDMATE_PROJECTS" ] || { echo "error: --secondmate requires at least one project, or --no-projects for a project-less home" >&2; exit 1; }
+  fi
+else
+  [ "${#POS[@]}" -eq 2 ] && [ -n "${POS[1]}" ] || {
+    echo "error: $KIND briefs require exactly <task-id> <repo-name>" >&2
+    exit 1
+  }
+  REPO=${POS[1]}
+fi
+
 BRIEF="$DATA/$ID/brief.md"
 # A re-scaffold is a real need (a corrected base ref, a changed delivery mode), and
 # a bare refusal does not remove that need - it only pushes the operator into an
@@ -188,25 +212,38 @@ BRIEF="$DATA/$ID/brief.md"
 # governs, so the worker follows whichever copy it read last. --replace is the
 # supported path, and it archives the superseded brief instead of destroying the
 # filled-in task text that made hand-editing look safer than regenerating.
-if [ -e "$BRIEF" ]; then
+if [ -e "$BRIEF" ] || [ -L "$BRIEF" ]; then
   if [ "$REPLACE" -eq 0 ]; then
     echo "error: $BRIEF already exists; pass --replace to regenerate it (the superseded brief is archived, never appended to)" >&2
     exit 1
   fi
   n=1
-  while [ -e "$DATA/$ID/brief.superseded-$n.md" ]; do n=$((n + 1)); done
+  while [ -e "$DATA/$ID/brief.superseded-$n.md" ] || [ -L "$DATA/$ID/brief.superseded-$n.md" ]; do n=$((n + 1)); done
   ARCHIVED="$DATA/$ID/brief.superseded-$n.md"
-  mv "$BRIEF" "$ARCHIVED"
 fi
 mkdir -p "$DATA/$ID"
+STAGE_DIR=$(mktemp -d "$DATA/$ID/.brief-stage.XXXXXX")
+STAGED="$STAGE_DIR/brief.md"
 
-# Announce the scaffold. A replace names the archive so the superseded brief -
-# which usually holds the filled-in task text - is never quietly lost.
-announce() {  # <detail>
+cleanup_staged_brief() {
+  [ -z "${STAGED:-}" ] || rm -f -- "$STAGED"
+  [ -z "${STAGE_DIR:-}" ] || rmdir "$STAGE_DIR" 2>/dev/null || true
+}
+trap cleanup_staged_brief EXIT
+
+publish_brief() {
+  local detail=$1
   if [ -n "$ARCHIVED" ]; then
-    echo "scaffolded: $BRIEF ($1; replaced, superseded brief archived at $ARCHIVED)"
+    cp -pP -- "$BRIEF" "$ARCHIVED"
+  fi
+  mv -f -- "$STAGED" "$BRIEF"
+  STAGED=
+  rmdir "$STAGE_DIR"
+  STAGE_DIR=
+  if [ -n "$ARCHIVED" ]; then
+    echo "scaffolded: $BRIEF ($detail; replaced, superseded brief archived at $ARCHIVED)"
   else
-    echo "scaffolded: $BRIEF ($1)"
+    echo "scaffolded: $BRIEF ($detail)"
   fi
 }
 
@@ -219,17 +256,6 @@ shell_quote() {
 STATUS_FILE=$(shell_quote "$STATE/$ID.status")
 
 if [ "$KIND" = secondmate ]; then
-SECONDMATE_PROJECTS=""
-idx=1
-while [ "$idx" -lt "${#POS[@]}" ]; do
-  SECONDMATE_PROJECTS="${SECONDMATE_PROJECTS}${SECONDMATE_PROJECTS:+ }${POS[$idx]}"
-  idx=$((idx + 1))
-done
-if [ "$NO_PROJECTS" -eq 1 ]; then
-  [ -z "$SECONDMATE_PROJECTS" ] || { echo "error: --no-projects cannot be combined with a project list" >&2; exit 1; }
-else
-  [ -n "$SECONDMATE_PROJECTS" ] || { echo "error: --secondmate requires at least one project, or --no-projects for a project-less home" >&2; exit 1; }
-fi
 SECONDMATE_CHARTER=${FM_SECONDMATE_CHARTER:-"{TASK}"}
 SECONDMATE_SCOPE=${FM_SECONDMATE_SCOPE:-${FM_SECONDMATE_CHARTER:-"{TASK}"}}
 if [ "$NO_PROJECTS" -eq 1 ]; then
@@ -239,7 +265,7 @@ else
   PROJECT_CLONES_BODY=$(printf '%s\n' "$SECONDMATE_PROJECTS" | tr ' ' '\n' | sed 's/^/- /')
   PROJECT_CLONES_NOTE="The projects above are local clones for work you supervise; they are not an exclusive ownership claim."
 fi
-cat > "$BRIEF" <<EOF
+cat > "$STAGED" <<EOF
 You are a persistent second mate managed by the main firstmate. Work on your own; do not wait for a human.
 
 # Charter
@@ -297,14 +323,12 @@ An empty queue is a healthy resting state, not a cue to invent work: never spawn
 If this charter cannot be carried out, append \`blocked: {why}\` or \`failed: {why}\` to the main status file and stop.
 EOF
 if [ "$SECONDMATE_CHARTER" = "{TASK}" ]; then
-  announce "secondmate charter; replace {TASK}"
+  publish_brief "secondmate charter; replace {TASK}"
 else
-  announce "secondmate charter"
+  publish_brief "secondmate charter"
 fi
 exit 0
 fi
-
-REPO=${POS[1]}
 
 if [ "$HERDR_LAB" -eq 1 ]; then
 HERDR_LAB_HELPER=$(shell_quote "$FM_ROOT/bin/fm-herdr-lab.sh")
@@ -373,7 +397,7 @@ EOF
 WAIT_SECTION=${WAIT_SECTION%$'\n'}
 
 if [ "$KIND" = scout ]; then
-cat > "$BRIEF" <<EOF
+cat > "$STAGED" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
 
 # Task
@@ -416,7 +440,7 @@ Before reporting done, read and follow \`$FM_ROOT/.agents/skills/decision-hold-l
 When the report is complete, append \`done: {one-line conclusion}\` to the status file and stop.
 If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.
 EOF
-announce "scout; replace {TASK}"
+publish_brief "scout; replace {TASK}"
 exit 0
 fi
 
@@ -478,7 +502,7 @@ esac
 # briefs stay byte-identical to the historical Bash 5 output.
 DOD=${DOD%$'\n'}
 
-cat > "$BRIEF" <<EOF
+cat > "$STAGED" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
 
 # Task
@@ -526,4 +550,4 @@ Keep it proportionate: skip \`AGENTS.md\` edits for trivial tasks that produced 
 
 $DOD
 EOF
-announce "ship, mode=$MODE; replace {TASK}"
+publish_brief "ship, mode=$MODE; replace {TASK}"

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -213,6 +213,10 @@ BRIEF="$DATA/$ID/brief.md"
 # supported path, and it archives the superseded brief instead of destroying the
 # filled-in task text that made hand-editing look safer than regenerating.
 if [ -e "$BRIEF" ] || [ -L "$BRIEF" ]; then
+  if [ -L "$BRIEF" ] || [ ! -f "$BRIEF" ]; then
+    echo "error: existing brief must be a regular file, not a symlink or other file type: $BRIEF" >&2
+    exit 1
+  fi
   if [ "$REPLACE" -eq 0 ]; then
     echo "error: $BRIEF already exists; pass --replace to regenerate it (the superseded brief is archived, never appended to)" >&2
     exit 1
@@ -224,19 +228,32 @@ fi
 mkdir -p "$DATA/$ID"
 STAGE_DIR=$(mktemp -d "$DATA/$ID/.brief-stage.XXXXXX")
 STAGED="$STAGE_DIR/brief.md"
+ARCHIVE_STAGED=
 
 cleanup_staged_brief() {
   [ -z "${STAGED:-}" ] || rm -f -- "$STAGED"
+  [ -z "${ARCHIVE_STAGED:-}" ] || rm -f -- "$ARCHIVE_STAGED"
   [ -z "${STAGE_DIR:-}" ] || rmdir "$STAGE_DIR" 2>/dev/null || true
 }
 trap cleanup_staged_brief EXIT
 
+replace_staged_brief() {
+  case "${OSTYPE:-}" in
+    darwin*) mv -fh -- "$1" "$2" ;;
+    linux*) mv -fT -- "$1" "$2" ;;
+    *) echo "error: unsupported platform for no-follow brief replacement: ${OSTYPE:-unknown}" >&2; return 1 ;;
+  esac
+}
+
 publish_brief() {
   local detail=$1
   if [ -n "$ARCHIVED" ]; then
-    cp -pP -- "$BRIEF" "$ARCHIVED"
+    ARCHIVE_STAGED="$STAGE_DIR/brief.superseded.md"
+    cp -p -- "$BRIEF" "$ARCHIVE_STAGED"
+    replace_staged_brief "$ARCHIVE_STAGED" "$ARCHIVED"
+    ARCHIVE_STAGED=
   fi
-  mv -f -- "$STAGED" "$BRIEF"
+  replace_staged_brief "$STAGED" "$BRIEF"
   STAGED=
   rmdir "$STAGE_DIR"
   STAGE_DIR=

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -6,9 +6,9 @@
 # description, acceptance criteria, and context, and may adjust other sections
 # when the task genuinely deviates (e.g. working an existing external PR instead
 # of shipping a new one).
-# Usage: fm-brief.sh <task-id> <repo-name> --mode <no-mistakes|direct-PR|local-only> [--herdr-lab]
-#        fm-brief.sh <task-id> <repo-name> --scout [--herdr-lab]
-#        fm-brief.sh <task-id> --secondmate {<project>...|--no-projects}
+# Usage: fm-brief.sh <task-id> <repo-name> --mode <no-mistakes|direct-PR|local-only> [--herdr-lab] [--replace]
+#        fm-brief.sh <task-id> <repo-name> --scout [--herdr-lab] [--replace]
+#        fm-brief.sh <task-id> --secondmate {<project>...|--no-projects} [--replace]
 #   --scout writes the scout contract instead: the deliverable is a report at
 #   data/<task-id>/report.md (no branch, no push, no PR) and the worktree is scratch.
 #   --secondmate writes a persistent secondmate charter. The project list
@@ -50,11 +50,22 @@
 # "blocked:": pause for a known external wait expected to clear on its own,
 # blocked when firstmate must act.
 # Ship tasks include a project-memory section so durable project-intrinsic
-# learnings can be committed to AGENTS.md through the project's delivery path;
-# it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers
-# over copied detail) and has the crewmate add the fm-ensure-agents-md.sh
-# self-governance section when a touched project AGENTS.md lacks it.
-# Refuses to overwrite an existing brief.
+# learnings can be committed to AGENTS.md through the project's delivery path.
+# It points at bin/fm-ensure-agents-md.sh rather than restating the authoring bar:
+# that script owns the bar and writes it into the touched file's own
+# "## Maintaining this file" section, so the rule arrives in the artifact the
+# crewmate is editing at the moment it applies.
+# The generated brief is progressively disclosed. Its always-present part carries
+# only what a worker must act on unprompted; conditional contracts live in
+# docs/crew-reference.md, and the brief names the trigger that sends the worker
+# there (a decision/blocker/wait it opened clearing, or its first no-mistakes
+# command). The declared-wait rule is deliberately NOT deferred and carries its own
+# heading: deferral needs a trigger the worker recognises before it needs the rule,
+# and workers demonstrably do not recognise that their own running loop has become
+# a wait.
+# An existing brief is never appended to. Re-scaffolding refuses by default and
+# needs an explicit --replace, which archives the superseded brief alongside it as
+# brief.superseded-<n>.md so filled-in task text is recoverable.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -104,6 +115,8 @@ fi
 KIND=ship
 HERDR_LAB=0
 NO_PROJECTS=0
+REPLACE=0
+ARCHIVED=
 MODE=
 MODE_SET=0
 POS=()
@@ -125,6 +138,7 @@ for a in "$@"; do
     --secondmate) KIND=secondmate ;;
     --herdr-lab) HERDR_LAB=1 ;;
     --no-projects) NO_PROJECTS=1 ;;
+    --replace) REPLACE=1 ;;
     --mode) want_value=mode ;;
     --mode=*) MODE=${a#--mode=}; MODE_SET=1 ;;
     # yolo never reaches the worker: it is firstmate's approval authority, not a
@@ -167,8 +181,34 @@ if [ "$NO_PROJECTS" -eq 1 ] && [ "$KIND" != secondmate ]; then
 fi
 
 BRIEF="$DATA/$ID/brief.md"
-[ -e "$BRIEF" ] && { echo "error: $BRIEF already exists" >&2; exit 1; }
+# A re-scaffold is a real need (a corrected base ref, a changed delivery mode), and
+# a bare refusal does not remove that need - it only pushes the operator into an
+# unguarded path. Hand-appending a regenerated brief onto the old one is what that
+# produced: two full Setup/Rules blocks in one file, with nothing marking which
+# governs, so the worker follows whichever copy it read last. --replace is the
+# supported path, and it archives the superseded brief instead of destroying the
+# filled-in task text that made hand-editing look safer than regenerating.
+if [ -e "$BRIEF" ]; then
+  if [ "$REPLACE" -eq 0 ]; then
+    echo "error: $BRIEF already exists; pass --replace to regenerate it (the superseded brief is archived, never appended to)" >&2
+    exit 1
+  fi
+  n=1
+  while [ -e "$DATA/$ID/brief.superseded-$n.md" ]; do n=$((n + 1)); done
+  ARCHIVED="$DATA/$ID/brief.superseded-$n.md"
+  mv "$BRIEF" "$ARCHIVED"
+fi
 mkdir -p "$DATA/$ID"
+
+# Announce the scaffold. A replace names the archive so the superseded brief -
+# which usually holds the filled-in task text - is never quietly lost.
+announce() {  # <detail>
+  if [ -n "$ARCHIVED" ]; then
+    echo "scaffolded: $BRIEF ($1; replaced, superseded brief archived at $ARCHIVED)"
+  else
+    echo "scaffolded: $BRIEF ($1)"
+  fi
+}
 
 shell_quote() {
   printf "'"
@@ -257,9 +297,9 @@ An empty queue is a healthy resting state, not a cue to invent work: never spawn
 If this charter cannot be carried out, append \`blocked: {why}\` or \`failed: {why}\` to the main status file and stop.
 EOF
 if [ "$SECONDMATE_CHARTER" = "{TASK}" ]; then
-  echo "scaffolded: $BRIEF (secondmate charter; replace {TASK})"
+  announce "secondmate charter; replace {TASK}"
 else
-  echo "scaffolded: $BRIEF (secondmate charter)"
+  announce "secondmate charter"
 fi
 exit 0
 fi
@@ -291,12 +331,46 @@ HERDR_SECTION=$(printf '%s\n' \
 else
 IFS= read -r -d '' HERDR_SECTION <<'EOF' || true
 # Herdr lifecycle declaration - NOT ENABLED
-**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
-If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
+**HARD SAFETY GATE:** this brief carries no Herdr isolation contract, so any Herdr lifecycle command you run here would hit the captain's live fleet.
+If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and have the brief regenerated with `--herdr-lab` before you continue.
 Do not add Herdr lifecycle commands to this unguarded brief by hand.
 EOF
 HERDR_SECTION=${HERDR_SECTION%$'\n'}
 fi
+
+# Deferred crew contracts live in one tracked reference the worker opens at a
+# named trigger, so their cost is paid only by the tasks that reach that moment.
+CREW_REFERENCE="$FM_ROOT/docs/crew-reference.md"
+
+# The declared-wait rule is NOT deferred, and deliberately so. Deferring a rule
+# needs a trigger the worker recognises BEFORE it needs the rule, and the
+# evidence says workers do not reliably notice that their own running loop has
+# become a wait: five crews idled on a long job in one day with this rule
+# present in every brief, buried as one numbered item among equals. So it gets a
+# heading of its own, the exact command, and the mechanism that makes declaring
+# matter - bin/fm-classify-lib.sh reads only the LAST status line, so a later
+# working: line silently cancels the pause bin/fm-watch.sh was honoring.
+# The gate-wait example is load-bearing, not decoration. Every example here used
+# to name something outside the pipeline (an upstream release, a rate-limit reset,
+# a scheduled window), and two workers on 2026-08-19 idled on their own validation
+# round without declaring, each costing a false wedge escalation: the run is their
+# own work, so it did not read as an external wait. The self-test is therefore
+# "working or watching", never "is this something other than me" - that phrasing
+# reproduces the miss. Do not trim the gate-wait case back out.
+IFS= read -r -d '' WAIT_SECTION <<EOF || true
+# Before you wait, declare it
+Ask this before every long-running command: once it starts, am I working, or watching?
+If you are watching, you are waiting, and a wait has to be declared.
+**Your own validation round returning through the gate counts, and it is the case workers miss.**
+It is your work, so it does not feel like an external wait - but while it runs you are idle, and an idle pane is all firstmate can see.
+A CI run, a long build or test suite, a review you are hosting, a rate-limit reset, a scheduled window all count the same way.
+Declare it BEFORE you start waiting:
+   \`echo "$PAUSED_VERB: {what you await, and what will end it}" >> $STATUS_FILE\`
+Firstmate cannot tell a pane that is waiting on purpose from one that has wedged, so an undeclared wait makes it interrupt you to find out; a declared one is left alone and rechecked on a long cadence.
+The declaration holds only while it is your LAST status line - appending \`working:\` on top of it cancels the pause, and you look wedged again.
+This is not \`blocked:\`. Pause when the wait will clear on its own; block when firstmate has to act.
+EOF
+WAIT_SECTION=${WAIT_SECTION%$'\n'}
 
 if [ "$KIND" = scout ]; then
 cat > "$BRIEF" <<EOF
@@ -321,20 +395,18 @@ The report is the only thing that survives, so anything worth keeping must be in
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
    Each append wakes firstmate, so report sparingly: only phase changes a supervisor
-   would act on and the needs-decision/blocked/paused/done/failed states. No step-by-step
+   would act on and the needs-decision/blocked/$PAUSED_VERB/done/failed states. No step-by-step
    FYI progress lines; firstmate reads your pane for that.
-   Use \`$PAUSED_VERB: {why}\` - distinct from \`blocked:\` - ONLY when you are deliberately idling on a
-   known external wait you expect to clear on its own (an upstream release, a rate-limit reset):
-   firstmate then leaves your idle pane alone and rechecks it on a long cadence instead of
-   treating it as a possible wedge. Use \`blocked:\` when you are stuck and need help.
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
 6. If a decision belongs to a human (product choices, destructive actions),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
-   A decision or blocker you opened stays open until a \`resolved\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
-   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved: {how it cleared}\` yourself (same \`[key=<slug>]\` if you opened it with one) as you resume.
+   You own closing what you open: when a decision, blocker, or wait you declared stops being true,
+   read \`$CREW_REFERENCE\` first - only a matching \`resolved\` line closes it.
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+
+$WAIT_SECTION
 
 # Definition of done
 Write your findings to \`$DATA/$ID/report.md\`.
@@ -344,7 +416,7 @@ Before reporting done, read and follow \`$FM_ROOT/.agents/skills/decision-hold-l
 When the report is complete, append \`done: {one-line conclusion}\` to the status file and stop.
 If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.
 EOF
-echo "scaffolded: $BRIEF (scout; replace {TASK})"
+announce "scout; replace {TASK}"
 exit 0
 fi
 
@@ -389,16 +461,12 @@ The task is complete only when committed on your branch.
 When you believe it is complete, append \`done: {summary}\` to the status file and stop.
 Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
 
-You drive no-mistakes by responding to its gates, not by implementing fixes.
-Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
-When starting no-mistakes, make \`--intent\` preserve all relevant content from this brief's \`# Task\` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
-Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
+Before your first \`no-mistakes\` command, read \`$CREW_REFERENCE\`.
+It owns how you drive the pipeline: that you answer gates rather than implement fixes, what \`--intent\` must carry, how an escalated decision comes back to the gate, and where you stop.
+Reading it then is part of the task, not optional background.
 
-Two firstmate-specific rules layer on top of that guidance:
-- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
-  Firstmate applies the authority contract in its \`AGENTS.md\` and obtains any required captain decision.
-  When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
-- Avoid \`--yes\`: it would silently bypass firstmate's authority check and any required captain escalation.
+One rule from it stays here, because it fires against your instinct at the moment it applies: ask-user findings are never yours to answer.
+Escalate with \`needs-decision:\` and stop (rule 6). Firstmate applies the authority contract in its \`AGENTS.md\` and obtains any required captain decision.
 
 After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
 EOF
@@ -436,30 +504,26 @@ $RULE1
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
    Each append wakes firstmate, so report sparingly: only phase changes a supervisor
    would act on (setup done, bug reproduced, fix implemented, validation passed) and the
-   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
+   needs-decision/blocked/$PAUSED_VERB/done/failed states. No step-by-step FYI progress lines;
    firstmate reads your pane for that.
    A mid-task \`working:\` line (including setup complete) is nonterminal: do not end the
    turn after it; continue the same stage until a defined \`done:\` gate under Definition of done.
-   Use \`$PAUSED_VERB: {why}\` - distinct from \`blocked:\` - ONLY when you are deliberately idling on a
-   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
-   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
-   cadence instead of treating it as a possible wedge. Use \`blocked:\` when you are stuck and need help.
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
 6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
    append \`needs-decision: {summary of options}\` and stop. Firstmate will apply the configured authority and reply with the decision.
-   A decision or blocker you opened stays open until a \`resolved\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
-   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved: {how it cleared}\` yourself (same \`[key=<slug>]\` if you opened it with one) as you resume.
+   You own closing what you open: when a decision, blocker, or wait you declared stops being true,
+   read \`$CREW_REFERENCE\` first - only a matching \`resolved\` line closes it.
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
 
+$WAIT_SECTION
+
 # Project memory
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.
-Record only project knowledge useful to almost every future session.
-For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
-If you touch a project \`AGENTS.md\` that lacks \`## Maintaining this file\`, add that short self-governance section from \`$FM_ROOT/bin/fm-ensure-agents-md.sh\` in the same pass.
+That script owns the authoring bar and writes it into the file's own \`## Maintaining this file\` section; follow the bar you find there for whatever you add.
 Keep it proportionate: skip \`AGENTS.md\` edits for trivial tasks that produced no durable project knowledge.
 
 $DOD
 EOF
-echo "scaffolded: $BRIEF (ship, mode=$MODE; replace {TASK})"
+announce "ship, mode=$MODE; replace {TASK}"

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -111,6 +111,7 @@ else
 fi
 if [ -n "${FM_STATE_OVERRIDE:-}" ]; then
   STATE=$(resolve_directory_input FM_STATE_OVERRIDE "$FM_STATE_OVERRIDE") || exit 1
+  FM_STATE_OVERRIDE=$STATE
 else
   STATE="$FM_HOME/state"
 fi
@@ -204,6 +205,11 @@ else
   REPO=${POS[1]}
 fi
 
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
+# shellcheck source=bin/fm-brief-lib.sh
+. "$SCRIPT_DIR/fm-brief-lib.sh"
+
 BRIEF="$DATA/$ID/brief.md"
 # A re-scaffold is a real need (a corrected base ref, a changed delivery mode), and
 # a bare refusal does not remove that need - it only pushes the operator into an
@@ -212,53 +218,54 @@ BRIEF="$DATA/$ID/brief.md"
 # governs, so the worker follows whichever copy it read last. --replace is the
 # supported path, and it archives the superseded brief instead of destroying the
 # filled-in task text that made hand-editing look safer than regenerating.
-if [ -e "$BRIEF" ] || [ -L "$BRIEF" ]; then
-  if [ -L "$BRIEF" ] || [ ! -f "$BRIEF" ]; then
-    echo "error: existing brief must be a regular file, not a symlink or other file type: $BRIEF" >&2
-    exit 1
-  fi
-  if [ "$REPLACE" -eq 0 ]; then
-    echo "error: $BRIEF already exists; pass --replace to regenerate it (the superseded brief is archived, never appended to)" >&2
-    exit 1
-  fi
-  n=1
-  while [ -e "$DATA/$ID/brief.superseded-$n.md" ] || [ -L "$DATA/$ID/brief.superseded-$n.md" ]; do n=$((n + 1)); done
-  ARCHIVED="$DATA/$ID/brief.superseded-$n.md"
-fi
 mkdir -p "$DATA/$ID"
 STAGE_DIR=$(mktemp -d "$DATA/$ID/.brief-stage.XXXXXX")
 STAGED="$STAGE_DIR/brief.md"
 ARCHIVE_STAGED=
+BRIEF_LOCK=$(fm_brief_publication_lock_path "$STATE" "$ID")
+BRIEF_LOCK_HELD=0
 
 cleanup_staged_brief() {
+  if [ "${BRIEF_LOCK_HELD:-0}" -eq 1 ]; then
+    BRIEF_LOCK_HELD=0
+    fm_lock_release "$BRIEF_LOCK"
+  fi
   [ -z "${STAGED:-}" ] || rm -f -- "$STAGED"
   [ -z "${ARCHIVE_STAGED:-}" ] || rm -f -- "$ARCHIVE_STAGED"
   [ -z "${STAGE_DIR:-}" ] || rmdir "$STAGE_DIR" 2>/dev/null || true
 }
 trap cleanup_staged_brief EXIT
 
-replace_staged_brief() {
-  case "${OSTYPE:-}" in
-    darwin*)
-      perl -e 'rename($ARGV[0], $ARGV[1]) or die "error: cannot replace $ARGV[1]: $!\n"' -- "$1" "$2" || return 1
-      ;;
-    linux*) mv -fT -- "$1" "$2" ;;
-    *) echo "error: unsupported platform for no-follow brief replacement: ${OSTYPE:-unknown}" >&2; return 1 ;;
-  esac
-}
-
 publish_brief() {
   local detail=$1
+  fm_lock_acquire_wait "$BRIEF_LOCK"
+  BRIEF_LOCK_HELD=1
+  ARCHIVED=
+  if [ -e "$BRIEF" ] || [ -L "$BRIEF" ]; then
+    if [ -L "$BRIEF" ] || [ ! -f "$BRIEF" ]; then
+      echo "error: existing brief must be a regular file, not a symlink or other file type: $BRIEF" >&2
+      return 1
+    fi
+    if [ "$REPLACE" -eq 0 ]; then
+      echo "error: $BRIEF already exists; pass --replace to regenerate it (the superseded brief is archived, never appended to)" >&2
+      return 1
+    fi
+    n=1
+    while [ -e "$DATA/$ID/brief.superseded-$n.md" ] || [ -L "$DATA/$ID/brief.superseded-$n.md" ]; do n=$((n + 1)); done
+    ARCHIVED="$DATA/$ID/brief.superseded-$n.md"
+  fi
   if [ -n "$ARCHIVED" ]; then
     ARCHIVE_STAGED="$STAGE_DIR/brief.superseded.md"
     cp -p -- "$BRIEF" "$ARCHIVE_STAGED"
-    replace_staged_brief "$ARCHIVE_STAGED" "$ARCHIVED"
+    fm_brief_replace_staged "$ARCHIVE_STAGED" "$ARCHIVED"
     ARCHIVE_STAGED=
   fi
-  replace_staged_brief "$STAGED" "$BRIEF"
+  fm_brief_replace_staged "$STAGED" "$BRIEF"
   STAGED=
   rmdir "$STAGE_DIR"
   STAGE_DIR=
+  BRIEF_LOCK_HELD=0
+  fm_lock_release "$BRIEF_LOCK"
   if [ -n "$ARCHIVED" ]; then
     echo "scaffolded: $BRIEF ($detail; replaced, superseded brief archived at $ARCHIVED)"
   else

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -239,7 +239,9 @@ trap cleanup_staged_brief EXIT
 
 replace_staged_brief() {
   case "${OSTYPE:-}" in
-    darwin*) mv -fh -- "$1" "$2" ;;
+    darwin*)
+      perl -e 'rename($ARGV[0], $ARGV[1]) or die "error: cannot replace $ARGV[1]: $!\n"' -- "$1" "$2" || return 1
+      ;;
     linux*) mv -fT -- "$1" "$2" ;;
     *) echo "error: unsupported platform for no-follow brief replacement: ${OSTYPE:-unknown}" >&2; return 1 ;;
   esac

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -134,6 +134,8 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 . "$SCRIPT_DIR/fm-pr-lib.sh"
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
+# shellcheck source=bin/fm-brief-lib.sh
+. "$SCRIPT_DIR/fm-brief-lib.sh"
 
 POLL=${FM_CONTROL_POLL:-0.5}
 SETTLE_WAIT=${FM_CONTROL_SETTLE_WAIT:-5}
@@ -160,6 +162,10 @@ control_cleanup() {
   if [ "$CONTROL_LOCK_HELD" = 1 ]; then
     CONTROL_LOCK_HELD=0
     fm_lock_release "$CONTROL_LOCK" || true
+  fi
+  if [ "${RELAUNCH_BRIEF_LOCK_HELD:-0}" = 1 ]; then
+    RELAUNCH_BRIEF_LOCK_HELD=0
+    fm_lock_release "$RELAUNCH_BRIEF_LOCK" || true
   fi
   return "$status"
 }
@@ -494,11 +500,16 @@ do_exit() {
 JOURNAL="$STATE/$ID.control-relaunch"
 META_PRIOR="$JOURNAL.meta-prior"
 BRIEF_PRIOR="$JOURNAL.brief-prior"
+BRIEF_NEXT="$JOURNAL.brief-next"
 NOTE_FILE="$JOURNAL.note"
 RELAUNCH_META_PUBLISHED=0
 RELAUNCH_AGENT_CONFIRMED=0
 RELAUNCH_TX=
 RELAUNCH_BRIEF=
+RELAUNCH_BRIEF_LOCK=
+RELAUNCH_BRIEF_LOCK_HELD=0
+RELAUNCH_BRIEF_ROLLBACK=
+RELAUNCH_BRIEF_NEXT_READY=0
 PRIOR_HARNESS=$HARNESS
 PRIOR_RECORDED_HARNESS=$RECORDED_HARNESS
 CONFIG_HARNESS=
@@ -539,6 +550,33 @@ journal_write() {  # <phase> [extra-line]...
   return 1
 }
 
+relaunch_brief_lock_release() {
+  [ "$RELAUNCH_BRIEF_LOCK_HELD" = 1 ] || return 0
+  RELAUNCH_BRIEF_LOCK_HELD=0
+  fm_lock_release "$RELAUNCH_BRIEF_LOCK"
+}
+
+restore_relaunch_brief() {
+  local rc
+  RELAUNCH_BRIEF_ROLLBACK=unchanged
+  [ "$RELAUNCH_BRIEF_NEXT_READY" = 1 ] \
+    && [ -n "$RELAUNCH_BRIEF" ] && [ -f "$BRIEF_PRIOR" ] && [ -f "$BRIEF_NEXT" ] \
+    || return 0
+  if fm_brief_restore_if_matches_locked "$STATE" "$ID" "$BRIEF_NEXT" \
+      "$BRIEF_PRIOR" "$RELAUNCH_BRIEF"; then
+    RELAUNCH_BRIEF_ROLLBACK=instructions-restored
+    return 0
+  else
+    rc=$?
+  fi
+  if [ "$rc" -eq 2 ]; then
+    RELAUNCH_BRIEF_ROLLBACK=superseding-instructions-preserved
+    return 0
+  fi
+  RELAUNCH_BRIEF_ROLLBACK=instructions-restore-failed
+  return "$rc"
+}
+
 relaunch_rollback() {
   local state
   [ "$RELAUNCH_ACTIVE" = 1 ] || return 0
@@ -548,21 +586,25 @@ relaunch_rollback() {
     checkpoint|noted)
       # The old agent was never touched. Restore the instructions byte-exact so
       # a refused relaunch leaves nothing behind.
-      if [ -n "$RELAUNCH_BRIEF" ] && [ -f "$BRIEF_PRIOR" ]; then
-        cp -p "$BRIEF_PRIOR" "$RELAUNCH_BRIEF" 2>/dev/null || true
+      restore_relaunch_brief || true
+      journal_write "failed:$RELAUNCH_PHASE" "rollback=$RELAUNCH_BRIEF_ROLLBACK" || true
+      if [ "$RELAUNCH_BRIEF_ROLLBACK" = superseding-instructions-preserved ]; then
+        echo "error: relaunch of $ID was refused before its agent was touched; a newer instructions publication was preserved" >&2
+      else
+        echo "error: relaunch of $ID was refused before its agent was touched; nothing changed" >&2
       fi
-      journal_write "failed:$RELAUNCH_PHASE" "rollback=instructions-restored" || true
-      echo "error: relaunch of $ID was refused before its agent was touched; nothing changed" >&2
       ;;
     stopping)
       state=$(agent_state 2>/dev/null || printf unknown)
       case "$state" in
         alive)
-          if [ -n "$RELAUNCH_BRIEF" ] && [ -f "$BRIEF_PRIOR" ]; then
-            cp -p "$BRIEF_PRIOR" "$RELAUNCH_BRIEF" 2>/dev/null || true
+          restore_relaunch_brief || true
+          journal_write "failed:$RELAUNCH_PHASE" "rollback=$RELAUNCH_BRIEF_ROLLBACK-agent-alive" || true
+          if [ "$RELAUNCH_BRIEF_ROLLBACK" = superseding-instructions-preserved ]; then
+            echo "error: relaunch of $ID failed while stopping the old agent, which is still running; a newer instructions publication was preserved" >&2
+          else
+            echo "error: relaunch of $ID failed while stopping the old agent, which is still running; its original instructions were restored" >&2
           fi
-          journal_write "failed:$RELAUNCH_PHASE" "rollback=instructions-restored-agent-alive" || true
-          echo "error: relaunch of $ID failed while stopping the old agent, which is still running; its original instructions were restored" >&2
           ;;
         dead)
           journal_write "failed:$RELAUNCH_PHASE" "rollback=prior-record-kept-agent-dead" || true
@@ -749,8 +791,19 @@ record_note() {
   printf '%s\n' "$NOTE" > "$NOTE_FILE"
   case "$KIND" in
     ship|scout)
-      cp -p "$RELAUNCH_BRIEF" "$BRIEF_PRIOR" \
-        || die "could not preserve task $ID's instructions before recording the progress note"
+      RELAUNCH_BRIEF_LOCK=$(fm_brief_publication_lock_path "$STATE" "$ID") \
+        || die "could not resolve task $ID's instructions publication lock"
+      fm_lock_acquire_wait "$RELAUNCH_BRIEF_LOCK" \
+        || die "could not lock task $ID's instructions before recording the progress note"
+      RELAUNCH_BRIEF_LOCK_HELD=1
+      if ! fm_brief_snapshot "$RELAUNCH_BRIEF" "$BRIEF_PRIOR"; then
+        relaunch_brief_lock_release || true
+        die "could not preserve task $ID's instructions before recording the progress note"
+      fi
+      if ! fm_brief_snapshot "$BRIEF_PRIOR" "$BRIEF_NEXT"; then
+        relaunch_brief_lock_release || true
+        die "could not stage task $ID's progress-note instructions"
+      fi
       {
         echo
         echo "## Progress note ($stamp)"
@@ -759,14 +812,23 @@ record_note() {
         echo "uncommitted change are exactly as the previous worker left them."
         echo
         printf '%s\n' "$NOTE"
-      } >> "$RELAUNCH_BRIEF" \
-        || die "could not append the progress note to task $ID's instructions"
+      } >> "$BRIEF_NEXT" || {
+        relaunch_brief_lock_release || true
+        die "could not append the progress note to task $ID's staged instructions"
+      }
+      if ! fm_brief_copy_atomic "$BRIEF_NEXT" "$RELAUNCH_BRIEF"; then
+        relaunch_brief_lock_release || true
+        die "could not publish the progress note to task $ID's instructions"
+      fi
+      RELAUNCH_BRIEF_NEXT_READY=1
+      relaunch_brief_lock_release \
+        || die "could not unlock task $ID's instructions after recording the progress note"
       ;;
   esac
 }
 
 do_relaunch() {
-  local exit_result state note_line
+  local exit_result state note_line spawn_status
   local -a spawn_args
 
   require_state_verified_backend relaunch
@@ -814,8 +876,24 @@ do_relaunch() {
   spawn_args=("$ID" --relaunch --harness "$TARGET_HARNESS")
   [ "$TARGET_MODEL" = default ] || spawn_args+=(--model "$TARGET_MODEL")
   [ "$TARGET_EFFORT" = default ] || spawn_args+=(--effort "$TARGET_EFFORT")
-  if FM_CONTROL_RELAUNCH_TX="$RELAUNCH_TX" \
-      "$SCRIPT_DIR/fm-spawn.sh" "${spawn_args[@]}" >/dev/null; then
+  spawn_status=0
+  if [ "$RELAUNCH_BRIEF_NEXT_READY" = 1 ]; then
+    if FM_CONTROL_RELAUNCH_TX="$RELAUNCH_TX" \
+        FM_CONTROL_RELAUNCH_BRIEF_SNAPSHOT="$BRIEF_NEXT" \
+        "$SCRIPT_DIR/fm-spawn.sh" "${spawn_args[@]}" >/dev/null; then
+      :
+    else
+      spawn_status=$?
+    fi
+  else
+    if FM_CONTROL_RELAUNCH_TX="$RELAUNCH_TX" \
+        "$SCRIPT_DIR/fm-spawn.sh" "${spawn_args[@]}" >/dev/null; then
+      :
+    else
+      spawn_status=$?
+    fi
+  fi
+  if [ "$spawn_status" -eq 0 ]; then
     RELAUNCH_META_PUBLISHED=1
   else
     [ "$(fm_meta_get "$META" control_relaunch_tx)" != "$RELAUNCH_TX" ] \

--- a/bin/fm-home-seed.sh
+++ b/bin/fm-home-seed.sh
@@ -49,6 +49,8 @@ SUB_HOME_PARENT_MARKER=".fm-secondmate-parent"
 . "$SCRIPT_DIR/fm-secondmate-charter-lib.sh"
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
+# shellcheck source=bin/fm-brief-lib.sh
+. "$SCRIPT_DIR/fm-brief-lib.sh"
 
 usage() {
   echo "usage: fm-home-seed.sh <id> <home|-> {<project>...|--no-projects}" >&2
@@ -526,10 +528,13 @@ SEED_PARENT_REG_EXISTED=0
 SEED_PARENT_BRIEF=
 SEED_PARENT_BRIEF_CREATED=0
 SEED_PARENT_BRIEF_DIR_CREATED=0
+SEED_PARENT_BRIEF_SNAPSHOT=
 SEED_SUB_REG_EXISTED=0
 SEED_CHARTER_EXISTED=0
+SEED_CHARTER_PUBLISHED=0
 SEED_MARKER_EXISTED=0
 SEED_PARENT_MARKER_EXISTED=0
+SEED_ID=
 
 restore_seed_file() {
   local existed=$1 backup=$2 path=$3
@@ -539,6 +544,21 @@ restore_seed_file() {
   else
     rm -f "$path" 2>/dev/null || true
   fi
+}
+
+restore_seed_charter() {
+  local replacement='' rc
+  [ "$SEED_CHARTER_PUBLISHED" = 1 ] || return 0
+  if [ "$SEED_CHARTER_EXISTED" = 1 ]; then
+    replacement="$SEED_BACKUP_DIR/charter.md"
+  fi
+  if fm_brief_restore_if_matches_locked "$SEED_HOME/state" "$SEED_ID" \
+      "$SEED_PARENT_BRIEF_SNAPSHOT" "$replacement" "$SEED_HOME/data/charter.md"; then
+    return 0
+  else
+    rc=$?
+  fi
+  [ "$rc" -eq 2 ] || return "$rc"
 }
 
 seed_rollback_target() {
@@ -628,8 +648,10 @@ seed_rollback() {
   [ "${SEED_ROLLBACK_ACTIVE:-0}" = 1 ] || return 0
   [ "${SEED_COMMITTED:-0}" = 0 ] || return 0
 
-  if [ -n "${SEED_PARENT_BRIEF:-}" ] && [ "$SEED_PARENT_BRIEF_CREATED" = 1 ]; then
-    rm -f "$SEED_PARENT_BRIEF" 2>/dev/null || true
+  if [ -n "${SEED_PARENT_BRIEF:-}" ] && [ "$SEED_PARENT_BRIEF_CREATED" = 1 ] \
+     && [ -f "$SEED_PARENT_BRIEF_SNAPSHOT" ]; then
+    fm_brief_restore_if_matches_locked "$STATE" "$SEED_ID" \
+      "$SEED_PARENT_BRIEF_SNAPSHOT" "" "$SEED_PARENT_BRIEF" 2>/dev/null || true
   fi
   if [ -n "${SEED_PARENT_BRIEF:-}" ] && [ "$SEED_PARENT_BRIEF_DIR_CREATED" = 1 ]; then
     rmdir "$(dirname "$SEED_PARENT_BRIEF")" 2>/dev/null || true
@@ -650,7 +672,7 @@ seed_rollback() {
       if [ -n "${SEED_BACKUP_DIR:-}" ] && [ "${SEED_HOME_BACKED_UP:-0}" = 1 ]; then
         restore_seed_file "$SEED_MARKER_EXISTED" "$SEED_BACKUP_DIR/marker" "$SEED_HOME/$SUB_HOME_MARKER"
         restore_seed_file "$SEED_PARENT_MARKER_EXISTED" "$SEED_BACKUP_DIR/parent-marker" "$SEED_HOME/$SUB_HOME_PARENT_MARKER"
-        restore_seed_file "$SEED_CHARTER_EXISTED" "$SEED_BACKUP_DIR/charter.md" "$SEED_HOME/data/charter.md"
+        restore_seed_charter || true
         restore_seed_file "$SEED_SUB_REG_EXISTED" "$SEED_BACKUP_DIR/sub-projects.md" "$SEED_HOME/data/projects.md"
       fi
     fi
@@ -846,10 +868,13 @@ seed_home() {
   : > "$SEED_CREATED_PROJECTS_FILE"
   SEED_PARENT_REG_EXISTED=0
   SEED_PARENT_BRIEF="$DATA/$id/brief.md"
+  SEED_ID=$id
   SEED_PARENT_BRIEF_CREATED=0
   SEED_PARENT_BRIEF_DIR_CREATED=0
+  SEED_PARENT_BRIEF_SNAPSHOT=
   SEED_SUB_REG_EXISTED=0
   SEED_CHARTER_EXISTED=0
+  SEED_CHARTER_PUBLISHED=0
   SEED_MARKER_EXISTED=0
   if [ -f "$REG" ]; then
     SEED_PARENT_REG_EXISTED=1
@@ -877,9 +902,6 @@ seed_home() {
   validate_existing_parent_binding "$home" || return 1
   if [ "$no_projects" -eq 1 ]; then
     refuse_populated_projectless_home "$home" || return 1
-    if [ -f "$SEED_PARENT_BRIEF" ]; then
-      refuse_projectful_projectless_charter "$id" "$SEED_PARENT_BRIEF" || return 1
-    fi
   fi
   mkdir -p "$DATA" "$home/data" "$home/state" "$home/config" "$home/projects"
   if [ -f "$home/data/projects.md" ]; then
@@ -888,7 +910,8 @@ seed_home() {
   fi
   if [ -f "$home/data/charter.md" ]; then
     SEED_CHARTER_EXISTED=1
-    cp "$home/data/charter.md" "$SEED_BACKUP_DIR/charter.md"
+    fm_brief_copy_locked "$home/state" "$id" "$home/data/charter.md" \
+      "$SEED_BACKUP_DIR/charter.md" || return 1
   fi
   if [ -f "$home/$SUB_HOME_MARKER" ]; then
     SEED_MARKER_EXISTED=1
@@ -913,16 +936,22 @@ seed_home() {
     fi
     SEED_PARENT_BRIEF_CREATED=1
   fi
-  if grep -F '{TASK}' "$SEED_PARENT_BRIEF" >/dev/null 2>&1; then
+  SEED_PARENT_BRIEF_SNAPSHOT="$SEED_BACKUP_DIR/parent-brief.snapshot.md"
+  fm_brief_copy_locked "$STATE" "$id" "$SEED_PARENT_BRIEF" \
+    "$SEED_PARENT_BRIEF_SNAPSHOT" || return 1
+  if [ "$no_projects" -eq 1 ]; then
+    refuse_projectful_projectless_charter "$id" "$SEED_PARENT_BRIEF_SNAPSHOT" || return 1
+  fi
+  if grep -F '{TASK}' "$SEED_PARENT_BRIEF_SNAPSHOT" >/dev/null 2>&1; then
     echo "error: secondmate charter brief at $SEED_PARENT_BRIEF still contains {TASK}; fill it before seeding" >&2
     return 1
   fi
-  charter_summary=$(registry_summary_for_brief "$SEED_PARENT_BRIEF")
+  charter_summary=$(registry_summary_for_brief "$SEED_PARENT_BRIEF_SNAPSHOT")
   [ -n "$charter_summary" ] || {
     echo "error: secondmate charter brief at $SEED_PARENT_BRIEF has an empty Charter section; fill it before seeding" >&2
     return 1
   }
-  charter_scope=$(registry_scope_for_brief "$SEED_PARENT_BRIEF")
+  charter_scope=$(registry_scope_for_brief "$SEED_PARENT_BRIEF_SNAPSHOT")
   [ -n "$charter_scope" ] || {
     echo "error: secondmate charter brief at $SEED_PARENT_BRIEF has an empty Routing scope section; fill it before seeding" >&2
     return 1
@@ -943,7 +972,9 @@ seed_home() {
     fi
   done
 
-  cp "$SEED_PARENT_BRIEF" "$home/data/charter.md"
+  fm_brief_copy_locked "$home/state" "$id" "$SEED_PARENT_BRIEF_SNAPSHOT" \
+    "$home/data/charter.md" || return 1
+  SEED_CHARTER_PUBLISHED=1
 
   projects_csv=$(join_projects "$@")
   # Durable record of this home's route to its parent, written once here next
@@ -959,7 +990,7 @@ seed_home() {
   mv -f -- "$home/$SUB_HOME_PARENT_MARKER.tmp.$$" "$home/$SUB_HOME_PARENT_MARKER"
   printf '%s\n' "$id" > "$home/$SUB_HOME_MARKER.tmp.$$"
   mv -f -- "$home/$SUB_HOME_MARKER.tmp.$$" "$home/$SUB_HOME_MARKER"
-  write_registry "$id" "$home" "$projects_csv" "$SEED_PARENT_BRIEF"
+  write_registry "$id" "$home" "$projects_csv" "$SEED_PARENT_BRIEF_SNAPSHOT"
   validate_registry
   SEED_COMMITTED=1
   seed_registry_lock_release

--- a/bin/fm-home-seed.sh
+++ b/bin/fm-home-seed.sh
@@ -794,7 +794,7 @@ refuse_projectful_projectless_charter() {
     return 0
   fi
   printf 'error: cannot seed project-less secondmate home because existing charter brief at %s conflicts with --no-projects\n' "$brief" >&2
-  printf 'error: re-scaffold it with fm-brief.sh %s --secondmate --no-projects or remove the stale brief before seeding\n' "$id" >&2
+  printf 'error: re-scaffold it with fm-brief.sh %s --secondmate --no-projects --replace or remove the stale brief before seeding\n' "$id" >&2
   return 1
 }
 

--- a/bin/fm-remote-home-provision.sh
+++ b/bin/fm-remote-home-provision.sh
@@ -49,6 +49,7 @@ CREATED_HOME=0
 CREATED_BACKLOG=0
 EXISTING_HOME=0
 PUBLISHED=0
+CHARTER_PUBLISHED=0
 PROVISION_LOCK=
 PROVISION_LOCK_HELD=0
 CREATED_PROJECTS="$TMP/created-projects"
@@ -61,6 +62,21 @@ release_provision_lock() {
 }
 restore_owned_file() { # <relative-path>
   local rel=$1 dest="$FM_HOME/$1" backup="$TMP/before/$1"
+  if [ "$rel" = data/charter.md ]; then
+    local replacement='' rc
+    [ "$CHARTER_PUBLISHED" -eq 1 ] || return 0
+    if [ -f "$backup.present" ]; then
+      replacement=$backup
+    fi
+    if fm_brief_restore_if_matches_locked "$FM_HOME/state" "$ID" \
+        "$TMP/charter" "$replacement" "$dest"; then
+      return 0
+    else
+      rc=$?
+    fi
+    [ "$rc" -eq 2 ] || return "$rc"
+    return 0
+  fi
   if [ -f "$backup.present" ]; then
     mkdir -p "$(dirname "$dest")" || return 1
     cp -p -- "$backup" "$dest.tmp.rollback.$$" || return 1
@@ -141,6 +157,8 @@ fi
 FM_STATE_OVERRIDE="$PROVISION_LOCK_STATE"
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
+# shellcheck source=bin/fm-brief-lib.sh
+. "$SCRIPT_DIR/fm-brief-lib.sh"
 PROVISION_LOCK="$STATE/.remote-home-provision-$HOME_LOCK_KEY.lock"
 fm_lock_acquire_wait "$PROVISION_LOCK"
 PROVISION_LOCK_HELD=1
@@ -239,9 +257,10 @@ EOF
   printf '%s\n' "$REGISTRY_LINE" >> "$PROJECT_REG"
 done < <(grep '^project=' "$TMP/manifest")
 
-cp "$TMP/charter" "$FM_HOME/data/charter.md.tmp.$$"
-chmod 600 "$FM_HOME/data/charter.md.tmp.$$"
-mv -f -- "$FM_HOME/data/charter.md.tmp.$$" "$FM_HOME/data/charter.md"
+chmod 600 "$TMP/charter"
+fm_brief_copy_locked "$FM_HOME/state" "$ID" "$TMP/charter" "$FM_HOME/data/charter.md" \
+  || die "cannot publish the remote charter"
+CHARTER_PUBLISHED=1
 cp "$PROJECT_REG" "$FM_HOME/data/projects.md.tmp.$$"
 mv -f -- "$FM_HOME/data/projects.md.tmp.$$" "$FM_HOME/data/projects.md"
 {

--- a/bin/fm-remote-home-seed.sh
+++ b/bin/fm-remote-home-seed.sh
@@ -39,6 +39,8 @@ MAX_MANIFEST_BYTES=1048576
 . "$SCRIPT_DIR/fm-secondmate-charter-lib.sh"
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
+# shellcheck source=bin/fm-brief-lib.sh
+. "$SCRIPT_DIR/fm-brief-lib.sh"
 # shellcheck source=bin/fm-remote-readiness-lib.sh
 . "$SCRIPT_DIR/fm-remote-readiness-lib.sh"
 # shellcheck source=bin/fm-project-origin-lib.sh
@@ -80,6 +82,7 @@ case "$REMOTE_HOME/" in "$REMOTE_ROOT/"*) die "remote home must not be inside th
 case "$REMOTE_ROOT/" in "$REMOTE_HOME/"*) die "remote code root must not be inside the remote home" ;; esac
 
 NO_PROJECTS=0
+PROJECT_COUNT=0
 PROJECT_NAMES=()
 PROJECT_ORIGINS=()
 for arg in "$@"; do
@@ -96,12 +99,13 @@ for arg in "$@"; do
     esac
     PROJECT_NAMES+=("$name")
     PROJECT_ORIGINS+=("$origin")
+    PROJECT_COUNT=$((PROJECT_COUNT + 1))
   fi
 done
 if [ "$NO_PROJECTS" -eq 1 ]; then
-  [ "${#PROJECT_NAMES[@]}" -eq 0 ] || die "--no-projects cannot be combined with project names"
+  [ "$PROJECT_COUNT" -eq 0 ] || die "--no-projects cannot be combined with project names"
 else
-  [ "${#PROJECT_NAMES[@]}" -gt 0 ] || die "at least one project or --no-projects is required"
+  [ "$PROJECT_COUNT" -gt 0 ] || die "at least one project or --no-projects is required"
 fi
 
 mkdir -p "$STATE" || die "cannot create parent state directory"
@@ -134,15 +138,21 @@ if [ ! -f "$BRIEF" ]; then
   fi
   BRIEF_CREATED=1
 fi
-if grep -F '{TASK}' "$BRIEF" >/dev/null 2>&1; then
-  [ "$BRIEF_CREATED" -eq 0 ] || rm -f -- "$BRIEF"
+TMP=$(mktemp -d "${TMPDIR:-/tmp}/fm-remote-home-seed.XXXXXX") || die "cannot create seed staging directory"
+BRIEF_SNAPSHOT="$TMP/brief.snapshot.md"
+fm_brief_copy_locked "$STATE" "$ID" "$BRIEF" "$BRIEF_SNAPSHOT" \
+  || die "cannot snapshot the parent charter"
+if grep -F '{TASK}' "$BRIEF_SNAPSHOT" >/dev/null 2>&1; then
+  if [ "$BRIEF_CREATED" -eq 1 ]; then
+    fm_brief_restore_if_matches_locked "$STATE" "$ID" "$BRIEF_SNAPSHOT" "" "$BRIEF" \
+      2>/dev/null || true
+  fi
   die "secondmate charter still contains {TASK}: $BRIEF"
 fi
-SUMMARY=$(registry_summary_for_brief "$BRIEF")
-SCOPE=$(registry_scope_for_brief "$BRIEF")
+SUMMARY=$(registry_summary_for_brief "$BRIEF_SNAPSHOT")
+SCOPE=$(registry_scope_for_brief "$BRIEF_SNAPSHOT")
 [ -n "$SUMMARY" ] && [ -n "$SCOPE" ] || die "charter summary and routing scope must be nonempty"
 
-TMP=$(mktemp -d "${TMPDIR:-/tmp}/fm-remote-home-seed.XXXXXX") || die "cannot create seed staging directory"
 REG_EXISTED=0
 [ -f "$REG" ] && { cp "$REG" "$TMP/registry.before"; REG_EXISTED=1; }
 
@@ -152,42 +162,44 @@ PARENT_STATUS="$STATE/$ID.status"
 REMOTE_STATUS="$REMOTE_HOME/state/parent-replies.status"
 while IFS= read -r line || [ -n "$line" ]; do
   printf '%s\n' "${line//"$PARENT_STATUS"/"$REMOTE_STATUS"}"
-done < "$BRIEF" > "$TMP/charter.remote"
+done < "$BRIEF_SNAPSHOT" > "$TMP/charter.remote"
 
 PROJECTS_CSV=
 : > "$TMP/project.records"
 PROJECT_INDEX=0
-for project in "${PROJECT_NAMES[@]}"; do
-  ORIGIN=${PROJECT_ORIGINS[$PROJECT_INDEX]}
-  PROJECT_INDEX=$((PROJECT_INDEX + 1))
-  MODE_LINE=$(FM_HOME="$FM_HOME" FM_DATA_OVERRIDE="$DATA" "$SCRIPT_DIR/fm-project-mode.sh" "$project")
-  read -r MODE _ <<EOF
+if [ "$PROJECT_COUNT" -gt 0 ]; then
+  for project in "${PROJECT_NAMES[@]}"; do
+    ORIGIN=${PROJECT_ORIGINS[$PROJECT_INDEX]}
+    PROJECT_INDEX=$((PROJECT_INDEX + 1))
+    MODE_LINE=$(FM_HOME="$FM_HOME" FM_DATA_OVERRIDE="$DATA" "$SCRIPT_DIR/fm-project-mode.sh" "$project")
+    read -r MODE _ <<EOF
 $MODE_LINE
 EOF
-  case "$MODE" in
-    no-mistakes|direct-PR) ;;
-    local-only) die "project $project is local-only and cannot be provisioned remotely" ;;
-    *) die "project $project has unsupported delivery mode: $MODE" ;;
-  esac
-  # An origin named on the command line is authoritative. Reading one from a
-  # clone this home happens to have is only a convenience for the already-cloned
-  # case; it is never a reason to create one.
-  if [ -z "$ORIGIN" ] && [ -d "$PROJECTS/$project/.git" ]; then
-    ORIGIN=$(git -C "$PROJECTS/$project" remote get-url origin 2>/dev/null || true)
-  fi
-  [ -n "$ORIGIN" ] \
-    || die "project $project has no origin; pass $project=<origin-url> so the remote host can clone it"
-  fm_project_origin_safe "$ORIGIN" \
-    || die "project $project origin is not an accepted clone URL: $ORIGIN"
-  REGISTRY_LINE=$(awk -v p="$project" '$1 == "-" && $2 == p { print; exit }' "$DATA/projects.md" 2>/dev/null || true)
-  [ -n "$REGISTRY_LINE" ] || die "project $project has no registry record"
-  NAME_B64=$(printf '%s' "$project" | encode)
-  ORIGIN_B64=$(printf '%s' "$ORIGIN" | encode)
-  PROJECT_REG_B64=$(printf '%s' "$REGISTRY_LINE" | encode)
-  MODE_B64=$(printf '%s' "$MODE" | encode)
-  printf 'project=%s|%s|%s|%s\n' "$NAME_B64" "$ORIGIN_B64" "$PROJECT_REG_B64" "$MODE_B64" >> "$TMP/project.records"
-  PROJECTS_CSV="${PROJECTS_CSV}${PROJECTS_CSV:+, }$project"
-done
+    case "$MODE" in
+      no-mistakes|direct-PR) ;;
+      local-only) die "project $project is local-only and cannot be provisioned remotely" ;;
+      *) die "project $project has unsupported delivery mode: $MODE" ;;
+    esac
+    # An origin named on the command line is authoritative. Reading one from a
+    # clone this home happens to have is only a convenience for the already-cloned
+    # case; it is never a reason to create one.
+    if [ -z "$ORIGIN" ] && [ -d "$PROJECTS/$project/.git" ]; then
+      ORIGIN=$(git -C "$PROJECTS/$project" remote get-url origin 2>/dev/null || true)
+    fi
+    [ -n "$ORIGIN" ] \
+      || die "project $project has no origin; pass $project=<origin-url> so the remote host can clone it"
+    fm_project_origin_safe "$ORIGIN" \
+      || die "project $project origin is not an accepted clone URL: $ORIGIN"
+    REGISTRY_LINE=$(awk -v p="$project" '$1 == "-" && $2 == p { print; exit }' "$DATA/projects.md" 2>/dev/null || true)
+    [ -n "$REGISTRY_LINE" ] || die "project $project has no registry record"
+    NAME_B64=$(printf '%s' "$project" | encode)
+    ORIGIN_B64=$(printf '%s' "$ORIGIN" | encode)
+    PROJECT_REG_B64=$(printf '%s' "$REGISTRY_LINE" | encode)
+    MODE_B64=$(printf '%s' "$MODE" | encode)
+    printf 'project=%s|%s|%s|%s\n' "$NAME_B64" "$ORIGIN_B64" "$PROJECT_REG_B64" "$MODE_B64" >> "$TMP/project.records"
+    PROJECTS_CSV="${PROJECTS_CSV}${PROJECTS_CSV:+, }$project"
+  done
+fi
 
 {
   printf 'schema=fm-remote-home-provision.v1\n'
@@ -200,7 +212,7 @@ done
   # back; the parent's real filesystem path is never sent, since it names
   # nothing on the remote filesystem.
   printf 'parent_host_b64=%s\n' "$(printf '%s' "$HOST" | encode)"
-  printf 'project_count=%s\n' "${#PROJECT_NAMES[@]}"
+  printf 'project_count=%s\n' "$PROJECT_COUNT"
   cat "$TMP/project.records"
 } > "$TMP/manifest"
 MANIFEST_BYTES=$(LC_ALL=C wc -c < "$TMP/manifest" | tr -d ' ')
@@ -220,7 +232,10 @@ fi
 
 restore_registry_and_brief() {
   if [ "$REG_EXISTED" -eq 1 ]; then cp "$TMP/registry.before" "$REG"; else rm -f -- "$REG"; fi
-  [ "$BRIEF_CREATED" -eq 0 ] || rm -f -- "$BRIEF"
+  if [ "$BRIEF_CREATED" -eq 1 ]; then
+    fm_brief_restore_if_matches_locked "$STATE" "$ID" "$BRIEF_SNAPSHOT" "" "$BRIEF" \
+      2>/dev/null || true
+  fi
 }
 
 # Preflight and, where it can, repair the remote runtime before anything is

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -14,6 +14,10 @@
 #   scaffolded before that line existed warns once and launches on the flag. When
 #   the explicit mode carries less rigor than the project's standing posture, a
 #   loud one-line deviation notice is printed and the spawn continues.
+#   Every spawn also refuses a brief that repeats a top-level "# " section, which
+#   is what hand-appending a regenerated brief onto the old one produces: the
+#   worker would follow whichever copy it read last. Regenerate with
+#   bin/fm-brief.sh --replace instead.
 #   no-mistakes-prod-only is a registry policy rather than a task mode and is
 #   refused as a flag value.
 #        fm-spawn.sh <task-id> --relaunch [--harness <name>] [--model <name>] [--effort <level>]
@@ -1642,6 +1646,21 @@ else
   BRIEF="$DATA/$ID/brief.md"
 fi
 [ -f "$BRIEF" ] || { echo "error: no brief at $BRIEF" >&2; exit 1; }
+
+# A brief that carries the same top-level section twice was appended to rather
+# than regenerated, which fm-brief.sh --replace now makes unnecessary. Refuse it
+# here because the damage lands on the worker: an agent follows the nearest,
+# most recent statement of a rule, so a duplicated brief silently governs by
+# whichever copy was read last, and nothing in the file marks which is current.
+# The mode check below reads only the FIRST delivery contract line, so a second
+# block carrying a different mode would otherwise launch unnoticed.
+DUP_SECTIONS=$(grep '^# ' "$BRIEF" | sort | uniq -d | sed 's/^/  /')
+if [ -n "$DUP_SECTIONS" ]; then
+  echo "error: $BRIEF repeats these sections, so which copy governs is undefined:" >&2
+  echo "$DUP_SECTIONS" >&2
+  echo "regenerate it with bin/fm-brief.sh --replace (which archives the superseded brief) instead of appending a second copy; use '##' for headings inside the task body" >&2
+  exit 1
+fi
 
 delivery_rigor_rank() {  # <mode> -> 3 (most rigor) .. 1 (least); 0 = not a task mode
   case "$1" in

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -153,7 +153,7 @@
 #   multi-task shell loop (the tool shell is zsh, which does not word-split unquoted
 #   $vars and silently breaks ad-hoc `for ... in $pairs` loops).
 #   Launch templates live in launch_template() below; placeholders replaced before launch:
-#     __BRIEF__    absolute path to data/<task-id>/brief.md
+#     __BRIEF__    absolute path to the task's immutable launch-brief snapshot
 #     __PIBIN__    quoted concrete Pi-family executable path resolved from PATH
 #     __PITUIMODE__ optional --tui-mode regular when that executable advertises it
 #     __TURNEND__  absolute path to state/<task-id>.turn-ended (for harnesses whose
@@ -244,6 +244,10 @@ SUB_HOME_MARKER=".fm-secondmate-home"
 . "$SCRIPT_DIR/fm-ff-lib.sh"
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
+# shellcheck source=bin/fm-brief-lib.sh
+. "$SCRIPT_DIR/fm-brief-lib.sh"
+# shellcheck source=bin/fm-secondmate-parent-lib.sh
+. "$SCRIPT_DIR/fm-secondmate-parent-lib.sh"
 # shellcheck source=bin/fm-secondmate-nudge-lib.sh
 . "$SCRIPT_DIR/fm-secondmate-nudge-lib.sh"
 # shellcheck source=bin/fm-config-inherit-lib.sh
@@ -676,6 +680,8 @@ RELAUNCH_REPLACEMENT_STATE=
 RELAUNCH_REPLACEMENT_WT=
 CONFIG_INHERIT_LOCK=
 CONFIG_INHERIT_LOCK_HELD=0
+BRIEF_SNAPSHOT=
+BRIEF_SNAPSHOT_RETAIN=0
 
 parse_orca_worktree_result() {
   local raw=$1 rest
@@ -786,6 +792,9 @@ spawn_abort_cleanup() {
   if [ "$CONFIG_INHERIT_LOCK_HELD" = 1 ]; then
     CONFIG_INHERIT_LOCK_HELD=0
     fm_lock_release "$CONFIG_INHERIT_LOCK" || true
+  fi
+  if [ "$BRIEF_SNAPSHOT_RETAIN" -ne 1 ] && [ -n "$BRIEF_SNAPSHOT" ]; then
+    rm -f -- "$BRIEF_SNAPSHOT" 2>/dev/null || true
   fi
   return "$status"
 }
@@ -1646,6 +1655,30 @@ else
   BRIEF="$DATA/$ID/brief.md"
 fi
 [ -f "$BRIEF" ] || { echo "error: no brief at $BRIEF" >&2; exit 1; }
+BRIEF_SOURCE=$BRIEF
+BRIEF_SNAPSHOT="$STATE/$ID.launch-brief.md"
+fm_brief_snapshot "$BRIEF_SOURCE" "$BRIEF_SNAPSHOT" || exit 1
+BRIEF=$BRIEF_SNAPSHOT
+
+duplicate_brief_recovery_guidance() {
+  if [ "$KIND" != secondmate ] || [ "$BRIEF_SOURCE" != "$PROJ_ABS/data/charter.md" ]; then
+    echo "regenerate it with bin/fm-brief.sh --replace (which archives the superseded brief) instead of appending a second copy" >&2
+    return
+  fi
+  if fm_secondmate_parent_record_parse "$PROJ_ABS/.fm-secondmate-parent"; then
+    case "$FM_SECONDMATE_PARENT_ROUTE" in
+      local)
+        echo "regenerate the parent charter with bin/fm-brief.sh --replace, then rerun bin/fm-home-seed.sh from the parent home to republish $PROJ_ABS/data/charter.md instead of appending a second copy" >&2
+        return
+        ;;
+      remote)
+        echo "regenerate the parent charter with bin/fm-brief.sh --replace, then rerun bin/fm-remote-home-seed.sh from the parent home to republish $PROJ_ABS/data/charter.md instead of appending a second copy" >&2
+        return
+        ;;
+    esac
+  fi
+  echo "regenerate the parent charter with bin/fm-brief.sh --replace, then republish $PROJ_ABS/data/charter.md with its route's bin/fm-home-seed.sh or bin/fm-remote-home-seed.sh instead of appending a second copy" >&2
+}
 
 # This guard is deliberately signature-based rather than refusing any repeated
 # heading. The duplication arose because bin/fm-brief.sh refused the re-scaffold,
@@ -1697,9 +1730,9 @@ DUP_SECTIONS=$(awk '
   }
 ' "$BRIEF" | sort | sed 's/^/  /')
 if [ -n "$DUP_SECTIONS" ]; then
-  echo "error: $BRIEF repeats these sections, so which copy governs is undefined:" >&2
+  echo "error: $BRIEF_SOURCE repeats these sections, so which copy governs is undefined:" >&2
   echo "$DUP_SECTIONS" >&2
-  echo "regenerate it with bin/fm-brief.sh --replace (which archives the superseded brief) instead of appending a second copy" >&2
+  duplicate_brief_recovery_guidance
   exit 1
 fi
 
@@ -1720,7 +1753,7 @@ if [ "$KIND" = ship ]; then
   PROJ_NAME=$(basename "$PROJ_ABS")
   BRIEF_MODE=$(sed -n 's/^Delivery contract: mode=\([^ ]*\).*$/\1/p' "$BRIEF" | head -n 1)
   if [ -z "$BRIEF_MODE" ]; then
-    echo "warning: $BRIEF records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode $MODE - confirm its definition of done matches" >&2
+    echo "warning: $BRIEF_SOURCE records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode $MODE - confirm its definition of done matches" >&2
   elif [ "$BRIEF_MODE" != "$MODE" ]; then
     echo "error: delivery mismatch for $ID: the brief says mode=$BRIEF_MODE but this spawn passed --mode $MODE; correct the flag or re-scaffold the brief so the worker's instructions and the task record agree" >&2
     exit 1
@@ -2149,6 +2182,7 @@ EOF
     ;;
 esac
 fi
+BRIEF_SNAPSHOT_RETAIN=1
 if [ "$KIND" = secondmate ]; then
   FM_INHERITABLE_CONFIG=trace-context \
     propagate_inheritable_config "$CONFIG" "$PROJ_ABS/config" \

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -14,10 +14,10 @@
 #   scaffolded before that line existed warns once and launches on the flag. When
 #   the explicit mode carries less rigor than the project's standing posture, a
 #   loud one-line deviation notice is printed and the spawn continues.
-#   Every spawn also refuses more than one generated-scaffold marker. Task Markdown
-#   may legitimately repeat scaffold heading names, so headings are not treated as
-#   generation identity. Regenerate a duplicated scaffold with bin/fm-brief.sh
-#   --replace instead.
+#   Every spawn also refuses more than one generated-scaffold marker, or more than
+#   one complete ordered legacy scaffold signature outside fenced code. Task
+#   Markdown may legitimately repeat individual scaffold heading names. Regenerate
+#   a duplicated scaffold with bin/fm-brief.sh --replace instead.
 #   no-mistakes-prod-only is a registry policy rather than a task mode and is
 #   refused as a flag value.
 #        fm-spawn.sh <task-id> --relaunch [--harness <name>] [--model <name>] [--effort <level>]
@@ -1700,12 +1700,85 @@ duplicate_brief_recovery_guidance() {
   echo "regenerate the parent charter with bin/fm-brief.sh --replace, then republish $PROJ_ABS/data/charter.md with its route's bin/fm-home-seed.sh or bin/fm-remote-home-seed.sh instead of appending a second copy" >&2
 }
 
+legacy_scaffold_signature_count() {
+  awk -v kind="$KIND" '
+    function trim_fence_indent(text, i) {
+      for (i = 0; i < 3 && substr(text, 1, 1) == " "; i++) text = substr(text, 2)
+      return text
+    }
+    function fence_marker_run(text, marker, i) {
+      marker = substr(text, 1, 1)
+      if (marker != "`" && marker != "~") return 0
+      for (i = 1; substr(text, i, 1) == marker; i++) {}
+      return i - 1
+    }
+    {
+      candidate = trim_fence_indent($0)
+      run = fence_marker_run(candidate)
+      marker = substr(candidate, 1, 1)
+      if (fence_marker == "") {
+        if (run >= 3) {
+          fence_marker = marker
+          fence_length = run
+          next
+        }
+      } else {
+        if (marker == fence_marker && run >= fence_length &&
+            substr(candidate, run + 1) ~ /^[[:space:]]*$/) {
+          fence_marker = ""
+          fence_length = 0
+        }
+        next
+      }
+      if ($0 !~ /^# /) next
+      if (kind == "secondmate") {
+        if ($0 == "# Charter") {
+          step = 1
+          next
+        }
+        if (step == 1 && $0 == "# Routing scope") {
+          step = 2
+          next
+        }
+        if (step == 2 && $0 == "# Operating model") {
+          step = 3
+          next
+        }
+      } else {
+        if ($0 == "# Task") {
+          step = 1
+          next
+        }
+        if (step == 1 && $0 == "# Setup") {
+          step = 2
+          next
+        }
+        if (step == 2 && $0 == "# Rules") {
+          step = 3
+          next
+        }
+      }
+      if (step == 3 && $0 == "# Definition of done") {
+        signatures++
+        step = 0
+      }
+    }
+    END { print signatures + 0 }
+  ' "$1"
+}
+
 # Each generated scaffold carries one fixed marker. Appending another generated
 # scaffold therefore has an unambiguous signature that cannot drift with section
 # names, while arbitrary task headings remain valid Markdown.
 SCAFFOLD_MARKER_COUNT=$(grep -Fxc "$FM_BRIEF_SCAFFOLD_MARKER" "$BRIEF" 2>/dev/null || true)
 if [ "$SCAFFOLD_MARKER_COUNT" -gt 1 ]; then
   echo "error: $BRIEF_SOURCE contains multiple generated scaffold markers, so which copy governs is undefined" >&2
+  duplicate_brief_recovery_guidance
+  exit 1
+fi
+LEGACY_SCAFFOLD_COUNT=$(legacy_scaffold_signature_count "$BRIEF") || exit 1
+if [ "$LEGACY_SCAFFOLD_COUNT" -gt 1 ]; then
+  echo "error: $BRIEF_SOURCE contains multiple generated scaffold signatures, so which copy governs is undefined" >&2
   duplicate_brief_recovery_guidance
   exit 1
 fi

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -14,8 +14,8 @@
 #   scaffolded before that line existed warns once and launches on the flag. When
 #   the explicit mode carries less rigor than the project's standing posture, a
 #   loud one-line deviation notice is printed and the spawn continues.
-#   Every spawn also refuses more than one generated-scaffold marker, or more than
-#   one complete ordered legacy scaffold signature outside fenced code. Task
+#   Every spawn also refuses more than one generated-scaffold marker or complete
+#   ordered legacy scaffold signature found outside fenced code. Task
 #   Markdown may legitimately repeat individual scaffold heading names. Regenerate
 #   a duplicated scaffold with bin/fm-brief.sh --replace instead.
 #   no-mistakes-prod-only is a registry policy rather than a task mode and is
@@ -1700,8 +1700,8 @@ duplicate_brief_recovery_guidance() {
   echo "regenerate the parent charter with bin/fm-brief.sh --replace, then republish $PROJ_ABS/data/charter.md with its route's bin/fm-home-seed.sh or bin/fm-remote-home-seed.sh instead of appending a second copy" >&2
 }
 
-legacy_scaffold_signature_count() {
-  awk -v kind="$KIND" '
+scaffold_detection_counts() {
+  awk -v kind="$KIND" -v scaffold_marker="$FM_BRIEF_SCAFFOLD_MARKER" '
     function trim_fence_indent(text, i) {
       for (i = 0; i < 3 && substr(text, 1, 1) == " "; i++) text = substr(text, 2)
       return text
@@ -1730,6 +1730,7 @@ legacy_scaffold_signature_count() {
         }
         next
       }
+      if ($0 == scaffold_marker) markers++
       if ($0 !~ /^# /) next
       if (kind == "secondmate") {
         if ($0 == "# Charter") {
@@ -1763,20 +1764,21 @@ legacy_scaffold_signature_count() {
         step = 0
       }
     }
-    END { print signatures + 0 }
+    END { print markers + 0, signatures + 0 }
   ' "$1"
 }
 
 # Each generated scaffold carries one fixed marker. Appending another generated
 # scaffold therefore has an unambiguous signature that cannot drift with section
 # names, while arbitrary task headings remain valid Markdown.
-SCAFFOLD_MARKER_COUNT=$(grep -Fxc "$FM_BRIEF_SCAFFOLD_MARKER" "$BRIEF" 2>/dev/null || true)
+SCAFFOLD_DETECTION_COUNTS=$(scaffold_detection_counts "$BRIEF") || exit 1
+SCAFFOLD_MARKER_COUNT=${SCAFFOLD_DETECTION_COUNTS%% *}
+LEGACY_SCAFFOLD_COUNT=${SCAFFOLD_DETECTION_COUNTS#* }
 if [ "$SCAFFOLD_MARKER_COUNT" -gt 1 ]; then
   echo "error: $BRIEF_SOURCE contains multiple generated scaffold markers, so which copy governs is undefined" >&2
   duplicate_brief_recovery_guidance
   exit 1
 fi
-LEGACY_SCAFFOLD_COUNT=$(legacy_scaffold_signature_count "$BRIEF") || exit 1
 if [ "$LEGACY_SCAFFOLD_COUNT" -gt 1 ]; then
   echo "error: $BRIEF_SOURCE contains multiple generated scaffold signatures, so which copy governs is undefined" >&2
   duplicate_brief_recovery_guidance

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -14,9 +14,9 @@
 #   scaffolded before that line existed warns once and launches on the flag. When
 #   the explicit mode carries less rigor than the project's standing posture, a
 #   loud one-line deviation notice is printed and the spawn continues.
-#   Every spawn also refuses a brief that repeats a top-level "# " section, which
-#   is what hand-appending a regenerated brief onto the old one produces: the
-#   worker would follow whichever copy it read last. Regenerate with
+#   Every spawn also refuses an appended-scaffold signature: at least two distinct
+#   top-level "# " sections repeated outside fenced code blocks. A single repeat
+#   may be legitimate task Markdown. Regenerate a duplicated scaffold with
 #   bin/fm-brief.sh --replace instead.
 #   no-mistakes-prod-only is a registry policy rather than a task mode and is
 #   refused as a flag value.
@@ -1647,18 +1647,59 @@ else
 fi
 [ -f "$BRIEF" ] || { echo "error: no brief at $BRIEF" >&2; exit 1; }
 
-# A brief that carries the same top-level section twice was appended to rather
-# than regenerated, which fm-brief.sh --replace now makes unnecessary. Refuse it
-# here because the damage lands on the worker: an agent follows the nearest,
-# most recent statement of a rule, so a duplicated brief silently governs by
-# whichever copy was read last, and nothing in the file marks which is current.
+# This guard is deliberately signature-based rather than refusing any repeated
+# heading. The duplication arose because bin/fm-brief.sh refused the re-scaffold,
+# so the regenerated brief was hand-appended around that refusal. A false refusal
+# here would push firstmate back into hand-editing and recreate the exact defect
+# this guard exists to prevent, making false refusal a correctness problem rather
+# than an inconvenience. An appended scaffold repeats several sections whose
+# competing rules have no precedence marker, while one repeated heading may be
+# legitimate task-body Markdown. Fenced code examples are not brief structure.
 # The mode check below reads only the FIRST delivery contract line, so a second
-# block carrying a different mode would otherwise launch unnoticed.
-DUP_SECTIONS=$(grep '^# ' "$BRIEF" | sort | uniq -d | sed 's/^/  /')
+# scaffold carrying a different mode would otherwise launch unnoticed.
+DUP_SECTIONS=$(awk '
+  function trim_fence_indent(text, i) {
+    for (i = 0; i < 3 && substr(text, 1, 1) == " "; i++) text = substr(text, 2)
+    return text
+  }
+  function fence_marker_run(text, marker, i) {
+    marker = substr(text, 1, 1)
+    if (marker != "`" && marker != "~") return 0
+    for (i = 1; substr(text, i, 1) == marker; i++) {}
+    return i - 1
+  }
+  {
+    candidate = trim_fence_indent($0)
+    run = fence_marker_run(candidate)
+    marker = substr(candidate, 1, 1)
+    if (fence_marker == "") {
+      if (run >= 3) {
+        fence_marker = marker
+        fence_length = run
+        next
+      }
+      if ($0 ~ /^# /) sections[$0]++
+      next
+    }
+    if (marker == fence_marker && run >= fence_length &&
+        substr(candidate, run + 1) ~ /^[[:space:]]*$/) {
+      fence_marker = ""
+      fence_length = 0
+    }
+  }
+  END {
+    for (section in sections) {
+      if (sections[section] > 1) repeated[++count] = section
+    }
+    if (count >= 2) {
+      for (i = 1; i <= count; i++) print repeated[i]
+    }
+  }
+' "$BRIEF" | sort | sed 's/^/  /')
 if [ -n "$DUP_SECTIONS" ]; then
   echo "error: $BRIEF repeats these sections, so which copy governs is undefined:" >&2
   echo "$DUP_SECTIONS" >&2
-  echo "regenerate it with bin/fm-brief.sh --replace (which archives the superseded brief) instead of appending a second copy; use '##' for headings inside the task body" >&2
+  echo "regenerate it with bin/fm-brief.sh --replace (which archives the superseded brief) instead of appending a second copy" >&2
   exit 1
 fi
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -14,10 +14,10 @@
 #   scaffolded before that line existed warns once and launches on the flag. When
 #   the explicit mode carries less rigor than the project's standing posture, a
 #   loud one-line deviation notice is printed and the spawn continues.
-#   Every spawn also refuses an appended-scaffold signature: at least two distinct
-#   top-level "# " sections repeated outside fenced code blocks. A single repeat
-#   may be legitimate task Markdown. Regenerate a duplicated scaffold with
-#   bin/fm-brief.sh --replace instead.
+#   Every spawn also refuses more than one generated-scaffold marker. Task Markdown
+#   may legitimately repeat scaffold heading names, so headings are not treated as
+#   generation identity. Regenerate a duplicated scaffold with bin/fm-brief.sh
+#   --replace instead.
 #   no-mistakes-prod-only is a registry policy rather than a task mode and is
 #   refused as a flag value.
 #        fm-spawn.sh <task-id> --relaunch [--harness <name>] [--model <name>] [--effort <level>]
@@ -1657,7 +1657,27 @@ fi
 [ -f "$BRIEF" ] || { echo "error: no brief at $BRIEF" >&2; exit 1; }
 BRIEF_SOURCE=$BRIEF
 BRIEF_SNAPSHOT="$STATE/$ID.launch-brief.md"
-fm_brief_snapshot "$BRIEF_SOURCE" "$BRIEF_SNAPSHOT" || exit 1
+BRIEF_INPUT=$BRIEF_SOURCE
+if [ -n "${FM_CONTROL_RELAUNCH_BRIEF_SNAPSHOT:-}" ]; then
+  [ "$RELAUNCH" -eq 1 ] && [ "$SPAWN_CONTROL_PARENT" -eq 1 ] || {
+    echo "error: a control-plane relaunch instructions snapshot is accepted only from the owning fm-control process" >&2
+    exit 1
+  }
+  [ "$FM_CONTROL_RELAUNCH_BRIEF_SNAPSHOT" = "$STATE/$ID.control-relaunch.brief-next" ] \
+    && [ -f "$FM_CONTROL_RELAUNCH_BRIEF_SNAPSHOT" ] \
+    && [ ! -L "$FM_CONTROL_RELAUNCH_BRIEF_SNAPSHOT" ] || {
+      echo "error: control-plane relaunch instructions snapshot is unavailable or unsafe" >&2
+      exit 1
+    }
+  BRIEF_INPUT=$FM_CONTROL_RELAUNCH_BRIEF_SNAPSHOT
+  fm_brief_snapshot "$BRIEF_INPUT" "$BRIEF_SNAPSHOT" || exit 1
+else
+  BRIEF_LOCK_STATE=$STATE
+  if [ "$KIND" = secondmate ] && [ "$BRIEF_SOURCE" = "$PROJ_ABS/data/charter.md" ]; then
+    BRIEF_LOCK_STATE="$PROJ_ABS/state"
+  fi
+  fm_brief_copy_locked "$BRIEF_LOCK_STATE" "$ID" "$BRIEF_INPUT" "$BRIEF_SNAPSHOT" || exit 1
+fi
 BRIEF=$BRIEF_SNAPSHOT
 
 duplicate_brief_recovery_guidance() {
@@ -1680,58 +1700,12 @@ duplicate_brief_recovery_guidance() {
   echo "regenerate the parent charter with bin/fm-brief.sh --replace, then republish $PROJ_ABS/data/charter.md with its route's bin/fm-home-seed.sh or bin/fm-remote-home-seed.sh instead of appending a second copy" >&2
 }
 
-# This guard is deliberately signature-based rather than refusing any repeated
-# heading. The duplication arose because bin/fm-brief.sh refused the re-scaffold,
-# so the regenerated brief was hand-appended around that refusal. A false refusal
-# here would push firstmate back into hand-editing and recreate the exact defect
-# this guard exists to prevent, making false refusal a correctness problem rather
-# than an inconvenience. An appended scaffold repeats several sections whose
-# competing rules have no precedence marker, while one repeated heading may be
-# legitimate task-body Markdown. Fenced code examples are not brief structure.
-# The mode check below reads only the FIRST delivery contract line, so a second
-# scaffold carrying a different mode would otherwise launch unnoticed.
-DUP_SECTIONS=$(awk '
-  function trim_fence_indent(text, i) {
-    for (i = 0; i < 3 && substr(text, 1, 1) == " "; i++) text = substr(text, 2)
-    return text
-  }
-  function fence_marker_run(text, marker, i) {
-    marker = substr(text, 1, 1)
-    if (marker != "`" && marker != "~") return 0
-    for (i = 1; substr(text, i, 1) == marker; i++) {}
-    return i - 1
-  }
-  {
-    candidate = trim_fence_indent($0)
-    run = fence_marker_run(candidate)
-    marker = substr(candidate, 1, 1)
-    if (fence_marker == "") {
-      if (run >= 3) {
-        fence_marker = marker
-        fence_length = run
-        next
-      }
-      if ($0 ~ /^# /) sections[$0]++
-      next
-    }
-    if (marker == fence_marker && run >= fence_length &&
-        substr(candidate, run + 1) ~ /^[[:space:]]*$/) {
-      fence_marker = ""
-      fence_length = 0
-    }
-  }
-  END {
-    for (section in sections) {
-      if (sections[section] > 1) repeated[++count] = section
-    }
-    if (count >= 2) {
-      for (i = 1; i <= count; i++) print repeated[i]
-    }
-  }
-' "$BRIEF" | sort | sed 's/^/  /')
-if [ -n "$DUP_SECTIONS" ]; then
-  echo "error: $BRIEF_SOURCE repeats these sections, so which copy governs is undefined:" >&2
-  echo "$DUP_SECTIONS" >&2
+# Each generated scaffold carries one fixed marker. Appending another generated
+# scaffold therefore has an unambiguous signature that cannot drift with section
+# names, while arbitrary task headings remain valid Markdown.
+SCAFFOLD_MARKER_COUNT=$(grep -Fxc "$FM_BRIEF_SCAFFOLD_MARKER" "$BRIEF" 2>/dev/null || true)
+if [ "$SCAFFOLD_MARKER_COUNT" -gt 1 ]; then
+  echo "error: $BRIEF_SOURCE contains multiple generated scaffold markers, so which copy governs is undefined" >&2
   duplicate_brief_recovery_guidance
   exit 1
 fi

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -395,7 +395,7 @@ remote_secondmate_teardown() {
   grep -vE "^- $ID( |$)" "$SECONDMATE_REG" > "$tmp" || true
   mv -f -- "$tmp" "$SECONDMATE_REG"
   status_retire_presentation_task "$STATE" "$ID" || return 1
-  rm -f -- "$STATE/$ID.meta" "$STATE/$ID.turn-ended"
+  rm -f -- "$STATE/$ID.meta" "$STATE/$ID.turn-ended" "$STATE/$ID.launch-brief.md"
   printf 'teardown %s complete (remote %s:%s)\n' "$ID" "$remote_host" "$remote_home"
   return 0
 }
@@ -2262,7 +2262,7 @@ cleanup_firstmate_home_children() {
       "$sub_state/$child_id.meta" "$sub_state/$child_id.pi-ext.ts" \
       "$sub_state/$child_id.grok-turnend-token" "$sub_state/$child_id.kimi-turnend-token" \
       "$sub_state/$child_id.muse-session" "$sub_state/$child_id.muse-session-current" \
-      "$sub_state/$child_id.cursor-session"
+      "$sub_state/$child_id.cursor-session" "$sub_state/$child_id.launch-brief.md"
   done
 }
 
@@ -2542,6 +2542,7 @@ rm -f "$STATE/$ID.turn-ended" "$STATE/$ID.meta" \
   "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token" \
   "$STATE/$ID.kimi-turnend-token" "$STATE/$ID.muse-session" \
   "$STATE/$ID.muse-session-current" "$STATE/$ID.cursor-session" \
+  "$STATE/$ID.launch-brief.md" \
   "$STATE/$ID.control-relaunch" "$STATE/$ID.control-relaunch.meta-prior" \
   "$STATE/$ID.control-relaunch.brief-prior" "$STATE/$ID.control-relaunch.note"
 fm_lock_release "$META_LOCK"

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -2544,7 +2544,8 @@ rm -f "$STATE/$ID.turn-ended" "$STATE/$ID.meta" \
   "$STATE/$ID.muse-session-current" "$STATE/$ID.cursor-session" \
   "$STATE/$ID.launch-brief.md" \
   "$STATE/$ID.control-relaunch" "$STATE/$ID.control-relaunch.meta-prior" \
-  "$STATE/$ID.control-relaunch.brief-prior" "$STATE/$ID.control-relaunch.note"
+  "$STATE/$ID.control-relaunch.brief-prior" "$STATE/$ID.control-relaunch.brief-next" \
+  "$STATE/$ID.control-relaunch.note"
 fm_lock_release "$META_LOCK"
 META_LOCK_HELD=0
 if [ "$KIND" != scout ] && [ "$KIND" != secondmate ] && [ "$MODE" != local-only ]; then

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -49,7 +49,7 @@ Removing a worktree, closing an endpoint, or discarding work stays with [`bin/fm
 
 **`resume` is not a verb.**
 It is not deterministic across the verified adapters: codex and grok resume only from a session id printed at exit, opencode continues the most recent session for the cwd, and claude, pi, pi-signed, and kimi have no verified pane-resume contract.
-`relaunch` covers the same need on every adapter, because the brief on disk - not a harness-private session - is the durable instruction.
+`relaunch` covers the same need on every adapter, because a disk-backed instruction generation - not a harness-private session - is the durable source, and each launch reads one immutable snapshot of that generation.
 
 ## Transactional relaunch
 
@@ -66,16 +66,19 @@ It is not deterministic across the verified adapters: codex and grok resume only
    For a `kind=secondmate` task, the home's identity marker must match and its child records must be readable, so a relaunch can never strand child work behind an unreadable home.
    A secondmate's own crewmates run in their own endpoints and outlive its relaunch; the relaunched secondmate reconciles them from its home's durable records at startup.
 3. **Record the note.**
-   A ship or scout relaunch requires `--note`, because the replacement inherits the local copy but none of the conversation; the note is appended to the instructions it reads.
+   A ship or scout relaunch requires `--note`, because the replacement inherits the local copy but none of the conversation.
+   The control plane stages the note on a snapshot of the current instructions, publishes that generation atomically, and passes the exact staged generation to the launch owner.
+   A concurrent instructions replacement therefore cannot mix generations in the replacement worker or be overwritten by rollback.
    A secondmate relaunch does not require one and never rewrites its standing charter.
 4. **Stop the old agent** through the `exit` verb, with its postcondition.
-5. **Launch the replacement** through its single owner, `bin/fm-spawn.sh --relaunch`, which adopts the recorded endpoint and worktree instead of creating either, clears the previous harness's per-task wiring, and arms a fresh busy generation.
+5. **Launch the replacement** through its single owner, `bin/fm-spawn.sh --relaunch`, which snapshots the selected instruction generation before delivery, adopts the recorded endpoint and worktree instead of creating either, clears the previous harness's per-task wiring, and arms a fresh busy generation.
 
 Switching harness is therefore one ordinary relaunch rather than a separate mechanism.
 
 ### Failure and rollback
 
-- A refusal **before** the agent is stopped leaves the durable record and the instructions byte-identical.
+- A refusal **before** the agent is stopped leaves the durable record unchanged and restores the prior instructions byte-identically when the live generation still matches the relaunch publication.
+  If another writer published newer instructions meanwhile, rollback preserves that newer generation instead.
 - A launch failure **after** the agent is stopped restores the prior durable record, keeps the progress note so a later recovery still has it, marks the journal `failed:launching`, and reports plainly that no agent is running and where the work is preserved.
 - If the launch owner already published the new record but no running agent can be confirmed, the new record is kept: the task is recorded on the new harness with no agent confirmed, which is exactly what recovery reconciles.
   Rewriting it back to the old harness would be a second, worse inaccuracy.
@@ -118,5 +121,5 @@ The empirical basis for each adapter's value is the `harness-adapters` skill's v
 ## Verification
 
 - `tests/fm-control.test.sh` - the adapter contract for every verified harness, the backend capability matrix, exact-id scoping, the closed verb list, the busy, idle, dead, and idempotent lifecycle cases, and marker non-regression, all against a stubbed session provider.
-- `tests/fm-control-relaunch.test.sh` - the relaunch transaction: identity preservation, harness switching, the progress note, checkpoint refusals, and rollback after a failed launch.
+- `tests/fm-control-relaunch.test.sh` - the relaunch transaction: identity preservation, harness switching, generation-stable progress-note delivery, concurrent instructions replacement, checkpoint refusals, and rollback after a failed launch.
 - `tests/fm-control-herdr-smoke.test.sh` - the second state-verified backend against the real herdr binary, on an isolated throwaway lab session.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -176,7 +176,7 @@ For remote provisioning, including supplied project origins, follow [Remote seco
 Use the deliberate `--no-projects` signal only for a firstmate-repo domain that needs no separate project clones.
 It cannot be combined with a project list, and omitting both still fails loudly.
 A project-less seed requires no existing project clones or `data/projects.md` entries in the home, so it refuses a populated-home conversion without changing that home.
-A preexisting project-bearing charter is also refused until it is re-scaffolded with `--no-projects` or removed.
+A preexisting project-bearing charter is also refused until it is re-scaffolded through the `--replace` path documented by `bin/fm-brief.sh --help`, with `--no-projects` as the new charter's project contract.
 The lease is held under the secondmate id until explicit retirement or seed rollback returns it, so normal restarts do not free or recycle the home.
 Teardown of a leased home fails closed if `treehouse return` cannot release the lease; plain-clone homes with no treehouse pool slot are removed directly.
 Secondmate routes cover `no-mistakes` and `direct-PR` projects; `local-only` projects remain main-firstmate work.

--- a/docs/crew-reference.md
+++ b/docs/crew-reference.md
@@ -1,0 +1,61 @@
+# Crewmate reference
+
+Audience: a crewmate or scout working a firstmate task.
+
+Your brief is deliberately short.
+It carries what you must act on without being prompted.
+This file carries the rest: contracts that only matter once you reach a specific moment.
+Your brief names that moment and points here; read the matching section then, not before.
+
+## Closing a decision, blocker, or wait you opened
+
+Read this when a `needs-decision:`, `blocked:`, or declared-wait line you appended has stopped being true.
+
+Firstmate tracks each escalation you open as a record that stays open until a `resolved` line closes it.
+Only a `resolved` line closes one.
+A later `done:` or `working:` line does not, even when the answer you received is exactly what started that work.
+Without the closing line, firstmate keeps re-surfacing a decision you have already moved past.
+
+Two paths close a record, depending on who ended it:
+
+- **Firstmate answered you.** Firstmate normally writes the closing line at answer time; you do not need to write one.
+- **It cleared on its own.** Append `resolved: {how it cleared}` yourself as you resume.
+
+If you opened the record with a key - `blocked [key=<slug>]: ...` - the closing line must carry that same key: `resolved [key=<slug>]: ...`.
+The key is how firstmate matches the close to the record; a `resolved` line with the wrong key or no key leaves the original open.
+
+## Driving the no-mistakes pipeline
+
+Read this before your first `no-mistakes` command on a task whose delivery contract is `mode=no-mistakes`.
+
+Your role changes when the pipeline starts.
+Up to that point you were implementing; from that point you are answering gates.
+The pipeline applies every fix itself, so do not hand-edit, commit, or fix findings while a run is active - a hand-edit during a run puts your changes and the pipeline's in conflict over the same branch.
+
+The mechanics are owned by the installed binary, not by this file.
+`/no-mistakes` loads its own guidance when you invoke it, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to what is installed.
+Follow those over any remembered flag.
+
+### What `--intent` must carry
+
+`--intent` is how the pipeline learns what you were asked to build, and it is judged against that text.
+Make it preserve all relevant content from your brief's `# Task` section, plus every later accepted firstmate requirement, clarification, constraint, exclusion, and supersession.
+Carry only each requirement's current accepted form: when a requirement was superseded, state the version that now stands rather than both.
+Retain the direct requirements themselves instead of substituting a summary of the diff you wrote.
+Exclude generic operational, status, delivery, and other scaffold boilerplate unless it is specific to this task.
+
+### ask-user findings are not yours to answer
+
+An ask-user finding is a decision above the implementation worker, and you are the implementation worker.
+Escalate it with a `needs-decision:` line and stop, exactly as your brief's escalation rule says.
+Firstmate applies the authority contract in its own `AGENTS.md` and obtains any captain decision the finding requires.
+
+When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it.
+Do not route the question onward to "the user", and do not implement the fix yourself.
+Avoid `--yes`: it answers gates on your behalf, and would silently bypass firstmate's authority check and any required captain escalation.
+
+### Where you stop
+
+CI turning green is your return point.
+Report it and stop; do not keep monitoring in the background until merge.
+Merge authority sits with firstmate and the captain, never with you.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -245,6 +245,10 @@
       "audience": "operator-current"
     },
     {
+      "path": "docs/crew-reference.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": "docs/decision-hold-lifecycle.md",
       "audience": "maintainer-architecture"
     },

--- a/tests/fm-ask-user-authority.test.sh
+++ b/tests/fm-ask-user-authority.test.sh
@@ -20,8 +20,18 @@ test_primary_and_secondmate_instruction_generation() {
     "generated implementation brief lets the worker own an ask-user decision"
   assert_grep "Firstmate applies the authority contract in its \`AGENTS.md\`" "$ship" \
     "generated implementation brief bypasses the primary authority owner"
-  assert_grep "silently bypass firstmate's authority check and any required captain escalation" "$ship" \
-    "generated implementation brief permits silent ask-user auto-resolution"
+  # The procedure is deferred to the crew reference at a named trigger, but the
+  # boundary itself stays inline: it fires against the worker's instinct to just
+  # answer the question, so it must not depend on the reference having been read.
+  assert_grep "Escalate with \`needs-decision:\` and stop" "$ship" \
+    "generated implementation brief lost the inline escalate-and-stop action"
+  assert_grep "$ROOT/docs/crew-reference.md" "$ship" \
+    "generated implementation brief lost the pointer to the deferred pipeline procedure"
+  assert_grep "silently bypass firstmate's authority check and any required captain escalation" \
+    "$ROOT/docs/crew-reference.md" \
+    "the crew reference permits silent ask-user auto-resolution"
+  assert_grep "no-mistakes axi respond" "$ROOT/docs/crew-reference.md" \
+    "the crew reference lost how an escalated decision returns to the gate"
   assert_no_grep 'the captain, not you, owns the ask-user decisions' "$ship" \
     "generated implementation brief retained conflicting captain-only wording"
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -1019,7 +1019,7 @@ test_replace_does_not_move_into_a_swapped_directory() {
     'printf "nested sentinel\\n" > "$FM_TEST_BRIEF/brief.md"' > "$shim/cp"
   chmod +x "$shim/cp"
 
-  out=$(FM_TEST_REAL_CP="$real_cp" FM_TEST_BRIEF="$brief" \
+  out=$(FM_TEST_REAL_CP="$real_cp" FM_TEST_BRIEF="$brief" OSTYPE=darwin-ci \
     PATH="$shim:$PATH" FM_HOME="$home" \
     "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode direct-PR --replace 2>&1); status=$?
   expect_code 1 "$status" "--replace must fail when its destination is swapped to a directory"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -856,6 +856,48 @@ test_replace_regenerates_in_place_and_archives_the_superseded_brief() {
   pass "fm-brief.sh: --replace regenerates in place and archives the superseded brief"
 }
 
+test_concurrent_replacements_preserve_every_superseded_brief() {
+  local home id brief shim barrier real_cat p1 p2 rc1 rc2 mode_count
+  home="$TMP_ROOT/rescaffold-concurrent-home"
+  shim="$TMP_ROOT/rescaffold-concurrent-bin"
+  barrier="$TMP_ROOT/rescaffold-concurrent-barrier"
+  mkdir -p "$home/data" "$shim" "$barrier"
+  real_cat=$(command -v cat)
+  id="brief-rescaffold-concurrent"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+
+  printf '%s\n' \
+    '#!/bin/sh' \
+    ': > "$FM_TEST_BARRIER/$$"' \
+    'while [ "$(find "$FM_TEST_BARRIER" -type f | wc -l | tr -d " ")" -lt 2 ]; do sleep 0.01; done' \
+    'exec "$FM_TEST_REAL_CAT" "$@"' > "$shim/cat"
+  chmod +x "$shim/cat"
+
+  FM_TEST_BARRIER="$barrier" FM_TEST_REAL_CAT="$real_cat" PATH="$shim:$PATH" \
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode direct-PR --replace >/dev/null 2>&1 &
+  p1=$!
+  FM_TEST_BARRIER="$barrier" FM_TEST_REAL_CAT="$real_cat" PATH="$shim:$PATH" \
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode local-only --replace >/dev/null 2>&1 &
+  p2=$!
+  wait "$p1"; rc1=$?
+  wait "$p2"; rc2=$?
+  expect_code 0 "$rc1" "the first concurrent --replace should succeed"
+  expect_code 0 "$rc2" "the second concurrent --replace should succeed"
+
+  assert_present "$home/data/$id/brief.superseded-1.md" \
+    "concurrent replacement lost the first superseded brief"
+  assert_present "$home/data/$id/brief.superseded-2.md" \
+    "concurrent replacement reused and overwrote the first archive slot"
+  mode_count=$(grep -h '^Delivery contract: mode=' \
+    "$brief" \
+    "$home/data/$id/brief.superseded-1.md" \
+    "$home/data/$id/brief.superseded-2.md" | sort -u | wc -l | tr -d ' ')
+  [ "$mode_count" -eq 3 ] \
+    || fail "concurrent replacements did not preserve all three brief generations"
+  pass "fm-brief.sh: concurrent replacements serialize archive publication"
+}
+
 test_replace_validates_before_archiving() {
   local home id brief before out status escaped
   home="$TMP_ROOT/rescaffold-validation-home"
@@ -1144,6 +1186,7 @@ test_secondmate_directory_paths_are_absolute_and_output_is_stable
 test_pause_verb_override_renders_all_brief_scaffolds
 test_rescaffold_refuses_by_default_and_changes_nothing
 test_replace_regenerates_in_place_and_archives_the_superseded_brief
+test_concurrent_replacements_preserve_every_superseded_brief
 test_replace_validates_before_archiving
 test_replace_generation_failure_preserves_live_brief
 test_replace_rejects_non_regular_live_briefs

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -934,6 +934,74 @@ test_replace_generation_failure_preserves_live_brief() {
   pass "fm-brief.sh: generation failure preserves the live brief"
 }
 
+test_replace_rejects_non_regular_live_briefs() {
+  local home outside id brief out status
+  home="$TMP_ROOT/rescaffold-non-regular-home"
+  outside="$TMP_ROOT/rescaffold-non-regular-outside"
+  mkdir -p "$home/data" "$outside"
+  printf 'outside sentinel\n' > "$outside/brief.md"
+
+  id="brief-replace-symlink"
+  mkdir -p "$home/data/$id"
+  brief="$home/data/$id/brief.md"
+  ln -s "$outside" "$brief"
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode direct-PR --replace 2>&1); status=$?
+  expect_code 1 "$status" "--replace must reject a symlinked live brief"
+  assert_contains "$out" "must be a regular file" \
+    "symlinked brief refusal did not name the required file type"
+  [ -L "$brief" ] || fail "symlinked brief refusal replaced the live path"
+  [ "$(cat "$outside/brief.md")" = "outside sentinel" ] \
+    || fail "symlinked brief replacement changed the target directory"
+  assert_absent "$home/data/$id/brief.superseded-1.md" \
+    "symlinked brief refusal created an archive"
+
+  id="brief-replace-directory"
+  mkdir -p "$home/data/$id/brief.md"
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode direct-PR --replace 2>&1); status=$?
+  expect_code 1 "$status" "--replace must reject a directory at the live brief path"
+  assert_contains "$out" "must be a regular file" \
+    "directory brief refusal did not name the required file type"
+  [ -d "$home/data/$id/brief.md" ] || fail "directory brief refusal replaced the live path"
+  assert_absent "$home/data/$id/brief.superseded-1.md" \
+    "directory brief refusal created an archive"
+
+  pass "fm-brief.sh: --replace rejects non-regular live briefs"
+}
+
+test_replace_does_not_follow_a_swapped_destination() {
+  local home outside shim real_cp id brief out status
+  home="$TMP_ROOT/rescaffold-no-follow-home"
+  outside="$TMP_ROOT/rescaffold-no-follow-outside"
+  shim="$TMP_ROOT/rescaffold-no-follow-bin"
+  mkdir -p "$home/data" "$outside" "$shim"
+  printf 'outside sentinel\n' > "$outside/brief.md"
+  real_cp=$(command -v cp)
+  id="brief-replace-no-follow"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  printf '%s\n' \
+    '#!/bin/sh' \
+    '"$FM_TEST_REAL_CP" "$@" || exit $?' \
+    'rm -f -- "$FM_TEST_BRIEF"' \
+    'ln -s "$FM_TEST_OUTSIDE" "$FM_TEST_BRIEF"' > "$shim/cp"
+  chmod +x "$shim/cp"
+
+  out=$(FM_TEST_REAL_CP="$real_cp" FM_TEST_BRIEF="$brief" FM_TEST_OUTSIDE="$outside" \
+    PATH="$shim:$PATH" FM_HOME="$home" \
+    "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode direct-PR --replace 2>&1); status=$?
+  expect_code 0 "$status" "--replace must publish without following a destination swapped to a symlink (got: $out)"
+  [ ! -L "$brief" ] || fail "publication left the swapped destination symlink in place"
+  assert_grep "Delivery contract: mode=direct-PR" "$brief" \
+    "publication did not replace the swapped destination path"
+  [ "$(cat "$outside/brief.md")" = "outside sentinel" ] \
+    || fail "publication followed the swapped symlink into its target directory"
+  assert_grep "Delivery contract: mode=no-mistakes" \
+    "$home/data/$id/brief.superseded-1.md" \
+    "publication lost the archived live brief"
+
+  pass "fm-brief.sh: publication never follows the destination"
+}
+
 # --replace applies to every scaffold kind, so no kind is left with hand-editing
 # as its only regeneration path.
 test_replace_applies_to_every_scaffold_kind() {
@@ -1045,6 +1113,8 @@ test_rescaffold_refuses_by_default_and_changes_nothing
 test_replace_regenerates_in_place_and_archives_the_superseded_brief
 test_replace_validates_before_archiving
 test_replace_generation_failure_preserves_live_brief
+test_replace_rejects_non_regular_live_briefs
+test_replace_does_not_follow_a_swapped_destination
 test_replace_applies_to_every_scaffold_kind
 test_generated_briefs_carry_each_section_once
 test_scout_and_secondmate_load_decision_hold_policy

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -1002,6 +1002,37 @@ test_replace_does_not_follow_a_swapped_destination() {
   pass "fm-brief.sh: publication never follows the destination"
 }
 
+test_replace_does_not_move_into_a_swapped_directory() {
+  local home shim real_cp id brief out status
+  home="$TMP_ROOT/rescaffold-directory-swap-home"
+  shim="$TMP_ROOT/rescaffold-directory-swap-bin"
+  mkdir -p "$home/data" "$shim"
+  real_cp=$(command -v cp)
+  id="brief-replace-directory-swap"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  printf '%s\n' \
+    '#!/bin/sh' \
+    '"$FM_TEST_REAL_CP" "$@" || exit $?' \
+    'rm -f -- "$FM_TEST_BRIEF"' \
+    'mkdir "$FM_TEST_BRIEF"' \
+    'printf "nested sentinel\\n" > "$FM_TEST_BRIEF/brief.md"' > "$shim/cp"
+  chmod +x "$shim/cp"
+
+  out=$(FM_TEST_REAL_CP="$real_cp" FM_TEST_BRIEF="$brief" \
+    PATH="$shim:$PATH" FM_HOME="$home" \
+    "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode direct-PR --replace 2>&1); status=$?
+  expect_code 1 "$status" "--replace must fail when its destination is swapped to a directory"
+  [ -d "$brief" ] || fail "failed publication replaced the swapped destination directory"
+  [ "$(cat "$brief/brief.md")" = "nested sentinel" ] \
+    || fail "publication moved into the swapped destination directory (got: $out)"
+  assert_grep "Delivery contract: mode=no-mistakes" \
+    "$home/data/$id/brief.superseded-1.md" \
+    "publication lost the archived live brief after a directory swap"
+
+  pass "fm-brief.sh: publication never moves into the destination"
+}
+
 # --replace applies to every scaffold kind, so no kind is left with hand-editing
 # as its only regeneration path.
 test_replace_applies_to_every_scaffold_kind() {
@@ -1115,6 +1146,7 @@ test_replace_validates_before_archiving
 test_replace_generation_failure_preserves_live_brief
 test_replace_rejects_non_regular_live_briefs
 test_replace_does_not_follow_a_swapped_destination
+test_replace_does_not_move_into_a_swapped_directory
 test_replace_applies_to_every_scaffold_kind
 test_generated_briefs_carry_each_section_once
 test_scout_and_secondmate_load_decision_hold_policy

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -867,6 +867,7 @@ test_concurrent_replacements_preserve_every_superseded_brief() {
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
   brief="$home/data/$id/brief.md"
 
+  # shellcheck disable=SC2016 # Variables expand in the generated cat shim, not this test shell.
   printf '%s\n' \
     '#!/bin/sh' \
     ': > "$FM_TEST_BARRIER/$$"' \

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -856,6 +856,84 @@ test_replace_regenerates_in_place_and_archives_the_superseded_brief() {
   pass "fm-brief.sh: --replace regenerates in place and archives the superseded brief"
 }
 
+test_replace_validates_before_archiving() {
+  local home id brief before out status escaped
+  home="$TMP_ROOT/rescaffold-validation-home"
+  mkdir -p "$home/data"
+
+  id="brief-replace-invalid-ship"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  before=$(cat "$brief")
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" --mode direct-PR --replace 2>&1); status=$?
+  expect_code 1 "$status" "ship --replace without a repo must refuse"
+  assert_contains "$out" "briefs require exactly <task-id> <repo-name>" \
+    "ship --replace without a repo did not report the positional contract"
+  [ "$(cat "$brief")" = "$before" ] || fail "invalid ship --replace changed the live brief"
+  assert_absent "$home/data/$id/brief.superseded-1.md" \
+    "invalid ship --replace archived the live brief"
+
+  id="brief-replace-invalid-scout"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --scout >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  before=$(cat "$brief")
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" --scout --replace 2>&1); status=$?
+  expect_code 1 "$status" "scout --replace without a repo must refuse"
+  assert_contains "$out" "briefs require exactly <task-id> <repo-name>" \
+    "scout --replace without a repo did not report the positional contract"
+  [ "$(cat "$brief")" = "$before" ] || fail "invalid scout --replace changed the live brief"
+  assert_absent "$home/data/$id/brief.superseded-1.md" \
+    "invalid scout --replace archived the live brief"
+
+  id="brief-replace-invalid-secondmate"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" --secondmate --no-projects >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  before=$(cat "$brief")
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" --secondmate --replace 2>&1); status=$?
+  expect_code 1 "$status" "secondmate --replace without a project contract must refuse"
+  assert_contains "$out" "requires at least one project" \
+    "secondmate --replace without a project contract did not explain the requirement"
+  [ "$(cat "$brief")" = "$before" ] || fail "invalid secondmate --replace changed the live brief"
+  assert_absent "$home/data/$id/brief.superseded-1.md" \
+    "invalid secondmate --replace archived the live brief"
+
+  escaped="$home/escaped"
+  mkdir -p "$escaped"
+  printf 'outside sentinel\n' > "$escaped/brief.md"
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-brief.sh" ../escaped some-proj --scout --replace 2>&1); status=$?
+  expect_code 2 "$status" "path-traversing task id must refuse"
+  assert_contains "$out" "invalid task id" "unsafe task id refusal was not explicit"
+  [ "$(cat "$escaped/brief.md")" = "outside sentinel" ] \
+    || fail "unsafe task id changed a brief outside the data directory"
+  assert_absent "$escaped/brief.superseded-1.md" \
+    "unsafe task id archived a brief outside the data directory"
+
+  pass "fm-brief.sh: --replace validates every target before archiving"
+}
+
+test_replace_generation_failure_preserves_live_brief() {
+  local home id brief before shim status
+  home="$TMP_ROOT/rescaffold-stage-home"
+  shim="$TMP_ROOT/rescaffold-stage-bin"
+  mkdir -p "$home/data" "$shim"
+  id="brief-replace-stage-failure"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  before=$(cat "$brief")
+  printf '#!/bin/sh\nexit 71\n' > "$shim/cat"
+  chmod +x "$shim/cat"
+
+  PATH="$shim:$PATH" FM_HOME="$home" \
+    "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode direct-PR --replace >/dev/null 2>&1; status=$?
+  expect_code 71 "$status" "a staged generation failure must propagate"
+  [ "$(cat "$brief")" = "$before" ] \
+    || fail "generation failure removed or changed the live brief"
+  assert_absent "$home/data/$id/brief.superseded-1.md" \
+    "generation failure archived the live brief before replacement was ready"
+
+  pass "fm-brief.sh: generation failure preserves the live brief"
+}
+
 # --replace applies to every scaffold kind, so no kind is left with hand-editing
 # as its only regeneration path.
 test_replace_applies_to_every_scaffold_kind() {
@@ -965,6 +1043,8 @@ test_secondmate_directory_paths_are_absolute_and_output_is_stable
 test_pause_verb_override_renders_all_brief_scaffolds
 test_rescaffold_refuses_by_default_and_changes_nothing
 test_replace_regenerates_in_place_and_archives_the_superseded_brief
+test_replace_validates_before_archiving
+test_replace_generation_failure_preserves_live_brief
 test_replace_applies_to_every_scaffold_kind
 test_generated_briefs_carry_each_section_once
 test_scout_and_secondmate_load_decision_hold_policy

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -1098,11 +1098,10 @@ test_replace_applies_to_every_scaffold_kind() {
   pass "fm-brief.sh: --replace works for ship, scout and secondmate scaffolds"
 }
 
-# Every generated brief must carry each top-level section exactly once. This is
-# the shape bin/fm-spawn.sh refuses on, so the scaffold and the guard cannot
-# drift into disagreement.
-test_generated_briefs_carry_each_section_once() {
-  local home kind id brief dupes
+# Every generated brief carries exactly one stable generation marker, while
+# retaining unique top-level scaffold sections for readable instructions.
+test_generated_briefs_carry_one_marker_and_each_section_once() {
+  local home kind id brief dupes markers
   home="$TMP_ROOT/section-uniqueness-home"
   mkdir -p "$home/data"
   for kind in no-mistakes direct-PR local-only scout secondmate herdr; do
@@ -1115,11 +1114,14 @@ test_generated_briefs_carry_each_section_once() {
     esac
     brief="$home/data/$id/brief.md"
     assert_present "$brief" "$kind: brief was not scaffolded"
+    markers=$(grep -Fc '<!-- firstmate:generated-brief-scaffold:v1 -->' "$brief" || true)
+    [ "$markers" -eq 1 ] \
+      || fail "$kind: generated brief carries $markers scaffold markers instead of exactly one"
     dupes=$(grep '^# ' "$brief" | sort | uniq -d)
     [ -z "$dupes" ] \
-      || fail "$kind: brief repeats top-level sections, which bin/fm-spawn.sh refuses: $dupes"
+      || fail "$kind: generated scaffold repeats top-level sections: $dupes"
   done
-  pass "fm-brief.sh: every generated brief carries each top-level section exactly once"
+  pass "fm-brief.sh: every generated brief carries one marker and unique top-level sections"
 }
 
 test_scout_and_secondmate_load_decision_hold_policy() {
@@ -1193,6 +1195,6 @@ test_replace_rejects_non_regular_live_briefs
 test_replace_does_not_follow_a_swapped_destination
 test_replace_does_not_move_into_a_swapped_directory
 test_replace_applies_to_every_scaffold_kind
-test_generated_briefs_carry_each_section_once
+test_generated_briefs_carry_one_marker_and_each_section_once
 test_scout_and_secondmate_load_decision_hold_policy
 test_scout_and_secondmate_scaffold

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -979,6 +979,7 @@ test_replace_does_not_follow_a_swapped_destination() {
   id="brief-replace-no-follow"
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
   brief="$home/data/$id/brief.md"
+  # shellcheck disable=SC2016 # Variables expand in the generated cp shim, not this test shell.
   printf '%s\n' \
     '#!/bin/sh' \
     '"$FM_TEST_REAL_CP" "$@" || exit $?' \
@@ -1011,6 +1012,7 @@ test_replace_does_not_move_into_a_swapped_directory() {
   id="brief-replace-directory-swap"
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
   brief="$home/data/$id/brief.md"
+  # shellcheck disable=SC2016 # Variables expand in the generated cp shim, not this test shell.
   printf '%s\n' \
     '#!/bin/sh' \
     '"$FM_TEST_REAL_CP" "$@" || exit $?' \

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -173,7 +173,7 @@ PERL
 test_help_includes_entire_header() {
   local help
   help=$("$ROOT/bin/fm-brief.sh" --help)
-  assert_contains "$help" "Refuses to overwrite an existing brief." "fm-brief.sh --help omitted its header terminator"
+  assert_contains "$help" "brief.superseded-<n>.md so filled-in task text is recoverable." "fm-brief.sh --help omitted its header terminator"
   pass "fm-brief.sh: --help renders the complete header"
 }
 
@@ -321,54 +321,158 @@ test_faster_paths_use_configured_authority_without_stacked_review() {
 
 # Pin the specific line the bug lived on: the no-mistakes DOD's no-mistakes
 # reference must render as plain prose with no dangling apostrophe artifact.
-test_no_mistakes_dod_wording() {
+# The no-mistakes pipeline contract is deferred, not deleted: the brief carries
+# the trigger and the pointer, and docs/crew-reference.md carries the substance.
+# Asserting both halves is what keeps a future "shorten the brief" edit from
+# quietly dropping a rule instead of moving it.
+test_no_mistakes_dod_defers_pipeline_contract_to_reference() {
   local home id brief
   home="$TMP_ROOT/wording-home"
   mkdir -p "$home/data"
   id="brief-wording-b1"
-  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
+  FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+    "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
   brief="$home/data/$id/brief.md"
   assert_present "$brief" "brief was not scaffolded"
-  assert_grep "no-mistakes itself provides for the mechanics" "$brief" \
-    "no-mistakes DOD lost its guidance-reference sentence"
+
+  # The trigger must name the moment the worker will recognise, and the pointer
+  # must be an absolute path it can open from a project worktree.
   # shellcheck disable=SC2016  # single quotes are deliberate: the backticks must stay literal
-  assert_grep '`no-mistakes axi run --help`' "$brief" \
-    "no-mistakes DOD must render literal backticks around the help command"
-  # shellcheck disable=SC2016  # single quotes are deliberate: the backticks must stay literal
-  assert_grep '`help`' "$brief" \
-    "no-mistakes DOD must render literal backticks around help"
-  assert_grep "make \`--intent\` preserve all relevant content from this brief" "$brief" \
-    "no-mistakes DOD must require --intent to retain the accepted task contract"
-  assert_grep "carrying only each requirement's current accepted form" "$brief" \
-    "no-mistakes DOD must replace superseded requirements with their current accepted form"
-  assert_grep "retain direct requirements instead of substituting a diff summary" "$brief" \
-    "no-mistakes DOD must keep direct requirements and exclude generic scaffold boilerplate from --intent"
-  assert_grep "exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific" "$brief" \
-    "no-mistakes DOD must exclude non-task-specific scaffold boilerplate from --intent"
-  # The apostrophe in "firstmate's authority check" is now structurally safe
-  # (no `$(...)` wrapper around the heredoc), so it renders verbatim instead of
-  # being reworded or escaped away. test_no_heredoc_in_command_substitution
-  # guards the structure that makes it safe.
-  assert_grep "firstmate's authority check" "$brief" \
-    "no-mistakes DOD lost the apostrophe prose that the structural fix makes parse-safe"
-  pass "fm-brief.sh: no-mistakes DOD keeps its apostrophe prose, now parse-safe"
+  assert_grep 'Before your first `no-mistakes` command, read' "$brief" \
+    "no-mistakes DOD lost the trigger that sends the worker to the pipeline contract"
+  assert_grep "$ROOT/docs/crew-reference.md" "$brief" \
+    "no-mistakes DOD must point at the crew reference by absolute path"
+  assert_grep "Reading it then is part of the task" "$brief" \
+    "no-mistakes DOD must make reading the deferred contract mandatory, not optional"
+
+  # The always-present part keeps only what the worker acts on unprompted.
+  assert_grep "Delivery contract: mode=no-mistakes" "$brief" \
+    "no-mistakes DOD lost its machine-readable delivery contract line"
+  assert_grep 'done: PR {url} checks green' "$brief" \
+    "no-mistakes DOD lost its CI-green return point"
+
+  # ...and the deferred detail is gone from the brief itself, so the deferral is
+  # real rather than a second copy.
+  assert_no_grep 'preserve all relevant content' "$brief" \
+    "no-mistakes DOD still restates the --intent contract the reference owns"
+  assert_no_grep "Avoid \`--yes\`" "$brief" \
+    "no-mistakes DOD still restates the --yes rule the reference owns"
+  pass "fm-brief.sh: no-mistakes DOD defers the pipeline contract behind a named trigger"
 }
 
-test_ship_project_memory_wording() {
+# Everything the brief stopped saying must still be reachable. This test is the
+# other half of the deferral: it fails if the reference is missing or has lost a
+# contract the brief now assumes it carries.
+test_crew_reference_owns_every_deferred_contract() {
+  local ref
+  ref="$ROOT/docs/crew-reference.md"
+  assert_present "$ref" "docs/crew-reference.md is missing, so every deferred contract is unreachable"
+
+  assert_grep "## Closing a decision, blocker, or wait you opened" "$ref" \
+    "crew reference lost the section the escalation rule points at"
+  assert_grep "even when the answer you received is exactly what started that work" "$ref" \
+    "crew reference lost the rule that done:/working: never closes a decision"
+  assert_grep 'key=<slug>' "$ref" \
+    "crew reference lost the keyed-close requirement"
+
+  assert_grep "## Driving the no-mistakes pipeline" "$ref" \
+    "crew reference lost the section the definition of done points at"
+  assert_grep "do not hand-edit, commit, or fix findings while a run is active" "$ref" \
+    "crew reference lost the no-hand-edit-during-a-run rule"
+  assert_grep "\`--intent\`" "$ref" \
+    "crew reference lost the --intent contract"
+  assert_grep "ask-user findings are not yours to answer" "$ref" \
+    "crew reference lost the ask-user escalation rule"
+  assert_grep "\`--yes\`" "$ref" \
+    "crew reference lost the --yes prohibition"
+  assert_grep "no-mistakes axi run --help" "$ref" \
+    "crew reference lost the pointer to the authoritative installed-binary help"
+  pass "fm-brief.sh: every contract deferred out of the brief is reachable in the crew reference"
+}
+
+# The declared-wait rule is deliberately NOT deferred: workers do not reliably
+# notice that their own running loop has become a wait, so there is no moment to
+# load it at. It must stay in the always-present part, carry its own heading
+# rather than sit as one numbered item among equals, and state the mechanism -
+# fm-classify-lib.sh reads only the LAST status line.
+test_declared_wait_rule_is_upfront_and_salient() {
+  local home kind id brief
+  home="$TMP_ROOT/declared-wait-home"
+  mkdir -p "$home/data"
+
+  for kind in ship scout; do
+    id="brief-declared-wait-$kind"
+    case "$kind" in
+      ship) FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1 ;;
+      scout) FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --scout >/dev/null 2>&1 ;;
+    esac
+    brief="$home/data/$id/brief.md"
+    assert_present "$brief" "$kind: brief was not scaffolded"
+    assert_grep "# Before you wait, declare it" "$brief" \
+      "$kind: the declared-wait rule lost its own heading and is buried again"
+    assert_grep "Declare it BEFORE you start waiting" "$brief" \
+      "$kind: the declared-wait rule lost its before-the-wait ordering"
+    # The observed failure was a classification error, not a salience one: every
+    # example used to name something outside the pipeline, so two workers on
+    # 2026-08-19 idled on their own validation round without declaring, because
+    # the run was their own work. Name that case, and keep the self-test off the
+    # phrasing that reproduces the miss.
+    assert_grep "own validation round returning through the gate counts" "$brief" \
+      "$kind: the declared-wait rule stopped naming the gate wait, the case workers actually miss"
+    assert_grep "am I working, or watching?" "$brief" \
+      "$kind: the declared-wait self-test must ask working-or-watching"
+    assert_no_grep "wait on something that is not me" "$brief" \
+      "$kind: the self-test reverted to internal-vs-external framing, which is what made workers skip their own gate wait"
+    assert_grep 'holds only while it is your LAST status line' "$brief" \
+      "$kind: the declared-wait rule lost the mechanism that makes declaring stick"
+    assert_grep "$home/state/$id.status" "$brief" \
+      "$kind: the declared-wait rule must carry the ready-to-run status command"
+    # It must NOT have been pushed behind a pointer. The crew reference is
+    # linked only from the escalation rule (and, on a no-mistakes ship, from the
+    # definition of done); a third pointer means the wait rule was deferred too.
+    local refs expected
+    refs=$(grep -c "docs/crew-reference.md" "$brief")
+    case "$kind" in ship) expected=2 ;; *) expected=1 ;; esac
+    [ "$refs" -eq "$expected" ] \
+      || fail "$kind: expected $expected crew-reference pointers, found $refs - the declared-wait rule must stay inline, not be deferred behind a trigger"
+  done
+  pass "fm-brief.sh: the declared-wait rule stays upfront with its own heading and mechanism"
+}
+
+test_ship_project_memory_points_at_the_bar_owner() {
   local home id brief
   home="$TMP_ROOT/project-memory-home"
   mkdir -p "$home/data"
   id="brief-memory-c1"
-  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
+  FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+    "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
   brief="$home/data/$id/brief.md"
   assert_present "$brief" "brief was not scaffolded"
-  assert_grep "Record only project knowledge useful to almost every future session." "$brief" \
-    "project-memory contract lost the durable-knowledge bar"
-  assert_grep "prefer a pointer to the authoritative file, command, or doc over copying the detail" "$brief" \
-    "project-memory contract lost pointer-over-copy guidance"
-  assert_grep "lacks \`## Maintaining this file\`, add that short self-governance section" "$brief" \
-    "project-memory contract lost the self-governance add-in-same-pass rule"
-  pass "fm-brief.sh: ship project-memory wording carries the AGENTS.md authoring bar"
+  assert_grep "bin/fm-ensure-agents-md.sh ." "$brief" \
+    "project-memory contract lost the command that owns and injects the authoring bar"
+  assert_grep "follow the bar you find there" "$brief" \
+    "project-memory contract must send the worker to the bar the script writes into the file"
+  assert_grep "skip \`AGENTS.md\` edits for trivial tasks" "$brief" \
+    "project-memory contract lost its proportionality rule"
+  pass "fm-brief.sh: project memory points at the script that owns the authoring bar"
+}
+
+# fm-ensure-agents-md.sh must really own the bar the brief now defers to, and
+# must really inject it, or the brief's pointer is a dangling promise.
+test_agents_md_helper_carries_the_authoring_bar() {
+  local proj out
+  proj="$TMP_ROOT/authoring-bar-proj"
+  mkdir -p "$proj"
+  printf '# Demo\n\nExisting project knowledge.\n' > "$proj/AGENTS.md"
+  out=$("$ROOT/bin/fm-ensure-agents-md.sh" "$proj" 2>&1) \
+    || fail "fm-ensure-agents-md.sh failed on an AGENTS.md lacking the section: $out"
+  assert_grep "## Maintaining this file" "$proj/AGENTS.md" \
+    "fm-ensure-agents-md.sh did not inject the self-governance section the brief defers to"
+  assert_grep "useful to almost every future agent session" "$proj/AGENTS.md" \
+    "injected section lost the durable-knowledge bar the brief stopped restating"
+  assert_grep "point to the authoritative file or command instead" "$proj/AGENTS.md" \
+    "injected section lost the pointer-over-copy bar the brief stopped restating"
+  pass "fm-ensure-agents-md.sh: injects the authoring bar the brief defers to"
 }
 
 test_herdr_lab_contract_is_explicit_and_complete() {
@@ -433,8 +537,10 @@ test_herdr_lab_omission_is_loud_for_ship_and_scout() {
     brief="$home/data/$id/brief.md"
     assert_grep "# Herdr lifecycle declaration - NOT ENABLED" "$brief" \
       "$kind brief silently omitted the Herdr declaration"
-    assert_grep "regenerate the brief with \`--herdr-lab\` before dispatch" "$brief" \
+    assert_grep "have the brief regenerated with \`--herdr-lab\` before you continue" "$brief" \
       "$kind brief missing the fail-visible regeneration instruction"
+    assert_grep "would hit the captain's live fleet" "$brief" \
+      "$kind brief must name the concrete harm, not the scaffold's own detection limit"
   done
   pass "fm-brief.sh: ship and scout scaffolds make omitted Herdr intent fail-visible"
 }
@@ -657,18 +763,142 @@ test_pause_verb_override_renders_all_brief_scaffolds() {
     brief="$home/data/$id/brief.md"
     assert_grep "States: working, needs-decision, blocked, awaiting, done, failed." "$brief" \
       "$kind brief did not render the configured pause verb in its states list"
-    # shellcheck disable=SC2016 # Literal backticks and braces must remain unexpanded.
-    assert_grep 'Use `awaiting: {why}`' "$brief" \
-      "$kind brief did not instruct the configured pause status"
-    # shellcheck disable=SC2016 # Literal backticks and braces must remain unexpanded.
-    assert_no_grep '`paused: {why}`' "$brief" \
+    assert_no_grep 'paused: {' "$brief" \
       "$kind brief still instructs the default paused status"
-    assert_grep 'a blocker or wait clears' "$brief" \
-      "$kind brief did not require durable resolution when a blocker clears"
-    assert_grep 'even when the answer is what started that work' "$brief" \
-      "$kind brief did not warn that an answer-started done/working never closes a decision"
+    # Crew scaffolds carry the declared-wait section with a ready-to-run command;
+    # a secondmate charter keeps its own prose form, because a secondmate's idle
+    # endpoint is healthy by design and needs no wedge-avoidance push.
+    case "$kind" in
+      ship|scout)
+        assert_grep 'awaiting: {what you await' "$brief" \
+          "$kind brief did not render the configured pause verb in its declaration command"
+        ;;
+      secondmate)
+        # shellcheck disable=SC2016 # Literal backticks and braces must remain unexpanded.
+        assert_grep 'Use `awaiting: {why}`' "$brief" \
+          "secondmate charter did not instruct the configured pause status"
+        ;;
+    esac
   done
+  assert_grep 'even when the answer is what started that work' \
+    "$home/data/brief-pause-verb-secondmate/brief.md" \
+    "secondmate charter lost its inline decision-closing contract"
   pass "fm-brief.sh: custom pause verb renders in every scaffold"
+}
+
+# The append defect: re-scaffolding an existing brief used to have exactly one
+# outcome, a refusal, which did not remove the need to re-scaffold (a corrected
+# base ref, a changed delivery mode). Operators satisfied that need by hand,
+# appending the regenerated text onto the old brief, and two live briefs ended up
+# carrying a full second copy of # Setup, # Rules and the status protocol with
+# nothing marking which governed. These tests pin both halves of the fix: the
+# default still refuses and changes nothing, and --replace regenerates in place
+# while archiving what it superseded.
+test_rescaffold_refuses_by_default_and_changes_nothing() {
+  local home id brief before out status
+  home="$TMP_ROOT/rescaffold-refuse-home"
+  mkdir -p "$home/data"
+  id="brief-rescaffold-r1"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "brief was not scaffolded"
+  printf '\n## Hand-added task detail\nAcceptance criteria the operator filled in.\n' >> "$brief"
+  before=$(cat "$brief")
+
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes 2>&1); status=$?
+  expect_code 1 "$status" "a re-scaffold without --replace must refuse"
+  assert_contains "$out" "already exists" "refusal must name the collision"
+  assert_contains "$out" "--replace" "refusal must name the supported regeneration path"
+  [ "$(cat "$brief")" = "$before" ] \
+    || fail "a refused re-scaffold modified the existing brief"
+  assert_absent "$home/data/$id/brief.superseded-1.md" \
+    "a refused re-scaffold must not archive anything"
+  pass "fm-brief.sh: a re-scaffold without --replace refuses and leaves the brief untouched"
+}
+
+test_replace_regenerates_in_place_and_archives_the_superseded_brief() {
+  local home id brief out status section count
+  home="$TMP_ROOT/rescaffold-replace-home"
+  mkdir -p "$home/data"
+  id="brief-rescaffold-r2"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  printf '\n## Hand-added task detail\nAcceptance criteria the operator filled in.\n' >> "$brief"
+
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode direct-PR --replace 2>&1); status=$?
+  expect_code 0 "$status" "--replace must regenerate an existing brief (got: $out)"
+
+  # Replaced, not appended: every contract section appears exactly once, and the
+  # superseded mode is gone rather than sitting above the new one.
+  for section in "# Setup" "# Rules" "# Definition of done" "# Before you wait, declare it"; do
+    count=$(grep -c "^$section\$" "$brief")
+    [ "$count" -eq 1 ] \
+      || fail "--replace produced $count copies of '$section'; a regenerated brief must replace, never append"
+  done
+  count=$(grep -c '^Delivery contract: mode=' "$brief")
+  [ "$count" -eq 1 ] \
+    || fail "--replace left $count delivery contract lines; the brief must record exactly one"
+  assert_grep "Delivery contract: mode=direct-PR" "$brief" "--replace did not apply the new delivery mode"
+  assert_no_grep "Delivery contract: mode=no-mistakes" "$brief" "--replace left the superseded delivery mode in the brief"
+
+  # Nothing is destroyed: the filled-in task text stays recoverable, and the
+  # operator is told where, so regenerating never looks riskier than hand-editing.
+  assert_present "$home/data/$id/brief.superseded-1.md" "--replace must archive the superseded brief"
+  assert_grep "Hand-added task detail" "$home/data/$id/brief.superseded-1.md" \
+    "the archived brief lost the operator's filled-in task text"
+  assert_contains "$out" "brief.superseded-1.md" "--replace must tell the operator where the superseded brief went"
+
+  # A second replace archives alongside the first rather than clobbering it.
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode local-only --replace >/dev/null 2>&1
+  assert_present "$home/data/$id/brief.superseded-2.md" "a second --replace must archive under a fresh name"
+  assert_grep "Hand-added task detail" "$home/data/$id/brief.superseded-1.md" \
+    "a second --replace overwrote the first archive"
+  pass "fm-brief.sh: --replace regenerates in place and archives the superseded brief"
+}
+
+# --replace applies to every scaffold kind, so no kind is left with hand-editing
+# as its only regeneration path.
+test_replace_applies_to_every_scaffold_kind() {
+  local home id status
+  home="$TMP_ROOT/rescaffold-kinds-home"
+  mkdir -p "$home/data"
+
+  id="brief-replace-scout"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --scout >/dev/null 2>&1
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --scout --replace >/dev/null 2>&1; status=$?
+  expect_code 0 "$status" "--replace must regenerate a scout brief"
+  assert_present "$home/data/$id/brief.superseded-1.md" "scout --replace must archive the superseded brief"
+
+  id="brief-replace-secondmate"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" --secondmate --no-projects >/dev/null 2>&1
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" --secondmate --no-projects --replace >/dev/null 2>&1; status=$?
+  expect_code 0 "$status" "--replace must regenerate a secondmate charter"
+  assert_present "$home/data/$id/brief.superseded-1.md" "secondmate --replace must archive the superseded charter"
+  pass "fm-brief.sh: --replace works for ship, scout and secondmate scaffolds"
+}
+
+# Every generated brief must carry each top-level section exactly once. This is
+# the shape bin/fm-spawn.sh refuses on, so the scaffold and the guard cannot
+# drift into disagreement.
+test_generated_briefs_carry_each_section_once() {
+  local home kind id brief dupes
+  home="$TMP_ROOT/section-uniqueness-home"
+  mkdir -p "$home/data"
+  for kind in no-mistakes direct-PR local-only scout secondmate herdr; do
+    id="brief-unique-$kind"
+    case "$kind" in
+      scout) FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --scout >/dev/null 2>&1 ;;
+      secondmate) FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" --secondmate --no-projects >/dev/null 2>&1 ;;
+      herdr) FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes --herdr-lab >/dev/null 2>&1 ;;
+      *) FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode "$kind" >/dev/null 2>&1 ;;
+    esac
+    brief="$home/data/$id/brief.md"
+    assert_present "$brief" "$kind: brief was not scaffolded"
+    dupes=$(grep '^# ' "$brief" | sort | uniq -d)
+    [ -z "$dupes" ] \
+      || fail "$kind: brief repeats top-level sections, which bin/fm-spawn.sh refuses: $dupes"
+  done
+  pass "fm-brief.sh: every generated brief carries each top-level section exactly once"
 }
 
 test_scout_and_secondmate_load_decision_hold_policy() {
@@ -720,8 +950,11 @@ test_ship_mode_is_required_and_closed_set
 test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply
 test_faster_paths_use_configured_authority_without_stacked_review
-test_no_mistakes_dod_wording
-test_ship_project_memory_wording
+test_no_mistakes_dod_defers_pipeline_contract_to_reference
+test_crew_reference_owns_every_deferred_contract
+test_declared_wait_rule_is_upfront_and_salient
+test_ship_project_memory_points_at_the_bar_owner
+test_agents_md_helper_carries_the_authoring_bar
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path
 test_herdr_lab_omission_is_loud_for_ship_and_scout
@@ -730,5 +963,9 @@ test_secondmate_no_projects_charter
 test_secondmate_marked_request_reporting_contract
 test_secondmate_directory_paths_are_absolute_and_output_is_stable
 test_pause_verb_override_renders_all_brief_scaffolds
+test_rescaffold_refuses_by_default_and_changes_nothing
+test_replace_regenerates_in_place_and_archives_the_superseded_brief
+test_replace_applies_to_every_scaffold_kind
+test_generated_briefs_carry_each_section_once
 test_scout_and_secondmate_load_decision_hold_policy
 test_scout_and_secondmate_scaffold

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -72,6 +72,15 @@ case "${1:-}" in
       printf '%s\n' "$payload" >> "$D/literal"
       case "$payload" in
         /exit|/quit)
+          if [ -n "${FM_FAKE_EXIT_ENTERED:-}" ]; then
+            : > "$FM_FAKE_EXIT_ENTERED"
+            attempt=0
+            while [ ! -e "$FM_FAKE_EXIT_RELEASE" ] && [ "$attempt" -lt 500 ]; do
+              /bin/sleep 0.01
+              attempt=$((attempt + 1))
+            done
+          fi
+          [ -z "${FM_FAKE_EXIT_TRANSPORT_FAIL_BEFORE_STOP:-}" ] || exit 1
           printf 'zsh' > "$D/command"
           [ -z "${FM_FAKE_EXIT_TRANSPORT_FAIL_AFTER_STOP:-}" ] || exit 1
           ;;
@@ -171,6 +180,9 @@ run_control() {  # <case-dir> <args...>
     FM_FAKE_TRACE_PREPARE="${FM_FAKE_TRACE_PREPARE:-}" \
     FM_FAKE_META_WRITER_READY="${FM_FAKE_META_WRITER_READY:-}" \
     FM_FAKE_TRACE_EXPORTED="${FM_FAKE_TRACE_EXPORTED:-}" \
+    FM_FAKE_EXIT_ENTERED="${FM_FAKE_EXIT_ENTERED:-}" \
+    FM_FAKE_EXIT_RELEASE="${FM_FAKE_EXIT_RELEASE:-}" \
+    FM_FAKE_EXIT_TRANSPORT_FAIL_BEFORE_STOP="${FM_FAKE_EXIT_TRANSPORT_FAIL_BEFORE_STOP:-}" \
     "$CONTROL" "$@" 2>&1
 }
 
@@ -391,6 +403,78 @@ test_relaunch_appends_the_progress_note_to_the_instructions() {
   assert_grep "reproduced the crash in parser.go" "$dir/home/state/rl2.control-relaunch.note" \
     "the note should also be preserved beside the transaction record"
   pass "fm-control relaunch: the progress note lands in the instructions the replacement reads"
+}
+
+test_relaunch_launches_the_progress_note_generation() {
+  local dir entered release control_pid wait_count=0 rc launch_snapshot live_brief
+  dir=$(new_case note-generation rl35)
+  add_ship_task "$dir" rl35 claude
+  entered="$dir/exit-entered"
+  release="$dir/exit-release"
+  FM_FAKE_EXIT_ENTERED="$entered" FM_FAKE_EXIT_RELEASE="$release" \
+    run_control "$dir" rl35 relaunch --note "generation-specific progress" \
+    > "$dir/control.out" 2>&1 &
+  control_pid=$!
+  while [ ! -e "$entered" ] && kill -0 "$control_pid" 2>/dev/null; do
+    wait_count=$((wait_count + 1))
+    [ "$wait_count" -lt 500 ] || break
+    /bin/sleep 0.01
+  done
+  [ -e "$entered" ] || {
+    touch "$release"
+    wait "$control_pid" 2>/dev/null || true
+    fail "relaunch did not reach its blocked exit after publishing the note"
+  }
+
+  FM_HOME="$dir/home" "$ROOT/bin/fm-brief.sh" rl35 proj --mode no-mistakes --replace >/dev/null \
+    || fail "concurrent instructions replacement failed"
+  touch "$release"
+  wait "$control_pid"; rc=$?
+  expect_code 0 "$rc" "relaunch should succeed across a concurrent instructions replacement"$'\n'"$(cat "$dir/control.out")"
+
+  launch_snapshot="$dir/home/state/rl35.launch-brief.md"
+  live_brief="$dir/home/data/rl35/brief.md"
+  assert_grep 'generation-specific progress' "$launch_snapshot" \
+    "replacement agent did not receive the progress-note generation"
+  assert_no_grep 'generation-specific progress' "$live_brief" \
+    "relaunch overwrote the concurrently published live instructions"
+  pass "fm-control relaunch launches its stable progress-note generation"
+}
+
+test_relaunch_rollback_preserves_superseding_instructions() {
+  local dir entered release control_pid wait_count=0 rc live_brief
+  dir=$(new_case note-rollback-generation rl36)
+  add_ship_task "$dir" rl36 claude
+  entered="$dir/exit-entered"
+  release="$dir/exit-release"
+  FM_FAKE_EXIT_ENTERED="$entered" FM_FAKE_EXIT_RELEASE="$release" \
+    FM_FAKE_EXIT_TRANSPORT_FAIL_BEFORE_STOP=1 \
+    run_control "$dir" rl36 relaunch --note "rollback-specific progress" \
+    > "$dir/control.out" 2>&1 &
+  control_pid=$!
+  while [ ! -e "$entered" ] && kill -0 "$control_pid" 2>/dev/null; do
+    wait_count=$((wait_count + 1))
+    [ "$wait_count" -lt 500 ] || break
+    /bin/sleep 0.01
+  done
+  [ -e "$entered" ] || {
+    touch "$release"
+    wait "$control_pid" 2>/dev/null || true
+    fail "failing relaunch did not reach its blocked exit after publishing the note"
+  }
+
+  FM_HOME="$dir/home" "$ROOT/bin/fm-brief.sh" rl36 proj --mode no-mistakes --replace >/dev/null \
+    || fail "superseding instructions replacement failed"
+  touch "$release"
+  if wait "$control_pid"; then rc=0; else rc=$?; fi
+  expect_code 1 "$rc" "transport-refused relaunch should fail"$'\n'"$(cat "$dir/control.out")"
+
+  live_brief="$dir/home/data/rl36/brief.md"
+  assert_grep '<!-- firstmate:generated-brief-scaffold:v1 -->' "$live_brief" \
+    "rollback clobbered the superseding generated instructions"
+  assert_no_grep 'Do the thing.' "$live_brief" \
+    "rollback restored stale instructions over a newer publication"
+  pass "fm-control relaunch rollback preserves superseding instructions"
 }
 
 test_relaunch_requires_a_note_for_a_ship_task() {
@@ -1312,11 +1396,21 @@ test_spawn_relaunch_refuses_a_pane_outside_the_worktree() {
   pass "fm-spawn --relaunch: refuses to start a replacement outside the copy holding the work"
 }
 
+if [ "${FM_TEST_BRIEF_PUBLICATION_ONLY:-0}" = 1 ]; then
+  test_relaunch_appends_the_progress_note_to_the_instructions
+  test_relaunch_launches_the_progress_note_generation
+  test_relaunch_rollback_preserves_superseding_instructions
+  echo "ALL TESTS PASSED"
+  exit 0
+fi
+
 test_same_harness_relaunch_keeps_identity_and_reuses_the_endpoint
 test_relaunch_preserves_durable_task_metadata
 test_relaunch_serializes_concurrent_durable_metadata_publication
 test_disabled_relaunch_clears_prior_trace_context
 test_relaunch_appends_the_progress_note_to_the_instructions
+test_relaunch_launches_the_progress_note_generation
+test_relaunch_rollback_preserves_superseding_instructions
 test_relaunch_requires_a_note_for_a_ship_task
 test_harness_switch_moves_the_record_and_clears_prior_wiring
 test_harness_switch_does_not_carry_the_old_profile_axes

--- a/tests/fm-remote-secondmate-lifecycle-e2e.test.sh
+++ b/tests/fm-remote-secondmate-lifecycle-e2e.test.sh
@@ -357,7 +357,8 @@ FM_SECONDMATE_CHARTER='Failing seed charter.' FM_SECONDMATE_SCOPE='failed seed' 
 seed_fail_pid=$!
 seed_wait=0
 while [ ! -f "$TMP_ROOT/seed.entered" ]; do
-  kill -0 "$seed_fail_pid" 2>/dev/null || fail "failing seed exited before remote provisioning"
+  kill -0 "$seed_fail_pid" 2>/dev/null \
+    || fail "failing seed exited before remote provisioning"$'\n'"$(cat "$TMP_ROOT/seed-fail.out")"
   seed_wait=$((seed_wait + 1))
   [ "$seed_wait" -le 250 ] || fail "failing seed never reached remote provisioning"
   sleep 0.02
@@ -377,6 +378,80 @@ assert_no_grep '- seed-fail ' "$TMP_ROOT/seed-parent/data/secondmates.md" "faile
 assert_grep '- seed-keep ' "$TMP_ROOT/seed-parent/data/secondmates.md" "failed seed rollback removed a competing successful route"
 assert_present "$TMP_ROOT/seed-keep-home/.fm-secondmate-home" "serialized seed lost its published remote home"
 pass "remote seed rollback preserves serialized competing routes"
+
+seed_generation_cpbin="$TMP_ROOT/seed-generation-cpbin"
+seed_generation_ready="$TMP_ROOT/seed-generation-ready"
+seed_generation_release="$TMP_ROOT/seed-generation-release"
+seed_generation_home="$TMP_ROOT/seed-generation-home"
+seed_generation_real_cp=$(command -v cp)
+mkdir -p "$seed_generation_cpbin"
+FM_HOME="$TMP_ROOT/seed-parent" FM_ROOT_OVERRIDE="$REMOTE_ROOT" \
+  FM_SECONDMATE_CHARTER='remote generation B charter' \
+  FM_SECONDMATE_SCOPE='remote generation B scope' \
+  "$ROOT/bin/fm-brief.sh" seed-generation --secondmate --no-projects >/dev/null \
+  || fail "remote generation B charter scaffold failed"
+cat > "$seed_generation_cpbin/cp" <<'SH'
+#!/usr/bin/env bash
+set -eu
+src=${@: -2:1}
+dest=${@: -1}
+if [ "$src" = "$FM_TEST_SEED_REGISTRY" ]; then
+  case "$dest" in
+    */registry.before)
+      "$FM_REAL_CP" "$@"
+      : > "$FM_TEST_SEED_READY"
+      attempt=0
+      while [ ! -e "$FM_TEST_SEED_RELEASE" ] && [ "$attempt" -lt 500 ]; do
+        /bin/sleep 0.01
+        attempt=$((attempt + 1))
+      done
+      exit 0
+      ;;
+  esac
+fi
+exec "$FM_REAL_CP" "$@"
+SH
+chmod +x "$seed_generation_cpbin/cp"
+PATH="$seed_generation_cpbin:$PATH" FM_REAL_CP="$seed_generation_real_cp" \
+  FM_TEST_SEED_REGISTRY="$TMP_ROOT/seed-parent/data/secondmates.md" \
+  FM_TEST_SEED_READY="$seed_generation_ready" \
+  FM_TEST_SEED_RELEASE="$seed_generation_release" \
+  seed_env "$ROOT/bin/fm-remote-home-seed.sh" seed-generation remote-mac \
+  "$REMOTE_ROOT" "$seed_generation_home" --no-projects \
+  > "$TMP_ROOT/seed-generation.out" 2>&1 &
+seed_generation_pid=$!
+seed_generation_wait=0
+while [ ! -e "$seed_generation_ready" ] && kill -0 "$seed_generation_pid" 2>/dev/null; do
+  seed_generation_wait=$((seed_generation_wait + 1))
+  [ "$seed_generation_wait" -lt 500 ] || break
+  /bin/sleep 0.01
+done
+[ -e "$seed_generation_ready" ] || {
+  touch "$seed_generation_release"
+  wait "$seed_generation_pid" 2>/dev/null || true
+  fail "remote seed never reached its post-snapshot registry backup"
+}
+FM_HOME="$TMP_ROOT/seed-parent" FM_ROOT_OVERRIDE="$REMOTE_ROOT" \
+  FM_SECONDMATE_CHARTER='remote generation C charter' \
+  FM_SECONDMATE_SCOPE='remote generation C scope' \
+  "$ROOT/bin/fm-brief.sh" seed-generation --secondmate --no-projects --replace >/dev/null \
+  || fail "concurrent remote generation C replacement failed"
+touch "$seed_generation_release"
+wait "$seed_generation_pid" \
+  || fail "remote generation seed failed"$'\n'"$(cat "$TMP_ROOT/seed-generation.out")"
+assert_grep 'remote generation B charter' "$seed_generation_home/data/charter.md" \
+  "remote seed transported a different charter generation than it validated"
+assert_no_grep 'remote generation C charter' "$seed_generation_home/data/charter.md" \
+  "remote seed reread the mutable parent charter while building its manifest"
+assert_grep '- seed-generation - remote generation B charter' \
+  "$TMP_ROOT/seed-parent/data/secondmates.md" \
+  "remote route registry disagrees with the transported charter generation"
+pass "remote seed consumes one parent charter generation"
+
+if [ "${FM_TEST_BRIEF_PUBLICATION_ONLY:-0}" = 1 ]; then
+  echo "ALL TESTS PASSED"
+  exit 0
+fi
 
 : > "$DOCTOR_LOG"
 if FM_SECONDMATE_CHARTER='Unknown readiness charter.' FM_SECONDMATE_SCOPE='unknown readiness' \

--- a/tests/fm-secondmate-safety.test.sh
+++ b/tests/fm-secondmate-safety.test.sh
@@ -536,6 +536,120 @@ test_home_seed_no_projects_end_to_end() {
   pass "home seeding scaffolds, registers, and spawns a project-less home end to end"
 }
 
+test_home_seed_and_spawn_consume_one_charter_generation() {
+  local home sub cpbin fakebin ready release snapshot_done seed_pid spawn_pid
+  local seed_wait spawn_wait seed_rc spawn_rc parent_brief generation_b launch_snapshot log
+  home="$TMP_ROOT/charter-generation-home"
+  sub="$TMP_ROOT/charter-generation-subhome"
+  cpbin="$TMP_ROOT/charter-generation-cpbin"
+  ready="$TMP_ROOT/charter-generation-copy-ready"
+  release="$TMP_ROOT/charter-generation-copy-release"
+  snapshot_done="$TMP_ROOT/charter-generation-spawn-snapshot"
+  mkdir -p "$home/data" "$home/state" "$home/projects" "$cpbin"
+
+  FM_HOME="$home" FM_SECONDMATE_CHARTER='generation A charter' \
+    FM_SECONDMATE_SCOPE='generation A scope' \
+    "$ROOT/bin/fm-home-seed.sh" generation "$sub" --no-projects >/dev/null \
+    || fail "initial generation seed failed"
+  sub=$(cd "$sub" && pwd -P)
+  FM_HOME="$home" FM_SECONDMATE_CHARTER='generation B charter' \
+    FM_SECONDMATE_SCOPE='generation B scope' \
+    "$ROOT/bin/fm-brief.sh" generation --secondmate --no-projects --replace >/dev/null \
+    || fail "generation B charter replacement failed"
+  parent_brief="$home/data/generation/brief.md"
+  generation_b="$TMP_ROOT/charter-generation-b.md"
+  cp -p "$parent_brief" "$generation_b"
+
+  cat > "$cpbin/cp" <<'SH'
+#!/usr/bin/env bash
+set -eu
+src=${@: -2:1}
+dest=${@: -1}
+case "$dest" in
+  "$FM_TEST_CHILD_DATA"/*)
+    if grep -F 'generation B charter' "$src" >/dev/null 2>&1; then
+      bytes=$(LC_ALL=C wc -c < "$src" | tr -d ' ')
+      first=$((bytes / 2))
+      head -c "$first" "$src" > "$dest"
+      : > "$FM_TEST_COPY_READY"
+      attempt=0
+      while [ ! -e "$FM_TEST_COPY_RELEASE" ] && [ "$attempt" -lt 500 ]; do
+        /bin/sleep 0.01
+        attempt=$((attempt + 1))
+      done
+      tail -c "+$((first + 1))" "$src" >> "$dest"
+      exit 0
+    fi
+    ;;
+esac
+if [ "$src" = "$FM_TEST_CHILD_CHARTER" ]; then
+  "$FM_REAL_CP" "$@"
+  : > "$FM_TEST_SNAPSHOT_DONE"
+  exit 0
+fi
+exec "$FM_REAL_CP" "$@"
+SH
+  chmod +x "$cpbin/cp"
+
+  PATH="$cpbin:$PATH" FM_REAL_CP="$(command -v cp)" \
+    FM_TEST_CHILD_DATA="$sub/data" FM_TEST_CHILD_CHARTER="$sub/data/charter.md" \
+    FM_TEST_COPY_READY="$ready" FM_TEST_COPY_RELEASE="$release" \
+    FM_TEST_SNAPSHOT_DONE="$snapshot_done" FM_HOME="$home" \
+    "$ROOT/bin/fm-home-seed.sh" generation "$sub" --no-projects \
+    > "$TMP_ROOT/charter-generation-seed.out" 2>&1 &
+  seed_pid=$!
+  seed_wait=0
+  while [ ! -e "$ready" ] && kill -0 "$seed_pid" 2>/dev/null; do
+    seed_wait=$((seed_wait + 1))
+    [ "$seed_wait" -lt 500 ] || break
+    /bin/sleep 0.01
+  done
+  [ -e "$ready" ] || {
+    touch "$release"
+    wait "$seed_pid" 2>/dev/null || true
+    fail "re-seed never reached charter publication"$'\n'"$(cat "$TMP_ROOT/charter-generation-seed.out")"
+  }
+
+  FM_HOME="$home" FM_SECONDMATE_CHARTER='generation C charter' \
+    FM_SECONDMATE_SCOPE='generation C scope' \
+    "$ROOT/bin/fm-brief.sh" generation --secondmate --no-projects --replace >/dev/null \
+    || fail "concurrent generation C charter replacement failed"
+
+  fakebin=$(make_fake_tmux "$TMP_ROOT/charter-generation-tmux")
+  log="$TMP_ROOT/charter-generation-tmux/tmux.log"
+  PATH="$cpbin:$fakebin:$PATH" FM_REAL_CP="$(command -v cp)" \
+    FM_TEST_CHILD_DATA="$sub/data" FM_TEST_CHILD_CHARTER="$sub/data/charter.md" \
+    FM_TEST_COPY_READY="$ready" FM_TEST_COPY_RELEASE="$release" \
+    FM_TEST_SNAPSHOT_DONE="$snapshot_done" FM_HOME="$home" \
+    FM_SKIP_SECONDMATE_INHERIT=1 FM_FAKE_TMUX_LOG="$log" \
+    FM_FAKE_TMUX_CAPTURE="$TMP_ROOT/charter-generation-tmux/pane.txt" \
+    "$ROOT/bin/fm-spawn.sh" generation "$sub" codex --secondmate \
+    > "$TMP_ROOT/charter-generation-spawn.out" 2>&1 &
+  spawn_pid=$!
+  spawn_wait=0
+  while [ ! -e "$snapshot_done" ] && kill -0 "$spawn_pid" 2>/dev/null; do
+    spawn_wait=$((spawn_wait + 1))
+    [ "$spawn_wait" -lt 100 ] || break
+    /bin/sleep 0.01
+  done
+  touch "$release"
+  wait "$seed_pid"; seed_rc=$?
+  wait "$spawn_pid"; spawn_rc=$?
+  expect_code 0 "$seed_rc" "concurrent re-seed should succeed"$'\n'"$(cat "$TMP_ROOT/charter-generation-seed.out")"
+  expect_code 0 "$spawn_rc" "concurrent secondmate spawn should succeed"$'\n'"$(cat "$TMP_ROOT/charter-generation-spawn.out")"
+
+  launch_snapshot="$home/state/generation.launch-brief.md"
+  cmp -s "$generation_b" "$sub/data/charter.md" \
+    || fail "re-seed published a charter other than its snapshotted generation"
+  cmp -s "$generation_b" "$launch_snapshot" \
+    || fail "spawn consumed a partial or different charter generation"
+  assert_grep 'generation B charter' "$home/data/secondmates.md" \
+    "registry publication reread a different parent charter generation"
+  assert_no_grep 'generation C charter' "$home/data/secondmates.md" \
+    "registry publication mixed in the concurrent replacement generation"
+  pass "home seed and spawn consume one atomic charter generation"
+}
+
 test_secondmate_spawn_resolves_punctuated_registry_projects() {
   local home sub sub_abs fakebin log meta projects
   home="$TMP_ROOT/punctuated-spawn-home"
@@ -2953,6 +3067,12 @@ EOF
   pass "fm-backlog-handoff refuses Done items under whitespace section headings and unsafe homes"
 }
 
+if [ "${FM_TEST_BRIEF_PUBLICATION_ONLY:-0}" = 1 ]; then
+  test_home_seed_and_spawn_consume_one_charter_generation
+  echo "ALL TESTS PASSED"
+  exit 0
+fi
+
 test_fm_home_parameterization
 test_lock_status_is_per_home
 test_seed_allows_overlapping_clones_and_drops_owner
@@ -2971,6 +3091,7 @@ test_home_seed_refuses_missing_filled_charter
 test_home_seed_refuses_placeholder_charter
 test_home_seed_refuses_empty_charter_fields
 test_home_seed_no_projects_end_to_end
+test_home_seed_and_spawn_consume_one_charter_generation
 test_secondmate_spawn_resolves_punctuated_registry_projects
 test_secondmate_spawn_refuses_ambiguous_and_mismatched_registry_bindings
 test_home_seed_refuses_projectful_reused_charter_for_projectless_home

--- a/tests/fm-secondmate-safety.test.sh
+++ b/tests/fm-secondmate-safety.test.sh
@@ -655,8 +655,8 @@ test_home_seed_refuses_projectful_reused_charter_for_projectless_home() {
   fi
   grep -F 'existing charter brief' "$err" >/dev/null \
     || fail "project-less charter refusal did not name the stale charter conflict"
-  grep -F 'fm-brief.sh stale --secondmate --no-projects' "$err" >/dev/null \
-    || fail "project-less charter refusal did not explain how to re-scaffold"
+  grep -F 'fm-brief.sh stale --secondmate --no-projects --replace' "$err" >/dev/null \
+    || fail "project-less charter refusal did not explain the supported replacement path"
   cmp -s "$stale_brief_before" "$stale_brief" \
     || fail "project-less charter refusal changed the reused charter"
   assert_absent "$stale_sub/.fm-secondmate-home" "project-less charter refusal wrote a home marker"

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -42,7 +42,14 @@ esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
   list-windows) exit 0 ;;
-  has-session|new-session|new-window|kill-window) exit 0 ;;
+  has-session|new-session|kill-window) exit 0 ;;
+  new-window)
+    if [ -n "${FM_FAKE_MUTATE_BRIEF:-}" ]; then
+      printf 'You are a crewmate.\n\n# Definition of done\nDelivery contract: mode=direct-PR\n' \
+        > "$FM_FAKE_MUTATE_BRIEF"
+    fi
+    exit 0
+    ;;
   send-keys)
     if [ -n "${FM_FAKE_LAUNCH_LOG:-}" ]; then
       prev=
@@ -90,7 +97,8 @@ make_spawn_case() {
   fakebin=$(make_spawn_fakebin "$case_dir/fake")
   mkdir -p "$home/data" "$home/projects" "$home/state" "$home/config"
   printf '%s\n' "$harness" > "$home/config/crew-harness"
-  fm_git_worktree "$proj" "$wt" "wt-$name"
+  GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false \
+    fm_git_worktree "$proj" "$wt" "wt-$name"
   touch "$home/state/.last-watcher-beat"
   for id in "$@"; do
     mkdir -p "$home/data/$id"
@@ -129,6 +137,7 @@ run_spawn() {
     FM_FAKE_LAUNCH_LOG="$launchlog" FM_FAKE_PI_VERSION="${FM_TEST_PI_VERSION:-0.84.0}" \
     FM_FAKE_CURSOR_MODELS="${FM_TEST_CURSOR_MODELS:-}" \
     FM_FAKE_CURSOR_LIST_STATUS="${FM_TEST_CURSOR_LIST_STATUS:-0}" \
+    FM_FAKE_MUTATE_BRIEF="${FM_TEST_MUTATE_BRIEF:-}" \
     GROK_HOME="$home/grok-home" PATH="$fakebin:$PATH" \
     "$SPAWN" "$@" 2>&1
 }
@@ -165,9 +174,32 @@ test_no_profile_keeps_claude_profile_defaults() {
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude default default
 
   launch=$(cat "$LAUNCH_LOG")
-  expected="env -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/brief.md')\""
+  expected="env -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/state/$id.launch-brief.md')\""
   [ "$launch" = "$expected" ] || fail "no-profile claude launch did not use the canonical launch kind"$'\n'"expected: $expected"$'\n'"actual:   $launch"
   pass "no --model/--effort records defaults and types the claude launch instructions"
+}
+
+test_spawn_launches_the_validated_brief_snapshot() {
+  local rec id brief out status launch snapshot
+  id=profile-brief-snapshot-z1a
+  rec=$(make_spawn_case profile-brief-snapshot claude "$id")
+  read_case_record "$rec"
+  brief="$HOME_DIR/data/$id/brief.md"
+  printf 'You are a crewmate.\n\n# Definition of done\nDelivery contract: mode=no-mistakes\n' > "$brief"
+
+  out=$(FM_TEST_MUTATE_BRIEF="$brief" \
+    run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "spawn should retain the brief generation it validated"
+  launch=$(cat "$LAUNCH_LOG")
+  snapshot="$HOME_DIR/state/$id.launch-brief.md"
+  assert_contains "$launch" "< '$snapshot'" \
+    "spawn launch did not read from its immutable brief snapshot"
+  assert_grep 'Delivery contract: mode=no-mistakes' "$snapshot" \
+    "spawn snapshot did not preserve the validated delivery contract"
+  assert_grep 'Delivery contract: mode=direct-PR' "$brief" \
+    "the fixture did not replace the mutable brief after validation"
+  pass "spawn validates and launches one immutable brief snapshot"
 }
 
 test_non_cursor_launch_clears_inherited_cursor_markers() {
@@ -210,8 +242,8 @@ test_relative_home_overrides_launch_with_absolute_cross_process_paths() {
   launch=$(cat "$LAUNCH_LOG")
   assert_contains "$launch" "-e '$home_real/state/$id.pi-ext.ts'" \
     "relative FM_STATE_OVERRIDE leaked into Pi's cross-process extension path"
-  assert_contains "$launch" "< '$home_real/data/$id/brief.md'" \
-    "relative FM_DATA_OVERRIDE leaked into the cross-process brief path"
+  assert_contains "$launch" "< '$home_real/state/$id.launch-brief.md'" \
+    "relative FM_STATE_OVERRIDE leaked into the cross-process brief snapshot path"
   pass "relative home overrides ignore CDPATH and become absolute before spawn launch construction"
 }
 
@@ -239,8 +271,8 @@ test_home_defaults_preserve_absolute_or_resolve_relative_paths() {
   launch=$(cat "$LAUNCH_LOG")
   assert_contains "$launch" "-e '$home_real/state/$relative_id.pi-ext.ts'" \
     "relative FM_HOME leaked into Pi's default cross-process extension path"
-  assert_contains "$launch" "< '$home_real/data/$relative_id/brief.md'" \
-    "relative FM_HOME leaked into the default cross-process brief path"
+  assert_contains "$launch" "< '$home_real/state/$relative_id.launch-brief.md'" \
+    "relative FM_HOME leaked into the default cross-process brief snapshot path"
 
   linked_home="$CASE_DIR/home-link"
   ln -s "$HOME_DIR" "$linked_home"
@@ -259,8 +291,8 @@ test_home_defaults_preserve_absolute_or_resolve_relative_paths() {
   launch=$(cat "$LAUNCH_LOG")
   assert_contains "$launch" "-e '$linked_home/state/$absolute_id.pi-ext.ts'" \
     "absolute FM_HOME spelling changed in Pi's default cross-process extension path"
-  assert_contains "$launch" "< '$linked_home/data/$absolute_id/brief.md'" \
-    "absolute FM_HOME spelling changed in the default cross-process brief path"
+  assert_contains "$launch" "< '$linked_home/state/$absolute_id.launch-brief.md'" \
+    "absolute FM_HOME spelling changed in the default cross-process brief snapshot path"
   pass "FM_HOME defaults resolve relative paths and preserve absolute spellings"
 }
 
@@ -287,8 +319,8 @@ test_absolute_override_spelling_is_preserved_in_launch_paths() {
   launch=$(cat "$LAUNCH_LOG")
   assert_contains "$launch" "-e '$linked_home/state/$id.pi-ext.ts'" \
     "absolute FM_STATE_OVERRIDE spelling changed in Pi's cross-process extension path"
-  assert_contains "$launch" "< '$linked_home/data/$id/brief.md'" \
-    "absolute FM_DATA_OVERRIDE spelling changed in the cross-process brief path"
+  assert_contains "$launch" "< '$linked_home/state/$id.launch-brief.md'" \
+    "absolute FM_STATE_OVERRIDE spelling changed in the cross-process brief snapshot path"
   pass "absolute override spellings are preserved in spawn launch paths"
 }
 
@@ -827,6 +859,7 @@ test_active_dispatch_profile_does_not_block_secondmate_launch() {
 }
 
 test_no_profile_keeps_claude_profile_defaults
+test_spawn_launches_the_validated_brief_snapshot
 test_non_cursor_launch_clears_inherited_cursor_markers
 test_relative_home_overrides_launch_with_absolute_cross_process_paths
 test_home_defaults_preserve_absolute_or_resolve_relative_paths

--- a/tests/fm-task-delivery.test.sh
+++ b/tests/fm-task-delivery.test.sh
@@ -18,6 +18,7 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 SPAWN="$ROOT/bin/fm-spawn.sh"
+BRIEF="$ROOT/bin/fm-brief.sh"
 PROMOTE="$ROOT/bin/fm-promote.sh"
 PROJECT_MODE="$ROOT/bin/fm-project-mode.sh"
 TMP_ROOT=$(fm_test_tmproot fm-task-delivery)
@@ -156,86 +157,60 @@ EOF
 # contract line, so an appended block carrying a different mode would otherwise
 # launch unnoticed.
 test_spawn_refuses_an_appended_scaffold_signature() {
-  local rec home proj fakebin brief out status
+  local rec home proj fakebin brief generated_a generated_b out status
   rec=$(make_home duplicated)
   IFS='|' read -r home proj fakebin <<EOF
 $rec
 EOF
-  mkdir -p "$home/data/delivery-duplicated-d1"
+  generated_a="$TMP_ROOT/duplicated/generated-a"
+  generated_b="$TMP_ROOT/duplicated/generated-b"
+  mkdir -p "$home/data/delivery-duplicated-d1" "$generated_a" "$generated_b"
   brief="$home/data/delivery-duplicated-d1/brief.md"
-  cat > "$brief" <<'EOF'
-You are a crewmate.
-
-# Task
-Original task.
-
-# Setup
-Original setup.
-
-# Rules
-Original rules.
-
-# Project memory
-Original memory contract.
-
-# Definition of done
-Delivery contract: mode=no-mistakes
-
-# Setup
-Re-scaffolded setup.
-
-# Rules
-Re-scaffolded rules.
-
-# Project memory
-Re-scaffolded memory contract.
-
-# Definition of done
-Delivery contract: mode=direct-PR
-EOF
+  FM_HOME="$generated_a" "$BRIEF" delivery-duplicated-d1 proj --mode no-mistakes >/dev/null
+  FM_HOME="$generated_b" "$BRIEF" delivery-duplicated-d1 proj --mode direct-PR >/dev/null
+  cat "$generated_a/data/delivery-duplicated-d1/brief.md" \
+    "$generated_b/data/delivery-duplicated-d1/brief.md" > "$brief"
 
   out=$(run_spawn "$home" "$fakebin" delivery-duplicated-d1 "$proj" claude --mode no-mistakes --yolo off)
   status=$?
   [ "$status" -ne 0 ] || fail "a brief with duplicated sections should exit non-zero"
-  assert_contains "$out" "repeats these sections" "the refusal did not say what is wrong with the brief"
-  assert_contains "$out" "# Setup" "the refusal did not list the repeated setup section"
-  assert_contains "$out" "# Rules" "the refusal did not list the repeated rules section"
-  assert_contains "$out" "# Project memory" "the refusal did not list the repeated project-memory section"
-  assert_contains "$out" "# Definition of done" "the refusal did not list the repeated section"
+  assert_contains "$out" "multiple generated scaffold markers" \
+    "the refusal did not identify the duplicated generated scaffold"
   assert_contains "$out" "--replace" "the refusal did not name the supported regeneration path"
   assert_absent "$home/state/delivery-duplicated-d1.meta" "a duplicated-brief spawn wrote task metadata"
   pass "fm-spawn: an appended scaffold signature is refused"
 }
 
 test_spawn_accepts_legitimate_repeated_task_headings() {
-  local rec home proj fakebin brief marker suffix out
+  local rec home proj fakebin brief marker suffix out status
   rec=$(make_home legitimate-headings)
   IFS='|' read -r home proj fakebin <<EOF
 $rec
 EOF
-  mkdir -p "$home/data/delivery-task-heading-d2"
+  FM_HOME="$home" "$BRIEF" delivery-task-heading-d2 proj --mode no-mistakes >/dev/null
   brief="$home/data/delivery-task-heading-d2/brief.md"
-  cat > "$brief" <<'EOF'
-You are a crewmate.
-
-# Task
-Explain a setup procedure.
-
-# Setup
-This heading belongs to the task body.
-
-# Setup
-This heading belongs to the scaffold.
-
-# Rules
-Scaffold rules.
-
-# Definition of done
-Delivery contract: mode=no-mistakes
-EOF
+  awk '
+    $0 == "{TASK}" {
+      print "Explain setup and rule concepts."
+      print ""
+      print "# Setup"
+      print "This heading belongs to the task body."
+      print ""
+      print "# Rules"
+      print "This heading also belongs to the task body."
+      next
+    }
+    { print }
+  ' "$brief" > "$brief.next"
+  mv "$brief.next" "$brief"
+  printf '#!/bin/sh\nprintf "task headings reached endpoint launch\\n" >&2\nexit 1\n' > "$fakebin/tmux"
   out=$(run_spawn "$home" "$fakebin" delivery-task-heading-d2 "$proj" claude --mode no-mistakes --yolo off)
-  assert_not_contains "$out" "repeats these sections" \
-    "one task-body heading matching a scaffold heading was falsely refused"
+  status=$?
+  expect_code 1 "$status" "the hermetic endpoint fixture should stop the launch"
+  assert_contains "$out" "task headings reached endpoint launch" \
+    "task-body Setup and Rules headings did not reach endpoint launch"
+  assert_not_contains "$out" "multiple generated scaffold markers" \
+    "task-body Setup and Rules headings were falsely refused"
 
   for marker in '```' '~~~'; do
     case "$marker" in '```') suffix=backticks ;; *) suffix=tildes ;; esac
@@ -248,14 +223,14 @@ EOF
       printf '\n# Definition of done\nDelivery contract: mode=no-mistakes\n'
     } > "$brief"
     out=$(run_spawn "$home" "$fakebin" "delivery-fenced-$suffix-d3" "$proj" claude --mode no-mistakes --yolo off)
-    assert_not_contains "$out" "repeats these sections" \
+    assert_not_contains "$out" "multiple generated scaffold markers" \
       "$marker fenced scaffold-looking headings were falsely refused"
   done
   pass "fm-spawn: legitimate task headings clear the scaffold-signature guard"
 }
 
 test_secondmate_duplicate_guidance_names_the_charter_publisher() {
-  local rec home proj fakebin route sm brief out status
+  local rec home proj fakebin route sm brief generated_a generated_b out status
   rec=$(make_home secondmate-duplicate-guidance)
   IFS='|' read -r home proj fakebin <<EOF
 $rec
@@ -273,19 +248,17 @@ EOF
         > "$sm/.fm-secondmate-parent"
     fi
     brief="$sm/data/charter.md"
-    cat > "$brief" <<'EOF'
-# Charter
-Original charter.
-
-# Operating model
-Original operating model.
-
-# Charter
-Appended charter.
-
-# Operating model
-Appended operating model.
-EOF
+    generated_a="$TMP_ROOT/secondmate-duplicate-guidance-$route-generated-a"
+    generated_b="$TMP_ROOT/secondmate-duplicate-guidance-$route-generated-b"
+    mkdir -p "$generated_a" "$generated_b"
+    FM_HOME="$generated_a" FM_SECONDMATE_CHARTER='Original charter.' \
+      FM_SECONDMATE_SCOPE='Original scope.' \
+      "$BRIEF" "delivery-charter-$route" --secondmate --no-projects >/dev/null
+    FM_HOME="$generated_b" FM_SECONDMATE_CHARTER='Appended charter.' \
+      FM_SECONDMATE_SCOPE='Appended scope.' \
+      "$BRIEF" "delivery-charter-$route" --secondmate --no-projects >/dev/null
+    cat "$generated_a/data/delivery-charter-$route/brief.md" \
+      "$generated_b/data/delivery-charter-$route/brief.md" > "$brief"
 
     out=$(FM_SKIP_SECONDMATE_INHERIT=1 run_spawn "$home" "$fakebin" \
       "delivery-charter-$route" "$sm" claude --secondmate)

--- a/tests/fm-task-delivery.test.sh
+++ b/tests/fm-task-delivery.test.sh
@@ -151,48 +151,107 @@ EOF
 # unregistered project resolves to the same no-mistakes standing default
 # (AGENTS.md section 7), so a downgrade there is announced too. A conditional
 # policy is excluded because both of its legs are legitimate classifications.
-# A brief that carries the same top-level section twice was appended to rather
-# than regenerated. The worker would follow whichever copy it read last, and the
-# mode check above reads only the FIRST delivery contract line, so a second block
-# carrying a different mode would launch unnoticed. Every spawn kind refuses it.
-test_spawn_refuses_a_brief_with_duplicated_sections() {
-  local rec home proj fakebin out status
+# A second full scaffold leaves several repeated sections whose competing rules
+# have no precedence marker. The mode check above reads only the FIRST delivery
+# contract line, so an appended block carrying a different mode would otherwise
+# launch unnoticed.
+test_spawn_refuses_an_appended_scaffold_signature() {
+  local rec home proj fakebin brief out status
   rec=$(make_home duplicated)
   IFS='|' read -r home proj fakebin <<EOF
 $rec
 EOF
-  # Exactly the shape hand-appending produced: a second full contract block,
-  # here even recording a different delivery mode than the first.
-  write_brief "$home" delivery-duplicated-d1 no-mistakes
-  {
-    printf '\n# Setup\nRe-scaffolded instructions.\n'
-    printf '\n# Rules\n1. Never push to the default branch.\n'
-    printf '\n# Definition of done\nDelivery contract: mode=direct-PR\n'
-  } >> "$home/data/delivery-duplicated-d1/brief.md"
+  mkdir -p "$home/data/delivery-duplicated-d1"
+  brief="$home/data/delivery-duplicated-d1/brief.md"
+  cat > "$brief" <<'EOF'
+You are a crewmate.
+
+# Task
+Original task.
+
+# Setup
+Original setup.
+
+# Rules
+Original rules.
+
+# Project memory
+Original memory contract.
+
+# Definition of done
+Delivery contract: mode=no-mistakes
+
+# Setup
+Re-scaffolded setup.
+
+# Rules
+Re-scaffolded rules.
+
+# Project memory
+Re-scaffolded memory contract.
+
+# Definition of done
+Delivery contract: mode=direct-PR
+EOF
 
   out=$(run_spawn "$home" "$fakebin" delivery-duplicated-d1 "$proj" claude --mode no-mistakes --yolo off)
   status=$?
   [ "$status" -ne 0 ] || fail "a brief with duplicated sections should exit non-zero"
   assert_contains "$out" "repeats these sections" "the refusal did not say what is wrong with the brief"
+  assert_contains "$out" "# Setup" "the refusal did not list the repeated setup section"
+  assert_contains "$out" "# Rules" "the refusal did not list the repeated rules section"
+  assert_contains "$out" "# Project memory" "the refusal did not list the repeated project-memory section"
   assert_contains "$out" "# Definition of done" "the refusal did not list the repeated section"
   assert_contains "$out" "--replace" "the refusal did not name the supported regeneration path"
   assert_absent "$home/state/delivery-duplicated-d1.meta" "a duplicated-brief spawn wrote task metadata"
+  pass "fm-spawn: an appended scaffold signature is refused"
+}
 
-  # The guard is not ship-only: a scout brief is appended to the same way.
-  write_brief "$home" scout-duplicated-d2
-  printf '\n# Definition of done\nWrite your findings to the report.\n' \
-    >> "$home/data/scout-duplicated-d2/brief.md"
-  out=$(run_spawn "$home" "$fakebin" scout-duplicated-d2 "$proj" claude --scout)
-  status=$?
-  [ "$status" -ne 0 ] || fail "a duplicated scout brief should exit non-zero"
-  assert_contains "$out" "repeats these sections" "the scout refusal did not explain the duplication"
+test_spawn_accepts_legitimate_repeated_task_headings() {
+  local rec home proj fakebin brief marker suffix out
+  rec=$(make_home legitimate-headings)
+  IFS='|' read -r home proj fakebin <<EOF
+$rec
+EOF
+  mkdir -p "$home/data/delivery-task-heading-d2"
+  brief="$home/data/delivery-task-heading-d2/brief.md"
+  cat > "$brief" <<'EOF'
+You are a crewmate.
 
-  # A single-copy brief is untouched by the guard and only fails later, at the
-  # refusing tmux, so the check cannot be passing vacuously.
-  write_brief "$home" delivery-single-d3 no-mistakes
-  out=$(run_spawn "$home" "$fakebin" delivery-single-d3 "$proj" claude --mode no-mistakes --yolo off)
-  assert_not_contains "$out" "repeats these sections" "a well-formed brief was refused as duplicated"
-  pass "fm-spawn: a brief carrying the same section twice is refused, never launched"
+# Task
+Explain a setup procedure.
+
+# Setup
+This heading belongs to the task body.
+
+# Setup
+This heading belongs to the scaffold.
+
+# Rules
+Scaffold rules.
+
+# Definition of done
+Delivery contract: mode=no-mistakes
+EOF
+  out=$(run_spawn "$home" "$fakebin" delivery-task-heading-d2 "$proj" claude --mode no-mistakes --yolo off)
+  assert_not_contains "$out" "repeats these sections" \
+    "one task-body heading matching a scaffold heading was falsely refused"
+
+  for marker in '```' '~~~'; do
+    case "$marker" in '```') suffix=backticks ;; *) suffix=tildes ;; esac
+    mkdir -p "$home/data/delivery-fenced-$suffix-d3"
+    brief="$home/data/delivery-fenced-$suffix-d3/brief.md"
+    {
+      printf 'You are a crewmate.\n\n# Task\n'
+      printf '%smarkdown\n# Setup\nExample setup.\n# Rules\nExample rules.\n%s\n' "$marker" "$marker"
+      printf '\n# Setup\nScaffold setup.\n\n# Rules\nScaffold rules.\n'
+      printf '\n# Definition of done\nDelivery contract: mode=no-mistakes\n'
+    } > "$brief"
+    out=$(run_spawn "$home" "$fakebin" "delivery-fenced-$suffix-d3" "$proj" claude --mode no-mistakes --yolo off)
+    assert_not_contains "$out" "repeats these sections" \
+      "$marker fenced scaffold-looking headings were falsely refused"
+  done
+  pass "fm-spawn: legitimate task headings clear the scaffold-signature guard"
 }
 
 test_spawn_notices_a_rigor_downgrade_against_the_registry() {
@@ -319,7 +378,8 @@ EOF
 test_ship_spawn_requires_a_valid_delivery_contract
 test_scout_and_secondmate_refuse_delivery_flags
 test_spawn_refuses_a_brief_mode_mismatch
-test_spawn_refuses_a_brief_with_duplicated_sections
+test_spawn_refuses_an_appended_scaffold_signature
+test_spawn_accepts_legitimate_repeated_task_headings
 test_spawn_notices_a_rigor_downgrade_against_the_registry
 test_scout_records_no_delivery_posture
 test_promote_requires_and_records_the_delivery_contract

--- a/tests/fm-task-delivery.test.sh
+++ b/tests/fm-task-delivery.test.sh
@@ -50,6 +50,28 @@ write_brief() {  # <home> <id> [<recorded-mode>]
   } > "$home/data/$id/brief.md"
 }
 
+append_legacy_ship_scaffold() {  # <brief> <task> <mode>
+  cat >> "$1" <<EOF
+You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
+
+# Task
+$2
+
+# Setup
+Prepare the disposable worktree.
+
+# Rules
+Stay inside the worktree and report material status changes.
+
+# Project memory
+Record only durable project knowledge.
+
+# Definition of done
+Delivery contract: mode=$3
+Complete the selected delivery path.
+EOF
+}
+
 run_spawn() {  # <home> <fakebin> <spawn-args...>
   local home=$1 fakebin=$2
   shift 2
@@ -181,6 +203,41 @@ EOF
   pass "fm-spawn: an appended scaffold signature is refused"
 }
 
+test_spawn_refuses_legacy_scaffold_signatures() {
+  local shape rec home proj fakebin id brief out status
+  for shape in legacy-only mixed; do
+    rec=$(make_home "legacy-duplicated-$shape")
+    IFS='|' read -r home proj fakebin <<EOF
+$rec
+EOF
+    id="delivery-legacy-duplicated-$shape"
+    mkdir -p "$home/data/$id"
+    brief="$home/data/$id/brief.md"
+    case "$shape" in
+      legacy-only)
+        : > "$brief"
+        append_legacy_ship_scaffold "$brief" "Original legacy task." no-mistakes
+        append_legacy_ship_scaffold "$brief" "Appended legacy task." direct-PR
+        ;;
+      mixed)
+        FM_HOME="$home" "$BRIEF" "$id" proj --mode no-mistakes >/dev/null
+        append_legacy_ship_scaffold "$brief" "Appended legacy task." direct-PR
+        ;;
+    esac
+
+    out=$(run_spawn "$home" "$fakebin" "$id" "$proj" claude --mode no-mistakes --yolo off)
+    status=$?
+    [ "$status" -ne 0 ] || fail "$shape duplicated scaffold should exit non-zero"
+    assert_contains "$out" "multiple generated scaffold signatures" \
+      "$shape duplicated scaffold was not identified structurally"
+    assert_contains "$out" "--replace" \
+      "$shape duplicated scaffold refusal omitted the supported regeneration path"
+    assert_absent "$home/state/$id.meta" \
+      "$shape duplicated scaffold spawn wrote task metadata"
+  done
+  pass "fm-spawn: legacy and mixed appended scaffolds are refused"
+}
+
 test_spawn_accepts_legitimate_repeated_task_headings() {
   local rec home proj fakebin brief marker suffix out status
   rec=$(make_home legitimate-headings)
@@ -211,6 +268,8 @@ EOF
     "task-body Setup and Rules headings did not reach endpoint launch"
   assert_not_contains "$out" "multiple generated scaffold markers" \
     "task-body Setup and Rules headings were falsely refused"
+  assert_not_contains "$out" "multiple generated scaffold signatures" \
+    "task-body Setup and Rules headings matched a legacy scaffold signature"
 
   for marker in '```' '~~~'; do
     case "$marker" in '```') suffix=backticks ;; *) suffix=tildes ;; esac
@@ -223,8 +282,12 @@ EOF
       printf '\n# Definition of done\nDelivery contract: mode=no-mistakes\n'
     } > "$brief"
     out=$(run_spawn "$home" "$fakebin" "delivery-fenced-$suffix-d3" "$proj" claude --mode no-mistakes --yolo off)
+    assert_contains "$out" "task headings reached endpoint launch" \
+      "$marker fenced headings did not reach endpoint launch"
     assert_not_contains "$out" "multiple generated scaffold markers" \
       "$marker fenced scaffold-looking headings were falsely refused"
+    assert_not_contains "$out" "multiple generated scaffold signatures" \
+      "$marker fenced headings matched a legacy scaffold signature"
   done
   pass "fm-spawn: legitimate task headings clear the scaffold-signature guard"
 }
@@ -403,6 +466,7 @@ test_ship_spawn_requires_a_valid_delivery_contract
 test_scout_and_secondmate_refuse_delivery_flags
 test_spawn_refuses_a_brief_mode_mismatch
 test_spawn_refuses_an_appended_scaffold_signature
+test_spawn_refuses_legacy_scaffold_signatures
 test_spawn_accepts_legitimate_repeated_task_headings
 test_secondmate_duplicate_guidance_names_the_charter_publisher
 test_spawn_notices_a_rigor_downgrade_against_the_registry

--- a/tests/fm-task-delivery.test.sh
+++ b/tests/fm-task-delivery.test.sh
@@ -151,6 +151,50 @@ EOF
 # unregistered project resolves to the same no-mistakes standing default
 # (AGENTS.md section 7), so a downgrade there is announced too. A conditional
 # policy is excluded because both of its legs are legitimate classifications.
+# A brief that carries the same top-level section twice was appended to rather
+# than regenerated. The worker would follow whichever copy it read last, and the
+# mode check above reads only the FIRST delivery contract line, so a second block
+# carrying a different mode would launch unnoticed. Every spawn kind refuses it.
+test_spawn_refuses_a_brief_with_duplicated_sections() {
+  local rec home proj fakebin out status
+  rec=$(make_home duplicated)
+  IFS='|' read -r home proj fakebin <<EOF
+$rec
+EOF
+  # Exactly the shape hand-appending produced: a second full contract block,
+  # here even recording a different delivery mode than the first.
+  write_brief "$home" delivery-duplicated-d1 no-mistakes
+  {
+    printf '\n# Setup\nRe-scaffolded instructions.\n'
+    printf '\n# Rules\n1. Never push to the default branch.\n'
+    printf '\n# Definition of done\nDelivery contract: mode=direct-PR\n'
+  } >> "$home/data/delivery-duplicated-d1/brief.md"
+
+  out=$(run_spawn "$home" "$fakebin" delivery-duplicated-d1 "$proj" claude --mode no-mistakes --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "a brief with duplicated sections should exit non-zero"
+  assert_contains "$out" "repeats these sections" "the refusal did not say what is wrong with the brief"
+  assert_contains "$out" "# Definition of done" "the refusal did not list the repeated section"
+  assert_contains "$out" "--replace" "the refusal did not name the supported regeneration path"
+  assert_absent "$home/state/delivery-duplicated-d1.meta" "a duplicated-brief spawn wrote task metadata"
+
+  # The guard is not ship-only: a scout brief is appended to the same way.
+  write_brief "$home" scout-duplicated-d2
+  printf '\n# Definition of done\nWrite your findings to the report.\n' \
+    >> "$home/data/scout-duplicated-d2/brief.md"
+  out=$(run_spawn "$home" "$fakebin" scout-duplicated-d2 "$proj" claude --scout)
+  status=$?
+  [ "$status" -ne 0 ] || fail "a duplicated scout brief should exit non-zero"
+  assert_contains "$out" "repeats these sections" "the scout refusal did not explain the duplication"
+
+  # A single-copy brief is untouched by the guard and only fails later, at the
+  # refusing tmux, so the check cannot be passing vacuously.
+  write_brief "$home" delivery-single-d3 no-mistakes
+  out=$(run_spawn "$home" "$fakebin" delivery-single-d3 "$proj" claude --mode no-mistakes --yolo off)
+  assert_not_contains "$out" "repeats these sections" "a well-formed brief was refused as duplicated"
+  pass "fm-spawn: a brief carrying the same section twice is refused, never launched"
+}
+
 test_spawn_notices_a_rigor_downgrade_against_the_registry() {
   local rec home proj fakebin out label mode registry expect registered n=0
   while IFS='|' read -r label registry mode expect registered; do
@@ -275,6 +319,7 @@ EOF
 test_ship_spawn_requires_a_valid_delivery_contract
 test_scout_and_secondmate_refuse_delivery_flags
 test_spawn_refuses_a_brief_mode_mismatch
+test_spawn_refuses_a_brief_with_duplicated_sections
 test_spawn_notices_a_rigor_downgrade_against_the_registry
 test_scout_records_no_delivery_posture
 test_promote_requires_and_records_the_delivery_contract

--- a/tests/fm-task-delivery.test.sh
+++ b/tests/fm-task-delivery.test.sh
@@ -239,7 +239,7 @@ EOF
 }
 
 test_spawn_accepts_legitimate_repeated_task_headings() {
-  local rec home proj fakebin brief marker suffix out status
+  local rec home proj fakebin brief marker suffix id out status
   rec=$(make_home legitimate-headings)
   IFS='|' read -r home proj fakebin <<EOF
 $rec
@@ -273,19 +273,32 @@ EOF
 
   for marker in '```' '~~~'; do
     case "$marker" in '```') suffix=backticks ;; *) suffix=tildes ;; esac
-    mkdir -p "$home/data/delivery-fenced-$suffix-d3"
-    brief="$home/data/delivery-fenced-$suffix-d3/brief.md"
-    {
-      printf 'You are a crewmate.\n\n# Task\n'
-      printf '%smarkdown\n# Setup\nExample setup.\n# Rules\nExample rules.\n%s\n' "$marker" "$marker"
-      printf '\n# Setup\nScaffold setup.\n\n# Rules\nScaffold rules.\n'
-      printf '\n# Definition of done\nDelivery contract: mode=no-mistakes\n'
-    } > "$brief"
-    out=$(run_spawn "$home" "$fakebin" "delivery-fenced-$suffix-d3" "$proj" claude --mode no-mistakes --yolo off)
+    id="delivery-fenced-$suffix-d3"
+    FM_HOME="$home" "$BRIEF" "$id" proj --mode no-mistakes >/dev/null
+    brief="$home/data/$id/brief.md"
+    awk -v fence="$marker" '
+      $0 == "{TASK}" {
+        print "Show scaffold examples."
+        print ""
+        print fence "markdown"
+        print "# Setup"
+        print "Example setup."
+        print "# Rules"
+        print "Example rules."
+        print "<!-- firstmate:generated-brief-scaffold:v1 -->"
+        print fence
+        next
+      }
+      { print }
+    ' "$brief" > "$brief.next"
+    mv "$brief.next" "$brief"
+    out=$(run_spawn "$home" "$fakebin" "$id" "$proj" claude --mode no-mistakes --yolo off)
+    status=$?
+    expect_code 1 "$status" "the hermetic endpoint fixture should stop the $suffix launch"
     assert_contains "$out" "task headings reached endpoint launch" \
-      "$marker fenced headings did not reach endpoint launch"
+      "$marker fenced scaffold example did not reach endpoint launch"
     assert_not_contains "$out" "multiple generated scaffold markers" \
-      "$marker fenced scaffold-looking headings were falsely refused"
+      "$marker fenced generated marker was falsely refused"
     assert_not_contains "$out" "multiple generated scaffold signatures" \
       "$marker fenced headings matched a legacy scaffold signature"
   done

--- a/tests/fm-task-delivery.test.sh
+++ b/tests/fm-task-delivery.test.sh
@@ -254,6 +254,57 @@ EOF
   pass "fm-spawn: legitimate task headings clear the scaffold-signature guard"
 }
 
+test_secondmate_duplicate_guidance_names_the_charter_publisher() {
+  local rec home proj fakebin route sm brief out status
+  rec=$(make_home secondmate-duplicate-guidance)
+  IFS='|' read -r home proj fakebin <<EOF
+$rec
+EOF
+  for route in local remote; do
+    sm="$TMP_ROOT/secondmate-duplicate-guidance-$route"
+    mkdir -p "$sm/bin" "$sm/data" "$sm/state" "$sm/config" "$sm/projects"
+    printf '# Firstmate\n' > "$sm/AGENTS.md"
+    printf '%s\n' "delivery-charter-$route" > "$sm/.fm-secondmate-home"
+    if [ "$route" = local ]; then
+      printf 'schema=fm-secondmate-parent.v1\nroute=local\nparent_home=%s\n' "$home" \
+        > "$sm/.fm-secondmate-parent"
+    else
+      printf 'schema=fm-secondmate-parent.v1\nroute=remote\nparent_host=test-host\n' \
+        > "$sm/.fm-secondmate-parent"
+    fi
+    brief="$sm/data/charter.md"
+    cat > "$brief" <<'EOF'
+# Charter
+Original charter.
+
+# Operating model
+Original operating model.
+
+# Charter
+Appended charter.
+
+# Operating model
+Appended operating model.
+EOF
+
+    out=$(FM_SKIP_SECONDMATE_INHERIT=1 run_spawn "$home" "$fakebin" \
+      "delivery-charter-$route" "$sm" claude --secondmate)
+    status=$?
+    [ "$status" -ne 0 ] || fail "$route secondmate with a duplicated charter should exit non-zero"
+    assert_contains "$out" "data/charter.md" \
+      "$route secondmate recovery did not name the charter actually launched"
+    case "$route" in
+      local)
+        assert_contains "$out" "bin/fm-home-seed.sh" \
+          "local secondmate recovery did not name the local charter publisher" ;;
+      remote)
+        assert_contains "$out" "bin/fm-remote-home-seed.sh" \
+          "remote secondmate recovery did not name the remote charter publisher" ;;
+    esac
+  done
+  pass "fm-spawn: duplicated secondmate charters name their route publisher"
+}
+
 test_spawn_notices_a_rigor_downgrade_against_the_registry() {
   local rec home proj fakebin out label mode registry expect registered n=0
   while IFS='|' read -r label registry mode expect registered; do
@@ -380,6 +431,7 @@ test_scout_and_secondmate_refuse_delivery_flags
 test_spawn_refuses_a_brief_mode_mismatch
 test_spawn_refuses_an_appended_scaffold_signature
 test_spawn_accepts_legitimate_repeated_task_headings
+test_secondmate_duplicate_guidance_names_the_charter_publisher
 test_spawn_notices_a_rigor_downgrade_against_the_registry
 test_scout_records_no_delivery_posture
 test_promote_requires_and_records_the_delivery_contract


### PR DESCRIPTION
## What Changed

- Shorten generated ship and scout briefs by moving conditional escalation-resolution and no-mistakes guidance into `docs/crew-reference.md`, with explicit triggers for loading it.
- Add a guarded `fm-brief.sh --replace` flow that atomically publishes new scaffolds, archives superseded briefs, rejects unsafe targets, and detects duplicated scaffolds without misreading fenced examples.
- Serialize and snapshot brief and charter publication across spawn, relaunch, and local or remote secondmate seeding so each launch receives one immutable instruction generation and concurrent updates survive rollback.

## Risk Assessment

✅ Low: Captain, the fence-aware shared scanner now preserves all required duplicate-detection paths while preventing quoted scaffold markers from becoming semantic, and the change is narrow and internally consistent.

## Testing

No pre-run baseline was supplied. Targeted brief generation, delivery validation, immutable snapshots, relaunch publication, and local/remote charter publication all passed on a fresh rerun; an initial remote fixture attempt inherited `commit.gpgsign=true` and passed after disabling signing only for that test process. Manual CLI and generated-Markdown artifacts demonstrate progressive disclosure, safe replacement, fenced-example acceptance, and duplicate-scaffold refusal end to end.

<details>
<summary>Evidence: End-to-end brief CLI transcript</summary>

`Shows brief generation, inline wait guidance, deferred-contract trigger, archive-preserving replacement, fenced-marker acceptance, and actionable duplicate-scaffold refusal.`

```text
$ Generate a no-mistakes worker brief
scaffolded: /var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/no-mistakes-evidence/01M0FF2M4Z5P0J9CCVB3SB90G8/brief-progressive-disclosure/home/data/proof-task/brief.md (ship, mode=no-mistakes; replace {TASK})
$ Show the always-present wait rule and the deferred-contract trigger
40:   read `/Users/tiago/.no-mistakes/worktrees/bbb16e1f0808/01M0FF2M4Z5P0J9CCVB3SB90G8/docs/crew-reference.md` first - only a matching `resolved` line closes it.
41-7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
42-   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
43-   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.
44-
45:# Before you wait, declare it
46-Ask this before every long-running command: once it starts, am I working, or watching?
47-If you are watching, you are waiting, and a wait has to be declared.
48-**Your own validation round returning through the gate counts, and it is the case workers miss.**
49-It is your work, so it does not feel like an external wait - but while it runs you are idle, and an idle pane is all firstmate can see.
50-A CI run, a long build or test suite, a review you are hosting, a rate-limit reset, a scheduled window all count the same way.
51-Declare it BEFORE you start waiting:
52-   `echo "paused: {what you await, and what will end it}" >> '/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/no-mistakes-evidence/01M0FF2M4Z5P0J9CCVB3SB90G8/brief-progressive-disclosure/home/state/proof-task.status'`
53-Firstmate cannot tell a pane that is waiting on purpose from one that has wedged, so an undeclared wait makes it interrupt you to find out; a declared one is left alone and rechecked on a long cadence.
54-The declaration holds only while it is your LAST status line - appending `working:` on top of it cancels the pause, and you look wedged again.
--
68:Before your first `no-mistakes` command, read `/Users/tiago/.no-mistakes/worktrees/bbb16e1f0808/01M0FF2M4Z5P0J9CCVB3SB90G8/docs/crew-reference.md`.
69-It owns how you drive the pipeline: that you answer gates rather than implement fixes, what `--intent` must carry, how an escalated decision comes back to the gate, and where you stop.
70-Reading it then is part of the task, not optional background.
71-
72-One rule from it stays here, because it fires against your instinct at the moment it applies: ask-user findings are never yours to answer.
73-Escalate with `needs-decision:` and stop (rule 6). Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.
74-
75-After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
$ Regenerate safely with a changed delivery mode
scaffolded: /var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/no-mistakes-evidence/01M0FF2M4Z5P0J9CCVB3SB90G8/brief-progressive-disclosure/home/data/proof-task/brief.md (ship, mode=direct-PR; replace {TASK}; replaced, superseded brief archived at /var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/no-mistakes-evidence/01M0FF2M4Z5P0J9CCVB3SB90G8/brief-progressive-disclosure/home/data/proof-task/brief.superseded-1.md)
$ Confirm the live brief changed while the prior task text and delivery mode remain archived
/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/no-mistakes-evidence/01M0FF2M4Z5P0J9CCVB3SB90G8/brief-progressive-disclosure/home/data/proof-task/brief.superseded-1.md:63:Delivery contract: mode=no-mistakes
/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/no-mistakes-evidence/01M0FF2M4Z5P0J9CCVB3SB90G8/brief-progressive-disclosure/home/data/proof-task/brief.md:62:Delivery contract: mode=direct-PR
6:Preserve this operator-authored task text.
$ Generate a brief whose task contains a fenced scaffold marker example
scaffolded: /var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/no-mistakes-evidence/01M0FF2M4Z5P0J9CCVB3SB90G8/brief-progressive-disclosure/home/data/fenced-proof/brief.md (ship, mode=no-mistakes; replace {TASK})
$ Ask spawn to validate it; delivery mismatch is the deliberate stopping sentinel
error: no-mistakes gate agent must not drive the fleet (NO_MISTAKES_GATE set)
spawn exit status: 3
$ Hermetic validation retry with the repository test bypass; no endpoint is created
error: delivery mismatch for fenced-proof: the brief says mode=no-mistakes but this spawn passed --mode direct-PR; correct the flag or re-scaffold the brief so the worker's instructions and the task record agree
spawn exit status: 1
$ Confirm the fenced generated marker remains in the task source while validation advanced to the delivery check
1:<!-- firstmate:generated-brief-scaffold:v1 -->
8:`` `markdown
11:<!-- firstmate:generated-brief-scaffold:v1 -->
71:Delivery contract: mode=no-mistakes
$ Validate a mistakenly appended second scaffold
error: /var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/no-mistakes-evidence/01M0FF2M4Z5P0J9CCVB3SB90G8/brief-progressive-disclosure/home/data/duplicate-proof/brief.md contains multiple generated scaffold markers, so which copy governs is undefined
regenerate it with bin/fm-brief.sh --replace (which archives the superseded brief) instead of appending a second copy
spawn exit status: 1
```
</details>
<details>
<summary>Evidence: Generated no-mistakes worker brief</summary>

```text
<!-- firstmate:generated-brief-scaffold:v1 -->

You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this brief carries no Herdr isolation contract, so any Herdr lifecycle command you run here would hit the captain's live fleet.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and have the brief regenerated with `--herdr-lab` before you continue.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of project, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/proof-task`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/no-mistakes-evidence/01M0FF2M4Z5P0J9CCVB3SB90G8/brief-progressive-disclosure/home/state/proof-task.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   You own closing what you open: when a decision, blocker, or wait you declared stops being true,
   read `/Users/tiago/.no-mistakes/worktrees/bbb16e1f0808/01M0FF2M4Z5P0J9CCVB3SB90G8/docs/crew-reference.md` first - only a matching `resolved` line closes it.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Before you wait, declare it
Ask this before every long-running command: once it starts, am I working, or watching?
If you are watching, you are waiting, and a wait has to be declared.
**Your own validation round returning through the gate counts, and it is the case workers miss.**
It is your work, so it does not feel like an external wait - but while it runs you are idle, and an idle pane is all firstmate can see.
A CI run, a long build or test suite, a review you are hosting, a rate-limit reset, a scheduled window all count the same way.
Declare it BEFORE you start waiting:
   `echo "paused: {what you await, and what will end it}" >> '/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/no-mistakes-evidence/01M0FF2M4Z5P0J9CCVB3SB90G8/brief-progressive-disclosure/home/state/proof-task.status'`
Firstmate cannot tell a pane that is waiting on purpose from one that has wedged, so an undeclared wait makes it interrupt you to find out; a declared one is left alone and rechecked on a long cadence.
The declaration holds only while it is your LAST status line - appending `working:` on top of it cancels the pause, and you look wedged again.
This is not `blocked:`. Pause when the wait will clear on its own; block when firstmate has to act.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/tiago/.no-mistakes/worktrees/bbb16e1f0808/01M0FF2M4Z5P0J9CCVB3SB90G8/bin/fm-ensure-agents-md.sh .` in the worktree.
That script owns the authoring bar and writes it into the file's own `## Maintaining this file` section; follow the bar you find there for whatever you add.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=no-mistakes
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

Before your first `no-mistakes` command, read `/Users/tiago/.no-mistakes/worktrees/bbb16e1f0808/01M0FF2M4Z5P0J9CCVB3SB90G8/docs/crew-reference.md`.
It owns how you drive the pipeline: that you answer gates rather than implement fixes, what `--intent` must carry, how an escalated decision comes back to the gate, and where you stop.
Reading it then is part of the task, not optional background.

One rule from it stays here, because it fires against your instinct at the moment it applies: ask-user findings are never yours to answer.
Escalate with `needs-decision:` and stop (rule 6). Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Archived brief preserving operator-authored task text</summary>

```text
<!-- firstmate:generated-brief-scaffold:v1 -->

You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
Preserve this operator-authored task text.

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this brief carries no Herdr isolation contract, so any Herdr lifecycle command you run here would hit the captain's live fleet.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and have the brief regenerated with `--herdr-lab` before you continue.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of project, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/proof-task`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/no-mistakes-evidence/01M0FF2M4Z5P0J9CCVB3SB90G8/brief-progressive-disclosure/home/state/proof-task.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   You own closing what you open: when a decision, blocker, or wait you declared stops being true,
   read `/Users/tiago/.no-mistakes/worktrees/bbb16e1f0808/01M0FF2M4Z5P0J9CCVB3SB90G8/docs/crew-reference.md` first - only a matching `resolved` line closes it.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Before you wait, declare it
Ask this before every long-running command: once it starts, am I working, or watching?
If you are watching, you are waiting, and a wait has to be declared.
**Your own validation round returning through the gate counts, and it is the case workers miss.**
It is your work, so it does not feel like an external wait - but while it runs you are idle, and an idle pane is all firstmate can see.
A CI run, a long build or test suite, a review you are hosting, a rate-limit reset, a scheduled window all count the same way.
Declare it BEFORE you start waiting:
   `echo "paused: {what you await, and what will end it}" >> '/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/no-mistakes-evidence/01M0FF2M4Z5P0J9CCVB3SB90G8/brief-progressive-disclosure/home/state/proof-task.status'`
Firstmate cannot tell a pane that is waiting on purpose from one that has wedged, so an undeclared wait makes it interrupt you to find out; a declared one is left alone and rechecked on a long cadence.
The declaration holds only while it is your LAST status line - appending `working:` on top of it cancels the pause, and you look wedged again.
This is not `blocked:`. Pause when the wait will clear on its own; block when firstmate has to act.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/tiago/.no-mistakes/worktrees/bbb16e1f0808/01M0FF2M4Z5P0J9CCVB3SB90G8/bin/fm-ensure-agents-md.sh .` in the worktree.
That script owns the authoring bar and writes it into the file's own `## Maintaining this file` section; follow the bar you find there for whatever you add.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=no-mistakes
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

Before your first `no-mistakes` command, read `/Users/tiago/.no-mistakes/worktrees/bbb16e1f0808/01M0FF2M4Z5P0J9CCVB3SB90G8/docs/crew-reference.md`.
It owns how you drive the pipeline: that you answer gates rather than implement fixes, what `--intent` must carry, how an escalated decision comes back to the gate, and where you stop.
Reading it then is part of the task, not optional background.

One rule from it stays here, because it fires against your instinct at the moment it applies: ask-user findings are never yours to answer.
Escalate with `needs-decision:` and stop (rule 6). Firstmate applies the authority contract in its `AGENTS.md` and obtains any required captain decision.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (3) ✅</summary>

- 🚨 `bin/fm-spawn.sh:1660` - Snapshotting does not establish one stable generation across supported publishers. `fm-home-seed.sh` rewrites the local charter with an in-place `cp` at line 946, so a concurrent secondmate spawn can snapshot a truncated charter; it also rereads the mutable parent brief for validation, copying, and registry publication, allowing concurrent `--replace` output to disagree. Remote seeding and relaunch note/rollback paths likewise bypass the new publication lock. Route all brief and charter publication through the atomic helper and consume one snapshot throughout each operation.
- 🚨 `bin/fm-spawn.sh:1727` - The two-heading threshold retains the false-refusal path this fix intends to eliminate. A legitimate Task body containing both `# Setup` and `# Rules` produces `count &gt;= 2` and refuses spawn despite having only one scaffold; the added test proves only the one-heading case. Detect an actual generated scaffold block—such as an ordered structural signature or generation marker—instead of counting arbitrary task headings.

🔧 Fix: Serialize brief publication and mark generated scaffolds
1 error still open:
- 🚨 `bin/fm-spawn.sh:1706` - The marker-only guard misses the existing malformed briefs this durable fix targets: duplicated scaffolds created before marker introduction contain zero markers, while a legacy scaffold appended to one newly generated scaffold contains only one, so both pass this check and launch with competing rules. When fewer than two markers exist, detect the ordered legacy scaffold signature at this spawn boundary or migrate legacy briefs before accepting them.

🔧 Fix: Detect duplicated legacy scaffold signatures
1 error still open:
- 🚨 `bin/fm-spawn.sh:1773` - The raw marker count includes markers quoted inside fenced Task content. A generated brief already has one real marker, so a fenced example containing the exact marker makes the count 2 and refuses an otherwise single-scaffold spawn before the fence-aware legacy scanner runs. Count markers only outside fenced code, ideally in the same scanner, so fenced examples remain non-semantic.

🔧 Fix: Ignore fenced scaffold markers during spawn
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-brief.test.sh` (fresh final rerun passed)</code>
- <code>`bash tests/fm-task-delivery.test.sh` (fresh final rerun passed)</code>
- <code>`bash tests/fm-spawn-dispatch-profile.test.sh` (fresh final rerun passed)</code>
- <code>`FM_TEST_BRIEF_PUBLICATION_ONLY=1 bash tests/fm-secondmate-safety.test.sh` (fresh final rerun passed)</code>
- <code>`GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false FM_TEST_BRIEF_PUBLICATION_ONLY=1 bash tests/fm-control-relaunch.test.sh` (fresh final rerun passed)</code>
- <code>`FM_TEST_BRIEF_PUBLICATION_ONLY=1 bash tests/fm-remote-secondmate-lifecycle-e2e.test.sh` (initial setup-only failure because the host forced GPG signing for fixture commits)</code>
- <code>`GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false FM_TEST_BRIEF_PUBLICATION_ONLY=1 bash tests/fm-remote-secondmate-lifecycle-e2e.test.sh` (clean retry and fresh final rerun passed)</code>
- <code>Generated a real no-mistakes brief, exercised `--replace`, and confirmed the archived brief retained operator-authored text and its prior delivery mode.</code>
- <code>Hermetically exercised `fm-spawn.sh` with a fenced scaffold marker, confirming validation advanced to the deliberate delivery-mismatch sentinel without creating an endpoint.</code>
- <code>Hermetically exercised `fm-spawn.sh` with an appended second scaffold, confirming actionable refusal and `--replace` recovery guidance.</code>
- <code>Verified the evidence files and required content with `test -s` and focused `rg -q` assertions; confirmed no source-tree changes with `test -z &#34;$(git status --porcelain)&#34;`.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Annotate intentional deferred shell expansion for ShellCheck
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
