### PR TITLE
fix(bin): keep fleet-sized snapshot documents out of jq's argv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,8 +377,8 @@ jobs:
           snapshot_output=$(/bin/bash tests/fm-fleet-snapshot-view.test.sh)
           printf '%s\n' "$snapshot_output"
           snapshot_count=$(printf '%s\n' "$snapshot_output" | grep -c '^ok - ')
-          [ "$snapshot_count" -eq 15 ] || {
-            echo "::error::expected 15 snapshot/fleet-view tests, got $snapshot_count"
+          [ "$snapshot_count" -eq 17 ] || {
+            echo "::error::expected 17 snapshot/fleet-view tests, got $snapshot_count"
             exit 1
           }
 

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -5,6 +5,8 @@
 # `fm-fleet-snapshot.v1`.
 # The command is read-only: it does not acquire the session lock, drain wakes,
 # arm watchers, mutate backlog state, or write reports.
+# It writes nothing at all: fleet-sized JSON documents reach jq through pipes,
+# not argv, so no scratch file is needed to stay under the execve argument limit.
 #
 # Top-level fields:
 #   schema: stable schema id.
@@ -195,6 +197,28 @@ case "${1:---json}" in
 esac
 
 command -v jq >/dev/null 2>&1 || { echo "fm-fleet-snapshot: jq not found" >&2; exit 1; }
+
+# jq arguments cross execve, which caps a SINGLE argument string far below the
+# total ARG_MAX (on Linux, MAX_ARG_STRLEN is 128 KiB). A document that grows
+# with the fleet - the backlog, the task inventory, a home summary, the
+# aggregated secondmate records - therefore reaches jq through a pipe rather
+# than argv, so the snapshot does not start failing once a home gets large
+# enough. The form is `--slurpfile <name> <(printf '%s' "$doc")`, read back in
+# the filter as `($<name>[0]) as $<binding>`, which leaves every filter body
+# below identical to the --argjson form it replaced. Nothing is staged on disk
+# and no signal trap is added, so the bounded, routinely killed cross-home reads
+# below still die promptly and leave nothing behind.
+# --argjson stays where the value is bounded by something other than fleet size:
+# a flag, a count, a single id, one task's own state or paths, or a surface an
+# FM_SNAPSHOT_* cap already truncates.
+require_json_docs() {  # <json-document>...
+  local doc
+  # An empty document stays the hard failure --argjson raised. Through a pipe it
+  # would otherwise slurp to [] and bind null, silently reshaping the output.
+  for doc in "$@"; do
+    [ -n "$doc" ] || return 1
+  done
+}
 
 bool_json() {
   if [ "$1" = 1 ]; then printf 'true'; else printf 'false'; fi
@@ -632,11 +656,14 @@ task_json_lines() {
 # Meta inventory remains the sole source of live workers; this object only
 # discloses backlog↔task inconsistency for renderers (Bearings omitted/gates).
 main_inventory_json() {  # <backlog-json> <tasks-json>
+  require_json_docs "$1" "$2" || return 1
   jq -n \
-    --argjson backlog "$1" \
-    --argjson tasks "$2" '
-    ([ $backlog.records[]?
-       | select((.state == "in_flight" or .state == "queued") and (.structured | not)) ]) as $unstructured_current
+    --slurpfile backlog_doc <(printf '%s' "$1") \
+    --slurpfile tasks_doc <(printf '%s' "$2") '
+    ($backlog_doc[0]) as $backlog
+    | ($tasks_doc[0]) as $tasks
+    | ([ $backlog.records[]?
+         | select((.state == "in_flight" or .state == "queued") and (.structured | not)) ]) as $unstructured_current
     | ([ $backlog.records[]?
          | select(.state == "in_flight" and .structured and .requires_child_metadata) ]) as $owned_in_flight
     | ([ $owned_in_flight[]
@@ -660,6 +687,7 @@ main_inventory_json() {  # <backlog-json> <tasks-json>
 # This mode never reads parent events or terminal text and never aggregates
 # nested secondmates.
 secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
+  require_json_docs "$1" "$2" || return 1
   jq -n \
     --arg generated "$SNAPSHOT_NOW" \
     --arg home "$FM_HOME" \
@@ -667,9 +695,11 @@ secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
     --argjson queued_n "$FM_SNAPSHOT_SECONDMATE_QUEUED" \
     --argjson decisions_n "$FM_SNAPSHOT_SECONDMATE_DECISIONS" \
     --argjson landed_n "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" \
-    --argjson backlog "$1" \
-    --argjson tasks "$2" '
-    def trunc($n):
+    --slurpfile backlog_doc <(printf '%s' "$1") \
+    --slurpfile tasks_doc <(printf '%s' "$2") '
+    ($backlog_doc[0]) as $backlog
+    | ($tasks_doc[0]) as $tasks
+    | def trunc($n):
       tostring | gsub("\\s+"; " ")
       | if length > $n then .[:$n] + "…" else . end;
     ([ $backlog.records[]?
@@ -1079,8 +1109,10 @@ terminal_evidence_json() {  # <parent-task-json> <event-note> <evidence-contradi
 }
 
 parent_evidence_reconciliation_json() {  # <summary-json> <activities-json> <decisions-json>
-  jq -n --argjson summary "$1" --argjson activities "$2" --argjson decisions "$3" '
-    def keyed: . != null and . != "" and . != "default";
+  require_json_docs "$1" || return 1
+  jq -n --slurpfile summary_doc <(printf '%s' "$1") --argjson activities "$2" --argjson decisions "$3" '
+    ($summary_doc[0]) as $summary
+    | def keyed: . != null and . != "" and . != "default";
     def result($e; $matches; $complete; $surface):
       $e + {
         verdict:(if ($e.key | keyed | not) then "inconclusive"
@@ -1141,11 +1173,15 @@ parent_evidence_reconciliation_json() {  # <summary-json> <activities-json> <dec
 secondmate_current_json() {  # <parent-tasks-json>
   local tasks=$1 registry union rows total_registered total shown truncated
   local row id home host remote registered registry_error task status_file event_raw event_note event_epoch event_age
-  local activity_scan activities decisions reconciliation provenance freshness reason summary summary_rc summary_bytes summary_valid summary_reason summary_invalidity state current_reason terminal terminal_contradiction contradiction
+  local activity_scan activities decisions reconciliation provenance freshness reason summary summary_rc summary_bytes summary_valid summary_reason summary_invalidity state current_reason terminal terminal_contradiction contradiction registry_out
   local records='[]' seen_homes=''
   registry=$(registry_secondmates_json) || return 1
-  union=$(jq -n --argjson registry "$registry" --argjson tasks "$tasks" '
-    ($registry.records // []) as $registered
+  require_json_docs "$registry" "$tasks" || return 1
+  union=$(jq -n --slurpfile registry_doc <(printf '%s' "$registry") \
+                --slurpfile tasks_doc <(printf '%s' "$tasks") '
+    ($registry_doc[0]) as $registry
+    | ($tasks_doc[0]) as $tasks
+    | ($registry.records // []) as $registered
     | (($registered | map(.id)) // []) as $registered_ids
     | ([ $registered[] as $r
          | $r + {parent_task:([$tasks[] | select(.id == $r.id)][0] // null)} ]
@@ -1283,22 +1319,24 @@ secondmate_current_json() {  # <parent-tasks-json>
           '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"not-collected",reason:"no useful contradiction check",lines:0,bytes:0,event_note_seen:false,contradiction:false}')
       fi
       if printf '%s' "$terminal" | jq -e '.contradiction == true' >/dev/null; then contradiction=true; fi
+      require_json_docs "$summary" || return 1
       record=$(jq -n \
         --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg state "$state" --arg current_reason "$current_reason" --arg observed "$SNAPSHOT_NOW" \
-        --argjson registered "$registered" --argjson summary "$summary" --argjson summary_valid "$summary_valid" --argjson decisions "$decisions" \
+        --argjson registered "$registered" --slurpfile summary_doc <(printf '%s' "$summary") --argjson summary_valid "$summary_valid" --argjson decisions "$decisions" \
         --argjson activities "$activities" --argjson activity_scan "$activity_scan" \
         --argjson reconciliation "$reconciliation" --argjson terminal "$terminal" --argjson contradiction "$contradiction" \
         --arg event_raw "$event_raw" --arg event_note "$event_note" --argjson event_age "$event_age" '
-        {id:$id,home:$home,host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
-         current:{state:$state,reason:($current_reason | if . == "" then null else . end)},invalidity:$summary.invalidity,
-         provenance:{selected:"structured-home",structured_home:$home,summary_valid:$summary_valid,
-           trust:(if $summary_valid then "complete" else "partial-structured" end),parent_event_role:"historical-only"},
-         freshness:{status:"fresh",observed_at:$observed,age_seconds:0},
-         active_children:$summary.active_children,
-         decisions_open:$summary.decisions_open,holds:$summary.holds,queued:$summary.queued,
-         landed:$summary.landed,endpoints:$summary.endpoints,counts:$summary.counts,omitted:$summary.omitted,
-         parent_event:{raw:$event_raw,note:$event_note,age_seconds:$event_age,open_activities:$activities,open_decisions:$decisions,activity_scan:$activity_scan,reconciliation:$reconciliation},
-         terminal_evidence:$terminal,contradiction:$contradiction}')
+        ($summary_doc[0]) as $summary
+        | {id:$id,home:$home,host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
+           current:{state:$state,reason:($current_reason | if . == "" then null else . end)},invalidity:$summary.invalidity,
+           provenance:{selected:"structured-home",structured_home:$home,summary_valid:$summary_valid,
+             trust:(if $summary_valid then "complete" else "partial-structured" end),parent_event_role:"historical-only"},
+           freshness:{status:"fresh",observed_at:$observed,age_seconds:0},
+           active_children:$summary.active_children,
+           decisions_open:$summary.decisions_open,holds:$summary.holds,queued:$summary.queued,
+           landed:$summary.landed,endpoints:$summary.endpoints,counts:$summary.counts,omitted:$summary.omitted,
+           parent_event:{raw:$event_raw,note:$event_note,age_seconds:$event_age,open_activities:$activities,open_decisions:$decisions,activity_scan:$activity_scan,reconciliation:$reconciliation},
+           terminal_evidence:$terminal,contradiction:$contradiction}')
     else
       if [ -n "$event_raw" ]; then
         provenance='parent-event-fallback'
@@ -1326,35 +1364,42 @@ secondmate_current_json() {  # <parent-tasks-json>
          parent_event:{raw:$event_raw,note:$event_note,age_seconds:$event_age,open_activities:$activities,open_decisions:$decisions,activity_scan:$activity_scan},
          terminal_evidence:$terminal,contradiction:false}')
     fi
-    records=$(jq -n --argjson records "$records" --argjson record "$record" '$records + [$record]')
+    require_json_docs "$record" || return 1
+    records=$(printf '%s' "$records" | jq --slurpfile record <(printf '%s' "$record") '. + [$record[0]]') || return 1
   done <<EOF
 $rows
 EOF
+  registry_out=$(printf '%s' "$union" | jq '.registry') || return 1
+  require_json_docs "$registry_out" "$records" || return 1
   jq -n \
-    --argjson registry "$(printf '%s' "$union" | jq '.registry')" \
-    --argjson records "$records" \
+    --slurpfile registry_doc <(printf '%s' "$registry_out") \
+    --slurpfile records_doc <(printf '%s' "$records") \
     --argjson total_registered "$total_registered" \
     --argjson total "$total" \
     --argjson shown "$shown" \
     --argjson truncated "$truncated" \
-    '{registry:$registry,records:$records,total_registered:$total_registered,total:$total,shown:$shown,truncated:$truncated}'
+    '($registry_doc[0]) as $registry
+     | ($records_doc[0]) as $records
+     | {registry:$registry,records:$records,total_registered:$total_registered,total:$total,shown:$shown,truncated:$truncated}'
 }
 
 secondmate_landed_from_current_json() {  # <secondmate-current-json>
-  jq -n --argjson current "$1" '
-    {records:[ $current.records[]
-      | select(.provenance.selected == "structured-home") as $mate
-      | $mate.landed[]
-      | . + {home:$mate.home,home_id:$mate.id}],
-     truncated:[ $current.records[]
-       | select(.provenance.selected == "structured-home" and (.counts.landed > (.landed | length)))
-       | .home],
-     unreadable:[ $current.records[]
-       | select(.current.state == "unknown" and .provenance.selected != "structured-home")
-       | .home // ("<" + .id + ": unavailable>")],
-     partial:[ $current.records[]
-       | select(.current.state == "unknown" and .provenance.selected == "structured-home")
-       | .home // ("<" + .id + ": partial>")]}
+  require_json_docs "$1" || return 1
+  jq -n --slurpfile current_doc <(printf '%s' "$1") '
+    ($current_doc[0]) as $current
+    | {records:[ $current.records[]
+        | select(.provenance.selected == "structured-home") as $mate
+        | $mate.landed[]
+        | . + {home:$mate.home,home_id:$mate.id}],
+       truncated:[ $current.records[]
+         | select(.provenance.selected == "structured-home" and (.counts.landed > (.landed | length)))
+         | .home],
+       unreadable:[ $current.records[]
+         | select(.current.state == "unknown" and .provenance.selected != "structured-home")
+         | .home // ("<" + .id + ": unavailable>")],
+       partial:[ $current.records[]
+         | select(.current.state == "unknown" and .provenance.selected == "structured-home")
+         | .home // ("<" + .id + ": partial>")]}
     | .records |= sort_by([(.completion.date // ""), .id]) | .records |= reverse'
 }
 
@@ -1390,6 +1435,10 @@ SECONDMATE_CURRENT_JSON=$(secondmate_current_json "$TASKS_JSON") \
 SECONDMATE_LANDED_JSON=$(secondmate_landed_from_current_json "$SECONDMATE_CURRENT_JSON") \
   || { echo "fm-fleet-snapshot: secondmate landed projection failed" >&2; exit 1; }
 
+require_json_docs "$BACKLOG_JSON" "$TASKS_JSON" "$MAIN_INVENTORY_JSON" \
+  "$SCOUT_REPORTS_JSON" "$SECONDMATE_CURRENT_JSON" "$SECONDMATE_LANDED_JSON" \
+  || { echo "fm-fleet-snapshot: empty snapshot document" >&2; exit 1; }
+
 jq -n \
   --arg generated "$SNAPSHOT_NOW" \
   --arg fm_home "$FM_HOME" \
@@ -1398,13 +1447,19 @@ jq -n \
   --arg data "$DATA" \
   --arg config "$CONFIG" \
   --arg projects "$PROJECTS" \
-  --argjson backlog "$BACKLOG_JSON" \
-  --argjson tasks "$TASKS_JSON" \
-  --argjson main_inventory "$MAIN_INVENTORY_JSON" \
-  --argjson scout_reports "$SCOUT_REPORTS_JSON" \
-  --argjson secondmate_current "$SECONDMATE_CURRENT_JSON" \
-  --argjson secondmate_landed "$SECONDMATE_LANDED_JSON" \
-  'def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
+  --slurpfile backlog_doc <(printf '%s' "$BACKLOG_JSON") \
+  --slurpfile tasks_doc <(printf '%s' "$TASKS_JSON") \
+  --slurpfile main_inventory_doc <(printf '%s' "$MAIN_INVENTORY_JSON") \
+  --slurpfile scout_reports_doc <(printf '%s' "$SCOUT_REPORTS_JSON") \
+  --slurpfile secondmate_current_doc <(printf '%s' "$SECONDMATE_CURRENT_JSON") \
+  --slurpfile secondmate_landed_doc <(printf '%s' "$SECONDMATE_LANDED_JSON") \
+  '($backlog_doc[0]) as $backlog
+   | ($tasks_doc[0]) as $tasks
+   | ($main_inventory_doc[0]) as $main_inventory
+   | ($scout_reports_doc[0]) as $scout_reports
+   | ($secondmate_current_doc[0]) as $secondmate_current
+   | ($secondmate_landed_doc[0]) as $secondmate_landed
+   | def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
    def task_by_id($id): ($tasks[]? | select(.id == $id) | .) // null;
    def report_kind($id): (task_by_id($id).kind // backlog_by_id($id).kind // "scout");
    {

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -799,6 +799,95 @@ test_parked_scout_decision_stays_pending() {
   pass "a scout still parked at a decision stays pending (terminal clear does not over-fire)"
 }
 
+# The snapshot hands whole JSON documents to jq. execve caps ONE argument string
+# far below the total ARG_MAX (on Linux, MAX_ARG_STRLEN is 128 KiB), so once a
+# home's backlog document crossed that ceiling the whole snapshot aborted with
+# "Argument list too long" before jq ever ran. Size the fixture from the ceiling
+# this host actually enforces, rather than a guess, so the regression is neither
+# needlessly slow here nor vacuous on a platform with a different cap.
+probe_single_arg_ceiling() {  # smallest refused single-argument size, 0 if none
+  local n=32768 blob
+  while [ "$n" -le 2097152 ]; do
+    blob=$(head -c "$n" /dev/zero | tr '\0' a)
+    env true "$blob" 2>/dev/null || { printf '%s\n' "$n"; return 0; }
+    n=$((n * 2))
+  done
+  printf '%s\n' 0
+}
+
+write_oversize_backlog() {  # <home> <record-count>
+  local home=$1 records=$2 i=1
+  {
+    printf '## Queued\n'
+    while [ "$i" -le "$records" ]; do
+      printf -- '- [ ] argv-task-%05d - Queued task %05d with a title long enough to give every record real weight (repo: alpha) (kind: ship) (since 2026-07-08)\n' \
+        "$i" "$i"
+      i=$((i + 1))
+    done
+  } > "$home/data/backlog.md"
+}
+
+test_backlog_larger_than_one_argv_string() {
+  local home ceiling records out backlog_bytes summary
+  ceiling=$(probe_single_arg_ceiling)
+  if [ "$ceiling" -eq 0 ]; then
+    echo "skip: this host accepts a 2 MiB single argument, so the argv ceiling cannot be sized"
+    return 0
+  fi
+  home=$(make_home argv-ceiling)
+  # ~600 compact JSON bytes per record is a deliberate underestimate, so the
+  # fixture overshoots the ceiling; the assertion below proves it actually did.
+  records=$((ceiling / 600 + 40))
+  write_oversize_backlog "$home" "$records"
+
+  out=$(FM_HOME="$home" "$SNAPSHOT" --json) \
+    || fail "snapshot must survive a backlog document larger than one argv string ($records records)"
+  printf '%s' "$out" | jq -e . >/dev/null \
+    || fail "snapshot over an oversize backlog must still be valid JSON"
+
+  # Compact bytes understate the document the snapshot actually carries, so
+  # clearing the ceiling here means the pre-fix argv form cleared it too.
+  backlog_bytes=$(printf '%s' "$out" | jq -c '.backlog' | LC_ALL=C wc -c | tr -d ' ')
+  [ "$backlog_bytes" -gt "$ceiling" ] \
+    || fail "fixture proves nothing: backlog document is $backlog_bytes bytes, this host refuses $ceiling"
+
+  printf '%s' "$out" | jq -e --argjson n "$records" '
+    .schema == "fm-fleet-snapshot.v1"
+      and (.backlog.records | length) == $n
+      and .main_inventory.valid == true
+      and .main_inventory.unstructured_current_count == 0
+  ' >/dev/null || fail "oversize-backlog snapshot lost records or inventory validity"
+
+  # The home-summary mode carries the same two documents into a different jq
+  # call, so it has the same ceiling and needs the same proof.
+  summary=$(FM_HOME="$home" "$SNAPSHOT" --secondmate-home-summary) \
+    || fail "the home-summary mode must survive the same oversize backlog document"
+  printf '%s' "$summary" | jq -e --argjson n "$records" '
+    .schema == "fm-secondmate-home-summary.v1" and .counts.queued == $n
+  ' >/dev/null || fail "oversize-backlog home summary malformed or lost queued items: $summary"
+
+  pass "a backlog document larger than one argv string still produces a complete snapshot ($records records over a $ceiling-byte ceiling)"
+}
+
+# The documented contract is that the snapshot stages nothing on disk: the
+# oversize documents above reach jq through pipes, so a run under a private
+# TMPDIR must leave that directory exactly as empty as it found it. A staged
+# scratch file would also need a signal trap to survive the bounded, routinely
+# killed cross-home reads, so "wrote nothing" is the property worth pinning.
+test_snapshot_stages_nothing_on_disk() {
+  local home scratch left
+  home=$(make_home tmpdir-untouched)
+  scratch=$TMP_ROOT/tmpdir-probe
+  rm -rf "$scratch"
+  mkdir -p "$scratch"
+  TMPDIR="$scratch" FM_HOME="$home" "$SNAPSHOT" --json >/dev/null \
+    || fail "snapshot failed while running under a private TMPDIR"
+  left=$(find "$scratch" -mindepth 1 | wc -l | tr -d ' ')
+  [ "$left" -eq 0 ] \
+    || fail "snapshot left $left entries behind in its TMPDIR: $(find "$scratch" -mindepth 1)"
+  pass "the snapshot stages no documents on disk and leaves its TMPDIR empty"
+}
+
 test_empty_fleet_json
 test_fixture_snapshot_json
 test_main_inventory_orphan_and_unstructured_disclosure
@@ -810,6 +899,8 @@ test_open_decision_transfers_to_captain_hold
 test_open_decision_clears_on_keyed_resolution
 test_completed_scout_report_is_pointer_not_pending
 test_parked_scout_decision_stays_pending
+test_backlog_larger_than_one_argv_string
+test_snapshot_stages_nothing_on_disk
 test_scout_reports_include_teardown_reports
 test_backlog_tasks_axi_forms_and_overrides
 test_view_renders_snapshot


### PR DESCRIPTION
## Intent

Fix bin/fm-bearings-snapshot.sh failing outright with "jq: Argument list too long" / "fm-fleet-snapshot: main inventory summary failed".

Root cause: bin/fm-fleet-snapshot.sh's main_inventory_json() passed whole JSON documents to jq on the command line via --argjson backlog "$1" and --argjson tasks "$2". With 67 backlog records the serialized document exceeds the kernel's argv limit, so execve refuses before jq ever runs. It is a hard size ceiling, not a jq bug, and it only worsens as the backlog grows.

Required fix: stop passing JSON documents through argv. Feed them to jq through files or stdin - --slurpfile/--rawfile against a temp file, or piping one document in and reading the other with --slurpfile, whichever reads more naturally in the surrounding code. Keep the function's signature and its output contract byte-identical so every caller is unaffected.

Required audit: audit the rest of the file in the same change. main_inventory_json is where it surfaced, but any other --argjson carrying a document that grows with the fleet has the same latent ceiling. Fix every instance found; leave --argjson alone where the value is genuinely small and bounded (a flag, a count, a single id).

Required test: ship a test that fails without this change - construct a backlog document large enough to exceed getconf ARG_MAX on the host, run the snapshot, and assert it produces valid output rather than erroring. Follow whatever test convention this repo already uses; do not invent a new harness.

Required verification: run bin/fm-bearings-snapshot.sh against the real home and confirm it returns a complete snapshot.

Decisions and tradeoffs made while doing the work, which a reviewer reading only the diff would not know:

- Chose process substitution with --slurpfile (`--slurpfile <name> <(printf '%s' "$doc")`, read back as `($<name>[0]) as $<binding>`) over staging a temp file. Deliberate: nothing is staged on disk, so no signal trap is needed, and the bounded, routinely killed cross-home reads elsewhere in this script still die promptly and leave nothing behind. The binding form was chosen specifically so every jq filter body stays identical to the --argjson form it replaced, keeping the output contract byte-identical.
- Converted every document that grows with the fleet: main_inventory_json, secondmate_home_summary_json, parent_evidence_reconciliation_json, secondmate_current_json (including its per-record accumulator, which previously rebuilt the whole array through argv on every iteration), secondmate_landed_from_current_json, and the top-level snapshot assembly.
- Deliberately left --argjson in place where the value is bounded by something other than fleet size: flags, counts, a single id, one task's own state or paths, and surfaces an FM_SNAPSHOT_* cap already truncates. This is the brief's explicit instruction, not an oversight. Per-task open_decisions is bounded by that one task's own distinct open keys, not by fleet size, so it stays on --argjson too.
- Added a require_json_docs guard because the failure modes differ: --argjson rejected an empty document outright, but through a pipe an empty document slurps to [] and binds null, which would silently reshape the output instead of failing. Keeping that a hard failure is intentional.
- The regression test sizes its fixture from the ceiling the host actually enforces (probing for the smallest refused single-argument size) rather than a hardcoded guess, and then asserts the resulting document really did clear that ceiling - so the test is neither needlessly slow on this host nor silently vacuous on a platform with a different cap. It covers both the canonical --json mode and the --secondmate-home-summary mode, which carries the same two documents into a different jq call.
- Also added a test for the newly documented "stages nothing on disk" contract (a run under a private TMPDIR must leave it empty). This replaced an earlier test of mine that asserted cleanup of a scratch directory - that test was left over from a temp-file design I abandoned for the pipe design, so it named a mechanism that no longer exists and could never fail.

Constraints: this is firstmate's own shared tracked material, so firstmate-coding-guidelines applies - bin/*.sh must pass shellcheck and bin/fm-lint.sh, tests stay colocated in tests/ extending the existing tests/fm-fleet-snapshot-view.test.sh rather than adding a runner, one sentence per line in tracked markdown, plain dash never an em dash, and no agent co-author on the commit.

Verified before this run: the new test fails without the fix with the exact reported error ("jq: Argument list too long", 258 records over this host's 131072-byte ceiling); the full tests/fm-fleet-snapshot-view.test.sh suite is 17/17 green with it; bin/fm-lint.sh passes (ShellCheck 0.11.0, actionlint 1.7.12); and bin/fm-bearings-snapshot.sh against the real home returns rc=0 with a complete snapshot (64 backlog records, 8 tasks, 2 secondmates, main_inventory.valid true).

Known and deliberately out of scope: tests/fm-bearings-snapshot.test.sh fails on this machine under load, with its bounded cross-home reads reporting "structured home snapshot timed out" at a load average around 19. That failure reproduces at HEAD without this change and the failing test moves between runs, so it is a pre-existing load-sensitive flake, not a regression from this work, and it is deliberately not fixed here.

## What Changed

- In `bin/fm-fleet-snapshot.sh`, replaced `--argjson` with `--slurpfile <name> <(printf '%s' "$doc")` (bound back via `($<name>[0]) as $<binding>`) for every JSON document whose size grows with the fleet, so large documents reach `jq` through a pipe instead of argv and stop tripping the kernel's per-argument execve limit: `main_inventory_json`, `secondmate_home_summary_json`, `parent_evidence_reconciliation_json`, `secondmate_current_json` (including its per-record accumulator, previously rebuilt through argv on every loop iteration), `secondmate_landed_from_current_json`, and the top-level snapshot assembly.
- Left `--argjson` in place for values bounded independently of fleet size (flags, counts, a single id, one task's own state, an already-truncated `FM_SNAPSHOT_*` surface).
- Added a `require_json_docs` guard so an empty document still hard-fails as it did under `--argjson`, instead of silently slurping to `[]`/`null` and reshaping output.
- Added `tests/fm-fleet-snapshot-view.test.sh` coverage: a regression test sized from the host's actual `ARG_MAX` ceiling for both `--json` and `--secondmate-home-summary` modes, plus a test asserting the snapshot stages nothing on disk under a private `TMPDIR`.

## Risk Assessment

✅ Low: The change mechanically replaces --argjson with guarded --slurpfile/process-substitution at every site that carries a fleet-sized document (verified via grep that all --slurpfile call sites have a matching require_json_docs guard, and that all remaining --argjson uses carry genuinely bounded scalars/single-record values, matching the stated audit scope), preserves each jq filter body unchanged apart from the added binding preamble, adds a require_json_docs guard with correct empty-vs-null semantics, and ships a regression test that sizes its fixture from the host's actual argv ceiling and asserts both output validity and that the fixture genuinely exceeds the ceiling; no risky, ambiguous, or unverified behavior was found.

## Testing

All 17 tests in tests/fm-fleet-snapshot-view.test.sh pass against the fix, the two new regression tests were confirmed to fail with the exact pre-fix error against the base commit's script, and manual end-to-end runs of both bin/fm-fleet-snapshot.sh --json and its bin/fm-bearings-snapshot.sh wrapper against a 300-record synthetic backlog completed successfully (rc=0, valid output) - the author's real firstmate home referenced in the intent's verification note is not reachable from this isolated test worktree, so a synthetic large-backlog home was substituted to demonstrate the same end-to-end path.

<details>
<summary>Evidence: Pre-fix regression test output (confirms failure without the change)</summary>

```text
/tmp/fm-base-check/bin/fm-fleet-snapshot.sh: line 635: /home/dev/.local/share/mise/installs/jq/1.8.2/jq: Argument list too long
fm-fleet-snapshot: main inventory summary failed
not ok - snapshot must survive a backlog document larger than one argv string (258 records)
```
</details>
<details>
<summary>Evidence: Manual fm-bearings-snapshot.sh run against a small synthetic home</summary>

```text
schema: fm-bearings.v1
home: tmp/fm-manual-home
generated: "2026-08-22T04:00:32Z"
prs: "not_requested (run: /bearings include PRs)"
in_flight: []
secondmates: []
decisions_open: []
landed[1]{id,what,artifact,owner}:
  done-task-1,Done Task One,"-",(main)
gates[2]{id,title,blocked_by,reason,owner}:
  queued-task-1,Queued Task One,"-","-",(main)
  queued-task-2,Queued Task Two,"-","-",(main)
reports: []
recorded_prs: []
omitted[7]{surface,reveal}:
  backlog item bodies,"--fields bodies"
  task paths,"--fields paths"
  watch/steer actions,"--fields actions"
  healthy endpoint detail,"--fields endpoints"
  full scout-report inventory,"--all-reports"
  superseded or prose-deferred queued items,"--all-queued"
  live PR discovery + checks,"--include-prs"
```
</details>
<details>
<summary>Evidence: Manual fm-bearings-snapshot.sh run against a 300-record oversize backlog</summary>

```text
schema: fm-bearings.v1
home: tmp/fm-manual-home-big
generated: "2026-08-22T04:00:48Z"
prs: "not_requested (run: /bearings include PRs)"
in_flight: []
secondmates: []
decisions_open: []
landed: []
gates[20]{id,title,blocked_by,reason,owner}:
  argv-task-00001,Queued task 00001 with a title long enough to give every rec…,"-","-",(main)
  argv-task-00002,Queued task 00002 with a title long enough to give every rec…,"-","-",(main)
  argv-task-00003,Queued task 00003 with a title long enough to give every rec…,"-","-",(main)
  argv-task-00004,Queued task 00004 with a title long enough to give every rec…,"-","-",(main)
  argv-task-00005,Queued task 00005 with a title long enough to give every rec…,"-","-",(main)
  argv-task-00006,Queued task 00006 with a title long enough to give every rec…,"-","-",(main)
  argv-task-00007,Queued task 00007 with a title long enough to give every rec…,"-","-",(main)
  argv-task-00008,Queued task 00008 with a title long enough to give every rec…,"-","-",(main)
  argv-task-00009,Queued task 00009 with a title long enough to give every rec…,"-","-",(main)
  argv-task-00010,Queued task 00010 with a title long enough to give every rec…,"-","-",(main)
  argv-task-00011,Queued task 00011 with a title long enough to give every rec…,"-","-",(main)
  argv-task-00012,Queued task 00012 with a title long enough to give every rec…,"-","-",(main)
  argv-task-00013,Queued task 00013 with a title long enough to give every rec…,"-","-",(main)
  argv-task-00014,Queued task 00014 with a title long enough to give every rec…,"-","-",(main)
  argv-task-00015,Queued task 00015 with a title long enough to give every rec…,"-","-",(main)
  argv-task-00016,Queued task 00016 with a title long enough to give every rec…,"-","-",(main)
  argv-task-00017,Queued task 00017 with a title long enough to give every rec…,"-","-",(main)
  argv-task-00018,Queued task 00018 with a title long enough to give every rec…,"-","-",(main)
  argv-task-00019,Queued task 00019 with a title long enough to give every rec…,"-","-",(main)
  argv-task-00020,Queued task 00020 with a title long enough to give every rec…,"-","-",(main)
reports: []
recorded_prs: []
omitted[8]{surface,reveal}:
  backlog item bodies,"--fields bodies"
  task paths,"--fields paths"
  watch/steer actions,"--fields actions"
  healthy endpoint detail,"--fields endpoints"
  full scout-report inventory,"--all-reports"
  superseded or prose-deferred queued items,"--all-queued"
  gates showing 20 of 300,"--all-queued"
  live PR discovery + checks,"--include-prs"
```
</details>
<details>
<summary>Evidence: fm-fleet-snapshot.sh --json output over a 300-record oversize backlog</summary>

```text
{
  "schema": "fm-fleet-snapshot.v1",
  "generated": "2026-08-22T04:00:40Z",
  "fm_home": "/tmp/fm-manual-home-big",
  "roots": {
    "fm_root": "/home/dev/.no-mistakes/worktrees/5480956096ee/01M0KSNFGXYTFWK5WPCYR15JFJ",
    "state": "/tmp/fm-manual-home-big/state",
    "data": "/tmp/fm-manual-home-big/data",
    "config": "/tmp/fm-manual-home-big/config",
    "projects": "/tmp/fm-manual-home-big/projects"
  },
  "backlog": {
    "path": "/tmp/fm-manual-home-big/data/backlog.md",
    "present": true,
    "records": [
      {
        "order": 1,
        "state": "queued",
        "structured": true,
        "id": "argv-task-00001",
        "checked": false,
        "title": "Queued task 00001 with a title long enough to give every record real weight",
        "repo": "alpha",
        "kind": "ship",
        "priority": null,
        "hold_reason": null,
        "hold_kind": null,
        "hold_until": null,
        "blocked_by": null,
        "blocked_by_ids": [],
        "blocked_reason": null,
        "since": "2026-07-08",
        "merged": null,
        "reported": null,
        "done": null,
        "completion": {
          "verb": null,
          "date": null
        },
        "links": [],
        "pr_url": null,
        "report_path": null,
        "local_note": null,
        "raw": "- [ ] argv-task-00001 - Queued task 00001 with a title long enough to give every record real weight (repo: alpha) (kind: ship) (since 2026-07-08)",
        "body_lines": [],
        "body_excerpt": null,
        "unresolved_blocker_ids": [],
        "current_role": "queued",
        "requires_child_metadata": false,
        "captain_actionable": false,
        "deferred_marker": false
      },
      {
        "order": 2,
        "state": "queued",
        "structured": true,
        "id": "argv-task-00002",
        "checked": false,
        "title": "Queued task 00002 with a title long enough to give every record real weight",
        "repo": "alpha",
        "kind": "ship",
        "priority": null,
        "hold_reason": null,
        "hold_kind": null,
        "hold_until": null,
        "blocked_by": null,
        "blocked_by_ids": [],
        "blocked_reason": null,
        "since": "2026-07-08",
        "merged": null,
        "reported": null,
        "done": null,
        "completion": {
          "verb": null,
          "date": null
        },
        "links": [],
        "pr_url": null,
        "report_path": null,
        "local_note": null,
        "raw": "- [ ] argv-task-00002 - Queued task 00002 with a title long enough to give every record real weight (repo: alpha) (kind: ship) (since 2026-07-08)",
        "body_lines": [],
        "body_excerpt": null,
        "unresolved_blocker_ids": [],
        "current_role": "queued",
        "requires_child_metadata": false,
        "captain_actionable": false,
        "deferred_marker": false
      },
      {
        "order": 3,
        "state": "queued",
        "structured": true,
        "id": "argv-task-00003",
        "checked": false,
        "title": "Queued task 00003 with a title long enough to give every record real weight",
        "repo": "alpha",
        "kind": "ship",
        "priority": null,
        "hold_reason": null,
        "hold_kind": null,
        "hold_until": null,
        "blocked_by": null,
        "blocked_by_ids": [],
        "blocked_reason": null,
        "since": "2026-07-08",
        "merged": null,
        "reported": null,
        "done": null,
        "completion": {
          "verb": null,
          "date": null
        },
        "links": [],
        "pr_url": null,
        "report_path": null,
        "local_note": null,
        "raw": "- [ ] argv-task-00003 - Queued task 00003 with a title long enough to give every record real weight (repo: alpha) (kind: ship) (since 2026-07-08)",
        "body_lines": [],
        "body_excerpt": null,
        "unresolved_blocker_ids": [],
        "current_role": "queued",
        "requires_child_metadata": false,
        "captain_actionable": false,
        "deferred_marker": false
      },
      {
        "order": 4,
        "state": "queued",
        "structured": true,
        "id": "argv-task-00004",
        "checked": false,
        "title": "Queued task 00004 with a title long enough to give every record real weight",
        "repo": "alpha",
        "kind": "ship",
        "priority": null,
        "hold_reason": null,
        "hold_kind": null,
        "hold_until": null,
        "blocked_by": null,
        "blocked_by_ids": [],
        "blocked_reason": null,
        "since": "2026-07-08",
        "merged": null,
        "reported": null,
        "done": null,
        "completion": {
          "verb": null,
          "date": null
        },
        "links": [],
        "pr_url": null,
        "report_path": null,
        "local_note": null,
        "raw": "- [ ] argv-task-00004 - Queued task 00004 with a title long enough to give every record real weight (repo: alpha) (kind: ship) (since 2026-07-08)",
        "body_lines": [],
        "body_excerpt": null,
        "unresolved_blocker_ids": [],
        "current_role": "queued",
        "requires_child_metadata": false,
        "captain_actionable": false,
        "deferred_marker": false
      },
      {
        "order": 5,
        "state": "queued",
        "structured": true,
        "id": "argv-task-00005",
        "checked": false,
        "title": "Queued task 00005 with a title long enough to give every record real weight",
        "repo": "alpha",
        "kind": "ship",
        "priority": null,
        "hold_reason": null,
        "hold_kind": null,
        "hold_until": null,
        "blocked_by": null,
        "blocked_by_ids": [],
        "blocked_reason": null,
        "since": "2026-07-08",
        "merged": null,
        "reported": null,
        "done": null,
        "completion": {
          "verb": null,
          "date": null
        },
        "links": [],
        "pr_url": null,
        "report_path": null,
        "local_note": null,
        "raw": "- [ ] argv-task-00005 - Queued task 00005 with a title long enough to give every record real weight (repo: alpha) (kind: ship) (since 2026-07-08)",
        "body_lines": [],
        "body_excerpt": null,
        "unresolved_blocker_ids": [],
        "current_role": "queued",
        "requires_child_metadata": false,
        "captain_actionable": false,
        "deferred_marker": false
      },
      {
        "order": 6,
        "state": "queued",
        "structured": true,
        "id": "argv-task-00006",
        "checked": false,
        "title": "Queued task 00006 with a title long enough to give every record real weight",
        "repo": "alpha",
        "kind": "ship",
        "priority": null,
        "hold_reason": null,
        "hold_kind": null,
        "hold_until": null,
        "blocked_by": null,
        "blocked_by_ids": [],
        "blocked_reason": null,
        "since": "2026-07-08",
        "merged": null,
        "reported": null,
        "done": null,
        "completion": {
          "verb": null,
          "date": null
        },
        "links": [],
        "pr_url": null,
        "report_path": null,
        "local_note": null,
        "raw": "- [ ] argv-task-00006 - Queued task 00006 with a title long enough to give every record real weight (repo: alpha) (kind: ship) (since 2026-07-08)",
        "body_lines": [],
        "body_excerpt": null,
        "unresolved_blocker_ids": [],
        "current_role": "queued",
        "requires_child_metadata": false,
        "captain_actionable": false,
        "deferred_marker": false
      },
      {
        "order": 7,
        "state": "queued",
        "structured": true,
        "id": "argv-task-00007",
        "checked": false,
        "title": "Queued task 00007 with a title long enough to give every record real weight",
        "repo": "alpha",
        "kind": "ship",
        "priority": null,
        "hold_reason": null,
        "hold_kind": null,
        "hold_until": null,
        "blocked_by": null,
        "blocked_by_ids": [],
        "blocked_reason": null,
        "since": "2026-07-08",
        "merged": null,
     

... [341884 bytes truncated] ...

d": "argv-task-00295",
        "checked": false,
        "title": "Queued task 00295 with a title long enough to give every record real weight",
        "repo": "alpha",
        "kind": "ship",
        "priority": null,
        "hold_reason": null,
        "hold_kind": null,
        "hold_until": null,
        "blocked_by": null,
        "blocked_by_ids": [],
        "blocked_reason": null,
        "since": "2026-07-08",
        "merged": null,
        "reported": null,
        "done": null,
        "completion": {
          "verb": null,
          "date": null
        },
        "links": [],
        "pr_url": null,
        "report_path": null,
        "local_note": null,
        "raw": "- [ ] argv-task-00295 - Queued task 00295 with a title long enough to give every record real weight (repo: alpha) (kind: ship) (since 2026-07-08)",
        "body_lines": [],
        "body_excerpt": null,
        "unresolved_blocker_ids": [],
        "current_role": "queued",
        "requires_child_metadata": false,
        "captain_actionable": false,
        "deferred_marker": false
      },
      {
        "order": 296,
        "state": "queued",
        "structured": true,
        "id": "argv-task-00296",
        "checked": false,
        "title": "Queued task 00296 with a title long enough to give every record real weight",
        "repo": "alpha",
        "kind": "ship",
        "priority": null,
        "hold_reason": null,
        "hold_kind": null,
        "hold_until": null,
        "blocked_by": null,
        "blocked_by_ids": [],
        "blocked_reason": null,
        "since": "2026-07-08",
        "merged": null,
        "reported": null,
        "done": null,
        "completion": {
          "verb": null,
          "date": null
        },
        "links": [],
        "pr_url": null,
        "report_path": null,
        "local_note": null,
        "raw": "- [ ] argv-task-00296 - Queued task 00296 with a title long enough to give every record real weight (repo: alpha) (kind: ship) (since 2026-07-08)",
        "body_lines": [],
        "body_excerpt": null,
        "unresolved_blocker_ids": [],
        "current_role": "queued",
        "requires_child_metadata": false,
        "captain_actionable": false,
        "deferred_marker": false
      },
      {
        "order": 297,
        "state": "queued",
        "structured": true,
        "id": "argv-task-00297",
        "checked": false,
        "title": "Queued task 00297 with a title long enough to give every record real weight",
        "repo": "alpha",
        "kind": "ship",
        "priority": null,
        "hold_reason": null,
        "hold_kind": null,
        "hold_until": null,
        "blocked_by": null,
        "blocked_by_ids": [],
        "blocked_reason": null,
        "since": "2026-07-08",
        "merged": null,
        "reported": null,
        "done": null,
        "completion": {
          "verb": null,
          "date": null
        },
        "links": [],
        "pr_url": null,
        "report_path": null,
        "local_note": null,
        "raw": "- [ ] argv-task-00297 - Queued task 00297 with a title long enough to give every record real weight (repo: alpha) (kind: ship) (since 2026-07-08)",
        "body_lines": [],
        "body_excerpt": null,
        "unresolved_blocker_ids": [],
        "current_role": "queued",
        "requires_child_metadata": false,
        "captain_actionable": false,
        "deferred_marker": false
      },
      {
        "order": 298,
        "state": "queued",
        "structured": true,
        "id": "argv-task-00298",
        "checked": false,
        "title": "Queued task 00298 with a title long enough to give every record real weight",
        "repo": "alpha",
        "kind": "ship",
        "priority": null,
        "hold_reason": null,
        "hold_kind": null,
        "hold_until": null,
        "blocked_by": null,
        "blocked_by_ids": [],
        "blocked_reason": null,
        "since": "2026-07-08",
        "merged": null,
        "reported": null,
        "done": null,
        "completion": {
          "verb": null,
          "date": null
        },
        "links": [],
        "pr_url": null,
        "report_path": null,
        "local_note": null,
        "raw": "- [ ] argv-task-00298 - Queued task 00298 with a title long enough to give every record real weight (repo: alpha) (kind: ship) (since 2026-07-08)",
        "body_lines": [],
        "body_excerpt": null,
        "unresolved_blocker_ids": [],
        "current_role": "queued",
        "requires_child_metadata": false,
        "captain_actionable": false,
        "deferred_marker": false
      },
      {
        "order": 299,
        "state": "queued",
        "structured": true,
        "id": "argv-task-00299",
        "checked": false,
        "title": "Queued task 00299 with a title long enough to give every record real weight",
        "repo": "alpha",
        "kind": "ship",
        "priority": null,
        "hold_reason": null,
        "hold_kind": null,
        "hold_until": null,
        "blocked_by": null,
        "blocked_by_ids": [],
        "blocked_reason": null,
        "since": "2026-07-08",
        "merged": null,
        "reported": null,
        "done": null,
        "completion": {
          "verb": null,
          "date": null
        },
        "links": [],
        "pr_url": null,
        "report_path": null,
        "local_note": null,
        "raw": "- [ ] argv-task-00299 - Queued task 00299 with a title long enough to give every record real weight (repo: alpha) (kind: ship) (since 2026-07-08)",
        "body_lines": [],
        "body_excerpt": null,
        "unresolved_blocker_ids": [],
        "current_role": "queued",
        "requires_child_metadata": false,
        "captain_actionable": false,
        "deferred_marker": false
      },
      {
        "order": 300,
        "state": "queued",
        "structured": true,
        "id": "argv-task-00300",
        "checked": false,
        "title": "Queued task 00300 with a title long enough to give every record real weight",
        "repo": "alpha",
        "kind": "ship",
        "priority": null,
        "hold_reason": null,
        "hold_kind": null,
        "hold_until": null,
        "blocked_by": null,
        "blocked_by_ids": [],
        "blocked_reason": null,
        "since": "2026-07-08",
        "merged": null,
        "reported": null,
        "done": null,
        "completion": {
          "verb": null,
          "date": null
        },
        "links": [],
        "pr_url": null,
        "report_path": null,
        "local_note": null,
        "raw": "- [ ] argv-task-00300 - Queued task 00300 with a title long enough to give every record real weight (repo: alpha) (kind: ship) (since 2026-07-08)",
        "body_lines": [],
        "body_excerpt": null,
        "unresolved_blocker_ids": [],
        "current_role": "queued",
        "requires_child_metadata": false,
        "captain_actionable": false,
        "deferred_marker": false
      }
    ]
  },
  "tasks": [],
  "main_inventory": {
    "valid": true,
    "reason": null,
    "orphan_in_flight": [],
    "unstructured_current_count": 0
  },
  "scout_reports": [],
  "secondmate_current": {
    "registry": {
      "present": false,
      "available": true,
      "complete": true,
      "reason": null,
      "provenance": "registered-table",
      "path": "/tmp/fm-manual-home-big/data/secondmates.md",
      "freshness": {
        "status": "fresh",
        "observed_at": "2026-08-22T04:00:40Z"
      },
      "records": [],
      "input_truncated": false,
      "records_truncated": false,
      "reasons": [],
      "lines_in_window": 0,
      "records_in_window": 0
    },
    "records": [],
    "total_registered": 0,
    "total": 0,
    "shown": 0,
    "truncated": 0
  },
  "secondmate_landed": {
    "records": [],
    "truncated": [],
    "unreadable": [],
    "partial": []
  },
  "secondmate_guidance": {
    "note": "For kind=secondmate, bearings selects validated structured state from that registered home; parent events and bounded terminal evidence are fallback-only supplements and never current-state authority."
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-fleet-snapshot-view.test.sh` on the fix (db3ab48) - all 17 tests pass, including test_backlog_larger_than_one_argv_string (258 records over a 131072-byte ceiling) and test_snapshot_stages_nothing_on_disk</code>
- `Same two new tests run in isolation against the pre-fix bin/fm-fleet-snapshot.sh (base dc0172c) via a scratch copy - fails with the exact reported error: 'jq: Argument list too long' / 'fm-fleet-snapshot: main inventory summary failed'`
- <code>Manual end-to-end run: `FM_HOME=&lt;synthetic-home&gt; bin/fm-fleet-snapshot.sh --json` against a 300-record queued backlog - rc=0, valid JSON, backlog.records length 300, main_inventory.valid true</code>
- <code>Manual end-to-end run: `FM_HOME=&lt;synthetic-home&gt; bin/fm-bearings-snapshot.sh` against the same 300-record backlog - rc=0, complete TOON snapshot with 20-row gates table shown (bounded by default fields)</code>
- <code>Manual smoke run: `FM_HOME=&lt;small-synthetic-home&gt; bin/fm-bearings-snapshot.sh` against a 3-record backlog (queued/done mix) - rc=0, complete snapshot</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
