### PR TITLE
fix(bin): reconcile treehouse pool path spellings on a symlinked home

### DIFF
--- a/bin/fm-home-seed.sh
+++ b/bin/fm-home-seed.sh
@@ -49,6 +49,8 @@ SUB_HOME_PARENT_MARKER=".fm-secondmate-parent"
 . "$SCRIPT_DIR/fm-secondmate-charter-lib.sh"
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
+# shellcheck source=bin/fm-treehouse-lib.sh
+. "$SCRIPT_DIR/fm-treehouse-lib.sh"
 
 usage() {
   echo "usage: fm-home-seed.sh <id> <home|-> {<project>...|--no-projects}" >&2
@@ -582,7 +584,10 @@ seed_return_treehouse_home() {
     echo "warning: failed to return treehouse-acquired home $abs_home during seed rollback; treehouse command not found" >&2
     return 0
   fi
-  ( cd "$FM_ROOT" && treehouse return --force "$abs_home" >/dev/null ) || {
+  # The rollback target is resolved physical while treehouse's inventory holds its
+  # own as-written spelling, so reconcile the two before deciding the lease leaked;
+  # bin/fm-treehouse-lib.sh owns which spellings name this same directory.
+  fm_treehouse_return_force "$FM_ROOT" "$abs_home" >/dev/null || {
     echo "warning: failed to return treehouse-acquired home $abs_home during seed rollback; lease may still be held" >&2
     return 0
   }

--- a/bin/fm-install-herdr.sh
+++ b/bin/fm-install-herdr.sh
@@ -7,6 +7,7 @@
 #
 # Usage:
 #   fm-install-herdr.sh <destination-directory>
+#   fm-install-herdr.sh --required-version   print the exact Herdr pin
 #
 # Pins Herdr v0.7.4 (protocol 16), the suite-verified protocol-16 release.
 # Selects the official GitHub Releases asset for the host OS/arch, downloads
@@ -27,6 +28,14 @@ die() {
   printf 'fm-install-herdr.sh: %s\n' "$*" >&2
   exit 1
 }
+
+# Publish the pin through an interface so a suite that must match it never has to
+# read this file's source. Answered before the positional is consumed so it needs
+# no destination.
+if [ "${1:-}" = "--required-version" ]; then
+  printf '%s\n' "$FM_HERDR_CI_VERSION"
+  exit 0
+fi
 
 DESTINATION=${1:?usage: fm-install-herdr.sh <destination-directory>}
 

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -68,8 +68,10 @@
 # therefore tries each spelling that provably names the same directory, in the order
 # owned by bin/fm-treehouse-lib.sh, before spending the lock patience window below.
 # Only a spelling that resolves to the identical physical directory is ever tried, so
-# reconciliation can never return a different worktree, and a total failure still
-# reports the recorded path's own refusal rather than an alternative spelling's.
+# reconciliation can never return a different worktree. A total failure headlines the
+# recorded path's own refusal, then still reports any alternative spelling's failure
+# that is not merely an unmanaged-path refusal, so a real cause found under the
+# spelling treehouse does manage never hides behind the refusal of the one it does not.
 #
 # Transient / stale worktree git lock recovery (teardown-lock-race): a crew process
 # killed mid-git-operation can leave a .git/worktrees/<wt>/index.lock (or, for a
@@ -1081,7 +1083,7 @@ teardown_treehouse_note_spelling() { # <label> <used> <recorded>
 teardown_treehouse_return() {
   local dir=$1 cd_dir=$2 label=$3 post_cleanup_check=${4:-}
   local out lock attempt=0 max_retries lock_desc
-  local recorded=$dir spelling first_out='' first_seen=0 lock_hit=0
+  local recorded=$dir spelling first_out='' first_seen=0 other_out='' lock_hit=0
 
   # Try every spelling that provably names this same directory before spending
   # the lock patience window on any one of them, because treehouse matches its
@@ -1103,6 +1105,8 @@ teardown_treehouse_return() {
     if [ "$first_seen" -eq 0 ]; then
       first_out=$out
       first_seen=1
+    elif [ -n "$out" ] && ! fm_treehouse_is_unmanaged_refusal "$out"; then
+      other_out="$other_out$out"$'\n'
     fi
     if treehouse_return_is_index_lock_error "$out"; then
       teardown_treehouse_note_spelling "$label" "$spelling" "$recorded"
@@ -1115,9 +1119,12 @@ $(fm_treehouse_path_spellings "$recorded" || printf '%s\n' "$recorded")
 EOF
 
   if [ "$lock_hit" -eq 0 ]; then
-    # Report the recorded path's own failure; a refusal aimed at an alternative
-    # spelling describes a path the caller never recorded.
+    # Headline the recorded path's own failure, since a refusal aimed at an
+    # alternative spelling describes a path the caller never recorded. Anything an
+    # alternative spelling failed with for a different reason is the real cause,
+    # so keep it too rather than pointing the operator at a spelling mismatch.
     [ -n "$first_out" ] && printf '%s\n' "$first_out" >&2
+    [ -n "$other_out" ] && printf '%s' "$other_out" >&2
     return 1
   fi
   [ -n "$out" ] && printf '%s\n' "$out" >&2

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -59,6 +59,18 @@
 #   checks, and discards secondmate child work for kind=secondmate. Only use it
 #   when the captain has explicitly said to discard the work.
 #
+# Pool path spelling reconciliation (teardown-worktree-path): treehouse matches its
+# managed inventory by string and builds pool paths from its configured root exactly
+# as written, while firstmate records the fully resolved physical worktree path so its
+# liveness and worktree-isolation checks compare one exact directory. On a host whose
+# home is a symlink those two records name a single directory and differ as strings, so
+# the recorded path is refused with "is not managed by treehouse". teardown_treehouse_return
+# therefore tries each spelling that provably names the same directory, in the order
+# owned by bin/fm-treehouse-lib.sh, before spending the lock patience window below.
+# Only a spelling that resolves to the identical physical directory is ever tried, so
+# reconciliation can never return a different worktree, and a total failure still
+# reports the recorded path's own refusal rather than an alternative spelling's.
+#
 # Transient / stale worktree git lock recovery (teardown-lock-race): a crew process
 # killed mid-git-operation can leave a .git/worktrees/<wt>/index.lock (or, for a
 # non-linked worktree, .git/index.lock) that makes `treehouse return --force` fail
@@ -73,7 +85,8 @@
 #      attempts. Retries key off the error text, not whether the lock file still
 #      exists after the failed attempt - a lock that self-clears mid-check still
 #      deserves a retry of the return.
-#   2. Other treehouse return failures still abort immediately and loudly (no retry).
+#   2. Other treehouse return failures still abort immediately and loudly (no lock
+#      retry), once every equivalent spelling above has been tried.
 #   3. If every retry still hits the lock signature and the lock remains, it is removed
 #      and the return tried once more ONLY when the lock is provably stale per
 #      bin/fm-lock-lib.sh's fm_lock_is_provably_stale, passing the worktree dir as the
@@ -152,6 +165,8 @@ SUB_HOME_PARENT_MARKER=".fm-secondmate-parent"
 . "$SCRIPT_DIR/fm-control-lib.sh"
 # shellcheck source=bin/fm-lock-lib.sh
 . "$SCRIPT_DIR/fm-lock-lib.sh"
+# shellcheck source=bin/fm-treehouse-lib.sh
+. "$SCRIPT_DIR/fm-treehouse-lib.sh"
 # shellcheck source=bin/fm-classify-lib.sh
 . "$SCRIPT_DIR/fm-classify-lib.sh"
 # shellcheck source=bin/fm-gate-refuse-lib.sh
@@ -1056,23 +1071,56 @@ cleanup_stale_lock_for_safety_check() {
   return "$TEARDOWN_TREEHOUSE_LOCK_REFUSED"
 }
 
-# Return a worktree/home via `treehouse return --force`, tolerating a transient or
+teardown_treehouse_note_spelling() { # <label> <used> <recorded>
+  [ "$2" = "$3" ] || echo "teardown: $1 return matched treehouse's pool path $2 for recorded worktree $3 (same directory, different spelling)" >&2
+}
+
+# Return a worktree/home via `treehouse return --force`, reconciling the recorded
+# path spelling with the one treehouse manages and tolerating a transient or
 # stale git index.lock left by a killed crew process. See the script header.
 teardown_treehouse_return() {
   local dir=$1 cd_dir=$2 label=$3 post_cleanup_check=${4:-}
   local out lock attempt=0 max_retries lock_desc
+  local recorded=$dir spelling first_out='' first_seen=0 lock_hit=0
 
-  # Capture stdout+stderr so non-lock failures stay visible and lock failures can
-  # be matched by signature even when the lock file is already gone mid-check.
-  if out=$( ( cd "$cd_dir" && treehouse return --force "$dir" ) 2>&1 ); then
-    [ -n "$out" ] && printf '%s\n' "$out"
-    return 0
-  fi
-  [ -n "$out" ] && printf '%s\n' "$out" >&2
+  # Try every spelling that provably names this same directory before spending
+  # the lock patience window on any one of them, because treehouse matches its
+  # managed inventory by string and accepts only the spelling built from its own
+  # as-written root. bin/fm-treehouse-lib.sh owns which spellings qualify and
+  # the invariant that each resolves to the identical physical directory, so an
+  # alternative spelling can never return a different worktree. Capture
+  # stdout+stderr so non-lock failures stay visible and lock failures can be
+  # matched by signature even when the lock file is already gone mid-check. An
+  # index.lock signature proves treehouse already recognized that spelling, so
+  # keep it and drop into the patience window rather than trying another.
+  while IFS= read -r spelling; do
+    [ -n "$spelling" ] || continue
+    if out=$( ( cd "$cd_dir" && treehouse return --force "$spelling" ) 2>&1 ); then
+      [ -n "$out" ] && printf '%s\n' "$out"
+      teardown_treehouse_note_spelling "$label" "$spelling" "$recorded"
+      return 0
+    fi
+    if [ "$first_seen" -eq 0 ]; then
+      first_out=$out
+      first_seen=1
+    fi
+    if treehouse_return_is_index_lock_error "$out"; then
+      teardown_treehouse_note_spelling "$label" "$spelling" "$recorded"
+      lock_hit=1
+      dir=$spelling
+      break
+    fi
+  done <<EOF
+$(fm_treehouse_path_spellings "$recorded" || printf '%s\n' "$recorded")
+EOF
 
-  if ! treehouse_return_is_index_lock_error "$out"; then
+  if [ "$lock_hit" -eq 0 ]; then
+    # Report the recorded path's own failure; a refusal aimed at an alternative
+    # spelling describes a path the caller never recorded.
+    [ -n "$first_out" ] && printf '%s\n' "$first_out" >&2
     return 1
   fi
+  [ -n "$out" ] && printf '%s\n' "$out" >&2
 
   lock=$(worktree_git_lock_path "$dir") || lock=""
   if [ -n "$lock" ]; then

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -941,6 +941,16 @@ families_for_changed_path() {
       printf '%s\n' pure-contract-unit
       printf '%s\n' pr-forge
       ;;
+    bin/fm-treehouse-lib.sh)
+      # Shared pool-path spelling reconciliation, sourced by bin/fm-teardown.sh's
+      # worktree return (pr-forge), bin/fm-home-seed.sh's seed rollback
+      # (secondmate), and the real-Herdr suites' own pool cleanup. Naming the
+      # portable consumers matters because the real-Herdr family gate-skips on any
+      # host without the pinned build.
+      printf '%s\n' pr-forge
+      printf '%s\n' secondmate
+      printf '%s\n' real-herdr-gated
+      ;;
     bin/fm-composer-lib.sh)
       # The shared shape catalogue is vendor-rendered signal; a change to it
       # re-selects the live guard (fm-composer-matrix-live-e2e) alongside the

--- a/bin/fm-treehouse-lib.sh
+++ b/bin/fm-treehouse-lib.sh
@@ -41,15 +41,23 @@
 #       Fails and prints nothing when <recorded-path> is not an existing
 #       directory.
 #
+#   fm_treehouse_is_unmanaged_refusal <output>
+#       True when the output is treehouse refusing a path only because that exact
+#       spelling is absent from its managed inventory. That is the one failure an
+#       alternative spelling explains away; every other failure says something
+#       real about the worktree and must reach the operator.
+#
 #   fm_treehouse_return_force <cd-dir> <recorded-path> [treehouse-bin]
 #       Run `treehouse return --force` from <cd-dir> (empty means the current
 #       directory), trying each spelling until one is accepted, and print the
 #       accepted attempt's output. On total failure returns 1 and reports the
 #       first attempt's output, the one describing the caller's own recorded
-#       path; an intermediate spelling's refusal is dropped because it describes
-#       a path the caller never recorded. [treehouse-bin] defaults to
-#       `treehouse` and exists for a caller that must bypass a PATH wrapper,
-#       such as a test with an instrumented fake.
+#       path, as the headline, followed by any later attempt's output that is not
+#       an unmanaged-path refusal. A later spelling's own refusal is dropped
+#       because it describes a path the caller never recorded, but a later
+#       spelling's genuinely different failure is the real cause and is kept.
+#       [treehouse-bin] defaults to `treehouse` and exists for a caller that must
+#       bypass a PATH wrapper, such as a test with an instrumented fake.
 set -u
 
 fm_treehouse_physical_dir() { # <path>
@@ -93,9 +101,13 @@ $candidates
 EOF
 }
 
+fm_treehouse_is_unmanaged_refusal() { # <output>
+  printf '%s\n' "${1:-}" | grep -Fq 'is not managed by treehouse'
+}
+
 fm_treehouse_return_force() { # <cd-dir> <recorded-path> [treehouse-bin]
   local cd_dir=${1:-} recorded=${2:-} bin=${3:-treehouse}
-  local spellings spelling out first_out='' first_seen=0
+  local spellings spelling out first_out='' first_seen=0 other_out=''
 
   [ -n "$recorded" ] || return 1
   [ -n "$cd_dir" ] || cd_dir=.
@@ -112,11 +124,14 @@ fm_treehouse_return_force() { # <cd-dir> <recorded-path> [treehouse-bin]
     if [ "$first_seen" -eq 0 ]; then
       first_out=$out
       first_seen=1
+    elif [ -n "$out" ] && ! fm_treehouse_is_unmanaged_refusal "$out"; then
+      other_out="$other_out$out"$'\n'
     fi
   done <<EOF
 $spellings
 EOF
 
   [ -n "$first_out" ] && printf '%s\n' "$first_out" >&2
+  [ -n "$other_out" ] && printf '%s' "$other_out" >&2
   return 1
 }

--- a/bin/fm-treehouse-lib.sh
+++ b/bin/fm-treehouse-lib.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# fm-treehouse-lib.sh - the single owner of pool-path spelling reconciliation
+# between firstmate's recorded worktree paths and treehouse's managed inventory.
+#
+# Sourced, never executed.
+#
+# Why this exists: treehouse builds pool paths from its configured root exactly
+# as that root is written, and the root defaults to `$HOME` used literally, so
+# its inventory holds `/home/you/.treehouse/...`. Firstmate records the fully
+# resolved physical path instead, because its liveness and worktree-isolation
+# checks must prove one exact directory rather than compare strings that merely
+# look equal. On a host whose home is a symlink the two records name a single
+# directory yet differ as strings, and treehouse matches its inventory by
+# string, so it refuses the physical spelling as "not managed by treehouse".
+#
+# Both records are right for their own purpose, so this library reconciles the
+# spellings where they are used instead of making either side adopt the other's.
+# That is the same shape bin/fm-teardown.sh's worktree_registered_for_project
+# already uses for git's worktree list: resolve both sides, then compare.
+#
+# Safety invariant: a candidate spelling is offered only when it provably
+# resolves to the same physical directory as the caller's own record, so
+# reconciliation can never act on a worktree other than the recorded one.
+#
+# Not owned here: retry policy, deliberately. bin/fm-teardown.sh iterates the
+# spellings itself because it interleaves its git index.lock patience window,
+# while simpler callers use fm_treehouse_return_force below. The spelling
+# knowledge lives here; each caller's own patience stays where it belongs.
+#
+# Usage:
+#   . "$SCRIPT_DIR/fm-treehouse-lib.sh"
+#
+#   fm_treehouse_physical_dir <path>
+#       Print the physical directory <path> names. Fails when <path> is empty or
+#       is not an existing directory.
+#
+#   fm_treehouse_path_spellings <recorded-path>
+#       Print each distinct spelling that provably names the same directory as
+#       <recorded-path>, one per line, the recorded spelling first so a host
+#       whose spellings already agree keeps exactly its previous single attempt.
+#       Fails and prints nothing when <recorded-path> is not an existing
+#       directory.
+#
+#   fm_treehouse_return_force <cd-dir> <recorded-path> [treehouse-bin]
+#       Run `treehouse return --force` from <cd-dir> (empty means the current
+#       directory), trying each spelling until one is accepted, and print the
+#       accepted attempt's output. On total failure returns 1 and reports the
+#       first attempt's output, the one describing the caller's own recorded
+#       path; an intermediate spelling's refusal is dropped because it describes
+#       a path the caller never recorded. [treehouse-bin] defaults to
+#       `treehouse` and exists for a caller that must bypass a PATH wrapper,
+#       such as a test with an instrumented fake.
+set -u
+
+fm_treehouse_physical_dir() { # <path>
+  local target=$1
+  [ -n "$target" ] || return 1
+  [ -d "$target" ] || return 1
+  ( cd "$target" && pwd -P )
+}
+
+fm_treehouse_path_spellings() { # <recorded-path>
+  local recorded=$1 physical home_physical candidates candidate resolved seen
+  [ -n "$recorded" ] || return 1
+  physical=$(fm_treehouse_physical_dir "$recorded") || return 1
+
+  # Candidate order is deliberate: the caller's own record first, then the
+  # $HOME-rooted rewrite that treehouse's as-written default root produces on a
+  # symlinked home, then the fully resolved spelling for a pool whose root is
+  # configured physical while the record carries a symlinked prefix.
+  candidates=$recorded
+  if [ -n "${HOME:-}" ] && home_physical=$(fm_treehouse_physical_dir "$HOME") &&
+    [ "$home_physical" != "$HOME" ]; then
+    case "$physical" in
+      "$home_physical") candidates="$candidates"$'\n'"$HOME" ;;
+      "$home_physical"/*) candidates="$candidates"$'\n'"$HOME${physical#"$home_physical"}" ;;
+    esac
+  fi
+  candidates="$candidates"$'\n'"$physical"
+
+  # Newline-delimited rather than an array so a path containing spaces is safe
+  # without depending on how a given bash treats an empty array under `set -u`.
+  seen=$'\n'
+  while IFS= read -r candidate; do
+    [ -n "$candidate" ] || continue
+    case "$seen" in *$'\n'"$candidate"$'\n'*) continue ;; esac
+    resolved=$(fm_treehouse_physical_dir "$candidate") || continue
+    [ "$resolved" = "$physical" ] || continue
+    seen="$seen$candidate"$'\n'
+    printf '%s\n' "$candidate"
+  done <<EOF
+$candidates
+EOF
+}
+
+fm_treehouse_return_force() { # <cd-dir> <recorded-path> [treehouse-bin]
+  local cd_dir=${1:-} recorded=${2:-} bin=${3:-treehouse}
+  local spellings spelling out first_out='' first_seen=0
+
+  [ -n "$recorded" ] || return 1
+  [ -n "$cd_dir" ] || cd_dir=.
+  # A record that does not resolve falls back to itself, so the caller sees
+  # exactly the refusal it would have seen without any reconciliation.
+  spellings=$(fm_treehouse_path_spellings "$recorded") || spellings=$recorded
+
+  while IFS= read -r spelling; do
+    [ -n "$spelling" ] || continue
+    if out=$( ( cd "$cd_dir" && "$bin" return --force "$spelling" ) 2>&1 ); then
+      [ -n "$out" ] && printf '%s\n' "$out"
+      return 0
+    fi
+    if [ "$first_seen" -eq 0 ]; then
+      first_out=$out
+      first_seen=1
+    fi
+  done <<EOF
+$spellings
+EOF
+
+  [ -n "$first_out" ] && printf '%s\n' "$first_out" >&2
+  return 1
+}

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -316,6 +316,7 @@ Tests use thin compatibility wrappers in `tests/herdr-test-safety.sh` and never 
 
 - Herdr remains experimental.
 - Presentation ordering needs protocol 16 and Python and is best-effort only.
+- On Herdr 0.8.2 a projected task cleanup does not remove that task's presentation workspace, so one orphaned workspace is left behind per cleanup; `herdr-082-projection-orphan-o4` owns that defect.
 - Mutable labels can collide; they are never placement or destructive authority.
 - A Firstmate outside Herdr cannot resolve a launcher workspace, so a colliding home label refuses new spawns until the collision is cleared.
 - Ghost and placeholder recognition uses ANSI de-emphasis when available; an unstyled glyph row carrying trailing non-idle text fails safely to `unknown`.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -86,6 +86,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-supervision-lib.sh`  | Shared in-flight-work-without-fresh-watcher-beacon predicate                         |
 | `fm-ff-lib.sh`           | Shared guarded fast-forward helper for origin pulls and local secondmate syncs       |
 | `fm-lock-lib.sh`         | Shared "is this git lock provably abandoned?" proof used by teardown and fleet-sync   |
+| `fm-treehouse-lib.sh`    | Single owner of pool-path spelling reconciliation between recorded physical worktrees and treehouse's own inventory |
 | `fm-config-inherit-lib.sh` | Shared primary-to-secondmate inherited local-material propagation and config-reread delivery |
 | `fm-tasks-axi-lib.sh`    | Shared backlog-backend selector and `tasks-axi` compatibility probe                  |
 | `fm-quota-axi-lib.sh`    | Shared `quota-axi` compatibility floor for the bootstrap diagnostic                  |

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -351,6 +351,9 @@ HERDR_LAB_HELPER=bin/fm-herdr-lab.sh \
 
 Observed guarantee: the primary and secondmate used distinct home workspaces, a child launched by the secondmate stayed in that secondmate workspace, list-live remained home-scoped, and exact cleanup did not affect sibling homes.
 
+`tests/fm-backend-herdr-presentation-e2e.test.sh` runs only on the exact Herdr pin that `bin/fm-install-herdr.sh --required-version` publishes, and skips on any other installed release, because its fixtures encode one release's pane and workspace lifecycle; the suite's own gate comment owns that reasoning, and an unreadable pin or installed version fails loudly instead of skipping.
+The dated runs below on other releases therefore predate that gate: each remains the evidence for the behavior it records, while a rerun on anything but the pin now skips the suite rather than reproducing it.
+
 The complete projection suite ran on 2026-07-21 against Herdr 0.7.4 protocol 16:
 
 ```sh
@@ -496,7 +499,7 @@ HERDR_LAB_HELPER=bin/fm-herdr-lab.sh bin/fm-test-run.sh --lane real-herdr-gated
 ```
 
 Both runs reported `family=real-herdr-gated count=11 failed=0`.
-The projection suite's unconfigured-home case is release-aware rather than pinned to one outcome, so it proves the projected default on 0.8.0 and the flat fallback with its naming warning on 0.7.4:
+The projection suite's unconfigured-home case was release-aware rather than pinned to one outcome, so that run proved the projected default on 0.8.0 and the flat fallback with its naming warning on 0.7.4:
 
 ```text
 ok - real Herdr lab: a home that configured nothing is projected by default on herdr 0.8.0
@@ -504,6 +507,7 @@ ok - real Herdr lab: a home that configured nothing falls back flat on below-flo
 ```
 
 Every other case in that suite uses an explicit opt-in or opt-out, so the floor leaves them unchanged on both releases.
+Under the pin gate that unconfigured-home case can now reach only its below-floor 0.7.4 branch, so the at-or-above outcome stays enforced by the portable floor classifier above.
 
 Direct lab probes on 2026-07-28 established the removal rules the emptying-close plan relies on, each verified with `workspace list` focus reads around one mutation in a guarded `fm-lab-` session:
 

--- a/tests/fm-backend-autodetect-smoke.test.sh
+++ b/tests/fm-backend-autodetect-smoke.test.sh
@@ -45,6 +45,10 @@ export FM_GATE_REFUSE_BYPASS=1
 
 # shellcheck source=tests/herdr-test-safety.sh
 . "$ROOT/tests/herdr-test-safety.sh"
+# Cleanup returns the worktree by its recorded physical path, which treehouse's
+# own inventory may spell differently on a symlinked home.
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-treehouse-lib.sh"
 # This suite asserts that HERDR_ENV=1 alone selects the backend, and it runs
 # against its own isolated lab session. A Herdr pane inherited from the terminal
 # it was launched in must not follow spawn into that session as a cross-session
@@ -69,7 +73,7 @@ ID="autodetectsmoke1"
 WT=
 cleanup_all() {
   local cleanup_status=0
-  [ -n "$WT" ] && command -v treehouse >/dev/null 2>&1 && treehouse return --force "$WT" >/dev/null 2>&1
+  [ -n "$WT" ] && command -v treehouse >/dev/null 2>&1 && fm_treehouse_return_force "" "$WT" >/dev/null 2>&1
   "$HERDR_LAB_HELPER" teardown "$HERDR_LAB_SESSION" || cleanup_status=$?
   rm -rf "$TMP_ROOT"
   return "$cleanup_status"

--- a/tests/fm-backend-herdr-launcher-workspace-e2e.test.sh
+++ b/tests/fm-backend-herdr-launcher-workspace-e2e.test.sh
@@ -41,6 +41,10 @@ command -v treehouse >/dev/null 2>&1 || { echo "skip: treehouse not found (requi
 
 # shellcheck source=tests/herdr-test-safety.sh
 . "$ROOT/tests/herdr-test-safety.sh"
+# Cleanup returns worktrees by their recorded physical path, which treehouse's
+# own inventory may spell differently on a symlinked home.
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-treehouse-lib.sh"
 
 # Every spawn below states its own launcher identity, so a pane inherited from
 # the terminal this suite was started in must not leak into any of them.
@@ -65,7 +69,7 @@ cleanup_all() {
   [ "$CLEANED" = 0 ] || return 0
   CLEANED=1
   for wt in ${WORKTREES[@]+"${WORKTREES[@]}"}; do
-    [ -n "$wt" ] && treehouse return --force "$wt" >/dev/null 2>&1
+    [ -n "$wt" ] && fm_treehouse_return_force "" "$wt" >/dev/null 2>&1
   done
   WORKTREES=()
   "$HERDR_LAB_HELPER" teardown "$HERDR_LAB_SESSION" || status=$?

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -29,15 +29,15 @@ REAL_TREEHOUSE=$(command -v treehouse)
 # That difference is a real product gap tracked as its own task. Skipping keeps
 # it visible rather than adapting these fixtures to whatever the local release
 # happens to do, which would print a green tick over a live defect.
-# bin/fm-install-herdr.sh stays the single owner of the pin, so read the number
-# from there instead of repeating it here. An unreadable pin or an unreadable
-# installed version is a loud failure and never a silent skip, because a skip
-# nobody can trust would quietly disable this whole lane. The required Herdr CI
-# lane also asserts the pin before it runs any suite, so a skip here cannot hide
-# a mispinned runner.
-HERDR_SUITE_PIN=$(sed -n 's/^FM_HERDR_CI_VERSION=\([0-9][0-9.]*\)$/\1/p' "$ROOT/bin/fm-install-herdr.sh" | head -1)
+# bin/fm-install-herdr.sh stays the single owner of the pin, so ask it for the
+# number through its --required-version interface instead of repeating it here or
+# reading its source. An unreadable pin or an unreadable installed version is a
+# loud failure and never a silent skip, because a skip nobody can trust would
+# quietly disable this whole lane. The required Herdr CI lane also asserts the pin
+# before it runs any suite, so a skip here cannot hide a mispinned runner.
+HERDR_SUITE_PIN=$("$ROOT/bin/fm-install-herdr.sh" --required-version 2>/dev/null) || HERDR_SUITE_PIN=
 [ -n "$HERDR_SUITE_PIN" ] \
-  || { echo "not ok - could not read the exact Herdr pin from bin/fm-install-herdr.sh" >&2; exit 1; }
+  || { echo "not ok - could not read the exact Herdr pin from bin/fm-install-herdr.sh --required-version" >&2; exit 1; }
 HERDR_SUITE_VERSION=$("$REAL_HERDR" --version 2>/dev/null | awk '{print $2; exit}')
 [ -n "$HERDR_SUITE_VERSION" ] \
   || { echo "not ok - could not read the installed Herdr version from $REAL_HERDR" >&2; exit 1; }

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -19,6 +19,33 @@ command -v treehouse >/dev/null 2>&1 || { echo "skip: treehouse not found"; exit
 
 REAL_HERDR=$(command -v herdr)
 REAL_TREEHOUSE=$(command -v treehouse)
+
+# This suite is only honest on the exact CI pin, because its assertions encode
+# one release's pane and workspace lifecycle. On herdr 0.8.2, for example,
+# closing a tab's last pane respawns a replacement pane, so a projected
+# workspace never becomes empty, the emptying-close plan in bin/backends/herdr.sh
+# never matches, a projected workspace is therefore never removed by a pane
+# close, and the ordering assertions below see a leftover fixture workspace.
+# That difference is a real product gap tracked as its own task. Skipping keeps
+# it visible rather than adapting these fixtures to whatever the local release
+# happens to do, which would print a green tick over a live defect.
+# bin/fm-install-herdr.sh stays the single owner of the pin, so read the number
+# from there instead of repeating it here. An unreadable pin or an unreadable
+# installed version is a loud failure and never a silent skip, because a skip
+# nobody can trust would quietly disable this whole lane. The required Herdr CI
+# lane also asserts the pin before it runs any suite, so a skip here cannot hide
+# a mispinned runner.
+HERDR_SUITE_PIN=$(sed -n 's/^FM_HERDR_CI_VERSION=\([0-9][0-9.]*\)$/\1/p' "$ROOT/bin/fm-install-herdr.sh" | head -1)
+[ -n "$HERDR_SUITE_PIN" ] \
+  || { echo "not ok - could not read the exact Herdr pin from bin/fm-install-herdr.sh" >&2; exit 1; }
+HERDR_SUITE_VERSION=$("$REAL_HERDR" --version 2>/dev/null | awk '{print $2; exit}')
+[ -n "$HERDR_SUITE_VERSION" ] \
+  || { echo "not ok - could not read the installed Herdr version from $REAL_HERDR" >&2; exit 1; }
+if [ "$HERDR_SUITE_VERSION" != "$HERDR_SUITE_PIN" ]; then
+  echo "skip: herdr $HERDR_SUITE_VERSION is not the suite-verified pin $HERDR_SUITE_PIN; install it with bin/fm-install-herdr.sh"
+  exit 0
+fi
+
 HERDR_ORIGINAL_PATH=$PATH
 TMP_ROOT=$(mktemp -d "$(cd "${TMPDIR:-/tmp}" && pwd -P)/fm-herdr-presentation.XXXXXX")
 FAKEBIN="$TMP_ROOT/fakebin"

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -255,6 +255,8 @@ export FM_BACKEND_HERDR_WORKSPACE_MOVER="$FAKEBIN/herdr-workspace-mover"
 
 # shellcheck source=tests/herdr-test-safety.sh
 . "$ROOT/tests/herdr-test-safety.sh"
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-treehouse-lib.sh"
 # This suite runs against its own isolated lab session, so a Herdr pane
 # inherited from the terminal it was launched in must not follow spawn into it
 # as a cross-session parent identity. Every projection below is anchored on the
@@ -267,6 +269,17 @@ export HERDR_SESSION="$HERDR_LAB_SESSION" HERDR_LAB_SESSION
 LAB_READY=0
 RECORDED_WORKTREES=""
 LOCK_CONTENTION_OWNER_PID=
+
+# Give one pool worktree back, best effort. Recorded worktrees carry fm-spawn's
+# resolved physical spelling while treehouse's inventory holds the spelling its
+# as-written root produces, so a symlinked home makes a raw return silently
+# refuse and orphan the slot. Every return below goes through this so the suite
+# releases slots as it advances instead of exhausting the pool mid-run.
+return_pool_worktree() { # <recorded-worktree>
+  [ -n "${1:-}" ] || return 0
+  fm_treehouse_return_force "" "$1" "$REAL_TREEHOUSE" >/dev/null 2>&1 || true
+}
+
 cleanup_all() {
   local wt
   if [ -n "$LOCK_CONTENTION_OWNER_PID" ]; then
@@ -277,7 +290,7 @@ cleanup_all() {
   while IFS= read -r wt; do
     [ -n "$wt" ] || continue
     [ -d "$wt" ] || continue
-    "$REAL_TREEHOUSE" return --force "$wt" >/dev/null 2>&1 || true
+    return_pool_worktree "$wt"
   done <<EOF
 $RECORDED_WORKTREES
 EOF
@@ -1211,15 +1224,15 @@ for RESTART_ID in fm-hibit-resume-r1 wheelhouse-healing-r1; do
       || fail "$RESTART_ID repeated reclaim changed workspace identity"
     [ "$NEW_RESTART_PANE" != "$PRIOR_RESTART_PANE" ] \
       || fail "$RESTART_ID repeated reclaim reused the prior husk pane"
-    "$REAL_TREEHOUSE" return --force "$PRIOR_RESTART_WT" >/dev/null 2>&1 || true
+    return_pool_worktree "$PRIOR_RESTART_WT"
   fi
 
   teardown_task "$RESTART_ID" "$HOME_DIR" > "$TMP_ROOT/$RESTART_ID-teardown.out" 2> "$TMP_ROOT/$RESTART_ID-teardown.err" \
     || fail "$RESTART_ID teardown after reclaim failed: $(cat "$TMP_ROOT/$RESTART_ID-teardown.err")"
   [ ! -e "$HOME_DIR/state/$RESTART_ID.herdr-presentation" ] \
     || fail "$RESTART_ID exact reclaimed teardown did not retire its journal"
-  "$REAL_TREEHOUSE" return --force "$OLD_RESTART_WT" >/dev/null 2>&1 || true
-  "$REAL_TREEHOUSE" return --force "$NEW_RESTART_WT" >/dev/null 2>&1 || true
+  return_pool_worktree "$OLD_RESTART_WT"
+  return_pool_worktree "$NEW_RESTART_WT"
 done
 pass "real Herdr lab: Hi Bit and Wheelhouse-style same-identity restarts reclaim one nested space with exact focus and idempotence"
 
@@ -1254,8 +1267,8 @@ CROSS_NEW_PANE=$(grep '^herdr_pane_id=' "$CROSS_RESTART_META" | cut -d= -f2-)
   || fail "cross-home reclaim changed the secondmate child's presentation label"
 teardown_task "$CROSS_RESTART_ID" "$SECOND_HOME_A" > "$TMP_ROOT/cross-restart-teardown.out" 2> "$TMP_ROOT/cross-restart-teardown.err" \
   || fail "cross-home reclaimed teardown failed: $(cat "$TMP_ROOT/cross-restart-teardown.err")"
-"$REAL_TREEHOUSE" return --force "$CROSS_OLD_WT" >/dev/null 2>&1 || true
-"$REAL_TREEHOUSE" return --force "$CROSS_NEW_WT" >/dev/null 2>&1 || true
+return_pool_worktree "$CROSS_OLD_WT"
+return_pool_worktree "$CROSS_NEW_WT"
 pass "real Herdr lab: secondmate restart binding and reclaim stay isolated to the exact child home and parent"
 
 # Two homes recovering concurrently serialize on the named session lock and
@@ -1307,10 +1320,10 @@ teardown_task "$PRIMARY_WAVE_ID" "$HOME_DIR" > "$TMP_ROOT/primary-wave-teardown.
   || fail "concurrent primary recovery teardown failed"
 teardown_task "$BRAVO_WAVE_ID" "$SECOND_HOME_B" > "$TMP_ROOT/bravo-wave-teardown.out" 2> "$TMP_ROOT/bravo-wave-teardown.err" \
   || fail "concurrent secondmate recovery teardown failed"
-"$REAL_TREEHOUSE" return --force "$PRIMARY_WAVE_OLD_WT" >/dev/null 2>&1 || true
-"$REAL_TREEHOUSE" return --force "$BRAVO_WAVE_OLD_WT" >/dev/null 2>&1 || true
-"$REAL_TREEHOUSE" return --force "$PRIMARY_WAVE_NEW_WT" >/dev/null 2>&1 || true
-"$REAL_TREEHOUSE" return --force "$BRAVO_WAVE_NEW_WT" >/dev/null 2>&1 || true
+return_pool_worktree "$PRIMARY_WAVE_OLD_WT"
+return_pool_worktree "$BRAVO_WAVE_OLD_WT"
+return_pool_worktree "$PRIMARY_WAVE_NEW_WT"
+return_pool_worktree "$BRAVO_WAVE_NEW_WT"
 pass "real Herdr lab: concurrent cross-home recoveries replace exact husks under one session lock with no focus drift"
 
 # Seed a legacy old-format primary projection and a flat secondmate tab; correction must not migrate them.

--- a/tests/fm-backend-herdr-workspace-per-home-e2e.test.sh
+++ b/tests/fm-backend-herdr-workspace-per-home-e2e.test.sh
@@ -53,6 +53,10 @@ command -v treehouse >/dev/null 2>&1 || { echo "skip: treehouse not found (requi
 
 # shellcheck source=tests/herdr-test-safety.sh
 . "$ROOT/tests/herdr-test-safety.sh"
+# Cleanup returns worktrees by their recorded physical path, which treehouse's
+# own inventory may spell differently on a symlinked home.
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-treehouse-lib.sh"
 
 # This suite runs against its own isolated lab session, so a Herdr pane
 # inherited from the terminal it was launched in must not follow spawn into it
@@ -70,8 +74,8 @@ SESSION="fm-lab-herdr-e2e-$$"
 export HERDR_SESSION="$SESSION"
 WT1=; WT2=
 cleanup_all() {
-  [ -n "$WT1" ] && command -v treehouse >/dev/null 2>&1 && treehouse return --force "$WT1" >/dev/null 2>&1
-  [ -n "$WT2" ] && command -v treehouse >/dev/null 2>&1 && treehouse return --force "$WT2" >/dev/null 2>&1
+  [ -n "$WT1" ] && command -v treehouse >/dev/null 2>&1 && fm_treehouse_return_force "" "$WT1" >/dev/null 2>&1
+  [ -n "$WT2" ] && command -v treehouse >/dev/null 2>&1 && fm_treehouse_return_force "" "$WT2" >/dev/null 2>&1
   herdr_safe_stop_and_delete "$SESSION"
   rm -rf "$TMP_ROOT"
 }

--- a/tests/fm-gotmp.test.sh
+++ b/tests/fm-gotmp.test.sh
@@ -61,6 +61,9 @@ make_fake_root() {
   ln -s "$ROOT/bin/fm-nm-run-lib.sh" "$fake/bin/fm-nm-run-lib.sh"
   # fm-lock-lib.sh: teardown sources it for the shared lock-staleness proof.
   ln -s "$ROOT/bin/fm-lock-lib.sh" "$fake/bin/fm-lock-lib.sh"
+  # fm-treehouse-lib.sh: teardown sources it for the shared pool-path spelling
+  # reconciliation used by its treehouse return.
+  ln -s "$ROOT/bin/fm-treehouse-lib.sh" "$fake/bin/fm-treehouse-lib.sh"
   # Lifecycle serialization, status presentation retirement, and shared adapter
   # ownership are sourced by teardown.
   ln -s "$ROOT/bin/fm-control-lib.sh" "$fake/bin/fm-control-lib.sh"
@@ -141,6 +144,7 @@ test_teardown_skips_gracefully_without_tasktmp() {
   ln -s "$ROOT/bin/fm-composer-lib.sh" "$fake/bin/fm-composer-lib.sh"
   ln -s "$ROOT/bin/fm-nm-run-lib.sh" "$fake/bin/fm-nm-run-lib.sh"
   ln -s "$ROOT/bin/fm-lock-lib.sh" "$fake/bin/fm-lock-lib.sh"
+  ln -s "$ROOT/bin/fm-treehouse-lib.sh" "$fake/bin/fm-treehouse-lib.sh"
   ln -s "$ROOT/bin/fm-control-lib.sh" "$fake/bin/fm-control-lib.sh"
   ln -s "$ROOT/bin/fm-classify-lib.sh" "$fake/bin/fm-classify-lib.sh"
   ln -s "$ROOT/bin/fm-wake-lib.sh" "$fake/bin/fm-wake-lib.sh"

--- a/tests/fm-secondmate-safety.test.sh
+++ b/tests/fm-secondmate-safety.test.sh
@@ -324,6 +324,61 @@ test_home_seed_returns_treehouse_acquired_home_on_assignment_failure() {
   pass "home seeding returns rejected acquired homes through treehouse"
 }
 
+# The seed records the acquired home by its resolved physical path while treehouse
+# holds the spelling its as-written root produces, so on a host whose home is a
+# symlink the two name one directory and differ as strings. Treehouse matches its
+# inventory by string, so without reconciliation the rollback return is refused as
+# unmanaged and the durable lease leaks silently behind a warning. The fake here
+# manages only the $HOME-rooted spelling, so a return that lands proves the
+# rollback reconciled the two rather than that the fake accepts anything.
+test_home_seed_rollback_return_reconciles_symlinked_home_spelling() {
+  local home pool pool_phys home_link acquired acquired_abs managed
+  local fakebin log lease err returns
+  home="$TMP_ROOT/dash-spelling-home"
+  pool="$TMP_ROOT/dash-spelling-pool"
+  err="$TMP_ROOT/dash-spelling.err"
+  mkdir -p "$home/projects" "$home/data" "$home/state" "$pool"
+  fm_git_init_commit "$home/projects/alpha"
+  fm_git_add_origin "$home/projects/alpha" "$TMP_ROOT/remotes/dash-spelling-alpha.git"
+  printf '%s\n' '- alpha [direct-PR] - alpha project (added 2026-06-22)' > "$home/data/projects.md"
+
+  # A symlinked home whose target holds the pool, the shape of this host. The link
+  # points at a sibling directory so the fixture holds no self-referential loop.
+  pool_phys=$(cd "$pool" && pwd -P)
+  home_link="$TMP_ROOT/dash-spelling-home-link"
+  ln -s "$pool_phys" "$home_link"
+  acquired="$pool_phys/dash-spelling-acquired-home"
+  git clone --quiet "$ROOT" "$acquired"
+  acquired_abs=$(cd "$acquired" && pwd -P)
+  managed="$home_link/dash-spelling-acquired-home"
+  [ "$managed" != "$acquired_abs" ] \
+    || fail "precondition: the fixture's two spellings must differ as strings"
+  printf 'other\n' > "$acquired/.fm-secondmate-home"
+  fakebin=$(make_fake_tmux "$TMP_ROOT/dash-spelling-fake")
+  log="$TMP_ROOT/dash-spelling-fake/tmux.log"
+  lease="$TMP_ROOT/dash-spelling-fake/lease"
+
+  if PATH="$fakebin:$PATH" HOME="$home_link" FM_HOME="$home" \
+    FM_FAKE_TREEHOUSE_HOME="$acquired" FM_FAKE_TMUX_LOG="$log" \
+    FM_FAKE_TREEHOUSE_LEASE_FILE="$lease" FM_FAKE_TREEHOUSE_MANAGED="$managed" \
+    FM_SECONDMATE_CHARTER='dash acquired scope' FM_SECONDMATE_SCOPE='dash acquired scope' \
+    "$ROOT/bin/fm-home-seed.sh" dash - alpha >/dev/null 2>"$err"; then
+    fail "seed reused an acquired home marked for another secondmate"
+  fi
+  grep -F 'already marked for other' "$err" >/dev/null \
+    || fail "seed did not explain acquired marked-home rejection"
+  grep -F 'lease may still be held' "$err" >/dev/null \
+    && fail "seed rollback reported a leaked lease instead of reconciling the two spellings"
+  returns=$(grep -F 'treehouse return --force' "$log" | sed 's/^treehouse return --force //')
+  [ "$(printf '%s\n' "$returns" | sed -n 1p)" = "$acquired_abs" ] \
+    || fail "seed rollback did not try its own recorded spelling first"
+  [ "$(printf '%s\n' "$returns" | sed -n 2p)" = "$managed" ] \
+    || fail "seed rollback did not try treehouse's own \$HOME-rooted spelling next"
+  [ ! -f "$lease" ] \
+    || fail "seed rollback left the durable lease held after the reconciled return"
+  pass "home seed rollback returns a physically recorded home by treehouse's own \$HOME-rooted spelling"
+}
+
 test_home_seed_warns_when_acquired_home_return_fails() {
   local home acquired acquired_abs fakebin log err lease
   home="$TMP_ROOT/dash-return-fail-home"
@@ -2964,6 +3019,7 @@ test_home_seed_validate_rejects_duplicate_ids
 test_home_seed_validate_rejects_nested_homes
 test_home_seed_uses_treehouse_acquired_home
 test_home_seed_returns_treehouse_acquired_home_on_assignment_failure
+test_home_seed_rollback_return_reconciles_symlinked_home_spelling
 test_home_seed_warns_when_acquired_home_return_fails
 test_home_seed_does_not_return_unsafe_acquired_home
 test_home_seed_rolls_back_failed_clone

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -58,6 +58,8 @@
 #   (z)  recorded physical path, pool holds the $HOME spelling -> ALLOW  (reconciled)
 #   (aa) no pool spelling manages the worktree at all          -> REFUSE as recorded
 #   (ab) managed spelling fails for its own reason             -> REFUSE, real cause kept
+#   (ac) managed spelling momentarily locked, recorded refused -> retry ALLOW under
+#        the recognized spelling (the two recoveries composed)
 set -u
 
 # shellcheck source=tests/lib.sh disable=SC1091
@@ -382,7 +384,11 @@ SH
 # FM_FAKE_TREEHOUSE_LOG so a test can assert which spellings were tried, and in
 # what order. FM_FAKE_TREEHOUSE_MANAGED_FAIL makes the managed spelling fail with
 # that text instead of succeeding, the shape of a worktree treehouse does manage
-# but cannot return for a reason of its own.
+# but cannot return for a reason of its own. FM_FAKE_TREEHOUSE_MANAGED_LOCK_ONCE
+# names a marker file and makes the managed spelling's first attempt fail with the
+# git index.lock signature (clearing the lock as a dying crew git process would),
+# the shape of a worktree whose recorded spelling is refused while the spelling
+# treehouse does manage is momentarily locked.
 add_pool_spelling_treehouse() {
   local case_dir=$1
   cat > "$case_dir/fakebin/treehouse" <<'SH'
@@ -401,6 +407,18 @@ if [ "${1:-}" = return ]; then
     if [ -n "${FM_FAKE_TREEHOUSE_MANAGED_FAIL:-}" ]; then
       echo "$FM_FAKE_TREEHOUSE_MANAGED_FAIL" >&2
       exit 1
+    fi
+    if [ -n "${FM_FAKE_TREEHOUSE_MANAGED_LOCK_ONCE:-}" ] \
+      && [ ! -e "$FM_FAKE_TREEHOUSE_MANAGED_LOCK_ONCE" ]; then
+      : > "$FM_FAKE_TREEHOUSE_MANAGED_LOCK_ONCE"
+      lock=$(git -C "$wt" rev-parse --git-path index.lock 2>/dev/null || true)
+      case "$lock" in
+        /*|'') ;;
+        *) lock="$wt/$lock" ;;
+      esac
+      echo "fatal: Unable to create '${lock:-index.lock}': File exists." >&2
+      [ -z "$lock" ] || rm -f "$lock"
+      exit 128
     fi
     echo "Worktree returned to pool."
     exit 0
@@ -2224,6 +2242,59 @@ test_managed_spelling_real_failure_is_not_hidden_by_the_recorded_refusal() {
   pass "an alternative spelling's genuinely different failure survives the recorded path's refusal"
 }
 
+test_managed_spelling_transient_lock_is_retried_under_that_same_spelling() {
+  local case_dir rc home_link recorded managed log marker lock
+  case_dir=$(make_case managed-spelling-transient-lock)
+  home_link=$(make_symlinked_home "$case_dir" managed-spelling-transient-lock)
+  recorded="$(cd "$case_dir" && pwd -P)/wt"
+  managed="$home_link/wt"
+  log="$case_dir/treehouse-paths"
+  marker="$case_dir/managed-lock-once"
+  : > "$log"
+
+  write_physical_meta "$case_dir"
+  land_shippable_commit "$case_dir"
+  add_pool_spelling_treehouse "$case_dir"
+  add_lsof_no_holder "$case_dir"
+
+  # A fresh lock, so patience must win rather than the stale-lock force-remove.
+  lock=$(git_index_lock_path "$case_dir/wt")
+  mkdir -p "$(dirname "$lock")"
+  : > "$lock"
+  touch "$lock"
+
+  set +e
+  # The recorded spelling is refused as unmanaged, then the spelling treehouse does
+  # manage is momentarily locked. The patience window must be spent on that same
+  # spelling: retrying the recorded one would keep being refused forever.
+  FM_FAKE_TREEHOUSE_MANAGED="$managed" \
+  FM_FAKE_TREEHOUSE_MANAGED_LOCK_ONCE="$marker" \
+  FM_FAKE_TREEHOUSE_LOG="$log" \
+  FM_TREEHOUSE_RETURN_LOCK_RETRIES=2 \
+  FM_TREEHOUSE_RETURN_LOCK_RETRY_WAIT_SECS=0 \
+  FM_STALE_WORKTREE_LOCK_AGE_SECS=3600 \
+    run_teardown --home "$home_link" "$case_dir" \
+      > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" \
+    "managed-spelling-transient-lock: teardown should succeed once the lock under treehouse's own spelling clears"
+  assert_grep "succeeded on retry" "$case_dir/stderr" \
+    "managed-spelling-transient-lock: teardown did not report success on retry"
+  assert_not_contains "$(cat "$case_dir/stderr")" "removed provably-stale git lock" \
+    "managed-spelling-transient-lock: teardown force-removed a lock that only needed patience"
+  [ "$(sed -n 1p "$log")" = "$recorded" ] \
+    || fail "managed-spelling-transient-lock: the recorded path must be tried first, got '$(sed -n 1p "$log")'"
+  [ "$(sed -n 2p "$log")" = "$managed" ] \
+    || fail "managed-spelling-transient-lock: treehouse's own spelling must be tried next, got '$(sed -n 2p "$log")'"
+  [ "$(sed -n 3p "$log")" = "$managed" ] \
+    || fail "managed-spelling-transient-lock: the lock retry must reuse the recognized spelling, got '$(sed -n 3p "$log")'"
+  assert_absent "$lock" \
+    "managed-spelling-transient-lock: lock should remain cleared after success"
+  pass "a transient lock under treehouse's own spelling is retried under that spelling, not the refused one"
+}
+
 test_parked_own_run_is_aborted_before_teardown() {
   local case_dir rc head
   case_dir=$(make_case parked-run-abort)
@@ -2809,6 +2880,7 @@ test_persistent_index_lock_exhausts_retries_and_refuses_loudly
 test_symlinked_home_pool_spelling_is_reconciled_on_return
 test_unmanaged_worktree_return_reports_the_recorded_path
 test_managed_spelling_real_failure_is_not_hidden_by_the_recorded_refusal
+test_managed_spelling_transient_lock_is_retried_under_that_same_spelling
 test_empty_retry_wait_uses_default_without_aborting
 test_fractional_legacy_retry_wait_refuses_without_arithmetic_error
 test_parked_own_run_is_aborted_before_teardown

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -49,6 +49,14 @@
 #   (w) index.lock mtime read failure                         -> lock kept, REFUSE
 #   (x) transient lock cleared after first failed return      -> retry ALLOW
 #   (y) persistent lock (never clears, not provably stale)    -> REFUSE loudly
+#
+# Also covers teardown-worktree-path: treehouse matches its managed pool inventory by
+# string and builds pool paths from its root exactly as written, while firstmate records
+# the resolved physical worktree path, so on a symlinked home the two spell one directory
+# differently and the recorded path is refused as unmanaged. The fakes for these two cases
+# mimic that string matching instead of accepting any path.
+#   (z)  recorded physical path, pool holds the $HOME spelling -> ALLOW  (reconciled)
+#   (aa) no pool spelling manages the worktree at all          -> REFUSE as recorded
 set -u
 
 # shellcheck source=tests/lib.sh disable=SC1091
@@ -366,6 +374,50 @@ SH
   chmod +x "$case_dir/fakebin/treehouse"
 }
 
+# treehouse return that matches its managed pool inventory by string, exactly as
+# the real one does: it accepts only the spelling in FM_FAKE_TREEHOUSE_MANAGED
+# (unset means it manages nothing) and refuses every other spelling of the same
+# directory in treehouse's own wording. Each requested path is appended to
+# FM_FAKE_TREEHOUSE_LOG so a test can assert which spellings were tried, and in
+# what order.
+add_pool_spelling_treehouse() {
+  local case_dir=$1
+  cat > "$case_dir/fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = return ]; then
+  shift
+  wt=""
+  for a in "$@"; do
+    case "$a" in
+      --force) ;;
+      *) wt=$a ;;
+    esac
+  done
+  [ -z "${FM_FAKE_TREEHOUSE_LOG:-}" ] || printf '%s\n' "$wt" >> "$FM_FAKE_TREEHOUSE_LOG"
+  if [ -n "${FM_FAKE_TREEHOUSE_MANAGED:-}" ] && [ "$wt" = "$FM_FAKE_TREEHOUSE_MANAGED" ]; then
+    echo "Worktree returned to pool."
+    exit 0
+  fi
+  echo "worktree $wt is not managed by treehouse" >&2
+  exit 1
+fi
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+}
+
+# Point HOME at a symlink to the case dir, the shape of a host whose home is a
+# symlink, and echo that as-written home path. The link lives beside the case dir
+# rather than inside it so the fixture holds no self-referential loop.
+make_symlinked_home() {  # <case-dir> <name>
+  local case_dir=$1 name=$2 phys_case phys_tmp link
+  phys_case=$(cd "$case_dir" && pwd -P)
+  phys_tmp=$(cd "$TMP_ROOT" && pwd -P)
+  link="$phys_tmp/$name-home"
+  ln -s "$phys_case" "$link"
+  printf '%s\n' "$link"
+}
+
 # treehouse return fails once with the index.lock signature, then clears the lock
 # (simulating a dying crew git process finishing) so the next retry succeeds.
 # The first failure always reports the lock path even if the file is removed in
@@ -539,9 +591,15 @@ SH
   chmod +x "$case_dir/fakebin/git"
 }
 
-# Run teardown with PATH mocking. Args: case_dir [extra args...]
+# Run teardown with PATH mocking. Args: [--home <path>] case_dir [extra args...]
+# --home points the child's HOME at <path> for the symlinked-home pool cases; it
+# is a prefix on the script itself, so it never leaks into the rest of the suite
+# the way a prefix on this function call would.
 run_teardown() {
+  local home=${HOME:-}
+  if [ "${1:-}" = --home ]; then home=$2; shift 2; fi
   local case_dir=$1; shift
+  HOME="$home" \
   FM_ROOT_OVERRIDE="$ROOT" \
   FM_STATE_OVERRIDE="$case_dir/state" \
   FM_CONFIG_OVERRIDE="$case_dir/config" \
@@ -2048,6 +2106,85 @@ land_shippable_commit() {
   git -C "$case_dir/project" fetch -q origin
 }
 
+# Record the worktree and project by their fully resolved physical paths, the way
+# bin/fm-spawn.sh does, so the recorded spelling differs from treehouse's own
+# $HOME-rooted one whenever the home is a symlink.
+write_physical_meta() {  # <case-dir>
+  local case_dir=$1 phys_case
+  phys_case=$(cd "$case_dir" && pwd -P)
+  fm_write_meta "$case_dir/state/task-x1.meta" \
+    "window=firstmate:fm-task-x1" \
+    "endpoint_task_id=task-x1" \
+    "worktree=$phys_case/wt" \
+    "project=$phys_case/project" \
+    "kind=ship" \
+    "mode=no-mistakes"
+}
+
+test_symlinked_home_pool_spelling_is_reconciled_on_return() {
+  local case_dir rc home_link recorded managed log
+  case_dir=$(make_case symlinked-home-pool-path)
+  home_link=$(make_symlinked_home "$case_dir" symlinked-home-pool-path)
+  recorded="$(cd "$case_dir" && pwd -P)/wt"
+  managed="$home_link/wt"
+  log="$case_dir/treehouse-paths"
+  : > "$log"
+
+  write_physical_meta "$case_dir"
+  land_shippable_commit "$case_dir"
+  add_pool_spelling_treehouse "$case_dir"
+
+  set +e
+  FM_FAKE_TREEHOUSE_MANAGED="$managed" \
+  FM_FAKE_TREEHOUSE_LOG="$log" \
+    run_teardown --home "$home_link" "$case_dir" \
+      > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" \
+    "symlinked-home-pool-path: teardown should return the worktree by treehouse's own spelling of the same directory"
+  assert_not_contains "$(cat "$case_dir/stderr")" "teardown aborted" \
+    "symlinked-home-pool-path: teardown aborted instead of reconciling the two spellings"
+  assert_grep "matched treehouse's pool path" "$case_dir/stderr" \
+    "symlinked-home-pool-path: teardown did not report which pool spelling it used"
+  [ "$(sed -n 1p "$log")" = "$recorded" ] \
+    || fail "symlinked-home-pool-path: the recorded path must be tried first, got '$(sed -n 1p "$log")'"
+  [ "$(sed -n 2p "$log")" = "$managed" ] \
+    || fail "symlinked-home-pool-path: treehouse's own spelling must be tried next, got '$(sed -n 2p "$log")'"
+  pass "a physically recorded worktree is returned by treehouse's own \$HOME-rooted spelling of it"
+}
+
+test_unmanaged_worktree_return_reports_the_recorded_path() {
+  local case_dir rc home_link recorded managed
+  case_dir=$(make_case unmanaged-pool-path)
+  home_link=$(make_symlinked_home "$case_dir" unmanaged-pool-path)
+  recorded="$(cd "$case_dir" && pwd -P)/wt"
+  managed="$home_link/wt"
+
+  write_physical_meta "$case_dir"
+  land_shippable_commit "$case_dir"
+  add_pool_spelling_treehouse "$case_dir"
+
+  set +e
+  # An empty managed spelling means no spelling of this worktree is in the pool.
+  FM_FAKE_TREEHOUSE_MANAGED='' \
+  FM_FAKE_TREEHOUSE_LOG='' \
+    run_teardown --home "$home_link" "$case_dir" \
+      > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "unmanaged-pool-path: a worktree in no pool spelling must still fail the return"
+  assert_grep "worktree $recorded is not managed by treehouse" "$case_dir/stderr" \
+    "unmanaged-pool-path: the failure must report the recorded path's own refusal"
+  assert_not_contains "$(cat "$case_dir/stderr")" "worktree $managed is not managed" \
+    "unmanaged-pool-path: the failure reported an alternative spelling the caller never recorded"
+  assert_grep "teardown aborted" "$case_dir/stderr" \
+    "unmanaged-pool-path: teardown should abort loudly when no spelling is managed"
+  pass "a genuinely unmanaged worktree still fails, reported as the recorded path"
+}
+
 test_parked_own_run_is_aborted_before_teardown() {
   local case_dir rc head
   case_dir=$(make_case parked-run-abort)
@@ -2630,6 +2767,8 @@ test_non_linked_index_lock_path_is_checked_from_worktree
 test_index_lock_mtime_read_failure_refuses
 test_transient_index_lock_clears_after_first_attempt_and_retry_succeeds
 test_persistent_index_lock_exhausts_retries_and_refuses_loudly
+test_symlinked_home_pool_spelling_is_reconciled_on_return
+test_unmanaged_worktree_return_reports_the_recorded_path
 test_empty_retry_wait_uses_default_without_aborting
 test_fractional_legacy_retry_wait_refuses_without_arithmetic_error
 test_parked_own_run_is_aborted_before_teardown

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -57,6 +57,7 @@
 # mimic that string matching instead of accepting any path.
 #   (z)  recorded physical path, pool holds the $HOME spelling -> ALLOW  (reconciled)
 #   (aa) no pool spelling manages the worktree at all          -> REFUSE as recorded
+#   (ab) managed spelling fails for its own reason             -> REFUSE, real cause kept
 set -u
 
 # shellcheck source=tests/lib.sh disable=SC1091
@@ -379,7 +380,9 @@ SH
 # (unset means it manages nothing) and refuses every other spelling of the same
 # directory in treehouse's own wording. Each requested path is appended to
 # FM_FAKE_TREEHOUSE_LOG so a test can assert which spellings were tried, and in
-# what order.
+# what order. FM_FAKE_TREEHOUSE_MANAGED_FAIL makes the managed spelling fail with
+# that text instead of succeeding, the shape of a worktree treehouse does manage
+# but cannot return for a reason of its own.
 add_pool_spelling_treehouse() {
   local case_dir=$1
   cat > "$case_dir/fakebin/treehouse" <<'SH'
@@ -395,6 +398,10 @@ if [ "${1:-}" = return ]; then
   done
   [ -z "${FM_FAKE_TREEHOUSE_LOG:-}" ] || printf '%s\n' "$wt" >> "$FM_FAKE_TREEHOUSE_LOG"
   if [ -n "${FM_FAKE_TREEHOUSE_MANAGED:-}" ] && [ "$wt" = "$FM_FAKE_TREEHOUSE_MANAGED" ]; then
+    if [ -n "${FM_FAKE_TREEHOUSE_MANAGED_FAIL:-}" ]; then
+      echo "$FM_FAKE_TREEHOUSE_MANAGED_FAIL" >&2
+      exit 1
+    fi
     echo "Worktree returned to pool."
     exit 0
   fi
@@ -2185,6 +2192,38 @@ test_unmanaged_worktree_return_reports_the_recorded_path() {
   pass "a genuinely unmanaged worktree still fails, reported as the recorded path"
 }
 
+test_managed_spelling_real_failure_is_not_hidden_by_the_recorded_refusal() {
+  local case_dir rc home_link recorded managed
+  case_dir=$(make_case managed-spelling-real-failure)
+  home_link=$(make_symlinked_home "$case_dir" managed-spelling-real-failure)
+  recorded="$(cd "$case_dir" && pwd -P)/wt"
+  managed="$home_link/wt"
+
+  write_physical_meta "$case_dir"
+  land_shippable_commit "$case_dir"
+  add_pool_spelling_treehouse "$case_dir"
+
+  set +e
+  # The recorded spelling is refused as unmanaged, then the spelling treehouse does
+  # manage fails for a reason of its own. That second text is the actual cause.
+  FM_FAKE_TREEHOUSE_MANAGED="$managed" \
+  FM_FAKE_TREEHOUSE_MANAGED_FAIL='fatal: could not reset pool worktree' \
+  FM_FAKE_TREEHOUSE_LOG='' \
+    run_teardown --home "$home_link" "$case_dir" \
+      > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "managed-spelling-real-failure: a failing return must still fail teardown"
+  assert_grep "fatal: could not reset pool worktree" "$case_dir/stderr" \
+    "managed-spelling-real-failure: the real cause under the managed spelling was swallowed by the recorded path's refusal"
+  assert_grep "worktree $recorded is not managed by treehouse" "$case_dir/stderr" \
+    "managed-spelling-real-failure: the recorded path's own refusal must stay the headline"
+  assert_not_contains "$(cat "$case_dir/stderr")" "worktree $managed is not managed" \
+    "managed-spelling-real-failure: reported an alternative spelling's own refusal"
+  pass "an alternative spelling's genuinely different failure survives the recorded path's refusal"
+}
+
 test_parked_own_run_is_aborted_before_teardown() {
   local case_dir rc head
   case_dir=$(make_case parked-run-abort)
@@ -2769,6 +2808,7 @@ test_transient_index_lock_clears_after_first_attempt_and_retry_succeeds
 test_persistent_index_lock_exhausts_retries_and_refuses_loudly
 test_symlinked_home_pool_spelling_is_reconciled_on_return
 test_unmanaged_worktree_return_reports_the_recorded_path
+test_managed_spelling_real_failure_is_not_hidden_by_the_recorded_refusal
 test_empty_retry_wait_uses_default_without_aborting
 test_fractional_legacy_retry_wait_refuses_without_arithmetic_error
 test_parked_own_run_is_aborted_before_teardown

--- a/tests/secondmate-helpers.sh
+++ b/tests/secondmate-helpers.sh
@@ -14,7 +14,10 @@
 # FM_FAKE_TMUX_WINDOW, capture-pane echoes FM_FAKE_TMUX_CAPTURE) plus a fake
 # treehouse (durable lease of FM_FAKE_TREEHOUSE_HOME, recording the lease holder
 # to FM_FAKE_TREEHOUSE_LEASE_FILE; `return` removes the target and lease unless
-# FM_FAKE_TREEHOUSE_RETURN_FAIL is set). Echoes the fakebin dir.
+# FM_FAKE_TREEHOUSE_RETURN_FAIL is set). Setting FM_FAKE_TREEHOUSE_MANAGED makes
+# `return` match its managed inventory by string the way the real treehouse does,
+# accepting only that exact spelling and refusing any other spelling of the same
+# directory in treehouse's own wording. Echoes the fakebin dir.
 make_fake_tmux() {
   local dir=$1 fakebin capture
   fakebin=$(fm_fakebin "$dir")
@@ -88,6 +91,10 @@ case "${1:-}" in
       shift
     done
     [ -z "${FM_FAKE_TREEHOUSE_RETURN_FAIL:-}" ] || exit 17
+    if [ -n "${FM_FAKE_TREEHOUSE_MANAGED:-}" ] && [ "$target" != "$FM_FAKE_TREEHOUSE_MANAGED" ]; then
+      printf 'worktree %s is not managed by treehouse\n' "$target" >&2
+      exit 1
+    fi
     [ -n "${FM_FAKE_TREEHOUSE_LEASE_FILE:-}" ] && rm -f "$FM_FAKE_TREEHOUSE_LEASE_FILE"
     [ -n "$target" ] && rm -rf -- "$target"
     exit 0


### PR DESCRIPTION
## Intent

Stop firstmate having to hand-edit a recorded worktree path before every crewmate or scout cleanup on this host.

On this machine /home/inthuson is a symlink to /local/home/inthuson, so treehouse records pool worktree paths using its as-written $HOME-rooted spelling (/home/inthuson/...) while bin/fm-spawn.sh records the fully resolved physical path (/local/home/inthuson/...). Treehouse matches its managed inventory by string rather than by resolved path, so "treehouse return" refused with "is not managed by treehouse" and cleanup aborted at bin/fm-teardown.sh:2453 after it had already reaped the worktree processes, leaving the task half cleaned. Nine occurrences across two days, and every cleanup on this host needed a manual rewrite of worktree= in state/<id>.meta first.

Required approach, as specified by the task: reconcile the two spellings rather than picking one, comparing paths after resolving both sides so a symlinked home stops being a special case. Explicitly ruled out: simply switching firstmate to the $HOME spelling without checking every other consumer of worktree=, because the physical path is what the liveness and worktree-isolation checks compare against, and breaking isolation detection to fix a cleanup annoyance would be a bad trade. The new bin/fm-treehouse-lib.sh is the single owner of the reconciliation and only ever offers spellings that provably resolve to the identical physical directory; retry and lock patience policy deliberately stays with the caller. bin/fm-home-seed.sh needed the same reconciliation because the identical defect silently leaked a durable lease during seed rollback.

Explicitly out of scope and deliberately not fixed here: teardown-shared-slot-guard-s2, the separate hazard that cleanup returns a pool slot without checking whether another task holds it.

Verification owed and completed: a real pooled worktree torn down on this host with no hand-editing; and a colocated regression in tests/fm-teardown.test.sh covering the symlinked-home spelling on both sides, since a happy-path-only test would be worthless here when the bug is a comparison that is wrong only when the two spellings differ.

The third owed item was making tests/fm-backend-herdr-presentation-e2e.test.sh complete rather than abort 77 lines before the code it exists to exercise, which was a silent coverage hole rather than a green tick. The abort is gone: the suite now reaches and passes five checks, including the previously unreachable opted-out spawn and teardown. It then failed on an unrelated assertion because this host runs herdr 0.8.2 while CI pins 0.7.4 exactly. On 0.8.2, closing a tab's last pane respawns a replacement pane, so a projected workspace never becomes empty, the exactly-one-tab-and-one-pane test in fm_backend_herdr_emptying_close_plan never matches, a projected workspace is therefore never removed by a pane close, and the leftover fixture workspace trails the ordering label list. That was confirmed by direct probe through the guarded Herdr lab helper, not inferred, and it is a real product defect whose captain-visible symptom is that every projected cleanup on 0.8.2 orphans a workspace in their own window.

Accepted decision on that item: bound the suite to the supported pin so a non-pinned host skips rather than fails, which keeps the signal honest without masking anything. Do not fix the 0.8.2 cleanup defect in this change; it is filed separately as herdr-082-projection-orphan-o4 at priority 1. Adapting or deleting the fixture to go green was considered and rejected outright, because it would hide the orphan defect behind a green tick. Downgrading herdr locally to the pin was also rejected, because it would disturb the live session holding the captain's own terminal and two parked validation runs. The pin gate reads the version from bin/fm-install-herdr.sh so that file remains the single owner of the pin, and an unreadable pin or unreadable installed version exits non-zero rather than skipping, because a skip nobody can trust would quietly disable this whole required lane.

The PR body must state four things: that unblocking this test immediately exposed a real 0.8.2 defect which CI's 0.7.4 pin hides, since that is the strongest argument for the change; that a correct path makes teardown-shared-slot-guard-s2's wrong return succeed rather than abort, so this change slightly raises the stakes on that separate task; that the reconciliation is bounded to the $HOME root alias plus the fully physical reverse direction and does not cover an arbitrary symlinked custom root in a repo's treehouse.toml; and that no docs/verification record is owed because nothing here is harness-dependent.

Constraints: this is firstmate's own shared tracked material, so firstmate-coding-guidelines applies; shellcheck-clean at the pinned 0.11.0; no em-dashes anywhere, including commit messages and the PR body; never add an agent name as a commit co-author.

Note for review: four failures in the changed-file test selection are pre-existing and unrelated to this change, proven by byte-identical failures on a pristine 1cb900c baseline clone: fm-backlog-handoff, fm-on, fm-remote-backlog-handoff, and fm-secondmate-lifecycle-e2e.

## What Changed

- Added `bin/fm-treehouse-lib.sh` as the single owner of pool path spelling reconciliation between firstmate's recorded physical worktree paths and treehouse's string-matched inventory. It offers only spellings that provably resolve to the identical physical directory (recorded spelling first, then the `$HOME`-rooted rewrite, then the fully resolved path) and exposes `fm_treehouse_return_force`. `bin/fm-teardown.sh`'s `teardown_treehouse_return` now tries each equivalent spelling before spending its git `index.lock` patience window, headlining the recorded path's own refusal on total failure while still surfacing any other spelling's genuinely different failure; `bin/fm-home-seed.sh`'s seed rollback uses the same reconciliation so a refused return no longer leaks a durable lease behind a warning. Retry and lock patience policy stays with each caller.
- `tests/fm-backend-herdr-presentation-e2e.test.sh` no longer aborts before the code it exists to exercise: it now reaches and passes its five checks, including the previously unreachable opted-out spawn and teardown, and it gates on the exact Herdr pin read from the new `bin/fm-install-herdr.sh --required-version` flag so a non-pinned host skips rather than fails. An unreadable pin or unreadable installed version exits non-zero instead of skipping. That suite plus the autodetect, launcher-workspace, and workspace-per-home real-Herdr suites return pool worktrees through the shared helper.
- Test and wiring updates: the fake treehouse in `tests/secondmate-helpers.sh` gained `FM_FAKE_TREEHOUSE_MANAGED` string matching so fixtures mimic the real inventory refusal; `tests/fm-teardown.test.sh` adds four colocated cases (reconciled return on a symlinked home, a genuinely unmanaged worktree still failing as the recorded path, a managed spelling's real failure surviving the recorded refusal, and a transient lock retried under the recognized spelling), `tests/fm-secondmate-safety.test.sh` covers the seed rollback path, `bin/fm-test-run.sh` maps the new library to the `pr-forge`, `secondmate`, and `real-herdr-gated` families, and `tests/fm-gotmp.test.sh` links it into its fake roots.

## Notes

- Unblocking the presentation suite immediately exposed a real Herdr 0.8.2 defect that CI's exact 0.7.4 pin hides, which is the strongest argument for this change. On 0.8.2, closing a tab's last pane respawns a replacement pane, so a projected workspace never becomes empty, the exactly-one-tab-and-one-pane test in `fm_backend_herdr_emptying_close_plan` never matches, and a projected workspace is never removed by a pane close. The captain-visible symptom is that every projected cleanup on 0.8.2 orphans a workspace in their own window. Confirmed by direct probe through the guarded Herdr lab helper, filed separately as `herdr-082-projection-orphan-o4` at priority 1, and deliberately not fixed here.
- This slightly raises the stakes on `teardown-shared-slot-guard-s2`, which is out of scope here: with a correct path, cleanup's pool slot return now succeeds rather than aborting, so a return that never checks whether another task holds the slot will actually go through.
- The reconciliation is bounded to the `$HOME` root alias plus the fully physical reverse direction. It does not cover an arbitrary symlinked custom root configured in a repo's `treehouse.toml`.
- No `docs/verification` record is owed, because nothing here is harness dependent. The `docs/verification/runtime-backends.md` edits only annotate that the presentation suite is now pin gated and that the dated runs on other releases predate that gate.
- The pin gate's first implementation was wrong, and that is a review miss rather than a late tightening. It recovered the pinned version by regexing `bin/fm-install-herdr.sh` for its `FM_HERDR_CI_VERSION` assignment. The goal of keeping one owner of the pin was right and the gate was accepted on that basis, but nobody caught that the mechanism breaks this repo's own rule that a test must never assert implementation source bytes, including through a regex, so a behavior preserving edit to that assignment could have silently disabled a required lane. The `--required-version` flag added here is that correction rather than a tidy-up: it publishes the pin through an executable interface in the shape `bin/fm-lint.sh --required-version` already established, and the pin still has exactly one owner.
- The presentation suite's five checks are confirmed only by the pinned CI lane, not by any run on the host this was developed on. That host runs Herdr 0.8.2 while the suite is bound to 0.7.4, so with the gate in place the suite skips there, and what was actually exercised locally is the gate itself: the skip path on a non-pinned host, plus both loud failure modes, an unreadable pin and an unreadable installed version, each exiting non-zero rather than skipping. The five checks were seen reaching and passing on 0.8.2 before the gate existed, which is how the orphan defect above surfaced at all, but that is not the same as the committed suite passing at the pin. Downgrading Herdr locally to 0.7.4 would have closed that gap and was refused on purpose, because it would disturb a live session holding a working terminal and two parked validation runs. Pull requests from this fork also wait on a maintainer to approve workflow runs before they start, so that lane's output cannot be attached here before merge.

## Risk Assessment

✅ Low: The reconciliation is bounded by a provable same-physical-directory invariant, dedups to a single byte-identical attempt on non-symlinked hosts, every treehouse return call site in bin/ now routes through the one library, all five prior findings are verifiably fixed with genuine regression tests, and the only stakes-raising interaction (teardown-shared-slot-guard-s2) is explicitly acknowledged and separately tracked in the intent.

## Testing

I reproduced the reported failure and its fix with the real treehouse binary and the real bin/fm-teardown.sh on a symlinked-home fixture: treehouse refuses the physically recorded pool path and keeps the lease, pre-fix teardown aborts at the return, and post-fix teardown completes with no hand-edited worktree= and the pool slot released. I then probed the claimed reconciliation boundaries against the real binary (reverse physical-root direction, recorded-first ordering, no $HOME candidate for a directory outside $HOME, single attempt for a path that no longer resolves). On the automated side I ran the changed-file portable suites that this host can run (fm-teardown, fm-secondmate-safety, fm-gotmp, fm-test-run, plus a spot check of fm-backlog-handoff which gate-skips here), proved both colocated regressions fail on a 1cb900c baseline tree carrying the new tests, added one focused teardown case for the reconciliation-plus-lock-patience interaction and mutation-checked it, and exercised the runner's changed-file mapping through bin/fm-test-run.sh --list --changed, which selects the consumer families for the new library where the pre-fix runner dies as unmapped. The Herdr presentation suite skips cleanly on this host's herdr 0.8.2 against the 0.7.4 pin and exits non-zero rather than skipping when either the pin owner or the installed version cannot be read, and it does not skip when the reported version equals the pin. This change is shell and CLI only with no rendered surface, so the evidence is CLI transcripts and treehouse's own pool status rather than screenshots. All tests and checks I ran passed; scratch trees are removed, the captain's herdr session and the $HOME treehouse pool are untouched, and the only working-tree change is the added test case.

<details>
<summary>Evidence: Real treehouse + real fm-teardown.sh on a symlinked home (the fix)</summary>

<code>== the bug: real treehouse return --force with the recorded physical path ==&#10;worktree /tmp/fm-th-e2e-lQmVLi/physhome/.treehouse/proj-c2b672/1/proj is not managed by treehouse&#10;exit=1&#10;pool status: [{&#34;path&#34;:&#34;.../home/.treehouse/proj-c2b672/1/proj&#34;,&#34;status&#34;:&#34;leased&#34;,&#34;lease_holder&#34;:&#34;fm-evidence&#34;}]&#10;&#10;== recorded task meta (worktree= is the physical spelling, unedited) ==&#10;worktree=/tmp/fm-th-e2e-lQmVLi/physhome/.treehouse/proj-c2b672/1/proj&#10;&#10;== the fix: real bin/fm-teardown.sh on that recorded path ==&#10;🌳 Worktree returned to pool.&#10;teardown: worktree return matched treehouse&#39;s pool path /tmp/fm-th-e2e-lQmVLi/home/.treehouse/proj-c2b672/1/proj for recorded worktree /tmp/fm-th-e2e-lQmVLi/physhome/.treehouse/proj-c2b672/1/proj (same directory, different spelling)&#10;teardown task-e2e complete (window firstmate:fm-task-e2e, worktree /tmp/fm-th-e2e-lQmVLi/physhome/.treehouse/proj-c2b672/1/proj)&#10;fm-teardown.sh exit=0&#10;&#10;== treehouse&#39;s own pool status after teardown ==&#10;[{&#34;path&#34;:&#34;.../home/.treehouse/proj-c2b672/1/proj&#34;,&#34;status&#34;:&#34;available&#34;,&#34;lease_id&#34;:&#34;&#34;,&#34;lease_holder&#34;:&#34;&#34;}]</code>

```text

== host-shaped fixture: a home that is a symlink ==
HOME as written : /tmp/fm-th-e2e-lQmVLi/home
HOME physical   : /tmp/fm-th-e2e-lQmVLi/physhome
treehouse       : /home/linuxbrew/.linuxbrew/bin/treehouse (2.1.1)

== treehouse get --lease (real pool acquire) ==
🌳 Setting up worktree...
🌳 Leased worktree at ~/.treehouse/proj-c2b672/1/proj. Run 'treehouse return ~/.treehouse/proj-c2b672/1/proj' to release it.
treehouse's own pool spelling : /tmp/fm-th-e2e-lQmVLi/home/.treehouse/proj-c2b672/1/proj
fm-spawn's recorded worktree= : /tmp/fm-th-e2e-lQmVLi/physhome/.treehouse/proj-c2b672/1/proj

== the bug: real treehouse return --force with the recorded physical path ==
worktree /tmp/fm-th-e2e-lQmVLi/physhome/.treehouse/proj-c2b672/1/proj is not managed by treehouse
exit=1
pool status: [{"name":"1","path":"/tmp/fm-th-e2e-lQmVLi/home/.treehouse/proj-c2b672/1/proj","status":"leased","lease_id":"64b261d690d78832ca4150836c1fefd0","lease_holder":"fm-evidence","leased_at":"2026-08-20T19:24:23.044538541Z","processes":[]}]

== recorded task meta (worktree= is the physical spelling, unedited) ==
window=firstmate:fm-task-e2e
endpoint_task_id=task-e2e
worktree=/tmp/fm-th-e2e-lQmVLi/physhome/.treehouse/proj-c2b672/1/proj
project=/tmp/fm-th-e2e-lQmVLi/physhome/proj
kind=ship
mode=no-mistakes

== the fix: real bin/fm-teardown.sh on that recorded path ==
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no watcher has a fresh beacon (last beat: never, grace 300s).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  watcher supervision needs Stop-owned automatic recovery; inspect the hook registration and startup status before ending the turn.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🌳 Worktree returned to pool.
teardown: worktree return matched treehouse's pool path /tmp/fm-th-e2e-lQmVLi/home/.treehouse/proj-c2b672/1/proj for recorded worktree /tmp/fm-th-e2e-lQmVLi/physhome/.treehouse/proj-c2b672/1/proj (same directory, different spelling)
/tmp/fm-th-e2e-lQmVLi/physhome/proj: STUCK: on branch main with uncommitted changes, 0 commits behind origin/main - needs attention
teardown task-e2e complete (window firstmate:fm-task-e2e, worktree /tmp/fm-th-e2e-lQmVLi/physhome/.treehouse/proj-c2b672/1/proj)
Backlog: task-e2e just finished. Update data/backlog.md - move task-e2e to Done, keep Done to the 10 most recent, then re-scan Queued and dispatch only work whose blockers are gone and date is due.
fm-teardown.sh exit=0

== treehouse's own pool status after teardown ==
[{"name":"1","path":"/tmp/fm-th-e2e-lQmVLi/home/.treehouse/proj-c2b672/1/proj","status":"available","lease_id":"","lease_holder":"","leased_at":null,"processes":[]}]
```
</details>
<details>
<summary>Evidence: Same real e2e against the pre-fix 1cb900c tree (the reported symptom)</summary>

<code>== the fix: real bin/fm-teardown.sh on that recorded path ==&#10;worktree /tmp/fm-th-e2e-bSX1si/physhome/.treehouse/proj-eecd16/1/proj is not managed by treehouse&#10;error: treehouse return failed for worktree /tmp/fm-th-e2e-bSX1si/physhome/.treehouse/proj-eecd16/1/proj; teardown aborted&#10;fm-teardown.sh exit=1&#10;&#10;== treehouse&#39;s own pool status after teardown ==&#10;[{&#34;path&#34;:&#34;.../home/.treehouse/proj-eecd16/1/proj&#34;,&#34;status&#34;:&#34;leased&#34;,&#34;lease_holder&#34;:&#34;fm-evidence&#34;}]</code>

```text

== host-shaped fixture: a home that is a symlink ==
HOME as written : /tmp/fm-th-e2e-bSX1si/home
HOME physical   : /tmp/fm-th-e2e-bSX1si/physhome
treehouse       : /home/linuxbrew/.linuxbrew/bin/treehouse (2.1.1)

== treehouse get --lease (real pool acquire) ==
🌳 Setting up worktree...
🌳 Leased worktree at ~/.treehouse/proj-eecd16/1/proj. Run 'treehouse return ~/.treehouse/proj-eecd16/1/proj' to release it.
treehouse's own pool spelling : /tmp/fm-th-e2e-bSX1si/home/.treehouse/proj-eecd16/1/proj
fm-spawn's recorded worktree= : /tmp/fm-th-e2e-bSX1si/physhome/.treehouse/proj-eecd16/1/proj

== the bug: real treehouse return --force with the recorded physical path ==
worktree /tmp/fm-th-e2e-bSX1si/physhome/.treehouse/proj-eecd16/1/proj is not managed by treehouse
exit=1
pool status: [{"name":"1","path":"/tmp/fm-th-e2e-bSX1si/home/.treehouse/proj-eecd16/1/proj","status":"leased","lease_id":"7166fe5eb5d4fb171694b65054e15ca3","lease_holder":"fm-evidence","leased_at":"2026-08-20T19:24:34.296056307Z","processes":[]}]

== recorded task meta (worktree= is the physical spelling, unedited) ==
window=firstmate:fm-task-e2e
endpoint_task_id=task-e2e
worktree=/tmp/fm-th-e2e-bSX1si/physhome/.treehouse/proj-eecd16/1/proj
project=/tmp/fm-th-e2e-bSX1si/physhome/proj
kind=ship
mode=no-mistakes

== the fix: real bin/fm-teardown.sh on that recorded path ==
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no watcher has a fresh beacon (last beat: never, grace 300s).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  watcher supervision needs Stop-owned automatic recovery; inspect the hook registration and startup status before ending the turn.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
worktree /tmp/fm-th-e2e-bSX1si/physhome/.treehouse/proj-eecd16/1/proj is not managed by treehouse
error: treehouse return failed for worktree /tmp/fm-th-e2e-bSX1si/physhome/.treehouse/proj-eecd16/1/proj; teardown aborted
fm-teardown.sh exit=1

== treehouse's own pool status after teardown ==
[{"name":"1","path":"/tmp/fm-th-e2e-bSX1si/home/.treehouse/proj-eecd16/1/proj","status":"leased","lease_id":"7166fe5eb5d4fb171694b65054e15ca3","lease_holder":"fm-evidence","leased_at":"2026-08-20T19:24:34.296056307Z","processes":[]}]
```
</details>
<details>
<summary>Evidence: Reconciliation boundaries against the real treehouse (reverse direction, safety invariant, non-resolving record)</summary>

<code>A. reverse direction: pool root physical, record $HOME-rooted&#10;raw treehouse return --force -&gt; &#34;is not managed by treehouse&#34;, exit=1, lease still held&#10;fm_treehouse_return_force -&gt; 🌳 Worktree returned to pool. exit=0, pool status &#34;available&#34;&#10;&#10;B. recorded dir outside $HOME: only its own spelling offered; every spelling resolves to the recorded directory: yes&#10;B2. under a symlinked $HOME: physhome/wt then home/wt (recorded first)&#10;C. record that no longer resolves: attempts made: 1, refusal unchanged</code>

```text

== A. reverse direction: pool root is physical, firstmate records the $HOME spelling ==
treehouse's own pool spelling : /tmp/fm-recon-probe-adBidr/physhome/.treehouse/proj-12e57c/1/proj
the recorded spelling         : /tmp/fm-recon-probe-adBidr/home/.treehouse/proj-12e57c/1/proj
both name one directory       : /tmp/fm-recon-probe-adBidr/physhome/.treehouse/proj-12e57c/1/proj

raw treehouse return --force "$RECORDED":
worktree /tmp/fm-recon-probe-adBidr/home/.treehouse/proj-12e57c/1/proj is not managed by treehouse
exit=1
lease still held: [{"name":"1","path":"/tmp/fm-recon-probe-adBidr/physhome/.treehouse/proj-12e57c/1/proj","status":"leased","lease_id":"38c862e47fab0b9b2f9b1960c99f96a6","lease_holder":"fm-evidence","leased_at":"2026-08-20T19:29:02.92035286Z","processes":[]}]

fm_treehouse_return_force "" "$RECORDED" (from the project dir):
🌳 Worktree returned to pool.
exit=0
pool after: [{"name":"1","path":"/tmp/fm-recon-probe-adBidr/physhome/.treehouse/proj-12e57c/1/proj","status":"available","lease_id":"","lease_holder":"","leased_at":null,"processes":[]}]

== B. safety invariant: a directory outside $HOME gets no $HOME-rooted candidate ==
HOME              : /tmp/fm-recon-probe-adBidr/home -> /tmp/fm-recon-probe-adBidr/physhome
recorded (outside): /tmp/fm-recon-probe-adBidr/elsewhere/wt
spellings offered :
  /tmp/fm-recon-probe-adBidr/elsewhere/wt
every spelling resolves to the recorded directory: yes

== B2. same-directory spellings under a symlinked $HOME are offered, recorded first ==
  /tmp/fm-recon-probe-adBidr/physhome/wt
  /tmp/fm-recon-probe-adBidr/home/wt

== C. a recorded path that no longer resolves: exactly one attempt, refusal unchanged ==
worktree /tmp/fm-recon-probe-adBidr/physhome/gone-forever is not managed by treehouse
exit=1
attempts made: 1
attempted path: /tmp/fm-recon-probe-adBidr/physhome/gone-forever
```
</details>
<details>
<summary>Evidence: Colocated regressions fail before the fix, pass after</summary>

<code>against 1cb900c code:&#10;not ok - symlinked-home-pool-path: teardown should return the worktree by treehouse&#39;s own spelling of the same directory: expected exit 0, got 1&#10;not ok - seed rollback reported a leaked lease instead of reconciling the two spellings&#10;&#10;against this change:&#10;ok - a physically recorded worktree is returned by treehouse&#39;s own $HOME-rooted spelling of it&#10;ok - a genuinely unmanaged worktree still fails, reported as the recorded path&#10;ok - an alternative spelling&#39;s genuinely different failure survives the recorded path&#39;s refusal&#10;ok - a transient lock under treehouse&#39;s own spelling is retried under that spelling, not the refused one&#10;ok - home seed rollback returns a physically recorded home by treehouse&#39;s own $HOME-rooted spelling</code>

```text
Pre-fix baseline = 1cb900c source tree + this change's new test cases.

== tests/fm-teardown.test.sh, the three reconciliation cases, against 1cb900c code ==
not ok - symlinked-home-pool-path: teardown should return the worktree by treehouse's own spelling of the same directory: expected exit 0, got 1
exit=1

== tests/fm-secondmate-safety.test.sh, the seed-rollback case, against 1cb900c code ==
not ok - seed rollback reported a leaked lease instead of reconciling the two spellings

== the same cases against this change (c6fb6e5 + this phase's added case ac) ==
ok - a physically recorded worktree is returned by treehouse's own $HOME-rooted spelling of it
ok - an alternative spelling's genuinely different failure survives the recorded path's refusal
ok - a transient lock under treehouse's own spelling is retried under that spelling, not the refused one
ok - home seed rollback returns a physically recorded home by treehouse's own $HOME-rooted spelling
```
</details>
<details>
<summary>Evidence: Herdr pin gate: honest skip here, loud failure when the pin or version is unreadable, no skip at the pin</summary>

<code>pin published by bin/fm-install-herdr.sh --required-version : 0.7.4&#10;installed herdr : herdr 0.8.2&#10;&#10;real run on this host:&#10;skip: herdr 0.8.2 is not the suite-verified pin 0.7.4; install it with bin/fm-install-herdr.sh (exit=0)&#10;pin owner cannot answer:&#10;not ok - could not read the exact Herdr pin from bin/fm-install-herdr.sh --required-version (exit=1)&#10;installed version unreadable:&#10;not ok - could not read the installed Herdr version from ... (exit=1)&#10;version equals the pin:&#10;no skip line; the suite proceeds past the gate into lab provisioning</code>

```text
== this host ==
pin published by bin/fm-install-herdr.sh --required-version : 0.7.4
installed herdr                                            : herdr 0.8.2

== real run of tests/fm-backend-herdr-presentation-e2e.test.sh on this host ==
skip: herdr 0.8.2 is not the suite-verified pin 0.7.4; install it with bin/fm-install-herdr.sh
exit=0

== gate failure mode 1: the pin owner cannot answer (must not skip) ==
not ok - could not read the exact Herdr pin from bin/fm-install-herdr.sh --required-version
exit=1

== gate failure mode 2: the installed version cannot be read (must not skip) ==
not ok - could not read the installed Herdr version from /tmp/fm-pin-gate-zSn7VX/fakebin/herdr
exit=1

== gate is not vacuous: a herdr reporting the pin 0.7.4 is NOT skipped ==
fm-herdr-lab: fleet-state tripwire requires exactly one running default session
not ok - could not provision the isolated Herdr lab
(no 'skip:' line: the suite proceeded past the pin gate into lab provisioning)
```
</details>
<details>
<summary>Evidence: Mutation check for the case I added (reconciliation x lock patience)</summary>

<code>control (unmutated c6fb6e5):&#10;ok - a transient lock under treehouse&#39;s own spelling is retried under that spelling, not the refused one&#10;mutated (dir=$spelling removed):&#10;not ok - managed-spelling-transient-lock: teardown should succeed once the lock under treehouse&#39;s own spelling clears: expected exit 0, got 1</code>

```text
Mutation check for the added case (ac): drop 'dir=$spelling' from
teardown_treehouse_return so the lock patience window keeps the refused
recorded spelling instead of the one treehouse recognized.

== control: unmutated c6fb6e5 ==
ok - a transient lock under treehouse's own spelling is retried under that spelling, not the refused one

== mutated ==
not ok - managed-spelling-transient-lock: teardown should succeed once the lock under treehouse's own spelling clears: expected exit 0, got 1
```
</details>
<details>
<summary>Evidence: Changed-file selection for bin/fm-treehouse-lib.sh alone (fixed runner selects pr-forge, secondmate, real-herdr-gated; pre-fix runner dies unmapped)</summary>

<code>pre-fix runner: fm-test-run: no changed-test mapping for source path: bin/fm-treehouse-lib.sh (exit=2)&#10;fixed runner selects 35 scripts, including tests/fm-teardown.test.sh, tests/fm-secondmate-safety.test.sh, tests/fm-backend-herdr-presentation-e2e.test.sh</code>

```text
tests/fm-pr-check-security.test.sh
tests/fm-pr-merge.test.sh
tests/fm-review-diff.test.sh
tests/fm-teardown.test.sh
tests/fm-x-mode.test.sh
tests/fm-backlog-handoff.test.sh
tests/fm-on.test.sh
tests/fm-remote-backlog-handoff.test.sh
tests/fm-remote-doctor.test.sh
tests/fm-remote-job-orphan-reap.test.sh
tests/fm-remote-job.test.sh
tests/fm-remote-reply.test.sh
tests/fm-remote-secondmate-lifecycle-e2e.test.sh
tests/fm-remote-secondmate-trace-context.test.sh
tests/fm-secondmate-harness.test.sh
tests/fm-secondmate-lifecycle-e2e.test.sh
tests/fm-secondmate-liveness.test.sh
tests/fm-secondmate-safety.test.sh
tests/fm-secondmate-sync.test.sh
tests/fm-send-secondmate-marker.test.sh
tests/fm-shared-captain-inheritance.test.sh
tests/fm-startup-memory-budget.test.sh
tests/fm-stow-cascade.test.sh
tests/fm-afk-inject-herdr-e2e.test.sh
tests/fm-afk-launch.test.sh
tests/fm-backend-autodetect-smoke.test.sh
tests/fm-backend-herdr-eventwait-smoke.test.sh
tests/fm-backend-herdr-launcher-workspace-e2e.test.sh
tests/fm-backend-herdr-presentation-e2e.test.sh
tests/fm-backend-herdr-prune-safety-e2e.test.sh
tests/fm-backend-herdr-respawn-idem-e2e.test.sh
tests/fm-backend-herdr-smoke.test.sh
tests/fm-backend-herdr-workspace-per-home-e2e.test.sh
tests/fm-control-herdr-smoke.test.sh
tests/fm-herdr-session-cleanup-e2e.test.sh
```
</details>
<details>
<summary>Evidence: Suite log: tests/fm-teardown.test.sh (reconciliation cases z, aa, ab, ac)</summary>

```text
ok - local-only worktree with HEAD on a fork remote is torn down (fix holds)
ok - teardown prompts tasks-axi backlog refresh when compatible
ok - teardown honors config/backlog-backend=manual even when tasks-axi is compatible
ok - local-only worktree with truly unpushed work is refused (safety preserved)
ok - local-only worktree with work merged into local main is torn down (no regression)
ok - no-mistakes worktree with HEAD on origin is torn down (no regression)
ok - no-mistakes worktree with genuinely unlanded work is refused (safety preserved)
ok - local-only worktree with unpushed work is torn down under --force (escape hatch)
ok - teardown completes when an exact busy-state sidecar is already absent
ok - herdr teardown removes pane-owned escalation dedupe state
ok - herdr flat teardown refuses before returning the isolated copy under lock contention and the retry completes cleanly
ok - herdr flat teardown never erases records when pane presence is unparseable
ok - herdr flat teardown preflight refuses before every destructive change
ok - forced secondmate teardown preflights every Herdr child before cleanup mutation
ok - forced secondmate teardown holds every descendant lifecycle and metadata lock
ok - forced secondmate teardown retains Herdr child identity until exact pane disappearance
ok - forced teardown retains a nested secondmate home and its grandchild's Herdr identity when the grandchild close is unconfirmed
ok - herdr projection teardown retires its journal only after confirming the exact recorded pane is gone
ok - herdr projection teardown retains every record when post-close presence is unknown
ok - herdr projection teardown surfaces failed focus restoration without turning confirmed cleanup into a hard failure
ok - squash-merged + deleted-branch worktree (PR merged) is torn down (the fix)
ok - squash-merged PR accepts a local HEAD that is an ancestor of the final PR head
ok - teardown discovers a merged PR by branch name and tears down when no pr= was ever recorded
ok - squash-merged PR accepts replayed unpushed local patches contained in the PR head
ok - merged PR does not allow teardown after a later local commit
ok - fm-pr-check does not refresh PR head after HEAD moves
ok - fm-pr-check records the remote PR head when the local worktree lags
ok - worktree whose content already landed in the default branch is torn down (content fallback)
ok - content fallback refreshes origin default before comparing trees
ok - dirty worktree is refused even when its committed work has landed (dirty always wins)
ok - gh lookup error with content not in default refuses (fail-safe)
ok - provably-stale worktree index.lock (old, no live holder) is cleared and teardown succeeds
ok - live-held worktree index.lock is never removed and teardown refuses
ok - lsof errors leave worktree index.lock in place and refuse teardown
ok - stale lock cleanup rechecks and refuses dirty worktree before return
ok - normal repo index.lock is resolved from the worktree and cleared when stale
ok - lock mtime read failures leave worktree index.lock in place and refuse teardown
ok - transient index.lock cleared after first failed return is retried successfully without force-remove
ok - persistent index.lock exhausts retries and refuses without force-removing the lock
ok - a physically recorded worktree is returned by treehouse's own $HOME-rooted spelling of it
ok - a genuinely unmanaged worktree still fails, reported as the recorded path
ok - an alternative spelling's genuinely different failure survives the recorded path's refusal
ok - a transient lock under treehouse's own spelling is retried under that spelling, not the refused one
ok - empty retry wait overrides use the default without aborting teardown
ok - fractional legacy retry wait remains supported without arithmetic
ok - a task's own parked no-mistakes run is aborted, not orphaned, before the worker is removed
ok - teardown refuses before reap or removal when a task-owned run remains parked
ok - a different run cannot confirm the targeted abort
ok - empty post-abort status is not accepted as confirmation
ok - the CLI's exact run-not-found signal confirms completion
ok - a parked run on another branch is never aborted by this task's teardown (ownership is precise)
ok - a task-owned autonomous running step is left alone rather than aborted
ok - a leaked descendant process rooted under the task's worktree is reaped by teardown, not left surviving
ok - a leaked descendant process rooted under the task's per-task tasktmp is reaped by teardown too
ok - missing lsof falls back to reaping the tmux pane process group
ok - an erroring lsof scan refuses teardown and preserves the task
ok - a reused pid with a different start time is never force-killed
ok - an exec change preserves birth identity and the process is reaped
ok - a process spawned during grace is reaped on a later pass
ok - persistent leaked processes refuse teardown after bounded retries
ok - a process exiting during identity lookup does not block teardown
ok - the run abort and the leaked-process reap both complete before the destructive worktree return
```
</details>
<details>
<summary>Evidence: Suite log: tests/fm-secondmate-safety.test.sh (seed-rollback reconciliation case)</summary>

```text
ok - FM_HOME parameterizes data and state paths
ok - fm-lock status is scoped per home
ok - seed allows overlapping project clone lists and drops the owns/owner routing
ok - home-seed validation rejects registry records no operational parser can consume
ok - home seeding refuses broken registry symlinks before provisioning
ok - home seeding refuses unreadable registries before provisioning
ok - home seed validation rejects duplicate home routes
ok - home seed validation rejects duplicate id routes
ok - home seed validation rejects nested home routes
leased worktree for dash
ok - home seeding durably leases treehouse-acquired dash homes under the secondmate id
ok - home seeding returns rejected acquired homes through treehouse
ok - home seed rollback returns a physically recorded home by treehouse's own $HOME-rooted spelling
ok - home seed rollback warns when treehouse-acquired return fails
ok - home seeding leaves unsafe acquired active homes untouched
ok - home seeding rolls back failed clone attempts without residue
ok - home seeding refuses direct seed without filled charter text
ok - home seeding refuses unfilled placeholder charters
ok - home seeding refuses empty normalized charter fields
ok - home seeding scaffolds, registers, and spawns a project-less home end to end
ok - secondmate spawn resolves home validation and projects from punctuated registry fields
ok - secondmate spawn refuses ambiguous, supplied-home, and metadata-home registry bindings
ok - home seeding validates reused project-less charters before mutation
ok - home seeding refuses project-less conversion of a populated home
ok - home seeding refuses project-less homes whose projects directory cannot be inspected
ok - home seeding refuses project-less homes with symlinked projects directories
ok - home seeding refuses project-less homes with non-directory projects paths
ok - home seeding refuses project-less homes whose project registry cannot be inspected
ok - home seeding fails loudly on accidental project omission and rejects mixed --no-projects
ok - home seeding refuses local-only projects
ok - home seeding refuses registry delimiter home paths
ok - home seeding refuses active home and repo root
ok - home seeding refuses homes marked for another id
ok - home seeding refuses homes registered to another id
ok - home seeding refuses same-id reassignment to a different home
ok - home seeding refuses registered home overlaps
ok - remote-backed subhome seeding requires a source origin
ok - remote-backed subhome seeding validates existing destination origins
ok - home seeding resolves relative source origins against the source project
ok - home seeding skips initialized existing no-mistakes clones
ok - home seeding refuses uninitialized existing no-mistakes clones
ok - home seeding refuses project destinations outside the subhome
ok - home seeding refuses operational directories outside the subhome
ok - home seeding refuses symlinked and non-regular leaf files
ok - home reseeding preserves and enforces the durable parent binding
ok - secondmate spawn validates homes before launch
ok - secondmate spawn refuses operational directories outside the subhome
ok - fm-send refuses a bare firstmate window with no metadata in this home
ok - secondmate teardown retires empty homes and releases routing
ok - secondmate teardown refuses ambiguous and identity-mismatched registry bindings
ok - normal secondmate teardown sweeps process events before removal
ok - secondmate teardown preserves state when process-event sweeping is unavailable
ok - later teardown refusals preserve active process-event sources
ok - force teardown sweeps nested secondmate homes before deletion
ok - force teardown preserves nested process-event restoration status and recovery state
ok - secondmate teardown refuses to hide failed leased-home return
ok - secondmate teardown raw-removes plain-clone homes
ok - secondmate force teardown discards child work
ok - secondmate force teardown prevalidates child quarantine cleanup without following symlinks
ok - secondmate force teardown preserves child worktree after unproven lock refusal
ok - force teardown allows non-state operational directory symlinks inside the subhome
ok - force teardown refuses operational directory symlinks outside the subhome
ok - secondmate teardown refuses homes containing registered nested homes
ok - secondmate teardown refuses nested homes from the child registry
ok - force teardown validates subhome before child cleanup
ok - forced teardown refuses a non-directory descendant state path
ok - forced teardown refuses a symlinked descendant state path
ok - forced teardown locks a descendant whose state directory was absent
ok - forced teardown refuses while a fresh task is being published in the home
ok - a fresh spawn refuses to publish while a forced teardown owns the task set
ok - a fresh remote secondmate spawn refuses while the task set is owned
ok - force teardown refuses child worktrees inside the active home
ok - force teardown refuses child worktrees inside the firstmate repo
ok - force teardown refuses unregistered child worktree paths
ok - secondmate teardown path-boundary matrix refuses unmarked/ancestor/active-descendant/repo-descendant homes
ok - idle kind=secondmate pane is healthy and not stale
ok - secondmate charter brief is idle by default and does not self-initiate work
ok - fm-backlog-handoff aborts atomically on unmatched, in-flight, and unregistered targets
ok - fm-backlog-handoff refuses Done items under whitespace section headings and unsafe homes
```
</details>
<details>
<summary>Evidence: Reproducible demo scripts used for the manual verification</summary>

```text
#!/usr/bin/env bash
# Manual end-to-end verification for teardown-worktree-path.
#
# Uses the REAL treehouse binary and the REAL bin/fm-teardown.sh on a home that
# is a symlink (the shape of this host, where /home/inthuson -> /local/home/inthuson).
# Treehouse leases the pool worktree under its as-written $HOME root; firstmate
# records the fully resolved physical path. The demo shows:
#   1. real treehouse refusing the recorded physical spelling ("is not managed by
#      treehouse") with the lease still held  -- the reported bug
#   2. real fm-teardown.sh completing the return with no hand-edited worktree=,
#      and the lease released in treehouse's own pool status
#
# Usage: real-treehouse-teardown-demo.sh <firstmate-repo-root>
set -u

ROOT=${1:?usage: real-treehouse-teardown-demo.sh <firstmate-repo-root>}
SCRATCH=$(mktemp -d "${TMPDIR:-/tmp}/fm-th-e2e-XXXXXX")
PHYS="$SCRATCH/physhome"
LINK="$SCRATCH/home"
mkdir -p "$PHYS"
ln -s "$PHYS" "$LINK"
export HOME="$LINK"
export FM_GATE_REFUSE_BYPASS=1

hr() { printf '\n== %s ==\n' "$1"; }

hr "host-shaped fixture: a home that is a symlink"
printf 'HOME as written : %s\n' "$HOME"
printf 'HOME physical   : %s\n' "$(cd "$HOME" && pwd -P)"
printf 'treehouse       : %s (%s)\n' "$(command -v treehouse)" "$(treehouse --version 2>&1 | head -1)"

# A project with an origin, so the committed work is provably landed and teardown
# is allowed to make the destructive pool return.
mkdir -p "$PHYS/proj"
git init -q -b main "$PHYS/proj"
git -C "$PHYS/proj" config user.email t@t
git -C "$PHYS/proj" config user.name t
echo hello > "$PHYS/proj/file.txt"
git -C "$PHYS/proj" add -A
git -C "$PHYS/proj" commit -q -m "seed work"
git init -q --bare "$PHYS/origin.git"
git -C "$PHYS/proj" remote add origin "$PHYS/origin.git"
git -C "$PHYS/proj" push -q -u origin main
printf 'max_trees = 4\nroot = ""\n' > "$PHYS/proj/treehouse.toml"

hr "treehouse get --lease (real pool acquire)"
WT_ASWRITTEN=$( cd "$PHYS/proj" && treehouse get --lease --lease-holder fm-evidence ) || exit 1
WT_PHYS=$(cd "$WT_ASWRITTEN" && pwd -P)
printf "treehouse's own pool spelling : %s\n" "$WT_ASWRITTEN"
printf "fm-spawn's recorded worktree= : %s\n" "$WT_PHYS"

hr "the bug: real treehouse return --force with the recorded physical path"
( cd "$PHYS/proj" && treehouse return --force "$WT_PHYS" ) 2>&1
printf 'exit=%s\n' "$?"
printf 'pool status: %s\n' "$( cd "$PHYS/proj" && treehouse status --json )"

# Record the task exactly as bin/fm-spawn.sh does: resolved physical paths, no
# hand-editing of worktree=.
CASE="$SCRATCH/case"
mkdir -p "$CASE/state" "$CASE/config" "$CASE/fakebin"
{
  echo "window=firstmate:fm-task-e2e"
  echo "endpoint_task_id=task-e2e"
  echo "worktree=$WT_PHYS"
  echo "project=$PHYS/proj"
  echo "kind=ship"
  echo "mode=no-mistakes"
} > "$CASE/state/task-e2e.meta"

# Terminal / GitHub / no-mistakes stubs only. treehouse is deliberately NOT
# stubbed, so the return below goes to the real binary.
for stub in tmux gh gh-axi no-mistakes; do
  printf '#!/usr/bin/env bash\nexit 0\n' > "$CASE/fakebin/$stub"
  chmod +x "$CASE/fakebin/$stub"
done

hr "recorded task meta (worktree= is the physical spelling, unedited)"
cat "$CASE/state/task-e2e.meta"

hr "the fix: real bin/fm-teardown.sh on that recorded path"
HOME="$LINK" \
FM_ROOT_OVERRIDE="$ROOT" \
FM_STATE_OVERRIDE="$CASE/state" \
FM_CONFIG_OVERRIDE="$CASE/config" \
PATH="$CASE/fakebin:$PATH" \
  "$ROOT/bin/fm-teardown.sh" task-e2e
printf 'fm-teardown.sh exit=%s\n' "$?"

hr "treehouse's own pool status after teardown"
( cd "$PHYS/proj" && treehouse status --json )

rm -rf "$SCRATCH"
```
</details>
- Outcome: ⚠️ 2 warnings across 1 run (17m20s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"29094710cff97855347810c19c5916a8e807b6ff","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- 🚨 `bin/fm-teardown.sh:169` - fm-teardown.sh now sources a new sibling, $SCRIPT_DIR/fm-treehouse-lib.sh, but tests/fm-gotmp.test.sh runs the real teardown from a hand-built fake bin/ that symlinks each lib teardown sources one by one (tests/fm-gotmp.test.sh:63 and :143) and has no entry for the new file. SCRIPT_DIR resolves to that fake bin/ (the fixture exists precisely because BASH_SOURCE[0] is not dereferenced), so the source fails and, under teardown&#39;s `set -eu`, the script exits 1 before it ever parses its argument. Failure: `bash &#34;$fake/bin/fm-teardown.sh&#34; td-rm-z2` prints &#34;fm-treehouse-lib.sh: No such file or directory&#34; and exits 1, so both test_teardown_removes_tasktmp_dir and test_teardown_skips_gracefully_without_tasktmp fail with &#34;teardown exited non-zero with a valid tasktmp&#34;. bin/fm-teardown.sh maps only to the pr-forge family, so the changed-file selection never selects fm-gotmp.test.sh (pure-contract-unit), but CI&#39;s portable lanes run it. Fix: add `ln -s &#34;$ROOT/bin/fm-treehouse-lib.sh&#34; &#34;$fake/bin/fm-treehouse-lib.sh&#34;` at both fixture sites, matching the fm-lock-lib.sh line above each.
- ⚠️ `bin/fm-treehouse-lib.sh:1` - The new lib has no entry in bin/fm-test-run.sh&#39;s families_for_changed_path, so it falls through the `bin/*` case to families_for_test_reference on its basename. Only the four real-Herdr suites source it by name, and all four are family real-herdr-gated, so a future change to bin/fm-treehouse-lib.sh selects only suites that gate-skip on any host without pinned herdr, and never selects pr-forge (tests/fm-teardown.test.sh, which owns this change&#39;s reconciliation regression) or secondmate (tests/fm-secondmate-safety.test.sh, which owns the home-seed rollback return). Failure: editing the spelling-candidate order in fm_treehouse_path_spellings and running the changed-file selection runs zero assertions about it on a non-pinned host, reporting green. bin/fm-nm-run-lib.sh at bin/fm-test-run.sh:937 is the existing precedent for a shared lib mapping to each consumer&#39;s family; add bin/fm-treehouse-lib.sh emitting pr-forge, secondmate, and real-herdr-gated.
- ⚠️ `bin/fm-teardown.sh:1120` - On total failure only the first attempt&#39;s output is reported. That is right when later attempts are &#34;not managed by treehouse&#34; refusals, but it also discards a later attempt&#39;s genuinely different failure. Failure: on the symlinked home this change targets, the recorded physical path is refused as unmanaged (first_out), then the $HOME spelling that treehouse does manage fails for a real reason such as an unreadable worktree or a failed reset; teardown prints only &#34;worktree /local/home/... is not managed by treehouse&#34; plus &#34;teardown aborted&#34;, so the operator is pointed at the spelling defect this change just fixed instead of the actual cause, and the real error text is lost entirely. bin/fm-treehouse-lib.sh:120 has the same shape, where the seed-rollback warning then claims only that the lease may still be held. Suggest keeping first_out as the headline but still emitting any attempt output that is not an unmanaged-path refusal; flagging rather than changing it because the intent states this reporting rule deliberately.
- ⚠️ `bin/fm-treehouse-lib.sh:96` - fm_treehouse_return_force is a separate ~25-line loop from teardown&#39;s inline one, and no test covers it succeeding on an alternative spelling. The two new tests in tests/fm-teardown.test.sh drive teardown_treehouse_return&#39;s own loop, not this function. tests/fm-secondmate-safety.test.sh:327 only exercises the total-failure branch with an always-failing fake, and the four real-Herdr suites call it in best-effort cleanup behind `|| true` and gate-skip without pinned herdr. Failure: invert the candidate order or drop the `resolved = physical` guard in this function and every portable suite still passes, while the seed-rollback lease leak the intent names as the reason for touching fm-home-seed.sh silently returns. Mirror test_home_seed_returns_treehouse_acquired_home_on_assignment_failure with a symlinked HOME and a string-matching treehouse fake, the shape add_pool_spelling_treehouse already provides.
- ⚠️ `tests/fm-backend-herdr-presentation-e2e.test.sh:38` - The pin gate recovers the expected version by regexing bin/fm-install-herdr.sh&#39;s source with `sed -n &#39;s/^FM_HERDR_CI_VERSION=\([0-9][0-9.]*\)$/\1/p&#39;`, and hard-fails the suite when that pattern does not match. That couples a required-lane suite to the byte shape of an implementation file, which the repo&#39;s own rule forbids (firstmate-coding-guidelines: &#34;Tests must exercise behavior through an executable or public interface and must never assert implementation-source bytes, including through parsers, regexes, snapshots, or indirect wrappers&#34;). Failure: a behavior-preserving edit to the install script, quoting the value as FM_HERDR_CI_VERSION=&#34;0.7.4&#34; or appending a trailing comment, makes the sed return empty and this suite exits 1 with &#34;could not read the exact Herdr pin&#34;, blocking the required Herdr lane on every PR while the install script itself still works. Keeping bin/fm-install-herdr.sh as the single pin owner is compatible with an interface: a `--print-pin` mode, or a tiny pin file both the installer and the suite read. Raising rather than changing it because the intent specifies reading the pin from that file.

🔧 Fix: expose Herdr pin via flag and cover spelling reconciliation
2 infos still open:
- ℹ️ `bin/fm-teardown.sh:1127` - A spelling-independent failure is now reported twice. When the first spelling fails for a reason that is neither an unmanaged-path refusal nor an index.lock signature, the loop continues to the next spelling, which then fails with the identical text; that text lands in first_out (printed at :1126) and again in other_out (printed at :1127). Concretely, the worktree return at bin/fm-teardown.sh:2502 passes cd_dir=$PROJ with no `[ -d &#34;$PROJ&#34; ]` or `command -v treehouse` guard, so on a symlinked home a missing project dir prints `cd: /.../project: No such file or directory` twice, and a missing treehouse binary prints `treehouse: command not found` twice, before `teardown aborted`. The same shape exists at bin/fm-treehouse-lib.sh:135. The intent behind keeping other_out was that a later spelling&#39;s *genuinely different* failure is the real cause; text identical to first_out is not a different failure. Suggest skipping an other_out entry equal to first_out.
- ℹ️ `bin/fm-treehouse-lib.sh:127` - The library copy of the later-attempt real-failure reporting added this round has no test. tests/fm-secondmate-safety.test.sh:327 covers only fm_treehouse_return_force succeeding on the alternative spelling, and the pre-existing test_home_seed_warns_when_acquired_home_return_fails drives an FM_FAKE_TREEHOUSE_RETURN_FAIL fake that exits 17 with no output, so other_out stays empty on both paths. Deleting lines 127-128 and 135 leaves every portable suite green while the seed-rollback warning again claims only that the lease may still be held, which is exactly the misleading message the round-1 fix existed to remove. The teardown twin is covered by test_managed_spelling_real_failure_is_not_hidden_by_the_recorded_refusal; the equivalent for the lib is one FM_FAKE_TREEHOUSE_MANAGED plus FM_FAKE_TREEHOUSE_MANAGED_FAIL-style case asserting the managed spelling&#39;s own error text reaches the seed&#39;s stderr. Separately, the third candidate at line 87 (the fully physical reverse direction) is live, since WT at bin/fm-teardown.sh:453 is the raw meta value and a meta hand-edited to the $HOME spelling reaches it, but no test exercises it either.

</details>

<details>
<summary>⚠️ **Test** - 2 warnings</summary>

- ⚠️ `tests/fm-backend-herdr-presentation-e2e.test.sh:22` - The presentation suite&#39;s substantive claim (the abort is gone and the suite now reaches and passes five checks, including the previously unreachable opted-out spawn and teardown) is not verifiable on this host: herdr is 0.8.2 while the suite is bound to the 0.7.4 pin, and downgrading was explicitly ruled out to protect the live session. Locally I could only prove the skip path plus the gate&#39;s loud failure modes. Only the required Herdr CI lane, which asserts the exact 0.7.4 pin before running any suite, can confirm the five checks actually pass. You may want to decide whether CI confirmation is enough or whether you want that lane&#39;s output attached before merge.
- ⚠️ `tests/fm-backend-herdr-workspace-per-home-e2e.test.sh:74` - Three real-herdr-gated suites this change touches (fm-backend-autodetect-smoke, fm-backend-herdr-launcher-workspace-e2e, fm-backend-herdr-workspace-per-home-e2e) received the new fm_treehouse_return_force cleanup call but have no pin gate, so on this host they would run against the captain&#39;s live herdr 0.8.2 server and the real $HOME treehouse pool. I deliberately did not run them: on 0.8.2 a projected cleanup orphans a workspace (the defect this change itself documents as herdr-082-projection-orphan-o4), and they would acquire and reset real pool worktrees while parked validation runs hold slots. Their changed line is the shared cleanup call, which I verified directly against the real treehouse binary, so the residual gap is their own suite bodies at the pin, which the Herdr CI lane owns.
- `bash tests/fm-teardown.test.sh`
- `bash tests/fm-secondmate-safety.test.sh`
- `bash tests/fm-gotmp.test.sh`
- `bash tests/fm-test-run.test.sh`
- `bash tests/fm-backend-herdr-presentation-e2e.test.sh`
- `bash tests/fm-backlog-handoff.test.sh`
- <code>Real-tooling e2e: `treehouse get --lease` under a symlinked HOME, `treehouse return --force &lt;physical&gt;` (refused, lease held), then real `bin/fm-teardown.sh task-e2e` (returns; pool leased -&gt; available)</code>
- `Same e2e against a pre-fix 1cb900c tree (teardown aborted, exit 1, lease still held)`
- <code>Boundary probe of `fm_treehouse_path_spellings` / `fm_treehouse_return_force` against the real treehouse binary</code>
- `Pre-fix baseline runs of both colocated regressions (both fail without the fix)`
- <code>Mutation check: removing `dir=$spelling` from `teardown_treehouse_return` fails the case I added</code>
- <code>`bin/fm-install-herdr.sh --required-version` plus the three pin-gate paths (unreadable pin, unreadable version, version equals pin)</code>
- <code>`bin/fm-test-run.sh --list --changed --base 1cb900c` and an isolated single-path selection for `bin/fm-treehouse-lib.sh`</code>

</details>

<details>
<summary>🔧 **Document** - 2 issues found → auto-fixed ✅</summary>

- ℹ️ `docs/herdr-backend.md:318` - Unblocking the presentation suite exposed a real Herdr 0.8.2 defect (closing a tab&#39;s last pane respawns a pane, so projected cleanup never removes the projected workspace and orphans one per cleanup), and docs/herdr-backend.md&#39;s &#34;Presentation spaces&#34; and &#34;Active limits&#34; sections state no such limit. I did not add it: this change does not alter product behavior on 0.8.2, that doc scopes its claims to the verified 0.7.1-0.8.0 set so nothing there is currently contradicted, and the intent files the defect separately as herdr-082-projection-orphan-o4 at priority 1. Judgment call for you: if that task will not land soon, the captain-visible limit is worth one line in docs/herdr-backend.md&#39;s &#34;Active limits&#34; (owned by that follow-up task, not this change), since this host itself runs 0.8.2.
- ℹ️ `.github/workflows/ci.yml:236` - Out-of-scope follow-up: .github/workflows/ci.yml&#39;s &#34;Assert Herdr pin and protocol floor&#34; step hand-copies the pin value 0.7.4 twice, while this change made bin/fm-install-herdr.sh the queryable single owner via --required-version. The copies agree today so nothing is stale, and a docs phase cannot change workflow behavior, but reading the pin from the interface would remove the hand-copied duplicate the new flag exists to serve.

🔧 Fix: note Herdr 0.8.2 projected-cleanup workspace orphan limit
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
