### PR TITLE
fix(bin): pass large fleet snapshot JSON to jq through files instead of argv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,8 +377,8 @@ jobs:
           snapshot_output=$(/bin/bash tests/fm-fleet-snapshot-view.test.sh)
           printf '%s\n' "$snapshot_output"
           snapshot_count=$(printf '%s\n' "$snapshot_output" | grep -c '^ok - ')
-          [ "$snapshot_count" -eq 18 ] || {
-            echo "::error::expected 18 snapshot/fleet-view tests, got $snapshot_count"
+          [ "$snapshot_count" -eq 19 ] || {
+            echo "::error::expected 19 snapshot/fleet-view tests, got $snapshot_count"
             exit 1
           }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,8 +377,8 @@ jobs:
           snapshot_output=$(/bin/bash tests/fm-fleet-snapshot-view.test.sh)
           printf '%s\n' "$snapshot_output"
           snapshot_count=$(printf '%s\n' "$snapshot_output" | grep -c '^ok - ')
-          [ "$snapshot_count" -eq 15 ] || {
-            echo "::error::expected 15 snapshot/fleet-view tests, got $snapshot_count"
+          [ "$snapshot_count" -eq 18 ] || {
+            echo "::error::expected 18 snapshot/fleet-view tests, got $snapshot_count"
             exit 1
           }
 

--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 # GitHub concurrency groups retain at most one pending run, replacing older
 # pending runs even when cancel-in-progress is false. Give body-bearing events
@@ -26,5 +27,63 @@ jobs:
       github.event.pull_request.user.login != 'github-actions[bot]' &&
       github.event.pull_request.user.login != 'dependabot[bot]'
     steps:
+      # The event payload snapshots the PR body at the moment the event fires.
+      # `git push no-mistakes` pushes the branch first (synchronize) and rebinds
+      # the body attestation to the new head a moment later (edited), so the
+      # synchronize run's payload body still attests the previous head even
+      # when the live body was corrected long before a runner picked the job
+      # up. Judge the live body instead, waiting briefly for that rebind. The
+      # pinned action still owns the verdict: this step only chooses which body
+      # it reads, and a body that never binds the pushed head fails as before.
+      # If the API cannot be read at all, the action falls back to the payload
+      # body, so the gate never gets weaker than the snapshot it judged before.
+      - name: Read the live pull request body
+        id: live-body
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -eu
+          attempts=${NM_LIVE_BODY_ATTEMPTS:-12}
+          interval=${NM_LIVE_BODY_INTERVAL:-10}
+          # A cheap wait probe only: the pinned action parses the attestation.
+          bound="\"head_sha\":\"${PR_HEAD_SHA}\""
+          scratch=$(mktemp -d)
+          trap 'rm -rf "$scratch"' EXIT
+          live="$scratch/pr.json"
+          have_live=0
+          attempt=1
+          while :; do
+            if gh api "repos/${PR_REPO}/pulls/${PR_NUMBER}" > "$scratch/fetch.json" 2> "$scratch/fetch.err" &&
+              jq -e 'type == "object"' "$scratch/fetch.json" > /dev/null 2>&1; then
+              mv "$scratch/fetch.json" "$live"
+              have_live=1
+              if jq -e --arg bound "$bound" '(.body // "") | contains($bound)' "$live" > /dev/null; then
+                echo "PR #${PR_NUMBER} body attests head ${PR_HEAD_SHA} (attempt ${attempt}/${attempts})."
+                break
+              fi
+              echo "PR #${PR_NUMBER} body does not attest head ${PR_HEAD_SHA} yet (attempt ${attempt}/${attempts})."
+            else
+              echo "Could not read PR #${PR_NUMBER} from the GitHub API (attempt ${attempt}/${attempts}): $(cat "$scratch/fetch.err")"
+            fi
+            [ "$attempt" -lt "$attempts" ] || break
+            attempt=$((attempt + 1))
+            sleep "$interval"
+          done
+          if [ "$have_live" -eq 1 ]; then
+            delimiter="nm-live-body-$$-${RANDOM}${RANDOM}"
+            {
+              printf 'body<<%s\n' "$delimiter"
+              jq -r '.body // ""' "$live"
+              printf '%s\n' "$delimiter"
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::Could not read the live PR #${PR_NUMBER} body; judging the event payload body instead."
+            printf 'body=\n' >> "$GITHUB_OUTPUT"
+          fi
       - name: Verify no-mistakes signature and pipeline attestation
         uses: kunchenguid/no-mistakes/.github/actions/require-no-mistakes@32d396ac0f29135daf7fcb9964aba9d5f4e796d6 # post-v1.57.1, untagged (action added in #819)
+        with:
+          pr-body: ${{ steps.live-body.outputs.body }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@ Pushing through it runs an AI-driven review/test/lint pipeline in an isolated wo
 A GitHub Actions check (`Require no-mistakes`) runs on PRs targeting `main` and requires both the deterministic signature and a parseable structured attestation from no-mistakes v1.46.0 or newer.
 The attestation must bind to the current PR head commit and report the review, test, and document steps as completed, so a stale attestation, a missing `head_sha`, or a skipped required step fails.
 It evaluates every PR opening and body edit independently, reruns after head synchronization or reopening, and prevents a later edit from replacing an earlier pending compliance check.
+Each run judges the live PR body read from the GitHub API when its job starts, waiting up to about two minutes for the pipeline to rebind the attestation to a freshly pushed head, so a head-synchronization run does not fail on the stale body snapshot in its event payload; a body that never binds the pushed head still fails.
 GitHub Actions and Dependabot are exempt so their automation keeps working, but other contributor PRs that do not satisfy the attestation contract will not be reviewed or merged.
 
 ## Workflow

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -226,6 +226,7 @@ trap 'exit 129' HUP
 
 jq_value_file() {  # <name> <json-value>
   local path="$SNAPSHOT_TMPDIR/$1.json"
+  [ -n "$2" ] || return 1
   printf '%s' "$2" >"$path" || return 1
   printf '%s' "$path"
 }
@@ -1365,7 +1366,7 @@ secondmate_current_json() {  # <parent-tasks-json-file>
          decisions_open:$summary.decisions_open,holds:$summary.holds,queued:$summary.queued,
          landed:$summary.landed,endpoints:$summary.endpoints,counts:$summary.counts,omitted:$summary.omitted,
          parent_event:{raw:$event_raw,note:$event_note,age_seconds:$event_age,open_activities:$activities,open_decisions:$decisions,activity_scan:$activity_scan,reconciliation:$reconciliation},
-         terminal_evidence:$terminal,contradiction:$contradiction}')
+         terminal_evidence:$terminal,contradiction:$contradiction}') || return 1
     else
       if [ -n "$event_raw" ]; then
         provenance='parent-event-fallback'
@@ -1395,7 +1396,7 @@ secondmate_current_json() {  # <parent-tasks-json-file>
          freshness:{status:$freshness,observed_at:$observed,age_seconds:$event_age},
          active_children:[],decisions_open:[],holds:[],queued:[],landed:[],endpoints:[],counts:{active_children:0,decisions_open:0,holds:0,queued:0,landed:0,endpoints:0},omitted:[],
          parent_event:{raw:$event_raw,note:$event_note,age_seconds:$event_age,open_activities:$activities,open_decisions:$decisions,activity_scan:$activity_scan},
-         terminal_evidence:$terminal,contradiction:false}')
+         terminal_evidence:$terminal,contradiction:false}') || return 1
     fi
     printf '%s\n' "$record" >>"$records_file" || return 1
   done <<EOF

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -4,7 +4,9 @@
 # Output contract: `--json` prints one object with schema
 # `fm-fleet-snapshot.v1`.
 # The command is read-only: it does not acquire the session lock, drain wakes,
-# arm watchers, mutate backlog state, or write reports.
+# arm watchers, mutate backlog state, or write reports. Its only writes are
+# scratch JSON staged for jq in a trap-cleaned directory under TMPDIR (see
+# jq_value_file), so it needs a writable TMPDIR and never touches the fleet home.
 #
 # Top-level fields:
 #   schema: stable schema id.

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -201,6 +201,33 @@ esac
 
 command -v jq >/dev/null 2>&1 || { echo "fm-fleet-snapshot: jq not found" >&2; exit 1; }
 
+# Large JSON values reach jq through files, never argv. A grown backlog easily
+# exceeds the Linux per-argument cap (MAX_ARG_STRLEN, 131072 bytes), and an
+# --argjson carrying it makes every jq exec fail with "Argument list too long".
+# Callers pass a path and each jq program binds it with --slurpfile, so the
+# program bodies stay identical to the argv form.
+SNAPSHOT_TMPDIR=$(mktemp -d "${TMPDIR:-/tmp}/fm-fleet-snapshot.XXXXXX") \
+  || { echo "fm-fleet-snapshot: temp directory creation failed" >&2; exit 1; }
+snapshot_tmp_cleanup() {
+  rm -rf "$SNAPSHOT_TMPDIR"
+  return 0
+}
+# The directory is created here, on the main shell, rather than lazily inside
+# jq_value_file: that helper runs in a command substitution, so a lazy
+# assignment would never reach this shell and the cleanup trap would miss it.
+trap snapshot_tmp_cleanup EXIT
+# A timed-out cross-home read is killed by its caller, so signal exits route
+# through the same EXIT cleanup instead of leaving the directory behind.
+trap 'exit 130' INT
+trap 'exit 143' TERM
+trap 'exit 129' HUP
+
+jq_value_file() {  # <name> <json-value>
+  local path="$SNAPSHOT_TMPDIR/$1.json"
+  printf '%s' "$2" >"$path" || return 1
+  printf '%s' "$path"
+}
+
 bool_json() {
   if [ "$1" = 1 ]; then printf 'true'; else printf 'false'; fi
 }
@@ -639,11 +666,13 @@ task_json_lines() {
 # used by secondmate_home_summary_json, without inventing live task rows.
 # Meta inventory remains the sole source of live workers; this object only
 # discloses backlog↔task inconsistency for renderers (Bearings omitted/gates).
-main_inventory_json() {  # <backlog-json> <tasks-json>
+main_inventory_json() {  # <backlog-json-file> <tasks-json-file>
   jq -n \
-    --argjson backlog "$1" \
-    --argjson tasks "$2" '
-    ([ $backlog.records[]?
+    --slurpfile backlog_in "$1" \
+    --slurpfile tasks_in "$2" '
+    $backlog_in[0] as $backlog
+    | $tasks_in[0] as $tasks
+    | ([ $backlog.records[]?
        | select((.state == "in_flight" or .state == "queued") and (.structured | not)) ]) as $unstructured_current
     | ([ $backlog.records[]?
          | select(.state == "in_flight" and .structured and .requires_child_metadata) ]) as $owned_in_flight
@@ -667,7 +696,7 @@ main_inventory_json() {  # <backlog-json> <tasks-json>
 # validated parent read needs.
 # This mode never reads parent events or terminal text and never aggregates
 # nested secondmates.
-secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
+secondmate_home_summary_json() {  # <backlog-json-file> <tasks-json-file>
   jq -n \
     --arg generated "$SNAPSHOT_NOW" \
     --arg home "$FM_HOME" \
@@ -675,9 +704,11 @@ secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
     --argjson queued_n "$FM_SNAPSHOT_SECONDMATE_QUEUED" \
     --argjson decisions_n "$FM_SNAPSHOT_SECONDMATE_DECISIONS" \
     --argjson landed_n "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" \
-    --argjson backlog "$1" \
-    --argjson tasks "$2" '
-    def trunc($n):
+    --slurpfile backlog_in "$1" \
+    --slurpfile tasks_in "$2" '
+    $backlog_in[0] as $backlog
+    | $tasks_in[0] as $tasks
+    | def trunc($n):
       tostring | gsub("\\s+"; " ")
       | if length > $n then .[:$n] + "…" else . end;
     ([ $backlog.records[]?
@@ -1150,14 +1181,15 @@ parent_evidence_reconciliation_json() {  # <summary-json> <activities-json> <dec
        inconclusive:any(($activity_results + $decision_results)[]; .verdict == "inconclusive")}'
 }
 
-secondmate_current_json() {  # <parent-tasks-json>
-  local tasks=$1 registry union rows total_registered total shown truncated
+secondmate_current_json() {  # <parent-tasks-json-file>
+  local tasks_file=$1 registry union rows total_registered total shown truncated
   local row id home host remote registered registry_error task sampled_spawn_gen status_file event_raw event_note event_epoch event_age
   local activity_scan activities decisions reconciliation provenance freshness reason summary summary_rc summary_bytes summary_sampled summary_valid summary_reason summary_invalidity state current_reason terminal terminal_contradiction contradiction
   local records='[]' seen_homes=''
   registry=$(registry_secondmates_json) || return 1
-  union=$(jq -n --argjson registry "$registry" --argjson tasks "$tasks" '
-    ($registry.records // []) as $registered
+  union=$(jq -n --argjson registry "$registry" --slurpfile tasks_in "$tasks_file" '
+    $tasks_in[0] as $tasks
+    | ($registry.records // []) as $registered
     | (($registered | map(.id)) // []) as $registered_ids
     | ([ $registered[] as $r
          | $r + {parent_task:([$tasks[] | select(.id == $r.id)][0] // null)} ]
@@ -1398,17 +1430,21 @@ scout_report_lines() {
 
 BACKLOG_JSON=$(backlog_json) || { echo "fm-fleet-snapshot: backlog read failed" >&2; exit 1; }
 TASKS_JSON=$(task_json_lines) || { echo "fm-fleet-snapshot: task snapshot failed" >&2; exit 1; }
+BACKLOG_FILE=$(jq_value_file backlog "$BACKLOG_JSON") \
+  || { echo "fm-fleet-snapshot: backlog staging failed" >&2; exit 1; }
+TASKS_FILE=$(jq_value_file tasks "$TASKS_JSON") \
+  || { echo "fm-fleet-snapshot: task staging failed" >&2; exit 1; }
 
 if [ "$OUTPUT_MODE" = secondmate-home-summary ]; then
-  secondmate_home_summary_json "$BACKLOG_JSON" "$TASKS_JSON" \
+  secondmate_home_summary_json "$BACKLOG_FILE" "$TASKS_FILE" \
     || { echo "fm-fleet-snapshot: secondmate home summary failed" >&2; exit 1; }
   exit 0
 fi
 
 SCOUT_REPORTS_JSON=$(scout_report_lines)
-MAIN_INVENTORY_JSON=$(main_inventory_json "$BACKLOG_JSON" "$TASKS_JSON") \
+MAIN_INVENTORY_JSON=$(main_inventory_json "$BACKLOG_FILE" "$TASKS_FILE") \
   || { echo "fm-fleet-snapshot: main inventory summary failed" >&2; exit 1; }
-SECONDMATE_CURRENT_JSON=$(secondmate_current_json "$TASKS_JSON") \
+SECONDMATE_CURRENT_JSON=$(secondmate_current_json "$TASKS_FILE") \
   || { echo "fm-fleet-snapshot: registered secondmate aggregation failed" >&2; exit 1; }
 SECONDMATE_LANDED_JSON=$(secondmate_landed_from_current_json "$SECONDMATE_CURRENT_JSON") \
   || { echo "fm-fleet-snapshot: secondmate landed projection failed" >&2; exit 1; }
@@ -1421,13 +1457,15 @@ jq -n \
   --arg data "$DATA" \
   --arg config "$CONFIG" \
   --arg projects "$PROJECTS" \
-  --argjson backlog "$BACKLOG_JSON" \
-  --argjson tasks "$TASKS_JSON" \
+  --slurpfile backlog_in "$BACKLOG_FILE" \
+  --slurpfile tasks_in "$TASKS_FILE" \
   --argjson main_inventory "$MAIN_INVENTORY_JSON" \
   --argjson scout_reports "$SCOUT_REPORTS_JSON" \
   --argjson secondmate_current "$SECONDMATE_CURRENT_JSON" \
   --argjson secondmate_landed "$SECONDMATE_LANDED_JSON" \
-  'def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
+  '$backlog_in[0] as $backlog
+   | $tasks_in[0] as $tasks
+   | def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
    def task_by_id($id): ($tasks[]? | select(.id == $id) | .) // null;
    def report_kind($id): (task_by_id($id).kind // backlog_by_id($id).kind // "scout");
    {

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -1121,9 +1121,10 @@ terminal_evidence_json() {  # <parent-task-json> <event-note> <evidence-contradi
     '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:true,observed_at:$observed,freshness:"fresh",reason:null,lines:$lines,bytes:$bytes,event_note_seen:$seen,contradiction:$contradiction}'
 }
 
-parent_evidence_reconciliation_json() {  # <summary-json> <activities-json> <decisions-json>
-  jq -n --argjson summary "$1" --argjson activities "$2" --argjson decisions "$3" '
-    def keyed: . != null and . != "" and . != "default";
+parent_evidence_reconciliation_json() {  # <summary-json-file> <activities-json> <decisions-json>
+  jq -n --slurpfile summary_in "$1" --argjson activities "$2" --argjson decisions "$3" '
+    $summary_in[0] as $summary
+    | def keyed: . != null and . != "" and . != "default";
     def result($e; $matches; $complete; $surface):
       $e + {
         verdict:(if ($e.key | keyed | not) then "inconclusive"
@@ -1185,7 +1186,8 @@ secondmate_current_json() {  # <parent-tasks-json-file>
   local tasks_file=$1 registry union rows total_registered total shown truncated
   local row id home host remote registered registry_error task sampled_spawn_gen status_file event_raw event_note event_epoch event_age
   local activity_scan activities decisions reconciliation provenance freshness reason summary summary_rc summary_bytes summary_sampled summary_valid summary_reason summary_invalidity state current_reason terminal terminal_contradiction contradiction
-  local records='[]' seen_homes=''
+  local summary_file records_file="$SNAPSHOT_TMPDIR/secondmate-records.jsonl" seen_homes=''
+  : >"$records_file" || return 1
   registry=$(registry_secondmates_json) || return 1
   union=$(jq -n --argjson registry "$registry" --slurpfile tasks_in "$tasks_file" '
     $tasks_in[0] as $tasks
@@ -1315,13 +1317,23 @@ secondmate_current_json() {  # <parent-tasks-json-file>
       fi
     fi
 
+    # Both record shapes read the sampled summary through a file: an accepted
+    # summary can sit between the argv cap and the byte guard, and a sampled
+    # summary that was rejected above still feeds the fallback record's
+    # inventory reconciliation. An unsampled value is only the placeholder or
+    # rejected raw output, which neither record reads.
+    if [ "$summary_sampled" = true ]; then
+      summary_file=$(jq_value_file summary "$summary") || return 1
+    else
+      summary_file=$(jq_value_file summary '{}') || return 1
+    fi
     if [ -z "$reason" ]; then
       state=$(printf '%s' "$summary" | jq -r '.state')
       current_reason=
       if [ "$summary_valid" != true ]; then
         current_reason="structured home state invalid: $(printf '%s' "$summary" | jq -r '.reason // "unknown reason"')"
       fi
-      reconciliation=$(parent_evidence_reconciliation_json "$summary" "$activities" "$decisions")
+      reconciliation=$(parent_evidence_reconciliation_json "$summary_file" "$activities" "$decisions")
       contradiction=$(printf '%s' "$reconciliation" | jq -r '.contradiction')
       terminal_contradiction=$(printf '%s' "$reconciliation" | jq -r --arg note "$event_note" '
         any(.activities[]; .verdict == "contradicts" and .summary == $note)')
@@ -1335,11 +1347,12 @@ secondmate_current_json() {  # <parent-tasks-json-file>
       record=$(jq -n \
         --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg state "$state" --arg current_reason "$current_reason" --arg observed "$SNAPSHOT_NOW" \
         --arg spawn_gen "$sampled_spawn_gen" \
-        --argjson registered "$registered" --argjson summary "$summary" --argjson summary_valid "$summary_valid" --argjson decisions "$decisions" \
+        --argjson registered "$registered" --slurpfile summary_in "$summary_file" --argjson summary_valid "$summary_valid" --argjson decisions "$decisions" \
         --argjson activities "$activities" --argjson activity_scan "$activity_scan" \
         --argjson reconciliation "$reconciliation" --argjson terminal "$terminal" --argjson contradiction "$contradiction" \
         --arg event_raw "$event_raw" --arg event_note "$event_note" --argjson event_age "$event_age" '
-        {id:$id,home:$home,host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
+        $summary_in[0] as $summary
+        | {id:$id,home:$home,host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
          spawn_gen:($spawn_gen | if . == "" then null else . end),
          current:{state:$state,reason:($current_reason | if . == "" then null else . end)},invalidity:$summary.invalidity,
          reconcile_inventory:$summary.invalidity,
@@ -1370,8 +1383,9 @@ secondmate_current_json() {  # <parent-tasks-json-file>
         --arg spawn_gen "$sampled_spawn_gen" \
         --arg provenance "$provenance" --arg freshness "$freshness" --arg event_raw "$event_raw" --arg event_note "$event_note" \
         --argjson registered "$registered" --argjson event_age "$event_age" --argjson activities "$activities" --argjson activity_scan "$activity_scan" \
-        --argjson decisions "$decisions" --argjson terminal "$terminal" --argjson summary "$summary" --argjson summary_sampled "$summary_sampled" '
-        {id:$id,home:($home | if . == "" then null else . end),host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
+        --argjson decisions "$decisions" --argjson terminal "$terminal" --slurpfile summary_in "$summary_file" --argjson summary_sampled "$summary_sampled" '
+        $summary_in[0] as $summary
+        | {id:$id,home:($home | if . == "" then null else . end),host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
          spawn_gen:($spawn_gen | if . == "" then null else . end),
          current:{state:"unknown",reason:$reason},invalidity:null,
          reconcile_inventory:(if $summary_sampled then $summary.invalidity else null end),
@@ -1381,23 +1395,24 @@ secondmate_current_json() {  # <parent-tasks-json-file>
          parent_event:{raw:$event_raw,note:$event_note,age_seconds:$event_age,open_activities:$activities,open_decisions:$decisions,activity_scan:$activity_scan},
          terminal_evidence:$terminal,contradiction:false}')
     fi
-    records=$(jq -n --argjson records "$records" --argjson record "$record" '$records + [$record]')
+    printf '%s\n' "$record" >>"$records_file" || return 1
   done <<EOF
 $rows
 EOF
   jq -n \
     --argjson registry "$(printf '%s' "$union" | jq '.registry')" \
-    --argjson records "$records" \
+    --slurpfile records_in "$records_file" \
     --argjson total_registered "$total_registered" \
     --argjson total "$total" \
     --argjson shown "$shown" \
     --argjson truncated "$truncated" \
-    '{registry:$registry,records:$records,total_registered:$total_registered,total:$total,shown:$shown,truncated:$truncated}'
+    '{registry:$registry,records:$records_in,total_registered:$total_registered,total:$total,shown:$shown,truncated:$truncated}'
 }
 
-secondmate_landed_from_current_json() {  # <secondmate-current-json>
-  jq -n --argjson current "$1" '
-    {records:[ $current.records[]
+secondmate_landed_from_current_json() {  # <secondmate-current-json-file>
+  jq -n --slurpfile current_in "$1" '
+    $current_in[0] as $current
+    | {records:[ $current.records[]
       | select(.provenance.selected == "structured-home") as $mate
       | $mate.landed[]
       | . + {home:$mate.home,home_id:$mate.id}],
@@ -1442,12 +1457,20 @@ if [ "$OUTPUT_MODE" = secondmate-home-summary ]; then
 fi
 
 SCOUT_REPORTS_JSON=$(scout_report_lines)
+SCOUT_REPORTS_FILE=$(jq_value_file scout_reports "$SCOUT_REPORTS_JSON") \
+  || { echo "fm-fleet-snapshot: scout report staging failed" >&2; exit 1; }
 MAIN_INVENTORY_JSON=$(main_inventory_json "$BACKLOG_FILE" "$TASKS_FILE") \
   || { echo "fm-fleet-snapshot: main inventory summary failed" >&2; exit 1; }
+MAIN_INVENTORY_FILE=$(jq_value_file main_inventory "$MAIN_INVENTORY_JSON") \
+  || { echo "fm-fleet-snapshot: main inventory staging failed" >&2; exit 1; }
 SECONDMATE_CURRENT_JSON=$(secondmate_current_json "$TASKS_FILE") \
   || { echo "fm-fleet-snapshot: registered secondmate aggregation failed" >&2; exit 1; }
-SECONDMATE_LANDED_JSON=$(secondmate_landed_from_current_json "$SECONDMATE_CURRENT_JSON") \
+SECONDMATE_CURRENT_FILE=$(jq_value_file secondmate_current "$SECONDMATE_CURRENT_JSON") \
+  || { echo "fm-fleet-snapshot: registered secondmate staging failed" >&2; exit 1; }
+SECONDMATE_LANDED_JSON=$(secondmate_landed_from_current_json "$SECONDMATE_CURRENT_FILE") \
   || { echo "fm-fleet-snapshot: secondmate landed projection failed" >&2; exit 1; }
+SECONDMATE_LANDED_FILE=$(jq_value_file secondmate_landed "$SECONDMATE_LANDED_JSON") \
+  || { echo "fm-fleet-snapshot: secondmate landed staging failed" >&2; exit 1; }
 
 jq -n \
   --arg generated "$SNAPSHOT_NOW" \
@@ -1459,12 +1482,16 @@ jq -n \
   --arg projects "$PROJECTS" \
   --slurpfile backlog_in "$BACKLOG_FILE" \
   --slurpfile tasks_in "$TASKS_FILE" \
-  --argjson main_inventory "$MAIN_INVENTORY_JSON" \
-  --argjson scout_reports "$SCOUT_REPORTS_JSON" \
-  --argjson secondmate_current "$SECONDMATE_CURRENT_JSON" \
-  --argjson secondmate_landed "$SECONDMATE_LANDED_JSON" \
+  --slurpfile main_inventory_in "$MAIN_INVENTORY_FILE" \
+  --slurpfile scout_reports_in "$SCOUT_REPORTS_FILE" \
+  --slurpfile secondmate_current_in "$SECONDMATE_CURRENT_FILE" \
+  --slurpfile secondmate_landed_in "$SECONDMATE_LANDED_FILE" \
   '$backlog_in[0] as $backlog
    | $tasks_in[0] as $tasks
+   | $main_inventory_in[0] as $main_inventory
+   | $scout_reports_in[0] as $scout_reports
+   | $secondmate_current_in[0] as $secondmate_current
+   | $secondmate_landed_in[0] as $secondmate_landed
    | def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
    def task_by_id($id): ($tasks[]? | select(.id == $id) | .) // null;
    def report_kind($id): (task_by_id($id).kind // backlog_by_id($id).kind // "scout");

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -1062,7 +1062,7 @@ test_perl_fallback_bounds_github_call() {
   fakebin=$(make_fakebin "$home")
   toolbin="$home/toolbin"
   mkdir -p "$toolbin"
-  for cmd in bash dirname basename jq date sed git grep tail cut tr head sort wc perl sleep cat find; do
+  for cmd in bash dirname basename jq date sed git grep tail cut tr head sort wc perl sleep cat find mktemp rm; do
     ln -s "$(command -v "$cmd")" "$toolbin/$cmd"
   done
   started=$(date +%s)

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -799,8 +799,62 @@ test_parked_scout_decision_stays_pending() {
   pass "a scout still parked at a decision stays pending (terminal clear does not over-fire)"
 }
 
+# The Linux per-argument cap (MAX_ARG_STRLEN, 131072 bytes) is what an --argjson
+# backlog used to hit: once the backlog grew past it, every jq exec died with
+# "Argument list too long" and the whole snapshot failed. Both output modes must
+# survive a backlog whose parsed JSON is comfortably over that cap.
+ARGV_CAP_BYTES=131072
+
+write_oversized_backlog() {  # <home>
+  local home=$1 i reason
+  reason="captain must choose between the long-standing option A and the equally"
+  reason="$reason long-standing option B before this queued item can proceed"
+  {
+    printf '## In flight\n\n## Queued\n'
+    i=1
+    while [ "$i" -le 400 ]; do
+      printf -- '- [ ] hold-%03d - Captain decision %03d (repo: alpha) (kind: captain) (hold: %s) (hold-kind: captain)\n' \
+        "$i" "$i" "$reason"
+      i=$((i + 1))
+    done
+    printf '\n## Done\n'
+  } > "$home/data/backlog.md"
+}
+
+test_oversized_backlog_survives_argv_cap() {
+  local home fakebin out err rc bytes
+  home=$(make_home oversized-backlog)
+  write_oversized_backlog "$home"
+  fakebin=$(make_fakebin "$home")
+
+  err="$home/snapshot.err"
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$SNAPSHOT" --json 2>"$err") && rc=0 || rc=$?
+  [ "$rc" -eq 0 ] || fail "oversized backlog snapshot failed (rc=$rc): $(cat "$err")"
+  assert_no_grep 'Argument list too long' "$err" \
+    "oversized backlog must not push jq arguments past the argv cap"
+
+  bytes=$(printf '%s' "$out" | jq -c '.backlog' | LC_ALL=C wc -c | tr -d ' ')
+  [ "$bytes" -gt "$ARGV_CAP_BYTES" ] \
+    || fail "fixture backlog JSON is only $bytes bytes; it must exceed $ARGV_CAP_BYTES to exercise the cap"
+  printf '%s' "$out" | jq -e '
+    (.backlog.records | length) == 400
+      and .main_inventory.valid == true
+      and .main_inventory.unstructured_current_count == 0
+  ' >/dev/null || fail "oversized backlog produced an incomplete snapshot: $(printf '%s' "$out" | head -c 400)"
+
+  err="$home/summary.err"
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$SNAPSHOT" --secondmate-home-summary 2>"$err") && rc=0 || rc=$?
+  [ "$rc" -eq 0 ] || fail "oversized backlog home summary failed (rc=$rc): $(cat "$err")"
+  assert_no_grep 'Argument list too long' "$err" \
+    "the home-summary mode must not push jq arguments past the argv cap either"
+  printf '%s' "$out" | jq -e '.counts.queued == 400' >/dev/null \
+    || fail "oversized backlog home summary lost queued rows: $(printf '%s' "$out" | head -c 400)"
+  pass "a backlog larger than the argv cap still snapshots in both output modes"
+}
+
 test_empty_fleet_json
 test_fixture_snapshot_json
+test_oversized_backlog_survives_argv_cap
 test_main_inventory_orphan_and_unstructured_disclosure
 test_normalized_roles_and_plural_blocker_readiness
 test_event_hints_follow_reconciled_current_state

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -942,11 +942,60 @@ test_secondmate_aggregate_over_argv_cap_survives() {
   pass "a fleet aggregate larger than the argv cap still snapshots"
 }
 
+# Before the JSONL staging, a per-mate record that failed to build broke the
+# next --argjson accumulation and the whole snapshot exited non-zero. The
+# --slurpfile roll-up skips an empty line, so the same failure must still be
+# loud instead of quietly shrinking records[] below shown. The wrapper fails
+# the first jq exec that emits a per-mate record, recognised by the documented
+# reconcile_inventory field every sampled secondmate_current record carries.
+write_record_failing_jq() {  # <fakebin> <scratch-dir> <trip-file>
+  local fakebin=$1 scratch=$2 trip=$3 real_jq
+  real_jq=$(command -v jq) || fail "jq is required to wrap"
+  cat > "$fakebin/jq" <<SH
+#!/usr/bin/env bash
+out=\$(mktemp '$scratch/jq-out.XXXXXX') || exit 3
+'$real_jq' "\$@" > "\$out"
+rc=\$?
+if [ "\$rc" -eq 0 ] && [ ! -e '$trip' ] && grep -q '"reconcile_inventory"' "\$out"; then
+  : > '$trip'
+  rm -f "\$out"
+  exit 5
+fi
+cat "\$out"
+rm -f "\$out"
+exit "\$rc"
+SH
+  chmod +x "$fakebin/jq"
+}
+
+test_secondmate_record_build_failure_fails_loudly() {
+  local home mate fakebin trip out err rc
+  home=$(make_home record-fail-parent)
+  printf '## In flight\n\n## Queued\n\n## Done\n' > "$home/data/backlog.md"
+  mate=$TMP_ROOT/record-fail-mate
+  write_registered_mate "$home" failmate "$mate" 3
+  fakebin=$(make_fakebin "$home")
+  mkdir -p "$home/jq-scratch"
+  trip="$home/jq-record.tripped"
+  write_record_failing_jq "$fakebin" "$home/jq-scratch" "$trip"
+
+  err="$home/snapshot.err"
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" FM_SNAPSHOT_SECONDMATE_TIMEOUT=60 \
+    "$SNAPSHOT" --json 2>"$err") && rc=0 || rc=$?
+  [ -e "$trip" ] || fail "fixture never reached a per-mate record build (rc=$rc): $(cat "$err")"
+  [ "$rc" -ne 0 ] || fail "a failed per-mate record build must fail the snapshot, got rc=0 with $(printf '%s' "$out" | jq -c '.secondmate_current | {shown, records:(.records | length)}')"
+  assert_grep 'registered secondmate aggregation failed' "$err" \
+    "a failed per-mate record build must name the aggregation failure: $(cat "$err")"
+  [ -z "$out" ] || fail "a failed snapshot must not print a partial document: $(printf '%s' "$out" | head -c 200)"
+  pass "a failed per-mate record build fails the snapshot instead of dropping the mate"
+}
+
 test_empty_fleet_json
 test_fixture_snapshot_json
 test_oversized_backlog_survives_argv_cap
 test_oversized_secondmate_summary_survives_argv_cap
 test_secondmate_aggregate_over_argv_cap_survives
+test_secondmate_record_build_failure_fails_loudly
 test_main_inventory_orphan_and_unstructured_disclosure
 test_normalized_roles_and_plural_blocker_readiness
 test_event_hints_follow_reconciled_current_state

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -852,9 +852,101 @@ test_oversized_backlog_survives_argv_cap() {
   pass "a backlog larger than the argv cap still snapshots in both output modes"
 }
 
+write_registered_mate() {  # <parent-home> <mate-id> <mate-home> <landed-count>
+  local home=$1 id=$2 mate=$3 count=$4 i
+  mkdir -p "$mate/data" "$mate/state" "$mate/config" "$mate/projects" "$mate/bin"
+  printf '# Firstmate fixture\n' > "$mate/AGENTS.md"
+  printf '%s\n' "$id" > "$mate/.fm-secondmate-home"
+  printf -- '- %s - delegated domain (home: %s; scope: delegated work; projects: alpha; added 2026-07-11)\n' \
+    "$id" "$mate" >> "$home/data/secondmates.md"
+  {
+    printf '## In flight\n\n## Queued\n\n## Done\n'
+    i=1
+    while [ "$i" -le "$count" ]; do
+      printf -- '- [x] %s-landed-%04d - Landed change %04d covering the long-running snapshot pipeline refactor stage %04d of the delegated domain https://github.com/kunchenguid/firstmate/pull/%d (repo: alpha) (kind: ship) (merged 2026-07-01)\n' \
+        "$id" "$i" "$i" "$i" "$i"
+      i=$((i + 1))
+    done
+  } > "$mate/data/backlog.md"
+}
+
+# A child-home summary can pass the FM_SNAPSHOT_SECONDMATE_MAX_BYTES acceptance
+# guard (default 262144) while still exceeding the argv cap, because the guard
+# bound is twice MAX_ARG_STRLEN. The documented landed cap-lift
+# (FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME=0) reaches that window with an
+# ordinary grown Done section, so the parent must carry the accepted summary
+# to jq without putting it back on argv.
+test_oversized_secondmate_summary_survives_argv_cap() {
+  local home mate fakebin out err rc landed_bytes
+  home=$(make_home big-mate-parent)
+  printf '## In flight\n\n## Queued\n\n## Done\n' > "$home/data/backlog.md"
+  mate=$TMP_ROOT/big-mate-home
+  write_registered_mate "$home" bigmate "$mate" 520
+  fakebin=$(make_fakebin "$home")
+
+  err="$home/snapshot.err"
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" \
+    FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME=0 FM_SNAPSHOT_SECONDMATE_TIMEOUT=60 \
+    "$SNAPSHOT" --json 2>"$err") && rc=0 || rc=$?
+  [ "$rc" -eq 0 ] || fail "snapshot with an argv-window child summary failed (rc=$rc): $(cat "$err")"
+  assert_no_grep 'Argument list too long' "$err" \
+    "an accepted child summary larger than the argv cap must not ride jq argv"
+
+  landed_bytes=$(printf '%s' "$out" | jq -c '.secondmate_current.records[0].landed' | LC_ALL=C wc -c | tr -d ' ')
+  [ "$landed_bytes" -gt "$ARGV_CAP_BYTES" ] \
+    || fail "fixture child summary landed roll-up is only $landed_bytes bytes; it must exceed $ARGV_CAP_BYTES to exercise the guard window"
+  printf '%s' "$out" | jq -e '
+    (.secondmate_current.records | length) == 1
+      and .secondmate_current.records[0].id == "bigmate"
+      and .secondmate_current.records[0].provenance.selected == "structured-home"
+      and .secondmate_current.records[0].current.state == "no_active_work"
+      and (.secondmate_current.records[0].landed | length) == 520
+      and (.secondmate_landed.records | length) == 520
+  ' >/dev/null || fail "argv-window child summary was not carried into the snapshot intact: $(printf '%s' "$out" | head -c 400)"
+  pass "a child summary between the argv cap and the byte guard still snapshots"
+}
+
+# Individually small summaries still sum into one fleet aggregate; once the
+# combined secondmate_current object crosses the argv cap it must reach the
+# remaining jq handoffs (record roll-up, landed projection, final assembly)
+# through files as well.
+test_secondmate_aggregate_over_argv_cap_survives() {
+  local home fakebin out err rc n biggest total_bytes
+  home=$(make_home fleet-agg-parent)
+  printf '## In flight\n\n## Queued\n\n## Done\n' > "$home/data/backlog.md"
+  for n in 1 2 3; do
+    write_registered_mate "$home" "aggmate$n" "$TMP_ROOT/fleet-agg-mate-$n" 200
+  done
+  fakebin=$(make_fakebin "$home")
+
+  err="$home/snapshot.err"
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" \
+    FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME=0 FM_SNAPSHOT_SECONDMATE_TIMEOUT=60 \
+    "$SNAPSHOT" --json 2>"$err") && rc=0 || rc=$?
+  [ "$rc" -eq 0 ] || fail "snapshot with an oversized fleet aggregate failed (rc=$rc): $(cat "$err")"
+  assert_no_grep 'Argument list too long' "$err" \
+    "a fleet aggregate larger than the argv cap must not ride jq argv"
+
+  biggest=$(printf '%s' "$out" | jq '[.secondmate_current.records[] | tojson | length] | max')
+  [ "$biggest" -lt "$ARGV_CAP_BYTES" ] \
+    || fail "fixture per-home summaries must each fit under $ARGV_CAP_BYTES to isolate the aggregate window (largest was $biggest)"
+  total_bytes=$(printf '%s' "$out" | jq -c '.secondmate_current' | LC_ALL=C wc -c | tr -d ' ')
+  [ "$total_bytes" -gt "$ARGV_CAP_BYTES" ] \
+    || fail "fixture fleet aggregate is only $total_bytes bytes; it must exceed $ARGV_CAP_BYTES to exercise the cap"
+  printf '%s' "$out" | jq -e '
+    (.secondmate_current.records | length) == 3
+      and ([.secondmate_current.records[] | select(.provenance.selected == "structured-home")] | length) == 3
+      and ([.secondmate_current.records[] | .landed | length] | add) == 600
+      and (.secondmate_landed.records | length) == 600
+  ' >/dev/null || fail "oversized fleet aggregate produced an incomplete snapshot: $(printf '%s' "$out" | head -c 400)"
+  pass "a fleet aggregate larger than the argv cap still snapshots"
+}
+
 test_empty_fleet_json
 test_fixture_snapshot_json
 test_oversized_backlog_survives_argv_cap
+test_oversized_secondmate_summary_survives_argv_cap
+test_secondmate_aggregate_over_argv_cap_survives
 test_main_inventory_orphan_and_unstructured_disclosure
 test_normalized_roles_and_plural_blocker_readiness
 test_event_hints_follow_reconciled_current_state

--- a/tests/fm-no-mistakes-required.test.sh
+++ b/tests/fm-no-mistakes-required.test.sh
@@ -1,5 +1,15 @@
 #!/usr/bin/env bash
-# Regression tests for the pinned shared no-mistakes gate action.
+# Regression tests for the pinned shared no-mistakes gate action and for the
+# workflow step that hands it the live PR body.
+#
+# Regression origin: `git push no-mistakes` pushes the branch (synchronize) and
+# rebinds the PR body attestation to the new head a moment later (edited). The
+# synchronize event payload snapshots the body before that rebind, so judging
+# the payload body failed every re-pushed PR on a stale head_sha (#2737) even
+# when the live body was corrected minutes before the runner started. The
+# workflow's live-body step is extracted from the YAML and executed here
+# against a fake `gh`, and whatever it emits is judged by the real pinned
+# verifier, so the tests prove the body the gate judges, not the YAML text.
 set -u
 
 # shellcheck source=tests/lib.sh disable=SC1091
@@ -66,7 +76,225 @@ test_missing_head_fails() {
   pass "shared action rejects an attestation with no head_sha"
 }
 
+# --- workflow live-body step ---------------------------------------------------
+
+WORKFLOW="$ROOT/.github/workflows/no-mistakes-required.yml"
+LIVE_BODY_SCRIPT="$TMP_ROOT/live-body.sh"
+PR_REPO=kunchenguid/firstmate
+PR_NUMBER=3006
+
+bound_body() {
+  printf '%s\n<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"%s","steps":%s} -->\n' \
+    "$SIGNATURE" "$1" "$COMPLETED_STEPS"
+}
+
+# Pull the `run:` block scalar of the step whose id is live-body out of the
+# workflow so the same script GitHub executes runs here. Any other shape (a
+# renamed id, the script moved out of the step) fails loudly instead of
+# silently testing nothing.
+extract_live_body_script() {
+  python3 - "$WORKFLOW" > "$LIVE_BODY_SCRIPT" <<'PY2'
+import sys
+
+lines = open(sys.argv[1], encoding="utf-8").read().splitlines()
+
+
+def indent(line):
+    return len(line) - len(line.lstrip())
+
+
+start = next((i for i, line in enumerate(lines) if line.strip() == "id: live-body"), None)
+if start is None:
+    sys.exit("no step with id: live-body in the workflow")
+key_indent = indent(lines[start])
+run_at = None
+for j in range(start + 1, len(lines)):
+    line = lines[j]
+    if not line.strip():
+        continue
+    if indent(line) < key_indent or (indent(line) == key_indent and line.lstrip().startswith("- ")):
+        break
+    if indent(line) == key_indent and line.strip() == "run: |":
+        run_at = j
+        break
+if run_at is None:
+    sys.exit("the live-body step has no `run: |` block")
+block = []
+block_indent = None
+for line in lines[run_at + 1:]:
+    if not line.strip():
+        block.append("")
+        continue
+    if indent(line) <= key_indent:
+        break
+    if block_indent is None:
+        block_indent = indent(line)
+    block.append(line[block_indent:])
+print("\n".join(block).rstrip("\n"))
+PY2
+  [ -s "$LIVE_BODY_SCRIPT" ] || fail "could not extract the live-body step script from the workflow"
+}
+
+# Fake `gh api` that answers with numbered response files: call n reads
+# <dir>/n.json, repeating the last file once the sequence is exhausted. A file
+# holding the single word FAIL makes that call exit 1 like an API outage.
+install_fake_gh() {
+  local fakebin=$1
+  cat > "$fakebin/gh" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_FAKE_LOG"
+count=$(cat "$GH_FAKE_COUNT" 2>/dev/null || printf 0)
+count=$((count + 1))
+printf '%s\n' "$count" > "$GH_FAKE_COUNT"
+last=$(ls "$GH_FAKE_RESPONSES" | sed 's/\.json$//' | sort -n | tail -1)
+[ "$count" -le "$last" ] || count=$last
+file="$GH_FAKE_RESPONSES/$count.json"
+if [ "$(cat "$file")" = FAIL ]; then
+  printf 'gh: HTTP 503 unavailable\n' >&2
+  exit 1
+fi
+cat "$file"
+SH
+  chmod +x "$fakebin/gh"
+}
+
+# run_live_body_step <case> <attempts> <response-body>... ; sets STEP_RC,
+# STEP_OUTPUT (stdout+stderr), STEP_BODY (the body= output GitHub would pass
+# on, or the literal string NONE when the step emitted an empty body), and
+# STEP_CALLS (how many times gh was invoked).
+run_live_body_step() {
+  local case_dir=$1 attempts=$2 fakebin n=0 body
+  shift 2
+  case_dir="$TMP_ROOT/$case_dir"
+  mkdir -p "$case_dir/responses"
+  fakebin=$(fm_fakebin "$case_dir")
+  install_fake_gh "$fakebin"
+  for body in "$@"; do
+    n=$((n + 1))
+    if [ "$body" = FAIL ]; then
+      printf 'FAIL\n' > "$case_dir/responses/$n.json"
+    else
+      jq -n --arg body "$body" '{number: 3006, body: $body}' > "$case_dir/responses/$n.json"
+    fi
+  done
+  : > "$case_dir/output"
+  : > "$case_dir/gh.log"
+  STEP_RC=0
+  STEP_OUTPUT=$(
+    PATH="$fakebin:$PATH" GITHUB_OUTPUT="$case_dir/output" \
+      GH_FAKE_RESPONSES="$case_dir/responses" GH_FAKE_LOG="$case_dir/gh.log" \
+      GH_FAKE_COUNT="$case_dir/gh.count" \
+      PR_REPO="$PR_REPO" PR_NUMBER="$PR_NUMBER" PR_HEAD_SHA="$NEW_SHA" \
+      NM_LIVE_BODY_ATTEMPTS="$attempts" NM_LIVE_BODY_INTERVAL=0 \
+      bash "$LIVE_BODY_SCRIPT" 2>&1
+  ) || STEP_RC=$?
+  STEP_CALLS=$(cat "$case_dir/gh.count" 2>/dev/null || printf 0)
+  STEP_BODY=$(python3 - "$case_dir/output" <<'PY2'
+import sys
+
+lines = open(sys.argv[1], encoding="utf-8").read().split("\n")
+i = 0
+while i < len(lines):
+    if lines[i].startswith("body<<"):
+        delimiter = lines[i][len("body<<"):]
+        j = i + 1
+        while j < len(lines) and lines[j] != delimiter:
+            j += 1
+        if j >= len(lines):
+            sys.exit("body heredoc output never closed")
+        value = "\n".join(lines[i + 1:j])
+        print(value if value else "NONE")
+        sys.exit(0)
+    if lines[i].startswith("body="):
+        value = lines[i][len("body="):]
+        print(value if value else "NONE")
+        sys.exit(0)
+    i += 1
+sys.exit("the step emitted no body output")
+PY2
+  ) || fail "live-body step wrote no usable GITHUB_OUTPUT body"
+}
+
+assert_gh_read_this_pr() {
+  local calls
+  calls=$(sort -u "$TMP_ROOT/$1/gh.log")
+  [ "$calls" = "api repos/$PR_REPO/pulls/$PR_NUMBER" ] \
+    || fail "live-body step did not read this PR through the API (saw: $calls)"
+}
+
+test_live_body_step_hands_over_an_already_bound_body() {
+  local rc output
+  run_live_body_step bound 12 "$(bound_body "$NEW_SHA")"
+  expect_code 0 "$STEP_RC" "live-body step failed on an already bound body"
+  assert_gh_read_this_pr bound
+  [ "$STEP_CALLS" = 1 ] || fail "live-body step kept polling a body that already bound the head ($STEP_CALLS calls)"
+  rc=0
+  output=$(run_verifier "$STEP_BODY" "$NEW_SHA") || rc=$?
+  expect_code 0 "$rc" "pinned verifier rejected the live body the step handed over"
+  assert_contains "$output" "Found structurally compliant pipeline step attestation." \
+    "handed-over live body was not judged compliant"
+  pass "live-body step hands an already bound body to the verifier after one read"
+}
+
+test_live_body_step_waits_for_the_pipeline_rebind() {
+  local stale rc output
+  stale=$(bound_body "$OLD_SHA")
+  rc=0
+  output=$(run_verifier "$stale" "$NEW_SHA") || rc=$?
+  [ "$rc" -ne 0 ] || fail "the stale payload body should fail against the pushed head"
+  run_live_body_step rebind 12 "$stale" "$stale" "$(bound_body "$NEW_SHA")"
+  expect_code 0 "$STEP_RC" "live-body step failed while waiting for the rebind"
+  assert_gh_read_this_pr rebind
+  [ "$STEP_CALLS" = 3 ] || fail "live-body step did not stop polling once the body bound the head ($STEP_CALLS calls)"
+  assert_contains "$STEP_OUTPUT" "does not attest head $NEW_SHA yet (attempt 1/12)" \
+    "live-body step did not report the stale body it waited through"
+  rc=0
+  output=$(run_verifier "$STEP_BODY" "$NEW_SHA") || rc=$?
+  expect_code 0 "$rc" "pinned verifier rejected the rebound live body"
+  assert_contains "$output" "Found structurally compliant pipeline step attestation." \
+    "rebound live body was not judged compliant"
+  pass "live-body step waits through the stale snapshot until the body binds the pushed head"
+}
+
+test_live_body_step_never_passes_an_unbound_body() {
+  local stale rc output
+  stale=$(bound_body "$OLD_SHA")
+  run_live_body_step unbound 3 "$stale"
+  expect_code 0 "$STEP_RC" "live-body step must leave the verdict to the verifier"
+  [ "$STEP_CALLS" = 3 ] || fail "live-body step did not spend exactly its attempt budget ($STEP_CALLS calls)"
+  [ "$STEP_BODY" = "$stale" ] || fail "live-body step did not hand over the last live body it read"
+  rc=0
+  output=$(run_verifier "$STEP_BODY" "$NEW_SHA") || rc=$?
+  [ "$rc" -ne 0 ] || fail "a body that never bound the pushed head passed the gate"
+  assert_contains "$output" "$OLD_SHA" "unbound failure did not name the attestation head"
+  assert_contains "$output" "$NEW_SHA" "unbound failure did not name the pushed head"
+  pass "live-body step exhausts its budget and the verifier still rejects an unbound body"
+}
+
+test_live_body_step_falls_back_to_the_payload_when_the_api_is_down() {
+  local event rc output
+  run_live_body_step outage 2 FAIL
+  expect_code 0 "$STEP_RC" "live-body step must not turn an API outage into a verdict"
+  [ "$STEP_CALLS" = 2 ] || fail "live-body step did not retry the API before falling back ($STEP_CALLS calls)"
+  [ "$STEP_BODY" = NONE ] || fail "live-body step handed over a body it never read"
+  assert_contains "$STEP_OUTPUT" "::warning::" "API fallback was silent"
+  event="$TMP_ROOT/outage/event.json"
+  jq -n --arg body "$(bound_body "$NEW_SHA")" --arg sha "$NEW_SHA" \
+    '{pull_request: {number: 3006, body: $body, head: {sha: $sha}, user: {login: "regression"}}}' > "$event"
+  rc=0
+  output=$(PR_BODY="" GITHUB_EVENT_PATH="$event" PR_HEAD_SHA="$NEW_SHA" python3 "$VERIFY" 2>&1) || rc=$?
+  expect_code 0 "$rc" "pinned verifier did not fall back to the event payload body"
+  assert_contains "$output" "Found structurally compliant pipeline step attestation." \
+    "payload fallback was not judged"
+  pass "live-body step falls back to the event payload body when the API cannot be read"
+}
+
 fetch_shared_verifier
+extract_live_body_script
 test_matching_head_and_completed_steps_pass
 test_mismatched_head_fails_with_both_shas
 test_missing_head_fails
+test_live_body_step_hands_over_an_already_bound_body
+test_live_body_step_waits_for_the_pipeline_rebind
+test_live_body_step_never_passes_an_unbound_body
+test_live_body_step_falls_back_to_the_payload_when_the_api_is_down


### PR DESCRIPTION
## Intent

Publish the confirmed large-fleet snapshot correction in one upstream PR referencing https://github.com/kunchenguid/firstmate/issues/2629 (not duplicate #2613). Ensure every bin/fm-fleet-snapshot.sh handoff that passes unbounded backlog, task, child-home summary, or fleet-wide derived aggregates to jq avoids Linux argv-size limits through the existing trap-cleaned file/--slurpfile path, while preserving bounded scalar --argjson uses. Preserve jq semantics and normal-sized output. Include executable oversized regressions where an ordinary source backlog comfortably beyond Linux MAX_ARGSTRLEN succeeds, one child summary falls in the 131073-262144 byte window, and aggregate current-home data exceeds the cap; prove normal output compatibility without source-text assertions. Validate focused fleet snapshot, fleet view, and bearings behavior, all oversized regressions, documentation audience checks if prose changes, exact bin/fm-lint.sh, and the full no-mistakes pipeline. Preserve the fix while reconciling current upstream changes through no-mistakes. Do not include private data, state, config, .env, project content, credentials, local paths, unrelated changes, or agent co-authorship. Push only this task branch through no-mistakes to the authorized public fork Omar-Nawaf/firstmate, update the existing PR against kunchenguid/firstmate:main, and never merge.

## What Changed

- `bin/fm-fleet-snapshot.sh` now stages every unbounded JSON value — backlog, task rows, scout reports, main inventory, each sampled child-home summary, and the fleet-wide `secondmate_current`/`secondmate_landed` aggregates — into a `mktemp -d` scratch directory (cleaned by an `EXIT` trap, with `INT`/`TERM`/`HUP` routed through it) and binds them with `--slurpfile` (`$x_in[0] as $x`) so jq program bodies are unchanged and bounded scalars keep their `--argjson` form. Per-mate records accumulate in a JSONL file instead of a growing `--argjson` array, and a failed per-mate record build now fails the snapshot with `registered secondmate aggregation failed` rather than silently dropping the mate. This removes the `Argument list too long` failure on large fleets reported in #2629.
- `tests/fm-fleet-snapshot-view.test.sh` adds four regressions: a 400-row backlog whose JSON exceeds 131072 bytes snapshots in both `--json` and `--secondmate-home-summary` modes; a child summary between the argv cap and the 262144-byte acceptance guard is carried intact (520 landed rows); three under-cap child summaries whose combined aggregate exceeds the cap still roll up (600 landed rows); and a wrapped `jq` that fails one record build makes the snapshot exit non-zero with no partial output. All assert on output shape and byte sizes, not source text.
- `.github/workflows/ci.yml` raises the expected snapshot/fleet-view test count from 15 to 19; `tests/fm-bearings-snapshot.test.sh` adds `mktemp` and `rm` to the perl-fallback minimal toolbin; the script header documents the TMPDIR scratch write as the only write under its read-only contract.

Fixes #2629

## Risk Assessment

✅ Low: The fix round verifiably restores the loud-failure invariant on every per-mate construction/append step with a regression test that fails on the pre-fix code, the argv-cap staging is mechanically uniform across all unbounded handoffs with jq semantics preserved, and the three required oversized regressions plus CI count/toolbin updates are consistent with the intent.

## Testing

Exercised the focused snapshot/fleet-view and bearings test files (all pass, counts match the CI bump to 19/42), proved the four new regression tests fail against the base-commit script and pass on the target, and reproduced the user-facing failure end-to-end: at base, fm-fleet-snapshot.sh aborts with "jq: Argument list too long" on a 400-row backlog in both output modes and silently reports registered mates as unknown when a child summary sits in the 131073–262144 window or the fleet aggregate crosses the cap, while the target returns complete records (400 backlog rows, 520 landed for the window child, 8 structured mates for the aggregate-only case). Normal-sized output is identical between base and target after normalizing timestamps, the fleet home is untouched, killed runs leave no TMPDIR scratch, and fm-fleet-view/fm-bearings render the oversized homes correctly. This is a CLI tool with no graphical surface, so the fleet-view/bearings text renders are the reviewer-visible artifacts; lint, docs audience checks, push/PR, and the full pipeline are owned by the outer executor's other phases and were not run here.

<details>
<summary>Evidence: Before/after argv-cap reproduction transcript (base d63b0e2 vs target 4a8a77e)</summary>

Source: [Before/after argv-cap reproduction transcript (base d63b0e2 vs target 4a8a77e)](https://github.com/Omar-Nawaf/firstmate/blob/8b87bd3b3e0b1e5abf9bd519499efe7a5c1ffd07/.no-mistakes/evidence/fm/firstmate-fleet-snapshot-upstream-pr/argv-cap-before-after.txt)

```text
== Environment ==
jq: jq-1.8.2   bash: 5.3.9(1)-release   MAX_ARG_STRLEN=131072 bytes
base script : git show d63b0e2feeafd5a91e6f229ab9510d6d7f5ed17d:bin/fm-fleet-snapshot.sh (copied over a snapshot of the current bin/ dir)
target script: /home/omarn/.no-mistakes/worktrees/79daa7753079/01M10TA820DXA5A05CFFNSH84W/bin/fm-fleet-snapshot.sh @ 4a8a77e
FM_ROOT_OVERRIDE is pinned to one fixture root for every run (base and target)

== A. Ordinary source backlog comfortably beyond MAX_ARG_STRLEN (400 queued captain-hold rows) ==
  fixture: data/backlog.md = 90833 bytes, 400 rows
  [base] fm-fleet-snapshot.sh --json
    rc=1  stdout=0 bytes
    stderr (first 6 lines):
      | /tmp/fm-snapshot-evidence.bAFqsw/base-bin/fm-fleet-snapshot.sh: line 643: /home/omarn/.local/bin/jq: Argument list too long
      | fm-fleet-snapshot: main inventory summary failed
    stderr lines: 2  occurrences of 'Argument list too long': 1
  [target] fm-fleet-snapshot.sh --json
    rc=0  stdout=535372 bytes
    stderr: (empty)
    target parsed .backlog size: 386803 bytes (> 131072)
    target summary: {"schema":"fm-fleet-snapshot.v1","backlog_records":400,"captain_actionable":400,"main_inventory":{"valid":true,"reason":null,"orphan_in_flight":[],"unstructured_current_count":0}}
  [base] fm-fleet-snapshot.sh --secondmate-home-summary
    rc=1  stdout=0 bytes
    stderr (first 6 lines):
      | /tmp/fm-snapshot-evidence.bAFqsw/base-bin/fm-fleet-snapshot.sh: line 671: /home/omarn/.local/bin/jq: Argument list too long
      | fm-fleet-snapshot: secondmate home summary failed
    stderr lines: 2  occurrences of 'Argument list too long': 1
  [target] fm-fleet-snapshot.sh --secondmate-home-summary
    rc=0  stdout=25089 bytes
    stderr: (empty)
    target summary: {"state":"captain_decision","valid":true,"counts":{"active_children":0,"decisions_open":400,"holds":400,"queued":400,"landed":0,"endpoints":0},"decisions_open":20}
    read-only check: fleet home files unchanged after both target runs (md5 listing identical)
    scratch check: fm-fleet-snapshot.* dirs left in TMPDIR after runs = 0

== B. One registered child-home summary between the argv cap and the 262144-byte acceptance guard (520 landed rows, FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME=0) ==
  child summary (target, FM_HOME=<mate>): rc=0 bytes=198039  -> in the 131073..262144 window? yes
  child's own parsed backlog JSON: 705331 bytes (OVER the cap) -- when over the cap, at base the child summary run itself dies before the parent handoff is reached
  [base] FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME=0 fm-fleet-snapshot.sh --json
    rc=0  stdout=4215 bytes
    stderr: (empty)
    base records (child lost silently; the child's stderr is discarded by the parent):
      {"id":"bigmate","selected":"unknown","state":"unknown","reason":"structured home snapshot failed","landed":0}
  [target] FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME=0 fm-fleet-snapshot.sh --json
    rc=0  stdout=498358 bytes
    stderr: (empty)
    target records:
      {"id":"bigmate","selected":"structured-home","state":"no_active_work","reason":null,"landed":520}
    target record counts: {"active_children":0,"decisions_open":0,"holds":0,"queued":0,"landed":520,"endpoints":0}  secondmate_landed.records=520  record .landed size=153294 bytes
    scratch check: fm-fleet-snapshot.* dirs left in TMPDIR after runs = 0

== C. Fleet aggregate over the cap, test-fixture shape: 3 registered mates x 200 landed ==
  each child's own parsed backlog JSON: 271494 bytes (OVER the cap) -- when over the cap, base loses the children before aggregating
  [base] FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME=0 fm-fleet-snapshot.sh --json
    rc=0  stdout=8944 bytes
    stderr: (empty)
    base records:
      {"id":"aggmate1","selected":"unknown","state":"unknown","reason":"structured home snapshot failed","landed":0}
      {"id":"aggmate2","selected":"unknown","state":"unknown","reason":"structured home snapshot failed","landed":0}
      {"id":"aggmate3","selected":"unknown","state":"unknown","reason":"structured home snapshot failed","landed":0}
  [target] FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME=0 fm-fleet-snapshot.sh --json
    rc=0  stdout=582964 bytes
    stderr: (empty)
    target records:
      {"id":"aggmate1","selected":"structured-home","state":"no_active_work","reason":null,"landed":200}
      {"id":"aggmate2","selected":"structured-home","state":"no_active_work","reason":null,"landed":200}
      {"id":"aggmate3","selected":"structured-home","state":"no_active_work","reason":null,"landed":200}
    target: largest single record=60574 bytes (< 131072); .secondmate_current=182657 bytes (> 131072)
    target: {"records":3,"structured":3,"landed_total":600,"secondmate_landed":600,"shown":3,"truncated":0}
    scratch check: fm-fleet-snapshot.* dirs left in TMPDIR after runs = 0

== C2. Aggregate-only window: 8 registered mates x 50 landed, each child backlog AND summary under the cap, combined aggregate over it ==
  each child's own parsed backlog JSON: 67941 bytes (under the cap) -- under the cap means base children summarize fine and only the aggregate handoff is over
  each child summary: 19591 bytes (under the cap)
  [base] FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME=0 fm-fleet-snapshot.sh --json
    rc=1  stdout=0 bytes
    stderr (first 6 lines):
      | /tmp/fm-snapshot-evidence.bAFqsw/base-bin/fm-fleet-snapshot.sh: line 1352: /home/omarn/.local/bin/jq: Argument list too long
      | jq: invalid JSON text passed to --argjson
      | Use jq --help for help with command-line options,
      | or see the jq manpage, or online docs at https://jqlang.org
      | jq: invalid JSON text passed to --argjson
      | Use jq --help for help with command-line options,
    stderr lines: 8  occurrences of 'Argument list too long': 1
    base records:
  [target] FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME=0 fm-fleet-snapshot.sh --json
    rc=0  stdout=406657 bytes
    stderr: (empty)
    target records:
      {"id":"agg5mate1","selected":"structured-home","state":"no_active_work","reason":null,"landed":50}
      {"id":"agg5mate2","selected":"structured-home","state":"no_active_work","reason":null,"landed":50}
      {"id":"agg5mate3","selected":"structured-home","state":"no_active_work","reason":null,"landed":50}
      {"id":"agg5mate4","selected":"structured-home","state":"no_active_work","reason":null,"landed":50}
      {"id":"agg5mate5","selected":"structured-home","state":"no_active_work","reason":null,"landed":50}
      {"id":"agg5mate6","selected":"structured-home","state":"no_active_work","reason":null,"landed":50}
      {"id":"agg5mate7","selected":"structured-home","state":"no_active_work","reason":null,"landed":50}
      {"id":"agg5mate8","selected":"structured-home","state":"no_active_work","reason":null,"landed":50}
    target: largest single record=16275 bytes (< 131072); .secondmate_current=131967 bytes (> 131072); secondmate_landed.records=400
    scratch check: fm-fleet-snapshot.* dirs left in TMPDIR after runs = 0

== D. Normal-sized fleet: base vs target output must match (timestamps/ages normalized) ==
  [base] fm-fleet-snapshot.sh --json
    rc=0  stdout=16057 bytes
    stderr: (empty)
  [target] fm-fleet-snapshot.sh --json
    rc=0  stdout=16057 bytes
    stderr: (empty)
    normalized output diff base vs target (--json): IDENTICAL (510 lines)
  [base] fm-fleet-snapshot.sh --secondmate-home-summary
    rc=0  stdout=2778 bytes
    stderr: (empty)
  [target] fm-fleet-snapshot.sh --secondmate-home-summary
    rc=0  stdout=2778 bytes
    stderr: (empty)
    normalized output diff base vs target (--secondmate-home-summary): IDENTICAL (122 lines)
    target raw JSON kept at normal-fleet-target-raw.json: {"schema":"fm-fleet-snapshot.v1","backlog":5,"tasks":1,"mates":1,"landed":3}

== E. Human renderers over the oversized homes (target) ==
  fm-fleet-view.sh (400-row backlog home): rc=0, 417 lines -> fleet-view-oversized-backlog.txt
  fm-fleet-view.sh (3-mate aggregate home): rc=0, 16 lines -> fleet-view-oversized-aggregate.txt
  fm-bearings-snapshot.sh (400-row backlog home): rc=0, 41 lines -> bearings-oversized-backlog.txt
  fm-bearings-snapshot.sh (3-mate aggregate home): rc=0, 34 lines -> bearings-oversized-aggregate.txt
  fm-bearings-snapshot.sh (normal fleet home): rc=0, 32 lines -> bearings-normal-fleet.txt

== F. Scratch directory cleanup when the snapshot is killed mid-run (SIGTERM via timeout 1s on the aggregate home) ==
  rc=124 (124 = killed by timeout)  fm-fleet-snapshot.* dirs left in TMPDIR = 0

== done ==
```
</details>
<details>
<summary>Evidence: Key before/after results</summary>

```text
base d63b0e2 vs target 4a8a77e (jq 1.8.2, Linux MAX_ARG_STRLEN=131072)
A 400-row backlog (.backlog JSON 386,803 B): base --json rc=1 "jq: Argument list too long" (main inventory summary failed); --secondmate-home-summary rc=1 same. target: rc=0, 400 records, main_inventory.valid=true, summary counts.queued=400; fleet home unchanged; 0 scratch dirs left
B child summary 198,039 B (in 131073..262144): base -> mate unknown / "structured home snapshot failed", landed 0; target -> structured-home, no_active_work, landed 520, secondmate_landed 520
C 3 mates x 200 (aggregate 182,657 B, max record 60,574 B): base -> 3 unknown mates; target -> 3 structured-home, 600 landed
C2 8 mates x 50 (each child summary 19,591 B, aggregate 131,967 B): base rc=1 "line 1352: jq: Argument list too long"; target rc=0, 8 structured-home, 400 landed
D normal fleet: base vs target --json and --secondmate-home-summary normalized output IDENTICAL
F SIGTERM mid-run: rc=124, 0 fm-fleet-snapshot.* scratch dirs left in TMPDIR
```
</details>
<details>
<summary>Evidence: New regression tests run in isolation against base vs target script</summary>

Source: [New regression tests run in isolation against base vs target script](https://github.com/Omar-Nawaf/firstmate/blob/8b87bd3b3e0b1e5abf9bd519499efe7a5c1ffd07/.no-mistakes/evidence/fm/firstmate-fleet-snapshot-upstream-pr/regression-tests-base-vs-target.txt)

```text
# The four new tests from tests/fm-fleet-snapshot-view.test.sh, each run in isolation against
# (a) bin/fm-fleet-snapshot.sh at base commit d63b0e2 and (b) at target commit 4a8a77e.
# Every other file (bin/ libs, tests/) is identical between the two runs.

== base (d63b0e2) ==
FAIL test_oversized_backlog_survives_argv_cap -> not ok - oversized backlog snapshot failed (rc=1): /tmp/fm-regress-base.P07nHt/base/bin/fm-fleet-snapshot.sh: line 643: /home/omarn/.local/bin/jq: Argument list too long fm-fleet-snapshot: main inventory summary failed 
FAIL test_oversized_secondmate_summary_survives_argv_cap -> not ok - fixture child summary landed roll-up is only 3 bytes; it must exceed 131072 to exercise the guard window 
FAIL test_secondmate_aggregate_over_argv_cap_survives -> not ok - fixture fleet aggregate is only 4646 bytes; it must exceed 131072 to exercise the cap 
PASS test_secondmate_record_build_failure_fails_loudly -> ok - a failed per-mate record build fails the snapshot instead of dropping the mate

== target (4a8a77e) ==
PASS test_oversized_backlog_survives_argv_cap -> ok - a backlog larger than the argv cap still snapshots in both output modes
PASS test_oversized_secondmate_summary_survives_argv_cap -> ok - a child summary between the argv cap and the byte guard still snapshots
PASS test_secondmate_aggregate_over_argv_cap_survives -> ok - a fleet aggregate larger than the argv cap still snapshots
PASS test_secondmate_record_build_failure_fails_loudly -> ok - a failed per-mate record build fails the snapshot instead of dropping the mate
```
</details>
<details>
<summary>Evidence: Reproduction script (exact fixtures and commands)</summary>

Source: [Reproduction script (exact fixtures and commands)](https://github.com/Omar-Nawaf/firstmate/blob/8b87bd3b3e0b1e5abf9bd519499efe7a5c1ffd07/.no-mistakes/evidence/fm/firstmate-fleet-snapshot-upstream-pr/argv-cap-before-after.sh)

```text
#!/usr/bin/env bash
# Evidence script: reproduce the Linux argv-cap (MAX_ARG_STRLEN=131072) failure in
# bin/fm-fleet-snapshot.sh at the base commit and show the target commit surviving
# the same fixtures, then prove normal-sized output is identical (modulo
# observation timestamps) between base and target.
set -u
ROOT=${ROOT:?}; EVID=${EVID:?}; BASE=${BASE:?}
SCRATCH=$(mktemp -d "${TMPDIR:-/tmp}/fm-snapshot-evidence.XXXXXX")
trap 'rm -rf "$SCRATCH"' EXIT
export TMPDIR="$SCRATCH/tmp"; mkdir -p "$TMPDIR"
# Same fleet root for base and target runs; keeps fixture homes outside either script copy's repo boundary.
export FM_ROOT_OVERRIDE="$SCRATCH/fixture-root"; mkdir -p "$FM_ROOT_OVERRIDE"
T="$EVID/argv-cap-before-after.txt"; : > "$T"
say() { printf '%s\n' "$*" | tee -a "$T"; }

mkdir -p "$SCRATCH/base-bin"
cp -R "$ROOT/bin/." "$SCRATCH/base-bin/"
git -C "$ROOT" show "$BASE:bin/fm-fleet-snapshot.sh" > "$SCRATCH/base-bin/fm-fleet-snapshot.sh"
chmod +x "$SCRATCH/base-bin/fm-fleet-snapshot.sh"
BASE_SNAP="$SCRATCH/base-bin/fm-fleet-snapshot.sh"
NEW_SNAP="$ROOT/bin/fm-fleet-snapshot.sh"

FAKEBIN="$SCRATCH/fakebin"; mkdir -p "$FAKEBIN"
cat > "$FAKEBIN/no-mistakes" <<'SH'
#!/usr/bin/env bash
exit 0
SH
cat > "$FAKEBIN/tmux" <<'SH'
#!/usr/bin/env bash
set -u
case "${1:-}" in
  list-windows) sed -n 's/^window=[^:]*://p' "${FM_HOME:?}"/state/*.meta 2>/dev/null ;;
  display-message) case "$*" in *pane_current_command*) printf 'codex\n' ;; *) printf '%%1\n' ;; esac ;;
  capture-pane) printf 'all quiet\n> \n' ;;
esac
exit 0
SH
chmod +x "$FAKEBIN"/*
export PATH="$FAKEBIN:$PATH"

make_home() { local h="$SCRATCH/homes/$1"; mkdir -p "$h/state" "$h/data" "$h/projects" "$h/config"; printf '%s\n' "$h"; }

write_oversized_backlog() {  # <home> <rows>
  local home=$1 rows=$2 i reason
  reason="captain must choose between the long-standing option A and the equally"
  reason="$reason long-standing option B before this queued item can proceed"
  {
    printf '## In flight\n\n## Queued\n'
    i=1
    while [ "$i" -le "$rows" ]; do
      printf -- '- [ ] hold-%03d - Captain decision %03d (repo: alpha) (kind: captain) (hold: %s) (hold-kind: captain)\n' "$i" "$i" "$reason"
      i=$((i + 1))
    done
    printf '\n## Done\n'
  } > "$home/data/backlog.md"
}

write_registered_mate() {  # <parent-home> <mate-id> <mate-home> <landed-count>
  local home=$1 id=$2 mate=$3 count=$4 i
  mkdir -p "$mate/data" "$mate/state" "$mate/config" "$mate/projects" "$mate/bin"
  printf '# Firstmate fixture\n' > "$mate/AGENTS.md"
  printf '%s\n' "$id" > "$mate/.fm-secondmate-home"
  printf -- '- %s - delegated domain (home: %s; scope: delegated work; projects: alpha; added 2026-07-11)\n' "$id" "$mate" >> "$home/data/secondmates.md"
  {
    printf '## In flight\n\n## Queued\n\n## Done\n'
    i=1
    while [ "$i" -le "$count" ]; do
      printf -- '- [x] %s-landed-%04d - Landed change %04d covering the long-running snapshot pipeline refactor stage %04d of the delegated domain https://github.com/kunchenguid/firstmate/pull/%d (repo: alpha) (kind: ship) (merged 2026-07-01)\n' "$id" "$i" "$i" "$i" "$i"
      i=$((i + 1))
    done
  } > "$mate/data/backlog.md"
}

run_snap() {  # <label> <script> <home> <mode> [VAR=val ...] -> prints rc; writes $SCRATCH/out/<label>.{json,err}
  local label=$1 script=$2 home=$3 mode=$4 rc; shift 4
  mkdir -p "$SCRATCH/out"
  env FM_HOME="$home" "$@" "$script" "$mode" >"$SCRATCH/out/$label.json" 2>"$SCRATCH/out/$label.err"; rc=$?
  printf '%s' "$rc"
}
show() {  # <label> <version> <cmdline> <rc>
  say "  [$2] $3"
  say "    rc=$4  stdout=$(LC_ALL=C wc -c <"$SCRATCH/out/$1.json" | tr -d ' ') bytes"
  if [ -s "$SCRATCH/out/$1.err" ]; then
    say "    stderr (first 6 lines):"; head -n 6 "$SCRATCH/out/$1.err" | sed 's/^/      | /' | tee -a "$T"
    say "    stderr lines: $(wc -l <"$SCRATCH/out/$1.err" | tr -d ' ')  occurrences of 'Argument list too long': $(grep -c 'Argument list too long' "$SCRATCH/out/$1.err")"
  else
    say "    stderr: (empty)"
  fi
}
mates() {  # <label>: one line per secondmate_current record
  jq -c '.secondmate_current.records[] | {id, selected:.provenance.selected, state:.current.state, reason:.current.reason, landed:(.landed|length)}' "$SCRATCH/out/$1.json" | sed 's/^/      /' | tee -a "$T"
}
mate_backlog_bytes() {  # <mate-home>: size of the mate's own parsed backlog JSON as the script carries it (pretty-printed jq output; target script)
  env FM_HOME="$1" "$NEW_SNAP" --json 2>/dev/null | jq '.backlog' | LC_ALL=C wc -c | tr -d ' '
}
leftovers() { find "$TMPDIR" -maxdepth 1 -name 'fm-fleet-snapshot.*' | wc -l | tr -d ' '; }
capcmp() { [ "$1" -le 131072 ] && echo "under the cap" || echo "OVER the cap"; }

say "== Environment =="
say "jq: $(jq --version)   bash: $BASH_VERSION   MAX_ARG_STRLEN=$(( $(getconf PAGE_SIZE) * 32 )) bytes"
say "base script : git show $BASE:bin/fm-fleet-snapshot.sh (copied over a snapshot of the current bin/ dir)"
say "target script: $NEW_SNAP @ $(git -C "$ROOT" rev-parse --short HEAD)"
say "FM_ROOT_OVERRIDE is pinned to one fixture root for every run (base and target)"
say ""

########## Scenario A: oversized source backlog ##########
say "== A. Ordinary source backlog comfortably beyond MAX_ARG_STRLEN (400 queued captain-hold rows) =="
A=$(make_home oversized-backlog); write_oversized_backlog "$A" 400
say "  fixture: data/backlog.md = $(LC_ALL=C wc -c <"$A/data/backlog.md" | tr -d ' ') bytes, $(grep -c '^- \[ \]' "$A/data/backlog.md") rows"
before=$(find "$A" -type f -exec md5sum {} + | sort)
rc=$(run_snap A-base-json "$BASE_SNAP" "$A" --json); show A-base-json base "fm-fleet-snapshot.sh --json" "$rc"
rc=$(run_snap A-new-json "$NEW_SNAP" "$A" --json); show A-new-json target "fm-fleet-snapshot.sh --json" "$rc"
say "    target parsed .backlog size: $(jq -c '.backlog' "$SCRATCH/out/A-new-json.json" | LC_ALL=C wc -c | tr -d ' ') bytes (> 131072)"
say "    target summary: $(jq -c '{schema, backlog_records:(.backlog.records|length), captain_actionable:([.backlog.records[]|select(.captain_actionable==true)]|length), main_inventory}' "$SCRATCH/out/A-new-json.json")"
rc=$(run_snap A-base-summary "$BASE_SNAP" "$A" --secondmate-home-summary); show A-base-summary base "fm-fleet-snapshot.sh --secondmate-home-summary" "$rc"
rc=$(run_snap A-new-summary "$NEW_SNAP" "$A" --secondmate-home-summary); show A-new-summary target "fm-fleet-snapshot.sh --secondmate-home-summary" "$rc"
say "    target summary: $(jq -c '{state, valid, counts, decisions_open:(.decisions_open|length)}' "$SCRATCH/out/A-new-summary.json")"
after=$(find "$A" -type f -exec md5sum {} + | sort)
if [ "$before" = "$after" ]; then say "    read-only check: fleet home files unchanged after both target runs (md5 listing identical)"; else say "    read-only check: FLEET HOME CHANGED"; diff <(printf '%s\n' "$before") <(printf '%s\n' "$after") | tee -a "$T"; fi
say "    scratch check: fm-fleet-snapshot.* dirs left in TMPDIR after runs = $(leftovers)"
say ""

########## Scenario B: one child summary in the 131073..262144 window ##########
say "== B. One registered child-home summary between the argv cap and the 262144-byte acceptance guard (520 landed rows, FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME=0) =="
B=$(make_home big-mate-parent); printf '## In flight\n\n## Queued\n\n## Done\n' > "$B/data/backlog.md"
BM="$SCRATCH/homes/big-mate-home"; write_registered_mate "$B" bigmate "$BM" 520
rc=$(run_snap B-child-summary "$NEW_SNAP" "$BM" --secondmate-home-summary FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME=0)
cb=$(LC_ALL=C wc -c <"$SCRATCH/out/B-child-summary.json" | tr -d ' ')
say "  child summary (target, FM_HOME=<mate>): rc=$rc bytes=$cb  -> in the 131073..262144 window? $([ "$cb" -gt 131072 ] && [ "$cb" -le 262144 ] && echo yes || echo NO)"
cbb=$(mate_backlog_bytes "$BM"); say "  child's own parsed backlog JSON: $cbb bytes ($(capcmp "$cbb")) -- when over the cap, at base the child summary run itself dies before the parent handoff is reached"
rc=$(run_snap B-base-json "$BASE_SNAP" "$B" --json FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME=0 FM_SNAPSHOT_SECONDMATE_TIMEOUT=60); show B-base-json base "FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME=0 fm-fleet-snapshot.sh --json" "$rc"
say "    base records 

... [2169 bytes truncated] ...

| LC_ALL=C wc -c | tr -d ' ') bytes (> 131072)"
say "    target: $(jq -c '{records:(.secondmate_current.records|length), structured:([.secondmate_current.records[]|select(.provenance.selected=="structured-home")]|length), landed_total:([.secondmate_current.records[]|.landed|length]|add), secondmate_landed:(.secondmate_landed.records|length), shown:.secondmate_current.shown, truncated:.secondmate_current.truncated}' "$SCRATCH/out/C-new-json.json")"
say "    scratch check: fm-fleet-snapshot.* dirs left in TMPDIR after runs = $(leftovers)"
say ""

########## Scenario C2: aggregate over the cap while every child fits under it at base ##########
say "== C2. Aggregate-only window: 8 registered mates x 50 landed, each child backlog AND summary under the cap, combined aggregate over it =="
C2=$(make_home fleet-agg5-parent); printf '## In flight\n\n## Queued\n\n## Done\n' > "$C2/data/backlog.md"
for n in 1 2 3 4 5 6 7 8; do write_registered_mate "$C2" "agg5mate$n" "$SCRATCH/homes/fleet-agg5-mate-$n" 50; done
cbb=$(mate_backlog_bytes "$SCRATCH/homes/fleet-agg5-mate-1"); say "  each child's own parsed backlog JSON: $cbb bytes ($(capcmp "$cbb")) -- under the cap means base children summarize fine and only the aggregate handoff is over"
csb=$(env FM_HOME="$SCRATCH/homes/fleet-agg5-mate-1" FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME=0 "$NEW_SNAP" --secondmate-home-summary 2>/dev/null | LC_ALL=C wc -c | tr -d ' '); say "  each child summary: $csb bytes ($(capcmp "$csb"))"
rc=$(run_snap C2-base-json "$BASE_SNAP" "$C2" --json FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME=0 FM_SNAPSHOT_SECONDMATE_TIMEOUT=60); show C2-base-json base "FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME=0 fm-fleet-snapshot.sh --json" "$rc"
say "    base records:"; mates C2-base-json
rc=$(run_snap C2-new-json "$NEW_SNAP" "$C2" --json FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME=0 FM_SNAPSHOT_SECONDMATE_TIMEOUT=60); show C2-new-json target "FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME=0 fm-fleet-snapshot.sh --json" "$rc"
say "    target records:"; mates C2-new-json
say "    target: largest single record=$(jq '[.secondmate_current.records[]|tojson|length]|max' "$SCRATCH/out/C2-new-json.json") bytes (< 131072); .secondmate_current=$(jq -c '.secondmate_current' "$SCRATCH/out/C2-new-json.json" | LC_ALL=C wc -c | tr -d ' ') bytes (> 131072); secondmate_landed.records=$(jq '.secondmate_landed.records|length' "$SCRATCH/out/C2-new-json.json")"
say "    scratch check: fm-fleet-snapshot.* dirs left in TMPDIR after runs = $(leftovers)"
say ""

########## Scenario D: normal-sized output compatibility ##########
say "== D. Normal-sized fleet: base vs target output must match (timestamps/ages normalized) =="
D=$(make_home normal-fleet)
cat > "$D/data/backlog.md" <<'MD'
## In flight
- [ ] ship-task - Ship Task https://github.com/kunchenguid/firstmate/pull/9 (repo: alpha) (kind: ship) (priority: 2) (since 2026-07-07)
  Preserve this detail for bearings.

## Queued
- [ ] queued-task - Queued Task blocked-by: ship-task (repo: alpha) (kind: ship) (since 2026-07-08)
- [ ] hold-001 - Captain decision 001 (repo: alpha) (kind: captain) (hold: pick A or B) (hold-kind: captain)
handoff note without canonical syntax

## Done
- [x] done-task - Done Task https://github.com/kunchenguid/firstmate/pull/7 (repo: alpha) (kind: ship) (merged 2026-07-06)
MD
mkdir -p "$D/projects/alpha-worktree"
printf '%s\n' "window=firstmate:fm-ship-task" "worktree=$D/projects/alpha-worktree" "project=alpha" "harness=codex" "kind=ship" "mode=ship" "yolo=off" "pr=https://github.com/kunchenguid/firstmate/pull/9" > "$D/state/ship-task.meta"
printf 'needs-decision: choose an API shape\n' > "$D/state/ship-task.status"
write_registered_mate "$D" smallmate "$SCRATCH/homes/small-mate-home" 3
norm='walk(if type=="string" and test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$") then "<timestamp>" elif type=="object" and has("age_seconds") then .age_seconds="<age>" else . end)'
for mode in --json --secondmate-home-summary; do
  tag=${mode#--}
  rc1=$(run_snap "D-base-$tag" "$BASE_SNAP" "$D" "$mode" FM_SNAPSHOT_SECONDMATE_TIMEOUT=60); show "D-base-$tag" base "fm-fleet-snapshot.sh $mode" "$rc1"
  rc2=$(run_snap "D-new-$tag" "$NEW_SNAP" "$D" "$mode" FM_SNAPSHOT_SECONDMATE_TIMEOUT=60); show "D-new-$tag" target "fm-fleet-snapshot.sh $mode" "$rc2"
  jq -S "$norm" "$SCRATCH/out/D-base-$tag.json" > "$EVID/normal-fleet-$tag.base.normalized.json"
  jq -S "$norm" "$SCRATCH/out/D-new-$tag.json"  > "$EVID/normal-fleet-$tag.target.normalized.json"
  if diff -u "$EVID/normal-fleet-$tag.base.normalized.json" "$EVID/normal-fleet-$tag.target.normalized.json" > "$EVID/normal-fleet-$tag.diff"; then
    say "    normalized output diff base vs target ($mode): IDENTICAL ($(wc -l <"$EVID/normal-fleet-$tag.target.normalized.json" | tr -d ' ') lines)"; rm -f "$EVID/normal-fleet-$tag.diff"
  else
    say "    normalized output diff base vs target ($mode): DIFFERS -> see normal-fleet-$tag.diff"; head -n 40 "$EVID/normal-fleet-$tag.diff" | tee -a "$T"
  fi
done
cp "$SCRATCH/out/D-new-json.json" "$EVID/normal-fleet-target-raw.json"
say "    target raw JSON kept at normal-fleet-target-raw.json: $(jq -c '{schema, backlog:(.backlog.records|length), tasks:(.tasks|length), mates:(.secondmate_current.records|length), landed:(.secondmate_landed.records|length)}' "$EVID/normal-fleet-target-raw.json")"
say ""

########## Scenario E: human surfaces on the oversized home ##########
say "== E. Human renderers over the oversized homes (target) =="
env FM_HOME="$A" "$ROOT/bin/fm-fleet-view.sh" > "$EVID/fleet-view-oversized-backlog.txt" 2>"$SCRATCH/out/E-view.err"; rc=$?
say "  fm-fleet-view.sh (400-row backlog home): rc=$rc, $(wc -l <"$EVID/fleet-view-oversized-backlog.txt" | tr -d ' ') lines -> fleet-view-oversized-backlog.txt"; [ -s "$SCRATCH/out/E-view.err" ] && sed 's/^/      | /' "$SCRATCH/out/E-view.err" | head -5 | tee -a "$T"
env FM_HOME="$C" FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME=0 FM_SNAPSHOT_SECONDMATE_TIMEOUT=60 "$ROOT/bin/fm-fleet-view.sh" > "$EVID/fleet-view-oversized-aggregate.txt" 2>"$SCRATCH/out/E-view2.err"; rc=$?
say "  fm-fleet-view.sh (3-mate aggregate home): rc=$rc, $(wc -l <"$EVID/fleet-view-oversized-aggregate.txt" | tr -d ' ') lines -> fleet-view-oversized-aggregate.txt"; [ -s "$SCRATCH/out/E-view2.err" ] && sed 's/^/      | /' "$SCRATCH/out/E-view2.err" | head -5 | tee -a "$T"
env FM_HOME="$A" "$ROOT/bin/fm-bearings-snapshot.sh" > "$EVID/bearings-oversized-backlog.txt" 2>"$SCRATCH/out/E-bearings.err"; rc=$?
say "  fm-bearings-snapshot.sh (400-row backlog home): rc=$rc, $(wc -l <"$EVID/bearings-oversized-backlog.txt" | tr -d ' ') lines -> bearings-oversized-backlog.txt"; [ -s "$SCRATCH/out/E-bearings.err" ] && sed 's/^/      | /' "$SCRATCH/out/E-bearings.err" | head -8 | tee -a "$T"
env FM_HOME="$C" FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME=0 FM_SNAPSHOT_SECONDMATE_TIMEOUT=60 "$ROOT/bin/fm-bearings-snapshot.sh" > "$EVID/bearings-oversized-aggregate.txt" 2>"$SCRATCH/out/E-bearings3.err"; rc=$?
say "  fm-bearings-snapshot.sh (3-mate aggregate home): rc=$rc, $(wc -l <"$EVID/bearings-oversized-aggregate.txt" | tr -d ' ') lines -> bearings-oversized-aggregate.txt"; [ -s "$SCRATCH/out/E-bearings3.err" ] && sed 's/^/      | /' "$SCRATCH/out/E-bearings3.err" | head -8 | tee -a "$T"
env FM_HOME="$D" FM_SNAPSHOT_SECONDMATE_TIMEOUT=60 "$ROOT/bin/fm-bearings-snapshot.sh" > "$EVID/bearings-normal-fleet.txt" 2>"$SCRATCH/out/E-bearings2.err"; rc=$?
say "  fm-bearings-snapshot.sh (normal fleet home): rc=$rc, $(wc -l <"$EVID/bearings-normal-fleet.txt" | tr -d ' ') lines -> bearings-normal-fleet.txt"; [ -s "$SCRATCH/out/E-bearings2.err" ] && sed 's/^/      | /' "$SCRATCH/out/E-bearings2.err" | head -8 | tee -a "$T"
say ""

########## Scenario F: trap cleanup on a killed run ##########
say "== F. Scratch directory cleanup when the snapshot is killed mid-run (SIGTERM via timeout 1s on the aggregate home) =="
timeout -s TERM 1 env FM_HOME="$C" FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME=0 FM_SNAPSHOT_SECONDMATE_TIMEOUT=60 "$NEW_SNAP" --json >/dev/null 2>"$SCRATCH/out/F.err"; rc=$?
sleep 1
say "  rc=$rc (124 = killed by timeout)  fm-fleet-snapshot.* dirs left in TMPDIR = $(leftovers)"
say ""
say "== done =="
```
</details>
<details>
<summary>Evidence: tests/fm-fleet-snapshot-view.test.sh output (19 ok)</summary>

Source: [tests/fm-fleet-snapshot-view.test.sh output (19 ok)](https://github.com/Omar-Nawaf/firstmate/blob/8b87bd3b3e0b1e5abf9bd519499efe7a5c1ffd07/.no-mistakes/evidence/fm/firstmate-fleet-snapshot-upstream-pr/fm-fleet-snapshot-view.test.log)

```text
ok - empty fleet snapshot and view use explicit absence markers
ok - fixture snapshot covers task rows, backlog rows, pointers, and stable ordering
ok - a backlog larger than the argv cap still snapshots in both output modes
ok - a child summary between the argv cap and the byte guard still snapshots
ok - a fleet aggregate larger than the argv cap still snapshots
ok - a failed per-mate record build fails the snapshot instead of dropping the mate
ok - main_inventory discloses orphan/unstructured and clears when inventory is consistent
ok - backlog normalization preserves strict roles and resolves every blocker compatibly
ok - snapshot event hints follow reconciled current state
ok - durable fold keeps an open decision past a later unrelated event
ok - a live secondmate endpoint preserves unrelated open decisions
ok - durable captain-held transfer closes the duplicate live status decision
ok - durable fold clears a decision only on a keyed resolution
ok - a completed scout's stale decision surfaces as a report pointer, not pending
ok - a scout still parked at a decision stays pending (terminal clear does not over-fire)
ok - snapshot includes durable scout reports after teardown
ok - snapshot parses tasks-axi rows and respects operational overrides
ok - fleet view renders the snapshot without secondmate peek guidance
ok - fleet view renders secondmate agent liveness
```
</details>
<details>
<summary>Evidence: tests/fm-bearings-snapshot.test.sh output (42 ok)</summary>

Source: [tests/fm-bearings-snapshot.test.sh output (42 ok)](https://github.com/Omar-Nawaf/firstmate/blob/8b87bd3b3e0b1e5abf9bd519499efe7a5c1ffd07/.no-mistakes/evidence/fm/firstmate-fleet-snapshot-upstream-pr/fm-bearings-snapshot.test.log)

```text
ok - Domain Alpha structured state overrides a stale parent Phase 7 event
ok - GNU stat file reads select -c without BSD filesystem-report pollution
ok - parent activity evidence is bounded and disclosed
ok - Bearings excludes a status-only child decision
ok - a structured child captain hold reaches Captain's Call
ok - missing, invalid, unreadable, malformed, and timed-out homes stay explicit unknowns
ok - an oversized secondmate summary retains the strict empty unknown fallback
ok - secondmate and per-home child counts are bounded, disclosed, and explicitly expandable
ok - parent decisions remain untrusted contradiction evidence
ok - parent evidence reconciliation distinguishes matching holds, blocks, and decisions
ok - nonprogressing child states are explicit and inconsistent terminal rows invalidate
ok - registry unavailability and bounded truncation remain explicit
ok - repeated snapshots keep the same current landed baseline and ignore prior reports
ok - default output is bounded, local-only, and marks omitted surfaces
ok - TOON and JSON are parity representations of the same model
ok - landed includes secondmate-managed merges alongside main-home merges
ok - default landed selection balances one dominant home with sparse homes
ok - landed selection refills capacity after sparse homes exhaust
ok - landed selection uses deterministic home order when homes exceed the cap
ok - landed selection preserves deterministic home and internal tie ordering
ok - landed selection handles no landed items
ok - --all-landed keeps the complete global landed output
ok - landed stays bounded with per-home + overall caps and omitted[] disclosure
ok - Bearings keeps a live blocker in structured live state and never converts it to Charted Next queue work
ok - action-free items (working/done/queued/landed) do not leak into Captain's Call
ok - main orphan in-flight stays out of Underway and is disclosed in omitted/gates
ok - main unstructured current is disclosed while structured siblings still project
ok - counterfactual meta clears main inventory warning and projects the live task
ok - mixed secondmate roles, partial state, and captain readiness project independently
ok - main and secondmate captain actionability use the same blocker readiness
ok - a completed scout with decision-like report prose is a pointer, not pending
ok - an authoritative captain hold surfaces end-to-end
ok - current report pointers surface
ok - superseded queued items are dropped by default and restored with --all-queued
ok - --include-prs is the only path that fetches, and it enriches correctly
ok - a partial GitHub failure degrades gracefully
ok - Perl fallback bounds stalled GitHub calls without coreutils timeout
ok - all fleet-sized sections are capped with counted opt-in expansion
ok - captain-held tasks of any kind reach Captain's Call, deferral is honored, and landed excludes answered calls
ok - live PR enrichment caps repositories with counted expansion
ok - per-repository open-PR caps are disclosed with an expansion knob
ok - projection and TOON rendering failures exit nonzero with diagnostics
```
</details>
- Evidence: [fm-fleet-view.sh render over the 400-row oversized backlog home](https://github.com/Omar-Nawaf/firstmate/blob/8b87bd3b3e0b1e5abf9bd519499efe7a5c1ffd07/.no-mistakes/evidence/fm/firstmate-fleet-snapshot-upstream-pr/fleet-view-oversized-backlog.txt)
<details>
<summary>Evidence: fm-fleet-view.sh render over the 3-mate aggregate home</summary>

Source: [fm-fleet-view.sh render over the 3-mate aggregate home](https://github.com/Omar-Nawaf/firstmate/blob/8b87bd3b3e0b1e5abf9bd519499efe7a5c1ffd07/.no-mistakes/evidence/fm/firstmate-fleet-snapshot-upstream-pr/fleet-view-oversized-aggregate.txt)

```text
# Fleet View

Schema: fm-fleet-snapshot.v1
Home: /tmp/fm-snapshot-evidence.bAFqsw/homes/fleet-agg-parent

## Under Way
No live task metadata found.

## Queued
No queued backlog records found.

## Done
No done backlog records found.

## Secondmates
For kind=secondmate, bearings selects validated structured state from that registered home; parent events and bounded terminal evidence are fallback-only supplements and never current-state authority.
```
</details>
- Evidence: [fm-bearings-snapshot.sh (TOON) over the oversized backlog home](https://github.com/Omar-Nawaf/firstmate/blob/8b87bd3b3e0b1e5abf9bd519499efe7a5c1ffd07/.no-mistakes/evidence/fm/firstmate-fleet-snapshot-upstream-pr/bearings-oversized-backlog.txt)
- Evidence: [fm-bearings-snapshot.sh (TOON) over the 3-mate aggregate home](https://github.com/Omar-Nawaf/firstmate/blob/8b87bd3b3e0b1e5abf9bd519499efe7a5c1ffd07/.no-mistakes/evidence/fm/firstmate-fleet-snapshot-upstream-pr/bearings-oversized-aggregate.txt)
- Evidence: [fm-bearings-snapshot.sh (TOON) over a normal fleet home](https://github.com/Omar-Nawaf/firstmate/blob/8b87bd3b3e0b1e5abf9bd519499efe7a5c1ffd07/.no-mistakes/evidence/fm/firstmate-fleet-snapshot-upstream-pr/bearings-normal-fleet.txt)
- Evidence: [Normal fleet --json, base output (timestamps normalized)](https://github.com/Omar-Nawaf/firstmate/blob/8b87bd3b3e0b1e5abf9bd519499efe7a5c1ffd07/.no-mistakes/evidence/fm/firstmate-fleet-snapshot-upstream-pr/normal-fleet-json.base.normalized.json)
- Evidence: [Normal fleet --json, target output (timestamps normalized; identical to base)](https://github.com/Omar-Nawaf/firstmate/blob/8b87bd3b3e0b1e5abf9bd519499efe7a5c1ffd07/.no-mistakes/evidence/fm/firstmate-fleet-snapshot-upstream-pr/normal-fleet-json.target.normalized.json)
- Evidence: [Normal fleet --secondmate-home-summary, base output (normalized)](https://github.com/Omar-Nawaf/firstmate/blob/8b87bd3b3e0b1e5abf9bd519499efe7a5c1ffd07/.no-mistakes/evidence/fm/firstmate-fleet-snapshot-upstream-pr/normal-fleet-secondmate-home-summary.base.normalized.json)
- Evidence: [Normal fleet --secondmate-home-summary, target output (normalized; identical to base)](https://github.com/Omar-Nawaf/firstmate/blob/8b87bd3b3e0b1e5abf9bd519499efe7a5c1ffd07/.no-mistakes/evidence/fm/firstmate-fleet-snapshot-upstream-pr/normal-fleet-secondmate-home-summary.target.normalized.json)
- Evidence: [Normal fleet --json raw target output (fm-fleet-snapshot.v1)](https://github.com/Omar-Nawaf/firstmate/blob/8b87bd3b3e0b1e5abf9bd519499efe7a5c1ffd07/.no-mistakes/evidence/fm/firstmate-fleet-snapshot-upstream-pr/normal-fleet-target-raw.json)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"4a8a77e6cdd844aa3e333299b9f6a1bf3bd7c886","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-fleet-snapshot.sh` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `bin/fm-fleet-snapshot.sh:1400` - The two `record=$(jq -n ...)` assignments (lines 1349 and 1383) have no `|| return 1`. Before this change a failed record jq produced an empty `$record`, which made the next `--argjson record &#34;$record&#34;` accumulation fail and the snapshot exit with &#34;registered secondmate aggregation failed&#34;. Now `printf &#39;%s\n&#39; &#34;$record&#34; &gt;&gt;&#34;$records_file&#34;` appends an empty line that `--slurpfile records_in` silently ignores, so `secondmate_current.records` shrinks below `shown` with rc 0 instead of failing loudly. Reachability is low (inputs are jq-validated, so it needs a jq failure or an I/O error such as a full TMPDIR), but the loud-failure invariant was removed by this change. Fix: append `|| return 1` to both `record=$(jq -n ... )` assignments (or guard `[ -n &#34;$record&#34; ] || return 1` before the append).

🔧 Fix: fail snapshot loudly when a secondmate record build fails
1 info still open:
- ℹ️ `bin/fm-fleet-snapshot.sh:1353` - After this change the only per-mate value still handed to jq via --argjson that is not capped by an explicit bound is `$decisions` (the parent task&#39;s `hints.open_decisions`, a keyed fold over the whole parent status log; used at lines 1128, 1353, 1389, and per-task at 618). Every other remaining --argjson is a scalar or an explicitly capped structure (registry ≤ FM_SNAPSHOT_REGISTRY_BYTES/LINES/RECORDS, activities ≤ FM_SNAPSHOT_PARENT_ACTIVITIES from a 64 KB tail, terminal ≤ FM_SNAPSHOT_TERMINAL_BYTES). Reaching MAX_ARG_STRLEN here would need on the order of a thousand simultaneously unresolved keyed decisions on one mate&#39;s status log, which is outside the ordinary-fleet scenarios the intent names (backlog, tasks array, child summary, fleet aggregates), so this is noted as the residual exposure, not a defect in this change.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-fleet-snapshot-view.test.sh` (19 ok, includes test_oversized_backlog_survives_argv_cap, test_oversized_secondmate_summary_survives_argv_cap, test_secondmate_aggregate_over_argv_cap_survives, test_secondmate_record_build_failure_fails_loudly)</code>
- <code>`bash tests/fm-bearings-snapshot.test.sh` (42 ok)</code>
- <code>Ran the four new test functions in isolation against `git show d63b0e2:bin/fm-fleet-snapshot.sh` (base) and the target script: 3 fail at base (Argument list too long / children lost), all 4 pass on target -&gt; regression-tests-base-vs-target.txt</code>
- <code>Before/after reproduction script `argv-cap-before-after.sh` (base vs target, pinned FM_ROOT_OVERRIDE, jq 1.8.2, MAX_ARG_STRLEN=131072): 400-row backlog `--json` and `--secondmate-home-summary`; one child summary of 198,039 bytes (131073..262144 window) with FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME=0; 3x200 aggregate; 8x50 aggregate-only window (each child summary 19,591 B, combined 131,967 B)</code>
- <code>Normal-sized fleet: base vs target `--json` and `--secondmate-home-summary` output diffed after normalizing only timestamps/age_seconds -&gt; IDENTICAL (510 and 122 lines)</code>
- <code>Read-only contract: md5 listing of the fleet home unchanged after target runs; zero `fm-fleet-snapshot.*` scratch dirs left in TMPDIR after normal exits and after `timeout -s TERM 1` kill (rc=124)</code>
- <code>`bin/fm-fleet-view.sh` and `bin/fm-bearings-snapshot.sh` rendered over the 400-row backlog home, the 3-mate aggregate home, and a normal fleet home (all rc=0)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
