### PR TITLE
fix: prevent fleet snapshot argument overflow

### DIFF
--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -428,7 +428,7 @@ task_json_lines() {
   local meta id kind harness mode yolo project worktree home projects backend target status_log report_path
   local remote_host remote_root remote_state remote_rc remote_home_present
   local pr pr_source event_json current_json endpoint_exists agent_alive meta_json status_json report_json worktree_json home_json
-  local last_event_raw current_state current_source pending_decision blocked_event report_present=0 pr_from_status
+  local current_state current_source pending_decision blocked_event report_present=0 pr_from_status
   local open_decisions_tsv open_decisions_json
 
   for meta in "$STATE"/*.meta; do
@@ -469,7 +469,6 @@ task_json_lines() {
 
     current_json=$(crew_state_json "$id")
     event_json=$(status_event_json "$status_log")
-    last_event_raw=$(printf '%s' "$event_json" | jq -r '.last_event.raw // ""')
     current_state=$(printf '%s' "$current_json" | jq -r '.state // ""')
     current_source=$(printf '%s' "$current_json" | jq -r '.source // ""')
 
@@ -552,7 +551,11 @@ task_json_lines() {
       home_json=$(jq -n '{path:null,present:false}')
     fi
 
-    jq -n \
+    printf '%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n' \
+      "$current_json" "$meta_json" "$status_json" "$report_json" "$worktree_json" "$home_json" \
+      "$endpoint_exists" "$open_decisions_json" "$(bool_json "$pending_decision")" \
+      "$(bool_json "$blocked_event")" "$(bool_json "$report_present")" \
+      | jq -s \
       --arg id "$id" \
       --arg kind "$kind" \
       --arg harness "$harness" \
@@ -570,19 +573,18 @@ task_json_lines() {
       --arg pr_source "$pr_source" \
       --arg agent_alive "$agent_alive" \
       --arg observed_at "$SNAPSHOT_NOW" \
-      --arg last_event_raw "$last_event_raw" \
-      --argjson current_state "$current_json" \
-      --argjson meta_path "$meta_json" \
-      --argjson status_log "$status_json" \
-      --argjson report "$report_json" \
-      --argjson worktree_path "$worktree_json" \
-      --argjson home_path "$home_json" \
-      --argjson endpoint_exists "$endpoint_exists" \
-      --argjson open_decisions "$open_decisions_json" \
-      --argjson pending_decision "$(bool_json "$pending_decision")" \
-      --argjson blocked_event "$(bool_json "$blocked_event")" \
-      --argjson report_present "$(bool_json "$report_present")" \
-      '{
+      '.[0] as $current_state
+       | .[1] as $meta_path
+       | .[2] as $status_log
+       | .[3] as $report
+       | .[4] as $worktree_path
+       | .[5] as $home_path
+       | .[6] as $endpoint_exists
+       | .[7] as $open_decisions
+       | .[8] as $pending_decision
+       | .[9] as $blocked_event
+       | .[10] as $report_present
+       | {
         id:$id,
         kind:$kind,
         harness:($harness // ""),
@@ -611,7 +613,7 @@ task_json_lines() {
           blocked_event:$blocked_event,
           open_decisions:$open_decisions,
           scout_report_present:$report_present,
-          last_event_text:$last_event_raw
+          last_event_text:($status_log.last_event.raw // "")
         },
         actions:(
           if $kind == "secondmate" then
@@ -632,10 +634,10 @@ task_json_lines() {
 # Meta inventory remains the sole source of live workers; this object only
 # discloses backlog↔task inconsistency for renderers (Bearings omitted/gates).
 main_inventory_json() {  # <backlog-json> <tasks-json>
-  jq -n \
-    --argjson backlog "$1" \
-    --argjson tasks "$2" '
-    ([ $backlog.records[]?
+  printf '%s\n%s\n' "$1" "$2" | jq -s '
+    .[0] as $backlog
+    | .[1] as $tasks
+    | ([ $backlog.records[]?
        | select((.state == "in_flight" or .state == "queued") and (.structured | not)) ]) as $unstructured_current
     | ([ $backlog.records[]?
          | select(.state == "in_flight" and .structured and .requires_child_metadata) ]) as $owned_in_flight
@@ -660,18 +662,19 @@ main_inventory_json() {  # <backlog-json> <tasks-json>
 # This mode never reads parent events or terminal text and never aggregates
 # nested secondmates.
 secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
-  jq -n \
+  printf '%s\n%s\n' "$1" "$2" | jq -s \
     --arg generated "$SNAPSHOT_NOW" \
     --arg home "$FM_HOME" \
     --argjson child_n "$FM_SNAPSHOT_SECONDMATE_CHILDREN" \
     --argjson queued_n "$FM_SNAPSHOT_SECONDMATE_QUEUED" \
     --argjson decisions_n "$FM_SNAPSHOT_SECONDMATE_DECISIONS" \
-    --argjson landed_n "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" \
-    --argjson backlog "$1" \
-    --argjson tasks "$2" '
+    --argjson landed_n "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" '
     def trunc($n):
       tostring | gsub("\\s+"; " ")
       | if length > $n then .[:$n] + "…" else . end;
+    .[0] as $backlog
+    | .[1] as $tasks
+    |
     ([ $backlog.records[]?
        | select((.state == "in_flight" or .state == "queued") and (.structured | not)) ]) as $unstructured_current
     | ([ $backlog.records[]? | select(.state == "in_flight" and .structured) ]) as $owned_in_flight
@@ -1079,7 +1082,7 @@ terminal_evidence_json() {  # <parent-task-json> <event-note> <evidence-contradi
 }
 
 parent_evidence_reconciliation_json() {  # <summary-json> <activities-json> <decisions-json>
-  jq -n --argjson summary "$1" --argjson activities "$2" --argjson decisions "$3" '
+  printf '%s\n%s\n%s\n' "$1" "$2" "$3" | jq -s '
     def keyed: . != null and . != "" and . != "default";
     def result($e; $matches; $complete; $surface):
       $e + {
@@ -1090,6 +1093,10 @@ parent_evidence_reconciliation_json() {  # <summary-json> <activities-json> <dec
         compared_to:$surface,
         matched:(if ($e.key | keyed) then ($matches[0] // null) else null end)
       };
+    .[0] as $summary
+    | .[1] as $activities
+    | .[2] as $decisions
+    |
     ([ $activities[] as $e
        | if $e.verb == "working" then
            ([ $summary.active_children[]
@@ -1144,7 +1151,10 @@ secondmate_current_json() {  # <parent-tasks-json>
   local activity_scan activities decisions reconciliation provenance freshness reason summary summary_rc summary_bytes summary_valid summary_reason summary_invalidity state current_reason terminal terminal_contradiction contradiction
   local records='[]' seen_homes=''
   registry=$(registry_secondmates_json) || return 1
-  union=$(jq -n --argjson registry "$registry" --argjson tasks "$tasks" '
+  union=$(printf '%s\n%s\n' "$registry" "$tasks" | jq -s '
+    .[0] as $registry
+    | .[1] as $tasks
+    |
     ($registry.records // []) as $registered
     | (($registered | map(.id)) // []) as $registered_ids
     | ([ $registered[] as $r
@@ -1283,13 +1293,20 @@ secondmate_current_json() {  # <parent-tasks-json>
           '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"not-collected",reason:"no useful contradiction check",lines:0,bytes:0,event_note_seen:false,contradiction:false}')
       fi
       if printf '%s' "$terminal" | jq -e '.contradiction == true' >/dev/null; then contradiction=true; fi
-      record=$(jq -n \
+      record=$(printf '%s\n%s\n%s\n%s\n%s\n%s\n%s\n' \
+        "$summary" "$decisions" "$activities" "$activity_scan" "$reconciliation" "$terminal" "$task" \
+        | jq -s \
         --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg state "$state" --arg current_reason "$current_reason" --arg observed "$SNAPSHOT_NOW" \
-        --argjson registered "$registered" --argjson summary "$summary" --argjson summary_valid "$summary_valid" --argjson decisions "$decisions" \
-        --argjson activities "$activities" --argjson activity_scan "$activity_scan" \
-        --argjson reconciliation "$reconciliation" --argjson terminal "$terminal" --argjson contradiction "$contradiction" \
-        --arg event_raw "$event_raw" --arg event_note "$event_note" --argjson event_age "$event_age" '
-        {id:$id,home:$home,host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
+        --argjson registered "$registered" --argjson summary_valid "$summary_valid" --argjson contradiction "$contradiction" \
+        --argjson event_age "$event_age" '
+        .[0] as $summary
+        | .[1] as $decisions
+        | .[2] as $activities
+        | .[3] as $activity_scan
+        | .[4] as $reconciliation
+        | .[5] as $terminal
+        | .[6] as $task
+        | {id:$id,home:$home,host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
          current:{state:$state,reason:($current_reason | if . == "" then null else . end)},invalidity:$summary.invalidity,
          provenance:{selected:"structured-home",structured_home:$home,summary_valid:$summary_valid,
            trust:(if $summary_valid then "complete" else "partial-structured" end),parent_event_role:"historical-only"},
@@ -1297,7 +1314,7 @@ secondmate_current_json() {  # <parent-tasks-json>
          active_children:$summary.active_children,
          decisions_open:$summary.decisions_open,holds:$summary.holds,queued:$summary.queued,
          landed:$summary.landed,endpoints:$summary.endpoints,counts:$summary.counts,omitted:$summary.omitted,
-         parent_event:{raw:$event_raw,note:$event_note,age_seconds:$event_age,open_activities:$activities,open_decisions:$decisions,activity_scan:$activity_scan,reconciliation:$reconciliation},
+         parent_event:{raw:($task.paths.status_log.last_event.raw // ""),note:($task.paths.status_log.last_event.note // ""),age_seconds:$event_age,open_activities:$activities,open_decisions:$decisions,activity_scan:$activity_scan,reconciliation:$reconciliation},
          terminal_evidence:$terminal,contradiction:$contradiction}')
     else
       if [ -n "$event_raw" ]; then
@@ -1313,35 +1330,44 @@ secondmate_current_json() {  # <parent-tasks-json>
         terminal=$(jq -n --arg observed "$SNAPSHOT_NOW" \
           '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"not-collected",reason:"no parent event to compare",lines:0,bytes:0,event_note_seen:false,contradiction:false}')
       fi
-      record=$(jq -n \
+      record=$(printf '%s\n%s\n%s\n%s\n%s\n' \
+        "$activities" "$activity_scan" "$decisions" "$terminal" "$task" \
+        | jq -s \
         --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg reason "$reason" --arg observed "$SNAPSHOT_NOW" \
-        --arg provenance "$provenance" --arg freshness "$freshness" --arg event_raw "$event_raw" --arg event_note "$event_note" \
-        --argjson registered "$registered" --argjson event_age "$event_age" --argjson activities "$activities" --argjson activity_scan "$activity_scan" \
-        --argjson decisions "$decisions" --argjson terminal "$terminal" '
-        {id:$id,home:($home | if . == "" then null else . end),host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
+        --arg provenance "$provenance" --arg freshness "$freshness" \
+        --argjson registered "$registered" --argjson event_age "$event_age" '
+        .[0] as $activities
+        | .[1] as $activity_scan
+        | .[2] as $decisions
+        | .[3] as $terminal
+        | .[4] as $task
+        | {id:$id,home:($home | if . == "" then null else . end),host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
          current:{state:"unknown",reason:$reason},invalidity:null,
          provenance:{selected:$provenance,structured_home:($home | if . == "" then null else . end),parent_event_role:"fallback-only-not-current"},
          freshness:{status:$freshness,observed_at:$observed,age_seconds:$event_age},
          active_children:[],decisions_open:[],holds:[],queued:[],landed:[],endpoints:[],counts:{active_children:0,decisions_open:0,holds:0,queued:0,landed:0,endpoints:0},omitted:[],
-         parent_event:{raw:$event_raw,note:$event_note,age_seconds:$event_age,open_activities:$activities,open_decisions:$decisions,activity_scan:$activity_scan},
+         parent_event:{raw:($task.paths.status_log.last_event.raw // ""),note:($task.paths.status_log.last_event.note // ""),age_seconds:$event_age,open_activities:$activities,open_decisions:$decisions,activity_scan:$activity_scan},
          terminal_evidence:$terminal,contradiction:false}')
     fi
-    records=$(jq -n --argjson records "$records" --argjson record "$record" '$records + [$record]')
+    records=$(printf '%s\n%s\n' "$records" "$record" | jq -s '.[0] + [.[1]]')
   done <<EOF
 $rows
 EOF
-  jq -n \
-    --argjson registry "$(printf '%s' "$union" | jq '.registry')" \
-    --argjson records "$records" \
-    --argjson total_registered "$total_registered" \
-    --argjson total "$total" \
-    --argjson shown "$shown" \
-    --argjson truncated "$truncated" \
-    '{registry:$registry,records:$records,total_registered:$total_registered,total:$total,shown:$shown,truncated:$truncated}'
+  printf '%s\n%s\n%s\n%s\n%s\n' \
+    "$union" "$records" "$total_registered" "$total" "$shown" \
+    | jq -s --argjson truncated "$truncated" '
+    .[0].registry as $registry
+    | .[1] as $records
+    | .[2] as $total_registered
+    | .[3] as $total
+    | .[4] as $shown
+    | {registry:$registry,records:$records,total_registered:$total_registered,total:$total,shown:$shown,truncated:$truncated}'
 }
 
 secondmate_landed_from_current_json() {  # <secondmate-current-json>
-  jq -n --argjson current "$1" '
+  printf '%s\n' "$1" | jq -s '
+    .[0] as $current
+    |
     {records:[ $current.records[]
       | select(.provenance.selected == "structured-home") as $mate
       | $mate.landed[]
@@ -1390,7 +1416,10 @@ SECONDMATE_CURRENT_JSON=$(secondmate_current_json "$TASKS_JSON") \
 SECONDMATE_LANDED_JSON=$(secondmate_landed_from_current_json "$SECONDMATE_CURRENT_JSON") \
   || { echo "fm-fleet-snapshot: secondmate landed projection failed" >&2; exit 1; }
 
-jq -n \
+printf '%s\n%s\n%s\n%s\n%s\n%s\n' \
+  "$BACKLOG_JSON" "$TASKS_JSON" "$MAIN_INVENTORY_JSON" "$SCOUT_REPORTS_JSON" \
+  "$SECONDMATE_CURRENT_JSON" "$SECONDMATE_LANDED_JSON" \
+  | jq -s \
   --arg generated "$SNAPSHOT_NOW" \
   --arg fm_home "$FM_HOME" \
   --arg fm_root "$FM_ROOT" \
@@ -1398,13 +1427,13 @@ jq -n \
   --arg data "$DATA" \
   --arg config "$CONFIG" \
   --arg projects "$PROJECTS" \
-  --argjson backlog "$BACKLOG_JSON" \
-  --argjson tasks "$TASKS_JSON" \
-  --argjson main_inventory "$MAIN_INVENTORY_JSON" \
-  --argjson scout_reports "$SCOUT_REPORTS_JSON" \
-  --argjson secondmate_current "$SECONDMATE_CURRENT_JSON" \
-  --argjson secondmate_landed "$SECONDMATE_LANDED_JSON" \
-  'def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
+  '.[0] as $backlog
+   | .[1] as $tasks
+   | .[2] as $main_inventory
+   | .[3] as $scout_reports
+   | .[4] as $secondmate_current
+   | .[5] as $secondmate_landed
+   | def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
    def task_by_id($id): ($tasks[]? | select(.id == $id) | .) // null;
    def report_kind($id): (task_by_id($id).kind // backlog_by_id($id).kind // "scout");
    {

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -799,6 +799,38 @@ test_parked_scout_decision_stays_pending() {
   pass "a scout still parked at a decision stays pending (terminal clear does not over-fire)"
 }
 
+test_large_fleet_snapshot_streams_composite_json() {
+  local home fakebin out view payload id i
+  home=$(make_home large-fleet)
+  fakebin=$(make_fakebin "$home")
+  payload=$(printf '%*s' 100000 '' | tr ' ' x)
+  for i in $(seq 1 24); do
+    id=$(printf 'large-task-%02d' "$i")
+    fm_write_meta "$home/state/$id.meta" \
+      "window=firstmate:fm-$id" \
+      "project=alpha" \
+      "harness=codex" \
+      "kind=ship" \
+      "mode=ship"
+    printf 'needs-decision [key=%s]: %s\n' "$id" "$payload" > "$home/state/$id.status"
+  done
+
+  out=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$SNAPSHOT" --json) \
+    || fail "large synthetic fleet snapshot should not fail"
+  printf '%s' "$out" | jq -e '
+    .schema == "fm-fleet-snapshot.v1"
+      and (.tasks | length) == 24
+      and ([.tasks[].hints.open_decisions[] | .summary | length] | max) == 100000
+      and .main_inventory.valid == true
+  ' >/dev/null || fail "large synthetic fleet snapshot lost tasks or decision payloads"
+
+  view=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$VIEW") \
+    || fail "large synthetic fleet view should not fail"
+  assert_contains "$view" "| large-task-01 | unknown / none |" \
+    "large synthetic fleet view should render task rows"
+  pass "large fleet snapshot and view stream composite JSON through jq stdin"
+}
+
 test_empty_fleet_json
 test_fixture_snapshot_json
 test_main_inventory_orphan_and_unstructured_disclosure
@@ -810,6 +842,7 @@ test_open_decision_transfers_to_captain_hold
 test_open_decision_clears_on_keyed_resolution
 test_completed_scout_report_is_pointer_not_pending
 test_parked_scout_decision_stays_pending
+test_large_fleet_snapshot_streams_composite_json
 test_scout_reports_include_teardown_reports
 test_backlog_tasks_axi_forms_and_overrides
 test_view_renders_snapshot


### PR DESCRIPTION
## Intent

Fix fm-fleet-view/fm-fleet-snapshot failing with jq 'Argument list too long' at bin/fm-fleet-snapshot.sh:635 once the fleet reaches 17+ task metas, reproducing the current 29-meta failure first. Move all fleet-sized JSON payloads off jq argv and onto stdin or equivalent streamed/file transport while keeping normal-case output byte-identical. Sweep bin/fm-fleet-snapshot.sh and bin/fm-fleet-view.sh for any other jq or xargs call whose argv grows with fleet size and fix those in the same pass. Add a tests/fm-fleet-snapshot-view.test.sh regression using a large synthetic fleet sufficient to trip the old limit. Do not merge the PR. Push the feature branch to the fork over SSH at git@github.com:unhexquadium/firstmate.git, open the PR against upstream kunchenguid/firstmate, and preserve this exact line under a ## Pipeline section in the PR body: Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes). Use a concise top-level summary, a dedicated Risk assessment section with a green/yellow/red status-color emoji, and collapsible details for per-item breakdowns, background, validation notes, and caveats; refer to the captain as she/her. Drive all no-mistakes gates through PR and CI, and when the fork-PR workflow is awaiting upstream maintainer approval after the pipeline finishes, report the PR as delivered with CI awaiting that approval.

## What Changed

- Stream task, inventory, secondmate, and final snapshot JSON into `jq` through stdin instead of passing fleet-sized payloads through `--argjson` arguments.
- Add a 24-task synthetic fleet regression with large decision payloads that verifies both snapshot generation and fleet view rendering.

## Risk Assessment

✅ Low: Captain, the change is a focused transport refactor that moves every fleet-sized JSON value in both snapshot modes off jq argv while preserving the existing JSON structure and rendering path.

## Testing

The focused behavior suite passed, the base commit reproduced `jq: Argument list too long` at line 635 with 29 metas, and the target preserved all 29 tasks through snapshot JSON, secondmate-summary, and rendered-view paths while remaining byte-identical for a normal two-task fleet; the CLI evidence was captured and the worktree remained clean.

<details>
<summary>Evidence: 29-meta base-versus-target CLI transcript</summary>

Source: [29-meta base-versus-target CLI transcript](https://github.com/unhexquadium/firstmate/blob/b7449998a61b8af45ee6f1cc730a459312dbc65c/.no-mistakes/evidence/fm/fm-fleet-view-jq-arglist/large-fleet-e2e.txt)

```text
$ base fm-fleet-snapshot.sh --json with 29 task metas and 40000-byte decision summaries
exit=1
/tmp/fm-large-fleet-e2e.SrGnsW/base-bin/fm-fleet-snapshot.sh: line 635: /usr/bin/jq: Argument list too long
fm-fleet-snapshot: main inventory summary failed

$ target fm-fleet-snapshot.sh --json with the same 29-meta fleet
{
  "schema": "fm-fleet-snapshot.v1",
  "task_count": 29,
  "max_decision_summary_bytes": 40000,
  "main_inventory_valid": true
}

$ target fm-fleet-snapshot.sh --secondmate-home-summary with the same 29-meta fleet
{
  "schema": "fm-secondmate-home-summary.v1",
  "endpoint_count": 29,
  "decision_count": 29,
  "shown_endpoints": 20,
  "omitted": [
    {
      "surface": "decisions_open",
      "count": 9
    },
    {
      "surface": "endpoints",
      "count": 9
    }
  ]
}

$ target fm-fleet-view.sh with the same 29-meta fleet (representative rendered rows)
# Fleet View

Schema: fm-fleet-snapshot.v1
Home: /tmp/fm-large-fleet-e2e.SrGnsW/home

## Under Way
| ID | Current | Kind | Repo/Project | Backend | Endpoint | Artifact | Path | Watch / return channel |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| large-task-01 | unknown / none | ship | alpha | tmux | present | - | - | bin/fm-peek.sh fm-large-task-01 |
| large-task-02 | unknown / none | ship | alpha | tmux | present | - | - | bin/fm-peek.sh fm-large-task-02 |
| large-task-03 | unknown / none | ship | alpha | tmux | present | - | - | bin/fm-peek.sh fm-large-task-03 |
| large-task-29 | unknown / none | ship | alpha | tmux | present | - | - | bin/fm-peek.sh fm-large-task-29 |

$ byte-for-byte normal-case comparison: base vs target with two ordinary task metas
identical=yes
sha256=23d0e11154effa398116f6989c202a4c0b1f0df694ad341276afbb54f61916dd
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"26ef299d5ac8074c2c9f4ced36a7c8fc4372a671","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `tests/fm-fleet-snapshot-view.test.sh`
- `/home/kalvira/.no-mistakes/evidence/01M0NSSEMQB2TYB1GZFWXJ9RF8/large-fleet-e2e.sh "$PWD" 1231b6ae7fd4c5ff7e94d2f5ca2159536c4c41cb`
- `rg -n "OUTPUT_MODE|secondmate-home-summary|jq |xargs" bin/fm-fleet-snapshot.sh bin/fm-fleet-view.sh`
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
