### PR TITLE
fix(crew-state): stop passed runs from implying PR landing

### DIFF
--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -497,10 +497,10 @@ if [ "$HAVE_RUN" = 1 ]; then
     if [ -n "$outcome" ]; then
       case "$outcome" in
         # `passed` is a claim about the pipeline's own nine steps completing.
-        # It says nothing about the forge: the PR may still be open awaiting
-        # a human merge decision, and only teardown's own pr_is_merged check
-        # establishes landing. Never render a landing claim here.
-        passed)        RUN_STATE="done"; RUN_DETAIL="run passed: PR awaiting review/merge" ;;
+        # It establishes nothing about the forge: the PR may still be open,
+        # already merged, or not exist. Only teardown's own pr_is_merged
+        # check establishes landing, so this detail stays neutral about it.
+        passed)        RUN_STATE="done"; RUN_DETAIL="run passed: pipeline complete" ;;
         checks-passed) RUN_STATE="done"; RUN_DETAIL="checks green: PR ready for review" ;;
         failed)        RUN_STATE=failed; RUN_DETAIL="run failed" ;;
         cancelled)     RUN_STATE=failed; RUN_DETAIL="run cancelled" ;;

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -496,7 +496,11 @@ if [ "$HAVE_RUN" = 1 ]; then
 
     if [ -n "$outcome" ]; then
       case "$outcome" in
-        passed)        RUN_STATE="done"; RUN_DETAIL="run passed: PR merged/closed" ;;
+        # `passed` is a claim about the pipeline's own nine steps completing.
+        # It says nothing about the forge: the PR may still be open awaiting
+        # a human merge decision, and only teardown's own pr_is_merged check
+        # establishes landing. Never render a landing claim here.
+        passed)        RUN_STATE="done"; RUN_DETAIL="run passed: PR awaiting review/merge" ;;
         checks-passed) RUN_STATE="done"; RUN_DETAIL="checks green: PR ready for review" ;;
         failed)        RUN_STATE=failed; RUN_DETAIL="run failed" ;;
         cancelled)     RUN_STATE=failed; RUN_DETAIL="run cancelled" ;;

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -671,6 +671,30 @@ test_terminal_passed() {
   pass "terminal passed run is authoritative"
 }
 
+test_terminal_passed_does_not_claim_landing() {
+  # Regression for issue #2421: a pipeline `passed` outcome is a claim about
+  # the run's own steps, not about the forge. The PR is typically still open
+  # awaiting a human merge decision, and rendering "PR merged/closed" invents
+  # landing the helper never established.
+  reset_fakes
+  local d; d=$(new_case passed-open-pr)
+  make_repo_on_branch "$d/wt" fm/feat-landing
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-landing.meta" "window=fm:fm-feat-landing" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_AXI_STATUS="$(run_passed fm/feat-landing)"
+  local out; out=$(run_crew_state "$d" feat-landing)
+  assert_contains "$out" "run passed" "passed run keeps its run claim"
+  assert_contains "$out" "awaiting review/merge" "detail names the PR as awaiting, not landed"
+  case "$out" in
+    *merged/closed*)
+      fail "passed run must not render a forge landing claim"
+      ;;
+    *)
+      pass "no landing claim for an outcome=passed run"
+      ;;
+  esac
+}
+
 test_terminal_failed() {
   reset_fakes
   local d; d=$(new_case failed)
@@ -1427,6 +1451,7 @@ test_ci_fixing_after_green_stays_working
 test_top_level_fixing_ci_running_after_green_stays_working
 test_top_level_fixing_done_log_stays_working
 test_terminal_passed
+test_terminal_passed_does_not_claim_landing
 test_terminal_failed
 test_cross_branch_attribution_via_runs_list
 test_cross_branch_attribution_picks_most_recent_row

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -673,9 +673,9 @@ test_terminal_passed() {
 
 test_terminal_passed_does_not_claim_landing() {
   # Regression for issue #2421: a pipeline `passed` outcome is a claim about
-  # the run's own steps, not about the forge. The PR is typically still open
-  # awaiting a human merge decision, and rendering "PR merged/closed" invents
-  # landing the helper never established.
+  # the run's own steps, not about the forge. The PR may be open, already
+  # merged, or absent; rendering "PR merged/closed" (the old wording) or any
+  # other forge state invents landing the helper never established.
   reset_fakes
   local d; d=$(new_case passed-open-pr)
   make_repo_on_branch "$d/wt" fm/feat-landing
@@ -684,13 +684,13 @@ test_terminal_passed_does_not_claim_landing() {
   FM_FAKE_AXI_STATUS="$(run_passed fm/feat-landing)"
   local out; out=$(run_crew_state "$d" feat-landing)
   assert_contains "$out" "run passed" "passed run keeps its run claim"
-  assert_contains "$out" "awaiting review/merge" "detail names the PR as awaiting, not landed"
+  assert_contains "$out" "pipeline complete" "detail stays neutral about the forge"
   case "$out" in
-    *merged/closed*)
-      fail "passed run must not render a forge landing claim"
+    *merged/closed*|*awaiting*review*)
+      fail "passed run must not render any forge claim about the PR"
       ;;
     *)
-      pass "no landing claim for an outcome=passed run"
+      pass "no forge claim for an outcome=passed run"
       ;;
   esac
 }


### PR DESCRIPTION
## What Changed

- Report a `passed` pipeline outcome as `pipeline complete` without claiming that its PR merged or closed.
- Add regression coverage that preserves the completed run state while rejecting unsupported forge-status claims.

## Risk Assessment

✅ Low: Captain, the change is narrowly scoped and truthfully maps a passed pipeline to pipeline completion without claiming unverified forge state; the regression test exercises observable helper output.

## Testing

No prior baseline command was supplied. The focused crew-state behavior suite passed, and a base-versus-target CLI counterfactual proved the fix end to end: the base falsely claimed `PR merged/closed`, while the target reports `run passed: pipeline complete` with or without a PR URL. CLI transcripts provide the reviewer-visible evidence; no UI screenshot applies to this shell-output change.

<details>
<summary>Evidence: Target commit CLI transcript</summary>

Source: [Target commit CLI transcript](https://github.com/Mr-Neutr0n/firstmate/blob/8587d49c1d18c9fadf6b0d8416d95181bd2fb2eb/.no-mistakes/evidence/fix/crew-state-passed-no-landing-claim/passed-run-cli-transcript.txt)

<code>Input: outcome=passed, PR field contains a URL&#10;state: done · source: run-step · run passed: pipeline complete&#10;Input: outcome=passed, PR field is empty&#10;state: done · source: run-step · run passed: pipeline complete</code>

```text
Input: outcome=passed, PR field contains a URL
state: done · source: run-step · run passed: pipeline complete
Input: outcome=passed, PR field is empty
state: done · source: run-step · run passed: pipeline complete
```
</details>
<details>
<summary>Evidence: Base commit regression reproduction</summary>

Source: [Base commit regression reproduction](https://github.com/Mr-Neutr0n/firstmate/blob/8587d49c1d18c9fadf6b0d8416d95181bd2fb2eb/.no-mistakes/evidence/fix/crew-state-passed-no-landing-claim/base-passed-run-cli-transcript.txt)

<code>Input: outcome=passed, PR field contains a URL&#10;state: done · source: run-step · run passed: PR merged/closed&#10;Input: outcome=passed, PR field is empty&#10;state: done · source: run-step · run passed: PR merged/closed</code>

```text
Input: outcome=passed, PR field contains a URL
state: done · source: run-step · run passed: PR merged/closed
Input: outcome=passed, PR field is empty
state: done · source: run-step · run passed: PR merged/closed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"068c5ce16e7929516d4b97a248fde402c882dbef","steps":[{"step":"intent","status":"skipped"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-crew-state.test.sh`
- <code>Executed the real target `bin/fm-crew-state.sh` with `outcome: passed` and both populated and empty PR fields using `passed-run-cli-evidence.sh`.</code>
- <code>Extracted base `dc0172c48b36a6303501af25d0915ad6e7d04192:bin/fm-crew-state.sh` with `git show` and ran the same CLI harness to reproduce the false `PR merged/closed` claim.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
