### PR TITLE
docs(bin): state main as the default-branch convention, master as legacy fallback

### DIFF
--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -44,7 +44,7 @@ default_branch() {
 BRANCH="fm/$ID"
 git -C "$PROJ" rev-parse --verify --quiet "refs/heads/$BRANCH" >/dev/null || { echo "error: branch $BRANCH does not exist in $PROJ" >&2; exit 1; }
 
-DEFAULT=$(default_branch) || { echo "error: cannot determine default branch for $PROJ; expected origin/HEAD, main, or master" >&2; exit 1; }
+DEFAULT=$(default_branch) || { echo "error: cannot determine default branch for $PROJ; expected origin/HEAD, or a local main (legacy master also accepted)" >&2; exit 1; }
 
 # The project's main checkout must be on its default branch and clean, so the
 # fast-forward lands predictably (firstmate never writes here otherwise).

--- a/bin/fm-review-diff.sh
+++ b/bin/fm-review-diff.sh
@@ -65,7 +65,7 @@ default_branch() {
   return 1
 }
 
-DEFAULT=$(default_branch) || { echo "error: cannot determine default branch for $PROJ; expected origin/HEAD, main, or master" >&2; exit 1; }
+DEFAULT=$(default_branch) || { echo "error: cannot determine default branch for $PROJ; expected origin/HEAD, or a local main (legacy master also accepted)" >&2; exit 1; }
 
 BRANCH="fm/$ID"
 if ! git -C "$WT" rev-parse --verify --quiet "refs/heads/$BRANCH" >/dev/null; then

--- a/bin/fm-tangle-lib.sh
+++ b/bin/fm-tangle-lib.sh
@@ -18,7 +18,7 @@
 # primary checkout is the alarm.
 
 # Resolve the default branch name of the git repo at <dir>: prefer origin/HEAD,
-# then fall back to a local main/master. Echoes the name, or returns 1.
+# then fall back to a local main (legacy master as a secondary fallback). Echoes the name, or returns 1.
 fm_default_branch() {
   local dir=$1 ref branch
   ref=$(git -C "$dir" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1163,7 +1163,7 @@ validate_worktree_teardown_safety() {
   unpushed=$(printf '%s\n' "$unpushed_raw" | head -5)
 
   if [ -n "$unpushed" ] && [ "$MODE" = local-only ]; then
-    DEFAULT=$(default_branch) || { echo "REFUSED: cannot determine default branch for $PROJ; expected origin/HEAD, main, or master." >&2; return 1; }
+    DEFAULT=$(default_branch) || { echo "REFUSED: cannot determine default branch for $PROJ; expected origin/HEAD, or a local main (legacy master also accepted)." >&2; return 1; }
     if ! unmerged_raw=$(git -C "$WT" log --oneline HEAD --not "$DEFAULT" -- 2>/dev/null); then
       if worktree_safety_blocked_by_lock "commits not on $DEFAULT"; then
         return "$TEARDOWN_WORKTREE_SAFETY_LOCK_BLOCKED"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -165,7 +165,7 @@ Its operating checkout (`FM_ROOT`) and the disposable crewmate worktrees are all
 The primary checkout is healthy on its default branch, and linked worktrees or secondmate homes are healthy at detached HEAD.
 Only a named non-default branch checked out in `FM_ROOT` is a worktree tangle.
 
-`fm-tangle-lib.sh` resolves the default branch from `origin/HEAD`, then local `main` or `master`, and classifies that named non-default primary branch as the tangle.
+`fm-tangle-lib.sh` resolves the default branch from `origin/HEAD`, then local `main` (legacy `master` as a secondary fallback), and classifies that named non-default primary branch as the tangle.
 `fm-guard.sh` prints the repair command on the next mutable fleet action, while `bin/fm-session-start.sh` reports the same condition through bootstrap as a `TANGLE:` line at session start.
 If another live session holds the fleet lock, both surfaces keep the alarm but switch to read-only wording with no repair command.
 Ship briefs also tell the crewmate to verify `pwd -P` and `git rev-parse --show-toplevel` before creating `fm/<id>`, then stop with a blocked status if it landed in the primary checkout.


### PR DESCRIPTION
## Intent

The captain changed the fleet's branch convention: moving forward, all repos use 'main' as the default branch instead of 'master'. They asked to update the internal docs as needed. The firstmate repo itself is already on main (local checkout, remote HEAD, and CI workflows all use main), and every default-branch resolver already prefers main first with master as a legacy fallback (for branch in main master). The change rewords the five spots that still named 'master' as an equal alternative so the docs, comments, and error messages state main as the primary convention and master as an accepted legacy fallback: the cannot-determine-default-branch error messages in bin/fm-teardown.sh, bin/fm-review-diff.sh, and bin/fm-merge-local.sh now read 'expected origin/HEAD, or a local main (legacy master also accepted)'; the fm-tangle-lib.sh comment says 'local main (legacy master as a secondary fallback)'; docs/architecture.md says 'local main (legacy master as a secondary fallback)'. The resolver loops themselves are unchanged - they already resolve main first. No behavior change; pure message/comment/documentation wording.

## What Changed

- Reworded the cannot-determine-default-branch error messages in `bin/fm-teardown.sh`, `bin/fm-review-diff.sh`, and `bin/fm-merge-local.sh` to read "expected origin/HEAD, or a local main (legacy master also accepted)".
- Updated the resolver comment in `bin/fm-tangle-lib.sh` and the matching passage in `docs/architecture.md` to describe `main` as the primary local fallback with `master` as a legacy secondary fallback.
- No behavior change: the resolver loops are untouched and still prefer `main` first; only message/comment/documentation wording was adjusted.

## Risk Assessment

✅ Low: The change is a five-line, non-functional rewording of error messages, a comment, and a doc line that accurately matches the unchanged resolver behavior and the stated intent, with no test or behavior impact.

## Testing

Exercised the real end-user error paths: triggered the cannot-determine-default-branch failure in bin/fm-review-diff.sh, bin/fm-merge-local.sh, and bin/fm-teardown.sh against sandbox repos with no resolvable default branch and confirmed each emits the exact new wording; confirmed the fm_default_branch resolver behavior is unchanged (main first, master legacy fallback, origin/HEAD priority, failure rc=1); confirmed docs/architecture.md renders the new sentence; confirmed no equal-alternative 'main or master' wording remains and no tests assert the old messages; existing tangle-guard suite passes 6/6. This is a pure message/comment/doc wording change with no behavior delta, and all evidence is captured in CLI transcripts.

<details>
<summary>Evidence: End-to-end transcript: new default-branch error wording from all three scripts</summary>

<code>### bin/fm-review-diff.sh t1&#10;error: cannot determine default branch for /tmp/fm-sandbox-01M0GHAZR/proj; expected origin/HEAD, or a local main (legacy master also accepted)&#10;exit=1&#10;&#10;### bin/fm-merge-local.sh t2&#10;error: cannot determine default branch for /tmp/fm-sandbox-01M0GHAZR/proj; expected origin/HEAD, or a local main (legacy master also accepted)&#10;exit=1&#10;&#10;### bin/fm-teardown.sh t3 (worktree with unlanded commits, local-only mode)&#10;REFUSED: cannot determine default branch for /tmp/fm-sandbox-01M0GHAZR/proj3; expected origin/HEAD, or a local main (legacy master also accepted).&#10;exit=1</code>

```text
## End-to-end: new default-branch error wording when no default branch is resolvable

### bin/fm-review-diff.sh t1
error: cannot determine default branch for /tmp/fm-sandbox-01M0GHAZR/proj; expected origin/HEAD, or a local main (legacy master also accepted)
exit=1

### bin/fm-merge-local.sh t2
error: cannot determine default branch for /tmp/fm-sandbox-01M0GHAZR/proj; expected origin/HEAD, or a local main (legacy master also accepted)
exit=1

### bin/fm-teardown.sh t3 (worktree with unlanded commits, local-only mode)
REFUSED: cannot determine default branch for /tmp/fm-sandbox-01M0GHAZR/proj3; expected origin/HEAD, or a local main (legacy master also accepted).
exit=1
```
</details>
<details>
<summary>Evidence: Resolver behavior unchanged (main first, master legacy fallback)</summary>

<code>repo with main+master, no origin/HEAD -&gt; main (expect main)&#10;repo with origin/HEAD=master, main exists -&gt; master (expect master, origin/HEAD wins)&#10;repo with only master (legacy fallback) -&gt; master (expect master)&#10;repo with neither main nor master -&gt; rc=1 (expect non-zero)</code>

```text
Exercising fm_default_branch (the unchanged resolver) via `. bin/fm-tangle-lib.sh`:

repo with main+master, no origin/HEAD       -> main (expect main)
repo with origin/HEAD=master, main exists -> master (expect master, origin/HEAD wins)
repo with only master (legacy fallback)    -> master (expect master)
repo with neither main nor master           -> rc=1 (expect non-zero)
```
</details>
<details>
<summary>Evidence: docs/architecture.md rendered wording</summary>

<code>`fm-tangle-lib.sh` resolves the default branch from `origin/HEAD`, then local `main` (legacy `master` as a secondary fallback), and classifies that named non-default primary branch as the tangle.</code>

```text
`fm-spawn.sh` also owns the base-freshness boundary for every fresh ship and scout: no worker starts until its clean task worktree matches the fetched tip of origin's resolved default branch, and any unsafe or unverifiable base stops the spawn.
Its header owns the exact refusal mechanics, while `tests/fm-spawn-pool-base-freshen.test.sh` owns the portable regression coverage.

The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.
Its operating checkout (`FM_ROOT`) and the disposable crewmate worktrees are all linked git worktrees of the same repository, so the valid discriminator is branch state, not whether the checkout is linked.
The primary checkout is healthy on its default branch, and linked worktrees or secondmate homes are healthy at detached HEAD.
Only a named non-default branch checked out in `FM_ROOT` is a worktree tangle.

`fm-tangle-lib.sh` resolves the default branch from `origin/HEAD`, then local `main` (legacy `master` as a secondary fallback), and classifies that named non-default primary branch as the tangle.
`fm-guard.sh` prints the repair command on the next mutable fleet action, while `bin/fm-session-start.sh` reports the same condition through bootstrap as a `TANGLE:` line at session start.
If another live session holds the fleet lock, both surfaces keep the alarm but switch to read-only wording with no repair command.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"38d426dfd981d6392f7e2b97f42ef56ce0a08171","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Ran `bin/fm-review-diff.sh t1` (FM_GATE_REFUSE_BYPASS=1, sandbox FM_HOME/FM_STATE_OVERRIDE) against a project with only fm/* branches, no origin/HEAD/main/master -&gt; new error wording, exit 1</code>
- <code>Ran `bin/fm-merge-local.sh t2` with mode=local-only meta and existing fm/t2 branch in the no-default-branch project -&gt; new error wording, exit 1</code>
- <code>Ran `bin/fm-teardown.sh t3` with local-only meta and a worktree holding unlanded commits in a no-default-branch project -&gt; new REFUSED wording, exit 1</code>
- <code>Sourced `. bin/fm-tangle-lib.sh` and exercised `fm_default_branch`: main+master-&gt;main, origin/HEAD=master with local main-&gt;master, master-only-&gt;master, neither-&gt;rc=1 (resolver unchanged)</code>
- <code>Ran `bash tests/fm-tangle-guard.test.sh` -&gt; 6/6 ok (resolver regression sanity)</code>
- <code>Grepped repo: no remaining &#39;main, or master&#39; / &#39;main or master&#39; / &#39;local main/master&#39; equal-alternative phrasing; new &#39;legacy master&#39; phrasing present in exactly the five intended spots; `grep -rln &#39;cannot determine default branch&#39; tests/` finds no test asserting the old messages</code>
- `Read docs/architecture.md section context to confirm rendered sentence: 'resolves the default branch from origin/HEAD, then local main (legacy master as a secondary fallback)'`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
