### PR TITLE
docs: clarify delivery mode risk heuristic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,6 +280,8 @@ Load `diagnostic-reasoning` before scoping a reported bug and before acting on a
 
 Resolve every ship task's concrete delivery mode and yolo posture at intake, and pass both explicitly to the brief, the spawn, and any scout promotion, which all refuse to guess.
 A current explicit captain instruction wins; otherwise the project's registry entry is the captain's standing posture, and dropping below its rigor needs a reason you can state.
+A mechanical, well-trodden change (a version bump, a config tweak, copying an established pattern) is itself a sufficient reason.
+Symmetrically, raising a task above a direct-PR project's standing posture is warranted for genuinely new or risky work (a new algorithm, a concurrency-sensitive change, unfamiliar territory) even when the project defaults lighter.
 On a `no-mistakes-prod-only` project, classify the task's surface: internal-only tooling, automation, contributor or operator process, and release or submission work ships `direct-PR`, while product-facing, mixed, and uncertain work ships `no-mistakes`; never infer internal-only from file location or project name.
 An unregistered project or absent registry resolves to `no-mistakes` with yolo off, and the registration gap goes to the captain.
 Record the resulting mode, yolo, and the one-line reason for any deviation in the backlog item note.


### PR DESCRIPTION
## Intent

In AGENTS.md section 7, insert two sentences immediately after the existing sentence "A current explicit captain instruction wins; otherwise the project's registry entry is the captain's standing posture, and dropping below its rigor needs a reason you can state." as a direct continuation of that same point, with no rephrasing of the existing sentence, no new section or heading, and no duplication of this policy elsewhere in the file: "A mechanical, well-trodden change (a version bump, a config tweak, copying an established pattern) is itself a sufficient reason. Symmetrically, raising a task above a direct-PR project's standing posture is warranted for genuinely new or risky work (a new algorithm, a concurrency-sensitive change, unfamiliar territory) even when the project defaults lighter." This is the only change in the PR. Follow firstmate-coding-guidelines repo style: one full sentence per line in tracked Markdown, plain dash not em dash.

## What Changed

- Clarified when mechanical, established changes may use a delivery posture below a project's standing rigor.
- Added matching guidance to raise direct-PR work for genuinely new or risky changes.

## Risk Assessment

✅ Low: The sole two-line documentation change exactly satisfies the specified placement, wording, formatting, and no-duplication constraints.

## Testing

The target commit changes only AGENTS.md, with the two required sentences immediately following the unchanged standing-posture sentence; whitespace validation passed and an end-user-facing policy excerpt was recorded as evidence. No screenshot was applicable because this is a Markdown agent-instruction contract with no rendered UI surface.

<details>
<summary>Evidence: Rendered policy excerpt and diff-scope evidence</summary>

Source: [Rendered policy excerpt and diff-scope evidence](https://github.com/trevorallred/firstmate/blob/0434dd4151c9442391c789a2136e12e700e91421/.no-mistakes/evidence/fm/firstmate-mode-risk-heuristic/agents-mode-posture-policy-evidence.md)

```text
# AGENTS.md delivery-mode policy evidence

Target commit: `d5b181a5b49b21010c0bc0125c079e097f328ce7`

The end-user-facing agent instruction now reads as one continuous policy block:

> A current explicit captain instruction wins; otherwise the project's registry entry is the captain's standing posture, and dropping below its rigor needs a reason you can state.
> A mechanical, well-trodden change (a version bump, a config tweak, copying an established pattern) is itself a sufficient reason.
> Symmetrically, raising a task above a direct-PR project's standing posture is warranted for genuinely new or risky work (a new algorithm, a concurrency-sensitive change, unfamiliar territory) even when the project defaults lighter.

The committed diff changes only `AGENTS.md`, adding exactly the latter two full sentences immediately after the standing-posture sentence. `git diff --check` accepts the change with no whitespace errors.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"d5b181a5b49b21010c0bc0125c079e097f328ce7","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --check 1cb900c28faf23fe23c9bb54e63f7c3b436ea096 d5b181a5b49b21010c0bc0125c079e097f328ce7`
- `git diff --name-status 1cb900c28faf23fe23c9bb54e63f7c3b436ea096 d5b181a5b49b21010c0bc0125c079e097f328ce7`
- `Inspected the target-commit AGENTS.md policy block at lines 281–285 to verify immediate placement, exact sentence-per-line presentation, and policy continuity.`
- `git diff --exit-code d5b181a5b49b21010c0bc0125c079e097f328ce7 -- AGENTS.md`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
