### PR TITLE
fix(bin): fold path spellings in worktree and watcher identity checks

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1690,15 +1690,17 @@ BRIEF_REAL="$BRIEF_DIR_REAL/$(basename "$BRIEF")"
 # isolation guard refuses a spawn that never actually tangled). Canonicalize
 # once here so every downstream comparison uses the same physical form
 # (docs/herdr-backend.md "Known gaps").
-PROJ_ABS_REAL=$(cd "$PROJ_ABS" 2>/dev/null && pwd -P) || PROJ_ABS_REAL="$PROJ_ABS"
+#
+# fm_canonical_path (bin/fm-wake-lib.sh) is used rather than `cd … && pwd -P`
+# because pwd -P preserves the CALLER's spelling of each component. On a
+# case-insensitive filesystem a session opened as .../Firstmate and a treehouse
+# path spelled .../firstmate are one directory, and a pwd -P compare calls them
+# different - which let a crewmate be placed directly in the primary clone with
+# no refusal. See fm_canonical_path's header for why realpath(1) is required.
+PROJ_ABS_REAL=$(fm_canonical_path "$PROJ_ABS")
 
 real_path_or_raw() {  # <path>
-  local path=$1 real
-  if real=$(cd "$path" 2>/dev/null && pwd -P); then
-    printf '%s\n' "$real"
-  else
-    printf '%s\n' "$path"
-  fi
+  fm_canonical_path "$1"
 }
 
 # Session-provider container-ensure + task creation. tmux stays exactly as P1
@@ -1712,19 +1714,49 @@ real_path_or_raw() {  # <path>
 validate_spawn_worktree() {  # <source> <inspect-target>
   local source=$1 inspect_target=$2 wt_real proj_real wt_top wt_top_real
   wt_real=
-  if ! wt_real=$(cd "$WT" 2>/dev/null && pwd -P); then
-    wt_real=
+  if [ -d "$WT" ]; then
+    wt_real=$(fm_canonical_path "$WT")
   fi
   proj_real=$PROJ_ABS_REAL
   wt_top=$(git -C "$WT" rev-parse --show-toplevel 2>/dev/null || true)
   wt_top_real=
-  if ! wt_top_real=$(cd "$wt_top" 2>/dev/null && pwd -P); then
-    wt_top_real=
+  if [ -n "$wt_top" ] && [ -d "$wt_top" ]; then
+    wt_top_real=$(fm_canonical_path "$wt_top")
   fi
   if [ -z "$wt_real" ] || [ -z "$wt_top_real" ] || [ "$wt_real" != "$wt_top_real" ] || [ "$wt_real" = "$proj_real" ]; then
     echo "error: $source did not yield an isolated worktree (resolved '$WT'; worktree root '${wt_top:-none}'; primary '$PROJ_ABS'); refusing to launch to avoid tangling the primary checkout. Inspect target $inspect_target" >&2
     exit 1
   fi
+}
+
+# warn_worktree_double_leased <worktree> <task-id>
+# Check AFTER acquisition whether the slot treehouse actually handed us is one that
+# another task's metadata already records. A pool slot is a reusable lease, so
+# the slot printed at request time is not proof of what the lease landed on; only
+# reading back the settled path and checking it against the recorded fleet is.
+# Recorded worktree= values and the landed path are compared in canonical physical
+# form so two spellings of one slot cannot read as two different slots.
+#
+# This WARNS rather than refuses, deliberately. A lingering record is usually just
+# a finished task whose teardown has not run yet, and a pool slot is legitimately
+# reused after that; hard-failing here would block routine spawns on stale
+# metadata. The destructive end is where the ambiguity actually causes damage, and
+# bin/fm-teardown.sh's validate_worktree_branch_identity refuses there on positive
+# proof. Surfacing it at spawn gives the supervisor the chance to reconcile the
+# stale pointer before two records name one slot.
+warn_worktree_double_leased() {  # <worktree> <task-id>
+  local wt=$1 id=$2 wt_real other_meta other_id other_wt
+  wt_real=$(fm_canonical_path "$wt")
+  for other_meta in "$STATE"/*.meta; do
+    [ -e "$other_meta" ] || continue
+    other_id=$(basename "$other_meta" .meta)
+    [ "$other_id" != "$id" ] || continue
+    other_wt=$(fm_meta_get "$other_meta" worktree)
+    [ -n "$other_wt" ] || continue
+    [ "$(fm_canonical_path "$other_wt")" = "$wt_real" ] || continue
+    echo "warning: task $id landed in worktree '$wt_real', which task '$other_id' also records." >&2
+    echo "If '$other_id' is finished, tear it down so one workspace is not recorded by two tasks; cleanup refuses a slot holding another task's branch." >&2
+  done
 }
 
 freshen_spawn_worktree_base() {  # <worktree>
@@ -2241,7 +2273,12 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
       p_real=$(real_path_or_raw "$p")
       if [ "$p_real" != "$PROJ_ABS_REAL" ]; then
         if [ -n "$candidate" ] && [ "$p_real" = "$candidate" ]; then
-          WT="$p"
+          # Record the CANONICAL landed path, not the raw pane string: this value
+          # becomes worktree= in state/<id>.meta, and teardown later aims
+          # destructive operations at it. Keeping the same physical form that was
+          # just validated means the recorded pointer and the checked path are
+          # never two different spellings of the lease.
+          WT="$p_real"
           break
         fi
         candidate="$p_real"
@@ -2259,6 +2296,7 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   fi
 
   validate_spawn_worktree "treehouse get" "$T"
+  warn_worktree_double_leased "$WT" "$ID"
 fi
 if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ]; then
   freshen_spawn_worktree_base "$WT" || exit 1

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1134,6 +1134,43 @@ teardown_treehouse_return() {
   return 1
 }
 
+# validate_worktree_branch_identity <worktree> <task-id>
+# Refuse to tear down a pooled worktree that is demonstrably ANOTHER task's
+# workspace. fm-spawn records worktree= in state/<id>.meta, but a treehouse pool
+# slot is a reusable lease: under pool churn a recorded slot can already have been
+# returned and re-leased to a different live task. Teardown's next steps delete the
+# checked-out branch and hard-reset the worktree, so aiming at a recycled slot
+# destroys another crewmate's unlanded work.
+#
+# The identity signal is the checked-out branch against the fm/<id> convention the
+# generated brief establishes (bin/fm-brief.sh). This refuses ONLY on positive proof
+# of a conflict - the worktree is on some OTHER task's fm/<other-id> branch. A
+# detached HEAD, a non-fm/ branch name, or an unreadable branch is NOT proof of a
+# mismatch (a landed task legitimately ends detached, and crewmates may pick their
+# own branch names), so those keep teardown on its existing checks rather than
+# blocking routine cleanup on a weak signal.
+#
+# This runs before the destructive block and is deliberately NOT exempted by
+# --force or by kind=scout: those exemptions exist to authorize discarding THIS
+# task's own work, never to authorize touching a different task's workspace.
+validate_worktree_branch_identity() {  # <worktree> <task-id>
+  local wt=$1 id=$2 branch other
+  [ -d "$wt" ] || return 0
+  branch=$(git -C "$wt" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+  # No branch, unreadable, or detached: not positive proof of a conflict.
+  [ -n "$branch" ] && [ "$branch" != HEAD ] || return 0
+  case "$branch" in
+    fm/*) ;;
+    *) return 0 ;;
+  esac
+  other=${branch#fm/}
+  [ "$other" != "$id" ] || return 0
+  echo "REFUSED: task $id's recorded worktree $wt is checked out on branch '$branch', which belongs to task '$other'." >&2
+  echo "The recorded workspace was most likely returned to the pool and re-leased to another task, so tearing it down would destroy that task's work." >&2
+  echo "Confirm which workspace really belongs to $id (bin/fm-crew-state.sh $id) and correct worktree= in $META before retrying; --force does not override this." >&2
+  return 1
+}
+
 validate_worktree_teardown_safety() {
   local dirty_raw dirty unpushed_raw unpushed DEFAULT unmerged_raw unmerged branch
   [ -d "$WT" ] || return 0
@@ -2427,6 +2464,7 @@ if [ "$BACKEND" = orca ] && [ "$KIND" != secondmate ]; then
   [ -z "$T_ORCA" ] || fm_backend_kill "$BACKEND" "$T" "$(meta_value "$META" zellij_tab_id)" "fm-$ID" 2>/dev/null || true
   fm_backend_remove_worktree "$BACKEND" "$ORCA_WORKTREE_ID"
 elif [ -d "$WT" ] && [ "$KIND" != secondmate ]; then
+  validate_worktree_branch_identity "$WT" "$ID" || exit 1
   branch=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)
   if [ "$branch" != "HEAD" ]; then
     if git -C "$WT" checkout --detach -q 2>/dev/null; then

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -974,7 +974,7 @@ canonical_existing_dir() {
   local target=$1
   [ -n "$target" ] || return 1
   [ -d "$target" ] || return 1
-  ( cd "$target" && pwd -P )
+  fm_canonical_path "$target"
 }
 
 retry_wait_secs_is_valid() {
@@ -2451,6 +2451,7 @@ if [ "$BACKEND" = orca ] && [ "$KIND" != secondmate ]; then
     ORCA_PATH_MATCH_VERIFIED=1
   fi
   if [ -d "$WT" ]; then
+    validate_worktree_branch_identity "$WT" "$ID" || exit 1
     branch=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)
     if [ "$branch" != "HEAD" ]; then
       if git -C "$WT" checkout --detach -q 2>/dev/null; then

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -78,6 +78,60 @@ fm_path_age() {
   echo $(( $(date +%s) - m ))
 }
 
+# fm_canonical_path <path>
+# Print <path> in its physical, on-disk form: symlinked components resolved AND,
+# on a case-insensitive filesystem (APFS/HFS+), the filesystem's own spelling of
+# every component. Falls back to the deepest form it can compute so a caller
+# comparing a since-removed path still gets a deterministic value.
+#
+# `cd … && pwd -P` is NOT sufficient here and must not be substituted back in. It
+# resolves symlinks but echoes the CALLER's spelling: on APFS, `cd /x/Home && pwd -P`
+# prints /x/Home while `cd /x/home && pwd -P` prints /x/home, even though both name
+# one directory (same inode). realpath(3) is what folds the spelling to the on-disk
+# name. Perl's Cwd::realpath and Python's os.path.realpath share pwd -P's behavior
+# and are equally unsuitable, so this deliberately shells out to realpath(1).
+#
+# Identity checks comparing a LIVE value (an ambient FM_HOME, a resolved script dir)
+# against a DURABLE one recorded earlier must send both sides through this: their
+# provenance differs, so one directory can reach them under two spellings and a raw
+# compare reports two different homes. Same-provenance comparisons (two recorded
+# paths from one writer) do not need it.
+#
+# On a case-SENSITIVE filesystem the variant path simply does not exist, so this
+# case cannot arise there and the helper degrades to plain symlink resolution.
+fm_canonical_path() {
+  local path=${1-} real
+  [ -n "$path" ] || return 1
+  if real=$(realpath -- "$path" 2>/dev/null) && [ -n "$real" ]; then
+    printf '%s\n' "$real"
+    return 0
+  fi
+  # realpath(1) absent, or the path no longer exists: keep the best available
+  # physical form rather than an empty string.
+  if real=$(CDPATH='' cd -- "$path" 2>/dev/null && pwd -P); then
+    printf '%s\n' "$real"
+  else
+    printf '%s\n' "$path"
+  fi
+}
+
+# fm_canonical_file_path <path>
+# fm_canonical_path for a path whose final component is a FILE (the watcher script
+# itself). realpath(1) handles files directly; the fallback canonicalizes the
+# containing directory and re-appends the basename, since `cd` cannot enter a file.
+fm_canonical_file_path() {
+  local path=${1-} dir base real
+  [ -n "$path" ] || return 1
+  if real=$(realpath -- "$path" 2>/dev/null) && [ -n "$real" ]; then
+    printf '%s\n' "$real"
+    return 0
+  fi
+  dir=$(dirname -- "$path")
+  base=$(basename -- "$path")
+  dir=$(fm_canonical_path "$dir") || return 1
+  printf '%s/%s\n' "${dir%/}" "$base"
+}
+
 # fm_watcher_lock_unheld <state>
 # True when the watcher lock or its symlinked owner directory is absent, or when
 # the existing lock records no pid at all. Any non-empty pid remains held here;
@@ -99,8 +153,8 @@ fm_watcher_lock_matches_pid() {
   lock_home=$(cat "$lockdir/fm-home" 2>/dev/null || true)
   lock_path=$(cat "$lockdir/watcher-path" 2>/dev/null || true)
   lock_identity=$(cat "$lockdir/pid-identity" 2>/dev/null || true)
-  [ "$lock_home" = "$home" ] || return 1
-  [ "$lock_path" = "$watch_path" ] || return 1
+  [ "$(fm_canonical_path "$lock_home")" = "$(fm_canonical_path "$home")" ] || return 1
+  [ "$(fm_canonical_file_path "$lock_path")" = "$(fm_canonical_file_path "$watch_path")" ] || return 1
   [ -n "$lock_identity" ] || return 1
   current_identity=$(fm_pid_identity "$pid") || return 1
   [ "$current_identity" = "$lock_identity" ] || return 1

--- a/bin/fm-watch-arm.sh
+++ b/bin/fm-watch-arm.sh
@@ -227,8 +227,8 @@ clear_stale_recorded_watcher_lock() {
   lock_home=$(cat "$WATCH_LOCK/fm-home" 2>/dev/null || true)
   lock_path=$(cat "$WATCH_LOCK/watcher-path" 2>/dev/null || true)
   lock_identity=$(cat "$WATCH_LOCK/pid-identity" 2>/dev/null || true)
-  [ "$lock_home" = "$FM_HOME" ] || return 0
-  [ "$lock_path" = "$WATCH" ] || return 0
+  [ "$(fm_canonical_path "$lock_home")" = "$(fm_canonical_path "$FM_HOME")" ] || return 0
+  [ "$(fm_canonical_file_path "$lock_path")" = "$(fm_canonical_file_path "$WATCH")" ] || return 0
   [ -n "$lock_identity" ] || return 0
   fm_recovery_transition "$STATE/.watcher-down" clear-stale-lock "$WATCH_LOCK" downtime
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -157,8 +157,12 @@ Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectab
 
 Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees for tmux, herdr, zellij, and cmux tasks, while Orca creates its own worktrees for `backend=orca`.
 For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout.
+Both sides of that comparison, and the watcher-lock identity checks in `fm-wake-lib.sh` and `fm-watch-arm.sh`, go through `fm_canonical_path`/`fm_canonical_file_path` (`bin/fm-wake-lib.sh`), which shells out to `realpath(1)` rather than `cd … && pwd -P`: on a case-insensitive filesystem (APFS/HFS+), `pwd -P` resolves symlinks but still echoes the caller's spelling of each path component, so two spellings of one on-disk directory would otherwise compare unequal.
 `fm-spawn.sh` also owns the base-freshness boundary for every fresh ship and scout: no worker starts until its clean task worktree matches the fetched tip of origin's resolved default branch, and any unsafe or unverifiable base stops the spawn.
 Its header owns the exact refusal mechanics, while `tests/fm-spawn-pool-base-freshen.test.sh` owns the portable regression coverage.
+
+Because a treehouse pool slot is a reusable lease, `fm-spawn.sh` records the canonical settled worktree path in `state/<id>.meta`'s `worktree=` field and warns (without refusing) when that path is already recorded against a different live task, so a stale pointer left by a finished-but-untorn-down task can be reconciled before it names two tasks' workspaces at once.
+On the destructive end, `fm-teardown.sh` refuses outright when the recorded worktree is checked out on another task's `fm/<id>` branch, since that is positive proof the slot was returned to the pool and re-leased; a detached `HEAD` or a non-`fm/` branch name is not treated as proof, and `--force` does not override this refusal because it authorizes discarding only the task's own work.
 
 The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.
 Its operating checkout (`FM_ROOT`) and the disposable crewmate worktrees are all linked git worktrees of the same repository, so the valid discriminator is branch state, not whether the checkout is linked.

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -1024,6 +1024,75 @@ test_ship_teardown_removes_orca_worktree_when_id_path_matches() {
   pass "fm-teardown.sh backend=orca: ship teardown requires a matching Orca id path"
 }
 
+test_ship_teardown_refuses_orca_recycled_pool_slot_other_task_branch() {
+  local proj wt data state config id out rc neutral
+  id="orcashiprecycledz3"
+  proj="$TMP_ROOT/ship-recycled-project"
+  wt="$TMP_ROOT/ship-recycled-wt"
+  data="$TMP_ROOT/ship-recycled-data"
+  state="$TMP_ROOT/ship-recycled-state"
+  config="$TMP_ROOT/ship-recycled-config"
+  fm_git_worktree "$proj" "$wt" "fm/other-live-task"
+  mkdir -p "$data/$id" "$state" "$config"
+  touch "$state/.last-watcher-beat"
+  fm_write_meta "$state/$id.meta" \
+    "window=fm-$id" "endpoint_task_id=$id" "terminal=term-ship-recycled" "worktree=$wt" "project=$proj" \
+    "harness=claude" "kind=ship" "mode=local-only" "yolo=off" \
+    "backend=orca" "orca_worktree_id=wt-ship-recycled"
+  orca_case ship-recycled
+  printf '{"ok":true,"result":{"worktree":{"id":"wt-ship-recycled","path":"%s"}}}\n' "$wt" > "$RESP/1.out"
+  neutral=$(neutral_fm_root "$CASE_DIR/neutral")
+  set +e
+  out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
+    FM_ROOT_OVERRIDE="$neutral" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
+    "$ROOT/bin/fm-teardown.sh" "$id" --force 2>&1 )
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "Orca ship teardown should refuse a recycled pool slot holding another task's branch"
+  assert_contains "$out" "belongs to task 'other-live-task'" \
+    "recycled Orca pool slot refusal should name the conflicting task"
+  [ "$(git -C "$wt" rev-parse --abbrev-ref HEAD)" = "fm/other-live-task" ] \
+    || fail "recycled Orca pool slot: the other task's branch was mutated"
+  assert_not_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close' \
+    "refused recycled Orca ship teardown should not close terminals"
+  assert_not_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm' \
+    "refused recycled Orca ship teardown should not remove worktrees"
+  assert_present "$state/$id.meta" "refused recycled Orca ship teardown should preserve metadata"
+  pass "fm-teardown.sh backend=orca: ship teardown refuses a recycled pool slot holding another task's branch, even with --force"
+}
+
+test_ship_teardown_proceeds_orca_own_task_branch() {
+  local proj wt data state config id out rc neutral
+  id="orcashipownbranchz4"
+  proj="$TMP_ROOT/ship-ownbranch-project"
+  wt="$TMP_ROOT/ship-ownbranch-wt"
+  data="$TMP_ROOT/ship-ownbranch-data"
+  state="$TMP_ROOT/ship-ownbranch-state"
+  config="$TMP_ROOT/ship-ownbranch-config"
+  fm_git_worktree "$proj" "$wt" "fm/$id"
+  mkdir -p "$data/$id" "$state" "$config"
+  touch "$state/.last-watcher-beat"
+  fm_write_meta "$state/$id.meta" \
+    "window=fm-$id" "endpoint_task_id=$id" "terminal=term-ship-ownbranch" "worktree=$wt" "project=$proj" \
+    "harness=claude" "kind=ship" "mode=local-only" "yolo=off" \
+    "backend=orca" "orca_worktree_id=wt-ship-ownbranch"
+  orca_case ship-ownbranch
+  printf '{"ok":true,"result":{"worktree":{"id":"wt-ship-ownbranch","path":"%s"}}}\n' "$wt" > "$RESP/1.out"
+  neutral=$(neutral_fm_root "$CASE_DIR/neutral")
+  set +e
+  out=$( PATH="$FB:$PATH" FM_ORCA_LOG="$LOG" FM_ORCA_RESPONSES="$RESP" \
+    FM_ROOT_OVERRIDE="$neutral" FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
+    "$ROOT/bin/fm-teardown.sh" "$id" 2>&1 )
+  rc=$?
+  set -e
+  expect_code 0 "$rc" "Orca ship teardown should proceed when the worktree holds the task's own branch"$'\n'"$out"
+  assert_not_contains "$out" "belongs to task" \
+    "own-branch Orca ship teardown must not report a foreign-branch conflict"
+  assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-ship-ownbranch'$'\x1f''--force'$'\x1f''--json' \
+    "own-branch Orca ship teardown did not remove the worktree"
+  pass "fm-teardown.sh backend=orca: ship teardown proceeds past the branch identity check on its own branch"
+}
+
 test_ship_teardown_refuses_orca_unresolvable_worktree_id() {
   local proj wt data state config id out rc neutral
   id="orcashipunresolvedz1"
@@ -1341,6 +1410,8 @@ test_teardown_preserves_metadata_when_orca_remove_error_json
 test_scout_teardown_refuses_orca_missing_report_when_path_missing
 test_ship_teardown_refuses_orca_missing_worktree_path
 test_ship_teardown_removes_orca_worktree_when_id_path_matches
+test_ship_teardown_refuses_orca_recycled_pool_slot_other_task_branch
+test_ship_teardown_proceeds_orca_own_task_branch
 test_ship_teardown_refuses_orca_unresolvable_worktree_id
 test_ship_teardown_refuses_orca_id_path_mismatch
 test_teardown_refuses_orca_missing_worktree_id

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -86,6 +86,13 @@ read_settle_record() {
   IFS='|' read -r _ HOME_DIR PROJ_DIR WT_DIR STALE_DIR FAKEBIN_DIR COUNTFILE STALE_READS <<EOF
 $1
 EOF
+  # fm-spawn records the CANONICAL physical worktree path (bin/fm-wake-lib.sh's
+  # fm_canonical_path), so the recorded pointer and the path its isolation guard
+  # validated are never two spellings of one directory. Fixture paths live under
+  # $TMPDIR, which is itself symlinked on macOS (/var -> /private/var), so assert
+  # against the same canonical form rather than the raw fixture string.
+  WT_DIR_CANON=$(realpath "$WT_DIR" 2>/dev/null || printf '%s' "$WT_DIR")
+  STALE_DIR_CANON=$(realpath "$STALE_DIR" 2>/dev/null || printf '%s' "$STALE_DIR")
 }
 
 run_settle_spawn() {
@@ -113,9 +120,9 @@ test_single_stale_first_read_is_not_accepted() {
   status=$?
   expect_code 0 "$status" "spawn should succeed once the pane settles"
   assert_contains "$out" "spawned $id" "spawn did not report success"
-  assert_grep "worktree=$WT_DIR" "$HOME_DIR/state/$id.meta" \
+  assert_grep "worktree=$WT_DIR_CANON" "$HOME_DIR/state/$id.meta" \
     "meta did not record the settled worktree"
-  assert_no_grep "worktree=$STALE_DIR" "$HOME_DIR/state/$id.meta" \
+  assert_no_grep "worktree=$STALE_DIR_CANON" "$HOME_DIR/state/$id.meta" \
     "meta wrongly recorded the transient stale path as the worktree"
   pass "a single transient stale pane_current_path read is not accepted as the worktree"
 }
@@ -135,7 +142,7 @@ test_already_settled_pane_costs_one_confirm_sleep() {
   end=$(date +%s)
   elapsed=$((end - start))
   expect_code 0 "$status" "spawn should succeed when the pane is already settled"
-  assert_grep "worktree=$WT_DIR" "$HOME_DIR/state/$id.meta" \
+  assert_grep "worktree=$WT_DIR_CANON" "$HOME_DIR/state/$id.meta" \
     "meta did not record the already-settled worktree"
   [ "$elapsed" -le 5 ] || fail "already-settled pane took ${elapsed}s to confirm - expected close to the single inter-poll sleep"
   pass "an already-settled pane confirms via the existing inter-poll sleep, not an extra full cycle"

--- a/tests/fm-teardown-endpoint-safety.test.sh
+++ b/tests/fm-teardown-endpoint-safety.test.sh
@@ -365,6 +365,74 @@ SH
   pass "fm-teardown: exact tmux cleanup preserves invalid and prefix-matched neighbors while removing only the recorded target"
 }
 
+# A treehouse pool slot is a reusable lease. Under pool churn, the slot recorded in
+# state/<id>.meta can already have been returned and re-leased to another live task,
+# and teardown's next steps delete the checked-out branch and hard-reset the
+# worktree. Aiming that at a recycled slot destroys another crewmate's work, so a
+# worktree carrying a DIFFERENT task's fm/<id> branch must be refused - including
+# under --force, which authorizes discarding this task's own work, never another's.
+init_branch_worktree() {  # <dir> <branch>
+  local dir=$1 branch=$2
+  git -C "$dir" init -q .
+  git -C "$dir" config user.email test@example.com
+  git -C "$dir" config user.name test
+  git -C "$dir" config commit.gpgsign false
+  : > "$dir/seed"
+  git -C "$dir" add -A
+  git -C "$dir" commit -qm seed
+  git -C "$dir" checkout -q -b "$branch"
+}
+
+test_recycled_pool_slot_refuses_other_task_branch() {
+  local dir id=slotfix-a rc
+
+  # The recorded worktree now holds ANOTHER task's branch: must refuse, no mutation.
+  dir=$(make_case recycled-slot)
+  init_branch_worktree "$dir/worktree" "fm/other-live-task"
+  fm_write_meta "$dir/home/state/$id.meta" \
+    "window=isolated:fm-$id" "endpoint_task_id=$id" \
+    "worktree=$dir/worktree" "project=$dir/project" "kind=ship"
+  set +e
+  run_case "$dir" "$id" > "$dir/stdout" 2> "$dir/stderr"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "recycled pool slot: teardown must refuse another task's workspace"
+  grep -q "belongs to task 'other-live-task'" "$dir/stderr" \
+    || fail "recycled pool slot: refusal must name the conflicting task: $(cat "$dir/stderr")"
+  [ "$(git -C "$dir/worktree" rev-parse --abbrev-ref HEAD)" = "fm/other-live-task" ] \
+    || fail "recycled pool slot: the other task's branch was mutated"
+  assert_present "$dir/worktree/seed" "recycled pool slot: worktree changed before refusal"
+
+  # The worktree carrying this task's OWN branch is not a conflict and must proceed
+  # past the identity gate (proving the refusal is targeted, not a blanket block).
+  dir=$(make_case own-slot)
+  init_branch_worktree "$dir/worktree" "fm/$id"
+  fm_write_meta "$dir/home/state/$id.meta" \
+    "window=isolated:fm-$id" "endpoint_task_id=$id" \
+    "worktree=$dir/worktree" "project=$dir/project" "kind=ship"
+  set +e
+  run_case "$dir" "$id" > "$dir/stdout" 2> "$dir/stderr"
+  set -e
+  grep -q "belongs to task" "$dir/stderr" \
+    && fail "own slot: teardown must not refuse the task's own workspace: $(cat "$dir/stderr")"
+
+  # A detached HEAD is how a landed task legitimately ends; it is not proof of a
+  # mismatch and must not be turned into a refusal.
+  dir=$(make_case detached-slot)
+  init_branch_worktree "$dir/worktree" "fm/$id"
+  git -C "$dir/worktree" checkout -q --detach
+  fm_write_meta "$dir/home/state/$id.meta" \
+    "window=isolated:fm-$id" "endpoint_task_id=$id" \
+    "worktree=$dir/worktree" "project=$dir/project" "kind=ship"
+  set +e
+  run_case "$dir" "$id" > "$dir/stdout" 2> "$dir/stderr"
+  set -e
+  grep -q "belongs to task" "$dir/stderr" \
+    && fail "detached slot: a detached HEAD must not be treated as a foreign workspace: $(cat "$dir/stderr")"
+
+  pass "fm-teardown: a recycled pool slot holding another task's branch is refused before any mutation"
+}
+
 test_invalid_endpoint_records_refuse_before_mutation
 test_control_lock_contention_refuses_before_mutation
 test_metadata_lock_serializes_destructive_cleanup
@@ -372,3 +440,4 @@ test_supported_backend_endpoint_records_validate
 test_tmux_empty_target_refuses_without_invocation
 test_recorded_process_identity_cleanup_is_exact
 test_isolated_tmux_invalid_and_valid_cleanup
+test_recycled_pool_slot_refuses_other_task_branch

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -1098,6 +1098,92 @@ test_msys_pid_identity_uses_proc() {
   pass "MSYS process identity uses compatible /proc fields"
 }
 
+# A case-insensitive filesystem (APFS/HFS+) lets one directory be reached under
+# several spellings. FM_HOME arrives from the ambient environment while the lock's
+# fm-home was written by an earlier session, so the two sides can legitimately
+# disagree on spelling and a raw string compare then reports a live watcher as a
+# different home's - the false "watcher down" alarm seen after a session resume.
+# Skipped where the filesystem is case-sensitive, because the variant path simply
+# does not exist there and the case cannot arise.
+fs_is_case_insensitive() {  # <dir>
+  local dir=$1
+  mkdir -p "$dir/CaseProbe" || return 1
+  [ -d "$dir/caseprobe" ]
+}
+
+test_watcher_lock_identity_is_case_insensitive_path_safe() {
+  local dir state lockdir variant out
+  dir=$(make_case case-variant-home)
+  state="$dir/state"
+  if ! fs_is_case_insensitive "$dir"; then
+    printf 'ok - watcher lock case-variant home (skipped: case-sensitive filesystem)\n'
+    return 0
+  fi
+  lockdir="$state/.watch.lock"
+  mkdir -p "$lockdir"
+  # Lock recorded by a session that reached the home as .../Home.
+  printf '%s\n' "$dir/Home" > "$lockdir/fm-home"
+  printf '%s\n' "$ROOT/bin/fm-watch.sh" > "$lockdir/watcher-path"
+  printf '%s\n' "recorded-identity" > "$lockdir/pid-identity"
+  printf '%s\n' 4242 > "$lockdir/pid"
+  mkdir -p "$dir/Home"
+
+  # This session reached the same directory as .../home.
+  variant="$dir/home"
+  out=$(FM_TEST_LOCKDIR="$state" bash -c '
+    # shellcheck disable=SC1090
+    . "$1"
+    fm_pid_identity() { printf "recorded-identity\n"; }
+    if fm_watcher_lock_matches_pid "$2" "$3" 4242 "$4"; then echo MATCH; else echo NOMATCH; fi
+  ' _ "$LIB" "$state" "$ROOT/bin/fm-watch.sh" "$variant")
+  [ "$out" = MATCH ] || fail "case-variant FM_HOME spelling must still match its own watcher lock (got $out)"
+
+  # A genuinely different home must still be rejected: the fix folds spelling, not identity.
+  mkdir -p "$dir/Other"
+  out=$(bash -c '
+    # shellcheck disable=SC1090
+    . "$1"
+    fm_pid_identity() { printf "recorded-identity\n"; }
+    if fm_watcher_lock_matches_pid "$2" "$3" 4242 "$4"; then echo MATCH; else echo NOMATCH; fi
+  ' _ "$LIB" "$state" "$ROOT/bin/fm-watch.sh" "$dir/Other")
+  [ "$out" = NOMATCH ] || fail "an unrelated home must never match this home's watcher lock (got $out)"
+  printf 'ok - watcher lock identity folds case-variant path spellings\n'
+}
+
+test_canonical_path_folds_case_but_not_identity() {
+  local dir out
+  dir=$(make_case canonical-path)
+  if ! fs_is_case_insensitive "$dir"; then
+    printf 'ok - fm_canonical_path case folding (skipped: case-sensitive filesystem)\n'
+    return 0
+  fi
+  mkdir -p "$dir/Alpha"
+  out=$(bash -c '
+    # shellcheck disable=SC1090
+    . "$1"
+    a=$(fm_canonical_path "$2/Alpha")
+    b=$(fm_canonical_path "$2/alpha")
+    [ "$a" = "$b" ] && echo SAME || echo "DIFF a=$a b=$b"
+  ' _ "$LIB" "$dir")
+  [ "$out" = SAME ] || fail "fm_canonical_path must fold case-variant spellings of one directory ($out)"
+
+  # pwd -P alone is NOT sufficient; assert the property that motivated realpath.
+  out=$( ( cd "$dir/alpha" && pwd -P ) )
+  [ "$out" != "$(cd "$dir/Alpha" && pwd -P)" ] \
+    || fail "expected pwd -P to preserve caller spelling; the realpath-based helper is what folds it"
+
+  mkdir -p "$dir/Beta"
+  out=$(bash -c '
+    # shellcheck disable=SC1090
+    . "$1"
+    a=$(fm_canonical_path "$2/Alpha")
+    b=$(fm_canonical_path "$2/Beta")
+    [ "$a" = "$b" ] && echo SAME || echo DIFF
+  ' _ "$LIB" "$dir")
+  [ "$out" = DIFF ] || fail "fm_canonical_path must keep genuinely different directories distinct"
+  printf 'ok - fm_canonical_path folds spelling without collapsing distinct paths\n'
+}
+
 test_singleton_start
 test_pid_identity_is_locale_invariant
 test_proc_pid_identity_ignores_wall_clock_and_detects_pid_reuse
@@ -1127,3 +1213,5 @@ test_arm_waits_for_peer_beacon_after_child_stands_down
 test_arm_fails_loud_when_no_fresh_watcher_confirmable
 test_cycle_exit_ledger_links_successor_and_stays_bounded
 test_stopped_watcher_is_live_but_stale_then_exit_is_classified
+test_watcher_lock_identity_is_case_insensitive_path_safe
+test_canonical_path_folds_case_but_not_identity


### PR DESCRIPTION
## Summary

Two safety checks in firstmate's own tooling compared paths as raw strings, so one directory reached under two spellings read as two different locations. Both defeat checks that protect the never-write-to-projects prime directive.

## Defect 1: case-variant home path defeats identity checks

**A finding that departs from the original framing:** the task prescribed normalizing with `pwd -P`, and `fm-spawn` already did that (landed in #294, a month before the incident). `pwd -P` resolves symlinks but **preserves the caller's spelling** of each component:

```
cd /x/Home && pwd -P   ->  /x/Home
cd /x/home && pwd -P   ->  /x/home     # same inode, different string
realpath /x/home       ->  /x/Home     # folds to the on-disk name
```

Perl's `Cwd::realpath` and Python's `os.path.realpath` behave like `pwd -P`, so the new helper deliberately shells out to `realpath(1)` despite an existing perl-realpath idiom elsewhere in the repo.

Reproduced the near-miss: a worktree pointed at the primary clone with a case-variant project path was **ACCEPTED** before the fix, **REFUSED** after.

New `fm_canonical_path` / `fm_canonical_file_path` in `fm-wake-lib.sh` are applied on both sides of the spawn isolation assertion and both watcher-lock identity comparisons (`fm-wake-lib.sh` and `fm-watch-arm.sh` shared the weakness). The guard failure produced false "watcher down" alarms after a session resume.

## Defect 2: pool slot reuse leaves stale meta worktree pointers

`fm-spawn` now records the canonical path the lease actually settled on. `fm-teardown` refuses when the recorded worktree holds a different task's `fm/<id>` branch, before the step that deletes that branch and resets the worktree.

## Deliberate design decisions

- The spawn-side double-lease check **warns rather than refuses**. A lingering record is usually a finished task awaiting cleanup, so refusing would block routine spawns on stale metadata. The destructive end refuses.
- The teardown refusal requires **positive proof**: a detached `HEAD` (how a landed task legitimately ends) or a non-`fm/` branch name does not block cleanup.
- `--force` deliberately does **not** override the refusal: it authorizes discarding this task's own work, never another task's.

## Review round

The review gate caught that the guard covered only the non-orca destructive path while the orca branch ran the identical `checkout --detach` + `branch -D` sequence unguarded. Extended to orca, plus `canonical_existing_dir` (feeding orca's path-match equality check) had the same `pwd -P` weakness and could cause a spurious refusal on a legitimate orca teardown. The hazard class is now closed on every supported backend.

## Verification

- `bin/fm-lint.sh` passes (pinned ShellCheck 0.11.0, actionlint 1.7.12).
- New tests are proven to fail without their fix and pass with it.
- Tests skip on case-sensitive filesystems, where the variant path cannot exist.
- Four pre-existing test failures (`fm-teardown` herdr-preflight, `fm-watch-arm`, `fm-wake-queue`, `fm-backend-orca` metadata-write) were each confirmed failing identically on the clean baseline via `git stash` / `git checkout` — unrelated to this change.
