### PR TITLE
ci: require no-mistakes pipeline step attestation

### DIFF
--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -36,6 +36,75 @@ jobs:
           marker='Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)'
           if printf '%s' "${PR_BODY:-}" | grep -qF -- "$marker"; then
             echo "Found no-mistakes signature in PR #${PR_NUMBER} body."
+            if ! command -v jq >/dev/null 2>&1; then
+              echo "::error::This check requires jq to parse no-mistakes pipeline step attestation, but jq was not found on the runner." >&2
+              exit 1
+            fi
+            prefix='<!-- no-mistakes-pipeline-attestation:v1 '
+            suffix=' -->'
+            body="${PR_BODY:-}"
+            json=''
+            parse_ok=0
+            case "$body" in
+              *"$prefix"*)
+                rest="${body#*"$prefix"}"
+                case "$rest" in
+                  *"$suffix"*)
+                    json="${rest%%"$suffix"*}"
+                    if printf '%s' "$json" | jq -e . >/dev/null 2>&1; then
+                      parse_ok=1
+                    fi
+                    ;;
+                esac
+                ;;
+            esac
+            if [ "$parse_ok" -ne 1 ]; then
+              {
+                echo "::error::This repository requires no-mistakes >= 1.46.0; structured pipeline step attestation is missing or unparseable."
+                echo
+                echo "The no-mistakes signature was found, but this check also requires one"
+                echo "HTML comment in the PR body:"
+                echo
+                echo '    <!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"...","steps":[...]} -->'
+                echo
+                echo "That comment is emitted by no-mistakes >= 1.46.0 (the release that started"
+                echo "emitting structured step attestation; see https://github.com/kunchenguid/no-mistakes/pull/670)."
+                echo "An older no-mistakes that writes only the signature line is not enough."
+                echo
+                echo "Re-run the pipeline with 'git push no-mistakes' using no-mistakes >= 1.46.0."
+                echo "See CONTRIBUTING.md for setup and the full workflow."
+                echo
+                echo "PR author: ${PR_AUTHOR}"
+              } >&2
+              exit 1
+            fi
+            incomplete=''
+            for required in review test document; do
+              status=$(printf '%s' "$json" | jq -r --arg step "$required" \
+                '([(.steps | arrays | .[]) | select(.step == $step) | .status] | first // empty | select(. != "")) // "missing"')
+              if [ "$status" != "completed" ]; then
+                if [ -n "$incomplete" ]; then
+                  incomplete="${incomplete}, "
+                fi
+                incomplete="${incomplete}${required}=${status}"
+              fi
+            done
+            if [ -n "$incomplete" ]; then
+              {
+                echo "::error::Required no-mistakes pipeline steps are not completed: ${incomplete}."
+                echo
+                echo "This repository requires review, test, and document to each have status"
+                echo "exactly 'completed'. Quota skips and agent skips are not compliant."
+                echo
+                echo "Re-run the pipeline with 'git push no-mistakes' using no-mistakes >= 1.46.0"
+                echo "so those required steps complete rather than skip."
+                echo "See CONTRIBUTING.md for setup and the full workflow."
+                echo
+                echo "PR author: ${PR_AUTHOR}"
+              } >&2
+              exit 1
+            fi
+            echo "Pipeline step attestation is valid: review, test, and document are completed."
             exit 0
           fi
           {


### PR DESCRIPTION
## Summary
- Keep the existing no-mistakes signature requirement for human PRs.
- After that signature, require the v1 HTML pipeline-attestation comment from no-mistakes >= 1.46.0.
- Fail if attestation is missing or unparseable, or if `review`, `test`, or `document` is anything other than `completed` (quota/agent skips included). Bot exemptions are unchanged.

This is a direct-PR: GitHub will run the current main (signature-only) check against this PR, so `PR must be raised via no-mistakes` is expected red until merge. The new attestation logic applies to later PRs after this lands.

## Test plan
- [x] Local dry-run of the inline gate: missing signature, signature-only, garbled JSON, skipped/missing required steps, and a completed attestation.
- [x] `bin/fm-lint-workflows.sh .github/workflows/no-mistakes-required.yml` passes (actionlint 1.7.12).
- [ ] Confirm CI: the only expected red check is `PR must be raised via no-mistakes`.