### PR TITLE
fix(bin): record a lost relay connection instead of an unanswered turn

### DIFF
--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -7,6 +7,8 @@ dropped stops being a decision and becomes a blind spot.
 
 ## A captain-facing surface is not automatically a `VISION.md` violation
 
+This is the first mate's working interpretation rather than settled repository policy; whether `VISION.md` itself should be reconciled remains an open question belonging to the captain; and the conditions listed below are what this interpretation depends on.
+
 `VISION.md` says "The captain talks to the first mate and to nobody else; every
 worker reports through the first mate and never addresses the captain directly."
 That line protects who is answerable for work. Read alongside the sentence it

--- a/bin/fm-voice-client.py
+++ b/bin/fm-voice-client.py
@@ -211,6 +211,15 @@ class FilePlayback:
         # own turn lock, so nothing slow may ever be done under it. _handle_lock
         # covers the file itself, so a write and a close cannot overlap. The
         # ordering is always _handle_lock then _lock and never the reverse.
+        #
+        # What close() needing _handle_lock costs: the exit is now only as bounded
+        # as one write to --out-file, so on a hung or full filesystem the five
+        # second downlink join in Client.close no longer bounds it. The wedged relay
+        # that join was written for is unaffected, being another process while this
+        # write is local. That cost belongs to the filed teardown-ordering work,
+        # whose other half is the same five second join being shorter than the ten
+        # seconds the relay may spend draining its own reply stream, which is why
+        # audio can arrive after the output is released at all.
         self._handle_lock = threading.Lock()
         self._lock = threading.Lock()
         self.first_played = None
@@ -299,8 +308,14 @@ class SpeakerPlayback:
         self._lock = threading.Lock()
         self.first_played = None
         self.turn_bytes = 0
+        # The same diagnostic the file path keeps, for the same reason. A counter
+        # that can only ever read zero is indistinguishable from one that measured
+        # zero, and this is the path the captain will actually use, so the write
+        # after close that the counter exists to catch has to be visible here too.
+        self.discarded = 0
         self._turn = None
         self._earlier = 0
+        self._closed = False
         self._stream = sounddevice.RawOutputStream(
             samplerate=OUT_RATE, channels=1, dtype="int16",
             blocksize=OUT_BLOCK, device=device, latency="low",
@@ -325,6 +340,17 @@ class SpeakerPlayback:
 
     def write(self, pcm, turn):
         with self._lock:
+            # close() stops the stream, and after that no callback drains the
+            # buffer, so a chunk arriving here was never going to be heard however
+            # it is stored. Discarded and counted rather than queued and credited
+            # to the turn, which is what the file path does: queued, it is a
+            # measurement the captain never heard, and silent, the write after
+            # close outside teardown that this counts for would be invisible on the
+            # one path they use. Counted and nothing more, so it stamps no clock
+            # and reaches neither answered, first_audio_s nor the exit code.
+            if self._closed:
+                self.discarded += 1
+                return
             if turn == self._turn:
                 self.turn_bytes += len(pcm)
             else:
@@ -352,6 +378,13 @@ class SpeakerPlayback:
         time.sleep(0.2)
 
     def close(self):
+        # Marked before the stream is stopped and not while the lock is held: the
+        # device callback takes this lock, and stop() waits for a callback already
+        # running, so holding it across the stop is a deadlock. Marking first
+        # instead leaves no instant where the stream is gone and a write still
+        # queues for it.
+        with self._lock:
+            self._closed = True
         try:
             self._stream.stop()
             self._stream.close()
@@ -660,9 +693,17 @@ class Client:
 
         Expected while this end is shutting down and said nowhere else, so a count
         appearing on a session that has not ended is the logic bug it is kept for.
-        Diagnostic only: it names nothing in the record and decides no exit code.
+        That holds on both output paths, because both count it. Diagnostic only: it
+        names nothing in the record and decides no exit code.
+
+        Read straight off the playback rather than through a default, so a playback
+        that cannot answer is a failure here rather than a zero indistinguishable
+        from having measured none. The None check is close()'s own, for the startup
+        that refused before there was an output at all.
         """
-        dropped = getattr(self.playback, "discarded", 0)
+        if self.playback is None:
+            return
+        dropped = self.playback.discarded
         if dropped:
             log(self.verbose,
                 "discarded {} reply audio chunk(s) that arrived after the output "

--- a/bin/fm-voice-client.py
+++ b/bin/fm-voice-client.py
@@ -838,7 +838,8 @@ class Client:
                     self.closed.set()
                 break
             if got is None:
-                say("client: the connection ended")
+                if not self.quitting.is_set():
+                    say("client: the connection ended")
                 # The subject only. Whether it ended before the turn was answered
                 # or partway through the answer is decided by _unfinished at the
                 # tail, where the audio count is read.
@@ -1062,6 +1063,7 @@ class Client:
             turn = dict(self.turn)
         marks = turn.get("marks", {})
         played = self.playback.first_played
+        reply_bytes = self.playback.turn_bytes
         first_frame = turn.get("first_frame")
 
         def since(at):
@@ -1103,8 +1105,8 @@ class Client:
             # cannot tell a reply from the previous reply's tail arriving late, and
             # counting that tail here reports a turn nobody answered as answered.
             "reply_audio_seconds": round(
-                self.playback.turn_bytes / float(OUT_RATE * 2), 3),
-            "answered": self.playback.turn_bytes > 0,
+                reply_bytes / float(OUT_RATE * 2), 3),
+            "answered": reply_bytes > 0,
         }
         if release is None:
             record["first_audio_note"] = (

--- a/bin/fm-voice-client.py
+++ b/bin/fm-voice-client.py
@@ -91,8 +91,8 @@ import fm_voice_frame as frame              # noqa: E402
 
 IN_RATE = 16000
 OUT_RATE = 24000
-# 100 ms at each rate. The uplink chunk matches what the relay and the survey
-# measured with; changing it changes the numbers.
+# 100 ms at each rate. The uplink chunk matches what the relay and the earlier
+# prototype work measured with; changing it changes the numbers.
 CHUNK = 3200
 OUT_BLOCK = 2400
 

--- a/bin/fm-voice-client.py
+++ b/bin/fm-voice-client.py
@@ -831,7 +831,9 @@ class Client:
                 with self.lock:
                     if not self.reply_done.is_set():
                         self.turn.setdefault(
-                            "failed", "the connection was lost: {}".format(exc))
+                            "failed", "{}: {}".format(
+                                self._unfinished("the connection was lost"),
+                                exc))
                     self.closed_because = "the connection was lost"
                     self.closed.set()
                 break

--- a/bin/fm-voice-client.py
+++ b/bin/fm-voice-client.py
@@ -84,6 +84,7 @@ import subprocess
 import sys
 import threading
 import time
+import traceback
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
@@ -186,22 +187,39 @@ class Uplink:
 
 
 class FilePlayback:
-    """Write reply audio to a file. This is the path that can be verified here."""
+    """Write reply audio to a file. This is the path that can be verified here.
+
+    Every chunk carries the turn it belongs to, and turn_reset names the turn
+    being measured. A chunk from a turn that has already been recorded is still
+    written, because it is the tail of an answer the captain is still listening
+    to, but it stamps no clock and is counted toward nobody: attributed to the
+    turn that happens to be open, it would hand that turn a first-audio figure
+    measured from somebody else's reply and report it answered when it was not.
+    """
 
     def __init__(self, path):
         self._handle = open(path, "wb")
         self.first_played = None
         self.device_latency = None
+        # Everything written, and what the turn being measured is owed. The
+        # difference is the audio of turns already recorded.
         self.bytes = 0
+        self.turn_bytes = 0
+        self._turn = None
 
-    def write(self, pcm):
-        if self.first_played is None:
+    def write(self, pcm, turn):
+        mine = turn == self._turn
+        if mine and self.first_played is None:
             self.first_played = time.monotonic()
         self._handle.write(pcm)
         self.bytes += len(pcm)
+        if mine:
+            self.turn_bytes += len(pcm)
 
-    def turn_reset(self):
+    def turn_reset(self, turn):
+        self._turn = turn
         self.first_played = None
+        self.turn_bytes = 0
 
     def drain(self, timeout=5):
         del timeout
@@ -219,6 +237,16 @@ class SpeakerPlayback:
     the last moment this process can see. The device's own output buffer sits
     after that, so its reported latency is included in the turn record rather
     than pretended away.
+
+    That timestamp is why the turn a chunk belongs to has to travel with the
+    chunk rather than being checked before the write: the moment that matters
+    happens in the callback, later than the frame arriving, and the gap between
+    the two is the honest content of the figure. So the buffer remembers how many
+    of its leading bytes belong to turns already recorded, and the first audio of
+    the turn being measured is the first byte past them. Ordering makes that a
+    count rather than a per-chunk tag: the downlink hands chunks over in arrival
+    order on one thread and a turn number never goes backwards, so a chunk from an
+    earlier turn can never queue behind one from a later turn.
     """
 
     def __init__(self, device=None):
@@ -227,6 +255,9 @@ class SpeakerPlayback:
         self._lock = threading.Lock()
         self.first_played = None
         self.bytes = 0
+        self.turn_bytes = 0
+        self._turn = None
+        self._earlier = 0
         self._stream = sounddevice.RawOutputStream(
             samplerate=OUT_RATE, channels=1, dtype="int16",
             blocksize=OUT_BLOCK, device=device, latency="low",
@@ -241,20 +272,32 @@ class SpeakerPlayback:
             take = min(want, len(self._buffer))
             chunk = bytes(self._buffer[:take])
             del self._buffer[:take]
-            if chunk and self.first_played is None:
+            spent = min(self._earlier, take)
+            self._earlier -= spent
+            if take > spent and self.first_played is None:
                 self.first_played = time.monotonic()
         outdata[:take] = chunk
         if take < want:
             outdata[take:want] = b"\x00" * (want - take)
 
-    def write(self, pcm):
+    def write(self, pcm, turn):
         with self._lock:
+            if turn == self._turn:
+                self.turn_bytes += len(pcm)
+            else:
+                self._earlier += len(pcm)
             self._buffer += pcm
         self.bytes += len(pcm)
 
-    def turn_reset(self):
+    def turn_reset(self, turn):
         with self._lock:
+            self._turn = turn
             self.first_played = None
+            self.turn_bytes = 0
+            # Whatever is still queued was spoken for an earlier turn. Counted as
+            # this turn's, the previous answer's undrained tail would stamp this
+            # turn's first audio the instant the device next asked for a block.
+            self._earlier = len(self._buffer)
 
     def drain(self, timeout=30):
         """Wait for the buffered reply to finish, so the process does not cut it off."""
@@ -415,11 +458,17 @@ class Client:
         self.uplink = None
         self.playback = None
         self.capture = None
+        self.down_thread = None
         self.up_q = queue.Queue()
         self.talking = threading.Event()
         self.ready = threading.Event()
         self.reply_done = threading.Event()
         self.closed = threading.Event()
+        # Set the moment this end asks the relay to stop. It is the only thing
+        # that tells an expected goodbye from the relay stopping on its own,
+        # because the frame is the same one either way, and reading a clean end as
+        # a fault would train the captain to ignore the line that means it.
+        self.quitting = threading.Event()
         self.ready_notice = {}
         self.turn = {}
         # Which turn self.turn is. A frame is read on one thread and applied on
@@ -432,10 +481,12 @@ class Client:
         # downlink takes a copy of this when a frame arrives and applies nothing
         # once it no longer matches.
         self.turn_id = 0
-        # What run() tells the captain when no further turn can be taken. The
-        # connection ending is the ordinary reason and stays the default; a fault
-        # on this end replaces it, because a line naming the wrong cause sends
-        # them looking where the fault is not.
+        # What run() tells the captain when no further turn can be taken. Every
+        # path that makes the connection unusable names itself here, so the line
+        # about the runs that were lost restates the cause that was recorded
+        # rather than asserting one; a line naming the wrong cause sends them
+        # looking where the fault is not. The default only covers a closure with
+        # no path at all behind it, which nothing here can currently produce.
         self.closed_because = "the connection closed"
         self.lock = threading.Lock()
 
@@ -485,7 +536,8 @@ class Client:
                 lambda: MicCapture(self.options.input_device))
         self.capture.start(self.up_q, self.talking)
 
-        threading.Thread(target=self._downlink, daemon=True).start()
+        self.down_thread = threading.Thread(target=self._downlink, daemon=True)
+        self.down_thread.start()
         threading.Thread(target=self._sender, daemon=True).start()
 
         self._wait_ready()
@@ -531,7 +583,19 @@ class Client:
         # fields are still None and the original refusal is the message worth
         # keeping.
         if self.uplink is not None:
+            # Before the frame, so the goodbye that answers it is read as the
+            # answer to a question this end asked rather than as the relay
+            # stopping on its own.
+            self.quitting.set()
             self._quietly("the uplink", lambda: self.uplink.send(frame.QUIT))
+        # Before the devices are released, and bounded so a wedged relay cannot
+        # hold the exit. The downlink is still handing reply audio to the speaker,
+        # and a speaker closed underneath it raises there, which the frame-handling
+        # guard would then report as a fault on the way out of a session that
+        # worked. Letting the goodbye above end that thread first costs nothing and
+        # keeps the fault line meaning a fault.
+        if self.down_thread is not None:
+            self.down_thread.join(timeout=5)
         if self.capture is not None:
             self._quietly("the microphone", self.capture.close)
         if self.playback is not None:
@@ -593,6 +657,10 @@ class Client:
         # different faults, so each names itself rather than leaving the tail to
         # guess or to say nothing.
         why = None
+        # And what run() says about the runs that were lost to it. Separate from
+        # the reason above because they are different statements: that one is why
+        # this turn has no answer, this one is why there will be no more turns.
+        cause = None
         while True:
             try:
                 got = self.reader.read()
@@ -612,11 +680,13 @@ class Client:
                 with self.lock:
                     self.turn.setdefault(
                         "failed", "the connection was lost: {}".format(exc))
+                    self.closed_because = "the connection was lost"
                     self.closed.set()
                 break
             if got is None:
                 say("client: the connection ended")
                 why = "the connection ended before this turn was answered"
+                cause = "the connection ended"
                 break
             kind, payload = got
             # Which turn this frame belongs to, taken the moment it arrives. Every
@@ -630,11 +700,15 @@ class Client:
                             now = time.monotonic()
                             self.turn.setdefault("first_frame", now)
                             self.turn["last_frame"] = now
-                    # Played whichever turn it belongs to. Late audio is the tail
-                    # of an answer the captain is still listening to, so dropping
-                    # it would cut them off; only the timing figures are a claim
-                    # about a particular turn.
-                    self.playback.write(payload)
+                    # Played whichever turn it belongs to, and told which that is.
+                    # Late audio is the tail of an answer the captain is still
+                    # listening to, so dropping it would cut them off, but three
+                    # figures are read off what this call does - first_played, the
+                    # reply's own duration and whether the turn was answered at all
+                    # - and a stale chunk credited to the turn now open reports an
+                    # unanswered turn as answered, which is an exit code of zero on
+                    # a session that lost one.
+                    self.playback.write(payload, arrived_in)
                 elif kind == frame.TEXT:
                     obj = frame.decode_json(payload)
                     text = (obj.get("text") or "").strip()
@@ -699,8 +773,20 @@ class Client:
                             if obj.get("mark") == "reply_end":
                                 self.reply_done.set()
                 elif kind == frame.BYE:
-                    say("client: the relay said goodbye")
-                    why = "the relay said goodbye before this turn was answered"
+                    # The same frame ends a session this end asked to end and a
+                    # relay that stopped on its own, so the frame says nothing on
+                    # its own and whether we asked is the whole discriminator.
+                    # Both speak, because a session that ended should say so, and
+                    # neither borrows the other's words: a line that also appears
+                    # when everything worked is a line the captain learns to skip,
+                    # and then the one that means trouble is invisible too.
+                    if self.quitting.is_set():
+                        say("client: the relay signed off")
+                        cause = "the relay signed off after being asked to stop"
+                    else:
+                        say("client: the relay stopped without being asked to")
+                        why = "the relay stopped before this turn was answered"
+                        cause = "the relay stopped without being asked to"
                     break
             except Exception as exc:               # noqa: BLE001
                 # A fault on THIS end, handling a reply that did arrive: the
@@ -718,6 +804,15 @@ class Client:
                 fault = ("this end could not handle the relay's reply: {}: {}"
                          .format(type(exc).__name__, exc))
                 say("client: {}".format(fault))
+                # The one line is for the captain and the record; the traceback is
+                # for whoever has to find the bug behind it. Before this guard
+                # existed the thread died and threading.excepthook printed one, so
+                # a programming error in here would otherwise be strictly harder to
+                # locate than it used to be. Terminal path, so this prints once per
+                # session at worst, and the record keeps the one-line reason
+                # because that field is machine read.
+                sys.stderr.write(traceback.format_exc())
+                sys.stderr.flush()
                 with self.lock:
                     self.turn.setdefault("failed", fault)
                     self.closed_because = fault
@@ -740,6 +835,8 @@ class Client:
         with self.lock:
             if why is not None and not self.reply_done.is_set():
                 self.turn.setdefault("failed", why)
+            if cause is not None:
+                self.closed_because = cause
             self.closed.set()
         self.reply_done.set()
 
@@ -773,8 +870,10 @@ class Client:
             # event as nobody waiting and named nothing, and this turn then waits
             # out its whole timeout to be recorded with no reason at all.
             self.reply_done.clear()
-        self.playback.turn_reset()
-        before = self.playback.bytes
+            # In the same critical section, and named with the same identity the
+            # frames carry, so there is no instant where the turn has advanced and
+            # the playback is still counting audio toward the turn before it.
+            self.playback.turn_reset(self.turn_id)
         self.up_q.put(START)
 
         # Unreachable while parse_args refuses open-mic, and kept so that turning
@@ -834,9 +933,13 @@ class Client:
             "device_output_latency_s": self.playback.device_latency,
             "device_input_latency_s": self.capture.device_latency,
             "relay_marks_since_talk_end": marks,
+            # This turn's own audio, counted by the playback rather than by
+            # subtracting a byte total it shares with every other turn. A total
+            # cannot tell a reply from the previous reply's tail arriving late, and
+            # counting that tail here reports a turn nobody answered as answered.
             "reply_audio_seconds": round(
-                (self.playback.bytes - before) / float(OUT_RATE * 2), 3),
-            "answered": self.playback.bytes > before,
+                self.playback.turn_bytes / float(OUT_RATE * 2), 3),
+            "answered": self.playback.turn_bytes > 0,
         }
         if release is None:
             record["first_audio_note"] = (
@@ -946,6 +1049,18 @@ class Client:
                 "waiting {:.2f}s for the answer to finish".format(remaining))
             time.sleep(remaining)
 
+    def _say_stopped(self, index):
+        """Name why no more turns can be taken, and which run was the first lost.
+
+        The cause is whatever the path that closed the connection recorded, not an
+        assertion made here: a fault on this end leaves the connection open, and a
+        line blaming the connection for it sends the captain to the wrong end.
+        """
+        with self.lock:
+            because = self.closed_because
+        say("client: {} before run {} of {}; it and the rest were not "
+            "taken".format(because, index, self.options.runs))
+
     def run(self):
         rc = 0
         for index in range(1, self.options.runs + 1):
@@ -961,13 +1076,7 @@ class Client:
             # a turn that never opened, since an invented turn is the whole thing
             # being kept out of runs.jsonl.
             if record is None:
-                # What actually stopped it, not an assumption that the connection
-                # went: a fault on this end leaves the connection open, and a line
-                # blaming it would send the captain to the wrong end.
-                with self.lock:
-                    because = self.closed_because
-                say("client: {} before run {} of {}; it and the rest were not "
-                    "taken".format(because, index, self.options.runs))
+                self._say_stopped(index)
                 rc = 1
                 break
             print(json.dumps(record))
@@ -975,6 +1084,17 @@ class Client:
             if not record["answered"]:
                 rc = 1
             if index < self.options.runs:
+                # Checked after the record and before the wait, because that wait
+                # is seconds long and exists only to avoid interrupting the model's
+                # own speech, which a relay that is already gone cannot be doing.
+                # Waiting it out here left the captain sitting through the last
+                # reply's whole spoken duration before being told the session had
+                # stopped. The exit code is still the unhappy one: the runs asked
+                # for were not taken, whatever the last one reported.
+                if self.closed.is_set():
+                    self._say_stopped(index + 1)
+                    rc = 1
+                    break
                 self._let_reply_finish(record)
         return rc
 

--- a/bin/fm-voice-client.py
+++ b/bin/fm-voice-client.py
@@ -583,9 +583,16 @@ class Client:
                 # connection that only says answered: false is indistinguishable
                 # there from a turn the model declined to answer. setdefault
                 # because a relay that named the failure first said it better.
+                #
+                # closed is set in this same critical section, not left to the
+                # tail below, because take_turn decides whether another turn can
+                # be opened by reading it under this lock. Naming the failure
+                # first and announcing the closure afterwards left a window where
+                # the connection was known gone and no reader could tell.
                 with self.lock:
                     self.turn.setdefault(
                         "failed", "the connection was lost: {}".format(exc))
+                    self.closed.set()
                 break
             if got is None:
                 break
@@ -641,14 +648,34 @@ class Client:
                     self.reply_done.set()
             elif kind == frame.BYE:
                 break
-        self.closed.set()
+        # Under the turn lock for the same reason the failure above is: a clean
+        # end of file and a goodbye leave the connection just as unusable as a
+        # dropped one, and take_turn reads this under that lock to decide whether
+        # a turn can still be opened. Already set on the failure path; setting an
+        # event twice costs nothing.
+        with self.lock:
+            self.closed.set()
         self.reply_done.set()
 
     # ---------------------------------------------------------------------- turns
 
     def take_turn(self, index):
-        """Run one turn and return its record."""
+        """Run one turn and return its record, or None if the connection is gone.
+
+        The check and the reset share one critical section with the downlink's
+        closure mark on purpose. The wait between turns is seconds long and is
+        where a relay that dies between questions dies, so the run loop cannot
+        decide to open another turn by reading a flag the downlink sets after it
+        records the failure: between those two writes the connection is already
+        gone and the loop cannot see it. It then cleared the failure the downlink
+        had recorded, sent talk-start into a dead pipe, and came back after the
+        whole reply timeout as answered: false with relay_error: null - a lost
+        connection wearing the shape of a turn the model declined, in the file
+        docs/voice-relay.md computes its published latency spread from.
+        """
         with self.lock:
+            if self.closed.is_set():
+                return None
             self.turn = {}
         self.playback.turn_reset()
         self.reply_done.clear()
@@ -828,29 +855,27 @@ class Client:
         rc = 0
         for index in range(1, self.options.runs + 1):
             record = self.take_turn(index)
+            # take_turn refusing is the one place a closed connection stops the
+            # session, so the outcome is the same wherever the connection went:
+            # nothing more can be taken over it, the runs the captain asked for
+            # were not, and the exit code says so, because a session that stops
+            # early while reporting success is read later as a complete
+            # measurement. A second check here, on a flag read before the turn
+            # rather than under the lock that guards it, is what let a lost
+            # connection through in the first place; and no record is printed for
+            # a turn that never opened, since an invented turn is the whole thing
+            # being kept out of runs.jsonl.
+            if record is None:
+                say("client: the connection closed before run {} of {}; it and "
+                    "the rest were not taken".format(index, self.options.runs))
+                rc = 1
+                break
             print(json.dumps(record))
             sys.stdout.flush()
             if not record["answered"]:
                 rc = 1
-            if self.closed.is_set():
-                break
             if index < self.options.runs:
                 self._let_reply_finish(record)
-                # The connection is checked again on the way out, because that
-                # wait is seconds long and is where a relay that dies between
-                # questions dies. Opening the next turn on a dead connection
-                # cleared the failure the downlink had already recorded, left
-                # nothing to answer it, and returned after the whole reply
-                # timeout as answered: false with relay_error: null - a lost
-                # connection wearing the shape of a turn the model declined, in
-                # the file the published latency spread is read from. Nothing
-                # more can be taken over it, and the runs the captain asked for
-                # were not, so the exit code says so as well.
-                if self.closed.is_set():
-                    say("client: the connection closed after run {} of {}; the "
-                        "rest were not taken".format(index, self.options.runs))
-                    rc = 1
-                    break
         return rc
 
 

--- a/bin/fm-voice-client.py
+++ b/bin/fm-voice-client.py
@@ -422,6 +422,21 @@ class Client:
         self.closed = threading.Event()
         self.ready_notice = {}
         self.turn = {}
+        # Which turn self.turn is. A frame is read on one thread and applied on
+        # another, so a reply that arrives late, or a notice whose handling is
+        # descheduled, can be applied after the turn it belongs to has already
+        # been recorded and the next one opened. Without an identity to compare,
+        # that reply lands on the wrong turn: it names a fault that turn never
+        # had, releases it before its own answer, and stamps its first and last
+        # audio, which are the figures this whole tool exists to report. The
+        # downlink takes a copy of this when a frame arrives and applies nothing
+        # once it no longer matches.
+        self.turn_id = 0
+        # What run() tells the captain when no further turn can be taken. The
+        # connection ending is the ordinary reason and stays the default; a fault
+        # on this end replaces it, because a line naming the wrong cause sends
+        # them looking where the fault is not.
+        self.closed_because = "the connection closed"
         self.lock = threading.Lock()
 
     # ------------------------------------------------------------------ lifecycle
@@ -600,71 +615,113 @@ class Client:
                     self.closed.set()
                 break
             if got is None:
+                say("client: the connection ended")
                 why = "the connection ended before this turn was answered"
                 break
             kind, payload = got
-            if kind == frame.AUDIO:
-                with self.lock:
-                    now = time.monotonic()
-                    self.turn.setdefault("first_frame", now)
-                    self.turn["last_frame"] = now
-                self.playback.write(payload)
-            elif kind == frame.TEXT:
-                obj = frame.decode_json(payload)
-                text = (obj.get("text") or "").strip()
-                if text and not text.startswith("{"):
-                    who = "you" if obj.get("role") == "USER" else "assistant"
-                    say("  {}: {}".format(who, text))
-            elif kind == frame.NOTICE:
-                obj = frame.decode_json(payload)
-                event = obj.get("event", "")
-                if event == "ready":
-                    self.ready_notice = obj
-                    self.ready.set()
-                elif event == "queued":
-                    say("  handed to the first mate: {}".format(
-                        obj.get("request", "")))
+            # Which turn this frame belongs to, taken the moment it arrives. Every
+            # write below applies only while it is still that turn; see turn_id.
+            with self.lock:
+                arrived_in = self.turn_id
+            try:
+                if kind == frame.AUDIO:
                     with self.lock:
-                        self.turn["queued"] = obj.get("note_id", "")
-                elif event == "interrupted":
+                        if arrived_in == self.turn_id:
+                            now = time.monotonic()
+                            self.turn.setdefault("first_frame", now)
+                            self.turn["last_frame"] = now
+                    # Played whichever turn it belongs to. Late audio is the tail
+                    # of an answer the captain is still listening to, so dropping
+                    # it would cut them off; only the timing figures are a claim
+                    # about a particular turn.
+                    self.playback.write(payload)
+                elif kind == frame.TEXT:
+                    obj = frame.decode_json(payload)
+                    text = (obj.get("text") or "").strip()
+                    if text and not text.startswith("{"):
+                        who = "you" if obj.get("role") == "USER" else "assistant"
+                        say("  {}: {}".format(who, text))
+                elif kind == frame.NOTICE:
+                    obj = frame.decode_json(payload)
+                    event = obj.get("event", "")
+                    if event == "ready":
+                        self.ready_notice = obj
+                        self.ready.set()
+                    elif event == "queued":
+                        say("  handed to the first mate: {}".format(
+                            obj.get("request", "")))
+                        with self.lock:
+                            if arrived_in == self.turn_id:
+                                self.turn["queued"] = obj.get("note_id", "")
+                    elif event == "interrupted":
+                        with self.lock:
+                            if arrived_in == self.turn_id:
+                                self.turn["interrupted"] = True
+                        log(self.verbose, "the model treated this turn as an "
+                                          "interruption of its own speech")
+                    elif event == "turn-failed":
+                        # The relay is still there and the next talk key gets a
+                        # new session, so this ends the turn rather than the run.
+                        say("client: the relay could not finish that turn: {}"
+                            .format(obj.get("error", "")))
+                        # Named and released in one critical section, so no turn
+                        # can be released without also being told why.
+                        with self.lock:
+                            if arrived_in == self.turn_id:
+                                self.turn["failed"] = obj.get("error", "")
+                                self.reply_done.set()
+                    elif event == "session-ended":
+                        say("client: the relay ended the session")
+                        # An ordinary session end is not a turn failure at the
+                        # relay, and the next talk key still gets a working one. A
+                        # turn released by it nevertheless has no answer, and
+                        # relay_error is where the reason for that is read from
+                        # later, so it carries what the captain was just told. The
+                        # reply_done test and the setdefault are the tail's, for
+                        # the tail's reasons.
+                        with self.lock:
+                            if arrived_in == self.turn_id:
+                                if not self.reply_done.is_set():
+                                    self.turn.setdefault(
+                                        "failed", "the relay ended the session "
+                                                  "before this turn was answered")
+                                self.reply_done.set()
+                    else:
+                        log(self.verbose, "notice {}".format(obj))
+                elif kind == frame.MARK:
+                    obj = frame.decode_json(payload)
                     with self.lock:
-                        self.turn["interrupted"] = True
-                    log(self.verbose, "the model treated this turn as an "
-                                      "interruption of its own speech")
-                elif event == "turn-failed":
-                    # The relay is still there and the next talk key gets a new
-                    # session, so this ends the turn rather than the run.
-                    say("client: the relay could not finish that turn: {}".format(
-                        obj.get("error", "")))
-                    with self.lock:
-                        self.turn["failed"] = obj.get("error", "")
-                    self.reply_done.set()
-                elif event == "session-ended":
-                    say("client: the relay ended the session")
-                    # An ordinary session end is not a turn failure at the relay,
-                    # and the next talk key still gets a working one. A turn
-                    # released by it nevertheless has no answer, and relay_error
-                    # is where the reason for that is read from later, so it
-                    # carries what the captain was just told. The test and the
-                    # setdefault are the tail's, for the tail's reasons.
-                    with self.lock:
-                        if not self.reply_done.is_set():
+                        if arrived_in == self.turn_id:
                             self.turn.setdefault(
-                                "failed", "the relay ended the session before "
-                                          "this turn was answered")
-                    self.reply_done.set()
-                else:
-                    log(self.verbose, "notice {}".format(obj))
-            elif kind == frame.MARK:
-                obj = frame.decode_json(payload)
+                                "marks", {})[obj.get("mark", "?")] = \
+                                obj.get("since_talk_end")
+                            self.turn["tool_calls"] = obj.get("tool_calls", 0)
+                            if obj.get("mark") == "reply_end":
+                                self.reply_done.set()
+                elif kind == frame.BYE:
+                    say("client: the relay said goodbye")
+                    why = "the relay said goodbye before this turn was answered"
+                    break
+            except Exception as exc:               # noqa: BLE001
+                # A fault on THIS end, handling a reply that did arrive: the
+                # speaker or the output file refusing the audio, or a payload that
+                # is not the JSON the wire format promises. Caught as a class
+                # rather than as a list, because this handling code can raise
+                # something nobody listed, and the failure being removed here is
+                # this thread dying silently: closed and reply_done then stay
+                # unset, and every remaining run opens a turn, waits out the whole
+                # timeout and is recorded unanswered with no reason at all, so one
+                # fault costs the session instead of one turn.
+                #
+                # Deliberately not worded as a lost connection. The connection is
+                # fine and naming it would send the captain to the wrong end.
+                fault = ("this end could not handle the relay's reply: {}: {}"
+                         .format(type(exc).__name__, exc))
+                say("client: {}".format(fault))
                 with self.lock:
-                    self.turn.setdefault("marks", {})[obj.get("mark", "?")] = \
-                        obj.get("since_talk_end")
-                    self.turn["tool_calls"] = obj.get("tool_calls", 0)
-                if obj.get("mark") == "reply_end":
-                    self.reply_done.set()
-            elif kind == frame.BYE:
-                why = "the relay said goodbye before this turn was answered"
+                    self.turn.setdefault("failed", fault)
+                    self.closed_because = fault
+                    self.closed.set()
                 break
         # Under the turn lock for the same reason the failure above is: a clean
         # end of file and a goodbye leave the connection just as unusable as a
@@ -706,6 +763,9 @@ class Client:
             if self.closed.is_set():
                 return None
             self.turn = {}
+            # Advanced here, with the reset it names, so a frame still being
+            # handled from the previous turn can tell that its turn is over.
+            self.turn_id += 1
             # In the same critical section as the closure mark, because this
             # event is how the downlink tells a turn waiting for a reply from the
             # space between turns. Cleared outside the lock it leaves a window
@@ -901,8 +961,13 @@ class Client:
             # a turn that never opened, since an invented turn is the whole thing
             # being kept out of runs.jsonl.
             if record is None:
-                say("client: the connection closed before run {} of {}; it and "
-                    "the rest were not taken".format(index, self.options.runs))
+                # What actually stopped it, not an assumption that the connection
+                # went: a fault on this end leaves the connection open, and a line
+                # blaming it would send the captain to the wrong end.
+                with self.lock:
+                    because = self.closed_because
+                say("client: {} before run {} of {}; it and the rest were not "
+                    "taken".format(because, index, self.options.runs))
                 rc = 1
                 break
             print(json.dumps(record))

--- a/bin/fm-voice-client.py
+++ b/bin/fm-voice-client.py
@@ -685,21 +685,25 @@ class Client:
             except subprocess.TimeoutExpired:
                 self.proc.kill()
         # Said last, because the relay exiting above is what stops the audio still
-        # in flight.
-        self._say_dropped()
+        # in flight, and through _quietly like every other step here: a playback
+        # that cannot answer for its count must not replace the refusal that
+        # brought us into close() in the first place.
+        self._quietly("the discard count", self._say_dropped)
 
     def _say_dropped(self):
         """Report reply audio the output was no longer open to take.
 
-        Expected while this end is shutting down and said nowhere else, so a count
-        appearing on a session that has not ended is the logic bug it is kept for.
-        That holds on both output paths, because both count it. Diagnostic only: it
+        A count read at teardown, which should normally be zero. This has one
+        caller and it is the last statement of close(), so the count is only ever
+        reported at the end of a session; the tripwire is still worth keeping,
+        because a close() added anywhere else would be counted here too. Both
+        output paths count it rather than only the file one. Diagnostic only: it
         names nothing in the record and decides no exit code.
 
         Read straight off the playback rather than through a default, so a playback
-        that cannot answer is a failure here rather than a zero indistinguishable
-        from having measured none. The None check is close()'s own, for the startup
-        that refused before there was an output at all.
+        that cannot answer is a failure rather than a zero indistinguishable from
+        having measured none. The None check is close()'s own, for the startup that
+        refused before there was an output at all.
         """
         if self.playback is None:
             return
@@ -793,9 +797,41 @@ class Client:
                 # be opened by reading it under this lock. Naming the failure
                 # first and announcing the closure afterwards left a window where
                 # the connection was known gone and no reader could tell.
+                #
+                # The reply_done test is the one the quiet close paths below
+                # already apply, and it is here for the same reason: a reason
+                # belongs to a turn that has not had its answer yet. Without it a
+                # fault landing in the gap between reply_end arriving and the
+                # record being copied named a turn that was fully answered, and
+                # since a recorded reason exits non-zero that failed a session
+                # which had delivered everything asked of it. An end of stream and
+                # a reset differ only in what the kernel handed us, so they must
+                # not produce two different exit codes for one relay death.
+                #
+                # WHAT THE TEST MAKES INVISIBLE, because it is a real cost rather
+                # than none: a relay failure arriving after the FINAL turn's reply
+                # was already complete now records no reason and exits 0. The relay
+                # puts every audioOutput chunk and the reply_end mark on one
+                # ordered queue, so by the time this end sets reply_done every byte
+                # of that answer has already reached the playback, and a fault
+                # after it cannot have cost the captain any part of what they were
+                # given. What it can still cost is a LATER turn, and that is
+                # reported with no per-turn reason at all by the remaining-runs
+                # check, which exits non-zero whenever the connection is known gone
+                # with runs still to take. A relay dying at that instant is also
+                # indistinguishable from the same relay dying a moment later during
+                # this end's own teardown, which this client already treats as
+                # benign. The bound: take_turn clears reply_done in the same
+                # critical section as the closure mark, so the blind spot is
+                # exactly "after this turn's reply completed" and never "during a
+                # turn".
+                #
+                # closed_because and the closure mark stay outside it, so the
+                # session still knows the connection went and still says so.
                 with self.lock:
-                    self.turn.setdefault(
-                        "failed", "the connection was lost: {}".format(exc))
+                    if not self.reply_done.is_set():
+                        self.turn.setdefault(
+                            "failed", "the connection was lost: {}".format(exc))
                     self.closed_because = "the connection was lost"
                     self.closed.set()
                 break
@@ -858,10 +894,17 @@ class Client:
                         say("client: the relay could not finish that turn: {}"
                             .format(obj.get("error", "")))
                         # Named and released in one critical section, so no turn
-                        # can be released without also being told why.
+                        # can be released without also being told why. The
+                        # reply_done test is the read path's, for the reason given
+                        # there: a relay whose model stream broke in the gap after
+                        # this turn's answer completed has cost this turn nothing,
+                        # and naming it here would fail a session that answered.
+                        # The release stays outside the test, so a failure arriving
+                        # while the turn is still waiting still ends its wait.
                         with self.lock:
                             if arrived_in == self.turn_id:
-                                self.turn["failed"] = obj.get("error", "")
+                                if not self.reply_done.is_set():
+                                    self.turn["failed"] = obj.get("error", "")
                                 self.reply_done.set()
                     elif event == "session-ended":
                         say("client: the relay ended the session")

--- a/bin/fm-voice-client.py
+++ b/bin/fm-voice-client.py
@@ -573,6 +573,11 @@ class Client:
                 return
 
     def _downlink(self):
+        # Why the loop stopped, for a turn that was still waiting for its reply
+        # when it did. Neither of the quiet exits below raises, and they are
+        # different faults, so each names itself rather than leaving the tail to
+        # guess or to say nothing.
+        why = None
         while True:
             try:
                 got = self.reader.read()
@@ -595,6 +600,7 @@ class Client:
                     self.closed.set()
                 break
             if got is None:
+                why = "the connection ended before this turn was answered"
                 break
             kind, payload = got
             if kind == frame.AUDIO:
@@ -635,6 +641,17 @@ class Client:
                     self.reply_done.set()
                 elif event == "session-ended":
                     say("client: the relay ended the session")
+                    # An ordinary session end is not a turn failure at the relay,
+                    # and the next talk key still gets a working one. A turn
+                    # released by it nevertheless has no answer, and relay_error
+                    # is where the reason for that is read from later, so it
+                    # carries what the captain was just told. The test and the
+                    # setdefault are the tail's, for the tail's reasons.
+                    with self.lock:
+                        if not self.reply_done.is_set():
+                            self.turn.setdefault(
+                                "failed", "the relay ended the session before "
+                                          "this turn was answered")
                     self.reply_done.set()
                 else:
                     log(self.verbose, "notice {}".format(obj))
@@ -647,13 +664,25 @@ class Client:
                 if obj.get("mark") == "reply_end":
                     self.reply_done.set()
             elif kind == frame.BYE:
+                why = "the relay said goodbye before this turn was answered"
                 break
         # Under the turn lock for the same reason the failure above is: a clean
         # end of file and a goodbye leave the connection just as unusable as a
         # dropped one, and take_turn reads this under that lock to decide whether
         # a turn can still be opened. Already set on the failure path; setting an
         # event twice costs nothing.
+        #
+        # A turn still waiting for its reply is named in the same critical
+        # section, and before the event that releases it, so the turn reading the
+        # record finds the reason rather than racing it. reply_done is the test:
+        # take_turn clears it under this lock when it opens a turn and it is set
+        # at every other moment, so an answered turn whose connection then ends
+        # cleanly keeps its record and stays reason-free. setdefault, because a
+        # relay that named the failure first said it more precisely than this end
+        # can infer it.
         with self.lock:
+            if why is not None and not self.reply_done.is_set():
+                self.turn.setdefault("failed", why)
             self.closed.set()
         self.reply_done.set()
 
@@ -677,8 +706,14 @@ class Client:
             if self.closed.is_set():
                 return None
             self.turn = {}
+            # In the same critical section as the closure mark, because this
+            # event is how the downlink tells a turn waiting for a reply from the
+            # space between turns. Cleared outside the lock it leaves a window
+            # where the connection has already gone, the downlink has read the
+            # event as nobody waiting and named nothing, and this turn then waits
+            # out its whole timeout to be recorded with no reason at all.
+            self.reply_done.clear()
         self.playback.turn_reset()
-        self.reply_done.clear()
         before = self.playback.bytes
         self.up_q.put(START)
 

--- a/bin/fm-voice-client.py
+++ b/bin/fm-voice-client.py
@@ -206,25 +206,52 @@ class FilePlayback:
 
     def __init__(self, path):
         self._handle = open(path, "wb")
+        # Two locks, and which one covers what is the point of them. _lock is the
+        # per-turn accounting, and turn_reset takes it while the client holds its
+        # own turn lock, so nothing slow may ever be done under it. _handle_lock
+        # covers the file itself, so a write and a close cannot overlap. The
+        # ordering is always _handle_lock then _lock and never the reverse.
+        self._handle_lock = threading.Lock()
         self._lock = threading.Lock()
         self.first_played = None
         self.device_latency = None
         self.turn_bytes = 0
+        # Chunks dropped because they arrived after the file was released. Read by
+        # --verbose only; see write() for why it is not an outcome input.
+        self.discarded = 0
         self._turn = None
+        self._closed = False
 
     def write(self, pcm, turn):
-        # Held across the whole body, as the speaker's is, because the turn
-        # comparison, the stamp and the count are one decision and the file write
-        # sitting between them releases the interpreter. A turn advancing in that
-        # gap took the credit for a chunk that was not its own and a first-audio
-        # stamp from before it began, which is a negative headline figure.
-        with self._lock:
-            mine = turn == self._turn
-            if mine and self.first_played is None:
-                self.first_played = time.monotonic()
+        # A chunk arriving after close is DISCARDED rather than raising. close()
+        # joins the downlink at five seconds while the relay teardown it waits on
+        # can take up to ten, so reply audio still in flight when the file is
+        # released is an expected and benign race, and erroring on it reported this
+        # end's own teardown as a fault through the frame-handling guard, on a
+        # session that worked. Discard is the honest semantic for it, and after
+        # this any fault line printed during teardown is a real one.
+        #
+        # Counted, because a write after close OUTSIDE teardown is a logic bug and
+        # a silent no-op would hide it. Counted and nothing more: discarded bytes
+        # stamp no clock, are credited to no turn, and so reach neither answered,
+        # first_audio_s nor the exit code, which are decided from turn_bytes.
+        #
+        # The turn comparison, the stamp and the count are one decision and are
+        # made together under _lock. The file write is not: it blocks, and holding
+        # the lock turn_reset needs across it would stall the whole client behind
+        # the filesystem. One writer keeps the file in order without that.
+        with self._handle_lock:
+            if self._closed:
+                with self._lock:
+                    self.discarded += 1
+                return
+            with self._lock:
+                mine = turn == self._turn
+                if mine and self.first_played is None:
+                    self.first_played = time.monotonic()
+                if mine:
+                    self.turn_bytes += len(pcm)
             self._handle.write(pcm)
-            if mine:
-                self.turn_bytes += len(pcm)
 
     def turn_reset(self, turn):
         with self._lock:
@@ -236,16 +263,22 @@ class FilePlayback:
         del timeout
 
     def close(self):
-        self._handle.close()
+        with self._handle_lock:
+            self._closed = True
+            self._handle.close()
 
 
 class SpeakerPlayback:
     """Play reply audio through the laptop speaker.
 
-    UNVERIFIED: written from the sounddevice interface and never run against a
-    real device, because the machine this was built on has no speaker. The
-    timestamp is taken when the audio is handed to the device callback, which is
-    the last moment this process can see. The device's own output buffer sits
+    The DEVICE is UNVERIFIED: written from the sounddevice interface and never run
+    against a real one, because the machine this was built on has no speaker, so
+    the first live run is its test. The byte ACCOUNTING below is covered, against
+    a stub stream with the callback driven by hand, and covering it says nothing
+    about how a real device behaves.
+
+    The timestamp is taken when the audio is handed to the device callback, which
+    is the last moment this process can see. The device's own output buffer sits
     after that, so its reported latency is included in the turn record rather
     than pretended away.
 
@@ -597,12 +630,11 @@ class Client:
             # stopping on its own.
             self.quitting.set()
             self._quietly("the uplink", lambda: self.uplink.send(frame.QUIT))
-        # Before the devices are released, and bounded so a wedged relay cannot
-        # hold the exit. The downlink is still handing reply audio to the speaker,
-        # and a speaker closed underneath it raises there, which the frame-handling
-        # guard would then report as a fault on the way out of a session that
-        # worked. Letting the goodbye above end that thread first costs nothing and
-        # keeps the fault line meaning a fault.
+        # Before the devices are released, so the reply the goodbye above answers
+        # has somewhere to land, and bounded so a wedged relay cannot hold the
+        # exit. The bound is shorter than the relay's own teardown, so audio can
+        # still arrive after the output is released; the playback discards that
+        # rather than raising, which is what keeps a fault line meaning a fault.
         if self.down_thread is not None:
             self.down_thread.join(timeout=5)
         if self.capture is not None:
@@ -619,6 +651,22 @@ class Client:
                 self.proc.wait(timeout=10)
             except subprocess.TimeoutExpired:
                 self.proc.kill()
+        # Said last, because the relay exiting above is what stops the audio still
+        # in flight.
+        self._say_dropped()
+
+    def _say_dropped(self):
+        """Report reply audio the output was no longer open to take.
+
+        Expected while this end is shutting down and said nowhere else, so a count
+        appearing on a session that has not ended is the logic bug it is kept for.
+        Diagnostic only: it names nothing in the record and decides no exit code.
+        """
+        dropped = getattr(self.playback, "discarded", 0)
+        if dropped:
+            log(self.verbose,
+                "discarded {} reply audio chunk(s) that arrived after the output "
+                "was released".format(dropped))
 
     # -------------------------------------------------------------------- threads
 

--- a/bin/fm-voice-client.py
+++ b/bin/fm-voice-client.py
@@ -14,11 +14,18 @@ WHAT IS VERIFIED AND WHAT IS NOT. Read this before trusting a number from it.
   replace the microphone and the speaker with files and leave everything else
   alone.
 
-  NOT verified, and cannot be from here: the microphone capture path and the
-  speaker playback path. The desktop this was written on has neither a
-  microphone nor a speaker, and no worker can reach the captain's laptop. The
-  sounddevice calls below are written from its documented interface and have
-  never been run against a real device. Treat the first live run as the test.
+  NOT verified, and cannot be from here: the audio DEVICES. The desktop this was
+  written on has neither a microphone nor a speaker, and no worker can reach the
+  captain's laptop. The sounddevice calls below are written from its documented
+  interface and have never been run against a real device. Treat the first live
+  run as the test.
+
+  Verified, and worth telling apart from the devices: the speaker's own byte
+  ACCOUNTING, which is the arithmetic deciding which turn a chunk of reply audio
+  is credited to and which turn's first-audio clock it stamps. That is plain
+  logic rather than device work, so it is exercised against a stub stream with
+  the callback driven by hand. Nothing in that says how a real output device
+  behaves.
 
 TWO KINDS OF LISTENING, one of them built. --listen push-to-talk is the default
 and the only mode that runs: the captain says when they are talking, the model is
@@ -199,27 +206,31 @@ class FilePlayback:
 
     def __init__(self, path):
         self._handle = open(path, "wb")
+        self._lock = threading.Lock()
         self.first_played = None
         self.device_latency = None
-        # Everything written, and what the turn being measured is owed. The
-        # difference is the audio of turns already recorded.
-        self.bytes = 0
         self.turn_bytes = 0
         self._turn = None
 
     def write(self, pcm, turn):
-        mine = turn == self._turn
-        if mine and self.first_played is None:
-            self.first_played = time.monotonic()
-        self._handle.write(pcm)
-        self.bytes += len(pcm)
-        if mine:
-            self.turn_bytes += len(pcm)
+        # Held across the whole body, as the speaker's is, because the turn
+        # comparison, the stamp and the count are one decision and the file write
+        # sitting between them releases the interpreter. A turn advancing in that
+        # gap took the credit for a chunk that was not its own and a first-audio
+        # stamp from before it began, which is a negative headline figure.
+        with self._lock:
+            mine = turn == self._turn
+            if mine and self.first_played is None:
+                self.first_played = time.monotonic()
+            self._handle.write(pcm)
+            if mine:
+                self.turn_bytes += len(pcm)
 
     def turn_reset(self, turn):
-        self._turn = turn
-        self.first_played = None
-        self.turn_bytes = 0
+        with self._lock:
+            self._turn = turn
+            self.first_played = None
+            self.turn_bytes = 0
 
     def drain(self, timeout=5):
         del timeout
@@ -254,7 +265,6 @@ class SpeakerPlayback:
         self._buffer = bytearray()
         self._lock = threading.Lock()
         self.first_played = None
-        self.bytes = 0
         self.turn_bytes = 0
         self._turn = None
         self._earlier = 0
@@ -287,7 +297,6 @@ class SpeakerPlayback:
             else:
                 self._earlier += len(pcm)
             self._buffer += pcm
-        self.bytes += len(pcm)
 
     def turn_reset(self, turn):
         with self._lock:
@@ -651,6 +660,24 @@ class Client:
             except (BrokenPipeError, OSError):
                 return
 
+    def _unfinished(self, subject):
+        """Name a fault that landed on an open turn, in the words that turn earned.
+
+        A relay dies mid-turn in two shapes and they are not the same fault. With
+        no reply audio yet, the turn went unanswered. With some already played,
+        the captain heard the start of an answer and the rest was cut off, so the
+        turn WAS answered and first_audio_s is a real measurement of when: saying
+        nothing arrived would contradict the answered field two lines below it in
+        the same record, and a reader who believes the wrong one goes looking in
+        the wrong place.
+
+        Read off the same count answered is read off, so the two cannot disagree
+        about one turn whatever the timing.
+        """
+        if self.playback.turn_bytes > 0:
+            return "{} before the reply finished".format(subject)
+        return "{} before this turn was answered".format(subject)
+
     def _downlink(self):
         # Why the loop stopped, for a turn that was still waiting for its reply
         # when it did. Neither of the quiet exits below raises, and they are
@@ -685,7 +712,10 @@ class Client:
                 break
             if got is None:
                 say("client: the connection ended")
-                why = "the connection ended before this turn was answered"
+                # The subject only. Whether it ended before the turn was answered
+                # or partway through the answer is decided by _unfinished at the
+                # tail, where the audio count is read.
+                why = "the connection ended"
                 cause = "the connection ended"
                 break
             kind, payload = got
@@ -757,8 +787,9 @@ class Client:
                             if arrived_in == self.turn_id:
                                 if not self.reply_done.is_set():
                                     self.turn.setdefault(
-                                        "failed", "the relay ended the session "
-                                                  "before this turn was answered")
+                                        "failed",
+                                        self._unfinished(
+                                            "the relay ended the session"))
                                 self.reply_done.set()
                     else:
                         log(self.verbose, "notice {}".format(obj))
@@ -785,7 +816,7 @@ class Client:
                         cause = "the relay signed off after being asked to stop"
                     else:
                         say("client: the relay stopped without being asked to")
-                        why = "the relay stopped before this turn was answered"
+                        why = "the relay stopped"
                         cause = "the relay stopped without being asked to"
                     break
             except Exception as exc:               # noqa: BLE001
@@ -834,7 +865,7 @@ class Client:
         # can infer it.
         with self.lock:
             if why is not None and not self.reply_done.is_set():
-                self.turn.setdefault("failed", why)
+                self.turn.setdefault("failed", self._unfinished(why))
             if cause is not None:
                 self.closed_because = cause
             self.closed.set()
@@ -1081,7 +1112,14 @@ class Client:
                 break
             print(json.dumps(record))
             sys.stdout.flush()
-            if not record["answered"]:
+            # A named reason counts as well as an unanswered turn, and not only
+            # when a later run remains. A relay killed while speaking leaves a
+            # turn that was answered and a record that says why the answer stopped
+            # partway, and at the default of one run that turn cleared all three of
+            # the other paths to a non-zero code and reported the session a
+            # success. A results file whose own record names an infrastructure
+            # failure must not sit behind an exit code that says nothing happened.
+            if not record["answered"] or record["relay_error"]:
                 rc = 1
             if index < self.options.runs:
                 # Checked after the record and before the wait, because that wait

--- a/bin/fm-voice-relay.py
+++ b/bin/fm-voice-relay.py
@@ -22,8 +22,8 @@ Modes:
                      This is the control measurement for the relay path, and it
                      needs no client, no SSH and no microphone.
 
-The two traps this code already avoids, both found the expensive way and
-recorded in data/speech-to-speech-survey-s2/report.md section 10:
+The two traps this code already avoids, both found the expensive way and both
+measured rather than assumed:
 
   1. completionEnd does not arrive on its own. The model holds the session open
      waiting for more speech. The real "the reply is finished" signal is a
@@ -108,8 +108,8 @@ SETTINGS = {
 
 IN_RATE = 16000
 OUT_RATE = 24000
-# 3200 bytes is 100 ms at 16 kHz 16-bit mono, the chunk size the survey measured
-# its timings with. Keeping it identical keeps those numbers comparable.
+# 3200 bytes is 100 ms at 16 kHz 16-bit mono, the chunk size earlier prototype
+# work measured its timings with. Keeping it identical keeps those comparable.
 CHUNK = 3200
 BYTES_PER_MS_IN = IN_RATE * 2 // 1000
 

--- a/bin/fm-voice-relay.py
+++ b/bin/fm-voice-relay.py
@@ -1012,6 +1012,11 @@ async def serve(options):
         "connect_seconds": session.connect_seconds})
 
     status = 0
+    # A fault the client cannot see for itself, held so the teardown can name it
+    # down the connection as well as on this stderr. Nothing is captured on the
+    # branch above it: there the client is the end that went away, and there is
+    # nobody left to tell.
+    reason = None
     try:
         while True:
             kind, payload = await read_uplink_frame(reader)
@@ -1025,8 +1030,17 @@ async def serve(options):
         sys.stderr.write(
             "fm-voice-relay: the uplink is not a frame stream any more: {}\n"
             .format(exc))
+        reason = "{}: {}".format(type(exc).__name__, exc)
         status = 2
     finally:
+        # On fail_turn's shape and before close(), which awaits the model stream
+        # and can be slow or raise. session.close() also sets closing, which
+        # silences the reader's own notice, so a goodbye on its own would leave
+        # the captain's turn record saying only that the turn went unanswered
+        # while the reason for it sat on a stderr no run file quotes.
+        if reason is not None:
+            down.send_json(frame.NOTICE, {"event": "turn-failed",
+                                          "error": reason})
         await session.close()
         down.send(frame.BYE)
         down.close()

--- a/docs/voice-relay.md
+++ b/docs/voice-relay.md
@@ -153,7 +153,7 @@ the timings for each turn as JSON on stdout and everything human on stderr, so
 above.
 
 Every record carries `relay_error`, which is null when nothing broke and otherwise names what did.
-It tells the two mid-turn failures apart, because they are not the same fault: a turn that got no reply audio at all says the connection ended, or the relay stopped, or the session ended, before that turn was answered, while a turn whose answer had already started playing says the same thing happened before the reply finished.
+It tells the two mid-turn failures apart, because they are not the same fault: a turn that got no reply audio at all says the connection ended, or was lost, or the relay stopped, or the session ended, before that turn was answered, while a turn whose answer had already started playing says the same thing happened before the reply finished.
 The second still reads `answered: true`, because sound did reach you and `first_audio_s` is a real measurement of when.
 
 The exit code is non-zero if any turn went unanswered, if any record carries a `relay_error`, or if the session stopped before it had taken the runs you asked for.

--- a/docs/voice-relay.md
+++ b/docs/voice-relay.md
@@ -153,8 +153,10 @@ the timings for each turn as JSON on stdout and everything human on stderr, so
 above.
 
 Every record carries `relay_error`, which is null when nothing broke and otherwise names what did.
-It tells the two mid-turn failures apart, because they are not the same fault: a turn that got no reply audio at all says the connection ended, or was lost, or the relay stopped, or the session ended, before that turn was answered, while a turn whose answer had already started playing says the same thing happened before the reply finished.
+Where this end is left to infer what happened, it tells the two mid-turn failures apart, because they are not the same fault: a turn that got no reply audio at all says the connection ended, or was lost, or the relay stopped, or the session ended, before that turn was answered, while a turn whose answer had already started playing says the same thing happened before the reply finished.
 The second still reads `answered: true`, because sound did reach you and `first_audio_s` is a real measurement of when.
+Two other shapes carry neither clause, so do not read the pair above as the whole list: a fault the relay names itself arrives as the relay's own words, which point at the desktop and are kept unaltered because it knows what this end can only guess at.
+A reason opening `this end could not handle the relay's reply` is the one that points at your laptop instead, so a healthy relay is not where to look for it.
 
 The exit code is non-zero if any turn went unanswered, if any record carries a `relay_error`, or if the session stopped before it had taken the runs you asked for.
 A truncated answer therefore fails the run rather than passing it, so a spread computed from `runs.jsonl` cannot quietly average an infrastructure failure into a latency figure.

--- a/docs/voice-relay.md
+++ b/docs/voice-relay.md
@@ -120,10 +120,11 @@ wrong instant rather than printing a number that looks fast.
 
 ## Setting up the laptop
 
-**None of this is verified.** No worker can reach the captain's laptop, so the
-capture and playback paths have never run. Everything else in the client is
-exercised with files. Treat the first live run as the test, and expect the audio
-device setup to be where it fails.
+**The audio devices are not verified.** No worker can reach the captain's laptop, so neither the microphone nor the speaker has ever been opened.
+Treat the first live run as their test, and expect the device setup to be where it fails.
+Everything around them is exercised with files.
+That includes the speaker's own byte accounting, the arithmetic deciding which turn a chunk of reply audio is credited to and whose first-audio clock it stamps, which runs against a stub stream in the test suite.
+Covering that arithmetic says nothing about how a real output device behaves.
 
 Copy the two files the laptop needs, and install the one dependency:
 

--- a/docs/voice-relay.md
+++ b/docs/voice-relay.md
@@ -151,6 +151,13 @@ the timings for each turn as JSON on stdout and everything human on stderr, so
 `--runs 5 > runs.jsonl` gives you your own spread to compare against the table
 above.
 
+Every record carries `relay_error`, which is null when nothing broke and otherwise names what did.
+It tells the two mid-turn failures apart, because they are not the same fault: a turn that got no reply audio at all says the connection ended, or the relay stopped, or the session ended, before that turn was answered, while a turn whose answer had already started playing says the same thing happened before the reply finished.
+The second still reads `answered: true`, because sound did reach you and `first_audio_s` is a real measurement of when.
+
+The exit code is non-zero if any turn went unanswered, if any record carries a `relay_error`, or if the session stopped before it had taken the runs you asked for.
+A truncated answer therefore fails the run rather than passing it, so a spread computed from `runs.jsonl` cannot quietly average an infrastructure failure into a latency figure.
+
 If the audio devices are not the ones you want, `--input-device` and `--output-device` take a name or an index.
 Neither the client nor this guide can yet tell you which device it resolved, so an unexpected device is diagnosed by trying the other name or index rather than by reading a log line.
 If it fails before any audio, add `--verbose` and look for the handshake: a chatty login shell on the desktop printing to stdout is the one failure that looks like a protocol error and is not.

--- a/docs/voice-relay.md
+++ b/docs/voice-relay.md
@@ -239,8 +239,8 @@ it, six turns in a row all answered.
 The same path covers a session the model ends on its own, mid-conversation: that
 costs the turn it was in and not the relay, and the next talk key builds a
 replacement. Either way the client hears about it at once rather than waiting out
-the whole reply timeout in silence, and a turn that broke rather than merely
-ending carries the reason on its own JSON record.
+the whole reply timeout in silence.
+A turn still waiting for its answer when either happens names why in its own `relay_error`, and [setting up the laptop](#setting-up-the-laptop) describes those reasons.
 
 **What it gives up is memory.** Every question starts fresh, so "and what about
 that one" will not work. Carrying context across turns means handling

--- a/tests/fm-voice-relay.test.sh
+++ b/tests/fm-voice-relay.test.sh
@@ -1513,8 +1513,11 @@ check(cut_record["relay_error"],
       "a dropped connection must be reported in the turn record rather than "
       "leaving it indistinguishable from a turn nobody answered: %r"
       % cut_record)
-check("connection" in cut_record["relay_error"],
-      "and it should say the connection went: %r" % cut_record["relay_error"])
+check("the connection was lost before this turn was answered"
+      in cut_record["relay_error"],
+      "and it should say the connection went before this turn had its answer, "
+      "which is the half of that fault this case is: %r"
+      % cut_record["relay_error"])
 
 # The other moment a connection can go is BETWEEN two turns, during the seconds
 # the client spends letting the previous answer finish. That wait is most of a
@@ -1777,21 +1780,29 @@ class ScriptedStream:
     """Serves prepared downlink bytes, held until the turn under test has opened.
 
     One class for every case below, because each of them differs only in the bytes
-    it serves: the gate, the slicing and the exhaustion behaviour are the same
-    everywhere, and an empty script is what an end of stream at a frame boundary
-    looks like. The label is per case so a fixture that never fires still names
-    which case it belonged to.
+    it serves: the gate and the slicing are the same everywhere, and an empty
+    script is what an end of stream at a frame boundary looks like. The label is
+    per case so a fixture that never fires still names which case it belonged to.
+
+    What happens once the script is spent is the one thing a case may choose, and
+    the default is the clean end of stream every case but one wants. at_end takes
+    a callable for the case that needs the other shape a dropped link has, a reset
+    rather than a close, which reaches the client as a raised error instead of an
+    empty read.
     """
 
-    def __init__(self, gate, payload, label):
+    def __init__(self, gate, payload, label, at_end=None):
         self._gate = gate
         self._bytes = payload
         self._label = label
+        self._at_end = at_end
         self._at = 0
 
     def read(self, count):
         check(self._gate.wait(10),
               "the turn never opened, so %s was never served" % self._label)
+        if self._at >= len(self._bytes) and self._at_end is not None:
+            self._at_end()
         chunk = self._bytes[self._at:self._at + count]
         self._at += len(chunk)
         return chunk
@@ -1925,14 +1936,14 @@ SOME_REPLY = frame.encode(frame.AUDIO, b"\x00\x00" * 1200)
 SESSION_ENDED = frame.encode_json(frame.NOTICE, {"event": "session-ended"})
 
 
-def turn_cut(label, payload, out_name):
+def turn_cut(label, payload, out_name, at_end=None):
     """Take one turn, at the default run count, against a scripted downlink."""
     gate = thread_lib.Event()
     cut = wire_client(
         ["--host", "desk", "--in-file", os.path.join(TMP, "clip.pcm"),
          "--out-file", os.path.join(TMP, out_name),
          "--timeout", "2", "--audio-idle", "0.05"],
-        ScriptedStream(gate, payload, label), StartGate(gate))
+        ScriptedStream(gate, payload, label, at_end), StartGate(gate))
     out, said = io.StringIO(), io.StringIO()
     with contextlib.redirect_stdout(out), contextlib.redirect_stderr(said):
         code = cut.run()
@@ -1989,6 +2000,45 @@ for label, payload, subject in (
           "%s: a record naming a fault must not exit 0, even at the default of "
           "one run and even though the turn was answered, got %r"
           % (label, partial_code))
+
+# THE FOURTH SUBJECT, and the one a real captain is likeliest to meet. The three
+# above all reach the client as an orderly end: a close, a goodbye frame, or a
+# notice. A dropped SSH link is a reset instead, which arrives as a raised error
+# from the read rather than as anything the far end chose to send, and that is a
+# separate path in the downlink from all three. It has to tell the same two halves
+# apart, because the fault is no different from the captain's side.
+#
+# Its never-played half is the cut-header case far above, which pins the other
+# wording, so this is the half that was missing.
+
+
+def a_reset():
+    raise OSError(104, "Connection reset by peer")
+
+
+reset, _, reset_code = turn_cut(
+    "reset, part of a reply played", SOME_REPLY, "reply-partial-reset.pcm",
+    at_end=a_reset)
+check(reset["answered"] and reset["reply_audio_seconds"] > 0,
+      "a reset after some of the reply played still reached the captain, so the "
+      "turn was answered: %r" % reset)
+check(reset["first_audio_s"] is not None,
+      "and when it reached them is a real measurement, not a null: %r" % reset)
+check(reset["relay_error"].startswith(
+          "the connection was lost before the reply finished"),
+      "a reply cut short by a reset must say the reply did not finish, the same "
+      "as one cut short by a close: %r" % reset["relay_error"])
+check("before this turn was answered" not in reset["relay_error"],
+      "and must not claim nothing arrived, which its own answered field "
+      "contradicts: %r" % reset["relay_error"])
+# The clause is what the reader acts on and the detail is what tells a reset from
+# a header cut in half, so neither may be lost to the other.
+check("Connection reset by peer" in reset["relay_error"],
+      "and must still carry what the kernel said, which is the only thing that "
+      "tells a reset from a truncated frame: %r" % reset["relay_error"])
+check(reset_code != 0,
+      "a record naming a fault must not exit 0, even at the default of one run "
+      "and even though the turn was answered, got %r" % reset_code)
 
 # THE OTHER SIDE OF THE SAME LINE, and the complement of the answered case further
 # up this block. Those cases are faults that landed while the turn was still owed

--- a/tests/fm-voice-relay.test.sh
+++ b/tests/fm-voice-relay.test.sh
@@ -1818,7 +1818,7 @@ RELAY_REASON = "FrameError: unknown frame kind: b'\\xff'"
 
 
 def turn_lost(label, make_stream, out_name):
-    """Take one turn against a downlink that ends during it, and return its run."""
+    """Take one turn against a downlink that ends during it, and return run and stderr."""
     gate = thread_lib.Event()
     lost = client.Client(client.parse_args(
         ["--host", "desk", "--in-file", os.path.join(TMP, "clip.pcm"),
@@ -1831,8 +1831,8 @@ def turn_lost(label, make_stream, out_name):
     lost.capture.start(lost.up_q, lost.talking)
     thread_lib.Thread(target=lost._sender, daemon=True).start()
     thread_lib.Thread(target=lost._downlink, daemon=True).start()
-    out = io.StringIO()
-    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(io.StringIO()):
+    out, said = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(said):
         code = lost.run()
     lost.up_q.put(None)
     lost.playback.close()
@@ -1852,28 +1852,231 @@ def turn_lost(label, make_stream, out_name):
           "%s: a turn lost to the connection must say so rather than reading in "
           "runs.jsonl exactly like a turn the model declined: %r"
           % (label, runs[0]))
-    return runs[0]
+    # This is the only run asked for, so the run loop never reaches its "and the
+    # rest were not taken" line. A record on stdout and silence on stderr is a
+    # captain who spoke, heard nothing back, and was told nothing either; the
+    # module docstring puts everything human on stderr.
+    check("client:" in said.getvalue(),
+          "%s: the captain must be told the connection went, not only the file: "
+          "%r" % (label, said.getvalue()))
+    return runs[0], said.getvalue()
 
 
-eof_run = turn_lost("end of stream", SilentEndStream, "reply-eof.pcm")
+eof_run, eof_said = turn_lost("end of stream", SilentEndStream, "reply-eof.pcm")
 check("ended" in eof_run["relay_error"],
       "an end of stream should say the connection ended: %r"
       % eof_run["relay_error"])
+check("the connection ended" in eof_said,
+      "and should say so on stderr as well: %r" % eof_said)
 
-bye_run = turn_lost("goodbye", GoodbyeStream, "reply-bye.pcm")
+bye_run, bye_said = turn_lost("goodbye", GoodbyeStream, "reply-bye.pcm")
 check("goodbye" in bye_run["relay_error"],
       "a goodbye mid-turn should say so, because it is the relay deciding to "
       "stop rather than the connection dying: %r" % bye_run["relay_error"])
+# Distinct from the line above, because they are distinct faults: a stream that
+# stopped, versus a relay that chose to stop. One line for both would send the
+# captain looking for the wrong thing.
+check("the relay said goodbye" in bye_said and "the connection ended" not in bye_said,
+      "a goodbye should name itself on stderr rather than borrowing the wording "
+      "of an ended stream: %r" % bye_said)
 
 # And when the relay does name the fault, its words are what the record carries.
 # This end can only infer that a goodbye arrived; the relay knows what happened,
 # so a reason it sent is never replaced by one inferred here.
-named_run = turn_lost(
+named_run, _ = turn_lost(
     "named fault", lambda gate: NamedFaultStream(gate, RELAY_REASON),
     "reply-named.pcm")
 check(named_run["relay_error"] == RELAY_REASON,
       "the relay's own reason must reach the record unchanged rather than being "
       "overwritten by the goodbye behind it: %r" % named_run["relay_error"])
+
+# A fault on THIS end, handling a reply that did arrive. The try in the downlink
+# used to cover only the read, so the output file refusing the audio, or a payload
+# that is not the JSON the wire format promises, killed the reader thread outright
+# with the connection neither marked closed nor released. run() then opened every
+# remaining turn, each waiting out the whole timeout and printing answered false
+# with no reason, so ONE fault cost the session instead of one turn.
+#
+# The reason it records must also be the right reason: the connection here is
+# perfectly healthy, and a record or a message blaming it sends whoever reads it
+# to the wrong end of a working link.
+class FullDiskPlayback(client.FilePlayback):
+    """Refuses reply audio the way a filesystem with nothing left does."""
+
+    def write(self, pcm):
+        raise OSError(28, "No space left on device")
+
+
+class OneReplyStream:
+    """Serves one audio frame once the turn is under way, and nothing after it."""
+
+    def __init__(self, gate):
+        self._gate = gate
+        self._bytes = frame.encode(frame.AUDIO, b"\x00\x00" * 600)
+        self._at = 0
+
+    def read(self, count):
+        check(self._gate.wait(10), "the turn never opened, so nothing was served")
+        chunk = self._bytes[self._at:self._at + count]
+        self._at += len(chunk)
+        return chunk
+
+
+handling_served = thread_lib.Event()
+handling = client.Client(client.parse_args(
+    ["--host", "desk", "--in-file", os.path.join(TMP, "clip.pcm"),
+     "--out-file", os.path.join(TMP, "reply-handling.pcm"), "--runs", "2",
+     "--timeout", "2", "--audio-idle", "0.05", "--gap-seconds", "0.05"]))
+handling.reader = frame.Reader(OneReplyStream(handling_served))
+handling.uplink = StartGate(handling_served)
+handling.playback = FullDiskPlayback(os.path.join(TMP, "reply-handling.pcm"))
+handling.capture = client.FileCapture(os.path.join(TMP, "clip.pcm"))
+handling.capture.start(handling.up_q, handling.talking)
+thread_lib.Thread(target=handling._sender, daemon=True).start()
+thread_lib.Thread(target=handling._downlink, daemon=True).start()
+handling_out, handling_said = io.StringIO(), io.StringIO()
+with contextlib.redirect_stdout(handling_out), \
+        contextlib.redirect_stderr(handling_said):
+    handling_code = handling.run()
+handling.up_q.put(None)
+handling.playback.close()
+handling_said = handling_said.getvalue()
+
+handling_runs = [json_lib.loads(line)
+                 for line in handling_out.getvalue().splitlines() if line.strip()]
+# One fault, one lost turn. The reader surviving is the whole point: without it
+# the second run opens as well and burns another whole timeout for nothing.
+check(len(handling_runs) == 1,
+      "a fault handling a reply must stop the session rather than opening every "
+      "remaining turn: %d run(s), %r" % (len(handling_runs), handling_runs))
+check(not handling_runs[0]["answered"],
+      "the audio never reached the file, so the turn was not answered: %r"
+      % handling_runs[0])
+check(handling_runs[0]["relay_error"],
+      "a fault this end could name must not be recorded as a turn that merely "
+      "went unanswered: %r" % handling_runs[0])
+check("No space left on device" in handling_runs[0]["relay_error"],
+      "the record should carry what actually raised: %r"
+      % handling_runs[0]["relay_error"])
+# The overriding rule: a wrong cause is worse than a missing one.
+check("connection" not in handling_runs[0]["relay_error"],
+      "the connection was never lost here, so the record must not say it was: %r"
+      % handling_runs[0]["relay_error"])
+check("connection" not in handling_said,
+      "and the captain must not be sent to a connection that is working: %r"
+      % handling_said)
+check("No space left on device" in handling_said
+      and "run 2 of 2" in handling_said,
+      "the run loop should name the real reason and the run it stopped at: %r"
+      % handling_said)
+check(handling_code != 0,
+      "a session that took none of its runs must not exit 0, got %r"
+      % handling_code)
+
+# A reply that is handled AFTER the turn it belongs to has already been recorded.
+# The downlink reads a frame on one thread and applies it on another, so a turn
+# that times out while a notice is in flight used to have that notice applied to
+# whatever turn came next: it named the new turn with the old turn's fault, and
+# released it before its own answer had arrived. A turn that would have been
+# answered normally was reported unanswered, carrying a reason belonging to a turn
+# the captain had already been told about.
+#
+# Driven through the client's own say(), not a sleep: the notice is parked exactly
+# where the real window is, after the frame has arrived and before its handler
+# takes the lock, and it is released only once the NEXT turn has really opened,
+# which the uplink reports when that turn's talk start goes out.
+class StaleNoticeStream:
+    """Fails turn one, then answers turn two, both once their turn has opened."""
+
+    def __init__(self, gate):
+        self._gate = gate
+        self._bytes = (
+            frame.encode_json(frame.NOTICE,
+                              {"event": "turn-failed",
+                               "error": "the model dropped turn one"})
+            + frame.encode(frame.AUDIO, b"\x00\x00" * 1200)
+            + frame.encode_json(frame.MARK, {"mark": "reply_end",
+                                             "since_talk_end": 0.4,
+                                             "tool_calls": 0}))
+        self._at = 0
+
+    def read(self, count):
+        check(self._gate.wait(10), "the turn never opened, so nothing was served")
+        chunk = self._bytes[self._at:self._at + count]
+        self._at += len(chunk)
+        return chunk
+
+
+class TurnCountingGate:
+    """Reports the first turn opening, and the second one separately."""
+
+    def __init__(self, first, second):
+        self._first = first
+        self._second = second
+        self.starts = 0
+
+    def send(self, kind, payload=b""):
+        if kind == frame.TALK_START:
+            self.starts += 1
+            (self._first if self.starts == 1 else self._second).set()
+
+
+stale_open, stale_next = thread_lib.Event(), thread_lib.Event()
+stale = client.Client(client.parse_args(
+    ["--host", "desk", "--in-file", os.path.join(TMP, "clip.pcm"),
+     "--out-file", os.path.join(TMP, "reply-stale.pcm"), "--runs", "2",
+     "--timeout", "2", "--audio-idle", "0.05", "--gap-seconds", "0.05"]))
+stale.reader = frame.Reader(StaleNoticeStream(stale_open))
+stale.uplink = TurnCountingGate(stale_open, stale_next)
+stale.playback = client.FilePlayback(os.path.join(TMP, "reply-stale.pcm"))
+stale.capture = client.FileCapture(os.path.join(TMP, "clip.pcm"))
+stale.capture.start(stale.up_q, stale.talking)
+
+# The notice is held between arriving and being applied, which is the window the
+# turn identity exists to close. Turn one then times out and is recorded, turn two
+# opens, and only then is the notice allowed to finish being handled.
+said_plainly = client.say
+
+
+def park_the_notice(message):
+    said_plainly(message)
+    if "could not finish that turn" in message:
+        check(stale_next.wait(10),
+              "fixture: the second turn never opened, so nothing went stale")
+
+
+client.say = park_the_notice
+try:
+    thread_lib.Thread(target=stale._sender, daemon=True).start()
+    thread_lib.Thread(target=stale._downlink, daemon=True).start()
+    stale_out, stale_said = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(stale_out), contextlib.redirect_stderr(stale_said):
+        stale_code = stale.run()
+finally:
+    client.say = said_plainly
+stale.up_q.put(None)
+stale.playback.close()
+
+stale_runs = [json_lib.loads(line) for line in stale_out.getvalue().splitlines()
+              if line.strip()]
+check(len(stale_runs) == 2,
+      "both turns were taken, so both belong in the file: %d, %r"
+      % (len(stale_runs), stale_runs))
+check(not stale_runs[0]["answered"],
+      "fixture is wrong: the first turn should time out unanswered: %r"
+      % stale_runs[0])
+# THE POINT. The stale notice belonged to turn one and must touch nothing else.
+check(stale_runs[1]["relay_error"] is None,
+      "a fault from a turn that has already ended must not be recorded against "
+      "the next one: %r" % stale_runs[1])
+check(stale_runs[1]["answered"] and stale_runs[1]["reply_audio_seconds"] > 0,
+      "and the next turn must be left to run normally rather than released "
+      "before its answer arrived: %r" % stale_runs[1])
+check(stale_code != 0,
+      "one turn of two was still lost, so the exit code must say so, got %r"
+      % stale_code)
+
+
 
 # A startup that refuses part way through releases what it already started, and
 # close() therefore has to survive a half-built client. The real devices cannot be

--- a/tests/fm-voice-relay.test.sh
+++ b/tests/fm-voice-relay.test.sh
@@ -1803,20 +1803,35 @@ REPLY_END = frame.encode_json(frame.MARK, {"mark": "reply_end",
                                            "tool_calls": 0})
 
 
+def wire_client(args, reader, uplink, playback=None, start=True):
+    """Build a client wired to stand-ins for both its ends, threads running.
+
+    The same seven lines were written out at every case below. playback defaults to
+    a file at whatever --out-file the arguments name, which is what most of them
+    want; a case needing a playback of its own passes one. start=False is for the
+    one case that has to arrange something before the threads may read.
+    """
+    wired = client.Client(client.parse_args(args))
+    wired.reader = frame.Reader(reader)
+    wired.uplink = uplink
+    wired.playback = (client.FilePlayback(wired.options.out_file)
+                      if playback is None else playback)
+    wired.capture = client.FileCapture(os.path.join(TMP, "clip.pcm"))
+    wired.capture.start(wired.up_q, wired.talking)
+    if start:
+        thread_lib.Thread(target=wired._sender, daemon=True).start()
+        thread_lib.Thread(target=wired._downlink, daemon=True).start()
+    return wired
+
+
 def turn_lost(label, make_stream, out_name, runs="1"):
     """Take one turn against a downlink that ends during it, and return run and stderr."""
     gate = thread_lib.Event()
-    lost = client.Client(client.parse_args(
+    lost = wire_client(
         ["--host", "desk", "--in-file", os.path.join(TMP, "clip.pcm"),
          "--out-file", os.path.join(TMP, out_name), "--runs", runs,
-         "--timeout", "2", "--audio-idle", "0.05"]))
-    lost.reader = frame.Reader(make_stream(gate))
-    lost.uplink = StartGate(gate)
-    lost.playback = client.FilePlayback(os.path.join(TMP, out_name))
-    lost.capture = client.FileCapture(os.path.join(TMP, "clip.pcm"))
-    lost.capture.start(lost.up_q, lost.talking)
-    thread_lib.Thread(target=lost._sender, daemon=True).start()
-    thread_lib.Thread(target=lost._downlink, daemon=True).start()
+         "--timeout", "2", "--audio-idle", "0.05"],
+        make_stream(gate), StartGate(gate))
     out, said = io.StringIO(), io.StringIO()
     with contextlib.redirect_stdout(out), contextlib.redirect_stderr(said):
         code = lost.run()
@@ -1913,17 +1928,11 @@ SESSION_ENDED = frame.encode_json(frame.NOTICE, {"event": "session-ended"})
 def turn_cut(label, payload, out_name):
     """Take one turn, at the default run count, against a scripted downlink."""
     gate = thread_lib.Event()
-    cut = client.Client(client.parse_args(
+    cut = wire_client(
         ["--host", "desk", "--in-file", os.path.join(TMP, "clip.pcm"),
          "--out-file", os.path.join(TMP, out_name),
-         "--timeout", "2", "--audio-idle", "0.05"]))
-    cut.reader = frame.Reader(ScriptedStream(gate, payload, label))
-    cut.uplink = StartGate(gate)
-    cut.playback = client.FilePlayback(os.path.join(TMP, out_name))
-    cut.capture = client.FileCapture(os.path.join(TMP, "clip.pcm"))
-    cut.capture.start(cut.up_q, cut.talking)
-    thread_lib.Thread(target=cut._sender, daemon=True).start()
-    thread_lib.Thread(target=cut._downlink, daemon=True).start()
+         "--timeout", "2", "--audio-idle", "0.05"],
+        ScriptedStream(gate, payload, label), StartGate(gate))
     out, said = io.StringIO(), io.StringIO()
     with contextlib.redirect_stdout(out), contextlib.redirect_stderr(said):
         code = cut.run()
@@ -1981,6 +1990,133 @@ for label, payload, subject in (
           "one run and even though the turn was answered, got %r"
           % (label, partial_code))
 
+# THE OTHER SIDE OF THE SAME LINE, and the complement of the answered case further
+# up this block. Those cases are faults that landed while the turn was still owed
+# an answer. These two land AFTER the answer was complete, in the gap between the
+# reply_end mark arriving and the record being copied, which the client spends
+# waiting for the reply audio to go quiet. A turn answered in full must carry no
+# reason and must not fail the session, whichever path the late fault takes: an
+# end of stream and a reset differ only in what the kernel delivered, and one relay
+# death must not produce two different exit codes depending on which it was.
+#
+# Gated at both ends rather than timed. The fault cannot be delivered until the
+# client has passed the reply_end wait, and the record cannot be copied until the
+# downlink has marked the connection finished with, which it does only after the
+# fault has been applied. Nothing here sleeps and nothing races.
+class RaisingAfterReply:
+    """Serves one whole answer, then raises once the record window is open."""
+
+    def __init__(self, gate, window):
+        self._gate = gate
+        self._window = window
+        self._bytes = frame.encode(frame.AUDIO, b"\x00\x00" * 1200) + REPLY_END
+        self._at = 0
+
+    def read(self, count):
+        check(self._gate.wait(10), "the turn never opened, so nothing was served")
+        if self._at < len(self._bytes):
+            chunk = self._bytes[self._at:self._at + count]
+            self._at += len(chunk)
+            return chunk
+        check(self._window.wait(10),
+              "fixture: the record window never opened, so nothing raced it")
+        raise OSError(104, "Connection reset by peer")
+
+
+class FailingAfterReply:
+    """Serves one whole answer, then a named turn failure in that same window."""
+
+    def __init__(self, gate, window):
+        self._gate = gate
+        self._window = window
+        self._reply = frame.encode(frame.AUDIO, b"\x00\x00" * 1200) + REPLY_END
+        self._late = frame.encode_json(
+            frame.NOTICE, {"event": "turn-failed",
+                           "error": "the model stream dropped"})
+        self._at = 0
+        self._late_at = 0
+
+    def read(self, count):
+        check(self._gate.wait(10), "the turn never opened, so nothing was served")
+        if self._at < len(self._reply):
+            chunk = self._reply[self._at:self._at + count]
+            self._at += len(chunk)
+            return chunk
+        check(self._window.wait(10),
+              "fixture: the record window never opened, so nothing raced it")
+        if self._late_at < len(self._late):
+            chunk = self._late[self._late_at:self._late_at + count]
+            self._late_at += len(chunk)
+            return chunk
+        # The notice is handled before this read is reached again, and the end of
+        # stream behind it is what marks the connection finished with, which is the
+        # gate the record waits on below.
+        return b""
+
+
+def fault_after_answer(label, make_stream, out_name):
+    """Answer one turn in full, then land a fault before the record is copied."""
+    gate, window = thread_lib.Event(), thread_lib.Event()
+    after = wire_client(
+        ["--host", "desk", "--in-file", os.path.join(TMP, "clip.pcm"),
+         "--out-file", os.path.join(TMP, out_name),
+         "--timeout", "2", "--audio-idle", "0.05"],
+        make_stream(gate, window), StartGate(gate))
+    quiet_wait = after._wait_audio_quiet
+
+    def open_the_window(deadline):
+        window.set()
+        quiet_wait(deadline)
+        # take_turn copies the record on the line after this returns, so the fault
+        # has to be in before it. closed is the downlink's own mark that it has
+        # finished with the connection and it is set only after the fault has been
+        # applied, which makes it the gate rather than any elapsed time.
+        check(after.closed.wait(10),
+              "%s: fixture: the late fault never landed before the record"
+              % label)
+
+    after._wait_audio_quiet = open_the_window
+    out, said = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(said):
+        code = after.run()
+    after.up_q.put(None)
+    after.playback.close()
+    records = [json_lib.loads(line) for line in out.getvalue().splitlines()
+               if line.strip()]
+    check(len(records) == 1,
+          "%s: one turn was answered, so one record belongs in the file: %r"
+          % (label, records))
+    check(after.options.runs == 1,
+          "%s: fixture is wrong, this case is about the default run count: %r"
+          % (label, after.options.runs))
+    check(records[0]["answered"] and records[0]["reply_audio_seconds"] > 0,
+          "%s: fixture is wrong, the whole reply should have arrived: %r"
+          % (label, records[0]))
+    check(records[0]["relay_error"] is None,
+          "%s: a turn answered in full must carry no reason, whatever arrived "
+          "afterwards: %r" % (label, records[0]["relay_error"]))
+    check(code == 0,
+          "%s: and a session that delivered its answer must exit 0, got %r"
+          % (label, code))
+    return said.getvalue()
+
+
+# The read-failure path: a reset rather than a clean end of stream.
+rst_said = fault_after_answer(
+    "a reset after the answer", RaisingAfterReply, "reply-rst.pcm")
+# The guard is on the record and nothing else, so the captain is still told.
+check("connection lost" in rst_said,
+      "the connection going is still said on stderr, only not recorded against a "
+      "turn it did not cost: %r" % rst_said)
+
+# The relay fail_turn path: its own model stream broke, after this turn's answer.
+failed_said = fault_after_answer(
+    "a named relay failure after the answer", FailingAfterReply,
+    "reply-late-fail.pcm")
+check("could not finish that turn" in failed_said,
+      "the relay's own words are still said on stderr for the same reason: %r"
+      % failed_said)
+
 # With runs still to take, the loop also has to say why they were not taken, and
 # that line has to restate the cause that was recorded rather than asserting a
 # default. Told "the relay stopped" and then "the connection closed", the captain
@@ -2019,19 +2155,14 @@ class FullDiskPlayback(client.FilePlayback):
 
 
 handling_served = thread_lib.Event()
-handling = client.Client(client.parse_args(
+handling = wire_client(
     ["--host", "desk", "--in-file", os.path.join(TMP, "clip.pcm"),
      "--out-file", os.path.join(TMP, "reply-handling.pcm"), "--runs", "2",
-     "--timeout", "2", "--audio-idle", "0.05", "--gap-seconds", "0.05"]))
-handling.reader = frame.Reader(ScriptedStream(
-    handling_served, frame.encode(frame.AUDIO, b"\x00\x00" * 600),
-    "the one reply frame"))
-handling.uplink = StartGate(handling_served)
-handling.playback = FullDiskPlayback(os.path.join(TMP, "reply-handling.pcm"))
-handling.capture = client.FileCapture(os.path.join(TMP, "clip.pcm"))
-handling.capture.start(handling.up_q, handling.talking)
-thread_lib.Thread(target=handling._sender, daemon=True).start()
-thread_lib.Thread(target=handling._downlink, daemon=True).start()
+     "--timeout", "2", "--audio-idle", "0.05", "--gap-seconds", "0.05"],
+    ScriptedStream(handling_served, frame.encode(frame.AUDIO, b"\x00\x00" * 600),
+                   "the one reply frame"),
+    StartGate(handling_served),
+    FullDiskPlayback(os.path.join(TMP, "reply-handling.pcm")))
 handling_out, handling_said = io.StringIO(), io.StringIO()
 with contextlib.redirect_stdout(handling_out), \
         contextlib.redirect_stderr(handling_said):
@@ -2149,17 +2280,12 @@ def audio_after_close(label, extra):
     opened, released, handled = (thread_lib.Event(), thread_lib.Event(),
                                  thread_lib.Event())
     out_file = os.path.join(TMP, "reply-late-%s.pcm" % label)
-    late = client.Client(client.parse_args(
+    late = wire_client(
         ["--host", "desk", "--in-file", os.path.join(TMP, "clip.pcm"),
          "--out-file", out_file, "--timeout", "2", "--audio-idle", "0.05"]
-        + extra))
-    late.reader = frame.Reader(LateAudioStream(opened, released))
-    late.uplink = StartGate(opened)
-    late.playback = CountingPlayback(out_file, handled)
-    late.capture = client.FileCapture(os.path.join(TMP, "clip.pcm"))
-    late.capture.start(late.up_q, late.talking)
-    thread_lib.Thread(target=late._sender, daemon=True).start()
-    thread_lib.Thread(target=late._downlink, daemon=True).start()
+        + extra,
+        LateAudioStream(opened, released), StartGate(opened),
+        CountingPlayback(out_file, handled))
     out, said = io.StringIO(), io.StringIO()
     with contextlib.redirect_stdout(out), contextlib.redirect_stderr(said):
         code = late.run()
@@ -2302,20 +2428,19 @@ class TurnCountingGate:
 
 
 stale_open, stale_next = thread_lib.Event(), thread_lib.Event()
-stale = client.Client(client.parse_args(
+# Wired without starting its threads, because the notice has to be parked before
+# the downlink is allowed to read it.
+stale = wire_client(
     ["--host", "desk", "--in-file", os.path.join(TMP, "clip.pcm"),
      "--out-file", os.path.join(TMP, "reply-stale.pcm"), "--runs", "2",
-     "--timeout", "2", "--audio-idle", "0.05", "--gap-seconds", "0.05"]))
-stale.reader = frame.Reader(ScriptedStream(
-    stale_open,
-    frame.encode_json(frame.NOTICE, {"event": "turn-failed",
-                                     "error": "the model dropped turn one"})
-    + frame.encode(frame.AUDIO, b"\x00\x00" * 1200) + REPLY_END,
-    "turn one's failure and turn two's answer"))
-stale.uplink = TurnCountingGate(stale_open, stale_next)
-stale.playback = client.FilePlayback(os.path.join(TMP, "reply-stale.pcm"))
-stale.capture = client.FileCapture(os.path.join(TMP, "clip.pcm"))
-stale.capture.start(stale.up_q, stale.talking)
+     "--timeout", "2", "--audio-idle", "0.05", "--gap-seconds", "0.05"],
+    ScriptedStream(
+        stale_open,
+        frame.encode_json(frame.NOTICE, {"event": "turn-failed",
+                                         "error": "the model dropped turn one"})
+        + frame.encode(frame.AUDIO, b"\x00\x00" * 1200) + REPLY_END,
+        "turn one's failure and turn two's answer"),
+    TurnCountingGate(stale_open, stale_next), start=False)
 
 # The notice is held between arriving and being applied, which is the window the
 # turn identity exists to close. Turn one then times out and is recorded, turn two
@@ -2390,19 +2515,14 @@ class LatePlayback(client.FilePlayback):
 
 late_open, late_next = thread_lib.Event(), thread_lib.Event()
 late_out_file = os.path.join(TMP, "reply-late.pcm")
-late = client.Client(client.parse_args(
+late = wire_client(
     ["--host", "desk", "--in-file", os.path.join(TMP, "clip.pcm"),
      "--out-file", late_out_file, "--runs", "2",
-     "--timeout", "2", "--audio-idle", "0.05", "--gap-seconds", "0.05"]))
-late.reader = frame.Reader(ScriptedStream(
-    late_open, frame.encode(frame.AUDIO, b"\x00\x00" * 1200),
-    "turn one's audio"))
-late.uplink = TurnCountingGate(late_open, late_next)
-late.playback = LatePlayback(late_out_file, late_next)
-late.capture = client.FileCapture(os.path.join(TMP, "clip.pcm"))
-late.capture.start(late.up_q, late.talking)
-thread_lib.Thread(target=late._sender, daemon=True).start()
-thread_lib.Thread(target=late._downlink, daemon=True).start()
+     "--timeout", "2", "--audio-idle", "0.05", "--gap-seconds", "0.05"],
+    ScriptedStream(late_open, frame.encode(frame.AUDIO, b"\x00\x00" * 1200),
+                   "turn one's audio"),
+    TurnCountingGate(late_open, late_next),
+    LatePlayback(late_out_file, late_next))
 late_out, late_said = io.StringIO(), io.StringIO()
 with contextlib.redirect_stdout(late_out), contextlib.redirect_stderr(late_said):
     late_code = late.run()
@@ -2447,20 +2567,14 @@ check(os.path.getsize(late_out_file) == 2400,
 # the elapsed time distinguishes stopping from waiting; nothing in the case sleeps
 # on purpose, the code under test is the sleep.
 prompt_served = thread_lib.Event()
-prompt = client.Client(client.parse_args(
+prompt = wire_client(
     ["--host", "desk", "--in-file", os.path.join(TMP, "clip.pcm"),
      "--out-file", os.path.join(TMP, "reply-prompt.pcm"), "--runs", "3",
-     "--timeout", "2", "--audio-idle", "0.05", "--gap-seconds", "5"]))
-prompt.reader = frame.Reader(ScriptedStream(
-    prompt_served,
-    frame.encode(frame.AUDIO, b"\x00\x00" * 1200) + REPLY_END,
-    "one whole answer and then the end of stream"))
-prompt.uplink = StartGate(prompt_served)
-prompt.playback = client.FilePlayback(os.path.join(TMP, "reply-prompt.pcm"))
-prompt.capture = client.FileCapture(os.path.join(TMP, "clip.pcm"))
-prompt.capture.start(prompt.up_q, prompt.talking)
-thread_lib.Thread(target=prompt._sender, daemon=True).start()
-thread_lib.Thread(target=prompt._downlink, daemon=True).start()
+     "--timeout", "2", "--audio-idle", "0.05", "--gap-seconds", "5"],
+    ScriptedStream(prompt_served,
+                   frame.encode(frame.AUDIO, b"\x00\x00" * 1200) + REPLY_END,
+                   "one whole answer and then the end of stream"),
+    StartGate(prompt_served))
 prompt_out, prompt_said = io.StringIO(), io.StringIO()
 prompt_began = clock.monotonic()
 with contextlib.redirect_stdout(prompt_out), contextlib.redirect_stderr(prompt_said):

--- a/tests/fm-voice-relay.test.sh
+++ b/tests/fm-voice-relay.test.sh
@@ -1278,12 +1278,14 @@ pass "a reader failure is named to the captain, a clean end and a close are not"
 
 # --- the laptop end ---------------------------------------------------------
 #
-# The microphone and speaker paths cannot be tested from a host with neither, and
-# are not tested anywhere: the first live run is their test. What IS testable is
-# everything around them, and these are the pieces whose failure is hardest to
-# read from the symptom. A missing -T corrupts audio rather than erroring, and a
-# banner-printing login shell desynchronises the stream in a way that looks like a
-# protocol bug and is not.
+# The microphone and speaker DEVICES cannot be opened on a host with neither, so
+# the first live run is their test and nothing below touches audio hardware. What
+# IS testable is everything around them, and these are the pieces whose failure is
+# hardest to read from the symptom. A missing -T corrupts audio rather than
+# erroring, and a banner-printing login shell desynchronises the stream in a way
+# that looks like a protocol bug and is not. The speaker's byte accounting is
+# testable as well, being arithmetic rather than device work, and is covered
+# further down this block against a stub stream with the callback driven by hand.
 
 mkdir -p "$TMP_ROOT/client-files"
 printf '\0\0\0\0' > "$TMP_ROOT/client-files/clip.pcm"
@@ -2080,6 +2082,193 @@ check("Traceback" not in (handling_runs[0]["relay_error"] or ""),
 check(handling_code != 0,
       "a session that took none of its runs must not exit 0, got %r"
       % handling_code)
+
+# The other end of the same handler: reply audio that arrives after THIS end has
+# released the output. close() joins the downlink at five seconds while the relay
+# teardown it waits on can take up to ten, so the join can expire with audio still
+# in flight, and the chunk behind it then met a closed file. That raised into the
+# guard above and printed its fault line and a full traceback on a session that
+# answered its turn and exited 0, which is an alarm firing on success: the reader
+# learns to skip the line, and the real one is then invisible too. The connection
+# was never the problem either, so it was a wrong cause as well as a false one.
+#
+# Driven through the events the client itself reaches, not a sleep: the turn is
+# answered and recorded, the output is released exactly as close() releases it, and
+# only then is the late chunk let through.
+class LateAudioStream:
+    """Serves one whole answer, then one more chunk once the output is released."""
+
+    def __init__(self, opened, released):
+        self._opened = opened
+        self._released = released
+        self._reply = frame.encode(frame.AUDIO, b"\x00\x00" * 1200) + REPLY_END
+        self._late = frame.encode(frame.AUDIO, b"\x00\x00" * 1200)
+        self._at = 0
+        self._late_at = 0
+        self._never = thread_lib.Event()
+
+    def read(self, count):
+        check(self._opened.wait(10), "the turn never opened, so nothing was served")
+        if self._at < len(self._reply):
+            chunk = self._reply[self._at:self._at + count]
+            self._at += len(chunk)
+            return chunk
+        check(self._released.wait(10),
+              "fixture: the output was never released, so nothing arrived late")
+        if self._late_at < len(self._late):
+            chunk = self._late[self._late_at:self._late_at + count]
+            self._late_at += len(chunk)
+            return chunk
+        # Parked rather than ending the stream, so the only lines on stderr are the
+        # ones this case is about.
+        self._never.wait(30)
+        return b""
+
+
+class CountingPlayback(client.FilePlayback):
+    """Reports each chunk once it has been handed over, so the test can wait."""
+
+    def __init__(self, path, handled):
+        client.FilePlayback.__init__(self, path)
+        self._handled = handled
+        self.calls = 0
+
+    def write(self, pcm, turn):
+        self.calls += 1
+        try:
+            client.FilePlayback.write(self, pcm, turn)
+        finally:
+            # In a finally, so the late chunk raising is as observable as the late
+            # chunk being discarded and neither outcome hangs the case.
+            if self.calls >= 2:
+                self._handled.set()
+
+
+def audio_after_close(label, extra):
+    """Answer one turn, release the output, then let a late chunk arrive."""
+    opened, released, handled = (thread_lib.Event(), thread_lib.Event(),
+                                 thread_lib.Event())
+    out_file = os.path.join(TMP, "reply-late-%s.pcm" % label)
+    late = client.Client(client.parse_args(
+        ["--host", "desk", "--in-file", os.path.join(TMP, "clip.pcm"),
+         "--out-file", out_file, "--timeout", "2", "--audio-idle", "0.05"]
+        + extra))
+    late.reader = frame.Reader(LateAudioStream(opened, released))
+    late.uplink = StartGate(opened)
+    late.playback = CountingPlayback(out_file, handled)
+    late.capture = client.FileCapture(os.path.join(TMP, "clip.pcm"))
+    late.capture.start(late.up_q, late.talking)
+    thread_lib.Thread(target=late._sender, daemon=True).start()
+    thread_lib.Thread(target=late._downlink, daemon=True).start()
+    out, said = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(said):
+        code = late.run()
+        # Exactly what close() does with the output, at the point close() does it.
+        late.playback.close()
+        released.set()
+        check(handled.wait(10), "fixture: the late chunk never reached the output")
+        late._say_dropped()
+    late.up_q.put(None)
+    records = [json_lib.loads(line) for line in out.getvalue().splitlines()
+               if line.strip()]
+    check(len(records) == 1,
+          "%s: one turn was answered, so one record belongs in the file: %r"
+          % (label, records))
+    return late, records[0], said.getvalue(), code, out_file
+
+
+quiet, quiet_run, quiet_said, quiet_code, quiet_file = audio_after_close(
+    "quiet", [])
+# THE POINT. The session worked, so nothing may read as a fault.
+check("could not handle the relay's reply" not in quiet_said,
+      "audio arriving after the output was released is this end's own teardown, "
+      "not a fault to alarm on: %r" % quiet_said)
+check("Traceback" not in quiet_said,
+      "and it must not leave a traceback behind either: %r" % quiet_said)
+check(quiet_code == 0,
+      "a session whose only turn was answered must still exit 0, got %r"
+      % quiet_code)
+check(quiet_run["answered"] and quiet_run["relay_error"] is None,
+      "and its record stands, reason-free: %r" % quiet_run)
+# Condition 2: the discard is diagnostic only. The late chunk is the same size as
+# the answer, so anything crediting it would double both figures.
+check(quiet.playback.discarded == 1,
+      "the late chunk must be counted as discarded: %r"
+      % quiet.playback.discarded)
+check(quiet.playback.turn_bytes == 2400,
+      "but must not be credited to the turn: %r" % quiet.playback.turn_bytes)
+check(quiet_run["reply_audio_seconds"] == 0.05,
+      "so the reply's own duration stands: %r" % quiet_run["reply_audio_seconds"])
+check(quiet_run["first_audio_s"] is not None,
+      "and the answer's real first-audio figure stands: %r"
+      % quiet_run["first_audio_s"])
+check(os.path.getsize(quiet_file) == 2400,
+      "and the discarded chunk reached no file: %d bytes"
+      % os.path.getsize(quiet_file))
+
+# Condition 1: discarded, not silently swallowed. A write after close outside
+# teardown is a real logic bug, so the count has somewhere to be read.
+loud, _, loud_said, loud_code, _ = audio_after_close("loud", ["--verbose"])
+check("discarded 1 reply audio chunk" in loud_said,
+      "--verbose must say how many chunks were dropped: %r" % loud_said)
+check("could not handle the relay's reply" not in loud_said
+      and "Traceback" not in loud_said,
+      "and saying so is not the same as calling it a fault: %r" % loud_said)
+check(loud_code == 0 and loud.playback.turn_bytes == 2400,
+      "and reporting it changes neither the exit code nor the turn's bytes: %r %r"
+      % (loud_code, loud.playback.turn_bytes))
+
+# Which of the playback's two locks covers what, driven rather than asserted about.
+# take_turn calls turn_reset while holding the client's own turn lock, so anything
+# turn_reset can wait behind stalls the whole client: neither the downlink nor the
+# sender can stamp a thing without that lock. The file write is the one slow step
+# here, so it must sit outside the lock turn_reset takes. The handle below parks
+# instead of writing, which makes a slow filesystem exact rather than simulated.
+parked, release_write, reset_done = (thread_lib.Event(), thread_lib.Event(),
+                                     thread_lib.Event())
+
+
+class ParkingHandle:
+    """A file whose write blocks until this case lets it through."""
+
+    def __init__(self):
+        self.written = 0
+
+    def write(self, pcm):
+        self.written += len(pcm)
+        parked.set()
+        check(release_write.wait(10), "fixture: the parked write was never freed")
+
+    def close(self):
+        pass
+
+
+slow = client.FilePlayback(os.path.join(TMP, "reply-slow.pcm"))
+slow._handle.close()
+slow._handle = ParkingHandle()
+slow.turn_reset(1)
+thread_lib.Thread(target=slow.write, args=(b"\x00\x00" * 600, 1),
+                  daemon=True).start()
+check(parked.wait(10), "fixture: the write never reached the handle")
+
+
+def advance_the_turn():
+    slow.turn_reset(2)
+    reset_done.set()
+
+
+thread_lib.Thread(target=advance_the_turn, daemon=True).start()
+# Bounded, and it discriminates in both directions: with the write outside that
+# lock the reset completes at once, and with the write inside it the reset cannot
+# complete until the line below runs, whatever the machine is doing.
+check(reset_done.wait(5),
+      "a turn advance must not wait behind a file write, because take_turn makes "
+      "it while holding the lock the downlink and the sender both need")
+release_write.set()
+# The accounting still had to happen, and under the lock: the chunk was turn one's.
+check(slow.turn_bytes == 0 and slow.first_played is None,
+      "and turn two starts owed nothing and unstamped: %r %r"
+      % (slow.turn_bytes, slow.first_played))
 
 # A reply that is handled AFTER the turn it belongs to has already been recorded.
 # The downlink reads a frame on one thread and applies it on another, so a turn

--- a/tests/fm-voice-relay.test.sh
+++ b/tests/fm-voice-relay.test.sh
@@ -2451,6 +2451,162 @@ check(slow.turn_bytes == 0 and slow.first_played is None,
       "and turn two starts owed nothing and unstamped: %r %r"
       % (slow.turn_bytes, slow.first_played))
 
+# The record's own two figures for one turn's audio. reply_audio_seconds and
+# answered are the same measurement asked twice, and the record is built outside
+# the playback's lock, so reading that measurement twice lets a chunk land between
+# the two reads and produce a record saying both that no audio arrived and that the
+# turn was answered. The reader of runs.jsonl then has to guess which half to
+# believe, which is the whole failure this work exists to remove.
+#
+# The playback below is that interleaving made exact rather than raced for: the
+# count grows between one read of it and the next, so a record built from two reads
+# cannot agree with itself and a record built from one always does.
+class SlippingCount(client.FilePlayback):
+    """A playback whose byte count grows between one read of it and the next."""
+
+    def __init__(self, path):
+        self.reads = 0
+        client.FilePlayback.__init__(self, path)
+
+    @property
+    def turn_bytes(self):
+        self.reads += 1
+        return self._counted if self.reads == 1 else self._counted + 2400
+
+    @turn_bytes.setter
+    def turn_bytes(self, count):
+        self._counted = count
+
+
+slip_open, slip_parked = thread_lib.Event(), thread_lib.Event()
+
+
+def park_the_downlink():
+    # Parked rather than ended, because an end of stream would make the downlink
+    # name a reason, and naming one reads the byte count itself. The turn has to
+    # reach its record with the count still unread by anything else.
+    slip_parked.wait(30)
+
+
+slipping = SlippingCount(os.path.join(TMP, "reply-slip.pcm"))
+# The timeout boundary is the one moment the first chunk of a reply can land while
+# the record is being built, because a turn that timed out with nothing played is
+# the only one whose count is still zero when the record reads it.
+slipped = wire_client(
+    ["--host", "desk", "--in-file", os.path.join(TMP, "clip.pcm"),
+     "--out-file", os.path.join(TMP, "reply-slip.pcm"),
+     "--timeout", "0.3", "--audio-idle", "0.05"],
+    ScriptedStream(slip_open, b"", "nothing at all", park_the_downlink),
+    StartGate(slip_open), slipping)
+slip_out, slip_said = io.StringIO(), io.StringIO()
+with contextlib.redirect_stdout(slip_out), contextlib.redirect_stderr(slip_said):
+    slip_code = slipped.run()
+slipped.up_q.put(None)
+slip_records = [json_lib.loads(line) for line in slip_out.getvalue().splitlines()
+                if line.strip()]
+check(len(slip_records) == 1,
+      "the turn was taken, so its record belongs in the file: %r" % slip_records)
+slip = slip_records[0]
+check(slipping.reads >= 1,
+      "fixture: the record never read the byte count at all, so this case proves "
+      "nothing: %r" % slipping.reads)
+# THE POINT. One record may not answer the same question two ways.
+check(slip["answered"] == (slip["reply_audio_seconds"] > 0),
+      "a record that counts no reply audio must not also call the turn answered: "
+      "%r" % slip)
+check(slip["reply_audio_seconds"] == 0.0 and slip["answered"] is False,
+      "and the figures are the ones true when the record was built, not one from "
+      "before the chunk and one from after: %r" % slip)
+check(slip_code != 0,
+      "an unanswered turn must not exit 0, got %r" % slip_code)
+# Released under a redirect so the end of stream this case parked cannot print into
+# the suite's own output, and waited for so it cannot land after the case has ended.
+with contextlib.redirect_stderr(io.StringIO()):
+    slip_parked.set()
+    slip_drained = slipped.closed.wait(10)
+check(slip_drained, "fixture: the parked stream never ended")
+
+# An end of stream arriving during THIS end's own teardown. close() bounds the
+# relay's exit and the relay's own teardown can outlast that bound, so the child is
+# killed with no goodbye written and the still-live downlink reads the empty stream
+# it left behind. Every turn was answered and the session exits 0, so the mid-turn
+# fault line must not be the last thing the captain reads: an alarm that also fires
+# on success is one they learn to skip past, and then the real one is invisible too.
+#
+# The discriminator is the same one the goodbye branch uses, whether this end asked
+# to stop, and the mid-session case further up this file is the other direction of
+# it: there the stream ends long before close() is reached, so the line still fires.
+class QuitThenEnd:
+    """Serves one whole answer, then ends the stream once this end says goodbye."""
+
+    def __init__(self, opened, quit_seen):
+        self._opened = opened
+        self._quit = quit_seen
+        self._bytes = frame.encode(frame.AUDIO, b"\x00\x00" * 1200) + REPLY_END
+        self._at = 0
+
+    def read(self, count):
+        check(self._opened.wait(10), "the turn never opened, so nothing was served")
+        if self._at < len(self._bytes):
+            chunk = self._bytes[self._at:self._at + count]
+            self._at += len(chunk)
+            return chunk
+        check(self._quit.wait(10),
+              "fixture: this end never asked to stop, so the stream never ended")
+        return b""
+
+
+class GoodbyeWatchingGate:
+    """Opens on the turn's first frame and reports this end asking to stop."""
+
+    def __init__(self, opened, quit_seen):
+        self._opened = opened
+        self._quit = quit_seen
+
+    def send(self, kind, payload=b""):
+        if kind == frame.TALK_START:
+            self._opened.set()
+        elif kind == frame.QUIT:
+            self._quit.set()
+
+
+tidy_open, tidy_quit = thread_lib.Event(), thread_lib.Event()
+tidy = wire_client(
+    ["--host", "desk", "--in-file", os.path.join(TMP, "clip.pcm"),
+     "--out-file", os.path.join(TMP, "reply-tidy.pcm"),
+     "--timeout", "2", "--audio-idle", "0.05"],
+    QuitThenEnd(tidy_open, tidy_quit), GoodbyeWatchingGate(tidy_open, tidy_quit))
+tidy_out, tidy_said = io.StringIO(), io.StringIO()
+with contextlib.redirect_stdout(tidy_out), contextlib.redirect_stderr(tidy_said):
+    tidy_code = tidy.run()
+    # Gated on the downlink reaching the end of stream rather than on any elapsed
+    # time: close() does not wait for it here, so without this the case could pass
+    # by asserting on output the downlink had not written yet.
+    tidy.close()
+    tidy_drained = tidy.closed.wait(10)
+tidy.up_q.put(None)
+check(tidy_drained, "fixture: the downlink never saw the stream end")
+tidy_records = [json_lib.loads(line) for line in tidy_out.getvalue().splitlines()
+                if line.strip()]
+check(len(tidy_records) == 1,
+      "one turn was answered, so one record belongs in the file: %r" % tidy_records)
+# Proof the end of stream really was taken, so the silence below is a decision
+# rather than a branch this case never reached: the cause is recorded outside the
+# test that decides whether to speak.
+check(tidy.closed_because == "the connection ended",
+      "fixture: the downlink did not take the end of stream at all: %r"
+      % tidy.closed_because)
+# THE POINT. The session answered everything asked of it, so nothing may read as a
+# fault, least of all as the last line the captain sees.
+check("the connection ended" not in tidy_said.getvalue(),
+      "an end of stream during this end's own teardown is the relay doing as it "
+      "was told, not a fault to alarm on: %r" % tidy_said.getvalue())
+check(tidy_code == 0,
+      "and a session whose only turn was answered must still exit 0, got %r"
+      % tidy_code)
+check(tidy_records[0]["answered"] and tidy_records[0]["relay_error"] is None,
+      "and its record stands, reason-free: %r" % tidy_records[0])
+
 # A reply that is handled AFTER the turn it belongs to has already been recorded.
 # The downlink reads a frame on one thread and applies it on another, so a turn
 # that times out while a notice is in flight used to have that notice applied to

--- a/tests/fm-voice-relay.test.sh
+++ b/tests/fm-voice-relay.test.sh
@@ -1619,6 +1619,141 @@ check(closing_code != 0,
 check("connection closed" in spoken.getvalue(),
       "and the captain should be told why it stopped: %r" % spoken.getvalue())
 
+# The case above is the connection going while the run loop is watching for it.
+# The loop cannot only be watching, though: the downlink names the failure and
+# marks the connection closed, and a loop that decides by reading the mark alone
+# is blind for as long as those are two separate writes - the connection is gone,
+# the failure is on the record, and the check has already passed. So the decision
+# belongs where the turn is opened, under the lock both writes are made under.
+# With the connection already gone, opening the turn anyway erased the failure the
+# downlink had recorded, pushed talk-start into a dead pipe, and printed a run
+# that waited out the whole reply timeout as answered: false with relay_error:
+# null - the invented turn this whole seam exists to keep out of runs.jsonl.
+class LostStream:
+    """A downlink that is already gone the first time it is read."""
+
+    def read(self, count):
+        raise OSError(104, "Connection reset by peer")
+
+
+class CountingUplink:
+    """Accepts frames and remembers which kinds were pushed at it."""
+
+    def __init__(self):
+        self.sent = []
+
+    def send(self, kind, payload=b""):
+        self.sent.append(kind)
+
+
+gone = client.Client(client.parse_args(
+    ["--host", "desk", "--in-file", os.path.join(TMP, "clip.pcm"),
+     "--out-file", os.path.join(TMP, "reply-gone.pcm"), "--runs", "2",
+     "--timeout", "2", "--audio-idle", "0.05", "--gap-seconds", "0.05"]))
+gone.reader = frame.Reader(LostStream())
+gone.uplink = CountingUplink()
+gone.playback = client.FilePlayback(os.path.join(TMP, "reply-gone.pcm"))
+gone.capture = client.FileCapture(os.path.join(TMP, "clip.pcm"))
+gone.capture.start(gone.up_q, gone.talking)
+thread_lib.Thread(target=gone._sender, daemon=True).start()
+# Run to completion in this thread rather than in a started one: the connection
+# is gone before the first read returns, so the whole downlink is over by the
+# time run() begins and there is no ordering left for the scheduler to decide.
+gone._downlink()
+check(gone.closed.is_set(),
+      "fixture: a connection lost on the first read must leave the client closed")
+
+gone_out, gone_said = io.StringIO(), io.StringIO()
+with contextlib.redirect_stdout(gone_out), contextlib.redirect_stderr(gone_said):
+    gone_code = gone.run()
+gone.up_q.put(None)
+gone.playback.close()
+
+gone_runs = [json_lib.loads(line) for line in gone_out.getvalue().splitlines()
+             if line.strip()]
+check(gone_runs == [],
+      "a turn must not be opened on a connection already known gone, and no run "
+      "reported for one that never opened: %r" % gone_runs)
+check(gone.uplink.sent == [],
+      "and nothing should be pushed into the dead pipe: %r" % gone.uplink.sent)
+check(gone_code != 0,
+      "a session that took none of its 2 runs must not exit 0, got %r" % gone_code)
+check("connection closed" in gone_said.getvalue()
+      and "run 1 of 2" in gone_said.getvalue(),
+      "and the captain should be told why nothing was taken, naming the run it "
+      "stopped at: %r" % gone_said.getvalue())
+
+# The third moment is a connection that goes DURING a turn that answered anyway,
+# with runs still to take. The answer is real and its record stands, so nothing
+# here is a turn failure; what must not happen is the session ending quietly on a
+# happy exit code, because two of the three runs asked for are missing and a
+# runs.jsonl short of its runs, reported as success, is read later as the whole
+# measurement. Refusing the next turn is the one place a closed connection stops
+# a session, so it reports the same way wherever the connection went.
+class EndingStream:
+    """Serves one whole turn, then reports end of file without waiting."""
+
+    def __init__(self, gate):
+        self._gate = gate
+        self._reply = (
+            frame.encode(frame.AUDIO, b"\x00\x00" * 1200)
+            + frame.encode_json(frame.MARK, {"mark": "reply_end",
+                                             "since_talk_end": 0.4,
+                                             "tool_calls": 0}))
+        self._at = 0
+
+    def read(self, count):
+        check(self._gate.wait(10), "the turn never opened, so nothing was served")
+        chunk = self._reply[self._at:self._at + count]
+        self._at += len(chunk)
+        return chunk
+
+
+ending_served = thread_lib.Event()
+ending = client.Client(client.parse_args(
+    ["--host", "desk", "--in-file", os.path.join(TMP, "clip.pcm"),
+     "--out-file", os.path.join(TMP, "reply-ending.pcm"), "--runs", "3",
+     "--timeout", "2", "--audio-idle", "0.05", "--gap-seconds", "0.05"]))
+ending.reader = frame.Reader(EndingStream(ending_served))
+ending.uplink = StartGate(ending_served)
+ending.playback = client.FilePlayback(os.path.join(TMP, "reply-ending.pcm"))
+ending.capture = client.FileCapture(os.path.join(TMP, "clip.pcm"))
+ending.capture.start(ending.up_q, ending.talking)
+thread_lib.Thread(target=ending._sender, daemon=True).start()
+thread_lib.Thread(target=ending._downlink, daemon=True).start()
+
+# The end of file lands inside the first turn, so it is already seen by the time
+# the wait after that turn begins. Confirming it here rather than trusting the
+# timing keeps the sequence exact on a loaded host as well as an idle one.
+finish_after_end = ending._let_reply_finish
+
+
+def confirm_ended_then_wait(record):
+    check(ending.closed.wait(10),
+          "fixture: the end of file never reached the client during the turn")
+    return finish_after_end(record)
+
+
+ending._let_reply_finish = confirm_ended_then_wait
+ending_out, ending_said = io.StringIO(), io.StringIO()
+with contextlib.redirect_stdout(ending_out), contextlib.redirect_stderr(ending_said):
+    ending_code = ending.run()
+ending.up_q.put(None)
+ending.playback.close()
+
+ending_runs = [json_lib.loads(line) for line in ending_out.getvalue().splitlines()
+               if line.strip()]
+check(len(ending_runs) == 1,
+      "one turn was served, so exactly one run belongs in the file: %d, %r"
+      % (len(ending_runs), ending_runs))
+check(ending_runs[0]["answered"] and ending_runs[0]["relay_error"] is None,
+      "an answered turn whose connection then ended cleanly is not a turn "
+      "failure, and its record stands: %r" % ending_runs[0])
+check(ending_code != 0,
+      "but a session that took 1 of 3 runs must not exit 0, got %r" % ending_code)
+check("run 2 of 3" in ending_said.getvalue(),
+      "and it should name the run it stopped at: %r" % ending_said.getvalue())
+
 # A startup that refuses part way through releases what it already started, and
 # close() therefore has to survive a half-built client. The real devices cannot be
 # opened on this host, so these stand in for them; what is tested here is the

--- a/tests/fm-voice-relay.test.sh
+++ b/tests/fm-voice-relay.test.sh
@@ -1754,6 +1754,127 @@ check(ending_code != 0,
 check("run 2 of 3" in ending_said.getvalue(),
       "and it should name the run it stopped at: %r" % ending_said.getvalue())
 
+# The case above is the connection ending AFTER a turn was answered, which is the
+# negative case: nothing broke inside a turn, so nothing is named. The three
+# below are the same three endings landing INSIDE a turn, while it is still
+# waiting for its reply, and there each of them has to name itself.
+#
+# None of them raises. frame.Writer sends whole frames and the relay spends
+# almost all of a turn awaiting the model, so a relay killed mid-turn - SIGKILL,
+# the host going, the SSH connection dropping between frames - ends its stdout on
+# a frame boundary. Reader then reads nothing at all where a header should start
+# and reports end of input by design. A goodbye is the same shape by another
+# route: the relay sends one from its own teardown after a fault. Released with
+# no reason recorded, both come back as answered: false with relay_error: null,
+# which in runs.jsonl is the shape of a turn the model declined, and runs.jsonl
+# is the file docs/voice-relay.md computes its published latency spread from. An
+# infrastructure failure averaged into that number is the whole thing being kept
+# out of it.
+class SilentEndStream:
+    """Ends the stream at a frame boundary once the turn is under way."""
+
+    def __init__(self, gate):
+        self._gate = gate
+
+    def read(self, count):
+        check(self._gate.wait(10), "the turn never opened, so nothing ended")
+        return b""
+
+
+class GoodbyeStream:
+    """Says goodbye once the turn is under way, without answering it."""
+
+    def __init__(self, gate):
+        self._gate = gate
+        self._bytes = frame.encode(frame.BYE)
+        self._at = 0
+
+    def read(self, count):
+        check(self._gate.wait(10), "the turn never opened, so nothing was said")
+        chunk = self._bytes[self._at:self._at + count]
+        self._at += len(chunk)
+        return chunk
+
+
+class NamedFaultStream:
+    """Names the fault the relay saw, then says goodbye, with the turn open."""
+
+    def __init__(self, gate, reason):
+        self._gate = gate
+        self._bytes = (
+            frame.encode_json(frame.NOTICE,
+                              {"event": "turn-failed", "error": reason})
+            + frame.encode(frame.BYE))
+        self._at = 0
+
+    def read(self, count):
+        check(self._gate.wait(10), "the turn never opened, so nothing was named")
+        chunk = self._bytes[self._at:self._at + count]
+        self._at += len(chunk)
+        return chunk
+
+
+RELAY_REASON = "FrameError: unknown frame kind: b'\\xff'"
+
+
+def turn_lost(label, make_stream, out_name):
+    """Take one turn against a downlink that ends during it, and return its run."""
+    gate = thread_lib.Event()
+    lost = client.Client(client.parse_args(
+        ["--host", "desk", "--in-file", os.path.join(TMP, "clip.pcm"),
+         "--out-file", os.path.join(TMP, out_name), "--timeout", "2",
+         "--audio-idle", "0.05"]))
+    lost.reader = frame.Reader(make_stream(gate))
+    lost.uplink = StartGate(gate)
+    lost.playback = client.FilePlayback(os.path.join(TMP, out_name))
+    lost.capture = client.FileCapture(os.path.join(TMP, "clip.pcm"))
+    lost.capture.start(lost.up_q, lost.talking)
+    thread_lib.Thread(target=lost._sender, daemon=True).start()
+    thread_lib.Thread(target=lost._downlink, daemon=True).start()
+    out = io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(io.StringIO()):
+        code = lost.run()
+    lost.up_q.put(None)
+    lost.playback.close()
+    runs = [json_lib.loads(line) for line in out.getvalue().splitlines()
+            if line.strip()]
+    # The record is still emitted: the turn was taken and it really did go
+    # unanswered, so dropping it would hide the failure instead of naming it.
+    check(len(runs) == 1,
+          "%s: the turn was taken, so its run belongs in the file: %d, %r"
+          % (label, len(runs), runs))
+    check(not runs[0]["answered"],
+          "%s: fixture is wrong, the turn was answered after all: %r"
+          % (label, runs[0]))
+    check(code != 0, "%s: an unanswered turn must not exit 0, got %r"
+          % (label, code))
+    check(runs[0]["relay_error"],
+          "%s: a turn lost to the connection must say so rather than reading in "
+          "runs.jsonl exactly like a turn the model declined: %r"
+          % (label, runs[0]))
+    return runs[0]
+
+
+eof_run = turn_lost("end of stream", SilentEndStream, "reply-eof.pcm")
+check("ended" in eof_run["relay_error"],
+      "an end of stream should say the connection ended: %r"
+      % eof_run["relay_error"])
+
+bye_run = turn_lost("goodbye", GoodbyeStream, "reply-bye.pcm")
+check("goodbye" in bye_run["relay_error"],
+      "a goodbye mid-turn should say so, because it is the relay deciding to "
+      "stop rather than the connection dying: %r" % bye_run["relay_error"])
+
+# And when the relay does name the fault, its words are what the record carries.
+# This end can only infer that a goodbye arrived; the relay knows what happened,
+# so a reason it sent is never replaced by one inferred here.
+named_run = turn_lost(
+    "named fault", lambda gate: NamedFaultStream(gate, RELAY_REASON),
+    "reply-named.pcm")
+check(named_run["relay_error"] == RELAY_REASON,
+      "the relay's own reason must reach the record unchanged rather than being "
+      "overwritten by the goodbye behind it: %r" % named_run["relay_error"])
+
 # A startup that refuses part way through releases what it already started, and
 # close() therefore has to survive a half-built client. The real devices cannot be
 # opened on this host, so these stand in for them; what is tested here is the
@@ -3197,8 +3318,20 @@ check(len(runs) == 2,
 check(len(sessions) == 2,
       "the next talk key did not get a session: %d opened" % len(sessions))
 check(not runs[0]["answered"], "the lost turn should be the first one: %r" % runs[0])
-check(runs[0]["relay_error"] is None,
-      "an ordinary session end is not a turn failure: %r" % runs[0]["relay_error"])
+# An ordinary session end is not a turn FAILURE - the relay names none, marks the
+# session spent for nobody, and the next talk key gets a working one - but the
+# turn it landed in still has no answer, and the record has to say why. Left null
+# there, the only turn in this whole file that went unanswered for a knowable
+# reason reads in runs.jsonl exactly like a turn the model declined, and that file
+# is where the published latency spread comes from.
+check(runs[0]["relay_error"],
+      "a turn released by the session ending must name why it has no answer: %r"
+      % runs[0])
+check("session" in runs[0]["relay_error"],
+      "and it should name the session ending rather than some other fault: %r"
+      % runs[0]["relay_error"])
+check("could not finish that turn" not in transcript,
+      "the relay must not have called this a failed turn: %r" % transcript)
 
 # And it was a working session rather than a closed pipe: a real answer, composed
 # from a real read of the records, spoken to the captain over the same connection.
@@ -3242,6 +3375,104 @@ check("connection lost" not in transcript,
       "the connection should have outlived the session: %r" % transcript)
 PY
 pass "a model session that ends mid-conversation costs one turn, not the relay"
+
+# --- an uplink that stops being a frame stream --------------------------------
+#
+# One of the three things that ends the relay, and the only one it diagnoses: the
+# captain's uplink desynchronises, so the relay can no longer tell a header from
+# audio. It writes what it saw on its own stderr and exits 2, which is honest,
+# and it used to tell the client only goodbye. Everything the relay knew stayed
+# on a stderr no run file quotes, while the turn the captain was in the middle of
+# came back as answered: false with nothing in relay_error - the reason existed
+# and was thrown away.
+#
+# Worse, the teardown closes the model session first, and that sets the flag which
+# silences the session reader's own notice, so this path really did send the client
+# nothing at all but the goodbye.
+#
+# The relay is driven directly here rather than through the client, because no
+# client sends a bad frame: the desync is the transport corrupting one, and the
+# only way to put one on the wire is to be the other end. The model is the same
+# stand-in the round trip above uses, and it is never asked to answer.
+
+set +e
+env -i PATH="$PATH" HOME="$E2E/desktop-home" PYTHONPATH="$E2E/fakesdk" \
+  PYTHONDONTWRITEBYTECODE=1 FM_HOME="$E2E/home" \
+  AWS_ACCESS_KEY_ID="$E2E_KEY" \
+  AWS_SECRET_ACCESS_KEY=desktop-secret-not-a-real-key \
+  python3 - "$ROOT/bin" <<'PY'
+import os, subprocess, sys
+sys.path.insert(0, sys.argv[1])
+import fm_voice_frame as frame
+
+relay = os.path.join(sys.argv[1], "fm-voice-relay.py")
+
+
+def check(cond, label):
+    if not cond:
+        sys.exit("desync: " + label)
+
+
+proc = subprocess.Popen(
+    [sys.executable, relay, "--serve"],
+    stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+try:
+    magic = proc.stdout.read(len(frame.MAGIC))
+    check(magic == frame.MAGIC, "the relay did not open the stream: %r" % magic)
+    reader = frame.Reader(proc.stdout)
+    kind, payload = reader.read()
+    check(kind == frame.NOTICE
+          and frame.decode_json(payload).get("event") == "ready",
+          "the relay was never ready: %r %r" % (kind, payload))
+
+    # A turn is open when the uplink goes, which is when it goes in practice: the
+    # captain is holding the talk key, so that is when there are frames on the
+    # wire to be corrupted at all.
+    proc.stdin.write(frame.encode(frame.TALK_START))
+    proc.stdin.write(b"\xff\x00\x00\x00\x00")
+    proc.stdin.flush()
+
+    frames = []
+    while True:
+        got = reader.read()
+        if got is None:
+            break
+        frames.append(got)
+        if got[0] == frame.BYE:
+            break
+finally:
+    proc.stdin.close()
+    said = proc.stderr.read().decode("utf-8", "replace")
+    code = proc.wait(timeout=30)
+
+kinds = [k for k, _ in frames]
+check(frame.BYE in kinds, "the relay never said goodbye: %r" % kinds)
+named = [n for n in (frame.decode_json(p) for k, p in frames if k == frame.NOTICE)
+         if n.get("event") == "turn-failed"]
+check(named,
+      "the relay diagnosed the fault and told the client only goodbye: %r" % kinds)
+check("FrameError" in named[0].get("error", ""),
+      "the notice should carry what the relay saw: %r" % named[0])
+# Before the goodbye, and before the model session is closed: closing it awaits
+# the model stream, which can be slow or raise, and the client must learn the
+# reason either way.
+failed_at = next(i for i, (k, p) in enumerate(frames)
+                 if k == frame.NOTICE
+                 and frame.decode_json(p).get("event") == "turn-failed")
+check(failed_at < kinds.index(frame.BYE),
+      "the reason must reach the client ahead of the goodbye: %r" % kinds)
+
+# Still said on the relay's own stderr, which the captain reads over SSH, and
+# still the unhappy exit code: naming the fault down the connection does not make
+# it a turn the relay recovered from.
+check("not a frame stream any more" in said,
+      "the relay should still name the desync on its stderr: %r" % said)
+check(code == 2, "a desynchronised uplink must exit 2, got %r" % code)
+PY
+desync_code=$?
+set -e
+[ "$desync_code" = 0 ] || fail "a desynchronised uplink was not named to the client"
+pass "a desynchronised uplink is named to the client before the goodbye, not only to stderr"
 
 # --- the desktop's own check, and the clock it refuses to lie about ----------
 #

--- a/tests/fm-voice-relay.test.sh
+++ b/tests/fm-voice-relay.test.sh
@@ -2167,7 +2167,12 @@ def audio_after_close(label, extra):
         late.playback.close()
         released.set()
         check(handled.wait(10), "fixture: the late chunk never reached the output")
-        late._say_dropped()
+        # Through close(), not the reporting method directly, so the wiring is
+        # covered as well as the report: nothing else drives the only production
+        # caller, and hand-calling it would pass with that call deleted. Returns at
+        # once here, because the uplink stand-in swallows the quit, no downlink
+        # thread or relay process was ever assigned, and the file drain is a no-op.
+        late.close()
     late.up_q.put(None)
     records = [json_lib.loads(line) for line in out.getvalue().splitlines()
                if line.strip()]
@@ -2620,6 +2625,49 @@ check(pull(speaker, 300) == b"\x0a\x0a" * 100 + b"\x00" * 400,
       "a short earlier tail is padded rather than repeated")
 check(speaker.first_played is None, "and the padding stamps nothing")
 
+# A chunk arriving after close, which is the same teardown race the file path
+# already discards and counts. Nothing here goes near a device: the stream is the
+# same stub, and stopping it is what makes the chunk unplayable, so queuing it
+# would be recording a measurement the captain never heard.
+speaker = fresh_speaker()
+speaker.turn_reset(1)
+speaker.write(b"\x0b\x0b" * 300, 1)
+speaker.turn_reset(2)
+speaker.write(b"\x0c\x0c" * 150, 2)
+was = (speaker.turn_bytes, speaker._earlier, speaker.first_played,
+       bytes(speaker._buffer))
+check(was == (300, 600, None, b"\x0b\x0b" * 300 + b"\x0c\x0c" * 150),
+      "fixture: turn two should be owed its own bytes behind turn one's tail: %r"
+      % (was,))
+speaker.close()
+speaker.write(b"\x0d\x0d" * 300, 2)
+check(speaker.discarded == 1,
+      "a chunk arriving after close must be counted, not silently swallowed: %r"
+      % speaker.discarded)
+check(bytes(speaker._buffer) == was[3],
+      "and must not be queued for a stream that has already stopped")
+check((speaker.turn_bytes, speaker._earlier, speaker.first_played) == was[:3],
+      "and must leave every per-turn figure exactly as it was: %r"
+      % ((speaker.turn_bytes, speaker._earlier, speaker.first_played),))
+
+# And the count reaches the captain on this path through the same close() that
+# reports it on the file path, so the counter is not merely present here.
+heard = fresh_speaker()
+heard.turn_reset(1)
+heard.write(b"\x0e\x0e" * 300, 1)
+check(pull(heard, 300) == b"\x0e\x0e" * 300,
+      "fixture: the turn's own reply should drain before the output is released")
+heard.close()
+heard.write(b"\x0f\x0f" * 300, 1)
+reported = client.Client(client.parse_args(["--host", "desk", "--verbose"]))
+reported.playback = heard
+speaker_said = io.StringIO()
+with contextlib.redirect_stderr(speaker_said):
+    reported.close()
+check("discarded 1 reply audio chunk" in speaker_said.getvalue(),
+      "--verbose must report the count on this path as it does on the file one: %r"
+      % speaker_said.getvalue())
+
 del sys.modules["sounddevice"]
 
 
@@ -2633,6 +2681,7 @@ class Recorder:
         self._closed = closed
         self.first_played = None
         self.device_latency = None
+        self.discarded = 0
 
     def drain(self, timeout=5):
         pass

--- a/tests/fm-voice-relay.test.sh
+++ b/tests/fm-voice-relay.test.sh
@@ -1289,7 +1289,7 @@ mkdir -p "$TMP_ROOT/client-files"
 printf '\0\0\0\0' > "$TMP_ROOT/client-files/clip.pcm"
 
 python3 - "$ROOT/bin" "$TMP_ROOT/client-files" <<'PY' || fail "laptop client"
-import io, os, sys
+import io, os, sys, types
 sys.path.insert(0, sys.argv[1])
 import importlib.util, pathlib
 spec = importlib.util.spec_from_file_location(
@@ -1890,6 +1890,95 @@ check(named_run["relay_error"] == RELAY_REASON,
       "the relay's own reason must reach the record unchanged rather than being "
       "overwritten by the goodbye behind it: %r" % named_run["relay_error"])
 
+# THE MIDDLE OF THE SCENARIO, which the cases above and below both miss. A relay
+# killed mid-turn ends its stdout on a frame boundary, and it spends nearly the
+# whole turn streaming a reply, so dying AFTER some of that reply has played is
+# the likelier half of the very fault this work exists to name. The cases above
+# cover dying before any of it, and the answered-turn case below covers a reply
+# that finished, so nothing pinned the middle.
+#
+# In the middle both halves of the record are true at once and must say so: sound
+# reached the captain, so the turn was answered and first_audio_s measures when,
+# AND the answer stopped partway, so the reason has to say the reply did not
+# finish rather than that the turn was never answered. A record asserting both
+# "answered" and "before this turn was answered" sends whoever reads it to the
+# wrong end. At the default of one run this also used to clear every path to a
+# non-zero exit code and report the session a success.
+SOME_REPLY = frame.encode(frame.AUDIO, b"\x00\x00" * 1200)
+SESSION_ENDED = frame.encode_json(frame.NOTICE, {"event": "session-ended"})
+
+
+def turn_cut(label, payload, out_name):
+    """Take one turn, at the default run count, against a scripted downlink."""
+    gate = thread_lib.Event()
+    cut = client.Client(client.parse_args(
+        ["--host", "desk", "--in-file", os.path.join(TMP, "clip.pcm"),
+         "--out-file", os.path.join(TMP, out_name),
+         "--timeout", "2", "--audio-idle", "0.05"]))
+    cut.reader = frame.Reader(ScriptedStream(gate, payload, label))
+    cut.uplink = StartGate(gate)
+    cut.playback = client.FilePlayback(os.path.join(TMP, out_name))
+    cut.capture = client.FileCapture(os.path.join(TMP, "clip.pcm"))
+    cut.capture.start(cut.up_q, cut.talking)
+    thread_lib.Thread(target=cut._sender, daemon=True).start()
+    thread_lib.Thread(target=cut._downlink, daemon=True).start()
+    out, said = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(said):
+        code = cut.run()
+    cut.up_q.put(None)
+    cut.playback.close()
+    records = [json_lib.loads(line) for line in out.getvalue().splitlines()
+               if line.strip()]
+    check(len(records) == 1,
+          "%s: one turn was taken, so one record belongs in the file: %r"
+          % (label, records))
+    check(cut.options.runs == 1,
+          "%s: fixture is wrong, this case is about the default run count: %r"
+          % (label, cut.options.runs))
+    return records[0], said.getvalue(), code
+
+
+for label, payload, subject in (
+        ("end of stream", b"", "the connection ended"),
+        ("relay stopped", frame.encode(frame.BYE), "the relay stopped"),
+        ("session ended", SESSION_ENDED, "the relay ended the session")):
+    slug = label.replace(" ", "-")
+    # No audio at all. This half keeps the wording it already had, so the two can
+    # never be collapsed back into one sentence that fits neither.
+    silent, _, silent_code = turn_cut(
+        "%s, nothing played" % label, payload, "reply-silent-%s.pcm" % slug)
+    check(not silent["answered"] and silent["reply_audio_seconds"] == 0,
+          "%s: fixture is wrong, this half is the one where nothing played: %r"
+          % (label, silent))
+    check(silent["relay_error"] == "%s before this turn was answered" % subject,
+          "%s: a turn that got no audio went unanswered and the reason should say "
+          "so: %r" % (label, silent["relay_error"]))
+    check(silent_code != 0,
+          "%s: an unanswered turn must not exit 0, got %r" % (label, silent_code))
+
+    # Some of the reply played, then the same ending. Same fault, different turn,
+    # and the record has to describe the turn it actually got.
+    partial, _, partial_code = turn_cut(
+        "%s, part of a reply played" % label, SOME_REPLY + payload,
+        "reply-partial-%s.pcm" % slug)
+    check(partial["answered"] and partial["reply_audio_seconds"] > 0,
+          "%s: audio reached the captain, so the turn was answered: %r"
+          % (label, partial))
+    check(partial["first_audio_s"] is not None,
+          "%s: and when it reached them is a real measurement, not a null: %r"
+          % (label, partial))
+    check(partial["relay_error"] == "%s before the reply finished" % subject,
+          "%s: a reply cut short must say the reply did not finish: %r"
+          % (label, partial["relay_error"]))
+    check("before this turn was answered" not in partial["relay_error"],
+          "%s: and must not claim nothing arrived, which its own answered field "
+          "contradicts: %r" % (label, partial["relay_error"]))
+    # The record and the exit code have to agree with each other as well.
+    check(partial_code != 0,
+          "%s: a record naming a fault must not exit 0, even at the default of "
+          "one run and even though the turn was answered, got %r"
+          % (label, partial_code))
+
 # With runs still to take, the loop also has to say why they were not taken, and
 # that line has to restate the cause that was recorded rather than asserting a
 # default. Told "the relay stopped" and then "the connection closed", the captain
@@ -2155,9 +2244,6 @@ check(late_code != 0,
 check(os.path.getsize(late_out_file) == 2400,
       "the late chunk must still reach the output, not be discarded to make the "
       "figures tidy: %d bytes" % os.path.getsize(late_out_file))
-check(late.playback.bytes == 2400,
-      "and the playback should still count it among everything it wrote: %r"
-      % late.playback.bytes)
 
 # The wait between turns is the last thing a lost session should do. It exists
 # only to avoid talking over the model's own speech, and a relay that is already
@@ -2203,6 +2289,150 @@ check("the connection ended before run 2 of 3" in prompt_said.getvalue(),
       "and it should name the cause and the first run it lost: %r"
       % prompt_said.getvalue())
 
+# The speaker's byte ACCOUNTING, which is not the speaker. No audio device is
+# reached here and none can be on this host: the stream is a stub and the device
+# callback is called by hand, so nothing below says anything about how a real
+# output device behaves. What it does cover is the arithmetic deciding which turn
+# a chunk is credited to and whose first-audio clock it stamps, which until now
+# was the one piece of that logic with no coverage at all while the file path it
+# mirrors had plenty. Its correctness rests on the earlier turns' bytes being a
+# prefix of the buffer, and a sign or bound slip in the prefix count would
+# silently mismeasure the headline latency on the path the captain will use.
+class StubStream:
+    """Stands in for the output device: accepts the settings, plays nothing."""
+
+    def __init__(self, **settings):
+        self.settings = settings
+        self.latency = 0.011
+        self.started = False
+
+    def start(self):
+        self.started = True
+
+    def stop(self):
+        pass
+
+    def close(self):
+        pass
+
+
+stub_audio = types.ModuleType("sounddevice")
+stub_audio.RawOutputStream = StubStream
+sys.modules["sounddevice"] = stub_audio
+
+
+def fresh_speaker():
+    return client.SpeakerPlayback()
+
+
+def pull(speaker, frames):
+    """Ask the stub device for one block, and return exactly what it was handed."""
+    block = bytearray(frames * 2)
+    speaker._callback(block, frames, None, None)
+    return bytes(block)
+
+
+opened = fresh_speaker()
+check(opened.device_latency == 0.011,
+      "the reported device latency should come from the stream: %r"
+      % opened.device_latency)
+
+# No earlier bytes at all: the first chunk of this turn's own reply is this turn's
+# first audio.
+speaker = fresh_speaker()
+speaker.turn_reset(1)
+speaker.write(b"\x01\x01" * 300, 1)
+check(speaker.turn_bytes == 600,
+      "this turn's own audio is credited to it: %r" % speaker.turn_bytes)
+check(pull(speaker, 300) == b"\x01\x01" * 300, "and is played unchanged")
+check(speaker.first_played is not None,
+      "and stamps this turn's first audio when it reaches the device")
+
+# An empty buffer. Silence handed to the device is not the reply arriving, so the
+# count taken and the count skipped are equal at zero and nothing is stamped.
+speaker = fresh_speaker()
+speaker.turn_reset(1)
+check(pull(speaker, 100) == b"\x00" * 200,
+      "an empty buffer is padded with silence")
+check(speaker.first_played is None,
+      "and stamps nothing: no reply audio has reached the device yet")
+
+# Earlier bytes exactly equal to the block taken. The whole block belongs to a turn
+# already recorded, so it plays and stamps nothing.
+speaker = fresh_speaker()
+speaker.turn_reset(2)
+speaker.write(b"\x02\x02" * 300, 1)
+check(speaker.turn_bytes == 0,
+      "a chunk from an earlier turn is credited to nobody: %r" % speaker.turn_bytes)
+check(pull(speaker, 300) == b"\x02\x02" * 300,
+      "but is still played, because it is the tail of an answer being listened to")
+check(speaker.first_played is None,
+      "and must not stamp the later turn's first audio")
+
+# Earlier bytes larger than the block taken, drained across two blocks. The count
+# has to come down by what was taken and no more, or the turn's real first audio
+# is stamped by somebody else's tail.
+speaker = fresh_speaker()
+speaker.turn_reset(2)
+speaker.write(b"\x03\x03" * 300, 1)
+speaker.write(b"\x04\x04" * 300, 1)
+check(pull(speaker, 150) == b"\x03\x03" * 150, "the earlier tail plays in order")
+check(speaker.first_played is None, "and stamps nothing on the first block")
+check(pull(speaker, 150) == b"\x03\x03" * 150, "nor on the second")
+check(speaker.first_played is None, "still nothing stamped")
+check(pull(speaker, 300) == b"\x04\x04" * 300, "nor while the rest of it drains")
+check(speaker.first_played is None,
+      "1200 earlier bytes must take 1200 bytes to drain, not one block")
+speaker.write(b"\x05\x05" * 300, 2)
+check(pull(speaker, 300) == b"\x05\x05" * 300, "then this turn's own reply plays")
+check(speaker.first_played is not None, "and that is what stamps the clock")
+
+# Earlier bytes smaller than the block taken, so one block spans the boundary. The
+# first byte past the earlier tail is this turn's first audio, and it is inside a
+# block that started with somebody else's.
+speaker = fresh_speaker()
+speaker.turn_reset(2)
+speaker.write(b"\x06\x06" * 150, 1)
+speaker.write(b"\x07\x07" * 150, 2)
+check(pull(speaker, 300) == b"\x06\x06" * 150 + b"\x07\x07" * 150,
+      "a block spanning the boundary is played whole")
+check(speaker.first_played is not None,
+      "and the first byte past the earlier tail stamps this turn's first audio")
+check(speaker.turn_bytes == 300,
+      "with only this turn's half credited to it: %r" % speaker.turn_bytes)
+
+# A turn advancing while the previous answer is still queued, which is the case
+# turn_reset itself has to handle: everything already buffered belongs to the turn
+# that is being closed, however it got there.
+speaker = fresh_speaker()
+speaker.turn_reset(1)
+speaker.write(b"\x08\x08" * 300, 1)
+check(speaker.turn_bytes == 600, "turn one is credited its own reply")
+speaker.turn_reset(2)
+check(speaker.turn_bytes == 0 and speaker.first_played is None,
+      "turn two starts owed nothing and unstamped: %r %r"
+      % (speaker.turn_bytes, speaker.first_played))
+check(pull(speaker, 300) == b"\x08\x08" * 300,
+      "turn one's undrained tail still reaches the device")
+check(speaker.first_played is None,
+      "but it must not stamp turn two, which is what it would have done before "
+      "turn_reset counted what was already queued")
+speaker.write(b"\x09\x09" * 300, 2)
+check(pull(speaker, 300) == b"\x09\x09" * 300 and speaker.first_played is not None,
+      "and turn two's own reply is what stamps turn two")
+check(speaker.turn_bytes == 600, "credited to turn two: %r" % speaker.turn_bytes)
+
+# A short buffer of earlier bytes: padded with silence, and the padding is not
+# mistaken for this turn's reply either.
+speaker = fresh_speaker()
+speaker.turn_reset(2)
+speaker.write(b"\x0a\x0a" * 100, 1)
+check(pull(speaker, 300) == b"\x0a\x0a" * 100 + b"\x00" * 400,
+      "a short earlier tail is padded rather than repeated")
+check(speaker.first_played is None, "and the padding stamps nothing")
+
+del sys.modules["sounddevice"]
+
 
 
 # A startup that refuses part way through releases what it already started, and
@@ -2212,7 +2442,6 @@ check("the connection ended before run 2 of 3" in prompt_said.getvalue(),
 class Recorder:
     def __init__(self, closed):
         self._closed = closed
-        self.bytes = 0
         self.first_played = None
         self.device_latency = None
 
@@ -3558,6 +3787,13 @@ for alarming in ("stopped without being asked", "could not handle the relay's",
     check(alarming not in transcript,
           "a session where every turn was answered said %r: %r"
           % (alarming, transcript))
+# And no record named a reason, which is what now decides the exit code as well.
+# A fault that fires on a session where everything worked would fail every clean
+# run from here on, so the absence is worth pinning next to the exit code itself.
+for run in runs:
+    check(run["relay_error"] is None,
+          "turn %s recorded a reason on a session that worked: %r"
+          % (run["run"], run["relay_error"]))
 check("the relay signed off" in transcript,
       "but the end of the session should still be said, in wording that cannot be "
       "read as a fault: %r" % transcript)

--- a/tests/fm-voice-relay.test.sh
+++ b/tests/fm-voice-relay.test.sh
@@ -1616,8 +1616,9 @@ check(closing_runs[0]["answered"] and closing_runs[0]["relay_error"] is None,
 # measurement someone reads as complete.
 check(closing_code != 0,
       "a session that took 1 of 2 runs must not exit 0, got %r" % closing_code)
-check("connection closed" in spoken.getvalue(),
-      "and the captain should be told why it stopped: %r" % spoken.getvalue())
+check("the connection ended before run 2 of 2" in spoken.getvalue(),
+      "and the captain should be told why it stopped, in the words the path that "
+      "stopped it recorded: %r" % spoken.getvalue())
 
 # The case above is the connection going while the run loop is watching for it.
 # The loop cannot only be watching, though: the downlink names the failure and
@@ -1678,10 +1679,10 @@ check(gone.uplink.sent == [],
       "and nothing should be pushed into the dead pipe: %r" % gone.uplink.sent)
 check(gone_code != 0,
       "a session that took none of its 2 runs must not exit 0, got %r" % gone_code)
-check("connection closed" in gone_said.getvalue()
-      and "run 1 of 2" in gone_said.getvalue(),
+check("the connection was lost before run 1 of 2" in gone_said.getvalue(),
       "and the captain should be told why nothing was taken, naming the run it "
-      "stopped at: %r" % gone_said.getvalue())
+      "stopped at and the cause the read that failed recorded: %r"
+      % gone_said.getvalue())
 
 # The third moment is a connection that goes DURING a turn that answered anyway,
 # with runs still to take. The answer is real and its record stands, so nothing
@@ -1770,60 +1771,43 @@ check("run 2 of 3" in ending_said.getvalue(),
 # is the file docs/voice-relay.md computes its published latency spread from. An
 # infrastructure failure averaged into that number is the whole thing being kept
 # out of it.
-class SilentEndStream:
-    """Ends the stream at a frame boundary once the turn is under way."""
+class ScriptedStream:
+    """Serves prepared downlink bytes, held until the turn under test has opened.
 
-    def __init__(self, gate):
+    One class for every case below, because each of them differs only in the bytes
+    it serves: the gate, the slicing and the exhaustion behaviour are the same
+    everywhere, and an empty script is what an end of stream at a frame boundary
+    looks like. The label is per case so a fixture that never fires still names
+    which case it belonged to.
+    """
+
+    def __init__(self, gate, payload, label):
         self._gate = gate
-
-    def read(self, count):
-        check(self._gate.wait(10), "the turn never opened, so nothing ended")
-        return b""
-
-
-class GoodbyeStream:
-    """Says goodbye once the turn is under way, without answering it."""
-
-    def __init__(self, gate):
-        self._gate = gate
-        self._bytes = frame.encode(frame.BYE)
+        self._bytes = payload
+        self._label = label
         self._at = 0
 
     def read(self, count):
-        check(self._gate.wait(10), "the turn never opened, so nothing was said")
-        chunk = self._bytes[self._at:self._at + count]
-        self._at += len(chunk)
-        return chunk
-
-
-class NamedFaultStream:
-    """Names the fault the relay saw, then says goodbye, with the turn open."""
-
-    def __init__(self, gate, reason):
-        self._gate = gate
-        self._bytes = (
-            frame.encode_json(frame.NOTICE,
-                              {"event": "turn-failed", "error": reason})
-            + frame.encode(frame.BYE))
-        self._at = 0
-
-    def read(self, count):
-        check(self._gate.wait(10), "the turn never opened, so nothing was named")
+        check(self._gate.wait(10),
+              "the turn never opened, so %s was never served" % self._label)
         chunk = self._bytes[self._at:self._at + count]
         self._at += len(chunk)
         return chunk
 
 
 RELAY_REASON = "FrameError: unknown frame kind: b'\\xff'"
+REPLY_END = frame.encode_json(frame.MARK, {"mark": "reply_end",
+                                           "since_talk_end": 0.4,
+                                           "tool_calls": 0})
 
 
-def turn_lost(label, make_stream, out_name):
+def turn_lost(label, make_stream, out_name, runs="1"):
     """Take one turn against a downlink that ends during it, and return run and stderr."""
     gate = thread_lib.Event()
     lost = client.Client(client.parse_args(
         ["--host", "desk", "--in-file", os.path.join(TMP, "clip.pcm"),
-         "--out-file", os.path.join(TMP, out_name), "--timeout", "2",
-         "--audio-idle", "0.05"]))
+         "--out-file", os.path.join(TMP, out_name), "--runs", runs,
+         "--timeout", "2", "--audio-idle", "0.05"]))
     lost.reader = frame.Reader(make_stream(gate))
     lost.uplink = StartGate(gate)
     lost.playback = client.FilePlayback(os.path.join(TMP, out_name))
@@ -1852,31 +1836,41 @@ def turn_lost(label, make_stream, out_name):
           "%s: a turn lost to the connection must say so rather than reading in "
           "runs.jsonl exactly like a turn the model declined: %r"
           % (label, runs[0]))
-    # This is the only run asked for, so the run loop never reaches its "and the
-    # rest were not taken" line. A record on stdout and silence on stderr is a
-    # captain who spoke, heard nothing back, and was told nothing either; the
-    # module docstring puts everything human on stderr.
+    # With one run asked for, the run loop never reaches its "and the rest were
+    # not taken" line. A record on stdout and silence on stderr is a captain who
+    # spoke, heard nothing back, and was told nothing either; the module docstring
+    # puts everything human on stderr.
     check("client:" in said.getvalue(),
           "%s: the captain must be told the connection went, not only the file: "
           "%r" % (label, said.getvalue()))
     return runs[0], said.getvalue()
 
 
-eof_run, eof_said = turn_lost("end of stream", SilentEndStream, "reply-eof.pcm")
+eof_run, eof_said = turn_lost(
+    "end of stream",
+    lambda gate: ScriptedStream(gate, b"", "the end of stream"),
+    "reply-eof.pcm")
 check("ended" in eof_run["relay_error"],
       "an end of stream should say the connection ended: %r"
       % eof_run["relay_error"])
 check("the connection ended" in eof_said,
       "and should say so on stderr as well: %r" % eof_said)
 
-bye_run, bye_said = turn_lost("goodbye", GoodbyeStream, "reply-bye.pcm")
-check("goodbye" in bye_run["relay_error"],
-      "a goodbye mid-turn should say so, because it is the relay deciding to "
-      "stop rather than the connection dying: %r" % bye_run["relay_error"])
+# A goodbye nobody asked for. This end sent no quit, so the relay stopping is the
+# relay's own decision, and mid-turn it costs the captain their question.
+bye_run, bye_said = turn_lost(
+    "goodbye",
+    lambda gate: ScriptedStream(gate, frame.encode(frame.BYE), "the goodbye"),
+    "reply-bye.pcm")
+check("the relay stopped" in bye_run["relay_error"],
+      "a goodbye nobody asked for mid-turn should say the relay stopped, because "
+      "that is the relay deciding rather than the connection dying: %r"
+      % bye_run["relay_error"])
 # Distinct from the line above, because they are distinct faults: a stream that
 # stopped, versus a relay that chose to stop. One line for both would send the
 # captain looking for the wrong thing.
-check("the relay said goodbye" in bye_said and "the connection ended" not in bye_said,
+check("stopped without being asked" in bye_said
+      and "the connection ended" not in bye_said,
       "a goodbye should name itself on stderr rather than borrowing the wording "
       "of an ended stream: %r" % bye_said)
 
@@ -1884,11 +1878,37 @@ check("the relay said goodbye" in bye_said and "the connection ended" not in bye
 # This end can only infer that a goodbye arrived; the relay knows what happened,
 # so a reason it sent is never replaced by one inferred here.
 named_run, _ = turn_lost(
-    "named fault", lambda gate: NamedFaultStream(gate, RELAY_REASON),
+    "named fault",
+    lambda gate: ScriptedStream(
+        gate,
+        frame.encode_json(frame.NOTICE,
+                          {"event": "turn-failed", "error": RELAY_REASON})
+        + frame.encode(frame.BYE),
+        "the named fault"),
     "reply-named.pcm")
 check(named_run["relay_error"] == RELAY_REASON,
       "the relay's own reason must reach the record unchanged rather than being "
       "overwritten by the goodbye behind it: %r" % named_run["relay_error"])
+
+# With runs still to take, the loop also has to say why they were not taken, and
+# that line has to restate the cause that was recorded rather than asserting a
+# default. Told "the relay stopped" and then "the connection closed", the captain
+# has been given two causes for one event and has to guess which end to look at.
+for label, payload, expected in (
+        ("end of stream", b"", "the connection ended"),
+        ("goodbye", frame.encode(frame.BYE),
+         "the relay stopped without being asked to")):
+    _, stopped_said = turn_lost(
+        "%s, runs remaining" % label,
+        lambda gate, payload=payload, label=label: ScriptedStream(
+            gate, payload, "the %s" % label),
+        "reply-stop-%s.pcm" % label.replace(" ", "-"), runs="2")
+    check("%s before run 2 of 2" % expected in stopped_said,
+          "the run loop should restate the recorded cause for %s: %r"
+          % (label, stopped_said))
+    check("the connection closed" not in stopped_said,
+          "and must not fall back to the default wording for %s: %r"
+          % (label, stopped_said))
 
 # A fault on THIS end, handling a reply that did arrive. The try in the downlink
 # used to cover only the read, so the output file refusing the audio, or a payload
@@ -1903,23 +1923,8 @@ check(named_run["relay_error"] == RELAY_REASON,
 class FullDiskPlayback(client.FilePlayback):
     """Refuses reply audio the way a filesystem with nothing left does."""
 
-    def write(self, pcm):
+    def write(self, pcm, turn):
         raise OSError(28, "No space left on device")
-
-
-class OneReplyStream:
-    """Serves one audio frame once the turn is under way, and nothing after it."""
-
-    def __init__(self, gate):
-        self._gate = gate
-        self._bytes = frame.encode(frame.AUDIO, b"\x00\x00" * 600)
-        self._at = 0
-
-    def read(self, count):
-        check(self._gate.wait(10), "the turn never opened, so nothing was served")
-        chunk = self._bytes[self._at:self._at + count]
-        self._at += len(chunk)
-        return chunk
 
 
 handling_served = thread_lib.Event()
@@ -1927,7 +1932,9 @@ handling = client.Client(client.parse_args(
     ["--host", "desk", "--in-file", os.path.join(TMP, "clip.pcm"),
      "--out-file", os.path.join(TMP, "reply-handling.pcm"), "--runs", "2",
      "--timeout", "2", "--audio-idle", "0.05", "--gap-seconds", "0.05"]))
-handling.reader = frame.Reader(OneReplyStream(handling_served))
+handling.reader = frame.Reader(ScriptedStream(
+    handling_served, frame.encode(frame.AUDIO, b"\x00\x00" * 600),
+    "the one reply frame"))
 handling.uplink = StartGate(handling_served)
 handling.playback = FullDiskPlayback(os.path.join(TMP, "reply-handling.pcm"))
 handling.capture = client.FileCapture(os.path.join(TMP, "clip.pcm"))
@@ -1962,13 +1969,25 @@ check("No space left on device" in handling_runs[0]["relay_error"],
 check("connection" not in handling_runs[0]["relay_error"],
       "the connection was never lost here, so the record must not say it was: %r"
       % handling_runs[0]["relay_error"])
-check("connection" not in handling_said,
+handling_lines = [line for line in handling_said.splitlines()
+                  if line.startswith("client:")]
+check(not any("connection" in line for line in handling_lines),
       "and the captain must not be sent to a connection that is working: %r"
-      % handling_said)
+      % handling_lines)
 check("No space left on device" in handling_said
       and "run 2 of 2" in handling_said,
       "the run loop should name the real reason and the run it stopped at: %r"
       % handling_said)
+# The one line is what the captain and the record get. The traceback is what
+# whoever has to find the bug behind it gets, and before the guard existed a dying
+# thread printed one, so losing it would make a programming error in the frame
+# handling strictly harder to locate than it used to be.
+check("Traceback (most recent call last)" in handling_said,
+      "a fault this end raised should still leave its traceback on stderr: %r"
+      % handling_said)
+check("Traceback" not in (handling_runs[0]["relay_error"] or ""),
+      "but the record is machine read, so the one-line reason belongs there: %r"
+      % handling_runs[0]["relay_error"])
 check(handling_code != 0,
       "a session that took none of its runs must not exit 0, got %r"
       % handling_code)
@@ -1985,28 +2004,6 @@ check(handling_code != 0,
 # where the real window is, after the frame has arrived and before its handler
 # takes the lock, and it is released only once the NEXT turn has really opened,
 # which the uplink reports when that turn's talk start goes out.
-class StaleNoticeStream:
-    """Fails turn one, then answers turn two, both once their turn has opened."""
-
-    def __init__(self, gate):
-        self._gate = gate
-        self._bytes = (
-            frame.encode_json(frame.NOTICE,
-                              {"event": "turn-failed",
-                               "error": "the model dropped turn one"})
-            + frame.encode(frame.AUDIO, b"\x00\x00" * 1200)
-            + frame.encode_json(frame.MARK, {"mark": "reply_end",
-                                             "since_talk_end": 0.4,
-                                             "tool_calls": 0}))
-        self._at = 0
-
-    def read(self, count):
-        check(self._gate.wait(10), "the turn never opened, so nothing was served")
-        chunk = self._bytes[self._at:self._at + count]
-        self._at += len(chunk)
-        return chunk
-
-
 class TurnCountingGate:
     """Reports the first turn opening, and the second one separately."""
 
@@ -2026,7 +2023,12 @@ stale = client.Client(client.parse_args(
     ["--host", "desk", "--in-file", os.path.join(TMP, "clip.pcm"),
      "--out-file", os.path.join(TMP, "reply-stale.pcm"), "--runs", "2",
      "--timeout", "2", "--audio-idle", "0.05", "--gap-seconds", "0.05"]))
-stale.reader = frame.Reader(StaleNoticeStream(stale_open))
+stale.reader = frame.Reader(ScriptedStream(
+    stale_open,
+    frame.encode_json(frame.NOTICE, {"event": "turn-failed",
+                                     "error": "the model dropped turn one"})
+    + frame.encode(frame.AUDIO, b"\x00\x00" * 1200) + REPLY_END,
+    "turn one's failure and turn two's answer"))
 stale.uplink = TurnCountingGate(stale_open, stale_next)
 stale.playback = client.FilePlayback(os.path.join(TMP, "reply-stale.pcm"))
 stale.capture = client.FileCapture(os.path.join(TMP, "clip.pcm"))
@@ -2075,6 +2077,131 @@ check(stale_runs[1]["answered"] and stale_runs[1]["reply_audio_seconds"] > 0,
 check(stale_code != 0,
       "one turn of two was still lost, so the exit code must say so, got %r"
       % stale_code)
+
+# The same window, with AUDIO in it instead of a notice, which is the worse half.
+# The frame's timing marks are taken under the turn lock, but the audio itself goes
+# to the playback, and the playback is where first_played is stamped, where the
+# reply's duration is counted, and where answered comes from. Credited to whatever
+# turn is open, one stale chunk gives a turn that was never answered a headline
+# latency figure measured from somebody else's reply, reports it answered, and with
+# that the whole session exits 0 having lost a turn.
+#
+# Parked at the playback rather than at say(), because that IS the accounting
+# point: the write is released only once the next turn has really opened, which the
+# uplink reports when that turn's talk start goes out. No sleeps.
+class LatePlayback(client.FilePlayback):
+    """Holds the first chunk until the turn after the one it belongs to has opened."""
+
+    def __init__(self, path, opened):
+        client.FilePlayback.__init__(self, path)
+        self._opened = opened
+        self._held = False
+
+    def write(self, pcm, turn):
+        if not self._held:
+            self._held = True
+            check(self._opened.wait(10),
+                  "fixture: the next turn never opened, so nothing went stale")
+        client.FilePlayback.write(self, pcm, turn)
+
+
+late_open, late_next = thread_lib.Event(), thread_lib.Event()
+late_out_file = os.path.join(TMP, "reply-late.pcm")
+late = client.Client(client.parse_args(
+    ["--host", "desk", "--in-file", os.path.join(TMP, "clip.pcm"),
+     "--out-file", late_out_file, "--runs", "2",
+     "--timeout", "2", "--audio-idle", "0.05", "--gap-seconds", "0.05"]))
+late.reader = frame.Reader(ScriptedStream(
+    late_open, frame.encode(frame.AUDIO, b"\x00\x00" * 1200),
+    "turn one's audio"))
+late.uplink = TurnCountingGate(late_open, late_next)
+late.playback = LatePlayback(late_out_file, late_next)
+late.capture = client.FileCapture(os.path.join(TMP, "clip.pcm"))
+late.capture.start(late.up_q, late.talking)
+thread_lib.Thread(target=late._sender, daemon=True).start()
+thread_lib.Thread(target=late._downlink, daemon=True).start()
+late_out, late_said = io.StringIO(), io.StringIO()
+with contextlib.redirect_stdout(late_out), contextlib.redirect_stderr(late_said):
+    late_code = late.run()
+late.up_q.put(None)
+late.playback.close()
+
+late_runs = [json_lib.loads(line) for line in late_out.getvalue().splitlines()
+             if line.strip()]
+check(len(late_runs) == 2,
+      "both turns were taken, so both belong in the file: %d, %r"
+      % (len(late_runs), late_runs))
+# THE POINT. Turn two was served nothing at all, and the stale chunk must not make
+# it look otherwise on any of the four figures the playback feeds.
+second = late_runs[1]
+check(not second["answered"],
+      "a turn served no audio of its own must not be reported answered because "
+      "an earlier turn's chunk arrived during it: %r" % second)
+check(second["reply_audio_seconds"] == 0,
+      "and none of that chunk's duration belongs to it: %r" % second)
+check(second["first_played_s"] is None,
+      "and it must not be stamped with when that chunk reached the output: %r"
+      % second)
+check(second["first_audio_s"] is None,
+      "and the headline figure, which prefers the playback stamp, must be absent "
+      "too rather than measured from another turn's reply: %r" % second)
+check(second["first_frame_s"] is None,
+      "and the frame stamp stays absent, as the turn identity already ensured: %r"
+      % second)
+check(late_code != 0,
+      "a session that lost a turn must not exit 0, got %r" % late_code)
+# And the audio was still written. Attributing it to nobody must not mean dropping
+# it: it is the tail of an answer the captain is still listening to.
+check(os.path.getsize(late_out_file) == 2400,
+      "the late chunk must still reach the output, not be discarded to make the "
+      "figures tidy: %d bytes" % os.path.getsize(late_out_file))
+check(late.playback.bytes == 2400,
+      "and the playback should still count it among everything it wrote: %r"
+      % late.playback.bytes)
+
+# The wait between turns is the last thing a lost session should do. It exists
+# only to avoid talking over the model's own speech, and a relay that is already
+# gone is not speaking, so waiting it out leaves the captain sitting through the
+# previous reply's whole spoken duration before anyone tells them the session
+# stopped. The gap here is deliberately long and the reply deliberately short, so
+# the elapsed time distinguishes stopping from waiting; nothing in the case sleeps
+# on purpose, the code under test is the sleep.
+prompt_served = thread_lib.Event()
+prompt = client.Client(client.parse_args(
+    ["--host", "desk", "--in-file", os.path.join(TMP, "clip.pcm"),
+     "--out-file", os.path.join(TMP, "reply-prompt.pcm"), "--runs", "3",
+     "--timeout", "2", "--audio-idle", "0.05", "--gap-seconds", "5"]))
+prompt.reader = frame.Reader(ScriptedStream(
+    prompt_served,
+    frame.encode(frame.AUDIO, b"\x00\x00" * 1200) + REPLY_END,
+    "one whole answer and then the end of stream"))
+prompt.uplink = StartGate(prompt_served)
+prompt.playback = client.FilePlayback(os.path.join(TMP, "reply-prompt.pcm"))
+prompt.capture = client.FileCapture(os.path.join(TMP, "clip.pcm"))
+prompt.capture.start(prompt.up_q, prompt.talking)
+thread_lib.Thread(target=prompt._sender, daemon=True).start()
+thread_lib.Thread(target=prompt._downlink, daemon=True).start()
+prompt_out, prompt_said = io.StringIO(), io.StringIO()
+prompt_began = clock.monotonic()
+with contextlib.redirect_stdout(prompt_out), contextlib.redirect_stderr(prompt_said):
+    prompt_code = prompt.run()
+prompt_took = clock.monotonic() - prompt_began
+prompt.up_q.put(None)
+prompt.playback.close()
+
+prompt_runs = [json_lib.loads(line) for line in prompt_out.getvalue().splitlines()
+               if line.strip()]
+check(len(prompt_runs) == 1 and prompt_runs[0]["answered"],
+      "fixture is wrong: one answered turn should be taken and no more: %r"
+      % prompt_runs)
+check(prompt_code != 0,
+      "a session that took 1 of 3 runs must not exit 0, got %r" % prompt_code)
+check(prompt_took < 3,
+      "a session that already knows the connection is gone must stop rather than "
+      "wait out the 5s gap first: took %.2fs" % prompt_took)
+check("the connection ended before run 2 of 3" in prompt_said.getvalue(),
+      "and it should name the cause and the first run it lost: %r"
+      % prompt_said.getvalue())
 
 
 
@@ -3418,6 +3545,22 @@ sent = sum(s["reply_audio_bytes"] for s in sessions)
 got = os.path.getsize(os.path.join(root, "reply.pcm"))
 check(sent > 0 and sent == got,
       "the model sent %d bytes of reply audio and the client wrote %d" % (sent, got))
+
+# AND NOTHING ALARMING WAS SAID, which is the other half of every fault line this
+# build added. The relay's goodbye arrives on this path too, at the end of every
+# ordinary session, so a line that reads as a fault would fire here on a session
+# where all of it worked. An alarm that also goes off on success is worse than no
+# alarm: the captain learns to skip it, and then the one that means their question
+# was lost is invisible as well. The session end still speaks, in its own words.
+for alarming in ("stopped without being asked", "could not handle the relay's",
+                 "connection lost", "the connection ended",
+                 "were not taken", "no reply within"):
+    check(alarming not in transcript,
+          "a session where every turn was answered said %r: %r"
+          % (alarming, transcript))
+check("the relay signed off" in transcript,
+      "but the end of the session should still be said, in wording that cannot be "
+      "read as a fault: %r" % transcript)
 PY
 pass "a spoken turn goes out and comes back: the records answer, firstmate gets the work"
 


### PR DESCRIPTION
## Intent

Correct three defects that reached the default branch with the spoken interface in pull request 2767. Remove a private, gitignored fleet record citation from the bin/fm-voice-relay.py docstring and reword the two comments that referred to an unpublished survey as though a reader could open it, weakening the claim rather than publishing anything to make it resolve. Land the transport failure fix that was pushed fifteen minutes after 2767 merged and so never reached the default branch, so a closed connection can no longer be recorded as a run with answered false and relay_error null, which would let an infrastructure failure be averaged into a latency figure. Keep .greptile/rules.md and narrow it with one sentence saying it is the first mate working interpretation, that whether VISION.md should be reconciled remains an open question belonging to the captain, and that the conditions listed below are what the interpretation depends on.

## What Changed

- `bin/fm-voice-client.py` no longer turns a dead connection into a normal-looking turn record: `take_turn` checks the closure mark inside the same critical section the downlink sets it in and returns `None` instead of opening a turn, every close path (`the connection was lost`, `the connection ended`, `the relay stopped`, `session-ended`, and a new guard around this end's own frame handling) names its cause in `relay_error`, reply audio is credited per turn via `turn_bytes` and a turn id carried with each frame rather than a shared byte total, audio arriving after the output is released is discarded and counted rather than raising, and `run()` exits non-zero when a record carries a `relay_error` or when the session stops before taking the requested runs. `bin/fm-voice-relay.py` now sends a `turn-failed` notice with the uplink fault down the connection before its goodbye, so the reason reaches the run record instead of only stderr.
- Provenance cleanup: the relay docstring's citation of a private, gitignored survey report is gone and the two chunk-size comments in the relay and client now say the timings came from earlier prototype work rather than pointing at an unpublished document. `docs/voice-relay.md` narrows the unverified claim to the audio devices themselves, documents what `relay_error` reports and how a cut-short reply differs from an unanswered turn, and states the exit-code rule.
- `.greptile/rules.md` gains one sentence marking the captain-facing-surface section as the first mate's working interpretation, leaving whether `VISION.md` should be reconciled as an open question for the captain and pointing at the listed conditions the interpretation rests on. `tests/fm-voice-relay.test.sh` adds around 1,500 lines of coverage for these paths, including new sections for a model session ending while the captain is still talking and an uplink that stops being a frame stream.

## Risk Assessment

✅ Low: Every intent criterion is source-verifiable and met, the newest commit is a two-line behavioral change pinned in both directions by new deterministic tests, and nothing above info severity survived verification - the three residual items are narrow races and a test dedup, all safe as follow-ups.

## Testing

Ran the feature's own suite (`tests/fm-voice-relay.test.sh`, all cases pass) and then, because a passing suite does not show the captain's results file, drove the real client CLI in a before/after harness: the same stub relay and the same real relay against the default-branch client and the fixed one. That reproduces the forbidden shape on base — a closed connection recorded as `answered: false` with `relay_error: null`, and a relay killed mid-answer exiting 0 with a real `first_audio_s` — and shows each path named and exiting non-zero after the fix, with the healthy two-run control unchanged at exit 0. The real relay run adds the other half: a model session ending mid key press now carries `relay_error: 'the relay ended the session before this turn was answered'`, and a desynchronised uplink sends a `turn-failed` notice ahead of its goodbye instead of stranding the reason on stderr. The citation removal, the two reworded comments and the narrowed `.greptile/rules.md` were verified by hand and captured as transcripts. No screenshot or rendered-UI artifact applies: the surfaces this change touches are a terminal CLI (captured as transcripts plus the raw runs.jsonl records), source comments, and markdown docs, with no rendered UI anywhere in the change. Transient `bin/__pycache__` from the runs was removed; the worktree is clean.

<details>
<summary>Evidence: Evidence index tying every artifact to the intent it demonstrates</summary>

```text
# Test evidence: voice relay build v4 corrections

Branch `fm/voice-relay-build-v4-corrections`, base `dc0172c`, target `dfe12ac`.

Everything below is the captain's own surface: `bin/fm-voice-client.py` run from a
shell with `--runs N > runs.jsonl`, which is exactly how `docs/voice-relay.md`
tells them to take a measurement. Each comparison runs the **same** stub or real
relay twice - once against the client as it stands on the default branch (`base`)
and once against the fix under test (`head`) - so the difference in the transcript
is the fix and nothing else.

| file | what it shows |
| --- | --- |
| `before-after-transport-failure.txt` | four scenarios through the real client CLI and the real wire format against a stub relay: a relay that dies before any reply, one that dies partway through the answer, one that dies between two runs, and a healthy control |
| `before-after-real-relay.txt` | the same defect through the **real** `bin/fm-voice-relay.py` and its real records reader, with only the paid Bedrock model stood in for: the model session ends mid key press, run 1 has no answer, run 2 does |
| `before-after-relay-names-the-fault.txt` | the frames the real relay puts on the wire when the uplink desynchronises: base tells the laptop only goodbye, head names the fault first |
| `citation-and-wording.txt` | the gitignored fleet-record citation is gone from `bin/fm-voice-relay.py`, no tracked file cites it, and what a reader now sees in its place |
| `greptile-rule-narrowed.txt` | `.greptile/rules.md` is kept and narrowed by one sentence |
| `voice-relay-suite.log` | `bash tests/fm-voice-relay.test.sh`, the suite that owns this feature |
| `harness/` | the scripts that produced the transcripts, and the base/head copies of the client they ran |
| `out/` | the raw `runs.jsonl`, stderr and reply audio from every run above |

## The defect, in the captain's own results file

The forbidden shape is a closed connection recorded as a run with `answered`
false and `relay_error` null, because in `runs.jsonl` that reads exactly like a
turn the model declined, and `runs.jsonl` is where the published latency spread
comes from.

    base   run 1: answered=False relay_error=None                                              exit 1
    head   run 1: answered=False relay_error='the connection ended before this turn was answered'   exit 1

And the shape that let an infrastructure failure be averaged into a latency
figure - a relay killed while speaking, at the default of one run:

    base   run 1: answered=True relay_error=None      first_audio_s=0.0   exit 0
    head   run 1: answered=True relay_error='the connection ended before the reply finished'  exit 1

And a session that took one of the two runs asked for:

    base   1 record, nothing said, exit 0
    head   1 record, "the connection ended before run 2 of 2; it and the rest were not taken", exit 1

The healthy control is unchanged: two whole answers, no `relay_error`, exit 0.

## Reproducing

    bash harness/run_scenarios.sh                 # stub relay, four scenarios
    bash harness/run_real_relay.sh <repo root>    # the real relay
    bash tests/fm-voice-relay.test.sh             # from the repo
```
</details>
<details>
<summary>Evidence: Before/after through the real client CLI: four transport-failure scenarios and a healthy control</summary>

<code>===== A-relay-dies-before-any-reply | client=base =====&#10;run 1: answered=False relay_error=None first_audio_s=None reply_audio_seconds=0.0&#10;--- exit code: 1 ---&#10;&#10;===== A-relay-dies-before-any-reply | client=head =====&#10;client: the connection ended&#10;run 1: answered=False relay_error=&#39;the connection ended before this turn was answered&#39; first_audio_s=None reply_audio_seconds=0.0&#10;--- exit code: 1 ---&#10;&#10;===== B-relay-dies-partway-through-the-answer | client=base =====&#10;run 1: answered=True relay_error=None first_audio_s=0.0 reply_audio_seconds=0.125&#10;--- exit code: 0 ---&#10;&#10;===== B-relay-dies-partway-through-the-answer | client=head =====&#10;run 1: answered=True relay_error=&#39;the connection ended before the reply finished&#39; first_audio_s=0.0 reply_audio_seconds=0.125&#10;--- exit code: 1 ---&#10;&#10;===== C-relay-dies-between-two-runs | client=base =====&#10;run 1: answered=True relay_error=None ...&#10;--- exit code: 0 ---&#10;&#10;===== C-relay-dies-between-two-runs | client=head =====&#10;client: the connection ended before run 2 of 2; it and the rest were not taken&#10;run 1: answered=True relay_error=None ...&#10;--- exit code: 1 ---&#10;&#10;===== D-control-two-good-runs | client=base / head =====&#10;run 1 and run 2 answered, relay_error=None, exit code: 0 (both)</code>

```text
stub relay stands in for the desktop; the client, the wire format and the
record shape are the real ones. No AWS account, microphone or speaker.

===== A-relay-dies-before-any-reply | client=base | stub=drop-before-reply | --runs 1 =====
--- what the captain sees on the terminal (stderr) ---
    client: relay ready, stub-relay in us-east-1, read scope counts, connected in 0.01s
    stub-relay: dying before the reply
--- runs.jsonl, the file the latency spread is computed from ---
    run 1: answered=False relay_error=None first_audio_s=None reply_audio_seconds=0.0
--- exit code: 1 ---

===== A-relay-dies-before-any-reply | client=head | stub=drop-before-reply | --runs 1 =====
--- what the captain sees on the terminal (stderr) ---
    client: relay ready, stub-relay in us-east-1, read scope counts, connected in 0.01s
    stub-relay: dying before the reply
    client: the connection ended
--- runs.jsonl, the file the latency spread is computed from ---
    run 1: answered=False relay_error='the connection ended before this turn was answered' first_audio_s=None reply_audio_seconds=0.0
--- exit code: 1 ---

===== B-relay-dies-partway-through-the-answer | client=base | stub=cut-mid-reply | --runs 1 =====
--- what the captain sees on the terminal (stderr) ---
    client: relay ready, stub-relay in us-east-1, read scope counts, connected in 0.01s
    stub-relay: dying partway through the reply
--- runs.jsonl, the file the latency spread is computed from ---
    run 1: answered=True relay_error=None first_audio_s=0.0 reply_audio_seconds=0.125
--- exit code: 0 ---

===== B-relay-dies-partway-through-the-answer | client=head | stub=cut-mid-reply | --runs 1 =====
--- what the captain sees on the terminal (stderr) ---
    client: relay ready, stub-relay in us-east-1, read scope counts, connected in 0.01s
    stub-relay: dying partway through the reply
    client: the connection ended
--- runs.jsonl, the file the latency spread is computed from ---
    run 1: answered=True relay_error='the connection ended before the reply finished' first_audio_s=0.0 reply_audio_seconds=0.125
--- exit code: 1 ---

===== C-relay-dies-between-two-runs | client=base | stub=die-between-turns | --runs 2 =====
--- what the captain sees on the terminal (stderr) ---
    client: relay ready, stub-relay in us-east-1, read scope counts, connected in 0.01s
    stub-relay: dying after the first answer
--- runs.jsonl, the file the latency spread is computed from ---
    run 1: answered=True relay_error=None first_audio_s=0.0 reply_audio_seconds=0.125
--- exit code: 0 ---

===== C-relay-dies-between-two-runs | client=head | stub=die-between-turns | --runs 2 =====
--- what the captain sees on the terminal (stderr) ---
    client: relay ready, stub-relay in us-east-1, read scope counts, connected in 0.01s
    stub-relay: dying after the first answer
    client: the connection ended
    client: the connection ended before run 2 of 2; it and the rest were not taken
--- runs.jsonl, the file the latency spread is computed from ---
    run 1: answered=True relay_error=None first_audio_s=0.0 reply_audio_seconds=0.125
--- exit code: 1 ---

===== D-control-two-good-runs | client=base | stub=healthy | --runs 2 =====
--- what the captain sees on the terminal (stderr) ---
    client: relay ready, stub-relay in us-east-1, read scope counts, connected in 0.01s
--- runs.jsonl, the file the latency spread is computed from ---
    run 1: answered=True relay_error=None first_audio_s=0.0 reply_audio_seconds=0.125
    run 2: answered=True relay_error=None first_audio_s=0.0 reply_audio_seconds=0.125
--- exit code: 0 ---

===== D-control-two-good-runs | client=head | stub=healthy | --runs 2 =====
--- what the captain sees on the terminal (stderr) ---
    client: relay ready, stub-relay in us-east-1, read scope counts, connected in 0.01s
    client: the relay signed off
--- runs.jsonl, the file the latency spread is computed from ---
    run 1: answered=True relay_error=None first_audio_s=0.0 reply_audio_seconds=0.125
    run 2: answered=True relay_error=None first_audio_s=0.0 reply_audio_seconds=0.125
--- exit code: 0 ---
```
</details>
<details>
<summary>Evidence: Before/after through the REAL bin/fm-voice-relay.py: a model session ending mid key press</summary>

<code>===== E-model-session-ends-mid-key-press | client=base | real bin/fm-voice-relay.py =====&#10;client: the relay ended the session&#10;assistant: Right now, 2 in flight, 1 waiting on you, 1 open pull requests. The ones moving are alpha-one and beta-two.&#10;run 1: answered=False relay_error=None first_audio_s=None reply_audio_seconds=0.0&#10;run 2: answered=True relay_error=None first_audio_s=0.409 reply_audio_seconds=0.4&#10;--- exit code: 1 ---&#10;&#10;===== E-model-session-ends-mid-key-press | client=head | real bin/fm-voice-relay.py =====&#10;client: the relay ended the session&#10;assistant: Right now, 2 in flight, 1 waiting on you, 1 open pull requests. The ones moving are alpha-one and beta-two.&#10;run 1: answered=False relay_error=&#39;the relay ended the session before this turn was answered&#39; first_audio_s=None reply_audio_seconds=0.0&#10;run 2: answered=True relay_error=None first_audio_s=0.409 reply_audio_seconds=0.4&#10;--- exit code: 1 ---</code>

```text
The relay, the records reader, the client and the wire format are real.
Only the paid Bedrock model is stood in for.

===== E-model-session-ends-mid-key-press | client=base | real bin/fm-voice-relay.py =====
--- what the captain sees on the terminal (stderr) ---
    client: relay ready, amazon.nova-2-sonic-v1:0 in eu-north-1, read scope full, connected in 0.0s
    client: the relay ended the session
      you: how is the fleet doing right now
      assistant: Right now, 2 in flight, 1 waiting on you, 1 open pull requests. The ones moving are alpha-one and beta-two.
--- runs.jsonl, the file the latency spread is computed from ---
    run 1: answered=False relay_error=None first_audio_s=None reply_audio_seconds=0.0
    run 2: answered=True relay_error=None first_audio_s=0.409 reply_audio_seconds=0.4
--- exit code: 1 ---

===== E-model-session-ends-mid-key-press | client=head | real bin/fm-voice-relay.py =====
--- what the captain sees on the terminal (stderr) ---
    client: relay ready, amazon.nova-2-sonic-v1:0 in eu-north-1, read scope full, connected in 0.0s
    client: the relay ended the session
      you: how is the fleet doing right now
      assistant: Right now, 2 in flight, 1 waiting on you, 1 open pull requests. The ones moving are alpha-one and beta-two.
    client: the relay signed off
--- runs.jsonl, the file the latency spread is computed from ---
    run 1: answered=False relay_error='the relay ended the session before this turn was answered' first_audio_s=None reply_audio_seconds=0.0
    run 2: answered=True relay_error=None first_audio_s=0.409 reply_audio_seconds=0.4
--- exit code: 1 ---
```
</details>
<details>
<summary>Evidence: The frames the real relay puts on the wire when the uplink desynchronises</summary>

<code>===== the uplink desynchronises mid-turn | relay=base (default branch) =====&#10;--- frames the relay sent down to the laptop, in order ---&#10;BYE&#10;--- the relay&#39;s own stderr, which no runs.jsonl quotes ---&#10;fm-voice-relay: the uplink is not a frame stream any more: unknown frame kind: b&#39;\xff&#39;&#10;--- exit code: 2 ---&#10;&#10;===== the uplink desynchronises mid-turn | relay=head (fix under test) =====&#10;--- frames the relay sent down to the laptop, in order ---&#10;NOTICE {&#39;event&#39;: &#39;turn-failed&#39;, &#39;error&#39;: &#34;FrameError: unknown frame kind: b&#39;\\xff&#39;&#34;}&#10;BYE&#10;--- the relay&#39;s own stderr, which no runs.jsonl quotes ---&#10;fm-voice-relay: the uplink is not a frame stream any more: unknown frame kind: b&#39;\xff&#39;&#10;--- exit code: 2 ---</code>

```text

===== the uplink desynchronises mid-turn | relay=base (default branch) =====
--- frames the relay sent down to the laptop, in order ---
    BYE   
--- the relay's own stderr, which no runs.jsonl quotes ---
    fm-voice-relay: the uplink is not a frame stream any more: unknown frame kind: b'\xff'
--- exit code: 2 ---

===== the uplink desynchronises mid-turn | relay=head (fix under test) =====
--- frames the relay sent down to the laptop, in order ---
    NOTICE {'event': 'turn-failed', 'error': "FrameError: unknown frame kind: b'\\xff'"}
    BYE   
--- the relay's own stderr, which no runs.jsonl quotes ---
    fm-voice-relay: the uplink is not a frame stream any more: unknown frame kind: b'\xff'
--- exit code: 2 ---
```
</details>
<details>
<summary>Evidence: The gitignored fleet-record citation is gone, and what a reader now sees in its place</summary>

<code>$ git check-ignore -v data/speech-to-speech-survey-s2/report.md&#10;.gitignore:3:data/ data/speech-to-speech-survey-s2/report.md&#10;$ git grep -n &#39;speech-to-speech-survey&#39; -- . | wc -l&#10;0&#10;$ git grep -n &#39;the survey&#39; -- . | wc -l&#10;0&#10;&#10;The two traps this code already avoids, both found the expensive way and both&#10;measured rather than assumed:&#10;&#10;# 3200 bytes is 100 ms at 16 kHz 16-bit mono, the chunk size earlier prototype&#10;# work measured its timings with. Keeping it identical keeps those comparable.</code>

```text
### 1. The private, gitignored path is unreachable to a reader of this repo

$ git check-ignore -v data/speech-to-speech-survey-s2/report.md
.gitignore:3:data/	data/speech-to-speech-survey-s2/report.md
$ ls data   # not present in a fresh clone either
ls: cannot access 'data': No such file or directory

### 2. No tracked file cites that record any more
$ git grep -n 'speech-to-speech-survey' -- . | wc -l
0
$ git grep -n 'the survey' -- . | wc -l
0

### 3. What a reader of bin/fm-voice-relay.py now sees where the citation was

  --self-test FILE   feed one raw 16 kHz PCM file into a session as if it had
                     arrived from the client, print the timings as JSON, exit.
                     This is the control measurement for the relay path, and it
                     needs no client, no SSH and no microphone.

The two traps this code already avoids, both found the expensive way and both
measured rather than assumed:

  1. completionEnd does not arrive on its own. The model holds the session open
     waiting for more speech. The real "the reply is finished" signal is a
     contentEnd carrying stopReason END_TURN.
  2. Audio with no trailing silence is truncated and never answered, even when
     contentEnd follows immediately. A push-to-talk release supplies no trailing

    "voice": ("voice-id", "FM_VOICE_ID", "output voice"),
}

IN_RATE = 16000
OUT_RATE = 24000
# 3200 bytes is 100 ms at 16 kHz 16-bit mono, the chunk size earlier prototype
# work measured its timings with. Keeping it identical keeps those comparable.
CHUNK = 3200

### 4. And the client's copy of the same claim


IN_RATE = 16000
OUT_RATE = 24000
# 100 ms at each rate. The uplink chunk matches what the relay and the earlier
# prototype work measured with; changing it changes the numbers.
CHUNK = 3200
```
</details>
<details>
<summary>Evidence: .greptile/rules.md kept and narrowed by one sentence</summary>

<code>.greptile/rules.md | 2 ++&#10;1 file changed, 2 insertions(+)&#10;&#10;+This is the first mate&#39;s working interpretation rather than settled repository policy; whether `VISION.md` itself should be reconciled remains an open question belonging to the captain; and the conditions listed below are what this interpretation depends on.&#10;&#10;$ git ls-files .greptile # still tracked, not removed&#10;.greptile/rules.md</code>

```text
### .greptile/rules.md is kept, and narrowed by one sentence

$ git diff --stat dc0172c..dfe12ac -- .greptile/rules.md
 .greptile/rules.md | 2 ++
 1 file changed, 2 insertions(+)

$ git diff dc0172c..dfe12ac -- .greptile/rules.md
diff --git a/.greptile/rules.md b/.greptile/rules.md
index 79908ed..42b5c4f 100644
--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -7,6 +7,8 @@ dropped stops being a decision and becomes a blind spot.
 
 ## A captain-facing surface is not automatically a `VISION.md` violation
 
+This is the first mate's working interpretation rather than settled repository policy; whether `VISION.md` itself should be reconciled remains an open question belonging to the captain; and the conditions listed below are what this interpretation depends on.
+
 `VISION.md` says "The captain talks to the first mate and to nobody else; every
 worker reports through the first mate and never addresses the captain directly."
 That line protects who is answerable for work. Read alongside the sentence it

$ git ls-files .greptile   # still tracked, not removed
.greptile/rules.md
```
</details>
<details>
<summary>Evidence: tests/fm-voice-relay.test.sh full output (all cases pass)</summary>

```text
ok - wire format round trips and rejects a desynchronised stream
ok - the relay refuses a desynchronised uplink header instead of waiting for its payload
ok - the relay reads whose account to use from this home and refuses to guess
ok - an unconfigured home can still read how to configure the relay
ok - the model-backed subcommands refuse by name while note keeps working
ok - fm-inbox.sh --help prints its whole header, privacy paragraph included
ok - the relay and the reader agree on the tool names and the handover argument
ok - credentials are resolved once per relay, refreshed before expiry, off the event loop
ok - a turn the model refuses is announced and costs one turn, not the relay
ok - audio that arrives with no turn open is dropped, not turned into a turn
ok - a failure inside the model reader costs one turn, not every later one
ok - a reader failure is named to the captain, a clean end and a close are not
usage: fm-voice-client.py [-h] [--host HOST] [--local] [--relay RELAY]
                          [--relay-python RELAY_PYTHON]
                          [--relay-arg RELAY_ARG]
                          [--listen {push-to-talk,open-mic}] [--runs RUNS]
                          [--talk-seconds TALK_SECONDS] [--in-file IN_FILE]
                          [--out-file OUT_FILE] [--input-device INPUT_DEVICE]
                          [--output-device OUTPUT_DEVICE] [--timeout TIMEOUT]
                          [--wait-for-reply | --no-wait-for-reply]
                          [--gap-seconds GAP_SECONDS]
                          [--audio-idle AUDIO_IDLE] [--verbose]
fm-voice-client.py: error: say where the relay is: --relay <path to fm-voice-relay.py on the desktop>, or set FM_VOICE_RELAY
usage: fm-voice-client.py [-h] [--host HOST] [--local] [--relay RELAY]
                          [--relay-python RELAY_PYTHON]
                          [--relay-arg RELAY_ARG]
                          [--listen {push-to-talk,open-mic}] [--runs RUNS]
                          [--talk-seconds TALK_SECONDS] [--in-file IN_FILE]
                          [--out-file OUT_FILE] [--input-device INPUT_DEVICE]
                          [--output-device OUTPUT_DEVICE] [--timeout TIMEOUT]
                          [--wait-for-reply | --no-wait-for-reply]
                          [--gap-seconds GAP_SECONDS]
                          [--audio-idle AUDIO_IDLE] [--verbose]
fm-voice-client.py: error: --listen open-mic is not built yet: it needs end-of-speech detection to know when a turn ended, which lands with session continuity across turns, so it would stream forever and never end a turn. Use the default --listen push-to-talk.
client: connection lost: stream ended after 2 of the 5 bytes of a frame header
client: connection lost: [Errno 104] Connection reset by peer
client: discarded 15 bytes your login shell printed before the relay started: b'You have mail.\n'
ok - the laptop client builds the right remote command and survives a chatty login shell
ok - the client runs from a laptop holding only the two files the guide names
ok - --listen open-mic refuses at startup, before it opens anything
ok - the narrow scope answers how much is waiting without saying what it is
ok - the wide scope names open work and reports state without quoting event lines
ok - an absent read-scope setting means the narrowest answer, not the widest
ok - a home widens its own read scope by writing the setting
ok - finished work and note bodies never reach a spoken answer at any scope
ok - excluding a note body does not distort the counts
ok - a denied item becomes a withheld count without hiding that work exists
ok - the deny list matches regardless of case
ok - an item denied in more than one list is counted as withheld once
ok - one deny decision per item covers every list that item could appear in
ok - the state verb is a closed vocabulary, so free text cannot ride out on it
ok - the backlog and the state directory always come from the same home
ok - a finished task's pull request is neither counted nor named
ok - a deny substring on an open title removes its pull request and says so
ok - an unknown read scope refuses instead of widening
ok - the configured read scope is honoured
ok - handover queues the request for firstmate and wakes it exactly once
ok - the reader and the queue resolve the state directory the same way
ok - an empty request is refused rather than queued as a blank note
ok - a home with no records answers nothing rather than failing
ok - a spoken turn goes out and comes back: the records answer, firstmate gets the work
ok - a model session that ends mid-conversation costs one turn, not the relay
ok - a desynchronised uplink is named to the client before the goodbye, not only to stderr
ok - the desktop's own check answers from the records and times it from the talk end
ok - a reply that arrives before the end of the clip is named as an unusable clock
all voice relay cases passed
```
</details>
- Evidence: Raw runs.jsonl, stderr and reply audio from every base/head run above (local file: <code>/tmp/no-mistakes-evidence/01M0KNX9WMG97PK718REV0BN01/out</code>)
- Evidence: The harness that produced the transcripts, with the base and head client copies it ran (local file: <code>/tmp/no-mistakes-evidence/01M0KNX9WMG97PK718REV0BN01/harness</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"1b2ce4950d2b79eb90943753a8e500d0e23e941c","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

_... (6 earlier update rounds omitted to keep the PR body within GitHub's 65536-char limit; full history is in the run log.)_

<details>
<summary>⚠️ **Review** - 3 infos</summary>

🔧 Fix: tell a cut-short reply from an unanswered turn
3 issues (1 warning, 2 infos) still open:
- ⚠️ `bin/fm-voice-client.py:837` - bin/fm-voice-client.py:837 - the frame-handling guard still reports this end&#39;s own teardown as a fault, and the mitigation added for it at line 606 is bounded where the thing it waits on is not. The comment at 599-605 says joining the downlink before releasing the devices &#34;keeps the fault line meaning a fault&#34;, but the join is `timeout=5` (line 607) while the relay&#39;s teardown after QUIT is `await session.close()`, which sends contentEnd/promptEnd/sessionEnd and then awaits `asyncio.wait_for(gather(reader_task), timeout=10)` (bin/fm-voice-relay.py:600-604) - the reader task being the very thing that emits reply AUDIO. So the join can expire with the downlink alive and audio still in flight, `playback.close()` runs at line 612, and the next AUDIO frame hits `self._handle.write(pcm)` on a closed handle (line 225), raising ValueError into the broad handler: &#34;client: this end could not handle the relay&#39;s reply: ValueError: I/O operation on closed file&#34; plus a full `traceback.format_exc()` (line 845). Concrete sequence that exits 0 while printing it: a reply longer than `--timeout` at `--runs 1`, so `reply_end` never arrives; the turn is recorded `answered: true` (audio did arrive) with `relay_error: null`, `run()` returns 0 at line 1137 before main&#39;s `finally` calls `close()`; the relay is mid-reply, its teardown exceeds 5s, and the alarm lands after the record. That is both a wrong cause (the connection is healthy; the file was closed by us) and an alarm on a run reporting success, which is the pair of rules this branch has been enforcing. `self.quitting` is already set before QUIT (line 598) and is the discriminator: gate the say() and the traceback on it, downgrading to `log(self.verbose, ...)` during teardown, or make FilePlayback.write a no-op once closed so teardown cannot manufacture a fault at all.
- ℹ️ `tests/fm-voice-relay.test.sh:1282` - tests/fm-voice-relay.test.sh:1282 - the round that narrowed the module docstring to say the speaker&#39;s byte accounting IS verified left the mirror claim in the test file asserting the opposite, in the same file that now contains the coverage. The header comment reads &#34;The microphone and speaker paths cannot be tested from a host with neither, and are not tested anywhere: the first live run is their test&#34;, while lines 2289-2434 of the same block drive `SpeakerPlayback.write`, `turn_reset` and `_callback` against a stub stream. A reader of the test file is told there is no speaker coverage roughly 1000 lines above the coverage. docs/voice-relay.md:123-124 carries the same now-imprecise sentence (&#34;the capture and playback paths have never run&#34;); that one errs toward understating, which is the safe direction, but both would read better narrowed the way the docstring was - the DEVICES are unverified, the accounting is covered - and the change&#39;s own standard is that a claim about what is verified has to be exact in both directions.
- ℹ️ `bin/fm-voice-client.py:225` - bin/fm-voice-client.py:225 - the new FilePlayback lock is correct but wider than it needs to be, and it puts blocking I/O inside a critical section another thread enters while holding the global turn lock. `take_turn` calls `self.playback.turn_reset(self.turn_id)` at line 907 from inside `with self.lock`, so it blocks on `playback._lock` for however long the downlink&#39;s `self._handle.write(pcm)` takes; while it does, the downlink cannot stamp the next frame and `_sender` cannot stamp `wire_end`, since both need `self.lock`. There is no deadlock today - nothing acquires `self.lock` while holding `playback._lock` - but the ordering is one edit away from one, and tests/fm-voice-relay.test.sh:2189 already had to park its fixture&#39;s wait outside the parent&#39;s lock to avoid exactly that. Only the downlink thread ever writes to the handle, so the decision, the stamp and the count can stay under the lock with the write left outside it: file ordering is preserved by the single writer, and the stamp already precedes the write today, so the semantics are unchanged. The one difference is that a write which raises would leave its bytes counted, which the terminal handling-fault path at 822 renders moot.

🔧 Fix: discard reply audio arriving after the output closes
3 infos still open:
- ℹ️ `bin/fm-voice-client.py:665` - bin/fm-voice-client.py:665 - the discard accounting exists on one of the two playback classes only, and the getattr hides that rather than recording it. An AST sweep confirms `_closed` and `discarded` appear nowhere outside FilePlayback (lines 214-267); SpeakerPlayback (271-359) has neither, so `getattr(self.playback, &#34;discarded&#34;, 0)` is always 0 on the laptop path and `_say_dropped` says nothing there. The audit conclusion this round acted on is right about raising: `SpeakerPlayback.write` (326-332) only appends to `self._buffer` under `self._lock` and never touches `self._stream`, so a post-close write cannot reach the frame-handling guard, and the ruling said to change nothing in that case. What is left over is the diagnostic, not the fault: after `close()` stops the stream (354-359) no callback drains the buffer, so reply audio arriving in the same teardown window is appended to a bytearray that is never played and never counted, while the file path counts it. `_say_dropped`&#39;s own docstring (659-663) states the property that justifies keeping the counter - &#34;a count appearing on a session that has not ended is the logic bug it is kept for&#34; - and that property holds only for --out-file, so the write-after-close logic bug the counter exists to catch is undetectable on the path the captain will actually use. Mirroring `_closed` plus `discarded` into SpeakerPlayback.close/write is a few lines and would let the getattr become a plain attribute read; flagged as a question rather than a fix because the earlier ruling scoped the speaker change to the raising case, and this is the diagnostic half of it.
- ℹ️ `tests/fm-voice-relay.test.sh:2170` - tests/fm-voice-relay.test.sh:2170 - the only test for condition 1 proves the reporting method works, not that anything calls it. `audio_after_close` hand-calls `late._say_dropped()`, and `Client.close()` (the sole production caller, bin/fm-voice-client.py:656) is never driven anywhere in the added coverage, so the assertion at 2212 (&#34;discarded 1 reply audio chunk&#34; in loud_said) would still pass with line 656 deleted and the count consequently never reported on a real session. Everything else in this case is pinned through the public surface, which is why this one stands out. The fix is cheap and stays in the existing style: this fixture leaves `late.down_thread` and `late.proc` as None and its uplink stand-in swallows QUIT, so `late.close()` returns immediately, and replacing the direct `_say_dropped()` call with `late.close()` after `handled.wait(10)` exercises the wiring while keeping the required ordering (playback closed at 2167 before `released.set()` at 2168). Note `close()` also sets `quitting`, which is inert here.
- ℹ️ `bin/fm-voice-client.py:266` - bin/fm-voice-client.py:266 - recording a tradeoff this round introduced rather than a defect to fix. `write` now holds `_handle_lock` across the blocking `self._handle.write(pcm)` (243-254) and `close` needs the same lock, so `Client.close()`&#39;s `self._quietly(&#34;the speaker&#34;, self.playback.close)` (644) can wait for however long a write to --out-file takes. Before this commit `close()` took no lock and returned at once, so the deliberately bounded `down_thread.join(timeout=5)` (639) really did bound the exit; it no longer does if that write stalls, and `_quietly` catches exceptions but cannot interrupt a block. Reachability is thin: the handle is a BufferedWriter over a regular file, so a stall needs a full or hung filesystem, and the wedged-relay case the 5s bound was written for is unaffected. It is also hard to do better - dropping the lock is what let `close()` slip between the `_closed` check and the write and produce the ValueError fault line this round removed - so the current choice looks like the right one. Worth knowing it was a choice: the comment at 209-213 explains which lock covers what but not that the exit is now only as bounded as a single file write.

🔧 Fix: count discarded reply audio on the speaker path too
3 issues (1 warning, 2 infos) still open:
- ⚠️ `bin/fm-voice-client.py:797` - bin/fm-voice-client.py:797 and 864 - two of the four paths that write turn[&#34;failed&#34;] lack the reply_done guard the other two have, so a fully answered turn can be recorded with a relay_error, and round 5&#39;s new rule at line 1211 turns that into exit 1 on a session where every turn was answered. The window is exact: take_turn&#39;s reply_done.wait returns the instant reply_end arrives (1012), then _wait_audio_quiet spins until now - last_frame &gt;= audio_idle (1090-1098, default 0.4s), and only then is the dict copied at 1016-1017. For that ~0.4s the downlink is free to write into the live turn. (a) reader.read() raising OSError, an ECONNRESET rather than a clean FIN, hits 797 and its setdefault lands because a good turn has no &#34;failed&#34;. (b) the relay&#39;s model reader task breaking after the reply hits fail_turn (bin/fm-voice-relay.py:766, 889), which the client applies at 864 with a plain assignment and arrived_in == turn_id still true because take_turn has not advanced. Either way the record reads answered: true with a relay_error, and `if not record[&#34;answered&#34;] or record[&#34;relay_error&#34;]` sets rc = 1; at the default --runs 1 that is a non-zero code on a session that delivered its answer, and the docs line added by this change (docs/voice-relay.md:155) says relay_error &#34;is null when nothing broke&#34;. The same physical event through the two quiet paths does the opposite: a clean end of stream or an unasked goodbye in that identical window reaches the tail at 955-957, whose `not self.reply_done.is_set()` test declines, records nothing and exits 0 - which tests/fm-voice-relay.test.sh:1751-1754 pins as the required negative case. So EOF versus RST, differing only in what the kernel delivered, now produce different records and different exit codes for one relay death, and nothing covers the raising variants: tests/fm-voice-relay.test.sh:1500 and 1658 both drive the read-failure path on turns that were never answered. Earliest shared boundary: apply the same `not self.reply_done.is_set()` test the tail and the session-ended handler at 877 already use to both of these writes, so all four close paths agree on when a turn earns a reason. Guarding cannot swallow a genuine failure, because take_turn clears reply_done for the whole life of an open turn. Raised as ask-user rather than auto-fix because it changes what a record says and what the exit code means, which is exactly what you widened on purpose in round 5.
- ℹ️ `bin/fm-voice-client.py:689` - bin/fm-voice-client.py:689 and 691-706 - two small mismatches in the round 7 diagnostic. First, the docstring&#39;s discriminating claim, &#34;a count appearing on a session that has not ended is the logic bug it is kept for&#34;, cannot be observed: _say_dropped has exactly one caller, the last statement of close() itself, so the count is only ever reported at session end and a reader can never see it on a session that has not ended. The tripwire is real, a future close() outside teardown would still be counted, but the reported line would be indistinguishable from the benign teardown race the counter exists to tolerate, so the sentence promises a distinction the code cannot make. Second, dropping the getattr for a plain self.playback.discarded read makes this the one unguarded step in a method whose own comment at 656-659 says &#34;Every step is guarded and every field is checked... the original refusal is the message worth keeping&#34;: every other step goes through _quietly, and close() runs from open()&#39;s except BaseException at 582-584, so an AttributeError here would replace the startup refusal that is the whole reason for cleaning up, and in main&#39;s finally at 1321-1322 it would replace run()&#39;s return value. Not reachable today, since both playback classes define discarded and the tests&#39; Recorder now does too, which is why this is info rather than a defect. Either wrap the call in _quietly like its neighbours, or narrow the docstring to say what the counter actually gives, which is a count read at teardown that should normally be zero.
- ℹ️ `tests/fm-voice-relay.test.sh:1913` - tests/fm-voice-relay.test.sh:1913 and 1806 - turn_cut and turn_lost are the same helper twice. Both build a Client from the same flag list, wrap a ScriptedStream in frame.Reader, attach StartGate, a FilePlayback and a FileCapture over clip.pcm, start _sender and _downlink as daemon threads, run under redirected stdout and stderr, drain up_q, close the playback and parse the records; they differ only in the run count and in which assertions they then make. The same eight-line wiring block is also written out inline at 2030 (handling), 2158 (audio_after_close), 2316 (stale), 2401 (late) and 2459 (prompt). One `wire_client(args, reader, uplink, playback=None)` returning the client, plus turn_cut expressed as turn_lost with runs=&#34;1&#34; and its own assertion block, collapses roughly 70 of these lines with no change to what is asserted. Scoped deliberately: this touches none of EndingStream, CountingUplink, ClosingStream or StartGate, whose provenance from the verbatim cherry-pick is why you left them alone twice, and none of the cut/closing/gone/ending blocks that came with it. Every site listed above was authored by this run&#39;s own fix rounds, the same boundary you accepted for the five-stream dedup.

🔧 Fix: keep a reason off a turn already answered in full
2 infos still open:
- ℹ️ `bin/fm-voice-client.py:833` - bin/fm-voice-client.py:833 - the read-failure path is the only mid-turn reason that does not tell a truncated answer from an unanswered turn, and the docs added by this change say it does. `_unfinished` (756-772) is applied at 923 (session-ended) and at 1000 (the tail, covering both an ended stream and an unasked goodbye), which is exactly the three subjects docs/voice-relay.md:157 enumerates. The read at 787 raises for a fourth shape - an ECONNRESET rather than a clean FIN, or a header cut in half - and records the flat string &#34;the connection was lost: {exc}&#34;. So for a relay killed mid-reply on a connection that resets rather than closing, the record reads `answered: true`, `first_audio_s` measured, and a reason that says only that the connection went, while the doc line promises &#34;a turn whose answer had already started playing says the same thing happened before the reply finished&#34;. A reset is the likelier shape of a dropped SSH link than a clean FIN, so this is the half a reader is most likely to meet. Nothing pins it in either direction: the `turn_cut` loop at 1952-1991 drives only the three `_unfinished` subjects with SOME_REPLY, and the two read-failure cases (tests/fm-voice-relay.test.sh:1495 CutStream, 1635 LostStream) both run on turns that were never answered. Not a correctness break - the reason is non-null, rc is 1, and nothing contradicts `answered` - which is why this is info rather than a defect: `&#34;the connection was lost&#34;` makes no claim about whether audio arrived. The fix is to route this subject through `_unfinished` as well (`self._unfinished(&#34;the connection was lost&#34;)` plus the exception detail) and add the missing reset-after-partial-audio case, or to narrow the doc sentence so it does not promise a distinction one of the four paths does not make. Raised as ask-user because it changes user-visible record wording and a published promise, which is the author&#39;s call.
- ℹ️ `bin/fm-voice-client.py:980` - bin/fm-voice-client.py:980 - recording the result of the audit the fix round asked for, so a later round does not undo it. After round 8 this is the one `turn[&#34;failed&#34;]` write with neither the turn-identity gate nor the reply_done test: the read failure at 833 and the relay `turn-failed` at 907 gained the test, `session-ended` at 921 and the tail at 1000 already had it. It is reachable in the same post-answer window the guard exists for: reply audio belonging to turn N-1 arriving while turn N is open and already answered goes through `FilePlayback.write` with `mine` false, still reaches `self._handle.write(pcm)` at 263, and an OSError there (full or hung filesystem) is recorded against turn N and forces exit 1 through the rule at 1254. I judge leaving it ungated CORRECT and am not asking for a change. The symmetry argument that justified guarding 833 - &#34;an end of stream and a reset differ only in what the kernel handed us&#34; - has no partner here: a read failure means the far end went after delivering the whole answer, which cost the captain nothing, while this handler means THIS end could not put the audio it was handed anywhere, the session must stop, and rc 1 with a reason naming the real cause is the honest report. What is missing is only that the code does not say so, so the next reader has to re-derive it; the earlier note that these writes are &#34;ungated deliberately because they describe the connection rather than a frame&#34; no longer explains the split now that 833 carries the test.

🔧 Fix: say a reset cut a reply short, not that none arrived
3 infos still open:
- ℹ️ `bin/fm-voice-client.py:1107` - bin/fm-voice-client.py:1064, 1106 and 1107 - the record is built from a snapshot everywhere except the playback figures, which are three separate reads of live shared state. `played = self.playback.first_played` at 1064, `self.playback.turn_bytes` at 1106 for `reply_audio_seconds`, and `self.playback.turn_bytes` again at 1107 for `answered`, while `turn = dict(self.turn)` at 1062 deliberately snapshots the rest. A chunk written by the downlink between two of those reads produces the self-contradiction this branch exists to remove. Concrete sequence: a turn whose `reply_done.wait` expires at line 1057 while no audio has arrived; `_wait_audio_quiet` reads `last_frame` as None and returns immediately at 1139-1140 with no idle wait at all; `arrived_in == self.turn_id` still holds because take_turn has not advanced, so the reply&#39;s first AUDIO frame landing during dict construction stamps `first_played` and credits `turn_bytes`. If it lands between 1106 and 1107 the record reads `reply_audio_seconds: 0.0` with `answered: true`; between 1064 and 1106 it reads `answered: true` with `first_played_s: null` and `first_audio_s` falling back to a frame stamp the copied dict may not even carry. The window is microseconds wide and needs the reply to arrive at the exact timeout boundary, and the two-read shape predates this branch (base computed `self.playback.bytes - before` and `self.playback.bytes &gt; before` the same way), which is why this is info rather than a defect. It is worth closing because `_unfinished` at 770 was added precisely so a reason and `answered` are read off one input, and these two fields are the pair that reason is checked against. Fix is mechanical and non-functional: read `first_played` and `turn_bytes` once into locals before the dict literal, so the three figures describe one instant.
- ℹ️ `bin/fm-voice-client.py:841` - bin/fm-voice-client.py:841 - the end-of-stream branch is the only close path whose `say()` has no teardown discriminator, so it can print a mid-session fault line on a session that answered every turn and exits 0. The BYE branch at 940-954 was given exactly that discriminator (`self.quitting`, set at 664 before the QUIT frame) after round 4 found the goodbye firing on clean shutdown; the EOF path beside it was left unconditional. Reachable path, and it is a timing asymmetry rather than a coincidence: `close()` bounds the relay at `down_thread.join(timeout=5)` (672) and `proc.wait(timeout=10)` (684), while the relay&#39;s teardown after QUIT is `await session.close()` awaiting the model reader with `timeout=10` (bin/fm-voice-relay.py:600-602) plus `down.close()`&#39;s own `join(timeout=5)` (482), so a slow Bedrock stream close overruns both client bounds, `proc.kill()` fires at 686, the child&#39;s stdout closes without a BYE ever being written, and the still-live downlink thread reads b&#34;&#34; and prints &#34;client: the connection ended&#34; as the last human line of a successful run. The record and the exit code are unaffected (`reply_done` is set after the final answered turn, so the tail at 1001 correctly declines to name anything, and run() has already returned), so this is only the alarm-on-success rule the branch enforced twice, not a wrong record. Note it is also a latent flake: the clean end-to-end case asserts this exact string is absent (tests/fm-voice-relay.test.sh:4187). The 5s/10s/15s bounds themselves belong to the teardown-ordering work you filed and are out of scope; the change here is to gate this one line on `self.quitting` (or downgrade it to `log(self.verbose, ...)` when quitting), which leaves the mid-session case pinned at tests/fm-voice-relay.test.sh:1885-1886 untouched because `quitting` is only ever set from close().
- ℹ️ `docs/voice-relay.md:156` - docs/voice-relay.md:156 - the sentence added by this change reads as an exhaustive account of `relay_error` and promises a distinction two of the reasons the code emits do not make. It enumerates four subjects (the connection ended, or was lost, or the relay stopped, or the session ended) and states that each says either &#34;before that turn was answered&#34; or &#34;before the reply finished&#34;. Two other reason strings reach the same field and match neither half. The relay&#39;s own words, applied verbatim at bin/fm-voice-client.py:909 from `fail_turn` (bin/fm-voice-relay.py:886), carry no clause at all, so a truncated turn can read `answered: true` with `relay_error: &#34;ModelStreamErrorException: ...&#34;`; that is deliberate and correct, since the relay knows more than this end can infer, but the doc does not say it. The handling-fault reason at bin/fm-voice-client.py:969-970, &#34;this end could not handle the relay&#39;s reply: &lt;type&gt;: &lt;message&gt;&#34;, was introduced by this branch in round 3 and is documented nowhere; it is also the one reason that is not about the far end, which is the distinction its own comment at 967-968 calls out as the thing a reader must not get wrong. A captain who reads line 156 as the set and then meets either string has no way to place it. Since line 159 makes any `relay_error` non-zero the exit code, the enumeration is also what tells them which failures fail a run. Raised as ask-user because it is the author&#39;s call whether to name the two extra shapes or to reword line 156 so it stops reading as a complete list.

🔧 Fix: read one turn&#39;s audio count once, and hush a tidy exit
3 infos still open:
- ℹ️ `bin/fm-voice-client.py:1066` - bin/fm-voice-client.py:1065-1066 - this round hoisted `turn_bytes` into `reply_bytes` so the record stops asking one question twice, but `played` (1065) and `reply_bytes` (1066) are still two separate lock-free reads of state `FilePlayback.write` updates together inside one critical section. Lines 257-262 hold `self._lock` across `mine = turn == self._turn`, `self.first_played = time.monotonic()` and `self.turn_bytes += len(pcm)`, and the record reader takes no playback lock, so it can observe the instant between the stamp at 260 and the credit at 262. Concrete sequence, on the one path that can reach the record with a frame in flight: a turn whose `reply_done.wait` expires at 1058 with nothing played, so `_wait_audio_quiet` reads `last_frame` as None and returns immediately (1141-1142) with no idle wait; `arrived_in == self.turn_id` still holds because take_turn has not advanced; the turn thread copies the dict at 1063 and is descheduled; the downlink stamps `first_frame`/`last_frame` (859-860), releases, enters `write`, stamps `first_played` at 260, and is preempted before 262; the turn thread then runs 1065-1066. The record reads `answered: false`, `reply_audio_seconds: 0.0`, `first_frame_s: null` - and `first_played_s` plus `first_audio_s` as real numbers, so it reports the headline latency for audio it also says never arrived. That is the same one-record-two-answers shape this round removed, in the direction the round-9 instruction did not consider: it explicitly reasoned about `played` and `first_frame` being None together and accepted that null, but not about `played` being set while the count is still zero. The opposite read order is worse (any interleave after the stamp loses), so reordering does not help. Reachability is narrow and I am reporting it as such: the downlink must cover 856 through 260 inside two statements of the turn thread and then stall on one bytecode. Flagged because it is the residual of the invariant this commit claims, the FilePlayback path is the one every published figure in docs/voice-relay.md was measured with, and nothing pins the implication that a stamped `first_played_s` means the turn was answered (tests/fm-voice-relay.test.sh:2751 pins the null case, 4327 the happy path). Earliest shared boundary: one accessor on the playback returning `first_played` and `turn_bytes` together under `_lock`, which both classes already have. That is inside the playback rather than in `take_turn`, so it does not contradict the standing &#34;do not take the playback lock here&#34; ruling; the speaker path needs it too, where `write` credits bytes and `_callback` stamps the clock on different threads. Raised as ask-user because closing it touches how a record is assembled, which is the area you have fenced off for the single-outcome-computation work.
- ℹ️ `tests/fm-voice-relay.test.sh:2539` - tests/fm-voice-relay.test.sh:2539 - `QuitThenEnd` is `ScriptedStream` (1779) with a gate wait bolted on, and `ScriptedStream` grew the `at_end` callable one commit earlier (bdc7bef) for exactly that shape. `ScriptedStream(tidy_open, AUDIO + REPLY_END, &#34;the tidy exit&#34;, at_end=lambda: check(tidy_quit.wait(10), ...))` is behaviourally identical: `read` waits the open gate, slices, and once `_at &gt;= len(_bytes)` calls `at_end` and returns the empty slice, which is the `return b&#34;&#34;` this class writes out by hand. `a_reset` at 2015-2021 is the existing precedent for an `at_end` that blocks or raises. `RaisingAfterReply` (2056) is the same substitution with `at_end` raising. `FailingAfterReply` (2076) and `LateAudioStream` (2279) share the same body and differ only in serving a second payload after the gate, which a `then` argument would cover. So four classes of roughly fifteen lines each carry one shape that the shared fixture already expresses, and the newest of them was added one commit after the parameter that retires it. Scoped the same way you scoped the two dedups you accepted: this touches none of EndingStream, CountingUplink, ClosingStream or StartGate, whose provenance from the verbatim cherry-pick is why they are left alone, and every site named here was authored by this run&#39;s own fix rounds. `GoodbyeWatchingGate` (2559) is excluded, since the uplink it would otherwise extend is StartGate.
- ℹ️ `bin/fm-voice-client.py:841` - bin/fm-voice-client.py:841 - gating the end-of-stream line on `self.quitting` is the right call for the alarm-on-success rule, and the mid-session case stays pinned (tests/fm-voice-relay.test.sh:1884). What it also removes is the only signal that the relay had to be killed rather than shutting down. The BYE branch beside it still speaks during teardown, &#34;client: the relay signed off&#34; (950), so a relay that exited cleanly says a line while one whose teardown outran both bounds - `down_thread.join(timeout=5)` at 672 and `proc.wait(timeout=10)` at 684, against the relay&#39;s own `session.close()` awaiting the model reader at bin/fm-voice-relay.py:600-604 - says nothing at all. `proc.kill()` at 686 is silent too, and `closed_because` is only read by `_say_stopped`, which `run()` has already finished with, so the record and the exit code carry nothing either. The captain therefore cannot tell a tidy exit from a SIGKILLed one, which is the operational signal the timing asymmetry you have filed under teardown ordering would actually surface. A `log(self.verbose, &#34;the relay was still running when the connection ended&#34;)` on the quitting side keeps the distinction without an alarm, and is compatible with the ruling against downgrading the line, which was about not losing the mid-session fault. Raised as ask-user rather than auto-fix because it adds a line of human output on a path you deliberately just silenced, and the silence may be what you want.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-voice-relay.test.sh` — the suite that owns the spoken interface (all cases pass, ~35s), including the cut-header turn, the connection lost between turns, the connection already known gone when a turn opens, the truncated answer at `--runs 1`, the relay naming a desync ahead of its goodbye, and the whole round trip</code>
- <code>`bash harness/run_scenarios.sh` — drives the real `bin/fm-voice-client.py` CLI (`--local --runs N &gt; runs.jsonl`) against a stub relay speaking the real wire format, once with the default-branch client and once with the fix, over four scenarios: relay dies before any reply, relay dies partway through the answer, relay dies between two runs, healthy two-run control</code>
- <code>`bash harness/run_real_relay.sh &lt;repo&gt;` — same before/after with the REAL `bin/fm-voice-relay.py` and its real records reader (only the paid Bedrock model stood in for, using the suite&#39;s own extracted stand-in): the model session ends mid key press, run 1 unanswered and run 2 answered over the same connection</code>
- <code>`python3 harness/relay_desync_frames.py &lt;relay&gt; &lt;label&gt;` — opens the real relay `--serve`, starts a turn, writes a byte that is not a frame kind, and prints the frames it sends back; run against both the base and the fixed relay</code>
- <code>`git check-ignore -v data/speech-to-speech-survey-s2/report.md` and `git grep -n &#39;speech-to-speech-survey&#39;` / `git grep -n &#39;the survey&#39;` — the cited record is gitignored and no tracked file cites it any more</code>
- <code>`git diff dc0172c..dfe12ac -- .greptile/rules.md` and `git ls-files .greptile` — the rule file is kept and narrowed by one sentence rather than removed</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `.greptile/rules.md:10` - The narrowing sentence this change added restates a fact the same file already carries at lines 35-36 (&#34;Whether `VISION.md` should be reconciled to describe that is the captain&#39;s call and is not settled by any single pull request&#34;), so the repo&#39;s one-owner rule is now stated twice in a 38-line file. I did not consolidate it: the intent pinned the new sentence&#39;s three clauses verbatim, and the older sentence carries extra content (&#34;not settled by any single pull request&#34;) that the sentence immediately after it depends on (&#34;Raising it as new is what this rule is here to stop&#34;), so trimming it risks breaking the reviewer&#39;s recorded argument. Worth a follow-up decision on which of the two should own the open question.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
