### PR TITLE
fix(agents): honor Codex subagent defaults

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -113,9 +113,13 @@ When changing any primary watcher adapter, update `docs/supervision-protocols/`,
 `bin/fm-spawn.sh` accepts concrete `--harness`, `--model`, and `--effort` values chosen by firstmate at intake.
 Do not make the shell scripts parse or match natural-language dispatch rules.
 
-Effort precedence is an explicit per-task captain instruction first, then any applicable standing dispatch profile or secondmate pin, then the generic fallback below.
-Never replace an effort value supplied by either higher-precedence source.
-Use the fallback only when neither the captain nor applicable standing configuration specifies effort.
+Model and effort precedence is an explicit per-task captain instruction first, then any applicable standing dispatch profile or secondmate pin, then harness-specific standing configuration, then the generic effort fallback below.
+Never replace a model or effort value supplied by a higher-precedence source.
+For a Codex crewmate or scout, inspect the live Codex `[agents]` settings at intake and treat `default_subagent_model` and `default_subagent_reasoning_effort` as harness-specific standing configuration, even though Firstmate launches an isolated CLI process rather than a Codex-native subagent.
+Pass each configured value explicitly to `fm-spawn` so the separate worker launch matches the captain's Codex subagent preference instead of inheriting unrelated top-level Codex session defaults.
+When either `[agents]` value is absent, continue down this precedence independently for that axis.
+Selecting `gpt-5.6-sol` with `high`, `xhigh`, `max`, or an equivalent high-or-higher effort requires explicit captain approval for the current task, regardless of standing configuration; Firstmate may recommend that profile with its expected benefit, but must not launch it from a standing preference alone.
+Use the generic effort fallback only when neither the captain nor applicable standing or harness-specific configuration specifies effort.
 Use `low` for well-understood work with an explicit bounded path and `xhigh` for ambiguous investigation or design.
 Choose intermediate levels proportionally as complexity, uncertainty, blast radius, or open-ended reasoning increases.
 When a verified adapter lacks `xhigh`, cap the choice at its highest supported non-`max` level rather than omitting the intended effort silently.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,8 +199,9 @@ When every candidate is tight, preserve the captain's strongest-reasoning class 
 Break genuine evidence ties without array-order or harness bias.
 `quota-axi` owns how model or product windows relate to bounding account windows and remains data-only.
 Load `quota-array-dispatch` before choosing among a matched profile array; that skill is the single owner of the TOON-first spendPriority selection procedure.
-The generic effort fallback and its precedence are owned by `harness-adapters`: explicit captain and standing configured effort win; otherwise use low for well-understood explicit work, xhigh for ambiguous investigation or design, intermediate levels proportionally, and never max without explicit captain preference.
-Do not add model-specific versions of that policy.
+Model and effort precedence is owned by `harness-adapters`: explicit captain and standing configured values win, Codex `[agents]` defaults guide otherwise-unconfigured Codex workers, and `gpt-5.6-sol` at high-or-higher effort requires explicit captain approval for the current task.
+The same owner defines the generic effort fallback: use low for well-understood explicit work, xhigh for ambiguous investigation or design, intermediate levels proportionally, and never max without explicit captain preference.
+Do not add model-specific versions of the generic effort fallback.
 
 `secondmate-provisioning` owns secondmate harness pins and inherited local material, while `harness-adapters` owns the harness consequences.
 Dispatch only on a backend that `fm-spawn` validates as spawn-capable; pass an explicit per-spawn `--backend` only under that exact task's own authority, never as later-task precedent (selection contract: [`docs/configuration.md`](docs/configuration.md) "Runtime backend").


### PR DESCRIPTION
## Intent

Change Firstmate's Codex worker dispatch policy to honor the captain's live Codex config.toml [agents] defaults for otherwise-unconfigured worker model and reasoning effort. Preserve concurrent isolated-worker capability. gpt-5.6-sol at high or higher may be recommended when its expected benefit warrants it, but it must not launch without the captain's explicit approval for that current task. This is a policy-only change; do not add a new worker or alter the captain's private config.

## What Changed

- Updated worker-dispatch policy to use Codex `[agents]` subagent model and reasoning defaults when higher-precedence configuration is absent.
- Requires explicit current-task captain approval before launching `gpt-5.6-sol` at high-or-higher reasoning effort.
- Keeps configured model and effort precedence independent so a missing value falls through only for that setting.

## Risk Assessment

✅ Low: The policy-only change clearly defines per-axis precedence, forwards live Codex [agents] defaults into isolated Codex worker launches, and preserves the required per-task approval guard for gpt-5.6-sol at high-or-higher effort.

## Testing

Exercised concrete Codex model/effort handoff through fake tmux with real isolated worktrees and batch routing, then captured a read-only Codex intake transcript showing Terra/medium is explicitly launchable while Sol/high from standing defaults is refused without current-task approval. A CLI transcript is the applicable reviewer-visible evidence because this is a model-visible policy change, not a rendered UI.

<details>
<summary>Evidence: Read-only Codex dispatch-policy transcript</summary>

Source: [Read-only Codex dispatch-policy transcript](https://github.com/mint5auce/firstmate/blob/9d5c892589bd30c25101fb1a7a1950e49e973fb2/.no-mistakes/evidence/fm/codex-subagent-config-policy-r1/codex-dispatch-policy-transcript.md)

<code>1. `gpt-5.6-terra` / `medium`: pass `--model gpt-5.6-terra --effort medium`; launch allowed.&#10;2. `gpt-5.6-sol` / `high` from standing defaults only: do not launch without current-task captain approval.&#10;&#10;No worker was launched.</code>

```text
Captain, dispatch decision:

1. `gpt-5.6-terra` / `medium`  
   Pass `--model gpt-5.6-terra --effort medium` to `fm-spawn`. Launch allowed.

2. `gpt-5.6-sol` / `high` from standing defaults only  
   Would pass `--model gpt-5.6-sol --effort high`, but launch is not allowed without current-task captain approval.

Codex workers are isolated CLI processes, so these Codex `[agents]` values must still be passed explicitly; isolation creates no exception to the Sol/high approval rule.

No worker was launched. Separately, the required session-start digest twice reported an incomplete `unknown` stage, including with `FM_SESSION_START_TIMEOUT=300`; that fleet control-plane issue remains unresolved.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"bce107578acd46afbf4cbf180566aca0554c4585","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-spawn-dispatch-profile.test.sh`
- `bash tests/fm-spawn-batch.test.sh`
- <code>`codex exec --ephemeral --json --sandbox read-only ...` using Terra/medium and Sol/high standing-default scenarios</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
