### PR TITLE
feat(bin): add a spoken interface that answers from records and hands work over

### DIFF
--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -1,0 +1,35 @@
+# Review standards for this repository
+
+Rules the reviewer asked to have written down, recorded here so that a decision
+already argued out on one pull request is not re-litigated on the next one. Each
+rule states the conditions it depends on, because a rule with its conditions
+dropped stops being a decision and becomes a blind spot.
+
+## A captain-facing surface is not automatically a `VISION.md` violation
+
+`VISION.md` says "The captain talks to the first mate and to nobody else; every
+worker reports through the first mate and never addresses the captain directly."
+That line protects who is answerable for work. Read alongside the sentence it
+shares a paragraph with, it governs workers reporting outward, not the surfaces
+the captain reaches inward through, so a front end the captain chooses to speak
+or type into is not by itself a breach of it.
+
+Do not flag a captain-facing front end as violating that line while **all** of
+these hold:
+
+- it never claims to be the first mate, and says so in its own instructions;
+- it has no tool that can change a project, merge, discard work, or grant
+  authority;
+- work that is not answering from existing records is handed to the first mate
+  and announced as a handover, rather than performed or claimed.
+
+Any one of those failing is worth flagging, and flagging loudly: a front end that
+gains a write tool, drops the disclaimer, or reports work as its own is the case
+this line exists to catch.
+
+The known tension is not a defect either, and is already on the record: such a
+front end may hold read access to the captain's records, so the captain does
+sometimes get a substantive answer from something that is not the first mate.
+Whether `VISION.md` should be reconciled to describe that is the captain's call
+and is not settled by any single pull request. Raising it as new is what this rule
+is here to stop; `bin/fm-voice-relay.py` is the surface it was decided on.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,7 @@ state/               runtime records and signals; gitignored
   procevent-inbox/   private captured results and their durable handled-acknowledgement markers; source output lives here and never in an event line
   decision-bindings/ private records marking a captured-answer source as feeding the keyed-answer intake, with a legacy origin on pre-collapse records; written only by bin/fm-captain-hold.sh bind, dropped by unbind and by source retirement (section 13; docs/captain-hold-lifecycle.md)
   when/              private condition->action watch specs, their trust bindings, and single-fire markers; written only by bin/fm-procevent-when.sh (section 13's process-event-sources trigger)
+  inbox/             captain notes captured out of band by bin/fm-inbox.sh, including the voice handover's queued requests; each note appends one `check` wake and stays pending until acknowledged with `bin/fm-inbox.sh drain --ack <id>`, which moves it to inbox/handled/ (docs/voice-relay.md)
   x-inbox/           generated Relay pending mention payloads; fmx-respond drains it (section 14)
   x-context/         generated Relay durable per-request reply context and one-wake offer markers, keyed by request_id; survives inbox cleanup and expires within seven days (section 14; bin/fm-x-lib.sh)
   x-outbox/          generated Relay dry-run reply and dismiss previews; inspect it when FMX_DRY_RUN is set (section 14)
@@ -400,7 +401,7 @@ Handle actionable wakes as follows:
 
 1. For `signal:`, read the listed event lines first, then reconcile current state only where action depends on it.
 2. For `stale:`, inspect the recorded endpoint and load `stuck-crewmate-recovery` for a stopped, looping, confused, or unresponsive worker; a deep-inspection reason also requires current-state and validation-log inspection.
-3. For `check:`, act on the named poll result, including merges, Relay events, and process-to-event source results.
+3. For `check:`, act on the named poll result, including merges, Relay events, process-to-event source results, and captain inbox notes; a handled inbox note is also acknowledged with `bin/fm-inbox.sh drain --ack <id>`, or it stays counted as still waiting for firstmate.
 4. For `heartbeat:`, review the whole fleet from the structured fleet view, reconcile suspicious tasks and PR state, update the backlog, and never report an unchanged fleet as progress.
 
 When any wake reports a merged PR for a project cloned in this home, refresh that clone through the guarded fleet-sync path.

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Firstmate's skills live in two separate places with different audiences:
 - [docs/configuration.md](docs/configuration.md) - environment variables, `FM_HOME`, runtime backend selection, optional Relay and its X and Discord setup steps, the files you set, and harness support.
 - [docs/remote-secondmates.md](docs/remote-secondmates.md) - current setup, routing, transfer, recovery, and safety behavior for whole-home remote second mates.
 - [docs/calm.md](docs/calm.md) - current Pi `/calm` behavior and supported presentation limits.
+- [docs/voice-relay.md](docs/voice-relay.md) - the optional spoken interface: setup on both machines, measured round-trip cost, what a spoken answer may read, and what this build does not do yet.
 - [docs/wedge-alarm.md](docs/wedge-alarm.md) - configure the active alert for an away-mode escalation delivery that gets stuck.
 - [docs/tmux-backend.md](docs/tmux-backend.md) - current setup and limits for the tmux reference backend.
 - [docs/herdr-backend.md](docs/herdr-backend.md) - current setup, safety boundaries, and limits for the experimental Herdr backend.

--- a/bin/fm-inbox.sh
+++ b/bin/fm-inbox.sh
@@ -1,0 +1,329 @@
+#!/usr/bin/env bash
+# fm-inbox.sh - the captain's out-of-band capture surface.
+#
+# Solves three DIFFERENT problems with three different mechanisms, because they
+# are not the same problem:
+#
+#   note    Queue an idea for firstmate while firstmate is mid-turn and cannot
+#           answer. Writes a durable record and appends ONE `check` wake, so the
+#           note survives a crash and is presented at firstmate's next drain.
+#           This is the only subcommand that touches firstmate's wake queue.
+#   say     Same as `note`, but the body comes from spoken audio on stdin.
+#           Speech is an INPUT METHOD here, not an architecture: it transcribes
+#           and then takes exactly the `note` path.
+#   status  Answer "what is happening" from durable records ONLY. Reads no
+#           network and appends NO wake, so it never interrupts work and is safe
+#           to run in a loop.
+#   ask     Answer a side question with a one-shot model call that never touches
+#           firstmate, the backlog, or the wake queue. A side question is not
+#           fleet work and must not become fleet work.
+#
+# Usage:
+#   fm-inbox.sh note <text>...          | fm-inbox.sh note -   (body from stdin)
+#   fm-inbox.sh say  [<file.wav>]       (default: audio on stdin)
+#   fm-inbox.sh status
+#   fm-inbox.sh ask  <question>...
+#   fm-inbox.sh list
+#   fm-inbox.sh drain [--ack <id>...]
+#
+# Environment:
+#   FM_HOME              operational home whose state/ and data/ are used.
+#   FM_INBOX_REGION      AWS region for model calls.   default eu-west-1
+#   FM_INBOX_STT_MODEL   speech-to-text model.         default mistral.voxtral-small-24b-2507
+#   FM_INBOX_ASK_MODEL   side-question model.          default eu.anthropic.claude-haiku-4-5-20251001-v1:0
+#   FM_INBOX_PROFILE     AWS profile for model calls.  default inthuson-ct-sandbox
+#
+# PRIVACY: `say` sends your audio and `ask` sends your question to Bedrock.
+# `note`, `status`, `list` and `drain` make no network call at all.
+#
+# `note` is also the queueing half of the spoken interface: when the voice agent
+# in bin/fm-voice-relay.py hands real work over to firstmate, it runs this
+# subcommand rather than carrying a second queue of its own. Keep the `note`
+# contract stable for that caller. `status` is the HUMAN view of the records;
+# bin/fm_voice_records.py owns the scope-controlled machine view the voice agent
+# reads, because the voice agent must be able to answer without record free text
+# ever reaching a model.
+set -euo pipefail
+
+# A non-interactive `ssh host fm-inbox.sh ...` does NOT get a login shell, so it
+# does not get ~/.toolbox/bin on PATH. The AWS profile's credential_process is
+# the bare word `ada`, so without this the model-backed subcommands fail with
+# "[Errno 2] No such file or directory: 'ada'" while note/status still work.
+# Verified: this is exactly what happens over SSH without the fix.
+for _extra in "$HOME/.toolbox/bin" "$HOME/.local/bin"; do
+  case ":$PATH:" in
+    *":$_extra:"*) ;;
+    *) [ -d "$_extra" ] && PATH="$_extra:$PATH" ;;
+  esac
+done
+unset _extra
+export PATH
+
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="$(cd "$SELF_DIR/.." && pwd)"
+FM_HOME="${FM_HOME:-$FM_ROOT}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+DATA="$FM_HOME/data"
+INBOX="$STATE/inbox"
+
+REGION="${FM_INBOX_REGION:-eu-west-1}"
+STT_MODEL="${FM_INBOX_STT_MODEL:-mistral.voxtral-small-24b-2507}"
+ASK_MODEL="${FM_INBOX_ASK_MODEL:-eu.anthropic.claude-haiku-4-5-20251001-v1:0}"
+PROFILE="${FM_INBOX_PROFILE:-inthuson-ct-sandbox}"
+
+die() { printf 'fm-inbox: %s\n' "$*" >&2; exit 1; }
+
+need() { command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"; }
+
+# The profile's credential_process (`ada`) costs a MEASURED ~1030ms on every
+# single call, which is about half the wall time of `say` and `ask`. If real
+# credentials are already in the environment, skip --profile entirely and let the
+# ambient ones win. Set FM_INBOX_PROFILE= (empty) to force that even without env
+# credentials present.
+aws_call() {
+  if [ -z "$PROFILE" ] || [ -n "${AWS_ACCESS_KEY_ID:-}" ]; then
+    aws --region "$REGION" "$@"
+  else
+    aws --profile "$PROFILE" --region "$REGION" "$@"
+  fi
+}
+
+# ---------------------------------------------------------------- note
+
+# Append exactly one wake so firstmate picks the note up at its next drain.
+# Failure to wake is NOT allowed to lose the note: the record is already on
+# disk, so we report the wake failure and still exit non-zero loudly.
+wake_for() {
+  local id=$1 summary=$2 lib="$FM_ROOT/bin/fm-wake-lib.sh"
+  if [ ! -r "$lib" ]; then
+    printf 'fm-inbox: note saved but NOT announced (missing %s)\n' "$lib" >&2
+    return 1
+  fi
+  # shellcheck source=/dev/null
+  FM_ROOT_OVERRIDE="$FM_ROOT" FM_HOME="$FM_HOME" STATE="$STATE" . "$lib"
+  fm_wake_append check "inbox:$id" "check: captain inbox note $id - $summary"
+}
+
+queue_note() {
+  local source=$1 body=$2 extra=${3:-}
+  [ -n "${body//[[:space:]]/}" ] || die "refusing to queue an empty note"
+  mkdir -p "$INBOX"
+
+  local tmp id summary
+  tmp=$(mktemp "$INBOX/.staging-XXXXXX")
+  {
+    printf 'id=PENDING\n'
+    printf 'at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf 'source=%s\n' "$source"
+    [ -z "$extra" ] || printf '%s\n' "$extra"
+    printf -- '--\n'
+    printf '%s\n' "$body"
+  } >"$tmp"
+
+  id="$(date +%s)-$(basename "$tmp" | sed 's/^\.staging-//')"
+  # Rewrite the id line now that we know it, then publish atomically.
+  sed -i "s/^id=PENDING$/id=$id/" "$tmp"
+  mv "$tmp" "$INBOX/$id.note"
+
+  # One-line summary for the wake payload; the full body stays in the file.
+  summary=$(printf '%s' "$body" | tr '\n\t' '  ' | cut -c1-100)
+  printf 'queued %s\n' "$id"
+  printf '  %s\n' "$summary"
+  if wake_for "$id" "$summary"; then
+    printf '  firstmate will pick this up at its next check.\n'
+  else
+    die "note $id is saved at $INBOX/$id.note but firstmate was NOT woken"
+  fi
+}
+
+cmd_note() {
+  local body
+  if [ "$#" -eq 0 ]; then
+    die "usage: fm-inbox.sh note <text>...   (or: note - to read stdin)"
+  elif [ "$1" = "-" ]; then
+    body=$(cat)
+  else
+    body="$*"
+  fi
+  queue_note text "$body"
+}
+
+# ---------------------------------------------------------------- say
+
+cmd_say() {
+  need aws
+  need python3
+  need base64
+
+  local src wav raw transcript
+  raw=$(mktemp /tmp/fm-inbox-audio-XXXXXX)
+  wav=$(mktemp /tmp/fm-inbox-wav-XXXXXX.wav)
+  # shellcheck disable=SC2064
+  trap "rm -f '$raw' '$wav' '$wav.json'" EXIT
+
+  if [ "$#" -ge 1 ] && [ "$1" != "-" ]; then
+    src=$1
+    [ -r "$src" ] || die "cannot read audio file: $src"
+    cat "$src" >"$raw"
+  else
+    cat >"$raw"
+  fi
+  [ -s "$raw" ] || die "no audio received on stdin"
+
+  # Accept a real WAV as-is; wrap headerless 16kHz mono s16le PCM if that is
+  # what arrived. Anything else is rejected rather than silently mistranscribed.
+  python3 - "$raw" "$wav" <<'PY'
+import sys, wave
+src, dst = sys.argv[1], sys.argv[2]
+data = open(src, 'rb').read()
+if data[:4] == b'RIFF':
+    open(dst, 'wb').write(data)
+    sys.stderr.write("fm-inbox: input is WAV, passing through\n")
+elif data[:4] in (b'OggS', b'fLaC') or data[:3] == b'ID3':
+    sys.exit("fm-inbox: got Ogg/FLAC/MP3; re-encode to WAV first")
+else:
+    if len(data) % 2:
+        data = data[:-1]
+    w = wave.open(dst, 'wb')
+    w.setnchannels(1); w.setsampwidth(2); w.setframerate(16000)
+    w.writeframes(data); w.close()
+    sys.stderr.write("fm-inbox: input looked like raw PCM, wrapped as 16kHz mono WAV\n")
+PY
+
+  local secs
+  secs=$(python3 -c "
+import wave,sys
+w=wave.open('$wav'); print(round(w.getnframes()/w.getframerate(),2))")
+  printf 'fm-inbox: %ss of audio, transcribing with %s in %s\n' "$secs" "$STT_MODEL" "$REGION" >&2
+
+  python3 - "$wav" "$wav.json" <<'PY'
+import base64, json, sys
+b = base64.b64encode(open(sys.argv[1], 'rb').read()).decode()
+json.dump([{"role": "user", "content": [
+    {"audio": {"format": "wav", "source": {"bytes": b}}},
+    {"text": "Transcribe the speech exactly. Output only the transcript, nothing else."},
+]}], open(sys.argv[2], 'w'))
+PY
+
+  transcript=$(aws_call bedrock-runtime converse \
+    --model-id "$STT_MODEL" \
+    --messages "file://$wav.json" \
+    --inference-config '{"maxTokens":600,"temperature":0}' \
+    --query 'output.message.content[0].text' --output text) \
+    || die "transcription failed"
+
+  [ -n "${transcript//[[:space:]]/}" ] || die "transcription came back empty"
+  printf 'fm-inbox: heard: %s\n' "$transcript" >&2
+  queue_note voice "$transcript" "transcript_model=$STT_MODEL
+audio_seconds=$secs"
+}
+
+# ---------------------------------------------------------------- status
+
+cmd_status() {
+  local pending=0
+  [ -d "$INBOX" ] && pending=$(find "$INBOX" -maxdepth 1 -name '*.note' 2>/dev/null | wc -l | tr -d ' ')
+
+  printf '=== firstmate status (read-only, no wake sent) ===\n'
+  printf 'home     %s\n' "$FM_HOME"
+  printf 'time     %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  printf 'inbox    %s note(s) waiting for firstmate\n' "$pending"
+
+  if [ -f "$DATA/backlog.md" ]; then
+    printf '\n--- in flight ---\n'
+    awk '/^## In flight/{f=1;next} /^## /{f=0} f && /^- \[/{print}' \
+      "$DATA/backlog.md" | sed 's/^- \[ \] /  /' | cut -c1-150
+  else
+    printf '\n(no backlog at %s)\n' "$DATA/backlog.md"
+  fi
+
+  local any=0
+  for m in "$STATE"/*.meta; do
+    [ -e "$m" ] || break
+    if [ "$any" -eq 0 ]; then printf '\n--- workers ---\n'; any=1; fi
+    local id kind mode last
+    id=$(basename "$m" .meta)
+    kind=$(sed -n 's/^kind=//p' "$m" | head -1)
+    mode=$(sed -n 's/^mode=//p' "$m" | head -1)
+    last=""
+    [ -f "$STATE/$id.status" ] && last=$(tail -1 "$STATE/$id.status" 2>/dev/null | cut -c1-100)
+    printf '  %-42s %-6s %-10s %s\n' "$id" "${kind:-?}" "${mode:--}" "${last:-(no events yet)}"
+  done
+  [ "$any" -eq 1 ] || printf '\n(no workers on deck)\n'
+
+  printf '\nNote: the last event line is history, not current state.\n'
+}
+
+# ---------------------------------------------------------------- ask
+
+cmd_ask() {
+  need aws
+  need python3
+  [ "$#" -gt 0 ] || die "usage: fm-inbox.sh ask <question>..."
+  local q="$*" msg
+  msg=$(mktemp /tmp/fm-inbox-ask-XXXXXX.json)
+  # shellcheck disable=SC2064
+  trap "rm -f '$msg'" EXIT
+
+  Q="$q" python3 - "$msg" <<'PY'
+import json, os, sys
+json.dump([{"role": "user", "content": [{"text": os.environ["Q"]}]}],
+          open(sys.argv[1], 'w'))
+PY
+
+  aws_call bedrock-runtime converse \
+    --model-id "$ASK_MODEL" \
+    --messages "file://$msg" \
+    --system '[{"text":"You are a terse engineering assistant answering a side question. Be direct and concrete. No preamble. If you are not sure, say so."}]' \
+    --inference-config '{"maxTokens":700,"temperature":0.2}' \
+    --query 'output.message.content[0].text' --output text \
+    || die "ask failed"
+}
+
+# ---------------------------------------------------------------- list / drain
+
+cmd_list() {
+  [ -d "$INBOX" ] || { printf '(inbox empty)\n'; return 0; }
+  local any=0
+  for f in "$INBOX"/*.note; do
+    [ -e "$f" ] || break
+    any=1
+    printf '%s\n' "$(basename "$f" .note)"
+    sed -n '/^--$/,$p' "$f" | tail -n +2 | sed 's/^/    /'
+  done
+  [ "$any" -eq 1 ] || printf '(inbox empty)\n'
+}
+
+cmd_drain() {
+  if [ "${1:-}" = "--ack" ]; then
+    shift
+    [ "$#" -gt 0 ] || die "usage: fm-inbox.sh drain --ack <id>..."
+    mkdir -p "$INBOX/handled"
+    local id
+    for id in "$@"; do
+      if [ -f "$INBOX/$id.note" ]; then
+        mv "$INBOX/$id.note" "$INBOX/handled/$id.note"
+        printf 'acked %s\n' "$id"
+      else
+        printf 'already-acked %s\n' "$id"
+      fi
+    done
+    return 0
+  fi
+  cmd_list
+  printf '\nAck with: fm-inbox.sh drain --ack <id>...\n'
+}
+
+# ---------------------------------------------------------------- dispatch
+
+case "${1:-}" in
+  note)   shift; cmd_note "$@" ;;
+  say)    shift; cmd_say "$@" ;;
+  status) shift; cmd_status ;;
+  ask)    shift; cmd_ask "$@" ;;
+  list)   shift; cmd_list ;;
+  drain)  shift; cmd_drain "$@" ;;
+  ''|-h|--help|help)
+    sed -n '2,45p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//' ;;
+  *) die "unknown subcommand: $1 (try --help)" ;;
+esac

--- a/bin/fm-inbox.sh
+++ b/bin/fm-inbox.sh
@@ -78,7 +78,7 @@ SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="$(cd "$SELF_DIR/.." && pwd)"
 FM_HOME="${FM_HOME:-$FM_ROOT}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
-DATA="$FM_HOME/data"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 INBOX="$STATE/inbox"
 
 CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
@@ -387,6 +387,13 @@ case "${1:-}" in
   list)   shift; cmd_list ;;
   drain)  shift; cmd_drain "$@" ;;
   ''|-h|--help|help)
-    sed -n '2,45p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//' ;;
+    # The whole header block, found rather than counted: everything after the
+    # shebang up to the first line that is not a comment. A fixed line range
+    # silently truncates this help the next time the header grows, and the last
+    # thing to fall off the end is the PRIVACY paragraph, which is the one place
+    # a new operator is told which subcommands send anything off this host.
+    awk 'NR == 1 { next }
+         /^#/ { sub(/^# ?/, ""); print; next }
+         { exit }' "${BASH_SOURCE[0]}" ;;
   *) die "unknown subcommand: $1 (try --help)" ;;
 esac

--- a/bin/fm-inbox.sh
+++ b/bin/fm-inbox.sh
@@ -26,12 +26,27 @@
 #   fm-inbox.sh list
 #   fm-inbox.sh drain [--ack <id>...]
 #
+# Configuration. A region, a model id and an AWS profile name somebody's account
+# and somebody's choices, so this file carries no default for any of them. Each is
+# read from the home's gitignored config/ directory, or from the matching
+# environment variable, and the model-backed subcommands refuse with the path to
+# write rather than reaching for a value that belongs to another home. That
+# configuration is also the opt-in: `say` and `ask` are off until it exists.
+#
+#   config/inbox-region     FM_INBOX_REGION     AWS region.            required
+#   config/inbox-stt-model  FM_INBOX_STT_MODEL  speech-to-text model.  required by say
+#   config/inbox-ask-model  FM_INBOX_ASK_MODEL  side-question model.   required by ask
+#   config/inbox-profile    FM_INBOX_PROFILE    AWS profile.           optional
+#
+# An absent profile means the call uses whatever credentials are already in the
+# environment, which is also what FM_INBOX_PROFILE= (empty) forces.
+#
+# `note`, `status`, `list` and `drain` need NO configuration at all, because they
+# make no model call. The voice handover depends on `note`, so it keeps working in
+# a home that has configured nothing.
+#
 # Environment:
 #   FM_HOME              operational home whose state/ and data/ are used.
-#   FM_INBOX_REGION      AWS region for model calls.   default eu-west-1
-#   FM_INBOX_STT_MODEL   speech-to-text model.         default mistral.voxtral-small-24b-2507
-#   FM_INBOX_ASK_MODEL   side-question model.          default eu.anthropic.claude-haiku-4-5-20251001-v1:0
-#   FM_INBOX_PROFILE     AWS profile for model calls.  default inthuson-ct-sandbox
 #
 # PRIVACY: `say` sends your audio and `ask` sends your question to Bedrock.
 # `note`, `status`, `list` and `drain` make no network call at all.
@@ -66,12 +81,56 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 DATA="$FM_HOME/data"
 INBOX="$STATE/inbox"
 
-REGION="${FM_INBOX_REGION:-eu-west-1}"
-STT_MODEL="${FM_INBOX_STT_MODEL:-mistral.voxtral-small-24b-2507}"
-ASK_MODEL="${FM_INBOX_ASK_MODEL:-eu.anthropic.claude-haiku-4-5-20251001-v1:0}"
-PROFILE="${FM_INBOX_PROFILE:-inthuson-ct-sandbox}"
+CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 
 die() { printf 'fm-inbox: %s\n' "$*" >&2; exit 1; }
+
+# First non-comment, non-blank line of a config file, or nothing.
+read_setting() {  # <file-name>
+  local path="$CONFIG/$1" line
+  [ -r "$path" ] || return 0
+  while IFS= read -r line || [ -n "$line" ]; do
+    line=${line%%#*}
+    line=${line#"${line%%[![:space:]]*}"}
+    line=${line%"${line##*[![:space:]]}"}
+    [ -n "$line" ] || continue
+    printf '%s' "$line"
+    return 0
+  done < "$path"
+}
+
+# Refuse by naming the file to write. A model call that guessed at a region or an
+# account would either fail confusingly or, worse, succeed against a stranger's.
+require_setting() {  # <file-name> <env-var> <what>
+  local value
+  value=$(read_setting "$1")
+  [ -n "$value" ] || die "no $3 is configured: write one line into $CONFIG/$1 or set $2"
+  printf '%s' "$value"
+}
+
+REGION="${FM_INBOX_REGION:-}"
+STT_MODEL="${FM_INBOX_STT_MODEL:-}"
+ASK_MODEL="${FM_INBOX_ASK_MODEL:-}"
+# Unset falls through to config; explicitly empty means "use ambient credentials".
+PROFILE="${FM_INBOX_PROFILE-$(read_setting inbox-profile)}"
+
+# Resolved only by the subcommands that make a model call, so note, status, list
+# and drain keep working in a home that has configured nothing.
+need_region() {
+  [ -n "$REGION" ] || REGION=$(require_setting inbox-region FM_INBOX_REGION "AWS region")
+}
+
+need_stt_model() {
+  need_region
+  [ -n "$STT_MODEL" ] || STT_MODEL=$(require_setting inbox-stt-model \
+    FM_INBOX_STT_MODEL "speech-to-text model")
+}
+
+need_ask_model() {
+  need_region
+  [ -n "$ASK_MODEL" ] || ASK_MODEL=$(require_setting inbox-ask-model \
+    FM_INBOX_ASK_MODEL "side-question model")
+}
 
 need() { command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"; }
 
@@ -151,6 +210,9 @@ cmd_note() {
 # ---------------------------------------------------------------- say
 
 cmd_say() {
+  # Before the tool checks, so an unconfigured home is told what to configure
+  # rather than what to install for a call it is not yet allowed to make.
+  need_stt_model
   need aws
   need python3
   need base64
@@ -257,9 +319,10 @@ cmd_status() {
 # ---------------------------------------------------------------- ask
 
 cmd_ask() {
+  [ "$#" -gt 0 ] || die "usage: fm-inbox.sh ask <question>..."
+  need_ask_model
   need aws
   need python3
-  [ "$#" -gt 0 ] || die "usage: fm-inbox.sh ask <question>..."
   local q="$*" msg
   msg=$(mktemp /tmp/fm-inbox-ask-XXXXXX.json)
   # shellcheck disable=SC2064

--- a/bin/fm-voice-client.py
+++ b/bin/fm-voice-client.py
@@ -107,6 +107,10 @@ MAX_PREAMBLE = 8192
 END = object()
 
 
+class DeviceError(Exception):
+    """A microphone or speaker could not be opened, said in one line."""
+
+
 def log(enabled, message):
     if enabled:
         sys.stderr.write("client: {}\n".format(message))
@@ -382,6 +386,22 @@ class Client:
     # ------------------------------------------------------------------ lifecycle
 
     def open(self):
+        """Start the relay, the audio devices and the two frame threads.
+
+        A startup that refuses part way through releases whatever it already
+        started, including on the SystemExit _wait_ready raises: a started
+        PortAudio stream left open at interpreter shutdown is a known hang on
+        macOS, which is the laptop this runs on. Whether it releases them
+        correctly against a real device is not something this host can show, for
+        the reason the module docstring gives.
+        """
+        try:
+            self._start()
+        except BaseException:
+            self.close()
+            raise
+
+    def _start(self):
         argv = relay_command(self.options)
         log(self.verbose, "starting relay: {}".format(" ".join(argv)))
         self.proc = subprocess.Popen(
@@ -390,15 +410,25 @@ class Client:
         self.reader = frame.Reader(self.proc.stdout)
         self.uplink = Uplink(self.proc.stdin)
 
-        if self.options.out_file:
-            self.playback = FilePlayback(self.options.out_file)
-        else:
-            self.playback = SpeakerPlayback(self.options.output_device)
+        try:
+            if self.options.out_file:
+                self.playback = FilePlayback(self.options.out_file)
+            else:
+                self.playback = SpeakerPlayback(self.options.output_device)
 
-        if self.options.in_file:
-            self.capture = FileCapture(self.options.in_file)
-        else:
-            self.capture = MicCapture(self.options.input_device)
+            if self.options.in_file:
+                self.capture = FileCapture(self.options.in_file)
+            else:
+                self.capture = MicCapture(self.options.input_device)
+        except Exception as exc:                   # noqa: BLE001
+            # A named refusal with a next step, like every other refusal here.
+            # sounddevice raises its own error types and is an optional import,
+            # so neither shape reaches main as an OSError on its own.
+            raise DeviceError(
+                "could not open the audio devices ({}: {}). Name another device "
+                "with --input-device or --output-device, or run without them "
+                "using --in-file and --out-file".format(
+                    type(exc).__name__, exc))
         self.capture.start(self.up_q, self.talking)
 
         threading.Thread(target=self._downlink, daemon=True).start()
@@ -433,14 +463,26 @@ class Client:
                     "hand over SSH to see why")
             self.ready.wait(0.2)
 
-    def close(self):
+    def _quietly(self, what, action):
+        """Run one cleanup step without letting it mask why we are cleaning up."""
         try:
-            self.uplink.send(frame.QUIT)
-        except Exception:                      # noqa: BLE001
-            pass
-        self.capture.close()
-        self.playback.drain()
-        self.playback.close()
+            action()
+        except Exception as exc:                   # noqa: BLE001
+            log(self.verbose, "{} did not close cleanly: {}: {}".format(
+                what, type(exc).__name__, exc))
+
+    def close(self):
+        # Every step is guarded and every field is checked, because close() also
+        # runs from a startup that refused part way through, where the later
+        # fields are still None and the original refusal is the message worth
+        # keeping.
+        if self.uplink is not None:
+            self._quietly("the uplink", lambda: self.uplink.send(frame.QUIT))
+        if self.capture is not None:
+            self._quietly("the microphone", self.capture.close)
+        if self.playback is not None:
+            self._quietly("the speaker", self.playback.drain)
+            self._quietly("the speaker", self.playback.close)
         if self.proc is not None:
             try:
                 self.proc.stdin.close()
@@ -544,6 +586,10 @@ class Client:
         before = self.playback.bytes
         self.uplink.send(frame.TALK_START)
 
+        # Unreachable while parse_args refuses open-mic, and kept so that turning
+        # the mode on later is a small change. It is still missing the turn
+        # boundary: it opens the gate and nothing ever closes it, so no talk end
+        # is ever sent. Do not lift the refusal without adding that first.
         if self.options.listen == OPEN_MIC:
             release = None
             self.talking.set()
@@ -796,8 +842,19 @@ def main(argv):
     client = Client(options)
     try:
         client.open()
-    except (frame.FrameError, OSError) as exc:
+    except SystemExit as exc:
+        # _wait_ready refuses this way and its message is already the whole
+        # story. open() has released what it started; this turns the refusal
+        # into the same one-line exit the rest of this file gives.
+        if exc.code not in (None, 0):
+            sys.stderr.write("{}\n".format(exc.code))
+        return 2
+    except (frame.FrameError, OSError, DeviceError) as exc:
         sys.stderr.write("fm-voice-client: {}\n".format(exc))
+        return 2
+    except Exception as exc:                       # noqa: BLE001
+        sys.stderr.write("fm-voice-client: could not start: {}: {}\n".format(
+            type(exc).__name__, exc))
         return 2
     try:
         return client.run()

--- a/bin/fm-voice-client.py
+++ b/bin/fm-voice-client.py
@@ -836,6 +836,21 @@ class Client:
                 break
             if index < self.options.runs:
                 self._let_reply_finish(record)
+                # The connection is checked again on the way out, because that
+                # wait is seconds long and is where a relay that dies between
+                # questions dies. Opening the next turn on a dead connection
+                # cleared the failure the downlink had already recorded, left
+                # nothing to answer it, and returned after the whole reply
+                # timeout as answered: false with relay_error: null - a lost
+                # connection wearing the shape of a turn the model declined, in
+                # the file the published latency spread is read from. Nothing
+                # more can be taken over it, and the runs the captain asked for
+                # were not, so the exit code says so as well.
+                if self.closed.is_set():
+                    say("client: the connection closed after run {} of {}; the "
+                        "rest were not taken".format(index, self.options.runs))
+                    rc = 1
+                    break
         return rc
 
 

--- a/bin/fm-voice-client.py
+++ b/bin/fm-voice-client.py
@@ -686,6 +686,17 @@ class Client:
         return rc
 
 
+def device_selector(value):
+    """Return a sounddevice device: an index when the value is digits, a name otherwise.
+
+    sounddevice reads an int as an index into its device list and a str as a
+    substring to match against device names, so an index left as text is looked
+    up as a device literally called "3" and raises. docs/voice-relay.md tells the
+    captain these flags take a name or an index, so both have to arrive typed.
+    """
+    return int(value) if value.strip().isdigit() else value
+
+
 def parse_args(argv):
     parser = argparse.ArgumentParser(
         prog="fm-voice-client.py", add_help=True,
@@ -702,8 +713,8 @@ def parse_args(argv):
     parser.add_argument("--talk-seconds", type=float)
     parser.add_argument("--in-file")
     parser.add_argument("--out-file")
-    parser.add_argument("--input-device")
-    parser.add_argument("--output-device")
+    parser.add_argument("--input-device", type=device_selector)
+    parser.add_argument("--output-device", type=device_selector)
     parser.add_argument("--timeout", type=float, default=30.0)
     parser.add_argument("--wait-for-reply", action=argparse.BooleanOptionalAction,
                         default=True,

--- a/bin/fm-voice-client.py
+++ b/bin/fm-voice-client.py
@@ -40,9 +40,10 @@ Options:
   --host <name>          SSH destination of the desktop holding the relay.
   --local                run the relay as a local child process instead. This is
                          how the relay path is measured without a laptop.
-  --relay <path>         relay script on the desktop.
-                         default $FM_VOICE_RELAY or
-                         /workplace/inthuson/firstmate/bin/fm-voice-relay.py
+  --relay <path>         path to fm-voice-relay.py on the desktop, or set
+                         $FM_VOICE_RELAY. Required: this file carries no default,
+                         because one operator's home directory is not a path to
+                         hand anybody else.
   --relay-python <path>  interpreter that has aws-sdk-bedrock-runtime installed.
                          default $FM_VOICE_PYTHON or python3
   --relay-arg <arg>      extra argument for the relay, repeatable. Write it
@@ -92,8 +93,6 @@ OUT_BLOCK = 2400
 PUSH_TO_TALK = "push-to-talk"
 OPEN_MIC = "open-mic"
 LISTEN_MODES = (PUSH_TO_TALK, OPEN_MIC)
-
-DEFAULT_RELAY = "/workplace/inthuson/firstmate/bin/fm-voice-relay.py"
 
 # Anything the relay's login shell prints on stdout ahead of the first frame is
 # discarded, up to this much. Past it, the stream is not a relay.
@@ -715,8 +714,9 @@ def parse_args(argv):
         description=__doc__.splitlines()[0])
     parser.add_argument("--host")
     parser.add_argument("--local", action="store_true")
-    parser.add_argument("--relay",
-                        default=os.environ.get("FM_VOICE_RELAY", DEFAULT_RELAY))
+    parser.add_argument("--relay", default=os.environ.get("FM_VOICE_RELAY"),
+                        help="path to fm-voice-relay.py on the desktop; required, "
+                             "and FM_VOICE_RELAY sets it for a whole shell")
     parser.add_argument("--relay-python",
                         default=os.environ.get("FM_VOICE_PYTHON", "python3"))
     parser.add_argument("--relay-arg", action="append")
@@ -741,6 +741,10 @@ def parse_args(argv):
     options = parser.parse_args(argv)
     if bool(options.host) == bool(options.local):
         parser.error("give exactly one of --host <sshhost> or --local")
+    if not options.relay:
+        parser.error(
+            "say where the relay is: --relay <path to fm-voice-relay.py on the "
+            "desktop>, or set FM_VOICE_RELAY")
     if options.runs < 1:
         parser.error("--runs must be at least 1")
     if options.listen == OPEN_MIC and options.in_file:

--- a/bin/fm-voice-client.py
+++ b/bin/fm-voice-client.py
@@ -20,13 +20,18 @@ WHAT IS VERIFIED AND WHAT IS NOT. Read this before trusting a number from it.
   sounddevice calls below are written from its documented interface and have
   never been run against a real device. Treat the first live run as the test.
 
-TWO KINDS OF LISTENING, one setting. --listen push-to-talk is the default: the
-captain says when they are talking, the model is only paid for that audio, and
-nothing is streamed while they are thinking. --listen open-mic streams
-continuously and lets the model decide when a turn ended, which is a nicer
-conversation and costs about half again as much per minute. The captain has not
-decided that question, so the cheaper one is the default and the flag is the
-whole difference.
+TWO KINDS OF LISTENING, one of them built. --listen push-to-talk is the default
+and the only mode that runs: the captain says when they are talking, the model is
+only paid for that audio, and nothing is streamed while they are thinking.
+
+--listen open-mic is accepted as a setting and REFUSES at startup. Streaming
+continuously needs something to decide when the captain stopped speaking, and
+this client has no end-of-speech detection: it would open a turn, stream audio
+forever and never mark a boundary, so the relay would keep appending to a session
+that had already answered. That detection belongs with session continuity across
+turns, which is step three of the design. The setting stays here so that turning
+it on later is a small change rather than a new flag, and refusing is honest
+where half a mode would not be.
 
 Copy this file and fm_voice_frame.py to the laptop; they are the only two files
 it needs and both are standard library only, apart from sounddevice for the
@@ -50,7 +55,8 @@ Options:
                          joined with an equals sign, --relay-arg=--scope
                          --relay-arg=counts, or the leading dashes are read as
                          options of this client instead.
-  --listen <mode>        push-to-talk (default) or open-mic.
+  --listen <mode>        push-to-talk, the default and the only mode that runs.
+                         open-mic is accepted and refuses; see above.
   --runs <n>             turns to take in one session.        default 1
   --talk-seconds <sec>   capture for this long instead of waiting on a keypress.
   --in-file <file.pcm>   raw 16 kHz mono 16-bit input instead of the microphone.
@@ -740,7 +746,10 @@ def parse_args(argv):
     parser.add_argument("--relay-python",
                         default=os.environ.get("FM_VOICE_PYTHON", "python3"))
     parser.add_argument("--relay-arg", action="append")
-    parser.add_argument("--listen", choices=LISTEN_MODES, default=PUSH_TO_TALK)
+    parser.add_argument("--listen", choices=LISTEN_MODES, default=PUSH_TO_TALK,
+                        help="push-to-talk is the default and the only mode that "
+                             "runs; open-mic is accepted and refuses until "
+                             "end-of-speech detection exists")
     parser.add_argument("--runs", type=int, default=1)
     parser.add_argument("--talk-seconds", type=float)
     parser.add_argument("--in-file")
@@ -771,6 +780,14 @@ def parse_args(argv):
         parser.error(
             "--listen open-mic with --in-file would end the turn when the file "
             "ran out, which is not what an open microphone does")
+    if options.listen == OPEN_MIC:
+        # Here rather than in open(), so nothing is spent: no ssh, no relay, no
+        # model session. See the module docstring on the two kinds of listening.
+        parser.error(
+            "--listen open-mic is not built yet: it needs end-of-speech "
+            "detection to know when a turn ended, which lands with session "
+            "continuity across turns, so it would stream forever and never end "
+            "a turn. Use the default --listen push-to-talk.")
     return options
 
 

--- a/bin/fm-voice-client.py
+++ b/bin/fm-voice-client.py
@@ -482,6 +482,14 @@ class Client:
                         self.turn["interrupted"] = True
                     log(self.verbose, "the model treated this turn as an "
                                       "interruption of its own speech")
+                elif event == "turn-failed":
+                    # The relay is still there and the next talk key gets a new
+                    # session, so this ends the turn rather than the run.
+                    say("client: the relay could not finish that turn: {}".format(
+                        obj.get("error", "")))
+                    with self.lock:
+                        self.turn["failed"] = obj.get("error", "")
+                    self.reply_done.set()
                 elif event == "session-ended":
                     say("client: the relay ended the session")
                     self.reply_done.set()
@@ -549,6 +557,10 @@ class Client:
             "tool_calls": turn.get("tool_calls", 0),
             "queued_note": turn.get("queued"),
             "interrupted": bool(turn.get("interrupted")),
+            # Why a turn has no answer, when the relay knows. A results file
+            # that only says answered: false invites the reader to average an
+            # infrastructure failure into a latency figure.
+            "relay_error": turn.get("failed"),
             # The number this build exists to produce: the captain stopped
             # talking, and this many seconds later sound came out.
             "first_audio_s": since(played if played is not None else first_frame),

--- a/bin/fm-voice-client.py
+++ b/bin/fm-voice-client.py
@@ -398,14 +398,34 @@ class Client:
         threading.Thread(target=self._downlink, daemon=True).start()
         threading.Thread(target=self._sender, daemon=True).start()
 
-        if not self.ready.wait(timeout=self.options.timeout):
-            raise SystemExit(
-                "fm-voice-client: the relay never reported ready; run it by hand "
-                "over SSH to see why")
+        self._wait_ready()
         notice = self.ready_notice
         say("client: relay ready, {} in {}, read scope {}, connected in {}s".format(
             notice.get("model", "?"), notice.get("region", "?"),
             notice.get("read_scope", "?"), notice.get("connect_seconds", "?")))
+
+    def _wait_ready(self):
+        """Wait for the relay's ready notice, or for the connection to close first.
+
+        A relay that dies after the handshake is the likely first-run failure:
+        the Bedrock SDK is imported inside the model session, so a forgotten
+        --relay-python exits the relay after the handshake and before ready. Its
+        own one-line error is already on the captain's terminal, because stderr is
+        inherited rather than piped, so waiting out the full timeout after that
+        just leaves them watching nothing.
+        """
+        deadline = time.monotonic() + self.options.timeout
+        while not self.ready.is_set():
+            if self.closed.is_set():
+                raise SystemExit(
+                    "fm-voice-client: the relay closed the connection before it "
+                    "was ready; run the relay command by hand over SSH to see "
+                    "its error")
+            if time.monotonic() >= deadline:
+                raise SystemExit(
+                    "fm-voice-client: the relay never reported ready; run it by "
+                    "hand over SSH to see why")
+            self.ready.wait(0.2)
 
     def close(self):
         try:

--- a/bin/fm-voice-client.py
+++ b/bin/fm-voice-client.py
@@ -1,0 +1,748 @@
+#!/usr/bin/env python3
+"""fm-voice-client.py - the captain's laptop end of the spoken interface.
+
+Captures audio on the laptop, streams it over the SSH connection the captain
+already has to the desktop, plays back the spoken reply, and reports how long
+the round trip took. The desktop holds the Bedrock session and the AWS
+credentials; this client needs neither. It needs Python and a microphone.
+
+WHAT IS VERIFIED AND WHAT IS NOT. Read this before trusting a number from it.
+
+  Verified on the desktop: the frame protocol, the SSH transport, the relay
+  handshake, turn sequencing, the reply audio arriving intact, and the timing
+  arithmetic. All of that was exercised with --in-file and --out-file, which
+  replace the microphone and the speaker with files and leave everything else
+  alone.
+
+  NOT verified, and cannot be from here: the microphone capture path and the
+  speaker playback path. The desktop this was written on has neither a
+  microphone nor a speaker, and no worker can reach the captain's laptop. The
+  sounddevice calls below are written from its documented interface and have
+  never been run against a real device. Treat the first live run as the test.
+
+TWO KINDS OF LISTENING, one setting. --listen push-to-talk is the default: the
+captain says when they are talking, the model is only paid for that audio, and
+nothing is streamed while they are thinking. --listen open-mic streams
+continuously and lets the model decide when a turn ended, which is a nicer
+conversation and costs about half again as much per minute. The captain has not
+decided that question, so the cheaper one is the default and the flag is the
+whole difference.
+
+Copy this file and fm_voice_frame.py to the laptop; they are the only two files
+it needs and both are standard library only, apart from sounddevice for the
+audio devices.
+
+Usage:
+  fm-voice-client.py --host <sshhost> [options]
+  fm-voice-client.py --local [options]          (relay as a child, no SSH)
+
+Options:
+  --host <name>          SSH destination of the desktop holding the relay.
+  --local                run the relay as a local child process instead. This is
+                         how the relay path is measured without a laptop.
+  --relay <path>         relay script on the desktop.
+                         default $FM_VOICE_RELAY or
+                         /workplace/inthuson/firstmate/bin/fm-voice-relay.py
+  --relay-python <path>  interpreter that has aws-sdk-bedrock-runtime installed.
+                         default $FM_VOICE_PYTHON or python3
+  --relay-arg <arg>      extra argument for the relay, repeatable. Write it
+                         joined with an equals sign, --relay-arg=--scope
+                         --relay-arg=counts, or the leading dashes are read as
+                         options of this client instead.
+  --listen <mode>        push-to-talk (default) or open-mic.
+  --runs <n>             turns to take in one session.        default 1
+  --talk-seconds <sec>   capture for this long instead of waiting on a keypress.
+  --in-file <file.pcm>   raw 16 kHz mono 16-bit input instead of the microphone.
+  --out-file <file.pcm>  write reply audio here instead of playing it.
+  --input-device <id>    sounddevice input device.
+  --output-device <id>   sounddevice output device.
+  --timeout <sec>        how long to wait for a reply.        default 30
+  --no-wait-for-reply    open the next turn without waiting for the previous
+                         answer to finish. The model treats that as being
+                         interrupted and stops instead of answering, so this
+                         exists to reproduce the trap, not to use.
+  --gap-seconds <sec>    quiet beat after an answer finishes.  default 0.5
+  --verbose              log the session to stderr.
+
+One JSON record per turn goes to stdout; everything human goes to stderr, so
+`fm-voice-client.py --host desktop --runs 5 > runs.jsonl` gives measurements and
+a readable session at the same time.
+"""
+
+import argparse
+import json
+import os
+import queue
+import subprocess
+import sys
+import threading
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import fm_voice_frame as frame              # noqa: E402
+
+IN_RATE = 16000
+OUT_RATE = 24000
+# 100 ms at each rate. The uplink chunk matches what the relay and the survey
+# measured with; changing it changes the numbers.
+CHUNK = 3200
+OUT_BLOCK = 2400
+
+PUSH_TO_TALK = "push-to-talk"
+OPEN_MIC = "open-mic"
+LISTEN_MODES = (PUSH_TO_TALK, OPEN_MIC)
+
+DEFAULT_RELAY = "/workplace/inthuson/firstmate/bin/fm-voice-relay.py"
+
+# Anything the relay's login shell prints on stdout ahead of the first frame is
+# discarded, up to this much. Past it, the stream is not a relay.
+MAX_PREAMBLE = 8192
+
+END = object()
+
+
+def log(enabled, message):
+    if enabled:
+        sys.stderr.write("client: {}\n".format(message))
+        sys.stderr.flush()
+
+
+def say(message):
+    sys.stderr.write("{}\n".format(message))
+    sys.stderr.flush()
+
+
+# --------------------------------------------------------------------- transport
+
+
+def sync_magic(stream, verbose=False):
+    """Discard anything ahead of the relay's magic preamble.
+
+    `ssh host command` runs the command through the captain's login shell, so a
+    shell startup file that prints a banner lands in front of the first frame.
+    Skipping to the preamble turns that from a baffling protocol error into a
+    warning naming the offending text.
+    """
+    seen = bytearray()
+    while True:
+        byte = stream.read(1)
+        if not byte:
+            raise frame.FrameError(
+                "the relay closed the connection before it said hello; run the "
+                "relay command by hand over SSH to see its error")
+        seen += byte
+        if seen.endswith(frame.MAGIC):
+            junk = bytes(seen[: -len(frame.MAGIC)])
+            if junk:
+                say("client: discarded {} bytes your login shell printed before "
+                    "the relay started: {!r}".format(len(junk), junk[:200]))
+            log(verbose, "relay handshake found")
+            return
+        if len(seen) > MAX_PREAMBLE:
+            raise frame.FrameError(
+                "no relay handshake in the first {} bytes; the command on the "
+                "far end is not fm-voice-relay.py --serve".format(MAX_PREAMBLE))
+
+
+def relay_command(options):
+    """Return the argv that starts the relay, locally or over SSH."""
+    remote = [options.relay_python, options.relay, "--serve"]
+    remote += list(options.relay_arg or [])
+    if options.verbose:
+        remote.append("--verbose")
+    if options.local:
+        return remote
+    # -T because a pty would rewrite bytes in the audio stream, which is the
+    # single most confusing way this could fail.
+    return ["ssh", "-T", options.host] + remote
+
+
+class Uplink:
+    """Serialise every frame the client sends, from whichever thread sends it."""
+
+    def __init__(self, stream):
+        self._writer = frame.Writer(stream)
+        self._lock = threading.Lock()
+
+    def send(self, kind, payload=b""):
+        with self._lock:
+            self._writer.send(kind, payload)
+
+
+# ---------------------------------------------------------------------- playback
+
+
+class FilePlayback:
+    """Write reply audio to a file. This is the path that can be verified here."""
+
+    def __init__(self, path):
+        self._handle = open(path, "wb")
+        self.first_played = None
+        self.device_latency = None
+        self.bytes = 0
+
+    def write(self, pcm):
+        if self.first_played is None:
+            self.first_played = time.monotonic()
+        self._handle.write(pcm)
+        self.bytes += len(pcm)
+
+    def turn_reset(self):
+        self.first_played = None
+
+    def drain(self, timeout=5):
+        del timeout
+
+    def close(self):
+        self._handle.close()
+
+
+class SpeakerPlayback:
+    """Play reply audio through the laptop speaker.
+
+    UNVERIFIED: written from the sounddevice interface and never run against a
+    real device, because the machine this was built on has no speaker. The
+    timestamp is taken when the audio is handed to the device callback, which is
+    the last moment this process can see. The device's own output buffer sits
+    after that, so its reported latency is included in the turn record rather
+    than pretended away.
+    """
+
+    def __init__(self, device=None):
+        import sounddevice                    # noqa: PLC0415
+        self._buffer = bytearray()
+        self._lock = threading.Lock()
+        self.first_played = None
+        self.bytes = 0
+        self._stream = sounddevice.RawOutputStream(
+            samplerate=OUT_RATE, channels=1, dtype="int16",
+            blocksize=OUT_BLOCK, device=device, latency="low",
+            callback=self._callback)
+        self._stream.start()
+        self.device_latency = getattr(self._stream, "latency", None)
+
+    def _callback(self, outdata, frames_wanted, time_info, status):
+        del time_info, status
+        want = frames_wanted * 2
+        with self._lock:
+            take = min(want, len(self._buffer))
+            chunk = bytes(self._buffer[:take])
+            del self._buffer[:take]
+            if chunk and self.first_played is None:
+                self.first_played = time.monotonic()
+        outdata[:take] = chunk
+        if take < want:
+            outdata[take:want] = b"\x00" * (want - take)
+
+    def write(self, pcm):
+        with self._lock:
+            self._buffer += pcm
+        self.bytes += len(pcm)
+
+    def turn_reset(self):
+        with self._lock:
+            self.first_played = None
+
+    def drain(self, timeout=30):
+        """Wait for the buffered reply to finish, so the process does not cut it off."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            with self._lock:
+                if not self._buffer:
+                    break
+            time.sleep(0.05)
+        time.sleep(0.2)
+
+    def close(self):
+        try:
+            self._stream.stop()
+            self._stream.close()
+        except Exception:                      # noqa: BLE001
+            pass
+
+
+# ----------------------------------------------------------------------- capture
+
+
+class FileCapture:
+    """Stream a PCM file as if it were the microphone, paced at real time.
+
+    Paced deliberately: a file pushed as fast as the socket accepts it measures
+    the socket rather than the conversation.
+    """
+
+    def __init__(self, path):
+        with open(path, "rb") as handle:
+            self._pcm = handle.read()
+        self.seconds = round(len(self._pcm) / float(IN_RATE * 2), 3)
+        self.device_latency = None
+        self._q = None
+        self._talking = None
+        self._done = threading.Event()
+
+    def start(self, out_q, talking):
+        self._q = out_q
+        self._talking = talking
+
+    def begin_turn(self):
+        """Start feeding the file. One pass per turn, from the top each time."""
+        self._done.clear()
+
+        def run():
+            for at in range(0, len(self._pcm), CHUNK):
+                if not self._talking.is_set():
+                    return
+                self._q.put(self._pcm[at:at + CHUNK])
+                time.sleep(CHUNK / float(IN_RATE * 2))
+            self._done.set()
+
+        threading.Thread(target=run, daemon=True).start()
+
+    def wait_exhausted(self, timeout):
+        return self._done.wait(timeout)
+
+    def close(self):
+        pass
+
+
+class MicCapture:
+    """Capture from the laptop microphone.
+
+    UNVERIFIED: written from the sounddevice interface and never run against a
+    real device. The stream stays open for the whole session and the gate decides
+    what is sent, so push to talk costs no device setup per turn and the model is
+    only paid for audio while the gate is open.
+    """
+
+    def __init__(self, device=None):
+        import sounddevice                    # noqa: PLC0415
+        self.seconds = None
+        self._q = None
+        self._talking = None
+        self._stream = sounddevice.RawInputStream(
+            samplerate=IN_RATE, channels=1, dtype="int16",
+            blocksize=CHUNK // 2, device=device, latency="low",
+            callback=self._callback)
+        self._stream.start()
+        self.device_latency = getattr(self._stream, "latency", None)
+
+    def _callback(self, indata, frames_read, time_info, status):
+        del frames_read, time_info, status
+        if self._talking is not None and self._talking.is_set():
+            self._q.put(bytes(indata))
+
+    def start(self, out_q, talking):
+        self._q = out_q
+        self._talking = talking
+
+    def begin_turn(self):
+        """Nothing to do: the device stream is already open and the gate decides."""
+
+    def wait_exhausted(self, timeout):
+        del timeout
+        return False
+
+    def close(self):
+        try:
+            self._stream.stop()
+            self._stream.close()
+        except Exception:                      # noqa: BLE001
+            pass
+
+
+# ------------------------------------------------------------------------ client
+
+
+class Client:
+    """One relay connection and the turns taken over it."""
+
+    def __init__(self, options):
+        self.options = options
+        self.verbose = options.verbose
+        self.proc = None
+        self.reader = None
+        self.uplink = None
+        self.playback = None
+        self.capture = None
+        self.up_q = queue.Queue()
+        self.talking = threading.Event()
+        self.ready = threading.Event()
+        self.reply_done = threading.Event()
+        self.closed = threading.Event()
+        self.ready_notice = {}
+        self.turn = {}
+        self.lock = threading.Lock()
+
+    # ------------------------------------------------------------------ lifecycle
+
+    def open(self):
+        argv = relay_command(self.options)
+        log(self.verbose, "starting relay: {}".format(" ".join(argv)))
+        self.proc = subprocess.Popen(
+            argv, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+        sync_magic(self.proc.stdout, self.verbose)
+        self.reader = frame.Reader(self.proc.stdout)
+        self.uplink = Uplink(self.proc.stdin)
+
+        if self.options.out_file:
+            self.playback = FilePlayback(self.options.out_file)
+        else:
+            self.playback = SpeakerPlayback(self.options.output_device)
+
+        if self.options.in_file:
+            self.capture = FileCapture(self.options.in_file)
+        else:
+            self.capture = MicCapture(self.options.input_device)
+        self.capture.start(self.up_q, self.talking)
+
+        threading.Thread(target=self._downlink, daemon=True).start()
+        threading.Thread(target=self._sender, daemon=True).start()
+
+        if not self.ready.wait(timeout=self.options.timeout):
+            raise SystemExit(
+                "fm-voice-client: the relay never reported ready; run it by hand "
+                "over SSH to see why")
+        notice = self.ready_notice
+        say("client: relay ready, {} in {}, read scope {}, connected in {}s".format(
+            notice.get("model", "?"), notice.get("region", "?"),
+            notice.get("read_scope", "?"), notice.get("connect_seconds", "?")))
+
+    def close(self):
+        try:
+            self.uplink.send(frame.QUIT)
+        except Exception:                      # noqa: BLE001
+            pass
+        self.capture.close()
+        self.playback.drain()
+        self.playback.close()
+        if self.proc is not None:
+            try:
+                self.proc.stdin.close()
+            except Exception:                  # noqa: BLE001
+                pass
+            try:
+                self.proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                self.proc.kill()
+
+    # -------------------------------------------------------------------- threads
+
+    def _sender(self):
+        """Own the uplink audio, so talk end is never sent ahead of the last chunk."""
+        while True:
+            item = self.up_q.get()
+            if item is None:
+                return
+            if item is END:
+                with self.lock:
+                    self.turn["wire_end"] = time.monotonic()
+                self.uplink.send(frame.TALK_END)
+                continue
+            try:
+                self.uplink.send(frame.AUDIO, item)
+            except (BrokenPipeError, OSError):
+                return
+
+    def _downlink(self):
+        while True:
+            try:
+                got = self.reader.read()
+            except (frame.FrameError, OSError) as exc:
+                say("client: connection lost: {}".format(exc))
+                break
+            if got is None:
+                break
+            kind, payload = got
+            if kind == frame.AUDIO:
+                with self.lock:
+                    now = time.monotonic()
+                    self.turn.setdefault("first_frame", now)
+                    self.turn["last_frame"] = now
+                self.playback.write(payload)
+            elif kind == frame.TEXT:
+                obj = frame.decode_json(payload)
+                text = (obj.get("text") or "").strip()
+                if text and not text.startswith("{"):
+                    who = "you" if obj.get("role") == "USER" else "assistant"
+                    say("  {}: {}".format(who, text))
+            elif kind == frame.NOTICE:
+                obj = frame.decode_json(payload)
+                event = obj.get("event", "")
+                if event == "ready":
+                    self.ready_notice = obj
+                    self.ready.set()
+                elif event == "queued":
+                    say("  handed to the first mate: {}".format(
+                        obj.get("request", "")))
+                    with self.lock:
+                        self.turn["queued"] = obj.get("note_id", "")
+                elif event == "interrupted":
+                    with self.lock:
+                        self.turn["interrupted"] = True
+                    log(self.verbose, "the model treated this turn as an "
+                                      "interruption of its own speech")
+                elif event == "session-ended":
+                    say("client: the relay ended the session")
+                    self.reply_done.set()
+                else:
+                    log(self.verbose, "notice {}".format(obj))
+            elif kind == frame.MARK:
+                obj = frame.decode_json(payload)
+                with self.lock:
+                    self.turn.setdefault("marks", {})[obj.get("mark", "?")] = \
+                        obj.get("since_talk_end")
+                    self.turn["tool_calls"] = obj.get("tool_calls", 0)
+                if obj.get("mark") == "reply_end":
+                    self.reply_done.set()
+            elif kind == frame.BYE:
+                break
+        self.closed.set()
+        self.reply_done.set()
+
+    # ---------------------------------------------------------------------- turns
+
+    def take_turn(self, index):
+        """Run one turn and return its record."""
+        with self.lock:
+            self.turn = {}
+        self.playback.turn_reset()
+        self.reply_done.clear()
+        before = self.playback.bytes
+        self.uplink.send(frame.TALK_START)
+
+        if self.options.listen == OPEN_MIC:
+            release = None
+            self.talking.set()
+            self.capture.begin_turn()
+            say("client: open microphone, run {}. Speak when you like.".format(index))
+        else:
+            release = self._push_to_talk(index)
+
+        deadline = self.options.timeout
+        if not self.reply_done.wait(timeout=deadline):
+            say("client: no reply within {}s".format(deadline))
+        self._wait_audio_quiet(deadline)
+
+        with self.lock:
+            turn = dict(self.turn)
+        marks = turn.get("marks", {})
+        played = self.playback.first_played
+        first_frame = turn.get("first_frame")
+
+        def since(at):
+            if release is None or at is None:
+                return None
+            return round(at - release, 3)
+
+        record = {
+            "run": index,
+            "listen": self.options.listen,
+            "transport": "local" if self.options.local else "ssh",
+            "host": None if self.options.local else self.options.host,
+            "input": self.options.in_file or "microphone",
+            "output": self.options.out_file or "speaker",
+            "model": self.ready_notice.get("model"),
+            "region": self.ready_notice.get("region"),
+            "read_scope": self.ready_notice.get("read_scope"),
+            "connect_seconds": self.ready_notice.get("connect_seconds"),
+            "tool_calls": turn.get("tool_calls", 0),
+            "queued_note": turn.get("queued"),
+            "interrupted": bool(turn.get("interrupted")),
+            # The number this build exists to produce: the captain stopped
+            # talking, and this many seconds later sound came out.
+            "first_audio_s": since(played if played is not None else first_frame),
+            "first_frame_s": since(first_frame),
+            "first_played_s": since(played),
+            "last_frame_s": since(turn.get("last_frame")),
+            "uplink_drain_s": since(turn.get("wire_end")),
+            "device_output_latency_s": self.playback.device_latency,
+            "device_input_latency_s": self.capture.device_latency,
+            "relay_marks_since_talk_end": marks,
+            "reply_audio_seconds": round(
+                (self.playback.bytes - before) / float(OUT_RATE * 2), 3),
+            "answered": self.playback.bytes > before,
+        }
+        if release is None:
+            record["first_audio_note"] = (
+                "An open microphone has no local end of speech, so the model's "
+                "own detector is the only clock. Read "
+                "relay_marks_since_talk_end instead.")
+        elif not self.options.out_file:
+            record["first_audio_note"] = (
+                "Measured to the moment audio was handed to the output device. "
+                "The device's own buffer, reported as "
+                "device_output_latency_s, comes after that.")
+        else:
+            record["first_audio_note"] = (
+                "Measured to the moment reply audio reached this process. There "
+                "is no speaker in this configuration, so no playback latency is "
+                "included.")
+        return record
+
+    def _wait_audio_quiet(self, deadline):
+        """Wait for the reply audio to stop arriving before reading the turn.
+
+        Measured, the last audio frame and END_TURN land within about ten
+        milliseconds of each other, audio first, so this almost always returns
+        at once. It is here because the count of reply audio is what the
+        no-overlap wait below depends on, and a turn that ends any other way,
+        such as the session closing, would otherwise be counted short.
+        """
+        limit = time.monotonic() + deadline
+        while time.monotonic() < limit:
+            with self.lock:
+                last = self.turn.get("last_frame")
+            if last is None:
+                return
+            if time.monotonic() - last >= self.options.audio_idle:
+                return
+            time.sleep(0.05)
+
+    def _push_to_talk(self, index):
+        """Open the gate, close it, and return the moment the captain stopped.
+
+        That instant, not the moment the last byte reaches the wire, is what the
+        captain experiences as the end of their own speech. Every headline number
+        is measured from it, and uplink_drain_s reports the difference so a slow
+        connection stays visible rather than hiding inside the total.
+        """
+        seconds = self.options.talk_seconds
+        if seconds is None and not self.options.in_file:
+            try:
+                input("\nrun {}: press Enter, speak, then press Enter again.".format(
+                    index))
+            except EOFError:
+                raise SystemExit(
+                    "fm-voice-client: no keyboard on this input. Use "
+                    "--talk-seconds or --in-file for an unattended run.")
+
+        self.talking.set()
+        self.capture.begin_turn()
+        if seconds is not None:
+            say("client: run {}, capturing {}s.".format(index, seconds))
+            time.sleep(seconds)
+        elif self.options.in_file:
+            self.capture.wait_exhausted(self.options.timeout)
+        else:
+            say("  listening. Enter to send.")
+            try:
+                input()
+            except EOFError:
+                pass
+
+        self.talking.clear()
+        release = time.monotonic()
+        self.up_q.put(END)
+        log(self.verbose, "talk end queued")
+        return release
+
+    def _let_reply_finish(self, record):
+        """Wait for the previous answer to finish before opening another turn.
+
+        The model tracks its own speech, and audio arriving while it believes it
+        is still talking is an interruption: it emits an INTERRUPTED marker, and
+        the interrupted turn is then lost. It goes as far as calling the tool and
+        then produces no answer at all, which is the worst of both, so this is
+        not an inconvenience to be tolerated.
+
+        The clock that matters runs from the END of generation, not the start.
+        The model streams a six second answer in about one second, and a turn
+        opened at first-frame plus six seconds was still interrupted, while
+        last-frame plus six seconds was not. So the wait is the reply's own
+        duration measured from the last frame, plus a beat. In conversation that
+        costs nothing: it is exactly the pause a captain takes anyway, because
+        they are listening to the answer.
+
+        Barge-in is step three of the design, so until it is built a turn waits.
+        --no-wait-for-reply reproduces the trap deliberately.
+        """
+        if not self.options.wait_for_reply:
+            return
+        self.playback.drain()
+        with self.lock:
+            last = self.turn.get("last_frame")
+        seconds = record.get("reply_audio_seconds") or 0
+        if last is None or not seconds:
+            return
+        remaining = last + seconds + self.options.gap_seconds - time.monotonic()
+        if remaining > 0:
+            log(self.verbose,
+                "waiting {:.2f}s for the answer to finish".format(remaining))
+            time.sleep(remaining)
+
+    def run(self):
+        rc = 0
+        for index in range(1, self.options.runs + 1):
+            record = self.take_turn(index)
+            print(json.dumps(record))
+            sys.stdout.flush()
+            if not record["answered"]:
+                rc = 1
+            if self.closed.is_set():
+                break
+            if index < self.options.runs:
+                self._let_reply_finish(record)
+        return rc
+
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(
+        prog="fm-voice-client.py", add_help=True,
+        description=__doc__.splitlines()[0])
+    parser.add_argument("--host")
+    parser.add_argument("--local", action="store_true")
+    parser.add_argument("--relay",
+                        default=os.environ.get("FM_VOICE_RELAY", DEFAULT_RELAY))
+    parser.add_argument("--relay-python",
+                        default=os.environ.get("FM_VOICE_PYTHON", "python3"))
+    parser.add_argument("--relay-arg", action="append")
+    parser.add_argument("--listen", choices=LISTEN_MODES, default=PUSH_TO_TALK)
+    parser.add_argument("--runs", type=int, default=1)
+    parser.add_argument("--talk-seconds", type=float)
+    parser.add_argument("--in-file")
+    parser.add_argument("--out-file")
+    parser.add_argument("--input-device")
+    parser.add_argument("--output-device")
+    parser.add_argument("--timeout", type=float, default=30.0)
+    parser.add_argument("--wait-for-reply", action=argparse.BooleanOptionalAction,
+                        default=True,
+                        help="wait for each answer to finish being spoken before "
+                             "opening the next turn (default on)")
+    parser.add_argument("--gap-seconds", type=float, default=0.5,
+                        help="quiet beat after an answer finishes. default 0.5")
+    parser.add_argument("--audio-idle", type=float, default=0.4,
+                        help="silence that counts as the reply having stopped "
+                             "arriving. default 0.4")
+    parser.add_argument("--verbose", action="store_true")
+    options = parser.parse_args(argv)
+    if bool(options.host) == bool(options.local):
+        parser.error("give exactly one of --host <sshhost> or --local")
+    if options.runs < 1:
+        parser.error("--runs must be at least 1")
+    if options.listen == OPEN_MIC and options.in_file:
+        parser.error(
+            "--listen open-mic with --in-file would end the turn when the file "
+            "ran out, which is not what an open microphone does")
+    return options
+
+
+def main(argv):
+    options = parse_args(argv)
+    client = Client(options)
+    try:
+        client.open()
+    except (frame.FrameError, OSError) as exc:
+        sys.stderr.write("fm-voice-client: {}\n".format(exc))
+        return 2
+    try:
+        return client.run()
+    except KeyboardInterrupt:
+        say("client: stopping.")
+        return 130
+    finally:
+        client.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/bin/fm-voice-client.py
+++ b/bin/fm-voice-client.py
@@ -546,21 +546,29 @@ class Client:
         turn's talk end to it, and the captain's entire next question was dropped
         as audio arriving with no turn open. It answered a question nobody had
         finished asking.
+
+        A closed connection is a dead uplink for talk start and talk end just as
+        much as for audio, so all three are sent through the same guard. Sending
+        the control frames outside it cost the rest of the session: the write
+        raised, this thread died with a traceback, and every later turn queued
+        frames nobody was left to send, so it waited out the full timeout with
+        no answer instead of reporting the lost connection the downlink had
+        already seen.
         """
         while True:
             item = self.up_q.get()
             if item is None:
                 return
             if item is START:
-                self.uplink.send(frame.TALK_START)
-                continue
-            if item is END:
+                kind, payload = frame.TALK_START, b""
+            elif item is END:
                 with self.lock:
                     self.turn["wire_end"] = time.monotonic()
-                self.uplink.send(frame.TALK_END)
-                continue
+                kind, payload = frame.TALK_END, b""
+            else:
+                kind, payload = frame.AUDIO, item
             try:
-                self.uplink.send(frame.AUDIO, item)
+                self.uplink.send(kind, payload)
             except (BrokenPipeError, OSError):
                 return
 
@@ -570,6 +578,14 @@ class Client:
                 got = self.reader.read()
             except (frame.FrameError, OSError) as exc:
                 say("client: connection lost: {}".format(exc))
+                # Recorded as well as said, because the turn record is what a
+                # latency figure is read from later and stderr is not. A dropped
+                # connection that only says answered: false is indistinguishable
+                # there from a turn the model declined to answer. setdefault
+                # because a relay that named the failure first said it better.
+                with self.lock:
+                    self.turn.setdefault(
+                        "failed", "the connection was lost: {}".format(exc))
                 break
             if got is None:
                 break
@@ -681,9 +697,10 @@ class Client:
             "tool_calls": turn.get("tool_calls", 0),
             "queued_note": turn.get("queued"),
             "interrupted": bool(turn.get("interrupted")),
-            # Why a turn has no answer, when the relay knows. A results file
-            # that only says answered: false invites the reader to average an
-            # infrastructure failure into a latency figure.
+            # Why a turn has no answer, when either end knows: the relay names a
+            # failed turn, and this end names a connection that went during one.
+            # A results file that only says answered: false invites the reader to
+            # average an infrastructure failure into a latency figure.
             "relay_error": turn.get("failed"),
             # The number this build exists to produce: the captain stopped
             # talking, and this many seconds later sound came out.

--- a/bin/fm-voice-client.py
+++ b/bin/fm-voice-client.py
@@ -104,6 +104,9 @@ LISTEN_MODES = (PUSH_TO_TALK, OPEN_MIC)
 # discarded, up to this much. Past it, the stream is not a relay.
 MAX_PREAMBLE = 8192
 
+# The two ends of a turn, queued rather than written, for the reason _sender
+# gives: everything the uplink carries has to stay in the order it happened in.
+START = object()
 END = object()
 
 
@@ -532,11 +535,25 @@ class Client:
     # -------------------------------------------------------------------- threads
 
     def _sender(self):
-        """Own the uplink audio, so talk end is never sent ahead of the last chunk."""
+        """Own the whole uplink, so nothing on it can be sent out of order.
+
+        Every frame a turn consists of goes through this one queue, talk start
+        included. Sending the start from the turn thread instead cost a turn: a
+        turn that ends with no answer to wait for - a failed turn, or the model
+        finishing with the session - returns as soon as it is told, while the last
+        chunk and the talk end may still be here. The next talk start would then
+        overtake them, the relay would open a fresh session and apply the previous
+        turn's talk end to it, and the captain's entire next question was dropped
+        as audio arriving with no turn open. It answered a question nobody had
+        finished asking.
+        """
         while True:
             item = self.up_q.get()
             if item is None:
                 return
+            if item is START:
+                self.uplink.send(frame.TALK_START)
+                continue
             if item is END:
                 with self.lock:
                     self.turn["wire_end"] = time.monotonic()
@@ -620,7 +637,7 @@ class Client:
         self.playback.turn_reset()
         self.reply_done.clear()
         before = self.playback.bytes
-        self.uplink.send(frame.TALK_START)
+        self.up_q.put(START)
 
         # Unreachable while parse_args refuses open-mic, and kept so that turning
         # the mode on later is a small change. It is still missing the turn

--- a/bin/fm-voice-client.py
+++ b/bin/fm-voice-client.py
@@ -360,6 +360,44 @@ class MicCapture:
             pass
 
 
+# ------------------------------------------------------------------- audio setup
+
+
+def open_file_end(flag, path, build):
+    """Open a file-backed end of the audio, naming the path and the flag for it.
+
+    The file ends are the ones this host can run, and they are what every figure
+    in docs/voice-relay.md was measured with, so their refusal is the one most
+    likely to be read. It stays an OSError, which main prints as it stands, and it
+    names the path and the flag that chose it. Reporting a mistyped path as a
+    device failure would send the reader to the device flags instead of to the
+    path.
+    """
+    try:
+        return build()
+    except OSError as exc:
+        raise OSError("could not open {}, given as {}: {}".format(
+            path, flag, exc))
+
+
+def open_device_end(flag, build):
+    """Open a device-backed end of the audio, or refuse in one line with a next step.
+
+    sounddevice raises its own error types and is an optional import, so neither
+    shape reaches main as an OSError on its own and a traceback is what the
+    captain would otherwise get. Whether this refusal ever fires, and what a real
+    device says when it does, is unverified for the reason the module docstring
+    gives.
+    """
+    try:
+        return build()
+    except Exception as exc:                       # noqa: BLE001
+        raise DeviceError(
+            "could not open the audio device ({}: {}). Name another one with {}, "
+            "or run without a device using --in-file and --out-file".format(
+                type(exc).__name__, exc, flag))
+
+
 # ------------------------------------------------------------------------ client
 
 
@@ -410,25 +448,23 @@ class Client:
         self.reader = frame.Reader(self.proc.stdout)
         self.uplink = Uplink(self.proc.stdin)
 
-        try:
-            if self.options.out_file:
-                self.playback = FilePlayback(self.options.out_file)
-            else:
-                self.playback = SpeakerPlayback(self.options.output_device)
+        if self.options.out_file:
+            self.playback = open_file_end(
+                "--out-file", self.options.out_file,
+                lambda: FilePlayback(self.options.out_file))
+        else:
+            self.playback = open_device_end(
+                "--output-device",
+                lambda: SpeakerPlayback(self.options.output_device))
 
-            if self.options.in_file:
-                self.capture = FileCapture(self.options.in_file)
-            else:
-                self.capture = MicCapture(self.options.input_device)
-        except Exception as exc:                   # noqa: BLE001
-            # A named refusal with a next step, like every other refusal here.
-            # sounddevice raises its own error types and is an optional import,
-            # so neither shape reaches main as an OSError on its own.
-            raise DeviceError(
-                "could not open the audio devices ({}: {}). Name another device "
-                "with --input-device or --output-device, or run without them "
-                "using --in-file and --out-file".format(
-                    type(exc).__name__, exc))
+        if self.options.in_file:
+            self.capture = open_file_end(
+                "--in-file", self.options.in_file,
+                lambda: FileCapture(self.options.in_file))
+        else:
+            self.capture = open_device_end(
+                "--input-device",
+                lambda: MicCapture(self.options.input_device))
         self.capture.start(self.up_q, self.talking)
 
         threading.Thread(target=self._downlink, daemon=True).start()

--- a/bin/fm-voice-relay.py
+++ b/bin/fm-voice-relay.py
@@ -236,7 +236,7 @@ def _expires_at(stamp):
     return when.timestamp()
 
 
-def ambient_credentials(verbose=False, margin=0):
+def ambient_credentials(verbose=False, margin=0, only_source=False):
     """Return (credentials, expiry) from the environment, or None if it has none to give.
 
     None means "ask the profile instead", and there are three ways to get it.
@@ -246,6 +246,13 @@ def ambient_credentials(verbose=False, margin=0):
     And one whose AWS_CREDENTIAL_EXPIRATION has passed, or passes within margin
     seconds, is no longer usable: os.environ cannot get fresher values while
     this process runs, so the only way forward is the profile.
+
+    only_source says there is no profile to ask, which changes what a passed
+    deadline means. The environment is then the only place a credential can come
+    from, so a stale one is still the best answer available, and refusing it
+    would end a live conversation over something only the operator can refresh.
+    AWS says so itself if the credential really is dead. An environment with no
+    keys in it at all is a refusal either way.
 
     Temporary credentials with no stated deadline are reported as
     EXPIRY_UNKNOWN rather than as eternal, because a session token always has a
@@ -263,7 +270,8 @@ def ambient_credentials(verbose=False, margin=0):
     expires = _expires_at(os.environ.get("AWS_CREDENTIAL_EXPIRATION"))
     if expires is None and token:
         expires = EXPIRY_UNKNOWN
-    if expires not in (None, EXPIRY_UNKNOWN) and time.time() + margin >= expires:
+    if (not only_source and expires not in (None, EXPIRY_UNKNOWN)
+            and time.time() + margin >= expires):
         log(verbose, "the credentials in the environment have expired")
         return None
     log(verbose, "using credentials already in the environment")
@@ -311,9 +319,20 @@ def resolve_credentials(profile, verbose=False, margin=0, allow_ambient=True):
     second, so Credentials below owns when this runs and keeps it out of a turn.
     The source is reported because only one of the two can be asked again for
     something fresher, and the cache has to know which it is holding.
+
+    A relay with no profile at all is a supported shape, so the environment gets
+    a second look when there is nothing to escalate to. Giving up on the only
+    source there is would turn "these credentials are getting old" into "this
+    relay is over", which is a worse answer than handing over keys that AWS can
+    refuse for itself.
     """
     if allow_ambient:
         ambient = ambient_credentials(verbose, margin)
+        if ambient is None and not profile:
+            ambient = ambient_credentials(verbose, margin, only_source=True)
+            if ambient is not None:
+                log(verbose, "keeping the credentials in the environment anyway: "
+                             "there is no profile to fall back to")
         if ambient is not None:
             return ambient[0], ambient[1], FROM_ENVIRONMENT
     creds, expires = profile_credentials(profile, verbose)
@@ -343,6 +362,12 @@ class Credentials:
     bound above would be a bound in name only. Once an ambient answer is spent,
     this asks the profile from then on.
 
+    An ambient answer is only ever spent when there IS a profile to spend it on.
+    With no profile the environment is the only source, so the bound becomes a
+    re-read of it rather than an escalation: a relay configured that way keeps
+    answering, and whether the keys still work is between AWS and the operator
+    who exported them.
+
     Every resolution, the first one included, runs in a worker thread, so the
     event loop keeps reading the captain's audio while it happens.
     """
@@ -371,7 +396,7 @@ class Credentials:
     async def get(self):
         async with self._lock:
             if not self._usable():
-                if self._source == FROM_ENVIRONMENT:
+                if self._source == FROM_ENVIRONMENT and self.profile:
                     log(self.verbose, "the credentials from the environment are "
                                       "spent; asking the profile from now on")
                     self._ambient_spent = True
@@ -717,7 +742,11 @@ class Session:
 
         try:
             if name == "get_fleet_status":
-                result = records.fleet_status(home=self.home, scope=self.scope)
+                # Off the loop like the handover below it: the model is told to
+                # call this on every question, and its directory and file reads
+                # would otherwise stop the relay reading the captain's audio.
+                result = await asyncio.to_thread(
+                    records.fleet_status, self.home, self.scope)
             elif name == "hand_over_to_firstmate":
                 request = (arguments.get("request") or "").strip()
                 result = await asyncio.to_thread(

--- a/bin/fm-voice-relay.py
+++ b/bin/fm-voice-relay.py
@@ -584,7 +584,16 @@ class Session:
             log(self.verbose, "close: {}: {}".format(type(exc).__name__, exc))
         if self.reader_task is not None:
             try:
-                await asyncio.wait_for(self.reader_task, timeout=10)
+                # gather collects a reader that died on its own instead of
+                # re-raising it here, the same way the sends above are absorbed.
+                # Awaiting a failed task raises on EVERY await, and close() is
+                # the first statement of renew and of serve's finally, so a
+                # close that re-raises is the difference between one failed turn
+                # and a relay that can never build another session or even say
+                # goodbye to the client.
+                await asyncio.wait_for(
+                    asyncio.gather(self.reader_task, return_exceptions=True),
+                    timeout=10)
             except (asyncio.TimeoutError, asyncio.CancelledError):
                 pass
 
@@ -688,26 +697,42 @@ class Session:
             log(True, "event {}{}".format(name, detail))
 
     async def _read_model(self):
-        while True:
-            try:
-                out = await self.stream.await_output()
-                result = await out[1].receive()
-            except Exception as exc:                   # noqa: BLE001
-                log(self.verbose, "model stream ended: {}: {}".format(
-                    type(exc).__name__, exc))
-                break
-            if result is None:
-                break
-            raw = result.value.bytes_
-            if not raw:
-                continue
-            try:
-                event = json.loads(raw.decode()).get("event", {})
-            except ValueError:
-                continue
-            await self._handle(event)
-        self.ended.set()
-        self.turn_done.set()
+        """Read the model's events until the stream ends, then say the session is over.
+
+        Handling an event reaches back into the model, to answer a tool call, so
+        it can fail on its own rather than only the read can. Either way this
+        session is finished, and the one thing that must still happen is the
+        finally below: a turn waiting on turn_done, and a serve loop watching
+        ended, are how the relay recovers. Leaving them clear is what turned one
+        dropped stream into a relay that never answered again.
+        """
+        try:
+            while True:
+                try:
+                    out = await self.stream.await_output()
+                    result = await out[1].receive()
+                except Exception as exc:               # noqa: BLE001
+                    log(self.verbose, "model stream ended: {}: {}".format(
+                        type(exc).__name__, exc))
+                    break
+                if result is None:
+                    break
+                raw = result.value.bytes_
+                if not raw:
+                    continue
+                try:
+                    event = json.loads(raw.decode()).get("event", {})
+                except ValueError:
+                    continue
+                try:
+                    await self._handle(event)
+                except Exception as exc:               # noqa: BLE001
+                    log(self.verbose, "handling {} failed: {}: {}".format(
+                        ", ".join(event) or "an event", type(exc).__name__, exc))
+                    break
+        finally:
+            self.ended.set()
+            self.turn_done.set()
 
     async def _handle(self, event):
         if self.verbose:

--- a/bin/fm-voice-relay.py
+++ b/bin/fm-voice-relay.py
@@ -39,14 +39,34 @@ recorded in data/speech-to-speech-survey-s2/report.md section 10:
 Read scope, deny list and the handover queue all belong to bin/fm_voice_records.py.
 docs/voice-relay.md is the operator-facing guide and owns the wire contract.
 
+CONFIGURATION. The region, the model and the AWS profile name somebody's account
+and somebody's choices, so this file carries no default for them. Each is read
+from the home's gitignored config/ directory, or from the matching environment
+variable, and a missing one refuses with the path to write rather than reaching
+for a value that belongs to another home. That configuration is also the opt-in:
+an unconfigured home cannot start this relay at all.
+
+  config/voice-region   FM_VOICE_REGION   Bedrock region.        required
+  config/voice-model    FM_VOICE_MODEL    Nova Sonic model id.   required
+  config/voice-profile  FM_VOICE_PROFILE  AWS profile.           optional
+  config/voice-id       FM_VOICE_ID       output voice.          default matthew
+
+An absent profile means the relay uses only credentials that are already in its
+environment, which is what `--profile ""` forces when a config file exists.
+
+On the model: amazon.nova-sonic-v1:0 is marked legacy by AWS and measured 25
+percent slower on the tool-backed path, which is the path this interface actually
+uses, so amazon.nova-2-sonic-v1:0 is what the figures in docs/voice-relay.md were
+taken against.
+
 Usage:
   fm-voice-relay.py [--serve] [options]
   fm-voice-relay.py --self-test <file.pcm> [options]
 
 Options:
-  --region <name>       Bedrock region.              default eu-north-1
-  --model <id>          Nova Sonic model id.         default amazon.nova-2-sonic-v1:0
-  --profile <name>      AWS profile.                 default inthuson-ct-sandbox
+  --region <name>       Bedrock region.              default from config
+  --model <id>          Nova Sonic model id.         default from config
+  --profile <name>      AWS profile.                 default from config
   --voice <id>          output voice.                default matthew
   --home <dir>          firstmate home for records.  default $FM_HOME or this repo
   --scope <name>        override the read scope for this run.
@@ -74,12 +94,15 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import fm_voice_frame as frame              # noqa: E402
 import fm_voice_records as records          # noqa: E402
 
-REGION = "eu-north-1"
-# amazon.nova-sonic-v1:0 is marked legacy by AWS and measured 25 percent slower
-# on the tool-backed path, which is the path this interface actually uses.
-MODEL = "amazon.nova-2-sonic-v1:0"
-PROFILE = "inthuson-ct-sandbox"
+# A voice id names nobody and costs nothing to inherit, so this one has a
+# default. The region, the model and the profile do not; see CONFIGURATION above.
 VOICE = "matthew"
+SETTINGS = {
+    "region": ("voice-region", "FM_VOICE_REGION", "Bedrock region"),
+    "model": ("voice-model", "FM_VOICE_MODEL", "Nova Sonic model id"),
+    "profile": ("voice-profile", "FM_VOICE_PROFILE", "AWS profile"),
+    "voice": ("voice-id", "FM_VOICE_ID", "output voice"),
+}
 
 IN_RATE = 16000
 OUT_RATE = 24000
@@ -173,6 +196,23 @@ def widen_path():
 # same thing as not having one.
 EXPIRY_UNKNOWN = object()
 
+# Where a set of credentials came from. The difference matters to the cache: the
+# profile can be asked again for fresher credentials, and the environment of an
+# already-running process cannot.
+FROM_ENVIRONMENT = "environment"
+FROM_PROFILE = "profile"
+
+
+class CredentialError(Exception):
+    """No usable AWS credentials, and the caller is told which door was tried.
+
+    An ordinary exception rather than SystemExit, because credentials are now
+    resolved lazily and a refresh can therefore land in the middle of a turn.
+    SystemExit would walk straight through the turn boundary in
+    handle_uplink_frame and end the relay over one bad refresh, which is the
+    failure that boundary exists to absorb.
+    """
+
 
 def _expires_at(stamp):
     """Return the expiry as epoch seconds, None when there is none, or EXPIRY_UNKNOWN.
@@ -233,16 +273,13 @@ def ambient_credentials(verbose=False, margin=0):
     }, expires
 
 
-def resolve_credentials(profile, verbose=False, margin=0):
-    """Return (credentials dict, expiry epoch or None), preferring the environment.
-
-    The sandbox profile's credential_process costs about a second, so ambient
-    credentials win while they are usable. It also blocks the caller for that
-    second, so Credentials below owns when this runs and keeps it out of a turn.
-    """
-    ambient = ambient_credentials(verbose, margin)
-    if ambient is not None:
-        return ambient
+def profile_credentials(profile, verbose=False):
+    """Return (credentials, expiry) exported from an AWS profile, or refuse by name."""
+    if not profile:
+        raise CredentialError(
+            "no credentials in the environment and no AWS profile configured: "
+            "write one into config/voice-profile, set FM_VOICE_PROFILE, or "
+            "export AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY")
     log(verbose, "exporting credentials from profile {}".format(profile))
     widen_path()
     done = subprocess.run(
@@ -254,8 +291,8 @@ def resolve_credentials(profile, verbose=False, margin=0):
         stdin=subprocess.DEVNULL,
         capture_output=True, text=True, timeout=60, check=False)
     if done.returncode != 0:
-        raise SystemExit(
-            "fm-voice-relay: could not get credentials for profile {}: {}".format(
+        raise CredentialError(
+            "could not get credentials for profile {}: {}".format(
                 profile, (done.stderr or done.stdout).strip()))
     blob = json.loads(done.stdout)
     return {
@@ -263,6 +300,23 @@ def resolve_credentials(profile, verbose=False, margin=0):
         "aws_secret_access_key": blob["SecretAccessKey"],
         "aws_session_token": blob.get("SessionToken"),
     }, _expires_at(blob.get("Expiration"))
+
+
+def resolve_credentials(profile, verbose=False, margin=0, allow_ambient=True):
+    """Return (credentials, expiry, source), preferring the environment when allowed.
+
+    The sandbox profile's credential_process costs about a second, so ambient
+    credentials win while they are usable. It also blocks the caller for that
+    second, so Credentials below owns when this runs and keeps it out of a turn.
+    The source is reported because only one of the two can be asked again for
+    something fresher, and the cache has to know which it is holding.
+    """
+    if allow_ambient:
+        ambient = ambient_credentials(verbose, margin)
+        if ambient is not None:
+            return ambient[0], ambient[1], FROM_ENVIRONMENT
+    creds, expires = profile_credentials(profile, verbose)
+    return creds, expires, FROM_PROFILE
 
 
 class Credentials:
@@ -281,6 +335,13 @@ class Credentials:
     margin is handed to the resolver as well, because credentials taken from the
     environment cannot be refreshed in place and have to be abandoned for the
     profile once they are that close to the end.
+
+    That abandonment has to be remembered, not just decided. os.environ never
+    gets fresher values while this process runs, so re-reading it after giving up
+    on an ambient credential would hand back the same stale keys forever and the
+    bound above would be a bound in name only. Once an ambient answer is spent,
+    this asks the profile from then on.
+
     Every resolution, the first one included, runs in a worker thread, so the
     event loop keeps reading the captain's audio while it happens.
     """
@@ -292,7 +353,9 @@ class Credentials:
         self.verbose = verbose
         self._creds = None
         self._expires = None
+        self._source = None
         self._resolved = None
+        self._ambient_spent = False
         self._lock = asyncio.Lock()
 
     def _usable(self):
@@ -307,9 +370,13 @@ class Credentials:
     async def get(self):
         async with self._lock:
             if not self._usable():
-                self._creds, self._expires = await asyncio.to_thread(
+                if self._source == FROM_ENVIRONMENT:
+                    log(self.verbose, "the credentials from the environment are "
+                                      "spent; asking the profile from now on")
+                    self._ambient_spent = True
+                self._creds, self._expires, self._source = await asyncio.to_thread(
                     resolve_credentials, self.profile, self.verbose,
-                    self.REFRESH_MARGIN)
+                    self.REFRESH_MARGIN, not self._ambient_spent)
                 self._resolved = time.monotonic()
             return dict(self._creds)
 
@@ -702,7 +769,15 @@ async def renew(session, options, down):
     log(options.verbose, "renewing the session for a new turn")
     await session.close()
     fresh = Session(options, down, session.credentials)
-    await fresh.start()
+    try:
+        await fresh.start()
+    except BaseException:
+        # start() creates the reader task before it sends anything, so a
+        # reconnect that fails part way leaves a live task holding an open
+        # bidirectional stream. Nothing would ever close it, and it would keep
+        # writing into the shared Downlink, so each retry would strand one more.
+        await fresh.close()
+        raise
     down.send_json(frame.NOTICE, {
         "event": "renewed", "connect_seconds": fresh.connect_seconds})
     return fresh
@@ -733,11 +808,20 @@ async def handle_uplink_frame(kind, payload, session, options, down):
     on the stderr the client inherits, and cost the captain a whole session for
     a single bad reconnect. Instead it is named in a notice and the session is
     marked spent, so the next press of the talk key builds a new one and tries
-    again. A failure the model cannot recover from repeats the notice per turn,
-    which is a captain who can hear what is wrong rather than a dead pipe.
+    again. A failure the model cannot recover from is named once per turn, which
+    is a captain who can hear what is wrong rather than a dead pipe.
+
+    Once per TURN and not once per frame: the captain is still holding the talk
+    key when the failure lands, and the rest of that key press is another thirty
+    audio frames a second apart in tenths. Reporting each one would put ten
+    identical lines a second in front of the captain and keep calling into a
+    session that is already gone, so the remainder of a failed turn is dropped
+    where it arrives.
     """
     if kind == frame.QUIT:
         return session, False
+    if session.failed and kind != frame.TALK_START:
+        return session, True
     try:
         if kind == frame.TALK_START:
             if session.failed or session.replies or session.ended.is_set():
@@ -928,10 +1012,19 @@ def parse_args(argv):
         description=__doc__.splitlines()[0])
     parser.add_argument("--serve", action="store_true")
     parser.add_argument("--self-test", metavar="FILE")
-    parser.add_argument("--region", default=REGION)
-    parser.add_argument("--model", default=MODEL)
-    parser.add_argument("--profile", default=PROFILE)
-    parser.add_argument("--voice", default=VOICE)
+    parser.add_argument("--region",
+                        help="Bedrock region; required, from config/voice-region "
+                             "or FM_VOICE_REGION when not given here")
+    parser.add_argument("--model",
+                        help="Nova Sonic model id; required, from config/voice-model "
+                             "or FM_VOICE_MODEL when not given here")
+    parser.add_argument("--profile",
+                        help="AWS profile; optional, from config/voice-profile or "
+                             "FM_VOICE_PROFILE, and empty means the credentials "
+                             "already in the environment")
+    parser.add_argument("--voice",
+                        help="output voice; from config/voice-id or FM_VOICE_ID, "
+                             "default {}".format(VOICE))
     parser.add_argument("--home")
     parser.add_argument("--scope", choices=records.SCOPES)
     parser.add_argument("--tail-ms", type=int, default=TAIL_MS)
@@ -944,13 +1037,34 @@ def parse_args(argv):
     return options
 
 
+def resolve_settings(options):
+    """Fill in what this home configures, refusing rather than guessing.
+
+    Deliberately not part of parse_args: --help and the flags this file can
+    answer for itself must work in a home that has configured nothing, and only
+    a run that is about to reach Bedrock needs to know whose account it is.
+    """
+    home = options.home or records.default_home()
+    options.home = home
+    if not options.region:
+        options.region = records.require_setting(home, *SETTINGS["region"])
+    if not options.model:
+        options.model = records.require_setting(home, *SETTINGS["model"])
+    if options.profile is None:
+        options.profile = records.read_setting(home, *SETTINGS["profile"][:2]) or ""
+    if not options.voice:
+        options.voice = records.read_setting(home, *SETTINGS["voice"][:2]) or VOICE
+    return options
+
+
 def main(argv):
     options = parse_args(argv)
     try:
+        resolve_settings(options)
         if options.self_test:
             return asyncio.run(self_test(options))
         return asyncio.run(serve(options)) or 0
-    except records.RecordError as exc:
+    except (records.RecordError, CredentialError) as exc:
         sys.stderr.write("fm-voice-relay: {}\n".format(exc))
         return 2
     except KeyboardInterrupt:

--- a/bin/fm-voice-relay.py
+++ b/bin/fm-voice-relay.py
@@ -58,6 +58,7 @@ Options:
 import argparse
 import asyncio
 import base64
+import datetime
 import json
 import os
 import queue
@@ -166,12 +167,25 @@ def widen_path():
         os.environ["PATH"] = os.pathsep.join(added + parts)
 
 
+def _expires_at(stamp):
+    """Return an ISO 8601 expiry as epoch seconds, or None when there is none."""
+    if not stamp:
+        return None
+    try:
+        when = datetime.datetime.fromisoformat(str(stamp).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=datetime.timezone.utc)
+    return when.timestamp()
+
+
 def resolve_credentials(profile, verbose=False):
-    """Return AWS credentials as a dict, preferring ones already in the environment.
+    """Return (credentials dict, expiry epoch or None), preferring the environment.
 
     The sandbox profile's credential_process costs about a second, so ambient
-    credentials win when they are present. This runs once per relay start and
-    never inside a turn.
+    credentials win when they are present. It also blocks the caller for that
+    second, so Credentials below owns when this runs and keeps it out of a turn.
     """
     if os.environ.get("AWS_ACCESS_KEY_ID"):
         log(verbose, "using credentials already in the environment")
@@ -179,12 +193,16 @@ def resolve_credentials(profile, verbose=False):
             "aws_access_key_id": os.environ["AWS_ACCESS_KEY_ID"],
             "aws_secret_access_key": os.environ["AWS_SECRET_ACCESS_KEY"],
             "aws_session_token": os.environ.get("AWS_SESSION_TOKEN"),
-        }
+        }, None
     log(verbose, "exporting credentials from profile {}".format(profile))
     widen_path()
     done = subprocess.run(
         ["aws", "configure", "export-credentials", "--profile", profile,
          "--format", "process"],
+        # The relay's own stdin is the captain's audio in --serve mode. A child
+        # that read it would eat frames and desynchronise the uplink, so no
+        # child gets it.
+        stdin=subprocess.DEVNULL,
         capture_output=True, text=True, timeout=60, check=False)
     if done.returncode != 0:
         raise SystemExit(
@@ -195,7 +213,46 @@ def resolve_credentials(profile, verbose=False):
         "aws_access_key_id": blob["AccessKeyId"],
         "aws_secret_access_key": blob["SecretAccessKey"],
         "aws_session_token": blob.get("SessionToken"),
-    }
+    }, _expires_at(blob.get("Expiration"))
+
+
+class Credentials:
+    """The relay's credentials, resolved once and shared by every session it opens.
+
+    A session is rebuilt for every turn, on purpose and for a measured reason
+    (see renew), so resolving per session would charge the credential_process
+    second to each turn after the first. The relay resolves once at start and
+    every later session reuses that answer, so a reconnect costs a reconnect
+    and not a credential fetch.
+
+    Credentials that carry an expiry are refreshed a few minutes ahead of it,
+    because a relay left running outlives them. Every resolution, the first one
+    included, runs in a worker thread, so the event loop keeps reading the
+    captain's audio while it happens.
+    """
+
+    REFRESH_MARGIN = 300
+
+    def __init__(self, profile, verbose=False):
+        self.profile = profile
+        self.verbose = verbose
+        self._creds = None
+        self._expires = None
+        self._lock = asyncio.Lock()
+
+    def _usable(self):
+        if self._creds is None:
+            return False
+        if self._expires is None:
+            return True
+        return time.time() + self.REFRESH_MARGIN < self._expires
+
+    async def get(self):
+        async with self._lock:
+            if not self._usable():
+                self._creds, self._expires = await asyncio.to_thread(
+                    resolve_credentials, self.profile, self.verbose)
+            return dict(self._creds)
 
 
 class Downlink:
@@ -254,9 +311,10 @@ class Downlink:
 class Session:
     """One Nova Sonic bidirectional session, plus the turn bookkeeping around it."""
 
-    def __init__(self, options, down):
+    def __init__(self, options, down, credentials):
         self.options = options
         self.down = down
+        self.credentials = credentials
         self.verbose = options.verbose
         self.prompt = str(uuid.uuid4())
         self.stream = None
@@ -297,7 +355,7 @@ class Session:
             InvokeModelWithBidirectionalStreamOperationInput)
         from aws_sdk_bedrock_runtime.config import AsyncBedrockRuntimeConfig
 
-        creds = resolve_credentials(self.options.profile, self.verbose)
+        creds = await self.credentials.get()
         began = time.monotonic()
         config = await AsyncBedrockRuntimeConfig.resolve(
             endpoint_uri="https://bedrock-runtime.{}.amazonaws.com".format(
@@ -412,8 +470,8 @@ class Session:
 
     # ---------------------------------------------------------------- downlink
 
-    def _mark(self, name):
-        now = time.monotonic()
+    def _mark(self, name, at=None):
+        now = at if at is not None else time.monotonic()
         self.turn.setdefault(name, now)
         base = self.turn.get("talk_end")
         if base is None:
@@ -504,6 +562,14 @@ class Session:
             if stop == "END_TURN":
                 # Trap 1: this, not completionEnd, is the end of the reply.
                 self._mark("reply_end")
+                # first_audio above is stamped when the model event is decoded.
+                # The Downlink knows the later instant when that audio reached
+                # the connection, which is the one the captain hears, so it is
+                # reported too rather than measured and thrown away. It can only
+                # be read once the frame is out, hence here and not there.
+                wire = self.down.first_audio()
+                if wire is not None:
+                    self._mark("first_audio_wire", wire)
                 self.replies += 1
                 self.turn_done.set()
 
@@ -573,7 +639,7 @@ async def renew(session, options, down):
     """
     log(options.verbose, "renewing the session for a new turn")
     await session.close()
-    fresh = Session(options, down)
+    fresh = Session(options, down, session.credentials)
     await fresh.start()
     down.send_json(frame.NOTICE, {
         "event": "renewed", "connect_seconds": fresh.connect_seconds})
@@ -591,17 +657,22 @@ async def serve(options):
     sys.stdout.buffer.write(frame.MAGIC)
     sys.stdout.buffer.flush()
     down = Downlink(sys.stdout.buffer)
-    session = Session(options, down)
+    session = Session(options, down, Credentials(options.profile, options.verbose))
     await session.start()
     down.send_json(frame.NOTICE, {
         "event": "ready", "model": options.model, "region": options.region,
         "read_scope": session.scope, "tail_ms": options.tail_ms,
         "connect_seconds": session.connect_seconds})
 
+    status = 0
     try:
         while True:
             head = await reader.readexactly(frame.HEADER.size)
             kind, length = frame.HEADER.unpack(head)
+            # Before the payload read, not after: a desynchronised uplink offers
+            # a length of up to 4 GiB, and waiting for that many bytes is a hang
+            # rather than the loud error this format promises.
+            frame.check_header(kind, length)
             payload = await reader.readexactly(length) if length else b""
             if kind == frame.TALK_START:
                 if session.replies or session.ended.is_set():
@@ -620,10 +691,16 @@ async def serve(options):
                 break
     except (asyncio.IncompleteReadError, ConnectionResetError):
         log(options.verbose, "client closed the connection")
+    except frame.FrameError as exc:
+        sys.stderr.write(
+            "fm-voice-relay: the uplink is not a frame stream any more: {}\n"
+            .format(exc))
+        status = 2
     finally:
         await session.close()
         down.send(frame.BYE)
         down.close()
+    return status
 
 
 async def self_test(options):
@@ -669,7 +746,7 @@ async def self_test(options):
             return self.first
 
     sink = Sink()
-    session = Session(options, sink)
+    session = Session(options, sink, Credentials(options.profile, options.verbose))
     await session.start()
     await session.talk_start()
     # Paced at real time, because a file pushed as fast as the socket accepts it
@@ -723,6 +800,7 @@ async def self_test(options):
         "tool_names": session.tool_names,
         "tool_use_s": since("tool_use"),
         "first_audio_s": since("first_audio"),
+        "first_audio_wire_s": since("first_audio_wire"),
         "reply_end_s": since("reply_end"),
         "reply_audio_seconds": round(sink.bytes / float(OUT_RATE * 2), 3),
         "answered": sink.bytes > 0,

--- a/bin/fm-voice-relay.py
+++ b/bin/fm-voice-relay.py
@@ -37,7 +37,8 @@ recorded in data/speech-to-speech-survey-s2/report.md section 10:
      silence is sent unpaced. The 400 ms default is margin that costs nothing.
 
 Read scope, deny list and the handover queue all belong to bin/fm_voice_records.py.
-docs/voice-relay.md is the operator-facing guide and owns the wire contract.
+bin/fm_voice_frame.py owns the wire contract between the two machines, and
+docs/voice-relay.md is the operator-facing guide.
 
 CONFIGURATION. The region, the model and the AWS profile name somebody's account
 and somebody's choices, so this file carries no default for them. Each is read

--- a/bin/fm-voice-relay.py
+++ b/bin/fm-voice-relay.py
@@ -55,10 +55,10 @@ An absent profile means the relay uses only credentials that are already in its
 environment. An empty FM_VOICE_PROFILE, or an empty `--profile ""`, forces that
 even when config/voice-profile exists.
 
-On the model: amazon.nova-sonic-v1:0 is marked legacy by AWS and measured 25
-percent slower on the tool-backed path, which is the path this interface actually
-uses, so amazon.nova-2-sonic-v1:0 is what the figures in docs/voice-relay.md were
-taken against.
+On choosing the model: the first-generation Nova Sonic model is marked legacy by
+AWS and measured 25 percent slower on the tool-backed path, which is the path this
+interface actually uses, so the figures in docs/voice-relay.md were taken against
+the second generation, which that document names.
 
 Usage:
   fm-voice-relay.py [--serve] [options]
@@ -335,7 +335,20 @@ def resolve_credentials(profile, verbose=False, margin=0, allow_ambient=True):
                              "there is no profile to fall back to")
         if ambient is not None:
             return ambient[0], ambient[1], FROM_ENVIRONMENT
-    creds, expires = profile_credentials(profile, verbose)
+    try:
+        creds, expires = profile_credentials(profile, verbose)
+    except CredentialError:
+        # The profile was the escalation and it refused. Whatever the environment
+        # still holds is older than we would like, which is why the profile was
+        # asked at all, but it is a real answer and AWS refuses it for itself if
+        # it is dead. Ending the conversation instead would spend the captain's
+        # session on a preference. An environment with nothing in it re-raises.
+        ambient = ambient_credentials(verbose, margin, only_source=True)
+        if ambient is None:
+            raise
+        log(verbose, "the profile refused, so falling back to the credentials "
+                     "still in the environment")
+        return ambient[0], ambient[1], FROM_ENVIRONMENT
     return creds, expires, FROM_PROFILE
 
 
@@ -396,13 +409,21 @@ class Credentials:
     async def get(self):
         async with self._lock:
             if not self._usable():
-                if self._source == FROM_ENVIRONMENT and self.profile:
+                spend = self._source == FROM_ENVIRONMENT and bool(self.profile)
+                creds, expires, source = await asyncio.to_thread(
+                    resolve_credentials, self.profile, self.verbose,
+                    self.REFRESH_MARGIN, not (self._ambient_spent or spend))
+                # Latched only now, and only if the profile is what answered. A
+                # profile that cannot answer raises out of the line above or is
+                # answered for by the environment, and latching either of those
+                # would abandon credentials this process is still holding on the
+                # strength of a source that just refused, turning one failed
+                # refresh into every later turn.
+                if spend and source == FROM_PROFILE:
                     log(self.verbose, "the credentials from the environment are "
                                       "spent; asking the profile from now on")
                     self._ambient_spent = True
-                self._creds, self._expires, self._source = await asyncio.to_thread(
-                    resolve_credentials, self.profile, self.verbose,
-                    self.REFRESH_MARGIN, not self._ambient_spent)
+                self._creds, self._expires, self._source = creds, expires, source
                 self._resolved = time.monotonic()
             return dict(self._creds)
 
@@ -589,9 +610,21 @@ class Session:
         log(self.verbose, "talk start")
 
     async def audio(self, pcm):
-        """Forward captured audio, chunked the way the measurements were taken."""
+        """Forward captured audio, chunked the way the measurements were taken.
+
+        Audio with no turn open is dropped rather than opening one. Both listen
+        modes send a talk start before any audio, so this never fires in ordinary
+        use, but the capture callback races the key release: a chunk already past
+        the gate check can reach the relay behind the talk end. Opening a block
+        for it would append the captain's stray tenth of a second to a session
+        that is already generating its reply, which is the unconditional barge-in
+        the per-turn reconnect exists to avoid, and it would leave that block open
+        so the next turn skipped its own reset and its first-audio mark.
+        """
         if self.audio_content is None:
-            await self.talk_start()
+            log(self.verbose, "dropping {} bytes of audio that arrived with no "
+                              "turn open".format(len(pcm)))
+            return
         for at in range(0, len(pcm), CHUNK):
             await self._send({"audioInput": {
                 "promptName": self.prompt, "contentName": self.audio_content,

--- a/bin/fm-voice-relay.py
+++ b/bin/fm-voice-relay.py
@@ -66,6 +66,7 @@ import subprocess
 import sys
 import threading
 import time
+import traceback
 import uuid
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -194,20 +195,54 @@ def _expires_at(stamp):
     return when.timestamp()
 
 
-def resolve_credentials(profile, verbose=False):
+def ambient_credentials(verbose=False, margin=0):
+    """Return (credentials, expiry) from the environment, or None if it has none to give.
+
+    None means "ask the profile instead", and there are three ways to get it.
+    An environment with no key id at all is the ordinary ssh case. One carrying
+    a key id without a secret beside it is a half-set variable, which is a
+    mistake worth naming rather than a KeyError from inside a worker thread.
+    And one whose AWS_CREDENTIAL_EXPIRATION has passed, or passes within margin
+    seconds, is no longer usable: os.environ cannot get fresher values while
+    this process runs, so the only way forward is the profile.
+
+    Temporary credentials with no stated deadline are reported as
+    EXPIRY_UNKNOWN rather than as eternal, because a session token always has a
+    deadline whether or not the shell that exported it said so.
+    """
+    key = os.environ.get("AWS_ACCESS_KEY_ID")
+    if not key:
+        return None
+    secret = os.environ.get("AWS_SECRET_ACCESS_KEY")
+    if not secret:
+        log(verbose, "AWS_ACCESS_KEY_ID is set with no AWS_SECRET_ACCESS_KEY "
+                     "beside it, so the environment is being ignored")
+        return None
+    token = os.environ.get("AWS_SESSION_TOKEN")
+    expires = _expires_at(os.environ.get("AWS_CREDENTIAL_EXPIRATION"))
+    if expires is None and token:
+        expires = EXPIRY_UNKNOWN
+    if expires not in (None, EXPIRY_UNKNOWN) and time.time() + margin >= expires:
+        log(verbose, "the credentials in the environment have expired")
+        return None
+    log(verbose, "using credentials already in the environment")
+    return {
+        "aws_access_key_id": key,
+        "aws_secret_access_key": secret,
+        "aws_session_token": token,
+    }, expires
+
+
+def resolve_credentials(profile, verbose=False, margin=0):
     """Return (credentials dict, expiry epoch or None), preferring the environment.
 
     The sandbox profile's credential_process costs about a second, so ambient
-    credentials win when they are present. It also blocks the caller for that
+    credentials win while they are usable. It also blocks the caller for that
     second, so Credentials below owns when this runs and keeps it out of a turn.
     """
-    if os.environ.get("AWS_ACCESS_KEY_ID"):
-        log(verbose, "using credentials already in the environment")
-        return {
-            "aws_access_key_id": os.environ["AWS_ACCESS_KEY_ID"],
-            "aws_secret_access_key": os.environ["AWS_SECRET_ACCESS_KEY"],
-            "aws_session_token": os.environ.get("AWS_SESSION_TOKEN"),
-        }, None
+    ambient = ambient_credentials(verbose, margin)
+    if ambient is not None:
+        return ambient
     log(verbose, "exporting credentials from profile {}".format(profile))
     widen_path()
     done = subprocess.run(
@@ -242,7 +277,10 @@ class Credentials:
     Credentials that carry an expiry are refreshed a few minutes ahead of it,
     because a relay left running outlives them. One whose expiry cannot be read
     is held for that same margin and no longer, so an unreadable deadline costs
-    an occasional resolution rather than every session after the deadline.
+    an occasional resolution rather than every session after the deadline. The
+    margin is handed to the resolver as well, because credentials taken from the
+    environment cannot be refreshed in place and have to be abandoned for the
+    profile once they are that close to the end.
     Every resolution, the first one included, runs in a worker thread, so the
     event loop keeps reading the captain's audio while it happens.
     """
@@ -270,7 +308,8 @@ class Credentials:
         async with self._lock:
             if not self._usable():
                 self._creds, self._expires = await asyncio.to_thread(
-                    resolve_credentials, self.profile, self.verbose)
+                    resolve_credentials, self.profile, self.verbose,
+                    self.REFRESH_MARGIN)
                 self._resolved = time.monotonic()
             return dict(self._creds)
 
@@ -345,6 +384,9 @@ class Session:
         # Replies this session has finished. One is the most it should ever
         # deliver; see serve() for why a second turn gets a new session.
         self.replies = 0
+        # Set when a call into the model raised, which makes this session spent
+        # whether or not it ever answered. handle_uplink_frame owns it.
+        self.failed = False
         # Which tools ran, in order. The handover boundary is the whole point of
         # this relay, so "it called hand_over_to_firstmate and did not answer
         # for firstmate" has to be evidence in the run record, not an inference
@@ -681,6 +723,42 @@ async def read_uplink_frame(reader):
     return kind, payload
 
 
+async def handle_uplink_frame(kind, payload, session, options, down):
+    """Act on one frame from the client. Returns (session to use next, keep serving).
+
+    Every branch below reaches the model, and the model side fails on its own:
+    a reconnect can be throttled, a token can expire between turns, a stream can
+    drop. Because the relay rebuilds the session on every turn by design, one
+    such failure would otherwise leave the loop, end the relay with a traceback
+    on the stderr the client inherits, and cost the captain a whole session for
+    a single bad reconnect. Instead it is named in a notice and the session is
+    marked spent, so the next press of the talk key builds a new one and tries
+    again. A failure the model cannot recover from repeats the notice per turn,
+    which is a captain who can hear what is wrong rather than a dead pipe.
+    """
+    if kind == frame.QUIT:
+        return session, False
+    try:
+        if kind == frame.TALK_START:
+            if session.failed or session.replies or session.ended.is_set():
+                session = await renew(session, options, down)
+            await session.talk_start()
+        elif kind == frame.AUDIO:
+            await session.audio(payload)
+        elif kind == frame.TALK_END:
+            await session.talk_end()
+        else:
+            log(options.verbose, "ignoring uplink kind {!r}".format(kind))
+    except Exception as exc:                       # noqa: BLE001
+        session.failed = True
+        log(options.verbose, "turn failed: {}: {}".format(
+            type(exc).__name__, exc))
+        down.send_json(frame.NOTICE, {
+            "event": "turn-failed",
+            "error": "{}: {}".format(type(exc).__name__, exc)})
+    return session, True
+
+
 async def serve(options):
     """Relay frames between the client on stdin/stdout and one Nova Sonic session."""
     loop = asyncio.get_running_loop()
@@ -703,19 +781,14 @@ async def serve(options):
     try:
         while True:
             kind, payload = await read_uplink_frame(reader)
-            if kind == frame.TALK_START:
-                if session.replies or session.ended.is_set():
-                    session = await renew(session, options, down)
-                await session.talk_start()
-            elif kind == frame.AUDIO:
-                await session.audio(payload)
-            elif kind == frame.TALK_END:
-                await session.talk_end()
-            elif kind == frame.QUIT:
+            session, serving = await handle_uplink_frame(
+                kind, payload, session, options, down)
+            if not serving:
                 break
-            else:
-                log(options.verbose, "ignoring downlink kind {!r}".format(kind))
-            if session.ended.is_set():
+            # A session already marked spent is about to be replaced on the next
+            # talk key, so its stream closing is expected rather than the end of
+            # the relay's usefulness.
+            if session.ended.is_set() and not session.failed:
                 down.send_json(frame.NOTICE, {"event": "session-ended"})
                 break
     except (asyncio.IncompleteReadError, ConnectionResetError):
@@ -882,6 +955,15 @@ def main(argv):
         return 2
     except KeyboardInterrupt:
         return 130
+    except Exception as exc:                       # noqa: BLE001
+        # The captain reads this stderr over SSH, so a failure that gets this
+        # far says what it was in one line. --verbose still gets the traceback,
+        # because whoever passed it is debugging rather than talking.
+        sys.stderr.write("fm-voice-relay: {}: {}\n".format(
+            type(exc).__name__, exc))
+        if options.verbose:
+            traceback.print_exc()
+        return 2
 
 
 if __name__ == "__main__":

--- a/bin/fm-voice-relay.py
+++ b/bin/fm-voice-relay.py
@@ -1,0 +1,774 @@
+#!/usr/bin/env python3
+"""fm-voice-relay.py - hold the Nova Sonic session on this desktop, on behalf of the laptop.
+
+The captain talks into their laptop. The laptop captures audio and streams it
+over the SSH connection it already has to this desktop. This relay holds the
+Bedrock bidirectional session, answers the model's tool calls from firstmate's
+records, and streams the spoken reply back down the same connection. AWS
+credentials therefore stay on this desktop and never go near the laptop, which
+is the whole reason for the shape.
+
+The voice agent this relay runs is NOT firstmate. It stands in front of
+firstmate: it answers questions about the fleet from the records, and when the
+captain asks for real work it says out loud that it is handing the request over
+and then queues it. It never claims to have done the work.
+
+Modes:
+  --serve            read fm_voice_frame frames on stdin, write them on stdout.
+                     This is what the laptop client runs over SSH, and the
+                     default when no mode is given.
+  --self-test FILE   feed one raw 16 kHz PCM file into a session as if it had
+                     arrived from the client, print the timings as JSON, exit.
+                     This is the control measurement for the relay path, and it
+                     needs no client, no SSH and no microphone.
+
+The two traps this code already avoids, both found the expensive way and
+recorded in data/speech-to-speech-survey-s2/report.md section 10:
+
+  1. completionEnd does not arrive on its own. The model holds the session open
+     waiting for more speech. The real "the reply is finished" signal is a
+     contentEnd carrying stopReason END_TURN.
+  2. Audio with no trailing silence is truncated and never answered, even when
+     contentEnd follows immediately. A push-to-talk release supplies no trailing
+     silence at all, so this relay appends its own on talk end. --tail-ms sets
+     how much. Measured here, the tail is a content requirement and not a time
+     one: nothing was answered at 0 or 100 ms, everything was answered from
+     200 ms up, and 200 through 800 ms all landed in the same spread because the
+     silence is sent unpaced. The 400 ms default is margin that costs nothing.
+
+Read scope, deny list and the handover queue all belong to bin/fm_voice_records.py.
+docs/voice-relay.md is the operator-facing guide and owns the wire contract.
+
+Usage:
+  fm-voice-relay.py [--serve] [options]
+  fm-voice-relay.py --self-test <file.pcm> [options]
+
+Options:
+  --region <name>       Bedrock region.              default eu-north-1
+  --model <id>          Nova Sonic model id.         default amazon.nova-2-sonic-v1:0
+  --profile <name>      AWS profile.                 default inthuson-ct-sandbox
+  --voice <id>          output voice.                default matthew
+  --home <dir>          firstmate home for records.  default $FM_HOME or this repo
+  --scope <name>        override the read scope for this run.
+  --tail-ms <int>       silence appended on talk end. default 400
+  --turn-timeout <sec>  how long --self-test waits.   default 40
+  --verbose             log the session to stderr.
+"""
+
+import argparse
+import asyncio
+import base64
+import json
+import os
+import queue
+import subprocess
+import sys
+import threading
+import time
+import uuid
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import fm_voice_frame as frame              # noqa: E402
+import fm_voice_records as records          # noqa: E402
+
+REGION = "eu-north-1"
+# amazon.nova-sonic-v1:0 is marked legacy by AWS and measured 25 percent slower
+# on the tool-backed path, which is the path this interface actually uses.
+MODEL = "amazon.nova-2-sonic-v1:0"
+PROFILE = "inthuson-ct-sandbox"
+VOICE = "matthew"
+
+IN_RATE = 16000
+OUT_RATE = 24000
+# 3200 bytes is 100 ms at 16 kHz 16-bit mono, the chunk size the survey measured
+# its timings with. Keeping it identical keeps those numbers comparable.
+CHUNK = 3200
+BYTES_PER_MS_IN = IN_RATE * 2 // 1000
+
+# Push-to-talk supplies no trailing silence, and trap 2 above means a turn with
+# none is never answered. 400 ms is the measured floor plus one chunk of margin;
+# see docs/voice-relay.md for the runs behind it.
+TAIL_MS = 400
+
+SYSTEM_PROMPT = (
+    "You are the captain's voice assistant. You are NOT the first mate, and you "
+    "must never claim to be. You stand in front of the first mate and you are "
+    "the captain's spoken way of reaching it.\n"
+    "\n"
+    "When the captain asks how things are going, what is in flight, what is "
+    "waiting on them, or whether anything is ready to review, call "
+    "get_fleet_status and answer from what it returns. Give counts and at most a "
+    "couple of names. Never invent a number, a name or a pull request. If the "
+    "tool says detail is withheld, say the detail is not available by voice.\n"
+    "\n"
+    "Call get_fleet_status every single time the captain asks, including when "
+    "they asked a moment ago. The records change while you are talking, and an "
+    "answer repeated from memory is a stale answer given confidently, which is "
+    "worse than a slow one.\n"
+    "\n"
+    "When the captain asks for actual work, anything that would change code, "
+    "open a pull request, investigate a bug, or start a job, you do not do it "
+    "and you do not pretend to. Say out loud that you are handing it to the "
+    "first mate, then call hand_over_to_firstmate with the captain's request in "
+    "their own words. Then confirm it is queued. Never say you have done, "
+    "started, fixed or built anything yourself.\n"
+    "\n"
+    "Speak in one or two short sentences. You are being listened to, not read."
+)
+
+TOOLS = {"tools": [
+    {"toolSpec": {
+        "name": "get_fleet_status",
+        "description": (
+            "Read the first mate's durable records: how many jobs are in "
+            "flight, how many decisions are waiting on the captain, how many "
+            "pull requests are open, and the names of a few of them."),
+        "inputSchema": {"json": json.dumps(
+            {"type": "object", "properties": {}, "required": []})},
+    }},
+    {"toolSpec": {
+        "name": "hand_over_to_firstmate",
+        "description": (
+            "Hand a request for real work to the first mate, which will pick it "
+            "up at its next check. Use this for anything you cannot answer from "
+            "the records. It queues the request and does not do the work."),
+        "inputSchema": {"json": json.dumps({
+            "type": "object",
+            "properties": {"request": {
+                "type": "string",
+                "description": "The captain's request, in the captain's own words.",
+            }},
+            "required": ["request"],
+        })},
+    }},
+]}
+
+
+def log(enabled, message):
+    if enabled:
+        sys.stderr.write("relay: {}\n".format(message))
+        sys.stderr.flush()
+
+
+def widen_path():
+    """Put the toolbox directories on PATH, as bin/fm-inbox.sh does and for the same reason.
+
+    `ssh host command` gets no login shell, so it gets no ~/.toolbox/bin. The
+    sandbox profile's credential_process is the bare word `ada`, so without this
+    the relay starts, connects to nothing, and reports a missing file. That is
+    the normal way this relay is launched, so it has to hold here.
+    """
+    extra = [os.path.expanduser(p) for p in ("~/.toolbox/bin", "~/.local/bin")]
+    parts = os.environ.get("PATH", "").split(os.pathsep)
+    added = [p for p in extra if os.path.isdir(p) and p not in parts]
+    if added:
+        os.environ["PATH"] = os.pathsep.join(added + parts)
+
+
+def resolve_credentials(profile, verbose=False):
+    """Return AWS credentials as a dict, preferring ones already in the environment.
+
+    The sandbox profile's credential_process costs about a second, so ambient
+    credentials win when they are present. This runs once per relay start and
+    never inside a turn.
+    """
+    if os.environ.get("AWS_ACCESS_KEY_ID"):
+        log(verbose, "using credentials already in the environment")
+        return {
+            "aws_access_key_id": os.environ["AWS_ACCESS_KEY_ID"],
+            "aws_secret_access_key": os.environ["AWS_SECRET_ACCESS_KEY"],
+            "aws_session_token": os.environ.get("AWS_SESSION_TOKEN"),
+        }
+    log(verbose, "exporting credentials from profile {}".format(profile))
+    widen_path()
+    done = subprocess.run(
+        ["aws", "configure", "export-credentials", "--profile", profile,
+         "--format", "process"],
+        capture_output=True, text=True, timeout=60, check=False)
+    if done.returncode != 0:
+        raise SystemExit(
+            "fm-voice-relay: could not get credentials for profile {}: {}".format(
+                profile, (done.stderr or done.stdout).strip()))
+    blob = json.loads(done.stdout)
+    return {
+        "aws_access_key_id": blob["AccessKeyId"],
+        "aws_secret_access_key": blob["SecretAccessKey"],
+        "aws_session_token": blob.get("SessionToken"),
+    }
+
+
+class Downlink:
+    """Write frames to the client from one dedicated thread.
+
+    A blocking write to a stalled SSH channel must not stop the relay reading
+    the captain's audio or the model's output, and the moment a reply byte is
+    actually handed to the connection is the only honest place to timestamp it.
+    Both of those want the writes off the event loop, so they live here.
+    """
+
+    def __init__(self, stream):
+        self._stream = stream
+        self._queue = queue.Queue()
+        self._first_audio = None
+        self._lock = threading.Lock()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def _run(self):
+        writer = frame.Writer(self._stream)
+        while True:
+            item = self._queue.get()
+            if item is None:
+                return
+            kind, payload = item
+            try:
+                writer.send(kind, payload)
+            except (BrokenPipeError, ValueError, OSError):
+                return
+            if kind == frame.AUDIO:
+                with self._lock:
+                    if self._first_audio is None:
+                        self._first_audio = time.monotonic()
+
+    def send(self, kind, payload=b""):
+        self._queue.put((kind, payload))
+
+    def send_json(self, kind, obj):
+        self.send(kind, json.dumps(obj, separators=(",", ":")).encode("utf-8"))
+
+    def arm_turn(self):
+        """Forget the previous turn's first-audio mark."""
+        with self._lock:
+            self._first_audio = None
+
+    def first_audio(self):
+        with self._lock:
+            return self._first_audio
+
+    def close(self):
+        self._queue.put(None)
+        self._thread.join(timeout=5)
+
+
+class Session:
+    """One Nova Sonic bidirectional session, plus the turn bookkeeping around it."""
+
+    def __init__(self, options, down):
+        self.options = options
+        self.down = down
+        self.verbose = options.verbose
+        self.prompt = str(uuid.uuid4())
+        self.stream = None
+        self.reader_task = None
+        self.audio_content = None
+        self.turn = {}
+        self.tool_calls = 0
+        # Replies this session has finished. One is the most it should ever
+        # deliver; see serve() for why a second turn gets a new session.
+        self.replies = 0
+        # Which tools ran, in order. The handover boundary is the whole point of
+        # this relay, so "it called hand_over_to_firstmate and did not answer
+        # for firstmate" has to be evidence in the run record, not an inference
+        # from a count.
+        self.tool_names = []
+        self.ended = asyncio.Event()
+        self.turn_done = asyncio.Event()
+        self.home = options.home or records.default_home()
+        self.scope = options.scope or records.read_scope(self.home)
+        self.root = os.path.dirname(os.path.abspath(__file__))
+
+    # ---------------------------------------------------------------- protocol
+
+    def _event(self, obj):
+        from aws_sdk_bedrock_runtime.models import (
+            BidirectionalInputPayloadPart,
+            InvokeModelWithBidirectionalStreamInputChunk)
+        return InvokeModelWithBidirectionalStreamInputChunk(
+            value=BidirectionalInputPayloadPart(
+                bytes_=json.dumps({"event": obj}).encode()))
+
+    async def _send(self, obj):
+        await self.stream.input_stream.send(self._event(obj))
+
+    async def start(self):
+        from aws_sdk_bedrock_runtime.client import (
+            AsyncBedrockRuntimeClient,
+            InvokeModelWithBidirectionalStreamOperationInput)
+        from aws_sdk_bedrock_runtime.config import AsyncBedrockRuntimeConfig
+
+        creds = resolve_credentials(self.options.profile, self.verbose)
+        began = time.monotonic()
+        config = await AsyncBedrockRuntimeConfig.resolve(
+            endpoint_uri="https://bedrock-runtime.{}.amazonaws.com".format(
+                self.options.region),
+            region=self.options.region, **creds)
+        client = AsyncBedrockRuntimeClient(config=config)
+        self.stream = await client.invoke_model_with_bidirectional_stream(
+            InvokeModelWithBidirectionalStreamOperationInput(
+                model_id=self.options.model))
+        self.connect_seconds = round(time.monotonic() - began, 3)
+        self.reader_task = asyncio.create_task(self._read_model())
+
+        await self._send({"sessionStart": {"inferenceConfiguration": {
+            "maxTokens": 512, "topP": 0.9, "temperature": 0.7}}})
+        await self._send({"promptStart": {
+            "promptName": self.prompt,
+            "textOutputConfiguration": {"mediaType": "text/plain"},
+            "audioOutputConfiguration": {
+                "mediaType": "audio/lpcm", "sampleRateHertz": OUT_RATE,
+                "sampleSizeBits": 16, "channelCount": 1,
+                "voiceId": self.options.voice, "encoding": "base64",
+                "audioType": "SPEECH"},
+            "toolUseOutputConfiguration": {"mediaType": "application/json"},
+            "toolConfiguration": TOOLS}})
+        content = str(uuid.uuid4())
+        await self._send({"contentStart": {
+            "promptName": self.prompt, "contentName": content, "type": "TEXT",
+            "interactive": True, "role": "SYSTEM",
+            "textInputConfiguration": {"mediaType": "text/plain"}}})
+        await self._send({"textInput": {
+            "promptName": self.prompt, "contentName": content,
+            "content": SYSTEM_PROMPT}})
+        await self._send({"contentEnd": {
+            "promptName": self.prompt, "contentName": content}})
+        log(self.verbose, "session up in {}s, read scope {}".format(
+            self.connect_seconds, self.scope))
+
+    async def close(self):
+        if self.stream is None:
+            return
+        try:
+            if self.audio_content:
+                await self._send({"contentEnd": {
+                    "promptName": self.prompt, "contentName": self.audio_content}})
+                self.audio_content = None
+            await self._send({"promptEnd": {"promptName": self.prompt}})
+            await self._send({"sessionEnd": {}})
+            await self.stream.input_stream.close()
+        except Exception as exc:                       # noqa: BLE001
+            log(self.verbose, "close: {}: {}".format(type(exc).__name__, exc))
+        if self.reader_task is not None:
+            try:
+                await asyncio.wait_for(self.reader_task, timeout=10)
+            except (asyncio.TimeoutError, asyncio.CancelledError):
+                pass
+
+    # ------------------------------------------------------------------ uplink
+
+    async def talk_start(self):
+        """Open an audio block for a new turn, if one is not already open."""
+        if self.audio_content is not None:
+            return
+        self.audio_content = str(uuid.uuid4())
+        self.turn = {"began": time.monotonic()}
+        self.tool_calls = 0
+        self.tool_names = []
+        self.turn_done.clear()
+        self.down.arm_turn()
+        await self._send({"contentStart": {
+            "promptName": self.prompt, "contentName": self.audio_content,
+            "type": "AUDIO", "interactive": True, "role": "USER",
+            "audioInputConfiguration": {
+                "mediaType": "audio/lpcm", "sampleRateHertz": IN_RATE,
+                "sampleSizeBits": 16, "channelCount": 1,
+                "audioType": "SPEECH", "encoding": "base64"}}})
+        log(self.verbose, "talk start")
+
+    async def audio(self, pcm):
+        """Forward captured audio, chunked the way the measurements were taken."""
+        if self.audio_content is None:
+            await self.talk_start()
+        for at in range(0, len(pcm), CHUNK):
+            await self._send({"audioInput": {
+                "promptName": self.prompt, "contentName": self.audio_content,
+                "content": base64.b64encode(pcm[at:at + CHUNK]).decode()}})
+
+    async def talk_end(self):
+        """Close the turn: pad with silence, then close the audio block.
+
+        The padding is trap 2: a clip with no trailing silence is truncated and
+        never answered. It is a CONTENT requirement rather than a time one. The
+        padding is sent unpaced, so measured against tail_ms 200 through 800 it
+        cost no wall clock at all; what it buys is the model deciding the
+        captain has stopped. 400 ms is therefore free margin above the 200 ms
+        floor where answers first appear.
+
+        The clock is still taken before the padding, because that instant is
+        when the captain actually stopped talking and every number this build
+        reports has to be measured from there.
+        """
+        if self.audio_content is None:
+            return
+        self.turn["talk_end"] = time.monotonic()
+        tail = self.options.tail_ms * BYTES_PER_MS_IN
+        if tail:
+            await self.audio(b"\x00" * tail)
+        await self._send({"contentEnd": {
+            "promptName": self.prompt, "contentName": self.audio_content}})
+        self.audio_content = None
+        log(self.verbose, "talk end, {} ms of silence appended".format(
+            self.options.tail_ms))
+
+    # ---------------------------------------------------------------- downlink
+
+    def _mark(self, name):
+        now = time.monotonic()
+        self.turn.setdefault(name, now)
+        base = self.turn.get("talk_end")
+        if base is None:
+            return
+        self.down.send_json(frame.MARK, {
+            "mark": name,
+            "since_talk_end": round(now - base, 3),
+            "tool_calls": self.tool_calls,
+        })
+
+    # Every question worth asking about a session is a question about the order
+    # of these events and the stop reason on them, so --verbose prints that
+    # order. audioOutput and usageEvent are left out because they repeat many
+    # times per reply and bury everything else.
+    TRACE_SKIP = ("audioOutput", "usageEvent")
+
+    def _trace(self, event):
+        for name, body in event.items():
+            if name in self.TRACE_SKIP:
+                continue
+            detail = ""
+            if isinstance(body, dict):
+                bits = [(k, body.get(k)) for k in ("type", "role", "stopReason")
+                        if body.get(k)]
+                detail = "".join(" {}={}".format(k, v) for k, v in bits)
+            log(True, "event {}{}".format(name, detail))
+
+    async def _read_model(self):
+        while True:
+            try:
+                out = await self.stream.await_output()
+                result = await out[1].receive()
+            except Exception as exc:                   # noqa: BLE001
+                log(self.verbose, "model stream ended: {}: {}".format(
+                    type(exc).__name__, exc))
+                break
+            if result is None:
+                break
+            raw = result.value.bytes_
+            if not raw:
+                continue
+            try:
+                event = json.loads(raw.decode()).get("event", {})
+            except ValueError:
+                continue
+            await self._handle(event)
+        self.ended.set()
+        self.turn_done.set()
+
+    async def _handle(self, event):
+        if self.verbose:
+            self._trace(event)
+
+        if "userSpeechEnd" in event:
+            # Open microphone: the model's own detector, not a talk-end frame,
+            # is what ends the turn, so the clock starts here instead.
+            self.turn.setdefault("talk_end", time.monotonic())
+            log(self.verbose, "model reports the captain stopped speaking")
+
+        if "audioOutput" in event:
+            pcm = base64.b64decode(event["audioOutput"].get("content", ""))
+            if pcm:
+                if "first_audio" not in self.turn:
+                    self._mark("first_audio")
+                self.down.send(frame.AUDIO, pcm)
+
+        if "textOutput" in event:
+            text = event["textOutput"].get("content", "")
+            role = event["textOutput"].get("role", "")
+            if text:
+                self.down.send_json(frame.TEXT, {"role": role, "text": text})
+                log(self.verbose, "{}: {}".format(role.lower(), text[:120]))
+                if '"interrupted"' in text and "true" in text:
+                    # Informational only. Stopping playback mid-sentence is
+                    # barge-in, which is step three of the design, not this build.
+                    self.down.send_json(frame.NOTICE, {"event": "interrupted"})
+
+        if "toolUse" in event:
+            self._mark("tool_use")
+            self.tool_calls += 1
+            self.tool_names.append(event["toolUse"].get("toolName", ""))
+            await self._run_tool(event["toolUse"])
+
+        if "contentEnd" in event:
+            stop = event["contentEnd"].get("stopReason")
+            if stop == "INTERRUPTED":
+                self.down.send_json(frame.NOTICE, {"event": "interrupted"})
+            if stop == "END_TURN":
+                # Trap 1: this, not completionEnd, is the end of the reply.
+                self._mark("reply_end")
+                self.replies += 1
+                self.turn_done.set()
+
+    # -------------------------------------------------------------------- tools
+
+    async def _run_tool(self, call):
+        name = call.get("toolName", "")
+        use_id = call.get("toolUseId")
+        raw = call.get("content") or "{}"
+        try:
+            arguments = json.loads(raw) if isinstance(raw, str) else dict(raw)
+        except ValueError:
+            arguments = {}
+        log(self.verbose, "tool {} {}".format(name, arguments))
+
+        try:
+            if name == "get_fleet_status":
+                result = records.fleet_status(home=self.home, scope=self.scope)
+            elif name == "hand_over_to_firstmate":
+                request = (arguments.get("request") or "").strip()
+                result = await asyncio.to_thread(
+                    records.queue_request, request, self.home, self.root)
+                self.down.send_json(frame.NOTICE, {
+                    "event": "queued", "request": request,
+                    "note_id": result.get("note_id", "")})
+            else:
+                result = {"error": "no such tool: {}".format(name)}
+        except records.RecordError as exc:
+            result = {"error": str(exc)}
+        except Exception as exc:                       # noqa: BLE001
+            result = {"error": "{}: {}".format(type(exc).__name__, exc)}
+
+        content = str(uuid.uuid4())
+        await self._send({"contentStart": {
+            "promptName": self.prompt, "contentName": content, "type": "TOOL",
+            "interactive": False, "role": "TOOL",
+            "toolResultInputConfiguration": {
+                "toolUseId": use_id, "type": "TEXT",
+                "textInputConfiguration": {"mediaType": "text/plain"}}}})
+        await self._send({"toolResult": {
+            "promptName": self.prompt, "contentName": content,
+            "content": json.dumps(result)}})
+        await self._send({"contentEnd": {
+            "promptName": self.prompt, "contentName": content}})
+        self._mark("tool_answered")
+
+
+async def renew(session, options, down):
+    """Replace a session that has already answered once, and return the new one.
+
+    MEASURED, and the reason this exists: a second user audio block in a session
+    that has already spoken is treated as barge-in, unconditionally. The model
+    raises INTERRUPTED the instant the block opens, and waiting does not help.
+    Six consecutive turns were tried with no wait, with a wait until the reply's
+    audio had all arrived, and with a wait of the reply's full spoken duration
+    after that; every one of those interrupted every second turn. Worse, an
+    interrupted turn that calls a tool is then lost outright: the model asks for
+    the tool, takes the result, and never answers.
+
+    Reconnecting instead costs 0.02 seconds, measured, and it happens when the
+    captain presses the talk key rather than while they are waiting for a reply,
+    so it is invisible. What it gives up is conversational memory: each turn
+    starts fresh, so the captain cannot say "and what about that one". Carrying
+    context across turns means handling barge-in properly, which is step three of
+    the design, not this build. It also means the system prompt is sent once per
+    turn rather than once per session, which is the small cost of the trade.
+    """
+    log(options.verbose, "renewing the session for a new turn")
+    await session.close()
+    fresh = Session(options, down)
+    await fresh.start()
+    down.send_json(frame.NOTICE, {
+        "event": "renewed", "connect_seconds": fresh.connect_seconds})
+    return fresh
+
+
+async def serve(options):
+    """Relay frames between the client on stdin/stdout and one Nova Sonic session."""
+    loop = asyncio.get_running_loop()
+    reader = asyncio.StreamReader()
+    await loop.connect_read_pipe(
+        lambda: asyncio.StreamReaderProtocol(reader), sys.stdin.buffer)
+    # Ahead of every frame, so a login shell that prints a banner on stdout
+    # cannot desynchronise the client. See fm_voice_frame.MAGIC.
+    sys.stdout.buffer.write(frame.MAGIC)
+    sys.stdout.buffer.flush()
+    down = Downlink(sys.stdout.buffer)
+    session = Session(options, down)
+    await session.start()
+    down.send_json(frame.NOTICE, {
+        "event": "ready", "model": options.model, "region": options.region,
+        "read_scope": session.scope, "tail_ms": options.tail_ms,
+        "connect_seconds": session.connect_seconds})
+
+    try:
+        while True:
+            head = await reader.readexactly(frame.HEADER.size)
+            kind, length = frame.HEADER.unpack(head)
+            payload = await reader.readexactly(length) if length else b""
+            if kind == frame.TALK_START:
+                if session.replies or session.ended.is_set():
+                    session = await renew(session, options, down)
+                await session.talk_start()
+            elif kind == frame.AUDIO:
+                await session.audio(payload)
+            elif kind == frame.TALK_END:
+                await session.talk_end()
+            elif kind == frame.QUIT:
+                break
+            else:
+                log(options.verbose, "ignoring downlink kind {!r}".format(kind))
+            if session.ended.is_set():
+                down.send_json(frame.NOTICE, {"event": "session-ended"})
+                break
+    except (asyncio.IncompleteReadError, ConnectionResetError):
+        log(options.verbose, "client closed the connection")
+    finally:
+        await session.close()
+        down.send(frame.BYE)
+        down.close()
+
+
+async def self_test(options):
+    """Feed one PCM file through a real session and report the timings."""
+    with open(options.self_test, "rb") as handle:
+        pcm = handle.read()
+
+    class Sink:
+        """Stands in for the client, counting reply audio and timing its arrival."""
+
+        def __init__(self):
+            self.first = None
+            self.bytes = 0
+            self.heard = []
+            self.said = []
+            self.notices = []
+
+        def send(self, kind, payload=b""):
+            if kind == frame.AUDIO:
+                if self.first is None:
+                    self.first = time.monotonic()
+                self.bytes += len(payload)
+
+        def send_json(self, kind, obj):
+            # The transcript is the only way to check the two things that matter
+            # about a spoken answer: that the words were heard correctly, and
+            # that the agent handed real work over instead of claiming it.
+            if kind == frame.TEXT:
+                text = (obj.get("text") or "").strip()
+                if not text or text.startswith("{"):
+                    return
+                if obj.get("role") == "USER":
+                    self.heard.append(text)
+                elif obj.get("role") == "ASSISTANT":
+                    self.said.append(text)
+            elif kind == frame.NOTICE:
+                self.notices.append(obj.get("event", ""))
+
+        def arm_turn(self):
+            self.first = None
+
+        def first_audio(self):
+            return self.first
+
+    sink = Sink()
+    session = Session(options, sink)
+    await session.start()
+    await session.talk_start()
+    # Paced at real time, because a file pushed as fast as the socket accepts it
+    # would measure the socket rather than the conversation.
+    for at in range(0, len(pcm), CHUNK):
+        await session.audio(pcm[at:at + CHUNK])
+        await asyncio.sleep(CHUNK / (IN_RATE * 2.0))
+    await session.talk_end()
+    try:
+        await asyncio.wait_for(session.turn_done.wait(),
+                               timeout=options.turn_timeout)
+    except asyncio.TimeoutError:
+        session.turn["timeout"] = True
+    await session.close()
+
+    base = session.turn.get("talk_end")
+
+    def since(name):
+        at = session.turn.get(name)
+        if at is None or base is None:
+            return None
+        return round(at - base, 3)
+
+    # A negative figure means the model started answering before this end of the
+    # stream said the turn was over, which happens when the clip handed in
+    # ALREADY ends in silence: the model's own endpoint detector fires part way
+    # through that silence while the file is still being streamed at real time.
+    # The reply is genuinely fast in that case but the number is meaningless,
+    # because it is measured from the wrong instant. Feed --self-test a clip that
+    # ends on speech and let --tail-ms add the silence. This is flagged rather
+    # than silently recorded, because a negative in a results file gets averaged
+    # into a report by someone who was not here.
+    early = [n for n in ("tool_use", "first_audio", "reply_end")
+             if (since(n) or 0) < 0]
+    if early:
+        sys.stderr.write(
+            "fm-voice-relay: {} came in before the end of the clip, so these "
+            "timings are measured from the wrong instant. The clip already ends "
+            "in silence; pass one that ends on speech and use --tail-ms.\n"
+            .format(", ".join(early)))
+
+    print(json.dumps({
+        "mode": "self-test",
+        "model": options.model,
+        "region": options.region,
+        "read_scope": session.scope,
+        "input_seconds": round(len(pcm) / float(IN_RATE * 2), 3),
+        "tail_ms": options.tail_ms,
+        "connect_seconds": session.connect_seconds,
+        "tool_calls": session.tool_calls,
+        "tool_names": session.tool_names,
+        "tool_use_s": since("tool_use"),
+        "first_audio_s": since("first_audio"),
+        "reply_end_s": since("reply_end"),
+        "reply_audio_seconds": round(sink.bytes / float(OUT_RATE * 2), 3),
+        "answered": sink.bytes > 0,
+        "timed_out": bool(session.turn.get("timeout")),
+        "clock_unusable": early,
+        "heard": " ".join(sink.heard),
+        "said": " ".join(sink.said),
+        "notices": sink.notices,
+    }))
+    return 0 if sink.bytes > 0 else 1
+
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(
+        prog="fm-voice-relay.py", add_help=True,
+        description=__doc__.splitlines()[0])
+    parser.add_argument("--serve", action="store_true")
+    parser.add_argument("--self-test", metavar="FILE")
+    parser.add_argument("--region", default=REGION)
+    parser.add_argument("--model", default=MODEL)
+    parser.add_argument("--profile", default=PROFILE)
+    parser.add_argument("--voice", default=VOICE)
+    parser.add_argument("--home")
+    parser.add_argument("--scope", choices=records.SCOPES)
+    parser.add_argument("--tail-ms", type=int, default=TAIL_MS)
+    parser.add_argument("--turn-timeout", type=float, default=40.0,
+                        help="seconds --self-test waits for a reply")
+    parser.add_argument("--verbose", action="store_true")
+    options = parser.parse_args(argv)
+    if options.tail_ms < 0:
+        parser.error("--tail-ms cannot be negative")
+    return options
+
+
+def main(argv):
+    options = parse_args(argv)
+    try:
+        if options.self_test:
+            return asyncio.run(self_test(options))
+        return asyncio.run(serve(options)) or 0
+    except records.RecordError as exc:
+        sys.stderr.write("fm-voice-relay: {}\n".format(exc))
+        return 2
+    except KeyboardInterrupt:
+        return 130
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/bin/fm-voice-relay.py
+++ b/bin/fm-voice-relay.py
@@ -499,8 +499,12 @@ class Session:
         # deliver; see serve() for why a second turn gets a new session.
         self.replies = 0
         # Set when a call into the model raised, which makes this session spent
-        # whether or not it ever answered. handle_uplink_frame owns it.
+        # whether or not it ever answered. fail_turn owns it.
         self.failed = False
+        # Set while close() is deliberately tearing this session down, so the
+        # reader can tell a stream that went away because we ended it from one
+        # that went away on its own.
+        self.closing = False
         # Which tools ran, in order. The handover boundary is the whole point of
         # this relay, so "it called hand_over_to_firstmate and did not answer
         # for firstmate" has to be evidence in the run record, not an inference
@@ -570,6 +574,7 @@ class Session:
             self.connect_seconds, self.scope))
 
     async def close(self):
+        self.closing = True
         if self.stream is None:
             return
         try:
@@ -697,23 +702,35 @@ class Session:
             log(True, "event {}{}".format(name, detail))
 
     async def _read_model(self):
-        """Read the model's events until the stream ends, then say the session is over.
+        """Read the model's events until the stream ends or fails, and report which.
 
         Handling an event reaches back into the model, to answer a tool call, so
         it can fail on its own rather than only the read can. Either way this
-        session is finished, and the one thing that must still happen is the
-        finally below: a turn waiting on turn_done, and a serve loop watching
-        ended, are how the relay recovers. Leaving them clear is what turned one
-        dropped stream into a relay that never answered again.
+        session is finished, and the finally below is the one thing that must
+        still happen: --self-test waits on turn_done for the length of a turn,
+        and both the serve loop and the next talk key read ended to decide
+        whether this session can still be used. Leaving them clear is what turned
+        one dropped stream into a relay that never answered again.
+
+        The two ways out are not the same event and are not reported the same
+        way. A stream that simply ends is the end of a session and nothing more.
+        A stream that raises, here or under an event handler, is this turn
+        failing, so it goes through fail_turn and reaches the captain.
+
+        Neither is a stream that went away because close() asked it to: renew
+        closes the old session on every single turn, so announcing that would put
+        a failure notice in front of the captain on every ordinary turn.
         """
+        broke = None
         try:
             while True:
                 try:
                     out = await self.stream.await_output()
                     result = await out[1].receive()
                 except Exception as exc:               # noqa: BLE001
-                    log(self.verbose, "model stream ended: {}: {}".format(
+                    log(self.verbose, "model stream dropped: {}: {}".format(
                         type(exc).__name__, exc))
+                    broke = exc
                     break
                 if result is None:
                     break
@@ -729,8 +746,14 @@ class Session:
                 except Exception as exc:               # noqa: BLE001
                     log(self.verbose, "handling {} failed: {}: {}".format(
                         ", ".join(event) or "an event", type(exc).__name__, exc))
+                    broke = exc
                     break
         finally:
+            # Not when the uplink has already named this turn: the frame that
+            # broke the model usually breaks the reader an instant later, and the
+            # captain hears about one turn once.
+            if broke is not None and not self.closing and not self.failed:
+                fail_turn(self, self.down, broke)
             self.ended.set()
             self.turn_done.set()
 
@@ -834,6 +857,25 @@ class Session:
         self._mark("tool_answered")
 
 
+def fail_turn(session, down, exc):
+    """Mark a session spent and name this turn's failure to the client.
+
+    One place, because both ends of the relay can break a turn and the captain
+    should not be able to tell which by whether they heard anything. Every part
+    of it is for a different reader. The mark is what the next talk key reads to
+    build a replacement instead of talking into a session that is already gone.
+    The notice is what the captain gets, and it is the only thing that releases a
+    client waiting for a reply, so a failure that is merely marked costs them
+    their whole timeout and leaves a record saying the turn went unanswered
+    without saying why. The reason on the turn is for --self-test, which has no
+    client to notice anything.
+    """
+    reason = "{}: {}".format(type(exc).__name__, exc)
+    session.failed = True
+    session.turn["failed"] = reason
+    down.send_json(frame.NOTICE, {"event": "turn-failed", "error": reason})
+
+
 async def renew(session, options, down):
     """Replace a session that has already answered once, and return the new one.
 
@@ -922,12 +964,9 @@ async def handle_uplink_frame(kind, payload, session, options, down):
         else:
             log(options.verbose, "ignoring uplink kind {!r}".format(kind))
     except Exception as exc:                       # noqa: BLE001
-        session.failed = True
         log(options.verbose, "turn failed: {}: {}".format(
             type(exc).__name__, exc))
-        down.send_json(frame.NOTICE, {
-            "event": "turn-failed",
-            "error": "{}: {}".format(type(exc).__name__, exc)})
+        fail_turn(session, down, exc)
     return session, True
 
 
@@ -1086,6 +1125,11 @@ async def self_test(options):
         "reply_audio_seconds": round(sink.bytes / float(OUT_RATE * 2), 3),
         "answered": sink.bytes > 0,
         "timed_out": bool(session.turn.get("timeout")),
+        # Named the same as the client's turn record, and here for the same
+        # reason: a record that says only that the turn was not answered invites
+        # someone who was not here to average an infrastructure failure into a
+        # latency figure.
+        "relay_error": session.turn.get("failed"),
         "clock_unusable": early,
         "heard": " ".join(sink.heard),
         "said": " ".join(sink.said),

--- a/bin/fm-voice-relay.py
+++ b/bin/fm-voice-relay.py
@@ -708,14 +708,22 @@ class Session:
         it can fail on its own rather than only the read can. Either way this
         session is finished, and the finally below is the one thing that must
         still happen: --self-test waits on turn_done for the length of a turn,
-        and both the serve loop and the next talk key read ended to decide
-        whether this session can still be used. Leaving them clear is what turned
-        one dropped stream into a relay that never answered again.
+        and the next talk key reads ended to decide whether this session can
+        still be used. Leaving them clear is what turned one dropped stream into
+        a relay that never answered again.
 
         The two ways out are not the same event and are not reported the same
-        way. A stream that simply ends is the end of a session and nothing more.
-        A stream that raises, here or under an event handler, is this turn
-        failing, so it goes through fail_turn and reaches the captain.
+        way. A stream that simply ends is the end of a session and nothing more,
+        so it is named as that and not as a failure. A stream that raises, here
+        or under an event handler, is this turn failing, so it goes through
+        fail_turn and reaches the captain.
+
+        Either way the client is told, once, because either way it is waiting on
+        a turn that is not coming and a notice is the only thing that releases it.
+        The end is announced HERE rather than from the serve loop because this is
+        the one moment it happens: the flag it sets stays set for every later
+        frame of the same key press, so a loop that announced it would say it ten
+        times a second while the captain was still speaking.
 
         Neither is a stream that went away because close() asked it to: renew
         closes the old session on every single turn, so announcing that would put
@@ -749,11 +757,15 @@ class Session:
                     broke = exc
                     break
         finally:
-            # Not when the uplink has already named this turn: the frame that
-            # broke the model usually breaks the reader an instant later, and the
-            # captain hears about one turn once.
-            if broke is not None and not self.closing and not self.failed:
-                fail_turn(self, self.down, broke)
+            # Neither is said when the uplink has already named this turn: the
+            # frame that broke the model usually breaks the reader an instant
+            # later, and the captain hears about one turn once.
+            if not self.closing and not self.failed:
+                if broke is not None:
+                    fail_turn(self, self.down, broke)
+                else:
+                    self.down.send_json(
+                        frame.NOTICE, {"event": "session-ended"})
             self.ended.set()
             self.turn_done.set()
 
@@ -971,7 +983,17 @@ async def handle_uplink_frame(kind, payload, session, options, down):
 
 
 async def serve(options):
-    """Relay frames between the client on stdin/stdout and one Nova Sonic session."""
+    """Relay frames between the client on stdin/stdout and the model sessions behind it.
+
+    Three things end this, and nothing else does: the client's QUIT frame, the
+    client closing the connection, and an uplink that has stopped being a frame
+    stream. In particular a model session ending is not one of them. It happens
+    on its own, mid-conversation, and the next talk key builds a replacement
+    through the same path every ordinary turn already uses, at a measured cost of
+    0.02 s. A renew that cannot be made is spoken to the captain by fail_turn, so
+    the loud failure is the one they get; ending the relay here would instead
+    leave them speaking a whole question into nothing.
+    """
     loop = asyncio.get_running_loop()
     reader = asyncio.StreamReader()
     await loop.connect_read_pipe(
@@ -995,12 +1017,6 @@ async def serve(options):
             session, serving = await handle_uplink_frame(
                 kind, payload, session, options, down)
             if not serving:
-                break
-            # A session already marked spent is about to be replaced on the next
-            # talk key, so its stream closing is expected rather than the end of
-            # the relay's usefulness.
-            if session.ended.is_set() and not session.failed:
-                down.send_json(frame.NOTICE, {"event": "session-ended"})
                 break
     except (asyncio.IncompleteReadError, ConnectionResetError):
         log(options.verbose, "client closed the connection")

--- a/bin/fm-voice-relay.py
+++ b/bin/fm-voice-relay.py
@@ -52,7 +52,8 @@ an unconfigured home cannot start this relay at all.
   config/voice-id       FM_VOICE_ID       output voice.          default matthew
 
 An absent profile means the relay uses only credentials that are already in its
-environment, which is what `--profile ""` forces when a config file exists.
+environment. An empty FM_VOICE_PROFILE, or an empty `--profile ""`, forces that
+even when config/voice-profile exists.
 
 On the model: amazon.nova-sonic-v1:0 is marked legacy by AWS and measured 25
 percent slower on the tool-backed path, which is the path this interface actually
@@ -1051,7 +1052,16 @@ def resolve_settings(options):
     if not options.model:
         options.model = records.require_setting(home, *SETTINGS["model"])
     if options.profile is None:
-        options.profile = records.read_setting(home, *SETTINGS["profile"][:2]) or ""
+        # Presence, not truthiness: an empty FM_VOICE_PROFILE is the captain
+        # saying "use the credentials I already have" and must not fall through
+        # to a configured profile, which is how fm-inbox.sh reads its own
+        # equivalent and what docs/configuration.md promises for both. An empty
+        # region or model is still nothing, so those keep falling through.
+        name, env = SETTINGS["profile"][:2]
+        chosen = os.environ.get(env)
+        if chosen is None:
+            chosen = records.read_setting(home, name)
+        options.profile = (chosen or "").strip()
     if not options.voice:
         options.voice = records.read_setting(home, *SETTINGS["voice"][:2]) or VOICE
     return options

--- a/bin/fm-voice-relay.py
+++ b/bin/fm-voice-relay.py
@@ -167,14 +167,28 @@ def widen_path():
         os.environ["PATH"] = os.pathsep.join(added + parts)
 
 
+# A credential that states an expiry this interpreter cannot read. The
+# credential itself is fine; only its deadline is unknown, and that is not the
+# same thing as not having one.
+EXPIRY_UNKNOWN = object()
+
+
 def _expires_at(stamp):
-    """Return an ISO 8601 expiry as epoch seconds, or None when there is none."""
+    """Return the expiry as epoch seconds, None when there is none, or EXPIRY_UNKNOWN.
+
+    The two failure shapes mean opposite things and must not collapse into one.
+    No Expiration at all is a credential that does not expire. An Expiration
+    that will not parse, such as an offset written +0000 on an interpreter older
+    than 3.11, is a credential that does expire at a moment this process cannot
+    read, and treating that as "never" would cache it past its real deadline and
+    fail every session from then on.
+    """
     if not stamp:
         return None
     try:
         when = datetime.datetime.fromisoformat(str(stamp).replace("Z", "+00:00"))
     except ValueError:
-        return None
+        return EXPIRY_UNKNOWN
     if when.tzinfo is None:
         when = when.replace(tzinfo=datetime.timezone.utc)
     return when.timestamp()
@@ -226,9 +240,11 @@ class Credentials:
     and not a credential fetch.
 
     Credentials that carry an expiry are refreshed a few minutes ahead of it,
-    because a relay left running outlives them. Every resolution, the first one
-    included, runs in a worker thread, so the event loop keeps reading the
-    captain's audio while it happens.
+    because a relay left running outlives them. One whose expiry cannot be read
+    is held for that same margin and no longer, so an unreadable deadline costs
+    an occasional resolution rather than every session after the deadline.
+    Every resolution, the first one included, runs in a worker thread, so the
+    event loop keeps reading the captain's audio while it happens.
     """
 
     REFRESH_MARGIN = 300
@@ -238,11 +254,14 @@ class Credentials:
         self.verbose = verbose
         self._creds = None
         self._expires = None
+        self._resolved = None
         self._lock = asyncio.Lock()
 
     def _usable(self):
         if self._creds is None:
             return False
+        if self._expires is EXPIRY_UNKNOWN:
+            return time.monotonic() - self._resolved < self.REFRESH_MARGIN
         if self._expires is None:
             return True
         return time.time() + self.REFRESH_MARGIN < self._expires
@@ -252,6 +271,7 @@ class Credentials:
             if not self._usable():
                 self._creds, self._expires = await asyncio.to_thread(
                     resolve_credentials, self.profile, self.verbose)
+                self._resolved = time.monotonic()
             return dict(self._creds)
 
 
@@ -646,6 +666,21 @@ async def renew(session, options, down):
     return fresh
 
 
+async def read_uplink_frame(reader):
+    """Return the next (kind, payload) the client sent, or raise on a bad header.
+
+    The header is checked before the payload is read, not after. A
+    desynchronised uplink offers a length of up to 4 GiB, and waiting for that
+    many bytes is a hang where the wire format promises a loud error, with the
+    captain sitting in front of a client that will never answer.
+    """
+    head = await reader.readexactly(frame.HEADER.size)
+    kind, length = frame.HEADER.unpack(head)
+    frame.check_header(kind, length)
+    payload = await reader.readexactly(length) if length else b""
+    return kind, payload
+
+
 async def serve(options):
     """Relay frames between the client on stdin/stdout and one Nova Sonic session."""
     loop = asyncio.get_running_loop()
@@ -667,13 +702,7 @@ async def serve(options):
     status = 0
     try:
         while True:
-            head = await reader.readexactly(frame.HEADER.size)
-            kind, length = frame.HEADER.unpack(head)
-            # Before the payload read, not after: a desynchronised uplink offers
-            # a length of up to 4 GiB, and waiting for that many bytes is a hang
-            # rather than the loud error this format promises.
-            frame.check_header(kind, length)
-            payload = await reader.readexactly(length) if length else b""
+            kind, payload = await read_uplink_frame(reader)
             if kind == frame.TALK_START:
                 if session.replies or session.ended.is_set():
                     session = await renew(session, options, down)
@@ -709,7 +738,15 @@ async def self_test(options):
         pcm = handle.read()
 
     class Sink:
-        """Stands in for the client, counting reply audio and timing its arrival."""
+        """Stands in for the client, counting reply audio and timing its arrival.
+
+        There is no connection here and no writer thread: this stamps its arrival
+        inline, in the same coroutine that decoded the model event. So the wire
+        hand-off Downlink times on the --serve path does not exist in this mode,
+        and the record below reports no figure for it rather than reporting one
+        that would be zero because of how this stub is built. The first_audio
+        figure it does report is the model event, which is real in both modes.
+        """
 
         def __init__(self):
             self.first = None
@@ -800,7 +837,6 @@ async def self_test(options):
         "tool_names": session.tool_names,
         "tool_use_s": since("tool_use"),
         "first_audio_s": since("first_audio"),
-        "first_audio_wire_s": since("first_audio_wire"),
         "reply_end_s": since("reply_end"),
         "reply_audio_seconds": round(sink.bytes / float(OUT_RATE * 2), 3),
         "answered": sink.bytes > 0,

--- a/bin/fm_voice_frame.py
+++ b/bin/fm_voice_frame.py
@@ -27,7 +27,8 @@ Audio is raw PCM rather than base64 because base64 belongs to the Bedrock
 event protocol, not to this hop, and the extra third of the bytes would sit
 inside the latency this build exists to measure.
 
-docs/voice-relay.md is the owner of this contract and of the sample rates.
+This module is the owner of the contract above and of the sample rates;
+docs/voice-relay.md is the operator-facing guide and points here for the format.
 This module is copied to the laptop beside fm-voice-client.py, so it imports
 nothing outside the standard library.
 """

--- a/bin/fm_voice_frame.py
+++ b/bin/fm_voice_frame.py
@@ -110,26 +110,38 @@ class Reader:
     def __init__(self, stream):
         self._stream = stream
 
-    def _exact(self, count):
+    def _exact(self, count, what):
+        """Return exactly count bytes, or None if the stream ended before any.
+
+        Ending part way through raises rather than returning None, because the
+        two are not the same fault and only the caller reading a header can
+        treat nothing-at-all as end of input. A partial header returned as None
+        would be read as a clean close, and a dropped connection would be
+        recorded as a turn the model simply did not answer.
+        """
         parts = []
         have = 0
         while have < count:
             chunk = self._stream.read(count - have)
             if not chunk:
+                if have:
+                    raise FrameError(
+                        "stream ended after {} of the {} bytes of a {}".format(
+                            have, count, what))
                 return None
             parts.append(chunk)
             have += len(chunk)
         return b"".join(parts)
 
     def read(self):
-        head = self._exact(HEADER.size)
+        head = self._exact(HEADER.size, "frame header")
         if head is None:
             return None
         kind, length = HEADER.unpack(head)
         check_header(kind, length)
         if length == 0:
             return kind, b""
-        payload = self._exact(length)
+        payload = self._exact(length, "payload")
         if payload is None:
             raise FrameError("stream ended inside a {} byte payload".format(length))
         return kind, payload

--- a/bin/fm_voice_frame.py
+++ b/bin/fm_voice_frame.py
@@ -1,0 +1,143 @@
+"""fm_voice_frame.py - the wire format between the voice client and the relay.
+
+The client and the relay share one bidirectional byte stream: an SSH exec
+channel, where the client's stdout is the relay's stdin and the relay's stdout
+is the client's stdin. Audio and control therefore travel together and need
+framing. A frame is a 1 byte kind, a 4 byte unsigned big-endian payload length,
+then exactly that many payload bytes.
+
+Kinds the client sends up to the relay:
+  S  talk start, empty payload
+  A  captured audio, 16000 Hz mono signed 16-bit little-endian
+  E  talk end, empty payload
+  Q  quit, empty payload
+
+Kinds the relay sends down to the client:
+  A  reply audio, 24000 Hz mono signed 16-bit little-endian
+  T  JSON {"role": ..., "text": ...}, one transcript line
+  V  JSON {"event": ..., ...}, a notice such as a queued request
+  M  JSON {"mark": ..., "t": ...}, a relay-side timing mark
+  B  bye, empty payload
+
+Audio is raw PCM rather than base64 because base64 belongs to the Bedrock
+event protocol, not to this hop, and the extra third of the bytes would sit
+inside the latency this build exists to measure.
+
+docs/voice-relay.md is the owner of this contract and of the sample rates.
+This module is copied to the laptop beside fm-voice-client.py, so it imports
+nothing outside the standard library.
+"""
+
+import json
+import struct
+
+HEADER = struct.Struct(">cI")
+
+# The relay writes this once before its first frame and the client discards
+# everything ahead of it. `ssh host command` runs the command through the login
+# shell, so a shell startup file that prints to stdout would otherwise land in
+# front of the first frame and desynchronise the stream, which reads as a
+# baffling protocol error rather than as the chatty shell it is.
+MAGIC = b"FMVOICE1"
+
+# One second of 24000 Hz 16-bit mono is 48000 bytes, so this ceiling is far
+# above any real chunk while still rejecting a desynchronised stream early.
+MAX_PAYLOAD = 1 << 20
+
+TALK_START = b"S"
+AUDIO = b"A"
+TALK_END = b"E"
+QUIT = b"Q"
+TEXT = b"T"
+NOTICE = b"V"
+MARK = b"M"
+BYE = b"B"
+
+KINDS = (TALK_START, AUDIO, TALK_END, QUIT, TEXT, NOTICE, MARK, BYE)
+
+
+class FrameError(Exception):
+    """A frame could not be encoded or decoded."""
+
+
+def encode(kind, payload=b""):
+    """Return the wire bytes for one frame."""
+    if kind not in KINDS:
+        raise FrameError("unknown frame kind: {!r}".format(kind))
+    if len(payload) > MAX_PAYLOAD:
+        raise FrameError("payload of {} bytes exceeds the {} byte limit".format(
+            len(payload), MAX_PAYLOAD))
+    return HEADER.pack(kind, len(payload)) + payload
+
+
+def encode_json(kind, obj):
+    """Return the wire bytes for one frame carrying a compact JSON payload."""
+    return encode(kind, json.dumps(obj, separators=(",", ":")).encode("utf-8"))
+
+
+def decode_json(payload):
+    """Return the object in a JSON frame payload."""
+    try:
+        return json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, ValueError) as exc:
+        raise FrameError("payload is not JSON: {}".format(exc))
+
+
+class Reader:
+    """Read frames from a blocking binary stream.
+
+    read() returns a (kind, payload) pair, or None once the peer has closed
+    the stream cleanly between frames. A stream that ends part way through a
+    frame raises FrameError, because a truncated frame is a real fault and
+    silently treating it as end of input would hide a dropped connection.
+    """
+
+    def __init__(self, stream):
+        self._stream = stream
+
+    def _exact(self, count):
+        parts = []
+        have = 0
+        while have < count:
+            chunk = self._stream.read(count - have)
+            if not chunk:
+                return None
+            parts.append(chunk)
+            have += len(chunk)
+        return b"".join(parts)
+
+    def read(self):
+        head = self._exact(HEADER.size)
+        if head is None:
+            return None
+        kind, length = HEADER.unpack(head)
+        if kind not in KINDS:
+            raise FrameError("unknown frame kind: {!r}".format(kind))
+        if length > MAX_PAYLOAD:
+            raise FrameError("payload of {} bytes exceeds the {} byte limit".format(
+                length, MAX_PAYLOAD))
+        if length == 0:
+            return kind, b""
+        payload = self._exact(length)
+        if payload is None:
+            raise FrameError("stream ended inside a {} byte payload".format(length))
+        return kind, payload
+
+
+class Writer:
+    """Write frames to a blocking binary stream, flushing each one.
+
+    Every frame is flushed because a buffered reply frame is indistinguishable
+    from a slow model, and this build exists to measure the difference.
+    """
+
+    def __init__(self, stream):
+        self._stream = stream
+
+    def send(self, kind, payload=b""):
+        self._stream.write(encode(kind, payload))
+        self._stream.flush()
+
+    def send_json(self, kind, obj):
+        self._stream.write(encode_json(kind, obj))
+        self._stream.flush()

--- a/bin/fm_voice_frame.py
+++ b/bin/fm_voice_frame.py
@@ -60,13 +60,23 @@ class FrameError(Exception):
     """A frame could not be encoded or decoded."""
 
 
-def encode(kind, payload=b""):
-    """Return the wire bytes for one frame."""
+def check_header(kind, length):
+    """Raise FrameError unless a decoded header is one this format allows.
+
+    Both directions of the stream decode headers, and audio that happens to
+    look like one must be rejected identically wherever that happens, so the
+    rules live here rather than beside each decoder.
+    """
     if kind not in KINDS:
         raise FrameError("unknown frame kind: {!r}".format(kind))
-    if len(payload) > MAX_PAYLOAD:
+    if length > MAX_PAYLOAD:
         raise FrameError("payload of {} bytes exceeds the {} byte limit".format(
-            len(payload), MAX_PAYLOAD))
+            length, MAX_PAYLOAD))
+
+
+def encode(kind, payload=b""):
+    """Return the wire bytes for one frame."""
+    check_header(kind, len(payload))
     return HEADER.pack(kind, len(payload)) + payload
 
 
@@ -111,11 +121,7 @@ class Reader:
         if head is None:
             return None
         kind, length = HEADER.unpack(head)
-        if kind not in KINDS:
-            raise FrameError("unknown frame kind: {!r}".format(kind))
-        if length > MAX_PAYLOAD:
-            raise FrameError("payload of {} bytes exceeds the {} byte limit".format(
-                length, MAX_PAYLOAD))
+        check_header(kind, length)
         if length == 0:
             return kind, b""
         payload = self._exact(length)

--- a/bin/fm_voice_frame.py
+++ b/bin/fm_voice_frame.py
@@ -15,8 +15,12 @@ Kinds the client sends up to the relay:
 Kinds the relay sends down to the client:
   A  reply audio, 24000 Hz mono signed 16-bit little-endian
   T  JSON {"role": ..., "text": ...}, one transcript line
-  V  JSON {"event": ..., ...}, a notice such as a queued request
-  M  JSON {"mark": ..., "t": ...}, a relay-side timing mark
+  V  JSON {"event": ..., ...}, a notice such as a queued request or a failed turn
+  M  JSON {"mark": ..., "since_talk_end": ..., "tool_calls": ...}, one relay-side
+     timing mark. since_talk_end is seconds from the moment the captain stopped
+     talking, which is the instant every figure in this build is measured from.
+     The marks the relay sends are tool_use, first_audio, first_audio_wire,
+     tool_answered and reply_end; bin/fm-voice-relay.py owns what each means.
   B  bye, empty payload
 
 Audio is raw PCM rather than base64 because base64 belongs to the Bedrock

--- a/bin/fm_voice_records.py
+++ b/bin/fm_voice_records.py
@@ -25,11 +25,21 @@ the test rather than quietly widening what is sent.
 
 Runtime records outlive the work they describe: a task keeps its state/<id>.meta
 until teardown removes it, which happens separately from marking the item done.
-So every reading here is filtered to ids that are still open, pull requests
-included. A finished task's pull request is therefore not counted and not named,
-and that lost count is a deliberate cost: the alternative names finished work and
-puts it out of reach of the deny list, which has no title to match without an
-open item to take it from.
+Two readings here treat that differently, on purpose.
+
+  Pull requests, the count and the list, cover OPEN ids only. They name work, and
+  they feed the deny decision, which needs an open item to take a title from. A
+  finished task's pull request is therefore not counted and not named, and that
+  lost count is a deliberate cost: the alternative names finished work and puts
+  it out of reach of the deny list, which has no title to match without an open
+  item to take it from.
+
+  The worker count and the state histogram cover every live runtime record,
+  finished ids included, because a task with a meta file still on disk is still
+  on deck and still needs tearing down. That is the question those two figures
+  answer, and it is the same meaning bin/fm-inbox.sh gives "workers" in the human
+  rendering. Neither can carry record free text: one is an integer, and the
+  other's keys are the state verb folded through the closed set below.
 
 READ SCOPE. config/voice-read-scope selects what a status answer may contain:
 

--- a/bin/fm_voice_records.py
+++ b/bin/fm_voice_records.py
@@ -38,11 +38,15 @@ DENY LIST. config/voice-read-deny holds anything that must never leave this
 host even in full scope: one plain case-insensitive substring per line, `#`
 starts a comment, blank lines ignored. Substrings rather than regular
 expressions, because a confidentiality list is the wrong place for a pattern
-that can match more or less than it looks like it matches. A matching item is
-reduced to a withheld count, so the agent still says how much is waiting
-without saying what it is. The file is optional and an absent file means an
-empty list; it exists so that a future open task carrying a customer name can
-be excluded in one line rather than by turning the whole feature down.
+that can match more or less than it looks like it matches. Each open item is
+matched once, against its identifier, its title, its tag values and its pull
+request link together, and a match is then withheld from every list it could
+have appeared in and reduced to a withheld count. One decision per item rather
+than one per list, because an item named in any list is an item that left this
+host. The agent still says how much is waiting without saying what it is. The
+file is optional and an absent file means an empty list; it exists so that a
+future open task carrying a customer name can be excluded in one line rather
+than by turning the whole feature down.
 
 WORKER STATE. This module reports the last recorded event verb, which is
 history rather than a live check, and labels it that way in its own output so
@@ -307,22 +311,39 @@ def fleet_status(home=None, scope=None):
             "than guessing at it.")
         return answer
 
-    # Distinct denied items, not denial events. The lists below overlap by
-    # design: one task can be in flight, held for the captain and carrying a
-    # pull request at once, and counting each refusal would tell the captain
-    # three things are being withheld when it is one.
-    withheld_ids = set()
     by_id = {w["id"]: w for w in workers}
 
-    def keep(item_id, *fields):
-        if _denied(denies, item_id, *fields):
+    # ONE deny decision per item, taken over everything known about that item
+    # before any list is built, and then shared by every list it could appear
+    # in. The lists overlap by design: a task can be in flight, waiting on the
+    # captain and carrying a pull request at once. Deciding per list, from the
+    # fields that list happens to use, would withhold an item from one list and
+    # name it in another, which is not a narrower answer but a leak with a
+    # reassuring count beside it. It also makes the count what it says it is,
+    # distinct items rather than refusals.
+    listable = {}
+    for item in in_flight + held_for_captain:
+        listable.setdefault(item["id"], item)
+
+    withheld_ids = set()
+    for item_id in set(listable) | {w["id"] for w in with_pr}:
+        item = listable.get(item_id)
+        worker = by_id.get(item_id)
+        fields = [item_id]
+        if item is not None:
+            fields.append(item["title"])
+            fields.extend(item["tags"].values())
+        if worker is not None:
+            fields.append(worker["pr"])
+        if _denied(denies, *fields):
             withheld_ids.add(item_id)
-            return False
-        return True
+
+    def keep(item_id):
+        return item_id not in withheld_ids
 
     detail_in_flight = []
     for item in in_flight:
-        if not keep(item["id"], item["title"]):
+        if not keep(item["id"]):
             continue
         worker = by_id.get(item["id"])
         detail_in_flight.append({
@@ -335,13 +356,13 @@ def fleet_status(home=None, scope=None):
 
     detail_captain = []
     for item in held_for_captain:
-        if not keep(item["id"], item["title"], item["tags"].get("hold", "")):
+        if not keep(item["id"]):
             continue
         detail_captain.append({"id": item["id"], "title": item["title"]})
 
     detail_prs = []
     for worker in with_pr:
-        if not keep(worker["id"], worker["pr"]):
+        if not keep(worker["id"]):
             continue
         detail_prs.append({"id": worker["id"], "url": worker["pr"]})
 

--- a/bin/fm_voice_records.py
+++ b/bin/fm_voice_records.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""fm_voice_records.py - what the voice agent is allowed to know, and how it hands work over.
+
+The voice agent answers status questions from firstmate's durable records and
+queues everything else. This module owns both halves, because both halves are
+where a mistake is expensive: one sends the captain's records to a model in
+another region, and the other writes to firstmate's wake queue.
+
+WHAT IS NEVER READ. Two whole classes of record are excluded at every scope,
+not filtered at the end:
+
+  Done history, because a spoken "what is happening" answer is about open work,
+  and the finished items are where old engagements accumulate.
+  Free-form note bodies under a task, because they are long, they are written
+  for a reader with the whole file in front of them, and they are where
+  commercial detail gets quoted.
+
+Only open task lines and this home's own runtime records are ever assembled.
+That is a confidentiality boundary as much as a brevity one. Verified on the
+captain's live records on 2026-08-21: every occurrence of the one engagement
+identifier those records contain sits in Done history or a note body, so
+nothing in a full status answer named a customer. tests/fm-voice-relay.test.sh
+holds that boundary as an executable check, so widening the reader later fails
+the test rather than quietly widening what is sent.
+
+READ SCOPE. config/voice-read-scope selects what a status answer may contain:
+
+  full (the default, and the value used when the file is absent)
+      Counts plus the identifiers, titles and pull request links of open work.
+      This is the access the captain granted.
+
+  counts
+      Counts, states and one basis note, with no record free text assembled at
+      all. Safe by construction rather than by filtering, for anyone who wants
+      the agent able to say how much is waiting without saying what it is.
+
+DENY LIST. config/voice-read-deny holds anything that must never leave this
+host even in full scope: one plain case-insensitive substring per line, `#`
+starts a comment, blank lines ignored. Substrings rather than regular
+expressions, because a confidentiality list is the wrong place for a pattern
+that can match more or less than it looks like it matches. A matching item is
+reduced to a withheld count, so the agent still says how much is waiting
+without saying what it is. The file is optional and an absent file means an
+empty list; it exists so that a future open task carrying a customer name can
+be excluded in one line rather than by turning the whole feature down.
+
+WORKER STATE. This module reports the last recorded event verb, which is
+history rather than a live check, and labels it that way in its own output so
+the model cannot present it as current truth. bin/fm-crew-state.sh remains the
+owner of real current-state reconciliation and is far too slow for a spoken
+answer.
+
+bin/fm-inbox.sh `status` is the human rendering of the same records and stays
+the owner of that. This module exists because a spoken answer needs a machine
+shape and a read scope that the human rendering has no reason to carry.
+
+Usage:
+  fm_voice_records.py status [--home <dir>] [--scope counts|full]
+  fm_voice_records.py queue <text>... [--home <dir>]
+
+Both subcommands print JSON, which is exactly what the relay hands to the model
+as a tool result, so the shell form is the same interface the relay uses.
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+
+SCOPE_COUNTS = "counts"
+SCOPE_FULL = "full"
+SCOPES = (SCOPE_FULL, SCOPE_COUNTS)
+SCOPE_DEFAULT = SCOPE_FULL
+
+BASIS = "Last recorded event, which is history and not a live check."
+
+# A spoken answer names a few things and gives a count for the rest. Every row
+# sent is input tokens the model reads before it starts speaking, and this whole
+# build exists to keep that delay honest, so the lists are capped rather than
+# complete. A complete list is a screen, not a sentence.
+DETAIL_LIMIT = 5
+
+ITEM = re.compile(r"^- \[(?P<done>[ x])\] (?P<id>\S+) - (?P<rest>.*)$")
+TAG = re.compile(r"\((?P<key>[a-z-]+): (?P<value>[^)]*)\)")
+# (since 2026-08-21) and (done 2026-08-21) carry no colon, so the tag pattern
+# leaves them in the title. A date read aloud in the middle of a sentence is
+# noise, so they come out too.
+DATE_TAG = re.compile(r"\((?:since|done) [0-9-]+\)")
+
+# The only backlog sections this module will parse. Done history is skipped
+# before a line is even split, so widening the answer cannot reach it by
+# accident. See "WHAT IS NEVER READ" above.
+READ_SECTIONS = ("in flight", "queued")
+
+
+class RecordError(Exception):
+    """The records or the read-scope configuration cannot be used as asked."""
+
+
+def default_home():
+    """Return the operational home, matching bin/fm-inbox.sh's resolution."""
+    env = os.environ.get("FM_HOME")
+    if env:
+        return env
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _read_config(home, name):
+    path = os.path.join(home, "config", name)
+    try:
+        with open(path, encoding="utf-8") as handle:
+            return handle.read()
+    except FileNotFoundError:
+        return None
+
+
+def read_scope(home):
+    """Return the configured read scope, defaulting to full."""
+    raw = _read_config(home, "voice-read-scope")
+    if raw is None:
+        return SCOPE_DEFAULT
+    value = raw.strip()
+    if not value:
+        return SCOPE_DEFAULT
+    if value not in SCOPES:
+        raise RecordError(
+            "config/voice-read-scope says {!r}; it must be one of {}".format(
+                value, " or ".join(SCOPES)))
+    return value
+
+
+def deny_list(home):
+    """Return the deny substrings; an absent file means an empty list."""
+    raw = _read_config(home, "voice-read-deny")
+    if raw is None:
+        return []
+    out = []
+    for line in raw.splitlines():
+        text = line.split("#", 1)[0].strip()
+        if text:
+            out.append(text.lower())
+    return out
+
+
+def _denied(denies, *fields):
+    haystack = " ".join(f for f in fields if f).lower()
+    return any(needle in haystack for needle in denies)
+
+
+def _parse_backlog(path):
+    """Return (section, item) pairs for every task line in the backlog."""
+    items = []
+    section = ""
+    try:
+        with open(path, encoding="utf-8") as handle:
+            lines = handle.read().splitlines()
+    except FileNotFoundError:
+        return items
+    for line in lines:
+        if line.startswith("## "):
+            section = line[3:].strip().lower()
+            continue
+        if section not in READ_SECTIONS:
+            continue
+        match = ITEM.match(line)
+        if not match:
+            continue
+        rest = match.group("rest")
+        tags = {m.group("key"): m.group("value") for m in TAG.finditer(rest)}
+        title = re.sub(r"\s+", " ", DATE_TAG.sub("", TAG.sub("", rest))).strip()
+        items.append({
+            "section": section,
+            "id": match.group("id"),
+            "title": title,
+            "done": match.group("done") == "x",
+            "tags": tags,
+        })
+    return items
+
+
+def _last_event(state_dir, task_id):
+    """Return (verb, line) from the last status event, or (None, None)."""
+    path = os.path.join(state_dir, task_id + ".status")
+    try:
+        with open(path, encoding="utf-8", errors="replace") as handle:
+            lines = [text.strip() for text in handle if text.strip()]
+    except OSError:
+        return None, None
+    if not lines:
+        return None, None
+    line = lines[-1]
+    verb = line.split(":", 1)[0].strip().lower() if ":" in line else "note"
+    if not re.fullmatch(r"[a-z-]+", verb or ""):
+        verb = "note"
+    return verb, line
+
+
+def _workers(state_dir):
+    """Return one record per task with runtime metadata in this home."""
+    out = []
+    try:
+        names = sorted(n for n in os.listdir(state_dir) if n.endswith(".meta"))
+    except OSError:
+        return out
+    for name in names:
+        task_id = name[: -len(".meta")]
+        meta = {}
+        try:
+            with open(os.path.join(state_dir, name), encoding="utf-8") as handle:
+                for line in handle:
+                    if "=" in line:
+                        key, value = line.rstrip("\n").split("=", 1)
+                        meta[key] = value
+        except OSError:
+            continue
+        verb, line = _last_event(state_dir, task_id)
+        out.append({
+            "id": task_id,
+            "kind": meta.get("kind", ""),
+            "mode": meta.get("mode", ""),
+            "pr": meta.get("pr", ""),
+            "verb": verb or "no events yet",
+            "line": line or "",
+        })
+    return out
+
+
+def fleet_status(home=None, scope=None):
+    """Return the status answer the voice agent is allowed to give."""
+    home = home or default_home()
+    scope = scope or read_scope(home)
+    if scope not in SCOPES:
+        raise RecordError("unknown read scope: {!r}".format(scope))
+    denies = deny_list(home)
+
+    state_dir = os.path.join(home, "state")
+    workers = _workers(state_dir)
+    items = _parse_backlog(os.path.join(home, "data", "backlog.md"))
+
+    open_items = [i for i in items if not i["done"]]
+    in_flight = [i for i in open_items if i["section"] == "in flight"]
+    queued = [i for i in open_items if i["section"] == "queued"]
+    # "What is waiting on me" is the union of decisions filed for the captain
+    # and anything explicitly held for them. The two overlap but neither
+    # contains the other, because a decision can be filed before it is held.
+    held_for_captain = [
+        i for i in open_items
+        if i["tags"].get("hold-kind") == "captain"
+        or i["tags"].get("kind") == "captain"
+    ]
+    with_pr = [w for w in workers if w["pr"]]
+
+    inbox = os.path.join(state_dir, "inbox")
+    try:
+        waiting = len([n for n in os.listdir(inbox) if n.endswith(".note")])
+    except OSError:
+        waiting = 0
+
+    states = {}
+    for worker in workers:
+        states[worker["verb"]] = states.get(worker["verb"], 0) + 1
+
+    answer = {
+        "scope": scope,
+        "basis": BASIS,
+        "workers_on_deck": len(workers),
+        "worker_states": states,
+        "in_flight": len(in_flight),
+        "queued": len(queued),
+        "awaiting_captain": len(held_for_captain),
+        "open_pull_requests": len(with_pr),
+        "captain_notes_waiting": waiting,
+    }
+    if scope == SCOPE_COUNTS:
+        answer["detail"] = (
+            "Identifiers, titles and pull request links are withheld at this "
+            "read scope. Say that the detail is not available by voice rather "
+            "than guessing at it.")
+        return answer
+
+    withheld = 0
+    by_id = {w["id"]: w for w in workers}
+
+    def keep(*fields):
+        return not _denied(denies, *fields)
+
+    detail_in_flight = []
+    for item in in_flight:
+        if not keep(item["id"], item["title"]):
+            withheld += 1
+            continue
+        worker = by_id.get(item["id"])
+        detail_in_flight.append({
+            "id": item["id"],
+            "title": item["title"],
+            # The state word only, never the raw event line. The agent speaks to
+            # the captain and must not read internal record text aloud.
+            "state": worker["verb"] if worker else "not started",
+        })
+
+    detail_captain = []
+    for item in held_for_captain:
+        if not keep(item["id"], item["title"], item["tags"].get("hold", "")):
+            withheld += 1
+            continue
+        detail_captain.append({"id": item["id"], "title": item["title"]})
+
+    detail_prs = []
+    for worker in with_pr:
+        if not keep(worker["id"], worker["pr"]):
+            withheld += 1
+            continue
+        detail_prs.append({"id": worker["id"], "url": worker["pr"]})
+
+    def capped(rows, key):
+        answer[key] = rows[:DETAIL_LIMIT]
+        if len(rows) > DETAIL_LIMIT:
+            answer[key + "_not_listed"] = len(rows) - DETAIL_LIMIT
+
+    capped(detail_in_flight, "in_flight_detail")
+    capped(detail_captain, "awaiting_captain_detail")
+    capped(detail_prs, "pull_request_detail")
+    answer["withheld_as_confidential"] = withheld
+    answer["detail"] = (
+        "The lists name at most {} items each; the counts above are the whole "
+        "picture. Give the captain the counts and a couple of names, not every "
+        "row.".format(DETAIL_LIMIT))
+    return answer
+
+
+def queue_request(text, home=None, root=None):
+    """Hand real work to firstmate through bin/fm-inbox.sh note."""
+    home = home or default_home()
+    root = root or os.path.dirname(os.path.abspath(__file__))
+    body = (text or "").strip()
+    if not body:
+        raise RecordError("refusing to queue an empty request")
+    inbox = os.path.join(root, "fm-inbox.sh")
+    if not os.access(inbox, os.X_OK):
+        raise RecordError("cannot run {}".format(inbox))
+    env = dict(os.environ, FM_HOME=home)
+    done = subprocess.run(
+        [inbox, "note", body],
+        env=env, capture_output=True, text=True, timeout=30, check=False)
+    if done.returncode != 0:
+        raise RecordError("fm-inbox.sh note failed: {}".format(
+            (done.stderr or done.stdout).strip()))
+    note_id = ""
+    for line in done.stdout.splitlines():
+        if line.startswith("queued "):
+            note_id = line.split(None, 1)[1].strip()
+            break
+    return {
+        "queued": True,
+        "note_id": note_id,
+        "queued_text": body,
+        "handover": "Firstmate now owns this request and will pick it up at "
+                    "its next check. You did not do the work yourself.",
+    }
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(
+        prog="fm_voice_records.py", description=__doc__.splitlines()[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    status = sub.add_parser("status", help="print the allowed status answer")
+    status.add_argument("--home")
+    status.add_argument("--scope", choices=SCOPES)
+
+    queue = sub.add_parser("queue", help="hand a request to firstmate")
+    queue.add_argument("text", nargs="+")
+    queue.add_argument("--home")
+
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "status":
+            result = fleet_status(home=args.home, scope=args.scope)
+        else:
+            result = queue_request(" ".join(args.text), home=args.home)
+    except RecordError as exc:
+        sys.stderr.write("fm_voice_records: {}\n".format(exc))
+        return 2
+    json.dump(result, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/bin/fm_voice_records.py
+++ b/bin/fm_voice_records.py
@@ -25,14 +25,19 @@ the test rather than quietly widening what is sent.
 
 READ SCOPE. config/voice-read-scope selects what a status answer may contain:
 
-  full (the default, and the value used when the file is absent)
-      Counts plus the identifiers, titles and pull request links of open work.
-      This is the access the captain granted.
-
-  counts
+  counts (the default, and the value used when the file is absent)
       Counts, states and one basis note, with no record free text assembled at
-      all. Safe by construction rather than by filtering, for anyone who wants
-      the agent able to say how much is waiting without saying what it is.
+      all. Safe by construction rather than by filtering: the agent can say how
+      much is waiting without saying what it is. This is the default because a
+      home that has configured nothing has granted nothing, and sending task
+      identifiers, titles and pull request links to a model in another region is
+      not something to inherit from somebody else's settings file.
+
+  full
+      Counts plus the identifiers, titles and pull request links of open work.
+      A home widens to this by writing `full` into config/voice-read-scope,
+      which is the access being granted deliberately by the captain whose
+      records they are.
 
 DENY LIST. config/voice-read-deny holds anything that must never leave this
 host even in full scope: one plain case-insensitive substring per line, `#`
@@ -76,7 +81,7 @@ import sys
 SCOPE_COUNTS = "counts"
 SCOPE_FULL = "full"
 SCOPES = (SCOPE_FULL, SCOPE_COUNTS)
-SCOPE_DEFAULT = SCOPE_FULL
+SCOPE_DEFAULT = SCOPE_COUNTS
 
 BASIS = "Last recorded event, which is history and not a live check."
 
@@ -127,8 +132,16 @@ def state_dir(home):
     return os.path.join(home, "state")
 
 
+def config_dir(home):
+    """Return the configuration directory, honouring the repo-wide override."""
+    override = os.environ.get("FM_CONFIG_OVERRIDE")
+    if override:
+        return override
+    return os.path.join(home, "config")
+
+
 def _read_config(home, name):
-    path = os.path.join(home, "config", name)
+    path = os.path.join(config_dir(home), name)
     try:
         with open(path, encoding="utf-8") as handle:
             return handle.read()
@@ -136,8 +149,40 @@ def _read_config(home, name):
         return None
 
 
+def read_setting(home, name, env=None):
+    """Return a one-line setting from the environment or this home's config, else None.
+
+    The values this feature needs, an AWS profile and a region and a model id,
+    name somebody's account and somebody's choices. They belong to the home that
+    runs the relay rather than to the repository, so they are read from gitignored
+    config/ with an environment override and never carry a tracked default.
+    """
+    if env:
+        value = (os.environ.get(env) or "").strip()
+        if value:
+            return value
+    raw = _read_config(home, name)
+    if raw is None:
+        return None
+    for line in raw.splitlines():
+        text = line.split("#", 1)[0].strip()
+        if text:
+            return text
+    return None
+
+
+def require_setting(home, name, env, what):
+    """Return a setting, or refuse naming the file to write and the variable to set."""
+    value = read_setting(home, name, env)
+    if value is None:
+        raise RecordError(
+            "no {} is configured: write one line into {} or set {}".format(
+                what, os.path.join(config_dir(home), name), env))
+    return value
+
+
 def read_scope(home):
-    """Return the configured read scope, defaulting to full."""
+    """Return the configured read scope, defaulting to the narrowest one."""
     raw = _read_config(home, "voice-read-scope")
     if raw is None:
         return SCOPE_DEFAULT
@@ -321,13 +366,22 @@ def fleet_status(home=None, scope=None):
     # name it in another, which is not a narrower answer but a leak with a
     # reassuring count beside it. It also makes the count what it says it is,
     # distinct items rather than refusals.
-    listable = {}
-    for item in in_flight + held_for_captain:
-        listable.setdefault(item["id"], item)
+    #
+    # The fields come from every OPEN item, not only the ones a list iterates. A
+    # queued item that is not held for the captain still reaches the answer
+    # through its pull request link, and assembling its fields only where a list
+    # walks past it is how a title match gets missed on exactly that item. What
+    # is COUNTED is narrower: an item that no list could have named is not
+    # something the captain is having withheld.
+    known = {}
+    for item in open_items:
+        known.setdefault(item["id"], item)
+    nameable = ({i["id"] for i in in_flight} | {i["id"] for i in held_for_captain}
+                | {w["id"] for w in with_pr})
 
     withheld_ids = set()
-    for item_id in set(listable) | {w["id"] for w in with_pr}:
-        item = listable.get(item_id)
+    for item_id in nameable:
+        item = known.get(item_id)
         worker = by_id.get(item_id)
         fields = [item_id]
         if item is not None:

--- a/bin/fm_voice_records.py
+++ b/bin/fm_voice_records.py
@@ -306,10 +306,6 @@ def _last_event(state_dir, task_id):
         return None, None
     lines = [text.strip() for text in
              window.decode("utf-8", errors="replace").splitlines() if text.strip()]
-    if size > STATUS_TAIL_BYTES and len(lines) > 1:
-        # The window can open part way through a line, and a fragment is not an
-        # event. It is kept only when it is all there is.
-        lines = lines[1:]
     if not lines:
         return None, None
     line = lines[-1]

--- a/bin/fm_voice_records.py
+++ b/bin/fm_voice_records.py
@@ -23,6 +23,14 @@ nothing in a full status answer named a customer. tests/fm-voice-relay.test.sh
 holds that boundary as an executable check, so widening the reader later fails
 the test rather than quietly widening what is sent.
 
+Runtime records outlive the work they describe: a task keeps its state/<id>.meta
+until teardown removes it, which happens separately from marking the item done.
+So every reading here is filtered to ids that are still open, pull requests
+included. A finished task's pull request is therefore not counted and not named,
+and that lost count is a deliberate cost: the alternative names finished work and
+puts it out of reach of the deny list, which has no title to match without an
+open item to take it from.
+
 READ SCOPE. config/voice-read-scope selects what a status answer may contain:
 
   counts (the default, and the value used when the file is absent)
@@ -370,7 +378,16 @@ def fleet_status(home=None, scope=None):
         if i["tags"].get("hold-kind") == "captain"
         or i["tags"].get("kind") == "captain"
     ]
-    with_pr = [w for w in workers if w["pr"]]
+    # OPEN work only. _workers lists every state/*.meta in the home, and a task
+    # keeps its meta after it is marked done until teardown removes it, so taking
+    # every worker with a pull request would count and name finished tasks. That
+    # breaks the promise at the top of this file twice over: it reads finished
+    # work, and the deny decision below cannot reach those items, because their
+    # ids have no open item to supply a title, so a captain substring matching a
+    # title would silently fail for exactly them. Losing the count of a pull
+    # request on a task already marked done is the accepted cost.
+    open_ids = {i["id"] for i in open_items}
+    with_pr = [w for w in workers if w["pr"] and w["id"] in open_ids]
 
     inbox = os.path.join(state, "inbox")
     try:

--- a/bin/fm_voice_records.py
+++ b/bin/fm_voice_records.py
@@ -57,7 +57,9 @@ WORKER STATE. This module reports the last recorded event verb, which is
 history rather than a live check, and labels it that way in its own output so
 the model cannot present it as current truth. bin/fm-crew-state.sh remains the
 owner of real current-state reconciliation and is far too slow for a spoken
-answer.
+answer. The verb is folded through the closed STATE_VERBS vocabulary below, and
+anything outside it becomes "note": a status line is free text, and this verb is
+the only thing derived from a record that a counts-scope answer says out loud.
 
 bin/fm-inbox.sh `status` is the human rendering of the same records and stays
 the owner of that. This module exists because a spoken answer needs a machine
@@ -103,6 +105,26 @@ DATE_TAG = re.compile(r"\((?:since|done) [0-9-]+\)")
 # accident. See "WHAT IS NEVER READ" above.
 READ_SECTIONS = ("in flight", "queued")
 
+# The states a worker is asked to report, and the two more that close a decision.
+# bin/fm-brief.sh states the first six to every crewmate and bin/fm-classify-lib.sh
+# owns resolved and captain-held; this module only recognises them.
+#
+# A CLOSED set, not a shape. A status line is free text appended by a crewmate,
+# and the verb taken off the front of it is the one record-derived string that
+# reaches a counts-scope answer, where there are no titles or links for a deny
+# list to filter. So an unrecognised token is reported as a note instead of being
+# spoken, exactly as a malformed one already was; otherwise a crewmate writing
+# "acmecorp-migration: waiting on their review" would put that word in front of a
+# model in another region, with nothing in config/voice-read-deny able to stop it.
+STATE_VERBS = ("working", "needs-decision", "blocked", "paused", "done",
+               "failed", "resolved", "captain-held")
+NOTE_VERB = "note"
+
+# Enough tail to hold the last line of a status log. These logs are append-only
+# and grow for the life of a task, while every spoken question reads one per
+# worker, so the read is bounded and seeks rather than scanning from the top.
+STATUS_TAIL_BYTES = 8192
+
 
 class RecordError(Exception):
     """The records or the read-scope configuration cannot be used as asked."""
@@ -123,13 +145,28 @@ def state_dir(home):
     below queues through fm-inbox.sh with the ambient environment. A reader that
     ignored the override would count notes in one directory while the queue wrote
     them to another, so the agent would tell the captain their request was queued
-    and then, asked what is waiting, report nothing. Only state moves with the
-    override; data stays under the home, again as fm-inbox.sh has it.
+    and then, asked what is waiting, report nothing.
     """
     override = os.environ.get("FM_STATE_OVERRIDE")
     if override:
         return override
     return os.path.join(home, "state")
+
+
+def data_dir(home):
+    """Return the durable records directory, the other half of the same pair.
+
+    Every script that sets FM_DATA_OVERRIDE for a child sets FM_STATE_OVERRIDE
+    beside it, so resolving one and not the other would answer one question from
+    two different homes: counts of workers and notes from the overridden state
+    directory, counts of in-flight and queued work from the home's own backlog.
+    A spliced answer is worse than a wrong one, because nothing about it looks
+    wrong.
+    """
+    override = os.environ.get("FM_DATA_OVERRIDE")
+    if override:
+        return override
+    return os.path.join(home, "data")
 
 
 def config_dir(home):
@@ -253,23 +290,34 @@ def _last_event(state_dir, task_id):
     that remains the owner of the format. The bracket matters: status metadata
     sits between the verb and the colon, as in "done [token]: shipped it" and
     "needs-decision [key=api-shape]: which shape". A line carrying no colon is
-    not a status line, and anything that does not read as a single state word is
-    reported as a note rather than spoken aloud as a state.
+    not a status line, and any token outside STATE_VERBS is reported as a note
+    rather than spoken aloud as a state.
+
+    Only the tail of the log is read; see STATUS_TAIL_BYTES.
     """
     path = os.path.join(state_dir, task_id + ".status")
     try:
-        with open(path, encoding="utf-8", errors="replace") as handle:
-            lines = [text.strip() for text in handle if text.strip()]
+        with open(path, "rb") as handle:
+            handle.seek(0, os.SEEK_END)
+            size = handle.tell()
+            handle.seek(max(0, size - STATUS_TAIL_BYTES))
+            window = handle.read()
     except OSError:
         return None, None
+    lines = [text.strip() for text in
+             window.decode("utf-8", errors="replace").splitlines() if text.strip()]
+    if size > STATUS_TAIL_BYTES and len(lines) > 1:
+        # The window can open part way through a line, and a fragment is not an
+        # event. It is kept only when it is all there is.
+        lines = lines[1:]
     if not lines:
         return None, None
     line = lines[-1]
-    verb = "note"
+    verb = NOTE_VERB
     if ":" in line:
         verb = line.split(":", 1)[0].split("[", 1)[0].strip().lower()
-    if not re.fullmatch(r"[a-z-]+", verb or ""):
-        verb = "note"
+    if verb not in STATE_VERBS:
+        verb = NOTE_VERB
     return verb, line
 
 
@@ -313,7 +361,7 @@ def fleet_status(home=None, scope=None):
 
     state = state_dir(home)
     workers = _workers(state)
-    items = _parse_backlog(os.path.join(home, "data", "backlog.md"))
+    items = _parse_backlog(os.path.join(data_dir(home), "backlog.md"))
 
     open_items = [i for i in items if not i["done"]]
     in_flight = [i for i in open_items if i["section"] == "in flight"]

--- a/bin/fm_voice_records.py
+++ b/bin/fm_voice_records.py
@@ -181,7 +181,16 @@ def _parse_backlog(path):
 
 
 def _last_event(state_dir, task_id):
-    """Return (verb, line) from the last status event, or (None, None)."""
+    """Return (verb, line) from the last status event, or (None, None).
+
+    The verb is what precedes the first ':' and the first '[', whichever comes
+    first, which is what status_line_verb in bin/fm-classify-lib.sh does and
+    that remains the owner of the format. The bracket matters: status metadata
+    sits between the verb and the colon, as in "done [token]: shipped it" and
+    "needs-decision [key=api-shape]: which shape". A line carrying no colon is
+    not a status line, and anything that does not read as a single state word is
+    reported as a note rather than spoken aloud as a state.
+    """
     path = os.path.join(state_dir, task_id + ".status")
     try:
         with open(path, encoding="utf-8", errors="replace") as handle:
@@ -191,7 +200,9 @@ def _last_event(state_dir, task_id):
     if not lines:
         return None, None
     line = lines[-1]
-    verb = line.split(":", 1)[0].strip().lower() if ":" in line else "note"
+    verb = "note"
+    if ":" in line:
+        verb = line.split(":", 1)[0].split("[", 1)[0].strip().lower()
     if not re.fullmatch(r"[a-z-]+", verb or ""):
         verb = "note"
     return verb, line
@@ -280,16 +291,22 @@ def fleet_status(home=None, scope=None):
             "than guessing at it.")
         return answer
 
-    withheld = 0
+    # Distinct denied items, not denial events. The lists below overlap by
+    # design: one task can be in flight, held for the captain and carrying a
+    # pull request at once, and counting each refusal would tell the captain
+    # three things are being withheld when it is one.
+    withheld_ids = set()
     by_id = {w["id"]: w for w in workers}
 
-    def keep(*fields):
-        return not _denied(denies, *fields)
+    def keep(item_id, *fields):
+        if _denied(denies, item_id, *fields):
+            withheld_ids.add(item_id)
+            return False
+        return True
 
     detail_in_flight = []
     for item in in_flight:
         if not keep(item["id"], item["title"]):
-            withheld += 1
             continue
         worker = by_id.get(item["id"])
         detail_in_flight.append({
@@ -303,14 +320,12 @@ def fleet_status(home=None, scope=None):
     detail_captain = []
     for item in held_for_captain:
         if not keep(item["id"], item["title"], item["tags"].get("hold", "")):
-            withheld += 1
             continue
         detail_captain.append({"id": item["id"], "title": item["title"]})
 
     detail_prs = []
     for worker in with_pr:
         if not keep(worker["id"], worker["pr"]):
-            withheld += 1
             continue
         detail_prs.append({"id": worker["id"], "url": worker["pr"]})
 
@@ -322,7 +337,7 @@ def fleet_status(home=None, scope=None):
     capped(detail_in_flight, "in_flight_detail")
     capped(detail_captain, "awaiting_captain_detail")
     capped(detail_prs, "pull_request_detail")
-    answer["withheld_as_confidential"] = withheld
+    answer["withheld_as_confidential"] = len(withheld_ids)
     answer["detail"] = (
         "The lists name at most {} items each; the counts above are the whole "
         "picture. Give the captain the counts and a couple of names, not every "
@@ -343,6 +358,10 @@ def queue_request(text, home=None, root=None):
     env = dict(os.environ, FM_HOME=home)
     done = subprocess.run(
         [inbox, "note", body],
+        # The relay's stdin is the captain's audio when this runs under
+        # --serve, and fm-inbox.sh reads a body from stdin for an argument of
+        # "-", so no child of the relay is given that stream to consume.
+        stdin=subprocess.DEVNULL,
         env=env, capture_output=True, text=True, timeout=30, check=False)
     if done.returncode != 0:
         raise RecordError("fm-inbox.sh note failed: {}".format(

--- a/bin/fm_voice_records.py
+++ b/bin/fm_voice_records.py
@@ -107,6 +107,22 @@ def default_home():
     return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
+def state_dir(home):
+    """Return the runtime state directory, resolved as bin/fm-inbox.sh resolves it.
+
+    fm-inbox.sh reads ${FM_STATE_OVERRIDE:-$FM_HOME/state}, and the handover
+    below queues through fm-inbox.sh with the ambient environment. A reader that
+    ignored the override would count notes in one directory while the queue wrote
+    them to another, so the agent would tell the captain their request was queued
+    and then, asked what is waiting, report nothing. Only state moves with the
+    override; data stays under the home, again as fm-inbox.sh has it.
+    """
+    override = os.environ.get("FM_STATE_OVERRIDE")
+    if override:
+        return override
+    return os.path.join(home, "state")
+
+
 def _read_config(home, name):
     path = os.path.join(home, "config", name)
     try:
@@ -246,8 +262,8 @@ def fleet_status(home=None, scope=None):
         raise RecordError("unknown read scope: {!r}".format(scope))
     denies = deny_list(home)
 
-    state_dir = os.path.join(home, "state")
-    workers = _workers(state_dir)
+    state = state_dir(home)
+    workers = _workers(state)
     items = _parse_backlog(os.path.join(home, "data", "backlog.md"))
 
     open_items = [i for i in items if not i["done"]]
@@ -263,7 +279,7 @@ def fleet_status(home=None, scope=None):
     ]
     with_pr = [w for w in workers if w["pr"]]
 
-    inbox = os.path.join(state_dir, "inbox")
+    inbox = os.path.join(state, "inbox")
     try:
         waiting = len([n for n in os.listdir(inbox) if n.endswith(".note")])
     except OSError:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -526,7 +526,7 @@ The voice handover depends on `note`, so it keeps working in a home that has con
 | --- | --- | --- |
 | `config/voice-region` | `FM_VOICE_REGION` | Bedrock region for the relay's bidirectional session, required by `bin/fm-voice-relay.py`. |
 | `config/voice-model` | `FM_VOICE_MODEL` | Speech-to-speech model id, required by `bin/fm-voice-relay.py`. |
-| `config/voice-profile` | `FM_VOICE_PROFILE` | AWS profile the relay exports credentials from; absent means it uses only credentials already in its environment. |
+| `config/voice-profile` | `FM_VOICE_PROFILE` | AWS profile the relay exports credentials from; absent, or an explicitly empty variable, means it uses only credentials already in its environment. |
 | `config/voice-id` | `FM_VOICE_ID` | Output voice id, optional, `matthew` when unset. |
 | `config/voice-read-scope` | none | `counts` (the default, and what an absent file means) or `full`; see [`docs/voice-relay.md`](voice-relay.md) for what each scope may say. |
 | `config/voice-read-deny` | none | One plain case-insensitive substring per line; a matching open item is withheld from every list and reduced to a count. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -660,7 +660,7 @@ FM_LOG_KEEP_LINES=2000             # daemon log lines kept when trimming
 # spoken interface and captain inbox; see "Spoken interface and captain inbox" above
 FM_VOICE_REGION=        # overrides config/voice-region for one relay run
 FM_VOICE_MODEL=         # overrides config/voice-model for one relay run
-FM_VOICE_PROFILE=       # overrides config/voice-profile; absent means environment credentials only
+FM_VOICE_PROFILE=       # overrides config/voice-profile; explicitly empty forces ambient credentials
 FM_VOICE_ID=            # overrides config/voice-id; matthew when neither is set
 FM_VOICE_RELAY=         # laptop-side path to bin/fm-voice-relay.py on the desktop; required by fm-voice-client.py unless --relay is passed
 FM_VOICE_PYTHON=python3 # laptop-side interpreter used to start the relay over ssh

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -515,6 +515,29 @@ The published `lavish-axi poll` clears feedback destructively before returning i
 Never describe this path as at-least-once, no-loss, or lossless.
 `docs/verification/process-event-sources.md` holds the measurements and `.agents/skills/process-event-sources/SKILL.md` owns the handling procedure.
 
+## Spoken interface and captain inbox (config/voice-*, config/inbox-*)
+
+The spoken interface in [`docs/voice-relay.md`](voice-relay.md) and the model-backed subcommands of `bin/fm-inbox.sh` reach a paid API in a named account, so no region, model id or AWS profile is shipped as a tracked default.
+Each is one line in a local, gitignored `config/` file, with an environment variable that overrides it for a single run, and a missing required value refuses with the path to write rather than falling back to a value that belongs to another home.
+That configuration is the whole opt-in: an unconfigured home cannot start the relay and cannot run `fm-inbox.sh say` or `ask`, while `note`, `status`, `list` and `drain` need no configuration at all because they make no model call.
+The voice handover depends on `note`, so it keeps working in a home that has configured nothing.
+
+| File | Environment | Holds |
+| --- | --- | --- |
+| `config/voice-region` | `FM_VOICE_REGION` | Bedrock region for the relay's bidirectional session, required by `bin/fm-voice-relay.py`. |
+| `config/voice-model` | `FM_VOICE_MODEL` | Speech-to-speech model id, required by `bin/fm-voice-relay.py`. |
+| `config/voice-profile` | `FM_VOICE_PROFILE` | AWS profile the relay exports credentials from; absent means it uses only credentials already in its environment. |
+| `config/voice-id` | `FM_VOICE_ID` | Output voice id, optional, `matthew` when unset. |
+| `config/voice-read-scope` | none | `counts` (the default, and what an absent file means) or `full`; see [`docs/voice-relay.md`](voice-relay.md) for what each scope may say. |
+| `config/voice-read-deny` | none | One plain case-insensitive substring per line; a matching open item is withheld from every list and reduced to a count. |
+| `config/inbox-region` | `FM_INBOX_REGION` | AWS region for `fm-inbox.sh say` and `ask`. |
+| `config/inbox-stt-model` | `FM_INBOX_STT_MODEL` | Speech-to-text model id, required by `fm-inbox.sh say`. |
+| `config/inbox-ask-model` | `FM_INBOX_ASK_MODEL` | Side-question model id, required by `fm-inbox.sh ask`. |
+| `config/inbox-profile` | `FM_INBOX_PROFILE` | AWS profile for those two calls; absent, or an explicitly empty variable, means whatever credentials are already in the environment. |
+
+Each file is read as its first line that is not blank and not a `#` comment, so a comment above the value is fine.
+`FM_VOICE_RELAY` and `FM_VOICE_PYTHON` belong to the laptop rather than to a home, so they have no config file: `bin/fm-voice-client.py` requires the relay path as a flag or that variable and carries no default path.
+
 ## Environment variables
 
 Runtime tuning via environment variables (defaults shown):
@@ -634,6 +657,17 @@ FM_CRASH_BACKOFF=60                # seconds to wait after crossing the crash th
 FM_CRASH_NORMAL_SLEEP=5            # seconds to wait after an isolated watcher crash
 FM_LOG_MAX_BYTES=1048576           # daemon log size that triggers trimming
 FM_LOG_KEEP_LINES=2000             # daemon log lines kept when trimming
+# spoken interface and captain inbox; see "Spoken interface and captain inbox" above
+FM_VOICE_REGION=        # overrides config/voice-region for one relay run
+FM_VOICE_MODEL=         # overrides config/voice-model for one relay run
+FM_VOICE_PROFILE=       # overrides config/voice-profile; absent means environment credentials only
+FM_VOICE_ID=            # overrides config/voice-id; matthew when neither is set
+FM_VOICE_RELAY=         # laptop-side path to bin/fm-voice-relay.py on the desktop; required by fm-voice-client.py unless --relay is passed
+FM_VOICE_PYTHON=python3 # laptop-side interpreter used to start the relay over ssh
+FM_INBOX_REGION=        # overrides config/inbox-region for fm-inbox.sh say and ask
+FM_INBOX_STT_MODEL=     # overrides config/inbox-stt-model for fm-inbox.sh say
+FM_INBOX_ASK_MODEL=     # overrides config/inbox-ask-model for fm-inbox.sh ask
+FM_INBOX_PROFILE=       # overrides config/inbox-profile; explicitly empty forces ambient credentials
 ```
 
 `fm-teardown.sh` retries only Git's `Unable to create '...index.lock': File exists` return failure up to `FM_TREEHOUSE_RETURN_LOCK_RETRIES` times.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -535,7 +535,8 @@ The voice handover depends on `note`, so it keeps working in a home that has con
 | `config/inbox-ask-model` | `FM_INBOX_ASK_MODEL` | Side-question model id, required by `fm-inbox.sh ask`. |
 | `config/inbox-profile` | `FM_INBOX_PROFILE` | AWS profile for those two calls; absent, or an explicitly empty variable, means whatever credentials are already in the environment. |
 
-Each file is read as its first line that is not blank and not a `#` comment, so a comment above the value is fine.
+Each account, model and voice file above is read as its first line that is not blank and not a `#` comment, so a comment above the value is fine.
+The two read files are parsed differently: `config/voice-read-scope` must hold the bare word and nothing but blank space around it, so a comment header there refuses instead of being skipped, while every line of `config/voice-read-deny` that is not blank and not a `#` comment is one more substring.
 `FM_VOICE_RELAY` and `FM_VOICE_PYTHON` belong to the laptop rather than to a home, so they have no config file: `bin/fm-voice-client.py` requires the relay path as a flag or that variable and carries no default path.
 
 ## Environment variables

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -189,6 +189,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".greptile/rules.md",
+      "audience": "maintainer-architecture"
+    },
+    {
       "path": "AGENTS.md",
       "audience": "agent-runtime"
     },

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -373,6 +373,10 @@
       "audience": "maintainer-verification"
     },
     {
+      "path": "docs/voice-relay.md",
+      "audience": "operator-current"
+    },
+    {
       "path": "docs/watcher-continuity.md",
       "audience": "operator-current"
     },

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -121,3 +121,8 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-public-followup-lib.sh` | Shared relay-activation gate, O(1) presence checks, and private transport paths for promised public replies |
 | `fm-public-followup.sh`  | Reconcile typed terminal work results into a public commitment and deliver its final reply once |
 | `fm-public-followup-emit.sh` | Report one typed terminal work result into the home that owes the public reply    |
+| `fm-inbox.sh`            | The captain's out-of-band capture surface: queue a note, dictate one, read status, ask a side question |
+| `fm-voice-relay.py`      | Hold the spoken conversation on this host, answer from the records, and hand real work to `fm-inbox.sh` ([voice-relay.md](voice-relay.md)) |
+| `fm-voice-client.py`     | The laptop end of the spoken interface: capture, playback, and turn timing over SSH; audio devices unverified |
+| `fm_voice_frame.py`      | The wire format both machines share, copied to the laptop beside the client          |
+| `fm_voice_records.py`    | What a spoken answer may read, and the handover that queues real work                |

--- a/docs/voice-relay.md
+++ b/docs/voice-relay.md
@@ -101,9 +101,11 @@ cd <your firstmate home>
 
 The clip is headerless 16000 Hz mono signed 16-bit little-endian PCM and must end
 on speech, not silence. It prints one JSON line: what it heard, what it said, how
-long each stage took, and whether it answered at all. Feed it a clip that already
-ends in silence and it will tell you the timings are measured from the wrong
-instant rather than printing a number that looks fast.
+long each stage took, whether it answered at all, and, in `relay_error`, what
+broke when a turn broke rather than merely going unanswered, so an
+infrastructure failure is not read as a slow answer. Feed it a clip that
+already ends in silence and it will tell you the timings are measured from the
+wrong instant rather than printing a number that looks fast.
 
 ## Setting up the laptop
 
@@ -148,15 +150,18 @@ An unconfigured home gets the narrow scope: counts of what is in flight, what is
 Widening that is one line the captain of those records writes into `config/voice-read-scope` themselves.
 Two whole classes of record are excluded at every scope, and excluded by construction rather than filtered on the way out:
 
-- **Finished work**, because a spoken "what is happening" answer is about open
-  work, and old engagements accumulate in the history.
+- **Finished work in the backlog's done history**, because a spoken "what is
+  happening" answer is about open work, and old engagements accumulate there.
 - **Free-form note bodies**, because they are written for someone with the whole
   file in front of them, and they are where commercial detail gets quoted.
 
-Only open work and this home's own runtime records are ever assembled. Verified
-against the captain's live records on 2026-08-21: every occurrence of the one
-customer identifier those records contain sits in finished work or a note body,
-so nothing a status answer can say names a customer.
+Only open work and this home's own runtime records are ever assembled.
+A task keeps its runtime record until teardown, so the count of workers on deck
+and the states beside it still include one whose item is already done; both are a
+number and a state word, never anything written in a record.
+Verified against the captain's live records on 2026-08-21: every occurrence of
+the one customer identifier those records contain sits in finished work or a note
+body, so nothing a status answer can say names a customer.
 `tests/fm-voice-relay.test.sh` holds that boundary as an executable check, so
 widening the reader later fails a test instead of quietly widening what is sent.
 
@@ -208,6 +213,12 @@ asks for the records, takes them, and then never answers at all.
 Reconnecting costs 0.02 seconds and happens while the captain is pressing the
 talk key rather than while they are waiting for a reply, so it is invisible. With
 it, six turns in a row all answered.
+
+The same path covers a session the model ends on its own, mid-conversation: that
+costs the turn it was in and not the relay, and the next talk key builds a
+replacement. Either way the client hears about it at once rather than waiting out
+the whole reply timeout in silence, and a turn that broke rather than merely
+ending carries the reason on its own JSON record.
 
 **What it gives up is memory.** Every question starts fresh, so "and what about
 that one" will not work. Carrying context across turns means handling

--- a/docs/voice-relay.md
+++ b/docs/voice-relay.md
@@ -44,47 +44,39 @@ Six runs each, all six answered each way.
 | Direct from this desktop, no relay | 1.165 1.190 1.215 1.250 1.281 1.352 | 1.232 |
 | Over the relay, real client and framing | 1.138 1.165 1.171 1.174 1.177 1.283 | 1.172 |
 
-The clock starts the instant the captain stops speaking and stops when the first
-byte of reply audio arrives. The direct figure reproduces the 1.164 second
-measurement in the earlier survey, to within the noise floor below, which is what
-makes it usable as a control.
+The clock starts the instant the captain stops speaking and stops when the first byte of reply audio arrives.
+An earlier measurement of the same question, on the same model and region and also reading the records, put the direct path at 1.164 seconds median over five runs, and this control reproduces it to within the noise floor below.
+That measurement is not published here, so read it as corroboration rather than as something to open: the direct column stands as a control on its own, because it was taken in the same pass, on the same clip, model, region and read scope, with only the relay removed.
 
-**The relay's own cost is smaller than this measurement can resolve.** The relay
-median lands below the direct control, which does not mean the relay is faster:
-two direct-control passes twenty minutes apart differ by 0.070 seconds of median,
-so that is the floor, and framing and the extra process hop are both under it.
+**The relay's own cost is smaller than this measurement can resolve.**
+The relay median lands below the direct control, which does not mean the relay is faster: two direct-control passes twenty minutes apart differ by 0.070 seconds of median, so that is the floor, and framing and the extra process hop are both under it.
+The earlier measurement above independently agrees on that floor, spreading 0.087 seconds across its own five runs, and two measurements agreeing on the noise are worth more than one asserting it.
 Read the two rows as the same number.
 
-The first pass, on the relay as first written, put it 0.22 seconds behind the
-control, and that gap read as framing, the process hop and the per-turn reconnect.
-It was none of them, and the difference is worth keeping, because a wrong number
-invites a re-measurement while a wrong cause invites a fix to the wrong part of
-the relay. Each relay run is six turns in one session, so a per-turn defect shows
-up as a step: that pass stepped from 1.229 on turn one to a 1.447 median across
-turns two to six, and the same step appeared independently on the
-talk-end-to-tool-request mark, 0.599 rising to 0.730. The re-measured passes are
-flat, stepping 0.009 and 0.021. The 0.22 seconds was the relay resolving AWS
-credentials again for every turn's session, which review found and fixed:
-`Credentials` in `bin/fm-voice-relay.py` resolves once, and every later session
-reuses that answer, so a reconnect costs a reconnect.
+The first pass, on the relay as first written, put it 0.22 seconds behind the control, and that gap read as framing, the process hop and the per-turn reconnect.
+It was none of them, and the difference is worth keeping, because a wrong number invites a re-measurement while a wrong cause invites a fix to the wrong part of the relay.
+Each relay run is six turns in one session, so a per-turn defect shows up as a step: that pass stepped from 1.229 on turn one to a 1.447 median across turns two to six, and the same step appeared independently on the talk-end-to-tool-request mark, 0.599 rising to 0.730.
+The re-measured passes are flat, stepping 0.009 and 0.021.
+The 0.22 seconds was the relay resolving AWS credentials again for every turn's session, which review found and fixed: `Credentials` in `bin/fm-voice-relay.py` resolves once, and every later session reuses that answer, so a reconnect costs a reconnect.
+This is the second time credential resolution has dominated a voice path's latency on a host like this one, because earlier prototype work measured the local credential helper at about a second per call and found that fixed per-call overhead exceeded the model's own cost.
+So it is the first thing to suspect when a spoken path is slower than the model, and it is worth checking that anything new doing per-turn work resolves credentials once rather than once per session.
 
 What the relay figure does NOT include, and could not be measured from here:
 
 - **The SSH hop itself.**
-These runs drove the relay as a local child process, which is the identical relay command with only the `ssh -T <host>` prefix omitted, so the client, the framing, the uplink ordering, the relay, the records read and the handover are all real and only the SSH subprocess is absent.
-Two facts bound what its absence can be hiding.
-A constant transport cost cannot produce the turn-by-turn step that the credential defect produced, and the first pass, which did run over `ssh localhost`, put its own first turn 0.009 seconds above its own direct control.
-Neither of those is a measurement of the SSH path on this code, and neither is offered as one.
+  These runs drove the relay as a local child process, which is the identical relay command with only the `ssh -T <host>` prefix omitted, so the client, the framing, the uplink ordering, the relay, the records read and the handover are all real and only the SSH subprocess is absent.
+  Two facts bound what its absence can be hiding.
+  A constant transport cost cannot produce the turn-by-turn step that the credential defect produced, and the first pass, which did run over `ssh localhost`, put its own first turn 0.009 seconds above its own direct control.
+  Neither of those is a measurement of the SSH path on this code, and neither is offered as one.
 - **Your laptop's round trip to this desktop.**
-Add roughly your own round trip time: the audio goes up and the reply comes back, so it lands about once.
+  Add roughly your own round trip time: the audio goes up and the reply comes back, so it lands about once.
 - **Microphone capture and speaker output latency.**
-This desktop has no microphone and no speaker, so every measurement used audio files.
-The client reports both device figures in its own output, so your first live run measures them rather than guessing.
+  This desktop has no microphone and no speaker, so every measurement used audio files.
+  The client reports both device figures in its own output, so your first live run measures them rather than guessing.
 
-So your number is about 1.15 to 1.3 seconds plus your round trip time plus your
-audio devices. It is worth saying plainly that this came in under the bottom of
-the 1.5 to 2.5 second estimate the relay shape was given before it was built. The
-safer shape, with no credentials on the laptop, is not the slower one.
+So your number is about 1.15 to 1.3 seconds plus your round trip time plus your audio devices.
+It is worth saying plainly that this came in under the bottom of the 1.5 to 2.5 second estimate the relay shape was given before it was built.
+The safer shape, with no credentials on the laptop, is not the slower one.
 
 ## Setting up this desktop
 
@@ -274,8 +266,7 @@ these are the shapes.
 
 `$0.00293` per exchange, derived from the first pass's token counts and session seconds, which is roughly a dollar for three hundred and forty questions.
 The re-measured exchange is about a quarter of a second shorter, worth about `$0.00004` at the session rate below, so the figure is unchanged at the precision it is quoted to.
-Push to talk is `$0.0101` per minute of session
-against `$0.0151` with an open microphone.
+Push to talk is `$0.0101` per minute of session against `$0.0151` with an open microphone.
 
 Text in and out is materially dearer on this model version than the one it
 replaces, so a long system prompt or a large record answer is a real cost as well

--- a/docs/voice-relay.md
+++ b/docs/voice-relay.md
@@ -36,21 +36,39 @@ out-of-band capture already uses, rather than a second queue.
 
 ## What it costs in time
 
-Measured on 2026-08-21, `amazon.nova-2-sonic-v1:0` in `eu-north-1`, on a spoken
-question that makes the agent read the records before it can answer, which is the
-slowest ordinary case. Six runs each, all six answered each way.
+Measured on 2026-08-22 against the reviewed relay code, `amazon.nova-2-sonic-v1:0`
+in `eu-north-1`, on a spoken question that makes the agent read the records before
+it can answer, which is the slowest ordinary case. Six runs each, all six answered
+each way.
 
 | Path | First audio out, seconds | Median |
 | --- | --- | --- |
-| Direct from this desktop, no relay | 1.147 1.179 1.203 1.237 1.244 1.317 | 1.220 |
-| Over the relay, real client and framing | 1.229 1.379 1.428 1.447 1.481 1.516 | 1.438 |
+| Direct from this desktop, no relay | 1.165 1.190 1.215 1.250 1.281 1.352 | 1.232 |
+| Over the relay, real client and framing | 1.138 1.165 1.171 1.174 1.177 1.283 | 1.172 |
 
 The clock starts the instant the captain stops speaking and stops when the first
 byte of reply audio arrives. The direct figure reproduces the 1.164 second
-measurement in the earlier survey, which is what makes it usable as a control.
+measurement in the earlier survey, to within the noise floor below, which is what
+makes it usable as a control.
 
-**The relay costs about 0.22 seconds of the median.** That is framing, the extra
-process hop, and reconnecting the model session at the start of each turn.
+**The relay's own cost is smaller than this measurement can resolve.** The relay
+median lands below the direct control, which does not mean the relay is faster:
+two direct-control passes twenty minutes apart differ by 0.070 seconds of median,
+so that is the floor, and framing and the extra process hop are both under it.
+Read the two rows as the same number.
+
+The first pass, on the relay as first written, put it 0.22 seconds behind the
+control, and that gap read as framing, the process hop and the per-turn reconnect.
+It was none of them, and the difference is worth keeping, because a wrong number
+invites a re-measurement while a wrong cause invites a fix to the wrong part of
+the relay. Each relay run is six turns in one session, so a per-turn defect shows
+up as a step: that pass stepped from 1.229 on turn one to a 1.447 median across
+turns two to six, and the same step appeared independently on the
+talk-end-to-tool-request mark, 0.599 rising to 0.730. The re-measured passes are
+flat, stepping 0.009 and 0.021. The 0.22 seconds was the relay resolving AWS
+credentials again for every turn's session, which review found and fixed:
+`Credentials` in `bin/fm-voice-relay.py` resolves once, and every later session
+reuses that answer, so a reconnect costs a reconnect.
 
 What the relay figure does NOT include, and could not be measured from here:
 
@@ -62,10 +80,10 @@ What the relay figure does NOT include, and could not be measured from here:
   reports both device figures in its own output, so your first live run measures
   them rather than guessing.
 
-So your number is about 1.2 to 1.5 seconds plus your round trip time plus your
-audio devices. It is worth saying plainly that this came in at or under the
-bottom of the 1.5 to 2.5 second estimate the relay shape was given before it was
-built. The safer shape, with no credentials on the laptop, is not the slower one.
+So your number is about 1.15 to 1.3 seconds plus your round trip time plus your
+audio devices. It is worth saying plainly that this came in under the bottom of
+the 1.5 to 2.5 second estimate the relay shape was given before it was built. The
+safer shape, with no credentials on the laptop, is not the slower one.
 
 ## Setting up this desktop
 
@@ -175,11 +193,12 @@ Two settings control it, both optional and both in `config/`:
 `voice-read-deny` exists so that one future open item carrying a customer name
 can be excluded in a single line rather than by turning the feature off.
 
-The wider scope is not free. Measured on the same question, the wide answer is
-2872 bytes against 445, and it costs both time and consistency: 1.348, 1.866 and
-2.273 seconds against 1.351, 1.299 and 1.376. If the spoken answer only ever
-needs to be "three jobs running, two decisions waiting", `counts` is faster and
-steadier as well as narrower.
+The wider scope is not free. Measured on 2026-08-21 on the same question, on the
+relay as first written, so compare the two sides with each other rather than with
+the table above: the wide answer is 2872 bytes against 445, and it costs both time
+and consistency, at 1.348, 1.866 and 2.273 seconds against 1.351, 1.299 and 1.376.
+If the spoken answer only ever needs to be "three jobs running, two decisions
+waiting", `counts` is faster and steadier as well as narrower.
 
 An unreadable or misspelled `voice-read-scope` refuses rather than falling back
 to the wider setting, because falling back would widen what is sent on the

--- a/docs/voice-relay.md
+++ b/docs/voice-relay.md
@@ -36,10 +36,8 @@ out-of-band capture already uses, rather than a second queue.
 
 ## What it costs in time
 
-Measured on 2026-08-22 against the reviewed relay code, `amazon.nova-2-sonic-v1:0`
-in `eu-north-1`, on a spoken question that makes the agent read the records before
-it can answer, which is the slowest ordinary case. Six runs each, all six answered
-each way.
+Measured on 2026-08-21 against the reviewed relay code, `amazon.nova-2-sonic-v1:0` in `eu-north-1`, on a spoken question that makes the agent read the records before it can answer, which is the slowest ordinary case.
+Six runs each, all six answered each way.
 
 | Path | First audio out, seconds | Median |
 | --- | --- | --- |
@@ -72,13 +70,16 @@ reuses that answer, so a reconnect costs a reconnect.
 
 What the relay figure does NOT include, and could not be measured from here:
 
-- **Your laptop's round trip to this desktop.** The measurement ran over
-  `ssh localhost`, so the network hop is zero. Add roughly your own round trip
-  time: the audio goes up and the reply comes back, so it lands about once.
-- **Microphone capture and speaker output latency.** This desktop has no
-  microphone and no speaker, so every measurement used audio files. The client
-  reports both device figures in its own output, so your first live run measures
-  them rather than guessing.
+- **The SSH hop itself.**
+These runs drove the relay as a local child process, which is the identical relay command with only the `ssh -T <host>` prefix omitted, so the client, the framing, the uplink ordering, the relay, the records read and the handover are all real and only the SSH subprocess is absent.
+Two facts bound what its absence can be hiding.
+A constant transport cost cannot produce the turn-by-turn step that the credential defect produced, and the first pass, which did run over `ssh localhost`, put its own first turn 0.009 seconds above its own direct control.
+Neither of those is a measurement of the SSH path on this code, and neither is offered as one.
+- **Your laptop's round trip to this desktop.**
+Add roughly your own round trip time: the audio goes up and the reply comes back, so it lands about once.
+- **Microphone capture and speaker output latency.**
+This desktop has no microphone and no speaker, so every measurement used audio files.
+The client reports both device figures in its own output, so your first live run measures them rather than guessing.
 
 So your number is about 1.15 to 1.3 seconds plus your round trip time plus your
 audio devices. It is worth saying plainly that this came in under the bottom of
@@ -271,8 +272,9 @@ these are the shapes.
 
 ## Cost
 
-`$0.00293` per exchange on the numbers above, which is roughly a dollar for three
-hundred and forty questions. Push to talk is `$0.0101` per minute of session
+`$0.00293` per exchange, derived from the first pass's token counts and session seconds, which is roughly a dollar for three hundred and forty questions.
+The re-measured exchange is about a quarter of a second shorter, worth about `$0.00004` at the session rate below, so the figure is unchanged at the precision it is quoted to.
+Push to talk is `$0.0101` per minute of session
 against `$0.0151` with an open microphone.
 
 Text in and out is materially dearer on this model version than the one it

--- a/docs/voice-relay.md
+++ b/docs/voice-relay.md
@@ -1,0 +1,245 @@
+# The spoken interface
+
+Talk to a voice agent that sits in front of the first mate. It answers questions
+about what is happening from the first mate's own records, and when you ask for
+real work it says so out loud and queues the request rather than pretending to
+do it.
+
+This is step one of three: a spoken round trip that works. Interrupting the agent
+mid-sentence and carrying context from one question to the next are step three,
+and [what this build does not do](#what-this-build-does-not-do) is explicit about
+where the edge is.
+
+## The shape
+
+Your laptop captures the audio and plays the reply. This desktop holds the
+conversation with the model. Nothing in between needs AWS credentials on the
+laptop, which is the whole reason for this shape.
+
+```
+laptop                          this desktop                      AWS
+------                          ------------                      ---
+microphone --> fm-voice-client.py --(ssh)--> fm-voice-relay.py --> Nova Sonic 2
+speaker    <-------------------------------------------------      (eu-north-1)
+                                        |
+                                        +--> the first mate's records (read)
+                                        +--> fm-inbox.sh note (queue real work)
+```
+
+The two ends share one bidirectional byte stream over an SSH exec channel, so
+audio and control travel together and need framing. `bin/fm_voice_frame.py` is
+the owner of that format and is the only file both machines run.
+
+The relay reads records and queues work. It never changes a project, and the
+queueing half is `bin/fm-inbox.sh note`, the same surface the captain's own
+out-of-band capture already uses, rather than a second queue.
+
+## What it costs in time
+
+Measured on 2026-08-21, `amazon.nova-2-sonic-v1:0` in `eu-north-1`, on a spoken
+question that makes the agent read the records before it can answer, which is the
+slowest ordinary case. Six runs each, all six answered each way.
+
+| Path | First audio out, seconds | Median |
+| --- | --- | --- |
+| Direct from this desktop, no relay | 1.147 1.179 1.203 1.237 1.244 1.317 | 1.220 |
+| Over the relay, real client and framing | 1.229 1.379 1.428 1.447 1.481 1.516 | 1.438 |
+
+The clock starts the instant the captain stops speaking and stops when the first
+byte of reply audio arrives. The direct figure reproduces the 1.164 second
+measurement in the earlier survey, which is what makes it usable as a control.
+
+**The relay costs about 0.22 seconds of the median.** That is framing, the extra
+process hop, and reconnecting the model session at the start of each turn.
+
+What the relay figure does NOT include, and could not be measured from here:
+
+- **Your laptop's round trip to this desktop.** The measurement ran over
+  `ssh localhost`, so the network hop is zero. Add roughly your own round trip
+  time: the audio goes up and the reply comes back, so it lands about once.
+- **Microphone capture and speaker output latency.** This desktop has no
+  microphone and no speaker, so every measurement used audio files. The client
+  reports both device figures in its own output, so your first live run measures
+  them rather than guessing.
+
+So your number is about 1.2 to 1.5 seconds plus your round trip time plus your
+audio devices. It is worth saying plainly that this came in at or under the
+bottom of the 1.5 to 2.5 second estimate the relay shape was given before it was
+built. The safer shape, with no credentials on the laptop, is not the slower one.
+
+## Setting up this desktop
+
+The model is only reachable over HTTP/2 bidirectional streaming, which the AWS
+CLI cannot drive and `boto3` cannot either. It needs the experimental SDK, in a
+virtual environment of its own:
+
+```
+python3 -m venv ~/.fm-voice-venv
+~/.fm-voice-venv/bin/pip install aws-sdk-bedrock-runtime
+```
+
+Check it end to end without a microphone, using a recorded question:
+
+```
+cd /workplace/inthuson/firstmate
+~/.fm-voice-venv/bin/python bin/fm-voice-relay.py --self-test <clip.pcm>
+```
+
+The clip is headerless 16000 Hz mono signed 16-bit little-endian PCM and must end
+on speech, not silence. It prints one JSON line: what it heard, what it said, how
+long each stage took, and whether it answered at all. Feed it a clip that already
+ends in silence and it will tell you the timings are measured from the wrong
+instant rather than printing a number that looks fast.
+
+## Setting up the laptop
+
+**None of this is verified.** No worker can reach the captain's laptop, so the
+capture and playback paths have never run. Everything else in the client is
+exercised with files. Treat the first live run as the test, and expect the audio
+device setup to be where it fails.
+
+Copy the two files the laptop needs, and install the one dependency:
+
+```
+scp <desktop>:/workplace/inthuson/firstmate/bin/fm-voice-client.py .
+scp <desktop>:/workplace/inthuson/firstmate/bin/fm_voice_frame.py .
+python3 -m pip install sounddevice
+```
+
+`sounddevice` needs PortAudio, which on macOS is `brew install portaudio`. macOS
+will ask for microphone permission for whichever terminal you run this from, once.
+
+Then talk:
+
+```
+python3 fm-voice-client.py --host <desktop> --relay-python ~/.fm-voice-venv/bin/python
+```
+
+Press Enter to start talking, press Enter again when you have finished. It prints
+the timings for each turn as JSON on stdout and everything human on stderr, so
+`--runs 5 > runs.jsonl` gives you your own spread to compare against the table
+above.
+
+If the audio devices are not the ones you want, `--input-device` and
+`--output-device` take a name or an index; run with `--verbose` to see what it
+picked. If it fails before any audio, add `--verbose` and look for the handshake:
+a chatty login shell on the desktop printing to stdout is the one failure that
+looks like a protocol error and is not.
+
+## What it may read
+
+The captain granted the voice agent full read access to the first mate's records.
+Two whole classes of record are still excluded, and excluded by construction
+rather than filtered on the way out:
+
+- **Finished work**, because a spoken "what is happening" answer is about open
+  work, and old engagements accumulate in the history.
+- **Free-form note bodies**, because they are written for someone with the whole
+  file in front of them, and they are where commercial detail gets quoted.
+
+Only open work and this home's own runtime records are ever assembled. Verified
+against the captain's live records on 2026-08-21: every occurrence of the one
+customer identifier those records contain sits in finished work or a note body,
+so nothing a status answer can say names a customer.
+`tests/fm-voice-relay.test.sh` holds that boundary as an executable check, so
+widening the reader later fails a test instead of quietly widening what is sent.
+
+Two settings narrow it further, both optional and both in `config/`:
+
+| File | Effect |
+| --- | --- |
+| `voice-read-scope` | `full` (the default) sends counts plus the names, titles and pull request links of open work. `counts` sends counts only, with no record free text assembled at all. |
+| `voice-read-deny` | One plain case-insensitive substring per line; `#` comments. Anything matching becomes a withheld count, so the agent still says how much is waiting without saying what it is. An absent file means an empty list. |
+
+`voice-read-deny` exists so that one future open item carrying a customer name
+can be excluded in a single line rather than by turning the feature off.
+
+The wider scope is not free. Measured on the same question, the wide answer is
+2872 bytes against 445, and it costs both time and consistency: 1.348, 1.866 and
+2.273 seconds against 1.351, 1.299 and 1.376. If the spoken answer only ever
+needs to be "three jobs running, two decisions waiting", `counts` is faster and
+steadier as well as narrower.
+
+An unreadable or misspelled `voice-read-scope` refuses rather than falling back
+to the wider setting, because falling back would widen what is sent on the
+strength of a typo.
+
+## Push to talk, and how to flip it
+
+Push to talk is the default: the microphone is closed until you ask for it. That
+is `$0.0101` per minute against `$0.0151` for an open microphone, and it is the
+setting nobody has decided yet, so this build does not choose the expensive one
+on the captain's behalf.
+
+One flag flips it: `--listen open-mic`. The model's own speech detector then ends
+each turn instead of your key release, and the relay clock follows it, so the
+timings above stay comparable.
+
+## One turn per session, and what that gives up
+
+The relay reconnects to the model at the start of each turn. That is not
+tidiness, it is a measured requirement.
+
+A second question inside a session that has already answered one is treated as an
+interruption, unconditionally: the model raises it the instant the audio block
+opens. Waiting does not help. Six consecutive turns were tried with no wait, with
+a wait until all the reply audio had arrived, and with a wait of the reply's full
+spoken duration on top of that. Every one interrupted every second turn. Worse,
+an interrupted turn that needs to read the records is lost outright: the model
+asks for the records, takes them, and then never answers at all.
+
+Reconnecting costs 0.02 seconds and happens while the captain is pressing the
+talk key rather than while they are waiting for a reply, so it is invisible. With
+it, six turns in a row all answered.
+
+**What it gives up is memory.** Every question starts fresh, so "and what about
+that one" will not work. Carrying context across turns means handling
+interruption properly, which is step three.
+
+## Two traps worth keeping
+
+Both cost real time to find the first time. The code comments own the detail;
+these are the shapes.
+
+1. **The end of a reply is not the event that says the reply ended.** The obvious
+   completion event never arrives on its own. The real end is the content-end
+   event carrying an end-of-turn reason.
+2. **A clip with no trailing silence is never answered.** The model truncates it
+   and waits forever. The relay appends 400 ms of silence. Measured, this is a
+   content requirement and not a timing one: 0 ms and 100 ms were never answered,
+   while 200, 300, 400 and 800 ms all answered inside the same spread, because the
+   padding is sent as fast as the socket takes it. 400 ms is free margin above the
+   floor where answers start.
+
+## What this build does not do
+
+- **Interrupting the agent mid-sentence.** Nova Sonic supports it, measured, on
+  both model versions, so the capability is there when it is wanted. The concrete
+  thing step three has to solve is the interruption finding above: today any
+  second question in a session is treated as an interruption, and an interrupted
+  turn that reads the records produces no answer at all.
+- **Remembering the last question.** See above.
+- **Doing any project work.** Real work is queued for the first mate and the
+  agent says so out loud. It has no tool that changes a project.
+
+## Cost
+
+`$0.00293` per exchange on the numbers above, which is roughly a dollar for three
+hundred and forty questions. Push to talk is `$0.0101` per minute of session
+against `$0.0151` with an open microphone.
+
+Text in and out is materially dearer on this model version than the one it
+replaces, so a long system prompt or a large record answer is a real cost as well
+as a real delay. That is the second reason the reader caps its lists rather than
+sending every row.
+
+## Owners
+
+| Concern | Owner |
+| --- | --- |
+| Wire format between the two machines | `bin/fm_voice_frame.py` |
+| The relay, the model session, the tools | `bin/fm-voice-relay.py` |
+| The laptop end, capture and playback | `bin/fm-voice-client.py` |
+| What may be read, and queueing real work | `bin/fm_voice_records.py` |
+| The queue the handover writes to | `bin/fm-inbox.sh` |
+| The boundary as an executable check | `tests/fm-voice-relay.test.sh` |

--- a/docs/voice-relay.md
+++ b/docs/voice-relay.md
@@ -20,7 +20,7 @@ laptop, which is the whole reason for this shape.
 laptop                          this desktop                      AWS
 ------                          ------------                      ---
 microphone --> fm-voice-client.py --(ssh)--> fm-voice-relay.py --> Nova Sonic 2
-speaker    <-------------------------------------------------      (eu-north-1)
+speaker    <-------------------------------------------------      (your region)
                                         |
                                         +--> the first mate's records (read)
                                         +--> fm-inbox.sh note (queue real work)
@@ -78,10 +78,24 @@ python3 -m venv ~/.fm-voice-venv
 ~/.fm-voice-venv/bin/pip install aws-sdk-bedrock-runtime
 ```
 
+Then tell this home which account and model to use.
+The relay carries no default for any of these, because a region, a model id and an AWS profile name somebody's account and somebody's choices, and inheriting those from whoever wrote the code is not a sensible way to start talking to a paid API.
+Each value is one line in your gitignored `config/` directory, and each has an environment variable that overrides it for a single run.
+
+| File | Environment | Holds |
+| --- | --- | --- |
+| `config/voice-region` | `FM_VOICE_REGION` | The Bedrock region to open the session in, required. |
+| `config/voice-model` | `FM_VOICE_MODEL` | The Nova Sonic model id, required. |
+| `config/voice-profile` | `FM_VOICE_PROFILE` | The AWS profile to export credentials from, optional: with no profile the relay uses only credentials that are already in its environment. |
+| `config/voice-id` | `FM_VOICE_ID` | The output voice, optional and `matthew` when unset. |
+
+A missing required value refuses with the path to write, so an unconfigured home cannot start the relay by accident, and that configuration is the whole opt-in.
+`docs/configuration.md` is the registry for these files.
+
 Check it end to end without a microphone, using a recorded question:
 
 ```
-cd /workplace/inthuson/firstmate
+cd <your firstmate home>
 ~/.fm-voice-venv/bin/python bin/fm-voice-relay.py --self-test <clip.pcm>
 ```
 
@@ -101,8 +115,8 @@ device setup to be where it fails.
 Copy the two files the laptop needs, and install the one dependency:
 
 ```
-scp <desktop>:/workplace/inthuson/firstmate/bin/fm-voice-client.py .
-scp <desktop>:/workplace/inthuson/firstmate/bin/fm_voice_frame.py .
+scp <desktop>:<firstmate home>/bin/fm-voice-client.py .
+scp <desktop>:<firstmate home>/bin/fm_voice_frame.py .
 python3 -m pip install sounddevice
 ```
 
@@ -112,25 +126,27 @@ will ask for microphone permission for whichever terminal you run this from, onc
 Then talk:
 
 ```
-python3 fm-voice-client.py --host <desktop> --relay-python ~/.fm-voice-venv/bin/python
+python3 fm-voice-client.py --host <desktop> \
+  --relay <firstmate home>/bin/fm-voice-relay.py \
+  --relay-python ~/.fm-voice-venv/bin/python
 ```
+
+The client has no built-in idea of where the relay lives on your desktop, so `--relay` is required and `FM_VOICE_RELAY` sets it once for a shell.
 
 Press Enter to start talking, press Enter again when you have finished. It prints
 the timings for each turn as JSON on stdout and everything human on stderr, so
 `--runs 5 > runs.jsonl` gives you your own spread to compare against the table
 above.
 
-If the audio devices are not the ones you want, `--input-device` and
-`--output-device` take a name or an index; run with `--verbose` to see what it
-picked. If it fails before any audio, add `--verbose` and look for the handshake:
-a chatty login shell on the desktop printing to stdout is the one failure that
-looks like a protocol error and is not.
+If the audio devices are not the ones you want, `--input-device` and `--output-device` take a name or an index.
+Neither the client nor this guide can yet tell you which device it resolved, so an unexpected device is diagnosed by trying the other name or index rather than by reading a log line.
+If it fails before any audio, add `--verbose` and look for the handshake: a chatty login shell on the desktop printing to stdout is the one failure that looks like a protocol error and is not.
 
 ## What it may read
 
-The captain granted the voice agent full read access to the first mate's records.
-Two whole classes of record are still excluded, and excluded by construction
-rather than filtered on the way out:
+An unconfigured home gets the narrow scope: counts of what is in flight, what is waiting on the captain and what is open for review, with no identifier, title or link assembled at all.
+Widening that is one line the captain of those records writes into `config/voice-read-scope` themselves.
+Two whole classes of record are excluded at every scope, and excluded by construction rather than filtered on the way out:
 
 - **Finished work**, because a spoken "what is happening" answer is about open
   work, and old engagements accumulate in the history.
@@ -144,12 +160,12 @@ so nothing a status answer can say names a customer.
 `tests/fm-voice-relay.test.sh` holds that boundary as an executable check, so
 widening the reader later fails a test instead of quietly widening what is sent.
 
-Two settings narrow it further, both optional and both in `config/`:
+Two settings control it, both optional and both in `config/`:
 
 | File | Effect |
 | --- | --- |
-| `voice-read-scope` | `full` (the default) sends counts plus the names, titles and pull request links of open work. `counts` sends counts only, with no record free text assembled at all. |
-| `voice-read-deny` | One plain case-insensitive substring per line; `#` comments. Anything matching becomes a withheld count, so the agent still says how much is waiting without saying what it is. An absent file means an empty list. |
+| `voice-read-scope` | `counts` (the default, and what an absent file means) sends counts only, with no record free text assembled at all. `full` sends counts plus the names, titles and pull request links of open work. |
+| `voice-read-deny` | One plain case-insensitive substring per line; `#` comments. Each open item is matched once, against its identifier, its title, its tag values and its pull request link together, and a match is withheld from every list it could have appeared in and reduced to a count, so the agent still says how much is waiting without saying what it is. An absent file means an empty list. |
 
 `voice-read-deny` exists so that one future open item carrying a customer name
 can be excluded in a single line rather than by turning the feature off.

--- a/docs/voice-relay.md
+++ b/docs/voice-relay.md
@@ -180,16 +180,17 @@ An unreadable or misspelled `voice-read-scope` refuses rather than falling back
 to the wider setting, because falling back would widen what is sent on the
 strength of a typo.
 
-## Push to talk, and how to flip it
+## Push to talk, and the setting that refuses
 
 Push to talk is the default: the microphone is closed until you ask for it. That
 is `$0.0101` per minute against `$0.0151` for an open microphone, and it is the
 setting nobody has decided yet, so this build does not choose the expensive one
 on the captain's behalf.
 
-One flag flips it: `--listen open-mic`. The model's own speech detector then ends
-each turn instead of your key release, and the relay clock follows it, so the
-timings above stay comparable.
+`--listen open-mic` exists as a setting and refuses at startup today.
+An open microphone needs something to decide when you stopped speaking, and the client has no end-of-speech detection, so the mode would open a turn, stream audio forever and never mark a boundary, which leaves the relay appending to a session that has already answered.
+That detection belongs with carrying context across turns, which is step three, so the flag refuses before it opens an SSH connection or spends anything rather than half working.
+The setting stays where it is so that turning it on later is a small change rather than a new flag.
 
 ## One turn per session, and what that gives up
 

--- a/tests/fm-voice-relay.test.sh
+++ b/tests/fm-voice-relay.test.sh
@@ -210,6 +210,134 @@ for bad in (frame.HEADER.pack(frame.AUDIO, frame.MAX_PAYLOAD + 1),
 PY
 pass "the relay refuses a desynchronised uplink header instead of waiting for its payload"
 
+# --- whose account, whose model ---------------------------------------------
+#
+# A region, a model id and an AWS profile name somebody's account and somebody's
+# choices, so nothing here ships one. A home that has configured none of them
+# cannot start the relay at all, and it is told which file to write rather than
+# quietly reaching an API in somebody else's account. That configuration IS the
+# opt-in, so this case is what keeps the feature off by default.
+
+CONFIG_HOME="$TMP_ROOT/unconfigured"
+mkdir -p "$CONFIG_HOME/config"
+
+python3 - "$ROOT/bin" "$CONFIG_HOME" <<'PY' || fail "relay configuration"
+import sys
+sys.path.insert(0, sys.argv[1])
+import importlib.util, os, pathlib
+spec = importlib.util.spec_from_file_location(
+    "relay", str(pathlib.Path(sys.argv[1]) / "fm-voice-relay.py"))
+relay = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(relay)
+import fm_voice_records as records
+
+home = sys.argv[2]
+for name in ("FM_VOICE_REGION", "FM_VOICE_MODEL", "FM_VOICE_PROFILE", "FM_VOICE_ID",
+             "FM_CONFIG_OVERRIDE"):
+    os.environ.pop(name, None)
+
+def check(cond, label):
+    if not cond:
+        sys.exit("configuration: " + label)
+
+# An unconfigured home refuses, and the refusal is the path to write.
+try:
+    relay.resolve_settings(relay.parse_args(["--serve", "--home", home]))
+    sys.exit("configuration: an unconfigured home started the relay")
+except records.RecordError as exc:
+    check("voice-region" in str(exc),
+          "the refusal should name the file to write: %s" % exc)
+    check(home in str(exc), "and it should be this home's path: %s" % exc)
+
+# One file at a time: the region alone is not enough to reach a model.
+with open(os.path.join(home, "config", "voice-region"), "w") as handle:
+    handle.write("# the region this home talks to\neu-somewhere-1\n")
+try:
+    relay.resolve_settings(relay.parse_args(["--serve", "--home", home]))
+    sys.exit("configuration: a home with no model id started the relay")
+except records.RecordError as exc:
+    check("voice-model" in str(exc),
+          "the refusal should name the missing model file: %s" % exc)
+
+with open(os.path.join(home, "config", "voice-model"), "w") as handle:
+    handle.write("some.model-v1:0\n")
+options = relay.resolve_settings(relay.parse_args(["--serve", "--home", home]))
+check(options.region == "eu-somewhere-1",
+      "the configured region should be used, comment and all: %r" % options.region)
+check(options.model == "some.model-v1:0",
+      "the configured model should be used: %r" % options.model)
+# No profile configured means ambient credentials only, which is a real choice
+# rather than a missing one, so it is not a refusal.
+check(options.profile == "", "an absent profile should stay empty: %r" % options.profile)
+check(options.voice == relay.VOICE,
+      "an absent voice should fall back to the shipped one: %r" % options.voice)
+
+# The environment overrides a file for a single run.
+os.environ["FM_VOICE_REGION"] = "eu-elsewhere-2"
+os.environ["FM_VOICE_ID"] = "amy"
+options = relay.resolve_settings(relay.parse_args(["--serve", "--home", home]))
+check(options.region == "eu-elsewhere-2",
+      "the environment should override the file: %r" % options.region)
+check(options.voice == "amy", "the voice should be overridable: %r" % options.voice)
+
+# And an explicit flag overrides both.
+options = relay.resolve_settings(
+    relay.parse_args(["--serve", "--home", home, "--region", "eu-flag-3"]))
+check(options.region == "eu-flag-3", "a flag should win: %r" % options.region)
+
+# --help must work in a home that has configured nothing, or the captain cannot
+# read how to configure it.
+PY
+pass "the relay reads whose account to use from this home and refuses to guess"
+
+set +e
+help_out=$(python3 "$ROOT/bin/fm-voice-relay.py" --help 2>&1)
+help_code=$?
+set -e
+expect_code 0 "$help_code" "--help must work with no configuration: $help_out"
+assert_contains "$help_out" 'voice-region' \
+  "--help should name the files a home has to write"
+pass "an unconfigured home can still read how to configure the relay"
+
+# The captain inbox is the same rule with a different consequence: note, status,
+# list and drain make no model call, so they must keep working unconfigured. The
+# voice handover depends on note, so that is not a nicety.
+inbox_env=(FM_HOME="$CONFIG_HOME" FM_STATE_OVERRIDE="$CONFIG_HOME/state"
+           FM_CONFIG_OVERRIDE="$CONFIG_HOME/config")
+
+set +e
+ask_out=$(env "${inbox_env[@]}" "$ROOT/bin/fm-inbox.sh" ask "how is the fleet" 2>&1)
+ask_code=$?
+set -e
+[ "$ask_code" -ne 0 ] || fail "ask ran with nothing configured"
+assert_contains "$ask_out" 'inbox-region' \
+  "the first refusal should name the region file: $ask_out"
+
+# One file at a time, so each refusal names one thing to do.
+printf 'eu-somewhere-1\n' > "$CONFIG_HOME/config/inbox-region"
+set +e
+ask_out=$(env "${inbox_env[@]}" "$ROOT/bin/fm-inbox.sh" ask "how is the fleet" 2>&1)
+ask_code=$?
+set -e
+[ "$ask_code" -ne 0 ] || fail "ask ran without a configured model"
+assert_contains "$ask_out" 'inbox-ask-model' \
+  "the refusal should name the model file to write: $ask_out"
+
+set +e
+say_out=$(printf '' | env "${inbox_env[@]}" "$ROOT/bin/fm-inbox.sh" say 2>&1)
+say_code=$?
+set -e
+[ "$say_code" -ne 0 ] || fail "say ran without a configured model"
+assert_contains "$say_out" 'inbox-stt-model' \
+  "the refusal should name the model file to write: $say_out"
+
+rm -f "$CONFIG_HOME/config/inbox-region"
+unconfigured_note=$(env "${inbox_env[@]}" \
+  "$ROOT/bin/fm-inbox.sh" note "the handover must work with no configuration") \
+  || fail "note should not need any configuration"
+assert_contains "$unconfigured_note" 'queued ' "note should still queue a record"
+pass "the model-backed subcommands refuse by name while note keeps working"
+
 # --- the tool surface the two sides share -----------------------------------
 #
 # The relay declares the tools and fm_voice_records implements them. Renaming one
@@ -302,8 +430,11 @@ os.environ["AWS_CREDENTIAL_EXPIRATION"] = iso(time.time() + 3600)
 check(isinstance(relay.ambient_credentials()[1], float),
       "a stated deadline should be carried through as the expiry")
 # The environment wins while it is usable, so this never shells out to a profile.
-check(relay.resolve_credentials("no-such-profile")[0]["aws_session_token"] == "t0ken",
+picked = relay.resolve_credentials("no-such-profile")
+check(picked[0]["aws_session_token"] == "t0ken",
       "the environment should be preferred over the profile while it is usable")
+check(picked[2] == relay.FROM_ENVIRONMENT,
+      "the resolver must say where the credentials came from: %r" % (picked[2],))
 
 os.environ["AWS_CREDENTIAL_EXPIRATION"] = iso(time.time() - 1)
 check(relay.ambient_credentials() is None,
@@ -315,6 +446,37 @@ check(relay.ambient_credentials(margin=300) is None,
 check(relay.ambient_credentials(margin=0) is not None,
       "the same credentials are still usable when no margin is asked for")
 
+# A profile export that fails must be an ordinary exception. SystemExit would walk
+# straight through the per-turn boundary in handle_uplink_frame and end the relay,
+# and since credentials are resolved lazily this refusal can land mid-conversation.
+class Failed:
+    returncode = 1
+    stdout = ""
+    stderr = "The config profile (nobody) could not be found"
+
+real_run = relay.subprocess.run
+relay.subprocess.run = lambda *a, **k: Failed()
+try:
+    relay.profile_credentials("nobody")
+    sys.exit("credentials: a failed profile export was accepted")
+except relay.CredentialError as exc:
+    check(isinstance(exc, Exception),
+          "the refusal must be an ordinary exception, not a SystemExit")
+    check("nobody" in str(exc), "the refusal should name the profile: %s" % exc)
+except SystemExit:
+    sys.exit("credentials: a failed profile export raised SystemExit")
+finally:
+    relay.subprocess.run = real_run
+
+# No profile and no environment is also a named refusal rather than a traceback
+# from inside the AWS CLI argument list.
+try:
+    relay.profile_credentials("")
+    sys.exit("credentials: an empty profile was accepted")
+except relay.CredentialError as exc:
+    check("voice-profile" in str(exc),
+          "the refusal should name the file to write: %s" % exc)
+
 for name in AWS_VARS:
     os.environ.pop(name, None)
 
@@ -322,14 +484,15 @@ calls = []
 stamp = [""]
 delay = [0.0]
 
-def fake(profile, verbose=False, margin=0):
+def fake(profile, verbose=False, margin=0, allow_ambient=True):
     # Whatever the profile says about expiry reaches the cache through the real
     # parser, so the fixture hands it a stamp rather than a decided answer.
     calls.append(profile)
     time.sleep(delay[0])
     return ({"aws_access_key_id": "AK%d" % len(calls)},
-            relay._expires_at(stamp[0]))
+            relay._expires_at(stamp[0]), relay.FROM_PROFILE)
 
+real_resolve = relay.resolve_credentials
 relay.resolve_credentials = fake
 
 async def take(cache, count):
@@ -407,6 +570,41 @@ async def resolve_while_the_loop_runs():
 during = asyncio.run(resolve_while_the_loop_runs())
 check(during >= 2,
       "the event loop ran %d times during a 0.3s credential resolution" % during)
+
+# GIVING UP ON AMBIENT CREDENTIALS HAS TO STICK. A bound that re-reads the same
+# environment is not a bound: os.environ never gets fresher values while this
+# process runs, so the same stale keys would come back every time and every
+# session past the real deadline would fail while a working profile went untried.
+# This drives the real resolver, with only the profile export replaced.
+relay.resolve_credentials = real_resolve
+exports = []
+
+def fake_profile(profile, verbose=False):
+    exports.append(profile)
+    return {"aws_access_key_id": "FROM-PROFILE",
+            "aws_secret_access_key": "s", "aws_session_token": None}, None
+
+relay.profile_credentials = fake_profile
+os.environ["AWS_ACCESS_KEY_ID"] = "AKIAENVIRONMENT"
+os.environ["AWS_SECRET_ACCESS_KEY"] = "s3cret"
+os.environ["AWS_SESSION_TOKEN"] = "stale-token"
+os.environ.pop("AWS_CREDENTIAL_EXPIRATION", None)
+
+cache = Bounded("a-profile")
+first = asyncio.run(cache.get())
+check(first["aws_session_token"] == "stale-token",
+      "usable ambient credentials should be preferred: %r" % first)
+check(exports == [], "the profile should not be consulted while ambient ones hold")
+time.sleep(0.1)
+later = [asyncio.run(cache.get()) for _ in range(3)]
+check([c["aws_access_key_id"] for c in later] == ["FROM-PROFILE"] * 3,
+      "past the margin the relay must ask the profile, not re-read the "
+      "environment it already gave up on: %r" % later)
+check(len(exports) == 1,
+      "and the profile answer is then cached like any other: %d exports" % len(exports))
+
+for name in AWS_VARS:
+    os.environ.pop(name, None)
 PY
 pass "credentials are resolved once per relay, refreshed before expiry, off the event loop"
 
@@ -501,10 +699,28 @@ check([n["event"] for n in down.notices] == ["turn-failed"],
 check("ThrottlingException" in down.notices[0].get("error", ""),
       "the notice should name the failure: %s" % down.notices[0])
 
+# ONCE PER TURN, not once per frame. The captain is still holding the talk key
+# when the failure lands, so the rest of that press is another thirty audio
+# frames, one per hundred milliseconds. The client says every notice out loud on
+# stderr, so reporting each one would put ten identical lines a second in front of
+# the captain while they are still speaking, and would keep calling into a session
+# that is already gone.
+held = Stub(raises=RuntimeError("ValidationException"))
+frames = [(frame.TALK_START, b"")] + [(frame.AUDIO, b"x" * 3200)] * 30
+frames.append((frame.TALK_END, b""))
+session, serving, down = asyncio.run(drive(held, frames))
+check(serving, "a failed turn must not stop the relay")
+check(len(down.notices) == 1,
+      "a failed turn must be announced once, not once per frame: %d notices"
+      % len(down.notices))
+check(held.calls == ["talk_start"],
+      "nothing after the failure should reach the dead session: %s" % held.calls)
+
 # And the next talk key rebuilds instead of reusing it, which is what marking it
 # spent is for.
 renewed = []
 fresh = Stub()
+real_renew = relay.renew
 
 async def fake_renew(session, options, down):
     renewed.append(session)
@@ -534,6 +750,44 @@ check(spent.calls == [], "a session whose reconnect failed must not be spoken to
 # Quit still ends the loop, so the relay exits when the client says so.
 session, serving, down = asyncio.run(drive(Stub(), [(frame.QUIT, b"")]))
 check(not serving, "quit must end the loop")
+
+# A reconnect that fails part way must not strand the session it was building.
+# start() opens the model stream and a reader task before it sends anything, and
+# the relay now survives the failure and retries, so a session left open here
+# would accumulate one live stream and one live task per retry, all of them still
+# writing into the shared downlink.
+class Partial:
+    """A session whose start fails after it would have opened the stream."""
+
+    def __init__(self, *args):
+        self.closed = 0
+        self.credentials = None
+        self.connect_seconds = None
+
+    async def start(self):
+        raise RuntimeError("ServiceUnavailableException")
+
+    async def close(self):
+        self.closed += 1
+
+built = []
+
+def make_partial(options, down, credentials):
+    session = Partial()
+    built.append(session)
+    return session
+
+relay.Session = make_partial
+outgoing = Partial()
+try:
+    asyncio.run(real_renew(outgoing, options, Down()))
+    sys.exit("failed turn: a failed reconnect was reported as success")
+except RuntimeError:
+    pass
+check(len(built) == 1, "renew should have built one replacement: %d" % len(built))
+check(built[0].closed == 1,
+      "a session whose start failed must be closed, not stranded: %d closes"
+      % built[0].closed)
 PY
 pass "a turn the model refuses is announced and costs one turn, not the relay"
 
@@ -547,7 +801,7 @@ pass "a turn the model refuses is announced and costs one turn, not the relay"
 # protocol bug and is not.
 
 python3 - "$ROOT/bin" <<'PY' || fail "laptop client"
-import io, sys
+import io, os, sys
 sys.path.insert(0, sys.argv[1])
 import importlib.util, pathlib
 spec = importlib.util.spec_from_file_location(
@@ -559,6 +813,24 @@ import fm_voice_frame as frame
 def check(cond, label):
     if not cond:
         sys.exit("client: " + label)
+
+# Where the relay lives on the desktop is one operator's directory layout, so the
+# client carries no default for it and says so rather than trying a path that
+# belongs to somebody else. The refusal is checked before the variable below is
+# set, because after that every other case supplies it.
+os.environ.pop("FM_VOICE_RELAY", None)
+try:
+    client.parse_args(["--host", "desk"])
+    sys.exit("client: started with no relay path at all")
+except SystemExit as exc:
+    check(exc.code != 0, "a missing relay path must be a refusal, not a default")
+
+os.environ["FM_VOICE_RELAY"] = "/desktop/firstmate/bin/fm-voice-relay.py"
+check(client.parse_args(["--host", "desk"]).relay
+      == "/desktop/firstmate/bin/fm-voice-relay.py",
+      "FM_VOICE_RELAY should supply the relay path for a whole shell")
+check(client.parse_args(["--host", "desk", "--relay", "/other/relay.py"]).relay
+      == "/other/relay.py", "an explicit --relay must win over the variable")
 
 # Push to talk is the default for this build, and open mic is the one flip.
 check(client.parse_args(["--host", "h"]).listen == client.PUSH_TO_TALK,
@@ -706,14 +978,35 @@ assert_not_contains "$wide" 'needs a credential' \
   "full scope must not carry the raw event line of a bracketed status"
 pass "the wide scope names open work and reports state without quoting event lines"
 
-# The default is the wide scope, because that is the access the captain granted.
+# THE DEFAULT IS THE NARROW SCOPE. A home that has configured nothing has granted
+# nothing, and sending task identifiers, titles and pull request links to a model
+# in another region is not something to inherit from somebody else's settings
+# file. Widening is one line the captain of those records writes themselves.
 default=$(records_status) || fail "default scope failed"
-assert_contains "$default" '"scope": "full"' "the default read scope should be full"
-pass "an absent read-scope setting means the access the captain granted"
+assert_contains "$default" '"scope": "counts"' \
+  "an unconfigured home should get the narrow scope"
+assert_not_contains "$default" 'alpha-one' \
+  "an unconfigured home must not name work"
+assert_not_contains "$default" 'sign-in redirect' \
+  "an unconfigured home must not carry titles"
+assert_not_contains "$default" 'github.com' \
+  "an unconfigured home must not carry pull request links"
+assert_contains "$default" '"in_flight": 3' \
+  "an unconfigured home should still say how much is waiting"
+pass "an absent read-scope setting means the narrowest answer, not the widest"
+
+# Widening is what the file is for, and it takes effect without a flag.
+printf 'full\n' > "$HOME_FIXTURE/config/voice-read-scope"
+widened=$(records_status) || fail "configured wide scope failed"
+assert_contains "$widened" '"scope": "full"' \
+  "writing full into config/voice-read-scope should widen the answer"
+assert_contains "$widened" 'alpha-one' "the wide scope should then name work"
+rm -f "$HOME_FIXTURE/config/voice-read-scope"
+pass "a home widens its own read scope by writing the setting"
 
 # --- the confidentiality boundary -------------------------------------------
 #
-# This is the case that lets the wide scope be the default.
+# This is the case that lets a home widen to the full scope at all.
 
 for scope in full counts; do
   answer=$(records_status --scope "$scope") || fail "scope $scope failed"
@@ -798,9 +1091,15 @@ rm -f "$HOME_FIXTURE/config/voice-read-deny"
 # That is not a narrower answer, it is a leak with a reassuring count beside it.
 # Both items below sit in all three lists, and each is matched on a field only
 # one of those lists reads.
+#
+# The third item is the one an in-flight-only fixture cannot catch: a QUEUED item
+# that nothing holds for the captain, so no list iterates it, while its pull
+# request link still reaches the answer through the worker records. Assembling its
+# fields only where some list walks past it misses a match on its own title.
 LEAK_HOME="$TMP_ROOT/deny-every-list"
 TITLE_TOKEN=LEAKSBYTITLE
 HOLD_TOKEN=LEAKSBYHOLD
+QUEUED_TOKEN=LEAKSFROMQUEUED
 mkdir -p "$LEAK_HOME/data" "$LEAK_HOME/state" "$LEAK_HOME/config"
 cat > "$LEAK_HOME/data/backlog.md" <<EOF
 # Backlog
@@ -808,11 +1107,16 @@ cat > "$LEAK_HOME/data/backlog.md" <<EOF
 ## In flight
 - [ ] omega-nine - Renew the $TITLE_TOKEN contract (repo: omega) (kind: captain)
 - [ ] sigma-ten - Move the account onto the new tier (repo: sigma) (kind: ship) (hold-kind: captain) (hold: waiting on the $HOLD_TOKEN owner)
+
+## Queued
+- [ ] zeta-eight - Migrate the $QUEUED_TOKEN estate (repo: zeta) (kind: ship)
 EOF
 fm_write_meta "$LEAK_HOME/state/omega-nine.meta" \
   kind=captain pr=https://github.com/example/omega/pull/11
 fm_write_meta "$LEAK_HOME/state/sigma-ten.meta" \
   kind=ship pr=https://github.com/example/sigma/pull/12
+fm_write_meta "$LEAK_HOME/state/zeta-eight.meta" \
+  kind=ship pr=https://github.com/example/zeta/pull/99
 
 leak_status() {
   python3 "$ROOT/bin/fm_voice_records.py" status --home "$LEAK_HOME" --scope full
@@ -826,7 +1130,10 @@ assert_contains "$reachable" 'pull/11' "fixture: its pull request should be reac
 assert_contains "$reachable" 'sigma-ten' "fixture: the held item should be named"
 assert_contains "$reachable" 'pull/12' "fixture: its pull request should be reachable"
 assert_contains "$reachable" '"awaiting_captain": 2' \
-  "fixture: both items should be waiting on the captain"
+  "fixture: both in-flight items should be waiting on the captain"
+assert_contains "$reachable" 'pull/99' \
+  "fixture: the queued item should reach the answer through its pull request"
+assert_contains "$reachable" '"queued": 1' "fixture: the queued item should be counted"
 
 # Matched on its title, which only the in-flight list reads.
 printf '%s\n' "$TITLE_TOKEN" > "$LEAK_HOME/config/voice-read-deny"
@@ -838,10 +1145,11 @@ assert_not_contains "$by_title" 'pull/11' \
   "a denied item must not surface through its pull request link"
 assert_contains "$by_title" '"withheld_as_confidential": 1' \
   "the denied item should be counted once"
-# The other item is untouched, so this is a substring list and not a switch.
+# The other items are untouched, so this is a substring list and not a switch.
 assert_contains "$by_title" 'sigma-ten' "the deny list must not suppress everything"
-assert_contains "$by_title" 'pull/12' "the other pull request should still be named"
-assert_contains "$by_title" '"open_pull_requests": 2' \
+assert_contains "$by_title" 'pull/12' "the other pull requests should still be named"
+assert_contains "$by_title" 'pull/99' "the other pull requests should still be named"
+assert_contains "$by_title" '"open_pull_requests": 3' \
   "denying an item must not change the count of open pull requests"
 
 # Matched on its hold text, which only the captain list reads. The mirror of the
@@ -858,6 +1166,24 @@ assert_contains "$by_hold" 'omega-nine' "the deny list must not suppress everyth
 assert_contains "$by_hold" 'pull/11' "the other pull request should still be named"
 assert_contains "$by_hold" '"in_flight": 2' \
   "denying an item must not change the count of in-flight work"
+
+# Matched on the title of a QUEUED item that no list iterates. Its only way into
+# the answer is its pull request link, and the pull request list knows nothing
+# about titles, so a field set assembled per list never sees the match at all.
+printf '%s\n' "$QUEUED_TOKEN" > "$LEAK_HOME/config/voice-read-deny"
+by_queued=$(leak_status) || fail "deny by queued title failed"
+assert_not_contains "$by_queued" "$QUEUED_TOKEN" \
+  "a queued item's title match must be suppressed"
+assert_not_contains "$by_queued" 'zeta-eight' \
+  "a denied queued item must not be named"
+assert_not_contains "$by_queued" 'pull/99' \
+  "a denied queued item must not surface through its pull request link"
+assert_contains "$by_queued" '"withheld_as_confidential": 1' \
+  "a denied queued item must be counted, so nothing is hidden silently"
+assert_contains "$by_queued" '"queued": 1' \
+  "denying it must not change the count of queued work"
+assert_contains "$by_queued" 'pull/11' "the other pull requests should still be named"
+assert_contains "$by_queued" 'pull/12' "the other pull requests should still be named"
 pass "one deny decision per item covers every list that item could appear in"
 
 # --- refusals ---------------------------------------------------------------

--- a/tests/fm-voice-relay.test.sh
+++ b/tests/fm-voice-relay.test.sh
@@ -800,6 +800,7 @@ class Stub:
         self.replies = 0
         self.failed = False
         self.ended = asyncio.Event()
+        self.turn = {}
         self.calls = []
 
     async def _step(self, name):
@@ -1024,10 +1025,18 @@ pass "audio that arrives with no turn open is dropped, not turned into a turn"
 # kept its exception, close() re-raised it on every await, renew never reached
 # the line that builds a replacement, and the captain heard the same failure
 # forever with no way back short of restarting the relay.
+#
+# Releasing the waiting turn is only half of it. The client waits for a reply end
+# or a notice, so a reader failure that says nothing costs the captain their whole
+# timeout and leaves a record that says the turn was not answered without saying
+# why. It has to be named, once, and only when it really is a failure: a stream
+# that simply ends, and a stream that went away because close() asked it to, are
+# both ordinary and neither may look like one.
 
 python3 - "$ROOT/bin" "$TMP_ROOT/reader-home" <<'PY' || fail "reader failure"
 import asyncio, json, os, sys
 sys.path.insert(0, sys.argv[1])
+import fm_voice_frame as frame
 import importlib.util, pathlib
 spec = importlib.util.spec_from_file_location(
     "relay", str(pathlib.Path(sys.argv[1]) / "fm-voice-relay.py"))
@@ -1078,40 +1087,68 @@ class Receiver:
         self._raw = raw
 
     async def receive(self):
-        return Result(self._raw)
+        return None if self._raw is None else Result(self._raw)
 
 class Stream:
-    """One model event, then a stream that has gone away."""
+    """The scripted events, and then either a clean end or a stream that is gone."""
 
-    def __init__(self, raws):
+    def __init__(self, raws, clean=False):
         self._raws = list(raws)
+        self._clean = clean
         self.input_stream = Input()
 
     async def await_output(self):
         if not self._raws:
+            if self._clean:
+                return (None, Receiver(None))
             raise RuntimeError("the model stream is gone")
         return (None, Receiver(self._raws.pop(0)))
 
 TOOL_EVENT = json.dumps({"event": {"toolUse": {
     "toolName": "no_such_tool", "toolUseId": "t-1", "content": "{}"}}}).encode()
 
-async def one_case(fail_in_handler):
-    """Poison a session the way the finding describes, then try the next turn."""
-    session = relay.Session(options, Down(), None)
+def failures(down):
+    return [n for n in down.notices if n.get("event") == "turn-failed"]
+
+async def poison(how):
+    """Break a session one of the ways the model side can break it."""
+    down = Down()
+    session = relay.Session(options, down, None)
     session.stream = Stream([TOOL_EVENT])
-    if fail_in_handler:
+    # A turn is open and waiting for a reply, which is when this costs the most.
+    session.turn["talk_end"] = 0.0
+    if how == "handler":
         async def boom(event):
             raise RuntimeError("handling blew up")
         session._handle = boom
-    else:
+    elif how == "tool-result":
         # The real _handle and _run_tool, with the tool-result send failing: the
         # shape a dropped stream takes while the relay answers a tool call.
         async def refuse(obj):
             raise RuntimeError("the model stream is gone")
         session._send = refuse
+    elif how == "drop":
+        # Nothing to read and no clean end: the stream simply goes away, which is
+        # what a network blip looks like from here.
+        session.stream = Stream([])
     session.reader_task = asyncio.create_task(session._read_model())
     await asyncio.wait_for(session.ended.wait(), timeout=5)
-    check(session.turn_done.is_set(), "a waiting turn must be released")
+    return down, session
+
+async def one_case(how):
+    """Break a session, then take the next turn over the same relay."""
+    down, session = await poison(how)
+    check(session.turn_done.is_set(),
+          "%s: a waiting turn must be released" % how)
+    check(session.failed, "%s: the session must be marked spent" % how)
+    named = failures(down)
+    check(len(named) == 1,
+          "%s: the captain must be told once, not never and not twice: %r"
+          % (how, down.notices))
+    check(named[0].get("error"),
+          "%s: the notice must carry the cause: %r" % (how, named[0]))
+    check(session.turn.get("failed") == named[0]["error"],
+          "%s: the run record must carry the same cause: %r" % (how, session.turn))
 
     # close() absorbs the stored failure however many times it is asked, which is
     # what lets the next turn get as far as building a replacement.
@@ -1123,28 +1160,98 @@ async def one_case(fail_in_handler):
     class Fresh:
         def __init__(self, *args):
             self.connect_seconds = 0.02
+            self.failed = False
+            self.replies = 0
+            self.ended = asyncio.Event()
+            self.turns = 0
             built.append(self)
 
         async def start(self):
             pass
 
+        async def talk_start(self):
+            self.turns += 1
+
     real, relay.Session = relay.Session, Fresh
     try:
-        replacement = await relay.renew(session, options, Down())
+        used, serving = await relay.handle_uplink_frame(
+            frame.TALK_START, b"", session, options, down)
     finally:
         relay.Session = real
-    return replacement, built
-
-for fails_in_handler in (True, False):
-    where = "the event handler" if fails_in_handler else "the tool result send"
-    replacement, built = asyncio.run(one_case(fails_in_handler))
     check(len(built) == 1,
-          "after a failure in %s the next turn must build a session: %r"
-          % (where, built))
-    check(replacement is built[0],
-          "and renew must hand that replacement back for %s" % where)
+          "%s: the next talk key must build a session: %r" % (how, built))
+    check(used is built[0] and serving,
+          "%s: the relay must go on serving with it: %r %r" % (how, used, serving))
+    check(used.turns == 1, "%s: and give it the new turn: %r" % (how, used.turns))
+    check(len(failures(down)) == 1,
+          "%s: recovering must not name the turn again: %r" % (how, down.notices))
+
+for how in ("handler", "tool-result", "drop"):
+    asyncio.run(one_case(how))
+
+# A stream that simply ends is the end of a session, not a failed turn, and the
+# relay reads the two differently: serve treats a clean end as its own reason to
+# stop, so calling one a failure would change what a model-initiated end means.
+async def clean_end():
+    down = Down()
+    session = relay.Session(options, down, None)
+    session.stream = Stream([], clean=True)
+    session.reader_task = asyncio.create_task(session._read_model())
+    await asyncio.wait_for(session.ended.wait(), timeout=5)
+    return down, session
+
+down, ended = asyncio.run(clean_end())
+check(ended.turn_done.is_set(), "a clean end must release a waiting turn too")
+check(not ended.failed, "a clean end of stream is not a turn failure")
+check(not failures(down),
+      "and nothing should be named to the captain: %r" % (down.notices,))
+
+# Nor is a stream that went away because close() asked it to. renew closes the
+# old session on every single turn, so announcing that would put a failure notice
+# in front of the captain on every ordinary turn.
+async def torn_down():
+    down = Down()
+    session = relay.Session(options, down, None)
+    gone = asyncio.Event()
+
+    class Closer:
+        async def send(self, chunk):
+            pass
+
+        async def close(self):
+            # The stream goes away exactly when close() closes the input half,
+            # which is the ordering every renewed turn goes through.
+            gone.set()
+
+    class Blocking:
+        def __init__(self):
+            self.input_stream = Closer()
+
+        async def await_output(self):
+            await gone.wait()
+            raise RuntimeError("the model stream is gone")
+
+    async def quiet(obj):
+        pass
+
+    session.stream = Blocking()
+    # The real one builds an SDK event, and the SDK is deliberately not installed
+    # here; what this case needs is close() getting as far as the input half.
+    session._send = quiet
+    session.reader_task = asyncio.create_task(session._read_model())
+    await asyncio.sleep(0)
+    await session.close()
+    await asyncio.wait_for(session.ended.wait(), timeout=5)
+    return down, session
+
+down, closed = asyncio.run(torn_down())
+check(closed.ended.is_set(), "the reader must still report the session over")
+check(not closed.failed, "a deliberate close is not a turn failure")
+check(not failures(down),
+      "and an ordinary renew must not look like a failure: %r" % (down.notices,))
 PY
 pass "a failure inside the model reader costs one turn, not every later one"
+pass "a reader failure is named to the captain, a clean end and a close are not"
 
 # --- the laptop end ---------------------------------------------------------
 #
@@ -1155,7 +1262,10 @@ pass "a failure inside the model reader costs one turn, not every later one"
 # banner-printing login shell desynchronises the stream in a way that looks like a
 # protocol bug and is not.
 
-python3 - "$ROOT/bin" <<'PY' || fail "laptop client"
+mkdir -p "$TMP_ROOT/client-files"
+printf '\0\0\0\0' > "$TMP_ROOT/client-files/clip.pcm"
+
+python3 - "$ROOT/bin" "$TMP_ROOT/client-files" <<'PY' || fail "laptop client"
 import io, os, sys
 sys.path.insert(0, sys.argv[1])
 import importlib.util, pathlib
@@ -1164,6 +1274,8 @@ spec = importlib.util.spec_from_file_location(
 client = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(client)
 import fm_voice_frame as frame
+
+TMP = sys.argv[2]
 
 def check(cond, label):
     if not cond:
@@ -1354,20 +1466,50 @@ real_sync = client.sync_magic
 client.SpeakerPlayback = Boom
 client.subprocess.Popen = FakeProc
 client.sync_magic = lambda stream, verbose=False: None
-named = None
+
+def refusal_for(argv):
+    """Return how open() refuses, as (exception type name, message)."""
+    try:
+        client.Client(client.parse_args(["--host", "desk"] + argv)).open()
+    except BaseException as exc:               # noqa: BLE001
+        return type(exc).__name__, str(exc)
+    return None, "open() did not refuse"
+
+kind, named = refusal_for([])
 try:
-    client.Client(client.parse_args(["--host", "desk"])).open()
-except client.DeviceError as exc:
-    named = str(exc)
-except Exception as exc:                       # noqa: BLE001
-    named = "wrong type: %s: %s" % (type(exc).__name__, exc)
+    check(kind == "DeviceError",
+          "a device failure should be a named refusal, got %s: %s" % (kind, named))
+    check("could not open the audio device" in named,
+          "and should say what it could not open: %s" % named)
+    check("--output-device" in named,
+          "and should name the flag for that end: %s" % named)
+    check("--in-file" in named,
+          "and should name a way to run without a device: %s" % named)
+
+    # The file ends are the ones this host runs and the ones every measured
+    # figure was taken with, so a path that cannot be opened must say so and name
+    # the flag that chose it. Calling it a device failure sends the reader to
+    # --input-device when the thing to fix is the path.
+    missing = os.path.join(TMP, "no-such-clip.pcm")
+    kind, named = refusal_for(["--in-file", missing, "--out-file",
+                               os.path.join(TMP, "reply.pcm")])
+    check(kind in ("OSError", "FileNotFoundError"),
+          "a missing clip is not a device failure, got %s: %s" % (kind, named))
+    check(missing in named, "the refusal must name the path: %s" % named)
+    check("--in-file" in named and "--output-device" not in named,
+          "and the flag that named it, and no device advice: %s" % named)
+
+    nowhere = os.path.join(TMP, "no-such-dir", "reply.pcm")
+    kind, named = refusal_for(["--in-file", os.path.join(TMP, "clip.pcm"),
+                               "--out-file", nowhere])
+    check(kind in ("OSError", "FileNotFoundError"),
+          "an unwritable reply file is not a device failure either: %s" % named)
+    check(nowhere in named and "--out-file" in named,
+          "and must name the path and its flag: %s" % named)
 finally:
     client.SpeakerPlayback = real_speaker
     client.subprocess.Popen = real_popen
     client.sync_magic = real_sync
-check(named is not None and "could not open the audio devices" in named,
-      "a device failure should be a named refusal: %s" % named)
-check("--in-file" in named, "and should name a way to run without them: %s" % named)
 
 # A login shell banner is discarded with a warning naming it, not an error.
 noise = b"You have mail.\n"

--- a/tests/fm-voice-relay.test.sh
+++ b/tests/fm-voice-relay.test.sh
@@ -68,7 +68,11 @@ EOF
     pr=https://github.com/example/alpha/pull/7
   fm_write_meta "$HOME_FIXTURE/state/gamma-three.meta" kind=ship mode=direct-PR
   printf 'working: reading the failing test\n' > "$HOME_FIXTURE/state/alpha-one.status"
-  printf 'blocked: needs a credential\n' > "$HOME_FIXTURE/state/gamma-three.status"
+  # The bracketed shape, which is what bin/fm-secondmate-report.sh writes and
+  # what a keyed decision line looks like. Status metadata sits between the verb
+  # and the colon, so a reader that only cuts at the colon reads no verb here.
+  printf 'blocked [key=api-shape]: needs a credential (via-helper)\n' \
+    > "$HOME_FIXTURE/state/gamma-three.status"
 }
 
 records_status() {
@@ -143,11 +147,17 @@ try:
 except frame.FrameError:
     pass
 
-# The magic string exists so a chatty login shell cannot desynchronise the
-# stream, so it has to be findable in a prefix that contains junk.
-noise = b"Welcome to the host!\n" + frame.MAGIC + frame.encode(frame.BYE)
-check(noise.index(frame.MAGIC) == len(b"Welcome to the host!\n"),
-      "magic not locatable after preamble noise")
+# The relay's uplink decodes headers itself, on an asynchronous stream Reader
+# cannot drive, and calls this to decide whether to read the payload at all. A
+# bogus length has to be refused BEFORE the read, or the relay waits for up to
+# four gigabytes while the captain waits for an answer.
+for kind, length in ((b"\xff", 0), (frame.AUDIO, frame.MAX_PAYLOAD + 1)):
+    try:
+        frame.check_header(kind, length)
+        sys.exit("frame: check_header accepted %r/%d" % (kind, length))
+    except frame.FrameError:
+        pass
+frame.check_header(frame.AUDIO, frame.MAX_PAYLOAD)
 PY
 pass "wire format round trips and rejects a desynchronised stream"
 
@@ -185,6 +195,88 @@ if options.tail_ms <= 0:
     sys.exit("the trailing silence default must be positive; 0 is never answered")
 PY
 pass "the relay and the reader agree on the tool names and the handover argument"
+
+# --- credentials -------------------------------------------------------------
+#
+# The relay rebuilds the model session on every turn, on purpose. Resolving AWS
+# credentials belongs to the relay's start rather than to that rebuild: the
+# sandbox profile's credential_process costs about a second, and a second spent
+# there is a second added to the delay this whole build exists to keep honest.
+# Nothing here talks to AWS; the resolver is replaced with a counter.
+
+python3 - "$ROOT/bin" <<'PY' || fail "credential reuse"
+import asyncio, sys, time
+sys.path.insert(0, sys.argv[1])
+import importlib.util, pathlib
+spec = importlib.util.spec_from_file_location(
+    "relay", str(pathlib.Path(sys.argv[1]) / "fm-voice-relay.py"))
+relay = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(relay)
+
+def check(cond, label):
+    if not cond:
+        sys.exit("credentials: " + label)
+
+calls = []
+expiry = [None]
+delay = [0.0]
+
+def fake(profile, verbose=False):
+    calls.append(profile)
+    time.sleep(delay[0])
+    return {"aws_access_key_id": "AK%d" % len(calls)}, expiry[0]
+
+relay.resolve_credentials = fake
+
+async def take(cache, count):
+    return [await cache.get() for _ in range(count)]
+
+# Three sessions, one resolution: the second and third turns pay nothing.
+cache = relay.Credentials("a-profile")
+got = asyncio.run(take(cache, 3))
+check(len(calls) == 1, "three sessions resolved credentials %d times" % len(calls))
+check([c["aws_access_key_id"] for c in got] == ["AK1"] * 3,
+      "every session should get the same credentials: %s" % got)
+
+# A session that edits what it was handed must not edit what the next one gets.
+got[0]["aws_access_key_id"] = "tampered"
+check(asyncio.run(take(cache, 1))[0]["aws_access_key_id"] == "AK1",
+      "one session must not be able to corrupt the shared credentials")
+
+# Credentials with an expiry are refreshed ahead of it, because a relay left
+# running outlives them and a dead credential is a dead session.
+del calls[:]
+expiry[0] = time.time() + relay.Credentials.REFRESH_MARGIN - 1
+cache = relay.Credentials("a-profile")
+asyncio.run(take(cache, 2))
+check(len(calls) == 2,
+      "credentials near expiry should be refreshed, resolved %d times" % len(calls))
+
+# Whenever a resolution does happen it must stay off the event loop, or the
+# relay stops reading the captain's audio for as long as it takes.
+del calls[:]
+expiry[0] = None
+delay[0] = 0.3
+
+async def resolve_while_the_loop_runs():
+    ticks = []
+
+    async def tick():
+        for _ in range(20):
+            await asyncio.sleep(0.01)
+            ticks.append(1)
+
+    task = asyncio.create_task(tick())
+    await relay.Credentials("slow-profile").get()
+    during = len(ticks)
+    task.cancel()
+    return during
+
+during = asyncio.run(resolve_while_the_loop_runs())
+check(during >= 2,
+      "the event loop ran %d times during a 0.3s credential resolution" % during)
+PY
+pass "credentials are resolved once per relay, refreshed before expiry, off the event loop"
 
 # --- the laptop end ---------------------------------------------------------
 #
@@ -257,27 +349,6 @@ except frame.FrameError as exc:
     check("before it said hello" in str(exc),
           "the refusal should name the early close: %s" % exc)
 
-# The laptop gets the client and its local imports and nothing else, because
-# docs/voice-relay.md tells the captain to copy exactly two files. A third local
-# import would leave that instruction wrong and the laptop failing at import time,
-# a long way from the change that caused it.
-import ast, pathlib as _p
-bindir = _p.Path(sys.argv[1])
-tree = ast.parse((bindir / "fm-voice-client.py").read_text(encoding="utf-8"))
-local = set()
-for node in ast.walk(tree):
-    names = []
-    if isinstance(node, ast.Import):
-        names = [alias.name for alias in node.names]
-    elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
-        names = [node.module]
-    for name in names:
-        if (bindir / (name + ".py")).exists():
-            local.add(name + ".py")
-check(local == {"fm_voice_frame.py"},
-      "the laptop needs exactly fm_voice_frame.py beside the client, found %s "
-      "(update docs/voice-relay.md if this is intended)" % sorted(local))
-
 # The two ends must agree on the sample rates, or the reply plays at the wrong
 # pitch and nothing reports an error.
 relay_spec = importlib.util.spec_from_file_location(
@@ -288,6 +359,39 @@ check((client.IN_RATE, client.OUT_RATE) == (relay.IN_RATE, relay.OUT_RATE),
       "the two ends disagree on the sample rates")
 PY
 pass "the laptop client builds the right remote command and survives a chatty login shell"
+
+# docs/voice-relay.md tells the captain to copy exactly two files to the laptop,
+# so the real property is that the client runs from a directory holding exactly
+# those two and nothing else from bin/. A third local import would leave that
+# instruction wrong and the laptop dying at import time, a long way from the
+# change that caused it. Run there with no PYTHONPATH, so bin/ cannot supply the
+# missing piece the way it does on this host.
+LAPTOP="$TMP_ROOT/laptop"
+mkdir -p "$LAPTOP"
+cp "$ROOT/bin/fm-voice-client.py" "$ROOT/bin/fm_voice_frame.py" "$LAPTOP/"
+
+set +e
+copied_out=$(cd "$LAPTOP" && env -u PYTHONPATH python3 ./fm-voice-client.py --help 2>&1)
+copied_code=$?
+set -e
+expect_code 0 "$copied_code" \
+  "the client must start with only the two copied files: $copied_out"
+assert_contains "$copied_out" 'fm-voice-client.py' \
+  "the copied client should print its own usage"
+
+# The negative half, so the case above is not passing because bin/ was reachable
+# after all: without its one companion the client must fail at import and name it.
+SHORT="$TMP_ROOT/laptop-missing-companion"
+mkdir -p "$SHORT"
+cp "$ROOT/bin/fm-voice-client.py" "$SHORT/"
+set +e
+short_out=$(cd "$SHORT" && env -u PYTHONPATH python3 ./fm-voice-client.py --help 2>&1)
+short_code=$?
+set -e
+[ "$short_code" -ne 0 ] || fail "the client started without fm_voice_frame.py beside it"
+assert_contains "$short_out" 'fm_voice_frame' \
+  "the import failure should name the file the laptop is missing"
+pass "the client runs from a laptop holding only the two files the guide names"
 
 # --- read scope -------------------------------------------------------------
 
@@ -316,6 +420,14 @@ assert_contains "$wide" 'beta-two' "full scope should name what waits on the cap
 assert_contains "$wide" '"state": "working"' "full scope should carry the state verb"
 assert_not_contains "$wide" 'reading the failing test' \
   "full scope must not carry the raw event line"
+# The same rule against the bracketed shape: the verb is still the verb, and the
+# metadata and the note stay unspoken.
+assert_contains "$wide" '"state": "blocked"' \
+  "a status line with a metadata token before the colon should still report its verb"
+assert_not_contains "$wide" 'key=api-shape' \
+  "full scope must not carry status metadata"
+assert_not_contains "$wide" 'needs a credential' \
+  "full scope must not carry the raw event line of a bracketed status"
 pass "the wide scope names open work and reports state without quoting event lines"
 
 # The default is the wide scope, because that is the access the captain granted.
@@ -379,6 +491,25 @@ printf '%s\n' "$(printf '%s' "$DENY_TOKEN" | tr '[:upper:]' '[:lower:]')" \
 lower=$(records_status --scope full) || fail "lowercase deny list failed"
 assert_not_contains "$lower" "$DENY_TOKEN" "the deny list must match regardless of case"
 pass "the deny list matches regardless of case"
+
+# The withheld figure counts denied items, not refusals, and the lists overlap by
+# design: alpha-one is in flight AND carries a pull request, beta-two is in flight
+# AND waiting on the captain. Counting each refusal would tell the captain four
+# things are being withheld when two are, which is a wrong number spoken
+# confidently about exactly the subject the captain is most careful with.
+printf '%s\n%s\n' alpha-one beta-two > "$HOME_FIXTURE/config/voice-read-deny"
+overlap=$(records_status --scope full) || fail "overlapping deny list failed"
+assert_contains "$overlap" '"withheld_as_confidential": 2' \
+  "two denied items appearing in two lists each must be withheld twice, not four times"
+assert_not_contains "$overlap" 'alpha-one' "a denied item must not be named"
+assert_not_contains "$overlap" 'beta-two' "a denied item must not be named"
+assert_not_contains "$overlap" 'github.com' \
+  "denying an item must suppress its pull request link too"
+assert_contains "$overlap" '"in_flight": 3' \
+  "denying items must not change the count of in-flight work"
+assert_contains "$overlap" '"open_pull_requests": 1' \
+  "denying items must not change the count of open pull requests"
+pass "an item denied in more than one list is counted as withheld once"
 
 rm -f "$HOME_FIXTURE/config/voice-read-deny"
 

--- a/tests/fm-voice-relay.test.sh
+++ b/tests/fm-voice-relay.test.sh
@@ -1,0 +1,456 @@
+#!/usr/bin/env bash
+# tests/fm-voice-relay.test.sh - the spoken interface's wire format, read scope and handover.
+#
+# Every case here runs offline. The three things worth protecting in this feature
+# are all offline properties: the frame format the laptop and the desktop agree
+# on, WHAT a status answer is allowed to contain, and the fact that real work is
+# handed to firstmate rather than done by the voice agent. The latency work that
+# motivated the build is a measurement, not an assertion, so it is not here; the
+# numbers and the method live in docs/voice-relay.md.
+#
+# THE CASE THAT MATTERS MOST is the confidentiality boundary. The captain granted
+# the voice agent full read access to their records, so the reader defaults to the
+# wider scope. What keeps that safe is structural: finished work and free-form
+# note bodies are never assembled at all, and those are exactly where commercial
+# detail accumulates. This suite plants a marker in both places and fails if it
+# ever reaches an answer, so widening the reader later breaks a test instead of
+# quietly widening what is sent to a model in another region.
+#
+# The markers below are invented for this fixture. Real customer names are not
+# committed to a test file.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+command -v python3 >/dev/null 2>&1 || { echo "skip: python3 not found"; exit 0; }
+
+TMP_ROOT=$(fm_test_tmproot fm-voice-relay)
+HOME_FIXTURE="$TMP_ROOT/home"
+
+# NEVER_TOKEN sits in finished work and in a note body: both are excluded by
+# construction, so it must never appear at any scope.
+NEVER_TOKEN=NEVERLEAVESTHISHOST
+# DENY_TOKEN sits in the title of open in-flight work, which the wide scope does
+# report. It proves the deny list suppresses something that genuinely would have
+# been sent, rather than passing vacuously against text no answer contains.
+DENY_TOKEN=DENYMEPLEASE
+
+seed_home() {
+  mkdir -p "$HOME_FIXTURE/data" "$HOME_FIXTURE/state" "$HOME_FIXTURE/config"
+  cat > "$HOME_FIXTURE/data/backlog.md" <<EOF
+# Backlog
+
+## In flight
+- [ ] alpha-one - Fix the sign-in redirect (repo: alpha) (kind: ship) (priority: 0) (since 2026-08-01)
+  Long note body written for someone with the whole file open, mentioning
+  $NEVER_TOKEN and the rate we agreed.
+- [ ] beta-two - Decide the storage shape (repo: beta) (kind: captain) (priority: 1)
+- [ ] gamma-three - Migrate the $DENY_TOKEN account onto the new plan (repo: gamma) (kind: ship)
+
+## Queued
+- [ ] delta-four - Add the retry (repo: delta) (kind: ship) (hold-kind: captain) (hold: waiting on the captain)
+- [ ] epsilon-five - Tidy the logs (repo: epsilon) (kind: ship)
+
+## Done
+- [x] old-six - Shipped the $NEVER_TOKEN integration (repo: alpha) (done 2026-07-01)
+# An unticked line under Done, held for the captain. Two separate mechanisms keep
+# finished work out of an answer: the section is never parsed, and a ticked box is
+# dropped. A ticked line is blocked by both, so it cannot tell which one broke.
+# This line is blocked by the section rule alone, and the list of what waits on
+# the captain is assembled with no section filter at all, so it is the one place
+# where losing that rule would put finished work into a spoken answer.
+- [ ] old-seven - Decide the $NEVER_TOKEN renewal (repo: alpha) (kind: captain)
+EOF
+
+  fm_write_meta "$HOME_FIXTURE/state/alpha-one.meta" \
+    kind=ship mode=no-mistakes window=firstmate:fm-alpha-one \
+    pr=https://github.com/example/alpha/pull/7
+  fm_write_meta "$HOME_FIXTURE/state/gamma-three.meta" kind=ship mode=direct-PR
+  printf 'working: reading the failing test\n' > "$HOME_FIXTURE/state/alpha-one.status"
+  printf 'blocked: needs a credential\n' > "$HOME_FIXTURE/state/gamma-three.status"
+}
+
+records_status() {
+  python3 "$ROOT/bin/fm_voice_records.py" status --home "$HOME_FIXTURE" "$@"
+}
+
+seed_home
+
+# --- the wire format --------------------------------------------------------
+#
+# A desynchronised stream must be a loud error rather than audio interpreted as
+# a frame header. The laptop copy of this module is the only other place these
+# rules exist, so they are pinned here.
+
+python3 - "$ROOT/bin" <<'PY' || fail "frame round trip"
+import os, io, sys
+sys.path.insert(0, sys.argv[1])
+import fm_voice_frame as frame
+
+def check(cond, label):
+    if not cond:
+        sys.exit("frame: " + label)
+
+# Round trip of every kind, including an empty payload and a large one.
+buf = io.BytesIO()
+w = frame.Writer(buf)
+w.send(frame.TALK_START)
+w.send(frame.AUDIO, b"\x01\x02" * 1600)
+w.send_json(frame.TEXT, {"role": "USER", "text": "how is the fleet"})
+w.send(frame.TALK_END)
+buf.seek(0)
+r = frame.Reader(buf)
+got = []
+while True:
+    item = r.read()
+    if item is None:
+        break
+    got.append(item)
+check([k for k, _ in got] == [frame.TALK_START, frame.AUDIO, frame.TEXT,
+                              frame.TALK_END], "kinds did not round trip")
+check(got[1][1] == b"\x01\x02" * 1600, "audio payload did not round trip")
+check(frame.decode_json(got[2][1])["text"] == "how is the fleet",
+      "json payload did not round trip")
+
+# A clean close between frames is end of input, not an error.
+check(frame.Reader(io.BytesIO(b"")).read() is None, "clean EOF should be None")
+
+# A stream cut inside a payload is a dropped connection and must say so.
+try:
+    frame.Reader(io.BytesIO(frame.encode(frame.AUDIO, b"12345")[:-2])).read()
+    sys.exit("frame: truncated payload was accepted")
+except frame.FrameError:
+    pass
+
+# Audio bytes that happen to look like a header must not be trusted.
+for bad in (b"\xffZZZZ", frame.HEADER.pack(frame.AUDIO, frame.MAX_PAYLOAD + 1)):
+    try:
+        frame.Reader(io.BytesIO(bad)).read()
+        sys.exit("frame: accepted a bad header: %r" % bad)
+    except frame.FrameError:
+        pass
+
+try:
+    frame.encode(b"?")
+    sys.exit("frame: encoded an unknown kind")
+except frame.FrameError:
+    pass
+
+try:
+    frame.encode(frame.AUDIO, b"x" * (frame.MAX_PAYLOAD + 1))
+    sys.exit("frame: encoded an oversized payload")
+except frame.FrameError:
+    pass
+
+# The magic string exists so a chatty login shell cannot desynchronise the
+# stream, so it has to be findable in a prefix that contains junk.
+noise = b"Welcome to the host!\n" + frame.MAGIC + frame.encode(frame.BYE)
+check(noise.index(frame.MAGIC) == len(b"Welcome to the host!\n"),
+      "magic not locatable after preamble noise")
+PY
+pass "wire format round trips and rejects a desynchronised stream"
+
+# --- the tool surface the two sides share -----------------------------------
+#
+# The relay declares the tools and fm_voice_records implements them. Renaming one
+# side only would leave the agent unable to answer or unable to hand over, and
+# the failure would look like a confused model rather than a typo.
+
+python3 - "$ROOT/bin" <<'PY' || fail "tool surface"
+import sys
+sys.path.insert(0, sys.argv[1])
+import importlib.util, pathlib
+spec = importlib.util.spec_from_file_location(
+    "relay", str(pathlib.Path(sys.argv[1]) / "fm-voice-relay.py"))
+relay = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(relay)
+
+names = sorted(t["toolSpec"]["name"] for t in relay.TOOLS["tools"])
+if names != ["get_fleet_status", "hand_over_to_firstmate"]:
+    sys.exit("relay declares unexpected tools: %s" % names)
+
+# The handover tool has to take the request text, or the agent can announce a
+# handover it never performed.
+handover = [t["toolSpec"] for t in relay.TOOLS["tools"]
+            if t["toolSpec"]["name"] == "hand_over_to_firstmate"][0]
+import json
+schema = json.loads(handover["inputSchema"]["json"])
+if schema.get("required") != ["request"]:
+    sys.exit("hand_over_to_firstmate must require the request text")
+
+# Push to talk is the default for this build and is meant to be one setting.
+options = relay.parse_args(["--self-test", "x.pcm"])
+if options.tail_ms <= 0:
+    sys.exit("the trailing silence default must be positive; 0 is never answered")
+PY
+pass "the relay and the reader agree on the tool names and the handover argument"
+
+# --- the laptop end ---------------------------------------------------------
+#
+# The microphone and speaker paths cannot be tested from a host with neither, and
+# are not tested anywhere: the first live run is their test. What IS testable is
+# everything around them, and these are the pieces whose failure is hardest to
+# read from the symptom. A missing -T corrupts audio rather than erroring, and a
+# banner-printing login shell desynchronises the stream in a way that looks like a
+# protocol bug and is not.
+
+python3 - "$ROOT/bin" <<'PY' || fail "laptop client"
+import io, sys
+sys.path.insert(0, sys.argv[1])
+import importlib.util, pathlib
+spec = importlib.util.spec_from_file_location(
+    "client", str(pathlib.Path(sys.argv[1]) / "fm-voice-client.py"))
+client = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(client)
+import fm_voice_frame as frame
+
+def check(cond, label):
+    if not cond:
+        sys.exit("client: " + label)
+
+# Push to talk is the default for this build, and open mic is the one flip.
+check(client.parse_args(["--host", "h"]).listen == client.PUSH_TO_TALK,
+      "push to talk must be the default")
+check(client.parse_args(["--host", "h", "--listen", "open-mic"]).listen
+      == client.OPEN_MIC, "open mic must be selectable")
+
+# Over SSH: no pty, or the audio stream is silently rewritten.
+argv = client.relay_command(client.parse_args(["--host", "desk"]))
+check(argv[:3] == ["ssh", "-T", "desk"], "ssh must be invoked with -T: %s" % argv)
+check("--serve" in argv, "the relay must be started in serve mode")
+
+# Locally: no ssh at all, so the same client can be measured on this host.
+argv = client.relay_command(client.parse_args(["--local"]))
+check(argv[0] != "ssh", "--local must not invoke ssh: %s" % argv)
+
+# The interpreter is a setting because the relay needs a virtual environment the
+# system interpreter does not have.
+argv = client.relay_command(client.parse_args(
+    ["--host", "desk", "--relay-python", "/opt/venv/bin/python",
+     "--relay-arg=--scope", "--relay-arg=counts"]))
+check("/opt/venv/bin/python" in argv, "the relay interpreter must be passed: %s" % argv)
+check(argv[-2:] == ["--scope", "counts"],
+      "relay arguments must reach the relay: %s" % argv)
+
+# A login shell banner is discarded with a warning naming it, not an error.
+noise = b"You have mail.\n"
+stream = io.BytesIO(noise + frame.MAGIC + frame.encode(frame.BYE))
+client.sync_magic(stream)
+check(frame.Reader(stream).read()[0] == frame.BYE,
+      "the first frame after the handshake must still be readable")
+
+# Junk with no handshake at all must be a named refusal rather than a hang.
+try:
+    client.sync_magic(io.BytesIO(b"x" * (client.MAX_PREAMBLE + 64)))
+    sys.exit("client: accepted a stream with no handshake")
+except frame.FrameError as exc:
+    check("not fm-voice-relay.py" in str(exc),
+          "the refusal should say what is on the far end: %s" % exc)
+
+# A far end that dies before saying hello must say that, because the useful next
+# step is running the relay command by hand.
+try:
+    client.sync_magic(io.BytesIO(b""))
+    sys.exit("client: accepted a closed stream")
+except frame.FrameError as exc:
+    check("before it said hello" in str(exc),
+          "the refusal should name the early close: %s" % exc)
+
+# The laptop gets the client and its local imports and nothing else, because
+# docs/voice-relay.md tells the captain to copy exactly two files. A third local
+# import would leave that instruction wrong and the laptop failing at import time,
+# a long way from the change that caused it.
+import ast, pathlib as _p
+bindir = _p.Path(sys.argv[1])
+tree = ast.parse((bindir / "fm-voice-client.py").read_text(encoding="utf-8"))
+local = set()
+for node in ast.walk(tree):
+    names = []
+    if isinstance(node, ast.Import):
+        names = [alias.name for alias in node.names]
+    elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+        names = [node.module]
+    for name in names:
+        if (bindir / (name + ".py")).exists():
+            local.add(name + ".py")
+check(local == {"fm_voice_frame.py"},
+      "the laptop needs exactly fm_voice_frame.py beside the client, found %s "
+      "(update docs/voice-relay.md if this is intended)" % sorted(local))
+
+# The two ends must agree on the sample rates, or the reply plays at the wrong
+# pitch and nothing reports an error.
+relay_spec = importlib.util.spec_from_file_location(
+    "relay", str(pathlib.Path(sys.argv[1]) / "fm-voice-relay.py"))
+relay = importlib.util.module_from_spec(relay_spec)
+relay_spec.loader.exec_module(relay)
+check((client.IN_RATE, client.OUT_RATE) == (relay.IN_RATE, relay.OUT_RATE),
+      "the two ends disagree on the sample rates")
+PY
+pass "the laptop client builds the right remote command and survives a chatty login shell"
+
+# --- read scope -------------------------------------------------------------
+
+narrow=$(records_status --scope counts) || fail "counts scope failed"
+assert_contains "$narrow" '"scope": "counts"' "counts scope should say so"
+assert_contains "$narrow" '"in_flight": 3' "counts scope should still count in-flight work"
+assert_contains "$narrow" '"queued": 2' "counts scope should still count queued work"
+assert_contains "$narrow" '"awaiting_captain": 2' "counts scope should count what waits on the captain"
+assert_contains "$narrow" '"open_pull_requests": 1' "counts scope should count open pull requests"
+# No record free text is assembled at all at this scope, so there is nothing to
+# filter and nothing to get wrong.
+assert_not_contains "$narrow" 'alpha-one' "counts scope must not name work"
+assert_not_contains "$narrow" 'sign-in redirect' "counts scope must not carry titles"
+assert_not_contains "$narrow" 'github.com' "counts scope must not carry pull request links"
+pass "the narrow scope answers how much is waiting without saying what it is"
+
+wide=$(records_status --scope full) || fail "full scope failed"
+assert_contains "$wide" '"scope": "full"' "full scope should say so"
+assert_contains "$wide" 'alpha-one' "full scope should name in-flight work"
+assert_contains "$wide" 'sign-in redirect' "full scope should carry titles"
+assert_contains "$wide" 'https://github.com/example/alpha/pull/7' \
+  "full scope should carry the pull request link"
+assert_contains "$wide" 'beta-two' "full scope should name what waits on the captain"
+# The state verb only. The agent speaks to the captain and must not read an
+# internal event line aloud.
+assert_contains "$wide" '"state": "working"' "full scope should carry the state verb"
+assert_not_contains "$wide" 'reading the failing test' \
+  "full scope must not carry the raw event line"
+pass "the wide scope names open work and reports state without quoting event lines"
+
+# The default is the wide scope, because that is the access the captain granted.
+default=$(records_status) || fail "default scope failed"
+assert_contains "$default" '"scope": "full"' "the default read scope should be full"
+pass "an absent read-scope setting means the access the captain granted"
+
+# --- the confidentiality boundary -------------------------------------------
+#
+# This is the case that lets the wide scope be the default.
+
+for scope in full counts; do
+  answer=$(records_status --scope "$scope") || fail "scope $scope failed"
+  assert_not_contains "$answer" "$NEVER_TOKEN" \
+    "finished work and note bodies must never reach a $scope answer"
+  assert_not_contains "$answer" 'old-six' \
+    "finished work must not be named in a $scope answer"
+  assert_not_contains "$answer" 'old-seven' \
+    "an unticked line under finished work must not be named in a $scope answer"
+  assert_not_contains "$answer" 'the rate we agreed' \
+    "a note body must not reach a $scope answer"
+  # The count is the assertion that bites if the section rule is lost: old-seven
+  # is held for the captain and that list has no section filter of its own.
+  assert_contains "$answer" '"awaiting_captain": 2' \
+    "finished work must not be counted as waiting on the captain at $scope scope"
+done
+pass "finished work and note bodies never reach a spoken answer at any scope"
+
+# The exclusion has to be structural rather than a filter on the way out, so the
+# count of in-flight work stays honest while the body stays unread.
+assert_contains "$wide" '"in_flight": 3' \
+  "excluding note bodies must not change the count of in-flight work"
+pass "excluding a note body does not distort the counts"
+
+# --- the deny list ----------------------------------------------------------
+#
+# Reachable first, suppressed second. Without the first assertion the second
+# proves nothing.
+
+assert_contains "$wide" "$DENY_TOKEN" \
+  "fixture is wrong: the deny marker should be reachable before it is denied"
+
+printf '# one plain substring per line\n%s\n' "$DENY_TOKEN" \
+  > "$HOME_FIXTURE/config/voice-read-deny"
+denied=$(records_status --scope full) || fail "full scope with a deny list failed"
+assert_not_contains "$denied" "$DENY_TOKEN" "the deny list must suppress a match"
+assert_not_contains "$denied" 'gamma-three' \
+  "a denied item must not be named at all"
+assert_contains "$denied" '"withheld_as_confidential": 1' \
+  "a denied item must still be counted so the captain knows it exists"
+assert_contains "$denied" '"in_flight": 3' \
+  "denying an item must not change the count of in-flight work"
+# The other in-flight work is unaffected: this is a substring list, not a switch.
+assert_contains "$denied" 'alpha-one' "the deny list must not suppress everything"
+pass "a denied item becomes a withheld count without hiding that work exists"
+
+# Case-insensitive, because a confidentiality list that depends on the captain
+# matching the file's capitalisation is a confidentiality list that fails quietly.
+printf '%s\n' "$(printf '%s' "$DENY_TOKEN" | tr '[:upper:]' '[:lower:]')" \
+  > "$HOME_FIXTURE/config/voice-read-deny"
+lower=$(records_status --scope full) || fail "lowercase deny list failed"
+assert_not_contains "$lower" "$DENY_TOKEN" "the deny list must match regardless of case"
+pass "the deny list matches regardless of case"
+
+rm -f "$HOME_FIXTURE/config/voice-read-deny"
+
+# --- refusals ---------------------------------------------------------------
+#
+# A misconfigured read scope must stop rather than fall back to the wider one,
+# because falling back would widen what is sent on the strength of a typo.
+
+printf 'everything\n' > "$HOME_FIXTURE/config/voice-read-scope"
+set +e
+out=$(records_status 2>&1)
+code=$?
+set -e
+expect_code 2 "$code" "an unknown read scope should refuse"
+assert_contains "$out" 'voice-read-scope' "the refusal should name the setting"
+pass "an unknown read scope refuses instead of widening"
+
+printf 'counts\n' > "$HOME_FIXTURE/config/voice-read-scope"
+configured=$(records_status) || fail "configured scope failed"
+assert_contains "$configured" '"scope": "counts"' "the configured scope should be used"
+rm -f "$HOME_FIXTURE/config/voice-read-scope"
+pass "the configured read scope is honoured"
+
+# --- handover ---------------------------------------------------------------
+#
+# The point of the boundary: real work is queued for firstmate, not done by the
+# voice agent. It reuses bin/fm-inbox.sh rather than carrying a second queue.
+
+before=$(find "$HOME_FIXTURE/state" -maxdepth 2 -name '*.note' | wc -l)
+[ "$before" = 0 ] || fail "fixture should start with an empty inbox"
+
+handed=$(FM_HOME="$HOME_FIXTURE" python3 "$ROOT/bin/fm_voice_records.py" queue \
+  "Refactor the login module and open a pull request for it" \
+  --home "$HOME_FIXTURE") || fail "handover failed"
+assert_contains "$handed" '"queued": true' "handover should report the request queued"
+assert_contains "$handed" 'did not do the work yourself' \
+  "handover should tell the model it handed over rather than acted"
+
+notes=$(find "$HOME_FIXTURE/state/inbox" -maxdepth 1 -name '*.note' | wc -l)
+[ "$notes" = 1 ] || fail "handover should leave exactly one note, found $notes"
+note_file=$(find "$HOME_FIXTURE/state/inbox" -maxdepth 1 -name '*.note' | head -1)
+assert_grep 'Refactor the login module' "$note_file" \
+  "the note should carry the captain's words"
+
+# Exactly one wake, so a spoken request is presented once at firstmate's next
+# check rather than queued twice or lost.
+assert_present "$HOME_FIXTURE/state/.wake-queue" \
+  "handover should wake firstmate"
+wakes=$(grep -c 'inbox:' "$HOME_FIXTURE/state/.wake-queue")
+[ "$wakes" = 1 ] || fail "handover should append exactly one wake, found $wakes"
+pass "handover queues the request for firstmate and wakes it exactly once"
+
+set +e
+empty_out=$(python3 "$ROOT/bin/fm_voice_records.py" queue "   " \
+  --home "$HOME_FIXTURE" 2>&1)
+empty_code=$?
+set -e
+expect_code 2 "$empty_code" "queueing empty text should refuse"
+assert_contains "$empty_out" 'empty' "the refusal should say the request was empty"
+pass "an empty request is refused rather than queued as a blank note"
+
+# --- absent records ---------------------------------------------------------
+#
+# A home with no records at all must answer "nothing" rather than fail, because
+# the agent is spoken to and an exception is not an answer.
+
+bare="$TMP_ROOT/bare"
+mkdir -p "$bare"
+bare_out=$(python3 "$ROOT/bin/fm_voice_records.py" status --home "$bare") \
+  || fail "an empty home should still answer"
+assert_contains "$bare_out" '"in_flight": 0' "an empty home should report no work"
+assert_contains "$bare_out" '"workers_on_deck": 0' "an empty home should report no workers"
+pass "a home with no records answers nothing rather than failing"
+
+printf 'all voice relay cases passed\n'

--- a/tests/fm-voice-relay.test.sh
+++ b/tests/fm-voice-relay.test.sh
@@ -127,6 +127,26 @@ try:
 except frame.FrameError:
     pass
 
+# A payload that never starts at all is the same fault, one byte earlier.
+try:
+    frame.Reader(io.BytesIO(frame.HEADER.pack(frame.AUDIO, 5))).read()
+    sys.exit("frame: a header with no payload behind it was accepted")
+except frame.FrameError:
+    pass
+
+# A stream cut inside the HEADER is a dropped connection too, and must NOT come
+# back as the clean close checked above. A lost SSH connection does not politely
+# end on a frame boundary, and a partial header read as end of input records the
+# turn as unanswered with no error, which puts a transport failure into a results
+# file as an ordinary turn the model did not answer.
+for cut in range(1, frame.HEADER.size):
+    try:
+        frame.Reader(io.BytesIO(frame.encode(frame.BYE)[:cut])).read()
+        sys.exit("frame: %d header bytes then EOF was read as a clean close" % cut)
+    except frame.FrameError as exc:
+        check("header" in str(exc),
+              "a truncated header should name itself: %s" % exc)
+
 # Audio bytes that happen to look like a header must not be trusted.
 for bad in (b"\xffZZZZ", frame.HEADER.pack(frame.AUDIO, frame.MAX_PAYLOAD + 1)):
     try:
@@ -1393,6 +1413,106 @@ except SystemExit as exc:
 check(timed_out is not None, "a silent relay was treated as ready")
 check("never reported ready" in timed_out,
       "a silent relay should time out with its own message: %s" % timed_out)
+
+# The uplink can die mid-session - the SSH connection drops, or the relay exits -
+# and the next talk start or talk end is then a write to a dead pipe. Every frame
+# a turn is made of goes through the one sender thread, so that write has to end
+# the thread the same quiet way a dead audio write does. Raising instead killed
+# the thread with a traceback and left the queue unserved, so each remaining run
+# sat out the full timeout with nothing sending its frames and was reported as an
+# unanswered turn rather than as the lost connection the downlink had already seen.
+class DeadPipe:
+    def __init__(self):
+        self.sent = []
+
+    def send(self, kind, payload=b""):
+        self.sent.append(kind)
+        raise BrokenPipeError(32, "Broken pipe")
+
+for label, opening in (("talk start", client.START), ("talk end", client.END),
+                       ("audio", b"\x00\x00")):
+    sending = client.Client(client.parse_args(["--host", "desk"]))
+    sending.uplink = DeadPipe()
+    sending.up_q.put(opening)
+    sending.up_q.put(b"\x01\x01")
+    sending.up_q.put(None)
+    try:
+        sending._sender()
+    except BaseException as exc:               # noqa: BLE001
+        sys.exit("client: a broken pipe on %s killed the sender thread: %s: %s"
+                 % (label, type(exc).__name__, exc))
+    check(sending.uplink.sent and len(sending.uplink.sent) == 1,
+          "the sender should stop at the broken pipe on %s rather than keep "
+          "writing into it: %r" % (label, sending.uplink.sent))
+    if opening is client.END:
+        # Talk end stamps the moment it reached the wire before the write is
+        # attempted, so uplink_drain_s survives a turn the connection cut short.
+        check("wire_end" in sending.turn,
+              "talk end must still record when it reached the wire: %r"
+              % sending.turn)
+
+# A connection that drops mid-turn does not wait for a frame boundary, so the
+# downlink meets a header cut in half. That is a transport failure and the turn
+# record has to say so: a run that only reports answered: false reads in
+# runs.jsonl exactly like a turn the model declined, and the latency spread
+# docs/voice-relay.md publishes is computed from that file.
+import threading as thread_lib
+
+
+class CutStream:
+    """A downlink that drops mid-header once the turn is under way.
+
+    Held closed until the client has actually opened the turn, so the cut lands
+    inside the turn being measured rather than before it, which is the sequence
+    a dropped SSH connection produces and the only one whose record matters.
+    """
+
+    def __init__(self, gate):
+        self._gate = gate
+        self._half = frame.encode(frame.BYE)[:2]
+        self._at = 0
+
+    def read(self, count):
+        check(self._gate.wait(10), "the turn never opened, so nothing was cut")
+        chunk = self._half[self._at:self._at + count]
+        self._at += len(chunk)
+        return chunk
+
+
+opened = thread_lib.Event()
+
+
+class GateOpeningUplink:
+    """Discards the uplink and reports when the turn's first frame went out."""
+
+    def send(self, kind, payload=b""):
+        if kind == frame.TALK_START:
+            opened.set()
+
+
+cut = client.Client(client.parse_args(
+    ["--host", "desk", "--in-file", os.path.join(TMP, "clip.pcm"),
+     "--out-file", os.path.join(TMP, "reply-cut.pcm"), "--timeout", "5"]))
+cut.reader = frame.Reader(CutStream(opened))
+cut.uplink = GateOpeningUplink()
+cut.playback = client.FilePlayback(os.path.join(TMP, "reply-cut.pcm"))
+cut.capture = client.FileCapture(os.path.join(TMP, "clip.pcm"))
+cut.capture.start(cut.up_q, cut.talking)
+thread_lib.Thread(target=cut._sender, daemon=True).start()
+thread_lib.Thread(target=cut._downlink, daemon=True).start()
+cut_record = cut.take_turn(1)
+cut.up_q.put(None)
+cut.playback.close()
+
+check(cut.closed.wait(10), "a cut header must end the downlink, not hang it")
+check(not cut_record["answered"], "a cut connection cannot have answered: %r"
+      % cut_record)
+check(cut_record["relay_error"],
+      "a dropped connection must be reported in the turn record rather than "
+      "leaving it indistinguishable from a turn nobody answered: %r"
+      % cut_record)
+check("connection" in cut_record["relay_error"],
+      "and it should say the connection went: %r" % cut_record["relay_error"])
 
 # A startup that refuses part way through releases what it already started, and
 # close() therefore has to survive a half-built client. The real devices cannot be

--- a/tests/fm-voice-relay.test.sh
+++ b/tests/fm-voice-relay.test.sh
@@ -254,7 +254,7 @@ pass "the relay and the reader agree on the tool names and the handover argument
 # Nothing here talks to AWS; the resolver is replaced with a counter.
 
 python3 - "$ROOT/bin" <<'PY' || fail "credential reuse"
-import asyncio, datetime, sys, time
+import asyncio, datetime, os, sys, time
 sys.path.insert(0, sys.argv[1])
 import importlib.util, pathlib
 spec = importlib.util.spec_from_file_location(
@@ -266,14 +266,63 @@ def check(cond, label):
     if not cond:
         sys.exit("credentials: " + label)
 
-calls = []
-stamp = [""]
-delay = [0.0]
+AWS_VARS = ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN",
+            "AWS_CREDENTIAL_EXPIRATION")
 
 def iso(at):
     return datetime.datetime.fromtimestamp(at, datetime.timezone.utc).isoformat()
 
-def fake(profile, verbose=False):
+# Credentials taken from the environment cannot be refreshed in place, because
+# os.environ never gets fresher values while this process runs. So they are only
+# preferred while they are usable, and what decides that is the deadline the
+# exporter states beside the keys. Treating one as eternal strands a long-lived
+# relay: every session after the real deadline is rejected for an expired token.
+for name in AWS_VARS:
+    os.environ.pop(name, None)
+
+check(relay.ambient_credentials() is None,
+      "an environment with no keys must send the relay to the profile")
+
+os.environ["AWS_ACCESS_KEY_ID"] = "AKIAEXAMPLE"
+check(relay.ambient_credentials() is None,
+      "a key id with no secret beside it must be refused, not indexed blindly")
+
+os.environ["AWS_SECRET_ACCESS_KEY"] = "s3cret"
+ambient = relay.ambient_credentials()
+check(ambient[0]["aws_access_key_id"] == "AKIAEXAMPLE",
+      "a complete environment should be used: %r" % (ambient,))
+check(ambient[1] is None,
+      "long-term keys, with no session token and no stated deadline, do not expire")
+
+os.environ["AWS_SESSION_TOKEN"] = "t0ken"
+check(relay.ambient_credentials()[1] is relay.EXPIRY_UNKNOWN,
+      "a session token has a deadline whether or not the shell stated it")
+
+os.environ["AWS_CREDENTIAL_EXPIRATION"] = iso(time.time() + 3600)
+check(isinstance(relay.ambient_credentials()[1], float),
+      "a stated deadline should be carried through as the expiry")
+# The environment wins while it is usable, so this never shells out to a profile.
+check(relay.resolve_credentials("no-such-profile")[0]["aws_session_token"] == "t0ken",
+      "the environment should be preferred over the profile while it is usable")
+
+os.environ["AWS_CREDENTIAL_EXPIRATION"] = iso(time.time() - 1)
+check(relay.ambient_credentials() is None,
+      "expired ambient credentials must send the relay to the profile instead")
+
+os.environ["AWS_CREDENTIAL_EXPIRATION"] = iso(time.time() + 60)
+check(relay.ambient_credentials(margin=300) is None,
+      "ambient credentials inside the refresh margin must not start a session")
+check(relay.ambient_credentials(margin=0) is not None,
+      "the same credentials are still usable when no margin is asked for")
+
+for name in AWS_VARS:
+    os.environ.pop(name, None)
+
+calls = []
+stamp = [""]
+delay = [0.0]
+
+def fake(profile, verbose=False, margin=0):
     # Whatever the profile says about expiry reaches the cache through the real
     # parser, so the fixture hands it a stamp rather than a decided answer.
     calls.append(profile)
@@ -360,6 +409,133 @@ check(during >= 2,
       "the event loop ran %d times during a 0.3s credential resolution" % during)
 PY
 pass "credentials are resolved once per relay, refreshed before expiry, off the event loop"
+
+# --- a turn the model refuses -----------------------------------------------
+#
+# The relay rebuilds the model session on every turn by design, so every turn
+# reaches the model and every turn can fail on its own: a throttle, a dropped
+# stream, a token that went stale between turns. That has to cost the captain one
+# turn rather than the whole session, because the alternative is a traceback on
+# the stderr the client inherits and a relay restarted by hand.
+
+python3 - "$ROOT/bin" <<'PY' || fail "failed turn"
+import asyncio, sys
+sys.path.insert(0, sys.argv[1])
+import importlib.util, pathlib
+spec = importlib.util.spec_from_file_location(
+    "relay", str(pathlib.Path(sys.argv[1]) / "fm-voice-relay.py"))
+relay = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(relay)
+import fm_voice_frame as frame
+
+def check(cond, label):
+    if not cond:
+        sys.exit("failed turn: " + label)
+
+class Down:
+    def __init__(self):
+        self.notices = []
+
+    def send(self, kind, payload=b""):
+        pass
+
+    def send_json(self, kind, obj):
+        if kind == frame.NOTICE:
+            self.notices.append(obj)
+
+class Stub:
+    """A session that records what it was asked, or raises where the model would."""
+
+    def __init__(self, raises=None):
+        self.raises = raises
+        self.replies = 0
+        self.failed = False
+        self.ended = asyncio.Event()
+        self.calls = []
+
+    async def _step(self, name):
+        self.calls.append(name)
+        if self.raises is not None:
+            raise self.raises
+
+    async def talk_start(self):
+        await self._step("talk_start")
+
+    async def audio(self, pcm):
+        await self._step("audio:%d" % len(pcm))
+
+    async def talk_end(self):
+        await self._step("talk_end")
+
+options = relay.parse_args(["--serve"])
+
+async def drive(session, items):
+    down = Down()
+    serving = True
+    for kind, payload in items:
+        session, serving = await relay.handle_uplink_frame(
+            kind, payload, session, options, down)
+        if not serving:
+            break
+    return session, serving, down
+
+# The ordinary path is unchanged: the frames reach the session in order.
+good = Stub()
+session, serving, down = asyncio.run(drive(good, [
+    (frame.TALK_START, b""), (frame.AUDIO, b"1234"), (frame.TALK_END, b"")]))
+check(good.calls == ["talk_start", "audio:4", "talk_end"],
+      "a good turn should reach the session: %s" % good.calls)
+check(serving and not good.failed,
+      "a good turn must not mark the session spent")
+check(down.notices == [], "a good turn should not announce a failure")
+
+# A model failure mid-turn: the captain is told what happened, the relay stays
+# up, and the session is marked spent so nothing reuses a dead stream.
+broken = Stub(raises=RuntimeError("ThrottlingException"))
+session, serving, down = asyncio.run(drive(broken, [(frame.AUDIO, b"1234")]))
+check(serving, "a failed turn must not stop the relay")
+check(session is broken and broken.failed,
+      "a failed session must be marked spent")
+check([n["event"] for n in down.notices] == ["turn-failed"],
+      "a failed turn must be announced to the client: %s" % down.notices)
+check("ThrottlingException" in down.notices[0].get("error", ""),
+      "the notice should name the failure: %s" % down.notices[0])
+
+# And the next talk key rebuilds instead of reusing it, which is what marking it
+# spent is for.
+renewed = []
+fresh = Stub()
+
+async def fake_renew(session, options, down):
+    renewed.append(session)
+    return fresh
+
+relay.renew = fake_renew
+session, serving, down = asyncio.run(drive(broken, [(frame.TALK_START, b"")]))
+check(renewed == [broken], "a spent session must be replaced on the next turn")
+check(session is fresh and fresh.calls == ["talk_start"],
+      "the replacement session must take the turn: %s" % fresh.calls)
+
+# A reconnect that fails is itself just a failed turn: the captain presses the
+# key again rather than restarting the relay.
+async def failing_renew(session, options, down):
+    raise RuntimeError("EndpointConnectionError")
+
+relay.renew = failing_renew
+spent = Stub()
+spent.replies = 1
+session, serving, down = asyncio.run(drive(spent, [(frame.TALK_START, b"")]))
+check(serving, "a failed reconnect must not stop the relay")
+check(spent.failed, "a failed reconnect must leave the session spent")
+check([n["event"] for n in down.notices] == ["turn-failed"],
+      "a failed reconnect must be announced: %s" % down.notices)
+check(spent.calls == [], "a session whose reconnect failed must not be spoken to")
+
+# Quit still ends the loop, so the relay exits when the client says so.
+session, serving, down = asyncio.run(drive(Stub(), [(frame.QUIT, b"")]))
+check(not serving, "quit must end the loop")
+PY
+pass "a turn the model refuses is announced and costs one turn, not the relay"
 
 # --- the laptop end ---------------------------------------------------------
 #
@@ -612,6 +788,77 @@ assert_contains "$overlap" '"open_pull_requests": 1' \
 pass "an item denied in more than one list is counted as withheld once"
 
 rm -f "$HOME_FIXTURE/config/voice-read-deny"
+
+# THE CASE THE DENY LIST EXISTS FOR, and the one a per-list decision gets wrong.
+# The docstring says the list is for a future open task carrying a customer name,
+# and a name like that lives in the TITLE or in the HOLD text of an item that is
+# also in flight, also waiting on the captain, and also carrying a pull request.
+# A decision taken separately in each list, from whichever fields that list
+# happens to use, withholds such an item from one list and names it in another.
+# That is not a narrower answer, it is a leak with a reassuring count beside it.
+# Both items below sit in all three lists, and each is matched on a field only
+# one of those lists reads.
+LEAK_HOME="$TMP_ROOT/deny-every-list"
+TITLE_TOKEN=LEAKSBYTITLE
+HOLD_TOKEN=LEAKSBYHOLD
+mkdir -p "$LEAK_HOME/data" "$LEAK_HOME/state" "$LEAK_HOME/config"
+cat > "$LEAK_HOME/data/backlog.md" <<EOF
+# Backlog
+
+## In flight
+- [ ] omega-nine - Renew the $TITLE_TOKEN contract (repo: omega) (kind: captain)
+- [ ] sigma-ten - Move the account onto the new tier (repo: sigma) (kind: ship) (hold-kind: captain) (hold: waiting on the $HOLD_TOKEN owner)
+EOF
+fm_write_meta "$LEAK_HOME/state/omega-nine.meta" \
+  kind=captain pr=https://github.com/example/omega/pull/11
+fm_write_meta "$LEAK_HOME/state/sigma-ten.meta" \
+  kind=ship pr=https://github.com/example/sigma/pull/12
+
+leak_status() {
+  python3 "$ROOT/bin/fm_voice_records.py" status --home "$LEAK_HOME" --scope full
+}
+
+# Reachable in all three lists first, or the suppression below proves nothing.
+reachable=$(leak_status) || fail "the deny-every-list fixture failed"
+assert_contains "$reachable" "$TITLE_TOKEN" "fixture: the title marker should be reachable"
+assert_contains "$reachable" 'omega-nine' "fixture: the item should be named"
+assert_contains "$reachable" 'pull/11' "fixture: its pull request should be reachable"
+assert_contains "$reachable" 'sigma-ten' "fixture: the held item should be named"
+assert_contains "$reachable" 'pull/12' "fixture: its pull request should be reachable"
+assert_contains "$reachable" '"awaiting_captain": 2' \
+  "fixture: both items should be waiting on the captain"
+
+# Matched on its title, which only the in-flight list reads.
+printf '%s\n' "$TITLE_TOKEN" > "$LEAK_HOME/config/voice-read-deny"
+by_title=$(leak_status) || fail "deny by title failed"
+assert_not_contains "$by_title" "$TITLE_TOKEN" "a title match must be suppressed"
+assert_not_contains "$by_title" 'omega-nine' \
+  "a denied item must not be named in any list"
+assert_not_contains "$by_title" 'pull/11' \
+  "a denied item must not surface through its pull request link"
+assert_contains "$by_title" '"withheld_as_confidential": 1' \
+  "the denied item should be counted once"
+# The other item is untouched, so this is a substring list and not a switch.
+assert_contains "$by_title" 'sigma-ten' "the deny list must not suppress everything"
+assert_contains "$by_title" 'pull/12' "the other pull request should still be named"
+assert_contains "$by_title" '"open_pull_requests": 2' \
+  "denying an item must not change the count of open pull requests"
+
+# Matched on its hold text, which only the captain list reads. The mirror of the
+# case above: get one list right and this one still leaks.
+printf '%s\n' "$HOLD_TOKEN" > "$LEAK_HOME/config/voice-read-deny"
+by_hold=$(leak_status) || fail "deny by hold text failed"
+assert_not_contains "$by_hold" 'sigma-ten' \
+  "an item matched on its hold text must not be named in the in-flight list"
+assert_not_contains "$by_hold" 'pull/12' \
+  "an item matched on its hold text must not surface through its pull request"
+assert_contains "$by_hold" '"withheld_as_confidential": 1' \
+  "the denied item should be counted once"
+assert_contains "$by_hold" 'omega-nine' "the deny list must not suppress everything"
+assert_contains "$by_hold" 'pull/11' "the other pull request should still be named"
+assert_contains "$by_hold" '"in_flight": 2' \
+  "denying an item must not change the count of in-flight work"
+pass "one deny decision per item covers every list that item could appear in"
 
 # --- refusals ---------------------------------------------------------------
 #

--- a/tests/fm-voice-relay.test.sh
+++ b/tests/fm-voice-relay.test.sh
@@ -161,6 +161,55 @@ frame.check_header(frame.AUDIO, frame.MAX_PAYLOAD)
 PY
 pass "wire format round trips and rejects a desynchronised stream"
 
+# --- the relay's uplink ------------------------------------------------------
+#
+# The relay decodes the captain's frames on an asyncio stream, which frame.Reader
+# cannot drive, so the rule above has to be exercised on that path as well. The
+# failure mode it prevents is not a wrong answer, it is no answer: a relay that
+# reads the payload before it checks the length waits inside readexactly for up
+# to four gigabytes that will never arrive, while the captain sits in front of a
+# client that never replies. The timeout below is what tells those two apart.
+
+python3 - "$ROOT/bin" <<'PY' || fail "relay uplink"
+import asyncio, sys
+sys.path.insert(0, sys.argv[1])
+import importlib.util, pathlib
+spec = importlib.util.spec_from_file_location(
+    "relay", str(pathlib.Path(sys.argv[1]) / "fm-voice-relay.py"))
+relay = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(relay)
+import fm_voice_frame as frame
+
+def check(cond, label):
+    if not cond:
+        sys.exit("uplink: " + label)
+
+async def read(raw):
+    reader = asyncio.StreamReader()
+    reader.feed_data(raw)
+    return await asyncio.wait_for(relay.read_uplink_frame(reader), timeout=5)
+
+audio = b"\x01\x02" * 8
+check(asyncio.run(read(frame.encode(frame.AUDIO, audio))) == (frame.AUDIO, audio),
+      "a frame carrying audio did not survive the uplink")
+check(asyncio.run(read(frame.encode(frame.TALK_END))) == (frame.TALK_END, b""),
+      "an empty control frame did not survive the uplink")
+
+# A header with nothing behind it. Refused on the header, this raises at once;
+# read first and checked later, it hangs, so a timeout here is the regression.
+for bad in (frame.HEADER.pack(frame.AUDIO, frame.MAX_PAYLOAD + 1),
+            b"\xff\x00\x00\x10\x00"):
+    try:
+        asyncio.run(read(bad))
+        sys.exit("uplink: accepted a bad header: %r" % bad)
+    except frame.FrameError:
+        pass
+    except (asyncio.TimeoutError, TimeoutError):
+        sys.exit("uplink: waited for the payload of a bad header instead of "
+                 "refusing it: %r" % bad)
+PY
+pass "the relay refuses a desynchronised uplink header instead of waiting for its payload"
+
 # --- the tool surface the two sides share -----------------------------------
 #
 # The relay declares the tools and fm_voice_records implements them. Renaming one
@@ -205,7 +254,7 @@ pass "the relay and the reader agree on the tool names and the handover argument
 # Nothing here talks to AWS; the resolver is replaced with a counter.
 
 python3 - "$ROOT/bin" <<'PY' || fail "credential reuse"
-import asyncio, sys, time
+import asyncio, datetime, sys, time
 sys.path.insert(0, sys.argv[1])
 import importlib.util, pathlib
 spec = importlib.util.spec_from_file_location(
@@ -218,13 +267,19 @@ def check(cond, label):
         sys.exit("credentials: " + label)
 
 calls = []
-expiry = [None]
+stamp = [""]
 delay = [0.0]
 
+def iso(at):
+    return datetime.datetime.fromtimestamp(at, datetime.timezone.utc).isoformat()
+
 def fake(profile, verbose=False):
+    # Whatever the profile says about expiry reaches the cache through the real
+    # parser, so the fixture hands it a stamp rather than a decided answer.
     calls.append(profile)
     time.sleep(delay[0])
-    return {"aws_access_key_id": "AK%d" % len(calls)}, expiry[0]
+    return ({"aws_access_key_id": "AK%d" % len(calls)},
+            relay._expires_at(stamp[0]))
 
 relay.resolve_credentials = fake
 
@@ -246,16 +301,44 @@ check(asyncio.run(take(cache, 1))[0]["aws_access_key_id"] == "AK1",
 # Credentials with an expiry are refreshed ahead of it, because a relay left
 # running outlives them and a dead credential is a dead session.
 del calls[:]
-expiry[0] = time.time() + relay.Credentials.REFRESH_MARGIN - 1
+stamp[0] = iso(time.time() + relay.Credentials.REFRESH_MARGIN - 1)
 cache = relay.Credentials("a-profile")
 asyncio.run(take(cache, 2))
 check(len(calls) == 2,
       "credentials near expiry should be refreshed, resolved %d times" % len(calls))
 
+# An expiry this interpreter cannot read is NOT an expiry that never comes. The
+# credential works, its deadline does not, so it is held for the same margin and
+# no longer. Read as "never expires" it would be cached past the real deadline
+# and every session from then on would fail to start with no way back.
+class Bounded(relay.Credentials):
+    REFRESH_MARGIN = 0.05
+
+del calls[:]
+stamp[0] = "expires some time on Tuesday"
+cache = Bounded("a-profile")
+asyncio.run(take(cache, 2))
+check(len(calls) == 1,
+      "an unreadable expiry should still be reused within the margin: %d" % len(calls))
+time.sleep(0.1)
+asyncio.run(take(cache, 1))
+check(len(calls) == 2,
+      "an unreadable expiry must not be cached for the life of the relay")
+
+# An absent expiry keeps meaning what it says: this credential does not expire.
+del calls[:]
+stamp[0] = ""
+cache = Bounded("a-profile")
+asyncio.run(take(cache, 1))
+time.sleep(0.1)
+asyncio.run(take(cache, 1))
+check(len(calls) == 1,
+      "a credential with no expiry should not be resolved again: %d" % len(calls))
+
 # Whenever a resolution does happen it must stay off the event loop, or the
 # relay stops reading the captain's audio for as long as it takes.
 del calls[:]
-expiry[0] = None
+stamp[0] = ""
 delay[0] = 0.3
 
 async def resolve_while_the_loop_runs():
@@ -306,6 +389,23 @@ check(client.parse_args(["--host", "h"]).listen == client.PUSH_TO_TALK,
       "push to talk must be the default")
 check(client.parse_args(["--host", "h", "--listen", "open-mic"]).listen
       == client.OPEN_MIC, "open mic must be selectable")
+
+# The audio devices themselves cannot be reached from here, but their SELECTOR
+# can be, and it is typed: sounddevice reads an int as an index into its device
+# list and a str as a name to match, so an index left as text is looked up as a
+# device literally called "3" and raises on the captain's first live run.
+picked = client.parse_args(["--host", "h", "--input-device", "3",
+                            "--output-device", "External Headphones"])
+check(picked.input_device == 3 and not isinstance(picked.input_device, str),
+      "a numeric device must arrive as an index: %r" % picked.input_device)
+check(picked.output_device == "External Headphones",
+      "a named device must stay a name: %r" % picked.output_device)
+check(client.parse_args(
+          ["--host", "h", "--input-device", "2 - Built-in Microphone"]
+      ).input_device == "2 - Built-in Microphone",
+      "a device name that begins with a digit must stay a name")
+check(client.parse_args(["--host", "h"]).input_device is None,
+      "no device flag must stay unset, so sounddevice picks the default")
 
 # Over SSH: no pty, or the audio stream is silently rewritten.
 argv = client.relay_command(client.parse_args(["--host", "desk"]))
@@ -560,7 +660,37 @@ assert_present "$HOME_FIXTURE/state/.wake-queue" \
   "handover should wake firstmate"
 wakes=$(grep -c 'inbox:' "$HOME_FIXTURE/state/.wake-queue")
 [ "$wakes" = 1 ] || fail "handover should append exactly one wake, found $wakes"
+
+# The reading half must see what the queueing half just wrote, or the agent says
+# the request is queued and then, asked what is waiting, says nothing is.
+paired=$(records_status --scope counts) || fail "status after a handover failed"
+assert_contains "$paired" '"captain_notes_waiting": 1' \
+  "the reader should count the note the handover just queued"
 pass "handover queues the request for firstmate and wakes it exactly once"
+
+# The same pairing when the state directory is moved. bin/fm-inbox.sh resolves
+# ${FM_STATE_OVERRIDE:-$FM_HOME/state} and the handover queues through it with
+# the ambient environment, so a reader that ignored the override would count
+# notes in a directory nothing writes to.
+alt_state="$TMP_ROOT/state-elsewhere"
+alt_home="$TMP_ROOT/override-home"
+mkdir -p "$alt_state" "$alt_home/data" "$alt_home/state"
+FM_STATE_OVERRIDE="$alt_state" python3 "$ROOT/bin/fm_voice_records.py" queue \
+  "Chase the flaky retry test" --home "$alt_home" >/dev/null \
+  || fail "handover with an overridden state directory failed"
+
+moved=$(find "$alt_state/inbox" -maxdepth 1 -name '*.note' | wc -l)
+[ "$moved" = 1 ] || \
+  fail "the queue should write into the overridden state directory, found $moved"
+[ ! -e "$alt_home/state/inbox" ] || \
+  fail "the queue should not have written under the home when the state is moved"
+
+overridden=$(FM_STATE_OVERRIDE="$alt_state" python3 \
+  "$ROOT/bin/fm_voice_records.py" status --home "$alt_home") \
+  || fail "status with an overridden state directory failed"
+assert_contains "$overridden" '"captain_notes_waiting": 1' \
+  "the reader must count notes where the queue actually wrote them"
+pass "the reader and the queue resolve the state directory the same way"
 
 set +e
 empty_out=$(python3 "$ROOT/bin/fm_voice_records.py" queue "   " \

--- a/tests/fm-voice-relay.test.sh
+++ b/tests/fm-voice-relay.test.sh
@@ -1514,6 +1514,111 @@ check(cut_record["relay_error"],
 check("connection" in cut_record["relay_error"],
       "and it should say the connection went: %r" % cut_record["relay_error"])
 
+# The other moment a connection can go is BETWEEN two turns, during the seconds
+# the client spends letting the previous answer finish. That wait is most of a
+# multi-run session, so it is where a relay that dies between questions dies.
+# Opening the next turn anyway cleared the failure the downlink had recorded,
+# left nothing on the far end to answer it, and produced a run that came back
+# after the whole reply timeout saying answered: false with relay_error: null.
+# In runs.jsonl that is indistinguishable from a turn the model declined, and
+# runs.jsonl is the file docs/voice-relay.md computes its latency spread from, so
+# the invented turn would be averaged into a published number.
+import contextlib
+import json as json_lib
+
+
+class ClosingStream:
+    """Serves one whole turn, then closes during the wait after it.
+
+    Both moments are released by the client reaching them rather than by a
+    timer: the frames wait for the turn to open, and the close waits for the
+    client to enter the inter-turn wait. So the sequence under test is the same
+    on a loaded host as on an idle one.
+    """
+
+    def __init__(self, gate, waiting):
+        self._gate = gate
+        self._waiting = waiting
+        self._reply = (
+            frame.encode(frame.AUDIO, b"\x00\x00" * 1200)
+            + frame.encode_json(frame.MARK, {"mark": "reply_end",
+                                             "since_talk_end": 0.4,
+                                             "tool_calls": 1}))
+        self._at = 0
+
+    def read(self, count):
+        check(self._gate.wait(10), "the turn never opened, so nothing was served")
+        if self._at >= len(self._reply):
+            check(self._waiting.wait(10),
+                  "fixture: the client never reached the wait between turns")
+            return b""
+        chunk = self._reply[self._at:self._at + count]
+        self._at += len(chunk)
+        return chunk
+
+
+class StartGate:
+    """Discards the uplink and reports when a turn's first frame went out."""
+
+    def __init__(self, gate):
+        self._gate = gate
+
+    def send(self, kind, payload=b""):
+        if kind == frame.TALK_START:
+            self._gate.set()
+
+
+served, waiting_between = thread_lib.Event(), thread_lib.Event()
+closing = client.Client(client.parse_args(
+    ["--host", "desk", "--in-file", os.path.join(TMP, "clip.pcm"),
+     "--out-file", os.path.join(TMP, "reply-closing.pcm"), "--runs", "2",
+     "--timeout", "2", "--audio-idle", "0.05", "--gap-seconds", "0.05"]))
+closing.reader = frame.Reader(ClosingStream(served, waiting_between))
+closing.uplink = StartGate(served)
+closing.playback = client.FilePlayback(os.path.join(TMP, "reply-closing.pcm"))
+closing.capture = client.FileCapture(os.path.join(TMP, "clip.pcm"))
+closing.capture.start(closing.up_q, closing.talking)
+thread_lib.Thread(target=closing._sender, daemon=True).start()
+thread_lib.Thread(target=closing._downlink, daemon=True).start()
+
+# The wait between turns is the seam: the connection goes while the client is
+# inside it, after the first run was reported and before the second could open.
+# Waiting for the downlink to see it keeps that ordering exact rather than
+# leaving it to whichever thread the scheduler runs next.
+finish_wait = closing._let_reply_finish
+
+
+def lose_connection_while_waiting(record):
+    waiting_between.set()
+    check(closing.closed.wait(10),
+          "fixture: the connection never closed during the wait between turns")
+    return finish_wait(record)
+
+
+closing._let_reply_finish = lose_connection_while_waiting
+emitted, spoken = io.StringIO(), io.StringIO()
+with contextlib.redirect_stdout(emitted), contextlib.redirect_stderr(spoken):
+    closing_code = closing.run()
+closing.up_q.put(None)
+closing.playback.close()
+
+closing_runs = [json_lib.loads(line) for line in emitted.getvalue().splitlines()
+                if line.strip()]
+check(len(closing_runs) == 1,
+      "a connection lost between turns must end the session rather than invent a "
+      "turn nobody took: %d run(s) reported, %r" % (len(closing_runs), closing_runs))
+check(closing_runs[0]["answered"] and closing_runs[0]["relay_error"] is None,
+      "fixture is wrong: the turn before the connection went should be a good "
+      "one, so the case cannot pass on a run that failed anyway: %r"
+      % closing_runs[0])
+# Two runs were asked for and one was taken, so the exit code has to be the
+# unhappy one; a session that stops early while reporting success is a
+# measurement someone reads as complete.
+check(closing_code != 0,
+      "a session that took 1 of 2 runs must not exit 0, got %r" % closing_code)
+check("connection closed" in spoken.getvalue(),
+      "and the captain should be told why it stopped: %r" % spoken.getvalue())
+
 # A startup that refuses part way through releases what it already started, and
 # close() therefore has to survive a half-built client. The real devices cannot be
 # opened on this host, so these stand in for them; what is tested here is the

--- a/tests/fm-voice-relay.test.sh
+++ b/tests/fm-voice-relay.test.sh
@@ -1014,6 +1014,138 @@ check(session.audio_content is None, "talk end must close the block")
 PY
 pass "audio that arrives with no turn open is dropped, not turned into a turn"
 
+# --- a model stream that dies while answering --------------------------------
+#
+# The reader task is the other place a turn can fail, and it fails in the middle
+# of work: handling an event reaches back into the model to answer a tool call. A
+# failure there must still tell a waiting turn the session is over, and close()
+# must absorb it, because close() is the first thing renew does. Neither held
+# once, and the cost was not one lost turn but every later one: the reader task
+# kept its exception, close() re-raised it on every await, renew never reached
+# the line that builds a replacement, and the captain heard the same failure
+# forever with no way back short of restarting the relay.
+
+python3 - "$ROOT/bin" "$TMP_ROOT/reader-home" <<'PY' || fail "reader failure"
+import asyncio, json, os, sys
+sys.path.insert(0, sys.argv[1])
+import importlib.util, pathlib
+spec = importlib.util.spec_from_file_location(
+    "relay", str(pathlib.Path(sys.argv[1]) / "fm-voice-relay.py"))
+relay = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(relay)
+
+home = sys.argv[2]
+os.makedirs(home, exist_ok=True)
+options = relay.parse_args(["--serve", "--home", home])
+
+def check(cond, label):
+    if not cond:
+        sys.exit("reader failure: " + label)
+
+class Down:
+    def __init__(self):
+        self.notices = []
+
+    def send(self, kind, payload=b""):
+        pass
+
+    def send_json(self, kind, obj):
+        self.notices.append(obj)
+
+    def arm_turn(self):
+        pass
+
+    def first_audio(self):
+        return None
+
+class Input:
+    async def send(self, chunk):
+        pass
+
+    async def close(self):
+        pass
+
+class Payload:
+    def __init__(self, raw):
+        self.bytes_ = raw
+
+class Result:
+    def __init__(self, raw):
+        self.value = Payload(raw)
+
+class Receiver:
+    def __init__(self, raw):
+        self._raw = raw
+
+    async def receive(self):
+        return Result(self._raw)
+
+class Stream:
+    """One model event, then a stream that has gone away."""
+
+    def __init__(self, raws):
+        self._raws = list(raws)
+        self.input_stream = Input()
+
+    async def await_output(self):
+        if not self._raws:
+            raise RuntimeError("the model stream is gone")
+        return (None, Receiver(self._raws.pop(0)))
+
+TOOL_EVENT = json.dumps({"event": {"toolUse": {
+    "toolName": "no_such_tool", "toolUseId": "t-1", "content": "{}"}}}).encode()
+
+async def one_case(fail_in_handler):
+    """Poison a session the way the finding describes, then try the next turn."""
+    session = relay.Session(options, Down(), None)
+    session.stream = Stream([TOOL_EVENT])
+    if fail_in_handler:
+        async def boom(event):
+            raise RuntimeError("handling blew up")
+        session._handle = boom
+    else:
+        # The real _handle and _run_tool, with the tool-result send failing: the
+        # shape a dropped stream takes while the relay answers a tool call.
+        async def refuse(obj):
+            raise RuntimeError("the model stream is gone")
+        session._send = refuse
+    session.reader_task = asyncio.create_task(session._read_model())
+    await asyncio.wait_for(session.ended.wait(), timeout=5)
+    check(session.turn_done.is_set(), "a waiting turn must be released")
+
+    # close() absorbs the stored failure however many times it is asked, which is
+    # what lets the next turn get as far as building a replacement.
+    for _ in range(3):
+        await session.close()
+
+    built = []
+
+    class Fresh:
+        def __init__(self, *args):
+            self.connect_seconds = 0.02
+            built.append(self)
+
+        async def start(self):
+            pass
+
+    real, relay.Session = relay.Session, Fresh
+    try:
+        replacement = await relay.renew(session, options, Down())
+    finally:
+        relay.Session = real
+    return replacement, built
+
+for fails_in_handler in (True, False):
+    where = "the event handler" if fails_in_handler else "the tool result send"
+    replacement, built = asyncio.run(one_case(fails_in_handler))
+    check(len(built) == 1,
+          "after a failure in %s the next turn must build a session: %r"
+          % (where, built))
+    check(replacement is built[0],
+          "and renew must hand that replacement back for %s" % where)
+PY
+pass "a failure inside the model reader costs one turn, not every later one"
+
 # --- the laptop end ---------------------------------------------------------
 #
 # The microphone and speaker paths cannot be tested from a host with neither, and
@@ -1146,6 +1278,96 @@ except SystemExit as exc:
 check(timed_out is not None, "a silent relay was treated as ready")
 check("never reported ready" in timed_out,
       "a silent relay should time out with its own message: %s" % timed_out)
+
+# A startup that refuses part way through releases what it already started, and
+# close() therefore has to survive a half-built client. The real devices cannot be
+# opened on this host, so these stand in for them; what is tested here is the
+# release path and the refusal, not the devices themselves.
+class Recorder:
+    def __init__(self, closed):
+        self._closed = closed
+        self.bytes = 0
+        self.first_played = None
+        self.device_latency = None
+
+    def drain(self, timeout=5):
+        pass
+
+    def close(self):
+        self._closed.append("closed")
+
+    def start(self, out_q, talking):
+        pass
+
+# Nothing built yet: close() must not trip over the fields that are still None.
+client.Client(client.parse_args(["--host", "desk"])).close()
+
+# Built part way, then refused: whatever was started is released once.
+half = client.Client(client.parse_args(["--host", "desk"]))
+speaker, microphone = [], []
+half.playback = Recorder(speaker)
+half.capture = Recorder(microphone)
+half.close()
+check(speaker == ["closed"] and microphone == ["closed"],
+      "a half-built client must release both devices: %r %r" % (speaker, microphone))
+
+# open() releases them itself when a later step refuses, so no caller has to.
+refusing = client.Client(client.parse_args(["--host", "desk"]))
+speaker, microphone = [], []
+
+def half_start():
+    refusing.playback = Recorder(speaker)
+    refusing.capture = Recorder(microphone)
+    raise SystemExit("fm-voice-client: the relay closed the connection")
+
+refusing._start = half_start
+raised = None
+try:
+    refusing.open()
+except SystemExit as exc:
+    raised = str(exc)
+check(raised is not None, "open must not swallow the refusal")
+check(speaker == ["closed"] and microphone == ["closed"],
+      "open must release the devices it started: %r %r" % (speaker, microphone))
+
+# A device that cannot be opened is one named line with a next step, not a
+# traceback, because this is the path the guide warns will fail first. The relay
+# side is stubbed out here so nothing is launched: the subject is the refusal.
+class Boom:
+    def __init__(self, *args, **kwargs):
+        raise RuntimeError("PortAudio said no")
+
+class FakeProc:
+    def __init__(self, *args, **kwargs):
+        self.stdin = io.BytesIO()
+        self.stdout = io.BytesIO(frame.MAGIC)
+
+    def wait(self, timeout=None):
+        return 0
+
+    def kill(self):
+        pass
+
+real_speaker = client.SpeakerPlayback
+real_popen = client.subprocess.Popen
+real_sync = client.sync_magic
+client.SpeakerPlayback = Boom
+client.subprocess.Popen = FakeProc
+client.sync_magic = lambda stream, verbose=False: None
+named = None
+try:
+    client.Client(client.parse_args(["--host", "desk"])).open()
+except client.DeviceError as exc:
+    named = str(exc)
+except Exception as exc:                       # noqa: BLE001
+    named = "wrong type: %s: %s" % (type(exc).__name__, exc)
+finally:
+    client.SpeakerPlayback = real_speaker
+    client.subprocess.Popen = real_popen
+    client.sync_magic = real_sync
+check(named is not None and "could not open the audio devices" in named,
+      "a device failure should be a named refusal: %s" % named)
+check("--in-file" in named, "and should name a way to run without them: %s" % named)
 
 # A login shell banner is discarded with a warning naming it, not an error.
 noise = b"You have mail.\n"
@@ -1627,18 +1849,34 @@ assert_not_contains "$open_only" 'pull/3' \
   "an item under Done must not have its pull request named"
 assert_not_contains "$open_only" "$FINISHED_TOKEN" \
   "no finished title may reach the answer at any scope"
-
-# The deny list is the only control the guide offers for a customer name, and it
-# could not touch these items at all, because their titles were never in the field
-# set it matches against.
-printf '%s\n' "$FINISHED_TOKEN" > "$DONE_HOME/config/voice-read-deny"
-denied_done=$(done_status) || fail "deny by a finished title failed"
-assert_not_contains "$denied_done" 'pull/2' \
-  "a deny substring matching a finished title must not leave its link named"
-assert_not_contains "$denied_done" 'pull/3' \
-  "a deny substring matching a finished title must not leave its link named"
-assert_contains "$denied_done" 'pull/1' "the open task is unaffected"
+# Excluded by construction, not withheld and counted. A later change that put
+# finished work back in and leaned on the deny list to hide it would fail here.
+assert_contains "$open_only" '"withheld_as_confidential": 0' \
+  "finished work is left out rather than counted as withheld"
+# The worker count is deliberately NOT open-only: a task keeps its runtime record
+# until teardown removes it, and that record is what "on deck" counts. Asserted in
+# the same case as the pull request count so the two cannot quietly converge.
+assert_contains "$open_only" '"workers_on_deck": 3' \
+  "every live runtime record is still on deck, finished or not"
 pass "a finished task's pull request is neither counted nor named"
+
+# The deny list, observed doing its job on the one list that still carries links.
+# A substring matching an OPEN task's title takes that task out of the pull
+# request detail and says one thing is being withheld, while the count stays
+# honest: that split is the contract this module states and the earlier cases
+# pin, so the captain learns how much is waiting without learning what it is.
+printf '%s\n' 'Fix the retry' > "$DONE_HOME/config/voice-read-deny"
+denied_open=$(done_status) || fail "deny by an open title failed"
+assert_not_contains "$denied_open" 'still-open' \
+  "a denied open task must not be named in the pull request detail"
+assert_not_contains "$denied_open" 'pull/1' \
+  "a denied open task's pull request link must go with it"
+assert_contains "$denied_open" '"withheld_as_confidential": 1' \
+  "and the captain must be told one thing is being withheld"
+assert_contains "$denied_open" '"open_pull_requests": 1' \
+  "while the count of open pull requests stays honest"
+rm -f "$DONE_HOME/config/voice-read-deny"
+pass "a deny substring on an open title removes its pull request and says so"
 
 # --- refusals ---------------------------------------------------------------
 #

--- a/tests/fm-voice-relay.test.sh
+++ b/tests/fm-voice-relay.test.sh
@@ -2199,11 +2199,18 @@ with and what it was asked. tests/fm-voice-relay.test.sh reads that record.
   FM_FAKE_STATE    file holding the turn counter across the relay's reconnects
   FM_FAKE_LOG      where to append the per-session record
   FM_FAKE_REQUEST  the words the captain uses when asking for real work
+  FM_FAKE_EARLY    1 to answer from the first audio in, not from the talk end
 
 A clean-end turn is a session the model finishes with while the captain is still
 speaking: the output stream simply ends, with no error and no answer. That is an
 ordinary end of a Bedrock session rather than a fault, and the relay has to
 survive it, so it is a turn kind here rather than a failure injection.
+
+FM_FAKE_EARLY stands in for the model's own end-of-speech detector firing inside
+a clip that already ends in silence: the answer begins before this end of the
+stream has said the turn is over. Nova Sonic really does that, and the relay's
+own timing figures are negative when it happens, which is the one case where a
+fast-looking number is meaningless.
 """
 
 import asyncio
@@ -2225,6 +2232,7 @@ SCRIPT = [s.strip() for s in os.environ.get("FM_FAKE_SCRIPT", "status").split(",
 STATE = os.environ.get("FM_FAKE_STATE", "")
 LOG = os.environ.get("FM_FAKE_LOG", "")
 REQUEST = os.environ.get("FM_FAKE_REQUEST", "open a pull request for the retry")
+EARLY = os.environ.get("FM_FAKE_EARLY", "") == "1"
 
 HEARD = {"status": "how is the fleet doing right now", "handover": REQUEST}
 
@@ -2369,6 +2377,12 @@ class _Stream:
                 self.record["audio_bytes_in"] += len(
                     base64.b64decode(body.get("content", "")))
                 self._maybe_end_cleanly()
+                if EARLY and not self._replied and not self._ended_early:
+                    # Answering while the captain's clip is still arriving, which
+                    # is what the model's own endpoint detector does to a clip
+                    # that ends in silence.
+                    self._replied = True
+                    self._reply_task = asyncio.create_task(self._reply())
             elif name == "toolResult":
                 self._tool_result(body)
             elif name == "contentEnd":
@@ -2868,5 +2882,129 @@ check("connection lost" not in transcript,
       "the connection should have outlived the session: %r" % transcript)
 PY
 pass "a model session that ends mid-conversation costs one turn, not the relay"
+
+# --- the desktop's own check, and the clock it refuses to lie about ----------
+#
+# `fm-voice-relay.py --self-test <clip.pcm>` is what docs/voice-relay.md tells the
+# captain to run before they touch the laptop, and it is also the instrument the
+# direct column of the latency table was measured with. Everything above drives
+# the relay through the client; this drives the desktop check itself, because a
+# broken --self-test is a captain who cannot tell a configured desktop from an
+# unconfigured one, and a number in a table that nobody can reproduce.
+#
+# The second case is the one worth having. A clip that already ends in silence
+# makes the model answer before this end of the stream has said the turn is over,
+# so every figure is measured from the wrong instant and comes out negative. The
+# reply really is fast and the number really is meaningless, which is the worst
+# combination to leave in a results file for someone who was not here. The guard
+# has to name the marks and say why, not print the figure.
+
+SELFTEST="$E2E/self-test"
+mkdir -p "$SELFTEST"
+printf '0\n' > "$SELFTEST/turn-counter"
+
+# The same two seconds of speech, with a second of silence glued on the end: the
+# shape the docs warn against, and the only way to reach the guard.
+cat "$E2E/clip.pcm" > "$SELFTEST/ends-in-silence.pcm"
+python3 - "$SELFTEST/ends-in-silence.pcm" <<'PY' \
+  || fail "could not write the silence-tailed clip"
+import sys
+with open(sys.argv[1], "ab") as handle:
+    handle.write(b"\x00\x00" * 16000)
+PY
+
+# The desktop, and only the desktop: the AWS credential and the SDK live here.
+relay_self_test() {
+  local clip=$1
+  shift
+  env -i PATH="$PATH" HOME="$E2E/desktop-home" PYTHONPATH="$E2E/fakesdk" \
+    PYTHONDONTWRITEBYTECODE=1 FM_HOME="$E2E/home" \
+    FM_FAKE_STATE="$SELFTEST/turn-counter" FM_FAKE_LOG="$SELFTEST/sessions.jsonl" \
+    FM_FAKE_THINK=0.4 FM_FAKE_REPLY_SECONDS=0.4 FM_FAKE_SCRIPT=status \
+    AWS_ACCESS_KEY_ID="$E2E_KEY" \
+    AWS_SECRET_ACCESS_KEY=desktop-secret-not-a-real-key \
+    "$@" python3 "$ROOT/bin/fm-voice-relay.py" --self-test "$clip"
+}
+
+set +e
+ok_out=$(relay_self_test "$E2E/clip.pcm" 2> "$SELFTEST/ok.err")
+ok_code=$?
+set -e
+expect_code 0 "$ok_code" "the documented desktop check should answer"
+printf '%s\n' "$ok_out" > "$SELFTEST/ok.json"
+
+python3 - "$SELFTEST/ok.json" "$E2E/independent.json" "$E2E_REGION" "$E2E_MODEL" \
+  <<'PY' || fail "the desktop check did not report a usable measurement"
+import json, sys
+
+report = json.load(open(sys.argv[1], encoding="utf-8"))
+records = json.load(open(sys.argv[2], encoding="utf-8"))
+region, model = sys.argv[3:5]
+
+
+def check(cond, label):
+    if not cond:
+        sys.exit("self-test: %s -- %r" % (label, report))
+
+
+check(report["mode"] == "self-test", "not a self-test report")
+check(report["answered"] and report["reply_audio_seconds"] > 0, "it did not answer")
+check(report["relay_error"] is None, "it reported an error")
+check(report["region"] == region and report["model"] == model,
+      "it used the wrong account's model")
+check(report["tool_names"] == ["get_fleet_status"], "it called the wrong tool")
+# The words are the records, the same as over the relay.
+check("{} in flight".format(records["in_flight"]) in report["said"],
+      "the spoken answer did not carry the count")
+check(report["heard"], "it reported nothing heard")
+# The figure the direct column of the latency table is made of, measured from the
+# talk end: the clip is two seconds and the stand-in thinks for 0.4 s, so a clock
+# started at the wrong end lands near 2.4.
+check(report["clock_unusable"] == [], "it flagged a clip that ends on speech")
+for mark in ("tool_use_s", "first_audio_s", "reply_end_s"):
+    check(report[mark] is not None, "no %s figure" % mark)
+check(0.2 < report["first_audio_s"] < 1.6,
+      "first audio at %r is not measured from the talk end" % report["first_audio_s"])
+check(report["tool_use_s"] <= report["first_audio_s"] <= report["reply_end_s"],
+      "the figures are out of order")
+PY
+pass "the desktop's own check answers from the records and times it from the talk end"
+
+set +e
+early_out=$(relay_self_test "$SELFTEST/ends-in-silence.pcm" FM_FAKE_EARLY=1 \
+  2> "$SELFTEST/early.err")
+early_code=$?
+set -e
+expect_code 0 "$early_code" "an answered turn is still an answered turn"
+printf '%s\n' "$early_out" > "$SELFTEST/early.json"
+
+early_err=$(cat "$SELFTEST/early.err")
+assert_contains "$early_err" "measured from the wrong instant" \
+  "the guard must say why the timings cannot be used"
+assert_contains "$early_err" "ends on speech" \
+  "the guard must say what clip to pass instead"
+
+python3 - "$SELFTEST/early.json" <<'PY' \
+  || fail "a reply that beat the end of the clip was recorded as a good measurement"
+import json, sys
+
+report = json.load(open(sys.argv[1], encoding="utf-8"))
+
+
+def check(cond, label):
+    if not cond:
+        sys.exit("wrong clock: %s -- %r" % (label, report))
+
+
+# It answered. That is exactly why the figure is dangerous rather than obviously
+# broken: a reader sees answered: true and a fast number.
+check(report["answered"] and report["reply_audio_seconds"] > 0,
+      "the turn was not answered at all, so this is not the case under test")
+check(report["first_audio_s"] < 0,
+      "the reply did not beat the end of the clip, so the guard was not reached")
+for mark in ("tool_use", "first_audio", "reply_end"):
+    check(mark in report["clock_unusable"], "%s is not named as unusable" % mark)
+PY
+pass "a reply that arrives before the end of the clip is named as an unusable clock"
 
 printf 'all voice relay cases passed\n'

--- a/tests/fm-voice-relay.test.sh
+++ b/tests/fm-voice-relay.test.sh
@@ -285,6 +285,39 @@ options = relay.resolve_settings(
     relay.parse_args(["--serve", "--home", home, "--region", "eu-flag-3"]))
 check(options.region == "eu-flag-3", "a flag should win: %r" % options.region)
 
+os.environ.pop("FM_VOICE_REGION", None)
+os.environ.pop("FM_VOICE_ID", None)
+
+# THE PROFILE IS READ BY PRESENCE, NOT BY TRUTHINESS. An empty FM_VOICE_PROFILE is
+# the captain saying "use the credentials I already have", so it must not fall
+# through to a configured profile and spend a second exporting from an account
+# they just opted out of. fm-inbox.sh reads its own equivalent that way and
+# docs/configuration.md promises it for both.
+with open(os.path.join(home, "config", "voice-profile"), "w") as handle:
+    handle.write("a-configured-profile\n")
+options = relay.resolve_settings(relay.parse_args(["--serve", "--home", home]))
+check(options.profile == "a-configured-profile",
+      "a configured profile should be used: %r" % options.profile)
+
+os.environ["FM_VOICE_PROFILE"] = ""
+options = relay.resolve_settings(relay.parse_args(["--serve", "--home", home]))
+check(options.profile == "",
+      "an empty FM_VOICE_PROFILE must force ambient credentials: %r" % options.profile)
+
+os.environ["FM_VOICE_PROFILE"] = "another-profile"
+options = relay.resolve_settings(relay.parse_args(["--serve", "--home", home]))
+check(options.profile == "another-profile",
+      "a set FM_VOICE_PROFILE should override the file: %r" % options.profile)
+os.environ.pop("FM_VOICE_PROFILE", None)
+
+# An empty region, by contrast, is not a choice about anything, so it still falls
+# through to the file rather than refusing.
+os.environ["FM_VOICE_REGION"] = ""
+options = relay.resolve_settings(relay.parse_args(["--serve", "--home", home]))
+check(options.region == "eu-somewhere-1",
+      "an empty region variable should fall through to the file: %r" % options.region)
+os.environ.pop("FM_VOICE_REGION", None)
+
 # --help must work in a home that has configured nothing, or the captain cannot
 # read how to configure it.
 PY
@@ -337,6 +370,24 @@ unconfigured_note=$(env "${inbox_env[@]}" \
   || fail "note should not need any configuration"
 assert_contains "$unconfigured_note" 'queued ' "note should still queue a record"
 pass "the model-backed subcommands refuse by name while note keeps working"
+
+# --help prints the whole header block, and finds where that block ends rather
+# than counting lines to it, so growing the header cannot silently truncate the
+# help again. The PRIVACY paragraph is the part that matters: it is the only place
+# a new operator is told which subcommands send audio or text off this host, and a
+# fixed line range had already dropped it.
+inbox_help=$("$ROOT/bin/fm-inbox.sh" --help) || fail "fm-inbox.sh --help failed"
+assert_contains "$inbox_help" 'PRIVACY:' \
+  "the help must say which subcommands send anything to a model"
+assert_contains "$inbox_help" 'make no network call at all' \
+  "the help must name the subcommands that stay on this host"
+assert_contains "$inbox_help" 'FM_HOME' \
+  "the help must keep its environment section"
+assert_contains "$inbox_help" 'inbox-ask-model' \
+  "the help must name the files a home has to write"
+assert_contains "$inbox_help" 'fm-inbox.sh note' \
+  "the help must still open with the usage it always had"
+pass "fm-inbox.sh --help prints its whole header, privacy paragraph included"
 
 # --- the tool surface the two sides share -----------------------------------
 #
@@ -873,6 +924,44 @@ check("/opt/venv/bin/python" in argv, "the relay interpreter must be passed: %s"
 check(argv[-2:] == ["--scope", "counts"],
       "relay arguments must reach the relay: %s" % argv)
 
+# A relay that dies after the handshake must be reported at once rather than at
+# the end of the timeout. Its own one-line error is already on the captain's
+# terminal, because the relay's stderr is inherited rather than piped, so the only
+# thing a full timeout adds is thirty seconds of watching nothing. This is the
+# likely first-run shape: the Bedrock SDK is imported inside the model session, so
+# a forgotten --relay-python exits the relay after the handshake.
+import time as clock
+waiting = client.Client(client.parse_args(["--host", "desk", "--timeout", "5"]))
+waiting.closed.set()
+began = clock.monotonic()
+refused = None
+try:
+    waiting._wait_ready()
+except SystemExit as exc:
+    refused = str(exc)
+check(refused is not None, "a closed relay was treated as ready")
+check("closed the connection" in refused,
+      "the refusal should name the closed connection: %s" % refused)
+check("by hand" in refused, "and should give the next step: %s" % refused)
+took = clock.monotonic() - began
+check(took < 2, "a closed relay should be reported at once, waited %.1fs" % took)
+
+# Ready still wins, and a relay that says nothing at all still times out with the
+# message that fits that case instead.
+ready = client.Client(client.parse_args(["--host", "desk", "--timeout", "5"]))
+ready.ready.set()
+ready._wait_ready()
+
+silent = client.Client(client.parse_args(["--host", "desk", "--timeout", "0.3"]))
+timed_out = None
+try:
+    silent._wait_ready()
+except SystemExit as exc:
+    timed_out = str(exc)
+check(timed_out is not None, "a silent relay was treated as ready")
+check("never reported ready" in timed_out,
+      "a silent relay should time out with its own message: %s" % timed_out)
+
 # A login shell banner is discarded with a warning naming it, not an error.
 noise = b"You have mail.\n"
 stream = io.BytesIO(noise + frame.MAGIC + frame.encode(frame.BYE))
@@ -1185,6 +1274,85 @@ assert_contains "$by_queued" '"queued": 1' \
 assert_contains "$by_queued" 'pull/11' "the other pull requests should still be named"
 assert_contains "$by_queued" 'pull/12' "the other pull requests should still be named"
 pass "one deny decision per item covers every list that item could appear in"
+
+# --- what a status line may say ---------------------------------------------
+#
+# A status line is free text a crewmate appended, and the verb taken off the
+# front of it is the ONE record-derived string a counts-scope answer says out
+# loud. At that scope there is no title and no link, so there is nothing for the
+# deny list to filter and no scope setting that makes it safe. The vocabulary is
+# therefore closed to the states bin/fm-brief.sh gives every crewmate plus the two
+# bin/fm-classify-lib.sh adds when a decision closes, and anything else is a note.
+VERB_HOME="$TMP_ROOT/status-verbs"
+CUSTOMER_TOKEN=ACMECORPMIGRATION
+mkdir -p "$VERB_HOME/data" "$VERB_HOME/state"
+cat > "$VERB_HOME/data/backlog.md" <<'EOF'
+# Backlog
+
+## In flight
+- [ ] one - First thing (repo: a) (kind: ship)
+- [ ] two - Second thing (repo: b) (kind: ship)
+- [ ] three - Third thing (repo: c) (kind: ship)
+EOF
+fm_write_meta "$VERB_HOME/state/one.meta" kind=ship
+fm_write_meta "$VERB_HOME/state/two.meta" kind=ship
+fm_write_meta "$VERB_HOME/state/three.meta" kind=ship
+printf 'needs-decision [key=shape]: which shape\n' > "$VERB_HOME/state/one.status"
+printf '%s: waiting on their security review\n' "$CUSTOMER_TOKEN" \
+  > "$VERB_HOME/state/two.status"
+# A log past the tail window, so the read is proven to end at the last line
+# rather than at the start of whatever window it happened to open.
+{
+  verb_line=0
+  while [ "$verb_line" -lt 400 ]; do
+    printf 'working: step %s of a long task with a wordy status line\n' "$verb_line"
+    verb_line=$((verb_line + 1))
+  done
+  printf 'done: shipped it\n'
+} > "$VERB_HOME/state/three.status"
+[ "$(wc -c < "$VERB_HOME/state/three.status")" -gt 8192 ] \
+  || fail "fixture: the long status log should exceed the tail window"
+
+verb_status() {
+  python3 "$ROOT/bin/fm_voice_records.py" status --home "$VERB_HOME" "$@"
+}
+
+verbs=$(verb_status --scope counts) || fail "counts scope with odd verbs failed"
+assert_not_contains "$verbs" "$CUSTOMER_TOKEN" \
+  "a word outside the vocabulary must not be spoken, at the default scope least of all"
+assert_contains "$verbs" '"note": 1' \
+  "an unrecognised verb should be counted as a note instead"
+assert_contains "$verbs" '"needs-decision": 1' \
+  "a canonical verb, brackets and all, should survive the fold"
+assert_contains "$verbs" '"done": 1' \
+  "the last line of a long log is the line that counts"
+assert_not_contains "$verbs" '"working"' \
+  "an earlier line in the same log must not be reported as the state"
+pass "the state verb is a closed vocabulary, so free text cannot ride out on it"
+
+# The two halves of one answer must come from one home. Every script that sets
+# FM_DATA_OVERRIDE sets FM_STATE_OVERRIDE beside it, so a reader that resolved one
+# and not the other would count workers and notes from one home while counting
+# in-flight work from another, which reads exactly like an ordinary answer.
+alt_data="$TMP_ROOT/data-elsewhere"
+mkdir -p "$alt_data"
+cat > "$alt_data/backlog.md" <<'EOF'
+# Backlog
+
+## In flight
+- [ ] moved-one - Work recorded in the overridden data directory (repo: m) (kind: ship)
+EOF
+moved=$(FM_DATA_OVERRIDE="$alt_data" verb_status --scope full) \
+  || fail "status with an overridden data directory failed"
+assert_contains "$moved" 'moved-one' \
+  "the reader must take the backlog from the overridden data directory"
+assert_contains "$moved" '"in_flight": 1' "and count only what that backlog holds"
+inbox_moved=$(FM_HOME="$VERB_HOME" FM_STATE_OVERRIDE="$VERB_HOME/state" \
+  FM_DATA_OVERRIDE="$alt_data" "$ROOT/bin/fm-inbox.sh" status) \
+  || fail "fm-inbox status with an overridden data directory failed"
+assert_contains "$inbox_moved" 'moved-one' \
+  "the human rendering of the same records must read the same backlog"
+pass "the backlog and the state directory always come from the same home"
 
 # --- refusals ---------------------------------------------------------------
 #

--- a/tests/fm-voice-relay.test.sh
+++ b/tests/fm-voice-relay.test.sh
@@ -335,8 +335,33 @@ pass "an unconfigured home can still read how to configure the relay"
 # The captain inbox is the same rule with a different consequence: note, status,
 # list and drain make no model call, so they must keep working unconfigured. The
 # voice handover depends on note, so that is not a nicety.
-inbox_env=(FM_HOME="$CONFIG_HOME" FM_STATE_OVERRIDE="$CONFIG_HOME/state"
-           FM_CONFIG_OVERRIDE="$CONFIG_HOME/config")
+#
+# EVERY FM_INBOX_ VARIABLE IS NEUTRALIZED HERE, at the harness rather than in each
+# case, and the list is read out of the environment rather than written down, so a
+# knob added later cannot quietly survive into a refusal case. A shell that
+# exports a region and a model id would otherwise walk these cases straight past
+# the refusal they assert and into a real model call: an offline suite that can
+# spend the operator's credentials is worse than a failing one.
+inbox_env=()
+while IFS= read -r inbox_knob; do
+  [ -n "$inbox_knob" ] || continue
+  inbox_env+=(-u "$inbox_knob")
+done < <(env | sed -n 's/^\(FM_INBOX_[A-Za-z0-9_]*\)=.*/\1/p' | sort -u)
+inbox_env+=(FM_HOME="$CONFIG_HOME" FM_STATE_OVERRIDE="$CONFIG_HOME/state"
+            FM_CONFIG_OVERRIDE="$CONFIG_HOME/config")
+
+# And a stub that records any attempt, so "no model call" is a checked fact rather
+# than a claim about control flow. The real aws would need credentials; this one
+# leaves evidence and exits non-zero.
+INBOX_FAKEBIN=$(fm_fakebin "$TMP_ROOT/inbox-fake")
+AWS_CALLED="$TMP_ROOT/aws-was-called"
+cat > "$INBOX_FAKEBIN/aws" <<SH
+#!/usr/bin/env bash
+printf 'aws %s\n' "\$*" >> "$AWS_CALLED"
+exit 9
+SH
+chmod +x "$INBOX_FAKEBIN/aws"
+inbox_env+=(PATH="$INBOX_FAKEBIN:$PATH")
 
 set +e
 ask_out=$(env "${inbox_env[@]}" "$ROOT/bin/fm-inbox.sh" ask "how is the fleet" 2>&1)
@@ -369,6 +394,8 @@ unconfigured_note=$(env "${inbox_env[@]}" \
   "$ROOT/bin/fm-inbox.sh" note "the handover must work with no configuration") \
   || fail "note should not need any configuration"
 assert_contains "$unconfigured_note" 'queued ' "note should still queue a record"
+assert_absent "$AWS_CALLED" \
+  "no case above may reach a model: the aws stub recorded an attempt"
 pass "the model-backed subcommands refuse by name while note keeps working"
 
 # --help prints the whole header block, and finds where that block ends rather
@@ -685,6 +712,37 @@ check(asyncio.run(cache.get())["aws_access_key_id"] == "FROM-PROFILE",
       "an expired ambient credential should be abandoned when a profile exists")
 os.environ.pop("AWS_CREDENTIAL_EXPIRATION", None)
 
+# A PROFILE THAT CANNOT ANSWER must not cost the environment. Abandoning ambient
+# credentials is justified by the profile answering, so it is only decided once the
+# profile has: otherwise one failed export strands a relay that is still holding
+# keys, and every later turn names a profile while the answer sits in os.environ.
+del exports[:]
+
+def refusing_profile(profile, verbose=False):
+    exports.append(profile)
+    raise relay.CredentialError(
+        "could not get credentials for profile {}".format(profile))
+
+relay.profile_credentials = refusing_profile
+os.environ["AWS_ACCESS_KEY_ID"] = "AKIAENVIRONMENT"
+os.environ["AWS_SECRET_ACCESS_KEY"] = "s3cret"
+os.environ["AWS_SESSION_TOKEN"] = "still-held-token"
+os.environ.pop("AWS_CREDENTIAL_EXPIRATION", None)
+
+cache = Bounded("a-profile")
+check(asyncio.run(cache.get())["aws_session_token"] == "still-held-token",
+      "usable ambient credentials should be preferred while they hold")
+kept = []
+for _ in range(3):
+    time.sleep(0.1)
+    try:
+        kept.append(asyncio.run(cache.get())["aws_session_token"])
+    except relay.CredentialError:
+        kept.append("CredentialError")
+check(kept == ["still-held-token"] * 3,
+      "a refusing profile must cost one attempt, not the conversation: %r" % kept)
+check(exports, "and the profile should have been tried at least once: %r" % exports)
+
 # An environment with nothing in it and no profile is still a named refusal, so
 # this restores the real resolver rather than asking the stub to pretend.
 for name in AWS_VARS:
@@ -884,6 +942,78 @@ check(built[0].closed == 1,
 PY
 pass "a turn the model refuses is announced and costs one turn, not the relay"
 
+# --- audio that arrives with no turn open ------------------------------------
+#
+# Both listen modes send a talk start before any audio, so audio outside a turn
+# means the capture callback raced the key release and a stray chunk landed behind
+# the talk end. Opening a block for it would append the captain's stray tenth of a
+# second to a session that is already answering, which is the unconditional
+# barge-in the per-turn reconnect exists to avoid, and would leave that block open
+# so the next turn skipped its own reset and its first-audio mark.
+
+python3 - "$ROOT/bin" "$TMP_ROOT/stray-home" <<'PY' || fail "stray audio"
+import asyncio, os, sys
+sys.path.insert(0, sys.argv[1])
+import importlib.util, pathlib
+spec = importlib.util.spec_from_file_location(
+    "relay", str(pathlib.Path(sys.argv[1]) / "fm-voice-relay.py"))
+relay = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(relay)
+
+home = sys.argv[2]
+os.makedirs(home, exist_ok=True)
+
+def check(cond, label):
+    if not cond:
+        sys.exit("stray audio: " + label)
+
+class Down:
+    def send(self, kind, payload=b""):
+        pass
+
+    def send_json(self, kind, obj):
+        pass
+
+    def arm_turn(self):
+        pass
+
+    def first_audio(self):
+        return None
+
+sent = []
+
+async def record(event):
+    sent.append(event)
+
+session = relay.Session(relay.parse_args(["--serve", "--home", home]), Down(), None)
+session._send = record
+
+# No turn open: the stray chunk goes nowhere, and no block is left behind for the
+# next turn to trip over. This session has no model stream either, so anything
+# that did try to open a block would raise rather than pass quietly.
+asyncio.run(session.audio(b"\x01" * 3200))
+check(sent == [], "audio with no turn open must not be forwarded: %r" % sent)
+check(session.audio_content is None,
+      "and must not leave an audio block open: %r" % session.audio_content)
+
+# Inside a turn it flows, so the guard is about the boundary and not about audio.
+asyncio.run(session.talk_start())
+del sent[:]
+asyncio.run(session.audio(b"\x01" * 3200))
+check([next(iter(event)) for event in sent] == ["audioInput"],
+      "audio inside a turn must still be forwarded: %r" % sent)
+
+# And talk end still pads with its trailing silence before closing the block,
+# which is the whole reason a push-to-talk clip gets answered at all.
+del sent[:]
+asyncio.run(session.talk_end())
+kinds = [next(iter(event)) for event in sent]
+check(kinds.count("audioInput") > 0 and kinds[-1] == "contentEnd",
+      "talk end must pad with silence and then close the block: %r" % kinds)
+check(session.audio_content is None, "talk end must close the block")
+PY
+pass "audio that arrives with no turn open is dropped, not turned into a turn"
+
 # --- the laptop end ---------------------------------------------------------
 #
 # The microphone and speaker paths cannot be tested from a host with neither, and
@@ -925,11 +1055,24 @@ check(client.parse_args(["--host", "desk"]).relay
 check(client.parse_args(["--host", "desk", "--relay", "/other/relay.py"]).relay
       == "/other/relay.py", "an explicit --relay must win over the variable")
 
-# Push to talk is the default for this build, and open mic is the one flip.
+# Push to talk is the default for this build, and the only mode that runs.
 check(client.parse_args(["--host", "h"]).listen == client.PUSH_TO_TALK,
       "push to talk must be the default")
-check(client.parse_args(["--host", "h", "--listen", "open-mic"]).listen
-      == client.OPEN_MIC, "open mic must be selectable")
+
+# An open microphone needs to know when the captain stopped speaking, and this
+# client cannot: it would open a turn and stream forever without ever marking a
+# boundary. So the setting is accepted as a value and refuses at parse time,
+# before any ssh connection is opened or any model session is paid for. The value
+# stays in the accepted set so switching it on later is a small change.
+check(client.OPEN_MIC in client.LISTEN_MODES,
+      "open mic must stay a value the flag accepts")
+refusal = None
+try:
+    client.parse_args(["--host", "h", "--listen", "open-mic"])
+except SystemExit as exc:
+    refusal = exc.code
+check(refusal not in (None, 0),
+      "open mic must refuse rather than start: %r" % (refusal,))
 
 # The audio devices themselves cannot be reached from here, but their SELECTOR
 # can be, and it is typed: sounddevice reads an int as an index into its device
@@ -1071,6 +1214,43 @@ set -e
 assert_contains "$short_out" 'fm_voice_frame' \
   "the import failure should name the file the laptop is missing"
 pass "the client runs from a laptop holding only the two files the guide names"
+
+# --listen open-mic refuses, out loud and early. The mode has no way to tell when
+# the captain stopped speaking, so it would stream a turn that never ends; the
+# captain should be told that rather than watching it half work. Early matters as
+# much as loud: an ssh stub here records any attempt to reach the desktop, and the
+# refusal must come before it, so nothing is opened and nothing is spent.
+OPENMIC_FAKEBIN=$(fm_fakebin "$TMP_ROOT/openmic-fake")
+SSH_CALLED="$TMP_ROOT/ssh-was-called"
+cat > "$OPENMIC_FAKEBIN/ssh" <<SH
+#!/usr/bin/env bash
+printf 'ssh %s\n' "\$*" >> "$SSH_CALLED"
+exit 9
+SH
+chmod +x "$OPENMIC_FAKEBIN/ssh"
+
+set +e
+openmic_out=$(PATH="$OPENMIC_FAKEBIN:$PATH" python3 "$ROOT/bin/fm-voice-client.py" \
+  --host a-desktop --relay /desktop/bin/fm-voice-relay.py --listen open-mic 2>&1)
+openmic_code=$?
+set -e
+[ "$openmic_code" -ne 0 ] || fail "--listen open-mic started instead of refusing"
+assert_contains "$openmic_out" 'end-of-speech' \
+  "the refusal should name the missing piece: $openmic_out"
+assert_contains "$openmic_out" 'push-to-talk' \
+  "the refusal should name the mode that does work: $openmic_out"
+assert_absent "$SSH_CALLED" \
+  "the refusal must come before anything reaches the desktop"
+# The default still starts far enough to try the connection, so the case above is
+# a property of the setting rather than of the fixture refusing everything.
+set +e
+PATH="$OPENMIC_FAKEBIN:$PATH" python3 "$ROOT/bin/fm-voice-client.py" \
+  --host a-desktop --relay /desktop/bin/fm-voice-relay.py --talk-seconds 0 \
+  >/dev/null 2>&1
+set -e
+assert_present "$SSH_CALLED" \
+  "fixture is wrong: push to talk should have reached the ssh stub"
+pass "--listen open-mic refuses at startup, before it opens anything"
 
 # --- read scope -------------------------------------------------------------
 
@@ -1398,6 +1578,67 @@ inbox_moved=$(FM_HOME="$VERB_HOME" FM_STATE_OVERRIDE="$VERB_HOME/state" \
 assert_contains "$inbox_moved" 'moved-one' \
   "the human rendering of the same records must read the same backlog"
 pass "the backlog and the state directory always come from the same home"
+
+# --- pull requests on finished work -----------------------------------------
+#
+# A task keeps its state/<id>.meta after its backlog item is marked done, because
+# removing the record and moving the item are separate steps. So a reader that took
+# every worker carrying a pull request would count and name finished work, which
+# this module promises never to read. Worse, the deny list could not reach those
+# items: with no open item there is no title in the field set, so a captain
+# substring matching the title silently failed for exactly them while working
+# everywhere else. Losing the count of a pull request on a finished task is the
+# accepted cost of that control applying everywhere it appears to.
+DONE_HOME="$TMP_ROOT/finished-pull-requests"
+FINISHED_TOKEN=SHIPPEDLASTWEEK
+mkdir -p "$DONE_HOME/data" "$DONE_HOME/state" "$DONE_HOME/config"
+cat > "$DONE_HOME/data/backlog.md" <<EOF
+# Backlog
+
+## In flight
+- [ ] still-open - Fix the retry (repo: a) (kind: ship)
+- [x] ticked-two - Renew the $FINISHED_TOKEN contract (repo: b) (kind: ship)
+
+## Done
+- [x] older-three - Migrate the $FINISHED_TOKEN estate (repo: c) (kind: ship)
+EOF
+fm_write_meta "$DONE_HOME/state/still-open.meta" \
+  kind=ship pr=https://github.com/example/a/pull/1
+fm_write_meta "$DONE_HOME/state/ticked-two.meta" \
+  kind=ship pr=https://github.com/example/b/pull/2
+fm_write_meta "$DONE_HOME/state/older-three.meta" \
+  kind=ship pr=https://github.com/example/c/pull/3
+
+done_status() {
+  python3 "$ROOT/bin/fm_voice_records.py" status --home "$DONE_HOME" --scope full
+}
+
+open_only=$(done_status) || fail "the finished-pull-request fixture failed"
+assert_contains "$open_only" '"open_pull_requests": 1' \
+  "only open work has an open pull request"
+assert_contains "$open_only" 'pull/1' "the open task's pull request should be named"
+assert_not_contains "$open_only" 'ticked-two' \
+  "a ticked item must not be named through its pull request"
+assert_not_contains "$open_only" 'pull/2' \
+  "a ticked item's pull request must not be named"
+assert_not_contains "$open_only" 'older-three' \
+  "an item under Done must not be named through its pull request"
+assert_not_contains "$open_only" 'pull/3' \
+  "an item under Done must not have its pull request named"
+assert_not_contains "$open_only" "$FINISHED_TOKEN" \
+  "no finished title may reach the answer at any scope"
+
+# The deny list is the only control the guide offers for a customer name, and it
+# could not touch these items at all, because their titles were never in the field
+# set it matches against.
+printf '%s\n' "$FINISHED_TOKEN" > "$DONE_HOME/config/voice-read-deny"
+denied_done=$(done_status) || fail "deny by a finished title failed"
+assert_not_contains "$denied_done" 'pull/2' \
+  "a deny substring matching a finished title must not leave its link named"
+assert_not_contains "$denied_done" 'pull/3' \
+  "a deny substring matching a finished title must not leave its link named"
+assert_contains "$denied_done" 'pull/1' "the open task is unaffected"
+pass "a finished task's pull request is neither counted nor named"
 
 # --- refusals ---------------------------------------------------------------
 #

--- a/tests/fm-voice-relay.test.sh
+++ b/tests/fm-voice-relay.test.sh
@@ -635,6 +635,7 @@ def fake_profile(profile, verbose=False):
     return {"aws_access_key_id": "FROM-PROFILE",
             "aws_secret_access_key": "s", "aws_session_token": None}, None
 
+real_profile = relay.profile_credentials
 relay.profile_credentials = fake_profile
 os.environ["AWS_ACCESS_KEY_ID"] = "AKIAENVIRONMENT"
 os.environ["AWS_SECRET_ACCESS_KEY"] = "s3cret"
@@ -654,8 +655,49 @@ check([c["aws_access_key_id"] for c in later] == ["FROM-PROFILE"] * 3,
 check(len(exports) == 1,
       "and the profile answer is then cached like any other: %d exports" % len(exports))
 
+# WITH NO PROFILE THERE IS NOTHING TO ESCALATE TO, and a relay configured that
+# way is a documented shape. Giving up on the environment there would end every
+# turn from the margin onwards, with a message saying there are no credentials in
+# the environment while the process is still holding them. The bound becomes a
+# re-read instead: the keys may be stale, which is between AWS and whoever
+# exported them, but the conversation survives.
+del exports[:]
+cache = Bounded("")
+kept = [asyncio.run(cache.get())]
+for _ in range(3):
+    time.sleep(0.1)
+    kept.append(asyncio.run(cache.get()))
+check([c["aws_session_token"] for c in kept] == ["stale-token"] * 4,
+      "a profile-free relay must keep answering from the environment: %r" % kept)
+check(exports == [], "and must not try to export from a profile it does not have")
+
+# Even a credential whose stated deadline has already passed, for the same
+# reason: there is no fresher source, so refusing is a dead relay rather than a
+# safer one.
+os.environ["AWS_CREDENTIAL_EXPIRATION"] = iso(time.time() - 60)
+cache = Bounded("")
+past = asyncio.run(cache.get())
+check(past["aws_session_token"] == "stale-token",
+      "an expired ambient credential is still the only answer available: %r" % past)
+# With a profile, that same credential is abandoned for it, as before.
+cache = Bounded("a-profile")
+check(asyncio.run(cache.get())["aws_access_key_id"] == "FROM-PROFILE",
+      "an expired ambient credential should be abandoned when a profile exists")
+os.environ.pop("AWS_CREDENTIAL_EXPIRATION", None)
+
+# An environment with nothing in it and no profile is still a named refusal, so
+# this restores the real resolver rather than asking the stub to pretend.
 for name in AWS_VARS:
     os.environ.pop(name, None)
+relay.profile_credentials = real_profile
+refused = None
+try:
+    asyncio.run(Bounded("").get())
+except relay.CredentialError as exc:
+    refused = str(exc)
+check(refused is not None, "no credentials anywhere should refuse")
+check("voice-profile" in refused,
+      "and the refusal should name the file to write: %s" % refused)
 PY
 pass "credentials are resolved once per relay, refreshed before expiry, off the event loop"
 
@@ -1284,7 +1326,10 @@ pass "one deny decision per item covers every list that item could appear in"
 # therefore closed to the states bin/fm-brief.sh gives every crewmate plus the two
 # bin/fm-classify-lib.sh adds when a decision closes, and anything else is a note.
 VERB_HOME="$TMP_ROOT/status-verbs"
-CUSTOMER_TOKEN=ACMECORPMIGRATION
+# Lowercase on purpose. The reader lowercases a verb before it could ever be
+# emitted, and assert_not_contains compares case-sensitively, so an uppercase
+# marker here would make the assertion below unable to fail on leaking code.
+CUSTOMER_TOKEN=acmecorpmigration
 mkdir -p "$VERB_HOME/data" "$VERB_HOME/state"
 cat > "$VERB_HOME/data/backlog.md" <<'EOF'
 # Backlog

--- a/tests/fm-voice-relay.test.sh
+++ b/tests/fm-voice-relay.test.sh
@@ -1189,9 +1189,10 @@ async def one_case(how):
 for how in ("handler", "tool-result", "drop"):
     asyncio.run(one_case(how))
 
-# A stream that simply ends is the end of a session, not a failed turn, and the
-# relay reads the two differently: serve treats a clean end as its own reason to
-# stop, so calling one a failure would change what a model-initiated end means.
+# A stream that simply ends is the end of a session, not a failed turn. It is
+# still said out loud, once, and it says what it is: the client is waiting on a
+# turn that is not coming, and only a notice releases it, but calling it a failure
+# would tell the captain something broke when the model merely finished.
 async def clean_end():
     down = Down()
     session = relay.Session(options, down, None)
@@ -1204,7 +1205,9 @@ down, ended = asyncio.run(clean_end())
 check(ended.turn_done.is_set(), "a clean end must release a waiting turn too")
 check(not ended.failed, "a clean end of stream is not a turn failure")
 check(not failures(down),
-      "and nothing should be named to the captain: %r" % (down.notices,))
+      "and no failure should be named to the captain: %r" % (down.notices,))
+check([n.get("event") for n in down.notices] == ["session-ended"],
+      "a clean end must be announced once, as the end it is: %r" % (down.notices,))
 
 # Nor is a stream that went away because close() asked it to. renew closes the
 # old session on every single turn, so announcing that would put a failure notice
@@ -1247,8 +1250,8 @@ async def torn_down():
 down, closed = asyncio.run(torn_down())
 check(closed.ended.is_set(), "the reader must still report the session over")
 check(not closed.failed, "a deliberate close is not a turn failure")
-check(not failures(down),
-      "and an ordinary renew must not look like a failure: %r" % (down.notices,))
+check(not down.notices,
+      "and an ordinary renew must say nothing at all: %r" % (down.notices,))
 PY
 pass "a failure inside the model reader costs one turn, not every later one"
 pass "a reader failure is named to the captain, a clean end and a close are not"
@@ -2120,5 +2123,750 @@ bare_out=$(python3 "$ROOT/bin/fm_voice_records.py" status --home "$bare") \
 assert_contains "$bare_out" '"in_flight": 0' "an empty home should report no work"
 assert_contains "$bare_out" '"workers_on_deck": 0' "an empty home should report no workers"
 pass "a home with no records answers nothing rather than failing"
+
+# --- the whole round trip ----------------------------------------------------
+#
+# Every case above holds one piece of the spoken interface still. This one runs
+# the piece the captain experiences: the laptop client opens the transport, the
+# relay answers a spoken question from the records and hands a spoken request for
+# real work to firstmate, and the reply audio and the timing come back down the
+# same stream. It is the only case that would notice the round trip stopping
+# working while all of the pieces still passed.
+#
+# ONE thing is stood in for: the model. It is a paid service in another region
+# and no test has a credential for it. The stand-in below speaks the same event
+# protocol Nova Sonic does and composes what it says out of the tool results the
+# relay actually hands it, so the words asserted here are the records rather than
+# a script, and it records what the session was opened with so this case can
+# check the account and the model the relay chose. Everything else is real: the
+# client, the frame format, the relay, the reader and bin/fm-inbox.sh.
+#
+# What only this case can hold:
+#   the round trip completes at all, in both of its shapes, a status answer and a
+#   handover, and a second turn is not treated as an interruption of the first;
+#   the headline figure is measured from the captain's talk end rather than from
+#   the start of their speech, which on this clip is the difference between half
+#   a second and two and a half;
+#   the talk-end silence padding really is sent, which is trap 2 and the
+#   difference between an answer and no answer;
+#   the laptop needs no AWS credential: the client runs with an environment that
+#   has none, and the session is opened with the key only the desktop side holds.
+
+E2E="$TMP_ROOT/e2e"
+E2E_KEY=AKIADESKTOPONLYEXAMPLE
+E2E_REGION=eu-north-1
+E2E_MODEL=amazon.nova-2-sonic-v1:0
+E2E_REQUEST="take the flaky sign-in test on alpha and open a pull request for it"
+mkdir -p "$E2E/bin" "$E2E/laptop" "$E2E/desktop-home" "$E2E/laptop-home" \
+  "$E2E/fakesdk/aws_sdk_bedrock_runtime" \
+  "$E2E/home/data" "$E2E/home/state" "$E2E/home/config"
+
+# The laptop holds the two files the guide says to copy, and nothing else.
+cp "$ROOT/bin/fm-voice-client.py" "$ROOT/bin/fm_voice_frame.py" "$E2E/laptop/"
+
+cat > "$E2E/home/data/backlog.md" <<EOF
+# Backlog
+
+## In flight
+- [ ] alpha-one - Fix the sign-in redirect (repo: alpha) (kind: ship) (priority: 0)
+  A note body, which is never assembled: $NEVER_TOKEN and the rate we agreed.
+- [ ] beta-two - Decide the storage shape (repo: beta) (kind: captain)
+
+## Queued
+- [ ] delta-four - Add the retry (repo: delta) (kind: ship) (hold-kind: captain)
+
+## Done
+- [x] old-six - Shipped the $NEVER_TOKEN integration (repo: alpha) (done 2026-07-01)
+EOF
+fm_write_meta "$E2E/home/state/alpha-one.meta" kind=ship mode=no-mistakes \
+  pr=https://github.com/example/alpha/pull/7
+printf 'working: reading the failing test\n' > "$E2E/home/state/alpha-one.status"
+printf '%s\n' "$E2E_REGION" > "$E2E/home/config/voice-region"
+printf '%s\n' "$E2E_MODEL" > "$E2E/home/config/voice-model"
+printf 'full\n' > "$E2E/home/config/voice-read-scope"
+
+# The model stand-in, at exactly the import boundary bin/fm-voice-relay.py uses.
+cat > "$E2E/fakesdk/aws_sdk_bedrock_runtime/__init__.py" <<'PY'
+"""A scripted stand-in for Nova Sonic's bidirectional stream.
+
+It answers with what the relay's own tool results contain, so a spoken answer
+here is derived from firstmate's records rather than from a fixture string, and
+it appends one JSON line per session describing what that session was opened
+with and what it was asked. tests/fm-voice-relay.test.sh reads that record.
+
+  FM_FAKE_SCRIPT   comma-separated turn kinds: status | handover | clean-end
+  FM_FAKE_THINK    seconds before the reply begins, standing in for the model
+  FM_FAKE_STATE    file holding the turn counter across the relay's reconnects
+  FM_FAKE_LOG      where to append the per-session record
+  FM_FAKE_REQUEST  the words the captain uses when asking for real work
+
+A clean-end turn is a session the model finishes with while the captain is still
+speaking: the output stream simply ends, with no error and no answer. That is an
+ordinary end of a Bedrock session rather than a fault, and the relay has to
+survive it, so it is a turn kind here rather than a failure injection.
+"""
+
+import asyncio
+import base64
+import json
+import math
+import os
+import struct
+import sys
+import types
+
+OUT_RATE = 24000
+CHUNK_MS = 100
+
+THINK = float(os.environ.get("FM_FAKE_THINK", "0.4"))
+REPLY_SECONDS = float(os.environ.get("FM_FAKE_REPLY_SECONDS", "0.4"))
+SCRIPT = [s.strip() for s in os.environ.get("FM_FAKE_SCRIPT", "status").split(",")
+          if s.strip()]
+STATE = os.environ.get("FM_FAKE_STATE", "")
+LOG = os.environ.get("FM_FAKE_LOG", "")
+REQUEST = os.environ.get("FM_FAKE_REQUEST", "open a pull request for the retry")
+
+HEARD = {"status": "how is the fleet doing right now", "handover": REQUEST}
+
+# How much of the captain's speech a clean-end session takes before its output
+# stream ends. Three chunks is 300 ms, so on a two second clip the end lands well
+# inside the key press and the rest of that press arrives at a session that is
+# already over.
+CLEAN_END_AFTER_BYTES = 3200 * 3
+
+
+def _turn_kind():
+    """Return this session's turn kind, advancing a counter that lives on disk.
+
+    The relay reconnects per turn on purpose, so the count cannot live in this
+    process: each turn is a new stream in a new session.
+    """
+    index = 0
+    if STATE:
+        try:
+            with open(STATE, encoding="utf-8") as handle:
+                index = int(handle.read().strip() or "0")
+        except (OSError, ValueError):
+            index = 0
+        try:
+            with open(STATE, "w", encoding="utf-8") as handle:
+                handle.write(str(index + 1))
+        except OSError:
+            pass
+    if not SCRIPT:
+        return "status", index
+    return SCRIPT[index % len(SCRIPT)], index
+
+
+def _speech(seconds):
+    """Return reply audio: a quiet tone, so a byte count is a duration."""
+    out = bytearray()
+    for n in range(int(OUT_RATE * seconds)):
+        out += struct.pack("<h", int(6000 * math.sin(2 * math.pi * 220 * n / OUT_RATE)))
+    return bytes(out)
+
+
+def _status_sentence(result):
+    """Compose the spoken answer out of what the records reader returned."""
+    if result.get("error"):
+        return "I could not read the records: {}".format(result["error"])
+    said = "Right now, {} in flight, {} waiting on you, {} open pull requests.".format(
+        result.get("in_flight"), result.get("awaiting_captain"),
+        result.get("open_pull_requests"))
+    names = [row.get("id") for row in result.get("in_flight_detail", [])][:2]
+    if names:
+        said += " The ones moving are {}.".format(" and ".join(names))
+    notes = result.get("captain_notes_waiting") or 0
+    if notes:
+        said += " {} note is queued for the first mate.".format(notes)
+    if result.get("scope") == "counts":
+        said += " Identifiers are not available by voice at this read scope."
+    return said
+
+
+def _queued_sentence(result):
+    if result.get("error"):
+        return "I could not queue that: {}".format(result["error"])
+    return ("That is queued with the first mate as {}. I have not done any of it "
+            "myself.".format(result.get("note_id") or "a note"))
+
+
+class _Result:
+    def __init__(self, payload):
+        self.value = types.SimpleNamespace(bytes_=payload)
+
+
+class _OutputReader:
+    def __init__(self, queue):
+        self._queue = queue
+
+    async def receive(self):
+        item = await self._queue.get()
+        return None if item is None else _Result(item)
+
+
+class _InputStream:
+    def __init__(self, stream):
+        self._stream = stream
+
+    async def send(self, chunk):
+        await self._stream.on_input(chunk.value.bytes_)
+
+    async def close(self):
+        await self._stream.finish()
+
+
+class _Stream:
+    """One bidirectional session, which is one turn the way the relay uses it."""
+
+    def __init__(self, model_id, config):
+        self.kind, self.index = _turn_kind()
+        self.out = asyncio.Queue()
+        self.input_stream = _InputStream(self)
+        self._reader = _OutputReader(self.out)
+        self._audio_content = None
+        self._pending_use = None
+        self._tools = {}
+        self._next_tool = 0
+        self._replied = False
+        self._reply_task = None
+        self._logged = False
+        self._ended_early = False
+        self.record = {
+            "turn": self.index + 1,
+            "turn_kind": self.kind,
+            "model_id": model_id,
+            "endpoint": config.endpoint_uri,
+            "region": config.region,
+            "credential_key_id": config.credentials.get("aws_access_key_id"),
+            "tool_names_offered": [],
+            "audio_bytes_in": 0,
+            "tool_calls": [],
+            "heard": "",
+            "said": [],
+            "reply_audio_bytes": 0,
+        }
+
+    async def await_output(self):
+        return (None, self._reader)
+
+    def _emit(self, event):
+        self.out.put_nowait(json.dumps({"event": event}).encode())
+
+    async def on_input(self, raw):
+        event = json.loads(raw.decode()).get("event", {})
+        for name, body in event.items():
+            if name == "promptStart":
+                self.record["tool_names_offered"] = [
+                    t.get("toolSpec", {}).get("name")
+                    for t in body.get("toolConfiguration", {}).get("tools", [])]
+            elif name == "contentStart" and body.get("type") == "AUDIO":
+                self._audio_content = body.get("contentName")
+            elif name == "contentStart" and body.get("type") == "TOOL":
+                self._pending_use = body.get(
+                    "toolResultInputConfiguration", {}).get("toolUseId")
+            elif name == "audioInput":
+                self.record["audio_bytes_in"] += len(
+                    base64.b64decode(body.get("content", "")))
+                self._maybe_end_cleanly()
+            elif name == "toolResult":
+                self._tool_result(body)
+            elif name == "contentEnd":
+                if (body.get("contentName") == self._audio_content
+                        and not self._replied and not self._ended_early):
+                    # The captain's talk end. Everything measured is measured
+                    # from here, so the reply starts no earlier than this.
+                    self._replied = True
+                    self._audio_content = None
+                    self._reply_task = asyncio.create_task(self._reply())
+
+    def _maybe_end_cleanly(self):
+        """End a clean-end session's output stream, mid-key-press and unannounced.
+
+        None on the output queue is what the SDK gives the reader for a stream
+        that is simply over: no exception, no stop reason, nothing to report. The
+        input half stays open, exactly as it does when the model is the side that
+        finished, so the rest of the captain's key press still arrives here and
+        goes nowhere.
+        """
+        if (self.kind != "clean-end" or self._ended_early
+                or self.record["audio_bytes_in"] < CLEAN_END_AFTER_BYTES):
+            return
+        self._ended_early = True
+        self.record["ended_early"] = True
+        self._write_log()
+        self.out.put_nowait(None)
+
+    def _tool_result(self, body):
+        try:
+            result = json.loads(body.get("content") or "{}")
+        except ValueError:
+            result = {}
+        if self.record["tool_calls"]:
+            self.record["tool_calls"][-1]["result"] = result
+        future = self._tools.pop(self._pending_use, None)
+        if future is not None and not future.done():
+            future.set_result(result)
+
+    async def _call_tool(self, name, arguments):
+        self._next_tool += 1
+        use_id = "use-{}-{}".format(self.index + 1, self._next_tool)
+        future = asyncio.get_running_loop().create_future()
+        self._tools[use_id] = future
+        self.record["tool_calls"].append({"name": name, "arguments": arguments})
+        self._emit({"toolUse": {"toolName": name, "toolUseId": use_id,
+                                "content": json.dumps(arguments)}})
+        try:
+            return await asyncio.wait_for(future, timeout=15)
+        except asyncio.TimeoutError:
+            return {"error": "the relay never answered the tool call"}
+
+    def _say(self, text):
+        self.record["said"].append(text)
+        self._emit({"textOutput": {"role": "ASSISTANT", "content": text}})
+
+    async def _reply(self):
+        await asyncio.sleep(THINK)
+        heard = HEARD.get(self.kind, "how is the fleet doing")
+        self.record["heard"] = heard
+        self._emit({"textOutput": {"role": "USER", "content": heard}})
+        if self.kind == "handover":
+            self._say("I am not the first mate, so I am handing that to it.")
+            result = await self._call_tool("hand_over_to_firstmate",
+                                           {"request": REQUEST})
+            self._say(_queued_sentence(result))
+        else:
+            result = await self._call_tool("get_fleet_status", {})
+            self._say(_status_sentence(result))
+        pcm = _speech(REPLY_SECONDS)
+        step = OUT_RATE * 2 * CHUNK_MS // 1000
+        for at in range(0, len(pcm), step):
+            block = pcm[at:at + step]
+            self._emit({"audioOutput": {
+                "content": base64.b64encode(block).decode()}})
+            self.record["reply_audio_bytes"] += len(block)
+            await asyncio.sleep(0.01)
+        # Trap 1: this, not completionEnd, is what says the reply ended.
+        self._emit({"contentEnd": {"stopReason": "END_TURN"}})
+        self._write_log()
+
+    def _write_log(self):
+        if self._logged or not LOG:
+            return
+        self._logged = True
+        with open(LOG, "a", encoding="utf-8") as handle:
+            handle.write(json.dumps(self.record) + "\n")
+
+    async def finish(self):
+        self._write_log()
+        self.out.put_nowait(None)
+
+
+class AsyncBedrockRuntimeConfig:
+    def __init__(self, endpoint_uri, region, credentials):
+        self.endpoint_uri = endpoint_uri
+        self.region = region
+        self.credentials = credentials
+
+    @classmethod
+    async def resolve(cls, endpoint_uri=None, region=None, **credentials):
+        return cls(endpoint_uri, region, credentials)
+
+
+class AsyncBedrockRuntimeClient:
+    def __init__(self, config=None):
+        self.config = config
+
+    async def invoke_model_with_bidirectional_stream(self, operation):
+        return _Stream(operation.model_id, self.config)
+
+
+class InvokeModelWithBidirectionalStreamOperationInput:
+    def __init__(self, model_id=None):
+        self.model_id = model_id
+
+
+class BidirectionalInputPayloadPart:
+    def __init__(self, bytes_=b""):
+        self.bytes_ = bytes_
+
+
+class InvokeModelWithBidirectionalStreamInputChunk:
+    def __init__(self, value=None):
+        self.value = value
+
+
+def _submodule(name, **members):
+    module = types.ModuleType(__name__ + "." + name)
+    for key, value in members.items():
+        setattr(module, key, value)
+    sys.modules[module.__name__] = module
+    return module
+
+
+client = _submodule(
+    "client",
+    AsyncBedrockRuntimeClient=AsyncBedrockRuntimeClient,
+    InvokeModelWithBidirectionalStreamOperationInput=(
+        InvokeModelWithBidirectionalStreamOperationInput))
+config = _submodule("config", AsyncBedrockRuntimeConfig=AsyncBedrockRuntimeConfig)
+models = _submodule(
+    "models",
+    BidirectionalInputPayloadPart=BidirectionalInputPayloadPart,
+    InvokeModelWithBidirectionalStreamInputChunk=(
+        InvokeModelWithBidirectionalStreamInputChunk))
+PY
+
+# What the desktop side of the connection has, and the laptop side does not. The
+# AWS credential is here and nowhere else, which is the whole point of the shape.
+cat > "$E2E/bin/desktop.env" <<EOF
+PATH=$PATH
+HOME=$E2E/desktop-home
+PYTHONPATH=$E2E/fakesdk
+PYTHONDONTWRITEBYTECODE=1
+FM_HOME=$E2E/home
+FM_FAKE_STATE=$E2E/turn-counter
+FM_FAKE_LOG=$E2E/model-sessions.jsonl
+FM_FAKE_THINK=0.4
+FM_FAKE_REPLY_SECONDS=0.4
+FM_FAKE_SCRIPT=status,handover
+FM_FAKE_REQUEST=$E2E_REQUEST
+AWS_ACCESS_KEY_ID=$E2E_KEY
+AWS_SECRET_ACCESS_KEY=desktop-secret-not-a-real-key
+EOF
+
+# Stands in for ssh, so the client takes its real `ssh -T <host> <relay>` path
+# and the desktop's environment is a boundary rather than an assertion: the relay
+# starts from env -i and desktop.env, so nothing the laptop holds can reach it.
+cat > "$E2E/bin/ssh" <<'SH'
+#!/usr/bin/env bash
+set -eu
+DIR="$(cd "$(dirname "$0")" && pwd)"
+if [ "${1:-}" = "-T" ]; then shift; fi
+shift                                   # the host, which is this machine
+desktop_env=()
+while IFS= read -r line; do desktop_env+=("$line"); done < "$DIR/desktop.env"
+exec env -i "${desktop_env[@]}" "$@"
+SH
+chmod +x "$E2E/bin/ssh"
+
+# Two seconds of speech-shaped audio ending on speech, not silence: the relay's
+# own 400 ms of padding is what makes a push-to-talk release answerable, and a
+# clip this long makes a clock started at the wrong end unmistakable.
+python3 - "$E2E/clip.pcm" <<'PY' || fail "could not write the e2e clip"
+import math, struct, sys
+out = bytearray()
+for n in range(16000 * 2):
+    swell = 0.5 + 0.5 * math.sin(2 * math.pi * 2.5 * n / 16000)
+    out += struct.pack("<h", int(9000 * swell * math.sin(2 * math.pi * 190 * n / 16000)))
+open(sys.argv[1], "wb").write(bytes(out))
+PY
+
+printf '0\n' > "$E2E/turn-counter"
+: > "$E2E/model-sessions.jsonl"
+
+# env -i: the laptop has PATH and HOME and nothing else. No AWS variable, no
+# interpreter that can reach Bedrock, no firstmate home.
+laptop_aws=$(env -i PATH="$E2E/bin:$PATH" HOME="$E2E/laptop-home" env \
+  | grep -c '^AWS_' || true)
+[ "$laptop_aws" = 0 ] || fail "the laptop end should hold no AWS variables"
+
+set +e
+env -i PATH="$E2E/bin:$PATH" HOME="$E2E/laptop-home" PYTHONDONTWRITEBYTECODE=1 \
+  python3 "$E2E/laptop/fm-voice-client.py" \
+    --host desktop.example \
+    --relay "$ROOT/bin/fm-voice-relay.py" \
+    --relay-python python3 \
+    --in-file "$E2E/clip.pcm" --out-file "$E2E/reply.pcm" \
+    --runs 2 > "$E2E/runs.jsonl" 2> "$E2E/session.log"
+e2e_code=$?
+set -e
+[ "$e2e_code" = 0 ] || {
+  cat "$E2E/session.log" >&2
+  fail "the spoken round trip exited $e2e_code"
+}
+
+# The reader's own answer, taken independently, so the spoken answer is checked
+# against the records rather than against itself.
+independent=$(python3 "$ROOT/bin/fm_voice_records.py" status \
+  --home "$E2E/home" --scope full) || fail "independent status read failed"
+printf '%s' "$independent" > "$E2E/independent.json"
+
+python3 - "$E2E" "$E2E_KEY" "$E2E_REGION" "$E2E_MODEL" "$E2E_REQUEST" \
+  "$NEVER_TOKEN" <<'PY' || fail "the spoken round trip did not hold"
+import json, os, sys
+
+root, key, region, model, request, never = sys.argv[1:7]
+
+
+def check(cond, label):
+    if not cond:
+        sys.exit("round trip: " + label)
+
+
+def read(name):
+    with open(os.path.join(root, name), encoding="utf-8") as handle:
+        return [json.loads(line) for line in handle if line.strip()]
+
+
+runs = read("runs.jsonl")
+sessions = read("model-sessions.jsonl")
+records = json.load(open(os.path.join(root, "independent.json"), encoding="utf-8"))
+transcript = open(os.path.join(root, "session.log"), encoding="utf-8").read()
+
+# Two turns asked, two turns answered with audio, neither of them lost.
+check(len(runs) == 2, "expected two turn records, got %d" % len(runs))
+check(len(sessions) == 2, "expected two model sessions, got %d" % len(sessions))
+for run in runs:
+    check(run["answered"], "turn %s was not answered" % run["run"])
+    check(run["relay_error"] is None,
+          "turn %s failed: %s" % (run["run"], run["relay_error"]))
+    check(run["reply_audio_seconds"] > 0,
+          "turn %s produced no reply audio" % run["run"])
+    # Push to talk is the default and the only mode that runs, and the transport
+    # is the ssh path rather than a local child.
+    check(run["listen"] == "push-to-talk", "listen mode was %r" % run["listen"])
+    check(run["transport"] == "ssh", "transport was %r" % run["transport"])
+    # The per-turn reconnect exists so a second question is not barge-in.
+    check(not run["interrupted"],
+          "turn %s was treated as an interruption" % run["run"])
+
+# Whose account and which model. The relay carries no default for either, so
+# this is the home's configuration reaching Bedrock, and the credential is the
+# one only the desktop side of the connection holds.
+for session in sessions:
+    check(session["model_id"] == model, "model was %r" % session["model_id"])
+    check(session["region"] == region, "region was %r" % session["region"])
+    check(session["endpoint"] ==
+          "https://bedrock-runtime.{}.amazonaws.com".format(region),
+          "endpoint was %r" % session["endpoint"])
+    check(session["credential_key_id"] == key,
+          "session opened with %r" % session["credential_key_id"])
+    check(session["tool_names_offered"] ==
+          ["get_fleet_status", "hand_over_to_firstmate"],
+          "tools offered were %r" % session["tool_names_offered"])
+    # Trap 2: a push-to-talk release supplies no trailing silence, so the relay
+    # appends its own. Without it the model truncates the turn and never answers.
+    check(session["audio_bytes_in"] == 16000 * 2 * 2 + 400 * 32,
+          "the uplink carried %d bytes, so the talk-end padding is not being "
+          "sent" % session["audio_bytes_in"])
+
+# The status answer is the records. Every number the agent said aloud came from
+# the reader, checked against a separate read of the same home.
+status = sessions[0]
+check([c["name"] for c in status["tool_calls"]] == ["get_fleet_status"],
+      "the status turn called %r" % [c["name"] for c in status["tool_calls"]])
+served = status["tool_calls"][0]["result"]
+for field in ("in_flight", "awaiting_captain", "open_pull_requests", "queued"):
+    check(served[field] == records[field],
+          "the reader served %s=%r but the records say %r"
+          % (field, served[field], records[field]))
+said = " ".join(status["said"])
+check("{} in flight".format(records["in_flight"]) in said,
+      "the spoken answer did not carry the count: %r" % said)
+check(records["in_flight_detail"][0]["id"] in said,
+      "the spoken answer named no open work: %r" % said)
+check(never not in said and never not in json.dumps(served),
+      "a note body or finished title reached a spoken answer")
+check(said in transcript, "the captain never saw the answer: %r" % transcript)
+
+# The handover turn queues real work and says so. The note is firstmate's own
+# queue, written by bin/fm-inbox.sh, and the agent's confirmation carries the id
+# that queue gave it, so it cannot be claiming to have queued something it did
+# not.
+handover = sessions[1]
+check([c["name"] for c in handover["tool_calls"]] == ["hand_over_to_firstmate"],
+      "the handover turn called %r" % [c["name"] for c in handover["tool_calls"]])
+check(handover["tool_calls"][0]["arguments"]["request"] == request,
+      "the captain's words were rewritten: %r"
+      % handover["tool_calls"][0]["arguments"])
+queued = handover["tool_calls"][0]["result"]
+check(queued.get("queued") is True, "the request was not queued: %r" % queued)
+note_id = queued.get("note_id")
+check(bool(note_id), "the queue returned no note id: %r" % queued)
+check(runs[1]["queued_note"] == note_id,
+      "the client was told %r, the queue wrote %r"
+      % (runs[1]["queued_note"], note_id))
+check(note_id in " ".join(handover["said"]),
+      "the agent did not confirm the queued note: %r" % handover["said"])
+check("handed to the first mate" in transcript,
+      "the captain was never told it was handed over: %r" % transcript)
+note = os.path.join(root, "home", "state", "inbox", note_id + ".note")
+check(os.path.exists(note), "no note on disk at %s" % note)
+check(request in open(note, encoding="utf-8").read(),
+      "the note does not carry the captain's words")
+
+# THE NUMBER THIS BUILD EXISTS TO PRODUCE, and the instant it is measured from.
+# The clip is two seconds long and the stand-in waits 0.4 s before speaking, so a
+# figure measured from the captain's talk end lands near half a second and one
+# measured from the start of their speech lands near two and a half. The bound is
+# loose enough for a loaded machine and nowhere near the wrong clock.
+for run in runs:
+    first = run["first_audio_s"]
+    check(first is not None, "turn %s reported no first audio" % run["run"])
+    check(0.2 < first < 1.6,
+          "turn %s reported first audio at %.3fs, which is not measured from the "
+          "captain's talk end" % (run["run"], first))
+    marks = run["relay_marks_since_talk_end"]
+    for mark in ("tool_use", "tool_answered", "first_audio", "reply_end"):
+        check(mark in marks, "turn %s is missing the %s mark" % (run["run"], mark))
+    check(marks["tool_use"] <= marks["first_audio"] <= marks["reply_end"],
+          "turn %s reports its marks out of order: %r" % (run["run"], marks))
+    check(run["first_frame_s"] is not None and run["first_played_s"] is not None,
+          "turn %s reported no wire or playback figure" % run["run"])
+
+# The reply audio survived the framing byte for byte.
+sent = sum(s["reply_audio_bytes"] for s in sessions)
+got = os.path.getsize(os.path.join(root, "reply.pcm"))
+check(sent > 0 and sent == got,
+      "the model sent %d bytes of reply audio and the client wrote %d" % (sent, got))
+PY
+pass "a spoken turn goes out and comes back: the records answer, firstmate gets the work"
+
+# --- a model session that ends while the captain is still talking ------------
+#
+# A Bedrock session ending is not a fault. The stream simply stops: no exception,
+# no stop reason, nothing to report. It can happen mid-conversation, and when it
+# does the captain is usually still holding the talk key, because that is when
+# the relay is talking to the model at all.
+#
+# The relay used to treat that as its own reason to stop, which is the worst
+# available failure shape: the relay dies without saying anything the captain can
+# act on, and they find out by speaking a whole question into nothing and getting
+# no answer. Per-turn reconnect already covers this - the next talk key builds a
+# new session, at a measured cost of 0.02 s - and a reconnect that cannot be made
+# is spoken to the captain through the turn-failed path. So the session ending
+# costs them the remainder of one key press, and nothing else.
+#
+# This case is the round trip above with one difference: the model finishes with
+# the first session 300 ms into a two second key press. What it holds is that the
+# relay is still serving afterwards and that the NEXT talk key gets a working
+# session rather than a closed pipe - a real answer, out of the real records, over
+# the same connection. The relay may exit for three reasons and this is not one of
+# them.
+
+SURVIVE="$E2E/survive"
+mkdir -p "$SURVIVE/bin"
+
+# The same desktop, with its own turn script and its own record of what the model
+# was asked, so neither run can read the other's sessions.
+grep -v '^FM_FAKE_' "$E2E/bin/desktop.env" > "$SURVIVE/bin/desktop.env"
+cat >> "$SURVIVE/bin/desktop.env" <<EOF
+FM_FAKE_STATE=$SURVIVE/turn-counter
+FM_FAKE_LOG=$SURVIVE/model-sessions.jsonl
+FM_FAKE_THINK=0.4
+FM_FAKE_REPLY_SECONDS=0.4
+FM_FAKE_SCRIPT=clean-end,status
+EOF
+cp "$E2E/bin/ssh" "$SURVIVE/bin/ssh"
+printf '0\n' > "$SURVIVE/turn-counter"
+: > "$SURVIVE/model-sessions.jsonl"
+
+# Exit 1 is the honest outcome and what is asserted: one of the two turns really
+# was lost, because the model stopped listening part way through it.
+set +e
+env -i PATH="$SURVIVE/bin:$PATH" HOME="$E2E/laptop-home" PYTHONDONTWRITEBYTECODE=1 \
+  python3 "$E2E/laptop/fm-voice-client.py" \
+    --host desktop.example \
+    --relay "$ROOT/bin/fm-voice-relay.py" \
+    --relay-python python3 \
+    --in-file "$E2E/clip.pcm" --out-file "$SURVIVE/reply.pcm" \
+    --timeout 12 --runs 2 > "$SURVIVE/runs.jsonl" 2> "$SURVIVE/session.log"
+survive_code=$?
+set -e
+[ "$survive_code" = 1 ] || {
+  cat "$SURVIVE/session.log" >&2
+  fail "a lost turn and a good one should exit 1, not $survive_code"
+}
+
+python3 - "$SURVIVE" "$E2E/independent.json" <<'PY' \
+  || fail "a model session ending did not leave the relay serving"
+import json, os, sys
+
+root, records_path = sys.argv[1:3]
+
+CLIP_BYTES = 16000 * 2 * 2
+
+
+def check(cond, label):
+    if not cond:
+        sys.exit("session ended: " + label)
+
+
+def read(name):
+    with open(os.path.join(root, name), encoding="utf-8") as handle:
+        return [json.loads(line) for line in handle if line.strip()]
+
+
+runs = read("runs.jsonl")
+sessions = read("model-sessions.jsonl")
+records = json.load(open(records_path, encoding="utf-8"))
+transcript = open(os.path.join(root, "session.log"), encoding="utf-8").read()
+
+# The first session really did end part way through the captain's key press,
+# rather than after answering: it took some of the clip and not all of it.
+check(len(sessions) >= 1, "the model was never asked anything")
+first = sessions[0]
+check(first["turn_kind"] == "clean-end" and first.get("ended_early"),
+      "the first session did not end early: %r" % first)
+check(0 < first["audio_bytes_in"] < CLIP_BYTES,
+      "the session ended after %d of %d bytes, so it did not end mid-press"
+      % (first["audio_bytes_in"], CLIP_BYTES))
+check(not first["said"] and not first["reply_audio_bytes"],
+      "the lost turn was answered after all: %r" % first)
+
+# THE POINT. The relay was still there for the next talk key, so two turns were
+# taken over the one connection and the second one was a whole session of its own.
+check(len(runs) == 2,
+      "the relay stopped serving when the model ended its session: %d turn(s) "
+      "taken, %r" % (len(runs), transcript))
+check(len(sessions) == 2,
+      "the next talk key did not get a session: %d opened" % len(sessions))
+check(not runs[0]["answered"], "the lost turn should be the first one: %r" % runs[0])
+check(runs[0]["relay_error"] is None,
+      "an ordinary session end is not a turn failure: %r" % runs[0]["relay_error"])
+
+# And it was a working session rather than a closed pipe: a real answer, composed
+# from a real read of the records, spoken to the captain over the same connection.
+good = runs[1]
+check(good["answered"] and good["reply_audio_seconds"] > 0,
+      "the next talk key got no answer: %r" % good)
+check(good["relay_error"] is None,
+      "the replacement session failed: %r" % good["relay_error"])
+check([c["name"] for c in sessions[1]["tool_calls"]] == ["get_fleet_status"],
+      "the replacement turn called %r"
+      % [c["name"] for c in sessions[1]["tool_calls"]])
+# The whole question, not an answer to nothing: every byte of the clip and the
+# talk-end padding reached the replacement session.
+check(sessions[1]["audio_bytes_in"] == CLIP_BYTES + 400 * 32,
+      "the replacement session heard %d bytes of a %d byte question"
+      % (sessions[1]["audio_bytes_in"], CLIP_BYTES + 400 * 32))
+served = sessions[1]["tool_calls"][0]["result"]
+for field in ("in_flight", "open_pull_requests"):
+    check(served[field] == records[field],
+          "the replacement session served %s=%r but the records say %r"
+          % (field, served[field], records[field]))
+said = " ".join(sessions[1]["said"])
+check("{} in flight".format(records["in_flight"]) in said,
+      "the answer did not carry the count: %r" % said)
+check(said in transcript, "the captain never heard the answer: %r" % transcript)
+check(good["first_audio_s"] is not None and 0.2 < good["first_audio_s"] < 1.6,
+      "the recovered turn reported first audio at %r, which is not measured from "
+      "the captain's talk end" % good["first_audio_s"])
+check(os.path.getsize(os.path.join(root, "reply.pcm"))
+      == sessions[1]["reply_audio_bytes"],
+      "the reply audio the client wrote is not what the good session sent")
+
+# Said once. The rest of that key press is another seventeen audio frames, and
+# the flag saying the session is over stays set for every one of them, so a
+# notice sent from the frame loop instead of from the end itself would put this
+# line in front of the captain ten times a second while they were still speaking.
+check(transcript.count("the relay ended the session") == 1,
+      "the session ending was announced %d times: %r"
+      % (transcript.count("the relay ended the session"), transcript))
+check("connection lost" not in transcript,
+      "the connection should have outlived the session: %r" % transcript)
+PY
+pass "a model session that ends mid-conversation costs one turn, not the relay"
 
 printf 'all voice relay cases passed\n'


### PR DESCRIPTION
## Intent

Give the captain a spoken round trip to firstmate that actually works: they talk to a voice agent on their laptop, it answers from firstmate's records and queues real work by handing over rather than pretending to be firstmate, on amazon.nova-2-sonic-v1:0 in eu-north-1 with the model session held on this desktop so no AWS credential sits on the laptop. The second goal is a real measurement to replace an unmeasured 1.5 to 2.5 second estimate for that relay shape: time from the end of the captain's speech to the first audio out, reported as a spread. Push to talk is the deliberate default because the captain has not chosen open mic yet. Barge-in and conversational memory across turns are step three and out of scope here.

## What Changed

- Adds the spoken round trip as four new files: `bin/fm-voice-relay.py` holds the `amazon.nova-2-sonic-v1:0` bidirectional session on the desktop (region, model, profile and voice id read from gitignored `config/voice-*` or `FM_VOICE_*`, with a missing required value refusing rather than defaulting), `bin/fm-voice-client.py` captures and plays on the laptop over an SSH exec channel with no AWS credentials, `bin/fm_voice_frame.py` owns the shared frame format, and `bin/fm_voice_records.py` owns the read scope and the handover. The relay opens one model session per turn, appends 400 ms of trailing silence on talk end, treats a `contentEnd`/`END_TURN` as the end of a reply, and resolves credentials once instead of per session; `--listen push-to-talk` is the only mode that runs and `--listen open-mic` refuses at startup.
- Adds `bin/fm-inbox.sh` (`note`, `say`, `status`, `ask`, `list`, `drain --ack`) and the `state/inbox/` records it writes, and routes the voice agent's real-work handover through `note` so it appends one `check` wake instead of carrying a second queue. Status reads are scope-controlled: `config/voice-read-scope` defaults to `counts`, `full` adds open ids, titles and PR links, `config/voice-read-deny` substrings reduce a matching open item to a count, and done history and free-form note bodies are never assembled at any scope.
- Adds `tests/fm-voice-relay.test.sh`, an offline suite covering the frame format, the read-scope and deny boundary (planted markers in finished work and a note body must never reach an answer), and the handover. Documents the interface in new `docs/voice-relay.md`, including the measured end-of-speech-to-first-audio spread over six runs per path (direct 1.165–1.352 s, median 1.232; over the relay 1.138–1.283 s, median 1.172) that replaces the prior unmeasured 1.5–2.5 s estimate, and registers the new scripts, config files and doc in `README.md`, `AGENTS.md`, `docs/configuration.md`, `docs/scripts.md` and `docs/documentation-audiences.json`.

## Risk Assessment

⚠️ Medium: The two fixes from the last round are correct and well pinned, every intent criterion is satisfiable from source, and nothing left is a merge blocker; but this is 5685 lines of new subsystem whose microphone and speaker paths are unrunnable here by construction, and three narrow diagnostic gaps remain that are better closed as follow-ups than left unstated.

## Testing

I drove the real client, framing, ssh path, relay, records reader and fm-inbox.sh end to end with only Nova Sonic stood in for, and captured what the captain actually sees: a spoken status answer whose numbers match an independent read of the same records, a request for real work handed over with a note and one wake on disk, and the round-2 case where the model finishes with a session mid key press — before the fix the relay is gone and the next question is never asked, after it the captain loses the rest of one key press and the next talk key gets a full working session. Both halves of the commit go red against the pre-fix files and against one-line mutations of the checked-out code, with the other 36 cases still passing. While gathering the measurement evidence I found the documented desktop check, `fm-voice-relay.py --self-test`, had no coverage at all, so I added two offline cases for it — that it answers from the records and times from the talk end, and that a reply arriving before the end of the clip is flagged as an unusable clock instead of recorded as a fast number — and confirmed with three mutations that neither passes vacuously. There is no rendered UI here; the end-user surface is a terminal transcript and audio, so the artifacts are the captain's transcripts, the persisted note and wake queue, the desktop's per-session records, and the reply audio as a playable WAV. Two limits stand, both already known and accepted: the absolute 1.2-1.5 s figures in docs/voice-relay.md need the live endpoint in eu-north-1 (offline the relay's own framing and process hop cost about 3 ms of median, so the docs' 0.22 s is dominated by something only the live run sees), and the microphone and speaker paths still cannot be exercised from a host with no audio device.

<details>
<summary>Evidence: Round-2 evidence index: what each file shows, and the red-before/green-after table</summary>

```text
# Round 2: the relay survives the model finishing with a session

Round 1's evidence (`README.md`, the `harness/` and `home/` directories and the
flat `relay-*` / `handover-*` files) covers the intent as a whole. This round
covers the two changes the target commit makes, and both are the same failure
seen from the two ends of the connection:

* the relay no longer treats a clean model-session end as its own reason to stop;
* the client no longer writes a talk start ahead of the previous turn's queued
  frames, which is only reachable once a turn can end with no answer to wait for.

Everything below is the real client, the real `ssh -T` argv through a shim that
starts the relay from `env -i` plus the desktop's own environment, the real relay,
the real records reader and the real `bin/fm-inbox.sh`. Nova Sonic is the only
stand-in, and it composes its words out of the tool results the relay hands it.
It is scripted to finish with the first session 300 ms into a two second key
press, which is an ordinary end of a Bedrock session: no exception, no stop
reason, nothing to report.

## What the captain sees

Before the fix - `round2-prefix-relay-transcript.txt`. The relay is gone. The
captain is holding the talk key and there is nothing on the other end; the second
question is never asked at all, because the connection is closed before they
press again. One turn taken, one model session opened.

`` `
client: relay ready, amazon.nova-2-sonic-v1:0 in eu-north-1, read scope full, connected in 0.0s
client: the relay ended the session
`` `

After the fix - `round2-fixed-transcript.txt`. The same session end costs the
remainder of one key press, and the next talk key gets a whole working session:
a real answer, composed from a real read of the records, over the same connection.

`` `
client: relay ready, amazon.nova-2-sonic-v1:0 in eu-north-1, read scope full, connected in 0.0s
client: the relay ended the session
  you: how is the fleet doing right now
  assistant: Right now, 2 in flight, 2 waiting on you, 1 open pull requests. The ones moving are alpha-one and beta-two.
`` `

Said once, not seventeen times: the rest of that key press is another seventeen
audio frames arriving at a session that is already over.

The desktop's own record of the two sessions, `demo/session-b-fixed/model-sessions.jsonl`:

| Turn | Ended early | Audio in | Said |
| --- | --- | --- | --- |
| 1 | yes | 9,600 of 76,800 bytes | nothing |
| 2 | no | 76,800 bytes, the whole question and the talk-end padding | the answer above |

`round2-recovered-turn-reply.wav` is the reply audio the replacement session sent,
as the client wrote it, playable.

## The client half

`round2-prefix-client-transcript.txt` is the same scenario with the pre-fix client
and the fixed relay. The relay survives, but the replacement session heard
**12,800 bytes of a 76,800 byte question** - the talk-end padding and nothing else.
The captain's entire question was written after the next turn's talk start, so it
arrived with no turn open and was dropped, and the model answered a question
nobody had finished asking. The sender thread also died on
`ValueError: write to closed file`.

## Red before, green after

Each of these is the suite with one line of product code changed back, so the
cases are not passing vacuously.

| Log | Mutation | Result |
| --- | --- | --- |
| `mutation-4-session-end-break-restored.log` | the `break` on a clean session end, restored | `not ok - a model session ending did not leave the relay serving`: "the relay stopped serving when the model ended its session: 1 turn(s) taken". 36 other cases still pass. |
| `mutation-5-talk-start-unordered.log` | talk start written from the turn thread again | `not ok`: "the replacement session heard 12800 bytes of a 76800 byte question". 36 other cases still pass. |
| `mutation-1-guard-removed.log` | the self-test wrong-clock guard removed | `not ok - the guard must say why the timings cannot be used` |
| `mutation-3-clock-from-speech-start.log` | the self-test clock moved to the clip's start | `not ok`: "first audio at 2.409 is not measured from the talk end" |
| `mutation-2-wrong-clock.log` | the self-test clock keyed on a mark that does not exist | `not ok`: "no tool_use_s figure" |

## The measuring instrument

`docs/voice-relay.md` sends the captain to `fm-voice-relay.py --self-test
<clip.pcm>` before they touch the laptop, and that is also what the direct column
of the latency table was measured with. Nothing ran it. Two cases now do, and
`relay-cost-table.txt` is the instrument driven both ways, six runs each:

`` `
| Path | First audio out, seconds (6 runs) | Median |
| --- | --- | --- |
| Direct from this desktop, no relay (--self-test) | 0.409 0.409 0.409 0.409 0.409 0.413 | 0.409 |
| Over the relay, real client and framing         | 0.409 0.409 0.409 0.414 0.416 0.420 | 0.411 |
`` `

The absolute numbers are the stand-in's fixed 0.400 s think time, not Nova Sonic.
What is real is the shape - a spread, measured from the captain's talk end - and
the difference between the rows, which is framing plus the extra process hop:
about 3 ms with no network and no real session setup between the two ends. The
1.2 to 1.5 second figures in the docs need the real endpoint in `eu-north-1` and
still cannot be reproduced from this host.

## Reproducing

`` `
REPO=<firstmate checkout> bash demo/run-demo.sh <outdir> <relay path> clean-end,status 2
`` `

`demo/fakesdk/aws_sdk_bedrock_runtime/__init__.py` is lifted verbatim out of
`tests/fm-voice-relay.test.sh`, so the demo and the suite drive the same stand-in.
`prefix-relay/` and `prefix-client/` are shadow trees whose only difference from
the checkout is the one pre-fix file each.
```
</details>
<details>
<summary>Evidence: Captain&#39;s transcript AFTER the fix: the model finishes with the session mid key press, the next talk key still gets an answer out of the records</summary>

<code>client: relay ready, amazon.nova-2-sonic-v1:0 in eu-north-1, read scope full, connected in 0.0s&#10;client: the relay ended the session&#10;you: how is the fleet doing right now&#10;assistant: Right now, 2 in flight, 2 waiting on you, 1 open pull requests. The ones moving are alpha-one and beta-two.</code>

```text
client: relay ready, amazon.nova-2-sonic-v1:0 in eu-north-1, read scope full, connected in 0.0s
client: the relay ended the session
  you: how is the fleet doing right now
  assistant: Right now, 2 in flight, 2 waiting on you, 1 open pull requests. The ones moving are alpha-one and beta-two.
```
</details>
<details>
<summary>Evidence: Captain&#39;s transcript BEFORE the fix (pre-fix relay, same scenario): the relay is gone and the second question is never asked</summary>

<code>client: relay ready, amazon.nova-2-sonic-v1:0 in eu-north-1, read scope full, connected in 0.0s&#10;client: the relay ended the session&#10;&#10;(1 turn taken, 1 model session opened, client exit 1)</code>

```text
client: relay ready, amazon.nova-2-sonic-v1:0 in eu-north-1, read scope full, connected in 0.0s
client: the relay ended the session
```
</details>
<details>
<summary>Evidence: The two spoken turns: a status answer from the records, then real work handed over with the note id the queue gave it</summary>

<code>client: relay ready, amazon.nova-2-sonic-v1:0 in eu-north-1, read scope full, connected in 0.0s&#10;you: how is the fleet doing right now&#10;assistant: Right now, 2 in flight, 2 waiting on you, 1 open pull requests. The ones moving are alpha-one and beta-two.&#10;you: take the flaky sign-in test on alpha and open a pull request for it&#10;assistant: I am not the first mate, so I am handing that to it.&#10;handed to the first mate: take the flaky sign-in test on alpha and open a pull request for it&#10;assistant: That is queued with the first mate as 1787355719-RWCPAm. I have not done any of it myself.</code>

```text
client: relay ready, amazon.nova-2-sonic-v1:0 in eu-north-1, read scope full, connected in 0.0s
  you: how is the fleet doing right now
  assistant: Right now, 2 in flight, 2 waiting on you, 1 open pull requests. The ones moving are alpha-one and beta-two.
  you: take the flaky sign-in test on alpha and open a pull request for it
  assistant: I am not the first mate, so I am handing that to it.
  handed to the first mate: take the flaky sign-in test on alpha and open a pull request for it
  assistant: That is queued with the first mate as 1787355719-RWCPAm. I have not done any of it myself.
```
</details>
<details>
<summary>Evidence: The note and the single wake the handover actually wrote to firstmate&#39;s own queue</summary>

<code>state/inbox/1787355719-RWCPAm.note&#10;id=1787355719-RWCPAm&#10;at=2026-08-21T23:41:59Z&#10;source=text&#10;--&#10;take the flaky sign-in test on alpha and open a pull request for it&#10;&#10;state/.wake-queue&#10;1787355719 1 check inbox:1787355719-RWCPAm check: captain inbox note 1787355719-RWCPAm - take the flaky sign-in test on alpha and open a pull request for it</code>

```text
id=1787355719-RWCPAm
at=2026-08-21T23:41:59Z
source=text
--
take the flaky sign-in test on alpha and open a pull request for it
```
</details>
<details>
<summary>Evidence: Pre-fix client: the relay survives but the replacement session hears only the talk-end padding</summary>

<code>model sessions: turn 2 audio_bytes_in = 12800 of a 76800 byte question&#10;Exeption in thread Thread-2 (_sender): ValueError: write to closed file&#10;(the captain&#39;s whole question arrived with no turn open and was dropped)</code>

```text
client: relay ready, amazon.nova-2-sonic-v1:0 in eu-north-1, read scope full, connected in 0.0s
client: the relay ended the session
  you: how is the fleet doing right now
  assistant: Right now, 2 in flight, 2 waiting on you, 1 open pull requests. The ones moving are alpha-one and beta-two.
Exception in thread Thread-2 (_sender):
Traceback (most recent call last):
  File "/home/linuxbrew/.linuxbrew/Cellar/python@3.14/3.14.7/lib/python3.14/threading.py", line 1082, in _bootstrap_inner
    self._context.run(self.run)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/home/linuxbrew/.linuxbrew/Cellar/python@3.14/3.14.7/lib/python3.14/threading.py", line 1024, in run
    self._target(*self._args, **self._kwargs)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/no-mistakes-evidence/01M0JSJBAA3G54NKRYJSW9XKF4/demo/session-c2-prefix-client/laptop/fm-voice-client.py", line 543, in _sender
    self.uplink.send(frame.TALK_END)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "/tmp/no-mistakes-evidence/01M0JSJBAA3G54NKRYJSW9XKF4/demo/session-c2-prefix-client/laptop/fm-voice-client.py", line 179, in send
    self._writer.send(kind, payload)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/tmp/no-mistakes-evidence/01M0JSJBAA3G54NKRYJSW9XKF4/demo/session-c2-prefix-client/laptop/fm_voice_frame.py", line 148, in send
    self._stream.write(encode(kind, payload))
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
ValueError: write to closed file
```
</details>
<details>
<summary>Evidence: The desktop side of the recovery: session 1 ended after 9,600 of 76,800 bytes and said nothing; session 2 heard the whole question and answered</summary>

<code>{&#34;turn&#34;: 1, &#34;kind&#34;: &#34;clean-end&#34;, &#34;ended_early&#34;: true, &#34;audio_bytes_in&#34;: 9600, &#34;said&#34;: [], &#34;reply_audio_bytes&#34;: 0}&#10;{&#34;turn&#34;: 2, &#34;kind&#34;: &#34;status&#34;, &#34;ended_early&#34;: false, &#34;audio_bytes_in&#34;: 76800, &#34;said&#34;: [&#34;Right now, 2 in flight, 2 waiting on you, 1 open pull requests. The ones moving are alpha-one and beta-two.&#34;], &#34;reply_audio_bytes&#34;: 19200}</code>

```text
{"turn": 1, "turn_kind": "clean-end", "model_id": "amazon.nova-2-sonic-v1:0", "endpoint": "https://bedrock-runtime.eu-north-1.amazonaws.com", "region": "eu-north-1", "credential_key_id": "AKIADESKTOPONLYEXAMPLE", "tool_names_offered": ["get_fleet_status", "hand_over_to_firstmate"], "audio_bytes_in": 9600, "tool_calls": [], "heard": "", "said": [], "reply_audio_bytes": 0, "ended_early": true}
{"turn": 2, "turn_kind": "status", "model_id": "amazon.nova-2-sonic-v1:0", "endpoint": "https://bedrock-runtime.eu-north-1.amazonaws.com", "region": "eu-north-1", "credential_key_id": "AKIADESKTOPONLYEXAMPLE", "tool_names_offered": ["get_fleet_status", "hand_over_to_firstmate"], "audio_bytes_in": 76800, "tool_calls": [{"name": "get_fleet_status", "arguments": {}, "result": {"scope": "full", "basis": "Last recorded event, which is history and not a live check.", "workers_on_deck": 1, "worker_states": {"working": 1}, "in_flight": 2, "queued": 1, "awaiting_captain": 2, "open_pull_requests": 1, "captain_notes_waiting": 0, "in_flight_detail": [{"id": "alpha-one", "title": "Fix the sign-in redirect", "state": "working"}, {"id": "beta-two", "title": "Decide the storage shape", "state": "not started"}], "awaiting_captain_detail": [{"id": "beta-two", "title": "Decide the storage shape"}, {"id": "delta-four", "title": "Add the retry"}], "pull_request_detail": [{"id": "alpha-one", "url": "https://github.com/example/alpha/pull/7"}], "withheld_as_confidential": 0, "detail": "The lists name at most 5 items each; the counts above are the whole picture. Give the captain the counts and a couple of names, not every row."}}], "heard": "how is the fleet doing right now", "said": ["Right now, 2 in flight, 2 waiting on you, 1 open pull requests. The ones moving are alpha-one and beta-two."], "reply_audio_bytes": 19200}
```
</details>
<details>
<summary>Evidence: The measuring instrument driven both ways, six runs each, reported as a spread</summary>

<code>| Path | First audio out, seconds (6 runs) | Median |&#10;| --- | --- | --- |&#10;| Direct from this desktop, no relay (--self-test) | 0.409 0.409 0.409 0.409 0.409 0.413 | 0.409 |&#10;| Over the relay, real client and framing | 0.409 0.409 0.409 0.414 0.416 0.420 | 0.411 |&#10;&#10;relay cost at the median: 0.003 s&#10;model stand-in think time: 0.400 s (so the direct row is instrument overhead only)&#10;The absolute numbers are the stand-in, not Nova Sonic; the DIFFERENCE is real.</code>

```text
The measurement instrument, run against an offline model stand-in that
thinks for a fixed 0.400 s. The absolute numbers are the stand-in, not
Nova Sonic; the DIFFERENCE between the rows is real - it is framing, the
extra process hop and the per-turn session reconnect.

| Path | First audio out, seconds (6 runs) | Median |
| --- | --- | --- |
| Direct from this desktop, no relay (--self-test) | 0.409 0.409 0.409 0.409 0.409 0.413 | 0.409 |
| Over the relay, real client and framing | 0.409 0.409 0.409 0.414 0.416 0.420 | 0.411 |

relay cost at the median: 0.003 s
model stand-in think time: 0.400 s (so the direct row is instrument overhead only)
```
</details>
<details>
<summary>Evidence: The documented desktop check, run as docs/voice-relay.md tells the captain to run it</summary>

<code>$ fm-voice-relay.py --self-test clip.pcm&#10;{&#34;mode&#34;: &#34;self-test&#34;, &#34;model&#34;: &#34;amazon.nova-2-sonic-v1:0&#34;, &#34;region&#34;: &#34;eu-north-1&#34;, &#34;read_scope&#34;: &#34;full&#34;, &#34;input_seconds&#34;: 2.0, &#34;tail_ms&#34;: 400, &#34;connect_seconds&#34;: 0.0, &#34;tool_calls&#34;: 1, &#34;tool_names&#34;: [&#34;get_fleet_status&#34;], &#34;tool_use_s&#34;: 0.404, &#34;first_audio_s&#34;: 0.419, &#34;reply_end_s&#34;: 0.46, &#34;reply_audio_seconds&#34;: 0.4, &#34;answered&#34;: true, &#34;timed_out&#34;: false, &#34;relay_error&#34;: null, &#34;clock_unusable&#34;: [], &#34;heard&#34;: &#34;how is the fleet doing right now&#34;, &#34;said&#34;: &#34;Right now, 2 in flight, 2 waiting on you, 1 open pull requests. The ones moving are alpha-one and beta-two.&#34;}</code>

```text
{"mode": "self-test", "model": "amazon.nova-2-sonic-v1:0", "region": "eu-north-1", "read_scope": "full", "input_seconds": 2.0, "tail_ms": 400, "connect_seconds": 0.0, "tool_calls": 1, "tool_names": ["get_fleet_status"], "tool_use_s": 0.404, "first_audio_s": 0.419, "reply_end_s": 0.46, "reply_audio_seconds": 0.4, "answered": true, "timed_out": false, "relay_error": null, "clock_unusable": [], "heard": "how is the fleet doing right now", "said": "Right now, 2 in flight, 2 waiting on you, 1 open pull requests. The ones moving are alpha-one and beta-two.", "notices": []}
```
</details>
<details>
<summary>Evidence: Mutation: restore the break on a clean session end — the new regression goes red</summary>

<code>session ended: the relay stopped serving when the model ended its session: 1 turn(s) taken&#10;not ok - a model session ending did not leave the relay serving&#10;(36 other cases still ok)</code>

```text
ok - wire format round trips and rejects a desynchronised stream
ok - the relay refuses a desynchronised uplink header instead of waiting for its payload
ok - the relay reads whose account to use from this home and refuses to guess
ok - an unconfigured home can still read how to configure the relay
ok - the model-backed subcommands refuse by name while note keeps working
ok - fm-inbox.sh --help prints its whole header, privacy paragraph included
ok - the relay and the reader agree on the tool names and the handover argument
ok - credentials are resolved once per relay, refreshed before expiry, off the event loop
ok - a turn the model refuses is announced and costs one turn, not the relay
ok - audio that arrives with no turn open is dropped, not turned into a turn
ok - a failure inside the model reader costs one turn, not every later one
ok - a reader failure is named to the captain, a clean end and a close are not
usage: fm-voice-client.py [-h] [--host HOST] [--local] [--relay RELAY]
                          [--relay-python RELAY_PYTHON]
                          [--relay-arg RELAY_ARG]
                          [--listen {push-to-talk,open-mic}] [--runs RUNS]
                          [--talk-seconds TALK_SECONDS] [--in-file IN_FILE]
                          [--out-file OUT_FILE] [--input-device INPUT_DEVICE]
                          [--output-device OUTPUT_DEVICE] [--timeout TIMEOUT]
                          [--wait-for-reply | --no-wait-for-reply]
                          [--gap-seconds GAP_SECONDS]
                          [--audio-idle AUDIO_IDLE] [--verbose]
fm-voice-client.py: error: say where the relay is: --relay <path to fm-voice-relay.py on the desktop>, or set FM_VOICE_RELAY
usage: fm-voice-client.py [-h] [--host HOST] [--local] [--relay RELAY]
                          [--relay-python RELAY_PYTHON]
                          [--relay-arg RELAY_ARG]
                          [--listen {push-to-talk,open-mic}] [--runs RUNS]
                          [--talk-seconds TALK_SECONDS] [--in-file IN_FILE]
                          [--out-file OUT_FILE] [--input-device INPUT_DEVICE]
                          [--output-device OUTPUT_DEVICE] [--timeout TIMEOUT]
                          [--wait-for-reply | --no-wait-for-reply]
                          [--gap-seconds GAP_SECONDS]
                          [--audio-idle AUDIO_IDLE] [--verbose]
fm-voice-client.py: error: --listen open-mic is not built yet: it needs end-of-speech detection to know when a turn ended, which lands with session continuity across turns, so it would stream forever and never end a turn. Use the default --listen push-to-talk.
client: discarded 15 bytes your login shell printed before the relay started: b'You have mail.\n'
ok - the laptop client builds the right remote command and survives a chatty login shell
ok - the client runs from a laptop holding only the two files the guide names
ok - --listen open-mic refuses at startup, before it opens anything
ok - the narrow scope answers how much is waiting without saying what it is
ok - the wide scope names open work and reports state without quoting event lines
ok - an absent read-scope setting means the narrowest answer, not the widest
ok - a home widens its own read scope by writing the setting
ok - finished work and note bodies never reach a spoken answer at any scope
ok - excluding a note body does not distort the counts
ok - a denied item becomes a withheld count without hiding that work exists
ok - the deny list matches regardless of case
ok - an item denied in more than one list is counted as withheld once
ok - one deny decision per item covers every list that item could appear in
ok - the state verb is a closed vocabulary, so free text cannot ride out on it
ok - the backlog and the state directory always come from the same home
ok - a finished task's pull request is neither counted nor named
ok - a deny substring on an open title removes its pull request and says so
ok - an unknown read scope refuses instead of widening
ok - the configured read scope is honoured
ok - handover queues the request for firstmate and wakes it exactly once
ok - the reader and the queue resolve the state directory the same way
ok - an empty request is refused rather than queued as a blank note
ok - a home with no records answers nothing rather than failing
ok - a spoken turn goes out and comes back: the records answer, firstmate gets the work
session ended: the relay stopped serving when the model ended its session: 1 turn(s) taken, 'client: relay ready, amazon.nova-2-sonic-v1:0 in eu-north-1, read scope full, connected in 0.0s\nclient: the relay ended the session\n'
not ok - a model session ending did not leave the relay serving
```
</details>
<details>
<summary>Evidence: Mutation: talk start written from the turn thread again — the client half goes red</summary>

<code>session ended: the replacement session heard 12800 bytes of a 76800 byte question&#10;not ok - a model session ending did not leave the relay serving&#10;(36 other cases still ok)</code>

```text
ok - wire format round trips and rejects a desynchronised stream
ok - the relay refuses a desynchronised uplink header instead of waiting for its payload
ok - the relay reads whose account to use from this home and refuses to guess
ok - an unconfigured home can still read how to configure the relay
ok - the model-backed subcommands refuse by name while note keeps working
ok - fm-inbox.sh --help prints its whole header, privacy paragraph included
ok - the relay and the reader agree on the tool names and the handover argument
ok - credentials are resolved once per relay, refreshed before expiry, off the event loop
ok - a turn the model refuses is announced and costs one turn, not the relay
ok - audio that arrives with no turn open is dropped, not turned into a turn
ok - a failure inside the model reader costs one turn, not every later one
ok - a reader failure is named to the captain, a clean end and a close are not
usage: fm-voice-client.py [-h] [--host HOST] [--local] [--relay RELAY]
                          [--relay-python RELAY_PYTHON]
                          [--relay-arg RELAY_ARG]
                          [--listen {push-to-talk,open-mic}] [--runs RUNS]
                          [--talk-seconds TALK_SECONDS] [--in-file IN_FILE]
                          [--out-file OUT_FILE] [--input-device INPUT_DEVICE]
                          [--output-device OUTPUT_DEVICE] [--timeout TIMEOUT]
                          [--wait-for-reply | --no-wait-for-reply]
                          [--gap-seconds GAP_SECONDS]
                          [--audio-idle AUDIO_IDLE] [--verbose]
fm-voice-client.py: error: say where the relay is: --relay <path to fm-voice-relay.py on the desktop>, or set FM_VOICE_RELAY
usage: fm-voice-client.py [-h] [--host HOST] [--local] [--relay RELAY]
                          [--relay-python RELAY_PYTHON]
                          [--relay-arg RELAY_ARG]
                          [--listen {push-to-talk,open-mic}] [--runs RUNS]
                          [--talk-seconds TALK_SECONDS] [--in-file IN_FILE]
                          [--out-file OUT_FILE] [--input-device INPUT_DEVICE]
                          [--output-device OUTPUT_DEVICE] [--timeout TIMEOUT]
                          [--wait-for-reply | --no-wait-for-reply]
                          [--gap-seconds GAP_SECONDS]
                          [--audio-idle AUDIO_IDLE] [--verbose]
fm-voice-client.py: error: --listen open-mic is not built yet: it needs end-of-speech detection to know when a turn ended, which lands with session continuity across turns, so it would stream forever and never end a turn. Use the default --listen push-to-talk.
client: discarded 15 bytes your login shell printed before the relay started: b'You have mail.\n'
ok - the laptop client builds the right remote command and survives a chatty login shell
ok - the client runs from a laptop holding only the two files the guide names
ok - --listen open-mic refuses at startup, before it opens anything
ok - the narrow scope answers how much is waiting without saying what it is
ok - the wide scope names open work and reports state without quoting event lines
ok - an absent read-scope setting means the narrowest answer, not the widest
ok - a home widens its own read scope by writing the setting
ok - finished work and note bodies never reach a spoken answer at any scope
ok - excluding a note body does not distort the counts
ok - a denied item becomes a withheld count without hiding that work exists
ok - the deny list matches regardless of case
ok - an item denied in more than one list is counted as withheld once
ok - one deny decision per item covers every list that item could appear in
ok - the state verb is a closed vocabulary, so free text cannot ride out on it
ok - the backlog and the state directory always come from the same home
ok - a finished task's pull request is neither counted nor named
ok - a deny substring on an open title removes its pull request and says so
ok - an unknown read scope refuses instead of widening
ok - the configured read scope is honoured
ok - handover queues the request for firstmate and wakes it exactly once
ok - the reader and the queue resolve the state directory the same way
ok - an empty request is refused rather than queued as a blank note
ok - a home with no records answers nothing rather than failing
ok - a spoken turn goes out and comes back: the records answer, firstmate gets the work
session ended: the replacement session heard 12800 bytes of a 76800 byte question
not ok - a model session ending did not leave the relay serving
```
</details>
<details>
<summary>Evidence: Mutations proving the two new self-test cases are not vacuous</summary>

<code>guard removed: not ok - the guard must say why the timings cannot be used&#10;clock from clip start: self-test: first audio at 2.409 is not measured from the talk end&#10;clock on a missing mark: self-test: no tool_use_s figure</code>

```text
ok - wire format round trips and rejects a desynchronised stream
ok - the relay refuses a desynchronised uplink header instead of waiting for its payload
ok - the relay reads whose account to use from this home and refuses to guess
ok - an unconfigured home can still read how to configure the relay
ok - the model-backed subcommands refuse by name while note keeps working
ok - fm-inbox.sh --help prints its whole header, privacy paragraph included
ok - the relay and the reader agree on the tool names and the handover argument
ok - credentials are resolved once per relay, refreshed before expiry, off the event loop
ok - a turn the model refuses is announced and costs one turn, not the relay
ok - audio that arrives with no turn open is dropped, not turned into a turn
ok - a failure inside the model reader costs one turn, not every later one
ok - a reader failure is named to the captain, a clean end and a close are not
usage: fm-voice-client.py [-h] [--host HOST] [--local] [--relay RELAY]
                          [--relay-python RELAY_PYTHON]
                          [--relay-arg RELAY_ARG]
                          [--listen {push-to-talk,open-mic}] [--runs RUNS]
                          [--talk-seconds TALK_SECONDS] [--in-file IN_FILE]
                          [--out-file OUT_FILE] [--input-device INPUT_DEVICE]
                          [--output-device OUTPUT_DEVICE] [--timeout TIMEOUT]
                          [--wait-for-reply | --no-wait-for-reply]
                          [--gap-seconds GAP_SECONDS]
                          [--audio-idle AUDIO_IDLE] [--verbose]
fm-voice-client.py: error: say where the relay is: --relay <path to fm-voice-relay.py on the desktop>, or set FM_VOICE_RELAY
usage: fm-voice-client.py [-h] [--host HOST] [--local] [--relay RELAY]
                          [--relay-python RELAY_PYTHON]
                          [--relay-arg RELAY_ARG]
                          [--listen {push-to-talk,open-mic}] [--runs RUNS]
                          [--talk-seconds TALK_SECONDS] [--in-file IN_FILE]
                          [--out-file OUT_FILE] [--input-device INPUT_DEVICE]
                          [--output-device OUTPUT_DEVICE] [--timeout TIMEOUT]
                          [--wait-for-reply | --no-wait-for-reply]
                          [--gap-seconds GAP_SECONDS]
                          [--audio-idle AUDIO_IDLE] [--verbose]
fm-voice-client.py: error: --listen open-mic is not built yet: it needs end-of-speech detection to know when a turn ended, which lands with session continuity across turns, so it would stream forever and never end a turn. Use the default --listen push-to-talk.
client: discarded 15 bytes your login shell printed before the relay started: b'You have mail.\n'
ok - the laptop client builds the right remote command and survives a chatty login shell
ok - the client runs from a laptop holding only the two files the guide names
ok - --listen open-mic refuses at startup, before it opens anything
ok - the narrow scope answers how much is waiting without saying what it is
ok - the wide scope names open work and reports state without quoting event lines
ok - an absent read-scope setting means the narrowest answer, not the widest
ok - a home widens its own read scope by writing the setting
ok - finished work and note bodies never reach a spoken answer at any scope
ok - excluding a note body does not distort the counts
ok - a denied item becomes a withheld count without hiding that work exists
ok - the deny list matches regardless of case
ok - an item denied in more than one list is counted as withheld once
ok - one deny decision per item covers every list that item could appear in
ok - the state verb is a closed vocabulary, so free text cannot ride out on it
ok - the backlog and the state directory always come from the same home
ok - a finished task's pull request is neither counted nor named
ok - a deny substring on an open title removes its pull request and says so
ok - an unknown read scope refuses instead of widening
ok - the configured read scope is honoured
ok - handover queues the request for firstmate and wakes it exactly once
ok - the reader and the queue resolve the state directory the same way
ok - an empty request is refused rather than queued as a blank note
ok - a home with no records answers nothing rather than failing
ok - a spoken turn goes out and comes back: the records answer, firstmate gets the work
ok - a model session that ends mid-conversation costs one turn, not the relay
self-test: first audio at 2.409 is not measured from the talk end -- {'mode': 'self-test', 'model': 'amazon.nova-2-sonic-v1:0', 'region': 'eu-north-1', 'read_scope': 'full', 'input_seconds': 2.0, 'tail_ms': 400, 'connect_seconds': 0.0, 'tool_calls': 1, 'tool_names': ['get_fleet_status'], 'tool_use_s': 2.401, 'first_audio_s': 2.409, 'reply_end_s': 2.45, 'reply_audio_seconds': 0.4, 'answered': True, 'timed_out': False, 'relay_error': None, 'clock_unusable': [], 'heard': 'how is the fleet doing right now', 'said': 'Right now, 2 in flight, 2 waiting on you, 1 open pull requests. The ones moving are alpha-one and beta-two. 1 note is queued for the first mate.', 'notices': []}
not ok - the desktop check did not report a usable measurement
```
</details>
- Evidence: The reply audio the replacement session sent, as the client wrote it, playable (local file: <code>/tmp/no-mistakes-evidence/01M0JSJBAA3G54NKRYJSW9XKF4/round2-recovered-turn-reply.wav</code>)
<details>
<summary>Evidence: Full targeted suite run, 39 cases</summary>

<code>ok - a spoken turn goes out and comes back: the records answer, firstmate gets the work&#10;ok - a model session that ends mid-conversation costs one turn, not the relay&#10;ok - the desktop&#39;s own check answers from the records and times it from the talk end&#10;ok - a reply that arrives before the end of the clip is named as an unusable clock&#10;all voice relay cases passed</code>

```text
ok - wire format round trips and rejects a desynchronised stream
ok - the relay refuses a desynchronised uplink header instead of waiting for its payload
ok - the relay reads whose account to use from this home and refuses to guess
ok - an unconfigured home can still read how to configure the relay
ok - the model-backed subcommands refuse by name while note keeps working
ok - fm-inbox.sh --help prints its whole header, privacy paragraph included
ok - the relay and the reader agree on the tool names and the handover argument
ok - credentials are resolved once per relay, refreshed before expiry, off the event loop
ok - a turn the model refuses is announced and costs one turn, not the relay
ok - audio that arrives with no turn open is dropped, not turned into a turn
ok - a failure inside the model reader costs one turn, not every later one
ok - a reader failure is named to the captain, a clean end and a close are not
usage: fm-voice-client.py [-h] [--host HOST] [--local] [--relay RELAY]
                          [--relay-python RELAY_PYTHON]
                          [--relay-arg RELAY_ARG]
                          [--listen {push-to-talk,open-mic}] [--runs RUNS]
                          [--talk-seconds TALK_SECONDS] [--in-file IN_FILE]
                          [--out-file OUT_FILE] [--input-device INPUT_DEVICE]
                          [--output-device OUTPUT_DEVICE] [--timeout TIMEOUT]
                          [--wait-for-reply | --no-wait-for-reply]
                          [--gap-seconds GAP_SECONDS]
                          [--audio-idle AUDIO_IDLE] [--verbose]
fm-voice-client.py: error: say where the relay is: --relay <path to fm-voice-relay.py on the desktop>, or set FM_VOICE_RELAY
usage: fm-voice-client.py [-h] [--host HOST] [--local] [--relay RELAY]
                          [--relay-python RELAY_PYTHON]
                          [--relay-arg RELAY_ARG]
                          [--listen {push-to-talk,open-mic}] [--runs RUNS]
                          [--talk-seconds TALK_SECONDS] [--in-file IN_FILE]
                          [--out-file OUT_FILE] [--input-device INPUT_DEVICE]
                          [--output-device OUTPUT_DEVICE] [--timeout TIMEOUT]
                          [--wait-for-reply | --no-wait-for-reply]
                          [--gap-seconds GAP_SECONDS]
                          [--audio-idle AUDIO_IDLE] [--verbose]
fm-voice-client.py: error: --listen open-mic is not built yet: it needs end-of-speech detection to know when a turn ended, which lands with session continuity across turns, so it would stream forever and never end a turn. Use the default --listen push-to-talk.
client: discarded 15 bytes your login shell printed before the relay started: b'You have mail.\n'
ok - the laptop client builds the right remote command and survives a chatty login shell
ok - the client runs from a laptop holding only the two files the guide names
ok - --listen open-mic refuses at startup, before it opens anything
ok - the narrow scope answers how much is waiting without saying what it is
ok - the wide scope names open work and reports state without quoting event lines
ok - an absent read-scope setting means the narrowest answer, not the widest
ok - a home widens its own read scope by writing the setting
ok - finished work and note bodies never reach a spoken answer at any scope
ok - excluding a note body does not distort the counts
ok - a denied item becomes a withheld count without hiding that work exists
ok - the deny list matches regardless of case
ok - an item denied in more than one list is counted as withheld once
ok - one deny decision per item covers every list that item could appear in
ok - the state verb is a closed vocabulary, so free text cannot ride out on it
ok - the backlog and the state directory always come from the same home
ok - a finished task's pull request is neither counted nor named
ok - a deny substring on an open title removes its pull request and says so
ok - an unknown read scope refuses instead of widening
ok - the configured read scope is honoured
ok - handover queues the request for firstmate and wakes it exactly once
ok - the reader and the queue resolve the state directory the same way
ok - an empty request is refused rather than queued as a blank note
ok - a home with no records answers nothing rather than failing
ok - a spoken turn goes out and comes back: the records answer, firstmate gets the work
ok - a model session that ends mid-conversation costs one turn, not the relay
ok - the desktop's own check answers from the records and times it from the talk end
ok - a reply that arrives before the end of the clip is named as an unusable clock
all voice relay cases passed
```
</details>
- Outcome: 🔧 2 issues found → auto-fixed ✅ across 2 runs (58m27s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"e05b2d2d24662f1a137c620e5c7a7cb8befed43c","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

_... (10 earlier update rounds omitted to keep the PR body within GitHub's 65536-char limit; full history is in the run log.)_

<details>
<summary>⚠️ **Review** - 3 infos</summary>

🔧 Fix: survive reader failures, release devices, fix claims
4 issues (1 warning, 3 infos) still open:
- ⚠️ `bin/fm-voice-relay.py:733` - `_read_model`&#39;s new `finally` releases `ended` and `turn_done` but tells nobody, so a reader-side failure is the one turn failure that reaches neither the client nor the run record. Verified by probe (stubbed bidirectional stream, `_send` raising while answering a tool call, a turn open with `talk_end` stamped): the reader ends, `ended` and `turn_done` are set, `session.failed` stays False, and the only frame the Downlink ever saw was the `tool_use` MARK, with `notices == []`. Two consequences. In `--serve`, the client is waiting on `reply_done`, which only a `reply_end` MARK or a notice sets (bin/fm-voice-client.py:552-572), so the captain gets the whole `--timeout` (30 s by default) of nothing and then a record with `answered: false` and `relay_error: null` - the field whose own comment at bin/fm-voice-client.py:632-634 says it exists precisely so a results file that only says `answered: false` cannot invite averaging an infrastructure failure into a latency figure. In `--self-test`, the same failure now prints `answered: false` with `timed_out: false` and no cause at all, where before this round it at least tripped the turn timeout and said so. The sibling uplink failure is named within milliseconds (`turn-failed`, line 928-930) and the client already handles that notice by ending the turn and recording the reason, so the fix is to name the reader&#39;s failure from the same place and carry it into the self-test record. While there, the new docstring says &#34;a turn waiting on turn_done, and a serve loop watching ended, are how the relay recovers&#34;: nothing in `serve` ever awaits `turn_done`, only `--self-test` does.
- ℹ️ `bin/fm-voice-client.py:423` - The `except Exception` that becomes `DeviceError` wraps the file-backed playback and capture as well as the real devices, so a bad `--in-file` or `--out-file` is now reported as a device failure whose advice names the flag that just failed. Verified by probe with `subprocess.Popen` and `sync_magic` stubbed: `--in-file /tmp/definitely-missing.pcm` raises `DeviceError: could not open the audio devices (FileNotFoundError: [Errno 2] No such file or directory: &#39;/tmp/definitely-missing.pcm&#39;). Name another device with --input-device or --output-device, or run without them using --in-file and --out-file`, and an `--out-file` under a missing directory produces the same sentence. Before this round both were plain OSErrors that `main` printed verbatim, which named the actual path. This is the file path rather than the device path: it is what every figure in docs/voice-relay.md was measured with and what the guide tells the captain to use for `--runs 5 &gt; runs.jsonl`, so it is the shape most likely to be hit while the device paths stay unverified. Wrap only the `SpeakerPlayback` and `MicCapture` constructions in `DeviceError` and let `FilePlayback`/`FileCapture` keep raising OSError.
- ℹ️ `bin/fm_voice_records.py:420` - `open_pull_requests` is `len(with_pr)` computed before the deny decision at lines 453-464, so a denied open item is still counted while its row is gone, and the new test pins that as the wanted outcome (`&#39;&#34;open_pull_requests&#34;: 1&#39;` with the only open pull request denied, tests/fm-voice-relay.test.sh:1876). The round-8 instruction asked for the opposite: &#34;remove that task&#39;s row from pull_request_detail, drop open_pull_requests accordingly, and increment withheld_as_confidential&#34;. The implemented behaviour is the more internally consistent of the two, because every other count in the answer is pre-deny (`in_flight` at line 418, `queued`, `awaiting_captain`) and two earlier accepted cases pin exactly this for this field (tests/fm-voice-relay.test.sh:1612 and :1685), so dropping the count would have contradicted them. Raising it rather than changing it: which behaviour the captain wants is a product call about what a spoken answer says, and a deviation from an explicit instruction should be visible rather than silent.
- ℹ️ `bin/fm-voice-relay.py:963` - `serve` still ends the relay whenever a session reports `ended` without `failed`, which is the state a dropped model stream leaves behind, so a single stream drop mid-utterance can cost the whole session rather than one turn. Verified by probe: after the reader dies, `session.failed` is False, and driving one more frame of that same turn through `handle_uplink_frame` (a TALK_END, or a stray AUDIO once the block is already closed, which `audio()` drops without raising) returns normally, at which point `session.ended.is_set() and not session.failed` is True, so serve sends `session-ended`, breaks, and the client stops on the BYE. It only bites when that frame does not itself raise: an AUDIO chunk pushed into a broken input half raises and is correctly converted into `turn-failed`, which is why the common shape survives. The branch predates the per-turn reconnect and its comment reasons only about the failed case; with `renew` rebuilding on every TALK_START, an ended-but-not-failed session could be replaced on the next talk key instead of ending the run, which is the property rounds 3 and 8 were spent establishing. Whether a model-initiated session end should still end the relay is the author&#39;s call, so it is flagged rather than changed.

🔧 Fix: name reader failures, split file and device refusals
3 infos still open:
- ℹ️ `tests/fm-voice-relay.test.sh:12` - The suite header still says &#34;The captain granted the voice agent full read access to their records, so the reader defaults to the wider scope.&#34; That was true before the genericisation round and is now false: `SCOPE_DEFAULT = SCOPE_COUNTS` (bin/fm_voice_records.py:104), and this same file asserts the opposite 1650 lines further down (&#34;an unconfigured home should get the narrow scope&#34;, line 1662). This file is named in docs/voice-relay.md:160 and in the Owners table as the executable owner of the confidentiality boundary, so its header is where someone auditing &#34;what does an unconfigured install send to a model in another region?&#34; will look first, and it currently answers `full`. Rewrite those two lines to say what the code does: the default is the narrow scope, the captain widens their own home by writing `full` into config/voice-read-scope, and what keeps the wide setting safe is the structural exclusion described in the sentence that follows. Comment only, no behaviour change.
- ℹ️ `bin/fm_voice_frame.py:124` - `Reader`&#39;s docstring promises &#34;A stream that ends part way through a frame raises FrameError, because a truncated frame is a real fault and silently treating it as end of input would hide a dropped connection&#34; (lines 104-107), but that only holds for a truncated payload. `_exact` returns None on ANY short read, including a partial 5 byte header, and `read()` treats `head is None` as a clean close. Verified by probe against the real module: `Reader(BytesIO(encode(AUDIO, b&#39;1234&#39;)[:3])).read()` returns None, while cutting the payload instead raises `FrameError: stream ended inside a 4 byte payload`. The suite pins only the payload case (line 124-128), so the gap is unguarded. Consequence on the laptop: bin/fm-voice-client.py:557 `break`s on None with no message, where a FrameError would have printed &#34;client: connection lost: ...&#34;, so a relay killed mid-header produces a turn record with `answered: false` and `relay_error: null` and no line saying why. That is the exact silent shape the last two fix rounds were spent eliminating. Make `_exact` distinguish &#34;nothing read at all&#34; from &#34;a short read&#34;, and raise FrameError for the latter in both the header and the payload path.
- ℹ️ `bin/fm-voice-client.py:623` - `take_turn` sends TALK_START directly on the uplink with no guard, and `run()` checks `self.closed` BEFORE `_let_reply_finish` (lines 801-804), not after. So a relay that dies during the inter-turn wait, which is up to the reply&#39;s own spoken duration plus `--gap-seconds`, is not noticed: the loop returns to `take_turn`, `self.uplink.send(frame.TALK_START)` writes to a pipe whose read end is gone, and BrokenPipeError propagates. `main` wraps `client.run()` in `except KeyboardInterrupt` only (line 897), so it escapes as a raw traceback and exit 1 instead of the one-line refusal every other failure in this file gives, and the remaining runs produce no records. The `_sender` thread already guards its own writes for this reason (line 547). It is reachable in the documented measurement flow, `--runs 5 &gt; runs.jsonl` per docs/voice-relay.md:138; a single-run session is unaffected because there is no second turn. Either re-check `self.closed` at the top of `take_turn` and stop with a named message, or catch BrokenPipeError/OSError around the TALK_START send and report it the way a lost connection is reported at line 555.

</details>

<details>
<summary>🔧 **Test** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `docs/voice-relay.md:45` - The headline measurement in docs/voice-relay.md (1.229-1.516 s over the relay, 1.147-1.317 s direct, on amazon.nova-2-sonic-v1:0 in eu-north-1) cannot be reproduced or checked from this host: there is no ~/.fm-voice-venv, no aws-sdk-bedrock-runtime, and no credential for a Bedrock region. I verified the measuring instrument instead - the clock starts at the captain&#39;s talk end, the marks are ordered, and a six-run spread is what comes out - but the absolute numbers that replace the 1.5 to 2.5 second estimate rest on the author&#39;s own live run. Decide whether one live `--self-test` pass against the real endpoint is required before this merges.
- ⚠️ `bin/fm-voice-client.py:318` - The laptop microphone capture and speaker playback paths have still never been executed, here or by the author, because no machine in reach has an audio device; MicCapture and SpeakerPlayback are written from the sounddevice interface alone. Everything around them - framing, transport, relay handshake, turn sequencing, reply audio, timing arithmetic - I exercised with --in-file and --out-file. The captain&#39;s first live run is therefore the first test of the two device classes, which is the part of &#34;they talk to a voice agent on their laptop&#34; that no evidence here covers.
- <code>`bash tests/fm-voice-relay.test.sh` - baseline before my change: all 36 cases pass</code>
- <code>`bash tests/fm-voice-relay.test.sh` - after adding the new case: 37 cases pass, 16.3 s, no leftover /tmp/fm-voice-relay.* fixtures</code>
- <code>New case `a spoken turn goes out and comes back: the records answer, firstmate gets the work` - real client -&gt; ssh shim -&gt; real relay --serve -&gt; scripted Nova Sonic stand-in -&gt; real reader -&gt; real fm-inbox.sh, two turns (status, handover)</code>
- <code>Mutation check: client clocks the turn from the start of speech instead of talk end -&gt; new case fails with `turn 1 reported first audio at 2.423s, which is not measured from the captain&#39;s talk end` (caught by nothing else)</code>
- <code>Mutation check: relay returns a fabricated `{queued: true, note_id: pretend-1}` instead of calling records.queue_request -&gt; new case fails with `no note on disk at .../inbox/pretend-1.note` (caught by nothing else)</code>
- <code>Mutation check: relay serves scope &#34;counts&#34; regardless of config/voice-read-scope -&gt; new case fails with `the spoken answer named no open work`</code>
- <code>Mutation check: relay stops sending the 400 ms talk-end padding -&gt; caught by the existing tool-surface case and by the new case&#39;s `audio_bytes_in == 16000*2*2 + 400*32` assertion</code>
- <code>`bash harness/run-evidence.sh` - six spoken status turns over the relay, one status/handover/status session, six `fm-voice-relay.py --self-test` control runs, all 15 sessions answered</code>
- <code>`bin/fm-inbox.sh status` and `bin/fm-inbox.sh list` on the fixture home after the handover - one note waiting carrying the captain&#39;s words, one `check` wake in state/.wake-queue</code>
- <code>`python3 bin/fm_voice_records.py status --home &lt;fixture&gt; --scope full` - independent read, compared field by field against the tool result the relay served the model</code>
- <code>`fm-voice-client.py --listen open-mic` from the laptop directory - refuses at startup with exit 2 and zero model sessions opened</code>
- <code>`python3 harness/report.py` - spread table, strip-plot SVG, and byte-for-byte check that the reply audio the client wrote equals what the model sent (172800 and 86400 bytes, identical)</code>
- <code>`bash tests/fm-documentation-audiences.test.sh` - the new docs/voice-relay.md surface is classified exactly once and its owner pointers resolve</code>

🔧 Fix: survive model session end, order client turn frames
✅ Re-checked - no issues remain.
- <code>`bash tests/fm-voice-relay.test.sh` — 39 cases, all pass, 28s</code>
- <code>`bash demo/run-demo.sh session-a bin/fm-voice-relay.py status,handover 2` — manual end-to-end: captain transcript, per-turn timings, inbox note and wake queue on disk</code>
- <code>`bash demo/run-demo.sh session-b-fixed bin/fm-voice-relay.py clean-end,status 2` — the model ends its session 300 ms into a two second key press; relay keeps serving, next talk key answers from the records</code>
- <code>`bash demo/run-demo.sh session-c1-prefix-relay prefix-relay/bin/fm-voice-relay.py clean-end,status 2` — pre-fix relay (parent commit): 1 turn taken, second question never asked</code>
- <code>`bash demo/run-demo.sh session-c2-prefix-client ... clean-end,status 2` with `REPO=prefix-client` — pre-fix client: replacement session heard 12,800 of 76,800 bytes and the sender thread died on `write to closed file`</code>
- <code>`fm-voice-relay.py --self-test clip.pcm` under the stand-in — the documented desktop check, run manually and then covered by a new suite case</code>
- <code>`fm-voice-relay.py --self-test` ×6 vs client `--runs 6` — the six-run spread both ways, the shape the docs table reports</code>
- <code>mutation: restore the `break` on a clean session end → `not ok - a model session ending did not leave the relay serving`</code>
- <code>mutation: `self.uplink.send(frame.TALK_START)` instead of `self.up_q.put(START)` → `not ok`, replacement session heard 12800 of 76800 bytes</code>
- <code>mutation: `early = []` (wrong-clock guard removed) → `not ok - the guard must say why the timings cannot be used`</code>
- <code>mutation: self-test clock shifted to the clip&#39;s start → `not ok`, &#34;first audio at 2.409 is not measured from the talk end&#34;</code>
- <code>mutation: self-test clock keyed on a nonexistent mark → `not ok`, &#34;no tool_use_s figure&#34;</code>
- <code>new cases added to `tests/fm-voice-relay.test.sh`: &#34;the desktop&#39;s own check answers from the records and times it from the talk end&#34;, &#34;a reply that arrives before the end of the clip is named as an unusable clock&#34;</code>

</details>

<details>
<summary>🔧 **Document** - 2 issues found → auto-fixed (3) ✅</summary>

- ℹ️ `README.md:205` - README&#39;s Features list and docs/architecture.md still have no spoken-interface entry. I routed docs/voice-relay.md from README&#39;s Documentation index but deliberately did not add a product-feature bullet or an architecture section, because the laptop capture and playback paths are explicitly unverified (bin/fm-voice-client.py module docstring, docs/voice-relay.md &#34;Setting up the laptop&#34;), so a Features claim would promise a path nobody has run. Worth revisiting once a live run verifies the audio devices.
- ℹ️ `docs/voice-relay.md:39` - docs/voice-relay.md (classified operator-current) carries maintainer-verification-shaped evidence: dated six-run latency spreads, the wide-vs-counts byte and second figures, and the padding-floor runs. The repo has a maintainer-verification audience and a docs/verification/ home for exactly that. I left it in place because the user intent requires the measurement be reported as a spread and splitting it would create a new surface for one feature; propose it as a follow-up consolidation (operator page keeps the headline &#34;about 1.2 to 1.5 s plus your round trip&#34;, docs/verification/ owns the runs) if that page grows further.

🔧 Fix: re-measure relay latency and correct its cause
1 info still open:
- ℹ️ `docs/voice-relay.md:274` - The Cost section&#39;s `$0.00293` per exchange says it is &#34;on the numbers above&#34;, and that cross-reference now points at the re-measured table, but the figure itself was derived from the first pass and I could not re-derive it: it needs the per-run token counts and session seconds, which the page does not carry and which the re-measurement report did not include. I left it as it stands because the drift is below the figure&#39;s own stated precision - the session is about 0.27 s shorter per exchange, which at the quoted `$0.0101` per minute is about `$0.00005`, so &#34;roughly a dollar for three hundred and forty questions&#34; still holds and the old figure is the conservative side. Worth re-deriving from the new runs&#39; token counts if the author has them.

🔧 Fix: correct measurement date and name the unmeasured SSH hop
1 info still open:
- ℹ️ `docs/voice-relay.md:48` - Line 48 credits the direct control with reproducing &#34;the 1.164 second measurement in the earlier survey&#34;, and no such survey exists anywhere in the repository: 1.164 and the phrase &#34;earlier survey&#34; appear only on this line, so a reader who wants to check the control&#39;s calibration has nothing to open. That clause is the one remaining provenance pointer on this page that leads nowhere, and it is load-bearing, because it is the sole stated reason the direct column is usable as a control at all. I did not touch it: the instruction for this round was three enumerated edits and nothing else in this or any other file, and repairing it needs a fact I do not have, either the survey&#39;s location so the clause can become a link or the author&#39;s decision to drop the appeal and let the noise floor carry the calibration on its own.

🔧 Fix: describe the unpublished control measurement, fix list formatting
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 127)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
