### PR TITLE
fix(bin): stop liveness from suppressing declared waits

### DIFF
--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -133,9 +133,9 @@ status_is_paused() {  # <status-line>
 
 # 0 if a status line declares either an external-wait pause or a verified
 # captain-held transfer.
-# Both declarations can intentionally leave an exited crew's endpoint idle, so
-# the watcher applies its bounded pause cadence when agent death confirms that
-# no live decision gate is being silenced.
+# Both declarations can intentionally leave the endpoint idle; pause_state_class
+# owns their current-state and liveness reconciliation before the watcher selects
+# the bounded pause cadence.
 status_is_paused_or_captain_held() {  # <status-line>
   local line=$1 verb
   status_is_paused "$line" && return 0

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -399,8 +399,12 @@ clear_pause_tracking() {  # <window>
 }
 
 # Reconcile a declared pause or captain-held status with authoritative crew state.
-# Only a confidently dead ordinary crew may recover paused classification after
-# fm-crew-state has fallen back to stopped or unknown.
+# A declared wait is trusted on its own terms; agent liveness never SUPPRESSES it,
+# because an inconclusive read would otherwise silence the declaration exactly where
+# it has learned least. Liveness is still read for the one thing it can settle: a
+# confidently dead ordinary crew recovers paused classification after fm-crew-state
+# has fallen back to stopped or unknown, so an exited crew keeps its bounded recheck
+# instead of surfacing as a bare stopped crew.
 pause_state_class() {  # <window> <task>
   local win=$1 task=$2 key last recheck_file class agent_alive
   key=${win//:/_}
@@ -414,14 +418,6 @@ pause_state_class() {  # <window> <task>
     return
   fi
   if [ -e "$STATE/.paused-$key" ] && [ "$(age_of "$recheck_file")" -lt "$STALE_ESCALATE_SECS" ]; then
-    if [ "$(window_kind "$win")" != secondmate ]; then
-      agent_alive=$(fm_backend_agent_alive "$(window_backend "$win")" "$win" 2>/dev/null) || agent_alive=unknown
-      if [ "$agent_alive" != dead ]; then
-        rm -f "$recheck_file"
-        printf 'none'
-        return
-      fi
-    fi
     printf 'paused'
     return
   fi
@@ -433,11 +429,6 @@ pause_state_class() {  # <window> <task>
   fi
   if [ "$(window_kind "$win")" != secondmate ]; then
     agent_alive=$(fm_backend_agent_alive "$(window_backend "$win")" "$win" 2>/dev/null) || agent_alive=unknown
-    if [ "$agent_alive" != dead ]; then
-      rm -f "$recheck_file"
-      printf 'none'
-      return
-    fi
   fi
   [ "$class" = none ] && [ "${agent_alive:-unknown}" = dead ] && class=paused
   case "$class" in

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -1113,9 +1113,10 @@ EOF
           #   - working: an actively-running pipeline legitimately sits on a static
           #     pane (e.g. waiting on CI), so absorb and start the wedge timer so a
           #     genuinely frozen run still escalates past STALE_ESCALATE_SECS;
-          #   - paused: the crew declared an external wait, or a declared pause or
-          #     captain hold is paired with a confidently dead agent, so absorb on
-          #     the long PAUSE_RESURFACE_SECS cadence instead of wedge-escalating;
+          #   - paused: current state preserves the declared external wait, or a
+          #     confidently dead agent recovers a lost pause or captain hold, so
+          #     absorb on the long PAUSE_RESURFACE_SECS cadence instead of
+          #     wedge-escalating;
           #   - none: no running pipeline, no exact busy verdict, no declared pause.
           #     Surface immediately so firstmate inspects the inconclusive state
           #     (it may be done via an interactive menu that wrote no done: status,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,8 +22,8 @@ A concurrent replacement remains armed, every non-merged or invalid observation 
 No-verb wakes, such as `working:` notes and bare turn-ended signals, are benign only when `bin/fm-crew-state.sh` reports positive evidence that the crew is still working: an actively running no-mistakes step attributed to that crew's current code, or an exact busy verdict from the semantic busy-state contract.
 A `kind=secondmate` task's status signal is the parent-directed reply stream and is never absorbed as provably working; only its bare turn-ended signal retains the ordinary absorb rule.
 A crew that declares `paused:` for a known external wait is separately absorbed while idle and re-surfaced only on the longer pause cadence, rather than being treated as a possible wedge.
-For an ordinary crew that has stopped, the normal-mode watcher first surfaces one stale wake, then applies that same cadence to an unchanged `paused:` or durable `captain-held` endpoint only when the backend confidently reports its agent dead.
-Live or inconclusive liveness remains fail-open at that initial surface, and the secondmate idle-endpoint exemption is unchanged.
+Once current-state reconciliation accepts that declaration, normal-mode watcher liveness cannot suppress it: alive, dead, and inconclusive verdicts all retain the bounded pause cadence.
+A confidently dead verdict remains a one-way recovery input when current-state reconciliation has fallen back to `stopped` or `unknown`, preserving the bounded annotated recheck for an exited crew instead of surfacing a bare stopped crew; the secondmate idle-endpoint exemption is unchanged.
 Its initial normal-mode status signal still surfaces through the no-verb path, while away mode self-handles that routine signal and owns the later recheck.
 Fresh stale panes use the same current-state read before trusting the status log, so an active run or a proven busy worker outranks an old captain-relevant status-log line left behind before validation.
 No-change heartbeats are also benign.

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -880,10 +880,10 @@ test_nonterminal_stale_paused_absorbed_then_resurfaced() {
 # fm-crew-state then authoritatively reports stopped rather than paused, but the
 # confirmed-dead agent plus the declared wait or captain-held transfer must retain
 # bounded pause handling.
-# A still-live agent at an external-decision gate is the disconfirming case: it
-# must surface once, while the unchanged hash must not append the same wake on
-# every watcher re-arm.
-test_exited_declared_pause_is_bounded_but_live_gate_surfaces() {
+# A still-live agent at an external-decision gate confirms the other half of the
+# contract: its declared wait must be absorbed on first sight and on every
+# unchanged-hash re-arm before the bounded pause cadence expires.
+test_exited_declared_pause_is_bounded_and_live_gate_absorbs() {
   local dir state fakebin out capture_file statusf window key pane_hash sig pid back round wakes bare
   dir=$(make_case exited-declared-pause); state="$dir/state"; fakebin="$dir/fakebin"
   out="$dir/watch.out"; capture_file="$dir/pane.txt"; statusf="$state/held.status"
@@ -978,10 +978,9 @@ test_exited_declared_pause_is_bounded_but_live_gate_surfaces() {
   reap "$pid"
   ack_stopped_cycle "$state" || fail "could not acknowledge the live declared-pause absorb"
 
-  # Re-arm with the stale timer already beyond the wedge threshold. This is the
-  # exact unchanged-hash fallback after the immediate surface: it must retain
-  # the pause cadence and discard any residual wedge timer instead of emitting
-  # a second possible-wedge wake.
+  # Re-arm with the stale timer already beyond the wedge threshold. The
+  # unchanged-hash path must retain the pause cadence and discard any residual
+  # wedge timer instead of emitting a possible-wedge wake.
   printf '%s\n' $(( $(date +%s) - 500 )) > "$state/.stale-since-$key"
   PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
     FM_FAKE_TMUX_CURRENT_COMMAND=grok FM_FAKE_CREW_STATE='state: paused · source: status-log · waiting at an active external-decision gate' \
@@ -990,16 +989,16 @@ test_exited_declared_pause_is_bounded_but_live_gate_surfaces() {
   pid=$!
   if ! wait_poll_cycle "$state" "$pid"; then
     reap "$pid"
-    fail "live external-decision gate escalated on the wedge timer after its immediate surface: $(cat "$out")"
+    fail "live external-decision gate escalated on the wedge timer after its initial absorb: $(cat "$out")"
   fi
   [ -e "$state/.paused-$key" ] || { reap "$pid"; fail "live external-decision gate lost its pause cadence marker"; }
   [ ! -e "$state/.stale-since-$key" ] || { reap "$pid"; fail "live external-decision gate retained the wedge timer"; }
   reap "$pid"
   wakes=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w { n++ } END { print n + 0 }' "$state/.wake-queue")
   bare=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w && $5 == "stale: " w { n++ } END { print n + 0 }' "$state/.wake-queue")
-  [ "$wakes" -eq 0 ] || fail "acknowledged external-decision surface replayed $wakes wakes"
-  [ "$bare" -eq 0 ] || fail "acknowledged external-decision bare stale remained queued"
-  pass "exited declared-pause and captain-held panes use bounded pause cadence while a live decision gate still surfaces once"
+  [ "$wakes" -eq 0 ] || fail "live external-decision gate unexpectedly queued $wakes wakes"
+  [ "$bare" -eq 0 ] || fail "live external-decision gate unexpectedly queued $bare bare stale wakes"
+  pass "exited declared-pause and captain-held panes use bounded pause cadence while a live decision gate is absorbed"
 }
 
 test_secondmate_paused_resurfaces_in_normal_mode() {
@@ -2192,7 +2191,7 @@ test_busy_declared_pause_is_rechecked_not_wedge_escalated
 test_nonterminal_stale_not_working_surfaced
 test_declared_pause_absorbs_whatever_liveness_reports
 test_nonterminal_stale_paused_absorbed_then_resurfaced
-test_exited_declared_pause_is_bounded_but_live_gate_surfaces
+test_exited_declared_pause_is_bounded_and_live_gate_absorbs
 test_secondmate_paused_resurfaces_in_normal_mode
 test_secondmate_nonpaused_stale_remains_suppressed
 test_secondmate_unpause_clears_pause_tracking

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -744,6 +744,68 @@ test_nonterminal_stale_not_working_surfaced() {
   pass "a not-provably-working non-terminal stale is surfaced immediately (never left to wait out the timer)"
 }
 
+# --- a DECLARED pause is trusted on its own terms, whatever liveness reports ------
+# Regression for an inverted suppression: pause_state_class consulted the backend's
+# agent-liveness verdict and returned `none` for any agent that was not confidently
+# `dead`, so a healthy worker parked on a current, accurate `paused:` line was
+# surfaced on sight - its idle pane being exactly what the declaration predicted.
+# The suppression fired hardest where it knew least, because `unknown` (an unreadable
+# read, an ambiguous foreground process, or an unverified backend) is also "not dead".
+#
+# Liveness is no longer consulted here, so every verdict absorbs: the declaration is
+# the worker's own evidence and the bounded PAUSE_RESURFACE_SECS recheck remains the
+# backstop against a wait that has quietly rotted.
+#
+# Asserted on the classification's observable effects rather than on wake wording: the
+# pause is FRESH under a high re-surface threshold, so the bounded cadence cannot wake
+# here, and any queued stale wake means the declaration was rejected.
+declared_pause_absorbs_case() {  # <case-name> <pane-command>
+  local name=$1 command=$2
+  local dir state fakebin out statusf window key pane pane_hash pid
+  dir=$(make_case "declared-pause-$name"); state="$dir/state"; fakebin="$dir/fakebin"
+  out="$dir/watch.out"; statusf="$state/held.status"
+  window="test:fm-held"
+  pane='idle, holding for the upstream tool release'
+  printf '%s\n' "$pane" > "$dir/pane.txt"
+  printf 'window=%s\nkind=ship\nharness=grok\nbackend=tmux\n' "$window" > "$state/held.meta"
+  printf 'paused: holding for the upstream tool release\n' > "$statusf"
+  printf '%s' "$(seen_sig "$statusf")" > "$state/.seen-held_status"
+  key=$(printf '%s' "$window" | tr ':/.' '___')
+  pane_hash=$(hash_text "$pane")
+  printf '%s' "$pane_hash" > "$state/.hash-$key"
+  printf '1\n' > "$state/.count-$key"
+  PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$dir/pane.txt" \
+    FM_FAKE_TMUX_CURRENT_COMMAND="$command" \
+    FM_FAKE_CREW_STATE='state: paused · source: status-log · holding for the upstream tool release' \
+    FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" \
+    FM_PAUSE_RESURFACE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
+    FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out" &
+  pid=$!
+  if ! wait_live "$pid" 30; then
+    reap "$pid"
+    fail "declared pause with a $name agent surfaced instead of absorbing: $(cat "$out")"
+  fi
+  [ ! -s "$state/.wake-queue" ] \
+    || { reap "$pid"; fail "declared pause with a $name agent queued a stale wake instead of absorbing"; }
+  [ -e "$state/.paused-$key" ] \
+    || { reap "$pid"; fail "declared pause with a $name agent did not take the bounded pause cadence"; }
+  [ ! -e "$state/.stale-since-$key" ] \
+    || { reap "$pid"; fail "declared pause with a $name agent started the wedge timer"; }
+  reap "$pid"
+}
+
+test_declared_pause_absorbs_whatever_liveness_reports() {
+  # grok, zsh, node and an empty command are read through the real tmux liveness
+  # classifier, which resolves them to alive, dead, ambiguous and unreadable. All four
+  # must absorb, so no verdict - least of all an inconclusive one - can suppress a
+  # declared wait.
+  declared_pause_absorbs_case live grok
+  declared_pause_absorbs_case dead zsh
+  declared_pause_absorbs_case ambiguous node
+  declared_pause_absorbs_case unreadable ''
+  pass "a declared pause is absorbed whatever the backend reports about agent liveness"
+}
+
 # --- non-terminal stale, crew DECLARED a pause: absorbed, re-surfaced on a long
 #     cadence, never wedge-escalated ------------------------------------------
 # The live 2026-07-09/10 case: a crew intentionally held awaiting an upstream tool
@@ -897,15 +959,24 @@ test_exited_declared_pause_is_bounded_but_live_gate_surfaces() {
   printf '%s' "$pane_hash" > "$state/.hash-$key"
   printf '1\n' > "$state/.count-$key"
 
-  # First sight must surface promptly so a live external-decision gate is not
-  # hidden behind the pause cadence.
+  # A live worker parked on a declared wait is absorbed on the bounded cadence. This
+  # case previously required the opposite - an immediate surface on first sight - which
+  # was the inverted suppression itself written down as an expectation: liveness was
+  # used to silence the declaration rather than to judge it. A worker that is still
+  # running is the one best placed to end its own declared wait, so it is left alone.
   PATH="$fakebin:$PATH" FM_FAKE_TMUX_WINDOW="$window" FM_FAKE_TMUX_CAPTURE="$capture_file" \
     FM_FAKE_TMUX_CURRENT_COMMAND=grok FM_FAKE_CREW_STATE='state: paused · source: status-log · waiting at an active external-decision gate' \
     FM_STATE_OVERRIDE="$state" FM_CREW_STATE_BIN="$fakebin/fm-crew-state.sh" FM_PAUSE_RESURFACE_SECS=999 FM_POLL=1 FM_SIGNAL_GRACE=1 \
     FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" >> "$out" &
   pid=$!
-  wait_for_exit "$pid" 100 || fail "live external-decision gate did not surface immediately"
-  ack_stopped_cycle "$state" || fail "could not acknowledge the immediate external-decision surface"
+  if ! wait_live "$pid" 30; then
+    reap "$pid"
+    fail "live declared pause surfaced instead of absorbing on the bounded cadence: $(cat "$out")"
+  fi
+  [ ! -s "$state/.wake-queue" ] \
+    || { reap "$pid"; fail "live declared pause queued a stale wake instead of absorbing"; }
+  reap "$pid"
+  ack_stopped_cycle "$state" || fail "could not acknowledge the live declared-pause absorb"
 
   # Re-arm with the stale timer already beyond the wedge threshold. This is the
   # exact unchanged-hash fallback after the immediate surface: it must retain
@@ -2119,6 +2190,7 @@ test_busy_pane_repeated_escalation_reaches_demand_deep_inspection
 test_busy_pane_default_turn_age_bound_is_3600s
 test_busy_declared_pause_is_rechecked_not_wedge_escalated
 test_nonterminal_stale_not_working_surfaced
+test_declared_pause_absorbs_whatever_liveness_reports
 test_nonterminal_stale_paused_absorbed_then_resurfaced
 test_exited_declared_pause_is_bounded_but_live_gate_surfaces
 test_secondmate_paused_resurfaces_in_normal_mode


### PR DESCRIPTION
## Intent

Fix an inverted safety check in bin/fm-watch.sh with the smallest change that closes it, and nothing more.

The defect: pause_state_class consults the backend's agent-liveness verdict and returns `none` for any agent that is not confidently `dead`, in two places. A worker parked on a current, accurate `paused:` line is therefore surfaced on sight, while the long PAUSE_RESURFACE_SECS cadence it should take is reachable only once its agent has already exited. The healthy worker is woken and the exited one is quieted. The suppression fires hardest where it knows least, because fm_backend_agent_alive folds an unreadable read, an ambiguous foreground process, and an unverified backend into `unknown`, and `unknown` is also "not dead".

This change deletes the two suppressions and nothing else. It deliberately KEEPS the liveness read and the promotion beneath it, which are a separate and still-correct fix: when fm-crew-state has fallen back to `stopped` for an exited crew, a confidently dead verdict recovers the paused classification so that crew keeps its bounded annotated recheck rather than surfacing as a bare stopped crew. Removing that promotion too was attempted first and regressed exactly that guarantee, which the existing suite caught; the corrected principle is that liveness may still settle what it can settle, but may no longer suppress what it cannot.

This is deliberately the minimal fix rather than a larger correction. A much larger restructure of this behaviour exists on a separate branch and was assessed and DROPPED on its merits: it was 1,381 insertions and restructured the main triage loop inside two of the most actively edited files in the tree, which is an unreasonable thing to carry as a permanent fork divergence. This change fixes the same reported defect in a deletion. What it gives up relative to that restructure is prompt surfacing of a worker that dies while holding a declared wait, which now falls back to the bounded recheck; that trade was made deliberately and is documented.

Two tests changed because they asserted the removed behaviour rather than the behaviour. The new regression drives all four liveness verdicts - alive, dead, ambiguous and unreadable - through the real tmux liveness classifier and requires every one to absorb; against the unmodified source it fails for alive, ambiguous and unreadable and passes only for dead, which is the inversion stated as a test result. The live external-decision-gate case previously demanded an immediate surface on first sight, which was the inversion written down as an expectation, and now expects the bounded absorb with the reasoning recorded in place.

Acceptance is that a declared wait is trusted whatever the backend reports about liveness, that an exited crew still keeps its bounded recheck rather than surfacing as a bare stopped crew, and that every existing guarantee in the watcher triage suite stays green. Scope is strictly the two deletions plus those test changes: no restructure, no new state, no config knob, no wrapper, and no change to fork integration or divergence registration, which are deliberately out of scope here and owned elsewhere.

## What Changed

- Stop agent-liveness verdicts from suppressing declared waits, keeping alive, dead, ambiguous, and unreadable cases on the bounded pause cadence.
- Preserve confidently dead liveness as a recovery signal for stopped or unknown crews, retaining annotated rechecks for exited workers.
- Update watcher documentation and regression coverage for all liveness outcomes and live external-decision gates.

## Risk Assessment

✅ Low: Captain, source risk is low because the narrowly scoped deletions close both reachable suppression paths while preserving dead-agent promotion; only contradictory test documentation remains.

## Testing

Inspected the target diff, ran the focused watcher-triage suite twice, and captured direct watcher-state evidence showing every liveness verdict absorbs while an exited/stopped crew retains one annotated bounded recheck; all checks passed. No screenshot was applicable because this is a background CLI watcher change.

<details>
<summary>Evidence: Declared-wait end-to-end watcher transcript</summary>

<code>alive/dead/ambiguous/unreadable: watcher=absorbed, wake_queue_bytes=0, pause_marker=present, wedge_timer=absent&#10;exited + stopped: watcher=bounded-recheck, stale_wakes=1, bare_stale_wakes=0</code>

```text
fm-watch declared-wait end-to-end evidence
fresh declared waits (real watcher subprocess + real tmux liveness classifier):
alive      detailed=alive      compatibility=alive   watcher=absorbed wake_queue_bytes=0 pause_marker=present wedge_timer=absent
dead       detailed=dead       compatibility=dead    watcher=absorbed wake_queue_bytes=0 pause_marker=present wedge_timer=absent
ambiguous  detailed=ambiguous  compatibility=unknown watcher=absorbed wake_queue_bytes=0 pause_marker=present wedge_timer=absent
unreadable detailed=unreadable compatibility=unknown watcher=absorbed wake_queue_bytes=0 pause_marker=present wedge_timer=absent

exited crew with authoritative stopped state:
detailed=dead authoritative_state=stopped watcher=bounded-recheck stale_wakes=1 bare_stale_wakes=0
watcher_stdout=stale: test:fm-held (paused 502s, awaiting external - declared pause, rechecked on a long cadence not a wedge; confirm the wait still holds)
durable_queue_payload=stale: test:fm-held (paused 502s, awaiting external - declared pause, rechecked on a long cadence not a wedge; confirm the wait still holds)
```
</details>
<details>
<summary>Evidence: Focused watcher-triage suite transcript</summary>

```text
ok - signal_reason_is_actionable: benign absorbed, captain verbs and coalesced batches surfaced
ok - stale_is_terminal: terminal status surfaces, non-terminal and no-status are benign
ok - scan_captain_relevant_statuses lists only captain-relevant statuses
ok - classifier primitives: keyed decisions and activity phases, captain relevance, window-to-task, and overrides
ok - crew_is_provably_working: only working+run-step/pane is provable; idle/finished/parked/failed/unknown surface
ok - status_is_paused: only the leading paused verb matches, and paused is not captain-relevant
ok - crew_absorb_class: working/paused/none from one read; crew_is_paused and crew_is_provably_working agree
ok - signal_crew_provably_working: benign only when every referenced crew is provably working
ok - a secondmate's status signal is never absorbed as provably working; crewmates are unaffected
ok - a no-verb signal whose crew is provably working is absorbed (no exit, no queue, suppressor advanced, beacon present)
ok - a bare turn-end whose crew is provably working (busy pane) is absorbed
ok - a bare turn-end whose crew is not provably working is surfaced (the swallowed-finish fix)
ok - a no-verb working: note whose crew is idle with no running pipeline is surfaced
ok - a secondmate's status note surfaces even while its own agent is busy
ok - a self-announced close never wakes its own home, and the next real note still does
ok - captain-relevant signal is surfaced (queue + exit) and marked surfaced
ok - a stale pane sitting on a terminal status is surfaced (queue + exit)
ok - a stale terminal-looking status is overridden and absorbed while a run is actively working, then wedge-escalated
ok - provably-working non-terminal stale is absorbed on first sight, then wedge-escalated past the threshold
ok - consecutive wedge escalations on the same pane accumulate and demand deep inspection at the threshold
ok - a pane becoming active again resets the consecutive wedge-escalation counter
ok - a busy worker below the turn-age bound remains working with no escalation
ok - a busy worker with a stable pane hash still escalates once its completed-turn age reaches the bound
ok - a busy worker whose pane hash changes every poll still escalates once its completed-turn age reaches the bound
ok - touching a busy worker's completed-turn marker resets the age and prevents an old-age escalation
ok - repeated busy turn-age escalations reuse the existing escalation counter and demand deep inspection at the threshold
ok - the production default busy-turn-age bound is 3600s (5min under does not wedge, 66min over does)
ok - a busy pane under a declared pause is rechecked on the long cadence, and lifting the pause restores the wedge escalation
ok - a not-provably-working non-terminal stale is surfaced immediately (never left to wait out the timer)
ok - a declared pause is absorbed whatever the backend reports about agent liveness
ok - a declared pause is absorbed on first sight, then re-surfaced as a recheck past the threshold, never wedge-escalated
ok - exited declared-pause and captain-held panes use bounded pause cadence while a live decision gate is absorbed
ok - a declared paused secondmate re-surfaces on the bounded normal-mode cadence
ok - a non-paused secondmate retains normal stale suppression
ok - a resumed secondmate clears pause and stale tracking before stale exemption
ok - unchanged stale hashes reclassify when a crew enters or leaves pause
ok - a declared pause is periodically rechecked against authoritative active-run state
ok - a paused status overridden by authoritative working preserves its wedge timer and escalates
ok - matching non-terminal stale suppressors repair missing or corrupt stale-since timers
ok - triage log capping handles wc byte counts with leading spaces
ok - a captured process-event result wakes a healthy watcher proactively, with no manual drain
ok - an unacknowledged process-event result re-drains until handling is acknowledged
ok - complete process-event queue keys map to distinct seen markers
WAKE_ACK_REQUIRED: after handling completes run bin/fm-wake-drain.sh --ack-through 1 --recovery-generation 64019.1787242162.giprIW
ok - queue revalidation, proactive output, and marker commit serialize with drain
/Users/tiago/.no-mistakes/worktrees/bbb16e1f0808/01M0FY1GBT5A6JZKCM2ZK0CM10/bin/fm-push-transition-lib.sh: line 96: echo: write error: Broken pipe
tests/wake-helpers.sh: line 277: 66105 Killed: 9               PATH="$dir/fakebin:$PATH" FM_HOME="$dir" FM_PROCEVENT_CLAIM_ROOT="$dir/claims" FM_CREW_STATE_BIN="$dir/fakebin/fm-crew-state.sh" FM_POLL=0.2 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out"
tests/wake-helpers.sh: line 277: 67072 Killed: 9               PATH="$dir/fakebin:$PATH" FM_HOME="$dir" FM_PROCEVENT_CLAIM_ROOT="$dir/claims" FM_CREW_STATE_BIN="$dir/fakebin/fm-crew-state.sh" FM_POLL=0.2 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out"
ok - surfacing failures replay until post-handling acknowledgement
ok - marker failure exits through the shared wake owner, releases its lock, and replays later
ok - a heartbeat with no captain-relevant change is absorbed and backs off the cadence
ok - heartbeat backstop fail-safe surfaces a captain-relevant status the per-wake path missed
ok - the liveness beacon stays fresh while the watcher absorbs benign wakes (fm-guard never false-alarms)
ok - with .afk present the watcher reverts to one-shot so the daemon owns triage (no double-triage)
ok - AFK changed paused panes hand off plain stale identities for daemon-owned pause triage
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `tests/fm-watch-triage.test.sh:755` - The new comment says liveness is no longer consulted, but `pause_state_class` deliberately still reads it for dead-agent promotion. This test also retains the inverse contract in its function name, lines 883–885 and 981–1002, which still say the live gate surfaces despite asserting zero wakes. Update the wording to say liveness no longer suppresses a declared pause and the live gate is absorbed.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git status --short --branch` and base-to-target `git diff` inspection</code>
- <code>`bash tests/fm-watch-triage.test.sh` before and after the test-evidence wording correction; both runs exited 0</code>
- `Pre-fix transcript assertion for the corrected live-gate success label; it failed as expected`
- <code>Manual end-to-end invocation of `bin/fm-watch.sh` across real tmux classifier outcomes `alive`, `dead`, `ambiguous`, and `unreadable`</code>
- <code>Manual exited-agent check with authoritative `stopped` state, inspecting watcher stdout and the durable wake queue</code>
- `Final worktree and evidence-file hygiene inspection`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
