### PR TITLE
feat(bin): add engineering-craft discipline to crewmate briefs

### DIFF
--- a/.agents/skills/firstmate-coding-guidelines/SKILL.md
+++ b/.agents/skills/firstmate-coding-guidelines/SKILL.md
@@ -3,7 +3,7 @@ name: firstmate-coding-guidelines
 description: >-
   Agent-only reference for changing firstmate's shared, tracked material per AGENTS.md section 1.
   Use before editing any of that material, whether working as firstmate directly or as a crewmate briefed on a firstmate-repo task.
-  Covers the knowledge-placement decision tree, the one-owner rule for contracts, the inline-stub pattern for content moved into a skill, AGENTS.md size discipline, trigger hygiene for new skills, and repo style rules (one sentence per line, plain dash, no agent co-author, shellcheck-clean bin scripts, colocated tests, and maintainer-verification evidence).
+  Covers the knowledge-placement decision tree, the one-owner rule for contracts, the inline-stub pattern for content moved into a skill, AGENTS.md size discipline, trigger hygiene for new skills, and repo style rules (one sentence per line, plain dash, a pointer to the AI-attribution rule's owner, shellcheck-clean bin scripts, colocated tests, and maintainer-verification evidence).
 user-invocable: false
 metadata:
   internal: true
@@ -116,7 +116,7 @@ Run `bin/fm-doc-audience-check.sh`; it enforces classification, README setup rou
 - Put one full sentence per line in tracked Markdown.
 - Never wrap multiple sentences onto one physical line.
 - Plain dash `-`, never an em dash.
-- Never add an agent name as a commit co-author.
+- `AGENTS.md` section 1 owns the AI-attribution rule; apply it to every commit, PR body, and file you touch here.
 - `bin/*.sh` and `bin/backends/*.sh` must pass `shellcheck`.
 - Run `bin/fm-lint.sh` before treating a script change as done; it is the single owner of the lint definition (file set, config, pinned shellcheck version, and pinned actionlint workflow lint) that CI and the no-mistakes pre-push gate both invoke, and it refuses to run under any other version of either linter.
 - When a task names a specific tool, implement the work with that tool, or explicitly flag the substitution and its new dependency footprint for review before shipping.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,8 @@ Shared tracked material is `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.tasks.
 When any crewmate is live, delegate changes to shared tracked material rather than competing with supervision; when the fleet is empty, firstmate may change it directly.
 This repo is a shared template, while `.env`, `data/`, `state/`, `config/`, `projects/`, and `.no-mistakes/` are captain-private and gitignored.
 Ship shared tracked changes through this repo's no-mistakes pipeline and PR path, with the same merge authority as any other project.
-Never add an agent name as a commit co-author.
+Never leave AI attribution in the work you ship: no agent co-author trailer, no agent session trailer, and no generated-by note, in commit messages, PR bodies, or files.
+Harnesses emit these by default, so strip them deliberately rather than relying on never typing them.
 
 ## 2. Layout and state
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -54,6 +54,15 @@
 # it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers
 # over copied detail) and has the crewmate add the fm-ensure-agents-md.sh
 # self-governance section when a touched project AGENTS.md lacks it.
+# Ship and scout briefs carry an "Engineering craft" section separate from the
+# numbered lifecycle Rules, so the lifecycle rule numbers other instructions cite
+# stay stable. The ship variant carries the full set; the scout variant carries
+# only the two items that survive a discarded laboratory worktree - state your
+# assumptions, and never add AI attribution (which binds a scout because
+# bin/fm-promote.sh ships from this same worktree without regenerating the brief).
+# A secondmate charter carries no craft section: a second mate delegates rather than
+# codes, reads the full AGENTS.md that owns the attribution rule, and its own
+# crewmates get this scaffold's craft section in their briefs.
 # Refuses to overwrite an existing brief.
 set -eu
 
@@ -336,6 +345,10 @@ The report is the only thing that survives, so anything worth keeping must be in
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
 
+# Engineering craft
+1. State your assumptions explicitly before non-trivial work. If the task has more than one reasonable reading, name them in the report rather than silently picking one.
+2. Never add AI attribution: no agent co-author trailer (a \`Co-Authored-By:\` naming your harness or model), no agent session trailer, no generated-by note, in commit messages, PR bodies, or files. Your harness emits these by default, so strip them deliberately rather than relying on never typing them. This binds your scratch commits too, because firstmate may promote this task in place and you would then commit and open a PR from this same worktree.
+
 # Definition of done
 Write your findings to \`$DATA/$ID/report.md\`.
 The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
@@ -452,6 +465,15 @@ $RULE1
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+
+# Engineering craft
+1. Turn a vague task into a verifiable goal before writing code: "fix the bug" becomes a failing test that reproduces it, then make it pass; "refactor X" means confirming the relevant tests pass before AND after.
+2. State your assumptions explicitly before non-trivial work. If the task has more than one reasonable reading, name them rather than silently picking one.
+3. Every changed line traces to the actual request. No drive-by edits.
+4. If the diff is 200 lines and could be 50, rewrite it.
+5. Remove imports, variables, and functions that YOUR change orphaned. Pre-existing dead code is mentioned, not deleted.
+6. Delete throwaway test and debug scripts once they are no longer needed. This does not mean the project's real test suite.
+7. Never add AI attribution: no agent co-author trailer (a \`Co-Authored-By:\` naming your harness or model), no agent session trailer, no generated-by note, in commit messages, PR bodies, or files. Your harness emits these by default, so strip them deliberately rather than relying on never typing them.
 
 # Project memory
 If \`AGENTS.md\` or \`CLAUDE.md\` already exists, or if this task produced durable project-intrinsic knowledge, run \`$FM_ROOT/bin/fm-ensure-agents-md.sh .\` in the worktree.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -371,6 +371,76 @@ test_ship_project_memory_wording() {
   pass "fm-brief.sh: ship project-memory wording carries the AGENTS.md authoring bar"
 }
 
+# The craft section is deliberately per-variant, not one block pasted everywhere.
+# A ship task delivers a diff, so it carries all seven items. A scout's worktree is
+# a declared laboratory that is discarded whole, so diff-hygiene and cleanup items
+# would contradict its own Setup section; it keeps only the two that survive -
+# assumptions, and the attribution rule, which binds a scout because
+# bin/fm-promote.sh ships from the same worktree without regenerating the brief.
+# A secondmate delegates rather than codes and reads the AGENTS.md that owns the
+# attribution rule, so its charter carries no craft section at all.
+test_craft_section_is_scoped_per_variant() {
+  local home brief mode
+  home="$TMP_ROOT/craft-home"
+  mkdir -p "$home/data"
+
+  for mode in no-mistakes direct-PR local-only; do
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "brief-craft-$mode" some-proj --mode "$mode" >/dev/null 2>&1 \
+      || fail "fm-brief.sh --mode $mode exited non-zero"
+    brief="$home/data/brief-craft-$mode/brief.md"
+    grep -qx "# Engineering craft" "$brief" \
+      || fail "$mode ship brief lost its engineering-craft section"
+    assert_grep "becomes a failing test that reproduces it" "$brief" \
+      "$mode ship brief lost the verifiable-goal rule"
+    assert_grep "name them rather than silently picking one" "$brief" \
+      "$mode ship brief lost the explicit-assumptions rule"
+    assert_grep "No drive-by edits." "$brief" \
+      "$mode ship brief lost the traceable-change rule"
+    assert_grep "200 lines and could be 50" "$brief" \
+      "$mode ship brief lost the diff-size rule"
+    assert_grep "Pre-existing dead code is mentioned, not deleted." "$brief" \
+      "$mode ship brief lost the orphaned-code rule"
+    assert_grep "This does not mean the project's real test suite." "$brief" \
+      "$mode ship brief lost the throwaway-script cleanup rule"
+    assert_grep "Never add AI attribution" "$brief" \
+      "$mode ship brief lost the AI-attribution rule"
+    assert_grep "in commit messages, PR bodies, or files" "$brief" \
+      "$mode ship brief did not extend the attribution rule past the co-author field"
+    assert_grep "strip them deliberately" "$brief" \
+      "$mode ship brief did not require actively stripping harness-emitted attribution"
+  done
+
+  # The lifecycle Rules list keeps its own numbering: the no-mistakes DOD cites
+  # "rule 6" by number, so the craft items must never be folded into that list.
+  brief="$home/data/brief-craft-no-mistakes/brief.md"
+  assert_grep "escalate to firstmate (rule 6)" "$brief" \
+    "the craft section must not disturb the numbered lifecycle rules the DOD cites"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-craft-scout some-proj --scout >/dev/null 2>&1 \
+    || fail "fm-brief.sh --scout exited non-zero"
+  brief="$home/data/brief-craft-scout/brief.md"
+  grep -qx "# Engineering craft" "$brief" \
+    || fail "scout brief lost its engineering-craft section"
+  assert_grep "name them in the report rather than silently picking one" "$brief" \
+    "scout brief lost the explicit-assumptions rule"
+  assert_grep "Never add AI attribution" "$brief" \
+    "scout brief lost the AI-attribution rule"
+  assert_grep "firstmate may promote this task in place" "$brief" \
+    "scout brief did not explain why attribution binds its scratch commits"
+  assert_no_grep "200 lines and could be 50" "$brief" \
+    "scout brief carries diff-size discipline its discarded laboratory worktree contradicts"
+  assert_no_grep "becomes a failing test that reproduces it" "$brief" \
+    "scout brief carries the ship-only verifiable-goal rule"
+
+  FM_SECONDMATE_CHARTER='Supervise the alpha domain.' \
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-craft-mate --secondmate alpha >/dev/null 2>&1 \
+    || fail "fm-brief.sh --secondmate exited non-zero"
+  brief="$home/data/brief-craft-mate/brief.md"
+  assert_no_grep "Engineering craft" "$brief" \
+    "secondmate charter must not carry the crewmate craft section"
+  pass "fm-brief.sh: engineering-craft section is scoped to the variants it fits"
+}
+
 test_herdr_lab_contract_is_explicit_and_complete() {
   local home id brief
   home="$TMP_ROOT/herdr-lab-home"
@@ -722,6 +792,7 @@ test_delivery_flags_are_refused_where_they_do_not_apply
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
 test_ship_project_memory_wording
+test_craft_section_is_scoped_per_variant
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path
 test_herdr_lab_omission_is_loud_for_ship_and_scout


### PR DESCRIPTION
> Supersedes #2825, which was closed unmerged. Same branch and same commit; no code changes between the two.

## Why

The generated crewmate brief said nothing about *how* to do engineering work well. Its `# Rules` section is entirely lifecycle mechanics: status protocol, do not push, do not touch the shared `no-mistakes` daemon.

Separately, `AGENTS.md` section 1 said only "Never add an agent name as a commit co-author". That is too narrow. On 2026-08-23 a crewmate shipped commits carrying both a `Co-Authored-By` trailer and a session trailer, because agent harnesses emit them by default. The rule has to say they must be actively stripped, and it has to cover PR bodies and files, not just the co-author field.

## Change 1 - craft discipline in the brief scaffold (`bin/fm-brief.sh`)

A new `# Engineering craft` section in the generated brief, placed between `# Rules` and `# Project memory` / `# Definition of done` rather than appended to the numbered Rules list. That placement is deliberate: the generated no-mistakes definition of done cites "rule 6" by number, so the lifecycle numbering has to stay stable.

### Which variants get it, and why

The block is **not** pasted into all three variants.

| Variant | Craft items | Reasoning |
| --- | --- | --- |
| Ship (all 3 delivery modes, one shared template) | all 7 | A ship task delivers a diff; every item applies. |
| Scout | 2 only (assumptions, AI attribution) | See below. |
| Secondmate charter | none | See below. |

**Scout.** The scout template's own `# Setup` section declares the worktree a laboratory: "install, run, edit, and make scratch commits freely; all of it is discarded at teardown." Items 3-6 (no drive-by edits, diff size, orphaned code, throwaway-script cleanup) would directly contradict the brief's own instructions two sections earlier, and item 1 is test-centric ship work. What survives is item 2 (state your assumptions -- an investigation with two readings must name them) and item 7.

Item 7 binds a scout for a concrete reason: `bin/fm-promote.sh` converts a scout task to a ship task **in place** and only emits a one-line steer -- it does not regenerate the brief. The crewmate then commits and opens a PR from the same worktree having never seen the attribution rule. The scout item says so explicitly.

**Secondmate charter.** A second mate delegates rather than codes, reads the full `AGENTS.md` that owns the attribution rule, and its own crewmates receive this same scaffold's craft section in their briefs. Adding it there would be a third copy with no reader.

The reasoning is recorded in the script header, so `fm-brief.sh --help` carries it.

### Generated output

Ship brief (identical in `no-mistakes`, `direct-PR`, and `local-only`):

```
# Engineering craft
1. Turn a vague task into a verifiable goal before writing code: "fix the bug" becomes a failing test that reproduces it, then make it pass; "refactor X" means confirming the relevant tests pass before AND after.
2. State your assumptions explicitly before non-trivial work. If the task has more than one reasonable reading, name them rather than silently picking one.
3. Every changed line traces to the actual request. No drive-by edits.
4. If the diff is 200 lines and could be 50, rewrite it.
5. Remove imports, variables, and functions that YOUR change orphaned. Pre-existing dead code is mentioned, not deleted.
6. Delete throwaway test and debug scripts once they are no longer needed. This does not mean the project's real test suite.
7. Never add AI attribution: no agent co-author trailer (a `Co-Authored-By:` naming your harness or model), no agent session trailer, no generated-by note, in commit messages, PR bodies, or files. Your harness emits these by default, so strip them deliberately rather than relying on never typing them.
```

Scout brief:

```
# Engineering craft
1. State your assumptions explicitly before non-trivial work. If the task has more than one reasonable reading, name them in the report rather than silently picking one.
2. Never add AI attribution: no agent co-author trailer (a `Co-Authored-By:` naming your harness or model), no agent session trailer, no generated-by note, in commit messages, PR bodies, or files. Your harness emits these by default, so strip them deliberately rather than relying on never typing them. This binds your scratch commits too, because firstmate may promote this task in place and you would then commit and open a PR from this same worktree.
```

Secondmate charter: no `Engineering craft` section (asserted by test).

### Harness-agnostic wording

The motivating incident involved `Claude-Session` and "Generated with Claude", but this scaffold generates briefs for codex, opencode, pi, grok, kimi, cursor, and muse workers as well as claude. Naming a Claude-specific trailer would read as inapplicable to those workers, so the rule generalizes to "agent session trailer" and "generated-by note". The one field named concretely is `Co-Authored-By:`, which is git's own, so a worker on any harness recognizes it.

## Change 2 - `AGENTS.md`

The narrow sentence is **replaced**, not supplemented, and no new section is added. Net +1 line in section 1:

```
Never leave AI attribution in the work you ship: no agent co-author trailer, no agent session trailer, and no generated-by note, in commit messages, PR bodies, or files.
Harnesses emit these by default, so strip them deliberately rather than relying on never typing them.
```

## Change 3 - one owner

`.agents/skills/firstmate-coding-guidelines/SKILL.md` restated the same narrow rule in its repo style rules and named it in its frontmatter description. Per that skill's own one-owner rule, `AGENTS.md` section 1 is now the owner; the skill carries a one-line cross-reference, and the frontmatter description was updated so it stays accurate. A repo-wide grep for `co-author`, `Co-Authored`, `Claude-Session`, `Generated with`, and `attribution` confirms no other copy of the contract remains.

## Test evidence

New `test_craft_section_is_scoped_per_variant` in `tests/fm-brief.test.sh` drives the real scaffold and asserts against its generated output (behavior through the executable interface, not implementation-source bytes):

- each of the seven items, in all three ship delivery modes;
- the two scout items, **plus** `assert_no_grep` on the two ship-only items, so the per-variant scoping cannot silently collapse into one pasted block;
- no craft section in a secondmate charter;
- that the no-mistakes definition of done still cites `rule 6`, guarding the lifecycle numbering the new section was kept out of.

```
$ bash tests/fm-brief.test.sh
... 21 ok, 0 not ok
```

```
$ bin/fm-lint.sh
fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)
fm-lint-workflows.sh: actionlint 1.7.12 (pinned 1.7.12)
fm-lint-workflows.sh: 3 workflow files valid
```

```
$ bin/fm-doc-audience-check.sh
fm-doc-audience-check: ok surfaces=73 local_links=266
```

`tests/fm-documentation-audiences.test.sh` and `tests/fm-ensure-agents-md.test.sh` also pass.

## Out of scope

Captain-facing style rules, the em-dash convention, how firstmate talks to the captain, `data/`, `config/`, and project clones are untouched.
