### PR TITLE
doc: instruct firstmate to proactively state next steps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -469,6 +469,10 @@ Reach the captain immediately for:
 - Anything destructive, irreversible, or security-sensitive.
 - A needed credential or login.
 
+**Keep the captain moving, not waiting.**
+After completing a step toward a stated goal, say what happens next rather than going idle until asked.
+When the very next step needs the captain's hands, such as a command only they can run because firstmate cannot write to a project, bundle that request with whatever firstmate itself will do right after, so one reply carries the whole next action instead of leaving the captain to relay it back manually.
+
 Do not surface automatic fixes, retries, routine progress, or internal supervision mechanics.
 When a routine operational update's specific event requires no action but a response must be sent, reply exactly `Captain, shipshape.` without characterizing the visible session's unrelated decisions.
 Batch non-urgent updates into the next natural reply.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -470,8 +470,8 @@ Reach the captain immediately for:
 - A needed credential or login.
 
 **Keep the captain moving, not waiting.**
-After completing a step toward a stated goal, say what happens next rather than going idle until asked.
-When the very next step needs the captain's hands, such as a command only they can run because firstmate cannot write to a project, bundle that request with whatever firstmate itself will do right after, so one reply carries the whole next action instead of leaving the captain to relay it back manually.
+At a response-worthy stopping point toward a stated goal, say what happens next rather than going idle until asked.
+When the very next step needs the captain's hands, such as an unapproved mutation or an interactive command only they can run, bundle that request with whatever firstmate itself will do right after, so one reply carries the whole next action instead of leaving the captain to relay it back manually.
 
 Do not surface automatic fixes, retries, routine progress, or internal supervision mechanics.
 When a routine operational update's specific event requires no action but a response must be sent, reply exactly `Captain, shipshape.` without characterizing the visible session's unrelated decisions.


### PR DESCRIPTION
## Summary

- Adds a short instruction to `AGENTS.md` section 9 (Escalation and captain etiquette): after completing a step toward a stated captain goal, proactively state what happens next rather than going idle, and bundle a step that needs the captain's own hands with whatever firstmate itself does right after.
- Captures live captain feedback from a session where a multi-step fix (a project-file edit firstmate can't perform, followed by a service restart firstmate can perform) was handled as separate round-trips instead of being bundled or proactively announced.
- Doc-only change; no scripts or workflows touched. Placed after the "Reach the captain immediately for" list, matching section 9's existing bolded-lead-in style. Does not restate section 1's "never write to a project" rule or its exceptions - this addition is about response shape/pacing, not what firstmate is allowed to do.

## Test plan

- [x] `bin/fm-doc-audience-check.sh` passes (`fm-doc-audience-check: ok surfaces=69 local_links=255`)
- [x] `tests/fm-documentation-audiences.test.sh` passes
- [x] Manual review: one sentence per line, plain dash, correct section placement, matches section 9 tone
- [x] Validated through the no-mistakes pipeline (intent, rebase, review, test, document, lint gates all cleared)
