### PR TITLE
chore: add .gitattributes to enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Normalize line endings so a Windows checkout or editor cannot introduce
+# CRLF into tracked text files.
+* text=auto eol=lf
+
+*.sh text eol=lf
+*.bash text eol=lf
+*.py text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.json text eol=lf
+*.toml text eol=lf


### PR DESCRIPTION
## Summary

The task brief reported ~140+ files under `bin/` plus ~24 elsewhere with CRLF line endings breaking bash execution (e.g. `env: $'bash\r': No such file or directory`). Investigating this isolated worktree found the committed tree at `HEAD` already contains zero CRLF bytes:

- `git grep -Il $'\r' HEAD -- .` returns no matches.
- `git cat-file -p HEAD:bin/fm-brief.sh` and spot checks of other scripts show LF-only content.
- No `core.autocrlf` is configured in this worktree.

So the CRLF corruption described in the primary checkout appears to be a local checkout-time artifact of that specific checkout (e.g. a local `core.autocrlf` setting or editor), not something present in the repository's committed history. There is nothing to normalize in this branch.

This PR adds a root `.gitattributes` enforcing LF line endings for tracked text files, so a future Windows checkout or misconfigured editor cannot silently reintroduce CRLF.

## Test plan

- [x] `git grep -Il $'\r' HEAD -- .` returns nothing (no CRLF in tracked content)
- [x] `bash bin/fm-brief.sh --help`, `bash bin/fm-spawn.sh --help`, `bash bin/fm-claude-stop-autoarm.sh --help` all exit 0
- [ ] Captain to confirm whether the primary checkout's CRLF issue is a local git/editor config problem there, since it isn't reproducible from a fresh clone/worktree