### PR TITLE
fix(ci): gate PRs into the adapter branch and pin the base-filter rule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,15 @@
 name: CI
 
+# `pull_request.branches` filters a PR's BASE branch, so a base missing from
+# this list gets zero checks - which the PR UI cannot distinguish from passing
+# checks. Add every long-lived base we open PRs into, here and in
+# no-mistakes-required.yml, on the day that branch is created.
+# bin/fm-lint-workflows.sh owns that rule and fails the lint on a mismatch.
 on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, feat/omp-adaptor]
 
 permissions:
   contents: read

--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -1,11 +1,18 @@
 name: Require no-mistakes
 run-name: "PR #${{ github.event.pull_request.number }} body compliance - ${{ github.event.action }} - event ${{ github.run_number }} (run ${{ github.run_id }})"
 
+# `pull_request.branches` filters a PR's BASE branch, so a base missing from
+# this list means this required check never runs for PRs into it - and an absent
+# required check is indistinguishable from a passing one in the PR UI. Keep this
+# list covering every base any PR-triggered workflow gates, adding each
+# long-lived base on the day that branch is created.
+# bin/fm-lint-workflows.sh owns that rule and fails the lint on a mismatch.
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
     branches:
       - main
+      - feat/omp-adaptor
 
 permissions:
   contents: read

--- a/.github/workflows/windows-herdr-spike.yml
+++ b/.github/workflows/windows-herdr-spike.yml
@@ -1,5 +1,9 @@
 name: Windows Herdr automation spike
 
+# Manual dispatch only: no `pull_request` trigger, so there is no base-branch
+# filter to maintain here. If one is ever added, its `branches` list must stay
+# within no-mistakes-required.yml's bases, which bin/fm-lint-workflows.sh
+# enforces, so a PR base can never be gated by CI without the required check.
 on:
   workflow_dispatch:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ We require this to reduce the maintainer's burden of reviewing and merging contr
 `no-mistakes` puts a local git proxy in front of your real remote.
 Pushing through it runs an AI-driven review/test/lint pipeline in an isolated worktree, forwards the push upstream only after every check passes, and opens a clean PR automatically.
 
-A GitHub Actions check (`Require no-mistakes`) runs on PRs targeting `main` and fails if the body is missing the deterministic signature that no-mistakes writes.
+A GitHub Actions check (`Require no-mistakes`) runs on PRs targeting any base branch listed in [`.github/workflows/no-mistakes-required.yml`](.github/workflows/no-mistakes-required.yml), `main` included, and fails if the body is missing the deterministic signature that no-mistakes writes.
 It evaluates every PR opening and body edit independently, so a later edit cannot replace an earlier pending compliance check.
 GitHub Actions and Dependabot are exempt so their automation keeps working, but regular contributor PRs without the signature will not be reviewed or merged.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,7 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
   Test scripts and helpers in `tests/` are plain bash too.
   `bin/fm-lint.sh` must pass: it is the single owner of the lint definition (the shellcheck file set, config, pinned shellcheck version, and pinned actionlint workflow lint), and both CI and the no-mistakes pre-push gate run it, so local and CI can never diverge.
   A malformed `.github/workflows/*.yml`, including a self-broken `ci.yml`, fails that local lint path before merge because a broken workflow cannot report its own breakage.
+  The same lint also refuses a workflow set where some pull request base branch gets CI without also getting the required check, because `pull_request.branches` matches the base branch and an absent required check is indistinguishable from a passing one; add every long-lived base to both `.github/workflows/ci.yml` and `.github/workflows/no-mistakes-required.yml` on the day that branch is created.
   It pins one exact shellcheck version and one exact actionlint version and refuses to run under any other.
   Print the shellcheck pin with `bin/fm-lint.sh --required-version` and the actionlint pin with `bin/fm-lint-workflows.sh --required-version`.
   Use `bin/fm-install-shellcheck.sh` and `bin/fm-install-actionlint.sh` to install those exact builds locally; each installer's header owns its destination usage and supported platforms.

--- a/bin/fm-lint-workflows.sh
+++ b/bin/fm-lint-workflows.sh
@@ -8,6 +8,12 @@
 # invokes this owner on its default (no explicit-path) path, which CI and
 # commands.lint both use.
 #
+# The directory-scan path then checks one gating invariant across the scanned
+# set: every PR base gated by any pull_request-triggered workflow must also be
+# gated by no-mistakes-required.yml, so a base can never get CI without the
+# check branch protection requires. See the comment above
+# REQUIRED_CHECK_WORKFLOW for why that is worth enforcing mechanically.
+#
 # Usage:
 #   fm-lint-workflows.sh                 lint workflows under this repo
 #   fm-lint-workflows.sh --root <dir>    lint workflows under <dir>
@@ -27,7 +33,7 @@ if [ "${1:-}" = "--required-version" ]; then
 fi
 
 fm_lint_workflows_usage() {
-  sed -n '2,16{s/^# \{0,1\}//;p;}' "$SELF"
+  sed -n '2,22{s/^# \{0,1\}//;p;}' "$SELF"
 }
 
 EXPLICIT_ROOT=
@@ -78,7 +84,218 @@ collect_workflow_files() {
     | LC_ALL=C sort
 }
 
+# A `pull_request` trigger's `branches` filter matches the PR BASE branch, and
+# GitHub reads the workflow file from the PR merge commit rather than from the
+# base tip. Two consequences make this worth a gate: a base absent from every
+# filter gets no checks at all, which the pull request UI cannot distinguish
+# from passing checks, and the PR that adds a base to a filter gates itself.
+# Which branches deserve gating is not statically knowable, so the rule pinned
+# here is the superset one: every base gated by any PR-triggered workflow must
+# also be gated by the required check, so a base can never get CI without also
+# getting the check branch protection requires. The reminder to add a new
+# long-lived base at all lives in each workflow's own `on:` block comment.
+REQUIRED_CHECK_WORKFLOW=no-mistakes-required.yml
+
+# Prints exactly one classification line for one workflow file:
+#   none                  no `pull_request` trigger
+#   all                   `pull_request` with no base filter, so every base
+#   bases <base>...       `pull_request` filtered to these bases
+#   unsupported <reason>  a form this gate refuses to guess at
+fm_lint_workflows_pr_filter() {
+  awk '
+function ind(s) { match(s, /^ */); return RLENGTH }
+function trim(s) { sub(/^[ \t]+/, "", s); sub(/[ \t]+$/, "", s); return s }
+function unq(s, q) {
+  s = trim(s)
+  q = "\047"
+  if (length(s) >= 2) {
+    if (substr(s, 1, 1) == "\"" && substr(s, length(s), 1) == "\"") \
+      return substr(s, 2, length(s) - 2)
+    if (substr(s, 1, 1) == q && substr(s, length(s), 1) == q) \
+      return substr(s, 2, length(s) - 2)
+  }
+  return s
+}
+function emit(v) { print v; emitted = 1; exit }
+function tokens(s, n, i, a, t, r) {
+  gsub(/[\[\]]/, " ", s)
+  gsub(/,/, " ", s)
+  n = split(s, a, /[ \t]+/)
+  r = ""
+  for (i = 1; i <= n; i++) { t = unq(a[i]); if (t != "") r = r " " t }
+  return r
+}
+function events(s, n, i, a) {
+  n = split(tokens(s), a, / /)
+  for (i = 1; i <= n; i++) if (a[i] == "pull_request") return "all"
+  return "none"
+}
+function branch_list() {
+  return bases == "" ? "unsupported empty branches list" : "bases" bases
+}
+{
+  line = $0
+  sub(/\r$/, "", line)
+  sub(/[ \t]+#.*$/, "", line)
+  t = trim(line)
+  if (t == "" || substr(t, 1, 1) == "#") next
+  i = ind(line)
+  ci = index(line, ":")
+  key = ""
+  val = ""
+  if (ci > 0) {
+    key = unq(substr(line, 1, ci - 1))
+    val = trim(substr(line, ci + 1))
+  }
+  if (mode == 0) {
+    if (i == 0 && key == "on") {
+      if (substr(val, 1, 1) == "{") emit("unsupported flow-mapping on: value")
+      if (val != "") emit(events(val))
+      mode = 1
+      on_indent = -1
+    }
+    next
+  }
+  # A top-level key ends the on: block, so the verdict is whatever we have.
+  if (i == 0) {
+    if (seq) emit(events(ev))
+    if (mode == 1) emit("none")
+    if (mode == 2) emit("all")
+    emit(branch_list())
+  }
+  if (mode == 1) {
+    if (on_indent < 0) {
+      on_indent = i
+      if (substr(t, 1, 1) == "-") seq = 1
+    }
+    if (seq) {
+      if (substr(t, 1, 1) != "-") emit("unsupported mixed sequence in on: block")
+      ev = ev " " unq(trim(substr(t, 2)))
+      next
+    }
+    if (i != on_indent || key != "pull_request") next
+    if (val != "") emit("unsupported inline pull_request value")
+    mode = 2
+    pr_indent = -1
+    next
+  }
+  if (mode == 2) {
+    # The pull_request block ended without a branches filter: every base.
+    if (i <= on_indent) emit("all")
+    if (pr_indent < 0) pr_indent = i
+    if (i != pr_indent) next
+    if (key == "branches-ignore") \
+      emit("unsupported branches-ignore under pull_request")
+    if (key != "branches") next
+    if (val == "") { mode = 3; next }
+    if (substr(val, 1, 1) == "[") {
+      if (index(val, "]") == 0) \
+        emit("unsupported multi-line flow sequence under branches")
+      bases = tokens(val)
+      emit(branch_list())
+    }
+    emit("unsupported scalar branches value")
+  }
+  if (i <= pr_indent) emit(branch_list())
+  if (substr(t, 1, 1) != "-") emit("unsupported non-sequence entry under branches")
+  b = unq(trim(substr(t, 2)))
+  if (b == "") emit("unsupported empty branches entry")
+  bases = bases " " b
+}
+END {
+  if (emitted) exit
+  if (mode == 0) emit("unsupported no top-level on: key")
+  if (seq) emit(events(ev))
+  if (mode == 1) emit("none")
+  if (mode == 2) emit("all")
+  emit(branch_list())
+}
+' "$1"
+}
+
+# Compares the scanned workflow set against REQUIRED_CHECK_WORKFLOW. Runs only
+# on the directory-scan path, because the invariant is a property of the whole
+# workflow set rather than of one explicitly linted file.
+fm_lint_workflows_pr_gating() {
+  local file name verdict required_verdict='' required_set='' found_required=0
+  local rc=0 i n base missing
+  local names=() verdicts=()
+
+  for file in "${FILES[@]}"; do
+    verdict=$(fm_lint_workflows_pr_filter "$file")
+    name=${file##*/}
+    case "$verdict" in
+      "unsupported "*)
+        printf 'fm-lint-workflows.sh: %s: cannot read the pull_request base filter (%s). Keep the on: block in block style with an explicit branches: list, or teach this gate the new form.\n' \
+          "$name" "${verdict#unsupported }" >&2
+        return 1
+        ;;
+    esac
+    if [ "$name" = "$REQUIRED_CHECK_WORKFLOW" ]; then
+      found_required=1
+      required_verdict=$verdict
+      continue
+    fi
+    names+=("$name")
+    verdicts+=("$verdict")
+  done
+
+  if [ "$found_required" -eq 0 ]; then
+    printf 'fm-lint-workflows.sh: PR base gating: %s is absent from this workflow set, so base coverage was not compared.\n' \
+      "$REQUIRED_CHECK_WORKFLOW" >&2
+    return 0
+  fi
+  if [ "$required_verdict" = none ]; then
+    printf 'fm-lint-workflows.sh: %s has no pull_request trigger, so the required check can never run. Restore its pull_request trigger and base list.\n' \
+      "$REQUIRED_CHECK_WORKFLOW" >&2
+    return 1
+  fi
+  case "$required_verdict" in
+    bases*) required_set="${required_verdict#bases} " ;;
+  esac
+
+  n=${#names[@]}
+  i=0
+  while [ "$i" -lt "$n" ]; do
+    name=${names[$i]}
+    verdict=${verdicts[$i]}
+    i=$((i + 1))
+    [ "$verdict" != none ] || continue
+    [ "$required_verdict" != all ] || continue
+    if [ "$verdict" = all ]; then
+      printf 'fm-lint-workflows.sh: %s gates every PR base while %s requires checks only on:%s. Drop the base filter in %s or widen it there.\n' \
+        "$name" "$REQUIRED_CHECK_WORKFLOW" "${required_verdict#bases}" \
+        "$REQUIRED_CHECK_WORKFLOW" >&2
+      rc=1
+      continue
+    fi
+    missing=''
+    # Intentional word split: the classifier emits bases separated by spaces.
+    for base in ${verdict#bases}; do
+      case "$required_set" in
+        *" $base "*) ;;
+        *) missing="$missing $base" ;;
+      esac
+    done
+    if [ -n "$missing" ]; then
+      printf 'fm-lint-workflows.sh: %s gates PR base(s)%s that %s does not require, so a PR into them can merge with the required check absent. Add them to %s.\n' \
+        "$name" "$missing" "$REQUIRED_CHECK_WORKFLOW" "$REQUIRED_CHECK_WORKFLOW" >&2
+      rc=1
+    fi
+  done
+
+  [ "$rc" -eq 0 ] || return 1
+  if [ "$required_verdict" = all ]; then
+    printf 'fm-lint-workflows.sh: PR base gating: %s requires checks on every PR base\n' \
+      "$REQUIRED_CHECK_WORKFLOW"
+  else
+    printf 'fm-lint-workflows.sh: PR base gating: %s requires checks on:%s\n' \
+      "$REQUIRED_CHECK_WORKFLOW" "${required_verdict#bases}"
+  fi
+}
+
 FILES=()
+SCAN_MODE=0
 if [ "$#" -gt 0 ]; then
   for path in "$@"; do
     case "$path" in
@@ -95,6 +312,7 @@ if [ "$#" -gt 0 ]; then
     FILES+=("$path")
   done
 else
+  SCAN_MODE=1
   workflow_dir="$ROOT/.github/workflows"
   while IFS= read -r path; do
     [ -n "$path" ] || continue
@@ -134,4 +352,8 @@ if [ "$rc" -ne 0 ]; then
 fi
 
 printf 'fm-lint-workflows.sh: %s workflow files valid\n' "${#FILES[@]}"
+
+if [ "$SCAN_MODE" -eq 1 ]; then
+  fm_lint_workflows_pr_gating || exit 1
+fi
 exit 0

--- a/bin/fm-lint-workflows.sh
+++ b/bin/fm-lint-workflows.sh
@@ -94,6 +94,14 @@ collect_workflow_files() {
 # also be gated by the required check, so a base can never get CI without also
 # getting the check branch protection requires. The reminder to add a new
 # long-lived base at all lives in each workflow's own `on:` block comment.
+#
+# Stated limitation: base names are compared literally. A glob or pattern in
+# the required check's branch list is not understood here, so a required check
+# written with one fails this lint loudly rather than passing silently. That is
+# the deliberate trade, for two reasons: a loud refusal is the opposite of the
+# silent-absence defect this gate exists to catch, and no workflow in this repo
+# uses such a construct today. Teach this gate pattern semantics on the day one
+# does, rather than guessing at coverage in the meantime.
 REQUIRED_CHECK_WORKFLOW=no-mistakes-required.yml
 
 # Prints exactly one classification line for one workflow file:
@@ -101,6 +109,9 @@ REQUIRED_CHECK_WORKFLOW=no-mistakes-required.yml
 #   all                   `pull_request` with no base filter, so every base
 #   bases <base>...       `pull_request` filtered to these bases
 #   unsupported <reason>  a form this gate refuses to guess at
+# A definite verdict carries a `paths <key> ` prefix when the `pull_request`
+# trigger is also narrowed by a `paths:` or `paths-ignore:` filter, because
+# such a trigger produces no run at all for a PR touching no matching file.
 fm_lint_workflows_pr_filter() {
   awk '
 function ind(s) { match(s, /^ */); return RLENGTH }
@@ -116,7 +127,13 @@ function unq(s, q) {
   }
   return s
 }
-function emit(v) { print v; emitted = 1; exit }
+function emit(v) {
+  if (pathsfilter != "" && (v == "all" || substr(v, 1, 5) == "bases")) \
+    v = "paths " pathsfilter " " v
+  print v
+  emitted = 1
+  exit
+}
 function tokens(s, n, i, a, t, r) {
   gsub(/[\[\]]/, " ", s)
   gsub(/,/, " ", s)
@@ -132,6 +149,11 @@ function events(s, n, i, a) {
 }
 function branch_list() {
   return bases == "" ? "unsupported empty branches list" : "bases" bases
+}
+# The pull_request block is only classified once it ends, because a narrowing
+# `paths:` sibling may follow the `branches:` list it narrows.
+function pr_verdict() {
+  return has_branches ? branch_list() : "all"
 }
 {
   line = $0
@@ -169,9 +191,10 @@ function branch_list() {
       bases = bases " " b
       next
     }
-    # Anything that is not an item of this sequence ends the branches list.
-    if (i <= br_indent) emit(branch_list())
-    emit("unsupported non-sequence entry under branches")
+    # Anything that is not an item of this sequence ends the branches list and
+    # is reconsidered below as a sibling key of the pull_request block.
+    if (i > br_indent) emit("unsupported non-sequence entry under branches")
+    mode = 2
   }
   if (mode == 1) {
     # The first member line decides whether on: holds a sequence or a mapping;
@@ -198,8 +221,9 @@ function branch_list() {
     pr_indent = -1
     next
   }
-  # The pull_request block ended without a branches filter: every base.
-  if (i <= on_indent) emit("all")
+  # A line at or above the pull_request key ends its block, so the collected
+  # branches list, or its absence, is the verdict.
+  if (i <= on_indent) emit(pr_verdict())
   if (pr_indent < 0) {
     if (dash) emit("unsupported sequence under pull_request")
     pr_indent = i
@@ -207,17 +231,25 @@ function branch_list() {
   if (i != pr_indent) next
   if (key == "branches-ignore") \
     emit("unsupported branches-ignore under pull_request")
+  # A paths filter makes the trigger conditional on which files a PR touches,
+  # whatever its value, so only the key itself needs reading.
+  if (key == "paths" || key == "paths-ignore") {
+    pathsfilter = key
+    next
+  }
   if (key != "branches") next
   if (val == "") {
     mode = 3
     br_indent = i
+    has_branches = 1
     next
   }
   if (substr(val, 1, 1) == "[") {
     if (index(val, "]") == 0) \
       emit("unsupported multi-line flow sequence under branches")
     bases = tokens(val)
-    emit(branch_list())
+    has_branches = 1
+    next
   }
   emit("unsupported scalar branches value")
 }
@@ -226,8 +258,7 @@ END {
   if (mode == 0) emit("unsupported no top-level on: key")
   if (seq) emit(events(ev))
   if (mode == 1) emit("none")
-  if (mode == 2) emit("all")
-  emit(branch_list())
+  emit(pr_verdict())
 }
 ' "$1"
 }
@@ -237,7 +268,7 @@ END {
 # workflow set rather than of one explicitly linted file.
 fm_lint_workflows_pr_gating() {
   local file name verdict required_verdict='' required_set='' found_required=0
-  local rc=0 i n base missing
+  local rc=0 i n base missing paths_filter required_paths='' glob_note=''
   local names=() verdicts=()
 
   for file in "${FILES[@]}"; do
@@ -254,9 +285,18 @@ fm_lint_workflows_pr_gating() {
         return 1
         ;;
     esac
+    paths_filter=''
+    case "$verdict" in
+      "paths "*)
+        verdict=${verdict#paths }
+        paths_filter=${verdict%% *}
+        verdict=${verdict#* }
+        ;;
+    esac
     if [ "$name" = "$REQUIRED_CHECK_WORKFLOW" ]; then
       found_required=1
       required_verdict=$verdict
+      required_paths=$paths_filter
       continue
     fi
     names+=("$name")
@@ -291,8 +331,28 @@ fm_lint_workflows_pr_gating() {
       "$REQUIRED_CHECK_WORKFLOW" >&2
     return 1
   fi
+  # A paths filter on any other workflow only makes that workflow conditional;
+  # on the required check it means a PR touching no matching file gets no run
+  # of it at all, which reads exactly like a passing required check.
+  if [ -n "$required_paths" ]; then
+    if [ "$required_verdict" = all ]; then
+      printf 'fm-lint-workflows.sh: %s narrows its pull_request trigger with a %s filter, so on every PR base it gates a PR touching no matching file produces no run of the required check at all, which is indistinguishable from a passing one. Remove the %s filter from %s.\n' \
+        "$REQUIRED_CHECK_WORKFLOW" "$required_paths" "$required_paths" \
+        "$REQUIRED_CHECK_WORKFLOW" >&2
+    else
+      printf 'fm-lint-workflows.sh: %s narrows its pull_request trigger with a %s filter, so PR base(s)%s are only conditionally gated: a PR touching no matching file produces no run of the required check at all, which is indistinguishable from a passing one. Remove the %s filter from %s.\n' \
+        "$REQUIRED_CHECK_WORKFLOW" "$required_paths" "${required_verdict#bases}" \
+        "$required_paths" "$REQUIRED_CHECK_WORKFLOW" >&2
+    fi
+    return 1
+  fi
   case "$required_verdict" in
     bases*) required_set="${required_verdict#bases} " ;;
+  esac
+  case "$required_verdict" in
+    *[*?]*)
+      glob_note=" Base names are compared literally, so a glob in $REQUIRED_CHECK_WORKFLOW is not expanded here; list each gated base by name."
+      ;;
   esac
 
   i=0
@@ -303,23 +363,28 @@ fm_lint_workflows_pr_gating() {
     [ "$verdict" != none ] || continue
     [ "$required_verdict" != all ] || continue
     if [ "$verdict" = all ]; then
-      printf 'fm-lint-workflows.sh: %s gates every PR base while %s requires checks only on:%s. Drop the base filter in %s or widen it there.\n' \
+      printf 'fm-lint-workflows.sh: %s gates every PR base while %s requires checks only on:%s. Drop the base filter in %s or widen it there.%s\n' \
         "$name" "$REQUIRED_CHECK_WORKFLOW" "${required_verdict#bases}" \
-        "$REQUIRED_CHECK_WORKFLOW" >&2
+        "$REQUIRED_CHECK_WORKFLOW" "$glob_note" >&2
       rc=1
       continue
     fi
     missing=''
     # Intentional word split: the classifier emits bases separated by spaces.
+    # Globbing stays off so a base is compared as the literal name it is,
+    # rather than expanded against the working directory.
+    set -f
     for base in ${verdict#bases}; do
       case "$required_set" in
         *" $base "*) ;;
         *) missing="$missing $base" ;;
       esac
     done
+    set +f
     if [ -n "$missing" ]; then
-      printf 'fm-lint-workflows.sh: %s gates PR base(s)%s that %s does not require, so a PR into them can merge with the required check absent. Add them to %s.\n' \
-        "$name" "$missing" "$REQUIRED_CHECK_WORKFLOW" "$REQUIRED_CHECK_WORKFLOW" >&2
+      printf 'fm-lint-workflows.sh: %s gates PR base(s)%s that %s does not require, so a PR into them can merge with the required check absent. Add them to %s.%s\n' \
+        "$name" "$missing" "$REQUIRED_CHECK_WORKFLOW" "$REQUIRED_CHECK_WORKFLOW" \
+        "$glob_note" >&2
       rc=1
     fi
   done

--- a/bin/fm-lint-workflows.sh
+++ b/bin/fm-lint-workflows.sh
@@ -105,10 +105,12 @@ collect_workflow_files() {
 # branch, while a `pull_request_target` filter edit takes effect only once it
 # reaches the default branch. Do not carry `pull_request` reasoning across.
 #
-# Stated limitation: base names are compared literally. A glob or pattern in
-# the required check's branch list is not understood here, so a required check
-# written with one fails this lint loudly rather than passing silently. That is
-# the deliberate trade, for two reasons: a loud refusal is the opposite of the
+# Stated limitation: base names are compared literally, so a GitHub filter
+# pattern in any `branches:` list is refused by name with its reason rather
+# than compared. Comparing one literally cannot decide coverage: `**` and
+# `['**', '!docs']` match as strings while the second gates strictly fewer
+# bases, which would pass a set where a PR into `docs` gets CI and no required
+# check. Refusing keeps that path loud, which is the opposite of the
 # silent-absence defect this gate exists to catch, and no workflow in this repo
 # uses such a construct today. Teach this gate pattern semantics on the day one
 # does, rather than guessing at coverage in the meantime.
@@ -162,6 +164,25 @@ function events(s, n, i, a, e) {
 }
 function branch_list() {
   return bases == "" ? "unsupported empty branches list" : "bases" bases
+}
+# A GitHub filter pattern is not a base name, and this gate compares names
+# literally, so a pattern is a form it refuses rather than one it can judge.
+function pattern(b) {
+  return b ~ /[]*?+[]/ || substr(b, 1, 1) == "!"
+}
+function refuse_pattern(b) {
+  emit("unsupported pattern base \"" b "\" in a branches list")
+}
+# The flow form is scanned before tokens() strips its brackets, so a bracket
+# expression inside an entry is still visible as part of that entry.
+function flow_patterns(s, n, i, a, b) {
+  sub(/^[ \t]*\[/, "", s)
+  sub(/\][ \t]*$/, "", s)
+  n = split(s, a, /,/)
+  for (i = 1; i <= n; i++) {
+    b = unq(trim(a[i]))
+    if (b != "" && pattern(b)) refuse_pattern(b)
+  }
 }
 # An event block is only classified once it ends, because a narrowing `paths:`
 # sibling may follow the `branches:` list it narrows.
@@ -228,6 +249,7 @@ function bank(v) {
       if (dash && i >= br_indent) {
         b = unq(trim(substr(t, 2)))
         if (b == "") emit("unsupported empty branches entry")
+        if (pattern(b)) refuse_pattern(b)
         bases = bases " " b
         next
       }
@@ -266,6 +288,7 @@ function bank(v) {
       if (substr(val, 1, 1) == "[") {
         if (index(val, "]") == 0) \
           emit("unsupported multi-line flow sequence under branches")
+        flow_patterns(val)
         bases = tokens(val)
         has_branches = 1
         next
@@ -314,6 +337,13 @@ END {
 # Every classification the gate refuses is reported the same way, so a caller
 # never has to recognize a refusal by more than one shape.
 fm_lint_workflows_refuse() {
+  case "$2" in
+    "pattern base "*)
+      printf 'fm-lint-workflows.sh: %s: %s. Base names are compared literally here, so this gate cannot judge whether a pattern covers the bases other workflows gate. List each gated base by name, or teach this gate pattern semantics.\n' \
+        "$1" "$2" >&2
+      return
+      ;;
+  esac
   printf 'fm-lint-workflows.sh: %s: cannot read the pull_request base filter (%s). Keep the on: block in block style with an explicit branches: list, or teach this gate the new form.\n' \
     "$1" "$2" >&2
 }
@@ -336,7 +366,7 @@ fm_lint_workflows_event_note() {
 # workflow set rather than of one explicitly linted file.
 fm_lint_workflows_pr_gating() {
   local file name verdict required_verdict='' required_set='' found_required=0
-  local rc=0 i n base missing paths_filter required_paths='' glob_note='' skip_when
+  local rc=0 i n base missing paths_filter required_paths='' skip_when
   local verdict_event required_event='' event note
   local names=() verdicts=() wf_events=()
 
@@ -441,11 +471,6 @@ fm_lint_workflows_pr_gating() {
   case "$required_verdict" in
     bases*) required_set="${required_verdict#bases} " ;;
   esac
-  case "$required_verdict" in
-    *[*?]*)
-      glob_note=" Base names are compared literally, so a glob in $REQUIRED_CHECK_WORKFLOW is not expanded here; list each gated base by name."
-      ;;
-  esac
 
   i=0
   while [ "$i" -lt "$n" ]; do
@@ -458,9 +483,9 @@ fm_lint_workflows_pr_gating() {
     note=$note$(fm_lint_workflows_event_note "$name" "$event")
     [ "$required_verdict" != all ] || continue
     if [ "$verdict" = all ]; then
-      printf 'fm-lint-workflows.sh: %s gates every PR base through its %s trigger while %s requires checks only on:%s. Drop the base filter in %s or widen it there.%s%s\n' \
+      printf 'fm-lint-workflows.sh: %s gates every PR base through its %s trigger while %s requires checks only on:%s. Drop the base filter in %s or widen it there.%s\n' \
         "$name" "$event" "$REQUIRED_CHECK_WORKFLOW" "${required_verdict#bases}" \
-        "$REQUIRED_CHECK_WORKFLOW" "$glob_note" "$note" >&2
+        "$REQUIRED_CHECK_WORKFLOW" "$note" >&2
       rc=1
       continue
     fi
@@ -477,9 +502,9 @@ fm_lint_workflows_pr_gating() {
     done
     set +f
     if [ -n "$missing" ]; then
-      printf 'fm-lint-workflows.sh: %s gates PR base(s)%s through its %s trigger that %s does not require, so a PR into them can merge with the required check absent. Add them to %s.%s%s\n' \
+      printf 'fm-lint-workflows.sh: %s gates PR base(s)%s through its %s trigger that %s does not require, so a PR into them can merge with the required check absent. Add them to %s.%s\n' \
         "$name" "$missing" "$event" "$REQUIRED_CHECK_WORKFLOW" \
-        "$REQUIRED_CHECK_WORKFLOW" "$glob_note" "$note" >&2
+        "$REQUIRED_CHECK_WORKFLOW" "$note" >&2
       rc=1
     fi
   done

--- a/bin/fm-lint-workflows.sh
+++ b/bin/fm-lint-workflows.sh
@@ -147,6 +147,12 @@ function branch_list() {
     key = unq(substr(line, 1, ci - 1))
     val = trim(substr(line, ci + 1))
   }
+  # YAML lets a block sequence sit at the indent of its parent key, so block
+  # membership rather than raw indent decides where a block ends: a `-` line at
+  # or deeper than the indent of the key it belongs to is an item of that key,
+  # never the next key. A mapping key always carries a `:` and never starts
+  # with `-`, so the two forms never collide.
+  dash = (substr(t, 1, 1) == "-")
   if (mode == 0) {
     if (i == 0 && key == "on") {
       if (substr(val, 1, 1) == "{") emit("unsupported flow-mapping on: value")
@@ -156,51 +162,64 @@ function branch_list() {
     }
     next
   }
-  # A top-level key ends the on: block, so the verdict is whatever we have.
-  if (i == 0) {
-    if (seq) emit(events(ev))
-    if (mode == 1) emit("none")
-    if (mode == 2) emit("all")
-    emit(branch_list())
-  }
-  if (mode == 1) {
-    if (on_indent < 0) {
-      on_indent = i
-      if (substr(t, 1, 1) == "-") seq = 1
-    }
-    if (seq) {
-      if (substr(t, 1, 1) != "-") emit("unsupported mixed sequence in on: block")
-      ev = ev " " unq(trim(substr(t, 2)))
+  if (mode == 3) {
+    if (dash && i >= br_indent) {
+      b = unq(trim(substr(t, 2)))
+      if (b == "") emit("unsupported empty branches entry")
+      bases = bases " " b
       next
     }
+    # Anything that is not an item of this sequence ends the branches list.
+    if (i <= br_indent) emit(branch_list())
+    emit("unsupported non-sequence entry under branches")
+  }
+  if (mode == 1) {
+    # The first member line decides whether on: holds a sequence or a mapping;
+    # under a mapping, deeper `-` lines belong to some other event key.
+    if (on_indent < 0) {
+      on_indent = i
+      if (dash) seq = 1
+    }
+    if (seq) {
+      if (dash && i >= on_indent) {
+        ev = ev " " unq(trim(substr(t, 2)))
+        next
+      }
+      # on: sits at column 0, so only a column-0 key can end its block; a
+      # shallower-but-not-top-level line is mixed content this gate refuses.
+      if (i == 0) emit(events(ev))
+      emit("unsupported mixed sequence in on: block")
+    }
+    # A top-level key ends the on: block, so the verdict is whatever we have.
+    if (i == 0) emit("none")
     if (i != on_indent || key != "pull_request") next
     if (val != "") emit("unsupported inline pull_request value")
     mode = 2
     pr_indent = -1
     next
   }
-  if (mode == 2) {
-    # The pull_request block ended without a branches filter: every base.
-    if (i <= on_indent) emit("all")
-    if (pr_indent < 0) pr_indent = i
-    if (i != pr_indent) next
-    if (key == "branches-ignore") \
-      emit("unsupported branches-ignore under pull_request")
-    if (key != "branches") next
-    if (val == "") { mode = 3; next }
-    if (substr(val, 1, 1) == "[") {
-      if (index(val, "]") == 0) \
-        emit("unsupported multi-line flow sequence under branches")
-      bases = tokens(val)
-      emit(branch_list())
-    }
-    emit("unsupported scalar branches value")
+  # The pull_request block ended without a branches filter: every base.
+  if (i <= on_indent) emit("all")
+  if (pr_indent < 0) {
+    if (dash) emit("unsupported sequence under pull_request")
+    pr_indent = i
   }
-  if (i <= pr_indent) emit(branch_list())
-  if (substr(t, 1, 1) != "-") emit("unsupported non-sequence entry under branches")
-  b = unq(trim(substr(t, 2)))
-  if (b == "") emit("unsupported empty branches entry")
-  bases = bases " " b
+  if (i != pr_indent) next
+  if (key == "branches-ignore") \
+    emit("unsupported branches-ignore under pull_request")
+  if (key != "branches") next
+  if (val == "") {
+    mode = 3
+    br_indent = i
+    next
+  }
+  if (substr(val, 1, 1) == "[") {
+    if (index(val, "]") == 0) \
+      emit("unsupported multi-line flow sequence under branches")
+    bases = tokens(val)
+    emit(branch_list())
+  }
+  emit("unsupported scalar branches value")
 }
 END {
   if (emitted) exit
@@ -244,8 +263,26 @@ fm_lint_workflows_pr_gating() {
     verdicts+=("$verdict")
   done
 
+  n=${#names[@]}
   if [ "$found_required" -eq 0 ]; then
-    printf 'fm-lint-workflows.sh: PR base gating: %s is absent from this workflow set, so base coverage was not compared.\n' \
+    # A deleted required check is exactly the failure this gate exists to catch:
+    # no checks at all reads like passing checks in the pull request UI. Its
+    # absence is only acceptable when nothing in the set gates pull requests.
+    missing=''
+    i=0
+    while [ "$i" -lt "$n" ]; do
+      name=${names[$i]}
+      verdict=${verdicts[$i]}
+      i=$((i + 1))
+      [ "$verdict" != none ] || continue
+      missing="$missing $name"
+    done
+    if [ -n "$missing" ]; then
+      printf 'fm-lint-workflows.sh: %s is absent from this workflow set while%s gate(s) pull requests, so every PR base they gate can merge with no required check. Restore %s with a pull_request trigger covering those bases.\n' \
+        "$REQUIRED_CHECK_WORKFLOW" "$missing" "$REQUIRED_CHECK_WORKFLOW" >&2
+      return 1
+    fi
+    printf 'fm-lint-workflows.sh: PR base gating: no workflow in this set has a pull_request trigger, so %s is not needed here.\n' \
       "$REQUIRED_CHECK_WORKFLOW" >&2
     return 0
   fi
@@ -258,7 +295,6 @@ fm_lint_workflows_pr_gating() {
     bases*) required_set="${required_verdict#bases} " ;;
   esac
 
-  n=${#names[@]}
   i=0
   while [ "$i" -lt "$n" ]; do
     name=${names[$i]}

--- a/bin/fm-lint-workflows.sh
+++ b/bin/fm-lint-workflows.sh
@@ -95,6 +95,13 @@ collect_workflow_files() {
 # getting the check branch protection requires. The reminder to add a new
 # long-lived base at all lives in each workflow's own `on:` block comment.
 #
+# `pull_request_target` gates a base the same way and so counts the same here,
+# but it reads the workflow file from the repository's DEFAULT branch rather
+# than from the PR merge commit. That changes where a fix has to land: a
+# `pull_request` filter edit gates itself once merged into the integration
+# branch, while a `pull_request_target` filter edit takes effect only once it
+# reaches the default branch. Do not carry `pull_request` reasoning across.
+#
 # Stated limitation: base names are compared literally. A glob or pattern in
 # the required check's branch list is not understood here, so a required check
 # written with one fails this lint loudly rather than passing silently. That is
@@ -105,13 +112,15 @@ collect_workflow_files() {
 REQUIRED_CHECK_WORKFLOW=no-mistakes-required.yml
 
 # Prints exactly one classification line for one workflow file:
-#   none                  no `pull_request` trigger
-#   all                   `pull_request` with no base filter, so every base
-#   bases <base>...       `pull_request` filtered to these bases
-#   unsupported <reason>  a form this gate refuses to guess at
-# A definite verdict carries a `paths <key> ` prefix when the `pull_request`
-# trigger is also narrowed by a `paths:` or `paths-ignore:` filter, because
-# such a trigger produces no run at all for a PR touching no matching file.
+#   none                          no base-gating trigger
+#   event <event> all             that event with no base filter, so every base
+#   event <event> bases <base>... that event filtered to these bases
+#   unsupported <reason>          a form this gate refuses to guess at
+# <event> is `pull_request` or `pull_request_target`; both gate a PR by its
+# base branch, so both are read, and the verdict names the one actually used.
+# A definite verdict carries a `paths <key> ` prefix ahead of the base part
+# when the trigger is also narrowed by a `paths:` or `paths-ignore:` filter,
+# because such a trigger can produce no run at all for a given PR.
 fm_lint_workflows_pr_filter() {
   awk '
 function ind(s) { match(s, /^ */); return RLENGTH }
@@ -127,13 +136,8 @@ function unq(s, q) {
   }
   return s
 }
-function emit(v) {
-  if (pathsfilter != "" && (v == "all" || substr(v, 1, 5) == "bases")) \
-    v = "paths " pathsfilter " " v
-  print v
-  emitted = 1
-  exit
-}
+function emit(v) { print v; emitted = 1; exit }
+function gating(e) { return e == "pull_request" || e == "pull_request_target" }
 function tokens(s, n, i, a, t, r) {
   gsub(/[\[\]]/, " ", s)
   gsub(/,/, " ", s)
@@ -142,18 +146,38 @@ function tokens(s, n, i, a, t, r) {
   for (i = 1; i <= n; i++) { t = unq(a[i]); if (t != "") r = r " " t }
   return r
 }
-function events(s, n, i, a) {
+function events(s, n, i, a, e) {
   n = split(tokens(s), a, / /)
-  for (i = 1; i <= n; i++) if (a[i] == "pull_request") return "all"
-  return "none"
+  e = ""
+  for (i = 1; i <= n; i++) {
+    if (!gating(a[i])) continue
+    if (e != "" && e != a[i]) \
+      return "unsupported both pull_request and pull_request_target triggers"
+    e = a[i]
+  }
+  return e == "" ? "none" : "event " e " all"
 }
 function branch_list() {
   return bases == "" ? "unsupported empty branches list" : "bases" bases
 }
-# The pull_request block is only classified once it ends, because a narrowing
-# `paths:` sibling may follow the `branches:` list it narrows.
+# An event block is only classified once it ends, because a narrowing `paths:`
+# sibling may follow the `branches:` list it narrows.
 function pr_verdict() {
   return has_branches ? branch_list() : "all"
+}
+# The banked verdict for the base-gating event this file uses, if any. Scanning
+# continues past that block so a second gating event cannot go unread.
+function banked(v) {
+  if (found_event == "") return "none"
+  v = found_verdict
+  if (found_paths != "") v = "paths " found_paths " " v
+  return "event " found_event " " v
+}
+function bank() {
+  found_event = pr_event
+  found_verdict = pr_verdict()
+  found_paths = pathsfilter
+  pathsfilter = ""
 }
 {
   line = $0
@@ -186,19 +210,59 @@ function pr_verdict() {
     }
     next
   }
-  if (mode == 3) {
-    if (dash && i >= br_indent) {
-      b = unq(trim(substr(t, 2)))
-      if (b == "") emit("unsupported empty branches entry")
-      bases = bases " " b
-      next
+  # A line that is not a member of the innermost open block closes it, and is
+  # then reconsidered by the block that encloses it.
+  reconsider = 1
+  while (reconsider) {
+    reconsider = 0
+    if (mode == 3) {
+      if (dash && i >= br_indent) {
+        b = unq(trim(substr(t, 2)))
+        if (b == "") emit("unsupported empty branches entry")
+        bases = bases " " b
+        next
+      }
+      if (i > br_indent) emit("unsupported non-sequence entry under branches")
+      mode = 2
+      reconsider = 1
+      continue
     }
-    # Anything that is not an item of this sequence ends the branches list and
-    # is reconsidered below as a sibling key of the pull_request block.
-    if (i > br_indent) emit("unsupported non-sequence entry under branches")
-    mode = 2
-  }
-  if (mode == 1) {
+    if (mode == 2) {
+      if (i <= on_indent) {
+        bank()
+        mode = 1
+        reconsider = 1
+        continue
+      }
+      if (pr_indent < 0) {
+        if (dash) emit("unsupported sequence under " pr_event)
+        pr_indent = i
+      }
+      if (i != pr_indent) next
+      if (key == "branches-ignore") \
+        emit("unsupported branches-ignore under " pr_event)
+      # A paths filter makes the trigger conditional on which files a PR
+      # touches, whatever its value, so only the key itself needs reading.
+      if (key == "paths" || key == "paths-ignore") {
+        pathsfilter = key
+        next
+      }
+      if (key != "branches") next
+      if (val == "") {
+        mode = 3
+        br_indent = i
+        has_branches = 1
+        next
+      }
+      if (substr(val, 1, 1) == "[") {
+        if (index(val, "]") == 0) \
+          emit("unsupported multi-line flow sequence under branches")
+        bases = tokens(val)
+        has_branches = 1
+        next
+      }
+      emit("unsupported scalar branches value")
+    }
     # The first member line decides whether on: holds a sequence or a mapping;
     # under a mapping, deeper `-` lines belong to some other event key.
     if (on_indent < 0) {
@@ -215,54 +279,38 @@ function pr_verdict() {
       if (i == 0) emit(events(ev))
       emit("unsupported mixed sequence in on: block")
     }
-    # A top-level key ends the on: block, so the verdict is whatever we have.
-    if (i == 0) emit("none")
-    if (i != on_indent || key != "pull_request") next
-    if (val != "") emit("unsupported inline pull_request value")
+    # A top-level key ends the on: block, so the verdict is whatever we banked.
+    if (i == 0) emit(banked())
+    if (i != on_indent || !gating(key)) next
+    if (found_event == key) emit("unsupported duplicate " key " key in on: block")
+    if (found_event != "") \
+      emit("unsupported both pull_request and pull_request_target triggers")
+    if (val != "") emit("unsupported inline " key " value")
+    pr_event = key
     mode = 2
     pr_indent = -1
     next
   }
-  # A line at or above the pull_request key ends its block, so the collected
-  # branches list, or its absence, is the verdict.
-  if (i <= on_indent) emit(pr_verdict())
-  if (pr_indent < 0) {
-    if (dash) emit("unsupported sequence under pull_request")
-    pr_indent = i
-  }
-  if (i != pr_indent) next
-  if (key == "branches-ignore") \
-    emit("unsupported branches-ignore under pull_request")
-  # A paths filter makes the trigger conditional on which files a PR touches,
-  # whatever its value, so only the key itself needs reading.
-  if (key == "paths" || key == "paths-ignore") {
-    pathsfilter = key
-    next
-  }
-  if (key != "branches") next
-  if (val == "") {
-    mode = 3
-    br_indent = i
-    has_branches = 1
-    next
-  }
-  if (substr(val, 1, 1) == "[") {
-    if (index(val, "]") == 0) \
-      emit("unsupported multi-line flow sequence under branches")
-    bases = tokens(val)
-    has_branches = 1
-    next
-  }
-  emit("unsupported scalar branches value")
 }
 END {
   if (emitted) exit
   if (mode == 0) emit("unsupported no top-level on: key")
   if (seq) emit(events(ev))
-  if (mode == 1) emit("none")
-  emit(pr_verdict())
+  if (mode == 2 || mode == 3) bank()
+  emit(banked())
 }
 ' "$1"
+}
+
+# `pull_request_target` reads the workflow file from the default branch, so a
+# reader acting on one of these findings must not assume the merge-commit
+# behavior `pull_request` has. Every diagnostic naming that event says so.
+fm_lint_workflows_event_note() {
+  case "$1" in
+    pull_request_target)
+      printf ' Note: pull_request_target reads the workflow file from the default branch, not from the PR merge commit as pull_request does, so that edit only takes effect once it reaches the default branch.'
+      ;;
+  esac
 }
 
 # Compares the scanned workflow set against REQUIRED_CHECK_WORKFLOW. Runs only
@@ -271,7 +319,8 @@ END {
 fm_lint_workflows_pr_gating() {
   local file name verdict required_verdict='' required_set='' found_required=0
   local rc=0 i n base missing paths_filter required_paths='' glob_note='' skip_when
-  local names=() verdicts=()
+  local verdict_event required_event='' event note
+  local names=() verdicts=() wf_events=()
 
   for file in "${FILES[@]}"; do
     name=${file##*/}
@@ -287,7 +336,15 @@ fm_lint_workflows_pr_gating() {
         return 1
         ;;
     esac
+    verdict_event=''
     paths_filter=''
+    case "$verdict" in
+      "event "*)
+        verdict=${verdict#event }
+        verdict_event=${verdict%% *}
+        verdict=${verdict#* }
+        ;;
+    esac
     case "$verdict" in
       "paths "*)
         verdict=${verdict#paths }
@@ -299,10 +356,12 @@ fm_lint_workflows_pr_gating() {
       found_required=1
       required_verdict=$verdict
       required_paths=$paths_filter
+      required_event=$verdict_event
       continue
     fi
     names+=("$name")
     verdicts+=("$verdict")
+    wf_events+=("$verdict_event")
   done
 
   n=${#names[@]}
@@ -324,7 +383,7 @@ fm_lint_workflows_pr_gating() {
         "$REQUIRED_CHECK_WORKFLOW" "$missing" "$REQUIRED_CHECK_WORKFLOW" >&2
       return 1
     fi
-    printf 'fm-lint-workflows.sh: PR base gating: no workflow in this set has a pull_request trigger, so %s is not needed here.\n' \
+    printf 'fm-lint-workflows.sh: PR base gating: no workflow in this set has a pull_request or pull_request_target trigger, so %s is not needed here.\n' \
       "$REQUIRED_CHECK_WORKFLOW" >&2
     return 0
   fi
@@ -342,14 +401,16 @@ fm_lint_workflows_pr_gating() {
       paths-ignore) skip_when='a PR touching only files the filter ignores' ;;
       *) skip_when='a PR touching no file the filter matches' ;;
     esac
+    note=$(fm_lint_workflows_event_note "$required_event")
     if [ "$required_verdict" = all ]; then
-      printf 'fm-lint-workflows.sh: %s narrows its pull_request trigger with a %s filter, so on every PR base it gates, %s produces no run of the required check at all, which is indistinguishable from a passing one. Remove the %s filter from %s.\n' \
-        "$REQUIRED_CHECK_WORKFLOW" "$required_paths" "$skip_when" \
-        "$required_paths" "$REQUIRED_CHECK_WORKFLOW" >&2
+      printf 'fm-lint-workflows.sh: %s narrows its %s trigger with a %s filter, so on every PR base it gates, %s produces no run of the required check at all, which is indistinguishable from a passing one. Remove the %s filter from %s.%s\n' \
+        "$REQUIRED_CHECK_WORKFLOW" "$required_event" "$required_paths" "$skip_when" \
+        "$required_paths" "$REQUIRED_CHECK_WORKFLOW" "$note" >&2
     else
-      printf 'fm-lint-workflows.sh: %s narrows its pull_request trigger with a %s filter, so PR base(s)%s are only conditionally gated: %s produces no run of the required check at all, which is indistinguishable from a passing one. Remove the %s filter from %s.\n' \
-        "$REQUIRED_CHECK_WORKFLOW" "$required_paths" "${required_verdict#bases}" \
-        "$skip_when" "$required_paths" "$REQUIRED_CHECK_WORKFLOW" >&2
+      printf 'fm-lint-workflows.sh: %s narrows its %s trigger with a %s filter, so PR base(s)%s are only conditionally gated: %s produces no run of the required check at all, which is indistinguishable from a passing one. Remove the %s filter from %s.%s\n' \
+        "$REQUIRED_CHECK_WORKFLOW" "$required_event" "$required_paths" \
+        "${required_verdict#bases}" "$skip_when" "$required_paths" \
+        "$REQUIRED_CHECK_WORKFLOW" "$note" >&2
     fi
     return 1
   fi
@@ -366,13 +427,15 @@ fm_lint_workflows_pr_gating() {
   while [ "$i" -lt "$n" ]; do
     name=${names[$i]}
     verdict=${verdicts[$i]}
+    event=${wf_events[$i]}
     i=$((i + 1))
     [ "$verdict" != none ] || continue
+    note=$(fm_lint_workflows_event_note "$event")
     [ "$required_verdict" != all ] || continue
     if [ "$verdict" = all ]; then
-      printf 'fm-lint-workflows.sh: %s gates every PR base while %s requires checks only on:%s. Drop the base filter in %s or widen it there.%s\n' \
-        "$name" "$REQUIRED_CHECK_WORKFLOW" "${required_verdict#bases}" \
-        "$REQUIRED_CHECK_WORKFLOW" "$glob_note" >&2
+      printf 'fm-lint-workflows.sh: %s gates every PR base through its %s trigger while %s requires checks only on:%s. Drop the base filter in %s or widen it there.%s%s\n' \
+        "$name" "$event" "$REQUIRED_CHECK_WORKFLOW" "${required_verdict#bases}" \
+        "$REQUIRED_CHECK_WORKFLOW" "$glob_note" "$note" >&2
       rc=1
       continue
     fi
@@ -389,9 +452,9 @@ fm_lint_workflows_pr_gating() {
     done
     set +f
     if [ -n "$missing" ]; then
-      printf 'fm-lint-workflows.sh: %s gates PR base(s)%s that %s does not require, so a PR into them can merge with the required check absent. Add them to %s.%s\n' \
-        "$name" "$missing" "$REQUIRED_CHECK_WORKFLOW" "$REQUIRED_CHECK_WORKFLOW" \
-        "$glob_note" >&2
+      printf 'fm-lint-workflows.sh: %s gates PR base(s)%s through its %s trigger that %s does not require, so a PR into them can merge with the required check absent. Add them to %s.%s%s\n' \
+        "$name" "$missing" "$event" "$REQUIRED_CHECK_WORKFLOW" \
+        "$REQUIRED_CHECK_WORKFLOW" "$glob_note" "$note" >&2
       rc=1
     fi
   done

--- a/bin/fm-lint-workflows.sh
+++ b/bin/fm-lint-workflows.sh
@@ -9,10 +9,13 @@
 # commands.lint both use.
 #
 # The directory-scan path then checks one gating invariant across the scanned
-# set: every PR base gated by any pull_request-triggered workflow must also be
-# gated by no-mistakes-required.yml, so a base can never get CI without the
-# check branch protection requires. See the comment above
-# REQUIRED_CHECK_WORKFLOW for why that is worth enforcing mechanically.
+# set: every PR base gated by any pull_request or pull_request_target workflow
+# must also be gated by no-mistakes-required.yml, so a base can never get CI
+# without the check branch protection requires. A required check narrowed by a
+# paths: or paths-ignore: filter fails too, because it then stops gating every
+# base it lists. Any on: form this gate cannot read confidently is refused by
+# name rather than guessed at. See the comment above REQUIRED_CHECK_WORKFLOW
+# for why that is worth enforcing mechanically.
 #
 # Usage:
 #   fm-lint-workflows.sh                 lint workflows under this repo
@@ -33,7 +36,7 @@ if [ "${1:-}" = "--required-version" ]; then
 fi
 
 fm_lint_workflows_usage() {
-  sed -n '2,22{s/^# \{0,1\}//;p;}' "$SELF"
+  sed -n '2,25{s/^# \{0,1\}//;p;}' "$SELF"
 }
 
 EXPLICIT_ROOT=
@@ -165,17 +168,23 @@ function branch_list() {
 function pr_verdict() {
   return has_branches ? branch_list() : "all"
 }
+function refusal(v) { return substr(v, 1, 12) == "unsupported " }
 # The banked verdict for the base-gating event this file uses, if any. Scanning
 # continues past that block so a second gating event cannot go unread.
 function banked(v) {
   if (found_event == "") return "none"
   v = found_verdict
+  if (refusal(v)) return v
   if (found_paths != "") v = "paths " found_paths " " v
   return "event " found_event " " v
 }
-function bank() {
+# A refusal is terminal and never gains an event prefix, so the reason always
+# reaches the caller in the one shape the caller recognizes as a refusal.
+function bank(v) {
+  v = pr_verdict()
+  if (refusal(v)) emit(v)
   found_event = pr_event
-  found_verdict = pr_verdict()
+  found_verdict = v
   found_paths = pathsfilter
   pathsfilter = ""
 }
@@ -302,13 +311,22 @@ END {
 ' "$1"
 }
 
+# Every classification the gate refuses is reported the same way, so a caller
+# never has to recognize a refusal by more than one shape.
+fm_lint_workflows_refuse() {
+  printf 'fm-lint-workflows.sh: %s: cannot read the pull_request base filter (%s). Keep the on: block in block style with an explicit branches: list, or teach this gate the new form.\n' \
+    "$1" "$2" >&2
+}
+
 # `pull_request_target` reads the workflow file from the default branch, so a
 # reader acting on one of these findings must not assume the merge-commit
-# behavior `pull_request` has. Every diagnostic naming that event says so.
+# behavior `pull_request` has. The note names the file it describes, because a
+# finding involves two files whose events can differ.
 fm_lint_workflows_event_note() {
-  case "$1" in
+  case "$2" in
     pull_request_target)
-      printf ' Note: pull_request_target reads the workflow file from the default branch, not from the PR merge commit as pull_request does, so that edit only takes effect once it reaches the default branch.'
+      printf ' Note: %s is triggered by pull_request_target, which reads the workflow file from the default branch rather than from the PR merge commit as pull_request does, so an edit there only takes effect once it reaches the default branch.' \
+        "$1"
       ;;
   esac
 }
@@ -331,8 +349,7 @@ fm_lint_workflows_pr_gating() {
     }
     case "$verdict" in
       "unsupported "*)
-        printf 'fm-lint-workflows.sh: %s: cannot read the pull_request base filter (%s). Keep the on: block in block style with an explicit branches: list, or teach this gate the new form.\n' \
-          "$name" "${verdict#unsupported }" >&2
+        fm_lint_workflows_refuse "$name" "${verdict#unsupported }"
         return 1
         ;;
     esac
@@ -350,6 +367,13 @@ fm_lint_workflows_pr_gating() {
         verdict=${verdict#paths }
         paths_filter=${verdict%% *}
         verdict=${verdict#* }
+        ;;
+    esac
+    case "$verdict" in
+      none|all|"bases "*) ;;
+      *)
+        fm_lint_workflows_refuse "$name" "unrecognized classification: $verdict"
+        return 1
         ;;
     esac
     if [ "$name" = "$REQUIRED_CHECK_WORKFLOW" ]; then
@@ -401,7 +425,7 @@ fm_lint_workflows_pr_gating() {
       paths-ignore) skip_when='a PR touching only files the filter ignores' ;;
       *) skip_when='a PR touching no file the filter matches' ;;
     esac
-    note=$(fm_lint_workflows_event_note "$required_event")
+    note=$(fm_lint_workflows_event_note "$REQUIRED_CHECK_WORKFLOW" "$required_event")
     if [ "$required_verdict" = all ]; then
       printf 'fm-lint-workflows.sh: %s narrows its %s trigger with a %s filter, so on every PR base it gates, %s produces no run of the required check at all, which is indistinguishable from a passing one. Remove the %s filter from %s.%s\n' \
         "$REQUIRED_CHECK_WORKFLOW" "$required_event" "$required_paths" "$skip_when" \
@@ -430,7 +454,8 @@ fm_lint_workflows_pr_gating() {
     event=${wf_events[$i]}
     i=$((i + 1))
     [ "$verdict" != none ] || continue
-    note=$(fm_lint_workflows_event_note "$event")
+    note=$(fm_lint_workflows_event_note "$REQUIRED_CHECK_WORKFLOW" "$required_event")
+    note=$note$(fm_lint_workflows_event_note "$name" "$event")
     [ "$required_verdict" != all ] || continue
     if [ "$verdict" = all ]; then
       printf 'fm-lint-workflows.sh: %s gates every PR base through its %s trigger while %s requires checks only on:%s. Drop the base filter in %s or widen it there.%s%s\n' \

--- a/bin/fm-lint-workflows.sh
+++ b/bin/fm-lint-workflows.sh
@@ -178,6 +178,8 @@ function pr_verdict() {
   if (mode == 0) {
     if (i == 0 && key == "on") {
       if (substr(val, 1, 1) == "{") emit("unsupported flow-mapping on: value")
+      if (substr(val, 1, 1) == "[" && index(val, "]") == 0) \
+        emit("unsupported multi-line flow sequence for on:")
       if (val != "") emit(events(val))
       mode = 1
       on_indent = -1
@@ -268,7 +270,7 @@ END {
 # workflow set rather than of one explicitly linted file.
 fm_lint_workflows_pr_gating() {
   local file name verdict required_verdict='' required_set='' found_required=0
-  local rc=0 i n base missing paths_filter required_paths='' glob_note=''
+  local rc=0 i n base missing paths_filter required_paths='' glob_note='' skip_when
   local names=() verdicts=()
 
   for file in "${FILES[@]}"; do
@@ -332,17 +334,22 @@ fm_lint_workflows_pr_gating() {
     return 1
   fi
   # A paths filter on any other workflow only makes that workflow conditional;
-  # on the required check it means a PR touching no matching file gets no run
-  # of it at all, which reads exactly like a passing required check.
+  # on the required check it leaves a PR with no run of it at all, which reads
+  # exactly like a passing required check. The two keys skip a run under
+  # opposite conditions, so each names its own.
   if [ -n "$required_paths" ]; then
+    case "$required_paths" in
+      paths-ignore) skip_when='a PR touching only files the filter ignores' ;;
+      *) skip_when='a PR touching no file the filter matches' ;;
+    esac
     if [ "$required_verdict" = all ]; then
-      printf 'fm-lint-workflows.sh: %s narrows its pull_request trigger with a %s filter, so on every PR base it gates a PR touching no matching file produces no run of the required check at all, which is indistinguishable from a passing one. Remove the %s filter from %s.\n' \
-        "$REQUIRED_CHECK_WORKFLOW" "$required_paths" "$required_paths" \
-        "$REQUIRED_CHECK_WORKFLOW" >&2
-    else
-      printf 'fm-lint-workflows.sh: %s narrows its pull_request trigger with a %s filter, so PR base(s)%s are only conditionally gated: a PR touching no matching file produces no run of the required check at all, which is indistinguishable from a passing one. Remove the %s filter from %s.\n' \
-        "$REQUIRED_CHECK_WORKFLOW" "$required_paths" "${required_verdict#bases}" \
+      printf 'fm-lint-workflows.sh: %s narrows its pull_request trigger with a %s filter, so on every PR base it gates, %s produces no run of the required check at all, which is indistinguishable from a passing one. Remove the %s filter from %s.\n' \
+        "$REQUIRED_CHECK_WORKFLOW" "$required_paths" "$skip_when" \
         "$required_paths" "$REQUIRED_CHECK_WORKFLOW" >&2
+    else
+      printf 'fm-lint-workflows.sh: %s narrows its pull_request trigger with a %s filter, so PR base(s)%s are only conditionally gated: %s produces no run of the required check at all, which is indistinguishable from a passing one. Remove the %s filter from %s.\n' \
+        "$REQUIRED_CHECK_WORKFLOW" "$required_paths" "${required_verdict#bases}" \
+        "$skip_when" "$required_paths" "$REQUIRED_CHECK_WORKFLOW" >&2
     fi
     return 1
   fi

--- a/bin/fm-lint-workflows.sh
+++ b/bin/fm-lint-workflows.sh
@@ -222,8 +222,12 @@ fm_lint_workflows_pr_gating() {
   local names=() verdicts=()
 
   for file in "${FILES[@]}"; do
-    verdict=$(fm_lint_workflows_pr_filter "$file")
     name=${file##*/}
+    verdict=$(fm_lint_workflows_pr_filter "$file") || {
+      printf 'fm-lint-workflows.sh: %s: could not be read for its pull_request base filter.\n' \
+        "$name" >&2
+      return 1
+    }
     case "$verdict" in
       "unsupported "*)
         printf 'fm-lint-workflows.sh: %s: cannot read the pull_request base filter (%s). Keep the on: block in block style with an explicit branches: list, or teach this gate the new form.\n' \

--- a/tests/fm-lint-workflows.test.sh
+++ b/tests/fm-lint-workflows.test.sh
@@ -704,6 +704,8 @@ test_required_check_with_paths_filter_fails() {
     "the failure did not name the filter that made the check conditional"
   assert_contains "$out" "main" \
     "the failure did not name the base left only conditionally gated"
+  assert_contains "$out" "touching no file the filter matches" \
+    "the failure did not state the condition under which paths skips the run"
   pass "a paths filter on the required check fails the lint"
 }
 
@@ -742,6 +744,71 @@ test_glob_base_in_required_check_fails_loudly() {
   assert_contains "$out" "main" \
     "the failure did not name the base it could not match"
   pass "a glob base in the required check fails loudly, not silently"
+}
+
+# `paths-ignore:` skips a run under the opposite condition to `paths:`, so the
+# diagnostic has to name its own condition rather than a shared one.
+test_required_check_with_paths_ignore_filter_fails() {
+  local tmp out rc
+  tmp=$(gating_root fm-lint-wf-gate-required-paths-ignore)
+  write_gating_workflow "$tmp/.github/workflows/ci.yml" CI \
+    'on:' '  pull_request:' '    branches: [main]'
+  write_gating_workflow "$tmp/.github/workflows/no-mistakes-required.yml" Require \
+    'on:' '  pull_request:' '    branches: [main]' '    paths-ignore: ["docs/**"]'
+  rc=0
+  out=$("$LINT_WF" --root "$tmp" 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "a paths-ignore-filtered required check unexpectedly passed"$'\n'"$out"
+  assert_contains "$out" "paths-ignore" \
+    "the failure did not name the filter that made the check conditional"
+  assert_contains "$out" "touching only files the filter ignores" \
+    "the failure did not state the condition under which paths-ignore skips the run"
+  case "$out" in
+    *"touching no file the filter matches"*)
+      fail "paths-ignore reported the inverted paths: skip condition"$'\n'"$out"
+      ;;
+  esac
+  pass "a paths-ignore filter on the required check names its own skip condition"
+}
+
+# An `on:` value spanning lines as a flow sequence is read one physical line at
+# a time, so guessing from the first line would report a workflow that gates
+# every PR base as having no pull_request trigger at all.
+test_multiline_flow_on_value_fails_closed() {
+  local tmp out rc
+  tmp=$(gating_root fm-lint-wf-gate-multiline-flow)
+  write_gating_workflow "$tmp/.github/workflows/ci.yml" CI \
+    'on: [push,' '  pull_request]'
+  write_gating_workflow "$tmp/.github/workflows/no-mistakes-required.yml" Require \
+    'on:' '  pull_request:' '    branches: [main]'
+  rc=0
+  out=$("$LINT_WF" --root "$tmp" 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "a multi-line flow on: value unexpectedly passed"$'\n'"$out"
+  assert_contains "$out" "multi-line flow sequence" \
+    "the refusal did not name the construct it cannot read"
+  assert_contains "$out" "ci.yml" \
+    "the refusal did not name the unreadable workflow"
+  pass "a multi-line flow on: value fails closed instead of reading as not PR-triggered"
+}
+
+# The refusal above must stay narrow: a flow sequence closed on its own line is
+# still classified, not swept up by the same check.
+test_single_line_flow_on_value_still_classifies() {
+  local tmp out rc
+  tmp=$(gating_root fm-lint-wf-gate-single-line-flow)
+  write_gating_workflow "$tmp/.github/workflows/ci.yml" CI 'on: [push, pull_request]'
+  write_gating_workflow "$tmp/.github/workflows/no-mistakes-required.yml" Require \
+    'on:' '  pull_request:' '    branches: [main]'
+  rc=0
+  out=$("$LINT_WF" --root "$tmp" 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "an unfiltered flow-sequence CI trigger unexpectedly passed"$'\n'"$out"
+  assert_contains "$out" "gates every PR base" \
+    "a single-line flow on: value was not classified as gating every PR base"
+  case "$out" in
+    *"cannot read the pull_request base filter"*)
+      fail "a single-line flow on: value was refused instead of classified"$'\n'"$out"
+      ;;
+  esac
+  pass "a single-line flow on: value still classifies as before"
 }
 
 test_explicit_path_skips_set_level_gating() {
@@ -788,4 +855,7 @@ test_missing_required_check_with_pr_workflow_fails
 test_required_check_with_paths_filter_fails
 test_paths_filter_on_other_workflow_passes
 test_glob_base_in_required_check_fails_loudly
+test_required_check_with_paths_ignore_filter_fails
+test_multiline_flow_on_value_fails_closed
+test_single_line_flow_on_value_still_classifies
 test_explicit_path_skips_set_level_gating

--- a/tests/fm-lint-workflows.test.sh
+++ b/tests/fm-lint-workflows.test.sh
@@ -729,7 +729,7 @@ test_paths_filter_on_other_workflow_passes() {
 }
 
 # Stated limitation, pinned as intentional: base names are compared literally,
-# so a glob in the required check fails loudly rather than passing silently.
+# so a filter pattern is refused by name rather than compared.
 test_glob_base_in_required_check_fails_loudly() {
   local tmp out rc
   tmp=$(gating_root fm-lint-wf-gate-glob)
@@ -742,8 +742,10 @@ test_glob_base_in_required_check_fails_loudly() {
   [ "$rc" -ne 0 ] || fail "a glob base in the required check unexpectedly passed"$'\n'"$out"
   assert_contains "$out" "compared literally" \
     "the failure did not disclose that base names are compared literally"
-  assert_contains "$out" "main" \
-    "the failure did not name the base it could not match"
+  assert_contains "$out" '"**"' \
+    "the failure did not name the pattern it refuses to judge"
+  assert_contains "$out" "no-mistakes-required.yml" \
+    "the failure did not name the workflow carrying the pattern"
   pass "a glob base in the required check fails loudly, not silently"
 }
 
@@ -1008,6 +1010,70 @@ test_empty_branches_list_refuses_by_name() {
   pass "an empty branches list is refused by name rather than banked as a verdict"
 }
 
+# Comparing patterns as strings cannot decide coverage: these two lists match
+# literally while the required check gates strictly fewer bases, so a PR into
+# `docs` would get CI and no required check. That set used to pass.
+test_negated_pattern_in_required_check_is_refused() {
+  local tmp out rc
+  tmp=$(gating_root fm-lint-wf-gate-negation)
+  write_gating_workflow "$tmp/.github/workflows/ci.yml" CI \
+    'on:' '  pull_request:' "    branches: ['**']"
+  write_gating_workflow "$tmp/.github/workflows/no-mistakes-required.yml" Require \
+    'on:' '  pull_request:' "    branches: ['**', '!docs']"
+  rc=0
+  out=$("$LINT_WF" --root "$tmp" 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "a negated pattern in the required check passed"$'\n'"$out"
+  assert_contains "$out" "compared literally" \
+    "the refusal did not disclose why a pattern cannot be judged"
+  case "$out" in
+    *"requires checks on"*)
+      fail "a negated pattern was reported as covered bases"$'\n'"$out"
+      ;;
+  esac
+  pass "a negated pattern in the required check is refused, not matched literally"
+}
+
+# The same refusal applies to the other side of the comparison, so a pattern
+# there cannot produce coverage advice that would be wrong.
+test_pattern_in_other_workflow_is_refused() {
+  local tmp out rc
+  tmp=$(gating_root fm-lint-wf-gate-pattern-other)
+  write_gating_workflow "$tmp/.github/workflows/ci.yml" CI \
+    'on:' '  pull_request:' '    branches:' '      - "releases/**"'
+  write_gating_workflow "$tmp/.github/workflows/no-mistakes-required.yml" Require \
+    'on:' '  pull_request:' '    branches: [main]'
+  rc=0
+  out=$("$LINT_WF" --root "$tmp" 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "a pattern base outside the required check passed"$'\n'"$out"
+  assert_contains "$out" "ci.yml" \
+    "the refusal did not name the workflow carrying the pattern"
+  assert_contains "$out" '"releases/**"' \
+    "the refusal did not name the block-sequence pattern entry"
+  case "$out" in
+    *"does not require"*)
+      fail "a pattern base was reported as an unrequired base"$'\n'"$out"
+      ;;
+  esac
+  pass "a pattern base outside the required check is refused, not miscompared"
+}
+
+# The refusal has to stay narrow: ordinary literal base names, including ones
+# carrying dashes and slashes, still classify and pass.
+test_literal_base_names_still_pass() {
+  local tmp out rc
+  tmp=$(gating_root fm-lint-wf-gate-literal-bases)
+  write_gating_workflow "$tmp/.github/workflows/ci.yml" CI \
+    'on:' '  pull_request:' '    branches: [main, feat/omp-adaptor]'
+  write_gating_workflow "$tmp/.github/workflows/no-mistakes-required.yml" Require \
+    'on:' '  pull_request:' '    branches:' '      - main' '      - feat/omp-adaptor'
+  rc=0
+  out=$("$LINT_WF" --root "$tmp" 2>&1) || rc=$?
+  [ "$rc" -eq 0 ] || fail "literal base names must still pass, got $rc"$'\n'"$out"
+  assert_contains "$out" "requires checks on: main feat/omp-adaptor" \
+    "the passing verdict did not list the literal bases"
+  pass "ordinary literal base names still classify and pass"
+}
+
 test_explicit_path_skips_set_level_gating() {
   local tmp out rc
   tmp=$(gating_root fm-lint-wf-gate-explicit)
@@ -1062,4 +1128,7 @@ test_required_check_pull_request_target_paths_fails
 test_both_gating_events_in_one_workflow_fails_closed
 test_event_note_names_the_file_it_describes
 test_empty_branches_list_refuses_by_name
+test_negated_pattern_in_required_check_is_refused
+test_pattern_in_other_workflow_is_refused
+test_literal_base_names_still_pass
 test_explicit_path_skips_set_level_gating

--- a/tests/fm-lint-workflows.test.sh
+++ b/tests/fm-lint-workflows.test.sh
@@ -952,6 +952,62 @@ test_event_note_names_the_file_it_describes() {
   pass "the default-branch note names the file whose event it describes"
 }
 
+# actionlint rejects every empty and null `branches:` spelling before the gating
+# check ever sees the file, so the gate's own handling of one is only reachable
+# with the linter stubbed to pass. It still has to be right: this is the one
+# refusal that reaches the caller through the banked verdict rather than being
+# emitted directly, and wrapping it in an event prefix once turned it into a
+# report of the bases the required check covers.
+fm_stub_actionlint_accepts_everything() {
+  local fakebin=$1
+  cat > "$fakebin/actionlint" <<SH
+#!/usr/bin/env bash
+if [ "\${1:-}" = "-version" ]; then
+  printf '%s\n' "$REQUIRED"
+  exit 0
+fi
+exit 0
+SH
+  chmod +x "$fakebin/actionlint"
+}
+
+test_empty_branches_list_refuses_by_name() {
+  local tmp fakebin out rc form
+  for form in flow null; do
+    tmp=$(gating_root "fm-lint-wf-gate-empty-$form")
+    fakebin=$(fm_fakebin "$tmp")
+    fm_stub_actionlint_accepts_everything "$fakebin"
+    # A required check that gates main would make this set pass, so the test can
+    # only stay green while the empty list is refused rather than read as a
+    # filter covering everything or covering nothing.
+    write_gating_workflow "$tmp/.github/workflows/ci.yml" CI \
+      'on:' '  pull_request:' '    branches: [main]'
+    if [ "$form" = flow ]; then
+      write_gating_workflow "$tmp/.github/workflows/no-mistakes-required.yml" Require \
+        'on:' '  pull_request:' '    branches: []'
+    else
+      write_gating_workflow "$tmp/.github/workflows/no-mistakes-required.yml" Require \
+        'on:' '  pull_request:' '    branches:' '    types: [opened]'
+    fi
+    rc=0
+    out=$(PATH="$fakebin:$PATH" "$LINT_WF" --root "$tmp" 2>&1) || rc=$?
+    [ "$rc" -ne 0 ] || fail "an empty branches list ($form form) exited 0"$'\n'"$out"
+    assert_contains "$out" "(empty branches list)" \
+      "the $form-form refusal did not reach the caller naming its own construct"
+    assert_contains "$out" "no-mistakes-required.yml" \
+      "the $form-form refusal did not name the workflow it cannot read"
+    case "$out" in
+      *"unrecognized classification"*)
+        fail "the $form-form refusal reached the caller in an unrecognized shape"$'\n'"$out"
+        ;;
+      *"requires checks on"*)
+        fail "an empty branches list ($form form) was reported as required bases"$'\n'"$out"
+        ;;
+    esac
+  done
+  pass "an empty branches list is refused by name rather than banked as a verdict"
+}
+
 test_explicit_path_skips_set_level_gating() {
   local tmp out rc
   tmp=$(gating_root fm-lint-wf-gate-explicit)
@@ -1005,4 +1061,5 @@ test_pull_request_target_scalar_trigger_is_gated
 test_required_check_pull_request_target_paths_fails
 test_both_gating_events_in_one_workflow_fails_closed
 test_event_note_names_the_file_it_describes
+test_empty_branches_list_refuses_by_name
 test_explicit_path_skips_set_level_gating

--- a/tests/fm-lint-workflows.test.sh
+++ b/tests/fm-lint-workflows.test.sh
@@ -710,8 +710,9 @@ test_required_check_with_paths_filter_fails() {
 }
 
 # The same filter elsewhere only makes that workflow conditional, which cannot
-# defeat the required check, so it must not fail the lint. The block-sequence
-# form doubles as coverage of the non-flow paths spelling.
+# defeat the required check, so it must not fail the lint. This proves the
+# scoping only; the block-sequence spelling is pinned where it changes the
+# verdict, in test_required_check_with_block_sequence_paths_fails.
 test_paths_filter_on_other_workflow_passes() {
   local tmp out rc
   tmp=$(gating_root fm-lint-wf-gate-other-paths)
@@ -811,6 +812,108 @@ test_single_line_flow_on_value_still_classifies() {
   pass "a single-line flow on: value still classifies as before"
 }
 
+# The paths detection is key-based, so the block-sequence spelling has to be
+# pinned where recognizing it is what produces the failure: on the required
+# check itself, with the dashes at the key's own indentation.
+test_required_check_with_block_sequence_paths_fails() {
+  local tmp out rc
+  tmp=$(gating_root fm-lint-wf-gate-required-block-paths)
+  write_gating_workflow "$tmp/.github/workflows/ci.yml" CI \
+    'on:' '  pull_request:' '    branches: [main]'
+  write_gating_workflow "$tmp/.github/workflows/no-mistakes-required.yml" Require \
+    'on:' '  pull_request:' '    branches: [main]' '    paths:' '    - "bin/**"'
+  rc=0
+  out=$("$LINT_WF" --root "$tmp" 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "a block-sequence paths filter on the required check passed"$'\n'"$out"
+  assert_contains "$out" "no-mistakes-required.yml" \
+    "the failure did not name the conditionally triggered required check"
+  assert_contains "$out" "paths" \
+    "the failure did not name the filter that made the check conditional"
+  assert_contains "$out" "main" \
+    "the failure did not name the base left only conditionally gated"
+  pass "a block-sequence paths filter on the required check fails the lint"
+}
+
+# `pull_request_target` filters the PR BASE branch exactly as `pull_request`
+# does, so a base it gates must be covered by the required check too. Reading
+# it as not PR-triggered would let that base merge with no required check.
+test_pull_request_target_base_is_gated() {
+  local tmp out rc
+  tmp=$(gating_root fm-lint-wf-gate-prt-base)
+  write_gating_workflow "$tmp/.github/workflows/ci.yml" CI \
+    'on:' '  pull_request_target:' '    branches: [main, feat/omp-adaptor]'
+  write_gating_workflow "$tmp/.github/workflows/no-mistakes-required.yml" Require \
+    'on:' '  pull_request:' '    branches: [main]'
+  rc=0
+  out=$("$LINT_WF" --root "$tmp" 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "a pull_request_target-gated base with no required check passed"$'\n'"$out"
+  assert_contains "$out" "feat/omp-adaptor" \
+    "the failure did not name the base gated without the required check"
+  assert_contains "$out" "pull_request_target" \
+    "the failure did not name the event that gates that base"
+  assert_contains "$out" "default branch" \
+    "the failure did not state how pull_request_target differs from pull_request"
+  pass "a pull_request_target base filter is held to the same gating rule"
+}
+
+# The scalar form of the same event must be read too, not only the mapping.
+test_pull_request_target_scalar_trigger_is_gated() {
+  local tmp out rc
+  tmp=$(gating_root fm-lint-wf-gate-prt-scalar)
+  write_gating_workflow "$tmp/.github/workflows/ci.yml" CI 'on: pull_request_target'
+  write_gating_workflow "$tmp/.github/workflows/no-mistakes-required.yml" Require \
+    'on:' '  pull_request:' '    branches: [main]'
+  rc=0
+  out=$("$LINT_WF" --root "$tmp" 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "an unfiltered pull_request_target trigger passed"$'\n'"$out"
+  assert_contains "$out" "gates every PR base" \
+    "a scalar pull_request_target value was not read as gating every PR base"
+  assert_contains "$out" "pull_request_target" \
+    "the failure did not name the event that gates every base"
+  pass "a scalar pull_request_target value is read as a base-gating trigger"
+}
+
+# A required check narrowed by paths is defeated the same way whichever
+# base-gating event it uses.
+test_required_check_pull_request_target_paths_fails() {
+  local tmp out rc
+  tmp=$(gating_root fm-lint-wf-gate-prt-paths)
+  write_gating_workflow "$tmp/.github/workflows/ci.yml" CI \
+    'on:' '  pull_request:' '    branches: [main]'
+  write_gating_workflow "$tmp/.github/workflows/no-mistakes-required.yml" Require \
+    'on:' '  pull_request_target:' '    branches: [main]' '    paths: ["bin/**"]'
+  rc=0
+  out=$("$LINT_WF" --root "$tmp" 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "a paths-filtered pull_request_target required check passed"$'\n'"$out"
+  assert_contains "$out" "pull_request_target" \
+    "the failure did not name the trigger it narrowed"
+  assert_contains "$out" "paths" \
+    "the failure did not name the filter that made the check conditional"
+  assert_contains "$out" "main" \
+    "the failure did not name the base left only conditionally gated"
+  pass "a paths filter on a pull_request_target required check fails the lint"
+}
+
+# Reading only the first of two base-gating events would under-report the bases
+# a file gates, so the gate refuses the combination rather than guessing.
+test_both_gating_events_in_one_workflow_fails_closed() {
+  local tmp out rc
+  tmp=$(gating_root fm-lint-wf-gate-both-events)
+  write_gating_workflow "$tmp/.github/workflows/ci.yml" CI \
+    'on:' '  pull_request:' '    branches: [main]' \
+    '  pull_request_target:' '    branches: [feat/omp-adaptor]'
+  write_gating_workflow "$tmp/.github/workflows/no-mistakes-required.yml" Require \
+    'on:' '  pull_request:' '    branches: [main, feat/omp-adaptor]'
+  rc=0
+  out=$("$LINT_WF" --root "$tmp" 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "a workflow using both gating events unexpectedly passed"$'\n'"$out"
+  assert_contains "$out" "both pull_request and pull_request_target" \
+    "the refusal did not name the combination it will not read"
+  assert_contains "$out" "ci.yml" \
+    "the refusal did not name the workflow it cannot read"
+  pass "a workflow declaring both base-gating events fails closed"
+}
+
 test_explicit_path_skips_set_level_gating() {
   local tmp out rc
   tmp=$(gating_root fm-lint-wf-gate-explicit)
@@ -858,4 +961,9 @@ test_glob_base_in_required_check_fails_loudly
 test_required_check_with_paths_ignore_filter_fails
 test_multiline_flow_on_value_fails_closed
 test_single_line_flow_on_value_still_classifies
+test_required_check_with_block_sequence_paths_fails
+test_pull_request_target_base_is_gated
+test_pull_request_target_scalar_trigger_is_gated
+test_required_check_pull_request_target_paths_fails
+test_both_gating_events_in_one_workflow_fails_closed
 test_explicit_path_skips_set_level_gating

--- a/tests/fm-lint-workflows.test.sh
+++ b/tests/fm-lint-workflows.test.sh
@@ -5,6 +5,9 @@
 # in the local/no-mistakes lint path before merge. Regression origin: #2512 put
 # a column-0 heredoc body inside a `run: |` block in ci.yml; there was no
 # workflow YAML lint, and the broken workflow could not report its own breakage.
+#
+# It also covers the PR base gating invariant that same owner checks on its
+# directory-scan path; the section comment above those cases owns the rule.
 set -u
 
 # shellcheck source=tests/lib.sh

--- a/tests/fm-lint-workflows.test.sh
+++ b/tests/fm-lint-workflows.test.sh
@@ -632,6 +632,59 @@ test_unreadable_base_filter_fails_closed() {
   pass "a base filter this gate cannot read fails closed"
 }
 
+# A block sequence may sit at column 0, where its dashes are items of `on:`
+# rather than the next top-level key. Misreading them reported a CI workflow
+# that gates every PR base as having no pull_request trigger at all.
+test_zero_indent_on_sequence_is_pr_triggered() {
+  local tmp out rc
+  tmp=$(gating_root fm-lint-wf-gate-flush-on)
+  write_gating_workflow "$tmp/.github/workflows/ci.yml" CI \
+    'on:' '- pull_request'
+  write_gating_workflow "$tmp/.github/workflows/no-mistakes-required.yml" Require \
+    'on:' '  pull_request:' '    branches: [main]'
+  rc=0
+  out=$("$LINT_WF" --root "$tmp" 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "a column-0 on: sequence gating every PR base passed"$'\n'"$out"
+  assert_contains "$out" "gates every PR base" \
+    "a column-0 on: sequence was not read as pull_request-triggered"
+  assert_contains "$out" "ci.yml" \
+    "the gating failure did not name the unfiltered workflow"
+  pass "an on: block sequence written at column 0 is read as PR-triggered"
+}
+
+# The same rule applies one level down: `branches:` followed by dashes at the
+# key own indent is a legal list, not an empty one.
+test_branches_sequence_at_key_indent_is_read() {
+  local tmp out rc
+  tmp=$(gating_root fm-lint-wf-gate-flush-branches)
+  write_gating_workflow "$tmp/.github/workflows/ci.yml" CI \
+    'on:' '  pull_request:' '    branches:' '    - main'
+  write_gating_workflow "$tmp/.github/workflows/no-mistakes-required.yml" Require \
+    'on:' '  pull_request:' '    branches:' '    - main' '    - feat/omp-adaptor'
+  rc=0
+  out=$("$LINT_WF" --root "$tmp" 2>&1) || rc=$?
+  [ "$rc" -eq 0 ] || fail "a branches list level with its key must classify, got $rc"$'\n'"$out"
+  assert_contains "$out" "requires checks on: main feat/omp-adaptor" \
+    "a branches list level with its key did not classify its bases"
+  pass "a branches list indented level with its key classifies its bases"
+}
+
+# Deleting the required check must not be indistinguishable from passing it.
+test_missing_required_check_with_pr_workflow_fails() {
+  local tmp out rc
+  tmp=$(gating_root fm-lint-wf-gate-absent-required)
+  write_gating_workflow "$tmp/.github/workflows/ci.yml" CI \
+    'on:' '  pull_request:' '    branches: [main, feat/omp-adaptor]'
+  rc=0
+  out=$("$LINT_WF" --root "$tmp" 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "a PR-gating set with no required check unexpectedly passed"$'\n'"$out"
+  assert_contains "$out" "no-mistakes-required.yml" \
+    "the failure did not name the missing required check"
+  assert_contains "$out" "ci.yml" \
+    "the failure did not name the workflow whose PR bases are unrequired"
+  pass "a PR-triggered workflow set with no required check fails the lint"
+}
+
 test_explicit_path_skips_set_level_gating() {
   local tmp out rc
   tmp=$(gating_root fm-lint-wf-gate-explicit)
@@ -670,4 +723,7 @@ test_required_superset_of_gated_bases_passes
 test_unfiltered_pr_workflow_fails
 test_required_check_without_pr_trigger_fails
 test_unreadable_base_filter_fails_closed
+test_zero_indent_on_sequence_is_pr_triggered
+test_branches_sequence_at_key_indent_is_read
+test_missing_required_check_with_pr_workflow_fails
 test_explicit_path_skips_set_level_gating

--- a/tests/fm-lint-workflows.test.sh
+++ b/tests/fm-lint-workflows.test.sh
@@ -914,6 +914,44 @@ test_both_gating_events_in_one_workflow_fails_closed() {
   pass "a workflow declaring both base-gating events fails closed"
 }
 
+# A finding names two files whose events can differ, and the default-branch
+# caveat belongs to whichever of them the event actually applies to.
+test_event_note_names_the_file_it_describes() {
+  local tmp out rc
+  tmp=$(gating_root fm-lint-wf-gate-note-offender)
+  write_gating_workflow "$tmp/.github/workflows/ci.yml" CI \
+    'on:' '  pull_request_target:' '    branches: [main, feat/omp-adaptor]'
+  write_gating_workflow "$tmp/.github/workflows/no-mistakes-required.yml" Require \
+    'on:' '  pull_request:' '    branches: [main]'
+  rc=0
+  out=$("$LINT_WF" --root "$tmp" 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "a pull_request_target-gated base with no required check passed"$'\n'"$out"
+  assert_contains "$out" "ci.yml is triggered by pull_request_target" \
+    "the note did not attribute pull_request_target to the workflow that uses it"
+  case "$out" in
+    *"no-mistakes-required.yml is triggered by pull_request_target"*)
+      fail "the note credited the required check with an event it does not use"$'\n'"$out"
+      ;;
+  esac
+
+  tmp=$(gating_root fm-lint-wf-gate-note-required)
+  write_gating_workflow "$tmp/.github/workflows/ci.yml" CI \
+    'on:' '  pull_request:' '    branches: [main, feat/omp-adaptor]'
+  write_gating_workflow "$tmp/.github/workflows/no-mistakes-required.yml" Require \
+    'on:' '  pull_request_target:' '    branches: [main]'
+  rc=0
+  out=$("$LINT_WF" --root "$tmp" 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "a base gated beyond a pull_request_target required check passed"$'\n'"$out"
+  assert_contains "$out" "no-mistakes-required.yml is triggered by pull_request_target" \
+    "the note did not warn that the recommended edit lands on the default branch"
+  case "$out" in
+    *"ci.yml is triggered by pull_request_target"*)
+      fail "the note credited the offending workflow with an event it does not use"$'\n'"$out"
+      ;;
+  esac
+  pass "the default-branch note names the file whose event it describes"
+}
+
 test_explicit_path_skips_set_level_gating() {
   local tmp out rc
   tmp=$(gating_root fm-lint-wf-gate-explicit)
@@ -966,4 +1004,5 @@ test_pull_request_target_base_is_gated
 test_pull_request_target_scalar_trigger_is_gated
 test_required_check_pull_request_target_paths_fails
 test_both_gating_events_in_one_workflow_fails_closed
+test_event_note_names_the_file_it_describes
 test_explicit_path_skips_set_level_gating

--- a/tests/fm-lint-workflows.test.sh
+++ b/tests/fm-lint-workflows.test.sh
@@ -685,6 +685,65 @@ test_missing_required_check_with_pr_workflow_fails() {
   pass "a PR-triggered workflow set with no required check fails the lint"
 }
 
+# A `paths:` filter makes a trigger conditional on which files a PR touches, so
+# a required check carrying one produces no run at all for a PR that touches no
+# matching file - zero checks, which reads exactly like a passing one.
+test_required_check_with_paths_filter_fails() {
+  local tmp out rc
+  tmp=$(gating_root fm-lint-wf-gate-required-paths)
+  write_gating_workflow "$tmp/.github/workflows/ci.yml" CI \
+    'on:' '  pull_request:' '    branches: [main]'
+  write_gating_workflow "$tmp/.github/workflows/no-mistakes-required.yml" Require \
+    'on:' '  pull_request:' '    branches: [main]' '    paths: ["bin/**"]'
+  rc=0
+  out=$("$LINT_WF" --root "$tmp" 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "a paths-filtered required check unexpectedly passed"$'\n'"$out"
+  assert_contains "$out" "no-mistakes-required.yml" \
+    "the failure did not name the conditionally triggered required check"
+  assert_contains "$out" "paths" \
+    "the failure did not name the filter that made the check conditional"
+  assert_contains "$out" "main" \
+    "the failure did not name the base left only conditionally gated"
+  pass "a paths filter on the required check fails the lint"
+}
+
+# The same filter elsewhere only makes that workflow conditional, which cannot
+# defeat the required check, so it must not fail the lint. The block-sequence
+# form doubles as coverage of the non-flow paths spelling.
+test_paths_filter_on_other_workflow_passes() {
+  local tmp out rc
+  tmp=$(gating_root fm-lint-wf-gate-other-paths)
+  write_gating_workflow "$tmp/.github/workflows/ci.yml" CI \
+    'on:' '  pull_request:' '    paths:' '    - "bin/**"' '    branches: [main]'
+  write_gating_workflow "$tmp/.github/workflows/no-mistakes-required.yml" Require \
+    'on:' '  pull_request:' '    branches: [main]'
+  rc=0
+  out=$("$LINT_WF" --root "$tmp" 2>&1) || rc=$?
+  [ "$rc" -eq 0 ] || fail "a paths filter outside the required check must pass, got $rc"$'\n'"$out"
+  assert_contains "$out" "requires checks on: main" \
+    "the passing verdict did not read the paths-filtered workflow base list"
+  pass "a paths filter on a workflow other than the required check passes"
+}
+
+# Stated limitation, pinned as intentional: base names are compared literally,
+# so a glob in the required check fails loudly rather than passing silently.
+test_glob_base_in_required_check_fails_loudly() {
+  local tmp out rc
+  tmp=$(gating_root fm-lint-wf-gate-glob)
+  write_gating_workflow "$tmp/.github/workflows/ci.yml" CI \
+    'on:' '  pull_request:' '    branches: [main]'
+  write_gating_workflow "$tmp/.github/workflows/no-mistakes-required.yml" Require \
+    'on:' '  pull_request:' '    branches: ["**"]'
+  rc=0
+  out=$("$LINT_WF" --root "$tmp" 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "a glob base in the required check unexpectedly passed"$'\n'"$out"
+  assert_contains "$out" "compared literally" \
+    "the failure did not disclose that base names are compared literally"
+  assert_contains "$out" "main" \
+    "the failure did not name the base it could not match"
+  pass "a glob base in the required check fails loudly, not silently"
+}
+
 test_explicit_path_skips_set_level_gating() {
   local tmp out rc
   tmp=$(gating_root fm-lint-wf-gate-explicit)
@@ -726,4 +785,7 @@ test_unreadable_base_filter_fails_closed
 test_zero_indent_on_sequence_is_pr_triggered
 test_branches_sequence_at_key_indent_is_read
 test_missing_required_check_with_pr_workflow_fails
+test_required_check_with_paths_filter_fails
+test_paths_filter_on_other_workflow_passes
+test_glob_base_in_required_check_fails_loudly
 test_explicit_path_skips_set_level_gating

--- a/tests/fm-lint-workflows.test.sh
+++ b/tests/fm-lint-workflows.test.sh
@@ -514,6 +514,140 @@ SH
   pass "fm-lint.sh default path catches a self-broken ci.yml"
 }
 
+# PR base gating. `pull_request.branches` matches the PR BASE branch, so a base
+# absent from every filter gets no checks at all, and an absent required check
+# reads exactly like a passing one in the pull request UI. The gate pins the
+# superset rule: no base may be gated by CI without also being required.
+
+# Fixtures vary only the `on:` block; the job body exists so actionlint accepts
+# the file. Pass the `on:` block as one argument per line.
+write_gating_workflow() {
+  local path=$1 workflow_name=$2
+  shift 2
+  {
+    printf 'name: %s\n' "$workflow_name"
+    printf '%s\n' "$@"
+    cat <<'YAML'
+jobs:
+  x:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+YAML
+  } > "$path"
+}
+
+gating_root() {
+  local tmp
+  tmp=$(fm_test_tmproot "$1")
+  mkdir -p "$tmp/.github/workflows"
+  printf '%s\n' "$tmp"
+}
+
+test_current_workflows_gate_the_adapter_branch() {
+  local out rc
+  rc=0
+  out=$("$LINT_WF" 2>&1) || rc=$?
+  [ "$rc" -eq 0 ] || fail "current workflows failed the gating check, got $rc"$'\n'"$out"
+  assert_contains "$out" "PR base gating: no-mistakes-required.yml requires checks on:" \
+    "current workflows did not report which PR bases the required check covers"
+  assert_contains "$out" "main" \
+    "the required check does not cover the default branch"
+  assert_contains "$out" "feat/omp-adaptor" \
+    "the required check does not cover the long-lived adapter branch"
+  pass "current workflows require checks on every gated PR base"
+}
+
+test_base_gated_without_required_check_fails() {
+  local tmp out rc
+  tmp=$(gating_root fm-lint-wf-gate-missing)
+  write_gating_workflow "$tmp/.github/workflows/ci.yml" CI \
+    'on:' '  pull_request:' '    branches: [main, feat/omp-adaptor]'
+  write_gating_workflow "$tmp/.github/workflows/no-mistakes-required.yml" Require \
+    'on:' '  pull_request:' '    types: [opened]' '    branches:' '      - main'
+  rc=0
+  out=$("$LINT_WF" --root "$tmp" 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "a base gated by CI but not required unexpectedly passed"$'\n'"$out"
+  assert_contains "$out" "feat/omp-adaptor" \
+    "the gating failure did not name the unrequired base"
+  assert_contains "$out" "no-mistakes-required.yml" \
+    "the gating failure did not name the required check to fix"
+  pass "a PR base gated by CI but not by the required check fails the lint"
+}
+
+test_required_superset_of_gated_bases_passes() {
+  local tmp out rc
+  tmp=$(gating_root fm-lint-wf-gate-superset)
+  write_gating_workflow "$tmp/.github/workflows/ci.yml" CI \
+    'on:' '  push:' '    branches: [main]' '  pull_request:' '    branches: [main]'
+  write_gating_workflow "$tmp/.github/workflows/no-mistakes-required.yml" Require \
+    'on:' '  pull_request:' '    branches:' '      - main' '      - feat/omp-adaptor'
+  rc=0
+  out=$("$LINT_WF" --root "$tmp" 2>&1) || rc=$?
+  [ "$rc" -eq 0 ] || fail "a required check wider than CI must pass, got $rc"$'\n'"$out"
+  assert_contains "$out" "requires checks on: main feat/omp-adaptor" \
+    "the passing verdict did not list the required bases"
+  pass "a required check wider than the CI filter passes"
+}
+
+test_unfiltered_pr_workflow_fails() {
+  local tmp out rc
+  tmp=$(gating_root fm-lint-wf-gate-unfiltered)
+  write_gating_workflow "$tmp/.github/workflows/ci.yml" CI 'on: pull_request'
+  write_gating_workflow "$tmp/.github/workflows/no-mistakes-required.yml" Require \
+    'on:' '  pull_request:' '    branches: [main]'
+  rc=0
+  out=$("$LINT_WF" --root "$tmp" 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "CI on every base with a narrower required check passed"$'\n'"$out"
+  assert_contains "$out" "gates every PR base" \
+    "the gating failure did not report the unfiltered CI trigger"
+  pass "an unfiltered CI trigger with a narrower required check fails the lint"
+}
+
+test_required_check_without_pr_trigger_fails() {
+  local tmp out rc
+  tmp=$(gating_root fm-lint-wf-gate-nopr)
+  write_gating_workflow "$tmp/.github/workflows/ci.yml" CI \
+    'on:' '  pull_request:' '    branches: [main]'
+  write_gating_workflow "$tmp/.github/workflows/no-mistakes-required.yml" Require \
+    'on:' '  push:' '    branches: [main]'
+  rc=0
+  out=$("$LINT_WF" --root "$tmp" 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "a required check with no pull_request trigger passed"$'\n'"$out"
+  assert_contains "$out" "no pull_request trigger" \
+    "the failure did not report that the required check can never run"
+  pass "a required check with no pull_request trigger fails the lint"
+}
+
+test_unreadable_base_filter_fails_closed() {
+  local tmp out rc
+  tmp=$(gating_root fm-lint-wf-gate-ignore)
+  write_gating_workflow "$tmp/.github/workflows/no-mistakes-required.yml" Require \
+    'on:' '  pull_request:' '    branches-ignore: [docs]'
+  rc=0
+  out=$("$LINT_WF" --root "$tmp" 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "an unreadable base filter unexpectedly passed"$'\n'"$out"
+  assert_contains "$out" "branches-ignore" \
+    "the refusal did not name the construct it cannot read"
+  pass "a base filter this gate cannot read fails closed"
+}
+
+test_explicit_path_skips_set_level_gating() {
+  local tmp out rc
+  tmp=$(gating_root fm-lint-wf-gate-explicit)
+  write_gating_workflow "$tmp/.github/workflows/ci.yml" CI \
+    'on:' '  pull_request:' '    branches: [main, feat/omp-adaptor]'
+  rc=0
+  out=$("$LINT_WF" "$tmp/.github/workflows/ci.yml" 2>&1) || rc=$?
+  [ "$rc" -eq 0 ] || fail "explicit-path lint of a valid workflow failed, got $rc"$'\n'"$out"
+  case "$out" in
+    *"PR base gating"*)
+      fail "explicit-path mode ran the set-level gating check"$'\n'"$out"
+      ;;
+  esac
+  pass "explicit-path mode lints one file without the set-level gating check"
+}
+
 test_pins_an_explicit_version
 test_current_workflows_pass
 test_col0_heredoc_fails_with_clear_error
@@ -530,3 +664,10 @@ test_installer_falls_back_to_shasum
 test_installer_prefers_sha256sum_over_shasum
 test_installer_rejects_unsupported_platform
 test_fm_lint_default_path_catches_broken_ci_yml
+test_current_workflows_gate_the_adapter_branch
+test_base_gated_without_required_check_fails
+test_required_superset_of_gated_bases_passes
+test_unfiltered_pr_workflow_fails
+test_required_check_without_pr_trigger_fails
+test_unreadable_base_filter_fails_closed
+test_explicit_path_skips_set_level_gating


### PR DESCRIPTION
## Intent

Close firstmate's own absent-CI-gate defect: pull requests into `feat/omp-adaptor` were getting zero checks, because `.github/workflows/ci.yml` and `.github/workflows/no-mistakes-required.yml` both filtered `pull_request` to `branches: [main]`. That filter matches the PR's BASE branch, so every PR into `feat/omp-adaptor` could merge with no checks at all, and an absent required check is indistinguishable from a passing one in the pull request UI. `feat/omp-adaptor` is this home's deliberate working branch by captain decision, so it is where firstmate's own changes land.

The mechanism was settled with evidence before this task and was to be cited rather than re-derived (it was re-confirmed, not re-litigated): `pull_request.branches` compares the base branch NAME, but the workflow FILE GitHub reads is the PR's MERGE COMMIT, not the base tip. GitHub documents this only by contrast, in the `pull_request_target` section of "Events that trigger workflows": that event runs "in the context of the default branch of the base repository, rather than in the context of the merge commit, as the `pull_request` event does." Two consequences decided where the change had to land: a PR that ADDS a base to a filter gates itself, and the entry must exist ON the integration branch to gate anything else opened against it. This was proven in crons PR 675 and applied again in krew-fastapi PR 1294.

Required work, all of which is in this branch:
1. Add `feat/omp-adaptor` to the `pull_request` base filter of `ci.yml` and `no-mistakes-required.yml`.
2. Audit EVERY other workflow in `.github/workflows/` the same way and report the full picture, stating which lines were read per file - not fix two and leave a third silently ungated. The audit is recorded in the first commit message: ci.yml (on: block lines 1-7 before, 1-12 after), no-mistakes-required.yml (1-8 before, 1-15 after), windows-herdr-spike.yml (1-4 before, 1-8 after; `workflow_dispatch` only, no PR trigger, so nothing was ungated there). Each file's whole `on:` block was read in full rather than through a windowed grep, because a truncated `grep -A8` had previously produced two false findings.
3. Add or extend a comment on each `on:` block recording the base-branch rule, so the next long-lived branch gets added the day it is created.
4. Consider whether a guard test can pin this invariant; crons pins a SUPERSET rule (every base gated by any PR workflow must also be in the required check's list). Add one if firstmate has a natural home for it, or say why rather than inventing an awkward one.
5. Do NOT narrow any existing trigger, add `paths` filters, or remove entries: dropping an entry is the one edit direction that can lose signal. Nothing was narrowed, no `paths` filter was added, and no entry was removed.

The separately filed `fm-adapter-ci-gap` item describes the same defect as a "decide whether the adapter line should run CI at all" question. The captain's use of this branch as the working line answers it: it should. This change supersedes that item so firstmate can close it, and the PR should say so.

Deliberate decisions and tradeoffs made while doing the work, which a reviewer reading only the diff would not know:
- The invariant went into `bin/fm-lint-workflows.sh`, the existing workflow-lint owner that both CI and the no-mistakes pre-push gate already run, rather than a new script (which would split the workflow-lint contract) or a test that asserts workflow YAML contents directly. firstmate's coding guidelines require tests to exercise behavior through an executable or public interface and never to assert implementation-source bytes, so the checker is the executable and the seven new regressions in `tests/fm-lint-workflows.test.sh` drive it through `--root` fixtures. Extending that existing suite was chosen over inventing a new runner, per the same guidelines.
- The classifier is awk, deliberately adding no new interpreter dependency to a core gate. Ruby's stdlib YAML (already used by one existing test) and PyYAML were both rejected for this path because the lint runs on every pre-push and Apple's bundled ruby is on a deprecation path; a broken core gate is a worse failure than a narrower parser. The parser therefore fails closed, naming the construct, on any form it cannot read confidently - flow-mapping `on:`, `branches-ignore`, a scalar `branches` value, a multi-line flow sequence - instead of silently passing. It does handle the forms actually in use: block mappings, flow sequences, scalar `on:`, and block sequences.
- The rule pinned is the superset one (every base gated by any PR-triggered workflow must also be gated by `no-mistakes-required.yml`), not symmetry, so a future legitimately main-only heavy workflow is still allowed. The absolute question of which long-lived branches deserve gating is not statically knowable, which is exactly why the `on:` block comments carry that reminder.
- The check runs only on the directory-scan path, because the invariant is a property of the whole workflow set; explicit-path mode stays a single-file lint, matching how explicit paths already bypass file-set selection.
- `feat/omp-adaptor` was deliberately NOT added to `ci.yml`'s `push:` filter. That is a different gap from the one in scope, and the PR run already tests the merge result, so the marginal value did not justify unrequested scope in core CI config.
- The rule was deliberately NOT added to `AGENTS.md`. Under the knowledge-placement decision tree in `firstmate-coding-guidelines`, exact mechanics belong in the script header plus `--help` (both updated), and the situational reminder belongs at the risk point in each `on:` block. One contributor-facing sentence went into `CONTRIBUTING.md`'s existing lint paragraph, which is that surface's established owner, patching its language rather than adding a second copy of the contract.
- No `docs/verification/` record was added: the guarantee is pinned by a portable regression that CI runs, and that test is itself the reusable verification, so a dated maintainer record would only duplicate it.

Evidence gathered while verifying the premise, which strengthened it: the defect had already caused real ungated merges. The two most recent pull requests merged into `Boxyboxy:feat/omp-adaptor` had zero check runs (head 9823c987, merged 2026-08-22, and head cc5cf844, merged 2026-08-21; both `total_count: 0`). One detail in the original task description was stale and was reported rather than quietly worked around: no PR is currently in flight against that branch, so the urgency is retrospective rather than prospective.

Two limitations were reported to the captain rather than silently fixed, and remain intentionally out of this diff: `feat/omp-adaptor` exists only on the fork `Boxyboxy/firstmate`, not on `origin`, so this change gates PRs into that branch only once it reaches it through the routine main-into-adapter merge; and nothing at the forge currently requires these checks (origin's single ruleset targets `~DEFAULT_BRANCH` with no `required_status_checks` rule, and the fork has no rulesets and no protection on the adapter branch), which is a repository-settings decision belonging to the captain.

Repo conventions that constrain the diff: one full sentence per line in tracked Markdown, plain dashes rather than em dashes, no agent name as a commit co-author, and `bin/*.sh` must pass `shellcheck` and parse under stock macOS bash 3.2.

## What Changed

- Added `feat/omp-adaptor` to the `pull_request` base filters in `.github/workflows/ci.yml` and `.github/workflows/no-mistakes-required.yml`, so PRs into that long-lived branch get checks instead of merging with none. `pull_request.branches` matches the PR's base branch, and an absent required check is indistinguishable from a passing one in the PR UI. Every workflow in `.github/workflows/` was audited the same way; `windows-herdr-spike.yml` is `workflow_dispatch` only, so nothing was ungated there. Each `on:` block now carries a comment recording the base-branch rule, and no trigger was narrowed, no `paths` filter added, and no entry removed.
- Extended `bin/fm-lint-workflows.sh` (the existing workflow-lint owner that both CI and the no-mistakes pre-push gate already run) with an awk classifier of each workflow's `on:` block, enforced on the directory-scan path only: every PR base gated by any `pull_request` or `pull_request_target` workflow must also be gated by `no-mistakes-required.yml`. It also fails when the required check is missing, has no PR trigger, or is narrowed by `paths:`/`paths-ignore:`, and refuses by name any construct it cannot read confidently - flow-mapping `on:`, `branches-ignore`, scalar `branches`, multi-line flow sequences, duplicate or mixed gating events, and filter patterns in a `branches` list - rather than guessing at coverage. The script header and `--help` output document the rule.
- Added 26 regression cases to `tests/fm-lint-workflows.test.sh` driving the checker through `--root` fixtures, and updated `CONTRIBUTING.md`'s existing lint paragraph to point at the required check's base list rather than naming `main` alone.

This supersedes the separately filed `fm-adapter-ci-gap` item, which framed the same defect as an open question about whether the adapter line should run CI; the captain's use of the branch as the working line answers that it should, so that item can be closed.

Two limitations are intentionally out of this diff and belong to repository settings: `feat/omp-adaptor` exists only on the fork `Boxyboxy/firstmate`, so this gates PRs into it once the change reaches that branch through the routine main-into-adapter merge, and nothing at the forge currently *requires* these checks (origin's only ruleset targets `~DEFAULT_BRANCH` with no `required_status_checks` rule).

## Risk Assessment

✅ Low: The change is additive lint tooling plus two one-line workflow base-filter edits that are exactly what the intent requires; the gate fails closed on every form it cannot read, I found no input that produces a silent wrong pass, and the only surviving finding is a scoping imprecision in an explanatory comment.

## Testing

I installed the pinned actionlint into a temp dir, then exercised the change through its actual executable surface rather than only its unit tests: the real-repo lint now names both gated bases, the base-commit workflow set reports the adapter branch ungated, and a half-fixed set (adapter base added to ci.yml only) fails the new invariant with a clear message and exit 1, which is the fail-before/pass-after proof for the guard. A real YAML parse of all three workflows records the audit item 2 asked for, and live GitHub API queries show the defect had already caused three ungated merges into feat/omp-adaptor (0 check runs each) against 14-15 on main-based PRs. The full tests/fm-lint-workflows.test.sh (42 assertions incl. 7 new gating regressions) and the adjacent tests/fm-lint.test.sh both pass under stock macOS bash 3.2. No screenshot applies: this change is CI configuration plus a shell gate, whose end-user surfaces are the CLI transcript and the GitHub checks list, both captured as artifacts. The one unreachable piece is a live check run on a PR into feat/omp-adaptor, since that branch exists only on the fork and no PR is in flight - already recorded in the intent as a captain-owned limitation. Temp fixtures and the temp actionlint install were removed and the worktree is clean.

<details>
<summary>Evidence: Lint before/half-fix/after: the guard catching the exact defect shape</summary>

Source: [Lint before/half-fix/after: the guard catching the exact defect shape](https://github.com/Boxyboxy/firstmate/blob/c6f53d49ce73ae2de5c75c3704370d565b3dc577/.no-mistakes/evidence/fm/fm-ci-absent-on-adapter-branch/gating-before-after.txt)

<code>$ bin/fm-lint-workflows.sh --root &lt;base commit 1231b6ae workflow set&gt;&#10;fm-lint-workflows.sh: PR base gating: no-mistakes-required.yml requires checks on: main&#10;exit=0&#10;&#10;$ bin/fm-lint-workflows.sh --root &lt;this branch, but adapter base added to ci.yml only&gt;&#10;fm-lint-workflows.sh: ci.yml gates PR base(s) feat/omp-adaptor through its pull_request trigger that no-mistakes-required.yml does not require, so a PR into them can merge with the required check absent. Add them to no-mistakes-required.yml.&#10;exit=1&#10;&#10;$ bin/fm-lint-workflows.sh (this branch, real repo)&#10;fm-lint-workflows.sh: PR base gating: no-mistakes-required.yml requires checks on: main feat/omp-adaptor&#10;exit=0</code>

```text
$ bin/fm-lint-workflows.sh --root <base commit 1231b6ae workflow set>
fm-lint-workflows.sh: actionlint 1.7.12 (pinned 1.7.12)
fm-lint-workflows.sh: 3 workflow files valid
fm-lint-workflows.sh: PR base gating: no-mistakes-required.yml requires checks on: main
exit=0

$ bin/fm-lint-workflows.sh --root <this branch, but adapter base added to ci.yml only>
fm-lint-workflows.sh: actionlint 1.7.12 (pinned 1.7.12)
fm-lint-workflows.sh: 3 workflow files valid
fm-lint-workflows.sh: ci.yml gates PR base(s) feat/omp-adaptor through its pull_request trigger that no-mistakes-required.yml does not require, so a PR into them can merge with the required check absent. Add them to no-mistakes-required.yml.
exit=1

$ bin/fm-lint-workflows.sh   (this branch, real repo)
fm-lint-workflows.sh: actionlint 1.7.12 (pinned 1.7.12)
fm-lint-workflows.sh: 3 workflow files valid
fm-lint-workflows.sh: PR base gating: no-mistakes-required.yml requires checks on: main feat/omp-adaptor
exit=0
```
</details>
<details>
<summary>Evidence: Real-world impact: PRs merged into feat/omp-adaptor had zero checks</summary>

Source: [Real-world impact: PRs merged into feat/omp-adaptor had zero checks](https://github.com/Boxyboxy/firstmate/blob/c6f53d49ce73ae2de5c75c3704370d565b3dc577/.no-mistakes/evidence/fm/fm-ci-absent-on-adapter-branch/adapter-branch-zero-checks.txt)

<code>Real-world impact of the defect: check runs on pull requests merged into Boxyboxy:feat/omp-adaptor&#10;(queried live with: gh api repos/Boxyboxy/firstmate/commits/&lt;head-sha&gt;/check-runs)&#10;&#10;PR #11 head 9823c987 check runs: 0&#10;PR #10 head cc5cf844 check runs: 0&#10;PR #9 head ec08bc43 check runs: 0&#10;&#10;Contrast - pull requests whose BASE is main, the one branch the old filter listed&#10;(Boxyboxy/firstmate has no PRs based on main; these are the upstream kunchenguid/firstmate ones):&#10;upstream PR #2811 head 77e36fd7 check runs: 14&#10;upstream PR #2810 head 20a480f8 check runs: 14&#10;upstream PR #2795 head efea26ef check runs: 15</code>

```text
Real-world impact of the defect: check runs on pull requests merged into Boxyboxy:feat/omp-adaptor
(queried live with: gh api repos/Boxyboxy/firstmate/commits/<head-sha>/check-runs)

PR #11  head 9823c987  check runs: 0
PR #10  head cc5cf844  check runs: 0
PR #9  head ec08bc43  check runs: 0

Contrast - pull requests whose BASE is main, the one branch the old filter listed
(Boxyboxy/firstmate has no PRs based on main; these are the upstream kunchenguid/firstmate ones):
upstream PR #2811  head 77e36fd7  check runs: 14
upstream PR #2810  head 20a480f8  check runs: 14
upstream PR #2795  head efea26ef  check runs: 15
```
</details>
<details>
<summary>Evidence: Whole-workflow-set audit: PR trigger model as GitHub reads it</summary>

Source: [Whole-workflow-set audit: PR trigger model as GitHub reads it](https://github.com/Boxyboxy/firstmate/blob/c6f53d49ce73ae2de5c75c3704370d565b3dc577/.no-mistakes/evidence/fm/fm-ci-absent-on-adapter-branch/workflow-trigger-model.txt)

<code>ci.yml&#10;triggers: [&#34;pull_request&#34;, &#34;push&#34;]&#10;pull_request.branches (matches the PR BASE branch): [&#34;main&#34;, &#34;feat/omp-adaptor&#34;]&#10;gates a PR whose base is feat/omp-adaptor: true&#10;&#10;no-mistakes-required.yml&#10;triggers: [&#34;pull_request&#34;]&#10;pull_request.branches (matches the PR BASE branch): [&#34;main&#34;, &#34;feat/omp-adaptor&#34;]&#10;gates a PR whose base is feat/omp-adaptor: true&#10;&#10;windows-herdr-spike.yml&#10;triggers: [&#34;workflow_dispatch&#34;]&#10;no pull_request trigger - no base filter to maintain here</code>

```text
Parsed .github/workflows/*.yml with a real YAML parser (Ruby Psych).
Shown below: the PR trigger model GitHub evaluates, per file.

ci.yml
  triggers: ["pull_request", "push"]
  pull_request.branches (matches the PR BASE branch): ["main", "feat/omp-adaptor"]
  gates a PR whose base is feat/omp-adaptor: true
  gates a PR whose base is main: true

no-mistakes-required.yml
  triggers: ["pull_request"]
  pull_request.branches (matches the PR BASE branch): ["main", "feat/omp-adaptor"]
  gates a PR whose base is feat/omp-adaptor: true
  gates a PR whose base is main: true

windows-herdr-spike.yml
  triggers: ["workflow_dispatch"]
  no pull_request trigger - no base filter to maintain here
```
</details>
<details>
<summary>Evidence: Real-repo lint run</summary>

Source: [Real-repo lint run](https://github.com/Boxyboxy/firstmate/blob/c6f53d49ce73ae2de5c75c3704370d565b3dc577/.no-mistakes/evidence/fm/fm-ci-absent-on-adapter-branch/lint-real-repo.txt)

```text
fm-lint-workflows.sh: actionlint 1.7.12 (pinned 1.7.12)
fm-lint-workflows.sh: 3 workflow files valid
fm-lint-workflows.sh: PR base gating: no-mistakes-required.yml requires checks on: main feat/omp-adaptor
exit=0
```
</details>
<details>
<summary>Evidence: fm-lint-workflows.sh --help documenting the gating rule</summary>

Source: [fm-lint-workflows.sh --help documenting the gating rule](https://github.com/Boxyboxy/firstmate/blob/c6f53d49ce73ae2de5c75c3704370d565b3dc577/.no-mistakes/evidence/fm/fm-ci-absent-on-adapter-branch/lint-help.txt)

```text
fm-lint-workflows.sh - owner of firstmate's GitHub workflow lint.

Runs pinned actionlint on every .github/workflows/*.{yml,yaml} so a malformed
workflow, including a self-broken ci.yml, fails in the local and no-mistakes
lint lane before merge. A broken ci.yml cannot report its own breakage, so
this check must not live only as a step inside that workflow. bin/fm-lint.sh
invokes this owner on its default (no explicit-path) path, which CI and
commands.lint both use.

The directory-scan path then checks one gating invariant across the scanned
set: every PR base gated by any pull_request or pull_request_target workflow
must also be gated by no-mistakes-required.yml, so a base can never get CI
without the check branch protection requires. A required check narrowed by a
paths: or paths-ignore: filter fails too, because it then stops gating every
base it lists. Any on: form this gate cannot read confidently is refused by
name rather than guessed at. See the comment above REQUIRED_CHECK_WORKFLOW
for why that is worth enforcing mechanically.

Usage:
  fm-lint-workflows.sh                 lint workflows under this repo
  fm-lint-workflows.sh --root <dir>    lint workflows under <dir>
  fm-lint-workflows.sh <path>...       lint explicit workflow files
  fm-lint-workflows.sh --required-version
  fm-lint-workflows.sh --help
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"5ab3d72cbba4719855f4cdcd45c670503c14b87a","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `bin/fm-lint-workflows.sh:160` - The classifier returns the wrong label for a legal `on:` block sequence written at column 0. In the main awk rule the top-level-key branch `if (i == 0) { ... if (mode == 1) emit(&#34;none&#34;) ... }` (line 160-165) is evaluated before the `mode == 1` sequence detection (`if (substr(t, 1, 1) == &#34;-&#34;) seq = 1`, line 169), so the first item of a zero-indent sequence ends the `on:` block while mode is still 1 and emits `none`. Verified by running the extracted classifier plus fm_lint_workflows_pr_gating on a two-file set: ci.yml with `on:` newline `- pull_request` (CI on every PR base) and no-mistakes-required.yml with `branches: [main]` produced `PR base gating: no-mistakes-required.yml requires checks on: main` and exit 0. That is precisely the CI-gates-a-base-the-required-check-does-not violation the gate was added to catch, reported as passing. The intent states block sequences are a supported form; they are only supported when indented. Fix: test for a leading `-` while mode == 1 before treating an i == 0 line as a new top-level key (or set `seq` as soon as the first non-comment line after `on:` starts with `-`, regardless of indent).
- ⚠️ `bin/fm-lint-workflows.sh:247` - Deleting the required-check workflow defeats the gate silently. When `no-mistakes-required.yml` is missing from the scanned set, fm_lint_workflows_pr_gating prints an informational note to stderr and `return 0` (lines 247-251), so a repo whose ci.yml still gates `main` and `feat/omp-adaptor` lints clean with the required check gone - the same &#39;absent required check is indistinguishable from a passing one&#39; failure this change exists to prevent. Verified by running the extracted gating function with FILES containing only a PR-gating ci.yml: output was the absence note and EXIT=0. The permissive branch is only needed for fixture roots, and every existing fixture that lacks the required workflow (write_valid_workflow) uses `on: push`, verdict `none`. Fix: return 0 only when no other workflow in the set has a pull_request trigger, and fail when at least one does while the required workflow is absent.
- ⚠️ `bin/fm-lint-workflows.sh:199` - A `branches:` key followed by list dashes at the key&#39;s own indentation - legal and common YAML - hard-fails the lint with a wrong diagnosis. `pr_indent` is set to the indent of the `branches:` line itself (line 185), so the first `- main` at that same column hits `if (i &lt;= pr_indent) emit(branch_list())` (line 199) with `bases` still empty, emitting `unsupported empty branches list`. Verified: a file containing `on:` / `  pull_request:` / `    branches:` / `    - main` / `    - feat/x` classifies as `unsupported empty branches list`. bin/fm-lint.sh runs this on every pre-push and in CI, so such a workflow fails the gate and the message tells the author to &#39;keep the on: block in block style with an explicit branches: list&#39;, which is exactly what they wrote. It fails closed rather than passing wrongly, but it blocks a valid file with a misleading reason. Fix: in mode 3, treat a line beginning with `-` as a sequence entry regardless of whether its indent equals pr_indent, and only end the list on a non-dash line at or below pr_indent.

🔧 Fix: read YAML block sequences by membership, not indent
2 issues (1 warning, 1 info) still open:
- ⚠️ `bin/fm-lint-workflows.sh:210` - A `paths:`/`paths-ignore:` filter under `pull_request:` is silently ignored, so the gate reports success while the required check is conditional. In mode 2 the classifier refuses `branches-ignore` (line 208) but skips every other sibling key (`if (key != &#34;branches&#34;) next`, line 210), so `paths` never reaches a verdict. Verified by driving the extracted gating function on a two-file set: no-mistakes-required.yml with `pull_request:` / `paths: [&#34;bin/**&#34;]` / `branches: [main]` and ci.yml with `branches: [main]` printed `PR base gating: no-mistakes-required.yml requires checks on: main` and exited 0. A PR into `main` touching only `docs/` then creates no run of the required check at all - zero checks, indistinguishable from passing checks in the PR UI, which is the exact failure class this gate exists to catch and the same shape as the deleted-required-workflow hole just closed. The intent states the parser &#34;fails closed, naming the construct, on any form it cannot read confidently&#34;; `paths` is the one narrowing construct that silently passes. Suggested fix at the same shared boundary as `branches-ignore`: in mode 2, emit `unsupported paths filter under pull_request` (and `paths-ignore`) so the construct is named rather than ignored.
- ℹ️ `bin/fm-lint-workflows.sh:315` - Base names are compared as literal strings, so a glob in the required check&#39;s `branches:` list produces a false failure with a misleading message. `case &#34;$required_set&#34; in *&#34; $base &#34;*)` (lines 315-318) quotes `$base`, making any glob metacharacter literal in both directions. Verified with the extracted gating function: no-mistakes-required.yml with `branches: [&#34;**&#34;]` and ci.yml with `branches: [main]` exits 1 with `ci.yml gates PR base(s) main that no-mistakes-required.yml does not require ... Add them to no-mistakes-required.yml` - but `**` already matches `main`, so the advice is wrong and the config is correct. GitHub allows globs in `branches:` (`releases/**`, `feat/*`), and this gate runs on every pre-push, so a future required check written with a glob blocks the lint with a diagnosis that cannot be acted on. It only ever fails closed (no glob combination produces a wrong pass), so this is not a merge blocker. Cheapest correct fix consistent with the parser&#39;s stated philosophy: emit `unsupported glob base pattern &lt;pattern&gt;` when a base contains `*` or `?`, so the refusal names the real construct instead of reporting a false coverage gap.

🔧 Fix: fail a required check narrowed by a paths filter
2 issues (1 warning, 1 info) still open:
- ⚠️ `bin/fm-lint-workflows.sh:181` - A multi-line flow sequence as the `on:` value silently classifies as `none`, so a workflow that gates every PR base is reported as having no pull_request trigger. At line 180-181 the `on:` scalar branch refuses a flow mapping (`{`) but hands any other non-empty value straight to `events(val)`, which only sees the first physical line. For `on: [push,` / `     pull_request]` - valid YAML and valid Actions syntax - `val` is `[push,`, `tokens()` yields just `push`, and the verdict is `none`. Verified end to end: driving the extracted classifier plus fm_lint_workflows_pr_gating on a two-file set (ci.yml with that multi-line `on:` value, no-mistakes-required.yml with `branches: [main]`) printed `PR base gating: no-mistakes-required.yml requires checks on: main` and exited 0, while that ci.yml in fact gates every PR base including bases the required check never runs on. That is the CI-gates-a-base-the-required-check-does-not violation reported as passing. The parser already refuses this exact construct one level down (`unsupported multi-line flow sequence under branches`, line 248-249), and the intent states the parser fails closed naming the construct on &#34;a multi-line flow sequence&#34;; the `on:` value is the one place it does not. Fix at the same boundary: in the `on:` scalar branch, when `val` starts with `[` and contains no `]`, emit `unsupported multi-line flow sequence in on: value` before calling `events(val)`.
- ℹ️ `bin/fm-lint-workflows.sh:339` - The required-check paths-filter failure message describes the wrong skip condition for `paths-ignore`. Both branches (lines 339-341 and 343-345) say &#34;a PR touching no matching file produces no run of the required check at all&#34;, which is accurate for `paths:` but inverted for `paths-ignore:`, where the run is skipped when a PR touches ONLY ignored files. Verified: a required check with `paths-ignore: [&#34;docs/**&#34;]` printed `narrows its pull_request trigger with a paths-ignore filter, so on every PR base it gates a PR touching no matching file produces no run...` - a PR touching no `docs/**` file is precisely the case that DOES run. The verdict and exit code are correct; only the explanation misleads a reader trying to confirm the diagnosis. Phrase the condition per key, e.g. &#34;a PR touching only ignored files&#34; for `paths-ignore`.

🔧 Fix: refuse a multi-line flow on: value, fix paths-ignore wording
2 infos still open:
- ℹ️ `bin/fm-lint-workflows.sh:147` - A `pull_request_target`-triggered workflow bypasses the gating invariant silently. `events()` (line 147) and the mapping branch (line 220) both match the key `pull_request` exactly, so `on:\n  pull_request_target:\n    branches: [main, feat/omp-adaptor]` classifies as `none` and is skipped by the loop at line 370. Verified by driving the extracted gating function on a two-file set: that ci.yml plus a no-mistakes-required.yml with `branches: [main]` printed `PR base gating: no-mistakes-required.yml requires checks on: main` and exited 0, while a PR into `feat/omp-adaptor` would get that workflow&#39;s check and no required check. This is the same base-gated-by-CI-without-the-required-check shape the gate exists to catch, and it is the only PR-gating trigger the classifier reads confidently and answers wrongly rather than refusing. It is not a merge blocker: no workflow in the repo uses `pull_request_target`, and adding one is a deliberate act. Options, in the spirit of the existing design: treat `pull_request_target` as PR-triggered for the base comparison, or emit `unsupported pull_request_target trigger` so it fails loudly like the other forms this gate will not guess at. If neither, the stated-limitation comment beside REQUIRED_CHECK_WORKFLOW is the natural place to record that only the `pull_request` event is read.
- ℹ️ `tests/fm-lint-workflows.test.sh:713` - The comment at lines 713-714 says the block-sequence `paths:` form in `test_paths_filter_on_other_workflow_passes` &#34;doubles as coverage of the non-flow paths spelling&#34;, but that test cannot prove it. The fixture puts the block-sequence `paths:` on ci.yml, where a paths filter is deliberately ignored, so the test asserts rc==0 and `requires checks on: main` - exactly what it would assert if the classifier never set `pathsfilter` for the block form at all. Every test that actually exercises the paths failure (`test_required_check_with_paths_filter_fails`, `test_required_check_with_paths_ignore_filter_fails`) uses the flow form on the required check, so the block-sequence branch of the requirement is unpinned. I confirmed the code itself is correct - the detection is key-based at line 238 and indifferent to the value form, and `paths:` / `paths-ignore:` written as same-indent or deeper block sequences both produce the `paths &lt;key&gt; ` prefix - so this is a coverage claim gap, not a defect. Fix by giving the required check the block-sequence `paths:` form in one of the failing tests (or adding a third), and correcting the comment.

🔧 Fix: gate pull_request_target bases like pull_request
3 issues (2 warnings, 1 info) still open:
- ⚠️ `bin/fm-lint-workflows.sh:178` - The `unsupported empty branches list` refusal no longer reaches the shell as a refusal, and in one reachable shape the gate exits 0 on a required check that gates nothing. `bank()` (line 176-181) stores `pr_verdict()`&#39;s result in `found_verdict`, and `banked()` unconditionally wraps it as `&#34;event &#34; found_event &#34; &#34; v` (line 174), so `branch_list()`&#39;s `unsupported empty branches list` (line 161) is emitted as `event pull_request unsupported empty branches list`. The shell&#39;s refusal branch tests `case &#34;$verdict&#34; in &#34;unsupported &#34;*)` (line 332-338) and does not match; the `event ` prefix is then stripped and the reason becomes the verdict body. Verified by driving the extracted classifier plus fm_lint_workflows_pr_gating on a set of no-mistakes-required.yml with `on:` / `  pull_request:` / `    branches: []` and one push-only workflow: output was `fm-lint-workflows.sh: PR base gating: no-mistakes-required.yml requires checks on:unsupported empty branches list` with EXIT=0. The null form (`branches:` followed by a sibling key at the same indent) produces the identical wrong pass. actionlint 1.7.12 does not catch this first: its webhook-filter rule only checks filter/ignore exclusivity and filter availability, not emptiness, so the file reaches the gating check. This is a regression from the fix rounds - before 722ab5f the same input hit `emit(branch_list())` and was refused with exit 1 - and it reintroduces exactly the silent-hole class this change exists to close, in the one construct where a required check gates no base at all. No test pins it. Fix at the same shared boundary the other refusals use: in `bank()` or `banked()`, emit a verdict matching /^unsupported / directly instead of banking it, so the contract documented at line 118 holds on every path.
- ⚠️ `bin/fm-lint-workflows.sh:433` - The `pull_request_target` note in the base-comparison loop describes the wrong file&#39;s event, so it gives concretely wrong guidance in one case and is silently absent in the case where it is true. `note=$(fm_lint_workflows_event_note &#34;$event&#34;)` (line 433) takes the event of the OFFENDING workflow, but both messages it is appended to (lines 436-438 and 455-457) recommend editing `no-mistakes-required.yml`, whose event is `$required_event`. Verified with the extracted gating function: ci.yml `on: pull_request_target` plus no-mistakes-required.yml with `pull_request` / `branches: [main]` prints `... Drop the base filter in no-mistakes-required.yml or widen it there. Note: pull_request_target reads the workflow file from the default branch, not from the PR merge commit as pull_request does, so that edit only takes effect once it reaches the default branch.` - but that edit is to a `pull_request`-triggered file, which gates itself on the merge commit, so the reader is told to land it on the default branch first for no reason. The mirror case (ci.yml on `pull_request` gating `feat/omp-adaptor`, no-mistakes-required.yml on `pull_request_target` with `branches: [main]`) emits no note at all, even though there the recommended edit genuinely does only take effect once it reaches the default branch. The required-check paths branch at line 404 is already correct because it uses `$required_event` and names that same file. Fix: in the loop, derive the note from the event of the file the message tells the reader to edit (`$required_event`), or state both events explicitly when they differ. Same class as the `paths-ignore` inversion fixed in round 3: verdicts and exit codes are correct, only the explanation misleads.
- ℹ️ `bin/fm-lint-workflows.sh:12` - The header paragraph, which is also the `--help` output (`fm_lint_workflows_usage` extracts lines 2-22 verbatim, line 36), still states the invariant as &#34;every PR base gated by any pull_request-triggered workflow must also be gated by no-mistakes-required.yml&#34;. Since ab13244 the gate also holds `pull_request_target` bases to that rule and refuses a workflow declaring both events, and the required check&#39;s `paths`/`paths-ignore` filter is now a failure too. Confirmed by running the extractor: the emitted help contains only the pull_request wording. A contributor who adds a `pull_request_target` workflow and trips the lint gets a message naming that event while the surface the header itself points them to describes a narrower rule. The fuller rule lives only in the block comment above REQUIRED_CHECK_WORKFLOW (lines 98-103), which `--help` does not include. Widening line 12 to name both events keeps the two consistent without duplicating the default-branch caveat.

🔧 Fix: keep refusals recognizable, fix event note attribution
1 warning still open:
- ⚠️ `tests/fm-lint-workflows.test.sh:622` - The `unsupported empty branches list` refusal is the only refusal that flows through `bank()`, and it is the exact path that this run&#39;s own fix rounds regressed into a silent pass (round 5). The code fix is in place and correct - I verified it by driving the extracted classifier plus fm_lint_workflows_pr_gating on a set of no-mistakes-required.yml with `on:` / `  pull_request:` / `    branches: []` plus one push-only workflow: output was `cannot read the pull_request base filter (empty branches list)` with EXIT=1, and the null form (`branches:` followed by a sibling key at the same indent) behaves identically. But nothing pins it. No fixture in tests/fm-lint-workflows.test.sh writes an empty or null `branches:` value - every base list in the suite (lines 565-959) is non-empty - so the guard at bin/fm-lint-workflows.sh:185 (`if (refusal(v)) emit(v)`) is never executed by a test. Deleting that one line restores the defect verbatim: the verdict reaches the shell as `event pull_request unsupported empty branches list`, misses the `&#34;unsupported &#34;*` branch at bin/fm-lint-workflows.sh:351, and the run prints `PR base gating: no-mistakes-required.yml requires checks on:unsupported empty branches list` with EXIT=0 on a required check that gates no base at all. The three existing refusal tests all cover paths that emit directly rather than through `bank()`: `branches-ignore` (bin/fm-lint-workflows.sh:252, test at line 622), the multi-line flow `on:` value (line 215, test at line 776), and the both-events combination (line 296, test at line 899). Round 5&#39;s instructions asked for this regression explicitly (&#34;Add the regression that proves the reachable shape now refuses with a nonzero status rather than passing&#34;) and it was not added. Fix: add a test that lints a --root fixture whose no-mistakes-required.yml has `branches: []` and asserts a nonzero exit plus the `empty branches list` reason, following the style of test_unreadable_base_filter_fails_closed, and register it in the invocation list at the bottom.

🔧 Fix: pin the empty branches list refusal
1 info still open:
- ℹ️ `bin/fm-lint-workflows.sh:110` - The stated limitation at lines 108-114 claims a glob in the required check&#39;s branch list &#34;fails this lint loudly rather than passing silently.&#34; That is true only when the literal comparison happens to miss; with a negation pattern it passes silently on exactly the defect this gate exists to catch. Verified end to end with real actionlint 1.7.12: no-mistakes-required.yml with `branches: [&#39;**&#39;, &#39;!docs&#39;]` and ci.yml with `branches: [&#39;**&#39;]` prints `PR base gating: no-mistakes-required.yml requires checks on: ** !docs` and exits 0. Both files pass actionlint, so the set reaches the gating check. Semantically ci.yml gates every PR base including `docs`, while the required check excludes it, so a PR into `docs` gets CI and no required check - the absent-required-check-reads-as-passing failure. The literal match succeeds because ci.yml&#39;s single token `**` is present verbatim in required_set (line 473), so no base is ever reported missing and glob_note (line 445) never fires. test_glob_base_in_required_check_fails_loudly pins only the loud direction and cannot catch this. Not a merge blocker: no workflow in the repo uses a glob or negation in `branches:`, and the task owner explicitly declined glob semantics in round 2. Cheapest fix consistent with that ruling is to correct the comment (a glob fails loudly only when the literal comparison misses; identical or negation-bearing pattern lists can pass), or, if the claim should hold as written, refuse a required-check base containing `*`, `?` or a leading `!` by name the way branches-ignore is refused.

🔧 Fix: refuse filter patterns in branches lists by name
1 info still open:
- ℹ️ `bin/fm-lint-workflows.sh:108` - The stated-limitation comment rewritten in d53cbf4 over-claims its scope: &#34;a GitHub filter pattern in any `branches:` list is refused by name with its reason rather than compared&#34; (lines 108-110). The classifier only ever reads a `branches:` list inside a `pull_request:`/`pull_request_target:` mapping - mode 2 is entered solely for a gating key at line 316 - so a pattern in a `push:` (or any non-gating trigger&#39;s) `branches:` list is never seen and never refused. Verified with the extracted gating function: ci.yml with `on:` / `  push:` / `    branches: [&#34;releases/**&#34;]` plus a required check on `branches: [main]` printed `PR base gating: no-mistakes-required.yml requires checks on: main` and exited 0, no refusal. The behavior is correct - a push filter has nothing to do with PR base coverage - only the sentence is wrong. This matters because the block above REQUIRED_CHECK_WORKFLOW is this repo&#39;s designated single owner of the gate&#39;s rule, and the round-5 header/--help mismatch was accepted as a real defect on exactly that basis. Fix: scope the noun, e.g. &#34;a GitHub filter pattern in any PR base `branches:` list&#34; (or &#34;in a `branches:` list under a base-gating trigger&#34;), leaving the rest of the paragraph unchanged. It does not affect the `--help` extraction range, which covers lines 2-25 only.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bin/fm-lint-workflows.sh` on the real repo workflow set (exit 0, reports both gated bases)</code>
- <code>`bin/fm-lint-workflows.sh --root &lt;base-commit 1231b6ae workflows&gt;` - reports `requires checks on: main` only, showing the pre-fix ungated adapter branch</code>
- <code>`bin/fm-lint-workflows.sh --root &lt;half-fix: adapter base in ci.yml only&gt;` - fails with the missing-required-check message, exit 1</code>
- <code>`bash tests/fm-lint-workflows.test.sh` - all 42 assertions pass, including the 7 new PR-base-gating regressions</code>
- <code>`bash tests/fm-lint.test.sh` - adjacent consumer of the modified script, all assertions pass</code>
- <code>`/bin/bash -n bin/fm-lint-workflows.sh` and full suite re-run under stock macOS bash 3.2.57</code>
- <code>`ruby -ryaml` parse of `.github/workflows/*.yml` into a trigger model asserting `pull_request.branches` membership per file</code>
- <code>`gh api repos/Boxyboxy/firstmate/commits/&lt;sha&gt;/check-runs` for PRs #11, #10, #9 based on `feat/omp-adaptor` (total_count 0) and upstream main-based PRs #2811, #2810, #2795 (14-15)</code>
- <code>`bin/fm-lint-workflows.sh --help` - confirms the gating rule is documented on the user-facing surface</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: lint clean, no code changes needed
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
