### PR TITLE
fix(bin): resolve the session lock's harness identity on Windows hosts

### DIFF
--- a/bin/fm-cursor-lib.sh
+++ b/bin/fm-cursor-lib.sh
@@ -224,7 +224,10 @@ fm_cursor_process_matches() {  # <comm> <args> [argv0]
   local comm=$1 argv0=${3:-} base
   [ -n "$comm" ] || [ -n "$argv0" ] || return 1
   argv0=${argv0:-$comm}
-  base=$(basename -- "$comm")
+  # Builtin rather than basename: the session-lock ancestry walk reaches this
+  # for every hop that is not already a harness, on every turn end, and a fork
+  # here costs real time under MSYS's emulated process creation.
+  base=${comm##*/}
   base=${base#-}
   case "$base" in
     cursor-agent) return 0 ;;

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -7,6 +7,10 @@
 # bin/fm-claude-stop-autoarm.sh uses it to prove a Stop hook fires inside the
 # lock-owning primary session before it may arm or rewake.
 # This file is sourced by scripts and has no side effects on source.
+#
+# Harness identity is pure logic and lives at the top. How a process is read at
+# all is a platform question, and its single owner is the "platform process
+# access" section below.
 
 # Cursor process identity is NOT expressible as a command-name pattern and is
 # deliberately not added to the tables below: Cursor's installed names are
@@ -34,12 +38,19 @@ FM_HARNESS_NAMES=(claude codex opencode grok kimi pi-signed pi)
 # whole path components only is what keeps that widening safe: an ordinary path
 # such as bin/fm-claude-stop-autoarm.sh or ~/.claude/hooks/notify.sh has no
 # "claude" component and is correctly not a harness process.
+#
+# The name is published in FM_HARNESS_PATH_NAME as well as printed, so the
+# ancestry walk can read it without a command substitution. A fork per hop is
+# invisible on Linux and dominates the whole answer under MSYS, where process
+# creation is emulated.
+FM_HARNESS_PATH_NAME=
 fm_harness_path_name() {  # <path>
   local path=$1 name
+  FM_HARNESS_PATH_NAME=
   [ -n "$path" ] || return 1
   for name in "${FM_HARNESS_NAMES[@]}"; do
     case "/$path/" in
-      */"$name"/*) printf '%s' "$name"; return 0 ;;
+      */"$name"/*) FM_HARNESS_PATH_NAME=$name; printf '%s' "$name"; return 0 ;;
     esac
   done
   return 1
@@ -57,24 +68,29 @@ fm_harness_path_name() {  # <path>
 #      is identified by its install path on macOS and by argv[0] on Linux.
 #   3. a bare interpreter (node, python) running a harness script path.
 #   4. Cursor's own structural identity, owned by bin/fm-cursor-lib.sh.
+#
+# Every test here is a shell builtin. The walk asks this question once per hop
+# on every turn end, and the basename, grep and command-substitution forks it
+# used to spend were free on Linux but cost roughly a tenth of a second each
+# under MSYS's emulated process creation - enough to dominate the answer.
 FM_HARNESS_IS_CLAUDE=0
 fm_harness_process_matches() {  # <comm> <args>
-  local comm=$1 args=$2 base argv0 name
+  local comm=$1 args=$2 base argv0
   FM_HARNESS_IS_CLAUDE=0
-  base=$(basename -- "$comm")
-  if printf '%s' "$base" | grep -qE "$FM_HARNESS_RE"; then
+  base=${comm##*/}
+  if [[ $base =~ $FM_HARNESS_RE ]]; then
     case "$base" in *claude*) FM_HARNESS_IS_CLAUDE=1 ;; esac
     return 0
   fi
   argv0=${args%% *}
-  if name=$(fm_harness_path_name "$comm") || name=$(fm_harness_path_name "$argv0"); then
-    case "$name" in claude) FM_HARNESS_IS_CLAUDE=1 ;; esac
+  if fm_harness_path_name "$comm" >/dev/null || fm_harness_path_name "$argv0" >/dev/null; then
+    case "$FM_HARNESS_PATH_NAME" in claude) FM_HARNESS_IS_CLAUDE=1 ;; esac
     return 0
   fi
   # Bare interpreter (e.g. node): match the harness name in its script path.
   case "$comm" in
     *node*|*python*)
-      if printf '%s' "$args" | grep -qE "$FM_HARNESS_RE"; then
+      if [[ $args =~ $FM_HARNESS_RE ]]; then
         case "$args" in *claude*) FM_HARNESS_IS_CLAUDE=1 ;; esac
         return 0
       fi
@@ -86,6 +102,220 @@ fm_harness_process_matches() {  # <comm> <args>
   # fleet lock as read-only and the park can never arm.
   fm_cursor_process_matches "$comm" "$args" "$argv0" && return 0
   return 1
+}
+
+
+# --- platform process access -------------------------------------------------
+#
+# ONE owner of the questions the ancestry walk and the liveness predicate ask
+# about a process: its command, its arguments, its parent, and whether it still
+# exists. Everything above this point is pure identity logic and stays platform
+# independent; everything below it asks the platform.
+#
+# POSIX answers with ps and kill. Windows can answer neither way. Under Git
+# Bash, MSYS2, and Cygwin the emulation layer tracks parentage only between its
+# own processes, so a shell spawned by a native Windows parent - which is every
+# tool shell a harness starts - reports PPid 1, and the walk ends before it can
+# reach the harness. The bundled ps has no -o at all. The Windows branch
+# therefore ignores the emulated view and walks the real Win32 process tree by
+# WINPID, the only pid namespace a native harness process exists in. Every pid
+# this file reports on Windows is a WINPID, including the one written to
+# state/.lock, because a native harness has no other identity to record.
+#
+# A Windows lookup costs a PowerShell start, so the table is read once per shell
+# and reused. fm_session_lock_owned_by_self primes it in the caller's own shell
+# before forking, so the subshell it uses for the walk inherits the table and
+# one lock decision costs one read.
+#
+# FM_PROC_PLATFORM_OVERRIDE and FM_PROC_SELF_PID_OVERRIDE are test seams so the
+# portable regression can drive either branch from either host. Nothing in bin/
+# sets them.
+
+FM_PROC_IS_WINDOWS=
+fm_proc_is_windows() {
+  if [ -z "$FM_PROC_IS_WINDOWS" ]; then
+    case "${FM_PROC_PLATFORM_OVERRIDE:-$(uname -s 2>/dev/null)}" in
+      windows|MINGW*|MSYS*|CYGWIN*) FM_PROC_IS_WINDOWS=0 ;;
+      *) FM_PROC_IS_WINDOWS=1 ;;
+    esac
+  fi
+  return "$FM_PROC_IS_WINDOWS"
+}
+
+# The Win32 process table as pid<TAB>ppid<TAB>start<TAB>exe<TAB>command-line.
+#
+# The start time is carried because a Windows ParentProcessId is only the pid
+# recorded when the child was created: once that parent exits, Windows may hand
+# its number to an unrelated process, and a walk that trusted the number alone
+# could climb into a stranger and hand this home's lock to the wrong session. A
+# real parent always starts no later than its child, so the walk refuses any hop
+# that violates that ordering.
+# shellcheck disable=SC2016 # single quotes are required: every $ below is PowerShell's, not the shell's
+FM_WIN_PROC_QUERY='$ErrorActionPreference="Stop";$t=[char]9;Get-CimInstance -Query "SELECT ProcessId,ParentProcessId,Name,ExecutablePath,CommandLine,CreationDate FROM Win32_Process"|ForEach-Object{$e=$_.ExecutablePath;if([string]::IsNullOrEmpty($e)){$e=$_.Name};$c=$_.CommandLine;if($null -eq $c){$c=""};$k=0;if($null -ne $_.CreationDate){$k=$_.CreationDate.Ticks};[string]$_.ProcessId+$t+[string]$_.ParentProcessId+$t+[string]$k+$t+($e -replace "[\t\r\n]"," ")+$t+($c -replace "[\t\r\n]"," ")}'
+
+# The table is indexed by pid into an associative array at load time, so a walk
+# costs one PowerShell start and no process at all per hop. That matters because
+# a Claude Stop hook asks this question at every turn end, and MSYS process
+# creation is expensive enough that a fork per hop would dominate the answer.
+declare -A FM_WIN_PROC_ROW=()
+FM_WIN_PROC_TABLE_STATE=
+
+# Windows parentage is not enough on its own, because MSYS has no execve: it
+# implements exec by starting a fresh Windows process and ending the old one.
+# Every MSYS process launched from a shell therefore records a Windows parent
+# that is already dead by the time anyone asks - a session-start script would
+# see its own chain end one hop up, one hop short of everything.
+#
+# MSYS does track its own processes correctly, so this index maps each MSYS
+# process's WINPID to its MSYS parent's WINPID, and fm_proc_read prefers that
+# link when it has one. The walk then crosses the emulation boundary without
+# knowing it exists: inside MSYS the parent comes from here, and at the
+# outermost MSYS process - the one a native harness actually started - there is
+# no entry and the real Windows parent takes over.
+#
+# FM_PROC_MSYS_PROC_ROOT is a test seam, like the two overrides above: it lets
+# the portable regression build this boundary out of ordinary files and prove
+# the bridge is load-bearing from a host that has no MSYS at all. Nothing in
+# bin/ sets it, and on a real host the emulation's own /proc is the only source.
+declare -A FM_MSYS_PARENT_WINPID=()
+fm_msys_parent_index_load() {
+  local root=${FM_PROC_MSYS_PROC_ROOT:-/proc} dir winpid parent parent_winpid
+  FM_MSYS_PARENT_WINPID=()
+  for dir in "$root"/[0-9]*; do
+    [ -d "$dir" ] || continue
+    read -r winpid < "$dir/winpid" 2>/dev/null || continue
+    read -r parent < "$dir/ppid" 2>/dev/null || continue
+    case "$winpid" in ''|*[!0-9]*) continue ;; esac
+    case "$parent" in ''|*[!0-9]*) continue ;; esac
+    # PPid 1 is MSYS's own root: that process was started by something native,
+    # which is exactly the hop the Windows table answers correctly.
+    [ "$parent" -gt 1 ] || continue
+    read -r parent_winpid < "$root/$parent/winpid" 2>/dev/null || continue
+    case "$parent_winpid" in ''|*[!0-9]*) continue ;; esac
+    FM_MSYS_PARENT_WINPID[$winpid]=$parent_winpid
+  done
+}
+
+fm_win_proc_table_load() {
+  case "$FM_WIN_PROC_TABLE_STATE" in
+    ok) return 0 ;;
+    failed) return 1 ;;
+  esac
+  local exe line pid
+  exe=$(command -v powershell.exe 2>/dev/null || command -v pwsh.exe 2>/dev/null || true)
+  if [ -z "$exe" ]; then
+    FM_WIN_PROC_TABLE_STATE=failed
+    echo "fm-session-lock: no powershell.exe or pwsh.exe on PATH; the Windows process tree cannot be read, so this session cannot prove it owns the fleet lock" >&2
+    return 1
+  fi
+  FM_WIN_PROC_ROW=()
+  # Read the rows straight off the pipe. Capturing them into a variable first
+  # and feeding the loop a here-document costs a temporary file per load, and
+  # the whole point of indexing once is that the load is the only slow step.
+  # The row count below is what proves the query actually produced a table, so
+  # nothing is lost by not inspecting the capture.
+  while IFS= read -r line; do
+    pid=${line%%$'\t'*}
+    case "$pid" in ''|*[!0-9]*) continue ;; esac
+    FM_WIN_PROC_ROW[$pid]=${line#*$'\t'}
+  done < <("$exe" -NoProfile -NonInteractive -Command "$FM_WIN_PROC_QUERY" 2>/dev/null | tr -d '\r')
+  if [ "${#FM_WIN_PROC_ROW[@]}" -eq 0 ]; then
+    FM_WIN_PROC_TABLE_STATE=failed
+    echo "fm-session-lock: the Win32 process table from $exe held no readable rows; this session cannot prove it owns the fleet lock" >&2
+    return 1
+  fi
+  fm_msys_parent_index_load
+  FM_WIN_PROC_TABLE_STATE=ok
+  return 0
+}
+
+# fm_proc_read <pid>: publish FM_PROC_COMM, FM_PROC_ARGS, FM_PROC_PPID and
+# FM_PROC_START for <pid>, or return 1 when the process cannot be read.
+# FM_PROC_START is empty on POSIX, which carries no start time here.
+#
+# The Windows branch reports the executable path as the command, with separators
+# normalized to forward slashes, so the whole-path-component evidence in
+# fm_harness_path_name keeps meaning what it means everywhere else: a
+# backslash path has no components to match, and every ordinary firstmate script
+# path would collapse into one basename that spuriously contains a harness name.
+FM_PROC_COMM=
+FM_PROC_ARGS=
+FM_PROC_PPID=
+FM_PROC_START=
+fm_proc_read() {  # <pid>
+  local pid=$1 rest
+  FM_PROC_COMM=
+  FM_PROC_ARGS=
+  FM_PROC_PPID=
+  FM_PROC_START=
+  case "$pid" in ''|*[!0-9]*) return 1 ;; esac
+  if fm_proc_is_windows; then
+    fm_win_proc_table_load || return 1
+    rest=${FM_WIN_PROC_ROW[$pid]-}
+    [ -n "$rest" ] || return 1
+    # Split in the shell, without forking: the command line is the only field
+    # that may contain anything at all, and it is last, so it is whatever
+    # remains after the three fixed fields have been taken off the front.
+    FM_PROC_PPID=${rest%%$'\t'*}; rest=${rest#*$'\t'}
+    FM_PROC_START=${rest%%$'\t'*}; rest=${rest#*$'\t'}
+    FM_PROC_COMM=${rest%%$'\t'*}; rest=${rest#*$'\t'}
+    FM_PROC_COMM=${FM_PROC_COMM//\\//}
+    FM_PROC_ARGS=$rest
+    # An MSYS process knows its real parent; the Windows table only remembers
+    # the one that exec replaced. Prefer the link that is still true.
+    if [ -n "${FM_MSYS_PARENT_WINPID[$pid]-}" ]; then
+      FM_PROC_PPID=${FM_MSYS_PARENT_WINPID[$pid]}
+    fi
+    return 0
+  fi
+  FM_PROC_COMM=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
+  FM_PROC_ARGS=$(ps -o args= -p "$pid" 2>/dev/null)
+  FM_PROC_PPID=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+  return 0
+}
+
+# True unless the platform can prove the hop impossible, because a real parent
+# starts no later than its child. Only Windows carries a start time, so this is
+# where a recycled ParentProcessId is caught; POSIX stands aside.
+fm_proc_parent_ordered() {  # <parent-pid> <child-start>
+  local parent=$1 child=$2 parent_start
+  [ -n "$child" ] && [ "$child" != 0 ] || return 0
+  fm_proc_read "$parent" || return 1
+  parent_start=$FM_PROC_START
+  [ -n "$parent_start" ] && [ "$parent_start" != 0 ] || return 0
+  [ "$parent_start" -le "$child" ]
+}
+
+# The pid the ancestry walk starts from, in the namespace fm_proc_read answers
+# in. A Windows shell must translate its emulated pid to its WINPID, and a
+# translation that cannot be read fails closed rather than walking a pid that
+# means something else entirely. Published in FM_PROC_SELF_PID as well as
+# printed, so the walk need not fork to ask.
+FM_PROC_SELF_PID=
+fm_proc_self_pid() {
+  local winpid
+  FM_PROC_SELF_PID=
+  if [ -n "${FM_PROC_SELF_PID_OVERRIDE:-}" ]; then
+    FM_PROC_SELF_PID=$FM_PROC_SELF_PID_OVERRIDE
+    printf '%s\n' "$FM_PROC_SELF_PID"
+    return 0
+  fi
+  if fm_proc_is_windows; then
+    read -r winpid < "/proc/$$/winpid" 2>/dev/null || return 1
+    case "$winpid" in ''|*[!0-9]*) return 1 ;; esac
+    FM_PROC_SELF_PID=$winpid
+    printf '%s\n' "$winpid"
+    return 0
+  fi
+  FM_PROC_SELF_PID=$$
+  printf '%s\n' "$$"
+}
+
+# Load the platform's process table into THIS shell, so a caller that asks its
+# question across a subshell pays for it once. A no-op wherever reads are cheap.
+fm_proc_prime() {
+  fm_proc_is_windows || return 0
+  fm_win_proc_table_load
 }
 
 # Walk the current process ancestry (up to 16 hops) and print this session's
@@ -107,11 +337,12 @@ fm_harness_process_matches() {  # <comm> <args>
 # session cannot be read off the ancestry at all, so the whole contiguous run is
 # reported and the callers below decide what they need from it.
 fm_harness_ancestry_pids() {
-  local pid=$$ comm args extending=0 printed=0
+  local pid parent child_start extending=0 printed=0
+  fm_proc_self_pid >/dev/null || return 1
+  pid=$FM_PROC_SELF_PID
   for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
-    comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
-    args=$(ps -o args= -p "$pid" 2>/dev/null)
-    if fm_harness_process_matches "$comm" "$args"; then
+    fm_proc_read "$pid" || break
+    if fm_harness_process_matches "$FM_PROC_COMM" "$FM_PROC_ARGS"; then
       printf '%s\n' "$pid"
       printed=1
       [ "$FM_HARNESS_IS_CLAUDE" -eq 1 ] || break
@@ -119,8 +350,11 @@ fm_harness_ancestry_pids() {
     elif [ "$extending" -eq 1 ]; then
       break
     fi
-    pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
-    [ -n "$pid" ] && [ "$pid" -gt 1 ] || break
+    parent=$FM_PROC_PPID
+    child_start=$FM_PROC_START
+    [ -n "$parent" ] && [ "$parent" -gt 1 ] || break
+    fm_proc_parent_ordered "$parent" "$child_start" || break
+    pid=$parent
   done
   [ "$printed" -eq 1 ]
 }
@@ -145,11 +379,15 @@ EOF
 
 # True if $1 is a live process that looks like a verified harness.
 fm_harness_pid_alive() {
-  local pid=$1 comm args
-  kill -0 "$pid" 2>/dev/null || return 1
-  comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
-  args=$(ps -o args= -p "$pid" 2>/dev/null)
-  fm_harness_process_matches "$comm" "$args"
+  local pid=$1
+  # kill -0 answers existence in the pid namespace ps reports in. On Windows
+  # that namespace is not the one the lock records, so presence in the Win32
+  # table is the existence proof there.
+  if ! fm_proc_is_windows; then
+    kill -0 "$pid" 2>/dev/null || return 1
+  fi
+  fm_proc_read "$pid" || return 1
+  fm_harness_process_matches "$FM_PROC_COMM" "$FM_PROC_ARGS"
 }
 
 # True when state dir $1 holds a session lock whose pid is ANY harness ancestor
@@ -166,6 +404,9 @@ fm_session_lock_owned_by_self() {
   case "$lock_pid" in
     ''|*[!0-9]*) return 1 ;;
   esac
+  # Prime here, in the caller's own shell, so the walk's subshell inherits the
+  # platform's process table instead of paying for its own copy.
+  fm_proc_prime || return 1
   pids=$(fm_harness_ancestry_pids) || return 1
   while IFS= read -r pid; do
     [ "$pid" = "$lock_pid" ] && return 0

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -403,6 +403,22 @@ fm_lock_claim() {
   return 0
 }
 
+# Say once, per shell, why a lock can never be taken here.
+#
+# Refusing the claim is the correct outcome when the platform cannot make a
+# symlink, but every caller of fm_lock_acquire_wait then waits for a lock that
+# can never be granted. Without this the whole fleet simply stops with no
+# output at all. The condition is narrow on purpose: an ordinary lost race
+# leaves an existing lock behind and says nothing.
+FM_LOCK_SYMLINK_UNSUPPORTED_REPORTED=0
+fm_lock_report_unsupported_symlink() {
+  local lockdir=$1
+  [ "$FM_LOCK_SYMLINK_UNSUPPORTED_REPORTED" -eq 0 ] || return 0
+  [ -e "$lockdir" ] && [ ! -L "$lockdir" ] || return 0
+  FM_LOCK_SYMLINK_UNSUPPORTED_REPORTED=1
+  echo "fm-lock: this filesystem or platform will not create a symbolic link, so $lockdir cannot be claimed and every wait for it will block forever. On Windows this means Developer Mode is off: enable it (Settings > System > For developers), then start a new session." >&2
+}
+
 fm_lock_try_create() {
   local lockdir=$1 allowed_steal_owner=${2:-} ownerdir
   FM_LOCK_OWNER_DIR=
@@ -415,7 +431,14 @@ fm_lock_try_create() {
     fm_lock_discard_owner "$ownerdir"
     return 1
   fi
-  if ln -s "$ownerdir" "$lockdir" 2>/dev/null && fm_lock_points_to_owner "$lockdir" "$ownerdir"; then
+  # MSYS is inert everywhere else and decides, on Windows, whether ln -s makes a
+  # real symlink. Git Bash's default quietly substitutes a COPY of the target
+  # and still exits 0, which would turn this compare-and-swap into two sessions
+  # each holding their own private directory and each believing it won.
+  # nativestrict makes it refuse instead, and the verification below is what
+  # turns any such substitution into a lost race rather than a granted lock.
+  if MSYS="winsymlinks:nativestrict" ln -s "$ownerdir" "$lockdir" 2>/dev/null \
+    && fm_lock_points_to_owner "$lockdir" "$ownerdir"; then
     if fm_lock_claim "$lockdir" "$ownerdir" "$allowed_steal_owner"; then
       FM_LOCK_OWNER_DIR=$ownerdir
       return 0
@@ -424,6 +447,7 @@ fm_lock_try_create() {
       rm -f "$lockdir" 2>/dev/null || true
     fi
   else
+    fm_lock_report_unsupported_symlink "$lockdir"
     fm_lock_remove_stray_owner_link "$lockdir" "$ownerdir"
   fi
   fm_lock_discard_owner "$ownerdir"

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -914,3 +914,95 @@ Refresh this harness-dependent proof before accepting a cursor upgrade:
 ```sh
 FM_HARNESS_LIVENESS_DRIFT=1 bin/fm-test-run.sh tests/fm-harness-liveness-drift-live-e2e.test.sh
 ```
+
+## Windows host (MSYS and Git Bash)
+
+Audience: maintainer verification.
+
+The session lock's identity walk and every `fm_lock_*` claim depend on host facts that differ from POSIX.
+These were verified on 2026-08-21 on Windows 11 build 26200 with Git for Windows bash (`MINGW64_NT-10.0-26200`) and bash 5.3.15.
+`docs/configuration.md` and `bin/fm-session-lock-lib.sh` own the resulting behavior; this record is the evidence for why that behavior exists.
+
+### The emulated process view answers neither identity question
+
+```sh
+uname -s
+ps -o comm= -p $$
+grep '^PPid' /proc/$$/status
+```
+
+Observed output:
+
+```text
+MINGW64_NT-10.0-26200
+ps: unknown option -- o
+PPid:	1
+```
+
+The bundled `ps` has no `-o`, so the POSIX ancestry walk cannot read a command, argument string, or parent at all.
+A shell the harness started natively is reported with `PPid: 1`, because MSYS tracks parentage only between its own processes.
+Both together mean the POSIX branch can never locate a harness on this host, and a session start that trusted it stays read-only forever.
+
+### MSYS has no execve, so a recorded Win32 parent is routinely dead
+
+MSYS implements exec by starting a fresh Windows process and ending the old one.
+A child launched from a shell therefore records a Windows parent that has already exited, while its MSYS parent is still correct.
+
+```sh
+echo "shell msys pid: $$"
+bash -c 'echo "child msys ppid: $(cat /proc/$$/ppid)"; w=$(cat /proc/$$/winpid); \
+  p=$(powershell.exe -NoProfile -NonInteractive -Command "(Get-CimInstance Win32_Process -Filter \"ProcessId=$w\").ParentProcessId" | tr -d "\r "); \
+  echo "child winpid: $w  recorded win32 parent: $p"; \
+  powershell.exe -NoProfile -NonInteractive -Command "if (Get-CimInstance Win32_Process -Filter \"ProcessId=$p\") {(...)} else {\"win32 parent GONE\"}" | tr -d "\r"'
+```
+
+Observed output:
+
+```text
+shell msys pid: 51725
+child msys ppid: 51725
+child winpid: 36148  recorded win32 parent: 23472
+win32 parent GONE
+```
+
+This is why the walk prefers the MSYS parent link where one exists and falls back to the Win32 link only at the outermost MSYS process, which is the hop a native harness actually started.
+Trusting the Win32 link alone ends the ancestry one hop above the caller; trusting the MSYS link alone never leaves the emulation and never reaches the harness.
+
+### Windows reuses process ids, so a parent link needs a second signal
+
+A `ParentProcessId` is only the number recorded when the child was created, and Windows may reassign it after that parent exits.
+The walk therefore refuses any hop whose claimed parent started after its own child, which no real parent can do.
+`tests/fm-session-lock-ancestry.test.sh` pins that refusal, and pins that the same shape with a possible start time still resolves, so the case cannot go vacuous.
+
+### Lock claims require real symlinks, which are off by default
+
+Every `fm_lock_*` claim is an atomic `ln -s`.
+Git Bash's default substitutes a directory copy and still exits 0, which would let two sessions each hold their own private directory and each believe it won the race.
+
+```sh
+ln -s owner link; [ -L link ] && echo symlink || echo "plain directory"
+MSYS="winsymlinks:nativestrict" ln -s owner link2
+```
+
+Observed output before Windows Developer Mode was enabled:
+
+```text
+plain directory
+ln: failed to create symbolic link 'link2': Operation not permitted
+```
+
+With Developer Mode enabled the same `nativestrict` call creates a real symlink and the claim verification passes.
+`fm_lock_try_create` requests `nativestrict` and verifies the result with `readlink`, so a substituted copy is a lost race rather than a granted lock.
+`git config core.symlinks` must also be `true` for this repo's own tracked symlink to check out as a link rather than a text file.
+
+### Session start needs a larger time budget here
+
+Every external command costs roughly ten times what it does on Linux, because process creation is emulated.
+Detect-only bootstrap measured 82s against the default 120s `FM_SESSION_START_TIMEOUT`, and the digest truncated intermittently.
+Individual tool version probes measured 0.9s to 3.2s each.
+Raising `FM_SESSION_START_TIMEOUT` lets the digest complete; the cost is the tools' own startup, not firstmate's work.
+
+### Pinned ShellCheck is not installable by the bundled helper
+
+`bin/fm-install-shellcheck.sh` supports linux and darwin only, so it refuses on this host.
+The pinned version is published for Windows as `shellcheck-v0.11.0.zip` on the upstream release, and `bin/fm-lint.sh` accepts that binary once it is on PATH.

--- a/tests/fm-session-lock-ancestry.test.sh
+++ b/tests/fm-session-lock-ancestry.test.sh
@@ -36,9 +36,13 @@ NAMED_CLAUDE="$FAKEBIN/claude"
 
 # Run one library expression with <fakebin> shadowing ps. kill is stubbed so
 # liveness questions are decided by the process table alone.
+# These cases describe the POSIX branch, so they pin it rather than inheriting
+# whatever host runs the suite: on Windows the library reads the Win32 process
+# tree and would ignore the fake ps entirely, and the failure would look like a
+# broken classifier instead of a test asking the wrong branch a question.
 lib_eval() {  # <fakebin> <expression>
   local fakebin=$1 expr=$2
-  PATH="$fakebin:$PATH" bash -c "
+  PATH="$fakebin:$PATH" FM_PROC_PLATFORM_OVERRIDE=posix bash -c "
     . \"\$0\"
     kill() { return 0; }
     $expr
@@ -220,6 +224,178 @@ SH
   pass "session-lock: a live version-named session holding the lock is not mistaken for a stale owner"
 }
 
+# --- Windows layer: the same identity question over the Win32 process tree ---
+#
+# Windows answers none of the questions the POSIX branch asks. The bundled ps
+# has no -o, and MSYS reports PPid 1 for every shell a native harness started,
+# so the walk reads the real Win32 tree instead. These cases drive that branch
+# from any host through its documented seams, because the platform it describes
+# cannot be reached from CI at all.
+
+# win_fake_powershell <fakebin> <table-file>: stand in for the Win32 process
+# table query. The real one shells out to PowerShell; this prints rows.
+win_fake_powershell() {  # <fakebin> <table-file>
+  local fakebin=$1 table=$2
+  cat > "$fakebin/powershell.exe" <<SH
+#!/usr/bin/env bash
+cat "$table"
+SH
+  chmod +x "$fakebin/powershell.exe"
+}
+
+# win_proc_root <dir> <msys-pid:winpid:msys-ppid>...: build the files MSYS
+# publishes for its own processes, which is where the true parent link lives.
+win_proc_root() {  # <dir> <spec>...
+  local root=$1 spec msys winpid parent
+  shift
+  mkdir -p "$root"
+  for spec in "$@"; do
+    IFS=: read -r msys winpid parent <<EOF
+$spec
+EOF
+    mkdir -p "$root/$msys"
+    printf '%s\n' "$winpid" > "$root/$msys/winpid"
+    printf '%s\n' "$parent" > "$root/$msys/ppid"
+  done
+  printf '%s\n' "$root"
+}
+
+# Run one library expression on the Windows branch, with <self> as the starting
+# WINPID and <proc-root> as the MSYS view.
+win_eval() {  # <fakebin> <self-winpid> <proc-root> <expression>
+  local fakebin=$1 self=$2 proc_root=$3 expr=$4
+  PATH="$fakebin:$PATH" \
+  FM_PROC_PLATFORM_OVERRIDE=windows \
+  FM_PROC_SELF_PID_OVERRIDE="$self" \
+  FM_PROC_MSYS_PROC_ROOT="$proc_root" \
+    bash -c ". \"\$0\"; $expr" "$LIB"
+}
+
+test_windows_walk_crosses_the_msys_exec_boundary() {
+  local dir fakebin table proc_root empty_root got
+  dir="$TMP_ROOT/win-msys-boundary"
+  fakebin=$(fm_fakebin "$dir")
+  mkdir -p "$dir/state"
+
+  # WINPID 1000 is this shell. Its RECORDED Win32 parent is 9999, which is
+  # absent from the table: MSYS has no execve, so it starts a fresh process and
+  # ends the old one, leaving every exec'd child pointing at a corpse. The
+  # living link - 1000's MSYS parent is 1100 - is the one that reaches the
+  # harness. Above 1100 the emulation stops and Windows is right again.
+  table="$dir/table"
+  cat > "$table" <<'ROWS'
+1000	9999	300	C:\Program Files\Git\usr\bin\bash.exe	bash session-start
+1100	1200	200	C:\Program Files\Git\bin\bash.exe	bash -c fm
+1200	1300	100	C:\Users\u\.local\bin\claude.exe	claude --resume
+1300	0	50	C:\windows\System32\WindowsPowerShell\v1.0\powershell.exe	powershell
+ROWS
+  win_fake_powershell "$fakebin" "$table"
+  proc_root=$(win_proc_root "$dir/proc" 10:1000:11 11:1100:1)
+
+  got=$(win_eval "$fakebin" 1000 "$proc_root" 'fm_harness_ancestry_pid') \
+    || fail "the walk never reached the harness across the MSYS exec boundary"
+  [ "$got" = 1200 ] \
+    || fail "ancestry resolved '$got', expected the claude.exe WINPID 1200"
+
+  # The divergence itself: without the MSYS link the walk follows the recorded
+  # Win32 parent into a process that no longer exists and finds nothing. If this
+  # ever starts passing, the case above has stopped proving anything.
+  empty_root="$dir/proc-empty"
+  mkdir -p "$empty_root"
+  if win_eval "$fakebin" 1000 "$empty_root" 'fm_harness_ancestry_pid' >/dev/null 2>&1; then
+    fail "the walk found a harness without the MSYS link, so this fixture no longer exercises the boundary"
+  fi
+  pass "session-lock windows: the walk crosses MSYS's exec boundary to reach the native harness"
+}
+
+test_windows_walk_refuses_a_parent_that_starts_after_its_child() {
+  local dir fakebin table proc_root got
+  dir="$TMP_ROOT/win-recycled-parent"
+  fakebin=$(fm_fakebin "$dir")
+  mkdir -p "$dir/state" "$dir/proc"
+  proc_root="$dir/proc"
+
+  # Windows reuses process ids, and a ParentProcessId is only the number
+  # recorded at creation. Once that parent exits the number can name a
+  # stranger - and if the stranger is a harness, the walk would hand this
+  # home's lock to an unrelated session. A real parent cannot start after its
+  # own child, so that ordering is what catches it.
+  table="$dir/table"
+  cat > "$table" <<'ROWS'
+2000	2100	100	C:\Program Files\Git\usr\bin\bash.exe	bash
+2100	0	500	C:\Users\u\.local\bin\claude.exe	claude --resume
+ROWS
+  win_fake_powershell "$fakebin" "$table"
+  if win_eval "$fakebin" 2000 "$proc_root" 'fm_harness_ancestry_pid' >/dev/null 2>&1; then
+    fail "the walk climbed into a claimed parent that started after its own child"
+  fi
+
+  # And the divergence: the SAME shape with a possible start time does resolve,
+  # so the refusal above is the ordering check and not a broken fixture.
+  cat > "$table" <<'ROWS'
+2000	2100	100	C:\Program Files\Git\usr\bin\bash.exe	bash
+2100	0	50	C:\Users\u\.local\bin\claude.exe	claude --resume
+ROWS
+  got=$(win_eval "$fakebin" 2000 "$proc_root" 'fm_harness_ancestry_pid') \
+    || fail "a parent that plausibly precedes its child was rejected too"
+  [ "$got" = 2100 ] || fail "ancestry resolved '$got', expected 2100"
+  pass "session-lock windows: a parent that starts after its child is refused as a recycled id"
+}
+
+test_windows_liveness_reads_the_win32_table() {
+  local dir fakebin table proc_root
+  dir="$TMP_ROOT/win-liveness"
+  fakebin=$(fm_fakebin "$dir")
+  mkdir -p "$dir/state" "$dir/proc"
+  proc_root="$dir/proc"
+
+  # The lock records a WINPID, which is not a pid `kill -0` can ask about, so
+  # presence in the Win32 table is what existence means here. These ids do not
+  # exist on the host running this test, which is the point: a POSIX liveness
+  # check would call the harness dead and let a live session's home be stolen.
+  table="$dir/table"
+  cat > "$table" <<'ROWS'
+3000	0	100	C:\Program Files\Git\usr\bin\bash.exe	bash
+3100	0	100	C:\Users\u\.local\bin\claude.exe	claude --resume
+ROWS
+  win_fake_powershell "$fakebin" "$table"
+
+  win_eval "$fakebin" 3000 "$proc_root" 'fm_harness_pid_alive 3100' \
+    || fail "a harness present in the Win32 table was reported dead"
+  if win_eval "$fakebin" 3000 "$proc_root" 'fm_harness_pid_alive 3000'; then
+    fail "an ordinary shell was accepted as a live harness lock owner"
+  fi
+  if win_eval "$fakebin" 3000 "$proc_root" 'fm_harness_pid_alive 4242'; then
+    fail "a pid absent from the Win32 table was reported alive"
+  fi
+  pass "session-lock windows: harness liveness is decided by the Win32 table, not by kill"
+}
+
+test_windows_unreadable_process_table_never_resolves_an_owner() {
+  local dir fakebin proc_root
+  dir="$TMP_ROOT/win-no-table"
+  fakebin=$(fm_fakebin "$dir")
+  mkdir -p "$dir/state" "$dir/proc"
+  proc_root="$dir/proc"
+
+  # No table means the question was not answered, which must never be reported
+  # as "no competing session": that reading would let two sessions each take
+  # the home. The absent-powershell case is the same answer by another route.
+  cat > "$fakebin/powershell.exe" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+  chmod +x "$fakebin/powershell.exe"
+  if win_eval "$fakebin" 5000 "$proc_root" 'fm_harness_ancestry_pid' >/dev/null 2>&1; then
+    fail "an ancestry was resolved from a process table that could not be read"
+  fi
+  printf '5000\n' > "$dir/state/.lock"
+  if win_eval "$fakebin" 5000 "$proc_root" "fm_session_lock_owned_by_self '$dir/state'" 2>/dev/null; then
+    fail "lock ownership was claimed while the process table was unreadable"
+  fi
+  pass "session-lock windows: an unreadable process table resolves no owner and claims no lock"
+}
+
 # --- end-to-end layer: the real Stop auto-arm in real process trees ----------
 
 install_autoarm_scripts() {
@@ -360,6 +536,10 @@ test_version_named_session_is_identified_on_both_platforms
 test_ordinary_paths_are_never_harness_processes
 test_harness_beyond_a_gap_never_owns_the_lock
 test_competing_version_named_session_is_seen_as_live
+test_windows_walk_crosses_the_msys_exec_boundary
+test_windows_walk_refuses_a_parent_that_starts_after_its_child
+test_windows_liveness_reads_the_win32_table
+test_windows_unreadable_process_table_never_resolves_an_owner
 test_e2e_version_named_session_claims_the_home
 test_e2e_daemon_parented_session_claims_the_home
 test_e2e_daemon_parented_version_named_session_keeps_its_lock


### PR DESCRIPTION
## The problem

On an MSYS host (Git Bash, MSYS2, Cygwin) the session lock can never be acquired. `fm_harness_ancestry_pids` finds no harness in the ancestry, so `bin/fm-lock.sh` exits with `error: cannot locate harness process in ancestry`, every session start refuses the fleet lock and stays read-only, and the Claude Stop auto-arm can never claim the home. In practice firstmate cannot spawn, steer, merge, drain the wake queue, or supervise anything on Windows at all.

Three host facts are involved, and each one defeats the obvious fix for the previous one.

**The bundled `ps` has no `-o`.** The POSIX walk asks `ps -o comm= -p <pid>`, which answers nothing here:

```console
$ ps -o comm= -p $$
ps: unknown option -- o
```

**MSYS reports `PPid: 1` for any shell a native harness started**, because it tracks parentage only among its own processes. So even with a working `ps`, the ancestry ends immediately:

```console
$ grep '^PPid' /proc/$$/status
PPid:	1
```

**MSYS has no `execve`.** It implements exec by starting a fresh Windows process and ending the old one, so an exec'd child records a Windows parent that has *already exited*. Walking the Win32 tree alone therefore ends one hop above the caller — which is exactly where any firstmate script runs:

```console
$ echo "shell msys pid: $$"; bash /tmp/evidence.sh
shell msys pid: 51725
child msys ppid: 51725
child winpid: 36148  recorded win32 parent: 23472
win32 parent GONE
```

Note the split: the child's *MSYS* parent is correct, while its *Win32* parent is a corpse.

## The fix

A platform process-access layer in `bin/fm-session-lock-lib.sh` becomes the single owner of "what is this process, and who is its parent". Everything above it stays pure identity logic and is unchanged.

- **POSIX is untouched** — still `ps` and `kill`, same code path, same semantics.
- **The Windows branch** reads the Win32 process tree once per shell and indexes it by pid, so a walk costs one PowerShell start and no process per hop. `fm_session_lock_owned_by_self` primes it in the caller's own shell so the subshell it forks for the walk inherits the table and one lock decision costs one read.
- **The emulation boundary is bridged** by preferring each MSYS process's own parent link where it has one, falling back to the Win32 link only at the outermost MSYS process — the hop a native harness actually started. Neither link alone reaches the harness.
- **Recycled parent ids are refused.** A Windows `ParentProcessId` is only the number recorded at creation, and Windows may reassign it once that parent exits. If the stranger it names is a harness, the walk would hand the home's lock to an unrelated session. A real parent cannot start after its own child, so hops violating that ordering are refused.

Every pid this reports on Windows is a WINPID, including the one written to `state/.lock`, because a native harness process has no other identity to record.

### Lock claims

Every `fm_lock_*` claim is an atomic `ln -s`. Git Bash's default silently substitutes a *directory copy* and still exits 0:

```console
$ ln -s owner link; [ -L link ] && echo symlink || echo "plain directory"
plain directory
```

Left alone this turns the compare-and-swap into two sessions each holding their own private directory and each believing it won. `fm_lock_try_create` now requests `winsymlinks:nativestrict`, and the existing `readlink` verification turns any substitution into a lost race rather than a granted lock. Because the correct outcome is then "refuse forever", it also reports once — previously every caller of `fm_lock_acquire_wait` simply blocked with no output at all.

This needs Windows Developer Mode enabled; the diagnostic says so.

### Fork-free hot path

`fm_harness_process_matches` and `fm_cursor_process_matches` ran `basename`, `grep` and command substitutions on every hop. Those are free on Linux and cost ~0.1s each under emulated process creation, and this runs at every turn end. They are now shell builtins.

Measured on the host below: ~236ms per matcher call before, ~0ms after; a warm walk went from 1.67s to under 0.01s.

Verdicts are unchanged. I diffed the matcher across 23 process shapes (version-named installs, hook script paths, bare interpreters, pi/pi-signed, cursor's real shapes and lookalikes) before and after: **byte-identical on every case**.

## Tests

`tests/fm-session-lock-ancestry.test.sh` gains a Windows layer that runs from any host through documented seams (`FM_PROC_PLATFORM_OVERRIDE`, `FM_PROC_SELF_PID_OVERRIDE`, `FM_PROC_MSYS_PROC_ROOT` — nothing in `bin/` sets them), because the platform it describes cannot be reached from CI:

- the walk crosses MSYS's exec boundary to reach the native harness — and **asserts the divergence**: with the MSYS link removed the walk finds nothing, so the case cannot go quietly vacuous
- a parent that starts after its own child is refused as a recycled id — and the same shape with a possible start time still resolves, so the refusal is the ordering check and not a broken fixture
- harness liveness is decided by the Win32 table rather than `kill`, using ids that do not exist on the host running the test
- an unreadable process table resolves no owner and claims no lock

The existing POSIX cases now pin their own branch explicitly rather than inheriting the host's, so the file is meaningful on either platform.

`docs/verification/runtime-backends.md` gains a dated Windows-host section carrying the evidence above.

## What was verified, and where

Verified on Windows 11 build 26200, Git for Windows bash (`MINGW64_NT-10.0-26200`), bash 5.3.15, Claude Code as primary harness:

- `bin/fm-lock.sh` acquires the lock and `bin/fm-session-start.sh` completes a full digest — both previously impossible
- `bin/fm-lint.sh` fully green (ShellCheck 0.11.0 pinned, actionlint 1.7.12 pinned, 3 workflows valid)
- `tests/fm-session-lock-ancestry.test.sh` unit layer 8/8, including the 4 new Windows cases
- `tests/fm-wake-queue.test.sh` and `tests/fm-watcher-lock.test.sh` produced no assertion failures

**I could not run the full suite on this host.** Its e2e layers spawn fixture trees that Windows cannot execute (`CreateProcessW failed` on a symlink to `/bin/bash`), and those same failures reproduce identically on unmodified `main` here, so they are a Windows fixture limitation rather than a regression. Linux CI is the authority for the full suite.

Two adjacent Windows gaps I did **not** touch, to keep this focused — both are recorded in the verification doc:

- `bin/fm-install-shellcheck.sh` supports linux/darwin only, so the pinned linter must be fetched by hand on Windows (upstream does publish `shellcheck-v0.11.0.zip`). Same for `bin/fm-install-actionlint.sh`.
- Detect-only bootstrap measures ~82s against the default 120s `FM_SESSION_START_TIMEOUT`, so the digest truncates intermittently until it is raised. Individual tool version probes cost 0.9–3.2s each; that is the tools' own startup, not firstmate's work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mm7UoJ8Jwspaqcm8iZMo8x
