### PR TITLE
docs: add captain quickstart guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ The preference persists for the effective Firstmate home, and toggling it off re
 > alright merge it
 ```
 
+### Then read the quickstart
+
+[docs/quickstart.md](docs/quickstart.md) walks through the first session, registering a project, dispatching your first ship or scout task, what supervision feels like, and landing work.
+
 ### More backends
 
 Setup guides for tmux (the default) and every other supported backend (herdr, zellij, Orca, cmux) are linked in [Documentation](#documentation) below.
@@ -198,6 +202,7 @@ Firstmate's skills live in two separate places with different audiences:
 
 ## Documentation
 
+- [docs/quickstart.md](docs/quickstart.md) - the captain's day-one walkthrough from first launch to merged work.
 - [docs/architecture.md](docs/architecture.md) - maintainer architecture for the crew, supervision, worktrees, secondmates, and project modes.
 - [docs/configuration.md](docs/configuration.md) - environment variables, `FM_HOME`, runtime backend selection, optional Relay and its X and Discord setup steps, the files you set, and harness support.
 - [docs/remote-secondmates.md](docs/remote-secondmates.md) - current setup, routing, transfer, recovery, and safety behavior for whole-home remote second mates.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -293,6 +293,10 @@
       "audience": "operator-current"
     },
     {
+      "path": "docs/quickstart.md",
+      "audience": "operator-current"
+    },
+    {
       "path": "docs/remote-secondmates.md",
       "audience": "operator-current"
     },

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -24,6 +24,7 @@
     "operator-example"
   ],
   "readmeSetupTargets": [
+    "docs/quickstart.md",
     "docs/configuration.md",
     "docs/wedge-alarm.md",
     "docs/tmux-backend.md",

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -18,7 +18,7 @@ Most of the time your job is to answer questions, review a finished pull request
 
 ## Your first session
 
-Launch your harness inside the firstmate clone, as shown in the README, and let it read `AGENTS.md`.
+Launch Claude Code, Grok, or Pi inside the firstmate clone, as shown in the README, and let it read `AGENTS.md`.
 The first thing it does is a session start: it takes charge of this home, checks the tools it needs, picks up anything left over from your last session, and prints a startup summary.
 
 That summary - the digest - is the first mate orienting itself out loud, and it is worth skimming once.
@@ -45,12 +45,18 @@ At that point it will settle two things with you, and it helps to know what they
 **Delivery mode** is how finished work reaches you:
 
 - `no-mistakes` runs the full validation pipeline - review, tests, documentation - before a pull request is offered to you.
-  This is the safe default and the right choice for anything product-facing.
+  The right choice for anything product-facing.
 - `direct-PR` skips that pipeline and simply opens a pull request.
   Good for small, low-risk, or internal work where the extra rigor is not worth the wait.
 - `local-only` never pushes anywhere.
   The worker leaves a clean branch in your local copy, and the first mate merges it locally once you approve.
   Use this for private repos, experiments, or anything that must not reach a remote.
+
+You are not asked to pick one cold.
+The first mate works out the default for the project it just registered, tells you what it resolved, and lets you confirm or change it.
+A project with a remote resolves to `no-mistakes-prod-only`, which is not a fourth flat mode but a policy: product-facing, mixed, and uncertain work ships `no-mistakes`, while genuinely internal tooling, automation, and process work ships `direct-PR`.
+A project with no remote resolves to `local-only`.
+Ask for one flat mode instead whenever you would rather have it.
 
 **Merge authority** is the separate question of who presses merge.
 By default you do: every pull request and every local landing waits for your explicit word.
@@ -58,7 +64,7 @@ If you set `yolo` on a project, the first mate will merge green, in-scope work i
 It still never merges anything failing, and anything destructive, irreversible, or security-sensitive still comes to you.
 
 You can pick a standing choice per project and override it for a single request whenever you want.
-[docs/configuration.md](configuration.md) owns the files and settings behind these choices, and [docs/architecture.md](architecture.md) explains how delivery modes work under the hood.
+The [`project-management` skill](../.agents/skills/project-management/SKILL.md) owns how registration resolves a posture, and [docs/architecture.md](architecture.md) owns the registry entry behind it, including the `+yolo` merge flag and how each task's mode is decided.
 
 ## Dispatching your first piece of work
 
@@ -93,7 +99,7 @@ Once work is under way the first mate watches it for you continuously and withou
 You get pulled in for four things:
 
 - A decision only you can make.
-- Work that is ready for your review, always with the full pull request link.
+- Work that is ready for your review, with the full pull request link whenever the work produced one.
 - A real failure or blocker, after the first mate has already tried the obvious recovery.
 - Something it needs from you, such as a login or a credential.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -93,12 +93,13 @@ Running them in parallel is the normal case, not a special mode.
 ## What supervision feels like
 
 Silence is the healthy state.
-Once work is under way the first mate watches it for you continuously and without burning tokens, so an idle-looking session usually means everything is fine.
+Once work is under way the first mate keeps watch for you, so an idle-looking session usually means everything is fine.
 
-You get pulled in for four things:
+You get pulled in for five things:
 
 - A decision only you can make.
 - Work that is ready for your review, with the full pull request link whenever the work produced one.
+- Findings from a finished scout, handed to you as the findings themselves rather than a bare "done".
 - A real failure or blocker, after the first mate has already tried the obvious recovery.
 - Something it needs from you, such as a login or a credential.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -31,7 +31,7 @@ It tells you four useful things:
 - Any setup problem it found, such as a missing tool or a GitHub login that has expired.
 
 If it asks to install something, that is intentional: it detects, asks, and only installs after you approve.
-If it reports a GitHub authentication problem, fix that before dispatching work, because everything downstream depends on it.
+If it reports a GitHub authentication problem, fix that before dispatching work on any project that pushes to a remote.
 
 On a fresh clone the digest is mostly empty, and that is correct.
 You have no projects and no work yet.
@@ -45,8 +45,8 @@ At that point it will settle two things with you, and it helps to know what they
 
 **Delivery mode** is how finished work reaches you:
 
-- `no-mistakes` runs the full validation pipeline, which owns the review, the tests, the documentation, and the pull request and its checks.
-  What reaches you is already reviewed and green, so this is the right choice for anything product-facing.
+- `no-mistakes` runs the full validation pipeline before the pull request is opened.
+  What reaches you is already validated and reports green checks, so this is the right choice for anything product-facing.
 - `direct-PR` skips that pipeline and simply opens a pull request.
   Good for small, low-risk, or internal work where the extra rigor is not worth the wait.
 - `local-only` never pushes anywhere.
@@ -128,7 +128,7 @@ You mostly talk in plain language, but these are the commands you type directly.
 
 | Command            | Reach for it when                                                                              |
 | ------------------ | ---------------------------------------------------------------------------------------------- |
-| `/bearings`        | You want a status picture: what is running, what is waiting on you, what landed.                 |
+| `/bearings`        | You want a status picture: what needs you, what landed, what is running, what is queued.         |
 | `/ahoy`            | You lost the thread of this conversation and want a recap plus a walkthrough of open decisions.  |
 | `/afk`             | You are stepping away and want routine matters handled quietly and real escalations batched.     |
 | `/stow`            | You are about to reset or compact the session and want what was learned written down first.      |
@@ -143,7 +143,7 @@ Nothing here needs you to debug internals; point at the owner and let the first 
 
 - Ask it plainly: "what is the state of that work?" or "why has nothing happened?" is a legitimate instruction, and it will reconcile and report.
 - Setup, tool, and authentication problems surface in the startup summary; [docs/configuration.md](configuration.md) owns every setting behind them.
-- Runtime problems specific to how workers are launched belong to your backend's page, linked from the README's Documentation section.
+- If the trouble is with the tool that opens and runs those worker sessions, its own setup page is linked from the README's Documentation section.
 - If you want to understand a behavior rather than fix it, [docs/architecture.md](architecture.md) explains how the parts fit together, and [`AGENTS.md`](../AGENTS.md) is the contract the first mate itself follows.
 
 If the first mate is stuck rather than merely quiet, restarting the session is safe.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -53,10 +53,9 @@ At that point it will settle two things with you, and it helps to know what they
   Use this for private repos, experiments, or anything that must not reach a remote.
 
 You are not asked to pick one cold.
-The first mate works out the default for the project it just registered, tells you what it resolved, and lets you confirm or change it.
-A project with a remote resolves to `no-mistakes-prod-only`, which is not a fourth flat mode but a policy: product-facing, mixed, and uncertain work ships `no-mistakes`, while genuinely internal tooling, automation, and process work ships `direct-PR`.
-A project with no remote resolves to `local-only`.
-Ask for one flat mode instead whenever you would rather have it.
+A newly added project with a remote resolves to `no-mistakes-prod-only` unless you say otherwise, and a project with no remote resolves to `local-only`.
+The first mate states the posture it resolved when it confirms the registration, so you only have to speak up if you want a different one.
+`no-mistakes-prod-only` is a conditional policy rather than a fourth flat mode, and the [`project-management` skill](../.agents/skills/project-management/SKILL.md) owns which work it sends down which path.
 
 **Merge authority** is the separate question of who presses merge.
 By default you do: every pull request and every local landing waits for your explicit word.
@@ -64,7 +63,7 @@ If you set `yolo` on a project, the first mate will merge green, in-scope work i
 It still never merges anything failing, and anything destructive, irreversible, or security-sensitive still comes to you.
 
 You can pick a standing choice per project and override it for a single request whenever you want.
-The [`project-management` skill](../.agents/skills/project-management/SKILL.md) owns how registration resolves a posture, and [docs/architecture.md](architecture.md) owns the registry entry behind it, including the `+yolo` merge flag and how each task's mode is decided.
+[docs/architecture.md](architecture.md) owns the registry entry behind these choices, including the `+yolo` merge flag and how each task's mode is decided.
 
 ## Dispatching your first piece of work
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,142 @@
+# Quickstart
+
+This is a day-one walkthrough for someone who has just cloned firstmate and wants to use it.
+It is deliberately short and concrete, and it points at the reference pages instead of repeating them.
+If you have not installed the prerequisites yet, start with the Quick Start section of the [README](../README.md), then come back here.
+
+## The mental model
+
+You have one conversation, with the first mate.
+You describe what you want in plain language, and the first mate figures out which project you mean, what shape the work is, and who should do it.
+
+The actual project work is done by workers the first mate launches for you.
+Each worker gets its own isolated copy of the repository, so several pieces of work can run at once without stepping on each other, and none of them touch the copy you are looking at.
+
+You stay the captain.
+The first mate is read-only over your projects, workers make the changes, and nothing lands until the merge authority you set says it can.
+Most of the time your job is to answer questions, review a finished pull request, and say "merge it".
+
+## Your first session
+
+Launch your harness inside the firstmate clone, as shown in the README, and let it read `AGENTS.md`.
+The first thing it does is a session start: it takes charge of this home, checks the tools it needs, picks up anything left over from your last session, and prints a startup summary.
+
+That summary - the digest - is the first mate orienting itself out loud, and it is worth skimming once.
+It tells you four useful things:
+
+- Anything that needs your attention right now, such as work that finished while you were away or a decision waiting on you.
+- The state of your fleet: which pieces of work are under way and what each one is doing.
+- Your projects and your recorded preferences, so you can see what it thinks it knows about you.
+- Any setup problem it found, such as a missing tool or a GitHub login that has expired.
+
+If it asks to install something, that is intentional: it detects, asks, and only installs after you approve.
+If it reports a GitHub authentication problem, fix that before dispatching work, because everything downstream depends on it.
+
+On a fresh clone the digest is mostly empty, and that is correct.
+You have no projects and no work yet.
+
+## Registering your first project
+
+Just tell the first mate about the project.
+Something like "add my repo github.com/you/xyz" or "clone xyz and set it up" is enough; it will make a local copy and register it.
+
+At that point it will settle two things with you, and it helps to know what they mean.
+
+**Delivery mode** is how finished work reaches you:
+
+- `no-mistakes` runs the full validation pipeline - review, tests, documentation - before a pull request is offered to you.
+  This is the safe default and the right choice for anything product-facing.
+- `direct-PR` skips that pipeline and simply opens a pull request.
+  Good for small, low-risk, or internal work where the extra rigor is not worth the wait.
+- `local-only` never pushes anywhere.
+  The worker leaves a clean branch in your local copy, and the first mate merges it locally once you approve.
+  Use this for private repos, experiments, or anything that must not reach a remote.
+
+**Merge authority** is the separate question of who presses merge.
+By default you do: every pull request and every local landing waits for your explicit word.
+If you set `yolo` on a project, the first mate will merge green, in-scope work itself and tell you afterwards.
+It still never merges anything failing, and anything destructive, irreversible, or security-sensitive still comes to you.
+
+You can pick a standing choice per project and override it for a single request whenever you want.
+[docs/configuration.md](configuration.md) owns the files and settings behind these choices, and [docs/architecture.md](architecture.md) explains how delivery modes work under the hood.
+
+## Dispatching your first piece of work
+
+Say what you want.
+
+```
+> the login test is flaky in xyz, fix it
+```
+
+That is a **ship** task: you want the project changed, so a worker implements it and delivers it through the project's delivery mode.
+Ship is the default, and it is what most requests become.
+
+```
+> before we touch it, figure out why our build got 3 minutes slower last month
+```
+
+That is a **scout** task: you want to know something, not change something.
+A scout investigates and writes up what it found, and it never opens a pull request.
+When the findings point at a fix you want, you say so, and the same worker is promoted to implement it rather than starting over.
+
+From your seat the difference is simply what comes back: a scout returns findings, a ship returns something to merge.
+You do not have to choose the label; describing the outcome you want is enough, and the first mate will tell you which one it dispatched.
+
+If several pieces of work are independent, just ask for all of them.
+Running them in parallel is the normal case, not a special mode.
+
+## What supervision feels like
+
+Silence is the healthy state.
+Once work is under way the first mate watches it for you continuously and without burning tokens, so an idle-looking session usually means everything is fine.
+
+You get pulled in for four things:
+
+- A decision only you can make.
+- Work that is ready for your review, always with the full pull request link.
+- A real failure or blocker, after the first mate has already tried the obvious recovery.
+- Something it needs from you, such as a login or a credential.
+
+You will not be told about retries, routine progress, or the machinery it uses to keep track.
+If you want a status picture on demand rather than waiting to be told, ask for one with `/bearings`.
+
+You can also watch any worker directly: each one runs in its own visible session you can attach to and even type into.
+The first mate reconciles whatever you do there at its next check.
+
+## Landing work
+
+When a ship task is ready you get a message with the pull request link, a one-line summary of what changed, and the risk level when the validation pipeline produced one.
+
+Review it however you normally would.
+When you are happy, tell the first mate to merge, and it does the merge and records it.
+For a `local-only` project there is no pull request; you approve the branch and it fast-forwards your local copy.
+
+Afterwards it cleans up on its own: the worker's isolated copy is released, the work is recorded as done, and anything that was waiting on it is re-evaluated and may start immediately.
+Cleanup deliberately refuses to run while there is unmerged or uncommitted work, so if you ever see it refuse, treat that as a signal to look rather than something to force.
+
+## Commands worth knowing
+
+You mostly talk in plain language, but these are the commands you type directly.
+
+| Command            | Reach for it when                                                                              |
+| ------------------ | ---------------------------------------------------------------------------------------------- |
+| `/bearings`        | You want a status picture: what is running, what is waiting on you, what landed.                 |
+| `/ahoy`            | You lost the thread of this conversation and want a recap plus a walkthrough of open decisions.  |
+| `/afk`             | You are stepping away and want routine matters handled quietly and real escalations batched.     |
+| `/stow`            | You are about to reset or compact the session and want what was learned written down first.      |
+| `/updatefirstmate` | You want to pull the latest firstmate and update everything it runs.                             |
+
+Codex uses the same names with `$` instead of `/`, such as `$afk`.
+The README's built-in skills table has the fuller description of each.
+
+## When something looks wrong
+
+Nothing here needs you to debug internals; point at the owner and let the first mate work.
+
+- Ask it plainly: "what is the state of that work?" or "why has nothing happened?" is a legitimate instruction, and it will reconcile and report.
+- Setup, tool, and authentication problems surface in the startup summary; [docs/configuration.md](configuration.md) owns every setting behind them.
+- Runtime problems specific to how workers are launched belong to your backend's page, linked from the README's Documentation section.
+- If you want to understand a behavior rather than fix it, [docs/architecture.md](architecture.md) explains how the parts fit together, and [`AGENTS.md`](../AGENTS.md) is the contract the first mate itself follows.
+
+If the first mate is stuck rather than merely quiet, restarting the session is safe.
+Everything durable lives on disk, so the next session picks up exactly where this one was.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -19,7 +19,8 @@ Most of the time your job is to answer questions, review a finished pull request
 
 ## Your first session
 
-Launch Claude Code, Grok, or Pi inside the firstmate clone, as shown in the README, and let it read `AGENTS.md`.
+Launch one of the supported coding agents inside the firstmate clone, as shown in the README, and let it read `AGENTS.md`.
+Claude Code, Grok, and Pi are the recommended starting points, and the README's Requirements and Recommended harnesses sections own the full supported list.
 The first thing it does is a session start: it takes charge of this home, checks the tools it needs, picks up anything left over from your last session, and prints a startup summary.
 
 That summary - the digest - is the first mate orienting itself out loud, and it is worth skimming once.
@@ -45,8 +46,8 @@ At that point it will settle two things with you, and it helps to know what they
 
 **Delivery mode** is how finished work reaches you:
 
-- `no-mistakes` runs the full validation pipeline before the pull request is opened.
-  What reaches you is already validated and reports green checks, so this is the right choice for anything product-facing.
+- `no-mistakes` runs the full validation pipeline, which carries the work through review, tests, documentation, the pull request, and its checks.
+  It reaches you only once those checks are green, so this is the right choice for anything product-facing.
 - `direct-PR` skips that pipeline and simply opens a pull request.
   Good for small, low-risk, or internal work where the extra rigor is not worth the wait.
 - `local-only` never pushes anywhere.
@@ -134,8 +135,8 @@ You mostly talk in plain language, but these are the commands you type directly.
 | `/stow`            | You are about to reset or compact the session and want what was learned written down first.      |
 | `/updatefirstmate` | You want to pull the latest firstmate and update everything it runs.                             |
 
-Codex uses the same names with `$` instead of `/`, such as `$afk`.
-The README's built-in skills table has the fuller description of each.
+The slash form shown here is what Claude Code and Grok use.
+The README's built-in skills table owns the prefix other agents use and the fuller description of each.
 
 ## When something looks wrong
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -13,7 +13,8 @@ The actual project work is done by workers the first mate launches for you.
 Each worker gets its own isolated copy of the repository, so several pieces of work can run at once without stepping on each other, and none of them touch the copy you are looking at.
 
 You stay the captain.
-The first mate is read-only over your projects, workers make the changes, and nothing lands until the merge authority you set says it can.
+Workers make the changes; the first mate does not edit your projects itself, apart from a few guarded steps such as setting a project up and landing a merge you approved.
+Nothing lands until the merge authority you set says it can.
 Most of the time your job is to answer questions, review a finished pull request, and say "merge it".
 
 ## Your first session
@@ -44,8 +45,8 @@ At that point it will settle two things with you, and it helps to know what they
 
 **Delivery mode** is how finished work reaches you:
 
-- `no-mistakes` runs the full validation pipeline - review, tests, documentation - before a pull request is offered to you.
-  The right choice for anything product-facing.
+- `no-mistakes` runs the full validation pipeline, which owns the review, the tests, the documentation, and the pull request and its checks.
+  What reaches you is already reviewed and green, so this is the right choice for anything product-facing.
 - `direct-PR` skips that pipeline and simply opens a pull request.
   Good for small, low-risk, or internal work where the extra rigor is not worth the wait.
 - `local-only` never pushes anywhere.
@@ -95,12 +96,13 @@ Running them in parallel is the normal case, not a special mode.
 Silence is the healthy state.
 Once work is under way the first mate keeps watch for you, so an idle-looking session usually means everything is fine.
 
-You get pulled in for five things:
+You get pulled in for six things:
 
 - A decision only you can make.
 - Work that is ready for your review, with the full pull request link whenever the work produced one.
 - Findings from a finished scout, handed to you as the findings themselves rather than a bare "done".
 - A real failure or blocker, after the first mate has already tried the obvious recovery.
+- Anything destructive, irreversible, or security-sensitive, whatever a project's standing settings say.
 - Something it needs from you, such as a login or a credential.
 
 You will not be told about retries, routine progress, or the machinery it uses to keep track.


### PR DESCRIPTION
## Intent

Write a captain-facing quickstart guide for firstmate: a short, concrete day-one walkthrough for someone who just cloned the repo and wants to use it, not a reference manual. New tracked prose page docs/quickstart.md covering, in order: the mental model (one conversation with the first mate; workers do project work in isolated copies; the captain approves and merges); the first session (launch, what session start does, what the digest tells you); registering a first project and choosing delivery mode (no-mistakes, direct-PR, local-only) and whether to set yolo; dispatching first work in plain language and the captain-visible difference between ship and scout tasks; what supervision feels like (silence is normal, woken only for decisions, failures, and review-ready work); landing work (reviewing the PR, giving merge approval, what cleanup happens after); the captain-invocable commands /bearings, /ahoy, /afk, /stow, /updatefirstmate with one line each; and a short 'when something looks wrong' section pointing at existing doc owners rather than restating them. Constraints: follow .agents/skills/firstmate-coding-guidelines/SKILL.md since this is firstmate's own shared tracked material; classify the page correctly in docs/documentation-audiences.json per docs/documentation-audiences.md and keep bin/fm-doc-audience-check.sh passing; respect the one-owner rule so the guide orients and links rather than restating contracts owned by AGENTS.md, docs/configuration.md, docs/architecture.md, or the backend docs; write in captain vocabulary without exposing internal machinery terms (watchers, wakes, briefs, worktrees, harnesses, teardown, task ids) except where the captain genuinely types or sees them, explained once in plain words; repo style of one sentence per line, plain dash, no agent co-author; and update README's Quick Start and Documentation sections to link the new guide for discoverability without duplicating its content.

## What Changed

- New `docs/quickstart.md`: a day-one captain walkthrough covering the mental model, first session, registering a project and choosing a delivery mode, dispatching ship vs scout work, what supervision feels like, landing work, the five captain-invocable commands, and a "when something looks wrong" section that points at existing doc owners.
- `README.md` links the guide from both the Quick Start flow and the Documentation list, without duplicating its content.
- `docs/documentation-audiences.json` classifies the page as `operator-current` and adds it to `readmeSetupTargets`, so `bin/fm-doc-audience-check.sh` enforces that the README keeps linking it; the Test stage reports both checks passing plus negative controls that fail when the entry is removed or misclassified.

## Risk Assessment

✅ Low: Documentation-only change whose final round removes a drifted duplicate of a normative rule and replaces it with a pointer at the owning skill, leaving every source-verifiable acceptance criterion in the intent satisfied and no findings outstanding.

## Testing

I ran the repo's targeted documentation regression (tests/fm-documentation-audiences.test.sh, 4/4 ok) and bin/fm-doc-audience-check.sh, then proved the new page's classification is genuinely enforced with two negative controls that made the check fail on purpose (unclassified surface, and a disallowed audience for a README setup target). Because this is a prose surface, I produced reviewer-visible evidence by rendering docs/quickstart.md and README.md to HTML and capturing headless Chrome screenshots: three panels covering the whole guide, plus the README Quick Start pointer and the Documentation list entry. Visual review confirms all nine requested sections appear in the requested order with the ship/scout examples and the five-command table, and manual greps confirm one sentence per line, no em dashes, no agent co-author trailer, and no leaked internal machinery vocabulary. I also cross-checked the guide's factual claims against their owning documents rather than trusting the prose. Everything passed and the working tree is unchanged.

- Evidence: Rendered quickstart guide, panel 1 of 3 - mental model, first session and digest, start of project registration (local file: <code>/var/folders/rf/dk8qlvbj6dj0hxt767_fz8ww0000gp/T/no-mistakes-evidence/01M0NA5T8JMP7VCREJ8BNY29TR/quickstart-01.png</code>)
- Evidence: Rendered quickstart guide, panel 2 of 3 - delivery modes and merge authority, ship vs scout dispatch, supervision (local file: <code>/var/folders/rf/dk8qlvbj6dj0hxt767_fz8ww0000gp/T/no-mistakes-evidence/01M0NA5T8JMP7VCREJ8BNY29TR/quickstart-02.png</code>)
- Evidence: Rendered quickstart guide, panel 3 of 3 - landing work, the five captain commands, when something looks wrong (local file: <code>/var/folders/rf/dk8qlvbj6dj0hxt767_fz8ww0000gp/T/no-mistakes-evidence/01M0NA5T8JMP7VCREJ8BNY29TR/quickstart-03.png</code>)
- Evidence: README Quick Start now ends with a &#39;Then read the quickstart&#39; pointer to docs/quickstart.md (local file: <code>/var/folders/rf/dk8qlvbj6dj0hxt767_fz8ww0000gp/T/no-mistakes-evidence/01M0NA5T8JMP7VCREJ8BNY29TR/readme-quickstart-link.png</code>)
- Evidence: README Documentation section lists docs/quickstart.md first as the captain&#39;s day-one walkthrough (local file: <code>/var/folders/rf/dk8qlvbj6dj0hxt767_fz8ww0000gp/T/no-mistakes-evidence/01M0NA5T8JMP7VCREJ8BNY29TR/readme-documentation.png</code>)
<details>
<summary>Evidence: fm-doc-audience-check transcript: passing run plus two negative controls that fail on purpose</summary>

<code>$ bin/fm-doc-audience-check.sh # repository as committed&#10;fm-doc-audience-check: ok surfaces=74 local_links=274&#10;exit=0&#10;&#10;$ bin/fm-doc-audience-check.sh --inventory &lt;copy with docs/quickstart.md unclassified&gt;&#10;fm-doc-audience-check: unclassified: docs/quickstart.md&#10;exit=1&#10;&#10;$ bin/fm-doc-audience-check.sh --inventory &lt;copy classifying docs/quickstart.md maintainer-verification&gt;&#10;fm-doc-audience-check: README setup target docs/quickstart.md has disallowed audience &#39;maintainer-verification&#39;&#10;exit=1</code>

```text
$ bin/fm-doc-audience-check.sh              # repository as committed
fm-doc-audience-check: ok surfaces=74 local_links=274
exit=0

$ bin/fm-doc-audience-check.sh --inventory <copy with docs/quickstart.md unclassified>
fm-doc-audience-check: unclassified: docs/quickstart.md
exit=1

$ bin/fm-doc-audience-check.sh --inventory <copy classifying docs/quickstart.md maintainer-verification>
fm-doc-audience-check: README setup target docs/quickstart.md has disallowed audience 'maintainer-verification'
exit=1
```
</details>
<details>
<summary>Evidence: Rendered HTML of the guide used for the screenshots (open in a browser to review the page as a reader sees it)</summary>

```text
<!doctype html><meta charset='utf-8'><title>quickstart.md</title><style>
body { margin: 0; background: #ffffff; }
.wrap { max-width: 900px; margin: 0 auto; padding: 32px 40px 48px;
  font: 16px/1.55 -apple-system, "Segoe UI", Helvetica, Arial, sans-serif; color: #1f2328; }
h1 { font-size: 32px; padding-bottom: .3em; border-bottom: 1px solid #d1d9e0; margin-top: 24px; }
h2 { font-size: 24px; padding-bottom: .3em; border-bottom: 1px solid #d1d9e0; margin-top: 28px; }
h3 { font-size: 20px; margin-top: 24px; }
p, li { margin: 0 0 12px; }
ul { padding-left: 2em; }
a { color: #0969da; text-decoration: none; }
code { background: #eff1f3; padding: .2em .4em; border-radius: 6px; font-size: 85%;
  font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
pre { background: #f6f8fa; padding: 16px; border-radius: 6px; overflow: auto; }
pre code { background: none; padding: 0; font-size: 85%; }
table { border-collapse: collapse; margin: 0 0 16px; display: block; width: max-content; max-width: 100%; }
th, td { border: 1px solid #d1d9e0; padding: 6px 13px; text-align: left; vertical-align: top; }
tr:nth-child(2n) { background: #f6f8fa; }
blockquote { margin: 0 0 16px; padding: 0 1em; color: #59636e; border-left: .25em solid #d1d9e0; }
</style><div class='wrap'><h1>Quickstart</h1>
<p>This is a day-one walkthrough for someone who has just cloned firstmate and wants to use it.<br>It is deliberately short and concrete, and it points at the reference pages instead of repeating them.<br>If you have not installed the prerequisites yet, start with the Quick Start section of the <a href="../README.md">README</a>, then come back here.</p>
<h2>The mental model</h2>
<p>You have one conversation, with the first mate.<br>You describe what you want in plain language, and the first mate figures out which project you mean, what shape the work is, and who should do it.</p>
<p>The actual project work is done by workers the first mate launches for you.<br>Each worker gets its own isolated copy of the repository, so several pieces of work can run at once without stepping on each other, and none of them touch the copy you are looking at.</p>
<p>You stay the captain.<br>The first mate is read-only over your projects, workers make the changes, and nothing lands until the merge authority you set says it can.<br>Most of the time your job is to answer questions, review a finished pull request, and say &quot;merge it&quot;.</p>
<h2>Your first session</h2>
<p>Launch Claude Code, Grok, or Pi inside the firstmate clone, as shown in the README, and let it read <code>AGENTS.md</code>.<br>The first thing it does is a session start: it takes charge of this home, checks the tools it needs, picks up anything left over from your last session, and prints a startup summary.</p>
<p>That summary - the digest - is the first mate orienting itself out loud, and it is worth skimming once.<br>It tells you four useful things:</p>
<ul>
<li>Anything that needs your attention right now, such as work that finished while you were away or a decision waiting on you.</li>
<li>The state of your fleet: which pieces of work are under way and what each one is doing.</li>
<li>Your projects and your recorded preferences, so you can see what it thinks it knows about you.</li>
<li>Any setup problem it found, such as a missing tool or a GitHub login that has expired.</li>
</ul>
<p>If it asks to install something, that is intentional: it detects, asks, and only installs after you approve.<br>If it reports a GitHub authentication problem, fix that before dispatching work, because everything downstream depends on it.</p>
<p>On a fresh clone the digest is mostly empty, and that is correct.<br>You have no projects and no work yet.</p>
<h2>Registering your first project</h2>
<p>Just tell the first mate about the project.<br>Something like &quot;add my repo github.com/you/xyz&quot; or &quot;clone xyz and set it up&quot; is enough; it will make a local copy and register it.</p>
<p>At that point it will settle two things with you, and it helps to know what they mean.</p>
<p><strong>Delivery mode</strong> is how finished work reaches you:</p>
<ul>
<li><code>no-mistakes</code> runs the full validation pipeline - review, tests, documentation - before a pull request is offered to you.<br>The right choice for anything product-facing.</li>
<li><code>direct-PR</code> skips that pipeline and simply opens a pull request.<br>Good for small, low-risk, or internal work where the extra rigor is not worth the wait.</li>
<li><code>local-only</code> never pushes anywhere.<br>The worker leaves a clean branch in your local copy, and the first mate merges it locally once you approve.<br>Use this for private repos, experiments, or anything that must not reach a remote.</li>
</ul>
<p>You are not asked to pick one cold.<br>A newly added project with a remote resolves to <code>no-mistakes-prod-only</code> unless you say otherwise, and a project with no remote resolves to <code>local-only</code>.<br>The first mate states the posture it resolved when it confirms the registration, so you only have to speak up if you want a different one.<br><code>no-mistakes-prod-only</code> is a conditional policy rather than a fourth flat mode, and the <a href="../.agents/skills/project-management/SKILL.md"><code>project-management</code> skill</a> owns which work it sends down which path.</p>
<p><strong>Merge authority</strong> is the separate question of who presses merge.<br>By default you do: every pull request and every local landing waits for your explicit word.<br>If you set <code>yolo</code> on a project, the first mate will merge green, in-scope work itself and tell you afterwards.<br>It still never merges anything failing, and anything destructive, irreversible, or security-sensitive still comes to you.</p>
<p>You can pick a standing choice per project and override it for a single request whenever you want.<br><a href="architecture.md">docs/architecture.md</a> owns the registry entry behind these choices, including the <code>+yolo</code> merge flag and how each task&#x27;s mode is decided.</p>
<h2>Dispatching your first piece of work</h2>
<p>Say what you want.</p>
<pre><code>&gt; the login test is flaky in xyz, fix it</code></pre>
<p>That is a <strong>ship</strong> task: you want the project changed, so a worker implements it and delivers it through the project&#x27;s delivery mode.<br>Ship is the default, and it is what most requests become.</p>
<pre><code>&gt; before we touch it, figure out why our build got 3 minutes slower last month</code></pre>
<p>That is a <strong>scout</strong> task: you want to know something, not change something.<br>A scout investigates and writes up what it found, and it never opens a pull request.<br>When the findings point at a fix you want, you say so, and the same worker is promoted to implement it rather than starting over.</p>
<p>From your seat the difference is simply what comes back: a scout returns findings, a ship returns something to merge.<br>You do not have to choose the label; describing the outcome you want is enough, and the first mate will tell you which one it dispatched.</p>
<p>If several pieces of work are independent, just ask for all of them.<br>Running them in parallel is the normal case, not a special mode.</p>
<h2>What supervision feels like</h2>
<p>Silence is the healthy state.<br>Once work is under way the first mate watches it for you continuously and without burning tokens, so an idle-looking session usually means everything is fine.</p>
<p>You get pulled in for four things:</p>
<ul>
<li>A decision only you can make.</li>
<li>Work that is ready for your review, with the full pull request link whenever the work produced one.</li>
<li>A real failure or blocker, after the first mate has already tried the obvious recovery.</li>
<li>Something it needs from you, such as a login or a credential.</li>
</ul>
<p>You will not be told about retries, routine progress, or the machinery it uses to keep track.<br>If you want a status picture on demand rather than waiting to be told, ask for one with <code>/bearings</code>.</p>
<p>You can also watch any worker directly: each one runs in its own visible session you can attach to and even type into.<br>The first mate reconciles whatever you do there at its next check.</p>
<h2>Landing work</h2>
<p>When a ship task is ready you get a message with the pull request link, a one-line summary of what changed, and the risk level when the validation pipeline produced one.</p>
<p>Review it however you normally would.<br>When you are happy, tell the first mate to merge, and it does the merge and records it.<br>For a <code>local-only</code> project there is no pull request; you approve the branch and it fast-forwards your local copy.</p>
<p>Afterwards it cleans up on its own: the worker&#x27;s isolated copy is released, the work is recorded as done, and anything that was waiting on it is re-evaluated and may start immediately.<br>Cleanup deliberately refuses to run while there is unmerged or uncommitted work, so if you ever see it refuse, treat that as a signal to look rather than something to force.</p>
<h2>Commands worth knowing</h2>
<p>You mostly talk in plain language, but these are the commands you type directly.</p>
<table><thead><tr><th>Command</th><th>Reach for it when</th></tr></thead><tbody>
<tr><td><code>/bearings</code></td><td>You want a status picture: what is running, what is waiting on you, what landed.</td></tr>
<tr><td><code>/ahoy</code></td><td>You lost the thread of this conversation and want a recap plus a walkthrough of open decisions.</td></tr>
<tr><td><code>/afk</code></td><td>You are stepping away and want routine matters handled quietly and real escalations batched.</td></tr>
<tr><td><code>/stow</code></td><td>You are about to reset or compact the session and want what was learned written down first.</td></tr>
<tr><td><code>/updatefirstmate</code></td><td>You want to pull the latest firstmate and update everything it runs.</td></tr>
</tbody></table>
<p>Codex uses the same names with <code>$</code> instead of <code>/</code>, such as <code>$afk</code>.<br>The README&#x27;s built-in skills table has the fuller description of each.</p>
<h2>When something looks wrong</h2>
<p>Nothing here needs you to debug internals; point at the owner and let the first mate work.</p>
<ul>
<li>Ask it plainly: &quot;what is the state of that work?&quot; or &quot;why has nothing happened?&quot; is a legitimate instruction, and it will reconcile and report.</li>
<li>Setup, tool, and authentication problems surface in the startup summary; <a href="configuration.md">docs/configuration.md</a> owns every setting behind them.</li>
<li>Runtime problems specific to how workers are launched belong to your backend&#x27;s page, linked from the README&#x27;s Documentation section.</li>
<li>If you want to understand a behavior rather than fix it, <a href="architecture.md">docs/architecture.md</a> explains how the parts fit together, and <a href="../AGENTS.md"><code>AGENTS.md</code></a> is the contract the first mate itself follows.</li>
</ul>
<p>If the first mate is stuck rather than merely quiet, restarting the session is safe.<br>Everything durable lives on disk, so the next session picks up exactly where this one was.</p></div>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 5 issues found → auto-fixed (2) ✅</summary>

- ⚠️ `docs/quickstart.md:48` - The guide tells a captain registering their first project that `no-mistakes` &#34;is the safe default&#34;, but `.agents/skills/project-management/SKILL.md:52` states &#34;`no-mistakes-prod-only` is the default for a newly added or created remote-backed project when the captain specifies nothing, and a project with no remote defaults to `local-only`&#34;, and the skill instructs the first mate to state that resolved default while confirming registration. A captain following this walkthrough will be offered a posture the guide never names and told a different default than it promised. The intent&#39;s criterion is &#34;registering a first project and choosing delivery mode (no-mistakes, direct-PR, local-only)&#34;, so whether to name the fourth registry posture here or just drop the incorrect &#34;safe default&#34; sentence is a content decision for the author.
- ⚠️ `docs/quickstart.md:61` - &#34;[docs/configuration.md](configuration.md) owns the files and settings behind these choices&#34; misdirects the reader: configuration.md has no section for `data/projects.md`, delivery mode, or the `+yolo` flag - it only names &#34;the project and secondmate registries&#34; in passing in its state-layout sentence (line 13). The actual operator-facing owner is docs/architecture.md:251 (&#34;`data/projects.md` records each project&#39;s standing posture and optional `+yolo` merge flag&#34;). Since the whole point of the page is to orient and link rather than restate, a pointer at a non-owner is the one thing that breaks it. Point the registry/posture half of the sentence at architecture.md.
- ℹ️ `docs/quickstart.md:96` - &#34;Work that is ready for your review, always with the full pull request link&#34; is contradicted 16 lines later by line 112 (&#34;For a `local-only` project there is no pull request&#34;) and by scout tasks, which per AGENTS.md never produce a PR and return a report instead. Qualify it, e.g. &#34;always with the full pull request link when there is one&#34;.
- ℹ️ `docs/documentation-audiences.json:296` - `docs/quickstart.md` is classified but not added to `readmeSetupTargets`, so `bin/fm-doc-audience-check.sh` does not enforce that README keeps linking it - the discoverability requirement in the intent can silently regress on a future README edit. Its `operator-current` audience is already inside `setupAudiences` and README links it from two places, so adding the entry would pass the check today and pin the link.
- ℹ️ `docs/quickstart.md:21` - The intent requires &#34;captain vocabulary without exposing internal machinery terms (watchers, wakes, briefs, worktrees, harnesses, teardown, task ids) except where the captain genuinely types or sees them, explained once in plain words&#34;. &#34;Launch your harness inside the firstmate clone&#34; is the page&#39;s only such term and it is not explained; the captain types `claude` or `grok`, not &#34;harness&#34;. Naming the tools directly (&#34;launch Claude Code, Grok, or Pi inside the firstmate clone&#34;) satisfies the criterion without the jargon, but this is close enough to the intent&#39;s own exception clause that the author should decide.

🔧 Fix: fix quickstart delivery-mode accuracy and owner pointers
1 info still open:
- ℹ️ `docs/quickstart.md:57` - The new sentence restates the `no-mistakes-prod-only` surface-classification rule that is already owned in full by `.agents/skills/project-management/SKILL.md:44` and `AGENTS.md:288`, making this a third copy in a repo whose guidelines require each contract be stated in full exactly once. The captain&#39;s own fix instruction was to &#34;point at the project-management owner rather than restating its rules&#34;, and the intent&#39;s constraint is that the guide &#34;orients and links rather than restating contracts&#34;. The copy has already drifted: the owners route four internal categories to `direct-PR` (&#34;internal-only tooling, automation, contributor or operator process, and release or submission work&#34;) while line 57 lists three and silently drops &#34;release or submission work&#34;, so a captain reading only the quickstart would expect a release task on a prod-only project to run the full pipeline when the policy actually ships it `direct-PR`. The product-facing half (&#34;product-facing, mixed, and uncertain work ships `no-mistakes`&#34;) is word-for-word identical to both owners. Two defensible resolutions and the choice is the author&#39;s: replace the colon clause with a pointer such as &#34;which is not a fourth flat mode but a policy that routes each task to `no-mistakes` or `direct-PR` by the surface it touches&#34;, leaning on the owner link already present at line 67; or keep the gloss and complete the enumeration so it matches the owner. Flagging rather than auto-fixing because the captain explicitly asked to &#34;keep the plain-language explanation of what each mode means for the captain&#34;, and trimming the gloss trades accuracy risk for captain-facing clarity.

🔧 Fix: point quickstart at prod-only policy owner instead of restating
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-documentation-audiences.test.sh` - 4/4 checks ok (classification coverage, fail-safe classification/setup routing/scope, required owner pointers, local-link resolution)</code>
- <code>`bash bin/fm-doc-audience-check.sh` - ok surfaces=74 local_links=274 on the repository as committed</code>
- <code>Negative control: `bin/fm-doc-audience-check.sh --inventory &lt;copy with docs/quickstart.md removed from surfaces&gt;` - fails with `unclassified: docs/quickstart.md`</code>
- <code>Negative control: `bin/fm-doc-audience-check.sh --inventory &lt;copy classifying docs/quickstart.md as maintainer-verification&gt;` - fails with `README setup target docs/quickstart.md has disallowed audience`</code>
- <code>Manual render: converted `docs/quickstart.md` and `README.md` to GitHub-styled HTML and captured headless Chrome screenshots of the full guide (3 panels) and both README touchpoints</code>
- `Visual review of the rendered guide confirming all nine required sections appear in the intended order, including the ship/scout examples and the five-command table`
- <code>`grep -n $&#39;[—–]&#39; docs/quickstart.md README.md` - no em/en dashes</code>
- <code>Multi-sentence-per-line heuristic scan over `docs/quickstart.md` outside code fences and tables - no violations</code>
- <code>`git log 1231b6a..5f4430f --format=&#39;%b&#39;` - no agent co-author trailers</code>
- <code>`grep -niE &#34;watcher|wake|brief|worktree|harness|teardown|task id|crewmate|secondmate&#34; docs/quickstart.md` - zero internal-machinery terms</code>
- <code>Cross-checked guide claims against their owners: default posture vs `.agents/skills/project-management/SKILL.md:46`, `+yolo`/registry vs `docs/architecture.md:251`, Codex `$` prefix vs `README.md:174`, and existence of `.agents/skills/{bearings,ahoy,afk,stow,updatefirstmate}/SKILL.md`</code>
- <code>`git status --short` - working tree clean, no source files touched by testing</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/quickstart.md:62` - Judgment call, left unfixed as an out-of-scope follow-up: merge-authority semantics have no operator-current owner, so docs/quickstart.md:62-63 is now a second substantive copy of the safety contract in AGENTS.md:325-326 (&#34;merges green, in-scope work itself&#34;; &#34;never merges anything failing&#34;; &#34;destructive, irreversible, or security-sensitive still comes to you&#34;). The section already points at docs/architecture.md for the registry entry and the +yolo flag, but architecture.md is maintainer-architecture and AGENTS.md is agent-runtime, so neither is a surface a captain should be sent to for the limits of an autonomy grant they are being asked to set. Restating it in captain language is defensible as the deliberate one-line reinforcement the firstmate-coding-guidelines one-owner rule permits at a genuine risk point, but two sentences of a safety contract is past that allowance and will drift silently if the escalation set in AGENTS.md is ever narrowed or widened. Fixing it properly means either giving delivery mode and merge authority a classified operator-current owner or reducing the quickstart to a pointer at a weaker surface - both larger than this change, and creating a new documentation surface is explicitly discouraged here. Left as-is so this change stays safe.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
