### PR TITLE
fix(bin): prefer pipeline-owned current run state

### DIFF
--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -28,9 +28,10 @@
 #      unreachable or unreadable remote reports unknown-remote, never a false
 #      gone/dead.
 #   2. Matching no-mistakes run for this crew's branch AND current code identity,
-#      active or terminal (from `axi status`, or the coarse `no-mistakes runs`
-#      fallback)? Branch name alone is not enough: a historical run on a reused
-#      branch whose head was rewritten or diverged must not be attributed.
+#      active or terminal (from `axi status`, its pipeline-owned branch_sync
+#      binding, or the coarse `no-mistakes runs` fallback)? Branch name alone is
+#      not enough: a historical run on a reused branch whose head was rewritten
+#      or diverged must not be attributed.
 #      A run matches when its head equals the worktree HEAD, or the worktree HEAD
 #      is an ancestor of the run head (pipeline fix commits advanced the run on
 #      the same line of history). Local work that advanced past the run head, or
@@ -430,6 +431,63 @@ nm_coarse_head_matches_worktree() {  # <short-sha>
   fm_nm_head_matches_worktree "$WT" "$1"
 }
 
+# `axi status` can name another run as the repository-wide active/recent one
+# while branch_sync identifies this worktree's pipeline-owned run. Accept that
+# alternate identity only when the binding is complete: branch_sync says the
+# pipeline owns it, its current head is on this worktree's history, and a
+# direct status lookup repeats the exact run ID, crew branch, and head.
+nm_branch_sync_field() {  # <key>
+  local key=$1
+  printf '%s\n' "$RUN_OUT" | awk -v key="$key" '
+    function indent(line) { match(line, /[^[:space:]]/); return RSTART - 1 }
+    /^[[:space:]]*branch_sync:[[:space:]]*$/ { base = indent($0); in_sync = 1; next }
+    in_sync && $0 ~ /[^[:space:]]/ && indent($0) <= base { exit }
+    in_sync && $0 ~ "^[[:space:]]*" key ":[[:space:]]*" {
+      sub("^[[:space:]]*" key ":[[:space:]]*", "")
+      print
+      exit
+    }
+  '
+}
+nm_branch_sync_pipeline_field() {  # <key>
+  local key=$1
+  printf '%s\n' "$RUN_OUT" | awk -v key="$key" '
+    function indent(line) { match(line, /[^[:space:]]/); return RSTART - 1 }
+    /^[[:space:]]*branch_sync:[[:space:]]*$/ { sync_indent = indent($0); in_sync = 1; next }
+    in_sync && $0 ~ /[^[:space:]]/ && indent($0) <= sync_indent { exit }
+    in_sync && /^[[:space:]]*pipeline:[[:space:]]*$/ { pipeline_indent = indent($0); in_pipeline = 1; next }
+    in_pipeline && $0 ~ /[^[:space:]]/ && indent($0) <= pipeline_indent { exit }
+    in_pipeline && $0 ~ "^[[:space:]]*" key ":[[:space:]]*" {
+      sub("^[[:space:]]*" key ":[[:space:]]*", "")
+      print
+      exit
+    }
+  '
+}
+nm_same_commit() {  # <head-a> <head-b>
+  local a b
+  a=$(git -C "$WT" rev-parse --verify "${1}^{commit}" 2>/dev/null) || return 1
+  b=$(git -C "$WT" rev-parse --verify "${2}^{commit}" 2>/dev/null) || return 1
+  [ "$a" = "$b" ]
+}
+nm_pipeline_owned_run() {
+  local pipeline_run pipeline_head pipeline_out detail_id detail_branch detail_head
+  [ "$(strip_quotes "$(nm_branch_sync_field state)")" = pipeline_owned ] || return 1
+  pipeline_run=$(strip_quotes "$(nm_branch_sync_pipeline_field run)")
+  pipeline_head=$(strip_quotes "$(nm_branch_sync_pipeline_field current_head)")
+  [ -n "$pipeline_run" ] && [ -n "$pipeline_head" ] || return 1
+  fm_nm_head_matches_worktree "$WT" "$pipeline_head" || return 1
+  pipeline_out=$(nm_run axi status --run "$pipeline_run")
+  [ -n "$pipeline_out" ] || return 1
+  detail_id=$(strip_quotes "$(fm_nm_field "$pipeline_out" id)")
+  detail_branch=$(strip_quotes "$(fm_nm_field "$pipeline_out" branch)")
+  detail_head=$(strip_quotes "$(fm_nm_field "$pipeline_out" head)")
+  [ "$detail_id" = "$pipeline_run" ] && [ "$detail_branch" = "$CREW_BRANCH" ] || return 1
+  nm_same_commit "$pipeline_head" "$detail_head" || return 1
+  fm_nm_head_matches_worktree "$WT" "$detail_head" || return 1
+  RUN_OUT=$pipeline_out
+}
+
 HAVE_RUN=0
 # RUN_SOURCE distinguishes the two ways HAVE_RUN=1 can happen: "full" means
 # $RUN_OUT is real `axi status` TOON with step/gate detail; "coarse" means only
@@ -446,6 +504,11 @@ if [ "$KIND" = ship ] && [ -n "$CREW_BRANCH" ] && command -v no-mistakes >/dev/n
     if [ -n "$run_branch" ] && [ "$run_branch" = "$CREW_BRANCH" ] && nm_run_head_matches_worktree; then
       HAVE_RUN=1
     else
+      if nm_pipeline_owned_run; then
+        HAVE_RUN=1
+      fi
+    fi
+    if [ "$HAVE_RUN" = 0 ]; then
       # The active-or-most-recent run is for another branch, or same branch with
       # a rewritten/diverged head (the CLI is alive and answered; only the
       # attribution missed) - try the coarse fallback.

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -291,6 +291,16 @@ outcome: failed
 EOF
 }
 
+branch_sync_pipeline_owned() {  # <run-id> <current-head>
+  cat <<EOF
+branch_sync:
+  state: pipeline_owned
+  pipeline:
+    run: "$1"
+    current_head: "$2"
+EOF
+}
+
 run_ci_monitoring() {  # <branch>
   cat <<EOF
 run:
@@ -736,6 +746,67 @@ EOF
   assert_contains "$out" "state: working" "most recent (running) row wins over an older completed row"
   assert_contains "$out" "source: run-step" "most-recent-row resolution -> run-step source"
   pass "cross-branch attribution picks the branch's most recent row"
+}
+
+# A pipeline-owned review-fix round can advance its current head while the
+# isolated crew copy remains at the submitted head. The repository-wide status
+# may meanwhile name another run, and the coarse list can still contain an
+# older failed row at the submitted head. The proven branch_sync run identity
+# must win over that historical coarse row.
+test_pipeline_owned_run_beats_historical_coarse_failure() {
+  reset_fakes
+  local d base_head pipeline_head short out
+  d=$(new_case pipeline-owned-current)
+  make_repo_on_branch "$d/wt" fm/feat-pipeline-owned
+  base_head=$(git -C "$d/wt" rev-parse HEAD)
+  git -C "$d/wt" commit -q --allow-empty -m 'pipeline-owned review fix'
+  pipeline_head=$(git -C "$d/wt" rev-parse HEAD)
+  git -C "$d/wt" reset -q --hard "$base_head"
+  short=$(git -C "$d/wt" rev-parse --short=7 HEAD)
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/pipeline-owned.meta" "window=fm:fm-pipeline-owned" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)
+$(branch_sync_pipeline_owned 01CURRENT "$pipeline_head")"
+  FM_FAKE_RUN_HEAD="$pipeline_head"
+  FM_FAKE_AXI_STATUS_RUN="$(run_fixing fm/feat-pipeline-owned | sed 's/01RUN/01CURRENT/')"
+  FM_FAKE_RUNS_LIST="$(cat <<EOF
+running    fm/other-crew aaaaaaa  2026-08-20 12:10
+failed     fm/feat-pipeline-owned ${short}  2026-08-20 12:00
+EOF
+)"
+  out=$(run_crew_state "$d" pipeline-owned)
+  assert_contains "$out" "state: working" "pipeline-owned review-fix run must not report historical failure"
+  assert_contains "$out" "source: run-step" "pipeline-owned run is authoritative"
+  assert_contains "$out" "validating (fixing)" "pipeline-owned review-fix round is surfaced"
+  pass "pipeline-owned run beats historical coarse failure"
+}
+
+# A branch_sync record that names a divergent tip has not proven pipeline
+# custody of this worktree. It must not weaken rewritten-tip protection.
+test_pipeline_owned_run_requires_current_head_binding() {
+  reset_fakes
+  local d divergent_head out
+  d=$(new_case pipeline-owned-divergent)
+  make_repo_on_branch "$d/wt" fm/feat-pipeline-divergent
+  git -C "$d/wt" checkout -q --orphan divergent-pipeline
+  git -C "$d/wt" commit -q --allow-empty -m 'unrelated pipeline tip'
+  divergent_head=$(git -C "$d/wt" rev-parse HEAD)
+  git -C "$d/wt" checkout -q fm/feat-pipeline-divergent
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/pipeline-divergent.meta" "window=fm:fm-pipeline-divergent" "worktree=$d/wt" "kind=ship" "harness=claude"
+  printf 'working: current worker is active\n' > "$d/state/pipeline-divergent.status"
+  FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)
+$(branch_sync_pipeline_owned 01CURRENT "$divergent_head")"
+  FM_FAKE_RUN_HEAD="$divergent_head"
+  FM_FAKE_AXI_STATUS_RUN="$(run_fixing fm/feat-pipeline-divergent | sed 's/01RUN/01CURRENT/')"
+  FM_FAKE_RUNS_LIST=""
+  FM_FAKE_BUSY=0
+  arm_idle_record "$d/state" pipeline-divergent
+  out=$(run_crew_state "$d" pipeline-divergent)
+  assert_not_contains "$out" "source: run-step" "divergent branch_sync head must not bind a pipeline run"
+  assert_contains "$out" "source: status-log" "unbound pipeline record falls back to current state"
+  assert_contains "$out" "state: working" "unbound pipeline record does not mask current worker state"
+  pass "pipeline-owned run requires current-head binding"
 }
 
 test_coarse_run_does_not_probe_other_branch_ci_log_for_ready_status() {
@@ -1430,6 +1501,8 @@ test_terminal_passed
 test_terminal_failed
 test_cross_branch_attribution_via_runs_list
 test_cross_branch_attribution_picks_most_recent_row
+test_pipeline_owned_run_beats_historical_coarse_failure
+test_pipeline_owned_run_requires_current_head_binding
 test_coarse_run_does_not_probe_other_branch_ci_log_for_ready_status
 test_other_branch_run_ignored
 test_no_run_busy_pane


### PR DESCRIPTION
## summary
- prefer the run identified by a proven pipeline-owned branch-sync record before the coarse branch/SHA fallback
- preserve the rewritten and unrelated tip rejection boundary
- cover a current active fix round beside an older failed run, plus divergent-head rejection

## verification
- `tests/fm-crew-state.test.sh` passed
- no-mistakes completed review and validation through the push stage; its upstream push failed with HTTP 403 before the writable fork was configured

## delivery note
The validated branch is pushed to `kastheco/firstmate`; upstream CI is authoritative for this PR.