### PR TITLE
fix(bin): fail closed for blocked Pi composers

### DIFF
--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -63,7 +63,7 @@
 #                mode/model footer line.
 #   separated  - pi: content rows between two solid horizontal `─` rules, no
 #                glyph and no side border. Provable only with a live agent
-#                identity reporting an idle/done/blocked pi (herdr `agent
+#                identity reporting an idle/done pi (herdr `agent
 #                get`; the tmux foreground-process probe), because a blank
 #                region between two transcript rules is otherwise exactly the
 #                strict rule's unidentifiable blank row.
@@ -1379,7 +1379,11 @@ _fm_composer_classify_bare_pi_overlap() {  # <screen> <styled> <has-identity> <i
 # rule, now fleet-wide). A missing identity capability keeps the shape
 # unknown; an unfetched identity on an identity-capable backend asks the
 # adapter to probe (lazily) and re-call. Proven input remains pending for every
-# live pi state, while only an idle/done/blocked pi proves an empty composer.
+# live pi state, while only an idle/done pi proves an empty composer. A blocked
+# pi is parked on an interactive prompt waiting for a human keystroke: its menu
+# is drawn above the separator pair, so the composer region looks free while the
+# keys would answer the prompt instead of composing (issue #2797). Structure
+# cannot disprove that, so a blocked pi defers rather than claiming empty.
 _fm_composer_pi_verdict() {  # <screen> <styled> <has_identity> <identity>
   local screen=$1 styled=$2 has_identity=$3 identity=$4 agent agent_status state
   if [ "$has_identity" != 1 ]; then
@@ -1406,7 +1410,7 @@ _fm_composer_pi_verdict() {  # <screen> <styled> <has_identity> <identity>
     return 0
   fi
   case "$agent_status" in
-    idle|done|blocked) printf 'empty' ;;
+    idle|done) printf 'empty' ;;
     *) printf 'unknown' ;;
   esac
 }

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -238,7 +238,8 @@ A human-blocked permission dialog has no busy banner and still surfaces.
 ## Composer and injection safety
 
 Herdr has no direct cursor-row primitive.
-The adapter is a thin capture: it hands a bounded ANSI tail plus Herdr's capability facts to the fleet-wide classifier in `bin/fm-composer-lib.sh`, which owns every shape - bordered boxes, bare agent-glyph rows (including muse's `⟩`, which the adapter's retired local pattern silently omitted), opencode's left bar, and the Pi separator region this adapter pioneered, admitted only when native `agent get` identity is exactly Pi and state is idle, done, or blocked.
+The adapter is a thin capture: it hands a bounded ANSI tail plus Herdr's capability facts to the fleet-wide classifier in `bin/fm-composer-lib.sh`, which owns every shape - bordered boxes, bare agent-glyph rows (including muse's `⟩`, which the adapter's retired local pattern silently omitted), opencode's left bar, and the Pi separator region this adapter pioneered, admitted only when native `agent get` identity is exactly Pi and state is idle or done.
+A blocked Pi is parked on an interactive prompt, so its blank composer region is a menu's and not a free composer's; that state defers instead of proving emptiness.
 A working Pi, pending middle row, missing identity, incomplete separator pair, or over-tall candidate remains unknown or pending.
 Identity stays a lazy second read, consulted only when a separator pair could change the verdict.
 

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -3083,6 +3083,28 @@ test_composer_state_pi_separator_idle_is_empty() {
   pass "fm_backend_herdr_composer_state: a native idle Pi separator composer reads empty"
 }
 
+# A pi worker parked on an interactive prompt (permission dialog, question
+# menu, trust dialog) reports agent_status=blocked: it is waiting on a human
+# keystroke. The menu is drawn ABOVE the separator pair, so the composer region
+# itself is blank and structure alone looks like a free composer. Typing there
+# does not compose a message - the menu consumes the keys and Enter selects the
+# highlighted default, so the text is discarded and a decision nobody made is
+# recorded (issue #2797). Every "is it safe to type here?" consumer reads this
+# verdict: the away-mode injection guard (bin/fm-supervise-daemon.sh) and
+# fm-send's pre-type refusal both proceed ONLY on an affirmative `empty`.
+test_composer_state_pi_parked_prompt_is_not_empty() {
+  local dir log resp fb out
+  dir="$TMP_ROOT/composer-pi-parked-prompt"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf 'Should I keep going?\n  1. Yes, continue\n\x1b[7m  2. Stop, do not act\x1b[0m\n\x1b[0m\x1b[38;2;129;162;190m─────────────────────────────────────────────────────\x1b[0m\n\x1b[0m\x1b[7m \x1b[0m                                                    \n\x1b[0m\x1b[38;2;129;162;190m─────────────────────────────────────────────────────\x1b[0m\n' > "$resp/1.out"
+  printf '{"result":{"agent":{"agent":"pi","agent_status":"blocked"}}}\n' > "$resp/2.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_composer_state lab:w1:p2' "$ROOT" )
+  [ "$out" != empty ] \
+    || fail "a pi pane parked on a prompt must not report an affirmatively empty composer, got '$out'"
+  pass "fm_backend_herdr_composer_state: a blocked pi pane parked on a prompt is not an empty composer"
+}
+
 test_composer_state_pi_separator_real_text_is_pending() {
   local dir log resp fb out
   dir="$TMP_ROOT/composer-pi-separated-pending"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
@@ -4520,6 +4542,7 @@ test_composer_state_real_text_is_pending
 test_composer_state_popup_placeholder_fill_is_pending
 test_composer_state_unknown_on_capture_failure
 test_composer_state_unknown_when_no_composer_row_found
+test_composer_state_pi_parked_prompt_is_not_empty
 test_composer_state_pi_separator_idle_is_empty
 test_composer_state_pi_separator_real_text_is_pending
 test_composer_state_pi_incomplete_separator_below_stale_generic_is_unknown

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -291,11 +291,12 @@ test_matrix_herdr_halfblock_rule_bounds_bare_wrap() {
 test_matrix_pi_separated_needs_identity() {
   # Real idle pi: a blank row between two solid rules. The blank row alone is
   # exactly what the strict rule refuses; only structure PLUS a live
-  # idle/done/blocked pi identity proves the composer (herdr's rule, now
+  # idle/done pi identity proves the composer (herdr's rule, now
   # fleet-wide; tmux supplies identity from its foreground-process probe).
-  local screen typed pi_idle pi_working none
+  local screen typed pi_idle pi_working pi_blocked none
   screen=$'transcript\n────────────────────────\n\n────────────────────────\n footer'
   pi_idle=$(printf 'pi\tidle'); pi_working=$(printf 'pi\tworking'); none=$(printf 'zsh\t')
+  pi_blocked=$(printf 'pi\tblocked')
   assert_screen "pi idle with identity" empty "$CAPS_STYLED" "$screen" '' "$pi_idle"
   assert_screen "pi idle on tmux with identity" empty "$CAPS_TMUX" "$screen" 2 "$pi_idle"
   assert_screen "pi idle on zellij" unknown "$CAPS_STYLED_NOID" "$screen"
@@ -306,6 +307,10 @@ test_matrix_pi_separated_needs_identity() {
   assert_screen "pi pair without identity capability" unknown "$CAPS_PLAIN" "$screen"
   # A working pi cannot authorize injection into the blank region.
   assert_screen "working pi defers" unknown "$CAPS_STYLED" "$screen" '' "$pi_working"
+  # A pi parked on an interactive prompt reports `blocked`: it is waiting on a
+  # human keystroke, so the blank region is a menu's, not a free composer's.
+  # Typing there answers the prompt and the text is discarded (issue #2797).
+  assert_screen "blocked pi defers" unknown "$CAPS_STYLED" "$screen" '' "$pi_blocked"
   # The audit's live counterexample: a plain shell running sleep, cursor
   # parked on a blank line between two rules, NO pi process. The permissive
   # rule read this `empty`; identity+structure refuses it.


### PR DESCRIPTION
## Intent

Close the remaining herdr-side hole in the "text delivered to a worker parked on an interactive prompt answers the prompt and is silently discarded" defect (upstream issue #2797, and its duplicate #1474, which reports the same defect from the stale-draft symptom).

Scope is deliberately narrow and was set after a shadow check of the open PR queue, so the diff is intentionally one behavioral line. Two open upstream PRs already cover this defect and must NOT be duplicated or re-implemented: #2439 (feat: preflight composers before steering) adds fm-send's pre-type refusal, which is backend-generic because it dispatches through fm_backend_composer_state "$TARGET_BACKEND"; #2800 (fix(tmux): refuse text dropped by composer) adds a post-type payload-append proof, which lives in bin/fm-tmux-lib.sh and is therefore tmux-only. This change is complementary adapter coverage that makes those mechanisms correct on herdr; it is not an alternative to either, and the PR body must say so plainly and reference both.

The verified gap: bin/fm-composer-lib.sh's _fm_composer_pi_verdict admitted `blocked` alongside `idle` and `done` as proof of an affirmatively empty composer. But `blocked` is exactly the native agent_status of a pi pane parked on an interactive prompt - a permission dialog, an AskUserQuestion menu, a trust dialog - where the agent is waiting on a human keystroke. Pi draws that menu ABOVE its separator pair, so the composer region between the two rules is blank and structure alone looks like a free composer. Classifying that screen through the herdr adapter on current main returned `empty`, which is the single verdict #2439's guard lets through and which #2800's tmux-only proof never sees. A Claude-style bordered permission dialog classifies as `pending` on the same path and so is already refused by #2439; it is specifically the pi separator shape that was admitted.

Why this matters on current main independently of either open PR: the same verdict is read by the away-mode injection guard in bin/fm-supervise-daemon.sh, which injects only into a confirmed-empty composer. So away mode will type an escalation straight into a parked pi prompt, the keys answer the menu instead of composing a message, the highlighted default is selected, the text is discarded, and the record attributes a decision to a human who never made it.

The fix, at the classifier that owns composer shapes and verdicts (adapters only contribute capture facts): `blocked` now falls through to `unknown`, which every consumer already treats as fail-closed. `idle` and `done` still prove an empty composer, so ordinary steering is unchanged and this does not regress delivery-truth for readable panes. Cursor is unaffected because its always-blocked panes never reach this pi-only branch (_fm_composer_pi_verdict returns unknown unless identity is exactly pi). Deliberately NOT introducing a new composer verdict value: adding one would ripple through every consumer of composer_state and collide with the two open PRs, while the existing `unknown` already carries the required fail-closed meaning.

Regression coverage was written first and confirmed RED against main at both levels, then green: tests/fm-composer-lib.test.sh gains a "blocked pi defers" assertion at the verdict owner (was: expected unknown, got 'empty'), and tests/fm-backend-herdr.test.sh gains test_composer_state_pi_parked_prompt_is_not_empty at the adapter (was: got 'empty'). Documentation was updated only where behavior changed: the authoritative composer-and-injection-safety section of docs/herdr-backend.md, plus the function and header comments in bin/fm-composer-lib.sh that stated the old idle/done/blocked rule.

Deliberately out of scope, already handled, and not to be re-opened by this change: upstream issue #2361 (fm-send falsely reports delivery unconfirmed for live idle herdr/pi panes) is ALREADY FIXED on main by merged PR #2647 and needs no code here. The PR must therefore close ONLY #2797 and #1474 with Fixes lines and must NOT reference #2361 as fixed.

Deliver as a pull request to upstream kunchenguid/firstmate from the karotkriss fork. Never merge it.

## What Changed

- Treat blocked Pi separator panes as `unknown`, preventing Herdr composer consumers from mistaking interactive prompts for empty input while preserving idle and done behavior.
- Add classifier-level and Herdr adapter regression coverage, and document the fail-closed behavior.
- Complement #2439's backend-generic pre-type refusal and #2800's tmux-only post-type proof without duplicating either change.

Fixes #2797
Fixes #1474

## Risk Assessment

✅ Low: The well-bounded fail-closed classifier change closes the reachable blocked-Pi injection path while preserving proven idle, done, and pending behavior.

## Testing

Diff inspection and a read-only Herdr 0.8.2 availability check established the test context. Both focused automated suites passed. The behavioral transcript reproduces the base defect (`blocked` returned `empty`), proves the target returns fail-closed `unknown`, and shows away-mode injection defers without sending while the idle control still sends. No screenshot was captured because this is a shell classifier and backend safety change with no rendered UI; the CLI transcript is the reviewer-visible product evidence.

<details>
<summary>Evidence: Herdr pi blocked-prompt safety transcript</summary>

Source: [Herdr pi blocked-prompt safety transcript](https://github.com/karotkriss/firstmate/blob/456fb936e69d942ef402801ffc59d3997a98e063/.no-mistakes/evidence/fm/fm-send-truth/herdr-pi-blocked-safety-transcript.txt)

<code>base blocked verdict: empty&#10;target blocked verdict: unknown&#10;target idle verdict: empty&#10;target done verdict: empty&#10;target working verdict: unknown&#10;blocked prompt injection: deferred&#10;idle composer injection: sent</code>

```text
Herdr pi parked-prompt safety proof
===================================
base blocked verdict:   empty
target blocked verdict: unknown
target idle verdict:    empty
target done verdict:    empty
target working verdict: unknown

Away-mode injection boundary
guard log: inject deferred: supervisor composer not confirmed-empty (state=unknown: pending input, dead-shell prompt, or unreadable pane)
blocked prompt injection: deferred
send seam invoked
idle composer injection: sent
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"77e36fd709e617ba51d72e78e64188f8c4a85b34","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `tests/fm-composer-lib.test.sh`
- `tests/fm-backend-herdr.test.sh`
- <code>Compared the base and target `fm_composer_classify_screen` behavior using the same parked pi prompt for blocked, idle, done, and working states</code>
- <code>Exercised `inject_msg` through the herdr adapter seam for blocked and idle pi states</code>
- <code>Confirmed `HEAD` is target commit `77e36fd709e617ba51d72e78e64188f8c4a85b34` and the worktree remained clean</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
