### PR TITLE
fix(bin): require crewmate status lines to be written in English

### DIFF
--- a/.agents/skills/firstmate-codexapp/SKILL.md
+++ b/.agents/skills/firstmate-codexapp/SKILL.md
@@ -62,6 +62,7 @@ For a Firstmate-managed task, include an explicit status instruction:
 ```text
 Append supervisor-visible status lines to <absolute-firstmate-home>/state/<task-id>.status.
 Use only these prefixes for status changes: working:, needs-decision:, blocked:, paused:, done:, failed:.
+Write every status line in English, whatever language you are working in: firstmate reads these lines and acts on them.
 Use paused: only for a deliberate known external wait that should be rechecked later, never for a blocker that needs firstmate to act.
 Before doing substantive work, append "working: Codex Desktop thread started".
 ```

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -49,6 +49,9 @@
 # declared-external-wait verb (FM_CLASSIFY_PAUSED_VERB, default "paused") from
 # "blocked:": pause for a known external wait expected to clear on its own,
 # blocked when firstmate must act.
+# It also states the language of the signal itself: status lines are read and
+# acted on by firstmate, so every scaffold requires them in English regardless
+# of the language the worker is working in.
 # Every scaffold also carries the steering-inbox receive-and-ack section:
 # process state/<id>.inbox/*.msg in order and acknowledge each by moving it to
 # handled/ (record, doorbell, and ladder owned by bin/fm-task-inbox-lib.sh).
@@ -259,6 +262,7 @@ Handle routine work yourself.
 Report only true captain-relevant outcomes or a declared external wait by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
 States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
+Write every status line in English, whatever language you are working in: the main firstmate reads these lines and acts on them.
 Use \`$PAUSED_VERB: {why}\` (distinct from \`blocked:\`) only when your domain is deliberately idling on a known external wait you expect to clear on its own; use \`blocked:\` when you are stuck and need firstmate to act.
 Use this only for material phase changes, a captain decision, a real blocker, a failure, work ready for review, or work you landed.
 Work you landed includes a merge you performed yourself under standing merge authority and one the captain merged on the forge: under that authority nothing is ever \"ready for review\", so a landed merge that goes unreported reaches the captain as silence.
@@ -343,6 +347,8 @@ The report is the only thing that survives, so anything worth keeping must be in
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
+   Write every status line in English, whatever language you are working in:
+   firstmate reads these lines and acts on them.
    Each append wakes firstmate, so report sparingly: only phase changes a supervisor
    would act on and the needs-decision/blocked/paused/done/failed states. No step-by-step
    FYI progress lines; firstmate reads your pane for that.
@@ -419,6 +425,8 @@ $RULE1
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
+   Write every status line in English, whatever language you are working in:
+   firstmate reads these lines and acts on them.
    Each append wakes firstmate, so report sparingly: only phase changes a supervisor
    would act on (setup done, bug reproduced, fix implemented, validation passed) and the
    needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -772,22 +772,6 @@ test_status_lines_declare_english() {
   pass "fm-brief.sh: every scaffold requires English status lines"
 }
 
-# Codex Desktop threads never read a scaffolded brief: firstmate pastes the status
-# protocol from .agents/skills/firstmate-codexapp/SKILL.md into the Desktop thread
-# instead. That prompt duplicates the contract above, so the language rule has to
-# hold on both copies or a Desktop worker is the one surface still free to report
-# in another language.
-test_codex_desktop_status_prompt_declares_english() {
-  local prompt
-  prompt="$ROOT/.agents/skills/firstmate-codexapp/SKILL.md"
-  assert_present "$prompt" "the Codex Desktop skill is missing"
-  assert_grep "Write every status line in English" "$prompt" \
-    "the Codex Desktop status prompt did not tell the worker which language to write status lines in"
-  assert_grep "whatever language you are working in" "$prompt" \
-    "the Codex Desktop status prompt did not cover a worker whose working language is not English"
-  pass "firstmate-codexapp: the Desktop status prompt requires English status lines"
-}
-
 # Scout and secondmate paths still scaffold well-formed briefs.
 test_scout_and_secondmate_scaffold() {
   local brief
@@ -831,5 +815,4 @@ test_secondmate_directory_paths_are_absolute_and_output_is_stable
 test_pause_verb_override_renders_all_brief_scaffolds
 test_scout_and_secondmate_load_decision_hold_policy
 test_status_lines_declare_english
-test_codex_desktop_status_prompt_declares_english
 test_scout_and_secondmate_scaffold

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -772,6 +772,22 @@ test_status_lines_declare_english() {
   pass "fm-brief.sh: every scaffold requires English status lines"
 }
 
+# Codex Desktop threads never read a scaffolded brief: firstmate pastes the status
+# protocol from .agents/skills/firstmate-codexapp/SKILL.md into the Desktop thread
+# instead. That prompt duplicates the contract above, so the language rule has to
+# hold on both copies or a Desktop worker is the one surface still free to report
+# in another language.
+test_codex_desktop_status_prompt_declares_english() {
+  local prompt
+  prompt="$ROOT/.agents/skills/firstmate-codexapp/SKILL.md"
+  assert_present "$prompt" "the Codex Desktop skill is missing"
+  assert_grep "Write every status line in English" "$prompt" \
+    "the Codex Desktop status prompt did not tell the worker which language to write status lines in"
+  assert_grep "whatever language you are working in" "$prompt" \
+    "the Codex Desktop status prompt did not cover a worker whose working language is not English"
+  pass "firstmate-codexapp: the Desktop status prompt requires English status lines"
+}
+
 # Scout and secondmate paths still scaffold well-formed briefs.
 test_scout_and_secondmate_scaffold() {
   local brief
@@ -815,4 +831,5 @@ test_secondmate_directory_paths_are_absolute_and_output_is_stable
 test_pause_verb_override_renders_all_brief_scaffolds
 test_scout_and_secondmate_load_decision_hold_policy
 test_status_lines_declare_english
+test_codex_desktop_status_prompt_declares_english
 test_scout_and_secondmate_scaffold

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -740,6 +740,38 @@ test_scout_and_secondmate_load_decision_hold_policy() {
   pass "fm-brief.sh: investigation and visual-review completions load the shared decision policy"
 }
 
+# Every scaffold's status protocol must name the language of the signal line.
+# Firstmate reads and acts on these lines, so they sit on the English side of the reader boundary.
+# Leaving the language unstated let workers whose working language was not English transliterate
+# the line into unaccented text instead, so the rule has to be stated in the scaffold itself.
+test_status_lines_declare_english() {
+  local home kind id brief
+  home="$TMP_ROOT/status-language-home"
+  mkdir -p "$home/data"
+
+  for kind in ship scout secondmate; do
+    id="brief-status-language-$kind"
+    case "$kind" in
+      ship)
+        FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" firstmate --mode no-mistakes >/dev/null 2>&1
+        ;;
+      scout)
+        FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" firstmate --scout >/dev/null 2>&1
+        ;;
+      secondmate)
+        FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" --secondmate --no-projects >/dev/null 2>&1
+        ;;
+    esac
+    brief="$home/data/$id/brief.md"
+    assert_present "$brief" "$kind brief was not scaffolded"
+    assert_grep "Write every status line in English" "$brief" \
+      "$kind brief did not tell the worker which language to write status lines in"
+    assert_grep "whatever language you are working in" "$brief" \
+      "$kind brief did not cover a worker whose working language is not English"
+  done
+  pass "fm-brief.sh: every scaffold requires English status lines"
+}
+
 # Scout and secondmate paths still scaffold well-formed briefs.
 test_scout_and_secondmate_scaffold() {
   local brief
@@ -782,4 +814,5 @@ test_secondmate_marked_request_reporting_contract
 test_secondmate_directory_paths_are_absolute_and_output_is_stable
 test_pause_verb_override_renders_all_brief_scaffolds
 test_scout_and_secondmate_load_decision_hold_policy
+test_status_lines_declare_english
 test_scout_and_secondmate_scaffold


### PR DESCRIPTION
## Intent

Every crewmate brief scaffold in bin/fm-brief.sh tells a worker to report progress by appending a status line to its status file, but never states which language that line is written in. A worker whose working language is not English fills that gap on its own, usually by transliterating, which makes the line hard for firstmate and other readers to parse. Make all three scaffolds - ship, scout, and second-mate - state explicitly that status lines are written in English, and cover it with a behavioral test in tests/fm-brief.test.sh that renders each scaffold by running bin/fm-brief.sh and asserts the directive is present in the generated brief. Keep the change additive: the state names, the append mechanics, and the pause-versus-blocked distinction stay unchanged. Keep the Codex Desktop status prompt documentation accurate under the new rule without asserting implementation-source bytes. Deliberately out of scope: the scout report and the second-mate answer document, whose language rule is a separate design question filed separately.

## What Changed

- All three crewmate brief scaffolds in `bin/fm-brief.sh` (ship, scout, second-mate) now add a line to the status protocol telling the worker to write every status line in English whatever language they are working in, because firstmate reads and acts on those lines; the header comment block records the same rule. State names, the `>> $STATUS_FILE` append mechanics, and the pause-versus-blocked distinction are untouched.
- `tests/fm-brief.test.sh` gains `test_status_lines_declare_english`, which renders each of the three scaffolds by invoking `bin/fm-brief.sh` (`--mode no-mistakes`, `--scout`, `--secondmate --no-projects`) and asserts the generated `brief.md` contains both the English directive and the clause covering a worker whose working language is not English; the test is registered in the run list.
- The Codex Desktop status instruction in `.agents/skills/firstmate-codexapp/SKILL.md` carries the same English requirement alongside the existing prefix rules.

## Risk Assessment

✅ Low: The change is purely additive prose inside three brief scaffolds plus one behavioral test that renders each scaffold through bin/fm-brief.sh, with no state names, control flow, parsing, or shell-expansion surface touched, and every required intent constraint is satisfied.

## Testing

I ran the targeted brief test file, which passes fully with the new behavioral test that renders each of the three scaffolds through bin/fm-brief.sh, and proved the regression by swapping in the base-commit scaffolder, watching the same test fail with the ship-brief message, and restoring the file to a clean worktree. To show the end-user experience I generated the ship, scout, and second-mate briefs twice under an identical FM_HOME - once with the base scaffolder, once with the target - and the diff of the text a worker reads contains only the three inserted directive blocks, with the state list, the echo-append mechanics, and the paused-versus-blocked sentence unchanged and the scout report and second-mate answer sections untouched. I also confirmed the directive lives inside the emitted Codex Desktop prompt block, that the source-byte assertion is gone from the test file, and that the two brief-consuming suites (task delivery and second-mate safety) still pass. No visual artifact applies: the end-user surface here is generated Markdown brief text handed to a worker agent in a terminal pane, so the rendered brief and its before/after diff are the faithful product-level evidence.

<details>
<summary>Evidence: Diff of the generated briefs a worker reads (base 4ad8cba vs target c3ec911, identical FM_HOME)</summary>

Source: [Diff of the generated briefs a worker reads (base 4ad8cba vs target c3ec911, identical FM_HOME)](https://github.com/jonathankv/firstmate/blob/4c238b26861f6d14ff623c7ebf3d2b5a92087632/.no-mistakes/evidence/fm/fm-status-line-language/generated-brief-diff.txt)

<code>===== ship brief =====&#10;4. Report status by appending one line:&#10;`echo &#34;{state}: {one short line}&#34; &gt;&gt; &#39;&lt;home&gt;/state/ship-demo.status&#39;`&#10;States: working, needs-decision, blocked, paused, done, failed.&#10;+ Write every status line in English, whatever language you are working in:&#10;+ firstmate reads these lines and acts on them.&#10;Each append wakes firstmate, so report sparingly: ...&#10;&#10;===== scout brief =====&#10;States: working, needs-decision, blocked, paused, done, failed.&#10;+ Write every status line in English, whatever language you are working in:&#10;+ firstmate reads these lines and acts on them.&#10;&#10;===== secondmate brief =====&#10;States: working, needs-decision, blocked, paused, done, failed.&#10;+Write every status line in English, whatever language you are working in: the main firstmate reads these lines and acts on them.&#10;Use `paused: {why}` (distinct from `blocked:`) only when your domain is deliberately idling ...&#10;&#10;(No other line differs in any of the three briefs.)</code>

```text
Generated crewmate briefs: base 4ad8cba vs target c3ec911 (same FM_HOME both runs)
Command per scaffold:
  FM_HOME=<home> bin/fm-brief.sh ship-demo firstmate --mode no-mistakes
  FM_HOME=<home> bin/fm-brief.sh scout-demo firstmate --scout
  FM_HOME=<home> bin/fm-brief.sh secondmate-demo --secondmate --no-projects

===== ship brief: diff of the text the worker reads =====
--- ~/.no-mistakes/evidence/01M1C6ZCWMA61KTFTMXFH7CJ8M/briefs-before/ship-brief.md	2026-08-31 22:32:53
+++ ~/.no-mistakes/evidence/01M1C6ZCWMA61KTFTMXFH7CJ8M/briefs-after/ship-brief.md	2026-08-31 22:32:53
@@ -25,6 +25,8 @@
 4. Report status by appending one line:
    `echo "{state}: {one short line}" >> '~/.no-mistakes/evidence/01M1C6ZCWMA61KTFTMXFH7CJ8M/fm-home/state/ship-demo.status'`
    States: working, needs-decision, blocked, paused, done, failed.
+   Write every status line in English, whatever language you are working in:
+   firstmate reads these lines and acts on them.
    Each append wakes firstmate, so report sparingly: only phase changes a supervisor
    would act on (setup done, bug reproduced, fix implemented, validation passed) and the
    needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;

===== scout brief: diff of the text the worker reads =====
--- ~/.no-mistakes/evidence/01M1C6ZCWMA61KTFTMXFH7CJ8M/briefs-before/scout-brief.md	2026-08-31 22:32:53
+++ ~/.no-mistakes/evidence/01M1C6ZCWMA61KTFTMXFH7CJ8M/briefs-after/scout-brief.md	2026-08-31 22:32:53
@@ -21,6 +21,8 @@
 4. Report status by appending one line:
    `echo "{state}: {one short line}" >> '~/.no-mistakes/evidence/01M1C6ZCWMA61KTFTMXFH7CJ8M/fm-home/state/scout-demo.status'`
    States: working, needs-decision, blocked, paused, done, failed.
+   Write every status line in English, whatever language you are working in:
+   firstmate reads these lines and acts on them.
    Each append wakes firstmate, so report sparingly: only phase changes a supervisor
    would act on and the needs-decision/blocked/paused/done/failed states. No step-by-step
    FYI progress lines; firstmate reads your pane for that.

===== secondmate brief: diff of the text the worker reads =====
--- ~/.no-mistakes/evidence/01M1C6ZCWMA61KTFTMXFH7CJ8M/briefs-before/secondmate-brief.md	2026-08-31 22:32:53
+++ ~/.no-mistakes/evidence/01M1C6ZCWMA61KTFTMXFH7CJ8M/briefs-after/secondmate-brief.md	2026-08-31 22:32:53
@@ -41,6 +41,7 @@
 Report only true captain-relevant outcomes or a declared external wait by appending one line:
    `echo "{state}: {one short line}" >> '~/.no-mistakes/evidence/01M1C6ZCWMA61KTFTMXFH7CJ8M/fm-home/state/secondmate-demo.status'`
 States: working, needs-decision, blocked, paused, done, failed.
+Write every status line in English, whatever language you are working in: the main firstmate reads these lines and acts on them.
 Use `paused: {why}` (distinct from `blocked:`) only when your domain is deliberately idling on a known external wait you expect to clear on its own; use `blocked:` when you are stuck and need firstmate to act.
 Use this only for material phase changes, a captain decision, a real blocker, a failure, work ready for review, or work you landed.
 Work you landed includes a merge you performed yourself under standing merge authority and one the captain merged on the forge: under that authority nothing is ever \"ready for review\", so a landed merge that goes unreported reaches the captain as silence.
```
</details>
<details>
<summary>Evidence: Regression proof: the new test against the base scaffolder</summary>

Source: [Regression proof: the new test against the base scaffolder](https://github.com/jonathankv/firstmate/blob/4c238b26861f6d14ff623c7ebf3d2b5a92087632/.no-mistakes/evidence/fm/fm-status-line-language/regression-before-fix.txt)

<code>$ bash bin/fm-test-run.sh tests/fm-brief.test.sh # with bin/fm-brief.sh from 4ad8cba&#10;not ok - ship brief did not tell the worker which language to write status lines in&#10;FM_TEST_END tests/fm-brief.test.sh exit=1&#10;FM_TEST_SUMMARY total=1 failed=1&#10;&#10;$ bash bin/fm-test-run.sh tests/fm-brief.test.sh # with the change in place&#10;ok - fm-brief.sh: every scaffold requires English status lines&#10;FM_TEST_END tests/fm-brief.test.sh exit=0</code>

```text
# Regression proof: new test run against the BASE scaffolder (bin/fm-brief.sh from 4ad8cba)
$ bash bin/fm-test-run.sh tests/fm-brief.test.sh
FM_TEST_BEGIN 2026-08-31T15:33:08Z tests/fm-brief.test.sh family=pure-contract-unit expected_gate_skip=none
<tmp>
not ok - ship brief did not tell the worker which language to write status lines in
FM_TEST_END 2026-08-31T15:33:10Z tests/fm-brief.test.sh exit=1 duration_ms=1810 gate_skip=false
FM_TEST_SUMMARY total=1 failed=1 skipped_gate=0 duration_ms=1894
FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=1 duration_ms=1810 failed=1
FM_TEST_SLOWEST rank=1 script=tests/fm-brief.test.sh duration_ms=1810
```
</details>
<details>
<summary>Evidence: Rendered ship brief handed to a worker (target commit)</summary>

Source: [Rendered ship brief handed to a worker (target commit)](https://github.com/jonathankv/firstmate/blob/4c238b26861f6d14ff623c7ebf3d2b5a92087632/.no-mistakes/evidence/fm/fm-status-line-language/briefs-after/ship-brief.md)

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text filled in above.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of firstmate, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/ship-demo`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '~/.no-mistakes/evidence/01M1C6ZCWMA61KTFTMXFH7CJ8M/fm-home/state/ship-demo.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Write every status line in English, whatever language you are working in:
   firstmate reads these lines and acts on them.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Firstmate instruction inbox
Firstmate steers you through durable message files in '~/.no-mistakes/evidence/01M1C6ZCWMA61KTFTMXFH7CJ8M/fm-home/state/ship-demo.inbox'.
When a terminal message says an instruction is waiting there - and at any natural checkpoint when you are unsure - list '~/.no-mistakes/evidence/01M1C6ZCWMA61KTFTMXFH7CJ8M/fm-home/state/ship-demo.inbox'/*.msg, read and act on each message in numeric order, then acknowledge each handled message by moving it: `mv '~/.no-mistakes/evidence/01M1C6ZCWMA61KTFTMXFH7CJ8M/fm-home/state/ship-demo.inbox'/NNN.msg '~/.no-mistakes/evidence/01M1C6ZCWMA61KTFTMXFH7CJ8M/fm-home/state/ship-demo.inbox'/handled/`.
The move IS the acknowledgement: without it firstmate rings again and eventually treats you as stuck. An empty or absent inbox needs no action.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `~/.no-mistakes/worktrees/38c446864270/01M1C6ZCWMA61KTFTMXFH7CJ8M/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `~/.no-mistakes/worktrees/38c446864270/01M1C6ZCWMA61KTFTMXFH7CJ8M/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=no-mistakes
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies `ask-user-authority` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- NEVER pass `--yes` (or `-y`) to `no-mistakes axi run` or `no-mistakes axi respond`. It is banned fleet-wide.
  It auto-resolves every gate including ask-user findings with no escalation, and answering your own ask-user finding is a hard rule violation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Rendered scout brief handed to a worker (target commit)</summary>

Source: [Rendered scout brief handed to a worker (target commit)](https://github.com/jonathankv/firstmate/blob/4c238b26861f6d14ff623c7ebf3d2b5a92087632/.no-mistakes/evidence/fm/fm-status-line-language/briefs-after/scout-brief.md)

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text filled in above.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of firstmate, at a detached HEAD on a clean default branch.
This is a SCOUT task: the deliverable is a written report, not a PR.
The worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
The report is the only thing that survives, so anything worth keeping must be in it.

# Rules
1. Never push to any remote and never open a PR.
2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '~/.no-mistakes/evidence/01M1C6ZCWMA61KTFTMXFH7CJ8M/fm-home/state/scout-demo.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Write every status line in English, whatever language you are working in:
   firstmate reads these lines and acts on them.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on and the needs-decision/blocked/paused/done/failed states. No step-by-step
   FYI progress lines; firstmate reads your pane for that.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset):
   firstmate then leaves your idle pane alone and rechecks it on a long cadence instead of
   treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Firstmate instruction inbox
Firstmate steers you through durable message files in '~/.no-mistakes/evidence/01M1C6ZCWMA61KTFTMXFH7CJ8M/fm-home/state/scout-demo.inbox'.
When a terminal message says an instruction is waiting there - and at any natural checkpoint when you are unsure - list '~/.no-mistakes/evidence/01M1C6ZCWMA61KTFTMXFH7CJ8M/fm-home/state/scout-demo.inbox'/*.msg, read and act on each message in numeric order, then acknowledge each handled message by moving it: `mv '~/.no-mistakes/evidence/01M1C6ZCWMA61KTFTMXFH7CJ8M/fm-home/state/scout-demo.inbox'/NNN.msg '~/.no-mistakes/evidence/01M1C6ZCWMA61KTFTMXFH7CJ8M/fm-home/state/scout-demo.inbox'/handled/`.
The move IS the acknowledgement: without it firstmate rings again and eventually treats you as stuck. An empty or absent inbox needs no action.

# Definition of done
Write your findings to `~/.no-mistakes/evidence/01M1C6ZCWMA61KTFTMXFH7CJ8M/fm-home/data/scout-demo/report.md`.
The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
If your deliverable is a visual artifact the captain will review and iterate on, you may host the Lavish review loop yourself (poll, revise, re-serve, staying alive) instead of handing it back to firstmate.
Before reporting done, read and follow `~/.no-mistakes/worktrees/38c446864270/01M1C6ZCWMA61KTFTMXFH7CJ8M/.agents/skills/captain-hold-lifecycle/SKILL.md` and pass its shared completion gate for the report and any visual review.
When the report is complete, append `done: {one-line conclusion}` to the status file and stop.
If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.
```
</details>
<details>
<summary>Evidence: Rendered second-mate charter handed to a worker (target commit)</summary>

Source: [Rendered second-mate charter handed to a worker (target commit)](https://github.com/jonathankv/firstmate/blob/4c238b26861f6d14ff623c7ebf3d2b5a92087632/.no-mistakes/evidence/fm/fm-status-line-language/briefs-after/secondmate-brief.md)

```text
You are a persistent second mate managed by the main firstmate. Work on your own; do not wait for a human.

# Charter
{TASK}

# Routing scope
{TASK}

# Project clones
None. This is a project-less domain: its subject is the firstmate repo this home lives in, so it needs no separate clones under `projects/`; its crews take pooled worktrees of that firstmate repo.

# Operating model
You are in an isolated firstmate home. The local `AGENTS.md` is your job description, and your local `data/`, `state/`, `config/`, and `projects/` dirs are yours to operate.
This domain has no separate project clones: its subject is the firstmate repo this home lives in, and its crews take pooled worktrees of that repo.
Delegate project work to your own crewmates with the normal firstmate lifecycle: brief, spawn, status, watcher, steer, teardown, and recovery.
Do not invent a second delegation system.
You do not generate your own work.
Act only on tasks the main firstmate routes to you.
Never start a survey, audit, or "find improvements" sweep on your own initiative; that is not your job and it is unwanted.

# Requests from the main firstmate
You are a firstmate in your own home, so an incoming message reaches you in your own chat.
You must distinguish who it is from, because the answer goes to a different place.
A request relayed to you by the main firstmate is tagged with a leading `[fm-from-firstmate]` marker followed by an invisible system separator; this marker is untypable, so a human never produces it.
When a message carries that marker, do the work, then respond via the STATUS/ESCALATION path below, never only in this chat: the main firstmate does not read your chat, so a chat-only reply is lost.
Marked requests also carry a privacy-safe `corr=<id>` token after the marker; include that exact token in your parent status reply (or in the status pointer to a detailed doc) so the parent can correlate the answer.
Optional helper: `bin/fm-secondmate-report.sh` can append a correlated status line for you, but a plain `echo` that includes the same `corr=<id>` is equally valid - do not depend on the helper being present.
For a terse result, a status line is the whole answer.
For a detailed answer (an investigation, a plan, an audit), write it to a doc under your home's `data/` and append a status line that points to that doc - the scout-report pattern - so the main firstmate is woken and can read it.
Before treating an investigation or visual review as complete, load `captain-hold-lifecycle` from this home's `.agents/skills/` and pass its shared completion gate.
A message with NO marker is the captain typing directly into your pane: treat it as authoritative captain intervention and stay conversational exactly as you would for any captain message; do not force it onto the status path.
A request arriving through the instruction inbox below follows the same marker and reply rules.

# Firstmate instruction inbox
Firstmate steers you through durable message files in '~/.no-mistakes/evidence/01M1C6ZCWMA61KTFTMXFH7CJ8M/fm-home/state/secondmate-demo.inbox'.
When a terminal message says an instruction is waiting there - and at any natural checkpoint when you are unsure - list '~/.no-mistakes/evidence/01M1C6ZCWMA61KTFTMXFH7CJ8M/fm-home/state/secondmate-demo.inbox'/*.msg, read and act on each message in numeric order, then acknowledge each handled message by moving it: `mv '~/.no-mistakes/evidence/01M1C6ZCWMA61KTFTMXFH7CJ8M/fm-home/state/secondmate-demo.inbox'/NNN.msg '~/.no-mistakes/evidence/01M1C6ZCWMA61KTFTMXFH7CJ8M/fm-home/state/secondmate-demo.inbox'/handled/`.
The move IS the acknowledgement: without it firstmate rings again and eventually treats you as stuck. An empty or absent inbox needs no action.

# Escalation to main firstmate
Handle routine work yourself.
Report only true captain-relevant outcomes or a declared external wait by appending one line:
   `echo "{state}: {one short line}" >> '~/.no-mistakes/evidence/01M1C6ZCWMA61KTFTMXFH7CJ8M/fm-home/state/secondmate-demo.status'`
States: working, needs-decision, blocked, paused, done, failed.
Write every status line in English, whatever language you are working in: the main firstmate reads these lines and acts on them.
Use `paused: {why}` (distinct from `blocked:`) only when your domain is deliberately idling on a known external wait you expect to clear on its own; use `blocked:` when you are stuck and need firstmate to act.
Use this only for material phase changes, a captain decision, a real blocker, a failure, work ready for review, or work you landed.
Work you landed includes a merge you performed yourself under standing merge authority and one the captain merged on the forge: under that authority nothing is ever \"ready for review\", so a landed merge that goes unreported reaches the captain as silence.
This is also how you return the answer to a marked from-firstmate request above.
A marked request requires one correlated answer after the work; it does not require a separate receipt or start acknowledgement.
Never append `working:` merely to acknowledge receipt or announce that a marked request has started.
When a routed-work phase has a supervisor-actionable material change worth reporting under the rule above, give that reported phase a stable key.
If its first reportable event is `working [key=<work-slug>]: {material phase}`, use the same key on its later `paused`, `done`, `failed`, `needs-decision`, or `blocked` event so the earlier working phase is superseded.
When a keyed phase ends without another reportable state, append `resolved [key=<work-slug>]: {why it is no longer active}`.
`resolved` separately closes an escalated decision or blocker, and only a `resolved` line carrying that decision's exact key closes it: a later `done` or `working` event never does, even when the answer is what started that work.
The main firstmate's answer normally writes that closing line at answer time; when a blocker or wait clears WITHOUT an answer from the main firstmate, append `resolved: {how it cleared}` yourself (keyed with `[key=<slug>]` if you opened it with one) as your domain resumes.
Routine internal supervision, heartbeats, retries, and crewmate churn stay inside your own home and must not touch that status file.

# Definition of done
You are persistent by default. Do not exit just because your queue is empty.
On startup and restart, run normal firstmate bootstrap and recovery through `bin/fm-session-start.sh` for your own home, but only to RECONCILE work that is already yours: in-flight crewmates, tracked backlog items, and durable watches recorded in this home.
When you have no assigned or in-flight work after that reconciliation, go idle and wait silently for the main firstmate to route you a task.
An empty queue is a healthy resting state, not a cue to invent work: never spawn a survey, audit, or any self-directed "find work" task on your own initiative.
If this charter cannot be carried out, append `blocked: {why}` or `failed: {why}` to the main status file and stop.
```
</details>
<details>
<summary>Evidence: Codex Desktop status-return prompt as pasted into a Desktop thread</summary>

Source: [Codex Desktop status-return prompt as pasted into a Desktop thread](https://github.com/jonathankv/firstmate/blob/4c238b26861f6d14ff623c7ebf3d2b5a92087632/.no-mistakes/evidence/fm/fm-status-line-language/codex-desktop-status-prompt.txt)

<code>Append supervisor-visible status lines to &lt;absolute-firstmate-home&gt;/state/&lt;task-id&gt;.status.&#10;Use only these prefixes for status changes: working:, needs-decision:, blocked:, paused:, done:, failed:.&#10;Write every status line in English, whatever language you are working in: firstmate reads these lines and acts on them.&#10;Use paused: only for a deliberate known external wait that should be rechecked later, never for a blocker that needs firstmate to act.&#10;Before doing substantive work, append &#34;working: Codex Desktop thread started&#34;.</code>

```text
# Codex Desktop status-return prompt, the text an operator pastes into a Desktop thread
# source: .agents/skills/firstmate-codexapp/SKILL.md, Status Return Channel section


`` `text
Append supervisor-visible status lines to <absolute-firstmate-home>/state/<task-id>.status.
Use only these prefixes for status changes: working:, needs-decision:, blocked:, paused:, done:, failed:.
Write every status line in English, whatever language you are working in: firstmate reads these lines and acts on them.
Use paused: only for a deliberate known external wait that should be rechecked later, never for a blocker that needs firstmate to act.
Before doing substantive work, append "working: Codex Desktop thread started".
`` `
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"c3ec911608b36a7c23ad8e9d791ee43aee1f3b50","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `tests/fm-brief.test.sh:769` - The second assertion is a strict substring-neighbour of the first: in every scaffold the directive renders as one physical line - bin/fm-brief.sh:265 in full, and bin/fm-brief.sh:350 / :428 wrapped so that &#34;Write every status line in English, whatever language you are working in:&#34; is line one - so grep -F on &#34;whatever language you are working in&#34; matches exactly the line the previous assert_grep already matched. It cannot fail independently, and its failure message (&#34;did not cover a worker whose working language is not English&#34;) describes coverage the check does not actually add. The half of the sentence that is not asserted anywhere is the rationale clause (&#34;firstmate reads these lines and acts on them&#34;). Either drop the second assertion or point it at that unasserted clause. No behavior is wrong; the test still fails correctly if the directive is removed from any scaffold.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash bin/fm-test-run.sh tests/fm-brief.test.sh` - all 22 checks pass, including the new `test_status_lines_declare_english`, which renders ship, scout, and second-mate briefs by invoking bin/fm-brief.sh and asserts on the generated brief</code>
- <code>Regression proof: temporarily replaced bin/fm-brief.sh with its base-commit version (`git show 4ad8cba:bin/fm-brief.sh`), re-ran `bash bin/fm-test-run.sh tests/fm-brief.test.sh` -&gt; `not ok - ship brief did not tell the worker which language to write status lines in`, then restored the file and confirmed a clean worktree</code>
- <code>Rendered all three scaffolds against base and target with an identical FM_HOME (`FM_HOME=&lt;home&gt; bin/fm-brief.sh ship-demo firstmate --mode no-mistakes`, `... scout-demo firstmate --scout`, `... secondmate-demo --secondmate --no-projects`) and diffed the generated brief.md pairs to show the change is purely additive</code>
- <code>`bash bin/fm-test-run.sh tests/fm-task-delivery.test.sh tests/fm-secondmate-safety.test.sh` - the two brief-rendering consumer suites still pass with the added lines</code>
- <code>Manual check that no test greps .agents/skills/firstmate-codexapp/SKILL.md any more (`grep -n &#34;codex_desktop_status_prompt\|SKILL.md&#34; tests/fm-brief.test.sh`), and that the directive sits inside the emitted ```text prompt block an operator pastes into a Codex Desktop thread</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
