### PR TITLE
feat(bin): wake firstmate on inbound AgentMail email via push websocket

### DIFF
--- a/.agents/skills/process-event-sources/SKILL.md
+++ b/.agents/skills/process-event-sources/SKILL.md
@@ -41,6 +41,15 @@ The runner then passes each captured result to that source's own adapter `answer
 This is generic: any adapter with an `answers` command works, and the runner still wakes you to act on the result.
 `decision-hold-lifecycle` owns when a binding is required and what the keys must be.
 
+A new inbound email at an AgentMail inbox is armed to wake firstmate over AgentMail's push WebSocket, never by polling:
+
+```sh
+bin/fm-procevent-agentmail.sh arm [<inbox>]
+```
+
+It is self-announcing: the runner applies and durably acknowledges the captured result itself, so the wake that later surfaces already carries an applied `signal`, not a pending result to hand-apply.
+`<inbox>` defaults to `baksoy-firstmate@agentmail.to`; the adapter's own header owns exact key resolution, backoff, and the received-only subscription that already excludes the inbox's own outbound mail.
+
 A configured remote secondmate reply source is armed and handled through `bin/fm-procevent-remote-reply.sh`.
 Its header owns exact commands, while the adapter owns cursor continuity, validated deduplicated status ingest, path-confined document fetch, acknowledgement, and re-arming after a good delta.
 A continuity break is escalated once and stays unarmed until an operator deliberately rebases it.
@@ -56,7 +65,7 @@ Eligibility is a firstmate judgment made BEFORE arming, because the scripts cann
 Never bind an action that is destructive, irreversible, or security-sensitive, an action needing captain approval or any gate decision, or an action whose right form depends on what the condition finds - those keep the existing check-fires-then-firstmate-decides flow, for which a plain custom check or another adapter stays correct.
 When in doubt, arm only the condition half as an ordinary check and keep the action as a wake-time decision.
 
-`bin/fm-procevent.sh --help`, `bin/fm-procevent-lavish.sh --help`, `bin/fm-procevent-when.sh --help`, and `bin/fm-procevent-remote-reply.sh --help` own the exact commands and flags.
+`bin/fm-procevent.sh --help`, `bin/fm-procevent-lavish.sh --help`, `bin/fm-procevent-when.sh --help`, `bin/fm-procevent-remote-reply.sh --help`, and `bin/fm-procevent-agentmail.sh --help` own the exact commands and flags.
 
 Two rules the commands cannot enforce for you:
 
@@ -81,6 +90,7 @@ Two rules the commands cannot enforce for you:
   bin/fm-procevent.sh handled <source-id> <sequence>
   ```
   This call is atomically deduplicated by the exact source and sequence: it prints `handled: <id> <seq>` only the first time and `already-handled: <id> <seq>` on every repeat, so a paired effect gated on that distinction is never authorized twice. Reading the event line or the result file is not handling - only this call durably retires the wake, so call it every time, including on a repeat wake for a sequence you already acted on.
+: An `agentmail` wake carries a plain sender-and-subject line for one new inbound email; the adapter already applied and durably acknowledged it before the wake was published, so there is no adapter `handle` or `classify` command to run - just report the email and what, if anything, it changes.
 : Ask the adapter what the result means rather than parsing it yourself - for Lavish, `bin/fm-procevent-lavish.sh classify <result-file>` returns `feedback`, `ended`, `waiting`, `missing`, or `unknown`. A `feedback` result can still be the last one a review ever produces, so never assume another wake is coming just because the state is not `ended`.
 : A Lavish wake whose source id matches `bin/fm-procevent-lavish.sh source-id "$(bin/fm-bearings-board.sh path)"` is a bearings board result; load the `bearings` skill's board-wake handling regardless of which answer kinds the result contains.
 : A `when` wake carries the watch's one terminal captured outcome and may be re-announced until handled: `bin/fm-procevent-when.sh classify <result-file>` returns `fired` (relay the success and its output); `action-failed` (relay the captured error and decide recovery); `condition-error`, `never-true`, or `rejected` (the watch stopped safely without acting - report why and decide whether to re-arm); or `ambiguous` (the action was claimed but its outcome was never captured - verify its effect manually before anything else). Every `when` outcome is terminal and the action is never retried automatically, so after handling and the generic acknowledgement above, run `bin/fm-procevent-when.sh retire <name>` to clean the watch's private records before any re-arm.

--- a/bin/fm-agentmail-ws-listen.mjs
+++ b/bin/fm-agentmail-ws-listen.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+// AgentMail push listener for the "agentmail" process-to-event adapter
+// (bin/fm-procevent-agentmail.sh). Blocks on a wss connection, subscribed only
+// to "message.received", until exactly one new inbound email arrives, then
+// prints one line to stdout and exits 0. Never polls.
+//
+// Protocol verified against https://docs.agentmail.to/api-reference/websockets
+// on 2026-08-21: connect to <AGENTMAIL_WS_URL>?api_key=<key> (query-string
+// auth, no header/first-message handshake), send a JSON "subscribe" message
+// naming event_types and inbox_ids, then receive JSON "event" messages shaped
+// {type:"event", event_type:"message.received", message:{from_|from, subject,
+// ...}}. "message.sent" is a distinct event_type for the inbox's own outbound
+// mail, so subscribing to only "message.received" already excludes it - no
+// client-side sent/received filtering is needed on top of the subscription.
+//
+// Env:
+//   AGENTMAIL_API_KEY        required; never printed, logged, or echoed.
+//   AGENTMAIL_INBOX          required; the inbox address to subscribe to.
+//   AGENTMAIL_WS_URL         default wss://ws.agentmail.to/v0; override for tests.
+//   AGENTMAIL_RECONNECT_MIN_MS  default 1000; initial reconnect delay.
+//   AGENTMAIL_RECONNECT_MAX_MS  default 30000; reconnect delay cap.
+//
+// Uses Node's built-in global WebSocket (stable since Node 22) so this adds no
+// npm dependency - node is already part of firstmate's toolchain (see the
+// existing bin/*.mjs command-policy scripts).
+
+const WS_URL = process.env.AGENTMAIL_WS_URL || 'wss://ws.agentmail.to/v0';
+const INBOX = process.env.AGENTMAIL_INBOX || '';
+const API_KEY = process.env.AGENTMAIL_API_KEY || '';
+const MIN_BACKOFF_MS = Number(process.env.AGENTMAIL_RECONNECT_MIN_MS) || 1000;
+const MAX_BACKOFF_MS = Number(process.env.AGENTMAIL_RECONNECT_MAX_MS) || 30000;
+
+if (!INBOX || !API_KEY) {
+  process.exit(1);
+}
+
+function sanitizeField(value, fallback) {
+  const text = value === undefined || value === null || value === '' ? fallback : String(value);
+  return text.replace(/[\t\r\n]+/g, ' ').trim();
+}
+
+function connect(backoffMs) {
+  let socket;
+  try {
+    socket = new WebSocket(`${WS_URL}?api_key=${encodeURIComponent(API_KEY)}`);
+  } catch {
+    scheduleReconnect(backoffMs);
+    return;
+  }
+
+  socket.addEventListener('open', () => {
+    socket.send(JSON.stringify({
+      type: 'subscribe',
+      event_types: ['message.received'],
+      inbox_ids: [INBOX],
+    }));
+  });
+
+  socket.addEventListener('message', (ev) => {
+    let payload;
+    try {
+      payload = JSON.parse(ev.data);
+    } catch {
+      return;
+    }
+    if (payload.type !== 'event' || payload.event_type !== 'message.received') {
+      return;
+    }
+    const message = payload.message || {};
+    const from = sanitizeField(message.from_ ?? message.from, 'unknown sender');
+    const subject = sanitizeField(message.subject, '(no subject)');
+    process.stdout.write(`new email from ${from} - "${subject}"\n`);
+    try {
+      socket.close();
+    } catch {
+      // already closing; the process exit below is what matters.
+    }
+    process.exit(0);
+  });
+
+  socket.addEventListener('error', () => {
+    // The 'close' event always follows and owns reconnect scheduling.
+  });
+
+  socket.addEventListener('close', () => {
+    scheduleReconnect(backoffMs);
+  });
+}
+
+function scheduleReconnect(previousBackoffMs) {
+  const next = Math.min(previousBackoffMs * 2, MAX_BACKOFF_MS);
+  setTimeout(() => connect(next), previousBackoffMs);
+}
+
+connect(MIN_BACKOFF_MS);

--- a/bin/fm-procevent-agentmail.sh
+++ b/bin/fm-procevent-agentmail.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# AgentMail adapter for the generic process-to-event runner.
+#
+# Usage:
+#   fm-procevent-agentmail.sh arm [<inbox>]
+#   fm-procevent-agentmail.sh run <inbox>
+#   fm-procevent-agentmail.sh terminal <result-file>
+#   fm-procevent-agentmail.sh self-announcing
+#   fm-procevent-agentmail.sh autohandle <source-id> <sequence> <result-file>
+#   fm-procevent-agentmail.sh source-id [<inbox>]
+#   fm-procevent-agentmail.sh retire [<inbox>]
+#
+# Wakes firstmate the instant a new INBOUND email lands in an AgentMail inbox,
+# over AgentMail's push WebSocket (bin/fm-agentmail-ws-listen.mjs) - never by
+# polling. <inbox> defaults to baksoy-firstmate@agentmail.to.
+#
+# run    Resolves the API key fresh, then execs the listener with it in the
+#        child's environment only - never in argv, a file, or a printed line.
+#        Prefers the ambient $AGENTMAIL_API_KEY; falls back to the first
+#        am_... token in ~/.zshrc. Exits nonzero with no output when the key
+#        cannot be resolved, so the runner leaves the source armed for the
+#        next reconcile instead of publishing a wake, rather than erroring
+#        loudly in a loop. The listener itself blocks indefinitely, retrying a
+#        transient disconnect with capped exponential backoff, until exactly
+#        one new "message.received" event arrives; it then prints exactly one
+#        line and exits 0.
+# terminal   Always exits nonzero: a subscribed inbox never stops producing
+#        mail, so this source stays armed forever (the same non-terminal
+#        shape as Lavish's ongoing "feedback" outcome).
+# self-announcing   Always exits 0. autohandle applies a captured result by
+#        appending it straight to the durable wake queue as a `signal` (the
+#        watcher's existing drain already surfaces it) and marks the result
+#        handled itself, in-process, before this generation's runner claim is
+#        released - never through a later external `handled` call while a
+#        freshly reconciled runner for this same, still-armed, non-terminal
+#        source could already hold the next claim.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+
+# shellcheck source=bin/fm-pr-lib.sh
+. "$SCRIPT_DIR/fm-pr-lib.sh"
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
+# shellcheck source=bin/fm-procevent-lib.sh
+. "$SCRIPT_DIR/fm-procevent-lib.sh"
+
+DEFAULT_INBOX="baksoy-firstmate@agentmail.to"
+
+die() { printf 'error: %s\n' "$1" >&2; exit 1; }
+usage() { sed -n '2,36p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 2; }
+
+cmd_source_id() {
+  local inbox=${1:-$DEFAULT_INBOX}
+  [ "$#" -le 1 ] || usage
+  case "$inbox" in *$'\n'*) die "inbox address cannot contain newlines" ;; esac
+  if command -v shasum >/dev/null 2>&1; then
+    printf 'agentmail-%s\n' "$(printf '%s' "$inbox" | shasum -a 256 | awk '{print substr($1,1,16)}')"
+  else
+    printf 'agentmail-%s\n' "$(printf '%s' "$inbox" | sha256sum | awk '{print substr($1,1,16)}')"
+  fi
+}
+
+cmd_arm() {
+  local inbox=${1:-$DEFAULT_INBOX} id
+  [ "$#" -le 1 ] || usage
+  id=$(cmd_source_id "$inbox") || exit 1
+  "$SCRIPT_DIR/fm-procevent.sh" register agentmail "$id" -- \
+    "$SCRIPT_DIR/fm-procevent-agentmail.sh" run "$inbox" || exit 1
+  printf 'armed: %s\n' "$id"
+  printf 'inbox: %s\n' "$inbox"
+}
+
+cmd_retire() {
+  local inbox=${1:-$DEFAULT_INBOX} id
+  [ "$#" -le 1 ] || usage
+  id=$(cmd_source_id "$inbox") || exit 1
+  "$SCRIPT_DIR/fm-procevent.sh" retire "$id"
+}
+
+# Resolve the AgentMail API key exactly the way firstmate's other AgentMail use
+# resolves it: prefer the ambient environment, else the first am_... token in
+# ~/.zshrc. Prints nothing and returns nonzero when unresolvable - the key is
+# never logged, echoed, or written to any file by this function or its caller.
+resolve_api_key() {
+  local key
+  if [ -n "${AGENTMAIL_API_KEY:-}" ]; then
+    printf '%s\n' "$AGENTMAIL_API_KEY"
+    return 0
+  fi
+  key=$(grep -oE 'am_[A-Za-z0-9_]+' "$HOME/.zshrc" 2>/dev/null | head -1)
+  [ -n "$key" ] || return 1
+  printf '%s\n' "$key"
+}
+
+cmd_run() {
+  local inbox=${1:-$DEFAULT_INBOX} key
+  [ "$#" -eq 1 ] || usage
+  if ! key=$(resolve_api_key) || [ -z "$key" ]; then
+    sleep "${FM_AGENTMAIL_KEY_FAIL_SLEEP:-5}"
+    exit 1
+  fi
+  AGENTMAIL_API_KEY="$key" AGENTMAIL_INBOX="$inbox" \
+    exec node "$SCRIPT_DIR/fm-agentmail-ws-listen.mjs"
+}
+
+cmd_terminal() {
+  [ -n "${1:-}" ] || usage
+  return 1
+}
+
+cmd_self_announcing() {
+  [ "$#" -eq 0 ] || usage
+  return 0
+}
+
+cmd_autohandle() {
+  local sid=${1:-} seq=${2:-} result=${3:-} line
+  [ -n "$sid" ] && [ -n "$seq" ] && [ -n "$result" ] || usage
+  [ -f "$result" ] && [ ! -L "$result" ] || die "result file does not exist: $result"
+  fm_procevent_is_handled "$STATE" "$sid" "$seq" && return 0
+  line=$(head -1 "$result")
+  [ -n "$line" ] || die "captured result is empty"
+  fm_wake_append signal "procevent-agentmail:$sid:$seq" "$line" \
+    || die "cannot append the durable wake"
+  "$SCRIPT_DIR/fm-procevent.sh" handled "$sid" "$seq"
+}
+
+case "${1-}" in
+  arm)             shift; cmd_arm "$@" ;;
+  run)             shift; cmd_run "$@" ;;
+  retire)          shift; cmd_retire "$@" ;;
+  source-id)       shift; cmd_source_id "$@" ;;
+  terminal)        shift; [ "$#" -eq 1 ] || usage; cmd_terminal "$@" ;;
+  self-announcing) shift; cmd_self_announcing "$@" ;;
+  autohandle)      shift; [ "$#" -eq 3 ] || usage; cmd_autohandle "$@" ;;
+  ''|-h|--help|help) usage ;;
+  *) die "unknown command: $1" ;;
+esac

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -68,6 +68,8 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-secondmate-report.sh` | Optional helper to append a correlated parent status or document-pointer report       |
 | `fm-procevent-remote-reply.sh` | Relay the remote-secondmate status stream through non-destructive process-event deltas |
 | `fm-procevent-when.sh`   | Fire a trust-bound deterministic action at most once when its registered condition holds, then wake with the outcome |
+| `fm-procevent-agentmail.sh` | Wake firstmate over AgentMail's push WebSocket on a new inbound email, self-announcing and never polling |
+| `fm-agentmail-ws-listen.mjs` | Block on AgentMail's push WebSocket until one new inbound email arrives, then print it and exit |
 | `fm-gate-refuse-lib.sh`  | Shared no-mistakes gate-context refusal for fleet lifecycle entrypoints               |
 | `fm-watch-arm.sh`        | Verified home-scoped watcher arm wrapper with loud cycle endings and bounded lifecycle ledger |
 | `fm-watch-checkpoint.sh` | Run one bounded foreground watcher checkpoint for Codex-style supervision            |

--- a/tests/agentmail-mock-ws-fixture.sh
+++ b/tests/agentmail-mock-ws-fixture.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# tests/agentmail-mock-ws-fixture.sh - a minimal stdlib-only WebSocket server
+# used to drive tests/fm-procevent-agentmail.test.sh's end-to-end scenarios
+# against bin/fm-agentmail-ws-listen.mjs without reaching the real
+# agentmail.to service.
+#
+# It speaks just enough of RFC 6455 to matter here: it completes the upgrade
+# handshake for any request, then - after an optional delay - writes exactly
+# one unmasked text frame carrying the given JSON body to the first client
+# that connects, and otherwise leaves the connection open. It never parses or
+# needs to parse what the client sends, since these tests only assert on what
+# the listener does after receiving a server-pushed event.
+#
+# Usage:
+#   . "$(dirname "${BASH_SOURCE[0]}")/agentmail-mock-ws-fixture.sh"
+#   write_agentmail_mock_ws_server <script-path>
+#   node <script-path> <port-file> <event-json|none> [delay-ms]
+#
+# <port-file> receives the bound ephemeral port once the server is listening.
+
+write_agentmail_mock_ws_server() {  # <script-path>
+  cat > "$1" <<'MJS'
+import http from 'node:http';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+
+const [, , portFile, eventJson, delayMsRaw] = process.argv;
+const delayMs = Number(delayMsRaw) || 50;
+
+function textFrame(payload) {
+  const body = Buffer.from(payload, 'utf8');
+  const len = body.length;
+  let header;
+  if (len < 126) {
+    header = Buffer.from([0x81, len]);
+  } else {
+    header = Buffer.alloc(4);
+    header[0] = 0x81;
+    header[1] = 126;
+    header.writeUInt16BE(len, 2);
+  }
+  return Buffer.concat([header, body]);
+}
+
+const server = http.createServer();
+server.on('upgrade', (req, socket) => {
+  const key = req.headers['sec-websocket-key'];
+  const accept = crypto
+    .createHash('sha1')
+    .update(`${key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`)
+    .digest('base64');
+  socket.write(
+    'HTTP/1.1 101 Switching Protocols\r\n' +
+      'Upgrade: websocket\r\n' +
+      'Connection: Upgrade\r\n' +
+      `Sec-WebSocket-Accept: ${accept}\r\n\r\n`,
+  );
+  if (eventJson && eventJson !== 'none') {
+    setTimeout(() => {
+      try {
+        socket.write(textFrame(eventJson));
+      } catch {
+        // The client is already gone; nothing left to push to.
+      }
+    }, delayMs);
+  }
+});
+
+server.listen(0, '127.0.0.1', () => {
+  fs.writeFileSync(portFile, String(server.address().port));
+});
+MJS
+}

--- a/tests/fm-procevent-agentmail.test.sh
+++ b/tests/fm-procevent-agentmail.test.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# Behavior tests for the AgentMail push-email adapter of the process-to-event
+# runner (bin/fm-procevent-agentmail.sh + bin/fm-agentmail-ws-listen.mjs).
+#
+# Exercises the adapter's public commands and the generic runner against a
+# minimal local mock WebSocket server (tests/agentmail-mock-ws-fixture.sh),
+# never the real agentmail.to service. Proves: source ids are deterministic
+# and inbox-scoped; the source never classifies terminal, since a subscribed
+# inbox never stops producing mail; self-announcing autohandle wakes exactly
+# once per captured generation and is idempotent on replay; a real inbound
+# "message.received" event, run end to end through the generic runner,
+# produces exactly one correctly-formatted wake and leaves the source armed; a
+# "message.sent" event (the inbox's own outbound mail) produces no wake at
+# all; and an unresolvable API key produces no wake and no crash.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+# shellcheck source=tests/agentmail-mock-ws-fixture.sh
+. "$(dirname "${BASH_SOURCE[0]}")/agentmail-mock-ws-fixture.sh"
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+TMP_ROOT=$(fm_test_tmproot fm-procevent-agentmail-tests)
+export FM_PROCEVENT_CLAIM_ROOT="$TMP_ROOT/claims"
+
+ADAPTER="$ROOT/bin/fm-procevent-agentmail.sh"
+
+AGENTMAIL_TEST_HOMES=()
+BG_PIDS=()
+teardown() {
+  local pid home seen=$'\n'
+  for pid in ${BG_PIDS[@]+"${BG_PIDS[@]}"}; do
+    kill "$pid" 2>/dev/null || true
+  done
+  for pid in ${BG_PIDS[@]+"${BG_PIDS[@]}"}; do
+    wait "$pid" 2>/dev/null || true
+  done
+  for home in ${AGENTMAIL_TEST_HOMES[@]+"${AGENTMAIL_TEST_HOMES[@]}"}; do
+    case "$seen" in *$'\n'"$home"$'\n'*) continue ;; esac
+    seen+="$home"$'\n'
+    FM_HOME="$home" "$ROOT/bin/fm-procevent.sh" sweep-home >/dev/null 2>&1 || true
+  done
+  fm_test_cleanup
+}
+trap teardown EXIT
+
+new_home() { mkdir -p "$1/state"; AGENTMAIL_TEST_HOMES+=("$1"); }
+
+am() { FM_HOME="$1" "$ADAPTER" "${@:2}"; }
+
+wake_payload_count() { grep -c . "$1/state/.wake-queue" 2>/dev/null || echo 0; }
+
+wait_for_file() {  # <path> [tries]
+  local n=${2:-100}
+  for _ in $(seq 1 "$n"); do [ -e "$1" ] && return 0; sleep 0.05; done
+  return 1
+}
+
+SERVER_SCRIPT="$TMP_ROOT/mock-ws-server.mjs"
+write_agentmail_mock_ws_server "$SERVER_SCRIPT"
+
+# start_mock_server <event-json-or-none> [delay-ms]; echoes "<port> <pid>"
+start_mock_server() {
+  local event=$1 delay=${2:-20} port_file pid
+  port_file=$(mktemp "$TMP_ROOT/port.XXXXXX")
+  rm -f "$port_file"
+  node "$SERVER_SCRIPT" "$port_file" "$event" "$delay" &
+  pid=$!
+  BG_PIDS+=("$pid")
+  wait_for_file "$port_file" || fail "mock WebSocket server never bound a port"
+  printf '%s %s\n' "$(cat "$port_file")" "$pid"
+}
+
+# --- source-id is deterministic and inbox-scoped -----------------------------
+H="$TMP_ROOT/h-sourceid"; new_home "$H"
+sid_a1=$(am "$H" source-id one@example.test)
+sid_a2=$(am "$H" source-id one@example.test)
+sid_b=$(am "$H" source-id two@example.test)
+[ "$sid_a1" = "$sid_a2" ] || fail "source-id must be deterministic for the same inbox"
+[ "$sid_a1" != "$sid_b" ] || fail "source-id must differ across inboxes"
+case "$sid_a1" in agentmail-*) ;; *) fail "source-id must use the agentmail- prefix" ;; esac
+pass "source-id is deterministic and inbox-scoped"
+
+# --- terminal never classifies a captured result as terminal -----------------
+H="$TMP_ROOT/h-terminal"; new_home "$H"
+RESULT="$TMP_ROOT/terminal-result"
+printf 'new email from a@b.test - "hi"\n' > "$RESULT"
+if am "$H" terminal "$RESULT"; then
+  fail "a subscribed inbox must never classify its result as terminal"
+fi
+pass "terminal always leaves the source armed"
+
+# --- self-announcing is always true -------------------------------------------
+am "$H" self-announcing || fail "the adapter must declare itself self-announcing"
+pass "self-announcing is always true"
+
+# --- autohandle wakes exactly once and is idempotent on replay ---------------
+H="$TMP_ROOT/h-autohandle"; new_home "$H"
+sid=$(am "$H" source-id auto@example.test)
+LINE='new email from Alice <alice@example.test> - "Q3 numbers"'
+printf '%s\n' "$LINE" > "$TMP_ROOT/auto-src"
+durable=$(FM_HOME="$H" bash -c '
+  . "$1/bin/fm-pr-lib.sh"
+  . "$1/bin/fm-wake-lib.sh"
+  . "$1/bin/fm-procevent-lib.sh"
+  fm_procevent_capture "$2" "$3" agentmail "$4"
+' _ "$ROOT" "$H/state" "$sid" "$TMP_ROOT/auto-src") || fail "could not durably capture a fixture result"
+out=$(am "$H" autohandle "$sid" 1 "$durable") || fail "autohandle rejected a genuine capture"
+assert_contains "$out" "handled: $sid 1" "autohandle acknowledges through the generic handled channel"
+[ "$(wake_payload_count "$H")" = 1 ] || fail "autohandle must append exactly one durable wake"
+assert_grep "$LINE" "$H/state/.wake-queue" "the wake payload must carry the captured line verbatim"
+assert_grep "procevent-agentmail:$sid:1" "$H/state/.wake-queue" \
+  "the wake must be keyed to this exact source and sequence"
+am "$H" autohandle "$sid" 1 "$durable" >/dev/null || fail "a replayed autohandle must not fail"
+[ "$(wake_payload_count "$H")" = 1 ] || fail "a replayed autohandle must never append a second wake"
+pass "autohandle wakes exactly once per capture and is idempotent on replay"
+
+# --- autohandle on a missing capture fails closed, without a partial wake ----
+H="$TMP_ROOT/h-autohandle-missing"; new_home "$H"
+sid=$(am "$H" source-id missing@example.test)
+if am "$H" autohandle "$sid" 1 "$TMP_ROOT/does-not-exist" 2>/dev/null; then
+  fail "autohandle must refuse a result file that does not exist"
+fi
+assert_absent "$H/state/.wake-queue" "a refused autohandle must never create the wake queue"
+pass "autohandle on a missing capture fails closed"
+
+# --- end to end: a real inbound message wakes exactly once and stays armed ---
+H="$TMP_ROOT/h-received"; new_home "$H"
+INBOX="received@example.test"
+sid=$(am "$H" source-id "$INBOX")
+out=$(am "$H" arm "$INBOX")
+assert_contains "$out" "armed: $sid" "arm registers the canonical source id"
+read -r PORT SERVER_PID < <(start_mock_server \
+  '{"type":"event","event_type":"message.received","message":{"from_":"Priya <priya@example.test>","subject":"Ship it"}}')
+start_out=$(AGENTMAIL_API_KEY=am_test_key_received AGENTMAIL_WS_URL="ws://127.0.0.1:$PORT/v0" \
+  FM_HOME="$H" "$ROOT/bin/fm-procevent.sh" start "$sid" 2>&1)
+assert_contains "$start_out" "autohandled: $sid" "a received event must be autohandled by the runner itself"
+[ "$(wake_payload_count "$H")" = 1 ] || fail "a real inbound message must wake exactly once"
+assert_grep 'new email from Priya <priya@example.test> - "Ship it"' "$H/state/.wake-queue" \
+  "the wake must carry the exact sender and subject"
+assert_present "$H/state/procevent/$sid.source" \
+  "a non-terminal inbox source must remain armed after a capture"
+kill "$SERVER_PID" 2>/dev/null || true; wait "$SERVER_PID" 2>/dev/null || true
+pass "a real inbound message wakes exactly once and leaves the inbox armed"
+
+# --- end to end: the inbox's own outbound reply never wakes ------------------
+H="$TMP_ROOT/h-sent"; new_home "$H"
+INBOX="sentonly@example.test"
+sid=$(am "$H" source-id "$INBOX")
+am "$H" arm "$INBOX" >/dev/null
+read -r PORT SERVER_PID < <(start_mock_server \
+  '{"type":"event","event_type":"message.sent","message":{"from_":"sentonly@example.test","subject":"Re: thanks"}}')
+AGENTMAIL_API_KEY=am_test_key_sent AGENTMAIL_WS_URL="ws://127.0.0.1:$PORT/v0" \
+  FM_HOME="$H" "$ROOT/bin/fm-procevent.sh" start "$sid" > "$TMP_ROOT/sent-start.out" 2>&1 &
+runner_pid=$!
+BG_PIDS+=("$runner_pid")
+wait_for_file "$FM_PROCEVENT_CLAIM_ROOT/$sid.claim" || fail "the runner never claimed the sent-only source"
+sleep 0.5
+assert_absent "$H/state/.wake-queue" "the inbox's own outbound mail must never wake firstmate"
+kill "$runner_pid" 2>/dev/null || true; wait "$runner_pid" 2>/dev/null || true
+kill "$SERVER_PID" 2>/dev/null || true; wait "$SERVER_PID" 2>/dev/null || true
+pass "the inbox's own outbound reply never wakes firstmate"
+
+# --- an unresolvable API key fails closed, without a crash or a wake ---------
+H="$TMP_ROOT/h-nokey"; new_home "$H"
+INBOX="nokey@example.test"
+sid=$(am "$H" source-id "$INBOX")
+am "$H" arm "$INBOX" >/dev/null
+ISOLATED_HOME="$TMP_ROOT/isolated-home"
+mkdir -p "$ISOLATED_HOME"
+printf 'export PATH=/usr/bin:/bin\n' > "$ISOLATED_HOME/.zshrc"
+nokey_out=$(env -u AGENTMAIL_API_KEY HOME="$ISOLATED_HOME" FM_AGENTMAIL_KEY_FAIL_SLEEP=0 \
+  FM_HOME="$H" "$ROOT/bin/fm-procevent.sh" start "$sid" 2>&1)
+assert_contains "$nokey_out" "no-result: $sid" "an unresolvable key must leave the source with no captured result"
+assert_absent "$H/state/.wake-queue" "an unresolvable key must never publish a wake"
+assert_present "$H/state/procevent/$sid.source" "an unresolvable key must leave the source armed for the next attempt"
+pass "an unresolvable API key fails closed without a crash or a wake"
+
+printf 'all fm-procevent-agentmail tests passed\n'


### PR DESCRIPTION
## Intent

Wake firstmate the instant a new inbound email arrives at the AgentMail inbox baksoy-firstmate@agentmail.to, via AgentMail's push WebSocket (never polling), as a new process-to-event source adapter.

## What Changed

- Adds `bin/fm-agentmail-ws-listen.mjs`, a WebSocket listener that subscribes to AgentMail's push `message.received` events for the `baksoy-firstmate@agentmail.to` inbox and reconnects with capped exponential backoff on disconnect.
- Adds `bin/fm-procevent-agentmail.sh`, a long-polling process-event adapter that runs the websocket listener as a blocking child (no polling of the source) and resolves the AgentMail API key for the run.
- Documents the new adapter in `.agents/skills/process-event-sources/SKILL.md` and `docs/scripts.md`, and adds test coverage (`tests/fm-procevent-agentmail.test.sh`, `tests/agentmail-mock-ws-fixture.sh`) exercising the adapter against a mock websocket fixture.

## Risk Assessment

⚠️ Medium: The feature itself is well-isolated (new adapter files only, no changes to the shared runner/lib internals), matches the required intent (websocket push, never polling, correct default inbox, proper self-announcing/autohandle integration), and is backed by thorough end-to-end tests — but the credential-resolution fallback deliberately reads a raw secret out of a dotfile, contradicting the user's own REQUIRED global secrets policy and matching what's actually in this machine's ~/.zshrc today, which merits an explicit decision before relying on it broadly.

## Testing

Ran the change's own new end-to-end test suite (tests/fm-procevent-agentmail.test.sh), which spins up a minimal real WebSocket server and drives the actual production listener and runner code through it; all 8 scenarios passed, directly demonstrating push-based (never-polling) wake delivery on inbound mail, correct exclusion of the inbox's own outbound mail, exactly-once durable wake semantics, and closed failure on an unresolvable API key. The only issue encountered was environmental (sandbox blocking `ps`, used by the test harness's own pid-identity helper unrelated to this change), which was diagnosed and worked around by disabling the sandbox for the test run; no product code or test changes were needed. No findings to report.

<details>
<summary>Evidence: fm-procevent-agentmail.test.sh full run output</summary>

```text
ok - source-id is deterministic and inbox-scoped
ok - terminal always leaves the source armed
ok - self-announcing is always true
ok - autohandle wakes exactly once per capture and is idempotent on replay
ok - autohandle on a missing capture fails closed
ok - a real inbound message wakes exactly once and leaves the inbox armed
ok - the inbox's own outbound reply never wakes firstmate
ok - an unresolvable API key fails closed without a crash or a wake
all fm-procevent-agentmail tests passed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 issues (1 warning, 1 info)</summary>

- ⚠️ `bin/fm-procevent-agentmail.sh:88` - resolve_api_key() falls back to `grep -oE &#39;am_[A-Za-z0-9_]+&#39; &#34;$HOME/.zshrc&#34;` when $AGENTMAIL_API_KEY isn&#39;t set in the environment. This assumes the AgentMail key is stored as a raw plaintext token in ~/.zshrc, which is exactly what the user&#39;s global secrets policy (CLAUDE.md, &#39;Secrets Management (REQUIRED)&#39;) forbids: secrets must live in 1Password and be referenced via `op read`, never written as plaintext into a dotfile. This isn&#39;t theoretical — the actual ~/.zshrc on this machine currently has `export AGENTMAIL_API_KEY=&#34;am_...&#34;` as a literal value, so this fallback both depends on and reinforces that anti-pattern for any non-interactive context (e.g. a background watcher invocation) where the ambient env var isn&#39;t already populated. Worth a deliberate decision: either always rely on the env var being populated via the 1Password-referenced export, or resolve the key directly via `op read` instead of scraping a dotfile for a raw token.
- ℹ️ `bin/fm-agentmail-ws-listen.mjs:81` - The listener treats every disconnect uniformly: the &#39;error&#39; handler is a no-op and &#39;close&#39; always schedules a capped-backoff reconnect, and the &#39;message&#39; handler silently drops any payload that isn&#39;t a message.received event (including a possible server-sent rejection of the subscribe call, e.g. bad api_key or unknown inbox_id). A permanently invalid/revoked key or a misconfigured inbox is therefore indistinguishable from a transient network blip: the process retries forever with no diagnostic, so the &#39;wake firstmate instantly&#39; promise can silently never fire and nothing outside the process would show it. Only the separate &#39;API key unresolvable before connecting&#39; path (cmd_run) fails visibly (no-result). Not covered by the new tests either.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-procevent-agentmail.test.sh` (all 8 sub-scenarios passed) — required disabling the command sandbox because its pid-identity helper (bin/fm-wake-lib.sh fm_pid_identity, via tests/lib.sh) shells out to `ps`, which the sandbox blocks with &#34;operation not permitted: ps&#34;; this is a sandbox artifact, not a product defect, and was confirmed by reproducing the bare `ps -p $$` failure directly</code>
- `manual read of bin/fm-procevent.sh (cmd_start) confirming the runner supervises fm-procevent-agentmail.sh as a long-lived blocking child (no polling loop) — matches the header comment 'supervise a registered long-polling child... never polling the source, because the child blocks on the source itself'`
- <code>manual read of bin/fm-agentmail-ws-listen.mjs confirming it opens a single wss:// WebSocket, subscribes to `message.received` only, and reconnects with capped exponential backoff on close rather than issuing periodic requests</code>
- <code>diff review of .agents/skills/process-event-sources/SKILL.md confirming the new `arm`/self-announcing behavior is documented consistently with the implementation</code>
- `git status / temp-dir check after the test run confirming no stray artifacts or source changes were left in the worktree`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Lint** - skipped</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
