### PR TITLE
fix(bin): let spawn skip the freshen step for remote-less local-only projects

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -138,6 +138,9 @@
 #   origin, resolves the current remote default branch, and resets to its tip.
 #   An unreachable origin, unresolved default branch, or non-clean worktree
 #   refuses the spawn rather than risking a PR based on stale history.
+#   A project with no origin remote at all (a local-only project registered
+#   with none) skips this freshen step silently, mirroring the same no-origin
+#   tolerance bin/fm-fleet-sync.sh already applies.
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
@@ -1729,6 +1732,9 @@ validate_spawn_worktree() {  # <source> <inspect-target>
 
 freshen_spawn_worktree_base() {  # <worktree>
   local worktree=$1 default target expected actual status
+  if ! git -C "$worktree" remote get-url origin >/dev/null 2>&1; then
+    return 0
+  fi
   if ! git -C "$worktree" fetch --quiet origin; then
     echo "error: could not fetch origin for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
     return 1


### PR DESCRIPTION
## Problem

A `local-only` project can be registered with no `origin` remote at all. But `freshen_spawn_worktree_base()` in `bin/fm-spawn.sh` unconditionally runs `git fetch origin` before launching a worker, so every ship/scout spawn against such a project fails outright with:

```
'origin' does not appear to be a git repository
```

## Fix

`bin/fm-fleet-sync.sh` already tolerates this exact case — it skips silently when a project has no `origin` remote. This change mirrors that same guard in the spawn path: if the worktree has no `origin`, the freshen step returns early instead of erroring.

6 lines, behavior-preserving for every project that *does* have an origin.

## Testing

Verified against a `local-only` pilot project (no remote): ship and scout spawns that previously failed at the freshen step now proceed. Projects with an origin are unaffected — the fetch/reset path runs exactly as before.