### PR TITLE
fix(bin): keep claude busy hooks out of the project worktree

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -184,7 +184,7 @@ The shared symptom is a healthy-looking pane with no work in progress, so each a
 
 | Fact | Value |
 |---|---|
-| Crew hook delivery | `claude --settings <state/<id>.claude-settings.json>`, never a file inside the worktree. Claude merges those hooks with the project's own settings instead of replacing them (live-verified 2026-08-20 on 2.1.237; [`supervision.md`](../../../docs/verification/supervision.md) owns the evidence and refresh command). |
+| Crew hook delivery | `claude --settings <state/<id>.claude-settings.json>`, never a file inside the worktree. Claude merges those hooks with the project's own settings instead of replacing them (live-verified 2026-08-20 on 2.1.237; [`supervision.md`](../../../docs/verification/supervision.md) owns the evidence and refresh command). A spawn given a RAW launch command whose basename is `claude` cannot be guaranteed to carry `--settings`, so `fm-spawn` writes no settings file and arms no busy contract for it, and the task classifies `unknown missing` rather than a permanently stuck busy. |
 | Busy state | Owned lifecycle hooks: `UserPromptSubmit` opens a turn, while `Stop`, `StopFailure`, and `SessionEnd` close it; because Claude fires no hook for a manual interrupt, `bin/fm-control.sh interrupt` reports only delivered keys and the verified endpoint or live agent, publishes no idle event, makes no cancellation claim, and leaves adapter-observed state unchanged, so a mid-turn worker typically remains busy via `claude-hook`. |
 | Exit command | `/exit` |
 | Interrupt | single Escape |
@@ -296,6 +296,7 @@ The decision persists per path in `~/.pi/agent/trust.json`, so later spawns in t
 
 `fm-spawn` keeps the turn-end extension in `state/`, outside the worktree, because project-local extension files make the trust gate strictly worse and pollute the project.
 The extension must listen for pi's `turn_end` event, not `agent_end`, so the watcher wakes after each completed turn instead of only when the whole agent run exits.
+Known gap, PRE-EXISTING and not introduced by the claude settings work: a spawn given a RAW launch command whose basename is `pi` still arms the busy contract even though the extension rides `-e __PIEXT__` in the template only, so those hooks never load and the task can stay busy.
 Pi sets `PI_CODING_AGENT=true` for its children; this is its harness-detection env marker.
 
 **Primary-session guard fact (verified 2026-07-09, Pi 0.80.5).**

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -184,6 +184,7 @@ The shared symptom is a healthy-looking pane with no work in progress, so each a
 
 | Fact | Value |
 |---|---|
+| Crew hook delivery | `claude --settings <state/<id>.claude-settings.json>`, never a file inside the worktree. Claude merges those hooks with the project's own settings instead of replacing them (live-verified 2026-08-20 on 2.1.237; [`supervision.md`](../../../docs/verification/supervision.md) owns the evidence and refresh command). |
 | Busy state | Owned lifecycle hooks: `UserPromptSubmit` opens a turn, while `Stop`, `StopFailure`, and `SessionEnd` close it; because Claude fires no hook for a manual interrupt, `bin/fm-control.sh interrupt` reports only delivered keys and the verified endpoint or live agent, publishes no idle event, makes no cancellation claim, and leaves adapter-observed state unchanged, so a mid-turn worker typically remains busy via `claude-hook`. |
 | Exit command | `/exit` |
 | Interrupt | single Escape |
@@ -203,7 +204,7 @@ That styled capture is internal to the boolean detector only.
 `fm-peek` and every other human or LLM-facing capture path stays plain `tmux capture-pane` with no escape codes.
 
 **Primary-session guard fact (verified 2026-07-04, Claude Code 2.1.201; preserved 2026-07-08, Claude Code 2.1.204; Stop-owned auto-arm revalidated 2026-07-24, Claude Code 2.1.219).**
-This is separate from the per-task crewmate turn-end hook above (that one just `touch`es a marker file in a task's own `.claude/settings.local.json`).
+This is separate from the per-task crewmate turn-end hook above, which `touch`es a marker file from hooks `fm-spawn` hands the worker through `claude --settings <state/<id>.claude-settings.json>`; firstmate writes no claude settings file into a worktree, so a project's own `.claude/settings.local.json` is never touched.
 The firstmate PRIMARY's own `.claude/settings.json` registers two Stop hooks: `bin/fm-turnend-guard.sh --claude` and the Stop-owned auto-arm `bin/fm-claude-stop-autoarm.sh` (`asyncRewake: true`, `timeout: 28800`), and exiting the guard with status 2 plus stderr reliably forces the model to continue.
 Claude Code's stdin payload to a Stop hook carries a `stop_hook_active` boolean that is `true` when the current stop attempt follows ANY stop-hook-driven continuation, including `asyncRewake` rewakes; the primary guard therefore ignores it in `--claude` mode and uses the cooperative claim/epoch check plus a bounded re-block budget instead, while the codex-mode default still treats it as a one-block loop guard.
 A project-level `.claude/settings.json` only takes effect when Claude Code's project root is that exact directory - it does not walk up from a subdirectory looking for one, so firstmate launches the primary from the repo root.
@@ -528,7 +529,7 @@ Both halves of the fold are trusted with no opt-in: an open run reads `busy`, a 
 
 muse fans out to its own sub-agents, but worktree isolation is per-child and opt-in: `--subagent-worktree-isolation` is a compatibility flag whose capability "defaults on" while "omission stays shared", and no nested git worktree appeared in any verified lab run.
 Firstmate deliberately does NOT exclude any muse path from `fm-teardown.sh`'s uncommitted-work check.
-Firstmate writes `.claude/settings.local.json` itself, which is why that path is excluded for claude; it does not write muse's, so a nested muse worktree or leftover scratch is the agent's own work product and MUST be able to refuse teardown.
+Firstmate writes no harness file into a worktree for claude either - its hooks ride `--settings` from `state/` - so nothing under `.claude/` is excluded from that check any more; a nested muse worktree or leftover scratch is likewise the agent's own work product and MUST be able to refuse teardown.
 A teardown refusal naming muse scratch is therefore correct behavior: inspect it rather than forcing past it.
 
 ### Maturity caveats

--- a/bin/fm-busy-lib.sh
+++ b/bin/fm-busy-lib.sh
@@ -174,6 +174,14 @@ fm_busy_current_gen() {  # <state-dir> <id>
   printf '%s' "$gen"
 }
 
+# The claude-hook lifecycle contract, as <settings-key>:<event-token> pairs.
+# bin/fm-spawn.sh EMITS exactly these four hook entries into
+# state/<id>.claude-settings.json, and bin/fm-teardown.sh proves ownership of a
+# pre-2026-08-20 worktree leftover against the same list, so the writer and the
+# ownership proof cannot drift apart.
+# shellcheck disable=SC2034 # read by bin/fm-spawn.sh and bin/fm-teardown.sh
+FM_BUSY_CLAUDE_HOOK_EVENTS='UserPromptSubmit:user-prompt-submit Stop:stop StopFailure:stop-failure SessionEnd:session-end'
+
 # fm_busy_sources_for_harness: the semantic sources trusted to classify a
 # task recorded with <harness>. One line, space-separated, possibly empty.
 # The firstmate-owned sources are appended for every converted adapter.

--- a/bin/fm-control-lib.sh
+++ b/bin/fm-control-lib.sh
@@ -204,7 +204,7 @@ fm_control_harness_wiring_paths() {  # <harness> <worktree> <state-dir> <id>
   local harness=${1-} wt=${2-} state=${3-} id=${4-}
   [ -n "$wt" ] && [ -n "$state" ] && [ -n "$id" ] || return 1
   case "$harness" in
-    claude) printf '%s\n' "$wt/.claude/settings.local.json" ;;
+    claude) printf '%s\n' "$state/$id.claude-settings.json" ;;
     opencode) printf '%s\n' "$wt/.opencode/plugins/fm-busy-state.js" ;;
     pi|pi-signed) printf '%s\n' "$state/$id.pi-ext.ts" ;;
     grok)

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2392,13 +2392,19 @@ if [ "$KIND" != secondmate ]; then
         claude_settings="$STATE_REAL/$ID.claude-settings.json"
         busy_cmd_prefix="$(shell_quote "$FM_ROOT/bin/fm-busy-event.sh") apply $(shell_quote "$STATE_REAL") $(shell_quote "$ID")"
         busy_suffix="--gen $(shell_quote "$BUSY_GEN") --source claude-hook"
-        j_submit=$(json_escape "$busy_cmd_prefix busy $busy_suffix --event user-prompt-submit 2>/dev/null || true")
-        j_stop=$(json_escape "touch $(shell_quote "$TURNEND"); $busy_cmd_prefix idle $busy_suffix --event stop 2>/dev/null || true")
-        j_stopfail=$(json_escape "$busy_cmd_prefix idle $busy_suffix --event stop-failure 2>/dev/null || true")
-        j_sessionend=$(json_escape "$busy_cmd_prefix idle $busy_suffix --event session-end 2>/dev/null || true")
-        cat > "$claude_settings" <<EOF
-{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"$j_submit"}]}],"Stop":[{"hooks":[{"type":"command","command":"$j_stop"}]}],"StopFailure":[{"hooks":[{"type":"command","command":"$j_stopfail"}]}],"SessionEnd":[{"hooks":[{"type":"command","command":"$j_sessionend"}]}]}}
-EOF
+        claude_hook_entries=
+        for claude_hook_pair in $FM_BUSY_CLAUDE_HOOK_EVENTS; do
+          claude_hook_key=${claude_hook_pair%%:*}
+          claude_hook_event=${claude_hook_pair#*:}
+          case "$claude_hook_key" in
+            UserPromptSubmit) claude_hook_cmd="$busy_cmd_prefix busy $busy_suffix" ;;
+            Stop) claude_hook_cmd="touch $(shell_quote "$TURNEND"); $busy_cmd_prefix idle $busy_suffix" ;;
+            *) claude_hook_cmd="$busy_cmd_prefix idle $busy_suffix" ;;
+          esac
+          claude_hook_cmd=$(json_escape "$claude_hook_cmd --event $claude_hook_event 2>/dev/null || true")
+          claude_hook_entries="$claude_hook_entries${claude_hook_entries:+,}\"$claude_hook_key\":[{\"hooks\":[{\"type\":\"command\",\"command\":\"$claude_hook_cmd\"}]}]"
+        done
+        printf '{"hooks":{%s}}\n' "$claude_hook_entries" > "$claude_settings"
       fi
       ;;
     opencode*)

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1195,9 +1195,11 @@ launch_template() {
   esac
 }
 
+RAW_LAUNCH=0
 case "$ARG3" in
   *' '*)  # raw launch command (unverified-adapter escape hatch)
     LAUNCH=$ARG3
+    RAW_LAUNCH=1
     HARNESS=""
     for word in $LAUNCH; do
       case "$word" in [A-Za-z_]*=*) continue ;; *) HARNESS=$(basename "$word"); break ;; esac
@@ -2333,13 +2335,25 @@ if [ "$KIND" != secondmate ]; then
       fi
       ;;
   esac
+  # A raw launch command is the operator's verbatim string, so nothing can
+  # guarantee it carries the --settings flag that loads claude's busy hooks.
+  # Arming there would seed a busy record nothing could ever clear, and
+  # permanently busy is strictly worse than unknown because supervision never
+  # re-examines a busy task. Decline like codex and muse do when no verified
+  # wiring exists; the classifier then reports unknown missing.
+  CLAUDE_BUSY_WIRING=1
+  case "$HARNESS" in
+    claude*) [ "$RAW_LAUNCH" -eq 0 ] || CLAUDE_BUSY_WIRING=0 ;;
+  esac
   case "$HARNESS" in
     claude*|opencode*|pi|pi-signed)
-      BUSY_GEN=$("$FM_ROOT/bin/fm-busy-event.sh" arm "$STATE_REAL" "$ID") || {
-        echo "error: failed to arm the busy-state contract for $ID" >&2
-        exit 1
-      }
-      [ "$RELAUNCH" -ne 1 ] || RELAUNCH_REPLACEMENT_BUSY_GEN=$BUSY_GEN
+      if [ "$CLAUDE_BUSY_WIRING" -eq 1 ]; then
+        BUSY_GEN=$("$FM_ROOT/bin/fm-busy-event.sh" arm "$STATE_REAL" "$ID") || {
+          echo "error: failed to arm the busy-state contract for $ID" >&2
+          exit 1
+        }
+        [ "$RELAUNCH" -ne 1 ] || RELAUNCH_REPLACEMENT_BUSY_GEN=$BUSY_GEN
+      fi
       ;;
     kimi*)
       # Standalone Kimi stays unknown until fm_busy_kimi_verified opens on a
@@ -2371,16 +2385,21 @@ if [ "$KIND" != secondmate ]; then
       # permanently modified, which then blocked teardown. --settings is Claude's
       # own supported way to load additional settings from an arbitrary path, and
       # its hooks merge with (never replace) the project's own.
-      claude_settings="$STATE_REAL/$ID.claude-settings.json"
-      busy_cmd_prefix="$(shell_quote "$FM_ROOT/bin/fm-busy-event.sh") apply $(shell_quote "$STATE_REAL") $(shell_quote "$ID")"
-      busy_suffix="--gen $(shell_quote "$BUSY_GEN") --source claude-hook"
-      j_submit=$(json_escape "$busy_cmd_prefix busy $busy_suffix --event user-prompt-submit 2>/dev/null || true")
-      j_stop=$(json_escape "touch $(shell_quote "$TURNEND"); $busy_cmd_prefix idle $busy_suffix --event stop 2>/dev/null || true")
-      j_stopfail=$(json_escape "$busy_cmd_prefix idle $busy_suffix --event stop-failure 2>/dev/null || true")
-      j_sessionend=$(json_escape "$busy_cmd_prefix idle $busy_suffix --event session-end 2>/dev/null || true")
-      cat > "$claude_settings" <<EOF
+      #
+      # A raw launch command arms no busy generation (see above), so there is
+      # nothing to wire and no settings file is written for it either.
+      if [ "$CLAUDE_BUSY_WIRING" -eq 1 ]; then
+        claude_settings="$STATE_REAL/$ID.claude-settings.json"
+        busy_cmd_prefix="$(shell_quote "$FM_ROOT/bin/fm-busy-event.sh") apply $(shell_quote "$STATE_REAL") $(shell_quote "$ID")"
+        busy_suffix="--gen $(shell_quote "$BUSY_GEN") --source claude-hook"
+        j_submit=$(json_escape "$busy_cmd_prefix busy $busy_suffix --event user-prompt-submit 2>/dev/null || true")
+        j_stop=$(json_escape "touch $(shell_quote "$TURNEND"); $busy_cmd_prefix idle $busy_suffix --event stop 2>/dev/null || true")
+        j_stopfail=$(json_escape "$busy_cmd_prefix idle $busy_suffix --event stop-failure 2>/dev/null || true")
+        j_sessionend=$(json_escape "$busy_cmd_prefix idle $busy_suffix --event session-end 2>/dev/null || true")
+        cat > "$claude_settings" <<EOF
 {"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"$j_submit"}]}],"Stop":[{"hooks":[{"type":"command","command":"$j_stop"}]}],"StopFailure":[{"hooks":[{"type":"command","command":"$j_stopfail"}]}],"SessionEnd":[{"hooks":[{"type":"command","command":"$j_sessionend"}]}]}}
 EOF
+      fi
       ;;
     opencode*)
       mkdir -p "$WT/.opencode/plugins"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -161,7 +161,11 @@
 #     __OPINPUT__   absolute path to the canonical operational-input encoder
 #     __WORKTREE__  absolute path to the task worktree
 #     __CURSORBIN__ resolved, cursor-verified executable for a cursor launch
+#     __CLAUDESETTINGS__ absolute path to state/<id>.claude-settings.json for a claude crewmate or scout
 # Verified per-harness turn-end hooks are installed automatically where enabled; some live outside the worktree.
+# claude uses state/<id>.claude-settings.json handed to the launch through --settings,
+# so no file is written into the worktree; claude merges those hooks with the
+# project's own settings instead of replacing them.
 # Kimi uses one surgically installed Firstmate region in $HOME/.kimi-code/config.toml,
 # a firstmate-owned global hook and registry, and a gitignored per-task pointer.
 # grok uses a firstmate-owned global hook under ${GROK_HOME:-$HOME/.grok}/hooks
@@ -1111,7 +1115,18 @@ launch_template() {
     # does NOT suppress the interactive ghost text (verified empirically), so the env
     # var is the correct control. The dim-aware composer reader in fm-tmux-lib.sh is
     # the defense-in-depth backstop for any pane this flag cannot reach.
-    claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    # --settings carries the semantic busy-state hooks from a firstmate-owned file
+    # in state/, so nothing is ever written inside the worktree - the same
+    # keep-it-out-of-the-project reasoning grok, kimi, and pi already follow.
+    # Claude merges --settings hooks with the project's own settings rather than
+    # replacing them, so a project's committed hooks keep firing (verified below).
+    # A secondmate arms no busy contract, so no settings file exists for it and the
+    # flag is omitted rather than pointed at a missing path.
+    claude)
+      printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions '
+      [ "$kind" = secondmate ] || printf '%s' '--settings __CLAUDESETTINGS__ '
+      printf '%s' '__MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+      ;;
     codex)
       if [ "$kind" = secondmate ]; then
         printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
@@ -2348,17 +2363,24 @@ if [ "$KIND" != secondmate ]; then
       # the turn-ended NOTIFICATION touch for the watcher. Every
       # hook command tolerates a refused event (|| true) so a stale-gen writer
       # can never break Claude's own lifecycle.
-      mkdir -p "$WT/.claude"
+      #
+      # The settings file lives in state/, NOT in the worktree. A worktree write
+      # would have to land on .claude/settings.local.json, a path the PROJECT owns
+      # and frequently tracks; firstmate wrote it wholesale, destroying the
+      # project's own settings for the life of the task and leaving a tracked file
+      # permanently modified, which then blocked teardown. --settings is Claude's
+      # own supported way to load additional settings from an arbitrary path, and
+      # its hooks merge with (never replace) the project's own.
+      claude_settings="$STATE_REAL/$ID.claude-settings.json"
       busy_cmd_prefix="$(shell_quote "$FM_ROOT/bin/fm-busy-event.sh") apply $(shell_quote "$STATE_REAL") $(shell_quote "$ID")"
       busy_suffix="--gen $(shell_quote "$BUSY_GEN") --source claude-hook"
       j_submit=$(json_escape "$busy_cmd_prefix busy $busy_suffix --event user-prompt-submit 2>/dev/null || true")
       j_stop=$(json_escape "touch $(shell_quote "$TURNEND"); $busy_cmd_prefix idle $busy_suffix --event stop 2>/dev/null || true")
       j_stopfail=$(json_escape "$busy_cmd_prefix idle $busy_suffix --event stop-failure 2>/dev/null || true")
       j_sessionend=$(json_escape "$busy_cmd_prefix idle $busy_suffix --event session-end 2>/dev/null || true")
-      cat > "$WT/.claude/settings.local.json" <<EOF
+      cat > "$claude_settings" <<EOF
 {"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"$j_submit"}]}],"Stop":[{"hooks":[{"type":"command","command":"$j_stop"}]}],"StopFailure":[{"hooks":[{"type":"command","command":"$j_stopfail"}]}],"SessionEnd":[{"hooks":[{"type":"command","command":"$j_sessionend"}]}]}}
 EOF
-      exclude_path '.claude/settings.local.json'
       ;;
     opencode*)
       mkdir -p "$WT/.opencode/plugins"
@@ -2708,6 +2730,7 @@ fi
 sq_brief=$(shell_quote "$BRIEF")
 sq_turnend=$(shell_quote "$TURNEND")
 sq_piext=$(shell_quote "$STATE/$ID.pi-ext.ts")
+sq_claudesettings=$(shell_quote "$STATE_REAL/$ID.claude-settings.json")
 sq_piturnend=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-turnend-guard.ts")
 sq_piwatch=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts")
 sq_opinput=$(shell_quote "$FM_ROOT/bin/fm-operational-input.sh")
@@ -2719,6 +2742,7 @@ LAUNCH=${LAUNCH//__EFFORTFLAG__/$EFFORTFLAG}
 LAUNCH=${LAUNCH//__BRIEF__/$sq_brief}
 LAUNCH=${LAUNCH//__TURNEND__/$sq_turnend}
 LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}
+LAUNCH=${LAUNCH//__CLAUDESETTINGS__/$sq_claudesettings}
 LAUNCH=${LAUNCH//__PITURNEND__/$sq_piturnend}
 LAUNCH=${LAUNCH//__PIWATCH__/$sq_piwatch}
 LAUNCH=${LAUNCH//__OPINPUT__/$sq_opinput}

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1134,6 +1134,21 @@ teardown_treehouse_return() {
   return 1
 }
 
+# One-time migration: before 2026-08-20 the claude spawn wrote its hooks into
+# <worktree>/.claude/settings.local.json and excluded that path in the repo's
+# info/exclude, so a leftover from a task already under way at update time stays
+# invisible to git status and its stale hooks would fire for the NEXT task in a
+# pooled worktree. Remove ONLY a file firstmate provably wrote: untracked, and
+# carrying firstmate's own busy-event command. A tracked or project-authored file
+# is never touched - that path belongs to the project.
+remove_legacy_claude_settings() {  # <worktree>
+  local wt=$1 f="$1/.claude/settings.local.json"
+  [ -f "$f" ] || return 0
+  git -C "$wt" ls-files --error-unmatch -- .claude/settings.local.json >/dev/null 2>&1 && return 0
+  grep -q 'fm-busy-event.sh' "$f" 2>/dev/null || return 0
+  rm -f "$f"
+}
+
 validate_worktree_teardown_safety() {
   local dirty_raw dirty unpushed_raw unpushed DEFAULT unmerged_raw unmerged branch
   [ -d "$WT" ] || return 0
@@ -1150,7 +1165,11 @@ validate_worktree_teardown_safety() {
     echo "Restore the git index state, or get the captain's explicit OK to discard, then --force." >&2
     return 1
   fi
-  dirty=$(printf '%s\n' "$dirty_raw" | grep -vE '^\?\? (\.claude/|\.fm-(grok|kimi)-turnend$)' | head -1 || true)
+  # Only firstmate's OWN per-task worktree artifacts are ignored. .claude/ is
+  # deliberately NOT among them: firstmate writes no claude file into a worktree
+  # (its hooks ride --settings from state/), so anything there is the project's or
+  # the worker's and must be able to refuse teardown.
+  dirty=$(printf '%s\n' "$dirty_raw" | grep -vE '^\?\? \.fm-(grok|kimi)-turnend$' | head -1 || true)
 
   if ! unpushed_raw=$(git -C "$WT" log --oneline HEAD --not --remotes -- 2>/dev/null); then
     if worktree_safety_blocked_by_lock "commits not on a remote"; then
@@ -2226,13 +2245,15 @@ cleanup_firstmate_home_children() {
     elif [ "$child_backend" = orca ]; then
       if [ -n "$child_wt" ] && [ -d "$child_wt" ]; then
         validate_child_worktree_for_removal "$child_wt" "$child_proj" >/dev/null || return 1
-        rm -f "$child_wt/.claude/settings.local.json" "$child_wt/.opencode/plugins/fm-turn-end.js" \
+        remove_legacy_claude_settings "$child_wt"
+        rm -f "$child_wt/.opencode/plugins/fm-turn-end.js" \
           "$child_wt/.fm-grok-turnend" "$child_wt/.fm-kimi-turnend"
       fi
       fm_backend_remove_worktree "$child_backend" "$child_orca_worktree_id" || return 1
     elif [ -n "$child_wt" ] && [ -d "$child_wt" ]; then
       validate_child_worktree_for_removal "$child_wt" "$child_proj" >/dev/null || return 1
-      rm -f "$child_wt/.claude/settings.local.json" "$child_wt/.opencode/plugins/fm-turn-end.js" \
+      remove_legacy_claude_settings "$child_wt"
+      rm -f "$child_wt/.opencode/plugins/fm-turn-end.js" \
         "$child_wt/.opencode/plugins/fm-busy-state.js" \
         "$child_wt/.fm-grok-turnend" "$child_wt/.fm-kimi-turnend"
       if [ -n "$child_proj" ] && [ -d "$child_proj" ] && command -v treehouse >/dev/null 2>&1; then
@@ -2260,6 +2281,7 @@ cleanup_firstmate_home_children() {
     status_retire_presentation_task "$sub_state" "$child_id" || return 1
     rm -f "$sub_state/$child_id.turn-ended" \
       "$sub_state/$child_id.meta" "$sub_state/$child_id.pi-ext.ts" \
+      "$sub_state/$child_id.claude-settings.json" \
       "$sub_state/$child_id.grok-turnend-token" "$sub_state/$child_id.kimi-turnend-token" \
       "$sub_state/$child_id.muse-session" "$sub_state/$child_id.muse-session-current" \
       "$sub_state/$child_id.cursor-session"
@@ -2420,7 +2442,8 @@ if [ "$BACKEND" = orca ] && [ "$KIND" != secondmate ]; then
         git -C "$WT" branch -D "$branch" >/dev/null 2>&1 || true
       fi
     fi
-    rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" \
+    remove_legacy_claude_settings "$WT"
+    rm -f "$WT/.opencode/plugins/fm-turn-end.js" \
       "$WT/.opencode/plugins/fm-busy-state.js" \
       "$WT/.fm-grok-turnend" "$WT/.fm-kimi-turnend"
   fi
@@ -2434,7 +2457,8 @@ elif [ -d "$WT" ] && [ "$KIND" != secondmate ]; then
     fi
   fi
   # Remove our hook file so a reused pool worktree cannot fire signals for a dead task.
-  rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" \
+  remove_legacy_claude_settings "$WT"
+  rm -f "$WT/.opencode/plugins/fm-turn-end.js" \
     "$WT/.fm-grok-turnend" "$WT/.fm-kimi-turnend"
   # Kills remaining processes in the worktree (including the agent), resets, returns
   # to pool. treehouse resolves the pool from the working directory, so run it from
@@ -2539,7 +2563,8 @@ remove_pr_poll_artifacts "$STATE" "$ID" || exit 1
 retire_busy_state "$STATE" "$ID" "$BUSY_GEN" || exit 1
 status_retire_presentation_task "$STATE" "$ID" || exit 1
 rm -f "$STATE/$ID.turn-ended" "$STATE/$ID.meta" \
-  "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token" \
+  "$STATE/$ID.pi-ext.ts" "$STATE/$ID.claude-settings.json" \
+  "$STATE/$ID.grok-turnend-token" \
   "$STATE/$ID.kimi-turnend-token" "$STATE/$ID.muse-session" \
   "$STATE/$ID.muse-session-current" "$STATE/$ID.cursor-session" \
   "$STATE/$ID.control-relaunch" "$STATE/$ID.control-relaunch.meta-prior" \

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -168,6 +168,8 @@ SUB_HOME_PARENT_MARKER=".fm-secondmate-parent"
 . "$SCRIPT_DIR/fm-wake-lib.sh"
 # shellcheck source=bin/fm-nm-run-lib.sh
 . "$SCRIPT_DIR/fm-nm-run-lib.sh"
+# shellcheck source=bin/fm-busy-lib.sh
+. "$SCRIPT_DIR/fm-busy-lib.sh"
 if [ "$#" -lt 1 ] || ! fm_task_id_path_safe "$1"; then
   echo "error: invalid teardown request" >&2
   exit 2
@@ -1139,13 +1141,33 @@ teardown_treehouse_return() {
 # info/exclude, so a leftover from a task already under way at update time stays
 # invisible to git status and its stale hooks would fire for the NEXT task in a
 # pooled worktree. Remove ONLY a file firstmate provably wrote: untracked, and
-# carrying firstmate's own busy-event command. A tracked or project-authored file
-# is never touched - that path belongs to the project.
+# carrying firstmate's own busy-event command bound to EVERY event of the
+# claude-hook lifecycle contract (FM_BUSY_CLAUDE_HOOK_EVENTS in
+# bin/fm-busy-lib.sh, the same list bin/fm-spawn.sh emits from, so the writer and
+# this proof cannot drift apart). A bare fm-busy-event.sh substring was not
+# enough: a captain's own hand-written settings file in a firstmate checkout may
+# wire one such hook itself, and deleting that is exactly the data loss this
+# branch exists to stop. Anything short of the full shape is preserved, and a
+# tracked or project-authored file is never touched - that path belongs to the
+# project.
+#
+# This migration deliberately runs AFTER validate_worktree_teardown_safety, so it
+# only ever reaches a leftover git status cannot see, which is the case the old
+# spawn's info/exclude entry creates. If that exclude line is absent the leftover
+# is visible as an untracked file, teardown refuses first, and a human clears it
+# by hand. That is an accepted best-effort limitation and it fails in the safe
+# direction. Do NOT move the migration ahead of the dirty check: it would delete a
+# file before the safety gate ran and suppress a legitimate refusal.
 remove_legacy_claude_settings() {  # <worktree>
-  local wt=$1 f="$1/.claude/settings.local.json"
+  local wt=$1 f="$1/.claude/settings.local.json" pair key event
   [ -f "$f" ] || return 0
   git -C "$wt" ls-files --error-unmatch -- .claude/settings.local.json >/dev/null 2>&1 && return 0
-  grep -q 'fm-busy-event.sh' "$f" 2>/dev/null || return 0
+  for pair in $FM_BUSY_CLAUDE_HOOK_EVENTS; do
+    key=${pair%%:*}
+    event=${pair#*:}
+    grep -q "\"$key\"" "$f" 2>/dev/null || return 0
+    grep -q "fm-busy-event.sh.*--event $event" "$f" 2>/dev/null || return 0
+  done
   rm -f "$f"
 }
 

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -187,7 +187,7 @@ family_for_basename() {
     fm-cmux-claude-composer-live-e2e.test.sh|\
     fm-composer-matrix-live-e2e.test.sh|\
     fm-codex-continuity-live-e2e.test.sh|fm-grok-continuity-live-e2e.test.sh|\
-    fm-cursor-primary-live-e2e.test.sh|\
+    fm-cursor-primary-live-e2e.test.sh|fm-claude-settings-live-e2e.test.sh|\
     fm-grok-stop-live-e2e.test.sh|fm-harness-liveness-drift-live-e2e.test.sh|\
     fm-muse-signals-live-e2e.test.sh|\
     fm-herdr-version-floor-live-e2e.test.sh|\
@@ -949,7 +949,15 @@ families_for_changed_path() {
       printf '%s\n' pure-contract-unit
       printf '%s\n' live-harness-optin
       ;;
-    bin/fm-spawn.sh|bin/fm-send.sh|bin/fm-harness.sh|\
+    bin/fm-spawn.sh)
+      # The claude branch rests on a vendor CLI fact - that --settings loads hooks
+      # from outside the workspace and merges them with the project's own - so a
+      # spawn change re-selects the live guard alongside the portable families.
+      printf '%s\n' backend-dispatch
+      printf '%s\n' pure-contract-unit
+      printf '%s\n' live-harness-optin
+      ;;
+    bin/fm-send.sh|bin/fm-harness.sh|\
     bin/fm-peek.sh|bin/fm-composer*)
       printf '%s\n' backend-dispatch
       printf '%s\n' pure-contract-unit

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -211,6 +211,9 @@ Hooks from `--settings` are therefore MERGED with the project's own rather than 
 
 This replaces the pre-2026-08-20 behavior, where the spawn wrote `<worktree>/.claude/settings.local.json` wholesale.
 On a project that tracks that path, the spawn destroyed its committed contents for the life of the task and left the tracked file permanently modified, which then blocked `bin/fm-teardown.sh` and re-escalated the finished task on every watcher pass.
+`bin/fm-teardown.sh` removes a leftover pre-fix file only when it is untracked AND carries firstmate's own `fm-busy-event.sh` command, so a tracked or project-authored file is never touched.
+One residue is deliberately left: the old spawn also appended `.claude/settings.local.json` to each project's shared `.git/info/exclude`, which outlives teardown and keeps a project's OWN untracked settings file hidden from `git status` repo-wide.
+It is not auto-removed because nothing proves firstmate rather than the operator wrote a given exclude line; remove it by hand if that repo needs its settings file visible.
 
 Refresh command, opt-in and self-skipping, which fails naming the installed version:
 

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -197,6 +197,27 @@ In this 2026-07-28 Codex 0.145.0 semantic-busy probe, Firstmate-written lifecycl
 Codex also exposes no `StopFailure` hook, so an API-error turn end would need separate coverage even after hook discovery works.
 The app-server protocol schema does define the required lifecycle (`turn/started`, plus a `turn/completed` status of `completed`, `interrupted`, `failed`, or `inProgress`), so the gate is a reachability problem rather than a protocol gap.
 
+### Claude hooks load from outside the workspace, 2026-08-20
+
+Claude's per-task busy hooks are delivered through `claude --settings <file>` and live in `state/<id>.claude-settings.json`, so `fm-spawn` writes nothing into the project worktree.
+Verified on 2026-08-20 against Claude Code 2.1.237 in a throwaway workspace holding its own `.claude/settings.local.json` with a `Stop` hook of its own.
+
+```sh
+claude --dangerously-skip-permissions --settings /tmp/fmprobe-external.json -p "say hi"
+```
+
+All three markers were created: the project `Stop` hook, and the `Stop` and `UserPromptSubmit` hooks supplied only through `--settings`.
+Hooks from `--settings` are therefore MERGED with the project's own rather than replacing them, and the project's settings file was byte-identical after the run.
+
+This replaces the pre-2026-08-20 behavior, where the spawn wrote `<worktree>/.claude/settings.local.json` wholesale.
+On a project that tracks that path, the spawn destroyed its committed contents for the life of the task and left the tracked file permanently modified, which then blocked `bin/fm-teardown.sh` and re-escalated the finished task on every watcher pass.
+
+Refresh command, opt-in and self-skipping, which fails naming the installed version:
+
+```sh
+FM_CLAUDE_SETTINGS_LIVE_E2E=1 tests/fm-claude-settings-live-e2e.test.sh
+```
+
 Deterministic entry points:
 
 ```sh

--- a/tests/fm-busy-adapter-wiring.test.sh
+++ b/tests/fm-busy-adapter-wiring.test.sh
@@ -365,6 +365,27 @@ JSON
   pass "a claude spawn arms its hooks without writing anything into the project worktree"
 }
 
+# A raw launch command is the operator's verbatim string, so nothing can
+# guarantee it carries the --settings flag that loads claude's hooks. Arming
+# there seeds a busy record nothing can ever clear, which is strictly worse than
+# unknown because supervision never re-examines a busy task.
+test_claude_raw_launch_arms_no_unclearable_busy() {
+  local rec id=busy-cl-4 out state
+  rec=$(make_spawn_case claude-raw-launch claude "$id")
+  read_case_record "$rec"
+  out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id" "$PROJ_DIR" 'claude --dangerously-skip-permissions')
+  expect_code 0 $? "raw-launch claude spawn should succeed: $out"
+  state="$HOME_DIR/state"
+  assert_absent "$state/$id.claude-settings.json" \
+    "a raw launch command cannot be guaranteed to load a settings file, so none must be written"
+  assert_absent "$state/$id.busy-gen" \
+    "a raw launch command must not arm a busy generation nothing can clear"
+  out=$(classify claude "$id" "$state")
+  [ "$out" = "unknown missing" ] \
+    || fail "raw-launch claude must classify unknown, never a permanently stuck busy, got '$out'"
+  pass "a raw-launch claude spawn declines the busy contract and classifies unknown"
+}
+
 test_codex_unverified_until_a_semantic_source_exists() {
   local rec id=busy-cx-1 out state
   rec=$(make_spawn_case codex-unverified codex "$id")
@@ -405,6 +426,7 @@ test_opencode_plugin_semantic_lifecycle
 test_claude_hooks_semantic_lifecycle
 test_claude_hooks_stale_incarnation_harmless
 test_claude_spawn_never_touches_the_projects_settings
+test_claude_raw_launch_arms_no_unclearable_busy
 test_codex_unverified_until_a_semantic_source_exists
 
 echo "all fm-busy-adapter-wiring tests passed"

--- a/tests/fm-busy-adapter-wiring.test.sh
+++ b/tests/fm-busy-adapter-wiring.test.sh
@@ -30,7 +30,10 @@ esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
   list-windows) exit 0 ;;
-  has-session|new-session|new-window|kill-window|send-keys) exit 0 ;;
+  send-keys)
+    [ -z "${FM_FAKE_TMUX_LOG:-}" ] || printf '%s\n' "$*" >> "$FM_FAKE_TMUX_LOG"
+    exit 0 ;;
+  has-session|new-session|new-window|kill-window) exit 0 ;;
 esac
 exit 0
 SH
@@ -263,7 +266,7 @@ test_claude_hooks_semantic_lifecycle() {
   out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id" "$PROJ_DIR")
   expect_code 0 $? "claude spawn should succeed: $out"
   state="$HOME_DIR/state"
-  settings="$WT_DIR/.claude/settings.local.json"
+  settings="$state/$id.claude-settings.json"
   assert_present "$settings" "claude spawn did not write hook settings"
   jq -e . "$settings" >/dev/null || fail "claude hook settings are not valid JSON"
   for ev in UserPromptSubmit Stop StopFailure SessionEnd; do
@@ -301,13 +304,65 @@ test_claude_hooks_stale_incarnation_harmless() {
   out=$(run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id" "$PROJ_DIR")
   expect_code 0 $? "claude spawn should succeed: $out"
   state="$HOME_DIR/state"
-  settings="$WT_DIR/.claude/settings.local.json"
+  settings="$state/$id.claude-settings.json"
   "$ROOT/bin/fm-busy-event.sh" arm "$state" "$id" >/dev/null
   run_claude_hook "$settings" UserPromptSubmit \
     || fail "a stale-gen hook must still exit 0 so Claude's lifecycle is never broken"
   out=$(classify claude "$id" "$state")
   [ "$out" = "busy fm-spawn" ] || fail "a stale-gen hook event must not change state, got '$out'"
   pass "claude hook events from a superseded incarnation are rejected without breaking the hook"
+}
+
+# Regression (observed 2026-08-20 on a real project): the claude branch used to
+# write <worktree>/.claude/settings.local.json WHOLESALE. On a project that tracks
+# that file, the spawn destroyed its committed contents for the life of the task
+# and left the tracked file permanently modified, which then blocked teardown and
+# produced an endless stale-wake loop. firstmate now writes no file into the
+# worktree at all: the hooks ride claude's own --settings flag from state/.
+test_claude_spawn_never_touches_the_projects_settings() {
+  local rec id=busy-cl-3 out state settings tracked before after launch_log
+  rec=$(make_spawn_case claude-project-settings claude "$id")
+  read_case_record "$rec"
+
+  # A project that TRACKS .claude/settings.local.json with real content, landed on
+  # the default branch so the spawn's base refresh brings it into the worktree.
+  mkdir -p "$PROJ_DIR/.claude"
+  cat > "$PROJ_DIR/.claude/settings.local.json" <<'JSON'
+{"env":{"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS":"1"},"permissions":{"allow":["Bash(npm test)"]},"enabledPlugins":{"context7":true}}
+JSON
+  git -C "$PROJ_DIR" add -f .claude/settings.local.json
+  git -C "$PROJ_DIR" -c user.email=t@t -c user.name=t commit -q -m "project settings"
+  git -C "$PROJ_DIR" push -q origin HEAD
+  before=$(cat "$PROJ_DIR/.claude/settings.local.json")
+  tracked="$WT_DIR/.claude/settings.local.json"
+
+  launch_log="$CASE_DIR/launch.log"
+  out=$(FM_FAKE_TMUX_LOG="$launch_log" run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$id" "$PROJ_DIR")
+  expect_code 0 $? "claude spawn should succeed: $out"
+  state="$HOME_DIR/state"
+
+  assert_present "$tracked" "the project's tracked settings must be present in the worktree"
+  after=$(cat "$tracked")
+  [ "$after" = "$before" ] \
+    || fail "the project's tracked settings must survive the spawn byte for byte, got: $after"
+  [ -z "$(git -C "$WT_DIR" status --porcelain)" ] \
+    || fail "the spawn must leave the worktree clean, got: $(git -C "$WT_DIR" status --porcelain)"
+  [ ! -e "$WT_DIR/.claude/settings.json" ] \
+    || fail "the spawn must not write any other claude settings file into the worktree"
+
+  # The hooks are armed all the same, from a firstmate-owned file outside the worktree.
+  settings="$state/$id.claude-settings.json"
+  assert_present "$settings" "claude spawn did not write its own hook settings into state/"
+  assert_grep "--settings '$(cd "$state" && pwd -P)/$id.claude-settings.json'" "$launch_log" \
+    "the launch command must load the hooks through claude's own --settings flag"
+  assert_no_grep "$WT_DIR/.claude" "$launch_log" \
+    "the launch command must not reference any claude settings inside the worktree"
+  rm -f "$state/$id.turn-ended"
+  run_claude_hook "$settings" Stop || fail "Stop hook command failed"
+  [ -f "$state/$id.turn-ended" ] || fail "the out-of-worktree hook no longer touches the marker"
+  out=$(classify claude "$id" "$state")
+  [ "$out" = "idle claude-hook" ] || fail "Stop must classify 'idle claude-hook', got '$out'"
+  pass "a claude spawn arms its hooks without writing anything into the project worktree"
 }
 
 test_codex_unverified_until_a_semantic_source_exists() {
@@ -349,6 +404,7 @@ test_kimi_and_grok_install_no_unverified_wiring
 test_opencode_plugin_semantic_lifecycle
 test_claude_hooks_semantic_lifecycle
 test_claude_hooks_stale_incarnation_harmless
+test_claude_spawn_never_touches_the_projects_settings
 test_codex_unverified_until_a_semantic_source_exists
 
 echo "all fm-busy-adapter-wiring tests passed"

--- a/tests/fm-claude-settings-live-e2e.test.sh
+++ b/tests/fm-claude-settings-live-e2e.test.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Opt-in live guard for the one vendor fact bin/fm-spawn.sh's claude branch rests on:
+# `claude --settings <file>` loads hooks from a path OUTSIDE the workspace, and those
+# hooks are MERGED with the project's own settings rather than replacing them.
+#
+# That is what lets firstmate arm per-task busy-state hooks without writing anything
+# into the project worktree. A stub claude could only echo the assumption back, so
+# this exercises the installed binary for real and fails naming its version.
+set -u
+
+if [ "${FM_CLAUDE_SETTINGS_LIVE_E2E:-0}" != 1 ]; then
+  echo "skip: set FM_CLAUDE_SETTINGS_LIVE_E2E=1 to run the live claude --settings guard"
+  exit 0
+fi
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+command -v claude >/dev/null 2>&1 || fail "claude not found; this guard requires the installed binary"
+CLAUDE_VERSION=$(claude --version 2>/dev/null | head -1)
+[ -n "$CLAUDE_VERSION" ] || fail "installed claude did not answer --version"
+
+LAB=$(fm_test_tmproot fm-claude-settings-live)
+WORKSPACE="$LAB/workspace"
+mkdir -p "$WORKSPACE/.claude"
+git -C "$LAB" init -q "$WORKSPACE"
+
+# The project's own committed settings, with content firstmate must never touch and
+# a hook of its own that must keep firing.
+cat > "$WORKSPACE/.claude/settings.local.json" <<JSON
+{"env":{"FM_LIVE_PROJECT_KEY":"kept"},
+ "hooks":{"Stop":[{"hooks":[{"type":"command","command":"touch '$LAB/project-stop'"}]}]}}
+JSON
+PROJECT_BEFORE=$(cat "$WORKSPACE/.claude/settings.local.json")
+
+# Firstmate's own settings, shaped like the file bin/fm-spawn.sh writes into state/.
+cat > "$LAB/fm-settings.json" <<JSON
+{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"touch '$LAB/fm-submit'"}]}],
+          "Stop":[{"hooks":[{"type":"command","command":"touch '$LAB/fm-stop'"}]}]}}
+JSON
+
+( cd "$WORKSPACE" && claude --dangerously-skip-permissions \
+    --settings "$LAB/fm-settings.json" -p "reply with the single word ok" ) \
+  > "$LAB/out" 2> "$LAB/err" < /dev/null \
+  || fail "claude $CLAUDE_VERSION refused the --settings launch: $(cat "$LAB/err")"
+
+[ -e "$LAB/fm-submit" ] \
+  || fail "claude $CLAUDE_VERSION did not fire the UserPromptSubmit hook supplied through --settings"
+[ -e "$LAB/fm-stop" ] \
+  || fail "claude $CLAUDE_VERSION did not fire the Stop hook supplied through --settings"
+[ -e "$LAB/project-stop" ] \
+  || fail "claude $CLAUDE_VERSION let --settings REPLACE the project's own hooks instead of merging them"
+[ "$(cat "$WORKSPACE/.claude/settings.local.json")" = "$PROJECT_BEFORE" ] \
+  || fail "claude $CLAUDE_VERSION rewrote the project's settings file during the run"
+
+pass "claude $CLAUDE_VERSION loads --settings hooks from outside the workspace and merges them with the project's own"
+echo "all fm-claude-settings-live-e2e tests passed"

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -414,15 +414,15 @@ test_harness_switch_moves_the_record_and_clears_prior_wiring() {
   local dir out rc
   dir=$(new_case switch rl4)
   add_ship_task "$dir" rl4 claude
-  # Wiring the previous claude incarnation left in the worktree.
-  mkdir -p "$dir/wt/.claude"
-  printf '{"hooks":{}}\n' > "$dir/wt/.claude/settings.local.json"
+  # Wiring the previous claude incarnation left behind. It lives in state/, never
+  # in the worktree - firstmate writes no claude file into a project checkout.
+  printf '{"hooks":{}}\n' > "$dir/home/state/rl4.claude-settings.json"
   printf 'codex' > "$dir/fake/becomes"
   out=$(run_control "$dir" rl4 relaunch --harness codex --note "switching runtime"); rc=$?
   expect_code 0 "$rc" "a harness switch should succeed"$'\n'"$out"
   assert_contains "$out" "harness=codex from=claude" "the outcome should name both harnesses"
   [ "$(meta_field "$dir" rl4 harness)" = codex ] || fail "the record should follow the switch"
-  [ ! -e "$dir/wt/.claude/settings.local.json" ] \
+  [ ! -e "$dir/home/state/rl4.claude-settings.json" ] \
     || fail "the previous harness's per-task wiring must be cleared on a switch"
   assert_grep "codex" "$dir/fake/literal" "the replacement launch should be the new harness"
   [ "$(journal_field "$dir" rl4 from_harness)" = claude ] || fail "the journal should record the origin harness"
@@ -561,8 +561,7 @@ test_wiring_removal_failure_refuses_before_replacement_arm() {
   local dir hook out rc real_rm
   dir=$(new_case wiring-failure rl29)
   add_ship_task "$dir" rl29 claude
-  hook="$dir/wt/.claude/settings.local.json"
-  mkdir -p "${hook%/*}"
+  hook="$dir/home/state/rl29.claude-settings.json"
   printf '{}\n' > "$hook"
   real_rm=$(command -v rm)
   make_rm_failure_stub "$dir"
@@ -1034,7 +1033,7 @@ test_prepublication_abort_retires_replacement_wiring_and_busy_state() {
   expect_code 1 "$rc" "a failed metadata publication should fail closed"$'\n'"$out"
   [ "$(meta_field "$dir" rl28 harness)" = claude ] \
     || fail "a failed publication should retain the prior durable record"
-  [ ! -e "$dir/wt/.claude/settings.local.json" ] \
+  [ ! -e "$dir/home/state/rl28.claude-settings.json" ] \
     || fail "an aborted replacement should remove its harness wiring"
   [ ! -e "$dir/home/state/rl28.busy-gen" ] \
     || fail "an aborted replacement should retire its busy generation"

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -165,7 +165,9 @@ test_no_profile_keeps_claude_profile_defaults() {
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude default default
 
   launch=$(cat "$LAUNCH_LOG")
-  expected="env -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/brief.md')\""
+  # The per-task busy hooks ride --settings from state/, so no file is written into
+  # the worktree (bin/fm-spawn.sh's claude branch).
+  expected="env -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions --settings '$(cd "$HOME_DIR/state" && pwd -P)/$id.claude-settings.json' \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/brief.md')\""
   [ "$launch" = "$expected" ] || fail "no-profile claude launch did not use the canonical launch kind"$'\n'"expected: $expected"$'\n'"actual:   $launch"
   pass "no --model/--effort records defaults and types the claude launch instructions"
 }
@@ -429,8 +431,8 @@ test_claude_threads_model_and_effort() {
   expect_code 0 "$status" "claude spawn with profile flags should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude sonnet high
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "claude --dangerously-skip-permissions --model 'sonnet' --effort 'high'" \
-    "claude launch did not thread model and effort flags"
+  assert_contains "$launch" "--settings '$(cd "$HOME_DIR/state" && pwd -P)/$id.claude-settings.json' --model 'sonnet' --effort 'high'" \
+    "claude launch did not thread model and effort flags after its out-of-worktree hook settings"
   assert_not_contains "$launch" "--tui-mode" "non-Pi launches must not receive Pi's TUI mode override"
   pass "claude receives --model and --effort profile flags"
 }

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -931,6 +931,95 @@ test_dirty_worktree_refuses() {
   pass "dirty worktree is refused even when its committed work has landed (dirty always wins)"
 }
 
+# Regression (observed 2026-08-20 on a real project): the claude spawn used to
+# write <worktree>/.claude/settings.local.json wholesale, and teardown used to
+# `rm -f` that same path while its dirty check ignored everything untracked under
+# .claude/. Both halves treated a PROJECT-owned path as firstmate's own. firstmate
+# now writes nothing into the worktree for claude, so teardown must leave .claude/
+# exactly as it found it - and anything untracked there is the project's or the
+# worker's work and must be able to refuse teardown like any other dirty file.
+test_teardown_leaves_the_projects_claude_settings_alone() {
+  local case_dir rc before after
+  case_dir=$(make_case claude-settings-kept)
+  write_meta "$case_dir" no-mistakes ship
+  fm_write_meta "$case_dir/state/task-x1.meta" \
+    "window=firstmate:fm-task-x1" "endpoint_task_id=task-x1" \
+    "worktree=$case_dir/wt" "project=$case_dir/project" \
+    "kind=ship" "mode=no-mistakes" "harness=claude"
+  mkdir -p "$case_dir/wt/.claude"
+  printf '%s\n' '{"permissions":{"allow":["Bash(npm test)"]}}' \
+    > "$case_dir/wt/.claude/settings.local.json"
+  git -C "$case_dir/wt" add -f -- .claude/settings.local.json
+  git -C "$case_dir/wt" -c user.email=t@t -c user.name=t commit -q -m "project settings"
+  before=$(cat "$case_dir/wt/.claude/settings.local.json")
+  # Land the branch content so the safety check allows teardown.
+  git -C "$case_dir/wt" push -q origin HEAD:main
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "claude-settings-kept: teardown should allow landed work"$'\n'"$(cat "$case_dir/stderr")"
+  [ -f "$case_dir/wt/.claude/settings.local.json" ] \
+    || fail "claude-settings-kept: teardown deleted the project's own settings file"
+  after=$(cat "$case_dir/wt/.claude/settings.local.json")
+  [ "$after" = "$before" ] \
+    || fail "claude-settings-kept: teardown rewrote the project's settings, got: $after"
+  pass "teardown leaves a project's tracked .claude/settings.local.json exactly as it found it"
+}
+
+test_untracked_claude_file_refuses_teardown() {
+  local case_dir rc
+  case_dir=$(make_case claude-untracked-dirty)
+  write_meta "$case_dir" no-mistakes ship
+  wt_commit_file "$case_dir" feature.txt hello "add feature"
+  git -C "$case_dir/wt" push -q origin HEAD:main
+  # A file the WORKER wrote under .claude/, not firstmate's own wiring.
+  mkdir -p "$case_dir/wt/.claude/agents"
+  printf '%s\n' 'reviewer agent' > "$case_dir/wt/.claude/agents/reviewer.md"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "claude-untracked-dirty: an untracked .claude/ file is not firstmate's to discard"
+  grep -q "uncommitted changes" "$case_dir/stderr" \
+    || fail "claude-untracked-dirty: refusal did not cite uncommitted changes"
+  pass "an untracked file under .claude/ refuses teardown instead of being silently discarded"
+}
+
+test_legacy_firstmate_claude_leftover_is_removed() {
+  local case_dir rc
+  case_dir=$(make_case claude-legacy-leftover)
+  write_meta "$case_dir" no-mistakes ship
+  wt_commit_file "$case_dir" feature.txt hello "add feature"
+  git -C "$case_dir/wt" push -q origin HEAD:main
+  # Exactly what a pre-2026-08-20 claude spawn left behind: firstmate's own hooks,
+  # untracked and hidden from git status by the exclude entry that spawn also wrote.
+  mkdir -p "$case_dir/wt/.claude"
+  printf '%s\n' '{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"/x/bin/fm-busy-event.sh apply /s id idle"}]}]}}' \
+    > "$case_dir/wt/.claude/settings.local.json"
+  mkdir -p "$case_dir/project/.git/info"
+  printf '%s\n' '.claude/settings.local.json' >> "$case_dir/project/.git/info/exclude"
+  # A project file next to it, which teardown must not touch.
+  printf '%s\n' 'keep me' > "$case_dir/wt/.claude/project-note.md"
+  printf '%s\n' '.claude/project-note.md' >> "$case_dir/project/.git/info/exclude"
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "claude-legacy-leftover: teardown should allow landed work"$'\n'"$(cat "$case_dir/stderr")"
+  [ ! -e "$case_dir/wt/.claude/settings.local.json" ] \
+    || fail "claude-legacy-leftover: firstmate's own pre-fix hook file must not survive teardown"
+  [ -f "$case_dir/wt/.claude/project-note.md" ] \
+    || fail "claude-legacy-leftover: teardown removed a file firstmate never wrote"
+  pass "teardown removes only the pre-fix hook file firstmate itself wrote under .claude/"
+}
+
 test_gh_error_and_content_absent_refuses() {
   local case_dir rc
   case_dir=$(make_case gh-error)
@@ -2621,6 +2710,9 @@ test_pr_check_records_remote_head_when_local_lags
 test_content_in_default_fallback_allows
 test_content_fallback_refreshes_stale_origin_ref
 test_dirty_worktree_refuses
+test_teardown_leaves_the_projects_claude_settings_alone
+test_untracked_claude_file_refuses_teardown
+test_legacy_firstmate_claude_leftover_is_removed
 test_gh_error_and_content_absent_refuses
 test_stale_index_lock_cleared_and_teardown_succeeds
 test_live_index_lock_is_never_removed_and_teardown_refuses

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -990,6 +990,20 @@ test_untracked_claude_file_refuses_teardown() {
   pass "an untracked file under .claude/ refuses teardown instead of being silently discarded"
 }
 
+# The full four-event lifecycle shape a pre-2026-08-20 claude spawn wrote into
+# the worktree, which is what proves the leftover is firstmate's own.
+write_legacy_claude_hooks() {  # <path>
+  local cmd='/x/bin/fm-busy-event.sh apply /s id'
+  {
+    printf '%s' '{"hooks":{'
+    printf '"UserPromptSubmit":[{"hooks":[{"type":"command","command":"%s busy --gen g --source claude-hook --event user-prompt-submit"}]}],' "$cmd"
+    printf '"Stop":[{"hooks":[{"type":"command","command":"touch /s/id.turn-ended; %s idle --gen g --source claude-hook --event stop"}]}],' "$cmd"
+    printf '"StopFailure":[{"hooks":[{"type":"command","command":"%s idle --gen g --source claude-hook --event stop-failure"}]}],' "$cmd"
+    printf '"SessionEnd":[{"hooks":[{"type":"command","command":"%s idle --gen g --source claude-hook --event session-end"}]}]' "$cmd"
+    printf '%s\n' '}}'
+  } > "$1"
+}
+
 test_legacy_firstmate_claude_leftover_is_removed() {
   local case_dir rc
   case_dir=$(make_case claude-legacy-leftover)
@@ -999,8 +1013,7 @@ test_legacy_firstmate_claude_leftover_is_removed() {
   # Exactly what a pre-2026-08-20 claude spawn left behind: firstmate's own hooks,
   # untracked and hidden from git status by the exclude entry that spawn also wrote.
   mkdir -p "$case_dir/wt/.claude"
-  printf '%s\n' '{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"/x/bin/fm-busy-event.sh apply /s id idle"}]}]}}' \
-    > "$case_dir/wt/.claude/settings.local.json"
+  write_legacy_claude_hooks "$case_dir/wt/.claude/settings.local.json"
   mkdir -p "$case_dir/project/.git/info"
   printf '%s\n' '.claude/settings.local.json' >> "$case_dir/project/.git/info/exclude"
   # A project file next to it, which teardown must not touch.
@@ -1018,6 +1031,36 @@ test_legacy_firstmate_claude_leftover_is_removed() {
   [ -f "$case_dir/wt/.claude/project-note.md" ] \
     || fail "claude-legacy-leftover: teardown removed a file firstmate never wrote"
   pass "teardown removes only the pre-fix hook file firstmate itself wrote under .claude/"
+}
+
+# A hand-written settings file may wire an fm-busy-event.sh hook of its own
+# without ever being firstmate's. Only the full four-event lifecycle shape proves
+# firstmate wrote the file; anything short of it must survive teardown.
+test_handwritten_claude_settings_with_busy_hook_is_preserved() {
+  local case_dir rc before after
+  case_dir=$(make_case claude-handwritten-busy-hook)
+  write_meta "$case_dir" no-mistakes ship
+  wt_commit_file "$case_dir" feature.txt hello "add feature"
+  git -C "$case_dir/wt" push -q origin HEAD:main
+  mkdir -p "$case_dir/wt/.claude"
+  printf '%s\n' '{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"/x/bin/fm-busy-event.sh apply /s id idle --event stop"}]}]},"permissions":{"allow":["Bash(npm test)"]}}' \
+    > "$case_dir/wt/.claude/settings.local.json"
+  mkdir -p "$case_dir/project/.git/info"
+  printf '%s\n' '.claude/settings.local.json' >> "$case_dir/project/.git/info/exclude"
+  before=$(cat "$case_dir/wt/.claude/settings.local.json")
+
+  set +e
+  run_teardown "$case_dir" > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "claude-handwritten-busy-hook: teardown should allow landed work"$'\n'"$(cat "$case_dir/stderr")"
+  [ -f "$case_dir/wt/.claude/settings.local.json" ] \
+    || fail "claude-handwritten-busy-hook: a hand-written settings file must survive teardown"
+  after=$(cat "$case_dir/wt/.claude/settings.local.json")
+  [ "$after" = "$before" ] \
+    || fail "claude-handwritten-busy-hook: the hand-written file must be untouched, got: $after"
+  pass "teardown preserves a hand-written settings file that merely wires an fm-busy-event.sh hook"
 }
 
 test_gh_error_and_content_absent_refuses() {
@@ -2713,6 +2756,7 @@ test_dirty_worktree_refuses
 test_teardown_leaves_the_projects_claude_settings_alone
 test_untracked_claude_file_refuses_teardown
 test_legacy_firstmate_claude_leftover_is_removed
+test_handwritten_claude_settings_with_busy_hook_is_preserved
 test_gh_error_and_content_absent_refuses
 test_stale_index_lock_cleared_and_teardown_succeeds
 test_live_index_lock_is_never_removed_and_teardown_refuses


### PR DESCRIPTION
## Intent

Stop firstmate from destroying a project's tracked .claude/settings.local.json.

The defect, observed 2026-08-20: spawning a Claude crewmate writes the busy-event hooks into <worktree>/.claude/settings.local.json, and it writes the file WHOLESALE. On the cosmic-show-hub project that file is TRACKED and had real content: a CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS env entry, a permissions.allow list, and an enabledPlugins entry for context7. The spawn replaced all of it with just the hooks block. Two consequences, both real: (1) the project's committed settings are silently destroyed in that worktree for the life of the task; (2) because the file is tracked, every spawn leaves the worktree permanently dirty, which then blocks fm-teardown.sh after the work has merged, producing an endless stale-wake loop where the watcher re-escalated the finished task every few minutes until it was cleared by hand.

What to build: firstmate must be able to install its hooks without destroying content it does not own. Two acceptable designs were named: (a) merge firstmate's hooks into the existing file, preserving every key firstmate does not own, and restore the original on teardown, safe when the file is absent, present-and-empty, malformed, or read-only; or (b) follow the existing Grok/Kimi precedent and keep the hooks outside the worktree entirely so no project file is touched at all, which removes the whole class of bug rather than mitigating it. The choice had to be argued from what Claude Code actually supports, not from preference. Whatever was built, teardown must leave the worktree exactly as it found it, because the pooled-worktree contract depends on it. The task also required checking whether the same wholesale-write pattern exists anywhere else in the spawn path for any harness, and reporting what was found. Definition of done: the no-mistakes pipeline through a green PR, regression tests for both the preservation and the clean teardown, and a note on whether any other harness had the same flaw.

Decisions made while doing the work, which a reviewer reading only the diff would not know:

Design chosen: option (b), hooks outside the worktree, argued from a live probe rather than preference. Claude Code's documented --settings flag (documented as "Path to a settings JSON file or a JSON string to load additional settings from") loads additional settings from an arbitrary path. Verified live on Claude Code 2.1.237 in a throwaway workspace that had its own .claude/settings.local.json with a Stop hook: running claude --dangerously-skip-permissions --settings <external.json> -p "say hi" created all three marker files - the project's own Stop hook, plus the Stop and UserPromptSubmit hooks supplied only through --settings. So --settings MERGES with the project's settings rather than replacing them. That makes the merge-into-the-file design strictly worse: it would still touch a project file, still need restore-on-teardown, still need absent/empty/malformed/read-only handling, and would still leave a tracked file dirty mid-task. Firstmate now writes zero files into the worktree for claude, matching what grok, kimi and pi already do.

Root cause was deliberately fixed in all three places it manifested, not just the reported one: (1) bin/fm-spawn.sh's claude branch now writes state/<id>.claude-settings.json and passes it via --settings, dropping the mkdir -p of $WT/.claude and the .git/info/exclude entry; (2) bin/fm-teardown.sh no longer removes <worktree>/.claude/settings.local.json at any of its four cleanup sites - that removal was unconditional and ran for EVERY harness, not just claude; (3) teardown's dirty check previously filtered untracked paths under .claude/, which silently discarded any untracked file a worker wrote anywhere under .claude/. That exclusion is now removed entirely, so anything under .claude/ belongs to the project or the worker and can refuse teardown like any other dirty file. The reported symptom came from the tracked case: git status shows a modified marker, which never matched the untracked-only filter, so teardown refused and the watcher re-escalated forever.

Deliberate scope decisions: a one-time migration helper remove_legacy_claude_settings was added to teardown, because a task already under way at update time still has firstmate's pre-fix file sitting in its worktree, hidden from git status by the exclude entry the old spawn also wrote, and its stale hooks would then fire for the next task in a pooled worktree. It removes the file ONLY when it is untracked AND contains firstmate's own fm-busy-event.sh command, so a tracked or project-authored file is provably never touched. A per-spawn probe of claude --help for the --settings flag was written and then deliberately REMOVED: an unsupported flag makes claude refuse to start, so the spawn readiness gate already fails loudly, and the probe would have added a subprocess per spawn plus a second place to keep in sync. Secondmates arm no busy contract, so the launch template omits --settings for kind=secondmate rather than pointing it at a file that does not exist.

Verification, following firstmate's own harness-dependent-check rule that a vendor-emitted fact must be proven end to end against the real harness and not against a stub: a new opt-in live guard tests/fm-claude-settings-live-e2e.test.sh (gated on FM_CLAUDE_SETTINGS_LIVE_E2E=1, self-skipping) exercises the installed binary and fails naming its version, and bin/fm-spawn.sh was added to the live-harness-optin family in bin/fm-test-run.sh so a spawn change re-selects it. The dated evidence and the refresh command are recorded in docs/verification/supervision.md.

Regression tests cover both directions as required: in tests/fm-busy-adapter-wiring.test.sh a project that tracks .claude/settings.local.json with real content (landed on the default branch so the spawn's base refresh brings it in) survives a real fm-spawn byte for byte with git status empty, the launch command carries --settings pointing outside the worktree, and the hooks still drive the busy classifier. In tests/fm-teardown.test.sh: the tracked file survives teardown unchanged; an untracked file under .claude/ now refuses teardown instead of being silently discarded; and a pre-fix firstmate leftover is removed while a neighbouring project file under .claude/ is not.

Audit result for the "does this exist elsewhere" requirement: no other harness has this flaw. opencode, grok, kimi, muse, cursor and pi all write either firstmate-named files (.fm-grok-turnend, .fm-kimi-turnend, fm-busy-state.js) or nothing inside the worktree at all; kimi's config.toml edit under the user's home is genuinely marker-delimited and atomic. One unrelated observation not fixed here: grok writes its global turn-end hook files non-atomically on every spawn without the validation guard kimi has.

Known caveat deliberately not addressed: the old exclude_path call appended .claude/settings.local.json to each project's SHARED .git/info/exclude, which outlives teardown and hides a project's own untracked settings file from git status repo-wide. It is not auto-removed because there is no way to prove firstmate wrote a given exclude line rather than the operator.

Pre-existing test failures on this machine, present on the untouched base commit and unrelated to this change, deliberately left alone rather than reaching into firstmate's herdr/secondmate safety code: fm-teardown's herdr-child-preflight case (herdr 0.8.0 installed), fm-secondmate-harness's crew-harness sweep case, and fm-test-run's ruby-missing YAML check. bin/fm-lint.sh passes; actionlint is not installed locally so workflow lint was skipped there.

Firstmate repo conventions that were followed and should not be flagged as omissions: knowledge was routed per the firstmate-coding-guidelines placement tree, so exact mechanics live in bin/fm-spawn.sh's own header rather than in AGENTS.md, situational adapter facts live in the harness-adapters skill, and dated empirical evidence lives in docs/verification/supervision.md; AGENTS.md was deliberately left unchanged because this change adds no always-loaded contract. bin/fm-doc-audience-check.sh passes.


DELIVERY NOTE (2026-08-20): the captain decided firstmate fixes land on his fork doitdigital0495/firstmate, not upstream kunchenguid/firstmate. The first run of this work opened upstream PR 2673, which was closed with a pointer to the replacement; a hand-created fork PR (doitdigital0495/firstmate#2) cannot pass the repo required check "PR must be raised via no-mistakes", which demands the deterministic ## Pipeline signature section only the pipeline writes. This run must therefore raise the PR itself against the fork main branch, which is now synced to upstream main 1cb900c. Do not hand-write that signature.

## What Changed

- `bin/fm-spawn.sh` now writes the claude busy-state hooks to `state/<id>.claude-settings.json` and hands them to the launch via `--settings` (new `__CLAUDESETTINGS__` placeholder), instead of overwriting `<worktree>/.claude/settings.local.json` and adding a `.git/info/exclude` entry; the hook set is generated from the shared `FM_BUSY_CLAUDE_HOOK_EVENTS` list added in `bin/fm-busy-lib.sh`, the flag is omitted for `kind=secondmate`, and a raw launch command no longer arms the busy contract at all since nothing guarantees it carries `--settings`.
- `bin/fm-teardown.sh` stops unconditionally deleting `<worktree>/.claude/settings.local.json` at all four cleanup sites, drops the `^?? \.claude/` exclusion from the dirty-worktree check so any untracked file under `.claude/` can refuse teardown, adds `remove_legacy_claude_settings` to clear only a pre-fix leftover that is untracked and matches firstmate's full hook shape, and removes `state/<id>.claude-settings.json` alongside the other per-task state files.
- Adds regression coverage for a tracked `.claude/settings.local.json` surviving spawn and teardown byte for byte (`tests/fm-busy-adapter-wiring.test.sh`, `tests/fm-teardown.test.sh`), plus an opt-in live guard `tests/fm-claude-settings-live-e2e.test.sh` (gated on `FM_CLAUDE_SETTINGS_LIVE_E2E=1`) wired into the live-harness opt-in family in `bin/fm-test-run.sh`; documents the `--settings` merge evidence in `docs/verification/supervision.md` and the harness-adapters skill.

## Risk Assessment

✅ Low: The change is well-bounded and removes an entire class of data loss by keeping firstmate's claude hooks outside the worktree, with regression tests covering both preservation and clean teardown; the remaining items are a narrow gap in the migration's ownership proof and one stale doc sentence, neither of which blocks merge.

## Testing

Exercised the real fm-spawn and fm-teardown scripts against a sandbox project that tracks .claude/settings.local.json, on both the target and the base commit. On the target the tracked file survives a spawn byte for byte, the worktree stays clean, the hooks are loaded from a firstmate-owned file outside the worktree via --settings and still drive the busy classifier, and teardown leaves the file untouched, refuses on a worker-written untracked .claude/ file, and removes only firstmate's own pre-fix leftover. The same checks fail on base 1cb900c, reproducing the reported defect exactly. The opt-in live guard confirmed against the installed claude 2.1.237 that --settings merges with the project's own settings. Two fm-teardown content-fallback cases fail on this machine, but they fail identically on the untouched base commit and are unrelated; because the harness aborts on first failure, the new claude cases were run from an out-of-worktree copy with those two skipped. No visual artifact applies - this change is CLI/filesystem behavior with no rendered surface - so evidence is captured as CLI transcripts.

<details>
<summary>Evidence: Target commit: real spawn leaves the project&#39;s tracked settings and the worktree untouched</summary>

Source: [Target commit: real spawn leaves the project&#39;s tracked settings and the worktree untouched](https://github.com/doitdigital0495/firstmate/blob/02544ab117d7618399870f15fe57c9ae6c8d9773/.no-mistakes/evidence/fm/fm-settings-clobber/claude-spawn-preserves-project-settings.txt)

<code>--- project&#39;s committed .claude/settings.local.json (before spawn) ---&#10;{&#34;env&#34;:{&#34;CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS&#34;:&#34;1&#34;},&#34;permissions&#34;:{&#34;allow&#34;:[&#34;Bash(npm test)&#34;]},&#34;enabledPlugins&#34;:{&#34;context7&#34;:true}}&#10;--- worktree .claude/settings.local.json (AFTER spawn) ---&#10;{&#34;env&#34;:{&#34;CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS&#34;:&#34;1&#34;},&#34;permissions&#34;:{&#34;allow&#34;:[&#34;Bash(npm test)&#34;]},&#34;enabledPlugins&#34;:{&#34;context7&#34;:true}}&#10;--- git -C &lt;worktree&gt; status --porcelain (AFTER spawn) ---&#10;(empty above = worktree clean)&#10;--- claude launch command captured from the tmux spawn ---&#10;--settings &#39;&lt;state&gt;/busy-cl-3.claude-settings.json&#39;</code>

```text
=== EVIDENCE: real fm-spawn.sh run, claude crewmate, project tracks .claude/settings.local.json ===

--- project's committed .claude/settings.local.json (before spawn) ---
{"env":{"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS":"1"},"permissions":{"allow":["Bash(npm test)"]},"enabledPlugins":{"context7":true}}
--- worktree .claude/settings.local.json (AFTER spawn) ---
{"env":{"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS":"1"},"permissions":{"allow":["Bash(npm test)"]},"enabledPlugins":{"context7":true}}
--- git -C <worktree> status --porcelain (AFTER spawn) ---
(empty above = worktree clean)
--- ls -A <worktree>/.claude ---
settings.local.json
--- firstmate hook settings written OUTSIDE the worktree ---
path: /tmp/fm-busy-adapter-wiring.YUpjFY/claude-project-settings/home/state/busy-cl-3.claude-settings.json
--- claude launch command captured from the tmux spawn ---
--settings '/tmp/fm-busy-adapter-wiring.YUpjFY/claude-project-settings/home/state/busy-cl-3.claude-settings.json' 
```
</details>
<details>
<summary>Evidence: Base commit 1cb900c: same spawn destroys the tracked settings and dirties the worktree (reported defect)</summary>

Source: [Base commit 1cb900c: same spawn destroys the tracked settings and dirties the worktree (reported defect)](https://github.com/doitdigital0495/firstmate/blob/02544ab117d7618399870f15fe57c9ae6c8d9773/.no-mistakes/evidence/fm/fm-settings-clobber/base-commit-destroys-project-settings.txt)

<code>--- worktree .claude/settings.local.json (AFTER spawn) ---&#10;{&#34;hooks&#34;:{&#34;UserPromptSubmit&#34;:[...fm-busy-event.sh...]},&#34;Stop&#34;:[...],&#34;StopFailure&#34;:[...],&#34;SessionEnd&#34;:[...]}}&#10;--- git -C &lt;worktree&gt; status --porcelain (AFTER spawn) ---&#10;M .claude/settings.local.json</code>

```text
=== EVIDENCE: real fm-spawn.sh run, claude crewmate, project tracks .claude/settings.local.json ===

--- project's committed .claude/settings.local.json (before spawn) ---
{"env":{"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS":"1"},"permissions":{"allow":["Bash(npm test)"]},"enabledPlugins":{"context7":true}}
--- worktree .claude/settings.local.json (AFTER spawn) ---
{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"'/tmp/fm-base-check/bin/fm-busy-event.sh' apply '/tmp/fm-busy-adapter-wiring.71wBSB/claude-project-settings/home/state' 'busy-cl-3' busy --gen 'g1787234554.549370.13731' --source claude-hook --event user-prompt-submit 2>/dev/null || true"}]}],"Stop":[{"hooks":[{"type":"command","command":"touch '/tmp/fm-busy-adapter-wiring.71wBSB/claude-project-settings/home/state/busy-cl-3.turn-ended'; '/tmp/fm-base-check/bin/fm-busy-event.sh' apply '/tmp/fm-busy-adapter-wiring.71wBSB/claude-project-settings/home/state' 'busy-cl-3' idle --gen 'g1787234554.549370.13731' --source claude-hook --event stop 2>/dev/null || true"}]}],"StopFailure":[{"hooks":[{"type":"command","command":"'/tmp/fm-base-check/bin/fm-busy-event.sh' apply '/tmp/fm-busy-adapter-wiring.71wBSB/claude-project-settings/home/state' 'busy-cl-3' idle --gen 'g1787234554.549370.13731' --source claude-hook --event stop-failure 2>/dev/null || true"}]}],"SessionEnd":[{"hooks":[{"type":"command","command":"'/tmp/fm-base-check/bin/fm-busy-event.sh' apply '/tmp/fm-busy-adapter-wiring.71wBSB/claude-project-settings/home/state' 'busy-cl-3' idle --gen 'g1787234554.549370.13731' --source claude-hook --event session-end 2>/dev/null || true"}]}]}}
--- git -C <worktree> status --porcelain (AFTER spawn) ---
 M .claude/settings.local.json
(empty above = worktree clean)
--- ls -A <worktree>/.claude ---
settings.local.json
--- firstmate hook settings written OUTSIDE the worktree ---
path: /tmp/fm-busy-adapter-wiring.71wBSB/claude-project-settings/home/state/busy-cl-3.claude-settings.json
--- claude launch command captured from the tmux spawn ---
```
</details>
<details>
<summary>Evidence: Teardown leaves the worktree exactly as it found it</summary>

Source: [Teardown leaves the worktree exactly as it found it](https://github.com/doitdigital0495/firstmate/blob/02544ab117d7618399870f15fe57c9ae6c8d9773/.no-mistakes/evidence/fm/fm-settings-clobber/teardown-leaves-worktree-as-found.txt)

<code>EVIDENCE 1 tracked settings: teardown exit 0, file identical before/after&#10;EVIDENCE 2 untracked .claude/agents/reviewer.md: teardown exit 1, &#34;REFUSED: worktree ... has uncommitted changes.&#34;, file still present&#10;EVIDENCE 3 pre-fix firstmate leftover: teardown exit 0, .claude/ now contains only project-note.md</code>

```text
=== EVIDENCE 1: teardown of a worktree whose project TRACKS .claude/settings.local.json ===
teardown exit code: 0  (0 = allowed)
--- file content before teardown ---
{"permissions":{"allow":["Bash(npm test)"]}}
--- file content after teardown ---
{"permissions":{"allow":["Bash(npm test)"]}}

=== EVIDENCE 2: a worker-written untracked file under .claude/ now refuses teardown ===
file: .claude/agents/reviewer.md
teardown exit code: 1  (1 = refused)
--- teardown stderr ---
REFUSED: worktree /tmp/fm-teardown-tests.dEsHDm/claude-untracked-dirty/wt has uncommitted changes.
uncommitted changes present
Commit them (or get the captain's explicit OK to discard, then --force).
--- file still present after refusal ---
reviewer.md

=== EVIDENCE 3: one-time migration of a pre-fix firstmate leftover ===
teardown exit code: 0  (0 = allowed)
--- .claude/ contents after teardown (firstmate hook file gone, project file kept) ---
project-note.md
```
</details>
<details>
<summary>Evidence: Live vendor-fact guard against installed claude</summary>

```text
$ FM_CLAUDE_SETTINGS_LIVE_E2E=1 bash tests/fm-claude-settings-live-e2e.test.sh
ok - claude 2.1.237 (Claude Code) loads --settings hooks from outside the workspace and merges them with the project's own
all fm-claude-settings-live-e2e tests passed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"6e74e5c804a31113a73432fa8d1e25f86151dbcb","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 3 infos</summary>

- ⚠️ `bin/fm-spawn.sh:2374` - Raw-launch-command spawns whose command basename is `claude` (the documented unverified-adapter escape hatch at fm-spawn.sh:1200-1206) no longer get busy hooks. The `case &#34;$HARNESS&#34; in claude*)` wiring block still writes state/&lt;id&gt;.claude-settings.json and the arm block at line 2336 still mints a busy generation seeding busy/fm-spawn, but the operator-supplied LAUNCH is used verbatim and contains no `--settings`, so nothing ever loads those hooks: the turn never closes to idle and state/&lt;id&gt;.turn-ended is never touched, leaving the task permanently busy to the watcher. Previously the file lived at &lt;worktree&gt;/.claude/settings.local.json, which Claude auto-loads regardless of launch flags, so this path worked. `pi` has the same shape pre-existing (its extension rides `-e __PIEXT__` in the template only), so this may be an accepted class rather than an oversight - decide whether to append `--settings` to a raw claude command, skip arming when the launch lacks the placeholder, or warn at spawn time.

🔧 Fix: stop arming claude busy contract on raw launch commands
2 infos still open:
- ℹ️ `bin/fm-teardown.sh:2445` - remove_legacy_claude_settings runs at 2445/2459/2248, but validate_worktree_teardown_safety already ran at 2385 and the .claude/ untracked filter was removed at 1165. The migration therefore only reaches a pre-fix leftover that git status cannot see. That holds for the normal case (the old spawn wrote the info/exclude entry in the same block, and info/exclude resolves to the shared common dir for a linked worktree, which is exactly what tests/fm-teardown.test.sh:990 models). If that exclude line is ever absent - the old exclude_path silently returned 0 whenever `git rev-parse --git-path info/exclude` produced nothing - the leftover shows as `?? .claude/settings.local.json`, teardown refuses, and the migration it needs never runs, which is the same endless stale-wake loop this branch is fixing. Running remove_legacy_claude_settings before the safety gate would close it; its untracked-AND-contains-fm-busy-event.sh gate already makes it safe to run early.
- ℹ️ `bin/fm-teardown.sh:1148` - The migration&#39;s ownership proof is `grep -q &#39;fm-busy-event.sh&#39;`, which matches any untracked .claude/settings.local.json that merely mentions that command - e.g. a captain&#39;s own local settings in a firstmate checkout that wires an fm-busy-event.sh hook by hand. Such a file would be deleted rather than preserved. Reachability is narrow (it must also be hidden from the dirty gate above, or teardown refuses first) and the alternative gates are no stronger, so this is worth knowing rather than changing; a tighter proof would be matching the exact hook shape fm-spawn wrote (the four-event UserPromptSubmit/Stop/StopFailure/SessionEnd object) instead of a bare command substring.

🔧 Fix: tighten legacy claude settings ownership proof in teardown
3 infos still open:
- ℹ️ `bin/fm-teardown.sh:1169` - remove_legacy_claude_settings now proves ownership with four whole-file greps, but it never proves the file contains ONLY firstmate&#39;s hooks. A pre-fix spawn wrote exactly {&#34;hooks&#34;:{...4 entries...}} and nothing else, so an untracked settings file that carries the four firstmate busy hooks AND additional project keys (permissions.allow, env, enabledPlugins) is still deleted wholesale. Two secondary looseness points in the same loop: the greps are whole-file, so key and command are never correlated to the same hook entry, and `--event stop` is a prefix of `--event stop-failure`, so the Stop-event proof is satisfied by the StopFailure entry alone. A dependency-free tightening that matches what the spawn actually emits: require the file to be a single `{&#34;hooks&#34;:{...}}` object with exactly the four keys and no other top-level key, and anchor the event match (`--event stop &#34;`/`--event stop 2&gt;`) so it cannot be satisfied by a sibling event.
- ℹ️ `docs/verification/supervision.md:214` - The doc still describes the pre-tightening gate: &#34;removes a leftover pre-fix file only when it is untracked AND carries firstmate&#39;s own `fm-busy-event.sh` command&#34;. Commit 6e74e5c changed the proof to require firstmate&#39;s busy-event command bound to ALL FOUR events of FM_BUSY_CLAUDE_HOOK_EVENTS; a bare fm-busy-event.sh substring is now explicitly not sufficient. Anyone reading supervision.md to decide whether their hand-written settings file is at risk gets the wrong (more alarming) answer. Update the sentence to name the four-event shape and FM_BUSY_CLAUDE_HOOK_EVENTS as the shared source of truth.
- ℹ️ `bin/fm-teardown.sh:1190` - Dropping `\.claude/` from the dirty-check filter is deliberate and stated in the intent, so this is a note rather than an objection. Operational consequence worth knowing: any untracked file a worker leaves under .claude/ (Claude Code writing settings.local.json on a permission/plugin change, a worker creating .claude/agents/*.md, scratch notes) now refuses teardown, which is the same refuse-then-watcher-re-escalates loop this branch exists to end - only now triggered by worker output instead of firstmate&#39;s own. It fails in the safe direction (refuse, never delete) and tests/fm-teardown.test.sh:test_untracked_claude_file_refuses_teardown pins it, so no change is requested; flagging only so the escalation path is expected rather than diagnosed as a regression later.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bin/fm-test-run.sh tests/fm-busy-adapter-wiring.test.sh` (all cases pass, including the new `a claude spawn arms its hooks without writing anything into the project worktree`)</code>
- <code>`bin/fm-test-run.sh tests/fm-teardown.test.sh` - stopped at the pre-existing `content-landed` failure, so the four new claude cases were re-run from an out-of-worktree copy of HEAD with only the two pre-existing failing invocations skipped: `teardown leaves a project&#39;s tracked .claude/settings.local.json exactly as it found it`, `an untracked file under .claude/ refuses teardown instead of being silently discarded`, `teardown removes only the pre-fix hook file firstmate itself wrote under .claude/`, `teardown preserves a hand-written settings file that merely wires an fm-busy-event.sh hook` - all pass</code>
- <code>Fail-before-fix check: ran the new `test_claude_spawn_never_touches_the_projects_settings` and `test_teardown_leaves_the_projects_claude_settings_alone` against a scratch checkout of base `1cb900c` - both fail (spawn replaced the tracked file with the hooks blob and left ` M .claude/settings.local.json`)</code>
- <code>Pre-existing-failure baseline: `bash tests/fm-teardown.test.sh` on a scratch checkout of base `1cb900c` reproduces both `content-landed` and `content-stale-ref` failures unchanged</code>
- <code>`FM_CLAUDE_SETTINGS_LIVE_E2E=1 bash tests/fm-claude-settings-live-e2e.test.sh` - live guard against installed claude 2.1.237, passes</code>
- <code>`bin/fm-test-run.sh tests/fm-control-relaunch.test.sh tests/fm-spawn-dispatch-profile.test.sh` - pass (cover the relocated harness wiring path in fm-control-lib.sh)</code>
- <code>Evidence capture: instrumented out-of-worktree copies of the spawn and teardown tests to dump the actual settings file content, `git status --porcelain`, worktree `.claude/` listing and the captured claude launch command before/after a real `bin/fm-spawn.sh` and `bin/fm-teardown.sh` run</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/configuration.md:243` - The leftover .git/info/exclude residue from the pre-fix spawn (a project&#39;s own untracked .claude/settings.local.json stays hidden from git status repo-wide) is recorded only in docs/verification/supervision.md, an evidence surface. Operators reading docs/configuration.md&#39;s per-harness hook-install section get no pointer to it. Out of scope for this change; a one-line pointer from configuration.md to the supervision.md section would close it without duplicating the fact.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
