### PR TITLE
fix(bin): guard Stop-hook path commands

### DIFF
--- a/bin/fm-claude-stop-autoarm.sh
+++ b/bin/fm-claude-stop-autoarm.sh
@@ -58,7 +58,7 @@
 set -u
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd -- "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"

--- a/bin/fm-claude-stop-autoarm.sh
+++ b/bin/fm-claude-stop-autoarm.sh
@@ -57,7 +57,7 @@
 # the model.
 set -u
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -7,7 +7,7 @@
 #        fm-lock.sh status    print holder and liveness; always exits 0
 set -u
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -8,7 +8,7 @@
 set -u
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd -- "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 LOCK="$STATE/.lock"

--- a/bin/fm-turnend-guard.sh
+++ b/bin/fm-turnend-guard.sh
@@ -66,7 +66,7 @@
 #      fail-open only for an already verified failure episode.
 set -u
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
@@ -86,7 +86,7 @@ for arg in "$@"; do
   case "$arg" in
     --claude) CLAUDE_MODE=1 ;;
     --cursor) CURSOR_MODE=1 ;;
-    *) echo "usage: $(basename "$0") [--claude|--cursor]" >&2; exit 2 ;;
+    *) echo "usage: $(basename -- "$0") [--claude|--cursor]" >&2; exit 2 ;;
   esac
 done
 

--- a/bin/fm-turnend-guard.sh
+++ b/bin/fm-turnend-guard.sh
@@ -67,7 +67,7 @@
 set -u
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd -- "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Shared durable wake queue and portable lock helpers.
 
-FM_WAKE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_WAKE_LIB_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 FM_WAKE_DEFAULT_ROOT="$(cd "$FM_WAKE_LIB_DIR/.." && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-${FM_ROOT:-$FM_WAKE_DEFAULT_ROOT}}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
@@ -314,11 +314,14 @@ fm_lock_role() {
   cat "$1/role" 2>/dev/null
 }
 
+# Every path tool below takes `--`, and every `cd` takes it too: a path whose
+# first character is a dash is otherwise parsed as an option bundle, which BSD
+# basename rejects loudly enough to prefix an operator-visible message.
 fm_lock_abs_path() {
   local path=$1 dir base
-  dir=$(dirname "$path")
-  base=$(basename "$path")
-  dir=$(cd "$dir" 2>/dev/null && pwd -P) || return 1
+  dir=$(dirname -- "$path")
+  base=$(basename -- "$path")
+  dir=$(cd -- "$dir" 2>/dev/null && pwd -P) || return 1
   printf '%s/%s\n' "$dir" "$base"
 }
 
@@ -338,17 +341,17 @@ fm_lock_prepare_owner() {
 
 fm_lock_link_owner() {
   local lockdir=$1 owner
-  owner=$(readlink "$lockdir" 2>/dev/null) || return 1
+  owner=$(readlink -- "$lockdir" 2>/dev/null) || return 1
   [ -n "$owner" ] || return 1
   case "$owner" in
     /*) printf '%s\n' "$owner" ;;
-    *) printf '%s/%s\n' "$(dirname "$lockdir")" "$owner" ;;
+    *) printf '%s/%s\n' "$(dirname -- "$lockdir")" "$owner" ;;
   esac
 }
 
 fm_lock_points_to_owner() {
   local lockdir=$1 ownerdir=$2 actual
-  actual=$(readlink "$lockdir" 2>/dev/null) || return 1
+  actual=$(readlink -- "$lockdir" 2>/dev/null) || return 1
   [ "$actual" = "$ownerdir" ]
 }
 
@@ -361,8 +364,8 @@ fm_lock_discard_owner() {
 
 fm_lock_remove_stray_owner_link() {
   local lockdir=$1 ownerdir=$2 stray
-  stray="$lockdir/$(basename "$ownerdir")"
-  if [ -L "$stray" ] && [ "$(readlink "$stray" 2>/dev/null || true)" = "$ownerdir" ]; then
+  stray="$lockdir/$(basename -- "$ownerdir")"
+  if [ -L "$stray" ] && [ "$(readlink -- "$stray" 2>/dev/null || true)" = "$ownerdir" ]; then
     rm -f "$stray" 2>/dev/null || true
   fi
 }
@@ -1228,7 +1231,7 @@ fm_wake_signal_sig() {  # <file> -> "size:mtime"
 }
 
 fm_wake_signal_seen_path() {  # <state> <file>
-  printf '%s/.seen-%s' "$1" "$(basename "$2" | tr '.' '_')"
+  printf '%s/.seen-%s' "$1" "$(basename -- "$2" | tr '.' '_')"
 }
 
 # 0 when <file>'s current signature exactly matches its recorded seen marker,

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -314,9 +314,13 @@ fm_lock_role() {
   cat "$1/role" 2>/dev/null
 }
 
-# Every path tool below takes `--`, and every `cd` takes it too: a path whose
-# first character is a dash is otherwise parsed as an option bundle, which BSD
-# basename rejects loudly enough to prefix an operator-visible message.
+# basename, dirname and cd take `--` here because they are reached from the
+# ancestry walk, where a login shell's own argv[0] arrives dash-prefixed and BSD
+# basename would otherwise reject it as an option bundle. The readlink calls
+# below deliberately do NOT: every lock path is built under the home's state
+# directory from FM_HOME and is absolute, so none can begin with a dash, and
+# adding a separator there would be hardening beyond the defect at the cost of
+# depending on `--` support in one more BSD tool.
 fm_lock_abs_path() {
   local path=$1 dir base
   dir=$(dirname -- "$path")
@@ -341,7 +345,7 @@ fm_lock_prepare_owner() {
 
 fm_lock_link_owner() {
   local lockdir=$1 owner
-  owner=$(readlink -- "$lockdir" 2>/dev/null) || return 1
+  owner=$(readlink "$lockdir" 2>/dev/null) || return 1
   [ -n "$owner" ] || return 1
   case "$owner" in
     /*) printf '%s\n' "$owner" ;;
@@ -351,7 +355,7 @@ fm_lock_link_owner() {
 
 fm_lock_points_to_owner() {
   local lockdir=$1 ownerdir=$2 actual
-  actual=$(readlink -- "$lockdir" 2>/dev/null) || return 1
+  actual=$(readlink "$lockdir" 2>/dev/null) || return 1
   [ "$actual" = "$ownerdir" ]
 }
 
@@ -365,7 +369,7 @@ fm_lock_discard_owner() {
 fm_lock_remove_stray_owner_link() {
   local lockdir=$1 ownerdir=$2 stray
   stray="$lockdir/$(basename -- "$ownerdir")"
-  if [ -L "$stray" ] && [ "$(readlink -- "$stray" 2>/dev/null || true)" = "$ownerdir" ]; then
+  if [ -L "$stray" ] && [ "$(readlink "$stray" 2>/dev/null || true)" = "$ownerdir" ]; then
     rm -f "$stray" 2>/dev/null || true
   fi
 }

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -2,7 +2,7 @@
 # Shared durable wake queue and portable lock helpers.
 
 FM_WAKE_LIB_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-FM_WAKE_DEFAULT_ROOT="$(cd "$FM_WAKE_LIB_DIR/.." && pwd)"
+FM_WAKE_DEFAULT_ROOT="$(cd -- "$FM_WAKE_LIB_DIR/.." && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-${FM_ROOT:-$FM_WAKE_DEFAULT_ROOT}}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-${STATE:-$FM_HOME/state}}"

--- a/bin/fm-watch-arm.sh
+++ b/bin/fm-watch-arm.sh
@@ -60,7 +60,7 @@
 # (secondmate homes run the same script) and would kill siblings.
 set -u
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
 
@@ -397,7 +397,7 @@ case "${1:-}" in
     case "$handling_watcher_pid" in ''|*[!0-9]*) echo "watcher: invalid successor watcher pid" >&2; exit 2 ;; esac
     [ "$#" -eq 4 ] || { echo "watcher: unexpected handling delivery arguments" >&2; exit 2; }
     ;;
-  *) echo "usage: $(basename "$0") [--restart | --handling-delivered GENERATION --watcher-pid PID]" >&2; exit 2 ;;
+  *) echo "usage: $(basename -- "$0") [--restart | --handling-delivered GENERATION --watcher-pid PID]" >&2; exit 2 ;;
 esac
 
 if [ "$mode" = handling-delivered ]; then

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -73,7 +73,7 @@
 # no-op through the watcher singleton lock.
 set -u
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
@@ -1011,7 +1011,7 @@ while :; do
     for c in "$STATE"/*.check.sh; do
       [ -e "$c" ] || continue
       is_pr_poll=0
-      if [ "$(basename "$c")" = x-watch.check.sh ]; then
+      if [ "$(basename -- "$c")" = x-watch.check.sh ]; then
         if fmx_poll_shim_valid "$c" "$FM_HOME" "$FM_ROOT" \
           && [ -f "$FM_ROOT/bin/fm-x-poll.sh" ] && [ ! -L "$FM_ROOT/bin/fm-x-poll.sh" ]; then
           FM_HOME="$FM_HOME" run_check_capture "$FM_ROOT/bin/fm-x-poll.sh" || exit 1
@@ -1021,7 +1021,7 @@ while :; do
           continue
         fi
       else
-        id=$(basename "$c" .check.sh)
+        id=$(basename -- "$c" .check.sh)
         if fm_pr_poll_snapshot_capture "$STATE" "$id" "$SCRIPT_DIR/fm-pr-poll.sh"; then
           is_pr_poll=1
           provider=$FM_PR_POLL_SNAPSHOT_PROVIDER
@@ -1101,7 +1101,7 @@ EOF
     if afk_present || signal_reason_is_actionable $files || ! signal_crew_provably_working $files; then
       while IFS=$(printf '\t') read -r sf sig f; do
         [ -n "$sf" ] || continue
-        fm_wake_append signal "$(basename "$f")" "$reason" || exit 1
+        fm_wake_append signal "$(basename -- "$f")" "$reason" || exit 1
       done <<EOF
 $pending
 EOF

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -74,7 +74,7 @@
 set -u
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd -- "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 mkdir -p "$STATE"

--- a/tests/fm-claude-stop-autoarm.test.sh
+++ b/tests/fm-claude-stop-autoarm.test.sh
@@ -786,6 +786,98 @@ test_fm_lock_status_still_works_with_shared_lib() {
   pass "fm-lock: shared session-lock lib preserves the status path"
 }
 
+# A login shell carries its own executable PATH as argv[0] with a leading dash
+# ("-/bin/zsh" under macOS `login`, "-/bin/bash" here), and that string reaches
+# every ancestry-walking path tool as an ordinary argument. BSD basename and
+# dirname parse a leading dash as an option bundle and reject it, so an
+# unguarded call printed a diagnostic ahead of every hook message the primary
+# session saw. These run the real hook and the real lock acquisition beneath
+# such an ancestor and require both a working outcome and a silent one.
+
+# Build a two-stage shim: stage 1 re-execs itself with a login-shell-shaped
+# argv[0], stage 2 runs $1 beneath the fake harness holding the fixture lock.
+write_login_shell_shim() {
+  local shim=$1
+  cat > "$shim" <<'SH'
+#!/usr/bin/env bash
+set -u
+if [ "${FM_LOGIN_SHELL_STAGE:-0}" = 0 ]; then
+  FM_LOGIN_SHELL_STAGE=1 exec -a "-$BASH" "$BASH" "$0" "$@"
+fi
+# Record what this platform's ps actually exposes, so the test can prove the
+# dash-prefixed path really reached the walk instead of passing vacuously.
+LC_ALL=C ps -o comm= -p $$ > "$FM_HOME/state/ancestor-comm" 2>/dev/null
+LC_ALL=C ps -o args= -p $$ > "$FM_HOME/state/ancestor-args" 2>/dev/null
+# No exec below: this process must SURVIVE as the dash-named ancestor, and the
+# harness must be its own pid, or the whole chain collapses into a single
+# process and the ancestry walk never sees a login shell at all.
+# The trailing `exit` on each level defeats bash's last-command exec
+# optimization, which would otherwise replace this shell (and the harness
+# shell) in place and collapse the whole chain into one pid with no login
+# shell left to walk past.
+"$FAKE_CLAUDE" -c '
+  printf "%s\n" "$$" > "$FM_HOME/state/.lock"
+  "$@"
+  exit $?
+' fm-login-shell-shim "$@"
+exit $?
+SH
+  chmod +x "$shim"
+}
+
+# 0 when either ps field recorded by the shim carries the dash-prefixed path.
+# macOS ps reports argv[0] in comm=; procps reports the kernel exec name there
+# and exposes argv[0] only through args=, so either field satisfies this.
+assert_login_shell_argv0_reached_walk() {
+  local dir=$1 comm args
+  comm=$(cat "$dir/state/ancestor-comm" 2>/dev/null || true)
+  args=$(cat "$dir/state/ancestor-args" 2>/dev/null || true)
+  case "$comm$args" in
+    *-/*) return 0 ;;
+  esac
+  fail "no ps field carried the login-shell argv[0]; comm='$comm' args='$args'"
+}
+
+assert_no_path_tool_diagnostic() {
+  local out=$1 what=$2
+  case "$out" in
+    *"illegal option"*|*"basename:"*|*"dirname:"*|*"usage: basename"*|*"usage: dirname"*)
+      fail "$what printed a path-tool diagnostic: $out"
+      ;;
+  esac
+}
+
+test_rewake_is_clean_under_login_shell_ancestor() {
+  local dir shim out status
+  dir=$(make_primary_dir "$TMP_ROOT/login-shell-rewake")
+  : > "$dir/state/task.meta"
+  write_arm_fixture "$dir" actionable
+  shim="$TMP_ROOT/login-shell-rewake-shim.sh"
+  write_login_shell_shim "$shim"
+  status=0
+  out=$(printf '%s\n' '{"session_id":"sess-login-shell","stop_hook_active":false}' \
+    | FM_HOME="$dir" "$shim" "$dir/bin/fm-claude-stop-autoarm.sh" 2>&1) || status=$?
+  assert_login_shell_argv0_reached_walk "$dir"
+  assert_no_path_tool_diagnostic "$out" "the Stop-owned auto-arm"
+  expect_code 2 "$status" "an actionable close must still rewake beneath a login-shell ancestor"
+  assert_contains "$out" "firstmate watcher wake" "the rewake banner must still be delivered"
+  pass "auto-arm: rewake beneath a login-shell ancestor carries no path-tool diagnostic"
+}
+
+test_lock_acquire_is_clean_under_login_shell_ancestor() {
+  local dir shim out status
+  dir=$(make_primary_dir "$TMP_ROOT/login-shell-lock")
+  shim="$TMP_ROOT/login-shell-lock-shim.sh"
+  write_login_shell_shim "$shim"
+  status=0
+  out=$(FM_HOME="$dir" "$shim" "$ROOT/bin/fm-lock.sh" 2>&1) || status=$?
+  assert_login_shell_argv0_reached_walk "$dir"
+  assert_no_path_tool_diagnostic "$out" "session-lock acquisition"
+  expect_code 0 "$status" "lock acquisition must succeed beneath a login-shell ancestor"
+  assert_contains "$out" "lock acquired: harness pid" "the lock must still report its harness pid"
+  pass "fm-lock: acquisition beneath a login-shell ancestor carries no path-tool diagnostic"
+}
+
 test_inert_in_child_worktree
 test_inert_without_session_lock
 test_reclaims_stale_session_lock_before_arming
@@ -815,3 +907,5 @@ test_need_vanished_mid_cycle_closes_quietly
 test_afk_mid_cycle_suppresses_rewake
 test_active_in_marked_secondmate_home
 test_fm_lock_status_still_works_with_shared_lib
+test_rewake_is_clean_under_login_shell_ancestor
+test_lock_acquire_is_clean_under_login_shell_ancestor

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -220,6 +220,32 @@ test_lock_single_winner_under_concurrency() {
   pass "concurrent fm_lock_try_acquire yields exactly one winner"
 }
 
+# BSD readlink parses a leading dash as an option bundle, so a lock path whose
+# first character is a dash is unreadable unless the call passes `--` first.
+# Measured on macOS 26.4.1 (build 25E253): `readlink "-weird"` fails with
+# `readlink: illegal option -- w` while `readlink -- "-weird"` prints the target.
+# The lock helpers resolve their owner link through readlink, so this pins the
+# guard that keeps a dash-prefixed lock path readable rather than silently
+# unresolvable. Drop the `--` from fm_lock_link_owner or fm_lock_points_to_owner
+# and this fails, because the helper reports the link as unreadable.
+test_lock_helpers_resolve_dash_prefixed_lock_path() {
+  local dir state out
+  dir=$(make_case lock-dash-link)
+  state="$dir/state"
+  out=$(cd "$state" && FM_STATE_OVERRIDE="$state" bash -c '
+    . "$1"
+    mkdir -p -- owner.d
+    ln -s -- "$PWD/owner.d" "-dash.lock"
+    resolved=$(fm_lock_link_owner "-dash.lock") || { printf "unreadable\n"; exit 1; }
+    [ "$resolved" = "$PWD/owner.d" ] || { printf "wrong-owner:%s\n" "$resolved"; exit 1; }
+    fm_lock_points_to_owner "-dash.lock" "$PWD/owner.d" || { printf "mismatch\n"; exit 1; }
+    printf "ok\n"
+  ' _ "$LIB" 2>&1)
+  [ "$out" = ok ] \
+    || fail "a dash-prefixed lock link must resolve through the lock helpers, got: $out"
+  pass "lock helpers resolve a dash-prefixed lock path through readlink"
+}
+
 test_lock_steals_dead_pid_lock() {
   local dir state lockdir dead rc newpid
   dir=$(make_case lock-dead-steal)
@@ -1107,6 +1133,7 @@ test_stale_watch_reclaim_publishes_before_clear
 test_live_stale_watch_lock_is_actionable
 test_guard_warnings
 test_lock_single_winner_under_concurrency
+test_lock_helpers_resolve_dash_prefixed_lock_path
 test_lock_steals_dead_pid_lock
 test_lock_stale_steal_single_winner_under_concurrency
 test_lock_live_steal_mutex_is_not_reclaimed

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -220,30 +220,42 @@ test_lock_single_winner_under_concurrency() {
   pass "concurrent fm_lock_try_acquire yields exactly one winner"
 }
 
-# BSD readlink parses a leading dash as an option bundle, so a lock path whose
-# first character is a dash is unreadable unless the call passes `--` first.
-# Measured on macOS 26.4.1 (build 25E253): `readlink "-weird"` fails with
-# `readlink: illegal option -- w` while `readlink -- "-weird"` prints the target.
-# The lock helpers resolve their owner link through readlink, so this pins the
-# guard that keeps a dash-prefixed lock path readable rather than silently
-# unresolvable. Drop the `--` from fm_lock_link_owner or fm_lock_points_to_owner
-# and this fails, because the helper reports the link as unreadable.
-test_lock_helpers_resolve_dash_prefixed_lock_path() {
+# The owner-link helpers resolve a lock symlink through readlink, which is
+# deliberately called WITHOUT a `--` separator: every lock path is built under
+# the home's state directory from FM_HOME and is absolute, so a dash-prefixed
+# lock path is outside the contract these helpers accept and is not pinned here.
+# What is in contract is the ordinary absolute owner link, which nothing else
+# exercises directly: an acquired lock must report the owner directory it points
+# at, agree only with that directory, and stop resolving once released.
+test_lock_helpers_resolve_owner_link_for_absolute_lock_path() {
   local dir state out
-  dir=$(make_case lock-dash-link)
+  dir=$(make_case lock-owner-link)
   state="$dir/state"
-  out=$(cd "$state" && FM_STATE_OVERRIDE="$state" bash -c '
+  out=$(FM_STATE_OVERRIDE="$state" bash -c '
     . "$1"
-    mkdir -p -- owner.d
-    ln -s -- "$PWD/owner.d" "-dash.lock"
-    resolved=$(fm_lock_link_owner "-dash.lock") || { printf "unreadable\n"; exit 1; }
-    [ "$resolved" = "$PWD/owner.d" ] || { printf "wrong-owner:%s\n" "$resolved"; exit 1; }
-    fm_lock_points_to_owner "-dash.lock" "$PWD/owner.d" || { printf "mismatch\n"; exit 1; }
+    lockdir="$2/.owner-link.lock"
+    fm_lock_try_acquire "$lockdir" || { printf "acquire-failed\n"; exit 1; }
+    owner=$(fm_lock_link_owner "$lockdir") || { printf "unreadable\n"; exit 1; }
+    case "$owner" in
+      /*) ;;
+      *) printf "not-absolute:%s\n" "$owner"; exit 1 ;;
+    esac
+    [ -d "$owner" ] || { printf "owner-missing:%s\n" "$owner"; exit 1; }
+    fm_lock_points_to_owner "$lockdir" "$owner" || { printf "mismatch\n"; exit 1; }
+    if fm_lock_points_to_owner "$lockdir" "$owner.other"; then
+      printf "false-match\n"
+      exit 1
+    fi
+    fm_lock_release "$lockdir"
+    if fm_lock_link_owner "$lockdir" >/dev/null 2>&1; then
+      printf "still-linked\n"
+      exit 1
+    fi
     printf "ok\n"
-  ' _ "$LIB" 2>&1)
+  ' _ "$LIB" "$state" 2>&1)
   [ "$out" = ok ] \
-    || fail "a dash-prefixed lock link must resolve through the lock helpers, got: $out"
-  pass "lock helpers resolve a dash-prefixed lock path through readlink"
+    || fail "an absolute lock path must resolve, match only its own owner, and clear on release, got: $out"
+  pass "lock helpers resolve and clear an absolute lock path's owner link"
 }
 
 test_lock_steals_dead_pid_lock() {
@@ -1133,7 +1145,7 @@ test_stale_watch_reclaim_publishes_before_clear
 test_live_stale_watch_lock_is_actionable
 test_guard_warnings
 test_lock_single_winner_under_concurrency
-test_lock_helpers_resolve_dash_prefixed_lock_path
+test_lock_helpers_resolve_owner_link_for_absolute_lock_path
 test_lock_steals_dead_pid_lock
 test_lock_stale_steal_single_winner_under_concurrency
 test_lock_live_steal_mutex_is_not_reclaimed


### PR DESCRIPTION
## Intent

Fix the `basename: illegal option -- /` noise prefixing Claude Stop-hook messages in the firstmate repo.

Reported symptom: every Stop-hook wake/error message the primary session saw was prefixed with `basename: illegal option -- /` plus BSD basename usage text. Wakes still delivered (cosmetic), but it polluted every Stop-hook message. The task was to find the actual call site by reading the Stop-hook chain (candidates named: bin/fm-turnend-guard.sh, bin/fm-claude-stop-autoarm.sh, bin/fm-watch-arm.sh, or a library they source) rather than guessing, and to reproduce the message shape on macOS BSD userland before and after.

Accepted requirements: fix the offending call robustly (`basename -- "$arg"` or a safe parameter-expansion substitute); fix sibling call sites with the same defect class in the touched chain in the same pass; demonstrate before/after that the reproduced BSD-basename error is gone from the Stop-hook message path while wakes still deliver; keep shellcheck clean on touched scripts; update or add colocated tests where the repo's existing test layout covers the touched files. The repo's own contributor rules apply (firstmate-coding-guidelines): one sentence per line in tracked prose, plain dash rather than em dash, shellcheck-clean bin scripts via bin/fm-lint.sh, colocated tests named `<subject>.test.sh` extending an existing script rather than a new runner, tests exercising behavior through an executable interface and never asserting implementation-source bytes, and no agent name as a commit co-author.

What the investigation established, which a reviewer reading only the diff would not know:

The offending call was `basename "$comm"` in the harness ancestry walk in bin/fm-session-lock-lib.sh. A login shell reports argv[0] as its own executable path with a leading dash - on macOS `login` that is literally `-/bin/zsh`, confirmed live with `ps -o comm=` on the primary session's shell ancestor - and BSD basename parses a leading dash as an option bundle, producing exactly `basename: illegal option -- /` plus its usage. It surfaced in the two places that merge that stderr into operator-visible output: the Stop-owned auto-arm's stderr (which Claude Code renders as "Stop hook blocking error") and the session-start LOCK section, which runs `fm-lock.sh 2>&1`. bin/fm-turnend-guard.sh never showed it, because it is the one script in the chain that does not source that lib - which is what pinned the location.

That specific call already takes `--` at HEAD; commit 6ec5e08 (2026-07-29) fixed it. Evidence gathered that the symptom is no longer live: the current primary session's LOCK section reads `lock acquired: harness pid 7930` with no diagnostic and all of its Stop-hook messages are clean, while every polluted message still visible in that home's history uses auto-arm banner wording that was removed from bin/ on 2026-08-01, i.e. it is pre-update scrollback in a long-running session. The guard, auto-arm (run end-to-end beneath a synthetic dash-prefixed-argv0 ancestor), arm wrapper, watcher, wake drain and lock acquisition were each exercised at HEAD against an instrumented basename/dirname shim and none produced the message.

Deliberate decisions made, so they are not read as accidents:

1. The remaining path-tool calls in that same chain carried the same latent defect, so they were hardened in this pass as the requirement asks: `--` separators for every basename, dirname, readlink and cd in bin/fm-turnend-guard.sh, bin/fm-claude-stop-autoarm.sh, bin/fm-watch-arm.sh, bin/fm-watch.sh, bin/fm-lock.sh and bin/fm-wake-lib.sh. Those arguments are absolute paths today, so the change is behavior-preserving hardening of the defect class, not a live bug fix. bin/fm-session-lock-lib.sh is deliberately unmodified: its call is already correct.
2. Scope was deliberately limited to the Stop-hook chain rather than the roughly 99 unprotected basename calls elsewhere in bin/, because the requirement is "sibling call sites in the touched chain".
3. Two regressions were added to the existing tests/fm-claude-stop-autoarm.test.sh rather than a new test script, per the repo's colocation rule. They run the real hook and the real lock acquisition beneath a live process whose argv[0] is a dash-prefixed path, built with `exec -a`. The shim deliberately avoids `exec` after that first re-exec and ends each level with `exit $?`, because bash's last-command exec optimization would otherwise collapse the whole chain into one pid and leave no login shell for the ancestry walk to pass. The test records what `ps -o comm=` and `ps -o args=` actually expose on the running platform and accepts either field, because macOS ps reports argv[0] in comm= while procps reports the kernel exec name there and exposes argv[0] only through args=; it asserts that one of them really carried the dash-prefixed path, so the case cannot pass vacuously.
4. Verification performed: with the original defect restored in bin/fm-session-lock-lib.sh the new test fails with `not ok - the Stop-owned auto-arm printed a path-tool diagnostic: basename: illegal option -- /`, reproducing the reported message exactly; at HEAD it passes with the hook still exiting 2 and the wake banner intact, stable across three consecutive suite runs. bin/fm-lint.sh exits 0.
5. Three other suites - fm-turnend-guard, fm-watcher-lock and fm-wake-queue - fail in this sandbox, and they fail identically on a pristine HEAD worktree with none of these changes applied, so they are pre-existing and unrelated to this work.

Follow-up round, answering the upstream review on PR 2727 (2026-08-21):

6. The review raised two points. The first claimed `readlink --` is not portable to macOS BSD readlink and that the `--` should be removed. That premise does not reproduce: measured on macOS 26.4.1 build 25E253, `readlink "-weird"` fails with `readlink: illegal option -- w` while `readlink -- "-weird"` prints the target, so on this platform `--` is required to read a dash-prefixed link rather than being unsupported. bin/fm-cursor-lib.sh on main already ships `readlink -- ` today, so the repo already depends on this. The `readlink --` calls are therefore deliberately unchanged, and the evidence is being posted to the PR for the maintainer to decide, since only one macOS version was measured.
7. The review's second point is correct and is what this round fixes: the regressions that shipped exercised only the basename ancestry walk under `exec -a`, so both readlink guards in bin/fm-wake-lib.sh were unpinned. One regression is added to tests/fm-watcher-lock.test.sh, which that suite's own header designates as the owner of watcher and lock-primitive behavior. It drives the lock helpers' own interface in the established style of the surrounding lock tests: a lock link whose path begins with a dash must resolve to its owner directory through fm_lock_link_owner and compare equal through fm_lock_points_to_owner. Verified non-vacuous by removing `--` from each helper independently - fm_lock_link_owner alone fails the test with "unreadable" and fm_lock_points_to_owner alone fails it with "mismatch". The measured readlink evidence is recorded in the test's comment so the guard cannot be removed quietly later. bin/fm-lint.sh exits 0.
8. Deliberately out of scope this round: while constructing the test it became visible that `mkdir -p "$STATE"` in bin/fm-lock.sh and bin/fm-wake-lib.sh, and `rm -f "$lockdir"` in the lock helpers, carry the same missing-separator class for a dash-prefixed relative state directory. Those were left unchanged because the accepted criterion for this branch names basename, dirname, readlink and cd, and widening it again mid-review would churn the diff the maintainer is already reviewing.

Second follow-up round, conceding the maintainer's re-review of PR 2727 (2026-08-21):

9. The maintainer re-reviewed head 72ddcf67 and held again on a different and better argument: production lock paths are absolute today, so `--` is not required for the original basename defect, and adding it to readlink is a regression risk on any BSD readlink that rejects `--`. They acknowledged the macOS 26.4.1 measurement and the existing `readlink --` on main and said neither closes the hold, because the question moved from portability to necessity. That argument holds: lock paths are built under `state/` from FM_HOME and are absolute in practice, so no lock path arrives dash-prefixed through any real call path, and the lock helpers were never part of the reported bug.
10. Accordingly the three `readlink --` calls in bin/fm-wake-lib.sh (fm_lock_link_owner, fm_lock_points_to_owner, fm_lock_remove_stray_owner_link) are reverted to plain `readlink`, byte-identical to main. Every `basename --`, `dirname --` and `cd --` separator is deliberately KEPT: those are the actual reported defect and no reviewer has questioned them. No portable readlink wrapper is added; the maintainer offered that and the smaller change is to not need one.
11. The tests/fm-watcher-lock.test.sh regression is re-aimed rather than deleted or left pinning a separator that no longer exists. Deleting it would leave fm_lock_link_owner and fm_lock_points_to_owner with no direct coverage at all, since nothing else in tests/ drives them. It now pins what is in contract for an absolute lock path: the acquired lock resolves to its owner directory, the resolved path is absolute and exists, fm_lock_points_to_owner agrees with that directory and rejects a different one, and the link stops resolving after release. The comment records that the dash-prefixed case is deliberately out of contract now that `--` is gone. Verified non-vacuous against three independent mutations: an unreadable link fails with "unreadable", an always-agreeing comparison fails with "false-match", and a release that leaves the link fails with "still-linked". bin/fm-lint.sh exits 0.
12. Re-run on updated tooling: the previous round's "PR must be raised via no-mistakes" failure was an installed-tooling version issue, not a defect in this diff. That check requires no-mistakes >= 1.46.0 for the structured pipeline step attestation HTML comment in the PR body, and the earlier runs used v1.41.2, which emits only the signature line. The fleet operator has since updated the shared install to v1.53.0, and this run exists to republish the PR body with that attestation so the check can pass. No code change accompanies it; the branch content is unchanged from the conceded state described above.

## What Changed

- Hardened Stop-hook, watcher, lock, and wake path handling by passing option separators to `basename`, `dirname`, and `cd` calls.
- Documented why lock helper `readlink` calls retain their existing absolute-path contract.
- Added regressions for clean Stop-hook and lock behavior beneath a dash-prefixed login-shell ancestor, plus lock owner-link lifecycle coverage.

## Risk Assessment

✅ Low: The changes consistently protect the Stop-hook chain’s basename, dirname, and cd path operands with `--`, preserve the existing session-lock fix, and add behavior-level regressions for the reported dash-prefixed ancestry case and lock-owner contract.

## Testing

The focused Stop-hook suite passed, including end-to-end dash-prefixed login-shell ancestry checks that preserve the Claude wake banner while emitting no path-tool noise; a BSD `basename` invocation reproduced the reported error shape, and direct lock-owner lifecycle evidence passed. The watcher-lock suite remains blocked by an unchanged, pre-existing X-mode guard-copy assertion before it reaches the newly added owner-link regression.

<details>
<summary>Evidence: BSD reproduction and clean Stop-hook/lock behavior</summary>

Source: [BSD reproduction and clean Stop-hook/lock behavior](https://github.com/gizm0duck/firstmate/blob/284b3d5afe1526bd685ff1eed3f9c142c9a6912a/.no-mistakes/evidence/fm/fm-stop-hook-basename-error/stop-hook-basename-e2e.txt)

<code>BSD basename reproduction (the reported unsafe argument):&#10;/usr/bin/basename: illegal option -- /&#10;usage: basename string [suffix]&#10;basename [-a] [-s suffix] string [...]&#10;&#10;Current lock-owner helper behavior:&#10;owner=/Users/shanewolf/.no-mistakes/evidence/01M0KGZZ8WM6XQ482WK36J6WSM/fm-lock-owner-evidence.fRirsc/state/.owner-link.lock.owner.ip0N0p&#10;owner-link-cleared=yes&#10;&#10;Live dash-prefixed Stop-hook ancestry regression:&#10;ok - auto-arm: rewake beneath a login-shell ancestor carries no path-tool diagnostic&#10;ok - fm-lock: acquisition beneath a login-shell ancestor carries no path-tool diagnostic</code>

```text
BSD basename reproduction (the reported unsafe argument):
/usr/bin/basename: illegal option -- /
usage: basename string [suffix]
       basename [-a] [-s suffix] string [...]

Current lock-owner helper behavior:
owner=/Users/shanewolf/.no-mistakes/evidence/01M0KGZZ8WM6XQ482WK36J6WSM/fm-lock-owner-evidence.fRirsc/state/.owner-link.lock.owner.ip0N0p
owner-link-cleared=yes

Live dash-prefixed Stop-hook ancestry regression:
ok - auto-arm: rewake beneath a login-shell ancestor carries no path-tool diagnostic
ok - fm-lock: acquisition beneath a login-shell ancestor carries no path-tool diagnostic
```
</details>
<details>
<summary>Evidence: Focused Claude Stop-hook behavioral test log</summary>

Source: [Focused Claude Stop-hook behavioral test log](https://github.com/gizm0duck/firstmate/blob/284b3d5afe1526bd685ff1eed3f9c142c9a6912a/.no-mistakes/evidence/fm/fm-stop-hook-basename-error/fm-claude-stop-autoarm.test.log)

```text
ok - auto-arm: inert in a linked child worktree even when in-flight
ok - auto-arm: inert with no session lock
ok - auto-arm: a demonstrably dead recorded session owner is reclaimed through fm-lock.sh before arming
ok - auto-arm: inert without arm, rewake, or lock replacement when another live harness owns the home
ok - auto-arm: inert while AFK owns supervision
ok - auto-arm: stale-owner recovery leaves the AFK and supervision-need gates unchanged
ok - auto-arm: resolves the outermost pid of a nested contiguous claude ancestry (bg-spare chain)
ok - auto-arm: inert with nothing in flight and no X-mode need
ok - auto-arm: actionable close translates to exactly one exit-2 rewake with reason
ok - auto-arm: actionable close survives a healthy successor without duplicate delivery
ok - auto-arm: bounded failure verification emits one automatic-mechanism alarm
ok - auto-arm: consecutive failures keep Stop-owned retry without repeating notice
ok - auto-arm: unverified clean close exhausts retries and fails closed
ok - auto-arm: post-alarm actionable outcomes cannot continue or reset failure state
ok - auto-arm: benign cycle end with a live watcher and fresh beacon stays silent across the next cycle
ok - auto-arm: budget contention preserves the episode and forces a reset retry
ok - auto-arm: X-mode poll need arms the cycle even with no tasks in flight
ok - auto-arm: concurrent firings admit one owner and one rewake translation
ok - auto-arm: an abandoned owner claim is reclaimed so a lapsed cycle re-arms
ok - auto-arm: an owner still arming is never reclaimed, however long the cycle runs
ok - auto-arm: a live claim the ledger does not name is never reclaimed
ok - auto-arm: a claim whose pid was reused is reclaimed even while its ledger entry still reads arming
ok - auto-arm: a reused-pid claim is reclaimed even with no ledger entry to prove it
ok - auto-arm: an identity-matched owner still arming is never reclaimed
ok - auto-arm: the guard's terminal-check claim is never reclaimed
ok - auto-arm: need vanishing mid-cycle closes without a rewake
ok - auto-arm: mid-cycle AFK hands triage to the daemon with no rewake
ok - auto-arm: active in a marked secondmate home
ok - fm-lock: shared session-lock lib preserves the status path
ok - auto-arm: rewake beneath a login-shell ancestor carries no path-tool diagnostic
ok - fm-lock: acquisition beneath a login-shell ancestor carries no path-tool diagnostic
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (2m41s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"9be08967b0887d20424d65eed094b70622f1e792","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `tests/fm-watcher-lock.test.sh:168` - `tests/fm-watcher-lock.test.sh` stops at its existing X-mode guard-copy assertion (`guard repair line did not source the X-mode cadence config`) before the newly added owner-link case. Neither `bin/fm-guard.sh` nor that assertion changed in this diff, so this is outside the Stop-hook hardening change.
- `bash tests/fm-claude-stop-autoarm.test.sh`
- <code>`bash tests/fm-watcher-lock.test.sh` (stopped at pre-existing X-mode guard-copy assertion before the newly added owner-link case)</code>
- <code>`/usr/bin/basename &#39;-/bin/zsh&#39;` plus direct `fm_lock_try_acquire` / `fm_lock_link_owner` / `fm_lock_points_to_owner` / `fm_lock_release` lifecycle check</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
