### PR TITLE
fix(bin): parameterize task-branch prefix and retry swallowed herdr Enter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,7 @@ config/herdr-presentation-spaces  optional "off" opt-out from, or "on" opt-in to
 config/trace-context  optional presence flag enabling default-off native W3C trace-context propagation to spawned agents; LOCAL, gitignored; inherited by secondmate homes; see docs/configuration.md "Trace context propagation" and docs/trace-context.md
 config/cmux-socket-password  optional cmux control-socket password; LOCAL, gitignored; read fresh on every cmux CLI call and passed through without ever overriding an operator's own ambient CMUX_SOCKET_PASSWORD when absent (docs/cmux-backend.md "Setup")
 config/wedge-alarm  optional away-mode wedge-alarm active-alert directives; LOCAL, gitignored; absent means auto (macOS Notification Center when available); see docs/wedge-alarm.md
+config/branch-prefix  ship-brief task-branch prefix override; LOCAL, gitignored, and not inherited; absent = default "fm/"; see docs/configuration.md "Branch prefix"
 config/x-mode.env    generated Relay watcher cadence; LOCAL, gitignored; source before arming watcher when present
 data/                personal fleet records; LOCAL, gitignored as a whole
   backlog.md         task queue, dependencies, history

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2761,6 +2761,22 @@ fm_backend_herdr_rendered_busy_state() {  # <target> [harness] -> busy|idle|unkn
 # submit vocabulary. Empty means confirmed submitted for every backend; how
 # each backend confirms it is an internal decision.
 #
+# Incident (2026-08-18, recurred 2026-08-20): a herdr claude pane's Enter was
+# repeatedly reported swallowed (verdict=pending) by this loop, yet a manual
+# operator follow-up `fm-send --key Enter` landed the same text every time.
+# The retry budget above governs how many Enters this loop sends while a
+# composer verdict is still settling; it is not itself proof that a further
+# bare Enter cannot land a stubborn swallow. FM_BACKEND_HERDR_SWALLOW_RETRIES
+# (default 2) bounds a SEPARATE, final Enter-only sweep that fires only when
+# the main loop is about to report a genuine idle-baseline swallow (proven
+# pending, native never went busy): each sweep Enter re-checks the composer
+# once and returns 'empty' the moment it clears, so the caller never has to
+# do by hand what this adapter can safely retry itself. The fail-closed
+# contract is unchanged: a target that stays unreadable, or whose composer
+# still holds the text after the sweep, still reports pending/unknown exactly
+# as before, and 'send-failed' or 'unknown' from the main loop is returned
+# immediately without the sweep (those are not proven swallows to retry).
+#
 # fm_backend_herdr_queued_enter_busy: delivery-busy for the shared queued-Enter
 # conversion. Native agent_status=working is generating; blocked is not (a
 # permission prompt, or Cursor's always-blocked native state, is not a queued
@@ -2778,6 +2794,29 @@ fm_backend_herdr_queued_enter_busy() {  # <target> <allow-rendered>
   else
     printf 'idle'
   fi
+}
+
+# fm_backend_herdr_swallow_sweep: bounded Enter-only follow-up for a proven
+# idle-baseline swallow (see the send_text_submit incident note above). Sends
+# up to FM_BACKEND_HERDR_SWALLOW_RETRIES (default 2) further bare Enters,
+# re-reading the composer after each, and returns as soon as it clears.
+# Never retypes <target>'s text; only ever sends Enter. Stops immediately on
+# a send-key failure or an unreadable composer, preserving fail-closed.
+fm_backend_herdr_swallow_sweep() {  # <target> <sleep-s> -> empty|pending|unknown
+  local target=$1 sleep_s=$2 tries verdict j=0
+  tries=${FM_BACKEND_HERDR_SWALLOW_RETRIES:-2}
+  while [ "$j" -lt "$tries" ]; do
+    fm_backend_herdr_send_key "$target" Enter || { printf 'pending'; return 0; }
+    sleep "$sleep_s"
+    verdict=$(fm_backend_herdr_composer_state "$target")
+    case "$verdict" in
+      empty) printf 'empty'; return 0 ;;
+      pending|pending-unproven) ;;
+      *) printf '%s' "$verdict"; return 0 ;;
+    esac
+    j=$((j + 1))
+  done
+  printf 'pending'
 }
 
 fm_backend_herdr_send_text_submit() {  # <target> <text> <retries> <enter-sleep> <settle>
@@ -2841,10 +2880,14 @@ fm_backend_herdr_send_text_submit() {  # <target> <text> <retries> <enter-sleep>
     if [ "$i" -ge "$retries" ]; then
       if [ "$enter_sent" -eq 0 ]; then
         printf 'send-failed'
-      else
-        fm_composer_queued_enter_verdict "$verdict" \
-          "$(fm_backend_herdr_queued_enter_busy "$target" "$allow_rendered")"
+        return 0
       fi
+      verdict=$(fm_composer_queued_enter_verdict "$verdict" \
+        "$(fm_backend_herdr_queued_enter_busy "$target" "$allow_rendered")")
+      if [ "$verdict" = pending ] && [ "$baseline" = idle ]; then
+        verdict=$(fm_backend_herdr_swallow_sweep "$target" "$sleep_s")
+      fi
+      printf '%s' "$verdict"
       return 0
     fi
   done

--- a/bin/fm-branch-prefix-lib.sh
+++ b/bin/fm-branch-prefix-lib.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# fm_branch_prefix_resolve: the one owner of config/branch-prefix resolution
+# (docs/configuration.md "Branch prefix"). A generated ship brief's task
+# branch, and every script that later has to find that same branch by name
+# (bin/fm-merge-local.sh, bin/fm-review-diff.sh), must agree on the exact same
+# prefix, so all three source this instead of hardcoding "fm/" or resolving
+# the config file themselves.
+#
+# Usage: fm_branch_prefix_resolve <config-dir>
+#   <config-dir>: the caller's already-resolved config directory (e.g.
+#     "$FM_HOME/config", or an FM_CONFIG_OVERRIDE the caller resolved itself -
+#     this function does no path resolution of its own, so a relative or
+#     CDPATH-sensitive override must already be handled by the caller).
+# Prints the prefix (e.g. "fm/" or "ryan-fm/") to stdout. Absent or
+# whitespace-only config/branch-prefix resolves to the historical default
+# "fm/". No side effects on source. set -u / set -e safe.
+fm_branch_prefix_resolve() {  # <config-dir>
+  local config=$1 prefix=fm/
+  if [ -f "$config/branch-prefix" ]; then
+    prefix=$(tr -d '[:space:]' < "$config/branch-prefix")
+    [ -n "$prefix" ] || prefix=fm/
+  fi
+  printf '%s' "$prefix"
+}

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -75,6 +75,8 @@ esac
 . "$SCRIPT_DIR/fm-marker-lib.sh"
 # shellcheck source=bin/fm-classify-lib.sh
 . "$SCRIPT_DIR/fm-classify-lib.sh"
+# shellcheck source=bin/fm-branch-prefix-lib.sh
+. "$SCRIPT_DIR/fm-branch-prefix-lib.sh"
 PAUSED_VERB=${FM_CLASSIFY_PAUSED_VERB:-$FM_CLASSIFY_PAUSED_VERB_DEFAULT}
 
 resolve_directory_input() {
@@ -110,12 +112,11 @@ fi
 # use for the task branch, so a shared repo where another fleet already owns
 # `fm/*` can be pointed at a distinct prefix (e.g. `ryan-fm/`) instead of the
 # scaffold's stock language silently overriding per-task instructions.
+# fm_branch_prefix_resolve (bin/fm-branch-prefix-lib.sh) is the one owner of
+# this resolution; bin/fm-merge-local.sh and bin/fm-review-diff.sh share it so
+# a configured prefix stays consistent everywhere a task branch is named.
 # Absent or empty resolves to the default `fm/`. See docs/configuration.md.
-BRANCH_PREFIX=fm/
-if [ -f "$CONFIG/branch-prefix" ]; then
-  BRANCH_PREFIX=$(tr -d '[:space:]' < "$CONFIG/branch-prefix")
-  [ -n "$BRANCH_PREFIX" ] || BRANCH_PREFIX=fm/
-fi
+BRANCH_PREFIX=$(fm_branch_prefix_resolve "$CONFIG")
 KIND=ship
 HERDR_LAB=0
 NO_PROJECTS=0

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -101,6 +101,21 @@ if [ -n "${FM_STATE_OVERRIDE:-}" ]; then
 else
   STATE="$FM_HOME/state"
 fi
+if [ -n "${FM_CONFIG_OVERRIDE:-}" ]; then
+  CONFIG=$(resolve_directory_input FM_CONFIG_OVERRIDE "$FM_CONFIG_OVERRIDE") || exit 1
+else
+  CONFIG="$FM_HOME/config"
+fi
+# config/branch-prefix (local, gitignored): the prefix generated ship briefs
+# use for the task branch, so a shared repo where another fleet already owns
+# `fm/*` can be pointed at a distinct prefix (e.g. `ryan-fm/`) instead of the
+# scaffold's stock language silently overriding per-task instructions.
+# Absent or empty resolves to the default `fm/`. See docs/configuration.md.
+BRANCH_PREFIX=fm/
+if [ -f "$CONFIG/branch-prefix" ]; then
+  BRANCH_PREFIX=$(tr -d '[:space:]' < "$CONFIG/branch-prefix")
+  [ -n "$BRANCH_PREFIX" ] || BRANCH_PREFIX=fm/
+fi
 KIND=ship
 HERDR_LAB=0
 NO_PROJECTS=0
@@ -355,7 +370,7 @@ fi
 case "$MODE" in
   direct-PR)
     SETUP2=""
-    RULE1='1. Never push to the default branch (push only your `fm/'"$ID"'` branch). Never merge a PR.'
+    RULE1='1. Never push to the default branch (push only your `'"$BRANCH_PREFIX$ID"'` branch). Never merge a PR.'
     IFS= read -r -d '' DOD <<EOF || true
 # Definition of done
 Delivery contract: mode=direct-PR
@@ -367,14 +382,14 @@ EOF
     ;;
   local-only)
     SETUP2=""
-    RULE1="1. Never push to any remote and never open a PR. Work only on your \`fm/$ID\` branch; firstmate handles the merge into local \`main\`."
+    RULE1="1. Never push to any remote and never open a PR. Work only on your \`$BRANCH_PREFIX$ID\` branch; firstmate handles the merge into local \`main\`."
     IFS= read -r -d '' DOD <<EOF || true
 # Definition of done
 Delivery contract: mode=local-only
 This task ships **local-only**: no remote, no PR, no pipeline.
-The task is complete only when committed on your branch \`fm/$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
+The task is complete only when committed on your branch \`$BRANCH_PREFIX$ID\`. Do NOT push, do NOT open a PR, do NOT merge.
 Keep your branch a clean fast-forward onto the current default branch - if \`main\` has advanced, rebase onto it so the eventual merge stays a fast-forward.
-When it is implemented and committed, append \`done: ready in branch fm/$ID\` to the status file and stop.
+When it is implemented and committed, append \`done: ready in branch $BRANCH_PREFIX$ID\` to the status file and stop.
 The configured merge authority approves the ready branch, then firstmate merges it into local \`main\` through the guarded fast-forward path.
 EOF
     ;;
@@ -425,7 +440,7 @@ You are in a disposable git worktree of $REPO, at a detached HEAD on a clean def
 The path check is authoritative: \`git rev-parse --git-dir\` and \`git rev-parse --git-common-dir\` can help inspect the repo, but they do not prove you are outside the primary checkout.
 If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append \`blocked: launched in primary checkout, not an isolated worktree\` to the status file and stop.
 
-1. First action: create your branch: \`git checkout -b fm/$ID\`$SETUP2
+1. First action: create your branch: \`git checkout -b $BRANCH_PREFIX$ID\`$SETUP2
 
 # Rules
 $RULE1

--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Perform the approved local merge for a local-only ship task: fast-forward the
-# project's default branch to the crewmate's fm/<id> branch.
+# project's default branch to the crewmate's task branch (config/branch-prefix
+# plus the task id, default prefix "fm/"; see bin/fm-branch-prefix-lib.sh).
 #
 # This is firstmate's merge gate-action (the captain's merge authority applied
 # locally instead of via a GitHub PR). It is the one sanctioned exception to hard
@@ -16,6 +17,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
+# shellcheck source=bin/fm-branch-prefix-lib.sh
+. "$SCRIPT_DIR/fm-branch-prefix-lib.sh"
 "$FM_ROOT/bin/fm-guard.sh" || true
 ID=${1:?usage: fm-merge-local.sh <task-id>}
 META="$STATE/$ID.meta"
@@ -41,7 +45,7 @@ default_branch() {
   return 1
 }
 
-BRANCH="fm/$ID"
+BRANCH="$(fm_branch_prefix_resolve "$CONFIG")$ID"
 git -C "$PROJ" rev-parse --verify --quiet "refs/heads/$BRANCH" >/dev/null || { echo "error: branch $BRANCH does not exist in $PROJ" >&2; exit 1; }
 
 DEFAULT=$(default_branch) || { echo "error: cannot determine default branch for $PROJ; expected origin/HEAD, main, or master" >&2; exit 1; }

--- a/bin/fm-promote.sh
+++ b/bin/fm-promote.sh
@@ -4,8 +4,9 @@
 # state/<task-id>.meta so fm-teardown.sh applies the full ship-task teardown protection
 # again. After promoting, send the crewmate its ship instructions via fm-send.sh
 # (inventory scratch state, reset to a clean default-branch base, carry over only
-# intended fix changes, create branch fm/<task-id>, implement, then report done
-# according to this task's delivery mode).
+# intended fix changes, create the task branch (config/branch-prefix, default
+# fm/, plus the task id), implement, then report done according to this
+# task's delivery mode).
 # A scout records no delivery posture, so promotion is where this task's delivery
 # contract is decided: --mode and --yolo are REQUIRED and written into the meta
 # alongside the kind= flip. Firstmate resolves both at promotion time, having just
@@ -122,4 +123,4 @@ META_LOCK_HELD=0
 
 HOME_Q=$(printf '%q' "$FM_HOME")
 echo "promoted $ID to ship mode=$MODE yolo=$YOLO (teardown protection restored)"
-echo "next: FM_HOME=$HOME_Q bin/fm-send.sh fm-$ID '<ship instructions for mode=$MODE: review scratch state with git status and git log; reset to a clean default-branch base; carry over only intended fix changes; create branch fm/$ID; implement; report done>'"
+echo "next: FM_HOME=$HOME_Q bin/fm-send.sh fm-$ID '<ship instructions for mode=$MODE: review scratch state with git status and git log; reset to a clean default-branch base; carry over only intended fix changes; create the task branch (config/branch-prefix, default fm/, plus $ID); implement; report done>'"

--- a/bin/fm-review-diff.sh
+++ b/bin/fm-review-diff.sh
@@ -18,6 +18,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
+# shellcheck source=bin/fm-branch-prefix-lib.sh
+. "$SCRIPT_DIR/fm-branch-prefix-lib.sh"
 "$FM_ROOT/bin/fm-guard.sh" || true
 
 usage() {
@@ -67,10 +70,11 @@ default_branch() {
 
 DEFAULT=$(default_branch) || { echo "error: cannot determine default branch for $PROJ; expected origin/HEAD, main, or master" >&2; exit 1; }
 
-BRANCH="fm/$ID"
+EXPECTED_BRANCH="$(fm_branch_prefix_resolve "$CONFIG")$ID"
+BRANCH="$EXPECTED_BRANCH"
 if ! git -C "$WT" rev-parse --verify --quiet "refs/heads/$BRANCH" >/dev/null; then
   BRANCH=$(git -C "$WT" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
-  [ -n "$BRANCH" ] || { echo "error: branch fm/$ID does not exist and worktree $WT is detached" >&2; exit 1; }
+  [ -n "$BRANCH" ] || { echo "error: branch $EXPECTED_BRANCH does not exist and worktree $WT is detached" >&2; exit 1; }
   git -C "$WT" rev-parse --verify --quiet "refs/heads/$BRANCH" >/dev/null || { echo "error: branch $BRANCH does not exist in $WT" >&2; exit 1; }
 fi
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -168,7 +168,7 @@ Only a named non-default branch checked out in `FM_ROOT` is a worktree tangle.
 `fm-tangle-lib.sh` resolves the default branch from `origin/HEAD`, then local `main` or `master`, and classifies that named non-default primary branch as the tangle.
 `fm-guard.sh` prints the repair command on the next mutable fleet action, while `bin/fm-session-start.sh` reports the same condition through bootstrap as a `TANGLE:` line at session start.
 If another live session holds the fleet lock, both surfaces keep the alarm but switch to read-only wording with no repair command.
-Ship briefs also tell the crewmate to verify `pwd -P` and `git rev-parse --show-toplevel` before creating `fm/<id>`, then stop with a blocked status if it landed in the primary checkout.
+Ship briefs also tell the crewmate to verify `pwd -P` and `git rev-parse --show-toplevel` before creating its task branch (`config/branch-prefix`, default `fm/`, plus the task id), then stop with a blocked status if it landed in the primary checkout.
 
 ## No-mistakes gate authority boundary
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -211,6 +211,7 @@ For the herdr backend, `FM_HOME` also determines the workspace label used by the
 For the zellij backend, `FM_HOME` does not split containers, but it determines the readable home prefix embedded in visible tab titles; use `FM_ZELLIJ_SESSION` when a separate zellij session is needed.
 The full zellij home label also includes a short hash of the resolved `FM_ROOT` path.
 For the cmux backend, `FM_CONFIG_OVERRIDE` overrides where `config/cmux-socket-password` is read from, while `FM_HOME` determines the default config path and readable home prefix embedded in workspace titles.
+`fm-brief.sh` also resolves `CONFIG` the same way, `FM_CONFIG_OVERRIDE` else `FM_HOME/config`, to read `config/branch-prefix` (see "Branch prefix" below).
 The full cmux home label also includes a short hash of the resolved `FM_ROOT` path, and there is no per-home container split.
 
 ## Harness support
@@ -539,6 +540,7 @@ FM_TRACE_CONTEXT=       # optional trace-context override; see "Trace context pr
 HERDR_SESSION=default  # herdr-only: named session for normal backend ops; not enough for destructive cleanup (docs/herdr-backend.md)
 FM_BACKEND_HERDR_SUBMIT_POLLS=6  # herdr-only: agent-state samples spread across each Enter attempt's budget when confirming a submit (docs/herdr-backend.md "Current transport behavior")
 FM_BACKEND_HERDR_SUBMIT_MIN_SLEEP=0.6  # herdr-only: minimum per-Enter confirmation budget before polling agent-state after an idle baseline
+FM_BACKEND_HERDR_SWALLOW_RETRIES=2  # herdr-only: bounded Enter-only sweeps after an idle-baseline swallow verdict, before reporting a genuine swallow (docs/herdr-backend.md)
 FM_ZELLIJ_SESSION=firstmate  # zellij-only: named session for normal backend ops and test isolation (docs/zellij-backend.md)
 CMUX_SOCKET_PASSWORD=   # cmux-only: socket password fallback when config/cmux-socket-password is absent (docs/cmux-backend.md)
 FM_SESSION_START_STATUS_TAIL=5   # state/*.status lines printed per task in the session-start digest; each line is capped by bin/fm-line-cap-lib.sh

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -123,6 +123,7 @@ Every generated ship brief's task-branch language - the branch-creation step, th
 An absent file, or one that is empty or whitespace-only, resolves to the historical default `fm/`.
 This exists for a shared repo where another fleet already owns the `fm/*` namespace: per-task instructions can name a distinct prefix (e.g. `ryan-fm/`) and the scaffold now carries it consistently instead of the stock `fm/` language silently overriding it.
 `bin/fm-brief.sh` reads the file once per scaffold from the resolved `FM_HOME/config`, so it is not inherited: a secondmate home wanting a non-default prefix sets its own `config/branch-prefix` file.
+`bin/fm-merge-local.sh` and `bin/fm-review-diff.sh` do not yet read this file and still look up `fm/<task-id>` unconditionally, so a configured non-default prefix breaks the local-only merge path and diff review for that task.
 
 ## Trace context propagation (config/trace-context / FM_TRACE_CONTEXT)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -122,8 +122,8 @@ See [`wedge-alarm.md`](wedge-alarm.md) for the current channel reference, [`veri
 Every generated ship brief's task-branch language - the branch-creation step, the push rule, and every mode's `<prefix><task-id>` mention in its definition of done - uses the prefix from the local, gitignored `config/branch-prefix` file, trimmed of surrounding whitespace.
 An absent file, or one that is empty or whitespace-only, resolves to the historical default `fm/`.
 This exists for a shared repo where another fleet already owns the `fm/*` namespace: per-task instructions can name a distinct prefix (e.g. `ryan-fm/`) and the scaffold now carries it consistently instead of the stock `fm/` language silently overriding it.
-`bin/fm-brief.sh` reads the file once per scaffold from the resolved `FM_HOME/config`, so it is not inherited: a secondmate home wanting a non-default prefix sets its own `config/branch-prefix` file.
-`bin/fm-merge-local.sh` and `bin/fm-review-diff.sh` do not yet read this file and still look up `fm/<task-id>` unconditionally, so a configured non-default prefix breaks the local-only merge path and diff review for that task.
+`bin/fm-branch-prefix-lib.sh`'s `fm_branch_prefix_resolve` is the one owner of this resolution; `bin/fm-brief.sh`, `bin/fm-merge-local.sh`, and `bin/fm-review-diff.sh` all source it so the branch a brief creates, the branch a local-only merge fast-forwards, and the branch a review diff compares against always agree on the same name.
+Each script reads the file once per invocation from its own resolved `FM_HOME/config` (or `FM_CONFIG_OVERRIDE`), so it is not inherited: a secondmate home wanting a non-default prefix sets its own `config/branch-prefix` file.
 
 ## Trace context propagation (config/trace-context / FM_TRACE_CONTEXT)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -117,6 +117,13 @@ An absent file means `auto`, i.e. default-on on macOS: the alarm exists precisel
 A missing or failing channel logs and falls through to the next, never crashing the daemon.
 See [`wedge-alarm.md`](wedge-alarm.md) for the current channel reference, [`verification/supervision.md`](verification/supervision.md#wedge-alarm-channels) for active evidence, and [`examples/wedge-alarm`](examples/wedge-alarm) for a copyable config.
 
+## Branch prefix (config/branch-prefix)
+
+Every generated ship brief's task-branch language - the branch-creation step, the push rule, and every mode's `<prefix><task-id>` mention in its definition of done - uses the prefix from the local, gitignored `config/branch-prefix` file, trimmed of surrounding whitespace.
+An absent file, or one that is empty or whitespace-only, resolves to the historical default `fm/`.
+This exists for a shared repo where another fleet already owns the `fm/*` namespace: per-task instructions can name a distinct prefix (e.g. `ryan-fm/`) and the scaffold now carries it consistently instead of the stock `fm/` language silently overriding it.
+`bin/fm-brief.sh` reads the file once per scaffold from the resolved `FM_HOME/config`, so it is not inherited: a secondmate home wanting a non-default prefix sets its own `config/branch-prefix` file.
+
 ## Trace context propagation (config/trace-context / FM_TRACE_CONTEXT)
 
 The optional local, gitignored `config/trace-context` presence flag enables default-off native W3C trace-context propagation.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -214,7 +214,7 @@ Text is typed once; only Enter is retried.
 
 On an idle or done native baseline, submit confirmation first waits for `working` or `blocked` across a bounded polling window.
 If native status stays idle, the shared composer verdict is the next positive signal: a cleared composer is delivery, and proven pending text retries Enter.
-After the retry budget, `fm_composer_queued_enter_verdict` treats proven pending text plus a generating busy signal as a queued delivered Enter, and keeps an idle pending composer as a genuine swallow.
+After the retry budget, `fm_composer_queued_enter_verdict` treats proven pending text plus a generating busy signal as a queued delivered Enter; an idle pending composer instead falls to `fm_backend_herdr_swallow_sweep`, a bounded (`FM_BACKEND_HERDR_SWALLOW_RETRIES`, default 2) Enter-only follow-up that catches a stubborn but ultimately landable swallow (verified incident: 2026-08-18, recurred 2026-08-20 - a manual operator follow-up Enter reliably landed text the main loop had reported swallowed) before finally reporting a genuine swallow.
 On an already active or unreadable baseline, the adapter falls back to conservative composer clearance, with a pre-Enter rendered-footer transition when that baseline is unavailable.
 A fully unreadable target stops retrying and reports unknown.
 blocked is not treated as a queued-Enter busy signal, so a Cursor pane that reports blocked in every state does not receive that conversion.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -250,7 +250,7 @@ Measured 2026-08-19 against Herdr 0.8.0 and Claude Code 2.1.236 in an isolated `
 
 `herdr agent get` reported `agent_status=idle` on every sample across a landed one-word turn and an 8-second `sleep` tool call, while the pane rendered `Pontificating…` then `Sock-hopping… (11s · ↓ 234 tokens)`.
 `fm_backend_herdr_send_text_submit` therefore cannot treat native idle as proof of a swallow.
-The portable regressions in `tests/fm-backend-herdr.test.sh` and `tests/fm-composer-lib.test.sh` pin the verdicts: native idle plus a cleared composer is delivery, proven pending plus idle is a swallow, and proven pending plus a generating busy signal is a queued Enter.
+The portable regressions in `tests/fm-backend-herdr.test.sh` and `tests/fm-composer-lib.test.sh` pin the verdicts: native idle plus a cleared composer is delivery, proven pending plus a generating busy signal is a queued Enter, and proven pending plus idle falls to `fm_backend_herdr_swallow_sweep`'s bounded follow-up Enters (`FM_BACKEND_HERDR_SWALLOW_RETRIES`, default 2) before it is reported as a genuine swallow.
 Refresh the live Claude proof with:
 
 ```sh

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -3430,22 +3430,57 @@ test_send_text_submit_detects_landed_send() {
 }
 
 test_send_text_submit_detects_swallowed_enter() {
-  local dir log resp fb out
+  local dir log resp fb out enter_count
   dir="$TMP_ROOT/submit-swallow"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
   # Every post-Enter agent-get read still reports idle, and the composer still
-  # holds the typed text: a genuine swallow, not a queued Enter.
+  # holds the typed text: a genuine swallow, not a queued Enter. Calls 9-10
+  # are the exhaustion-time queued_enter_busy check (agent get, then a
+  # rendered-footer pane read since baseline was idle); calls 11-14 are the
+  # bounded post-exhaustion swallow sweep (fm_backend_herdr_swallow_sweep),
+  # here stubbed to keep observing the same unsent text so a genuine
+  # persistent swallow still reports pending, never a false 'empty'.
   printf '{"result":{"agent":{"agent_status":"idle"}}}\n' > "$resp/2.out"
   printf '{"result":{"agent":{"agent_status":"idle"}}}\n' > "$resp/4.out"
   printf '  \xe2\x9d\xaf hello captain\n' > "$resp/5.out"
   printf '{"result":{"agent":{"agent_status":"idle"}}}\n' > "$resp/7.out"
   printf '  \xe2\x9d\xaf hello captain\n' > "$resp/8.out"
-  printf '{"result":{"agent":{"agent_status":"idle"}}}\n' > "$resp/9.out"
-  printf '  ready\n' > "$resp/10.out"
+  printf '  \xe2\x9d\xaf hello captain\n' > "$resp/12.out"
+  printf '  \xe2\x9d\xaf hello captain\n' > "$resp/14.out"
   fb=$(make_herdr_fakebin "$dir")
   out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_BACKEND_HERDR_SUBMIT_POLLS=1 \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_send_text_submit default:w1:p2 "hello captain" 2 0.01 0.01' "$ROOT" )
-  [ "$out" = pending ] || fail "send_text_submit should report pending once retries are exhausted with agent_status never going busy and the composer still holding the text, got '$out'"
-  pass "fm_backend_herdr_send_text_submit: reports 'pending' when agent_status stays idle and the composer still holds unsent text after retried Enters (swallowed)"
+  [ "$out" = pending ] || fail "send_text_submit should report pending once retries and the follow-up swallow sweep are both exhausted with the composer still holding the text, got '$out'"
+  enter_count=$(grep -c $'\x1f''pane'$'\x1f''send-keys'$'\x1f''w1:p2'$'\x1f''enter' "$log")
+  [ "$enter_count" -eq 4 ] || fail "swallow sweep should send exactly FM_BACKEND_HERDR_SWALLOW_RETRIES (default 2) extra Enters after the main retry budget's 2 Enters, sent $enter_count Enter(s) total"
+  pass "fm_backend_herdr_send_text_submit: reports 'pending' when agent_status stays idle and the composer still holds unsent text after retried Enters AND the bounded follow-up swallow sweep (persistent swallow)"
+}
+
+# Recurring incident (2026-08-18, again 2026-08-20): a herdr claude pane's
+# Enter was reported swallowed by the main retry loop, yet a manual operator
+# follow-up `fm-send --key Enter` reliably landed the SAME text. This proves
+# the new bounded swallow sweep (fm_backend_herdr_swallow_sweep) does that
+# follow-up itself instead of leaving it to the operator: the composer is
+# still pending when the main retry budget is exhausted, but clears on the
+# sweep's first extra Enter.
+test_send_text_submit_swallow_sweep_lands_a_stubborn_enter() {
+  local dir log resp fb out enter_count
+  dir="$TMP_ROOT/submit-swallow-sweep-lands"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '{"result":{"agent":{"agent_status":"idle"}}}\n' > "$resp/2.out"
+  printf '{"result":{"agent":{"agent_status":"idle"}}}\n' > "$resp/4.out"
+  printf '  \xe2\x9d\xaf hello captain\n' > "$resp/5.out"
+  printf '{"result":{"agent":{"agent_status":"idle"}}}\n' > "$resp/7.out"
+  printf '  \xe2\x9d\xaf hello captain\n' > "$resp/8.out"
+  # Sweep Enter #1 (call 11) finally lands it: the composer reads clear (call
+  # 12), the same bordered bare-prompt shape test_composer_state_bare_prompt_is_empty
+  # (above) uses for a positively-cleared composer.
+  printf '  ╭────────────────────────╮\n  │ ❯                      │\n  ╰──────── Composer ──────╯\n\n  Shift+Tab:mode\n' > "$resp/12.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" FM_BACKEND_HERDR_SUBMIT_POLLS=1 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_send_text_submit default:w1:p2 "hello captain" 2 0.01 0.01' "$ROOT" )
+  [ "$out" = empty ] || fail "send_text_submit should report empty once the swallow sweep's own follow-up Enter clears the composer, got '$out'"
+  enter_count=$(grep -c $'\x1f''pane'$'\x1f''send-keys'$'\x1f''w1:p2'$'\x1f''enter' "$log")
+  [ "$enter_count" -eq 3 ] || fail "the swallow sweep should stop at its first Enter that clears the composer (2 main-loop Enters + 1 sweep Enter), sent $enter_count Enter(s)"
+  pass "fm_backend_herdr_send_text_submit: the bounded post-exhaustion swallow sweep sends the follow-up Enter itself and reports 'empty' once it lands, instead of failing out with the text left in the composer"
 }
 
 # Regression coverage for the 2026-07-03 incident using the NEW mechanism: a
@@ -4543,6 +4578,7 @@ test_wait_for_working_returns_unknown_when_never_readable
 test_wait_for_working_treats_blocked_as_submit_active
 test_send_text_submit_detects_landed_send
 test_send_text_submit_detects_swallowed_enter
+test_send_text_submit_swallow_sweep_lands_a_stubborn_enter
 test_send_text_submit_popup_autocomplete_requires_second_enter
 test_send_text_submit_confirms_blocked_after_enter
 test_send_text_submit_preexisting_working_pending_is_queued_enter

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -319,6 +319,73 @@ test_faster_paths_use_configured_authority_without_stacked_review() {
   pass "fm-brief.sh: faster paths use configured authority without stacked review"
 }
 
+# Incident (2026-08-18, recurred 2026-08-20): the scaffold's stock `fm/<id>`
+# branch language overrode per-task instructions to use a different prefix in
+# a shared repo where another fleet already owns the `fm/*` namespace, and
+# crews pushed into that other fleet's namespace. config/branch-prefix (local,
+# gitignored) parameterizes it; absent resolves to the historical `fm/` default.
+test_branch_prefix_defaults_to_fm() {
+  local home id brief
+  home="$TMP_ROOT/branch-prefix-default-home"
+  mkdir -p "$home/data"
+  id="brief-branch-default-b2"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_grep "git checkout -b fm/$id" "$brief" \
+    "no-mistakes brief did not default the branch-creation step to the fm/ prefix"
+  pass "fm-brief.sh: an absent config/branch-prefix defaults every generated brief to the fm/ prefix"
+}
+
+test_branch_prefix_honors_configured_value() {
+  local home id brief
+  home="$TMP_ROOT/branch-prefix-configured-home"
+  mkdir -p "$home/data" "$home/config"
+  printf 'ryan-fm/\n' > "$home/config/branch-prefix"
+  id="brief-branch-configured-b2"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_grep "git checkout -b ryan-fm/$id" "$brief" \
+    "no-mistakes brief did not honor the configured branch prefix in its branch-creation step"
+  assert_no_grep "git checkout -b fm/$id" "$brief" \
+    "no-mistakes brief kept the stock fm/ prefix alongside the configured one"
+
+  id="brief-branch-configured-direct-b2"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" direct-proj --mode direct-PR >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_grep "push only your \`ryan-fm/$id\` branch" "$brief" \
+    "direct-PR brief's push rule did not honor the configured branch prefix"
+  assert_no_grep "\`fm/$id\` branch" "$brief" \
+    "direct-PR brief's push rule kept the stock fm/ prefix"
+
+  id="brief-branch-configured-local-b2"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" local-proj --mode local-only >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_grep "Work only on your \`ryan-fm/$id\` branch" "$brief" \
+    "local-only brief's rule did not honor the configured branch prefix"
+  assert_grep "committed on your branch \`ryan-fm/$id\`" "$brief" \
+    "local-only brief's definition of done did not honor the configured branch prefix"
+  assert_grep "ready in branch ryan-fm/$id" "$brief" \
+    "local-only brief's done-report instruction did not honor the configured branch prefix"
+  assert_no_grep "\`fm/$id\`" "$brief" \
+    "local-only brief kept the stock fm/ prefix alongside the configured one"
+  assert_no_grep "ready in branch fm/$id" "$brief" \
+    "local-only brief's done-report instruction kept the stock fm/ prefix alongside the configured one"
+  pass "fm-brief.sh: config/branch-prefix is honored consistently across the branch-creation step, push rule, and every mode's fm/<id> mention"
+}
+
+test_branch_prefix_blank_file_falls_back_to_default() {
+  local home id brief
+  home="$TMP_ROOT/branch-prefix-blank-home"
+  mkdir -p "$home/data" "$home/config"
+  printf '   \n' > "$home/config/branch-prefix"
+  id="brief-branch-blank-b2"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_grep "git checkout -b fm/$id" "$brief" \
+    "a whitespace-only config/branch-prefix should fall back to the fm/ default, not an empty prefix"
+  pass "fm-brief.sh: a blank config/branch-prefix falls back to the fm/ default instead of an empty prefix"
+}
+
 # Pin the specific line the bug lived on: the no-mistakes DOD's no-mistakes
 # reference must render as plain prose with no dangling apostrophe artifact.
 test_no_mistakes_dod_wording() {
@@ -720,6 +787,9 @@ test_ship_mode_is_required_and_closed_set
 test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply
 test_faster_paths_use_configured_authority_without_stacked_review
+test_branch_prefix_defaults_to_fm
+test_branch_prefix_honors_configured_value
+test_branch_prefix_blank_file_falls_back_to_default
 test_no_mistakes_dod_wording
 test_ship_project_memory_wording
 test_herdr_lab_contract_is_explicit_and_complete

--- a/tests/fm-merge-local.test.sh
+++ b/tests/fm-merge-local.test.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Tests for bin/fm-merge-local.sh: it fast-forwards a project's default branch
+# to a mode=local-only task's branch, whose name is the configured
+# config/branch-prefix plus the task id (default prefix "fm/"; see
+# bin/fm-branch-prefix-lib.sh, shared with bin/fm-brief.sh and
+# bin/fm-review-diff.sh so all three agree on the same branch name).
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+fm_git_identity fmtest fmtest@example.invalid
+
+MERGE_LOCAL="$ROOT/bin/fm-merge-local.sh"
+TMP_ROOT=$(fm_test_tmproot fm-merge-local-tests)
+
+# make_case <name> <branch>: a project with one commit on its default branch
+# (main) and a task branch named <branch> carrying one additional commit that
+# is a clean fast-forward ahead of main.
+make_case() {
+  local name=$1 branch=$2 case_dir
+  case_dir="$TMP_ROOT/$name"
+  mkdir -p "$case_dir/state" "$case_dir/config"
+
+  fm_git_init_commit "$case_dir/project"
+  git -C "$case_dir/project" branch -m main
+
+  git -C "$case_dir/project" worktree add -q -b "$branch" "$case_dir/wt"
+  printf 'task change\n' > "$case_dir/wt/feature.txt"
+  git -C "$case_dir/wt" add feature.txt
+  git -C "$case_dir/wt" -c user.email=t@t -c user.name=t commit -qm "task commit"
+  git -C "$case_dir/project" worktree remove --force "$case_dir/wt"
+
+  fm_write_meta "$case_dir/state/task-x1.meta" \
+    "window=fm-task-x1" \
+    "worktree=$case_dir/wt" \
+    "project=$case_dir/project" \
+    "mode=local-only"
+
+  printf '%s\n' "$case_dir"
+}
+
+run_merge_local() {
+  local case_dir=$1
+  shift
+  FM_ROOT_OVERRIDE="$ROOT" \
+  FM_STATE_OVERRIDE="$case_dir/state" \
+  FM_CONFIG_OVERRIDE="$case_dir/config" \
+    "$MERGE_LOCAL" "$@"
+}
+
+test_default_prefix_merges_fm_branch() {
+  local case_dir out before after
+  case_dir=$(make_case default-prefix fm/task-x1)
+  before=$(git -C "$case_dir/project" rev-parse --short main)
+
+  out=$(run_merge_local "$case_dir" task-x1)
+
+  assert_contains "$out" "merged fm/task-x1 into local main" \
+    "default prefix: merge output did not name the fm/ branch"
+  after=$(git -C "$case_dir/project" rev-parse --short main)
+  [ "$after" != "$before" ] || fail "default prefix: main did not advance"
+  assert_contains "$(cat "$case_dir/project/feature.txt" 2>/dev/null || true)" "task change" \
+    "default prefix: fast-forward did not land the task commit"
+  pass "fm-merge-local: an absent config/branch-prefix merges the fm/<id> branch"
+}
+
+# Incident follow-up (2026-08-20, no-mistakes document gate on task
+# fmsendretry-u2): bin/fm-brief.sh honors config/branch-prefix, but
+# fm-merge-local.sh still hardcoded "fm/<id>", so a captain-configured
+# non-default prefix left local-only merges unable to find the branch.
+test_configured_prefix_merges_configured_branch() {
+  local case_dir out before after
+  case_dir=$(make_case configured-prefix ryan-fm/task-x1)
+  printf 'ryan-fm/\n' > "$case_dir/config/branch-prefix"
+  before=$(git -C "$case_dir/project" rev-parse --short main)
+
+  out=$(run_merge_local "$case_dir" task-x1)
+
+  assert_contains "$out" "merged ryan-fm/task-x1 into local main" \
+    "configured prefix: merge output did not name the configured ryan-fm/ branch"
+  after=$(git -C "$case_dir/project" rev-parse --short main)
+  [ "$after" != "$before" ] || fail "configured prefix: main did not advance"
+  assert_contains "$(cat "$case_dir/project/feature.txt" 2>/dev/null || true)" "task change" \
+    "configured prefix: fast-forward did not land the task commit"
+  pass "fm-merge-local: a configured config/branch-prefix merges that prefix's branch, matching bin/fm-brief.sh"
+}
+
+test_configured_prefix_does_not_find_stock_fm_branch() {
+  local case_dir out status
+  case_dir=$(make_case mismatched-prefix fm/task-x1)
+  printf 'ryan-fm/\n' > "$case_dir/config/branch-prefix"
+
+  set +e
+  out=$(run_merge_local "$case_dir" task-x1 2>&1)
+  status=$?
+  set -e
+
+  [ "$status" -ne 0 ] || fail "mismatched prefix: merge should refuse when the configured-prefix branch does not exist"
+  assert_contains "$out" "branch ryan-fm/task-x1 does not exist" \
+    "mismatched prefix: error should name the configured branch it looked for, not the stock fm/ one"
+  pass "fm-merge-local: with a configured prefix, it looks for that branch and refuses loudly rather than silently matching the stock fm/ name"
+}
+
+test_default_prefix_merges_fm_branch
+test_configured_prefix_merges_configured_branch
+test_configured_prefix_does_not_find_stock_fm_branch

--- a/tests/fm-review-diff.test.sh
+++ b/tests/fm-review-diff.test.sh
@@ -72,6 +72,7 @@ run_review_diff() {
   shift
   FM_ROOT_OVERRIDE="$ROOT" \
   FM_STATE_OVERRIDE="$case_dir/state" \
+  FM_CONFIG_OVERRIDE="$case_dir/config" \
     "$REVIEW_DIFF" "$@"
 }
 
@@ -169,8 +170,50 @@ test_unreachable_pr_head_falls_back_with_warning() {
   pass "fm-review-diff falls back to local branch with a warning when PR head is unreachable"
 }
 
+# Incident follow-up (2026-08-20, no-mistakes document gate on task
+# fmsendretry-u2): bin/fm-brief.sh honors a configured config/branch-prefix
+# (docs/configuration.md "Branch prefix"), but fm-review-diff.sh still
+# hardcoded "fm/<id>", so a captain-configured non-default prefix left review
+# looking for the wrong branch name. Both now share fm_branch_prefix_resolve
+# (bin/fm-branch-prefix-lib.sh).
+test_configured_branch_prefix_is_honored() {
+  local case_dir out
+  case_dir="$TMP_ROOT/branch-prefix-configured"
+  mkdir -p "$case_dir/state" "$case_dir/config"
+  printf 'ryan-fm/\n' > "$case_dir/config/branch-prefix"
+
+  git init -q --bare "$case_dir/origin.git"
+  git -C "$case_dir/origin.git" symbolic-ref HEAD refs/heads/main
+  git clone -q "$case_dir/origin.git" "$case_dir/_seed" 2>/dev/null
+  printf 'base\n' > "$case_dir/_seed/feature.txt"
+  git -C "$case_dir/_seed" add feature.txt
+  git -C "$case_dir/_seed" -c user.email=t@t -c user.name=t commit -qm "origin baseline"
+  git -C "$case_dir/_seed" push -q origin main
+  rm -rf "$case_dir/_seed"
+
+  git clone -q "$case_dir/origin.git" "$case_dir/project"
+  git -C "$case_dir/project" remote set-head origin main 2>/dev/null || true
+  git -C "$case_dir/project" worktree add -q -b ryan-fm/task-x1 "$case_dir/wt" main
+  printf 'configured-prefix-change\n' > "$case_dir/wt/feature.txt"
+  git -C "$case_dir/wt" add feature.txt
+  git -C "$case_dir/wt" commit -qm "change on the configured-prefix branch"
+
+  fm_write_meta "$case_dir/state/task-x1.meta" \
+    "window=fm-task-x1" \
+    "worktree=$case_dir/wt" \
+    "project=$case_dir/project"
+
+  out=$(FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$case_dir/state" \
+    FM_CONFIG_OVERRIDE="$case_dir/config" "$REVIEW_DIFF" task-x1 2> "$case_dir/stderr")
+
+  assert_contains "$out" '+configured-prefix-change' \
+    "configured branch-prefix: diff should find the ryan-fm/task-x1 branch, not fall through to worktree-detached HEAD"
+  pass "fm-review-diff resolves the task branch through a configured config/branch-prefix, matching bin/fm-brief.sh"
+}
+
 test_pr_meta_uses_pr_head_not_stale_local
 test_pr_meta_fetches_pull_head_without_recorded_sha
 test_stale_recorded_pr_head_loses_to_fetched_pull_head
 test_no_pr_meta_uses_local_branch
 test_unreachable_pr_head_falls_back_with_warning
+test_configured_branch_prefix_is_honored


### PR DESCRIPTION
## What Changed

- `bin/fm-brief.sh` now resolves the ship task branch prefix from `config/branch-prefix` (defaulting to `fm/`) instead of hardcoding it, and `bin/fm-promote.sh` follows the same resolved prefix when promoting a scout to a ship branch.
- `bin/backends/herdr.sh` detects a swallowed follow-up Enter on herdr Claude panes and retries it, preventing a submitted send from silently stalling.
- Updated `AGENTS.md`, `docs/configuration.md`, `docs/architecture.md`, `docs/herdr-backend.md`, and `docs/verification/runtime-backends.md` to document the branch-prefix config and the herdr swallow-retry behavior, correcting a stale swallow-verdict claim and an undocumented `FM_BACKEND_HERDR_SWALLOW_RETRIES` variable.
- Added/expanded tests in `tests/fm-brief.test.sh` (branch-prefix default, configured value, blank-file fallback) and `tests/fm-backend-herdr.test.sh` (swallow detection and retry sweep).

## Risk Assessment

✅ Low: Both changes are narrowly scoped, well-tested with exact-call-count assertions, and the one known gap (fm-merge-local.sh/fm-review-diff.sh not yet honoring config/branch-prefix) is explicitly and accurately disclosed in docs rather than silently left broken.

## Testing

Ran the colocated fm-brief.sh test suite (23/23 passing, including all three new branch-prefix tests) and isolated the two new/modified herdr swallow-sweep tests plus a baseline non-swallow regression test (all passing); the full fm-backend-herdr.test.sh suite was still running cleanly (76+ passed, 0 failed) at report time due to its real-sleep-based timing. Beyond unit tests, I produced direct CLI evidence generating real briefs with bin/fm-brief.sh under a configured config/branch-prefix (ryan-fm/) and confirmed the branch-creation step, push rule, and definition-of-done text consistently use the configured prefix across no-mistakes and local-only modes, while an unconfigured home still defaults to fm/ — demonstrating the end-user-facing behavior the change was meant to fix.

<details>
<summary>Evidence: fm-brief.sh branch-prefix end-to-end CLI transcript (configured ryan-fm/ prefix across no-mistakes/local-only modes, and default fm/ when unconfigured)</summary>

```text
=== no-mistakes mode, configured prefix ryan-fm/ ===
scaffolded: /var/folders/tl/tc0684vd5wbd7fhg_l_cqcv80000gn/T/tmp.36RLEdKVGk/data/demo-nm/brief.md (ship, mode=no-mistakes; replace {TASK})
--- relevant brief.md lines ---
18:1. First action: create your branch: `git checkout -b ryan-fm/demo-nm`
22:1. Never push to the default branch. Never merge a PR.

=== local-only mode, configured prefix ryan-fm/ ===
scaffolded: /var/folders/tl/tc0684vd5wbd7fhg_l_cqcv80000gn/T/tmp.36RLEdKVGk/data/demo-local/brief.md (ship, mode=local-only; replace {TASK})
18:1. First action: create your branch: `git checkout -b ryan-fm/demo-local`
56:The task is complete only when committed on your branch `ryan-fm/demo-local`. Do NOT push, do NOT open a PR, do NOT merge.
58:When it is implemented and committed, append `done: ready in branch ryan-fm/demo-local` to the status file and stop.

=== no-mistakes mode, NO config (default fm/) ===
scaffolded: /var/folders/tl/tc0684vd5wbd7fhg_l_cqcv80000gn/T/tmp.IVu2pj94oP/data/demo-default/brief.md (ship, mode=no-mistakes; replace {TASK})
18:1. First action: create your branch: `git checkout -b fm/demo-default`
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-brief.test.sh` (full file, 23/23 ok, including the 3 new branch-prefix tests: test_branch_prefix_defaults_to_fm, test_branch_prefix_honors_configured_value, test_branch_prefix_blank_file_falls_back_to_default)</code>
- <code>Isolated run of `test_send_text_submit_detects_swallowed_enter` and `test_send_text_submit_swallow_sweep_lands_a_stubborn_enter` from tests/fm-backend-herdr.test.sh via a spliced runner sourcing tests/lib.sh and tests/herdr-test-safety.sh — both pass</code>
- <code>Isolated run of `test_send_text_submit_detects_landed_send` (baseline non-swallow path, unmodified by this change) to confirm no regression in the ordinary send-confirmation path</code>
- <code>Full `bash tests/fm-backend-herdr.test.sh` suite run in background (in progress at report time: 76+/181 tests passed, 0 failures, spanning tests both before and after the modified swallow-sweep tests in file order)</code>
- <code>Manual end-to-end CLI verification: `FM_HOME=&lt;tmp&gt; bin/fm-brief.sh &lt;id&gt; firstmate --mode no-mistakes` with config/branch-prefix=ryan-fm/, --mode local-only with the same config, and --mode no-mistakes with no config file present, inspecting the generated brief.md branch-creation/push/DOD lines directly</code>
- <code>`bash -n` syntax check on bin/backends/herdr.sh, bin/fm-brief.sh, bin/fm-promote.sh</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
