### PR TITLE
test: repair remote and update-check fixture assumptions

### DIFF
--- a/tests/fm-remote-backlog-handoff.test.sh
+++ b/tests/fm-remote-backlog-handoff.test.sh
@@ -53,6 +53,12 @@ cp "$ROOT/bin/fm-remote-entrypoint.sh" "$ROOT/bin/fm-remote-job-lib.sh" \
   "$ROOT/bin/fm-remote-job-worker.sh" "$ROOT/bin/fm-remote-file.sh" \
   "$ROOT/bin/fm-backlog-receive.sh" "$ROOT/bin/fm-tasks-axi-lib.sh" \
   "$ROOT/bin/fm-wake-lib.sh" "$REMOTE_ROOT/bin/"
+# Keep the fixture's copied wake library with its optional platform helper.
+# Downstream ports can add that source dependency while the canonical build
+# remains self-contained without the helper.
+if [ -f "$ROOT/bin/fm-ps-lib.sh" ]; then
+  cp "$ROOT/bin/fm-ps-lib.sh" "$REMOTE_ROOT/bin/"
+fi
 ln -s "$(command -v tasks-axi)" "$REMOTE_ROOT/bin/tasks-axi"
 ln -s "$(command -v node)" "$REMOTE_ROOT/bin/node"
 chmod +x "$REMOTE_ROOT/bin"/*.sh

--- a/tests/fm-remote-job-orphan-reap.test.sh
+++ b/tests/fm-remote-job-orphan-reap.test.sh
@@ -4,8 +4,10 @@
 # The leak this pins: a worker launched from a worktree's own bin/ outlives that
 # worktree. Its restart supervisor sits above the serving child, so killing the
 # recorded worker pid only makes the supervisor respawn, and nothing else ever
-# stops it. Observed 2026-08-07 as 29 workers at ppid 1, 1-2 days old, each
-# still appending to a log in a pruned no-mistakes gate worktree.
+# stops it. Observed 2026-08-07 as 29 workers reparented to init, 1-2 days old,
+# each still appending to a log in a pruned no-mistakes gate worktree. A process
+# subreaper may adopt the same detached worker instead of init, so the fixture
+# proves separation from its launcher rather than requiring one numeric ppid.
 #
 # bin/fm-remote-job-reap-orphans.sh is a machine-wide sweep by design, so these
 # cases assert only about their own fixture processes. Any other worker it
@@ -92,6 +94,8 @@ start_worker() {
     export FM_REMOTE_JOB_ORPHAN_GRACE_SECONDS=1
     # shellcheck source=bin/fm-remote-job-lib.sh
     . "$ROOT/bin/fm-remote-job-lib.sh"
+    mkdir -p "$state_root"
+    printf '%s\n' "$BASHPID" > "$state_root/fixture-launcher.pid"
     fm_remote_job_start_linux_worker "$root" "$account_home" >&2 || exit 1
     deadline=$(( $(date +%s) + 10 ))
     while [ "$(date +%s)" -lt "$deadline" ]; do
@@ -123,8 +127,11 @@ SERVE=$(pgrep -P "$WORKER" | head -n 1)
   fail "the serving child is outside the worker's process group"
 pass "the Linux start path puts the whole worker tree in its own process group"
 
-[ "$(ppid_of "$WORKER")" = 1 ] ||
-  fail "the fixture worker is not orphaned to init, so this case does not reproduce the leak"
+LAUNCHER=$(cat "$CASE1/remote-jobs/fixture-launcher.pid")
+pid_is_numeric "$LAUNCHER" || fail "the fixture did not record its launch shell"
+wait_gone "$LAUNCHER" 10 || fail "the fixture launch shell stayed alive, so this case does not reproduce a detached worker"
+[ "$(ppid_of "$WORKER")" != "$LAUNCHER" ] ||
+  fail "the fixture worker remains parented to its launch shell, so this case does not reproduce the leak"
 
 # The exact teardown shape that leaked in production: a fixture cleanup removes
 # the worker's state root and then stops only the single recorded worker pid -
@@ -137,7 +144,7 @@ kill -KILL "$SERVE" 2>/dev/null || true
 wait_gone "$SERVE" 10 || fail "the recorded serving child did not stop"
 alive "$WORKER" || fail "the fixture supervisor did not survive a lone child kill, so this case no longer covers the leak"
 wait_child "$WORKER" 15 || fail "the supervisor did not respawn after its recorded child pid was killed"
-pass "removing the state root and killing the recorded worker pid leaves the tree running at ppid 1"
+pass "removing the state root and killing the recorded worker pid leaves the detached tree running"
 
 # A worker whose code root is intact is never a reap candidate, which is what
 # keeps the account's healthy LaunchAgent worker out of scope.

--- a/tests/fm-tool-update-check.test.sh
+++ b/tests/fm-tool-update-check.test.sh
@@ -336,7 +336,11 @@ SH
   chmod 0755 "$dir/no-mistakes-fixture"
   write_config "$home" '{"tools":[{"name":"no-mistakes","command":"no-mistakes-fixture","version_args":["--version"],"announce_args":["--help"],"announce_pattern":"A new version of no-mistakes is available: [^ ]+ -> [^ ]+"}]}'
   out="$home/out.txt"
-  run_check "$home" "$(fixture_path "$dir")" "$out" FM_TOOL_UPDATE_BUDGET_SECS=1
+  # Two seconds leaves a full second for registry validation even when the
+  # process starts just before the whole-second clock rolls over. The stalled
+  # version probe still consumes the remaining budget, so the distinct
+  # announcement command is provably never queried.
+  run_check "$home" "$(fixture_path "$dir")" "$out" FM_TOOL_UPDATE_BUDGET_SECS=2
   report=$(cat "$out")
   assert_contains "$report" "no-mistakes check failed: the time budget ran out before the update announcement was checked" "an announcement source that was never asked was not reported"
   pass "an announcement source the budget could not reach is reported, not read as current"


### PR DESCRIPTION
## Summary

Repair three independent test-fixture assumptions exposed by full-suite run `01M0NK3HAGHN2HB06QXHCQN75H`:

- copy the optional `fm-ps-lib.sh` dependency into the remote handoff fixture when a downstream port provides it, preventing the copied wake library from failing before the confined-put assertion;
- prove the orphan-worker scenario by recording and observing exit of the actual launch shell instead of requiring Linux to reparent the worker specifically to PID 1, because a process subreaper may validly adopt it;
- give the update-announcement budget fixture one full clock second for setup before its stalled version probe consumes the budget, avoiding a whole-second boundary race that could stop before the watched source was reached.

The documentation failure was not a canonical documentation defect: the failing workspace contained unrelated `.paul/*.md` files from a divergent downstream default branch, while the tested branch and canonical inventory contain none of those files. No documentation text or inventory assertion was loosened.

## Diagnosis

- Remote handoff trigger: the mixed workspace supplied a wake library that sources `fm-ps-lib.sh`; masking condition: the fixture copied only the older dependency set; symptom: the superseded-payload comparison ran after fixture initialization had already failed.
- Orphan reap trigger: a detached worker is launched; masking condition: the full-suite process tree uses a subreaper; symptom: the fixture rejected a genuine detached worker solely because its parent was not PID 1.
- Tool update trigger: a one-second sweep starts near a whole-second rollover; masking condition: registry/setup overhead consumes the fractional remainder; symptom: the sweep reports it never reached NoMistakes rather than the more specific unqueried-announcement source.

## Validation

All commands were bounded by `timeout 600s`.

- `bash tests/fm-remote-backlog-handoff.test.sh` - passed
- `bash tests/fm-remote-job-orphan-reap.test.sh` - passed
- `bash tests/fm-documentation-audiences.test.sh` - passed
- `bash tests/fm-tool-update-check.test.sh` - passed, including three consecutive supporting runs during diagnosis
- `bin/fm-lint.sh` - ShellCheck 0.11.0 and actionlint 1.7.12 passed
- `bin/fm-doc-audience-check.sh` - passed with 73 surfaces and 266 local links
- `git diff --check upstream/main...HEAD` - passed
