### PR TITLE
fix(bin): enforce Wayfinder parent lifecycle gates

### DIFF
--- a/.agents/skills/captain-hold-lifecycle/SKILL.md
+++ b/.agents/skills/captain-hold-lifecycle/SKILL.md
@@ -32,6 +32,8 @@ Chat already feeds it through `bin/fm-send.sh --resolve-key`, and a captured-ans
 An unbound source and a key that names no captain-held task both simply feed nothing: the answer is still captured and firstmate is still woken, and closing falls back to the direct command above.
 A captain-held task closed outside this owner leaves no durable answer, so the completion gate keeps failing until `answer` records the decision the captain actually gave.
 Resolved findings, recommendations that need no captain choice, and prose that merely sounds decision-like do not create held tasks.
+Passing `complete`, including `--none`, inventories captain calls; it does not resolve a Wayfinder ticket, close GitHub issues, or satisfy a consuming project's lifecycle command.
+When a child names a Wayfinder ticket, load `wayfinder-parent-gate` before treating that child as tracker-resolved.
 Bearings reads the resulting structured state and must never compensate by scraping historical reports, visual-review artifacts, terminal output, chat, or other prose.
 
 A captain call can be written down twice - as the keyed status decision the fold reads, and as the backlog task held for the captain - and those two records can disagree without either surface saying so.

--- a/.agents/skills/decision-hold-lifecycle/SKILL.md
+++ b/.agents/skills/decision-hold-lifecycle/SKILL.md
@@ -13,3 +13,4 @@ metadata:
 The separate decision concept was collapsed into the one primitive the captain cares about: a task held for the captain.
 Read and follow `.agents/skills/captain-hold-lifecycle/SKILL.md`; it owns the completion gate, the recorded-answer rule, and every command this skill used to describe.
 Where an older brief says `bin/fm-decision-hold.sh`, that command still works as a one-release compatibility shim over `bin/fm-captain-hold.sh`.
+Passing that captain-call completion gate does not resolve a Wayfinder ticket; load `wayfinder-parent-gate` for the parent map-owner check.

--- a/.agents/skills/firstmate-orca/SKILL.md
+++ b/.agents/skills/firstmate-orca/SKILL.md
@@ -75,7 +75,7 @@ For a messy Orca-backed task:
 6. Stop and inspect if the recorded worktree path, Orca worktree id, or project checkout no longer matches expectations.
 
 Teardown remains governed by the normal firstmate landing rules.
-Scout work can be torn down after the report exists and the `captain-hold-lifecycle` completion gate passes.
+Scout work can be torn down only after the report and `captain-hold-lifecycle` completion gate pass; for a named Wayfinder child, also load `wayfinder-parent-gate`.
 Ship work can be torn down only after the work is landed by its project mode.
 
 ## Smoke Test

--- a/.agents/skills/stuck-crewmate-recovery/SKILL.md
+++ b/.agents/skills/stuck-crewmate-recovery/SKILL.md
@@ -35,6 +35,7 @@ Use `treehouse status` for treehouse-backed tmux, herdr, zellij, or cmux tasks, 
 Do not sweep another home's endpoints or infer ownership from a matching window label.
 
 Before relaunch, prove that no live agent still owns the recorded task and that the existing worktree remains available.
+For a map-dependent ship in a project that publishes `bin/wayfinder-lifecycle-gate`, load `wayfinder-parent-gate` and complete its fresh handoff procedure before stopping the existing agent.
 Preserve its uncommitted changes and commits, keep the same task identity, and resume or relaunch the recorded harness in that existing worktree with the same brief plus a concise progress note.
 Do not use a fresh generic spawn while the recorded worktree is unaccounted for, because allocating another worktree can split one task across two copies.
 If the worktree or ownership cannot be reconciled safely, leave all state intact and report the task failed or blocked with the conflicting evidence.

--- a/.agents/skills/wayfinder-parent-gate/SKILL.md
+++ b/.agents/skills/wayfinder-parent-gate/SKILL.md
@@ -37,9 +37,11 @@ Build the GitHub snapshot as that help describes; include local reports, captain
 
 ## Dispatch enforcement
 
-A ship spawn or scout promotion against a project that publishes `bin/wayfinder-lifecycle-gate` requires a passing `handoff` check.
+A ship spawn, scout promotion, or map-dependent ship relaunch against a project that publishes `bin/wayfinder-lifecycle-gate` requires a passing `handoff` check.
 Pass `--wayfinder-state <snapshot>` to `bin/fm-spawn.sh` or `bin/fm-promote.sh`.
 Pass `--wayfinder-independent` only when the work does not depend on the Wayfinder map.
+A relaunch takes its fresh snapshot through `bin/fm-control.sh <task-id> relaunch --wayfinder-state <snapshot>`.
+A map-independent spawn or promotion records that exemption for later relaunches.
 A scout spawn stays off that handoff path so read-only research can still run.
 
 ## Operating sequence
@@ -48,5 +50,5 @@ A scout spawn stays off that handoff path so read-only research can still run.
 2. If the worker is a research scout whose task forbids project or GitHub mutation, leave it read-only and take its report as input.
 3. Complete captain-call inventory through `captain-hold-lifecycle` as local input.
 4. As parent, write the project's tracker resolution, then verify `accept-child` before recording the child as Wayfinder-resolved.
-5. Verify `handoff` before a map-dependent ship spawn or promotion.
+5. Verify `handoff` before a map-dependent ship spawn, promotion, or relaunch.
 6. Stop if either project command rejects the snapshot; repair tracker state and rerun the same command rather than archiving or dispatching on local completion alone.

--- a/.agents/skills/wayfinder-parent-gate/SKILL.md
+++ b/.agents/skills/wayfinder-parent-gate/SKILL.md
@@ -29,18 +29,16 @@ When a Firstmate child names a Wayfinder ticket, Firstmate is the parent map own
 1. Keep a research scout read-only when its task requires that isolation.
    The scout's report plus captain-call completion is local input, not tracker resolution.
 2. Record tracker resolution yourself, using the consuming project's tracker contract.
-3. Before treating that child as Wayfinder-resolved or archiving it as such, run `bin/fm-wayfinder-parent.sh accept-child` against a GitHub snapshot that includes the child's local completion records.
-4. Before spawning or promoting map-dependent implementation, run `bin/fm-wayfinder-parent.sh handoff` the same way.
+3. Before treating that child as Wayfinder-resolved or archiving it as such, require `accept-child` to pass through Firstmate's public parent check.
+4. Before spawning or promoting map-dependent implementation, require `handoff` to pass through the same check.
 
-`bin/fm-wayfinder-parent.sh --help` owns flags, snapshot merging, and exit codes.
-Build the GitHub snapshot as that help describes; include local reports, captain-call completions, archives, and backlog rows so the project command can reject them as resolution.
+`bin/fm-wayfinder-parent.sh --help` owns commands, flags, snapshot merging, and exit codes.
 
 ## Dispatch enforcement
 
 A ship spawn, scout promotion, or map-dependent ship relaunch against a project that publishes `bin/wayfinder-lifecycle-gate` requires a passing `handoff` check.
-Pass `--wayfinder-state <snapshot>` to `bin/fm-spawn.sh` or `bin/fm-promote.sh`.
-Pass `--wayfinder-independent` only when the work does not depend on the Wayfinder map.
-A relaunch takes its fresh snapshot through `bin/fm-control.sh <task-id> relaunch --wayfinder-state <snapshot>`.
+Use the relevant public command's `--help` for Wayfinder invocation and snapshot mechanics.
+A map-independent exemption is appropriate only when the work does not depend on the Wayfinder map.
 A map-independent spawn or promotion records that exemption for later relaunches.
 A scout spawn stays off that handoff path so read-only research can still run.
 

--- a/.agents/skills/wayfinder-parent-gate/SKILL.md
+++ b/.agents/skills/wayfinder-parent-gate/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: wayfinder-parent-gate
+description: >-
+  Agent-only parent map-owner procedure for a consuming project's Wayfinder lifecycle command.
+  Load before treating a named Wayfinder child as resolved or archived, and before dispatching implementation that depends on a Wayfinder map.
+  Owns the Firstmate-side obligation to keep research scouts read-only, treat captain-call completion as local input, and invoke the project's public lifecycle command for accept-child and handoff.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# Wayfinder parent map owner
+
+Load this before treating a Firstmate child that names a Wayfinder ticket as tracker-resolved, and before dispatching implementation that depends on that map.
+
+`captain-hold-lifecycle` remains the sole owner of captain-call inventory.
+Passing its completion command, including `--none`, is local input to this parent check.
+It does not resolve a Wayfinder ticket, close GitHub issues, or satisfy a project lifecycle command.
+
+The consuming project owns the resolution policy.
+Invoke that project's public `bin/wayfinder-lifecycle-gate` through `bin/fm-wayfinder-parent.sh`.
+Do not restate or reimplement that policy inside Firstmate, `bin/fm-captain-hold.sh`, or `bin/fm-decision-hold.sh`.
+Do not modify the upstream Wayfinder skill or globally installed skill copies.
+
+## Parent obligation
+
+When a Firstmate child names a Wayfinder ticket, Firstmate is the parent map owner for that child.
+
+1. Keep a research scout read-only when its task requires that isolation.
+   The scout's report plus captain-call completion is local input, not tracker resolution.
+2. Record tracker resolution yourself, using the consuming project's tracker contract.
+3. Before treating that child as Wayfinder-resolved or archiving it as such, run `bin/fm-wayfinder-parent.sh accept-child` against a GitHub snapshot that includes the child's local completion records.
+4. Before spawning or promoting map-dependent implementation, run `bin/fm-wayfinder-parent.sh handoff` the same way.
+
+`bin/fm-wayfinder-parent.sh --help` owns flags, snapshot merging, and exit codes.
+Build the GitHub snapshot as that help describes; include local reports, captain-call completions, archives, and backlog rows so the project command can reject them as resolution.
+
+## Dispatch enforcement
+
+A ship spawn or scout promotion against a project that publishes `bin/wayfinder-lifecycle-gate` requires a passing `handoff` check.
+Pass `--wayfinder-state <snapshot>` to `bin/fm-spawn.sh` or `bin/fm-promote.sh`.
+Pass `--wayfinder-independent` only when the work does not depend on the Wayfinder map.
+A scout spawn stays off that handoff path so read-only research can still run.
+
+## Operating sequence
+
+1. Inventory the named Wayfinder ticket from the child's brief, task, or recorded identity.
+2. If the worker is a research scout whose task forbids project or GitHub mutation, leave it read-only and take its report as input.
+3. Complete captain-call inventory through `captain-hold-lifecycle` as local input.
+4. As parent, write the project's tracker resolution, then verify `accept-child` before recording the child as Wayfinder-resolved.
+5. Verify `handoff` before a map-dependent ship spawn or promotion.
+6. Stop if either project command rejects the snapshot; repair tracker state and rerun the same command rather than archiving or dispatching on local completion alone.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,7 +295,7 @@ Write the task-specific brief under section 11 before spawning.
 
 Spawn only through `bin/fm-spawn.sh` after the profile and backend checks in section 4.
 The spawn must resolve a genuine isolated task worktree distinct from the primary checkout; a failed isolation assertion stops the task.
-A ship spawn or promotion against a project that publishes `bin/wayfinder-lifecycle-gate` requires that command's `handoff` unless the work is explicitly map-independent; load `wayfinder-parent-gate`.
+A ship spawn, promotion, or relaunch against a project that publishes `bin/wayfinder-lifecycle-gate` requires that command's `handoff` unless the work is explicitly map-independent; load `wayfinder-parent-gate`.
 After spawning, confirm the worker is processing the brief, handle any trust dialog through `harness-adapters`, and record ship or scout work as under way.
 A persistent secondmate is recorded in the secondmate registry and runtime state, never as a backlog work item.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,6 +274,8 @@ Classify the deliverable:
 - **Ship** is the default and produces a project change through the selected delivery mode; once implementation is authorized, dispatch a ship and keep any remaining bounded research inside it unless unresolved uncertainty could materially change whether or what to build.
 - **Scout** produces knowledge in `data/<id>/report.md`, never a PR, and is appropriate for investigation, diagnosis, planning, reproduction, or audit work when the captain explicitly requests a separate knowledge or design deliverable or unresolved uncertainty could materially change whether or what to build.
 
+When a Firstmate child names a Wayfinder ticket, keep that research scout read-only if the task requires that isolation, and load `wayfinder-parent-gate` so the parent map owner records tracker resolution through the consuming project's lifecycle command.
+
 If established evidence already answers an informational question, relay it without a design-only scout; when implementation intent is unclear, answer and ask one concise implementation question when useful rather than dispatching speculative design work.
 Never both present a likely-enough solution and launch a parallel design exercise that is not expected to change it.
 A diagnostic request, report, recommendation, or implementation-ready finding is evidence, not authorization to change code.
@@ -293,6 +295,7 @@ Write the task-specific brief under section 11 before spawning.
 
 Spawn only through `bin/fm-spawn.sh` after the profile and backend checks in section 4.
 The spawn must resolve a genuine isolated task worktree distinct from the primary checkout; a failed isolation assertion stops the task.
+A ship spawn or promotion against a project that publishes `bin/wayfinder-lifecycle-gate` requires that command's `handoff` unless the work is explicitly map-independent; load `wayfinder-parent-gate`.
 After spawning, confirm the worker is processing the brief, handle any trust dialog through `harness-adapters`, and record ship or scout work as under way.
 A persistent secondmate is recorded in the secondmate registry and runtime state, never as a backlog work item.
 
@@ -373,6 +376,7 @@ Retire one only on an explicit captain or main-firstmate decision, after loading
 A completed scout must leave a self-contained report before its scratch worktree can be discarded; read and relay its findings, record the report as the Done artifact, and re-evaluate the queue.
 A report may recommend implementation but does not authorize it.
 Before treating the investigation or any visual review as complete, load `captain-hold-lifecycle`; teardown enforces that shared completion gate.
+A scout report that names a Wayfinder ticket is local input to the parent, not tracker resolution; load `wayfinder-parent-gate` before treating that child as Wayfinder-resolved or dispatching map-dependent implementation.
 When a scout's deliverable is a visual artifact the captain will iterate on, prefer keeping that scout alive to host its own Lavish loop rather than tearing it down and mediating from firstmate, so the scout keeps its investigation context and the captain iterates in one continuous session.
 When implementation is separately authorized, promote the existing scout through `bin/fm-promote.sh` rather than creating a duplicate task.
 The promoted worker must inventory scratch state, return to a clean default-branch base, carry over only intended fix changes, create the ship branch, and follow the project's selected delivery path while leaving scratch commits and debug edits behind and turning a reproduced bug into the regression test.
@@ -535,6 +539,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `stuck-crewmate-recovery` - load when the session-start digest reports an ordinary direct report's endpoint dead or its metadata has no window, or after a stale wake, looping pane, repeated confusion, an answered-by-brief question, an unresponsive crewmate, or a failed steer.
 - `secondmate-provisioning` - load before creating, seeding, validating, launching, handing backlog to, recovering, pushing inherited local material into, or retiring a secondmate home, and before editing `data/secondmates.md`.
 - `captain-hold-lifecycle` - load before treating an investigation or visual review as complete, before ending a visual review that exposed a captain decision, when recording or routing the captain's answer, and on any `RECORD DIVERGENCE` line from the wake drain.
+- `wayfinder-parent-gate` - load before treating a named Wayfinder child as resolved or archived, and before dispatching implementation that depends on a Wayfinder map.
 - `process-event-sources` - load before arming a long-polling source, before registering a deterministic condition->action watch (do X as soon as Y is true), and on any `procevent <adapter> <source-id> <sequence>` check wake.
   Never run a registered source's blocking command yourself in a conversational turn.
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the Relay configuration blocker, on a `public-followup ...` `check:` wake or a startup-surfaced public commitment, and on any milestone or terminal wake for a Relay-linked task before posting its completion follow-up; relevant only when Relay is on.

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Setup guides for tmux (the default) and every other supported backend (herdr, ze
      │
      ├─ ship: project mode ► PR/local merge ► teardown
      │
-     └─ scout: report at data/<id>/report.md ► decision inventory ► relay findings ► teardown
+     └─ scout: report at data/<id>/report.md ► decision inventory ► project accept-child (for a named Wayfinder child) ► relay findings ► teardown
 ```
 
 You chat with the first mate.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -341,6 +341,7 @@ Write your findings to \`$DATA/$ID/report.md\`.
 The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
 If your deliverable is a visual artifact the captain will review and iterate on, you may host the Lavish review loop yourself (poll, revise, re-serve, staying alive) instead of handing it back to firstmate.
 Before reporting done, read and follow \`$FM_ROOT/.agents/skills/captain-hold-lifecycle/SKILL.md\` and pass its shared completion gate for the report and any visual review.
+The report and captain-call completion are local input to firstmate; firstmate records tracker resolution separately when this scout names a Wayfinder ticket.
 When the report is complete, append \`done: {one-line conclusion}\` to the status file and stop.
 If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.
 EOF

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -5,7 +5,7 @@
 # Usage: fm-control.sh <task-id> interrupt
 #        fm-control.sh <task-id> exit
 #        fm-control.sh <task-id> relaunch [--harness <name>] [--model <name>]
-#                                         [--effort <level>]
+#                                         [--effort <level>] [--wayfinder-state <file>]
 #                                         (--note <text> | --note-file <path>)
 #
 # Why this exists, and how it differs from fm-send.sh. bin/fm-send.sh is the
@@ -187,9 +187,11 @@ fi
 NEW_HARNESS=
 NEW_MODEL=
 NEW_EFFORT=
+WAYFINDER_STATE=
 HARNESS_SET=0
 MODEL_SET=0
 EFFORT_SET=0
+WAYFINDER_STATE_SET=0
 NOTE=
 NOTE_SET=0
 want_value=
@@ -202,6 +204,7 @@ for a in "$@"; do
       harness) NEW_HARNESS=$a; HARNESS_SET=1 ;;
       model) NEW_MODEL=$a; MODEL_SET=1 ;;
       effort) NEW_EFFORT=$a; EFFORT_SET=1 ;;
+      wayfinder-state) WAYFINDER_STATE=$a; WAYFINDER_STATE_SET=1 ;;
       note) NOTE=$a; NOTE_SET=1 ;;
       note-file)
         [ -f "$a" ] || die "--note-file '$a' is not a readable file"
@@ -219,6 +222,8 @@ for a in "$@"; do
     --model=*) NEW_MODEL=${a#--model=}; MODEL_SET=1 ;;
     --effort) want_value=effort ;;
     --effort=*) NEW_EFFORT=${a#--effort=}; EFFORT_SET=1 ;;
+    --wayfinder-state) want_value=wayfinder-state ;;
+    --wayfinder-state=*) WAYFINDER_STATE=${a#--wayfinder-state=}; WAYFINDER_STATE_SET=1 ;;
     --note) want_value=note ;;
     --note=*) NOTE=${a#--note=}; NOTE_SET=1 ;;
     --note-file) want_value=note-file ;;
@@ -233,12 +238,13 @@ done
 [ -z "$want_value" ] || die "--$want_value requires a value"
 
 if [ "$VERB" != relaunch ]; then
-  [ "$HARNESS_SET" = 0 ] && [ "$MODEL_SET" = 0 ] && [ "$EFFORT_SET" = 0 ] && [ "$NOTE_SET" = 0 ] \
-    || die "--harness, --model, --effort, and --note apply to 'relaunch' only"
+  [ "$HARNESS_SET" = 0 ] && [ "$MODEL_SET" = 0 ] && [ "$EFFORT_SET" = 0 ] && [ "$WAYFINDER_STATE_SET" = 0 ] && [ "$NOTE_SET" = 0 ] \
+    || die "--harness, --model, --effort, --wayfinder-state, and --note apply to 'relaunch' only"
 fi
 [ "$HARNESS_SET" = 0 ] || [ -n "$NEW_HARNESS" ] || die "--harness requires a non-empty value"
 [ "$MODEL_SET" = 0 ] || [ -n "$NEW_MODEL" ] || die "--model requires a non-empty value"
 [ "$EFFORT_SET" = 0 ] || [ -n "$NEW_EFFORT" ] || die "--effort requires a non-empty value"
+[ "$WAYFINDER_STATE_SET" = 0 ] || [ -n "$WAYFINDER_STATE" ] || die "--wayfinder-state requires a non-empty value"
 case "$NEW_EFFORT" in
   ''|low|medium|high|xhigh|max) ;;
   *) die "--effort must be one of low, medium, high, xhigh, max" ;;
@@ -766,7 +772,7 @@ record_note() {
 }
 
 do_relaunch() {
-  local exit_result state note_line
+  local exit_result state note_line project map_independent
   local -a spawn_args
 
   require_state_verified_backend relaunch
@@ -789,6 +795,26 @@ do_relaunch() {
       die "task $ID records kind '$KIND', which has no defined relaunch shape"
       ;;
   esac
+
+  if [ "$KIND" = ship ]; then
+    project=$(fm_meta_get "$META" project)
+    if [ -f "$project/bin/wayfinder-lifecycle-gate" ]; then
+      map_independent=$(fm_meta_get "$META" wayfinder_independent)
+      case "$map_independent" in
+        ''|0)
+          [ "$WAYFINDER_STATE_SET" = 1 ] \
+            || die "task $ID relaunches against a project with bin/wayfinder-lifecycle-gate; pass --wayfinder-state <snapshot> so Firstmate can verify handoff"
+          "$SCRIPT_DIR/fm-wayfinder-parent.sh" handoff --project "$project" --state "$WAYFINDER_STATE" \
+            || die "the Wayfinder handoff for $ID was rejected before its agent was stopped"
+          ;;
+        1)
+          [ "$WAYFINDER_STATE_SET" = 0 ] \
+            || die "task $ID is recorded map-independent; --wayfinder-state does not apply to its relaunch"
+          ;;
+        *) die "task $ID has an invalid wayfinder_independent record; refusing to relaunch" ;;
+      esac
+    fi
+  fi
 
   if [ -n "$NOTE" ]; then
     note_line="note_file=$NOTE_FILE"
@@ -814,6 +840,7 @@ do_relaunch() {
   spawn_args=("$ID" --relaunch --harness "$TARGET_HARNESS")
   [ "$TARGET_MODEL" = default ] || spawn_args+=(--model "$TARGET_MODEL")
   [ "$TARGET_EFFORT" = default ] || spawn_args+=(--effort "$TARGET_EFFORT")
+  [ "$WAYFINDER_STATE_SET" = 0 ] || spawn_args+=(--wayfinder-state "$WAYFINDER_STATE")
   if FM_CONTROL_RELAUNCH_TX="$RELAUNCH_TX" \
       "$SCRIPT_DIR/fm-spawn.sh" "${spawn_args[@]}" >/dev/null; then
     RELAUNCH_META_PUBLISHED=1

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -150,6 +150,7 @@ CONTROL_LOCK=
 CONTROL_LOCK_HELD=0
 RELAUNCH_ACTIVE=0
 RELAUNCH_PHASE=start
+WAYFINDER_STATE_TEMP=
 
 control_cleanup() {
   local status=$?
@@ -160,6 +161,9 @@ control_cleanup() {
   if [ "$CONTROL_LOCK_HELD" = 1 ]; then
     CONTROL_LOCK_HELD=0
     fm_lock_release "$CONTROL_LOCK" || true
+  fi
+  if [ -n "$WAYFINDER_STATE_TEMP" ]; then
+    rm -f -- "$WAYFINDER_STATE_TEMP" || true
   fi
   return "$status"
 }
@@ -804,6 +808,13 @@ do_relaunch() {
         ''|0)
           [ "$WAYFINDER_STATE_SET" = 1 ] \
             || die "task $ID relaunches against a project with bin/wayfinder-lifecycle-gate; pass --wayfinder-state <snapshot> so Firstmate can verify handoff"
+          if [ "$WAYFINDER_STATE" = - ]; then
+            WAYFINDER_STATE_TEMP=$(mktemp "$STATE/.wayfinder-state.XXXXXX") \
+              || die "could not materialize the Wayfinder snapshot for $ID's relaunch"
+            cat > "$WAYFINDER_STATE_TEMP" \
+              || die "could not read the Wayfinder snapshot for $ID's relaunch"
+            WAYFINDER_STATE=$WAYFINDER_STATE_TEMP
+          fi
           "$SCRIPT_DIR/fm-wayfinder-parent.sh" handoff --project "$project" --state "$WAYFINDER_STATE" \
             || die "the Wayfinder handoff for $ID was rejected before its agent was stopped"
           ;;

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -50,6 +50,9 @@
 #              the prior durable record in place and reports the concrete
 #              state; it never leaves a half-transitioned task claiming to be
 #              running.
+#              A map-dependent ship relaunch for a project that publishes
+#              bin/wayfinder-lifecycle-gate requires --wayfinder-state so
+#              fm-spawn can check handoff; a recorded map-independent task is exempt.
 #
 # Teardown and discard are NOT verbs here and never will be. `exit` stops an
 # agent and preserves everything else; removing a worktree, killing an

--- a/bin/fm-promote.sh
+++ b/bin/fm-promote.sh
@@ -12,7 +12,10 @@
 # read the scout's report (AGENTS.md section 7); data/projects.md holds the
 # captain's standing posture as context, and this script never looks it up.
 # no-mistakes-prod-only is a registry policy rather than a task mode and is refused.
-# Usage: fm-promote.sh <task-id> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off>
+# Usage: fm-promote.sh <task-id> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off> [--wayfinder-state <file>|--wayfinder-independent]
+# Promoting a scout onto a project that publishes bin/wayfinder-lifecycle-gate
+# is map-dependent implementation dispatch: it requires that command's handoff
+# through bin/fm-wayfinder-parent.sh unless --wayfinder-independent is passed.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -27,8 +30,11 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 
 MODE=
 YOLO=
+WAYFINDER_STATE=
 MODE_SET=0
 YOLO_SET=0
+WAYFINDER_STATE_SET=0
+WAYFINDER_INDEPENDENT=0
 POS=()
 want_value=
 for a in "$@"; do
@@ -39,6 +45,7 @@ for a in "$@"; do
     case "$want_value" in
       mode) MODE=$a; MODE_SET=1 ;;
       yolo) YOLO=$a; YOLO_SET=1 ;;
+      wayfinder-state) WAYFINDER_STATE=$a; WAYFINDER_STATE_SET=1 ;;
     esac
     want_value=
     continue
@@ -48,11 +55,15 @@ for a in "$@"; do
     --mode=*) MODE=${a#--mode=}; MODE_SET=1 ;;
     --yolo) want_value=yolo ;;
     --yolo=*) YOLO=${a#--yolo=}; YOLO_SET=1 ;;
+    --wayfinder-state) want_value=wayfinder-state ;;
+    --wayfinder-state=*) WAYFINDER_STATE=${a#--wayfinder-state=}; WAYFINDER_STATE_SET=1 ;;
+    --wayfinder-independent) WAYFINDER_INDEPENDENT=1 ;;
     *) POS+=("$a") ;;
   esac
 done
 [ -z "$want_value" ] || { echo "error: --$want_value requires a value" >&2; exit 1; }
-[ "${#POS[@]}" -ge 1 ] || { echo "usage: fm-promote.sh <task-id> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off>" >&2; exit 1; }
+[ "${#POS[@]}" -ge 1 ] || { echo "usage: fm-promote.sh <task-id> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off> [--wayfinder-state <file>|--wayfinder-independent]" >&2; exit 1; }
+[ "$WAYFINDER_STATE_SET" -eq 0 ] || [ -n "$WAYFINDER_STATE" ] || { echo "error: --wayfinder-state requires a non-empty value" >&2; exit 1; }
 [ "$MODE_SET" -eq 1 ] || {
   echo "error: promotion requires --mode <no-mistakes|direct-PR|local-only>; decide it now from the scout's findings and the project's registered posture in data/projects.md" >&2
   exit 1
@@ -107,6 +118,18 @@ fm_lock_acquire_wait "$META_LOCK"
 META_LOCK_HELD=1
 [ -f "$META" ] || { echo "error: no meta for task $ID at $META" >&2; exit 1; }
 grep -qx 'kind=scout' "$META" || { echo "error: task $ID is not a scout task (kind=scout not in meta)" >&2; exit 1; }
+
+PROMOTE_PROJECT=$(grep '^project=' "$META" | tail -1 | cut -d= -f2- || true)
+if [ -n "$PROMOTE_PROJECT" ] && [ -f "$PROMOTE_PROJECT/bin/wayfinder-lifecycle-gate" ]; then
+  if [ "$WAYFINDER_INDEPENDENT" -eq 0 ]; then
+    if [ "$WAYFINDER_STATE_SET" -eq 0 ]; then
+      echo "error: $ID promotes onto a project with bin/wayfinder-lifecycle-gate; pass --wayfinder-state <snapshot> so Firstmate can verify handoff, or --wayfinder-independent when this work does not depend on the Wayfinder map" >&2
+      exit 1
+    fi
+    "$FM_ROOT/bin/fm-wayfinder-parent.sh" handoff --project "$PROMOTE_PROJECT" --state "$WAYFINDER_STATE" \
+      || exit $?
+  fi
+fi
 
 TMP="$STATE/.$ID.meta.promote.${BASHPID:-$$}"
 grep -v -e '^kind=' -e '^mode=' -e '^yolo=' "$META" > "$TMP"

--- a/bin/fm-promote.sh
+++ b/bin/fm-promote.sh
@@ -133,7 +133,8 @@ if [ -n "$PROMOTE_PROJECT" ] && [ -f "$PROMOTE_PROJECT/bin/wayfinder-lifecycle-g
 fi
 
 TMP="$STATE/.$ID.meta.promote.${BASHPID:-$$}"
-grep -v -e '^kind=' -e '^mode=' -e '^yolo=' -e '^wayfinder_independent=' "$META" > "$TMP"
+grep -v -e '^kind=' -e '^mode=' -e '^yolo=' -e '^wayfinder_independent=' \
+  -e '^wayfinder_child=' -e '^wayfinder_no_child=' "$META" > "$TMP"
 {
   echo "kind=ship"
   echo "mode=$MODE"

--- a/bin/fm-promote.sh
+++ b/bin/fm-promote.sh
@@ -64,6 +64,7 @@ done
 [ -z "$want_value" ] || { echo "error: --$want_value requires a value" >&2; exit 1; }
 [ "${#POS[@]}" -ge 1 ] || { echo "usage: fm-promote.sh <task-id> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off> [--wayfinder-state <file>|--wayfinder-independent]" >&2; exit 1; }
 [ "$WAYFINDER_STATE_SET" -eq 0 ] || [ -n "$WAYFINDER_STATE" ] || { echo "error: --wayfinder-state requires a non-empty value" >&2; exit 1; }
+[ "$WAYFINDER_STATE_SET" -eq 0 ] || [ "$WAYFINDER_INDEPENDENT" -eq 0 ] || { echo "error: --wayfinder-state and --wayfinder-independent cannot be combined" >&2; exit 1; }
 [ "$MODE_SET" -eq 1 ] || {
   echo "error: promotion requires --mode <no-mistakes|direct-PR|local-only>; decide it now from the scout's findings and the project's registered posture in data/projects.md" >&2
   exit 1

--- a/bin/fm-promote.sh
+++ b/bin/fm-promote.sh
@@ -16,6 +16,8 @@
 # Promoting a scout onto a project that publishes bin/wayfinder-lifecycle-gate
 # is map-dependent implementation dispatch: it requires that command's handoff
 # through bin/fm-wayfinder-parent.sh unless --wayfinder-independent is passed.
+# A recorded Wayfinder child remains attached through promotion for teardown's
+# accept-child check; a no-child scout classification is removed with the scout kind.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -134,7 +136,7 @@ fi
 
 TMP="$STATE/.$ID.meta.promote.${BASHPID:-$$}"
 grep -v -e '^kind=' -e '^mode=' -e '^yolo=' -e '^wayfinder_independent=' \
-  -e '^wayfinder_child=' -e '^wayfinder_no_child=' "$META" > "$TMP"
+  -e '^wayfinder_no_child=' "$META" > "$TMP"
 {
   echo "kind=ship"
   echo "mode=$MODE"

--- a/bin/fm-promote.sh
+++ b/bin/fm-promote.sh
@@ -12,12 +12,11 @@
 # read the scout's report (AGENTS.md section 7); data/projects.md holds the
 # captain's standing posture as context, and this script never looks it up.
 # no-mistakes-prod-only is a registry policy rather than a task mode and is refused.
-# Usage: fm-promote.sh <task-id> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off> [--wayfinder-state <file>|--wayfinder-independent]
+# Usage: fm-promote.sh <task-id> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off> [--wayfinder-state <file>|--wayfinder-independent] [--wayfinder-child <number-or-title>|--wayfinder-no-child]
 # Promoting a scout onto a project that publishes bin/wayfinder-lifecycle-gate
 # is map-dependent implementation dispatch: it requires that command's handoff
 # through bin/fm-wayfinder-parent.sh unless --wayfinder-independent is passed.
-# A recorded Wayfinder child remains attached through promotion for teardown's
-# accept-child check; a no-child scout classification is removed with the scout kind.
+# A Wayfinder child or no-child classification remains attached through promotion.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -37,6 +36,9 @@ MODE_SET=0
 YOLO_SET=0
 WAYFINDER_STATE_SET=0
 WAYFINDER_INDEPENDENT=0
+WAYFINDER_CHILD=
+WAYFINDER_CHILD_SET=0
+WAYFINDER_NO_CHILD=0
 POS=()
 want_value=
 for a in "$@"; do
@@ -48,6 +50,7 @@ for a in "$@"; do
       mode) MODE=$a; MODE_SET=1 ;;
       yolo) YOLO=$a; YOLO_SET=1 ;;
       wayfinder-state) WAYFINDER_STATE=$a; WAYFINDER_STATE_SET=1 ;;
+      wayfinder-child) WAYFINDER_CHILD=$a; WAYFINDER_CHILD_SET=1 ;;
     esac
     want_value=
     continue
@@ -59,13 +62,23 @@ for a in "$@"; do
     --yolo=*) YOLO=${a#--yolo=}; YOLO_SET=1 ;;
     --wayfinder-state) want_value=wayfinder-state ;;
     --wayfinder-state=*) WAYFINDER_STATE=${a#--wayfinder-state=}; WAYFINDER_STATE_SET=1 ;;
+    --wayfinder-child) want_value=wayfinder-child ;;
+    --wayfinder-child=*) WAYFINDER_CHILD=${a#--wayfinder-child=}; WAYFINDER_CHILD_SET=1 ;;
+    --wayfinder-no-child) WAYFINDER_NO_CHILD=1 ;;
     --wayfinder-independent) WAYFINDER_INDEPENDENT=1 ;;
     *) POS+=("$a") ;;
   esac
 done
 [ -z "$want_value" ] || { echo "error: --$want_value requires a value" >&2; exit 1; }
-[ "${#POS[@]}" -ge 1 ] || { echo "usage: fm-promote.sh <task-id> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off> [--wayfinder-state <file>|--wayfinder-independent]" >&2; exit 1; }
+[ "${#POS[@]}" -ge 1 ] || { echo "usage: fm-promote.sh <task-id> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off> [--wayfinder-state <file>|--wayfinder-independent] [--wayfinder-child <number-or-title>|--wayfinder-no-child]" >&2; exit 1; }
 [ "$WAYFINDER_STATE_SET" -eq 0 ] || [ -n "$WAYFINDER_STATE" ] || { echo "error: --wayfinder-state requires a non-empty value" >&2; exit 1; }
+[ "$WAYFINDER_CHILD_SET" -eq 0 ] || [ -n "$WAYFINDER_CHILD" ] || { echo "error: --wayfinder-child requires a non-empty value" >&2; exit 1; }
+if [ "$WAYFINDER_CHILD_SET" -eq 1 ]; then
+  case "$WAYFINDER_CHILD" in
+    *$'\n'*|*$'\r'*) echo "error: --wayfinder-child must be one line" >&2; exit 1 ;;
+  esac
+fi
+[ "$WAYFINDER_CHILD_SET" -eq 0 ] || [ "$WAYFINDER_NO_CHILD" -eq 0 ] || { echo "error: --wayfinder-child and --wayfinder-no-child cannot be combined" >&2; exit 1; }
 [ "$WAYFINDER_STATE_SET" -eq 0 ] || [ "$WAYFINDER_INDEPENDENT" -eq 0 ] || { echo "error: --wayfinder-state and --wayfinder-independent cannot be combined" >&2; exit 1; }
 [ "$MODE_SET" -eq 1 ] || {
   echo "error: promotion requires --mode <no-mistakes|direct-PR|local-only>; decide it now from the scout's findings and the project's registered posture in data/projects.md" >&2
@@ -123,7 +136,40 @@ META_LOCK_HELD=1
 grep -qx 'kind=scout' "$META" || { echo "error: task $ID is not a scout task (kind=scout not in meta)" >&2; exit 1; }
 
 PROMOTE_PROJECT=$(grep '^project=' "$META" | tail -1 | cut -d= -f2- || true)
+PROMOTE_WAYFINDER_CHILD=$(grep '^wayfinder_child=' "$META" | tail -1 | cut -d= -f2- || true)
+case "$PROMOTE_WAYFINDER_CHILD" in
+  *$'\n'*|*$'\r'*)
+    echo "error: task $ID has an invalid Wayfinder child record" >&2
+    exit 1
+    ;;
+esac
+PROMOTE_WAYFINDER_NO_CHILD=$(grep '^wayfinder_no_child=' "$META" | tail -1 | cut -d= -f2- || true)
+case "$PROMOTE_WAYFINDER_NO_CHILD" in
+  ''|1) ;;
+  *)
+    echo "error: task $ID has an invalid Wayfinder classification record" >&2
+    exit 1
+    ;;
+esac
+if [ -n "$PROMOTE_WAYFINDER_CHILD" ] && [ "$PROMOTE_WAYFINDER_NO_CHILD" = 1 ]; then
+  echo "error: task $ID has contradictory Wayfinder classification records" >&2
+  exit 1
+fi
 if [ -n "$PROMOTE_PROJECT" ] && [ -f "$PROMOTE_PROJECT/bin/wayfinder-lifecycle-gate" ]; then
+  if [ -n "$PROMOTE_WAYFINDER_CHILD" ] || [ "$PROMOTE_WAYFINDER_NO_CHILD" = 1 ]; then
+    [ "$WAYFINDER_CHILD_SET" -eq 0 ] && [ "$WAYFINDER_NO_CHILD" -eq 0 ] || {
+      echo "error: task $ID already records a Wayfinder classification; do not override it during promotion" >&2
+      exit 1
+    }
+  elif [ "$WAYFINDER_CHILD_SET" -eq 1 ]; then
+    PROMOTE_WAYFINDER_CHILD=$WAYFINDER_CHILD
+  elif [ "$WAYFINDER_NO_CHILD" -eq 1 ]; then
+    PROMOTE_WAYFINDER_NO_CHILD=1
+  else
+    echo "REFUSED: scout task $ID has no Wayfinder classification." >&2
+    echo "Pass --wayfinder-child <number-or-title> or --wayfinder-no-child before promotion." >&2
+    exit 1
+  fi
   if [ "$WAYFINDER_INDEPENDENT" -eq 0 ]; then
     if [ "$WAYFINDER_STATE_SET" -eq 0 ]; then
       echo "error: $ID promotes onto a project with bin/wayfinder-lifecycle-gate; pass --wayfinder-state <snapshot> so Firstmate can verify handoff, or --wayfinder-independent when this work does not depend on the Wayfinder map" >&2
@@ -132,16 +178,21 @@ if [ -n "$PROMOTE_PROJECT" ] && [ -f "$PROMOTE_PROJECT/bin/wayfinder-lifecycle-g
     "$FM_ROOT/bin/fm-wayfinder-parent.sh" handoff --project "$PROMOTE_PROJECT" --state "$WAYFINDER_STATE" \
       || exit $?
   fi
+elif [ "$WAYFINDER_CHILD_SET" -eq 1 ] || [ "$WAYFINDER_NO_CHILD" -eq 1 ]; then
+  echo "error: --wayfinder-child and --wayfinder-no-child require a project that publishes bin/wayfinder-lifecycle-gate" >&2
+  exit 1
 fi
 
 TMP="$STATE/.$ID.meta.promote.${BASHPID:-$$}"
 grep -v -e '^kind=' -e '^mode=' -e '^yolo=' -e '^wayfinder_independent=' \
-  -e '^wayfinder_no_child=' "$META" > "$TMP"
+  -e '^wayfinder_child=' -e '^wayfinder_no_child=' "$META" > "$TMP"
 {
   echo "kind=ship"
   echo "mode=$MODE"
   echo "yolo=$YOLO"
   [ "$WAYFINDER_INDEPENDENT" -eq 0 ] || echo "wayfinder_independent=1"
+  [ -z "$PROMOTE_WAYFINDER_CHILD" ] || echo "wayfinder_child=$PROMOTE_WAYFINDER_CHILD"
+  [ "$PROMOTE_WAYFINDER_NO_CHILD" != 1 ] || echo "wayfinder_no_child=1"
 } >> "$TMP"
 mv "$TMP" "$META"
 TMP=

--- a/bin/fm-promote.sh
+++ b/bin/fm-promote.sh
@@ -133,11 +133,12 @@ if [ -n "$PROMOTE_PROJECT" ] && [ -f "$PROMOTE_PROJECT/bin/wayfinder-lifecycle-g
 fi
 
 TMP="$STATE/.$ID.meta.promote.${BASHPID:-$$}"
-grep -v -e '^kind=' -e '^mode=' -e '^yolo=' "$META" > "$TMP"
+grep -v -e '^kind=' -e '^mode=' -e '^yolo=' -e '^wayfinder_independent=' "$META" > "$TMP"
 {
   echo "kind=ship"
   echo "mode=$MODE"
   echo "yolo=$YOLO"
+  [ "$WAYFINDER_INDEPENDENT" -eq 0 ] || echo "wayfinder_independent=1"
 } >> "$TMP"
 mv "$TMP" "$META"
 TMP=

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2,7 +2,7 @@
 # Spawn a direct report: a crewmate in a treehouse or Orca worktree, or a
 # secondmate in its isolated firstmate home.
 # Usage: fm-spawn.sh <task-id> <project-dir> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] [--wayfinder-state <file>|--wayfinder-independent]
-#        fm-spawn.sh <task-id> <project-dir> --scout [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>]
+#        fm-spawn.sh <task-id> <project-dir> --scout [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] [--wayfinder-child <number-or-title>]
 #        fm-spawn.sh <task-id> [<firstmate-home>] [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] --secondmate
 #   --mode and --yolo are this task's delivery contract, REQUIRED for every ship
 #   spawn and refused on --scout and --secondmate spawns. Firstmate resolves both
@@ -64,6 +64,8 @@
 #   --wayfinder-state <snapshot> with the GitHub snapshot that command
 #   consumes. Pass --wayfinder-independent only when this ship does not
 #   depend on the Wayfinder map. Scout and secondmate spawns skip that check.
+#   --wayfinder-child records the named Wayfinder child for a scout. Teardown
+#   requires its fresh accept-child verification before archiving that scout.
 #   The project command owns the resolution policy;
 #   Firstmate only invokes it.
 #   A herdr crewmate or scout is placed in the exact workspace of the firstmate
@@ -286,6 +288,7 @@ YOLO=
 TRACEPARENT_ARG=
 WAYFINDER_STATE=
 WAYFINDER_STATE_TEMP=
+WAYFINDER_CHILD=
 HARNESS_SET=0
 MODEL_SET=0
 EFFORT_SET=0
@@ -294,6 +297,7 @@ MODE_SET=0
 YOLO_SET=0
 TRACEPARENT_SET=0
 WAYFINDER_STATE_SET=0
+WAYFINDER_CHILD_SET=0
 WAYFINDER_INDEPENDENT=0
 WAYFINDER_MAP_INDEPENDENT=0
 RELAUNCH=0
@@ -313,6 +317,7 @@ for a in "$@"; do
       yolo) YOLO=$a; YOLO_SET=1 ;;
       traceparent) TRACEPARENT_ARG=$a; TRACEPARENT_SET=1 ;;
       wayfinder-state) WAYFINDER_STATE=$a; WAYFINDER_STATE_SET=1 ;;
+      wayfinder-child) WAYFINDER_CHILD=$a; WAYFINDER_CHILD_SET=1 ;;
       *) echo "error: internal parser state for --$want_value" >&2; exit 1 ;;
     esac
     want_value=
@@ -338,6 +343,8 @@ for a in "$@"; do
     --traceparent=*) TRACEPARENT_ARG=${a#--traceparent=}; TRACEPARENT_SET=1 ;;
     --wayfinder-state) want_value=wayfinder-state ;;
     --wayfinder-state=*) WAYFINDER_STATE=${a#--wayfinder-state=}; WAYFINDER_STATE_SET=1 ;;
+    --wayfinder-child) want_value=wayfinder-child ;;
+    --wayfinder-child=*) WAYFINDER_CHILD=${a#--wayfinder-child=}; WAYFINDER_CHILD_SET=1 ;;
     --wayfinder-independent) WAYFINDER_INDEPENDENT=1 ;;
     *) POS+=("$a") ;;
   esac
@@ -351,6 +358,12 @@ done
 [ "$YOLO_SET" -eq 0 ] || [ -n "$YOLO" ] || { echo "error: --yolo requires a non-empty value" >&2; exit 1; }
 [ "$TRACEPARENT_SET" -eq 0 ] || [ -n "$TRACEPARENT_ARG" ] || { echo "error: --traceparent requires a non-empty value" >&2; exit 1; }
 [ "$WAYFINDER_STATE_SET" -eq 0 ] || [ -n "$WAYFINDER_STATE" ] || { echo "error: --wayfinder-state requires a non-empty value" >&2; exit 1; }
+[ "$WAYFINDER_CHILD_SET" -eq 0 ] || [ -n "$WAYFINDER_CHILD" ] || { echo "error: --wayfinder-child requires a non-empty value" >&2; exit 1; }
+if [ "$WAYFINDER_CHILD_SET" -eq 1 ]; then
+  case "$WAYFINDER_CHILD" in
+    *$'\n'*|*$'\r'*) echo "error: --wayfinder-child must be one line" >&2; exit 1 ;;
+  esac
+fi
 [ "$WAYFINDER_STATE_SET" -eq 0 ] || [ "$WAYFINDER_INDEPENDENT" -eq 0 ] || { echo "error: --wayfinder-state and --wayfinder-independent cannot be combined" >&2; exit 1; }
 resolve_project_dir_arg() {
   local path=$1
@@ -387,12 +400,17 @@ if [ "$RELAUNCH" -eq 1 ]; then
   [ "$MODE_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded delivery mode; --mode cannot override it" >&2; exit 1; }
   [ "$YOLO_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded yolo posture; --yolo cannot override it" >&2; exit 1; }
   [ "$WAYFINDER_INDEPENDENT" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded Wayfinder dependency; --wayfinder-independent cannot override it" >&2; exit 1; }
+  [ "$WAYFINDER_CHILD_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded Wayfinder child; --wayfinder-child cannot override it" >&2; exit 1; }
 else
   # Delivery contract (AGENTS.md section 7). A ship task's mode and yolo are
   # firstmate's per-task decision, so they are required and closed-set validated
   # here rather than resolved from the project registry. Scouts deliver a report
   # and record no delivery posture; secondmate spawns hardcode theirs.
   if [ "$KIND" = ship ]; then
+    [ "$WAYFINDER_CHILD_SET" -eq 0 ] || {
+      echo "error: --wayfinder-child applies only to scout spawns" >&2
+      exit 1
+    }
     [ "$MODE_SET" -eq 1 ] || {
       echo "error: ship spawns require --mode <no-mistakes|direct-PR|local-only>; resolve it at intake from the captain's instruction and the project's registered posture in data/projects.md" >&2
       exit 1
@@ -429,6 +447,10 @@ else
       echo "error: --wayfinder-independent applies only to ship spawns; a scout stays off the map-dependent handoff path" >&2
       exit 1
     }
+    if [ "$KIND" != scout ] && [ "$WAYFINDER_CHILD_SET" -eq 1 ]; then
+      echo "error: --wayfinder-child applies only to scout spawns" >&2
+      exit 1
+    fi
   fi
 fi
 
@@ -890,6 +912,10 @@ if [ "$RELAUNCH" -eq 1 ] && [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart"
   exit 1
 fi
 if [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart" ] && case "$idpart" in */*) false ;; *) true ;; esac; then
+  [ "$WAYFINDER_CHILD_SET" -eq 0 ] || {
+    echo "error: --wayfinder-child is single-scout only; spawn each named Wayfinder scout separately" >&2
+    exit 1
+  }
   if [ "$KIND" != secondmate ] && [ -z "$HARNESS_ARG" ] && [ -f "$CONFIG/crew-dispatch.json" ]; then
     echo "error: config/crew-dispatch.json is active - pass an explicit harness resolved from the dispatch rules (the consultation backstop, so the rules are never silently skipped)." >&2
     exit 1
@@ -2739,6 +2765,7 @@ preserve_relaunch_meta() {
   [ -z "$MODE" ] || echo "mode=$MODE"
   [ -z "$YOLO" ] || echo "yolo=$YOLO"
   [ "$WAYFINDER_MAP_INDEPENDENT" -eq 0 ] || echo "wayfinder_independent=1"
+  [ "$WAYFINDER_CHILD_SET" -eq 0 ] || echo "wayfinder_child=$WAYFINDER_CHILD"
   echo "tasktmp=$TASK_TMP"
   echo "model=${MODEL:-default}"
   echo "effort=${EFFORT:-default}"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2,7 +2,7 @@
 # Spawn a direct report: a crewmate in a treehouse or Orca worktree, or a
 # secondmate in its isolated firstmate home.
 # Usage: fm-spawn.sh <task-id> <project-dir> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] [--wayfinder-state <file>|--wayfinder-independent]
-#        fm-spawn.sh <task-id> <project-dir> --scout [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] [--wayfinder-child <number-or-title>]
+#        fm-spawn.sh <task-id> <project-dir> --scout [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] [--wayfinder-child <number-or-title>|--wayfinder-no-child]
 #        fm-spawn.sh <task-id> [<firstmate-home>] [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] --secondmate
 #   --mode and --yolo are this task's delivery contract, REQUIRED for every ship
 #   spawn and refused on --scout and --secondmate spawns. Firstmate resolves both
@@ -64,8 +64,8 @@
 #   --wayfinder-state <snapshot> with the GitHub snapshot that command
 #   consumes. Pass --wayfinder-independent only when this ship does not
 #   depend on the Wayfinder map. Scout and secondmate spawns skip that check.
-#   --wayfinder-child records the named Wayfinder child for a scout. Teardown
-#   requires its fresh accept-child verification before archiving that scout.
+#   A scout against a project that publishes bin/wayfinder-lifecycle-gate must
+#   record --wayfinder-child or --wayfinder-no-child for teardown.
 #   The project command owns the resolution policy;
 #   Firstmate only invokes it.
 #   A herdr crewmate or scout is placed in the exact workspace of the firstmate
@@ -153,7 +153,7 @@
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
 #   source of truth; shared --scout/--harness/--model/--effort/--backend/--mode/--yolo
 #   and the ship-only --wayfinder-state/--wayfinder-independent flags
-#   apply to every pair. A ship batch therefore carries one delivery contract, and each
+#   plus scout-only --wayfinder-no-child apply to every pair. A ship batch therefore carries one delivery contract, and each
 #   pair still checks it against its own brief; a batch spanning modes is two invocations.
 #   If config/crew-dispatch.json exists, shared --harness is required for crewmate
 #   and scout batches. The loop lives here, in bash, so callers never hand-write a
@@ -298,6 +298,7 @@ YOLO_SET=0
 TRACEPARENT_SET=0
 WAYFINDER_STATE_SET=0
 WAYFINDER_CHILD_SET=0
+WAYFINDER_NO_CHILD=0
 WAYFINDER_INDEPENDENT=0
 WAYFINDER_MAP_INDEPENDENT=0
 RELAUNCH=0
@@ -345,6 +346,7 @@ for a in "$@"; do
     --wayfinder-state=*) WAYFINDER_STATE=${a#--wayfinder-state=}; WAYFINDER_STATE_SET=1 ;;
     --wayfinder-child) want_value=wayfinder-child ;;
     --wayfinder-child=*) WAYFINDER_CHILD=${a#--wayfinder-child=}; WAYFINDER_CHILD_SET=1 ;;
+    --wayfinder-no-child) WAYFINDER_NO_CHILD=1 ;;
     --wayfinder-independent) WAYFINDER_INDEPENDENT=1 ;;
     *) POS+=("$a") ;;
   esac
@@ -364,6 +366,10 @@ if [ "$WAYFINDER_CHILD_SET" -eq 1 ]; then
     *$'\n'*|*$'\r'*) echo "error: --wayfinder-child must be one line" >&2; exit 1 ;;
   esac
 fi
+[ "$WAYFINDER_CHILD_SET" -eq 0 ] || [ "$WAYFINDER_NO_CHILD" -eq 0 ] || {
+  echo "error: --wayfinder-child and --wayfinder-no-child cannot be combined" >&2
+  exit 1
+}
 [ "$WAYFINDER_STATE_SET" -eq 0 ] || [ "$WAYFINDER_INDEPENDENT" -eq 0 ] || { echo "error: --wayfinder-state and --wayfinder-independent cannot be combined" >&2; exit 1; }
 resolve_project_dir_arg() {
   local path=$1
@@ -401,6 +407,7 @@ if [ "$RELAUNCH" -eq 1 ]; then
   [ "$YOLO_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded yolo posture; --yolo cannot override it" >&2; exit 1; }
   [ "$WAYFINDER_INDEPENDENT" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded Wayfinder dependency; --wayfinder-independent cannot override it" >&2; exit 1; }
   [ "$WAYFINDER_CHILD_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded Wayfinder child; --wayfinder-child cannot override it" >&2; exit 1; }
+  [ "$WAYFINDER_NO_CHILD" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded Wayfinder classification; --wayfinder-no-child cannot override it" >&2; exit 1; }
 else
   # Delivery contract (AGENTS.md section 7). A ship task's mode and yolo are
   # firstmate's per-task decision, so they are required and closed-set validated
@@ -409,6 +416,10 @@ else
   if [ "$KIND" = ship ]; then
     [ "$WAYFINDER_CHILD_SET" -eq 0 ] || {
       echo "error: --wayfinder-child applies only to scout spawns" >&2
+      exit 1
+    }
+    [ "$WAYFINDER_NO_CHILD" -eq 0 ] || {
+      echo "error: --wayfinder-no-child applies only to scout spawns" >&2
       exit 1
     }
     [ "$MODE_SET" -eq 1 ] || {
@@ -447,8 +458,8 @@ else
       echo "error: --wayfinder-independent applies only to ship spawns; a scout stays off the map-dependent handoff path" >&2
       exit 1
     }
-    if [ "$KIND" != scout ] && [ "$WAYFINDER_CHILD_SET" -eq 1 ]; then
-      echo "error: --wayfinder-child applies only to scout spawns" >&2
+    if [ "$KIND" != scout ] && { [ "$WAYFINDER_CHILD_SET" -eq 1 ] || [ "$WAYFINDER_NO_CHILD" -eq 1 ]; }; then
+      echo "error: --wayfinder-child and --wayfinder-no-child apply only to scout spawns" >&2
       exit 1
     fi
   fi
@@ -968,6 +979,7 @@ if [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart" ] && case "$idpart" in *
     shared_args+=(--wayfinder-state "$WAYFINDER_STATE")
   fi
   [ "$WAYFINDER_INDEPENDENT" -eq 0 ] || shared_args+=(--wayfinder-independent)
+  [ "$WAYFINDER_NO_CHILD" -eq 0 ] || shared_args+=(--wayfinder-no-child)
   for pair in "${POS[@]}"; do
     case "$pair" in
       *=*) : ;;
@@ -1739,6 +1751,18 @@ else
   BRIEF="$DATA/$ID/brief.md"
 fi
 [ -f "$BRIEF" ] || { echo "error: no brief at $BRIEF" >&2; exit 1; }
+
+if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" = scout ]; then
+  if [ -f "$PROJ_ABS/bin/wayfinder-lifecycle-gate" ]; then
+    if [ "$WAYFINDER_CHILD_SET" -eq "$WAYFINDER_NO_CHILD" ]; then
+      echo "error: $ID scouts against a project with bin/wayfinder-lifecycle-gate; pass --wayfinder-child <number-or-title> or --wayfinder-no-child before the endpoint is created" >&2
+      exit 1
+    fi
+  elif [ "$WAYFINDER_CHILD_SET" -eq 1 ] || [ "$WAYFINDER_NO_CHILD" -eq 1 ]; then
+    echo "error: --wayfinder-child and --wayfinder-no-child require a project that publishes bin/wayfinder-lifecycle-gate" >&2
+    exit 1
+  fi
+fi
 
 delivery_rigor_rank() {  # <mode> -> 3 (most rigor) .. 1 (least); 0 = not a task mode
   case "$1" in
@@ -2766,6 +2790,7 @@ preserve_relaunch_meta() {
   [ -z "$YOLO" ] || echo "yolo=$YOLO"
   [ "$WAYFINDER_MAP_INDEPENDENT" -eq 0 ] || echo "wayfinder_independent=1"
   [ "$WAYFINDER_CHILD_SET" -eq 0 ] || echo "wayfinder_child=$WAYFINDER_CHILD"
+  [ "$WAYFINDER_NO_CHILD" -eq 0 ] || echo "wayfinder_no_child=1"
   echo "tasktmp=$TASK_TMP"
   echo "model=${MODEL:-default}"
   echo "effort=${EFFORT:-default}"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -285,6 +285,7 @@ MODE=
 YOLO=
 TRACEPARENT_ARG=
 WAYFINDER_STATE=
+WAYFINDER_STATE_TEMP=
 HARNESS_SET=0
 MODEL_SET=0
 EFFORT_SET=0
@@ -814,6 +815,7 @@ spawn_abort_cleanup() {
     fm_lock_release "$SPAWN_CONTROL_LOCK" || true
   fi
   [ -z "$SPAWN_META_TMP" ] || rm -f "$SPAWN_META_TMP" 2>/dev/null || true
+  [ -z "$WAYFINDER_STATE_TEMP" ] || rm -f "$WAYFINDER_STATE_TEMP" 2>/dev/null || true
   if [ "$CONFIG_INHERIT_LOCK_HELD" = 1 ]; then
     CONFIG_INHERIT_LOCK_HELD=0
     fm_lock_release "$CONFIG_INHERIT_LOCK" || true
@@ -922,6 +924,21 @@ if [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart" ] && case "$idpart" in *
       fi
       batch_wayfinder_project=$batch_project
     done
+    if [ "$WAYFINDER_STATE" = - ]; then
+      mkdir -p "$STATE" || {
+        echo "error: could not create parent state directory for the Wayfinder snapshot" >&2
+        exit 1
+      }
+      WAYFINDER_STATE_TEMP=$(mktemp "$STATE/.wayfinder-state.XXXXXX") || {
+        echo "error: could not materialize the Wayfinder snapshot for batch dispatch" >&2
+        exit 1
+      }
+      cat > "$WAYFINDER_STATE_TEMP" || {
+        echo "error: could not read the Wayfinder snapshot for batch dispatch" >&2
+        exit 1
+      }
+      WAYFINDER_STATE=$WAYFINDER_STATE_TEMP
+    fi
     shared_args+=(--wayfinder-state "$WAYFINDER_STATE")
   fi
   [ "$WAYFINDER_INDEPENDENT" -eq 0 ] || shared_args+=(--wayfinder-independent)

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -66,6 +66,10 @@
 #   depend on the Wayfinder map. Scout and secondmate spawns skip that check.
 #   A scout against a project that publishes bin/wayfinder-lifecycle-gate must
 #   record --wayfinder-child or --wayfinder-no-child for teardown.
+#   Wayfinder task metadata records wayfinder_independent=1 for a ship exempt
+#   from relaunch handoff, or exactly one scout classification:
+#   wayfinder_child=<number-or-title>, which teardown verifies with accept-child,
+#   or wayfinder_no_child=1, which records ordinary scout teardown.
 #   The project command owns the resolution policy;
 #   Firstmate only invokes it.
 #   A herdr crewmate or scout is placed in the exact workspace of the firstmate

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -67,9 +67,9 @@
 #   A scout against a project that publishes bin/wayfinder-lifecycle-gate must
 #   record --wayfinder-child or --wayfinder-no-child for teardown.
 #   Wayfinder task metadata records wayfinder_independent=1 for a ship exempt
-#   from relaunch handoff, or exactly one scout classification:
+#   from relaunch handoff, or exactly one child classification:
 #   wayfinder_child=<number-or-title>, which teardown verifies with accept-child,
-#   or wayfinder_no_child=1, which records ordinary scout teardown.
+#   or wayfinder_no_child=1, which records a task with no named child.
 #   The project command owns the resolution policy;
 #   Firstmate only invokes it.
 #   A herdr crewmate or scout is placed in the exact workspace of the firstmate
@@ -1820,6 +1820,10 @@ if [ "$KIND" = ship ] && [ -f "$PROJ_ABS/bin/wayfinder-lifecycle-gate" ]; then
     echo "error: $ID is recorded map-independent; --wayfinder-state does not apply to its relaunch" >&2
     exit 1
   fi
+fi
+if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" = ship ] \
+   && [ -f "$PROJ_ABS/bin/wayfinder-lifecycle-gate" ]; then
+  WAYFINDER_NO_CHILD=1
 fi
 
 BRIEF_DIR_REAL=$(cd "$(dirname "$BRIEF")" && pwd -P)

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -349,6 +349,7 @@ done
 [ "$YOLO_SET" -eq 0 ] || [ -n "$YOLO" ] || { echo "error: --yolo requires a non-empty value" >&2; exit 1; }
 [ "$TRACEPARENT_SET" -eq 0 ] || [ -n "$TRACEPARENT_ARG" ] || { echo "error: --traceparent requires a non-empty value" >&2; exit 1; }
 [ "$WAYFINDER_STATE_SET" -eq 0 ] || [ -n "$WAYFINDER_STATE" ] || { echo "error: --wayfinder-state requires a non-empty value" >&2; exit 1; }
+[ "$WAYFINDER_STATE_SET" -eq 0 ] || [ "$WAYFINDER_INDEPENDENT" -eq 0 ] || { echo "error: --wayfinder-state and --wayfinder-independent cannot be combined" >&2; exit 1; }
 # A parent-delivered carrier replaces this home's own resolution, so it is
 # refused unless it is a secondmate spawn carrying a strictly valid W3C value.
 # Nothing else may reach the pane's TRACEPARENT export.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -16,7 +16,7 @@
 #   loud one-line deviation notice is printed and the spawn continues.
 #   no-mistakes-prod-only is a registry policy rather than a task mode and is
 #   refused as a flag value.
-#        fm-spawn.sh <task-id> --relaunch [--harness <name>] [--model <name>] [--effort <level>]
+#        fm-spawn.sh <task-id> --relaunch [--harness <name>] [--model <name>] [--effort <level>] [--wayfinder-state <file>]
 #   --relaunch launches a replacement agent for an EXISTING task into that
 #   task's own recorded endpoint and worktree instead of creating either. It is
 #   the launch half of the control plane (bin/fm-control.sh relaunch), which
@@ -26,8 +26,8 @@
 #   backend, kind, project or home, worktree, endpoint - comes from the task's
 #   validated state/<id>.meta, so --backend, --scout, --secondmate, a project
 #   positional, and batch pairs are all refused alongside it; only harness,
-#   model, and effort may change, which is what makes a harness switch one
-#   ordinary relaunch. It refuses unless the recorded endpoint is positively
+#   model, effort, and a fresh Wayfinder snapshot may change. It refuses unless
+#   the recorded endpoint is positively
 #   agent-free on a backend with a recovery-grade agent-state classifier (tmux
 #   or herdr), refuses unless the endpoint's shell is sitting in the recorded
 #   worktree, and clears the previous harness's per-task wiring before arming
@@ -63,8 +63,8 @@
 #   bin/fm-wayfinder-parent.sh before any worker endpoint exists. Pass
 #   --wayfinder-state <snapshot> with the GitHub snapshot that command
 #   consumes. Pass --wayfinder-independent only when this ship does not
-#   depend on the Wayfinder map. Scout, secondmate, and --relaunch spawns
-#   skip that check. The project command owns the resolution policy;
+#   depend on the Wayfinder map. Scout and secondmate spawns skip that check.
+#   The project command owns the resolution policy;
 #   Firstmate only invokes it.
 #   A herdr crewmate or scout is placed in the exact workspace of the firstmate
 #   or secondmate process launching it, resolved from that process's own herdr
@@ -294,6 +294,7 @@ YOLO_SET=0
 TRACEPARENT_SET=0
 WAYFINDER_STATE_SET=0
 WAYFINDER_INDEPENDENT=0
+WAYFINDER_MAP_INDEPENDENT=0
 RELAUNCH=0
 POS=()
 want_value=
@@ -350,6 +351,13 @@ done
 [ "$TRACEPARENT_SET" -eq 0 ] || [ -n "$TRACEPARENT_ARG" ] || { echo "error: --traceparent requires a non-empty value" >&2; exit 1; }
 [ "$WAYFINDER_STATE_SET" -eq 0 ] || [ -n "$WAYFINDER_STATE" ] || { echo "error: --wayfinder-state requires a non-empty value" >&2; exit 1; }
 [ "$WAYFINDER_STATE_SET" -eq 0 ] || [ "$WAYFINDER_INDEPENDENT" -eq 0 ] || { echo "error: --wayfinder-state and --wayfinder-independent cannot be combined" >&2; exit 1; }
+resolve_project_dir_arg() {
+  local path=$1
+  case "$path" in
+    projects/*) printf '%s/%s\n' "$PROJECTS" "${path#projects/}" ;;
+    *) printf '%s\n' "$path" ;;
+  esac
+}
 # A parent-delivered carrier replaces this home's own resolution, so it is
 # refused unless it is a secondmate spawn carrying a strictly valid W3C value.
 # Nothing else may reach the pane's TRACEPARENT export.
@@ -377,8 +385,7 @@ if [ "$RELAUNCH" -eq 1 ]; then
   [ "$KIND_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded kind; --scout/--secondmate cannot override it" >&2; exit 1; }
   [ "$MODE_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded delivery mode; --mode cannot override it" >&2; exit 1; }
   [ "$YOLO_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded yolo posture; --yolo cannot override it" >&2; exit 1; }
-  [ "$WAYFINDER_STATE_SET" -eq 0 ] || { echo "error: --relaunch does not re-run Wayfinder handoff; --wayfinder-state cannot override it" >&2; exit 1; }
-  [ "$WAYFINDER_INDEPENDENT" -eq 0 ] || { echo "error: --relaunch does not re-run Wayfinder handoff; --wayfinder-independent cannot override it" >&2; exit 1; }
+  [ "$WAYFINDER_INDEPENDENT" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded Wayfinder dependency; --wayfinder-independent cannot override it" >&2; exit 1; }
 else
   # Delivery contract (AGENTS.md section 7). A ship task's mode and yolo are
   # firstmate's per-task decision, so they are required and closed-set validated
@@ -896,7 +903,27 @@ if [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart" ] && case "$idpart" in *
   # spanning several modes is two invocations rather than a silent mixed dispatch.
   [ "$MODE_SET" -eq 0 ] || shared_args+=(--mode "$MODE")
   [ "$YOLO_SET" -eq 0 ] || shared_args+=(--yolo "$YOLO")
-  [ "$WAYFINDER_STATE_SET" -eq 0 ] || shared_args+=(--wayfinder-state "$WAYFINDER_STATE")
+  if [ "$WAYFINDER_STATE_SET" -eq 1 ]; then
+    batch_wayfinder_project=
+    for pair in "${POS[@]}"; do
+      case "$pair" in
+        *=*) ;;
+        *) continue ;;
+      esac
+      batch_project=$(resolve_project_dir_arg "${pair#*=}")
+      [ -f "$batch_project/bin/wayfinder-lifecycle-gate" ] || continue
+      batch_project=$(cd "$batch_project" && pwd -P) || {
+        echo "error: batch Wayfinder project cannot be resolved: ${pair#*=}" >&2
+        exit 1
+      }
+      if [ -n "$batch_wayfinder_project" ] && [ "$batch_wayfinder_project" != "$batch_project" ]; then
+        echo "error: --wayfinder-state cannot be shared by distinct projects that publish bin/wayfinder-lifecycle-gate; dispatch each project separately" >&2
+        exit 1
+      fi
+      batch_wayfinder_project=$batch_project
+    done
+    shared_args+=(--wayfinder-state "$WAYFINDER_STATE")
+  fi
   [ "$WAYFINDER_INDEPENDENT" -eq 0 ] || shared_args+=(--wayfinder-independent)
   for pair in "${POS[@]}"; do
     case "$pair" in
@@ -1038,6 +1065,11 @@ if [ "$RELAUNCH" -eq 1 ]; then
     exit 1
   }
   RELAUNCH_PRIOR_HARNESS=$(fm_meta_get "$RELAUNCH_META" harness)
+  case "$(fm_meta_get "$RELAUNCH_META" wayfinder_independent)" in
+    ''|0) WAYFINDER_MAP_INDEPENDENT=0 ;;
+    1) WAYFINDER_MAP_INDEPENDENT=1 ;;
+    *) echo "error: task $ID has an invalid wayfinder_independent record; refusing to relaunch" >&2; exit 1 ;;
+  esac
   KIND=$(fm_meta_get "$RELAUNCH_META" kind)
   [ -n "$KIND" ] || KIND=ship
   MODE=$(fm_meta_get "$RELAUNCH_META" mode)
@@ -1497,14 +1529,6 @@ resolved_existing_dir() {
   cd "$path" && pwd -P
 }
 
-resolve_project_dir_arg() {
-  local path=$1
-  case "$path" in
-    projects/*) printf '%s/%s\n' "$PROJECTS" "${path#projects/}" ;;
-    *) printf '%s\n' "$path" ;;
-  esac
-}
-
 path_is_ancestor_of() {
   local ancestor=$1 path=$2
   [ -n "$ancestor" ] || return 1
@@ -1711,16 +1735,19 @@ fi
 # Wayfinder lifecycle command rejects handoff. Presence of that public command
 # is the project-local signal; --wayfinder-independent is the explicit opt-out
 # for work that does not depend on the map. Scout and secondmate spawns never
-# enter this path. Relaunch recovery of an already-dispatched ship is skipped
-# above because --relaunch refuses these flags and returns before this check.
-if [ "$KIND" = ship ] && [ "$RELAUNCH" -eq 0 ] && [ -f "$PROJ_ABS/bin/wayfinder-lifecycle-gate" ]; then
-  if [ "$WAYFINDER_INDEPENDENT" -eq 0 ]; then
+# enter this path.
+[ "$RELAUNCH" -eq 1 ] || WAYFINDER_MAP_INDEPENDENT=$WAYFINDER_INDEPENDENT
+if [ "$KIND" = ship ] && [ -f "$PROJ_ABS/bin/wayfinder-lifecycle-gate" ]; then
+  if [ "$WAYFINDER_MAP_INDEPENDENT" -eq 0 ]; then
     if [ "$WAYFINDER_STATE_SET" -eq 0 ]; then
       echo "error: $ID ships against a project with bin/wayfinder-lifecycle-gate; pass --wayfinder-state <snapshot> so Firstmate can verify handoff, or --wayfinder-independent when this work does not depend on the Wayfinder map" >&2
       exit 1
     fi
     "$FM_ROOT/bin/fm-wayfinder-parent.sh" handoff --project "$PROJ_ABS" --state "$WAYFINDER_STATE" \
       || exit $?
+  elif [ "$WAYFINDER_STATE_SET" -eq 1 ]; then
+    echo "error: $ID is recorded map-independent; --wayfinder-state does not apply to its relaunch" >&2
+    exit 1
   fi
 fi
 
@@ -2679,7 +2706,7 @@ fi
 preserve_relaunch_meta() {
   awk -F= '
     BEGIN {
-      split("window endpoint_task_id worktree project harness kind mode yolo tasktmp model effort busy_gen spawn_gen traceparent backend herdr_session herdr_workspace_id herdr_tab_id herdr_pane_id zellij_session zellij_tab_id zellij_pane_id orca_worktree_id terminal cmux_workspace_id cmux_surface_id home projects control_relaunch_tx", keys, " ")
+      split("window endpoint_task_id worktree project harness kind mode yolo wayfinder_independent tasktmp model effort busy_gen spawn_gen traceparent backend herdr_session herdr_workspace_id herdr_tab_id herdr_pane_id zellij_session zellij_tab_id zellij_pane_id orca_worktree_id terminal cmux_workspace_id cmux_surface_id home projects control_relaunch_tx", keys, " ")
       for (i in keys) owned[keys[i]] = 1
     }
     !($1 in owned)
@@ -2694,6 +2721,7 @@ preserve_relaunch_meta() {
   echo "kind=$KIND"
   [ -z "$MODE" ] || echo "mode=$MODE"
   [ -z "$YOLO" ] || echo "yolo=$YOLO"
+  [ "$WAYFINDER_MAP_INDEPENDENT" -eq 0 ] || echo "wayfinder_independent=1"
   echo "tasktmp=$TASK_TMP"
   echo "model=${MODEL:-default}"
   echo "effort=${EFFORT:-default}"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Spawn a direct report: a crewmate in a treehouse or Orca worktree, or a
 # secondmate in its isolated firstmate home.
-# Usage: fm-spawn.sh <task-id> <project-dir> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>]
+# Usage: fm-spawn.sh <task-id> <project-dir> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] [--wayfinder-state <file>|--wayfinder-independent]
 #        fm-spawn.sh <task-id> <project-dir> --scout [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>]
 #        fm-spawn.sh <task-id> [<firstmate-home>] [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] --secondmate
 #   --mode and --yolo are this task's delivery contract, REQUIRED for every ship
@@ -58,6 +58,14 @@
 #   A backend spawn refusal (missing dependency, version gate, unauthenticated
 #   socket, or unsupported secondmate mode) is terminal for that selected backend;
 #   callers must surface it instead of silently retrying another backend.
+#   A fresh ship spawn against a project that publishes
+#   bin/wayfinder-lifecycle-gate requires that command's handoff through
+#   bin/fm-wayfinder-parent.sh before any worker endpoint exists. Pass
+#   --wayfinder-state <snapshot> with the GitHub snapshot that command
+#   consumes. Pass --wayfinder-independent only when this ship does not
+#   depend on the Wayfinder map. Scout, secondmate, and --relaunch spawns
+#   skip that check. The project command owns the resolution policy;
+#   Firstmate only invokes it.
 #   A herdr crewmate or scout is placed in the exact workspace of the firstmate
 #   or secondmate process launching it, resolved from that process's own herdr
 #   pane rather than from a workspace label (herdr enforces no label uniqueness,
@@ -142,7 +150,8 @@
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
 #   source of truth; shared --scout/--harness/--model/--effort/--backend/--mode/--yolo
-#   applies to every pair. A ship batch therefore carries one delivery contract, and each
+#   and the ship-only --wayfinder-state/--wayfinder-independent flags
+#   apply to every pair. A ship batch therefore carries one delivery contract, and each
 #   pair still checks it against its own brief; a batch spanning modes is two invocations.
 #   If config/crew-dispatch.json exists, shared --harness is required for crewmate
 #   and scout batches. The loop lives here, in bash, so callers never hand-write a
@@ -275,6 +284,7 @@ BACKEND_ARG=
 MODE=
 YOLO=
 TRACEPARENT_ARG=
+WAYFINDER_STATE=
 HARNESS_SET=0
 MODEL_SET=0
 EFFORT_SET=0
@@ -282,6 +292,8 @@ BACKEND_SET=0
 MODE_SET=0
 YOLO_SET=0
 TRACEPARENT_SET=0
+WAYFINDER_STATE_SET=0
+WAYFINDER_INDEPENDENT=0
 RELAUNCH=0
 POS=()
 want_value=
@@ -298,6 +310,7 @@ for a in "$@"; do
       mode) MODE=$a; MODE_SET=1 ;;
       yolo) YOLO=$a; YOLO_SET=1 ;;
       traceparent) TRACEPARENT_ARG=$a; TRACEPARENT_SET=1 ;;
+      wayfinder-state) WAYFINDER_STATE=$a; WAYFINDER_STATE_SET=1 ;;
       *) echo "error: internal parser state for --$want_value" >&2; exit 1 ;;
     esac
     want_value=
@@ -321,6 +334,9 @@ for a in "$@"; do
     --yolo=*) YOLO=${a#--yolo=}; YOLO_SET=1 ;;
     --traceparent) want_value=traceparent ;;
     --traceparent=*) TRACEPARENT_ARG=${a#--traceparent=}; TRACEPARENT_SET=1 ;;
+    --wayfinder-state) want_value=wayfinder-state ;;
+    --wayfinder-state=*) WAYFINDER_STATE=${a#--wayfinder-state=}; WAYFINDER_STATE_SET=1 ;;
+    --wayfinder-independent) WAYFINDER_INDEPENDENT=1 ;;
     *) POS+=("$a") ;;
   esac
 done
@@ -332,6 +348,7 @@ done
 [ "$MODE_SET" -eq 0 ] || [ -n "$MODE" ] || { echo "error: --mode requires a non-empty value" >&2; exit 1; }
 [ "$YOLO_SET" -eq 0 ] || [ -n "$YOLO" ] || { echo "error: --yolo requires a non-empty value" >&2; exit 1; }
 [ "$TRACEPARENT_SET" -eq 0 ] || [ -n "$TRACEPARENT_ARG" ] || { echo "error: --traceparent requires a non-empty value" >&2; exit 1; }
+[ "$WAYFINDER_STATE_SET" -eq 0 ] || [ -n "$WAYFINDER_STATE" ] || { echo "error: --wayfinder-state requires a non-empty value" >&2; exit 1; }
 # A parent-delivered carrier replaces this home's own resolution, so it is
 # refused unless it is a secondmate spawn carrying a strictly valid W3C value.
 # Nothing else may reach the pane's TRACEPARENT export.
@@ -359,6 +376,8 @@ if [ "$RELAUNCH" -eq 1 ]; then
   [ "$KIND_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded kind; --scout/--secondmate cannot override it" >&2; exit 1; }
   [ "$MODE_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded delivery mode; --mode cannot override it" >&2; exit 1; }
   [ "$YOLO_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded yolo posture; --yolo cannot override it" >&2; exit 1; }
+  [ "$WAYFINDER_STATE_SET" -eq 0 ] || { echo "error: --relaunch does not re-run Wayfinder handoff; --wayfinder-state cannot override it" >&2; exit 1; }
+  [ "$WAYFINDER_INDEPENDENT" -eq 0 ] || { echo "error: --relaunch does not re-run Wayfinder handoff; --wayfinder-independent cannot override it" >&2; exit 1; }
 else
   # Delivery contract (AGENTS.md section 7). A ship task's mode and yolo are
   # firstmate's per-task decision, so they are required and closed-set validated
@@ -391,6 +410,14 @@ else
     }
     [ "$YOLO_SET" -eq 0 ] || {
       echo "error: --yolo applies only to ship spawns; a scout delivers a report and a secondmate records its own fixed posture" >&2
+      exit 1
+    }
+    [ "$WAYFINDER_STATE_SET" -eq 0 ] || {
+      echo "error: --wayfinder-state applies only to ship spawns; a scout stays off the map-dependent handoff path" >&2
+      exit 1
+    }
+    [ "$WAYFINDER_INDEPENDENT" -eq 0 ] || {
+      echo "error: --wayfinder-independent applies only to ship spawns; a scout stays off the map-dependent handoff path" >&2
       exit 1
     }
   fi
@@ -868,6 +895,8 @@ if [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart" ] && case "$idpart" in *
   # spanning several modes is two invocations rather than a silent mixed dispatch.
   [ "$MODE_SET" -eq 0 ] || shared_args+=(--mode "$MODE")
   [ "$YOLO_SET" -eq 0 ] || shared_args+=(--yolo "$YOLO")
+  [ "$WAYFINDER_STATE_SET" -eq 0 ] || shared_args+=(--wayfinder-state "$WAYFINDER_STATE")
+  [ "$WAYFINDER_INDEPENDENT" -eq 0 ] || shared_args+=(--wayfinder-independent)
   for pair in "${POS[@]}"; do
     case "$pair" in
       *=*) : ;;
@@ -1674,6 +1703,23 @@ if [ "$KIND" = ship ]; then
   if [ -n "$STANDING_MODE" ] && [ "$STANDING_MODE" != no-mistakes-prod-only ] \
      && [ "$(delivery_rigor_rank "$MODE")" -lt "$(delivery_rigor_rank "$STANDING_MODE")" ]; then
     echo "notice: $ID ships mode=$MODE while the standing posture for $PROJ_NAME is $STANDING_MODE - less rigor than the captain's standing posture; proceed only on a current explicit captain instruction or an intake judgment you can state" >&2
+  fi
+fi
+
+# Map-dependent implementation may not launch while the consuming project's
+# Wayfinder lifecycle command rejects handoff. Presence of that public command
+# is the project-local signal; --wayfinder-independent is the explicit opt-out
+# for work that does not depend on the map. Scout and secondmate spawns never
+# enter this path. Relaunch recovery of an already-dispatched ship is skipped
+# above because --relaunch refuses these flags and returns before this check.
+if [ "$KIND" = ship ] && [ "$RELAUNCH" -eq 0 ] && [ -f "$PROJ_ABS/bin/wayfinder-lifecycle-gate" ]; then
+  if [ "$WAYFINDER_INDEPENDENT" -eq 0 ]; then
+    if [ "$WAYFINDER_STATE_SET" -eq 0 ]; then
+      echo "error: $ID ships against a project with bin/wayfinder-lifecycle-gate; pass --wayfinder-state <snapshot> so Firstmate can verify handoff, or --wayfinder-independent when this work does not depend on the Wayfinder map" >&2
+      exit 1
+    fi
+    "$FM_ROOT/bin/fm-wayfinder-parent.sh" handoff --project "$PROJ_ABS" --state "$WAYFINDER_STATE" \
+      || exit $?
   fi
 fi
 

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -58,7 +58,8 @@
 #   --force skips ordinary-task dirty and landed-work checks, skips scout report
 #   checks, and discards secondmate child work for kind=secondmate. Only use it
 #   when the captain has explicitly said to discard the work.
-#   --wayfinder-state with --wayfinder-child verifies a legacy named scout.
+#   --wayfinder-state verifies accept-child for a recorded named Wayfinder child.
+#   It pairs with --wayfinder-child only to classify a legacy named scout.
 #   --wayfinder-no-child classifies a legacy scout without a Wayfinder child.
 #
 # Transient / stale worktree git lock recovery (teardown-lock-race): a crew process
@@ -537,20 +538,18 @@ if [ -n "$RECORDED_WAYFINDER_CHILD" ] && [ "$RECORDED_WAYFINDER_NO_CHILD" = 1 ];
   exit 1
 fi
 WAYFINDER_CHILD=
-if [ "$FORCE" != "--force" ] && [ "$KIND" = scout ] \
-  && [ -n "$RECORDED_WAYFINDER_CHILD" ] \
-  && [ ! -f "$PROJ/bin/wayfinder-lifecycle-gate" ]; then
-  echo "REFUSED: scout task $ID records Wayfinder child '$RECORDED_WAYFINDER_CHILD' but its project has no bin/wayfinder-lifecycle-gate." >&2
-  exit 1
-fi
-if [ "$FORCE" != "--force" ] && [ "$KIND" = scout ] && [ -f "$PROJ/bin/wayfinder-lifecycle-gate" ]; then
-  if [ -n "$RECORDED_WAYFINDER_CHILD" ]; then
-    [ "$WAYFINDER_CHILD_ARG_SET" -eq 0 ] && [ "$WAYFINDER_NO_CHILD" -eq 0 ] || {
-      echo "error: task $ID already records a Wayfinder child; do not override its classification at teardown" >&2
-      exit 2
-    }
-    WAYFINDER_CHILD=$RECORDED_WAYFINDER_CHILD
-  elif [ "$RECORDED_WAYFINDER_NO_CHILD" = 1 ]; then
+if [ "$FORCE" != "--force" ] && [ -n "$RECORDED_WAYFINDER_CHILD" ]; then
+  if [ ! -f "$PROJ/bin/wayfinder-lifecycle-gate" ]; then
+    echo "REFUSED: task $ID records Wayfinder child '$RECORDED_WAYFINDER_CHILD' but its project has no bin/wayfinder-lifecycle-gate." >&2
+    exit 1
+  fi
+  [ "$WAYFINDER_CHILD_ARG_SET" -eq 0 ] && [ "$WAYFINDER_NO_CHILD" -eq 0 ] || {
+    echo "error: task $ID already records a Wayfinder child; do not override its classification at teardown" >&2
+    exit 2
+  }
+  WAYFINDER_CHILD=$RECORDED_WAYFINDER_CHILD
+elif [ "$FORCE" != "--force" ] && [ "$KIND" = scout ] && [ -f "$PROJ/bin/wayfinder-lifecycle-gate" ]; then
+  if [ "$RECORDED_WAYFINDER_NO_CHILD" = 1 ]; then
     [ "$WAYFINDER_CHILD_ARG_SET" -eq 0 ] && [ "$WAYFINDER_NO_CHILD" -eq 0 ] || {
       echo "error: task $ID already records no Wayfinder child; do not override its classification at teardown" >&2
       exit 2
@@ -563,12 +562,12 @@ if [ "$FORCE" != "--force" ] && [ "$KIND" = scout ] && [ -f "$PROJ/bin/wayfinder
     exit 1
   fi
 elif [ "$WAYFINDER_CHILD_ARG_SET" -eq 1 ] || [ "$WAYFINDER_NO_CHILD" -eq 1 ] || [ "$WAYFINDER_STATE_SET" -eq 1 ]; then
-  echo "error: Wayfinder teardown flags apply only to a non-forced scout against a project with bin/wayfinder-lifecycle-gate" >&2
+  echo "error: Wayfinder classification flags apply only to a non-forced scout against a project with bin/wayfinder-lifecycle-gate; --wayfinder-state requires a recorded named child" >&2
   exit 2
 fi
 if [ -n "$WAYFINDER_CHILD" ] && [ "$WAYFINDER_STATE_SET" -eq 0 ]; then
-  echo "REFUSED: scout task $ID records Wayfinder child '$WAYFINDER_CHILD' but has no --wayfinder-state snapshot." >&2
-  echo "Pass --wayfinder-state <snapshot> so Firstmate can verify accept-child before archiving the scout." >&2
+  echo "REFUSED: task $ID records Wayfinder child '$WAYFINDER_CHILD' but has no --wayfinder-state snapshot." >&2
+  echo "Pass --wayfinder-state <snapshot> so Firstmate can verify accept-child before archiving the task." >&2
   exit 1
 fi
 if [ -z "$WAYFINDER_CHILD" ] && [ "$WAYFINDER_STATE_SET" -eq 1 ]; then
@@ -2448,13 +2447,14 @@ if [ "$KIND" = scout ] && [ "$FORCE" != "--force" ]; then
     echo "Inventory its report and any visual review through bin/fm-captain-hold.sh before teardown." >&2
     exit 1
   fi
-  if [ -n "$WAYFINDER_CHILD" ]; then
-    if ! FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" FM_DATA_OVERRIDE="$DATA" \
-        "$SCRIPT_DIR/fm-wayfinder-parent.sh" accept-child --project "$PROJ" \
-        --state "$WAYFINDER_STATE" --child "$WAYFINDER_CHILD" --task "$ID"; then
-      echo "REFUSED: the project's Wayfinder accept-child check rejected scout task $ID; task state and report were preserved." >&2
-      exit 1
-    fi
+fi
+
+if [ "$FORCE" != "--force" ] && [ -n "$WAYFINDER_CHILD" ]; then
+  if ! FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" FM_DATA_OVERRIDE="$DATA" \
+      "$SCRIPT_DIR/fm-wayfinder-parent.sh" accept-child --project "$PROJ" \
+      --state "$WAYFINDER_STATE" --child "$WAYFINDER_CHILD" --task "$ID"; then
+    echo "REFUSED: the project's Wayfinder accept-child check rejected task $ID; task state and report were preserved." >&2
+    exit 1
   fi
 fi
 

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -54,12 +54,12 @@
 # the retired home. Removing a leased home releases its durable treehouse lease so the pool slot is freed,
 # never left leased forever. If the treehouse return fails, teardown leaves the
 # leased home and state in place instead of hiding a still-held lease.
-# Usage: fm-teardown.sh <task-id> [--force] [--wayfinder-state <file>]
+# Usage: fm-teardown.sh <task-id> [--force] [--wayfinder-state <file> --wayfinder-child <number-or-title>|--wayfinder-no-child]
 #   --force skips ordinary-task dirty and landed-work checks, skips scout report
 #   checks, and discards secondmate child work for kind=secondmate. Only use it
 #   when the captain has explicitly said to discard the work.
-#   --wayfinder-state supplies the project snapshot required to archive a scout
-#   that recorded a Wayfinder child.
+#   --wayfinder-state with --wayfinder-child verifies a legacy named scout.
+#   --wayfinder-no-child classifies a legacy scout without a Wayfinder child.
 #
 # Transient / stale worktree git lock recovery (teardown-lock-race): a crew process
 # killed mid-git-operation can leave a .git/worktrees/<wt>/index.lock (or, for a
@@ -179,6 +179,9 @@ shift
 FORCE=
 WAYFINDER_STATE=
 WAYFINDER_STATE_SET=0
+WAYFINDER_CHILD_ARG=
+WAYFINDER_CHILD_ARG_SET=0
+WAYFINDER_NO_CHILD=0
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --force)
@@ -196,6 +199,20 @@ while [ "$#" -gt 0 ]; do
       WAYFINDER_STATE=${1#--wayfinder-state=}
       WAYFINDER_STATE_SET=1
       ;;
+    --wayfinder-child)
+      shift
+      [ "$#" -gt 0 ] || { echo "error: --wayfinder-child requires a value" >&2; exit 2; }
+      case "$1" in --*) echo "error: --wayfinder-child requires a value" >&2; exit 2 ;; esac
+      WAYFINDER_CHILD_ARG=$1
+      WAYFINDER_CHILD_ARG_SET=1
+      ;;
+    --wayfinder-child=*)
+      WAYFINDER_CHILD_ARG=${1#--wayfinder-child=}
+      WAYFINDER_CHILD_ARG_SET=1
+      ;;
+    --wayfinder-no-child)
+      WAYFINDER_NO_CHILD=1
+      ;;
     *)
       echo "error: unknown teardown argument $1" >&2
       exit 2
@@ -205,6 +222,19 @@ while [ "$#" -gt 0 ]; do
 done
 [ "$WAYFINDER_STATE_SET" -eq 0 ] || [ -n "$WAYFINDER_STATE" ] || {
   echo "error: --wayfinder-state requires a non-empty value" >&2
+  exit 2
+}
+[ "$WAYFINDER_CHILD_ARG_SET" -eq 0 ] || [ -n "$WAYFINDER_CHILD_ARG" ] || {
+  echo "error: --wayfinder-child requires a non-empty value" >&2
+  exit 2
+}
+if [ "$WAYFINDER_CHILD_ARG_SET" -eq 1 ]; then
+  case "$WAYFINDER_CHILD_ARG" in
+    *$'\n'*|*$'\r'*) echo "error: --wayfinder-child must be one line" >&2; exit 2 ;;
+  esac
+fi
+[ "$WAYFINDER_CHILD_ARG_SET" -eq 0 ] || [ "$WAYFINDER_NO_CHILD" -eq 0 ] || {
+  echo "error: --wayfinder-child and --wayfinder-no-child cannot be combined" >&2
   exit 2
 }
 # shellcheck source=bin/fm-wake-lib.sh
@@ -487,21 +517,63 @@ ORCA_PATH_MATCH_VERIFIED=0
 
 KIND=$(grep '^kind=' "$META" | cut -d= -f2- || true)
 [ -n "$KIND" ] || KIND=ship
-WAYFINDER_CHILD=$(fm_meta_get "$META" wayfinder_child)
-case "$WAYFINDER_CHILD" in
+RECORDED_WAYFINDER_CHILD=$(fm_meta_get "$META" wayfinder_child)
+case "$RECORDED_WAYFINDER_CHILD" in
   *$'\n'*|*$'\r'*)
     echo "error: task $ID has an invalid Wayfinder child record" >&2
     exit 1
     ;;
 esac
-if [ "$WAYFINDER_STATE_SET" -eq 1 ] && { [ "$KIND" != scout ] || [ -z "$WAYFINDER_CHILD" ]; }; then
-  echo "error: --wayfinder-state applies only to scouts with a recorded Wayfinder child" >&2
+RECORDED_WAYFINDER_NO_CHILD=$(fm_meta_get "$META" wayfinder_no_child)
+case "$RECORDED_WAYFINDER_NO_CHILD" in
+  ''|1) ;;
+  *)
+    echo "error: task $ID has an invalid Wayfinder classification record" >&2
+    exit 1
+    ;;
+esac
+if [ -n "$RECORDED_WAYFINDER_CHILD" ] && [ "$RECORDED_WAYFINDER_NO_CHILD" = 1 ]; then
+  echo "error: task $ID has contradictory Wayfinder classification records" >&2
+  exit 1
+fi
+WAYFINDER_CHILD=
+if [ "$FORCE" != "--force" ] && [ "$KIND" = scout ] \
+  && [ -n "$RECORDED_WAYFINDER_CHILD" ] \
+  && [ ! -f "$PROJ/bin/wayfinder-lifecycle-gate" ]; then
+  echo "REFUSED: scout task $ID records Wayfinder child '$RECORDED_WAYFINDER_CHILD' but its project has no bin/wayfinder-lifecycle-gate." >&2
+  exit 1
+fi
+if [ "$FORCE" != "--force" ] && [ "$KIND" = scout ] && [ -f "$PROJ/bin/wayfinder-lifecycle-gate" ]; then
+  if [ -n "$RECORDED_WAYFINDER_CHILD" ]; then
+    [ "$WAYFINDER_CHILD_ARG_SET" -eq 0 ] && [ "$WAYFINDER_NO_CHILD" -eq 0 ] || {
+      echo "error: task $ID already records a Wayfinder child; do not override its classification at teardown" >&2
+      exit 2
+    }
+    WAYFINDER_CHILD=$RECORDED_WAYFINDER_CHILD
+  elif [ "$RECORDED_WAYFINDER_NO_CHILD" = 1 ]; then
+    [ "$WAYFINDER_CHILD_ARG_SET" -eq 0 ] && [ "$WAYFINDER_NO_CHILD" -eq 0 ] || {
+      echo "error: task $ID already records no Wayfinder child; do not override its classification at teardown" >&2
+      exit 2
+    }
+  elif [ "$WAYFINDER_CHILD_ARG_SET" -eq 1 ]; then
+    WAYFINDER_CHILD=$WAYFINDER_CHILD_ARG
+  elif [ "$WAYFINDER_NO_CHILD" -eq 0 ]; then
+    echo "REFUSED: scout task $ID has no Wayfinder classification." >&2
+    echo "Pass --wayfinder-child <number-or-title> with --wayfinder-state <snapshot>, or --wayfinder-no-child before teardown." >&2
+    exit 1
+  fi
+elif [ "$WAYFINDER_CHILD_ARG_SET" -eq 1 ] || [ "$WAYFINDER_NO_CHILD" -eq 1 ] || [ "$WAYFINDER_STATE_SET" -eq 1 ]; then
+  echo "error: Wayfinder teardown flags apply only to a non-forced scout against a project with bin/wayfinder-lifecycle-gate" >&2
   exit 2
 fi
-if [ "$KIND" = scout ] && [ -n "$WAYFINDER_CHILD" ] && [ "$FORCE" != "--force" ] && [ "$WAYFINDER_STATE_SET" -eq 0 ]; then
+if [ -n "$WAYFINDER_CHILD" ] && [ "$WAYFINDER_STATE_SET" -eq 0 ]; then
   echo "REFUSED: scout task $ID records Wayfinder child '$WAYFINDER_CHILD' but has no --wayfinder-state snapshot." >&2
   echo "Pass --wayfinder-state <snapshot> so Firstmate can verify accept-child before archiving the scout." >&2
   exit 1
+fi
+if [ -z "$WAYFINDER_CHILD" ] && [ "$WAYFINDER_STATE_SET" -eq 1 ]; then
+  echo "error: --wayfinder-state requires a Wayfinder child" >&2
+  exit 2
 fi
 MODE=$(grep '^mode=' "$META" | cut -d= -f2- || true)
 [ -n "$MODE" ] || MODE=no-mistakes

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -54,10 +54,12 @@
 # the retired home. Removing a leased home releases its durable treehouse lease so the pool slot is freed,
 # never left leased forever. If the treehouse return fails, teardown leaves the
 # leased home and state in place instead of hiding a still-held lease.
-# Usage: fm-teardown.sh <task-id> [--force]
+# Usage: fm-teardown.sh <task-id> [--force] [--wayfinder-state <file>]
 #   --force skips ordinary-task dirty and landed-work checks, skips scout report
 #   checks, and discards secondmate child work for kind=secondmate. Only use it
 #   when the captain has explicitly said to discard the work.
+#   --wayfinder-state supplies the project snapshot required to archive a scout
+#   that recorded a Wayfinder child.
 #
 # Transient / stale worktree git lock recovery (teardown-lock-race): a crew process
 # killed mid-git-operation can leave a .git/worktrees/<wt>/index.lock (or, for a
@@ -173,7 +175,38 @@ if [ "$#" -lt 1 ] || ! fm_task_id_path_safe "$1"; then
   exit 2
 fi
 ID=$1
-FORCE=${2:-}
+shift
+FORCE=
+WAYFINDER_STATE=
+WAYFINDER_STATE_SET=0
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --force)
+      [ -z "$FORCE" ] || { echo "error: --force may be passed once" >&2; exit 2; }
+      FORCE=--force
+      ;;
+    --wayfinder-state)
+      shift
+      [ "$#" -gt 0 ] || { echo "error: --wayfinder-state requires a value" >&2; exit 2; }
+      case "$1" in --*) echo "error: --wayfinder-state requires a value" >&2; exit 2 ;; esac
+      WAYFINDER_STATE=$1
+      WAYFINDER_STATE_SET=1
+      ;;
+    --wayfinder-state=*)
+      WAYFINDER_STATE=${1#--wayfinder-state=}
+      WAYFINDER_STATE_SET=1
+      ;;
+    *)
+      echo "error: unknown teardown argument $1" >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+[ "$WAYFINDER_STATE_SET" -eq 0 ] || [ -n "$WAYFINDER_STATE" ] || {
+  echo "error: --wayfinder-state requires a non-empty value" >&2
+  exit 2
+}
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
 CONTROL_LOCK="$STATE/.control-$ID.lock"
@@ -454,6 +487,22 @@ ORCA_PATH_MATCH_VERIFIED=0
 
 KIND=$(grep '^kind=' "$META" | cut -d= -f2- || true)
 [ -n "$KIND" ] || KIND=ship
+WAYFINDER_CHILD=$(fm_meta_get "$META" wayfinder_child)
+case "$WAYFINDER_CHILD" in
+  *$'\n'*|*$'\r'*)
+    echo "error: task $ID has an invalid Wayfinder child record" >&2
+    exit 1
+    ;;
+esac
+if [ "$WAYFINDER_STATE_SET" -eq 1 ] && { [ "$KIND" != scout ] || [ -z "$WAYFINDER_CHILD" ]; }; then
+  echo "error: --wayfinder-state applies only to scouts with a recorded Wayfinder child" >&2
+  exit 2
+fi
+if [ "$KIND" = scout ] && [ -n "$WAYFINDER_CHILD" ] && [ "$FORCE" != "--force" ] && [ "$WAYFINDER_STATE_SET" -eq 0 ]; then
+  echo "REFUSED: scout task $ID records Wayfinder child '$WAYFINDER_CHILD' but has no --wayfinder-state snapshot." >&2
+  echo "Pass --wayfinder-state <snapshot> so Firstmate can verify accept-child before archiving the scout." >&2
+  exit 1
+fi
 MODE=$(grep '^mode=' "$META" | cut -d= -f2- || true)
 [ -n "$MODE" ] || MODE=no-mistakes
 PUBLIC_FOLLOWUP_HOME=$FM_HOME
@@ -2326,6 +2375,14 @@ if [ "$KIND" = scout ] && [ "$FORCE" != "--force" ]; then
     echo "REFUSED: scout task $ID has not passed the captain-call completion gate." >&2
     echo "Inventory its report and any visual review through bin/fm-captain-hold.sh before teardown." >&2
     exit 1
+  fi
+  if [ -n "$WAYFINDER_CHILD" ]; then
+    if ! FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" FM_DATA_OVERRIDE="$DATA" \
+        "$SCRIPT_DIR/fm-wayfinder-parent.sh" accept-child --project "$PROJ" \
+        --state "$WAYFINDER_STATE" --child "$WAYFINDER_CHILD" --task "$ID"; then
+      echo "REFUSED: the project's Wayfinder accept-child check rejected scout task $ID; task state and report were preserved." >&2
+      exit 1
+    fi
   fi
 fi
 

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -59,8 +59,8 @@
 #   checks, and discards secondmate child work for kind=secondmate. Only use it
 #   when the captain has explicitly said to discard the work.
 #   --wayfinder-state verifies accept-child for a recorded named Wayfinder child.
-#   It pairs with --wayfinder-child only to classify a legacy named scout.
-#   --wayfinder-no-child classifies a legacy scout without a Wayfinder child.
+#   It pairs with --wayfinder-child only to classify an unrecorded named scout or ship.
+#   --wayfinder-no-child classifies an unrecorded scout or ship without a Wayfinder child.
 #
 # Transient / stale worktree git lock recovery (teardown-lock-race): a crew process
 # killed mid-git-operation can leave a .git/worktrees/<wt>/index.lock (or, for a
@@ -244,6 +244,7 @@ CONTROL_LOCK="$STATE/.control-$ID.lock"
 CONTROL_LOCK_HELD=0
 META_LOCK=
 META_LOCK_HELD=0
+WAYFINDER_CLASSIFICATION_TMP=
 DESCENDANT_LOCK_PATHS=()
 DESCENDANT_TASK_STATES=()
 DESCENDANT_TASK_IDS=()
@@ -262,6 +263,7 @@ teardown_release_locks() {
     fm_lock_release "$META_LOCK" || true
     META_LOCK_HELD=0
   fi
+  [ -z "$WAYFINDER_CLASSIFICATION_TMP" ] || rm -f -- "$WAYFINDER_CLASSIFICATION_TMP" 2>/dev/null || true
   if [ "$CONTROL_LOCK_HELD" = 1 ]; then
     fm_lock_release "$CONTROL_LOCK" || true
     CONTROL_LOCK_HELD=0
@@ -538,6 +540,8 @@ if [ -n "$RECORDED_WAYFINDER_CHILD" ] && [ "$RECORDED_WAYFINDER_NO_CHILD" = 1 ];
   exit 1
 fi
 WAYFINDER_CHILD=
+WAYFINDER_CLASSIFICATION_MIGRATED=0
+WAYFINDER_CLASSIFICATION_NO_CHILD=0
 if [ "$FORCE" != "--force" ] && [ -n "$RECORDED_WAYFINDER_CHILD" ]; then
   if [ ! -f "$PROJ/bin/wayfinder-lifecycle-gate" ]; then
     echo "REFUSED: task $ID records Wayfinder child '$RECORDED_WAYFINDER_CHILD' but its project has no bin/wayfinder-lifecycle-gate." >&2
@@ -548,7 +552,9 @@ if [ "$FORCE" != "--force" ] && [ -n "$RECORDED_WAYFINDER_CHILD" ]; then
     exit 2
   }
   WAYFINDER_CHILD=$RECORDED_WAYFINDER_CHILD
-elif [ "$FORCE" != "--force" ] && [ "$KIND" = scout ] && [ -f "$PROJ/bin/wayfinder-lifecycle-gate" ]; then
+elif [ "$FORCE" != "--force" ] \
+   && { [ "$KIND" = scout ] || [ "$KIND" = ship ]; } \
+   && [ -f "$PROJ/bin/wayfinder-lifecycle-gate" ]; then
   if [ "$RECORDED_WAYFINDER_NO_CHILD" = 1 ]; then
     [ "$WAYFINDER_CHILD_ARG_SET" -eq 0 ] && [ "$WAYFINDER_NO_CHILD" -eq 0 ] || {
       echo "error: task $ID already records no Wayfinder child; do not override its classification at teardown" >&2
@@ -556,13 +562,21 @@ elif [ "$FORCE" != "--force" ] && [ "$KIND" = scout ] && [ -f "$PROJ/bin/wayfind
     }
   elif [ "$WAYFINDER_CHILD_ARG_SET" -eq 1 ]; then
     WAYFINDER_CHILD=$WAYFINDER_CHILD_ARG
-  elif [ "$WAYFINDER_NO_CHILD" -eq 0 ]; then
+    WAYFINDER_CLASSIFICATION_MIGRATED=1
+  elif [ "$WAYFINDER_NO_CHILD" -eq 1 ]; then
+    WAYFINDER_CLASSIFICATION_MIGRATED=1
+    WAYFINDER_CLASSIFICATION_NO_CHILD=1
+  elif [ "$KIND" = scout ]; then
     echo "REFUSED: scout task $ID has no Wayfinder classification." >&2
+    echo "Pass --wayfinder-child <number-or-title> with --wayfinder-state <snapshot>, or --wayfinder-no-child before teardown." >&2
+    exit 1
+  else
+    echo "REFUSED: ship task $ID has no Wayfinder classification." >&2
     echo "Pass --wayfinder-child <number-or-title> with --wayfinder-state <snapshot>, or --wayfinder-no-child before teardown." >&2
     exit 1
   fi
 elif [ "$WAYFINDER_CHILD_ARG_SET" -eq 1 ] || [ "$WAYFINDER_NO_CHILD" -eq 1 ] || [ "$WAYFINDER_STATE_SET" -eq 1 ]; then
-  echo "error: Wayfinder classification flags apply only to a non-forced scout against a project with bin/wayfinder-lifecycle-gate; --wayfinder-state requires a recorded named child" >&2
+  echo "error: Wayfinder classification flags apply only to a non-forced scout or unclassified ship against a project with bin/wayfinder-lifecycle-gate; --wayfinder-state requires a named child" >&2
   exit 2
 fi
 if [ -n "$WAYFINDER_CHILD" ] && [ "$WAYFINDER_STATE_SET" -eq 0 ]; then
@@ -573,6 +587,17 @@ fi
 if [ -z "$WAYFINDER_CHILD" ] && [ "$WAYFINDER_STATE_SET" -eq 1 ]; then
   echo "error: --wayfinder-state requires a Wayfinder child" >&2
   exit 2
+fi
+if [ "$WAYFINDER_CLASSIFICATION_MIGRATED" -eq 1 ]; then
+  WAYFINDER_CLASSIFICATION_TMP="$STATE/.$ID.meta.wayfinder.${BASHPID:-$$}"
+  grep -v -e '^wayfinder_child=' -e '^wayfinder_no_child=' "$META" > "$WAYFINDER_CLASSIFICATION_TMP"
+  if [ "$WAYFINDER_CLASSIFICATION_NO_CHILD" -eq 1 ]; then
+    echo "wayfinder_no_child=1" >> "$WAYFINDER_CLASSIFICATION_TMP"
+  else
+    echo "wayfinder_child=$WAYFINDER_CHILD" >> "$WAYFINDER_CLASSIFICATION_TMP"
+  fi
+  mv "$WAYFINDER_CLASSIFICATION_TMP" "$META"
+  WAYFINDER_CLASSIFICATION_TMP=
 fi
 MODE=$(grep '^mode=' "$META" | cut -d= -f2- || true)
 [ -n "$MODE" ] || MODE=no-mistakes

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -148,7 +148,8 @@ family_for_basename() {
     fm-supervision-instructions.test.sh|fm-task-delivery.test.sh|\
     fm-tmux-submit-busy.test.sh|fm-trace-context-lib.test.sh|\
     fm-transition-lib.test.sh|\
-    fm-test-run.test.sh|fm-test-isolation-proof.test.sh)
+    fm-test-run.test.sh|fm-test-isolation-proof.test.sh|\
+    fm-wayfinder-parent.test.sh)
       printf '%s\n' pure-contract-unit
       ;;
     fm-daemon.test.sh|fm-guard-stale-banner.test.sh|fm-pi-watch-extension.test.sh|\
@@ -973,7 +974,7 @@ families_for_changed_path() {
     bin/fm-tmux-lib.sh|bin/fm-marker-lib.sh|bin/fm-operational-input.sh|bin/fm-tasks-axi-lib.sh|\
     bin/fm-vendor-auth-probe.sh|\
     bin/fm-primary-scope-lib.sh|bin/fm-project-mode.sh|bin/fm-promote.sh|\
-    bin/fm-ff-lib.sh|bin/fm-gotmp*|bin/*pretool*)
+    bin/fm-ff-lib.sh|bin/fm-gotmp*|bin/*pretool*|bin/fm-wayfinder-parent.sh)
       printf '%s\n' pure-contract-unit
       ;;
     .agents/skills/quota-array-dispatch/SKILL.md)

--- a/bin/fm-wayfinder-parent.sh
+++ b/bin/fm-wayfinder-parent.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+# fm-wayfinder-parent.sh - Firstmate parent map-owner check for a consuming
+# project's Wayfinder lifecycle command.
+#
+# Firstmate does not own the resolution-triple policy. When a child names a
+# Wayfinder ticket, this script invokes that project's public
+# `bin/wayfinder-lifecycle-gate` and merges Firstmate local completions into
+# the snapshot so a report or captain-call inventory cannot stand in for
+# tracker resolution.
+#
+# Usage:
+#   fm-wayfinder-parent.sh accept-child --project <dir> --state <file> \
+#     --child <number-or-title> [--task <id>]
+#   fm-wayfinder-parent.sh handoff --project <dir> --state <file> [--task <id>]
+#
+#   accept-child
+#     Refuse to treat the named child as Wayfinder-resolved until the project
+#     command's accept-child verification passes.
+#   handoff
+#     Refuse map-dependent implementation dispatch until the project command's
+#     handoff verification passes.
+#
+#   --project  Consuming project directory that publishes
+#              bin/wayfinder-lifecycle-gate. Required.
+#   --state    GitHub snapshot JSON for that command, or - for stdin.
+#              Required. This script does not fetch GitHub.
+#   --child    Child issue number or exact ticket title. Required for
+#              accept-child.
+#   --task     Firstmate task id whose local report and captain-call
+#              completion records are merged into the snapshot. Optional.
+#              Completing bin/fm-captain-hold.sh or bin/fm-decision-hold.sh
+#              is not tracker resolution; those records are supplied so the
+#              project command can reject them as the triple.
+#
+# Exit codes: 0 success, 2 project-gate failure (stdout/stderr passed
+# through), 1 usage or missing project command.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+
+usage() {
+  awk '
+    NR == 1 { next }
+    /^#/ { sub(/^# ?/, ""); print; next }
+    { exit }
+  ' "$0"
+}
+
+fail() {
+  printf 'fm-wayfinder-parent: %s\n' "$*" >&2
+  exit 1
+}
+
+COMMAND=
+PROJECT=
+STATE_FILE=
+CHILD=
+TASK=
+POS=()
+want_value=
+for a in "$@"; do
+  if [ -n "$want_value" ]; then
+    case "$a" in
+      --*) fail "--$want_value requires a value" ;;
+    esac
+    case "$want_value" in
+      project) PROJECT=$a ;;
+      state) STATE_FILE=$a ;;
+      child) CHILD=$a ;;
+      task) TASK=$a ;;
+      *) fail "internal parser state for --$want_value" ;;
+    esac
+    want_value=
+    continue
+  fi
+  case "$a" in
+    -h|--help) usage; exit 0 ;;
+    --project) want_value=project ;;
+    --project=*) PROJECT=${a#--project=} ;;
+    --state) want_value=state ;;
+    --state=*) STATE_FILE=${a#--state=} ;;
+    --child) want_value=child ;;
+    --child=*) CHILD=${a#--child=} ;;
+    --task) want_value=task ;;
+    --task=*) TASK=${a#--task=} ;;
+    --*) fail "unknown flag $a" ;;
+    *) POS+=("$a") ;;
+  esac
+done
+[ -z "$want_value" ] || fail "--$want_value requires a value"
+
+if [ "${#POS[@]}" -ge 1 ]; then
+  COMMAND=${POS[0]}
+fi
+[ -n "$COMMAND" ] || { usage >&2; exit 1; }
+case "$COMMAND" in
+  accept-child|handoff) ;;
+  *) fail "unknown command $COMMAND (expected accept-child or handoff)" ;;
+esac
+[ -n "$PROJECT" ] || fail "--project is required"
+[ -n "$STATE_FILE" ] || fail "--state is required"
+if [ "$COMMAND" = accept-child ]; then
+  [ -n "$CHILD" ] || fail "accept-child requires --child <number-or-title>"
+else
+  [ -z "$CHILD" ] || fail "handoff does not take --child"
+fi
+[ -z "$TASK" ] || case "$TASK" in
+  *[!A-Za-z0-9._-]*) fail "--task must be a non-empty privacy-safe slug" ;;
+esac
+
+if [ ! -d "$PROJECT" ]; then
+  fail "project is not a directory: $PROJECT"
+fi
+PROJECT=$(cd "$PROJECT" && pwd)
+GATE="$PROJECT/bin/wayfinder-lifecycle-gate"
+if [ ! -f "$GATE" ]; then
+  fail "project has no bin/wayfinder-lifecycle-gate; invoke the consuming project's public lifecycle command rather than duplicating its policy"
+fi
+if [ ! -x "$GATE" ]; then
+  fail "bin/wayfinder-lifecycle-gate exists but is not executable: $GATE"
+fi
+
+command -v python3 >/dev/null 2>&1 || fail "python3 is required to merge local completions into the project snapshot"
+
+REPORT=
+META=
+if [ -n "$TASK" ]; then
+  REPORT="$DATA/$TASK/report.md"
+  META="$STATE/$TASK.meta"
+fi
+
+MERGED=
+STDIN_STATE=
+trap 'rm -f -- ${MERGED:+"$MERGED"} ${STDIN_STATE:+"$STDIN_STATE"} 2>/dev/null || true' EXIT
+
+if [ "$STATE_FILE" = - ]; then
+  STDIN_STATE=$(mktemp "${TMPDIR:-/tmp}/fm-wayfinder-state.XXXXXX") || fail "could not create a snapshot tempfile"
+  cat > "$STDIN_STATE" || fail "could not read snapshot JSON from stdin"
+  STATE_FILE=$STDIN_STATE
+fi
+[ -f "$STATE_FILE" ] || fail "snapshot is not a file: $STATE_FILE"
+
+MERGED=$(mktemp "${TMPDIR:-/tmp}/fm-wayfinder-merged.XXXXXX") || fail "could not create a merged snapshot tempfile"
+
+if ! python3 - "$STATE_FILE" "$MERGED" "${CHILD:-}" "${REPORT:-}" "${META:-}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+state_path, out_path, child_ref, report_path, meta_path = sys.argv[1:]
+
+try:
+    payload = json.loads(Path(state_path).read_text(encoding="utf-8"))
+except OSError as exc:
+    raise SystemExit(f"cannot read snapshot: {exc}") from exc
+except json.JSONDecodeError as exc:
+    raise SystemExit(f"snapshot is not valid JSON: {exc}") from exc
+
+if not isinstance(payload, dict):
+    raise SystemExit("snapshot must be a JSON object")
+
+children = payload.get("children") or []
+if not isinstance(children, list):
+    raise SystemExit("snapshot children must be a list")
+
+
+def child_number(ref: str):
+    if not ref:
+        return None
+    if ref.isdigit():
+        number = int(ref)
+        for raw in children:
+            if isinstance(raw, dict) and raw.get("number") == number:
+                return number
+        return number
+    for raw in children:
+        if isinstance(raw, dict) and raw.get("title") == ref:
+            number = raw.get("number")
+            if isinstance(number, int) and not isinstance(number, bool):
+                return number
+    return None
+
+
+number = child_number(child_ref)
+extras = []
+if number is not None:
+    if report_path and Path(report_path).is_file():
+        extras.append(
+            {"child": number, "source": "report", "complete": True}
+        )
+    meta_text = ""
+    if meta_path and Path(meta_path).is_file():
+        meta_text = Path(meta_path).read_text(encoding="utf-8")
+    reviewed = False
+    keys = ""
+    for line in meta_text.splitlines():
+        if line.startswith("decisions_reviewed="):
+            reviewed = line.split("=", 1)[1] == "1"
+        elif line.startswith("decision_keys="):
+            keys = line.split("=", 1)[1]
+    if reviewed and keys.strip():
+        extras.append(
+            {
+                "child": number,
+                "source": "captain-hold",
+                "complete": True,
+                "id": keys.strip(),
+            }
+        )
+
+local = payload.get("local")
+if local is None:
+    local = {}
+    payload["local"] = local
+if not isinstance(local, dict):
+    raise SystemExit("snapshot local must be an object")
+completions = local.get("completions")
+if completions is None:
+    completions = []
+    local["completions"] = completions
+if not isinstance(completions, list):
+    raise SystemExit("snapshot local.completions must be a list")
+
+seen = set()
+for raw in completions:
+    if not isinstance(raw, dict):
+        continue
+    seen.add(
+        (
+            raw.get("child"),
+            raw.get("source"),
+            raw.get("id") or raw.get("identifier") or "",
+        )
+    )
+for extra in extras:
+    key = (extra["child"], extra["source"], extra.get("id") or "")
+    if key in seen:
+        continue
+    completions.append(extra)
+    seen.add(key)
+
+Path(out_path).write_text(
+    json.dumps(payload, indent=2) + "\n", encoding="utf-8"
+)
+PY
+then
+  fail "could not merge local completions into the project snapshot"
+fi
+
+set +e
+if [ "$COMMAND" = accept-child ]; then
+  "$GATE" --state "$MERGED" accept-child "$CHILD"
+  rc=$?
+else
+  "$GATE" --state "$MERGED" handoff
+  rc=$?
+fi
+set -e
+exit "$rc"

--- a/bin/fm-wayfinder-parent.sh
+++ b/bin/fm-wayfinder-parent.sh
@@ -260,4 +260,4 @@ else
   rc=$?
 fi
 set -e
-exit "$rc"
+[ "$rc" -eq 0 ] || exit 2

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -61,15 +61,18 @@ It is not deterministic across the verified adapters: codex and grok resume only
    A ship or scout keeps the harness already recorded for it, because that harness comes from firstmate's dispatch-profile judgment at intake and must not be silently re-read from configuration.
    A recorded raw-command basename that differs from its resolved adapter cannot reproduce the command actually running, so relaunch refuses before the checkpoint unless the caller passes an explicit `--harness` to choose the replacement runtime deliberately.
    A harness change resets model and effort unless they are named too, because a model chosen for one adapter does not transfer to another.
-2. **Safe checkpoint.**
+2. **Wayfinder handoff.**
+   A map-dependent ship relaunch against a project that publishes `bin/wayfinder-lifecycle-gate` must pass the parent procedure's fresh `handoff` verification before the existing agent is stopped.
+   [`.agents/skills/wayfinder-parent-gate/SKILL.md`](../.agents/skills/wayfinder-parent-gate/SKILL.md) owns that condition and procedure, while `bin/fm-control.sh`'s header owns snapshot flags.
+3. **Safe checkpoint.**
    The recorded worktree must exist and be a worktree root; its head and dirty state are recorded.
    For a `kind=secondmate` task, the home's identity marker must match and its child records must be readable, so a relaunch can never strand child work behind an unreadable home.
    A secondmate's own crewmates run in their own endpoints and outlive its relaunch; the relaunched secondmate reconciles them from its home's durable records at startup.
-3. **Record the note.**
+4. **Record the note.**
    A ship or scout relaunch requires `--note`, because the replacement inherits the local copy but none of the conversation; the note is appended to the instructions it reads.
    A secondmate relaunch does not require one and never rewrites its standing charter.
-4. **Stop the old agent** through the `exit` verb, with its postcondition.
-5. **Launch the replacement** through its single owner, `bin/fm-spawn.sh --relaunch`, which adopts the recorded endpoint and worktree instead of creating either, clears the previous harness's per-task wiring, and arms a fresh busy generation.
+5. **Stop the old agent** through the `exit` verb, with its postcondition.
+6. **Launch the replacement** through its single owner, `bin/fm-spawn.sh --relaunch`, which adopts the recorded endpoint and worktree instead of creating either, clears the previous harness's per-task wiring, and arms a fresh busy generation.
 
 Switching harness is therefore one ordinary relaunch rather than a separate mechanism.
 

--- a/docs/captain-hold-lifecycle.md
+++ b/docs/captain-hold-lifecycle.md
@@ -28,6 +28,9 @@ Scout teardown calls the read-only `verify` subcommand after checking for the re
 `verify` requires the recorded attestation, requires every recorded inventory entry to still be durable (actively captain-held, or carrying a recorded answer), and fails on any keyed status decision that opened after the last `complete`, which makes re-running `complete` the repair.
 The `--force` path remains the explicit captain-approved discard escape hatch.
 
+This ledger is not a tracker-resolution record.
+Wayfinder child resolution is owned by `.agents/skills/wayfinder-parent-gate/SKILL.md` and `bin/fm-wayfinder-parent.sh`.
+
 ## Answer-time closure
 
 "A keyed answer closes its matching captain-held task" is one capability with one owner.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -189,6 +189,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/wayfinder-parent-gate/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": "AGENTS.md",
       "audience": "agent-runtime"
     },

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -51,7 +51,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-remote-home-seed.sh` | Register and provision a whole secondmate home on an SSH-reachable host              |
 | `fm-remote-readiness-lib.sh` | Shared remote second-mate readiness gate: check and, when needed, repair then re-check through `fm-remote-doctor.sh` |
 | [`fm-project-origin-lib.sh`](../bin/fm-project-origin-lib.sh) | Accepted origin-form owner shared by both remote provisioning boundaries |
-| `fm-spawn.sh`            | Spawn crewmates, scouts, `id=repo` batches, and secondmates on the resolved harness and runtime backend |
+| `fm-spawn.sh`            | Spawn crewmates, scouts, `id=repo` batches, and secondmates on the resolved harness and runtime backend, gating map-dependent ship dispatch through Wayfinder when published |
 | `fm-backend.sh`          | Runtime-backend selection, meta helpers, selector resolution, and operation dispatch |
 | `fm-backend-hometag-lib.sh` | Shared per-installation home-tag derivation for zellij tab and cmux workspace titles |
 | `fm-composer-lib.sh`     | Single fleet-wide owner of composer shapes, capability-aware screen classification, and verdicts |
@@ -108,8 +108,9 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-pr-check-migrate.sh` | Quarantine older task polls without execution and rebuild only canonical polls       |
 | `fm-pr-check.sh`         | Record validated `pr=` and `pr_head=` values, then atomically arm a static merge poll |
 | `fm-pr-merge.sh`         | Record PR metadata, then merge a task's canonical full GitHub URL                    |
-| `fm-promote.sh`          | Promote a scout task in place to a protected ship task with an explicit delivery mode |
-| `fm-teardown.sh`         | Fail-closed teardown: return landed ship worktrees, require completed scout deliverables, retire secondmate homes |
+| `fm-wayfinder-parent.sh` | Invoke a consuming project's Wayfinder lifecycle command for parent `accept-child` and map-dependent `handoff` checks |
+| `fm-promote.sh`          | Promote a scout task in place to a protected ship task with an explicit delivery mode and map-dependent Wayfinder handoff |
+| `fm-teardown.sh`         | Fail-closed teardown: return landed ship worktrees, require completed scout deliverables and recorded Wayfinder-child acceptance, retire secondmate homes |
 | `fm-harness.sh`          | Detect the running harness and resolve crew or secondmate harness, model, and effort |
 | `fm-lock.sh`             | Per-home firstmate session lock                                                      |
 | `fm-x-lib.sh`            | Shared Relay config, relay, and reply-threading helpers                              |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -51,7 +51,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-remote-home-seed.sh` | Register and provision a whole secondmate home on an SSH-reachable host              |
 | `fm-remote-readiness-lib.sh` | Shared remote second-mate readiness gate: check and, when needed, repair then re-check through `fm-remote-doctor.sh` |
 | [`fm-project-origin-lib.sh`](../bin/fm-project-origin-lib.sh) | Accepted origin-form owner shared by both remote provisioning boundaries |
-| `fm-spawn.sh`            | Spawn crewmates, scouts, `id=repo` batches, and secondmates on the resolved harness and runtime backend, gating map-dependent ship dispatch through Wayfinder when published |
+| `fm-spawn.sh`            | Spawn crewmates, scouts, `id=repo` batches, and secondmates on the resolved harness and runtime backend, gating map-dependent ship dispatch through a published Wayfinder lifecycle command |
 | `fm-backend.sh`          | Runtime-backend selection, meta helpers, selector resolution, and operation dispatch |
 | `fm-backend-hometag-lib.sh` | Shared per-installation home-tag derivation for zellij tab and cmux workspace titles |
 | `fm-composer-lib.sh`     | Single fleet-wide owner of composer shapes, capability-aware screen classification, and verdicts |

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -682,6 +682,10 @@ test_scout_and_secondmate_load_decision_hold_policy() {
     "scout brief did not load the captain-call policy before done"
   assert_grep "pass its shared completion gate for the report and any visual review" "$scout" \
     "scout brief did not cross-reference visual-review completion"
+  assert_grep "local input to firstmate" "$scout" \
+    "scout brief treated captain-call completion as Wayfinder resolution"
+  assert_grep "records tracker resolution separately when this scout names a Wayfinder ticket" "$scout" \
+    "scout brief did not keep Wayfinder resolution on the parent"
   FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" FM_SECONDMATE_CHARTER='sample reviews' \
     "$ROOT/bin/fm-brief.sh" sample-mate --secondmate --no-projects >/dev/null 2>&1
   charter="$home/data/sample-mate/brief.md"

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -181,6 +181,36 @@ run_spawn() {  # <case-dir> <args...>
     "$SPAWN" "$@" 2>&1
 }
 
+install_relaunch_wayfinder_gate() {  # <project-dir>
+  mkdir -p "$1/bin"
+  cat > "$1/bin/wayfinder-lifecycle-gate" <<'PY'
+#!/usr/bin/env python3
+import json
+import sys
+
+if len(sys.argv) == 4 and sys.argv[1] == "--state" and sys.argv[3] == "handoff":
+    with open(sys.argv[2], encoding="utf-8") as source:
+        if json.load(source).get("handoff") == "allowed":
+            print("handoff accepted")
+            raise SystemExit(0)
+print("gate failed", file=sys.stderr)
+raise SystemExit(2)
+PY
+  chmod +x "$1/bin/wayfinder-lifecycle-gate"
+}
+
+write_relaunch_wayfinder_snapshot() {  # <path> <allowed|rejected>
+  python3 - "$1" "$2" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+Path(sys.argv[1]).write_text(
+    json.dumps({"handoff": sys.argv[2]}) + "\n", encoding="utf-8"
+)
+PY
+}
+
 meta_field() {  # <case-dir> <id> <key>
   grep "^$3=" "$1/home/state/$2.meta" | tail -1 | cut -d= -f2-
 }
@@ -785,6 +815,55 @@ test_spawn_relaunch_without_a_harness_reuses_the_recorded_one() {
   pass "fm-spawn --relaunch: with no explicit harness it reuses the task's recorded one, never the crew default"
 }
 
+test_gated_ship_relaunch_rechecks_handoff_before_stopping() {
+  local dir bad good out rc before direct_before
+  dir=$(new_case wayfinder-relaunch rl36)
+  add_ship_task "$dir" rl36 claude
+  install_relaunch_wayfinder_gate "$dir/proj"
+  bad="$dir/rejected.json"
+  good="$dir/allowed.json"
+  write_relaunch_wayfinder_snapshot "$bad" rejected
+  write_relaunch_wayfinder_snapshot "$good" allowed
+  before=$(cat "$dir/home/data/rl36/brief.md")
+
+  out=$(run_control "$dir" rl36 relaunch --wayfinder-state "$bad" --note "resume safely")
+  rc=$?
+  expect_code 1 "$rc" "a rejecting handoff must refuse a gated relaunch"$'\n'"$out"
+  assert_contains "$out" "gate failed" "relaunch did not surface the project handoff rejection"
+  [ "$(cat "$dir/fake/command")" = claude ] \
+    || fail "a rejecting handoff must not stop the running agent"
+  [ "$(cat "$dir/home/data/rl36/brief.md")" = "$before" ] \
+    || fail "a rejecting handoff must not append a relaunch note"
+
+  out=$(run_control "$dir" rl36 relaunch --wayfinder-state "$good" --note "resume safely")
+  rc=$?
+  expect_code 0 "$rc" "a passing handoff must allow a gated relaunch"$'\n'"$out"
+  [ "$(cat "$dir/fake/command")" = claude ] \
+    || fail "a passing handoff did not start the replacement agent"
+
+  printf 'zsh' > "$dir/fake/command"
+  direct_before=$(cat "$dir/fake/literal")
+  out=$(run_spawn "$dir" rl36 --relaunch --wayfinder-state "$bad")
+  rc=$?
+  expect_code 2 "$rc" "a direct relaunch must recheck a rejecting handoff"$'\n'"$out"
+  assert_contains "$out" "gate failed" "direct relaunch did not surface the project handoff rejection"
+  [ "$(cat "$dir/fake/command")" = zsh ] \
+    || fail "a rejecting direct relaunch must not start a replacement agent"
+  [ "$(cat "$dir/fake/literal")" = "$direct_before" ] \
+    || fail "a rejecting direct relaunch must not deliver a launch command"
+
+  dir=$(new_case wayfinder-independent rl37)
+  add_ship_task "$dir" rl37 claude
+  install_relaunch_wayfinder_gate "$dir/proj"
+  printf 'wayfinder_independent=1\n' >> "$dir/home/state/rl37.meta"
+  out=$(run_control "$dir" rl37 relaunch --note "resume independent work")
+  rc=$?
+  expect_code 0 "$rc" "a recorded map-independent relaunch should not require a snapshot"$'\n'"$out"
+  [ "$(meta_field "$dir" rl37 wayfinder_independent)" = 1 ] \
+    || fail "a map-independent relaunch must preserve its recorded exemption"
+  pass "fm-control relaunch rechecks map-dependent handoff and preserves map independence"
+}
+
 # fm-spawn arms per-task wiring on harness PREFIXES, because a task launched
 # from a raw command records that command's basename rather than the exact
 # adapter name. Retirement must resolve the same way, or a task recorded as
@@ -1334,6 +1413,7 @@ test_secondmate_relaunch_onto_a_crewmate_only_adapter_refuses_before_stop
 test_explicit_secondmate_harness_ignores_configured_profile_axes
 test_ship_relaunch_ignores_the_crew_harness_config
 test_spawn_relaunch_without_a_harness_reuses_the_recorded_one
+test_gated_ship_relaunch_rechecks_handoff_before_stopping
 test_prefixed_prior_harness_wiring_is_still_retired
 test_muse_session_binding_is_retired_on_a_harness_switch
 test_cursor_session_binding_is_retired_on_a_harness_switch

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -174,6 +174,12 @@ run_control() {  # <case-dir> <args...>
     "$CONTROL" "$@" 2>&1
 }
 
+run_control_stdin() {  # <case-dir> <snapshot> <args...>
+  local dir=$1 snapshot=$2
+  shift 2
+  printf '%s\n' "$snapshot" | run_control "$dir" "$@"
+}
+
 run_spawn() {  # <case-dir> <args...>
   local dir=$1; shift
   env PATH="$dir/fakebin:$PATH" FM_HOME="$dir/home" FM_FAKE_DIR="$dir/fake" \
@@ -840,6 +846,12 @@ test_gated_ship_relaunch_rechecks_handoff_before_stopping() {
   expect_code 0 "$rc" "a passing handoff must allow a gated relaunch"$'\n'"$out"
   [ "$(cat "$dir/fake/command")" = claude ] \
     || fail "a passing handoff did not start the replacement agent"
+
+  out=$(run_control_stdin "$dir" '{"handoff":"allowed"}' rl36 relaunch --wayfinder-state - --note "resume from stdin")
+  rc=$?
+  expect_code 0 "$rc" "a passing stdin handoff must allow both gated relaunch checks"$'\n'"$out"
+  [ "$(cat "$dir/fake/command")" = claude ] \
+    || fail "a passing stdin handoff did not start the replacement agent"
 
   printf 'zsh' > "$dir/fake/command"
   direct_before=$(cat "$dir/fake/literal")

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -56,6 +56,7 @@ set -u
 fm_git_identity fmtest fmtest@example.invalid
 
 TEARDOWN="$ROOT/bin/fm-teardown.sh"
+PROMOTE="$ROOT/bin/fm-promote.sh"
 PR_CHECK="$ROOT/bin/fm-pr-check.sh"
 TMP_ROOT=$(fm_test_tmproot fm-teardown-tests)
 REAL_GIT_FOR_TEST=$(command -v git)
@@ -584,6 +585,16 @@ run_scout_spawn() {
     "$ROOT/bin/fm-spawn.sh" task-x1 "$case_dir/project" claude --scout "$@"
 }
 
+run_promote() {
+  local case_dir=$1
+  shift
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$case_dir" \
+    FM_STATE_OVERRIDE="$case_dir/state" FM_DATA_OVERRIDE="$case_dir/data" \
+    FM_CONFIG_OVERRIDE="$case_dir/config" \
+    PATH="$case_dir/fakebin:${FM_TEARDOWN_TEST_PATH:-$PATH}" \
+    "$PROMOTE" task-x1 "$@"
+}
+
 install_teardown_wayfinder_gate() {
   local project=$1
   mkdir -p "$project/bin"
@@ -675,7 +686,7 @@ test_teardown_manual_backend_prompts_hand_edit_even_when_tasks_axi_present() {
 }
 
 test_wayfinder_scout_teardown_requires_accept_child() {
-  local case_dir untracked_case rejected resolved out rc
+  local case_dir promoted_case untracked_case rejected resolved out rc
   case_dir=$(make_case wayfinder-scout-archive)
   prepare_spawn_endpoint "$case_dir"
   mkdir -p "$case_dir/data/task-x1"
@@ -728,6 +739,46 @@ test_wayfinder_scout_teardown_requires_accept_child() {
     "teardown did not preserve the project lifecycle success"
   assert_absent "$case_dir/state/task-x1.meta" \
     "Wayfinder-resolved scout teardown did not archive task metadata"
+
+  promoted_case=$(make_case wayfinder-promoted-scout-archive)
+  prepare_spawn_endpoint "$promoted_case"
+  mkdir -p "$promoted_case/data/task-x1"
+  printf '%s\n' 'Research the Wayfinder child.' > "$promoted_case/data/task-x1/brief.md"
+  install_teardown_wayfinder_gate "$promoted_case/project"
+  out=$(run_scout_spawn "$promoted_case" --wayfinder-child 5 2>&1)
+  rc=$?
+  expect_code 0 "$rc" "named Wayfinder scout should spawn before promotion"$'\n'"$out"
+  out=$(run_promote "$promoted_case" --mode no-mistakes --yolo off --wayfinder-independent 2>&1)
+  rc=$?
+  expect_code 0 "$rc" "map-independent promotion should retain the Wayfinder child obligation"$'\n'"$out"
+  assert_grep 'kind=ship' "$promoted_case/state/task-x1.meta" \
+    "promotion did not convert the scout to a ship"
+  assert_grep 'wayfinder_child=5' "$promoted_case/state/task-x1.meta" \
+    "promotion lost the named Wayfinder child"
+  rejected="$promoted_case/rejected.json"
+  resolved="$promoted_case/resolved.json"
+  printf '%s\n' '{"children":[{"number":5,"state":"open"}]}' > "$rejected"
+  printf '%s\n' '{"children":[{"number":5,"state":"closed"}]}' > "$resolved"
+
+  set +e
+  out=$(FM_DATA_OVERRIDE="$promoted_case/data" run_teardown "$promoted_case" \
+    --wayfinder-state "$rejected" 2>&1)
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "promoted Wayfinder scout must not archive while accept-child rejects"$'\n'"$out"
+  assert_contains "$out" "accept-child rejected" \
+    "promoted task teardown did not invoke the consuming project's accept-child command"
+  assert_present "$promoted_case/state/task-x1.meta" \
+    "Wayfinder-rejected promoted task teardown removed task metadata"
+
+  out=$(FM_DATA_OVERRIDE="$promoted_case/data" run_teardown "$promoted_case" \
+    --wayfinder-state "$resolved" 2>&1)
+  rc=$?
+  expect_code 0 "$rc" "promoted Wayfinder scout should archive after accept-child succeeds"$'\n'"$out"
+  assert_contains "$out" "accept-child accepted" \
+    "promoted task teardown did not preserve the project lifecycle success"
+  assert_absent "$promoted_case/state/task-x1.meta" \
+    "Wayfinder-resolved promoted task teardown did not archive task metadata"
 
   untracked_case=$(make_case wayfinder-untracked-scout)
   prepare_spawn_endpoint "$untracked_case"

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -553,6 +553,62 @@ run_teardown() {
     "$TEARDOWN" task-x1 "$@"
 }
 
+prepare_spawn_endpoint() {
+  local case_dir=$1
+  cat > "$case_dir/fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf '%s\n' firstmate ;;
+  list-windows|set-window-option|send-keys|kill-window) ;;
+  new-window)
+    [ -z "${FM_FAKE_TMUX_LOG:-}" ] || printf '%s\n' new-window >> "$FM_FAKE_TMUX_LOG"
+    printf '%s\n' '@42'
+    ;;
+  *) exit 1 ;;
+esac
+SH
+  chmod +x "$case_dir/fakebin/tmux"
+}
+
+run_scout_spawn() {
+  local case_dir=$1
+  shift
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$case_dir" \
+    FM_STATE_OVERRIDE="$case_dir/state" FM_DATA_OVERRIDE="$case_dir/data" \
+    FM_CONFIG_OVERRIDE="$case_dir/config" FM_SPAWN_NO_GUARD=1 FM_BACKEND=tmux \
+    FM_FAKE_PANE_PATH="$case_dir/wt" TMUX='fake,1,0' \
+    PATH="$case_dir/fakebin:${FM_TEARDOWN_TEST_PATH:-$PATH}" \
+    "$ROOT/bin/fm-spawn.sh" task-x1 "$case_dir/project" claude --scout "$@"
+}
+
+install_teardown_wayfinder_gate() {
+  local project=$1
+  mkdir -p "$project/bin"
+  cat > "$project/bin/wayfinder-lifecycle-gate" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" != --state ] || [ "${3:-}" != accept-child ]; then
+  echo 'unexpected Wayfinder lifecycle command' >&2
+  exit 1
+fi
+python3 - "$2" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as source:
+    snapshot = json.load(source)
+if (snapshot.get("children") or [{}])[0].get("state") == "closed":
+    print("accept-child accepted")
+    raise SystemExit(0)
+print("accept-child rejected", file=sys.stderr)
+raise SystemExit(2)
+PY
+SH
+  chmod +x "$project/bin/wayfinder-lifecycle-gate"
+}
+
 # Build the teardown test's executable search path without lsof, regardless of
 # whether the host installs it in /usr/bin, /usr/sbin, or a package-manager bin.
 make_path_without_lsof() {  # <case-dir>
@@ -619,36 +675,33 @@ test_teardown_manual_backend_prompts_hand_edit_even_when_tasks_axi_present() {
 }
 
 test_wayfinder_scout_teardown_requires_accept_child() {
-  local case_dir rejected resolved out rc
+  local case_dir untracked_case rejected resolved out rc
   case_dir=$(make_case wayfinder-scout-archive)
-  write_meta "$case_dir" no-mistakes scout
-  printf '%s\n' \
-    'decisions_reviewed=1' \
-    'decision_keys=' \
-    'wayfinder_child=5' >> "$case_dir/state/task-x1.meta"
-  add_compatible_tasks_axi "$case_dir"
-  mkdir -p "$case_dir/data/task-x1" "$case_dir/project/bin"
-  printf '%s\n' '# Research report' > "$case_dir/data/task-x1/report.md"
-  cat > "$case_dir/project/bin/wayfinder-lifecycle-gate" <<'SH'
-#!/usr/bin/env bash
-if [ "${1:-}" != --state ] || [ "${3:-}" != accept-child ]; then
-  echo 'unexpected Wayfinder lifecycle command' >&2
-  exit 1
-fi
-python3 - "$2" <<'PY'
-import json
-import sys
+  prepare_spawn_endpoint "$case_dir"
+  mkdir -p "$case_dir/data/task-x1"
+  printf '%s\n' 'Research the Wayfinder child.' > "$case_dir/data/task-x1/brief.md"
+  install_teardown_wayfinder_gate "$case_dir/project"
 
-with open(sys.argv[1], encoding="utf-8") as source:
-    snapshot = json.load(source)
-if (snapshot.get("children") or [{}])[0].get("state") == "closed":
-    print("accept-child accepted")
-    raise SystemExit(0)
-print("accept-child rejected", file=sys.stderr)
-raise SystemExit(2)
-PY
-SH
-  chmod +x "$case_dir/project/bin/wayfinder-lifecycle-gate"
+  set +e
+  out=$(FM_FAKE_TMUX_LOG="$case_dir/spawn.log" run_scout_spawn "$case_dir" 2>&1)
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "gated scout must declare its Wayfinder classification"$'\n'"$out"
+  assert_contains "$out" "--wayfinder-child <number-or-title> or --wayfinder-no-child" \
+    "gated scout spawn did not require a Wayfinder classification"
+  assert_absent "$case_dir/state/task-x1.meta" \
+    "unclassified gated scout spawn published task metadata"
+  assert_absent "$case_dir/spawn.log" \
+    "unclassified gated scout spawn created an endpoint"
+
+  out=$(run_scout_spawn "$case_dir" --wayfinder-child 5 2>&1)
+  rc=$?
+  expect_code 0 "$rc" "named Wayfinder scout should spawn with a child identity"$'\n'"$out"
+  assert_grep 'wayfinder_child=5' "$case_dir/state/task-x1.meta" \
+    "named Wayfinder scout did not persist its child identity"
+  add_compatible_tasks_axi "$case_dir"
+  printf '%s\n' '# Research report' > "$case_dir/data/task-x1/report.md"
+  printf '%s\n' 'decisions_reviewed=1' 'decision_keys=' >> "$case_dir/state/task-x1.meta"
   rejected="$case_dir/rejected.json"
   resolved="$case_dir/resolved.json"
   printf '%s\n' '{"children":[{"number":5,"state":"open"}]}' > "$rejected"
@@ -675,6 +728,25 @@ SH
     "teardown did not preserve the project lifecycle success"
   assert_absent "$case_dir/state/task-x1.meta" \
     "Wayfinder-resolved scout teardown did not archive task metadata"
+
+  untracked_case=$(make_case wayfinder-untracked-scout)
+  prepare_spawn_endpoint "$untracked_case"
+  mkdir -p "$untracked_case/data/task-x1"
+  printf '%s\n' 'Research an unrelated question.' > "$untracked_case/data/task-x1/brief.md"
+  install_teardown_wayfinder_gate "$untracked_case/project"
+  out=$(run_scout_spawn "$untracked_case" --wayfinder-no-child 2>&1)
+  rc=$?
+  expect_code 0 "$rc" "unrelated gated scout should spawn with an explicit no-child classification"$'\n'"$out"
+  assert_grep 'wayfinder_no_child=1' "$untracked_case/state/task-x1.meta" \
+    "unrelated gated scout did not persist its no-child classification"
+  add_compatible_tasks_axi "$untracked_case"
+  printf '%s\n' '# Unrelated research report' > "$untracked_case/data/task-x1/report.md"
+  printf '%s\n' 'decisions_reviewed=1' 'decision_keys=' >> "$untracked_case/state/task-x1.meta"
+  out=$(FM_DATA_OVERRIDE="$untracked_case/data" run_teardown "$untracked_case" 2>&1)
+  rc=$?
+  expect_code 0 "$rc" "explicit non-Wayfinder scout should tear down without a snapshot"$'\n'"$out"
+  assert_absent "$untracked_case/state/task-x1.meta" \
+    "explicit non-Wayfinder scout teardown did not archive task metadata"
   pass "Wayfinder scout teardown requires the project's accept-child check"
 }
 

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -686,7 +686,7 @@ test_teardown_manual_backend_prompts_hand_edit_even_when_tasks_axi_present() {
 }
 
 test_wayfinder_scout_teardown_requires_accept_child() {
-  local case_dir promoted_case untracked_case rejected resolved out rc
+  local case_dir promoted_case legacy_case untracked_case rejected resolved out rc
   case_dir=$(make_case wayfinder-scout-archive)
   prepare_spawn_endpoint "$case_dir"
   mkdir -p "$case_dir/data/task-x1"
@@ -780,6 +780,59 @@ test_wayfinder_scout_teardown_requires_accept_child() {
   assert_absent "$promoted_case/state/task-x1.meta" \
     "Wayfinder-resolved promoted task teardown did not archive task metadata"
 
+  legacy_case=$(make_case wayfinder-legacy-promoted-scout)
+  prepare_spawn_endpoint "$legacy_case"
+  mkdir -p "$legacy_case/data/task-x1"
+  printf '%s\n' 'Research the Wayfinder child.' > "$legacy_case/data/task-x1/brief.md"
+  install_teardown_wayfinder_gate "$legacy_case/project"
+  out=$(run_scout_spawn "$legacy_case" --wayfinder-child 5 2>&1)
+  rc=$?
+  expect_code 0 "$rc" "named Wayfinder scout should spawn before legacy migration"$'\n'"$out"
+  sed -i.bak '/^wayfinder_child=/d' "$legacy_case/state/task-x1.meta"
+  rm -f "$legacy_case/state/task-x1.meta.bak"
+
+  set +e
+  out=$(run_promote "$legacy_case" --mode no-mistakes --yolo off --wayfinder-independent 2>&1)
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "unclassified legacy Wayfinder scout must not promote"$'\n'"$out"
+  assert_contains "$out" "has no Wayfinder classification" \
+    "legacy Wayfinder promotion did not require explicit classification"
+  assert_grep 'kind=scout' "$legacy_case/state/task-x1.meta" \
+    "rejected legacy Wayfinder promotion changed the scout kind"
+
+  out=$(run_promote "$legacy_case" --mode no-mistakes --yolo off --wayfinder-independent \
+    --wayfinder-child 5 2>&1)
+  rc=$?
+  expect_code 0 "$rc" "classified legacy Wayfinder scout should promote"$'\n'"$out"
+  assert_grep 'wayfinder_child=5' "$legacy_case/state/task-x1.meta" \
+    "classified legacy promotion did not persist the named Wayfinder child"
+  add_compatible_tasks_axi "$legacy_case"
+  printf '%s\n' '# Research report' > "$legacy_case/data/task-x1/report.md"
+  printf '%s\n' 'decisions_reviewed=1' 'decision_keys=' >> "$legacy_case/state/task-x1.meta"
+  rejected="$legacy_case/rejected.json"
+  resolved="$legacy_case/resolved.json"
+  printf '%s\n' '{"children":[{"number":5,"state":"open"}]}' > "$rejected"
+  printf '%s\n' '{"children":[{"number":5,"state":"closed"}]}' > "$resolved"
+
+  set +e
+  out=$(FM_DATA_OVERRIDE="$legacy_case/data" run_teardown "$legacy_case" \
+    --wayfinder-state "$rejected" 2>&1)
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "classified legacy Wayfinder ship must not archive while accept-child rejects"$'\n'"$out"
+  assert_contains "$out" "accept-child rejected" \
+    "classified legacy promotion did not retain the accept-child obligation"
+  assert_present "$legacy_case/state/task-x1.meta" \
+    "Wayfinder-rejected classified legacy teardown removed task metadata"
+
+  out=$(FM_DATA_OVERRIDE="$legacy_case/data" run_teardown "$legacy_case" \
+    --wayfinder-state "$resolved" 2>&1)
+  rc=$?
+  expect_code 0 "$rc" "classified legacy Wayfinder ship should archive after accept-child succeeds"$'\n'"$out"
+  assert_absent "$legacy_case/state/task-x1.meta" \
+    "Wayfinder-resolved classified legacy teardown did not archive task metadata"
+
   untracked_case=$(make_case wayfinder-untracked-scout)
   prepare_spawn_endpoint "$untracked_case"
   mkdir -p "$untracked_case/data/task-x1"
@@ -790,6 +843,11 @@ test_wayfinder_scout_teardown_requires_accept_child() {
   expect_code 0 "$rc" "unrelated gated scout should spawn with an explicit no-child classification"$'\n'"$out"
   assert_grep 'wayfinder_no_child=1' "$untracked_case/state/task-x1.meta" \
     "unrelated gated scout did not persist its no-child classification"
+  out=$(run_promote "$untracked_case" --mode no-mistakes --yolo off --wayfinder-independent 2>&1)
+  rc=$?
+  expect_code 0 "$rc" "explicit non-Wayfinder scout should promote"$'\n'"$out"
+  assert_grep 'wayfinder_no_child=1' "$untracked_case/state/task-x1.meta" \
+    "promotion did not retain the explicit no-child classification"
   add_compatible_tasks_axi "$untracked_case"
   printf '%s\n' '# Unrelated research report' > "$untracked_case/data/task-x1/report.md"
   printf '%s\n' 'decisions_reviewed=1' 'decision_keys=' >> "$untracked_case/state/task-x1.meta"

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -686,7 +686,7 @@ test_teardown_manual_backend_prompts_hand_edit_even_when_tasks_axi_present() {
 }
 
 test_wayfinder_scout_teardown_requires_accept_child() {
-  local case_dir promoted_case legacy_case untracked_case rejected resolved out rc
+  local case_dir promoted_case legacy_case historic_case historic_no_child_case untracked_case rejected resolved out rc
   case_dir=$(make_case wayfinder-scout-archive)
   prepare_spawn_endpoint "$case_dir"
   mkdir -p "$case_dir/data/task-x1"
@@ -832,6 +832,79 @@ test_wayfinder_scout_teardown_requires_accept_child() {
   expect_code 0 "$rc" "classified legacy Wayfinder ship should archive after accept-child succeeds"$'\n'"$out"
   assert_absent "$legacy_case/state/task-x1.meta" \
     "Wayfinder-resolved classified legacy teardown did not archive task metadata"
+
+  historic_case=$(make_case wayfinder-historic-promoted-scout)
+  prepare_spawn_endpoint "$historic_case"
+  mkdir -p "$historic_case/data/task-x1"
+  printf '%s\n' 'Research the Wayfinder child.' > "$historic_case/data/task-x1/brief.md"
+  install_teardown_wayfinder_gate "$historic_case/project"
+  out=$(run_scout_spawn "$historic_case" --wayfinder-child 5 2>&1)
+  rc=$?
+  expect_code 0 "$rc" "named Wayfinder scout should spawn before historic promotion"$'\n'"$out"
+  printf '%s\n' '# Research report' > "$historic_case/data/task-x1/report.md"
+  printf '%s\n' 'decisions_reviewed=1' 'decision_keys=' >> "$historic_case/state/task-x1.meta"
+  sed -i.bak -e 's/^kind=scout$/kind=ship/' -e '/^wayfinder_child=/d' \
+    "$historic_case/state/task-x1.meta"
+  rm -f "$historic_case/state/task-x1.meta.bak"
+  add_compatible_tasks_axi "$historic_case"
+  rejected="$historic_case/rejected.json"
+  resolved="$historic_case/resolved.json"
+  printf '%s\n' '{"children":[{"number":5,"state":"open"}]}' > "$rejected"
+  printf '%s\n' '{"children":[{"number":5,"state":"closed"}]}' > "$resolved"
+
+  set +e
+  out=$(FM_DATA_OVERRIDE="$historic_case/data" run_teardown "$historic_case" 2>&1)
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "unclassified historic promoted scout must not archive"$'\n'"$out"
+  assert_contains "$out" "ship task task-x1 has no Wayfinder classification" \
+    "historic promoted scout teardown did not require Wayfinder migration"
+  assert_present "$historic_case/state/task-x1.meta" \
+    "unclassified historic promoted scout teardown removed task metadata"
+  assert_present "$historic_case/data/task-x1/report.md" \
+    "unclassified historic promoted scout teardown removed the report"
+
+  set +e
+  out=$(FM_DATA_OVERRIDE="$historic_case/data" run_teardown "$historic_case" \
+    --wayfinder-child 5 --wayfinder-state "$rejected" 2>&1)
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "historic promoted scout must not archive while accept-child rejects"$'\n'"$out"
+  assert_contains "$out" "accept-child rejected" \
+    "historic promoted scout teardown did not invoke accept-child"
+  assert_present "$historic_case/state/task-x1.meta" \
+    "Wayfinder-rejected historic teardown removed task metadata"
+  assert_grep 'wayfinder_child=5' "$historic_case/state/task-x1.meta" \
+    "historic Wayfinder migration did not persist the named child"
+
+  out=$(FM_DATA_OVERRIDE="$historic_case/data" run_teardown "$historic_case" \
+    --wayfinder-child 5 --wayfinder-state "$resolved" 2>&1)
+  rc=$?
+  expect_code 0 "$rc" "historic promoted scout should archive after accept-child succeeds"$'\n'"$out"
+  assert_absent "$historic_case/state/task-x1.meta" \
+    "Wayfinder-resolved historic teardown did not archive task metadata"
+
+  historic_no_child_case=$(make_case wayfinder-historic-no-child-ship)
+  prepare_spawn_endpoint "$historic_no_child_case"
+  install_teardown_wayfinder_gate "$historic_no_child_case/project"
+  write_meta "$historic_no_child_case" no-mistakes ship
+  add_compatible_tasks_axi "$historic_no_child_case"
+
+  set +e
+  out=$(run_teardown "$historic_no_child_case" 2>&1)
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "unclassified historic ship must not archive"$'\n'"$out"
+  assert_contains "$out" "ship task task-x1 has no Wayfinder classification" \
+    "historic ship teardown did not require Wayfinder migration"
+  assert_present "$historic_no_child_case/state/task-x1.meta" \
+    "unclassified historic ship teardown removed task metadata"
+
+  out=$(run_teardown "$historic_no_child_case" --wayfinder-no-child 2>&1)
+  rc=$?
+  expect_code 0 "$rc" "explicit no-child historic ship should archive"$'\n'"$out"
+  assert_absent "$historic_no_child_case/state/task-x1.meta" \
+    "explicit no-child historic ship teardown did not archive task metadata"
 
   untracked_case=$(make_case wayfinder-untracked-scout)
   prepare_spawn_endpoint "$untracked_case"

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -193,6 +193,10 @@ if [ "${1:-}" = mv ] && [ "${2:-}" = --help ]; then
   printf '%s\n' 'usage: tasks-axi mv <id> [<id>...] --to <path-or-dir>'
   exit 0
 fi
+if [ "${1:-}" = hold ] && [ "${2:-}" = --help ]; then
+  printf '%s\n' 'usage: tasks-axi hold <id> --kind captain'
+  exit 0
+fi
 exit 0
 SH
   chmod +x "$case_dir/fakebin/tasks-axi"
@@ -612,6 +616,66 @@ test_teardown_manual_backend_prompts_hand_edit_even_when_tasks_axi_present() {
   printf '%s\n' "$out" | grep -F 'tasks-axi done' >/dev/null \
     && fail "teardown prompted tasks-axi despite manual backend opt-out: $out"
   pass "teardown honors config/backlog-backend=manual even when tasks-axi is compatible"
+}
+
+test_wayfinder_scout_teardown_requires_accept_child() {
+  local case_dir rejected resolved out rc
+  case_dir=$(make_case wayfinder-scout-archive)
+  write_meta "$case_dir" no-mistakes scout
+  printf '%s\n' \
+    'decisions_reviewed=1' \
+    'decision_keys=' \
+    'wayfinder_child=5' >> "$case_dir/state/task-x1.meta"
+  add_compatible_tasks_axi "$case_dir"
+  mkdir -p "$case_dir/data/task-x1" "$case_dir/project/bin"
+  printf '%s\n' '# Research report' > "$case_dir/data/task-x1/report.md"
+  cat > "$case_dir/project/bin/wayfinder-lifecycle-gate" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" != --state ] || [ "${3:-}" != accept-child ]; then
+  echo 'unexpected Wayfinder lifecycle command' >&2
+  exit 1
+fi
+python3 - "$2" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as source:
+    snapshot = json.load(source)
+if (snapshot.get("children") or [{}])[0].get("state") == "closed":
+    print("accept-child accepted")
+    raise SystemExit(0)
+print("accept-child rejected", file=sys.stderr)
+raise SystemExit(2)
+PY
+SH
+  chmod +x "$case_dir/project/bin/wayfinder-lifecycle-gate"
+  rejected="$case_dir/rejected.json"
+  resolved="$case_dir/resolved.json"
+  printf '%s\n' '{"children":[{"number":5,"state":"open"}]}' > "$rejected"
+  printf '%s\n' '{"children":[{"number":5,"state":"closed"}]}' > "$resolved"
+
+  set +e
+  out=$(FM_DATA_OVERRIDE="$case_dir/data" run_teardown "$case_dir" \
+    --wayfinder-state "$rejected" 2>&1)
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "Wayfinder-rejected scout must not archive"$'\n'"$out"
+  assert_contains "$out" "accept-child rejected" \
+    "teardown did not invoke the consuming project's accept-child command"
+  assert_present "$case_dir/state/task-x1.meta" \
+    "Wayfinder-rejected scout teardown removed task metadata"
+  assert_present "$case_dir/data/task-x1/report.md" \
+    "Wayfinder-rejected scout teardown removed the report"
+
+  out=$(FM_DATA_OVERRIDE="$case_dir/data" run_teardown "$case_dir" \
+    --wayfinder-state "$resolved" 2>&1)
+  rc=$?
+  expect_code 0 "$rc" "Wayfinder-resolved scout should archive"$'\n'"$out"
+  assert_contains "$out" "accept-child accepted" \
+    "teardown did not preserve the project lifecycle success"
+  assert_absent "$case_dir/state/task-x1.meta" \
+    "Wayfinder-resolved scout teardown did not archive task metadata"
+  pass "Wayfinder scout teardown requires the project's accept-child check"
 }
 
 test_local_only_truly_unpushed_refuses() {
@@ -2594,6 +2658,7 @@ EOF
 test_local_only_fork_remote_allows
 test_teardown_prompts_tasks_axi_done_when_compatible
 test_teardown_manual_backend_prompts_hand_edit_even_when_tasks_axi_present
+test_wayfinder_scout_teardown_requires_accept_child
 test_local_only_truly_unpushed_refuses
 test_local_only_merged_to_local_main_allows
 test_no_mistakes_origin_remote_allows

--- a/tests/fm-wayfinder-parent.test.sh
+++ b/tests/fm-wayfinder-parent.test.sh
@@ -445,8 +445,6 @@ test_complete_none_alone_remains_insufficient() {
   id=wf-shopify-compliance
   snap="$TMP_ROOT/complete-none.json"
   write_snapshot "$snap" historical
-  mkdir -p "$home/data/$id"
-  printf '# Compliance research\n\nAnswered locally.\n' > "$home/data/$id/report.md"
   fm_write_meta "$home/state/$id.meta" \
     "window=firstmate:fm-$id" \
     "project=$project" \
@@ -466,8 +464,10 @@ test_complete_none_alone_remains_insufficient() {
   rc=$?
   set -e
   expect_code 2 "$rc" "complete --none must not satisfy accept-child"$'\n'"$out"
-  assert_contains "$out" "local-completion-is-not-resolution" \
-    "complete --none still masqueraded as Wayfinder resolution"
+  assert_contains "$out" "FAIL 5 open" \
+    "complete --none alone did not leave the Wayfinder child unresolved"
+  assert_absent "$home/data/$id/report.md" \
+    "complete --none fixture must not supply a local report"
   pass "fm-decision-hold.sh complete --none alone remains insufficient"
 }
 
@@ -491,6 +491,16 @@ test_map_dependent_spawn_and_promote() {
   [ "$rc" -ne 0 ] || fail "map-dependent spawn should refuse while handoff rejects"
   assert_contains "$out" "gate failed" "spawn did not surface the project handoff rejection"
   assert_absent "$home/state/$id.meta" "refused map-dependent spawn wrote task metadata"
+
+  set +e
+  out=$(run_spawn "$home" "$fakebin" "$id" "$project" claude --mode no-mistakes --yolo off \
+    --wayfinder-state "$snap_bad" --wayfinder-independent)
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "contradictory Wayfinder spawn flags must be refused"$'\n'"$out"
+  assert_contains "$out" "--wayfinder-state and --wayfinder-independent cannot be combined" \
+    "spawn accepted contradictory Wayfinder flags"
+  assert_absent "$home/state/$id.meta" "contradictory Wayfinder spawn flags wrote task metadata"
 
   set +e
   out=$(run_spawn "$home" "$fakebin" "$id" "$project" claude --mode no-mistakes --yolo off)
@@ -559,6 +569,17 @@ test_map_dependent_spawn_and_promote() {
   [ "$rc" -ne 0 ] || fail "map-dependent promotion should refuse while handoff rejects"
   assert_contains "$out" "gate failed" "promotion did not surface the project handoff rejection"
   assert_grep "kind=scout" "$home/state/$id.meta" "refused promotion flipped the scout to a ship"
+
+  set +e
+  out=$(run_promote "$home" "$id" --mode no-mistakes --yolo off \
+    --wayfinder-state "$snap_bad" --wayfinder-independent)
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "contradictory Wayfinder promotion flags must be refused"$'\n'"$out"
+  assert_contains "$out" "--wayfinder-state and --wayfinder-independent cannot be combined" \
+    "promotion accepted contradictory Wayfinder flags"
+  assert_grep "kind=scout" "$home/state/$id.meta" \
+    "contradictory Wayfinder promotion flags flipped the scout to a ship"
 
   set +e
   out=$(run_promote "$home" "$id" --mode no-mistakes --yolo off --wayfinder-state "$snap_good")

--- a/tests/fm-wayfinder-parent.test.sh
+++ b/tests/fm-wayfinder-parent.test.sh
@@ -320,6 +320,12 @@ run_spawn() {
     "$SPAWN" "$@" 2>&1
 }
 
+run_spawn_stdin() {
+  local home=$1 fakebin=$2 snapshot=$3
+  shift 3
+  printf '%s\n' "$snapshot" | run_spawn "$home" "$fakebin" "$@"
+}
+
 run_promote() {
   local home=$1
   shift
@@ -629,6 +635,37 @@ test_batch_refuses_foreign_wayfinder_snapshot() {
   pass "batch dispatch refuses a Wayfinder snapshot shared across gated projects"
 }
 
+test_batch_reuses_stdin_wayfinder_snapshot() {
+  local home project fakebin snap snapshot first_id second_id out rc handoff_count
+  home=$(make_home batch-wayfinder-stdin)
+  project=$(make_gated_project "$home" shop)
+  fakebin=$(fakebin_for "$home")
+  snap="$TMP_ROOT/batch-stdin-resolved.json"
+  write_snapshot "$snap" resolved
+  snapshot=$(cat "$snap")
+  first_id=batch-wayfinder-stdin-first
+  second_id=batch-wayfinder-stdin-second
+  write_ship_brief "$home" "$first_id"
+  write_ship_brief "$home" "$second_id"
+
+  set +e
+  out=$(run_spawn_stdin "$home" "$fakebin" "$snapshot" "$first_id=$project" "$second_id=$project" \
+    --harness claude --mode no-mistakes --yolo off --wayfinder-state -)
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "fixture batch should stop before creating endpoints"
+  handoff_count=$(printf '%s\n' "$out" | grep -Fxc 'OK handoff: Wayfinder: plan' || true)
+  [ "$handoff_count" = 2 ] \
+    || fail "a stdin snapshot must pass the project handoff for every same-project child: $out"
+  assert_contains "$out" "batch: FAILED to spawn $first_id ($project)" \
+    "first same-project child did not reach the post-handoff fixture refusal"
+  assert_contains "$out" "batch: FAILED to spawn $second_id ($project)" \
+    "second same-project child did not reach the post-handoff fixture refusal"
+  assert_absent "$home/state/$first_id.meta" "fixture batch wrote first task metadata"
+  assert_absent "$home/state/$second_id.meta" "fixture batch wrote second task metadata"
+  pass "batch dispatch reuses a stdin Wayfinder snapshot for every same-project child"
+}
+
 test_missing_project_command_is_loud() {
   local home project snap out rc
   home=$(make_home missing-gate)
@@ -651,4 +688,5 @@ test_resolved_research_and_decision_children_pass
 test_complete_none_alone_remains_insufficient
 test_map_dependent_spawn_and_promote
 test_batch_refuses_foreign_wayfinder_snapshot
+test_batch_reuses_stdin_wayfinder_snapshot
 test_missing_project_command_is_loud

--- a/tests/fm-wayfinder-parent.test.sh
+++ b/tests/fm-wayfinder-parent.test.sh
@@ -588,7 +588,7 @@ test_map_dependent_spawn_and_promote() {
   id=wf-research-scout
   write_scout_brief "$home" "$id"
   set +e
-  out=$(run_spawn "$home" "$fakebin" "$id" "$project" claude --scout)
+  out=$(run_spawn "$home" "$fakebin" "$id" "$project" claude --scout --wayfinder-no-child)
   rc=$?
   set -e
   [ "$rc" -ne 0 ] || fail "scout spawn should still stop before creating an endpoint in this fixture"

--- a/tests/fm-wayfinder-parent.test.sh
+++ b/tests/fm-wayfinder-parent.test.sh
@@ -587,7 +587,46 @@ test_map_dependent_spawn_and_promote() {
   set -e
   expect_code 0 "$rc" "promotion with passing handoff should succeed"$'\n'"$out"
   assert_grep "kind=ship" "$home/state/$id.meta" "passing promotion did not become a ship"
+
+  id=promote-independent
+  fm_write_meta "$home/state/$id.meta" \
+    "window=firstmate:fm-$id" \
+    "worktree=$project" \
+    "project=$project" \
+    "harness=codex" \
+    "kind=scout"
+  out=$(run_promote "$home" "$id" --mode no-mistakes --yolo off --wayfinder-independent)
+  rc=$?
+  expect_code 0 "$rc" "map-independent promotion should succeed without a snapshot"$'\n'"$out"
+  assert_grep "wayfinder_independent=1" "$home/state/$id.meta" \
+    "map-independent promotion did not preserve its relaunch exemption"
   pass "map-dependent dispatch is refused while handoff rejects and allowed when it passes"
+}
+
+test_batch_refuses_foreign_wayfinder_snapshot() {
+  local home first second fakebin snap out rc first_id second_id
+  home=$(make_home batch-wayfinder)
+  first=$(make_gated_project "$home" first)
+  second=$(make_gated_project "$home" second)
+  fakebin=$(fakebin_for "$home")
+  snap="$TMP_ROOT/batch-resolved.json"
+  write_snapshot "$snap" resolved
+  first_id=batch-wayfinder-first
+  second_id=batch-wayfinder-second
+  write_ship_brief "$home" "$first_id"
+  write_ship_brief "$home" "$second_id"
+
+  set +e
+  out=$(run_spawn "$home" "$fakebin" "$first_id=$first" "$second_id=$second" \
+    --harness claude --mode no-mistakes --yolo off --wayfinder-state "$snap")
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "a Wayfinder snapshot must not cross gated projects"$'\n'"$out"
+  assert_contains "$out" "cannot be shared by distinct projects" \
+    "batch dispatch accepted a foreign Wayfinder snapshot"
+  assert_absent "$home/state/$first_id.meta" "foreign-snapshot batch wrote first task metadata"
+  assert_absent "$home/state/$second_id.meta" "foreign-snapshot batch wrote second task metadata"
+  pass "batch dispatch refuses a Wayfinder snapshot shared across gated projects"
 }
 
 test_missing_project_command_is_loud() {
@@ -611,4 +650,5 @@ test_historical_local_completion_is_not_resolution
 test_resolved_research_and_decision_children_pass
 test_complete_none_alone_remains_insufficient
 test_map_dependent_spawn_and_promote
+test_batch_refuses_foreign_wayfinder_snapshot
 test_missing_project_command_is_loud

--- a/tests/fm-wayfinder-parent.test.sh
+++ b/tests/fm-wayfinder-parent.test.sh
@@ -1,0 +1,593 @@
+#!/usr/bin/env bash
+# Behavior tests for Firstmate's parent map-owner check.
+#
+# Drives bin/fm-wayfinder-parent.sh, bin/fm-spawn.sh, bin/fm-promote.sh, and
+# bin/fm-decision-hold.sh through a consuming project's public
+# bin/wayfinder-lifecycle-gate. Does not inspect Firstmate source text.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+PARENT="$ROOT/bin/fm-wayfinder-parent.sh"
+SPAWN="$ROOT/bin/fm-spawn.sh"
+PROMOTE="$ROOT/bin/fm-promote.sh"
+DECISION_HOLD="$ROOT/bin/fm-decision-hold.sh"
+TMP_ROOT=$(fm_test_tmproot fm-wayfinder-parent)
+TASKS_AXI_BIN=$(command -v tasks-axi || true)
+
+command -v python3 >/dev/null 2>&1 || { echo "skip: python3 not found"; exit 0; }
+
+# A compact consuming-project lifecycle command with the public CLI and
+# snapshot shape Firstmate must invoke. It refuses local completion as
+# resolution and requires a closed child, an evidence pointer, and a named
+# gist-and-link map line.
+install_project_gate() {  # <project-dir>
+  local project=$1
+  mkdir -p "$project/bin"
+  cat > "$project/bin/wayfinder-lifecycle-gate" <<'PY'
+#!/usr/bin/env python3
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+URL_RE = re.compile(r"https?://[^\s)>\]]+", re.I)
+PATH_RE = re.compile(
+    r"(?:^|[\s`(\[])((?:[\w.-]+/)+[\w.-]+\.(?:md|txt|json)|research/[\w./-]+)"
+)
+DECISIONS_HEADER_RE = re.compile(r"^##[ \t]+Decisions so far[ \t]*$", re.M)
+NEXT_HEADER_RE = re.compile(r"^##[ \t]+", re.M)
+DECISION_ITEM_RE = re.compile(
+    r"^[-*][ \t]+\[([^\]]+)\]\(([^)]+)\):[ \t]+(\S.*)$",
+    re.M,
+)
+
+
+def load_state(path):
+    raw = sys.stdin.read() if path == "-" else Path(path).read_text(encoding="utf-8")
+    return json.loads(raw)
+
+
+def comments(child):
+    out = []
+    for item in child.get("comments") or []:
+        if isinstance(item, str):
+            out.append(item)
+        elif isinstance(item, dict):
+            out.append(item.get("body") or "")
+    return out
+
+
+def has_evidence(text):
+    return bool(URL_RE.search(text) or PATH_RE.search(text))
+
+
+def has_answer(text):
+    stripped = URL_RE.sub(" ", text)
+    stripped = PATH_RE.sub(" ", stripped)
+    letters = re.sub(r"[^A-Za-z0-9]+", "", stripped)
+    return len(letters) >= 30
+
+
+def named_pointer(state, child):
+    body = ((state.get("map") or {}).get("body")) or ""
+    match = DECISIONS_HEADER_RE.search(body)
+    if match is None:
+        return False
+    rest = body[match.end() :]
+    nxt = NEXT_HEADER_RE.search(rest)
+    section = rest[: nxt.start()] if nxt else rest
+    title = child.get("title") or ""
+    number = child.get("number")
+    for item in DECISION_ITEM_RE.finditer(section):
+        if item.group(1).strip() != title:
+            continue
+        if not item.group(3).strip():
+            continue
+        url = item.group(2)
+        linked = re.search(r"(?:issues/|#)(\d+)\s*$", url)
+        if linked and int(linked.group(1)) != number:
+            continue
+        return True
+    return False
+
+
+def find_child(state, ref):
+    for child in state.get("children") or []:
+        if str(child.get("number")) == str(ref) or child.get("title") == ref:
+            return child
+    return None
+
+
+def local_for(state, number):
+    local = (state.get("local") or {}).get("completions") or []
+    return [item for item in local if item.get("child") == number]
+
+
+def evaluate(state, child):
+    findings = []
+    number = child.get("number")
+    closed = str(child.get("state") or "").lower() in {"closed", "close"}
+    bodies = comments(child)
+    evidence_comment = any(has_answer(body) and has_evidence(body) for body in bodies)
+    pointer = named_pointer(state, child)
+    local = local_for(state, number)
+    if any(item.get("complete") for item in local) and not (
+        closed and evidence_comment and pointer
+    ):
+        findings.append(
+            f"FAIL {number} local-completion-is-not-resolution: a Firstmate report, backlog state, archive, or captain-held decision is not Wayfinder resolution"
+        )
+    if not closed:
+        findings.append(f"FAIL {number} open: child is still open on GitHub")
+    if not evidence_comment:
+        findings.append(
+            f"FAIL {number} missing-evidence-pointer: resolution comment is missing a durable evidence pointer"
+        )
+    if not pointer:
+        findings.append(
+            f"FAIL {number} missing-named-map-pointer: canonical map Decisions so far has no named gist-and-link entry for this ticket title"
+        )
+    return findings
+
+
+def main(argv):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--state", required=True)
+    sub = parser.add_subparsers(dest="command", required=True)
+    accept = sub.add_parser("accept-child")
+    accept.add_argument("child")
+    sub.add_parser("handoff")
+    args = parser.parse_args(argv)
+    try:
+        state = load_state(args.state)
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    if args.command == "accept-child":
+        child = find_child(state, args.child)
+        if child is None:
+            print(f"error: child {args.child!r} is not in the snapshot", file=sys.stderr)
+            return 1
+        findings = evaluate(state, child)
+        if findings:
+            print("\n".join(findings), file=sys.stderr)
+            print("gate failed", file=sys.stderr)
+            return 2
+        print(f"OK {child['number']} resolved: {child['title']}")
+        return 0
+    findings = []
+    for child in state.get("children") or []:
+        findings.extend(evaluate(state, child))
+    if findings:
+        print("\n".join(findings), file=sys.stderr)
+        print("gate failed", file=sys.stderr)
+        return 2
+    title = ((state.get("map") or {}).get("title")) or "map"
+    print(f"OK handoff: {title}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))
+PY
+  chmod +x "$project/bin/wayfinder-lifecycle-gate"
+}
+
+empty_decisions() {
+  cat <<'EOF'
+## Destination
+
+A decision-ready plan. It does not implement the product.
+
+## Decisions so far
+
+<!-- Resolved ticket summaries are linked here. -->
+
+## Out of scope
+
+- Production implementation before the planning decisions in this map are resolved.
+EOF
+}
+
+resolved_decisions() {  # <research-title> <decision-title>
+  cat <<EOF
+## Destination
+
+A decision-ready plan. It does not implement the product.
+
+## Decisions so far
+
+- [$1](https://github.com/example/shop/issues/5): research answer gist
+- [$2](https://github.com/example/shop/issues/3): decision answer gist
+
+## Out of scope
+
+- Production implementation before the planning decisions in this map are resolved.
+EOF
+}
+
+RESEARCH_TITLE='Research: SMB market and competitor wedge'
+DECISION_TITLE='Decision: MVP autonomy boundary and action surface'
+
+write_snapshot() {  # <path> <kind>
+  local path=$1 kind=$2 body
+  case "$kind" in
+    historical)
+      body=$(empty_decisions)
+      python3 - "$path" "$body" "$RESEARCH_TITLE" "$DECISION_TITLE" <<'PY'
+import json, sys
+from pathlib import Path
+path, body, research, decision = sys.argv[1:]
+Path(path).write_text(json.dumps({
+    "map": {"number": 2, "title": "Wayfinder: plan", "state": "open", "body": body},
+    "children": [
+        {
+            "number": 5,
+            "title": research,
+            "state": "open",
+            "labels": ["wayfinder:research"],
+            "comments": [{"body": "Research complete. Evidence is in the planning report."}],
+        },
+        {
+            "number": 3,
+            "title": decision,
+            "state": "open",
+            "labels": ["wayfinder:grilling"],
+            "comments": [{"body": "Captain chose proposed-only changes with one-click accept."}],
+        },
+    ],
+    "local": {"completions": []},
+}, indent=2) + "\n", encoding="utf-8")
+PY
+      ;;
+    resolved)
+      body=$(resolved_decisions "$RESEARCH_TITLE" "$DECISION_TITLE")
+      python3 - "$path" "$body" "$RESEARCH_TITLE" "$DECISION_TITLE" <<'PY'
+import json, sys
+from pathlib import Path
+path, body, research, decision = sys.argv[1:]
+Path(path).write_text(json.dumps({
+    "map": {"number": 2, "title": "Wayfinder: plan", "state": "open", "body": body},
+    "children": [
+        {
+            "number": 5,
+            "title": research,
+            "state": "closed",
+            "labels": ["wayfinder:research"],
+            "comments": [{
+                "body": "Research complete. Do not position the MVP as a generic low-price optimizer. Evidence: https://example.test/research/smb-market.md"
+            }],
+        },
+        {
+            "number": 3,
+            "title": decision,
+            "state": "closed",
+            "labels": ["wayfinder:grilling"],
+            "comments": [{
+                "body": "By default all changes are proposed only, with one-click accept, pause, and rollback. Evidence: https://example.test/decisions/autonomy.md"
+            }],
+        },
+    ],
+    "local": {"completions": []},
+}, indent=2) + "\n", encoding="utf-8")
+PY
+      ;;
+    *) fail "unknown snapshot kind $kind" ;;
+  esac
+}
+
+make_home() {  # <name>
+  local home="$TMP_ROOT/$1/home"
+  mkdir -p "$home/data" "$home/state" "$home/config" "$home/projects"
+  cp "$ROOT/.tasks.toml" "$home/.tasks.toml"
+  cat > "$home/data/backlog.md" <<'EOF'
+## In flight
+
+## Queued
+
+## Done
+EOF
+  printf '%s\n' "$home"
+}
+
+make_gated_project() {  # <home> <name>
+  local home=$1 name=$2 project
+  project="$home/projects/$name"
+  mkdir -p "$project"
+  fm_git_init_commit "$project"
+  install_project_gate "$project"
+  printf '%s\n' "$project"
+}
+
+run_parent() {
+  local home=$1
+  shift
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    "$PARENT" "$@"
+}
+
+run_spawn() {
+  local home=$1 fakebin=$2
+  shift 2
+  FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SPAWN_NO_GUARD=1 FM_BACKEND=tmux PATH="$fakebin:$PATH" \
+    "$SPAWN" "$@" 2>&1
+}
+
+run_promote() {
+  local home=$1
+  shift
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    "$PROMOTE" "$@" 2>&1
+}
+
+write_ship_brief() {  # <home> <id>
+  mkdir -p "$1/data/$2"
+  printf 'You are a crewmate.\n\n# Definition of done\nDelivery contract: mode=no-mistakes\n' \
+    > "$1/data/$2/brief.md"
+}
+
+write_scout_brief() {  # <home> <id>
+  mkdir -p "$1/data/$2"
+  printf 'You are a crewmate.\n\n# Task\nNamed Wayfinder ticket.\n' \
+    > "$1/data/$2/brief.md"
+}
+
+fakebin_for() {  # <home>
+  local fakebin
+  fakebin=$(fm_fakebin "$1")
+  # Exit 1 so a spawn that clears the Wayfinder check still creates no endpoint.
+  printf '#!/bin/sh\nexit 1\n' > "$fakebin/tmux"
+  printf '#!/bin/sh\nexit 1\n' > "$fakebin/treehouse"
+  chmod +x "$fakebin/tmux" "$fakebin/treehouse"
+  printf '%s\n' "$fakebin"
+}
+
+# Historical failure: named Wayfinder scout has a report and completed
+# captain-call inventory while the project command rejects the child.
+test_historical_local_completion_is_not_resolution() {
+  local home project id snap out rc
+  home=$(make_home historical)
+  project=$(make_gated_project "$home" shop)
+  id=wf-market-wedge
+  snap="$TMP_ROOT/historical.json"
+  write_snapshot "$snap" historical
+  mkdir -p "$home/data/$id"
+  cat > "$home/data/$id/report.md" <<'EOF'
+# Research report
+
+The research question is answered. This local report is not GitHub resolution.
+EOF
+  fm_write_meta "$home/state/$id.meta" \
+    "window=firstmate:fm-$id" \
+    "worktree=$home/projects/missing-$id" \
+    "project=$project" \
+    "harness=codex" \
+    "kind=scout"
+
+  if [ -n "$TASKS_AXI_BIN" ]; then
+    (cd "$home" && tasks-axi add "$id" "Research the market wedge" --kind scout --repo shop --start >/dev/null) \
+      || fail "could not create historical scout backlog item"
+    out=$(PATH="$(dirname "$TASKS_AXI_BIN"):$PATH" FM_HOME="$home" \
+      FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+      "$DECISION_HOLD" complete "$id" --none 2>&1)
+    rc=$?
+    expect_code 0 "$rc" "complete --none should succeed as local captain-call inventory"$'\n'"$out"
+    grep -F 'captain-call inventory reviewed' <<<"$out" >/dev/null \
+      || fail "complete --none did not attest local inventory: $out"
+  else
+    printf 'decisions_reviewed=1\ndecision_keys=\n' >> "$home/state/$id.meta"
+  fi
+
+  set +e
+  out=$(run_parent "$home" accept-child --project "$project" --state "$snap" \
+    --child 5 --task "$id" 2>&1)
+  rc=$?
+  set -e
+  expect_code 2 "$rc" "accept-child must refuse a locally completed unresolved child"$'\n'"$out"
+  assert_contains "$out" "local-completion-is-not-resolution" \
+    "project gate must see the merged local report"
+  assert_not_contains "$out" "OK 5 resolved" \
+    "Firstmate must not treat the historical child as Wayfinder-resolved"
+
+  set +e
+  out=$(run_parent "$home" handoff --project "$project" --state "$snap" --task "$id" --child 5 2>&1)
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "handoff must not take --child"$'\n'"$out"
+
+  set +e
+  out=$(run_parent "$home" handoff --project "$project" --state "$snap" --task "$id" 2>&1)
+  rc=$?
+  set -e
+  expect_code 2 "$rc" "handoff must refuse while the map is unresolved"$'\n'"$out"
+  pass "historical local report plus captain-call completion is not Wayfinder resolution"
+}
+
+test_resolved_research_and_decision_children_pass() {
+  local home project snap out rc
+  home=$(make_home resolved)
+  project=$(make_gated_project "$home" shop)
+  snap="$TMP_ROOT/resolved.json"
+  write_snapshot "$snap" resolved
+
+  out=$(run_parent "$home" accept-child --project "$project" --state "$snap" --child 5)
+  rc=$?
+  expect_code 0 "$rc" "resolved research child must pass accept-child"$'\n'"$out"
+  assert_contains "$out" "OK 5 resolved: $RESEARCH_TITLE" \
+    "research accept-child did not report the project command success"
+
+  out=$(run_parent "$home" accept-child --project "$project" --state "$snap" \
+    --child "$DECISION_TITLE")
+  rc=$?
+  expect_code 0 "$rc" "resolved decision child must pass accept-child"$'\n'"$out"
+  assert_contains "$out" "OK 3 resolved: $DECISION_TITLE" \
+    "decision accept-child did not report the project command success"
+
+  out=$(run_parent "$home" handoff --project "$project" --state "$snap")
+  rc=$?
+  expect_code 0 "$rc" "resolved map must pass handoff"$'\n'"$out"
+  assert_contains "$out" "OK handoff:" "handoff did not report the project command success"
+  pass "parent accepts a resolved research child and a resolved decision child through the project command"
+}
+
+test_complete_none_alone_remains_insufficient() {
+  local home project id snap out rc
+  home=$(make_home complete-none)
+  project=$(make_gated_project "$home" shop)
+  id=wf-shopify-compliance
+  snap="$TMP_ROOT/complete-none.json"
+  write_snapshot "$snap" historical
+  mkdir -p "$home/data/$id"
+  printf '# Compliance research\n\nAnswered locally.\n' > "$home/data/$id/report.md"
+  fm_write_meta "$home/state/$id.meta" \
+    "window=firstmate:fm-$id" \
+    "project=$project" \
+    "kind=scout"
+  [ -n "$TASKS_AXI_BIN" ] || fail "tasks-axi is required to prove complete --none is insufficient"
+  (cd "$home" && tasks-axi add "$id" "Research compliance" --kind scout --repo shop --start >/dev/null) \
+    || fail "could not create complete --none scout"
+  out=$(PATH="$(dirname "$TASKS_AXI_BIN"):$PATH" FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    "$DECISION_HOLD" complete "$id" --none 2>&1)
+  rc=$?
+  expect_code 0 "$rc" "fm-decision-hold.sh complete --none should remain valid local attestation"$'\n'"$out"
+
+  set +e
+  out=$(run_parent "$home" accept-child --project "$project" --state "$snap" \
+    --child 5 --task "$id" 2>&1)
+  rc=$?
+  set -e
+  expect_code 2 "$rc" "complete --none must not satisfy accept-child"$'\n'"$out"
+  assert_contains "$out" "local-completion-is-not-resolution" \
+    "complete --none still masqueraded as Wayfinder resolution"
+  pass "fm-decision-hold.sh complete --none alone remains insufficient"
+}
+
+test_map_dependent_spawn_and_promote() {
+  local home project fakebin snap_bad snap_good out rc id
+  home=$(make_home dispatch)
+  project=$(make_gated_project "$home" shop)
+  fakebin=$(fakebin_for "$home")
+  snap_bad="$TMP_ROOT/dispatch-historical.json"
+  snap_good="$TMP_ROOT/dispatch-resolved.json"
+  write_snapshot "$snap_bad" historical
+  write_snapshot "$snap_good" resolved
+
+  id=ship-wayfinder-mvp
+  write_ship_brief "$home" "$id"
+  set +e
+  out=$(run_spawn "$home" "$fakebin" "$id" "$project" claude --mode no-mistakes --yolo off \
+    --wayfinder-state "$snap_bad")
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "map-dependent spawn should refuse while handoff rejects"
+  assert_contains "$out" "gate failed" "spawn did not surface the project handoff rejection"
+  assert_absent "$home/state/$id.meta" "refused map-dependent spawn wrote task metadata"
+
+  set +e
+  out=$(run_spawn "$home" "$fakebin" "$id" "$project" claude --mode no-mistakes --yolo off)
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "gated ship spawn without --wayfinder-state should refuse"
+  assert_contains "$out" "bin/wayfinder-lifecycle-gate" \
+    "missing snapshot did not name the project lifecycle command"
+  assert_absent "$home/state/$id.meta" "state-less gated spawn wrote task metadata"
+
+  set +e
+  out=$(run_spawn "$home" "$fakebin" "$id" "$project" claude --mode no-mistakes --yolo off \
+    --wayfinder-state "$snap_good")
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "handoff-passing spawn should still stop before creating an endpoint in this fixture"
+  assert_not_contains "$out" "gate failed" "passing handoff still refused the project command"
+  assert_not_contains "$out" "local-completion-is-not-resolution" \
+    "passing handoff still treated the child as unresolved"
+  assert_absent "$home/state/$id.meta" "fixture spawn that passed handoff should still fail before metadata"
+
+  id=wf-independent-docs
+  write_ship_brief "$home" "$id"
+  set +e
+  out=$(run_spawn "$home" "$fakebin" "$id" "$project" claude --mode no-mistakes --yolo off \
+    --wayfinder-independent)
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "independent ship spawn should still stop before creating an endpoint in this fixture"
+  assert_not_contains "$out" "gate failed" "map-independent spawn invoked handoff"
+  assert_not_contains "$out" "pass --wayfinder-state" "map-independent spawn still required a snapshot"
+
+  id=wf-research-scout
+  write_scout_brief "$home" "$id"
+  set +e
+  out=$(run_spawn "$home" "$fakebin" "$id" "$project" claude --scout)
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "scout spawn should still stop before creating an endpoint in this fixture"
+  assert_not_contains "$out" "gate failed" "read-only scout spawn invoked handoff"
+  assert_not_contains "$out" "pass --wayfinder-state" "scout spawn required a map snapshot"
+
+  id=plain-ship
+  write_ship_brief "$home" "$id"
+  mkdir -p "$home/projects/plain"
+  fm_git_init_commit "$home/projects/plain"
+  set +e
+  out=$(run_spawn "$home" "$fakebin" "$id" "$home/projects/plain" claude --mode no-mistakes --yolo off)
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "ungated ship spawn should still stop before creating an endpoint in this fixture"
+  assert_not_contains "$out" "wayfinder-lifecycle-gate" \
+    "a project without the lifecycle command picked up a Wayfinder handoff"
+
+  id=promote-research
+  fm_write_meta "$home/state/$id.meta" \
+    "window=firstmate:fm-$id" \
+    "worktree=$project" \
+    "project=$project" \
+    "harness=codex" \
+    "kind=scout"
+  set +e
+  out=$(run_promote "$home" "$id" --mode no-mistakes --yolo off --wayfinder-state "$snap_bad")
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "map-dependent promotion should refuse while handoff rejects"
+  assert_contains "$out" "gate failed" "promotion did not surface the project handoff rejection"
+  assert_grep "kind=scout" "$home/state/$id.meta" "refused promotion flipped the scout to a ship"
+
+  set +e
+  out=$(run_promote "$home" "$id" --mode no-mistakes --yolo off --wayfinder-state "$snap_good")
+  rc=$?
+  set -e
+  expect_code 0 "$rc" "promotion with passing handoff should succeed"$'\n'"$out"
+  assert_grep "kind=ship" "$home/state/$id.meta" "passing promotion did not become a ship"
+  pass "map-dependent dispatch is refused while handoff rejects and allowed when it passes"
+}
+
+test_missing_project_command_is_loud() {
+  local home project snap out rc
+  home=$(make_home missing-gate)
+  project="$home/projects/shop"
+  mkdir -p "$project"
+  snap="$TMP_ROOT/missing.json"
+  write_snapshot "$snap" resolved
+  set +e
+  out=$(run_parent "$home" accept-child --project "$project" --state "$snap" --child 5 2>&1)
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "missing project command should be a usage failure"$'\n'"$out"
+  assert_contains "$out" "bin/wayfinder-lifecycle-gate" \
+    "missing project command did not name the lifecycle command to invoke"
+  pass "parent check refuses when the consuming project has no lifecycle command"
+}
+
+test_historical_local_completion_is_not_resolution
+test_resolved_research_and_decision_children_pass
+test_complete_none_alone_remains_insufficient
+test_map_dependent_spawn_and_promote
+test_missing_project_command_is_loud

--- a/tests/fm-wayfinder-parent.test.sh
+++ b/tests/fm-wayfinder-parent.test.sh
@@ -176,6 +176,16 @@ PY
   chmod +x "$project/bin/wayfinder-lifecycle-gate"
 }
 
+install_exit_one_gate() {
+  mkdir -p "$1/bin"
+  cat > "$1/bin/wayfinder-lifecycle-gate" <<'SH'
+#!/usr/bin/env bash
+echo "project gate rejected" >&2
+exit 1
+SH
+  chmod +x "$1/bin/wayfinder-lifecycle-gate"
+}
+
 empty_decisions() {
   cat <<'EOF'
 ## Destination
@@ -666,6 +676,24 @@ test_batch_reuses_stdin_wayfinder_snapshot() {
   pass "batch dispatch reuses a stdin Wayfinder snapshot for every same-project child"
 }
 
+test_parent_normalizes_project_gate_failure() {
+  local home project snap out rc
+  home=$(make_home gate-exit-one)
+  project=$(make_gated_project "$home" shop)
+  install_exit_one_gate "$project"
+  snap="$TMP_ROOT/gate-exit-one.json"
+  write_snapshot "$snap" resolved
+
+  set +e
+  out=$(run_parent "$home" handoff --project "$project" --state "$snap" 2>&1)
+  rc=$?
+  set -e
+  expect_code 2 "$rc" "a project gate rejection must use the parent failure status"$'\n'"$out"
+  assert_contains "$out" "project gate rejected" \
+    "the parent check did not preserve project-gate rejection output"
+  pass "parent check normalizes a project gate rejection"
+}
+
 test_missing_project_command_is_loud() {
   local home project snap out rc
   home=$(make_home missing-gate)
@@ -689,4 +717,5 @@ test_complete_none_alone_remains_insufficient
 test_map_dependent_spawn_and_promote
 test_batch_refuses_foreign_wayfinder_snapshot
 test_batch_reuses_stdin_wayfinder_snapshot
+test_parent_normalizes_project_gate_failure
 test_missing_project_command_is_loud

--- a/tests/fm-wayfinder-parent.test.sh
+++ b/tests/fm-wayfinder-parent.test.sh
@@ -571,6 +571,8 @@ test_map_dependent_spawn_and_promote() {
   assert_contains "$out" "spawned $id harness=claude kind=ship" \
     "passing handoff did not launch the ship"
   assert_present "$home/state/$id.meta" "passing handoff did not publish task metadata"
+  assert_grep "wayfinder_no_child=1" "$home/state/$id.meta" \
+    "gated direct ship did not record its no-child classification"
   assert_grep "worktree=$worktree" "$home/state/$id.meta" \
     "passing handoff recorded the wrong isolated worktree"
 

--- a/tests/fm-wayfinder-parent.test.sh
+++ b/tests/fm-wayfinder-parent.test.sh
@@ -613,7 +613,8 @@ test_map_dependent_spawn_and_promote() {
     "worktree=$project" \
     "project=$project" \
     "harness=codex" \
-    "kind=scout"
+    "kind=scout" \
+    "wayfinder_no_child=1"
   set +e
   out=$(run_promote "$home" "$id" --mode no-mistakes --yolo off --wayfinder-state "$snap_bad")
   rc=$?
@@ -646,7 +647,8 @@ test_map_dependent_spawn_and_promote() {
     "worktree=$project" \
     "project=$project" \
     "harness=codex" \
-    "kind=scout"
+    "kind=scout" \
+    "wayfinder_no_child=1"
   out=$(run_promote "$home" "$id" --mode no-mistakes --yolo off --wayfinder-independent)
   rc=$?
   expect_code 0 "$rc" "map-independent promotion should succeed without a snapshot"$'\n'"$out"

--- a/tests/fm-wayfinder-parent.test.sh
+++ b/tests/fm-wayfinder-parent.test.sh
@@ -326,7 +326,8 @@ run_spawn() {
   FM_ROOT_OVERRIDE='' FM_HOME="$home" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
-    FM_SPAWN_NO_GUARD=1 FM_BACKEND=tmux PATH="$fakebin:$PATH" \
+    FM_SPAWN_NO_GUARD=1 FM_BACKEND=tmux FM_FAKE_PANE_PATH="${FM_FAKE_PANE_PATH:-}" \
+    TMUX="${FM_TEST_TMUX:-}" PATH="$fakebin:$PATH" \
     "$SPAWN" "$@" 2>&1
 }
 
@@ -363,6 +364,34 @@ fakebin_for() {  # <home>
   printf '#!/bin/sh\nexit 1\n' > "$fakebin/tmux"
   printf '#!/bin/sh\nexit 1\n' > "$fakebin/treehouse"
   chmod +x "$fakebin/tmux" "$fakebin/treehouse"
+  printf '%s\n' "$fakebin"
+}
+
+successful_fakebin_for() {  # <home>
+  local fakebin
+  fakebin=$(fm_fakebin "$1")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf '%s\n' firstmate ;;
+  list-windows|set-window-option|send-keys|kill-window) ;;
+  new-window) printf '%s\n' '@42' ;;
+  *) exit 1 ;;
+esac
+SH
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  cat > "$fakebin/timeout" <<'SH'
+#!/usr/bin/env bash
+shift
+exec "$@"
+SH
+  chmod +x "$fakebin/tmux" "$fakebin/treehouse" "$fakebin/timeout"
   printf '%s\n' "$fakebin"
 }
 
@@ -488,7 +517,7 @@ test_complete_none_alone_remains_insufficient() {
 }
 
 test_map_dependent_spawn_and_promote() {
-  local home project fakebin snap_bad snap_good out rc id
+  local home project fakebin successful_fakebin snap_bad snap_good out rc id worktree
   home=$(make_home dispatch)
   project=$(make_gated_project "$home" shop)
   fakebin=$(fakebin_for "$home")
@@ -527,16 +556,23 @@ test_map_dependent_spawn_and_promote() {
     "missing snapshot did not name the project lifecycle command"
   assert_absent "$home/state/$id.meta" "state-less gated spawn wrote task metadata"
 
-  set +e
-  out=$(run_spawn "$home" "$fakebin" "$id" "$project" claude --mode no-mistakes --yolo off \
-    --wayfinder-state "$snap_good")
+  fm_git_add_origin "$project" "$project.origin.git"
+  worktree="$home/worktrees/$id"
+  git -C "$project" worktree add -q -b "fm/$id" "$worktree"
+  successful_fakebin=$(successful_fakebin_for "$home/success-fixture")
+  out=$(FM_FAKE_PANE_PATH="$worktree" FM_TEST_TMUX='fake,1,0' \
+    run_spawn "$home" "$successful_fakebin" "$id" "$project" claude --mode no-mistakes --yolo off \
+      --wayfinder-state "$snap_good")
   rc=$?
-  set -e
-  [ "$rc" -ne 0 ] || fail "handoff-passing spawn should still stop before creating an endpoint in this fixture"
+  expect_code 0 "$rc" "handoff-passing spawn should launch an isolated worker"$'\n'"$out"
   assert_not_contains "$out" "gate failed" "passing handoff still refused the project command"
   assert_not_contains "$out" "local-completion-is-not-resolution" \
     "passing handoff still treated the child as unresolved"
-  assert_absent "$home/state/$id.meta" "fixture spawn that passed handoff should still fail before metadata"
+  assert_contains "$out" "spawned $id harness=claude kind=ship" \
+    "passing handoff did not launch the ship"
+  assert_present "$home/state/$id.meta" "passing handoff did not publish task metadata"
+  assert_grep "worktree=$worktree" "$home/state/$id.meta" \
+    "passing handoff recorded the wrong isolated worktree"
 
   id=wf-independent-docs
   write_ship_brief "$home" "$id"


### PR DESCRIPTION
## Intent

Fix Firstmate's Wayfinder integration defect established by the audit at /home/ryan/.treehouse/firstmate-8bf1b0/3/firstmate/data/audit-firstmate-wayfinder-integration/report.md. The captain explicitly authorized fixing Firstmate agent instructions and enforcement so Wayfinder works end to end. The defect is not an upstream Matt Pocock skill omission: Firstmate accepts read-only scout completion into its local ledger, archives it, and can dispatch map-dependent implementation without requiring the consuming project's Wayfinder lifecycle gate. Shopify PR #9 added a project-local bin/wayfinder-lifecycle-gate, but Firstmate never invokes it.

Implement the smallest durable Firstmate-owned correction:
- Keep research scouts read-only when their task requires that isolation. Their report plus captain-hold-lifecycle / decision-hold-lifecycle completion is local input to the parent, not tracker resolution.
- Assign the parent map owner the tracker-resolution obligation whenever a Firstmate child names a Wayfinder ticket.
- Before the parent archives that child as Wayfinder-resolved, require the consuming project's public lifecycle command to verify accept-child.
- Before dispatching implementation that depends on a Wayfinder map, require that project command's handoff verification.
- Invoke the project's existing gate rather than duplicating its resolution-triple policy inside Firstmate.
- Keep captain-hold-lifecycle the sole owner of captain-decision inventory (decision-hold-lifecycle remains the in-flight compatibility stub). Clarify that its completion does not resolve Wayfinder or satisfy a project lifecycle gate. Do not add GitHub logic to fm-decision-hold.sh.
- Put the full conditional procedure in the right agent-only owner, leaving only concise trigger/safety stubs in always-loaded instructions. Preserve AGENTS.md size discipline and one-owner rules.
- Do not modify the upstream mattpocock/skills branch or globally installed skill copies.

Regression acceptance:
1. Start from a red Firstmate-level behavioral test reproducing the historical failure: a named Wayfinder scout has a report and completed captain-decision inventory while the project gate rejects the child; Firstmate must not treat it as Wayfinder-resolved or allow map-dependent implementation handoff.
2. Prove the parent accepts a properly resolved research child and a properly resolved decision child through the consuming project's executable gate.
3. Prove passing fm-decision-hold.sh complete --none alone remains insufficient.
4. Prove map-dependent implementation dispatch is refused while handoff rejects and allowed when it passes.
5. Exercise behavior through public scripts/interfaces, not source-text assertions.
6. Preserve all unrelated lifecycle, scout teardown, project delivery, and supported harness/runtime behavior.
7. Run focused tests, bin/fm-doc-audience-check.sh, bin/fm-lint.sh, and the repository test suite required by the change.

A named Wayfinder scout must not bypass parent-owned accept-child archive merely because optional identity metadata was omitted. Promotion must preserve and enforce the named-child accept-child archive obligation. Fresh handoff verification on relaunch and project-bound verification in batch dispatch are required. Do not merge. Do not change Shopify product code or GitHub issues.

## What Changed

- Add a Firstmate parent wrapper that delegates Wayfinder `accept-child` and `handoff` checks to each consuming project’s public lifecycle command.
- Persist Wayfinder child classification through scout lifecycle and promotion, and refuse named-child archive until `accept-child` succeeds.
- Require fresh handoff snapshots for map-dependent ship spawns, promotions, and relaunches; document that local captain-call completion is not tracker resolution.

## Risk Assessment

⚠️ Medium: Captain, this is a broad lifecycle integration across spawn, promotion, relaunch, batch, and teardown paths, but the reviewed enforcement consistently delegates to the project gate with no source-verifiable bypass found.

## Testing

Focused behavioral, relaunch, teardown, brief, runner, and documentation-audience checks passed. CLI transcripts reproduce the base branch’s unguarded archive and show the target refusing unresolved accept-child/handoff checks before permitting project-gate approval. `bin/fm-lint.sh` was deferred to its owning lint phase because this test phase forbids linters.

<details>
<summary>Evidence: Behavior-suite transcript</summary>

Source: [Behavior-suite transcript](https://github.com/rtuosto/firstmate/blob/228c3adf722b092c94a30ddb7789ef40b66f0a8a/.no-mistakes/evidence/fm/fix-firstmate-wayfinder-parent-gate/fm-wayfinder-parent-behavior-test.txt)

```text
ok - historical local report plus captain-call completion is not Wayfinder resolution
ok - parent accepts a resolved research child and a resolved decision child through the project command
ok - fm-decision-hold.sh complete --none alone remains insufficient
ok - map-dependent dispatch is refused while handoff rejects and allowed when it passes
ok - batch dispatch refuses a Wayfinder snapshot shared across gated projects
ok - batch dispatch reuses a stdin Wayfinder snapshot for every same-project child
ok - parent check normalizes a project gate rejection
ok - parent check refuses when the consuming project has no lifecycle command
```
</details>
<details>
<summary>Evidence: Baseline historical CLI transcript</summary>

Source: [Baseline historical CLI transcript](https://github.com/rtuosto/firstmate/blob/228c3adf722b092c94a30ddb7789ef40b66f0a8a/.no-mistakes/evidence/fm/fix-firstmate-wayfinder-parent-gate/wayfinder-baseline-historical-transcript.txt)

```text
Baseline 4d2cb0ca5a85d700f8a89e354f9e0eb42b38a64b historical behavior
scout spawn exit: 0
spawned task-x1 harness=claude kind=scout window=firstmate:fm-task-x1 worktree=/tmp/fm-teardown-tests.L3aZIM/historical-unguarded/wt
teardown after local report plus completed captain-call inventory exit: 0
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no live watcher process holds this home lock (last beat: 2s ago).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  repair missing watcher supervision according to the session-start block for this harness; do not use shell &.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
teardown task-x1 complete (window firstmate:fm-task-x1, worktree /tmp/fm-teardown-tests.L3aZIM/historical-unguarded/wt)
Backlog: task-x1 just finished. Run tasks-axi done task-x1 --report data/task-x1/report.md, then run tasks-axi ready for dependency-cleared candidates, check date gates, and dispatch only work whose blockers are gone and date is due.
persisted task metadata: archived
research report: retained
```
</details>
<details>
<summary>Evidence: Corrected lifecycle CLI transcript</summary>

Source: [Corrected lifecycle CLI transcript](https://github.com/rtuosto/firstmate/blob/228c3adf722b092c94a30ddb7789ef40b66f0a8a/.no-mistakes/evidence/fm/fix-firstmate-wayfinder-parent-gate/wayfinder-corrected-lifecycle-transcript.txt)

```text
Corrected 36a321dd8ad44a100ff610a149c9e4b2a47ca931 lifecycle behavior
unclassified named-scout spawn exit: 1 (metadata absent)
error: task-x1 scouts against a project with bin/wayfinder-lifecycle-gate; pass --wayfinder-child <number-or-title> or --wayfinder-no-child before the endpoint is created
named-child scout spawn exit: 0
spawned task-x1 harness=claude kind=scout window=firstmate:fm-task-x1 worktree=/tmp/fm-teardown-tests.F0g51D/corrected-gated/wt
rejecting accept-child teardown exit: 1 (metadata retained)
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no live watcher process holds this home lock (last beat: 2s ago).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the guarded operation WILL still run.
●  repair missing watcher supervision according to the session-start block for this harness; do not use shell &.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
accept-child rejected
REFUSED: the project's Wayfinder accept-child check rejected task task-x1; task state and report were preserved.
passing accept-child teardown exit: 0 (metadata archived)
WARNING: watcher still down (same stale episode; last beat: 4s ago, grace 300s) - full banner already printed this episode.
accept-child accepted
teardown task-x1 complete (window firstmate:fm-task-x1, worktree /tmp/fm-teardown-tests.F0g51D/corrected-gated/wt)
Backlog: task-x1 just finished. Run tasks-axi done task-x1 --report data/task-x1/report.md, then run tasks-axi ready for dependency-cleared candidates, check date gates, and dispatch only work whose blockers are gone and date is due.
```
</details>
<details>
<summary>Evidence: Corrected dispatch CLI transcript</summary>

Source: [Corrected dispatch CLI transcript](https://github.com/rtuosto/firstmate/blob/228c3adf722b092c94a30ddb7789ef40b66f0a8a/.no-mistakes/evidence/fm/fix-firstmate-wayfinder-parent-gate/wayfinder-corrected-dispatch-transcript.txt)

```text
Corrected 36a321dd8ad44a100ff610a149c9e4b2a47ca931 map-dependent dispatch behavior
rejecting handoff spawn exit: 2 (metadata absent)
FAIL 5 open: child is still open on GitHub
FAIL 5 missing-evidence-pointer: resolution comment is missing a durable evidence pointer
FAIL 5 missing-named-map-pointer: canonical map Decisions so far has no named gist-and-link entry for this ticket title
FAIL 3 open: child is still open on GitHub
FAIL 3 missing-evidence-pointer: resolution comment is missing a durable evidence pointer
FAIL 3 missing-named-map-pointer: canonical map Decisions so far has no named gist-and-link entry for this ticket title
gate failed
passing handoff spawn exit: 0 (metadata published)
OK handoff: Wayfinder: plan
spawned ship-wayfinder-map harness=claude kind=ship mode=no-mistakes yolo=off window=firstmate:fm-ship-wayfinder-map worktree=/tmp/fm-wayfinder-dispatch.OenZHL/dispatch-proof/home/worktrees/ship-wayfinder-map
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"3cfefcd5ec01d87eea5c87e084d75558d7dbe3bf","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- 🚨 `bin/fm-promote.sh:137` - The new promotion transition can still bypass the parent gate for a legacy named scout whose optional `wayfinder_child` metadata is absent: it rewrites the record to `kind=ship` without a child classification. The new teardown fallback only refuses absent classification while `KIND=scout` (bin/fm-teardown.sh:551), so later ship teardown skips `accept-child`. This contradicts: “A named Wayfinder scout must not bypass parent-owned accept-child archive merely because optional identity metadata was omitted. Promotion must preserve and enforce the named-child accept-child archive obligation.” Fail closed at promotion by requiring and persisting explicit child/no-child classification before the kind flip.

🔧 Fix: Enforce Wayfinder classification across scout promotion
1 error still open:
- 🚨 `bin/fm-teardown.sh:551` - Already-promoted legacy records can still bypass `accept-child`: a named Wayfinder scout promoted before this change has `kind=ship` but no `wayfinder_*` metadata. This branch applies the missing-classification refusal only to `kind=scout`, so teardown skips the parent check and archives the ship normally. That contradicts “A named Wayfinder scout must not bypass parent-owned accept-child archive merely because optional identity metadata was omitted.” Settle a backward-compatible classification/migration policy for these already-promoted records before merge.

🔧 Fix: Migrate unclassified Wayfinder ships through parent gate
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-wayfinder-parent.test.sh`
- `bash tests/fm-control-relaunch.test.sh`
- `bash tests/fm-teardown.test.sh`
- `bash tests/fm-brief.test.sh`
- `bash tests/fm-test-run.test.sh`
- `bin/fm-doc-audience-check.sh`
- <code>Baseline public replay at `4d2cb0ca…`: scout spawn followed by teardown despite a rejecting project gate</code>
- `Target public lifecycle replay: classified scout rejection preserves state; accepted child archives it`
- `Target public dispatch replay: rejected handoff blocks spawn; accepted handoff launches it`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
