### PR TITLE
feat: stage Grokbots Discord rooms through Relay

### DIFF
--- a/.agents/skills/fmx-respond/SKILL.md
+++ b/.agents/skills/fmx-respond/SKILL.md
@@ -142,6 +142,12 @@ Treat `state/x-inbox/` as the source of truth and process **every** file you fin
       `in_reply_to_chain` is the optional surrounding-conversation transcript; [the Relay configuration reference](../../../docs/configuration.md#relay-env) owns its exact wire shape and compatibility semantics.
       Read every entry in its documented oldest-first order, including `history` entries and unavailable gaps, but treat the chain as optional context because it is often absent today: use it when present and proceed normally without it.
       Ignore `tweet_id` entirely - you never name a platform message id; the relay binds the reply for you.
+      When a Discord mention uses the explicit Grokbots room grammar, resolve it with `bin/fm-discord-rooms.sh route state/x-inbox/<request_id>.json` before classification.
+      The [Grokbots Discord rooms guide](../../../docs/discord-grokbots-rooms.md) owns the room purposes and activation boundary, while the helper's `--help` owns the address grammar.
+      Treat the returned body as the request and the returned seat as its recipient.
+      Deliver it through the active Grokbot runtime's existing message-to-seat action, never by spawning, cloning, or substituting a seat.
+      A mailbox is only a notice or question surface; if its body becomes job work, move that work into the single matching `#projects` job thread rather than making the mailbox its job home.
+      If this runtime has no live message-to-Grokbot action, reply truthfully that seat delivery is unavailable and preserve `UNKNOWN_LIVE_MESSAGE_TO_GROKBOT_SURFACE`; never start Rakazo or synthesize the named seat's answer.
    b. **Classify the mention into one of three cases** (see "A request to act on: acknowledge first, act, then follow up on completion"):
       - **Actionable instruction / request** ("add this to the backlog", "look into X", "fix Y", "ship Z") - go to step 2c and do the work first.
       - **Question** - nothing to do; skip step 2c and answer from live fleet state in step 2d.

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Firstmate's skills live in two separate places with different audiences:
 
 - [docs/architecture.md](docs/architecture.md) - maintainer architecture for the crew, supervision, worktrees, secondmates, and project modes.
 - [docs/configuration.md](docs/configuration.md) - environment variables, `FM_HOME`, runtime backend selection, optional Relay and its X and Discord setup steps, the files you set, and harness support.
+- [docs/discord-grokbots-rooms.md](docs/discord-grokbots-rooms.md) - owner-gated room plan, least-privilege activation, addressing, and live wake-measurement procedure for the eight existing Grokbots seats.
 - [docs/remote-secondmates.md](docs/remote-secondmates.md) - current setup, routing, transfer, recovery, and safety behavior for whole-home remote second mates.
 - [docs/calm.md](docs/calm.md) - current Pi `/calm` behavior and supported presentation limits.
 - [docs/wedge-alarm.md](docs/wedge-alarm.md) - configure the active alert for an away-mode escalation delivery that gets stuck.

--- a/bin/fm-discord-rooms.sh
+++ b/bin/fm-discord-rooms.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# Deterministic addressing and latency-receipt validation for the Grokbots
+# Discord room layer carried by the existing myfirstmate Relay.
+#
+# This script is deliberately not a Discord connector.
+# It performs no network access, reads no credential, creates no Discord room,
+# and does not deliver a message to a seat.
+# The Relay remains the only Discord ingress and reply path.
+# The active Grokbot runtime remains the owner of message-to-seat delivery.
+#
+# Usage:
+#   fm-discord-rooms.sh route <relay-mention.json|->
+#       Validate a Discord Relay mention and resolve its explicit room address.
+#       The mention text, after an optional leading Discord bot mention, must be
+#       one of:
+#         fleet: <message>
+#         continuum-guest: <message>
+#         mailbox/<seat-slug>: <message>
+#         job/<job-slug>/<seat-slug>: <message>
+#       Output is one JSON object with room_kind, seat, seat_slug, job_id, body,
+#       and request_id.
+#       fleet routes to Eleusis, the roster desk; continuum-guest routes to
+#       Flux; mailbox and job addresses route to the named existing seat.
+#
+#   fm-discord-rooms.sh latency <receipt.json|->
+#       Validate one eight-seat probe receipt and calculate its two event legs:
+#       Discord event -> Relay offer, then Relay offer -> seat seen.
+#       The input owns no credentials and has this public-safe shape:
+#         {"probe_id":"...","seats":[
+#           {"seat_slug":"eleusis","discord_event_ms":1,
+#            "relay_offer_ms":2,"seat_seen_ms":3,"proof":"live"}
+#         ]}
+#       Every canonical seat must occur exactly once, times are non-negative
+#       integer epoch milliseconds in order, and proof is live or fixture.
+#       Output is a JSON receipt with calculated leg and total latency values.
+#       A fixture receipt can validate the calculator but never proves a live
+#       Discord or seat wake.
+set -u
+
+usage() {
+  sed -n '2,/^set -u$/p' "$0" | sed '$d; s/^# \{0,1\}//'
+}
+
+die() {
+  printf 'fm-discord-rooms: %s\n' "$1" >&2
+  exit "${2:-2}"
+}
+
+require_jq() {
+  command -v jq >/dev/null 2>&1 || die 'jq is required' 1
+}
+
+read_input() {
+  local source=$1
+  if [ "$source" = '-' ]; then
+    cat
+    return
+  fi
+  [ -f "$source" ] && [ ! -L "$source" ] \
+    || die "input must be a regular non-symlink file: $source"
+  cat -- "$source"
+}
+
+seat_name() {
+  case "$1" in
+    eleusis) printf 'Eleusis\n' ;;
+    flux) printf 'Flux\n' ;;
+    spur) printf 'Spur\n' ;;
+    chronicle) printf 'Chronicle\n' ;;
+    thor) printf 'Thor\n' ;;
+    qa-engineer) printf 'QA Engineer\n' ;;
+    ledger) printf 'Ledger\n' ;;
+    argon) printf 'Argon\n' ;;
+    *) return 1 ;;
+  esac
+}
+
+route() {
+  local source=${1:-}
+  local payload platform text request address room_kind seat_slug seat job_id body
+  [ -n "$source" ] || die 'route requires a relay mention JSON file or -'
+  payload=$(read_input "$source") || exit $?
+  printf '%s' "$payload" | jq -e -s 'length == 1 and (.[0] | type == "object")' >/dev/null 2>&1 \
+    || die 'route input must be one JSON object'
+
+  platform=$(printf '%s' "$payload" | jq -r '
+    def explicit: (.platform // .reply_platform // .target_platform // .source_platform // .provider // "") | ascii_downcase;
+    if explicit != "" then
+      if explicit == "discord" then "discord" else "" end
+    elif ((.tweet_id // "") | startswith("discord:")) then "discord"
+    else ""
+    end') || die 'could not read route input'
+  [ "$platform" = 'discord' ] || die 'route input is not an explicit Discord Relay mention'
+  request=$(printf '%s' "$payload" | jq -r '.request_id // ""') || die 'could not read request_id'
+  case "$request" in
+    ''|.*|*[!A-Za-z0-9._-]*) die 'route input has an unsafe or missing request_id' ;;
+  esac
+  text=$(printf '%s' "$payload" | jq -r '.text // ""') || die 'could not read mention text'
+  [ -n "${text//[[:space:]]/}" ] || die 'route input has no message text'
+
+  # Discord may leave the leading bot mention in text, while relay versions
+  # that normalize mentions may remove it. Addressing is identical either way.
+  address=$text
+  if [[ "$address" =~ ^[[:space:]]*\<@!?[0-9]+\>[[:space:]]*(.*)$ ]]; then
+    address=${BASH_REMATCH[1]}
+  fi
+  address=${address#"${address%%[![:space:]]*}"}
+
+  room_kind=
+  seat_slug=
+  job_id=
+  body=
+  if [[ "$address" =~ ^fleet:[[:space:]]*(.*)$ ]]; then
+    room_kind=fleet
+    seat_slug=eleusis
+    body=${BASH_REMATCH[1]}
+  elif [[ "$address" =~ ^continuum-guest:[[:space:]]*(.*)$ ]]; then
+    room_kind=continuum-guest
+    seat_slug=flux
+    body=${BASH_REMATCH[1]}
+  elif [[ "$address" =~ ^mailbox/([a-z0-9-]+):[[:space:]]*(.*)$ ]]; then
+    room_kind=mailbox
+    seat_slug=${BASH_REMATCH[1]}
+    body=${BASH_REMATCH[2]}
+  elif [[ "$address" =~ ^job/([A-Za-z0-9][A-Za-z0-9._-]{0,63})/([a-z0-9-]+):[[:space:]]*(.*)$ ]]; then
+    room_kind=job
+    job_id=${BASH_REMATCH[1]}
+    seat_slug=${BASH_REMATCH[2]}
+    body=${BASH_REMATCH[3]}
+  else
+    die 'unrecognized address; use fleet, continuum-guest, mailbox/<seat>, or job/<job>/<seat>'
+  fi
+
+  seat=$(seat_name "$seat_slug") || die "unknown seat slug: $seat_slug"
+  [ -n "${body//[[:space:]]/}" ] || die 'addressed message body is empty'
+  jq -cn \
+    --arg room_kind "$room_kind" \
+    --arg seat "$seat" \
+    --arg seat_slug "$seat_slug" \
+    --arg job_id "$job_id" \
+    --arg body "$body" \
+    --arg request_id "$request" \
+    '{room_kind:$room_kind,seat:$seat,seat_slug:$seat_slug,
+      job_id:(if $job_id == "" then null else $job_id end),
+      body:$body,request_id:$request_id}'
+}
+
+latency() {
+  local source=${1:-}
+  local payload
+  [ -n "$source" ] || die 'latency requires a receipt JSON file or -'
+  payload=$(read_input "$source") || exit $?
+  printf '%s' "$payload" | jq -e -s 'length == 1 and (.[0] | type == "object")' >/dev/null 2>&1 \
+    || die 'latency input must be one JSON object'
+
+  printf '%s' "$payload" | jq -e '
+    def expected: ["eleusis","flux","spur","chronicle","thor","qa-engineer","ledger","argon"];
+    def integer_nonnegative: type == "number" and floor == . and . >= 0;
+    (.probe_id | type == "string" and length > 0)
+    and (.seats | type == "array" and length == 8)
+    and (([.seats[].seat_slug] | sort) == (expected | sort))
+    and (all(.seats[];
+      (.seat_slug | type == "string")
+      and (.discord_event_ms | integer_nonnegative)
+      and (.relay_offer_ms | integer_nonnegative)
+      and (.seat_seen_ms | integer_nonnegative)
+      and (.discord_event_ms <= .relay_offer_ms)
+      and (.relay_offer_ms <= .seat_seen_ms)
+      and (.proof == "live" or .proof == "fixture")))
+  ' >/dev/null 2>&1 || die 'invalid latency receipt: require all eight unique seats, ordered integer times, and live|fixture proof'
+
+  printf '%s' "$payload" | jq '
+    def display:
+      {"eleusis":"Eleusis","flux":"Flux","spur":"Spur",
+       "chronicle":"Chronicle","thor":"Thor",
+       "qa-engineer":"QA Engineer","ledger":"Ledger","argon":"Argon"}[.];
+    {
+      probe_id,
+      proof: (if all(.seats[]; .proof == "live") then "live" else "fixture" end),
+      seats: [.seats[] | {
+        seat: (.seat_slug | display),
+        seat_slug,
+        proof,
+        discord_to_relay_ms: (.relay_offer_ms - .discord_event_ms),
+        relay_to_seat_ms: (.seat_seen_ms - .relay_offer_ms),
+        total_ms: (.seat_seen_ms - .discord_event_ms)
+      }]
+    }'
+}
+
+require_jq
+case "${1:-}" in
+  route)
+    shift
+    [ "$#" -eq 1 ] || die 'route requires exactly one relay mention JSON file or -'
+    route "${1:-}"
+    ;;
+  latency)
+    shift
+    [ "$#" -eq 1 ] || die 'latency requires exactly one receipt JSON file or -'
+    latency "${1:-}"
+    ;;
+  -h|--help|help)
+    usage
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -139,6 +139,7 @@ family_for_basename() {
     fm-classify-decision-key.test.sh|\
     fm-composer-ghost.test.sh|fm-composer-lib.test.sh|\
     fm-crew-state.test.sh|fm-decision-hold-lifecycle.test.sh|\
+    fm-discord-rooms.test.sh|\
     fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
     fm-kimi-harness.test.sh|fm-muse-harness.test.sh|fm-herdr-lab.test.sh|fm-lint.test.sh|\
     fm-lint-workflows.test.sh|\
@@ -858,6 +859,10 @@ families_for_changed_path() {
       ;;
     bin/fm-test-run.sh|bin/fm-test-isolation-proof.sh)
       printf '%s\n' pure-contract-unit
+      ;;
+    bin/fm-discord-rooms.sh)
+      printf '%s\n' pure-contract-unit
+      printf '%s\n' pr-forge
       ;;
     bin/backends/herdr*|bin/fm-herdr-lab.sh|tests/herdr-test-safety.sh)
       printf '%s\n' real-herdr-gated

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -355,6 +355,7 @@ To turn it on:
 4. Start a new firstmate session so bootstrap picks the token up, then mention `@myfirstmate` on X or mention the bot in a server where it is installed.
 
 The dashboard owns account creation, identity linking, bot installation, and token issuance; this document owns only what the local firstmate home does with the token once it is in `.env`.
+For the eight-seat Grokbots room layer, follow the [Grokbots Discord rooms guide](discord-grokbots-rooms.md) before any server, room, installation, permission, pairing-token, or live-canary action.
 
 The locked session-start bootstrap step turns the token into local generated state.
 It writes `state/x-watch.check.sh`, a byte-static identity shim for `bin/fm-x-poll.sh`, and `config/x-mode.env`, which exports `FM_CHECK_INTERVAL=30` for watcher processes in that home.

--- a/docs/discord-grokbots-rooms.md
+++ b/docs/discord-grokbots-rooms.md
@@ -1,0 +1,169 @@
+# Grokbots Discord rooms
+
+This guide stages durable Discord rooms for the eight existing Grokbots seats through the official myfirstmate Relay.
+It does not create a ninth seat, a Discord connector, an orchestrator, or a memory authority.
+[`configuration.md`](configuration.md#relay-env) remains the owner of Relay activation and reply mechanics.
+`bin/fm-discord-rooms.sh --help` owns the address and latency-receipt formats.
+
+## Working path
+
+The working path is the existing Relay plus the seat-message action already used by the live Grokbot runtime:
+
+```text
+Jason directly mentions @myfirstmate in a room or job thread
+  -> official myfirstmate Discord service
+  -> existing authenticated Relay poll
+  -> x-mention wake in Firstmate
+  -> deterministic room address
+  -> existing message-to-seat action
+  -> the named existing seat wakes and replies
+  -> existing Relay reply returns to the originating Discord thread
+```
+
+The repository already proves that a Discord Relay object is retained whole, produces an `x-mention` wake once, keeps Discord reply context, and returns bounded replies through the original opaque request binding.
+The active Grokbot operating prompt already defines seat delegation as messaging an existing crewmate, which wakes that seat and returns its result.
+This room layer joins those two owners without replacing either one.
+
+The broken Discord Settings plugin is not part of this path.
+No direct Discord bot token, webhook, Gateway client, Composio connector, Rakazo process, or new polling loop is added.
+
+## Server and room plan
+
+Use the server name `Grokbots Rooms` unless Jason chooses an already-existing private server during activation.
+The name is a plan until the owner activation receipt records the live server.
+
+| Discord surface | Durable purpose | Wake route |
+| --- | --- | --- |
+| `#fleet` | Shared roster, short fleet notes, and routing | `fleet:` wakes Eleusis as the roster desk |
+| `#projects` | One thread per job, matching the Slack `#projects` convention | `job/<job-id>/<seat>:` wakes one explicitly named seat |
+| `#continuum-guest` | Guest door into Continuum conversation | `continuum-guest:` wakes Flux |
+| `#mailbox-eleusis` | Questions and notices for Eleusis | `mailbox/eleusis:` |
+| `#mailbox-flux` | Questions and notices for Flux | `mailbox/flux:` |
+| `#mailbox-spur` | Questions and notices for Spur | `mailbox/spur:` |
+| `#mailbox-chronicle` | Questions and notices for Chronicle | `mailbox/chronicle:` |
+| `#mailbox-thor` | Questions and notices for Thor | `mailbox/thor:` |
+| `#mailbox-qa-engineer` | Questions and notices for QA Engineer | `mailbox/qa-engineer:` |
+| `#mailbox-ledger` | Questions and notices for Ledger | `mailbox/ledger:` |
+| `#mailbox-argon` | Questions and notices for Argon | `mailbox/argon:` |
+
+Every actionable post directly mentions `@myfirstmate` and begins with the route shown above.
+Direct mention is the event trigger.
+An ordinary room message without the mention is durable Discord history but does not wake an agent.
+
+`#fleet` does not automatically fan out to eight seats.
+Eleusis sees the event first and routes only what needs another seat, avoiding eight simultaneous replies and a new roundtable orchestrator.
+`#continuum-guest` does not import Discord into Continuum.
+Continuum stays the source of truth, and Flux is the only guest door.
+
+Mailboxes are not job homes.
+A mailbox can notify a seat, ask a short question, or point at a job thread.
+When work becomes a job, create or use its single thread under `#projects` and continue there.
+The task record, project files, Continuum, and each seat's existing memory retain their current authority.
+
+## One owner activation sitting
+
+All account, server, installation, and credential actions below form one owner gate.
+Jason performs this sitting himself.
+An agent must not sign in, authorize the application, handle the pairing token, or ask Jason to paste a secret into chat.
+
+### Exact click path
+
+1. Open Discord while signed into Jason's intended owner account.
+2. Select an existing private server or click `+` in the server rail, choose `Create My Own`, choose `For me and my friends`, and name it `Grokbots Rooms`.
+3. Open `Server Settings`, then `Roles`, select `@everyone`, and turn off `View Channels` for the private Grokbots category.
+4. Create a category named `GROKBOTS` and create the eleven text channels listed in the room plan inside it.
+5. In `#projects`, use a normal message thread for each job and name the thread with the existing job id.
+6. Open `https://myfirstmate.io`, choose Discord sign-in, and confirm that the account shown is Jason's intended owner account.
+7. Use the authenticated dashboard's Discord install control, choose the `Grokbots Rooms` server, and inspect the authorization screen before approving it.
+8. Approve only the scopes and permissions in the least-privilege list below.
+9. Return to Discord, open the `GROKBOTS` category permissions, add the installed myfirstmate bot role, and allow the listed room permissions only.
+10. Return to the myfirstmate dashboard and copy the pairing token directly into this Firstmate home's gitignored `.env` with a local editor as `FMX_PAIRING_TOKEN=<token>`.
+11. Close the editor without placing the token in chat, shell arguments, terminal output, screenshots, Git, or any task artifact.
+12. Start a new Firstmate session so the existing locked bootstrap can activate the Relay poll.
+13. Hand control back to Firstmate for the eight-seat canary and latency run.
+
+The owner sitting ends after activation.
+The eight canary posts and evidence capture are agent verification, not additional owner authorization gates.
+
+### Least privilege
+
+Accept the `bot` installation scope.
+Accept `applications.commands` only if the official install screen shows that the service uses application commands.
+The baseline server and channel permissions are exactly:
+
+- `View Channels`.
+- `Send Messages`.
+- `Read Message History`.
+- `Send Messages in Threads`.
+
+Refuse `Administrator`, `Manage Server`, `Manage Roles`, `Manage Channels`, member management, moderation, voice administration, and every unexplained permission.
+Do not grant a bot permission merely because Discord offers it.
+If the official screen demands a permission outside the list, stop the sitting and record `UNKNOWN_INSTALL_PERMISSION_<name>` rather than approving it.
+
+The bot does not need `Create Public Threads`, `Attach Files`, or permission to create the category or channels because Jason creates the rooms and job threads and this canary uses text only.
+That is why the design complies with the prohibition on `Manage Channels`.
+
+## Event wake and measurement
+
+For each seat, post one harmless nonce in the matching mailbox:
+
+```text
+@myfirstmate mailbox/<seat-slug>: wake probe <nonce>; reply with the nonce only
+```
+
+Capture three timestamps from the live surfaces:
+
+- `discord_event_ms` from the Discord message event.
+- `relay_offer_ms` when the preserved Relay request first produces the `x-mention` wake.
+- `seat_seen_ms` from the named seat's received-message or run receipt.
+
+Record all eight in one private receipt and run:
+
+```sh
+bin/fm-discord-rooms.sh latency <receipt.json>
+```
+
+The calculator rejects a missing seat, a duplicate seat, backward timestamps, or a proof label other than `live` or `fixture`.
+Any receipt containing fixture evidence remains labeled `fixture`.
+Do not report designed cadence, a test-fixture duration, or one seat's observation as another seat's live latency.
+
+## Test post
+
+After the owner sitting, use this first harmless post in `#mailbox-eleusis`:
+
+```text
+@myfirstmate mailbox/eleusis: DISCORD-GROKBOTS-CANARY-1; reply with this marker only
+```
+
+The proof is the Discord post, the corresponding Relay request, Eleusis's received-message receipt, and the reply in the same Discord thread.
+Do not treat the prepared text above as a live post.
+
+## Named unknowns before activation
+
+Keep these names unchanged in the activation report until live evidence replaces them:
+
+- `UNKNOWN_LIVE_SERVER_NAME_OR_INVITE`.
+- `UNKNOWN_LIVE_ROOM_IDS`.
+- `UNKNOWN_OFFICIAL_INSTALL_SCOPES_AND_PERMISSIONS`.
+- `UNKNOWN_PAIRING_TOKEN_PRESENT`.
+- `UNKNOWN_LIVE_MESSAGE_TO_GROKBOT_SURFACE`.
+- `UNKNOWN_ELEUSIS_DISCORD_WAKE_LATENCY_MS`.
+- `UNKNOWN_FLUX_DISCORD_WAKE_LATENCY_MS`.
+- `UNKNOWN_SPUR_DISCORD_WAKE_LATENCY_MS`.
+- `UNKNOWN_CHRONICLE_DISCORD_WAKE_LATENCY_MS`.
+- `UNKNOWN_THOR_DISCORD_WAKE_LATENCY_MS`.
+- `UNKNOWN_QA_ENGINEER_DISCORD_WAKE_LATENCY_MS`.
+- `UNKNOWN_LEDGER_DISCORD_WAKE_LATENCY_MS`.
+- `UNKNOWN_ARGON_DISCORD_WAKE_LATENCY_MS`.
+- `UNKNOWN_LIVE_TEST_POST_RECEIPT`.
+
+Do not fill an unknown from the guild id recorded for the earlier Rakazo roundtable lane.
+That id is neither a credential nor authority for this room layer.
+
+## Failure boundaries
+
+If Relay does not expose enough live context to return to the originating room or thread, keep the request in Firstmate and report the binding as unavailable.
+Do not guess a channel id.
+If the current Firstmate runtime cannot invoke the existing message-to-Grokbot action, reply that seat delivery is unavailable and retain the named unknown.
+Do not substitute Rakazo, start its ports, create a stand-in seat, or synthesize a seat answer.
+If a seat does not respond to its canary, record that seat's failure independently and continue the other seven probes.

--- a/docs/discord-grokbots-rooms.md
+++ b/docs/discord-grokbots-rooms.md
@@ -7,6 +7,12 @@ It does not create a ninth seat, a Discord connector, an orchestrator, or a memo
 
 ## Working path
 
+The live capability audit on 2026-08-21 found one active Composio Discord user OAuth connection.
+That connection can identify its user and list the user's guilds, but its Discord toolkit has no action for creating a guild, channel, thread, invite, or message.
+The separate Composio Discord Bot toolkit has those actions but has no connected account.
+An authenticated read-only proxy request for the existing guild's channels also returned `401 Unauthorized`, confirming that the user OAuth grant is not a hidden bot-management path.
+Composio therefore remains discovery evidence only and is not a room connector or wake path.
+
 The working path is the existing Relay plus the seat-message action already used by the live Grokbot runtime:
 
 ```text
@@ -29,8 +35,8 @@ No direct Discord bot token, webhook, Gateway client, Composio connector, Rakazo
 
 ## Server and room plan
 
-Use the server name `Grokbots Rooms` unless Jason chooses an already-existing private server during activation.
-The name is a plan until the owner activation receipt records the live server.
+The live user OAuth audit proved that Jason owns an existing server named `Continuum server`.
+Use that server rather than creating another server or memory authority.
 
 | Discord surface | Durable purpose | Wake route |
 | --- | --- | --- |
@@ -68,19 +74,18 @@ An agent must not sign in, authorize the application, handle the pairing token, 
 
 ### Exact click path
 
-1. Open Discord while signed into Jason's intended owner account.
-2. Select an existing private server or click `+` in the server rail, choose `Create My Own`, choose `For me and my friends`, and name it `Grokbots Rooms`.
-3. Open `Server Settings`, then `Roles`, select `@everyone`, and turn off `View Channels` for the private Grokbots category.
-4. Create a category named `GROKBOTS` and create the eleven text channels listed in the room plan inside it.
-5. In `#projects`, use a normal message thread for each job and name the thread with the existing job id.
-6. Open `https://myfirstmate.io`, choose Discord sign-in, and confirm that the account shown is Jason's intended owner account.
-7. Use the authenticated dashboard's Discord install control, choose the `Grokbots Rooms` server, and inspect the authorization screen before approving it.
-8. Approve only the scopes and permissions in the least-privilege list below.
-9. Return to Discord, open the `GROKBOTS` category permissions, add the installed myfirstmate bot role, and allow the listed room permissions only.
-10. Return to the myfirstmate dashboard and copy the pairing token directly into this Firstmate home's gitignored `.env` with a local editor as `FMX_PAIRING_TOKEN=<token>`.
-11. Close the editor without placing the token in chat, shell arguments, terminal output, screenshots, Git, or any task artifact.
-12. Start a new Firstmate session so the existing locked bootstrap can activate the Relay poll.
-13. Hand control back to Firstmate for the eight-seat canary and latency run.
+1. Open Discord while signed into the owner account for `Continuum server`.
+2. Open `Continuum server`, create a category named `GROKBOTS`, and make it private from `@everyone` by disabling `View Channels` on the category.
+3. Create the eleven text channels listed in the room plan inside that category.
+4. In `#projects`, create one normal message thread for each current job and name each thread with its existing job id.
+5. Open `https://myfirstmate.io`, choose Discord sign-in, and confirm that the account shown is the same owner account.
+6. Use the authenticated dashboard's Discord install control, choose `Continuum server`, and inspect the authorization screen before approving it.
+7. Approve only the scopes and permissions in the least-privilege list below.
+8. Return to Discord, open the `GROKBOTS` category permissions, add the installed myfirstmate bot role, and allow the listed room permissions only.
+9. Return to the myfirstmate dashboard and copy the pairing token directly into `/home/jason/kun-agent-workspace/.env` with a local editor as `FMX_PAIRING_TOKEN=<token>`.
+10. Close the editor without placing the token in chat, shell arguments, terminal output, screenshots, Git, or any task artifact.
+11. Start a new Firstmate session so the existing locked bootstrap can activate the Relay poll.
+12. Hand control back to Firstmate for the eight-seat canary and latency run.
 
 The owner sitting ends after activation.
 The eight canary posts and evidence capture are agent verification, not additional owner authorization gates.
@@ -142,7 +147,6 @@ Do not treat the prepared text above as a live post.
 
 Keep these names unchanged in the activation report until live evidence replaces them:
 
-- `UNKNOWN_LIVE_SERVER_NAME_OR_INVITE`.
 - `UNKNOWN_LIVE_ROOM_IDS`.
 - `UNKNOWN_OFFICIAL_INSTALL_SCOPES_AND_PERMISSIONS`.
 - `UNKNOWN_PAIRING_TOKEN_PRESENT`.
@@ -157,8 +161,8 @@ Keep these names unchanged in the activation report until live evidence replaces
 - `UNKNOWN_ARGON_DISCORD_WAKE_LATENCY_MS`.
 - `UNKNOWN_LIVE_TEST_POST_RECEIPT`.
 
-Do not fill an unknown from the guild id recorded for the earlier Rakazo roundtable lane.
-That id is neither a credential nor authority for this room layer.
+The server name is live evidence from the active user OAuth audit, but no invite URL or requested room id is available.
+Do not infer any room or invite from the earlier Rakazo roundtable record.
 
 ## Failure boundaries
 

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -25,6 +25,7 @@
   ],
   "readmeSetupTargets": [
     "docs/configuration.md",
+    "docs/discord-grokbots-rooms.md",
     "docs/wedge-alarm.md",
     "docs/tmux-backend.md",
     "docs/herdr-backend.md",
@@ -249,6 +250,10 @@
       "audience": "maintainer-architecture"
     },
     {
+      "path": "docs/discord-grokbots-rooms.md",
+      "audience": "operator-current"
+    },
+    {
       "path": "docs/documentation-audiences.md",
       "audience": "maintainer-architecture"
     },
@@ -335,6 +340,10 @@
     {
       "path": "docs/turnend-guard.md",
       "audience": "operator-current"
+    },
+    {
+      "path": "docs/verification/discord-grokbots-rooms.md",
+      "audience": "maintainer-verification"
     },
     {
       "path": "docs/verification/dispatch-auth.md",

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -117,6 +117,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-x-dismiss.sh`        | Dismiss a skipped Relay mention at the relay without replying                        |
 | `fm-x-link.sh`           | Link a spawned task to its originating Relay mention in task meta                    |
 | `fm-x-followup.sh`       | Detect, post, and cap completion follow-ups for a Relay-linked task                  |
+| `fm-discord-rooms.sh`    | Resolve explicit Grokbots room addresses and validate complete eight-seat latency receipts without network or credentials |
 | `fm-public-followup-lib.sh` | Shared relay-activation gate, O(1) presence checks, and private transport paths for promised public replies |
 | `fm-public-followup.sh`  | Reconcile typed terminal work results into a public commitment and deliver its final reply once |
 | `fm-public-followup-emit.sh` | Report one typed terminal work result into the home that owes the public reply    |

--- a/docs/verification/discord-grokbots-rooms.md
+++ b/docs/verification/discord-grokbots-rooms.md
@@ -1,0 +1,74 @@
+# Grokbots Discord rooms verification
+
+Date: 2026-08-20.
+
+## Active claim
+
+The existing myfirstmate Relay can carry explicit Discord room addresses without a second Discord connector, and the new local helper resolves only the eight existing Grokbots seats and validates complete eight-seat latency receipts.
+The Discord server, room ids, application installation, live seat-delivery surface, live test post, and live per-seat latency remain owner-gated unknowns until the activation sitting completes.
+
+The operator plan and owner gate are in [`../discord-grokbots-rooms.md`](../discord-grokbots-rooms.md).
+The address and receipt mechanics are owned by `bin/fm-discord-rooms.sh --help`.
+
+## Evidence classes
+
+| Claim | Evidence class | Current result |
+| --- | --- | --- |
+| Relay is inert without a pairing token | Existing hermetic Relay tests | Proven by test |
+| A Discord Relay mention is stored whole and emits one `x-mention` wake | Existing hermetic Relay tests | Proven by test |
+| Discord replies retain the originating opaque request binding and Discord budget | Existing hermetic Relay tests | Proven by test |
+| Room addresses resolve only to Eleusis, Flux, Spur, Chronicle, Thor, QA Engineer, Ledger, or Argon | New hermetic route tests | Proven by test |
+| Fleet routes to Eleusis and Continuum guest routes to Flux | New hermetic route tests | Proven by test |
+| A latency receipt requires all eight seats exactly once and monotonic timestamps | New hermetic receipt tests | Proven by test |
+| Fixture latency cannot be reported as live | New hermetic receipt tests | Proven by test |
+| Discord server and rooms exist | Live Discord credential required | `UNKNOWN_LIVE_SERVER_NAME_OR_INVITE` |
+| Official bot is installed with the permitted scope | Owner authorization required | `UNKNOWN_OFFICIAL_INSTALL_SCOPES_AND_PERMISSIONS` |
+| Each live Grokbot receives the addressed event | Live seat-delivery surface required | `UNKNOWN_LIVE_MESSAGE_TO_GROKBOT_SURFACE` |
+| Per-seat end-to-end latency | Live Discord and seat receipts required | Eight named latency unknowns remain |
+| Canary post and reply landed | Live Discord credential required | `UNKNOWN_LIVE_TEST_POST_RECEIPT` |
+
+## Local seat-delivery evidence
+
+The current Grokbot operating prompt says that Firstmate delegates by messaging an existing crewmate, which wakes, performs the work, and messages Firstmate back.
+That is the current product-level seat delivery action this room layer targets.
+It is not exposed in this Codex worktree, so this change does not claim that a live Discord event reached any seat.
+
+Separate Rakazo evidence proves an analogous `trigger=peer` wake for QA Engineer and a digest-backed response from Ledger.
+Rakazo is paused and is not the Grokbot runtime, so those records are supporting fixture evidence only.
+They are not reused as live Discord or Grokbot latency proof.
+
+## Commands
+
+Run from the isolated Firstmate worktree:
+
+```sh
+bash tests/fm-discord-rooms.test.sh
+bash tests/fm-x-mode.test.sh
+bin/fm-doc-audience-check.sh
+bin/fm-lint.sh
+```
+
+The new suite uses only temporary JSON fixtures and `jq`.
+It makes no network call and reads no credential.
+The existing Relay suite uses fake transport and temporary homes.
+
+## Fixture receipt result
+
+The fixture covers all eight seats with distinct monotonic timestamps.
+The calculator returns both event legs and total latency while preserving `proof: fixture`.
+The rejection cases cover a missing seat, a duplicate seat, backward timestamps, a non-Discord message, an unknown ninth seat, and an empty addressed body.
+
+No fixture number is a live latency measurement.
+
+## Activation report template
+
+After the owner sitting and eight-seat probe, replace the unknowns in the private task report, not in this maintained verification page:
+
+1. Server name or invite URL.
+2. Seats actually reached.
+3. Per-seat Discord-to-Relay, Relay-to-seat, and total latency.
+4. One test post and its reply receipt.
+5. Whether the owner authorization gate existed and which one-sitting path completed it.
+
+Separate `PROVED LIVE` entries from `PROVED BY FIXTURE` entries.
+Never infer a live value from configuration or a designed cadence.

--- a/docs/verification/discord-grokbots-rooms.md
+++ b/docs/verification/discord-grokbots-rooms.md
@@ -1,11 +1,13 @@
 # Grokbots Discord rooms verification
 
-Date: 2026-08-20.
+Date: 2026-08-21.
 
 ## Active claim
 
-The existing myfirstmate Relay can carry explicit Discord room addresses without a second Discord connector, and the new local helper resolves only the eight existing Grokbots seats and validates complete eight-seat latency receipts.
-The Discord server, room ids, application installation, live seat-delivery surface, live test post, and live per-seat latency remain owner-gated unknowns until the activation sitting completes.
+The existing myfirstmate Relay can carry explicit Discord room addresses without a second Discord connector, and the local helper resolves only the eight existing Grokbots seats and validates complete eight-seat latency receipts.
+The live account audit proves that Jason owns an existing Discord server named `Continuum server`.
+The audit resolved the captain-supplied guild id `1539100295932551189` to that server, so the room plan targets it and does not create another guild.
+The requested room ids, application installation, live seat-delivery surface, live test post, and live per-seat latency remain owner-gated unknowns until the activation sitting completes.
 
 The operator plan and owner gate are in [`../discord-grokbots-rooms.md`](../discord-grokbots-rooms.md).
 The address and receipt mechanics are owned by `bin/fm-discord-rooms.sh --help`.
@@ -21,7 +23,9 @@ The address and receipt mechanics are owned by `bin/fm-discord-rooms.sh --help`.
 | Fleet routes to Eleusis and Continuum guest routes to Flux | New hermetic route tests | Proven by test |
 | A latency receipt requires all eight seats exactly once and monotonic timestamps | New hermetic receipt tests | Proven by test |
 | Fixture latency cannot be reported as live | New hermetic receipt tests | Proven by test |
-| Discord server and rooms exist | Live Discord credential required | `UNKNOWN_LIVE_SERVER_NAME_OR_INVITE` |
+| Existing Discord server is available | Live Composio user OAuth audit | `Continuum server` is visible and owner-held |
+| Active user OAuth can create or inspect rooms | Live tool-catalog and read-only proxy audit | Refuted: no mutation tools, and channel proxy returned `401 Unauthorized` |
+| Requested rooms exist | Owner activation required | `UNKNOWN_LIVE_ROOM_IDS` |
 | Official bot is installed with the permitted scope | Owner authorization required | `UNKNOWN_OFFICIAL_INSTALL_SCOPES_AND_PERMISSIONS` |
 | Each live Grokbot receives the addressed event | Live seat-delivery surface required | `UNKNOWN_LIVE_MESSAGE_TO_GROKBOT_SURFACE` |
 | Per-seat end-to-end latency | Live Discord and seat receipts required | Eight named latency unknowns remain |

--- a/tests/fm-discord-rooms.test.sh
+++ b/tests/fm-discord-rooms.test.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+SCRIPT="$ROOT/bin/fm-discord-rooms.sh"
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/fm-discord-rooms.test.XXXXXX")
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+pass() { printf 'ok - %s\n' "$1"; }
+fail() { printf 'not ok - %s\n' "$1" >&2; exit 1; }
+
+route_case() {
+  local request=$1 text=$2 expected_room=$3 expected_seat=$4 expected_job=$5
+  local file="$TMP_ROOT/$request.json" out
+  jq -cn --arg request "$request" --arg text "$text" \
+    '{request_id:$request,platform:"discord",reply_max_chars:1900,text:$text}' > "$file"
+  out=$("$SCRIPT" route "$file")
+  [ "$(printf '%s' "$out" | jq -r .room_kind)" = "$expected_room" ] || fail "$request room route"
+  [ "$(printf '%s' "$out" | jq -r .seat_slug)" = "$expected_seat" ] || fail "$request seat route"
+  [ "$(printf '%s' "$out" | jq -r '.job_id // ""')" = "$expected_job" ] || fail "$request job route"
+}
+
+route_case req-fleet 'fleet: status for the rooms' fleet eleusis ''
+route_case req-continuum 'continuum-guest: Muse, walk in through Flux' continuum-guest flux ''
+route_case req-job 'job/grokbots-discord-d1/ledger: record the quota note' job ledger grokbots-discord-d1
+for seat in eleusis flux spur chronicle thor qa-engineer ledger argon; do
+  route_case "req-mailbox-$seat" "<@123456789> mailbox/$seat: check the evidence" mailbox "$seat" ''
+done
+pass 'canonical room addresses resolve to the existing eight-seat roster'
+
+jq -cn '{request_id:"req-x",platform:"x",tweet_id:"discord:channel:message",text:"fleet: no"}' > "$TMP_ROOT/x.json"
+if "$SCRIPT" route "$TMP_ROOT/x.json" >/dev/null 2>&1; then
+  fail 'an explicit non-Discord platform must win over a legacy Discord id'
+fi
+jq -cn '{request_id:"req-unknown",platform:"discord",text:"mailbox/ninth-seat: no"}' > "$TMP_ROOT/unknown.json"
+if "$SCRIPT" route "$TMP_ROOT/unknown.json" >/dev/null 2>&1; then
+  fail 'unknown seats must be refused'
+fi
+jq -cn '{request_id:"req-empty",platform:"discord",text:"mailbox/flux:   "}' > "$TMP_ROOT/empty.json"
+if "$SCRIPT" route "$TMP_ROOT/empty.json" >/dev/null 2>&1; then
+  fail 'empty addressed messages must be refused'
+fi
+if "$SCRIPT" route "$TMP_ROOT/empty.json" extra >/dev/null 2>&1; then
+  fail 'extra route arguments must be refused'
+fi
+pass 'routing fails closed for other platforms, unknown seats, and empty messages'
+
+jq -n '{
+  probe_id:"fixture-eight",
+  seats:[
+    {seat_slug:"eleusis",discord_event_ms:1000,relay_offer_ms:1010,seat_seen_ms:1020,proof:"fixture"},
+    {seat_slug:"flux",discord_event_ms:2000,relay_offer_ms:2020,seat_seen_ms:2030,proof:"fixture"},
+    {seat_slug:"spur",discord_event_ms:3000,relay_offer_ms:3030,seat_seen_ms:3040,proof:"fixture"},
+    {seat_slug:"chronicle",discord_event_ms:4000,relay_offer_ms:4040,seat_seen_ms:4050,proof:"fixture"},
+    {seat_slug:"thor",discord_event_ms:5000,relay_offer_ms:5050,seat_seen_ms:5060,proof:"fixture"},
+    {seat_slug:"qa-engineer",discord_event_ms:6000,relay_offer_ms:6060,seat_seen_ms:6070,proof:"fixture"},
+    {seat_slug:"ledger",discord_event_ms:7000,relay_offer_ms:7070,seat_seen_ms:7080,proof:"fixture"},
+    {seat_slug:"argon",discord_event_ms:8000,relay_offer_ms:8080,seat_seen_ms:8090,proof:"fixture"}
+  ]
+}' > "$TMP_ROOT/latency.json"
+latency=$("$SCRIPT" latency "$TMP_ROOT/latency.json")
+[ "$(printf '%s' "$latency" | jq -r .proof)" = fixture ] || fail 'fixture receipt must stay labeled fixture'
+[ "$(printf '%s' "$latency" | jq '.seats | length')" -eq 8 ] || fail 'latency receipt must cover eight seats'
+[ "$(printf '%s' "$latency" | jq '.seats[] | select(.seat_slug == "ledger") | .discord_to_relay_ms')" -eq 70 ] \
+  || fail 'latency calculator must measure Discord to Relay'
+[ "$(printf '%s' "$latency" | jq '.seats[] | select(.seat_slug == "ledger") | .relay_to_seat_ms')" -eq 10 ] \
+  || fail 'latency calculator must measure Relay to seat'
+[ "$(printf '%s' "$latency" | jq '.seats[] | select(.seat_slug == "ledger") | .total_ms')" -eq 80 ] \
+  || fail 'latency calculator must measure end to end'
+pass 'latency receipts calculate both event legs without upgrading fixture proof'
+
+jq '.seats |= .[0:7]' "$TMP_ROOT/latency.json" > "$TMP_ROOT/missing.json"
+if "$SCRIPT" latency "$TMP_ROOT/missing.json" >/dev/null 2>&1; then
+  fail 'missing seat receipt must be refused'
+fi
+jq '.seats[7].seat_slug = "ledger"' "$TMP_ROOT/latency.json" > "$TMP_ROOT/duplicate.json"
+if "$SCRIPT" latency "$TMP_ROOT/duplicate.json" >/dev/null 2>&1; then
+  fail 'duplicate seat receipt must be refused'
+fi
+jq '.seats[0].seat_seen_ms = 1005' "$TMP_ROOT/latency.json" > "$TMP_ROOT/backward.json"
+if "$SCRIPT" latency "$TMP_ROOT/backward.json" >/dev/null 2>&1; then
+  fail 'backward timestamp receipt must be refused'
+fi
+pass 'latency validation requires every seat exactly once and monotonic timestamps'


### PR DESCRIPTION
## Summary

- add deterministic Relay message addressing for `fleet`, `continuum-guest`, eight seat mailboxes, and one thread per job
- validate complete eight-seat Discord-to-Relay-to-seat latency receipts without network access or credentials
- document the single owner activation sitting, exact Discord click path, and least-privilege bot permissions
- teach Relay mention handling to use the active Grokbot runtime's existing message-to-seat action and fail truthfully when it is unavailable
- keep Continuum authoritative, Flux as its guest door, mailboxes out of job ownership, and Rakazo paused

## Evidence boundary

Proved by hermetic tests:

- only the eight existing seats resolve
- explicit non-Discord platform metadata wins over legacy identifiers
- fleet routes to Eleusis and Continuum guest routes to Flux
- latency receipts require all eight seats exactly once with monotonic timestamps
- fixture evidence cannot become live evidence
- the existing Relay polling, Discord context, reply binding, and follow-up suite remains green

Still explicitly owner-gated and unknown:

- live server name, room ids, and official installation permissions
- pairing-token activation
- the live message-to-Grokbot surface in this Firstmate runtime
- one live canary post and reply
- measured wake latency for each of the eight seats

No Discord sign-in, server mutation, bot installation, OAuth approval, pairing-token access, live post, Rakazo start, or account action was performed.

## Validation

- `tests/fm-discord-rooms.test.sh`: pass
- `tests/fm-x-mode.test.sh`: pass
- `tests/fm-documentation-audiences.test.sh`: pass
- `bin/fm-doc-audience-check.sh`: pass
- `bin/fm-test-run.sh --check-coverage`: pass, 152 tests covered
- `bash -n bin/fm-discord-rooms.sh tests/fm-discord-rooms.test.sh`: pass

The complete local lint command could not run because this worktree lacks pinned ShellCheck 0.11.0 and actionlint 1.7.12.
The test-runner self-test additionally lacks Ruby for parsing the workflow YAML.
Those are environment dependency gaps, not hidden green results.
