### PR TITLE
fix(tmux): refuse text dropped by composer

### DIFF
--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -1186,7 +1186,7 @@ EOF
 # fm_composer_submission_content_normalize: normalize selected composer text
 # and a literal payload alike, so terminal wrapping cannot obscure an observed
 # append. Structural furniture has already been removed by
-# fm_composer_extract_selected_content; every content character remains literal.
+# fm_composer_extract_selected_content; non-whitespace content remains literal.
 fm_composer_submission_content_normalize() {  # <text>
   local content=$1
   content=$(printf '%s' "$content" | fm_composer_strip_ansi)

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -1183,6 +1183,34 @@ EOF
   printf '%s\n' "$joined" | LC_ALL=C awk '{$1=$1; printf "%s", $0}'
 }
 
+# fm_composer_payload_tail_anchor: normalize the tail of text a terminal
+# composer may wrap across rows, preserving punctuation while removing ANSI,
+# Unicode whitespace, and the box-drawing furniture around selected content.
+# A bounded tail keeps a long payload verifiable when its first rows scroll
+# above the bounded composer capture.
+fm_composer_payload_tail_anchor() {  # <text>
+  local anchor=$1
+  anchor=$(printf '%s' "$anchor" | fm_composer_strip_ansi)
+  fm_composer_normalize_spaces_var anchor
+  anchor=${anchor//[$' \t\r\n\v\f']/}
+  anchor=${anchor//[─━│┃╭╮╰╯┌┐└┘├┤┬┴┼╔╗╚╝║═]/}
+  [ -n "$anchor" ] || return 1
+  if [ "${#anchor}" -gt 48 ]; then
+    anchor=${anchor: -48}
+  fi
+  printf '%s' "$anchor"
+}
+
+# fm_composer_content_has_payload_tail: return success only when the selected
+# composer's real content contains the text payload's normalized tail.
+fm_composer_content_has_payload_tail() {  # <selected-content> <text>
+  local content=$1 anchor
+  anchor=$(fm_composer_payload_tail_anchor "$2") || return 1
+  content=$(fm_composer_payload_tail_anchor "$content") || return 1
+  case "$content" in *"$anchor"*) return 0 ;; esac
+  return 1
+}
+
 fm_composer_classify_screen() {  # <caps> <screen> [cursor_row] [identity]
   local caps=$1 screen=$2 cy=${3:-} identity=${4:-}
   local styled=0 cursor=0 has_identity=0 kv plain

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -1183,32 +1183,29 @@ EOF
   printf '%s\n' "$joined" | LC_ALL=C awk '{$1=$1; printf "%s", $0}'
 }
 
-# fm_composer_payload_tail_anchor: normalize the tail of text a terminal
-# composer may wrap across rows, preserving punctuation while removing ANSI,
-# Unicode whitespace, and the box-drawing furniture around selected content.
-# A bounded tail keeps a long payload verifiable when its first rows scroll
-# above the bounded composer capture.
-fm_composer_payload_tail_anchor() {  # <text>
-  local anchor=$1
-  anchor=$(printf '%s' "$anchor" | fm_composer_strip_ansi)
-  fm_composer_normalize_spaces_var anchor
-  anchor=${anchor//[$' \t\r\n\v\f']/}
-  anchor=${anchor//[─━│┃╭╮╰╯┌┐└┘├┤┬┴┼╔╗╚╝║═]/}
-  [ -n "$anchor" ] || return 1
-  if [ "${#anchor}" -gt 48 ]; then
-    anchor=${anchor: -48}
-  fi
-  printf '%s' "$anchor"
+# fm_composer_submission_content_normalize: normalize selected composer text
+# and a literal payload alike, so terminal wrapping cannot obscure an observed
+# append. Structural furniture has already been removed by
+# fm_composer_extract_selected_content; every content character remains literal.
+fm_composer_submission_content_normalize() {  # <text>
+  local content=$1
+  content=$(printf '%s' "$content" | fm_composer_strip_ansi)
+  fm_composer_normalize_spaces_var content
+  content=${content//[$' \t\r\n\v\f']/}
+  [ -n "$content" ] || return 1
+  printf '%s' "$content"
 }
 
-# fm_composer_content_has_payload_tail: return success only when the selected
-# composer's real content contains the text payload's normalized tail.
-fm_composer_content_has_payload_tail() {  # <selected-content> <text>
-  local content=$1 anchor
-  anchor=$(fm_composer_payload_tail_anchor "$2") || return 1
-  content=$(fm_composer_payload_tail_anchor "$content") || return 1
-  case "$content" in *"$anchor"*) return 0 ;; esac
-  return 1
+# fm_composer_content_observed_append: return success only when the post-send
+# selected composer content equals its pre-send selection with the normalized
+# literal payload appended.
+fm_composer_content_observed_append() {  # <before> <after> <text>
+  local before=$1 after=$2 text=$3 expected
+  before=$(fm_composer_submission_content_normalize "$before") || before=
+  after=$(fm_composer_submission_content_normalize "$after") || return 1
+  text=$(fm_composer_submission_content_normalize "$text") || return 1
+  expected=$before$text
+  [ "$after" = "$expected" ]
 }
 
 fm_composer_classify_screen() {  # <caps> <screen> [cursor_row] [identity]

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -465,14 +465,15 @@ do_exit() {
   cmd=$(fm_control_exit_command "$HARNESS")
   # The submit verdict is NOT the postcondition here: a successful exit command
   # destroys the composer the verdict is read from, so a post-exit read can
-  # legitimately report anything. Only a hard transport failure aborts; the
-  # authoritative proof is the agent-state wait below. The retried Enter still
-  # matters, because a slash command opens a completion popup on some TUIs that
-  # swallows the first Enter.
+  # legitimately report anything. A hard transport failure or a refusal before
+  # Enter aborts; the authoritative proof is the agent-state wait below. The
+  # retried Enter still matters, because a slash command opens a completion
+  # popup on some TUIs that swallows the first Enter.
   verdict=$(fm_backend_send_text_submit "$BACKEND" "$T" "$cmd" "$EXIT_RETRIES" "$POLL" 1.2 "$LABEL") \
     || die "the exit command could not be sent to task $ID on $BACKEND"
-  [ "$verdict" != send-failed ] \
-    || die "the exit command could not be sent to task $ID on $BACKEND"
+  case "$verdict" in
+    send-failed|not-accepted) die "the exit command could not be sent to task $ID on $BACKEND" ;;
+  esac
   state=$(wait_agent_state "$EXIT_WAIT" dead) || {
     die "exit-delivered $ID interrupt=$interrupt_result exit-command=delivered agent-state=$state exit=unconfirmed; the agent did not stop within ${EXIT_WAIT}s"
   }

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -10,12 +10,12 @@
 # Key support is backend-specific: tmux/herdr support Escape, Enter, and C-c;
 # Orca currently supports Enter and C-c only, and rejects Escape.
 #
-# Text submission is verified: the line is typed ONCE, its payload tail must
-# appear in the accepting composer before Enter is sent, then Enter is retried
-# (Enter only, never retyped) until the target backend confirms a submit or
-# reports an inconclusive send. If the literal text is not accepted, or a
-# swallowed Enter is positively confirmed, fm-send exits NON-ZERO so the caller
-# knows the steer did not land instead of silently leaving an unsubmitted
+# Text submission is verified: the line is typed ONCE, its payload must visibly
+# appear as an append in the accepting composer before Enter is sent, then Enter
+# is retried (Enter only, never retyped) until the target backend confirms a
+# submit or reports an inconclusive send. If the literal text is not accepted,
+# or a swallowed Enter is positively confirmed, fm-send exits NON-ZERO so the
+# caller knows the steer did not land instead of silently leaving an unsubmitted
 # instruction.
 # Exit status contract: 0 = submit confirmed (or, for a remote secondmate
 # target, delivered with confirmation pending - see the remote paragraph);

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -10,11 +10,13 @@
 # Key support is backend-specific: tmux/herdr support Escape, Enter, and C-c;
 # Orca currently supports Enter and C-c only, and rejects Escape.
 #
-# Text submission is verified: the line is typed ONCE, then Enter is sent and
-# retried (Enter only, never retyped) until the target backend confirms a
-# submit or reports an inconclusive send. If a swallowed Enter is positively
-# confirmed, fm-send exits NON-ZERO so the caller knows the steer did not land
-# instead of silently leaving an unsubmitted instruction.
+# Text submission is verified: the line is typed ONCE, its payload tail must
+# appear in the accepting composer before Enter is sent, then Enter is retried
+# (Enter only, never retyped) until the target backend confirms a submit or
+# reports an inconclusive send. If the literal text is not accepted, or a
+# swallowed Enter is positively confirmed, fm-send exits NON-ZERO so the caller
+# knows the steer did not land instead of silently leaving an unsubmitted
+# instruction.
 # Exit status contract: 0 = submit confirmed (or, for a remote secondmate
 # target, delivered with confirmation pending - see the remote paragraph);
 # 3 = the text was typed into the live endpoint and Enter was sent, but the
@@ -640,6 +642,13 @@ else
       # (bin/fm-pending-reply-lib.sh).
       echo "fm-send: text delivered to $T but submission is unconfirmed (verdict=pending; tried $RESOLUTION_TRIED); do not retype or blindly resend - verify with fm-peek.sh, then re-send '--key Enter' only if the composer still holds the text" >&2
       exit 3
+      ;;
+    not-accepted)
+      if [ "$PENDING_REPLY_CREATED" = 1 ] && [ -n "$PENDING_REPLY_CORR" ]; then
+        fm_pending_reply_discard_undelivered "$STATE" "$PENDING_REPLY_CORR" || true
+      fi
+      echo "error: text not accepted into the composer at $T (harness=${TARGET_HARNESS:-unknown}; backend=$TARGET_BACKEND); no Enter was sent, so an interactive prompt was not answered. Inspect with fm-peek.sh before retrying." >&2
+      exit 1
       ;;
     *)
       if [ "$PENDING_REPLY_CREATED" = 1 ] && [ -n "$PENDING_REPLY_CORR" ]; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2828,7 +2828,7 @@ if [ "$HARNESS" = kimi ]; then
     kimi_spawn_fail "kimi brief pointer could not be submitted"
     exit 1
   }
-  if [ "$KIMI_SUBMIT_VERDICT" = send-failed ]; then
+  if [ "$KIMI_SUBMIT_VERDICT" = send-failed ] || [ "$KIMI_SUBMIT_VERDICT" = not-accepted ]; then
     kimi_spawn_fail "kimi brief pointer could not be submitted"
     exit 1
   fi

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -214,12 +214,20 @@ fm_pane_is_busy() {  # <target> [harness]
   [ "$(fm_pane_busy_state "$1" "${2:-}")" = busy ]
 }
 
+# fm_tmux_composer_content: extract real content from the selected tmux
+# composer, including a nonempty pre-existing draft.
+fm_tmux_composer_content() {  # <target>
+  local target=$1 pane
+  pane=$(fm_tmux_composer_capture "$target") || return 1
+  fm_composer_extract_selected_content "$(fm_tmux_composer_caps)" "$pane"
+}
+
 # fm_tmux_submit_payload_accepted: after the literal text is typed, prove that
-# the selected composer shows the payload's own tail before an Enter can reach
-# the pane. A modal dialog can discard printable text but treat Enter as its
-# default answer, so an absent payload must refuse without sending Enter.
-fm_tmux_submit_payload_accepted() {  # <target> <text>
-  local target=$1 text=$2 pane state content
+# the selected composer received an append to the exact selection captured
+# before typing. A modal dialog can discard printable text but treat Enter as
+# its default answer, so an unobserved append must refuse without Enter.
+fm_tmux_submit_payload_accepted() {  # <target> <before> <text>
+  local target=$1 before=$2 text=$3 pane state content
   pane=$(fm_tmux_composer_capture "$target") || return 1
   state=$(fm_tmux_composer_state "$target")
   case "$state" in
@@ -227,7 +235,7 @@ fm_tmux_submit_payload_accepted() {  # <target> <text>
     *) return 1 ;;
   esac
   content=$(fm_composer_extract_selected_content "$(fm_tmux_composer_caps)" "$pane") || return 1
-  fm_composer_content_has_payload_tail "$content" "$text"
+  fm_composer_content_observed_append "$before" "$content" "$text"
 }
 
 # fm_tmux_submit_core: type <text> into <target> ONCE, prove the selected
@@ -296,7 +304,8 @@ fm_tmux_submit_enter_core() {  # <target> <retries> <enter-sleep> [baseline-idle
 }
 
 fm_tmux_submit_core() {  # <target> <text> <retries> <enter-sleep> <settle>
-  local target=$1 text=$2 retries=$3 sleep_s=$4 settle=$5 baseline_idle='' baseline_state
+  local target=$1 text=$2 retries=$3 sleep_s=$4 settle=$5 baseline_idle='' baseline_state before
+  before=$(fm_tmux_composer_content "$target") || { printf 'not-accepted'; return 0; }
   # The turn-started baseline must predate our own typing: a pane already
   # busy before the text lands can turn "busy" for reasons unrelated to our
   # Enter, so only a clean idle-to-busy transition may confirm a submit.
@@ -304,7 +313,7 @@ fm_tmux_submit_core() {  # <target> <text> <retries> <enter-sleep> <settle>
   [ "$baseline_state" = idle ] && baseline_idle=1
   tmux send-keys -t "$target" -l "$text" 2>/dev/null || { printf 'send-failed'; return 0; }
   sleep "$settle"
-  if ! fm_tmux_submit_payload_accepted "$target" "$text"; then
+  if ! fm_tmux_submit_payload_accepted "$target" "$before" "$text"; then
     printf 'not-accepted'
     return 0
   fi

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -214,11 +214,28 @@ fm_pane_is_busy() {  # <target> [harness]
   [ "$(fm_pane_busy_state "$1" "${2:-}")" = busy ]
 }
 
-# fm_tmux_submit_core: type <text> into <target> ONCE, then submit with Enter,
-# verifying the composer cleared. Retries Enter ONLY — never retypes, because a
-# swallowed Enter leaves our text in the composer and retyping would duplicate
-# it. Echoes the final proof-carrying verdict on stdout so callers can require
-# exact `empty` before treating submission as confirmed.
+# fm_tmux_submit_payload_accepted: after the literal text is typed, prove that
+# the selected composer shows the payload's own tail before an Enter can reach
+# the pane. A modal dialog can discard printable text but treat Enter as its
+# default answer, so an absent payload must refuse without sending Enter.
+fm_tmux_submit_payload_accepted() {  # <target> <text>
+  local target=$1 text=$2 pane state content
+  pane=$(fm_tmux_composer_capture "$target") || return 1
+  state=$(fm_tmux_composer_state "$target")
+  case "$state" in
+    pending|pending-unproven) ;;
+    *) return 1 ;;
+  esac
+  content=$(fm_composer_extract_selected_content "$(fm_tmux_composer_caps)" "$pane") || return 1
+  fm_composer_content_has_payload_tail "$content" "$text"
+}
+
+# fm_tmux_submit_core: type <text> into <target> ONCE, prove the selected
+# composer accepted it, then submit with Enter while verifying the composer
+# cleared. Retries Enter ONLY — never retypes, because a swallowed Enter leaves
+# our text in the composer and retyping would duplicate it. Echoes the final
+# proof-carrying verdict on stdout so callers can require exact `empty` before
+# treating submission as confirmed.
 # Busy-queued Enter (opencode 1.18.4): the harness accepts Enter while mid-turn
 # and queues it for after the current turn, but keeps the typed text visible in
 # the composer. Once the Enter-retry budget is spent and a structurally proven
@@ -287,5 +304,9 @@ fm_tmux_submit_core() {  # <target> <text> <retries> <enter-sleep> <settle>
   [ "$baseline_state" = idle ] && baseline_idle=1
   tmux send-keys -t "$target" -l "$text" 2>/dev/null || { printf 'send-failed'; return 0; }
   sleep "$settle"
+  if ! fm_tmux_submit_payload_accepted "$target" "$text"; then
+    printf 'not-accepted'
+    return 0
+  fi
   fm_tmux_submit_enter_core "$target" "$retries" "$sleep_s" "$baseline_idle"
 }

--- a/bin/fm-tmux-lib.sh
+++ b/bin/fm-tmux-lib.sh
@@ -223,9 +223,9 @@ fm_tmux_composer_content() {  # <target>
 }
 
 # fm_tmux_submit_payload_accepted: after the literal text is typed, prove that
-# the selected composer received an append to the exact selection captured
-# before typing. A modal dialog can discard printable text but treat Enter as
-# its default answer, so an unobserved append must refuse without Enter.
+# the selected composer visibly received a normalized append to its previously
+# observed content. A modal dialog can discard printable text but treat Enter
+# as its default answer, so an unobserved append must refuse without Enter.
 fm_tmux_submit_payload_accepted() {  # <target> <before> <text>
   local target=$1 before=$2 text=$3 pane state content
   pane=$(fm_tmux_composer_capture "$target") || return 1
@@ -239,11 +239,11 @@ fm_tmux_submit_payload_accepted() {  # <target> <before> <text>
 }
 
 # fm_tmux_submit_core: type <text> into <target> ONCE, prove the selected
-# composer accepted it, then submit with Enter while verifying the composer
-# cleared. Retries Enter ONLY — never retypes, because a swallowed Enter leaves
-# our text in the composer and retyping would duplicate it. Echoes the final
-# proof-carrying verdict on stdout so callers can require exact `empty` before
-# treating submission as confirmed.
+# composer visibly accepted a normalized append of it, then submit with Enter
+# while verifying the composer cleared. Retries Enter ONLY — never retypes,
+# because a swallowed Enter leaves our text in the composer and retyping would
+# duplicate it. Echoes the final proof-carrying verdict on stdout so callers
+# can require exact `empty` before treating submission as confirmed.
 # Busy-queued Enter (opencode 1.18.4): the harness accepts Enter while mid-turn
 # and queues it for after the current turn, but keeps the typed text visible in
 # the composer. Once the Enter-retry budget is spent and a structurally proven

--- a/docs/tmux-backend.md
+++ b/docs/tmux-backend.md
@@ -82,7 +82,7 @@ The submit acknowledgement and away-mode supervisor-pane busy guard below still 
 The supervisor guard selects only the detected primary harness's signature rather than a global union of vendor patterns.
 
 `bin/fm-tmux-lib.sh` owns exact type-and-submit mechanics.
-It snapshots the selected composer content before typing and sends Enter only after a later selected-composer capture proves that the exact message was appended, including when a user draft was already present.
+It snapshots selected composer content before typing and sends Enter only after a later selected-composer capture proves the payload appears as an append, including when a user draft was already present.
 If the append cannot be proven, `fm-send.sh` refuses without pressing Enter, so an interactive prompt cannot receive its default answer; inspect with `fm-peek.sh` before retrying.
 It types a message once and retries Enter only until the composer clears.
 Only a proven empty composer is a positive delivery acknowledgement.

--- a/docs/tmux-backend.md
+++ b/docs/tmux-backend.md
@@ -82,6 +82,8 @@ The submit acknowledgement and away-mode supervisor-pane busy guard below still 
 The supervisor guard selects only the detected primary harness's signature rather than a global union of vendor patterns.
 
 `bin/fm-tmux-lib.sh` owns exact type-and-submit mechanics.
+It snapshots the selected composer content before typing and sends Enter only after a later selected-composer capture proves that the exact message was appended, including when a user draft was already present.
+If the append cannot be proven, `fm-send.sh` refuses without pressing Enter, so an interactive prompt cannot receive its default answer; inspect with `fm-peek.sh` before retrying.
 It types a message once and retries Enter only until the composer clears.
 Only a proven empty composer is a positive delivery acknowledgement.
 Text left in established structure remains `pending`, text in ambiguous structure remains unproven, and unreadable or unsafe state remains unknown.
@@ -108,6 +110,7 @@ tests/fm-kimi-harness.test.sh
 tests/fm-cursor-harness.test.sh
 tests/fm-muse-harness.test.sh
 tests/fm-tmux-submit-busy.test.sh
+tests/fm-send-strict.test.sh
 tests/fm-bootstrap.test.sh
 ```
 

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -630,7 +630,21 @@ make_send_fakebin() {  # <dir> -> echoes fakebin dir; logs every tmux call to $F
 set -u
 { printf 'tmux'; for a in "$@"; do printf '\x1f%s' "$a"; done; printf '\n'; } >> "${FM_TMUX_LOG:?}"
 case "${1:-}" in
-  send-keys) exit 0 ;;
+  send-keys)
+    literal=0; text= key=
+    args=("$@")
+    i=1
+    while [ "$i" -lt "${#args[@]}" ]; do
+      case "${args[$i]}" in
+        -l) literal=1; i=$((i + 1)); text=${args[$i]:-} ;;
+        Enter) key=Enter ;;
+      esac
+      i=$((i + 1))
+    done
+    typed="$FM_TMUX_LOG.typed"
+    if [ "$literal" = 1 ]; then printf '%s' "$text" > "$typed"; fi
+    [ "$key" != Enter ] || rm -f "$typed"
+    exit 0 ;;
   display-message)
     for a in "$@"; do case "$a" in *cursor_y*) printf '1\n'; exit 0 ;; esac; done
     printf 'fakepane\n'; exit 0 ;;
@@ -643,7 +657,10 @@ case "${1:-}" in
         *) shift ;;
       esac
     done
-    if [ "$start" = 1 ] && [ "$end" = 1 ]; then
+    typed="$FM_TMUX_LOG.typed"
+    if [ -f "$typed" ]; then
+      printf '\n❯ %s\n\n' "$(cat "$typed")"
+    elif [ "$start" = 1 ] && [ "$end" = 1 ]; then
       printf '│    │\n'
     else
       printf '╭────╮\n│    │\n╰────╯\n'

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -72,8 +72,11 @@ case "${1:-}" in
       printf '%s\n' "$payload" >> "$D/literal"
       case "$payload" in
         /exit|/quit)
-          printf 'zsh' > "$D/command"
-          [ -z "${FM_FAKE_EXIT_TRANSPORT_FAIL_AFTER_STOP:-}" ] || exit 1
+          if [ -n "${FM_FAKE_EXIT_TRANSPORT_FAIL_AFTER_STOP:-}" ]; then
+            printf 'zsh' > "$D/command"
+            exit 1
+          fi
+          printf '%s' "$payload" > "$D/typed"
           ;;
         *'encode launch-brief'*)
           cat "$D/becomes" > "$D/command"
@@ -82,6 +85,13 @@ case "${1:-}" in
       esac
     else
       printf '%s\n' "$payload" >> "$D/keys"
+      if [ "$payload" = Enter ] && [ -f "$D/typed" ]; then
+        typed=$(cat "$D/typed")
+        case "$typed" in
+          /exit|/quit) printf 'zsh' > "$D/command" ;;
+        esac
+        rm -f "$D/typed"
+      fi
       case "$payload" in
         'export GOTMPDIR='*)
           if [ -n "${FM_FAKE_TRACE_PREPARE:-}" ]; then
@@ -109,7 +119,13 @@ case "${1:-}" in
       esac
     done
     printf 'fakepane\n'; exit 0 ;;
-  capture-pane) printf '╭────╮\n│    │\n╰────╯\n'; exit 0 ;;
+  capture-pane)
+    if [ -f "$D/typed" ]; then
+      printf '\n❯ %s\n\n' "$(cat "$D/typed")"
+    else
+      printf '\n❯ \n\n'
+    fi
+    exit 0 ;;
   list-windows) [ -f "$D/windows" ] && cat "$D/windows"; exit 0 ;;
 esac
 exit 0

--- a/tests/fm-control.test.sh
+++ b/tests/fm-control.test.sh
@@ -93,15 +93,27 @@ case "${1:-}" in
     payload=${1:-}
     if [ "$literal" = 1 ]; then
       printf '%s\n' "$payload" >> "$D/literal"
-      if [ -z "${FM_FAKE_NEVER_DIES:-}" ] \
+      if [ -n "${FM_FAKE_EXIT_TRANSPORT_FAIL_AFTER_STOP:-}" ] \
          && { [ "$payload" = /exit ] || [ "$payload" = /quit ]; }; then
         printf 'zsh' > "$D/command"
+        exit 1
+      fi
+      if [ "${FM_FAKE_DROP_LITERAL:-0}" != 1 ]; then
+        printf '%s' "$payload" > "$D/typed"
       fi
       case "$payload" in
         *'encode launch-brief'*) cat "$D/becomes" > "$D/command" ;;
       esac
     else
       printf '%s\n' "$payload" >> "$D/keys"
+      if [ "$payload" = Enter ] && [ -f "$D/typed" ]; then
+        typed=$(cat "$D/typed")
+        if [ -z "${FM_FAKE_NEVER_DIES:-}" ] \
+           && { [ "$typed" = /exit ] || [ "$typed" = /quit ]; }; then
+          printf 'zsh' > "$D/command"
+        fi
+        rm -f "$D/typed"
+      fi
       if [ -n "${FM_FAKE_INTERRUPT_STOPS_AGENT:-}" ] \
          && { [ "$payload" = Escape ] || [ "$payload" = C-c ]; }; then
         printf 'zsh' > "$D/command"
@@ -125,7 +137,13 @@ case "${1:-}" in
     done
     printf 'fakepane\n'; exit 0 ;;
   capture-pane)
-    if [ -f "$D/pane" ]; then cat "$D/pane"; else printf '╭────╮\n│    │\n╰────╯\n'; fi
+    if [ -f "$D/pane" ]; then
+      cat "$D/pane"
+    elif [ -f "$D/typed" ]; then
+      printf '\n❯ %s\n\n' "$(cat "$D/typed")"
+    else
+      printf '\n❯ %s\n\n' "${FM_FAKE_STALE_COMPOSER:-}"
+    fi
     exit 0 ;;
   list-windows)
     if [ -f "$D/windows" ]; then cat "$D/windows"; fi
@@ -197,6 +215,8 @@ run_control() {
     FM_FAKE_MUSE_LOG="${FM_FAKE_MUSE_LOG:-}" \
     FM_FAKE_MUSE_DISAPPEAR_BEFORE_ACK="${FM_FAKE_MUSE_DISAPPEAR_BEFORE_ACK:-}" \
     FM_FAKE_INTERRUPT_STOPS_AGENT="${FM_FAKE_INTERRUPT_STOPS_AGENT:-}" \
+    FM_FAKE_DROP_LITERAL="${FM_FAKE_DROP_LITERAL:-}" \
+    FM_FAKE_STALE_COMPOSER="${FM_FAKE_STALE_COMPOSER:-}" \
     "$CONTROL" "$@" 2>&1
 }
 
@@ -800,6 +820,20 @@ test_agent_that_does_not_stop_fails_closed() {
   pass "fm-control exit: a stubborn agent reports delivered input and an unconfirmed exit"
 }
 
+test_exit_refuses_a_not_accepted_literal_without_reporting_delivery() {
+  local dir out rc
+  dir=$(new_case not-accepted-exit)
+  add_task "$dir" t1 claude
+  alive_as "$dir" claude
+  out=$(FM_FAKE_DROP_LITERAL=1 FM_FAKE_STALE_COMPOSER=/exit run_control "$dir" t1 exit); rc=$?
+  expect_code 1 "$rc" "an exit literal refused by the composer must fail closed"$'\n'"$out"
+  assert_contains "$out" "exit command could not be sent" "the refusal should be reported as an undelivered lifecycle command"
+  assert_not_contains "$out" "exit-command=delivered" "a not-accepted lifecycle command must not be reported as delivered"
+  [ "$(cat "$dir/fake/command")" = claude ] || fail "a refused literal must not stop the agent"
+  assert_not_contains "$(cat "$dir/fake/keys")" "Enter" "a refused lifecycle literal must not press Enter"
+  pass "fm-control exit: a not-accepted literal fails before delivery confirmation"
+}
+
 test_grok_interrupt_without_acknowledgement_reports_unconfirmed() {
   local dir out rc
   dir=$(new_case nosettle)
@@ -901,6 +935,7 @@ test_muse_interrupt_confirms_adapter_acknowledgement
 test_interrupt_revalidates_agent_after_acknowledgement_wait
 test_exit_accepts_agent_stopped_by_busy_interrupt
 test_agent_that_does_not_stop_fails_closed
+test_exit_refuses_a_not_accepted_literal_without_reporting_delivery
 test_grok_interrupt_without_acknowledgement_reports_unconfirmed
 test_grok_idle_footer_does_not_confirm_cancellation
 test_secondmate_control_command_carries_no_marker

--- a/tests/fm-send-popup-settle.test.sh
+++ b/tests/fm-send-popup-settle.test.sh
@@ -48,11 +48,26 @@ make_stubs() {  # <dir> -> echoes fakebin dir
 #!/usr/bin/env bash
 set -u
 case "${1:-}" in
-  send-keys) exit 0 ;;
+  send-keys)
+    shift; literal=0; text= key=
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        -t) shift 2 ;;
+        -l) literal=1; shift; text=${1:-}; shift ;;
+        *) key=$1; shift ;;
+      esac
+    done
+    typed="$FM_SLEEP_LOG.typed"
+    if [ "$literal" = 1 ]; then printf '%s' "$text" > "$typed"; fi
+    [ "$key" != Enter ] || rm -f "$typed"
+    exit 0 ;;
   display-message)
     for a in "$@"; do case "$a" in *cursor_y*) printf '1\n'; exit 0 ;; esac; done
     printf 'fakepane\n'; exit 0 ;;
-  capture-pane) printf '╭────╮\n│    │\n╰────╯\n'; exit 0 ;;
+  capture-pane)
+    typed="$FM_SLEEP_LOG.typed"
+    if [ -f "$typed" ]; then printf '\n❯ %s\n\n' "$(cat "$typed")"; else printf '╭────╮\n│    │\n╰────╯\n'; fi
+    exit 0 ;;
   list-windows) exit 0 ;;
 esac
 exit 0

--- a/tests/fm-send-remote-delivery.test.sh
+++ b/tests/fm-send-remote-delivery.test.sh
@@ -53,23 +53,28 @@ case "${1:-}" in
   send-keys)
     shift
     literal=0
+    text=
+    key=
     while [ $# -gt 0 ]; do
       case "$1" in
         -t) shift 2 ;;
-        -l) literal=1; shift ;;
-        *) break ;;
+        -l) literal=1; shift; text=${1:-}; shift ;;
+        *) key=$1; break ;;
       esac
     done
     if [ "$literal" = 1 ]; then
-      printf '%s' "${1:-}" >> "$FM_SEND_LOG"
+      printf '%s' "$text" >> "$FM_SEND_LOG"
+      printf '%s' "$text" > "$FM_SEND_LOG.typed"
+    elif [ "$key" = Enter ] && [ "${FM_FAKE_TMUX_PENDING:-0}" != 1 ]; then
+      rm -f "$FM_SEND_LOG.typed"
     fi
     exit 0 ;;
   display-message)
     for a in "$@"; do case "$a" in *cursor_y*) printf '1\n'; exit 0 ;; esac; done
     printf 'fakepane\n'; exit 0 ;;
   capture-pane)
-    if [ "${FM_FAKE_TMUX_PENDING:-0}" = 1 ]; then
-      printf '╭────────────╮\n│ > steer    │\n╰────────────╯\n'
+    if [ -f "$FM_SEND_LOG.typed" ]; then
+      printf '\n❯ %s\n\n' "$(cat "$FM_SEND_LOG.typed")"
     else
       printf '╭────╮\n│    │\n╰────╯\n'
     fi

--- a/tests/fm-send-resolve-key.test.sh
+++ b/tests/fm-send-resolve-key.test.sh
@@ -48,21 +48,28 @@ case "${1:-}" in
     [ "${FM_FAKE_TMUX_SEND_FAIL:-0}" = 1 ] && exit 1
     shift
     literal=0
+    text=
+    key=
     while [ $# -gt 0 ]; do
       case "$1" in
         -t) shift 2 ;;
-        -l) literal=1; shift ;;
-        *) break ;;
+        -l) literal=1; shift; text=${1:-}; shift ;;
+        *) key=$1; break ;;
       esac
     done
     if [ "$literal" = 1 ]; then
-      printf '%s' "${1:-}" >> "$FM_SEND_LOG"
+      printf '%s' "$text" >> "$FM_SEND_LOG"
+      printf '%s' "$text" > "$FM_SEND_LOG.typed"
+    elif [ "$key" = Enter ]; then
+      rm -f "$FM_SEND_LOG.typed"
     fi
     exit 0 ;;
   display-message)
     for a in "$@"; do case "$a" in *cursor_y*) printf '1\n'; exit 0 ;; esac; done
     printf 'fakepane\n'; exit 0 ;;
-  capture-pane) printf '╭────╮\n│    │\n╰────╯\n'; exit 0 ;;
+  capture-pane)
+    if [ -f "$FM_SEND_LOG.typed" ]; then printf '\n❯ %s\n\n' "$(cat "$FM_SEND_LOG.typed")"; else printf '╭────╮\n│    │\n╰────╯\n'; fi
+    exit 0 ;;
   list-windows) exit 0 ;;
 esac
 exit 0

--- a/tests/fm-send-settle.test.sh
+++ b/tests/fm-send-settle.test.sh
@@ -36,11 +36,26 @@ make_stubs() {  # <dir> -> echoes fakebin dir
 #!/usr/bin/env bash
 set -u
 case "${1:-}" in
-  send-keys) exit 0 ;;
+  send-keys)
+    shift; literal=0; text= key=
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        -t) shift 2 ;;
+        -l) literal=1; shift; text=${1:-}; shift ;;
+        *) key=$1; shift ;;
+      esac
+    done
+    typed="$FM_SLEEP_LOG.typed"
+    if [ "$literal" = 1 ]; then printf '%s' "$text" > "$typed"; fi
+    [ "$key" != Enter ] || rm -f "$typed"
+    exit 0 ;;
   display-message)
     for a in "$@"; do case "$a" in *cursor_y*) printf '1\n'; exit 0 ;; esac; done
     printf 'fakepane\n'; exit 0 ;;
-  capture-pane) printf '╭────╮\n│    │\n╰────╯\n'; exit 0 ;;
+  capture-pane)
+    typed="$FM_SLEEP_LOG.typed"
+    if [ -f "$typed" ]; then printf '\n❯ %s\n\n' "$(cat "$typed")"; else printf '╭────╮\n│    │\n╰────╯\n'; fi
+    exit 0 ;;
   list-windows) exit 0 ;;
 esac
 exit 0

--- a/tests/fm-send-strict.test.sh
+++ b/tests/fm-send-strict.test.sh
@@ -33,6 +33,12 @@ case "${1:-}" in
       esac
     done
     printf 'send-keys target=%s literal=%s arg=%s\n' "$target" "$literal" "${1:-}" >> "$FM_TMUX_LOG"
+    typed=${FM_FAKE_TMUX_TYPED:-"$FM_TMUX_LOG.typed"}
+    if [ "$literal" = 1 ] && [ "${FM_FAKE_TMUX_DROP_LITERAL:-0}" != 1 ]; then
+      printf '%s' "${1:-}" > "$typed"
+    elif [ "$literal" = 0 ] && [ "${1:-}" = Enter ]; then
+      rm -f "$typed"
+    fi
     # FM_FAKE_TMUX_SEND_KEY_FAIL names one key whose delivery fails, so the
     # --key exit contract can be driven both ways from the same stub.
     if [ "$literal" = 0 ] && [ -n "${FM_FAKE_TMUX_SEND_KEY_FAIL:-}" ] \
@@ -57,7 +63,12 @@ case "${1:-}" in
     printf '%%1\n'
     exit 0 ;;
   capture-pane)
-    printf '╭────╮\n│    │\n╰────╯\n'
+    typed=${FM_FAKE_TMUX_TYPED:-"$FM_TMUX_LOG.typed"}
+    if [ -f "$typed" ]; then
+      printf '\n❯ %s\n\n' "$(cat "$typed")"
+    else
+      printf '\n❯ \n\n'
+    fi
     exit 0 ;;
   list-windows)
     printf 'foreign:%s\n' "${FM_FAKE_TMUX_WINDOW:-fm-lost}"
@@ -197,6 +208,23 @@ test_healthy_fm_id_send_still_works() {
   pass "fm-send strict: healthy fm-<id> sends still type once and submit"
 }
 
+test_dropped_literal_refuses_without_confirming_the_prompt() {
+  local dir fb home err log rc got
+  dir="$TMP_ROOT/dropped-literal"; mkdir -p "$dir"
+  fb=$(make_stubs "$dir"); home=$(setup_home droppedliteral); err="$dir/send.err"; log="$dir/tmux.log"; : > "$log"
+  fm_write_meta "$home/state/lane-prompt.meta" "window=sess:fm-lane-prompt" "kind=ship" "harness=claude"
+
+  PATH="$fb:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$home" FM_TMUX_LOG="$log" FM_SEND_SETTLE=0 \
+    FM_FAKE_TMUX_DROP_LITERAL=1 \
+    "$SEND" lane-prompt "continue with the requested work" >/dev/null 2>"$err"; rc=$?
+  [ "$rc" -ne 0 ] || fail "a literal ignored by an interactive prompt reported a confirmed send"
+  got=$(cat "$log")
+  assert_contains "$got" "target=sess:fm-lane-prompt literal=1 arg=continue with the requested work" "the prompt regression did not attempt the literal text"
+  assert_not_contains "$got" "target=sess:fm-lane-prompt literal=0 arg=Enter" "a rejected literal must not press Enter and answer the prompt"
+  assert_contains "$(cat "$err")" "not accepted into the composer" "the prompt refusal must name the failed composer acceptance"
+  pass "fm-send strict: a prompt that drops literal text refuses before Enter"
+}
+
 # A --key send is how firstmate interrupts a worker, so its exit status is the
 # only signal that the interrupt actually landed.
 # Reporting success for a key that was never delivered would leave supervision
@@ -233,3 +261,4 @@ test_prefixless_herdr_pane_id_fails
 test_unmatched_single_colon_target_must_exist
 test_fm_prefixed_herdr_session_is_an_explicit_target
 test_healthy_fm_id_send_still_works
+test_dropped_literal_refuses_without_confirming_the_prompt

--- a/tests/fm-send-strict.test.sh
+++ b/tests/fm-send-strict.test.sh
@@ -67,7 +67,7 @@ case "${1:-}" in
     if [ -f "$typed" ]; then
       printf '\n❯ %s\n\n' "$(cat "$typed")"
     else
-      printf '\n❯ \n\n'
+      printf '\n❯ %s\n\n' "${FM_FAKE_TMUX_STALE_COMPOSER:-}"
     fi
     exit 0 ;;
   list-windows)
@@ -225,6 +225,40 @@ test_dropped_literal_refuses_without_confirming_the_prompt() {
   pass "fm-send strict: a prompt that drops literal text refuses before Enter"
 }
 
+test_stale_matching_draft_cannot_prove_a_dropped_literal_landed() {
+  local dir fb home err log rc message got
+  dir="$TMP_ROOT/stale-draft"; mkdir -p "$dir"
+  fb=$(make_stubs "$dir"); home=$(setup_home staledraft); err="$dir/send.err"; log="$dir/tmux.log"; : > "$log"
+  message="continue with the requested work"
+  fm_write_meta "$home/state/lane-prompt.meta" "window=sess:fm-lane-prompt" "kind=ship" "harness=claude"
+
+  PATH="$fb:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$home" FM_TMUX_LOG="$log" FM_SEND_SETTLE=0 \
+    FM_FAKE_TMUX_DROP_LITERAL=1 FM_FAKE_TMUX_STALE_COMPOSER="$message" \
+    "$SEND" lane-prompt "$message" >/dev/null 2>"$err"; rc=$?
+  [ "$rc" -ne 0 ] || fail "a stale draft matching dropped text reported a confirmed send"
+  got=$(cat "$log")
+  assert_contains "$got" "target=sess:fm-lane-prompt literal=1 arg=$message" "the stale-draft regression did not attempt the literal text"
+  assert_not_contains "$got" "target=sess:fm-lane-prompt literal=0 arg=Enter" "a stale matching draft must not prove the literal landed or press Enter"
+  assert_contains "$(cat "$err")" "not accepted into the composer" "the stale-draft refusal must name failed composer acceptance"
+  pass "fm-send strict: a stale matching draft cannot prove a dropped literal landed"
+}
+
+test_box_drawing_literal_submits_normally() {
+  local dir fb home err log rc message got
+  dir="$TMP_ROOT/box-drawing"; mkdir -p "$dir"
+  fb=$(make_stubs "$dir"); home=$(setup_home boxdrawing); err="$dir/send.err"; log="$dir/tmux.log"; : > "$log"
+  message='────'
+  fm_write_meta "$home/state/lane-box.meta" "window=sess:fm-lane-box" "kind=ship" "harness=claude"
+
+  PATH="$fb:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$home" FM_TMUX_LOG="$log" FM_SEND_SETTLE=0 \
+    "$SEND" lane-box "$message" >/dev/null 2>"$err"; rc=$?
+  expect_code 0 "$rc" "a box-drawing literal accepted by the composer should submit"$'\n'"$(cat "$err")"
+  got=$(cat "$log")
+  assert_contains "$got" "target=sess:fm-lane-box literal=1 arg=$message" "the box-drawing literal was not typed"
+  assert_contains "$got" "target=sess:fm-lane-box literal=0 arg=Enter" "an accepted box-drawing literal must receive Enter"
+  pass "fm-send strict: a box-drawing-only literal submits after composer acceptance"
+}
+
 # A --key send is how firstmate interrupts a worker, so its exit status is the
 # only signal that the interrupt actually landed.
 # Reporting success for a key that was never delivered would leave supervision
@@ -262,3 +296,5 @@ test_unmatched_single_colon_target_must_exist
 test_fm_prefixed_herdr_session_is_an_explicit_target
 test_healthy_fm_id_send_still_works
 test_dropped_literal_refuses_without_confirming_the_prompt
+test_stale_matching_draft_cannot_prove_a_dropped_literal_landed
+test_box_drawing_literal_submits_normally

--- a/tests/fm-tmux-submit-busy.test.sh
+++ b/tests/fm-tmux-submit-busy.test.sh
@@ -42,10 +42,18 @@ case "${1:-}" in
     fi
     cat "$COMPOSER" 2>/dev/null; exit 0 ;;
   send-keys)
-    shift; is_enter=0
+    shift; is_enter=0; literal=0; text=
     while [ "$#" -gt 0 ]; do
-      case "$1" in -t) shift ;; -l) ;; Enter) is_enter=1 ;; esac; shift
+      case "$1" in
+        -t) shift 2; continue ;;
+        -l) literal=1; shift; text=${1:-}; shift; continue ;;
+        Enter) is_enter=1; shift; continue ;;
+        *) shift ;;
+      esac
     done
+    if [ "$literal" = 1 ] && [ "${FM_FAKE_ACCEPT_LITERAL:-0}" = 1 ]; then
+      printf '\n❯ %s\n\n' "$text" > "$COMPOSER"
+    fi
     if [ "$is_enter" = 1 ]; then
       [ -z "${FM_FAKE_SENT:-}" ] || printf 'Enter\n' >> "$FM_FAKE_SENT"
       if [ -n "${FM_FAKE_SWALLOW:-}" ] && [ -f "$FM_FAKE_SWALLOW" ]; then
@@ -202,11 +210,46 @@ test_failed_baseline_capture_keeps_busy_unknown_unconfirmed() {
     FM_FAKE_CAPTURE_COUNT="$dir/captures" FM_FAKE_FAIL_FIRST_CAPTURE=1 \
     FM_FAKE_SWALLOW="$dir/.swallow" FM_FAKE_PERSIST_SWALLOW=1 FM_FAKE_APPEND_BUSY=1 \
     fm_tmux_submit_core "win" "fix" 3 0.05 0.05 > "$vfile" 2>/dev/null
-  [ "$(cat "$vfile")" = unknown ] \
-    || fail "a failed idle-baseline capture must not let a later busy footer confirm delivery, got '$(cat "$vfile")'"
-  grep -q 'Working' "$composer" \
-    || fail "failed-baseline regression did not render the post-Enter busy footer"
-  pass "fm_tmux_submit_core: failed baseline capture disables busy unknown conversion"
+  [ "$(cat "$vfile")" = not-accepted ] \
+    || fail "a failed baseline without a visible payload must refuse before Enter, got '$(cat "$vfile")'"
+  ! grep -q 'Working' "$composer" \
+    || fail "a failed payload proof must not reach the Enter/busy-confirmation path"
+  pass "fm_tmux_submit_core: a failed baseline without payload proof refuses before Enter"
+}
+
+test_visible_literal_submits_normally() {
+  local dir fakebin composer sent vfile
+  dir="$TMP_ROOT/visible-literal"
+  fakebin=$(make_submit_mock "$dir")
+  composer="$dir/composer"
+  sent="$dir/sent.log"
+  vfile="$dir/verdict"
+  printf '\n❯ \n\n' > "$composer"
+  : > "$sent"
+  PATH="$fakebin:$PATH" FM_FAKE_COMPOSER="$composer" FM_FAKE_SENT="$sent" FM_FAKE_ACCEPT_LITERAL=1 \
+    fm_tmux_submit_core "win" "continue with the requested work" 3 0.05 0.05 > "$vfile" 2>/dev/null
+  [ "$(cat "$vfile")" = empty ] \
+    || fail "a visible literal must still submit normally, got '$(cat "$vfile")'"
+  [ "$(grep -c '^Enter$' "$sent" 2>/dev/null || true)" -eq 1 ] \
+    || fail "a visible literal must receive one Enter"
+  pass "fm_tmux_submit_core: visible literal text submits normally"
+}
+
+test_dropped_literal_refuses_before_enter() {
+  local dir fakebin composer sent vfile
+  dir="$TMP_ROOT/dropped-literal"
+  fakebin=$(make_submit_mock "$dir")
+  composer="$dir/composer"
+  sent="$dir/sent.log"
+  vfile="$dir/verdict"
+  printf 'Choose an action:\n1. Stop, do not act\n2. Continue\nPress Enter to confirm\n' > "$composer"
+  : > "$sent"
+  PATH="$fakebin:$PATH" FM_FAKE_COMPOSER="$composer" FM_FAKE_SENT="$sent" \
+    fm_tmux_submit_core "win" "continue with the requested work" 3 0.05 0.05 > "$vfile" 2>/dev/null
+  [ "$(cat "$vfile")" = not-accepted ] \
+    || fail "a prompt that drops literal text must refuse before Enter, got '$(cat "$vfile")'"
+  [ ! -s "$sent" ] || fail "a prompt that drops literal text still received Enter"$'\n'"$(cat "$sent")"
+  pass "fm_tmux_submit_core: dropped literal text refuses before Enter"
 }
 
 test_busy_pane_ambiguous_pending_retries_without_conversion() {
@@ -335,6 +378,8 @@ test_busy_pane_composer_clears_first_try
 test_idle_pane_composer_clears_first_try
 test_busy_pane_unknown_stays_unknown
 test_failed_baseline_capture_keeps_busy_unknown_unconfirmed
+test_visible_literal_submits_normally
+test_dropped_literal_refuses_before_enter
 test_busy_pane_ambiguous_pending_retries_without_conversion
 test_unrecognized_state_skips_busy_conversion
 test_claude_busy_signature_uses_real_capture_shapes


### PR DESCRIPTION
## Intent

Diagnose and fix the captain-reported pre-existing tmux-related failure in Firstmate from a clean upstream base: fm-send can report success after literal text sent to an interactive prompt is discarded while Enter answers the prompt default. Establish the exact failure and distinguish pre-existing upstream behavior from environmental availability, accidental local edits, intentionally opt-in live tests, and the concurrent fm-terminal-runtime-retirement task. Implement only confirmed independent tmux defects at the earliest causal boundary, without copying or competing with that concurrent task’s terminal-retirement contract. Add executable regression coverage through public/script interfaces, never implementation-source assertions; prove both refusal when a prompt drops typed text and normal submission when the composer accepts it. Preserve tmux endpoint identity, composer safety, task isolation, no-unlanded-work, remote-secondmate behavior, watcher continuity, cross-platform behavior, and all unaffected supported runtime-backend contracts. Review all call sites and backend impact; update only authoritative current documentation if behavior or an empirical guarantee changes. Require focused tmux regressions and relevant portable backend suites, bin/fm-lint.sh, and bin/fm-doc-audience-check.sh to pass. The independent implementation is committed as 7a97984 on fm/fm-tmux-preexisting-failures. Validate, push, and open a separate PR; never merge.

## What Changed

- Require tmux submissions to observe the typed payload appended to the selected composer content, including when a draft already exists, before pressing Enter.
- Return a `not-accepted` refusal without Enter when composer input is dropped, and propagate it through send, exit, and Kimi brief-submission flows.
- Document the composer-acceptance guarantee and add regression coverage for dropped text, stale drafts, normal submission, and affected backend paths.

## Risk Assessment

✅ Low: Captain, the scoped tmux change now proves a full composer append before Enter, safely propagates refusal outcomes, and preserves supported delivery paths.

## Testing

Focused tmux, portable backend/control, and remote-delivery regressions passed. Live tmux evidence reproduces the base defect (exit 0 plus `DEFAULT_ANSWERED`), verifies target refusal without Enter (exit 1 and no default), and verifies normal accepted-composer submission (exit 0). Lint and documentation static checks were not run because this assigned test phase explicitly prohibits linters and static analysis.

<details>
<summary>Evidence: Live tmux prompt regression transcript</summary>

Source: [Live tmux prompt regression transcript](https://github.com/SimTet/firstmate/blob/e789631f11c87dac72e3eb1b7193f9a4cec5e958/.no-mistakes/evidence/fm/fm-tmux-preexisting-failures/fm-send-live-tmux-prompt-transcript.txt)

```text
Live tmux interactive-prompt transcript (tmux 3.2a)
The prompt discards literal keys; Enter explicitly chooses DEFAULT_ANSWERED.

[baseline-live] exit=0 default-result=DEFAULT_ANSWERED
pane after fm-send:
❯
DEFAULT_ANSWERED
❯
fm-send diagnostic:
WARNING: watcher still down (same stale episode; last beat: never, grace 300s) - full banner already printed this episode.

[target-live] exit=1 default-result=
pane after fm-send:
❯
fm-send diagnostic:
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no watcher has a fresh beacon (last beat: never, grace 300s).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the requested message WILL still be sent.
●  repair missing watcher supervision with a foreground checkpoint: bin/fm-watch-checkpoint.sh --seconds 180.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
error: text not accepted into the composer at nm-live-prompt-target-live-31964:0 (harness=claude; backend=tmux); no Enter was sent, so an interactive prompt was not answered. Inspect with fm-peek.sh before retrying.
```
</details>
<details>
<summary>Evidence: Live tmux accepted-composer transcript</summary>

Source: [Live tmux accepted-composer transcript](https://github.com/SimTet/firstmate/blob/e789631f11c87dac72e3eb1b7193f9a4cec5e958/.no-mistakes/evidence/fm/fm-tmux-preexisting-failures/fm-send-live-tmux-composer-transcript.txt)

```text
Live tmux accepting-composer transcript (tmux 3.2a)
[target-live-composer] exit=0 submitted-result=SUBMITTED:continue with the requested work
pane after fm-send:
❯ continue with the requested work
SUBMITTED:continue with the requested work
❯
fm-send diagnostic:
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
●  WATCHER DOWN - SUPERVISION IS OFF
●  1 task(s) in flight, but no watcher has a fresh beacon (last beat: never, grace 300s).
●  Trust the emitted supervision protocol for this harness; do not use shell & for watcher repair.
●  This is a supervision warning only; the requested message WILL still be sent.
●  repair missing watcher supervision with a foreground checkpoint: bin/fm-watch-checkpoint.sh --seconds 180.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"20aec68b766a22a86f112a868566b940568b8ad0","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 4 issues found → auto-fixed ✅</summary>

- 🚨 `bin/fm-tmux-lib.sh:307` - The new proof only looks for the payload tail after typing, so it cannot establish that this send actually changed the composer. If a modal drops the literal while a visible stale draft already contains the same tail (or merely contains a short tail as a substring), this check succeeds and line 311 still sends Enter to the modal. `fm-send` has no empty-composer preflight, and the sibling Zellij adapter already treats pre-existing intended text as insufficient by requiring an observed append. Capture selected composer content before `send-keys` and require the post-send content to be that same selection with the normalized payload appended; add the stale-draft/modal case through `fm-send` and assert no Enter.
- ⚠️ `bin/fm-tmux-lib.sh:308` - `not-accepted` is a definitive no-delivery result, but the shared caller `fm-control.sh` only rejects `send-failed`; it therefore waits and reports `exit-command=delivered` even though this new path explicitly sent no Enter. Handle `not-accepted` as an immediate failed lifecycle delivery (and audit the other non-`fm-send` callers of the backend verdict) so the newly introduced result cannot be misreported.
- ⚠️ `bin/fm-composer-lib.sh:1196` - The anchor normalizer deletes every box-drawing character, then rejects an empty result. A legitimate literal message made solely of these characters (for example `────`) is therefore refused even when the composer visibly accepted it, contradicting the required normal-submission behavior for literal text. Preserve content characters after selected-composer extraction; only strip actual structural furniture.
- 🚨 `docs/tmux-backend.md:85` - User intent requires “update only authoritative current documentation if behavior or an empirical guarantee changes.” The diff adds a new pre-Enter payload-acceptance refusal, while this authoritative tmux-backend description still says only that a message is typed once and Enter is retried until the composer clears. No documentation hunk records the new refusal guarantee or recovery behavior. Should this contract be added here before merge?

🔧 Fix: Harden tmux composer append verification
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-test-run.sh tests/fm-tmux-submit-busy.test.sh tests/fm-send-strict.test.sh tests/fm-backend.test.sh tests/fm-control.test.sh tests/fm-control-relaunch.test.sh tests/fm-send-popup-settle.test.sh tests/fm-send-remote-delivery.test.sh tests/fm-send-resolve-key.test.sh tests/fm-send-settle.test.sh`
- `bash tests/fm-control.test.sh`
- `bash tests/fm-control-relaunch.test.sh`
- `bash tests/fm-send-popup-settle.test.sh`
- `bash tests/fm-send-remote-delivery.test.sh`
- `bash tests/fm-send-resolve-key.test.sh`
- `bash tests/fm-send-settle.test.sh`
- <code>Live tmux 3.2a public `fm-send.sh` runs against an interactive prompt that discards text and whose Enter selects `DEFAULT_ANSWERED`, using both base and target scripts.</code>
- <code>Live tmux 3.2a public `fm-send.sh` run against an accepting composer; persisted result is `SUBMITTED:continue with the requested work`.</code>
- <code>Temporary live tmux sessions were terminated; `git status --porcelain` remained empty.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
