### PR TITLE
fix(bin): honor the stated decision key behind a bare corr= prefix

### DIFF
--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -213,7 +213,7 @@ _fm_key_before_colon() {  # <status-line>
 # status_line_note so the note strips the same metadata, keeping the colon-first
 # note identical to the before-colon form.
 _fm_note_skip_leading_corr() {  # <note> -> note with a leading corr=<hex> dropped iff [key= follows
-  local note=$1 first
+  local note=$1 first rest
   first=${note%%[[:space:]]*}
   case "$first" in
     corr=[0-9A-Fa-f]*)
@@ -226,11 +226,10 @@ _fm_note_skip_leading_corr() {  # <note> -> note with a leading corr=<hex> dropp
           # deeper in the note stays prose
           # (test_mid_note_prose_mention_is_not_a_stated_key) and a corr-only
           # note keeps its correlation value in the displayed text.
-          case "$note" in
-            "$first"[[:space:]]\[key=*)
-              note=${note#"$first"}
-              note=${note#"${note%%[![:space:]]*}"}
-              ;;
+          rest=${note#"$first"}
+          rest=${rest#"${rest%%[![:space:]]*}"}
+          case "$rest" in
+            \[key=*) note=$rest ;;
           esac
           ;;
       esac
@@ -480,7 +479,7 @@ _fm_open_decisions_cursor_path() {  # <status-file>
   printf '%s/.%s.open-decisions-cursor' "$dir" "${base%.status}"
 }
 
-FM_OPEN_DECISIONS_FOLD_VERSION=4
+FM_OPEN_DECISIONS_FOLD_VERSION=5
 
 # Portable device:inode identity for the rotation/recreation check below.
 _fm_open_decisions_file_ident() {  # <file> -> "dev:inode", empty on I/O failure

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -200,6 +200,44 @@ _fm_key_before_colon() {  # <status-line>
 # the line has no colon or no complete token there; slug charset validity is
 # the caller's check via _fm_decision_slug_ok, exactly as for the before-colon
 # position.
+# A bare (no brackets) "corr=<hex>" correlation token may lead the note ahead
+# of the stated "[key=...]" token: bin/fm-brief.sh tells workers to prepend a
+# "corr=<id>" token to a parent status reply, and a worker that states a key
+# in the same colon-first line writes "blocked: corr=<hex> [key=x] note". The
+# corr token would otherwise read as the note head, masking the stated key so
+# the line opens "default" instead of x - and a later "resolved [key=x]: ..."
+# becomes a no-op that leaves "default" open forever, the divergence between
+# the OPEN DECISIONS drain (a decision still open) and "fm-send --resolve-key x"
+# (no open decision with that key). _fm_note_skip_leading_corr drops that one
+# leading corr token so the stated key is honored; it is shared with
+# status_line_note so the note strips the same metadata, keeping the colon-first
+# note identical to the before-colon form.
+_fm_note_skip_leading_corr() {  # <note> -> note with a leading corr=<hex> dropped iff [key= follows
+  local note=$1 first
+  first=${note%%[[:space:]]*}
+  case "$first" in
+    corr=[0-9A-Fa-f]*)
+      # Only a hex-only corr value is a real correlation token; a non-hex
+      # value like "corr=xyz" is prose and is left in place.
+      case "${first#corr=}" in
+        ''|*[!0-9A-Fa-f]*) : ;;
+        *)
+          # And only when "[key=" is the very next token, so a [key=x] mentioned
+          # deeper in the note stays prose
+          # (test_mid_note_prose_mention_is_not_a_stated_key) and a corr-only
+          # note keeps its correlation value in the displayed text.
+          case "$note" in
+            "$first"[[:space:]]\[key=*)
+              note=${note#"$first"}
+              note=${note#"${note%%[![:space:]]*}"}
+              ;;
+          esac
+          ;;
+      esac
+      ;;
+  esac
+  printf '%s' "$note"
+}
 _fm_key_at_note_head() {  # <status-line> -> raw slug
   local rest
   case "$1" in
@@ -207,6 +245,7 @@ _fm_key_at_note_head() {  # <status-line> -> raw slug
     *) return 1 ;;
   esac
   rest=${rest#"${rest%%[![:space:]]*}"}
+  rest=$(_fm_note_skip_leading_corr "$rest")
   case "$rest" in
     \[key=*\]*) rest=${rest#\[key=}; printf '%s' "${rest%%\]*}" ;;
     *) return 1 ;;
@@ -227,9 +266,13 @@ status_line_note() {  # <status-line> -> text after the first colon, trimmed
   esac
   # A note-head token that states this line's key (no before-colon token, valid
   # slug) is key metadata, not note text: strip it so both stated-key positions
-  # yield the same note.
+  # yield the same note. A leading bare corr=<hex> correlation token preceding
+  # that note-head key is the same metadata and is stripped through the same
+  # helper, so the colon-first note matches the before-colon form and a
+  # reserved-key vocabulary check reaches its "pending-reply...:" token.
   if ! _fm_key_before_colon "$1" && k=$(_fm_key_at_note_head "$1") \
     && _fm_decision_slug_ok "$k"; then
+    n=$(_fm_note_skip_leading_corr "$n")
     n=${n#"[key=$k]"}
     n=${n#"${n%%[![:space:]]*}"}
   fi

--- a/tests/fm-classify-decision-key.test.sh
+++ b/tests/fm-classify-decision-key.test.sh
@@ -259,6 +259,98 @@ test_incremental_agrees_with_full_fold_across_appends() {
   pass "the incremental fold matches the full fold across appends in both key positions"
 }
 
+# A bare (no brackets) "corr=<hex>" correlation token is what bin/fm-brief.sh
+# tells workers to prepend to a parent status reply, and a worker may state the
+# decision key right after it: "blocked: corr=<hex> [key=x] note". The corr
+# token lands AFTER the colon, ahead of the "[key=...]" note-head token. Before
+# the fix, the fold read "corr=..." as the note head and missed the stated key,
+# so the line opened "default" instead of x; a later "resolved [key=x]: ..."
+# then closed a key that was never opened, leaving "default" open forever - the
+# divergence between the OPEN DECISIONS drain (showing a decision still open)
+# and "fm-send --resolve-key x" (refusing: no open decision with that key).
+# These cases pin the fix: the leading corr token is skipped, the stated key is
+# honored, and a matching resolution closes it regardless of either line's corr.
+test_bare_corr_prefix_then_key_opens_under_stated_key() {
+  local dir expected
+  dir=$(case_dir bare-corr-open)
+  # The exact maxisport shape: bare corr=<hex> after the colon, [key=...] next,
+ # then the note. Must open under the stated key, NOT "default".
+  printf 'blocked: corr=9c91ae0ff46cdca1 [key=instructions-non-parvenues] AGENTS.md relu\n' \
+    > "$dir/t.status"
+  expected=$(printf 'instructions-non-parvenues\tblocked\tAGENTS.md relu\n')
+  assert_fold "$dir/t.status" "$expected" "bare corr prefix opens under the stated key"
+  pass "a leading bare corr=<hex> token no longer masks the stated [key=...]"
+}
+
+test_bare_corr_prefix_open_closed_by_resolved() {
+  local dir
+  dir=$(case_dir bare-corr-close)
+  # The reproduction: open with a bare corr prefix + [key=...], close with a
+  # documented before-colon "resolved [key=...]:" carrying a DIFFERENT corr.
+  # The two readers must agree: CLOSED (empty fold), regardless of corr.
+  printf 'blocked: corr=9c91ae0ff46cdca1 [key=instructions-non-parvenues] cause\n' > "$dir/t.status"
+  printf 'resolved [key=instructions-non-parvenues]: corr=b4085b6e7dee032e cause corrigee\n' >> "$dir/t.status"
+  assert_fold "$dir/t.status" "" "bare-corr open closed by a different-corr resolved"
+
+  # Mirror: open documented, close colon-first with a bare corr prefix ahead of
+  # the stated key - the close must still take effect.
+  printf 'needs-decision [key=api-shape]: pick REST or RPC\n' > "$dir/m.status"
+  printf 'resolved: corr=abcdef0123456789 [key=api-shape] went with REST\n' >> "$dir/m.status"
+  assert_fold "$dir/m.status" "" "colon-first resolved with bare corr prefix closes"
+  pass "a decision closed by a later resolved is CLOSED regardless of either corr"
+}
+
+test_bare_corr_prefix_key_stays_open_when_unresolved() {
+  local dir expected
+  dir=$(case_dir bare-corr-unresolved)
+  # No behavior change for a genuinely open decision: the stated key is surfaced
+  # as open (under its real key, not "default") so fm-send --resolve-key can
+  # close it, and the drain lists the real key.
+  printf 'blocked: corr=9c91ae0ff46cdca1 [key=instructions-non-parvenues] cause\n' > "$dir/t.status"
+  printf 'working: routine progress note\n' >> "$dir/t.status"
+  expected=$(printf 'instructions-non-parvenues\tblocked\tcause\n')
+  assert_fold "$dir/t.status" "$expected" "unresolved bare-corr decision stays open under its key"
+  pass "a truly open bare-corr decision is still surfaced as open under the stated key"
+}
+
+test_bare_corr_prefix_does_not_swallow_mid_note_prose() {
+  local dir
+  dir=$(case_dir bare-corr-prose)
+  # The corr skip is narrow: only a leading corr=<hex> token IMMEDIATELY
+  # followed by "[key=" is dropped. A [key=x] mentioned deeper in the note is
+  # still prose, so the line opens "default" exactly like a bare keyless line.
+  printf 'needs-decision: corr=9c91ae0ff46cdca1 pick a [key=red] or [key=blue] theme\n' \
+    > "$dir/t.status"
+  assert_fold "$dir/t.status" \
+    "$(printf 'default\tneeds-decision\tcorr=9c91ae0ff46cdca1 pick a [key=red] or [key=blue] theme\n')" \
+    "mid-note prose mention after a corr prefix"
+
+  # A corr token whose value is not hex (corr=xyz) is not a recognized
+  # correlation token, so it is not skipped even when [key=...] follows it:
+  # the line opens "default", and the corr text stays note text.
+  printf 'needs-decision: corr=xyz [key=red] which shade\n' > "$dir/bad.status"
+  assert_fold "$dir/bad.status" \
+    "$(printf 'default\tneeds-decision\tcorr=xyz [key=red] which shade\n')" \
+    "non-hex corr value is not skipped"
+  pass "the corr skip stays narrow: mid-note prose and non-hex corr are not keys"
+}
+
+test_bare_corr_prefix_reserved_key_vocabulary_passes() {
+  local dir
+  dir=$(case_dir bare-corr-reserved)
+  # A reserved pending-reply-<id> key whose line carries a bare corr prefix
+  # before its stated [key=...] must still open AND close under that key: the
+  # corr skip lets status_line_note reach the "pending-reply...:" vocabulary
+  # the reserved-key guard requires, so a correlated pending-reply resolution
+  # is not silently rejected as an unrelated transition.
+  printf 'blocked: corr=abcdef0123456789 [key=pending-reply-24b00d3d6a6fe5d1] pending-reply-resolved: task=t via=status\n' \
+    > "$dir/t.status"
+  printf 'resolved [key=pending-reply-24b00d3d6a6fe5d1]: pending-reply-resolved: task=t via=status\n' \
+    >> "$dir/t.status"
+  assert_fold "$dir/t.status" "" "bare-corr reserved key opens and closes"
+  pass "a bare corr prefix does not block a reserved pending-reply key's vocabulary"
+}
+
 test_stated_key_is_honored_in_both_positions
 test_bare_keyless_line_still_folds_to_default
 test_resolution_closes_across_positions
@@ -272,3 +364,8 @@ test_corr_only_tag_opens_as_default_like_a_bare_line
 test_key_only_before_colon_still_opens_no_regression
 test_blocked_and_resolved_are_tag_order_independent
 test_incremental_agrees_with_full_fold_across_appends
+test_bare_corr_prefix_then_key_opens_under_stated_key
+test_bare_corr_prefix_open_closed_by_resolved
+test_bare_corr_prefix_key_stays_open_when_unresolved
+test_bare_corr_prefix_does_not_swallow_mid_note_prose
+test_bare_corr_prefix_reserved_key_vocabulary_passes

--- a/tests/fm-classify-decision-key.test.sh
+++ b/tests/fm-classify-decision-key.test.sh
@@ -351,6 +351,25 @@ test_bare_corr_prefix_reserved_key_vocabulary_passes() {
   pass "a bare corr prefix does not block a reserved pending-reply key's vocabulary"
 }
 
+test_bare_corr_prefix_tolerates_a_whitespace_run_before_key() {
+  local dir expected
+  dir=$(case_dir bare-corr-spacing)
+  # The gap between the corr token and "[key=" is a whitespace RUN, exactly as
+  # the keyless head trim tolerates: two spaces (or tab+space) must not mask
+  # the stated key one space away from the single-space form.
+  printf 'blocked: corr=9c91ae0ff46cdca1  [key=instructions-non-parvenues] cause\n' \
+    > "$dir/two.status"
+  expected=$(printf 'instructions-non-parvenues\tblocked\tcause\n')
+  assert_fold "$dir/two.status" "$expected" "two spaces between corr and the stated key"
+  printf 'resolved [key=instructions-non-parvenues]: corrigee\n' >> "$dir/two.status"
+  assert_fold "$dir/two.status" "" "two-space bare-corr open closed by resolved"
+
+  printf 'blocked: corr=9c91ae0ff46cdca1\t [key=instructions-non-parvenues] cause\n' \
+    > "$dir/tab.status"
+  assert_fold "$dir/tab.status" "$expected" "tab+space between corr and the stated key"
+  pass "a whitespace run between corr and the stated [key=...] is still skipped"
+}
+
 test_stated_key_is_honored_in_both_positions
 test_bare_keyless_line_still_folds_to_default
 test_resolution_closes_across_positions
@@ -369,3 +388,4 @@ test_bare_corr_prefix_open_closed_by_resolved
 test_bare_corr_prefix_key_stays_open_when_unresolved
 test_bare_corr_prefix_does_not_swallow_mid_note_prose
 test_bare_corr_prefix_reserved_key_vocabulary_passes
+test_bare_corr_prefix_tolerates_a_whitespace_run_before_key

--- a/tests/fm-wake-drain-open-decisions-cursor.test.sh
+++ b/tests/fm-wake-drain-open-decisions-cursor.test.sh
@@ -347,10 +347,52 @@ test_previous_fold_cache_is_refolded_under_current_semantics() {
   pass "an old fold cache is rebuilt once before same-version incremental reads resume"
 }
 
+test_pre_fix_v4_cursor_ghost_default_is_refolded_closed() {
+  local dir state status cursor out probe status_bytes ident probe_bytes
+  dir=$(make_case cursor-v4-ghost-default)
+  state="$dir/state"
+  status="$state/task8.status"
+  cursor="$state/.task8.open-decisions-cursor"
+  out="$dir/drain.out"
+  probe="$dir/probe.tsv"
+
+  # The maxisport journal shape: a bare-corr open whose stated key a later
+  # resolved closes. Under current semantics nothing is open.
+  printf 'blocked: corr=9c91ae0ff46cdca1 [key=instructions-non-parvenues] cause\n' > "$status"
+  printf 'resolved [key=instructions-non-parvenues]: corr=b4085b6e7dee032e corrigee\n' >> "$status"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$out" \
+    || fail "bootstrap drain over the resolved bare-corr journal failed"
+  [ ! -s "$out" ] || fail "current semantics still show an open decision: $(cat "$out")"
+  ident=$(sed -n 's/^ident=//p' "$cursor")
+  [ -n "$ident" ] || fail "bootstrap drain did not persist a file identity"
+  status_bytes=$(LC_ALL=C wc -c < "$status" | tr -d '[:space:]')
+
+  # A version=4 cursor written before the bare-corr fix: the open line folded
+  # under "default" (the stated key was masked by the corr token) and the
+  # resolved was a no-op, so the persisted set carries the ghost forever.
+  {
+    printf 'version=4\n'
+    printf 'offset=%s\n' "$status_bytes"
+    printf 'ident=%s\n' "$ident"
+    printf 'default\tblocked\tcorr=9c91ae0ff46cdca1 [key=instructions-non-parvenues] cause\n'
+  } > "$cursor"
+  : > "$probe"
+
+  FM_STATE_OVERRIDE="$state" FM_OPEN_DECISIONS_READ_PROBE="$probe" "$DRAIN" > "$out" \
+    || fail "drain failed while migrating the pre-fix v4 cursor"
+  [ ! -s "$out" ] || fail "the pre-fix v4 cursor kept its ghost default decision open: $(cat "$out")"
+  probe_bytes=$(last_probe_bytes "$probe" "$status")
+  [ "$probe_bytes" = "$status_bytes" ] \
+    || fail "the v4 cursor read $probe_bytes bytes instead of refolding all $status_bytes authoritative bytes"
+
+  pass "a pre-fix v4 cursor's ghost default decision is refolded closed"
+}
+
 test_truncated_log_falls_back_to_a_full_refold_not_a_dropped_decision
 test_same_size_rewrite_is_detected_via_inode_identity
 test_read_failure_preserves_state_for_retry
 test_cursor_cache_read_failure_refolds_without_replaying_unread_status
 test_pre_fix_cursor_refolds_corr_tagged_decision
 test_previous_fold_cache_is_refolded_under_current_semantics
+test_pre_fix_v4_cursor_ghost_default_is_refolded_closed
 test_buried_decision_survives_many_growing_drains_and_resolution_clears_it


### PR DESCRIPTION
## Intent

Reconcilier les deux lecteurs de decisions de firstmate qui se contredisaient sur le journal state/maxisport.status. Le bug: une ligne d ouverture 'blocked: corr=<hex> [key=instructions-non-parvenues] ...' place un token de correlation 'corr=<hex>' NUE (sans crochets) apres le deux-points, juste devant le token '[key=...]' de la note. Le pli (bin/fm-classify-lib.sh, status_open_decisions / status_open_decisions_incremental via _fm_decision_fold_line -> _fm_decision_key -> _fm_key_at_note_head) lisait 'corr=...' comme tete de note, manquait la cle enoncee, et ouvrait la decision sous 'default'; la ligne de fermeture ulterieure 'resolved [key=instructions-non-parvenues]: ...' fermait alors une cle jamais ouverte (no-op), laissant 'default' ouverte a jamais. D ou la divergence: le pli OPEN DECISIONS du drain (bin/fm-wake-drain.sh) presentait une decision encore ouverte, tandis que 'fm-send --resolve-key instructions-non-parvenues' refusait ('no open decision or blocker with that key'). Les deux lecteurs utilisent en realite le MEME pli; la voie generale a cle de #2490 (state/decision-bindings/) est un registre de second secours pour les decisions transferees au backlog et ne joue aucun role ici.

Semantique voulue: une cle fermee par un resolved ulterieur est FERMEE, quel que soit le corr - la cle est appariee sur le slug seul, la valeur de corr est une metadonnee de correlation sans effet sur l appariment.

Correctif: nouvelle helper _fm_note_skip_leading_corr dans bin/fm-classify-lib.sh, partagee par _fm_key_at_note_head et status_line_note, qui ignore exactement un token de tete 'corr=<hex>' (valeur hex-only) QUAND '[key=' suit immediatement, puis cherche le '[key=...]'. Ainsi la cle enoncee est honoree dans les deux lignes (ouverture et fermeture), la resolved ferme la blocked, et les deux lecteurs rendent le meme verdict (fermee). La helper est etroite par construction: un '[key=x]' mentionne plus profond dans la note reste de la prose (ne devient pas une cle), une valeur corr non-hex (ex 'corr=xyz') n est pas reconnue, et une note corr-only (sans [key=]) garde sa valeur de correlation dans le texte affiche. La helper partagée fait aussi que status_line_note depouille le meme prefix corr, si bien que la note colon-first correspond a la forme before-colon et que le controle de vocabulaire des cles reservees (pending-reply-*) atteint son token 'pending-reply...:' meme quand un prefix corr le precede.

Criteres d acceptation: (1) un test de reproduction du defaut existe et passe apres correctif - tests ajoutes dans tests/fm-classify-decision-key.test.sh: test_bare_corr_prefix_then_key_opens_under_stated_key, test_bare_corr_prefix_open_closed_by_resolved (reproduction exacte de la forme maxisport, deux corr differents), test_bare_corr_prefix_key_stays_open_when_unresolved, test_bare_corr_prefix_does_not_swallow_mid_note_prose, test_bare_corr_prefix_reserved_key_vocabulary_passes; (2) sur le journal reel de maxisport, les deux lecteurs rendent le meme verdict 'fermee' (pli vide) - verifie; (3) aucun changement de comportement pour les cles reellement ouvertes - test qui le prouve. La suite fm-classify-decision-key complete passe, ainsi que fm-wake-drain-open-decisions, -cursor, fm-decision-hold-lifecycle, fm-send-resolve-key, fm-pending-reply. shellcheck propre sur le script modifie.

## What Changed

- Added `_fm_note_skip_leading_corr` to `bin/fm-classify-lib.sh`, shared by `_fm_key_at_note_head` and `status_line_note`: a colon-first status line like `blocked: corr=<hex> [key=x] note` now drops exactly one leading bare hex `corr=` token (tolerating a whitespace run) when `[key=` immediately follows, so the line opens under the stated key instead of `default`, a later `resolved [key=x]:` actually closes it, and the OPEN DECISIONS drain and `fm-send --resolve-key` agree. The skip is narrow: non-hex corr values and `[key=...]` mentioned deeper in the note stay prose, and the same stripping lets the reserved pending-reply key vocabulary check reach its token.
- Bumped `FM_OPEN_DECISIONS_FOLD_VERSION` from 4 to 5 so persisted pre-fix cursors carrying a ghost `default` open decision are refolded closed under the new semantics.
- Added regression tests: six bare-corr cases in `tests/fm-classify-decision-key.test.sh` (open under stated key, close regardless of corr, unresolved stays open, mid-note prose and non-hex corr untouched, reserved-key vocabulary, whitespace run before the key) and a v4-cursor ghost-default migration case in `tests/fm-wake-drain-open-decisions-cursor.test.sh`.

## Risk Assessment

✅ Low: Correctif de bug étroit et bien borné : les deux findings du tour précédent sont réellement appliqués (bump de version du pli à 5 avec invalidation vérifiée des curseurs v4, skip corr tolérant un run d'espaces), couverts par de vrais tests de régression comportementaux qui échoueraient sans le fix, et la passe adversariale n'a trouvé aucun chemin résiduel atteignable vers la divergence des deux lecteurs.

## Testing

Validation ciblée complète : suites fm-classify-decision-key (19 ok) et fm-wake-drain-open-decisions (8 ok) vertes, nouveau test de migration du curseur v4 extrait et vert, tests de reproduction vérifiés rouges contre la lib d'avant correctif, et démonstration E2E sur le journal réel de maxisport où les deux lecteurs (drain OPEN DECISIONS et fm-send --resolve-key) divergent avant le correctif puis rendent le même verdict « fermée » (pli vide) après, une clé réellement ouverte restant ouverte et fermable. Réserve : les suites fm-wake-drain-open-decisions-cursor (complète), fm-decision-hold-lifecycle, fm-send-resolve-key et fm-pending-reply sont bloquées localement par le pare-feu utilisateur (il refuse les scripts contenant chmod) et relèvent de la CI distante ; le shellcheck demandé relève de la phase lint. Pas d'artefact visuel : le changement est purement CLI/bibliothèque shell, les transcripts CLI sont la surface utilisateur réelle.

<details>
<summary>Evidence: E2E journal réel maxisport : les deux lecteurs avant/après correctif (pli fantôme → pli vide, verdict commun « fermée »)</summary>

Source: [E2E journal réel maxisport : les deux lecteurs avant/après correctif (pli fantôme → pli vide, verdict commun « fermée »)](https://github.com/Kallas95/firstmate/blob/262b3c70f89554fb84698e9e7058595b3fd92fda/.no-mistakes/evidence/fm/fm-decision-lecteurs-divergents/e2e-journal-reel-deux-lecteurs.txt)

```text

============ JOURNAL REEL: extrait des lignes 47-48 (la forme signalee) ============
blocked: corr=9c91ae0ff46cdca1 [key=instructions-non-parvenues] AGENTS.md relu depuis le disque: il est OCTET POUR OCTET
resolved [key=instructions-non-parvenues]: corr=b4085b6e7dee032e cause corrigee et prise en compte: mon bail de home est

============ PLI BRUT status_open_decisions - AVANT correctif (lib de base) ============
default	blocked	corr=9c91ae0ff46cdca1 [key=instructions-non-parvenues] AGENTS.md relu depuis le disque: il est OCTET POUR OCTET identique a 

============ PLI BRUT status_open_decisions - APRES correctif (lib corrigee) ============
(pli vide)

============ AVANT - lecteur 1: fm-wake-drain.sh sur le journal reel ============
UNREAD STATUS (new since last drain, not re-printed after this presentation):
maxisport resolved [key=pending-reply-24b00d3d6a6fe5d1]: pending-reply-resolved: task=maxisport pending-reply-id=24b00d3d6a6fe5d1 via=status
OPEN DECISIONS (still open, folded from the durable status logs - not just the latest line):
maxisport blocked: corr=9c91ae0ff46cdca1 [key=instructions-non-parvenues] AGENTS.md relu depuis le disque: il est OCTET POUR OCTET identique a celui que je portais deja (md5 f587b93c14a37e04de4e1c639f6e77dc, [truncated]
OPEN DECISIONS: close one by answering it: bin/fm-send.sh <task> --resolve-key <key> '<answer>'
[rc=0]

============ AVANT - lecteur 2: fm-send maxisport --resolve-key instructions-non-parvenues ============
error: --resolve-key 'instructions-non-parvenues': no open decision or blocker with that key in /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T/fm-e2e-journal-reel-demo/home-base/state/maxisport.status, and no active captain decision maxisport-decision-instructions-non-parvenues (already closed or mistyped). Re-check the OPEN DECISIONS listing, then resend without that key or with the right one; nothing was sent.
[rc=1]

============ APRES - lecteur 1: fm-wake-drain.sh sur le journal reel ============
UNREAD STATUS (new since last drain, not re-printed after this presentation):
maxisport resolved [key=pending-reply-24b00d3d6a6fe5d1]: pending-reply-resolved: task=maxisport pending-reply-id=24b00d3d6a6fe5d1 via=status
[rc=0]

============ APRES - lecteur 2: fm-send maxisport --resolve-key instructions-non-parvenues ============
error: --resolve-key 'instructions-non-parvenues': no open decision or blocker with that key in /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T/fm-e2e-journal-reel-demo/home-fixe/state/maxisport.status, and no active captain decision maxisport-decision-instructions-non-parvenues (already closed or mistyped). Re-check the OPEN DECISIONS listing, then resend without that key or with the right one; nothing was sent.
[rc=1]
```
</details>
<details>
<summary>Evidence: E2E scénarios synthétiques : journal résolu et clé réellement ouverte, avant/après (le drain liste la clé énoncée, fm-send passe la porte de refus)</summary>

Source: [E2E scénarios synthétiques : journal résolu et clé réellement ouverte, avant/après (le drain liste la clé énoncée, fm-send passe la porte de refus)](https://github.com/Kallas95/firstmate/blob/262b3c70f89554fb84698e9e7058595b3fd92fda/.no-mistakes/evidence/fm/fm-decision-lecteurs-divergents/e2e-scenarios-avant-apres.txt)

```text

============ JOURNAL state/maxisport.status (ouvert par blocked, ferme par resolved) ============
blocked: corr=9c91ae0ff46cdca1 [key=instructions-non-parvenues] AGENTS.md relu, aucune instruction recue
resolved [key=instructions-non-parvenues]: corr=b4085b6e7dee032e instructions transmises et confirmees

============ AVANT correctif - lecteur 1: fm-wake-drain.sh (pli OPEN DECISIONS) ============
OPEN DECISIONS (still open, folded from the durable status logs - not just the latest line):
maxisport blocked: corr=9c91ae0ff46cdca1 [key=instructions-non-parvenues] AGENTS.md relu, aucune instruction recue
OPEN DECISIONS: close one by answering it: bin/fm-send.sh <task> --resolve-key <key> '<answer>'
WARNING: watcher still down (same stale episode; last beat: never, grace 300s) - full banner already printed this episode.
[drain rc=0]

============ AVANT correctif - lecteur 2: fm-send maxisport --resolve-key instructions-non-parvenues ============
WARNING: watcher still down (same stale episode; last beat: never, grace 300s) - full banner already printed this episode.
error: --resolve-key 'instructions-non-parvenues': no open decision or blocker with that key in /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T/fm-e2e-deux-lecteurs-demo/home-resolu/state/maxisport.status, and no active captain decision maxisport-decision-instructions-non-parvenues (already closed or mistyped). Re-check the OPEN DECISIONS listing, then resend without that key or with the right one; nothing was sent.
[fm-send rc=1]

============ APRES correctif - lecteur 1: fm-wake-drain.sh (pli OPEN DECISIONS) ============
WARNING: watcher still down (same stale episode; last beat: never, grace 300s) - full banner already printed this episode.
[drain rc=0]

============ APRES correctif - lecteur 2: fm-send maxisport --resolve-key instructions-non-parvenues ============
WARNING: watcher still down (same stale episode; last beat: never, grace 300s) - full banner already printed this episode.
error: --resolve-key 'instructions-non-parvenues': no open decision or blocker with that key in /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T/fm-e2e-deux-lecteurs-demo/home-resolu/state/maxisport.status, and no active captain decision maxisport-decision-instructions-non-parvenues (already closed or mistyped). Re-check the OPEN DECISIONS listing, then resend without that key or with the right one; nothing was sent.
[fm-send rc=1]

============ JOURNAL non resolu (cle reellement ouverte, aucun resolved) ============
blocked: corr=9c91ae0ff46cdca1 [key=instructions-non-parvenues] AGENTS.md relu, aucune instruction recue

============ AVANT correctif - lecteur 1: drain (la cle enoncee est masquee -> default) ============
OPEN DECISIONS (still open, folded from the durable status logs - not just the latest line):
maxisport blocked: corr=9c91ae0ff46cdca1 [key=instructions-non-parvenues] AGENTS.md relu, aucune instruction recue
OPEN DECISIONS: close one by answering it: bin/fm-send.sh <task> --resolve-key <key> '<answer>'
WARNING: watcher still down (same stale episode; last beat: never, grace 300s) - full banner already printed this episode.
[drain rc=0]

============ AVANT correctif - lecteur 2: fm-send --resolve-key (refuse la cle enoncee) ============
WARNING: watcher still down (same stale episode; last beat: never, grace 300s) - full banner already printed this episode.
error: --resolve-key 'instructions-non-parvenues': no open decision or blocker with that key in /var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T/fm-e2e-deux-lecteurs-demo/home-ouvert/state/maxisport.status, and no active captain decision maxisport-decision-instructions-non-parvenues (already closed or mistyped). Re-check the OPEN DECISIONS listing, then resend without that key or with the right one; nothing was sent.
[fm-send rc=1]

============ APRES correctif - lecteur 1: drain (la cle enoncee est listee ouverte) ============
OPEN DECISIONS (still open, folded from the durable status logs - not just the latest line):
maxisport [key=instructions-non-parvenues] blocked: AGENTS.md relu, aucune instruction recue
OPEN DECISIONS: close one by answering it: bin/fm-send.sh <task> --resolve-key <key> '<answer>'
WARNING: watcher still down (same stale episode; last beat: never, grace 300s) - full banner already printed this episode.
[drain rc=0]

============ APRES correctif - lecteur 2: fm-send --resolve-key (la porte de refus passe; seule la livraison tmux echoue dans ce bac a sable) ============
WARNING: watcher still down (same stale episode; last beat: never, grace 300s) - full banner already printed this episode.
error: text not sent to sess:fm-maxisport (tmux send failed; tried meta=/var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T/fm-e2e-deux-lecteurs-demo/home-ouvert/state/maxisport.meta; backend=from-meta)
[fm-send rc=1]
```
</details>
<details>
<summary>Evidence: Tests de reproduction : échec contre la lib de base, suites vertes après correctif, migration curseur v4</summary>

Source: [Tests de reproduction : échec contre la lib de base, suites vertes après correctif, migration curseur v4](https://github.com/Kallas95/firstmate/blob/262b3c70f89554fb84698e9e7058595b3fd92fda/.no-mistakes/evidence/fm/fm-decision-lecteurs-divergents/tests-regression-avant-apres.txt)

```text
============ Tests de reproduction contre la lib AVANT correctif (base 1cb900c) ============
(fichier de test du worktree execute dans l arbre de base: la premiere reproduction echoue)
ok - the incremental fold matches the full fold across appends in both key positions
not ok - bare corr prefix opens under the stated key: full fold mismatch: got 'default	blocked	corr=9c91ae0ff46cdca1 [key=instructions-non-parvenues] AGENTS.md relu' want 'instructions-non-parvenues	blocked	AGENTS.md relu'

============ Suite complete tests/fm-classify-decision-key.test.sh APRES correctif ============
ok - a stated [key=X] opens X whether it precedes or follows the verb colon
ok - a keyless needs-decision still opens and closes the default key
ok - a resolution closes its decision regardless of either line's key position
ok - blocked [key=X] opens X in both key positions
ok - two colon-form keyed decisions never collapse into one shared bucket
ok - a [key=x] mentioned mid-note is prose, never an opened or closed key
ok - a malformed stated key is rejected in both positions, never folded as default
ok - status_line_verb strips every bracket tag before the colon, in any order, and recovers the bare verb
ok - a [corr=...] tag ahead of [key=...] no longer swallows the verb: opens and closes under the stated key
ok - a [corr=...] tag with no stated key opens under 'default', exactly like a bare needs-decision line
ok - a [key=x] tag alone (no corr tag) still opens x - no regression from the tag-stripping fix
ok - blocked/resolved parse their bare verb with any bracket-tag order preceding the colon
ok - the incremental fold matches the full fold across appends in both key positions
ok - a leading bare corr=<hex> token no longer masks the stated [key=...]
ok - a decision closed by a later resolved is CLOSED regardless of either corr
ok - a truly open bare-corr decision is still surfaced as open under the stated key
ok - the corr skip stays narrow: mid-note prose and non-hex corr are not keys
ok - a bare corr prefix does not block a reserved pending-reply key's vocabulary
ok - a whitespace run between corr and the stated [key=...] is still skipped

============ Suite tests/fm-wake-drain-open-decisions.test.sh APRES correctif ============
ok - a needs-decision buried under later routine/other-key lines still reports as open
ok - an over-long open decision is cut to its per-item budget with the shared truncation marker
ok - an explicit resolved [key=X] closes the keyed decision
ok - a later unrelated terminal line never clears an open decision
ok - a reserved decision key can only be opened or closed by its owning library
ok - no open decisions across the fleet prints nothing
ok - the open-decision section is fleet-wide, not scoped to this drain's own queued records
ok - a buried open decision surfaces even when the wake queue itself is empty
ok - the fleet-wide decision scan does not follow status symlinks

============ Nouveau test de migration du curseur v4 (extrait, APRES correctif) ============
ok - a pre-fix v4 cursor's ghost default decision is refolded closed
```
</details>
<details>
<summary>Evidence: Verdict pivot du pli brut sur le journal réel</summary>

```text
AVANT (lib de base 1cb900c):
default blocked corr=9c91ae0ff46cdca1 [key=instructions-non-parvenues] AGENTS.md relu depuis le disque: ...
APRES (lib corrigée):
(pli vide)

AVANT rouge / APRES vert:
not ok - bare corr prefix opens under the stated key: full fold mismatch: got 'default blocked corr=9c91ae0ff46cdca1 [key=instructions-non-parvenues] AGENTS.md relu' want 'instructions-non-parvenues blocked AGENTS.md relu'
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (10m27s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"b886b13da782d7c233fbd0a851a4f1be1b8a1be6","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `bin/fm-classify-lib.sh:483` - FM_OPEN_DECISIONS_FOLD_VERSION reste a 4 alors que la semantique de _fm_decision_fold_line change (une ligne &#39;blocked: corr=&lt;hex&gt; [key=x] ...&#39; se plie desormais sous &#39;x&#39; au lieu de &#39;default&#39;). La doc du fichier (bin/fm-classify-lib.sh:443-445) exige un bump a chaque changement de semantique du pli, et les deux changements precedents l&#39;ont fait (2-&gt;3 pour #2202, le fix analogue colon-first; 3-&gt;4 pour #2280). Sans bump, un sidecar de curseur ecrit avant le fix (state/.&lt;task&gt;.open-decisions-cursor, version=4) reste valide: le pli incremental (status_open_decisions_incremental ne relit jamais les octets consommes, lignes 592-599; scan_open_decisions_incremental alimente la section OPEN DECISIONS de bin/fm-wake-drain.sh:137) continue de presenter le fantome &#39;default&#39; ouvert a jamais, tandis que le pli complet (fm-send --resolve-key, bin/fm-send.sh:424) rend &#39;ferme&#39; et refuse tout append de resolution - exactement la divergence des deux lecteurs que ce fix pretend eliminer durablement, desormais sans voie de purge supportee. Correctif: bumper FM_OPEN_DECISIONS_FOLD_VERSION a 5 pour invalider les curseurs pre-fix et rejouer le pli depuis l&#39;octet 0 (idealement avec un test de regression qui pre-seed un curseur v4 contenant le fantome &#39;default&#39; et verifie que le pli incremental le reconstruit).
- ⚠️ `bin/fm-classify-lib.sh:230` - Le motif &#34;$first&#34;[[:space:]]\[key=* n&#39;accepte qu&#39;UN caractere d&#39;espacement entre le token corr et &#39;[key=&#39;: &#39;blocked: corr=9c91ae0ff46cdca1  [key=x] note&#39; (deux espaces, ou tab+espace) n&#39;est pas skippe, la ligne rouvre &#39;default&#39; et un &#39;resolved [key=x]:&#39; ulterieur redevient un no-op - la panne d&#39;origine a un espace pres. Le chemin sans corr tolere pourtant un run d&#39;espaces (trim de tete en bin/fm-classify-lib.sh:247) et le commentaire de la helper dit &#39;when &#34;[key=&#34; is the very next token&#39;. Correctif: apres validation hex du token, remplacer le case par strip du token (rest=${note#&#34;$first&#34;}), trim du run d&#39;espaces (rest=${rest#&#34;${rest%%[![:space:]]*}&#34;}) puis test de prefixe &#39;case &#34;$rest&#34; in \[key=*)&#39; avant d&#39;affecter note=$rest.

🔧 Fix: bump fold version to 5, widen corr whitespace skip
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `tests/fm-send-resolve-key.test.sh` - Quatre suites citées dans les critères d&#39;acceptation n&#39;ont pas pu être exécutées localement : le hook pare-feu de la machine (~/.claude/hooks/pre-tool-use-firewall.mjs) refuse d&#39;exécuter tout script contenant &#39;chmod&#39;, or fm-wake-drain-open-decisions-cursor (suite complète), fm-decision-hold-lifecycle, fm-send-resolve-key et fm-pending-reply créent leurs shims fakebin avec &#39;chmod +x&#39;. Compensations effectuées sans contourner le pare-feu : le seul nouveau test du curseur (test_pre_fix_v4_cursor_ghost_default_is_refolded_closed) a été extrait dans un pilote sans chmod et passe, et le comportement de fm-send --resolve-key a été exercé en E2E sur le journal réel. La CI distante doit confirmer ces suites complètes ; l&#39;auteur peut aussi vouloir ajuster l&#39;allowlist du hook pour que les suites du dépôt redeviennent exécutables localement.
- <code>`bash tests/fm-classify-decision-key.test.sh` - 19 ok, dont les 6 nouveaux tests bare-corr (critère 1)</code>
- <code>`bash tests/fm-wake-drain-open-decisions.test.sh` - 8 ok, câblage réel du drain</code>
- <code>Extraction sans chmod de `test_pre_fix_v4_cursor_ghost_default_is_refolded_closed` (tests/fm-wake-drain-open-decisions-cursor.test.sh) exécutée contre le vrai drain - ok, un curseur v4 portant le fantôme &#39;default&#39; est replié fermé</code>
- `Rouge-avant/vert-après : le fichier de test du worktree exécuté contre la lib de base 1cb900c échoue avec le défaut exact ('default' + corr en tête de note)`
- <code>E2E journal réel : copie de /Users/max/Documents/projects/firstmate/state/maxisport.status rejouée dans `fm-wake-drain.sh` et `fm-send maxisport --resolve-key instructions-non-parvenues` avec l&#39;arbre de base puis l&#39;arbre corrigé - divergence reproduite avant, verdict commun « fermée » (pli vide) après (critère 2)</code>
- <code>E2E clé réellement ouverte (journal sans resolved) : le drain corrigé liste `[key=instructions-non-parvenues]` et fm-send passe la porte de refus, n&#39;échouant qu&#39;à la livraison tmux du bac à sable (critère 3)</code>
- <code>`git status --porcelain` final vide - aucun résidu de test dans le worktree</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
