### PR TITLE
fix(spawn): base pooled worktrees on the local default branch when there is no origin

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1729,18 +1729,26 @@ validate_spawn_worktree() {  # <source> <inspect-target>
   fi
 }
 
+git_common_dir_real() {  # <dir>
+  local dir=$1 common
+  common=$(git -C "$dir" rev-parse --git-common-dir 2>/dev/null) || return 1
+  [ -n "$common" ] || return 1
+  case $common in
+    /*) ;;
+    *) common="$dir/$common" ;;
+  esac
+  ( cd "$common" 2>/dev/null && pwd -P ) || return 1
+}
+
 # Resolve a local-only project's default branch when neither `main` nor `master`
 # exists: read the primary checkout's HEAD symref through the shared git common
 # dir, so `git init -b trunk` style projects still yield a real spawn base.
 primary_checkout_head_branch() {  # <worktree>
-  local worktree=$1 common primary branch
-  common=$(git -C "$worktree" rev-parse --git-common-dir 2>/dev/null) || return 1
-  [ -n "$common" ] || return 1
-  case $common in
-    /*) ;;
-    *) common="$worktree/$common" ;;
-  esac
+  local worktree=$1 common primary primary_common branch
+  common=$(git_common_dir_real "$worktree") || return 1
   primary=$(cd "$common/.." 2>/dev/null && pwd -P) || return 1
+  primary_common=$(git_common_dir_real "$primary") || return 1
+  [ "$primary_common" = "$common" ] || return 1
   branch=$(git -C "$primary" symbolic-ref --quiet --short HEAD 2>/dev/null) || return 1
   [ -n "$branch" ] || return 1
   git -C "$worktree" show-ref --verify --quiet "refs/heads/$branch" || return 1
@@ -1781,7 +1789,7 @@ freshen_spawn_worktree_base() {  # <worktree>
       return 1
     fi
   else
-    echo "notice: project has no origin remote; using local default branch as spawn base" >&2
+    echo "notice: project has no origin remote; using local branch '$default' as spawn base" >&2
     target=$default
   fi
   expected=$(git -C "$worktree" rev-parse --verify --quiet "$target^{commit}" 2>/dev/null) || {

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -136,6 +136,8 @@
 #   git worktree root distinct from the primary project checkout.
 #   Before a fresh ship or scout worker starts, its clean task worktree fetches
 #   origin, resolves the current remote default branch, and resets to its tip.
+#   When the project has no origin remote (normal for local-only projects), the
+#   fetch is skipped and the local default branch is used as the spawn base.
 #   An unreachable origin, unresolved default branch, or non-clean worktree
 #   refuses the spawn rather than risking a PR based on stale history.
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
@@ -1728,23 +1730,37 @@ validate_spawn_worktree() {  # <source> <inspect-target>
 }
 
 freshen_spawn_worktree_base() {  # <worktree>
-  local worktree=$1 default target expected actual status
-  if ! git -C "$worktree" fetch --quiet origin; then
-    echo "error: could not fetch origin for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
-    return 1
+  local worktree=$1 default target expected actual status has_origin=1
+  if ! git -C "$worktree" remote get-url origin >/dev/null 2>&1; then
+    has_origin=0
   fi
-  if ! git -C "$worktree" remote set-head origin --auto >/dev/null 2>&1; then
-    echo "error: could not resolve origin's current default branch for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
-    return 1
+  if [ "$has_origin" = 1 ]; then
+    if ! git -C "$worktree" fetch --quiet origin; then
+      echo "error: could not fetch origin for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+      return 1
+    fi
+    if ! git -C "$worktree" remote set-head origin --auto >/dev/null 2>&1; then
+      echo "error: could not resolve origin's current default branch for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+      return 1
+    fi
   fi
   default=$(default_branch "$worktree") || {
-    echo "error: could not determine origin's default branch for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+    if [ "$has_origin" = 1 ]; then
+      echo "error: could not determine origin's default branch for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+    else
+      echo "error: could not determine default branch for pooled worktree '$worktree'; no origin remote and no local main or master branch" >&2
+    fi
     return 1
   }
-  target="origin/$default"
-  if ! git -C "$worktree" fetch --quiet origin "+refs/heads/$default:refs/remotes/origin/$default"; then
-    echo "error: could not fetch '$target' for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
-    return 1
+  if [ "$has_origin" = 1 ]; then
+    target="origin/$default"
+    if ! git -C "$worktree" fetch --quiet origin "+refs/heads/$default:refs/remotes/origin/$default"; then
+      echo "error: could not fetch '$target' for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+      return 1
+    fi
+  else
+    echo "notice: project has no origin remote; using local default branch as spawn base" >&2
+    target=$default
   fi
   expected=$(git -C "$worktree" rev-parse --verify --quiet "$target^{commit}" 2>/dev/null) || {
     echo "error: '$target' is not a commit for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1729,6 +1729,24 @@ validate_spawn_worktree() {  # <source> <inspect-target>
   fi
 }
 
+# Resolve a local-only project's default branch when neither `main` nor `master`
+# exists: read the primary checkout's HEAD symref through the shared git common
+# dir, so `git init -b trunk` style projects still yield a real spawn base.
+primary_checkout_head_branch() {  # <worktree>
+  local worktree=$1 common primary branch
+  common=$(git -C "$worktree" rev-parse --git-common-dir 2>/dev/null) || return 1
+  [ -n "$common" ] || return 1
+  case $common in
+    /*) ;;
+    *) common="$worktree/$common" ;;
+  esac
+  primary=$(cd "$common/.." 2>/dev/null && pwd -P) || return 1
+  branch=$(git -C "$primary" symbolic-ref --quiet --short HEAD 2>/dev/null) || return 1
+  [ -n "$branch" ] || return 1
+  git -C "$worktree" show-ref --verify --quiet "refs/heads/$branch" || return 1
+  printf '%s\n' "$branch"
+}
+
 freshen_spawn_worktree_base() {  # <worktree>
   local worktree=$1 default target expected actual status has_origin=1
   if ! git -C "$worktree" remote get-url origin >/dev/null 2>&1; then
@@ -1744,14 +1762,18 @@ freshen_spawn_worktree_base() {  # <worktree>
       return 1
     fi
   fi
-  default=$(default_branch "$worktree") || {
+  default=$(default_branch "$worktree" 2>/dev/null || true)
+  if [ -z "$default" ] && [ "$has_origin" = 0 ]; then
+    default=$(primary_checkout_head_branch "$worktree" 2>/dev/null || true)
+  fi
+  if [ -z "$default" ]; then
     if [ "$has_origin" = 1 ]; then
       echo "error: could not determine origin's default branch for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
     else
-      echo "error: could not determine default branch for pooled worktree '$worktree'; no origin remote and no local main or master branch" >&2
+      echo "error: could not determine default branch for pooled worktree '$worktree'; no origin remote and no local default branch to base the spawn on" >&2
     fi
     return 1
-  }
+  fi
   if [ "$has_origin" = 1 ]; then
     target="origin/$default"
     if ! git -C "$worktree" fetch --quiet origin "+refs/heads/$default:refs/remotes/origin/$default"; then

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -158,6 +158,7 @@ Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectab
 Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees for tmux, herdr, zellij, and cmux tasks, while Orca creates its own worktrees for `backend=orca`.
 For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout.
 `fm-spawn.sh` also owns the base-freshness boundary for every fresh ship and scout: no worker starts until its clean task worktree matches the fetched tip of origin's resolved default branch, and any unsafe or unverifiable base stops the spawn.
+A project with no origin remote is the local-only case, not a failure: the fetch is skipped with a notice and the pool worktree resets to the local default branch, which is already the current base because it shares the primary checkout's refs.
 Its header owns the exact refusal mechanics, while `tests/fm-spawn-pool-base-freshen.test.sh` owns the portable regression coverage.
 
 The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -227,11 +227,88 @@ test_unresolved_remote_default_refuses_pool() {
   pass "an unresolved remote default branch refuses the pooled worktree"
 }
 
+make_case_no_origin() {
+  local name=$1 id=$2 default=${3:-main} case_dir home project pool fakebin initial
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  project="$case_dir/project"
+  pool="$case_dir/pool"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
+  printf 'codex\n' > "$home/config/crew-harness"
+  printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
+  touch "$home/state/.last-watcher-beat"
+
+  git init --quiet -b "$default" "$project"
+  printf 'base\n' > "$project/README.md"
+  git -C "$project" add README.md
+  git -C "$project" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial
+  initial=$(git -C "$project" rev-parse HEAD)
+  git -C "$project" worktree add --quiet --detach "$pool" "$initial"
+
+  printf '%s\n' "$case_dir|$home|$project|$pool|$fakebin|$initial|$default"
+}
+
+test_no_origin_remote_uses_local_default_branch() {
+  local rec id out status head_before head_after
+  id='pool-no-origin-r6'
+  rec=$(make_case_no_origin no-origin "$id")
+  read_case_record "$rec"
+  head_before=$(git -C "$POOL_DIR" rev-parse HEAD)
+
+  out=$(run_spawn "$id" --mode local-only --yolo off)
+  status=$?
+  expect_code 0 "$status" "spawn should succeed for a project with no origin remote"
+  assert_contains "$out" "spawned $id" "spawn did not report success"
+  assert_contains "$out" "no origin remote" "spawn did not emit the no-origin notice"
+  head_after=$(git -C "$POOL_DIR" rev-parse HEAD)
+  [ "$head_after" = "$head_before" ] \
+    || fail "spawn moved HEAD unexpectedly for a no-origin project already at the local default branch tip"
+  pass "a project with no origin remote spawns using the local default branch"
+}
+
+test_no_origin_dirty_pool_still_refuses() {
+  local rec id out status
+  id='pool-no-origin-dirty-r7'
+  rec=$(make_case_no_origin no-origin-dirty "$id")
+  read_case_record "$rec"
+  printf 'keep this\n' > "$POOL_DIR/uncommitted.txt"
+
+  out=$(run_spawn "$id" --mode local-only --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn succeeded despite a dirty pooled worktree with no origin"
+  assert_contains "$out" "is not clean" "spawn did not refuse a dirty pool even without origin"
+  assert_grep 'keep this' "$POOL_DIR/uncommitted.txt" \
+    "spawn discarded uncommitted work while refusing the no-origin dirty pool"
+  pass "a dirty pooled worktree with no origin is refused without discarding its local work"
+}
+
+test_origin_present_still_fetches() {
+  local rec id out status current
+  id='pool-origin-present-r8'
+  rec=$(make_case origin-present "$id")
+  read_case_record "$rec"
+
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off)
+  status=$?
+  expect_code 0 "$status" "spawn should still fetch when origin is present"
+  current=$(git -C "$POOL_DIR" rev-parse origin/main)
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$current" ] \
+    || fail "spawn did not refresh to current origin/main when origin is present"
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" != "$INITIAL_SHA" ] \
+    || fail "fixture did not prove origin/main advanced"
+  pass "a project with origin still fetches and refreshes as before"
+}
+
 test_stale_pool_base_refreshes_before_branching
 test_non_main_default_branch_refreshes_before_branching
 test_direct_pr_and_scout_refresh_before_launch
 test_dirty_pool_refuses_without_discarding_work
 test_unresolved_remote_default_refuses_pool
 test_unreachable_origin_refuses_stale_pool_base
+test_no_origin_remote_uses_local_default_branch
+test_no_origin_dirty_pool_still_refuses
+test_origin_present_still_fetches
 
 echo "# all fm-spawn-pool-base-freshen tests passed"

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -228,7 +228,7 @@ test_unresolved_remote_default_refuses_pool() {
 }
 
 make_case_no_origin() {
-  local name=$1 id=$2 default=${3:-main} case_dir home project pool fakebin initial
+  local name=$1 id=$2 default=${3:-trunk} case_dir home project pool fakebin initial
   case_dir="$TMP_ROOT/$name"
   home="$case_dir/home"
   project="$case_dir/project"
@@ -247,15 +247,24 @@ make_case_no_origin() {
   initial=$(git -C "$project" rev-parse HEAD)
   git -C "$project" worktree add --quiet --detach "$pool" "$initial"
 
+  printf 'must survive a newly spawned branch\n' > "$project/advanced-local.txt"
+  git -C "$project" add advanced-local.txt
+  git -C "$project" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm advance-local
+
   printf '%s\n' "$case_dir|$home|$project|$pool|$fakebin|$initial|$default"
 }
 
 test_no_origin_remote_uses_local_default_branch() {
-  local rec id out status head_before head_after
+  local rec id out status head_before head_after advanced
   id='pool-no-origin-r6'
   rec=$(make_case_no_origin no-origin "$id")
   read_case_record "$rec"
   head_before=$(git -C "$POOL_DIR" rev-parse HEAD)
+  advanced=$(git -C "$PROJECT_DIR" rev-parse "$DEFAULT_BRANCH")
+  [ "$head_before" = "$INITIAL_SHA" ] \
+    || fail "fixture did not leave the no-origin pool on its allocation base"
+  [ "$advanced" != "$INITIAL_SHA" ] \
+    || fail "fixture did not advance the local default branch past the pool base"
 
   out=$(run_spawn "$id" --mode local-only --yolo off)
   status=$?
@@ -263,9 +272,11 @@ test_no_origin_remote_uses_local_default_branch() {
   assert_contains "$out" "spawned $id" "spawn did not report success"
   assert_contains "$out" "no origin remote" "spawn did not emit the no-origin notice"
   head_after=$(git -C "$POOL_DIR" rev-parse HEAD)
-  [ "$head_after" = "$head_before" ] \
-    || fail "spawn moved HEAD unexpectedly for a no-origin project already at the local default branch tip"
-  pass "a project with no origin remote spawns using the local default branch"
+  [ "$head_after" = "$advanced" ] \
+    || fail "spawn did not reset the no-origin pool to the local '$DEFAULT_BRANCH' tip"
+  assert_grep 'must survive a newly spawned branch' "$POOL_DIR/advanced-local.txt" \
+    "the refreshed no-origin pool omitted the advanced local default-branch content"
+  pass "a project with no origin remote spawns from the local default branch tip"
 }
 
 test_no_origin_dirty_pool_still_refuses() {

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -295,6 +295,64 @@ test_no_origin_dirty_pool_still_refuses() {
   pass "a dirty pooled worktree with no origin is refused without discarding its local work"
 }
 
+test_no_origin_notice_names_the_resolved_branch() {
+  local rec id out status
+  id='pool-no-origin-notice-r9'
+  rec=$(make_case_no_origin no-origin-notice "$id" develop)
+  read_case_record "$rec"
+
+  out=$(run_spawn "$id" --mode local-only --yolo off)
+  status=$?
+  expect_code 0 "$status" "spawn should succeed for a no-origin project on a non-standard default branch"
+  assert_contains "$out" "using local branch 'develop' as spawn base" \
+    "the no-origin notice did not name the branch it resolved"
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$(git -C "$PROJECT_DIR" rev-parse develop)" ] \
+    || fail "spawn did not base the no-origin pool on the branch named in its notice"
+  pass "the no-origin notice names the local branch used as the spawn base"
+}
+
+test_unrelated_common_dir_parent_refuses_pool() {
+  local case_dir home project gitdir pool fakebin id initial out status head_before
+  id='pool-no-origin-separate-gitdir-r10'
+  case_dir="$TMP_ROOT/no-origin-separate-gitdir"
+  home="$case_dir/home"
+  project="$case_dir/nest/project"
+  gitdir="$case_dir/nest/project.git"
+  pool="$case_dir/pool"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config" "$case_dir/nest"
+  printf 'codex\n' > "$home/config/crew-harness"
+  printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
+  touch "$home/state/.last-watcher-beat"
+
+  git init --quiet -b trunk "$case_dir/nest"
+  printf 'outer\n' > "$case_dir/nest/OUTER.md"
+  git -C "$case_dir/nest" add OUTER.md
+  git -C "$case_dir/nest" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm outer
+
+  git init --quiet -b trunk --separate-git-dir "$gitdir" "$project"
+  printf 'base\n' > "$project/README.md"
+  git -C "$project" add README.md
+  git -C "$project" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial
+  initial=$(git -C "$project" rev-parse HEAD)
+  git -C "$project" worktree add --quiet --detach "$pool" "$initial"
+
+  CASE_DIR=$case_dir HOME_DIR=$home PROJECT_DIR=$project POOL_DIR=$pool
+  FAKEBIN_DIR=$fakebin INITIAL_SHA=$initial DEFAULT_BRANCH=trunk
+  head_before=$(git -C "$POOL_DIR" rev-parse HEAD)
+
+  out=$(run_spawn "$id" --mode local-only --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] \
+    || fail "spawn trusted an unrelated repository's HEAD as the local default branch"
+  assert_contains "$out" "no local default branch" \
+    "spawn did not refuse when the common-dir parent is not this repository's checkout"
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$head_before" ] \
+    || fail "a refused spawn still moved the pooled worktree base"
+  pass "a common-dir parent that is not this repo's checkout refuses the pooled worktree"
+}
+
 test_origin_present_still_fetches() {
   local rec id out status current
   id='pool-origin-present-r8'
@@ -320,6 +378,8 @@ test_unresolved_remote_default_refuses_pool
 test_unreachable_origin_refuses_stale_pool_base
 test_no_origin_remote_uses_local_default_branch
 test_no_origin_dirty_pool_still_refuses
+test_no_origin_notice_names_the_resolved_branch
+test_unrelated_common_dir_parent_refuses_pool
 test_origin_present_still_fetches
 
 echo "# all fm-spawn-pool-base-freshen tests passed"


### PR DESCRIPTION
## Intent

Fix a regression in bin/fm-spawn.sh where freshen_spawn_worktree_base() unconditionally runs git fetch origin and hard-fails when the project has no origin remote - the normal state of a freshly created local-only project. The fix detects whether origin exists (git remote get-url origin) and when absent, skips the origin fetch/set-head/fetch-branch steps with a notice, resolving the default branch locally instead. The pool worktree shares the primary's object store and refs, so the local default branch IS the current base. The dirty-worktree refusal, base-reset behavior, and HEAD verification after reset are preserved for both paths. The header comment is updated to document the no-origin path. Three regression tests are added to the existing fm-spawn-pool-base-freshen.test.sh: no-origin spawn succeeds using local default branch, no-origin dirty pool still refuses, and origin-present path still fetches as before. No other guards are weakened.

## What Changed

- `freshen_spawn_worktree_base()` in `bin/fm-spawn.sh` now probes for an origin remote (`git remote get-url origin`) and, when absent, skips the origin fetch / `remote set-head` / per-branch fetch entirely, emitting a `notice: project has no origin remote; using local branch '<branch>' as spawn base` and resetting to that local branch instead of `origin/<branch>`. The dirty-worktree refusal, base reset, and post-reset HEAD verification still run on both paths; the origin-present path is unchanged.
- Added `git_common_dir_real()` and `primary_checkout_head_branch()` helpers so a local-only project whose default branch is neither `main` nor `master` (e.g. `git init -b trunk`) resolves its base from the primary checkout's HEAD symref, verified to share the same git common dir; unresolvable cases still refuse with a no-origin-specific error.
- Added five regression tests to `tests/fm-spawn-pool-base-freshen.test.sh` (no-origin spawn from the local default tip, no-origin dirty pool still refused without discarding work, notice names the resolved branch, unrelated common-dir parent refused, origin-present path still fetches) and documented the no-origin spawn base in `docs/architecture.md` plus the `fm-spawn.sh` header comment.

## Risk Assessment

✅ Low: The change is a well-bounded guard added around an existing refresh function: every prior guard (fetch failure, unresolved origin default, dirty-worktree refusal, post-reset HEAD verification) is preserved on the origin path unchanged, the new no-origin path fails closed when no local base can be resolved, and the added tests exercise the real spawn end-to-end and observe the base actually moving.

## Testing

Reproduced the reported regression first: running the branch's new tests against the pre-fix fm-spawn.sh fails the no-origin case, and a manual local-only project fixture reproduces the exact `fatal: 'origin' does not appear to be a git repository` / `could not fetch origin` refusal that made brand-new local projects unspawnable. Against the fixed script the same fixture spawns cleanly, printing the no-origin notice naming the resolved local branch and resetting the pool worktree to that branch's tip with its newest content present. Verified the preserved guards still fire — a dirty no-origin pool is refused with uncommitted work intact, and the unreachable-origin, unresolved-remote-default, and origin-present fetch paths behave as before — via the full 11-test targeted suite, which passes. Evidence is a before/after CLI transcript; this is a shell/CLI change with no rendered UI surface, so no screenshot applies. Temp fixtures were removed and the worktree left unmodified.

<details>
<summary>Evidence: Before/after CLI transcript: no-origin local project spawn</summary>

<code>SCENARIO: a freshly created local-only project - git init, commits, NO origin remote.&#10;&#10;$ git -C myapp remote -v # (no output: no remotes configured)&#10;&#10;===== BEFORE the fix (base bdae21e) ==&#10;$ fm-spawn.sh demo-r1 ./myapp --mode local-only --yolo off&#10;fatal: &#39;origin&#39; does not appear to be a git repository&#10;fatal: Could not read from remote repository.&#10;error: could not fetch origin for pooled worktree &#39;.../before/pool&#39;; refusing to launch from a potentially stale base&#10;exit=1&#10;&#10;===== AFTER the fix (37b20f8) =&#10;$ fm-spawn.sh demo-r1 ./myapp --mode local-only --yolo off&#10;notice: project has no origin remote; using local branch &#39;main&#39; as spawn base&#10;spawned demo-r1 harness=codex kind=ship mode=local-only yolo=off window=firstmate:fm-demo-r1 worktree=.../after/pool&#10;exit=0&#10;&#10;===== the spawned worker&#39;s base worktree ====&#10;$ git -C myapp log --oneline -1 # local default branch tip&#10;f73e6ce add feature&#10;$ git -C pool log --oneline -1 # spawn base after the freshen&#10;f73e6ce add feature&#10;$ ls pool/ # newest local-main content present in the base&#10;README.md&#10;feature.txt&#10;&#10;===== preserved guard: a DIRTY no-origin pool is still refused ====&#10;$ echo &#34;work in progress I must not lose&#34; &gt; pool/wip.txt&#10;$ fm-spawn.sh demo-r1 ./myapp --mode local-only --yolo off&#10;notice: project has no origin remote; using local branch &#39;main&#39; as spawn base&#10;error: pooled worktree &#39;.../dirty/pool&#39; is not clean; refusing to discard uncommitted work while refreshing its base&#10;exit=1&#10;$ cat pool/wip.txt # uncommitted work untouched&#10;work in progress I must not lose</code>

```text
SCENARIO: a freshly created local-only project - git init, commits, NO origin remote.
This is the normal state of a brand-new local project, and the regression made it unspawnable.

$ git -C myapp remote -v          # (no output: no remotes configured)

===== BEFORE the fix (base bdae21e) =====================================
$ fm-spawn.sh demo-r1 ./myapp --mode local-only --yolo off
warning: /tmp/no-origin-manual.AtBSId/before/home/data/demo-r1/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode local-only - confirm its definition of done matches
notice: demo-r1 ships mode=local-only while the standing posture for myapp is no-mistakes - less rigor than the captain's standing posture; proceed only on a current explicit captain instruction or an intake judgment you can state
fatal: 'origin' does not appear to be a git repository
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
exit=1

===== AFTER the fix (37b20f8) ===========================================
$ fm-spawn.sh demo-r1 ./myapp --mode local-only --yolo off
warning: /tmp/no-origin-manual.AtBSId/after/home/data/demo-r1/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode local-only - confirm its definition of done matches
notice: demo-r1 ships mode=local-only while the standing posture for myapp is no-mistakes - less rigor than the captain's standing posture; proceed only on a current explicit captain instruction or an intake judgment you can state
notice: project has no origin remote; using local branch 'main' as spawn base
spawned demo-r1 harness=codex kind=ship mode=local-only yolo=off window=firstmate:fm-demo-r1 worktree=/tmp/no-origin-manual.AtBSId/after/pool
exit=0

===== the spawned worker's base worktree ================================
$ git -C myapp log --oneline -1   # local default branch tip
f73e6ce add feature
$ git -C pool  log --oneline -1   # spawn base after the freshen
f73e6ce add feature
$ ls pool/                        # newest local-main content present in the base
README.md
feature.txt

===== preserved guard: a DIRTY no-origin pool is still refused ===========
$ echo "work in progress I must not lose" > pool/wip.txt
$ fm-spawn.sh demo-r1 ./myapp --mode local-only --yolo off
notice: project has no origin remote; using local branch 'main' as spawn base
error: pooled worktree '/tmp/no-origin-manual.AtBSId/dirty/pool' is not clean; refusing to discard uncommitted work while refreshing its base
exit=1
$ cat pool/wip.txt                # uncommitted work untouched
work in progress I must not lose
```
</details>
<details>
<summary>Evidence: Regression direction: new tests against pre-fix script</summary>

```text
$ git show bdae21e:bin/fm-spawn.sh > bin/fm-spawn.sh # temporarily, then restored
$ bash tests/fm-spawn-pool-base-freshen.test.sh
ok - a stale pooled worktree refreshes to current origin/main before a crew branch is created
ok - a stale pooled worktree resolves and refreshes a non-main default branch
ok - direct-PR ships and scouts both refresh stale pooled worktrees before launch
ok - a dirty pooled worktree is refused without discarding its local work
ok - an unresolved remote default branch refuses the pooled worktree
ok - an unreachable origin refuses a potentially stale pooled worktree
not ok - spawn should succeed for a project with no origin remote: expected exit 0, got 1
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"8cf4d028c53e4e45a213190d96e1b952d943822f","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ⚠️ `bin/fm-spawn.sh:1747` - In the new no-origin path, the default branch is resolved solely through default_branch(), which without an origin/HEAD symref only probes literal &#39;main&#39; and &#39;master&#39; (bin/fm-ff-lib.sh:43-49). A local-only project initialized with any other default (e.g. `git init -b trunk`, which this very test suite exercises for the origin case) still hard-fails the spawn with &#34;no origin remote and no local main or master branch&#34;, so the stated goal of supporting &#34;a freshly created local-only project&#34; holds only for main/master repos. The pool worktree is detached, so its own HEAD is not usable, but the shared common dir&#39;s HEAD symref (e.g. `git -C &#34;$worktree&#34; symbolic-ref --short refs/heads/...` via the primary checkout&#39;s HEAD) would resolve the real default. Confirm whether restricting no-origin support to main/master is intended.
- ⚠️ `tests/fm-spawn-pool-base-freshen.test.sh:264` - test_no_origin_remote_uses_local_default_branch builds a fixture where the pool worktree is already at the local default branch tip, then asserts head_after == head_before. That assertion is satisfied by any implementation that leaves HEAD alone, so it does not observe that the local default branch was used as the reset target - only that the spawn stopped failing. Advance local main past $initial (commit once more on the project checkout after `worktree add`) and assert the pool HEAD moves to that new tip, mirroring how the origin-present cases prove the refresh.
- ℹ️ `tests/fm-spawn-pool-base-freshen.test.sh:230` - make_case_no_origin duplicates make_case almost verbatim, differing only by omitting the bare clone, the `remote add origin`, and the publisher advance, and both emit the same 7-field record. A `with_origin` flag parameter on make_case would remove the parallel fixture and keep future fixture changes in one place.

🔧 Fix: resolve local default branch via primary HEAD when no origin
3 issues (1 warning, 2 infos) still open:
- ⚠️ `bin/fm-spawn.sh:1744` - primary_checkout_head_branch() resolves the primary checkout&#39;s *currently checked-out* branch (`symbolic-ref --short HEAD`), not its default branch, and freshen_spawn_worktree_base() then resets the pool worktree to it while printing &#34;using local default branch as spawn base&#34;. Concrete reachable path: a local-only project created with `git init -b trunk` (exactly the fixture this change adds) where the developer is sitting on `feature/x` in the primary checkout. default_branch() fails (no origin/HEAD, no refs/heads/main|master), the fallback returns `feature/x`, `show-ref` confirms it exists, and the ship worker is silently spawned on top of unmerged feature work — the ship then builds and PRs against a base that is not the project&#39;s trunk. bin/fm-ff-lib.sh:53-58 documents this precise hazard for the sibling resolver (&#34;even a primary stranded on a feature branch ... still yields the true default-branch tip instead of propagating a stray feature branch to the fleet&#34;), and this new path violates that invariant. Suggested boundary: prefer a locally-declared default (`git -C &lt;primary&gt; config --get init.defaultBranch`, then verify refs/heads/&lt;name&gt; exists) and fall back to primary HEAD only when it is the repository&#39;s sole branch; otherwise refuse rather than guess. Confirm which semantics you want, since the round-1 instruction prescribed the HEAD symref directly.
- ℹ️ `bin/fm-spawn.sh:1784` - The no-origin notice never names the branch that was chosen (&#34;using local default branch as spawn base&#34;), so an operator cannot tell from the log whether the spawn based on `trunk`, `develop`, or whatever the primary happened to have checked out — which is the only signal that would surface the resolution problem above. Include the resolved name, e.g. &#34;using local branch &#39;$default&#39; as spawn base&#34;.
- ℹ️ `bin/fm-spawn.sh:1743` - primary_checkout_head_branch() assumes `&lt;git-common-dir&gt;/..` is the primary checkout. That holds for the standard `&lt;primary&gt;/.git` layout, but not for a bare or separate-git-dir repository (e.g. `/x/y.git` with linked worktrees): there `primary` becomes an unrelated parent directory, and if that directory happens to be inside another git repository, `git -C &#34;$primary&#34; symbolic-ref HEAD` returns that unrelated repo&#39;s branch. The subsequent `show-ref --verify` in the worktree is the only thing preventing a bad base, and it passes whenever both repos share a branch name. Guard it by confirming the parent really is this repo, e.g. `[ &#34;$(git -C &#34;$primary&#34; rev-parse --git-common-dir 2&gt;/dev/null | ...)&#34; ]` resolves to the same path as `$common`, and return 1 otherwise.

🔧 Fix: verify common-dir parent and name resolved no-origin branch
2 infos still open:
- ℹ️ `bin/fm-spawn.sh:1793` - In the no-origin path the reset target is the bare branch name (`target=$default`), which git resolves through the ambiguous-refname order of gitrevisions: refs/&lt;name&gt;, refs/tags/&lt;name&gt;, then refs/heads/&lt;name&gt;. A repository that carries a tag with the same name as its default branch (e.g. a `trunk` or `main` tag) therefore makes `rev-parse --verify &#34;$target^{commit}&#34;` and `reset --hard &#34;$target&#34;` both resolve to the tag, silently spawning the worker on the tagged commit instead of the branch tip — and the HEAD verification cannot catch it because `expected` was computed from the same ambiguous name. The origin path was immune because it used the fully-qualified-by-construction `origin/$default`, and primary_checkout_head_branch() already verifies `refs/heads/$branch` exists, so qualifying the target is a pure tightening: set `target=&#34;refs/heads/$default&#34;` (the notice already prints `$default` on its own, so operator-facing text is unaffected).
- ℹ️ `bin/fm-spawn.sh:1772` - The primary-HEAD fallback only runs when default_branch() returns nothing, i.e. after its literal main/master probe fails (bin/fm-ff-lib.sh:44). So a local-only project whose real default is `trunk` but which still carries a leftover `main` ref resolves `main` and spawns workers on that stale branch, never consulting the primary&#39;s HEAD. This ordering is exactly what the round-1 instruction prescribed (&#34;after the existing main/master probe in default_branch() fails, add a fallback&#34;), and round 2&#39;s semantics finding was explicitly accepted, so this is recorded as a known boundary of the local resolution rather than a defect to change here.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-spawn-pool-base-freshen.test.sh` — all 11 tests pass (FM_TEST_EVIDENCE=1)</code>
- <code>RED proof: replaced `bin/fm-spawn.sh` with `git show bdae21e:bin/fm-spawn.sh` and re-ran the suite — `not ok - spawn should succeed for a project with no origin remote: expected exit 0, got 1`; file restored and worktree verified clean</code>
- <code>Manual end-to-end: real local-only fixture (`git init -b main`, 2 commits, no remotes, detached pool worktree) driven through `bin/fm-spawn.sh demo-r1 ./myapp --mode local-only --yolo off` on both the pre-fix and fixed scripts, capturing both transcripts</code>
- <code>Manual guard check: wrote `pool/wip.txt`, re-ran the no-origin spawn, confirmed `is not clean` refusal and that `wip.txt` content survived</code>
- <code>Base-state assertions on the manual fixture: `git -C pool log --oneline -1` matches `git -C myapp log --oneline -1`, and the newest local-main file is present in the spawn base</code>
- <code>`git status --porcelain` after cleanup — worktree unmodified, temp fixtures removed</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
