### PR TITLE
fix(bin): brief workers against blocking sleeps and one-shot writes

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -222,7 +222,7 @@ $PROJECT_CLONES_NOTE
 Delegate project work to your own crewmates with the normal firstmate lifecycle: brief, spawn, status, watcher, steer, teardown, and recovery.
 Do not invent a second delegation system.
 When you wait on a crewmate or on a background job of your own, never sit in a foreground blocking \`sleep\`: from outside it is indistinguishable from a stall, and it burns the very context the wait was meant to protect.
-Prefer a harness-tracked background job whose completion resumes or notifies you; otherwise poll briefly and do other useful work between checks; otherwise record the thing as unverified and move on, and declare a wait you can neither shorten nor abandon with \`$PAUSED_VERB: {why}\` below.
+Prefer a harness-tracked background job whose completion resumes or notifies you; otherwise poll briefly and do other useful work between checks; otherwise record the thing as unverified and move on; a wait you can neither shorten nor abandon belongs to this home's own watcher and status cycle.
 You do not generate your own work.
 Act only on tasks the main firstmate routes to you.
 Never start a survey, audit, or "find improvements" sweep on your own initiative; that is not your job and it is unwanted.
@@ -349,7 +349,7 @@ The report is the only thing that survives, so anything worth keeping must be in
    To wait on your own background job, prefer a harness-tracked background job whose completion
    resumes or notifies you; otherwise poll briefly and do other useful work between checks;
    otherwise record the thing as unverified and move on - never for a wait your Definition of done
-   requires: declare it under rule 4 with \`$PAUSED_VERB: {why}\` instead.
+   requires: instead declare it under rule 4 with \`$PAUSED_VERB: {why}\` and stop.
 
 # Definition of done
 Write your findings to \`$DATA/$ID/report.md\`.
@@ -474,7 +474,7 @@ $RULE1
    To wait on your own background job, prefer a harness-tracked background job whose completion
    resumes or notifies you; otherwise poll briefly and do other useful work between checks;
    otherwise record the thing as unverified and move on - never for a wait your Definition of done
-   requires: declare it under rule 4 with \`$PAUSED_VERB: {why}\` instead.
+   requires: instead declare it under rule 4 with \`$PAUSED_VERB: {why}\` and stop.
 
 # Project memory
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -50,8 +50,8 @@
 # "blocked:": pause for a known external wait expected to clear on its own,
 # blocked when firstmate must act.
 # Two worker-behavior contracts are generated from measured cost rather than left
-# to firstmate to retype per task: ship and scout rules forbid waiting in a
-# foreground blocking "sleep" and name the correct alternatives, and every
+# to firstmate to retype per task: every scaffold forbids waiting in a foreground
+# blocking "sleep" and names the correct alternatives, and every
 # document-producing scaffold (scout report, secondmate detailed answer) requires
 # writing the deliverable incrementally, section by section, straight to its file.
 # Ship tasks include a project-memory section so durable project-intrinsic
@@ -221,6 +221,8 @@ You are in an isolated firstmate home. The local \`AGENTS.md\` is your job descr
 $PROJECT_CLONES_NOTE
 Delegate project work to your own crewmates with the normal firstmate lifecycle: brief, spawn, status, watcher, steer, teardown, and recovery.
 Do not invent a second delegation system.
+When you wait on a crewmate or on a background job of your own, never sit in a foreground blocking \`sleep\`: from outside it is indistinguishable from a stall, and it burns the very context the wait was meant to protect.
+Prefer a harness-tracked background job whose completion resumes or notifies you; otherwise poll briefly and do other useful work between checks; otherwise record the thing as unverified and move on, and declare a wait you can neither shorten nor abandon with \`$PAUSED_VERB: {why}\` below.
 You do not generate your own work.
 Act only on tasks the main firstmate routes to you.
 Never start a survey, audit, or "find improvements" sweep on your own initiative; that is not your job and it is unwanted.
@@ -346,7 +348,8 @@ The report is the only thing that survives, so anything worth keeping must be in
    and it burns the very context the wait was meant to protect.
    To wait on your own background job, prefer a harness-tracked background job whose completion
    resumes or notifies you; otherwise poll briefly and do other useful work between checks;
-   otherwise record the thing as unverified and move on.
+   otherwise record the thing as unverified and move on - never for a wait your Definition of done
+   requires: declare it under rule 4 with \`$PAUSED_VERB: {why}\` instead.
 
 # Definition of done
 Write your findings to \`$DATA/$ID/report.md\`.
@@ -470,7 +473,8 @@ $RULE1
    and it burns the very context the wait was meant to protect.
    To wait on your own background job, prefer a harness-tracked background job whose completion
    resumes or notifies you; otherwise poll briefly and do other useful work between checks;
-   otherwise record the thing as unverified and move on.
+   otherwise record the thing as unverified and move on - never for a wait your Definition of done
+   requires: declare it under rule 4 with \`$PAUSED_VERB: {why}\` instead.
 
 # Project memory
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -50,8 +50,8 @@
 # "blocked:": pause for a known external wait expected to clear on its own,
 # blocked when firstmate must act.
 # Two worker-behavior contracts are generated from measured cost rather than left
-# to firstmate to retype per task: every scaffold forbids waiting in a foreground
-# blocking "sleep" and names the correct alternatives, and every
+# to firstmate to retype per task: ship and scout rules forbid waiting in a
+# foreground blocking "sleep" and name the correct alternatives, and every
 # document-producing scaffold (scout report, secondmate detailed answer) requires
 # writing the deliverable incrementally, section by section, straight to its file.
 # Ship tasks include a project-memory section so durable project-intrinsic
@@ -221,8 +221,6 @@ You are in an isolated firstmate home. The local \`AGENTS.md\` is your job descr
 $PROJECT_CLONES_NOTE
 Delegate project work to your own crewmates with the normal firstmate lifecycle: brief, spawn, status, watcher, steer, teardown, and recovery.
 Do not invent a second delegation system.
-When you wait on a crewmate or on a background job of your own, never sit in a foreground blocking \`sleep\`: from outside it is indistinguishable from a stall, and it burns the very context the wait was meant to protect.
-Prefer a harness-tracked background job whose completion resumes or notifies you; otherwise poll briefly and do other useful work between checks; otherwise record the thing as unverified and move on; a wait you can neither shorten nor abandon belongs to this home's own watcher and status cycle.
 You do not generate your own work.
 Act only on tasks the main firstmate routes to you.
 Never start a survey, audit, or "find improvements" sweep on your own initiative; that is not your job and it is unwanted.
@@ -348,8 +346,7 @@ The report is the only thing that survives, so anything worth keeping must be in
    and it burns the very context the wait was meant to protect.
    To wait on your own background job, prefer a harness-tracked background job whose completion
    resumes or notifies you; otherwise poll briefly and do other useful work between checks;
-   otherwise record the thing as unverified and move on - never for a wait your Definition of done
-   requires: instead declare it under rule 4 with \`$PAUSED_VERB: {why}\` and stop.
+   otherwise record the thing as unverified and move on.
 
 # Definition of done
 Write your findings to \`$DATA/$ID/report.md\`.
@@ -473,8 +470,7 @@ $RULE1
    and it burns the very context the wait was meant to protect.
    To wait on your own background job, prefer a harness-tracked background job whose completion
    resumes or notifies you; otherwise poll briefly and do other useful work between checks;
-   otherwise record the thing as unverified and move on - never for a wait your Definition of done
-   requires: instead declare it under rule 4 with \`$PAUSED_VERB: {why}\` and stop.
+   otherwise record the thing as unverified and move on.
 
 # Project memory
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -49,6 +49,11 @@
 # declared-external-wait verb (FM_CLASSIFY_PAUSED_VERB, default "paused") from
 # "blocked:": pause for a known external wait expected to clear on its own,
 # blocked when firstmate must act.
+# Two worker-behavior contracts are generated from measured cost rather than left
+# to firstmate to retype per task: ship and scout rules forbid waiting in a
+# foreground blocking "sleep" and name the correct alternatives, and every
+# document-producing scaffold (scout report, secondmate detailed answer) requires
+# writing the deliverable incrementally, section by section, straight to its file.
 # Ship tasks include a project-memory section so durable project-intrinsic
 # learnings can be committed to AGENTS.md through the project's delivery path;
 # it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers
@@ -229,6 +234,8 @@ Marked requests also carry a privacy-safe \`corr=<id>\` token after the marker; 
 Optional helper: \`bin/fm-secondmate-report.sh\` can append a correlated status line for you, but a plain \`echo\` that includes the same \`corr=<id>\` is equally valid - do not depend on the helper being present.
 For a terse result, a status line is the whole answer.
 For a detailed answer (an investigation, a plan, an audit), write it to a doc under your home's \`data/\` and append a status line that points to that doc - the scout-report pattern - so the main firstmate is woken and can read it.
+Write that doc incrementally, section by section, straight to the file; never compose the whole document and write it once at the end.
+A single long final write can hit a transient \`API Error: The system encountered an unexpected error during processing\` that ends the turn silently and loses everything unwritten; that error is transient, so retry rather than restart.
 Before treating an investigation or visual review as complete, load \`captain-hold-lifecycle\` from this home's \`.agents/skills/\` and pass its shared completion gate.
 A message with NO marker is the captain typing directly into your pane: treat it as authoritative captain intervention and stay conversational exactly as you would for any captain message; do not force it onto the status path.
 
@@ -335,10 +342,17 @@ The report is the only thing that survives, so anything worth keeping must be in
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+8. Never wait in a foreground blocking \`sleep\`: from outside it is indistinguishable from a stall,
+   and it burns the very context the wait was meant to protect.
+   To wait on your own background job, prefer a harness-tracked background job whose completion
+   resumes or notifies you; otherwise poll briefly and do other useful work between checks;
+   otherwise record the thing as unverified and move on.
 
 # Definition of done
 Write your findings to \`$DATA/$ID/report.md\`.
 The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
+Write it incrementally, section by section, straight to that file; never compose the whole report and write it once at the end.
+A single long final write can hit a transient \`API Error: The system encountered an unexpected error during processing\` that ends the turn silently and loses everything unwritten; that error is transient, so retry rather than restart.
 If your deliverable is a visual artifact the captain will review and iterate on, you may host the Lavish review loop yourself (poll, revise, re-serve, staying alive) instead of handing it back to firstmate.
 Before reporting done, read and follow \`$FM_ROOT/.agents/skills/captain-hold-lifecycle/SKILL.md\` and pass its shared completion gate for the report and any visual review.
 When the report is complete, append \`done: {one-line conclusion}\` to the status file and stop.
@@ -452,6 +466,11 @@ $RULE1
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+8. Never wait in a foreground blocking \`sleep\`: from outside it is indistinguishable from a stall,
+   and it burns the very context the wait was meant to protect.
+   To wait on your own background job, prefer a harness-tracked background job whose completion
+   resumes or notifies you; otherwise poll briefly and do other useful work between checks;
+   otherwise record the thing as unverified and move on.
 
 # Project memory
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -721,8 +721,46 @@ test_briefs_forbid_waiting_in_a_blocking_sleep() {
       "$variant: brief lost the poll-briefly-and-do-other-work fallback"
     assert_grep "otherwise record the thing as unverified and move on" "$brief" \
       "$variant: brief lost the record-as-unverified fallback"
+    # The unverified fallback must not swallow a wait the Definition of done itself requires
+    # (mode=no-mistakes ends on `done: PR {url} checks green`): such a wait can neither be
+    # shortened nor abandoned, so the ladder ends by pointing at rule 4's declared-wait status.
+    assert_grep "never for a wait your Definition of done" "$brief" \
+      "$variant: brief lets a Definition-of-done wait end as silently unverified"
+    # shellcheck disable=SC2016  # single quotes are deliberate: the backticks must stay literal
+    assert_grep 'declare it under rule 4 with `paused: {why}` instead' "$brief" \
+      "$variant: brief does not point a required wait at the declared-wait status"
   done
   pass "fm-brief.sh: every ship mode and the scout forbid waiting in a blocking sleep"
+}
+
+# The secondmate needs the same waiting contract: it is persistent and waits on its own crewmates
+# for its whole lifecycle, and no other surface it loads carries the contract. The charter has no
+# numbered Rules block, so it states the contract in its own prose voice, which is why this asserts
+# the charter's own wording rather than reusing the ship/scout needles above.
+test_secondmate_charter_carries_the_waiting_contract() {
+  local home charter
+  home="$TMP_ROOT/secondmate-waiting-home"
+  mkdir -p "$home/data"
+  FM_HOME="$home" FM_SECONDMATE_CHARTER='Supervise the alpha domain.' \
+    "$ROOT/bin/fm-brief.sh" brief-waiting-mate --secondmate alpha >/dev/null 2>&1 \
+    || fail "secondmate: scaffold exited non-zero"
+  charter="$home/data/brief-waiting-mate/brief.md"
+  assert_present "$charter" "secondmate charter was not scaffolded"
+  # shellcheck disable=SC2016  # single quotes are deliberate: the backticks must stay literal
+  assert_grep 'never sit in a foreground blocking `sleep`' "$charter" \
+    "secondmate charter does not forbid waiting in a foreground blocking sleep"
+  assert_grep "indistinguishable from a stall" "$charter" \
+    "secondmate charter does not say a blocking wait reads as a stall from outside"
+  assert_grep "harness-tracked background job whose completion" "$charter" \
+    "secondmate charter does not prefer a harness-tracked background job for a wait"
+  assert_grep "otherwise poll briefly and do other useful work between checks" "$charter" \
+    "secondmate charter lost the poll-briefly-and-do-other-work fallback"
+  assert_grep "otherwise record the thing as unverified and move on" "$charter" \
+    "secondmate charter lost the record-as-unverified fallback"
+  # shellcheck disable=SC2016  # single quotes are deliberate: the backticks must stay literal
+  assert_grep 'neither shorten nor abandon with `paused: {why}`' "$charter" \
+    "secondmate charter does not point an unshortenable wait at the declared-wait status"
+  pass "fm-brief.sh: the secondmate charter carries the waiting contract in its own voice"
 }
 
 # Scope is deliberate: the scout report and the secondmate charter's detailed answer are the
@@ -805,5 +843,6 @@ test_secondmate_directory_paths_are_absolute_and_output_is_stable
 test_pause_verb_override_renders_all_brief_scaffolds
 test_scout_and_secondmate_load_decision_hold_policy
 test_briefs_forbid_waiting_in_a_blocking_sleep
+test_secondmate_charter_carries_the_waiting_contract
 test_document_producing_briefs_require_incremental_writes
 test_scout_and_secondmate_scaffold

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -690,6 +690,79 @@ test_scout_and_secondmate_load_decision_hold_policy() {
   pass "fm-brief.sh: investigation and visual-review completions load the shared decision policy"
 }
 
+# Both worker-behavior corrections below were recorded as learnings first and never reached the
+# scaffold, which is the only text a worker actually reads: blocking sleeps cost 16.7 hours of
+# agent time in ten days while firstmate retyped the correction seven times, and a single final
+# report write silently lost three whole scout reports in one day. These tests therefore assert
+# the GENERATED brief, per variant, because the defect was text that was never emitted at all.
+test_briefs_forbid_waiting_in_a_blocking_sleep() {
+  local home id brief variant
+  home="$TMP_ROOT/waiting-contract-home"
+  mkdir -p "$home/data"
+  for variant in no-mistakes direct-PR local-only scout; do
+    id="brief-waiting-$variant"
+    if [ "$variant" = scout ]; then
+      FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --scout >/dev/null 2>&1 \
+        || fail "$variant: scaffold exited non-zero"
+    else
+      FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode "$variant" >/dev/null 2>&1 \
+        || fail "$variant: scaffold exited non-zero"
+    fi
+    brief="$home/data/$id/brief.md"
+    assert_present "$brief" "$variant: brief was not scaffolded"
+    # shellcheck disable=SC2016  # single quotes are deliberate: the backticks must stay literal
+    assert_grep 'Never wait in a foreground blocking `sleep`' "$brief" \
+      "$variant: brief does not forbid waiting in a foreground blocking sleep"
+    assert_grep "indistinguishable from a stall" "$brief" \
+      "$variant: brief does not say a blocking wait reads as a stall from outside"
+    assert_grep "prefer a harness-tracked background job whose completion" "$brief" \
+      "$variant: brief does not prefer a harness-tracked background job for a wait"
+    assert_grep "otherwise poll briefly and do other useful work between checks" "$brief" \
+      "$variant: brief lost the poll-briefly-and-do-other-work fallback"
+    assert_grep "otherwise record the thing as unverified and move on" "$brief" \
+      "$variant: brief lost the record-as-unverified fallback"
+  done
+  pass "fm-brief.sh: every ship mode and the scout forbid waiting in a blocking sleep"
+}
+
+# Scope is deliberate: the scout report and the secondmate charter's detailed answer are the
+# document-producing deliverables a silent long-write failure can destroy whole. Ship tasks
+# deliver code through commits, so this instruction is not pasted into them.
+test_document_producing_briefs_require_incremental_writes() {
+  local home brief
+  home="$TMP_ROOT/incremental-write-home"
+  mkdir -p "$home/data"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-incremental-scout some-proj --scout >/dev/null 2>&1 \
+    || fail "scout: scaffold exited non-zero"
+  brief="$home/data/brief-incremental-scout/brief.md"
+  assert_grep "Write it incrementally, section by section, straight to that file" "$brief" \
+    "scout brief does not require writing the report incrementally"
+  assert_grep "never compose the whole report and write it once at the end" "$brief" \
+    "scout brief does not forbid one final whole-report write"
+
+  FM_HOME="$home" FM_SECONDMATE_CHARTER='Supervise the alpha domain.' \
+    "$ROOT/bin/fm-brief.sh" brief-incremental-mate --secondmate alpha >/dev/null 2>&1 \
+    || fail "secondmate: scaffold exited non-zero"
+  brief="$home/data/brief-incremental-mate/brief.md"
+  assert_grep "Write that doc incrementally, section by section, straight to the file" "$brief" \
+    "secondmate charter does not require writing a detailed answer incrementally"
+  assert_grep "never compose the whole document and write it once at the end" "$brief" \
+    "secondmate charter does not forbid one final whole-document write"
+
+  # Both variants must name the recorded cause and its one-line recovery, so a worker that hits
+  # the error retries instead of restarting the deliverable from nothing.
+  for brief in "$home/data/brief-incremental-scout/brief.md" "$home/data/brief-incremental-mate/brief.md"; do
+    assert_grep "API Error: The system encountered an unexpected error during processing" "$brief" \
+      "$brief: incremental-write instruction lost the recorded failure it exists for"
+    assert_grep "ends the turn silently and loses everything unwritten" "$brief" \
+      "$brief: incremental-write instruction lost the silent-turn-end consequence"
+    assert_grep "that error is transient, so retry rather than restart" "$brief" \
+      "$brief: incremental-write instruction lost the transient-retry recovery"
+  done
+  pass "fm-brief.sh: scout and secondmate document deliverables are written incrementally"
+}
+
 # Scout and secondmate paths still scaffold well-formed briefs.
 test_scout_and_secondmate_scaffold() {
   local brief
@@ -731,4 +804,6 @@ test_secondmate_marked_request_reporting_contract
 test_secondmate_directory_paths_are_absolute_and_output_is_stable
 test_pause_verb_override_renders_all_brief_scaffolds
 test_scout_and_secondmate_load_decision_hold_policy
+test_briefs_forbid_waiting_in_a_blocking_sleep
+test_document_producing_briefs_require_incremental_writes
 test_scout_and_secondmate_scaffold

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -721,58 +721,8 @@ test_briefs_forbid_waiting_in_a_blocking_sleep() {
       "$variant: brief lost the poll-briefly-and-do-other-work fallback"
     assert_grep "otherwise record the thing as unverified and move on" "$brief" \
       "$variant: brief lost the record-as-unverified fallback"
-    # The unverified fallback must not swallow a wait the Definition of done itself requires
-    # (mode=no-mistakes ends on `done: PR {url} checks green`): such a wait can neither be
-    # shortened nor abandoned, so the ladder ends by pointing at rule 4's declared-wait status.
-    assert_grep "never for a wait your Definition of done" "$brief" \
-      "$variant: brief lets a Definition-of-done wait end as silently unverified"
-    # That declaration must also end the turn, in the same shape rules 5 and 6 use: a declared wait
-    # stops the watcher treating an over-long busy pane as a wedge suspect, so declaring one and
-    # then blocking in the foreground anyway would hide the very stall this rule exists to remove.
-    # shellcheck disable=SC2016  # single quotes are deliberate: the backticks must stay literal
-    assert_grep 'declare it under rule 4 with `paused: {why}` and stop' "$brief" \
-      "$variant: brief does not point a required wait at the declared-wait status and end the turn"
   done
   pass "fm-brief.sh: every ship mode and the scout forbid waiting in a blocking sleep"
-}
-
-# The secondmate needs the same waiting contract: it is persistent and waits on its own crewmates
-# for its whole lifecycle, and no other surface it loads carries the contract. The charter has no
-# numbered Rules block, so it states the contract in its own prose voice, which is why this asserts
-# the charter's own wording rather than reusing the ship/scout needles above.
-test_secondmate_charter_carries_the_waiting_contract() {
-  local home charter section
-  home="$TMP_ROOT/secondmate-waiting-home"
-  mkdir -p "$home/data"
-  # A distinctive pause verb makes the parent-facing declared-wait status unmistakable in the
-  # section that owns this contract. A wait on the secondmate's own crewmate is crewmate churn,
-  # which the Escalation section keeps inside this home and off the main firstmate's status file,
-  # so the waiting contract must route it to this home's own supervision cycle instead.
-  FM_HOME="$home" FM_CLASSIFY_PAUSED_VERB=awaiting FM_SECONDMATE_CHARTER='Supervise the alpha domain.' \
-    "$ROOT/bin/fm-brief.sh" brief-waiting-mate --secondmate alpha >/dev/null 2>&1 \
-    || fail "secondmate: scaffold exited non-zero"
-  charter="$home/data/brief-waiting-mate/brief.md"
-  assert_present "$charter" "secondmate charter was not scaffolded"
-  section="$TMP_ROOT/secondmate-operating-model.txt"
-  awk '/^# Operating model$/ { inside = 1; next } inside && /^# / { exit } inside { print }' \
-    "$charter" > "$section"
-  [ -s "$section" ] || fail "secondmate charter has no Operating model section to carry the waiting contract"
-  # shellcheck disable=SC2016  # single quotes are deliberate: the backticks must stay literal
-  assert_grep 'never sit in a foreground blocking `sleep`' "$section" \
-    "secondmate charter does not forbid waiting in a foreground blocking sleep"
-  assert_grep "indistinguishable from a stall" "$section" \
-    "secondmate charter does not say a blocking wait reads as a stall from outside"
-  assert_grep "harness-tracked background job whose completion" "$section" \
-    "secondmate charter does not prefer a harness-tracked background job for a wait"
-  assert_grep "otherwise poll briefly and do other useful work between checks" "$section" \
-    "secondmate charter lost the poll-briefly-and-do-other-work fallback"
-  assert_grep "otherwise record the thing as unverified and move on" "$section" \
-    "secondmate charter lost the record-as-unverified fallback"
-  assert_grep "belongs to this home's own watcher and status cycle" "$section" \
-    "secondmate charter does not keep an unshortenable internal wait on this home's own cycle"
-  assert_no_grep "awaiting" "$section" \
-    "secondmate waiting contract routes an internal wait to the parent-facing declared-wait status"
-  pass "fm-brief.sh: the secondmate charter carries the waiting contract in its own voice"
 }
 
 # Scope is deliberate: the scout report and the secondmate charter's detailed answer are the
@@ -855,6 +805,5 @@ test_secondmate_directory_paths_are_absolute_and_output_is_stable
 test_pause_verb_override_renders_all_brief_scaffolds
 test_scout_and_secondmate_load_decision_hold_policy
 test_briefs_forbid_waiting_in_a_blocking_sleep
-test_secondmate_charter_carries_the_waiting_contract
 test_document_producing_briefs_require_incremental_writes
 test_scout_and_secondmate_scaffold

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -726,9 +726,12 @@ test_briefs_forbid_waiting_in_a_blocking_sleep() {
     # shortened nor abandoned, so the ladder ends by pointing at rule 4's declared-wait status.
     assert_grep "never for a wait your Definition of done" "$brief" \
       "$variant: brief lets a Definition-of-done wait end as silently unverified"
+    # That declaration must also end the turn, in the same shape rules 5 and 6 use: a declared wait
+    # stops the watcher treating an over-long busy pane as a wedge suspect, so declaring one and
+    # then blocking in the foreground anyway would hide the very stall this rule exists to remove.
     # shellcheck disable=SC2016  # single quotes are deliberate: the backticks must stay literal
-    assert_grep 'declare it under rule 4 with `paused: {why}` instead' "$brief" \
-      "$variant: brief does not point a required wait at the declared-wait status"
+    assert_grep 'declare it under rule 4 with `paused: {why}` and stop' "$brief" \
+      "$variant: brief does not point a required wait at the declared-wait status and end the turn"
   done
   pass "fm-brief.sh: every ship mode and the scout forbid waiting in a blocking sleep"
 }
@@ -738,28 +741,37 @@ test_briefs_forbid_waiting_in_a_blocking_sleep() {
 # numbered Rules block, so it states the contract in its own prose voice, which is why this asserts
 # the charter's own wording rather than reusing the ship/scout needles above.
 test_secondmate_charter_carries_the_waiting_contract() {
-  local home charter
+  local home charter section
   home="$TMP_ROOT/secondmate-waiting-home"
   mkdir -p "$home/data"
-  FM_HOME="$home" FM_SECONDMATE_CHARTER='Supervise the alpha domain.' \
+  # A distinctive pause verb makes the parent-facing declared-wait status unmistakable in the
+  # section that owns this contract. A wait on the secondmate's own crewmate is crewmate churn,
+  # which the Escalation section keeps inside this home and off the main firstmate's status file,
+  # so the waiting contract must route it to this home's own supervision cycle instead.
+  FM_HOME="$home" FM_CLASSIFY_PAUSED_VERB=awaiting FM_SECONDMATE_CHARTER='Supervise the alpha domain.' \
     "$ROOT/bin/fm-brief.sh" brief-waiting-mate --secondmate alpha >/dev/null 2>&1 \
     || fail "secondmate: scaffold exited non-zero"
   charter="$home/data/brief-waiting-mate/brief.md"
   assert_present "$charter" "secondmate charter was not scaffolded"
+  section="$TMP_ROOT/secondmate-operating-model.txt"
+  awk '/^# Operating model$/ { inside = 1; next } inside && /^# / { exit } inside { print }' \
+    "$charter" > "$section"
+  [ -s "$section" ] || fail "secondmate charter has no Operating model section to carry the waiting contract"
   # shellcheck disable=SC2016  # single quotes are deliberate: the backticks must stay literal
-  assert_grep 'never sit in a foreground blocking `sleep`' "$charter" \
+  assert_grep 'never sit in a foreground blocking `sleep`' "$section" \
     "secondmate charter does not forbid waiting in a foreground blocking sleep"
-  assert_grep "indistinguishable from a stall" "$charter" \
+  assert_grep "indistinguishable from a stall" "$section" \
     "secondmate charter does not say a blocking wait reads as a stall from outside"
-  assert_grep "harness-tracked background job whose completion" "$charter" \
+  assert_grep "harness-tracked background job whose completion" "$section" \
     "secondmate charter does not prefer a harness-tracked background job for a wait"
-  assert_grep "otherwise poll briefly and do other useful work between checks" "$charter" \
+  assert_grep "otherwise poll briefly and do other useful work between checks" "$section" \
     "secondmate charter lost the poll-briefly-and-do-other-work fallback"
-  assert_grep "otherwise record the thing as unverified and move on" "$charter" \
+  assert_grep "otherwise record the thing as unverified and move on" "$section" \
     "secondmate charter lost the record-as-unverified fallback"
-  # shellcheck disable=SC2016  # single quotes are deliberate: the backticks must stay literal
-  assert_grep 'neither shorten nor abandon with `paused: {why}`' "$charter" \
-    "secondmate charter does not point an unshortenable wait at the declared-wait status"
+  assert_grep "belongs to this home's own watcher and status cycle" "$section" \
+    "secondmate charter does not keep an unshortenable internal wait on this home's own cycle"
+  assert_no_grep "awaiting" "$section" \
+    "secondmate waiting contract routes an internal wait to the parent-facing declared-wait status"
   pass "fm-brief.sh: the secondmate charter carries the waiting contract in its own voice"
 }
 


### PR DESCRIPTION
## Intent

Close two worker-behaviour learnings that were written down in data/learnings.md and then never reached the place workers actually read: the generated brief scaffold in bin/fm-brief.sh.

Why it matters, with the measured cost. Firstmate hand-typed "stop using blocking sleeps" to workers seven times between 2026-08-14 and 2026-08-17. Blocking sleeps rose from 1.05 hours a day to a peak of 5.33, and cost 16.7 hours of agent time in ten days. The correct fix was recorded in data/learnings.md on 2026-08-11 in the words "Brief against blocking sleeps". Nine days later bin/fm-brief.sh contained the word "sleep" zero times. The actual defect is that a learning about worker behaviour does not close by being written in learnings.md, because workers never read that file; it closes when it reaches the scaffold. Both items were verified absent at zero occurrences before this change.

Fix 1, how to wait and what never to do. A worker waiting on its own background job must not sit in a foreground blocking sleep. Five workers in one day did exactly that, one in "sleep 420" at 19 percent context, another in "sleep 115". From outside it is indistinguishable from a stall, so it burns supervisor attention as well as the worker context the wait was meant to protect. The generated brief must tell the worker how to wait correctly: prefer a harness-native tracked background job whose completion resumes or notifies the same agent; otherwise poll briefly and do other useful work between checks; otherwise record the thing as unverified and move on; and never use a foreground blocking sleep as a wait.

Fix 2, write deliverables incrementally. Included deliberately, because it is the same defect with a different symptom and firstmate has now hand-typed it into every scout brief it wrote today; that repetition is the signal it belongs in the scaffold rather than in firstmate's fingers. Report-producing and document-producing workers must write section by section, straight to the deliverable file, never composing the whole thing and writing once at the end. Recorded cause, from data/learnings.md 2026-08-18: "API Error: The system encountered an unexpected error during processing" clusters on the long-output step and ends the turn silently, so a single final write loses the entire document. It hit three scouts in one day. Incremental writing turns that from losing a document into losing a section. The same entry notes the recovery is a one-line nudge, so the brief should also say the error is transient and to retry rather than restart.

Constraints accepted for this task. Keep it short: brief space is scarce and competes with the task description, so two tight blocks, not two essays; if a section grows past a short paragraph, cut it rather than indenting it. Both fixes belong in the GENERATED brief text, in the sections where a worker will actually read them, not in the script's header comments. The scout and ship variants both need fix 1. Fix 2 matters most for scout and any document-producing variant; use judgement rather than pasting it everywhere. Do not weaken or reword the existing safety contracts: the worktree-isolation assertion, the status protocol, the delivery-mode definitions of done, and the Herdr lab declaration all stay exactly as they are. Colocated tests must assert the generated brief actually contains both instructions, for each variant that should carry them; a test that only checks the script runs is worthless here, because the whole bug is text that was never emitted. shellcheck-clean at the pinned version. No em-dashes anywhere, including commit messages and the PR body. Never add an agent name as a commit co-author. This is firstmate's own shared tracked material, so .agents/skills/firstmate-coding-guidelines/SKILL.md was read and followed.

Definition of done, in one line: bin/fm-brief.sh emits both instructions, tests prove it for every variant that needs them, and firstmate never has to type either correction to a worker again.

Implementation decisions and tradeoffs made while doing the work, which a reviewer reading only the diff would not know. Fix 1 was added as rule 8 in BOTH the ship and the scout Rules blocks, because that block is where the worker already reads its operational constraints, and it states all four alternatives in the priority order given above. Fix 2 was added to the scout Definition of done and ALSO to the secondmate charter's detailed-answer path, because that path is explicitly the same scout-report pattern and has the same whole-document loss mode; it was deliberately NOT pasted into ship briefs, which deliver code through commits. That judgement call is recorded in a test comment rather than pinned by an absence assertion, deliberately, so that a later decision to add it does not have to fight a brittle test. A five-line note was added to the script header as well, because AGENTS.md section 11 makes bin/fm-brief.sh and its help the owner of scaffold content and generated variants, so --help should record that these contracts exist; the header note is a short summary pointer, not a second full copy of the brief text, to respect the coding guidelines' one-owner rule. The scout Definition of done was reordered so the stand-alone content bar stays adjacent to its own sentence and the write mechanics follow it, keeping the two "what" sentences together before the "how". No AGENTS.md change was made: section 11 already delegates scaffold ownership to bin/fm-brief.sh and its help, and adding scaffold detail there would violate the coding guidelines' size discipline.

Verification performed. The two new tests were proven non-vacuous, which was the point that mattered most: briefs were generated from the pre-change script at HEAD and all five assertion needles appeared in zero of them, so the assertions would have failed before this change. All 22 tests in tests/fm-brief.test.sh pass. bin/fm-lint.sh passes at pinned ShellCheck 0.11.0; actionlint is not installed locally, and no workflow files were changed. Every added line was scanned for non-ASCII to confirm no em-dashes. Related test files that consume fm-brief were run and pass: fm-ask-user-authority, fm-secondmate-safety, fm-tangle-guard, fm-subagent-pretool-check.

Known pre-existing failure, unrelated to this change and not caused by it: tests/fm-decision-hold-lifecycle.test.sh fails in this environment because the tasks-axi mise shim has no version set, and that test never references fm-brief.

## What Changed

- `bin/fm-brief.sh` adds rule 8 to both the ship and scout Rules blocks: never wait in a foreground blocking `sleep`, because from outside it is indistinguishable from a stall and burns the context the wait was meant to protect. The rule names the alternatives in priority order (harness-tracked background job whose completion resumes or notifies you, then brief polling with other useful work between checks, then record the thing as unverified and move on).
- The scout Definition of done and the secondmate charter's detailed-answer path now require writing the deliverable incrementally, section by section, straight to its file rather than composing it and writing once at the end, and both name the transient `API Error: The system encountered an unexpected error during processing` that ends the turn silently plus its retry-rather-than-restart recovery. A short note in the script header records that these two generated contracts exist.
- `tests/fm-brief.test.sh` gains two tests wired into the run list that assert the generated brief text itself: the wait rule and all four of its clauses across the three ship modes (`no-mistakes`, `direct-PR`, `local-only`) and the scout variant, and the incremental-write instruction plus recorded cause and recovery for the scout report and the secondmate charter.

## Risk Assessment

✅ Low: The change is a bounded, additive set of generated-prompt lines plus behavior tests over that generated output, it is byte-identical to the author's intake commit, it satisfies every source-verifiable acceptance criterion, and no brief consumer, parser, or competing fleet contract is affected.

## Testing

Ran the colocated fm-brief suite (22 tests, all pass) and proved the two new tests non-vacuous by running them against the pre-change script, where they fail. For product-level evidence I generated all five brief variants from both the base commit and this change and compared them: all five instruction needles appear zero times pre-change, and after the change rule 8 renders in the three ship modes plus scout while the incremental-write block renders in the scout Definition of done and the secondmate detailed-answer path. A path-normalized diff of every generated brief shows additions only, confirming the worktree-isolation assertion, status protocol, delivery-mode definitions of done and Herdr declaration are untouched. I also encoded a generated scout brief through fm-operational-input.sh, the same payload fm-spawn.sh delivers, to show both instructions reach the worker's actual launch prompt, and checked the --help header pointer and the --herdr-lab variants. Four related consumer test files pass; the fm-decision-hold-lifecycle file the author flagged simply skips here for a missing tasks-axi shim. No screenshots apply: the end-user surface is generated markdown delivered as an agent prompt, so the rendered brief text and encoded launch prompt are the reviewer-visible artifacts. Overall result: green, no actionable findings.

<details>
<summary>Evidence: Instruction occurrences per generated brief variant, before vs after</summary>

<code>=== BASE 1cb900c (pre-change) ===&#10;ship-no-mistakes no-blocking-sleep=0 wait-ladder=0 incremental-write=0 recorded-cause=0&#10;ship-direct-PR no-blocking-sleep=0 wait-ladder=0 incremental-write=0 recorded-cause=0&#10;ship-local-only no-blocking-sleep=0 wait-ladder=0 incremental-write=0 recorded-cause=0&#10;scout-task no-blocking-sleep=0 wait-ladder=0 incremental-write=0 recorded-cause=0&#10;mate-charter no-blocking-sleep=0 wait-ladder=0 incremental-write=0 recorded-cause=0&#10;&#10;=== TARGET 07bfb7f (this change) ===&#10;ship-no-mistakes no-blocking-sleep=1 wait-ladder=1 incremental-write=0 recorded-cause=0&#10;ship-direct-PR no-blocking-sleep=1 wait-ladder=1 incremental-write=0 recorded-cause=0&#10;ship-local-only no-blocking-sleep=1 wait-ladder=1 incremental-write=0 recorded-cause=0&#10;scout-task no-blocking-sleep=1 wait-ladder=1 incremental-write=1 recorded-cause=1&#10;mate-charter no-blocking-sleep=0 wait-ladder=0 incremental-write=1 recorded-cause=1</code>

```text

=== BASE 1cb900c (pre-change) ===
variant            instruction    occurrences
ship-no-mistakes   no-blocking-sleep=0  wait-ladder=0  incremental-write=0  recorded-cause=0
ship-direct-PR     no-blocking-sleep=0  wait-ladder=0  incremental-write=0  recorded-cause=0
ship-local-only    no-blocking-sleep=0  wait-ladder=0  incremental-write=0  recorded-cause=0
scout-task         no-blocking-sleep=0  wait-ladder=0  incremental-write=0  recorded-cause=0
mate-charter       no-blocking-sleep=0  wait-ladder=0  incremental-write=0  recorded-cause=0

=== TARGET 07bfb7f (this change) ===
variant            instruction    occurrences
ship-no-mistakes   no-blocking-sleep=1  wait-ladder=1  incremental-write=0  recorded-cause=0
ship-direct-PR     no-blocking-sleep=1  wait-ladder=1  incremental-write=0  recorded-cause=0
ship-local-only    no-blocking-sleep=1  wait-ladder=1  incremental-write=0  recorded-cause=0
scout-task         no-blocking-sleep=1  wait-ladder=1  incremental-write=1  recorded-cause=1
mate-charter       no-blocking-sleep=0  wait-ladder=0  incremental-write=1  recorded-cause=1
```
</details>
<details>
<summary>Evidence: Generated brief text a worker reads (scout Definition of done, ship Rules item 8, secondmate detailed-answer path)</summary>

<code>### scout brief: Definition of done&#10;The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.&#10;Write it incrementally, section by section, straight to that file; never compose the whole report and write it once at the end.&#10;A single long final write can hit a transient `API Error: The system encountered an unexpected error during processing` that ends the turn silently and loses everything unwritten; that error is transient, so retry rather than restart.&#10;&#10;### ship brief (mode=no-mistakes): Rules item 8&#10;8. Never wait in a foreground blocking `sleep`: from outside it is indistinguishable from a stall,&#10;and it burns the very context the wait was meant to protect.&#10;To wait on your own background job, prefer a harness-tracked background job whose completion&#10;resumes or notifies you; otherwise poll briefly and do other useful work between checks;&#10;otherwise record the thing as unverified and move on.&#10;&#10;### secondmate charter: detailed-answer path&#10;For a detailed answer (an investigation, a plan, an audit), write it to a doc under your home&#39;s `data/` ...&#10;Write that doc incrementally, section by section, straight to the file; never compose the whole document and write it once at the end.&#10;A single long final write can hit a transient `API Error: ...` that ends the turn silently and loses everything unwritten; that error is transient, so retry rather than restart.</code>

```text
### scout brief: Definition of done (generated by bin/fm-brief.sh scout-task demo-proj --scout)
# Definition of done
Write your findings to `/tmp/no-mistakes-evidence/01M0FKB1BBA0KVGQTNSFACZ7BS/briefs-target/home/data/scout-task/report.md`.
The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
Write it incrementally, section by section, straight to that file; never compose the whole report and write it once at the end.
A single long final write can hit a transient `API Error: The system encountered an unexpected error during processing` that ends the turn silently and loses everything unwritten; that error is transient, so retry rather than restart.
If your deliverable is a visual artifact the captain will review and iterate on, you may host the Lavish review loop yourself (poll, revise, re-serve, staying alive) instead of handing it back to firstmate.
Before reporting done, read and follow `/home/inthuson/.no-mistakes/worktrees/d4c7ad84348d/01M0FKB1BBA0KVGQTNSFACZ7BS/.agents/skills/decision-hold-lifecycle/SKILL.md` and pass its shared completion gate for the report and any visual review.
When the report is complete, append `done: {one-line conclusion}` to the status file and stop.
If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.

### ship brief (mode=no-mistakes): Rules item 8
8. Never wait in a foreground blocking `sleep`: from outside it is indistinguishable from a stall,
   and it burns the very context the wait was meant to protect.
   To wait on your own background job, prefer a harness-tracked background job whose completion
   resumes or notifies you; otherwise poll briefly and do other useful work between checks;
   otherwise record the thing as unverified and move on.

### secondmate charter: detailed-answer path
29:For a detailed answer (an investigation, a plan, an audit), write it to a doc under your home's `data/` and append a status line that points to that doc - the scout-report pattern - so the main firstmate is woken and can read it.
30-Write that doc incrementally, section by section, straight to the file; never compose the whole document and write it once at the end.
31-A single long final write can hit a transient `API Error: The system encountered an unexpected error during processing` that ends the turn silently and loses everything unwritten; that error is transient, so retry rather than restart.
32-Before treating an investigation or visual review as complete, load `decision-hold-lifecycle` from this home's `.agents/skills/` and pass its shared completion gate.
```
</details>
<details>
<summary>Evidence: Path-normalized diff of every generated brief, base vs target (additions only, existing contracts intact)</summary>

<code>--- scout-task/brief.md&#10;38a39,43&#10;&gt; 8. Never wait in a foreground blocking `sleep`: from outside it is indistinguishable from a stall,&#10;&gt; and it burns the very context the wait was meant to protect.&#10;&gt; To wait on your own background job, prefer a harness-tracked background job whose completion&#10;&gt; resumes or notifies you; otherwise poll briefly and do other useful work between checks;&#10;&gt; otherwise record the thing as unverified and move on.&#10;42a48,49&#10;&gt; Write it incrementally, section by section, straight to that file; never compose the whole report and write it once at the end.&#10;&gt; A single long final write can hit a transient `API Error: ...`; that error is transient, so retry rather than restart.&#10;&#10;--- mate-charter/brief.md&#10;29a30,31&#10;&gt; Write that doc incrementally, section by section, straight to the file; never compose the whole document and write it once at the end.&#10;&gt; A single long final write can hit a transient `API Error: ...`; that error is transient, so retry rather than restart.&#10;&#10;(removed/modified lines across all five variants: 0)</code>

```text
# Path-normalized diff of every generated brief: base 1cb900c -> target 07bfb7f
# Only additions ('>') appear, so the worktree-isolation assertion, status protocol,
# delivery-mode definitions of done and Herdr declaration are byte-identical.

--- ship-no-mistakes/brief.md
45a46,50
> 8. Never wait in a foreground blocking `sleep`: from outside it is indistinguishable from a stall,
>    and it burns the very context the wait was meant to protect.
>    To wait on your own background job, prefer a harness-tracked background job whose completion
>    resumes or notifies you; otherwise poll briefly and do other useful work between checks;
>    otherwise record the thing as unverified and move on.

--- ship-direct-PR/brief.md
44a45,49
> 8. Never wait in a foreground blocking `sleep`: from outside it is indistinguishable from a stall,
>    and it burns the very context the wait was meant to protect.
>    To wait on your own background job, prefer a harness-tracked background job whose completion
>    resumes or notifies you; otherwise poll briefly and do other useful work between checks;
>    otherwise record the thing as unverified and move on.

--- ship-local-only/brief.md
44a45,49
> 8. Never wait in a foreground blocking `sleep`: from outside it is indistinguishable from a stall,
>    and it burns the very context the wait was meant to protect.
>    To wait on your own background job, prefer a harness-tracked background job whose completion
>    resumes or notifies you; otherwise poll briefly and do other useful work between checks;
>    otherwise record the thing as unverified and move on.

--- scout-task/brief.md
38a39,43
> 8. Never wait in a foreground blocking `sleep`: from outside it is indistinguishable from a stall,
>    and it burns the very context the wait was meant to protect.
>    To wait on your own background job, prefer a harness-tracked background job whose completion
>    resumes or notifies you; otherwise poll briefly and do other useful work between checks;
>    otherwise record the thing as unverified and move on.
42a48,49
> Write it incrementally, section by section, straight to that file; never compose the whole report and write it once at the end.
> A single long final write can hit a transient `API Error: The system encountered an unexpected error during processing` that ends the turn silently and loses everything unwritten; that error is transient, so retry rather than restart.

--- mate-charter/brief.md
29a30,31
> Write that doc incrementally, section by section, straight to the file; never compose the whole document and write it once at the end.
> A single long final write can hit a transient `API Error: The system encountered an unexpected error during processing` that ends the turn silently and loses everything unwritten; that error is transient, so retry rather than restart.
```
</details>
<details>
<summary>Evidence: Encoded launch prompt actually delivered to the worker agent (scout)</summary>

<code>needles in the delivered launch prompt (bin/fm-operational-input.sh encode launch-brief &lt; brief.md):&#10;Never wait in a foreground blocking `sleep` -&gt; 1&#10;prefer a harness-tracked background job whose completion -&gt; 1&#10;Write it incrementally, section by section, straight to that file -&gt; 1&#10;that error is transient, so retry rather than restart -&gt; 1</code>

```text
⁣FIRSTMATE_OP: v1 launch-brief: You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of demo-proj, at a detached HEAD on a clean default branch.
This is a SCOUT task: the deliverable is a written report, not a PR.
The worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
The report is the only thing that survives, so anything worth keeping must be in it.

# Rules
1. Never push to any remote and never open a PR.
2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/no-mistakes-evidence/01M0FKB1BBA0KVGQTNSFACZ7BS/briefs-target/home/state/scout-task.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on and the needs-decision/blocked/paused/done/failed states. No step-by-step
   FYI progress lines; firstmate reads your pane for that.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset):
   firstmate then leaves your idle pane alone and rechecks it on a long cadence instead of
   treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.
8. Never wait in a foreground blocking `sleep`: from outside it is indistinguishable from a stall,
   and it burns the very context the wait was meant to protect.
   To wait on your own background job, prefer a harness-tracked background job whose completion
   resumes or notifies you; otherwise poll briefly and do other useful work between checks;
   otherwise record the thing as unverified and move on.

# Definition of done
Write your findings to `/tmp/no-mistakes-evidence/01M0FKB1BBA0KVGQTNSFACZ7BS/briefs-target/home/data/scout-task/report.md`.
The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
Write it incrementally, section by section, straight to that file; never compose the whole report and write it once at the end.
A single long final write can hit a transient `API Error: The system encountered an unexpected error during processing` that ends the turn silently and loses everything unwritten; that error is transient, so retry rather than restart.
If your deliverable is a visual artifact the captain will review and iterate on, you may host the Lavish review loop yourself (poll, revise, re-serve, staying alive) instead of handing it back to firstmate.
Before reporting done, read and follow `/home/inthuson/.no-mistakes/worktrees/d4c7ad84348d/01M0FKB1BBA0KVGQTNSFACZ7BS/.agents/skills/decision-hold-lifecycle/SKILL.md` and pass its shared completion gate for the report and any visual review.
When the report is complete, append `done: {one-line conclusion}` to the status file and stop.
If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.
```
</details>
- Evidence: Generated briefs, target script (all five variants) (local file: <code>/tmp/no-mistakes-evidence/01M0FKB1BBA0KVGQTNSFACZ7BS/briefs-target/home/data</code>)
- Evidence: Generated briefs, base script 1cb900c (all five variants, instructions absent) (local file: <code>/tmp/no-mistakes-evidence/01M0FKB1BBA0KVGQTNSFACZ7BS/briefs-base/home/data</code>)
<details>
<summary>Evidence: New tests fail against the pre-change script (non-vacuity proof)</summary>

<code>not ok - no-mistakes: brief does not forbid waiting in a foreground blocking sleep&#10;exit=1</code>

```text
not ok - no-mistakes: brief does not forbid waiting in a foreground blocking sleep
exit=1
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"07bfb7f100b9b7b6353230bf442b11c2107c8997","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `bin/fm-brief.sh:473` - bin/fm-brief.sh:473 (and the identical scout copy at :349) ends rule 8&#39;s ladder with &#34;otherwise record the thing as unverified and move on&#34;, with no exception for a wait the Definition of done itself requires and no pointer to the brief&#39;s own sanctioned long-external-wait mechanism. The ship DOD requires `done: PR {url} checks green` (no-mistakes) and rule 4 already defines `paused: {why}` for a known external wait firstmate rechecks on a long cadence, which is the correct behavior for a wait the worker cannot shorten. As written, a worker that cannot use a tracked background job and cannot usefully poll can read the third fallback as license to end the turn with a DOD-required verification silently unverified, rather than declaring `paused:` and staying accountable for it. The four-step ladder is verbatim what the intent specified, so this is flagged for your decision, not changed: a single clause (&#34;never for a check your Definition of done requires - declare `paused:` instead&#34;) would close it inside the stated brevity bar.
- ℹ️ `bin/fm-brief.sh:237` - The secondmate charter received fix 2 (bin/fm-brief.sh:237-238) but not fix 1: it has no Rules block and no instruction against a foreground blocking sleep. A persistent secondmate waits on its own crewmates through the full firstmate lifecycle, and grep confirms no other surface it loads carries this contract (AGENTS.md never mentions sleeps; AGENTS.md:536 and .agents/skills/process-event-sources/SKILL.md:63 forbid only running a *registered source&#39;s* blocking command in a conversational turn). So the authorized failure - an agent parked in a foreground `sleep` waiting on work it started, indistinguishable from a stall - stays reachable for secondmates, and firstmate could still have to hand-type that correction, against the stated definition of done (&#34;firstmate never has to type either correction to a worker again&#34;). Your intent scoped fix 1 to &#34;the scout and ship variants&#34;, so I am not treating this as a contradiction or expanding scope: it is a scope call for you, and the cheapest close would be one line on the charter&#39;s escalation/operating path rather than a Rules block the charter does not have.

🔧 Fix: point required waits at paused, brief secondmate on waiting
2 issues (1 warning, 1 info) still open:
- ⚠️ `bin/fm-brief.sh:225` - The new secondmate clause sanctions a `paused:` escalation for a wait the charter&#39;s own escalation rules exclude. Line 224 scopes the clause to &#34;When you wait on a crewmate or on a background job of your own&#34;, and line 225 then says to &#34;declare a wait you can neither shorten nor abandon with `$PAUSED_VERB: {why}` below&#34; - `below` being the Escalation section, whose appends go to the MAIN firstmate&#39;s status file ($STATE/$ID.status, line 247). But that same section already scopes the verb narrowly: line 249 permits `paused:` &#34;only when your domain is deliberately idling on a known external wait you expect to clear on its own&#34;, and line 259 says &#34;Routine internal supervision, heartbeats, retries, and crewmate churn stay inside your own home and must not touch that status file.&#34; A wait on your own crewmate is internal churn, not an external wait, so the Operating model now sanctions what the Escalation section forbids, with two owners for one verb. Concrete path: the secondmate spawns crewmate fm-x for a long task, cannot shorten or abandon the wait, and appends `paused: waiting on crewmate fm-x`. bin/fm-watch.sh:1044 then flips that secondmate window from skipped stale detection into the paused cadence, and handle_paused_stale (bin/fm-watch.sh:351-356) re-surfaces a firstmate wake reading &#34;confirm the wait still holds&#34; once per PAUSE_RESURFACE_SECS for routine internal supervision; charter line 258 then requires a second append, a `resolved:` line, to close it. Net effect is supervisor wake-ups for exactly the churn the charter isolates, plus a persistent secondmate labelled as deliberately idling while it is actively supervising (its own DOD at line 262 says it is persistent and an empty queue needs no status line at all). This also brushes the intent&#39;s constraint &#34;Do not weaken or reword the existing safety contracts: the worktree-isolation assertion, the status protocol, ...&#34;: rule 8&#39;s paused pointer exists because a mode=no-mistakes ship DOD requires a wait, and the charter&#39;s DOD requires none, so the cheapest close is to drop the paused pointer from the charter (keeping the three-rung ladder, which is the part the accepted finding asked for) or to scope it explicitly to a genuinely external wait in line 249&#39;s words.
- ℹ️ `bin/fm-brief.sh:476` - Noting a residual, deliberately scoped gap rather than asking for a broader rule. Rule 8&#39;s ladder (ship copy here, identical scout copy at :351) forbids exactly one shape, &#34;a foreground blocking `sleep`&#34;, and its new last rung tells the worker to declare `$PAUSED_VERB: {why}` for a required wait. Unlike rules 5 and 6, which each end &#34;and stop&#34;, the new clause does not say the turn ends there, and a `paused:` declaration is not inert on the supervision side: bin/fm-watch.sh:365-373 documents that a `paused:` declaration deliberately stops treating an over-long BUSY pane as a wedge suspect, &#34;identifies that live foreground call as the expected external wait&#34;. So &#34;declare `paused: waiting for CI`, then block in the foreground on a non-sleep command&#34; (`gh run watch`, a blocking poll) reads as compliant: it is not a `sleep`, and the declaration now shields the busy pane from wedge escalation, which is the same stall-shaped, context-burning wait this change exists to remove. This is informational because the intent itself scopes the forbidden shape to `sleep` (&#34;never use a foreground blocking sleep as a wait&#34;) and explicitly caps the added text&#39;s size, so widening the prohibition to any blocking foreground wait, or adding &#34;and stop&#34;, would go past what was asked. Flagging the tradeoff only, so it is a known residual rather than an assumed-closed one.

🔧 Fix: keep secondmate waits in own home, end paused rung
2 issues (1 warning, 1 info) still open:
- ⚠️ `bin/fm-brief.sh:225` - The secondmate charter&#39;s new waiting ladder misdirects a wait on the secondmate&#39;s OWN crewmate away from the mechanism the always-loaded supervision contract owns. Line 224 scopes the clause to &#34;When you wait on a crewmate or on a background job of your own&#34;, and line 225&#39;s first rung says &#34;Prefer a harness-tracked background job whose completion resumes or notifies you&#34; while its third rung says &#34;otherwise record the thing as unverified and move on&#34;. A secondmate is a firstmate in its own home whose job description is the local AGENTS.md (charter line 220, and bin/fm-home-seed.sh:426 refuses a home without it), so section 8 binds it: AGENTS.md:384-385 requires exactly one live supervision cycle using the emitted protocol and states &#34;Do not substitute another harness&#39;s wait shape, use shell `&amp;`, or create a second cycle when a healthy one already exists&#34;, AGENTS.md:387 states &#34;No turn ends blind while work is under way, including turns described as holding or waiting&#34;, and AGENTS.md:167 puts the exact wait or wake mechanism under that emitted protocol. Concrete path: the secondmate spawns crewmate fm-x, follows rung 1 and starts a background poller for fm-x (a second cycle / substituted wait shape), or follows rung 3 and records fm-x&#39;s result as unverified and ends the turn with fm-x in flight (a blind turn end). The contradiction is adjacent inside the generated charter itself: line 222 already names &#34;watcher&#34; as the lifecycle mechanism, line 223 says &#34;Do not invent a second delegation system&#34;, and the charter&#39;s own Definition of done (lines 262-265) has the secondmate reconcile in-flight work and then wait silently. The round-3 fix corrected only the final rung, which now correctly says an unshortenable wait &#34;belongs to this home&#39;s own watcher and status cycle&#34;, so it stopped one rung short: the cheapest close is to send the whole crewmate-wait case to that same cycle and scope the three rungs to a background job of the secondmate&#39;s own, keeping the accepted criterion (never wait in a foreground blocking `sleep`) intact and the clause no longer than it is now. Flagged for your decision rather than changed, because your round-1 instruction deliberately extended this contract to cover waiting on crewmates.
- ℹ️ `bin/fm-brief.sh:477` - Noting a residual so the crewmate copy is not assumed closed by the round-3 secondmate fix. Rule 8&#39;s sentence antecedent is &#34;To wait on your own background job&#34; (line 474, identical scout copy at :349), and its last rung sends that wait to `$PAUSED_VERB: {why}` (line 477, scout :352). Rule 4 permits that verb &#34;ONLY when you are deliberately idling on a known external wait you expect to clear on its own&#34; (lines 460-463) and AGENTS.md:395 states the same contract fleet-wide (&#34;a bounded external wait expected to clear on its own&#34;); bin/fm-watch.sh:352 then renders the resurfaced firstmate wake as &#34;awaiting external - declared pause&#34;. So a worker whose Definition of done depends on its own long background job declares an internal wait under an external-wait verb and firstmate rechecks it under a reason that misnames it. This is informational, not a request to change: the realistic mode=no-mistakes DOD wait (`done: PR {url} checks green`, line 420) is genuinely external; a crewmate, unlike the secondmate, has no own-home watcher cycle to route an internal wait to, so the pause verb is the only parking signal it has and the watcher behavior it selects (the bounded 3600s pause cadence instead of a 240s wedge escalation) is the desired one; and you affirmed this exact pointer twice, adding &#34;and stop&#34; to it in round 2.

🔧 Fix: drop paused pointer and secondmate wait ladder
1 info still open:
- ℹ️ `bin/fm-brief.sh:52` - Informational, no action needed: the three pipeline fix-round commits net to exactly zero against the author&#39;s intake commit, so the reviewed tree is byte-identical to 5ed7c6f. `git diff 5ed7c6f..HEAD` is empty, which independently confirms every part of the round-4 removal instruction landed: the pause-verb pointer is absent from both rule 8 copies (bin/fm-brief.sh:345-349 and :469-473 end at &#34;otherwise record the thing as unverified and move on&#34;), the secondmate Operating model (:219-226) carries no waiting ladder, the header summary at :52-56 again attributes the waiting contract to ship and scout rules while attributing the incremental-write contract to every document-producing scaffold (accurate: scout report at :354-355 and secondmate detailed answer at :237-238 are the only two), and tests/fm-brief.test.sh shrank back rather than being edited, with 22 functions defined and 22 registered. The practical consequence is only PR history shape: the branch carries three review-round commits whose combined diff is nothing, so a reader diffing HEAD~1 sees a removal that is really a revert to the accepted intake change.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-brief.test.sh` (all 22 tests pass, including `test_briefs_forbid_waiting_in_a_blocking_sleep` and `test_document_producing_briefs_require_incremental_writes`)</code>
- <code>Non-vacuity: extracted base commit 1cb900c with `git archive`, copied the new test file in, ran it against the pre-change script - it fails (`not ok - no-mistakes: brief does not forbid waiting in a foreground blocking sleep`)</code>
- <code>Generated all five variants from both the base and target scripts (`fm-brief.sh &lt;id&gt; demo-proj --mode no-mistakes|direct-PR|local-only`, `--scout`, `--secondmate alpha`) and counted each instruction needle per variant: 0 occurrences pre-change everywhere, correct placement post-change</code>
- <code>Path-normalized `diff` of every generated brief, base vs target: 0 removed or modified lines, additions only (existing safety contracts intact)</code>
- <code>`./bin/fm-operational-input.sh encode launch-brief &lt; .../scout-task/brief.md` - confirmed both instructions survive into the actual launch prompt fm-spawn.sh delivers to the agent</code>
- <code>`./bin/fm-brief.sh ship-lab demo --mode no-mistakes --herdr-lab` and `--scout --herdr-lab` - rule 8 present alongside the Herdr declaration</code>
- <code>`./bin/fm-brief.sh --help` - header pointer note renders in the CLI help</code>
- <code>`bash tests/fm-ask-user-authority.test.sh`, `bash tests/fm-secondmate-safety.test.sh`, `bash tests/fm-tangle-guard.test.sh`, `bash tests/fm-subagent-pretool-check.test.sh` (all pass)</code>
- <code>`bash tests/fm-decision-hold-lifecycle.test.sh` - skips in this environment (`skip: tasks-axi not found`), does not reference fm-brief</code>
- <code>`grep -P &#39;[^\x00-\x7F]&#39;` over every added source line and every generated brief - no em-dashes or other non-ASCII</code>
- <code>`git status --porcelain` - worktree clean, no transient test artifacts left behind</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
