### PR TITLE
fix(bin): make lint prerequisites and harness tests reliable

### DIFF
--- a/bin/fm-lint-workflows.sh
+++ b/bin/fm-lint-workflows.sh
@@ -108,15 +108,15 @@ else
 fi
 
 if ! command -v actionlint >/dev/null 2>&1; then
-  printf 'fm-lint-workflows.sh: actionlint not found; install actionlint %s for CI parity.\n' \
+  printf 'fm-lint-workflows.sh: actionlint not found; install actionlint %s with bin/fm-install-actionlint.sh <destination-directory> and put that directory on PATH.\n' \
     "$REQUIRED_ACTIONLINT" >&2
-  exit 127
+  exit 1
 fi
 ACTIONLINT_BIN=$(command -v actionlint)
 resolved=$("$ACTIONLINT_BIN" -version | awk 'NR==1 {print; exit}')
 printf 'fm-lint-workflows.sh: actionlint %s (pinned %s)\n' "$resolved" "$REQUIRED_ACTIONLINT" >&2
 if [ "$resolved" != "$REQUIRED_ACTIONLINT" ]; then
-  printf 'fm-lint-workflows.sh: actionlint %s required for CI parity, found %s. Install %s.\n' \
+  printf 'fm-lint-workflows.sh: actionlint %s required for CI parity, found %s. Install %s with bin/fm-install-actionlint.sh <destination-directory>.\n' \
     "$REQUIRED_ACTIONLINT" "$resolved" "$REQUIRED_ACTIONLINT" >&2
   exit 1
 fi

--- a/bin/fm-lint.sh
+++ b/bin/fm-lint.sh
@@ -230,9 +230,9 @@ if [ "$LIST_FILES" -eq 1 ]; then
 fi
 
 if ! command -v shellcheck >/dev/null 2>&1; then
-  printf 'fm-lint.sh: ShellCheck not found; install ShellCheck %s for CI parity.\n' \
+  printf 'fm-lint.sh: ShellCheck not found; install ShellCheck %s with bin/fm-install-shellcheck.sh <destination-directory> and put that directory on PATH.\n' \
     "$REQUIRED_SHELLCHECK" >&2
-  exit 127
+  exit 1
 fi
 unset SHELLCHECK_OPTS
 SHELLCHECK_BIN=$(command -v shellcheck)
@@ -243,7 +243,7 @@ fi
 resolved=$("$SHELLCHECK_BIN" --version | awk '/^version:/ {print $2; exit}')
 printf 'fm-lint.sh: ShellCheck %s (pinned %s)\n' "$resolved" "$REQUIRED_SHELLCHECK" >&2
 if [ "$resolved" != "$REQUIRED_SHELLCHECK" ]; then
-  printf 'fm-lint.sh: ShellCheck %s required for CI parity, found %s. Install %s.\n' \
+  printf 'fm-lint.sh: ShellCheck %s required for CI parity, found %s. Install %s with bin/fm-install-shellcheck.sh <destination-directory>.\n' \
     "$REQUIRED_SHELLCHECK" "$resolved" "$REQUIRED_SHELLCHECK" >&2
   exit 1
 fi

--- a/docs/verification/muse.md
+++ b/docs/verification/muse.md
@@ -48,7 +48,7 @@ $ grep -nE 'muse-bin|exec ' launcher.sh
 
 `ps -o comm= -p <pid>` returns the full executable path, whose basename is `muse-bin-<version>`.
 That is why both `bin/fm-harness.sh` and `bin/backends/tmux.sh` match the anchored prefix `muse-bin-*` rather than an exact name, and why neither can rely on an install-path component: `~/.local/bin/muse-bin-<version>` contains no `muse` path component.
-The Muse launch clears `CLAUDECODE`, `PI_CODING_AGENT`, `GROK_AGENT`, and `FM_PI_HARNESS` before the worker starts so foreign primary markers cannot override the versioned ancestry.
+The Muse launch clears `CLAUDECODE`, `PI_CODING_AGENT`, `GROK_AGENT`, `FM_PI_HARNESS`, `CURSOR_AGENT`, and `CURSOR_INVOKED_AS` before the worker starts so foreign primary markers cannot override the versioned ancestry.
 
 [`runtime-backends.md`](runtime-backends.md#agent-liveness-name-sources) owns the resulting tmux liveness verdict and its relationship to the portable decoy regression.
 

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -5,6 +5,12 @@ set -u
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
+# bin/fm-harness.sh checks verified ENV markers before ancestry. A suite run
+# from inside Cursor, Claude, Pi, or Grok inherits those markers, which outrank
+# the fake ancestry the detection cases set up. Drop the ambient markers so the
+# asserted verdict does not depend on which harness launched the suite.
+unset CLAUDECODE PI_CODING_AGENT FM_PI_HARNESS GROK_AGENT CURSOR_AGENT CURSOR_INVOKED_AS
+
 SPAWN="$ROOT/bin/fm-spawn.sh"
 TEARDOWN="$ROOT/bin/fm-teardown.sh"
 KIMI_HOOK="$ROOT/bin/fm-kimi-turnend-hook.sh"
@@ -530,10 +536,12 @@ esac
 SH
   chmod +x "$fakebin/ps"
 
-  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+  out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT \
+    -u CURSOR_AGENT -u CURSOR_INVOKED_AS \
     PATH="$fakebin:$BASE_PATH" FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh")
   [ "$out" = kimi ] || fail "kimi ancestry detection returned '$out'"
-  out=$(CLAUDECODE=1 PATH="$fakebin:$BASE_PATH" FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh")
+  out=$(env -u CURSOR_AGENT -u CURSOR_INVOKED_AS \
+    CLAUDECODE=1 PATH="$fakebin:$BASE_PATH" FM_CONFIG_OVERRIDE="$cfg" "$ROOT/bin/fm-harness.sh")
   [ "$out" = claude ] || fail "verified env-marker precedence changed, got '$out'"
   pass "fm-harness: markerless kimi is detected by ancestry after env-marker precedence"
 }

--- a/tests/fm-lint-workflows.test.sh
+++ b/tests/fm-lint-workflows.test.sh
@@ -253,11 +253,13 @@ test_missing_actionlint_fails_closed() {
   done
   rc=0
   out=$(PATH="$fakebin" "$LINT_WF" --root "$tmp" 2>&1) || rc=$?
-  [ "$rc" -eq 127 ] || fail "missing actionlint expected exit 127, got $rc"$'\n'"$out"
+  [ "$rc" -eq 1 ] || fail "missing actionlint expected exit 1, got $rc"$'\n'"$out"
   assert_contains "$out" "actionlint not found" \
     "missing actionlint did not name the required linter"
   assert_contains "$out" "$REQUIRED" \
     "missing actionlint did not name the pinned version"
+  assert_contains "$out" "fm-install-actionlint.sh" \
+    "missing actionlint did not name the pinned installer"
   pass "missing actionlint fails closed"
 }
 

--- a/tests/fm-lint.test.sh
+++ b/tests/fm-lint.test.sh
@@ -534,6 +534,25 @@ test_installer_rejects_unsupported_platform() {
   pass "ShellCheck installer rejects an unsupported OS or architecture"
 }
 
+test_missing_shellcheck_fails_closed() {
+  local tmp fakebin out rc tool
+  tmp=$(fm_test_tmproot fm-lint-noshellcheck)
+  fakebin=$(fm_fakebin "$tmp")
+  for tool in bash dirname; do
+    ln -s "$(command -v "$tool")" "$fakebin/$tool"
+  done
+  rc=0
+  out=$(PATH="$fakebin" CI=true GITHUB_ACTIONS=true "$LINT" 2>&1) || rc=$?
+  [ "$rc" -eq 1 ] || fail "missing ShellCheck expected exit 1, got $rc"$'\n'"$out"
+  assert_contains "$out" "ShellCheck not found" \
+    "missing ShellCheck did not name the required linter"
+  assert_contains "$out" "$REQUIRED" \
+    "missing ShellCheck did not name the pinned version"
+  assert_contains "$out" "fm-install-shellcheck.sh" \
+    "missing ShellCheck did not name the pinned installer"
+  pass "missing ShellCheck fails closed"
+}
+
 test_rejects_wrong_shellcheck_version() {
   # Version-independent: a fake shellcheck reporting a different version must be
   # refused before any lint, proving local and CI cannot silently diverge.
@@ -866,6 +885,7 @@ test_installer_rejects_wrong_checksum
 test_installer_falls_back_to_shasum
 test_installer_prefers_sha256sum_over_shasum
 test_installer_rejects_unsupported_platform
+test_missing_shellcheck_fails_closed
 test_rejects_wrong_shellcheck_version
 test_catches_a_real_lint_defect
 test_ignores_ambient_shellcheck_opts

--- a/tests/fm-muse-harness.test.sh
+++ b/tests/fm-muse-harness.test.sh
@@ -13,6 +13,13 @@ set -u
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
+# bin/fm-harness.sh checks verified ENV markers before ancestry. Muse is
+# markerless, so an inherited Cursor/Claude/Pi/Grok marker would outrank the
+# versioned muse-bin ancestor these detection cases launch. Drop the ambient
+# markers so the asserted verdict does not depend on which harness launched
+# the suite.
+unset CLAUDECODE PI_CODING_AGENT FM_PI_HARNESS GROK_AGENT CURSOR_AGENT CURSOR_INVOKED_AS
+
 SPAWN="$ROOT/bin/fm-spawn.sh"
 TEARDOWN="$ROOT/bin/fm-teardown.sh"
 HARNESS="$ROOT/bin/fm-harness.sh"
@@ -154,9 +161,10 @@ run_muse_spawn() {  # <home> <proj> <wt> <fakebin> <id> [extra args...]
 # string, so each case launches an actual renamed executable and asks
 # fm-harness.sh from a child of it.
 #
-# The foreign env markers are cleared because muse is markerless and the marker
-# layer deliberately outranks ancestry: with one retained, these cases would
-# assert the marker's verdict instead of the ancestry match they exist to pin.
+# The foreign env markers, including Cursor's, are cleared because muse is
+# markerless and the marker layer deliberately outranks ancestry: with one
+# retained, these cases would assert the marker's verdict instead of the
+# ancestry match they exist to pin.
 # The command substitution around the probe is load-bearing: a bare `-c <cmd>`
 # lets the shell exec the probe in place, which REPLACES the muse-bin-* process
 # name the walk is supposed to find. Real muse keeps its TUI process alive and
@@ -167,7 +175,8 @@ test_detects_versioned_process_ancestor() {
   mkdir -p "$dir"
   for bin in muse-bin-0.1.0-R708.1 muse-bin-9.9.9-RZZZ.9 muse; do
     cp "$(command -v bash)" "$dir/$bin"
-    out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+    out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT \
+      -u CURSOR_AGENT -u CURSOR_INVOKED_AS \
       "$dir/$bin" -c "r=\$(\"$HARNESS\"); printf '%s' \"\$r\"")
     [ "$out" = muse ] || fail "fm-harness.sh under process '$bin' reported '$out', expected muse"
   done
@@ -182,7 +191,8 @@ test_detection_is_anchored() {
   mkdir -p "$dir"
   for bin in musescore amuse notmuse-bin muse-binary muse-bind; do
     cp "$(command -v bash)" "$dir/$bin"
-    out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT \
+    out=$(env -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT \
+      -u CURSOR_AGENT -u CURSOR_INVOKED_AS \
       "$dir/$bin" -c "r=\$(\"$HARNESS\"); printf '%s' \"\$r\"")
     [ "$out" != muse ] || fail "fm-harness.sh misdetected unrelated process '$bin' as muse"
   done
@@ -197,6 +207,7 @@ $rec
 EOF
   result="$case_dir/harness-result"
   out=$(CLAUDECODE=1 PI_CODING_AGENT=true GROK_AGENT=1 FM_PI_HARNESS=pi-signed \
+    CURSOR_AGENT=1 CURSOR_INVOKED_AS=cursor-agent \
     FM_FAKE_EXECUTE_MUSE_LAUNCH=1 FM_FAKE_HARNESS_RESULT="$result" \
     run_muse_spawn "$home" "$proj" "$wt" "$fakebin" "$id" --mode no-mistakes --yolo off)
   status=$?


### PR DESCRIPTION
## Intent

Get firstmate's lint + test suite GREEN on main by fixing the two pre-existing problems in gh-axi issue 2753. This is a prerequisite the main firstmate needs landed before other work; keep it small and focused. Firstmate SHARED, TRACKED lint/test material.

Part 1: bin/fm-lint.sh (workflow-lint path bin/fm-lint-workflows.sh) must not exit 127 when actionlint is absent. fm-lint already pins tools (REQUIRED_SHELLCHECK=0.11.0, actionlint 1.7.12) and refuses other versions. When actionlint is absent, fail with an ACTIONABLE message naming the tool, the pinned version (1.7.12), and how to install it - matching exactly how fm-lint already handles a missing/wrong shellcheck. Do NOT silently exit 127, and do NOT weaken the version pin. Only vendor/bootstrap actionlint if that is the ESTABLISHED pattern for shellcheck; if shellcheck is required-present-not-bootstrapped, mirror that (actionable-fail) for actionlint.

Decision taken: shellcheck is required-present-not-bootstrapped via bin/fm-install-shellcheck.sh (CI installs it; local lint does not auto-bootstrap). Mirrored that for actionlint: a missing tool now exits 1 (not 127) and names bin/fm-install-actionlint.sh <destination-directory> plus putting that directory on PATH. Same message shape applied to missing/wrong ShellCheck so the two linters stay matched. Version pins are unchanged.

Part 2: fix the 3 pre-existing red specs on main listed in issue 2753: tests/fm-composer-lib.test.sh, tests/fm-kimi-harness.test.sh, and tests/fm-muse-harness.test.sh.

fm-composer-lib: issue 2753 listed it red on a clean main, but on this isolated worktree at origin/main it was already green with no code change. That listing was not reproduced here. It is not an un-addressed finding. Verified green on a clean origin/main checkout in this worktree (all composer-lib assertions passed). Treat as env-specific or already-fixed upstream of this work; do not invent a composer-lib change. The PR must state this explicitly so review does not read composer-lib as skipped.

kimi and muse harness tests: reproduced on clean origin/main. Failure was "kimi ancestry detection returned 'cursor'" and "fm-harness.sh under process 'muse-bin-0.1.0-R708.1' reported 'cursor', expected muse". This is a REAL test isolation bug, not a missing local harness: fm-harness.sh checks CURSOR_AGENT/CURSOR_INVOKED_AS before ancestry, so markerless kimi/muse detection cases fail when the suite itself runs under Cursor. Counterfactual: unsetting those markers restored kimi/muse. Fix: clear verified env markers the same way tests/fm-secondmate-harness.test.sh already does. Do NOT self-skip; do NOT delete or weaken assertions. Muse spawn inherited-marker case also now includes Cursor markers to prove launch clears them.

Scope: ONLY the fm-lint tooling and the 3 test files (plus whatever code a real regression among them points at). Composer-lib needed no code change. Do not merge. mode=no-mistakes, yolo OFF - the captain owns the merge. Escalate ask-user findings; avoid --yes. This touches the shared lint definition CI and the no-mistakes gate both invoke: the PR must note that homes pick it up after merge + a self-update and that landing timing is coordinated with the main firstmate.

## What Changed

- Make missing ShellCheck or actionlint exit 1 with pinned-version installer and PATH guidance, while preserving version enforcement.
- Isolate Kimi and Muse ancestry tests from inherited harness markers, including Cursor markers, and verify Muse launches clear them.
- Leave composer-lib unchanged because its reported failure was not reproducible on clean main. Homes receive the shared lint update after merge and self-update; landing is coordinated with the main firstmate.

## Risk Assessment

✅ Low: The changes are narrowly scoped, preserve tool-version pins, provide actionable missing-tool failures, and deterministically isolate harness tests from inherited markers.

## Testing

The focused lint, workflow-lint, composer-lib, Kimi, and Muse suites passed, including Kimi/Muse ancestry detection under inherited Cursor markers; composer-lib was explicitly verified green without changes. Manual missing-tool checks showed actionable pinned-version installer guidance and exit status 1 rather than 127 for both actionlint and ShellCheck. No UI surface was changed, so visual evidence was not applicable.

<details>
<summary>Evidence: Issue 2753 targeted regression test transcript</summary>

Source: [Issue 2753 targeted regression test transcript](https://github.com/kunchenguid/firstmate/blob/a06f2b5aa2a965845e64f7d153c8c77ef9656a87/.no-mistakes/evidence/fm/fm-lint-green-on-main-r1/issue-2753-targeted-tests.txt)

```text
Targeted regression tests for firstmate issue 2753
===================================================


$ CURSOR_AGENT=1 CURSOR_INVOKED_AS=cursor-agent bash tests/fm-lint.test.sh
ok - fm-lint.sh --list-files reports the complete shell inventory
ok - fm-lint.sh pins an explicit ShellCheck version (0.11.0)
ok - ShellCheck installer retries a transient download failure
ok - ShellCheck installer selects the official archive, URL, and checksum per OS/arch
ok - ShellCheck installer rejects a wrong checksum
ok - ShellCheck installer falls back to shasum -a 256 when sha256sum is absent
ok - ShellCheck installer prefers sha256sum when both hashers are present
ok - ShellCheck installer rejects an unsupported OS or architecture
ok - missing ShellCheck fails closed
ok - fm-lint.sh refuses to lint under a non-pinned ShellCheck version
ok - fm-lint.sh catches a real lint defect the old no-op gate passed
ok - fm-lint.sh ignores ambient ShellCheck options
ok - fm-lint.sh passes a clean fixture
ok - jobs=1 and jobs=2 preserve deterministic diagnostics, failures, cleanup bounds, and quiet telemetry
ok - jobs=1 and jobs=2 stop complete worker trees with and without telemetry
ok - seeded dispatcher, adapter, production-owner, and test-local diagnostics preserve parity
ok - fm-lint.sh changed mode lints only the changed canonical file
ok - fm-lint.sh forces a full lint in CI even when the local diff would be empty
ok - fm-lint.sh forces a full lint when HEAD is on main
ok - fm-lint.sh explicit paths bypass changed-file mode selection
ok - fm-lint.sh exits 0 with a note when the local branch has no changed lint targets
ok - fm-lint.sh --list-files reports the would-be changed set in changed mode

$ CURSOR_AGENT=1 CURSOR_INVOKED_AS=cursor-agent bash tests/fm-lint-workflows.test.sh
ok - fm-lint-workflows.sh pins an explicit actionlint version (1.7.12)
ok - current .github/workflows YAML files parse
ok - column-0 heredoc workflow fails validation with a clear error
ok - valid fixture workflow passes
ok - empty workflows directory fails closed
ok - explicit malformed workflow path fails validation
ok - non-mapping workflow YAML root fails
ok - missing actionlint fails closed
ok - fm-lint-workflows.sh refuses to lint under a non-pinned actionlint version
ok - actionlint installer retries a transient download failure
ok - actionlint installer selects the official archive, URL, and checksum per OS/arch
ok - actionlint installer rejects a wrong checksum
ok - actionlint installer falls back to shasum -a 256 when sha256sum is absent
ok - actionlint installer prefers sha256sum when both hashers are present
ok - actionlint installer rejects an unsupported OS or architecture
ok - fm-lint.sh default path catches a self-broken ci.yml

$ CURSOR_AGENT=1 CURSOR_INVOKED_AS=cursor-agent bash tests/fm-composer-lib.test.sh
ok - fm_composer_classify_content: a bare shell prompt glyph (>/$/%/#) reads unknown, never empty
ok - fm_composer_classify_content: stripped unbordered content is unknown except verified agent glyphs
ok - fm_composer_classify_content: a bare shell prompt carrying a command is not empty
ok - fm_composer_classify_content: a bare prompt glyph inside a bordered composer box reads empty (claude's own idle composer)
ok - fm_composer_classify_content: agent prompt glyphs (❯ claude, › codex, ⟩ muse) read empty bordered or bare
ok - fm_composer_classify_content: an empty composer reads empty
ok - fm_composer_classify_content: idle matching is limited to proven placeholder positions
ok - fm_composer_classify_content: idle matching preserves the caller's case mode
ok - fm_composer_classify_content: real unsubmitted text reads pending (including a popup argument-hint fill)
ok - matrix: claude's ❯+NBSP row reads empty on every profile in both locales (#1988)
ok - matrix: codex's dim hint is empty when styling proves it, unknown (never pending) when it cannot
ok - matrix: muse's ⟩ reads empty everywhere and survives losing the styled-glyph signal
ok - matrix: cursor's reverse-video placeholder remnant reads empty; real typed text stays pending
ok - matrix: herdr half-block rules bound a bare composer's wrap region
ok - matrix: pi's separated composer needs identity + structure; the blank row alone never proves it
ok - matrix: opencode's left-bar composer reads empty everywhere and scans the full active run
ok - matrix: grok's titled bottom border is tolerated as a title, not read as ambiguity
ok - matrix: kimi's bordered shell-glyph box reads empty through the shared owner (spawn's fourth copy retired)
ok - matrix: the real claude-in-zellij --ansi dump reads empty in both locales
ok - strict posture: blank and unidentified rows are unknown, never injectable empty
ok - fm_composer_classify_screen: the bare composer's wrap region stays identified; structure breaks it
ok - fm_composer_classify_screen: a row-leading agent glyph reanchors the live composer
ok - fm_composer_classify_screen: a lower dead shell invalidates only cursorless stale composers
ok - fm_composer_classify_screen: cursorless bare wrap regions participate in verdicts
ok - fm_composer_classify_screen: cursorless containers reject only contiguous unclaimed activity
ok - fm_composer_classify_screen: the bottom-most candidate wins; stale banners cannot
ok - fm_composer_classify_screen: incomplete lower structure invalidates stale boxes
ok - fm_composer_classify_screen: titled bottoms retain full box geometry
ok - fm_composer_classify_screen: a proven box tolerates a bottom-border cursor
ok - fm_composer_extract_selected_content: scopes user content and excludes furniture
ok - fm_composer_queued_enter_verdict: pending + busy returns empty (queued Enter)
ok - fm_composer_queued_enter_verdict: pending + idle/unknown stays pending
ok - fm_composer_queued_enter_verdict: only proven pending is converted

$ CURSOR_AGENT=1 CURSOR_INVOKED_AS=cursor-agent bash tests/fm-kimi-harness.test.sh
ok - Kimi hook install is idempotent and removal restores every foreign config byte
ok - Kimi hook removal preserves owned newline boundaries and pristine bytes
ok - Kimi hook install refuses missing, malformed, and surprising config without writing
ok - Kimi hook install refuses without jq before any config write
ok - fm-spawn: kimi launches, delivers its brief, and registers a guarded turn-end token
ok - Kimi hook stays silent and inert without a Firstmate registry token
ok - fm-spawn: unsafe Kimi global config refuses before pane creation
ok - fm-teardown: Kimi task pointer and registry token are removed
ok - fm-spawn: Kimi fallback expands the active HOME
ok - fm-spawn: missing Kimi executable refuses before pane creation
ok - fm-spawn: kimi treats a silent pointer drop as a failed spawn
ok - fm-spawn: kimi never sends the brief pointer before an observable ready signal
ok - fm-harness: markerless kimi is detected by ancestry after env-marker precedence
lock acquired: harness pid 33511
ok - fm-lock recognizes Kimi ancestry and live lock holders
ok - busy detection: real Kimi moon-plus-middot captures require its harness while idle labels stay idle
ok - fm-watch classifies Kimi as unknown rather than from its spinner, and Grok's fallback stays isolated
ok - composer classifier: kimi's existing bordered > shape is already safe without an override

$ CURSOR_AGENT=1 CURSOR_INVOKED_AS=cursor-agent bash tests/fm-muse-harness.test.sh
ok - muse is detected through any versioned muse-bin ancestor
ok - muse detection does not claim unrelated muse-containing commands
ok - muse launch clears foreign harness markers before ancestry detection
ok - muse spawn launches with autonomy, privacy control, and a positional brief
ok - muse maps the shared effort vocabulary and reaches ultra only via explicit max
ok - muse spawn refuses when no credential can reach the provider
ok - muse spawn refuses a META_API_KEY that cannot reach the worker
ok - muse spawn accepts a stored credential without META_API_KEY
ok - muse resolves relative XDG roots before preflight and launch
ok - muse is refused as a secondmate harness
ok - muse spawn writes a session binding that teardown removes
ok - every accepted muse Escape alias clears the restored composer
ok - the composer clear is scoped to muse and does not touch other adapters
ok - a failed muse composer clear fails loudly instead of leaving stale input
ok - the run fold tracks open, settled, interrupted, reopened, and run-free logs
ok - a nested terminal record never settles an in-flight run
ok - the session binding folds only the log matching this task's worktree
ok - workspace bindings compare decoded paths literally
ok - spawn-time exclusions select the current session across equal mtimes
ok - the Muse session cache avoids rescans and refreshes safely across incarnations
ok - a changed Muse namespace revalidates cached session uniqueness
ok - sub-agent session logs are excluded from the parent's busy fold
ok - every unproven muse binding classifies unknown rather than idle
ok - a settled session log reads idle for both completed and interrupted turns
ok - muse trusts no busy record source
```
</details>
<details>
<summary>Evidence: Missing-linter end-user failure messages and exit statuses</summary>

Source: [Missing-linter end-user failure messages and exit statuses](https://github.com/kunchenguid/firstmate/blob/a06f2b5aa2a965845e64f7d153c8c77ef9656a87/.no-mistakes/evidence/fm/fm-lint-green-on-main-r1/missing-linter-user-experience.txt)

```text
$ PATH=<without actionlint> bin/fm-lint-workflows.sh
fm-lint-workflows.sh: actionlint not found; install actionlint 1.7.12 with bin/fm-install-actionlint.sh <destination-directory> and put that directory on PATH.
exit_status=1

$ PATH=<without shellcheck> CI=true GITHUB_ACTIONS=true bin/fm-lint.sh
fm-lint.sh: ShellCheck not found; install ShellCheck 0.11.0 with bin/fm-install-shellcheck.sh <destination-directory> and put that directory on PATH.
exit_status=1
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"8c4341ead7d60f92eeb9454a3484ecc7dd8fc2e1","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `Inspected the target diff and confirmed installed pins: ShellCheck 0.11.0 and actionlint 1.7.12.`
- `CURSOR_AGENT=1 CURSOR_INVOKED_AS=cursor-agent bash tests/fm-lint.test.sh`
- `CURSOR_AGENT=1 CURSOR_INVOKED_AS=cursor-agent bash tests/fm-lint-workflows.test.sh`
- `CURSOR_AGENT=1 CURSOR_INVOKED_AS=cursor-agent bash tests/fm-composer-lib.test.sh`
- `CURSOR_AGENT=1 CURSOR_INVOKED_AS=cursor-agent bash tests/fm-kimi-harness.test.sh`
- `CURSOR_AGENT=1 CURSOR_INVOKED_AS=cursor-agent bash tests/fm-muse-harness.test.sh`
- `Manually ran both lint entry points with PATHs excluding their required tools and recorded their messages and exit statuses.`
- <code>Verified transient worktree test files were removed with `git status --short` and a path existence check.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
