### PR TITLE
fix(bin): forbid agent commit co-authors in every generated crewmate brief

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -49,7 +49,7 @@
 # declared-external-wait verb (FM_CLASSIFY_PAUSED_VERB, default "paused") from
 # "blocked:": pause for a known external wait expected to clear on its own,
 # blocked when firstmate must act.
-# Every crewmate scaffold also carries the no-agent-co-author commit rule, so a
+# Every ship and scout scaffold also carries the no-agent-co-author commit rule, so a
 # worker that never reads firstmate's AGENTS.md still receives it.
 # Ship tasks include a project-memory section so durable project-intrinsic
 # learnings can be committed to AGENTS.md through the project's delivery path;

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -49,6 +49,8 @@
 # declared-external-wait verb (FM_CLASSIFY_PAUSED_VERB, default "paused") from
 # "blocked:": pause for a known external wait expected to clear on its own,
 # blocked when firstmate must act.
+# Every crewmate scaffold also carries the no-agent-co-author commit rule, so a
+# worker that never reads firstmate's AGENTS.md still receives it.
 # Ship tasks include a project-memory section so durable project-intrinsic
 # learnings can be committed to AGENTS.md through the project's delivery path;
 # it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers
@@ -335,6 +337,7 @@ The report is the only thing that survives, so anything worth keeping must be in
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+8. Never add an agent name as a commit co-author: no \`Co-Authored-By:\` trailer naming Claude, Codex, Cursor, Grok, Orca, or any other agent, model, or tool.
 
 # Definition of done
 Write your findings to \`$DATA/$ID/report.md\`.
@@ -452,6 +455,7 @@ $RULE1
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+8. Never add an agent name as a commit co-author: no \`Co-Authored-By:\` trailer naming Claude, Codex, Cursor, Grok, Orca, or any other agent, model, or tool.
 
 # Project memory
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -690,6 +690,32 @@ test_scout_and_secondmate_load_decision_hold_policy() {
   pass "fm-brief.sh: investigation and visual-review completions load the shared decision policy"
 }
 
+test_every_crewmate_scaffold_forbids_agent_co_authors() {
+  local home kind id brief
+  home="$TMP_ROOT/co-author-home"
+  mkdir -p "$home/data"
+
+  for kind in no-mistakes direct-PR local-only scout; do
+    id="brief-co-author-$kind"
+    case "$kind" in
+      scout)
+        FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" alpha --scout >/dev/null 2>&1 \
+          || fail "fm-brief.sh scout scaffold exited non-zero"
+        ;;
+      *)
+        FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" alpha --mode "$kind" >/dev/null 2>&1 \
+          || fail "fm-brief.sh $kind scaffold exited non-zero"
+        ;;
+    esac
+    brief="$home/data/$id/brief.md"
+    assert_grep "Never add an agent name as a commit co-author" "$brief" \
+      "$kind brief did not carry the no-agent-co-author commit rule"
+    assert_grep "Co-Authored-By:" "$brief" \
+      "$kind brief did not name the trailer the rule forbids"
+  done
+  pass "fm-brief.sh: every crewmate scaffold forbids agent commit co-authors"
+}
+
 # Scout and secondmate paths still scaffold well-formed briefs.
 test_scout_and_secondmate_scaffold() {
   local brief
@@ -732,3 +758,4 @@ test_secondmate_directory_paths_are_absolute_and_output_is_stable
 test_pause_verb_override_renders_all_brief_scaffolds
 test_scout_and_secondmate_load_decision_hold_policy
 test_scout_and_secondmate_scaffold
+test_every_crewmate_scaffold_forbids_agent_co_authors


### PR DESCRIPTION
## Intent

Firstmate repo task: stop agent co-author trailers from reaching landed history.

THE DEFECT: AGENTS.md carries the rule 'Never add an agent name as a commit co-author', but it is not reaching crewmates, because the generated brief scaffold never states it and firstmate does not reliably restate it by hand. Measured 2026-08-17: agent Co-Authored-By trailers are present across landed history in projects/InsightEngine (Claude Opus 5, Claude Code) and projects/orca-command-center (Orca, Claude Opus 5 1M context), including commits landed that same night. This is a rig defect, not a worker discipline problem: a rule that only lives in a file the worker never reads is not a control.

DELIVERABLE 1, pick the mechanism and say why. Two candidates were named: A, emit the rule in the standard brief contract so bin/fm-brief.sh states it in the generated Rules section of every ship brief and no brief can omit it; B, strip or refuse agent Co-Authored-By trailers on the commit path. The task required weighing them (A is advisory and depends on worker compliance; B is deterministic but needs a commit path firstmate actually controls across every harness and backend), considering whether both are warranted, and making the reasoning visible in the PR body rather than buried. CHOSEN: A only, deliberately, for these reasons which belong in the PR body: (1) firstmate owns no commit path that every worker goes through; workers commit inside project worktrees under eight verified harnesses plus muse, on five runtime backends. (2) The existing PreToolUse infrastructure (bin/fm-arm-pretool-check.sh) only sees a command string, so it cannot see a message supplied via -F, a heredoc, EDITOR, or a later --amend; a shell-layer guard is silently bypassed by ordinary usage. (3) The only guard that catches every message source is a git commit-msg hook, which lives in the project's shared .git common dir and is repo-wide config; installing one means firstmate writing into project git config, colliding with any project that already sets core.hooksPath, and affecting commits made outside firstmate entirely, trading a documentation gap for a project-mutation surface. (4) The no-mistakes pipeline is an external binary and not extensible here. (5) A is sufficient because the defect was never worker non-compliance, it was that the rule lived exclusively in AGENTS.md, which is firstmate's own instruction surface and which a crewmate in a project worktree never reads; the brief is the one document every crewmate does read, so stating it there closes the actual gap.

DELIVERABLE 2, implement it with a colocated test that fails against the current code and passes after, showing both. Implemented as rule 8 of the standard Rules section in bin/fm-brief.sh: 'Never add an agent name as a commit co-author: no Co-Authored-By: trailer naming Claude, Codex, Cursor, Grok, Orca, or any other agent, model, or tool.' Applied to BOTH the ship and the scout scaffold, deliberately: bin/fm-promote.sh keeps the scout brief loaded and sends ship instructions by message, so a promoted worker never receives a ship brief and its scratch work becomes ship commits under scout rules. A one-sentence pointer was added to the fm-brief.sh header, which is the owner of what the generated scaffolds contain. Test added to the existing colocated tests/fm-brief.test.sh as test_every_crewmate_scaffold_forbids_agent_co_authors, covering all four scaffolds (no-mistakes, direct-PR, local-only, scout). Evidence shown to the captain: before the change it reported 'not ok - no-mistakes brief did not carry the no-agent-co-author commit rule'; after, the suite is 21 ok / 0 not ok. The test asserts on the GENERATED brief output, which is fm-brief.sh's own generated public artifact, not on implementation source bytes.

DELIVERABLE 3, sweep the already-landed local-only commits: determine which existing commits carrying agent co-author trailers are still local-only (not pushed to any remote) and therefore still amendable, REPORT the list, and do NOT amend or rewrite any history. Done and reported: exactly one fleet-wide, InsightEngine acfb2e1f 'chore(planning): archive v1.0 ATX-1457 milestone', 2026-07-15, trailer 'Cursor <cursoragent@cursor.com>', reachable only from tag v1.0-atx-1457 and on no local or remote branch. Nothing was amended. Everything else is already pushed and stays as it is: InsightEngine has 1,563 trailered commits on remote refs, orca-command-center 61, and this repo's one (bc1a21b) is on fork/main.

HARD CONSTRAINTS accepted and honored, do not flag these as omissions: do not rewrite git history (no rebase -i, no filter-branch, no commit --amend on anything but the worker's own in-progress commit); do not touch anything under projects/ (the sweep was strictly read-only); do not weaken or restate the AGENTS.md rule in a second place, so AGENTS.md stays the owner and the brief is the allowed single-line reinforcement at the risk point, and AGENTS.md was deliberately NOT edited at all (minimal means zero here). Per .agents/skills/firstmate-coding-guidelines, a single deliberate one-line reinforcement at a genuine risk point is permitted and is what rule 8 is.

Commit hygiene was itself in scope: the delivered commit carries no Co-Authored-By trailer naming any agent. Verified: git log -1 --format='%(trailers)' is empty.

Verification already run locally: tests/fm-brief.test.sh 21 ok / 0 not ok; bin/fm-lint.sh clean (ShellCheck 0.11.0 pinned; actionlint absent locally and no workflow was touched); bin/fm-doc-audience-check.sh ok (surfaces=69, local_links=255); adjacent suites green: fm-ask-user-authority, fm-secondmate-safety 77 ok, fm-subagent-pretool-check 13 ok, fm-tangle-guard 6 ok.

## What Changed

- `bin/fm-brief.sh` now emits rule 8 in the standard Rules section of both the ship and the scout scaffold: "Never add an agent name as a commit co-author: no `Co-Authored-By:` trailer naming Claude, Codex, Cursor, Grok, Orca, or any other agent, model, or tool." The scout scaffold gets it too because `bin/fm-promote.sh` keeps the scout brief loaded and sends ship instructions by message, so a promoted worker's scratch work becomes ship commits under scout rules. A one-line pointer was added to the `fm-brief.sh` header, which owns what the generated scaffolds contain.
- `tests/fm-brief.test.sh` gains `test_every_crewmate_scaffold_forbids_agent_co_authors`, asserting on the generated `brief.md` for all four scaffolds (no-mistakes, direct-PR, local-only, scout) that both the rule text and the forbidden `Co-Authored-By:` trailer name are present. Against the base commit it reports `not ok - no-mistakes brief did not carry the no-agent-co-author commit rule`; with the change the suite is 21 ok / 0 not ok.
- Mechanism choice, stated here rather than buried: this is the brief-contract fix (A), not a commit-path guard (B), and A alone is deliberate. Firstmate owns no commit path every worker goes through — workers commit inside project worktrees across eight verified harnesses plus muse on five runtime backends. The existing `bin/fm-arm-pretool-check.sh` PreToolUse hook only sees a command string, so it cannot see a message supplied via `-F`, a heredoc, `EDITOR`, or a later `--amend`; a shell-layer guard is silently bypassed by ordinary usage. The only guard catching every message source is a `commit-msg` hook, which lives in the project's shared git common dir, collides with any project that sets `core.hooksPath`, and would affect commits made outside firstmate entirely — trading a documentation gap for a project-mutation surface. The no-mistakes pipeline is an external binary and not extensible here. The defect was never worker non-compliance: the rule lived only in `AGENTS.md`, firstmate's own instruction surface, which a crewmate in a project worktree never reads. `AGENTS.md` stays the owner and was deliberately left unedited; the brief is the one document every crewmate does read.

Read-only sweep of already-landed agent co-author trailers (nothing amended, no history rewritten, nothing under `projects/` touched): exactly one trailered commit is still local-only and therefore amendable — InsightEngine `acfb2e1f` "chore(planning): archive v1.0 ATX-1457 milestone" (2026-07-15, trailer `Cursor <cursoragent@cursor.com>`), reachable only from tag `v1.0-atx-1457` and on no local or remote branch. Everything else is already pushed and stays as it is: InsightEngine 1,563 trailered commits on remote refs, orca-command-center 61, and this repo's one (`bc1a21b`) on `fork/main`.

## Risk Assessment

✅ Low: Additive, well-bounded change: two identical instruction lines in the two brief heredocs that cover all four crewmate scaffolds, plus a colocated test that executes the real script and asserts on its generated brief artifact; no control flow, no existing assertion or downstream rule-number reference is affected.

## Testing

Exercised bin/fm-brief.sh directly and captured the generated brief.md — the document a crewmate actually reads — for all four scaffolds under both base and target code: rule 8 forbidding agent Co-Authored-By trailers is absent before and present after in every one, with rules 1-7 unchanged. The colocated suite passes 21 ok / 0 not ok at target, and the same target test file run against a pristine base-commit checkout fails on the new assertion, establishing the fail-before/pass-after regression. Also confirmed no history rewrite (base is ancestor, one new commit), no files touched outside bin/ and tests/, and zero Co-Authored-By trailer lines on the delivered commit. No screenshot applies: the change has no rendered UI surface — its end-user surface is generated markdown text, which is captured verbatim in the artifacts. Worktree left clean and temp scratch directories removed.

<details>
<summary>Evidence: Generated brief.md Rules section — base vs target, all four scaffolds</summary>

Source: [Generated brief.md Rules section — base vs target, all four scaffolds](https://github.com/Lakescape/firstmate/blob/e3f4d9cfb2959887bb52e064c4e2d1e27d4710c1/.no-mistakes/evidence/fm/fm-brief-agent-coauthor-rule/generated-brief-rules-before-after.txt)

```text
Generated crewmate brief.md — Rules section, base 1cb900c vs target 82a8d63
Command per scaffold: FM_HOME=<tmp> bin/fm-brief.sh <id> alpha --mode <kind>   (scout: --scout)

################ scaffold: no-mistakes ################
---------------- BEFORE (1cb900c) ----------------
# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/fmbrief-demo.dNujCP/before/state/demo-no-mistakes.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

---------------- AFTER (82a8d63) -----------------
# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/fmbrief-demo.dNujCP/after/state/demo-no-mistakes.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.
8. Never add an agent name as a commit co-author: no `Co-Authored-By:` trailer naming Claude, Codex, Cursor, Grok, Orca, or any other agent, model, or tool.


################ scaffold: direct-PR ################
---------------- BEFORE (1cb900c) ----------------
# Rules
1. Never push to the default branch (push only your `fm/demo-direct-PR` branch). Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/fmbrief-demo.dNujCP/before/state/demo-direct-PR.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

---------------- AFTER (82a8d63) -----------------
# Rules
1. Never push to the default branch (push only your `fm/demo-direct-PR` branch). Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/fmbrief-demo.dNujCP/after/state/demo-direct-PR.status'`
   States: wo

... [3626 bytes truncated] ...

stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

---------------- AFTER (82a8d63) -----------------
# Rules
1. Never push to any remote and never open a PR. Work only on your `fm/demo-local-only` branch; firstmate handles the merge into local `main`.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/fmbrief-demo.dNujCP/after/state/demo-local-only.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will apply the configured authority and reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.
8. Never add an agent name as a commit co-author: no `Co-Authored-By:` trailer naming Claude, Codex, Cursor, Grok, Orca, or any other agent, model, or tool.


################ scaffold: scout ################
---------------- BEFORE (1cb900c) ----------------
# Rules
1. Never push to any remote and never open a PR.
2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/fmbrief-demo.dNujCP/before/state/demo-scout.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on and the needs-decision/blocked/paused/done/failed states. No step-by-step
   FYI progress lines; firstmate reads your pane for that.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset):
   firstmate then leaves your idle pane alone and rechecks it on a long cadence instead of
   treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

---------------- AFTER (82a8d63) -----------------
# Rules
1. Never push to any remote and never open a PR.
2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/tmp/fmbrief-demo.dNujCP/after/state/demo-scout.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on and the needs-decision/blocked/paused/done/failed states. No step-by-step
   FYI progress lines; firstmate reads your pane for that.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset):
   firstmate then leaves your idle pane alone and rechecks it on a long cadence instead of
   treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.
8. Never add an agent name as a commit co-author: no `Co-Authored-By:` trailer naming Claude, Codex, Cursor, Grok, Orca, or any other agent, model, or tool.
```
</details>
<details>
<summary>Evidence: Regression counterfactual: new test fails on base code, passes on target</summary>

Source: [Regression counterfactual: new test fails on base code, passes on target](https://github.com/Lakescape/firstmate/blob/e3f4d9cfb2959887bb52e064c4e2d1e27d4710c1/.no-mistakes/evidence/fm/fm-brief-agent-coauthor-rule/test-counterfactual-before-after.txt)

<code>=== Counterfactual: target tests/fm-brief.test.sh run against BASE code 1cb900c ===&#10;not ok - no-mistakes brief did not carry the no-agent-co-author commit rule&#10;&#10;=== Same suite against TARGET code 82a8d63 ===&#10;ok - fm-brief.sh: every crewmate scaffold forbids agent commit co-authors&#10;&#10;ok count: 21 not-ok count: 0</code>

```text
=== Counterfactual: tests/fm-brief.test.sh (target test file) run against BASE code 1cb900c ===
not ok - no-mistakes brief did not carry the no-agent-co-author commit rule

=== Same suite against TARGET code 82a8d63 ===
ok - fm-brief.sh: investigation and visual-review completions load the shared decision policy
ok - fm-brief: scout and secondmate code paths still scaffold well-formed briefs
ok - fm-brief.sh: every crewmate scaffold forbids agent commit co-authors

ok count: 21   not-ok count: 0
```
</details>
<details>
<summary>Evidence: Rule 8 presence matrix across scaffolds (generated brief.md)</summary>

```text
scaffold BEFORE(1cb900c) AFTER(82a8d63)
no-mistakes 0 hit 1 hit
direct-PR 0 hit 1 hit
local-only 0 hit 1 hit
scout 0 hit 1 hit

AFTER, brief.md line 46:
8. Never add an agent name as a commit co-author: no `Co-Authored-By:` trailer naming Claude, Codex, Cursor, Grok, Orca, or any other agent, model, or tool.
```
</details>
<details>
<summary>Evidence: Hard-constraint checks: no history rewrite, scope, commit hygiene</summary>

```text
$ git merge-base --is-ancestor 1cb900c 82a8d63 && echo OK
1cb900c is ancestor of 82a8d63: OK
$ git rev-list --count 1cb900c..82a8d63
1
$ git diff --name-only 1cb900c 82a8d63
bin/fm-brief.sh
tests/fm-brief.test.sh
$ git log -1 --format='%B' 82a8d63 | grep -cE '^Co-Authored-By:'
0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"8319331879f4e39616a1e17374e78c1146995229","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-brief.test.sh` at target 82a8d63 — 21 ok / 0 not ok, including the new `test_every_crewmate_scaffold_forbids_agent_co_authors`</code>
- <code>Counterfactual: `git archive 1cb900c | tar -x -C $SCRATCH`, copied the target `tests/fm-brief.test.sh` in, ran `bash tests/fm-brief.test.sh` there → `not ok - no-mistakes brief did not carry the no-agent-co-author commit rule`</code>
- <code>Manual CLI exercise, ship scaffolds: `FM_HOME=&lt;tmp&gt; bin/fm-brief.sh demo-&lt;kind&gt; alpha --mode &lt;no-mistakes|direct-PR|local-only&gt;` against both base and target binaries; diffed the generated `brief.md` Rules sections</code>
- <code>Manual CLI exercise, scout scaffold: `FM_HOME=&lt;tmp&gt; bin/fm-brief.sh demo-scout alpha --scout` against both base and target</code>
- <code>Scope check on the secondmate path: `FM_HOME=&lt;tmp&gt; bin/fm-brief.sh demo-secondmate --secondmate alpha` — charter has no Rules section and no commit instruction, correctly excluded</code>
- <code>`git merge-base --is-ancestor 1cb900c 82a8d63` and `git rev-list --count 1cb900c..82a8d63` → 1 (no history rewrite)</code>
- <code>`git diff --name-only 1cb900c 82a8d63` → only bin/fm-brief.sh and tests/fm-brief.test.sh</code>
- <code>`git log -1 --format=&#39;%B&#39; 82a8d63 | grep -cE &#39;^Co-Authored-By:&#39;` → 0, and `git log -1 --format=&#39;%(trailers)&#39;` empty</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
