### PR TITLE
feat(board): decompose big-picture cards, place backlog work, and reconcile on the cycles that already exist

### DIFF
--- a/.agents/skills/board-orchestration/SKILL.md
+++ b/.agents/skills/board-orchestration/SKILL.md
@@ -101,6 +101,9 @@ Never move a card back to what firstmate expected, and never treat a captain's e
   Tell the captain which board owns the issue and let them decide which board should carry it; never re-home it by hand.
 - An `error` line means the board could not be read, or answered so implausibly that the adapter refused to act on it.
   Treat it as a board that is temporarily unavailable, let the next cycle reconcile, and never read it as work being withdrawn.
+- A `truncated` line means the board filled the read's card ceiling, so a card past it was never seen.
+  Everything that read did report still stands, but no withdrawal is reported from that board on this cycle, because absence cannot be told apart from the ceiling.
+  Re-run `poll` for that board with a higher `--limit`, and if it stays truncated tell the captain the board has outgrown the default read; the same ceiling applies to the card lookup `mark` needs, so a card sitting past it cannot be moved either.
 - A scope edit on a card mid-flight follows the lifecycle rule AGENTS.md section 7 already owns: route it to follow-up work unless it completely invalidates the work being validated.
   A board edit does not create a second, competing rule for that.
 

--- a/.agents/skills/board-orchestration/SKILL.md
+++ b/.agents/skills/board-orchestration/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: board-orchestration
+description: >-
+  Agent-only policy for bridging a configured project board and firstmate's existing backlog.
+  Load on a session-start or heartbeat cycle when a project board is configured, before importing a board item, before reflecting a dispatch, PR, blocker, or merge onto a board, and whenever a board edit disagrees with the backlog.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# Project board orchestration
+
+Firstmate is the orchestrator, the board is the captain's visible statement of intent, and `data/backlog.md` remains the one execution queue.
+This skill owns the policy; [`bin/fm-board.sh`](../../../bin/fm-board.sh)'s header owns every command, flag, record, and failure mode, and [`docs/configuration.md`](../../../docs/configuration.md) owns the local `config/boards` file.
+
+## The bridge is inert until a board is configured
+
+A home with no `config/boards` file, or an empty one, does none of this.
+It performs zero board reads and zero board writes, invokes no GitHub CLI for a board, and behaves exactly as it did before the bridge existed, the same way Relay stays inert until its own opt-in.
+Do not run a board command, mention a board to the captain, or offer board behavior in such a home.
+
+Deleting or emptying that file is the whole off switch and leaves no residue, because the bridge creates no poll, watcher check, cadence file, daemon, or background process to unwind.
+Say plainly what disabling does not undo: backlog items already imported stay, issues already created stay, comments already posted stay posted, and cards already moved stay where they were moved.
+Never offer to reverse those as part of turning the bridge off; that is separate work and needs the captain's word.
+
+The bridge is also strictly per project.
+Only a project with its own stanza in `config/boards` is ever mapped to a board, so work on any other project never reaches any board, and a home holding several boards resolves an event against that project's stanza alone.
+Never place, comment on, or move work for a project the captain did not configure a board for.
+
+## Scope
+
+The bridge may read the board's issues and cards, import new actionable items into the existing backlog, move a card to In Progress when a worker is dispatched, attach the working PR to the originating issue, record blockers on that issue, move the card to Done after a confirmed merge, and reconcile the backlog to cancellations and scope changes the captain makes on the board.
+
+It may not become a second execution system.
+Do not build or ask for webhook infrastructure, another daemon, another database, a second queue, continuous real-time synchronization, a separate board service, or a new orchestration layer.
+Reading on the cycles firstmate already has is the whole mechanism, and it is what the captain chose knowing the latency cost.
+
+## When the read happens
+
+Run `bin/fm-board.sh poll` on cycles firstmate already runs: once after the session-start digest, and on heartbeat wakes as part of the fleet review that AGENTS.md section 8 already requires.
+Add no wake source, no watcher check, and no timer for it.
+Never poll from a lock-refused read-only session, because that session is not authorized to mutate anything.
+
+Be honest about the resulting latency when the captain asks.
+An idle fleet produces no heartbeats, so an item filed while everything is idle is picked up at the next session start rather than within minutes.
+
+## Intake
+
+`poll` prints a `new` line only for a card that is a real issue, sits in the configured Todo column, and carries the configured trigger.
+The label is the authoritative trigger; the optional mention and assignee triggers are additional and off unless the captain configured them.
+Everything else on the board is deliberately invisible to intake, including draft cards, pull requests, and untagged issues.
+
+Import each `new` line exactly once, in this order:
+
+1. Confirm no backlog item already names that issue URL.
+2. Create the ordinary backlog item, recording the issue URL in its note, and resolve delivery mode and yolo at intake exactly as AGENTS.md section 7 requires.
+3. Immediately run `bin/fm-board.sh import <project> <issue-url> <task-id>` so the linkage is durable before the turn ends.
+
+Step 3 is what makes import idempotent, so it is never deferred to a later turn.
+The record lives with the durable fleet records rather than the task's runtime state, so it outlives cleanup: an issue whose task shipped and was torn down months ago is still linked and can never be imported a second time.
+Step 1 exists only for the narrow window where a turn died between steps 2 and 3.
+Re-running `import` for an already-linked issue is a successful no-op, and an attempt to point a linked issue at a different task is refused rather than silently rebound; investigate a refusal instead of working around it.
+
+## Status mapping
+
+Todo means queued or awaiting dispatch, In Progress means a worker actively owns it, and Done means merged and verified.
+There is no fourth state.
+A blocked item stays visible in the column it is already in, with the blocker recorded on its issue through `bin/fm-board.sh note <task-id> "Blocked: ..."`.
+A column the captain added that firstmate does not drive is recorded as the board's own and reported with its real name; leave the card there rather than forcing it into one of the three.
+
+## The events that move a card
+
+Only firstmate's own execution events move a card, and each one is a single command run at the moment the event actually happens:
+
+- A worker is dispatched onto the task: `bin/fm-board.sh mark <task-id> in-progress`.
+- The worker reports its PR: `bin/fm-board.sh pr <task-id> <pr-url>`, which attaches the PR to the originating issue.
+- Work is blocked: `bin/fm-board.sh note <task-id> "Blocked: <what is needed>"`, alongside the ordinary captain escalation when the blocker needs the captain.
+- A merge is confirmed: `bin/fm-board.sh mark <task-id> done`.
+
+Every one of these degrades to a stale board instead of blocking delivery, and each reports plainly whether the board took the change.
+A board that did not take a change is never a reason to delay a dispatch, a PR report, a merge, or cleanup, and it is not a captain escalation on its own.
+`poll` retries an outstanding card move on the next cycle; a blocker note is deliberately not retried, so re-run it if it matters and the captain escalation still stands either way.
+
+## The board owns intent
+
+This is the single most important rule here.
+An `instruction` line means the captain edited, reprioritized, or moved a card, and that is an instruction to reconcile the backlog to the board.
+The backlog is execution bookkeeping and never outranks the captain's visible intent.
+Never move a card back to what firstmate expected, and never treat a captain's edit as drift to correct; a sync that corrects a captain's board edit is a defect, not a safeguard.
+
+- A card moved backwards out of In Progress, or a `cancelled` line reporting a card that left the board entirely, means stop the worker.
+  Stop it through `bin/fm-control.sh <task-id> interrupt` and then `exit`, exactly as any other stop, then update the backlog and run `bin/fm-board.sh ack <task-id>` so the withdrawal is not reported again.
+  This never authorizes discarding unlanded work: hard rule 3 stands unchanged, so preserve the branch, report what is on it, and get an explicit captain instruction before anything is discarded.
+- A card the captain moved to Done while work is unfinished is the captain closing the item.
+  Stop the worker the same way, preserve the branch, and tell the captain plainly what had not landed.
+- An `error` line means the board could not be read, or answered so implausibly that the adapter refused to act on it.
+  Treat it as a board that is temporarily unavailable, let the next cycle reconcile, and never read it as work being withdrawn.
+- A scope edit on a card mid-flight follows the lifecycle rule AGENTS.md section 7 already owns: route it to follow-up work unless it completely invalidates the work being validated.
+  A board edit does not create a second, competing rule for that.
+
+## Reporting to the captain
+
+The board, the card, and the issue are the captain's own nouns and need no translation; everything else still follows AGENTS.md section 9.
+Report what the board now shows and what it changed about the work, not that a poll ran or that a record was updated.
+An unchanged board is not progress and is not worth a message.
+
+## Ownership
+
+The home whose linkage record holds an issue is the home that updates that issue and its card.
+Board configuration is local to that home and is not inherited by secondmates, so never ask a secondmate or a crewmate to update a board on firstmate's behalf.

--- a/.agents/skills/board-orchestration/SKILL.md
+++ b/.agents/skills/board-orchestration/SKILL.md
@@ -2,7 +2,7 @@
 name: board-orchestration
 description: >-
   Agent-only policy for bridging a configured project board and firstmate's existing backlog.
-  Load on a session-start or heartbeat cycle when a project board is configured, before importing a board item, before reflecting a dispatch, PR, blocker, or merge onto a board, and whenever a board edit disagrees with the backlog.
+  Load on a session-start or heartbeat cycle when a project board is configured, before importing or decomposing a board item, before placing existing work on a board, before reflecting a dispatch, PR, blocker, or merge onto a board, and whenever a card's status disagrees with firstmate's own records.
 user-invocable: false
 metadata:
   internal: true
@@ -10,7 +10,8 @@ metadata:
 
 # Project board orchestration
 
-Firstmate is the orchestrator, the board is the captain's visible statement of intent, and `data/backlog.md` remains the one execution queue.
+Firstmate is the orchestrator, `data/backlog.md` remains the one execution queue and the source of truth, and the board is how that queue is shown to the captain.
+Chat, not the board, is where the captain steers the work.
 This skill owns the policy; [`bin/fm-board.sh`](../../../bin/fm-board.sh)'s header owns every command, flag, record, and failure mode, and [`docs/configuration.md`](../../../docs/configuration.md) owns the local `config/boards` file.
 
 ## The bridge is inert until a board is configured
@@ -29,7 +30,7 @@ Never place, comment on, or move work for a project the captain did not configur
 
 ## Scope
 
-The bridge may read the board's issues and cards, import new actionable items into the existing backlog, move a card to In Progress when a worker is dispatched, attach the working PR to the originating issue, record blockers on that issue, move the card to Done after a confirmed merge, and reconcile the backlog to cancellations and scope changes the captain makes on the board.
+The bridge may read the board's issues and cards, import new actionable items into the existing backlog, break a big-picture container into linked child cards, place work firstmate already holds onto the board, move a card as firstmate's own execution events happen, attach the working PR to the originating issue, record blockers on that issue, and report a card whose status firstmate did not write.
 
 It may not become a second execution system.
 Do not build or ask for webhook infrastructure, another daemon, another database, a second queue, continuous real-time synchronization, a separate board service, or a new orchestration layer.
@@ -37,12 +38,20 @@ Reading on the cycles firstmate already has is the whole mechanism, and it is wh
 
 ## When the read happens
 
-Run `bin/fm-board.sh poll` on cycles firstmate already runs: once after the session-start digest, and on heartbeat wakes as part of the fleet review that AGENTS.md section 8 already requires.
-Add no wake source, no watcher check, and no timer for it.
-Never poll from a lock-refused read-only session, because that session is not authorized to mutate anything.
+The poll runs on cycles firstmate already has, and it runs on its own rather than because this skill was remembered.
 
-Be honest about the resulting latency when the captain asks.
+- **Session start** reconciles the board as part of the digest's own network checks and prints each actionable line as `BOARD_POLL: <line>`.
+  Act on those lines; do not run `poll` again for that board in the same turn, because the read has already happened and repeating it spends the board's request budget twice.
+  A board already reconciled prints nothing at all, and a home with no board configured never reads one.
+- **Heartbeat wakes** are where firstmate runs `bin/fm-board.sh poll` itself, as part of the fleet review AGENTS.md section 8 already requires.
+
+Add no wake source, no watcher check, no timer, no daemon, and no background process for it.
+Never poll from a lock-refused read-only session, because that session is not authorized to mutate anything; the session start's own board reconciliation is skipped there for the same reason.
+
+Be honest about the resulting freshness when the captain asks.
+The board is as current as the last cycle, never live.
 An idle fleet produces no heartbeats, so an item filed while everything is idle is picked up at the next session start rather than within minutes.
+A poll that could not read the board reports an `error` line and reconciles nothing; never present that to the captain as the board being in sync.
 
 ## Intake
 
@@ -61,50 +70,109 @@ The record lives with the durable fleet records rather than the task's runtime s
 Step 1 exists only for the narrow window where a turn died between steps 2 and 3.
 Re-running `import` for an already-linked issue is a successful no-op, and an attempt to point a linked issue at a different task is refused rather than silently rebound; investigate a refusal instead of working around it.
 
+### Board-sourced work is captain-gated
+
+Work that arrives from a board is not authorized to run merely because it arrived.
+Create the backlog item **held**, with `tasks-axi hold <id> --reason "imported from the <project> board, awaiting the captain's go" --kind captain`, report the new item to the captain, and dispatch it only on their explicit word.
+Use that existing hold mechanism; do not invent a second gating concept.
+
+The reason is worth keeping in mind so this is not later simplified away: the backlog is firstmate's own record, but a board is an outside surface, so anything with write access to that board could otherwise place work straight into an autonomous execution queue.
+This gate is not weakened by `yolo`, which is authority over routine gates inside work already authorized, while this is about whether the work is authorized at all.
+
+Be precise about what the gate covers.
+It gates **dispatch** of board-sourced work.
+It does not gate board reads, card creation, card movement, or any of the reflection commands, and it applies to every route by which board content becomes work, including the children of a decomposition: creating child cards unattended is exactly what the captain asked for, running them is not.
+This skill says nothing about work that did not come from a board; that is each home's own business and is recorded in its own captain preferences.
+
 ## Status mapping
 
-Todo means queued or awaiting dispatch, In Progress means a worker actively owns it, and Done means merged and verified.
-There is no fourth state.
+Todo means filed and not cleared to run, In Progress means a worker actively owns it, and Done means merged and verified.
+A configured optional `queued` column sits between the first two and means firstmate has been cleared to launch that work; a home that did not configure it has no such column and nothing changes.
 A blocked item stays visible in the column it is already in, with the blocker recorded on its issue through `bin/fm-board.sh note <task-id> "Blocked: ..."`.
-A column the captain added that firstmate does not drive is recorded as the board's own and reported with its real name; leave the card there rather than forcing it into one of the three.
+A column outside these is reported by its real name and never driven; leave the card there rather than forcing it into one of the others.
+
+## Breaking down a big-picture item
+
+A `decompose <project> <parent-issue-url>` line is a container the captain filed: an issue whose children are the real work, and which no worker can ship as it stands.
+Deciding what it breaks down into is judgement, which is why the script never invents children and this skill owns the procedure.
+Nothing here happens in a home whose board configures no big-picture columns, because no card is ever classified as a container there.
+
+1. Read the container issue in full, and any linked context it names.
+2. Break it into concrete work items that can each be independently implemented and validated - not a restatement of the container in three parts. If it genuinely cannot be broken down, or the split needs a product decision, say so to the captain rather than inventing pieces.
+3. Resolve delivery mode and yolo for each piece exactly as AGENTS.md section 7 requires, at intake, on that project's standing posture.
+4. For each piece, run `bin/fm-board.sh child-add <project> <parent-issue-url> <title> <body> <task-id>`. One command per piece creates the issue as a native GitHub sub-issue of the container, cards it in Todo, and records its link. A `child-partial` line names the step that did not land: re-run the same command, which converges on the issue it already filed rather than creating a second one.
+5. Create each backlog item, **held**, exactly as the captain gate above requires. Creating the child cards is unattended; running them is not.
+6. Run `bin/fm-board.sh decomposed <project> <parent-issue-url>`. Until that lands the container keeps being offered, which is what finishes an interrupted breakdown; once it lands the container is never offered again.
+7. Post the breakdown as a comment on the parent issue, so the captain has the reasoning where the work lives, then report it to them.
+
+Use GitHub's own sub-issue relationship and nothing else: the board already surfaces `Parent issue` and `Sub-issues progress`, so invent no parallel taxonomy, label scheme, or naming convention to express it.
+
+The container's own card then follows its children with no further action - any child in progress moves it to the big-picture In Progress column, all children done moves it to big-picture Done - and it is silent while it already shows what firstmate recorded.
+
+## Putting work firstmate already holds on the board
+
+`bin/fm-board.sh place <project> <task-id> <title> [<body>]` is the inverse of `import`: it files the issue, cards it in Todo, and records the link, after which every event below works on it with no special casing.
+Use it for a task that started in the backlog and belongs on that roadmap.
+
+Whether a task belongs on a board is an editorial call the script never makes, and project alone does not settle it.
+Firstmate's own work belongs on a captain's product roadmap when it serves that product's delivery and stays off it when it does not.
+When the change lands somewhere other than the repository the card's issue is filed in, pass `--lands-in <owner/name>` so the roadmap never implies a diff is somewhere it is not.
+
+There is deliberately no bulk placement, and never build one: existing work goes onto a board one item at a time, chosen deliberately.
 
 ## The events that move a card
 
-`mark`, `pr`, `note`, and `ack` apply only to a task imported from a board, which is the only kind of task that holds a link record.
-An ordinary locally-created task has no board link, so it is never passed to any of them; they refuse it outright rather than degrading, and that refusal is a sign the wrong task id was used.
+`mark`, `pr`, `note`, and `ack` apply only to a task that holds a link record - one imported from a board or placed on one.
+A task with no board link is never passed to any of them; they refuse it outright rather than degrading, and that refusal is a sign the wrong task id was used.
 
-Only firstmate's own execution events move a card, and each one is a single command run at the moment the event actually happens:
+Firstmate's own execution events are what move a card, and the ones that matter most happen on their own:
 
-- A worker is dispatched onto a board-imported task: `bin/fm-board.sh mark <task-id> in-progress`.
-- The worker reports its PR: `bin/fm-board.sh pr <task-id> <pr-url>`, which attaches the PR to the originating issue.
-- Work is blocked: `bin/fm-board.sh note <task-id> "Blocked: <what is needed>"`, alongside the ordinary captain escalation when the blocker needs the captain.
-- A merge is confirmed: `bin/fm-board.sh mark <task-id> done`.
+- **Dispatch and merge need no command.** `bin/fm-spawn.sh` places the card if the project has a board and the task has none, then marks it in progress; `bin/fm-pr-check.sh` attaches the PR to its originating issue; `bin/fm-pr-merge.sh` closes the card after a merge that actually landed. A task with no board, and every task in a home with no board configured, is untouched by all three.
+- **Cleared to launch:** `bin/fm-board.sh mark <task-id> queued` when the captain's go releases a held item and the board configures that column.
+- **Blocked:** `bin/fm-board.sh note <task-id> "Blocked: <what is needed>"`, alongside the ordinary captain escalation when the blocker needs the captain.
+- Run `mark` by hand only to correct a card, for instance after a divergence or when work leaves the cleared set.
 
-For a board-imported task, every one of these degrades to a stale board instead of blocking delivery, and each reports plainly whether the board took the change.
+Prefer a better card to a better command: when a task deserves a human title on the roadmap, `place` it yourself before dispatching, and the dispatch will then only move the card it finds.
+
+Every one of these degrades to a stale board instead of blocking delivery, and each reports plainly whether the board took the change.
 A board that did not take a change is never a reason to delay a dispatch, a PR report, a merge, or cleanup, and it is not a captain escalation on its own.
 `poll` retries an outstanding card move and an outstanding PR attachment on the next cycle, reporting each as `synced` or `stale`; a blocker note is deliberately not retried, so re-run it if it matters and the captain escalation still stands either way.
 
-## The board owns intent
+## Filing is intent; status is firstmate's report
 
-This is the single most important rule here.
-An `instruction` line means the captain edited, reprioritized, or moved a card, and that is an instruction to reconcile the backlog to the board.
-The backlog is execution bookkeeping and never outranks the captain's visible intent.
-Never move a card back to what firstmate expected, and never treat a captain's edit as drift to correct; a sync that corrects a captain's board edit is a defect, not a safeguard.
+This is the single most important rule here, and it has two halves that must not be collapsed into one.
 
-- A card moved backwards out of In Progress, or a `cancelled` line reporting a card that left the board entirely, means stop the worker.
-  Stop it through `bin/fm-control.sh <task-id> interrupt` and then `exit`, exactly as any other stop, then update the backlog and run `bin/fm-board.sh ack <task-id>` so the withdrawal is not reported again.
-  This never authorizes discarding unlanded work: hard rule 3 stands unchanged, so preserve the branch, report what is on it, and get an explicit captain instruction before anything is discarded.
-- A card the captain moved to Done while work is unfinished is the captain closing the item.
-  Stop the worker the same way, preserve the branch, and tell the captain plainly what had not landed.
+**Filing work on the board is the captain's intent.**
+A new labelled card is them adding work, and intake above is unchanged - including that it stays captain-gated before anything runs.
+
+**The status columns are firstmate's own report of its records.**
+Firstmate writes them outward from the backlog; a card's column never tells firstmate what to do.
+So a `divergence` line - a card showing a status firstmate did not write - means change nothing, dispatch nothing, stop nothing, and tell the captain in chat.
+The adapter has already declined to reconcile it in either direction, and firstmate must not do by hand what the adapter deliberately refused.
+Raise a given divergence once and do not repeat it every cycle while it stands unresolved; when the captain decides, `bin/fm-board.sh mark <task-id> <state>` is how the card is put right.
+
+Treat an unexplained appearance in a configured `queued` column as security-relevant, because under this model it can only mean something outside firstmate wrote to that board.
+It never launches a crew.
+
+Two consequences follow, and both are reports rather than actions:
+
+- A card moved backwards out of In Progress, or moved to Done while work is unfinished, is something to tell the captain plainly - what firstmate has running, and what has not landed - not a reason to stop a worker on its own. Stop work only on the captain's word, then through `bin/fm-control.sh <task-id> interrupt` and `exit` exactly as any other stop.
+- A `cancelled` line, a card that left the board entirely while firstmate was still executing it, is reported the same way; once the captain decides, update the backlog and run `bin/fm-board.sh ack <task-id>` so it is not reported again.
+
+Neither ever authorizes discarding unlanded work: hard rule 3 stands unchanged, so preserve the branch, report what is on it, and get an explicit captain instruction before anything is discarded.
+
+This is a real security property of the design and the captain accepted it knowingly: write access to a configured board is enough to file work into intake, and never enough to start it.
+
 - A `foreign` line means a card on the board being polled carries an issue that another configured board already owns.
   That is a configuration mistake, not an instruction, so the adapter names the owning project and touches neither the card nor the link.
   Tell the captain which board owns the issue and let them decide which board should carry it; never re-home it by hand.
 - An `error` line means the board could not be read, or answered so implausibly that the adapter refused to act on it.
   Treat it as a board that is temporarily unavailable, let the next cycle reconcile, and never read it as work being withdrawn.
+  A cycle that reported an error reconciled nothing, so never tell the captain the board is in sync on the strength of it.
 - A `truncated` line means the board filled the read's card ceiling, so a card past it was never seen.
   Everything that read did report still stands, but no withdrawal is reported from that board on this cycle, because absence cannot be told apart from the ceiling.
   Re-run `poll` for that board with a higher `--limit`, and if it stays truncated tell the captain the board has outgrown the default read; the same ceiling applies to the card lookup `mark` needs, so a card sitting past it cannot be moved either.
-- A scope edit on a card mid-flight follows the lifecycle rule AGENTS.md section 7 already owns: route it to follow-up work unless it completely invalidates the work being validated.
+- A scope edit to a card's own text mid-flight follows the lifecycle rule AGENTS.md section 7 already owns: route it to follow-up work unless it completely invalidates the work being validated.
   A board edit does not create a second, competing rule for that.
 
 ## Reporting to the captain

--- a/.agents/skills/board-orchestration/SKILL.md
+++ b/.agents/skills/board-orchestration/SKILL.md
@@ -70,16 +70,19 @@ A column the captain added that firstmate does not drive is recorded as the boar
 
 ## The events that move a card
 
+`mark`, `pr`, `note`, and `ack` apply only to a task imported from a board, which is the only kind of task that holds a link record.
+An ordinary locally-created task has no board link, so it is never passed to any of them; they refuse it outright rather than degrading, and that refusal is a sign the wrong task id was used.
+
 Only firstmate's own execution events move a card, and each one is a single command run at the moment the event actually happens:
 
-- A worker is dispatched onto the task: `bin/fm-board.sh mark <task-id> in-progress`.
+- A worker is dispatched onto a board-imported task: `bin/fm-board.sh mark <task-id> in-progress`.
 - The worker reports its PR: `bin/fm-board.sh pr <task-id> <pr-url>`, which attaches the PR to the originating issue.
 - Work is blocked: `bin/fm-board.sh note <task-id> "Blocked: <what is needed>"`, alongside the ordinary captain escalation when the blocker needs the captain.
 - A merge is confirmed: `bin/fm-board.sh mark <task-id> done`.
 
-Every one of these degrades to a stale board instead of blocking delivery, and each reports plainly whether the board took the change.
+For a board-imported task, every one of these degrades to a stale board instead of blocking delivery, and each reports plainly whether the board took the change.
 A board that did not take a change is never a reason to delay a dispatch, a PR report, a merge, or cleanup, and it is not a captain escalation on its own.
-`poll` retries an outstanding card move on the next cycle; a blocker note is deliberately not retried, so re-run it if it matters and the captain escalation still stands either way.
+`poll` retries an outstanding card move and an outstanding PR attachment on the next cycle, reporting each as `synced` or `stale`; a blocker note is deliberately not retried, so re-run it if it matters and the captain escalation still stands either way.
 
 ## The board owns intent
 
@@ -93,6 +96,9 @@ Never move a card back to what firstmate expected, and never treat a captain's e
   This never authorizes discarding unlanded work: hard rule 3 stands unchanged, so preserve the branch, report what is on it, and get an explicit captain instruction before anything is discarded.
 - A card the captain moved to Done while work is unfinished is the captain closing the item.
   Stop the worker the same way, preserve the branch, and tell the captain plainly what had not landed.
+- A `foreign` line means a card on the board being polled carries an issue that another configured board already owns.
+  That is a configuration mistake, not an instruction, so the adapter names the owning project and touches neither the card nor the link.
+  Tell the captain which board owns the issue and let them decide which board should carry it; never re-home it by hand.
 - An `error` line means the board could not be read, or answered so implausibly that the adapter refused to act on it.
   Treat it as a board that is temporarily unavailable, let the next cycle reconcile, and never read it as work being withdrawn.
 - A scope edit on a card mid-flight follows the lifecycle rule AGENTS.md section 7 already owns: route it to follow-up work unless it completely invalidates the work being validated.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,7 @@ config/startup-memory-budget     primary-authoritative per-home startup-memory b
 config/herdr-presentation-spaces  optional "off" opt-out from, or "on" opt-in to, Herdr's default-on disposable single-task visual projection, which is unconfigured-default-on only at or above a Herdr version floor; LOCAL, gitignored; inherited by secondmate homes; see docs/herdr-backend.md "Presentation spaces"
 config/trace-context  optional presence flag enabling default-off native W3C trace-context propagation to spawned agents; LOCAL, gitignored; inherited by secondmate homes; see docs/configuration.md "Trace context propagation" and docs/trace-context.md
 config/cmux-socket-password  optional cmux control-socket password; LOCAL, gitignored; read fresh on every cmux CLI call and passed through without ever overriding an operator's own ambient CMUX_SOCKET_PASSWORD when absent (docs/cmux-backend.md "Setup")
+config/boards   optional project board coordinates, one stanza per project; LOCAL, gitignored, and not inherited; absent or empty is the off switch and keeps the bridge inert with zero board reads or writes, and only a project with a stanza here is ever mapped to a board; see board-orchestration and docs/configuration.md "Project boards"
 config/wedge-alarm  optional away-mode wedge-alarm active-alert directives; LOCAL, gitignored; absent means auto (macOS Notification Center when available); see docs/wedge-alarm.md
 config/x-mode.env    generated Relay watcher cadence; LOCAL, gitignored; source before arming watcher when present
 data/                personal fleet records; LOCAL, gitignored as a whole
@@ -82,6 +83,7 @@ data/                personal fleet records; LOCAL, gitignored as a whole
   captain-shared.md  main-authoritative shared captain preferences propagated read-only to secondmate homes; LOCAL, gitignored, owned by secondmate-provisioning
   learnings.md       fleet-local operational facts and gotchas; LOCAL, gitignored; dated, evidence-backed, curated, and updated with inspect-then-update - rewrite and prune rather than append forever, the same contract as captain.md; created lazily, absent until this home has a learning to store
   projects.md        thin fleet navigation registry recording each project's standing delivery posture; firstmate-private, parsed for mechanical sync and seeding by fm-project-mode.sh (section 6)
+  board-links.tsv    durable issue-to-task links that keep a board import idempotent; firstmate-private, written only by bin/fm-board.sh, and kept after teardown so an imported issue is never imported twice; see board-orchestration
   secondmates.md      local and remote secondmate routing table; firstmate-private, maintained by the secondmate seed helpers (section 6)
   <id>/brief.md      per-task crewmate brief, or per-secondmate charter brief when kind=secondmate
   <id>/report.md     scout task deliverable, written by the crewmate; survives teardown
@@ -399,7 +401,7 @@ Handle actionable wakes as follows:
 1. For `signal:`, read the listed event lines first, then reconcile current state only where action depends on it.
 2. For `stale:`, inspect the recorded endpoint and load `stuck-crewmate-recovery` for a stopped, looping, confused, or unresponsive worker; a deep-inspection reason also requires current-state and validation-log inspection.
 3. For `check:`, act on the named poll result, including merges, Relay events, and process-to-event source results.
-4. For `heartbeat:`, review the whole fleet from the structured fleet view, reconcile suspicious tasks and PR state, update the backlog, and never report an unchanged fleet as progress.
+4. For `heartbeat:`, review the whole fleet from the structured fleet view, reconcile suspicious tasks and PR state, update the backlog, reconcile any configured project board through `board-orchestration`, and never report an unchanged fleet as progress.
 
 When any wake reports a merged PR for a project cloned in this home, refresh that clone through the guarded fleet-sync path.
 When Relay-linked work reaches a milestone or terminal state, load `fmx-respond`; before terminal teardown, use its promised-final reconciliation when a typed public commitment exists, otherwise post the final completion follow-up so the link clears even if earlier follow-ups were spent.
@@ -529,6 +531,8 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `firstmate-orca` - load before switching to Orca, spawning or supervising Orca-backed work, smoke-testing Orca backend behavior, debugging Orca task state, or reconciling Orca-backed task metadata.
 - `project-management` - load before adding, creating, removing, or initializing a project.
   Cloning or registering a project is add intake and uses the same trigger.
+- `board-orchestration` - load on a session-start or heartbeat cycle when `config/boards` configures a project board, before importing a board item into the backlog, before reflecting a dispatch, PR, blocker, or merge onto a board, and whenever a board edit disagrees with the backlog.
+  The board is the captain's intent and outranks the backlog; reconciling to it never authorizes discarding unlanded work.
 - `stuck-crewmate-recovery` - load when the session-start digest reports an ordinary direct report's endpoint dead or its metadata has no window, or after a stale wake, looping pane, repeated confusion, an answered-by-brief question, an unresponsive crewmate, or a failed steer.
 - `secondmate-provisioning` - load before creating, seeding, validating, launching, handing backlog to, recovering, pushing inherited local material into, or retiring a secondmate home, and before editing `data/secondmates.md`.
 - `decision-hold-lifecycle` - load before treating an investigation or visual review as complete, before ending a visual review that exposed a decision, and when recording or routing the captain's answer.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,7 @@ data/                personal fleet records; LOCAL, gitignored as a whole
   learnings.md       fleet-local operational facts and gotchas; LOCAL, gitignored; dated, evidence-backed, curated, and updated with inspect-then-update - rewrite and prune rather than append forever, the same contract as captain.md; created lazily, absent until this home has a learning to store
   projects.md        thin fleet navigation registry recording each project's standing delivery posture; firstmate-private, parsed for mechanical sync and seeding by fm-project-mode.sh (section 6)
   board-links.tsv    durable issue-to-task links that keep a board import idempotent; firstmate-private, written only by bin/fm-board.sh, and kept after teardown so an imported issue is never imported twice; see board-orchestration
+  board-decompositions.tsv  durable big-picture container records and their child links; firstmate-private, written only by bin/fm-board.sh, and kept after teardown so a container is never broken down twice; see board-orchestration
   secondmates.md      local and remote secondmate routing table; firstmate-private, maintained by the secondmate seed helpers (section 6)
   <id>/brief.md      per-task crewmate brief, or per-secondmate charter brief when kind=secondmate
   <id>/report.md     scout task deliverable, written by the crewmate; survives teardown
@@ -152,7 +153,7 @@ If the session lock cannot be acquired and verified, report its exact diagnostic
 A lock-refused session must not spawn, steer, merge, drain the wake queue, repair supervision, repair a checkout, or perform any other fleet mutation.
 
 The digest itself makes no external-network call and never waits for one.
-Every network check a session start owes - GitHub auth, dead-secondmate relaunch, secondmate convergence, pending handoff delivery, and project clone refresh - runs concurrently in a bounded worker owned by `bin/fm-startup-network.sh` and is reported in the digest's own `NETWORK CHECKS` section.
+Every network check a session start owes - GitHub auth, dead-secondmate relaunch, secondmate convergence, pending handoff delivery, project clone refresh, and configured project board reconciliation - runs concurrently in a bounded worker owned by `bin/fm-startup-network.sh` and is reported in the digest's own `NETWORK CHECKS` section.
 When that section reports its checks still in progress it names exactly what is unconfirmed; treat none of those as passed until the result lands, either from `bin/fm-startup-network.sh report` or as a `check: startup-network` wake.
 
 1. **Lock** - acquires the per-home session lock first, before anything mutates shared state, then starts the deferred network stage above.
@@ -531,8 +532,8 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `firstmate-orca` - load before switching to Orca, spawning or supervising Orca-backed work, smoke-testing Orca backend behavior, debugging Orca task state, or reconciling Orca-backed task metadata.
 - `project-management` - load before adding, creating, removing, or initializing a project.
   Cloning or registering a project is add intake and uses the same trigger.
-- `board-orchestration` - load on a session-start or heartbeat cycle when `config/boards` configures a project board, before importing a board item into the backlog, before reflecting a dispatch, PR, blocker, or merge onto a board, and whenever a board edit disagrees with the backlog.
-  The board is the captain's intent and outranks the backlog; reconciling to it never authorizes discarding unlanded work.
+- `board-orchestration` - load on a session-start or heartbeat cycle when `config/boards` configures a project board, before importing, decomposing, or placing a board item into or onto the backlog, before reflecting a dispatch, PR, blocker, or merge onto a board, and whenever a card's status disagrees with firstmate's own records.
+  Filing a card is the captain's intent, while the status columns are firstmate's report of its own records; reconciling either never authorizes discarding unlanded work.
 - `stuck-crewmate-recovery` - load when the session-start digest reports an ordinary direct report's endpoint dead or its metadata has no window, or after a stale wake, looping pane, repeated confusion, an answered-by-brief question, an unresponsive crewmate, or a failed steer.
 - `secondmate-provisioning` - load before creating, seeding, validating, launching, handing backlog to, recovering, pushing inherited local material into, or retiring a secondmate home, and before editing `data/secondmates.md`.
 - `decision-hold-lifecycle` - load before treating an investigation or visual review as complete, before ending a visual review that exposed a decision, and when recording or routing the captain's answer.

--- a/bin/fm-board.sh
+++ b/bin/fm-board.sh
@@ -1,0 +1,957 @@
+#!/usr/bin/env bash
+# fm-board.sh - the one thin adapter between a configured project board and
+# firstmate's existing backlog.
+#
+# The semantic policy is owned once by
+# .agents/skills/board-orchestration/SKILL.md. This script is deterministic
+# mechanics only: it reads a board, owns the durable issue-to-task linkage that
+# makes import idempotent, and reflects firstmate's own execution events back
+# onto the board. It never creates work, never decides what to import, and never
+# pushes firstmate's recorded state over a status the captain changed on the
+# board. The board owns intent; this script reconciles toward it.
+#
+# Usage:
+#   fm-board.sh boards [<project>]
+#   fm-board.sh poll [<project>] [--limit <n>]
+#   fm-board.sh import <project> <issue-url> <task-id>
+#   fm-board.sh links [<project>]
+#   fm-board.sh lookup <issue-url|task-id>
+#   fm-board.sh mark <task-id> todo|in-progress|done
+#   fm-board.sh pr <task-id> <pr-url>
+#   fm-board.sh note <task-id> <text>
+#   fm-board.sh ack <task-id>
+#   fm-board.sh -h | --help
+#
+# CONFIGURATION - config/boards, local and gitignored (docs/configuration.md
+# owns the operator-facing description). Plain text, one stanza per board, each
+# opened by its `project` key:
+#
+#   project = harbourlight
+#   owner = harbour-collective
+#   number = 7
+#   repo = harbour-collective/app  # optional; default: every repo on the board
+#   label = firstmate            # default: firstmate
+#   mention = @firstmate         # optional; default: mention trigger off
+#   assignee = some-login        # optional; default: assignee trigger off
+#   status-field = Status        # default: Status
+#   todo = Todo                  # default: Todo
+#   in-progress = In Progress    # default: In Progress
+#   done = Done                  # default: Done
+#
+# INERT UNTIL CONFIGURED. This is a contract, not a side effect. With no
+# `config/boards` file, or an empty one, this adapter performs zero board reads
+# and zero board writes, invokes no GitHub CLI at all, creates no state, and
+# behaves exactly as the home did before it existed - the same shape as Relay's
+# opt-in. Every board identity comes from that one local file, so nothing here
+# is org-specific or repo-specific.
+#
+# OFF SWITCH. Deleting or emptying `config/boards` fully disables the bridge and
+# leaves no residue: there is no generated poll, watcher check, cadence file,
+# daemon, or background process to unwind, because none was ever created. The
+# only file this adapter ever writes is data/board-links.tsv, and an unconfigured
+# home never reads it into any behavior.
+#
+# WHAT DISABLING DOES NOT UNDO, by design. Work already done stays done: issues
+# and backlog items already imported remain, comments already posted on an issue
+# remain posted, and cards already moved stay where they were moved. Disabling
+# stops future board reads and writes; it is not an undo.
+#
+# STRICTLY PER PROJECT. Only a project with its own stanza in `config/boards` is
+# ever mapped to a board. Work on any other project has no board coordinates to
+# resolve, so `import` refuses to name it and no card, issue, or comment for it
+# is ever touched. A home with several boards keeps them separate: an event on
+# one project resolves only that project's stanza.
+#
+# INTAKE. `poll` reports an item as importable only when it is a real issue (not
+# a draft card and not a pull request), sits in the configured Todo column, and
+# carries the configured trigger. The label is the authoritative trigger; the
+# optional mention and assignee triggers are additional and off unless set.
+#
+# IDEMPOTENCY. data/board-links.tsv is the durable linkage record and the single
+# thing consulted before an import. It lives in data/, not state/, so it
+# survives task cleanup: an issue whose task was long since torn down is still
+# linked and is never imported a second time. The issue URL is the identity, so
+# one issue can hold at most one task, and `import` for an issue that already
+# links to the same task is a successful no-op. A conflicting relink is refused
+# rather than overwritten.
+#
+# Record columns, tab separated:
+#   project  issue  task  desired  synced  pr  pr_synced
+# `desired` is the column state firstmate's execution events call for and
+# `synced` is the last state this adapter confirmed on the board, both drawn
+# from todo|in-progress|done|other. They differ exactly while a board write is
+# outstanding, which is what makes a failed write retryable on the next cycle.
+# `other` is a column the captain added that firstmate does not drive; it is
+# recorded so their intent is preserved, not so a fourth execution state exists.
+# No column is ever empty: `-` is the placeholder, because bash collapses empty
+# tab-separated fields when it reads them back.
+#
+# FAIL SOFT. Every board write degrades to a stale board instead of blocking
+# delivery: `mark`, `pr`, and `note` exit 0 whether or not the write landed,
+# reporting the failure on stderr and leaving `mark` and `pr` retryable. `poll`
+# retries outstanding writes and also exits 0 on a board read failure, reporting
+# it as an `error` line. A read that cannot tell absence from its own limits -
+# a full page, or a board answering with no cards at all while links are open -
+# says so and reconciles nothing rather than guessing. Only a usage or
+# configuration error exits non-zero, and a refused conflicting relink exits 3.
+#
+# WHO WINS. When the board disagrees with a record, the board is a captain
+# instruction: `poll` adopts the board's state into the record and reports an
+# `instruction` line for firstmate to reconcile the backlog to. It never writes
+# firstmate's state back over the captain's edit. The one exception is an
+# outstanding write the board has not taken yet, which is retried because the
+# board still shows the value this adapter last confirmed.
+#
+# A card that left the board is the captain withdrawing work firstmate is still
+# executing, so `poll` keeps reporting it as `cancelled` until `ack` records that
+# the withdrawal was reconciled. Repeating survives a missed cycle; a card that
+# left after reaching Done is ordinary archiving and is never reported. Neither
+# reporting nor acknowledging a withdrawal ever authorizes discarding unlanded
+# work: hard rule 3 stands, and this adapter touches no branch, worktree, or
+# repository.
+#
+# GITHUB CLI. This adapter calls `gh` rather than `gh-axi`, and adds no new
+# dependency because `gh` is already part of firstmate's universal toolchain
+# (docs/configuration.md, "Toolchain"). gh-axi can perform every read and write
+# needed here, but it renders project reads as truncated agent-readable output
+# with no machine-stable shape, while the status write needs the exact project,
+# field, and option node IDs that only the JSON surface returns - the same
+# `gh ... --format json` surface gh-axi itself calls. `gh` also carries an
+# embedded jq, so shaping that JSON needs no external jq either. Firstmate's own
+# conversational GitHub work stays on gh-axi. Board commands need gh's `project`
+# OAuth scope (`gh auth refresh -s project`).
+#
+# Overrides for tests and specialized setups: FM_HOME, FM_CONFIG_OVERRIDE,
+# FM_DATA_OVERRIDE, and FM_BOARD_GH (the GitHub CLI to invoke).
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+BOARDS_FILE="$CONFIG/boards"
+LINKS="$DATA/board-links.tsv"
+GH="${FM_BOARD_GH:-gh}"
+TAB=$'\t'
+
+die() {
+  printf 'error: %s\n' "$1" >&2
+  exit "${2:-2}"
+}
+
+warn() {
+  printf 'board: %s\n' "$1" >&2
+}
+
+print_help() {
+  sed -n '2,${/^#/!q;s/^# \{0,1\}//;p;}' "$0"
+}
+
+# --- configuration ----------------------------------------------------------
+#
+# boards_emit prints one tab-separated stanza per configured board:
+#   project owner number repo label mention assignee status_field todo in_progress done
+# Optional values that are unset print as `-`. Malformed configuration is an
+# actionable error rather than something to guess around.
+
+CONFIG_VALUE_RE='^[A-Za-z0-9 ._-]+$'
+CONFIG_SLUG_RE='^[A-Za-z0-9._-]+$'
+
+# Emits the stanza being accumulated by boards_emit. Called only from there, and
+# deliberately reads that caller's locals rather than taking eleven arguments.
+boards_flush() {
+  [ -n "$project" ] || return 0
+  [ "$owner" != - ] || die "config/boards: board \"$project\" has no owner"
+  [ "$number" != - ] || die "config/boards: board \"$project\" has no number"
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$project" "$owner" "$number" "$repo" "$label" "$mention" "$assignee" \
+    "$status_field" "$todo" "$in_progress" "$done_col"
+}
+
+boards_emit() {
+  local line key value project owner number repo label mention assignee
+  local status_field todo in_progress done_col lineno=0 seen=
+  [ -f "$BOARDS_FILE" ] || return 0
+
+  project=''
+  owner=- number=- repo=- label=firstmate mention=- assignee=-
+  status_field=Status todo=Todo in_progress='In Progress' done_col=Done
+  while IFS= read -r line || [ -n "$line" ]; do
+    lineno=$((lineno + 1))
+    line=${line%$'\r'}
+    case "$line" in
+      '' | '#'*) continue ;;
+      *=*) ;;
+      *) die "config/boards line $lineno: expected \"key = value\"" ;;
+    esac
+    key=${line%%=*}
+    value=${line#*=}
+    # Trim surrounding whitespace from both halves.
+    key=${key#"${key%%[![:space:]]*}"}
+    key=${key%"${key##*[![:space:]]}"}
+    value=${value#"${value%%[![:space:]]*}"}
+    value=${value%"${value##*[![:space:]]}"}
+    [ -n "$value" ] || die "config/boards line $lineno: \"$key\" has no value"
+    case "$value" in
+      *"$TAB"*) die "config/boards line $lineno: \"$key\" must not contain a tab" ;;
+    esac
+
+    if [ "$key" = project ]; then
+      boards_flush
+      case "$value" in
+        *' '*) die "config/boards line $lineno: project name must not contain a space" ;;
+      esac
+      case " $seen " in
+        *" $value "*) die "config/boards: project \"$value\" is configured twice" ;;
+      esac
+      seen="$seen $value"
+      project=$value
+      owner=- number=- repo=- label=firstmate mention=- assignee=-
+      status_field=Status todo=Todo in_progress='In Progress' done_col=Done
+      continue
+    fi
+    [ -n "$project" ] || die "config/boards line $lineno: \"$key\" appears before any project"
+
+    case "$key" in
+      owner)
+        [[ $value =~ $CONFIG_SLUG_RE ]] || die "config/boards line $lineno: owner \"$value\" is not a login"
+        owner=$value
+        ;;
+      number)
+        case "$value" in
+          *[!0-9]*) die "config/boards line $lineno: number \"$value\" is not a project number" ;;
+        esac
+        number=$value
+        ;;
+      repo)
+        case "$value" in
+          */*/* | */ | /* | *' '*) die "config/boards line $lineno: repo \"$value\" is not owner/name" ;;
+          */*) repo=$value ;;
+          *) die "config/boards line $lineno: repo \"$value\" is not owner/name" ;;
+        esac
+        ;;
+      label | todo | in-progress | done | status-field)
+        [[ $value =~ $CONFIG_VALUE_RE ]] \
+          || die "config/boards line $lineno: \"$key\" may use only letters, digits, spaces, dot, underscore, and dash"
+        case "$key" in
+          label) label=$value ;;
+          todo) todo=$value ;;
+          in-progress) in_progress=$value ;;
+          done) done_col=$value ;;
+          status-field) status_field=$value ;;
+        esac
+        ;;
+      mention)
+        case "$value" in
+          @*) [[ ${value#@} =~ $CONFIG_SLUG_RE ]] || die "config/boards line $lineno: mention \"$value\" is not @login" ;;
+          *) die "config/boards line $lineno: mention \"$value\" must start with @" ;;
+        esac
+        mention=$value
+        ;;
+      assignee)
+        [[ $value =~ $CONFIG_SLUG_RE ]] || die "config/boards line $lineno: assignee \"$value\" is not a login"
+        assignee=$value
+        ;;
+      *) die "config/boards line $lineno: unknown key \"$key\"" ;;
+    esac
+  done < "$BOARDS_FILE"
+  boards_flush
+}
+
+# boards_load caches the validated stanzas once. boards_emit refuses malformed
+# configuration by exiting, but it runs in a substitution subshell, so its status
+# has to be turned back into a real exit here.
+BOARDS_CACHE=
+BOARDS_LOADED=0
+boards_load() {
+  local rc=0
+  if [ "$BOARDS_LOADED" = 1 ]; then
+    return 0
+  fi
+  BOARDS_CACHE=$(boards_emit) || rc=$?
+  if [ "$rc" != 0 ]; then
+    exit "$rc"
+  fi
+  BOARDS_LOADED=1
+}
+
+boards_rows() {
+  [ -n "$BOARDS_CACHE" ] || return 0
+  printf '%s\n' "$BOARDS_CACHE"
+}
+
+# board_for <project>: print that one board stanza, or fail with a usable error.
+board_for() {
+  local want=$1 row found=
+  while IFS= read -r row; do
+    [ -n "$row" ] || continue
+    case "$row" in
+      "$want$TAB"*)
+        found=$row
+        break
+        ;;
+    esac
+  done < <(boards_rows)
+  [ -n "$found" ] || die "no board configured for project \"$want\" in config/boards"
+  printf '%s\n' "$found"
+}
+
+# --- durable linkage record -------------------------------------------------
+
+LINKS_HEADER="# fm-board.sh durable issue-to-task links: project${TAB}issue${TAB}task${TAB}desired${TAB}synced${TAB}pr${TAB}pr_synced"
+
+links_rows() {
+  local row
+  [ -f "$LINKS" ] || return 0
+  while IFS= read -r row || [ -n "$row" ]; do
+    case "$row" in
+      '' | '#'*) continue ;;
+    esac
+    printf '%s\n' "$row"
+  done < "$LINKS"
+}
+
+links_field() {
+  printf '%s' "$1" | cut -f"$2"
+}
+
+links_by_issue() {
+  local want=$1 row
+  while IFS= read -r row; do
+    [ "$(links_field "$row" 2)" = "$want" ] || continue
+    printf '%s\n' "$row"
+    return 0
+  done < <(links_rows)
+  return 1
+}
+
+links_by_task() {
+  local want=$1 row
+  while IFS= read -r row; do
+    [ "$(links_field "$row" 3)" = "$want" ] || continue
+    printf '%s\n' "$row"
+    return 0
+  done < <(links_rows)
+  return 1
+}
+
+# links_put <project> <issue> <task> <desired> <synced> <pr> <pr_synced>
+# Atomically rewrites the record file, replacing any row for the same issue.
+links_put() {
+  local project=$1 issue=$2 task=$3 desired=$4 synced=$5 pr=$6 pr_synced=$7
+  local tmp row
+  mkdir -p "$DATA" || die "cannot create $DATA" 1
+  tmp=$(umask 077; mktemp "$DATA/.board-links.XXXXXX") || die "cannot write the linkage record" 1
+  printf '%s\n' "$LINKS_HEADER" > "$tmp"
+  while IFS= read -r row; do
+    if [ "$(links_field "$row" 2)" = "$issue" ]; then
+      continue
+    fi
+    printf '%s\n' "$row" >> "$tmp"
+  done < <(links_rows)
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$project" "$issue" "$task" "$desired" "$synced" "${pr:--}" "${pr_synced:--}" >> "$tmp"
+  mv -f "$tmp" "$LINKS" || { rm -f "$tmp"; die "cannot replace the linkage record" 1; }
+}
+
+# --- identifiers ------------------------------------------------------------
+
+# issue_canonical <url>: print the canonical issue URL, or fail.
+issue_canonical() {
+  local url=${1:-} rest number
+  url=${url%%\#*}
+  url=${url%%\?*}
+  url=${url%/}
+  case "$url" in
+    https://*/*/*/issues/*) ;;
+    *) return 1 ;;
+  esac
+  rest=${url#https://}
+  number=${rest##*/}
+  case "$number" in
+    '' | *[!0-9]*) return 1 ;;
+  esac
+  case "$url" in
+    *"$TAB"* | *' '*) return 1 ;;
+  esac
+  printf '%s\n' "$url"
+}
+
+# issue_repo <canonical-url>: print owner/name.
+issue_repo() {
+  local rest=${1#https://}
+  rest=${rest#*/}
+  printf '%s/%s\n' "${rest%%/*}" "$(printf '%s' "${rest#*/}" | cut -d/ -f1)"
+}
+
+task_id_valid() {
+  case "${1:-}" in
+    '' | *[!A-Za-z0-9._-]*) return 1 ;;
+  esac
+  return 0
+}
+
+pr_url_valid() {
+  case "${1:-}" in
+    https://*) ;;
+    *) return 1 ;;
+  esac
+  case "$1" in
+    *"$TAB"* | *' '*) return 1 ;;
+  esac
+  return 0
+}
+
+# --- board reads ------------------------------------------------------------
+
+# Normalize a field, option, label, or login the way any JSON export may spell
+# it, so a "Status"/"status" or "In Progress"/"inProgress" difference is not a
+# behavioral difference.
+norm_name() {
+  printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]' | tr -d ' '
+}
+
+# json_string <text>: emit a JSON string literal for safe jq interpolation.
+# Configuration already restricts these names to letters, digits, spaces, dot,
+# underscore, and dash, so this is defence in depth rather than the only guard.
+json_string() {
+  printf '"%s"' "$(printf '%s' "${1:-}" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')"
+}
+
+# The board read's columns, in order:
+#   item_id  type  issue_url  status  labels  assignees  title  body
+# Every column falls back to `-` so the reader never sees an empty field.
+items_jq() {
+  local status_key
+  status_key=$(json_string "$(norm_name "$1")")
+  cat <<JQ
+def dash: if (. == null or . == "") then "-" else . end;
+def clean: (. // "") | tostring | gsub("[\\\\t\\\\n\\\\r]+"; " ") | dash;
+def names:
+  (. // [])
+  | if type == "array" then map(if type == "object" then (.name // .login // "") else tostring end) else [] end
+  | join(",") | dash;
+.items[]
+| . as \$i
+| ((\$i.content // {}) | if type == "object" then . else {} end) as \$c
+| [ (\$i.id // "" | tostring | dash),
+    (\$c.type // \$i.type // "" | tostring | dash),
+    (\$c.url // \$i.url // "" | tostring | dash),
+    ( \$i | to_entries
+         | map(select((.key | ascii_downcase | gsub(" "; "")) == $status_key))
+         | (.[0].value // "")
+         | (if type == "object" then (.name // "") else tostring end)
+         | dash ),
+    ((\$c.labels // \$i.labels) | names),
+    ((\$c.assignees // \$i.assignees) | names),
+    ((\$c.title // \$i.title) | clean),
+    ((\$c.body // \$i.body) | clean)
+  ] | @tsv
+JQ
+}
+
+# The field read's columns: "field"<TAB>id, then "option"<TAB>id<TAB>name.
+fields_jq() {
+  local field_key
+  field_key=$(json_string "$(norm_name "$1")")
+  cat <<JQ
+.fields[]
+| select((.name | ascii_downcase | gsub(" "; "")) == $field_key)
+| (["field", (.id // "" | tostring)] | @tsv),
+  ((.options // [])[] | ["option", (.id // "" | tostring), (.name // "" | tostring)] | @tsv)
+JQ
+}
+
+# board_items <owner> <number> <status_field> <limit> <outfile>
+board_items() {
+  local owner=$1 number=$2 status_field=$3 limit=$4 out=$5
+  "$GH" project item-list "$number" --owner "$owner" --limit "$limit" \
+    --format json --jq "$(items_jq "$status_field")" > "$out"
+}
+
+# --- board writes -----------------------------------------------------------
+
+# board_item_id <owner> <number> <status_field> <limit> <issue-url>
+board_item_id() {
+  local owner=$1 number=$2 status_field=$3 limit=$4 issue=$5
+  local tmp id url canonical rc=1
+  tmp=$(mktemp) || return 1
+  if board_items "$owner" "$number" "$status_field" "$limit" "$tmp"; then
+    while IFS=$'\t' read -r id _ url _ _ _ _ _; do
+      canonical=$(issue_canonical "$url" 2>/dev/null) || continue
+      [ "$canonical" = "$issue" ] || continue
+      printf '%s\n' "$id"
+      rc=0
+      break
+    done < "$tmp"
+  fi
+  rm -f "$tmp"
+  return "$rc"
+}
+
+# board_set_status <owner> <number> <status_field> <limit> <issue-url> <option-name>
+# Resolves every node ID the status write needs, then performs it. Any failing
+# step returns non-zero so the caller can leave the write outstanding.
+board_set_status() {
+  local owner=$1 number=$2 status_field=$3 limit=$4 issue=$5 option_name=$6
+  local item_id project_id field_id option_id tmp kind a b want
+  item_id=$(board_item_id "$owner" "$number" "$status_field" "$limit" "$issue") || {
+    warn "$issue is not a card on project $owner/$number"
+    return 1
+  }
+  project_id=$("$GH" project view "$number" --owner "$owner" --format json --jq '.id') || {
+    warn "could not read project $owner/$number"
+    return 1
+  }
+  [ -n "$project_id" ] || {
+    warn "project $owner/$number reported no id"
+    return 1
+  }
+  tmp=$(mktemp) || return 1
+  if ! "$GH" project field-list "$number" --owner "$owner" --limit 100 \
+    --format json --jq "$(fields_jq "$status_field")" > "$tmp"; then
+    rm -f "$tmp"
+    warn "could not read the fields of project $owner/$number"
+    return 1
+  fi
+  field_id=''
+  option_id=''
+  want=$(norm_name "$option_name")
+  while IFS=$'\t' read -r kind a b; do
+    case "$kind" in
+      field) field_id=$a ;;
+      option) if [ "$(norm_name "${b:-}")" = "$want" ]; then option_id=$a; fi ;;
+    esac
+  done < "$tmp"
+  rm -f "$tmp"
+  if [ -z "$field_id" ]; then
+    warn "project $owner/$number has no \"$status_field\" field"
+    return 1
+  fi
+  if [ -z "$option_id" ]; then
+    warn "field \"$status_field\" has no \"$option_name\" option"
+    return 1
+  fi
+  "$GH" project item-edit --id "$item_id" --project-id "$project_id" \
+    --field-id "$field_id" --single-select-option-id "$option_id" >/dev/null || {
+    warn "could not move $issue to \"$option_name\""
+    return 1
+  }
+  return 0
+}
+
+# board_comment <issue-url> <body>
+board_comment() {
+  "$GH" issue comment "$1" --body "$2" >/dev/null || {
+    warn "could not comment on $1"
+    return 1
+  }
+  return 0
+}
+
+# --- state vocabulary -------------------------------------------------------
+#
+# Todo, In Progress, and Done are the whole mapping. A column the captain added
+# is recorded as "other" so their intent survives, never as a fourth state
+# firstmate drives.
+
+state_column() {
+  local state=$1 todo=$2 in_progress=$3 done_col=$4
+  case "$state" in
+    todo) printf '%s\n' "$todo" ;;
+    in-progress) printf '%s\n' "$in_progress" ;;
+    done) printf '%s\n' "$done_col" ;;
+    *) return 1 ;;
+  esac
+}
+
+column_state() {
+  local raw=$1 todo=$2 in_progress=$3 done_col=$4 want
+  want=$(norm_name "$raw")
+  if [ "$want" = "$(norm_name "$todo")" ]; then
+    printf 'todo\n'
+  elif [ "$want" = "$(norm_name "$in_progress")" ]; then
+    printf 'in-progress\n'
+  elif [ "$want" = "$(norm_name "$done_col")" ]; then
+    printf 'done\n'
+  else
+    printf 'other\n'
+  fi
+}
+
+# text_has <haystack> <needle>: normalized substring test.
+text_has() {
+  local hay needle
+  hay=$(norm_name "$1")
+  needle=$(norm_name "$2")
+  case "$hay" in
+    *"$needle"*) return 0 ;;
+  esac
+  return 1
+}
+
+# list_has <comma-list> <needle>: normalized membership test.
+list_has() {
+  local list needle
+  list=",$(norm_name "$1"),"
+  needle=",$(norm_name "$2"),"
+  case "$list" in
+    *"$needle"*) return 0 ;;
+  esac
+  return 1
+}
+
+# --- verbs ------------------------------------------------------------------
+
+cmd_boards() {
+  local want=${1:-} project owner number repo label mention assignee
+  local status_field todo in_progress done_col
+  while IFS=$'\t' read -r project owner number repo label mention assignee \
+    status_field todo in_progress done_col; do
+    [ -n "$project" ] || continue
+    if [ -n "$want" ] && [ "$want" != "$project" ]; then
+      continue
+    fi
+    printf 'board %s %s/%s repo=%s label=%s mention=%s assignee=%s field=%s columns=%s|%s|%s\n' \
+      "$project" "$owner" "$number" "$repo" "$label" "$mention" "$assignee" \
+      "$status_field" "$todo" "$in_progress" "$done_col"
+  done < <(boards_rows)
+}
+
+cmd_links() {
+  local want=${1:-} row
+  while IFS= read -r row; do
+    if [ -n "$want" ] && [ "$want" != "$(links_field "$row" 1)" ]; then
+      continue
+    fi
+    printf '%s\n' "$row"
+  done < <(links_rows)
+}
+
+cmd_lookup() {
+  local want=${1:?usage: fm-board.sh lookup <issue-url|task-id>} canonical row
+  if canonical=$(issue_canonical "$want"); then
+    row=$(links_by_issue "$canonical") || return 1
+  else
+    row=$(links_by_task "$want") || return 1
+  fi
+  printf '%s\n' "$row"
+}
+
+cmd_import() {
+  local project=${1:?usage: fm-board.sh import <project> <issue-url> <task-id>}
+  local raw_issue=${2:?usage: fm-board.sh import <project> <issue-url> <task-id>}
+  local task=${3:?usage: fm-board.sh import <project> <issue-url> <task-id>}
+  local issue existing existing_task existing_issue board repo
+
+  board=$(board_for "$project")
+  repo=$(printf '%s' "$board" | cut -f4)
+  issue=$(issue_canonical "$raw_issue") || die "\"$raw_issue\" is not an issue URL"
+  task_id_valid "$task" || die "\"$task\" is not a task id"
+  if [ "$repo" != - ] && [ "$(issue_repo "$issue")" != "$repo" ]; then
+    die "$issue is not in $repo, the repo configured for board \"$project\""
+  fi
+
+  if existing=$(links_by_issue "$issue"); then
+    existing_task=$(links_field "$existing" 3)
+    if [ "$existing_task" = "$task" ]; then
+      printf 'already-linked %s %s %s\n' "$project" "$issue" "$task"
+      return 0
+    fi
+    die "$issue is already linked to task $existing_task; refusing to relink it to $task" 3
+  fi
+  if existing=$(links_by_task "$task"); then
+    existing_issue=$(links_field "$existing" 2)
+    die "task $task is already linked to $existing_issue" 3
+  fi
+
+  links_put "$project" "$issue" "$task" todo todo - -
+  printf 'linked %s %s %s\n' "$project" "$issue" "$task"
+}
+
+cmd_mark() {
+  local task=${1:?usage: fm-board.sh mark <task-id> todo|in-progress|done}
+  local state=${2:?usage: fm-board.sh mark <task-id> todo|in-progress|done}
+  local row project issue synced pr pr_synced board
+  local owner number status_field todo in_progress done_col column
+
+  case "$state" in
+    todo | in-progress | done) ;;
+    *) die "unknown board state \"$state\" (use todo, in-progress, or done)" ;;
+  esac
+  row=$(links_by_task "$task") || die "task $task is not linked to a board issue"
+  project=$(links_field "$row" 1)
+  issue=$(links_field "$row" 2)
+  synced=$(links_field "$row" 5)
+  pr=$(links_field "$row" 6)
+  pr_synced=$(links_field "$row" 7)
+  board=$(board_for "$project")
+  owner=$(printf '%s' "$board" | cut -f2)
+  number=$(printf '%s' "$board" | cut -f3)
+  status_field=$(printf '%s' "$board" | cut -f8)
+  todo=$(printf '%s' "$board" | cut -f9)
+  in_progress=$(printf '%s' "$board" | cut -f10)
+  done_col=$(printf '%s' "$board" | cut -f11)
+  column=$(state_column "$state" "$todo" "$in_progress" "$done_col")
+
+  links_put "$project" "$issue" "$task" "$state" "$synced" "$pr" "$pr_synced"
+  if board_set_status "$owner" "$number" "$status_field" 200 "$issue" "$column"; then
+    links_put "$project" "$issue" "$task" "$state" "$state" "$pr" "$pr_synced"
+    printf 'synced %s %s %s %s\n' "$project" "$issue" "$task" "$state"
+  else
+    printf 'stale %s %s %s %s\n' "$project" "$issue" "$task" "$state"
+  fi
+  return 0
+}
+
+cmd_pr() {
+  local task=${1:?usage: fm-board.sh pr <task-id> <pr-url>}
+  local url=${2:?usage: fm-board.sh pr <task-id> <pr-url>}
+  local row project issue desired synced pr pr_synced
+
+  pr_url_valid "$url" || die "\"$url\" is not a pull request URL"
+  row=$(links_by_task "$task") || die "task $task is not linked to a board issue"
+  project=$(links_field "$row" 1)
+  issue=$(links_field "$row" 2)
+  desired=$(links_field "$row" 4)
+  synced=$(links_field "$row" 5)
+  pr=$(links_field "$row" 6)
+  pr_synced=$(links_field "$row" 7)
+  if [ "$pr" = "$url" ] && [ "$pr_synced" = 1 ]; then
+    printf 'already-attached %s %s %s %s\n' "$project" "$issue" "$task" "$url"
+    return 0
+  fi
+
+  links_put "$project" "$issue" "$task" "$desired" "$synced" "$url" 0
+  if board_comment "$issue" "Working PR: $url"; then
+    links_put "$project" "$issue" "$task" "$desired" "$synced" "$url" 1
+    printf 'attached %s %s %s %s\n' "$project" "$issue" "$task" "$url"
+  else
+    printf 'stale %s %s %s %s\n' "$project" "$issue" "$task" "$url"
+  fi
+  return 0
+}
+
+cmd_note() {
+  local task=${1:?usage: fm-board.sh note <task-id> <text>}
+  local text=${2:?usage: fm-board.sh note <task-id> <text>}
+  local row project issue
+  row=$(links_by_task "$task") || die "task $task is not linked to a board issue"
+  project=$(links_field "$row" 1)
+  issue=$(links_field "$row" 2)
+  # A note is a point-in-time record, so it is never queued for retry: a blocker
+  # posted three cycles late would be noise, and firstmate escalates the blocker
+  # to the captain either way.
+  if board_comment "$issue" "$text"; then
+    printf 'noted %s %s %s\n' "$project" "$issue" "$task"
+  else
+    printf 'stale %s %s %s\n' "$project" "$issue" "$task"
+  fi
+  return 0
+}
+
+cmd_ack() {
+  local task=${1:?usage: fm-board.sh ack <task-id>}
+  local row project issue pr pr_synced
+  row=$(links_by_task "$task") || die "task $task is not linked to a board issue"
+  project=$(links_field "$row" 1)
+  issue=$(links_field "$row" 2)
+  pr=$(links_field "$row" 6)
+  pr_synced=$(links_field "$row" 7)
+  # The link stays forever so the issue can never be imported twice; only its
+  # active execution state retires.
+  links_put "$project" "$issue" "$task" other other "$pr" "$pr_synced"
+  printf 'acknowledged %s %s %s\n' "$project" "$issue" "$task"
+}
+
+# poll_board <board-row> <limit> <items-file>
+# Classifies every card, adopts captain edits, and retries outstanding writes.
+poll_board() {
+  local board=$1 limit=$2 items=$3
+  local project owner number repo label mention assignee status_field todo in_progress done_col
+  local id type url status labels assignees title body
+  local canonical row task desired synced pr pr_synced board_state count=0
+  local seen_file trigger column
+
+  project=$(printf '%s' "$board" | cut -f1)
+  owner=$(printf '%s' "$board" | cut -f2)
+  number=$(printf '%s' "$board" | cut -f3)
+  repo=$(printf '%s' "$board" | cut -f4)
+  label=$(printf '%s' "$board" | cut -f5)
+  mention=$(printf '%s' "$board" | cut -f6)
+  assignee=$(printf '%s' "$board" | cut -f7)
+  status_field=$(printf '%s' "$board" | cut -f8)
+  todo=$(printf '%s' "$board" | cut -f9)
+  in_progress=$(printf '%s' "$board" | cut -f10)
+  done_col=$(printf '%s' "$board" | cut -f11)
+
+  seen_file=$(mktemp) || return 1
+  while IFS=$'\t' read -r id type url status labels assignees title body; do
+    [ -n "$id" ] || continue
+    count=$((count + 1))
+    # A draft card or a pull request is not a real issue, so it is never intake.
+    [ "$type" = Issue ] || continue
+    canonical=$(issue_canonical "$url") || continue
+    if [ "$repo" != - ] && [ "$(issue_repo "$canonical")" != "$repo" ]; then
+      continue
+    fi
+    printf '%s\n' "$canonical" >> "$seen_file"
+    board_state=$(column_state "$status" "$todo" "$in_progress" "$done_col")
+
+    if row=$(links_by_issue "$canonical"); then
+      task=$(links_field "$row" 3)
+      desired=$(links_field "$row" 4)
+      synced=$(links_field "$row" 5)
+      pr=$(links_field "$row" 6)
+      pr_synced=$(links_field "$row" 7)
+      if [ "$desired" = "$synced" ]; then
+        if [ "$board_state" = "$desired" ]; then
+          printf 'linked %s %s %s %s\n' "$project" "$canonical" "$task" "$desired"
+        else
+          links_put "$project" "$canonical" "$task" "$board_state" "$board_state" "$pr" "$pr_synced"
+          printf 'instruction %s %s %s %s %s %s\n' \
+            "$project" "$canonical" "$task" "$desired" "$board_state" "$status"
+        fi
+        continue
+      fi
+      # A write is outstanding. The board still showing the last confirmed value
+      # is this adapter's own lag, not a captain edit.
+      if [ "$board_state" = "$desired" ]; then
+        links_put "$project" "$canonical" "$task" "$desired" "$desired" "$pr" "$pr_synced"
+        printf 'linked %s %s %s %s\n' "$project" "$canonical" "$task" "$desired"
+      elif [ "$board_state" = "$synced" ]; then
+        column=$(state_column "$desired" "$todo" "$in_progress" "$done_col") || column=
+        if [ -n "$column" ] && board_set_status "$owner" "$number" "$status_field" "$limit" "$canonical" "$column"; then
+          links_put "$project" "$canonical" "$task" "$desired" "$desired" "$pr" "$pr_synced"
+          printf 'synced %s %s %s %s\n' "$project" "$canonical" "$task" "$desired"
+        else
+          printf 'stale %s %s %s %s\n' "$project" "$canonical" "$task" "$desired"
+        fi
+      else
+        links_put "$project" "$canonical" "$task" "$board_state" "$board_state" "$pr" "$pr_synced"
+        printf 'instruction %s %s %s %s %s %s\n' \
+          "$project" "$canonical" "$task" "$desired" "$board_state" "$status"
+      fi
+      continue
+    fi
+
+    # Not linked yet: intake needs the Todo column and an explicit trigger.
+    [ "$board_state" = todo ] || continue
+    trigger=
+    if list_has "$labels" "$label"; then
+      trigger=label
+    elif [ "$assignee" != - ] && list_has "$assignees" "$assignee"; then
+      trigger=assignee
+    elif [ "$mention" != - ] && text_has "$title $body" "$mention"; then
+      trigger=mention
+    fi
+    [ -n "$trigger" ] || continue
+    printf 'new %s %s %s %s\n' "$project" "$canonical" "$trigger" "$title"
+  done < "$items"
+
+  # A card that vanished from the board is the captain withdrawing the work.
+  # Two reads cannot tell absence apart from something else and so reconcile
+  # nothing: a full page may have another page behind it, and a board that
+  # answers with no cards at all while links are open is far more likely to be
+  # a changed project number or a lost permission than the captain clearing
+  # every card by hand.
+  if [ "$count" -ge "$limit" ]; then
+    printf 'truncated %s %s\n' "$project" "$count"
+  elif [ "$count" -eq 0 ] && [ -n "$(cmd_links "$project")" ]; then
+    printf 'error %s the board returned no cards while links are open\n' "$project"
+  else
+    while IFS= read -r row; do
+      [ "$(links_field "$row" 1)" = "$project" ] || continue
+      canonical=$(links_field "$row" 2)
+      if grep -Fqx -- "$canonical" "$seen_file"; then
+        continue
+      fi
+      desired=$(links_field "$row" 4)
+      # Leaving the board after Done is archiving, and an acknowledged
+      # withdrawal is already reconciled; neither is an open instruction.
+      case "$desired" in
+        todo | in-progress) ;;
+        *) continue ;;
+      esac
+      task=$(links_field "$row" 3)
+      printf 'cancelled %s %s %s %s\n' "$project" "$canonical" "$task" "$desired"
+    done < <(links_rows)
+  fi
+  rm -f "$seen_file"
+}
+
+cmd_poll() {
+  local want='' limit=200 board items project owner number status_field
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --limit)
+        [ "$#" -gt 1 ] || die "--limit needs a value"
+        limit=$2
+        shift 2
+        ;;
+      --limit=*)
+        limit=${1#--limit=}
+        shift
+        ;;
+      -*) die "unknown option \"$1\"" ;;
+      *)
+        want=$1
+        shift
+        ;;
+    esac
+  done
+  case "$limit" in
+    '' | *[!0-9]* | 0) die "--limit must be a positive number" ;;
+  esac
+  if [ -n "$want" ]; then
+    board_for "$want" >/dev/null
+  fi
+
+  while IFS= read -r board; do
+    [ -n "$board" ] || continue
+    project=$(printf '%s' "$board" | cut -f1)
+    owner=$(printf '%s' "$board" | cut -f2)
+    number=$(printf '%s' "$board" | cut -f3)
+    status_field=$(printf '%s' "$board" | cut -f8)
+    if [ -n "$want" ] && [ "$want" != "$project" ]; then
+      continue
+    fi
+    items=$(mktemp) || die "cannot stage the board read" 1
+    if board_items "$owner" "$number" "$status_field" "$limit" "$items"; then
+      poll_board "$board" "$limit" "$items"
+    else
+      # A read failure never halts the cycle; the next one reconciles.
+      printf 'error %s could not read project %s/%s\n' "$project" "$owner" "$number"
+    fi
+    rm -f "$items"
+  done < <(boards_rows)
+  return 0
+}
+
+# --- dispatch ---------------------------------------------------------------
+
+case "${1:-}" in
+  -h | --help | help | '')
+    print_help
+    exit 0
+    ;;
+esac
+VERB=$1
+shift
+# Load and validate board configuration in this shell, before any verb runs, so
+# a malformed file is one actionable error rather than a command that quietly
+# behaves as though no board were configured.
+boards_load
+case "$VERB" in
+  boards) cmd_boards "$@" ;;
+  poll) cmd_poll "$@" ;;
+  import) cmd_import "$@" ;;
+  links) cmd_links "$@" ;;
+  lookup) cmd_lookup "$@" ;;
+  mark) cmd_mark "$@" ;;
+  pr) cmd_pr "$@" ;;
+  note) cmd_note "$@" ;;
+  ack) cmd_ack "$@" ;;
+  *) die "unknown command \"$VERB\" (see fm-board.sh --help)" ;;
+esac

--- a/bin/fm-board.sh
+++ b/bin/fm-board.sh
@@ -16,11 +16,16 @@
 #   fm-board.sh import <project> <issue-url> <task-id>
 #   fm-board.sh links [<project>]
 #   fm-board.sh lookup <issue-url|task-id>
-#   fm-board.sh mark <task-id> todo|in-progress|done
+#   fm-board.sh mark <task-id> todo|in-progress|done [--limit <n>]
 #   fm-board.sh pr <task-id> <pr-url>
 #   fm-board.sh note <task-id> <text>
 #   fm-board.sh ack <task-id>
 #   fm-board.sh -h | --help
+#
+# `--limit` caps how many cards one board read returns and defaults to 200, on
+# `poll` and on the card lookup `mark` needs. A board carrying more cards than
+# the limit needs it raised: `poll` says so with a `truncated` line, and `mark`
+# cannot find a card sitting past the limit at all.
 #
 # CONFIGURATION - config/boards, local and gitignored (docs/configuration.md
 # owns the operator-facing description). Plain text, one stanza per board, each
@@ -66,6 +71,9 @@
 # a draft card and not a pull request), sits in the configured Todo column, and
 # carries the configured trigger. The label is the authoritative trigger; the
 # optional mention and assignee triggers are additional and off unless set.
+# These are intake filters alone: a card they decline is still a card on the
+# board, recorded as present before any of them runs, so declining to import it
+# is never mistaken for it having left.
 #
 # IDEMPOTENCY. data/board-links.tsv is the durable linkage record and the single
 # thing consulted before an import. It lives in data/, not state/, so it
@@ -89,10 +97,12 @@
 # FAIL SOFT. Every board write degrades to a stale board instead of blocking
 # delivery: `mark`, `pr`, and `note` exit 0 whether or not the write landed,
 # reporting the failure on stderr and leaving `mark` and `pr` retryable. `poll`
-# retries outstanding writes and also exits 0 on a board read failure, reporting
-# it as an `error` line. A read that cannot tell absence from its own limits -
-# a full page, or a board answering with no cards at all while links are open -
-# says so and reconciles nothing rather than guessing. Only a usage or
+# retries both outstanding writes - the card move and the PR attachment - and
+# reports each with the same `synced` or `stale` line, and it also exits 0 on a
+# board read failure, reporting it as an `error` line. A read that cannot tell
+# absence from its own limits - a full page, or a board answering with no cards
+# at all while links are open - says so and reconciles nothing rather than
+# guessing. Only a usage or
 # configuration error exits non-zero, and a refused conflicting relink exits 3.
 #
 # WHO WINS. When the board disagrees with a record, the board is a captain
@@ -101,6 +111,13 @@
 # firstmate's state back over the captain's edit. The one exception is an
 # outstanding write the board has not taken yet, which is retried because the
 # board still shows the value this adapter last confirmed.
+#
+# An issue that a different configured board already owns is a misconfiguration
+# rather than an instruction, so `poll` names it in a `foreign` line carrying the
+# owning project and touches neither the card nor the record. Ownership is never
+# silently re-homed, because every later event would then resolve the wrong
+# board. `import` stays fleet-wide: an issue linked under any project can never
+# be imported a second time under another one.
 #
 # A card that left the board is the captain withdrawing work firstmate is still
 # executing, so `poll` keeps reporting it as `cancelled` until `ack` records that
@@ -134,6 +151,16 @@ BOARDS_FILE="$CONFIG/boards"
 LINKS="$DATA/board-links.tsv"
 GH="${FM_BOARD_GH:-gh}"
 TAB=$'\t'
+# One board read's ceiling, shared by `poll` and the card lookup `mark` needs.
+DEFAULT_LIMIT=200
+MARK_USAGE='usage: fm-board.sh mark <task-id> todo|in-progress|done [--limit <n>]'
+
+limit_valid() {
+  case "${1:-}" in
+    '' | *[!0-9]* | 0) return 1 ;;
+  esac
+  return 0
+}
 
 die() {
   printf 'error: %s\n' "$1" >&2
@@ -312,43 +339,55 @@ links_rows() {
   done < "$LINKS"
 }
 
-links_field() {
-  printf '%s' "$1" | cut -f"$2"
+# A row is seven tab-separated columns and no column is ever empty, so one
+# `read` splits it into named variables without a subprocess per field. The
+# record is kept forever by design, so a scan that forked per field would cost
+# more on every cycle than the one before it.
+LINK_PROJECT=- LINK_ISSUE=- LINK_TASK=- LINK_DESIRED=- LINK_SYNCED=-
+LINK_PR=- LINK_PR_SYNCED=-
+
+link_clear() {
+  LINK_PROJECT=- LINK_ISSUE=- LINK_TASK=- LINK_DESIRED=- LINK_SYNCED=-
+  LINK_PR=- LINK_PR_SYNCED=-
 }
 
-links_by_issue() {
-  local want=$1 row
-  while IFS= read -r row; do
-    [ "$(links_field "$row" 2)" = "$want" ] || continue
-    printf '%s\n' "$row"
-    return 0
+# links_find issue|task <value>: leave the matching record in the LINK_
+# variables and print it, or clear them and return 1. Callers read the
+# variables, so this is never run inside a command substitution.
+links_find() {
+  local by=$1 want=$2 found=
+  while IFS=$TAB read -r LINK_PROJECT LINK_ISSUE LINK_TASK LINK_DESIRED \
+    LINK_SYNCED LINK_PR LINK_PR_SYNCED; do
+    case "$by" in
+      issue) [ "$LINK_ISSUE" = "$want" ] || continue ;;
+      *) [ "$LINK_TASK" = "$want" ] || continue ;;
+    esac
+    found=1
+    break
   done < <(links_rows)
-  return 1
-}
-
-links_by_task() {
-  local want=$1 row
-  while IFS= read -r row; do
-    [ "$(links_field "$row" 3)" = "$want" ] || continue
-    printf '%s\n' "$row"
-    return 0
-  done < <(links_rows)
-  return 1
+  if [ -z "$found" ]; then
+    link_clear
+    return 1
+  fi
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$LINK_PROJECT" "$LINK_ISSUE" "$LINK_TASK" "$LINK_DESIRED" "$LINK_SYNCED" \
+    "$LINK_PR" "$LINK_PR_SYNCED"
 }
 
 # links_put <project> <issue> <task> <desired> <synced> <pr> <pr_synced>
 # Atomically rewrites the record file, replacing any row for the same issue.
 links_put() {
   local project=$1 issue=$2 task=$3 desired=$4 synced=$5 pr=$6 pr_synced=$7
-  local tmp row
+  local tmp r_project r_issue r_task r_desired r_synced r_pr r_pr_synced
   mkdir -p "$DATA" || die "cannot create $DATA" 1
   tmp=$(umask 077; mktemp "$DATA/.board-links.XXXXXX") || die "cannot write the linkage record" 1
   printf '%s\n' "$LINKS_HEADER" > "$tmp"
-  while IFS= read -r row; do
-    if [ "$(links_field "$row" 2)" = "$issue" ]; then
-      continue
-    fi
-    printf '%s\n' "$row" >> "$tmp"
+  while IFS=$TAB read -r r_project r_issue r_task r_desired r_synced r_pr \
+    r_pr_synced; do
+    [ "$r_issue" != "$issue" ] || continue
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+      "$r_project" "$r_issue" "$r_task" "$r_desired" "$r_synced" "$r_pr" \
+      "$r_pr_synced" >> "$tmp"
   done < <(links_rows)
   printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
     "$project" "$issue" "$task" "$desired" "$synced" "${pr:--}" "${pr_synced:--}" >> "$tmp"
@@ -490,17 +529,25 @@ board_item_id() {
   return "$rc"
 }
 
-# board_set_status <owner> <number> <status_field> <limit> <issue-url> <option-name>
-# Resolves every node ID the status write needs, then performs it. Any failing
-# step returns non-zero so the caller can leave the write outstanding.
-board_set_status() {
-  local owner=$1 number=$2 status_field=$3 limit=$4 issue=$5 option_name=$6
-  local item_id project_id field_id option_id tmp kind a b want
-  item_id=$(board_item_id "$owner" "$number" "$status_field" "$limit" "$issue") || {
-    warn "$issue is not a card on project $owner/$number"
-    return 1
-  }
-  project_id=$("$GH" project view "$number" --owner "$owner" --format json --jq '.id') || {
+# The project, field, and option node IDs are the same for every card on one
+# board, so they are read once per board and reused by every write in this run.
+# Resolving them per write would turn a cheap cycle into three project reads for
+# each outstanding write it retries.
+BOARD_IDS_KEY=
+BOARD_PROJECT_ID=
+BOARD_FIELD_ID=
+BOARD_OPTIONS=
+
+# board_status_ids <owner> <number> <status_field>: resolve and cache them.
+# A failure caches nothing, so the next write retries the read.
+board_status_ids() {
+  local owner=$1 number=$2 status_field=$3
+  local key project_id field_id options tmp kind a b
+  key="$owner$TAB$number$TAB$status_field"
+  if [ "$BOARD_IDS_KEY" = "$key" ]; then
+    return 0
+  fi
+  project_id=$("$GH" project view "$number" --owner "$owner" --format json --jq '.id' </dev/null) || {
     warn "could not read project $owner/$number"
     return 1
   }
@@ -510,18 +557,17 @@ board_set_status() {
   }
   tmp=$(mktemp) || return 1
   if ! "$GH" project field-list "$number" --owner "$owner" --limit 100 \
-    --format json --jq "$(fields_jq "$status_field")" > "$tmp"; then
+    --format json --jq "$(fields_jq "$status_field")" > "$tmp" </dev/null; then
     rm -f "$tmp"
     warn "could not read the fields of project $owner/$number"
     return 1
   fi
   field_id=''
-  option_id=''
-  want=$(norm_name "$option_name")
-  while IFS=$'\t' read -r kind a b; do
+  options=''
+  while IFS=$TAB read -r kind a b; do
     case "$kind" in
       field) field_id=$a ;;
-      option) if [ "$(norm_name "${b:-}")" = "$want" ]; then option_id=$a; fi ;;
+      option) options="$options$(norm_name "${b:-}")$TAB$a"$'\n' ;;
     esac
   done < "$tmp"
   rm -f "$tmp"
@@ -529,21 +575,62 @@ board_set_status() {
     warn "project $owner/$number has no \"$status_field\" field"
     return 1
   fi
-  if [ -z "$option_id" ]; then
+  BOARD_PROJECT_ID=$project_id
+  BOARD_FIELD_ID=$field_id
+  BOARD_OPTIONS=$options
+  BOARD_IDS_KEY=$key
+  return 0
+}
+
+# board_option_id <option-name>: the cached single-select option id, or fail.
+board_option_id() {
+  local want name id
+  want=$(norm_name "$1")
+  while IFS=$TAB read -r name id; do
+    [ "$name" = "$want" ] || continue
+    printf '%s\n' "$id"
+    return 0
+  done <<< "$BOARD_OPTIONS"
+  return 1
+}
+
+# board_write_status <owner> <number> <status_field> <item-id> <issue-url> <option-name>
+# For a caller that already holds the card's item id, which the board read hands
+# it. Any failing step returns non-zero so the write stays outstanding.
+board_write_status() {
+  local owner=$1 number=$2 status_field=$3 item_id=$4 issue=$5 option_name=$6
+  local option_id
+  board_status_ids "$owner" "$number" "$status_field" || return 1
+  option_id=$(board_option_id "$option_name") || {
     warn "field \"$status_field\" has no \"$option_name\" option"
     return 1
-  fi
-  "$GH" project item-edit --id "$item_id" --project-id "$project_id" \
-    --field-id "$field_id" --single-select-option-id "$option_id" >/dev/null || {
+  }
+  "$GH" project item-edit --id "$item_id" --project-id "$BOARD_PROJECT_ID" \
+    --field-id "$BOARD_FIELD_ID" --single-select-option-id "$option_id" \
+    >/dev/null </dev/null || {
     warn "could not move $issue to \"$option_name\""
     return 1
   }
   return 0
 }
 
+# board_set_status <owner> <number> <status_field> <limit> <issue-url> <option-name>
+# For a caller that holds only the issue URL and has to find its card first.
+board_set_status() {
+  local owner=$1 number=$2 status_field=$3 limit=$4 issue=$5 option_name=$6
+  local item_id
+  item_id=$(board_item_id "$owner" "$number" "$status_field" "$limit" "$issue") || {
+    warn "$issue is not a card on project $owner/$number"
+    return 1
+  }
+  board_write_status "$owner" "$number" "$status_field" "$item_id" "$issue" "$option_name"
+}
+
 # board_comment <issue-url> <body>
+# Runs from inside poll's item loop, so it never inherits the board read on
+# stdin.
 board_comment() {
-  "$GH" issue comment "$1" --body "$2" >/dev/null || {
+  "$GH" issue comment "$1" --body "$2" >/dev/null </dev/null || {
     warn "could not comment on $1"
     return 1
   }
@@ -622,28 +709,30 @@ cmd_boards() {
 cmd_links() {
   local want=${1:-} row
   while IFS= read -r row; do
-    if [ -n "$want" ] && [ "$want" != "$(links_field "$row" 1)" ]; then
-      continue
+    if [ -n "$want" ]; then
+      case "$row" in
+        "$want$TAB"*) ;;
+        *) continue ;;
+      esac
     fi
     printf '%s\n' "$row"
   done < <(links_rows)
 }
 
 cmd_lookup() {
-  local want=${1:?usage: fm-board.sh lookup <issue-url|task-id>} canonical row
+  local want=${1:?usage: fm-board.sh lookup <issue-url|task-id>} canonical
   if canonical=$(issue_canonical "$want"); then
-    row=$(links_by_issue "$canonical") || return 1
+    links_find issue "$canonical" || return 1
   else
-    row=$(links_by_task "$want") || return 1
+    links_find task "$want" || return 1
   fi
-  printf '%s\n' "$row"
 }
 
 cmd_import() {
   local project=${1:?usage: fm-board.sh import <project> <issue-url> <task-id>}
   local raw_issue=${2:?usage: fm-board.sh import <project> <issue-url> <task-id>}
   local task=${3:?usage: fm-board.sh import <project> <issue-url> <task-id>}
-  local issue existing existing_task existing_issue board repo
+  local issue board repo
 
   board=$(board_for "$project")
   repo=$(printf '%s' "$board" | cut -f4)
@@ -653,17 +742,17 @@ cmd_import() {
     die "$issue is not in $repo, the repo configured for board \"$project\""
   fi
 
-  if existing=$(links_by_issue "$issue"); then
-    existing_task=$(links_field "$existing" 3)
-    if [ "$existing_task" = "$task" ]; then
+  # This duplicate check is deliberately fleet-wide rather than scoped to one
+  # board: an issue holds at most one task no matter which board carries it.
+  if links_find issue "$issue" >/dev/null; then
+    if [ "$LINK_TASK" = "$task" ]; then
       printf 'already-linked %s %s %s\n' "$project" "$issue" "$task"
       return 0
     fi
-    die "$issue is already linked to task $existing_task; refusing to relink it to $task" 3
+    die "$issue is already linked to task $LINK_TASK; refusing to relink it to $task" 3
   fi
-  if existing=$(links_by_task "$task"); then
-    existing_issue=$(links_field "$existing" 2)
-    die "task $task is already linked to $existing_issue" 3
+  if links_find task "$task" >/dev/null; then
+    die "task $task is already linked to $LINK_ISSUE" 3
   fi
 
   links_put "$project" "$issue" "$task" todo todo - -
@@ -671,21 +760,48 @@ cmd_import() {
 }
 
 cmd_mark() {
-  local task=${1:?usage: fm-board.sh mark <task-id> todo|in-progress|done}
-  local state=${2:?usage: fm-board.sh mark <task-id> todo|in-progress|done}
-  local row project issue synced pr pr_synced board
+  local task='' state='' limit=$DEFAULT_LIMIT
+  local project issue synced pr pr_synced board
   local owner number status_field todo in_progress done_col column
 
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --limit)
+        [ "$#" -gt 1 ] || die "--limit needs a value"
+        limit=$2
+        shift 2
+        ;;
+      --limit=*)
+        limit=${1#--limit=}
+        shift
+        ;;
+      -*) die "unknown option \"$1\"" ;;
+      *)
+        if [ -z "$task" ]; then
+          task=$1
+        elif [ -z "$state" ]; then
+          state=$1
+        else
+          die "$MARK_USAGE"
+        fi
+        shift
+        ;;
+    esac
+  done
+  if [ -z "$task" ] || [ -z "$state" ]; then
+    die "$MARK_USAGE"
+  fi
+  limit_valid "$limit" || die "--limit must be a positive number"
   case "$state" in
     todo | in-progress | done) ;;
     *) die "unknown board state \"$state\" (use todo, in-progress, or done)" ;;
   esac
-  row=$(links_by_task "$task") || die "task $task is not linked to a board issue"
-  project=$(links_field "$row" 1)
-  issue=$(links_field "$row" 2)
-  synced=$(links_field "$row" 5)
-  pr=$(links_field "$row" 6)
-  pr_synced=$(links_field "$row" 7)
+  links_find task "$task" >/dev/null || die "task $task is not linked to a board issue"
+  project=$LINK_PROJECT
+  issue=$LINK_ISSUE
+  synced=$LINK_SYNCED
+  pr=$LINK_PR
+  pr_synced=$LINK_PR_SYNCED
   board=$(board_for "$project")
   owner=$(printf '%s' "$board" | cut -f2)
   number=$(printf '%s' "$board" | cut -f3)
@@ -696,7 +812,7 @@ cmd_mark() {
   column=$(state_column "$state" "$todo" "$in_progress" "$done_col")
 
   links_put "$project" "$issue" "$task" "$state" "$synced" "$pr" "$pr_synced"
-  if board_set_status "$owner" "$number" "$status_field" 200 "$issue" "$column"; then
+  if board_set_status "$owner" "$number" "$status_field" "$limit" "$issue" "$column"; then
     links_put "$project" "$issue" "$task" "$state" "$state" "$pr" "$pr_synced"
     printf 'synced %s %s %s %s\n' "$project" "$issue" "$task" "$state"
   else
@@ -708,16 +824,16 @@ cmd_mark() {
 cmd_pr() {
   local task=${1:?usage: fm-board.sh pr <task-id> <pr-url>}
   local url=${2:?usage: fm-board.sh pr <task-id> <pr-url>}
-  local row project issue desired synced pr pr_synced
+  local project issue desired synced pr pr_synced
 
   pr_url_valid "$url" || die "\"$url\" is not a pull request URL"
-  row=$(links_by_task "$task") || die "task $task is not linked to a board issue"
-  project=$(links_field "$row" 1)
-  issue=$(links_field "$row" 2)
-  desired=$(links_field "$row" 4)
-  synced=$(links_field "$row" 5)
-  pr=$(links_field "$row" 6)
-  pr_synced=$(links_field "$row" 7)
+  links_find task "$task" >/dev/null || die "task $task is not linked to a board issue"
+  project=$LINK_PROJECT
+  issue=$LINK_ISSUE
+  desired=$LINK_DESIRED
+  synced=$LINK_SYNCED
+  pr=$LINK_PR
+  pr_synced=$LINK_PR_SYNCED
   if [ "$pr" = "$url" ] && [ "$pr_synced" = 1 ]; then
     printf 'already-attached %s %s %s %s\n' "$project" "$issue" "$task" "$url"
     return 0
@@ -736,10 +852,10 @@ cmd_pr() {
 cmd_note() {
   local task=${1:?usage: fm-board.sh note <task-id> <text>}
   local text=${2:?usage: fm-board.sh note <task-id> <text>}
-  local row project issue
-  row=$(links_by_task "$task") || die "task $task is not linked to a board issue"
-  project=$(links_field "$row" 1)
-  issue=$(links_field "$row" 2)
+  local project issue
+  links_find task "$task" >/dev/null || die "task $task is not linked to a board issue"
+  project=$LINK_PROJECT
+  issue=$LINK_ISSUE
   # A note is a point-in-time record, so it is never queued for retry: a blocker
   # posted three cycles late would be noise, and firstmate escalates the blocker
   # to the captain either way.
@@ -753,12 +869,12 @@ cmd_note() {
 
 cmd_ack() {
   local task=${1:?usage: fm-board.sh ack <task-id>}
-  local row project issue pr pr_synced
-  row=$(links_by_task "$task") || die "task $task is not linked to a board issue"
-  project=$(links_field "$row" 1)
-  issue=$(links_field "$row" 2)
-  pr=$(links_field "$row" 6)
-  pr_synced=$(links_field "$row" 7)
+  local project issue pr pr_synced
+  links_find task "$task" >/dev/null || die "task $task is not linked to a board issue"
+  project=$LINK_PROJECT
+  issue=$LINK_ISSUE
+  pr=$LINK_PR
+  pr_synced=$LINK_PR_SYNCED
   # The link stays forever so the issue can never be imported twice; only its
   # active execution state retires.
   links_put "$project" "$issue" "$task" other other "$pr" "$pr_synced"
@@ -771,8 +887,9 @@ poll_board() {
   local board=$1 limit=$2 items=$3
   local project owner number repo label mention assignee status_field todo in_progress done_col
   local id type url status labels assignees title body
-  local canonical row task desired synced pr pr_synced board_state count=0
+  local canonical task desired synced pr pr_synced board_state count=0
   local seen_file trigger column
+  local l_project l_issue l_task l_desired
 
   project=$(printf '%s' "$board" | cut -f1)
   owner=$(printf '%s' "$board" | cut -f2)
@@ -787,24 +904,30 @@ poll_board() {
   done_col=$(printf '%s' "$board" | cut -f11)
 
   seen_file=$(mktemp) || return 1
-  while IFS=$'\t' read -r id type url status labels assignees title body; do
+  while IFS=$TAB read -r id type url status labels assignees title body; do
     [ -n "$id" ] || continue
     count=$((count + 1))
-    # A draft card or a pull request is not a real issue, so it is never intake.
-    [ "$type" = Issue ] || continue
     canonical=$(issue_canonical "$url") || continue
-    if [ "$repo" != - ] && [ "$(issue_repo "$canonical")" != "$repo" ]; then
-      continue
-    fi
+    # Presence on the board is established before any intake filter runs: a card
+    # this cycle declines to import is still a card that has not left, and the
+    # withdrawal scan below reads absence from this file.
     printf '%s\n' "$canonical" >> "$seen_file"
     board_state=$(column_state "$status" "$todo" "$in_progress" "$done_col")
 
-    if row=$(links_by_issue "$canonical"); then
-      task=$(links_field "$row" 3)
-      desired=$(links_field "$row" 4)
-      synced=$(links_field "$row" 5)
-      pr=$(links_field "$row" 6)
-      pr_synced=$(links_field "$row" 7)
+    if links_find issue "$canonical" >/dev/null; then
+      # An issue another configured board already owns is a misconfiguration,
+      # not an instruction. Re-homing it would point every later event at the
+      # wrong board, so this one is named and left entirely alone.
+      if [ "$LINK_PROJECT" != "$project" ]; then
+        printf 'foreign %s %s %s %s\n' \
+          "$project" "$canonical" "$LINK_PROJECT" "$LINK_TASK"
+        continue
+      fi
+      task=$LINK_TASK
+      desired=$LINK_DESIRED
+      synced=$LINK_SYNCED
+      pr=$LINK_PR
+      pr_synced=$LINK_PR_SYNCED
       if [ "$desired" = "$synced" ]; then
         if [ "$board_state" = "$desired" ]; then
           printf 'linked %s %s %s %s\n' "$project" "$canonical" "$task" "$desired"
@@ -812,18 +935,20 @@ poll_board() {
           links_put "$project" "$canonical" "$task" "$board_state" "$board_state" "$pr" "$pr_synced"
           printf 'instruction %s %s %s %s %s %s\n' \
             "$project" "$canonical" "$task" "$desired" "$board_state" "$status"
+          desired=$board_state
+          synced=$board_state
         fi
-        continue
-      fi
       # A write is outstanding. The board still showing the last confirmed value
       # is this adapter's own lag, not a captain edit.
-      if [ "$board_state" = "$desired" ]; then
+      elif [ "$board_state" = "$desired" ]; then
         links_put "$project" "$canonical" "$task" "$desired" "$desired" "$pr" "$pr_synced"
+        synced=$desired
         printf 'linked %s %s %s %s\n' "$project" "$canonical" "$task" "$desired"
       elif [ "$board_state" = "$synced" ]; then
         column=$(state_column "$desired" "$todo" "$in_progress" "$done_col") || column=
-        if [ -n "$column" ] && board_set_status "$owner" "$number" "$status_field" "$limit" "$canonical" "$column"; then
+        if [ -n "$column" ] && board_write_status "$owner" "$number" "$status_field" "$id" "$canonical" "$column"; then
           links_put "$project" "$canonical" "$task" "$desired" "$desired" "$pr" "$pr_synced"
+          synced=$desired
           printf 'synced %s %s %s %s\n' "$project" "$canonical" "$task" "$desired"
         else
           printf 'stale %s %s %s %s\n' "$project" "$canonical" "$task" "$desired"
@@ -832,11 +957,29 @@ poll_board() {
         links_put "$project" "$canonical" "$task" "$board_state" "$board_state" "$pr" "$pr_synced"
         printf 'instruction %s %s %s %s %s %s\n' \
           "$project" "$canonical" "$task" "$desired" "$board_state" "$status"
+        desired=$board_state
+        synced=$board_state
+      fi
+      # An outstanding PR attachment is retried exactly like an outstanding card
+      # move, because `pr` promised the next cycle would reconcile it.
+      if [ "$pr" != - ] && [ "$pr_synced" != 1 ]; then
+        if board_comment "$canonical" "Working PR: $pr"; then
+          links_put "$project" "$canonical" "$task" "$desired" "$synced" "$pr" 1
+          printf 'synced %s %s %s %s\n' "$project" "$canonical" "$task" "$pr"
+        else
+          printf 'stale %s %s %s %s\n' "$project" "$canonical" "$task" "$pr"
+        fi
       fi
       continue
     fi
 
-    # Not linked yet: intake needs the Todo column and an explicit trigger.
+    # Not linked yet, so from here on this is intake alone. A draft card or a
+    # pull request is not a real issue, and an issue outside the configured repo
+    # is not this board's work to take.
+    [ "$type" = Issue ] || continue
+    if [ "$repo" != - ] && [ "$(issue_repo "$canonical")" != "$repo" ]; then
+      continue
+    fi
     [ "$board_state" = todo ] || continue
     trigger=
     if list_has "$labels" "$label"; then
@@ -861,28 +1004,25 @@ poll_board() {
   elif [ "$count" -eq 0 ] && [ -n "$(cmd_links "$project")" ]; then
     printf 'error %s the board returned no cards while links are open\n' "$project"
   else
-    while IFS= read -r row; do
-      [ "$(links_field "$row" 1)" = "$project" ] || continue
-      canonical=$(links_field "$row" 2)
-      if grep -Fqx -- "$canonical" "$seen_file"; then
+    while IFS=$TAB read -r l_project l_issue l_task l_desired _ _ _; do
+      [ "$l_project" = "$project" ] || continue
+      if grep -Fqx -- "$l_issue" "$seen_file"; then
         continue
       fi
-      desired=$(links_field "$row" 4)
       # Leaving the board after Done is archiving, and an acknowledged
       # withdrawal is already reconciled; neither is an open instruction.
-      case "$desired" in
+      case "$l_desired" in
         todo | in-progress) ;;
         *) continue ;;
       esac
-      task=$(links_field "$row" 3)
-      printf 'cancelled %s %s %s %s\n' "$project" "$canonical" "$task" "$desired"
+      printf 'cancelled %s %s %s %s\n' "$project" "$l_issue" "$l_task" "$l_desired"
     done < <(links_rows)
   fi
   rm -f "$seen_file"
 }
 
 cmd_poll() {
-  local want='' limit=200 board items project owner number status_field
+  local want='' limit=$DEFAULT_LIMIT board items project owner number status_field
   while [ "$#" -gt 0 ]; do
     case "$1" in
       --limit)
@@ -901,9 +1041,7 @@ cmd_poll() {
         ;;
     esac
   done
-  case "$limit" in
-    '' | *[!0-9]* | 0) die "--limit must be a positive number" ;;
-  esac
+  limit_valid "$limit" || die "--limit must be a positive number"
   if [ -n "$want" ]; then
     board_for "$want" >/dev/null
   fi

--- a/bin/fm-board.sh
+++ b/bin/fm-board.sh
@@ -14,6 +14,10 @@
 #   fm-board.sh boards [<project>]
 #   fm-board.sh poll [<project>] [--limit <n>]
 #   fm-board.sh import <project> <issue-url> <task-id>
+#   fm-board.sh place <project> <task-id> <title> [<body>] [--lands-in <owner/name>]
+#   fm-board.sh child-add <project> <parent-issue-url> <title> <body> <task-id>
+#   fm-board.sh decomposed <project> <parent-issue-url>
+#   fm-board.sh decompositions [<project>]
 #   fm-board.sh links [<project>]
 #   fm-board.sh lookup <issue-url|task-id>
 #   fm-board.sh mark <task-id> todo|in-progress|done [--limit <n>]
@@ -42,6 +46,22 @@
 #   todo = Todo                  # default: Todo
 #   in-progress = In Progress    # default: In Progress
 #   done = Done                  # default: Done
+#   queued = Queued              # optional; default: off
+#   big-picture-todo = Big Picture Todo              # optional; default: off
+#   big-picture-in-progress = Big Picture In Progress  # optional; default: off
+#   big-picture-done = Big Picture Done              # optional; default: off
+#
+# `queued` is optional and off by default. Configured, it names the column a card
+# sits in once firstmate has been cleared to launch the work. Unconfigured, no
+# card is ever read or written as queued and the adapter behaves exactly as it
+# did before the key existed.
+#
+# The three `big-picture-*` keys are the whole on switch for decomposition and
+# default to unset. With none of them set this adapter behaves exactly as it did
+# before they existed: no card is ever classified as a container and `decompose`
+# is never printed. Setting some but not all three is a configuration error
+# rather than a half-enabled feature, and so is naming a column that a
+# `todo`, `in-progress`, or `done` key already names.
 #
 # INERT UNTIL CONFIGURED. This is a contract, not a side effect. With no
 # `config/boards` file, or an empty one, this adapter performs zero board reads
@@ -53,8 +73,9 @@
 # OFF SWITCH. Deleting or emptying `config/boards` fully disables the bridge and
 # leaves no residue: there is no generated poll, watcher check, cadence file,
 # daemon, or background process to unwind, because none was ever created. The
-# only file this adapter ever writes is data/board-links.tsv, and an unconfigured
-# home never reads it into any behavior.
+# only files this adapter ever writes are data/board-links.tsv and
+# data/board-decompositions.tsv, and an unconfigured home never reads either of
+# them into any behavior.
 #
 # WHAT DISABLING DOES NOT UNDO, by design. Work already done stays done: issues
 # and backlog items already imported remain, comments already posted on an issue
@@ -87,12 +108,100 @@
 #   project  issue  task  desired  synced  pr  pr_synced
 # `desired` is the column state firstmate's execution events call for and
 # `synced` is the last state this adapter confirmed on the board, both drawn
-# from todo|in-progress|done|other. They differ exactly while a board write is
+# from todo|queued|in-progress|done|other. They differ exactly while a board write is
 # outstanding, which is what makes a failed write retryable on the next cycle.
 # `other` is a column the captain added that firstmate does not drive; it is
 # recorded so their intent is preserved, not so a fourth execution state exists.
 # No column is ever empty: `-` is the placeholder, because bash collapses empty
 # tab-separated fields when it reads them back.
+#
+# DECOMPOSITION. A big-picture card is a container: an issue whose children are
+# the real work. No worker can ship a container, so a container must never spend
+# the one issue-to-task binding above, and this adapter makes that structural
+# rather than conventional. `poll` never prints `new` for a card sitting in a
+# big-picture column, `import` refuses an issue that holds a decomposition
+# record, and `child-add` refuses a parent that holds a link. Neither record can
+# therefore be reached from the other's side. `poll` writes a container's record
+# the first time it sees the card rather than when it is decomposed, so the
+# refusal covers every container the board has ever shown, not only the ones
+# already broken down.
+#
+# `poll` prints `decompose <project> <parent-issue-url>` for a real issue in the
+# big-picture Todo column that carries the configured label and is not yet
+# recorded as decomposed. Deciding what a container breaks down into is
+# judgement, so this script never invents children: firstmate reads that line,
+# runs `child-add` once per piece of work, and closes the container with
+# `decomposed`. Like `new`, a `decompose` line repeats every cycle until that
+# closing command runs, so an interrupted decomposition is finished rather than
+# lost; once closed it is never printed again, however long ago it was closed.
+#
+# data/board-decompositions.tsv is that durable record, alongside the linkage
+# record and for the same reason: it must outlive task cleanup, so a parent
+# decomposed months ago is never decomposed a second time. One row per parent,
+# tab separated, `-` for an empty column:
+#   project  parent  state  desired  synced  children
+# `state` is open while children are being created and done once `decomposed`
+# closed it. `children` is `-`, or a comma-separated list of `task=child-url`
+# pairs; neither half can contain a comma or an `=`, so the pair parses back
+# unambiguously. `desired` and `synced` carry the parent card's status exactly as
+# the linkage record's own two columns do.
+#
+# PLACEMENT, the inverse of import. `place` puts a task firstmate already holds
+# onto the board: it creates the issue, cards it, sets it to Todo, and records
+# the link, after which dispatch, PR attachment, and merge all reflect through
+# the ordinary events with no further special casing. `child-add` is the same
+# operation with a parent - it additionally creates the issue as a native GitHub
+# sub-issue of the container and records the child against it - so both verbs run
+# one shared implementation rather than two that can drift.
+#
+# Both create the issue in the board's configured repo (a board with no `repo`
+# key uses the parent's repo for a child, and refuses `place` because it has no
+# repo to choose), carrying the trigger label. `place` takes an optional
+# `--lands-in <owner/name>` that states on the card which repository the change
+# actually lands in; pass it whenever that is not the repository the issue itself
+# is filed in, so a roadmap never implies a diff is somewhere it is not.
+#
+# Which tasks belong on a board is an editorial call this script never makes.
+# There is deliberately no command that sweeps unlinked tasks onto a board:
+# placement is one task at a time, by a caller that decided that task belongs
+# there.
+#
+# Because the created issue carries the label and holds a link before the next
+# cycle reads the board, `poll` reports it as `linked` and can never offer it as
+# `new`.
+#
+# The failure contract has two halves, split at the one irreversible step.
+# Creating the issue is the command's whole purpose, so a creation that does not
+# land writes nothing, reports the failure, and exits 1 - there is nothing to
+# converge toward and firstmate must not build a backlog item on it. Every step
+# after creation degrades fail-soft: the command prints `placed-partial` or
+# `child-partial` naming the first step that did not land, and exits 0.
+#
+# Repeating either command converges instead of filing a second issue for the
+# same work, through three guards in falling order of cost. A task that already
+# holds a link is finished, and answers `already-placed` with no network call at
+# all - the link is written last precisely so that holding one proves the rest
+# landed. A child already recorded against its parent is reused rather than
+# created. Otherwise, before creating anything, the repo's most recent issues are
+# read and one already carrying this task's `firstmate-task:` marker is adopted;
+# that scan is deliberately shallow because the only gap it closes is an issue
+# created moments before an interruption.
+#
+# The link is written as soon as the card exists rather than at the very end, so
+# a card on the board is never briefly importable as new work; its `synced` stays
+# unconfirmed until the column write lands, which leaves the ordinary outstanding
+# -write retry to finish the job on the next cycle.
+#
+# PARENT STATUS. Once a parent has children, `poll` keeps its card honest from
+# their recorded states: any child in progress derives in-progress, all children
+# done derives done, and anything else derives todo. A child recorded in a column
+# firstmate does not drive is left out of that entirely, because a withdrawn
+# child must not hold its parent short of done forever. The derived state moves
+# the card through the three big-picture columns exactly as `mark` moves an
+# ordinary card, is retried on the next cycle when the write does not land, and
+# is reported with the same `synced` and `stale` vocabulary. A parent already
+# showing what firstmate recorded prints nothing at all, and one showing anything
+# firstmate did not write diverges exactly as any other card does.
 #
 # FAIL SOFT. Every board write degrades to a stale board instead of blocking
 # delivery: `mark`, `pr`, and `note` exit 0 whether or not the write landed,
@@ -102,15 +211,34 @@
 # board read failure, reporting it as an `error` line. A read that cannot tell
 # absence from its own limits - a full page, or a board answering with no cards
 # at all while links are open - says so and reconciles nothing rather than
-# guessing. Only a usage or
-# configuration error exits non-zero, and a refused conflicting relink exits 3.
+# guessing. Exiting non-zero is reserved for the three things a caller must not
+# proceed past: a usage or configuration error exits 2, a refused conflicting
+# relink or container-versus-task conflict exits 3, and an issue this adapter was
+# asked to create but could not exits 1, as PLACEMENT above sets out.
 #
-# WHO WINS. When the board disagrees with a record, the board is a captain
-# instruction: `poll` adopts the board's state into the record and reports an
-# `instruction` line for firstmate to reconcile the backlog to. It never writes
-# firstmate's state back over the captain's edit. The one exception is an
-# outstanding write the board has not taken yet, which is retried because the
-# board still shows the value this adapter last confirmed.
+# DIRECTION OF AUTHORITY. Firstmate's own durable records are the truth and the
+# board is how that truth is shown; chat, not the board, is where the captain
+# controls the work. So status flows one way, outward: this adapter writes
+# todo, queued, in-progress, and done onto a card from what firstmate already
+# recorded, and a card's column never tells firstmate what to do.
+#
+# That makes a status this adapter did not write a divergence rather than an
+# instruction. `poll` prints a `divergence` line, writes nothing to the record,
+# writes nothing to the board, and leaves it for firstmate to raise with the
+# captain; the deliberate exception is a write still outstanding, which is
+# retried because the board is showing the value this adapter last confirmed
+# rather than a change to it. A card that appears in the queued column without
+# firstmate having put it there can only mean something outside firstmate wrote
+# to this board, which is why nothing here reconciles it in either direction and
+# nothing about it starts work.
+#
+# Intake is the one thing the board still states rather than reports: a new
+# labelled card is the captain adding work, and `new` continues to mean exactly
+# that.
+#
+# An explicit `mark` is how a divergence is resolved, because it is firstmate
+# acting rather than the adapter reconciling behind the captain's back: it writes
+# the card and records what it confirmed, and the divergence stops being reported.
 #
 # An issue that a different configured board already owns is a misconfiguration
 # rather than an instruction, so `poll` names it in a `foreign` line carrying the
@@ -119,13 +247,23 @@
 # board. `import` stays fleet-wide: an issue linked under any project can never
 # be imported a second time under another one.
 #
-# A card that left the board is the captain withdrawing work firstmate is still
-# executing, so `poll` keeps reporting it as `cancelled` until `ack` records that
-# the withdrawal was reconciled. Repeating survives a missed cycle; a card that
-# left after reaching Done is ordinary archiving and is never reported. Neither
-# reporting nor acknowledging a withdrawal ever authorizes discarding unlanded
-# work: hard rule 3 stands, and this adapter touches no branch, worktree, or
-# repository.
+# A card that left the board while firstmate was still executing it is reported
+# as `cancelled` until `ack` records that it was reconciled. Repeating survives a
+# missed cycle; a card that left after reaching Done is ordinary archiving and is
+# never reported. Like a divergence it is something to raise, not something this
+# adapter acts on, and neither reporting nor acknowledging one ever authorizes
+# discarding unlanded work: hard rule 3 stands, and this adapter touches no
+# branch, worktree, or repository.
+#
+# COST. Board and Projects work is GraphQL with its own hourly budget, and a
+# full board read inside a per-item loop is what exhausts it. So one
+# reconciliation cycle reads the board exactly once and every write it then makes
+# reuses a card id from that one read; `place` and `child-add` read no board at
+# all, taking their card id from what the add itself returned, because a freshly
+# added card is not immediately visible in a board listing anyway. The project,
+# field, and option node IDs are resolved once per invocation and cached. Their
+# cost is therefore a small constant per card rather than a function of how many
+# cards the board carries.
 #
 # GITHUB CLI. This adapter calls `gh` rather than `gh-axi`, and adds no new
 # dependency because `gh` is already part of firstmate's universal toolchain
@@ -149,6 +287,7 @@ CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 BOARDS_FILE="$CONFIG/boards"
 LINKS="$DATA/board-links.tsv"
+DECOMPS="$DATA/board-decompositions.tsv"
 GH="${FM_BOARD_GH:-gh}"
 TAB=$'\t'
 # One board read's ceiling, shared by `poll` and the card lookup `mark` needs.
@@ -188,22 +327,47 @@ CONFIG_SLUG_RE='^[A-Za-z0-9._-]+$'
 # Emits the stanza being accumulated by boards_emit. Called only from there, and
 # deliberately reads that caller's locals rather than taking eleven arguments.
 boards_flush() {
+  local set_count=0 name norm seen_cols=
   [ -n "$project" ] || return 0
   [ "$owner" != - ] || die "config/boards: board \"$project\" has no owner"
   [ "$number" != - ] || die "config/boards: board \"$project\" has no number"
-  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+  # The three big-picture columns are one switch, not three independent keys: a
+  # partial set would classify some containers and not others, so it is refused
+  # here rather than half-enabled.
+  for name in "$bp_todo" "$bp_in_progress" "$bp_done"; do
+    [ "$name" = - ] || set_count=$((set_count + 1))
+  done
+  if [ "$set_count" != 0 ] && [ "$set_count" != 3 ]; then
+    die "config/boards: board \"$project\" sets some big-picture columns but not all three (big-picture-todo, big-picture-in-progress, big-picture-done)"
+  fi
+  # Two keys naming one column would make a single card mean two different
+  # things, so every configured column name has to be distinct.
+  for name in "$todo" "$in_progress" "$done_col" "$queued" "$bp_todo" \
+    "$bp_in_progress" "$bp_done"; do
+    [ "$name" != - ] || continue
+    norm=$(norm_name "$name")
+    case "$TAB$seen_cols" in
+      *"$TAB$norm$TAB"*)
+        die "config/boards: board \"$project\" gives \"$name\" as more than one column"
+        ;;
+    esac
+    seen_cols="$seen_cols$norm$TAB"
+  done
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
     "$project" "$owner" "$number" "$repo" "$label" "$mention" "$assignee" \
-    "$status_field" "$todo" "$in_progress" "$done_col"
+    "$status_field" "$todo" "$in_progress" "$done_col" \
+    "$bp_todo" "$bp_in_progress" "$bp_done" "$queued"
 }
-
 boards_emit() {
   local line key value project owner number repo label mention assignee
   local status_field todo in_progress done_col lineno=0 seen=
+  local bp_todo bp_in_progress bp_done queued
   [ -f "$BOARDS_FILE" ] || return 0
 
   project=''
   owner=- number=- repo=- label=firstmate mention=- assignee=-
   status_field=Status todo=Todo in_progress='In Progress' done_col=Done
+  bp_todo=- bp_in_progress=- bp_done=- queued=-
   while IFS= read -r line || [ -n "$line" ]; do
     lineno=$((lineno + 1))
     line=${line%$'\r'}
@@ -236,6 +400,7 @@ boards_emit() {
       project=$value
       owner=- number=- repo=- label=firstmate mention=- assignee=-
       status_field=Status todo=Todo in_progress='In Progress' done_col=Done
+      bp_todo=- bp_in_progress=- bp_done=- queued=-
       continue
     fi
     [ -n "$project" ] || die "config/boards line $lineno: \"$key\" appears before any project"
@@ -258,7 +423,8 @@ boards_emit() {
           *) die "config/boards line $lineno: repo \"$value\" is not owner/name" ;;
         esac
         ;;
-      label | todo | in-progress | done | status-field)
+      label | todo | in-progress | done | queued | status-field \
+        | big-picture-todo | big-picture-in-progress | big-picture-done)
         [[ $value =~ $CONFIG_VALUE_RE ]] \
           || die "config/boards line $lineno: \"$key\" may use only letters, digits, spaces, dot, underscore, and dash"
         case "$key" in
@@ -267,6 +433,10 @@ boards_emit() {
           in-progress) in_progress=$value ;;
           done) done_col=$value ;;
           status-field) status_field=$value ;;
+          queued) queued=$value ;;
+          big-picture-todo) bp_todo=$value ;;
+          big-picture-in-progress) bp_in_progress=$value ;;
+          big-picture-done) bp_done=$value ;;
         esac
         ;;
       mention)
@@ -392,6 +562,122 @@ links_put() {
   printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
     "$project" "$issue" "$task" "$desired" "$synced" "${pr:--}" "${pr_synced:--}" >> "$tmp"
   mv -f "$tmp" "$LINKS" || { rm -f "$tmp"; die "cannot replace the linkage record" 1; }
+}
+
+# --- durable decomposition record -------------------------------------------
+#
+# One row per container, kept for the same reason the linkage record is: a
+# parent decomposed long ago must never be offered for decomposition again.
+
+DECOMPS_HEADER="# fm-board.sh durable decompositions: project${TAB}parent${TAB}state${TAB}desired${TAB}synced${TAB}children"
+
+decomps_rows() {
+  local row
+  [ -f "$DECOMPS" ] || return 0
+  while IFS= read -r row || [ -n "$row" ]; do
+    case "$row" in
+      '' | '#'*) continue ;;
+    esac
+    printf '%s\n' "$row"
+  done < "$DECOMPS"
+}
+
+DECOMP_PROJECT=- DECOMP_PARENT=- DECOMP_STATE=-
+DECOMP_DESIRED=- DECOMP_SYNCED=- DECOMP_CHILDREN=-
+
+decomp_clear() {
+  DECOMP_PROJECT=- DECOMP_PARENT=- DECOMP_STATE=-
+  DECOMP_DESIRED=- DECOMP_SYNCED=- DECOMP_CHILDREN=-
+}
+
+# decomps_find <parent-issue-url>: leave the matching row in the DECOMP_
+# variables and print it, or clear them and return 1. Like links_find, callers
+# read the variables, so this never runs inside a command substitution.
+decomps_find() {
+  local want=$1 found=
+  while IFS=$TAB read -r DECOMP_PROJECT DECOMP_PARENT DECOMP_STATE \
+    DECOMP_DESIRED DECOMP_SYNCED DECOMP_CHILDREN; do
+    [ "$DECOMP_PARENT" = "$want" ] || continue
+    found=1
+    break
+  done < <(decomps_rows)
+  if [ -z "$found" ]; then
+    decomp_clear
+    return 1
+  fi
+  printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$DECOMP_PROJECT" "$DECOMP_PARENT" "$DECOMP_STATE" \
+    "$DECOMP_DESIRED" "$DECOMP_SYNCED" "$DECOMP_CHILDREN"
+}
+
+# decomps_put <project> <parent> <state> <desired> <synced> <children>
+decomps_put() {
+  local project=$1 parent=$2 state=$3 desired=$4 synced=$5 children=$6
+  local tmp r_project r_parent r_state r_desired r_synced r_children
+  mkdir -p "$DATA" || die "cannot create $DATA" 1
+  tmp=$(umask 077; mktemp "$DATA/.board-decompositions.XXXXXX") \
+    || die "cannot write the decomposition record" 1
+  printf '%s\n' "$DECOMPS_HEADER" > "$tmp"
+  while IFS=$TAB read -r r_project r_parent r_state r_desired \
+    r_synced r_children; do
+    [ "$r_parent" != "$parent" ] || continue
+    printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+      "$r_project" "$r_parent" "$r_state" "$r_desired" \
+      "$r_synced" "$r_children" >> "$tmp"
+  done < <(decomps_rows)
+  printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$project" "$parent" "$state" "$desired" "$synced" "$children" >> "$tmp"
+  mv -f "$tmp" "$DECOMPS" || { rm -f "$tmp"; die "cannot replace the decomposition record" 1; }
+}
+
+# The children column packs one `task=child-url` pair per child, comma
+# separated. Neither half can hold a comma or an `=`, so splitting on those two
+# characters recovers the pairs exactly.
+
+# children_pairs <children>: print one `task=url` pair per line.
+children_pairs() {
+  local children=${1:--} pair rest
+  [ "$children" != - ] || return 0
+  rest=$children
+  while [ -n "$rest" ]; do
+    pair=${rest%%,*}
+    if [ "$pair" = "$rest" ]; then
+      rest=
+    else
+      rest=${rest#*,}
+    fi
+    [ -z "$pair" ] || printf '%s\n' "$pair"
+  done
+}
+
+# children_child_for <children> <task-id>: print that task's recorded child URL.
+children_child_for() {
+  local children=$1 task=$2 pair
+  while IFS= read -r pair; do
+    [ "${pair%%=*}" = "$task" ] || continue
+    printf '%s\n' "${pair#*=}"
+    return 0
+  done < <(children_pairs "$children")
+  return 1
+}
+
+# children_add <children> <task-id> <child-url>: print the list with that pair
+# added, replacing any pair the same task already holds.
+children_add() {
+  local children=$1 task=$2 url=$3 pair out=
+  while IFS= read -r pair; do
+    [ "${pair%%=*}" != "$task" ] || continue
+    out="${out:+$out,}$pair"
+  done < <(children_pairs "$children")
+  printf '%s\n' "${out:+$out,}$task=$url"
+}
+
+# children_tasks <children>: print one child task id per line.
+children_tasks() {
+  local pair
+  while IFS= read -r pair; do
+    printf '%s\n' "${pair%%=*}"
+  done < <(children_pairs "${1:--}")
 }
 
 # --- identifiers ------------------------------------------------------------
@@ -626,6 +912,97 @@ board_set_status() {
   board_write_status "$owner" "$number" "$status_field" "$item_id" "$issue" "$option_name"
 }
 
+# board_item_add <owner> <number> <issue-url>: card an issue and print the item
+# id the add itself returned. The id is taken from the add's own answer and
+# never by re-reading the board, because a freshly added card is not immediately
+# visible in a board listing.
+board_item_add() {
+  local owner=$1 number=$2 issue=$3 id
+  id=$("$GH" project item-add "$number" --owner "$owner" --url "$issue" \
+    --format json --jq '.id' </dev/null) || {
+    warn "could not add $issue to project $owner/$number"
+    return 1
+  }
+  [ -n "$id" ] || {
+    warn "adding $issue to project $owner/$number returned no card id"
+    return 1
+  }
+  printf '%s\n' "$id"
+}
+
+# Every issue this adapter creates carries this marker line in its body, so an
+# issue created moments before an interruption can be recognized rather than
+# filed a second time.
+MARKER_PREFIX='firstmate-task:'
+# How far back the recovery scan looks. Deliberately shallow: the only gap it
+# closes is an issue created seconds ago, which is necessarily among the newest.
+MARKER_SCAN_LIMIT=30
+
+issue_marker() {
+  printf '%s %s\n' "$MARKER_PREFIX" "$1"
+}
+
+# issue_find_by_marker <repo> <task-id>: print the URL of a recent issue already
+# carrying this task's marker, or fail. The match is made here rather than in the
+# query so the scan stays one plain listing of recent issues.
+issue_find_by_marker() {
+  local repo=$1 task=$2 marker tmp url body found=
+  marker=$(issue_marker "$task")
+  tmp=$(mktemp) || return 1
+  if "$GH" issue list --repo "$repo" --state all --limit "$MARKER_SCAN_LIMIT" \
+    --json url,body \
+    --jq '.[] | [(.url // ""), ((.body // "") | gsub("[\\n\\t\\r]+"; " "))] | @tsv' \
+    > "$tmp" </dev/null; then
+    while IFS=$TAB read -r url body; do
+      case "$body" in
+        *"$marker"*) ;;
+        *) continue ;;
+      esac
+      found=$(issue_canonical "$url") || continue
+      break
+    done < "$tmp"
+  else
+    rm -f "$tmp"
+    warn "could not read the recent issues of $repo"
+    return 2
+  fi
+  rm -f "$tmp"
+  [ -n "$found" ] || return 1
+  printf '%s\n' "$found"
+}
+
+# issue_body <body> <task-id> <lands-in|->: the issue body actually filed.
+issue_body() {
+  local body=$1 task=$2 lands_in=$3 out=
+  [ "$body" = - ] || out=$body
+  if [ "$lands_in" != - ]; then
+    out="${out:+$out
+
+}Lands in: $lands_in"
+  fi
+  printf '%s\n' "${out:+$out
+
+}$(issue_marker "$task")"
+}
+
+# issue_create <repo> <label> <title> <body> <parent|-> : print the new issue URL.
+# A child is created as a native sub-issue in this same call, so a parent link is
+# never a separate step that can be left half-done.
+issue_create() {
+  local repo=$1 label=$2 title=$3 body=$4 parent=$5
+  local args url line
+  args=(issue create --repo "$repo" --title "$title" --body "$body" --label "$label")
+  [ "$parent" = - ] || args+=(--parent "$parent")
+  url=''
+  while IFS= read -r line; do
+    case "$line" in
+      https://*/issues/*) url=$line ;;
+    esac
+  done < <("$GH" "${args[@]}" </dev/null)
+  [ -n "$url" ] || return 1
+  issue_canonical "$url"
+}
+
 # board_comment <issue-url> <body>
 # Runs from inside poll's item loop, so it never inherits the board read on
 # stdin.
@@ -639,22 +1016,27 @@ board_comment() {
 
 # --- state vocabulary -------------------------------------------------------
 #
-# Todo, In Progress, and Done are the whole mapping. A column the captain added
-# is recorded as "other" so their intent survives, never as a fourth state
-# firstmate drives.
+# Todo, In Progress, and Done are always drivable, and a configured queued column
+# joins them. Firstmate writes all four from its own records. A column that is
+# none of them is read as "other": the adapter neither drives it nor pretends to
+# understand it, and a card sitting in one diverges from what firstmate recorded.
 
 state_column() {
-  local state=$1 todo=$2 in_progress=$3 done_col=$4
+  local state=$1 todo=$2 in_progress=$3 done_col=$4 queued=${5:--}
   case "$state" in
     todo) printf '%s\n' "$todo" ;;
     in-progress) printf '%s\n' "$in_progress" ;;
     done) printf '%s\n' "$done_col" ;;
+    queued)
+      [ "$queued" != - ] || return 1
+      printf '%s\n' "$queued"
+      ;;
     *) return 1 ;;
   esac
 }
 
 column_state() {
-  local raw=$1 todo=$2 in_progress=$3 done_col=$4 want
+  local raw=$1 todo=$2 in_progress=$3 done_col=$4 queued=${5:--} want
   want=$(norm_name "$raw")
   if [ "$want" = "$(norm_name "$todo")" ]; then
     printf 'todo\n'
@@ -662,8 +1044,40 @@ column_state() {
     printf 'in-progress\n'
   elif [ "$want" = "$(norm_name "$done_col")" ]; then
     printf 'done\n'
+  elif [ "$queued" != - ] && [ "$want" = "$(norm_name "$queued")" ]; then
+    printf 'queued\n'
   else
     printf 'other\n'
+  fi
+}
+
+# The big-picture columns carry the same three states, on a parallel set of
+# column names. They are the container lane, never a fourth execution state.
+
+bp_state_column() {
+  local state=$1 bp_todo=$2 bp_in_progress=$3 bp_done=$4
+  case "$state" in
+    todo) printf '%s\n' "$bp_todo" ;;
+    in-progress) printf '%s\n' "$bp_in_progress" ;;
+    done) printf '%s\n' "$bp_done" ;;
+    *) return 1 ;;
+  esac
+}
+
+# bp_column_state <raw> <bp_todo> <bp_in_progress> <bp_done>: the container state
+# that column names, or nothing at all when it names no big-picture column.
+bp_column_state() {
+  local raw=$1 bp_todo=$2 bp_in_progress=$3 bp_done=$4 want
+  [ "$bp_todo" != - ] || return 1
+  want=$(norm_name "$raw")
+  if [ "$want" = "$(norm_name "$bp_todo")" ]; then
+    printf 'todo\n'
+  elif [ "$want" = "$(norm_name "$bp_in_progress")" ]; then
+    printf 'in-progress\n'
+  elif [ "$want" = "$(norm_name "$bp_done")" ]; then
+    printf 'done\n'
+  else
+    return 1
   fi
 }
 
@@ -693,16 +1107,22 @@ list_has() {
 
 cmd_boards() {
   local want=${1:-} project owner number repo label mention assignee
-  local status_field todo in_progress done_col
+  local status_field todo in_progress done_col bp_todo bp_in_progress bp_done
+  local queued big
   while IFS=$'\t' read -r project owner number repo label mention assignee \
-    status_field todo in_progress done_col; do
+    status_field todo in_progress done_col bp_todo bp_in_progress bp_done queued; do
     [ -n "$project" ] || continue
     if [ -n "$want" ] && [ "$want" != "$project" ]; then
       continue
     fi
-    printf 'board %s %s/%s repo=%s label=%s mention=%s assignee=%s field=%s columns=%s|%s|%s\n' \
+    if [ "$bp_todo" = - ]; then
+      big=off
+    else
+      big="$bp_todo|$bp_in_progress|$bp_done"
+    fi
+    printf 'board %s %s/%s repo=%s label=%s mention=%s assignee=%s field=%s columns=%s|%s|%s queued=%s big-picture=%s\n' \
       "$project" "$owner" "$number" "$repo" "$label" "$mention" "$assignee" \
-      "$status_field" "$todo" "$in_progress" "$done_col"
+      "$status_field" "$todo" "$in_progress" "$done_col" "$queued" "$big"
   done < <(boards_rows)
 }
 
@@ -742,6 +1162,12 @@ cmd_import() {
     die "$issue is not in $repo, the repo configured for board \"$project\""
   fi
 
+  # A container's children are the real work, so the container itself must never
+  # spend the one binding an issue has. With poll never offering a big-picture
+  # card for import, this closes the other direction.
+  if decomps_find "$issue" >/dev/null; then
+    die "$issue is a decomposition container on board \"$DECOMP_PROJECT\"; its children hold the work" 3
+  fi
   # This duplicate check is deliberately fleet-wide rather than scoped to one
   # board: an issue holds at most one task no matter which board carries it.
   if links_find issue "$issue" >/dev/null; then
@@ -759,10 +1185,241 @@ cmd_import() {
   printf 'linked %s %s %s\n' "$project" "$issue" "$task"
 }
 
+# --- shared placement -------------------------------------------------------
+#
+# `place` and `child-add` are one operation with different parents, so they run
+# the same two steps here rather than two implementations that can drift.
+
+CARD_STEP=
+
+# card_ensure <project> <owner> <number> <status_field> <todo-column> <issue> <task>
+# Card the issue, record the issue-to-task link, and set it to the ordinary Todo
+# column. The link is written the moment the card exists so the next cycle can
+# never offer it as new work, and its `synced` stays unconfirmed until the column
+# write lands, which leaves poll's ordinary outstanding-write retry to finish it.
+card_ensure() {
+  local project=$1 owner=$2 number=$3 status_field=$4 column=$5 issue=$6 task=$7
+  local item_id pr=- pr_synced=-
+  CARD_STEP=
+  item_id=$(board_item_add "$owner" "$number" "$issue") || {
+    CARD_STEP=card
+    return 1
+  }
+  if links_find issue "$issue" >/dev/null; then
+    pr=$LINK_PR
+    pr_synced=$LINK_PR_SYNCED
+  fi
+  links_put "$project" "$issue" "$task" todo other "$pr" "$pr_synced"
+  if ! board_write_status "$owner" "$number" "$status_field" "$item_id" "$issue" "$column"; then
+    CARD_STEP=status
+    return 1
+  fi
+  links_put "$project" "$issue" "$task" todo todo "$pr" "$pr_synced"
+  return 0
+}
+
+# issue_ensure <repo> <label> <title> <body> <task> <parent|-> <known-url|->
+# Print the issue that carries this task's work, creating it only when neither
+# the caller's own record nor a shallow scan of the repo's newest issues already
+# holds one. A scan that cannot run stops the command instead of creating, so a
+# transient read failure can never file the same work twice.
+issue_ensure() {
+  local repo=$1 label=$2 title=$3 body=$4 task=$5 parent=$6 known=$7 url rc=0
+  if [ "$known" != - ]; then
+    printf '%s\n' "$known"
+    return 0
+  fi
+  url=$(issue_find_by_marker "$repo" "$task") || rc=$?
+  case "$rc" in
+    0)
+      printf '%s\n' "$url"
+      return 0
+      ;;
+    # A scan that could not run is not the same answer as one that found
+    # nothing, so it refuses rather than risk filing a second issue.
+    1) ;;
+    *) return 1 ;;
+  esac
+  issue_create "$repo" "$label" "$title" "$body" "$parent"
+}
+
+cmd_place() {
+  local project='' task='' title='' body=- lands_in=-
+  local board owner number repo label status_field todo issue
+  local PLACE_USAGE='usage: fm-board.sh place <project> <task-id> <title> [<body>] [--lands-in <owner/name>]'
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --lands-in)
+        [ "$#" -gt 1 ] || die "--lands-in needs a value"
+        lands_in=$2
+        shift 2
+        ;;
+      --lands-in=*)
+        lands_in=${1#--lands-in=}
+        shift
+        ;;
+      -*) die "unknown option \"$1\"" ;;
+      *)
+        if [ -z "$project" ]; then
+          project=$1
+        elif [ -z "$task" ]; then
+          task=$1
+        elif [ -z "$title" ]; then
+          title=$1
+        elif [ "$body" = - ]; then
+          body=$1
+        else
+          die "$PLACE_USAGE"
+        fi
+        shift
+        ;;
+    esac
+  done
+  if [ -z "$project" ] || [ -z "$task" ] || [ -z "$title" ]; then
+    die "$PLACE_USAGE"
+  fi
+  task_id_valid "$task" || die "\"$task\" is not a task id"
+  if [ "$lands_in" != - ]; then
+    case "$lands_in" in
+      */*/* | */ | /* | *' '*) die "--lands-in \"$lands_in\" is not owner/name" ;;
+      */*) ;;
+      *) die "--lands-in \"$lands_in\" is not owner/name" ;;
+    esac
+  fi
+
+  board=$(board_for "$project")
+  owner=$(printf '%s' "$board" | cut -f2)
+  number=$(printf '%s' "$board" | cut -f3)
+  repo=$(printf '%s' "$board" | cut -f4)
+  label=$(printf '%s' "$board" | cut -f5)
+  status_field=$(printf '%s' "$board" | cut -f8)
+  todo=$(printf '%s' "$board" | cut -f9)
+
+  # A task that already holds a link is finished, and says so without a single
+  # network call: the link is written last precisely so that holding one proves
+  # every earlier step landed.
+  if links_find task "$task" >/dev/null; then
+    printf 'already-placed %s %s %s\n' "$LINK_PROJECT" "$LINK_ISSUE" "$task"
+    return 0
+  fi
+  [ "$repo" != - ] \
+    || die "board \"$project\" has no repo key, so there is no repository to file a card in"
+
+  issue=$(issue_ensure "$repo" "$label" "$title" \
+    "$(issue_body "$body" "$task" "$lands_in")" "$task" - -) || {
+    printf 'error: could not create the issue for task %s in %s\n' "$task" "$repo" >&2
+    return 1
+  }
+  if card_ensure "$project" "$owner" "$number" "$status_field" "$todo" "$issue" "$task"; then
+    printf 'placed %s %s %s\n' "$project" "$issue" "$task"
+  else
+    printf 'placed-partial %s %s %s %s\n' "$project" "$issue" "$task" "$CARD_STEP"
+  fi
+  return 0
+}
+
+cmd_child_add() {
+  local project=${1:?usage: fm-board.sh child-add <project> <parent-issue-url> <title> <body> <task-id>}
+  local raw_parent=${2:?usage: fm-board.sh child-add <project> <parent-issue-url> <title> <body> <task-id>}
+  local title=${3:?usage: fm-board.sh child-add <project> <parent-issue-url> <title> <body> <task-id>}
+  local body=${4:?usage: fm-board.sh child-add <project> <parent-issue-url> <title> <body> <task-id>}
+  local task=${5:?usage: fm-board.sh child-add <project> <parent-issue-url> <title> <body> <task-id>}
+  local board owner number repo label status_field todo bp_todo
+  local parent known child state desired synced children
+
+  board=$(board_for "$project")
+  owner=$(printf '%s' "$board" | cut -f2)
+  number=$(printf '%s' "$board" | cut -f3)
+  repo=$(printf '%s' "$board" | cut -f4)
+  label=$(printf '%s' "$board" | cut -f5)
+  status_field=$(printf '%s' "$board" | cut -f8)
+  todo=$(printf '%s' "$board" | cut -f9)
+  bp_todo=$(printf '%s' "$board" | cut -f12)
+  [ "$bp_todo" != - ] \
+    || die "board \"$project\" has no big-picture columns configured, so it has no containers to decompose"
+  parent=$(issue_canonical "$raw_parent") || die "\"$raw_parent\" is not an issue URL"
+  task_id_valid "$task" || die "\"$task\" is not a task id"
+  # A container is work nobody can ship, so it must never hold the one binding an
+  # issue has. Refusing here is the other half of poll never offering a
+  # big-picture card for import.
+  if links_find issue "$parent" >/dev/null; then
+    die "$parent is linked to task $LINK_TASK, so it is ordinary work rather than a container" 3
+  fi
+  [ "$repo" != - ] || repo=$(issue_repo "$parent")
+
+  if decomps_find "$parent" >/dev/null; then
+    [ "$DECOMP_PROJECT" = "$project" ] \
+      || die "$parent is already decomposed under project $DECOMP_PROJECT" 3
+    state=$DECOMP_STATE
+    desired=$DECOMP_DESIRED
+    synced=$DECOMP_SYNCED
+    children=$DECOMP_CHILDREN
+  else
+    state=open desired=- synced=- children=-
+  fi
+
+  known=$(children_child_for "$children" "$task") || known=-
+  if [ "$known" = - ] && links_find task "$task" >/dev/null; then
+    die "task $task is already linked to $LINK_ISSUE" 3
+  fi
+  if [ "$known" != - ] && links_find task "$task" >/dev/null; then
+    printf 'already-child %s %s %s %s\n' "$project" "$parent" "$known" "$task"
+    return 0
+  fi
+
+  child=$(issue_ensure "$repo" "$label" "$title" \
+    "$(issue_body "$body" "$task" -)" "$task" "$parent" "$known") || {
+    printf 'error: could not create the child issue for task %s under %s\n' "$task" "$parent" >&2
+    return 1
+  }
+  # Recorded against the parent the instant it exists, so a run interrupted
+  # before the card lands is resumed rather than repeated.
+  children=$(children_add "$children" "$task" "$child")
+  decomps_put "$project" "$parent" "$state" "$desired" "$synced" "$children"
+
+  if card_ensure "$project" "$owner" "$number" "$status_field" "$todo" "$child" "$task"; then
+    printf 'child %s %s %s %s\n' "$project" "$parent" "$child" "$task"
+  else
+    printf 'child-partial %s %s %s %s %s\n' "$project" "$parent" "$child" "$task" "$CARD_STEP"
+  fi
+  return 0
+}
+
+cmd_decomposed() {
+  local project=${1:?usage: fm-board.sh decomposed <project> <parent-issue-url>}
+  local raw_parent=${2:?usage: fm-board.sh decomposed <project> <parent-issue-url>}
+  local parent
+  board_for "$project" >/dev/null
+  parent=$(issue_canonical "$raw_parent") || die "\"$raw_parent\" is not an issue URL"
+  if decomps_find "$parent" >/dev/null; then
+    [ "$DECOMP_PROJECT" = "$project" ] \
+      || die "$parent is decomposed under project $DECOMP_PROJECT" 3
+    decomps_put "$project" "$parent" 'done' "$DECOMP_DESIRED" \
+      "$DECOMP_SYNCED" "$DECOMP_CHILDREN"
+  else
+    decomps_put "$project" "$parent" 'done' - - -
+  fi
+  printf 'decomposed %s %s\n' "$project" "$parent"
+}
+
+cmd_decompositions() {
+  local want=${1:-} row
+  while IFS= read -r row; do
+    if [ -n "$want" ]; then
+      case "$row" in
+        "$want$TAB"*) ;;
+        *) continue ;;
+      esac
+    fi
+    printf '%s\n' "$row"
+  done < <(decomps_rows)
+}
+
 cmd_mark() {
   local task='' state='' limit=$DEFAULT_LIMIT
   local project issue synced pr pr_synced board
-  local owner number status_field todo in_progress done_col column
+  local owner number status_field todo in_progress done_col queued column
 
   while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -793,8 +1450,9 @@ cmd_mark() {
   fi
   limit_valid "$limit" || die "--limit must be a positive number"
   case "$state" in
-    todo | in-progress | done) ;;
-    *) die "unknown board state \"$state\" (use todo, in-progress, or done)" ;;
+    todo | in-progress | 'done') ;;
+    queued) ;;
+    *) die "unknown board state \"$state\" (use todo, queued, in-progress, or done)" ;;
   esac
   links_find task "$task" >/dev/null || die "task $task is not linked to a board issue"
   project=$LINK_PROJECT
@@ -809,7 +1467,9 @@ cmd_mark() {
   todo=$(printf '%s' "$board" | cut -f9)
   in_progress=$(printf '%s' "$board" | cut -f10)
   done_col=$(printf '%s' "$board" | cut -f11)
-  column=$(state_column "$state" "$todo" "$in_progress" "$done_col")
+  queued=$(printf '%s' "$board" | cut -f15)
+  column=$(state_column "$state" "$todo" "$in_progress" "$done_col" "$queued") \
+    || die "board \"$project\" has no queued column configured"
 
   links_put "$project" "$issue" "$task" "$state" "$synced" "$pr" "$pr_synced"
   if board_set_status "$owner" "$number" "$status_field" "$limit" "$issue" "$column"; then
@@ -882,13 +1542,17 @@ cmd_ack() {
 }
 
 # poll_board <board-row> <limit> <items-file>
-# Classifies every card, adopts captain edits, and retries outstanding writes.
+# Classifies every card from the one board read it is handed, reports what
+# firstmate has to act on, and retries writes the board has not taken yet. Every
+# write below reuses a card id from that same read, so nothing here refetches the
+# board per item.
 poll_board() {
   local board=$1 limit=$2 items=$3
   local project owner number repo label mention assignee status_field todo in_progress done_col
+  local bp_todo bp_in_progress bp_done queued
   local id type url status labels assignees title body
   local canonical task desired synced pr pr_synced board_state count=0
-  local seen_file trigger column
+  local seen_file trigger column container
   local l_project l_issue l_task l_desired
 
   project=$(printf '%s' "$board" | cut -f1)
@@ -902,6 +1566,10 @@ poll_board() {
   todo=$(printf '%s' "$board" | cut -f9)
   in_progress=$(printf '%s' "$board" | cut -f10)
   done_col=$(printf '%s' "$board" | cut -f11)
+  bp_todo=$(printf '%s' "$board" | cut -f12)
+  bp_in_progress=$(printf '%s' "$board" | cut -f13)
+  bp_done=$(printf '%s' "$board" | cut -f14)
+  queued=$(printf '%s' "$board" | cut -f15)
 
   seen_file=$(mktemp) || return 1
   while IFS=$TAB read -r id type url status labels assignees title body; do
@@ -912,12 +1580,12 @@ poll_board() {
     # this cycle declines to import is still a card that has not left, and the
     # withdrawal scan below reads absence from this file.
     printf '%s\n' "$canonical" >> "$seen_file"
-    board_state=$(column_state "$status" "$todo" "$in_progress" "$done_col")
+    board_state=$(column_state "$status" "$todo" "$in_progress" "$done_col" "$queued")
 
     if links_find issue "$canonical" >/dev/null; then
       # An issue another configured board already owns is a misconfiguration,
-      # not an instruction. Re-homing it would point every later event at the
-      # wrong board, so this one is named and left entirely alone.
+      # not something to reconcile. Re-homing it would point every later event at
+      # the wrong board, so this one is named and left entirely alone.
       if [ "$LINK_PROJECT" != "$project" ]; then
         printf 'foreign %s %s %s %s\n' \
           "$project" "$canonical" "$LINK_PROJECT" "$LINK_TASK"
@@ -928,24 +1596,17 @@ poll_board() {
       synced=$LINK_SYNCED
       pr=$LINK_PR
       pr_synced=$LINK_PR_SYNCED
-      if [ "$desired" = "$synced" ]; then
-        if [ "$board_state" = "$desired" ]; then
-          printf 'linked %s %s %s %s\n' "$project" "$canonical" "$task" "$desired"
-        else
-          links_put "$project" "$canonical" "$task" "$board_state" "$board_state" "$pr" "$pr_synced"
-          printf 'instruction %s %s %s %s %s %s\n' \
-            "$project" "$canonical" "$task" "$desired" "$board_state" "$status"
-          desired=$board_state
-          synced=$board_state
+      if [ "$board_state" = "$desired" ]; then
+        # The board agrees. Record it as confirmed if a write was outstanding.
+        if [ "$synced" != "$desired" ]; then
+          links_put "$project" "$canonical" "$task" "$desired" "$desired" "$pr" "$pr_synced"
+          synced=$desired
         fi
-      # A write is outstanding. The board still showing the last confirmed value
-      # is this adapter's own lag, not a captain edit.
-      elif [ "$board_state" = "$desired" ]; then
-        links_put "$project" "$canonical" "$task" "$desired" "$desired" "$pr" "$pr_synced"
-        synced=$desired
         printf 'linked %s %s %s %s\n' "$project" "$canonical" "$task" "$desired"
-      elif [ "$board_state" = "$synced" ]; then
-        column=$(state_column "$desired" "$todo" "$in_progress" "$done_col") || column=
+      elif [ "$desired" != "$synced" ] && [ "$board_state" = "$synced" ]; then
+        # A write is outstanding and the board still shows the value this adapter
+        # last confirmed, so this is its own lag rather than a change to it.
+        column=$(state_column "$desired" "$todo" "$in_progress" "$done_col" "$queued") || column=
         if [ -n "$column" ] && board_write_status "$owner" "$number" "$status_field" "$id" "$canonical" "$column"; then
           links_put "$project" "$canonical" "$task" "$desired" "$desired" "$pr" "$pr_synced"
           synced=$desired
@@ -954,11 +1615,11 @@ poll_board() {
           printf 'stale %s %s %s %s\n' "$project" "$canonical" "$task" "$desired"
         fi
       else
-        links_put "$project" "$canonical" "$task" "$board_state" "$board_state" "$pr" "$pr_synced"
-        printf 'instruction %s %s %s %s %s %s\n' \
+        # The card shows a status firstmate did not write. Firstmate's records are
+        # the truth here, so this changes nothing on either side and is reported
+        # for the captain rather than reconciled behind them.
+        printf 'divergence %s %s %s %s %s %s\n' \
           "$project" "$canonical" "$task" "$desired" "$board_state" "$status"
-        desired=$board_state
-        synced=$board_state
       fi
       # An outstanding PR attachment is retried exactly like an outstanding card
       # move, because `pr` promised the next cycle would reconcile it.
@@ -973,9 +1634,16 @@ poll_board() {
       continue
     fi
 
-    # Not linked yet, so from here on this is intake alone. A draft card or a
-    # pull request is not a real issue, and an issue outside the configured repo
-    # is not this board's work to take.
+    # Not linked. A card in a big-picture column is a container: its children
+    # hold the work, so it is never intake and never binds a task.
+    if container=$(bp_column_state "$status" "$bp_todo" "$bp_in_progress" "$bp_done"); then
+      poll_container "$board" "$id" "$canonical" "$container" "$status" "$labels"
+      continue
+    fi
+
+    # From here on this is intake alone. A draft card or a pull request is not a
+    # real issue, and an issue outside the configured repo is not this board's
+    # work to take.
     [ "$type" = Issue ] || continue
     if [ "$repo" != - ] && [ "$(issue_repo "$canonical")" != "$repo" ]; then
       continue
@@ -993,12 +1661,12 @@ poll_board() {
     printf 'new %s %s %s %s\n' "$project" "$canonical" "$trigger" "$title"
   done < "$items"
 
-  # A card that vanished from the board is the captain withdrawing the work.
+  # A card that vanished from the board while firstmate was still executing it.
   # Two reads cannot tell absence apart from something else and so reconcile
   # nothing: a full page may have another page behind it, and a board that
   # answers with no cards at all while links are open is far more likely to be
-  # a changed project number or a lost permission than the captain clearing
-  # every card by hand.
+  # a changed project number or a lost permission than every card being cleared
+  # by hand.
   if [ "$count" -ge "$limit" ]; then
     printf 'truncated %s %s\n' "$project" "$count"
   elif [ "$count" -eq 0 ] && [ -n "$(cmd_links "$project")" ]; then
@@ -1010,15 +1678,122 @@ poll_board() {
         continue
       fi
       # Leaving the board after Done is archiving, and an acknowledged
-      # withdrawal is already reconciled; neither is an open instruction.
+      # withdrawal is already reconciled; neither is open.
       case "$l_desired" in
-        todo | in-progress) ;;
+        todo | queued | in-progress) ;;
         *) continue ;;
       esac
       printf 'cancelled %s %s %s %s\n' "$project" "$l_issue" "$l_task" "$l_desired"
     done < <(links_rows)
   fi
   rm -f "$seen_file"
+}
+
+# poll_container <board-row> <card-id> <parent-issue> <container-state> <raw-status> <labels>
+# A container is offered for decomposition until it is recorded as decomposed,
+# and once it has children its own card follows their recorded states. A parent
+# whose card already shows what firstmate recorded prints nothing at all, so a
+# reconciled board stays silent.
+poll_container() {
+  local board=$1 id=$2 parent=$3 container=$4 raw=$5 labels=$6
+  local project owner number label status_field bp_todo bp_in_progress bp_done
+  local state desired synced children now column task child_state pair
+  local any_in_progress='' any_open='' any_driven=''
+
+  project=$(printf '%s' "$board" | cut -f1)
+  owner=$(printf '%s' "$board" | cut -f2)
+  number=$(printf '%s' "$board" | cut -f3)
+  label=$(printf '%s' "$board" | cut -f5)
+  status_field=$(printf '%s' "$board" | cut -f8)
+  bp_todo=$(printf '%s' "$board" | cut -f12)
+  bp_in_progress=$(printf '%s' "$board" | cut -f13)
+  bp_done=$(printf '%s' "$board" | cut -f14)
+
+  if decomps_find "$parent" >/dev/null; then
+    if [ "$DECOMP_PROJECT" != "$project" ]; then
+      printf 'foreign %s %s %s -\n' "$project" "$parent" "$DECOMP_PROJECT"
+      return 0
+    fi
+    state=$DECOMP_STATE
+    desired=$DECOMP_DESIRED
+    synced=$DECOMP_SYNCED
+    children=$DECOMP_CHILDREN
+  else
+    state=open desired=- synced=- children=-
+    # Recorded the first time it is seen, not the first time it is decomposed.
+    # `import` refuses any issue holding a decomposition record, so recording it
+    # here is what makes a container structurally unable to bind a task rather
+    # than merely never offered one.
+    decomps_put "$project" "$parent" "$state" "$desired" "$synced" "$children"
+  fi
+
+  # Offering a container for decomposition repeats until `decomposed` closes it,
+  # exactly as `new` repeats until `import` runs, so a decomposition interrupted
+  # part way is finished rather than lost.
+  if [ "$state" != 'done' ] && [ "$container" = todo ] && list_has "$labels" "$label"; then
+    printf 'decompose %s %s\n' "$project" "$parent"
+  fi
+
+  [ "$children" != - ] || return 0
+
+  # The parent's own column follows its children. A child recorded in a column
+  # firstmate does not drive is left out entirely, so a withdrawn child cannot
+  # hold its parent short of done forever.
+  while IFS= read -r task; do
+    child_state=todo
+    if links_find task "$task" >/dev/null; then
+      child_state=$LINK_DESIRED
+    fi
+    case "$child_state" in
+      in-progress)
+        any_driven=1
+        any_in_progress=1
+        ;;
+      done) any_driven=1 ;;
+      todo | queued)
+        any_driven=1
+        any_open=1
+        ;;
+      *) ;;
+    esac
+  done < <(children_tasks "$children")
+  [ -n "$any_driven" ] || return 0
+  if [ -n "$any_in_progress" ]; then
+    now=in-progress
+  elif [ -n "$any_open" ]; then
+    now=todo
+  else
+    now='done'
+  fi
+
+  # A newly derived state is firstmate's own event, exactly like `mark` on an
+  # ordinary card: it says what the card should show from now on.
+  if [ "$desired" != "$now" ]; then
+    desired=$now
+    decomps_put "$project" "$parent" "$state" "$desired" "$synced" "$children"
+  fi
+
+  if [ "$container" = "$desired" ]; then
+    # The card already shows it. Reconciled boards stay silent.
+    if [ "$synced" != "$desired" ]; then
+      decomps_put "$project" "$parent" "$state" "$desired" "$desired" "$children"
+    fi
+    return 0
+  fi
+  if [ "$desired" != "$synced" ] && { [ "$synced" = - ] || [ "$container" = "$synced" ]; }; then
+    # A write this adapter owes: either it has never written this card, or the
+    # card still shows the value it last confirmed.
+    column=$(bp_state_column "$desired" "$bp_todo" "$bp_in_progress" "$bp_done") || return 0
+    if board_write_status "$owner" "$number" "$status_field" "$id" "$parent" "$column"; then
+      decomps_put "$project" "$parent" "$state" "$desired" "$desired" "$children"
+      printf 'synced %s %s - %s\n' "$project" "$parent" "$desired"
+    else
+      printf 'stale %s %s - %s\n' "$project" "$parent" "$desired"
+    fi
+    return 0
+  fi
+  # The card shows a state firstmate never wrote.
+  printf 'divergence %s %s - %s %s %s\n' "$project" "$parent" "$desired" "$container" "$raw"
 }
 
 cmd_poll() {
@@ -1085,6 +1860,10 @@ case "$VERB" in
   boards) cmd_boards "$@" ;;
   poll) cmd_poll "$@" ;;
   import) cmd_import "$@" ;;
+  place) cmd_place "$@" ;;
+  child-add) cmd_child_add "$@" ;;
+  decomposed) cmd_decomposed "$@" ;;
+  decompositions) cmd_decompositions "$@" ;;
   links) cmd_links "$@" ;;
   lookup) cmd_lookup "$@" ;;
   mark) cmd_mark "$@" ;;

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -1193,6 +1193,29 @@ detect_local_config() {
   fi
 }
 
+# board_poll reconciles a configured project board on the one cycle a session
+# start already has. It is the whole reason firstmate no longer has to remember
+# to poll: a board that gained a card while the fleet was idle is picked up here.
+# A home with no board configuration performs zero board reads, because
+# bin/fm-board.sh is inert without it - and this returns before invoking it at
+# all. Only lines that need firstmate to act are printed, so a board that is
+# already reconciled adds nothing to a session start. bin/fm-board.sh owns every
+# board mechanic, including exiting 0 on an unreadable board so a board problem
+# can never fail a session start.
+board_poll() {
+  local board_sh="$FM_ROOT/bin/fm-board.sh" line
+  [ -s "$CONFIG/boards" ] || return 0
+  [ -x "$board_sh" ] || return 0
+  while IFS= read -r line; do
+    case "$line" in
+      # `linked` is a card already showing what firstmate recorded.
+      linked\ *) continue ;;
+      '') continue ;;
+    esac
+    printf 'BOARD_POLL: %s\n' "$line"
+  done < <(FM_HOME="$FM_HOME" "$board_sh" poll 2>&1 || true)
+}
+
 # The order below is the order the diagnostics have always printed in, so a
 # `skip` run is the same output with the network lines removed rather than a
 # reshuffle. `gh auth status` sits between the two local blocks because that is
@@ -1239,6 +1262,14 @@ if [ "${FM_BOOTSTRAP_DETECT_ONLY:-0}" != 1 ]; then
     __fm_timing_stamp=$(fm_timing_now_ms)
     fleet_sync
     fm_timing_record phase fleet-sync "$__fm_timing_stamp"
+  fi
+  # The configuration check comes first so a home with no board never even
+  # names this sweep, let alone runs it.
+  if network_phase && [ -s "$CONFIG/boards" ] \
+    && network_sweep_authorized 'project board reconciliation'; then
+    __fm_timing_stamp=$(fm_timing_now_ms)
+    board_poll
+    fm_timing_record phase board-poll "$__fm_timing_stamp"
   fi
 fi
 local_phase && secondmate_handoff_detect

--- a/bin/fm-pr-check.sh
+++ b/bin/fm-pr-check.sh
@@ -135,3 +135,11 @@ fm_pr_poll_publish_prepared || {
   exit 1
 }
 printf 'armed: state/%s.check.sh\n' "$ID"
+
+# Attach the PR to its originating card when the task holds a board link. A task
+# with no link - every task in a home with no configured board - reaches no board
+# at all, and a board write that does not land leaves the card stale for the next
+# poll rather than affecting this recording. bin/fm-board.sh owns the mechanics.
+if FM_HOME="$FM_HOME" "$SCRIPT_DIR/fm-board.sh" lookup "$ID" >/dev/null 2>&1; then
+  FM_HOME="$FM_HOME" "$SCRIPT_DIR/fm-board.sh" pr "$ID" "$URL" >&2 || true
+fi

--- a/bin/fm-pr-merge.sh
+++ b/bin/fm-pr-merge.sh
@@ -82,3 +82,11 @@ if ! caller_has_merge_method "$@"; then
 fi
 
 gh-axi pr merge "$PR_NUMBER" --repo "$PR_OWNER/$PR_REPO" "${merge_args[@]+"${merge_args[@]}"}" "$@"
+
+# Only a merge that actually landed moves the card: set -eu has already exited
+# above if it did not. A task with no board link reaches no board at all, and a
+# board write that does not land leaves the card stale for the next poll rather
+# than changing the merge's own outcome. bin/fm-board.sh owns the mechanics.
+if FM_HOME="$FM_HOME" "$SCRIPT_DIR/fm-board.sh" lookup "$ID" >/dev/null 2>&1; then
+  FM_HOME="$FM_HOME" "$SCRIPT_DIR/fm-board.sh" mark "$ID" 'done' >&2 || true
+fi

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2847,6 +2847,28 @@ if [ "$KIND" = secondmate ] && [ "${FM_SKIP_SECONDMATE_INHERIT:-0}" != 1 ]; then
   fi
 fi
 
+# Reflect the dispatch onto a configured project board, so a card reaching In
+# Progress is a property of dispatching rather than of anyone remembering to run
+# a second command. bin/fm-board.sh owns every board mechanic here, including
+# staying completely inert for a project with no board stanza: the name lookup
+# below is a local file read and reaches no board at all when none is
+# configured. A board write can never fail, delay, or alter this dispatch - a
+# card that does not land is left stale for the next poll to reconcile.
+spawn_reflect_on_board() {
+  local project board_sh="$FM_ROOT/bin/fm-board.sh"
+  [ "$KIND" = ship ] || return 0
+  [ -x "$board_sh" ] || return 0
+  project=$(basename "$PROJ_ABS")
+  [ -n "$(FM_HOME="$FM_HOME" "$board_sh" boards "$project" 2>/dev/null)" ] || return 0
+  if ! FM_HOME="$FM_HOME" "$board_sh" lookup "$ID" >/dev/null 2>&1; then
+    FM_HOME="$FM_HOME" "$board_sh" place "$project" "$ID" "$ID" \
+      "Dispatched by firstmate as task $ID." >&2 || true
+  fi
+  FM_HOME="$FM_HOME" "$board_sh" mark "$ID" in-progress >&2 || true
+  return 0
+}
+spawn_reflect_on_board || true
+
 SPAWN_DELIVERY=
 [ -z "$MODE" ] || SPAWN_DELIVERY=" mode=$MODE yolo=$YOLO"
 echo "spawned $ID harness=$HARNESS kind=$KIND$SPAWN_DELIVERY window=$META_WINDOW worktree=$WT"

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -133,7 +133,7 @@ now_ms() {
 family_for_basename() {
   case "$1" in
     fm-arm-pretool-check.test.sh|fm-ask-user-authority.test.sh|\
-    fm-bearings-board.test.sh|\
+    fm-bearings-board.test.sh|fm-board.test.sh|\
     fm-brief.test.sh|fm-vendor-auth-probe.test.sh|\
     fm-calm-pi-extension.test.sh|fm-cd-pretool-check.test.sh|\
     fm-classify-decision-key.test.sh|\

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,6 +47,66 @@ Set the local, gitignored `config/backlog-backend` file to `manual` to force man
 Absent or `tasks-axi` selects the default tasks-axi backend.
 The file format is unchanged in both modes; tasks-axi and manual edits produce the same `## In flight`, `## Queued`, and `## Done` sections.
 
+## Project boards (config/boards)
+
+A project board is optional and ships inert.
+With no `config/boards` file, firstmate performs no board reads and no board writes at all, contacts no board, and behaves exactly as it does today - the same opt-in shape as Relay below.
+Configure one and firstmate bridges that board to its existing backlog, importing tagged work and reflecting its own dispatch, PR, blocker, and merge events back onto the cards.
+The bridge is deliberately small - it adds no webhook, daemon, database, second queue, continuous synchronization, or separate board service, and reads only on the cycles firstmate already runs.
+[`bin/fm-board.sh`](../bin/fm-board.sh)'s header owns the commands, the durable link record, and the exact failure behavior, while [`board-orchestration`](../.agents/skills/board-orchestration/SKILL.md) owns what firstmate does with them.
+
+`config/boards` is local, gitignored, and plain text, with one stanza per board opened by its `project` key:
+
+```
+project = harbourlight
+owner = harbour-collective
+number = 4
+repo = harbour-collective/app
+label = firstmate
+mention = @firstmate
+assignee = firstmate-bot
+status-field = Status
+todo = Todo
+in-progress = In Progress
+done = Done
+```
+
+`project` is the project's name in the local project registry (`data/projects.md`), and `owner` plus `number` are the GitHub Projects owner login and project number.
+Everything else is optional: `repo` restricts intake to one repository on a board that carries several, `status-field` names the single-select field holding the columns, and `todo`, `in-progress`, and `done` name that field's three options.
+The defaults are `Status`, `Todo`, `In Progress`, and `Done`, and the names are matched ignoring case and spaces, so a field exported as `status` still resolves.
+Nothing about the board is baked into firstmate's tracked code; every identifier comes from this file, so any project can gain a board without a code change.
+
+A card is picked up only when it is a real issue, sits in the Todo column, and carries the trigger.
+The **label** is the authoritative trigger and defaults to `firstmate`, so add a `firstmate` label to an issue to hand it to the first mate.
+`mention` and `assignee` are additional triggers and are off unless you set them; a mention is a weaker signal than a label because a plausible handle may belong to a real GitHub account that is not yours, so prefer the label and treat a mention as a convenience.
+An issue is imported once and the link is kept forever, so the same issue can never produce two backlog items even after its task is finished and cleaned up.
+
+Cards move only on firstmate's own execution events: In Progress when a worker is dispatched, the working PR attached to the originating issue when it opens, and Done after a confirmed merge.
+A blocked item stays in the column it is already in with the blocker recorded as an issue comment; there is no fourth column.
+If you move, reprioritize, or cancel a card yourself, that is an instruction: firstmate reconciles its backlog to your board and never moves the card back.
+Cancelling a card stops the work and never discards unlanded work; that still needs you to say so.
+A board update that fails never blocks a dispatch, a merge, or cleanup - the board simply goes stale and the next cycle reconciles it.
+
+### Turning it off
+
+Delete `config/boards`, or empty it, and the bridge is fully disabled with no residue.
+That is the whole off switch: there is no generated poll, watcher check, cadence file, daemon, or background process to unwind, because the bridge never creates one.
+The only file it ever writes is the local link record `data/board-links.tsv`, which does nothing at all without configuration and is kept so a re-enabled board does not re-import issues it already imported.
+
+Disabling stops future board reads and writes; it is not an undo, and it deliberately leaves earlier work in place.
+Backlog items already imported stay in the backlog, issues already created stay on GitHub, comments already posted stay posted, and cards already moved stay in the column they were moved to.
+Undo any of those by hand if you want them gone.
+
+### One board per project, and only where you configured one
+
+The bridge is strictly per project.
+Only a project with its own stanza in `config/boards` is ever mapped to a board, so work on every other project is never placed on any board, never commented on, and never moved.
+Configuring a board for one project therefore has no effect on the rest of the fleet, and a home with several boards keeps them separate: an event on one project resolves that project's stanza and no other.
+
+The board is read at session start and on the heartbeat cycles firstmate already runs, so expect minutes of lag while the fleet is busy, and note that an idle fleet produces no heartbeats at all: an item filed while everything is idle is picked up at the next session start.
+Board commands use `gh`, already required by the toolchain below, and need its `project` scope; run `gh auth refresh -s project` once if `gh` reports the scope missing.
+Board configuration is local to one home and is not inherited by secondmate homes, because the home holding an issue's link is the home that updates it.
+
 ## Runtime backend (config/backend / FM_BACKEND)
 
 For spawn-capable adapters, the runtime session-provider backend controls where task windows/endpoints are created, captured, sent to, watched, and killed.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,29 +69,64 @@ status-field = Status
 todo = Todo
 in-progress = In Progress
 done = Done
+queued = Queued
+big-picture-todo = Big Picture Todo
+big-picture-in-progress = Big Picture In Progress
+big-picture-done = Big Picture Done
 ```
 
 `project` is the project's name in the local project registry (`data/projects.md`), and `owner` plus `number` are the GitHub Projects owner login and project number.
-Everything else is optional: `repo` restricts intake to one repository on a board that carries several, `status-field` names the single-select field holding the columns, and `todo`, `in-progress`, and `done` name that field's three options.
+Everything else is optional: `repo` restricts intake to one repository on a board that carries several and is also the repository firstmate files a new card's issue in, `status-field` names the single-select field holding the columns, and `todo`, `in-progress`, and `done` name that field's three options.
 The defaults are `Status`, `Todo`, `In Progress`, and `Done`, and the names are matched ignoring case and spaces, so a field exported as `status` still resolves.
 Nothing about the board is baked into firstmate's tracked code; every identifier comes from this file, so any project can gain a board without a code change.
+
+`queued` is optional and unset by default.
+Configure it and firstmate uses that column for work it has been cleared to launch, between filed and started; leave it out and there is no such column and nothing changes.
+
+The three `big-picture-*` keys are also optional and unset by default, and they are one switch rather than three: set all three or none, because a partial set is refused with the reason rather than half-enabled.
+They turn on decomposition, described below.
+No column name may be used twice across all of these keys.
 
 A card is picked up only when it is a real issue, sits in the Todo column, and carries the trigger.
 The **label** is the authoritative trigger and defaults to `firstmate`, so add a `firstmate` label to an issue to hand it to the first mate.
 `mention` and `assignee` are additional triggers and are off unless you set them; a mention is a weaker signal than a label because a plausible handle may belong to a real GitHub account that is not yours, so prefer the label and treat a mention as a convenience.
 An issue is imported once and the link is kept forever, so the same issue can never produce two backlog items even after its task is finished and cleaned up.
+Work you file on the board is never started just because it arrived: firstmate imports it, tells you it is there, and waits for your go before dispatching anything.
 
-Cards move only on firstmate's own execution events: In Progress when a worker is dispatched, the working PR attached to the originating issue when it opens, and Done after a confirmed merge.
-A blocked item stays in the column it is already in with the blocker recorded as an issue comment; there is no fourth column.
-If you move, reprioritize, or cancel a card yourself, that is an instruction: firstmate reconciles its backlog to your board and never moves the card back.
-Cancelling a card stops the work and never discards unlanded work; that still needs you to say so.
+Work can also go the other way. Firstmate puts a task it already holds onto the board, filing the issue and carding it, so the roadmap shows work that started in the backlog as well as work that started on the board.
+That happens automatically when it dispatches a task whose project has a board, and can be done deliberately for any task the first mate judges belongs on that roadmap.
+There is no bulk operation that sweeps existing work onto a board; cards are placed one at a time.
+
+Cards then move on firstmate's own execution events, without anyone remembering a step: In Progress when a worker is dispatched, the working PR attached to the originating issue when it opens, and Done after a confirmed merge.
+A blocked item stays in the column it is already in with the blocker recorded as an issue comment.
 A board update that fails never blocks a dispatch, a merge, or cleanup - the board simply goes stale and the next cycle reconciles it.
+
+### Who says what
+
+Firstmate's own records are the source of truth and the board shows them; chat, not the board, is where you steer the work.
+That splits into two halves worth knowing:
+
+- **Filing work on the board is you adding work.** A new labelled card is picked up as before.
+- **The status columns are firstmate's report.** If a card's column changes to something firstmate did not put there, it changes nothing, starts nothing, stops nothing, and tells you in chat instead - including if a card appears in the `queued` column, which under this model can only mean something outside firstmate wrote to the board.
+
+So moving a card yourself is a fine way to tell firstmate something, but tell it in chat too: it will report the difference rather than act on it.
+Nothing here ever discards unlanded work.
+
+### Big-picture items and their children
+
+With the three `big-picture-*` keys configured, a card in the big-picture Todo column carrying the trigger label is a container: an issue whose children are the real work.
+Firstmate reads it, breaks it into concrete work items, and files each one as a native GitHub sub-issue of that container, carded in the ordinary Todo column - so GitHub's own `Parent issue` and `Sub-issues progress` fields show the structure with nothing invented on top.
+A container never becomes a task itself, and is only ever broken down once.
+Its own card then follows its children: any child in progress moves it to the big-picture In Progress column, and all children done moves it to big-picture Done.
+
+Creating those child cards is unattended; running them is not.
+Children are captain-gated exactly like any other work that arrived from a board.
 
 ### Turning it off
 
 Delete `config/boards`, or empty it, and the bridge is fully disabled with no residue.
 That is the whole off switch: there is no generated poll, watcher check, cadence file, daemon, or background process to unwind, because the bridge never creates one.
-The only file it ever writes is the local link record `data/board-links.tsv`, which does nothing at all without configuration and is kept so a re-enabled board does not re-import issues it already imported.
+The only files it ever writes are the local records `data/board-links.tsv` and `data/board-decompositions.tsv`, which do nothing at all without configuration and are kept so a re-enabled board does not re-import issues it already imported or break down a container it already broke down.
 
 Disabling stops future board reads and writes; it is not an undo, and it deliberately leaves earlier work in place.
 Backlog items already imported stay in the backlog, issues already created stay on GitHub, comments already posted stay posted, and cards already moved stay in the column they were moved to.
@@ -103,7 +138,9 @@ The bridge is strictly per project.
 Only a project with its own stanza in `config/boards` is ever mapped to a board, so work on every other project is never placed on any board, never commented on, and never moved.
 Configuring a board for one project therefore has no effect on the rest of the fleet, and a home with several boards keeps them separate: an event on one project resolves that project's stanza and no other.
 
-The board is read at session start and on the heartbeat cycles firstmate already runs, so expect minutes of lag while the fleet is busy, and note that an idle fleet produces no heartbeats at all: an item filed while everything is idle is picked up at the next session start.
+The board is read at session start and on the heartbeat cycles firstmate already runs, and both happen on their own rather than because firstmate remembered to look.
+Expect minutes of lag while the fleet is busy, and note that an idle fleet produces no heartbeats at all: an item filed while everything is idle is picked up at the next session start.
+The columns are therefore as current as the last cycle rather than live.
 Board commands use `gh`, already required by the toolchain below, and need its `project` scope; run `gh auth refresh -s project` once if `gh` reports the scope missing.
 Board configuration is local to one home and is not inherited by secondmate homes, because the home holding an issue's link is the home that updates it.
 

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -125,6 +125,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/board-orchestration/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/bootstrap-diagnostics/SKILL.md",
       "audience": "agent-runtime"
     },

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -27,7 +27,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-backlog-handoff.sh`  | Validate and delegate queued backlog-item moves into a secondmate home               |
 | `fm-backlog-receive.sh`  | Idempotently ingest one confined remote handoff outbox through tasks-axi             |
 | `fm-decision-hold.sh`    | Create, verify, complete, close, and repair durable captain-held decisions       |
-| `fm-board.sh`            | Bridge a configured project board to the existing backlog: read cards, keep the durable issue-to-task link, and reflect dispatch, PR, blocker, and merge events |
+| `fm-board.sh`            | Bridge a configured project board to the existing backlog: read cards, keep the durable issue-to-task link, place work onto the board, break a big-picture container into linked child cards, and reflect dispatch, PR, blocker, and merge events |
 | `fm-brief.sh`            | Scaffold ship (explicit `--mode`), scout, secondmate-charter, and Herdr-lab briefs   |
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
 | `fm-install-herdr.sh`    | Install CI's exact-version Herdr pin with official asset URL, SHA-256, and protocol checks |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -27,6 +27,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-backlog-handoff.sh`  | Validate and delegate queued backlog-item moves into a secondmate home               |
 | `fm-backlog-receive.sh`  | Idempotently ingest one confined remote handoff outbox through tasks-axi             |
 | `fm-decision-hold.sh`    | Create, verify, complete, close, and repair durable captain-held decisions       |
+| `fm-board.sh`            | Bridge a configured project board to the existing backlog: read cards, keep the durable issue-to-task link, and reflect dispatch, PR, blocker, and merge events |
 | `fm-brief.sh`            | Scaffold ship (explicit `--mode`), scout, secondmate-charter, and Herdr-lab briefs   |
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
 | `fm-install-herdr.sh`    | Install CI's exact-version Herdr pin with official asset URL, SHA-256, and protocol checks |

--- a/tests/fm-board-dispatch.test.sh
+++ b/tests/fm-board-dispatch.test.sh
@@ -1,0 +1,307 @@
+#!/usr/bin/env bash
+# tests/fm-board-dispatch.test.sh - firstmate's own execution events reach a
+# configured board without anyone remembering to run a second command.
+#
+# The property under test is deliberately narrow and load-bearing: dispatching
+# work for a board-mapped project must leave a card on the board, in one
+# operation, and a home with no board configured must be completely unaffected -
+# no card, no issue, and not one call to the GitHub CLI. The board write must
+# also never be able to fail, delay, or alter the dispatch itself, so the failure
+# case here drives a board that refuses every write and asserts the crew launched
+# anyway.
+#
+# The spawn is driven through a fake tmux pane and a real isolated git worktree,
+# the same way the other fm-spawn behavior tests do, so no harness ever starts.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+BOARD="$ROOT/bin/fm-board.sh"
+TMP_ROOT=$(fm_test_tmproot fm-board-dispatch)
+
+# --- fixture ----------------------------------------------------------------
+
+# A GitHub CLI that behaves like a real board: issues are filed into a store,
+# adding a card returns the id the add itself minted, and a status write is
+# visible to the next read.
+make_gh_stub() {
+  cat > "$1/gh" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_LOG"
+if [ -n "${GH_REFUSE_WRITES:-}" ]; then
+  case "$1 $2" in
+    "project item-add" | "project item-edit" | "issue create") exit 1 ;;
+  esac
+fi
+case "$1 $2" in
+  "project view") printf 'PVT_fixture\n' ;;
+  "project field-list")
+    printf 'field\tPVTSSF_status\n'
+    printf 'option\topt_todo\tTodo\n'
+    printf 'option\topt_prog\tIn Progress\n'
+    printf 'option\topt_done\tDone\n'
+    ;;
+  "project item-list") cat "$GH_ITEMS" ;;
+  "issue list")
+    prev=''
+    repo=''
+    for arg in "$@"; do
+      [ "$prev" != --repo ] || repo=$arg
+      prev=$arg
+    done
+    awk -F'\t' -v OFS='\t' -v r="$repo" '$1 == r { print $2, $3 }' "$GH_ISSUES"
+    ;;
+  "issue create")
+    repo=''; title=''; body=''
+    shift 2
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --repo) repo=$2; shift 2 ;;
+        --title) title=$2; shift 2 ;;
+        --body) body=$2; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    url="https://github.com/$repo/issues/$(( $(wc -l < "$GH_ISSUES") + 500 ))"
+    printf '%s\t%s\t%s\t%s\n' "$repo" "$url" \
+      "$(printf '%s' "$body" | tr '\n' ' ')" "$title" >> "$GH_ISSUES"
+    printf '%s\n' "$url"
+    ;;
+  "project item-add")
+    url=''
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --url) url=$2; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    id="PVTI_card$(wc -l < "$GH_ITEMS")"
+    printf '%s\tIssue\t%s\t-\t-\t-\tcard\t-\n' "$id" "$url" >> "$GH_ITEMS"
+    printf '%s\n' "$id"
+    ;;
+  "project item-edit")
+    eid=''; eopt=''
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --id) eid=$2; shift 2 ;;
+        --single-select-option-id) eopt=$2; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    case "$eopt" in
+      opt_todo) name=Todo ;;
+      opt_prog) name='In Progress' ;;
+      *) name=Done ;;
+    esac
+    tmp=$(mktemp)
+    awk -F'\t' -v OFS='\t' -v id="$eid" -v s="$name" '$1 == id { $4 = s } { print }' \
+      "$GH_ITEMS" > "$tmp"
+    mv "$tmp" "$GH_ITEMS"
+    ;;
+  "issue comment") : ;;
+esac
+exit 0
+SH
+  chmod +x "$1/gh"
+}
+
+make_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse
+  cat > "$fakebin/timeout" <<'SH'
+#!/usr/bin/env bash
+shift
+exec "$@"
+SH
+  chmod +x "$fakebin/timeout"
+  make_gh_stub "$fakebin"
+  printf '%s\n' "$fakebin"
+}
+
+# make_case <name> <task-id>: an isolated home with one project clone whose
+# directory name is the project name a board stanza would have to match.
+make_case() {
+  local name=$1 id=$2 case_dir home proj wt fakebin
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  proj="$case_dir/harbourlight"
+  wt="$case_dir/wt"
+  fakebin=$(make_fakebin "$case_dir/fake")
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
+  printf '%s\n' claude > "$home/config/crew-harness"
+  fm_git_worktree "$proj" "$wt" "wt-$name"
+  touch "$home/state/.last-watcher-beat"
+  printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
+  : > "$case_dir/gh.log"
+  : > "$case_dir/items"
+  : > "$case_dir/issues"
+  printf '%s|%s|%s|%s|%s\n' "$case_dir" "$home" "$proj" "$wt" "$fakebin"
+}
+
+configure_board() {
+  cat > "$1/config/boards" <<'EOF'
+project = harbourlight
+owner = harbour-collective
+number = 4
+repo = harbour-collective/app
+label = firstmate
+EOF
+}
+
+read_case() {
+  IFS='|' read -r CASE_DIR HOME_DIR PROJ_DIR WT_DIR FAKEBIN <<EOF
+$1
+EOF
+}
+
+run_spawn() {
+  FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
+    FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+    FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$WT_DIR" TMUX="fake,1,0" \
+    FM_BACKEND=tmux CLAUDE_CONFIG_DIR='' \
+    GH_LOG="$CASE_DIR/gh.log" GH_ITEMS="$CASE_DIR/items" \
+    GH_ISSUES="$CASE_DIR/issues" GH_REFUSE_WRITES="${GH_REFUSE_WRITES:-}" \
+    PATH="$FAKEBIN:$PATH" \
+    "$SPAWN" "$@" --mode direct-PR --yolo off 2>&1
+}
+
+run_board() {
+  FM_HOME="$HOME_DIR" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    FM_DATA_OVERRIDE="$HOME_DIR/data" FM_BOARD_GH="$FAKEBIN/gh" \
+    GH_LOG="$CASE_DIR/gh.log" GH_ITEMS="$CASE_DIR/items" \
+    GH_ISSUES="$CASE_DIR/issues" \
+    "$BOARD" "$@"
+}
+
+# --- cases ------------------------------------------------------------------
+
+test_dispatching_board_mapped_work_leaves_a_card() {
+  local rec out id
+  id=fm-dispatch-card
+  rec=$(make_case dispatch-card "$id")
+  read_case "$rec"
+  configure_board "$HOME_DIR"
+
+  out=$(run_spawn "$id" "$PROJ_DIR")
+  assert_contains "$out" "spawned $id harness=claude" "the dispatch itself did not complete"
+
+  # One operation: the card exists and is already in the dispatched column.
+  assert_contains "$(run_board lookup "$id")" 'in-progress' \
+    "dispatching did not leave the task's card in the dispatched column"
+  [ "$(wc -l < "$CASE_DIR/issues")" = 1 ] || fail "dispatching did not file exactly one issue"
+  assert_contains "$(cat "$CASE_DIR/gh.log")" '--single-select-option-id opt_prog' \
+    "the card was never moved to In Progress"
+  pass "dispatching board-mapped work creates its card and marks it, in one operation"
+}
+
+test_a_second_dispatch_moves_the_card_it_already_has() {
+  local rec out id issues_before
+  id=fm-dispatch-again
+  rec=$(make_case dispatch-again "$id")
+  read_case "$rec"
+  configure_board "$HOME_DIR"
+
+  run_spawn "$id" "$PROJ_DIR" >/dev/null
+  issues_before=$(wc -l < "$CASE_DIR/issues")
+  run_board mark "$id" todo >/dev/null
+
+  rm -f "$HOME_DIR/state/$id.meta"
+  out=$(run_spawn "$id" "$PROJ_DIR")
+  assert_contains "$out" "spawned $id" "the second dispatch did not complete"
+  [ "$(wc -l < "$CASE_DIR/issues")" = "$issues_before" ] \
+    || fail "a re-dispatch filed a second issue for work already on the board"
+  assert_contains "$(run_board lookup "$id")" 'in-progress' "the re-dispatch did not move the card"
+  pass "a task already on the board is moved, never filed a second time"
+}
+
+test_a_home_with_no_board_is_completely_unaffected() {
+  local rec out id
+  id=fm-no-board
+  rec=$(make_case no-board "$id")
+  read_case "$rec"
+  [ ! -e "$HOME_DIR/config/boards" ] || fail "the fixture home already configured a board"
+
+  out=$(run_spawn "$id" "$PROJ_DIR")
+  assert_contains "$out" "spawned $id harness=claude" "a dispatch with no board configured did not complete"
+  [ ! -s "$CASE_DIR/gh.log" ] || fail "a home with no board called the GitHub CLI: $(cat "$CASE_DIR/gh.log")"
+  [ ! -s "$CASE_DIR/issues" ] || fail "a home with no board filed an issue"
+  assert_absent "$HOME_DIR/data/board-links.tsv" "a home with no board wrote a linkage record"
+  pass "a dispatch in a home with no configured board reads nothing, writes nothing, and files nothing"
+}
+
+test_a_project_with_no_stanza_is_never_placed() {
+  local rec out id
+  id=fm-other-project
+  rec=$(make_case other-project "$id")
+  read_case "$rec"
+  # A board exists in this home, but for a different project entirely.
+  cat > "$HOME_DIR/config/boards" <<'EOF'
+project = tidewheel
+owner = personal-account
+number = 91
+repo = personal-account/tidewheel
+EOF
+
+  out=$(run_spawn "$id" "$PROJ_DIR")
+  assert_contains "$out" "spawned $id" "the dispatch did not complete"
+  [ ! -s "$CASE_DIR/gh.log" ] || fail "work for an unconfigured project reached a board"
+  [ ! -s "$CASE_DIR/issues" ] || fail "work for an unconfigured project filed an issue"
+  pass "only a project with its own board stanza is ever placed on a board"
+}
+
+test_a_board_that_refuses_every_write_never_fails_the_dispatch() {
+  local rec out id
+  id=fm-board-down
+  rec=$(make_case board-down "$id")
+  read_case "$rec"
+  configure_board "$HOME_DIR"
+
+  out=$(GH_REFUSE_WRITES=1 run_spawn "$id" "$PROJ_DIR")
+  assert_contains "$out" "spawned $id harness=claude" \
+    "a board that refused every write blocked the dispatch"
+  assert_present "$HOME_DIR/state/$id.meta" "the dispatch did not record the task"
+  pass "a board write that cannot land leaves a stale card and never blocks a dispatch"
+}
+
+test_dispatching_a_scout_places_nothing() {
+  local rec out id
+  id=fm-scout-work
+  rec=$(make_case scout-work "$id")
+  read_case "$rec"
+  configure_board "$HOME_DIR"
+
+  out=$(FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
+    FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+    FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$WT_DIR" TMUX="fake,1,0" \
+    FM_BACKEND=tmux CLAUDE_CONFIG_DIR='' \
+    GH_LOG="$CASE_DIR/gh.log" GH_ITEMS="$CASE_DIR/items" \
+    GH_ISSUES="$CASE_DIR/issues" PATH="$FAKEBIN:$PATH" \
+    "$SPAWN" "$id" "$PROJ_DIR" --scout 2>&1)
+  assert_contains "$out" "spawned $id" "the scout dispatch did not complete"
+  [ ! -s "$CASE_DIR/issues" ] || fail "a scout filed a card for a deliverable that is a report"
+  pass "a scout produces a report rather than a card, and places nothing on the board"
+}
+
+test_dispatching_board_mapped_work_leaves_a_card
+test_a_second_dispatch_moves_the_card_it_already_has
+test_a_home_with_no_board_is_completely_unaffected
+test_a_project_with_no_stanza_is_never_placed
+test_a_board_that_refuses_every_write_never_fails_the_dispatch
+test_dispatching_a_scout_places_nothing

--- a/tests/fm-board.test.sh
+++ b/tests/fm-board.test.sh
@@ -651,6 +651,129 @@ test_a_truncated_read_reconciles_nothing() {
   pass "a page boundary is never mistaken for absence"
 }
 
+test_a_card_an_intake_filter_skips_is_not_a_withdrawal() {
+  local home issue out
+  home=$(new_home a_card_an_intake_filter_skips_is_not_a_withdrawal)
+  ordinary_board "$home"
+  issue=https://github.com/harbour-collective/app/issues/150
+  item "$home" PVTI_a Issue "$issue" Todo firstmate - 'Filtered but plainly there' -
+  board "$home" import harbourlight "$issue" fm-filtered >/dev/null
+  board "$home" mark fm-filtered in-progress >/dev/null
+
+  # The captain narrows the board to one repository after the import, so the
+  # intake repo filter now skips a card that has not moved at all.
+  cat > "$home/config/boards" <<'EOF'
+project = harbourlight
+owner = harbour-collective
+number = 4
+repo = harbour-collective/somewhere-else
+label = firstmate
+EOF
+  out=$(board "$home" poll)
+  assert_not_contains "$out" 'cancelled' "a card the repo filter skips was reported as withdrawn"
+  assert_contains "$out" "linked harbourlight $issue fm-filtered in-progress" \
+    "a card the repo filter skips stopped being reconciled"
+
+  # A card whose type intake does not recognize is still a card on the board.
+  ordinary_board "$home"
+  : > "$home/items"
+  item "$home" PVTI_a ISSUE "$issue" 'In Progress' firstmate - 'Filtered but plainly there' -
+  out=$(board "$home" poll)
+  assert_not_contains "$out" 'cancelled' "a card the type filter skips was reported as withdrawn"
+  assert_contains "$(board "$home" lookup fm-filtered)" "	in-progress	in-progress	" \
+    "a skipped card's record was changed"
+  pass "an intake filter decides what is importable, never what is still on the board"
+}
+
+test_an_issue_another_board_owns_is_skipped_not_re_homed() {
+  local home issue out log
+  home=$(new_home an_issue_another_board_owns_is_skipped_not_re_homed)
+  ordinary_board "$home"
+  cat >> "$home/config/boards" <<'EOF'
+
+project = tidewheel
+owner = personal-account
+number = 91
+EOF
+  issue=https://github.com/harbour-collective/app/issues/160
+  item "$home" PVTI_a Issue "$issue" Todo firstmate - 'The first board owns this' -
+  board "$home" import harbourlight "$issue" fm-owned >/dev/null
+  board "$home" mark fm-owned in-progress >/dev/null
+
+  # Both boards now answer with the same card, which is the misconfiguration.
+  : > "$home/gh.log"
+  out=$(board "$home" poll)
+  assert_contains "$out" "foreign tidewheel $issue harbourlight fm-owned" \
+    "a card another board owns was not reported with the project that owns it"
+  assert_not_contains "$out" 'new tidewheel' "a card another board owns was offered for import"
+  assert_not_contains "$out" 'cancelled' "a card another board owns was read as a withdrawal"
+  assert_not_contains "$(gh_log "$home")" 'item-edit' "polling a card another board owns wrote to a board"
+  assert_contains "$(board "$home" lookup fm-owned)" "harbourlight	$issue" \
+    "the link was re-homed to the board that does not own the issue"
+
+  # And every later event still resolves the board that does own it.
+  : > "$home/gh.log"
+  board "$home" mark fm-owned 'done' >/dev/null
+  log=$(gh_log "$home")
+  assert_contains "$log" '--owner harbour-collective' "a later event stopped resolving the owning board"
+  assert_not_contains "$log" 'personal-account' "a later event reached the board that does not own the issue"
+  pass "an issue another board owns is named and left alone, never silently re-homed"
+}
+
+test_an_outstanding_pr_attachment_is_retried_on_the_next_cycle() {
+  local home issue pr out
+  home=$(new_home an_outstanding_pr_attachment_is_retried_on_the_next_cycle)
+  ordinary_board "$home"
+  issue=https://github.com/harbour-collective/app/issues/170
+  pr=https://github.com/harbour-collective/app/pull/171
+  item "$home" PVTI_a Issue "$issue" Todo firstmate - 'Reports a PR' -
+  board "$home" import harbourlight "$issue" fm-latepr >/dev/null
+
+  out=$(GH_FAIL='issue comment' board "$home" pr fm-latepr "$pr" 2>/dev/null)
+  assert_contains "$out" "stale harbourlight $issue fm-latepr $pr" \
+    "the failed attachment was not reported as a stale board"
+  assert_contains "$(board "$home" lookup fm-latepr)" "$pr	0" \
+    "the failed attachment was not left outstanding for the next cycle"
+
+  : > "$home/gh.log"
+  out=$(board "$home" poll)
+  assert_contains "$out" "synced harbourlight $issue fm-latepr $pr" \
+    "the next cycle did not retry the outstanding PR attachment"
+  assert_contains "$(gh_log "$home")" "issue comment $issue --body Working PR: $pr" \
+    "the retry did not land the PR link on the originating issue"
+  assert_contains "$(board "$home" lookup fm-latepr)" "$pr	1" \
+    "the retried attachment was not recorded as confirmed"
+
+  : > "$home/gh.log"
+  board "$home" poll >/dev/null
+  assert_not_contains "$(gh_log "$home")" 'issue comment' \
+    "a confirmed attachment was posted onto the issue again"
+  pass "an outstanding PR attachment is retried until the issue has it, then left alone"
+}
+
+test_mark_reads_the_board_under_the_limit_it_is_given() {
+  local home issue out rc
+  home=$(new_home mark_reads_the_board_under_the_limit_it_is_given)
+  ordinary_board "$home"
+  issue=https://github.com/harbour-collective/app/issues/180
+  item "$home" PVTI_a Issue "$issue" Todo firstmate - 'On a crowded board' -
+  board "$home" import harbourlight "$issue" fm-crowded >/dev/null
+
+  : > "$home/gh.log"
+  board "$home" mark fm-crowded in-progress >/dev/null
+  assert_contains "$(gh_log "$home")" 'project item-list 4 --owner harbour-collective --limit 200' \
+    "the default card lookup limit changed"
+
+  : > "$home/gh.log"
+  board "$home" mark fm-crowded 'done' --limit 500 >/dev/null
+  assert_contains "$(gh_log "$home")" '--limit 500' "mark ignored the lookup limit it was given"
+
+  out=$(board "$home" mark fm-crowded todo --limit 0 2>&1) && rc=0 || rc=$?
+  expect_code 2 "$rc" "mark accepted a lookup limit of zero"
+  assert_contains "$out" 'positive number' "the refused lookup limit was not explained"
+  pass "mark looks a card up under a limit it exposes, the same way poll does"
+}
+
 # --- run --------------------------------------------------------------------
 
 test_boards_are_configuration_not_convention
@@ -673,3 +796,7 @@ test_a_failed_board_write_never_blocks_delivery
 test_a_failed_board_read_never_blocks_the_cycle
 test_an_empty_board_is_not_taken_as_mass_withdrawal
 test_a_truncated_read_reconciles_nothing
+test_a_card_an_intake_filter_skips_is_not_a_withdrawal
+test_an_issue_another_board_owns_is_skipped_not_re_homed
+test_an_outstanding_pr_attachment_is_retried_on_the_next_cycle
+test_mark_reads_the_board_under_the_limit_it_is_given

--- a/tests/fm-board.test.sh
+++ b/tests/fm-board.test.sh
@@ -32,6 +32,7 @@ new_home() {
   cat > "$home/bin/gh" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >> "$GH_LOG"
+l_prev=''
 if [ -n "${GH_FAIL:-}" ]; then
   case "$1 $2" in
     $GH_FAIL)
@@ -62,6 +63,59 @@ case "$1 $2" in
     mv "$edit_tmp" "$GH_ITEMS"
     ;;
   "issue comment") : ;;
+  "issue create")
+    # A real create: allocate the next number in the named repo, store the
+    # issue, and print its URL, exactly as gh does.
+    c_repo=''; c_title=''; c_body=''; c_labels=''; c_parent='-'
+    shift 2
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --repo) c_repo=$2; shift 2 ;;
+        --title) c_title=$2; shift 2 ;;
+        --body) c_body=$2; shift 2 ;;
+        --label) c_labels=$2; shift 2 ;;
+        --parent) c_parent=$2; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    if [ -n "${GH_NO_LABEL:-}" ] && [ "$c_labels" = "$GH_NO_LABEL" ]; then
+      printf 'label %s not found\n' "$c_labels" >&2
+      exit 1
+    fi
+    c_next=$(( $(wc -l < "$GH_ISSUES") + 900 ))
+    c_url="https://github.com/$c_repo/issues/$c_next"
+    printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$c_repo" "$c_url" "$c_title" \
+      "$(printf '%s' "$c_body" | tr '\n' ' ')" "$c_labels" "$c_parent" >> "$GH_ISSUES"
+    printf '%s\n' "$c_url"
+    ;;
+  "issue list")
+    # Only the shape the adapter asks for: url and body, newest first.
+    l_repo=''
+    for l_arg in "$@"; do
+      case "$l_prev" in
+        --repo) l_repo=$l_arg ;;
+      esac
+      l_prev=$l_arg
+    done
+    awk -F'\t' -v OFS='\t' -v r="$l_repo" '$1 == r { print $2, $4 }' "$GH_ISSUES" \
+      | tac
+    ;;
+  "project item-add")
+    a_url=''
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --url) a_url=$2; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    a_id="PVTI_added$(wc -l < "$GH_ITEMS")"
+    # A real board keeps a card with no status until one is set.
+    a_title=$(awk -F'\t' -v u="$a_url" '$2 == u { print $3 }' "$GH_ISSUES")
+    a_labels=$(awk -F'\t' -v u="$a_url" '$2 == u { print $5 }' "$GH_ISSUES")
+    printf '%s\tIssue\t%s\t-\t%s\t-\t%s\t-\n' \
+      "$a_id" "$a_url" "${a_labels:--}" "${a_title:--}" >> "$GH_ITEMS"
+    printf '%s\n' "$a_id"
+    ;;
   *)
     printf 'unexpected gh call: %s\n' "$*" >&2
     exit 9
@@ -72,6 +126,7 @@ SH
   : > "$home/gh.log"
   : > "$home/items"
   : > "$home/fields"
+  : > "$home/issues"
   printf '%s\n' "$home"
 }
 
@@ -86,7 +141,9 @@ board() {
   GH_LOG="$home/gh.log" \
   GH_ITEMS="$home/items" \
   GH_FIELDS="$home/fields" \
+  GH_ISSUES="$home/issues" \
   GH_FAIL="${GH_FAIL:-}" \
+  GH_NO_LABEL="${GH_NO_LABEL:-}" \
     "$BOARD" "$@"
 }
 
@@ -140,6 +197,34 @@ in-progress = Under Way
 done = Landed
 EOF
   fields "$home" PVTSSF_lane opt_wait:Waiting 'opt_under:Under Way' opt_landed:Landed
+}
+
+# An ordinary board that names the one repository its cards are filed in, which
+# is what a board has to state before firstmate can file a card on it.
+repo_board() {
+  local home=$1
+  cat > "$home/config/boards" <<'EOF'
+project = harbourlight
+owner = harbour-collective
+number = 4
+repo = harbour-collective/app
+label = firstmate
+EOF
+  fields "$home" PVTSSF_status opt_todo:Todo 'opt_prog:In Progress' opt_done:Done
+}
+
+# An ordinary board that also carries the optional authorized-to-launch column.
+queued_board() {
+  local home=$1
+  cat > "$home/config/boards" <<'EOF'
+project = harbourlight
+owner = harbour-collective
+number = 4
+label = firstmate
+queued = Queued
+EOF
+  fields "$home" PVTSSF_status opt_todo:Todo opt_queued:Queued \
+    'opt_prog:In Progress' opt_done:Done
 }
 
 # --- configuration is the whole board identity ------------------------------
@@ -433,14 +518,14 @@ test_a_column_firstmate_does_not_drive_is_recorded_not_invented() {
   : > "$home/items"
   item "$home" PVTI_a Issue "$issue" 'Needs Review' firstmate - 'Parked work' -
   out=$(board "$home" poll)
-  assert_contains "$out" "instruction harbourlight $issue fm-parked todo other Needs Review" \
-    "a column outside the three did not surface as an instruction carrying its own name"
-  assert_contains "$(board "$home" lookup fm-parked)" "	other	other	" \
-    "the captain's own column was not recorded"
+  assert_contains "$out" "divergence harbourlight $issue fm-parked todo other Needs Review" \
+    "a column outside the driven ones did not surface as a divergence carrying its own name"
+  assert_contains "$(board "$home" lookup fm-parked)" "	todo	todo	" \
+    "firstmate's record was rewritten to a column it never drove"
 
   out=$(board "$home" mark fm-parked blocked 2>&1) && rc=0 || rc=$?
-  expect_code 2 "$rc" "the adapter accepted a fourth execution state"
-  pass "a column the captain added is recorded as the board's own, never as a fourth state to drive"
+  expect_code 2 "$rc" "the adapter accepted a state it does not drive"
+  pass "a column the adapter does not drive is reported by its own name, never adopted as a state"
 }
 
 # --- PR linkage -------------------------------------------------------------
@@ -486,33 +571,93 @@ test_a_blocker_is_recorded_on_the_issue() {
   pass "a blocker is recorded on the issue while the item stays visible where it is"
 }
 
-# --- the board owns intent --------------------------------------------------
+# --- firstmate's records are the truth the board reports ---------------------
 
-test_a_captain_board_edit_is_an_instruction_never_a_correction() {
-  local home issue out log
-  home=$(new_home a_captain_board_edit_is_an_instruction_never_a_correction)
+test_a_status_firstmate_did_not_write_is_reported_not_reconciled() {
+  local home issue out log record
+  home=$(new_home a_status_firstmate_did_not_write_is_reported_not_reconciled)
   ordinary_board "$home"
   issue=https://github.com/harbour-collective/app/issues/60
   item "$home" PVTI_a Issue "$issue" Todo firstmate - 'Reprioritized work' -
   board "$home" import harbourlight "$issue" fm-repri >/dev/null
   board "$home" mark fm-repri in-progress >/dev/null
+  record=$(board "$home" lookup fm-repri)
 
-  # The captain pulls the card back to the first column.
+  # Something outside firstmate pulls the card back to the first column.
   : > "$home/items"
   : > "$home/gh.log"
   item "$home" PVTI_a Issue "$issue" Todo firstmate - 'Reprioritized work' -
   out=$(board "$home" poll)
-  assert_contains "$out" "instruction harbourlight $issue fm-repri in-progress todo Todo" \
-    "the captain's move backwards was not surfaced as an instruction"
+  assert_contains "$out" "divergence harbourlight $issue fm-repri in-progress todo Todo" \
+    "a status firstmate never wrote was not surfaced as a divergence"
+  assert_not_contains "$out" 'instruction' "a board status was still treated as an instruction"
   log=$(gh_log "$home")
-  assert_not_contains "$log" 'item-edit' "the sync tried to correct the captain's own board edit"
-  assert_contains "$(board "$home" lookup fm-repri)" "	todo	todo	" \
-    "the record did not reconcile to the captain's board"
+  assert_not_contains "$log" 'item-edit' "the poll reconciled the board behind the captain"
+  [ "$(board "$home" lookup fm-repri)" = "$record" ] \
+    || fail "the poll changed firstmate's own record to match the board"
 
-  # And it stays reconciled rather than drifting back on the next cycle.
+  # It keeps being reported, and still changes nothing, until firstmate acts.
   out=$(board "$home" poll)
-  assert_contains "$out" "linked harbourlight $issue fm-repri todo" "the reconciled state did not hold"
-  pass "a captain's board edit reconciles the record and is never written back over"
+  assert_contains "$out" 'divergence' "an unreconciled divergence stopped being reported"
+  [ "$(board "$home" lookup fm-repri)" = "$record" ] || fail "a later poll adopted the board status"
+
+  # An explicit mark is how it resolves: firstmate acting, not the poll deciding.
+  board "$home" mark fm-repri in-progress >/dev/null
+  out=$(board "$home" poll)
+  assert_not_contains "$out" 'divergence' "an explicitly re-marked card kept diverging"
+  pass "a status firstmate did not write is reported and changes nothing on either side"
+}
+
+test_a_queued_card_firstmate_did_not_place_never_starts_work() {
+  local home issue out
+  home=$(new_home a_queued_card_firstmate_did_not_place_never_starts_work)
+  queued_board "$home"
+  issue=https://github.com/harbour-collective/app/issues/62
+  item "$home" PVTI_a Issue "$issue" Todo firstmate - 'Not cleared yet' -
+  board "$home" import harbourlight "$issue" fm-notcleared >/dev/null
+
+  # A card appears in the authorized column that firstmate never put there.
+  : > "$home/items"
+  : > "$home/gh.log"
+  item "$home" PVTI_a Issue "$issue" Queued firstmate - 'Not cleared yet' -
+  out=$(board "$home" poll)
+  assert_contains "$out" "divergence harbourlight $issue fm-notcleared todo queued Queued" \
+    "a card in the authorized column that firstmate never placed was not reported"
+  assert_contains "$(board "$home" lookup fm-notcleared)" "	todo	todo	" \
+    "the record adopted an authorization firstmate never gave"
+  assert_not_contains "$(gh_log "$home")" 'item-edit' "the divergence caused a board write"
+
+  # Firstmate's own record is what puts a card in that column.
+  : > "$home/gh.log"
+  out=$(board "$home" mark fm-notcleared queued)
+  assert_contains "$out" "synced harbourlight $issue fm-notcleared queued" \
+    "firstmate could not record the work as cleared to launch"
+  assert_contains "$(gh_log "$home")" '--single-select-option-id opt_queued' \
+    "the queued write did not set this board's own Queued option"
+  pass "the queued column is written from firstmate's records, and a card it did not place starts nothing"
+}
+
+test_the_queued_column_does_not_exist_until_it_is_configured() {
+  local home issue out rc
+  home=$(new_home the_queued_column_does_not_exist_until_it_is_configured)
+  ordinary_board "$home"
+  issue=https://github.com/harbour-collective/app/issues/64
+  item "$home" PVTI_a Issue "$issue" Todo firstmate - 'Ordinary work' -
+  board "$home" import harbourlight "$issue" fm-ordinary >/dev/null
+
+  out=$(board "$home" mark fm-ordinary queued 2>&1) && rc=0 || rc=$?
+  expect_code 2 "$rc" "an unconfigured queued column was still writable"
+  assert_contains "$out" 'no queued column configured' "the refusal did not name the missing column"
+  assert_contains "$(board "$home" boards)" 'queued=-' "an unconfigured board reported a queued column"
+
+  # A board that happens to carry such a column reads it as a column firstmate
+  # does not drive, exactly as it did before the key existed.
+  : > "$home/items"
+  item "$home" PVTI_a Issue "$issue" Queued firstmate - 'Ordinary work' -
+  out=$(board "$home" poll)
+  assert_contains "$out" "divergence harbourlight $issue fm-ordinary todo other Queued" \
+    "an unconfigured queued column was read as a queued state"
+  pass "with no queued key configured the column does not exist in either direction"
 }
 
 test_a_withdrawn_card_stops_the_work_without_touching_it() {
@@ -774,6 +919,333 @@ test_mark_reads_the_board_under_the_limit_it_is_given() {
   pass "mark looks a card up under a limit it exposes, the same way poll does"
 }
 
+# --- containers and their children ------------------------------------------
+
+# The same ordinary board, plus the three container columns.
+big_picture_board() {
+  local home=$1
+  cat > "$home/config/boards" <<'EOF'
+project = harbourlight
+owner = harbour-collective
+number = 4
+repo = harbour-collective/app
+label = firstmate
+big-picture-todo = Big Picture Todo
+big-picture-in-progress = Big Picture In Progress
+big-picture-done = Big Picture Done
+EOF
+  fields "$home" PVTSSF_status opt_todo:Todo 'opt_prog:In Progress' opt_done:Done \
+    'opt_bptodo:Big Picture Todo' 'opt_bpprog:Big Picture In Progress' \
+    'opt_bpdone:Big Picture Done'
+}
+
+issues_created() {
+  wc -l < "$1/issues" | tr -d ' '
+}
+
+test_the_container_lane_does_not_exist_until_it_is_configured() {
+  local home out
+  home=$(new_home the_container_lane_does_not_exist_until_it_is_configured)
+  # Exactly the container board, minus the three keys.
+  ordinary_board "$home"
+  item "$home" PVTI_a Issue https://github.com/harbour-collective/app/issues/200 \
+    'Big Picture Todo' firstmate - 'A container nobody configured for' -
+  item "$home" PVTI_b Issue https://github.com/harbour-collective/app/issues/201 \
+    Todo firstmate - 'Ordinary work' -
+
+  out=$(board "$home" poll)
+  assert_not_contains "$out" 'decompose' "an unconfigured home offered a decomposition"
+  assert_not_contains "$out" 'issues/200' "an unconfigured home acted on a container column at all"
+  assert_contains "$out" 'new harbourlight https://github.com/harbour-collective/app/issues/201 label' \
+    "an ordinary Todo card stopped being importable"
+  assert_absent "$home/data/board-decompositions.tsv" \
+    "an unconfigured home created a decomposition record"
+  [ "$(issues_created "$home")" = 0 ] || fail "an unconfigured home created an issue"
+  assert_contains "$(board "$home" boards)" 'big-picture=off' \
+    "an unconfigured board reported container columns"
+  pass "with no container columns configured nothing about decomposition exists"
+}
+
+test_a_partial_container_configuration_is_refused() {
+  local home out rc
+  home=$(new_home a_partial_container_configuration_is_refused)
+  cat > "$home/config/boards" <<'EOF'
+project = harbourlight
+owner = harbour-collective
+number = 4
+big-picture-todo = Big Picture Todo
+big-picture-done = Big Picture Done
+EOF
+  out=$(board "$home" poll 2>&1) && rc=0 || rc=$?
+  expect_code 2 "$rc" "a half-configured container lane was accepted"
+  assert_contains "$out" 'big-picture' "the refusal did not name the incomplete key set"
+  [ -z "$(gh_log "$home")" ] || fail "a refused configuration still reached GitHub"
+
+  cat > "$home/config/boards" <<'EOF'
+project = harbourlight
+owner = harbour-collective
+number = 4
+todo = Todo
+big-picture-todo = Todo
+big-picture-in-progress = Big Picture In Progress
+big-picture-done = Big Picture Done
+EOF
+  out=$(board "$home" poll 2>&1) && rc=0 || rc=$?
+  expect_code 2 "$rc" "one column serving as both ordinary and container work was accepted"
+  assert_contains "$out" 'more than one column' "the duplicate column was not named"
+  pass "a half-configured or self-overlapping container lane is refused, never half-enabled"
+}
+
+test_a_container_is_offered_for_decomposition_and_never_imported() {
+  local home parent out rc
+  home=$(new_home a_container_is_offered_for_decomposition_and_never_imported)
+  big_picture_board "$home"
+  parent=https://github.com/harbour-collective/app/issues/210
+  item "$home" PVTI_p Issue "$parent" 'Big Picture Todo' firstmate - 'Rebuild the harbour' 'lots of work'
+  item "$home" PVTI_q Issue https://github.com/harbour-collective/app/issues/211 \
+    'Big Picture Todo' - - 'An untagged container' -
+
+  out=$(board "$home" poll)
+  assert_contains "$out" "decompose harbourlight $parent" "a labelled container was not offered for decomposition"
+  assert_not_contains "$out" "new harbourlight $parent" "a container was offered as importable work"
+  assert_not_contains "$out" 'issues/211' "an untagged container was offered for decomposition"
+
+  # The binding a container must never spend is unspendable from the moment the
+  # board first showed the card, not only once it has been broken down.
+  out=$(board "$home" import harbourlight "$parent" fm-container 2>&1) && rc=0 || rc=$?
+  expect_code 3 "$rc" "a container was allowed to bind a task"
+  assert_contains "$out" 'container' "the refusal did not say why the container cannot hold a task"
+  [ -z "$(board "$home" links)" ] || fail "a container wrote a linkage record"
+
+  board "$home" decomposed harbourlight "$parent" >/dev/null
+  board "$home" import harbourlight "$parent" fm-container >/dev/null 2>&1 && rc=0 || rc=$?
+  expect_code 3 "$rc" "a decomposed container was allowed to bind a task"
+
+  # And the refusal closes from the other side too: an issue that already holds a
+  # task can never be turned into a container.
+  item "$home" PVTI_w Issue https://github.com/harbour-collective/app/issues/212 \
+    Todo firstmate - 'Ordinary work' -
+  board "$home" import harbourlight https://github.com/harbour-collective/app/issues/212 fm-ordinary >/dev/null
+  out=$(board "$home" child-add harbourlight https://github.com/harbour-collective/app/issues/212 \
+    'A child of ordinary work' 'body' fm-child 2>&1) && rc=0 || rc=$?
+  expect_code 3 "$rc" "work that already holds a task was accepted as a container"
+  assert_contains "$out" 'ordinary work' "the refusal did not say why the task cannot be a container"
+  pass "a labelled container is offered for decomposition, and container and task can never be the same issue"
+}
+
+test_a_container_is_never_offered_twice_once_decomposed() {
+  local home parent out
+  home=$(new_home a_container_is_never_offered_twice_once_decomposed)
+  big_picture_board "$home"
+  parent=https://github.com/harbour-collective/app/issues/220
+  item "$home" PVTI_p Issue "$parent" 'Big Picture Todo' firstmate - 'Rebuild the harbour' -
+
+  out=$(board "$home" poll)
+  assert_contains "$out" 'decompose' "the container was not offered at all"
+  # An interrupted decomposition is finished, not lost: it keeps being offered.
+  out=$(board "$home" poll)
+  assert_contains "$out" 'decompose' "an unfinished decomposition stopped being offered"
+
+  board "$home" decomposed harbourlight "$parent" >/dev/null
+  out=$(board "$home" poll)
+  assert_not_contains "$out" 'decompose' "a decomposed container was offered a second time"
+
+  # The record outlives the tasks it produced, exactly as the linkage record does.
+  rm -rf "$home/state"
+  out=$(board "$home" poll)
+  assert_not_contains "$out" 'decompose' "the decomposition record did not survive task cleanup"
+  pass "a container is decomposed once, ever, and the record outlives the work"
+}
+
+test_a_child_is_created_linked_and_never_re_imported() {
+  local home parent out child log
+  home=$(new_home a_child_is_created_linked_and_never_re_imported)
+  big_picture_board "$home"
+  parent=https://github.com/harbour-collective/app/issues/230
+  item "$home" PVTI_p Issue "$parent" 'Big Picture Todo' firstmate - 'Rebuild the harbour' -
+
+  out=$(board "$home" child-add harbourlight "$parent" 'Replace the mooring lines' \
+    'The first piece of the rebuild.' fm-moorings)
+  assert_contains "$out" "child harbourlight $parent" "the child was not reported as created"
+  child=$(printf '%s' "$out" | cut -d" " -f4)
+  log=$(gh_log "$home")
+  assert_contains "$log" "--parent $parent" "the child was not created as a native sub-issue of the parent"
+  assert_contains "$log" '--label firstmate' "the child did not carry the trigger label"
+  assert_contains "$log" '--single-select-option-id opt_todo' "the child was not set to the ordinary Todo column"
+  assert_not_contains "$log" 'project item-list' "creating a child read the whole board"
+  assert_contains "$(board "$home" lookup fm-moorings)" "$child" "the child did not record its issue-to-task link"
+
+  # The next cycle sees an ordinary linked card, never new work.
+  out=$(board "$home" poll)
+  assert_contains "$out" "linked harbourlight $child fm-moorings todo" "the child was not reported as linked"
+  assert_not_contains "$out" "new harbourlight $child" "the child was offered as fresh work to import"
+  pass "a child is created labelled, linked to its parent, carded in Todo, and never re-imported"
+}
+
+test_child_add_converges_instead_of_filing_a_second_issue() {
+  local home parent out first
+  home=$(new_home child_add_converges_instead_of_filing_a_second_issue)
+  big_picture_board "$home"
+  parent=https://github.com/harbour-collective/app/issues/240
+  item "$home" PVTI_p Issue "$parent" 'Big Picture Todo' firstmate - 'Rebuild the harbour' -
+
+  # The card cannot be added, so the run stops half way with the issue created.
+  out=$(GH_FAIL="project item-add" board "$home" child-add harbourlight "$parent" \
+    'Dredge the channel' 'Second piece.' fm-dredge)
+  assert_contains "$out" 'child-partial' "an interrupted child was reported as complete"
+  assert_contains "$out" ' card' "the partial result did not name the step that failed"
+  [ "$(issues_created "$home")" = 1 ] || fail "the interrupted run did not create exactly one issue"
+  first=$(cut -f2 "$home/issues")
+  [ -z "$(board "$home" lookup fm-dredge)" ] || fail "an uncarded child recorded a link"
+
+  # Re-running finishes the job rather than filing the work twice.
+  out=$(board "$home" child-add harbourlight "$parent" 'Dredge the channel' 'Second piece.' fm-dredge)
+  assert_contains "$out" "child harbourlight $parent $first fm-dredge" \
+    "the repeat run did not converge on the issue that already existed"
+  [ "$(issues_created "$home")" = 1 ] || fail "the repeat run filed a second issue for the same work"
+
+  # And a third run is a plain no-op that touches nothing at all.
+  : > "$home/gh.log"
+  out=$(board "$home" child-add harbourlight "$parent" 'Dredge the channel' 'Second piece.' fm-dredge)
+  assert_contains "$out" 'already-child' "a settled child was not reported as already done"
+  [ -z "$(gh_log "$home")" ] || fail "a settled child still reached GitHub"
+  pass "an interrupted child-add converges on the issue it already filed, never a second one"
+}
+
+test_a_container_card_follows_its_children() {
+  local home parent out log
+  home=$(new_home a_container_card_follows_its_children)
+  big_picture_board "$home"
+  parent=https://github.com/harbour-collective/app/issues/250
+  item "$home" PVTI_p Issue "$parent" 'Big Picture Todo' firstmate - 'Rebuild the harbour' -
+  board "$home" child-add harbourlight "$parent" 'Piece one' 'body' fm-piece-one >/dev/null
+  board "$home" child-add harbourlight "$parent" 'Piece two' 'body' fm-piece-two >/dev/null
+  board "$home" decomposed harbourlight "$parent" >/dev/null
+
+  # Nothing has started, so the container stays where it is and says nothing.
+  : > "$home/gh.log"
+  out=$(board "$home" poll)
+  assert_not_contains "$out" "$parent" "a settled container printed a record with nothing to report"
+  assert_not_contains "$(gh_log "$home")" 'item-edit' "a settled container was written to the board"
+
+  # One child starts.
+  board "$home" mark fm-piece-one in-progress >/dev/null
+  : > "$home/gh.log"
+  out=$(board "$home" poll)
+  assert_contains "$out" "synced harbourlight $parent - in-progress" \
+    "a child in progress did not move its container"
+  assert_contains "$(gh_log "$home")" '--single-select-option-id opt_bpprog' \
+    "the container was not moved to this board's own container In Progress column"
+
+  # Both children finish.
+  board "$home" mark fm-piece-one 'done' >/dev/null
+  board "$home" mark fm-piece-two 'done' >/dev/null
+  : > "$home/gh.log"
+  out=$(board "$home" poll)
+  assert_contains "$out" "synced harbourlight $parent - done" "all children done did not finish the container"
+  assert_contains "$(gh_log "$home")" '--single-select-option-id opt_bpdone' \
+    "the container was not moved to this board's own container Done column"
+
+  # Settled again, and silent again.
+  out=$(board "$home" poll)
+  assert_not_contains "$out" "$parent" "a settled container kept reporting"
+  pass "a container card follows its children's recorded states, and is silent once it matches"
+}
+
+test_an_outstanding_container_move_is_retried_on_the_next_cycle() {
+  local home parent out
+  home=$(new_home an_outstanding_container_move_is_retried_on_the_next_cycle)
+  big_picture_board "$home"
+  parent=https://github.com/harbour-collective/app/issues/260
+  item "$home" PVTI_p Issue "$parent" 'Big Picture Todo' firstmate - 'Rebuild the harbour' -
+  board "$home" child-add harbourlight "$parent" 'Piece one' 'body' fm-only-piece >/dev/null
+  board "$home" decomposed harbourlight "$parent" >/dev/null
+  board "$home" mark fm-only-piece in-progress >/dev/null
+
+  out=$(GH_FAIL="project item-edit" board "$home" poll)
+  assert_contains "$out" "stale harbourlight $parent - in-progress" \
+    "a container move that did not land was not reported as stale"
+  out=$(board "$home" poll)
+  assert_contains "$out" "synced harbourlight $parent - in-progress" \
+    "an outstanding container move was not retried on the next cycle"
+  pass "a container move that does not land leaves a stale card the next cycle reconciles"
+}
+
+# --- placing work firstmate already holds ------------------------------------
+
+test_place_is_the_inverse_of_import() {
+  local home out issue log
+  home=$(new_home place_is_the_inverse_of_import)
+  repo_board "$home"
+
+  out=$(board "$home" place harbourlight fm-already-mine 'Work that started in the backlog' \
+    'Filed by firstmate, not by the captain.')
+  assert_contains "$out" 'placed harbourlight' "the task was not placed on the board"
+  issue=$(printf '%s' "$out" | cut -d" " -f3)
+  log=$(gh_log "$home")
+  assert_contains "$log" '--label firstmate' "the placed card did not carry the trigger label"
+  assert_contains "$log" '--single-select-option-id opt_todo' "the placed card was not set to Todo"
+  assert_not_contains "$log" 'project item-list' "placing a card read the whole board"
+  assert_contains "$(board "$home" lookup fm-already-mine)" "$issue" "placing did not record the link"
+
+  # From here it is an ordinary board task: dispatch, PR and merge all work.
+  out=$(board "$home" mark fm-already-mine in-progress)
+  assert_contains "$out" "synced harbourlight $issue fm-already-mine in-progress" \
+    "a placed task did not move on dispatch"
+  out=$(board "$home" poll)
+  assert_not_contains "$out" 'new harbourlight' "a placed card was offered as fresh work to import"
+
+  # Repeating is a no-op that never files a second issue and never asks GitHub.
+  : > "$home/gh.log"
+  out=$(board "$home" place harbourlight fm-already-mine 'Work that started in the backlog')
+  assert_contains "$out" "already-placed harbourlight $issue fm-already-mine" \
+    "a repeat placement was not reported as already done"
+  [ "$(issues_created "$home")" = 1 ] || fail "a repeat placement filed a second issue"
+  [ -z "$(gh_log "$home")" ] || fail "a repeat placement reached GitHub at all"
+  pass "place is the inverse of import: one command, convergent, and ordinary afterwards"
+}
+
+test_place_says_where_the_change_actually_lands() {
+  local home out body
+  home=$(new_home place_says_where_the_change_actually_lands)
+  repo_board "$home"
+  board "$home" place harbourlight fm-elsewhere-work 'Work that lands in another repo' \
+    'The roadmap carries it; the diff does not.' --lands-in harbour-collective/tooling >/dev/null
+  body=$(cut -f4 "$home/issues")
+  assert_contains "$body" 'Lands in: harbour-collective/tooling' \
+    "the card did not say which repository the change lands in"
+  out=$(board "$home" place harbourlight fm-bad-repo 'Bad' 'Bad' --lands-in 'not a repo' 2>&1) && rc=0 || rc=$?
+  expect_code 2 "${rc:-0}" "a malformed landing repository was accepted"
+  pass "a card can state plainly that its change lands somewhere other than its own repository"
+}
+
+test_placement_converges_after_an_interrupted_run() {
+  local home out first
+  home=$(new_home placement_converges_after_an_interrupted_run)
+  repo_board "$home"
+
+  out=$(GH_FAIL="project item-add" board "$home" place harbourlight fm-interrupted 'Interrupted placement' 'body')
+  assert_contains "$out" 'placed-partial' "an interrupted placement was reported as complete"
+  [ "$(issues_created "$home")" = 1 ] || fail "the interrupted run did not create exactly one issue"
+  first=$(cut -f2 "$home/issues")
+
+  out=$(board "$home" place harbourlight fm-interrupted 'Interrupted placement' 'body')
+  assert_contains "$out" "placed harbourlight $first fm-interrupted" \
+    "the repeat run did not converge on the issue it had already filed"
+  [ "$(issues_created "$home")" = 1 ] || fail "the repeat run filed a second issue for the same task"
+  pass "an interrupted placement is finished on the next run, never filed twice"
+}
+
+test_an_unreadable_repo_never_files_a_duplicate() {
+  local home out rc
+  home=$(new_home an_unreadable_repo_never_files_a_duplicate)
+  repo_board "$home"
+  out=$(GH_FAIL="issue list" board "$home" place harbourlight fm-unreadable 'Work' 'body' 2>&1) && rc=0 || rc=$?
+  expect_code 1 "$rc" "a placement continued after it could not check for an existing issue"
+  [ "$(issues_created "$home")" = 0 ] || fail "an unchecked placement filed an issue anyway"
+  pass "a check that cannot run stops the placement rather than risking a duplicate"
+}
+
 # --- run --------------------------------------------------------------------
 
 test_boards_are_configuration_not_convention
@@ -789,7 +1261,9 @@ test_transitions_follow_firstmate_execution_events
 test_a_column_firstmate_does_not_drive_is_recorded_not_invented
 test_the_pull_request_is_attached_to_the_originating_issue
 test_a_blocker_is_recorded_on_the_issue
-test_a_captain_board_edit_is_an_instruction_never_a_correction
+test_a_status_firstmate_did_not_write_is_reported_not_reconciled
+test_a_queued_card_firstmate_did_not_place_never_starts_work
+test_the_queued_column_does_not_exist_until_it_is_configured
 test_a_withdrawn_card_stops_the_work_without_touching_it
 test_a_completed_card_leaving_the_board_is_not_a_withdrawal
 test_a_failed_board_write_never_blocks_delivery
@@ -800,3 +1274,15 @@ test_a_card_an_intake_filter_skips_is_not_a_withdrawal
 test_an_issue_another_board_owns_is_skipped_not_re_homed
 test_an_outstanding_pr_attachment_is_retried_on_the_next_cycle
 test_mark_reads_the_board_under_the_limit_it_is_given
+test_the_container_lane_does_not_exist_until_it_is_configured
+test_a_partial_container_configuration_is_refused
+test_a_container_is_offered_for_decomposition_and_never_imported
+test_a_container_is_never_offered_twice_once_decomposed
+test_a_child_is_created_linked_and_never_re_imported
+test_child_add_converges_instead_of_filing_a_second_issue
+test_a_container_card_follows_its_children
+test_an_outstanding_container_move_is_retried_on_the_next_cycle
+test_place_is_the_inverse_of_import
+test_place_says_where_the_change_actually_lands
+test_placement_converges_after_an_interrupted_run
+test_an_unreadable_repo_never_files_a_duplicate

--- a/tests/fm-board.test.sh
+++ b/tests/fm-board.test.sh
@@ -1,0 +1,675 @@
+#!/usr/bin/env bash
+# tests/fm-board.test.sh - the board-to-backlog bridge's correctness properties.
+#
+# Four of these are load-bearing rather than incidental. Importing an issue twice
+# must never produce two tasks, and the record that prevents it has to outlive
+# the task it names. A card the captain moved is an instruction, so a sync that
+# "corrects" it back is the defect this suite is written to catch. A board write
+# that fails must degrade to a stale board instead of blocking delivery. And a
+# withdrawn card must stop the work without touching it, so the cancellation case
+# runs against a real repository with real unlanded changes and proves they
+# survive.
+#
+# Every board here is invented for the case at hand - different owners, project
+# numbers, labels, status fields, and column names - because the adapter is a
+# firstmate capability rather than any one project's integration, and a fixture
+# that reused one canonical board would not show that.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+BOARD="$ROOT/bin/fm-board.sh"
+TMP_ROOT=$(fm_test_tmproot fm-board)
+
+# --- fixture plumbing -------------------------------------------------------
+
+# new_home <name>: create an isolated firstmate home with a stub GitHub CLI.
+new_home() {
+  local home
+  home="$TMP_ROOT/$1"
+  mkdir -p "$home/config" "$home/data" "$home/state" "$home/bin"
+  cat > "$home/bin/gh" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_LOG"
+if [ -n "${GH_FAIL:-}" ]; then
+  case "$1 $2" in
+    $GH_FAIL)
+      printf 'simulated GitHub failure\n' >&2
+      exit 1
+      ;;
+  esac
+fi
+case "$1 $2" in
+  "project item-list") cat "$GH_ITEMS" ;;
+  "project view") printf 'PVT_fixture\n' ;;
+  "project field-list") cat "$GH_FIELDS" ;;
+  "project item-edit")
+    # Behave like the real board: the edit is visible to the next read.
+    edit_id=''
+    edit_option=''
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --id) edit_id=$2; shift 2 ;;
+        --single-select-option-id) edit_option=$2; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    edit_name=$(awk -F'\t' -v o="$edit_option" '$1 == "option" && $2 == o { print $3 }' "$GH_FIELDS")
+    edit_tmp=$(mktemp)
+    awk -F'\t' -v OFS='\t' -v id="$edit_id" -v s="$edit_name" \
+      '$1 == id { $4 = s } { print }' "$GH_ITEMS" > "$edit_tmp"
+    mv "$edit_tmp" "$GH_ITEMS"
+    ;;
+  "issue comment") : ;;
+  *)
+    printf 'unexpected gh call: %s\n' "$*" >&2
+    exit 9
+    ;;
+esac
+SH
+  chmod +x "$home/bin/gh"
+  : > "$home/gh.log"
+  : > "$home/items"
+  : > "$home/fields"
+  printf '%s\n' "$home"
+}
+
+# board <home> <args...>: run the adapter against that home.
+board() {
+  local home=$1
+  shift
+  FM_HOME="$home" \
+  FM_CONFIG_OVERRIDE="$home/config" \
+  FM_DATA_OVERRIDE="$home/data" \
+  FM_BOARD_GH="$home/bin/gh" \
+  GH_LOG="$home/gh.log" \
+  GH_ITEMS="$home/items" \
+  GH_FIELDS="$home/fields" \
+  GH_FAIL="${GH_FAIL:-}" \
+    "$BOARD" "$@"
+}
+
+# item <home> <id> <type> <url> <status> <labels> <assignees> <title> <body>
+item() {
+  local home=$1
+  shift
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$@" >> "$home/items"
+}
+
+# fields <home> <field-id> <option-id:option-name>...
+fields() {
+  local home=$1 field=$2 spec
+  shift 2
+  printf 'field\t%s\n' "$field" > "$home/fields"
+  for spec in "$@"; do
+    printf 'option\t%s\t%s\n' "${spec%%:*}" "${spec#*:}" >> "$home/fields"
+  done
+}
+
+gh_log() {
+  cat "$1/gh.log"
+}
+
+# --- a board with an ordinary shape, and one with an unusual one -------------
+
+ordinary_board() {
+  local home=$1
+  cat > "$home/config/boards" <<'EOF'
+project = harbourlight
+owner = harbour-collective
+number = 4
+label = firstmate
+EOF
+  fields "$home" PVTSSF_status opt_todo:Todo 'opt_prog:In Progress' opt_done:Done
+}
+
+unusual_board() {
+  local home=$1
+  cat > "$home/config/boards" <<'EOF'
+project = tidewheel
+owner = personal-account
+number = 91
+repo = personal-account/tidewheel
+label = take-it-mate
+mention = @deckhand
+assignee = deckhand-bot
+status-field = Lane
+todo = Waiting
+in-progress = Under Way
+done = Landed
+EOF
+  fields "$home" PVTSSF_lane opt_wait:Waiting 'opt_under:Under Way' opt_landed:Landed
+}
+
+# --- configuration is the whole board identity ------------------------------
+
+test_boards_are_configuration_not_convention() {
+  local home out
+  home=$(new_home boards_are_configuration_not_convention)
+  ordinary_board "$home"
+  cat >> "$home/config/boards" <<'EOF'
+
+project = tidewheel
+owner = personal-account
+number = 91
+label = take-it-mate
+status-field = Lane
+todo = Waiting
+in-progress = Under Way
+done = Landed
+EOF
+  out=$(board "$home" boards)
+  assert_contains "$out" 'board harbourlight harbour-collective/4' "the first board is not listed"
+  assert_contains "$out" 'board tidewheel personal-account/91' "the second board is not listed"
+  assert_contains "$out" 'columns=Waiting|Under Way|Landed' "a board's own column names are not carried"
+  assert_contains "$out" 'label=take-it-mate' "a board's own trigger label is not carried"
+
+  home=$(new_home unconfigured_home)
+  out=$(board "$home" boards)
+  [ -z "$out" ] || fail "a home with no board configuration reported a board"
+  out=$(board "$home" poll)
+  [ -z "$out" ] || fail "a home with no board configuration polled something"
+  pass "boards come entirely from local configuration, and an unconfigured home has none"
+}
+
+test_the_bridge_is_inert_until_a_board_is_configured() {
+  local home out rc verb
+  home=$(new_home the_bridge_is_inert_until_a_board_is_configured)
+  [ ! -e "$home/config/boards" ] || fail "the fixture home already has board configuration"
+
+  out=$(board "$home" boards)
+  [ -z "$out" ] || fail "an unconfigured home listed a board: $out"
+  out=$(board "$home" poll)
+  [ -z "$out" ] || fail "an unconfigured home polled a board: $out"
+  out=$(board "$home" links)
+  [ -z "$out" ] || fail "an unconfigured home reported a link: $out"
+
+  # Every verb that needs a board refuses, and none of them reaches GitHub.
+  board "$home" lookup fm-nothing >/dev/null 2>&1 && rc=0 || rc=$?
+  [ "$rc" != 0 ] || fail "an unconfigured home resolved a link"
+  board "$home" import somewhere https://github.com/someone/app/issues/1 fm-x >/dev/null 2>&1 && rc=0 || rc=$?
+  expect_code 2 "$rc" "an unconfigured home accepted an import"
+  for verb in mark pr note ack; do
+    board "$home" "$verb" fm-x https://github.com/someone/app/pull/1 >/dev/null 2>&1 && rc=0 || rc=$?
+    [ "$rc" != 0 ] || fail "an unconfigured home accepted \"$verb\""
+  done
+
+  [ -z "$(gh_log "$home")" ] || fail "an unconfigured home called the GitHub CLI: $(gh_log "$home")"
+  assert_absent "$home/data/board-links.tsv" "an unconfigured home created a link record"
+  [ -z "$(ls -A "$home/state")" ] || fail "an unconfigured home created runtime state"
+
+  # An empty configuration file is the same as no file at all.
+  : > "$home/config/boards"
+  out=$(board "$home" poll)
+  [ -z "$out" ] || fail "an empty board configuration polled a board: $out"
+  printf '# only a comment\n\n' > "$home/config/boards"
+  out=$(board "$home" boards)
+  [ -z "$out" ] || fail "a configuration with no stanza reported a board: $out"
+  [ -z "$(gh_log "$home")" ] || fail "an empty board configuration called the GitHub CLI"
+  pass "with no board configured the bridge reads nothing, writes nothing, and creates nothing"
+}
+
+test_removing_the_configuration_is_the_off_switch() {
+  local home issue out before
+  home=$(new_home removing_the_configuration_is_the_off_switch)
+  ordinary_board "$home"
+  issue=https://github.com/harbour-collective/app/issues/130
+  item "$home" PVTI_a Issue "$issue" Todo firstmate - 'Runs while configured' -
+  board "$home" import harbourlight "$issue" fm-configured >/dev/null
+  board "$home" mark fm-configured in-progress >/dev/null
+  [ -n "$(gh_log "$home")" ] || fail "the configured board never reached GitHub"
+
+  rm -f "$home/config/boards"
+  : > "$home/gh.log"
+  out=$(board "$home" poll)
+  [ -z "$out" ] || fail "the bridge still polled after its configuration was removed: $out"
+  out=$(board "$home" boards)
+  [ -z "$out" ] || fail "the bridge still reported a board after its configuration was removed"
+  [ -z "$(gh_log "$home")" ] || fail "the bridge called GitHub after its configuration was removed"
+
+  # No residue: the only artifact is the durable link record, and it is inert.
+  before=$(cat "$home/data/board-links.tsv")
+  [ -z "$(ls -A "$home/state")" ] || fail "disabling left runtime state behind"
+  assert_absent "$home/config/x-mode.env" "disabling left a generated cadence file behind"
+  board "$home" poll >/dev/null
+  [ "$(cat "$home/data/board-links.tsv")" = "$before" ] || fail "a disabled bridge still rewrote its record"
+
+  # And disabling is not an undo: what was already imported is still recorded.
+  assert_contains "$before" 'fm-configured' "disabling erased an import that had already happened"
+  pass "removing the configuration disables the bridge with no residue, and undoes nothing already done"
+}
+
+test_malformed_configuration_is_an_actionable_error() {
+  local home out rc
+  home=$(new_home malformed_configuration_is_an_actionable_error)
+  printf 'project = alpha\nowner = someone\n' > "$home/config/boards"
+  out=$(board "$home" poll 2>&1) && rc=0 || rc=$?
+  expect_code 2 "$rc" "a board with no project number was accepted"
+  assert_contains "$out" 'has no number' "the missing project number was not named"
+
+  printf 'project = alpha\nowner = someone\nnumber = 4\ncolumn = Todo\n' > "$home/config/boards"
+  out=$(board "$home" poll 2>&1) && rc=0 || rc=$?
+  expect_code 2 "$rc" "an unknown configuration key was accepted"
+  assert_contains "$out" 'unknown key "column"' "the unknown key was not named"
+
+  printf 'project = alpha\nowner = someone\nnumber = four\n' > "$home/config/boards"
+  out=$(board "$home" poll 2>&1) && rc=0 || rc=$?
+  expect_code 2 "$rc" "a non-numeric project number was accepted"
+  pass "malformed board configuration is refused with the reason, not guessed around"
+}
+
+# --- intake -----------------------------------------------------------------
+
+test_only_projects_with_a_board_are_ever_mapped() {
+  local home issue out rc log
+  home=$(new_home only_projects_with_a_board_are_ever_mapped)
+  # Two projects in one home: one has a board, the other deliberately does not.
+  ordinary_board "$home"
+  issue=https://github.com/harbour-collective/app/issues/140
+  item "$home" PVTI_a Issue "$issue" Todo firstmate - 'On the board' -
+  board "$home" import harbourlight "$issue" fm-onboard >/dev/null
+  : > "$home/gh.log"
+
+  # Work on a project with no board has nowhere to go, and nothing is touched.
+  out=$(board "$home" import elsewhere https://github.com/other-org/elsewhere/issues/1 fm-elsewhere 2>&1) && rc=0 || rc=$?
+  expect_code 2 "$rc" "a project with no configured board was mapped to one"
+  assert_contains "$out" 'no board configured for project "elsewhere"' \
+    "the refusal did not name the unconfigured project"
+  board "$home" mark fm-elsewhere in-progress >/dev/null 2>&1 && rc=0 || rc=$?
+  [ "$rc" != 0 ] || fail "a task from a project with no board was moved on a board"
+  board "$home" note fm-elsewhere 'Blocked: nothing' >/dev/null 2>&1 && rc=0 || rc=$?
+  [ "$rc" != 0 ] || fail "a task from a project with no board commented on an issue"
+  [ -z "$(gh_log "$home")" ] || fail "work on a project with no board reached GitHub: $(gh_log "$home")"
+  out=$(board "$home" poll)
+  assert_not_contains "$out" 'elsewhere' "polling reported a project that has no board"
+
+  # A second, differently configured board never receives the first one's work.
+  cat >> "$home/config/boards" <<'EOF'
+
+project = tidewheel
+owner = personal-account
+number = 91
+EOF
+  : > "$home/gh.log"
+  board "$home" mark fm-onboard in-progress >/dev/null
+  log=$(gh_log "$home")
+  assert_contains "$log" '--owner harbour-collective' "the event did not resolve its own project's board"
+  assert_not_contains "$log" 'personal-account' "the event reached another project's board"
+  assert_not_contains "$log" 'project item-list 91' "the event read another project's board"
+  pass "only a project with a configured board is mapped, and boards never cross"
+}
+
+test_only_tagged_todo_issues_are_importable() {
+  local home out
+  home=$(new_home only_tagged_todo_issues_are_importable)
+  unusual_board "$home"
+  item "$home" PVTI_a Issue https://github.com/personal-account/tidewheel/issues/1 \
+    Waiting take-it-mate - 'Tagged and waiting' 'ordinary body'
+  item "$home" PVTI_b DraftIssue - Waiting take-it-mate - 'A draft card' -
+  item "$home" PVTI_c PullRequest https://github.com/personal-account/tidewheel/pull/2 \
+    Waiting take-it-mate - 'A pull request' -
+  item "$home" PVTI_d Issue https://github.com/personal-account/tidewheel/issues/3 \
+    'Under Way' take-it-mate - 'Tagged but already moved' -
+  item "$home" PVTI_e Issue https://github.com/personal-account/tidewheel/issues/4 \
+    Waiting - - 'Waiting but untagged' 'no trigger here'
+  item "$home" PVTI_f Issue https://github.com/personal-account/tidewheel/issues/5 \
+    Waiting - - 'Mentioned instead' 'hey @deckhand take this'
+  item "$home" PVTI_g Issue https://github.com/personal-account/tidewheel/issues/6 \
+    Waiting - deckhand-bot 'Assigned instead' -
+  item "$home" PVTI_h Issue https://github.com/other-org/elsewhere/issues/7 \
+    Waiting take-it-mate - 'Another repo on the same board' -
+
+  out=$(board "$home" poll)
+  assert_contains "$out" 'new tidewheel https://github.com/personal-account/tidewheel/issues/1 label' \
+    "a tagged issue waiting in the first column is not importable"
+  assert_contains "$out" 'issues/5 mention' "the optional mention trigger did not fire"
+  assert_contains "$out" 'issues/6 assignee' "the optional assignee trigger did not fire"
+  assert_not_contains "$out" 'A draft card' "a draft card was offered as importable work"
+  assert_not_contains "$out" 'pull/2' "a pull request was offered as importable work"
+  assert_not_contains "$out" 'issues/3' "an issue already past the first column was offered for import"
+  assert_not_contains "$out" 'issues/4' "an untagged issue was offered for import"
+  assert_not_contains "$out" 'other-org' "an issue outside the configured repo was offered for import"
+  pass "intake takes real issues, in the first column, carrying the configured trigger"
+}
+
+test_mention_and_assignee_triggers_are_off_by_default() {
+  local home out
+  home=$(new_home mention_and_assignee_triggers_are_off_by_default)
+  ordinary_board "$home"
+  item "$home" PVTI_a Issue https://github.com/harbour-collective/app/issues/1 \
+    Todo - - 'Only mentioned' 'please @firstmate take this'
+  item "$home" PVTI_b Issue https://github.com/harbour-collective/app/issues/2 \
+    Todo - firstmate 'Only assigned' -
+  out=$(board "$home" poll)
+  [ -z "$out" ] || fail "an unconfigured mention or assignee trigger fired anyway: $out"
+  pass "the label is the authoritative trigger; mention and assignee stay off unless configured"
+}
+
+# --- idempotent import ------------------------------------------------------
+
+test_importing_the_same_issue_twice_is_a_no_op() {
+  local home out rc issue
+  home=$(new_home importing_the_same_issue_twice_is_a_no_op)
+  ordinary_board "$home"
+  issue=https://github.com/harbour-collective/app/issues/12
+  item "$home" PVTI_a Issue "$issue" Todo firstmate - 'Add a mooring' -
+
+  out=$(board "$home" import harbourlight "$issue" fm-mooring)
+  assert_contains "$out" "linked harbourlight $issue fm-mooring" "the first import did not link"
+
+  out=$(board "$home" import harbourlight "$issue" fm-mooring) && rc=0 || rc=$?
+  expect_code 0 "$rc" "re-importing an already-linked issue failed instead of being a no-op"
+  assert_contains "$out" 'already-linked' "the repeat import was not reported as already linked"
+  [ "$(board "$home" links | wc -l)" = 1 ] || fail "re-importing produced a second linkage record"
+
+  out=$(board "$home" poll)
+  assert_not_contains "$out" 'new harbourlight' "an already-linked issue was offered for import again"
+  assert_contains "$out" "linked harbourlight $issue fm-mooring todo" "the linked issue was not reported as linked"
+
+  out=$(board "$home" import harbourlight "$issue" fm-different 2>&1) && rc=0 || rc=$?
+  expect_code 3 "$rc" "relinking an issue to a different task was allowed"
+  assert_contains "$out" 'already linked to task fm-mooring' "the refusal did not name the existing task"
+  [ "$(board "$home" links | wc -l)" = 1 ] || fail "a refused relink still wrote a record"
+  pass "one issue holds one task: repeat import is a no-op and a conflicting relink is refused"
+}
+
+test_the_link_outlives_the_task_it_names() {
+  local home out issue
+  home=$(new_home the_link_outlives_the_task_it_names)
+  ordinary_board "$home"
+  issue=https://github.com/harbour-collective/app/issues/20
+  item "$home" PVTI_a Issue "$issue" Todo firstmate - 'Long-lived work' -
+  board "$home" import harbourlight "$issue" fm-longlived >/dev/null
+
+  # Everything a finished task leaves in state/ goes away at cleanup.
+  printf 'window=x\n' > "$home/state/fm-longlived.meta"
+  printf 'done: shipped\n' > "$home/state/fm-longlived.status"
+  rm -rf "$home/state"
+
+  out=$(board "$home" lookup "$issue") || fail "the link did not survive task cleanup"
+  assert_contains "$out" 'fm-longlived' "the surviving link lost its task identity"
+  out=$(board "$home" poll)
+  assert_not_contains "$out" 'new harbourlight' "a torn-down task's issue became importable again"
+  pass "the linkage record lives with the durable fleet records and survives task cleanup"
+}
+
+# --- status transitions driven by execution events --------------------------
+
+test_transitions_follow_firstmate_execution_events() {
+  local home issue out log
+  home=$(new_home transitions_follow_firstmate_execution_events)
+  unusual_board "$home"
+  issue=https://github.com/personal-account/tidewheel/issues/8
+  item "$home" PVTI_a Issue "$issue" Waiting take-it-mate - 'Ship it' -
+  board "$home" import tidewheel "$issue" fm-ship >/dev/null
+  assert_contains "$(board "$home" lookup fm-ship)" "	todo	todo	" "a fresh import did not start in the first column"
+
+  # Dispatch.
+  out=$(board "$home" mark fm-ship in-progress)
+  assert_contains "$out" "synced tidewheel $issue fm-ship in-progress" "dispatch did not move the card"
+  log=$(gh_log "$home")
+  assert_contains "$log" 'project item-edit --id PVTI_a --project-id PVT_fixture --field-id PVTSSF_lane --single-select-option-id opt_under' \
+    "the dispatch write did not set this board's own In Progress option"
+
+  # Merge.
+  : > "$home/gh.log"
+  out=$(board "$home" mark fm-ship 'done')
+  assert_contains "$out" "synced tidewheel $issue fm-ship done" "the merge did not move the card"
+  assert_contains "$(gh_log "$home")" '--single-select-option-id opt_landed' \
+    "the merge write did not set this board's own Done option"
+  assert_contains "$(board "$home" lookup fm-ship)" "	done	done	" "the record did not follow the card"
+  pass "Todo, In Progress, and Done are driven by dispatch and merge, on the board's own column names"
+}
+
+test_a_column_firstmate_does_not_drive_is_recorded_not_invented() {
+  local home issue out rc
+  home=$(new_home a_column_firstmate_does_not_drive_is_recorded_not_invented)
+  ordinary_board "$home"
+  issue=https://github.com/harbour-collective/app/issues/30
+  item "$home" PVTI_a Issue "$issue" Todo firstmate - 'Parked work' -
+  board "$home" import harbourlight "$issue" fm-parked >/dev/null
+
+  : > "$home/items"
+  item "$home" PVTI_a Issue "$issue" 'Needs Review' firstmate - 'Parked work' -
+  out=$(board "$home" poll)
+  assert_contains "$out" "instruction harbourlight $issue fm-parked todo other Needs Review" \
+    "a column outside the three did not surface as an instruction carrying its own name"
+  assert_contains "$(board "$home" lookup fm-parked)" "	other	other	" \
+    "the captain's own column was not recorded"
+
+  out=$(board "$home" mark fm-parked blocked 2>&1) && rc=0 || rc=$?
+  expect_code 2 "$rc" "the adapter accepted a fourth execution state"
+  pass "a column the captain added is recorded as the board's own, never as a fourth state to drive"
+}
+
+# --- PR linkage -------------------------------------------------------------
+
+test_the_pull_request_is_attached_to_the_originating_issue() {
+  local home issue pr out
+  home=$(new_home the_pull_request_is_attached_to_the_originating_issue)
+  ordinary_board "$home"
+  issue=https://github.com/harbour-collective/app/issues/40
+  pr=https://github.com/harbour-collective/app/pull/41
+  item "$home" PVTI_a Issue "$issue" Todo firstmate - 'Needs a PR' -
+  board "$home" import harbourlight "$issue" fm-pr >/dev/null
+
+  out=$(board "$home" pr fm-pr "$pr")
+  assert_contains "$out" "attached harbourlight $issue fm-pr $pr" "the PR was not attached"
+  assert_contains "$(gh_log "$home")" "issue comment $issue --body Working PR: $pr" \
+    "the PR link did not land on the originating issue"
+  assert_contains "$(board "$home" lookup fm-pr)" "$pr" "the PR was not recorded against the link"
+
+  : > "$home/gh.log"
+  out=$(board "$home" pr fm-pr "$pr")
+  assert_contains "$out" 'already-attached' "re-attaching the same PR was not a no-op"
+  [ -z "$(gh_log "$home")" ] || fail "re-attaching the same PR commented on the issue a second time"
+  pass "the working PR is attached to the issue that started the work, once"
+}
+
+test_a_blocker_is_recorded_on_the_issue() {
+  local home issue out
+  home=$(new_home a_blocker_is_recorded_on_the_issue)
+  ordinary_board "$home"
+  issue=https://github.com/harbour-collective/app/issues/50
+  item "$home" PVTI_a Issue "$issue" Todo firstmate - 'Will block' -
+  board "$home" import harbourlight "$issue" fm-blocked >/dev/null
+  board "$home" mark fm-blocked in-progress >/dev/null
+
+  out=$(board "$home" note fm-blocked 'Blocked: the staging credential expired')
+  assert_contains "$out" "noted harbourlight $issue fm-blocked" "the blocker was not recorded"
+  assert_contains "$(gh_log "$home")" 'issue comment '"$issue"' --body Blocked: the staging credential expired' \
+    "the blocker did not land on the issue"
+  out=$(board "$home" poll)
+  assert_contains "$out" "linked harbourlight $issue fm-blocked in-progress" \
+    "a blocked item stopped being visible on the board"
+  pass "a blocker is recorded on the issue while the item stays visible where it is"
+}
+
+# --- the board owns intent --------------------------------------------------
+
+test_a_captain_board_edit_is_an_instruction_never_a_correction() {
+  local home issue out log
+  home=$(new_home a_captain_board_edit_is_an_instruction_never_a_correction)
+  ordinary_board "$home"
+  issue=https://github.com/harbour-collective/app/issues/60
+  item "$home" PVTI_a Issue "$issue" Todo firstmate - 'Reprioritized work' -
+  board "$home" import harbourlight "$issue" fm-repri >/dev/null
+  board "$home" mark fm-repri in-progress >/dev/null
+
+  # The captain pulls the card back to the first column.
+  : > "$home/items"
+  : > "$home/gh.log"
+  item "$home" PVTI_a Issue "$issue" Todo firstmate - 'Reprioritized work' -
+  out=$(board "$home" poll)
+  assert_contains "$out" "instruction harbourlight $issue fm-repri in-progress todo Todo" \
+    "the captain's move backwards was not surfaced as an instruction"
+  log=$(gh_log "$home")
+  assert_not_contains "$log" 'item-edit' "the sync tried to correct the captain's own board edit"
+  assert_contains "$(board "$home" lookup fm-repri)" "	todo	todo	" \
+    "the record did not reconcile to the captain's board"
+
+  # And it stays reconciled rather than drifting back on the next cycle.
+  out=$(board "$home" poll)
+  assert_contains "$out" "linked harbourlight $issue fm-repri todo" "the reconciled state did not hold"
+  pass "a captain's board edit reconciles the record and is never written back over"
+}
+
+test_a_withdrawn_card_stops_the_work_without_touching_it() {
+  local home issue out repo before after
+  home=$(new_home a_withdrawn_card_stops_the_work_without_touching_it)
+  ordinary_board "$home"
+  issue=https://github.com/harbour-collective/app/issues/70
+  item "$home" PVTI_a Issue "$issue" Todo firstmate - 'Withdrawn work' -
+  board "$home" import harbourlight "$issue" fm-withdrawn >/dev/null
+  board "$home" mark fm-withdrawn in-progress >/dev/null
+
+  # A real worktree with real unlanded work, exactly what a cancellation must
+  # never cost.
+  repo="$home/work"
+  fm_git_init_commit "$repo"
+  git -C "$repo" checkout -q -b fm/withdrawn-work
+  printf 'half-finished\n' > "$repo/feature.txt"
+  before=$(git -C "$repo" status --porcelain)
+
+  : > "$home/items"
+  : > "$home/gh.log"
+  item "$home" PVTI_other Issue https://github.com/harbour-collective/app/issues/71 \
+    Done - - 'Something else on the board' -
+  out=$(board "$home" poll)
+  assert_contains "$out" "cancelled harbourlight $issue fm-withdrawn in-progress" \
+    "a card that left the board was not reported as withdrawn"
+  assert_not_contains "$(gh_log "$home")" 'item-edit' "the withdrawal triggered a board write"
+
+  board "$home" ack fm-withdrawn >/dev/null
+  after=$(git -C "$repo" status --porcelain)
+  [ "$before" = "$after" ] || fail "unlanded work changed while reconciling a withdrawn card"
+  assert_present "$repo/feature.txt" "unlanded work was removed while reconciling a withdrawn card"
+  git -C "$repo" rev-parse --verify -q fm/withdrawn-work >/dev/null \
+    || fail "the branch was removed while reconciling a withdrawn card"
+
+  out=$(board "$home" poll)
+  assert_not_contains "$out" 'cancelled' "an acknowledged withdrawal kept being reported"
+  out=$(board "$home" lookup "$issue") || fail "the link was dropped when the card was withdrawn"
+  pass "a withdrawn card is reported until reconciled, and never costs unlanded work"
+}
+
+test_a_completed_card_leaving_the_board_is_not_a_withdrawal() {
+  local home issue out
+  home=$(new_home a_completed_card_leaving_the_board_is_not_a_withdrawal)
+  ordinary_board "$home"
+  issue=https://github.com/harbour-collective/app/issues/80
+  item "$home" PVTI_a Issue "$issue" Todo firstmate - 'Finished work' -
+  board "$home" import harbourlight "$issue" fm-finished >/dev/null
+  board "$home" mark fm-finished 'done' >/dev/null
+  : > "$home/items"
+  item "$home" PVTI_other Issue https://github.com/harbour-collective/app/issues/81 \
+    Todo - - 'Something else on the board' -
+  out=$(board "$home" poll)
+  assert_not_contains "$out" 'cancelled' "archiving a finished card was reported as a withdrawal"
+  pass "archiving a finished card is ordinary housekeeping, not a withdrawal"
+}
+
+# --- fail soft --------------------------------------------------------------
+
+test_a_failed_board_write_never_blocks_delivery() {
+  local home issue out rc
+  home=$(new_home a_failed_board_write_never_blocks_delivery)
+  ordinary_board "$home"
+  issue=https://github.com/harbour-collective/app/issues/90
+  item "$home" PVTI_a Issue "$issue" Todo firstmate - 'Ships anyway' -
+  board "$home" import harbourlight "$issue" fm-ships >/dev/null
+
+  out=$(GH_FAIL='project item-edit' board "$home" mark fm-ships in-progress 2>/dev/null) && rc=0 || rc=$?
+  expect_code 0 "$rc" "a failed board write stopped the dispatch"
+  assert_contains "$out" "stale harbourlight $issue fm-ships in-progress" \
+    "the failed write was not reported as a stale board"
+  assert_contains "$(board "$home" lookup fm-ships)" "	in-progress	todo	" \
+    "the failed write was not left outstanding for the next cycle"
+
+  out=$(GH_FAIL='issue comment' board "$home" pr fm-ships https://github.com/harbour-collective/app/pull/91 2>/dev/null) && rc=0 || rc=$?
+  expect_code 0 "$rc" "a failed PR comment stopped the delivery report"
+  assert_contains "$out" 'stale' "the failed PR comment was not reported as a stale board"
+
+  out=$(GH_FAIL='issue comment' board "$home" note fm-ships 'Blocked: nothing' 2>/dev/null) && rc=0 || rc=$?
+  expect_code 0 "$rc" "a failed blocker note stopped the cycle"
+
+  # The next cycle reconciles what the failed write left behind.
+  out=$(board "$home" poll)
+  assert_contains "$out" "synced harbourlight $issue fm-ships in-progress" \
+    "the next cycle did not retry the outstanding board write"
+  assert_contains "$(board "$home" lookup fm-ships)" "	in-progress	in-progress	" \
+    "the retried write was not recorded as confirmed"
+  pass "board writes degrade to a stale board and reconcile on the next cycle"
+}
+
+test_a_failed_board_read_never_blocks_the_cycle() {
+  local home out rc
+  home=$(new_home a_failed_board_read_never_blocks_the_cycle)
+  ordinary_board "$home"
+  item "$home" PVTI_a Issue https://github.com/harbour-collective/app/issues/100 \
+    Todo firstmate - 'Unreadable today' -
+  out=$(GH_FAIL='project item-list' board "$home" poll 2>/dev/null) && rc=0 || rc=$?
+  expect_code 0 "$rc" "a board read failure stopped the cycle"
+  assert_contains "$out" 'error harbourlight could not read project harbour-collective/4' \
+    "the board read failure was not reported"
+  assert_not_contains "$out" 'cancelled' "an unreadable board was mistaken for withdrawn work"
+  pass "an unreadable board is reported and retried, never mistaken for withdrawn work"
+}
+
+test_an_empty_board_is_not_taken_as_mass_withdrawal() {
+  local home out
+  home=$(new_home an_empty_board_is_not_taken_as_mass_withdrawal)
+  ordinary_board "$home"
+  item "$home" PVTI_a Issue https://github.com/harbour-collective/app/issues/120 \
+    Todo firstmate - 'Still open' -
+  board "$home" import harbourlight https://github.com/harbour-collective/app/issues/120 fm-open >/dev/null
+
+  # The board answers successfully with nothing at all - a changed project
+  # number or a lost permission looks exactly like this.
+  : > "$home/items"
+  out=$(board "$home" poll)
+  assert_contains "$out" 'error harbourlight the board returned no cards while links are open' \
+    "an empty board read was not reported"
+  assert_not_contains "$out" 'cancelled' "an empty board read was taken as withdrawing every card"
+  assert_contains "$(board "$home" lookup fm-open)" '	todo	todo	' "an empty board read changed a record"
+  pass "a board that answers with nothing while links are open is reported, not obeyed"
+}
+
+test_a_truncated_read_reconciles_nothing() {
+  local home out
+  home=$(new_home a_truncated_read_reconciles_nothing)
+  ordinary_board "$home"
+  item "$home" PVTI_a Issue https://github.com/harbour-collective/app/issues/110 \
+    Todo firstmate - 'First' -
+  item "$home" PVTI_b Issue https://github.com/harbour-collective/app/issues/111 \
+    Todo firstmate - 'Second' -
+  board "$home" import harbourlight https://github.com/harbour-collective/app/issues/999 fm-offpage >/dev/null
+  out=$(board "$home" poll --limit 2)
+  assert_contains "$out" 'truncated harbourlight 2' "a full page was not reported as possibly truncated"
+  assert_not_contains "$out" 'cancelled' "a page boundary was mistaken for a withdrawn card"
+  pass "a page boundary is never mistaken for absence"
+}
+
+# --- run --------------------------------------------------------------------
+
+test_boards_are_configuration_not_convention
+test_the_bridge_is_inert_until_a_board_is_configured
+test_removing_the_configuration_is_the_off_switch
+test_malformed_configuration_is_an_actionable_error
+test_only_projects_with_a_board_are_ever_mapped
+test_only_tagged_todo_issues_are_importable
+test_mention_and_assignee_triggers_are_off_by_default
+test_importing_the_same_issue_twice_is_a_no_op
+test_the_link_outlives_the_task_it_names
+test_transitions_follow_firstmate_execution_events
+test_a_column_firstmate_does_not_drive_is_recorded_not_invented
+test_the_pull_request_is_attached_to_the_originating_issue
+test_a_blocker_is_recorded_on_the_issue
+test_a_captain_board_edit_is_an_instruction_never_a_correction
+test_a_withdrawn_card_stops_the_work_without_touching_it
+test_a_completed_card_leaving_the_board_is_not_a_withdrawal
+test_a_failed_board_write_never_blocks_delivery
+test_a_failed_board_read_never_blocks_the_cycle
+test_an_empty_board_is_not_taken_as_mass_withdrawal
+test_a_truncated_read_reconciles_nothing

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -928,6 +928,89 @@ SH
   pass "bootstrap: FM_BOOTSTRAP_NETWORK partitions one run into local and network halves"
 }
 
+# The session start is the cycle that makes the board reconcile on its own
+# rather than because firstmate remembered to poll. It has to run in the network
+# half, print only what firstmate must act on, and stay completely absent in a
+# home that configured no board.
+test_a_configured_board_is_reconciled_by_the_session_start() {
+  local case_dir fakebin out
+  case_dir="$TMP_ROOT/board-poll"
+  mkdir -p "$case_dir/home/config" "$case_dir/home/data" "$case_dir/home/state"
+  printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
+  cat > "$case_dir/home/config/boards" <<'EOF'
+project = harbourlight
+owner = harbour-collective
+number = 4
+label = firstmate
+EOF
+  fakebin=$(make_fake_toolchain "$case_dir")
+  # One tagged card waiting to be taken, and one already showing exactly what
+  # firstmate recorded.
+  printf '# links\n' > "$case_dir/home/data/board-links.tsv"
+  printf 'harbourlight\thttps://github.com/harbour-collective/app/issues/2\tfm-settled\ttodo\ttodo\t-\t-\n' \
+    >> "$case_dir/home/data/board-links.tsv"
+  cat > "$fakebin/gh" <<'SH'
+#!/usr/bin/env bash
+case "${1:-} ${2:-}" in
+  "project item-list")
+    printf 'PVTI_a	Issue	https://github.com/harbour-collective/app/issues/1	Todo	firstmate	-	New work	-
+'
+    printf 'PVTI_b	Issue	https://github.com/harbour-collective/app/issues/2	Todo	firstmate	-	Settled work	-
+'
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/gh"
+
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$ROOT" \
+    FM_CONFIG_OVERRIDE="$case_dir/home/config" FM_DATA_OVERRIDE="$case_dir/home/data" \
+    FM_FAKE_TREEHOUSE_LEASE_HELP=1 FM_BOOTSTRAP_NETWORK=only "$ROOT/bin/fm-bootstrap.sh")
+  assert_contains "$out" 'BOARD_POLL: new harbourlight https://github.com/harbour-collective/app/issues/1 label' \
+    "a session start did not surface work waiting on the board"
+  assert_not_contains "$out" 'issues/2' \
+    "a card already showing what firstmate recorded added noise to the session start"
+
+  # The local half never touches the board, so the digest itself stays off the
+  # network exactly as before.
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$ROOT" \
+    FM_CONFIG_OVERRIDE="$case_dir/home/config" FM_DATA_OVERRIDE="$case_dir/home/data" \
+    FM_FAKE_TREEHOUSE_LEASE_HELP=1 FM_BOOTSTRAP_NETWORK=skip "$ROOT/bin/fm-bootstrap.sh")
+  assert_not_contains "$out" 'BOARD_POLL' "the local half read a board"
+
+  # A read-only session is not authorized to mutate anything, so it polls nothing.
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$ROOT" \
+    FM_CONFIG_OVERRIDE="$case_dir/home/config" FM_DATA_OVERRIDE="$case_dir/home/data" \
+    FM_FAKE_TREEHOUSE_LEASE_HELP=1 FM_BOOTSTRAP_NETWORK=only \
+    FM_BOOTSTRAP_DETECT_ONLY=1 "$ROOT/bin/fm-bootstrap.sh")
+  assert_not_contains "$out" 'BOARD_POLL' "a read-only session reconciled a board"
+  pass "bootstrap: a configured board is reconciled by the session start, reporting only what needs acting on"
+}
+
+test_a_home_with_no_board_reconciles_nothing() {
+  local case_dir fakebin out log
+  case_dir="$TMP_ROOT/board-poll-absent"
+  mkdir -p "$case_dir/home/config" "$case_dir/home/state"
+  printf '%s\n' manual > "$case_dir/home/config/backlog-backend"
+  fakebin=$(make_fake_toolchain "$case_dir")
+  log="$case_dir/gh.log"
+  cat > "$fakebin/gh" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> '$log'
+exit 0
+SH
+  chmod +x "$fakebin/gh"
+  : > "$log"
+
+  out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$case_dir/home" FM_ROOT_OVERRIDE="$ROOT" \
+    FM_CONFIG_OVERRIDE="$case_dir/home/config" \
+    FM_FAKE_TREEHOUSE_LEASE_HELP=1 FM_BOOTSTRAP_NETWORK=only "$ROOT/bin/fm-bootstrap.sh")
+  assert_not_contains "$out" 'BOARD_POLL' "a home with no board reported a board poll"
+  assert_not_contains "$out" 'board' "a home with no board named the board sweep at all"
+  assert_no_grep 'project item-list' "$log" "a home with no board read a project board"
+  pass "bootstrap: a home with no board configuration reads no board and never names the sweep"
+}
+
 test_network_sweeps_recheck_lock_ownership() {
   local case_dir fakebin fake_root marker out
   case_dir="$TMP_ROOT/network-lock-handoff"
@@ -1172,6 +1255,8 @@ test_routine_bootstrap_confirmations_are_silent
 test_routine_bootstrap_contract_runs_under_system_bash
 test_network_phase_partitions_the_run
 test_network_sweeps_recheck_lock_ownership
+test_a_configured_board_is_reconciled_by_the_session_start
+test_a_home_with_no_board_reconciles_nothing
 test_network_phases_record_per_step_elapsed_times
 test_tasks_axi_verdict_handoff_is_consumed_once
 test_crew_dispatch_active_rules_are_verbose_bootstrap_info

--- a/tests/fm-pr-merge.test.sh
+++ b/tests/fm-pr-merge.test.sh
@@ -29,7 +29,7 @@ make_case() {
   local name=$1 case_dir fakebin
   case_dir="$TMP_ROOT/$name"
   fakebin="$case_dir/fakebin"
-  mkdir -p "$case_dir/state" "$fakebin"
+  mkdir -p "$case_dir/state" "$case_dir/config" "$case_dir/data" "$fakebin"
   fm_write_meta "$case_dir/state/task-x1.meta" \
     "window=fm-task-x1" \
     "worktree=$case_dir/wt" \
@@ -84,11 +84,55 @@ SH
   chmod +x "$case_dir/fakebin/gh-axi" "$case_dir/fakebin/gh"
 }
 
+# add_board <case-dir> <task-id> <issue-url>: give this case a configured board
+# with the task already linked to a card on it, and a GitHub CLI that answers
+# both fm-pr-check.sh's head lookup and the board reads, recording every board
+# call it is asked to make.
+add_board() {
+  local case_dir=$1 task=$2 issue=$3
+  cat > "$case_dir/config/boards" <<'EOF'
+project = example
+owner = example
+number = 3
+repo = example/repo
+EOF
+  printf '# links\n' > "$case_dir/data/board-links.tsv"
+  printf 'example\t%s\t%s\tin-progress\tin-progress\t-\t-\n' "$issue" "$task" \
+    >> "$case_dir/data/board-links.tsv"
+  : > "$case_dir/board.log"
+  cat > "$case_dir/fakebin/gh" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> '$case_dir/board.log'
+case "\${1:-} \${2:-}" in
+  "pr view")
+    case " \$* " in
+      *headRefOid*) printf '%s\n' '5555555555555555555555555555555555555555' ;;
+    esac
+    ;;
+  "project view") printf 'PVT_fixture\n' ;;
+  "project field-list")
+    printf 'field\tPVTSSF_status\n'
+    printf 'option\topt_done\tDone\n'
+    ;;
+  "project item-list")
+    printf 'PVTI_a\tIssue\t%s\tIn Progress\t-\t-\tcard\t-\n' '$issue'
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/gh"
+}
+
 run_pr_merge() {
   local case_dir=$1 rc; shift
+  # config/ and data/ are pinned into the case so a merge can never reach the
+  # developer's own board configuration or linkage record.
   FM_ROOT_OVERRIDE="$ROOT" \
   FM_STATE_OVERRIDE="$case_dir/state" \
+  FM_CONFIG_OVERRIDE="$case_dir/config" \
+  FM_DATA_OVERRIDE="$case_dir/data" \
   FM_TEST_GH_AXI_LOG="$case_dir/gh-axi.log" \
+  FM_TEST_BOARD_LOG="$case_dir/board.log" \
   PATH="$case_dir/fakebin:$PATH" \
     "$PR_MERGE" "$@"
   rc=$?
@@ -301,8 +345,77 @@ test_parses_pr_url_for_gh_axi() {
   pass "fm-pr-merge parses a GitHub PR URL into gh-axi number and --repo arguments"
 }
 
+# A merged PR closes its card the same way a dispatch opens one: as a property
+# of merging, not of anyone remembering a second command. A merge that did not
+# land must leave the card exactly where it was.
+test_a_confirmed_merge_closes_the_card() {
+  local case_dir rc
+  case_dir=$(make_case board-merge-closes-card)
+  mkdir -p "$case_dir/wt"
+  add_gh_mocks "$case_dir" 3333333333333333333333333333333333333333
+  add_board "$case_dir" task-x1 https://github.com/example/repo/issues/7
+  : > "$case_dir/gh-axi.log"
+
+  set +e
+  run_pr_merge "$case_dir" task-x1 https://github.com/example/repo/pull/21 \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "board-merge-closes-card: the merge should succeed"
+  assert_grep "$(printf 'https://github.com/example/repo/issues/7\ttask-x1\tdone\tdone')" \
+    "$case_dir/data/board-links.tsv" \
+    "board-merge-closes-card: a confirmed merge did not close the card on the board"
+  assert_grep 'Working PR: https://github.com/example/repo/pull/21' "$case_dir/board.log" \
+    "board-merge-closes-card: the PR was never attached to its originating issue"
+  pass "a confirmed merge closes the originating card and attaches the PR that did it"
+}
+
+test_a_failed_merge_leaves_the_card_alone() {
+  local case_dir rc
+  case_dir=$(make_case board-failed-merge)
+  mkdir -p "$case_dir/wt"
+  add_gh_mocks_merge_fails "$case_dir"
+  add_board "$case_dir" task-x1 https://github.com/example/repo/issues/8
+  : > "$case_dir/gh-axi.log"
+
+  set +e
+  run_pr_merge "$case_dir" task-x1 https://github.com/example/repo/pull/22 \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 1 "$rc" "board-failed-merge: the merge failure should propagate"
+  assert_no_grep "$(printf '\tdone\tdone')" "$case_dir/data/board-links.tsv" \
+    "board-failed-merge: a merge that never landed still closed the card"
+  pass "a merge that did not land never closes the card"
+}
+
+test_a_task_with_no_card_never_reaches_a_board() {
+  local case_dir rc
+  case_dir=$(make_case board-unlinked-task)
+  mkdir -p "$case_dir/wt"
+  add_gh_mocks "$case_dir" 4444444444444444444444444444444444444444
+  : > "$case_dir/gh-axi.log"
+  : > "$case_dir/board.log"
+
+  set +e
+  run_pr_merge "$case_dir" task-x1 https://github.com/example/repo/pull/23 \
+    > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+
+  expect_code 0 "$rc" "board-unlinked-task: the merge should succeed"
+  [ ! -s "$case_dir/board.log" ] \
+    || fail "board-unlinked-task: a task with no card still reached a board: $(cat "$case_dir/board.log")"
+  pass "a task with no card reaches no board at all when its PR merges"
+}
+
 test_records_pr_and_head_before_merging
 test_merge_failure_propagates_after_recording
+test_a_confirmed_merge_closes_the_card
+test_a_failed_merge_leaves_the_card_alone
+test_a_task_with_no_card_never_reaches_a_board
 test_extra_merge_args_forwarded
 test_missing_meta_refuses_before_merge
 test_malformed_url_refuses_before_merge


### PR DESCRIPTION
## What this adds

Three optional `big-picture-*` columns turn a container card into a decomposition request. `poll` reports `decompose`, firstmate breaks the container into concrete work, and `bin/fm-board.sh child-add` files each piece as a **native GitHub sub-issue** carded in the ordinary Todo column, so the board's own `Parent issue` and `Sub-issues progress` fields carry the structure with nothing invented on top. The parent card then follows its children.

Correction 2 added the missing direction: `place` puts a task that started in the backlog onto the board. It and `child-add` turned out to be the same operation with different parents, so they run one shared implementation rather than two that can drift.

Correction 5's ruling is encoded throughout: firstmate's records are the truth and the board reports them. A card showing a status firstmate did not write is a `divergence` that changes nothing on either side and is raised with the captain, replacing the old `instruction` adoption path. Filing a card stays the captain's intent, and board-sourced work lands **held**.

## Constraints, and how each is held

**A container never binds a task** - closed from four sides, not by convention: `poll` never emits `new` for a card in a big-picture column; `poll` writes the container's record the first time it *sees* the card rather than when it is decomposed; `import` refuses any issue holding that record; `child-add` refuses a parent that holds a link. Tested from both directions. The residual gap is an `import` of a container URL that no poll has ever seen, which requires inventing a URL the adapter never surfaced; the header states that boundary rather than implying it is closed.

**A child is never re-imported** - it carries the trigger label and holds a link before the next cycle reads the board, so `poll` reports it `linked`. The link is written as soon as the card exists, not at the very end, precisely so a just-created card is never briefly importable as fresh work.

**Convergence** - a repeat `place`/`child-add` for the same task never files a second issue, through three guards in falling order of cost: an existing link answers with no network call at all; a child already recorded against its parent is reused; otherwise a shallow scan of the repo's newest issues adopts one already carrying the task's `firstmate-task:` marker. A scan that *could not run* stops the command rather than risking a duplicate - a failed read is not the same answer as "nothing found".

**Rate limits** - `place` and `child-add` read no board at all, taking the card id from what `item-add` returned (a freshly added card is not visible in `item-list` anyway). Board/field/option ids resolve once per invocation. Cost is a small constant per card, independent of board size. Stated in a new `COST` section of the header.

**Fail soft** - unchanged. The one deliberate addition: `child-add`/`place` exit 1 if the issue itself could not be created, because that is the command's whole purpose and firstmate must not build a backlog item on it. Everything after that irreversible step degrades to `*-partial` and exits 0.

## Automatic reflection (correction 2, section 7)

`fm-spawn.sh` places-then-marks on a ship dispatch, `fm-pr-check.sh` attaches the PR, `fm-pr-merge.sh` closes the card after a merge that actually landed. All three are inert for a task with no link and for every home with no board - proven by a test asserting the GitHub CLI is never invoked at all. None can fail a dispatch or alter a merge's outcome.

## Session-start reconciliation (section 9)

The poll runs in the deferred network stage `bin/fm-startup-network.sh` already owns, via `fm-bootstrap.sh`'s network phase, printing actionable lines as `BOARD_POLL:`. No wake source, watcher check, timer, or daemon was added. It is skipped in a read-only session, and a home with no board never even names the sweep.

**This required a second AGENTS.md line beyond the trigger change.** Section 3 enumerates what the deferred network stage owes; leaving board reconciliation out of that list would have made the owner statement wrong. Total AGENTS.md diff is three lines: the trigger, that enumeration, and one `data/` layout entry for the new record file.

## On `fm-board-quiet-poll`'s invariants

Every new path satisfies them from the start: one board read per cycle, all writes against that snapshot, no refetch, and **every new record type is silent when reconciled** - a settled container prints nothing.

I did **not** suppress the pre-existing `linked` lines, which is that item's own stated purpose and carries its own test changes. Instead the session-start surfacing filters them out, so the new automatic poll adds no noise to every session while leaving `fm-board-quiet-poll` its scope, including invariant 7's complexity guard.

`fm-board-area-field` and `fm-board-closed-issue-withdrawal` were left alone.

## Verification

- `bin/fm-lint.sh` clean with both pinned linters (ShellCheck 0.11.0, actionlint 1.7.12; neither was installed here, so both were fetched at their pinned versions).
- `tests/fm-board.test.sh` 38 pass, `tests/fm-board-dispatch.test.sh` 6 pass (new), `tests/fm-bootstrap.test.sh` 30 pass, `tests/fm-pr-merge.test.sh` 13 pass, plus `fm-pr-check-security`, `fm-spawn-batch` and `fm-spawn-dispatch-profile` unaffected.
- Coverage includes: the feature fully off when keys are unset, a partial key set failing loudly, `decompose` never being `new`, a decomposed parent never reported twice, `child-add` and `place` convergent on repeat runs, parent status derived from child states, an ordinary Todo card untouched, a card firstmate did not place in `queued` producing a report and no dispatch, and a board that refuses every write never failing a dispatch.
- Two existing tests changed rather than being added to, because correction 5 reversed the rule they encoded: a captain's status edit is no longer adopted into firstmate's record.

While fixing the merge-reflection test I found the pr-merge fixture's `gh` mock ends in `exit 0`, so an appended case block was unreachable - which had made a first attempt at the assertion pass falsely. The mock is now written whole, and `run_pr_merge` pins `FM_CONFIG_OVERRIDE`/`FM_DATA_OVERRIDE` into the case so a merge test can never reach a developer's real board configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
