### PR TITLE
feat(bin): show the Ollama Cloud reserve on the Pi worker footer

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -293,7 +293,7 @@ Project trust dialog can appear on the first pi run in any not-yet-trusted direc
 Accept with Enter.
 The decision persists per path in `~/.pi/agent/trust.json`, so later spawns in the same worktree slot skip it.
 
-`fm-spawn` keeps the turn-end extension in `state/`, outside the worktree, because project-local extension files make the trust gate strictly worse and pollute the project.
+`fm-spawn` keeps the generated worker extension (its responsibilities are owned by `bin/fm-spawn.sh`'s header) in `state/`, outside the worktree, because project-local extension files make the trust gate strictly worse and pollute the project.
 The extension must listen for pi's `turn_end` event, not `agent_end`, so the watcher wakes after each completed turn instead of only when the whole agent run exits.
 Pi sets `PI_CODING_AGENT=true` for its children; this is its harness-detection env marker.
 

--- a/.pi/extensions/lib/fm-ollama-reserve.ts
+++ b/.pi/extensions/lib/fm-ollama-reserve.ts
@@ -1,0 +1,118 @@
+/**
+ * Ollama Cloud reserve segment for a Pi worker's footer.
+ *
+ * Pi's own footer already renders the working directory, the branch, context
+ * consumed against its ceiling, tokens exchanged, and the model. This module
+ * adds ONLY the one thing Pi cannot know: how much Ollama Cloud headroom is
+ * left. It never reproduces a segment Pi already owns.
+ *
+ * The reserve is read from the fleet's existing probe output, whose contract is
+ * owned by the private `srv-ollama-usage-watch` check: a JSON object carrying
+ * `fetched_at` (ISO 8601 UTC), `session_free`, and `weekly_free` (fractions in
+ * 0..1). This module is a reader of that file, never a second measurement.
+ *
+ * The displayed number is the SMALLER of the two free fractions, because the
+ * tighter window is the one that actually stops work.
+ *
+ * A reserve that cannot be trusted is rendered as an explicit unknown rather
+ * than as a number: a stale figure presented as current is worse than no
+ * figure at all.
+ */
+
+/** Age past which a probe reading is no longer presented as current. */
+export const OLLAMA_RESERVE_MAX_AGE_MS = 60 * 60 * 1000;
+
+/** Footer key this segment owns; Pi sorts extension statuses by key. */
+export const OLLAMA_RESERVE_STATUS_KEY = "fm-ollama";
+
+export type OllamaReserveUnknownReason =
+  | "absent"
+  | "unreadable"
+  | "malformed"
+  | "stale";
+
+export type OllamaReserve =
+  | { readonly kind: "known"; readonly freePercent: number }
+  | { readonly kind: "unknown"; readonly reason: OllamaReserveUnknownReason };
+
+const isFiniteFraction = (value: unknown): value is number =>
+  typeof value === "number" && Number.isFinite(value);
+
+/**
+ * Interpret one raw probe payload.
+ *
+ * `raw` is the file's contents, or null when the file does not exist.
+ * Staleness is judged in BOTH directions: a reading timestamped far in the
+ * future is a clock disagreement, and trusting it would let an arbitrarily old
+ * number keep looking current forever.
+ */
+export function parseOllamaReserve(
+  raw: string | null,
+  nowMs: number,
+  maxAgeMs: number = OLLAMA_RESERVE_MAX_AGE_MS,
+): OllamaReserve {
+  if (raw === null) return { kind: "unknown", reason: "absent" };
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    return { kind: "unknown", reason: "malformed" };
+  }
+  if (typeof payload !== "object" || payload === null) {
+    return { kind: "unknown", reason: "malformed" };
+  }
+
+  const record = payload as Record<string, unknown>;
+  const { fetched_at: fetchedAt, session_free: sessionFree, weekly_free: weeklyFree } = record;
+
+  if (!isFiniteFraction(sessionFree) || !isFiniteFraction(weeklyFree)) {
+    return { kind: "unknown", reason: "malformed" };
+  }
+  if (typeof fetchedAt !== "string") {
+    return { kind: "unknown", reason: "malformed" };
+  }
+
+  const fetchedMs = Date.parse(fetchedAt);
+  if (!Number.isFinite(fetchedMs)) {
+    return { kind: "unknown", reason: "malformed" };
+  }
+  if (Math.abs(nowMs - fetchedMs) > maxAgeMs) {
+    return { kind: "unknown", reason: "stale" };
+  }
+
+  // Floor rather than round: a reserve must never be reported larger than it is.
+  const tightest = Math.min(sessionFree, weeklyFree);
+  const freePercent = Math.max(0, Math.min(100, Math.floor(tightest * 100)));
+  return { kind: "known", freePercent };
+}
+
+/** Compact footer text; the footer line is already dense. */
+export function formatOllamaReserve(reserve: OllamaReserve): string {
+  return reserve.kind === "known" ? `olla ${reserve.freePercent}%` : "olla ?";
+}
+
+/**
+ * Read and interpret the probe file.
+ *
+ * A missing file is an ordinary, expected state (the probe only writes once it
+ * has credentials and a successful fetch), so it reports "absent" rather than
+ * throwing. Any other read failure reports "unreadable". This never throws:
+ * a footer segment must not be able to take down a worker's session.
+ */
+export function readOllamaReserve(
+  readFile: (path: string) => string,
+  path: string,
+  nowMs: number,
+  maxAgeMs: number = OLLAMA_RESERVE_MAX_AGE_MS,
+): OllamaReserve {
+  let raw: string;
+  try {
+    raw = readFile(path);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | undefined)?.code;
+    if (code === "ENOENT") return { kind: "unknown", reason: "absent" };
+    return { kind: "unknown", reason: "unreadable" };
+  }
+  return parseOllamaReserve(raw, nowMs, maxAgeMs);
+}

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -154,8 +154,9 @@
 #     __PITUIMODE__ optional --tui-mode regular when that executable advertises it
 #     __TURNEND__  absolute path to state/<task-id>.turn-ended (for harnesses whose
 #                  turn-end signal rides the launch command, e.g. codex -c notify=[...])
-#     __PIEXT__    absolute path to state/<task-id>.pi-ext.ts (pi turn-end extension,
-#                  written by this script; outside the worktree to avoid pi's trust gate)
+#     __PIEXT__    absolute path to state/<task-id>.pi-ext.ts (pi busy-state, turn-end,
+#                  and Ollama-reserve footer extension, written by this script; outside
+#                  the worktree to avoid pi's trust gate)
 #     __PITURNEND__ absolute path to .pi/extensions/fm-primary-turnend-guard.ts in a pi secondmate home
 #     __PIWATCH__   absolute path to .pi/extensions/fm-primary-pi-watch.ts in a pi secondmate home
 #     __OPINPUT__   absolute path to the canonical operational-input encoder
@@ -2428,7 +2429,12 @@ EOF
 // "turn_end" fires at every inner turn boundary (one LLM response plus its
 // tool calls) and stays a wake NOTIFICATION touch for the watcher, never
 // current-state truth.
+// The footer also carries an Ollama Cloud reserve segment. Pi's own footer
+// already renders cwd, branch, context, tokens, and model; ctx.ui.setStatus
+// APPENDS a keyed line below those without reproducing any of them, so this
+// adds the one number Pi cannot know and rewrites nothing.
 import { execFile } from "node:child_process";
+import { readFileSync } from "node:fs";
 const busyEvent = (state: string, event: string) =>
   new Promise<void>((resolve) => {
     execFile("$FM_ROOT/bin/fm-busy-event.sh", [
@@ -2436,13 +2442,65 @@ const busyEvent = (state: string, event: string) =>
       "--gen", "$BUSY_GEN", "--source", "pi-ext", "--event", event,
     ], () => resolve());
   });
+// Reserve rendering is owned by .pi/extensions/lib/fm-ollama-reserve.ts. It is
+// imported LAZILY and defensively: a footer nicety must never stop the
+// safety-critical busy-state and turn-end wiring above from registering, which
+// a failed top-level import would do.
+const RESERVE_PROBE = "$STATE_REAL/ollama-usage.json";
+const RESERVE_REFRESH_MS = 60000;
+let reserveLib: Promise<any> | null = null;
+let reserveText: string | null = null;
+let reserveCtx: any = null;
+let reserveTimer: any = null;
+const renderReserve = async (ctx: any) => {
+  if (ctx && ctx.ui && typeof ctx.ui.setStatus === "function") reserveCtx = ctx;
+  if (!reserveCtx) return;
+  // One shared promise, so concurrent events await the same load instead of
+  // racing it, and a failed load resolves to null rather than rejecting.
+  if (!reserveLib) {
+    reserveLib = import("$FM_ROOT/.pi/extensions/lib/fm-ollama-reserve.ts").catch(() => null);
+  }
+  const lib = await reserveLib;
+  if (!lib) return;
+  try {
+    const reserve = lib.readOllamaReserve(
+      (probe: string) => readFileSync(probe, "utf8"),
+      RESERVE_PROBE,
+      Date.now(),
+    );
+    const text = lib.formatOllamaReserve(reserve);
+    // Only publish on change, so the periodic refresh below costs no redraw.
+    if (text === reserveText) return;
+    reserveText = text;
+    reserveCtx.ui.setStatus(lib.OLLAMA_RESERVE_STATUS_KEY, text);
+  } catch {
+    // A footer segment must never break a turn.
+  }
+};
 export default function (pi: any) {
-  pi.on("agent_start", () => busyEvent("busy", "agent-start"));
+  pi.on("agent_start", (_event: any, ctx: any) => {
+    void renderReserve(ctx);
+    return busyEvent("busy", "agent-start");
+  });
   pi.on("agent_settled", (_event: any, ctx: any) => {
     if (ctx && typeof ctx.isIdle === "function" && !ctx.isIdle()) return;
     return busyEvent("idle", "agent-settled");
   });
-  pi.on("turn_end", () => execFile("touch", ["$TURNEND"]));
+  pi.on("turn_end", (_event: any, ctx: any) => {
+    void renderReserve(ctx);
+    execFile("touch", ["$TURNEND"]);
+  });
+  pi.on("session_start", (_event: any, ctx: any) => {
+    void renderReserve(ctx);
+    // A worker can idle for hours; without this the last reading would stay on
+    // screen past its shelf life and read as current. Unref'd so the segment
+    // can never hold the session open, and armed once so a restored session
+    // does not stack timers.
+    if (!reserveTimer) {
+      reserveTimer = setInterval(() => void renderReserve(null), RESERVE_REFRESH_MS);
+      if (typeof reserveTimer.unref === "function") reserveTimer.unref();
+    }
+  });
 }
 EOF
       ;;

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2491,6 +2491,10 @@ export default function (pi: any) {
     execFile("touch", ["$TURNEND"]);
   });
   pi.on("session_start", (_event: any, ctx: any) => {
+    // A replacement session (/new, /resume, fork) clears Pi's extension-status
+    // store while reusing this loaded module, so the cached text must be
+    // dropped or the publish-on-change guard would skip the emptied store.
+    reserveText = null;
     void renderReserve(ctx);
     // A worker can idle for hours; without this the last reading would stay on
     // screen past its shelf life and read as current. Unref'd so the segment

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -192,6 +192,7 @@ family_for_basename() {
     fm-muse-signals-live-e2e.test.sh|\
     fm-herdr-version-floor-live-e2e.test.sh|\
     fm-opencode-primary-live-e2e.test.sh|fm-pi-primary-live-e2e.test.sh|\
+    fm-pi-footer-live-e2e.test.sh|\
     fm-sessionstart-hook-live-e2e.test.sh|fm-sessionstart-instruction-refresh-live-e2e.test.sh|\
     fm-quota-array-dispatch-live-e2e.test.sh|fm-send-secondmate-marker-herdr-e2e.test.sh|\
     fm-herdr-submit-confirm-live-e2e.test.sh)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -123,6 +123,10 @@ Ordinary task-state consumers act only on an exact busy verdict, so an unreadabl
 Endpoint death is the only process-level override and yields dead; child processes, CPU, process sleep state, and marker modification times are not state signals.
 `state/<id>.turn-ended` files remain wake notifications, not current state.
 
+The Pi extension `fm-spawn` generates also carries one display-only responsibility: an Ollama Cloud reserve entry on the worker's footer, whose rendering is owned by [`.pi/extensions/lib/fm-ollama-reserve.ts`](../.pi/extensions/lib/fm-ollama-reserve.ts).
+It reads the reserve from the probe file a home's own usage check writes and never measures that quota a second time, it publishes through Pi's keyed `setStatus` so the working directory, branch, context, tokens, and model Pi already renders are neither replaced nor reproduced, and it loads lazily behind a guard so a display module that cannot load can never keep the busy-state and turn-end wiring above it from registering.
+A reserve that is absent, unreadable, malformed, or past its shelf life renders as an explicit unknown, on the same principle as unknown semantic state: a figure presented as current when it is not is worse than no figure.
+
 Each record is bound to an incarnation token minted when the task's wiring is armed, so an event from a superseded incarnation is rejected rather than applied, and a record left behind by one classifies unknown.
 Three rendered-text checks deliberately remain outside this contract because they answer delivery questions: submit acknowledgement and the away-mode supervisor-pane busy guard consume the shared delivery-footer matcher owned by `bin/fm-composer-lib.sh`, while `bin/fm-pending-reply-lib.sh` owns the secondmate delivery-confirmation observation.
 All are harness-scoped rather than a global pattern union, and none is a recorded worker state source.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -914,3 +914,35 @@ Refresh this harness-dependent proof before accepting a cursor upgrade:
 ```sh
 FM_HARNESS_LIVENESS_DRIFT=1 bin/fm-test-run.sh tests/fm-harness-liveness-drift-live-e2e.test.sh
 ```
+
+## Pi worker footer
+
+Pi's own footer already renders the working directory, the branch, context consumed against its ceiling, tokens exchanged, and the model, and firstmate reproduces none of them.
+The Ollama Cloud reserve rides beside them as a separate keyed entry, verified on 2026-08-20 against Pi 0.84.2 on macOS.
+
+Two facts carry the guarantee, and both are harness-dependent because Pi renders them:
+
+- `ctx.ui.setStatus(key, text)` APPENDS a line below Pi's own footer lines instead of replacing them.
+  A live pane with a fresh probe reading rendered three footer lines, the first two produced entirely by Pi:
+
+  ```
+  /private/tmp/.../wt (e2e)
+  0.0%/0 (auto)                                                        unknown
+  olla 85%
+  ```
+
+- An extension launched from outside the worktree through an explicit `-e` path loads its helper module from the code root by absolute path, with no project-trust dialog.
+  The pane's startup banner listed the extension under `[Extensions]` and reached the composer unprompted.
+
+Both were driven with the extension `bin/fm-spawn.sh` actually generates, not a hand-written stand-in, and the same run left `state/<id>.busy-state` carrying its spawn seed, so the reserve segment does not displace the busy-state wiring.
+An absent probe file and a reading stamped three hours earlier each rendered `olla ?` in the same live pane.
+
+The reserve is read from the private `srv-ollama-usage-watch` probe's `state/ollama-usage.json`; firstmate never measures that quota a second time.
+`quota-axi` does not model this provider, which is why the probe exists.
+
+The portable regression is `tests/fm-pi-ollama-reserve.test.sh`, which runs the real `fm-spawn` and drives the generated artifact in a plain Node host.
+Refresh this harness-dependent proof before accepting a Pi upgrade, since only Pi decides where a status entry lands:
+
+```sh
+bin/fm-test-run.sh tests/fm-pi-ollama-reserve.test.sh
+```

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -940,9 +940,9 @@ An absent probe file and a reading stamped three hours earlier each rendered `ol
 The reserve is read from the private `srv-ollama-usage-watch` probe's `state/ollama-usage.json`; firstmate never measures that quota a second time.
 `quota-axi` does not model this provider, which is why the probe exists.
 
-The portable regression is `tests/fm-pi-ollama-reserve.test.sh`, which runs the real `fm-spawn` and drives the generated artifact in a plain Node host.
-Refresh this harness-dependent proof before accepting a Pi upgrade, since only Pi decides where a status entry lands:
+The portable regression is `tests/fm-pi-ollama-reserve.test.sh`, which runs the real `fm-spawn` and drives the generated artifact in a plain Node host, pinning the reserve logic everywhere.
+Refresh this harness-dependent proof with the env-gated live guard before accepting a Pi upgrade, since only Pi decides where a status entry lands:
 
 ```sh
-bin/fm-test-run.sh tests/fm-pi-ollama-reserve.test.sh
+FM_PI_FOOTER_LIVE_E2E=1 bin/fm-test-run.sh tests/fm-pi-footer-live-e2e.test.sh
 ```

--- a/tests/fm-pi-footer-live-e2e.test.sh
+++ b/tests/fm-pi-footer-live-e2e.test.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Opt-in live guard for the Ollama reserve segment on a Pi worker's footer.
+#
+# Only Pi decides where a status entry lands, so the guarantee that
+# ctx.ui.setStatus APPENDS a line rather than replacing Pi's own footer cannot
+# be proven by a stub: a stub would only confirm the assumption written into it.
+# This launches the REAL Pi against the extension bin/fm-spawn.sh actually
+# generates and reads the rendered footer back.
+#
+# It needs no credentials - the footer renders offline - so it is cheap to run
+# after every Pi upgrade. Dated results live in
+# docs/verification/runtime-backends.md under "Pi worker footer".
+set -u
+
+if [ "${FM_PI_FOOTER_LIVE_E2E:-0}" != 1 ]; then
+  echo "skip: set FM_PI_FOOTER_LIVE_E2E=1 to run the live Pi footer guard"
+  exit 0
+fi
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+# An absent harness is reported, never passed over silently: a guard that
+# checked nothing must not look like a guard that passed.
+command -v pi >/dev/null 2>&1 || fail "pi is not installed, so the live Pi footer guard verified nothing"
+command -v tmux >/dev/null 2>&1 || fail "tmux is not installed, so the live Pi footer guard verified nothing"
+
+PI_VERSION=$(pi --version 2>/dev/null || true)
+[ -n "$PI_VERSION" ] || fail "could not determine the installed Pi version"
+
+TMP_ROOT=$(fm_test_tmproot fm-pi-footer-live)
+SOCKET="fm-pi-footer-$$"
+SPAWN="$ROOT/bin/fm-spawn.sh"
+
+cleanup() {
+  tmux -L "$SOCKET" kill-server 2>/dev/null || true
+  fm_test_cleanup
+}
+trap cleanup EXIT
+
+# generate_ext <name> <id>: run the REAL fm-spawn for a Pi ship task against a
+# fake pane, and print "<home>|<worktree>|<ext-path>".
+generate_ext() {
+  local name=$1 id=$2 case_dir home proj wt fakebin out
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  proj="$case_dir/project"
+  wt="$case_dir/wt"
+  fakebin=$(fm_fakebin "$case_dir/fake")
+  cat > "$case_dir/tmux.src" <<'TMUXSH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  has-session|new-session|new-window|kill-window|send-keys) exit 0 ;;
+esac
+exit 0
+TMUXSH
+  install -m 0755 "$case_dir/tmux.src" "$fakebin/tmux"
+  # A fake pi only stands in for the LAUNCH; the real binary renders the footer
+  # further down.
+  fm_fake_exit0 "$fakebin" treehouse pi
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
+  printf 'pi\n' > "$home/config/crew-harness"
+  printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
+  touch "$home/state/.last-watcher-beat"
+  fm_git_worktree "$proj" "$wt" "wt-$name"
+  out=$(FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
+    PATH="$fakebin:$PATH" \
+    "$SPAWN" "$id" "$proj" --mode no-mistakes --yolo off 2>&1) \
+    || fail "pi spawn for $name failed on Pi $PI_VERSION: $out"
+  printf '%s|%s|%s\n' "$home" "$wt" "$home/state/$id.pi-ext.ts"
+}
+
+# render_footer <worktree> <ext> <capture-file>: run the real Pi with the
+# generated extension until the footer settles, then store the pane.
+render_footer() {
+  local wt=$1 ext=$2 capture=$3 config attempt
+  config="$TMP_ROOT/pi-config"
+  mkdir -p "$config"
+  tmux -L "$SOCKET" kill-session -t footer 2>/dev/null || true
+  tmux -L "$SOCKET" new-session -d -s footer -x 180 -y 40 \
+    "cd '$wt' && env PI_CODING_AGENT_DIR='$config' PI_OFFLINE=1 pi --approve \
+      --no-context-files --no-skills --no-prompt-templates --no-extensions \
+      -e '$ext'; sleep 120"
+  attempt=0
+  while [ "$attempt" -lt 200 ]; do
+    tmux -L "$SOCKET" capture-pane -p -t footer >"$capture" 2>/dev/null || true
+    grep -q 'olla' "$capture" 2>/dev/null && return 0
+    sleep 0.25
+    attempt=$((attempt + 1))
+  done
+  fail "Pi $PI_VERSION never rendered the reserve segment: $(tr '\n' '|' <"$capture")"
+}
+
+test_reserve_appends_below_pi_own_footer_segments() {
+  local rec home wt ext capture pane branch
+  rec=$(generate_ext appends olla-live-fresh)
+  home=${rec%%|*}
+  wt=$(printf '%s' "$rec" | cut -d'|' -f2)
+  ext=${rec##*|}
+  python3 - "$home/state/ollama-usage.json" <<'PY'
+import json, sys, time
+with open(sys.argv[1], "w") as handle:
+    json.dump({
+        "fetched_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "session_free": 0.851,
+        "weekly_free": 0.924,
+    }, handle)
+PY
+
+  capture="$TMP_ROOT/fresh.pane"
+  render_footer "$wt" "$ext" "$capture"
+  pane=$(cat "$capture")
+
+  # The reserve is present AND every segment Pi renders itself survived, which
+  # is the whole point: the segment is added, never a rewritten footer.
+  assert_contains "$pane" "olla 85%" \
+    "Pi $PI_VERSION did not render the reserve read from the probe"
+  assert_contains "$pane" "$(basename "$wt")" \
+    "Pi $PI_VERSION lost its working-directory footer segment"
+  branch=$(git -C "$wt" rev-parse --abbrev-ref HEAD)
+  assert_contains "$pane" "$branch" \
+    "Pi $PI_VERSION lost its branch footer segment"
+  # The context ceiling itself is model-dependent and this pane runs with no
+  # model, so assert the "consumed/ceiling" shape Pi always renders rather than
+  # a particular ceiling. That same line carries the tokens and the right-
+  # aligned model, so its survival covers all three.
+  assert_contains "$pane" "%/" \
+    "Pi $PI_VERSION lost its context footer segment"
+
+  # Pi appends extension statuses BELOW its own lines; if a release ever made
+  # setStatus replace the footer, the reserve would be the last line with
+  # nothing above it.
+  local reserve_line context_line
+  reserve_line=$(printf '%s\n' "$pane" | grep -n 'olla 85%' | tail -1 | cut -d: -f1)
+  context_line=$(printf '%s\n' "$pane" | grep -n '%/' | grep -v 'olla' | tail -1 | cut -d: -f1)
+  [ -n "$reserve_line" ] && [ -n "$context_line" ] \
+    || fail "Pi $PI_VERSION rendered an unreadable footer: $(tr '\n' '|' <"$capture")"
+  [ "$reserve_line" -gt "$context_line" ] \
+    || fail "Pi $PI_VERSION no longer appends status entries below its own footer lines"
+  pass "Pi $PI_VERSION appends the reserve below its own footer segments and keeps all of them"
+}
+
+test_untrustworthy_reserve_renders_as_unknown_in_a_live_pane() {
+  local rec home wt ext capture pane
+  rec=$(generate_ext unknown olla-live-unknown)
+  home=${rec%%|*}
+  wt=$(printf '%s' "$rec" | cut -d'|' -f2)
+  ext=${rec##*|}
+  assert_absent "$home/state/ollama-usage.json" "the live unknown case must start with no probe file"
+
+  capture="$TMP_ROOT/absent.pane"
+  render_footer "$wt" "$ext" "$capture"
+  pane=$(cat "$capture")
+  assert_contains "$pane" "olla ?" \
+    "Pi $PI_VERSION did not render an explicit unknown for an absent probe file"
+
+  # Three hours old: well past the shelf life, with the probe's own field shape.
+  python3 - "$home/state/ollama-usage.json" <<'PY'
+import json, sys, time
+with open(sys.argv[1], "w") as handle:
+    json.dump({
+        "fetched_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time() - 10800)),
+        "session_free": 0.851,
+        "weekly_free": 0.924,
+    }, handle)
+PY
+  capture="$TMP_ROOT/stale.pane"
+  render_footer "$wt" "$ext" "$capture"
+  pane=$(cat "$capture")
+  assert_contains "$pane" "olla ?" \
+    "Pi $PI_VERSION did not render an explicit unknown for a stale probe reading"
+  assert_not_contains "$pane" "olla 85%" \
+    "Pi $PI_VERSION presented a stale reserve reading as current"
+  pass "Pi $PI_VERSION renders an absent or stale reserve as an explicit unknown"
+}
+
+test_reserve_appends_below_pi_own_footer_segments
+test_untrustworthy_reserve_renders_as_unknown_in_a_live_pane
+
+echo "all fm-pi-footer-live-e2e tests passed (Pi $PI_VERSION)"

--- a/tests/fm-pi-ollama-reserve.test.sh
+++ b/tests/fm-pi-ollama-reserve.test.sh
@@ -282,11 +282,14 @@ with open(target, "w") as handle:
 PY
 }
 
-# drive_ext <ext-path> <event>: load the generated extension in a plain Node
-# host, fire one lifecycle event with a RECORDING Pi context, and print every
-# interaction it attempted, one "<surface> <detail>" line each.
+# drive_ext <ext-path> <event> [expected-call]: load the generated extension in
+# a plain Node host, fire one lifecycle event with a RECORDING Pi context, and
+# print every interaction it attempted, one "<surface> <detail>" line each.
+# The reserve segment loads its module lazily, so the driver waits (bounded)
+# for the expected call to be recorded - or, with no expectation, for the
+# recording to go quiet - before printing.
 drive_ext() {
-  EXT_PATH="$1" EVENT="$2" node --input-type=module 2>&1 <<'JS'
+  EXT_PATH="$1" EVENT="$2" EXPECT="${3:-}" node --input-type=module 2>&1 <<'JS'
 import { pathToFileURL } from "node:url";
 
 const calls = [];
@@ -320,8 +323,26 @@ mod.default({
 const handler = handlers[process.env.EVENT];
 if (!handler) throw new Error("no handler for " + process.env.EVENT);
 await handler({}, ctx);
-// The reserve segment loads its module lazily, so let that settle.
-await new Promise((resolve) => setTimeout(resolve, 400));
+// On a lapsed deadline the recorded calls are still printed, so a real
+// regression reports what actually happened instead of looking like a timeout.
+const deadline = Date.now() + 5000;
+const tick = () => new Promise((resolve) => setTimeout(resolve, 25));
+const expected = process.env.EXPECT || "";
+if (expected) {
+  while (Date.now() < deadline && !calls.some((line) => line.includes(expected))) {
+    await tick();
+  }
+} else {
+  let seen = calls.length;
+  let quietSince = Date.now();
+  while (Date.now() < deadline && Date.now() - quietSince < 400) {
+    await tick();
+    if (calls.length !== seen) {
+      seen = calls.length;
+      quietSince = Date.now();
+    }
+  }
+}
 console.log(calls.join("\n"));
 JS
 }
@@ -334,7 +355,8 @@ test_generated_extension_publishes_the_reserve_from_the_home_probe() {
   ext=${rec#*|}
   write_probe "$home" 0.851 0.924 60
 
-  out=$(drive_ext "$ext" session_start) || fail "session_start drive failed: $out"
+  out=$(drive_ext "$ext" session_start "ui.setStatus fm-ollama ") \
+    || fail "session_start drive failed: $out"
   assert_contains "$out" "ui.setStatus fm-ollama olla 85%" \
     "the generated extension did not publish the reserve read from this home's probe"
 
@@ -355,7 +377,8 @@ test_generated_extension_renders_an_unknown_rather_than_a_stale_figure() {
   home=${rec%%|*}
   ext=${rec#*|}
   assert_absent "$home/state/ollama-usage.json" "the absent case must start with no probe file"
-  out=$(drive_ext "$ext" session_start) || fail "absent-probe drive failed: $out"
+  out=$(drive_ext "$ext" session_start "ui.setStatus fm-ollama ") \
+    || fail "absent-probe drive failed: $out"
   assert_contains "$out" "ui.setStatus fm-ollama olla ?" \
     "an absent probe file must publish an explicit unknown"
 
@@ -365,12 +388,80 @@ test_generated_extension_renders_an_unknown_rather_than_a_stale_figure() {
   # Well past the shelf life: the probe refreshes on a five-minute sweep, so a
   # reading this old means the sweep is not running.
   write_probe "$home" 0.851 0.924 10800
-  out=$(drive_ext "$ext" session_start) || fail "stale-probe drive failed: $out"
+  out=$(drive_ext "$ext" session_start "ui.setStatus fm-ollama ") \
+    || fail "stale-probe drive failed: $out"
   assert_contains "$out" "ui.setStatus fm-ollama olla ?" \
     "a stale probe reading must publish an explicit unknown"
   assert_not_contains "$out" "olla 85%" \
     "a stale probe reading must never be presented as current"
   pass "an absent or stale probe reading publishes an explicit unknown, never a figure"
+}
+
+# Pi's in-process session replacement (/new, /resume, fork) clears its
+# extension-status store while reusing the already-loaded extension module, so
+# a second session_start on the SAME instance must publish the reserve again
+# even though the rendered text has not changed. The recorder mirrors the
+# cleared store by dropping everything recorded before the replacement.
+test_generated_extension_republishes_after_session_replacement() {
+  require_node "the generated Pi extension session-replacement test" || return 0
+  local rec home ext out
+  rec=$(spawn_pi_case reserve-replace olla-replace)
+  home=${rec%%|*}
+  ext=${rec#*|}
+  write_probe "$home" 0.851 0.924 60
+
+  out=$(EXT_PATH="$ext" node --input-type=module 2>&1 <<'JS'
+import { pathToFileURL } from "node:url";
+
+const calls = [];
+const ui = new Proxy(
+  {},
+  {
+    has: () => true,
+    get: (_target, prop) => {
+      if (typeof prop !== "string") return undefined;
+      if (prop === "theme") return { fg: (_name, text) => text };
+      return (...args) => {
+        calls.push("ui." + prop + " " + args.join(" "));
+      };
+    },
+  },
+);
+const ctx = { ui, isIdle: () => true };
+
+const handlers = {};
+const mod = await import(pathToFileURL(process.env.EXT_PATH).href);
+mod.default({
+  on: (name, fn) => {
+    handlers[name] = fn;
+  },
+});
+
+const waitForPublish = async () => {
+  const deadline = Date.now() + 5000;
+  while (
+    Date.now() < deadline &&
+    !calls.some((line) => line.includes("ui.setStatus fm-ollama "))
+  ) {
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+};
+
+await handlers.session_start({}, ctx);
+await waitForPublish();
+const first = calls.splice(0, calls.length);
+if (!first.some((line) => line.includes("ui.setStatus fm-ollama "))) {
+  throw new Error("first session_start never published: " + JSON.stringify(first));
+}
+
+await handlers.session_start({}, ctx);
+await waitForPublish();
+console.log(calls.map((line) => "replacement " + line).join("\n"));
+JS
+  ) || fail "session-replacement drive failed: $out"
+  assert_contains "$out" "replacement ui.setStatus fm-ollama olla 85%" \
+    "a replacement session_start was swallowed by the publish-on-change cache"
+  pass "a replacement session_start republishes the reserve into the cleared store"
 }
 
 test_generated_extension_keeps_supervision_wiring_when_the_reserve_cannot_load() {
@@ -419,7 +510,8 @@ test_generated_extension_keeps_the_turn_end_notification() {
   marker="$home/state/olla-turnend.turn-ended"
   assert_absent "$marker" "a fresh spawn must not already carry a turn-end notification"
 
-  out=$(drive_ext "$ext" turn_end) || fail "turn_end drive failed: $out"
+  out=$(drive_ext "$ext" turn_end "ui.setStatus fm-ollama ") \
+    || fail "turn_end drive failed: $out"
   assert_present "$marker" "the reserve segment displaced the turn-end notification"
   assert_contains "$out" "ui.setStatus fm-ollama olla 40%" \
     "turn_end must also refresh the reserve so a long session stays current"
@@ -431,6 +523,7 @@ test_module_refuses_to_present_an_untrustworthy_reading_as_current
 test_module_reader_never_throws_on_a_failing_read
 test_generated_extension_publishes_the_reserve_from_the_home_probe
 test_generated_extension_renders_an_unknown_rather_than_a_stale_figure
+test_generated_extension_republishes_after_session_replacement
 test_generated_extension_keeps_supervision_wiring_when_the_reserve_cannot_load
 test_generated_extension_keeps_the_turn_end_notification
 

--- a/tests/fm-pi-ollama-reserve.test.sh
+++ b/tests/fm-pi-ollama-reserve.test.sh
@@ -1,0 +1,437 @@
+#!/usr/bin/env bash
+# Behavior tests for the Ollama Cloud reserve segment on a Pi worker's footer.
+#
+# Two layers, both through public interfaces and never through implementation
+# source bytes:
+#   1. .pi/extensions/lib/fm-ollama-reserve.ts driven directly in a plain Node
+#      host, covering every reading the probe file can present.
+#   2. The REAL fm-spawn against a fake tmux pane, then the extension artifact
+#      it generates driven in a plain Node host with a recording Pi context, so
+#      the interpolated probe path, the lazy module load, and the published
+#      footer entry are exercised together with no live harness session.
+#
+# Live evidence that ctx.ui.setStatus APPENDS a footer line rather than
+# replacing Pi's own cwd, branch, context, tokens, and model segments is
+# recorded in docs/verification/runtime-backends.md.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+MODULE="$ROOT/.pi/extensions/lib/fm-ollama-reserve.ts"
+TMP_ROOT=$(fm_test_tmproot fm-pi-ollama-reserve)
+
+require_node() {  # <context>
+  if ! command -v node >/dev/null 2>&1; then
+    echo "skip: node not found for $1"
+    return 1
+  fi
+  return 0
+}
+
+# ---------------------------------------------------------------- module layer
+
+drive_module() {  # stdin: driver body, run with MODULE_PATH exported
+  MODULE_PATH="$MODULE" node --input-type=module 2>&1
+}
+
+test_module_reports_the_tightest_window_and_never_overstates_it() {
+  require_node "the Ollama reserve module test" || return 0
+  local out
+  out=$(drive_module <<'JS'
+import { pathToFileURL } from "node:url";
+const m = await import(pathToFileURL(process.env.MODULE_PATH).href);
+const now = Date.UTC(2026, 7, 20, 12, 0, 0);
+const read = (session, weekly) =>
+  m.parseOllamaReserve(
+    JSON.stringify({
+      fetched_at: "2026-08-20T12:00:00Z",
+      session_free: session,
+      weekly_free: weekly,
+    }),
+    now,
+  );
+
+const check = (label, got, wantKind, wantValue) => {
+  if (got.kind !== wantKind) throw new Error(label + ": kind " + got.kind + " != " + wantKind);
+  const value = got.kind === "known" ? got.freePercent : got.reason;
+  if (value !== wantValue) throw new Error(label + ": " + value + " != " + wantValue);
+};
+
+// The tighter of the two windows is the one that actually stops work.
+check("session tighter", read(0.851, 0.924), "known", 85);
+check("weekly tighter", read(0.924, 0.851), "known", 85);
+// Floored, never rounded up: a reserve must not be reported larger than it is.
+check("floor not round", read(0.859, 0.999), "known", 85);
+check("floor at boundary", read(0.9999, 0.9999), "known", 99);
+// An over-limit account clamps instead of rendering a negative reserve.
+check("clamped low", read(-0.2, 0.5), "known", 0);
+check("empty reserve", read(0, 0.5), "known", 0);
+check("full reserve", read(1, 1), "known", 100);
+
+// The rendered text stays compact; the footer line is already dense.
+const text = m.formatOllamaReserve(read(0.851, 0.924));
+if (text !== "olla 85%") throw new Error('rendered "' + text + '"');
+console.log("OK");
+JS
+)
+  [ "$out" = "OK" ] || fail "the reserve is not the floored tightest window: $out"
+  pass "the reserve is the floored tightest of the two windows and renders compactly"
+}
+
+test_module_refuses_to_present_an_untrustworthy_reading_as_current() {
+  require_node "the Ollama reserve staleness test" || return 0
+  local out
+  out=$(drive_module <<'JS'
+import { pathToFileURL } from "node:url";
+const m = await import(pathToFileURL(process.env.MODULE_PATH).href);
+const now = Date.UTC(2026, 7, 20, 12, 0, 0);
+const hour = 60 * 60 * 1000;
+const at = (offsetMs) => new Date(now + offsetMs).toISOString().replace(/\.\d+Z$/, "Z");
+const read = (stamp) =>
+  m.parseOllamaReserve(
+    JSON.stringify({ fetched_at: stamp, session_free: 0.851, weekly_free: 0.924 }),
+    now,
+  );
+
+const expect = (label, got, wantKind, wantReason) => {
+  if (got.kind !== wantKind) throw new Error(label + ": kind " + got.kind + " != " + wantKind);
+  if (wantReason !== undefined && got.reason !== wantReason) {
+    throw new Error(label + ": reason " + got.reason + " != " + wantReason);
+  }
+};
+
+// Inside the shelf life the number is presented; past it, never.
+expect("just inside", read(at(-hour + 1000)), "known");
+expect("just outside", read(at(-hour - 1000)), "unknown", "stale");
+expect("long stale", read(at(-9 * hour)), "unknown", "stale");
+// A reading stamped in the future is a clock disagreement, not freshness:
+// trusting it would let an arbitrarily old number look current forever.
+expect("far future", read(at(9 * hour)), "unknown", "stale");
+
+// Nothing usable is ever guessed at.
+expect("absent file", m.parseOllamaReserve(null, now), "unknown", "absent");
+expect("not json", m.parseOllamaReserve("{not json", now), "unknown", "malformed");
+expect("not an object", m.parseOllamaReserve("42", now), "unknown", "malformed");
+expect("null payload", m.parseOllamaReserve("null", now), "unknown", "malformed");
+expect(
+  "no timestamp",
+  m.parseOllamaReserve(JSON.stringify({ session_free: 0.5, weekly_free: 0.5 }), now),
+  "unknown",
+  "malformed",
+);
+expect(
+  "unparseable timestamp",
+  m.parseOllamaReserve(
+    JSON.stringify({ fetched_at: "whenever", session_free: 0.5, weekly_free: 0.5 }),
+    now,
+  ),
+  "unknown",
+  "malformed",
+);
+expect(
+  "missing weekly",
+  m.parseOllamaReserve(JSON.stringify({ fetched_at: at(0), session_free: 0.5 }), now),
+  "unknown",
+  "malformed",
+);
+expect(
+  "string fraction",
+  m.parseOllamaReserve(
+    JSON.stringify({ fetched_at: at(0), session_free: "0.5", weekly_free: 0.5 }),
+    now,
+  ),
+  "unknown",
+  "malformed",
+);
+expect(
+  "null fraction",
+  m.parseOllamaReserve(
+    JSON.stringify({ fetched_at: at(0), session_free: null, weekly_free: 0.5 }),
+    now,
+  ),
+  "unknown",
+  "malformed",
+);
+
+// Every untrustworthy reading renders as an explicit unknown, never a figure.
+for (const reserve of [
+  m.parseOllamaReserve(null, now),
+  read(at(-9 * hour)),
+  m.parseOllamaReserve("{not json", now),
+]) {
+  const text = m.formatOllamaReserve(reserve);
+  if (text !== "olla ?") throw new Error('unknown rendered as "' + text + '"');
+  if (/[0-9]/.test(text)) throw new Error('unknown rendered a digit: "' + text + '"');
+}
+console.log("OK");
+JS
+)
+  [ "$out" = "OK" ] || fail "an untrustworthy reading is not rendered as an explicit unknown: $out"
+  pass "absent, malformed, stale, and future-stamped readings render as an explicit unknown"
+}
+
+test_module_reader_never_throws_on_a_failing_read() {
+  require_node "the Ollama reserve reader test" || return 0
+  local out
+  out=$(drive_module <<'JS'
+import { pathToFileURL } from "node:url";
+const m = await import(pathToFileURL(process.env.MODULE_PATH).href);
+const now = Date.UTC(2026, 7, 20, 12, 0, 0);
+const raising = (code) => () => {
+  const error = new Error("boom");
+  if (code) error.code = code;
+  throw error;
+};
+
+const expect = (label, got, reason) => {
+  if (got.kind !== "unknown" || got.reason !== reason) {
+    throw new Error(label + ": " + got.kind + "/" + got.reason + " != unknown/" + reason);
+  }
+};
+
+// A missing probe file is an ordinary state: the probe only writes once it has
+// credentials and a successful fetch.
+expect("enoent", m.readOllamaReserve(raising("ENOENT"), "/nope", now), "absent");
+expect("permission", m.readOllamaReserve(raising("EACCES"), "/nope", now), "unreadable");
+expect("no code", m.readOllamaReserve(raising(), "/nope", now), "unreadable");
+
+const good = m.readOllamaReserve(
+  () => JSON.stringify({
+    fetched_at: "2026-08-20T12:00:00Z",
+    session_free: 0.5,
+    weekly_free: 0.9,
+  }),
+  "/probe.json",
+  now,
+);
+if (good.kind !== "known" || good.freePercent !== 50) {
+  throw new Error("good read: " + JSON.stringify(good));
+}
+console.log("OK");
+JS
+)
+  [ "$out" = "OK" ] || fail "the reserve reader does not absorb read failures: $out"
+  pass "the reserve reader maps read failures to an unknown instead of throwing"
+}
+
+# ------------------------------------------------------- generated-artifact layer
+
+make_spawn_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$dir/tmux.src" <<'TMUXSH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  has-session|new-session|new-window|kill-window|send-keys) exit 0 ;;
+esac
+exit 0
+TMUXSH
+  install -m 0755 "$dir/tmux.src" "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse pi
+  printf '%s\n' "$fakebin"
+}
+
+# spawn_pi_case <name> <id> [fm-root]: run the REAL fm-spawn for a Pi ship task
+# and print "<home>|<ext-path>". An explicit fm-root lets a case prove what the
+# artifact does when its helper module is not where it was generated to expect.
+spawn_pi_case() {
+  local name=$1 id=$2 fm_root=${3:-} case_dir home proj wt fakebin out
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  proj="$case_dir/project"
+  wt="$case_dir/wt"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+  mkdir -p "$home/data" "$home/projects" "$home/state" "$home/config"
+  printf 'pi\n' > "$home/config/crew-harness"
+  fm_git_worktree "$proj" "$wt" "wt-$name"
+  touch "$home/state/.last-watcher-beat"
+  mkdir -p "$home/data/$id"
+  printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
+  out=$(FM_ROOT_OVERRIDE="$fm_root" FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
+    PATH="$fakebin:$PATH" \
+    "$SPAWN" "$id" "$proj" --mode no-mistakes --yolo off 2>&1) \
+    || fail "pi spawn for $name failed: $out"
+  assert_present "$home/state/$id.pi-ext.ts" "pi spawn did not write the extension for $name"
+  printf '%s|%s\n' "$home" "$home/state/$id.pi-ext.ts"
+}
+
+write_probe() {  # <home> <session-free> <weekly-free> <age-seconds>
+  python3 - "$1/state/ollama-usage.json" "$2" "$3" "$4" <<'PY'
+import json, sys, time
+target, session, weekly, age = sys.argv[1], float(sys.argv[2]), float(sys.argv[3]), int(sys.argv[4])
+stamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time() - age))
+with open(target, "w") as handle:
+    json.dump({
+        "fetched_at": stamp,
+        "session_usage": round(1 - session, 4),
+        "weekly_usage": round(1 - weekly, 4),
+        "session_free": session,
+        "weekly_free": weekly,
+    }, handle)
+PY
+}
+
+# drive_ext <ext-path> <event>: load the generated extension in a plain Node
+# host, fire one lifecycle event with a RECORDING Pi context, and print every
+# interaction it attempted, one "<surface> <detail>" line each.
+drive_ext() {
+  EXT_PATH="$1" EVENT="$2" node --input-type=module 2>&1 <<'JS'
+import { pathToFileURL } from "node:url";
+
+const calls = [];
+// A permissive recorder: every UI surface the extension could reach answers,
+// so a segment that tried to take the footer over would be recorded rather
+// than silently skipped over a missing method.
+const ui = new Proxy(
+  {},
+  {
+    has: () => true,
+    get: (_target, prop) => {
+      if (typeof prop !== "string") return undefined;
+      if (prop === "theme") return { fg: (_name, text) => text };
+      return (...args) => {
+        calls.push("ui." + prop + " " + args.join(" "));
+      };
+    },
+  },
+);
+const ctx = { ui, isIdle: () => true };
+
+const handlers = {};
+const mod = await import(pathToFileURL(process.env.EXT_PATH).href);
+mod.default({
+  on: (name, fn) => {
+    calls.push("register " + name);
+    handlers[name] = fn;
+  },
+});
+
+const handler = handlers[process.env.EVENT];
+if (!handler) throw new Error("no handler for " + process.env.EVENT);
+await handler({}, ctx);
+// The reserve segment loads its module lazily, so let that settle.
+await new Promise((resolve) => setTimeout(resolve, 400));
+console.log(calls.join("\n"));
+JS
+}
+
+test_generated_extension_publishes_the_reserve_from_the_home_probe() {
+  require_node "the generated Pi extension reserve test" || return 0
+  local rec home ext out other
+  rec=$(spawn_pi_case reserve-fresh olla-fresh)
+  home=${rec%%|*}
+  ext=${rec#*|}
+  write_probe "$home" 0.851 0.924 60
+
+  out=$(drive_ext "$ext" session_start) || fail "session_start drive failed: $out"
+  assert_contains "$out" "ui.setStatus fm-ollama olla 85%" \
+    "the generated extension did not publish the reserve read from this home's probe"
+
+  # The segments Pi already renders - working directory, branch, context,
+  # tokens, model - are Pi's to render. The extension must touch nothing but
+  # its own keyed status entry, or it would be reproducing them and drifting
+  # from them at the next Pi release.
+  other=$(printf '%s\n' "$out" | grep '^ui\.' | grep -v '^ui\.setStatus fm-ollama ' || true)
+  [ -z "$other" ] || fail "the extension reached past its own status entry: $other"
+  pass "the generated extension publishes the reserve under its own key and touches nothing else"
+}
+
+test_generated_extension_renders_an_unknown_rather_than_a_stale_figure() {
+  require_node "the generated Pi extension unknown-reserve test" || return 0
+  local rec home ext out
+
+  rec=$(spawn_pi_case reserve-absent olla-absent)
+  home=${rec%%|*}
+  ext=${rec#*|}
+  assert_absent "$home/state/ollama-usage.json" "the absent case must start with no probe file"
+  out=$(drive_ext "$ext" session_start) || fail "absent-probe drive failed: $out"
+  assert_contains "$out" "ui.setStatus fm-ollama olla ?" \
+    "an absent probe file must publish an explicit unknown"
+
+  rec=$(spawn_pi_case reserve-stale olla-stale)
+  home=${rec%%|*}
+  ext=${rec#*|}
+  # Well past the shelf life: the probe refreshes on a five-minute sweep, so a
+  # reading this old means the sweep is not running.
+  write_probe "$home" 0.851 0.924 10800
+  out=$(drive_ext "$ext" session_start) || fail "stale-probe drive failed: $out"
+  assert_contains "$out" "ui.setStatus fm-ollama olla ?" \
+    "a stale probe reading must publish an explicit unknown"
+  assert_not_contains "$out" "olla 85%" \
+    "a stale probe reading must never be presented as current"
+  pass "an absent or stale probe reading publishes an explicit unknown, never a figure"
+}
+
+test_generated_extension_keeps_supervision_wiring_when_the_reserve_cannot_load() {
+  require_node "the generated Pi extension degraded-module test" || return 0
+  local rec home ext out fm_root
+  # A code root with the real busy-state writer but no reserve module: the
+  # footer segment is a nicety, and it must not be able to keep the busy-state
+  # and turn-end wiring supervision depends on from registering.
+  fm_root="$TMP_ROOT/rootless"
+  mkdir -p "$fm_root"
+  # A complete, working code root except for .pi, so the only thing missing is
+  # the reserve module itself.
+  local entry
+  for entry in "$ROOT"/* "$ROOT"/.[!.]*; do
+    [ -e "$entry" ] || continue
+    [ "$(basename "$entry")" = ".pi" ] && continue
+    ln -s "$entry" "$fm_root/$(basename "$entry")"
+  done
+  assert_absent "$fm_root/.pi/extensions/lib/fm-ollama-reserve.ts" \
+    "the degraded case must have no reserve module"
+
+  rec=$(spawn_pi_case reserve-degraded olla-degraded "$fm_root")
+  home=${rec%%|*}
+  ext=${rec#*|}
+  write_probe "$home" 0.851 0.924 60
+
+  out=$(drive_ext "$ext" session_start) || fail "degraded-module drive failed: $out"
+  assert_contains "$out" "register agent_start" \
+    "a missing reserve module stopped the busy-state wiring from registering"
+  assert_contains "$out" "register agent_settled" \
+    "a missing reserve module stopped the settle wiring from registering"
+  assert_contains "$out" "register turn_end" \
+    "a missing reserve module stopped the turn-end wiring from registering"
+  assert_not_contains "$out" "ui.setStatus" \
+    "a missing reserve module must publish nothing rather than guess"
+  pass "a reserve module that cannot load leaves the supervision wiring intact"
+}
+
+test_generated_extension_keeps_the_turn_end_notification() {
+  require_node "the generated Pi extension turn-end test" || return 0
+  local rec home ext out marker
+  rec=$(spawn_pi_case reserve-turnend olla-turnend)
+  home=${rec%%|*}
+  ext=${rec#*|}
+  write_probe "$home" 0.4 0.9 60
+  marker="$home/state/olla-turnend.turn-ended"
+  assert_absent "$marker" "a fresh spawn must not already carry a turn-end notification"
+
+  out=$(drive_ext "$ext" turn_end) || fail "turn_end drive failed: $out"
+  assert_present "$marker" "the reserve segment displaced the turn-end notification"
+  assert_contains "$out" "ui.setStatus fm-ollama olla 40%" \
+    "turn_end must also refresh the reserve so a long session stays current"
+  pass "turn_end still touches the notification marker and refreshes the reserve"
+}
+
+test_module_reports_the_tightest_window_and_never_overstates_it
+test_module_refuses_to_present_an_untrustworthy_reading_as_current
+test_module_reader_never_throws_on_a_failing_read
+test_generated_extension_publishes_the_reserve_from_the_home_probe
+test_generated_extension_renders_an_unknown_rather_than_a_stale_figure
+test_generated_extension_keeps_supervision_wiring_when_the_reserve_cannot_load
+test_generated_extension_keeps_the_turn_end_notification
+
+echo "all fm-pi-ollama-reserve tests passed"


### PR DESCRIPTION
## Intent

Add the Ollama Cloud reserve to the status line of Pi worker agents, and reimplement nothing that already exists.

Context established before the work started (as of 2026-08-19): Pi already renders, at the bottom of its panel, the working directory, the branch, context consumed against its ceiling (e.g. "18.9%/128k"), tokens exchanged, and the model (e.g. "glm-5.2:cloud"). FOUR of the five elements the captain asked for are already there and MUST NOT be reimplemented.

First required check: the captain asked for this line "like claude code", so he may simply not be seeing it. Establish whether the existing line is visible in his view (herdr backend) or hidden/truncated. If the real defect were masking, fixing that would have been the whole job, with the Ollama reserve as a bonus if the surface allowed it easily. FINDING: a live capture of a running Pi worker's pane shows the existing footer fully visible and untruncated in the captain's view, so masking was not the defect and the real gap was only the missing reserve. This finding is an explicit acceptance criterion and must appear in the PR.

What was missing: the Ollama reserve. quota-axi does not model this provider. The fleet already reads this reserve through the private srv-ollama-usage-watch probe, which writes state/ollama-usage.json with fields session_free, weekly_free, and fetched_at. The implementation must LEAN ON THAT EXISTING SOURCE and must not invent a second measurement that would diverge from it.

Hook surface to establish: pi --help exposes no statusline option. The serious lead was the auto-discovered extension system, since bin/fm-spawn.sh already passes a per-task extension to pi and pi-signed workers via -e state/<id>.pi-ext.ts. The task required establishing whether that surface allows ADDING a segment to the line or only rewriting the line entirely.

ARBITRATION RULE given up front: if the only available route were rewriting the whole line - and therefore reproducing and maintaining the four existing elements at every Pi release - the worker must NOT do it, must post a needs-decision with the finding, and must stop, because that would be a bad trade and the decision belongs to firstmate. FINDING: the arbitration rule does not trigger. Pi's ctx.ui.setStatus(key, text) is a keyed, purely additive surface: it appends an extra footer line BELOW Pi's own lines and never replaces them. This was proven live against Pi 0.84.2 using the extension bin/fm-spawn.sh actually generates, not a hand-written stand-in. Therefore no existing segment is reproduced or maintained by this change.

Display requirements for the reserve, all mandatory:
- Read from state/ollama-usage.json (the existing probe's output).
- Explicit rendering when the data is ABSENT or STALE (fetched_at older than 1 hour): show "reserve?" or an equivalent, and NEVER a stale figure presented as fresh, because false assurance is worse than no information.
- Compact, on the order of "olla 96%", because the line is already dense.

Acceptance criteria:
1. The visibility finding (does the captain see the existing line?) is established and written in the PR.
2. The Ollama reserve appears, read from the probe, with explicit absent/stale rendering. Colocated tests.
3. The four existing elements are neither lost nor reimplemented.
4. If the surface forced a full rewrite: needs-decision, no code.

Deliberate implementation decisions made while doing the work, which a reviewer reading only the diff would not know:
- The displayed figure is the SMALLER of session_free and weekly_free, floored rather than rounded. Rationale: the tighter window is the one that actually stops work, and a reserve must never read larger than it is.
- Staleness is judged in BOTH directions. A reading stamped far in the future is treated as stale too, because that is a clock disagreement rather than freshness, and trusting it would let an arbitrarily old number keep looking current forever. This directly serves the "never present a stale figure as fresh" requirement.
- An unknown reserve renders "olla ?" with no digits, for absent, unreadable, malformed, and stale alike. The distinction is kept in the returned reason for diagnostics but deliberately not shown, to keep the segment compact.
- The rendering module lives at .pi/extensions/lib/fm-ollama-reserve.ts, matching the repo's existing convention for Pi extension helper modules. It is NOT auto-discovered as an extension: Pi discovers only .pi/extensions/*.ts and .pi/extensions/*/index.ts, and this placement was verified live to load nothing and warn about nothing.
- The generated worker extension imports that module LAZILY, behind a shared promise with a catch that resolves to null. Rationale: the same generated extension carries the safety-critical busy-state and turn-end wiring that fleet supervision depends on, and a failed top-level import would stop that wiring from registering. A display module that cannot load must degrade to showing nothing, never take the supervision wiring down with it. There is a test for exactly this.
- The reserve is refreshed on session_start, agent_start, and turn_end, plus an unref'd 60-second timer armed once. Rationale: a worker can idle for hours, and without the timer the last reading would stay on screen past its shelf life and read as current, which is the exact failure the requirements forbid. It publishes only when the rendered text changes, so the timer costs no redraw.
- Two test layers, deliberately separate because they fail for different reasons. tests/fm-pi-ollama-reserve.test.sh is the portable regression: it runs the REAL fm-spawn and drives the generated artifact in a plain Node host with a recording Pi context, asserting among other things that the extension touches nothing but its own keyed status entry (which is how criterion 3 is enforced mechanically). tests/fm-pi-footer-live-e2e.test.sh is an opt-in, env-gated, self-skipping live guard that launches the real Pi and reads the rendered footer back, because only Pi decides where a status entry lands and a stub could only confirm the assumption written into it; it refuses to pass if Pi is not installed. This two-test split follows the repo's own rule for harness-dependent checks in the firstmate-coding-guidelines skill.
- Dated live evidence is recorded in docs/verification/runtime-backends.md under "Pi worker footer", and the architecture boundary (a display responsibility riding the same generated extension as the supervision wiring, isolated from it) is recorded in docs/architecture.md. AGENTS.md was deliberately NOT touched: the coding guidelines' size discipline routes situation-specific detail away from the always-loaded file.
- Pre-existing failures observed locally and NOT caused by this change: two workflow-lint failures because actionlint is not installed on this machine (bin/fm-lint-workflows.sh deliberately exits non-zero naming the pinned version), and one one-off failure in tests/fm-spawn-dispatch-profile.test.sh that occurred only while a sibling test suite saturated the machine; that test passes in isolation both with and without this change, and twice more under self-inflicted parallel load.

This work touches firstmate's own shared, tracked material, so the firstmate-coding-guidelines skill was loaded before editing, and its rules were applied: one owner per contract, inline-stub discipline, AGENTS.md size discipline, one sentence per line in tracked Markdown, plain dash instead of em dash, no agent co-author, shellcheck-clean bin scripts via bin/fm-lint.sh, and colocated tests that assert behavior through executable interfaces rather than implementation-source bytes.

## What Changed

- `bin/fm-spawn.sh` now embeds an Ollama Cloud reserve segment in the Pi worker extension it generates: it reads the existing `srv-ollama-usage-watch` probe output (`state/ollama-usage.json`) instead of measuring the quota a second time, and publishes through Pi's keyed `ctx.ui.setStatus`, which appends a line below Pi's own footer, so the working directory, branch, context, tokens, and model Pi already renders are neither replaced nor reproduced. The rendering module is imported lazily behind a shared caught promise so a failed load degrades to no segment without stopping the safety-critical busy-state and turn-end wiring, and the reserve refreshes on `session_start`, `agent_start`, and `turn_end` plus a once-armed unref'd 60-second timer that republishes only when the rendered text changes.
- New `.pi/extensions/lib/fm-ollama-reserve.ts` owns parsing and formatting: it renders the floored smaller of `session_free` and `weekly_free` as a compact `olla 96%`, and renders an explicit `olla ?` when the reading is absent, unreadable, malformed, or stale (staleness is judged in both directions, so a future-stamped reading from a clock disagreement is never presented as fresh; the reason stays in the returned value for diagnostics).
- Two colocated test layers plus documentation: `tests/fm-pi-ollama-reserve.test.sh` runs the real `fm-spawn` and drives the generated extension in a plain Node host, asserting among other things that it touches nothing but its own keyed status entry, while the env-gated, self-skipping `tests/fm-pi-footer-live-e2e.test.sh` (registered in `bin/fm-test-run.sh`'s live-e2e family) launches real Pi and reads the rendered footer back. `docs/verification/runtime-backends.md` records the dated live evidence against Pi 0.84.2, including the visibility finding that a running Pi worker's existing footer is fully visible and untruncated in the captain's view, so the only missing element was the reserve; `docs/architecture.md` and the harness-adapters skill record the display-vs-supervision boundary of the generated extension.

## Risk Assessment

✅ Low: Both accepted fix-round changes are correctly applied at the prescribed shared boundary (session_start resets the publish cache; the test settle wait is now bounded polling), the new regression test provably fails before the fix and cannot false-pass, and a full re-pass over all seven changed files surfaced no new issues or intent violations.

## Testing

Round 2 : le fix documentaire du round 1 est vérifié appliqué à HEAD conformément aux instructions, puis les deux couches de test ont été re-exécutées - la régression portable (8/8) et la garde live env-gated contre le vrai Pi 0.84.2 (2/2), cette dernière prouvant en bout en bout que le segment « olla NN% » lu depuis la sonde s'ajoute sous le footer intact de Pi et qu'une lecture absente ou périmée rend « olla ? » ; les preuves visuelles du round 1 (PNG/HTML/panes) restent valides car seul le doc a changé depuis, et l'arbre de travail est resté propre.

- Evidence: [Captures visuelles des panes Pi 0.84.2 réels (frais « olla 85% », absent « olla ? », périmé « olla ? »)](https://github.com/Kallas95/firstmate/blob/c62535d1252c6a51ea20e0132c4a38af0436dd85/.no-mistakes/evidence/fm/fm-pi-ligne-statut/pi-footer-evidence.png)
<details>
<summary>Evidence: Rendu HTML des trois panes avec annotations</summary>

Source: [Rendu HTML des trois panes avec annotations](https://github.com/Kallas95/firstmate/blob/c62535d1252c6a51ea20e0132c4a38af0436dd85/.no-mistakes/evidence/fm/fm-pi-ligne-statut/pi-footer-evidence.html)

```text
<!doctype html>
<html lang="en"><head><meta charset="utf-8">
<title>Pi worker footer - Ollama reserve segment (live Pi 0.84.2)</title>
<style>
  body { background:#0d1117; color:#c9d1d9; font-family:-apple-system,'Segoe UI',sans-serif; margin:24px; }
  h1 { font-size:19px; font-weight:600; }
  p.sub { color:#8b949e; font-size:13px; max-width:900px; }
  .card { background:#161b22; border:1px solid #30363d; border-radius:8px; margin:18px 0; overflow:hidden; max-width:1080px; }
  .bar { background:#21262d; padding:7px 12px; display:flex; align-items:center; gap:6px; }
  .dot { width:11px; height:11px; border-radius:50%; display:inline-block; }
  .r { background:#ff5f57; } .y { background:#febc2e; } .g { background:#28c840; }
  .title { margin-left:8px; color:#8b949e; font-size:12px; font-family:ui-monospace,Menlo,monospace; }
  pre { margin:0; padding:12px 14px; background:#1e1e1e; color:#d4d4d4; font:12px/1.45 ui-monospace,Menlo,Consolas,monospace; overflow-x:auto; }
  .caption { padding:9px 14px; margin:0; font-size:13px; color:#8b949e; border-top:1px solid #30363d; }
</style></head><body>
<h1>Pi worker footer - Ollama Cloud reserve segment</h1>
<p class="sub">Real Pi 0.84.2 panes captured over tmux, each running the extension actually generated by
bin/fm-spawn.sh. Pi's own footer (working directory + branch, context %/ceiling, tokens, model) is
untouched; the reserve is a keyed status line appended below it.</p>

  <section class="card">
    <div class="bar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="title">pi worker - fresh probe reading</span></div>
    <pre> <span style="font-weight:700"></span><span style="color:rgb(138,190,183);font-weight:700">pi</span><span style="color:rgb(102,102,102)"> v0.84.2</span>
 <span style="color:rgb(102,102,102)">escape</span><span style="color:rgb(128,128,128)"> interrupt · </span><span style="color:rgb(102,102,102)">ctrl+c/ctrl+d</span><span style="color:rgb(128,128,128)"> clear/exit · </span><span style="color:rgb(102,102,102)">/</span><span style="color:rgb(128,128,128)"> commands · </span><span style="color:rgb(102,102,102)">!</span><span style="color:rgb(128,128,128)"> bash · </span><span style="color:rgb(102,102,102)">ctrl+o</span><span style="color:rgb(128,128,128)"> more</span>
 <span style="color:rgb(102,102,102)">Press ctrl+o to show full startup help and loaded resources.</span>

 <span style="color:rgb(102,102,102)">Pi can explain its own features and look up its docs. Ask it how to use or extend Pi.</span>

<span style="color:rgb(240,198,116)">[Extensions]</span>
<span style="color:rgb(102,102,102)">  olla-evidence-fresh.pi-ext.ts</span>


 <span style="color:rgb(255,255,0)">Warning: No models available. Use /login to log into a provider via OAuth or API key. See:
</span> <span style="color:rgb(255,255,0)">  /Users/max/.local/share/fnm/node-versions/v22.23.2/installation/lib/node_modules/@earendil-works/pi-coding-agent/docs/providers.md
</span> <span style="color:rgb(255,255,0)">  /Users/max/.local/share/fnm/node-versions/v22.23.2/installation/lib/node_modules/@earendil-works/pi-coding-agent/docs/models.md</span>

 <span style="color:rgb(255,255,0)">Warning: tmux extended-keys is off. Modified Enter keys may not work. Add `set -g extended-keys on` to ~/.tmux.conf and restart tmux.</span>

<span style="color:rgb(80,80,80)">────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
</span><span style="color:#1e1e1e;background:rgb(80,80,80)"></span><span style="color:#1e1e1e;background:#d4d4d4"> </span>
<span style="color:rgb(80,80,80)">────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
</span><span style="color:rgb(102,102,102)">/private/var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T/fm-pi-footer-evidence.VkG9Dk/fresh/wt (wt-fresh)</span>
<span style="color:rgb(102,102,102)">0.0%/0 (auto)                                                                                                                        unknown
</span>olla 85%</pre>
    <p class="caption">Fresh probe (session_free 0.851, weekly_free 0.924): the footer appends 'olla 85%' - the floored tightest of the two windows - below Pi's own cwd/branch, context and model line.</p>
  </section>

  <section class="card">
    <div class="bar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="title">pi worker - probe file absent</span></div>
    <pre> <span style="font-weight:700"></span><span style="color:rgb(138,190,183);font-weight:700">pi</span><span style="color:rgb(102,102,102)"> v0.84.2</span>
 <span style="color:rgb(102,102,102)">escape</span><span style="color:rgb(128,128,128)"> interrupt · </span><span style="color:rgb(102,102,102)">ctrl+c/ctrl+d</span><span style="color:rgb(128,128,128)"> clear/exit · </span><span style="color:rgb(102,102,102)">/</span><span style="color:rgb(128,128,128)"> commands · </span><span style="color:rgb(102,102,102)">!</span><span style="color:rgb(128,128,128)"> bash · </span><span style="color:rgb(102,102,102)">ctrl+o</span><span style="color:rgb(128,128,128)"> more</span>
 <span style="color:rgb(102,102,102)">Press ctrl+o to show full startup help and loaded resources.</span>

 <span style="color:rgb(102,102,102)">Pi can explain its own features and look up its docs. Ask it how to use or extend Pi.</span>

<span style="color:rgb(240,198,116)">[Extensions]</span>
<span style="color:rgb(102,102,102)">  olla-evidence-absent.pi-ext.ts</span>


 <span style="color:rgb(255,255,0)">Warning: No models available. Use /login to log into a provider via OAuth or API key. See:
</span> <span style="color:rgb(255,255,0)">  /Users/max/.local/share/fnm/node-versions/v22.23.2/installation/lib/node_modules/@earendil-works/pi-coding-agent/docs/providers.md
</span> <span style="color:rgb(255,255,0)">  /Users/max/.local/share/fnm/node-versions/v22.23.2/installation/lib/node_modules/@earendil-works/pi-coding-agent/docs/models.md</span>

 <span style="color:rgb(255,255,0)">Warning: tmux extended-keys is off. Modified Enter keys may not work. Add `set -g extended-keys on` to ~/.tmux.conf and restart tmux.</span>

<span style="color:rgb(80,80,80)">────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
</span><span style="color:#1e1e1e;background:rgb(80,80,80)"></span><span style="color:#1e1e1e;background:#d4d4d4"> </span>
<span style="color:rgb(80,80,80)">────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
</span><span style="color:rgb(102,102,102)">/private/var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T/fm-pi-footer-evidence.VkG9Dk/absent/wt (wt-absent)</span>
<span style="color:rgb(102,102,102)">0.0%/0 (auto)                                                                                                                        unknown
</span>olla ?</pre>
    <p class="caption">No state/ollama-usage.json: the footer renders the explicit unknown 'olla ?' instead of guessing a figure.</p>
  </section>

  <section class="card">
    <div class="bar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="title">pi worker - stale probe reading (3h old)</span></div>
    <pre> <span style="font-weight:700"></span><span style="color:rgb(138,190,183);font-weight:700">pi</span><span style="color:rgb(102,102,102)"> v0.84.2</span>
 <span style="color:rgb(102,102,102)">escape</span><span style="color:rgb(128,128,128)"> interrupt · </span><span style="color:rgb(102,102,102)">ctrl+c/ctrl+d</span><span style="color:rgb(128,128,128)"> clear/exit · </span><span style="color:rgb(102,102,102)">/</span><span style="color:rgb(128,128,128)"> commands · </span><span style="color:rgb(102,102,102)">!</span><span style="color:rgb(128,128,128)"> bash · </span><span style="color:rgb(102,102,102)">ctrl+o</span><span style="color:rgb(128,128,128)"> more</span>
 <span style="color:rgb(102,102,102)">Press ctrl+o to show full startup help and loaded resources.</span>

 <span style="color:rgb(102,102,102)">Pi can explain its own features and look up its docs. Ask it how to use or extend Pi.</span>

<span style="color:rgb(240,198,116)">[Extensions]</span>
<span style="color:rgb(102,102,102)">  olla-evidence-stale.pi-ext.ts</span>


 <span style="color:rgb(255,255,0)">Warning: No models available. Use /login to log into a provider via OAuth or API key. See:
</span> <span style="color:rgb(255,255,0)">  /Users/max/.local/share/fnm/node-versions/v22.23.2/installation/lib/node_modules/@earendil-works/pi-coding-agent/docs/providers.md
</span> <span style="color:rgb(255,255,0)">  /Users/max/.local/share/fnm/node-versions/v22.23.2/installation/lib/node_modules/@earendil-works/pi-coding-agent/docs/models.md</span>

 <span style="color:rgb(255,255,0)">Warning: tmux extended-keys is off. Modified Enter keys may not work. Add `set -g extended-keys on` to ~/.tmux.conf and restart tmux.</span>

<span style="color:rgb(80,80,80)">────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
</span><span style="color:#1e1e1e;background:rgb(80,80,80)"></span><span style="color:#1e1e1e;background:#d4d4d4"> </span>
<span style="color:rgb(80,80,80)">────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
</span><span style="color:rgb(102,102,102)">/private/var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T/fm-pi-footer-evidence.VkG9Dk/stale/wt (wt-stale)</span>
<span style="color:rgb(102,102,102)">0.0%/0 (auto)                                                                                                                        unknown
</span>olla ?</pre>
    <p class="caption">Probe reading stamped 3 hours ago (past the 1h shelf life): 'olla ?' again - the stale 85% figure is never presented as current.</p>
  </section>
</body></html>
```
</details>
<details>
<summary>Evidence: Transcription pane - sonde fraîche (olla 85%)</summary>

Source: [Transcription pane - sonde fraîche (olla 85%)](https://github.com/Kallas95/firstmate/blob/c62535d1252c6a51ea20e0132c4a38af0436dd85/.no-mistakes/evidence/fm/fm-pi-ligne-statut/pi-footer-fresh.txt)

```text
 pi v0.84.2
 escape interrupt · ctrl+c/ctrl+d clear/exit · / commands · ! bash · ctrl+o more
 Press ctrl+o to show full startup help and loaded resources.

 Pi can explain its own features and look up its docs. Ask it how to use or extend Pi.

[Extensions]
  olla-evidence-fresh.pi-ext.ts


 Warning: No models available. Use /login to log into a provider via OAuth or API key. See:
   /Users/max/.local/share/fnm/node-versions/v22.23.2/installation/lib/node_modules/@earendil-works/pi-coding-agent/docs/providers.md
   /Users/max/.local/share/fnm/node-versions/v22.23.2/installation/lib/node_modules/@earendil-works/pi-coding-agent/docs/models.md

 Warning: tmux extended-keys is off. Modified Enter keys may not work. Add `set -g extended-keys on` to ~/.tmux.conf and restart tmux.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
/private/var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T/fm-pi-footer-evidence.VkG9Dk/fresh/wt (wt-fresh)
0.0%/0 (auto)                                                                                                                        unknown
olla 85%
```
</details>
<details>
<summary>Evidence: Transcription pane - sonde absente (olla ?)</summary>

Source: [Transcription pane - sonde absente (olla ?)](https://github.com/Kallas95/firstmate/blob/c62535d1252c6a51ea20e0132c4a38af0436dd85/.no-mistakes/evidence/fm/fm-pi-ligne-statut/pi-footer-absent.txt)

```text
 pi v0.84.2
 escape interrupt · ctrl+c/ctrl+d clear/exit · / commands · ! bash · ctrl+o more
 Press ctrl+o to show full startup help and loaded resources.

 Pi can explain its own features and look up its docs. Ask it how to use or extend Pi.

[Extensions]
  olla-evidence-absent.pi-ext.ts


 Warning: No models available. Use /login to log into a provider via OAuth or API key. See:
   /Users/max/.local/share/fnm/node-versions/v22.23.2/installation/lib/node_modules/@earendil-works/pi-coding-agent/docs/providers.md
   /Users/max/.local/share/fnm/node-versions/v22.23.2/installation/lib/node_modules/@earendil-works/pi-coding-agent/docs/models.md

 Warning: tmux extended-keys is off. Modified Enter keys may not work. Add `set -g extended-keys on` to ~/.tmux.conf and restart tmux.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
/private/var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T/fm-pi-footer-evidence.VkG9Dk/absent/wt (wt-absent)
0.0%/0 (auto)                                                                                                                        unknown
olla ?
```
</details>
<details>
<summary>Evidence: Transcription pane - sonde périmée de 3 h (olla ?)</summary>

Source: [Transcription pane - sonde périmée de 3 h (olla ?)](https://github.com/Kallas95/firstmate/blob/c62535d1252c6a51ea20e0132c4a38af0436dd85/.no-mistakes/evidence/fm/fm-pi-ligne-statut/pi-footer-stale.txt)

```text
 pi v0.84.2
 escape interrupt · ctrl+c/ctrl+d clear/exit · / commands · ! bash · ctrl+o more
 Press ctrl+o to show full startup help and loaded resources.

 Pi can explain its own features and look up its docs. Ask it how to use or extend Pi.

[Extensions]
  olla-evidence-stale.pi-ext.ts


 Warning: No models available. Use /login to log into a provider via OAuth or API key. See:
   /Users/max/.local/share/fnm/node-versions/v22.23.2/installation/lib/node_modules/@earendil-works/pi-coding-agent/docs/providers.md
   /Users/max/.local/share/fnm/node-versions/v22.23.2/installation/lib/node_modules/@earendil-works/pi-coding-agent/docs/models.md

 Warning: tmux extended-keys is off. Modified Enter keys may not work. Add `set -g extended-keys on` to ~/.tmux.conf and restart tmux.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
/private/var/folders/5q/snmnm0_926ddy6xlmggzx1g80000gn/T/fm-pi-footer-evidence.VkG9Dk/stale/wt (wt-stale)
0.0%/0 (auto)                                                                                                                        unknown
olla ?
```
</details>
<details>
<summary>Evidence: Sortie de la garde live re-exécutée à HEAD (Pi 0.84.2)</summary>

```text
$ FM_PI_FOOTER_LIVE_E2E=1 bin/fm-test-run.sh tests/fm-pi-footer-live-e2e.test.sh
ok - Pi 0.84.2 appends the reserve below its own footer segments and keeps all of them
ok - Pi 0.84.2 renders an absent or stale reserve as an explicit unknown
all fm-pi-footer-live-e2e tests passed (Pi 0.84.2)
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (13m5s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"193ab3d03555b1313b8b4ac30f88ffc249a7c0d7","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-spawn.sh:2473` - The generated Pi extension&#39;s publish-on-change guard (reserveText) survives Pi in-process session replacement while Pi clears its extension-status store, so the reserve segment silently disappears after /new, /resume, or fork. Proven against installed Pi 0.84.2 source: teardownCurrent -&gt; beforeSessionInvalidate -&gt; resetExtensionUI() -&gt; footerDataProvider.clearExtensionStatuses() empties the footer store; the replacement runtime reuses the module-level extensionCache factory (same cwd and generation, loader.js), so the same module instance keeps reserveText; the re-emitted session_start (agent-session.js:1761) then renders unchanged text and renderReserve returns before setStatus, leaving the segment absent for the whole new session until the percentage changes or goes stale (possibly hours). Minimal durable fix at the shared boundary: reset reserveText = null in the session_start handler before renderReserve(ctx), keeping the timer&#39;s no-redraw optimization intact.
- ℹ️ `tests/fm-pi-ollama-reserve.test.sh:324` - drive_ext waits a fixed 400ms for the lazy module import to settle before reading the recorded calls. Under machine saturation (a failure mode the author already observed on a sibling suite) the import can exceed 400ms and the assertions would flake. Polling the recorded calls for the expected setStatus/register entries with a bounded deadline (e.g. up to 5s) is a mechanical, strictly more robust replacement.

🔧 Fix: republish reserve on session_start and poll test settle
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `docs/verification/runtime-backends.md:947` - docs/verification/runtime-backends.md:947 tells the reader to refresh &#39;this harness-dependent proof before accepting a Pi upgrade&#39; but the command it gives runs the portable regression (bin/fm-test-run.sh tests/fm-pi-ollama-reserve.test.sh), which drives a stub Node host and cannot detect a Pi rendering change. The actual harness-dependent guard is the env-gated live test, and every other section of that file follows the env-gated convention. The command should be: FM_PI_FOOTER_LIVE_E2E=1 bin/fm-test-run.sh tests/fm-pi-footer-live-e2e.test.sh. Doc-only fix, outside the test phase, so reported instead of applied.
- <code>`bash tests/fm-pi-ollama-reserve.test.sh` (régression portable : 8 cas, vrai fm-spawn + artefact généré piloté dans un hôte Node enregistreur)</code>
- <code>`FM_PI_FOOTER_LIVE_E2E=1 bash tests/fm-pi-footer-live-e2e.test.sh` (garde live : vrai Pi 0.84.2 + vrai tmux, footer relu depuis le pane rendu)</code>
- <code>Vérification manuelle live : 3 panes Pi 0.84.2 réels (sonde fraîche → `olla 85%`, sonde absente → `olla ?`, sonde datée de 3 h → `olla ?` sans le chiffre périmé) avec l&#39;extension réellement générée par `bin/fm-spawn.sh`, captures conservées en évidence</code>
- `Contrôle visuel que les quatre segments existants de Pi (cwd + branche, contexte %/plafond, tokens, modèle) restent rendus par Pi au-dessus de la réserve dans les trois panes`
- <code>`git status --porcelain` propre après les runs, répertoires temporaires des tests nettoyés par leurs traps</code>

🔧 Fix: point Pi footer refresh command at env-gated live guard
✅ Re-checked - no issues remain.
- <code>`bin/fm-test-run.sh tests/fm-pi-ollama-reserve.test.sh` - régression portable : fm-spawn réel + artefact généré piloté dans un hôte Node avec contexte Pi enregistreur, 8/8 ok (plus petite des deux fenêtres avec plancher, rendu « olla ? » pour absent/malformé/périmé/horodaté dans le futur, la clé de statut propre est la seule chose touchée, le câblage de supervision survit à un module d&#39;affichage qui ne charge pas)</code>
- <code>`FM_PI_FOOTER_LIVE_E2E=1 bin/fm-test-run.sh tests/fm-pi-footer-live-e2e.test.sh` - garde live env-gated contre le vrai Pi 0.84.2 via tmux : 2/2 ok, la réserve s&#39;ajoute SOUS les lignes de footer propres de Pi (répertoire, branche, contexte/tokens/modèle conservés) et une sonde absente ou périmée rend « olla ? »</code>
- `Vérification manuelle du diff de 65cea37 contre les instructions user_chose_to_fix du round 1 : édition doc uniquement, commande de rafraîchissement pointée sur la garde live, phrase de justification conservée, rôles des deux tests désambiguïsés, convention env-gated identique aux autres sections (lignes 87, 732, 915 du même fichier)`
- `Vérification que les preuves visuelles du round 1 (PNG, HTML, 3 transcriptions de pane) restent représentatives de HEAD : seul un changement de 3 lignes de doc a atterri depuis la capture, le code produit est identique`
- <code>Contrôles de propreté : `git status --porcelain` vide, aucun processus pi orphelin, aucun serveur tmux vivant après les tests</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
