### PR TITLE
fix(bin): let process ancestry outrank inherited env markers in harness detection

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -45,7 +45,7 @@ If the captain asks for a new harness, propose verifying it first: spawn a trivi
 
 ## Detection
 
-`bin/fm-harness.sh` prints firstmate's own harness, using verified env markers first and then process ancestry.
+`bin/fm-harness.sh` prints firstmate's own harness, using process ancestry first and verified env markers only as the fallback when no harness ancestor is visible.
 Within the Pi family, only the exact launch-boundary marker `FM_PI_HARNESS=pi-signed` alongside `PI_CODING_AGENT=true` selects the signed identity; unmarked shared launcher ancestry remains `pi`.
 `bin/fm-harness.sh crew` resolves the effective crewmate harness from `config/crew-harness` (absent or `default` -> own).
 `bin/fm-harness.sh secondmate` resolves the secondmate-launch harness through the chain `config/secondmate-harness` -> `config/crew-harness` -> own, so an unset `config/secondmate-harness` matches the crew harness.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -284,7 +284,7 @@ Pi's `packages/coding-agent/docs/settings.md` UI and display section documents `
 `pi-signed` is the signed wrapper identity verified on version 0.82.0 and exposes the same CLI and TUI behavior as Pi.
 Firstmate records `pi-signed` without normalization and refuses rather than falling back to `pi` when that wrapper is unavailable.
 The observed signed process tree is an exact `pi-signed` wrapper parent with the Pi application as its child, while tmux reports the foreground command as the exact `pi-launcher` name for both selected executables.
-The installed plain `pi` command also execs that signed launcher, so `FM_PI_HARNESS=pi-signed` is the authoritative selection marker and shared unmarked ancestry remains `pi`.
+The installed plain `pi` command also execs that signed launcher, so process ancestry establishes the Pi-family verdict and `FM_PI_HARNESS=pi-signed` is the exact same-family refinement marker; shared unmarked ancestry remains `pi`.
 Firstmate sets `FM_PI_HARNESS` explicitly for both worker launch identities, and a signed primary uses the README launch command to establish the same boundary.
 Keep the brief as one positional argument.
 Multiple positional args become separate queued messages; `fm-spawn`'s template already does this correctly.
@@ -386,9 +386,9 @@ Do not confuse `harness=cursor` using a `cursor-grok-4.5-*` model with `harness=
 | Primary limits | `stop` does not fire in headless `cursor-agent -p`. `preCompact` is deliberately unregistered because it cannot inject context, so a Cursor primary does not re-emit its digest after a compaction; that surface is deferred to a follow-up. Project hooks need `--trust`. |
 
 **Detection ordering is load-bearing.**
-Cursor does NOT clear an inherited `CLAUDECODE`, so a cursor worker under a claude primary carries both markers and whichever is tested first wins.
-`bin/fm-harness.sh` tests the cursor markers BEFORE the `CLAUDECODE` check, and the launch additionally clears the foreign markers.
-Both are kept: launch sanitization only covers sessions fm-spawn started, while the ordering also covers a cursor session a human started by hand.
+Cursor does NOT clear an inherited `CLAUDECODE`, so a cursor worker under a claude primary carries both markers; in the marker fallback, whichever is tested first wins.
+`bin/fm-harness.sh` uses process ancestry before environment markers; when no harness ancestor is visible, its fallback tests the cursor markers BEFORE the `CLAUDECODE` check.
+The launch additionally clears the foreign markers, but the fallback ordering also covers a cursor session a human started by hand.
 
 **The `node` process-name caveat.**
 Cursor runs as a bundled node script, so tmux reports `#{pane_current_command}` as a bare `node` while `ps -o comm=` carries the cursor-agent install path.

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -62,26 +62,11 @@ harness_path_name() {
   return 1
 }
 
-harness_interpreter_script_name() {
-  local args=$1 token name
-  local -a words=()
-  read -r -a words <<< "$args"
-  for token in "${words[@]:1}"; do
-    case "$token" in
-      ''|-*) continue ;;
-    esac
-    name=$(harness_path_name "$token" 2>/dev/null || true)
-    [ -n "$name" ] && { printf '%s\n' "$name"; return 0; }
-    return 1
-  done
-  return 1
-}
-
 # Layer 1: walk the parent chain and match the command name. Prints the
 # innermost harness ancestor's verdict, or "unknown" when no harness ancestor
 # is visible within the walk depth (or before FM_HARNESS_ANCESTRY_BOUNDARY).
 detect_ancestry() {
-  local pid=$$ comm args argv0 name
+  local pid=$$ comm argv0 name
   for _ in 1 2 3 4 5 6 7 8; do
     if [ -n "${FM_HARNESS_ANCESTRY_BOUNDARY:-}" ] && [ "$pid" = "$FM_HARNESS_ANCESTRY_BOUNDARY" ]; then
       break
@@ -92,25 +77,15 @@ detect_ancestry() {
       echo cursor
       return
     fi
-    case "$(basename -- "$comm")" in
-      *claude*) echo claude; return ;;
-      *codex*) echo codex; return ;;
-      *opencode*) echo opencode; return ;;
-      *grok*) echo grok; return ;;
-      kimi) echo kimi; return ;;
-      # muse's installed launcher ~/.local/bin/muse execs ~/.local/bin/muse-bin-<version>
-      # (verified in the published launcher, muse 0.1.0-R708.1), so the live process
-      # name carries the version and CHANGES on every auto-update. Match the stable
-      # prefix rather than any exact name. Deliberately anchored, never *muse*, so
-      # unrelated commands (musescore, amuse) cannot be misread as this harness.
-      muse|muse-bin-*) echo muse; return ;;
-      pi-signed) echo pi; return ;;
-      pi) echo pi; return ;;
-      node*|python*)
-        args=$(ps -o args= -p "$pid" 2>/dev/null)
-        name=$(harness_interpreter_script_name "$args")
-        [ -n "$name" ] && { echo "$name"; return; }
-    esac
+    name=$(harness_path_name "$comm" 2>/dev/null || true)
+    [ -n "$name" ] || name=$(harness_path_name "$argv0" 2>/dev/null || true)
+    if [ -n "$name" ]; then
+      case "$name" in
+        pi|pi-signed) echo pi ;;
+        *) echo "$name" ;;
+      esac
+      return
+    fi
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
     if [ -z "$pid" ] || [ "$pid" -le 1 ]; then
       break

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -41,7 +41,7 @@ CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 . "$SCRIPT_DIR/fm-cursor-lib.sh"
 
 harness_path_name() {
-  local path=$1 name base
+  local path=$1 base
   [ -n "$path" ] || return 1
   base=$(basename -- "$path")
   case "$base" in
@@ -54,11 +54,6 @@ harness_path_name() {
       return 0
       ;;
   esac
-  for name in claude codex opencode grok kimi pi-signed pi; do
-    case "/$path/" in
-      */"$name"/*) printf '%s\n' "$name"; return 0 ;;
-    esac
-  done
   return 1
 }
 

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -40,11 +40,48 @@ CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 # shellcheck source=bin/fm-cursor-lib.sh
 . "$SCRIPT_DIR/fm-cursor-lib.sh"
 
+harness_path_name() {
+  local path=$1 name base
+  [ -n "$path" ] || return 1
+  base=$(basename -- "$path")
+  case "$base" in
+    claude|codex|opencode|grok|kimi|pi|pi-signed|muse)
+      printf '%s\n' "$base"
+      return 0
+      ;;
+    muse-bin-*)
+      printf 'muse\n'
+      return 0
+      ;;
+  esac
+  for name in claude codex opencode grok kimi pi-signed pi; do
+    case "/$path/" in
+      */"$name"/*) printf '%s\n' "$name"; return 0 ;;
+    esac
+  done
+  return 1
+}
+
+harness_interpreter_script_name() {
+  local args=$1 token name
+  local -a words=()
+  read -r -a words <<< "$args"
+  for token in "${words[@]:1}"; do
+    case "$token" in
+      ''|-*) continue ;;
+    esac
+    name=$(harness_path_name "$token" 2>/dev/null || true)
+    [ -n "$name" ] && { printf '%s\n' "$name"; return 0; }
+    return 1
+  done
+  return 1
+}
+
 # Layer 1: walk the parent chain and match the command name. Prints the
 # innermost harness ancestor's verdict, or "unknown" when no harness ancestor
 # is visible within the walk depth (or before FM_HARNESS_ANCESTRY_BOUNDARY).
 detect_ancestry() {
-  local pid=$$ comm args argv0
+  local pid=$$ comm args argv0 name
   for _ in 1 2 3 4 5 6 7 8; do
     if [ -n "${FM_HARNESS_ANCESTRY_BOUNDARY:-}" ] && [ "$pid" = "$FM_HARNESS_ANCESTRY_BOUNDARY" ]; then
       break
@@ -70,15 +107,9 @@ detect_ancestry() {
       pi-signed) echo pi; return ;;
       pi) echo pi; return ;;
       node*|python*)
-        # Bare interpreter: match the harness name in its script path.
         args=$(ps -o args= -p "$pid" 2>/dev/null)
-        case "$args" in
-          *claude*) echo claude; return ;;
-          *codex*) echo codex; return ;;
-          *opencode*) echo opencode; return ;;
-          *grok*) echo grok; return ;;
-          *" pi "*|*/pi) echo pi; return ;;
-        esac ;;
+        name=$(harness_interpreter_script_name "$args")
+        [ -n "$name" ] && { echo "$name"; return; }
     esac
     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
     if [ -z "$pid" ] || [ "$pid" -le 1 ]; then

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -18,8 +18,18 @@
 # harness only, no model/effort. Only the first non-empty, non-comment line is parsed.
 # Model/effort come ONLY from this file - config/crew-harness stays a bare adapter
 # name and is never parsed for a model.
-# Detection layers: verified environment markers first, then process ancestry.
-# Record each newly verified env marker here.
+# Detection layers: process ancestry first, then verified environment markers
+# as the fallback when no harness ancestor is visible. Ancestry wins because
+# markers are inheritable: a child session keeps the parent harness's markers
+# unless something clears them, while the innermost harness-named ancestor is
+# positional truth about which harness is actually running this process tree
+# (observed live 2026-08-20: a codex primary carrying inherited CURSOR_AGENT/
+# CURSOR_INVOKED_AS detected as cursor and was handed the wrong supervision
+# protocol). Record each newly verified env marker here.
+# FM_HARNESS_ANCESTRY_BOUNDARY=<pid> is a test seam: the ancestry walk stops
+# when it reaches that pid, so the test suite's verdicts cannot depend on
+# which real harness happens to be running the suite. If it ever leaks into a
+# real session, detection merely degrades to the marker fallback.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -30,51 +40,15 @@ CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 # shellcheck source=bin/fm-cursor-lib.sh
 . "$SCRIPT_DIR/fm-cursor-lib.sh"
 
-detect_own() {
-  # Layer 1: environment markers for verified harnesses.
-  # Keep marker detection before ancestry detection as an explicit precedence rule.
-  # Claude, Pi, Grok, and Cursor set verified markers of their own; codex,
-  # opencode, Kimi, and Muse are markerless, so a foreign marker retained in a terminal
-  # multiplexer's stored environment can silently misidentify one of them before
-  # ancestry is consulted. This is a precedence hazard, not evidence that
-  # CLAUDECODE inheritance into a kimi child was observed; it was not observed.
-  # Cursor is checked BEFORE claude, deliberately. cursor-agent does NOT clear
-  # an inherited CLAUDECODE, so a cursor worker launched from a claude primary
-  # carries BOTH markers and whichever is tested first wins. Cursor's own
-  # markers are unambiguous when present, so ordering them first is what makes
-  # the verdict correct; bin/fm-spawn.sh additionally clears the foreign markers
-  # at the launch boundary. Both are kept: the launch sanitization only covers
-  # sessions fm-spawn started, while this ordering also covers a cursor session
-  # a human started by hand. Verified live on cursor-agent 2026.08.11-e8db854:
-  # CURSOR_INVOKED_AS=cursor-agent is set on the agent process itself, and
-  # CURSOR_AGENT=1 is set for the child/tool processes this script runs as.
-  [ "${CURSOR_AGENT:-}" = "1" ] && { echo cursor; return; }
-  [ "${CURSOR_INVOKED_AS:-}" = "cursor-agent" ] && { echo cursor; return; }
-  [ "${CLAUDECODE:-}" = "1" ] && { echo claude; return; }
-  if [ "${PI_CODING_AGENT:-}" = "true" ]; then
-    if [ "${FM_PI_HARNESS:-}" = pi-signed ]; then echo pi-signed; else echo pi; fi
-    return
-  fi
-  # grok set GROK_AGENT=1 for its child/tool processes (verified, grok 0.2.73).
-  # It does NOT set CLAUDECODE despite being Claude-Code-compatible, so the marker
-  # is unambiguous WHEN PRESENT - but it is not guaranteed present. A grok 1.0.0
-  # hook process carries GROK_HOOK_EVENT, GROK_HOOK_NAME, GROK_SESSION_ID, and
-  # GROK_WORKSPACE_ROOT with no GROK_AGENT at all (verified from the live process
-  # environment of a wedged grok 1.0.0 Stop hook, 2026-08-07). Treat this marker as
-  # a fast path only; the ancestry walk below is what actually guarantees grok is
-  # identified, and any rule that must be RELIABLE under grok has to test the hook
-  # markers too (see .claude/settings.json Stop entries, docs/turnend-guard.md).
-  [ "${GROK_AGENT:-}" = "1" ] && { echo grok; return; }
-  # muse (Muse Code) publishes no harness-identity marker of its own. The only
-  # MUSE_* variable it is documented to hand a child is MUSE_CURRENT_SESSION_LOG,
-  # a per-session log PATH rather than an identity, and its export to tool
-  # subprocesses is unverified (verified: muse 0.1.0-R708.1), so muse is detected
-  # by ancestry alone below. Do NOT promote MUSE_CURRENT_SESSION_LOG to a marker
-  # without verifying it reaches children AND that it cannot survive in a
-  # multiplexer's stored environment, which is the precedence hazard above.
-  # Layer 2: walk the parent chain and match the command name.
+# Layer 1: walk the parent chain and match the command name. Prints the
+# innermost harness ancestor's verdict, or "unknown" when no harness ancestor
+# is visible within the walk depth (or before FM_HARNESS_ANCESTRY_BOUNDARY).
+detect_ancestry() {
   local pid=$$ comm args argv0
   for _ in 1 2 3 4 5 6 7 8; do
+    if [ -n "${FM_HARNESS_ANCESTRY_BOUNDARY:-}" ] && [ "$pid" = "$FM_HARNESS_ANCESTRY_BOUNDARY" ]; then
+      break
+    fi
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
     argv0=$(fm_cursor_argv0_for_pid "$pid" "$comm" 2>/dev/null || true)
     if fm_cursor_process_matches "$comm" '' "$argv0"; then
@@ -111,6 +85,61 @@ detect_own() {
       break
     fi
   done
+  echo unknown
+}
+
+detect_own() {
+  local anc
+  anc=$(detect_ancestry)
+  if [ "$anc" != unknown ]; then
+    # Same-family refinement only: ancestry cannot express pi-signed (the walk
+    # maps a pi-signed ancestor to pi), so the session's own Pi markers refine
+    # the verdict. A FOREIGN marker never overrides a concrete ancestry match.
+    if [ "$anc" = pi ] && [ "${PI_CODING_AGENT:-}" = "true" ] && [ "${FM_PI_HARNESS:-}" = pi-signed ]; then
+      echo pi-signed
+    else
+      echo "$anc"
+    fi
+    return
+  fi
+  # Layer 2 fallback: environment markers for verified harnesses, consulted
+  # only when ancestry shows no harness (a detached/reparented hook process,
+  # a walk deeper than the depth cap, an exotic launcher).
+  # Cursor is checked BEFORE claude, deliberately. cursor-agent does NOT clear
+  # an inherited CLAUDECODE, so a cursor worker launched from a claude primary
+  # carries BOTH markers and whichever is tested first wins. Cursor's own
+  # markers are unambiguous when present, so ordering them first is what makes
+  # the verdict correct; bin/fm-spawn.sh additionally clears the foreign markers
+  # at the launch boundary. Both are kept: the launch sanitization only covers
+  # sessions fm-spawn started, while this ordering also covers a cursor session
+  # a human started by hand. Verified live on cursor-agent 2026.08.11-e8db854:
+  # CURSOR_INVOKED_AS=cursor-agent is set on the agent process itself, and
+  # CURSOR_AGENT=1 is set for the child/tool processes this script runs as.
+  [ "${CURSOR_AGENT:-}" = "1" ] && { echo cursor; return; }
+  [ "${CURSOR_INVOKED_AS:-}" = "cursor-agent" ] && { echo cursor; return; }
+  [ "${CLAUDECODE:-}" = "1" ] && { echo claude; return; }
+  if [ "${PI_CODING_AGENT:-}" = "true" ]; then
+    if [ "${FM_PI_HARNESS:-}" = pi-signed ]; then echo pi-signed; else echo pi; fi
+    return
+  fi
+  # grok set GROK_AGENT=1 for its child/tool processes (verified, grok 0.2.73).
+  # It does NOT set CLAUDECODE despite being Claude-Code-compatible, so the marker
+  # is unambiguous WHEN PRESENT - but it is not guaranteed present. A grok 1.0.0
+  # hook process carries GROK_HOOK_EVENT, GROK_HOOK_NAME, GROK_SESSION_ID, and
+  # GROK_WORKSPACE_ROOT with no GROK_AGENT at all (verified from the live process
+  # environment of a wedged grok 1.0.0 Stop hook, 2026-08-07). Treat this marker as
+  # a fallback only; the ancestry walk above is what actually guarantees grok is
+  # identified, and any rule that must be RELIABLE under grok has to test the hook
+  # markers too (see .claude/settings.json Stop entries, docs/turnend-guard.md).
+  [ "${GROK_AGENT:-}" = "1" ] && { echo grok; return; }
+  # muse (Muse Code) publishes no harness-identity marker of its own. The only
+  # MUSE_* variable it is documented to hand a child is MUSE_CURRENT_SESSION_LOG,
+  # a per-session log PATH rather than an identity, and its export to tool
+  # subprocesses is unverified (verified: muse 0.1.0-R708.1), so muse is detected
+  # by ancestry alone above. Do NOT promote MUSE_CURRENT_SESSION_LOG to a marker
+  # without verifying it reaches children AND that it cannot survive in a
+  # multiplexer's stored environment, which is the inheritance hazard the
+  # ancestry-first ordering exists to close.
   echo unknown
 }
 

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -49,6 +49,14 @@ harness_path_name() {
       printf '%s\n' "$base"
       return 0
       ;;
+    codex-aarch64-a)
+      printf 'codex\n'
+      return 0
+      ;;
+    kimi-code)
+      printf 'kimi\n'
+      return 0
+      ;;
     muse-bin-*)
       printf 'muse\n'
       return 0

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -132,8 +132,8 @@ state: done ...
 Both launches executed a submitted tool instruction and touched the generated `turn_end` marker.
 The pi-signed launch retained `harness=pi-signed`, while the plain comparison retained `harness=pi`.
 The exact wrapper ancestry was `pi-signed` parent to Pi engine child, and the plain Pi Launcher path also traversed the signed wrapper on this installation.
-That shared plain-Pi path is retained as disconfirming evidence against using ancestry as runtime-selection authority.
-Firstmate therefore sets the exact `FM_PI_HARNESS` selection marker on both worker launch paths, while an unmarked Pi-family process remains `pi`.
+That shared plain-Pi path is retained as disconfirming evidence against using ancestry alone as runtime-selection authority.
+Firstmate therefore uses ancestry for the Pi-family verdict and the exact `FM_PI_HARNESS` marker to refine `pi-signed`, while an unmarked Pi-family process remains `pi`.
 Both recorded runtime identities now classify the exact `pi-launcher` foreground command as `alive`.
 
 Backend applicability was reviewed across every spawn adapter.
@@ -790,8 +790,10 @@ Read from the live agent process and from a tool subprocess it spawned:
 | `CURSOR_CONVERSATION_ID=<uuid>` | child/tool processes |
 | `AGENT_TRANSCRIPTS=<projects-root>/<slug>/agent-transcripts` | child/tool processes |
 
-Cursor does not clear an inherited `CLAUDECODE`, so ordering decides the verdict.
-With both markers set, `bin/fm-harness.sh` reports `cursor`; with `CLAUDECODE` alone it still reports `claude`.
+Process ancestry now outranks these markers in `bin/fm-harness.sh`; marker ordering applies only when no harness ancestor is visible.
+Cursor does not clear an inherited `CLAUDECODE`, so the fallback ordering keeps cursor ahead of claude when both markers are present.
+With both markers set in the fallback, `bin/fm-harness.sh` reports `cursor`; with `CLAUDECODE` alone it still reports `claude`.
+The portable precedence regression and its ancestry boundary seam are pinned by `tests/fm-harness-detect.test.sh`.
 
 ### Composer
 

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -352,7 +352,7 @@ FM_TEST_SUMMARY total=4 failed=0 skipped_gate=0 duration_ms=80078
 ```
 
 The Pi extension-model pull-guard correction (`bin/fm-guard.sh` no longer reports a false watcher-down on a Pi primary during the extension's own watcher hand-off) was verified on 2026-08-13 with the installed ShellCheck 0.11.0 and isolated behavior suites.
-The guard verdict itself reads only state files and process liveness, so the portable suites are the enforcing evidence; `bin/fm-harness.sh`'s Pi marker detection, which selects the model, is exercised in the same suite through `PI_CODING_AGENT`.
+The guard verdict itself reads only state files and process liveness, so the portable suites are the enforcing evidence.
 
 ```sh
 bin/fm-lint.sh

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -1816,8 +1816,20 @@ TS
       fail "Pi follow-up $label case did not process the monitoring notification"
     fi
 
-    pane=$(tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" -S - 2>/dev/null || true)
-    [ "$(printf '%s\n' "$pane" | grep -Fc "CAPTAIN_ANSWER_$label" || true)" -eq 1 ] \
+    i=0
+    while [ "$i" -lt 240 ]; do
+      pane=$(tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" -S - 2>/dev/null || true)
+      if printf '%s\n' "$pane" | grep -Fq "CAPTAIN_ANSWER_$label" \
+        && printf '%s\n' "$pane" | grep -Fq "MONITOR_HANDLED_${label}_ONE"; then
+        break
+      fi
+      sleep 0.05
+      i=$((i + 1))
+    done
+    answer_count=$(printf '%s\n' "$pane" | grep -Fc "CAPTAIN_ANSWER_$label" || true)
+    [ "$answer_count" -ge 1 ] \
+      || fail "Pi follow-up $label case never rendered the captain answer"
+    [ "$answer_count" -eq 1 ] \
       || fail "Pi follow-up $label case rendered a duplicate captain answer"
     assert_contains "$pane" "CAPTAIN_PROMPT_$label" "Pi follow-up $label case hid the genuine captain prompt"
     assert_contains "$pane" "MONITOR_HANDLED_${label}_ONE" "Pi follow-up $label case did not render the intended processing result"

--- a/tests/fm-cursor-harness.test.sh
+++ b/tests/fm-cursor-harness.test.sh
@@ -15,8 +15,10 @@
 #      requires Cursor's own name or install tree in the path or argv[0].
 #   2. An unrelated `node`/`agent` pane classifies `other`, which the liveness
 #      callers fold into `ambiguous` - NEVER `dead`.
-#   3. Cursor's env marker outranks an inherited CLAUDECODE, because cursor does
-#      not clear it and whichever marker is tested first wins.
+#   3. In the marker fallback (no harness ancestry visible), cursor's env
+#      marker outranks an inherited CLAUDECODE, because cursor does not clear
+#      it and whichever marker is tested first wins. Ancestry-vs-marker
+#      precedence itself is pinned by tests/fm-harness-detect.test.sh.
 #   4. The transcript fold brackets a turn: a trailing turn_ended is idle, a
 #      later role:user is busy, and an unresolvable binding is unknown.
 #   5. Cursor is a crewmate/scout adapter only and refuses a secondmate launch.
@@ -177,20 +179,24 @@ test_tmux_classifies_cursor_pane_without_inferring_dead() {
 
 test_cursor_marker_outranks_inherited_claudecode() {
   local out
+  # These are marker-fallback assertions: FM_HARNESS_ANCESTRY_BOUNDARY stops
+  # the ancestry walk at this test shell so the harness actually running the
+  # suite can never leak into the verdict (same isolation as
+  # tests/fm-harness-detect.test.sh).
   # This is the exact hazard: cursor does NOT clear an inherited CLAUDECODE, so
   # a cursor worker under a claude primary carries both markers.
-  out=$(CLAUDECODE=1 CURSOR_AGENT=1 "$HARNESS")
+  out=$(CLAUDECODE=1 CURSOR_AGENT=1 FM_HARNESS_ANCESTRY_BOUNDARY=$$ "$HARNESS")
   [ "$out" = cursor ] || fail "CLAUDECODE + CURSOR_AGENT must detect cursor, got '$out'"
-  out=$(CLAUDECODE=1 CURSOR_INVOKED_AS=cursor-agent "$HARNESS")
+  out=$(CLAUDECODE=1 CURSOR_INVOKED_AS=cursor-agent FM_HARNESS_ANCESTRY_BOUNDARY=$$ "$HARNESS")
   [ "$out" = cursor ] || fail "CLAUDECODE + CURSOR_INVOKED_AS must detect cursor, got '$out'"
   # Both cursor markers stand alone, and neither steals a plain claude session.
-  out=$(env -u CLAUDECODE CURSOR_AGENT=1 "$HARNESS")
+  out=$(env -u CLAUDECODE CURSOR_AGENT=1 FM_HARNESS_ANCESTRY_BOUNDARY=$$ "$HARNESS")
   [ "$out" = cursor ] || fail "CURSOR_AGENT alone must detect cursor, got '$out'"
-  out=$(env -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDECODE=1 "$HARNESS")
+  out=$(env -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDECODE=1 FM_HARNESS_ANCESTRY_BOUNDARY=$$ "$HARNESS")
   [ "$out" = claude ] || fail "CLAUDECODE alone must still detect claude, got '$out'"
   # A CURSOR_* variable that is not the invocation identity proves nothing.
   out=$(env -u CURSOR_AGENT CLAUDECODE=1 CURSOR_API_ENDPOINT=https://example \
-        CURSOR_INVOKED_AS=something-else "$HARNESS")
+        CURSOR_INVOKED_AS=something-else FM_HARNESS_ANCESTRY_BOUNDARY=$$ "$HARNESS")
   [ "$out" = claude ] \
     || fail "an unrelated CURSOR_* setting must not claim the cursor identity, got '$out'"
   pass "fm-harness.sh: cursor's marker outranks an inherited CLAUDECODE"
@@ -212,7 +218,10 @@ process.stdout.write(result.stdout);
 process.stderr.write(result.stderr);
 process.exit(result.status === null ? 1 : result.status);
 JS
-  out=$(node "$helper" "$HARNESS")
+  # The boundary stops the walk at this test shell AFTER it has examined and
+  # rejected the node lookalike, so a real harness hosting the suite cannot
+  # supply the cursor verdict this case exists to rule out.
+  out=$(FM_HARNESS_ANCESTRY_BOUNDARY=$$ node "$helper" "$HARNESS")
   [ "$out" != cursor ] \
     || fail "a node script merely containing cursor-agent in its filename must not identify as cursor"
   pass "fm-harness.sh: cursor-like node script names do not establish ancestry identity"

--- a/tests/fm-guard-stale-banner.test.sh
+++ b/tests/fm-guard-stale-banner.test.sh
@@ -667,6 +667,7 @@ test_pi_harness_routes_itself_to_the_extension_model() {
     record_pi_extension_session "$dir" "$pid" || fail "could not record the Pi extension session"
     touch "$home/state/.last-watcher-beat"
     out=$(env -u CLAUDECODE -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u GROK_AGENT -u FM_SUPERVISION_MODEL \
+      FM_HARNESS_ANCESTRY_BOUNDARY=$$ \
       "${pi_env[@]}" \
       FM_ROOT_OVERRIDE="$(case_root "$dir")" \
       FM_HOME="$home" \

--- a/tests/fm-harness-detect.test.sh
+++ b/tests/fm-harness-detect.test.sh
@@ -33,7 +33,7 @@ probe_under() {
   local anc=$1
   shift
   env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u CLAUDECODE -u PI_CODING_AGENT \
-    -u FM_PI_HARNESS -u GROK_AGENT "$@" \
+    -u FM_PI_HARNESS -u GROK_AGENT FM_HARNESS_ANCESTRY_BOUNDARY=$$ "$@" \
     "$anc" -c "r=\$(\"$HARNESS\"); printf '%s' \"\$r\""
 }
 
@@ -80,20 +80,49 @@ test_cursor_ancestry_detects_cursor_even_with_inherited_claudecode() {
   pass "cursor ancestry detects cursor even when only a foreign CLAUDECODE marker is present"
 }
 
-test_interpreter_argument_substring_does_not_establish_ancestry() {
-  local out
-  if ! command -v python3 >/dev/null 2>&1; then
-    echo "skip: python3 not found for interpreter ancestry boundary test"
-    return 0
+test_non_harness_basename_falls_back_to_markers() {
+  local name out
+  for name in codex-helper my-claude-wrapper; do
+    out=$(probe_under "$(make_named_ancestor "$name")" CLAUDECODE=1)
+    [ "$out" = claude ] \
+      || fail "non-harness basename '$name' must fall back to CLAUDECODE, got '$out'"
+  done
+  pass "non-harness command basenames do not establish ancestry identity"
+}
+
+test_interpreter_arguments_do_not_establish_ancestry() {
+  local out module_dir node_dir
+  if command -v python3 >/dev/null 2>&1; then
+    module_dir="$TMP_ROOT/python-module"
+    mkdir -p "$module_dir"
+    printf '%s\n' \
+      'import os, subprocess' \
+      'print(subprocess.check_output([os.environ["HARNESS"]], env=os.environ, text=True), end="")' \
+      > "$module_dir/codex.py"
+    out=$(cd "$module_dir" && env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u PI_CODING_AGENT \
+      -u FM_PI_HARNESS -u GROK_AGENT CLAUDECODE=1 \
+      FM_HARNESS_ANCESTRY_BOUNDARY=$$ HARNESS="$HARNESS" python3 -m codex)
+    [ "$out" = claude ] \
+      || fail "python -m codex must fall back to CLAUDECODE, got '$out'"
+  else
+    echo "skip: python3 not found for interpreter module ancestry test"
   fi
-  out=$(env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u PI_CODING_AGENT \
-    -u FM_PI_HARNESS -u GROK_AGENT CLAUDECODE=1 \
-    FM_HARNESS_ANCESTRY_BOUNDARY=$$ HARNESS="$HARNESS" \
-    python3 -c 'import os, subprocess; print(subprocess.check_output([os.environ["HARNESS"]], env=os.environ, text=True), end="")' \
-    /work/codex-tools/run.py)
-  [ "$out" = claude ] \
-    || fail "a python argument containing codex must not establish codex ancestry, got '$out'"
-  pass "interpreter arguments require an executable boundary before ancestry wins"
+  if command -v node >/dev/null 2>&1; then
+    node_dir="$TMP_ROOT/node-script"
+    mkdir -p "$node_dir"
+    printf '%s\n' \
+      'const cp = require("child_process");' \
+      'process.stdout.write(cp.execFileSync(process.env.HARNESS, {env: process.env, encoding: "utf8"}));' \
+      > "$node_dir/codex"
+    out=$(env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u PI_CODING_AGENT \
+      -u FM_PI_HARNESS -u GROK_AGENT CLAUDECODE=1 \
+      FM_HARNESS_ANCESTRY_BOUNDARY=$$ HARNESS="$HARNESS" node "$node_dir/codex")
+    [ "$out" = claude ] \
+      || fail "node script arguments must fall back to CLAUDECODE, got '$out'"
+  else
+    echo "skip: node not found for interpreter script ancestry test"
+  fi
+  pass "interpreter arguments do not establish ancestry identity"
 }
 
 # --- 2. Markers remain the fallback when no harness ancestry is visible ------
@@ -141,6 +170,7 @@ test_pi_signed_refinement_survives_ancestry_detection() {
 test_codex_ancestry_outranks_inherited_cursor_markers
 test_codex_ancestry_outranks_inherited_claudecode
 test_cursor_ancestry_detects_cursor_even_with_inherited_claudecode
-test_interpreter_argument_substring_does_not_establish_ancestry
+test_non_harness_basename_falls_back_to_markers
+test_interpreter_arguments_do_not_establish_ancestry
 test_markers_remain_fallback_without_harness_ancestry
 test_pi_signed_refinement_survives_ancestry_detection

--- a/tests/fm-harness-detect.test.sh
+++ b/tests/fm-harness-detect.test.sh
@@ -90,6 +90,16 @@ test_non_harness_basename_falls_back_to_markers() {
   pass "non-harness command basenames do not establish ancestry identity"
 }
 
+test_harness_path_component_does_not_establish_ancestry() {
+  local runner="$TMP_ROOT/codex/tools/runner" out
+  mkdir -p "$(dirname "$runner")"
+  cp "$(command -v bash)" "$runner"
+  out=$(probe_under "$runner" CLAUDECODE=1)
+  [ "$out" = claude ] \
+    || fail "a codex directory component must fall back to CLAUDECODE, got '$out'"
+  pass "harness directory components do not establish ancestry identity"
+}
+
 test_interpreter_arguments_do_not_establish_ancestry() {
   local out module_dir node_dir
   if command -v python3 >/dev/null 2>&1; then
@@ -171,6 +181,7 @@ test_codex_ancestry_outranks_inherited_cursor_markers
 test_codex_ancestry_outranks_inherited_claudecode
 test_cursor_ancestry_detects_cursor_even_with_inherited_claudecode
 test_non_harness_basename_falls_back_to_markers
+test_harness_path_component_does_not_establish_ancestry
 test_interpreter_arguments_do_not_establish_ancestry
 test_markers_remain_fallback_without_harness_ancestry
 test_pi_signed_refinement_survives_ancestry_detection

--- a/tests/fm-harness-detect.test.sh
+++ b/tests/fm-harness-detect.test.sh
@@ -66,6 +66,21 @@ test_codex_ancestry_outranks_inherited_claudecode() {
   pass "codex ancestry outranks an inherited CLAUDECODE"
 }
 
+test_known_vendor_basenames_outrank_inherited_cursor_markers() {
+  local name expected out
+  for name in codex-aarch64-a kimi-code; do
+    case "$name" in
+      codex-aarch64-a) expected=codex ;;
+      kimi-code) expected=kimi ;;
+    esac
+    out=$(probe_under "$(make_named_ancestor "$name")" \
+      CURSOR_AGENT=1 CURSOR_INVOKED_AS=cursor-agent)
+    [ "$out" = "$expected" ] \
+      || fail "verified basename '$name' must detect '$expected' under inherited Cursor markers, got '$out'"
+  done
+  pass "known versioned vendor basenames outrank inherited Cursor markers"
+}
+
 test_cursor_ancestry_detects_cursor_even_with_inherited_claudecode() {
   # A real cursor install-tree shape: the versioned executable identifies by
   # both its name and its install path (tests/fm-cursor-harness.test.sh pins
@@ -179,6 +194,7 @@ test_pi_signed_refinement_survives_ancestry_detection() {
 
 test_codex_ancestry_outranks_inherited_cursor_markers
 test_codex_ancestry_outranks_inherited_claudecode
+test_known_vendor_basenames_outrank_inherited_cursor_markers
 test_cursor_ancestry_detects_cursor_even_with_inherited_claudecode
 test_non_harness_basename_falls_back_to_markers
 test_harness_path_component_does_not_establish_ancestry

--- a/tests/fm-harness-detect.test.sh
+++ b/tests/fm-harness-detect.test.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# tests/fm-harness-detect.test.sh - detect_own precedence: concrete process
+# ancestry outranks inheritable environment markers, and markers remain the
+# fallback when no harness ancestry is visible.
+#
+# The break these cases catch (observed live, 2026-08-20): a codex primary
+# launched from a cursor-agent context inherits CURSOR_AGENT and
+# CURSOR_INVOKED_AS, fm-harness.sh answered "cursor", and session start
+# emitted the cursor supervision protocol to a session that has no cursor
+# stop hook - so the watcher never re-armed and the fleet sat unsupervised
+# with a task in flight. Markers are inheritable and can lie about which
+# harness is actually running; the innermost harness-named ancestor cannot.
+#
+# Each case drives the real fm-harness.sh under a REAL renamed process (the
+# same technique as tests/fm-muse-harness.test.sh), so the verdicts come from
+# live ps ancestry, never from string inspection of the script.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+HARNESS="$ROOT/bin/fm-harness.sh"
+TMP_ROOT=$(fm_test_tmproot fm-harness-detect)
+
+# probe_under <ancestor-executable> [VAR=VAL ...]: run fm-harness.sh as a child
+# of a real process running <ancestor-executable>. Every verified harness
+# marker is cleared first so each case controls exactly the markers it names;
+# later VAR=VAL assignments win over the clearing (env applies -u first).
+# The harness runs inside a command substitution, never as the -c script's
+# only command: bash exec-optimizes a lone command, which would REPLACE the
+# named ancestor and make the ancestry under test disappear.
+probe_under() {
+  local anc=$1
+  shift
+  env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u CLAUDECODE -u PI_CODING_AGENT \
+    -u FM_PI_HARNESS -u GROK_AGENT "$@" \
+    "$anc" -c "r=\$(\"$HARNESS\"); printf '%s' \"\$r\""
+}
+
+# make_named_ancestor <name>: a real executable with a harness name, so the
+# probe's parent chain contains a genuinely running process by that name.
+make_named_ancestor() {
+  local name=$1 dir="$TMP_ROOT/anc"
+  mkdir -p "$dir"
+  [ -x "$dir/$name" ] || cp "$(command -v bash)" "$dir/$name"
+  printf '%s' "$dir/$name"
+}
+
+# --- 1. Ancestry outranks inherited foreign markers --------------------------
+
+test_codex_ancestry_outranks_inherited_cursor_markers() {
+  local codex out
+  codex=$(make_named_ancestor codex)
+  out=$(probe_under "$codex" CURSOR_AGENT=1 CURSOR_INVOKED_AS=cursor-agent)
+  [ "$out" = codex ] \
+    || fail "a codex ancestor with inherited CURSOR markers must detect codex, got '$out'"
+  pass "codex ancestry outranks inherited CURSOR_AGENT/CURSOR_INVOKED_AS"
+}
+
+test_codex_ancestry_outranks_inherited_claudecode() {
+  local codex out
+  codex=$(make_named_ancestor codex)
+  out=$(probe_under "$codex" CLAUDECODE=1)
+  [ "$out" = codex ] \
+    || fail "a codex ancestor with inherited CLAUDECODE must detect codex, got '$out'"
+  pass "codex ancestry outranks an inherited CLAUDECODE"
+}
+
+test_cursor_ancestry_detects_cursor_even_with_inherited_claudecode() {
+  # A real cursor install-tree shape: the versioned executable identifies by
+  # both its name and its install path (tests/fm-cursor-harness.test.sh pins
+  # the identity logic itself; this pins that detect_own reaches it through
+  # ancestry when the marker layer would have said claude).
+  local ver="$TMP_ROOT/share/cursor-agent/versions/2026.08.11-e8db854" out
+  mkdir -p "$ver"
+  cp "$(command -v bash)" "$ver/cursor-agent"
+  out=$(probe_under "$ver/cursor-agent" CLAUDECODE=1)
+  [ "$out" = cursor ] \
+    || fail "real cursor ancestry with inherited CLAUDECODE must detect cursor, got '$out'"
+  pass "cursor ancestry detects cursor even when only a foreign CLAUDECODE marker is present"
+}
+
+# --- 2. Markers remain the fallback when no harness ancestry is visible ------
+
+test_markers_remain_fallback_without_harness_ancestry() {
+  # FM_HARNESS_ANCESTRY_BOUNDARY stops the walk at this test shell, so the
+  # harness actually running this suite can never leak into the verdict and
+  # these cases behave identically on CI and inside any agent session.
+  local out
+  out=$(env -u CURSOR_INVOKED_AS -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+    CURSOR_AGENT=1 FM_HARNESS_ANCESTRY_BOUNDARY=$$ "$HARNESS")
+  [ "$out" = cursor ] \
+    || fail "with no harness ancestry the CURSOR_AGENT marker must still win, got '$out'"
+  # Cursor-before-CLAUDECODE ordering inside the fallback: both markers present
+  # is the verified cursor-worker-under-claude-primary shape.
+  out=$(env -u CURSOR_INVOKED_AS -u PI_CODING_AGENT -u GROK_AGENT \
+    CURSOR_AGENT=1 CLAUDECODE=1 FM_HARNESS_ANCESTRY_BOUNDARY=$$ "$HARNESS")
+  [ "$out" = cursor ] \
+    || fail "cursor marker must outrank inherited CLAUDECODE in the fallback, got '$out'"
+  # Control proving the boundary itself works: no ancestry, no markers, no verdict.
+  out=$(env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u CLAUDECODE -u PI_CODING_AGENT \
+    -u FM_PI_HARNESS -u GROK_AGENT FM_HARNESS_ANCESTRY_BOUNDARY=$$ "$HARNESS")
+  [ "$out" = unknown ] \
+    || fail "no ancestry and no markers must detect unknown (boundary leak?), got '$out'"
+  pass "markers stay authoritative as the fallback when ancestry shows no harness"
+}
+
+# --- 3. Same-family marker refinement survives ancestry-first ----------------
+
+test_pi_signed_refinement_survives_ancestry_detection() {
+  # Ancestry alone can only say "pi" (the walk maps a pi-signed ancestor to
+  # pi); the FM_PI_HARNESS marker refines it. An ancestry-first detector that
+  # drops the refinement would regress every pi-signed session to plain pi.
+  local pi out
+  pi=$(make_named_ancestor pi)
+  out=$(probe_under "$pi" PI_CODING_AGENT=true FM_PI_HARNESS=pi-signed)
+  [ "$out" = pi-signed ] \
+    || fail "pi ancestry with pi-signed markers must detect pi-signed, got '$out'"
+  out=$(probe_under "$pi" PI_CODING_AGENT=true)
+  [ "$out" = pi ] \
+    || fail "pi ancestry without the pi-signed refinement must detect pi, got '$out'"
+  pass "pi-signed marker refinement survives ancestry-first detection"
+}
+
+test_codex_ancestry_outranks_inherited_cursor_markers
+test_codex_ancestry_outranks_inherited_claudecode
+test_cursor_ancestry_detects_cursor_even_with_inherited_claudecode
+test_markers_remain_fallback_without_harness_ancestry
+test_pi_signed_refinement_survives_ancestry_detection

--- a/tests/fm-harness-detect.test.sh
+++ b/tests/fm-harness-detect.test.sh
@@ -80,6 +80,22 @@ test_cursor_ancestry_detects_cursor_even_with_inherited_claudecode() {
   pass "cursor ancestry detects cursor even when only a foreign CLAUDECODE marker is present"
 }
 
+test_interpreter_argument_substring_does_not_establish_ancestry() {
+  local out
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "skip: python3 not found for interpreter ancestry boundary test"
+    return 0
+  fi
+  out=$(env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u PI_CODING_AGENT \
+    -u FM_PI_HARNESS -u GROK_AGENT CLAUDECODE=1 \
+    FM_HARNESS_ANCESTRY_BOUNDARY=$$ HARNESS="$HARNESS" \
+    python3 -c 'import os, subprocess; print(subprocess.check_output([os.environ["HARNESS"]], env=os.environ, text=True), end="")' \
+    /work/codex-tools/run.py)
+  [ "$out" = claude ] \
+    || fail "a python argument containing codex must not establish codex ancestry, got '$out'"
+  pass "interpreter arguments require an executable boundary before ancestry wins"
+}
+
 # --- 2. Markers remain the fallback when no harness ancestry is visible ------
 
 test_markers_remain_fallback_without_harness_ancestry() {
@@ -125,5 +141,6 @@ test_pi_signed_refinement_survives_ancestry_detection() {
 test_codex_ancestry_outranks_inherited_cursor_markers
 test_codex_ancestry_outranks_inherited_claudecode
 test_cursor_ancestry_detects_cursor_even_with_inherited_claudecode
+test_interpreter_argument_substring_does_not_establish_ancestry
 test_markers_remain_fallback_without_harness_ancestry
 test_pi_signed_refinement_survives_ancestry_detection

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -533,9 +533,12 @@ SH
   out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
     PATH="$fakebin:$BASE_PATH" FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh")
   [ "$out" = kimi ] || fail "kimi ancestry detection returned '$out'"
+  # Markerless kimi is exactly the harness an inheritable foreign marker used
+  # to misidentify; ancestry now outranks the marker
+  # (tests/fm-harness-detect.test.sh pins the general precedence).
   out=$(CLAUDECODE=1 PATH="$fakebin:$BASE_PATH" FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh")
-  [ "$out" = claude ] || fail "verified env-marker precedence changed, got '$out'"
-  pass "fm-harness: markerless kimi is detected by ancestry after env-marker precedence"
+  [ "$out" = kimi ] || fail "kimi ancestry must outrank an inherited CLAUDECODE, got '$out'"
+  pass "fm-harness: markerless kimi is detected by ancestry even under an inherited foreign marker"
 }
 
 test_kimi_session_lock_identity() {

--- a/tests/fm-muse-harness.test.sh
+++ b/tests/fm-muse-harness.test.sh
@@ -154,9 +154,9 @@ run_muse_spawn() {  # <home> <proj> <wt> <fakebin> <id> [extra args...]
 # string, so each case launches an actual renamed executable and asks
 # fm-harness.sh from a child of it.
 #
-# The foreign env markers are cleared because muse is markerless and the marker
-# layer deliberately outranks ancestry: with one retained, these cases would
-# assert the marker's verdict instead of the ancestry match they exist to pin.
+# The foreign env markers are cleared for hygiene: ancestry now outranks
+# markers (tests/fm-harness-detect.test.sh pins that precedence), so these
+# cases assert the ancestry match on its own, without a marker as a crutch.
 # The command substitution around the probe is load-bearing: a bare `-c <cmd>`
 # lets the shell exec the probe in place, which REPLACES the muse-bin-* process
 # name the walk is supposed to find. Real muse keeps its TUI process alive and

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -51,13 +51,15 @@ set -u
 . "$ROOT/bin/fm-config-inherit-lib.sh"
 
 # The harness-detection cases below fake `ps` so process ancestry is fully
-# controlled, but bin/fm-harness.sh checks verified ENV markers before ancestry.
-# A suite run from inside one of those harnesses inherits its marker, and the
-# highest-precedence one wins over everything these cases set up: with an
-# ambient CLAUDECODE=1, the pi-signed ancestry case resolves "claude". Drop the
-# ambient markers so what this suite asserts does not depend on which harness it
-# was launched from; every case states the marker it means to test.
+# controlled, and the marker-pinned cases (CLAUDECODE=1 pins detect_own) rely
+# on the marker fallback. A suite run from inside a real harness inherits both
+# its markers and its real process ancestry, so neutralize each: drop the
+# ambient markers (every case states the marker it means to test), and stop
+# the real ancestry walk at this test shell so the hosting harness can never
+# outrank a pinned marker (ancestry outranks markers;
+# tests/fm-harness-detect.test.sh pins that precedence).
 unset CLAUDECODE PI_CODING_AGENT FM_PI_HARNESS GROK_AGENT CURSOR_AGENT CURSOR_INVOKED_AS
+export FM_HARNESS_ANCESTRY_BOUNDARY=$$
 
 BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
 fm_git_identity fmtest fmtest@example.com

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -19,6 +19,12 @@ set -u
 TMP_ROOT=$(fm_test_tmproot fm-turnend-guard)
 fm_git_identity fmtest fmtest@example.invalid
 
+# Hook cases pin the harness with explicit markers (run_hook sets CLAUDECODE=1).
+# Stop the detector's real ancestry walk at this test shell so a harness
+# actually hosting the suite cannot outrank those pinned markers (ancestry
+# outranks markers; tests/fm-harness-detect.test.sh pins that precedence).
+export FM_HARNESS_ANCESTRY_BOUNDARY=$$
+
 REQUIRED_REASON='watcher supervision needs Stop-owned automatic recovery; inspect the hook registration and startup status before ending the turn'
 
 # --- PREDICATE: bin/fm-supervision-lib.sh -----------------------------------
@@ -192,7 +198,10 @@ make_secondmate_linked_home_dir() {
 run_hook() {
   local dir=$1 stop_active=$2 home
   home=$(cd "$dir" && pwd)
-  printf '{"stop_hook_active":%s}' "$stop_active" | CLAUDECODE=1 FM_HOME="$home" bash "$dir/bin/fm-turnend-guard.sh" 2>&1
+  # Inherited cursor markers would outrank the pinned CLAUDECODE in the marker
+  # fallback (cursor-before-claude ordering), so clear them at the invocation.
+  printf '{"stop_hook_active":%s}' "$stop_active" \
+    | env -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDECODE=1 FM_HOME="$home" bash "$dir/bin/fm-turnend-guard.sh" 2>&1
 }
 
 nonexistent_pid() {
@@ -369,7 +378,7 @@ test_hook_blocks_from_fm_home_state() {
   home="$TMP_ROOT/hook-fm-home-op"
   mkdir -p "$home/state"
   : > "$home/state/task1.meta"
-  out=$(printf '{"stop_hook_active":false}' | CLAUDECODE=1 FM_HOME="$home" bash "$dir/bin/fm-turnend-guard.sh" 2>&1); status=$?
+  out=$(printf '{"stop_hook_active":false}' | env -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDECODE=1 FM_HOME="$home" bash "$dir/bin/fm-turnend-guard.sh" 2>&1); status=$?
   expect_code 2 "$status" "hook must inspect the active FM_HOME state dir"
   assert_contains "$out" "$REQUIRED_REASON" "block reason must contain the exact required instruction"
   pass "fm-turnend-guard: blocks from active FM_HOME state, not only repo-root state"
@@ -417,7 +426,7 @@ test_hook_uses_state_override() {
   state="$TMP_ROOT/hook-state-override-active"
   mkdir -p "$home/state" "$state"
   : > "$state/task1.meta"
-  out=$(printf '{"stop_hook_active":false}' | CLAUDECODE=1 FM_HOME="$home" FM_STATE_OVERRIDE="$state" bash "$dir/bin/fm-turnend-guard.sh" 2>&1); status=$?
+  out=$(printf '{"stop_hook_active":false}' | env -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDECODE=1 FM_HOME="$home" FM_STATE_OVERRIDE="$state" bash "$dir/bin/fm-turnend-guard.sh" 2>&1); status=$?
   expect_code 2 "$status" "hook must let FM_STATE_OVERRIDE win over FM_HOME/state"
   assert_contains "$out" "$REQUIRED_REASON" "block reason must contain the exact required instruction"
   pass "fm-turnend-guard: uses FM_STATE_OVERRIDE ahead of FM_HOME/state"
@@ -1093,7 +1102,7 @@ EOF
 run_hook_claude() {
   local dir=$1 stop_active=$2 home
   home=$(cd "$dir" && pwd)
-  printf '{"stop_hook_active":%s,"session_id":"sess-claude-mode"}' "$stop_active" | CLAUDECODE=1 FM_HOME="$home" bash "$dir/bin/fm-turnend-guard.sh" --claude 2>&1
+  printf '{"stop_hook_active":%s,"session_id":"sess-claude-mode"}' "$stop_active" | env -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDECODE=1 FM_HOME="$home" bash "$dir/bin/fm-turnend-guard.sh" --claude 2>&1
 }
 
 seed_claude_failure() {
@@ -1265,7 +1274,8 @@ SH
   chmod +x "$fakebin/cat"
   (
     printf '{"stop_hook_active":true,"session_id":"sess-claude-mode"}' \
-      | PATH="$fakebin:$PATH" \
+      | env -u CURSOR_AGENT -u CURSOR_INVOKED_AS \
+        PATH="$fakebin:$PATH" \
         FM_TERMINAL_ROLE_PATH="$dir/state/.claude-autoarm.lock/role" \
         FM_TERMINAL_READY="$ready" \
         FM_TERMINAL_RELEASE="$release" \


### PR DESCRIPTION
## Summary

- Fix harness misdetection: a codex primary that inherited `CURSOR_AGENT`/`CURSOR_INVOKED_AS` from its launch context detected as `cursor` and received the wrong supervision protocol, so the watcher was never re-armed (observed live 2026-08-20).
- `bin/fm-harness.sh detect_own` now resolves process ancestry first; verified environment markers remain the fallback when no harness ancestor is visible. The cursor-before-claude ordering and the pi-signed refinement are preserved. Ancestry matches only exact verified executable identities (including `codex-aarch64-a` and `kimi-code`); substring, interpreter-argument, and path-component shapes never classify.
- `FM_HARNESS_ANCESTRY_BOUNDARY=<pid>` is a test seam that stops the ancestry walk, so suite verdicts cannot depend on the harness hosting the suite. A leak into a real session only degrades detection to the marker fallback.
- New behavioral regression test `tests/fm-harness-detect.test.sh` pins the precedence, the exact-identity boundaries, and the fallback. Existing kimi/muse expectations updated; cursor, secondmate, and turnend-guard suites pinned with the seam and marker hygiene at controlled invocations.
- Separate test fix: the calm-pi follow-up assertion no longer races the pane render; it waits for both the captain answer and the processing result before asserting the exact count.

## Validation

- no-mistakes pipeline green at this head: review (findings fixed in-pipeline), tests, docs, lint.
- Local: changed selection 48 scripts 0 failed; calm-pi suite alone; four targeted harness suites; six detector-consumer suites; fm-lint clean.
