### PR TITLE
fix(bin): keep a local-only project's origin mirror in sync after merge

### DIFF
--- a/bin/fm-fleet-sync.sh
+++ b/bin/fm-fleet-sync.sh
@@ -327,6 +327,10 @@ sync_project() {
   mode_line=$("$FM_ROOT/bin/fm-project-mode.sh" "$label" 2>/dev/null || echo "no-mistakes off")
   mode=${mode_line%% *}
   if [ "$mode" = "local-only" ]; then
+    # This skip is pull-direction only (origin -> local); it never runs in
+    # reverse. Keeping a local-only project's local-mirror origin caught up
+    # (local -> mirror, after a merge advances the local default branch) is
+    # bin/fm-merge-local.sh's job, not this one - see its header comment.
     echo "$label: skipped: local-only project"
     return 0
   fi

--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -9,6 +9,24 @@
 # auto-approves), and only as a clean fast-forward - it refuses a diverged branch
 # and tells you to have the crewmate rebase. See AGENTS.md prime directives,
 # project management, and task lifecycle.
+#
+# After the local fast-forward, this is also the single owner of keeping a
+# local-mirror origin's default branch in step with it (fm-fleet-sync.sh's
+# mode=local-only skip cross-references this instead of duplicating it). Some
+# local-only projects point origin at a local bare mirror that exists only so
+# bin/fm-spawn.sh's pooled-worktree refresh has something to fetch from (never a
+# real forge - local-only never pushes there). Left alone, that mirror goes stale
+# the moment this script advances the project's real local default branch, and
+# the next pooled spawn fetches the stale mirror and silently drops already-merged
+# work from the new task's base. So: when `git remote get-url origin` resolves to
+# something that is not clearly network-addressed (no https/http/ssh/git:// scheme
+# and no scp-like [user@]host:path form) - i.e. a filesystem path or file:// URL -
+# treat it as that local mirror and fast-forward its copy of the default branch to
+# match (a plain `git push`, which git itself refuses if the mirror has diverged;
+# never forced). A real hosted origin is left untouched: local-only's no-push,
+# no-PR contract is unchanged for it. A failed mirror update is reported loudly on
+# stderr but never fails this script's exit status - the local fast-forward above
+# already succeeded and remains this script's primary guarantee.
 # Usage: fm-merge-local.sh <task-id>
 set -eu
 
@@ -72,3 +90,36 @@ before=$(git -C "$PROJ" rev-parse --short "$DEFAULT")
 git -C "$PROJ" merge --ff-only "$BRANCH" >/dev/null
 after=$(git -C "$PROJ" rev-parse --short "$DEFAULT")
 echo "merged $BRANCH into local $DEFAULT ($before -> $after) in $PROJ"
+
+# True (0) when $1 is clearly network-addressed: an https/http/ssh/git:// URL, or
+# scp-like [user@]host:path. Anything else - an absolute path, a file:// URL, or
+# any other form - is treated as the local-mirror case (see header comment).
+origin_is_network_addressed() {
+  local url=$1 before_colon
+  case "$url" in
+    https://* | http://* | ssh://* | git://*) return 0 ;;
+    /* | file://*) return 1 ;;
+  esac
+  case "$url" in
+    *:*)
+      before_colon=${url%%:*}
+      case "$before_colon" in
+        */*) return 1 ;;
+        *) return 0 ;;
+      esac
+      ;;
+  esac
+  return 1
+}
+
+ORIGIN_URL=$(git -C "$PROJ" remote get-url origin 2>/dev/null || true)
+if [ -n "$ORIGIN_URL" ] && ! origin_is_network_addressed "$ORIGIN_URL"; then
+  if PUSH_OUT=$(git -C "$PROJ" push origin "refs/heads/$DEFAULT:refs/heads/$DEFAULT" 2>&1); then
+    case "$PUSH_OUT" in
+      *"Everything up-to-date"*) ;;
+      *) echo "origin mirror updated: $DEFAULT now at $after ($ORIGIN_URL)" ;;
+    esac
+  else
+    echo "warning: could not fast-forward local-mirror origin '$ORIGIN_URL' to $DEFAULT ($after); pooled worktrees fetched from this mirror may still see stale history until this is fixed. git push said: $PUSH_OUT" >&2
+  fi
+fi

--- a/bin/fm-merge-local.sh
+++ b/bin/fm-merge-local.sh
@@ -18,15 +18,25 @@
 # real forge - local-only never pushes there). Left alone, that mirror goes stale
 # the moment this script advances the project's real local default branch, and
 # the next pooled spawn fetches the stale mirror and silently drops already-merged
-# work from the new task's base. So: when `git remote get-url origin` resolves to
-# something that is not clearly network-addressed (no https/http/ssh/git:// scheme
-# and no scp-like [user@]host:path form) - i.e. a filesystem path or file:// URL -
-# treat it as that local mirror and fast-forward its copy of the default branch to
-# match (a plain `git push`, which git itself refuses if the mirror has diverged;
-# never forced). A real hosted origin is left untouched: local-only's no-push,
-# no-PR contract is unchanged for it. A failed mirror update is reported loudly on
-# stderr but never fails this script's exit status - the local fast-forward above
-# already succeeded and remains this script's primary guarantee.
+# work from the new task's base. So: fast-forward the mirror's copy of the default
+# branch to match (a plain `git push`, which git itself refuses if the mirror has
+# diverged; never forced) - but only when every URL `git push origin` would
+# actually use is a filesystem path or file:// URL, never network-addressed
+# (no https/http/ssh/git:// scheme and no scp-like [user@]host:path form).
+# The decision is made on push URLs, not the fetch URL: a separately configured
+# remote.origin.pushurl (or several, via repeated `remote set-url --add --push`)
+# overrides the fetch URL entirely for `git push`, so a local-path fetch URL
+# paired with a hosted pushurl must still be treated as a real hosted origin, and
+# is - `git remote get-url --push --all` returns the configured pushurl(s) when
+# set and falls back to the fetch URL only when none is configured, so checking
+# every one of those exactly mirrors what `git push origin` would actually target.
+# A single hosted URL anywhere in that list disqualifies the whole remote from
+# this sync, silently and without a push attempt, identical to today's contract
+# for an ordinary hosted origin: local-only's no-push, no-PR contract is
+# unchanged for it. A failed mirror update (e.g. the mirror has diverged) is
+# reported loudly on stderr but never fails this script's exit status - the local
+# fast-forward above already succeeded and remains this script's primary
+# guarantee.
 # Usage: fm-merge-local.sh <task-id>
 set -eu
 
@@ -112,8 +122,22 @@ origin_is_network_addressed() {
   return 1
 }
 
+# True (0) only when every URL `git push origin` would actually use is a local
+# filesystem path or file:// URL - see header comment for why this must be push
+# URLs, never the fetch URL alone.
+origin_push_is_local_mirror() {
+  local urls u
+  urls=$(git -C "$PROJ" remote get-url --push --all origin 2>/dev/null) || return 1
+  [ -n "$urls" ] || return 1
+  while IFS= read -r u; do
+    [ -n "$u" ] || continue
+    origin_is_network_addressed "$u" && return 1
+  done <<< "$urls"
+  return 0
+}
+
 ORIGIN_URL=$(git -C "$PROJ" remote get-url origin 2>/dev/null || true)
-if [ -n "$ORIGIN_URL" ] && ! origin_is_network_addressed "$ORIGIN_URL"; then
+if [ -n "$ORIGIN_URL" ] && origin_push_is_local_mirror; then
   if PUSH_OUT=$(git -C "$PROJ" push origin "refs/heads/$DEFAULT:refs/heads/$DEFAULT" 2>&1); then
     case "$PUSH_OUT" in
       *"Everything up-to-date"*) ;;

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -279,7 +279,7 @@ family_for_basename() {
     fm-teardown-endpoint-safety.test.sh)
       printf '%s\n' backend-dispatch
       ;;
-    fm-check-unregister.test.sh|fm-pr-check-security.test.sh|fm-pr-merge.test.sh|\
+    fm-check-unregister.test.sh|fm-merge-local.test.sh|fm-pr-check-security.test.sh|fm-pr-merge.test.sh|\
     fm-review-diff.test.sh|fm-teardown.test.sh|fm-x-mode.test.sh)
       printf '%s\n' pr-forge
       ;;

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -65,7 +65,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `backends/cmux.sh`       | Experimental cmux session-provider adapter                                           |
 | `fm-config-push.sh`      | Push declared inherited local material to live local or remote secondmates and send the placement-specific config reread when changed |
 | `fm-project-mode.sh`     | Resolve a project's registered delivery posture from `data/projects.md` for fleet sync and home seeding |
-| `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval            |
+| `fm-merge-local.sh`      | Fast-forward a `local-only` project's local default branch after approval, and its local-mirror origin when one is configured |
 | `fm-review-diff.sh`      | Review a crewmate branch or resolved PR head against the authoritative base          |
 | `fm-marker-lib.sh`       | Compatibility entry point for the from-firstmate carrier owned by `fm-operational-input.sh` |
 | `fm-task-inbox-lib.sh`   | Single owner of durable steering-inbox records, acknowledgement, doorbells, and the delivery-attempt ladder |

--- a/tests/fm-merge-local.test.sh
+++ b/tests/fm-merge-local.test.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Behavior tests for fm-merge-local.sh's local-mirror-origin sync.
+#
+# fm-merge-local.sh fast-forwards a local-only project's local default branch to
+# the crewmate's fm/<id> branch. Some local-only projects point origin at a local
+# bare mirror that exists only so bin/fm-spawn.sh's pooled-worktree refresh has
+# something to fetch from. This suite pins the fix that keeps that mirror caught
+# up: after the local fast-forward, a local-path (or file://) origin gets its
+# default branch fast-forwarded to match, while a real hosted (https/ssh/scp-like)
+# origin is left completely untouched - no push is even attempted, so local-only's
+# no-push, no-PR contract for a real forge holds unchanged.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+fm_git_identity fmtest fmtest@example.invalid
+
+TMP_ROOT=$(fm_test_tmproot fm-merge-local-tests)
+HOME_N=0
+
+# --- fixtures ---------------------------------------------------------------
+
+new_home() {
+  HOME_N=$((HOME_N + 1))
+  local h="$TMP_ROOT/home-$HOME_N"
+  mkdir -p "$h/state"
+  printf '%s\n' "$h"
+}
+
+commit_file() {
+  local dir=$1 file=$2 content=$3 msg=$4
+  printf '%s\n' "$content" > "$dir/$file"
+  git -C "$dir" add "$file"
+  git -C "$dir" commit -qm "$msg"
+}
+
+# build_local_mirror_project <home> <name>: a bare local mirror plus a project
+# clone of it (origin set to the mirror's plain filesystem path, no file://
+# prefix - the real-world shape "data/local-remotes/<repo>.git" is cloned as).
+# Both start with one commit on main. Echoes "<mirror-path> <project-path>".
+build_local_mirror_project() {
+  local home=$1 name=$2 work mirror proj
+  work="$home/work-$name"
+  mirror="$home/mirrors/$name.git"
+  proj="$home/proj-$name"
+  mkdir -p "$home/mirrors"
+
+  git init -q "$work"
+  git -C "$work" symbolic-ref HEAD refs/heads/main
+  commit_file "$work" file.txt v0 C0
+  git clone --quiet --bare "$work" "$mirror"
+
+  git clone --quiet "$mirror" "$proj"
+  printf '%s %s\n' "$mirror" "$proj"
+}
+
+# task_branch <proj> <id>: create fm/<id> off the current default branch with one
+# extra commit, then return to that default branch (clean, checked out) so the
+# project checkout is in the state fm-merge-local.sh requires.
+task_branch() {
+  local proj=$1 id=$2 default
+  default=$(git -C "$proj" symbolic-ref --short HEAD)
+  git -C "$proj" checkout -qb "fm/$id"
+  commit_file "$proj" file.txt "v-$id" "C-$id"
+  git -C "$proj" checkout -q "$default"
+}
+
+run_merge_local() {
+  local home=$1 id=$2
+  FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" "$ROOT/bin/fm-merge-local.sh" "$id"
+}
+
+# --- tests ------------------------------------------------------------------
+
+test_local_mirror_origin_advances_to_match() {
+  local home id mirror proj built out mirror_main proj_main
+
+  home=$(new_home)
+  id=local-mirror-1
+  built=$(build_local_mirror_project "$home" alpha)
+  mirror=${built% *}
+  proj=${built#* }
+
+  task_branch "$proj" "$id"
+  fm_write_meta "$home/state/$id.meta" "project=$proj" "mode=local-only"
+
+  out=$(run_merge_local "$home" "$id" 2>&1) \
+    || fail "fm-merge-local.sh failed against a local-mirror origin: $out"
+
+  assert_contains "$out" "merged fm/$id into local main" \
+    "local-mirror: the local fast-forward itself was not reported"
+  assert_contains "$out" "origin mirror updated: main" \
+    "local-mirror: the mirror-sync outcome was not reported"
+
+  mirror_main=$(git -C "$mirror" rev-parse main)
+  proj_main=$(git -C "$proj" rev-parse main)
+  [ "$mirror_main" = "$proj_main" ] \
+    || fail "local-mirror: mirror main ($mirror_main) does not match project main ($proj_main) after merge"
+
+  pass "a local-path origin's default branch is fast-forwarded to match after the merge"
+}
+
+test_local_mirror_origin_already_current_is_quiet() {
+  local home id mirror proj built out
+
+  home=$(new_home)
+  id=local-mirror-2
+  built=$(build_local_mirror_project "$home" bravo)
+  mirror=${built% *}
+  proj=${built#* }
+
+  task_branch "$proj" "$id"
+  fm_write_meta "$home/state/$id.meta" "project=$proj" "mode=local-only"
+
+  out=$(run_merge_local "$home" "$id" 2>&1) \
+    || fail "fm-merge-local.sh failed on first run: $out"
+  assert_contains "$out" "origin mirror updated: main" \
+    "local-mirror: the first run's mirror-sync outcome was not reported"
+
+  # Re-running against the same already-merged branch is a no-op fast-forward
+  # (branch is an ancestor of an unchanged default) and the mirror is already
+  # exactly caught up from the first run, so the "Everything up-to-date" push
+  # outcome must not be misreported as a fresh update.
+  out=$(run_merge_local "$home" "$id" 2>&1) \
+    || fail "fm-merge-local.sh failed on the idempotent second run: $out"
+  assert_not_contains "$out" "origin mirror updated" \
+    "local-mirror: an already-current mirror was wrongly reported as updated again"
+
+  [ "$(git -C "$mirror" rev-parse main)" = "$(git -C "$proj" rev-parse main)" ] \
+    || fail "local-mirror: mirror main does not match project main after the idempotent re-run"
+
+  pass "an already-caught-up local mirror is not spuriously re-reported as updated"
+}
+
+test_hosted_origin_is_never_pushed_to() {
+  local home id proj fakebin out err push_log
+
+  home=$(new_home)
+  id=hosted-origin-1
+  proj="$home/proj-hosted"
+
+  git init -q "$proj"
+  git -C "$proj" symbolic-ref HEAD refs/heads/main
+  commit_file "$proj" file.txt v0 C0
+  git -C "$proj" remote add origin "https://example.invalid/fake/repo.git"
+
+  task_branch "$proj" "$id"
+  fm_write_meta "$home/state/$id.meta" "project=$proj" "mode=local-only"
+
+  fakebin="$home/fakebin"
+  mkdir -p "$fakebin"
+  push_log="$home/push.log"
+  realgit=$(command -v git)
+  cat > "$fakebin/git" <<SH
+#!/usr/bin/env bash
+real="$realgit"
+for a in "\$@"; do
+  if [ "\$a" = push ]; then
+    printf '%s\n' "push \$*" >> "$push_log"
+    exit 1
+  fi
+done
+exec "\$real" "\$@"
+SH
+  chmod +x "$fakebin/git"
+
+  out="$home/out"; err="$home/err"
+  set +e
+  PATH="$fakebin:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+    "$ROOT/bin/fm-merge-local.sh" "$id" >"$out" 2>"$err"
+  status=$?
+  set -e
+
+  [ "$status" -eq 0 ] || fail "hosted-origin: fm-merge-local.sh failed for a real https origin: $(cat "$err")"
+  assert_contains "$(cat "$out")" "merged fm/$id into local main" \
+    "hosted-origin: the local fast-forward itself was not reported"
+  assert_no_grep "origin mirror updated" "$out" \
+    "hosted-origin: a hosted origin was wrongly reported as mirror-updated"
+  assert_no_grep "could not fast-forward local-mirror origin" "$err" \
+    "hosted-origin: a hosted origin was wrongly treated as a local mirror"
+  [ ! -s "$push_log" ] || fail "hosted-origin: git push was attempted against a real hosted origin: $(cat "$push_log")"
+
+  pass "a real hosted (https) origin is never pushed to, preserving local-only's no-push contract"
+}
+
+test_local_mirror_origin_advances_to_match
+test_local_mirror_origin_already_current_is_quiet
+test_hosted_origin_is_never_pushed_to

--- a/tests/fm-merge-local.test.sh
+++ b/tests/fm-merge-local.test.sh
@@ -9,6 +9,12 @@
 # default branch fast-forwarded to match, while a real hosted (https/ssh/scp-like)
 # origin is left completely untouched - no push is even attempted, so local-only's
 # no-push, no-PR contract for a real forge holds unchanged.
+#
+# The decision is made on push URLs, never the fetch URL alone, because a
+# separately configured remote.origin.pushurl overrides the fetch URL for
+# `git push`: the local-fetch/hosted-pushurl, hosted-fetch/local-pushurl,
+# no-pushurl-configured, and multiple-pushurls cases below pin that boundary
+# from every direction a mismatched fetch/push URL pair could take it.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -184,6 +190,184 @@ SH
   pass "a real hosted (https) origin is never pushed to, preserving local-only's no-push contract"
 }
 
+test_local_fetch_hosted_pushurl_is_never_pushed_to() {
+  local home id built mirror proj fakebin out err push_log
+
+  home=$(new_home)
+  id=hosted-pushurl-1
+  built=$(build_local_mirror_project "$home" charlie)
+  mirror=${built% *}
+  proj=${built#* }
+  git -C "$proj" remote set-url --push origin "https://example.invalid/fake/repo.git"
+
+  task_branch "$proj" "$id"
+  fm_write_meta "$home/state/$id.meta" "project=$proj" "mode=local-only"
+
+  fakebin="$home/fakebin"
+  mkdir -p "$fakebin"
+  push_log="$home/push.log"
+  realgit=$(command -v git)
+  cat > "$fakebin/git" <<SH
+#!/usr/bin/env bash
+real="$realgit"
+for a in "\$@"; do
+  if [ "\$a" = push ]; then
+    printf '%s\n' "push \$*" >> "$push_log"
+    exit 1
+  fi
+done
+exec "\$real" "\$@"
+SH
+  chmod +x "$fakebin/git"
+
+  out="$home/out"; err="$home/err"
+  set +e
+  PATH="$fakebin:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+    "$ROOT/bin/fm-merge-local.sh" "$id" >"$out" 2>"$err"
+  status=$?
+  set -e
+
+  [ "$status" -eq 0 ] || fail "hosted-pushurl: fm-merge-local.sh failed for a local-fetch/hosted-push origin: $(cat "$err")"
+  assert_contains "$(cat "$out")" "merged fm/$id into local main" \
+    "hosted-pushurl: the local fast-forward itself was not reported"
+  assert_no_grep "origin mirror updated" "$out" \
+    "hosted-pushurl: a hosted pushurl was wrongly reported as mirror-updated"
+  [ ! -s "$push_log" ] || fail "hosted-pushurl: git push was attempted against a remote with a hosted pushurl: $(cat "$push_log")"
+
+  mirror_main=$(git -C "$mirror" rev-parse main)
+  proj_prev=$(git -C "$proj" rev-parse "main^")
+  [ "$mirror_main" = "$proj_prev" ] \
+    || fail "hosted-pushurl: the local mirror should have been left untouched at its prior commit"
+
+  pass "a local fetch URL paired with a hosted pushurl is never pushed to (the reported bypass)"
+}
+
+test_hosted_fetch_local_pushurl_still_syncs() {
+  local home id built mirror proj out mirror_main proj_main
+
+  home=$(new_home)
+  id=local-pushurl-1
+  built=$(build_local_mirror_project "$home" delta)
+  mirror=${built% *}
+  proj=${built#* }
+  git -C "$proj" remote set-url origin "https://example.invalid/fake/repo.git"
+  git -C "$proj" remote set-url --push origin "$mirror"
+
+  task_branch "$proj" "$id"
+  fm_write_meta "$home/state/$id.meta" "project=$proj" "mode=local-only"
+
+  out=$(run_merge_local "$home" "$id" 2>&1) \
+    || fail "local-pushurl: fm-merge-local.sh failed against a hosted-fetch/local-push origin: $out"
+
+  assert_contains "$out" "origin mirror updated: main" \
+    "local-pushurl: the mirror-sync outcome was not reported when the actual push destination is local"
+
+  mirror_main=$(git -C "$mirror" rev-parse main)
+  proj_main=$(git -C "$proj" rev-parse main)
+  [ "$mirror_main" = "$proj_main" ] \
+    || fail "local-pushurl: mirror main ($mirror_main) does not match project main ($proj_main) after merge"
+
+  pass "a hosted fetch URL paired with a local pushurl still syncs, since that is the actual push destination"
+}
+
+test_no_pushurl_falls_back_to_fetch_url() {
+  # Regression pin: git itself returns the fetch URL from `get-url --push` when
+  # no pushurl is configured, so the ordinary (no pushurl) local-mirror case must
+  # keep working unchanged - covered already by test_local_mirror_origin_advances_to_match,
+  # this test only pins the no-pushurl-configured hosted-origin side of that
+  # same fallback so the boundary is exercised from both directions.
+  local home id proj out err push_log fakebin
+
+  home=$(new_home)
+  id=no-pushurl-1
+  proj="$home/proj-no-pushurl"
+
+  git init -q "$proj"
+  git -C "$proj" symbolic-ref HEAD refs/heads/main
+  commit_file "$proj" file.txt v0 C0
+  git -C "$proj" remote add origin "https://example.invalid/fake/repo.git"
+
+  task_branch "$proj" "$id"
+  fm_write_meta "$home/state/$id.meta" "project=$proj" "mode=local-only"
+
+  fakebin="$home/fakebin"
+  mkdir -p "$fakebin"
+  push_log="$home/push.log"
+  realgit=$(command -v git)
+  cat > "$fakebin/git" <<SH
+#!/usr/bin/env bash
+real="$realgit"
+for a in "\$@"; do
+  if [ "\$a" = push ]; then
+    printf '%s\n' "push \$*" >> "$push_log"
+    exit 1
+  fi
+done
+exec "\$real" "\$@"
+SH
+  chmod +x "$fakebin/git"
+
+  out="$home/out"; err="$home/err"
+  set +e
+  PATH="$fakebin:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+    "$ROOT/bin/fm-merge-local.sh" "$id" >"$out" 2>"$err"
+  status=$?
+  set -e
+
+  [ "$status" -eq 0 ] || fail "no-pushurl: fm-merge-local.sh failed for an unconfigured-pushurl hosted origin: $(cat "$err")"
+  [ ! -s "$push_log" ] || fail "no-pushurl: git push was attempted against a hosted origin with no pushurl configured: $(cat "$push_log")"
+
+  pass "an unconfigured pushurl correctly falls back to the (hosted) fetch URL and is never pushed to"
+}
+
+test_multiple_pushurls_one_hosted_is_never_pushed_to() {
+  local home id built mirror proj out err push_log fakebin
+
+  home=$(new_home)
+  id=multi-pushurl-1
+  built=$(build_local_mirror_project "$home" echo)
+  mirror=${built% *}
+  proj=${built#* }
+  git -C "$proj" remote set-url --push origin "$mirror"
+  git -C "$proj" remote set-url --add --push origin "https://example.invalid/fake/repo.git"
+
+  task_branch "$proj" "$id"
+  fm_write_meta "$home/state/$id.meta" "project=$proj" "mode=local-only"
+
+  fakebin="$home/fakebin"
+  mkdir -p "$fakebin"
+  push_log="$home/push.log"
+  realgit=$(command -v git)
+  cat > "$fakebin/git" <<SH
+#!/usr/bin/env bash
+real="$realgit"
+for a in "\$@"; do
+  if [ "\$a" = push ]; then
+    printf '%s\n' "push \$*" >> "$push_log"
+    exit 1
+  fi
+done
+exec "\$real" "\$@"
+SH
+  chmod +x "$fakebin/git"
+
+  out="$home/out"; err="$home/err"
+  set +e
+  PATH="$fakebin:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+    "$ROOT/bin/fm-merge-local.sh" "$id" >"$out" 2>"$err"
+  status=$?
+  set -e
+
+  [ "$status" -eq 0 ] || fail "multi-pushurl: fm-merge-local.sh failed for a mixed local/hosted multi-pushurl origin: $(cat "$err")"
+  [ ! -s "$push_log" ] || fail "multi-pushurl: git push was attempted against a remote with one hosted pushurl among several: $(cat "$push_log")"
+
+  pass "one hosted URL among several configured pushurls disqualifies the whole remote from the sync"
+}
+
 test_local_mirror_origin_advances_to_match
 test_local_mirror_origin_already_current_is_quiet
 test_hosted_origin_is_never_pushed_to
+test_local_fetch_hosted_pushurl_is_never_pushed_to
+test_hosted_fetch_local_pushurl_still_syncs
+test_no_pushurl_falls_back_to_fetch_url
+test_multiple_pushurls_one_hosted_is_never_pushed_to


### PR DESCRIPTION
## Intent

This is a change to firstmate's own tracked material (bin/). bin/fm-merge-local.sh is firstmate's approved-merge action for mode=local-only ship tasks: it fast-forwards a project's local default branch (e.g. main) to the task's fm/<id> branch in the project's primary checkout. Separately, bin/fm-spawn.sh refreshes a pooled treehouse worktree before handing it to a new task by fetching the project's origin remote and resetting the pooled worktree to origin/<default>. For a project whose origin is a real hosted git remote, these two facts stay consistent because local-only mode never touches the remote. But some local-only projects (e.g. simit-party) have origin pointing at a local bare mirror repo used only so treehouse's worktree pool has something to fetch from (not a real forge). fm-merge-local.sh fast-forwards the project's local main but never touched that mirror, so the next fm-spawn.sh pooling for that project fetches the stale mirror and resets the new task's base to it, silently dropping already-merged local-only work from the new task's view. This caused a confirmed live incident where a crewmate correctly reported a needs-decision because gameplay code it was told exists was nowhere in the codebase - it wasn't missing, it was just not on the base it was given.

Required fix: after fm-merge-local.sh performs its fast-forward merge of the project's local default branch, it must also bring that project's origin remote's copy of the default branch up to date, but ONLY when origin is a local filesystem remote rather than a real hosted git remote (never push anything to a genuine GitHub/GitLab/etc. remote - local-only's never-push, no-PR contract must hold unchanged for any project whose origin is a real forge). Inspect git -C $PROJ remote get-url origin (or equivalent) and distinguish a filesystem path from a URL with a network scheme or an ssh-style user@host:path form; treat anything that is not clearly a network-addressed remote as the local-mirror case this fix targets. Bring the mirror's default branch ref up to the newly-advanced local default branch as a fast-forward-only operation - never force-push, and never silently swallow a failure here: report it loudly, but do not fail the overall merge result, since the local merge itself already succeeded and is the primary contract this script guarantees.

Investigated whether this belongs entirely inside fm-merge-local.sh, or whether fm-fleet-sync.sh's explicit local-only-project skip path is actually the more consistent single owner for keeping a local-only project's origin mirror in sync; picked fm-merge-local.sh as the single owner (fleet-sync's refresh direction is origin -> local, the opposite of what this fix needs, and doing it synchronously inside merge-local closes the race window that caused the live incident), and updated fm-fleet-sync.sh's local-only skip comment to cross-reference fm-merge-local.sh instead of duplicating the logic.

Constraints: do not touch bin/fm-spawn.sh's pooled-worktree refresh-from-origin logic itself. Do not touch anything under projects/ or any project's treehouse pool. Do not touch, restart, or interrupt any currently-running crewmate or its worktree/pool. Preserve local-only's existing behavior for every project whose origin is a real hosted remote: no push, no PR, unchanged. Update the header comment of whichever script(s) are changed to document the new behavior (mechanics belong in the script's own header + --help, not restated elsewhere). Add a regression test under tests/ that exercises the observable behavior through the real script against real local git repos (a primary checkout with a local-path origin bare mirror, plus one with a fake https:// origin to prove the no-op path) - never assert against implementation source bytes. Run bin/fm-lint.sh and the relevant bin/fm-test-run.sh invocation(s) for any test file added or touched before reporting done.

## What Changed

- `bin/fm-merge-local.sh`: after fast-forwarding a local-only project's local default branch, detects whether `origin` is a local filesystem/`file://` mirror (vs. a network-addressed remote like https/ssh/git) and, only in the mirror case, fast-forwards the mirror's default branch ref to match via `git push`; a failed mirror update is reported loudly on stderr without failing the script's exit status, and real hosted origins are left untouched.
- `bin/fm-fleet-sync.sh`: updates the `mode=local-only` skip path's comment to cross-reference `fm-merge-local.sh` as the owner of mirror sync, since fleet-sync's refresh direction is origin→local, the opposite of what's needed here.
- `bin/fm-test-run.sh`: registers `fm-merge-local.test.sh` in the `pr-forge` test family.
- `docs/scripts.md`: updates the `fm-merge-local.sh` description to mention the local-mirror origin update.
- `tests/fm-merge-local.test.sh`: adds a regression test exercising the script against real local git repos, covering both a local-path bare-mirror origin (mirror gets fast-forwarded) and a fake `https://` origin (no-op, no push attempted).

## Risk Assessment

✅ Low: The change is narrowly scoped to fm-merge-local.sh (plus a cross-reference comment and doc row), correctly classifies network vs. filesystem/scp-like origins using git's own scp-syntax heuristic, uses a non-force push that fails closed on divergence, reports failures without breaking the script's exit status, and is backed by real-git-repo behavioral tests (including one proving a hosted origin's `git push` is never invoked) rather than source-content assertions — no reachable gap in the fix or contradiction of the stated intent was found.

## Testing

Ran bin/fm-test-run.sh tests/fm-merge-local.test.sh, which exercises the real fm-merge-local.sh script against real local git repositories: one scenario builds a primary checkout with a filesystem-path bare-mirror origin and confirms the mirror's default branch is fast-forwarded to match after the local merge (and stays quiet on a second, already-current run), and another builds a checkout with a fake https:// origin and confirms git push is never invoked against it, preserving local-only's no-push contract. All 3 assertions passed (exit=0). Also confirmed bin/fm-lint.sh (ShellCheck + actionlint) passes and the diff between base and target touches only bin/fm-fleet-sync.sh (comment), bin/fm-merge-local.sh, bin/fm-test-run.sh (family mapping), docs/scripts.md, and tests/fm-merge-local.test.sh — no changes to bin/fm-spawn.sh, projects/, or any treehouse pool, matching the stated constraints. Working tree is clean with no transient artifacts left behind.

<details>
<summary>Evidence: fm-test-run.sh output for tests/fm-merge-local.test.sh (all 3 scenarios: local-mirror fast-forward, idempotent re-run, hosted-origin no-push)</summary>

```text
FM_TEST_BEGIN 2026-08-22T22:17:37Z tests/fm-merge-local.test.sh family=pr-forge expected_gate_skip=none
ok - a local-path origin's default branch is fast-forwarded to match after the merge
ok - an already-caught-up local mirror is not spuriously re-reported as updated
ok - a real hosted (https) origin is never pushed to, preserving local-only's no-push contract
FM_TEST_END 2026-08-22T22:17:37Z tests/fm-merge-local.test.sh exit=0 duration_ms=388 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=423
FM_TEST_SUMMARY_FAMILY family=pr-forge count=1 duration_ms=388 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-merge-local.test.sh duration_ms=388
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"5f04cdeeec2b108205392449c9132298d6e361a9","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-merge-local.test.sh`
- `bin/fm-test-run.sh tests/fm-merge-local.test.sh`
- `bin/fm-lint.sh`
- `git diff 1231b6a..5f04cde --name-only (scope-boundary check)`
- `git status --porcelain (post-test cleanliness check)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
