### PR TITLE
fix(herdr): support named primary sessions in lab tripwire

### DIFF
--- a/bin/fm-herdr-lab.sh
+++ b/bin/fm-herdr-lab.sh
@@ -21,8 +21,10 @@
 # delete is available only through teardown.
 # Both paths perform a fresh refuse-default check immediately before each
 # destructive call.
-# Provision records the running default session as a fleet-state tripwire and
+# Provision records the running primary session as a fleet-state tripwire and
 # teardown requires that record to be identical afterward.
+# FM_HERDR_LAB_PRIMARY_SESSION, then inherited HERDR_SESSION, identifies a
+# named primary; absent either record, the primary remains literal default.
 set -u
 
 fm_herdr_lab_error() {
@@ -58,21 +60,41 @@ fm_herdr_lab_session_list() { # <session>
   fm_herdr_lab_raw "$1" session list --json
 }
 
+fm_herdr_lab_primary_session() {
+  local primary=${FM_HERDR_LAB_PRIMARY_SESSION:-${HERDR_SESSION:-default}}
+  [ -n "$primary" ] || {
+    fm_herdr_lab_error "fleet-state tripwire requires a non-empty primary session record"
+    return 1
+  }
+  case "$primary" in
+    fm-lab-*)
+      fm_herdr_lab_error "fleet-state tripwire refuses lab session '$primary' as the primary"
+      return 1
+      ;;
+  esac
+  printf '%s\n' "$primary"
+}
+
 fm_herdr_lab_fleet_state() { # <session>
-  local name=$1 sessions snapshot
+  local name=$1 primary sessions snapshot
+  primary=$(fm_herdr_lab_primary_session) || return 1
+  [ "$primary" != "$name" ] || {
+    fm_herdr_lab_error "fleet-state tripwire refuses the lab session as its own primary"
+    return 1
+  }
   sessions=$(fm_herdr_lab_session_list "$name" 2>/dev/null) || {
     fm_herdr_lab_error "cannot read Herdr sessions for the fleet-state tripwire"
     return 1
   }
-  snapshot=$(printf '%s' "$sessions" | jq -c '
-    [.sessions[]? | select(.default == true)]
-    | if length == 1 and .[0].name == "default" and .[0].running == true
+  snapshot=$(printf '%s' "$sessions" | jq -c --arg primary "$primary" '
+    [.sessions[]? | select(.name == $primary and .running == true)]
+    | if length == 1
       then .[0] | {name, default, running, socket_path}
       else empty
       end
   ' 2>/dev/null)
   [ -n "$snapshot" ] || {
-    fm_herdr_lab_error "fleet-state tripwire requires exactly one running default session"
+    fm_herdr_lab_error "fleet-state tripwire requires exactly one running recorded primary session '$primary'"
     return 1
   }
   printf '%s\n' "$snapshot"
@@ -227,7 +249,7 @@ fm_herdr_lab_check_tripwire() { # <session>
   before=$(cat "$tripwire")
   after=$(fm_herdr_lab_fleet_state "$name") || return 1
   [ "$before" = "$after" ] || {
-    fm_herdr_lab_error "FLEET-STATE TRIPWIRE FAILED: default session changed during lab work"
+    fm_herdr_lab_error "FLEET-STATE TRIPWIRE FAILED: primary session changed during lab work"
     fm_herdr_lab_error "before: $before"
     fm_herdr_lab_error "after:  $after"
     return 1

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -307,7 +307,8 @@ An environment-only session selection can silently reach a different running ser
 `bin/fm-herdr-lab.sh` is the sole supported lifecycle helper for isolated verification.
 It provisions only non-default names beginning with `fm-lab-`, appends an explicit `--session` to allowed task commands, refuses caller-supplied session flags and server/session lifecycle subcommands, and performs destructive stop/delete only through its guarded lifecycle actions.
 Immediately before every destructive call it re-queries the named session and refuses empty, missing, literal `default`, or `default:true` identities.
-Its before/after tripwire requires the live default-session snapshot to remain byte-identical.
+Its before/after tripwire requires the recorded running primary-session snapshot to remain byte-identical.
+The helper uses `FM_HERDR_LAB_PRIMARY_SESSION`, then an inherited `HERDR_SESSION`, and otherwise literal `default`; it requires exactly one running session with that exact name and refuses a lab-namespaced, missing, stopped, or ambiguous primary record.
 
 The helper's header and `--help` own exact commands.
 Tests use thin compatibility wrappers in `tests/herdr-test-safety.sh` and never duplicate the destructive policy.
@@ -341,5 +342,5 @@ tests/fm-afk-inject-herdr-e2e.test.sh
 tests/fm-afk-pi-herdr-return-e2e.test.sh
 ```
 
-Real Herdr tests use the named lab helper and default-session tripwire.
+Real Herdr tests use the named lab helper and exact primary-session tripwire.
 [`verification/runtime-backends.md`](verification/runtime-backends.md#herdr) records the active version, CLI, projection, event, and lifecycle evidence without task-specific chronology.

--- a/tests/fm-backend-herdr-focus-flash-e2e.test.sh
+++ b/tests/fm-backend-herdr-focus-flash-e2e.test.sh
@@ -237,7 +237,7 @@ C_SURVIVOR_ORDER=$(printf '%s' "$C_ORDER" | tr ',' '\n' | grep -v "^$C_DOOMED_WS
 
 # One persistent background child of the pane's shell, started outside any
 # worktree so nothing reaps it, is enough to fail the proof on every sample.
-lab pane send-text "$C_DOOMED_PANE" 'cd / && sleep 3000 &' >/dev/null \
+lab pane send-text "$C_DOOMED_PANE" 'cd /; sleep 3000 &' >/dev/null \
   || fail 'could not send the Part C persistent-child command'
 lab pane send-keys "$C_DOOMED_PANE" enter >/dev/null \
   || fail 'could not submit the Part C persistent-child command'

--- a/tests/fm-herdr-lab.test.sh
+++ b/tests/fm-herdr-lab.test.sh
@@ -33,14 +33,27 @@ lab_state=absent
 
 case "$1 ${2:-}" in
   "session list")
-    if [ "$lab_state" = absent ] || [ "$lab_state" = deleted ]; then
-      jq -nc --arg socket "$default_socket" '{sessions:[{default:true,name:"default",running:true,socket_path:$socket}]}'
-    else
-      running=false
-      [ "$lab_state" = running ] && running=true
-      jq -nc --arg socket "$default_socket" --arg name "$session" --argjson running "$running" \
-        '{sessions:[{default:true,name:"default",running:true,socket_path:$socket},{default:false,name:$name,running:$running,socket_path:("/tmp/" + $name + ".sock")}]}'
-    fi
+    primary=${FM_FAKE_HERDR_PRIMARY_NAME:-default}
+    primary_running=${FM_FAKE_HERDR_PRIMARY_RUNNING:-true}
+    duplicate_primary=${FM_FAKE_HERDR_DUPLICATE_PRIMARY:-false}
+    running=false
+    [ "$lab_state" = running ] && running=true
+    lab_present=false
+    [ "$lab_state" = absent ] || [ "$lab_state" = deleted ] || lab_present=true
+    jq -nc \
+      --arg socket "$default_socket" \
+      --arg primary "$primary" \
+      --arg name "$session" \
+      --argjson primary_running "$primary_running" \
+      --argjson duplicate_primary "$duplicate_primary" \
+      --argjson running "$running" \
+      --argjson lab_present "$lab_present" '
+      ({default:($primary == "default"),name:$primary,running:$primary_running,socket_path:$socket}) as $primary_session
+      | (if $primary == "default" then [] else [{default:true,name:"default",running:false,socket_path:"/tmp/default.sock"}] end)
+        + [$primary_session]
+        + (if $duplicate_primary then [$primary_session] else [] end)
+        + (if $lab_present then [{default:false,name:$name,running:$running,socket_path:("/tmp/" + $name + ".sock")}] else [] end)
+      | {sessions:.}'
     ;;
   "server --session")
     if [ "${FM_FAKE_HERDR_SERVER_DELAY:-0}" != 0 ]; then
@@ -82,6 +95,10 @@ run_with_fake() {
     FM_FAKE_HERDR_SERVER_DELAY="${FM_FAKE_HERDR_SERVER_DELAY:-0}" \
     FM_FAKE_HERDR_FAST_POLL="${FM_FAKE_HERDR_FAST_POLL:-}" \
     FM_FAKE_HERDR_DELETE_FAIL="${FM_FAKE_HERDR_DELETE_FAIL:-}" \
+    FM_FAKE_HERDR_PRIMARY_NAME="${FM_FAKE_HERDR_PRIMARY_NAME:-default}" \
+    FM_FAKE_HERDR_PRIMARY_RUNNING="${FM_FAKE_HERDR_PRIMARY_RUNNING:-true}" \
+    FM_FAKE_HERDR_DUPLICATE_PRIMARY="${FM_FAKE_HERDR_DUPLICATE_PRIMARY:-false}" \
+    FM_HERDR_LAB_PRIMARY_SESSION="${FM_HERDR_LAB_PRIMARY_SESSION:-default}" \
     FM_HERDR_LAB_STATE_DIR="$TRIPWIRES" \
     "$@"
 }
@@ -154,6 +171,30 @@ test_provision_run_and_guarded_teardown() {
   sed -n "$((delete_line - 1))p" "$FAKE_LOG" | grep -F "session list --json --session $name" >/dev/null \
     || fail "delete was not immediately preceded by a fresh refuse-default session list"
   pass "fm-herdr-lab: provisioning, scoped calls, guarded teardown, and fleet tripwire are deterministic"
+}
+
+test_named_primary_is_exact_and_unambiguous() {
+  local name="fm-lab-named-primary-$$" stopped="fm-lab-stopped-primary-$$" duplicate="fm-lab-duplicate-primary-$$" status=0
+  : > "$FAKE_LOG"
+  FM_HERDR_LAB_PRIMARY_SESSION=fm-wsl-minimal FM_FAKE_HERDR_PRIMARY_NAME=fm-wsl-minimal \
+    run_with_fake fm_herdr_lab_provision "$name" || fail "named primary provision failed"
+  [ "$(jq -r '.name' "$TRIPWIRES/$name.fleet-state.json")" = fm-wsl-minimal ] \
+    || fail "tripwire did not record the exact named primary"
+  FM_HERDR_LAB_PRIMARY_SESSION=fm-wsl-minimal FM_FAKE_HERDR_PRIMARY_NAME=fm-wsl-minimal \
+    run_with_fake fm_herdr_lab_teardown "$name" || fail "named primary teardown failed"
+
+  status=0
+  FM_HERDR_LAB_PRIMARY_SESSION=fm-wsl-minimal FM_FAKE_HERDR_PRIMARY_NAME=fm-wsl-minimal \
+    FM_FAKE_HERDR_PRIMARY_RUNNING=false run_with_fake fm_herdr_lab_prepare "$stopped" >/dev/null 2>&1 || status=$?
+  expect_code 1 "$status" "stopped named primary must be refused"
+  assert_absent "$TRIPWIRES/$stopped.fleet-state.json" "stopped named primary left a tripwire"
+
+  status=0
+  FM_HERDR_LAB_PRIMARY_SESSION=fm-wsl-minimal FM_FAKE_HERDR_PRIMARY_NAME=fm-wsl-minimal \
+    FM_FAKE_HERDR_DUPLICATE_PRIMARY=true run_with_fake fm_herdr_lab_prepare "$duplicate" >/dev/null 2>&1 || status=$?
+  expect_code 1 "$status" "duplicate named primary candidates must be refused"
+  assert_absent "$TRIPWIRES/$duplicate.fleet-state.json" "ambiguous named primary left a tripwire"
+  pass "fm-herdr-lab: a recorded running named primary is accepted only when exact and unambiguous"
 }
 
 test_missing_tripwire_blocks_destruction() {
@@ -236,6 +277,7 @@ SH
 
 test_refuses_unsafe_names
 test_provision_run_and_guarded_teardown
+test_named_primary_is_exact_and_unambiguous
 test_missing_tripwire_blocks_destruction
 test_changed_default_trips_after_teardown
 test_stopped_owned_lab_can_reprovision

--- a/tests/herdr-test-safety.sh
+++ b/tests/herdr-test-safety.sh
@@ -11,6 +11,9 @@ set -u
 export FM_GATE_REFUSE_BYPASS=1
 
 HERDR_TEST_SAFETY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if [ -z "${FM_HERDR_LAB_PRIMARY_SESSION:-}" ] && [ -n "${HERDR_SESSION:-}" ]; then
+  export FM_HERDR_LAB_PRIMARY_SESSION=$HERDR_SESSION
+fi
 # shellcheck source=/dev/null
 . "$HERDR_TEST_SAFETY_DIR/bin/fm-herdr-lab.sh"
 


### PR DESCRIPTION
## Summary
- let the isolated Herdr lab tripwire protect one exact recorded running primary session, including a named primary such as `fm-wsl-minimal`
- retain strict lab namespace, running-state, uniqueness, byte-identical snapshot, and immediate destructive ownership checks
- fix the focus-flash Part C fixture so `sleep` is a direct shell child rather than a grandchild hidden behind an asynchronously executed `&&` list

## Causal units
1. `fix(herdr): protect recorded named primary in lab tests`
2. `test(herdr): keep persistent-child fixture direct`

## Validation
- `timeout 600s tests/fm-herdr-lab.test.sh`
- `timeout 600s tests/fm-backend-herdr-focus-flash-e2e.test.sh`
- bounded affected Herdr lab family: AFK injection/launch, autodetect, launcher workspace, presentation, prune safety, respawn idempotence, workspace-per-home, control, and session cleanup all passed
- `timeout 600s bin/fm-doc-audience-check.sh`
- `timeout 600s bin/fm-lint.sh`

No live primary Herdr lifecycle operation was performed.
