### PR TITLE
fix: isolate worktree pools per operational home

### DIFF
--- a/bin/fm-pool-root.sh
+++ b/bin/fm-pool-root.sh
@@ -57,6 +57,27 @@ short_hash() {  # <string>
   fi
 }
 
+full_hash() {  # <string>
+  local digest
+  if command -v shasum >/dev/null 2>&1; then
+    digest=$(printf '%s' "$1" | shasum -a 256) || return 1
+    digest=${digest%% *}
+  elif command -v sha256sum >/dev/null 2>&1; then
+    digest=$(printf '%s' "$1" | sha256sum) || return 1
+    digest=${digest%% *}
+  elif command -v node >/dev/null 2>&1; then
+    digest=$(node -e 'process.stdout.write(require("crypto").createHash("sha256").update(process.argv[1]).digest("hex"))' "$1") \
+      || return 1
+  else
+    return 1
+  fi
+  [ "${#digest}" -eq 64 ] || return 1
+  case "$digest" in
+    *[!0-9a-f]*) return 1 ;;
+  esac
+  printf '%s' "$digest"
+}
+
 # This home's own pool root. Keyed on FM_HOME - the home that owns the
 # state/<id>.meta records naming each leased copy - rather than on the code
 # root, because two homes sharing one code root would still double-claim.
@@ -65,7 +86,7 @@ canonical_home() {
 }
 
 pool_root() {
-  local home base name
+  local home base name namespace
   [ -z "${FM_POOL_ROOT:-}" ] \
     || die "FM_POOL_ROOT cannot preserve per-home isolation; use FM_POOL_ROOT_BASE"
   home=$(canonical_home) \
@@ -81,7 +102,9 @@ pool_root() {
   esac
   name=$(basename "$home")
   [ -n "$name" ] && [ "$name" != / ] || name=home
-  printf '%s/%s-%s' "$base" "$name" "$(short_hash "$home")"
+  namespace=$(full_hash "$home") \
+    || die "cannot derive a collision-resistant namespace for FM_HOME '$home'"
+  printf '%s/%s-%s' "$base" "$name" "$namespace"
 }
 
 canonical_intended_path() {  # <path>

--- a/bin/fm-pool-root.sh
+++ b/bin/fm-pool-root.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# Give this operational home its OWN treehouse worktree pool.
+#
+# Treehouse keys a pool by the repository, not by the checkout: two firstmate
+# homes that clone the same project resolve the SAME pool directory and hand
+# each other's slots out. Neither home can see the other's state/<id>.meta, so
+# the pool re-leases a slot that the other home's task still names, and that
+# task's cleanup later hard-resets a copy a live worker is using. Treehouse is a
+# pinned third-party binary whose allocation and return-on-exit are not ours to
+# change, so the guarantee has to come from the one knob its config exposes:
+# `root` in the clone's treehouse.toml, which decides where the pool lives.
+#
+# Usage:
+#   fm-pool-root.sh <project-dir>   ensure that clone's pool root, print it
+#   fm-pool-root.sh --print         print this home's pool root, write nothing
+#
+# The root is <base>/<home-basename>-<hash of the home's real path>, with base
+# ${FM_POOL_ROOT_BASE:-$HOME/.treehouse-homes}; FM_POOL_ROOT names one outright.
+# Treehouse then places the pool itself at <root>/.treehouse/<repo>-<hash>/.
+#
+# Idempotent by design, so running it before every spawn converges without
+# churn: an already-correct treehouse.toml is left byte-identical, other keys in
+# that file are preserved, and the file is added to the clone's
+# .git/info/exclude so it never dirties the project or reaches a commit.
+#
+# Existing pools are never touched. A worktree already handed out keeps its
+# absolute path, `treehouse return` accepts that path whatever the config now
+# says, and the separation applies only to slots leased from here on, so live
+# work drains out of a shared pool on its own.
+#
+# A clone that TRACKS treehouse.toml is refused rather than rewritten: silently
+# committing a machine-local path would be worse than stopping, and silently
+# sharing a pool is the very thing this exists to prevent. Exclude the file or
+# set FM_POOL_ROOT to resolve it.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+
+die() {
+  printf 'fm-pool-root.sh: %s\n' "$*" >&2
+  exit 1
+}
+
+short_hash() {  # <string>
+  if command -v shasum >/dev/null 2>&1; then
+    printf '%s' "$1" | shasum -a 256 | awk '{print substr($1,1,8)}'
+  elif command -v sha256sum >/dev/null 2>&1; then
+    printf '%s' "$1" | sha256sum | awk '{print substr($1,1,8)}'
+  else
+    printf '%s' "$1" | cksum | awk '{printf "%08x", $1}'
+  fi
+}
+
+# This home's own pool root. Keyed on FM_HOME - the home that owns the
+# state/<id>.meta records naming each leased copy - rather than on the code
+# root, because two homes sharing one code root would still double-claim.
+pool_root() {
+  local home base name
+  if [ -n "${FM_POOL_ROOT:-}" ]; then
+    printf '%s' "$FM_POOL_ROOT"
+    return 0
+  fi
+  home=$(cd "$FM_HOME" 2>/dev/null && pwd -P) || home=$FM_HOME
+  base=${FM_POOL_ROOT_BASE:-}
+  if [ -z "$base" ]; then
+    [ -n "${HOME:-}" ] || die "cannot derive a pool root: neither FM_POOL_ROOT, FM_POOL_ROOT_BASE, nor HOME is set"
+    base="$HOME/.treehouse-homes"
+  fi
+  name=$(basename "$home")
+  [ -n "$name" ] && [ "$name" != / ] || name=home
+  printf '%s/%s-%s' "$base" "$name" "$(short_hash "$home")"
+}
+
+# The `root` value already configured for this clone, empty when unset. Only
+# top-level keys count: treehouse's config is flat, and a `root` under some
+# future [section] would be a different key entirely.
+configured_root() {  # <toml>
+  local toml=$1 line value
+  [ -f "$toml" ] || return 0
+  while IFS= read -r line; do
+    case "$line" in
+      \[*) break ;;
+      root[[:space:]]*=*|root=*) ;;
+      *) continue ;;
+    esac
+    value=${line#*=}
+    value=${value#"${value%%[![:space:]]*}"}
+    value=${value%"${value##*[![:space:]]}"}
+    case "$value" in
+      \"*\") value=${value#\"}; value=${value%\"} ;;
+      \'*\') value=${value#\'}; value=${value%\'} ;;
+    esac
+    printf '%s' "$value"
+    return 0
+  done < "$toml"
+}
+
+# Rewrite <toml> so its top-level `root` is <root>, preserving every other line.
+# A file with no top-level `root` gains one at the top, where TOML requires
+# keys that belong to no section to live anyway.
+write_root() {  # <toml> <root>
+  local toml=$1 root=$2 tmp body seen=0 line in_body=1
+  tmp=$(mktemp "${toml%/*}/.fm-treehouse-toml.XXXXXX") || return 1
+  body=$(mktemp "${toml%/*}/.fm-treehouse-body.XXXXXX") || { rm -f -- "$tmp"; return 1; }
+  if [ -f "$toml" ]; then
+    while IFS= read -r line || [ -n "$line" ]; do
+      case "$line" in
+        \[*) in_body=0 ;;
+      esac
+      if [ "$in_body" = 1 ]; then
+        case "$line" in
+          root[[:space:]]*=*|root=*)
+            [ "$seen" = 1 ] || printf 'root = "%s"\n' "$root" >> "$body"
+            seen=1
+            continue
+            ;;
+        esac
+      fi
+      printf '%s\n' "$line" >> "$body"
+    done < "$toml"
+  fi
+  if [ "$seen" = 0 ]; then
+    printf 'root = "%s"\n' "$root" > "$tmp"
+  fi
+  cat "$body" >> "$tmp" || { rm -f -- "$tmp" "$body"; return 1; }
+  rm -f -- "$body"
+  chmod 0644 "$tmp" || { rm -f -- "$tmp"; return 1; }
+  mv -f -- "$tmp" "$toml"
+}
+
+# Keep the clone's own status clean: the file is machine-local configuration,
+# never project content.
+exclude_from_git() {  # <project> <relative-path>
+  local project=$1 rel=$2 excl
+  excl=$(git -C "$project" rev-parse --git-path info/exclude 2>/dev/null) || return 0
+  [ -n "$excl" ] || return 0
+  case "$excl" in
+    /*) ;;
+    *) excl="$project/$excl" ;;
+  esac
+  mkdir -p "$(dirname "$excl")" 2>/dev/null || return 0
+  grep -qxF "$rel" "$excl" 2>/dev/null || printf '%s\n' "$rel" >> "$excl"
+}
+
+case "${1:-}" in
+  --print)
+    [ "$#" -eq 1 ] || die "usage: fm-pool-root.sh --print"
+    pool_root
+    printf '\n'
+    exit 0
+    ;;
+  ''|-*)
+    die "usage: fm-pool-root.sh <project-dir> | fm-pool-root.sh --print"
+    ;;
+esac
+
+[ "$#" -eq 1 ] || die "usage: fm-pool-root.sh <project-dir>"
+PROJECT=$1
+[ -d "$PROJECT" ] || die "project directory '$PROJECT' does not exist"
+PROJECT=$(cd "$PROJECT" && pwd -P) || die "cannot resolve project directory '$1'"
+
+ROOT_VALUE=$(pool_root) || exit 1
+TOML="$PROJECT/treehouse.toml"
+
+if git -C "$PROJECT" ls-files --error-unmatch treehouse.toml >/dev/null 2>&1; then
+  die "project '$PROJECT' tracks treehouse.toml, so this home cannot claim its own worktree pool without changing project content. Untrack or exclude that file, or set FM_POOL_ROOT, then spawn again"
+fi
+
+[ ! -L "$TOML" ] || die "'$TOML' is a symlink; refusing to write this home's pool root through it"
+
+# Create and canonicalize before recording it: one home must always resolve the
+# same string, or an every-spawn rewrite would churn the file for nothing.
+mkdir -p "$ROOT_VALUE" || die "could not create this home's pool root '$ROOT_VALUE'"
+ROOT_VALUE=$(cd "$ROOT_VALUE" && pwd -P) || die "could not resolve this home's pool root"
+
+if [ "$(configured_root "$TOML")" != "$ROOT_VALUE" ]; then
+  write_root "$TOML" "$ROOT_VALUE" || die "could not record this home's pool root in '$TOML'"
+fi
+exclude_from_git "$PROJECT" treehouse.toml
+
+printf '%s\n' "$ROOT_VALUE"

--- a/bin/fm-pool-root.sh
+++ b/bin/fm-pool-root.sh
@@ -21,10 +21,11 @@
 #
 # The generated view lives at
 # <canonical-FM_HOME>/state/treehouse-config/<project-path-hash>/<project-name>.
-# Its .git symlink points at the project's existing Git directory and its
-# treehouse.toml contains only the safely encoded home root. Dispatch runs the
-# unwrapped `treehouse get` from that view. The project checkout and its
-# info/exclude remain byte-for-byte outside this configuration path.
+# Its private .git control directory shares the project's common object and ref
+# store while keeping a separate empty index, and its treehouse.toml contains
+# only the safely encoded home root. Dispatch runs the unwrapped `treehouse get`
+# from that view. The project checkout and its info/exclude remain byte-for-byte
+# outside this configuration path.
 #
 # Existing pools are never touched. A worktree already handed out keeps its
 # absolute path, `treehouse return` accepts that path whatever the config now
@@ -94,39 +95,204 @@ toml_basic_string() {  # <value>
   node -e 'process.stdout.write(JSON.stringify(process.argv[1]))' "$1"
 }
 
-write_config() {  # <view> <project-git-dir> <root>
-  local requested_view=$1 project_git_dir=$2 root=$3 home real_view toml tmp literal git_link
+configured_root() {  # <toml>
+  command -v node >/dev/null 2>&1 || return 1
+  node -e '
+    const fs = require("fs");
+    const source = fs.readFileSync(process.argv[1], "utf8");
+    const match = source.match(/^root[ \t]*=[ \t]*("(?:[^"\\]|\\.)*")[ \t]*\n?$/);
+    if (!match) process.exit(1);
+    let root;
+    try { root = JSON.parse(match[1]); } catch (_) { process.exit(1); }
+    if (typeof root !== "string") process.exit(1);
+    process.stdout.write(root);
+  ' "$1"
+}
+
+remove_private_git_dir() {  # <git-dir>
+  local git_dir=$1 status=0
+  rm -f -- "$git_dir/HEAD" "$git_dir/commondir" "$git_dir/index" || status=1
+  rmdir "$git_dir" 2>/dev/null || status=1
+  return "$status"
+}
+
+write_config() {  # <view> <project-git-dir> <project-common-dir> <root>
+  local requested_view=$1 project_git_dir=$2 project_common_dir=$3 root=$4
+  local home real_view toml ignore toml_tmp='' ignore_tmp='' transaction=''
+  local configured git_link literal top actual_git actual_common staged_git
+  local view_created=0 git_kind=absent new_git_installed=0 toml_had=0 ignore_had=0
+  local status=0 rollback_status=0
   home=$(canonical_home) || return 1
-  mkdir -p "$requested_view" || return 1
+  if [ ! -e "$requested_view" ] && [ ! -L "$requested_view" ]; then
+    mkdir -p "$requested_view" || return 1
+    view_created=1
+  fi
+  [ -d "$requested_view" ] && [ ! -L "$requested_view" ] || return 1
   real_view=$(cd "$requested_view" 2>/dev/null && pwd -P) || return 1
   case "$real_view" in
     "$home"/*) ;;
     *) return 1 ;;
   esac
   git_link="$real_view/.git"
-  if [ -e "$git_link" ] || [ -L "$git_link" ]; then
-    [ -L "$git_link" ] || return 1
-    [ "$(readlink "$git_link")" = "$project_git_dir" ] || return 1
-  else
-    ln -s "$project_git_dir" "$git_link" || return 1
-  fi
-  git -C "$real_view" rev-parse --show-toplevel >/dev/null 2>&1 || return 1
   toml="$real_view/treehouse.toml"
+  ignore="$real_view/.gitignore"
+  if [ -e "$git_link" ] || [ -L "$git_link" ]; then
+    if [ -L "$git_link" ]; then
+      if [ "$(readlink "$git_link")" != "$project_git_dir" ]; then
+        [ "$view_created" -ne 1 ] || rmdir "$real_view" 2>/dev/null || true
+        return 1
+      fi
+      git_kind=symlink
+    elif [ -d "$git_link" ]; then
+      actual_git=$(git -C "$real_view" rev-parse --absolute-git-dir 2>/dev/null) || return 1
+      actual_common=$(git -C "$real_view" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 1
+      if [ "$actual_git" != "$git_link" ] || [ "$actual_common" != "$project_common_dir" ]; then
+        return 1
+      fi
+      git_kind=private
+    else
+      [ "$view_created" -ne 1 ] || rmdir "$real_view" 2>/dev/null || true
+      return 1
+    fi
+  fi
   if [ -e "$toml" ] || [ -L "$toml" ]; then
-    [ -f "$toml" ] && [ ! -L "$toml" ] || return 1
+    if [ ! -f "$toml" ] || [ -L "$toml" ]; then
+      [ "$view_created" -ne 1 ] || rmdir "$real_view" 2>/dev/null || true
+      return 1
+    fi
+    toml_had=1
   fi
-  literal=$(toml_basic_string "$root") || return 1
-  tmp=$(mktemp "$real_view/.fm-treehouse-config.XXXXXX") || return 1
-  printf 'root = %s\n' "$literal" > "$tmp" \
-    || { rm -f -- "$tmp"; return 1; }
-  chmod 0600 "$tmp" || { rm -f -- "$tmp"; return 1; }
-  if [ -f "$toml" ] && cmp -s "$tmp" "$toml"; then
-    rm -f -- "$tmp"
+  if [ -e "$ignore" ] || [ -L "$ignore" ]; then
+    if [ ! -f "$ignore" ] || [ -L "$ignore" ]; then
+      [ "$view_created" -ne 1 ] || rmdir "$real_view" 2>/dev/null || true
+      return 1
+    fi
+    ignore_had=1
+  fi
+  transaction=$(mktemp -d "${real_view%/*}/.fm-treehouse-rollback.XXXXXX") || status=1
+  staged_git="$transaction/new.git"
+  if [ "$status" -eq 0 ] && [ "$toml_had" -eq 1 ]; then
+    cp -p -- "$toml" "$transaction/treehouse.toml" || status=1
+  fi
+  if [ "$status" -eq 0 ] && [ "$ignore_had" -eq 1 ]; then
+    cp -p -- "$ignore" "$transaction/.gitignore" || status=1
+  fi
+  if [ "$status" -eq 0 ] && [ "$git_kind" != private ]; then
+    mkdir -m 0700 "$staged_git" || status=1
+  fi
+  if [ "$status" -eq 0 ] && [ "$git_kind" != private ]; then
+    cp -p -- "$project_git_dir/HEAD" "$staged_git/HEAD" || status=1
+  fi
+  if [ "$status" -eq 0 ] && [ "$git_kind" != private ]; then
+    printf '%s\n' "$project_common_dir" > "$staged_git/commondir" || status=1
+  fi
+  if [ "$status" -eq 0 ] && [ "$git_kind" != private ]; then
+    GIT_DIR="$staged_git" GIT_WORK_TREE="$real_view" git read-tree --empty >/dev/null 2>&1 || status=1
+  fi
+  if [ "$status" -ne 0 ]; then
+    [ ! -d "$staged_git" ] || remove_private_git_dir "$staged_git" 2>/dev/null || true
+    [ -z "$transaction" ] || {
+      rm -f -- "$transaction/treehouse.toml" "$transaction/.gitignore" 2>/dev/null || true
+      rmdir "$transaction" 2>/dev/null || true
+    }
+    [ "$view_created" -ne 1 ] || rmdir "$real_view" 2>/dev/null || true
+    return 1
+  fi
+  if [ "$git_kind" = symlink ]; then
+    mv -- "$git_link" "$transaction/old.git" || status=1
+  fi
+  if [ "$status" -eq 0 ] && [ "$git_kind" != private ]; then
+    mv -- "$staged_git" "$git_link" || status=1
+    if [ "$status" -eq 0 ] && [ -d "$git_link" ] && [ ! -e "$staged_git" ]; then
+      new_git_installed=1
+    else
+      status=1
+    fi
+  fi
+  if [ "$status" -eq 0 ]; then
+    toml_tmp=$(mktemp "$real_view/.fm-treehouse-config.XXXXXX") || status=1
+  fi
+  if [ "$status" -eq 0 ]; then
+    literal=$(toml_basic_string "$root") || status=1
+  fi
+  if [ "$status" -eq 0 ]; then
+    printf 'root = %s\n' "$literal" > "$toml_tmp" || status=1
+  fi
+  if [ "$status" -eq 0 ]; then
+    chmod 0600 "$toml_tmp" || status=1
+  fi
+  if [ "$status" -eq 0 ]; then
+    mv -f -- "$toml_tmp" "$toml" || status=1
+    if [ "$status" -eq 0 ] && [ ! -e "$toml_tmp" ] && [ -f "$toml" ]; then
+      toml_tmp=''
+    else
+      status=1
+    fi
+  fi
+  if [ "$status" -eq 0 ]; then
+    ignore_tmp=$(mktemp "$real_view/.fm-treehouse-ignore.XXXXXX") || status=1
+  fi
+  if [ "$status" -eq 0 ]; then
+    printf '.gitignore\ntreehouse.toml\n' > "$ignore_tmp" || status=1
+  fi
+  if [ "$status" -eq 0 ]; then
+    chmod 0600 "$ignore_tmp" || status=1
+  fi
+  if [ "$status" -eq 0 ]; then
+    mv -f -- "$ignore_tmp" "$ignore" || status=1
+    if [ "$status" -eq 0 ] && [ ! -e "$ignore_tmp" ] && [ -f "$ignore" ]; then
+      ignore_tmp=''
+    else
+      status=1
+    fi
+  fi
+  if [ "$status" -eq 0 ]; then
+    top=$(git -C "$real_view" rev-parse --show-toplevel 2>/dev/null) || status=1
+    [ "$status" -ne 0 ] || [ "$(cd "$top" 2>/dev/null && pwd -P)" = "$real_view" ] || status=1
+  fi
+  if [ "$status" -eq 0 ]; then
+    configured=$(configured_root "$toml") || status=1
+    [ "$status" -ne 0 ] || [ "$configured" = "$root" ] || status=1
+  fi
+  if [ "$status" -eq 0 ]; then
+    git -C "$real_view" check-ignore -q -- treehouse.toml 2>/dev/null || status=1
+  fi
+  if [ "$status" -eq 0 ]; then
+    git -C "$real_view" check-ignore -q -- .gitignore 2>/dev/null || status=1
+  fi
+  if [ "$status" -eq 0 ]; then
+    rm -f -- "$transaction/treehouse.toml" "$transaction/.gitignore" 2>/dev/null || true
+    rm -f -- "$transaction/old.git" 2>/dev/null || true
+    rmdir "$transaction" 2>/dev/null || true
+    return 0
+  fi
+
+  [ -z "$toml_tmp" ] || rm -f -- "$toml_tmp" || rollback_status=1
+  [ -z "$ignore_tmp" ] || rm -f -- "$ignore_tmp" || rollback_status=1
+  if [ "$toml_had" -eq 1 ]; then
+    mv -f -- "$transaction/treehouse.toml" "$toml" || rollback_status=1
   else
-    mv -f -- "$tmp" "$toml" || { rm -f -- "$tmp"; return 1; }
+    rm -f -- "$toml" || rollback_status=1
   fi
-  literal=$(toml_basic_string "$root") || return 1
-  [ "$(cat "$toml" 2>/dev/null)" = "root = $literal" ] || return 1
+  if [ "$ignore_had" -eq 1 ]; then
+    mv -f -- "$transaction/.gitignore" "$ignore" || rollback_status=1
+  else
+    rm -f -- "$ignore" || rollback_status=1
+  fi
+  if [ "$new_git_installed" -eq 1 ]; then
+    remove_private_git_dir "$git_link" || rollback_status=1
+  elif [ -d "$staged_git" ]; then
+    remove_private_git_dir "$staged_git" || rollback_status=1
+  fi
+  if [ "$git_kind" = symlink ] && [ -L "$transaction/old.git" ]; then
+    mv -- "$transaction/old.git" "$git_link" || rollback_status=1
+  fi
+  rmdir "$transaction" 2>/dev/null || rollback_status=1
+  if [ "$view_created" -eq 1 ]; then
+    rmdir "$real_view" 2>/dev/null || rollback_status=1
+  fi
+  [ "$rollback_status" -eq 0 ] || return 1
+  return 1
 }
 
 case "${1:-}" in
@@ -154,6 +320,10 @@ PROJECT_GIT_DIR=$(git -C "$PROJECT" rev-parse --absolute-git-dir 2>/dev/null) \
   || die "project directory '$PROJECT' is not an available Git repository"
 [ -d "$PROJECT_GIT_DIR" ] \
   || die "project directory '$PROJECT' has no available Git directory"
+PROJECT_GIT_COMMON_DIR=$(git -C "$PROJECT" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) \
+  || die "project directory '$PROJECT' has no available common Git directory"
+[ -d "$PROJECT_GIT_COMMON_DIR" ] \
+  || die "project directory '$PROJECT' has no available common Git directory"
 
 ROOT_VALUE=$(pool_root) || exit 1
 CONFIG_VIEW=$(project_view "$PROJECT") || exit 1
@@ -162,7 +332,7 @@ CONFIG_VIEW=$(project_view "$PROJECT") || exit 1
 # same string, or an every-spawn rewrite would churn the file for nothing.
 mkdir -p "$ROOT_VALUE" || die "could not create this home's pool root '$ROOT_VALUE'"
 ROOT_VALUE=$(cd "$ROOT_VALUE" && pwd -P) || die "could not resolve this home's pool root"
-write_config "$CONFIG_VIEW" "$PROJECT_GIT_DIR" "$ROOT_VALUE" \
+write_config "$CONFIG_VIEW" "$PROJECT_GIT_DIR" "$PROJECT_GIT_COMMON_DIR" "$ROOT_VALUE" \
   || die "could not write and verify this home's isolated Treehouse config view at '$CONFIG_VIEW'"
 
 if [ "${VIEW_ONLY:-0}" = 1 ]; then

--- a/bin/fm-pool-root.sh
+++ b/bin/fm-pool-root.sh
@@ -79,6 +79,24 @@ pool_root() {
   printf '%s/%s-%s' "$base" "$name" "$(short_hash "$home")"
 }
 
+canonical_intended_path() {  # <path>
+  local candidate probe suffix='' component anchor
+  command -v node >/dev/null 2>&1 || return 1
+  candidate=$(node -e 'process.stdout.write(require("path").resolve(process.argv[1]))' "$1") || return 1
+  probe=$candidate
+  while [ ! -d "$probe" ]; do
+    if [ -e "$probe" ] || [ -L "$probe" ]; then
+      return 1
+    fi
+    component=$(basename "$probe")
+    suffix="/$component$suffix"
+    [ "$(dirname "$probe")" != "$probe" ] || return 1
+    probe=$(dirname "$probe")
+  done
+  anchor=$(cd "$probe" 2>/dev/null && pwd -P) || return 1
+  printf '%s%s' "$anchor" "$suffix"
+}
+
 project_view() {  # <project>
   local project=$1 home project_real name
   home=$(canonical_home) \
@@ -327,6 +345,13 @@ PROJECT_GIT_COMMON_DIR=$(git -C "$PROJECT" rev-parse --path-format=absolute --gi
 
 ROOT_VALUE=$(pool_root) || exit 1
 CONFIG_VIEW=$(project_view "$PROJECT") || exit 1
+ROOT_INTENDED=$(canonical_intended_path "$ROOT_VALUE") \
+  || die "cannot safely resolve this home's intended pool root '$ROOT_VALUE'"
+case "$ROOT_INTENDED" in
+  "$PROJECT"|"$PROJECT"/*)
+    die "this home's pool root '$ROOT_INTENDED' would mutate the primary project '$PROJECT'; choose FM_POOL_ROOT_BASE outside the project"
+    ;;
+esac
 
 # Create and canonicalize before recording it: one home must always resolve the
 # same string, or an every-spawn rewrite would churn the file for nothing.

--- a/bin/fm-pool-root.sh
+++ b/bin/fm-pool-root.sh
@@ -131,7 +131,7 @@ write_root() {  # <toml> <root>
 # Keep the clone's own status clean: the file is machine-local configuration,
 # never project content.
 exclude_from_git() {  # <project> <relative-path>
-  local project=$1 rel=$2 excl grep_status
+  local project=$1 rel=$2 excl grep_status backup='' had_exclude=0
   excl=$(git -C "$project" rev-parse --git-path info/exclude 2>/dev/null) || return 1
   [ -n "$excl" ] || return 1
   case "$excl" in
@@ -144,14 +144,46 @@ exclude_from_git() {  # <project> <relative-path>
     grep -qxF "$rel" "$excl" 2>/dev/null
     grep_status=$?
     case "$grep_status" in
-      0) ;;
-      1) printf '%s\n' "$rel" >> "$excl" || return 1 ;;
+      0)
+        git -C "$project" check-ignore -q -- "$rel" 2>/dev/null
+        return $?
+        ;;
+      1)
+        backup=$(mktemp "$(dirname "$excl")/.fm-git-exclude.XXXXXX") || return 1
+        cp -p -- "$excl" "$backup" || { rm -f -- "$backup"; return 1; }
+        had_exclude=1
+        printf '%s\n' "$rel" >> "$excl" || {
+          mv -f -- "$backup" "$excl" 2>/dev/null || return 1
+          return 1
+        }
+        ;;
       *) return 1 ;;
     esac
   else
-    printf '%s\n' "$rel" > "$excl" || return 1
+    printf '%s\n' "$rel" > "$excl" || { rm -f -- "$excl"; return 1; }
   fi
-  git -C "$project" check-ignore -q -- "$rel" 2>/dev/null
+  if git -C "$project" check-ignore -q -- "$rel" 2>/dev/null; then
+    if [ -n "$backup" ] && ! rm -f -- "$backup"; then
+      mv -f -- "$backup" "$excl" 2>/dev/null || true
+      return 1
+    fi
+    return 0
+  fi
+  if [ "$had_exclude" = 1 ]; then
+    mv -f -- "$backup" "$excl" 2>/dev/null || return 1
+  else
+    rm -f -- "$excl" 2>/dev/null || return 1
+  fi
+  return 1
+}
+
+restore_toml() {  # <toml> <backup> <had-file>
+  local toml=$1 backup=$2 had_file=$3
+  if [ "$had_file" = 1 ]; then
+    mv -f -- "$backup" "$toml"
+  else
+    rm -f -- "$toml"
+  fi
 }
 
 case "${1:-}" in
@@ -170,9 +202,16 @@ esac
 PROJECT=$1
 [ -d "$PROJECT" ] || die "project directory '$PROJECT' does not exist"
 PROJECT=$(cd "$PROJECT" && pwd -P) || die "cannot resolve project directory '$1'"
+PROJECT_GIT_DIR=$(git -C "$PROJECT" rev-parse --absolute-git-dir 2>/dev/null) \
+  || die "project directory '$PROJECT' is not an available Git repository"
+[ -d "$PROJECT_GIT_DIR" ] \
+  || die "project directory '$PROJECT' has no available Git directory"
 
 ROOT_VALUE=$(pool_root) || exit 1
 TOML="$PROJECT/treehouse.toml"
+TOML_BACKUP=''
+TOML_HAD_FILE=0
+TOML_CHANGED=0
 
 if git -C "$PROJECT" ls-files --error-unmatch treehouse.toml >/dev/null 2>&1; then
   die "project '$PROJECT' tracks treehouse.toml, so this home cannot claim its own worktree pool without changing project content. Untrack that file, then spawn again"
@@ -189,11 +228,36 @@ mkdir -p "$ROOT_VALUE" || die "could not create this home's pool root '$ROOT_VAL
 ROOT_VALUE=$(cd "$ROOT_VALUE" && pwd -P) || die "could not resolve this home's pool root"
 
 if [ "$(configured_root "$TOML")" != "$ROOT_VALUE" ]; then
-  write_root "$TOML" "$ROOT_VALUE" || die "could not record this home's pool root in '$TOML'"
+  if [ -f "$TOML" ]; then
+    TOML_BACKUP=$(mktemp "$PROJECT_GIT_DIR/fm-treehouse-rollback.XXXXXX") \
+      || die "could not preserve '$TOML' before configuring this home's pool"
+    cp -p -- "$TOML" "$TOML_BACKUP" || {
+      rm -f -- "$TOML_BACKUP"
+      die "could not preserve '$TOML' before configuring this home's pool"
+    }
+    TOML_HAD_FILE=1
+  fi
+  if ! write_root "$TOML" "$ROOT_VALUE"; then
+    restore_toml "$TOML" "$TOML_BACKUP" "$TOML_HAD_FILE" \
+      || die "could not restore '$TOML' after its pool-root write failed"
+    die "could not record this home's pool root in '$TOML'"
+  fi
+  TOML_CHANGED=1
 fi
-[ "$(configured_root "$TOML")" = "$ROOT_VALUE" ] \
-  || die "could not verify this home's pool root in '$TOML'"
-exclude_from_git "$PROJECT" treehouse.toml \
-  || die "could not exclude treehouse.toml from project '$PROJECT' or verify that Git ignores it"
+if [ "$(configured_root "$TOML")" != "$ROOT_VALUE" ]; then
+  [ "$TOML_CHANGED" = 0 ] \
+    || restore_toml "$TOML" "$TOML_BACKUP" "$TOML_HAD_FILE" \
+    || die "could not restore '$TOML' after verification failed"
+  die "could not verify this home's pool root in '$TOML'"
+fi
+if ! exclude_from_git "$PROJECT" treehouse.toml; then
+  [ "$TOML_CHANGED" = 0 ] \
+    || restore_toml "$TOML" "$TOML_BACKUP" "$TOML_HAD_FILE" \
+    || die "could not restore '$TOML' after Git exclusion failed"
+  die "could not exclude treehouse.toml from project '$PROJECT' or verify that Git ignores it"
+fi
+if [ -n "$TOML_BACKUP" ]; then
+  rm -f -- "$TOML_BACKUP" || die "could not remove the completed rollback snapshot for '$TOML'"
+fi
 
 printf '%s\n' "$ROOT_VALUE"

--- a/bin/fm-pool-root.sh
+++ b/bin/fm-pool-root.sh
@@ -7,30 +7,33 @@
 # the pool re-leases a slot that the other home's task still names, and that
 # task's cleanup later hard-resets a copy a live worker is using. Treehouse is a
 # pinned third-party binary whose allocation and return-on-exit are not ours to
-# change, so the guarantee has to come from the one knob its config exposes:
-# `root` in the clone's treehouse.toml, which decides where the pool lives.
+# change, so the guarantee uses its repo-level `root` setting from a generated
+# Git config view inside the canonical operational home.
 #
 # Usage:
-#   fm-pool-root.sh <project-dir>   ensure that clone's pool root, print it
+#   fm-pool-root.sh <project-dir>   ensure this home's config, print its root
 #   fm-pool-root.sh --print         print this home's pool root, write nothing
+#   fm-pool-root.sh --view <project-dir>  ensure and print the config view
 #
 # The root is <base>/<home-basename>-<hash of the home's real path>, with base
 # ${FM_POOL_ROOT_BASE:-$HOME/.treehouse-homes}.
 # Treehouse then places the pool itself at <root>/.treehouse/<repo>-<hash>/.
 #
-# Idempotent by design, so running it before every spawn converges without
-# churn: an already-correct treehouse.toml is left byte-identical, other keys in
-# that file are preserved, and the file is added to the clone's
-# .git/info/exclude so it never dirties the project or reaches a commit.
+# The generated view lives at
+# <canonical-FM_HOME>/state/treehouse-config/<project-path-hash>/<project-name>.
+# Its .git symlink points at the project's existing Git directory and its
+# treehouse.toml contains only the safely encoded home root. Dispatch runs the
+# unwrapped `treehouse get` from that view. The project checkout and its
+# info/exclude remain byte-for-byte outside this configuration path.
 #
 # Existing pools are never touched. A worktree already handed out keeps its
 # absolute path, `treehouse return` accepts that path whatever the config now
 # says, and the separation applies only to slots leased from here on, so live
 # work drains out of a shared pool on its own.
 #
-# A clone that TRACKS treehouse.toml is refused rather than rewritten: silently
-# committing a machine-local path would be worse than stopping, and silently
-# sharing a pool is the very thing this exists to prevent.
+# The view deliberately wins as Treehouse's repo root for Firstmate dispatches;
+# any treehouse.toml in the captain's primary checkout remains untouched and is
+# not configuration authority for another operational home's pool.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -55,11 +58,15 @@ short_hash() {  # <string>
 # This home's own pool root. Keyed on FM_HOME - the home that owns the
 # state/<id>.meta records naming each leased copy - rather than on the code
 # root, because two homes sharing one code root would still double-claim.
+canonical_home() {
+  cd "$FM_HOME" 2>/dev/null && pwd -P
+}
+
 pool_root() {
   local home base name
   [ -z "${FM_POOL_ROOT:-}" ] \
     || die "FM_POOL_ROOT cannot preserve per-home isolation; use FM_POOL_ROOT_BASE"
-  home=$(cd "$FM_HOME" 2>/dev/null && pwd -P) \
+  home=$(canonical_home) \
     || die "cannot resolve FM_HOME '$FM_HOME' for pool isolation"
   base=${FM_POOL_ROOT_BASE:-}
   if [ -z "$base" ]; then
@@ -71,119 +78,55 @@ pool_root() {
   printf '%s/%s-%s' "$base" "$name" "$(short_hash "$home")"
 }
 
-# The `root` value already configured for this clone, empty when unset. Only
-# top-level keys count: treehouse's config is flat, and a `root` under some
-# future [section] would be a different key entirely.
-configured_root() {  # <toml>
-  local toml=$1 line value
-  [ -f "$toml" ] || return 0
-  while IFS= read -r line; do
-    case "$line" in
-      \[*) break ;;
-      root[[:space:]]*=*|root=*) ;;
-      *) continue ;;
-    esac
-    value=${line#*=}
-    value=${value#"${value%%[![:space:]]*}"}
-    value=${value%"${value##*[![:space:]]}"}
-    case "$value" in
-      \"*\") value=${value#\"}; value=${value%\"} ;;
-      \'*\') value=${value#\'}; value=${value%\'} ;;
-    esac
-    printf '%s' "$value"
-    return 0
-  done < "$toml"
+project_view() {  # <project>
+  local project=$1 home project_real name
+  home=$(canonical_home) \
+    || die "cannot resolve FM_HOME '$FM_HOME' for pool isolation"
+  project_real=$(cd "$project" 2>/dev/null && pwd -P) \
+    || die "cannot resolve project '$project' for pool isolation"
+  name=$(basename "$project_real")
+  printf '%s/state/treehouse-config/%s/%s' \
+    "$home" "$(short_hash "$project_real")" "$name"
 }
 
-# Rewrite <toml> so its top-level `root` is <root>, preserving every other line.
-# A file with no top-level `root` gains one at the top, where TOML requires
-# keys that belong to no section to live anyway.
-write_root() {  # <toml> <root>
-  local toml=$1 root=$2 tmp body seen=0 line in_body=1
-  tmp=$(mktemp "${toml%/*}/.fm-treehouse-toml.XXXXXX") || return 1
-  body=$(mktemp "${toml%/*}/.fm-treehouse-body.XXXXXX") || { rm -f -- "$tmp"; return 1; }
-  if [ -f "$toml" ]; then
-    while IFS= read -r line || [ -n "$line" ]; do
-      case "$line" in
-        \[*) in_body=0 ;;
-      esac
-      if [ "$in_body" = 1 ]; then
-        case "$line" in
-          root[[:space:]]*=*|root=*)
-            [ "$seen" = 1 ] || printf 'root = "%s"\n' "$root" >> "$body"
-            seen=1
-            continue
-            ;;
-        esac
-      fi
-      printf '%s\n' "$line" >> "$body"
-    done < "$toml"
-  fi
-  if [ "$seen" = 0 ]; then
-    printf 'root = "%s"\n' "$root" > "$tmp"
-  fi
-  cat "$body" >> "$tmp" || { rm -f -- "$tmp" "$body"; return 1; }
-  rm -f -- "$body"
-  chmod 0644 "$tmp" || { rm -f -- "$tmp"; return 1; }
-  mv -f -- "$tmp" "$toml"
+toml_basic_string() {  # <value>
+  command -v node >/dev/null 2>&1 || return 1
+  node -e 'process.stdout.write(JSON.stringify(process.argv[1]))' "$1"
 }
 
-# Keep the clone's own status clean: the file is machine-local configuration,
-# never project content.
-exclude_from_git() {  # <project> <relative-path>
-  local project=$1 rel=$2 excl grep_status backup='' had_exclude=0
-  excl=$(git -C "$project" rev-parse --git-path info/exclude 2>/dev/null) || return 1
-  [ -n "$excl" ] || return 1
-  case "$excl" in
-    /*) ;;
-    *) excl="$project/$excl" ;;
+write_config() {  # <view> <project-git-dir> <root>
+  local requested_view=$1 project_git_dir=$2 root=$3 home real_view toml tmp literal git_link
+  home=$(canonical_home) || return 1
+  mkdir -p "$requested_view" || return 1
+  real_view=$(cd "$requested_view" 2>/dev/null && pwd -P) || return 1
+  case "$real_view" in
+    "$home"/*) ;;
+    *) return 1 ;;
   esac
-  mkdir -p "$(dirname "$excl")" 2>/dev/null || return 1
-  if [ -e "$excl" ] || [ -L "$excl" ]; then
-    [ -f "$excl" ] && [ ! -L "$excl" ] || return 1
-    grep -qxF "$rel" "$excl" 2>/dev/null
-    grep_status=$?
-    case "$grep_status" in
-      0)
-        git -C "$project" check-ignore -q -- "$rel" 2>/dev/null
-        return $?
-        ;;
-      1)
-        backup=$(mktemp "$(dirname "$excl")/.fm-git-exclude.XXXXXX") || return 1
-        cp -p -- "$excl" "$backup" || { rm -f -- "$backup"; return 1; }
-        had_exclude=1
-        printf '%s\n' "$rel" >> "$excl" || {
-          mv -f -- "$backup" "$excl" 2>/dev/null || return 1
-          return 1
-        }
-        ;;
-      *) return 1 ;;
-    esac
+  git_link="$real_view/.git"
+  if [ -e "$git_link" ] || [ -L "$git_link" ]; then
+    [ -L "$git_link" ] || return 1
+    [ "$(readlink "$git_link")" = "$project_git_dir" ] || return 1
   else
-    printf '%s\n' "$rel" > "$excl" || { rm -f -- "$excl"; return 1; }
+    ln -s "$project_git_dir" "$git_link" || return 1
   fi
-  if git -C "$project" check-ignore -q -- "$rel" 2>/dev/null; then
-    if [ -n "$backup" ] && ! rm -f -- "$backup"; then
-      mv -f -- "$backup" "$excl" 2>/dev/null || true
-      return 1
-    fi
-    return 0
+  git -C "$real_view" rev-parse --show-toplevel >/dev/null 2>&1 || return 1
+  toml="$real_view/treehouse.toml"
+  if [ -e "$toml" ] || [ -L "$toml" ]; then
+    [ -f "$toml" ] && [ ! -L "$toml" ] || return 1
   fi
-  if [ "$had_exclude" = 1 ]; then
-    mv -f -- "$backup" "$excl" 2>/dev/null || return 1
+  literal=$(toml_basic_string "$root") || return 1
+  tmp=$(mktemp "$real_view/.fm-treehouse-config.XXXXXX") || return 1
+  printf 'root = %s\n' "$literal" > "$tmp" \
+    || { rm -f -- "$tmp"; return 1; }
+  chmod 0600 "$tmp" || { rm -f -- "$tmp"; return 1; }
+  if [ -f "$toml" ] && cmp -s "$tmp" "$toml"; then
+    rm -f -- "$tmp"
   else
-    rm -f -- "$excl" 2>/dev/null || return 1
+    mv -f -- "$tmp" "$toml" || { rm -f -- "$tmp"; return 1; }
   fi
-  return 1
-}
-
-restore_toml() {  # <toml> <backup> <had-file>
-  local toml=$1 backup=$2 had_file=$3
-  if [ "$had_file" = 1 ]; then
-    mv -f -- "$backup" "$toml"
-  else
-    rm -f -- "$toml"
-  fi
+  literal=$(toml_basic_string "$root") || return 1
+  [ "$(cat "$toml" 2>/dev/null)" = "root = $literal" ] || return 1
 }
 
 case "${1:-}" in
@@ -193,12 +136,17 @@ case "${1:-}" in
     printf '\n'
     exit 0
     ;;
+  --view)
+    [ "$#" -eq 2 ] || die "usage: fm-pool-root.sh --view <project-dir>"
+    VIEW_ONLY=1
+    shift
+    ;;
   ''|-*)
-    die "usage: fm-pool-root.sh <project-dir> | fm-pool-root.sh --print"
+    die "usage: fm-pool-root.sh <project-dir> | fm-pool-root.sh --view <project-dir> | fm-pool-root.sh --print"
     ;;
 esac
 
-[ "$#" -eq 1 ] || die "usage: fm-pool-root.sh <project-dir>"
+[ "$#" -eq 1 ] || die "usage: fm-pool-root.sh <project-dir> | fm-pool-root.sh --view <project-dir> | fm-pool-root.sh --print"
 PROJECT=$1
 [ -d "$PROJECT" ] || die "project directory '$PROJECT' does not exist"
 PROJECT=$(cd "$PROJECT" && pwd -P) || die "cannot resolve project directory '$1'"
@@ -208,56 +156,18 @@ PROJECT_GIT_DIR=$(git -C "$PROJECT" rev-parse --absolute-git-dir 2>/dev/null) \
   || die "project directory '$PROJECT' has no available Git directory"
 
 ROOT_VALUE=$(pool_root) || exit 1
-TOML="$PROJECT/treehouse.toml"
-TOML_BACKUP=''
-TOML_HAD_FILE=0
-TOML_CHANGED=0
-
-if git -C "$PROJECT" ls-files --error-unmatch treehouse.toml >/dev/null 2>&1; then
-  die "project '$PROJECT' tracks treehouse.toml, so this home cannot claim its own worktree pool without changing project content. Untrack that file, then spawn again"
-fi
-
-if [ -e "$TOML" ] || [ -L "$TOML" ]; then
-  [ -f "$TOML" ] && [ ! -L "$TOML" ] \
-    || die "'$TOML' is not a regular file; refusing to configure this home's pool root"
-fi
+CONFIG_VIEW=$(project_view "$PROJECT") || exit 1
 
 # Create and canonicalize before recording it: one home must always resolve the
 # same string, or an every-spawn rewrite would churn the file for nothing.
 mkdir -p "$ROOT_VALUE" || die "could not create this home's pool root '$ROOT_VALUE'"
 ROOT_VALUE=$(cd "$ROOT_VALUE" && pwd -P) || die "could not resolve this home's pool root"
+write_config "$CONFIG_VIEW" "$PROJECT_GIT_DIR" "$ROOT_VALUE" \
+  || die "could not write and verify this home's isolated Treehouse config view at '$CONFIG_VIEW'"
 
-if [ "$(configured_root "$TOML")" != "$ROOT_VALUE" ]; then
-  if [ -f "$TOML" ]; then
-    TOML_BACKUP=$(mktemp "$PROJECT_GIT_DIR/fm-treehouse-rollback.XXXXXX") \
-      || die "could not preserve '$TOML' before configuring this home's pool"
-    cp -p -- "$TOML" "$TOML_BACKUP" || {
-      rm -f -- "$TOML_BACKUP"
-      die "could not preserve '$TOML' before configuring this home's pool"
-    }
-    TOML_HAD_FILE=1
-  fi
-  if ! write_root "$TOML" "$ROOT_VALUE"; then
-    restore_toml "$TOML" "$TOML_BACKUP" "$TOML_HAD_FILE" \
-      || die "could not restore '$TOML' after its pool-root write failed"
-    die "could not record this home's pool root in '$TOML'"
-  fi
-  TOML_CHANGED=1
-fi
-if [ "$(configured_root "$TOML")" != "$ROOT_VALUE" ]; then
-  [ "$TOML_CHANGED" = 0 ] \
-    || restore_toml "$TOML" "$TOML_BACKUP" "$TOML_HAD_FILE" \
-    || die "could not restore '$TOML' after verification failed"
-  die "could not verify this home's pool root in '$TOML'"
-fi
-if ! exclude_from_git "$PROJECT" treehouse.toml; then
-  [ "$TOML_CHANGED" = 0 ] \
-    || restore_toml "$TOML" "$TOML_BACKUP" "$TOML_HAD_FILE" \
-    || die "could not restore '$TOML' after Git exclusion failed"
-  die "could not exclude treehouse.toml from project '$PROJECT' or verify that Git ignores it"
-fi
-if [ -n "$TOML_BACKUP" ]; then
-  rm -f -- "$TOML_BACKUP" || die "could not remove the completed rollback snapshot for '$TOML'"
+if [ "${VIEW_ONLY:-0}" = 1 ]; then
+  printf '%s\n' "$CONFIG_VIEW"
+  exit 0
 fi
 
 printf '%s\n' "$ROOT_VALUE"

--- a/bin/fm-pool-root.sh
+++ b/bin/fm-pool-root.sh
@@ -40,6 +40,7 @@ set -u
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+TRANSACTION_CREATED_DIRS=()
 
 die() {
   printf 'fm-pool-root.sh: %s\n' "$*" >&2
@@ -97,6 +98,42 @@ canonical_intended_path() {  # <path>
   printf '%s%s' "$anchor" "$suffix"
 }
 
+ensure_transaction_directory() {  # <path>
+  local target=$1 probe parent i
+  local -a missing=()
+  if [ -e "$target" ] || [ -L "$target" ]; then
+    [ -d "$target" ] || return 1
+    return 0
+  fi
+  probe=$target
+  while [ ! -e "$probe" ] && [ ! -L "$probe" ]; do
+    missing+=("$probe")
+    parent=$(dirname "$probe")
+    [ "$parent" != "$probe" ] || return 1
+    probe=$parent
+  done
+  [ -d "$probe" ] || return 1
+  for ((i=${#missing[@]} - 1; i >= 0; i--)); do
+    if mkdir -- "${missing[$i]}"; then
+      TRANSACTION_CREATED_DIRS+=("${missing[$i]}")
+    elif [ ! -d "${missing[$i]}" ]; then
+      return 1
+    fi
+  done
+}
+
+rollback_transaction_directories() {
+  local i status=0 path
+  for ((i=${#TRANSACTION_CREATED_DIRS[@]} - 1; i >= 0; i--)); do
+    path=${TRANSACTION_CREATED_DIRS[$i]}
+    if [ -e "$path" ] || [ -L "$path" ]; then
+      rmdir -- "$path" 2>/dev/null || status=1
+    fi
+  done
+  TRANSACTION_CREATED_DIRS=()
+  return "$status"
+}
+
 project_view() {  # <project>
   local project=$1 home project_real name
   home=$(canonical_home) \
@@ -110,7 +147,7 @@ project_view() {  # <project>
 
 toml_basic_string() {  # <value>
   command -v node >/dev/null 2>&1 || return 1
-  node -e 'process.stdout.write(JSON.stringify(process.argv[1]))' "$1"
+  node -e 'process.stdout.write(JSON.stringify(process.argv[1]).replace(/\u007f/g, "\\u007F"))' "$1"
 }
 
 configured_root() {  # <toml>
@@ -142,7 +179,7 @@ write_config() {  # <view> <project-git-dir> <project-common-dir> <root>
   local status=0 rollback_status=0
   home=$(canonical_home) || return 1
   if [ ! -e "$requested_view" ] && [ ! -L "$requested_view" ]; then
-    mkdir -p "$requested_view" || return 1
+    ensure_transaction_directory "$requested_view" || return 1
     view_created=1
   fi
   [ -d "$requested_view" ] && [ ! -L "$requested_view" ] || return 1
@@ -279,6 +316,12 @@ write_config() {  # <view> <project-git-dir> <project-common-dir> <root>
     git -C "$real_view" check-ignore -q -- .gitignore 2>/dev/null || status=1
   fi
   if [ "$status" -eq 0 ]; then
+    command -v treehouse >/dev/null 2>&1 || status=1
+  fi
+  if [ "$status" -eq 0 ]; then
+    (cd "$real_view" && treehouse status >/dev/null 2>&1) || status=1
+  fi
+  if [ "$status" -eq 0 ]; then
     rm -f -- "$transaction/treehouse.toml" "$transaction/.gitignore" 2>/dev/null || true
     rm -f -- "$transaction/old.git" 2>/dev/null || true
     rmdir "$transaction" 2>/dev/null || true
@@ -355,10 +398,20 @@ esac
 
 # Create and canonicalize before recording it: one home must always resolve the
 # same string, or an every-spawn rewrite would churn the file for nothing.
-mkdir -p "$ROOT_VALUE" || die "could not create this home's pool root '$ROOT_VALUE'"
-ROOT_VALUE=$(cd "$ROOT_VALUE" && pwd -P) || die "could not resolve this home's pool root"
-write_config "$CONFIG_VIEW" "$PROJECT_GIT_DIR" "$PROJECT_GIT_COMMON_DIR" "$ROOT_VALUE" \
-  || die "could not write and verify this home's isolated Treehouse config view at '$CONFIG_VIEW'"
+if ! ensure_transaction_directory "$ROOT_VALUE"; then
+  rollback_transaction_directories || true
+  die "could not create this home's pool root '$ROOT_VALUE'"
+fi
+if ! ROOT_VALUE=$(cd "$ROOT_VALUE" && pwd -P); then
+  rollback_transaction_directories || true
+  die "could not resolve this home's pool root"
+fi
+if ! write_config "$CONFIG_VIEW" "$PROJECT_GIT_DIR" "$PROJECT_GIT_COMMON_DIR" "$ROOT_VALUE"; then
+  if ! rollback_transaction_directories; then
+    die "could not fully roll back failed Treehouse configuration at '$CONFIG_VIEW'"
+  fi
+  die "could not write and verify this home's isolated Treehouse config view at '$CONFIG_VIEW'"
+fi
 
 if [ "${VIEW_ONLY:-0}" = 1 ]; then
   printf '%s\n' "$CONFIG_VIEW"

--- a/bin/fm-pool-root.sh
+++ b/bin/fm-pool-root.sh
@@ -75,6 +75,10 @@ pool_root() {
     [ -n "${HOME:-}" ] || die "cannot derive a pool root: neither FM_POOL_ROOT_BASE nor HOME is set"
     base="$HOME/.treehouse-homes"
   fi
+  case "$base" in
+    /*) ;;
+    *) die "pool root base '$base' must be absolute; set FM_POOL_ROOT_BASE to an absolute path" ;;
+  esac
   name=$(basename "$home")
   [ -n "$name" ] && [ "$name" != / ] || name=home
   printf '%s/%s-%s' "$base" "$name" "$(short_hash "$home")"

--- a/bin/fm-pool-root.sh
+++ b/bin/fm-pool-root.sh
@@ -166,7 +166,10 @@ if git -C "$PROJECT" ls-files --error-unmatch treehouse.toml >/dev/null 2>&1; th
   die "project '$PROJECT' tracks treehouse.toml, so this home cannot claim its own worktree pool without changing project content. Untrack that file, then spawn again"
 fi
 
-[ ! -L "$TOML" ] || die "'$TOML' is a symlink; refusing to write this home's pool root through it"
+if [ -e "$TOML" ] || [ -L "$TOML" ]; then
+  [ -f "$TOML" ] && [ ! -L "$TOML" ] \
+    || die "'$TOML' is not a regular file; refusing to configure this home's pool root"
+fi
 
 # Create and canonicalize before recording it: one home must always resolve the
 # same string, or an every-spawn rewrite would churn the file for nothing.
@@ -176,6 +179,8 @@ ROOT_VALUE=$(cd "$ROOT_VALUE" && pwd -P) || die "could not resolve this home's p
 if [ "$(configured_root "$TOML")" != "$ROOT_VALUE" ]; then
   write_root "$TOML" "$ROOT_VALUE" || die "could not record this home's pool root in '$TOML'"
 fi
+[ "$(configured_root "$TOML")" = "$ROOT_VALUE" ] \
+  || die "could not verify this home's pool root in '$TOML'"
 exclude_from_git "$PROJECT" treehouse.toml
 
 printf '%s\n' "$ROOT_VALUE"

--- a/bin/fm-pool-root.sh
+++ b/bin/fm-pool-root.sh
@@ -131,15 +131,27 @@ write_root() {  # <toml> <root>
 # Keep the clone's own status clean: the file is machine-local configuration,
 # never project content.
 exclude_from_git() {  # <project> <relative-path>
-  local project=$1 rel=$2 excl
-  excl=$(git -C "$project" rev-parse --git-path info/exclude 2>/dev/null) || return 0
-  [ -n "$excl" ] || return 0
+  local project=$1 rel=$2 excl grep_status
+  excl=$(git -C "$project" rev-parse --git-path info/exclude 2>/dev/null) || return 1
+  [ -n "$excl" ] || return 1
   case "$excl" in
     /*) ;;
     *) excl="$project/$excl" ;;
   esac
-  mkdir -p "$(dirname "$excl")" 2>/dev/null || return 0
-  grep -qxF "$rel" "$excl" 2>/dev/null || printf '%s\n' "$rel" >> "$excl"
+  mkdir -p "$(dirname "$excl")" 2>/dev/null || return 1
+  if [ -e "$excl" ] || [ -L "$excl" ]; then
+    [ -f "$excl" ] && [ ! -L "$excl" ] || return 1
+    grep -qxF "$rel" "$excl" 2>/dev/null
+    grep_status=$?
+    case "$grep_status" in
+      0) ;;
+      1) printf '%s\n' "$rel" >> "$excl" || return 1 ;;
+      *) return 1 ;;
+    esac
+  else
+    printf '%s\n' "$rel" > "$excl" || return 1
+  fi
+  git -C "$project" check-ignore -q -- "$rel" 2>/dev/null
 }
 
 case "${1:-}" in
@@ -181,6 +193,7 @@ if [ "$(configured_root "$TOML")" != "$ROOT_VALUE" ]; then
 fi
 [ "$(configured_root "$TOML")" = "$ROOT_VALUE" ] \
   || die "could not verify this home's pool root in '$TOML'"
-exclude_from_git "$PROJECT" treehouse.toml
+exclude_from_git "$PROJECT" treehouse.toml \
+  || die "could not exclude treehouse.toml from project '$PROJECT' or verify that Git ignores it"
 
 printf '%s\n' "$ROOT_VALUE"

--- a/bin/fm-pool-root.sh
+++ b/bin/fm-pool-root.sh
@@ -15,7 +15,7 @@
 #   fm-pool-root.sh --print         print this home's pool root, write nothing
 #
 # The root is <base>/<home-basename>-<hash of the home's real path>, with base
-# ${FM_POOL_ROOT_BASE:-$HOME/.treehouse-homes}; FM_POOL_ROOT names one outright.
+# ${FM_POOL_ROOT_BASE:-$HOME/.treehouse-homes}.
 # Treehouse then places the pool itself at <root>/.treehouse/<repo>-<hash>/.
 #
 # Idempotent by design, so running it before every spawn converges without
@@ -30,8 +30,7 @@
 #
 # A clone that TRACKS treehouse.toml is refused rather than rewritten: silently
 # committing a machine-local path would be worse than stopping, and silently
-# sharing a pool is the very thing this exists to prevent. Exclude the file or
-# set FM_POOL_ROOT to resolve it.
+# sharing a pool is the very thing this exists to prevent.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -58,14 +57,13 @@ short_hash() {  # <string>
 # root, because two homes sharing one code root would still double-claim.
 pool_root() {
   local home base name
-  if [ -n "${FM_POOL_ROOT:-}" ]; then
-    printf '%s' "$FM_POOL_ROOT"
-    return 0
-  fi
-  home=$(cd "$FM_HOME" 2>/dev/null && pwd -P) || home=$FM_HOME
+  [ -z "${FM_POOL_ROOT:-}" ] \
+    || die "FM_POOL_ROOT cannot preserve per-home isolation; use FM_POOL_ROOT_BASE"
+  home=$(cd "$FM_HOME" 2>/dev/null && pwd -P) \
+    || die "cannot resolve FM_HOME '$FM_HOME' for pool isolation"
   base=${FM_POOL_ROOT_BASE:-}
   if [ -z "$base" ]; then
-    [ -n "${HOME:-}" ] || die "cannot derive a pool root: neither FM_POOL_ROOT, FM_POOL_ROOT_BASE, nor HOME is set"
+    [ -n "${HOME:-}" ] || die "cannot derive a pool root: neither FM_POOL_ROOT_BASE nor HOME is set"
     base="$HOME/.treehouse-homes"
   fi
   name=$(basename "$home")
@@ -165,7 +163,7 @@ ROOT_VALUE=$(pool_root) || exit 1
 TOML="$PROJECT/treehouse.toml"
 
 if git -C "$PROJECT" ls-files --error-unmatch treehouse.toml >/dev/null 2>&1; then
-  die "project '$PROJECT' tracks treehouse.toml, so this home cannot claim its own worktree pool without changing project content. Untrack or exclude that file, or set FM_POOL_ROOT, then spawn again"
+  die "project '$PROJECT' tracks treehouse.toml, so this home cannot claim its own worktree pool without changing project content. Untrack that file, then spawn again"
 fi
 
 [ ! -L "$TOML" ] || die "'$TOML' is a symlink; refusing to write this home's pool root through it"

--- a/bin/fm-project-script-lib.sh
+++ b/bin/fm-project-script-lib.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# bin/fm-project-script-lib.sh - ONE owner for the "a project opts in by
+# publishing a script" contract.
+#
+# Some guarantees only the project can answer: whether a pooled working copy
+# still has an owner (`check:worktree-custody`, bin/fm-teardown.sh), or which
+# delivered copies it is safe to release back to the pool
+# (`pool:release-delivered`, bin/fm-spawn.sh). Firstmate never implements those
+# verdicts; it asks the project, and only when the project published one.
+#
+# The contract, stated once:
+#   - Opt-in is presence of that exact key in the project's package.json
+#     "scripts". No package.json, or no such key, means the project published
+#     nothing and firstmate must behave exactly as it did before.
+#   - The manifest, not a grep, is authoritative. A project that looks like it
+#     published one but cannot be read is reported as UNCONFIRMED, and each
+#     caller applies its own policy - a safety gate refuses, housekeeping warns.
+#   - The runner is whichever package manager the project's own lockfile
+#     selects, and extra arguments reach the script the way that manager passes
+#     them (pnpm directly, npm and yarn behind `--`).
+#
+# Callers source this file; it defines functions only.
+
+FM_PROJECT_SCRIPT_DECLARED=0
+FM_PROJECT_SCRIPT_ABSENT=1
+FM_PROJECT_SCRIPT_UNCONFIRMED=2
+
+# Does <dir> publish <script>? Prints nothing.
+#   0 declared, 1 absent, 2 published-but-unconfirmable (no node to read it).
+fm_project_script_declared() {  # <dir> <script>
+  local dir=$1 script=$2
+  [ -f "$dir/package.json" ] || return "$FM_PROJECT_SCRIPT_ABSENT"
+  # Cheap presence signal first, so a project with no such script never pays
+  # for a node process.
+  grep -Fq "\"$script\"" "$dir/package.json" 2>/dev/null \
+    || return "$FM_PROJECT_SCRIPT_ABSENT"
+  command -v node >/dev/null 2>&1 || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
+  node -e 'const p=require(process.argv[1]);process.exit(p.scripts&&p.scripts[process.argv[2]]?0:1)' \
+    "$dir/package.json" "$script" 2>/dev/null \
+    || return "$FM_PROJECT_SCRIPT_ABSENT"
+  return "$FM_PROJECT_SCRIPT_DECLARED"
+}
+
+fm_project_script_manager() {  # <dir>
+  local dir=$1
+  if [ -f "$dir/pnpm-lock.yaml" ]; then printf 'pnpm\n'
+  elif [ -f "$dir/yarn.lock" ]; then printf 'yarn\n'
+  else printf 'npm\n'
+  fi
+}
+
+# Run <dir>'s <script> with <timeout> seconds and any extra arguments,
+# preserving its stdout, stderr, and exit status. Exit 127 means the selected
+# package manager is not installed, which no caller may read as a verdict.
+fm_project_script_run() {  # <dir> <script> <timeout> [args...]
+  local dir=$1 script=$2 timeout_secs=$3 manager bound
+  shift 3
+  manager=$(fm_project_script_manager "$dir")
+  command -v "$manager" >/dev/null 2>&1 || return 127
+  bound=
+  if command -v timeout >/dev/null 2>&1; then bound=timeout
+  elif command -v gtimeout >/dev/null 2>&1; then bound=gtimeout
+  fi
+  local -a argv
+  argv=("$manager" run "$script")
+  if [ "$#" -gt 0 ]; then
+    # pnpm forwards trailing arguments to the script; npm and yarn need `--`.
+    [ "$manager" = pnpm ] || argv+=(--)
+    argv+=("$@")
+  fi
+  if [ -n "$bound" ]; then
+    ( cd "$dir" && "$bound" "$timeout_secs" "${argv[@]}" )
+  else
+    ( cd "$dir" && "${argv[@]}" )
+  fi
+}

--- a/bin/fm-project-script-lib.sh
+++ b/bin/fm-project-script-lib.sh
@@ -9,11 +9,11 @@
 # verdicts; it asks the project, and only when the project published one.
 #
 # The contract, stated once:
-#   - Opt-in is presence of that exact key in the project's package.json
-#     "scripts". No untracked package.json, or no such key, means the project
-#     published nothing and firstmate must behave exactly as it did before. A
-#     missing manifest is resolved against both the index and HEAD; an
-#     unavailable repository or unreadable published manifest is unconfirmable.
+#   - Opt-in is presence of that exact key in any Git-proven package.json view:
+#     the working file when its path exists in the index or HEAD, the index, or
+#     HEAD. An untracked manifest publishes nothing. Absence is confirmed only
+#     when every available published view omits the key; an unavailable
+#     repository or unreadable published view is unconfirmable.
 #   - The manifest, not a grep, is authoritative. A project that looks like it
 #     published one but cannot be read is reported as UNCONFIRMED, and each
 #     caller applies its own policy - a safety gate refuses, housekeeping warns.
@@ -39,54 +39,69 @@ fm_project_manifest_script_verdict() {  # <script>
 # Does <dir> publish <script>? Prints nothing.
 #   0 declared, 1 absent, 2 unconfirmable.
 fm_project_script_declared() {  # <dir> <script>
-  local dir=$1 script=$2 verdict repo_top dir_real repo_real index_entry head_entry manifest
-  if [ ! -e "$dir/package.json" ] && [ ! -L "$dir/package.json" ]; then
-    [ -d "$dir" ] || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
-    repo_top=$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null) \
-      || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
-    dir_real=$(cd "$dir" 2>/dev/null && pwd -P) \
-      || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
-    repo_real=$(cd "$repo_top" 2>/dev/null && pwd -P) \
-      || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
-    [ "$dir_real" = "$repo_real" ] || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
-    git -C "$dir" rev-parse --verify HEAD >/dev/null 2>&1 \
-      || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
-    index_entry=$(git -C "$dir" ls-files --stage -- package.json 2>/dev/null) \
-      || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
-    head_entry=$(git -C "$dir" ls-tree --name-only HEAD -- package.json 2>/dev/null) \
-      || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
-    [ -n "$index_entry" ] || [ -n "$head_entry" ] \
-      || return "$FM_PROJECT_SCRIPT_ABSENT"
-    command -v node >/dev/null 2>&1 || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
-    if [ -n "$index_entry" ]; then
-      manifest=$(git -C "$dir" show :package.json 2>/dev/null) \
-        || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
-      verdict=$(printf '%s' "$manifest" | fm_project_manifest_script_verdict "$script" 2>/dev/null) \
-        || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
-      [ "$verdict" != declared ] || return "$FM_PROJECT_SCRIPT_DECLARED"
-      [ "$verdict" = absent ] || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
-    fi
-    if [ -n "$head_entry" ]; then
-      manifest=$(git -C "$dir" show HEAD:package.json 2>/dev/null) \
-        || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
-      verdict=$(printf '%s' "$manifest" | fm_project_manifest_script_verdict "$script" 2>/dev/null) \
-        || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
-      [ "$verdict" != declared ] || return "$FM_PROJECT_SCRIPT_DECLARED"
-      [ "$verdict" = absent ] || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
-    fi
-    return "$FM_PROJECT_SCRIPT_ABSENT"
-  fi
-  [ -f "$dir/package.json" ] && [ ! -L "$dir/package.json" ] \
+  local dir=$1 script=$2 verdict repo_top dir_real repo_real index_entry head_entry manifest unconfirmed=0
+  [ -d "$dir" ] || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
+  repo_top=$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null) \
     || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
+  dir_real=$(cd "$dir" 2>/dev/null && pwd -P) \
+    || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
+  repo_real=$(cd "$repo_top" 2>/dev/null && pwd -P) \
+    || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
+  [ "$dir_real" = "$repo_real" ] || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
+  git -C "$dir" rev-parse --verify HEAD >/dev/null 2>&1 \
+    || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
+  index_entry=$(git -C "$dir" ls-files --stage -- package.json 2>/dev/null) \
+    || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
+  head_entry=$(git -C "$dir" ls-tree --name-only HEAD -- package.json 2>/dev/null) \
+    || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
+  [ -n "$index_entry" ] || [ -n "$head_entry" ] \
+    || return "$FM_PROJECT_SCRIPT_ABSENT"
   command -v node >/dev/null 2>&1 || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
-  if ! verdict=$(fm_project_manifest_script_verdict "$script" < "$dir/package.json" 2>/dev/null); then
-    return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
+
+  if [ -e "$dir/package.json" ] || [ -L "$dir/package.json" ]; then
+    if [ -f "$dir/package.json" ] && [ ! -L "$dir/package.json" ]; then
+      if verdict=$(fm_project_manifest_script_verdict "$script" < "$dir/package.json" 2>/dev/null); then
+        case "$verdict" in
+          declared) return "$FM_PROJECT_SCRIPT_DECLARED" ;;
+          absent) ;;
+          *) unconfirmed=1 ;;
+        esac
+      else
+        unconfirmed=1
+      fi
+    else
+      unconfirmed=1
+    fi
   fi
-  case "$verdict" in
-    declared) return "$FM_PROJECT_SCRIPT_DECLARED" ;;
-    absent) return "$FM_PROJECT_SCRIPT_ABSENT" ;;
-    *) return "$FM_PROJECT_SCRIPT_UNCONFIRMED" ;;
-  esac
+
+  if [ -n "$index_entry" ]; then
+    if manifest=$(git -C "$dir" show :package.json 2>/dev/null) \
+      && verdict=$(printf '%s' "$manifest" | fm_project_manifest_script_verdict "$script" 2>/dev/null); then
+      case "$verdict" in
+        declared) return "$FM_PROJECT_SCRIPT_DECLARED" ;;
+        absent) ;;
+        *) unconfirmed=1 ;;
+      esac
+    else
+      unconfirmed=1
+    fi
+  fi
+
+  if [ -n "$head_entry" ]; then
+    if manifest=$(git -C "$dir" show HEAD:package.json 2>/dev/null) \
+      && verdict=$(printf '%s' "$manifest" | fm_project_manifest_script_verdict "$script" 2>/dev/null); then
+      case "$verdict" in
+        declared) return "$FM_PROJECT_SCRIPT_DECLARED" ;;
+        absent) ;;
+        *) unconfirmed=1 ;;
+      esac
+    else
+      unconfirmed=1
+    fi
+  fi
+
+  [ "$unconfirmed" -eq 0 ] || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
+  return "$FM_PROJECT_SCRIPT_ABSENT"
 }
 
 fm_project_script_manager() {  # <dir>

--- a/bin/fm-project-script-lib.sh
+++ b/bin/fm-project-script-lib.sh
@@ -142,7 +142,7 @@ fm_project_script_run() {  # <dir> <script> <timeout> [args...]
 }
 
 fm_project_script_run_canonical_head() (  # <dir> <script> <timeout> [args...]
-  local dir=$1 script=$2 timeout_secs=$3 head manifest verdict git_dir tmp_root archive source rc=0
+  local dir=$1 script=$2 timeout_secs=$3 head manifest verdict tmp_root archive source rc=0
   shift 3
   fm_project_script_timeout_valid "$timeout_secs" \
     || return "$FM_PROJECT_SCRIPT_INVALID_TIMEOUT"
@@ -155,10 +155,10 @@ fm_project_script_run_canonical_head() (  # <dir> <script> <timeout> [args...]
     || return "$FM_PROJECT_SCRIPT_CANONICAL_UNAVAILABLE"
   [ "$verdict" = declared ] || return "$FM_PROJECT_SCRIPT_CANONICAL_UNAVAILABLE"
   command -v tar >/dev/null 2>&1 || return "$FM_PROJECT_SCRIPT_CANONICAL_UNAVAILABLE"
-  git_dir=$(git -C "$dir" rev-parse --absolute-git-dir 2>/dev/null) \
-    || return "$FM_PROJECT_SCRIPT_CANONICAL_UNAVAILABLE"
-  [ -d "$git_dir" ] || return "$FM_PROJECT_SCRIPT_CANONICAL_UNAVAILABLE"
-  tmp_root=$(mktemp -d "$git_dir/fm-project-script.XXXXXX") \
+  # The snapshot must not be nested under the mutable clone: Node and other
+  # runtimes search ancestor directories for dependencies even without an
+  # explicit symlink, which would still let clone/node_modules forge a verdict.
+  tmp_root=$(mktemp -d /tmp/fm-project-script.XXXXXX) \
     || return "$FM_PROJECT_SCRIPT_CANONICAL_UNAVAILABLE"
   trap 'rm -rf -- "$tmp_root"' EXIT
   trap 'exit "$FM_PROJECT_SCRIPT_CANONICAL_UNAVAILABLE"' HUP INT TERM
@@ -170,10 +170,11 @@ fm_project_script_run_canonical_head() (  # <dir> <script> <timeout> [args...]
   tar -xf "$archive" -C "$source" 2>/dev/null \
     || return "$FM_PROJECT_SCRIPT_CANONICAL_UNAVAILABLE"
   rm -f -- "$archive" || return "$FM_PROJECT_SCRIPT_CANONICAL_UNAVAILABLE"
-  if [ -d "$dir/node_modules" ] && [ ! -e "$source/node_modules" ]; then
-    ln -s "$dir/node_modules" "$source/node_modules" \
-      || return "$FM_PROJECT_SCRIPT_CANONICAL_UNAVAILABLE"
-  fi
+  # Never link dependencies from a mutable clone into this authenticated HEAD
+  # snapshot. A self-contained published check can run; a check that needs
+  # untracked or mutable node_modules fails closed at its safety caller rather
+  # than letting arbitrary dependency code authorize destructive cleanup.
+  unset NODE_PATH NODE_OPTIONS
   fm_project_script_run "$source" "$script" "$timeout_secs" "$@" || rc=$?
   return "$rc"
 )

--- a/bin/fm-project-script-lib.sh
+++ b/bin/fm-project-script-lib.sh
@@ -10,8 +10,9 @@
 #
 # The contract, stated once:
 #   - Opt-in is presence of that exact key in the project's package.json
-#     "scripts". No package.json, or no such key, means the project published
-#     nothing and firstmate must behave exactly as it did before.
+#     "scripts". No untracked package.json, or no such key, means the project
+#     published nothing and firstmate must behave exactly as it did before. A
+#     tracked manifest missing from the checkout is unconfirmable, not absent.
 #   - The manifest, not a grep, is authoritative. A project that looks like it
 #     published one but cannot be read is reported as UNCONFIRMED, and each
 #     caller applies its own policy - a safety gate refuses, housekeeping warns.
@@ -32,8 +33,19 @@ FM_PROJECT_SCRIPT_INVALID_TIMEOUT=125
 # Does <dir> publish <script>? Prints nothing.
 #   0 declared, 1 absent, 2 unconfirmable.
 fm_project_script_declared() {  # <dir> <script>
-  local dir=$1 script=$2 verdict
-  [ -f "$dir/package.json" ] || return "$FM_PROJECT_SCRIPT_ABSENT"
+  local dir=$1 script=$2 verdict tracked
+  if [ ! -e "$dir/package.json" ] && [ ! -L "$dir/package.json" ]; then
+    if git -C "$dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+      tracked=$(git -C "$dir" ls-files --stage -- package.json 2>/dev/null) \
+        || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
+      [ -z "$tracked" ] || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
+    elif [ -e "$dir/.git" ] || [ -L "$dir/.git" ]; then
+      return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
+    fi
+    return "$FM_PROJECT_SCRIPT_ABSENT"
+  fi
+  [ -f "$dir/package.json" ] && [ ! -L "$dir/package.json" ] \
+    || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
   command -v node >/dev/null 2>&1 || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
   if ! verdict=$(node -e 'const fs=require("fs"); const p=JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.stdout.write(p.scripts && Object.prototype.hasOwnProperty.call(p.scripts, process.argv[2]) ? "declared" : "absent");' \
     "$dir/package.json" "$script" 2>/dev/null); then

--- a/bin/fm-project-script-lib.sh
+++ b/bin/fm-project-script-lib.sh
@@ -21,24 +21,29 @@
 #
 # Callers source this file; it defines functions only.
 
+# shellcheck source=bin/fm-timeout-lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/fm-timeout-lib.sh"
+
 FM_PROJECT_SCRIPT_DECLARED=0
 FM_PROJECT_SCRIPT_ABSENT=1
 FM_PROJECT_SCRIPT_UNCONFIRMED=2
+FM_PROJECT_SCRIPT_INVALID_TIMEOUT=125
 
 # Does <dir> publish <script>? Prints nothing.
-#   0 declared, 1 absent, 2 published-but-unconfirmable (no node to read it).
+#   0 declared, 1 absent, 2 unconfirmable.
 fm_project_script_declared() {  # <dir> <script>
-  local dir=$1 script=$2
+  local dir=$1 script=$2 verdict
   [ -f "$dir/package.json" ] || return "$FM_PROJECT_SCRIPT_ABSENT"
-  # Cheap presence signal first, so a project with no such script never pays
-  # for a node process.
-  grep -Fq "\"$script\"" "$dir/package.json" 2>/dev/null \
-    || return "$FM_PROJECT_SCRIPT_ABSENT"
   command -v node >/dev/null 2>&1 || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
-  node -e 'const p=require(process.argv[1]);process.exit(p.scripts&&p.scripts[process.argv[2]]?0:1)' \
-    "$dir/package.json" "$script" 2>/dev/null \
-    || return "$FM_PROJECT_SCRIPT_ABSENT"
-  return "$FM_PROJECT_SCRIPT_DECLARED"
+  if ! verdict=$(node -e 'const fs=require("fs"); const p=JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.stdout.write(p.scripts && Object.prototype.hasOwnProperty.call(p.scripts, process.argv[2]) ? "declared" : "absent");' \
+    "$dir/package.json" "$script" 2>/dev/null); then
+    return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
+  fi
+  case "$verdict" in
+    declared) return "$FM_PROJECT_SCRIPT_DECLARED" ;;
+    absent) return "$FM_PROJECT_SCRIPT_ABSENT" ;;
+    *) return "$FM_PROJECT_SCRIPT_UNCONFIRMED" ;;
+  esac
 }
 
 fm_project_script_manager() {  # <dir>
@@ -53,14 +58,13 @@ fm_project_script_manager() {  # <dir>
 # preserving its stdout, stderr, and exit status. Exit 127 means the selected
 # package manager is not installed, which no caller may read as a verdict.
 fm_project_script_run() {  # <dir> <script> <timeout> [args...]
-  local dir=$1 script=$2 timeout_secs=$3 manager bound
+  local dir=$1 script=$2 timeout_secs=$3 manager
   shift 3
+  case "$timeout_secs" in
+    ''|*[!0-9]*|0) return "$FM_PROJECT_SCRIPT_INVALID_TIMEOUT" ;;
+  esac
   manager=$(fm_project_script_manager "$dir")
   command -v "$manager" >/dev/null 2>&1 || return 127
-  bound=
-  if command -v timeout >/dev/null 2>&1; then bound=timeout
-  elif command -v gtimeout >/dev/null 2>&1; then bound=gtimeout
-  fi
   local -a argv
   argv=("$manager" run "$script")
   if [ "$#" -gt 0 ]; then
@@ -68,9 +72,5 @@ fm_project_script_run() {  # <dir> <script> <timeout> [args...]
     [ "$manager" = pnpm ] || argv+=(--)
     argv+=("$@")
   fi
-  if [ -n "$bound" ]; then
-    ( cd "$dir" && "$bound" "$timeout_secs" "${argv[@]}" )
-  else
-    ( cd "$dir" && "${argv[@]}" )
-  fi
+  ( cd "$dir" && fm_run_timed "$timeout_secs" "${argv[@]}" )
 }

--- a/bin/fm-project-script-lib.sh
+++ b/bin/fm-project-script-lib.sh
@@ -12,7 +12,8 @@
 #   - Opt-in is presence of that exact key in the project's package.json
 #     "scripts". No untracked package.json, or no such key, means the project
 #     published nothing and firstmate must behave exactly as it did before. A
-#     tracked manifest missing from the checkout is unconfirmable, not absent.
+#     missing manifest is resolved against both the index and HEAD; an
+#     unavailable repository or unreadable published manifest is unconfirmable.
 #   - The manifest, not a grep, is authoritative. A project that looks like it
 #     published one but cannot be read is reported as UNCONFIRMED, and each
 #     caller applies its own policy - a safety gate refuses, housekeeping warns.
@@ -30,25 +31,55 @@ FM_PROJECT_SCRIPT_ABSENT=1
 FM_PROJECT_SCRIPT_UNCONFIRMED=2
 FM_PROJECT_SCRIPT_INVALID_TIMEOUT=125
 
+fm_project_manifest_script_verdict() {  # <script>
+  node -e 'const fs=require("fs"); const p=JSON.parse(fs.readFileSync(0, "utf8")); process.stdout.write(p.scripts && Object.prototype.hasOwnProperty.call(p.scripts, process.argv[1]) ? "declared" : "absent");' \
+    "$1"
+}
+
 # Does <dir> publish <script>? Prints nothing.
 #   0 declared, 1 absent, 2 unconfirmable.
 fm_project_script_declared() {  # <dir> <script>
-  local dir=$1 script=$2 verdict tracked
+  local dir=$1 script=$2 verdict repo_top dir_real repo_real index_entry head_entry manifest
   if [ ! -e "$dir/package.json" ] && [ ! -L "$dir/package.json" ]; then
-    if git -C "$dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-      tracked=$(git -C "$dir" ls-files --stage -- package.json 2>/dev/null) \
+    [ -d "$dir" ] || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
+    repo_top=$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null) \
+      || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
+    dir_real=$(cd "$dir" 2>/dev/null && pwd -P) \
+      || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
+    repo_real=$(cd "$repo_top" 2>/dev/null && pwd -P) \
+      || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
+    [ "$dir_real" = "$repo_real" ] || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
+    git -C "$dir" rev-parse --verify HEAD >/dev/null 2>&1 \
+      || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
+    index_entry=$(git -C "$dir" ls-files --stage -- package.json 2>/dev/null) \
+      || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
+    head_entry=$(git -C "$dir" ls-tree --name-only HEAD -- package.json 2>/dev/null) \
+      || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
+    [ -n "$index_entry" ] || [ -n "$head_entry" ] \
+      || return "$FM_PROJECT_SCRIPT_ABSENT"
+    command -v node >/dev/null 2>&1 || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
+    if [ -n "$index_entry" ]; then
+      manifest=$(git -C "$dir" show :package.json 2>/dev/null) \
         || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
-      [ -z "$tracked" ] || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
-    elif [ -e "$dir/.git" ] || [ -L "$dir/.git" ]; then
-      return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
+      verdict=$(printf '%s' "$manifest" | fm_project_manifest_script_verdict "$script" 2>/dev/null) \
+        || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
+      [ "$verdict" != declared ] || return "$FM_PROJECT_SCRIPT_DECLARED"
+      [ "$verdict" = absent ] || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
+    fi
+    if [ -n "$head_entry" ]; then
+      manifest=$(git -C "$dir" show HEAD:package.json 2>/dev/null) \
+        || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
+      verdict=$(printf '%s' "$manifest" | fm_project_manifest_script_verdict "$script" 2>/dev/null) \
+        || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
+      [ "$verdict" != declared ] || return "$FM_PROJECT_SCRIPT_DECLARED"
+      [ "$verdict" = absent ] || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
     fi
     return "$FM_PROJECT_SCRIPT_ABSENT"
   fi
   [ -f "$dir/package.json" ] && [ ! -L "$dir/package.json" ] \
     || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
   command -v node >/dev/null 2>&1 || return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
-  if ! verdict=$(node -e 'const fs=require("fs"); const p=JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.stdout.write(p.scripts && Object.prototype.hasOwnProperty.call(p.scripts, process.argv[2]) ? "declared" : "absent");' \
-    "$dir/package.json" "$script" 2>/dev/null); then
+  if ! verdict=$(fm_project_manifest_script_verdict "$script" < "$dir/package.json" 2>/dev/null); then
     return "$FM_PROJECT_SCRIPT_UNCONFIRMED"
   fi
   case "$verdict" in

--- a/bin/fm-project-script-lib.sh
+++ b/bin/fm-project-script-lib.sh
@@ -30,6 +30,7 @@ FM_PROJECT_SCRIPT_DECLARED=0
 FM_PROJECT_SCRIPT_ABSENT=1
 FM_PROJECT_SCRIPT_UNCONFIRMED=2
 FM_PROJECT_SCRIPT_INVALID_TIMEOUT=125
+FM_PROJECT_SCRIPT_CANONICAL_UNAVAILABLE=126
 
 fm_project_manifest_script_verdict() {  # <script>
   node -e 'const fs=require("fs"); const p=JSON.parse(fs.readFileSync(0, "utf8")); process.stdout.write(p.scripts && Object.prototype.hasOwnProperty.call(p.scripts, process.argv[1]) ? "declared" : "absent");' \
@@ -112,15 +113,22 @@ fm_project_script_manager() {  # <dir>
   fi
 }
 
+fm_project_script_timeout_valid() {  # <seconds>
+  case "$1" in
+    ''|*[!0-9]*) return 1 ;;
+    *[1-9]*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 # Run <dir>'s <script> with <timeout> seconds and any extra arguments,
 # preserving its stdout, stderr, and exit status. Exit 127 means the selected
 # package manager is not installed, which no caller may read as a verdict.
 fm_project_script_run() {  # <dir> <script> <timeout> [args...]
   local dir=$1 script=$2 timeout_secs=$3 manager
   shift 3
-  case "$timeout_secs" in
-    ''|*[!0-9]*|0) return "$FM_PROJECT_SCRIPT_INVALID_TIMEOUT" ;;
-  esac
+  fm_project_script_timeout_valid "$timeout_secs" \
+    || return "$FM_PROJECT_SCRIPT_INVALID_TIMEOUT"
   manager=$(fm_project_script_manager "$dir")
   command -v "$manager" >/dev/null 2>&1 || return 127
   local -a argv
@@ -132,3 +140,40 @@ fm_project_script_run() {  # <dir> <script> <timeout> [args...]
   fi
   ( cd "$dir" && fm_run_timed "$timeout_secs" "${argv[@]}" )
 }
+
+fm_project_script_run_canonical_head() (  # <dir> <script> <timeout> [args...]
+  local dir=$1 script=$2 timeout_secs=$3 head manifest verdict git_dir tmp_root archive source rc=0
+  shift 3
+  fm_project_script_timeout_valid "$timeout_secs" \
+    || return "$FM_PROJECT_SCRIPT_INVALID_TIMEOUT"
+  [ -d "$dir" ] || return "$FM_PROJECT_SCRIPT_CANONICAL_UNAVAILABLE"
+  head=$(git -C "$dir" rev-parse --verify 'HEAD^{commit}' 2>/dev/null) \
+    || return "$FM_PROJECT_SCRIPT_CANONICAL_UNAVAILABLE"
+  manifest=$(git -C "$dir" show "$head:package.json" 2>/dev/null) \
+    || return "$FM_PROJECT_SCRIPT_CANONICAL_UNAVAILABLE"
+  verdict=$(printf '%s' "$manifest" | fm_project_manifest_script_verdict "$script" 2>/dev/null) \
+    || return "$FM_PROJECT_SCRIPT_CANONICAL_UNAVAILABLE"
+  [ "$verdict" = declared ] || return "$FM_PROJECT_SCRIPT_CANONICAL_UNAVAILABLE"
+  command -v tar >/dev/null 2>&1 || return "$FM_PROJECT_SCRIPT_CANONICAL_UNAVAILABLE"
+  git_dir=$(git -C "$dir" rev-parse --absolute-git-dir 2>/dev/null) \
+    || return "$FM_PROJECT_SCRIPT_CANONICAL_UNAVAILABLE"
+  [ -d "$git_dir" ] || return "$FM_PROJECT_SCRIPT_CANONICAL_UNAVAILABLE"
+  tmp_root=$(mktemp -d "$git_dir/fm-project-script.XXXXXX") \
+    || return "$FM_PROJECT_SCRIPT_CANONICAL_UNAVAILABLE"
+  trap 'rm -rf -- "$tmp_root"' EXIT
+  trap 'exit "$FM_PROJECT_SCRIPT_CANONICAL_UNAVAILABLE"' HUP INT TERM
+  archive="$tmp_root/source.tar"
+  source="$tmp_root/source"
+  mkdir "$source" || return "$FM_PROJECT_SCRIPT_CANONICAL_UNAVAILABLE"
+  git -C "$dir" archive --format=tar --output="$archive" "$head" 2>/dev/null \
+    || return "$FM_PROJECT_SCRIPT_CANONICAL_UNAVAILABLE"
+  tar -xf "$archive" -C "$source" 2>/dev/null \
+    || return "$FM_PROJECT_SCRIPT_CANONICAL_UNAVAILABLE"
+  rm -f -- "$archive" || return "$FM_PROJECT_SCRIPT_CANONICAL_UNAVAILABLE"
+  if [ -d "$dir/node_modules" ] && [ ! -e "$source/node_modules" ]; then
+    ln -s "$dir/node_modules" "$source/node_modules" \
+      || return "$FM_PROJECT_SCRIPT_CANONICAL_UNAVAILABLE"
+  fi
+  fm_project_script_run "$source" "$script" "$timeout_secs" "$@" || rc=$?
+  return "$rc"
+)

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -82,15 +82,18 @@
 #   then creates a disposable
 #   workspace containing only the ordinary task pane. A successful clean create
 #   upgrades its attempt journal with exact home, session, workspace, tab, pane,
-#   parent, and label bindings. On a same-identity restart, that complete binding
-#   plus authoritative metadata may replace one exact agent-free husk in place.
-#   The journal, visible token, and labels alone are never endpoint or ownership
-#   authority, and every ambiguous recovery stays on the flat fallback after
-#   duplicate-agent risk is independently absent. Treehouse allocation and task
-#   metadata are unchanged.
-#   A clean projected create or exact resume makes one bounded attempt to hold
-#   the one session-scoped presentation-order lock (keyed by named session plus
-#   canonical socket, outside any home's state/) through launch handoff. Lock
+#   parent, and label bindings. A durable task record always blocks a fresh
+#   spawn before backend or worktree side effects; neither that binding nor an
+#   agent-free restart husk authorizes endpoint replacement. Relaunch instead
+#   reuses the task's exact recorded endpoint and worktree, or refuses without
+#   mutation when they no longer agree. The journal, visible token, and labels
+#   alone are never endpoint or ownership authority, and every ambiguous orphan
+#   recovery stays on the flat fallback after duplicate-agent risk is
+#   independently absent.
+#   A clean projected create or orphan-journal recovery makes one bounded
+#   attempt to hold the one session-scoped presentation-order lock (keyed by
+#   named session plus canonical socket, outside any home's state/) through
+#   launch handoff. Lock
 #   contention warns and falls back to the ordinary flat layout before any
 #   projection mutation. The exact response-derived new workspace is inserted
 #   immediately after its owning parent (firstmate or 2ndmate-<id>) contiguous

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1784,10 +1784,19 @@ assert_worktree_unclaimed() {  # <worktree>
   local worktree=$1 meta claimed claimed_real other_id wt_real
   wt_real=$(real_path_or_raw "$worktree")
   for meta in "$STATE"/*.meta; do
-    [ -f "$meta" ] && [ ! -L "$meta" ] || continue
+    [ -e "$meta" ] || [ -L "$meta" ] || continue
     other_id=$(basename "$meta" .meta)
     [ "$other_id" != "$ID" ] || continue
-    claimed=$(fm_backend_meta_exact_value "$meta" worktree) || continue
+    if [ ! -f "$meta" ] || [ -L "$meta" ] || [ ! -r "$meta" ]; then
+      echo "error: cannot confirm worktree ownership because task metadata '$meta' is not a readable regular file; refusing to use '$worktree'. Nothing was returned or reset. Endpoint $T is parked in that copy." >&2
+      HERDR_PROJECTION_ABORT_CLEANUP=0
+      exit 1
+    fi
+    claimed=$(fm_backend_meta_exact_value "$meta" worktree) || {
+      echo "error: cannot confirm worktree ownership because task $other_id has missing, empty, or ambiguous worktree metadata in '$meta'; refusing to use '$worktree'. Nothing was returned or reset. Endpoint $T is parked in that copy." >&2
+      HERDR_PROJECTION_ABORT_CLEANUP=0
+      exit 1
+    }
     claimed_real=$(real_path_or_raw "$claimed")
     [ "$claimed_real" = "$wt_real" ] || continue
     echo "error: task $other_id already claims the working copy '$claimed' that treehouse just handed task $ID; refusing to launch a second owner into it, because either task's cleanup would hard-reset the other's work. Nothing was returned or reset - reconcile $other_id first (tear it down once its work has landed, or correct its record), then spawn $ID again. Endpoint $T is parked in that copy." >&2

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -685,6 +685,7 @@ RELAUNCH_REPLACEMENT_STATE=
 RELAUNCH_REPLACEMENT_WT=
 CONFIG_INHERIT_LOCK=
 CONFIG_INHERIT_LOCK_HELD=0
+TREEHOUSE_LEASE_HOLDER=
 
 parse_orca_worktree_result() {
   local raw=$1 rest
@@ -1774,20 +1775,48 @@ release_delivered_pool_copies() {  # <project>
   return 0
 }
 
-# A pooled copy has exactly one owner, and the pool cannot tell you who it is.
-# Treehouse re-leases a slot as soon as the shell that held it is gone, but this
-# home's durable records outlive that shell: a task whose agent died still names
-# that copy in state/<id>.meta, and that task's cleanup still hard-resets it.
-# Launching a second task into the same copy gives it two owners, and whichever
-# task is torn down first destroys the other's work. Run this after the slot is
-# acquired and BEFORE anything uses it - the base refresh below already resets
-# the copy - so the refusal lands while both tasks' work is still intact.
+# A pooled copy has exactly one owner. New acquisitions use Treehouse's durable
+# lease, while this home's records remain the custody authority consumed by
+# spawn and teardown.
 #
 # The refusal deliberately does NOT return the slot. `treehouse return`
 # terminates the processes inside a copy and hard-resets it, which is exactly
 # the damage this guard exists to prevent, and the conflicting task may still be
 # working in there. Firstmate reconciles the claim instead; the copy, its
 # processes, and this spawn's endpoint are all left exactly as they are.
+validate_worktree_metadata_before_lease() {  # <pool-root>
+  local pool_root=$1 meta claimed claimed_real holder other_id
+  for meta in "$STATE"/*.meta; do
+    [ -e "$meta" ] || [ -L "$meta" ] || continue
+    other_id=$(basename "$meta" .meta)
+    if [ "$other_id" = "$ID" ]; then
+      echo "error: task $ID acquired a durable record while its fresh spawn was preparing to lease; refusing to replace that task's ownership. No worktree lease was requested. Use --relaunch to reuse the existing task." >&2
+      exit 1
+    fi
+    if [ ! -f "$meta" ] || [ -L "$meta" ] || [ ! -r "$meta" ]; then
+      echo "error: cannot confirm worktree ownership because task metadata '$meta' is not a readable regular file; refusing before requesting a worktree lease" >&2
+      exit 1
+    fi
+    claimed=$(fm_backend_meta_exact_value "$meta" worktree) || {
+      echo "error: cannot confirm worktree ownership because task $other_id has missing, empty, or ambiguous worktree metadata in '$meta'; refusing before requesting a worktree lease" >&2
+      exit 1
+    }
+    claimed_real=$(real_path_or_raw "$claimed")
+    case "$claimed_real" in
+      "$pool_root"/.treehouse/*)
+        holder=$(fm_backend_meta_exact_value "$meta" treehouse_lease_holder) || {
+          echo "error: task $other_id claims '$claimed' in this home's pool without confirmable durable-lease metadata; refusing before Treehouse can recycle that copy" >&2
+          exit 1
+        }
+        if [ "$holder" != "$other_id" ]; then
+          echo "error: task $other_id claims '$claimed' with mismatched durable-lease holder '$holder'; refusing before Treehouse can recycle that copy" >&2
+          exit 1
+        fi
+        ;;
+    esac
+  done
+}
+
 assert_worktree_unclaimed() {  # <worktree>
   local worktree=$1 meta claimed claimed_real other_id wt_real
   wt_real=$(real_path_or_raw "$worktree")
@@ -2319,7 +2348,9 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
     exit 1
   }
   release_delivered_pool_copies "$PROJ_ABS"
-  spawn_send_text_line "$WT_TARGET" "(cd $(shell_quote "$TREEHOUSE_CONFIG_VIEW_REAL") && exec treehouse get)"
+  validate_worktree_metadata_before_lease "$TREEHOUSE_POOL_ROOT"
+  TREEHOUSE_LEASE_HOLDER=$ID
+  spawn_send_text_line "$WT_TARGET" "FM_TREEHOUSE_LEASED_WORKTREE=\$(cd $(shell_quote "$TREEHOUSE_CONFIG_VIEW_REAL") && treehouse get --lease --lease-holder $(shell_quote "$TREEHOUSE_LEASE_HOLDER")) && cd \"\$FM_TREEHOUSE_LEASED_WORKTREE\" && unset FM_TREEHOUSE_LEASED_WORKTREE"
 
   # Wait for the treehouse subshell: the pane's cwd moves from the project to the worktree.
   # Target the stable window id, not the name: if the name is ever lost (e.g. an
@@ -2758,6 +2789,7 @@ preserve_relaunch_meta() {
   echo "window=$META_WINDOW"
   echo "endpoint_task_id=$ID"
   echo "worktree=$WT"
+  [ -z "${TREEHOUSE_LEASE_HOLDER:-}" ] || echo "treehouse_lease_holder=$TREEHOUSE_LEASE_HOLDER"
   echo "project=$PROJ_ABS"
   echo "harness=$HARNESS"
   echo "kind=$KIND"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -686,6 +686,24 @@ RELAUNCH_REPLACEMENT_WT=
 CONFIG_INHERIT_LOCK=
 CONFIG_INHERIT_LOCK_HELD=0
 TREEHOUSE_LEASE_HOLDER=
+TREEHOUSE_ABORT_RETURN_PENDING=0
+TREEHOUSE_ABORT_RETURN_WORKTREE=
+TREEHOUSE_ABORT_RETURN_VIEW=
+TREEHOUSE_ABORT_RETURN_SUPPRESSED=0
+TREEHOUSE_LEASE_HANDOFF=
+TREEHOUSE_LEASE_HANDOFF_TMP=
+
+register_treehouse_abort_handoff() {
+  local leased
+  [ "$TREEHOUSE_ABORT_RETURN_PENDING" = 0 ] || return 0
+  [ -n "$TREEHOUSE_LEASE_HANDOFF" ] || return 1
+  [ -f "$TREEHOUSE_LEASE_HANDOFF" ] && [ ! -L "$TREEHOUSE_LEASE_HANDOFF" ] || return 1
+  IFS= read -r -d '' leased < "$TREEHOUSE_LEASE_HANDOFF" || return 2
+  [ -n "$leased" ] || return 2
+  TREEHOUSE_ABORT_RETURN_WORKTREE=$leased
+  TREEHOUSE_ABORT_RETURN_VIEW=$TREEHOUSE_CONFIG_VIEW_REAL
+  TREEHOUSE_ABORT_RETURN_PENDING=1
+}
 
 parse_orca_worktree_result() {
   local raw=$1 rest
@@ -706,6 +724,19 @@ parse_orca_worktree_result() {
 
 spawn_abort_cleanup() {
   local status=$?
+  if [ "$TREEHOUSE_ABORT_RETURN_PENDING" = 0 ] \
+     && [ "$TREEHOUSE_ABORT_RETURN_SUPPRESSED" = 0 ]; then
+    register_treehouse_abort_handoff || true
+  fi
+  if [ "$TREEHOUSE_ABORT_RETURN_PENDING" = 1 ]; then
+    TREEHOUSE_ABORT_RETURN_PENDING=0
+    if ! (cd "$TREEHOUSE_ABORT_RETURN_VIEW" 2>/dev/null \
+      && treehouse return --force "$TREEHOUSE_ABORT_RETURN_WORKTREE"); then
+      echo "warning: could not return unpublished Treehouse lease '$TREEHOUSE_ABORT_RETURN_WORKTREE' after spawn $ID aborted" >&2
+    fi
+  fi
+  [ -z "$TREEHOUSE_LEASE_HANDOFF_TMP" ] || rm -f -- "$TREEHOUSE_LEASE_HANDOFF_TMP" 2>/dev/null || true
+  [ -z "$TREEHOUSE_LEASE_HANDOFF" ] || rm -f -- "$TREEHOUSE_LEASE_HANDOFF" 2>/dev/null || true
   if [ "$RELAUNCH_REPLACEMENT_PENDING" = 1 ] \
      && [ "$SPAWN_META_PUBLISH_STARTED" = 1 ] \
      && [ -n "$SPAWN_META_TMP" ] \
@@ -1817,6 +1848,13 @@ validate_worktree_metadata_before_lease() {  # <pool-root>
   done
 }
 
+preserve_conflicted_worktree_lease() {
+  TREEHOUSE_ABORT_RETURN_PENDING=0
+  TREEHOUSE_ABORT_RETURN_SUPPRESSED=1
+  [ -z "$TREEHOUSE_LEASE_HANDOFF_TMP" ] || rm -f -- "$TREEHOUSE_LEASE_HANDOFF_TMP" 2>/dev/null || true
+  [ -z "$TREEHOUSE_LEASE_HANDOFF" ] || rm -f -- "$TREEHOUSE_LEASE_HANDOFF" 2>/dev/null || true
+}
+
 assert_worktree_unclaimed() {  # <worktree>
   local worktree=$1 meta claimed claimed_real other_id wt_real
   wt_real=$(real_path_or_raw "$worktree")
@@ -1824,22 +1862,26 @@ assert_worktree_unclaimed() {  # <worktree>
     [ -e "$meta" ] || [ -L "$meta" ] || continue
     other_id=$(basename "$meta" .meta)
     if [ "$other_id" = "$ID" ]; then
+      preserve_conflicted_worktree_lease
       echo "error: task $ID acquired a durable record while its fresh spawn was leasing '$worktree'; refusing to replace that task's ownership. Nothing was returned or reset. Endpoint $T is parked in that copy." >&2
       HERDR_PROJECTION_ABORT_CLEANUP=0
       exit 1
     fi
     if [ ! -f "$meta" ] || [ -L "$meta" ] || [ ! -r "$meta" ]; then
+      preserve_conflicted_worktree_lease
       echo "error: cannot confirm worktree ownership because task metadata '$meta' is not a readable regular file; refusing to use '$worktree'. Nothing was returned or reset. Endpoint $T is parked in that copy." >&2
       HERDR_PROJECTION_ABORT_CLEANUP=0
       exit 1
     fi
     claimed=$(fm_backend_meta_exact_value "$meta" worktree) || {
+      preserve_conflicted_worktree_lease
       echo "error: cannot confirm worktree ownership because task $other_id has missing, empty, or ambiguous worktree metadata in '$meta'; refusing to use '$worktree'. Nothing was returned or reset. Endpoint $T is parked in that copy." >&2
       HERDR_PROJECTION_ABORT_CLEANUP=0
       exit 1
     }
     claimed_real=$(real_path_or_raw "$claimed")
     [ "$claimed_real" = "$wt_real" ] || continue
+    preserve_conflicted_worktree_lease
     echo "error: task $other_id already claims the working copy '$claimed' that treehouse just handed task $ID; refusing to launch a second owner into it, because either task's cleanup would hard-reset the other's work. Nothing was returned or reset - reconcile $other_id first (tear it down once its work has landed, or correct its record), then spawn $ID again. Endpoint $T is parked in that copy." >&2
     HERDR_PROJECTION_ABORT_CLEANUP=0
     exit 1
@@ -2350,7 +2392,15 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   release_delivered_pool_copies "$PROJ_ABS"
   validate_worktree_metadata_before_lease "$TREEHOUSE_POOL_ROOT"
   TREEHOUSE_LEASE_HOLDER=$ID
-  spawn_send_text_line "$WT_TARGET" "FM_TREEHOUSE_LEASED_WORKTREE=\$(cd $(shell_quote "$TREEHOUSE_CONFIG_VIEW_REAL") && treehouse get --lease --lease-holder $(shell_quote "$TREEHOUSE_LEASE_HOLDER")) && cd \"\$FM_TREEHOUSE_LEASED_WORKTREE\" && unset FM_TREEHOUSE_LEASED_WORKTREE"
+  TREEHOUSE_LEASE_HANDOFF="$STATE/.$ID.treehouse-lease.${BASHPID:-$$}"
+  TREEHOUSE_LEASE_HANDOFF_TMP="$TREEHOUSE_LEASE_HANDOFF.tmp"
+  if [ -e "$TREEHOUSE_LEASE_HANDOFF" ] || [ -L "$TREEHOUSE_LEASE_HANDOFF" ] \
+     || [ -e "$TREEHOUSE_LEASE_HANDOFF_TMP" ] || [ -L "$TREEHOUSE_LEASE_HANDOFF_TMP" ]; then
+    TREEHOUSE_ABORT_RETURN_SUPPRESSED=1
+    echo "error: cannot safely create the Treehouse lease handoff for task $ID; refusing to lease" >&2
+    exit 1
+  fi
+  spawn_send_text_line "$WT_TARGET" "FM_TREEHOUSE_LEASED_WORKTREE=\$(cd $(shell_quote "$TREEHOUSE_CONFIG_VIEW_REAL") && treehouse get --lease --lease-holder $(shell_quote "$TREEHOUSE_LEASE_HOLDER")) && printf '%s\\0' \"\$FM_TREEHOUSE_LEASED_WORKTREE\" > $(shell_quote "$TREEHOUSE_LEASE_HANDOFF_TMP") && mv -f -- $(shell_quote "$TREEHOUSE_LEASE_HANDOFF_TMP") $(shell_quote "$TREEHOUSE_LEASE_HANDOFF") && cd \"\$FM_TREEHOUSE_LEASED_WORKTREE\" && unset FM_TREEHOUSE_LEASED_WORKTREE"
 
   # Wait for the treehouse subshell: the pane's cwd moves from the project to the worktree.
   # Target the stable window id, not the name: if the name is ever lost (e.g. an
@@ -2374,6 +2424,13 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   # inter-poll sleep as confirmation, not a whole extra cycle on top.
   candidate=""
   for _ in $(seq 1 60); do
+    if [ "$TREEHOUSE_ABORT_RETURN_PENDING" = 0 ] && [ -e "$TREEHOUSE_LEASE_HANDOFF" ]; then
+      if ! register_treehouse_abort_handoff; then
+        preserve_conflicted_worktree_lease
+        echo "error: cannot confirm the worktree path in task $ID's Treehouse lease handoff; preserving the lease for reconciliation" >&2
+        exit 1
+      fi
+    fi
     p=$(spawn_current_path "$WT_TARGET" || true)
     if [ -n "$p" ]; then
       p_real=$(real_path_or_raw "$p")
@@ -2396,8 +2453,17 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
     exit 1
   fi
 
-  validate_spawn_worktree "treehouse get" "$T"
+  if [ "$TREEHOUSE_ABORT_RETURN_PENDING" = 0 ]; then
+    TREEHOUSE_ABORT_RETURN_WORKTREE=$WT
+    TREEHOUSE_ABORT_RETURN_VIEW=$TREEHOUSE_CONFIG_VIEW_REAL
+    TREEHOUSE_ABORT_RETURN_PENDING=1
+  fi
   wt_pool_real=$(real_path_or_raw "$WT")
+  if [ "$(real_path_or_raw "$TREEHOUSE_ABORT_RETURN_WORKTREE")" != "$wt_pool_real" ]; then
+    preserve_conflicted_worktree_lease
+    echo "error: task $ID's Treehouse lease handoff and endpoint disagree on the acquired worktree; preserving the lease for reconciliation" >&2
+    exit 1
+  fi
   case "$wt_pool_real" in
     "$TREEHOUSE_POOL_ROOT"/.treehouse/*) ;;
     *)
@@ -2405,6 +2471,17 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
       exit 1
       ;;
   esac
+  acquired_status=$(git -C "$WT" status --porcelain 2>/dev/null) || {
+    preserve_conflicted_worktree_lease
+    echo "error: could not inspect newly leased worktree '$WT'; preserving its lease for reconciliation" >&2
+    exit 1
+  }
+  if [ -n "$acquired_status" ]; then
+    preserve_conflicted_worktree_lease
+    echo "error: newly leased worktree '$WT' is not clean; preserving its lease and local work for reconciliation" >&2
+    exit 1
+  fi
+  validate_spawn_worktree "treehouse get" "$T"
   assert_worktree_unclaimed "$WT"
 fi
 if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ]; then
@@ -2775,6 +2852,9 @@ if [ "$RELAUNCH" -eq 1 ]; then
   SPAWN_META_LOCK_HELD=1
   SPAWN_META_TMP="$STATE/.$ID.meta.relaunch.${BASHPID:-$$}"
   SPAWN_META_PATH=$SPAWN_META_TMP
+else
+  SPAWN_META_TMP="$STATE/.$ID.meta.spawn.${BASHPID:-$$}"
+  SPAWN_META_PATH=$SPAWN_META_TMP
 fi
 preserve_relaunch_meta() {
   awk -F= '
@@ -2785,7 +2865,7 @@ preserve_relaunch_meta() {
     !($1 in owned)
   ' "$RELAUNCH_META"
 }
-{
+if ! {
   echo "window=$META_WINDOW"
   echo "endpoint_task_id=$ID"
   echo "worktree=$WT"
@@ -2834,7 +2914,10 @@ preserve_relaunch_meta() {
   if [ "$SPAWN_CONTROL_PARENT" = 1 ] && [ -n "${FM_CONTROL_RELAUNCH_TX:-}" ]; then
     echo "control_relaunch_tx=$FM_CONTROL_RELAUNCH_TX"
   fi
-} > "$SPAWN_META_PATH"
+} > "$SPAWN_META_PATH"; then
+  echo "error: could not prepare durable metadata for task $ID" >&2
+  exit 1
+fi
 if [ "$RELAUNCH" -eq 1 ]; then
   SPAWN_META_PUBLISH_STARTED=1
   mv -f "$SPAWN_META_TMP" "$STATE/$ID.meta"
@@ -2843,6 +2926,16 @@ if [ "$RELAUNCH" -eq 1 ]; then
   SPAWN_META_TMP=
   fm_lock_release "$SPAWN_META_LOCK"
   SPAWN_META_LOCK_HELD=0
+else
+  if ! mv -f -- "$SPAWN_META_TMP" "$STATE/$ID.meta"; then
+    echo "error: could not publish durable metadata for task $ID" >&2
+    exit 1
+  fi
+  SPAWN_META_TMP=
+  [ -z "$TREEHOUSE_LEASE_HANDOFF_TMP" ] || rm -f -- "$TREEHOUSE_LEASE_HANDOFF_TMP" 2>/dev/null || true
+  [ -z "$TREEHOUSE_LEASE_HANDOFF" ] || rm -f -- "$TREEHOUSE_LEASE_HANDOFF" 2>/dev/null || true
+  TREEHOUSE_ABORT_RETURN_PENDING=0
+  TREEHOUSE_ABORT_RETURN_SUPPRESSED=1
 fi
 if [ "$SPAWN_TASK_SET_LOCK_HELD" = 1 ]; then
   # The record is published, so this task is now part of the set a teardown

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -58,6 +58,13 @@
 #   A backend spawn refusal (missing dependency, version gate, unauthenticated
 #   socket, or unsupported secondmate mode) is terminal for that selected backend;
 #   callers must surface it instead of silently retrying another backend.
+#   Every treehouse-get spawn first claims this home's OWN worktree pool
+#   (bin/fm-pool-root.sh, which refuses rather than sharing a pool), then asks
+#   the project to release its delivered copies when it published a
+#   `pool:release-delivered` script, and finally refuses the acquired copy if
+#   another task in this home already claims it - before the base refresh
+#   touches that copy. docs/configuration.md "Worktree pools" is the
+#   operator-facing owner.
 #   A herdr crewmate or scout is placed in the exact workspace of the firstmate
 #   or secondmate process launching it, resolved from that process's own herdr
 #   pane rather than from a workspace label (herdr enforces no label uniqueness,
@@ -258,6 +265,8 @@ SUB_HOME_MARKER=".fm-secondmate-home"
 . "$SCRIPT_DIR/fm-pr-lib.sh"
 # shellcheck source=bin/fm-trace-context-lib.sh
 . "$SCRIPT_DIR/fm-trace-context-lib.sh"
+# shellcheck source=bin/fm-project-script-lib.sh
+. "$SCRIPT_DIR/fm-project-script-lib.sh"
 # shellcheck source=bin/fm-remote-readiness-lib.sh
 . "$SCRIPT_DIR/fm-remote-readiness-lib.sh"
 # Fail closed before any fleet mutation: a no-mistakes gate agent must never spawn
@@ -1727,6 +1736,66 @@ validate_spawn_worktree() {  # <source> <inspect-target>
   fi
 }
 
+# A pool runs out when delivered copies are never handed back, and a dispatch
+# then fails for want of a slot rather than for want of work. Only the project
+# knows which of its copies are delivered, so a project may publish that
+# housekeeping as a `pool:release-delivered` script and firstmate calls it once,
+# before asking for a slot (opt-in by presence, per bin/fm-project-script-lib.sh;
+# the script owns its own idempotency and pool lock, and exits 0 with nothing to
+# release). This is capacity, not safety: a release that cannot run warns and
+# the spawn continues, because refusing to dispatch over failed housekeeping
+# would be a worse outage than the one it prevents.
+RELEASE_DELIVERED_SCRIPT=pool:release-delivered
+RELEASE_DELIVERED_TIMEOUT=${FM_SPAWN_RELEASE_DELIVERED_TIMEOUT:-60}
+case "$RELEASE_DELIVERED_TIMEOUT" in ''|*[!0-9]*) RELEASE_DELIVERED_TIMEOUT=60 ;; esac
+
+release_delivered_pool_copies() {  # <project>
+  local project=$1 out rc=0 declared=0
+  fm_project_script_declared "$project" "$RELEASE_DELIVERED_SCRIPT" || declared=$?
+  if [ "$declared" = "$FM_PROJECT_SCRIPT_ABSENT" ]; then
+    return 0
+  fi
+  if [ "$declared" = "$FM_PROJECT_SCRIPT_UNCONFIRMED" ]; then
+    echo "warning: $project names a $RELEASE_DELIVERED_SCRIPT step but node is unavailable to confirm it; leasing without releasing delivered copies" >&2
+    return 0
+  fi
+  out=$(fm_project_script_run "$project" "$RELEASE_DELIVERED_SCRIPT" \
+    "$RELEASE_DELIVERED_TIMEOUT" --yes 2>&1) || rc=$?
+  [ "$rc" -eq 0 ] && return 0
+  echo "warning: $RELEASE_DELIVERED_SCRIPT failed for $project (exit $rc); leasing without releasing delivered copies" >&2
+  printf '%s\n' "$out" >&2
+  return 0
+}
+
+# A pooled copy has exactly one owner, and the pool cannot tell you who it is.
+# Treehouse re-leases a slot as soon as the shell that held it is gone, but this
+# home's durable records outlive that shell: a task whose agent died still names
+# that copy in state/<id>.meta, and that task's cleanup still hard-resets it.
+# Launching a second task into the same copy gives it two owners, and whichever
+# task is torn down first destroys the other's work. Run this after the slot is
+# acquired and BEFORE anything uses it - the base refresh below already resets
+# the copy - so the refusal lands while both tasks' work is still intact.
+#
+# The refusal deliberately does NOT return the slot. `treehouse return`
+# terminates the processes inside a copy and hard-resets it, which is exactly
+# the damage this guard exists to prevent, and the conflicting task may still be
+# working in there. Firstmate reconciles the claim instead; the copy, its
+# processes, and this spawn's endpoint are all left exactly as they are.
+assert_worktree_unclaimed() {  # <worktree>
+  local worktree=$1 meta claimed claimed_real other_id wt_real
+  wt_real=$(real_path_or_raw "$worktree")
+  for meta in "$STATE"/*.meta; do
+    [ -f "$meta" ] && [ ! -L "$meta" ] || continue
+    other_id=$(basename "$meta" .meta)
+    [ "$other_id" != "$ID" ] || continue
+    claimed=$(fm_backend_meta_exact_value "$meta" worktree) || continue
+    claimed_real=$(real_path_or_raw "$claimed")
+    [ "$claimed_real" = "$wt_real" ] || continue
+    echo "error: task $other_id already claims the working copy '$claimed' that treehouse just handed task $ID; refusing to launch a second owner into it, because either task's cleanup would hard-reset the other's work. Nothing was returned or reset - reconcile $other_id first (tear it down once its work has landed, or correct its record), then spawn $ID again. Endpoint $T is parked in that copy." >&2
+    exit 1
+  done
+}
+
 freshen_spawn_worktree_base() {  # <worktree>
   local worktree=$1 default target expected actual status
   if ! git -C "$worktree" fetch --quiet origin; then
@@ -2212,6 +2281,15 @@ if [ "$RELAUNCH" -eq 1 ]; then
   fi
   [ "$KIND" = secondmate ] || validate_spawn_worktree "relaunch" "$T"
 elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
+  # Claim this home's own worktree pool before asking treehouse for a slot.
+  # Treehouse keys a pool by the repository, so without this two homes cloning
+  # the same project draw from one pool and hand each other's live slots out.
+  # bin/fm-pool-root.sh owns the derivation and refuses rather than guessing.
+  "$FM_ROOT/bin/fm-pool-root.sh" "$PROJ_ABS" >/dev/null || {
+    echo "error: could not give this home its own worktree pool for $PROJ_ABS; refusing to lease a slot another home may already have handed out" >&2
+    exit 1
+  }
+  release_delivered_pool_copies "$PROJ_ABS"
   spawn_send_text_line "$WT_TARGET" 'treehouse get'
 
   # Wait for the treehouse subshell: the pane's cwd moves from the project to the worktree.
@@ -2259,6 +2337,7 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   fi
 
   validate_spawn_worktree "treehouse get" "$T"
+  assert_worktree_unclaimed "$WT"
 fi
 if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ]; then
   freshen_spawn_worktree_base "$WT" || exit 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -58,7 +58,8 @@
 #   A backend spawn refusal (missing dependency, version gate, unauthenticated
 #   socket, or unsupported secondmate mode) is terminal for that selected backend;
 #   callers must surface it instead of silently retrying another backend.
-#   Every treehouse-get spawn first claims this home's OWN worktree pool
+#   Every treehouse-get spawn first claims this home's OWN worktree pool through
+#   a home-private Treehouse config view that never mutates the project clone
 #   (bin/fm-pool-root.sh, which refuses rather than sharing a pool), then asks
 #   the project to release its delivered copies when it published a
 #   `pool:release-delivered` script, and finally refuses the acquired copy if
@@ -2305,12 +2306,20 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   # Treehouse keys a pool by the repository, so without this two homes cloning
   # the same project draw from one pool and hand each other's live slots out.
   # bin/fm-pool-root.sh owns the derivation and refuses rather than guessing.
-  "$FM_ROOT/bin/fm-pool-root.sh" "$PROJ_ABS" >/dev/null || {
+  TREEHOUSE_POOL_ROOT=$("$FM_ROOT/bin/fm-pool-root.sh" "$PROJ_ABS") || {
     echo "error: could not give this home its own worktree pool for $PROJ_ABS; refusing to lease a slot another home may already have handed out" >&2
     exit 1
   }
+  TREEHOUSE_CONFIG_VIEW=$("$FM_ROOT/bin/fm-pool-root.sh" --view "$PROJ_ABS") || {
+    echo "error: could not resolve this home's isolated Treehouse config view; refusing to lease" >&2
+    exit 1
+  }
+  TREEHOUSE_CONFIG_VIEW_REAL=$(cd "$TREEHOUSE_CONFIG_VIEW" 2>/dev/null && pwd -P) || {
+    echo "error: could not canonicalize this home's isolated Treehouse config view; refusing to lease" >&2
+    exit 1
+  }
   release_delivered_pool_copies "$PROJ_ABS"
-  spawn_send_text_line "$WT_TARGET" 'treehouse get'
+  spawn_send_text_line "$WT_TARGET" "(cd $(shell_quote "$TREEHOUSE_CONFIG_VIEW_REAL") && exec treehouse get)"
 
   # Wait for the treehouse subshell: the pane's cwd moves from the project to the worktree.
   # Target the stable window id, not the name: if the name is ever lost (e.g. an
@@ -2337,7 +2346,7 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
     p=$(spawn_current_path "$WT_TARGET" || true)
     if [ -n "$p" ]; then
       p_real=$(real_path_or_raw "$p")
-      if [ "$p_real" != "$PROJ_ABS_REAL" ]; then
+      if [ "$p_real" != "$PROJ_ABS_REAL" ] && [ "$p_real" != "$TREEHOUSE_CONFIG_VIEW_REAL" ]; then
         if [ -n "$candidate" ] && [ "$p_real" = "$candidate" ]; then
           WT="$p"
           break
@@ -2357,6 +2366,14 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   fi
 
   validate_spawn_worktree "treehouse get" "$T"
+  wt_pool_real=$(real_path_or_raw "$WT")
+  case "$wt_pool_real" in
+    "$TREEHOUSE_POOL_ROOT"/.treehouse/*) ;;
+    *)
+      echo "error: treehouse get entered '$WT' outside this home's pool root '$TREEHOUSE_POOL_ROOT'; refusing before refresh" >&2
+      exit 1
+      ;;
+  esac
   assert_worktree_unclaimed "$WT"
 fi
 if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ]; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -689,6 +689,7 @@ TREEHOUSE_LEASE_HOLDER=
 TREEHOUSE_ABORT_RETURN_PENDING=0
 TREEHOUSE_ABORT_RETURN_WORKTREE=
 TREEHOUSE_ABORT_RETURN_VIEW=
+TREEHOUSE_ACQUIRE_DEFERRED_SIGNAL=
 
 treehouse_abort_lease_is_published() {
   local meta worktree holder
@@ -2381,8 +2382,27 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   release_delivered_pool_copies "$PROJ_ABS"
   validate_worktree_metadata_before_lease "$TREEHOUSE_POOL_ROOT"
   TREEHOUSE_LEASE_HOLDER=$ID
-  if ! WT=$(cd "$TREEHOUSE_CONFIG_VIEW_REAL" \
-    && treehouse get --lease --lease-holder "$TREEHOUSE_LEASE_HOLDER"); then
+  TREEHOUSE_ACQUIRE_DEFERRED_SIGNAL=
+  trap 'TREEHOUSE_ACQUIRE_DEFERRED_SIGNAL=${TREEHOUSE_ACQUIRE_DEFERRED_SIGNAL:-HUP}' HUP
+  trap 'TREEHOUSE_ACQUIRE_DEFERRED_SIGNAL=${TREEHOUSE_ACQUIRE_DEFERRED_SIGNAL:-INT}' INT
+  trap 'TREEHOUSE_ACQUIRE_DEFERRED_SIGNAL=${TREEHOUSE_ACQUIRE_DEFERRED_SIGNAL:-TERM}' TERM
+  treehouse_acquire_status=0
+  WT=$(trap '' HUP INT TERM
+    cd "$TREEHOUSE_CONFIG_VIEW_REAL" \
+      && treehouse get --lease --lease-holder "$TREEHOUSE_LEASE_HOLDER") \
+    || treehouse_acquire_status=$?
+  if [ "$treehouse_acquire_status" -eq 0 ] && [ -n "$WT" ]; then
+    TREEHOUSE_ABORT_RETURN_WORKTREE=$WT
+    TREEHOUSE_ABORT_RETURN_VIEW=$TREEHOUSE_CONFIG_VIEW_REAL
+    TREEHOUSE_ABORT_RETURN_PENDING=1
+  fi
+  trap - HUP INT TERM
+  case "$TREEHOUSE_ACQUIRE_DEFERRED_SIGNAL" in
+    HUP) exit 129 ;;
+    INT) exit 130 ;;
+    TERM) exit 143 ;;
+  esac
+  if [ "$treehouse_acquire_status" -ne 0 ]; then
     echo "error: treehouse could not acquire a durable worktree lease for task $ID" >&2
     exit 1
   fi
@@ -2390,9 +2410,6 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
     echo "error: treehouse returned no path for task $ID's durable worktree lease" >&2
     exit 1
   }
-  TREEHOUSE_ABORT_RETURN_WORKTREE=$WT
-  TREEHOUSE_ABORT_RETURN_VIEW=$TREEHOUSE_CONFIG_VIEW_REAL
-  TREEHOUSE_ABORT_RETURN_PENDING=1
   spawn_send_text_line "$WT_TARGET" "cd $(shell_quote "$WT")"
 
   # Wait until the pane enters the synchronously acquired worktree.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1791,6 +1791,7 @@ assert_worktree_unclaimed() {  # <worktree>
     claimed_real=$(real_path_or_raw "$claimed")
     [ "$claimed_real" = "$wt_real" ] || continue
     echo "error: task $other_id already claims the working copy '$claimed' that treehouse just handed task $ID; refusing to launch a second owner into it, because either task's cleanup would hard-reset the other's work. Nothing was returned or reset - reconcile $other_id first (tear it down once its work has landed, or correct its record), then spawn $ID again. Endpoint $T is parked in that copy." >&2
+    HERDR_PROJECTION_ABORT_CLEANUP=0
     exit 1
   done
 }

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -689,20 +689,16 @@ TREEHOUSE_LEASE_HOLDER=
 TREEHOUSE_ABORT_RETURN_PENDING=0
 TREEHOUSE_ABORT_RETURN_WORKTREE=
 TREEHOUSE_ABORT_RETURN_VIEW=
-TREEHOUSE_ABORT_RETURN_SUPPRESSED=0
-TREEHOUSE_LEASE_HANDOFF=
-TREEHOUSE_LEASE_HANDOFF_TMP=
 
-register_treehouse_abort_handoff() {
-  local leased
-  [ "$TREEHOUSE_ABORT_RETURN_PENDING" = 0 ] || return 0
-  [ -n "$TREEHOUSE_LEASE_HANDOFF" ] || return 1
-  [ -f "$TREEHOUSE_LEASE_HANDOFF" ] && [ ! -L "$TREEHOUSE_LEASE_HANDOFF" ] || return 1
-  IFS= read -r -d '' leased < "$TREEHOUSE_LEASE_HANDOFF" || return 2
-  [ -n "$leased" ] || return 2
-  TREEHOUSE_ABORT_RETURN_WORKTREE=$leased
-  TREEHOUSE_ABORT_RETURN_VIEW=$TREEHOUSE_CONFIG_VIEW_REAL
-  TREEHOUSE_ABORT_RETURN_PENDING=1
+treehouse_abort_lease_is_published() {
+  local meta worktree holder
+  [ -n "${ID:-}" ] && [ -n "${STATE:-}" ] || return 1
+  meta="$STATE/$ID.meta"
+  [ -f "$meta" ] && [ ! -L "$meta" ] && [ -r "$meta" ] || return 1
+  worktree=$(fm_backend_meta_exact_value "$meta" worktree) || return 1
+  holder=$(fm_backend_meta_exact_value "$meta" treehouse_lease_holder) || return 1
+  [ "$holder" = "$ID" ] || return 1
+  [ "$(real_path_or_raw "$worktree")" = "$(real_path_or_raw "$TREEHOUSE_ABORT_RETURN_WORKTREE")" ]
 }
 
 parse_orca_worktree_result() {
@@ -724,19 +720,15 @@ parse_orca_worktree_result() {
 
 spawn_abort_cleanup() {
   local status=$?
-  if [ "$TREEHOUSE_ABORT_RETURN_PENDING" = 0 ] \
-     && [ "$TREEHOUSE_ABORT_RETURN_SUPPRESSED" = 0 ]; then
-    register_treehouse_abort_handoff || true
-  fi
   if [ "$TREEHOUSE_ABORT_RETURN_PENDING" = 1 ]; then
     TREEHOUSE_ABORT_RETURN_PENDING=0
-    if ! (cd "$TREEHOUSE_ABORT_RETURN_VIEW" 2>/dev/null \
+    if treehouse_abort_lease_is_published; then
+      :
+    elif ! (cd "$TREEHOUSE_ABORT_RETURN_VIEW" 2>/dev/null \
       && treehouse return --force "$TREEHOUSE_ABORT_RETURN_WORKTREE"); then
       echo "warning: could not return unpublished Treehouse lease '$TREEHOUSE_ABORT_RETURN_WORKTREE' after spawn $ID aborted" >&2
     fi
   fi
-  [ -z "$TREEHOUSE_LEASE_HANDOFF_TMP" ] || rm -f -- "$TREEHOUSE_LEASE_HANDOFF_TMP" 2>/dev/null || true
-  [ -z "$TREEHOUSE_LEASE_HANDOFF" ] || rm -f -- "$TREEHOUSE_LEASE_HANDOFF" 2>/dev/null || true
   if [ "$RELAUNCH_REPLACEMENT_PENDING" = 1 ] \
      && [ "$SPAWN_META_PUBLISH_STARTED" = 1 ] \
      && [ -n "$SPAWN_META_TMP" ] \
@@ -1798,7 +1790,7 @@ release_delivered_pool_copies() {  # <project>
     echo "warning: cannot confirm whether $project publishes a $RELEASE_DELIVERED_SCRIPT step; leasing without releasing delivered copies" >&2
     return 0
   fi
-  out=$(fm_project_script_run "$project" "$RELEASE_DELIVERED_SCRIPT" \
+  out=$(fm_project_script_run_canonical_head "$project" "$RELEASE_DELIVERED_SCRIPT" \
     "$RELEASE_DELIVERED_TIMEOUT" --yes 2>&1) || rc=$?
   [ "$rc" -eq 0 ] && return 0
   echo "warning: $RELEASE_DELIVERED_SCRIPT failed for $project (exit $rc); leasing without releasing delivered copies" >&2
@@ -1850,9 +1842,6 @@ validate_worktree_metadata_before_lease() {  # <pool-root>
 
 preserve_conflicted_worktree_lease() {
   TREEHOUSE_ABORT_RETURN_PENDING=0
-  TREEHOUSE_ABORT_RETURN_SUPPRESSED=1
-  [ -z "$TREEHOUSE_LEASE_HANDOFF_TMP" ] || rm -f -- "$TREEHOUSE_LEASE_HANDOFF_TMP" 2>/dev/null || true
-  [ -z "$TREEHOUSE_LEASE_HANDOFF" ] || rm -f -- "$TREEHOUSE_LEASE_HANDOFF" 2>/dev/null || true
 }
 
 assert_worktree_unclaimed() {  # <worktree>
@@ -2392,78 +2381,49 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   release_delivered_pool_copies "$PROJ_ABS"
   validate_worktree_metadata_before_lease "$TREEHOUSE_POOL_ROOT"
   TREEHOUSE_LEASE_HOLDER=$ID
-  TREEHOUSE_LEASE_HANDOFF="$STATE/.$ID.treehouse-lease.${BASHPID:-$$}"
-  TREEHOUSE_LEASE_HANDOFF_TMP="$TREEHOUSE_LEASE_HANDOFF.tmp"
-  if [ -e "$TREEHOUSE_LEASE_HANDOFF" ] || [ -L "$TREEHOUSE_LEASE_HANDOFF" ] \
-     || [ -e "$TREEHOUSE_LEASE_HANDOFF_TMP" ] || [ -L "$TREEHOUSE_LEASE_HANDOFF_TMP" ]; then
-    TREEHOUSE_ABORT_RETURN_SUPPRESSED=1
-    echo "error: cannot safely create the Treehouse lease handoff for task $ID; refusing to lease" >&2
+  if ! WT=$(cd "$TREEHOUSE_CONFIG_VIEW_REAL" \
+    && treehouse get --lease --lease-holder "$TREEHOUSE_LEASE_HOLDER"); then
+    echo "error: treehouse could not acquire a durable worktree lease for task $ID" >&2
     exit 1
   fi
-  spawn_send_text_line "$WT_TARGET" "FM_TREEHOUSE_LEASED_WORKTREE=\$(cd $(shell_quote "$TREEHOUSE_CONFIG_VIEW_REAL") && treehouse get --lease --lease-holder $(shell_quote "$TREEHOUSE_LEASE_HOLDER")) && printf '%s\\0' \"\$FM_TREEHOUSE_LEASED_WORKTREE\" > $(shell_quote "$TREEHOUSE_LEASE_HANDOFF_TMP") && mv -f -- $(shell_quote "$TREEHOUSE_LEASE_HANDOFF_TMP") $(shell_quote "$TREEHOUSE_LEASE_HANDOFF") && cd \"\$FM_TREEHOUSE_LEASED_WORKTREE\" && unset FM_TREEHOUSE_LEASED_WORKTREE"
+  [ -n "$WT" ] || {
+    echo "error: treehouse returned no path for task $ID's durable worktree lease" >&2
+    exit 1
+  }
+  TREEHOUSE_ABORT_RETURN_WORKTREE=$WT
+  TREEHOUSE_ABORT_RETURN_VIEW=$TREEHOUSE_CONFIG_VIEW_REAL
+  TREEHOUSE_ABORT_RETURN_PENDING=1
+  spawn_send_text_line "$WT_TARGET" "cd $(shell_quote "$WT")"
 
-  # Wait for the treehouse subshell: the pane's cwd moves from the project to the worktree.
+  # Wait until the pane enters the synchronously acquired worktree.
   # Target the stable window id, not the name: if the name is ever lost (e.g. an
   # automatic-rename slips through), display-message -t <bad-name> falls back to the
   # active client's window, which would misread firstmate's OWN pane path as the
   # worktree and tangle a hook into the primary checkout. The window id never lies.
-  # Compare against PROJ_ABS_REAL (physical), not PROJ_ABS: a symlinked project
-  # prefix would otherwise make the pane's OS-level cwd read differ from
-  # PROJ_ABS on the very first poll, before the pane has actually moved.
-  #
-  # A single read that already differs from PROJ_ABS_REAL is not proof the pane
-  # settled there: on some tmux/WSL setups a brand-new window's pane_current_path
-  # transiently reports an unrelated stale path (seen live as another real git
-  # checkout entirely) before the shell catches up with treehouse get's cd. That
-  # stale path still passes the PROJ_ABS_REAL comparison and validate_spawn_worktree
-  # below (it resolves to a real, distinct worktree top-level too), so accepting it
-  # on one read alone silently records the wrong worktree= in state/<id>.meta. Require
-  # two consecutive reads to agree on the same non-project path before accepting it;
-  # a mismatch just becomes the new candidate rather than resetting the wait, so a
-  # pane that is already settled by the first real read only costs the one existing
-  # inter-poll sleep as confirmation, not a whole extra cycle on top.
-  candidate=""
+  # Two matching reads reject transient stale paths reported by a new pane.
+  leased_real=$(real_path_or_raw "$WT")
+  settled_reads=0
+  worktree_settled=0
   for _ in $(seq 1 60); do
-    if [ "$TREEHOUSE_ABORT_RETURN_PENDING" = 0 ] && [ -e "$TREEHOUSE_LEASE_HANDOFF" ]; then
-      if ! register_treehouse_abort_handoff; then
-        preserve_conflicted_worktree_lease
-        echo "error: cannot confirm the worktree path in task $ID's Treehouse lease handoff; preserving the lease for reconciliation" >&2
-        exit 1
-      fi
-    fi
     p=$(spawn_current_path "$WT_TARGET" || true)
-    if [ -n "$p" ]; then
-      p_real=$(real_path_or_raw "$p")
-      if [ "$p_real" != "$PROJ_ABS_REAL" ] && [ "$p_real" != "$TREEHOUSE_CONFIG_VIEW_REAL" ]; then
-        if [ -n "$candidate" ] && [ "$p_real" = "$candidate" ]; then
-          WT="$p"
-          break
-        fi
-        candidate="$p_real"
-      else
-        candidate=""
+    p_real=$(real_path_or_raw "$p")
+    if [ -n "$p" ] && [ "$p_real" = "$leased_real" ]; then
+      settled_reads=$((settled_reads + 1))
+      if [ "$settled_reads" -ge 2 ]; then
+        worktree_settled=1
+        break
       fi
     else
-      candidate=""
+      settled_reads=0
     fi
     sleep 1
   done
-  if [ -z "$WT" ]; then
+  if [ "$worktree_settled" != 1 ]; then
     echo "error: treehouse get did not enter a worktree within 60s; inspect window $T" >&2
     exit 1
   fi
 
-  if [ "$TREEHOUSE_ABORT_RETURN_PENDING" = 0 ]; then
-    TREEHOUSE_ABORT_RETURN_WORKTREE=$WT
-    TREEHOUSE_ABORT_RETURN_VIEW=$TREEHOUSE_CONFIG_VIEW_REAL
-    TREEHOUSE_ABORT_RETURN_PENDING=1
-  fi
   wt_pool_real=$(real_path_or_raw "$WT")
-  if [ "$(real_path_or_raw "$TREEHOUSE_ABORT_RETURN_WORKTREE")" != "$wt_pool_real" ]; then
-    preserve_conflicted_worktree_lease
-    echo "error: task $ID's Treehouse lease handoff and endpoint disagree on the acquired worktree; preserving the lease for reconciliation" >&2
-    exit 1
-  fi
   case "$wt_pool_real" in
     "$TREEHOUSE_POOL_ROOT"/.treehouse/*) ;;
     *)
@@ -2472,13 +2432,11 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
       ;;
   esac
   acquired_status=$(git -C "$WT" status --porcelain 2>/dev/null) || {
-    preserve_conflicted_worktree_lease
-    echo "error: could not inspect newly leased worktree '$WT'; preserving its lease for reconciliation" >&2
+    echo "error: could not inspect newly leased worktree '$WT'; refusing to publish custody" >&2
     exit 1
   }
   if [ -n "$acquired_status" ]; then
-    preserve_conflicted_worktree_lease
-    echo "error: newly leased worktree '$WT' is not clean; preserving its lease and local work for reconciliation" >&2
+    echo "error: newly leased worktree '$WT' is not clean; refusing to publish custody" >&2
     exit 1
   fi
   validate_spawn_worktree "treehouse get" "$T"
@@ -2931,11 +2889,8 @@ else
     echo "error: could not publish durable metadata for task $ID" >&2
     exit 1
   fi
-  SPAWN_META_TMP=
-  [ -z "$TREEHOUSE_LEASE_HANDOFF_TMP" ] || rm -f -- "$TREEHOUSE_LEASE_HANDOFF_TMP" 2>/dev/null || true
-  [ -z "$TREEHOUSE_LEASE_HANDOFF" ] || rm -f -- "$TREEHOUSE_LEASE_HANDOFF" 2>/dev/null || true
   TREEHOUSE_ABORT_RETURN_PENDING=0
-  TREEHOUSE_ABORT_RETURN_SUPPRESSED=1
+  SPAWN_META_TMP=
 fi
 if [ "$SPAWN_TASK_SET_LOCK_HELD" = 1 ]; then
   # The record is published, so this task is now part of the set a teardown

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -937,6 +937,10 @@ if [ "$RELAUNCH" -eq 0 ]; then
     exit 1
   fi
   SPAWN_TASK_SET_LOCK_HELD=1
+  if [ -e "$STATE/$ID.meta" ] || [ -L "$STATE/$ID.meta" ]; then
+    echo "error: task $ID already has a durable record at $STATE/$ID.meta; refusing a fresh spawn that could replace its endpoint or worktree. Use --relaunch to reuse an existing task." >&2
+    exit 1
+  fi
 fi
 if [ "$KIND" = secondmate ]; then
   if spawn_remote_secondmate "$ID"; then
@@ -1786,7 +1790,11 @@ assert_worktree_unclaimed() {  # <worktree>
   for meta in "$STATE"/*.meta; do
     [ -e "$meta" ] || [ -L "$meta" ] || continue
     other_id=$(basename "$meta" .meta)
-    [ "$other_id" != "$ID" ] || continue
+    if [ "$other_id" = "$ID" ]; then
+      echo "error: task $ID acquired a durable record while its fresh spawn was leasing '$worktree'; refusing to replace that task's ownership. Nothing was returned or reset. Endpoint $T is parked in that copy." >&2
+      HERDR_PROJECTION_ABORT_CLEANUP=0
+      exit 1
+    fi
     if [ ! -f "$meta" ] || [ -L "$meta" ] || [ ! -r "$meta" ]; then
       echo "error: cannot confirm worktree ownership because task metadata '$meta' is not a readable regular file; refusing to use '$worktree'. Nothing was returned or reset. Endpoint $T is parked in that copy." >&2
       HERDR_PROJECTION_ABORT_CLEANUP=0

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1747,7 +1747,6 @@ validate_spawn_worktree() {  # <source> <inspect-target>
 # would be a worse outage than the one it prevents.
 RELEASE_DELIVERED_SCRIPT=pool:release-delivered
 RELEASE_DELIVERED_TIMEOUT=${FM_SPAWN_RELEASE_DELIVERED_TIMEOUT:-60}
-case "$RELEASE_DELIVERED_TIMEOUT" in ''|*[!0-9]*) RELEASE_DELIVERED_TIMEOUT=60 ;; esac
 
 release_delivered_pool_copies() {  # <project>
   local project=$1 out rc=0 declared=0
@@ -1756,7 +1755,7 @@ release_delivered_pool_copies() {  # <project>
     return 0
   fi
   if [ "$declared" = "$FM_PROJECT_SCRIPT_UNCONFIRMED" ]; then
-    echo "warning: $project names a $RELEASE_DELIVERED_SCRIPT step but node is unavailable to confirm it; leasing without releasing delivered copies" >&2
+    echo "warning: cannot confirm whether $project publishes a $RELEASE_DELIVERED_SCRIPT step; leasing without releasing delivered copies" >&2
     return 0
   fi
   out=$(fm_project_script_run "$project" "$RELEASE_DELIVERED_SCRIPT" \

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -24,9 +24,10 @@
 # Uncommitted changes are never landed.
 # Landing is not the only question: a pooled copy can hold landed work and still
 # belong to somebody else. A project that published a `check:worktree-custody`
-# script is asked for that verdict after the landed check and before anything
-# destructive, and its exit 1 refuses cleanup (docs/configuration.md "Worktree
-# pools"; opt-in and runner mechanics in bin/fm-project-script-lib.sh).
+# script is asked for that verdict from an authenticated snapshot of the
+# canonical clone after the landed check and before anything destructive, and
+# its nonzero exit refuses cleanup (docs/configuration.md "Worktree pools";
+# opt-in and runner mechanics in bin/fm-project-script-lib.sh).
 # local-only projects additionally accept work merged into the local default
 # branch (firstmate performs that merge after configured approval) as a fallback
 # for the common case where there is no remote at all.
@@ -1227,7 +1228,7 @@ validate_worktree_teardown_safety() {
 # second task, or one whose branch was advanced from another checkout, passes
 # the first and fails the second. Only the project knows how to read its own
 # working copy, so a project may publish that verdict as a
-# `check:worktree-custody` script and firstmate refuses on its exit 1.
+# `check:worktree-custody` script and firstmate refuses on its nonzero exit.
 #
 # Opt-in by presence, per bin/fm-project-script-lib.sh: a project that published
 # no such script tears down exactly as before. A project that DID publish one
@@ -1253,17 +1254,21 @@ validate_worktree_custody() {  # <worktree> <project>
      && [ "$wt_declared" = "$FM_PROJECT_SCRIPT_ABSENT" ]; then
     return 0
   fi
-  case "$CUSTODY_CHECK_TIMEOUT" in
-    ''|*[!0-9]*|0)
-      echo "REFUSED: $CUSTODY_CHECK_SCRIPT requires a positive integer timeout, not '$CUSTODY_CHECK_TIMEOUT'." >&2
-      echo "Set FM_TEARDOWN_CUSTODY_TIMEOUT correctly before retrying." >&2
-      return 1
-      ;;
-  esac
-  out=$(fm_project_script_run "$wt" "$CUSTODY_CHECK_SCRIPT" "$CUSTODY_CHECK_TIMEOUT" 2>&1) || rc=$?
+  if ! fm_project_script_timeout_valid "$CUSTODY_CHECK_TIMEOUT"; then
+    echo "REFUSED: $CUSTODY_CHECK_SCRIPT requires a positive integer timeout, not '$CUSTODY_CHECK_TIMEOUT'." >&2
+    echo "Set FM_TEARDOWN_CUSTODY_TIMEOUT correctly before retrying." >&2
+    return 1
+  fi
+  out=$(fm_project_script_run_canonical_head "$project" "$CUSTODY_CHECK_SCRIPT" \
+    "$CUSTODY_CHECK_TIMEOUT" --worktree "$wt" 2>&1) || rc=$?
   [ "$rc" -eq 0 ] && return 0
+  if [ "$rc" -eq "$FM_PROJECT_SCRIPT_CANONICAL_UNAVAILABLE" ]; then
+    echo "REFUSED: cannot authenticate and execute $CUSTODY_CHECK_SCRIPT from canonical project $project." >&2
+    echo "Restore its published HEAD check before retrying." >&2
+    return 1
+  fi
   if [ "$rc" -eq 127 ]; then
-    echo "REFUSED: worktree $wt publishes a $CUSTODY_CHECK_SCRIPT check but $(fm_project_script_manager "$wt") is unavailable to run it." >&2
+    echo "REFUSED: canonical project $project publishes a $CUSTODY_CHECK_SCRIPT check but $(fm_project_script_manager "$project") is unavailable to run it." >&2
     echo "Install it before retrying." >&2
     return 1
   fi

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -22,6 +22,11 @@
 # A gh lookup error falls back to the content check; if that is also inconclusive,
 # teardown refuses rather than risk discarding unlanded work.
 # Uncommitted changes are never landed.
+# Landing is not the only question: a pooled copy can hold landed work and still
+# belong to somebody else. A project that published a `check:worktree-custody`
+# script is asked for that verdict after the landed check and before anything
+# destructive, and its exit 1 refuses cleanup (docs/configuration.md "Worktree
+# pools"; opt-in and runner mechanics in bin/fm-project-script-lib.sh).
 # local-only projects additionally accept work merged into the local default
 # branch (firstmate performs that merge after configured approval) as a fallback
 # for the common case where there is no remote at all.
@@ -168,6 +173,8 @@ SUB_HOME_PARENT_MARKER=".fm-secondmate-parent"
 . "$SCRIPT_DIR/fm-wake-lib.sh"
 # shellcheck source=bin/fm-nm-run-lib.sh
 . "$SCRIPT_DIR/fm-nm-run-lib.sh"
+# shellcheck source=bin/fm-project-script-lib.sh
+. "$SCRIPT_DIR/fm-project-script-lib.sh"
 if [ "$#" -lt 1 ] || ! fm_task_id_path_safe "$1"; then
   echo "error: invalid teardown request" >&2
   exit 2
@@ -1198,6 +1205,44 @@ validate_worktree_teardown_safety() {
       return 1
     fi
   fi
+}
+
+# The landed-work check above answers "would work be lost?". It does not answer
+# "does this copy still have exactly one owner?" - a pooled copy handed to a
+# second task, or one whose branch was advanced from another checkout, passes
+# the first and fails the second. Only the project knows how to read its own
+# working copy, so a project may publish that verdict as a
+# `check:worktree-custody` script and firstmate refuses on its exit 1.
+#
+# Opt-in by presence, per bin/fm-project-script-lib.sh: a project that published
+# no such script tears down exactly as before. A project that DID publish one
+# and cannot be asked refuses rather than tearing down on an unread verdict.
+CUSTODY_CHECK_SCRIPT=check:worktree-custody
+CUSTODY_CHECK_TIMEOUT=${FM_TEARDOWN_CUSTODY_TIMEOUT:-120}
+case "$CUSTODY_CHECK_TIMEOUT" in ''|*[!0-9]*) CUSTODY_CHECK_TIMEOUT=120 ;; esac
+
+validate_worktree_custody() {  # <worktree>
+  local wt=$1 out rc=0 declared=0
+  fm_project_script_declared "$wt" "$CUSTODY_CHECK_SCRIPT" || declared=$?
+  if [ "$declared" = "$FM_PROJECT_SCRIPT_ABSENT" ]; then
+    return 0
+  fi
+  if [ "$declared" = "$FM_PROJECT_SCRIPT_UNCONFIRMED" ]; then
+    echo "REFUSED: worktree $wt names a $CUSTODY_CHECK_SCRIPT check but node is unavailable to confirm it." >&2
+    echo "Install node, or get the captain's explicit OK to discard, then --force." >&2
+    return 1
+  fi
+  out=$(fm_project_script_run "$wt" "$CUSTODY_CHECK_SCRIPT" "$CUSTODY_CHECK_TIMEOUT" 2>&1) || rc=$?
+  [ "$rc" -eq 0 ] && return 0
+  if [ "$rc" -eq 127 ]; then
+    echo "REFUSED: worktree $wt publishes a $CUSTODY_CHECK_SCRIPT check but $(fm_project_script_manager "$wt") is unavailable to run it." >&2
+    echo "Install it, or get the captain's explicit OK to discard, then --force." >&2
+    return 1
+  fi
+  echo "REFUSED: $CUSTODY_CHECK_SCRIPT says worktree $wt is not this task's to discard (exit $rc)." >&2
+  printf '%s\n' "$out" >&2
+  echo "Resolve what that check reports first, or get the captain's explicit OK to discard, then --force." >&2
+  return 1
 }
 
 # Fix 1 (see script header): does the active-or-most-recent no-mistakes run in
@@ -2389,6 +2434,13 @@ if [ -d "$WT" ] && [ "$FORCE" != "--force" ]; then
       exit 1
     fi
   fi
+fi
+
+# Custody comes after the landed-work verdict and before anything destructive:
+# a copy whose work has landed can still be somebody else's copy. Not for
+# kind=secondmate, whose home is not a pooled task working copy.
+if [ -d "$WT" ] && [ "$FORCE" != "--force" ] && [ "$KIND" != secondmate ]; then
+  validate_worktree_custody "$WT" || exit 1
 fi
 
 # Every landed/discard-work refusal above has now passed (or --force skipped

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -223,10 +223,11 @@ TASK_SET_LOCK=$(fm_task_set_lock_path "$STATE") || {
   echo "error: could not resolve the task-set lock for $STATE; nothing was changed" >&2
   exit 1
 }
-fm_lock_try_acquire "$TASK_SET_LOCK" || {
-  echo "error: this home's task set is locked by another operation; refusing teardown of task $ID because nothing destructive may race a spawn" >&2
-  exit 1
-}
+# A fresh spawn refuses while teardown owns this lock. In the opposite
+# direction teardown waits for publication to finish, then validates the now
+# complete task set. Waiting also preserves the existing contract that two
+# cleanups in one home serialize rather than making one fail spuriously.
+fm_lock_acquire_wait "$TASK_SET_LOCK"
 TASK_SET_LOCK_HELD=1
 fm_lock_try_acquire "$CONTROL_LOCK" || {
   echo "error: another lifecycle action is already running for task $ID; nothing was changed" >&2

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -187,6 +187,8 @@ CONTROL_LOCK="$STATE/.control-$ID.lock"
 CONTROL_LOCK_HELD=0
 META_LOCK=
 META_LOCK_HELD=0
+TASK_SET_LOCK=
+TASK_SET_LOCK_HELD=0
 DESCENDANT_LOCK_PATHS=()
 DESCENDANT_TASK_STATES=()
 DESCENDANT_TASK_IDS=()
@@ -209,9 +211,22 @@ teardown_release_locks() {
     fm_lock_release "$CONTROL_LOCK" || true
     CONTROL_LOCK_HELD=0
   fi
+  if [ "$TASK_SET_LOCK_HELD" = 1 ]; then
+    fm_lock_release "$TASK_SET_LOCK" || true
+    TASK_SET_LOCK_HELD=0
+  fi
   return "$status"
 }
 trap teardown_release_locks EXIT
+TASK_SET_LOCK=$(fm_task_set_lock_path "$STATE") || {
+  echo "error: could not resolve the task-set lock for $STATE; nothing was changed" >&2
+  exit 1
+}
+fm_lock_try_acquire "$TASK_SET_LOCK" || {
+  echo "error: this home's task set is locked by another operation; refusing teardown of task $ID because nothing destructive may race a spawn" >&2
+  exit 1
+}
+TASK_SET_LOCK_HELD=1
 fm_lock_try_acquire "$CONTROL_LOCK" || {
   echo "error: another lifecycle action is already running for task $ID; nothing was changed" >&2
   exit 1

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1219,19 +1219,32 @@ validate_worktree_teardown_safety() {
 # and cannot be asked refuses rather than tearing down on an unread verdict.
 CUSTODY_CHECK_SCRIPT=check:worktree-custody
 CUSTODY_CHECK_TIMEOUT=${FM_TEARDOWN_CUSTODY_TIMEOUT:-120}
-case "$CUSTODY_CHECK_TIMEOUT" in ''|*[!0-9]*) CUSTODY_CHECK_TIMEOUT=120 ;; esac
 
-validate_worktree_custody() {  # <worktree>
-  local wt=$1 out rc=0 declared=0
-  fm_project_script_declared "$wt" "$CUSTODY_CHECK_SCRIPT" || declared=$?
-  if [ "$declared" = "$FM_PROJECT_SCRIPT_ABSENT" ]; then
-    return 0
-  fi
-  if [ "$declared" = "$FM_PROJECT_SCRIPT_UNCONFIRMED" ]; then
-    echo "REFUSED: worktree $wt names a $CUSTODY_CHECK_SCRIPT check but node is unavailable to confirm it." >&2
-    echo "Install node, or get the captain's explicit OK to discard, then --force." >&2
+validate_worktree_custody() {  # <worktree> <project>
+  local wt=$1 project=$2 out rc=0 project_declared=0 wt_declared=0
+  fm_project_script_declared "$project" "$CUSTODY_CHECK_SCRIPT" || project_declared=$?
+  fm_project_script_declared "$wt" "$CUSTODY_CHECK_SCRIPT" || wt_declared=$?
+  if [ "$project_declared" = "$FM_PROJECT_SCRIPT_UNCONFIRMED" ]; then
+    echo "REFUSED: cannot confirm whether project $project publishes a $CUSTODY_CHECK_SCRIPT check." >&2
+    echo "Make its package.json readable and valid, or get the captain's explicit OK to discard, then --force." >&2
     return 1
   fi
+  if [ "$wt_declared" = "$FM_PROJECT_SCRIPT_UNCONFIRMED" ]; then
+    echo "REFUSED: cannot confirm whether worktree $wt publishes a $CUSTODY_CHECK_SCRIPT check." >&2
+    echo "Make its package.json readable and valid, or get the captain's explicit OK to discard, then --force." >&2
+    return 1
+  fi
+  if [ "$project_declared" = "$FM_PROJECT_SCRIPT_ABSENT" ] \
+     && [ "$wt_declared" = "$FM_PROJECT_SCRIPT_ABSENT" ]; then
+    return 0
+  fi
+  case "$CUSTODY_CHECK_TIMEOUT" in
+    ''|*[!0-9]*|0)
+      echo "REFUSED: $CUSTODY_CHECK_SCRIPT requires a positive integer timeout, not '$CUSTODY_CHECK_TIMEOUT'." >&2
+      echo "Set FM_TEARDOWN_CUSTODY_TIMEOUT correctly, or get the captain's explicit OK to discard, then --force." >&2
+      return 1
+      ;;
+  esac
   out=$(fm_project_script_run "$wt" "$CUSTODY_CHECK_SCRIPT" "$CUSTODY_CHECK_TIMEOUT" 2>&1) || rc=$?
   [ "$rc" -eq 0 ] && return 0
   if [ "$rc" -eq 127 ]; then
@@ -2440,7 +2453,7 @@ fi
 # a copy whose work has landed can still be somebody else's copy. Not for
 # kind=secondmate, whose home is not a pooled task working copy.
 if [ -d "$WT" ] && [ "$FORCE" != "--force" ] && [ "$KIND" != secondmate ]; then
-  validate_worktree_custody "$WT" || exit 1
+  validate_worktree_custody "$WT" "$PROJ" || exit 1
 fi
 
 # Every landed/discard-work refusal above has now passed (or --force skipped

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1226,12 +1226,12 @@ validate_worktree_custody() {  # <worktree> <project>
   fm_project_script_declared "$wt" "$CUSTODY_CHECK_SCRIPT" || wt_declared=$?
   if [ "$project_declared" = "$FM_PROJECT_SCRIPT_UNCONFIRMED" ]; then
     echo "REFUSED: cannot confirm whether project $project publishes a $CUSTODY_CHECK_SCRIPT check." >&2
-    echo "Make its package.json readable and valid, or get the captain's explicit OK to discard, then --force." >&2
+    echo "Make its package.json readable and valid before retrying." >&2
     return 1
   fi
   if [ "$wt_declared" = "$FM_PROJECT_SCRIPT_UNCONFIRMED" ]; then
     echo "REFUSED: cannot confirm whether worktree $wt publishes a $CUSTODY_CHECK_SCRIPT check." >&2
-    echo "Make its package.json readable and valid, or get the captain's explicit OK to discard, then --force." >&2
+    echo "Make its package.json readable and valid before retrying." >&2
     return 1
   fi
   if [ "$project_declared" = "$FM_PROJECT_SCRIPT_ABSENT" ] \
@@ -1241,7 +1241,7 @@ validate_worktree_custody() {  # <worktree> <project>
   case "$CUSTODY_CHECK_TIMEOUT" in
     ''|*[!0-9]*|0)
       echo "REFUSED: $CUSTODY_CHECK_SCRIPT requires a positive integer timeout, not '$CUSTODY_CHECK_TIMEOUT'." >&2
-      echo "Set FM_TEARDOWN_CUSTODY_TIMEOUT correctly, or get the captain's explicit OK to discard, then --force." >&2
+      echo "Set FM_TEARDOWN_CUSTODY_TIMEOUT correctly before retrying." >&2
       return 1
       ;;
   esac
@@ -1249,12 +1249,12 @@ validate_worktree_custody() {  # <worktree> <project>
   [ "$rc" -eq 0 ] && return 0
   if [ "$rc" -eq 127 ]; then
     echo "REFUSED: worktree $wt publishes a $CUSTODY_CHECK_SCRIPT check but $(fm_project_script_manager "$wt") is unavailable to run it." >&2
-    echo "Install it, or get the captain's explicit OK to discard, then --force." >&2
+    echo "Install it before retrying." >&2
     return 1
   fi
   echo "REFUSED: $CUSTODY_CHECK_SCRIPT says worktree $wt is not this task's to discard (exit $rc)." >&2
   printf '%s\n' "$out" >&2
-  echo "Resolve what that check reports first, or get the captain's explicit OK to discard, then --force." >&2
+  echo "Resolve what that check reports first, then retry." >&2
   return 1
 }
 
@@ -2096,6 +2096,30 @@ validate_firstmate_home_children_removal() {
   done
 }
 
+validate_firstmate_home_children_custody() {
+  local home=$1 sub_state child_meta child_id child_wt child_proj child_kind child_home
+  sub_state="$home/state"
+  [ -d "$sub_state" ] || return 0
+  for child_meta in "$sub_state"/*.meta; do
+    [ -e "$child_meta" ] || continue
+    child_id=$(basename "$child_meta" .meta)
+    child_wt=$(meta_value "$child_meta" worktree)
+    child_proj=$(meta_value "$child_meta" project)
+    child_kind=$(meta_value "$child_meta" kind)
+    [ -n "$child_kind" ] || child_kind=ship
+    if [ "$child_kind" = secondmate ]; then
+      child_home=$(meta_value "$child_meta" home)
+      [ -n "$child_home" ] || child_home=$child_wt
+      validate_firstmate_home_children_custody "$child_home" || return 1
+    elif [ -n "$child_wt" ] && [ -d "$child_wt" ]; then
+      validate_worktree_custody "$child_wt" "$child_proj" || {
+        echo "REFUSED: child task $child_id failed its custody check; forced cleanup changed nothing." >&2
+        return 1
+      }
+    fi
+  done
+}
+
 TEARDOWN_HERDR_LOCK_RECORDS=
 teardown_release_herdr_locks() {
   local lock_session lock_path
@@ -2345,6 +2369,7 @@ if [ "$KIND" = secondmate ]; then
     validate_firstmate_home_children_removal "$HOME_PATH" || exit 1
     preflight_descendant_task_locks "$HOME_PATH" || exit 1
     validate_firstmate_home_children_removal "$HOME_PATH" || exit 1
+    validate_firstmate_home_children_custody "$HOME_PATH" || exit 1
     if [ "$BACKEND" = herdr ]; then
       teardown_herdr_preflight_target "$T" "$ID" || exit 1
     fi
@@ -2452,7 +2477,7 @@ fi
 # Custody comes after the landed-work verdict and before anything destructive:
 # a copy whose work has landed can still be somebody else's copy. Not for
 # kind=secondmate, whose home is not a pooled task working copy.
-if [ -d "$WT" ] && [ "$FORCE" != "--force" ] && [ "$KIND" != secondmate ]; then
+if [ -d "$WT" ] && [ "$KIND" != secondmate ]; then
   validate_worktree_custody "$WT" "$PROJ" || exit 1
 fi
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -226,17 +226,21 @@ When rejection detects another owner for the acquired copy, Firstmate neither re
 A fresh spawn also refuses before endpoint or lease creation when its task id already has a durable record; [`agent-control.md`](agent-control.md) owns how `relaunch` safely reuses that task's recorded endpoint and worktree.
 
 A pool also runs out when delivered copies are never handed back, and a dispatch then fails for want of a slot rather than for want of work.
-A project may publish that housekeeping as a `pool:release-delivered` script, which `bin/fm-spawn.sh` runs once with `--yes` from a temporary authenticated snapshot of the canonical clone's `HEAD` before asking for a worktree; the project owns the script's idempotency and its own pool lock.
+A project may publish that housekeeping as a `pool:release-delivered` script.
+[`bin/fm-project-script-lib.sh`](../bin/fm-project-script-lib.sh) owns the shared opt-in contract: only Git-proven `package.json` views from the working tree, index, or `HEAD` count; an untracked manifest publishes nothing; and confirmed absence remains distinct from an unavailable or unreadable published view.
+`bin/fm-spawn.sh` runs the script once with `--yes` from a temporary authenticated snapshot of the canonical clone's `HEAD` before asking for a worktree; the project owns the script's idempotency and its own pool lock.
 This one is capacity rather than safety, so a release that fails or cannot be confirmed warns and the spawn continues.
-`FM_SPAWN_RELEASE_DELIVERED_TIMEOUT` (default 60 seconds) bounds it.
+`FM_SPAWN_RELEASE_DELIVERED_TIMEOUT` is a positive integer number of seconds and defaults to 60; an invalid value makes this optional housekeeping warn and leaves the spawn free to continue.
 
-A project may also publish its own custody verdict as a `check:worktree-custody` script in its `package.json`, run with the package manager its lockfile selects.
+A project may also publish its own custody verdict as a `check:worktree-custody` script under that same Git-proven opt-in contract, run with the package manager its lockfile selects.
+Teardown resolves that opt-in independently from the canonical clone and protected worktree, and requires custody whenever either one declares it.
+It treats the check as absent only when every available published view omits it; an unavailable repository, unreadable published view, or otherwise unconfirmable result refuses cleanup.
 `bin/fm-teardown.sh` then runs the version committed at the canonical clone's `HEAD` from an authenticated Git snapshot, passing `--worktree <absolute-path>` for the copy being judged, after its landed-work verdict and before any destructive operation.
 The mutable code in that protected copy is never trusted to authorize its own return, and an unavailable or unauthenticated canonical check refuses cleanup.
 A non-zero verdict also refuses cleanup, which covers the copies a landed-work test cannot judge: one handed to a second owner, or one whose branch was advanced from another checkout.
 `--force` does not bypass this custody verdict.
 A project that publishes no such script is unaffected.
-`FM_TEARDOWN_CUSTODY_TIMEOUT` (default 120 seconds) bounds that run.
+`FM_TEARDOWN_CUSTODY_TIMEOUT` must be a positive integer number of seconds and defaults to 120; an invalid value refuses cleanup before the check runs.
 
 ## Harness support
 
@@ -646,8 +650,8 @@ FM_CONFIG_OVERRIDE=      # alternate config dir, mainly for tests
 FM_PROC_ROOT_OVERRIDE=   # alternate /proc root for Linux process-identity reads in fm-wake-lib.sh and fm-teardown.sh, mainly for tests
 FM_POOL_ROOT=            # unsupported literal override; non-empty values refuse and must migrate to FM_POOL_ROOT_BASE
 FM_POOL_ROOT_BASE=$HOME/.treehouse-homes  # directory the per-home pool roots live in
-FM_SPAWN_RELEASE_DELIVERED_TIMEOUT=60  # seconds bounding a project's own pool:release-delivered run before a spawn leases
-FM_TEARDOWN_CUSTODY_TIMEOUT=120  # seconds bounding a project's own check:worktree-custody run during cleanup
+FM_SPAWN_RELEASE_DELIVERED_TIMEOUT=60  # positive integer seconds bounding a project's own pool:release-delivered run before a spawn leases
+FM_TEARDOWN_CUSTODY_TIMEOUT=120  # positive integer seconds bounding a project's own check:worktree-custody run during cleanup
 FM_BACKEND=             # optional runtime backend override for new spawns; tmux/herdr/zellij/orca/cmux support ship/scout spawns, codex-app is not accepted
 FM_TRACE_CONTEXT=       # optional trace-context override; see "Trace context propagation"
 HERDR_SESSION=default  # herdr-only: named session for normal backend ops; not enough for destructive cleanup (docs/herdr-backend.md)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -214,8 +214,14 @@ Two firstmate homes that clone the same project would therefore draw from one po
 By default a home's pool root is `$HOME/.treehouse-homes/<home-directory-name>-<short hash of the home's real path>`, and treehouse places the pool itself under `<root>/.treehouse/`.
 `FM_POOL_ROOT_BASE` moves the directory those per-home roots live in while preserving the mandatory per-home suffix.
 The legacy literal `FM_POOL_ROOT` override is refused because the same inherited value could make multiple homes share a pool.
-The separation applies to worktrees leased from that point on; a worktree already leased keeps its path, is returned normally, and drains out of a previously shared pool on its own.
+The separation applies only to worktrees leased from that point on; reconfiguration never moves, resets, returns, invalidates, or recycles a worktree already leased.
+That existing lease keeps its absolute path and later follows ordinary teardown, so previously shared pools drain without a migration step.
 A project whose `treehouse.toml` is tracked in git is refused rather than rewritten, because recording a machine-local path there would change project content.
+
+After treehouse hands a fresh spawn a path, Firstmate checks every `state/*.meta` record in that same home before refreshing the copy or launching the agent.
+An unreadable, non-regular, missing, empty, or ambiguous worktree declaration fails closed, as does another task record that resolves to the acquired path.
+The refused spawn neither returns nor resets the copy and leaves its new endpoint parked there, so the recorded owner can be reconciled without losing work.
+A fresh spawn also refuses before endpoint or lease creation when its task id already has a durable record; [`agent-control.md`](agent-control.md) owns how `relaunch` safely reuses that task's recorded endpoint and worktree.
 
 A pool also runs out when delivered copies are never handed back, and a dispatch then fails for want of a slot rather than for want of work.
 A project may publish that housekeeping as a `pool:release-delivered` script, which `bin/fm-spawn.sh` runs once in the clone with `--yes` before asking for a worktree; the project owns the script's idempotency and its own pool lock.
@@ -226,6 +232,7 @@ A project may also publish its own custody verdict as a `check:worktree-custody`
 `bin/fm-teardown.sh` then runs the version committed at the canonical clone's `HEAD` from an authenticated Git snapshot, passing `--worktree <absolute-path>` for the copy being judged, after its landed-work verdict and before any destructive operation.
 The mutable code in that protected copy is never trusted to authorize its own return, and an unavailable or unauthenticated canonical check refuses cleanup.
 A non-zero verdict also refuses cleanup, which covers the copies a landed-work test cannot judge: one handed to a second owner, or one whose branch was advanced from another checkout.
+`--force` does not bypass this custody verdict.
 A project that publishes no such script is unaffected.
 `FM_TEARDOWN_CUSTODY_TIMEOUT` (default 120 seconds) bounds that run.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -221,11 +221,12 @@ Pool paths are encoded as TOML basic strings in the generated view, so quotes, b
 
 After treehouse hands a fresh spawn a path, Firstmate checks every `state/*.meta` record in that same home before refreshing the copy or launching the agent.
 An unreadable, non-regular, missing, empty, or ambiguous worktree declaration fails closed, as does another task record that resolves to the acquired path.
-The refused spawn neither returns nor resets the copy and leaves its new endpoint parked there, so the recorded owner can be reconciled without losing work.
+An unpublished lease is returned when spawn otherwise aborts.
+When rejection detects another owner for the acquired copy, Firstmate neither returns nor resets it and leaves its new endpoint parked there, so the recorded owner can be reconciled without losing work.
 A fresh spawn also refuses before endpoint or lease creation when its task id already has a durable record; [`agent-control.md`](agent-control.md) owns how `relaunch` safely reuses that task's recorded endpoint and worktree.
 
 A pool also runs out when delivered copies are never handed back, and a dispatch then fails for want of a slot rather than for want of work.
-A project may publish that housekeeping as a `pool:release-delivered` script, which `bin/fm-spawn.sh` runs once in the clone with `--yes` before asking for a worktree; the project owns the script's idempotency and its own pool lock.
+A project may publish that housekeeping as a `pool:release-delivered` script, which `bin/fm-spawn.sh` runs once with `--yes` from a temporary authenticated snapshot of the canonical clone's `HEAD` before asking for a worktree; the project owns the script's idempotency and its own pool lock.
 This one is capacity rather than safety, so a release that fails or cannot be confirmed warns and the spawn continues.
 `FM_SPAWN_RELEASE_DELIVERED_TIMEOUT` (default 60 seconds) bounds it.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -209,14 +209,15 @@ The full cmux home label also includes a short hash of the resolved `FM_ROOT` pa
 ## Worktree pools (FM_POOL_ROOT_BASE)
 
 Crewmate and scout worktrees come from a treehouse pool, and treehouse keys a pool by the repository rather than by the checkout.
-Two firstmate homes that clone the same project would therefore draw from one pool while neither can see the other's task records, so each home gives its own clone a pool of its own instead.
-`bin/fm-pool-root.sh` owns that derivation and its exact mechanics; `bin/fm-spawn.sh` runs it before every crewmate or scout worktree is acquired.
+Two firstmate homes that clone the same project would therefore draw from one pool while neither can see the other's task records, so each home gives its dispatches a pool of their own instead.
+`bin/fm-pool-root.sh` owns that derivation and creates a generated Git config view under the canonical home's `state/treehouse-config/`; `bin/fm-spawn.sh` runs the unwrapped `treehouse get` from that view before every crewmate or scout worktree is acquired.
+The view points Git at the same backing repository and carries the home-specific Treehouse root, while the captain's primary project checkout, its `treehouse.toml`, and its Git exclusion metadata remain untouched.
 By default a home's pool root is `$HOME/.treehouse-homes/<home-directory-name>-<short hash of the home's real path>`, and treehouse places the pool itself under `<root>/.treehouse/`.
 `FM_POOL_ROOT_BASE` moves the directory those per-home roots live in while preserving the mandatory per-home suffix.
 The legacy literal `FM_POOL_ROOT` override is refused because the same inherited value could make multiple homes share a pool.
 The separation applies only to worktrees leased from that point on; reconfiguration never moves, resets, returns, invalidates, or recycles a worktree already leased.
 That existing lease keeps its absolute path and later follows ordinary teardown, so previously shared pools drain without a migration step.
-A project whose `treehouse.toml` is tracked in git is refused rather than rewritten, because recording a machine-local path there would change project content.
+Pool paths are encoded as TOML basic strings in the generated view, so quotes, backslashes, and control characters in valid filesystem paths cannot corrupt Treehouse configuration.
 
 After treehouse hands a fresh spawn a path, Firstmate checks every `state/*.meta` record in that same home before refreshing the copy or launching the agent.
 An unreadable, non-regular, missing, empty, or ambiguous worktree declaration fails closed, as does another task record that resolves to the acquired path.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -206,13 +206,14 @@ The full zellij home label also includes a short hash of the resolved `FM_ROOT` 
 For the cmux backend, `FM_CONFIG_OVERRIDE` overrides where `config/cmux-socket-password` is read from, while `FM_HOME` determines the default config path and readable home prefix embedded in workspace titles.
 The full cmux home label also includes a short hash of the resolved `FM_ROOT` path, and there is no per-home container split.
 
-## Worktree pools (FM_POOL_ROOT / FM_POOL_ROOT_BASE)
+## Worktree pools (FM_POOL_ROOT_BASE)
 
 Crewmate and scout worktrees come from a treehouse pool, and treehouse keys a pool by the repository rather than by the checkout.
 Two firstmate homes that clone the same project would therefore draw from one pool while neither can see the other's task records, so each home gives its own clone a pool of its own instead.
 `bin/fm-pool-root.sh` owns that derivation and its exact mechanics; `bin/fm-spawn.sh` runs it before every crewmate or scout worktree is acquired.
 By default a home's pool root is `$HOME/.treehouse-homes/<home-directory-name>-<short hash of the home's real path>`, and treehouse places the pool itself under `<root>/.treehouse/`.
-`FM_POOL_ROOT_BASE` moves the directory those per-home roots live in, and `FM_POOL_ROOT` names one home's root outright.
+`FM_POOL_ROOT_BASE` moves the directory those per-home roots live in while preserving the mandatory per-home suffix.
+The legacy literal `FM_POOL_ROOT` override is refused because the same inherited value could make multiple homes share a pool.
 The separation applies to worktrees leased from that point on; a worktree already leased keeps its path, is returned normally, and drains out of a previously shared pool on its own.
 A project whose `treehouse.toml` is tracked in git is refused rather than rewritten, because recording a machine-local path there would change project content.
 
@@ -632,7 +633,7 @@ FM_DATA_OVERRIDE=        # alternate data dir, mainly for tests
 FM_PROJECTS_OVERRIDE=    # alternate projects dir, mainly for tests
 FM_CONFIG_OVERRIDE=      # alternate config dir, mainly for tests
 FM_PROC_ROOT_OVERRIDE=   # alternate /proc root for Linux process-identity reads in fm-wake-lib.sh and fm-teardown.sh, mainly for tests
-FM_POOL_ROOT=            # this home's treehouse worktree-pool root outright; see "Worktree pools"
+FM_POOL_ROOT=            # unsupported literal override; non-empty values refuse and must migrate to FM_POOL_ROOT_BASE
 FM_POOL_ROOT_BASE=$HOME/.treehouse-homes  # directory the per-home pool roots live in
 FM_SPAWN_RELEASE_DELIVERED_TIMEOUT=60  # seconds bounding a project's own pool:release-delivered run before a spawn leases
 FM_TEARDOWN_CUSTODY_TIMEOUT=120  # seconds bounding a project's own check:worktree-custody run during cleanup

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -212,7 +212,7 @@ Crewmate and scout worktrees come from a treehouse pool, and treehouse keys a po
 Two firstmate homes that clone the same project would therefore draw from one pool while neither can see the other's task records, so each home gives its dispatches a pool of their own instead.
 `bin/fm-pool-root.sh` owns that derivation and creates a generated Git config view under the canonical home's `state/treehouse-config/`; `bin/fm-spawn.sh` runs the unwrapped `treehouse get` from that view before every crewmate or scout worktree is acquired.
 The view points Git at the same backing repository and carries the home-specific Treehouse root, while the captain's primary project checkout, its `treehouse.toml`, and its Git exclusion metadata remain untouched.
-By default a home's pool root is `$HOME/.treehouse-homes/<home-directory-name>-<short hash of the home's real path>`, and treehouse places the pool itself under `<root>/.treehouse/`.
+By default a home's pool root is `$HOME/.treehouse-homes/<home-directory-name>-<full SHA-256 of the home's real path>`, and treehouse places the pool itself under `<root>/.treehouse/`.
 `FM_POOL_ROOT_BASE` moves the directory those per-home roots live in while preserving the mandatory per-home suffix.
 The legacy literal `FM_POOL_ROOT` override is refused because the same inherited value could make multiple homes share a pool.
 The separation applies only to worktrees leased from that point on; reconfiguration never moves, resets, returns, invalidates, or recycles a worktree already leased.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -206,6 +206,26 @@ The full zellij home label also includes a short hash of the resolved `FM_ROOT` 
 For the cmux backend, `FM_CONFIG_OVERRIDE` overrides where `config/cmux-socket-password` is read from, while `FM_HOME` determines the default config path and readable home prefix embedded in workspace titles.
 The full cmux home label also includes a short hash of the resolved `FM_ROOT` path, and there is no per-home container split.
 
+## Worktree pools (FM_POOL_ROOT / FM_POOL_ROOT_BASE)
+
+Crewmate and scout worktrees come from a treehouse pool, and treehouse keys a pool by the repository rather than by the checkout.
+Two firstmate homes that clone the same project would therefore draw from one pool while neither can see the other's task records, so each home gives its own clone a pool of its own instead.
+`bin/fm-pool-root.sh` owns that derivation and its exact mechanics; `bin/fm-spawn.sh` runs it before every crewmate or scout worktree is acquired.
+By default a home's pool root is `$HOME/.treehouse-homes/<home-directory-name>-<short hash of the home's real path>`, and treehouse places the pool itself under `<root>/.treehouse/`.
+`FM_POOL_ROOT_BASE` moves the directory those per-home roots live in, and `FM_POOL_ROOT` names one home's root outright.
+The separation applies to worktrees leased from that point on; a worktree already leased keeps its path, is returned normally, and drains out of a previously shared pool on its own.
+A project whose `treehouse.toml` is tracked in git is refused rather than rewritten, because recording a machine-local path there would change project content.
+
+A pool also runs out when delivered copies are never handed back, and a dispatch then fails for want of a slot rather than for want of work.
+A project may publish that housekeeping as a `pool:release-delivered` script, which `bin/fm-spawn.sh` runs once in the clone with `--yes` before asking for a worktree; the project owns the script's idempotency and its own pool lock.
+This one is capacity rather than safety, so a release that fails or cannot be confirmed warns and the spawn continues.
+`FM_SPAWN_RELEASE_DELIVERED_TIMEOUT` (default 60 seconds) bounds it.
+
+A project may also publish its own custody verdict as a `check:worktree-custody` script in its `package.json`, run with the package manager its lockfile selects.
+`bin/fm-teardown.sh` then runs that check in the worktree after its landed-work verdict and refuses cleanup when the check exits non-zero, which covers the copies a landed-work test cannot judge: one handed to a second owner, or one whose branch was advanced from another checkout.
+A project that publishes no such script is unaffected.
+`FM_TEARDOWN_CUSTODY_TIMEOUT` (default 120 seconds) bounds that run.
+
 ## Harness support
 
 claude, codex, opencode, pi, pi-signed, grok, kimi, and cursor are empirically verified for crewmate and secondmate launches; [README requirements](../README.md#requirements) own the set supported for the primary session.
@@ -612,6 +632,10 @@ FM_DATA_OVERRIDE=        # alternate data dir, mainly for tests
 FM_PROJECTS_OVERRIDE=    # alternate projects dir, mainly for tests
 FM_CONFIG_OVERRIDE=      # alternate config dir, mainly for tests
 FM_PROC_ROOT_OVERRIDE=   # alternate /proc root for Linux process-identity reads in fm-wake-lib.sh and fm-teardown.sh, mainly for tests
+FM_POOL_ROOT=            # this home's treehouse worktree-pool root outright; see "Worktree pools"
+FM_POOL_ROOT_BASE=$HOME/.treehouse-homes  # directory the per-home pool roots live in
+FM_SPAWN_RELEASE_DELIVERED_TIMEOUT=60  # seconds bounding a project's own pool:release-delivered run before a spawn leases
+FM_TEARDOWN_CUSTODY_TIMEOUT=120  # seconds bounding a project's own check:worktree-custody run during cleanup
 FM_BACKEND=             # optional runtime backend override for new spawns; tmux/herdr/zellij/orca/cmux support ship/scout spawns, codex-app is not accepted
 FM_TRACE_CONTEXT=       # optional trace-context override; see "Trace context propagation"
 HERDR_SESSION=default  # herdr-only: named session for normal backend ops; not enough for destructive cleanup (docs/herdr-backend.md)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -223,7 +223,9 @@ This one is capacity rather than safety, so a release that fails or cannot be co
 `FM_SPAWN_RELEASE_DELIVERED_TIMEOUT` (default 60 seconds) bounds it.
 
 A project may also publish its own custody verdict as a `check:worktree-custody` script in its `package.json`, run with the package manager its lockfile selects.
-`bin/fm-teardown.sh` then runs that check in the worktree after its landed-work verdict and refuses cleanup when the check exits non-zero, which covers the copies a landed-work test cannot judge: one handed to a second owner, or one whose branch was advanced from another checkout.
+`bin/fm-teardown.sh` then runs the version committed at the canonical clone's `HEAD` from an authenticated Git snapshot, passing `--worktree <absolute-path>` for the copy being judged, after its landed-work verdict and before any destructive operation.
+The mutable code in that protected copy is never trusted to authorize its own return, and an unavailable or unauthenticated canonical check refuses cleanup.
+A non-zero verdict also refuses cleanup, which covers the copies a landed-work test cannot judge: one handed to a second owner, or one whose branch was advanced from another checkout.
 A project that publishes no such script is unaffected.
 `FM_TEARDOWN_CUSTODY_TIMEOUT` (default 120 seconds) bounds that run.
 

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -381,6 +381,10 @@
       "audience": "maintainer-verification"
     },
     {
+      "path": "docs/verification/worktree-pools.md",
+      "audience": "maintainer-verification"
+    },
+    {
       "path": "docs/voice-relay.md",
       "audience": "operator-current"
     },

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -93,7 +93,7 @@ Presentation is a best-effort visual projection, never task ownership or lifecyc
 Only a fresh task with neither metadata nor an existing presentation journal is eligible for projected creation.
 Firstmate atomically publishes a three-field version 1 journal containing a random 128-bit base64url token before asking Herdr to create anything.
 After the new workspace converges to one exact task endpoint beneath one exact parent workspace id, the journal advances to a version 2 binding that records the physical home, named session, endpoint, parent, and immutable expected labels.
-Another parent with the same presentation label does not prevent publication or participate in restart reclaim.
+Another parent with the same presentation label does not prevent publication or grant endpoint, task, or restart authority.
 The token is visible in the workspace title because Herdr exposes no verified hidden persistent field, but neither token, title, nor journal authorizes send, capture, task ownership, Treehouse return, or general recovery.
 
 The owning parent is the launcher's own exact workspace, resolved from the same identity the flat path uses, and falls back to a unique home-label lookup only for a Firstmate outside Herdr.
@@ -130,13 +130,11 @@ If lock, snapshot, pane identity, or restoration is ambiguous, cleanup warns and
 
 Recovery is deliberately conservative and presentation-only.
 An existing journal suppresses another projected create.
-Before any recovery mutation, Firstmate holds both the task spawn lock and the named-session presentation lock.
-A same-identity version 2 binding may replace one exact agent-free restart husk in place only when the physical home, session, metadata endpoint, unique token match, workspace shape and labels, parent identity and placement, and non-target focus snapshot all agree.
-The replacement tab and pane are created and verified before the old pane is rechecked and closed, then the journal advances atomically to the replacement endpoint before metadata publication.
-The reclaim path never moves, closes, deletes, or renames a workspace and never touches a parent, sibling, captain, or foreign pane.
-A failed replacement rolls back only the exact response-derived new pane when focus-safe verification permits it.
-Version 1 journals, dead or missing panes, duplicate or absent tokens, renamed or detached spaces, cross-home mismatches, inconsistent endpoint bindings, active target tabs, and ambiguous identity or focus fall back flat without mutating the old projection when duplicate-agent risk is positively absent.
-A live or unknown recorded or token-matched endpoint refuses duplicate launch.
+A durable task record refuses a fresh spawn before Herdr endpoint or Treehouse worktree side effects, even when the recorded pane is an agent-free restart husk.
+The presentation binding never authorizes replacing that endpoint or moving the task to another worktree.
+Replacement agents follow [`agent-control.md`](agent-control.md#transactional-relaunch) and reuse the exact recorded endpoint and worktree; if a Herdr restart leaves that endpoint outside the recorded worktree, relaunch refuses while preserving the endpoint, worktree, and durable record.
+An orphaned journal with no task record may fall back to the ordinary flat layout only after duplicate-agent risk is positively absent, without mutating the old projection.
+Version 1 journals, dead or missing panes, duplicate or absent tokens, renamed or detached spaces, cross-home mismatches, inconsistent bindings, active target tabs, and ambiguous identity or focus remain quarantined rather than granting mutation authority.
 
 Locked session start has one narrower cleanup for a restored projected child that is no longer current task state.
 It runs only when the current home has at least one ordinary presentation journal and considers only that home; a primary never recursively sweeps a secondmate home.
@@ -156,18 +154,18 @@ A malformed or missing title or token, duplicate token, zero or multiple journal
 
 Operational compromises:
 
-- Grouping is best-effort; only an exact same-identity version 2 binding survives a Herdr restart in place.
+- Grouping is best-effort; a Herdr server restart does not authorize rebuilding or moving an existing task endpoint.
 - A failed journal publication or projected workspace create stops that spawn instead of falling back flat, so a Herdr create failure surfaces as a spawn failure in every Herdr home rather than only in homes that opted in; every earlier degradation on the fresh projected-create path (no session server, contended presentation lock, absent or ambiguous parent) still warns and continues flat.
 - Recovery of an existing presentation journal deliberately refuses the spawn when the shared presentation lock is contended rather than falling back flat, and default-on makes that refusal reachable in any Herdr home.
 - Existing layouts are not force-renamed or rearranged.
-- Missing or ambiguous restart bindings fall back to the ordinary home workspace while the old projection remains untouched.
+- Missing or ambiguous orphan-journal bindings fall back to the ordinary home workspace while the old projection remains untouched.
 - Crashes, lost responses, failed exact-pane cleanup, or human renames can leave quarantined spaces; session start removes only the exact home-local, uniquely journal-correlated, childless idle-shell shape above.
 - Spaces have no cross-home cleanup path, and a secondmate child can clean up only from its exact home.
 - Every stale-looking space outside that narrow startup proof still requires manual cleanup in Herdr's UI after human inspection.
 - Regaining a dedicated space after degradation requires stopping the flat task, manually checking the stale projection, and clearing its journal before a genuinely fresh launch.
 - The visible token is only a restart-stable correlator and never substitutes for the exact binding.
 
-`tests/fm-backend-herdr-presentation-e2e.test.sh` covers multi-home ordering, concurrency, lock contention, legacy coexistence, focus preservation, exact same-identity restart replacement, ambiguous bindings and tokens, and exact-pane cleanup through the guarded lab path.
+`tests/fm-backend-herdr-presentation-e2e.test.sh` covers multi-home ordering, concurrency, lock contention, legacy coexistence, focus preservation, non-mutating fresh-launch and relaunch refusal after a server restart, ambiguous bindings and tokens, and exact-pane cleanup through the guarded lab path.
 `tests/fm-herdr-session-cleanup.test.sh` covers every discovery, ownership, topology, process, locking, revalidation, focus, retirement, and continue-on-error boundary.
 `tests/fm-herdr-session-cleanup-e2e.test.sh` covers the restored-shell cleanup in a guarded non-default named lab.
 `tests/fm-backend-herdr-focus-flash-e2e.test.sh` reproduces the raw explicit-close focus steal on the installed release and proves the focus-safe emptying-close plan removes a doomed workspace with no wrong-focus interval; [`verification/runtime-backends.md`](verification/runtime-backends.md#workspace-removal-focus-safety) owns the active versioned evidence.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -378,15 +378,8 @@ HERDR_LAB_HELPER=bin/fm-herdr-lab.sh \
   tests/fm-backend-herdr-presentation-e2e.test.sh
 ```
 
-Observed restart-reclaim guarantees:
-
-```text
-ok - real Herdr lab: Hi Bit and Wheelhouse-style same-identity restarts reclaim one nested space with exact focus and idempotence
-ok - real Herdr lab: secondmate restart binding and reclaim stay isolated to the exact child home and parent
-ok - real Herdr lab: concurrent cross-home recoveries replace exact husks under one session lock with no focus drift
-ok - real Herdr lab: missing, renamed, and duplicate tokens trigger zero destructive or adoptive calls, and live duplicate risk refuses launch
-ok - real Herdr lab validation completed on Herdr 0.7.5 with the default-session tripwire intact
-```
+That run established projection compatibility with Herdr 0.7.5.
+The current restart-custody contract is owned by [`herdr-backend.md`](../herdr-backend.md#presentation-spaces) and enforced by `tests/fm-backend-herdr-presentation-e2e.test.sh`, which requires a fresh launch and relaunch after a server restart to refuse without moving or rewriting the existing endpoint, worktree, or durable task record.
 
 The projection suite ran again on 2026-08-04 against Herdr 0.8.0 protocol 19 for the default-on flip, where an absent `config/herdr-presentation-spaces` enables the projection and the value `off` opts out; since 2026-08-05 an absent file enables the projection only at or above the 0.8.0 floor recorded under "Presentation version floor" below, and `on` is the explicit opt-in that survives the floor:
 
@@ -405,7 +398,6 @@ ok - real Herdr lab validation completed on Herdr 0.8.0 with the default-session
 ```
 
 The projected spawn in that run used the historical empty opt-in file, so a home that had already enabled the projection keeps it without any migration step.
-One concurrent cross-home recovery case refused under contention on a loaded machine and passed on an immediate rerun; recovery-path presentation lock contention is a deliberate hard refusal rather than a flat fallback, which default-on now makes reachable from any Herdr home.
 That run measured the default-on projection on Herdr 0.8.0 only, while the focus-flash regression below was last run on 0.7.5 before the flip, so neither run covered a defective release under default-on projection; the version floor and the focus-flash suite's Part C close that gap.
 
 The restored-shell session-start cleanup ran on 2026-07-24 against Herdr 0.7.5 protocol 17:

--- a/docs/verification/worktree-pools.md
+++ b/docs/verification/worktree-pools.md
@@ -90,4 +90,4 @@ A copy left dirty is skipped rather than re-leased, so uncommitted work is not w
 ## Refreshing this record
 
 Re-run the sequence above against the installed `treehouse` after any upgrade past v2.0.0, and update the version row plus any output that changed.
-The portable half of the same guarantees is enforced continuously by `tests/fm-worktree-custody.test.sh`, whose real-treehouse case self-skips when the binary is absent.
+The portable half of the same guarantees is enforced continuously by `tests/fm-worktree-custody.test.sh`, including rejection of the unsafe literal-root override; its real-treehouse case self-skips when the binary is absent.

--- a/docs/verification/worktree-pools.md
+++ b/docs/verification/worktree-pools.md
@@ -9,7 +9,7 @@ Active empirical evidence for the pool facts firstmate's single-owner guarantees
 |---|---|
 | Tool | `treehouse` v2.0.0 (`treehouse --version`) |
 | Pinned for CI | v2.0.1 (`bin/fm-install-treehouse.sh`) |
-| Verified | 2026-08-16 |
+| Verified | 2026-08-22 |
 | Platform | macOS arm64 (Darwin 25.3.0) |
 
 Every run below used throwaway repositories and explicit `root` values under a scratch directory, so no run touched a real pool.
@@ -41,16 +41,21 @@ That is why the guarantee cannot rest on clone naming: firstmate's own layout ma
 
 ### `root` is the only knob that separates two homes' pools
 
-After each clone is given its own root, the same two clones no longer share a pool:
+After each home is given its own generated config view and root, the same two clones no longer share a pool without changing either primary checkout:
 
 ```
 $ FM_HOME=.../homeA fm-pool-root.sh .../homeA/projects/proj
 $ FM_HOME=.../homeB fm-pool-root.sh .../homeB/projects/proj
-$ (cd homeA/projects/proj && treehouse get --lease --lease-holder homeA)
+$ viewA=$(FM_HOME=.../homeA fm-pool-root.sh --view .../homeA/projects/proj)
+$ viewB=$(FM_HOME=.../homeB fm-pool-root.sh --view .../homeB/projects/proj)
+$ (cd "$viewA" && treehouse get --lease --lease-holder homeA)
 .../pools/homeA-4b5fe151/.treehouse/proj-dbcb21/1/proj
-$ (cd homeB/projects/proj && treehouse get --lease --lease-holder homeB)
+$ (cd "$viewB" && treehouse get --lease --lease-holder homeB)
 .../pools/homeB-0f7ece37/.treehouse/proj-dbcb21/1/proj
 ```
+
+Both primary clones remained clean and retained their original `treehouse.toml` paths and Git exclusion metadata.
+The portable regression also drives the installed Treehouse parser with a root containing a quote, backslash, and newline, then verifies that the leased path resolves under the intended root.
 
 ### A worktree already leased is unaffected by a later root change
 
@@ -90,4 +95,4 @@ A copy left dirty is skipped rather than re-leased, so uncommitted work is not w
 ## Refreshing this record
 
 Re-run the sequence above against the installed `treehouse` after any upgrade past v2.0.0, and update the version row plus any output that changed.
-The portable half of the same guarantees is enforced continuously by `tests/fm-worktree-custody.test.sh`, including rejection of the unsafe literal-root override; its real-treehouse case self-skips when the binary is absent.
+The portable half of the same guarantees is enforced continuously by `tests/fm-worktree-custody.test.sh`, including rejection of the unsafe literal-root override, primary-clone immutability, semantic TOML-path consumption, and fail-closed canonical custody dependencies; its real-treehouse cases self-skip when the binary is absent.

--- a/docs/verification/worktree-pools.md
+++ b/docs/verification/worktree-pools.md
@@ -95,4 +95,4 @@ A copy left dirty is skipped rather than re-leased, so uncommitted work is not w
 ## Refreshing this record
 
 Re-run the sequence above against the installed `treehouse` after any upgrade past v2.0.0, and update the version row plus any output that changed.
-The portable half of the same guarantees is enforced continuously by `tests/fm-worktree-custody.test.sh`, including rejection of the unsafe literal-root override, primary-clone immutability, semantic TOML-path consumption, and fail-closed canonical custody dependencies; its real-treehouse cases self-skip when the binary is absent.
+The portable half of the same guarantees is enforced continuously by `tests/fm-worktree-custody.test.sh`, including rejection of the unsafe literal-root override, primary-clone immutability, semantic TOML-path consumption, Git-proven script opt-ins with distinct absent and unconfirmed outcomes, and fail-closed canonical custody dependencies; its real-treehouse cases self-skip when the binary is absent.

--- a/docs/verification/worktree-pools.md
+++ b/docs/verification/worktree-pools.md
@@ -1,0 +1,93 @@
+# Verification: treehouse worktree pools across firstmate homes
+
+Active empirical evidence for the pool facts firstmate's single-owner guarantees rest on.
+[`docs/configuration.md`](../configuration.md) owns the operator-facing behavior and `bin/fm-pool-root.sh` owns the mechanics; this record owns how the underlying treehouse behavior was established.
+
+## Subject
+
+| Field | Value |
+|---|---|
+| Tool | `treehouse` v2.0.0 (`treehouse --version`) |
+| Pinned for CI | v2.0.1 (`bin/fm-install-treehouse.sh`) |
+| Verified | 2026-08-16 |
+| Platform | macOS arm64 (Darwin 25.3.0) |
+
+Every run below used throwaway repositories and explicit `root` values under a scratch directory, so no run touched a real pool.
+`bin/fm-pool-root.sh` is referenced below as `fm-pool-root.sh`.
+
+## Verified facts
+
+### A pool is keyed by clone name plus repository, not by the checkout
+
+Two clones of one origin, one per home, with the same clone directory name - exactly the shape firstmate produces, because it clones every project to `$FM_HOME/projects/<name>` - are pooled together and handed adjacent slots:
+
+```
+$ (cd homeA/projects/proj && treehouse get --lease --lease-holder homeA)
+.../shared/.treehouse/proj-dbcb21/1/proj
+$ (cd homeB/projects/proj && treehouse get --lease --lease-holder homeB)
+.../shared/.treehouse/proj-dbcb21/2/proj
+```
+
+The pool directory name carries the clone's own basename, so two clones named differently do not collide:
+
+```
+$ (cd homeA-proj && treehouse get --lease --lease-holder homeA)
+.../shared/.treehouse/homeA-proj-83944f/1/homeA-proj
+$ (cd homeB-proj && treehouse get --lease --lease-holder homeB)
+.../shared/.treehouse/homeB-proj-83944f/1/homeB-proj
+```
+
+That is why the guarantee cannot rest on clone naming: firstmate's own layout makes the names match.
+
+### `root` is the only knob that separates two homes' pools
+
+After each clone is given its own root, the same two clones no longer share a pool:
+
+```
+$ FM_HOME=.../homeA fm-pool-root.sh .../homeA/projects/proj
+$ FM_HOME=.../homeB fm-pool-root.sh .../homeB/projects/proj
+$ (cd homeA/projects/proj && treehouse get --lease --lease-holder homeA)
+.../pools/homeA-4b5fe151/.treehouse/proj-dbcb21/1/proj
+$ (cd homeB/projects/proj && treehouse get --lease --lease-holder homeB)
+.../pools/homeB-0f7ece37/.treehouse/proj-dbcb21/1/proj
+```
+
+### A worktree already leased is unaffected by a later root change
+
+Returning a worktree from the old shared pool still succeeds after its clone has been re-rooted, and frees exactly that slot:
+
+```
+$ (cd homeA/projects/proj && treehouse return --force .../shared/.treehouse/proj-dbcb21/1/proj)
+🌳 Worktree returned to pool.
+$ # .../shared/.treehouse/proj-dbcb21/treehouse-state.json
+[('1', False, None), ('2', True, 'homeB')]
+```
+
+This is what makes the separation safe to apply to a live fleet: existing leases keep their absolute paths, drain normally, and only new leases move.
+
+### A clean worktree whose holder is gone is re-leased and reset
+
+The damage mechanism itself. Slot 1 holds a clean copy with an unlanded commit on its own branch and no live owner:
+
+```
+$ git -C <slot 1> log --oneline -1 ; git -C <slot 1> rev-parse --abbrev-ref HEAD
+2cd3d54 unlanded work
+fm/unlanded
+$ # treehouse-state.json: [('1', None, False)]  - no owner_pid, not leased
+```
+
+Another clone asking for a worktree is handed that exact path, detached back onto the base commit:
+
+```
+$ (cd homeB/projects/proj && treehouse get)
+.../relerase/.treehouse/proj-dbcb21/1/proj
+ae48ecd init
+```
+
+The branch ref survives, so the commits are recoverable, but the copy now has two owners: whichever task is cleaned up first returns it and hard-resets what the other is doing.
+A copy left dirty is skipped rather than re-leased, so uncommitted work is not what this loses - committed, unlanded work in a clean copy is.
+
+## Refreshing this record
+
+Re-run the sequence above against the installed `treehouse` after any upgrade past v2.0.0, and update the version row plus any output that changed.
+The portable half of the same guarantees is enforced continuously by `tests/fm-worktree-custody.test.sh`, whose real-treehouse case self-skips when the binary is absent.

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -501,7 +501,7 @@ test_projected_custody_conflict() {
   mkdir -p "$(dirname "$conflict_wt")"
   git -C "$PROJECT_DIR" worktree add --quiet --detach "$conflict_wt" HEAD
   conflict_head=$(git -C "$conflict_wt" rev-parse HEAD)
-  printf 'window=firstmate:fm-other-owner\nworktree=%s\nproject=%s\nkind=ship\nmode=no-mistakes\n' \
+  printf 'window=firstmate:fm-other-owner\nworktree=%s\ntreehouse_lease_holder=other-owner\nproject=%s\nkind=ship\nmode=no-mistakes\n' \
     "$conflict_wt" "$PROJECT_DIR" > "$HOME_DIR/state/other-owner.meta"
   mkdir -p "$POST_CREATE_ABORT_CONTROL"
   printf '%s\n' "$conflict_wt" > "$POST_CREATE_ABORT_CONTROL/lease-path"

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -155,7 +155,7 @@ if [ "$status" -eq 0 ] && [ "$mutation" = workspace-create ]; then
       printf '%s\n' "$(printf '%s' "$out" | jq -r '.result.tab.tab_id')" > "$ACTIVE_SEEDED_CONTROL/seeded-tab"
       printf '%s\n' "$(printf '%s' "$out" | jq -r '.result.root_pane.pane_id')" > "$ACTIVE_SEEDED_CONTROL/seeded-pane"
       ;;
-    $'└ abort-a · p:'*|$'└ abort-b · p:'*)
+    $'└ abort-a · p:'*|$'└ abort-b · p:'*|$'└ custody-conflict · p:'*)
       task=${label#$'└ '}; task=${task%% *}
       mkdir -p "$POST_CREATE_ABORT_CONTROL/$task"
       printf '%s\n' "$(printf '%s' "$out" | jq -r '.result.workspace.workspace_id')" > "$POST_CREATE_ABORT_CONTROL/$task/workspace"
@@ -168,7 +168,7 @@ if [ "$status" -eq 0 ] && [ "$mutation" = tab-create ]; then
       printf '%s\n' "$(printf '%s' "$out" | jq -r '.result.root_pane.pane_id')" > "$ACTIVE_SEEDED_CONTROL/task-pane"
       printf '%s\n' task-created > "$ACTIVE_SEEDED_CONTROL/stage"
       ;;
-    fm-abort-a|fm-abort-b)
+    fm-abort-a|fm-abort-b|fm-custody-conflict)
       task=${label#fm-}
       mkdir -p "$POST_CREATE_ABORT_CONTROL/$task"
       printf '%s\n' "$(printf '%s' "$out" | jq -r '.result.root_pane.pane_id')" > "$POST_CREATE_ABORT_CONTROL/$task/task-pane"
@@ -176,10 +176,14 @@ if [ "$status" -eq 0 ] && [ "$mutation" = tab-create ]; then
   esac
 fi
 if [ "$status" -eq 0 ] && [ "${1:-} ${2:-}" = "pane get" ] && [ -d "$POST_CREATE_ABORT_CONTROL" ]; then
-  for task_dir in "$POST_CREATE_ABORT_CONTROL"/abort-*; do
+  for task_dir in "$POST_CREATE_ABORT_CONTROL"/abort-* "$POST_CREATE_ABORT_CONTROL"/custody-conflict; do
     [ -d "$task_dir" ] || continue
     [ "${3:-}" = "$(cat "$task_dir/task-pane" 2>/dev/null || true)" ] || continue
-    out=$(printf '%s' "$out" | jq --arg cwd "$POST_CREATE_ABORT_CONTROL/not-a-worktree" '.result.pane.foreground_cwd = $cwd')
+    task_cwd="$POST_CREATE_ABORT_CONTROL/not-a-worktree"
+    if [ "$(basename "$task_dir")" = custody-conflict ]; then
+      task_cwd=$(cat "$POST_CREATE_ABORT_CONTROL/lease-path")
+    fi
+    out=$(printf '%s' "$out" | jq --arg cwd "$task_cwd" '.result.pane.foreground_cwd = $cwd')
     break
   done
 fi
@@ -207,6 +211,10 @@ set -u
   done
   printf '\n'
 } >> "$TREEHOUSE_CALL_LOG"
+if [ -f "$POST_CREATE_ABORT_CONTROL/lease-path" ] && [ "${1:-}" = get ]; then
+  cat "$POST_CREATE_ABORT_CONTROL/lease-path"
+  exit 0
+fi
 if [ -d "$POST_CREATE_ABORT_CONTROL" ] && [ "${1:-}" = get ]; then
   exit 0
 fi
@@ -478,6 +486,38 @@ assert_no_projection_mutation_since() {  # <line-count> <case-name>
   fi
 }
 
+test_projected_custody_conflict() {
+  local conflict_wt conflict_head conflict_start conflict_pane
+  conflict_wt="$TMP_ROOT/custody-conflict-wt"
+  git -C "$PROJECT_DIR" worktree add --quiet --detach "$conflict_wt" HEAD
+  conflict_head=$(git -C "$conflict_wt" rev-parse HEAD)
+  printf 'window=firstmate:fm-other-owner\nworktree=%s\nproject=%s\nkind=ship\nmode=no-mistakes\n' \
+    "$conflict_wt" "$PROJECT_DIR" > "$HOME_DIR/state/other-owner.meta"
+  mkdir -p "$POST_CREATE_ABORT_CONTROL"
+  printf '%s\n' "$conflict_wt" > "$POST_CREATE_ABORT_CONTROL/lease-path"
+  conflict_start=$(log_line_count)
+  if spawn_task custody-conflict "$HOME_DIR" "$PROJECT_DIR" > "$TMP_ROOT/custody-conflict.out" 2> "$TMP_ROOT/custody-conflict.err"; then
+    fail "projected custody conflict unexpectedly spawned a second owner"
+  fi
+  grep -F "other-owner already claims" "$TMP_ROOT/custody-conflict.err" >/dev/null 2>&1 \
+    || fail "projected custody conflict did not name the existing owner"
+  conflict_pane=$(cat "$POST_CREATE_ABORT_CONTROL/custody-conflict/task-pane")
+  lab pane get "$conflict_pane" >/dev/null 2>&1 \
+    || fail "projected custody conflict closed the parked endpoint"
+  if sed -n "$((conflict_start + 1)),\$p" "$HERDR_CALL_LOG" \
+      | grep -F $'pane\tclose\t'"$conflict_pane" >/dev/null 2>&1; then
+    fail "projected custody conflict attempted to close the parked endpoint"
+  fi
+  [ ! -e "$HOME_DIR/state/custody-conflict.meta" ] \
+    || fail "projected custody conflict published a second owner record"
+  [ "$(git -C "$conflict_wt" rev-parse HEAD)" = "$conflict_head" ] \
+    || fail "projected custody conflict changed the existing owner's worktree"
+  rm -rf "$POST_CREATE_ABORT_CONTROL"
+  rm -f "$HOME_DIR/state/custody-conflict.herdr-presentation" "$HOME_DIR/state/other-owner.meta"
+  git -C "$PROJECT_DIR" worktree remove --force "$conflict_wt"
+  pass "real Herdr lab: custody conflict preserves the projected endpoint and claimed copy"
+}
+
 HOME_DIR="$TMP_ROOT/home"
 PROJECT_DIR="$TMP_ROOT/project"
 mkdir -p "$HOME_DIR/state" "$HOME_DIR/config" \
@@ -486,7 +526,7 @@ mkdir -p "$HOME_DIR/state" "$HOME_DIR/config" \
   "$HOME_DIR/data/order-fail" "$HOME_DIR/data/fm-hibit-resume-r1" \
   "$HOME_DIR/data/wheelhouse-healing-r1"
 mkdir -p "$HOME_DIR/data/active-seeded" "$HOME_DIR/data/abort-a" "$HOME_DIR/data/abort-b" \
-  "$HOME_DIR/data/lock-contended" "$HOME_DIR/data/default-on"
+  "$HOME_DIR/data/custody-conflict" "$HOME_DIR/data/lock-contended" "$HOME_DIR/data/default-on"
 touch "$HOME_DIR/state/.last-watcher-beat"
 # Presentation spaces are on by default, so the flat baseline below opts out
 # explicitly; the projected cases each restate the setting they exercise.
@@ -501,6 +541,7 @@ printf 'Wheelhouse-style projection restart fixture.\n' > "$HOME_DIR/data/wheelh
 printf 'Projection active seeded fixture.\n' > "$HOME_DIR/data/active-seeded/brief.md"
 printf 'Projection abort fixture A.\n' > "$HOME_DIR/data/abort-a/brief.md"
 printf 'Projection abort fixture B.\n' > "$HOME_DIR/data/abort-b/brief.md"
+printf 'Projection custody-conflict fixture.\n' > "$HOME_DIR/data/custody-conflict/brief.md"
 printf 'Projection lock contention fixture.\n' > "$HOME_DIR/data/lock-contended/brief.md"
 printf 'Projection default-on fixture.\n' > "$HOME_DIR/data/default-on/brief.md"
 make_project "$PROJECT_DIR"
@@ -643,6 +684,12 @@ SECOND_TWO_INFO=$(lab workspace get "$SECOND_TWO_WSID") || fail "focused secondm
 [ "$(printf '%s' "$SECOND_TWO_INFO" | jq -r '.result.workspace.focused')" = true ] \
   || fail "projected create or workspace.move stole focus from the captain's current space"
 pass "real Herdr lab: every projected create, task-tab create, seeded prune, and move preserves active workspace and tab"
+if [ "${FM_HERDR_PRESENTATION_CUSTODY_ONLY:-0}" = 1 ]; then
+  test_projected_custody_conflict
+  cleanup_all
+  trap - EXIT
+  exit 0
+fi
 
 mkdir -p "$ACTIVE_SEEDED_CONTROL"
 printf '%s\n' requested > "$ACTIVE_SEEDED_CONTROL/stage"
@@ -1411,6 +1458,8 @@ assert_no_projection_mutation_since "$START" "live duplicate-token recovery"
 lab workspace get "$DUP1_WSID" >/dev/null 2>&1 || fail "live duplicate refusal removed the first workspace"
 lab workspace get "$DUP2_WSID" >/dev/null 2>&1 || fail "live duplicate refusal removed the second workspace"
 pass "real Herdr lab: missing, renamed, and duplicate tokens trigger zero destructive or adoptive calls, and live duplicate risk refuses launch"
+
+test_projected_custody_conflict
 
 STATUS_JSON=$(lab status --json)
 HERDR_VERSION=$(printf '%s' "$STATUS_JSON" | jq -r '.client.version // "unknown"')

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -493,8 +493,12 @@ assert_no_projection_mutation_since() {  # <line-count> <case-name>
 }
 
 test_projected_custody_conflict() {
-  local conflict_wt conflict_head conflict_start conflict_pane
-  conflict_wt="$TMP_ROOT/custody-conflict-wt"
+  local conflict_pool conflict_wt conflict_head conflict_start conflict_pane
+  conflict_pool=$(FM_HOME="$HOME_DIR" FM_ROOT_OVERRIDE="$ROOT" \
+    "$ROOT/bin/fm-pool-root.sh" "$PROJECT_DIR") \
+    || fail "projected custody conflict could not resolve its home pool"
+  conflict_wt="$conflict_pool/.treehouse/custody-conflict-wt"
+  mkdir -p "$(dirname "$conflict_wt")"
   git -C "$PROJECT_DIR" worktree add --quiet --detach "$conflict_wt" HEAD
   conflict_head=$(git -C "$conflict_wt" rev-parse HEAD)
   printf 'window=firstmate:fm-other-owner\nworktree=%s\nproject=%s\nkind=ship\nmode=no-mistakes\n' \

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -396,6 +396,12 @@ spawn_task() {  # <id> <home> <project>
     "$ROOT/bin/fm-spawn.sh" "$id" "$project" "sh -c 'sleep 120'" --mode no-mistakes --yolo off --backend herdr
 }
 
+relaunch_task() {  # <id> <home>
+  local id=$1 home=$2
+  FM_GATE_REFUSE_BYPASS=1 FM_SPAWN_NO_GUARD=1 FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+    "$ROOT/bin/fm-spawn.sh" "$id" --relaunch --harness "sh -c 'sleep 120'"
+}
+
 finish_concurrent_spawn() {  # <id> <status> <stdout> <stderr>
   local id=$1 status=$2 out=$3 err=$4
   [ "$status" -ne 0 ] || return 0
@@ -1206,172 +1212,59 @@ teardown_task aflat "$SECOND_HOME_A" > "$TMP_ROOT/aflat-teardown.out" 2> "$TMP_R
   || fail "flat cross-home contention fixture teardown failed"
 pass "real Herdr lab: session lock contention from a secondmate home falls back flat with no journal"
 
-# Same-identity recovery replaces only one exact agent-free husk in its
-# original projected workspace.
-# Exercise both the leading fm- identity style seen in Hi Bit work and the
-# project-name identity style used by Wheelhouse work.
-for RESTART_ID in fm-hibit-resume-r1 wheelhouse-healing-r1; do
-  spawn_task "$RESTART_ID" "$HOME_DIR" "$PROJECT_DIR" > "$TMP_ROOT/$RESTART_ID-first.out" 2> "$TMP_ROOT/$RESTART_ID-first.err" \
-    || fail "$RESTART_ID fixture's projected spawn failed: $(cat "$TMP_ROOT/$RESTART_ID-first.err")"
-  RESTART_META="$HOME_DIR/state/$RESTART_ID.meta"
-  OLD_RESTART_WT=$(remember_meta_worktree "$RESTART_META")
-  OLD_RESTART_WSID=$(grep '^herdr_workspace_id=' "$RESTART_META" | cut -d= -f2-)
-  OLD_RESTART_PANE=$(grep '^herdr_pane_id=' "$RESTART_META" | cut -d= -f2-)
-  OLD_RESTART_LABEL=$(lab workspace get "$OLD_RESTART_WSID" | jq -r '.result.workspace.label')
-  [ "$(grep '^version=' "$HOME_DIR/state/$RESTART_ID.herdr-presentation")" = version=2 ] \
-    || fail "$RESTART_ID fresh projection did not publish an exact restart binding"
-  EXPECTED_CONCISE=${RESTART_ID#fm-}
-  case "$OLD_RESTART_LABEL" in
-    "└ $EXPECTED_CONCISE · p:"*) ;;
-    *) fail "$RESTART_ID fresh projection label did not apply concise prefix handling: $OLD_RESTART_LABEL" ;;
-  esac
-  PATH="$HERDR_ORIGINAL_PATH" \
-    "$HERDR_LAB_HELPER" stop "$HERDR_LAB_SESSION" >/dev/null \
-    || fail "could not stop the isolated session for $RESTART_ID validation"
-  PATH="$HERDR_ORIGINAL_PATH" \
-    "$HERDR_LAB_HELPER" provision "$HERDR_LAB_SESSION" \
-    || fail "could not reprovision the isolated session for $RESTART_ID validation"
-  lab pane get "$OLD_RESTART_PANE" >/dev/null 2>&1 \
-    || fail "$RESTART_ID restart did not preserve the projected pane structurally"
-  if lab agent get "$OLD_RESTART_PANE" >/dev/null 2>&1; then
-    fail "$RESTART_ID restart fixture unexpectedly retained a registered agent"
-  fi
-  RECLAIM_FOCUS=$(focus_snapshot)
-  spawn_task "$RESTART_ID" "$HOME_DIR" "$PROJECT_DIR" > "$TMP_ROOT/$RESTART_ID-reclaim.out" 2> "$TMP_ROOT/$RESTART_ID-reclaim.err" \
-    || fail "$RESTART_ID same-identity reclaim failed: $(cat "$TMP_ROOT/$RESTART_ID-reclaim.err")"
-  NEW_RESTART_WT=$(remember_meta_worktree "$RESTART_META")
-  NEW_RESTART_WSID=$(grep '^herdr_workspace_id=' "$RESTART_META" | cut -d= -f2-)
-  NEW_RESTART_PANE=$(grep '^herdr_pane_id=' "$RESTART_META" | cut -d= -f2-)
-  [ "$NEW_RESTART_WSID" = "$OLD_RESTART_WSID" ] \
-    || fail "$RESTART_ID reclaim flattened into a different workspace"
-  [ "$NEW_RESTART_PANE" != "$OLD_RESTART_PANE" ] \
-    || fail "$RESTART_ID reclaim reused the old husk pane"
-  [ "$(lab workspace get "$NEW_RESTART_WSID" | jq -r '.result.workspace.label')" = "$OLD_RESTART_LABEL" ] \
-    || fail "$RESTART_ID reclaim renamed or replaced the projected workspace"
-  if lab pane get "$OLD_RESTART_PANE" >/dev/null 2>&1; then
-    fail "$RESTART_ID reclaim did not close the exact old husk pane"
-  fi
-  [ "$(grep '^pane_id=' "$HOME_DIR/state/$RESTART_ID.herdr-presentation" | cut -d= -f2-)" = "$NEW_RESTART_PANE" ] \
-    || fail "$RESTART_ID reclaim did not advance the exact journal binding"
-  assert_focus_is "$RECLAIM_FOCUS" "$RESTART_ID same-identity reclaim"
+# A server restart can leave the durable task record and pooled copy alive while
+# its structural endpoint falls back to the project directory. Neither a fresh
+# spawn nor a relaunch may move that live task onto another copy or endpoint.
+test_restart_preserves_existing_task() {
+  local restart_id=fm-hibit-resume-r1 restart_meta old_wt old_wsid old_pane old_label before_meta
+  local after_wt after_wsid after_pane
+  spawn_task "$restart_id" "$HOME_DIR" "$PROJECT_DIR" > "$TMP_ROOT/$restart_id-first.out" 2> "$TMP_ROOT/$restart_id-first.err" \
+    || fail "$restart_id fixture projected spawn failed: $(cat "$TMP_ROOT/$restart_id-first.err")"
+  restart_meta="$HOME_DIR/state/$restart_id.meta"
+  old_wt=$(remember_meta_worktree "$restart_meta")
+  old_wsid=$(grep "^herdr_workspace_id=" "$restart_meta" | cut -d= -f2-)
+  old_pane=$(grep "^herdr_pane_id=" "$restart_meta" | cut -d= -f2-)
+  old_label=$(lab workspace get "$old_wsid" | jq -r ".result.workspace.label")
+  before_meta=$(cksum < "$restart_meta")
 
-  if [ "$RESTART_ID" = fm-hibit-resume-r1 ]; then
-    PATH="$HERDR_ORIGINAL_PATH" "$HERDR_LAB_HELPER" stop "$HERDR_LAB_SESSION" >/dev/null \
-      || fail "could not stop the isolated session for idempotent reclaim"
-    PATH="$HERDR_ORIGINAL_PATH" "$HERDR_LAB_HELPER" provision "$HERDR_LAB_SESSION" \
-      || fail "could not reprovision the isolated session for idempotent reclaim"
-    PRIOR_RESTART_WT=$NEW_RESTART_WT
-    PRIOR_RESTART_PANE=$NEW_RESTART_PANE
-    spawn_task "$RESTART_ID" "$HOME_DIR" "$PROJECT_DIR" > "$TMP_ROOT/$RESTART_ID-idempotent.out" 2> "$TMP_ROOT/$RESTART_ID-idempotent.err" \
-      || fail "$RESTART_ID repeated reclaim failed: $(cat "$TMP_ROOT/$RESTART_ID-idempotent.err")"
-    NEW_RESTART_WT=$(remember_meta_worktree "$RESTART_META")
-    NEW_RESTART_WSID=$(grep '^herdr_workspace_id=' "$RESTART_META" | cut -d= -f2-)
-    NEW_RESTART_PANE=$(grep '^herdr_pane_id=' "$RESTART_META" | cut -d= -f2-)
-    [ "$NEW_RESTART_WSID" = "$OLD_RESTART_WSID" ] \
-      || fail "$RESTART_ID repeated reclaim changed workspace identity"
-    [ "$NEW_RESTART_PANE" != "$PRIOR_RESTART_PANE" ] \
-      || fail "$RESTART_ID repeated reclaim reused the prior husk pane"
-    "$REAL_TREEHOUSE" return --force "$PRIOR_RESTART_WT" >/dev/null 2>&1 || true
+  PATH="$HERDR_ORIGINAL_PATH" "$HERDR_LAB_HELPER" stop "$HERDR_LAB_SESSION" >/dev/null \
+    || fail "could not stop the isolated session for restart custody validation"
+  PATH="$HERDR_ORIGINAL_PATH" "$HERDR_LAB_HELPER" provision "$HERDR_LAB_SESSION" \
+    || fail "could not reprovision the isolated session for restart custody validation"
+  lab pane get "$old_pane" >/dev/null 2>&1 \
+    || fail "$restart_id restart did not preserve the endpoint structurally"
+  if lab agent get "$old_pane" >/dev/null 2>&1; then
+    fail "$restart_id restart fixture unexpectedly retained a registered agent"
   fi
 
-  teardown_task "$RESTART_ID" "$HOME_DIR" > "$TMP_ROOT/$RESTART_ID-teardown.out" 2> "$TMP_ROOT/$RESTART_ID-teardown.err" \
-    || fail "$RESTART_ID teardown after reclaim failed: $(cat "$TMP_ROOT/$RESTART_ID-teardown.err")"
-  [ ! -e "$HOME_DIR/state/$RESTART_ID.herdr-presentation" ] \
-    || fail "$RESTART_ID exact reclaimed teardown did not retire its journal"
-  "$REAL_TREEHOUSE" return --force "$OLD_RESTART_WT" >/dev/null 2>&1 || true
-  "$REAL_TREEHOUSE" return --force "$NEW_RESTART_WT" >/dev/null 2>&1 || true
-done
-pass "real Herdr lab: Hi Bit and Wheelhouse-style same-identity restarts reclaim one nested space with exact focus and idempotence"
+  if spawn_task "$restart_id" "$HOME_DIR" "$PROJECT_DIR" > "$TMP_ROOT/$restart_id-fresh.out" 2> "$TMP_ROOT/$restart_id-fresh.err"; then
+    fail "$restart_id fresh spawn replaced an existing task record"
+  fi
+  grep -F "already has a durable record" "$TMP_ROOT/$restart_id-fresh.err" >/dev/null 2>&1 \
+    || fail "$restart_id fresh-spawn refusal did not name the existing task record"
+  if relaunch_task "$restart_id" "$HOME_DIR" > "$TMP_ROOT/$restart_id-relaunch.out" 2> "$TMP_ROOT/$restart_id-relaunch.err"; then
+    fail "$restart_id relaunch moved an endpoint outside its recorded worktree"
+  fi
+  grep -F "not its recorded worktree" "$TMP_ROOT/$restart_id-relaunch.err" >/dev/null 2>&1 \
+    || fail "$restart_id relaunch refusal did not name the endpoint/worktree mismatch"
 
-# A secondmate child binds and reclaims only inside its own home and parent.
-CROSS_RESTART_ID=wheel-child-resume
-mkdir -p "$SECOND_HOME_A/data/$CROSS_RESTART_ID"
-printf 'Cross-home restart fixture.\n' > "$SECOND_HOME_A/data/$CROSS_RESTART_ID/brief.md"
-spawn_task "$CROSS_RESTART_ID" "$SECOND_HOME_A" "$PROJECT_DIR" > "$TMP_ROOT/cross-restart-first.out" 2> "$TMP_ROOT/cross-restart-first.err" \
-  || fail "cross-home restart fixture failed: $(cat "$TMP_ROOT/cross-restart-first.err")"
-CROSS_RESTART_META="$SECOND_HOME_A/state/$CROSS_RESTART_ID.meta"
-CROSS_OLD_WT=$(remember_meta_worktree "$CROSS_RESTART_META")
-CROSS_OLD_WSID=$(grep '^herdr_workspace_id=' "$CROSS_RESTART_META" | cut -d= -f2-)
-CROSS_OLD_PANE=$(grep '^herdr_pane_id=' "$CROSS_RESTART_META" | cut -d= -f2-)
-CROSS_OLD_LABEL=$(lab workspace get "$CROSS_OLD_WSID" | jq -r '.result.workspace.label')
-CROSS_BOUND_HOME=$(grep '^home=' "$SECOND_HOME_A/state/$CROSS_RESTART_ID.herdr-presentation" | cut -d= -f2-)
-[ "$CROSS_BOUND_HOME" = "$(cd "$SECOND_HOME_A" && pwd -P)" ] \
-  || fail "cross-home restart journal did not bind the secondmate's exact home"
-[ ! -e "$HOME_DIR/state/$CROSS_RESTART_ID.herdr-presentation" ] \
-  || fail "cross-home restart published a journal in the primary home"
-PATH="$HERDR_ORIGINAL_PATH" "$HERDR_LAB_HELPER" stop "$HERDR_LAB_SESSION" >/dev/null \
-  || fail "could not stop the isolated session for cross-home restart"
-PATH="$HERDR_ORIGINAL_PATH" "$HERDR_LAB_HELPER" provision "$HERDR_LAB_SESSION" \
-  || fail "could not reprovision the isolated session for cross-home restart"
-spawn_task "$CROSS_RESTART_ID" "$SECOND_HOME_A" "$PROJECT_DIR" > "$TMP_ROOT/cross-restart-resume.out" 2> "$TMP_ROOT/cross-restart-resume.err" \
-  || fail "cross-home same-identity reclaim failed: $(cat "$TMP_ROOT/cross-restart-resume.err")"
-CROSS_NEW_WT=$(remember_meta_worktree "$CROSS_RESTART_META")
-CROSS_NEW_WSID=$(grep '^herdr_workspace_id=' "$CROSS_RESTART_META" | cut -d= -f2-)
-CROSS_NEW_PANE=$(grep '^herdr_pane_id=' "$CROSS_RESTART_META" | cut -d= -f2-)
-[ "$CROSS_NEW_WSID" = "$CROSS_OLD_WSID" ] && [ "$CROSS_NEW_PANE" != "$CROSS_OLD_PANE" ] \
-  || fail "cross-home reclaim did not replace one pane inside the same secondmate child workspace"
-[ "$(lab workspace get "$CROSS_NEW_WSID" | jq -r '.result.workspace.label')" = "$CROSS_OLD_LABEL" ] \
-  || fail "cross-home reclaim changed the secondmate child's presentation label"
-teardown_task "$CROSS_RESTART_ID" "$SECOND_HOME_A" > "$TMP_ROOT/cross-restart-teardown.out" 2> "$TMP_ROOT/cross-restart-teardown.err" \
-  || fail "cross-home reclaimed teardown failed: $(cat "$TMP_ROOT/cross-restart-teardown.err")"
-"$REAL_TREEHOUSE" return --force "$CROSS_OLD_WT" >/dev/null 2>&1 || true
-"$REAL_TREEHOUSE" return --force "$CROSS_NEW_WT" >/dev/null 2>&1 || true
-pass "real Herdr lab: secondmate restart binding and reclaim stay isolated to the exact child home and parent"
+  after_wt=$(remember_meta_worktree "$restart_meta")
+  after_wsid=$(grep "^herdr_workspace_id=" "$restart_meta" | cut -d= -f2-)
+  after_pane=$(grep "^herdr_pane_id=" "$restart_meta" | cut -d= -f2-)
+  [ "$after_wt" = "$old_wt" ] && [ "$after_wsid" = "$old_wsid" ] && [ "$after_pane" = "$old_pane" ] \
+    || fail "$restart_id refused restart moved its worktree, workspace, or endpoint"
+  [ "$(cksum < "$restart_meta")" = "$before_meta" ] \
+    || fail "$restart_id refused restart rewrote its durable task record"
+  [ "$(lab workspace get "$old_wsid" | jq -r ".result.workspace.label")" = "$old_label" ] \
+    || fail "$restart_id refused restart renamed its workspace"
+  lab pane get "$old_pane" >/dev/null 2>&1 \
+    || fail "$restart_id refused restart removed its endpoint"
 
-# Two homes recovering concurrently serialize on the named session lock and
-# each replace only their own exact husk.
-PRIMARY_WAVE_ID=resume-wave-primary
-BRAVO_WAVE_ID=resume-wave-bravo
-mkdir -p "$HOME_DIR/data/$PRIMARY_WAVE_ID" "$SECOND_HOME_B/data/$BRAVO_WAVE_ID"
-printf 'Concurrent primary recovery fixture.\n' > "$HOME_DIR/data/$PRIMARY_WAVE_ID/brief.md"
-printf 'Concurrent secondmate recovery fixture.\n' > "$SECOND_HOME_B/data/$BRAVO_WAVE_ID/brief.md"
-spawn_task "$PRIMARY_WAVE_ID" "$HOME_DIR" "$PROJECT_DIR" > "$TMP_ROOT/primary-wave-first.out" 2> "$TMP_ROOT/primary-wave-first.err" \
-  || fail "primary recovery-wave fixture failed: $(cat "$TMP_ROOT/primary-wave-first.err")"
-spawn_task "$BRAVO_WAVE_ID" "$SECOND_HOME_B" "$PROJECT_DIR" > "$TMP_ROOT/bravo-wave-first.out" 2> "$TMP_ROOT/bravo-wave-first.err" \
-  || fail "secondmate recovery-wave fixture failed: $(cat "$TMP_ROOT/bravo-wave-first.err")"
-PRIMARY_WAVE_META="$HOME_DIR/state/$PRIMARY_WAVE_ID.meta"
-BRAVO_WAVE_META="$SECOND_HOME_B/state/$BRAVO_WAVE_ID.meta"
-PRIMARY_WAVE_OLD_WT=$(remember_meta_worktree "$PRIMARY_WAVE_META")
-BRAVO_WAVE_OLD_WT=$(remember_meta_worktree "$BRAVO_WAVE_META")
-PRIMARY_WAVE_WSID=$(grep '^herdr_workspace_id=' "$PRIMARY_WAVE_META" | cut -d= -f2-)
-BRAVO_WAVE_WSID=$(grep '^herdr_workspace_id=' "$BRAVO_WAVE_META" | cut -d= -f2-)
-PRIMARY_WAVE_OLD_PANE=$(grep '^herdr_pane_id=' "$PRIMARY_WAVE_META" | cut -d= -f2-)
-BRAVO_WAVE_OLD_PANE=$(grep '^herdr_pane_id=' "$BRAVO_WAVE_META" | cut -d= -f2-)
-PATH="$HERDR_ORIGINAL_PATH" "$HERDR_LAB_HELPER" stop "$HERDR_LAB_SESSION" >/dev/null \
-  || fail "could not stop the isolated session for concurrent recovery"
-PATH="$HERDR_ORIGINAL_PATH" "$HERDR_LAB_HELPER" provision "$HERDR_LAB_SESSION" \
-  || fail "could not reprovision the isolated session for concurrent recovery"
-CONCURRENT_RECOVERY_FOCUS=$(focus_snapshot)
-spawn_task "$PRIMARY_WAVE_ID" "$HOME_DIR" "$PROJECT_DIR" > "$TMP_ROOT/primary-wave-resume.out" 2> "$TMP_ROOT/primary-wave-resume.err" &
-PRIMARY_WAVE_PID=$!
-spawn_task "$BRAVO_WAVE_ID" "$SECOND_HOME_B" "$PROJECT_DIR" > "$TMP_ROOT/bravo-wave-resume.out" 2> "$TMP_ROOT/bravo-wave-resume.err" &
-BRAVO_WAVE_PID=$!
-wait "$PRIMARY_WAVE_PID" || fail "concurrent primary recovery failed: $(cat "$TMP_ROOT/primary-wave-resume.err")"
-wait "$BRAVO_WAVE_PID" || fail "concurrent secondmate recovery failed: $(cat "$TMP_ROOT/bravo-wave-resume.err")"
-PRIMARY_WAVE_NEW_WT=$(remember_meta_worktree "$PRIMARY_WAVE_META")
-BRAVO_WAVE_NEW_WT=$(remember_meta_worktree "$BRAVO_WAVE_META")
-PRIMARY_WAVE_NEW_PANE=$(grep '^herdr_pane_id=' "$PRIMARY_WAVE_META" | cut -d= -f2-)
-BRAVO_WAVE_NEW_PANE=$(grep '^herdr_pane_id=' "$BRAVO_WAVE_META" | cut -d= -f2-)
-[ "$(grep '^herdr_workspace_id=' "$PRIMARY_WAVE_META" | cut -d= -f2-)" = "$PRIMARY_WAVE_WSID" ] \
-  && [ "$(grep '^herdr_workspace_id=' "$BRAVO_WAVE_META" | cut -d= -f2-)" = "$BRAVO_WAVE_WSID" ] \
-  || fail "concurrent recovery flattened one task into a different workspace"
-[ "$PRIMARY_WAVE_NEW_PANE" != "$PRIMARY_WAVE_OLD_PANE" ] \
-  && [ "$BRAVO_WAVE_NEW_PANE" != "$BRAVO_WAVE_OLD_PANE" ] \
-  || fail "concurrent recovery reused an old husk pane"
-if lab pane get "$PRIMARY_WAVE_OLD_PANE" >/dev/null 2>&1 \
-   || lab pane get "$BRAVO_WAVE_OLD_PANE" >/dev/null 2>&1; then
-  fail "concurrent recovery left an old husk pane behind"
-fi
-assert_focus_is "$CONCURRENT_RECOVERY_FOCUS" "concurrent cross-home recovery"
-teardown_task "$PRIMARY_WAVE_ID" "$HOME_DIR" > "$TMP_ROOT/primary-wave-teardown.out" 2> "$TMP_ROOT/primary-wave-teardown.err" \
-  || fail "concurrent primary recovery teardown failed"
-teardown_task "$BRAVO_WAVE_ID" "$SECOND_HOME_B" > "$TMP_ROOT/bravo-wave-teardown.out" 2> "$TMP_ROOT/bravo-wave-teardown.err" \
-  || fail "concurrent secondmate recovery teardown failed"
-"$REAL_TREEHOUSE" return --force "$PRIMARY_WAVE_OLD_WT" >/dev/null 2>&1 || true
-"$REAL_TREEHOUSE" return --force "$BRAVO_WAVE_OLD_WT" >/dev/null 2>&1 || true
-"$REAL_TREEHOUSE" return --force "$PRIMARY_WAVE_NEW_WT" >/dev/null 2>&1 || true
-"$REAL_TREEHOUSE" return --force "$BRAVO_WAVE_NEW_WT" >/dev/null 2>&1 || true
-pass "real Herdr lab: concurrent cross-home recoveries replace exact husks under one session lock with no focus drift"
+  teardown_task "$restart_id" "$HOME_DIR" > "$TMP_ROOT/$restart_id-teardown.out" 2> "$TMP_ROOT/$restart_id-teardown.err" \
+    || fail "$restart_id teardown after restart refusal failed: $(cat "$TMP_ROOT/$restart_id-teardown.err")"
+  pass "real Herdr lab: server restart refuses fresh launch and relaunch without moving the live endpoint or worktree"
+}
+
 
 # Seed a legacy old-format primary projection and a flat secondmate tab; correction must not migrate them.
 LEGACY_OUT=$(lab workspace create --cwd "$PROJECT_DIR" --label "firstmate/legacy-seed · p:AbCdEfGhIjKlMnOpQrStUv" --no-focus) \
@@ -1460,6 +1353,7 @@ lab workspace get "$DUP2_WSID" >/dev/null 2>&1 || fail "live duplicate refusal r
 pass "real Herdr lab: missing, renamed, and duplicate tokens trigger zero destructive or adoptive calls, and live duplicate risk refuses launch"
 
 test_projected_custody_conflict
+test_restart_preserves_existing_task
 
 STATUS_JSON=$(lab status --json)
 HERDR_VERSION=$(printf '%s' "$STATUS_JSON" | jq -r '.client.version // "unknown"')

--- a/tests/fm-backend.test.sh
+++ b/tests/fm-backend.test.sh
@@ -785,7 +785,12 @@ esac
 exit 0
 SH
   chmod +x "$fb/tmux"
-  fm_fake_exit0 "$fb" treehouse
+  cat > "$fb/treehouse" <<SH
+#!/usr/bin/env bash
+[ "\${1:-}" != get ] || printf '%s\n' "$wt"
+exit 0
+SH
+  chmod +x "$fb/treehouse"
   printf '%s\n' "$fb"
 }
 
@@ -855,17 +860,27 @@ esac
 exit 0
 SH
   chmod +x "$fb/tmux"
-  fm_fake_exit0 "$fb" treehouse
+  cat > "$fb/treehouse" <<SH
+#!/usr/bin/env bash
+[ "\${1:-}" != get ] || printf '%s\n' "$wt"
+exit 0
+SH
+  chmod +x "$fb/treehouse"
   printf '%s\n' "$fb"
 }
 
 run_spawn_symlink_case() {  # <label> <physical|logical>
-  local label=$1 first_reply=$2 real_root link_root proj wt id fb data state config log out rc proj_phys initial_path
+  local label=$1 first_reply=$2 real_root link_root proj wt id fb data state config log out rc proj_phys initial_path home pool_root
   real_root="$TMP_ROOT/symlink-real-$label"; link_root="$TMP_ROOT/symlink-link-$label"
   mkdir -p "$real_root"
   ln -s "$real_root" "$link_root"
   proj="$link_root/proj"
-  wt="$TMP_ROOT/symlink-wt-$label"
+  home="$TMP_ROOT/symlink-home-$label"
+  mkdir -p "$home"
+  pool_root=$(FM_HOME="$home" FM_POOL_ROOT_BASE="$home/pools" \
+    "$ROOT/bin/fm-pool-root.sh" --print)
+  wt="$pool_root/.treehouse/fixture/1/project"
+  mkdir -p "$(dirname "$wt")"
   id="spawnsymlink$label"
   fm_git_worktree "$real_root/proj" "$wt" "fm/$id"
   # TMP_ROOT itself can already sit behind an OS-level symlink (e.g. macOS's
@@ -887,7 +902,8 @@ run_spawn_symlink_case() {  # <label> <physical|logical>
   mkdir -p "$state" "$config"
   log="$TMP_ROOT/symlink-spawn-$label.log"
 
-  out=$(run_spawn_case "$ROOT" "$fb" "$log" "$state" "$data" "$config" "$proj" -- "$id" "$proj" claude --mode no-mistakes --yolo off 2>&1)
+  out=$(FM_HOME="$home" FM_POOL_ROOT_BASE="$home/pools" \
+    run_spawn_case "$ROOT" "$fb" "$log" "$state" "$data" "$config" "$proj" -- "$id" "$proj" claude --mode no-mistakes --yolo off 2>&1)
   rc=$?
   expect_code 0 "$rc" "fm-spawn.sh should succeed for a project reached through a symlinked prefix when the backend reports $first_reply cwd"$'\n'"$out"
   assert_contains "$out" "worktree=$wt" \
@@ -1037,9 +1053,15 @@ test_spawn_refuses_unknown_fm_backend_env() {
 }
 
 test_spawn_default_backend_writes_no_meta_field() {
-  local proj wt data id state config out
-  proj="$TMP_ROOT/nobackend-project"; wt="$TMP_ROOT/nobackend-wt"; data="$TMP_ROOT/nobackend-data"
+  local proj wt data id state config out home pool_root
+  proj="$TMP_ROOT/nobackend-project"; data="$TMP_ROOT/nobackend-data"
   id="nobackendz3"
+  home="$TMP_ROOT/nobackend-home"
+  mkdir -p "$home"
+  pool_root=$(FM_HOME="$home" FM_POOL_ROOT_BASE="$home/pools" \
+    "$ROOT/bin/fm-pool-root.sh" --print)
+  wt="$pool_root/.treehouse/fixture/1/project"
+  mkdir -p "$(dirname "$wt")"
   fm_git_worktree "$proj" "$wt" "fm/$id"
   local fb
   fb=$(make_spawn_fakebin "$TMP_ROOT/nobackend-fake" "$wt")
@@ -1047,7 +1069,7 @@ test_spawn_default_backend_writes_no_meta_field() {
   state="$TMP_ROOT/nobackend-state"; config="$TMP_ROOT/nobackend-config"
   mkdir -p "$state" "$config"
 
-  out=$(PATH="$fb:$PATH" FM_ROOT_OVERRIDE="$ROOT" \
+  out=$(PATH="$fb:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_POOL_ROOT_BASE="$home/pools" \
     FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
     FM_PROJECTS_OVERRIDE="$TMP_ROOT/unused-projects" FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
     FM_TMUX_LOG="$TMP_ROOT/nobackend.log" \
@@ -1060,9 +1082,15 @@ test_spawn_default_backend_writes_no_meta_field() {
 }
 
 test_spawn_explicit_backend_flag_beats_autodetect_herdr_env() {
-  local proj wt data id state config out fb
-  proj="$TMP_ROOT/explicit-backend-project"; wt="$TMP_ROOT/explicit-backend-wt"; data="$TMP_ROOT/explicit-backend-data"
+  local proj wt data id state config out fb home pool_root
+  proj="$TMP_ROOT/explicit-backend-project"; data="$TMP_ROOT/explicit-backend-data"
   id="explicitbackendz4"
+  home="$TMP_ROOT/explicit-backend-home"
+  mkdir -p "$home"
+  pool_root=$(FM_HOME="$home" FM_POOL_ROOT_BASE="$home/pools" \
+    "$ROOT/bin/fm-pool-root.sh" --print)
+  wt="$pool_root/.treehouse/fixture/1/project"
+  mkdir -p "$(dirname "$wt")"
   fm_git_worktree "$proj" "$wt" "fm/$id"
   fb=$(make_spawn_fakebin "$TMP_ROOT/explicit-backend-fake" "$wt")
   mkdir -p "$data/$id"; printf 'brief\n' > "$data/$id/brief.md"
@@ -1071,7 +1099,7 @@ test_spawn_explicit_backend_flag_beats_autodetect_herdr_env() {
 
   # HERDR_ENV=1 is present (as if firstmate itself were running under herdr),
   # but an explicit --backend tmux flag must still win outright.
-  out=$(PATH="$fb:$PATH" FM_ROOT_OVERRIDE="$ROOT" \
+  out=$(PATH="$fb:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_POOL_ROOT_BASE="$home/pools" \
     FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
     FM_PROJECTS_OVERRIDE="$TMP_ROOT/unused-projects" FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" HERDR_ENV=1 \
     FM_TMUX_LOG="$TMP_ROOT/explicit-backend.log" \
@@ -1084,9 +1112,15 @@ test_spawn_explicit_backend_flag_beats_autodetect_herdr_env() {
 }
 
 test_spawn_autodetect_nesting_resolves_tmux_silently() {
-  local proj wt data id state config out fb
-  proj="$TMP_ROOT/nest-project"; wt="$TMP_ROOT/nest-wt"; data="$TMP_ROOT/nest-data"
+  local proj wt data id state config out fb home pool_root
+  proj="$TMP_ROOT/nest-project"; data="$TMP_ROOT/nest-data"
   id="nestbackendz5"
+  home="$TMP_ROOT/nest-home"
+  mkdir -p "$home"
+  pool_root=$(FM_HOME="$home" FM_POOL_ROOT_BASE="$home/pools" \
+    "$ROOT/bin/fm-pool-root.sh" --print)
+  wt="$pool_root/.treehouse/fixture/1/project"
+  mkdir -p "$(dirname "$wt")"
   fm_git_worktree "$proj" "$wt" "fm/$id"
   fb=$(make_spawn_fakebin "$TMP_ROOT/nest-fake" "$wt")
   mkdir -p "$data/$id"; printf 'brief\n' > "$data/$id/brief.md"
@@ -1098,7 +1132,7 @@ test_spawn_autodetect_nesting_resolves_tmux_silently() {
   # (tmux nested inside a herdr pane) - the full fm-spawn.sh pipeline, not just
   # fm_backend_name, must resolve this to tmux and stay completely silent about
   # it (today's default path, byte-identical).
-  out=$(PATH="$fb:$PATH" FM_ROOT_OVERRIDE="$ROOT" \
+  out=$(PATH="$fb:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_POOL_ROOT_BASE="$home/pools" \
     FM_STATE_OVERRIDE="$state" FM_DATA_OVERRIDE="$data" FM_CONFIG_OVERRIDE="$config" \
     FM_PROJECTS_OVERRIDE="$TMP_ROOT/unused-projects" FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" HERDR_ENV=1 \
     FM_TMUX_LOG="$TMP_ROOT/nest.log" \

--- a/tests/fm-gotmp.test.sh
+++ b/tests/fm-gotmp.test.sh
@@ -62,6 +62,7 @@ make_fake_root() {
   # fm-project-script-lib.sh: teardown sources it for a project's own opt-in
   # worktree-custody verdict.
   ln -s "$ROOT/bin/fm-project-script-lib.sh" "$fake/bin/fm-project-script-lib.sh"
+  ln -s "$ROOT/bin/fm-timeout-lib.sh" "$fake/bin/fm-timeout-lib.sh"
   # fm-lock-lib.sh: teardown sources it for the shared lock-staleness proof.
   ln -s "$ROOT/bin/fm-lock-lib.sh" "$fake/bin/fm-lock-lib.sh"
   # Lifecycle serialization, status presentation retirement, and shared adapter
@@ -149,6 +150,7 @@ test_teardown_skips_gracefully_without_tasktmp() {
   # fm-project-script-lib.sh: teardown sources it for a project's own opt-in
   # worktree-custody verdict.
   ln -s "$ROOT/bin/fm-project-script-lib.sh" "$fake/bin/fm-project-script-lib.sh"
+  ln -s "$ROOT/bin/fm-timeout-lib.sh" "$fake/bin/fm-timeout-lib.sh"
   ln -s "$ROOT/bin/fm-lock-lib.sh" "$fake/bin/fm-lock-lib.sh"
   ln -s "$ROOT/bin/fm-control-lib.sh" "$fake/bin/fm-control-lib.sh"
   ln -s "$ROOT/bin/fm-classify-lib.sh" "$fake/bin/fm-classify-lib.sh"

--- a/tests/fm-gotmp.test.sh
+++ b/tests/fm-gotmp.test.sh
@@ -59,6 +59,9 @@ make_fake_root() {
   ln -s "$ROOT/bin/fm-tmux-lib.sh" "$fake/bin/fm-tmux-lib.sh"
   ln -s "$ROOT/bin/fm-composer-lib.sh" "$fake/bin/fm-composer-lib.sh"
   ln -s "$ROOT/bin/fm-nm-run-lib.sh" "$fake/bin/fm-nm-run-lib.sh"
+  # fm-project-script-lib.sh: teardown sources it for a project's own opt-in
+  # worktree-custody verdict.
+  ln -s "$ROOT/bin/fm-project-script-lib.sh" "$fake/bin/fm-project-script-lib.sh"
   # fm-lock-lib.sh: teardown sources it for the shared lock-staleness proof.
   ln -s "$ROOT/bin/fm-lock-lib.sh" "$fake/bin/fm-lock-lib.sh"
   # Lifecycle serialization, status presentation retirement, and shared adapter
@@ -143,6 +146,9 @@ test_teardown_skips_gracefully_without_tasktmp() {
   ln -s "$ROOT/bin/fm-tmux-lib.sh" "$fake/bin/fm-tmux-lib.sh"
   ln -s "$ROOT/bin/fm-composer-lib.sh" "$fake/bin/fm-composer-lib.sh"
   ln -s "$ROOT/bin/fm-nm-run-lib.sh" "$fake/bin/fm-nm-run-lib.sh"
+  # fm-project-script-lib.sh: teardown sources it for a project's own opt-in
+  # worktree-custody verdict.
+  ln -s "$ROOT/bin/fm-project-script-lib.sh" "$fake/bin/fm-project-script-lib.sh"
   ln -s "$ROOT/bin/fm-lock-lib.sh" "$fake/bin/fm-lock-lib.sh"
   ln -s "$ROOT/bin/fm-control-lib.sh" "$fake/bin/fm-control-lib.sh"
   ln -s "$ROOT/bin/fm-classify-lib.sh" "$fake/bin/fm-classify-lib.sh"

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -36,13 +36,37 @@ make_spawn_fakebin() {
   cat > "$fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
 set -u
+# FM_FAKE_PANE_PATH_DIR models a real pool: every window created here reports
+# its OWN copy under that directory, named for the task. Without it the stub
+# keeps its single-copy behavior.
+fake_tmux_arg_after() {  # <flag> <args...>
+  local flag=$1 prev= a
+  shift
+  for a in "$@"; do
+    [ "$prev" != "$flag" ] || { printf '%s' "$a"; return 0; }
+    prev=$a
+  done
+  return 1
+}
 case "$*" in
-  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
+  *"#{pane_current_path}"*)
+    if [ -n "${FM_FAKE_PANE_PATH_DIR:-}" ]; then
+      target=$(fake_tmux_arg_after -t "$@") || target=
+      printf '%s\n' "$FM_FAKE_PANE_PATH_DIR/${target#@}"
+      exit 0
+    fi
+    printf '%s\n' "${FM_FAKE_PANE_PATH:-}"; exit 0 ;;
 esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
   list-windows) exit 0 ;;
-  has-session|new-session|new-window|kill-window) exit 0 ;;
+  new-window)
+    if [ -n "${FM_FAKE_PANE_PATH_DIR:-}" ]; then
+      name=$(fake_tmux_arg_after -n "$@") || name=
+      printf '@%s\n' "$name"
+    fi
+    exit 0 ;;
+  has-session|new-session|kill-window) exit 0 ;;
   send-keys)
     if [ -n "${FM_FAKE_LAUNCH_LOG:-}" ]; then
       prev=
@@ -244,6 +268,10 @@ test_home_defaults_preserve_absolute_or_resolve_relative_paths() {
 
   linked_home="$CASE_DIR/home-link"
   ln -s "$HOME_DIR" "$linked_home"
+  # The second spawn reuses this one fake pooled copy, so the first task's claim
+  # on it is released first: spawn refuses a copy another task still names
+  # (tests/fm-worktree-custody.test.sh).
+  rm -f "$HOME_DIR/state/$relative_id.meta"
   : > "$LAUNCH_LOG"
   out=$(
     FM_ROOT_OVERRIDE='' FM_HOME="$linked_home" \
@@ -741,14 +769,22 @@ test_pi_signed_persistent_secondmate_uses_pi_extensions_and_identity() {
 }
 
 test_batch_forwards_shared_profile_flags() {
-  local rec id1 id2 out status
+  local rec id1 id2 out status pool
   id1=profile-batch-a-z9
   id2=profile-batch-b-z10
   rec=$(make_spawn_case profile-batch claude "$id1" "$id2")
   read_case_record "$rec"
   enable_dispatch_profile "$HOME_DIR"
+  # A batch dispatches two tasks in one invocation, and a pool gives each its
+  # OWN copy - spawn refuses a copy another task claims
+  # (tests/fm-worktree-custody.test.sh), so the fixture models one copy per task.
+  pool="$CASE_DIR/pool"
+  mkdir -p "$pool"
+  git -C "$PROJ_DIR" worktree add --quiet --detach "$pool/fm-$id1" HEAD
+  git -C "$PROJ_DIR" worktree add --quiet --detach "$pool/fm-$id2" HEAD
 
-  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+  out=$(FM_FAKE_PANE_PATH_DIR="$pool" \
+    run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
     "$id1=$PROJ_DIR" "$id2=$PROJ_DIR" --harness codex --model gpt-5 --effort high)
   status=$?
   expect_code 0 "$status" "batch spawn with shared profile flags should succeed"

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -143,9 +143,10 @@ make_seeded_secondmate_home() {
 }
 
 run_spawn() {
-  local home=$1 wt=$2 fakebin=$3 launchlog=$4
+  local home=$1 wt=$2 fakebin=$3 launchlog=$4 fake_pane_path=$2
   shift 4
   : > "$launchlog"
+  [ -z "${FM_FAKE_PANE_PATH_DIR:-}" ] || fake_pane_path=
   # CLAUDE_CONFIG_DIR is forwarded onto claude launches by fm-spawn, so pin it
   # explicitly (empty by default) instead of leaking the invoking shell's value,
   # which would make launch assertions depend on the developer's environment.
@@ -154,7 +155,7 @@ run_spawn() {
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
     FM_POOL_ROOT_BASE="$home/pools" \
-    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
+    FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$fake_pane_path" TMUX="fake,1,0" \
     CLAUDE_CONFIG_DIR="${FM_TEST_CLAUDE_CONFIG_DIR:-}" \
     FM_FAKE_LAUNCH_LOG="$launchlog" FM_FAKE_PI_VERSION="${FM_TEST_PI_VERSION:-0.84.0}" \
     FM_FAKE_CURSOR_MODELS="${FM_TEST_CURSOR_MODELS:-}" \
@@ -230,7 +231,7 @@ test_relative_home_overrides_launch_with_absolute_cross_process_paths() {
     CDPATH="$CASE_DIR/cdpath" FM_ROOT_OVERRIDE='' FM_HOME=home \
       FM_STATE_OVERRIDE=home/state FM_DATA_OVERRIDE=home/data \
       FM_PROJECTS_OVERRIDE=home/projects FM_CONFIG_OVERRIDE=home/config \
-      FM_POOL_ROOT_BASE=home/pools \
+      FM_POOL_ROOT_BASE="$home_real/pools" \
       FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$WT_DIR" TMUX="fake,1,0" \
       CLAUDE_CONFIG_DIR='' FM_FAKE_LAUNCH_LOG="$LAUNCH_LOG" \
       GROK_HOME=home/grok-home PATH="$FAKEBIN_DIR:$PATH" \
@@ -260,7 +261,7 @@ test_home_defaults_preserve_absolute_or_resolve_relative_paths() {
     FM_ROOT_OVERRIDE='' FM_HOME=home \
       FM_STATE_OVERRIDE='' FM_DATA_OVERRIDE='' \
       FM_PROJECTS_OVERRIDE=home/projects FM_CONFIG_OVERRIDE=home/config \
-      FM_POOL_ROOT_BASE=home/pools \
+      FM_POOL_ROOT_BASE="$home_real/pools" \
       FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$WT_DIR" TMUX="fake,1,0" \
       CLAUDE_CONFIG_DIR='' FM_FAKE_LAUNCH_LOG="$LAUNCH_LOG" \
       GROK_HOME=home/grok-home PATH="$FAKEBIN_DIR:$PATH" \

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -104,17 +104,22 @@ SH
 }
 
 make_spawn_case() {
-  local name=$1 harness=$2 case_dir home proj wt fakebin launchlog id
+  local name=$1 harness=$2 case_dir home proj wt fakebin launchlog id pool_root
   shift 2
   case_dir="$TMP_ROOT/$name"
   home="$case_dir/home"
   proj="$case_dir/project"
-  wt="$case_dir/wt"
   launchlog="$case_dir/launch.log"
   fakebin=$(make_spawn_fakebin "$case_dir/fake")
   mkdir -p "$home/data" "$home/projects" "$home/state" "$home/config"
   printf '%s\n' "$harness" > "$home/config/crew-harness"
-  fm_git_worktree "$proj" "$wt" "wt-$name"
+  fm_git_init_commit "$proj"
+  fm_git_add_origin "$proj" "$proj.origin.git"
+  pool_root=$(FM_HOME="$home" FM_POOL_ROOT_BASE="$home/pools" \
+    "$ROOT/bin/fm-pool-root.sh" --print)
+  wt="$pool_root/.treehouse/fixture/1/project"
+  mkdir -p "$(dirname "$wt")"
+  git -C "$proj" worktree add --quiet -b "wt-$name" "$wt"
   touch "$home/state/.last-watcher-beat"
   for id in "$@"; do
     mkdir -p "$home/data/$id"
@@ -148,6 +153,7 @@ run_spawn() {
   FM_ROOT_OVERRIDE='' FM_HOME="$home" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_POOL_ROOT_BASE="$home/pools" \
     FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
     CLAUDE_CONFIG_DIR="${FM_TEST_CLAUDE_CONFIG_DIR:-}" \
     FM_FAKE_LAUNCH_LOG="$launchlog" FM_FAKE_PI_VERSION="${FM_TEST_PI_VERSION:-0.84.0}" \
@@ -224,6 +230,7 @@ test_relative_home_overrides_launch_with_absolute_cross_process_paths() {
     CDPATH="$CASE_DIR/cdpath" FM_ROOT_OVERRIDE='' FM_HOME=home \
       FM_STATE_OVERRIDE=home/state FM_DATA_OVERRIDE=home/data \
       FM_PROJECTS_OVERRIDE=home/projects FM_CONFIG_OVERRIDE=home/config \
+      FM_POOL_ROOT_BASE=home/pools \
       FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$WT_DIR" TMUX="fake,1,0" \
       CLAUDE_CONFIG_DIR='' FM_FAKE_LAUNCH_LOG="$LAUNCH_LOG" \
       GROK_HOME=home/grok-home PATH="$FAKEBIN_DIR:$PATH" \
@@ -253,6 +260,7 @@ test_home_defaults_preserve_absolute_or_resolve_relative_paths() {
     FM_ROOT_OVERRIDE='' FM_HOME=home \
       FM_STATE_OVERRIDE='' FM_DATA_OVERRIDE='' \
       FM_PROJECTS_OVERRIDE=home/projects FM_CONFIG_OVERRIDE=home/config \
+      FM_POOL_ROOT_BASE=home/pools \
       FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$WT_DIR" TMUX="fake,1,0" \
       CLAUDE_CONFIG_DIR='' FM_FAKE_LAUNCH_LOG="$LAUNCH_LOG" \
       GROK_HOME=home/grok-home PATH="$FAKEBIN_DIR:$PATH" \
@@ -277,6 +285,7 @@ test_home_defaults_preserve_absolute_or_resolve_relative_paths() {
     FM_ROOT_OVERRIDE='' FM_HOME="$linked_home" \
       FM_STATE_OVERRIDE='' FM_DATA_OVERRIDE='' \
       FM_PROJECTS_OVERRIDE="$linked_home/projects" FM_CONFIG_OVERRIDE="$linked_home/config" \
+      FM_POOL_ROOT_BASE="$linked_home/pools" \
       FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$WT_DIR" TMUX="fake,1,0" \
       CLAUDE_CONFIG_DIR='' FM_FAKE_LAUNCH_LOG="$LAUNCH_LOG" \
       GROK_HOME="$linked_home/grok-home" PATH="$FAKEBIN_DIR:$PATH" \
@@ -305,6 +314,7 @@ test_absolute_override_spelling_is_preserved_in_launch_paths() {
     FM_ROOT_OVERRIDE='' FM_HOME="$linked_home" \
       FM_STATE_OVERRIDE="$linked_home/state" FM_DATA_OVERRIDE="$linked_home/data" \
       FM_PROJECTS_OVERRIDE="$linked_home/projects" FM_CONFIG_OVERRIDE="$linked_home/config" \
+      FM_POOL_ROOT_BASE="$linked_home/pools" \
       FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$WT_DIR" TMUX="fake,1,0" \
       CLAUDE_CONFIG_DIR='' FM_FAKE_LAUNCH_LOG="$LAUNCH_LOG" \
       GROK_HOME="$linked_home/grok-home" PATH="$FAKEBIN_DIR:$PATH" \
@@ -734,6 +744,7 @@ test_pi_signed_missing_binary_refuses_before_endpoint_or_metadata() {
   out=$(FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
     FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
     FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    FM_POOL_ROOT_BASE="$HOME_DIR/pools" \
     FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$WT_DIR" TMUX="fake,1,0" \
     FM_FAKE_LAUNCH_LOG="$LAUNCH_LOG" PATH="$FAKEBIN_DIR:/usr/bin:/bin:/usr/sbin:/sbin" \
     "$SPAWN" "$id" "$PROJ_DIR" --mode no-mistakes --yolo off 2>&1)
@@ -769,7 +780,7 @@ test_pi_signed_persistent_secondmate_uses_pi_extensions_and_identity() {
 }
 
 test_batch_forwards_shared_profile_flags() {
-  local rec id1 id2 out status pool
+  local rec id1 id2 out status pool pool_root
   id1=profile-batch-a-z9
   id2=profile-batch-b-z10
   rec=$(make_spawn_case profile-batch claude "$id1" "$id2")
@@ -778,7 +789,9 @@ test_batch_forwards_shared_profile_flags() {
   # A batch dispatches two tasks in one invocation, and a pool gives each its
   # OWN copy - spawn refuses a copy another task claims
   # (tests/fm-worktree-custody.test.sh), so the fixture models one copy per task.
-  pool="$CASE_DIR/pool"
+  pool_root=$(FM_HOME="$HOME_DIR" FM_POOL_ROOT_BASE="$HOME_DIR/pools" \
+    "$ROOT/bin/fm-pool-root.sh" --print)
+  pool="$pool_root/.treehouse/batch"
   mkdir -p "$pool"
   git -C "$PROJ_DIR" worktree add --quiet --detach "$pool/fm-$id1" HEAD
   git -C "$PROJ_DIR" worktree add --quiet --detach "$pool/fm-$id2" HEAD

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -35,12 +35,11 @@ SH
 }
 
 make_case() {
-  local name=$1 id=$2 default=${3:-main} case_dir home project origin pool publisher fakebin initial
+  local name=$1 id=$2 default=${3:-main} case_dir home project origin pool publisher fakebin initial pool_root
   case_dir="$TMP_ROOT/$name"
   home="$case_dir/home"
   project="$case_dir/project"
   origin="$case_dir/origin.git"
-  pool="$case_dir/pool"
   publisher="$case_dir/publisher"
   fakebin=$(make_spawn_fakebin "$case_dir/fake")
 
@@ -56,6 +55,10 @@ make_case() {
   git clone --quiet --bare "$project" "$origin"
   git -C "$project" remote add origin "file://$origin"
   initial=$(git -C "$project" rev-parse HEAD)
+  pool_root=$(FM_HOME="$home" FM_POOL_ROOT_BASE="$case_dir/base" \
+    "$ROOT/bin/fm-pool-root.sh" --print)
+  pool="$pool_root/.treehouse/fixture/1/$(basename "$project")"
+  mkdir -p "$(dirname "$pool")"
   git -C "$project" worktree add --quiet --detach "$pool" "$initial"
 
   git clone --quiet "file://$origin" "$publisher"
@@ -79,6 +82,7 @@ run_spawn() {
   FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
     FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
     FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    FM_POOL_ROOT_BASE="$CASE_DIR/base" \
     FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" FM_FAKE_PANE_PATH="$POOL_DIR" \
     PATH="$FAKEBIN_DIR:$PATH" \
     "$SPAWN" "$id" "$PROJECT_DIR" "$@" 2>&1

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -104,6 +104,11 @@ test_stale_pool_base_refreshes_before_branching() {
       "$branch_head" "$current" "$(cat "$POOL_DIR/advanced-main.txt")"
   fi
 
+  # The repeat models a LATER task receiving this same recycled slot, so the
+  # first task's claim on it is released first: a pooled copy has exactly one
+  # owner at a time, and spawn refuses a copy another task still names
+  # (tests/fm-worktree-custody.test.sh).
+  rm -f "$HOME_DIR/state/$id.meta"
   id='pool-current-base-repeat-r1'
   mkdir -p "$HOME_DIR/data/$id"
   printf 'brief for %s\n' "$id" > "$HOME_DIR/data/$id/brief.md"

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -33,6 +33,9 @@ SH
   cat > "$fakebin/treehouse" <<'SH'
 #!/usr/bin/env bash
 [ -z "${FM_TREEHOUSE_LOG:-}" ] || printf '%s\n' "$*" >> "$FM_TREEHOUSE_LOG"
+if [ "${1:-}" = get ]; then
+  printf '%s\n' "${FM_FAKE_PANE_PATH:?FM_FAKE_PANE_PATH unset}"
+fi
 exit 0
 SH
   chmod +x "$fakebin/treehouse"
@@ -204,7 +207,7 @@ test_direct_pr_and_scout_refresh_before_launch() {
   pass "direct-PR ships and scouts both refresh stale pooled worktrees before launch"
 }
 
-test_dirty_pool_refuses_without_discarding_work() {
+test_dirty_new_lease_aborts_and_returns() {
   local rec id out status before
   id='pool-dirty-refusal-r4'
   rec=$(make_case dirty-refusal "$id")
@@ -218,13 +221,15 @@ test_dirty_pool_refuses_without_discarding_work() {
   assert_contains "$out" "is not clean" "spawn did not clearly refuse a dirty pooled worktree"
   [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$before" ] \
     || fail "spawn moved HEAD while refusing a dirty pooled worktree"
-  assert_grep 'keep this local work' "$POOL_DIR/uncommitted.txt" \
-    "spawn discarded uncommitted work while refusing the pool"
+  assert_grep "return --force $POOL_DIR" "$CASE_DIR/treehouse.log" \
+    "spawn preserved an unpublished dirty lease outside the owner-conflict path"
+  assert_absent "$HOME_DIR/state/$id.meta" \
+    "spawn published custody metadata for a dirty lease"
   if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
-    printf '# observed dirty refusal: %s; preserved=%s\n' \
-      "$(printf '%s\n' "$out" | tail -n 1)" "$(cat "$POOL_DIR/uncommitted.txt")"
+    printf '# observed dirty refusal: %s; cleanup=%s\n' \
+      "$(printf '%s\n' "$out" | tail -n 1)" "$(tail -n 1 "$CASE_DIR/treehouse.log")"
   fi
-  pass "a dirty pooled worktree is refused without discarding its local work"
+  pass "a dirty newly acquired lease is aborted and returned"
 }
 
 test_unresolved_remote_default_refuses_pool() {
@@ -251,7 +256,7 @@ test_unresolved_remote_default_refuses_pool() {
 test_stale_pool_base_refreshes_before_branching
 test_non_main_default_branch_refreshes_before_branching
 test_direct_pr_and_scout_refresh_before_launch
-test_dirty_pool_refuses_without_discarding_work
+test_dirty_new_lease_aborts_and_returns
 test_unresolved_remote_default_refuses_pool
 test_unreachable_origin_refuses_stale_pool_base
 

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -30,7 +30,12 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+[ -z "${FM_TREEHOUSE_LOG:-}" ] || printf '%s\n' "$*" >> "$FM_TREEHOUSE_LOG"
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
   printf '%s\n' "$fakebin"
 }
 
@@ -84,6 +89,7 @@ run_spawn() {
     FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
     FM_POOL_ROOT_BASE="$CASE_DIR/base" \
     FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" FM_FAKE_PANE_PATH="$POOL_DIR" \
+    FM_TREEHOUSE_LOG="$CASE_DIR/treehouse.log" \
     PATH="$FAKEBIN_DIR:$PATH" \
     "$SPAWN" "$id" "$PROJECT_DIR" "$@" 2>&1
 }
@@ -119,6 +125,8 @@ test_stale_pool_base_refreshes_before_branching() {
   out=$(run_spawn "$id" --mode no-mistakes --yolo off)
   status=$?
   expect_code 0 "$status" "repeating the base refresh should be idempotent"
+  assert_no_grep 'return --force' "$CASE_DIR/treehouse.log" \
+    "spawn returned a lease after transferring custody to durable metadata"
   [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$current" ] \
     || fail "an idempotent repeat moved the pool away from current origin/main"
 
@@ -159,6 +167,10 @@ test_unreachable_origin_refuses_stale_pool_base() {
   [ "$status" -ne 0 ] || fail "spawn succeeded despite an unreachable origin"
   assert_contains "$out" "could not fetch origin" \
     "spawn did not clearly refuse an unreachable origin"
+  assert_grep "return --force $POOL_DIR" "$CASE_DIR/treehouse.log" \
+    "spawn leaked the durable lease after base refresh failed"
+  assert_absent "$HOME_DIR/state/$id.meta" \
+    "spawn published custody metadata after returning an aborted lease"
   after=$(git -C "$POOL_DIR" rev-parse HEAD)
   [ "$after" = "$before" ] || fail "spawn changed the pooled worktree after origin became unreachable"
   if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -64,17 +64,22 @@ SH
 # entirely, distinct from both the project and the worktree - mirroring the
 # live incident where the stale read was another real firstmate home).
 make_settle_case() {
-  local name=$1 id=$2 stale_reads=$3 case_dir home proj wt stale fakebin countfile
+  local name=$1 id=$2 stale_reads=$3 case_dir home proj wt stale fakebin countfile pool_root
   case_dir="$TMP_ROOT/$name"
   home="$case_dir/home"
   proj="$case_dir/project"
-  wt="$case_dir/wt"
   stale="$case_dir/stale-other-checkout"
   countfile="$case_dir/pane-call-count"
   fakebin=$(make_settle_fakebin "$case_dir/fake")
   mkdir -p "$home/data" "$home/projects" "$home/state" "$home/config"
   printf 'codex\n' > "$home/config/crew-harness"
-  fm_git_worktree "$proj" "$wt" "wt-$name"
+  fm_git_init_commit "$proj"
+  fm_git_add_origin "$proj" "$proj.origin.git"
+  pool_root=$(FM_HOME="$home" FM_POOL_ROOT_BASE="$home/pools" \
+    "$ROOT/bin/fm-pool-root.sh" --print)
+  wt="$pool_root/.treehouse/fixture/1/project"
+  mkdir -p "$(dirname "$wt")"
+  git -C "$proj" worktree add --quiet -b "wt-$name" "$wt"
   fm_git_init_commit "$stale"
   mkdir -p "$home/data/$id"
   printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
@@ -93,6 +98,7 @@ run_settle_spawn() {
   FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
     FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
     FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    FM_POOL_ROOT_BASE="$HOME_DIR/pools" \
     FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
     FM_FAKE_PANE_PATH="$WT_DIR" FM_FAKE_PANE_STALE="$STALE_DIR" \
     FM_FAKE_PANE_STALE_READS="$STALE_READS" FM_FAKE_PANE_COUNTFILE="$COUNTFILE" \

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -4,7 +4,7 @@
 #
 # On some tmux/WSL setups a brand-new window's pane_current_path transiently
 # reports a stale, unrelated-but-real path on the very first poll, before the
-# pane actually settles into the worktree treehouse get moved it to. That stale
+# pane actually settles into the acquired worktree. That stale
 # path still passes the loop's "differs from the project" check and
 # validate_spawn_worktree's "is a real, distinct worktree" check (it IS a real
 # git checkout, just the wrong one), so a naive single-read loop silently
@@ -54,7 +54,12 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+[ "${1:-}" != get ] || printf '%s\n' "${FM_FAKE_PANE_PATH:-}"
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
   printf '%s\n' "$fakebin"
 }
 

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -181,19 +181,24 @@ run_spawn() {
   FM_ROOT_OVERRIDE='' FM_HOME="$home" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_POOL_ROOT_BASE="$home/pools" \
     FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$pane" TMUX="fake,1,0" \
     PATH="$fakebin:$PATH" \
     "$ROOT/bin/fm-spawn.sh" "$id" "$proj" codex --mode no-mistakes --yolo off 2>&1
 }
 
 test_spawn_isolation_abort() {
-  local home proj fakebin out status
+  local home proj fakebin out status pool_root spawn_wt
   home="$TMP_ROOT/spawn-home"
   mkdir -p "$home/data"
   proj=$(make_repo "$TMP_ROOT/spawn-proj")
   fakebin=$(make_spawn_fakebin "$TMP_ROOT/spawn-fake")
-  # A genuine isolated linked worktree of the project, detached on the default.
-  git -C "$proj" worktree add -q --detach "$TMP_ROOT/spawn-wt" >/dev/null 2>&1
+  # A genuine isolated linked worktree in the home-private pool, detached on the default.
+  pool_root=$(FM_HOME="$home" FM_POOL_ROOT_BASE="$home/pools" \
+    "$ROOT/bin/fm-pool-root.sh" --print)
+  spawn_wt="$pool_root/.treehouse/fixture/1/spawn-proj"
+  mkdir -p "$(dirname "$spawn_wt")"
+  git -C "$proj" worktree add -q --detach "$spawn_wt" >/dev/null 2>&1
   mkdir -p "$TMP_ROOT/spawn-notgit" "$proj/sub"
 
   # Abort: the pane resolves to a plain non-git directory (not a worktree at all).
@@ -208,8 +213,8 @@ test_spawn_isolation_abort() {
   assert_contains "$out" "did not yield an isolated worktree" "primary-checkout spawn lacked the isolation error"
 
   # Proceed: the pane resolves to a genuine, isolated worktree.
-  out=$(run_spawn "$home" ok-isolated-ff6 "$proj" "$TMP_ROOT/spawn-wt" "$fakebin"); status=$?
-  expect_code 0 "$status" "spawn into a genuine isolated worktree should succeed"
+  out=$(run_spawn "$home" ok-isolated-ff6 "$proj" "$spawn_wt" "$fakebin"); status=$?
+  expect_code 0 "$status" "spawn into a genuine isolated worktree should succeed: $out"
   assert_contains "$out" "spawned ok-isolated-ff6" "isolated spawn did not report success"
   assert_not_contains "$out" "did not yield an isolated worktree" "isolated spawn wrongly tripped the guard"
   pass "fm-spawn: aborts unless the resolved worktree is a genuine, isolated worktree"
@@ -260,6 +265,7 @@ run_spawn_record() {
   FM_ROOT_OVERRIDE='' FM_HOME="$home" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_POOL_ROOT_BASE="$home/pools" \
     FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$pane" TMUX="fake,1,0" \
     FM_TMUX_REC="$rec" \
     PATH="$fakebin:$PATH" \
@@ -267,14 +273,17 @@ run_spawn_record() {
 }
 
 test_spawn_tmux_window_construction() {
-  local home proj fakebin rec wt out status
+  local home proj fakebin rec wt out status pool_root
   home="$TMP_ROOT/spawn-rec-home"
   mkdir -p "$home/data"
   proj=$(make_repo "$TMP_ROOT/spawn-rec-proj")
   fakebin=$(make_spawn_record_fakebin "$TMP_ROOT/spawn-rec-fake")
   rec="$TMP_ROOT/spawn-rec.log"
   : > "$rec"
-  wt="$TMP_ROOT/spawn-rec-wt"
+  pool_root=$(FM_HOME="$home" FM_POOL_ROOT_BASE="$home/pools" \
+    "$ROOT/bin/fm-pool-root.sh" --print)
+  wt="$pool_root/.treehouse/fixture/1/spawn-rec-proj"
+  mkdir -p "$(dirname "$wt")"
   git -C "$proj" worktree add -q --detach "$wt" >/dev/null 2>&1
 
   out=$(run_spawn_record "$home" rec-win-gg7 "$proj" "$wt" "$fakebin" "$rec"); status=$?
@@ -294,8 +303,12 @@ test_spawn_tmux_window_construction() {
     "must disable allow-rename on the spawned window"
 
   # Bug 2 fix (b): treehouse-get and the worktree wait loop target the stable id.
-  assert_grep "send-keys -t @spawnwid treehouse get Enter" "$rec" \
-    "treehouse get must be sent to the stable window id"
+  assert_grep "send-keys -t @spawnwid (cd '" "$rec" \
+    "treehouse get must start from the home-private config view on the stable window id"
+  assert_grep "/state/treehouse-config/" "$rec" \
+    "treehouse get did not use the home-namespaced config view"
+  assert_grep "exec treehouse get) Enter" "$rec" \
+    "the config view must invoke treehouse directly"
   assert_grep "display-message -p -t @spawnwid #{pane_current_path}" "$rec" \
     "the worktree wait loop must query the stable window id, not the name"
 

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -150,7 +150,7 @@ test_brief_assertion_precedes_branch() {
 
 # --- GUARD 1b: fm-spawn isolation abort -------------------------------------
 
-# A fake tmux that reports FM_FAKE_PANE_PATH as the post-`treehouse get` pane cwd
+# A fake tmux that reports FM_FAKE_PANE_PATH as the acquired pane cwd
 # (so the spawn's worktree-resolution loop resolves to a path we control), names
 # the session on '#S', and swallows window ops. Echoes the fakebin dir.
 make_spawn_fakebin() {
@@ -170,7 +170,12 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+[ "${1:-}" != get ] || printf '%s\n' "${FM_FAKE_PANE_PATH:-}"
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
   printf '%s\n' "$fakebin"
 }
 
@@ -204,13 +209,13 @@ test_spawn_isolation_abort() {
   # Abort: the pane resolves to a plain non-git directory (not a worktree at all).
   out=$(run_spawn "$home" abort-notgit-dd4 "$proj" "$TMP_ROOT/spawn-notgit" "$fakebin"); status=$?
   expect_code 1 "$status" "spawn into a non-worktree dir should abort"
-  assert_contains "$out" "did not yield an isolated worktree" "non-worktree spawn lacked the isolation error"
+  assert_contains "$out" "outside this home's pool root" "non-worktree spawn lacked the pool-boundary error"
   assert_absent "$home/state/abort-notgit-dd4.meta" "aborted spawn must not record meta"
 
   # Abort: the pane resolves INTO the primary checkout (a subdir of PROJ_ABS).
   out=$(run_spawn "$home" abort-primary-ee5 "$proj" "$proj/sub" "$fakebin"); status=$?
   expect_code 1 "$status" "spawn landing inside the primary checkout should abort"
-  assert_contains "$out" "did not yield an isolated worktree" "primary-checkout spawn lacked the isolation error"
+  assert_contains "$out" "outside this home's pool root" "primary-checkout spawn lacked the pool-boundary error"
 
   # Proceed: the pane resolves to a genuine, isolated worktree.
   out=$(run_spawn "$home" ok-isolated-ff6 "$proj" "$spawn_wt" "$fakebin"); status=$?
@@ -254,7 +259,14 @@ esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+[ -n "${FM_TMUX_REC:-}" ] && printf 'treehouse %s\n' "$*" >> "$FM_TMUX_REC"
+[ -n "${FM_TMUX_REC:-}" ] && printf 'treehouse-cwd %s\n' "$PWD" >> "$FM_TMUX_REC"
+[ "${1:-}" != get ] || printf '%s\n' "${FM_FAKE_PANE_PATH:-}"
+exit 0
+SH
+  chmod +x "$fakebin/treehouse"
   printf '%s\n' "$fakebin"
 }
 
@@ -302,13 +314,13 @@ test_spawn_tmux_window_construction() {
   assert_grep "set-window-option -t @spawnwid allow-rename off" "$rec" \
     "must disable allow-rename on the spawned window"
 
-  # Bug 2 fix (b): treehouse-get and the worktree wait loop target the stable id.
-  assert_grep "send-keys -t @spawnwid FM_TREEHOUSE_LEASED_WORKTREE=" "$rec" \
-    "treehouse get must start from the home-private config view on the stable window id"
+  # Bug 2 fix (b): the acquired path and the worktree wait loop target the stable id.
+  assert_grep "treehouse get --lease --lease-holder rec-win-gg7" "$rec" \
+    "the parent must acquire a durable task-labelled lease"
   assert_grep "/state/treehouse-config/" "$rec" \
-    "treehouse get did not use the home-namespaced config view"
-  assert_grep "treehouse get --lease --lease-holder 'rec-win-gg7'" "$rec" \
-    "the config view must acquire a durable task-labelled lease"
+    "the parent must acquire from the home-private config view"
+  assert_grep "send-keys -t @spawnwid cd '$wt'" "$rec" \
+    "the acquired worktree must be delivered to the stable window id"
   assert_grep "display-message -p -t @spawnwid #{pane_current_path}" "$rec" \
     "the worktree wait loop must query the stable window id, not the name"
 

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -303,12 +303,12 @@ test_spawn_tmux_window_construction() {
     "must disable allow-rename on the spawned window"
 
   # Bug 2 fix (b): treehouse-get and the worktree wait loop target the stable id.
-  assert_grep "send-keys -t @spawnwid (cd '" "$rec" \
+  assert_grep "send-keys -t @spawnwid FM_TREEHOUSE_LEASED_WORKTREE=" "$rec" \
     "treehouse get must start from the home-private config view on the stable window id"
   assert_grep "/state/treehouse-config/" "$rec" \
     "treehouse get did not use the home-namespaced config view"
-  assert_grep "exec treehouse get) Enter" "$rec" \
-    "the config view must invoke treehouse directly"
+  assert_grep "treehouse get --lease --lease-holder 'rec-win-gg7'" "$rec" \
+    "the config view must acquire a durable task-labelled lease"
   assert_grep "display-message -p -t @spawnwid #{pane_current_path}" "$rec" \
     "the worktree wait loop must query the stable window id, not the name"
 

--- a/tests/fm-worktree-custody.test.sh
+++ b/tests/fm-worktree-custody.test.sh
@@ -331,6 +331,44 @@ test_spawn_refuses_ambiguous_worktree_metadata() {
   pass "spawn fails closed on ambiguous worktree metadata without touching the copy"
 }
 
+test_fresh_spawn_refuses_an_existing_task_record_before_side_effects() {
+  local case_dir id out status before after
+  id='custody-existing-id-r1'
+  case_dir=$(make_spawn_case spawn-existing-id "$id")
+  fm_write_meta "$case_dir/home/state/$id.meta" \
+    "window=firstmate:fm-$id" \
+    "endpoint_task_id=$id" \
+    "worktree=$case_dir/pool" \
+    "project=$case_dir/project" \
+    "kind=ship" \
+    "mode=no-mistakes"
+  before=$(cksum < "$case_dir/home/state/$id.meta")
+  cat > "$case_dir/fakebin/tmux" <<SH
+#!/usr/bin/env bash
+case "\${1:-}" in
+  new-window) touch "$case_dir/endpoint-created" ;;
+  display-message) printf 'firstmate\n' ;;
+esac
+exit 0
+SH
+  cat > "$case_dir/fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+[ "\${1:-}" != get ] || touch "$case_dir/lease-requested"
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/tmux" "$case_dir/fakebin/treehouse"
+
+  out=$(run_spawn_case "$case_dir" "$id" --mode no-mistakes --yolo off)
+  status=$?
+  after=$(cksum < "$case_dir/home/state/$id.meta")
+  expect_code 1 "$status" "a fresh spawn must refuse an existing task record"
+  assert_contains "$out" "Use --relaunch" "the refusal did not name the supported reuse path"
+  assert_absent "$case_dir/endpoint-created" "the refused fresh spawn created an endpoint"
+  assert_absent "$case_dir/lease-requested" "the refused fresh spawn requested a worktree lease"
+  [ "$before" = "$after" ] || fail "the refused fresh spawn overwrote existing task metadata"
+  pass "a fresh spawn cannot replace an existing task record, endpoint, or lease"
+}
+
 test_spawn_claims_this_homes_pool_root_before_leasing() {
   local case_dir id out status base_real
   id='custody-own-pool-r1'
@@ -354,6 +392,7 @@ add_release_step() {  # <case-dir> <exit>
   local case_dir=$1 exit_code=$2
   printf '{\n  "name": "fixture",\n  "scripts": {\n    "pool:release-delivered": "node release.js"\n  }\n}\n' \
     > "$case_dir/project/package.json"
+  git -C "$case_dir/project" add package.json
   cat > "$case_dir/fakebin/npm" <<SH
 #!/usr/bin/env bash
 if [ "\${1:-}" = run ] && [ "\${2:-}" = pool:release-delivered ]; then
@@ -370,6 +409,7 @@ add_hanging_release_step() {  # <case-dir>
   local case_dir=$1
   printf '{\n  "name": "fixture",\n  "scripts": {\n    "pool:release-delivered": "node release.js"\n  }\n}\n' \
     > "$case_dir/project/package.json"
+  git -C "$case_dir/project" add package.json
   cat > "$case_dir/fakebin/npm" <<SH
 #!/usr/bin/env bash
 if [ "\${1:-}" = run ] && [ "\${2:-}" = pool:release-delivered ]; then
@@ -412,6 +452,27 @@ SH
   expect_code 0 "$status" "a project without the release step should spawn unchanged: $out"
   assert_not_contains "$out" "must not be invoked" "spawn ran a release step the project never published"
   pass "a project that publishes no release step spawns exactly as before"
+}
+
+test_spawn_ignores_an_untracked_release_manifest() {
+  local case_dir id out status
+  id='custody-untracked-release-r1'
+  case_dir=$(make_spawn_case spawn-untracked-release "$id")
+  printf '{\n  "name": "fixture",\n  "scripts": {\n    "pool:release-delivered": "node release.js"\n  }\n}\n' \
+    > "$case_dir/project/package.json"
+  cat > "$case_dir/fakebin/npm" <<SH
+#!/usr/bin/env bash
+touch "$case_dir/release-ran"
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/npm"
+
+  out=$(run_spawn_case "$case_dir" "$id" --mode no-mistakes --yolo off)
+  status=$?
+  expect_code 0 "$status" "an untracked release manifest should not block spawn: $out"
+  assert_absent "$case_dir/release-ran" "an untracked manifest activated housekeeping"
+  assert_contains "$out" "spawned $id" "spawn did not continue after ignoring untracked housekeeping"
+  pass "an untracked manifest cannot activate pool housekeeping"
 }
 
 test_spawn_continues_when_the_release_step_fails() {
@@ -721,6 +782,9 @@ test_teardown_uses_the_canonical_projects_custody_opt_in() {
   case_dir=$(make_teardown_case teardown-custody-canonical)
   printf '{\n  "name": "fixture",\n  "scripts": {\n    "check:worktree-custody": "node custody.js"\n  }\n}\n' \
     > "$case_dir/project/package.json"
+  git -C "$case_dir/project" add package.json
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t \
+    commit -qm "publish the custody check"
   cat > "$case_dir/fakebin/npm" <<SH
 #!/usr/bin/env bash
 if [ "\${1:-}" = run ] && [ "\${2:-}" = check:worktree-custody ]; then
@@ -744,6 +808,7 @@ test_teardown_refuses_an_unparseable_canonical_manifest() {
   local case_dir out status
   case_dir=$(make_teardown_case teardown-custody-invalid-manifest)
   printf '{"scripts":{"check:worktree-custody":' > "$case_dir/project/package.json"
+  git -C "$case_dir/project" add package.json
 
   out=$(run_teardown_case "$case_dir")
   status=$?
@@ -752,6 +817,37 @@ test_teardown_refuses_an_unparseable_canonical_manifest() {
   assert_present "$case_dir/state/task-c1.meta" "a refused cleanup removed the task record"
   [ -d "$case_dir/wt" ] || fail "a refused cleanup removed the working copy"
   pass "an unparseable canonical manifest refuses cleanup instead of disabling custody"
+}
+
+test_teardown_detects_custody_hidden_by_a_working_edit() {
+  local case_dir out status
+  case_dir=$(make_teardown_case teardown-custody-working-edit)
+  printf '{\n  "name": "fixture",\n  "scripts": {\n    "check:worktree-custody": "node custody.js"\n  }\n}\n' \
+    > "$case_dir/project/package.json"
+  git -C "$case_dir/project" add package.json
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t \
+    commit -qm "publish the custody check"
+  printf '{\n  "name": "fixture",\n  "scripts": {}\n}\n' > "$case_dir/project/package.json"
+  cat > "$case_dir/fakebin/npm" <<SH
+#!/usr/bin/env bash
+printf 'published custody survives working manifest edit\n'
+exit 4
+SH
+  cat > "$case_dir/fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$case_dir/treehouse.log"
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/npm" "$case_dir/fakebin/treehouse"
+
+  out=$(run_teardown_case "$case_dir")
+  status=$?
+  expect_code 1 "$status" "a working manifest edit must not hide published custody"
+  assert_contains "$out" "published custody survives" "the published check was hidden by the working manifest"
+  assert_present "$case_dir/state/task-c1.meta" "a refused cleanup removed the task record"
+  assert_absent "$case_dir/treehouse.log" "a working manifest edit allowed the copy to be returned"
+  [ -d "$case_dir/wt" ] || fail "a refused cleanup removed the working copy"
+  pass "a working manifest edit cannot hide custody published in Git"
 }
 
 test_teardown_refuses_a_missing_tracked_canonical_manifest() {
@@ -855,9 +951,11 @@ test_pool_root_refuses_when_git_exclude_cannot_be_written
 test_real_treehouse_stops_sharing_a_pool_between_homes
 test_spawn_refuses_a_copy_another_task_claims
 test_spawn_refuses_ambiguous_worktree_metadata
+test_fresh_spawn_refuses_an_existing_task_record_before_side_effects
 test_spawn_claims_this_homes_pool_root_before_leasing
 test_spawn_releases_delivered_copies_before_leasing
 test_spawn_skips_projects_that_publish_no_release_step
+test_spawn_ignores_an_untracked_release_manifest
 test_spawn_continues_when_the_release_step_fails
 test_spawn_bounds_a_hanging_release_step_without_external_timeout
 test_spawn_rejects_a_nonpositive_release_timeout
@@ -870,6 +968,7 @@ test_teardown_skips_projects_that_publish_no_check
 test_teardown_refuses_when_a_published_check_cannot_be_run
 test_teardown_uses_the_canonical_projects_custody_opt_in
 test_teardown_refuses_an_unparseable_canonical_manifest
+test_teardown_detects_custody_hidden_by_a_working_edit
 test_teardown_refuses_a_missing_tracked_canonical_manifest
 test_teardown_detects_a_staged_deleted_canonical_manifest
 test_teardown_refuses_an_unavailable_canonical_project

--- a/tests/fm-worktree-custody.test.sh
+++ b/tests/fm-worktree-custody.test.sh
@@ -74,6 +74,25 @@ test_two_homes_configure_distinct_pool_roots() {
   pass "two homes cloning one project configure distinct treehouse pool roots"
 }
 
+test_literal_pool_root_override_is_refused() {
+  local case_dir shared out_a out_b status_a status_b
+  case_dir=$(make_two_homes_one_project literal-root-refused)
+  shared="$case_dir/shared-root"
+
+  out_a=$(FM_HOME="$case_dir/homeA" FM_POOL_ROOT="$shared" \
+    "$POOL_ROOT_BIN" --print 2>&1)
+  status_a=$?
+  out_b=$(FM_HOME="$case_dir/homeB" FM_POOL_ROOT="$shared" \
+    "$POOL_ROOT_BIN" --print 2>&1)
+  status_b=$?
+  expect_code 1 "$status_a" "a literal root override must not bypass the first home's namespace"
+  expect_code 1 "$status_b" "a shared literal root override must not bypass the second home's namespace"
+  assert_contains "$out_a" "use FM_POOL_ROOT_BASE" "the first refusal did not provide the safe relocation setting"
+  assert_contains "$out_b" "use FM_POOL_ROOT_BASE" "the second refusal did not provide the safe relocation setting"
+  assert_absent "$shared" "the refused literal root override created a shared pool path"
+  pass "a literal pool root override cannot disable per-home isolation"
+}
+
 test_pool_root_is_idempotent_and_preserves_other_keys() {
   local case_dir clone before after root
   case_dir=$(make_two_homes_one_project idempotent)
@@ -522,6 +541,7 @@ test_teardown_refuses_an_unparseable_canonical_manifest() {
 }
 
 test_two_homes_configure_distinct_pool_roots
+test_literal_pool_root_override_is_refused
 test_pool_root_is_idempotent_and_preserves_other_keys
 test_pool_root_refuses_a_tracked_config
 test_real_treehouse_stops_sharing_a_pool_between_homes

--- a/tests/fm-worktree-custody.test.sh
+++ b/tests/fm-worktree-custody.test.sh
@@ -112,6 +112,26 @@ test_literal_pool_root_override_is_refused() {
   pass "a literal pool root override cannot disable per-home isolation"
 }
 
+test_pool_root_refuses_to_write_inside_the_primary_clone() {
+  local case_dir clone out status generated
+  case_dir=$(make_two_homes_one_project root-inside-primary-refused)
+  clone="$case_dir/homeA/project"
+
+  out=$(FM_HOME="$case_dir/homeA" FM_POOL_ROOT_BASE="$clone" \
+    "$POOL_ROOT_BIN" "$clone" 2>&1)
+  status=$?
+  expect_code 1 "$status" "a pool root inside the primary clone must be refused"
+  assert_contains "$out" "would mutate the primary project" \
+    "the unsafe pool-root refusal did not identify the primary-clone boundary"
+  generated=$(find "$clone" -mindepth 1 -maxdepth 1 -type d -name 'homeA-*' -print -quit)
+  [ -z "$generated" ] || fail "the refusal created a pool directory inside the primary clone"
+  assert_absent "$case_dir/homeA/state/treehouse-config" \
+    "the refusal created a generated config view before rejecting the root"
+  [ -z "$(git -C "$clone" status --porcelain)" ] \
+    || fail "the unsafe pool-root refusal dirtied the primary clone"
+  pass "a pool root inside the primary clone is rejected before any mutation"
+}
+
 test_pool_root_is_idempotent_without_mutating_the_clone() {
   local case_dir clone config before after
   case_dir=$(make_two_homes_one_project idempotent)
@@ -364,10 +384,43 @@ run_spawn_case() {  # <case-dir> <id> <args...>
     FM_STATE_OVERRIDE="$case_dir/home/state" FM_DATA_OVERRIDE="$case_dir/home/data" \
     FM_PROJECTS_OVERRIDE="$case_dir/home/projects" FM_CONFIG_OVERRIDE="$case_dir/home/config" \
     FM_POOL_ROOT_BASE="$case_dir/base" \
-    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" FM_FAKE_PANE_PATH="$case_dir/pool" \
+    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" FM_FAKE_PANE_PATH="${FM_CASE_PANE_PATH:-$case_dir/pool}" \
     FM_TREEHOUSE_LOG="$case_dir/treehouse.log" \
     PATH="$case_dir/fakebin:$PATH" \
     "$SPAWN" "$id" "$case_dir/project" "$@" 2>&1
+}
+
+test_spawn_returns_a_lease_when_endpoint_confirmation_fails() {
+  local case_dir id out status handoff
+  id='custody-unconfirmed-endpoint-r2'
+  case_dir=$(make_spawn_case spawn-unconfirmed-endpoint "$id")
+  cat > "$case_dir/fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$case_dir/treehouse.log"
+if [ "\${1:-}" = get ]; then
+  printf '%s\n' "$case_dir/pool"
+fi
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+  cat > "$case_dir/fakebin/sleep" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/sleep"
+
+  out=$(FM_CASE_PANE_PATH="$case_dir/project" \
+    run_spawn_case "$case_dir" "$id" --mode no-mistakes --yolo off)
+  status=$?
+  expect_code 1 "$status" "an unconfirmed endpoint must abort spawn"
+  assert_contains "$out" "did not enter a worktree" \
+    "the endpoint-confirmation failure was not reported"
+  assert_grep "return --force $case_dir/pool" "$case_dir/treehouse.log" \
+    "spawn leaked the acquired lease when endpoint confirmation failed"
+  assert_absent "$case_dir/home/state/$id.meta" \
+    "spawn published custody metadata for an unconfirmed endpoint"
+  handoff=$(find "$case_dir/home/state" -maxdepth 1 -name ".$id.treehouse-lease.*" -print -quit)
+  [ -z "$handoff" ] || fail "spawn left its private lease handoff behind after abort cleanup"
+  pass "an acquired lease is returned when endpoint confirmation fails"
 }
 
 test_spawn_refuses_a_copy_another_task_claims() {
@@ -424,6 +477,38 @@ test_spawn_refuses_ambiguous_worktree_metadata() {
   [ "$(git -C "$case_dir/pool" rev-parse --abbrev-ref HEAD)" = "fm/ambiguous-owner" ] \
     || fail "ambiguous metadata allowed spawn to move the claimed copy"
   pass "spawn fails closed on ambiguous worktree metadata without touching the copy"
+}
+
+test_spawn_preserves_a_post_acquire_owner_conflict() {
+  local case_dir id out status
+  id='custody-racing-owner-r2'
+  case_dir=$(make_spawn_case spawn-racing-owner "$id")
+  cat > "$case_dir/fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$case_dir/treehouse.log"
+if [ "\${1:-}" = get ]; then
+  printf '%s\n' \
+    'window=firstmate:fm-racing-task' \
+    'worktree=$case_dir/pool' \
+    'project=$case_dir/project' \
+    'kind=ship' \
+    'mode=no-mistakes' \
+    > "$case_dir/home/state/racing-task.meta"
+  printf '%s\n' "$case_dir/pool"
+fi
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+
+  out=$(run_spawn_case "$case_dir" "$id" --mode no-mistakes --yolo off)
+  status=$?
+  expect_code 1 "$status" "a post-acquire owner conflict must refuse spawn"
+  assert_contains "$out" "racing-task already claims" \
+    "the post-acquire conflict did not identify its owner"
+  assert_no_grep "return --force" "$case_dir/treehouse.log" \
+    "the owner-conflict refusal returned and reset the contested lease"
+  assert_absent "$case_dir/home/state/$id.meta" \
+    "the owner-conflict refusal published a second custody record"
+  pass "a post-acquire owner conflict preserves the contested lease"
 }
 
 test_fresh_spawn_refuses_an_existing_task_record_before_side_effects() {
@@ -1110,6 +1195,7 @@ SH
 
 test_two_homes_configure_distinct_pool_roots
 test_literal_pool_root_override_is_refused
+test_pool_root_refuses_to_write_inside_the_primary_clone
 test_pool_root_is_idempotent_without_mutating_the_clone
 test_pool_root_preserves_a_tracked_primary_config
 test_pool_root_preserves_a_nonregular_primary_config
@@ -1119,6 +1205,8 @@ test_real_treehouse_stops_sharing_a_pool_between_homes
 test_real_treehouse_accepts_encoded_pool_paths
 test_spawn_refuses_a_copy_another_task_claims
 test_spawn_refuses_ambiguous_worktree_metadata
+test_spawn_returns_a_lease_when_endpoint_confirmation_fails
+test_spawn_preserves_a_post_acquire_owner_conflict
 test_fresh_spawn_refuses_an_existing_task_record_before_side_effects
 test_spawn_claims_this_homes_pool_root_before_leasing
 test_spawn_releases_delivered_copies_before_leasing

--- a/tests/fm-worktree-custody.test.sh
+++ b/tests/fm-worktree-custody.test.sh
@@ -170,6 +170,23 @@ SH
   pass "pool configuration verifies the root that was actually written"
 }
 
+test_pool_root_refuses_when_git_exclude_cannot_be_written() {
+  local case_dir clone out status
+  case_dir=$(make_two_homes_one_project unwritable-exclude)
+  clone="$case_dir/homeA/project"
+  chmod 0444 "$clone/.git/info/exclude"
+
+  out=$(pool_root_for_home "$case_dir/homeA" "$case_dir/base" "$clone" 2>&1)
+  status=$?
+  chmod 0644 "$clone/.git/info/exclude"
+  expect_code 1 "$status" "pool configuration should refuse when info/exclude cannot be written"
+  assert_contains "$out" "could not exclude treehouse.toml" "the failed Git exclusion was not reported"
+  if git -C "$clone" check-ignore -q -- treehouse.toml; then
+    fail "the refused configuration unexpectedly left treehouse.toml ignored"
+  fi
+  pass "pool configuration refuses when Git exclusion cannot be established"
+}
+
 # The vendor fact the class rests on: treehouse hands two clones of one origin
 # slots from the SAME pool, and only `root` moves that pool. Self-skipping,
 # because the pool allocator is a third-party binary CI installs only for the
@@ -746,6 +763,70 @@ test_teardown_refuses_a_missing_tracked_canonical_manifest() {
   git -C "$case_dir/project" -c user.email=t@t -c user.name=t \
     commit -qm "publish the custody check"
   rm "$case_dir/project/package.json"
+  cat > "$case_dir/fakebin/npm" <<SH
+#!/usr/bin/env bash
+printf 'missing working manifest cannot run published custody check\n'
+exit 4
+SH
+  cat > "$case_dir/fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$case_dir/treehouse.log"
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/npm" "$case_dir/fakebin/treehouse"
+
+  out=$(run_teardown_case "$case_dir")
+  status=$?
+  expect_code 1 "$status" "a missing tracked canonical manifest must not disable custody"
+  assert_contains "$out" "missing working manifest cannot run" "the tracked manifest was not detected from repository state"
+  assert_present "$case_dir/state/task-c1.meta" "a refused cleanup removed the task record"
+  assert_absent "$case_dir/treehouse.log" "a missing tracked manifest allowed the copy to be returned"
+  [ -d "$case_dir/wt" ] || fail "a refused cleanup removed the working copy"
+  pass "a missing tracked canonical manifest remains a published custody opt-in"
+}
+
+test_teardown_detects_a_staged_deleted_canonical_manifest() {
+  local case_dir out status
+  case_dir=$(make_teardown_case teardown-custody-staged-deleted-manifest)
+  printf '{\n  "name": "fixture",\n  "scripts": {\n    "check:worktree-custody": "node custody.js"\n  }\n}\n' \
+    > "$case_dir/project/package.json"
+  git -C "$case_dir/project" add package.json
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t \
+    commit -qm "publish the custody check"
+  git -C "$case_dir/project" rm -q package.json
+  cat > "$case_dir/fakebin/npm" <<SH
+#!/usr/bin/env bash
+printf 'HEAD custody check survives staged manifest deletion\n'
+exit 4
+SH
+  cat > "$case_dir/fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$case_dir/treehouse.log"
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/npm" "$case_dir/fakebin/treehouse"
+
+  out=$(run_teardown_case "$case_dir")
+  status=$?
+  expect_code 1 "$status" "a staged manifest deletion must not disable published custody"
+  assert_contains "$out" "HEAD custody check survives" "the published check was not recovered from HEAD"
+  assert_present "$case_dir/state/task-c1.meta" "a refused cleanup removed the task record"
+  assert_absent "$case_dir/treehouse.log" "a staged manifest deletion allowed the copy to be returned"
+  [ -d "$case_dir/wt" ] || fail "a refused cleanup removed the working copy"
+  pass "a staged manifest deletion preserves the custody opt-in published by HEAD"
+}
+
+test_teardown_refuses_an_unavailable_canonical_project() {
+  local case_dir missing_project out status
+  case_dir=$(make_teardown_case teardown-custody-missing-project)
+  missing_project="$case_dir/missing-project"
+  fm_write_meta "$case_dir/state/task-c1.meta" \
+    "window=firstmate:fm-task-c1" \
+    "endpoint_task_id=task-c1" \
+    "worktree=$case_dir/wt" \
+    "project=$missing_project" \
+    "kind=ship" \
+    "mode=no-mistakes"
   cat > "$case_dir/fakebin/treehouse" <<SH
 #!/usr/bin/env bash
 printf '%s\n' "\$*" >> "$case_dir/treehouse.log"
@@ -755,12 +836,13 @@ SH
 
   out=$(run_teardown_case "$case_dir")
   status=$?
-  expect_code 1 "$status" "a missing tracked canonical manifest must not disable custody"
-  assert_contains "$out" "cannot confirm whether project" "the missing tracked manifest was not reported as unconfirmable"
-  assert_present "$case_dir/state/task-c1.meta" "a refused cleanup removed the task record"
-  assert_absent "$case_dir/treehouse.log" "a missing tracked manifest allowed the copy to be returned"
-  [ -d "$case_dir/wt" ] || fail "a refused cleanup removed the working copy"
-  pass "a missing tracked canonical manifest refuses cleanup instead of disabling custody"
+  expect_code 1 "$status" "an unavailable canonical project must refuse before cleanup"
+  assert_contains "$out" "cannot confirm whether project $missing_project" "the unavailable canonical project was not reported as unconfirmable"
+  assert_present "$case_dir/state/task-c1.meta" "an unavailable project removed the task record"
+  assert_absent "$case_dir/treehouse.log" "an unavailable project allowed the copy to be returned"
+  [ "$(git -C "$case_dir/wt" rev-parse --abbrev-ref HEAD)" = "fm/task-c1" ] \
+    || fail "an unavailable canonical project detached the protected working copy"
+  pass "an unavailable canonical project refuses cleanup before mutation"
 }
 
 test_two_homes_configure_distinct_pool_roots
@@ -769,6 +851,7 @@ test_pool_root_is_idempotent_and_preserves_other_keys
 test_pool_root_refuses_a_tracked_config
 test_pool_root_refuses_a_nonregular_config
 test_pool_root_verifies_the_written_config
+test_pool_root_refuses_when_git_exclude_cannot_be_written
 test_real_treehouse_stops_sharing_a_pool_between_homes
 test_spawn_refuses_a_copy_another_task_claims
 test_spawn_refuses_ambiguous_worktree_metadata
@@ -788,3 +871,5 @@ test_teardown_refuses_when_a_published_check_cannot_be_run
 test_teardown_uses_the_canonical_projects_custody_opt_in
 test_teardown_refuses_an_unparseable_canonical_manifest
 test_teardown_refuses_a_missing_tracked_canonical_manifest
+test_teardown_detects_a_staged_deleted_canonical_manifest
+test_teardown_refuses_an_unavailable_canonical_project

--- a/tests/fm-worktree-custody.test.sh
+++ b/tests/fm-worktree-custody.test.sh
@@ -268,6 +268,21 @@ SH
   chmod +x "$case_dir/fakebin/npm"
 }
 
+add_hanging_release_step() {  # <case-dir>
+  local case_dir=$1
+  printf '{\n  "name": "fixture",\n  "scripts": {\n    "pool:release-delivered": "node release.js"\n  }\n}\n' \
+    > "$case_dir/project/package.json"
+  cat > "$case_dir/fakebin/npm" <<SH
+#!/usr/bin/env bash
+if [ "\${1:-}" = run ] && [ "\${2:-}" = pool:release-delivered ]; then
+  sleep 5
+  touch "$case_dir/release-finished"
+fi
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/npm"
+}
+
 test_spawn_releases_delivered_copies_before_leasing() {
   local case_dir id out status
   id='custody-release-r1'
@@ -313,6 +328,38 @@ test_spawn_continues_when_the_release_step_fails() {
   assert_contains "$out" "pool:release-delivered failed" "a failed release step was not reported"
   assert_contains "$out" "spawned $id" "the spawn did not continue after the failed release step"
   pass "a failed release step warns loudly and never blocks the dispatch"
+}
+
+test_spawn_bounds_a_hanging_release_step_without_external_timeout() {
+  local case_dir id out status
+  id='custody-release-timeout-r1'
+  case_dir=$(make_spawn_case spawn-release-timeout "$id")
+  add_hanging_release_step "$case_dir"
+
+  out=$(FM_TIMEOUT_MECHANISM_OVERRIDE=bash FM_SPAWN_RELEASE_DELIVERED_TIMEOUT=1 \
+    run_spawn_case "$case_dir" "$id" --mode no-mistakes --yolo off)
+  status=$?
+  expect_code 0 "$status" "timed-out housekeeping must not block a dispatch: $out"
+  assert_contains "$out" "exit 124" "the hanging release step did not hit the shared deadline"
+  assert_contains "$out" "spawned $id" "the spawn did not continue after the release deadline"
+  assert_absent "$case_dir/release-finished" "the hanging release step escaped its deadline"
+  pass "a hanging release step is bounded without timeout or gtimeout and spawn continues"
+}
+
+test_spawn_rejects_a_nonpositive_release_timeout() {
+  local case_dir id out status
+  id='custody-release-zero-timeout-r1'
+  case_dir=$(make_spawn_case spawn-release-zero-timeout "$id")
+  add_release_step "$case_dir" 0
+
+  out=$(FM_SPAWN_RELEASE_DELIVERED_TIMEOUT=0 \
+    run_spawn_case "$case_dir" "$id" --mode no-mistakes --yolo off)
+  status=$?
+  expect_code 0 "$status" "invalid housekeeping configuration must not block a dispatch: $out"
+  assert_contains "$out" "exit 125" "a zero timeout was not rejected"
+  assert_absent "$case_dir/release.log" "the release step ran with a disabled deadline"
+  assert_contains "$out" "spawned $id" "the spawn did not continue after rejecting the zero timeout"
+  pass "a nonpositive release timeout is rejected without blocking spawn"
 }
 
 # --- (c) cleanup refuses when the project says the copy is not ours ----------
@@ -436,6 +483,44 @@ test_teardown_refuses_when_a_published_check_cannot_be_run() {
   pass "a published custody check that cannot be run refuses instead of tearing down"
 }
 
+test_teardown_uses_the_canonical_projects_custody_opt_in() {
+  local case_dir out status
+  case_dir=$(make_teardown_case teardown-custody-canonical)
+  printf '{\n  "name": "fixture",\n  "scripts": {\n    "check:worktree-custody": "node custody.js"\n  }\n}\n' \
+    > "$case_dir/project/package.json"
+  cat > "$case_dir/fakebin/npm" <<SH
+#!/usr/bin/env bash
+if [ "\${1:-}" = run ] && [ "\${2:-}" = check:worktree-custody ]; then
+  printf 'old worktree cannot execute canonical custody check\n'
+  exit 4
+fi
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/npm"
+
+  out=$(run_teardown_case "$case_dir")
+  status=$?
+  expect_code 1 "$status" "canonical opt-in must cover an older worktree"
+  assert_contains "$out" "old worktree cannot execute" "cleanup did not attempt the canonical custody check in the old worktree"
+  assert_present "$case_dir/state/task-c1.meta" "a refused cleanup removed the task record"
+  [ -d "$case_dir/wt" ] || fail "a refused cleanup removed the old working copy"
+  pass "canonical custody opt-in protects an older worktree that cannot run the check"
+}
+
+test_teardown_refuses_an_unparseable_canonical_manifest() {
+  local case_dir out status
+  case_dir=$(make_teardown_case teardown-custody-invalid-manifest)
+  printf '{"scripts":{"check:worktree-custody":' > "$case_dir/project/package.json"
+
+  out=$(run_teardown_case "$case_dir")
+  status=$?
+  expect_code 1 "$status" "an unparseable canonical manifest must not be treated as absent"
+  assert_contains "$out" "cannot confirm whether project" "the invalid manifest was not reported as unconfirmable"
+  assert_present "$case_dir/state/task-c1.meta" "a refused cleanup removed the task record"
+  [ -d "$case_dir/wt" ] || fail "a refused cleanup removed the working copy"
+  pass "an unparseable canonical manifest refuses cleanup instead of disabling custody"
+}
+
 test_two_homes_configure_distinct_pool_roots
 test_pool_root_is_idempotent_and_preserves_other_keys
 test_pool_root_refuses_a_tracked_config
@@ -445,7 +530,11 @@ test_spawn_claims_this_homes_pool_root_before_leasing
 test_spawn_releases_delivered_copies_before_leasing
 test_spawn_skips_projects_that_publish_no_release_step
 test_spawn_continues_when_the_release_step_fails
+test_spawn_bounds_a_hanging_release_step_without_external_timeout
+test_spawn_rejects_a_nonpositive_release_timeout
 test_teardown_refuses_a_red_custody_verdict
 test_teardown_proceeds_on_a_green_custody_verdict
 test_teardown_skips_projects_that_publish_no_check
 test_teardown_refuses_when_a_published_check_cannot_be_run
+test_teardown_uses_the_canonical_projects_custody_opt_in
+test_teardown_refuses_an_unparseable_canonical_manifest

--- a/tests/fm-worktree-custody.test.sh
+++ b/tests/fm-worktree-custody.test.sh
@@ -457,6 +457,75 @@ test_teardown_refuses_a_red_custody_verdict() {
   pass "cleanup refuses when the project's custody check says the copy is not this task's"
 }
 
+test_forced_teardown_still_refuses_a_red_custody_verdict() {
+  local case_dir out status
+  case_dir=$(make_teardown_case teardown-custody-force-red)
+  add_custody_check "$case_dir" 1
+  cat > "$case_dir/fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$case_dir/treehouse.log"
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+
+  out=$(run_teardown_case "$case_dir" --force)
+  status=$?
+  expect_code 1 "$status" "forced cleanup should still refuse another owner's copy"
+  assert_contains "$out" "check:worktree-custody" "the forced refusal did not name the project's check"
+  assert_present "$case_dir/state/task-c1.meta" "forced custody refusal removed the task record"
+  assert_absent "$case_dir/treehouse.log" "forced custody refusal returned the working copy"
+  [ -d "$case_dir/wt" ] || fail "forced custody refusal removed the working copy"
+  pass "--force discards own work but never bypasses a red custody verdict"
+}
+
+test_forced_secondmate_cleanup_preflights_child_custody() {
+  local case_dir home out status
+  case_dir=$(make_teardown_case teardown-child-custody-force-red)
+  home="$case_dir/secondmate-home"
+  mkdir -p "$home/state" "$home/data" "$home/config" "$home/projects"
+  printf '%s\n' task-c1 > "$home/.fm-secondmate-home"
+  fm_write_meta "$case_dir/state/task-c1.meta" \
+    "window=firstmate:fm-task-c1" \
+    "endpoint_task_id=task-c1" \
+    "worktree=$home" \
+    "home=$home" \
+    "project=$case_dir/project" \
+    "kind=secondmate" \
+    "mode=secondmate"
+  fm_write_meta "$home/state/child-c1.meta" \
+    "window=firstmate:fm-child-c1" \
+    "endpoint_task_id=child-c1" \
+    "worktree=$case_dir/wt" \
+    "project=$case_dir/project" \
+    "kind=ship" \
+    "mode=no-mistakes"
+  : > "$home/state/child-c1.status"
+  add_custody_check "$case_dir" 1
+  cat > "$case_dir/fakebin/tmux" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$case_dir/endpoint.log"
+exit 0
+SH
+  cat > "$case_dir/fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$case_dir/treehouse.log"
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/tmux" "$case_dir/fakebin/treehouse"
+
+  out=$(run_teardown_case "$case_dir" --force)
+  status=$?
+  expect_code 1 "$status" "forced secondmate cleanup should refuse a child owned elsewhere"
+  assert_contains "$out" "child task child-c1 failed its custody check" "the refusal did not identify the protected child"
+  assert_absent "$case_dir/endpoint.log" "child custody refusal closed an endpoint"
+  assert_absent "$case_dir/treehouse.log" "child custody refusal returned a working copy"
+  assert_present "$case_dir/state/task-c1.meta" "child custody refusal removed the parent record"
+  assert_present "$home/state/child-c1.meta" "child custody refusal removed the child record"
+  [ -d "$case_dir/wt" ] && [ -d "$home" ] \
+    || fail "child custody refusal removed the child worktree or secondmate home"
+  pass "forced secondmate cleanup validates every child before any mutation"
+}
+
 test_teardown_proceeds_on_a_green_custody_verdict() {
   local case_dir out status
   case_dir=$(make_teardown_case teardown-custody-green)
@@ -553,6 +622,8 @@ test_spawn_continues_when_the_release_step_fails
 test_spawn_bounds_a_hanging_release_step_without_external_timeout
 test_spawn_rejects_a_nonpositive_release_timeout
 test_teardown_refuses_a_red_custody_verdict
+test_forced_teardown_still_refuses_a_red_custody_verdict
+test_forced_secondmate_cleanup_preflights_child_custody
 test_teardown_proceeds_on_a_green_custody_verdict
 test_teardown_skips_projects_that_publish_no_check
 test_teardown_refuses_when_a_published_check_cannot_be_run

--- a/tests/fm-worktree-custody.test.sh
+++ b/tests/fm-worktree-custody.test.sh
@@ -80,6 +80,10 @@ test_two_homes_configure_distinct_pool_roots() {
   config_b=$(pool_config_view_for_home "$case_dir/homeB" "$case_dir/base" "$case_dir/homeB/project")
   assert_present "$config_a/treehouse.toml" "the first home has no generated Treehouse config"
   assert_present "$config_b/treehouse.toml" "the second home has no generated Treehouse config"
+  git -C "$config_a" check-ignore -q -- treehouse.toml \
+    || fail "the first generated Treehouse config is not actually ignored"
+  git -C "$config_a" check-ignore -q -- .gitignore \
+    || fail "the first generated ignore contract does not ignore itself"
   assert_absent "$case_dir/homeA/project/treehouse.toml" "pool setup mutated the first primary clone"
   assert_absent "$case_dir/homeB/project/treehouse.toml" "pool setup mutated the second primary clone"
   [ -z "$(git -C "$case_dir/homeA/project" status --porcelain)" ] \
@@ -174,8 +178,63 @@ SH
   assert_contains "$out" "could not write and verify" "the failed write postcondition was not reported"
   generated=$(find "$case_dir/homeA/state/treehouse-config" -name treehouse.toml -print -quit 2>/dev/null || true)
   [ -z "$generated" ] || fail "the no-op writer unexpectedly configured a pool root"
+  generated=$(find "$case_dir/homeA/state/treehouse-config" -name .git -print -quit 2>/dev/null || true)
+  [ -z "$generated" ] || fail "the failed generated write left a partial Git view"
   assert_absent "$clone/treehouse.toml" "the failed generated write mutated the primary clone"
   pass "pool configuration verifies the root that was actually written"
+}
+
+test_pool_root_rolls_back_an_existing_view_on_verification_failure() {
+  local case_dir clone config project_git_dir fakebin real_git out status toml_before ignore_before
+  local toml_mode ignore_mode exclude_before
+  case_dir=$(make_two_homes_one_project rollback-existing-view)
+  clone="$case_dir/homeA/project"
+  config=$(pool_config_view_for_home "$case_dir/homeA" "$case_dir/base" "$clone") \
+    || fail "could not create the rollback fixture view"
+  project_git_dir=$(git -C "$clone" rev-parse --absolute-git-dir)
+  rm -f -- "$config/.git/HEAD" "$config/.git/commondir" "$config/.git/index"
+  rmdir "$config/.git"
+  ln -s "$project_git_dir" "$config/.git"
+  printf 'root = "/preserved/original"\n' > "$config/treehouse.toml"
+  printf '.gitignore\ntreehouse.toml\npreserved-local-entry\n' > "$config/.gitignore"
+  chmod 0640 "$config/treehouse.toml"
+  chmod 0600 "$config/.gitignore"
+  toml_before=$(cksum < "$config/treehouse.toml")
+  ignore_before=$(cksum < "$config/.gitignore")
+  toml_mode=$(file_mode "$config/treehouse.toml")
+  ignore_mode=$(file_mode "$config/.gitignore")
+  exclude_before=$(cksum < "$clone/.git/info/exclude")
+  real_git=$(command -v git)
+  fakebin=$(fm_fakebin "$case_dir/verify-failure")
+  cat > "$fakebin/git" <<'SH'
+#!/usr/bin/env bash
+case "$*" in
+  *" check-ignore "*) exit 1 ;;
+esac
+exec "${FM_REAL_GIT:?}" "$@"
+SH
+  chmod +x "$fakebin/git"
+
+  out=$(FM_HOME="$case_dir/homeA" FM_POOL_ROOT_BASE="$case_dir/base" \
+    FM_REAL_GIT="$real_git" PATH="$fakebin:$PATH" "$POOL_ROOT_BIN" "$clone" 2>&1)
+  status=$?
+  expect_code 1 "$status" "a failed ignore verification must fail pool configuration"
+  assert_contains "$out" "could not write and verify" "the transactional verification failure was not reported"
+  [ "$(cksum < "$config/treehouse.toml")" = "$toml_before" ] \
+    || fail "failed verification did not restore the prior Treehouse config"
+  [ "$(cksum < "$config/.gitignore")" = "$ignore_before" ] \
+    || fail "failed verification did not restore the prior ignore contract"
+  [ "$(file_mode "$config/treehouse.toml")" = "$toml_mode" ] \
+    || fail "failed verification did not restore the Treehouse config mode"
+  [ "$(file_mode "$config/.gitignore")" = "$ignore_mode" ] \
+    || fail "failed verification did not restore the ignore-contract mode"
+  [ -L "$config/.git" ] && [ "$(readlink "$config/.git")" = "$project_git_dir" ] \
+    || fail "failed verification did not restore the prior Git control link"
+  [ "$(cksum < "$clone/.git/info/exclude")" = "$exclude_before" ] \
+    || fail "generated-view rollback mutated the primary clone's Git exclusion"
+  [ -z "$(git -C "$clone" status --porcelain)" ] \
+    || fail "generated-view rollback dirtied the primary clone"
+  pass "pool configuration restores the complete prior view after verification failure"
 }
 
 # The vendor fact the class rests on: treehouse hands two clones of one origin
@@ -266,11 +325,24 @@ case "$*" in
 esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
+  send-keys)
+    case "${4:-}" in
+      *"treehouse get --lease"*) bash -c "$4" ;;
+    esac
+    exit 0
+    ;;
 esac
 exit 0
 SH
   chmod +x "$fakebin/tmux"
-  fm_fake_exit0 "$fakebin" treehouse
+  cat > "$fakebin/treehouse" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${FM_TREEHOUSE_LOG:?}"
+case "${1:-}" in
+  get) printf '%s\n' "${FM_FAKE_PANE_PATH:?}" ;;
+esac
+SH
+  chmod +x "$fakebin/treehouse"
 
   fm_git_init_commit "$case_dir/upstream"
   git clone --quiet --bare "$case_dir/upstream" "$case_dir/origin.git"
@@ -293,6 +365,7 @@ run_spawn_case() {  # <case-dir> <id> <args...>
     FM_PROJECTS_OVERRIDE="$case_dir/home/projects" FM_CONFIG_OVERRIDE="$case_dir/home/config" \
     FM_POOL_ROOT_BASE="$case_dir/base" \
     FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" FM_FAKE_PANE_PATH="$case_dir/pool" \
+    FM_TREEHOUSE_LOG="$case_dir/treehouse.log" \
     PATH="$case_dir/fakebin:$PATH" \
     "$SPAWN" "$id" "$case_dir/project" "$@" 2>&1
 }
@@ -315,8 +388,9 @@ test_spawn_refuses_a_copy_another_task_claims() {
   out=$(run_spawn_case "$case_dir" "$id" --mode no-mistakes --yolo off)
   status=$?
   expect_code 1 "$status" "spawn should refuse a copy another task already claims: $out"
-  assert_contains "$out" "other-task already claims" "the refusal did not name the claiming task"
+  assert_contains "$out" "task other-task claims" "the refusal did not name the claiming task"
   assert_absent "$case_dir/home/state/$id.meta" "a refused spawn still published task metadata"
+  assert_absent "$case_dir/treehouse.log" "spawn asked Treehouse to recycle a copy already claimed by legacy metadata"
   [ "$(git -C "$case_dir/pool" rev-parse HEAD)" = "$pool_head" ] \
     || fail "the refused spawn reset the other task's copy before refusing"
   [ "$(git -C "$case_dir/pool" rev-parse --abbrev-ref HEAD)" = "fm/other-task" ] \
@@ -344,6 +418,7 @@ test_spawn_refuses_ambiguous_worktree_metadata() {
   expect_code 1 "$status" "spawn should fail closed on ambiguous worktree metadata"
   assert_contains "$out" "ambiguous worktree metadata" "the refusal did not identify the ambiguous ownership record"
   assert_absent "$case_dir/home/state/$id.meta" "ambiguous metadata still allowed a second owner record"
+  assert_absent "$case_dir/treehouse.log" "ambiguous metadata was checked only after requesting a lease"
   [ "$(git -C "$case_dir/pool" rev-parse HEAD)" = "$pool_head" ] \
     || fail "ambiguous metadata allowed spawn to reset the claimed copy"
   [ "$(git -C "$case_dir/pool" rev-parse --abbrev-ref HEAD)" = "fm/ambiguous-owner" ] \
@@ -398,6 +473,10 @@ test_spawn_claims_this_homes_pool_root_before_leasing() {
   status=$?
   expect_code 0 "$status" "an unclaimed pooled copy should still spawn"
   assert_contains "$out" "spawned $id" "spawn did not report success"
+  assert_grep "get --lease --lease-holder $id" "$case_dir/treehouse.log" \
+    "spawn did not acquire its worktree as a durable task-labelled Treehouse lease"
+  assert_grep "treehouse_lease_holder=$id" "$case_dir/home/state/$id.meta" \
+    "spawn did not persist the durable lease identity with task custody metadata"
   config_home=$(pool_config_view_for_home "$case_dir/home" "$case_dir/base" "$case_dir/project")
   assert_present "$config_home/treehouse.toml" "spawn did not generate this home's Treehouse config"
   assert_absent "$case_dir/project/treehouse.toml" "spawn wrote Treehouse config into the primary clone"
@@ -1035,6 +1114,7 @@ test_pool_root_is_idempotent_without_mutating_the_clone
 test_pool_root_preserves_a_tracked_primary_config
 test_pool_root_preserves_a_nonregular_primary_config
 test_pool_root_verifies_the_written_config
+test_pool_root_rolls_back_an_existing_view_on_verification_failure
 test_real_treehouse_stops_sharing_a_pool_between_homes
 test_real_treehouse_accepts_encoded_pool_paths
 test_spawn_refuses_a_copy_another_task_claims

--- a/tests/fm-worktree-custody.test.sh
+++ b/tests/fm-worktree-custody.test.sh
@@ -252,6 +252,33 @@ test_spawn_refuses_a_copy_another_task_claims() {
   pass "a spawn refuses a pooled copy another task claims, leaving that copy untouched"
 }
 
+test_spawn_refuses_ambiguous_worktree_metadata() {
+  local case_dir id out status pool_head
+  id='custody-ambiguous-r1'
+  case_dir=$(make_spawn_case spawn-ambiguous "$id")
+  fm_write_meta "$case_dir/home/state/ambiguous-task.meta" \
+    "window=firstmate:fm-ambiguous-task" \
+    "worktree=$case_dir/not-this-copy" \
+    "worktree=$case_dir/pool" \
+    "project=$case_dir/project" \
+    "kind=ship" \
+    "mode=no-mistakes"
+  git -C "$case_dir/pool" checkout --quiet -b fm/ambiguous-owner
+  git -C "$case_dir/pool" commit -q --allow-empty -m "ambiguous owner's unlanded work"
+  pool_head=$(git -C "$case_dir/pool" rev-parse HEAD)
+
+  out=$(run_spawn_case "$case_dir" "$id" --mode no-mistakes --yolo off)
+  status=$?
+  expect_code 1 "$status" "spawn should fail closed on ambiguous worktree metadata"
+  assert_contains "$out" "ambiguous worktree metadata" "the refusal did not identify the ambiguous ownership record"
+  assert_absent "$case_dir/home/state/$id.meta" "ambiguous metadata still allowed a second owner record"
+  [ "$(git -C "$case_dir/pool" rev-parse HEAD)" = "$pool_head" ] \
+    || fail "ambiguous metadata allowed spawn to reset the claimed copy"
+  [ "$(git -C "$case_dir/pool" rev-parse --abbrev-ref HEAD)" = "fm/ambiguous-owner" ] \
+    || fail "ambiguous metadata allowed spawn to move the claimed copy"
+  pass "spawn fails closed on ambiguous worktree metadata without touching the copy"
+}
+
 test_spawn_claims_this_homes_pool_root_before_leasing() {
   local case_dir id out status base_real
   id='custody-own-pool-r1'
@@ -526,6 +553,72 @@ SH
   pass "forced secondmate cleanup validates every child before any mutation"
 }
 
+test_teardown_holds_task_set_lock_through_destructive_return() {
+  local case_dir teardown_pid waited=0 spawn_out spawn_status teardown_status
+  local endpoint_created=0 meta_published=0 teardown_alive=0
+  case_dir=$(make_teardown_case teardown-spawn-race)
+  add_custody_check "$case_dir" 0
+  mkdir -p "$case_dir/home" "$case_dir/data/task-b" "$case_dir/projects" "$case_dir/base"
+  printf 'brief for task-b\n' > "$case_dir/data/task-b/brief.md"
+  printf 'codex\n' > "$case_dir/config/crew-harness"
+  cat > "$case_dir/fakebin/tmux" <<SH
+#!/usr/bin/env bash
+set -u
+printf '%s\n' "\$*" >> "$case_dir/endpoint.log"
+case "\$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "$case_dir/wt"; exit 0 ;;
+esac
+case "\${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+esac
+exit 0
+SH
+  cat > "$case_dir/fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$case_dir/treehouse.log"
+if [ "\${1:-}" = return ]; then
+  : > "$case_dir/return-started"
+  while [ ! -e "$case_dir/return-release" ]; do sleep 0.05; done
+fi
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/tmux" "$case_dir/fakebin/treehouse"
+
+  run_teardown_case "$case_dir" > "$case_dir/teardown.out" 2>&1 &
+  teardown_pid=$!
+  while [ ! -e "$case_dir/return-started" ] && kill -0 "$teardown_pid" 2>/dev/null \
+      && [ "$waited" -lt 1200 ]; do
+    sleep 0.05
+    waited=$((waited + 1))
+  done
+  [ -e "$case_dir/return-started" ] || {
+    : > "$case_dir/return-release"
+    wait "$teardown_pid" 2>/dev/null || true
+    fail "teardown never reached its destructive return boundary: $(cat "$case_dir/teardown.out")"
+  }
+
+  spawn_out=$(FM_ROOT_OVERRIDE='' FM_HOME="$case_dir/home" \
+    FM_STATE_OVERRIDE="$case_dir/state" FM_DATA_OVERRIDE="$case_dir/data" \
+    FM_PROJECTS_OVERRIDE="$case_dir/projects" FM_CONFIG_OVERRIDE="$case_dir/config" \
+    FM_POOL_ROOT_BASE="$case_dir/base" FM_SPAWN_NO_GUARD=1 \
+    TMUX="fake,1,0" PATH="$case_dir/fakebin:$PATH" \
+    "$SPAWN" task-b "$case_dir/project" --mode no-mistakes --yolo off 2>&1)
+  spawn_status=$?
+  [ ! -e "$case_dir/endpoint.log" ] || endpoint_created=1
+  [ ! -e "$case_dir/state/task-b.meta" ] || meta_published=1
+  kill -0 "$teardown_pid" 2>/dev/null && teardown_alive=1
+
+  : > "$case_dir/return-release"
+  if wait "$teardown_pid"; then teardown_status=0; else teardown_status=$?; fi
+  expect_code 1 "$spawn_status" "spawn should refuse while teardown owns the task set"
+  assert_contains "$spawn_out" "task set is locked" "concurrent spawn did not refuse on the teardown's task-set lock"
+  [ "$meta_published" -eq 0 ] || fail "concurrent spawn published metadata during destructive teardown"
+  [ "$endpoint_created" -eq 0 ] || fail "concurrent spawn created an endpoint during destructive teardown"
+  [ "$teardown_alive" -eq 1 ] || fail "teardown stopped holding the destructive boundary before the spawn refusal"
+  expect_code 0 "$teardown_status" "serialized teardown should complete after return is released"
+  pass "teardown holds the task-set lock through custody and destructive return"
+}
+
 test_teardown_proceeds_on_a_green_custody_verdict() {
   local case_dir out status
   case_dir=$(make_teardown_case teardown-custody-green)
@@ -615,6 +708,7 @@ test_pool_root_is_idempotent_and_preserves_other_keys
 test_pool_root_refuses_a_tracked_config
 test_real_treehouse_stops_sharing_a_pool_between_homes
 test_spawn_refuses_a_copy_another_task_claims
+test_spawn_refuses_ambiguous_worktree_metadata
 test_spawn_claims_this_homes_pool_root_before_leasing
 test_spawn_releases_delivered_copies_before_leasing
 test_spawn_skips_projects_that_publish_no_release_step
@@ -624,6 +718,7 @@ test_spawn_rejects_a_nonpositive_release_timeout
 test_teardown_refuses_a_red_custody_verdict
 test_forced_teardown_still_refuses_a_red_custody_verdict
 test_forced_secondmate_cleanup_preflights_child_custody
+test_teardown_holds_task_set_lock_through_destructive_return
 test_teardown_proceeds_on_a_green_custody_verdict
 test_teardown_skips_projects_that_publish_no_check
 test_teardown_refuses_when_a_published_check_cannot_be_run

--- a/tests/fm-worktree-custody.test.sh
+++ b/tests/fm-worktree-custody.test.sh
@@ -13,8 +13,9 @@
 #       into bin/fm-spawn.sh before the slot is acquired);
 #   (b) a spawn refuses a copy another task in this home already claims
 #       (bin/fm-spawn.sh), before the base refresh touches it;
-#   (c) cleanup refuses when the project's own custody check reports the copy
-#       is not this task's to discard (bin/fm-teardown.sh);
+#   (c) cleanup runs the canonical Git-authenticated custody check against the
+#       copy and refuses when it is not this task's to discard
+#       (bin/fm-teardown.sh);
 #   (d) a spawn asks the project to release its delivered copies before leasing,
 #       so a pool exhausted by copies nobody handed back does not block dispatch
 #       (bin/fm-spawn.sh) - capacity, so a failure warns and the spawn continues.
@@ -41,6 +42,14 @@ pool_root_for_home() {  # <home> <base> <project>
 
 configured_root_of() {  # <clone>
   sed -n 's/^root[[:space:]]*=[[:space:]]*"\(.*\)"$/\1/p' "$1/treehouse.toml" | head -1
+}
+
+file_mode() {  # <path>
+  if [ "$(uname)" = Darwin ]; then
+    stat -f %Lp "$1"
+  else
+    stat -c %a "$1"
+  fi
 }
 
 make_two_homes_one_project() {  # <name>
@@ -181,10 +190,33 @@ test_pool_root_refuses_when_git_exclude_cannot_be_written() {
   chmod 0644 "$clone/.git/info/exclude"
   expect_code 1 "$status" "pool configuration should refuse when info/exclude cannot be written"
   assert_contains "$out" "could not exclude treehouse.toml" "the failed Git exclusion was not reported"
+  assert_absent "$clone/treehouse.toml" "a failed Git exclusion left the new local config behind"
   if git -C "$clone" check-ignore -q -- treehouse.toml; then
     fail "the refused configuration unexpectedly left treehouse.toml ignored"
   fi
-  pass "pool configuration refuses when Git exclusion cannot be established"
+  pass "failed Git exclusion removes a newly created pool config"
+}
+
+test_pool_root_restores_existing_config_when_git_exclude_fails() {
+  local case_dir clone out status before_bytes before_mode
+  case_dir=$(make_two_homes_one_project restore-config-after-exclude)
+  clone="$case_dir/homeA/project"
+  printf 'max_trees = 7\nroot = "/shared/original"\n' > "$clone/treehouse.toml"
+  chmod 0600 "$clone/treehouse.toml"
+  before_bytes=$(cksum < "$clone/treehouse.toml")
+  before_mode=$(file_mode "$clone/treehouse.toml")
+  chmod 0444 "$clone/.git/info/exclude"
+
+  out=$(pool_root_for_home "$case_dir/homeA" "$case_dir/base" "$clone" 2>&1)
+  status=$?
+  chmod 0644 "$clone/.git/info/exclude"
+  expect_code 1 "$status" "pool configuration should refuse when an existing config cannot be excluded"
+  assert_contains "$out" "could not exclude treehouse.toml" "the existing-config exclusion failure was not reported"
+  [ "$(cksum < "$clone/treehouse.toml")" = "$before_bytes" ] \
+    || fail "the failed exclusion did not restore the previous config bytes"
+  [ "$(file_mode "$clone/treehouse.toml")" = "$before_mode" ] \
+    || fail "the failed exclusion did not restore the previous config mode"
+  pass "failed Git exclusion restores existing config bytes and mode"
 }
 
 # The vendor fact the class rests on: treehouse hands two clones of one origin
@@ -505,20 +537,20 @@ test_spawn_bounds_a_hanging_release_step_without_external_timeout() {
   pass "a hanging release step is bounded without timeout or gtimeout and spawn continues"
 }
 
-test_spawn_rejects_a_nonpositive_release_timeout() {
+test_spawn_rejects_a_zero_equivalent_release_timeout() {
   local case_dir id out status
   id='custody-release-zero-timeout-r1'
   case_dir=$(make_spawn_case spawn-release-zero-timeout "$id")
   add_release_step "$case_dir" 0
 
-  out=$(FM_SPAWN_RELEASE_DELIVERED_TIMEOUT=0 \
+  out=$(FM_SPAWN_RELEASE_DELIVERED_TIMEOUT=00 \
     run_spawn_case "$case_dir" "$id" --mode no-mistakes --yolo off)
   status=$?
   expect_code 0 "$status" "invalid housekeeping configuration must not block a dispatch: $out"
-  assert_contains "$out" "exit 125" "a zero timeout was not rejected"
+  assert_contains "$out" "exit 125" "a zero-equivalent timeout was not rejected"
   assert_absent "$case_dir/release.log" "the release step ran with a disabled deadline"
   assert_contains "$out" "spawned $id" "the spawn did not continue after rejecting the zero timeout"
-  pass "a nonpositive release timeout is rejected without blocking spawn"
+  pass "a zero-equivalent release timeout is rejected without blocking spawn"
 }
 
 # --- (c) cleanup refuses when the project says the copy is not ours ----------
@@ -555,17 +587,20 @@ make_teardown_case() {  # <name>
 add_custody_check() {  # <case-dir> <exit>
   local case_dir=$1 exit_code=$2
   printf '{\n  "name": "fixture",\n  "scripts": {\n    "check:worktree-custody": "node custody.js"\n  }\n}\n' \
-    > "$case_dir/wt/package.json"
-  # Landed, so the existing landed-work verdict passes and custody is what decides.
-  git -C "$case_dir/wt" add package.json
-  git -C "$case_dir/wt" -c user.email=t@t -c user.name=t commit -qm "publish the custody check"
+    > "$case_dir/project/package.json"
+  printf '%s\n' "$exit_code" > "$case_dir/project/custody.verdict"
+  git -C "$case_dir/project" add package.json custody.verdict
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t commit -qm "publish the custody check"
+  git -C "$case_dir/project" push -q origin main
+  git -C "$case_dir/wt" -c user.email=t@t -c user.name=t merge -q main
   git -C "$case_dir/wt" push -q origin fm/task-c1
-  git -C "$case_dir/project" fetch -q origin
   cat > "$case_dir/fakebin/npm" <<SH
 #!/usr/bin/env bash
 if [ "\${1:-}" = run ] && [ "\${2:-}" = check:worktree-custody ]; then
+  printf '%s\n' "\$PWD" > "$case_dir/custody-run-dir.log"
+  printf '%s\n' "\$*" > "$case_dir/custody-args.log"
   printf 'pushed-not-merged: this copy is still delivering\n'
-  exit $exit_code
+  exit "\$(cat "\$PWD/custody.verdict")"
 fi
 exit 0
 SH
@@ -598,9 +633,10 @@ test_teardown_refuses_a_red_custody_verdict() {
 }
 
 test_forced_teardown_still_refuses_a_red_custody_verdict() {
-  local case_dir out status
+  local case_dir out status run_dir
   case_dir=$(make_teardown_case teardown-custody-force-red)
   add_custody_check "$case_dir" 1
+  printf '0\n' > "$case_dir/wt/custody.verdict"
   cat > "$case_dir/fakebin/treehouse" <<SH
 #!/usr/bin/env bash
 printf '%s\n' "\$*" >> "$case_dir/treehouse.log"
@@ -615,7 +651,37 @@ SH
   assert_present "$case_dir/state/task-c1.meta" "forced custody refusal removed the task record"
   assert_absent "$case_dir/treehouse.log" "forced custody refusal returned the working copy"
   [ -d "$case_dir/wt" ] || fail "forced custody refusal removed the working copy"
-  pass "--force discards own work but never bypasses a red custody verdict"
+  run_dir=$(cat "$case_dir/custody-run-dir.log")
+  [ "$run_dir" != "$case_dir/wt" ] || fail "forced custody trusted the protected worktree's mutable check"
+  [ "$(cat "$case_dir/custody-args.log")" = "run check:worktree-custody -- --worktree $case_dir/wt" ] \
+    || fail "the canonical custody check did not receive the protected worktree path"
+  assert_absent "$run_dir" "the authenticated custody snapshot was not cleaned up"
+  pass "--force trusts canonical custody code, never the protected copy"
+}
+
+test_teardown_refuses_a_worktree_only_custody_check() {
+  local case_dir out status
+  case_dir=$(make_teardown_case teardown-custody-worktree-only)
+  printf '{\n  "name": "fixture",\n  "scripts": {\n    "check:worktree-custody": "node custody.js"\n  }\n}\n' \
+    > "$case_dir/wt/package.json"
+  git -C "$case_dir/wt" add package.json
+  git -C "$case_dir/wt" -c user.email=t@t -c user.name=t commit -qm "publish only in mutable worktree"
+  git -C "$case_dir/wt" push -q origin fm/task-c1
+  cat > "$case_dir/fakebin/npm" <<SH
+#!/usr/bin/env bash
+touch "$case_dir/unauthenticated-check-ran"
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/npm"
+
+  out=$(run_teardown_case "$case_dir" --force)
+  status=$?
+  expect_code 1 "$status" "a worktree-only custody check must not authorize destructive cleanup"
+  assert_contains "$out" "cannot authenticate and execute" "the unauthenticated custody source was not reported"
+  assert_absent "$case_dir/unauthenticated-check-ran" "teardown executed code from the protected worktree"
+  assert_present "$case_dir/state/task-c1.meta" "unauthenticated custody removed the task record"
+  [ -d "$case_dir/wt" ] || fail "unauthenticated custody removed the protected working copy"
+  pass "a worktree-only custody check cannot authorize teardown"
 }
 
 test_forced_secondmate_cleanup_preflights_child_custody() {
@@ -948,6 +1014,7 @@ test_pool_root_refuses_a_tracked_config
 test_pool_root_refuses_a_nonregular_config
 test_pool_root_verifies_the_written_config
 test_pool_root_refuses_when_git_exclude_cannot_be_written
+test_pool_root_restores_existing_config_when_git_exclude_fails
 test_real_treehouse_stops_sharing_a_pool_between_homes
 test_spawn_refuses_a_copy_another_task_claims
 test_spawn_refuses_ambiguous_worktree_metadata
@@ -958,9 +1025,10 @@ test_spawn_skips_projects_that_publish_no_release_step
 test_spawn_ignores_an_untracked_release_manifest
 test_spawn_continues_when_the_release_step_fails
 test_spawn_bounds_a_hanging_release_step_without_external_timeout
-test_spawn_rejects_a_nonpositive_release_timeout
+test_spawn_rejects_a_zero_equivalent_release_timeout
 test_teardown_refuses_a_red_custody_verdict
 test_forced_teardown_still_refuses_a_red_custody_verdict
+test_teardown_refuses_a_worktree_only_custody_check
 test_forced_secondmate_cleanup_preflights_child_custody
 test_teardown_holds_task_set_lock_through_destructive_return
 test_teardown_proceeds_on_a_green_custody_verdict

--- a/tests/fm-worktree-custody.test.sh
+++ b/tests/fm-worktree-custody.test.sh
@@ -135,6 +135,41 @@ test_pool_root_refuses_a_tracked_config() {
   pass "a project that tracks treehouse.toml is refused rather than rewritten"
 }
 
+test_pool_root_refuses_a_nonregular_config() {
+  local case_dir clone out status
+  case_dir=$(make_two_homes_one_project nonregular-config)
+  clone="$case_dir/homeA/project"
+  mkdir "$clone/treehouse.toml"
+  touch "$clone/treehouse.toml/preserved"
+
+  out=$(pool_root_for_home "$case_dir/homeA" "$case_dir/base" "$clone" 2>&1)
+  status=$?
+  expect_code 1 "$status" "a nonregular treehouse.toml should refuse before configuration"
+  assert_contains "$out" "not a regular file" "the refusal did not identify the invalid config path"
+  assert_present "$clone/treehouse.toml/preserved" "the invalid config path was modified"
+  pass "a nonregular treehouse config is refused without modification"
+}
+
+test_pool_root_verifies_the_written_config() {
+  local case_dir clone fakebin out status
+  case_dir=$(make_two_homes_one_project verify-written-config)
+  clone="$case_dir/homeA/project"
+  fakebin=$(fm_fakebin "$case_dir")
+  cat > "$fakebin/mv" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+  chmod +x "$fakebin/mv"
+
+  out=$(FM_HOME="$case_dir/homeA" FM_POOL_ROOT_BASE="$case_dir/base" \
+    PATH="$fakebin:$PATH" "$POOL_ROOT_BIN" "$clone" 2>&1)
+  status=$?
+  expect_code 1 "$status" "pool configuration should refuse when its write did not take effect"
+  assert_contains "$out" "could not verify" "the failed write postcondition was not reported"
+  assert_absent "$clone/treehouse.toml" "the no-op writer unexpectedly configured a pool root"
+  pass "pool configuration verifies the root that was actually written"
+}
+
 # The vendor fact the class rests on: treehouse hands two clones of one origin
 # slots from the SAME pool, and only `root` moves that pool. Self-skipping,
 # because the pool allocator is a third-party binary CI installs only for the
@@ -702,10 +737,38 @@ test_teardown_refuses_an_unparseable_canonical_manifest() {
   pass "an unparseable canonical manifest refuses cleanup instead of disabling custody"
 }
 
+test_teardown_refuses_a_missing_tracked_canonical_manifest() {
+  local case_dir out status
+  case_dir=$(make_teardown_case teardown-custody-missing-tracked-manifest)
+  printf '{\n  "name": "fixture",\n  "scripts": {\n    "check:worktree-custody": "node custody.js"\n  }\n}\n' \
+    > "$case_dir/project/package.json"
+  git -C "$case_dir/project" add package.json
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t \
+    commit -qm "publish the custody check"
+  rm "$case_dir/project/package.json"
+  cat > "$case_dir/fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$case_dir/treehouse.log"
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+
+  out=$(run_teardown_case "$case_dir")
+  status=$?
+  expect_code 1 "$status" "a missing tracked canonical manifest must not disable custody"
+  assert_contains "$out" "cannot confirm whether project" "the missing tracked manifest was not reported as unconfirmable"
+  assert_present "$case_dir/state/task-c1.meta" "a refused cleanup removed the task record"
+  assert_absent "$case_dir/treehouse.log" "a missing tracked manifest allowed the copy to be returned"
+  [ -d "$case_dir/wt" ] || fail "a refused cleanup removed the working copy"
+  pass "a missing tracked canonical manifest refuses cleanup instead of disabling custody"
+}
+
 test_two_homes_configure_distinct_pool_roots
 test_literal_pool_root_override_is_refused
 test_pool_root_is_idempotent_and_preserves_other_keys
 test_pool_root_refuses_a_tracked_config
+test_pool_root_refuses_a_nonregular_config
+test_pool_root_verifies_the_written_config
 test_real_treehouse_stops_sharing_a_pool_between_homes
 test_spawn_refuses_a_copy_another_task_claims
 test_spawn_refuses_ambiguous_worktree_metadata
@@ -724,3 +787,4 @@ test_teardown_skips_projects_that_publish_no_check
 test_teardown_refuses_when_a_published_check_cannot_be_run
 test_teardown_uses_the_canonical_projects_custody_opt_in
 test_teardown_refuses_an_unparseable_canonical_manifest
+test_teardown_refuses_a_missing_tracked_canonical_manifest

--- a/tests/fm-worktree-custody.test.sh
+++ b/tests/fm-worktree-custody.test.sh
@@ -181,9 +181,10 @@ test_pool_root_preserves_a_nonregular_primary_config() {
 }
 
 test_pool_root_verifies_the_written_config() {
-  local case_dir clone fakebin out status generated
+  local case_dir clone fakebin out status generated relocated_base
   case_dir=$(make_two_homes_one_project verify-written-config)
   clone="$case_dir/homeA/project"
+  relocated_base="$case_dir/new/relocated/base"
   fakebin=$(fm_fakebin "$case_dir")
   cat > "$fakebin/mv" <<'SH'
 #!/usr/bin/env bash
@@ -191,7 +192,7 @@ exit 0
 SH
   chmod +x "$fakebin/mv"
 
-  out=$(FM_HOME="$case_dir/homeA" FM_POOL_ROOT_BASE="$case_dir/base" \
+  out=$(FM_HOME="$case_dir/homeA" FM_POOL_ROOT_BASE="$relocated_base" \
     PATH="$fakebin:$PATH" "$POOL_ROOT_BIN" "$clone" 2>&1)
   status=$?
   expect_code 1 "$status" "pool configuration should refuse when its write did not take effect"
@@ -200,8 +201,12 @@ SH
   [ -z "$generated" ] || fail "the no-op writer unexpectedly configured a pool root"
   generated=$(find "$case_dir/homeA/state/treehouse-config" -name .git -print -quit 2>/dev/null || true)
   [ -z "$generated" ] || fail "the failed generated write left a partial Git view"
+  assert_absent "$case_dir/new" \
+    "the failed generated write left newly created pool-root parents"
+  assert_absent "$case_dir/homeA/state" \
+    "the failed generated write left newly created config-view parents"
   assert_absent "$clone/treehouse.toml" "the failed generated write mutated the primary clone"
-  pass "pool configuration verifies the root that was actually written"
+  pass "pool configuration rolls back every newly created path after verification fails"
 }
 
 test_pool_root_rolls_back_an_existing_view_on_verification_failure() {
@@ -311,7 +316,7 @@ test_real_treehouse_accepts_encoded_pool_paths() {
     return 0
   fi
   case_dir=$(make_two_homes_one_project encoded-root)
-  special_base="$case_dir/"$'pool"back\\slash\nline'
+  special_base="$case_dir/"$'pool"back\\slash\nline\177del'
   mkdir -p "$special_base"
   root=$(pool_root_for_home "$case_dir/homeA" "$special_base" "$case_dir/homeA/project") \
     || fail "fm-pool-root.sh rejected a valid filesystem path requiring TOML escapes"
@@ -345,12 +350,7 @@ case "$*" in
 esac
 case "${1:-}" in
   display-message) printf 'firstmate\n'; exit 0 ;;
-  send-keys)
-    case "${4:-}" in
-      *"treehouse get --lease"*) bash -c "$4" ;;
-    esac
-    exit 0
-    ;;
+  send-keys) exit 0 ;;
 esac
 exit 0
 SH
@@ -391,7 +391,7 @@ run_spawn_case() {  # <case-dir> <id> <args...>
 }
 
 test_spawn_returns_a_lease_when_endpoint_confirmation_fails() {
-  local case_dir id out status handoff
+  local case_dir id out status
   id='custody-unconfirmed-endpoint-r2'
   case_dir=$(make_spawn_case spawn-unconfirmed-endpoint "$id")
   cat > "$case_dir/fakebin/treehouse" <<SH
@@ -418,8 +418,6 @@ SH
     "spawn leaked the acquired lease when endpoint confirmation failed"
   assert_absent "$case_dir/home/state/$id.meta" \
     "spawn published custody metadata for an unconfirmed endpoint"
-  handoff=$(find "$case_dir/home/state" -maxdepth 1 -name ".$id.treehouse-lease.*" -print -quit)
-  [ -z "$handoff" ] || fail "spawn left its private lease handoff behind after abort cleanup"
   pass "an acquired lease is returned when endpoint confirmation fails"
 }
 
@@ -443,7 +441,8 @@ test_spawn_refuses_a_copy_another_task_claims() {
   expect_code 1 "$status" "spawn should refuse a copy another task already claims: $out"
   assert_contains "$out" "task other-task claims" "the refusal did not name the claiming task"
   assert_absent "$case_dir/home/state/$id.meta" "a refused spawn still published task metadata"
-  assert_absent "$case_dir/treehouse.log" "spawn asked Treehouse to recycle a copy already claimed by legacy metadata"
+  assert_no_grep 'get --lease' "$case_dir/treehouse.log" \
+    "spawn asked Treehouse to recycle a copy already claimed by legacy metadata"
   [ "$(git -C "$case_dir/pool" rev-parse HEAD)" = "$pool_head" ] \
     || fail "the refused spawn reset the other task's copy before refusing"
   [ "$(git -C "$case_dir/pool" rev-parse --abbrev-ref HEAD)" = "fm/other-task" ] \
@@ -471,7 +470,8 @@ test_spawn_refuses_ambiguous_worktree_metadata() {
   expect_code 1 "$status" "spawn should fail closed on ambiguous worktree metadata"
   assert_contains "$out" "ambiguous worktree metadata" "the refusal did not identify the ambiguous ownership record"
   assert_absent "$case_dir/home/state/$id.meta" "ambiguous metadata still allowed a second owner record"
-  assert_absent "$case_dir/treehouse.log" "ambiguous metadata was checked only after requesting a lease"
+  assert_no_grep 'get --lease' "$case_dir/treehouse.log" \
+    "ambiguous metadata was checked only after requesting a lease"
   [ "$(git -C "$case_dir/pool" rev-parse HEAD)" = "$pool_head" ] \
     || fail "ambiguous metadata allowed spawn to reset the claimed copy"
   [ "$(git -C "$case_dir/pool" rev-parse --abbrev-ref HEAD)" = "fm/ambiguous-owner" ] \
@@ -509,6 +509,33 @@ SH
   assert_absent "$case_dir/home/state/$id.meta" \
     "the owner-conflict refusal published a second custody record"
   pass "a post-acquire owner conflict preserves the contested lease"
+}
+
+test_spawn_does_not_return_a_published_lease_on_signal() {
+  local case_dir id out status real_mv
+  id='custody-published-signal-r3'
+  case_dir=$(make_spawn_case spawn-published-signal "$id")
+  real_mv=$(command -v mv)
+  cat > "$case_dir/fakebin/mv" <<SH
+#!/usr/bin/env bash
+"$real_mv" "\$@" || exit \$?
+case " \$* " in
+  *" $case_dir/home/state/$id.meta ") kill -TERM "\$PPID" ;;
+esac
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/mv"
+
+  out=$(run_spawn_case "$case_dir" "$id" --mode no-mistakes --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "the publication-boundary signal fixture did not stop spawn"
+  assert_present "$case_dir/home/state/$id.meta" \
+    "the signal fixture did not publish durable custody before stopping spawn"
+  assert_grep "treehouse_lease_holder=$id" "$case_dir/home/state/$id.meta" \
+    "the published record did not own the acquired durable lease"
+  assert_no_grep "return --force" "$case_dir/treehouse.log" \
+    "abort cleanup returned a lease after its custody record was published"
+  pass "a signal after atomic publication cannot return the published lease"
 }
 
 test_fresh_spawn_refuses_an_existing_task_record_before_side_effects() {
@@ -579,9 +606,12 @@ add_release_step() {  # <case-dir> <exit>
   printf '{\n  "name": "fixture",\n  "scripts": {\n    "pool:release-delivered": "node release.js"\n  }\n}\n' \
     > "$case_dir/project/package.json"
   git -C "$case_dir/project" add package.json
+  git -C "$case_dir/project" commit -qm "publish release housekeeping"
   cat > "$case_dir/fakebin/npm" <<SH
 #!/usr/bin/env bash
 if [ "\${1:-}" = run ] && [ "\${2:-}" = pool:release-delivered ]; then
+  printf '%s\n' "\$PWD" > "$case_dir/release-run-dir.log"
+  touch "\$PWD/release-artifact"
   printf '%s\\n' "\$*" >> "$case_dir/release.log"
   printf 'released 2 delivered copies\\n'
   exit $exit_code
@@ -596,6 +626,7 @@ add_hanging_release_step() {  # <case-dir>
   printf '{\n  "name": "fixture",\n  "scripts": {\n    "pool:release-delivered": "node release.js"\n  }\n}\n' \
     > "$case_dir/project/package.json"
   git -C "$case_dir/project" add package.json
+  git -C "$case_dir/project" commit -qm "publish hanging release housekeeping"
   cat > "$case_dir/fakebin/npm" <<SH
 #!/usr/bin/env bash
 if [ "\${1:-}" = run ] && [ "\${2:-}" = pool:release-delivered ]; then
@@ -608,7 +639,7 @@ SH
 }
 
 test_spawn_releases_delivered_copies_before_leasing() {
-  local case_dir id out status
+  local case_dir id out status run_dir
   id='custody-release-r1'
   case_dir=$(make_spawn_case spawn-release "$id")
   add_release_step "$case_dir" 0
@@ -619,7 +650,16 @@ test_spawn_releases_delivered_copies_before_leasing() {
   assert_present "$case_dir/release.log" "spawn never asked the project to release delivered copies"
   grep -qF -- '--yes' "$case_dir/release.log" \
     || fail "the release step was not run non-interactively"
-  pass "a spawn releases the project's delivered copies before asking for a slot"
+  run_dir=$(cat "$case_dir/release-run-dir.log")
+  [ "$run_dir" != "$case_dir/project" ] \
+    || fail "the release step executed inside the primary clone"
+  assert_absent "$case_dir/project/release-artifact" \
+    "the release step mutated the primary clone"
+  assert_absent "$run_dir" \
+    "the authenticated release snapshot was not cleaned up"
+  [ -z "$(git -C "$case_dir/project" status --porcelain)" ] \
+    || fail "release housekeeping dirtied the primary clone"
+  pass "a spawn runs release housekeeping from an authenticated isolated copy"
 }
 
 test_spawn_skips_projects_that_publish_no_release_step() {
@@ -1207,6 +1247,7 @@ test_spawn_refuses_a_copy_another_task_claims
 test_spawn_refuses_ambiguous_worktree_metadata
 test_spawn_returns_a_lease_when_endpoint_confirmation_fails
 test_spawn_preserves_a_post_acquire_owner_conflict
+test_spawn_does_not_return_a_published_lease_on_signal
 test_fresh_spawn_refuses_an_existing_task_record_before_side_effects
 test_spawn_claims_this_homes_pool_root_before_leasing
 test_spawn_releases_delivered_copies_before_leasing

--- a/tests/fm-worktree-custody.test.sh
+++ b/tests/fm-worktree-custody.test.sh
@@ -132,6 +132,29 @@ test_pool_root_refuses_to_write_inside_the_primary_clone() {
   pass "a pool root inside the primary clone is rejected before any mutation"
 }
 
+test_relative_pool_root_base_is_refused_before_mutation() {
+  local case_dir clone out_a out_b status_a status_b
+  case_dir=$(make_two_homes_one_project relative-root-refused)
+  clone="$case_dir/homeA/project"
+  mkdir -p "$case_dir/cwd-a" "$case_dir/cwd-b"
+
+  out_a=$(cd "$case_dir/cwd-a" && FM_HOME="$case_dir/homeA" \
+    FM_POOL_ROOT_BASE=relative-pools "$POOL_ROOT_BIN" "$clone" 2>&1)
+  status_a=$?
+  out_b=$(cd "$case_dir/cwd-b" && FM_HOME="$case_dir/homeA" \
+    FM_POOL_ROOT_BASE=relative-pools "$POOL_ROOT_BIN" "$clone" 2>&1)
+  status_b=$?
+  expect_code 1 "$status_a" "a relative pool base must be refused from the first directory"
+  expect_code 1 "$status_b" "a relative pool base must be refused from the second directory"
+  assert_contains "$out_a" "must be absolute" "the first relative-base refusal did not identify the stable-path requirement"
+  assert_contains "$out_b" "must be absolute" "the second relative-base refusal did not identify the stable-path requirement"
+  assert_absent "$case_dir/cwd-a/relative-pools" "the first refusal created a cwd-relative pool"
+  assert_absent "$case_dir/cwd-b/relative-pools" "the second refusal created a cwd-relative pool"
+  assert_absent "$case_dir/homeA/state/treehouse-config" \
+    "the relative-base refusal created a generated config view"
+  pass "relative pool bases cannot split one home's pool by working directory"
+}
+
 test_pool_root_is_idempotent_without_mutating_the_clone() {
   local case_dir clone config before after
   case_dir=$(make_two_homes_one_project idempotent)
@@ -419,6 +442,38 @@ SH
   assert_absent "$case_dir/home/state/$id.meta" \
     "spawn published custody metadata for an unconfirmed endpoint"
   pass "an acquired lease is returned when endpoint confirmation fails"
+}
+
+test_spawn_defers_a_signal_until_acquired_lease_custody_is_armed() {
+  local case_dir id out status wrapper
+  id='custody-acquire-signal-r4'
+  case_dir=$(make_spawn_case spawn-acquire-signal "$id")
+  wrapper="$case_dir/spawn-wrapper"
+  cat > "$wrapper" <<SH
+#!/usr/bin/env bash
+export FM_TEST_SPAWN_PID=\$\$
+exec "$SPAWN" "\$@"
+SH
+  cat > "$case_dir/fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$case_dir/treehouse.log"
+if [ "\${1:-}" = get ]; then
+  : > "$case_dir/lease-acquired"
+  kill -TERM "\${FM_TEST_SPAWN_PID:?}"
+  printf '%s\n' "$case_dir/pool"
+fi
+SH
+  chmod +x "$wrapper" "$case_dir/fakebin/treehouse"
+
+  out=$(SPAWN="$wrapper" run_spawn_case "$case_dir" "$id" --mode no-mistakes --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "the acquisition-boundary signal fixture did not stop spawn"
+  assert_present "$case_dir/lease-acquired" "the signal fixture did not acquire a durable lease"
+  assert_grep "return --force $case_dir/pool" "$case_dir/treehouse.log" \
+    "spawn leaked a lease interrupted before its path reached the parent"
+  assert_absent "$case_dir/home/state/$id.meta" \
+    "spawn published custody metadata after an acquisition-boundary signal"
+  pass "an acquisition-boundary signal returns the synchronously acquired lease"
 }
 
 test_spawn_refuses_a_copy_another_task_claims() {
@@ -1236,6 +1291,7 @@ SH
 test_two_homes_configure_distinct_pool_roots
 test_literal_pool_root_override_is_refused
 test_pool_root_refuses_to_write_inside_the_primary_clone
+test_relative_pool_root_base_is_refused_before_mutation
 test_pool_root_is_idempotent_without_mutating_the_clone
 test_pool_root_preserves_a_tracked_primary_config
 test_pool_root_preserves_a_nonregular_primary_config
@@ -1246,6 +1302,7 @@ test_real_treehouse_accepts_encoded_pool_paths
 test_spawn_refuses_a_copy_another_task_claims
 test_spawn_refuses_ambiguous_worktree_metadata
 test_spawn_returns_a_lease_when_endpoint_confirmation_fails
+test_spawn_defers_a_signal_until_acquired_lease_custody_is_armed
 test_spawn_preserves_a_post_acquire_owner_conflict
 test_spawn_does_not_return_a_published_lease_on_signal
 test_fresh_spawn_refuses_an_existing_task_record_before_side_effects

--- a/tests/fm-worktree-custody.test.sh
+++ b/tests/fm-worktree-custody.test.sh
@@ -1,0 +1,451 @@
+#!/usr/bin/env bash
+# Regression tests for single-owner custody of a pooled working copy.
+#
+# Treehouse keys a worktree pool by the repository, not by the checkout, and
+# re-leases a slot as soon as the shell that held it is gone. Two firstmate
+# homes that clone the same project therefore draw from ONE pool while neither
+# can see the other's task records, so a slot one home's task still names gets
+# handed to the other home - and whichever task is cleaned up first hard-resets
+# the copy the other is working in.
+#
+# Three guarantees close that, and each is pinned here:
+#   (a) every home leases from its OWN pool root (bin/fm-pool-root.sh, wired
+#       into bin/fm-spawn.sh before the slot is acquired);
+#   (b) a spawn refuses a copy another task in this home already claims
+#       (bin/fm-spawn.sh), before the base refresh touches it;
+#   (c) cleanup refuses when the project's own custody check reports the copy
+#       is not this task's to discard (bin/fm-teardown.sh);
+#   (d) a spawn asks the project to release its delivered copies before leasing,
+#       so a pool exhausted by copies nobody handed back does not block dispatch
+#       (bin/fm-spawn.sh) - capacity, so a failure warns and the spawn continues.
+#
+# (a) is proven twice: portably against the configuration firstmate writes, and
+# - where the real binary is installed - against treehouse itself allocating
+# two clones of one origin, which is the vendor fact the whole class rests on.
+set -u
+
+# shellcheck source=tests/lib.sh disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+fm_git_identity fmtest fmtest@example.invalid
+
+POOL_ROOT_BIN="$ROOT/bin/fm-pool-root.sh"
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TEARDOWN="$ROOT/bin/fm-teardown.sh"
+TMP_ROOT=$(fm_test_tmproot fm-worktree-custody)
+
+# --- (a) one pool root per home ---------------------------------------------
+
+pool_root_for_home() {  # <home> <base> <project>
+  FM_HOME="$1" FM_POOL_ROOT_BASE="$2" "$POOL_ROOT_BIN" "$3"
+}
+
+configured_root_of() {  # <clone>
+  sed -n 's/^root[[:space:]]*=[[:space:]]*"\(.*\)"$/\1/p' "$1/treehouse.toml" | head -1
+}
+
+make_two_homes_one_project() {  # <name>
+  local name=$1 case_dir
+  case_dir="$TMP_ROOT/$name"
+  mkdir -p "$case_dir/homeA" "$case_dir/homeB" "$case_dir/base"
+  fm_git_init_commit "$case_dir/upstream"
+  git clone --quiet --bare "$case_dir/upstream" "$case_dir/origin.git"
+  git clone --quiet "$case_dir/origin.git" "$case_dir/homeA/project"
+  git clone --quiet "$case_dir/origin.git" "$case_dir/homeB/project"
+  printf '%s\n' "$case_dir"
+}
+
+test_two_homes_configure_distinct_pool_roots() {
+  local case_dir root_a root_b
+  case_dir=$(make_two_homes_one_project distinct-roots)
+
+  root_a=$(pool_root_for_home "$case_dir/homeA" "$case_dir/base" "$case_dir/homeA/project") \
+    || fail "fm-pool-root.sh failed for the first home"
+  root_b=$(pool_root_for_home "$case_dir/homeB" "$case_dir/base" "$case_dir/homeB/project") \
+    || fail "fm-pool-root.sh failed for the second home"
+
+  [ -n "$root_a" ] && [ -n "$root_b" ] || fail "fm-pool-root.sh printed no pool root"
+  [ "$root_a" != "$root_b" ] \
+    || fail "two homes cloning one project resolved the SAME pool root ($root_a)"
+  [ -d "$root_a" ] && [ -d "$root_b" ] || fail "fm-pool-root.sh did not create the pool roots"
+  [ "$(configured_root_of "$case_dir/homeA/project")" = "$root_a" ] \
+    || fail "the first home's clone does not carry its own pool root"
+  [ "$(configured_root_of "$case_dir/homeB/project")" = "$root_b" ] \
+    || fail "the second home's clone does not carry its own pool root"
+  pass "two homes cloning one project configure distinct treehouse pool roots"
+}
+
+test_pool_root_is_idempotent_and_preserves_other_keys() {
+  local case_dir clone before after root
+  case_dir=$(make_two_homes_one_project idempotent)
+  clone="$case_dir/homeA/project"
+  printf 'max_trees = 20\nroot = ""\n\n# keep this comment\n' > "$clone/treehouse.toml"
+
+  root=$(pool_root_for_home "$case_dir/homeA" "$case_dir/base" "$clone") \
+    || fail "fm-pool-root.sh failed on an existing treehouse.toml"
+  [ "$(configured_root_of "$clone")" = "$root" ] || fail "an existing empty root was not replaced"
+  assert_grep 'max_trees = 20' "$clone/treehouse.toml" "max_trees was dropped"
+  assert_grep 'keep this comment' "$clone/treehouse.toml" "an unrelated line was dropped"
+
+  before=$(cksum < "$clone/treehouse.toml")
+  pool_root_for_home "$case_dir/homeA" "$case_dir/base" "$clone" >/dev/null \
+    || fail "a repeat run of fm-pool-root.sh failed"
+  after=$(cksum < "$clone/treehouse.toml")
+  [ "$before" = "$after" ] || fail "a repeat run rewrote an already-correct treehouse.toml"
+
+  grep -qxF 'treehouse.toml' "$clone/.git/info/exclude" \
+    || fail "the pool config was not excluded from the clone"
+  [ -z "$(git -C "$clone" status --porcelain)" ] \
+    || fail "writing the pool root left the clone dirty"
+  pass "the pool root is written idempotently, preserves other keys, and never dirties the clone"
+}
+
+test_pool_root_refuses_a_tracked_config() {
+  local case_dir clone out status
+  case_dir=$(make_two_homes_one_project tracked-config)
+  clone="$case_dir/homeA/project"
+  printf 'max_trees = 20\nroot = "/somewhere/shared"\n' > "$clone/treehouse.toml"
+  git -C "$clone" add treehouse.toml
+  git -C "$clone" commit -qm "track treehouse.toml"
+
+  out=$(pool_root_for_home "$case_dir/homeA" "$case_dir/base" "$clone" 2>&1)
+  status=$?
+  expect_code 1 "$status" "a tracked treehouse.toml should refuse, not be rewritten"
+  assert_contains "$out" "tracks treehouse.toml" "the refusal did not name the tracked config"
+  assert_grep '/somewhere/shared' "$clone/treehouse.toml" "a tracked config was rewritten anyway"
+  [ -z "$(git -C "$clone" status --porcelain)" ] || fail "the refusal left project content modified"
+  pass "a project that tracks treehouse.toml is refused rather than rewritten"
+}
+
+# The vendor fact the class rests on: treehouse hands two clones of one origin
+# slots from the SAME pool, and only `root` moves that pool. Self-skipping,
+# because the pool allocator is a third-party binary CI installs only for the
+# lanes that need it (bin/fm-install-treehouse.sh).
+test_real_treehouse_stops_sharing_a_pool_between_homes() {
+  local case_dir shared lease_a lease_b pool_a pool_b root_a root_b
+  if ! command -v treehouse >/dev/null 2>&1; then
+    printf 'ok - SKIP real-treehouse pool separation (treehouse not installed)\n'
+    return 0
+  fi
+  case_dir=$(make_two_homes_one_project real-treehouse)
+  shared="$case_dir/shared"
+  mkdir -p "$shared"
+
+  # Before: both clones point at one root, so treehouse pools them together.
+  printf 'max_trees = 5\nroot = "%s"\n' "$shared" > "$case_dir/homeA/project/treehouse.toml"
+  printf 'max_trees = 5\nroot = "%s"\n' "$shared" > "$case_dir/homeB/project/treehouse.toml"
+  lease_a=$( cd "$case_dir/homeA/project" && treehouse get --lease 2>/dev/null )
+  lease_b=$( cd "$case_dir/homeB/project" && treehouse get --lease 2>/dev/null )
+  [ -n "$lease_a" ] && [ -n "$lease_b" ] || fail "treehouse did not lease a worktree to each clone"
+  pool_a=$(dirname "$(dirname "$lease_a")")
+  pool_b=$(dirname "$(dirname "$lease_b")")
+  [ "$pool_a" = "$pool_b" ] \
+    || fail "fixture did not reproduce the shared pool: $pool_a vs $pool_b"
+  ( cd "$case_dir/homeA/project" && treehouse return --force "$lease_a" >/dev/null 2>&1 ) || true
+  ( cd "$case_dir/homeB/project" && treehouse return --force "$lease_b" >/dev/null 2>&1 ) || true
+
+  # After: each home claims its own root and the pools no longer overlap.
+  root_a=$(pool_root_for_home "$case_dir/homeA" "$case_dir/base" "$case_dir/homeA/project")
+  root_b=$(pool_root_for_home "$case_dir/homeB" "$case_dir/base" "$case_dir/homeB/project")
+  lease_a=$( cd "$case_dir/homeA/project" && treehouse get --lease 2>/dev/null )
+  lease_b=$( cd "$case_dir/homeB/project" && treehouse get --lease 2>/dev/null )
+  [ -n "$lease_a" ] && [ -n "$lease_b" ] || fail "treehouse did not lease from the per-home roots"
+  case "$(cd "$(dirname "$lease_a")" && pwd -P)" in "$root_a"/*) ;;
+    *) fail "the first home leased outside its own pool root: $lease_a" ;;
+  esac
+  case "$(cd "$(dirname "$lease_b")" && pwd -P)" in "$root_b"/*) ;;
+    *) fail "the second home leased outside its own pool root: $lease_b" ;;
+  esac
+  ( cd "$case_dir/homeA/project" && treehouse return --force "$lease_a" >/dev/null 2>&1 ) || true
+  ( cd "$case_dir/homeB/project" && treehouse return --force "$lease_b" >/dev/null 2>&1 ) || true
+  pass "real treehouse pools two homes together until each claims its own root"
+}
+
+# --- (b) a spawn never launches a second owner into one copy -----------------
+
+make_spawn_case() {  # <name> <id>
+  local name=$1 id=$2 case_dir fakebin
+  case_dir="$TMP_ROOT/$name"
+  fakebin=$(fm_fakebin "$case_dir")
+  mkdir -p "$case_dir/home/data/$id" "$case_dir/home/projects" \
+    "$case_dir/home/state" "$case_dir/home/config" "$case_dir/base"
+  printf 'codex\n' > "$case_dir/home/config/crew-harness"
+  printf 'brief for %s\n' "$id" > "$case_dir/home/data/$id/brief.md"
+  touch "$case_dir/home/state/.last-watcher-beat"
+
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:?FM_FAKE_PANE_PATH unset}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse
+
+  fm_git_init_commit "$case_dir/upstream"
+  git clone --quiet --bare "$case_dir/upstream" "$case_dir/origin.git"
+  git clone --quiet "$case_dir/origin.git" "$case_dir/project"
+  git -C "$case_dir/project" remote set-head origin --auto >/dev/null 2>&1 || true
+  git -C "$case_dir/project" worktree add --quiet --detach "$case_dir/pool" HEAD
+  printf '%s\n' "$case_dir"
+}
+
+run_spawn_case() {  # <case-dir> <id> <args...>
+  local case_dir=$1 id=$2
+  shift 2
+  FM_ROOT_OVERRIDE='' FM_HOME="$case_dir/home" \
+    FM_STATE_OVERRIDE="$case_dir/home/state" FM_DATA_OVERRIDE="$case_dir/home/data" \
+    FM_PROJECTS_OVERRIDE="$case_dir/home/projects" FM_CONFIG_OVERRIDE="$case_dir/home/config" \
+    FM_POOL_ROOT_BASE="$case_dir/base" \
+    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" FM_FAKE_PANE_PATH="$case_dir/pool" \
+    PATH="$case_dir/fakebin:$PATH" \
+    "$SPAWN" "$id" "$case_dir/project" "$@" 2>&1
+}
+
+test_spawn_refuses_a_copy_another_task_claims() {
+  local case_dir id out status pool_head
+  id='custody-claimed-r1'
+  case_dir=$(make_spawn_case spawn-claimed "$id")
+  # Another task of THIS home already owns that pooled copy and has unlanded work.
+  fm_write_meta "$case_dir/home/state/other-task.meta" \
+    "window=firstmate:fm-other-task" \
+    "worktree=$case_dir/pool" \
+    "project=$case_dir/project" \
+    "kind=ship" \
+    "mode=no-mistakes"
+  git -C "$case_dir/pool" checkout --quiet -b fm/other-task
+  git -C "$case_dir/pool" commit -q --allow-empty -m "other task's unlanded work"
+  pool_head=$(git -C "$case_dir/pool" rev-parse HEAD)
+
+  out=$(run_spawn_case "$case_dir" "$id" --mode no-mistakes --yolo off)
+  status=$?
+  expect_code 1 "$status" "spawn should refuse a copy another task already claims: $out"
+  assert_contains "$out" "other-task already claims" "the refusal did not name the claiming task"
+  assert_absent "$case_dir/home/state/$id.meta" "a refused spawn still published task metadata"
+  [ "$(git -C "$case_dir/pool" rev-parse HEAD)" = "$pool_head" ] \
+    || fail "the refused spawn reset the other task's copy before refusing"
+  [ "$(git -C "$case_dir/pool" rev-parse --abbrev-ref HEAD)" = "fm/other-task" ] \
+    || fail "the refused spawn moved the other task's copy off its branch"
+  pass "a spawn refuses a pooled copy another task claims, leaving that copy untouched"
+}
+
+test_spawn_claims_this_homes_pool_root_before_leasing() {
+  local case_dir id out status base_real
+  id='custody-own-pool-r1'
+  case_dir=$(make_spawn_case spawn-own-pool "$id")
+
+  out=$(run_spawn_case "$case_dir" "$id" --mode no-mistakes --yolo off)
+  status=$?
+  expect_code 0 "$status" "an unclaimed pooled copy should still spawn"
+  assert_contains "$out" "spawned $id" "spawn did not report success"
+  base_real=$(cd "$case_dir/base" && pwd -P)
+  grep -q "^root = \"$base_real/" "$case_dir/project/treehouse.toml" \
+    || fail "spawn did not point the clone at this home's own pool root"
+  pass "a spawn gives the clone this home's own pool root before asking for a slot"
+}
+
+# --- (d) delivered copies are released before a slot is requested ------------
+
+# The project publishes the release step; the runner records that it ran, and
+# reports <exit>.
+add_release_step() {  # <case-dir> <exit>
+  local case_dir=$1 exit_code=$2
+  printf '{\n  "name": "fixture",\n  "scripts": {\n    "pool:release-delivered": "node release.js"\n  }\n}\n' \
+    > "$case_dir/project/package.json"
+  cat > "$case_dir/fakebin/npm" <<SH
+#!/usr/bin/env bash
+if [ "\${1:-}" = run ] && [ "\${2:-}" = pool:release-delivered ]; then
+  printf '%s\\n' "\$*" >> "$case_dir/release.log"
+  printf 'released 2 delivered copies\\n'
+  exit $exit_code
+fi
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/npm"
+}
+
+test_spawn_releases_delivered_copies_before_leasing() {
+  local case_dir id out status
+  id='custody-release-r1'
+  case_dir=$(make_spawn_case spawn-release "$id")
+  add_release_step "$case_dir" 0
+
+  out=$(run_spawn_case "$case_dir" "$id" --mode no-mistakes --yolo off)
+  status=$?
+  expect_code 0 "$status" "a spawn should proceed after releasing delivered copies: $out"
+  assert_present "$case_dir/release.log" "spawn never asked the project to release delivered copies"
+  grep -qF -- '--yes' "$case_dir/release.log" \
+    || fail "the release step was not run non-interactively"
+  pass "a spawn releases the project's delivered copies before asking for a slot"
+}
+
+test_spawn_skips_projects_that_publish_no_release_step() {
+  local case_dir id out status
+  id='custody-no-release-r1'
+  case_dir=$(make_spawn_case spawn-no-release "$id")
+  cat > "$case_dir/fakebin/npm" <<'SH'
+#!/usr/bin/env bash
+printf 'npm must not be invoked for a project without the release step\n' >&2
+exit 1
+SH
+  chmod +x "$case_dir/fakebin/npm"
+
+  out=$(run_spawn_case "$case_dir" "$id" --mode no-mistakes --yolo off)
+  status=$?
+  expect_code 0 "$status" "a project without the release step should spawn unchanged: $out"
+  assert_not_contains "$out" "must not be invoked" "spawn ran a release step the project never published"
+  pass "a project that publishes no release step spawns exactly as before"
+}
+
+test_spawn_continues_when_the_release_step_fails() {
+  local case_dir id out status
+  id='custody-release-fails-r1'
+  case_dir=$(make_spawn_case spawn-release-fails "$id")
+  add_release_step "$case_dir" 3
+
+  out=$(run_spawn_case "$case_dir" "$id" --mode no-mistakes --yolo off)
+  status=$?
+  expect_code 0 "$status" "failed housekeeping must not block a dispatch: $out"
+  assert_contains "$out" "pool:release-delivered failed" "a failed release step was not reported"
+  assert_contains "$out" "spawned $id" "the spawn did not continue after the failed release step"
+  pass "a failed release step warns loudly and never blocks the dispatch"
+}
+
+# --- (c) cleanup refuses when the project says the copy is not ours ----------
+
+make_teardown_case() {  # <name>
+  local name=$1 case_dir fakebin
+  case_dir="$TMP_ROOT/$name"
+  fakebin="$case_dir/fakebin"
+  mkdir -p "$case_dir/state" "$case_dir/config" "$fakebin"
+  fm_fake_exit0 "$fakebin" treehouse tmux
+
+  git init -q --bare "$case_dir/origin.git"
+  git -C "$case_dir/origin.git" symbolic-ref HEAD refs/heads/main
+  git clone -q "$case_dir/origin.git" "$case_dir/_seed" 2>/dev/null
+  git -C "$case_dir/_seed" -c user.email=t@t -c user.name=t commit -q --allow-empty -m baseline
+  git -C "$case_dir/_seed" push -q origin main
+  rm -rf "$case_dir/_seed"
+  git clone -q "$case_dir/origin.git" "$case_dir/project"
+  git -C "$case_dir/project" remote set-head origin main >/dev/null 2>&1 || true
+  git -C "$case_dir/project" worktree add -q -b fm/task-c1 "$case_dir/wt" main
+
+  touch "$case_dir/state/.last-watcher-beat"
+  fm_write_meta "$case_dir/state/task-c1.meta" \
+    "window=firstmate:fm-task-c1" \
+    "endpoint_task_id=task-c1" \
+    "worktree=$case_dir/wt" \
+    "project=$case_dir/project" \
+    "kind=ship" \
+    "mode=no-mistakes"
+  printf '%s\n' "$case_dir"
+}
+
+# The project publishes the check; <exit> is the verdict its runner reports.
+add_custody_check() {  # <case-dir> <exit>
+  local case_dir=$1 exit_code=$2
+  printf '{\n  "name": "fixture",\n  "scripts": {\n    "check:worktree-custody": "node custody.js"\n  }\n}\n' \
+    > "$case_dir/wt/package.json"
+  # Landed, so the existing landed-work verdict passes and custody is what decides.
+  git -C "$case_dir/wt" add package.json
+  git -C "$case_dir/wt" -c user.email=t@t -c user.name=t commit -qm "publish the custody check"
+  git -C "$case_dir/wt" push -q origin fm/task-c1
+  git -C "$case_dir/project" fetch -q origin
+  cat > "$case_dir/fakebin/npm" <<SH
+#!/usr/bin/env bash
+if [ "\${1:-}" = run ] && [ "\${2:-}" = check:worktree-custody ]; then
+  printf 'pushed-not-merged: this copy is still delivering\n'
+  exit $exit_code
+fi
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/npm"
+}
+
+run_teardown_case() {  # <case-dir> <args...>
+  local case_dir=$1
+  shift
+  FM_ROOT_OVERRIDE="$ROOT" \
+  FM_STATE_OVERRIDE="$case_dir/state" \
+  FM_CONFIG_OVERRIDE="$case_dir/config" \
+  PATH="$case_dir/fakebin:$PATH" \
+    "$TEARDOWN" task-c1 "$@" 2>&1
+}
+
+test_teardown_refuses_a_red_custody_verdict() {
+  local case_dir out status
+  case_dir=$(make_teardown_case teardown-custody-red)
+  add_custody_check "$case_dir" 1
+
+  out=$(run_teardown_case "$case_dir")
+  status=$?
+  expect_code 1 "$status" "cleanup should refuse a red custody verdict"
+  assert_contains "$out" "check:worktree-custody" "the refusal did not name the project's check"
+  assert_contains "$out" "pushed-not-merged" "the refusal did not relay what the check reported"
+  assert_present "$case_dir/state/task-c1.meta" "a refused cleanup removed the task record"
+  [ -d "$case_dir/wt" ] || fail "a refused cleanup removed the working copy"
+  pass "cleanup refuses when the project's custody check says the copy is not this task's"
+}
+
+test_teardown_proceeds_on_a_green_custody_verdict() {
+  local case_dir out status
+  case_dir=$(make_teardown_case teardown-custody-green)
+  add_custody_check "$case_dir" 0
+
+  out=$(run_teardown_case "$case_dir")
+  status=$?
+  expect_code 0 "$status" "cleanup should proceed on a green custody verdict: $out"
+  assert_absent "$case_dir/state/task-c1.meta" "a completed cleanup left the task record behind"
+  pass "cleanup proceeds when the project's custody check reports the copy is free"
+}
+
+test_teardown_skips_projects_that_publish_no_check() {
+  local case_dir out status
+  case_dir=$(make_teardown_case teardown-custody-absent)
+  cat > "$case_dir/fakebin/npm" <<'SH'
+#!/usr/bin/env bash
+printf 'npm must not be invoked for a project without the check\n' >&2
+exit 1
+SH
+  chmod +x "$case_dir/fakebin/npm"
+
+  out=$(run_teardown_case "$case_dir")
+  status=$?
+  expect_code 0 "$status" "a project without the check should tear down unchanged: $out"
+  assert_not_contains "$out" "must not be invoked" "cleanup ran a check the project never published"
+  pass "a project that publishes no custody check tears down exactly as before"
+}
+
+test_teardown_refuses_when_a_published_check_cannot_be_run() {
+  local case_dir out status path_without_npm
+  case_dir=$(make_teardown_case teardown-custody-unrunnable)
+  add_custody_check "$case_dir" 0
+  rm -f "$case_dir/fakebin/npm"
+  # A PATH with no npm at all, so the published check cannot be answered.
+  path_without_npm="$case_dir/fakebin"
+
+  out=$(PATH="$path_without_npm:/usr/bin:/bin" run_teardown_case "$case_dir")
+  status=$?
+  expect_code 1 "$status" "an unanswerable custody check should refuse, not pass silently"
+  assert_contains "$out" "REFUSED" "the unanswerable check did not refuse loudly"
+  assert_present "$case_dir/state/task-c1.meta" "a refused cleanup removed the task record"
+  pass "a published custody check that cannot be run refuses instead of tearing down"
+}
+
+test_two_homes_configure_distinct_pool_roots
+test_pool_root_is_idempotent_and_preserves_other_keys
+test_pool_root_refuses_a_tracked_config
+test_real_treehouse_stops_sharing_a_pool_between_homes
+test_spawn_refuses_a_copy_another_task_claims
+test_spawn_claims_this_homes_pool_root_before_leasing
+test_spawn_releases_delivered_copies_before_leasing
+test_spawn_skips_projects_that_publish_no_release_step
+test_spawn_continues_when_the_release_step_fails
+test_teardown_refuses_a_red_custody_verdict
+test_teardown_proceeds_on_a_green_custody_verdict
+test_teardown_skips_projects_that_publish_no_check
+test_teardown_refuses_when_a_published_check_cannot_be_run

--- a/tests/fm-worktree-custody.test.sh
+++ b/tests/fm-worktree-custody.test.sh
@@ -93,6 +93,34 @@ test_two_homes_configure_distinct_pool_roots() {
   pass "two homes configure distinct roots outside their primary clones"
 }
 
+test_legacy_hash_collision_homes_resolve_distinct_pool_roots() {
+  local parent_a=/private/tmp/fm-home-collision-8782
+  local parent_b=/private/tmp/fm-home-collision-68310
+  local home_a="$parent_a/home" home_b="$parent_b/home"
+  local base="$TMP_ROOT/collision-base" status
+  if [ ! -d /private/tmp ] || [ ! -w /private/tmp ]; then
+    printf 'skip - exact canonical collision paths are unavailable on this platform\n'
+    return 0
+  fi
+
+  (
+    [ ! -e "$parent_a" ] && [ ! -L "$parent_a" ] || exit 2
+    [ ! -e "$parent_b" ] && [ ! -L "$parent_b" ] || exit 2
+    trap 'rmdir "$home_a" "$home_b" "$parent_a" "$parent_b" 2>/dev/null || true' EXIT
+    mkdir "$parent_a" "$parent_b" || exit 3
+    mkdir "$home_a" "$home_b" || exit 3
+    root_a=$(FM_HOME="$home_a" FM_POOL_ROOT_BASE="$base" "$POOL_ROOT_BIN" --print) \
+      || exit 4
+    root_b=$(FM_HOME="$home_b" FM_POOL_ROOT_BASE="$base" "$POOL_ROOT_BIN" --print) \
+      || exit 4
+    [ "$root_a" != "$root_b" ] || exit 5
+  )
+  status=$?
+  expect_code 0 "$status" \
+    "the exact homes sharing legacy prefix 5edc853f must resolve distinct pool roots"
+  pass "full home identities separate the exact legacy hash collision"
+}
+
 test_literal_pool_root_override_is_refused() {
   local case_dir shared out_a out_b status_a status_b
   case_dir=$(make_two_homes_one_project literal-root-refused)
@@ -1289,6 +1317,7 @@ SH
 }
 
 test_two_homes_configure_distinct_pool_roots
+test_legacy_hash_collision_homes_resolve_distinct_pool_roots
 test_literal_pool_root_override_is_refused
 test_pool_root_refuses_to_write_inside_the_primary_clone
 test_relative_pool_root_base_is_refused_before_mutation

--- a/tests/fm-worktree-custody.test.sh
+++ b/tests/fm-worktree-custody.test.sh
@@ -8,7 +8,7 @@
 # handed to the other home - and whichever task is cleaned up first hard-resets
 # the copy the other is working in.
 #
-# Three guarantees close that, and each is pinned here:
+# Four guarantees close that, and each is pinned here:
 #   (a) every home leases from its OWN pool root (bin/fm-pool-root.sh, wired
 #       into bin/fm-spawn.sh before the slot is acquired);
 #   (b) a spawn refuses a copy another task in this home already claims

--- a/tests/fm-worktree-custody.test.sh
+++ b/tests/fm-worktree-custody.test.sh
@@ -40,8 +40,8 @@ pool_root_for_home() {  # <home> <base> <project>
   FM_HOME="$1" FM_POOL_ROOT_BASE="$2" "$POOL_ROOT_BIN" "$3"
 }
 
-configured_root_of() {  # <clone>
-  sed -n 's/^root[[:space:]]*=[[:space:]]*"\(.*\)"$/\1/p' "$1/treehouse.toml" | head -1
+pool_config_view_for_home() {  # <home> <base> <project>
+  FM_HOME="$1" FM_POOL_ROOT_BASE="$2" "$POOL_ROOT_BIN" --view "$3"
 }
 
 file_mode() {  # <path>
@@ -64,7 +64,7 @@ make_two_homes_one_project() {  # <name>
 }
 
 test_two_homes_configure_distinct_pool_roots() {
-  local case_dir root_a root_b
+  local case_dir root_a root_b config_a config_b
   case_dir=$(make_two_homes_one_project distinct-roots)
 
   root_a=$(pool_root_for_home "$case_dir/homeA" "$case_dir/base" "$case_dir/homeA/project") \
@@ -76,11 +76,17 @@ test_two_homes_configure_distinct_pool_roots() {
   [ "$root_a" != "$root_b" ] \
     || fail "two homes cloning one project resolved the SAME pool root ($root_a)"
   [ -d "$root_a" ] && [ -d "$root_b" ] || fail "fm-pool-root.sh did not create the pool roots"
-  [ "$(configured_root_of "$case_dir/homeA/project")" = "$root_a" ] \
-    || fail "the first home's clone does not carry its own pool root"
-  [ "$(configured_root_of "$case_dir/homeB/project")" = "$root_b" ] \
-    || fail "the second home's clone does not carry its own pool root"
-  pass "two homes cloning one project configure distinct treehouse pool roots"
+  config_a=$(pool_config_view_for_home "$case_dir/homeA" "$case_dir/base" "$case_dir/homeA/project")
+  config_b=$(pool_config_view_for_home "$case_dir/homeB" "$case_dir/base" "$case_dir/homeB/project")
+  assert_present "$config_a/treehouse.toml" "the first home has no generated Treehouse config"
+  assert_present "$config_b/treehouse.toml" "the second home has no generated Treehouse config"
+  assert_absent "$case_dir/homeA/project/treehouse.toml" "pool setup mutated the first primary clone"
+  assert_absent "$case_dir/homeB/project/treehouse.toml" "pool setup mutated the second primary clone"
+  [ -z "$(git -C "$case_dir/homeA/project" status --porcelain)" ] \
+    || fail "pool setup dirtied the first primary clone"
+  [ -z "$(git -C "$case_dir/homeB/project" status --porcelain)" ] \
+    || fail "pool setup dirtied the second primary clone"
+  pass "two homes configure distinct roots outside their primary clones"
 }
 
 test_literal_pool_root_override_is_refused() {
@@ -102,32 +108,25 @@ test_literal_pool_root_override_is_refused() {
   pass "a literal pool root override cannot disable per-home isolation"
 }
 
-test_pool_root_is_idempotent_and_preserves_other_keys() {
-  local case_dir clone before after root
+test_pool_root_is_idempotent_without_mutating_the_clone() {
+  local case_dir clone config before after
   case_dir=$(make_two_homes_one_project idempotent)
   clone="$case_dir/homeA/project"
-  printf 'max_trees = 20\nroot = ""\n\n# keep this comment\n' > "$clone/treehouse.toml"
-
-  root=$(pool_root_for_home "$case_dir/homeA" "$case_dir/base" "$clone") \
-    || fail "fm-pool-root.sh failed on an existing treehouse.toml"
-  [ "$(configured_root_of "$clone")" = "$root" ] || fail "an existing empty root was not replaced"
-  assert_grep 'max_trees = 20' "$clone/treehouse.toml" "max_trees was dropped"
-  assert_grep 'keep this comment' "$clone/treehouse.toml" "an unrelated line was dropped"
-
-  before=$(cksum < "$clone/treehouse.toml")
+  pool_root_for_home "$case_dir/homeA" "$case_dir/base" "$clone" >/dev/null \
+    || fail "fm-pool-root.sh failed on its first generated config"
+  config="$(pool_config_view_for_home "$case_dir/homeA" "$case_dir/base" "$clone")/treehouse.toml"
+  before=$(cksum < "$config")
   pool_root_for_home "$case_dir/homeA" "$case_dir/base" "$clone" >/dev/null \
     || fail "a repeat run of fm-pool-root.sh failed"
-  after=$(cksum < "$clone/treehouse.toml")
-  [ "$before" = "$after" ] || fail "a repeat run rewrote an already-correct treehouse.toml"
-
-  grep -qxF 'treehouse.toml' "$clone/.git/info/exclude" \
-    || fail "the pool config was not excluded from the clone"
+  after=$(cksum < "$config")
+  [ "$before" = "$after" ] || fail "a repeat run rewrote an already-correct generated config"
+  assert_absent "$clone/treehouse.toml" "idempotent pool setup wrote into the primary clone"
   [ -z "$(git -C "$clone" status --porcelain)" ] \
-    || fail "writing the pool root left the clone dirty"
-  pass "the pool root is written idempotently, preserves other keys, and never dirties the clone"
+    || fail "idempotent pool setup dirtied the primary clone"
+  pass "the generated pool config is idempotent and never mutates the primary clone"
 }
 
-test_pool_root_refuses_a_tracked_config() {
+test_pool_root_preserves_a_tracked_primary_config() {
   local case_dir clone out status
   case_dir=$(make_two_homes_one_project tracked-config)
   clone="$case_dir/homeA/project"
@@ -137,14 +136,13 @@ test_pool_root_refuses_a_tracked_config() {
 
   out=$(pool_root_for_home "$case_dir/homeA" "$case_dir/base" "$clone" 2>&1)
   status=$?
-  expect_code 1 "$status" "a tracked treehouse.toml should refuse, not be rewritten"
-  assert_contains "$out" "tracks treehouse.toml" "the refusal did not name the tracked config"
+  expect_code 0 "$status" "an isolated config view should not rewrite or reject tracked project config: $out"
   assert_grep '/somewhere/shared' "$clone/treehouse.toml" "a tracked config was rewritten anyway"
   [ -z "$(git -C "$clone" status --porcelain)" ] || fail "the refusal left project content modified"
-  pass "a project that tracks treehouse.toml is refused rather than rewritten"
+  pass "a tracked primary treehouse.toml remains untouched and outside dispatch authority"
 }
 
-test_pool_root_refuses_a_nonregular_config() {
+test_pool_root_preserves_a_nonregular_primary_config() {
   local case_dir clone out status
   case_dir=$(make_two_homes_one_project nonregular-config)
   clone="$case_dir/homeA/project"
@@ -153,14 +151,13 @@ test_pool_root_refuses_a_nonregular_config() {
 
   out=$(pool_root_for_home "$case_dir/homeA" "$case_dir/base" "$clone" 2>&1)
   status=$?
-  expect_code 1 "$status" "a nonregular treehouse.toml should refuse before configuration"
-  assert_contains "$out" "not a regular file" "the refusal did not identify the invalid config path"
+  expect_code 0 "$status" "an isolated config view should not inspect or rewrite the primary config path: $out"
   assert_present "$clone/treehouse.toml/preserved" "the invalid config path was modified"
-  pass "a nonregular treehouse config is refused without modification"
+  pass "a nonregular primary config path remains untouched by dispatch"
 }
 
 test_pool_root_verifies_the_written_config() {
-  local case_dir clone fakebin out status
+  local case_dir clone fakebin out status generated
   case_dir=$(make_two_homes_one_project verify-written-config)
   clone="$case_dir/homeA/project"
   fakebin=$(fm_fakebin "$case_dir")
@@ -174,49 +171,11 @@ SH
     PATH="$fakebin:$PATH" "$POOL_ROOT_BIN" "$clone" 2>&1)
   status=$?
   expect_code 1 "$status" "pool configuration should refuse when its write did not take effect"
-  assert_contains "$out" "could not verify" "the failed write postcondition was not reported"
-  assert_absent "$clone/treehouse.toml" "the no-op writer unexpectedly configured a pool root"
+  assert_contains "$out" "could not write and verify" "the failed write postcondition was not reported"
+  generated=$(find "$case_dir/homeA/state/treehouse-config" -name treehouse.toml -print -quit 2>/dev/null || true)
+  [ -z "$generated" ] || fail "the no-op writer unexpectedly configured a pool root"
+  assert_absent "$clone/treehouse.toml" "the failed generated write mutated the primary clone"
   pass "pool configuration verifies the root that was actually written"
-}
-
-test_pool_root_refuses_when_git_exclude_cannot_be_written() {
-  local case_dir clone out status
-  case_dir=$(make_two_homes_one_project unwritable-exclude)
-  clone="$case_dir/homeA/project"
-  chmod 0444 "$clone/.git/info/exclude"
-
-  out=$(pool_root_for_home "$case_dir/homeA" "$case_dir/base" "$clone" 2>&1)
-  status=$?
-  chmod 0644 "$clone/.git/info/exclude"
-  expect_code 1 "$status" "pool configuration should refuse when info/exclude cannot be written"
-  assert_contains "$out" "could not exclude treehouse.toml" "the failed Git exclusion was not reported"
-  assert_absent "$clone/treehouse.toml" "a failed Git exclusion left the new local config behind"
-  if git -C "$clone" check-ignore -q -- treehouse.toml; then
-    fail "the refused configuration unexpectedly left treehouse.toml ignored"
-  fi
-  pass "failed Git exclusion removes a newly created pool config"
-}
-
-test_pool_root_restores_existing_config_when_git_exclude_fails() {
-  local case_dir clone out status before_bytes before_mode
-  case_dir=$(make_two_homes_one_project restore-config-after-exclude)
-  clone="$case_dir/homeA/project"
-  printf 'max_trees = 7\nroot = "/shared/original"\n' > "$clone/treehouse.toml"
-  chmod 0600 "$clone/treehouse.toml"
-  before_bytes=$(cksum < "$clone/treehouse.toml")
-  before_mode=$(file_mode "$clone/treehouse.toml")
-  chmod 0444 "$clone/.git/info/exclude"
-
-  out=$(pool_root_for_home "$case_dir/homeA" "$case_dir/base" "$clone" 2>&1)
-  status=$?
-  chmod 0644 "$clone/.git/info/exclude"
-  expect_code 1 "$status" "pool configuration should refuse when an existing config cannot be excluded"
-  assert_contains "$out" "could not exclude treehouse.toml" "the existing-config exclusion failure was not reported"
-  [ "$(cksum < "$clone/treehouse.toml")" = "$before_bytes" ] \
-    || fail "the failed exclusion did not restore the previous config bytes"
-  [ "$(file_mode "$clone/treehouse.toml")" = "$before_mode" ] \
-    || fail "the failed exclusion did not restore the previous config mode"
-  pass "failed Git exclusion restores existing config bytes and mode"
 }
 
 # The vendor fact the class rests on: treehouse hands two clones of one origin
@@ -224,7 +183,7 @@ test_pool_root_restores_existing_config_when_git_exclude_fails() {
 # because the pool allocator is a third-party binary CI installs only for the
 # lanes that need it (bin/fm-install-treehouse.sh).
 test_real_treehouse_stops_sharing_a_pool_between_homes() {
-  local case_dir shared lease_a lease_b pool_a pool_b root_a root_b
+  local case_dir shared lease_a lease_b pool_a pool_b root_a root_b config_a config_b
   if ! command -v treehouse >/dev/null 2>&1; then
     printf 'ok - SKIP real-treehouse pool separation (treehouse not installed)\n'
     return 0
@@ -245,12 +204,15 @@ test_real_treehouse_stops_sharing_a_pool_between_homes() {
     || fail "fixture did not reproduce the shared pool: $pool_a vs $pool_b"
   ( cd "$case_dir/homeA/project" && treehouse return --force "$lease_a" >/dev/null 2>&1 ) || true
   ( cd "$case_dir/homeB/project" && treehouse return --force "$lease_b" >/dev/null 2>&1 ) || true
+  rm -f -- "$case_dir/homeA/project/treehouse.toml" "$case_dir/homeB/project/treehouse.toml"
 
-  # After: each home claims its own root and the pools no longer overlap.
+  # After: each home uses an isolated user config and the pools no longer overlap.
   root_a=$(pool_root_for_home "$case_dir/homeA" "$case_dir/base" "$case_dir/homeA/project")
   root_b=$(pool_root_for_home "$case_dir/homeB" "$case_dir/base" "$case_dir/homeB/project")
-  lease_a=$( cd "$case_dir/homeA/project" && treehouse get --lease 2>/dev/null )
-  lease_b=$( cd "$case_dir/homeB/project" && treehouse get --lease 2>/dev/null )
+  config_a=$(pool_config_view_for_home "$case_dir/homeA" "$case_dir/base" "$case_dir/homeA/project")
+  config_b=$(pool_config_view_for_home "$case_dir/homeB" "$case_dir/base" "$case_dir/homeB/project")
+  lease_a=$( cd "$config_a" && treehouse get --lease 2>/dev/null )
+  lease_b=$( cd "$config_b" && treehouse get --lease 2>/dev/null )
   [ -n "$lease_a" ] && [ -n "$lease_b" ] || fail "treehouse did not lease from the per-home roots"
   case "$(cd "$(dirname "$lease_a")" && pwd -P)" in "$root_a"/*) ;;
     *) fail "the first home leased outside its own pool root: $lease_a" ;;
@@ -263,10 +225,31 @@ test_real_treehouse_stops_sharing_a_pool_between_homes() {
   pass "real treehouse pools two homes together until each claims its own root"
 }
 
+test_real_treehouse_accepts_encoded_pool_paths() {
+  local case_dir special_base root config_home lease
+  if ! command -v treehouse >/dev/null 2>&1; then
+    printf 'ok - SKIP real-treehouse encoded pool path (treehouse not installed)\n'
+    return 0
+  fi
+  case_dir=$(make_two_homes_one_project encoded-root)
+  special_base="$case_dir/"$'pool"back\\slash\nline'
+  mkdir -p "$special_base"
+  root=$(pool_root_for_home "$case_dir/homeA" "$special_base" "$case_dir/homeA/project") \
+    || fail "fm-pool-root.sh rejected a valid filesystem path requiring TOML escapes"
+  config_home=$(pool_config_view_for_home "$case_dir/homeA" "$special_base" "$case_dir/homeA/project")
+  lease=$(cd "$config_home" && treehouse get --lease 2>/dev/null) \
+    || fail "treehouse could not consume the safely encoded pool path"
+  case "$lease" in "$root"/*) ;;
+    *) fail "treehouse interpreted the encoded pool root differently: $lease" ;;
+  esac
+  treehouse return --force "$lease" >/dev/null 2>&1 || true
+  pass "valid filesystem paths are encoded into Treehouse-consumable TOML"
+}
+
 # --- (b) a spawn never launches a second owner into one copy -----------------
 
 make_spawn_case() {  # <name> <id>
-  local name=$1 id=$2 case_dir fakebin
+  local name=$1 id=$2 case_dir fakebin pool_root pool_worktree
   case_dir="$TMP_ROOT/$name"
   fakebin=$(fm_fakebin "$case_dir")
   mkdir -p "$case_dir/home/data/$id" "$case_dir/home/projects" \
@@ -293,7 +276,12 @@ SH
   git clone --quiet --bare "$case_dir/upstream" "$case_dir/origin.git"
   git clone --quiet "$case_dir/origin.git" "$case_dir/project"
   git -C "$case_dir/project" remote set-head origin --auto >/dev/null 2>&1 || true
-  git -C "$case_dir/project" worktree add --quiet --detach "$case_dir/pool" HEAD
+  pool_root=$(FM_HOME="$case_dir/home" FM_POOL_ROOT_BASE="$case_dir/base" \
+    "$POOL_ROOT_BIN" --print)
+  pool_worktree="$pool_root/.treehouse/fixture/1/project"
+  mkdir -p "$(dirname "$pool_worktree")"
+  git -C "$case_dir/project" worktree add --quiet --detach "$pool_worktree" HEAD
+  ln -s "$pool_worktree" "$case_dir/pool"
   printf '%s\n' "$case_dir"
 }
 
@@ -402,7 +390,7 @@ SH
 }
 
 test_spawn_claims_this_homes_pool_root_before_leasing() {
-  local case_dir id out status base_real
+  local case_dir id out status config_home
   id='custody-own-pool-r1'
   case_dir=$(make_spawn_case spawn-own-pool "$id")
 
@@ -410,10 +398,12 @@ test_spawn_claims_this_homes_pool_root_before_leasing() {
   status=$?
   expect_code 0 "$status" "an unclaimed pooled copy should still spawn"
   assert_contains "$out" "spawned $id" "spawn did not report success"
-  base_real=$(cd "$case_dir/base" && pwd -P)
-  grep -q "^root = \"$base_real/" "$case_dir/project/treehouse.toml" \
-    || fail "spawn did not point the clone at this home's own pool root"
-  pass "a spawn gives the clone this home's own pool root before asking for a slot"
+  config_home=$(pool_config_view_for_home "$case_dir/home" "$case_dir/base" "$case_dir/project")
+  assert_present "$config_home/treehouse.toml" "spawn did not generate this home's Treehouse config"
+  assert_absent "$case_dir/project/treehouse.toml" "spawn wrote Treehouse config into the primary clone"
+  [ -z "$(git -C "$case_dir/project" status --porcelain)" ] \
+    || fail "spawn dirtied the primary clone while selecting its pool"
+  pass "a spawn selects this home's pool without mutating the primary clone"
 }
 
 # --- (d) delivered copies are released before a slot is requested ------------
@@ -657,6 +647,38 @@ SH
     || fail "the canonical custody check did not receive the protected worktree path"
   assert_absent "$run_dir" "the authenticated custody snapshot was not cleaned up"
   pass "--force trusts canonical custody code, never the protected copy"
+}
+
+test_teardown_refuses_mutable_canonical_dependencies() {
+  local case_dir out status
+  case_dir=$(make_teardown_case teardown-custody-mutable-dependency)
+  printf '{\n  "name": "fixture",\n  "scripts": {\n    "check:worktree-custody": "node custody.js"\n  }\n}\n' \
+    > "$case_dir/project/package.json"
+  printf '%s\n' 'process.exit(require("custody-verdict"));' > "$case_dir/project/custody.js"
+  git -C "$case_dir/project" add package.json custody.js
+  git -C "$case_dir/project" -c user.email=t@t -c user.name=t \
+    commit -qm "publish dependency-backed custody check"
+  git -C "$case_dir/project" push -q origin main
+  git -C "$case_dir/wt" -c user.email=t@t -c user.name=t merge -q main
+  git -C "$case_dir/wt" push -q origin fm/task-c1
+  mkdir -p "$case_dir/project/node_modules/custody-verdict"
+  printf '%s\n' 'module.exports = 0;' \
+    > "$case_dir/project/node_modules/custody-verdict/index.js"
+  cat > "$case_dir/fakebin/treehouse" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$case_dir/treehouse.log"
+exit 0
+SH
+  chmod +x "$case_dir/fakebin/treehouse"
+
+  out=$(NODE_PATH="$case_dir/project/node_modules" run_teardown_case "$case_dir" --force)
+  status=$?
+  expect_code 1 "$status" "mutable node_modules must not authorize destructive cleanup"
+  assert_contains "$out" "check:worktree-custody says" "the unauthenticated dependency failure was not surfaced"
+  assert_absent "$case_dir/treehouse.log" "mutable dependency code authorized a Treehouse return"
+  assert_present "$case_dir/state/task-c1.meta" "mutable dependency code removed task ownership metadata"
+  [ -d "$case_dir/wt" ] || fail "mutable dependency code removed the protected working copy"
+  pass "canonical custody refuses rather than importing mutable node_modules"
 }
 
 test_teardown_refuses_a_worktree_only_custody_check() {
@@ -1009,13 +1031,12 @@ SH
 
 test_two_homes_configure_distinct_pool_roots
 test_literal_pool_root_override_is_refused
-test_pool_root_is_idempotent_and_preserves_other_keys
-test_pool_root_refuses_a_tracked_config
-test_pool_root_refuses_a_nonregular_config
+test_pool_root_is_idempotent_without_mutating_the_clone
+test_pool_root_preserves_a_tracked_primary_config
+test_pool_root_preserves_a_nonregular_primary_config
 test_pool_root_verifies_the_written_config
-test_pool_root_refuses_when_git_exclude_cannot_be_written
-test_pool_root_restores_existing_config_when_git_exclude_fails
 test_real_treehouse_stops_sharing_a_pool_between_homes
+test_real_treehouse_accepts_encoded_pool_paths
 test_spawn_refuses_a_copy_another_task_claims
 test_spawn_refuses_ambiguous_worktree_metadata
 test_fresh_spawn_refuses_an_existing_task_record_before_side_effects
@@ -1028,6 +1049,7 @@ test_spawn_bounds_a_hanging_release_step_without_external_timeout
 test_spawn_rejects_a_zero_equivalent_release_timeout
 test_teardown_refuses_a_red_custody_verdict
 test_forced_teardown_still_refuses_a_red_custody_verdict
+test_teardown_refuses_mutable_canonical_dependencies
 test_teardown_refuses_a_worktree_only_custody_check
 test_forced_secondmate_cleanup_preflights_child_custody
 test_teardown_holds_task_set_lock_through_destructive_return

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -162,6 +162,29 @@ fm_fake_exit0() {
   local fakebin=$1 tool
   shift
   for tool in "$@"; do
+    if [ "$tool" = treehouse ]; then
+      cat > "$fakebin/$tool" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = get ]; then
+  if [ -n "${FM_FAKE_TREEHOUSE_PATH:-}" ]; then
+    printf '%s\n' "$FM_FAKE_TREEHOUSE_PATH"
+  elif [ -n "${FM_FAKE_PANE_PATH:-}" ]; then
+    printf '%s\n' "$FM_FAKE_PANE_PATH"
+  elif [ -n "${FM_FAKE_PANE_PATH_DIR:-}" ]; then
+    holder=
+    prev=
+    for arg in "$@"; do
+      [ "$prev" != --lease-holder ] || holder=$arg
+      prev=$arg
+    done
+    [ -z "$holder" ] || printf '%s/fm-%s\n' "$FM_FAKE_PANE_PATH_DIR" "$holder"
+  fi
+fi
+exit 0
+SH
+      chmod +x "$fakebin/$tool"
+      continue
+    fi
     cat > "$fakebin/$tool" <<'SH'
 #!/usr/bin/env bash
 exit 0


### PR DESCRIPTION
## Summary

- namespace new Treehouse leases by canonical operational FM_HOME, with FM_POOL_ROOT_BASE as the relocation override
- fail closed when spawn ownership metadata or pool configuration cannot be authenticated, and serialize custody through destructive teardown
- resolve custody opt-ins from canonical Git provenance, enforce bounded hooks, and preserve existing live leases
- update Herdr relaunch coverage and shared documentation for the new ownership contract

## Validation

- no-mistakes review completed with no remaining findings
- focused custody, spawn, cleanup, timeout, rollback, and Herdr end-to-end tests passed
- documentation validation completed
- bin/fm-lint.sh passed