### PR TITLE
fix(bin): teach validation-round pauses in generated briefs

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -88,6 +88,7 @@ esac
 # shellcheck source=bin/fm-dod-lib.sh
 . "$SCRIPT_DIR/fm-dod-lib.sh"
 PAUSED_VERB=${FM_CLASSIFY_PAUSED_VERB:-$FM_CLASSIFY_PAUSED_VERB_DEFAULT}
+CREWMATE_PAUSE_WAIT_EXAMPLES='an upstream release, a rate-limit reset, a scheduled window, or your own validation round'
 
 resolve_directory_input() {
   local name=$1 path=$2 resolved
@@ -378,7 +379,7 @@ The report is the only thing that survives, so anything worth keeping must be in
    https:// URL exactly as the forge printed it, never a bare number such as "PR 108"; firstmate
    copies that URL from your line rather than assembling one.
    Use \`$PAUSED_VERB: {why}\` - distinct from \`blocked:\` - ONLY when you are deliberately idling on a
-   known external wait you expect to clear on its own (an upstream release, a rate-limit reset):
+   known external wait you expect to clear on its own ($CREWMATE_PAUSE_WAIT_EXAMPLES):
    firstmate then leaves your idle pane alone and rechecks it on a long cadence instead of
    treating it as a possible wedge. Use \`blocked:\` when you are stuck and need help.
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
@@ -459,8 +460,8 @@ $RULE1
    A mid-task \`working:\` line (including setup complete) is nonterminal: do not end the
    turn after it; continue the same stage until a defined \`done:\` gate under Definition of done.
    Use \`$PAUSED_VERB: {why}\` - distinct from \`blocked:\` - ONLY when you are deliberately idling on a
-   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
-   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
+   known external wait you expect to clear on its own ($CREWMATE_PAUSE_WAIT_EXAMPLES):
+   firstmate then leaves your idle pane alone and rechecks it on a long
    cadence instead of treating it as a possible wedge. Use \`blocked:\` when you are stuck and need help.
 5. If you hit the same obstacle twice, append \`blocked: {why}\` and stop; firstmate will help.
 6. If a decision belongs above the implementation worker (product choices, destructive actions),

--- a/bin/fm-classify-lib.sh
+++ b/bin/fm-classify-lib.sh
@@ -79,9 +79,9 @@ FM_CLASSIFY_CAPTAIN_RE_DEFAULT='done:|needs-decision:|blocked:|failed:|PR ready|
 
 # The deliberate-external-wait verb. A crew (or firstmate steering it) appends
 #   paused: <reason>
-# to declare it is intentionally idling on a KNOWN external dependency - an
-# upstream release, a vendor rate-limit reset, a scheduled window. Unlike
-# `blocked:` (stuck, firstmate must help) an idle `paused:` pane is EXPECTED, so
+# to declare it is intentionally idling on a KNOWN external dependency.
+# bin/fm-brief.sh owns the worker-facing wait examples.
+# Unlike `blocked:` (stuck, firstmate must help), an idle `paused:` pane is EXPECTED, so
 # the stale path absorbs it instead of escalating a possible wedge. It is
 # deliberately NOT in the captain-relevant set above: a pause is a "stop
 # wedge-nagging this idle pane" signal, not work to keep surfacing. This constant

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -798,6 +798,25 @@ test_pause_verb_override_renders_all_brief_scaffolds() {
   pass "fm-brief.sh: custom pause verb renders in every scaffold"
 }
 
+test_ship_and_scout_teach_validation_round_pause() {
+  local home kind id brief
+  home="$TMP_ROOT/validation-round-pause-home"
+  mkdir -p "$home/data"
+
+  for kind in ship scout; do
+    id="brief-validation-round-pause-$kind"
+    if [ "$kind" = scout ]; then
+      FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" firstmate --scout >/dev/null 2>&1
+    else
+      FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" firstmate --mode no-mistakes >/dev/null 2>&1
+    fi
+    brief="$home/data/$id/brief.md"
+    assert_grep "your own validation round" "$brief" \
+      "$kind brief did not teach workers to declare their validation-round wait"
+  done
+  pass "fm-brief.sh: ship and scout scaffolds teach validation-round pauses"
+}
+
 test_scout_and_secondmate_load_decision_hold_policy() {
   local home scout charter
   home="$TMP_ROOT/decision-policy-home"
@@ -866,5 +885,6 @@ test_secondmate_no_projects_charter
 test_secondmate_marked_request_reporting_contract
 test_secondmate_directory_paths_are_absolute_and_output_is_stable
 test_pause_verb_override_renders_all_brief_scaffolds
+test_ship_and_scout_teach_validation_round_pause
 test_scout_and_secondmate_load_decision_hold_policy
 test_scout_and_secondmate_scaffold


### PR DESCRIPTION
## Intent

Address https://github.com/kunchenguid/firstmate/issues/2683 by teaching generated ship and scout briefs that waiting for a worker's own validation round is a bounded `paused:` wait expected to clear on its own. Preserve `blocked:` for situations requiring help.

Use one shared examples list for both brief forms and cover the generated output with a focused behavioral regression. The scope is limited to this guidance correction; status semantics and adjacent supervision behavior remain unchanged. Verification covers the generated brief regression, affected tests, shell lint, and documentation checks.

## What Changed

- Teach ship and scout briefs that waiting for their own validation round is a valid `paused:` wait expected to clear on its own, preserving `blocked:` for situations needing help.
- Centralize pause-wait examples in `fm-brief.sh` and replace duplicated classifier examples with a reference to that owner.
- Add regression coverage checking both generated brief forms for the validation-round example.

## Risk Assessment

✅ Low: The change shares one examples list across ship and scout briefs, preserves existing status semantics, and adds proportionate generated-output regression coverage.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 1 run (5m3s)

## Verification

The no-mistakes run passed the generated brief regression and completed its review, test approval, documentation, and lint steps. Its affected-test command, `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`, reported 33 suites with exactly two failures. Both are documented pre-existing macOS fixture failures outside this change:

- `tests/fm-muse-harness.test.sh`: the copied and renamed system Bash fixture is killed by macOS code-signing enforcement before the intended process can run, so Muse ancestry detection sees no matching process. The assertion is `fm-harness.sh under process 'muse-bin-0.1.0-R708.1' reported '', expected muse`. Tracked in https://github.com/kunchenguid/firstmate/issues/3535.
- `tests/fm-composer-lib.test.sh`: Bash 3.2 emits literal backslash-u text for the fixture's Unicode escapes rather than the half-block glyph, causing `a half-block rule row must count as a structural edge`. The fixture correction is tracked by https://github.com/kunchenguid/firstmate/pull/2440.

The test step completed with these two documented exceptions; this is not an all-tests-green result. Hosted checks await maintainer approval.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"5ec4cb97511f1a7f9d6efa514b5ddaa440d192de","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `bin/fm-test-run.sh --changed --exclude-family real-herdr-gated`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
