### PR TITLE
fix(bin): keep long-running workers alive through host maintenance sleep

### DIFF
--- a/bin/fm-run-long-child.sh
+++ b/bin/fm-run-long-child.sh
@@ -10,7 +10,9 @@
 # effective only on AC power; -i and -m still request idle-system and disk-idle
 # protection on battery, but this interface does not claim that they prevent a
 # forced or maintenance sleep there. Other platforms execute the command
-# directly because this macOS assertion interface does not apply.
+# directly because this macOS assertion interface does not apply. A host whose
+# kernel identity cannot be read is refused loudly rather than launched
+# unprotected, because that fallback would silently drop the assertion on a Mac.
 #
 # FM_LONG_CHILD_CAFFEINATE_BIN overrides /usr/bin/caffeinate for hermetic
 # public-interface regression tests. Production callers leave it unset.
@@ -21,7 +23,12 @@ if [ "$#" -eq 0 ]; then
   exit 2
 fi
 
-if [ "$(uname -s 2>/dev/null || echo unknown)" = Darwin ]; then
+if ! host_kernel=$(uname -s 2>/dev/null) || [ -z "$host_kernel" ]; then
+  echo "error: long-child protection requires a host kernel identity from uname -s" >&2
+  exit 1
+fi
+
+if [ "$host_kernel" = Darwin ]; then
   caffeinate_bin=${FM_LONG_CHILD_CAFFEINATE_BIN:-/usr/bin/caffeinate}
   if [ ! -x "$caffeinate_bin" ]; then
     echo "error: macOS long-child protection requires executable caffeinate at $caffeinate_bin" >&2

--- a/bin/fm-run-long-child.sh
+++ b/bin/fm-run-long-child.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# fm-run-long-child.sh - run one Firstmate-owned long child with the host's
+# bounded power assertion.
+#
+# Usage:
+#   fm-run-long-child.sh <command> [arguments...]
+#
+# On macOS, this uses caffeinate's utility mode so the assertion owner exists
+# exactly as long as the command it starts. The system-sleep assertion (-s) is
+# effective only on AC power; -i and -m still request idle-system and disk-idle
+# protection on battery, but this interface does not claim that they prevent a
+# forced or maintenance sleep there. Other platforms execute the command
+# directly because this macOS assertion interface does not apply.
+#
+# FM_LONG_CHILD_CAFFEINATE_BIN overrides /usr/bin/caffeinate for hermetic
+# public-interface regression tests. Production callers leave it unset.
+set -eu
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: fm-run-long-child.sh <command> [arguments...]" >&2
+  exit 2
+fi
+
+if [ "$(uname -s 2>/dev/null || echo unknown)" = Darwin ]; then
+  caffeinate_bin=${FM_LONG_CHILD_CAFFEINATE_BIN:-/usr/bin/caffeinate}
+  if [ ! -x "$caffeinate_bin" ]; then
+    echo "error: macOS long-child protection requires executable caffeinate at $caffeinate_bin" >&2
+    exit 1
+  fi
+  exec "$caffeinate_bin" -s -i -m "$@"
+fi
+
+exec "$@"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -162,6 +162,10 @@
 #     __WORKTREE__  absolute path to the task worktree
 #     __CURSORBIN__ resolved, cursor-verified executable for a cursor launch
 #     __LONGCHILD__ absolute path to the bounded long-child power owner
+#                   Every verified template routes its worker through that owner so an
+#                   unattended host cannot sleep a live child out from under a turn; a raw
+#                   launch command for an unverified adapter is deliberately left unwrapped
+#                   (docs/architecture.md#spawned-workers-own-their-host-power-assertion).
 # Verified per-harness turn-end hooks are installed automatically where enabled; some live outside the worktree.
 # Kimi uses one surgically installed Firstmate region in $HOME/.kimi-code/config.toml,
 # a firstmate-owned global hook and registry, and a gitignored per-task pointer.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -161,6 +161,7 @@
 #     __OPINPUT__   absolute path to the canonical operational-input encoder
 #     __WORKTREE__  absolute path to the task worktree
 #     __CURSORBIN__ resolved, cursor-verified executable for a cursor launch
+#     __LONGCHILD__ absolute path to the bounded long-child power owner
 # Verified per-harness turn-end hooks are installed automatically where enabled; some live outside the worktree.
 # Kimi uses one surgically installed Firstmate region in $HOME/.kimi-code/config.toml,
 # a firstmate-owned global hook and registry, and a gitignored per-task pointer.
@@ -1111,17 +1112,17 @@ launch_template() {
     # does NOT suppress the interactive ghost text (verified empirically), so the env
     # var is the correct control. The dim-aware composer reader in fm-tmux-lib.sh is
     # the defense-in-depth backstop for any pane this flag cannot reach.
-    claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    claude) printf '%s' 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false __LONGCHILD__ claude --dangerously-skip-permissions __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     codex)
       if [ "$kind" = secondmate ]; then
-        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+        printf '%s' '__LONGCHILD__ codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       else
-        printf '%s' 'codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+        printf '%s' '__LONGCHILD__ codex __MODELFLAG____EFFORTFLAG__--dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch __TURNEND__\"]" "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       fi
       ;;
-    opencode) printf '%s' 'OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' opencode __MODELFLAG__--prompt "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    opencode) printf '%s' 'OPENCODE_CONFIG_CONTENT='\''{"permission":{"*":"allow"}}'\'' __LONGCHILD__ opencode __MODELFLAG__--prompt "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     pi|pi-signed)
-      printf '%s' '__PIBIN____PITUIMODE__'
+      printf '%s' '__LONGCHILD__ __PIBIN____PITUIMODE__'
       if [ "$kind" = secondmate ]; then
         printf '%s' ' __MODELFLAG____EFFORTFLAG__-e __PITURNEND__ -e __PIWATCH__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       else
@@ -1135,7 +1136,7 @@ launch_template() {
     # --dangerously-skip-permissions. grok's turn-end signal does NOT ride the
     # launch command - it is a Stop-event hook installed below (global hook +
     # per-task pointer), so the template is identical for ship/scout/secondmate.
-    grok) printf '%s' 'grok --always-approve __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    grok) printf '%s' '__LONGCHILD__ grok --always-approve __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     # Cursor Agent CLI. --trust suppresses the workspace-trust prompt, which
     # --yolo does NOT cover and which would otherwise block every spawn, since
     # each task gets a fresh worktree path cursor has never seen. --yolo is the
@@ -1148,12 +1149,12 @@ launch_template() {
     # inherited CLAUDECODE cannot outrank cursor's own marker in a process that
     # only reads the environment. Cursor exposes no effort flag, so the shared
     # effort axis is deliberately omitted and stays in task metadata only.
-    cursor) printf '%s' 'env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT -u FM_PI_HARNESS -u CURSOR_INVOKED_AS __CURSORBIN__ --trust --yolo __MODELFLAG__--workspace __WORKTREE__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    cursor) printf '%s' 'env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT -u FM_PI_HARNESS -u CURSOR_INVOKED_AS __LONGCHILD__ __CURSORBIN__ --trust --yolo __MODELFLAG__--workspace __WORKTREE__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     # Kimi Code rejects a positional prompt, so it launches bare and receives
     # only an absolute brief pointer after the TUI readiness gate below.
     # Its turn-end signal is a globally configured Stop hook plus a guarded
     # per-task worktree token, so no launch placeholder belongs here.
-    kimi) printf '%s' '__KIMIBIN__ __MODELFLAG__--auto' ;;
+    kimi) printf '%s' '__LONGCHILD__ __KIMIBIN__ __MODELFLAG__--auto' ;;
     # muse (Muse Code): a positional prompt starts the supervised interactive
     # session. --yolo is the single flag that makes a crewmate pane viable: muse
     # ships approval prompts AND a filesystem/network sandbox ON by default
@@ -1175,7 +1176,7 @@ launch_template() {
     # session event log instead (bin/fm-busy-lib.sh), bound by the sidecar
     # written below. Nothing to place in the template for it.
     # codex, opencode, and kimi are also markerless and share this inherited-marker hazard; changing their verified launch boundaries belongs in follow-up work.
-    muse) printf '%s' 'env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT -u FM_PI_HARNESS XDG_CONFIG_HOME=__MUSECONFIG__ XDG_DATA_HOME=__MUSEDATA__ MUSE_EXPERIMENTAL_FOREIGN_PERSONAL_CONTEXT_KILL=on __MUSEBIN__ --yolo __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
+    muse) printf '%s' 'env -u CLAUDECODE -u PI_CODING_AGENT -u GROK_AGENT -u FM_PI_HARNESS XDG_CONFIG_HOME=__MUSECONFIG__ XDG_DATA_HOME=__MUSEDATA__ MUSE_EXPERIMENTAL_FOREIGN_PERSONAL_CONTEXT_KILL=on __LONGCHILD__ __MUSEBIN__ --yolo __MODELFLAG____EFFORTFLAG__"$(__OPINPUT__ encode launch-brief < __BRIEF__)"' ;;
     *) return 1 ;;
   esac
 }
@@ -2712,6 +2713,7 @@ sq_piturnend=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-turnend-guard.ts
 sq_piwatch=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts")
 sq_opinput=$(shell_quote "$FM_ROOT/bin/fm-operational-input.sh")
 sq_worktree=$(shell_quote "$WT")
+sq_longchild=$(shell_quote "$FM_ROOT/bin/fm-run-long-child.sh")
 MODELFLAG=$(model_flag_for_harness "$HARNESS" "$MODEL")
 EFFORTFLAG=$(effort_flag_for_harness "$HARNESS" "$EFFORT")
 LAUNCH=${LAUNCH//__MODELFLAG__/$MODELFLAG}
@@ -2722,6 +2724,7 @@ LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}
 LAUNCH=${LAUNCH//__PITURNEND__/$sq_piturnend}
 LAUNCH=${LAUNCH//__PIWATCH__/$sq_piwatch}
 LAUNCH=${LAUNCH//__OPINPUT__/$sq_opinput}
+LAUNCH=${LAUNCH//__LONGCHILD__/$sq_longchild}
 case "$HARNESS" in
   pi|pi-signed) LAUNCH=${LAUNCH//__PIBIN__/"$(shell_quote "$PI_BIN")"} ;;
   cursor) LAUNCH=${LAUNCH//__CURSORBIN__/"$(shell_quote "$CURSOR_BIN")"} ;;

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -142,7 +142,7 @@ family_for_basename() {
     fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
     fm-kimi-harness.test.sh|fm-muse-harness.test.sh|fm-herdr-lab.test.sh|fm-lint.test.sh|\
     fm-lint-workflows.test.sh|\
-    fm-operational-input.test.sh|fm-pi-primary-types.test.sh|\
+    fm-operational-input.test.sh|fm-run-long-child.test.sh|fm-pi-primary-types.test.sh|\
     fm-send-popup-settle.test.sh|fm-send-settle.test.sh|\
     fm-subagent-pretool-check.test.sh|\
     fm-supervision-instructions.test.sh|fm-task-delivery.test.sh|\
@@ -1016,7 +1016,7 @@ families_for_changed_path() {
     bin/fm-install-actionlint.sh|\
     bin/fm-brief.sh|bin/fm-ensure-agents-md.sh|bin/fm-crew-state.sh|\
     bin/fm-captain-hold.sh|bin/fm-decision-hold.sh|bin/fm-supervision*|bin/fm-transition-lib.sh|\
-    bin/fm-tmux-lib.sh|bin/fm-marker-lib.sh|bin/fm-operational-input.sh|bin/fm-tasks-axi-lib.sh|\
+    bin/fm-tmux-lib.sh|bin/fm-marker-lib.sh|bin/fm-operational-input.sh|bin/fm-run-long-child.sh|bin/fm-tasks-axi-lib.sh|\
     bin/fm-vendor-auth-probe.sh|\
     bin/fm-primary-scope-lib.sh|bin/fm-project-mode.sh|bin/fm-promote.sh|\
     bin/fm-ff-lib.sh|bin/fm-gotmp*|bin/*pretool*)

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -999,12 +999,16 @@ families_for_changed_path() {
       printf '%s\n' live-harness-optin
       ;;
     bin/fm-spawn.sh)
-      # The launch templates live here, and the Orca suite is the only family
-      # that pins the composed launch text a template edit changes, so a spawn
-      # change re-runs it rather than deferring the break to full CI.
+      # The launch templates live here, so every family that pins the composed
+      # launch text is selected rather than deferring the break to full CI:
+      # backend-dispatch (spawn-dispatch-profile, trace-context-spawn),
+      # pure-contract-unit (kimi-harness, muse-harness), orca (backend-orca),
+      # and secondmate (secondmate-harness, which also executes the composed
+      # launch, and remote-secondmate-trace-context).
       printf '%s\n' backend-dispatch
       printf '%s\n' pure-contract-unit
       printf '%s\n' orca
+      printf '%s\n' secondmate
       ;;
     bin/fm-send.sh|bin/fm-harness.sh|\
     bin/fm-peek.sh|bin/fm-composer*)

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -1018,6 +1018,15 @@ families_for_changed_path() {
     bin/fm-bearings-snapshot.sh|bin/fm-fleet-snapshot.sh|bin/fm-fleet-view.sh)
       printf '%s\n' snapshot-bearings
       ;;
+    bin/fm-run-long-child.sh)
+      # The wrapper is EXECUTED, not just named, by suites in two families:
+      # pure-contract-unit (fm-run-long-child.test.sh, and fm-muse-harness.test.sh
+      # through FM_FAKE_EXECUTE_MUSE_LAUNCH) and secondmate
+      # (fm-secondmate-harness.test.sh runs the composed launch and asserts the
+      # claude case stays silent), so a wrapper edit selects both.
+      printf '%s\n' pure-contract-unit
+      printf '%s\n' secondmate
+      ;;
     bin/fm-install-herdr.sh|bin/fm-install-treehouse.sh|bin/fm-herdr-ci-cleanup.sh)
       printf '%s\n' pure-contract-unit
       # Pin or cleanup changes also select the real-Herdr family so the required
@@ -1028,7 +1037,7 @@ families_for_changed_path() {
     bin/fm-install-actionlint.sh|\
     bin/fm-brief.sh|bin/fm-ensure-agents-md.sh|bin/fm-crew-state.sh|\
     bin/fm-captain-hold.sh|bin/fm-decision-hold.sh|bin/fm-supervision*|bin/fm-transition-lib.sh|\
-    bin/fm-tmux-lib.sh|bin/fm-marker-lib.sh|bin/fm-operational-input.sh|bin/fm-run-long-child.sh|bin/fm-tasks-axi-lib.sh|\
+    bin/fm-tmux-lib.sh|bin/fm-marker-lib.sh|bin/fm-operational-input.sh|bin/fm-tasks-axi-lib.sh|\
     bin/fm-vendor-auth-probe.sh|\
     bin/fm-primary-scope-lib.sh|bin/fm-project-mode.sh|bin/fm-promote.sh|\
     bin/fm-ff-lib.sh|bin/fm-gotmp*|bin/*pretool*)

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -998,7 +998,15 @@ families_for_changed_path() {
       printf '%s\n' pure-contract-unit
       printf '%s\n' live-harness-optin
       ;;
-    bin/fm-spawn.sh|bin/fm-send.sh|bin/fm-harness.sh|\
+    bin/fm-spawn.sh)
+      # The launch templates live here, and the Orca suite is the only family
+      # that pins the composed launch text a template edit changes, so a spawn
+      # change re-runs it rather than deferring the break to full CI.
+      printf '%s\n' backend-dispatch
+      printf '%s\n' pure-contract-unit
+      printf '%s\n' orca
+      ;;
+    bin/fm-send.sh|bin/fm-harness.sh|\
     bin/fm-peek.sh|bin/fm-composer*)
       printf '%s\n' backend-dispatch
       printf '%s\n' pure-contract-unit

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -159,6 +159,15 @@ cmux is experimental, GUI-first, macOS-only, and can be selected explicitly or b
 cmux's container shape is one workspace per task with one surface, no per-home container split; workspace titles are scoped by the active home label plus a short hash of the resolved `FM_ROOT` path, and `--secondmate` spawns are refused, mirroring Orca.
 Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectable as a runtime backend.
 
+## Spawned workers own their host power assertion
+
+An unattended macOS host can enter Maintenance Sleep and stop a long-running worker mid-turn even while an idle-sleep assertion is active, so idle protection alone is not enough.
+Every verified launch template therefore routes its worker through `bin/fm-run-long-child.sh`, which on macOS runs the harness under `caffeinate` utility mode so one assertion exists exactly as long as that one owned child and is released on normal exit, failure, and interruption.
+The wrapper executes the command directly on a non-Darwin host and refuses the launch when the host kernel identity cannot be read at all, rather than starting a Mac worker unprotected; its header owns the exact contract.
+The system-sleep assertion is valid only on AC power, while the idle-system and disk-idle assertions still apply on battery, and no battery system-sleep guarantee is claimed.
+The raw launch-command escape hatch for an unverified adapter stays unwrapped, and nothing asserts power outside a live child.
+[`verification/runtime-backends.md`](verification/runtime-backends.md#spawned-long-child-power-ownership) owns the live evidence and its exact hardware-state limit.
+
 ## Worktrees, not branches in your checkout
 
 Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees for tmux, herdr, zellij, and cmux tasks, while Orca creates its own worktrees for `backend=orca`.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -11,7 +11,7 @@ Exact task chronology, branch names, temporary homes, local paths, process ids, 
 Firstmate's supported harness launch templates were verified on 2026-08-22 on macOS 26.6.2 build 25G83 arm64.
 Each template routes its owned long child through `bin/fm-run-long-child.sh`, while raw unverified launch commands remain unchanged.
 On macOS the wrapper uses `/usr/bin/caffeinate -s -i -m <command>` utility mode, which keeps the public wrapper PID as the command and forks a child `caffeinate` helper that owns the assertions for exactly that command's lifetime.
-The wrapper executes directly on non-Darwin hosts.
+The wrapper executes directly on non-Darwin hosts, and refuses with a non-zero status when the host kernel identity cannot be read at all, so no child launches unprotected on an unidentified host.
 
 The live host reported AC power, `sleep 0` on AC, and `sleep 1` on battery.
 An idle-only counterfactual left `PreventSystemSleep` at zero.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -6,6 +6,58 @@ This record contains reusable version-scoped evidence for active runtime guarant
 The backend guides own current setup, safety boundaries, and limitations.
 Exact task chronology, branch names, temporary homes, local paths, process ids, thread ids, and delivery transcripts remain in private reports or PR evidence.
 
+## Spawned long-child power ownership
+
+Firstmate's supported harness launch templates were verified on 2026-08-22 on macOS 26.6.2 build 25G83 arm64.
+Each template routes its owned long child through `bin/fm-run-long-child.sh`, while raw unverified launch commands remain unchanged.
+On macOS the wrapper uses `/usr/bin/caffeinate -s -i -m <command>` utility mode, which keeps the public wrapper PID as the command and forks a child `caffeinate` helper that owns the assertions for exactly that command's lifetime.
+The wrapper executes directly on non-Darwin hosts.
+
+The live host reported AC power, `sleep 0` on AC, and `sleep 1` on battery.
+An idle-only counterfactual left `PreventSystemSleep` at zero.
+The corrected path held `PreventSystemSleep`, `PreventUserIdleSystemSleep`, and `PreventDiskIdle` at the start and after 35 seconds of a bounded 70-second command, then returned `PreventSystemSleep` to zero with neither process alive after normal exit.
+
+```sh
+pmset -g batt
+pmset -g custom | awk '/Battery Power:|AC Power:| sleep / {print}'
+/usr/bin/caffeinate -i -m /bin/sleep 2 &
+pmset -g assertions
+wait "$!"
+
+bin/fm-run-long-child.sh /bin/sleep 70 &
+owner_pid=$!
+helper_pid=$(pgrep -P "$owner_pid")
+ps -o pid=,ppid=,pgid=,stat=,etime=,command= -p "$owner_pid,$helper_pid"
+pmset -g assertions
+wait "$owner_pid"
+pmset -g assertions
+```
+
+Bounded observed state:
+
+```text
+Now drawing from 'AC Power'
+Battery Power: sleep 1
+AC Power: sleep 0
+idle-only PreventSystemSleep=0
+start PreventSystemSleep=1 owner=/bin/sleep helper=/usr/bin/caffeinate
+35s PreventSystemSleep=1 owner=/bin/sleep helper=/usr/bin/caffeinate
+normal_exit_status=0 owner_alive=no helper_alive=no
+post_exit PreventSystemSleep=0
+```
+
+Real-interface interruption was also checked by starting a 120-second child and sending `TERM` only to the public wrapper owner.
+The owner returned 143, its child assertion helper exited, and `PreventSystemSleep` returned from one to zero.
+Portable public-interface regression coverage separately pins argument selection, normal and failing child lifetime, interruption propagation, and assertion-helper cleanup without inspecting implementation bytes.
+
+The battery system-sleep axis remains an explicit hardware-state limit of this verification.
+The host stayed on AC throughout, and `caffeinate -s` is documented by the installed macOS manual as valid only on AC power, so this run does not prove a battery `PreventSystemSleep` assertion or an actual battery sleep transition.
+It does prove the battery-applicable idle and disk assertion selection through the public interface, but those assertions alone are not claimed to prevent the maintenance-sleep path.
+No power source, power setting, lid state, or whole-machine sleep was changed to manufacture evidence.
+
+A 2026-08-14 bounded AC canary using the same `-s -i -m` assertion set recorded `AppleClamshellState = Yes` while the long command continued without a sleep transition.
+That contradictory evidence falsifies the earlier premise that a closed lid is necessarily a hard stop, so lid state is not used to explain away the battery limit above.
+
 ## tmux
 
 Foreground-process behavior was verified on 2026-07-07 with tmux 3.6a on macOS.

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -520,8 +520,8 @@ test_spawn_writes_orca_metadata_and_launches_harness() {
     "spawn should reuse the implicit terminal returned by Orca worktree creation"
   assert_contains "$(cat "$log")" $'orca\x1f''terminal'$'\x1f''send'$'\x1f''--terminal'$'\x1f''term-spawn'$'\x1f''--text'$'\x1f''export GOTMPDIR=/tmp/fm-orcaspawnz1/gotmp'$'\x1f''--enter'$'\x1f''--json' \
     "spawn did not export GOTMPDIR through the Orca terminal"
-  assert_contains "$(cat "$log")" "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions" \
-    "spawn did not send the selected harness launch command through Orca"
+  assert_contains "$(cat "$log")" "CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false '$ROOT/bin/fm-run-long-child.sh' claude --dangerously-skip-permissions" \
+    "spawn did not send the selected harness launch command through Orca under the long-child power owner"
   rm -rf "/tmp/fm-$id"
   pass "fm-spawn.sh --backend orca: reuses implicit terminal, records metadata, launches harness"
 }

--- a/tests/fm-kimi-harness.test.sh
+++ b/tests/fm-kimi-harness.test.sh
@@ -198,7 +198,7 @@ test_kimi_launch_then_send_is_verified() {
   assert_contains "$out" "spawned $id harness=kimi" "kimi spawn did not report success"
 
   launch=$(cat "$CASE_DIR/launch.log")
-  [ "$launch" = "env -u CURSOR_AGENT -u CURSOR_INVOKED_AS '$FAKEBIN_DIR/kimi' --model 'kimi-code/k3' --auto" ] \
+  [ "$launch" = "env -u CURSOR_AGENT -u CURSOR_INVOKED_AS '$ROOT/bin/fm-run-long-child.sh' '$FAKEBIN_DIR/kimi' --model 'kimi-code/k3' --auto" ] \
     || fail "kimi launch did not use the absolute binary, model, and --auto only: $launch"
   assert_not_contains "$launch" "--effort" "kimi launch emitted a nonexistent effort flag"
   assert_not_contains "$launch" "turn-ended" "kimi launch embedded a turn-end path"
@@ -455,7 +455,7 @@ test_kimi_falls_back_to_expanded_home_binary() {
   rc=$?
   expect_code 0 "$rc" "Kimi HOME fallback spawn should succeed"
   launch=$(cat "$CASE_DIR/launch.log")
-  [ "$launch" = "env -u CURSOR_AGENT -u CURSOR_INVOKED_AS '$fallback' --auto" ] \
+  [ "$launch" = "env -u CURSOR_AGENT -u CURSOR_INVOKED_AS '$ROOT/bin/fm-run-long-child.sh' '$fallback' --auto" ] \
     || fail "Kimi fallback did not expand HOME into an absolute executable: $launch"
   pass "fm-spawn: Kimi fallback expands the active HOME"
 }

--- a/tests/fm-muse-harness.test.sh
+++ b/tests/fm-muse-harness.test.sh
@@ -232,6 +232,8 @@ EOF
   assert_contains "$out" "spawned $id harness=muse" "muse spawn did not report success"
 
   launch=$(cat "$home/launch.log")
+  assert_contains "$launch" "'$ROOT/bin/fm-run-long-child.sh'" \
+    "muse launch omitted the bounded long-child owner"
   # --yolo is what makes a crewmate pane viable at all: without it muse holds
   # every tool call for approval and sandboxes the network to proxy-only.
   assert_contains "$launch" ' --yolo ' "muse launch omitted --yolo"

--- a/tests/fm-run-long-child.test.sh
+++ b/tests/fm-run-long-child.test.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# Public-interface regression tests for the bounded long-child power owner.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+OWNER="$ROOT/bin/fm-run-long-child.sh"
+TMP_ROOT=$(fm_test_tmproot fm-long-child)
+FAKEBIN="$TMP_ROOT/bin"
+ASSERTION="$TMP_ROOT/assertion-active"
+ARGS_LOG="$TMP_ROOT/caffeinate-args"
+OWNER_READY="$TMP_ROOT/owner-ready"
+OWNER_PID_LOG="$TMP_ROOT/owner-pid"
+OWNER_TERMINATED="$TMP_ROOT/owner-terminated"
+CHILD_PID_LOG="$TMP_ROOT/child-pid"
+RUNNER_PID=
+mkdir -p "$FAKEBIN"
+
+cleanup() {
+  if [ -n "$RUNNER_PID" ] && kill -0 "$RUNNER_PID" 2>/dev/null; then
+    kill -TERM "$RUNNER_PID" 2>/dev/null || true
+    wait "$RUNNER_PID" 2>/dev/null || true
+  fi
+  fm_test_cleanup
+}
+trap cleanup EXIT
+
+cat > "$FAKEBIN/uname" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "${FM_FAKE_UNAME:-Darwin}"
+SH
+
+cat > "$FAKEBIN/caffeinate" <<'SH'
+#!/usr/bin/env bash
+set -u
+printf '%s\n' "$@" > "$FM_FAKE_ARGS_LOG"
+[ "${1:-}" = -s ] && [ "${2:-}" = -i ] && [ "${3:-}" = -m ] || exit 97
+shift 3
+owner_pid=$$
+printf '%s\n' "$owner_pid" > "$FM_FAKE_OWNER_PID_LOG"
+(
+  cleanup() {
+    rm -f "$FM_FAKE_ASSERTION"
+    : > "$FM_FAKE_OWNER_TERMINATED"
+  }
+  trap cleanup EXIT
+  printf '%s\n' "$BASHPID" > "$FM_FAKE_CHILD_PID_LOG"
+  : > "$FM_FAKE_ASSERTION"
+  : > "$FM_FAKE_OWNER_READY"
+  while kill -0 "$owner_pid" 2>/dev/null; do
+    sleep 0.01
+  done
+) &
+exec "$@"
+SH
+
+cat > "$FAKEBIN/held-child" <<'SH'
+#!/usr/bin/env bash
+set -u
+printf 'ready\n' > "$FM_FAKE_READY"
+trap 'printf "terminated\n" > "$FM_FAKE_TERMINATED"; exit 143' TERM
+while [ ! -e "$FM_FAKE_RELEASE" ]; do
+  sleep 0.02
+done
+exit "${FM_FAKE_CHILD_STATUS:-0}"
+SH
+
+chmod +x "$FAKEBIN/uname" "$FAKEBIN/caffeinate" "$FAKEBIN/held-child"
+
+wait_for_file() {
+  local path=$1 attempt=0
+  while [ "$attempt" -lt 200 ]; do
+    [ -e "$path" ] && return 0
+    sleep 0.01
+    attempt=$((attempt + 1))
+  done
+  return 1
+}
+
+wait_for_pid_exit() {
+  local pid=$1 attempt=0
+  while [ "$attempt" -lt 200 ]; do
+    ! kill -0 "$pid" 2>/dev/null && return 0
+    sleep 0.01
+    attempt=$((attempt + 1))
+  done
+  return 1
+}
+
+test_darwin_selects_utility_mode_and_binds_normal_lifetime() {
+  local ready="$TMP_ROOT/normal-ready" release="$TMP_ROOT/normal-release"
+  local child_pid owner_pid status
+  rm -f "$ASSERTION" "$ARGS_LOG" "$OWNER_READY" "$OWNER_PID_LOG" \
+    "$OWNER_TERMINATED" "$CHILD_PID_LOG" "$ready" "$release"
+  env PATH="$FAKEBIN:$PATH" FM_FAKE_UNAME=Darwin \
+    FM_LONG_CHILD_CAFFEINATE_BIN="$FAKEBIN/caffeinate" \
+    FM_FAKE_ASSERTION="$ASSERTION" FM_FAKE_ARGS_LOG="$ARGS_LOG" \
+    FM_FAKE_OWNER_READY="$OWNER_READY" FM_FAKE_OWNER_PID_LOG="$OWNER_PID_LOG" \
+    FM_FAKE_OWNER_TERMINATED="$OWNER_TERMINATED" \
+    FM_FAKE_CHILD_PID_LOG="$CHILD_PID_LOG" FM_FAKE_READY="$ready" \
+    FM_FAKE_RELEASE="$release" FM_FAKE_TERMINATED="$TMP_ROOT/unused" \
+    "$OWNER" "$FAKEBIN/held-child" &
+  RUNNER_PID=$!
+  wait_for_file "$OWNER_READY" || fail "assertion owner did not become ready"
+  wait_for_file "$ready" || fail "normal child did not start through the public interface"
+  owner_pid=$(cat "$OWNER_PID_LOG")
+  child_pid=$(cat "$CHILD_PID_LOG")
+  [ "$RUNNER_PID" = "$owner_pid" ] || fail "public wrapper PID $RUNNER_PID did not become utility owner $owner_pid"
+  [ "$child_pid" != "$owner_pid" ] || fail "utility owner and assertion helper unexpectedly share PID $owner_pid"
+  helper_parent=$(ps -o ppid= -p "$child_pid" | tr -d ' ')
+  [ "$helper_parent" = "$owner_pid" ] || fail "assertion helper $child_pid was not bound beneath utility owner $owner_pid"
+  [ -e "$ASSERTION" ] || fail "power assertion was not active while the owned child was active"
+  expected=$(printf '%s\n' -s -i -m "$FAKEBIN/held-child")
+  actual=$(cat "$ARGS_LOG")
+  [ "$actual" = "$expected" ] || fail "Darwin argument selection was not utility-mode -s -i -m"
+  : > "$release"
+  wait "$RUNNER_PID"
+  status=$?
+  RUNNER_PID=
+  [ "$status" -eq 0 ] || fail "normal child status changed to $status"
+  wait_for_file "$OWNER_TERMINATED" || fail "assertion owner omitted its normal-exit termination handshake"
+  [ ! -e "$ASSERTION" ] || fail "power assertion survived normal child exit"
+  wait_for_pid_exit "$child_pid" || fail "assertion helper survived normal exit"
+  pass "long child: Darwin selects utility-mode assertions and releases them on normal exit"
+}
+
+test_failure_status_and_cleanup_are_preserved() {
+  local status
+  rm -f "$ASSERTION" "$ARGS_LOG" "$OWNER_READY" "$OWNER_PID_LOG" \
+    "$OWNER_TERMINATED" "$CHILD_PID_LOG"
+  env PATH="$FAKEBIN:$PATH" FM_FAKE_UNAME=Darwin \
+    FM_LONG_CHILD_CAFFEINATE_BIN="$FAKEBIN/caffeinate" \
+    FM_FAKE_ASSERTION="$ASSERTION" FM_FAKE_ARGS_LOG="$ARGS_LOG" \
+    FM_FAKE_OWNER_READY="$OWNER_READY" FM_FAKE_OWNER_PID_LOG="$OWNER_PID_LOG" \
+    FM_FAKE_OWNER_TERMINATED="$OWNER_TERMINATED" \
+    FM_FAKE_CHILD_PID_LOG="$CHILD_PID_LOG" \
+    "$OWNER" /bin/sh -c 'exit 23'
+  status=$?
+  [ "$status" -eq 23 ] || fail "failing child status changed from 23 to $status"
+  wait_for_file "$OWNER_TERMINATED" || fail "assertion owner omitted its failure termination handshake"
+  [ ! -e "$ASSERTION" ] || fail "power assertion survived failing child exit"
+  pass "long child: failure status is preserved and its assertion is released"
+}
+
+test_interruption_releases_assertion_and_terminates_child() {
+  local ready="$TMP_ROOT/interrupt-ready" release="$TMP_ROOT/never-release"
+  local child_terminated="$TMP_ROOT/interrupt-child-terminated"
+  local child_pid owner_pid status
+  rm -f "$ASSERTION" "$ARGS_LOG" "$OWNER_READY" "$OWNER_PID_LOG" \
+    "$OWNER_TERMINATED" "$CHILD_PID_LOG" "$ready" "$release" "$child_terminated"
+  env PATH="$FAKEBIN:$PATH" FM_FAKE_UNAME=Darwin \
+    FM_LONG_CHILD_CAFFEINATE_BIN="$FAKEBIN/caffeinate" \
+    FM_FAKE_ASSERTION="$ASSERTION" FM_FAKE_ARGS_LOG="$ARGS_LOG" \
+    FM_FAKE_OWNER_READY="$OWNER_READY" FM_FAKE_OWNER_PID_LOG="$OWNER_PID_LOG" \
+    FM_FAKE_OWNER_TERMINATED="$OWNER_TERMINATED" \
+    FM_FAKE_CHILD_PID_LOG="$CHILD_PID_LOG" FM_FAKE_READY="$ready" \
+    FM_FAKE_RELEASE="$release" FM_FAKE_TERMINATED="$child_terminated" \
+    "$OWNER" "$FAKEBIN/held-child" &
+  RUNNER_PID=$!
+  wait_for_file "$OWNER_READY" || fail "interruptible assertion owner did not become ready"
+  wait_for_file "$ready" || fail "interruptible child did not start"
+  owner_pid=$(cat "$OWNER_PID_LOG")
+  child_pid=$(cat "$CHILD_PID_LOG")
+  [ "$RUNNER_PID" = "$owner_pid" ] || fail "signal target $RUNNER_PID was not assertion owner $owner_pid"
+  [ -e "$ASSERTION" ] || fail "power assertion was not active before interruption"
+  kill -TERM "$owner_pid"
+  wait "$RUNNER_PID"
+  status=$?
+  RUNNER_PID=
+  [ "$status" -eq 143 ] || fail "interrupted owner returned $status instead of 143"
+  wait_for_file "$child_terminated" || fail "owned long child omitted its termination handshake"
+  wait_for_file "$OWNER_TERMINATED" || fail "assertion owner omitted its termination handshake"
+  [ ! -e "$ASSERTION" ] || fail "power assertion survived interruption"
+  wait_for_pid_exit "$child_pid" || fail "assertion helper survived interruption"
+  wait_for_pid_exit "$owner_pid" || fail "assertion owner survived interruption"
+  pass "long child: interruption reaches the child and cannot orphan its assertion"
+}
+
+test_non_darwin_executes_directly() {
+  local output status
+  rm -f "$ARGS_LOG"
+  output=$(PATH="$FAKEBIN:$PATH" FM_FAKE_UNAME=Linux \
+    FM_LONG_CHILD_CAFFEINATE_BIN="$FAKEBIN/caffeinate" \
+    "$OWNER" /bin/sh -c 'printf "direct:%s" "$1"; exit 19' _ value)
+  status=$?
+  [ "$status" -eq 19 ] || fail "non-Darwin child status changed from 19 to $status"
+  [ "$output" = direct:value ] || fail "non-Darwin child arguments changed: $output"
+  [ ! -e "$ARGS_LOG" ] || fail "non-Darwin path invoked the macOS assertion interface"
+  pass "long child: non-Darwin hosts execute the owned command directly"
+}
+
+test_missing_command_and_missing_macos_interface_fail_loudly() {
+  local output status
+  output=$(PATH="$FAKEBIN:$PATH" FM_FAKE_UNAME=Linux "$OWNER" 2>&1)
+  status=$?
+  [ "$status" -eq 2 ] || fail "missing command returned $status instead of usage status 2"
+  case "$output" in *"usage: fm-run-long-child.sh"*) ;; *) fail "missing command omitted usage" ;; esac
+
+  output=$(PATH="$FAKEBIN:$PATH" FM_FAKE_UNAME=Darwin \
+    FM_LONG_CHILD_CAFFEINATE_BIN="$TMP_ROOT/missing-caffeinate" \
+    "$OWNER" /bin/true 2>&1)
+  status=$?
+  [ "$status" -eq 1 ] || fail "missing macOS assertion interface returned $status"
+  case "$output" in *"requires executable caffeinate"*) ;; *) fail "missing caffeinate diagnostic was not actionable" ;; esac
+  pass "long child: invalid or unprotected launches fail loudly"
+}
+
+test_darwin_selects_utility_mode_and_binds_normal_lifetime
+test_failure_status_and_cleanup_are_preserved
+test_interruption_releases_assertion_and_terminates_child
+test_non_darwin_executes_directly
+test_missing_command_and_missing_macos_interface_fail_loudly

--- a/tests/fm-run-long-child.test.sh
+++ b/tests/fm-run-long-child.test.sh
@@ -183,6 +183,7 @@ test_non_darwin_executes_directly() {
   rm -f "$ARGS_LOG"
   output=$(PATH="$FAKEBIN:$PATH" FM_FAKE_UNAME=Linux \
     FM_LONG_CHILD_CAFFEINATE_BIN="$FAKEBIN/caffeinate" \
+    FM_FAKE_ARGS_LOG="$ARGS_LOG" \
     "$OWNER" /bin/sh -c 'printf "direct:%s" "$1"; exit 19' _ value)
   status=$?
   [ "$status" -eq 19 ] || fail "non-Darwin child status changed from 19 to $status"
@@ -212,6 +213,7 @@ test_unreadable_host_identity_fails_loudly() {
   rm -f "$ARGS_LOG"
   output=$(PATH="$FAKEBIN:$PATH" FM_FAKE_UNAME_STATUS=127 \
     FM_LONG_CHILD_CAFFEINATE_BIN="$FAKEBIN/caffeinate" \
+    FM_FAKE_ARGS_LOG="$ARGS_LOG" \
     "$OWNER" /bin/sh -c 'printf unprotected' 2>&1)
   status=$?
   [ "$status" -eq 1 ] || fail "unrunnable host lookup returned $status instead of failing loudly"
@@ -219,8 +221,10 @@ test_unreadable_host_identity_fails_loudly() {
   case "$output" in *"host kernel identity"*) ;; *) fail "unrunnable host lookup diagnostic was not actionable: $output" ;; esac
   [ ! -e "$ARGS_LOG" ] || fail "unrunnable host lookup still reached the macOS assertion interface"
 
+  rm -f "$ARGS_LOG"
   output=$(PATH="$FAKEBIN:$PATH" FM_FAKE_UNAME='' \
     FM_LONG_CHILD_CAFFEINATE_BIN="$FAKEBIN/caffeinate" \
+    FM_FAKE_ARGS_LOG="$ARGS_LOG" \
     "$OWNER" /bin/sh -c 'printf unprotected' 2>&1)
   status=$?
   [ "$status" -eq 1 ] || fail "empty host identity returned $status instead of failing loudly"

--- a/tests/fm-run-long-child.test.sh
+++ b/tests/fm-run-long-child.test.sh
@@ -181,6 +181,7 @@ test_interruption_releases_assertion_and_terminates_child() {
 test_non_darwin_executes_directly() {
   local output status
   rm -f "$ARGS_LOG"
+  # shellcheck disable=SC2016 # The inner /bin/sh, not this test shell, expands $1.
   output=$(PATH="$FAKEBIN:$PATH" FM_FAKE_UNAME=Linux \
     FM_LONG_CHILD_CAFFEINATE_BIN="$FAKEBIN/caffeinate" \
     FM_FAKE_ARGS_LOG="$ARGS_LOG" \

--- a/tests/fm-run-long-child.test.sh
+++ b/tests/fm-run-long-child.test.sh
@@ -28,7 +28,8 @@ trap cleanup EXIT
 
 cat > "$FAKEBIN/uname" <<'SH'
 #!/usr/bin/env bash
-printf '%s\n' "${FM_FAKE_UNAME:-Darwin}"
+[ -n "${FM_FAKE_UNAME_STATUS:-}" ] && exit "$FM_FAKE_UNAME_STATUS"
+printf '%s\n' "${FM_FAKE_UNAME-Darwin}"
 SH
 
 cat > "$FAKEBIN/caffeinate" <<'SH'
@@ -206,8 +207,32 @@ test_missing_command_and_missing_macos_interface_fail_loudly() {
   pass "long child: invalid or unprotected launches fail loudly"
 }
 
+test_unreadable_host_identity_fails_loudly() {
+  local output status
+  rm -f "$ARGS_LOG"
+  output=$(PATH="$FAKEBIN:$PATH" FM_FAKE_UNAME_STATUS=127 \
+    FM_LONG_CHILD_CAFFEINATE_BIN="$FAKEBIN/caffeinate" \
+    "$OWNER" /bin/sh -c 'printf unprotected' 2>&1)
+  status=$?
+  [ "$status" -eq 1 ] || fail "unrunnable host lookup returned $status instead of failing loudly"
+  case "$output" in *unprotected*) fail "unrunnable host lookup launched the child unprotected" ;; esac
+  case "$output" in *"host kernel identity"*) ;; *) fail "unrunnable host lookup diagnostic was not actionable: $output" ;; esac
+  [ ! -e "$ARGS_LOG" ] || fail "unrunnable host lookup still reached the macOS assertion interface"
+
+  output=$(PATH="$FAKEBIN:$PATH" FM_FAKE_UNAME='' \
+    FM_LONG_CHILD_CAFFEINATE_BIN="$FAKEBIN/caffeinate" \
+    "$OWNER" /bin/sh -c 'printf unprotected' 2>&1)
+  status=$?
+  [ "$status" -eq 1 ] || fail "empty host identity returned $status instead of failing loudly"
+  case "$output" in *unprotected*) fail "empty host identity launched the child unprotected" ;; esac
+  case "$output" in *"host kernel identity"*) ;; *) fail "empty host identity diagnostic was not actionable: $output" ;; esac
+  [ ! -e "$ARGS_LOG" ] || fail "empty host identity still reached the macOS assertion interface"
+  pass "long child: an unreadable host identity refuses instead of launching unprotected"
+}
+
 test_darwin_selects_utility_mode_and_binds_normal_lifetime
 test_failure_status_and_cleanup_are_preserved
 test_interruption_releases_assertion_and_terminates_child
 test_non_darwin_executes_directly
 test_missing_command_and_missing_macos_interface_fail_loudly
+test_unreadable_host_identity_fails_loudly

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -165,7 +165,7 @@ test_no_profile_keeps_claude_profile_defaults() {
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude default default
 
   launch=$(cat "$LAUNCH_LOG")
-  expected="env -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/brief.md')\""
+  expected="env -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false '${ROOT}/bin/fm-run-long-child.sh' claude --dangerously-skip-permissions \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/brief.md')\""
   [ "$launch" = "$expected" ] || fail "no-profile claude launch did not use the canonical launch kind"$'\n'"expected: $expected"$'\n'"actual:   $launch"
   pass "no --model/--effort records defaults and types the claude launch instructions"
 }
@@ -429,6 +429,8 @@ test_claude_threads_model_and_effort() {
   expect_code 0 "$status" "claude spawn with profile flags should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude sonnet high
   launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "'${ROOT}/bin/fm-run-long-child.sh'" \
+    "claude launch omitted the bounded long-child owner"
   assert_contains "$launch" "claude --dangerously-skip-permissions --model 'sonnet' --effort 'high'" \
     "claude launch did not thread model and effort flags"
   assert_not_contains "$launch" "--tui-mode" "non-Pi launches must not receive Pi's TUI mode override"
@@ -446,6 +448,8 @@ test_codex_threads_model_and_effort() {
   expect_code 0 "$status" "codex spawn with profile flags should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 high
   launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "'${ROOT}/bin/fm-run-long-child.sh'" \
+    "codex launch omitted the bounded long-child owner"
   assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"high\"' --dangerously-bypass-approvals-and-sandbox" \
     "codex launch did not thread model and reasoning effort config"
   pass "codex receives --model and model_reasoning_effort profile flags"
@@ -479,6 +483,8 @@ test_grok_threads_model_and_reasoning_effort() {
   expect_code 0 "$status" "grok spawn with profile flags should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" grok grok-4 high
   launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "'${ROOT}/bin/fm-run-long-child.sh'" \
+    "grok launch omitted the bounded long-child owner"
   assert_contains "$launch" "grok --always-approve --model 'grok-4' --reasoning-effort 'high'" \
     "grok launch did not thread model and reasoning-effort flags"
   assert_not_contains "$launch" "--effort" "grok launch must use --reasoning-effort, not --effort"
@@ -534,6 +540,8 @@ test_cursor_threads_model_workspace_and_omits_effort_axis() {
   expect_code 0 "$status" "cursor spawn with a model-qualified reasoning class should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" cursor cursor-grok-4.5-high high
   launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "'${ROOT}/bin/fm-run-long-child.sh'" \
+    "cursor launch omitted the bounded long-child owner"
   assert_contains "$launch" "--trust --yolo --model 'cursor-grok-4.5-high' --workspace '$WT_DIR'" \
     "cursor launch did not carry trust, autonomy, model, and exact workspace flags"
   # The executable is RESOLVED, never named: `cursor` is not the CLI, so a
@@ -603,6 +611,8 @@ test_opencode_threads_model_and_ignores_effort_axis() {
   expect_code 0 "$status" "opencode spawn with model and ignored effort should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" opencode anthropic/claude-sonnet-4-5 high
   launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "'${ROOT}/bin/fm-run-long-child.sh'" \
+    "opencode launch omitted the bounded long-child owner"
   assert_contains "$launch" "opencode --model 'anthropic/claude-sonnet-4-5' --prompt" \
     "opencode launch did not thread model"
   assert_not_contains "$launch" "--effort" "opencode launch must not pass unsupported --effort"
@@ -623,7 +633,7 @@ test_pi_threads_model_and_max_effort() {
   expect_code 0 "$status" "pi spawn with max effort should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" pi openai-codex/gpt-5.6-sol max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "FM_PI_HARNESS=pi '$FAKEBIN_DIR/pi' --tui-mode regular --model 'openai-codex/gpt-5.6-sol' --thinking 'max' -e" \
+  assert_contains "$launch" "FM_PI_HARNESS=pi '${ROOT}/bin/fm-run-long-child.sh' '$FAKEBIN_DIR/pi' --tui-mode regular --model 'openai-codex/gpt-5.6-sol' --thinking 'max' -e" \
     "pi launch did not force the regular TUI while threading the requested model and max thinking level"
   assert_not_contains "$launch" "FM_FIRSTMATE_PI_LAUNCH_BRIEF=" \
     "pi launch still exports the removed Calm input-reroute binding"
@@ -645,7 +655,7 @@ test_pi_signed_threads_shared_pi_profile_and_preserves_identity() {
   assert_contains "$out" "spawned $id harness=pi-signed" "pi-signed spawn did not preserve its visible identity"
   assert_meta_profile "$HOME_DIR/state/$id.meta" pi-signed openai-codex/gpt-5.6-sol max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "FM_PI_HARNESS=pi-signed '$FAKEBIN_DIR/pi-signed' --tui-mode regular --model 'openai-codex/gpt-5.6-sol' --thinking 'max' -e" \
+  assert_contains "$launch" "FM_PI_HARNESS=pi-signed '${ROOT}/bin/fm-run-long-child.sh' '$FAKEBIN_DIR/pi-signed' --tui-mode regular --model 'openai-codex/gpt-5.6-sol' --thinking 'max' -e" \
     "pi-signed launch did not force the regular TUI with Pi's model, thinking, and extension semantics"
   assert_contains "$launch" "fm-operational-input.sh' encode launch-brief" \
     "pi-signed launch lost the canonical typed launch-brief envelope"
@@ -735,7 +745,7 @@ test_pi_signed_persistent_secondmate_uses_pi_extensions_and_identity() {
     "pi-signed secondmate spawn did not preserve its runtime identity"
   assert_meta_profile "$HOME_DIR/state/$id.meta" pi-signed default default
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "FM_PI_HARNESS=pi-signed '$FAKEBIN_DIR/pi-signed' --tui-mode regular -e '$sm/.pi/extensions/fm-primary-turnend-guard.ts' -e '$sm/.pi/extensions/fm-primary-pi-watch.ts'" \
+  assert_contains "$launch" "FM_PI_HARNESS=pi-signed '${ROOT}/bin/fm-run-long-child.sh' '$FAKEBIN_DIR/pi-signed' --tui-mode regular -e '$sm/.pi/extensions/fm-primary-turnend-guard.ts' -e '$sm/.pi/extensions/fm-primary-pi-watch.ts'" \
     "pi-signed secondmate did not force the regular TUI with Pi's primary extension launch shape"
   pass "pi-signed is a distinct persistent secondmate runtime with shared Pi supervision semantics"
 }
@@ -770,7 +780,7 @@ test_claude_forwards_firstmate_config_dir_when_set() {
   status=$?
   expect_code 0 "$status" "claude spawn with CLAUDE_CONFIG_DIR set should succeed"
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "CLAUDE_CONFIG_DIR='/opt/test/claude-work' env -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude" \
+  assert_contains "$launch" "CLAUDE_CONFIG_DIR='/opt/test/claude-work' env -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false '${ROOT}/bin/fm-run-long-child.sh' claude" \
     "claude launch did not forward firstmate's CLAUDE_CONFIG_DIR to the crewmate pane"
   pass "claude forwards firstmate's CLAUDE_CONFIG_DIR so the crewmate uses the same credential store"
 }


### PR DESCRIPTION
## Intent

Implement the Captain-authorized CDO-43 correction so unattended Firstmate-owned long-running validation and worker children survive the intended host ordinary overnight maintenance-sleep conditions when configured to remain active. The observed incident had an active idle-sleep assertion yet entered Maintenance Sleep; prior reasoning that caffeinate -s was sufficient must account honestly for its AC-only validity, and the disproved premise that closed lid is necessarily a hard stop must not return. Reproduce and falsify the software-owned failure safely without triggering whole-machine sleep, taking foreground control, altering live scheduling, or changing system-wide power settings; compare idle-only and AC system-sleep assertion behavior, preserve incident history and contradictory closed-lid evidence, and report any exact hardware-state limit rather than claim an unproved battery transition. Put the smallest supported correction in the single authoritative Firstmate long-child launch owner, covering every supported harness and runtime integration surface while leaving raw unverified launch commands unchanged. Bind every assertion strictly to its owned child and prove release on normal exit, failure, and interruption with no orphan assertion and no wake behavior outside an active child. Add public-interface regression coverage for argument selection, real process/PID ownership topology, child lifetime, signaling only the production wrapper owner, and cleanup; do not assert source bytes. Perform a bounded overnight-shaped live test against the actual macOS process and assertion interfaces, including the applicable power condition, child lifetime, cleanup, exact verification, and honest AC/battery limit. Run repository lint, changed-surface tests, coverage, and no-mistakes. Do not add global always-awake behavior, launchd changes, a new control plane, unrelated refactors or Calm changes, disruptive sleep, unrelated follow-ups, system setting changes, or merge the PR. The unrelated Calm/Pi duplicate-answer failure was boundedly diagnosed without altering Calm: exported clean HEAD and the preserved branch both passed the unchanged test, demonstrating flakiness.

## What Changed

- Added `bin/fm-run-long-child.sh`, a single authoritative long-child launch owner that on macOS runs the child under `caffeinate -s -i -m` utility mode so one power assertion lives exactly as long as its owned child and is released on normal exit, failure, and interruption; it executes directly on non-Darwin hosts and refuses loudly when `uname -s` yields no host kernel identity rather than starting a Mac worker unprotected.
- Routed every verified `fm-spawn.sh` launch template (claude, codex, opencode, pi/pi-signed, grok, cursor, kimi, muse) through that owner via a new `__LONGCHILD__` placeholder, leaving the raw unverified-adapter launch command unwrapped, and extended `fm-test-run.sh` so edits to `bin/fm-spawn.sh` or the wrapper select the backend-dispatch, pure-contract-unit, orca, and secondmate families.
- Added `tests/fm-run-long-child.test.sh` covering argument selection, process/PID ownership topology, normal and failing child lifetime, TERM signalling of only the wrapper owner, and assertion cleanup through the public interface; updated the orca, kimi, muse, and spawn-dispatch-profile suites to pin the wrapped launch text, and documented the ownership contract plus the dated live macOS evidence — including the AC-only validity of `-s`, the unproved battery system-sleep limit, and the contradictory closed-lid canary — in `docs/architecture.md` and `docs/verification/runtime-backends.md`.

## Risk Assessment

✅ Low: The change is well-bounded and exec-preserving: it inserts one wrapper into every launch template without altering process ancestry, pgid, tty, exit-status propagation, or any liveness/identity probe; raw launch commands are untouched, the wrapper fails loudly on both unreadable host identity and missing caffeinate, the regression suite exercises the real public interface rather than source bytes, and the only residual gap (battery system-sleep) is an intent-authorized, honestly documented hardware limit.

## Testing

I exercised the bounded long-child power owner the way an operator actually hits it and it behaves as intended: on this macOS 26.6.2 arm64 host an idle-only assertion left PreventSystemSleep at 0 (the incident shape), while a child launched through bin/fm-run-long-child.sh held PreventSystemSleep, PreventUserIdleSystemSleep and PreventDiskIdle for the whole 70-second run, with pmset naming the assertion "on behalf of" the exact owned child PID, and returned all of them to 0 with no surviving caffeinate helper after normal exit; TERM sent only to the public wrapper owner returned 143, reaped the helper and released the assertion with no orphan. In a real tmux pane the harness is exec'd in place and remains the pane's foreground process with caffeinate as its child, so Firstmate's pane liveness/composer detection is unaffected, and killing the pane released everything. I also proved the regression direction: against an exported copy of the base commit the new long-child suite and the spawn launch-composition suite both fail (no wrapper, no assertion owner in the composed crewmate launch line) and both pass at the target; the raw --launch escape hatch stays byte-exact. Targeted suites (long-child, spawn-dispatch-profile, kimi, muse, backend-orca, secondmate-harness, trace-context-spawn, fm-test-run) and the runner's coverage guard all pass, and the changed-path routing now selects the orca and secondmate families that pin the launch text. No screenshot or rendered-UI artifact applies: this is a shell/process-level change with no UI, HTML or renderer surface, so the reviewer-visible evidence is CLI transcripts of the real power-assertion, process and tmux-pane state. One honest limit, which matches what the change documents rather than contradicting it: the host stayed on AC for the entire run, so the battery-side PreventSystemSleep behavior of caffeinate -s is not proven here and I did not change any power source or system power setting to manufacture it.

<details>
<summary>Evidence: Live macOS power-assertion transcript (idle-only counterfactual, 70s bounded child, interruption, AC/battery limit)</summary>

Source: [Live macOS power-assertion transcript (idle-only counterfactual, 70s bounded child, interruption, AC/battery limit)](https://github.com/cdonovan-abtex/firstmate/blob/41df91c84f79d782748ff4c68bd43e998a21ae9f/.no-mistakes/evidence/fm/firstmate-maintenance-sleep-survival-v1/live-macos-power-assertion-transcript.txt)

```text
=== Firstmate long-child power-assertion live verification ===
host: Darwin 25.6.0 arm64  macOS 26.6.2 build 25G83
date: 2026-08-22T22:13:37Z (UTC)
wrapper: /Users/christiandonovan/.no-mistakes/worktrees/d9c4fb60435f/01M0NN4HDT5VJNXGZH0E481X58/bin/fm-run-long-child.sh

--- [0] host power condition (read-only) ---
$ pmset -g batt
Now drawing from 'AC Power'
 -InternalBattery-0 (id=36044899)	100%; charged; 0:00 remaining present: true
$ pmset -g custom | awk '/Battery Power:|AC Power:| sleep /'
Battery Power:
 sleep                1
AC Power:
 sleep                0

--- [1] counterfactual: idle-only assertions (caffeinate -i -m) ---
$ pmset -g assertions  (idle-only owner pid=87154)
  PreventUserIdleSystemSleep=1  PreventSystemSleep=0  PreventDiskIdle=1
  => idle-only assertion does NOT hold PreventSystemSleep; maintenance/system sleep stays permitted

--- [2] corrected path: bin/fm-run-long-child.sh /bin/sleep 70 ---
$ ps -o pid=,ppid=,pgid=,stat=,etime=,command= -p 90385,90427
90385 87005 87000 S    00:02 /bin/sleep 70
90427 90385 87000 S    00:02 /usr/bin/caffeinate -s -i -m /bin/sleep 70
  public wrapper owner pid=90385   forked assertion helper pid=90427 (ppid=90385)
$ pmset -g assertions   [t+2s]
  PreventUserIdleSystemSleep=1  PreventSystemSleep=1  PreventDiskIdle=1
$ pmset -g assertions | grep -i caffeinate   [t+2s]
     PreventUserIdleDisplaySleep    0
     PreventSystemSleep             1
     PreventUserIdleSystemSleep     1
     pid 90427(caffeinate): [0x000104860001991b] 00:00:02 PreventUserIdleSystemSleep named: "caffeinate command-line tool"  
  	Details: caffeinate asserting on behalf of '/bin/sleep' (pid 90385)
  	Localized=THE CAFFEINATE TOOL IS PREVENTING SLEEP.
     pid 90427(caffeinate): [0x000104860007991c] 00:00:02 PreventSystemSleep named: "caffeinate command-line tool"  
  	Details: caffeinate asserting on behalf of '/bin/sleep' (pid 90385)
  	Localized=THE CAFFEINATE TOOL IS PREVENTING SLEEP.
     pid 90427(caffeinate): [0x00010486000f991d] 00:00:02 PreventDiskIdle named: "caffeinate command-line tool"  
  	Details: caffeinate asserting on behalf of '/bin/sleep' (pid 90385)
  	Localized=THE CAFFEINATE TOOL IS PREVENTING SLEEP.
     pid 550(powerd): [0x0000a81e0001a7f4] 06:34:18 PreventUserIdleSystemSleep named: "Powerd - Prevent sleep while display is on"  
$ pmset -g assertions   [t+35s, child still running: 00:35]
  PreventUserIdleSystemSleep=1  PreventSystemSleep=1  PreventDiskIdle=1
normal exit: status=0 owner_alive=no helper_alive=no
$ pmset -g assertions   [after normal exit]
  PreventUserIdleSystemSleep=1  PreventSystemSleep=0  PreventDiskIdle=?

--- [3] interruption: TERM the public wrapper owner only ---
owner pid=36668 helper pid=36672
$ pmset -g assertions   [before TERM]
  PreventSystemSleep=1
$ kill -TERM 36668  ->  status=143
owner_alive=no helper_alive=no
$ pgrep -f 'caffeinate -s -i -m /bin/sleep' -> '' (empty = no orphan assertion)
$ pmset -g assertions   [after TERM]
  PreventSystemSleep=0

--- [4] honest hardware-state limit ---
power source during this run: Now drawing from 'AC Power'
caffeinate(8) documents -s as valid only on AC power; this host stayed on AC for the whole run,
so no battery PreventSystemSleep assertion and no battery sleep transition is claimed here.
No power source, power setting, lid state, or whole-machine sleep was changed to produce this evidence.
=== end ===

--- note on the "PreventDiskIdle=?" reading above ---
`pmset -g assertions` omits PreventDiskIdle from its system-wide summary block when
nobody holds it, so "?" in the post-exit line means "no longer listed" (released),
not "unknown". Verified after the run:
  Assertion status system-wide:
     BackgroundTask                 0
     ApplePushServiceTask           0
     UserIsActive                   1
     PreventUserIdleDisplaySleep    0
     SoftwareUpdateTask             0
     PreventSystemSleep             0
     ExternalMedia                  0
     PreventUserIdleSystemSleep     1
     NetworkClientActive            0
  Listed by owning process:
  (no PreventDiskIdle row, no caffeinate owner: assertion fully released)
```
</details>
<details>
<summary>Evidence: Crewmate pane identity + teardown in a real tmux pane</summary>

Source: [Crewmate pane identity + teardown in a real tmux pane](https://github.com/cdonovan-abtex/firstmate/blob/41df91c84f79d782748ff4c68bd43e998a21ae9f/.no-mistakes/evidence/fm/firstmate-maintenance-sleep-survival-v1/tmux-pane-identity-and-teardown.txt)

```text
=== Crewmate pane identity + teardown through bin/fm-run-long-child.sh ===
tmux 3.7b on macOS 26.6.2 build 25G83

Why this matters: Firstmate reads a crewmate pane's FOREGROUND process for liveness and
composer detection. If the power-assertion tool took over that slot, every pane would look
like 'caffeinate'. This runs a real long-running foreground binary the way fm-spawn.sh now
composes a launch line: <long-child-owner> <harness>.

$ tmux new-session -d -s fm-longchild-evidence-41237 "'/Users/christiandonovan/.no-mistakes/worktrees/d9c4fb60435f/01M0NN4HDT5VJNXGZH0E481X58/bin/fm-run-long-child.sh' '/var/folders/l8/htqy6t0j6hd9y084y1jqmqbr0000gn/T/tmp.uDrEJBldAl/harness-stand-in'"
$ tmux display-message -p '#{pane_current_command}'  ->  cat      (NOT 'caffeinate')
$ tmux display-message -p '#{pane_pid}'              ->  41717

$ ps -eo pid=,ppid=,stat=,command=   (owner + its assertion helper)
   41704     1 Ss   tmux new-session -d -s fm-longchild-evidence-41237 '/Users/christiandonovan/.no-mistakes/worktrees/d9c4fb60435f/01M0NN4HDT5VJNXGZH0E481X58/bin/fm-run-long-child.sh' '/var/folders/l8/htqy6t0j6hd9y084y1jqmqbr0000gn/T/tmp.uDrEJBldAl/harness-stand-in'
   41717 41704 Ss+  /var/folders/l8/htqy6t0j6hd9y084y1jqmqbr0000gn/T/tmp.uDrEJBldAl/harness-stand-in
   41765 41717 S+   /usr/bin/caffeinate -s -i -m /var/folders/l8/htqy6t0j6hd9y084y1jqmqbr0000gn/T/tmp.uDrEJBldAl/harness-stand-in
   -> the harness was exec'd IN PLACE, so it keeps the pane's foreground PID;
      /usr/bin/caffeinate is its CHILD and holds the assertion for exactly that PID:

$ pmset -g assertions   (owning process + named beneficiary)
   pid 41765(caffeinate): [0x000106ca00019a63] 00:00:03 PreventUserIdleSystemSleep named: "caffeinate command-line tool"  
   	Details: caffeinate asserting on behalf of '/var/folders/l8/htqy6t0j6hd9y084y1jqmqbr0000gn/T/tmp.uDrEJBldAl/harness-stand-in' (pid 41717
   pid 41765(caffeinate): [0x000106ca00079a64] 00:00:03 PreventSystemSleep named: "caffeinate command-line tool"  
   	Details: caffeinate asserting on behalf of '/var/folders/l8/htqy6t0j6hd9y084y1jqmqbr0000gn/T/tmp.uDrEJBldAl/harness-stand-in' (pid 41717
   pid 41765(caffeinate): [0x000106ca000f9a65] 00:00:03 PreventDiskIdle named: "caffeinate command-line tool"  
   	Details: caffeinate asserting on behalf of '/var/folders/l8/htqy6t0j6hd9y084y1jqmqbr0000gn/T/tmp.uDrEJBldAl/harness-stand-in' (pid 41717

--- teardown: kill the pane, which is how a crewmate actually ends ---
$ tmux kill-session -t fm-longchild-evidence-41237
$ pgrep -f 'caffeinate -s -i -m'          -> ''   (empty: assertion died with the pane)
$ pgrep -f 'harness-stand-in'             -> ''   (empty: no orphaned child)
$ pmset -g assertions            ->       PreventSystemSleep             0
=== end ===
```
</details>
<details>
<summary>Evidence: Regression proof: new coverage fails at base commit, passes at target</summary>

Source: [Regression proof: new coverage fails at base commit, passes at target](https://github.com/cdonovan-abtex/firstmate/blob/41df91c84f79d782748ff4c68bd43e998a21ae9f/.no-mistakes/evidence/fm/firstmate-maintenance-sleep-survival-v1/regression-fail-before-pass-after.txt)

```text
=== Regression proof: new coverage fails at the base commit and passes at the target ===
base:   1231b6ae7fd4c5ff7e94d2f5ca2159536c4c41cb (exported read-only to /tmp/fm-base-check via git archive)
target: fc7196f3cf9118c7f7526a5406271506c25d8b29 (this worktree)
method: the target's test files were overlaid on the exported base tree and run with plain bash.

--- [A] tests/fm-run-long-child.test.sh @ base ---
$ cd /tmp/fm-base-check && bash tests/fm-run-long-child.test.sh
env: /tmp/fm-base-check/bin/fm-run-long-child.sh: No such file or directory
not ok - assertion owner did not become ready
(non-zero: the bounded long-child power owner does not exist at base)

--- [A'] tests/fm-run-long-child.test.sh @ target ---
ok - long child: Darwin selects utility-mode assertions and releases them on normal exit
ok - long child: failure status is preserved and its assertion is released
ok - long child: interruption reaches the child and cannot orphan its assertion
ok - long child: non-Darwin hosts execute the owned command directly
ok - long child: invalid or unprotected launches fail loudly
ok - long child: an unreadable host identity refuses instead of launching unprotected
FM_TEST_END 2026-08-22T22:20:55Z tests/fm-run-long-child.test.sh exit=0 duration_ms=1793 gate_skip=false

--- [B] tests/fm-spawn-dispatch-profile.test.sh @ base (real composed launch through fm-spawn.sh) ---
$ cd /tmp/fm-base-check && bash tests/fm-spawn-dispatch-profile.test.sh
not ok - no-profile claude launch did not use the canonical launch kind
expected: env -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false '/tmp/fm-base-check/bin/fm-run-long-child.sh' claude --dangerously-skip-permissions "$('/tmp/fm-base-check/bin/fm-operational-input.sh' encode launch-brief < '/var/folders/l8/htqy6t0j6hd9y084y1jqmqbr0000gn/T//fm-spawn-dispatch-profile.eLqjl5/profile-off/home/data/profile-off-z1/brief.md')"
actual:   env -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions "$('/tmp/fm-base-check/bin/fm-operational-input.sh' encode launch-brief < '/var/folders/l8/htqy6t0j6hd9y084y1jqmqbr0000gn/T//fm-spawn-dispatch-profile.eLqjl5/profile-off/home/data/profile-off-z1/brief.md')"
exit=1
(exit=1: at base the crewmate launch line has no power-assertion owner in front of the harness)

--- [B'] tests/fm-spawn-dispatch-profile.test.sh @ target ---
ok - no --model/--effort records defaults and types the claude launch instructions
ok - non-cursor launches clear inherited Cursor identity markers
ok - relative home overrides ignore CDPATH and become absolute before spawn launch construction
ok - absolute override spellings are preserved in spawn launch paths
ok - active crew-dispatch profile allows the raw launch-command escape hatch
ok - Pi launch probing omits --tui-mode on older Pi and preserves it on supporting Pi
ok - pi-signed shares Pi launch semantics while preserving its configured and recorded identity
ok - pi-signed is a distinct persistent secondmate runtime with shared Pi supervision semantics
ok - active crew-dispatch profile does not block secondmate launches
FM_TEST_END 2026-08-22T22:22:46Z tests/fm-spawn-dispatch-profile.test.sh exit=0 duration_ms=93481 gate_skip=false
```
</details>
<details>
<summary>Evidence: Targeted suite results and coverage guard</summary>

Source: [Targeted suite results and coverage guard](https://github.com/cdonovan-abtex/firstmate/blob/41df91c84f79d782748ff4c68bd43e998a21ae9f/.no-mistakes/evidence/fm/firstmate-maintenance-sleep-survival-v1/targeted-suite-results.txt)

```text
=== Targeted suite results (bin/fm-test-run.sh), all at target commit fc7196f ===

$ bin/fm-test-run.sh tests/fm-run-long-child.test.sh
FM_TEST_END tests/fm-run-long-child.test.sh exit=0   (6 behaviors, new suite)

$ bin/fm-test-run.sh tests/fm-spawn-dispatch-profile.test.sh tests/fm-kimi-harness.test.sh tests/fm-muse-harness.test.sh tests/fm-backend-orca.test.sh
FM_TEST_END 2026-08-22T22:14:16Z tests/fm-backend-orca.test.sh exit=0 duration_ms=36437 gate_skip=false
FM_TEST_SUMMARY total=4 failed=0 skipped_gate=0 duration_ms=199185
FM_TEST_SUMMARY_FAMILY family=backend-dispatch count=1 duration_ms=94477 failed=0
FM_TEST_SUMMARY_FAMILY family=orca count=1 duration_ms=36437 failed=0
FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=2 duration_ms=68105 failed=0

$ bin/fm-test-run.sh tests/fm-secondmate-harness.test.sh tests/fm-test-run.test.sh tests/fm-trace-context-spawn.test.sh
FM_TEST_END 2026-08-22T22:18:14Z tests/fm-secondmate-harness.test.sh exit=0 duration_ms=184109 gate_skip=false
FM_TEST_END 2026-08-22T22:18:33Z tests/fm-test-run.test.sh exit=0 duration_ms=19493 gate_skip=false
FM_TEST_END 2026-08-22T22:19:28Z tests/fm-trace-context-spawn.test.sh exit=0 duration_ms=54790 gate_skip=false
FM_TEST_SUMMARY total=3 failed=0 skipped_gate=0 duration_ms=258510

$ bin/fm-test-run.sh tests/fm-spawn-dispatch-profile.test.sh   (re-run alone, full log)
FM_TEST_END 2026-08-22T22:22:46Z tests/fm-spawn-dispatch-profile.test.sh exit=0 duration_ms=93481 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=93543

raw --launch escape hatch stays byte-exact (pre-existing expectation, unchanged):
ok - active crew-dispatch profile allows the raw launch-command escape hatch

$ bin/fm-test-run.sh --check-coverage
FM_TEST_COVERAGE ok total=155 parallel=24 serial=119 serial_shards=4 herdr=12
```
</details>
<details>
<summary>Evidence: Changed-surface family selection for this diff</summary>

Source: [Changed-surface family selection for this diff](https://github.com/cdonovan-abtex/firstmate/blob/41df91c84f79d782748ff4c68bd43e998a21ae9f/.no-mistakes/evidence/fm/firstmate-maintenance-sleep-survival-v1/changed-surface-family-selection.txt)

```text
=== bin/fm-test-run.sh changed-path routing for this change ===
$ bin/fm-test-run.sh --list --changed --base 1231b6a
(66 suites selected; the ones that pin or execute the composed crewmate launch:)
  tests/fm-kimi-harness.test.sh
  tests/fm-muse-harness.test.sh
  tests/fm-run-long-child.test.sh
  tests/fm-remote-secondmate-lifecycle-e2e.test.sh
  tests/fm-remote-secondmate-trace-context.test.sh
  tests/fm-secondmate-harness.test.sh
  tests/fm-secondmate-lifecycle-e2e.test.sh
  tests/fm-secondmate-liveness.test.sh
  tests/fm-secondmate-safety.test.sh
  tests/fm-secondmate-sync.test.sh
  tests/fm-send-secondmate-marker.test.sh
  tests/fm-spawn-dispatch-profile.test.sh
  tests/fm-trace-context-spawn.test.sh
  tests/fm-backend-orca.test.sh

Before this change bin/fm-spawn.sh routed only to backend-dispatch + pure-contract-unit,
so an orca/secondmate launch-text break would have deferred to full CI.

$ bin/fm-test-run.sh --check-coverage
FM_TEST_COVERAGE ok total=155 parallel=24 serial=119 serial_shards=4 herdr=12
```
</details>
<details>
<summary>Evidence: Key live observation: assertion is bound to the owned child PID and dies with it</summary>

```text
--- [1] counterfactual: idle-only assertions (caffeinate -i -m) ---
PreventUserIdleSystemSleep=1 PreventSystemSleep=0 PreventDiskIdle=1
=> idle-only assertion does NOT hold PreventSystemSleep; maintenance/system sleep stays permitted

--- [2] corrected path: bin/fm-run-long-child.sh /bin/sleep 70 ---
90385 87005 87000 S 00:02 /bin/sleep 70
90427 90385 87000 S 00:02 /usr/bin/caffeinate -s -i -m /bin/sleep 70
PreventUserIdleSystemSleep=1 PreventSystemSleep=1 PreventDiskIdle=1 [t+2s]
pid 90427(caffeinate): PreventSystemSleep named: "caffeinate command-line tool"
Details: caffeinate asserting on behalf of '/bin/sleep' (pid 90385)
PreventUserIdleSystemSleep=1 PreventSystemSleep=1 PreventDiskIdle=1 [t+35s]
normal exit: status=0 owner_alive=no helper_alive=no
PreventSystemSleep=0 [after normal exit]

--- [3] interruption: TERM the public wrapper owner only ---
$ kill -TERM 36668 -> status=143
owner_alive=no helper_alive=no
$ pgrep -f 'caffeinate -s -i -m' -> '' (empty = no orphan assertion)
PreventSystemSleep=0 [after TERM]
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"20a480f8a7157563ed8f61cf83bc57d74e9f02f3","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- 🚨 `tests/fm-backend-orca.test.sh:523` - The claude launch template now inserts the long-child wrapper between the env assignment and the binary, so the composed launch text is `...PROMPT_SUGGESTION=false &#39;&lt;ROOT&gt;/bin/fm-run-long-child.sh&#39; claude --dangerously-skip-permissions ...`. tests/fm-backend-orca.test.sh:523 asserts the contiguous substring &#34;CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions&#34; against the text fm-spawn sends through the fake Orca terminal (assert_contains is a plain `*&#34;$2&#34;*` glob, tests/lib.sh:266). That spawn is a template launch, not a raw command (`fm-spawn.sh &#34;$id&#34; &#34;$proj&#34; claude ...` has no space, so bin/fm-spawn.sh:1214 takes the launch_template branch), so the substring is no longer present and the test fails. The branch updated the equivalent assertions in fm-spawn-dispatch-profile, fm-kimi-harness, and fm-muse-harness but missed this one. It also will not surface in the required changed-surface run: bin/fm-test-run.sh:1001 maps bin/fm-spawn.sh to families `backend-dispatch` + `pure-contract-unit`, while fm-backend-orca.test.sh is classified into the `orca` family (bin/fm-test-run.sh:227), which only bin/backends/orca*|bin/backends/tmux.sh selects (bin/fm-test-run.sh:928). Fix the assertion to match the new shape (e.g. assert the wrapper path and &#34;claude --dangerously-skip-permissions&#34; separately, as the muse/dispatch-profile tests now do). Since launch-template edits are exactly what this assertion guards, also add `orca` to the families for bin/fm-spawn.sh in families_for_changed_path so a future launch-shape change re-runs the backend test that pins it rather than deferring the failure to full CI.
- ℹ️ `bin/fm-run-long-child.sh:26` - `[ &#34;$(uname -s 2&gt;/dev/null || echo unknown)&#34; = Darwin ]` folds a failed `uname` lookup into the non-Darwin branch, which then `exec &#34;$@&#34;` with no assertion at all. On a macOS host where `uname` is not resolvable on PATH, the harness still launches for every template whose binary is an absolute path (kimi, cursor, muse, pi/pi-signed) and runs completely unprotected with no diagnostic - reproducing the same silent &#34;looked protected, slept anyway&#34; class this change exists to close. Note the asymmetry: the sibling failure (missing caffeinate) is deliberately loud (`exit 1`, bin/fm-run-long-child.sh:28-30). Reachability is thin, so this is not a merge blocker, but distinguishing &#34;uname says non-Darwin&#34; from &#34;uname could not be run&#34; and failing loudly on the latter would make the wrapper&#39;s protection guarantee non-silent in every branch.
- ℹ️ `bin/fm-spawn.sh:1115` - Tradeoff note, not a defect. Every spawned crewmate pane on every supported harness now unconditionally holds PreventSystemSleep/PreventUserIdleSystemSleep/PreventDiskIdle for its whole life, so on AC the host will not system-sleep while any crewmate is alive - including short daytime scouts and a closed lid. This is bound strictly to a child (no launchd unit, no daemon, no config plane), which is what the intent authorizes and what its &#34;no global always-awake behavior&#34; and &#34;no new control plane&#34; constraints rule out alternatives to, and docs/verification/runtime-backends.md records the AC-only limit honestly. Flagged only so the whole-machine scope of the effect is visible in review rather than discovered in use.

🔧 Fix: fix orca launch assertion and loud host detection
2 issues (1 warning, 1 info) still open:
- ⚠️ `bin/fm-test-run.sh:1007` - The fix round added `orca` to families_for_changed_path for bin/fm-spawn.sh with the comment (bin/fm-test-run.sh:1002-1004) &#34;the Orca suite is the only family that pins the composed launch text a template edit changes&#34;. That claim is not true. tests/fm-secondmate-harness.test.sh is classified into the `secondmate` family (bin/fm-test-run.sh:175), and it both asserts composed launch text (line 769 `claude --dangerously-skip-permissions --model &#39;opus&#39;`, line 791, line 856 `codex --dangerously-bypass-approvals-and-sandbox`, lines 746/975 assert_not_contains `--model`) and, at line 914, actually EXECUTES the composed launch via `bash -c &#34;$launch&#34;` against a fake harness. bin/fm-spawn.sh now emits only backend-dispatch + pure-contract-unit + orca, so a future launch_template edit that breaks any of those can pass the changed-surface run and only fail in full CI - precisely the deferred-break class this hunk was added to close. This change itself does NOT break that suite (I traced each assertion: the wrapper is inserted before the binary, so every asserted substring stays contiguous; BASE_PATH at line 62 is /usr/bin:/bin:/usr/sbin:/sbin so `uname` resolves; and I verified on this macOS host that `caffeinate -s -i -m /usr/bin/true` is silent on stdout/stderr, so line 914&#39;s `[ -z &#34;$out&#34; ]` claude assertion still holds). Minimal fix: add `printf &#39;%s\n&#39; secondmate` to the bin/fm-spawn.sh branch and correct the comment to name every launch-text-pinning family rather than claiming Orca is the only one.
- ℹ️ `tests/fm-run-long-child.test.sh:220` - In test_unreadable_host_identity_fails_loudly (lines 220 and 229) and in the pre-existing test_non_darwin_executes_directly (line 190), the guard `[ ! -e &#34;$ARGS_LOG&#34; ] || fail &#34;... reached the macOS assertion interface&#34;` cannot fail. FM_FAKE_ARGS_LOG is not passed in those invocations, so if the Darwin branch ever did run, the fake caffeinate (lines 35-38, `set -u`) would die on the unbound `$FM_FAKE_ARGS_LOG` before writing anything, leaving ARGS_LOG absent and the guard green. The tests still detect the regression through their other assertions (status 1, absence of `unprotected` in output, presence of the `host kernel identity` diagnostic - I confirmed the pre-fix code would emit `unprotected` with status 0 under FM_FAKE_UNAME_STATUS=127), so this is a decorative assertion rather than a hole. Passing FM_FAKE_ARGS_LOG=&#34;$ARGS_LOG&#34; in these three invocations would make the guard load-bearing.

🔧 Fix: select secondmate family and harden long-child test guards
1 warning still open:
- ⚠️ `bin/fm-test-run.sh:1031` - families_for_changed_path maps bin/fm-run-long-child.sh only to `pure-contract-unit`, but the wrapper is EXECUTED (not just named) by a suite in another family. tests/fm-secondmate-harness.test.sh:915 runs `bash -c &#34;$launch&#34;` against the composed secondmate launch, which embeds &#39;&lt;ROOT&gt;/bin/fm-run-long-child.sh&#39; because spawn_secondmate_capture sets FM_ROOT_OVERRIDE=&#34;$ROOT&#34; (tests/fm-secondmate-harness.test.sh:677), and line 923 asserts `[ -z &#34;$out&#34; ]` for the claude case. That suite is classified into the `secondmate` family (bin/fm-test-run.sh:173-181). Concrete break: a later edit that adds any stdout/stderr diagnostic to the Darwin branch of bin/fm-run-long-child.sh, or changes its exit status, fails that assertion while the changed-surface run - which selects only pure-contract-unit - passes green, deferring the failure to full CI. This is exactly the class the two prior fix rounds closed for bin/fm-spawn.sh. Minimal fix: split bin/fm-run-long-child.sh out of the shared pure-contract-unit branch and emit both `pure-contract-unit` (fm-run-long-child.test.sh, and fm-muse-harness.test.sh, which also executes the composed launch via FM_FAKE_EXECUTE_MUSE_LAUNCH=1) and `secondmate`.

🔧 Fix: select secondmate family for long-child wrapper changes
1 info still open:
- ℹ️ `bin/fm-run-long-child.sh:37` - Residual-risk note, not a defect. `exec &#34;$caffeinate_bin&#34; -s -i -m &#34;$@&#34;` closes the incident only on AC: caffeinate(8) on this host documents `-s` as &#34;valid only when system is running on AC power&#34;, so on battery the child holds PreventUserIdleSystemSleep + PreventDiskIdle but NOT PreventSystemSleep, and the observed maintenance-sleep path stays reachable exactly as before. The wrapper does not distinguish the two cases at runtime - a battery-powered overnight worker launches, prints nothing, and looks protected. This is explicitly authorized containment: the intent requires reporting &#34;any exact hardware-state limit rather than claim an unproved battery transition&#34;, and docs/verification/runtime-backends.md:52-55 records the limit honestly (&#34;this run does not prove a battery PreventSystemSleep assertion or an actual battery sleep transition&#34;). Adding a runtime battery diagnostic would need a `pmset -g batt` read that the intent&#39;s &#34;no system setting changes / no new control plane&#34; boundary did not ask for, so this is flagged for visibility only. Verified against the vendor interface on this macOS host: caffeinate utility mode execs the command in the invoking PID and forks the assertion helper beneath it, the helper exits even when the utility is SIGKILLed (no orphan assertion), and a missing utility still yields the original diagnostic and exit 127 - so the AC path itself is sound and process topology is unchanged for every liveness and ancestry probe.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bin/fm-test-run.sh tests/fm-run-long-child.test.sh` — new public-interface suite: argument selection, PID topology, normal exit, failing exit, interruption, non-Darwin passthrough, loud refusal on unreadable host identity</code>
- <code>`bin/fm-test-run.sh tests/fm-spawn-dispatch-profile.test.sh tests/fm-kimi-harness.test.sh tests/fm-muse-harness.test.sh tests/fm-backend-orca.test.sh` — composed launch text for claude/codex/grok/cursor/opencode/pi/pi-signed/kimi/muse and the Orca send path</code>
- <code>`bin/fm-test-run.sh tests/fm-secondmate-harness.test.sh tests/fm-test-run.test.sh tests/fm-trace-context-spawn.test.sh` — secondmate family that actually executes the composed launch, plus the changed family-selection owner</code>
- <code>`bin/fm-test-run.sh --check-coverage` and `bin/fm-test-run.sh --list --changed --base 1231b6a` — confirmed the new suite is family-assigned and that a bin/fm-spawn.sh or bin/fm-run-long-child.sh edit now selects backend-dispatch, pure-contract-unit, orca and secondmate</code>
- <code>Live macOS check: `pmset -g batt`, `pmset -g custom`, idle-only counterfactual `/usr/bin/caffeinate -i -m /bin/sleep 6`, then `bin/fm-run-long-child.sh /bin/sleep 70` with `ps -o pid=,ppid=,pgid=,stat=,etime=,command=` and `pmset -g assertions` at t+2s, t+35s and after exit</code>
- <code>Live interruption check: `bin/fm-run-long-child.sh /bin/sleep 120` then `kill -TERM &lt;wrapper owner pid&gt;`; asserted status 143, helper gone, `pgrep -f &#39;caffeinate -s -i -m&#39;` empty, `PreventSystemSleep` back to 0</code>
- <code>Live pane check: `tmux new-session -d -s ... &#34;bin/fm-run-long-child.sh &lt;long-running binary&gt;&#34;`, then `tmux display-message -p &#39;#{pane_current_command}&#39; / &#39;#{pane_pid}&#39;`, `ps`, `pmset -g assertions`, then `tmux kill-session` and re-check for orphans</code>
- <code>Fail-before proof: exported base commit 1231b6a read-only with `git archive` to /tmp/fm-base-check, overlaid the target&#39;s test files, ran `bash tests/fm-run-long-child.test.sh` and `bash tests/fm-spawn-dispatch-profile.test.sh` there (both non-zero)</code>

</details>

<details>
<summary>⚠️ **Document** - 2 infos</summary>

- ℹ️ `docs/verification/runtime-backends.md:9` - The new evidence section lives in docs/verification/runtime-backends.md, whose stated scope is runtime session-backend guarantees, while this evidence is about harness launch power ownership rather than a backend adapter. I left it in place because relocating it would create a new documentation surface for a single record, which the placement policy discourages. If more launch-level verification accumulates, a follow-up could split a launch-verification owner out of the runtime-backend record and update the audience inventory accordingly.
- ℹ️ `docs/scripts.md:9` - docs/scripts.md does not list bin/fm-run-long-child.sh. I judged this not stale: the toolbelt is a curated list of first-mate-driven entrypoints and already omits ~33 internal helpers and libs (fm-cursor-lib.sh, fm-trace-context-lib.sh, fm-procevent-lib.sh, and others), and the wrapper is only invoked by fm-spawn.sh launch templates. Adding one row would set an exhaustiveness expectation the document does not currently meet; a separate follow-up could decide whether that inventory should be exhaustive and checked.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: annotate intentional SC2016 in long-child test
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
