### PR TITLE
fix(bin): isolate new Herdr server environments

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1447,8 +1447,9 @@ fm_backend_herdr_projection_order_best_effort() {  # <session> <created-workspac
 # has-session || tmux new-session -d`. Verified: a bare socket CLI call does
 # NOT auto-start the server, so this must run before any workspace/tab/pane
 # call. The server outlives its launcher and passes its startup environment to
-# every later pane, so remove home and harness identity inherited from whichever
-# agent happened to start it. Bounded poll for the server to report running.
+# every later pane, so remove home, harness identity, and supervision selection
+# inherited from whichever agent happened to start it. Bounded poll for the
+# server to report running.
 fm_backend_herdr_server_ensure() {  # <session>
   local session=$1 running out i
   running=$(fm_backend_herdr_cli "$session" status --json 2>/dev/null | jq -r '.server.running // false' 2>/dev/null)

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1446,12 +1446,18 @@ fm_backend_herdr_projection_order_best_effort() {  # <session> <created-workspac
 # headless (no TUI client) if not already running, mirroring tmux's `tmux
 # has-session || tmux new-session -d`. Verified: a bare socket CLI call does
 # NOT auto-start the server, so this must run before any workspace/tab/pane
-# call. Bounded poll for the server to report running.
+# call. The server outlives its launcher and passes its startup environment to
+# every later pane, so remove home and harness identity inherited from whichever
+# agent happened to start it. Bounded poll for the server to report running.
 fm_backend_herdr_server_ensure() {  # <session>
   local session=$1 running out i
   running=$(fm_backend_herdr_cli "$session" status --json 2>/dev/null | jq -r '.server.running // false' 2>/dev/null)
   [ "$running" = "true" ] && return 0
-  ( fm_backend_herdr_cli "$session" server >/dev/null 2>&1 & ) || return 1
+  (
+    unset FM_HOME FM_ROOT_OVERRIDE FM_STATE_OVERRIDE FM_DATA_OVERRIDE FM_PROJECTS_OVERRIDE FM_CONFIG_OVERRIDE \
+      CURSOR_AGENT CURSOR_INVOKED_AS CLAUDECODE PI_CODING_AGENT FM_PI_HARNESS GROK_AGENT
+    fm_backend_herdr_cli "$session" server >/dev/null 2>&1 &
+  ) || return 1
   for i in $(seq 1 20); do
     running=$(fm_backend_herdr_cli "$session" status --json 2>/dev/null | jq -r '.server.running // false' 2>/dev/null)
     [ "$running" = "true" ] && return 0

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -1455,7 +1455,7 @@ fm_backend_herdr_server_ensure() {  # <session>
   [ "$running" = "true" ] && return 0
   (
     unset FM_HOME FM_ROOT_OVERRIDE FM_STATE_OVERRIDE FM_DATA_OVERRIDE FM_PROJECTS_OVERRIDE FM_CONFIG_OVERRIDE \
-      CURSOR_AGENT CURSOR_INVOKED_AS CLAUDECODE PI_CODING_AGENT FM_PI_HARNESS GROK_AGENT
+      CURSOR_AGENT CURSOR_INVOKED_AS CLAUDECODE PI_CODING_AGENT FM_PI_HARNESS GROK_AGENT FM_SUPERVISION_MODEL
     fm_backend_herdr_cli "$session" server >/dev/null 2>&1 &
   ) || return 1
   for i in $(seq 1 20); do

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -205,7 +205,10 @@ Workspace and tab ids support verification and cleanup but are not inferred from
 The adapter starts and polls a named server before workspace, tab, pane, or agent calls.
 Every Herdr invocation goes through `fm_backend_herdr_cli`, which sets the environment and passes an explicit trailing `--session <name>`.
 An environment variable alone is not reliable when another Herdr server is running.
-Before launching a new long-lived server, the adapter removes inherited Firstmate home overrides and harness identity markers. Otherwise the server would pass the launcher's home and harness identity to every later pane, including panes for another home or harness.
+When the selected named server is not running, the adapter launches it without inherited Firstmate home and directory overrides, harness identity markers, or the supervision-model override.
+Herdr passes its server startup environment to every later pane, so retaining those values could misroute panes for another Firstmate home or harness.
+An already-running server is reused without restart or environment changes.
+Explicit named-session routing and unrelated launch environment remain intact.
 
 Literal text and Enter are separate operations for ordinary steers.
 Spawn-time fixed commands may use Herdr's atomic run primitive.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -205,6 +205,7 @@ Workspace and tab ids support verification and cleanup but are not inferred from
 The adapter starts and polls a named server before workspace, tab, pane, or agent calls.
 Every Herdr invocation goes through `fm_backend_herdr_cli`, which sets the environment and passes an explicit trailing `--session <name>`.
 An environment variable alone is not reliable when another Herdr server is running.
+Before launching a new long-lived server, the adapter removes inherited Firstmate home overrides and harness identity markers. Otherwise the server would pass the launcher's home and harness identity to every later pane, including panes for another home or harness.
 
 Literal text and Enter are separate operations for ordinary steers.
 Spawn-time fixed commands may use Herdr's atomic run primitive.

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -63,6 +63,38 @@ SH
   printf '%s\n' "$fb"
 }
 
+# make_herdr_server_env_fakebin: a stateful server stub that records only the
+# long-lived server launch environment, then reports the server as running.
+make_herdr_server_env_fakebin() {  # <dir> -> echoes fakebin dir
+  local dir=$1 fb="$1/fakebin"
+  mkdir -p "$fb"
+  cat > "$fb/herdr" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-}" in
+  status)
+    if [ -e "$FM_HERDR_SERVER_MARKER" ]; then
+      printf '{"server":{"running":true}}\n'
+    else
+      printf '{"server":{"running":false}}\n'
+    fi
+    ;;
+  server)
+    {
+      for name in FM_HOME FM_ROOT_OVERRIDE FM_STATE_OVERRIDE FM_DATA_OVERRIDE FM_PROJECTS_OVERRIDE FM_CONFIG_OVERRIDE CURSOR_AGENT CURSOR_INVOKED_AS CLAUDECODE PI_CODING_AGENT FM_PI_HARNESS GROK_AGENT FM_HERDR_SENTINEL HERDR_SESSION; do
+        eval 'value=${'"$name"'-<unset>}'
+        printf '%s=%s\n' "$name" "$value"
+      done
+      printf 'args=%s\n' "$*"
+    } > "$FM_HERDR_SERVER_ENV_LOG"
+    : > "$FM_HERDR_SERVER_MARKER"
+    ;;
+esac
+SH
+  chmod +x "$fb/herdr"
+  printf '%s\n' "$fb"
+}
+
 # make_herdr_statefake: a STATEFUL `herdr` stub that models the parts of herdr's
 # real container behavior the workspace-leak fix (and the default-tab-prune
 # safety fix) depend on, so a full spawn->teardown cycle can be replayed
@@ -522,6 +554,27 @@ test_container_ensure_starts_server_and_workspace() {
   assert_contains "$(cat "$log")" $'\x1f''workspace'$'\x1f''create'$'\x1f''--cwd'$'\x1f''/tmp'$'\x1f''--label'$'\x1f''firstmate' \
     "container_ensure did not create the firstmate workspace with the given cwd"
   pass "fm_backend_herdr_container_ensure: version-gates, starts the server, ensures the firstmate workspace, echoes session:workspace_id + the seeded default tab id"
+}
+
+test_server_ensure_scrubs_home_and_harness_identity() {
+  local dir log marker fb output name
+  dir="$TMP_ROOT/server-env"; mkdir -p "$dir"; log="$dir/env"; marker="$dir/running"
+  fb=$(make_herdr_server_env_fakebin "$dir")
+  PATH="$fb:$PATH" FM_HERDR_SERVER_ENV_LOG="$log" FM_HERDR_SERVER_MARKER="$marker" FM_HERDR_SENTINEL=kept \
+    FM_HOME=/tmp/wrong-home FM_ROOT_OVERRIDE=/tmp/wrong-root FM_STATE_OVERRIDE=/tmp/wrong-state \
+    FM_DATA_OVERRIDE=/tmp/wrong-data FM_PROJECTS_OVERRIDE=/tmp/wrong-projects FM_CONFIG_OVERRIDE=/tmp/wrong-config \
+    CURSOR_AGENT=1 CURSOR_INVOKED_AS=cursor-agent CLAUDECODE=1 PI_CODING_AGENT=true FM_PI_HARNESS=pi-signed GROK_AGENT=1 \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_server_ensure fmtest' "$ROOT"
+  expect_code 0 $? "server_ensure should start under a polluted launcher environment"
+  output=$(cat "$log")
+  for name in FM_HOME FM_ROOT_OVERRIDE FM_STATE_OVERRIDE FM_DATA_OVERRIDE FM_PROJECTS_OVERRIDE FM_CONFIG_OVERRIDE \
+    CURSOR_AGENT CURSOR_INVOKED_AS CLAUDECODE PI_CODING_AGENT FM_PI_HARNESS GROK_AGENT; do
+    assert_contains "$output" "$name=<unset>" "server_ensure leaked $name into the long-lived Herdr server"
+  done
+  assert_contains "$output" "FM_HERDR_SENTINEL=kept" "server_ensure removed an unrelated environment variable"
+  assert_contains "$output" "HERDR_SESSION=fmtest" "server_ensure lost explicit Herdr session routing"
+  assert_contains "$output" "args=server --session fmtest" "server_ensure lost the trailing Herdr session flag"
+  pass "fm_backend_herdr_server_ensure: scrubs home and harness identity without disturbing unrelated environment or session routing"
 }
 
 test_container_ensure_reuses_existing_workspace() {
@@ -4424,6 +4477,7 @@ test_workspace_ensure_refuses_an_ambiguous_label_with_no_launcher
 test_workspace_ensure_other_home_ignores_the_launcher_identity
 test_container_ensure_refuses_an_ambiguous_home_label
 test_container_ensure_starts_server_and_workspace
+test_server_ensure_scrubs_home_and_harness_identity
 test_container_ensure_reuses_existing_workspace
 test_container_ensure_creates_with_no_focus_flag
 test_container_ensure_uses_secondmate_home_label

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -81,7 +81,7 @@ case "${1:-}" in
     ;;
   server)
     {
-      for name in FM_HOME FM_ROOT_OVERRIDE FM_STATE_OVERRIDE FM_DATA_OVERRIDE FM_PROJECTS_OVERRIDE FM_CONFIG_OVERRIDE CURSOR_AGENT CURSOR_INVOKED_AS CLAUDECODE PI_CODING_AGENT FM_PI_HARNESS GROK_AGENT FM_HERDR_SENTINEL HERDR_SESSION; do
+      for name in FM_HOME FM_ROOT_OVERRIDE FM_STATE_OVERRIDE FM_DATA_OVERRIDE FM_PROJECTS_OVERRIDE FM_CONFIG_OVERRIDE CURSOR_AGENT CURSOR_INVOKED_AS CLAUDECODE PI_CODING_AGENT FM_PI_HARNESS GROK_AGENT FM_SUPERVISION_MODEL FM_HERDR_SENTINEL HERDR_SESSION; do
         eval 'value=${'"$name"'-<unset>}'
         printf '%s=%s\n' "$name" "$value"
       done
@@ -563,12 +563,12 @@ test_server_ensure_scrubs_home_and_harness_identity() {
   PATH="$fb:$PATH" FM_HERDR_SERVER_ENV_LOG="$log" FM_HERDR_SERVER_MARKER="$marker" FM_HERDR_SENTINEL=kept \
     FM_HOME=/tmp/wrong-home FM_ROOT_OVERRIDE=/tmp/wrong-root FM_STATE_OVERRIDE=/tmp/wrong-state \
     FM_DATA_OVERRIDE=/tmp/wrong-data FM_PROJECTS_OVERRIDE=/tmp/wrong-projects FM_CONFIG_OVERRIDE=/tmp/wrong-config \
-    CURSOR_AGENT=1 CURSOR_INVOKED_AS=cursor-agent CLAUDECODE=1 PI_CODING_AGENT=true FM_PI_HARNESS=pi-signed GROK_AGENT=1 \
+    CURSOR_AGENT=1 CURSOR_INVOKED_AS=cursor-agent CLAUDECODE=1 PI_CODING_AGENT=true FM_PI_HARNESS=pi-signed GROK_AGENT=1 FM_SUPERVISION_MODEL=autoarm \
     bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_server_ensure fmtest' "$ROOT"
   expect_code 0 $? "server_ensure should start under a polluted launcher environment"
   output=$(cat "$log")
   for name in FM_HOME FM_ROOT_OVERRIDE FM_STATE_OVERRIDE FM_DATA_OVERRIDE FM_PROJECTS_OVERRIDE FM_CONFIG_OVERRIDE \
-    CURSOR_AGENT CURSOR_INVOKED_AS CLAUDECODE PI_CODING_AGENT FM_PI_HARNESS GROK_AGENT; do
+    CURSOR_AGENT CURSOR_INVOKED_AS CLAUDECODE PI_CODING_AGENT FM_PI_HARNESS GROK_AGENT FM_SUPERVISION_MODEL; do
     assert_contains "$output" "$name=<unset>" "server_ensure leaked $name into the long-lived Herdr server"
   done
   assert_contains "$output" "FM_HERDR_SENTINEL=kept" "server_ensure removed an unrelated environment variable"


### PR DESCRIPTION
## Intent

Fix the verified Firstmate bug where a long-lived Herdr server inherits FM_HOME, Firstmate directory overrides, harness identity markers, and the supervision-model override from its launcher, then leaks them into later panes. This misclassified a real Pi session as Cursor, selected the wrong supervision protocol, failed to arm the Pi watcher, and triggered repeated TURN WOULD END BLIND guard aborts. Keep the fix Ponytail-small: sanitize only new Herdr server launches, preserve Herdr session routing and unrelated environment, do not broadly reorder harness detection, do not restart the currently active Herdr server, add one behavioral regression test that fails before the fix, document the boundary, and contribute the change as an upstream PR from the RooseveltAdvisors fork. Do not add unrelated cleanup or abstractions.

## What Changed

- Strip Firstmate directory overrides, harness identity markers, and supervision-model overrides when launching a new Herdr server, while preserving session routing and unrelated environment variables.
- Leave already-running Herdr servers unchanged and document the launch-only isolation boundary.
- Add a behavioral regression test covering the sanitized server environment.

## Risk Assessment

✅ Low: The change is narrowly scoped to new Herdr server launches and preserves active-server reuse, session routing, unrelated environment, and the requested behavioral coverage.

## Testing

After an initial setup-contaminated run, the targeted Herdr backend suite passed in a clean launcher environment; real-Herdr end-to-end checks showed later panes omit Firstmate home, directory, harness, and supervision variables while preserving unrelated environment and named-session routing, re-ensuring an active server does not replace its environment, and the active default server remains unchanged. A base-commit replay reproduced the original leak. CLI transcripts are the reviewer-visible evidence because this backend change has no UI surface.

<details>
<summary>Evidence: Real Herdr environment-isolation and active-server reuse transcript</summary>

Source: [Real Herdr environment-isolation and active-server reuse transcript](https://github.com/RooseveltAdvisors/firstmate/blob/e50d9de55457e8704dd2ffcc5791ec2664dde004/.no-mistakes/evidence/fix/herdr-server-env-isolation/herdr-env-isolation-e2e.log)

```text
default-session-before={"name":"default","default":true,"running":true,"socket_path":"/home/jon/.config/herdr/herdr.sock"}
isolated-server-running=true
first-later-pane=w1:p1
FM_HOME=<unset>
FM_ROOT_OVERRIDE=<unset>
FM_STATE_OVERRIDE=<unset>
FM_DATA_OVERRIDE=<unset>
FM_PROJECTS_OVERRIDE=<unset>
FM_CONFIG_OVERRIDE=<unset>
CURSOR_AGENT=<unset>
CURSOR_INVOKED_AS=<unset>
CLAUDECODE=<unset>
PI_CODING_AGENT=<unset>
FM_PI_HARNESS=<unset>
GROK_AGENT=<unset>
FM_SUPERVISION_MODEL=<unset>
FM_HERDR_SENTINEL=kept
HERDR_SESSION=fm-lab-env-isolation-1628912-3418
later-pane-after-reensure=w1:p2
FM_HOME=<unset>
FM_ROOT_OVERRIDE=<unset>
FM_STATE_OVERRIDE=<unset>
FM_DATA_OVERRIDE=<unset>
FM_PROJECTS_OVERRIDE=<unset>
FM_CONFIG_OVERRIDE=<unset>
CURSOR_AGENT=<unset>
CURSOR_INVOKED_AS=<unset>
CLAUDECODE=<unset>
PI_CODING_AGENT=<unset>
FM_PI_HARNESS=<unset>
GROK_AGENT=<unset>
FM_SUPERVISION_MODEL=<unset>
FM_HERDR_SENTINEL=kept
HERDR_SESSION=fm-lab-env-isolation-1628912-3418
assertion=scrubbed launch-only variables; preserved unrelated sentinel and named-session routing
assertion=already-running server retained original environment on re-ensure
default-session-after={"name":"default","default":true,"running":true,"socket_path":"/home/jon/.config/herdr/herdr.sock"}
cleanup=isolated session removed; active default session unchanged
```
</details>
<details>
<summary>Evidence: Base-commit behavioral regression reproduction</summary>

Source: [Base-commit behavioral regression reproduction](https://github.com/RooseveltAdvisors/firstmate/blob/e50d9de55457e8704dd2ffcc5791ec2664dde004/.no-mistakes/evidence/fix/herdr-server-env-isolation/herdr-env-isolation-base-replay.log)

```text
default-session-before={"name":"default","default":true,"running":true,"socket_path":"/home/jon/.config/herdr/herdr.sock"}
FM_HOME=/tmp/wrong-home
FM_ROOT_OVERRIDE=/tmp/wrong-root
FM_STATE_OVERRIDE=/tmp/wrong-state
FM_DATA_OVERRIDE=/tmp/wrong-data
FM_PROJECTS_OVERRIDE=/tmp/wrong-projects
FM_CONFIG_OVERRIDE=/tmp/wrong-config
CURSOR_AGENT=1
CURSOR_INVOKED_AS=cursor-agent
CLAUDECODE=1
PI_CODING_AGENT=true
FM_PI_HARNESS=pi-signed
GROK_AGENT=1
FM_SUPERVISION_MODEL=autoarm
FM_HERDR_SENTINEL=kept
HERDR_SESSION=fm-lab-base-replay-1647979-14687
expected-fixed-contract=FAIL (base server leaked launcher home, harness markers, and supervision override into a later pane)
default-session-after={"name":"default","default":true,"running":true,"socket_path":"/home/jon/.config/herdr/herdr.sock"}
cleanup=isolated base-replay session removed; active default session unchanged
contract-exit=1
```
</details>
<details>
<summary>Evidence: Later pane environment after re-ensuring the running server</summary>

Source: [Later pane environment after re-ensuring the running server](https://github.com/RooseveltAdvisors/firstmate/blob/e50d9de55457e8704dd2ffcc5791ec2664dde004/.no-mistakes/evidence/fix/herdr-server-env-isolation/pane-env-after-reensure.txt)

```text
FM_HOME=<unset>
FM_ROOT_OVERRIDE=<unset>
FM_STATE_OVERRIDE=<unset>
FM_DATA_OVERRIDE=<unset>
FM_PROJECTS_OVERRIDE=<unset>
FM_CONFIG_OVERRIDE=<unset>
CURSOR_AGENT=<unset>
CURSOR_INVOKED_AS=<unset>
CLAUDECODE=<unset>
PI_CODING_AGENT=<unset>
FM_PI_HARNESS=<unset>
GROK_AGENT=<unset>
FM_SUPERVISION_MODEL=<unset>
FM_HERDR_SENTINEL=kept
HERDR_SESSION=fm-lab-env-isolation-1628912-3418
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"ac0230589cd75b14c6d8aa57f883f2f2b332e2c9","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-backend-herdr.test.sh` (initially hit unrelated inherited `FM_HOME` test-environment contamination)</code>
- `env -u FM_HOME -u FM_ROOT_OVERRIDE -u FM_STATE_OVERRIDE -u FM_DATA_OVERRIDE -u FM_PROJECTS_OVERRIDE -u FM_CONFIG_OVERRIDE -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u CLAUDECODE -u PI_CODING_AGENT -u FM_PI_HARNESS -u GROK_AGENT -u FM_SUPERVISION_MODEL bash tests/fm-backend-herdr.test.sh`
- <code>`bash /tmp/no-mistakes-evidence/01M0MGT1QRAZYV2RRHYNW6QXEC/herdr-env-isolation-e2e.sh` against real Herdr 0.8.0</code>
- <code>Behavioral replay against base commit `1231b6ae7fd4c5ff7e94d2f5ca2159536c4c41cb`; the same fixed-contract assertion exited 1 after reproducing leaked launcher variables</code>
- `Verified temporary Herdr sessions were removed and the active default session remained running on the same socket`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>


Closes #2774
