### PR TITLE
fix(procevent): prove listener liveness before lavish arm reports ready

### DIFF
--- a/bin/fm-procevent-lavish.sh
+++ b/bin/fm-procevent-lavish.sh
@@ -66,6 +66,8 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 . "$SCRIPT_DIR/fm-wake-lib.sh"
 # shellcheck source=bin/fm-procevent-lib.sh
 . "$SCRIPT_DIR/fm-procevent-lib.sh"
+# shellcheck source=bin/fm-timeout-lib.sh
+. "$SCRIPT_DIR/fm-timeout-lib.sh"
 
 die() { printf 'error: %s\n' "$1" >&2; exit 1; }
 usage() { sed -n '2,56p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 2; }
@@ -123,6 +125,29 @@ arm_now_ms() {
   printf '%s\n' "$(( sec * 1000 ))"
 }
 
+# cmd_arm's polling loop below only checks the wall clock BETWEEN probes, so
+# it decides whether to start another one but cannot stop an already-started
+# probe from running long. fm_procevent_generation_live's own work - a
+# try-once source lock, a claim read, a pid identity check - is normally a
+# handful of fast, non-blocking filesystem/process operations with nothing
+# that retries or waits on contention, but nothing in its contract actually
+# bounds how long any single one of those operations can take (e.g. unusually
+# slow disk I/O). Give every probe its own hard bound via fm_run_bash_timeout,
+# this repo's bash-native bounded-execution mechanism (bin/fm-timeout-lib.sh):
+# it runs the probe in a background subshell of THIS interpreter, so it calls
+# fm_procevent_generation_live directly rather than needing to re-exec a bare
+# process that never sourced fm-procevent-lib.sh, the way fm_run_timed's
+# preferred timeout/gtimeout/perl mechanisms would. The bound is a generous
+# safety ceiling relative to that normal sub-millisecond cost, so it is never
+# expected to fire in ordinary operation; it exists only so a single
+# unexpectedly stuck probe cannot grow arm's overrun past
+# FM_PROCEVENT_LAVISH_ARM_WAIT_MS by an unbounded amount.
+FM_PROCEVENT_LAVISH_ARM_PROBE_TIMEOUT_S=2
+arm_probe_live() {
+  fm_run_bash_timeout "$FM_PROCEVENT_LAVISH_ARM_PROBE_TIMEOUT_S" \
+    fm_procevent_generation_live "$1" "$2"
+}
+
 cmd_arm() {
   local artifact=${1-} id real reg_out identity wait_ms live deadline_ms now_ms remaining_ms frac first
   [ -n "$artifact" ] || usage
@@ -174,7 +199,7 @@ cmd_arm() {
       [ "$now_ms" -lt "$deadline_ms" ] || break
     fi
     first=0
-    if fm_procevent_generation_live "$id" "$identity"; then
+    if arm_probe_live "$id" "$identity"; then
       live=0
       break
     fi

--- a/bin/fm-procevent-lavish.sh
+++ b/bin/fm-procevent-lavish.sh
@@ -87,8 +87,35 @@ cmd_source_id() {
   fi
 }
 
+# Milliseconds since the epoch, used only to bound cmd_arm's listener-liveness
+# wait by wall clock. Counting fixed sleep intervals cannot bound elapsed time,
+# because every iteration also spends real time on fm_procevent_generation_live's
+# own work - a filesystem lock, claim load, and process-identity check - which a
+# sleep-only budget never accounts for. EPOCHREALTIME is a bash builtin (no
+# fork); a shell without it degrades to whole-second granularity rather than
+# losing the bound entirely.
+arm_now_ms() {
+  local raw sec frac
+  raw=${EPOCHREALTIME:-}
+  case "$raw" in
+    *[0-9][.,][0-9]*)
+      sec=${raw%%[.,]*}
+      frac=${raw#*[.,]}
+      frac="${frac}000"
+      frac=${frac:0:3}
+      case "$sec$frac" in
+        ''|*[!0-9]*) ;;
+        *) printf '%s\n' "$(( sec * 1000 + 10#$frac ))"; return 0 ;;
+      esac
+      ;;
+  esac
+  sec=$(date +%s 2>/dev/null || printf '0')
+  case "$sec" in ''|*[!0-9]*) sec=0 ;; esac
+  printf '%s\n' "$(( sec * 1000 ))"
+}
+
 cmd_arm() {
-  local artifact=${1-} id real reg_out identity wait_ms i=0 max live
+  local artifact=${1-} id real reg_out identity wait_ms live deadline_ms now_ms remaining_ms frac
   [ -n "$artifact" ] || usage
   [ "$#" -eq 1 ] || usage
   command -v lavish-axi >/dev/null 2>&1 || die "lavish-axi is not installed"
@@ -122,19 +149,22 @@ cmd_arm() {
   # Running it synchronously here would let that internal blocking silently
   # replace the documented bound with reconcile's own, possibly unbounded, one.
   "$SCRIPT_DIR/fm-procevent.sh" reconcile >/dev/null 2>&1 &
-  max=$((wait_ms / 50 + 1))
+  deadline_ms=$(( $(arm_now_ms) + wait_ms ))
   live=1
-  while [ "$i" -lt "$max" ]; do
+  while :; do
     if fm_procevent_generation_live "$id" "$identity"; then
       live=0
       break
     fi
-    i=$((i + 1))
-    # Only sleep before a check the loop bound still allows: sleeping after
-    # the final permitted check would push arm past FM_PROCEVENT_LAVISH_ARM_WAIT_MS
-    # for no benefit, since that sleep's result is never sampled.
-    [ "$i" -lt "$max" ] || break
-    sleep 0.05
+    # Always attempted at least once above; from here the wall clock alone
+    # decides whether another probe fits, since the probe just run may already
+    # have consumed most or all of the budget.
+    now_ms=$(arm_now_ms)
+    [ "$now_ms" -lt "$deadline_ms" ] || break
+    remaining_ms=$(( deadline_ms - now_ms ))
+    [ "$remaining_ms" -le 50 ] || remaining_ms=50
+    printf -v frac '%03d' "$remaining_ms"
+    sleep "0.$frac"
   done
   [ "$live" -eq 0 ] || die "listener for $id did not confirm live within ${wait_ms}ms"
   printf 'armed: %s\n' "$id"

--- a/bin/fm-procevent-lavish.sh
+++ b/bin/fm-procevent-lavish.sh
@@ -151,9 +151,20 @@ arm_now_ms() {
 # deadline still gets a real, if brief, chance to complete rather than a
 # zero/negative timeout, which fm_run_bash_timeout does not accept as a bound.
 # In ordinary operation a probe finishes in sub-millisecond time either way, so
-# this floor is the only overrun a caller can ever see past its own deadline.
+# on a hang, these two are the only overrun a caller can ever see past its own
+# deadline: the floor above, and FM_PROCEVENT_LAVISH_ARM_PROBE_TERM_GRACE_S
+# below.
 FM_PROCEVENT_LAVISH_ARM_PROBE_TIMEOUT_S=2
 FM_PROCEVENT_LAVISH_ARM_PROBE_MIN_MS=50
+# fm_procevent_generation_live traps no signal - it is a plain shell function
+# with a try-once lock, a claim read, and a pid check, none of which install a
+# TERM handler - so SIGTERM already ends it outright and fm_run_bash_timeout's
+# general-purpose 0.2s post-TERM grace (meant for a bounded command that DOES
+# trap TERM to clean up) buys a hung probe nothing but 0.2s of extra overrun
+# past its own bound, and therefore past arm's deadline. Scope the grace down
+# for this call only, so a hung probe's worst-case overrun stays governed by
+# the floor above rather than by a teardown allowance this probe cannot use.
+FM_PROCEVENT_LAVISH_ARM_PROBE_TERM_GRACE_S=0.02
 arm_probe_live() {  # <source-id> <registration-identity> <remaining-ms>
   local id=$1 identity=$2 remaining_ms=$3 ceiling_ms bound_ms probe_s
   ceiling_ms=$(( FM_PROCEVENT_LAVISH_ARM_PROBE_TIMEOUT_S * 1000 ))
@@ -161,7 +172,8 @@ arm_probe_live() {  # <source-id> <registration-identity> <remaining-ms>
   [ "$bound_ms" -lt "$ceiling_ms" ] || bound_ms=$ceiling_ms
   [ "$bound_ms" -ge "$FM_PROCEVENT_LAVISH_ARM_PROBE_MIN_MS" ] || bound_ms=$FM_PROCEVENT_LAVISH_ARM_PROBE_MIN_MS
   printf -v probe_s '%d.%03d' "$(( bound_ms / 1000 ))" "$(( bound_ms % 1000 ))"
-  fm_run_bash_timeout "$probe_s" \
+  FM_TIMEOUT_TERM_GRACE_S=$FM_PROCEVENT_LAVISH_ARM_PROBE_TERM_GRACE_S \
+    fm_run_bash_timeout "$probe_s" \
     fm_procevent_generation_live "$id" "$identity"
 }
 
@@ -174,8 +186,22 @@ arm_reconcile_kick_lock() {
   printf '%s/.lavish-arm-reconcile-kick.lock\n' "$(fm_procevent_registry_dir "$STATE")"
 }
 
+# Companion lock: whether a reconcile kick is currently QUEUED for this home -
+# either waiting for arm_reconcile_kick_lock or about to. Bounds how many arm
+# calls ever act on a kick to at most one queued plus one running, no matter
+# how large a concurrent burst is, instead of one detached waiter per call.
+# Every arm call still forks its own background attempt (see cmd_arm) - that
+# fork cannot be avoided, since only a fresh process can try this lock
+# without blocking cmd_arm's own readiness wait - but an attempt that finds a
+# kick already queued does one non-blocking try, loses it, and exits
+# immediately: it never blocks, never runs reconcile, and never survives past
+# that try, so it is not itself a waiter.
+arm_reconcile_kick_pending_lock() {
+  printf '%s/.lavish-arm-reconcile-kick-pending.lock\n' "$(fm_procevent_registry_dir "$STATE")"
+}
+
 cmd_arm() {
-  local artifact=${1-} id real reg_out identity wait_ms live deadline_ms now_ms remaining_ms frac first kick_lock
+  local artifact=${1-} id real reg_out identity wait_ms live deadline_ms now_ms remaining_ms frac first kick_lock pending_lock
   [ -n "$artifact" ] || usage
   [ "$#" -eq 1 ] || usage
   command -v lavish-axi >/dev/null 2>&1 || die "lavish-axi is not installed"
@@ -208,22 +234,38 @@ cmd_arm() {
   # the timed sampling loop below is allowed to bound how long arm waits.
   # Running it synchronously here would let that internal blocking silently
   # replace the documented bound with reconcile's own, possibly unbounded, one.
-  # The kick is single-flighted through arm_reconcile_kick_lock rather than
-  # fired unconditionally: each call's kick blocks on that lock until any
-  # earlier kick's reconcile pass has fully finished, then runs its own fresh
-  # pass - which is guaranteed to see this call's own registration, already
-  # committed above before the kick was even queued. A burst of concurrent arm
-  # calls therefore collapses to at most one reconcile process actually
-  # running at a time, each still with a real pass of its own, instead of N
-  # independent, unowned processes racing reconcile's internal per-source
-  # locking. The lock's recorded pid IS the kick's ownership; if its holder
-  # dies mid-reconcile, the same stale-lock recovery every other lock in this
-  # repo relies on reclaims it.
+  #
+  # Coalesced through arm_reconcile_kick_pending_lock rather than fired
+  # unconditionally or queued per call. This background attempt first tries
+  # (non-blocking) to own the "a kick is queued" marker:
+  #   - Losing that try means some earlier, still-pending attempt already
+  #     owns it and has not yet started reconcile (it releases the marker
+  #     only once it actually holds arm_reconcile_kick_lock, immediately
+  #     before running reconcile). That earlier attempt is therefore
+  #     guaranteed to run its pass AFTER this call's own registration, which
+  #     was already committed above before this attempt even started. This
+  #     attempt does nothing further and exits.
+  #   - Winning it makes this attempt the queued kick: it waits for
+  #     arm_reconcile_kick_lock (serializing against any reconcile pass
+  #     already running), releases the pending marker the instant it holds
+  #     that lock so a later arm call can queue the NEXT pass, then runs its
+  #     own fresh reconcile pass and releases the lock. The lock's recorded
+  #     pid IS the kick's ownership; if its holder dies mid-reconcile, the
+  #     same stale-lock recovery every other lock in this repo relies on
+  #     reclaims it.
+  # A burst of concurrent arm calls therefore leaves at most one background
+  # process actually waiting on anything - one running (or about to run)
+  # reconcile pass plus, at most, one queued behind it - never one detached,
+  # unowned waiter per call.
   (
-    kick_lock=$(arm_reconcile_kick_lock)
-    fm_lock_acquire_wait "$kick_lock"
-    "$SCRIPT_DIR/fm-procevent.sh" reconcile >/dev/null 2>&1
-    fm_lock_release "$kick_lock"
+    pending_lock=$(arm_reconcile_kick_pending_lock)
+    if fm_lock_try_acquire "$pending_lock"; then
+      kick_lock=$(arm_reconcile_kick_lock)
+      fm_lock_acquire_wait "$kick_lock"
+      fm_lock_release "$pending_lock"
+      "$SCRIPT_DIR/fm-procevent.sh" reconcile >/dev/null 2>&1
+      fm_lock_release "$kick_lock"
+    fi
   ) &
   deadline_ms=$(( $(arm_now_ms) + wait_ms ))
   live=1

--- a/bin/fm-procevent-lavish.sh
+++ b/bin/fm-procevent-lavish.sh
@@ -126,55 +126,99 @@ arm_now_ms() {
   printf '%s\n' "$(( sec * 1000 ))"
 }
 
-# cmd_arm's polling loop below only checks the wall clock BETWEEN probes, so
-# it decides whether to start another one but cannot stop an already-started
-# probe from running long. fm_procevent_generation_live's own work - a
-# try-once source lock, a claim read, a pid identity check - is normally a
-# handful of fast, non-blocking filesystem/process operations with nothing
-# that retries or waits on contention, but nothing in its contract actually
-# bounds how long any single one of those operations can take (e.g. unusually
-# slow disk I/O). Give every probe its own hard bound via fm_run_bash_timeout,
-# this repo's bash-native bounded-execution mechanism (bin/fm-timeout-lib.sh):
-# it runs the probe in a background subshell of THIS interpreter, so it calls
+# fm_procevent_generation_live's own work - a try-once source lock, a claim
+# read, a pid identity check - is normally a handful of fast, non-blocking
+# filesystem/process operations with nothing that retries or waits on
+# contention, but nothing in its contract actually bounds how long any single
+# one of those operations can take (e.g. unusually slow disk I/O). Give every
+# probe its own hard bound via fm_run_bash_timeout, this repo's bash-native
+# bounded-execution mechanism (bin/fm-timeout-lib.sh): it runs the probe in a
+# background subshell of THIS interpreter, so it calls
 # fm_procevent_generation_live directly rather than needing to re-exec a bare
 # process that never sourced fm-procevent-lib.sh, the way fm_run_timed's
 # preferred timeout/gtimeout/perl mechanisms would.
 #
-# A FIXED ceiling here would itself blow the documented bound: the caller's
-# very first probe always runs even against a near-zero remaining budget (see
-# cmd_arm below), so a stuck probe given the full ceiling could return up to
-# FM_PROCEVENT_LAVISH_ARM_PROBE_TIMEOUT_S seconds after
-# FM_PROCEVENT_LAVISH_ARM_WAIT_MS already expired. Each probe is therefore
-# bounded by whichever is SMALLER: the safety ceiling, or the caller's own
-# remaining time until its deadline - floored at
-# FM_PROCEVENT_LAVISH_ARM_PROBE_MIN_MS so a probe launched at (or past) that
-# deadline still gets a real, if brief, chance to complete rather than a
-# zero/negative timeout, which fm_run_bash_timeout does not accept as a bound.
-# In ordinary operation a probe finishes in sub-millisecond time either way, so
-# on a hang, these two are the only overrun a caller can ever see past its own
-# deadline: the floor above, and FM_PROCEVENT_LAVISH_ARM_PROBE_TERM_GRACE_S
-# below.
+# This bound exists only to keep a wedged probe from running forever; it is
+# NOT how arm's own readiness wait is bounded (arm_await_live below owns
+# that, independently of how long any one probe takes). So a fixed
+# FM_PROCEVENT_LAVISH_ARM_PROBE_TIMEOUT_S ceiling on every probe, regardless
+# of how much of the caller's own budget remains, cannot make arm itself
+# return late: an earlier revision sized this bound to the caller's
+# remaining-ms, floored at a minimum so fm_run_bash_timeout was never handed
+# a zero/negative timeout (which disables the bound entirely), and that floor
+# is exactly what let a probe launched near the deadline still run past it -
+# because arm's loop back then WAITED synchronously for this call to return.
+# It no longer does; see arm_await_live.
 FM_PROCEVENT_LAVISH_ARM_PROBE_TIMEOUT_S=2
-FM_PROCEVENT_LAVISH_ARM_PROBE_MIN_MS=50
 # fm_procevent_generation_live traps no signal - it is a plain shell function
 # with a try-once lock, a claim read, and a pid check, none of which install a
 # TERM handler - so SIGTERM already ends it outright and fm_run_bash_timeout's
 # general-purpose 0.2s post-TERM grace (meant for a bounded command that DOES
-# trap TERM to clean up) buys a hung probe nothing but 0.2s of extra overrun
-# past its own bound, and therefore past arm's deadline. Scope the grace down
-# for this call only, so a hung probe's worst-case overrun stays governed by
-# the floor above rather than by a teardown allowance this probe cannot use.
+# trap TERM to clean up) buys a hung probe nothing. Scope it down so an
+# abandoned probe's own subshell exits promptly once its bound is hit, rather
+# than sitting around for a teardown allowance it cannot use.
 FM_PROCEVENT_LAVISH_ARM_PROBE_TERM_GRACE_S=0.02
-arm_probe_live() {  # <source-id> <registration-identity> <remaining-ms>
-  local id=$1 identity=$2 remaining_ms=$3 ceiling_ms bound_ms probe_s
-  ceiling_ms=$(( FM_PROCEVENT_LAVISH_ARM_PROBE_TIMEOUT_S * 1000 ))
-  bound_ms=$remaining_ms
-  [ "$bound_ms" -lt "$ceiling_ms" ] || bound_ms=$ceiling_ms
-  [ "$bound_ms" -ge "$FM_PROCEVENT_LAVISH_ARM_PROBE_MIN_MS" ] || bound_ms=$FM_PROCEVENT_LAVISH_ARM_PROBE_MIN_MS
-  printf -v probe_s '%d.%03d' "$(( bound_ms / 1000 ))" "$(( bound_ms % 1000 ))"
-  FM_TIMEOUT_TERM_GRACE_S=$FM_PROCEVENT_LAVISH_ARM_PROBE_TERM_GRACE_S \
-    fm_run_bash_timeout "$probe_s" \
-    fm_procevent_generation_live "$id" "$identity"
+# Launches one liveness probe in the background and returns immediately - the
+# caller reads $! for its pid. The probe's result (fm_run_bash_timeout's own
+# exit status, including 124 on the probe's internal bound) is written to
+# status_file once the probe subshell finishes; nothing here blocks on that.
+arm_probe_live() {  # <source-id> <registration-identity> <status-file>
+  local id=$1 identity=$2 status_file=$3
+  (
+    FM_TIMEOUT_TERM_GRACE_S=$FM_PROCEVENT_LAVISH_ARM_PROBE_TERM_GRACE_S \
+      fm_run_bash_timeout "$FM_PROCEVENT_LAVISH_ARM_PROBE_TIMEOUT_S" \
+      fm_procevent_generation_live "$id" "$identity"
+    printf '%s\n' "$?" > "$status_file"
+  ) &
+}
+
+# Confirms id/identity's registered generation is live before deadline_ms, or
+# gives up and returns nonzero - but NEVER blocks past deadline_ms on a single
+# probe. An earlier revision ran each probe through fm_run_bash_timeout and
+# then synchronously WAITED for that call to return (bound plus termination
+# grace) before rechecking the wall clock: a probe launched with only a few ms
+# of budget left still had to run its own full bound before the loop could
+# give up, so a genuinely wedged fm_procevent_generation_live could make arm
+# return tens of ms after FM_PROCEVENT_LAVISH_ARM_WAIT_MS already expired.
+# This version launches each probe in the background (arm_probe_live) and
+# polls its status file against the wall clock rather than waiting on it, so
+# once deadline_ms passes this returns immediately regardless of whether the
+# most recent probe has finished. An abandoned probe is left running - its own
+# fm_run_bash_timeout bound still terminates it eventually, so it cannot leak
+# forever, but nothing here waits for that to happen, and the status file it
+# was writing to is left for it to (harmlessly) recreate.
+arm_await_live() {  # <source-id> <registration-identity> <deadline-ms>
+  local id=$1 identity=$2 deadline_ms=$3
+  local status_file probe_pid now_ms remaining_ms rc frac live=1
+  status_file=$(mktemp "${TMPDIR:-/tmp}/fm-arm-probe-status.XXXXXX" 2>/dev/null) \
+    || die "cannot create a liveness-probe status file for $id"
+  probe_pid=
+  while :; do
+    if [ -z "$probe_pid" ]; then
+      now_ms=$(arm_now_ms)
+      [ "$now_ms" -lt "$deadline_ms" ] || break
+      arm_probe_live "$id" "$identity" "$status_file"
+      probe_pid=$!
+    fi
+    if [ -s "$status_file" ]; then
+      wait "$probe_pid" 2>/dev/null
+      rc=$(cat "$status_file" 2>/dev/null)
+      probe_pid=
+      [ "$rc" = 0 ] && { live=0; break; }
+      : > "$status_file"
+      now_ms=$(arm_now_ms)
+      [ "$now_ms" -lt "$deadline_ms" ] || break
+      continue
+    fi
+    now_ms=$(arm_now_ms)
+    [ "$now_ms" -lt "$deadline_ms" ] || break
+    remaining_ms=$(( deadline_ms - now_ms ))
+    [ "$remaining_ms" -le 20 ] || remaining_ms=20
+    printf -v frac '%03d' "$remaining_ms"
+    sleep "0.$frac"
+  done
+  rm -f "$status_file" 2>/dev/null || true
+  return "$live"
 }
 
 # Single-flight lock for cmd_arm's background reconcile kick, scoped to this
@@ -201,7 +245,7 @@ arm_reconcile_kick_pending_lock() {
 }
 
 cmd_arm() {
-  local artifact=${1-} id real reg_out identity wait_ms live deadline_ms now_ms remaining_ms frac first kick_lock pending_lock
+  local artifact=${1-} id real reg_out identity wait_ms deadline_ms kick_lock pending_lock
   [ -n "$artifact" ] || usage
   [ "$#" -eq 1 ] || usage
   command -v lavish-axi >/dev/null 2>&1 || die "lavish-axi is not installed"
@@ -268,37 +312,8 @@ cmd_arm() {
     fi
   ) &
   deadline_ms=$(( $(arm_now_ms) + wait_ms ))
-  live=1
-  first=1
-  while :; do
-    # The very first probe always runs, even for a 0ms budget, so a caller
-    # gets at least one real check. Every later probe is itself real work -
-    # a filesystem lock, claim load, and process-identity check - so the
-    # deadline is re-checked against the wall clock right before starting
-    # one, not only after it returns; otherwise a probe could be kicked off
-    # an instant after the budget already ran out, growing the overrun by
-    # that whole probe's duration instead of stopping at the deadline. The
-    # same fresh reading also bounds the probe itself (arm_probe_live), so a
-    # probe started near the deadline cannot run long past it either.
-    now_ms=$(arm_now_ms)
-    if [ "$first" -eq 0 ]; then
-      [ "$now_ms" -lt "$deadline_ms" ] || break
-    fi
-    first=0
-    remaining_ms=$(( deadline_ms - now_ms ))
-    [ "$remaining_ms" -gt 0 ] || remaining_ms=0
-    if arm_probe_live "$id" "$identity" "$remaining_ms"; then
-      live=0
-      break
-    fi
-    now_ms=$(arm_now_ms)
-    [ "$now_ms" -lt "$deadline_ms" ] || break
-    remaining_ms=$(( deadline_ms - now_ms ))
-    [ "$remaining_ms" -le 50 ] || remaining_ms=50
-    printf -v frac '%03d' "$remaining_ms"
-    sleep "0.$frac"
-  done
-  [ "$live" -eq 0 ] || die "listener for $id did not confirm live within ${wait_ms}ms"
+  arm_await_live "$id" "$identity" "$deadline_ms" \
+    || die "listener for $id did not confirm live within ${wait_ms}ms"
   printf 'armed: %s\n' "$id"
   printf 'artifact: %s\n' "$real"
 }

--- a/bin/fm-procevent-lavish.sh
+++ b/bin/fm-procevent-lavish.sh
@@ -129,8 +129,12 @@ cmd_arm() {
       live=0
       break
     fi
-    sleep 0.05
     i=$((i + 1))
+    # Only sleep before a check the loop bound still allows: sleeping after
+    # the final permitted check would push arm past FM_PROCEVENT_LAVISH_ARM_WAIT_MS
+    # for no benefit, since that sleep's result is never sampled.
+    [ "$i" -lt "$max" ] || break
+    sleep 0.05
   done
   [ "$live" -eq 0 ] || die "listener for $id did not confirm live within ${wait_ms}ms"
   printf 'armed: %s\n' "$id"

--- a/bin/fm-procevent-lavish.sh
+++ b/bin/fm-procevent-lavish.sh
@@ -59,6 +59,7 @@ set -u
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 
 # shellcheck source=bin/fm-pr-lib.sh
 . "$SCRIPT_DIR/fm-pr-lib.sh"
@@ -137,19 +138,44 @@ arm_now_ms() {
 # it runs the probe in a background subshell of THIS interpreter, so it calls
 # fm_procevent_generation_live directly rather than needing to re-exec a bare
 # process that never sourced fm-procevent-lib.sh, the way fm_run_timed's
-# preferred timeout/gtimeout/perl mechanisms would. The bound is a generous
-# safety ceiling relative to that normal sub-millisecond cost, so it is never
-# expected to fire in ordinary operation; it exists only so a single
-# unexpectedly stuck probe cannot grow arm's overrun past
-# FM_PROCEVENT_LAVISH_ARM_WAIT_MS by an unbounded amount.
+# preferred timeout/gtimeout/perl mechanisms would.
+#
+# A FIXED ceiling here would itself blow the documented bound: the caller's
+# very first probe always runs even against a near-zero remaining budget (see
+# cmd_arm below), so a stuck probe given the full ceiling could return up to
+# FM_PROCEVENT_LAVISH_ARM_PROBE_TIMEOUT_S seconds after
+# FM_PROCEVENT_LAVISH_ARM_WAIT_MS already expired. Each probe is therefore
+# bounded by whichever is SMALLER: the safety ceiling, or the caller's own
+# remaining time until its deadline - floored at
+# FM_PROCEVENT_LAVISH_ARM_PROBE_MIN_MS so a probe launched at (or past) that
+# deadline still gets a real, if brief, chance to complete rather than a
+# zero/negative timeout, which fm_run_bash_timeout does not accept as a bound.
+# In ordinary operation a probe finishes in sub-millisecond time either way, so
+# this floor is the only overrun a caller can ever see past its own deadline.
 FM_PROCEVENT_LAVISH_ARM_PROBE_TIMEOUT_S=2
-arm_probe_live() {
-  fm_run_bash_timeout "$FM_PROCEVENT_LAVISH_ARM_PROBE_TIMEOUT_S" \
-    fm_procevent_generation_live "$1" "$2"
+FM_PROCEVENT_LAVISH_ARM_PROBE_MIN_MS=50
+arm_probe_live() {  # <source-id> <registration-identity> <remaining-ms>
+  local id=$1 identity=$2 remaining_ms=$3 ceiling_ms bound_ms probe_s
+  ceiling_ms=$(( FM_PROCEVENT_LAVISH_ARM_PROBE_TIMEOUT_S * 1000 ))
+  bound_ms=$remaining_ms
+  [ "$bound_ms" -lt "$ceiling_ms" ] || bound_ms=$ceiling_ms
+  [ "$bound_ms" -ge "$FM_PROCEVENT_LAVISH_ARM_PROBE_MIN_MS" ] || bound_ms=$FM_PROCEVENT_LAVISH_ARM_PROBE_MIN_MS
+  printf -v probe_s '%d.%03d' "$(( bound_ms / 1000 ))" "$(( bound_ms % 1000 ))"
+  fm_run_bash_timeout "$probe_s" \
+    fm_procevent_generation_live "$id" "$identity"
+}
+
+# Single-flight lock for cmd_arm's background reconcile kick, scoped to this
+# home's own registry directory (the same STATE a sibling fm-procevent.sh
+# process derives) rather than the machine-wide claim root: reconcile's
+# runner-starting sweep only ever reads THIS home's own registrations, so
+# concurrent arm calls against a different home must never wait on this one.
+arm_reconcile_kick_lock() {
+  printf '%s/.lavish-arm-reconcile-kick.lock\n' "$(fm_procevent_registry_dir "$STATE")"
 }
 
 cmd_arm() {
-  local artifact=${1-} id real reg_out identity wait_ms live deadline_ms now_ms remaining_ms frac first
+  local artifact=${1-} id real reg_out identity wait_ms live deadline_ms now_ms remaining_ms frac first kick_lock
   [ -n "$artifact" ] || usage
   [ "$#" -eq 1 ] || usage
   command -v lavish-axi >/dev/null 2>&1 || die "lavish-axi is not installed"
@@ -182,7 +208,23 @@ cmd_arm() {
   # the timed sampling loop below is allowed to bound how long arm waits.
   # Running it synchronously here would let that internal blocking silently
   # replace the documented bound with reconcile's own, possibly unbounded, one.
-  "$SCRIPT_DIR/fm-procevent.sh" reconcile >/dev/null 2>&1 &
+  # The kick is single-flighted through arm_reconcile_kick_lock rather than
+  # fired unconditionally: each call's kick blocks on that lock until any
+  # earlier kick's reconcile pass has fully finished, then runs its own fresh
+  # pass - which is guaranteed to see this call's own registration, already
+  # committed above before the kick was even queued. A burst of concurrent arm
+  # calls therefore collapses to at most one reconcile process actually
+  # running at a time, each still with a real pass of its own, instead of N
+  # independent, unowned processes racing reconcile's internal per-source
+  # locking. The lock's recorded pid IS the kick's ownership; if its holder
+  # dies mid-reconcile, the same stale-lock recovery every other lock in this
+  # repo relies on reclaims it.
+  (
+    kick_lock=$(arm_reconcile_kick_lock)
+    fm_lock_acquire_wait "$kick_lock"
+    "$SCRIPT_DIR/fm-procevent.sh" reconcile >/dev/null 2>&1
+    fm_lock_release "$kick_lock"
+  ) &
   deadline_ms=$(( $(arm_now_ms) + wait_ms ))
   live=1
   first=1
@@ -193,13 +235,17 @@ cmd_arm() {
     # deadline is re-checked against the wall clock right before starting
     # one, not only after it returns; otherwise a probe could be kicked off
     # an instant after the budget already ran out, growing the overrun by
-    # that whole probe's duration instead of stopping at the deadline.
+    # that whole probe's duration instead of stopping at the deadline. The
+    # same fresh reading also bounds the probe itself (arm_probe_live), so a
+    # probe started near the deadline cannot run long past it either.
+    now_ms=$(arm_now_ms)
     if [ "$first" -eq 0 ]; then
-      now_ms=$(arm_now_ms)
       [ "$now_ms" -lt "$deadline_ms" ] || break
     fi
     first=0
-    if arm_probe_live "$id" "$identity"; then
+    remaining_ms=$(( deadline_ms - now_ms ))
+    [ "$remaining_ms" -gt 0 ] || remaining_ms=0
+    if arm_probe_live "$id" "$identity" "$remaining_ms"; then
       live=0
       break
     fi

--- a/bin/fm-procevent-lavish.sh
+++ b/bin/fm-procevent-lavish.sh
@@ -9,6 +9,15 @@
 #   fm-procevent-lavish.sh source-id <artifact.html>
 #   fm-procevent-lavish.sh retire <artifact.html>
 #
+# arm        Register the canonical source for the published poll argv, start
+#            this home's liveness reconciliation immediately rather than at a
+#            later watcher cycle, and print `armed:` only after a live owner
+#            of that exact registration is confirmed within a bounded wait
+#            (FM_PROCEVENT_LAVISH_ARM_WAIT_MS milliseconds, default 5000).
+#            Without confirmation arm exits nonzero without printing `armed:`;
+#            the registration stays in place for later reconciliation either
+#            way.
+#
 # classify   Print the lifecycle state a handler should act on: feedback, ended,
 #            waiting, missing, or unknown.
 # terminal   Exit 0 when the captured result means this Lavish source will never
@@ -59,7 +68,7 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 . "$SCRIPT_DIR/fm-procevent-lib.sh"
 
 die() { printf 'error: %s\n' "$1" >&2; exit 1; }
-usage() { sed -n '2,47p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 2; }
+usage() { sed -n '2,56p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 2; }
 
 # Canonical identity is physical, not the path string: Lavish itself keys a
 # session on the realpath of the artifact, so two names for one file are one
@@ -79,7 +88,7 @@ cmd_source_id() {
 }
 
 cmd_arm() {
-  local artifact=${1-} id real
+  local artifact=${1-} id real state reg identity wait_ms i=0 max live
   [ -n "$artifact" ] || usage
   [ "$#" -eq 1 ] || usage
   command -v lavish-axi >/dev/null 2>&1 || die "lavish-axi is not installed"
@@ -88,6 +97,32 @@ cmd_arm() {
     || die "cannot resolve the artifact path: $artifact"
   # The plain blocking form: no --timeout-ms, so completion is a server event.
   "$SCRIPT_DIR/fm-procevent.sh" register lavish "$id" -- lavish-axi poll "$real" || exit 1
+  # Registration proves the source definition was accepted; it does not prove
+  # this attempt's listener ever starts, because reconcile owns that launch.
+  # Readiness is therefore proved before it is reported: kick one reconcile so
+  # the runner starts now rather than at the watcher's leisure, then require a
+  # live owner whose claim names THIS registration attempt. Anything else stays
+  # unconfirmed - exit nonzero without armed:, leaving the registration in
+  # place for later reconciliation either way.
+  case "${FM_PROCEVENT_LAVISH_ARM_WAIT_MS:-5000}" in
+    ''|*[!0-9]*) die "FM_PROCEVENT_LAVISH_ARM_WAIT_MS must be a nonnegative integer" ;;
+  esac
+  wait_ms=${FM_PROCEVENT_LAVISH_ARM_WAIT_MS:-5000}
+  state="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+  reg="$(fm_procevent_registry_dir "$state")/$id.source"
+  identity=$(fm_pr_file_identity "$reg") || die "cannot read the registered generation: $id"
+  "$SCRIPT_DIR/fm-procevent.sh" reconcile >/dev/null 2>&1 || true
+  max=$((wait_ms / 50 + 1))
+  live=1
+  while [ "$i" -lt "$max" ]; do
+    if fm_procevent_generation_live "$id" "$identity"; then
+      live=0
+      break
+    fi
+    sleep 0.05
+    i=$((i + 1))
+  done
+  [ "$live" -eq 0 ] || die "listener for $id did not confirm live within ${wait_ms}ms"
   printf 'armed: %s\n' "$id"
   printf 'artifact: %s\n' "$real"
 }

--- a/bin/fm-procevent-lavish.sh
+++ b/bin/fm-procevent-lavish.sh
@@ -186,7 +186,9 @@ arm_probe_live() {  # <source-id> <registration-identity> <status-file>
 # most recent probe has finished. An abandoned probe is left running - its own
 # fm_run_bash_timeout bound still terminates it eventually, so it cannot leak
 # forever, but nothing here waits for that to happen, and the status file it
-# was writing to is left for it to (harmlessly) recreate.
+# was writing to is deliberately left in place (not unlinked) for it to
+# finish writing to, rather than removed out from under that pending write -
+# see the removal guard at the bottom of this function.
 arm_await_live() {  # <source-id> <registration-identity> <deadline-ms>
   local id=$1 identity=$2 deadline_ms=$3
   local status_file probe_pid now_ms remaining_ms rc frac live=1
@@ -217,7 +219,21 @@ arm_await_live() {  # <source-id> <registration-identity> <deadline-ms>
     printf -v frac '%03d' "$remaining_ms"
     sleep "0.$frac"
   done
-  rm -f "$status_file" 2>/dev/null || true
+  # Only unlink status_file when no probe is outstanding (probe_pid empty):
+  # every probe still in flight when the deadline hits is left running (see
+  # above) and will later reopen this exact path for its delayed write via a
+  # plain `>` redirection, which follows a symlink. Removing the path here
+  # while that write is still pending would hand a local attacker a window to
+  # replace it with a symlink to an arbitrary file the arm-running user can
+  # write, so the abandoned probe's delayed write clobbers that file instead
+  # of the status file it thinks it is writing to. Leaving the real file in
+  # place - rather than deleting it out from under a write we know is still
+  # coming - is what makes that write land on the file we created, symlink or
+  # not. The only cost is a single leaked temp file in the rare case a probe
+  # is still outstanding at the deadline; it is small, bounded to one file
+  # per arm_await_live call, and self-overwrites harmlessly once the
+  # abandoned probe finally does write to it.
+  [ -n "$probe_pid" ] || rm -f "$status_file" 2>/dev/null || true
   return "$live"
 }
 

--- a/bin/fm-procevent-lavish.sh
+++ b/bin/fm-procevent-lavish.sh
@@ -88,7 +88,7 @@ cmd_source_id() {
 }
 
 cmd_arm() {
-  local artifact=${1-} id real state reg identity wait_ms i=0 max live
+  local artifact=${1-} id real reg_out identity wait_ms i=0 max live
   [ -n "$artifact" ] || usage
   [ "$#" -eq 1 ] || usage
   command -v lavish-axi >/dev/null 2>&1 || die "lavish-axi is not installed"
@@ -96,7 +96,15 @@ cmd_arm() {
   real=$(perl -MCwd=realpath -e '$p = realpath($ARGV[0]); defined($p) or exit 1; print "$p\n"' "$artifact" 2>/dev/null) \
     || die "cannot resolve the artifact path: $artifact"
   # The plain blocking form: no --timeout-ms, so completion is a server event.
-  "$SCRIPT_DIR/fm-procevent.sh" register lavish "$id" -- lavish-axi poll "$real" || exit 1
+  # register reports the identity of the exact generation it just published,
+  # captured on the other side while it still held the source lock. Reading it
+  # back from that line - rather than re-deriving it here with a separate,
+  # unlocked stat of the registry file - is what keeps this attempt's identity
+  # from ever being some concurrent arm call's later registration instead.
+  reg_out=$("$SCRIPT_DIR/fm-procevent.sh" register lavish "$id" -- lavish-axi poll "$real") || exit 1
+  printf '%s\n' "$reg_out"
+  identity=${reg_out##* }
+  [ -n "$identity" ] || die "cannot read the registered generation: $id"
   # Registration proves the source definition was accepted; it does not prove
   # this attempt's listener ever starts, because reconcile owns that launch.
   # Readiness is therefore proved before it is reported: kick one reconcile so
@@ -108,10 +116,12 @@ cmd_arm() {
     ''|*[!0-9]*) die "FM_PROCEVENT_LAVISH_ARM_WAIT_MS must be a nonnegative integer" ;;
   esac
   wait_ms=${FM_PROCEVENT_LAVISH_ARM_WAIT_MS:-5000}
-  state="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
-  reg="$(fm_procevent_registry_dir "$state")/$id.source"
-  identity=$(fm_pr_file_identity "$reg") || die "cannot read the registered generation: $id"
-  "$SCRIPT_DIR/fm-procevent.sh" reconcile >/dev/null 2>&1 || true
+  # Kicked in the background, never awaited: reconcile can block on a source
+  # lock held by a live process elsewhere or on slow runner cleanup, and only
+  # the timed sampling loop below is allowed to bound how long arm waits.
+  # Running it synchronously here would let that internal blocking silently
+  # replace the documented bound with reconcile's own, possibly unbounded, one.
+  "$SCRIPT_DIR/fm-procevent.sh" reconcile >/dev/null 2>&1 &
   max=$((wait_ms / 50 + 1))
   live=1
   while [ "$i" -lt "$max" ]; do

--- a/bin/fm-procevent-lavish.sh
+++ b/bin/fm-procevent-lavish.sh
@@ -92,10 +92,14 @@ cmd_source_id() {
 # because every iteration also spends real time on fm_procevent_generation_live's
 # own work - a filesystem lock, claim load, and process-identity check - which a
 # sleep-only budget never accounts for. EPOCHREALTIME is a bash builtin (no
-# fork); a shell without it degrades to whole-second granularity rather than
-# losing the bound entirely.
+# fork) and is tried first. A shell without it - stock macOS ships Bash 3.2,
+# which predates EPOCHREALTIME - falls back to perl's Time::HiRes, a core
+# module bundled with every perl this adapter already requires elsewhere
+# (cmd_source_id, cmd_answers), so sub-second FM_PROCEVENT_LAVISH_ARM_WAIT_MS
+# values stay honored instead of degrading to whole-second granularity, which
+# could make a bounded wait take close to a full second longer than requested.
 arm_now_ms() {
-  local raw sec frac
+  local raw sec frac ms
   raw=${EPOCHREALTIME:-}
   case "$raw" in
     *[0-9][.,][0-9]*)
@@ -109,13 +113,18 @@ arm_now_ms() {
       esac
       ;;
   esac
+  ms=$(perl -MTime::HiRes=time -e 'printf "%.0f", time() * 1000' 2>/dev/null)
+  case "$ms" in
+    ''|*[!0-9]*) ;;
+    *) printf '%s\n' "$ms"; return 0 ;;
+  esac
   sec=$(date +%s 2>/dev/null || printf '0')
   case "$sec" in ''|*[!0-9]*) sec=0 ;; esac
   printf '%s\n' "$(( sec * 1000 ))"
 }
 
 cmd_arm() {
-  local artifact=${1-} id real reg_out identity wait_ms live deadline_ms now_ms remaining_ms frac
+  local artifact=${1-} id real reg_out identity wait_ms live deadline_ms now_ms remaining_ms frac first
   [ -n "$artifact" ] || usage
   [ "$#" -eq 1 ] || usage
   command -v lavish-axi >/dev/null 2>&1 || die "lavish-axi is not installed"
@@ -151,14 +160,24 @@ cmd_arm() {
   "$SCRIPT_DIR/fm-procevent.sh" reconcile >/dev/null 2>&1 &
   deadline_ms=$(( $(arm_now_ms) + wait_ms ))
   live=1
+  first=1
   while :; do
+    # The very first probe always runs, even for a 0ms budget, so a caller
+    # gets at least one real check. Every later probe is itself real work -
+    # a filesystem lock, claim load, and process-identity check - so the
+    # deadline is re-checked against the wall clock right before starting
+    # one, not only after it returns; otherwise a probe could be kicked off
+    # an instant after the budget already ran out, growing the overrun by
+    # that whole probe's duration instead of stopping at the deadline.
+    if [ "$first" -eq 0 ]; then
+      now_ms=$(arm_now_ms)
+      [ "$now_ms" -lt "$deadline_ms" ] || break
+    fi
+    first=0
     if fm_procevent_generation_live "$id" "$identity"; then
       live=0
       break
     fi
-    # Always attempted at least once above; from here the wall clock alone
-    # decides whether another probe fits, since the probe just run may already
-    # have consumed most or all of the budget.
     now_ms=$(arm_now_ms)
     [ "$now_ms" -lt "$deadline_ms" ] || break
     remaining_ms=$(( deadline_ms - now_ms ))

--- a/bin/fm-procevent-lib.sh
+++ b/bin/fm-procevent-lib.sh
@@ -199,6 +199,27 @@ fm_procevent_claim_state_locked() {
   fm_procevent_pid_state "$FM_PROCEVENT_CLAIM_PID" "$FM_PROCEVENT_CLAIM_IDENTITY"
 }
 
+# fm_procevent_generation_live <source-id> <registration-identity>
+# True only when a live owner holds exactly this registration generation: under
+# one try-acquire of the source lock, the claim must load, its recorded
+# registration identity must equal the caller's own register attempt, and the
+# owning process must be verifiably alive. A lock held elsewhere counts as not
+# confirmed yet - sampling never blocks - and every other outcome, including an
+# orphaned group whose leader is gone (nobody would capture its result), is no.
+fm_procevent_generation_live() {
+  local id=$1 identity=$2 st=1
+  fm_procevent_source_id_valid "$id" || return 1
+  if ! fm_lock_try_acquire "$(fm_procevent_source_lock_path "$id")"; then
+    return 1
+  fi
+  if fm_procevent_claim_load_locked "$id" \
+    && [ "$FM_PROCEVENT_CLAIM_REG_IDENTITY" = "$identity" ]; then
+    fm_procevent_pid_state "$FM_PROCEVENT_CLAIM_PID" "$FM_PROCEVENT_CLAIM_IDENTITY" && st=0
+  fi
+  fm_lock_release "$(fm_procevent_source_lock_path "$id")"
+  return "$st"
+}
+
 # fm_procevent_claim_acquire_locked <source-id> <home> <pid> <registration>
 # 0 acquired, 1 error, 2 held by a live owner (possibly another home).
 fm_procevent_claim_acquire_locked() {

--- a/bin/fm-procevent.sh
+++ b/bin/fm-procevent.sh
@@ -212,7 +212,7 @@ read_argv() {  # <source-id>
 }
 
 cmd_register() {
-  local adapter=${1-} id=${2-} sep=${3-}
+  local adapter=${1-} id=${2-} sep=${3-} identity
   shift 3 2>/dev/null || usage
   fm_procevent_adapter_valid "$adapter" || die "adapter name must be lowercase alphanumeric or dash: $adapter"
   fm_procevent_source_id_valid "$id" || die "source id must be path-safe and at most 64 characters: $id"
@@ -228,8 +228,17 @@ cmd_register() {
     fm_procevent_source_lock_release "$id"
     die "cannot publish the registration"
   fi
+  # Read the identity of the generation just published while STILL holding the
+  # source lock: register and every future register for this same id serialize
+  # on that lock, so no concurrent registration can replace this file before
+  # its own identity is captured here, and a caller that needs to confirm THIS
+  # attempt later never has to re-derive it through a separate, unlocked read.
+  if ! identity=$(fm_pr_file_identity "$(source_file "$id")"); then
+    fm_procevent_source_lock_release "$id"
+    die "cannot read the registered generation: $id"
+  fi
   fm_procevent_source_lock_release "$id"
-  printf 'registered: %s (%s)\n' "$id" "$adapter"
+  printf 'registered: %s (%s) %s\n' "$id" "$adapter" "$identity"
 }
 
 # Publish every durably captured result with no handled acknowledgement yet.

--- a/bin/fm-timeout-lib.sh
+++ b/bin/fm-timeout-lib.sh
@@ -15,6 +15,17 @@
 #       except 124, which means the bound was hit (GNU timeout's convention,
 #       reproduced by the perl and bash fallbacks).
 #
+#   FM_TIMEOUT_TERM_GRACE_S
+#       Seconds fm_run_bash_timeout waits after SIGTERM before escalating to
+#       SIGKILL on a hit bound. Default 0.2. This grace only helps a bounded
+#       command that traps TERM to clean up; a command with no such trap (a
+#       plain shell function, for instance) gains nothing from it and simply
+#       overruns its own requested bound by the grace on every hang. A caller
+#       whose command has no TERM trap can scope this down for that one call
+#       (`FM_TIMEOUT_TERM_GRACE_S=0.02 fm_run_bash_timeout ...`) to shrink its
+#       own worst-case overrun instead of inheriting the general-purpose
+#       default meant for commands that do clean up on TERM.
+#
 # A non-positive bound is not a bound: `timeout 0` and the perl fallback's
 # `alarm 0` both disable the deadline, so callers must reject 0 before calling.
 #
@@ -42,8 +53,9 @@ fm_timeout_mechanism() {
 }
 
 fm_run_bash_timeout() {
-  local seconds=$1 command_status deadline_status child_pid watchdog_pid command_rc recorded_rc monitor_was_on=0
+  local seconds=$1 command_status deadline_status child_pid watchdog_pid command_rc recorded_rc monitor_was_on=0 term_grace_s
   shift
+  term_grace_s=${FM_TIMEOUT_TERM_GRACE_S:-0.2}
   command_status=$(mktemp "${TMPDIR:-/tmp}/fm-bash-timeout-command.XXXXXX" 2>/dev/null) || return 124
   deadline_status="${command_status}.deadline"
   case $- in *m*) monitor_was_on=1 ;; esac
@@ -61,7 +73,7 @@ fm_run_bash_timeout() {
     sleep "$seconds"
     printf 'expired\n' > "$deadline_status"
     kill -TERM -- "-$child_pid" 2>/dev/null || true
-    sleep 0.2
+    sleep "$term_grace_s"
     kill -KILL -- "-$child_pid" 2>/dev/null || true
     exit 124
   ) &

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -640,6 +640,7 @@ FM_TOOL_UPDATE_BUDGET_SECS=20   # 1..120 seconds allowed for a whole watched-too
 FM_TOOL_UPDATE_NOW=     # test override for the watched-tool sweep clock; the sweep budget still uses real time
 FM_PROCEVENT_MAX_OUTPUT_BYTES=1048576   # bound on one captured process-to-event result
 FM_PROCEVENT_CLAIM_ROOT=                # machine-wide source claim root; default $XDG_STATE_HOME/firstmate/procevent-claims
+FM_PROCEVENT_LAVISH_ARM_WAIT_MS=5000    # milliseconds fm-procevent-lavish.sh arm waits to confirm its own registration generation live before printing armed:; unconfirmed exits nonzero with the registration left in place
 FM_WHEN_OUTPUT_TAIL_BYTES=8192          # bound on the command-output tail inside one condition->action outcome document
 FM_CODEX_WATCH_CHECKPOINT=180   # seconds per foreground watcher checkpoint in Codex primary supervision
 FM_CREW_STATE_NM_TIMEOUT=10   # seconds allowed per no-mistakes query inside fm-crew-state.sh

--- a/docs/verification/process-event-sources.md
+++ b/docs/verification/process-event-sources.md
@@ -8,6 +8,7 @@ This record holds reusable version-scoped evidence for the runner's active guara
 Verified on 2026-07-31 on macOS (Darwin 25.5.0) with `lavish-axi` 0.1.45 installed.
 Generic keyed-answer feed verified on 2026-08-16 on the same platform, against the same published poll response shape.
 Cross-origin keyed-answer feed verified on 2026-08-19 through the real runner and Lavish adapter interface.
+Arm listener-liveness confirmation verified on 2026-08-22 against a fake blocking Lavish stand-in, through the public `arm` command end to end.
 
 ## The published Lavish poll interface the adapter wraps
 
@@ -87,6 +88,7 @@ Exercised by `tests/fm-procevent.test.sh` against a fake blocking source whose c
 | terminal retirement preserves the result | the retired source's captured output, its announced event, its handled acknowledgement, and later explicit `retire` all still behave normally |
 | registration-generation retirement | an old terminal runner preserves a concurrently replaced registration and releases ownership so the replacement runs independently; injected registration-removal failure retains a terminal claim, performs no second poll, and completes idempotently once removal recovers |
 | one `Send & End`, one result | an armed Lavish source driven against a stand-in for the published poll, which delivers the final `session_ended` feedback once and empty ended sessions afterward, polls exactly once, captures exactly one result, publishes one distinct event, and retires itself |
+| arm proves listener liveness before reporting ready | `bin/fm-procevent-lavish.sh arm` kicks one reconcile immediately and prints `armed:` only once its own fresh registration generation is confirmed live, after which that same listener consumes a completed feedback result end to end; a live owner of a different, older registration generation keeps the fresh generation from ever being confirmed, so arm returns nonzero with no `armed:` line, names the cause, and leaves the registration in place for later reconciliation |
 | bounded re-announcement until handled | a durably captured result with no handled acknowledgement is re-announced by `reconcile` with the same source and sequence on every call - not only the first restart after a crash - and a presented-but-unacknowledged wake resurfaces identically after a simulated replacement session |
 | handled acknowledgement | `fm-procevent.sh handled <source-id> <sequence>` atomically and idempotently records handling at mode `0600`, fails without leaving a marker when private-mode enforcement fails, reports the first call distinctly from every repeat, stops further re-announcement once recorded, and never authorizes a paired effect twice across repeat calls |
 | publication-and-acknowledgement serialization | a concurrent `reconcile` cannot append a wake after `handled` wins the shared per-source boundary, so an acknowledged result is not re-announced by a publication race |

--- a/tests/fm-procevent.test.sh
+++ b/tests/fm-procevent.test.sh
@@ -783,13 +783,15 @@ pass "arm's readiness wait stays sub-second-accurate even without EPOCHREALTIME"
 # verbatim by byte range, not paraphrased) against a stand-in for
 # fm_procevent_generation_live that hangs forever, so the assertion is on
 # arm_probe_live's real, observed exit code and elapsed time - not on any
-# text in the file.
+# text in the file. A generous 10s remaining-budget argument is passed so the
+# safety-ceiling path is what gets exercised here, not the deadline-bound path
+# covered separately below.
 PROBE_HANG_OUT=$(bash -c '
   . "$1/bin/fm-timeout-lib.sh"
   eval "$(sed -n "/^FM_PROCEVENT_LAVISH_ARM_PROBE_TIMEOUT_S=/,/^}/p" "$1/bin/fm-procevent-lavish.sh")"
   fm_procevent_generation_live() { sleep 300; }
   start=$SECONDS
-  arm_probe_live x y
+  arm_probe_live x y 10000
   rc=$?
   printf "rc=%s elapsed=%s\n" "$rc" "$(( SECONDS - start ))"
 ' _ "$ROOT")
@@ -799,6 +801,95 @@ probe_hang_elapsed=${PROBE_HANG_OUT##*elapsed=}
 [ "$probe_hang_elapsed" -le 5 ] \
   || fail "arm_probe_live took ${probe_hang_elapsed}s to bound a hung probe: $PROBE_HANG_OUT"
 pass "a single hung liveness probe is bounded rather than left free to run indefinitely"
+
+# --- a probe launched near the deadline cannot overrun it by the full ceiling
+# Regression for the "probe timeout exceeds arm deadline" defect: a hung probe
+# was always given the full FM_PROCEVENT_LAVISH_ARM_PROBE_TIMEOUT_S (2s)
+# ceiling regardless of how much of the caller's own bound actually remained,
+# so a near-zero or already-exhausted budget could still overrun by roughly
+# 2s. arm_probe_live now bounds each probe by whichever is smaller: the
+# ceiling, or the caller's own remaining-ms argument (floored at
+# FM_PROCEVENT_LAVISH_ARM_PROBE_MIN_MS so a real check still happens). Same
+# extraction technique as above - the real shipped function, a hanging
+# fm_procevent_generation_live stand-in - but this time with a 0ms remaining
+# budget, so a passing result depends on the probe actually honoring that
+# argument rather than falling back to the full ceiling.
+PROBE_DEADLINE_OUT=$(bash -c '
+  . "$1/bin/fm-timeout-lib.sh"
+  eval "$(sed -n "/^FM_PROCEVENT_LAVISH_ARM_PROBE_TIMEOUT_S=/,/^}/p" "$1/bin/fm-procevent-lavish.sh")"
+  fm_procevent_generation_live() { sleep 300; }
+  start=$SECONDS
+  arm_probe_live x y 0
+  rc=$?
+  printf "rc=%s elapsed=%s\n" "$rc" "$(( SECONDS - start ))"
+' _ "$ROOT")
+assert_contains "$PROBE_DEADLINE_OUT" "rc=124" \
+  "a hung probe at a zero-ms remaining budget is still killed and reported as timed out: $PROBE_DEADLINE_OUT"
+probe_deadline_elapsed=${PROBE_DEADLINE_OUT##*elapsed=}
+[ "$probe_deadline_elapsed" -le 1 ] \
+  || fail "arm_probe_live took ${probe_deadline_elapsed}s to bound a hung probe at a zero-ms remaining budget (expected close to FM_PROCEVENT_LAVISH_ARM_PROBE_MIN_MS, not the full 2s ceiling): $PROBE_DEADLINE_OUT"
+pass "a liveness probe launched at a zero-ms remaining budget is bounded by that budget, not the full safety ceiling"
+
+# --- arm's background reconcile kick is single-flighted, not one-per-call ---
+# Regression for the "background reconciles remain unowned" defect: arm used
+# to fire an unconditional `fm-procevent.sh reconcile &` on every call, so a
+# burst of calls landing while an earlier kick was still blocked (e.g. on an
+# unrelated source's lock) could pile up N independent, untracked reconcile
+# processes each doing its own full sweep. arm_reconcile_kick_lock now
+# serializes the kick itself through fm_lock_acquire_wait/fm_lock_release -
+# the same ownership-by-lock-pid primitive every other resource in this repo
+# uses - so at most one reconcile process this adapter started is ever
+# running at once. Proven by holding an unrelated registered source's lock,
+# forcing any reconcile that reaches it to block inside cmd_reconcile (the
+# same mechanism the lock-contention cut above uses), firing several arm
+# calls while it is held, and counting the actual OS processes running this
+# repo's own `fm-procevent.sh reconcile` - real observed process state, not
+# source text.
+HLK="$TMP_ROOT/hlk"; new_home "$HLK"
+# Sorts before any "lavish-<hash>" source id, so reconcile's own *.source walk
+# reaches this home's contended registration before the arm-registered one.
+KICK_BLOCKER_ID="aab-arm-kick-single-flight-blocker"
+pe_register "$HLK" lavish "$KICK_BLOCKER_ID" -- /bin/true >/dev/null
+KICK_READY="$TMP_ROOT/kick-lock-ready"
+KICK_RELEASE="$TMP_ROOT/kick-lock-release"
+hold_source_lock "$KICK_BLOCKER_ID" "$KICK_READY" "$KICK_RELEASE"
+kick_holder_pid=$HOLDER_PID
+wait_for "$KICK_READY" || fail "could not hold the unrelated source's lock boundary for the kick single-flight cut"
+
+KICK_LAVISH_BIN=$(fm_fakebin "$TMP_ROOT/kick-lavish-stub")
+cat > "$KICK_LAVISH_BIN/lavish-axi" <<'SH'
+#!/usr/bin/env bash
+# Never needs to complete: this cut only inspects how many background
+# reconcile processes a burst of arm calls leaves running, not readiness.
+sleep 300
+SH
+chmod +x "$KICK_LAVISH_BIN/lavish-axi"
+
+KICK_ART="$TMP_ROOT/kick-review.html"
+printf '<h1>kick review</h1>\n' > "$KICK_ART"
+kick_id=$("$ROOT/bin/fm-procevent-lavish.sh" source-id "$KICK_ART")
+PE_TRACKED+=("$HLK|$kick_id")
+for _ in 1 2 3; do
+  PATH="$KICK_LAVISH_BIN:$PATH" FM_HOME="$HLK" FM_PROCEVENT_LAVISH_ARM_WAIT_MS=200 \
+    "$ROOT/bin/fm-procevent-lavish.sh" arm "$KICK_ART" >/dev/null 2>&1 || true
+done
+
+# pgrep -f excludes its own invocation from the match, so this needs no extra
+# filtering the way a `ps | grep` pipeline would to avoid matching itself.
+reconcile_pattern="$ROOT/bin/fm-procevent.sh reconcile"
+running_reconciles=0
+for _ in $(seq 1 50); do
+  running_reconciles=$(pgrep -cf "$reconcile_pattern" 2>/dev/null || printf '0')
+  [ "$running_reconciles" -ge 1 ] && break
+  sleep 0.1
+done
+: > "$KICK_RELEASE"
+wait "$kick_holder_pid" 2>/dev/null || true
+[ "$running_reconciles" -ge 1 ] \
+  || fail "no reconcile process was ever observed running while a kick was blocked; the single-flight cut proves nothing without one"
+[ "$running_reconciles" -le 1 ] \
+  || fail "3 arm calls issued while a kick was blocked left $running_reconciles reconcile processes running concurrently, expected at most 1"
+pass "a burst of arm calls single-flights its background reconcile kick instead of piling up untracked processes"
 
 # --- end-user-aligned regression: the exact drain-before-handling restart cut
 # Reproduces the confirmed defect through the public interface end to end: a

--- a/tests/fm-procevent.test.sh
+++ b/tests/fm-procevent.test.sh
@@ -575,7 +575,12 @@ REVIEW_ART="$TMP_ROOT/review.html"
 printf '<h1>review</h1>\n' > "$REVIEW_ART"
 lavish_id=$("$ROOT/bin/fm-procevent-lavish.sh" source-id "$REVIEW_ART")
 PE_TRACKED+=("$HLT|$lavish_id")
-PATH="$LAVISH_BIN:$PATH" FM_HOME="$HLT" "$ROOT/bin/fm-procevent-lavish.sh" arm "$REVIEW_ART" >/dev/null
+# Arm now proves listener liveness before printing armed:, and a Send & End
+# already queued can complete the whole generation inside that verification
+# window, so either outcome here leaves the captured result durable; the wait
+# is bounded only to keep the suite fast.
+PATH="$LAVISH_BIN:$PATH" FM_HOME="$HLT" FM_PROCEVENT_LAVISH_ARM_WAIT_MS=1000 \
+  "$ROOT/bin/fm-procevent-lavish.sh" arm "$REVIEW_ART" >/dev/null || true
 for _ in $(seq 1 6); do
   PATH="$LAVISH_BIN:$PATH" pe "$HLT" reconcile >/dev/null
   sleep 0.3
@@ -594,6 +599,76 @@ assert_grep 'ship it' "$LAVISH_RESULT" "automatic retirement retains the human's
 out=$(PATH="$LAVISH_BIN:$PATH" FM_HOME="$HLT" "$ROOT/bin/fm-procevent-lavish.sh" retire "$REVIEW_ART")
 assert_contains "$out" "retired: $lavish_id" "explicit adapter retirement stays supported after automatic retirement"
 pass "one Send & End yields exactly one captured result, automatic retirement, and no recurring poll"
+
+# --- arm reports ready only after the exact registered listener is live -----
+# The readiness-ordering defect from issue 2756: arm printed `armed:` the
+# moment registration was accepted, though reconcile - not registration -
+# launches the listener, so a source could sit armed with no live owner and
+# no way for feedback to wake anyone. Arm must prove that the generation it
+# just registered has a verifiably live owner before reporting ready, and
+# must return nonzero without `armed:` when that confirmation cannot be
+# obtained. Both sides run through the adapter's public arm command.
+HLA="$TMP_ROOT/hla"; new_home "$HLA"
+ARM_TRIG="$TMP_ROOT/arm-trigger"
+rm -f "$ARM_TRIG"
+LAVISH_BLOCK_BIN=$(fm_fakebin "$TMP_ROOT/lavish-block-stub")
+cat > "$LAVISH_BLOCK_BIN/lavish-axi" <<SH
+#!/usr/bin/env bash
+# Stand-in for \`lavish-axi poll\`: blocks until the trigger file appears,
+# then emits one feedback result, so completion stays under test control
+# while arm verifies listener liveness.
+while [ ! -e "$ARM_TRIG" ]; do sleep 0.02; done
+printf 'session:\n  file: /review.html\n  status: feedback\nfeedback[1]{text}:\n  looks good\n'
+SH
+chmod +x "$LAVISH_BLOCK_BIN/lavish-axi"
+ARM_ART="$TMP_ROOT/arm-review.html"
+printf '<h1>arm review</h1>\n' > "$ARM_ART"
+arm_id=$("$ROOT/bin/fm-procevent-lavish.sh" source-id "$ARM_ART")
+PE_TRACKED+=("$HLA|$arm_id")
+out=$(PATH="$LAVISH_BLOCK_BIN:$PATH" FM_HOME="$HLA" \
+  "$ROOT/bin/fm-procevent-lavish.sh" arm "$ARM_ART") \
+  || fail "arm refused although its own fresh listener generation went live: $out"
+assert_contains "$out" "armed: $arm_id" "arm prints armed only after its own listener generation is live"
+pe "$HLA" list | grep -Eq "^${arm_id}[[:space:]]+lavish[[:space:]]+live([[:space:]]|\$)" \
+  || fail "arm reported ready but list shows no live owner: $(pe "$HLA" list)"
+printf 'done\n' > "$ARM_TRIG"
+for _ in $(seq 1 30); do
+  case "$(wake_payloads "$HLA")" in *"procevent lavish $arm_id 1"*) break ;; esac
+  sleep 0.1
+done
+assert_contains "$(wake_payloads "$HLA")" "procevent lavish $arm_id 1" \
+  "the confirmed live listener really consumes the source end to end"
+
+# The refusal side: a live owner of an OLDER registration generation keeps
+# reconcile from starting this attempt's listener, so the fresh generation can
+# never be confirmed and arm must return nonzero without printing armed:,
+# leaving the registration in place for later reconciliation.
+HLB="$TMP_ROOT/hlb"; new_home "$HLB"
+OLD_ART="$TMP_ROOT/old-review.html"
+printf '<h1>old review</h1>\n' > "$OLD_ART"
+old_id=$("$ROOT/bin/fm-procevent-lavish.sh" source-id "$OLD_ART")
+PE_TRACKED+=("$HLB|$old_id")
+pe_register "$HLB" lavish "$old_id" -- "$BLOCKER" "$TMP_ROOT/never-trigger" "older generation" >/dev/null
+sleep 300 & sleep_pid=$!
+bash -c '
+  . "$1/bin/fm-pr-lib.sh"; . "$1/bin/fm-wake-lib.sh"; . "$1/bin/fm-procevent-lib.sh"
+  fm_procevent_source_lock_acquire "$2" || exit 1
+  fm_procevent_claim_acquire_locked "$2" "$3" "$4" "$3/state/procevent/$2.source" \
+    || { fm_procevent_source_lock_release "$2"; exit 1; }
+  fm_procevent_source_lock_release "$2"
+' _ "$ROOT" "$old_id" "$HLB" "$sleep_pid" \
+  || { kill "$sleep_pid" 2>/dev/null || true; fail "cannot stage an older live generation for the arm refusal cut"; }
+out=$(PATH="$LAVISH_BLOCK_BIN:$PATH" FM_HOME="$HLB" FM_PROCEVENT_LAVISH_ARM_WAIT_MS=300 \
+  "$ROOT/bin/fm-procevent-lavish.sh" arm "$OLD_ART" 2>&1) \
+  && { kill "$sleep_pid" 2>/dev/null || true; fail "arm printed ready although this registration's listener never started: $out"; }
+kill "$sleep_pid" 2>/dev/null || true
+wait "$sleep_pid" 2>/dev/null || true
+assert_not_contains "$out" "armed:" "an unconfirmed listener generation never reports ready"
+assert_contains "$out" "did not confirm live" "the unconfirmed-generation failure names its cause"
+assert_present "$HLB/state/procevent/$old_id.source" \
+  "a refused arm leaves the registration in place for later reconciliation"
+FM_HOME="$HLB" "$ROOT/bin/fm-procevent.sh" retire "$old_id" >/dev/null 2>&1 || true
+pass "arm proves the exact registered listener live before ready and refuses otherwise"
 
 # --- end-user-aligned regression: the exact drain-before-handling restart cut
 # Reproduces the confirmed defect through the public interface end to end: a

--- a/tests/fm-procevent.test.sh
+++ b/tests/fm-procevent.test.sh
@@ -670,6 +670,47 @@ assert_present "$HLB/state/procevent/$old_id.source" \
 FM_HOME="$HLB" "$ROOT/bin/fm-procevent.sh" retire "$old_id" >/dev/null 2>&1 || true
 pass "arm proves the exact registered listener live before ready and refuses otherwise"
 
+# --- reconcile's own lock contention on an UNRELATED source must never widen
+# arm's documented bound. Reconcile walks every machine-wide registered source,
+# not just the one this arm call just registered, so a lock held elsewhere for
+# some other source cannot be allowed to postpone the timed sampling loop that
+# is supposed to be the only thing bounding how long arm waits.
+HLC="$TMP_ROOT/hlc"; new_home "$HLC"
+CONTEND_LAVISH_BIN=$(fm_fakebin "$TMP_ROOT/contend-lavish-stub")
+cat > "$CONTEND_LAVISH_BIN/lavish-axi" <<'SH'
+#!/usr/bin/env bash
+# Never actually needs to run in this test: reconcile is kept from ever
+# reaching this source's own claim by contention staged on an unrelated one.
+printf 'session:\n  file: /review.html\n  status: feedback\nfeedback[1]{text}:\n  contend\n'
+SH
+chmod +x "$CONTEND_LAVISH_BIN/lavish-axi"
+# Sorts before any "lavish-<hash>" source id, so reconcile's own *.source walk
+# reaches this contended registration first.
+CONTEND_BLOCKER_ID="aaa-lock-contender-src"
+pe_register "$HLC" lavish "$CONTEND_BLOCKER_ID" -- /bin/true >/dev/null
+CONTEND_READY="$TMP_ROOT/contend-lock-ready"
+CONTEND_RELEASE="$TMP_ROOT/contend-lock-release"
+hold_source_lock "$CONTEND_BLOCKER_ID" "$CONTEND_READY" "$CONTEND_RELEASE"
+contend_holder_pid=$HOLDER_PID
+wait_for "$CONTEND_READY" || fail "could not hold the unrelated source's lock boundary"
+# Released on its own timer, independent of arm: a synchronous reconcile call
+# would otherwise deadlock this test against arm's own completion.
+( sleep 4; : > "$CONTEND_RELEASE" ) &
+contend_timer_pid=$!
+CONTEND_ART="$TMP_ROOT/contend-review.html"
+printf '<h1>contend review</h1>\n' > "$CONTEND_ART"
+contend_id=$("$ROOT/bin/fm-procevent-lavish.sh" source-id "$CONTEND_ART")
+PE_TRACKED+=("$HLC|$contend_id")
+contend_start=$(date +%s)
+PATH="$CONTEND_LAVISH_BIN:$PATH" FM_HOME="$HLC" FM_PROCEVENT_LAVISH_ARM_WAIT_MS=300 \
+  "$ROOT/bin/fm-procevent-lavish.sh" arm "$CONTEND_ART" >/dev/null 2>&1 || true
+contend_elapsed=$(( $(date +%s) - contend_start ))
+wait "$contend_holder_pid" 2>/dev/null || true
+wait "$contend_timer_pid" 2>/dev/null || true
+[ "$contend_elapsed" -le 2 ] \
+  || fail "arm's bounded wait (300ms) was extended by an unrelated source's lock contention: ${contend_elapsed}s (held for 4s)"
+pass "reconcile's contention on an unrelated source's lock never extends arm's own bound"
+
 # --- end-user-aligned regression: the exact drain-before-handling restart cut
 # Reproduces the confirmed defect through the public interface end to end: a
 # real blocking source completes, its result is captured and published, the

--- a/tests/fm-procevent.test.sh
+++ b/tests/fm-procevent.test.sh
@@ -711,6 +711,66 @@ wait "$contend_timer_pid" 2>/dev/null || true
   || fail "arm's bounded wait (300ms) was extended by an unrelated source's lock contention: ${contend_elapsed}s (held for 4s)"
 pass "reconcile's contention on an unrelated source's lock never extends arm's own bound"
 
+# epoch_ms: integer milliseconds from this shell's own $EPOCHREALTIME. Split on
+# either '.' or ',' - LC_NUMERIC can make bash format EPOCHREALTIME with a
+# comma fraction (seen under e.g. nb_NO.UTF-8) - the same tolerance
+# bin/fm-procevent-lavish.sh's own arm_now_ms uses, so this measurement stays
+# correct under whatever locale the suite happens to run in.
+epoch_ms() {
+  local raw=$EPOCHREALTIME sec frac
+  sec=${raw%%[.,]*}
+  frac=${raw#*[.,]}
+  frac="${frac}000"
+  frac=${frac:0:3}
+  printf '%s\n' "$(( sec * 1000 + 10#$frac ))"
+}
+
+# --- arm_now_ms's fallback clock must still honor a sub-second bound --------
+# Stock macOS ships Bash 3.2, which predates EPOCHREALTIME, so arm_now_ms falls
+# back to a portable clock when that builtin is unavailable. A whole-second
+# fallback (plain `date +%s`) cannot see its own truncated reading advance
+# until the wall clock crosses the NEXT full second, so a short documented
+# wait could silently stretch to almost a full extra second. Reproduced here
+# by unsetting EPOCHREALTIME for the adapter's own process (forcing the exact
+# fallback branch, regardless of which bash runs this suite) and staging a
+# listener generation that can never be confirmed live, same as the refusal
+# case above. The test is synchronized to just after a wall-clock second
+# boundary - the fallback's worst case - so the failure is deterministic
+# rather than a timing coin flip.
+HLE="$TMP_ROOT/hle"; new_home "$HLE"
+FALLBACK_ART="$TMP_ROOT/fallback-review.html"
+printf '<h1>fallback review</h1>\n' > "$FALLBACK_ART"
+fallback_id=$("$ROOT/bin/fm-procevent-lavish.sh" source-id "$FALLBACK_ART")
+PE_TRACKED+=("$HLE|$fallback_id")
+pe_register "$HLE" lavish "$fallback_id" -- "$BLOCKER" "$TMP_ROOT/fallback-never-trigger" "older fallback generation" >/dev/null
+sleep 300 & fallback_sleep_pid=$!
+bash -c '
+  . "$1/bin/fm-pr-lib.sh"; . "$1/bin/fm-wake-lib.sh"; . "$1/bin/fm-procevent-lib.sh"
+  fm_procevent_source_lock_acquire "$2" || exit 1
+  fm_procevent_claim_acquire_locked "$2" "$3" "$4" "$3/state/procevent/$2.source" \
+    || { fm_procevent_source_lock_release "$2"; exit 1; }
+  fm_procevent_source_lock_release "$2"
+' _ "$ROOT" "$fallback_id" "$HLE" "$fallback_sleep_pid" \
+  || { kill "$fallback_sleep_pid" 2>/dev/null || true; fail "cannot stage an older live generation for the fallback-clock cut"; }
+for _ in $(seq 1 400); do
+  frac=$(( $(epoch_ms) % 1000 ))
+  [ "$frac" -lt 60 ] && break
+  sleep 0.01
+done
+fallback_start=$(epoch_ms)
+out=$(PATH="$LAVISH_BLOCK_BIN:$PATH" FM_HOME="$HLE" FM_PROCEVENT_LAVISH_ARM_WAIT_MS=300 \
+  bash -c 'unset EPOCHREALTIME; . "$0" "$@"' "$ROOT/bin/fm-procevent-lavish.sh" arm "$FALLBACK_ART" 2>&1) \
+  && { kill "$fallback_sleep_pid" 2>/dev/null || true; fail "arm printed ready although this registration's listener never started: $out"; }
+fallback_end=$(epoch_ms)
+kill "$fallback_sleep_pid" 2>/dev/null || true
+wait "$fallback_sleep_pid" 2>/dev/null || true
+fallback_elapsed_ms=$(( fallback_end - fallback_start ))
+assert_not_contains "$out" "armed:" "an unconfirmed listener generation never reports ready without EPOCHREALTIME"
+[ "$fallback_elapsed_ms" -le 700 ] \
+  || fail "arm's bounded wait (300ms) took ${fallback_elapsed_ms}ms under the whole-second fallback clock"
+FM_HOME="$HLE" "$ROOT/bin/fm-procevent.sh" retire "$fallback_id" >/dev/null 2>&1 || true
+pass "arm's readiness wait stays sub-second-accurate even without EPOCHREALTIME"
+
 # --- end-user-aligned regression: the exact drain-before-handling restart cut
 # Reproduces the confirmed defect through the public interface end to end: a
 # real blocking source completes, its result is captured and published, the

--- a/tests/fm-procevent.test.sh
+++ b/tests/fm-procevent.test.sh
@@ -771,6 +771,35 @@ assert_not_contains "$out" "armed:" "an unconfirmed listener generation never re
 FM_HOME="$HLE" "$ROOT/bin/fm-procevent.sh" retire "$fallback_id" >/dev/null 2>&1 || true
 pass "arm's readiness wait stays sub-second-accurate even without EPOCHREALTIME"
 
+# --- a single liveness probe cannot hang arm's wait past its own bound ------
+# Regression for the "probe work exceeds timeout" defect: cmd_arm's polling
+# loop only checks the wall-clock deadline BETWEEN calls to
+# fm_procevent_generation_live, never during one, so nothing previously
+# stopped one unexpectedly slow probe (e.g. slow filesystem I/O on the source
+# lock, claim file, or /proc read) from growing arm's total wait past
+# FM_PROCEVENT_LAVISH_ARM_WAIT_MS without limit. arm_probe_live now routes
+# every probe through fm_run_bash_timeout so a stuck probe is killed instead.
+# This runs the adapter's own shipped arm_probe_live definition (extracted
+# verbatim by byte range, not paraphrased) against a stand-in for
+# fm_procevent_generation_live that hangs forever, so the assertion is on
+# arm_probe_live's real, observed exit code and elapsed time - not on any
+# text in the file.
+PROBE_HANG_OUT=$(bash -c '
+  . "$1/bin/fm-timeout-lib.sh"
+  eval "$(sed -n "/^FM_PROCEVENT_LAVISH_ARM_PROBE_TIMEOUT_S=/,/^}/p" "$1/bin/fm-procevent-lavish.sh")"
+  fm_procevent_generation_live() { sleep 300; }
+  start=$SECONDS
+  arm_probe_live x y
+  rc=$?
+  printf "rc=%s elapsed=%s\n" "$rc" "$(( SECONDS - start ))"
+' _ "$ROOT")
+assert_contains "$PROBE_HANG_OUT" "rc=124" \
+  "a liveness probe that hangs is killed and reported as timed out, not left to run forever: $PROBE_HANG_OUT"
+probe_hang_elapsed=${PROBE_HANG_OUT##*elapsed=}
+[ "$probe_hang_elapsed" -le 5 ] \
+  || fail "arm_probe_live took ${probe_hang_elapsed}s to bound a hung probe: $PROBE_HANG_OUT"
+pass "a single hung liveness probe is bounded rather than left free to run indefinitely"
+
 # --- end-user-aligned regression: the exact drain-before-handling restart cut
 # Reproduces the confirmed defect through the public interface end to end: a
 # real blocking source completes, its result is captured and published, the

--- a/tests/fm-procevent.test.sh
+++ b/tests/fm-procevent.test.sh
@@ -891,6 +891,96 @@ wait "$kick_holder_pid" 2>/dev/null || true
   || fail "3 arm calls issued while a kick was blocked left $running_reconciles reconcile processes running concurrently, expected at most 1"
 pass "a burst of arm calls single-flights its background reconcile kick instead of piling up untracked processes"
 
+# --- arm's background reconcile kick coalesces instead of queuing one -------
+# --- unowned waiter per call -------------------------------------------------
+# Regression for the "detached reconcile waiter that can survive the caller"
+# defect: the single-flight cut above proves at most one reconcile process
+# ever RUNS at a time, but the kick used to queue one independent background
+# waiter subshell per arm call regardless - each spin-polling
+# arm_reconcile_kick_lock until its own turn, surviving long after its own
+# arm invocation had already returned, so a burst of N calls left N such
+# detached processes behind rather than at most one running plus one queued.
+# cmd_arm's kick is now coalesced through arm_reconcile_kick_pending_lock:
+# only the one call whose background attempt wins that lock's non-blocking
+# try becomes a real waiter; every other call's attempt loses the try and
+# exits immediately, leaving nothing behind.
+#
+# Proven on real OS process survival, not source text. A backgrounded
+# subshell with more than one statement keeps the interpreter's own argv in
+# ps/cmdline - bash only replaces a background job's cmdline with a tail
+# command's own argv when that command is the subshell's single/last
+# statement (verified separately against this shell), which is never true of
+# this coalescing block since a lock release always follows the reconcile
+# call - so every surviving background arm-kick attempt is directly
+# countable by pattern once its own foreground `arm` invocation has already
+# exited.
+HLK2="$TMP_ROOT/hlk2"; new_home "$HLK2"
+COALESCE_BLOCKER_ID="aab-arm-kick-coalesce-blocker"
+pe_register "$HLK2" lavish "$COALESCE_BLOCKER_ID" -- /bin/true >/dev/null
+COALESCE_READY="$TMP_ROOT/coalesce-lock-ready"
+COALESCE_RELEASE="$TMP_ROOT/coalesce-lock-release"
+hold_source_lock "$COALESCE_BLOCKER_ID" "$COALESCE_READY" "$COALESCE_RELEASE"
+coalesce_holder_pid=$HOLDER_PID
+wait_for "$COALESCE_READY" || fail "could not hold the unrelated source's lock boundary for the kick coalescing cut"
+
+COALESCE_LAVISH_BIN=$(fm_fakebin "$TMP_ROOT/coalesce-lavish-stub")
+cat > "$COALESCE_LAVISH_BIN/lavish-axi" <<'SH'
+#!/usr/bin/env bash
+# Never needs to complete: this cut only inspects how many background
+# arm-kick attempts survive a burst of arm calls, not readiness.
+sleep 300
+SH
+chmod +x "$COALESCE_LAVISH_BIN/lavish-axi"
+
+COALESCE_ART="$TMP_ROOT/coalesce-review.html"
+printf '<h1>coalesce review</h1>\n' > "$COALESCE_ART"
+coalesce_id=$("$ROOT/bin/fm-procevent-lavish.sh" source-id "$COALESCE_ART")
+PE_TRACKED+=("$HLK2|$coalesce_id")
+
+reconcile_pattern="$ROOT/bin/fm-procevent.sh reconcile"
+arm_survivor_pattern="$ROOT/bin/fm-procevent-lavish.sh arm $COALESCE_ART"
+
+# The first call's kick always wins the pending lock uncontested (nothing
+# else is racing for it yet), so its reconcile process becoming observably
+# running is proof the pending lock is free again - releasing it happens
+# strictly before that process is started - which is the exact moment every
+# later call's own attempt below races for it.
+PATH="$COALESCE_LAVISH_BIN:$PATH" FM_HOME="$HLK2" FM_PROCEVENT_LAVISH_ARM_WAIT_MS=200 \
+  "$ROOT/bin/fm-procevent-lavish.sh" arm "$COALESCE_ART" >/dev/null 2>&1 &
+first_arm_pid=$!
+first_reconcile_seen=0
+for _ in $(seq 1 100); do
+  # pgrep -c prints "0" AND exits nonzero on a genuine zero-match, so an
+  # `|| printf '0'` fallback here would double it to "0\n0"; normalize
+  # instead of falling back.
+  reconcile_count=$(pgrep -cf "$reconcile_pattern" 2>/dev/null)
+  case "$reconcile_count" in ''|*[!0-9]*) reconcile_count=0 ;; esac
+  [ "$reconcile_count" -ge 1 ] && { first_reconcile_seen=1; break; }
+  sleep 0.05
+done
+if [ "$first_reconcile_seen" -ne 1 ]; then
+  : > "$COALESCE_RELEASE"
+  wait "$coalesce_holder_pid" 2>/dev/null || true
+  wait "$first_arm_pid" 2>/dev/null || true
+  fail "the first arm call's kick never started a reconcile process; the coalescing cut proves nothing without one"
+fi
+
+for _ in 1 2 3 4; do
+  PATH="$COALESCE_LAVISH_BIN:$PATH" FM_HOME="$HLK2" FM_PROCEVENT_LAVISH_ARM_WAIT_MS=200 \
+    "$ROOT/bin/fm-procevent-lavish.sh" arm "$COALESCE_ART" >/dev/null 2>&1 || true
+done
+wait "$first_arm_pid" 2>/dev/null || true
+
+survivors=$(pgrep -cf "$arm_survivor_pattern" 2>/dev/null)
+case "$survivors" in ''|*[!0-9]*) survivors=0 ;; esac
+: > "$COALESCE_RELEASE"
+wait "$coalesce_holder_pid" 2>/dev/null || true
+[ "$survivors" -ge 1 ] \
+  || fail "no background arm-kick attempt was ever observed surviving its own arm call; the coalescing cut proves nothing without one"
+[ "$survivors" -le 2 ] \
+  || fail "5 arm calls issued while a kick was blocked left $survivors background kick attempts alive at once, expected at most 2 (one running, one coalesced and queued)"
+pass "a burst of arm calls coalesces its background reconcile kick to at most one queued waiter instead of one detached waiter per call"
+
 # --- end-user-aligned regression: the exact drain-before-handling restart cut
 # Reproduces the confirmed defect through the public interface end to end: a
 # real blocking source completes, its result is captured and published, the

--- a/tests/fm-procevent.test.sh
+++ b/tests/fm-procevent.test.sh
@@ -848,6 +848,60 @@ await_deadline_elapsed_ms=${AWAIT_DEADLINE_OUT##*elapsed_ms=}
   || fail "arm_await_live took ${await_deadline_elapsed_ms}ms to give up on an already-exhausted deadline against a hung probe (expected single-digit ms, not the old 50ms-floor overrun): $AWAIT_DEADLINE_OUT"
 pass "arm_await_live gives up at its own deadline even while its most recently launched probe is still hung"
 
+# --- an abandoned probe never follows a symlink planted at its status path -
+# Regression for the "delayed probe follows replaced path" defect:
+# arm_await_live used to unconditionally `rm -f` its shared status_file right
+# before returning, even when the most recently launched probe was still
+# outstanding (deadline reached before that probe wrote its result). That
+# probe keeps running in the background and eventually performs
+# `printf '%s\n' "$?" > "$status_file"` - a plain `>` redirection that follows
+# a symlink. Removing the file first, then returning control to a caller
+# while that write is still pending, opened a window: a local process that
+# plants a symlink at the exact (now-unlinked) status path before the
+# abandoned probe's delayed write lands gets that write - and whatever it
+# points at truncated - instead. This exercises the real shipped
+# arm_now_ms/arm_probe_live/arm_await_live (same byte-range extraction as the
+# tests above) with a fm_procevent_generation_live stand-in that outlives an
+# already-short deadline, captures the actual status-file path a real
+# `mktemp` call produces (by shadowing the `mktemp` command with a logging
+# wrapper, not by guessing a name), races a symlink to a canary file into
+# that exact path the instant arm_await_live returns control, then lets the
+# abandoned probe's delayed write actually happen and asserts the canary
+# survived - the observable proof that removal is skipped whenever a probe
+# write to that path is still pending, not a read of the source text.
+SYMLINK_TMPDIR=$(mktemp -d "${TMPDIR:-/tmp}/arm-symlink-race.XXXXXX")
+CANARY="$SYMLINK_TMPDIR/canary"
+printf 'do-not-touch\n' > "$CANARY"
+MKTEMP_LOG="$SYMLINK_TMPDIR/mktemp.log"
+: > "$MKTEMP_LOG"
+bash -c '
+  . "$1/bin/fm-timeout-lib.sh"
+  eval "$(sed -n "/^FM_PROCEVENT_LAVISH_ARM_PROBE_TIMEOUT_S=/,/^}/p" "$1/bin/fm-procevent-lavish.sh")"
+  eval "$(sed -n "/^arm_now_ms()/,/^}/p" "$1/bin/fm-procevent-lavish.sh")"
+  eval "$(sed -n "/^arm_probe_live()/,/^}/p" "$1/bin/fm-procevent-lavish.sh")"
+  eval "$(sed -n "/^arm_await_live()/,/^}/p" "$1/bin/fm-procevent-lavish.sh")"
+  die() { printf "error: %s\n" "$1" >&2; exit 1; }
+  real_mktemp=$(command -v mktemp)
+  mktemp_log=$2
+  mktemp() { local p; p=$("$real_mktemp" "$@"); printf "%s\n" "$p" >> "$mktemp_log"; printf "%s\n" "$p"; }
+  fm_procevent_generation_live() { sleep 0.3; return 1; }
+  start_ms=$(arm_now_ms)
+  deadline_ms=$(( start_ms + 100 ))
+  arm_await_live x y "$deadline_ms"
+' _ "$ROOT" "$MKTEMP_LOG"
+SYMLINK_RACE_STATUS_FILE=$(head -n1 "$MKTEMP_LOG")
+[ -n "$SYMLINK_RACE_STATUS_FILE" ] \
+  || fail "arm_await_live's probe status file path was never captured"
+# Only succeeds pre-fix, where the file was already unlinked at this point;
+# post-fix the real file is still there so this is a harmless no-op.
+ln -s "$CANARY" "$SYMLINK_RACE_STATUS_FILE" 2>/dev/null || true
+sleep 1
+SYMLINK_RACE_CANARY_CONTENT=$(cat "$CANARY")
+rm -rf "$SYMLINK_TMPDIR"
+[ "$SYMLINK_RACE_CANARY_CONTENT" = "do-not-touch" ] \
+  || fail "an abandoned arm liveness probe followed a symlink planted at its removed status path and clobbered an unrelated file (got: $SYMLINK_RACE_CANARY_CONTENT)"
+pass "an abandoned arm liveness probe never follows a symlink planted at its status path"
+
 # --- arm's background reconcile kick is single-flighted, not one-per-call ---
 # Regression for the "background reconciles remain unowned" defect: arm used
 # to fire an unconditional `fm-procevent.sh reconcile &` on every call, so a

--- a/tests/fm-procevent.test.sh
+++ b/tests/fm-procevent.test.sh
@@ -773,26 +773,30 @@ pass "arm's readiness wait stays sub-second-accurate even without EPOCHREALTIME"
 
 # --- a single liveness probe cannot hang arm's wait past its own bound ------
 # Regression for the "probe work exceeds timeout" defect: cmd_arm's polling
-# loop only checks the wall-clock deadline BETWEEN calls to
+# loop only checked the wall-clock deadline BETWEEN calls to
 # fm_procevent_generation_live, never during one, so nothing previously
 # stopped one unexpectedly slow probe (e.g. slow filesystem I/O on the source
 # lock, claim file, or /proc read) from growing arm's total wait past
-# FM_PROCEVENT_LAVISH_ARM_WAIT_MS without limit. arm_probe_live now routes
-# every probe through fm_run_bash_timeout so a stuck probe is killed instead.
-# This runs the adapter's own shipped arm_probe_live definition (extracted
+# FM_PROCEVENT_LAVISH_ARM_WAIT_MS without limit. arm_probe_live routes every
+# probe through fm_run_bash_timeout so a stuck probe is killed instead. This
+# runs the adapter's own shipped arm_probe_live definition (extracted
 # verbatim by byte range, not paraphrased) against a stand-in for
-# fm_procevent_generation_live that hangs forever, so the assertion is on
-# arm_probe_live's real, observed exit code and elapsed time - not on any
-# text in the file. A generous 10s remaining-budget argument is passed so the
-# safety-ceiling path is what gets exercised here, not the deadline-bound path
-# covered separately below.
+# fm_procevent_generation_live that hangs forever, so the assertion is on the
+# real, observed exit code fm_run_bash_timeout records to the status file and
+# elapsed time - not on any text in the file. arm_probe_live itself now only
+# launches the probe in the background (see the next test for the caller-side
+# deadline guarantee that motivates that), so this test waits on it directly.
 PROBE_HANG_OUT=$(bash -c '
   . "$1/bin/fm-timeout-lib.sh"
   eval "$(sed -n "/^FM_PROCEVENT_LAVISH_ARM_PROBE_TIMEOUT_S=/,/^}/p" "$1/bin/fm-procevent-lavish.sh")"
   fm_procevent_generation_live() { sleep 300; }
+  status_file=$(mktemp "${TMPDIR:-/tmp}/probe-hang-status.XXXXXX")
   start=$SECONDS
-  arm_probe_live x y 10000
-  rc=$?
+  arm_probe_live x y "$status_file"
+  probe_pid=$!
+  wait "$probe_pid" 2>/dev/null
+  rc=$(cat "$status_file")
+  rm -f "$status_file"
   printf "rc=%s elapsed=%s\n" "$rc" "$(( SECONDS - start ))"
 ' _ "$ROOT")
 assert_contains "$PROBE_HANG_OUT" "rc=124" \
@@ -802,33 +806,47 @@ probe_hang_elapsed=${PROBE_HANG_OUT##*elapsed=}
   || fail "arm_probe_live took ${probe_hang_elapsed}s to bound a hung probe: $PROBE_HANG_OUT"
 pass "a single hung liveness probe is bounded rather than left free to run indefinitely"
 
-# --- a probe launched near the deadline cannot overrun it by the full ceiling
-# Regression for the "probe timeout exceeds arm deadline" defect: a hung probe
-# was always given the full FM_PROCEVENT_LAVISH_ARM_PROBE_TIMEOUT_S (2s)
-# ceiling regardless of how much of the caller's own bound actually remained,
-# so a near-zero or already-exhausted budget could still overrun by roughly
-# 2s. arm_probe_live now bounds each probe by whichever is smaller: the
-# ceiling, or the caller's own remaining-ms argument (floored at
-# FM_PROCEVENT_LAVISH_ARM_PROBE_MIN_MS so a real check still happens). Same
-# extraction technique as above - the real shipped function, a hanging
-# fm_procevent_generation_live stand-in - but this time with a 0ms remaining
-# budget, so a passing result depends on the probe actually honoring that
-# argument rather than falling back to the full ceiling.
-PROBE_DEADLINE_OUT=$(bash -c '
+# --- arm_await_live never blocks past its own deadline on a hung probe -----
+# Regression for the "probe floor exceeds deadline" defect: an earlier
+# revision sized each probe's fm_run_bash_timeout bound off the caller's own
+# remaining-ms budget, floored at FM_PROCEVENT_LAVISH_ARM_PROBE_MIN_MS so that
+# bound was never zero/negative (which disables it entirely) - and then
+# WAITED SYNCHRONOUSLY for that bounded call to return, termination grace
+# included, before rechecking the wall clock. A probe launched with only a
+# few ms of remaining budget therefore still ran for up to the floor, so a
+# genuinely wedged fm_procevent_generation_live made arm return tens of ms
+# after FM_PROCEVENT_LAVISH_ARM_WAIT_MS had already expired, no matter how
+# small that floor was shrunk. arm_await_live now launches each probe in the
+# background (arm_probe_live) and polls its status file against the wall
+# clock instead of waiting on it, so it can give up right at its deadline
+# regardless of how long the most recently launched probe takes to actually
+# die. Same extraction technique as above - the real shipped functions
+# (arm_now_ms, arm_probe_live, arm_await_live), a fm_procevent_generation_live
+# stand-in that never returns - with an already-exhausted (0ms) deadline, the
+# exact "arm wait is zero" case the defect report named: on the prior
+# implementation this measured ~85ms (the 50ms floor plus overhead) on this
+# machine; on this implementation it measures ~8ms, so 40ms is comfortably
+# between the two rather than a razor-thin margin either side could cross on
+# a noisy CI runner.
+AWAIT_DEADLINE_OUT=$(bash -c '
   . "$1/bin/fm-timeout-lib.sh"
   eval "$(sed -n "/^FM_PROCEVENT_LAVISH_ARM_PROBE_TIMEOUT_S=/,/^}/p" "$1/bin/fm-procevent-lavish.sh")"
+  eval "$(sed -n "/^arm_now_ms()/,/^}/p" "$1/bin/fm-procevent-lavish.sh")"
+  eval "$(sed -n "/^arm_await_live()/,/^}/p" "$1/bin/fm-procevent-lavish.sh")"
+  die() { printf "error: %s\n" "$1" >&2; exit 1; }
   fm_procevent_generation_live() { sleep 300; }
-  start=$SECONDS
-  arm_probe_live x y 0
+  start_ms=$(arm_now_ms)
+  arm_await_live x y "$start_ms"
   rc=$?
-  printf "rc=%s elapsed=%s\n" "$rc" "$(( SECONDS - start ))"
+  end_ms=$(arm_now_ms)
+  printf "rc=%s elapsed_ms=%s\n" "$rc" "$(( end_ms - start_ms ))"
 ' _ "$ROOT")
-assert_contains "$PROBE_DEADLINE_OUT" "rc=124" \
-  "a hung probe at a zero-ms remaining budget is still killed and reported as timed out: $PROBE_DEADLINE_OUT"
-probe_deadline_elapsed=${PROBE_DEADLINE_OUT##*elapsed=}
-[ "$probe_deadline_elapsed" -le 1 ] \
-  || fail "arm_probe_live took ${probe_deadline_elapsed}s to bound a hung probe at a zero-ms remaining budget (expected close to FM_PROCEVENT_LAVISH_ARM_PROBE_MIN_MS, not the full 2s ceiling): $PROBE_DEADLINE_OUT"
-pass "a liveness probe launched at a zero-ms remaining budget is bounded by that budget, not the full safety ceiling"
+assert_contains "$AWAIT_DEADLINE_OUT" "rc=1" \
+  "an unconfirmed generation with a permanently hung probe still refuses rather than blocking on it: $AWAIT_DEADLINE_OUT"
+await_deadline_elapsed_ms=${AWAIT_DEADLINE_OUT##*elapsed_ms=}
+[ "$await_deadline_elapsed_ms" -le 40 ] \
+  || fail "arm_await_live took ${await_deadline_elapsed_ms}ms to give up on an already-exhausted deadline against a hung probe (expected single-digit ms, not the old 50ms-floor overrun): $AWAIT_DEADLINE_OUT"
+pass "arm_await_live gives up at its own deadline even while its most recently launched probe is still hung"
 
 # --- arm's background reconcile kick is single-flighted, not one-per-call ---
 # Regression for the "background reconciles remain unowned" defect: arm used


### PR DESCRIPTION
## What Changed
- `bin/fm-procevent-lavish.sh arm` now kicks a single-flighted background `reconcile` pass immediately after registering, then polls `fm_procevent_generation_live` in a wall-clock-bounded loop (`FM_PROCEVENT_LAVISH_ARM_WAIT_MS`, default 5000ms) until a live owner holds exactly the freshly registered generation before printing `armed:`; on timeout it exits nonzero with the registration left in place for later reconciliation. Adds `arm_now_ms` (EPOCHREALTIME with a perl fallback) and `arm_probe_live` to bound each liveness probe via `fm_run_bash_timeout`.
- `bin/fm-procevent-lib.sh` adds `fm_procevent_generation_live`, which under a try-acquire of the source lock confirms a claim's recorded registration identity matches a caller-supplied identity and that its owning process is verifiably alive.
- `bin/fm-procevent.sh cmd_register` now captures the file identity of the just-published registration while still holding the source lock and includes it in the `registered: <id> (<adapter>) <identity>` output line, so callers can later confirm that exact generation.
- Updates `docs/configuration.md` and `docs/verification/process-event-sources.md` with the new `FM_PROCEVENT_LAVISH_ARM_WAIT_MS` setting and verification evidence, and extends `tests/fm-procevent.test.sh` with coverage for arm's liveness confirmation path.

## Risk Assessment

✅ Low: The change adds a bounded, single-flighted liveness-confirmation step to `fm-procevent-lavish.sh arm` (plus a matching identity-echo in `fm-procevent.sh register`); I traced the identity capture (device:inode under the source lock), the deadline/probe-timeout arithmetic (including the sub-second EPOCHREALTIME/perl/date fallback chain and the per-probe hard bound via fm_run_bash_timeout), the single-flight reconcile-kick lock's directory precondition, and confirmed the register output-format change is additive and only consumed via substring/exit-code checks elsewhere — no reachable path produces a wrong result or regresses a caller, and the new tests exercise real process/timing behavior rather than source-text matching.

## Testing

The targeted test file tests/fm-procevent.test.sh passes in full, and its 6 new cases directly cover the stated intent (arm proves listener liveness before reporting ready) end to end through the public CLI and real observed process/wake-queue state, not source-text matching. A manual CLI transcript reproducing both the success and refusal paths against the real `arm` command corroborates the same behavior. No test failures, no setup issues, and the worktree and temp dirs are clean of transient artifacts.

<details>
<summary>Evidence: CLI transcript: arm confirms listener liveness (success) and refuses cleanly (older live generation)</summary>

Source: [CLI transcript: arm confirms listener liveness (success) and refuses cleanly (older live generation)](https://github.com/Lifferado/firstmate/blob/8c92c0fa2371897d1ff53afc2d45ceb0d8b84a3e/.no-mistakes/evidence/fm/lavish-arm-y8/arm-liveness-cli-transcript.txt)

```text
==========================================================
SCENARIO 1: listener confirmed live -> arm reports armed:
==========================================================
$ fm-procevent-lavish.sh arm /tmp/arm-manual-demo.OT8WsW/review1.html
registered: lavish-388963c75c6b5270 (lavish) 54:419711
armed: lavish-388963c75c6b5270
artifact: /tmp/arm-manual-demo.OT8WsW/review1.html
(exit code: 0)

$ fm-procevent.sh list   # confirms a live owner exists at the moment armed: was printed
SOURCE                       ADAPTER      OWNER      PENDING
lavish-388963c75c6b5270      lavish       live       0

-- releasing the fake listener's trigger so it can complete --
$ cat state/.wake-queue   # the confirmed-live listener really consumed the source
1787394555	35	check	procevent:lavish-388963c75c6b5270:2	check: procevent lavish lavish-388963c75c6b5270 2
1787394556	36	check	procevent:lavish-388963c75c6b5270:1	check: procevent lavish lavish-388963c75c6b5270 1
1787394556	37	check	procevent:lavish-388963c75c6b5270:2	check: procevent lavish lavish-388963c75c6b5270 2

==========================================================
SCENARIO 2: an older generation's listener is live instead
of this attempt's - arm refuses, prints no armed: line
==========================================================
$ fm-procevent-lavish.sh arm /tmp/arm-manual-demo.OT8WsW/review2.html   # (FM_PROCEVENT_LAVISH_ARM_WAIT_MS=500 to keep the demo short)
registered: lavish-8a59ecbc002554e2 (lavish) 54:420196
error: listener for lavish-8a59ecbc002554e2 did not confirm live within 500ms
(exit code: 1 -- nonzero means refused; no 'armed:' line was printed above)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"d2b3ac795a4f6efb49658a6b41083ace249b121d","steps":[{"step":"intent","status":"skipped"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-procevent.test.sh (full file — the smallest self-contained test target for this change; all cases pass, including 6 new arm-liveness cases)`
- <code>Manual CLI transcript: `fm-procevent-lavish.sh arm &lt;artifact&gt;` success path — printed `armed:` only after `fm-procevent.sh list` showed a live owner, then the listener actually drained the source into the wake queue</code>
- <code>Manual CLI transcript: `fm-procevent-lavish.sh arm &lt;artifact&gt;` refusal path — an older live registration generation caused arm to exit nonzero with no `armed:` line and an explicit `did not confirm live` error, leaving the registration in place</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
