### PR TITLE
feat(bin): add opt-in pre-acquire worktree pool safety sweep

### DIFF
--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -9,6 +9,9 @@ on:
 
 permissions:
   contents: read
+  # Read-only, and only used to re-read this PR's live body when the event
+  # payload carries a body no-mistakes has already replaced.
+  pull-requests: read
 
 # GitHub concurrency groups retain at most one pending run, replacing older
 # pending runs even when cancel-in-progress is false. Give body-bearing events
@@ -31,23 +34,35 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -eu
           marker='Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)'
-          if printf '%s' "${PR_BODY:-}" | grep -qF -- "$marker"; then
-            echo "Found no-mistakes signature in PR #${PR_NUMBER} body."
+          prefix='<!-- no-mistakes-pipeline-attestation:v1 '
+          suffix=' -->'
+
+          # Classify one body snapshot into `verdict` (ok, no-signature,
+          # no-attestation, incomplete) plus, for incomplete, `incomplete`.
+          verdict=''
+          incomplete=''
+          classify_body() {
+            snapshot=$1
+            verdict=''
+            incomplete=''
+            if ! printf '%s' "$snapshot" | grep -qF -- "$marker"; then
+              verdict=no-signature
+              return 0
+            fi
             if ! command -v jq >/dev/null 2>&1; then
               echo "::error::This check requires jq to parse no-mistakes pipeline step attestation, but jq was not found on the runner." >&2
               exit 1
             fi
-            prefix='<!-- no-mistakes-pipeline-attestation:v1 '
-            suffix=' -->'
-            body="${PR_BODY:-}"
             json=''
             parse_ok=0
-            case "$body" in
+            case "$snapshot" in
               *"$prefix"*)
-                rest="${body#*"$prefix"}"
+                rest="${snapshot#*"$prefix"}"
                 case "$rest" in
                   *"$suffix"*)
                     json="${rest%%"$suffix"*}"
@@ -59,6 +74,57 @@ jobs:
                 ;;
             esac
             if [ "$parse_ok" -ne 1 ]; then
+              verdict=no-attestation
+              return 0
+            fi
+            for required in review test document; do
+              status=$(printf '%s' "$json" | jq -r --arg step "$required" \
+                '([(.steps | arrays | .[]) | select(.step == $step) | .status] | first // empty | select(. != "")) // "missing"')
+              if [ "$status" != "completed" ]; then
+                if [ -n "$incomplete" ]; then
+                  incomplete="${incomplete}, "
+                fi
+                incomplete="${incomplete}${required}=${status}"
+              fi
+            done
+            if [ -n "$incomplete" ]; then
+              verdict=incomplete
+              return 0
+            fi
+            verdict=ok
+          }
+
+          # no-mistakes pushes the branch and opens the PR before it writes the
+          # pipeline body, so an opened/synchronize payload can carry a body
+          # that was already replaced by the time this job starts. Re-read the
+          # live body before failing, so the gate reports the PR's real state
+          # instead of a race it cannot influence. Every event is still
+          # evaluated on its own run against the body that is live for it.
+          body="${PR_BODY:-}"
+          attempt=1
+          attempts=6
+          while :; do
+            classify_body "$body"
+            if [ "$verdict" = ok ] || [ "$attempt" -ge "$attempts" ]; then
+              break
+            fi
+            echo "PR #${PR_NUMBER} body is not compliant yet (${verdict}); re-reading the live body (attempt ${attempt} of $((attempts - 1)))."
+            sleep 10
+            attempt=$((attempt + 1))
+            if live=$(gh api "repos/${PR_REPO}/pulls/${PR_NUMBER}" --jq '.body // ""' 2>/dev/null); then
+              body="$live"
+            else
+              echo "Could not re-read the PR body from the API; keeping the event payload body."
+            fi
+          done
+
+          case "$verdict" in
+            ok)
+              echo "Found no-mistakes signature in PR #${PR_NUMBER} body."
+              echo "Pipeline step attestation is valid: review, test, and document are completed."
+              exit 0
+              ;;
+            no-attestation)
               {
                 echo "::error::This repository requires no-mistakes >= 1.46.0; structured pipeline step attestation is missing or unparseable."
                 echo
@@ -77,19 +143,8 @@ jobs:
                 echo "PR author: ${PR_AUTHOR}"
               } >&2
               exit 1
-            fi
-            incomplete=''
-            for required in review test document; do
-              status=$(printf '%s' "$json" | jq -r --arg step "$required" \
-                '([(.steps | arrays | .[]) | select(.step == $step) | .status] | first // empty | select(. != "")) // "missing"')
-              if [ "$status" != "completed" ]; then
-                if [ -n "$incomplete" ]; then
-                  incomplete="${incomplete}, "
-                fi
-                incomplete="${incomplete}${required}=${status}"
-              fi
-            done
-            if [ -n "$incomplete" ]; then
+              ;;
+            incomplete)
               {
                 echo "::error::Required no-mistakes pipeline steps are not completed: ${incomplete}."
                 echo
@@ -103,21 +158,21 @@ jobs:
                 echo "PR author: ${PR_AUTHOR}"
               } >&2
               exit 1
-            fi
-            echo "Pipeline step attestation is valid: review, test, and document are completed."
-            exit 0
-          fi
-          {
-            echo "::error::This PR was not raised through no-mistakes."
-            echo
-            echo "Contributions to this repository must be submitted via 'git push no-mistakes'."
-            echo "That pipeline runs the required review/test/lint/CI steps and writes a"
-            echo "deterministic '## Pipeline' section into the PR body containing:"
-            echo
-            echo "    $marker"
-            echo
-            echo "See CONTRIBUTING.md for setup and the full workflow."
-            echo
-            echo "PR author: ${PR_AUTHOR}"
-          } >&2
-          exit 1
+              ;;
+            *)
+              {
+                echo "::error::This PR was not raised through no-mistakes."
+                echo
+                echo "Contributions to this repository must be submitted via 'git push no-mistakes'."
+                echo "That pipeline runs the required review/test/lint/CI steps and writes a"
+                echo "deterministic '## Pipeline' section into the PR body containing:"
+                echo
+                echo "    $marker"
+                echo
+                echo "See CONTRIBUTING.md for setup and the full workflow."
+                echo
+                echo "PR author: ${PR_AUTHOR}"
+              } >&2
+              exit 1
+              ;;
+          esac

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ Pushing through it runs an AI-driven review/test/lint pipeline in an isolated wo
 
 A GitHub Actions check (`Require no-mistakes`) runs on PRs targeting `main` and fails if the body is missing the deterministic signature that no-mistakes writes.
 It evaluates every PR opening and body edit independently, so a later edit cannot replace an earlier pending compliance check.
+Because no-mistakes pushes the branch and opens the PR before it writes the pipeline body, a run whose event payload lacks that signature re-reads the PR's live body for up to a minute before failing, so the gate never reports a race it cannot influence.
 GitHub Actions and Dependabot are exempt so their automation keeps working, but regular contributor PRs without the signature will not be reviewed or merged.
 
 ## Workflow

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2259,6 +2259,17 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
   fi
 
   validate_spawn_worktree "treehouse get" "$T"
+
+  if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ]; then
+    if [ -x "$SCRIPT_DIR/fm-treehouse-pool-sweep.sh" ]; then
+      "$SCRIPT_DIR/fm-treehouse-pool-sweep.sh" "$WT"
+      sweep_rc=$?
+      if [ "$sweep_rc" -ne 0 ]; then
+        echo "error: worktree pool sweep refused worktree $WT (exit $sweep_rc); inspect unsafe state or disable sweep in config/worktree-pool-sweep" >&2
+        exit 1
+      fi
+    fi
+  fi
 fi
 if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ]; then
   freshen_spawn_worktree_base "$WT" || exit 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2262,7 +2262,8 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
 
   if [ -x "$SCRIPT_DIR/fm-treehouse-pool-sweep.sh" ]; then
     sweep_rc=0
-    "$SCRIPT_DIR/fm-treehouse-pool-sweep.sh" "$WT" || sweep_rc=$?
+    FM_CONFIG_OVERRIDE="$CONFIG" \
+      "$SCRIPT_DIR/fm-treehouse-pool-sweep.sh" "$WT" || sweep_rc=$?
     if [ "$sweep_rc" -ne 0 ]; then
       echo "error: worktree pool sweep refused worktree $WT (exit $sweep_rc); inspect unsafe state or disable sweep in config/worktree-pool-sweep" >&2
       exit 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2265,7 +2265,13 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
     FM_CONFIG_OVERRIDE="$CONFIG" \
       "$SCRIPT_DIR/fm-treehouse-pool-sweep.sh" "$WT" || sweep_rc=$?
     if [ "$sweep_rc" -ne 0 ]; then
+      # The refusal deliberately keeps the acquired slot: the sweep refuses
+      # precisely when the worktree may hold work nothing else references, and
+      # returning it here would discard exactly that. The slot stays held, and
+      # window $T stays open, until an operator has looked at the state; say so
+      # rather than leaving the hold to look like a leak.
       echo "error: worktree pool sweep refused worktree $WT (exit $sweep_rc); inspect unsafe state or disable sweep in config/worktree-pool-sweep" >&2
+      echo "error: the pool slot for $WT stays held and window $T stays open so its unsafe state is preserved for inspection; return it by hand once its work is safe" >&2
       exit 1
     fi
   fi

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2260,14 +2260,12 @@ elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
 
   validate_spawn_worktree "treehouse get" "$T"
 
-  if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ]; then
-    if [ -x "$SCRIPT_DIR/fm-treehouse-pool-sweep.sh" ]; then
-      "$SCRIPT_DIR/fm-treehouse-pool-sweep.sh" "$WT"
-      sweep_rc=$?
-      if [ "$sweep_rc" -ne 0 ]; then
-        echo "error: worktree pool sweep refused worktree $WT (exit $sweep_rc); inspect unsafe state or disable sweep in config/worktree-pool-sweep" >&2
-        exit 1
-      fi
+  if [ -x "$SCRIPT_DIR/fm-treehouse-pool-sweep.sh" ]; then
+    sweep_rc=0
+    "$SCRIPT_DIR/fm-treehouse-pool-sweep.sh" "$WT" || sweep_rc=$?
+    if [ "$sweep_rc" -ne 0 ]; then
+      echo "error: worktree pool sweep refused worktree $WT (exit $sweep_rc); inspect unsafe state or disable sweep in config/worktree-pool-sweep" >&2
+      exit 1
     fi
   fi
 fi

--- a/bin/fm-treehouse-pool-sweep.sh
+++ b/bin/fm-treehouse-pool-sweep.sh
@@ -11,14 +11,18 @@
 #
 # The sweep checks two conditions and refuses on either:
 #   1. Dirty worktree: tracked modifications, staged changes, or untracked
-#      non-ignored files. A HEAD that cannot be inspected at all counts as a
-#      refusal too, reported separately so the diagnostic is not "dirty".
+#      non-ignored files.
 #   2. HEAD contains at least one commit not reachable from an approved durable ref:
 #      - refs/heads/* (local branches)
 #      - refs/tags/* (tags)
 #      - refs/firstmate/rescue/* (reserved rescue namespace)
 #
 # Reflogs are NOT refs. A commit reachable only from a reflog is unreferenced.
+#
+# A question git cannot answer - an unreadable HEAD, a corrupt ref database, an
+# unreadable object - refuses under the same exit code as the negative answer it
+# resembles, but with its own diagnostic, so the operator is not sent looking for
+# uncommitted work or orphaned commits that do not exist.
 #
 # For refs/remotes/*: they are counted for reachability so an ordinary freshly-
 # checked-out pool worktree is not falsely refused, but the case where HEAD's
@@ -27,8 +31,9 @@
 #
 # Exit codes:
 #   0 - Worktree is safe to acquire (or sweep is disabled)
-#   1 - Worktree is unsafe: dirty, or HEAD cannot be inspected
-#   2 - Worktree is unsafe: HEAD contains commits not reachable from durable refs
+#   1 - Worktree is unsafe: dirty, or its dirty state cannot be determined
+#   2 - Worktree is unsafe: HEAD contains commits not reachable from durable refs,
+#       or that reachability cannot be computed
 #   3 - Worktree is unsafe: HEAD covered only by remote-tracking refs (prunable)
 #   4 - Worktree does not exist
 #  64 - Usage error (no worktree path given)
@@ -107,16 +112,26 @@ head_is_inspectable() {
 }
 
 is_dirty() {
-  local wt=$1
+  local wt=$1 st untracked
   git -C "$wt" update-index -q --ignore-submodules --refresh >/dev/null 2>&1 || true
-  if ! git -C "$wt" diff-index --quiet --ignore-submodules HEAD 2>/dev/null; then
+
+  st=0
+  git -C "$wt" diff-index --quiet --ignore-submodules HEAD 2>/dev/null || st=$?
+  if [ "$st" -eq 1 ]; then
     return 0
+  elif [ "$st" -ne 0 ]; then
+    return 2
   fi
-  if ! git -C "$wt" diff-index --quiet --ignore-submodules --cached HEAD 2>/dev/null; then
+
+  st=0
+  git -C "$wt" diff-index --quiet --ignore-submodules --cached HEAD 2>/dev/null || st=$?
+  if [ "$st" -eq 1 ]; then
     return 0
+  elif [ "$st" -ne 0 ]; then
+    return 2
   fi
-  local untracked
-  untracked=$(git -C "$wt" ls-files --others --exclude-standard 2>/dev/null)
+
+  untracked=$(git -C "$wt" ls-files --others --exclude-standard 2>/dev/null) || return 2
   if [ -n "$untracked" ]; then
     return 0
   fi
@@ -130,36 +145,51 @@ count_refs() {
 
 has_durable_refs() {
   local wt=$1
-  local count
-  count=$(count_refs "$wt" 'refs/heads/')
-  count=$((count + $(count_refs "$wt" 'refs/tags/')))
-  count=$((count + $(count_refs "$wt" 'refs/firstmate/rescue/')))
-  [ "$count" -gt 0 ]
+  local ns count total=0
+  for ns in 'refs/heads/' 'refs/tags/' 'refs/firstmate/rescue/'; do
+    count=$(count_refs "$wt" "$ns") || return 2
+    count=$(printf '%s' "$count" | tr -d '[:space:]')
+    case "$count" in
+      '' | *[!0-9]*) return 2 ;;
+    esac
+    total=$((total + count))
+  done
+  [ "$total" -gt 0 ]
 }
 
 head_covered_by_remotes() {
   local wt=$1
   local unremoted
-  unremoted=$(git -C "$wt" rev-list --count HEAD --not --remotes 2>/dev/null) || return 1
+  unremoted=$(git -C "$wt" rev-list --count HEAD --not --remotes 2>/dev/null) || return 2
   case "$unremoted" in
-    '' | *[!0-9]*) return 1 ;;
+    '' | *[!0-9]*) return 2 ;;
   esac
   [ "$unremoted" -eq 0 ]
 }
 
 check_head_reachable() {
   local wt=$1
-  local unique_count
-  if ! has_durable_refs "$wt"; then
-    if head_covered_by_remotes "$wt"; then
+  local unique_count durable_rc=0 remote_rc=0
+
+  has_durable_refs "$wt" || durable_rc=$?
+  if [ "$durable_rc" -eq 2 ]; then
+    return 5
+  fi
+  if [ "$durable_rc" -ne 0 ]; then
+    head_covered_by_remotes "$wt" || remote_rc=$?
+    if [ "$remote_rc" -eq 2 ]; then
+      return 5
+    fi
+    if [ "$remote_rc" -eq 0 ]; then
       return 3
     fi
     return 2
   fi
+
   unique_count=$(git -C "$wt" rev-list --count HEAD --not --branches --tags \
-    --glob='refs/firstmate/rescue/*' 2>/dev/null) || return 2
+    --glob='refs/firstmate/rescue/*' 2>/dev/null) || return 5
   case "$unique_count" in
-    '' | *[!0-9]*) return 2 ;;
+    '' | *[!0-9]*) return 5 ;;
   esac
   if [ "$unique_count" -gt 0 ]; then
     return 2
@@ -172,20 +202,33 @@ if ! head_is_inspectable "$WT"; then
   exit 1
 fi
 
-if is_dirty "$WT"; then
+dirty_rc=0
+is_dirty "$WT" || dirty_rc=$?
+
+if [ "$dirty_rc" -eq 0 ]; then
   echo "unsafe: dirty worktree at $WT" >&2
+  exit 1
+elif [ "$dirty_rc" -eq 2 ]; then
+  echo "unsafe: cannot determine whether $WT is dirty" >&2
   exit 1
 fi
 
 rc=0
 check_head_reachable "$WT" || rc=$?
 
-if [ $rc -eq 2 ]; then
-  echo "unsafe: HEAD contains commits not reachable from durable refs in $WT" >&2
-  exit 2
-elif [ $rc -eq 3 ]; then
-  echo "unsafe: HEAD commits covered only by remote-tracking refs (prunable) in $WT" >&2
-  exit 3
-fi
+case "$rc" in
+  2)
+    echo "unsafe: HEAD contains commits not reachable from durable refs in $WT" >&2
+    exit 2
+    ;;
+  3)
+    echo "unsafe: HEAD commits covered only by remote-tracking refs (prunable) in $WT" >&2
+    exit 3
+    ;;
+  5)
+    echo "unsafe: cannot compute HEAD reachability in $WT" >&2
+    exit 2
+    ;;
+esac
 
 exit 0

--- a/bin/fm-treehouse-pool-sweep.sh
+++ b/bin/fm-treehouse-pool-sweep.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# bin/fm-treehouse-pool-sweep.sh - Pre-acquire worktree pool safety sweep.
+#
+# This is a MITIGATION (not a fix) for the worktree reuse incident. It inspects
+# pooled worktrees before acquisition and refuses to request one when unsafe pool
+# state is observed. The upstream invariant is: "No consumer can reuse a worktree
+# whose state is unsafe." This mitigation can only observe and refuse; it cannot
+# enforce the invariant across all consumers.
+#
+# Two structural gaps this mitigation cannot close:
+#   1. A direct `treehouse get` by anything other than firstmate bypasses this sweep.
+#   2. Another firstmate home can race between sweep and acquire.
+#
+# Usage: fm-treehouse-pool-sweep.sh <worktree-path>
+# Exit codes:
+#   0 - Worktree is safe to acquire (or sweep is disabled)
+#   1 - Worktree is unsafe: dirty
+#   2 - Worktree is unsafe: HEAD contains commits not reachable from durable refs
+#   3 - Worktree is unsafe: HEAD covered only by remote-tracking refs (prunable)
+#   4 - Worktree does not exist
+set -euo pipefail
+
+usage() {
+  cat <<EOF
+fm-treehouse-pool-sweep.sh - Pre-acquire worktree pool safety sweep
+
+This is a MITIGATION for the worktree reuse incident (not a fix for the
+underlying invariant). It inspects pooled worktrees before acquisition and
+refuses to request one when unsafe pool state is observed.
+
+Usage: fm-treehouse-pool-sweep.sh <worktree-path>
+
+The sweep checks two conditions and refuses on either:
+  1. Dirty worktree: tracked modifications, staged changes, or untracked
+     non-ignored files.
+  2. HEAD contains at least one commit not reachable from an approved durable ref:
+     - refs/heads/* (local branches)
+     - refs/tags/* (tags)
+     - refs/firstmate/rescue/* (reserved rescue namespace)
+
+Reflogs are NOT refs. A commit reachable only from a reflog is unreferenced.
+
+For refs/remotes/*: they are counted for reachability so an ordinary freshly-
+checked-out pool worktree is not falsely refused, but the case where HEAD's
+commits are covered ONLY by remote-tracking refs (and no local head or tag) is
+classified as unsafe.
+
+Exit codes:
+  0 - Worktree is safe to acquire (or sweep is disabled)
+  1 - Worktree is unsafe: dirty
+  2 - Worktree is unsafe: HEAD contains commits not reachable from durable refs
+  3 - Worktree is unsafe: HEAD covered only by remote-tracking refs (prunable)
+  4 - Worktree does not exist
+
+Activation:
+  The sweep is disabled by default. To enable, create:
+    $HOME/.firstmate/config/worktree-pool-sweep
+  containing "on" (or any non-empty value).
+
+This mitigation is distinct from the upstream Treehouse invariant:
+  - MITIGATION: "Firstmate refuses to request a worktree when it observes unsafe pool state."
+  - INVARIANT:  "No consumer can reuse a worktree whose state is unsafe."
+
+Structural gaps this mitigation cannot close:
+  1. A direct treehouse get by anything other than firstmate bypasses the sweep.
+  2. Another firstmate home can race between sweep and acquire:
+
+     T1  Firstmate A sweeps -> safe
+     T2  Firstmate B acquires/modifies the same pool
+     T3  Firstmate A calls treehouse get
+
+     This race can cause the worktree to be unsafe when Firstmate A uses it.
+     The eventual Treehouse fix must kill this atomically at allocation time.
+EOF
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+WT="${1:-}"
+if [ -z "$WT" ]; then
+  echo "error: worktree path required" >&2
+  usage >&2
+  exit 4
+fi
+
+CONFIG_DIR="${FM_ROOT:-$HOME/.firstmate}/config"
+SWEEP_CONFIG="$CONFIG_DIR/worktree-pool-sweep"
+
+is_sweep_enabled() {
+  if [ -f "$SWEEP_CONFIG" ]; then
+    local val
+    val=$(cat "$SWEEP_CONFIG" 2>/dev/null | tr -d '[:space:]')
+    [ -n "$val" ] && [ "$val" != "off" ]
+  else
+    return 1
+  fi
+}
+
+if ! is_sweep_enabled; then
+  exit 0
+fi
+
+if [ ! -d "$WT" ]; then
+  exit 4
+fi
+
+is_dirty() {
+  local wt=$1
+  if ! git -C "$wt" diff-index --quiet --ignore-submodules HEAD 2>/dev/null; then
+    return 0
+  fi
+  if ! git -C "$wt" diff-index --quiet --ignore-submodules --cached HEAD 2>/dev/null; then
+    return 0
+  fi
+  local untracked
+  untracked=$(git -C "$wt" ls-files --others --exclude-standard 2>/dev/null)
+  if [ -n "$untracked" ]; then
+    return 0
+  fi
+  return 1
+}
+
+count_refs() {
+  local wt=$1 pattern=$2
+  git -C "$wt" for-each-ref --format='%(refname)' "$pattern" 2>/dev/null | wc -l
+}
+
+has_durable_refs() {
+  local wt=$1
+  local count
+  count=$(count_refs "$wt" 'refs/heads/')
+  count=$((count + $(count_refs "$wt" 'refs/tags/')))
+  count=$((count + $(count_refs "$wt" 'refs/firstmate/rescue/')))
+  [ "$count" -gt 0 ]
+}
+
+has_only_remote_refs() {
+  local wt=$1
+  local local_count remote_count
+  local_count=$(count_refs "$wt" 'refs/heads/')
+  local_count=$((local_count + $(count_refs "$wt" 'refs/tags/')))
+  remote_count=$(count_refs "$wt" 'refs/remotes/')
+  [ "$local_count" -eq 0 ] && [ "$remote_count" -gt 0 ]
+}
+
+check_head_reachable() {
+  local wt=$1
+  local unique_count
+  if ! has_durable_refs "$wt"; then
+    if has_only_remote_refs "$wt"; then
+      return 3
+    fi
+    return 2
+  fi
+  local refs_list
+  refs_list=$(git -C "$wt" for-each-ref --format='%(refname)' \
+    'refs/heads/' 'refs/tags/' 'refs/firstmate/rescue/' 2>/dev/null)
+  if [ -z "$refs_list" ]; then
+    if has_only_remote_refs "$wt"; then
+      return 3
+    fi
+    return 2
+  fi
+  unique_count=$(git -C "$wt" rev-list HEAD --not $refs_list 2>/dev/null | wc -l)
+  if [ "$unique_count" -gt 0 ]; then
+    return 2
+  fi
+  return 0
+}
+
+if is_dirty "$WT"; then
+  echo "unsafe: dirty worktree at $WT" >&2
+  exit 1
+fi
+
+check_head_reachable "$WT"
+rc=$?
+
+if [ $rc -eq 2 ]; then
+  echo "unsafe: HEAD contains commits not reachable from durable refs in $WT" >&2
+  exit 2
+elif [ $rc -eq 3 ]; then
+  echo "unsafe: HEAD commits covered only by remote-tracking refs (prunable) in $WT" >&2
+  exit 3
+fi
+
+exit 0

--- a/bin/fm-treehouse-pool-sweep.sh
+++ b/bin/fm-treehouse-pool-sweep.sh
@@ -17,6 +17,12 @@
 #      - refs/tags/* (tags)
 #      - refs/firstmate/rescue/* (reserved rescue namespace)
 #
+# The branch HEAD is attached to does NOT count as one of those durable refs.
+# fm-spawn.sh's freshen_spawn_worktree_base hard-resets the checked-out branch
+# onto origin's default branch immediately after acquisition, so a commit held
+# only by that branch is about to be discarded, not preserved: counting it would
+# green-light exactly the unlanded lane work this sweep exists to protect.
+#
 # Reflogs are NOT refs. A commit reachable only from a reflog is unreferenced.
 #
 # A question git cannot answer - an unreadable HEAD, a corrupt ref database, an
@@ -143,6 +149,36 @@ count_refs() {
   git -C "$wt" for-each-ref --format='%(refname)' "$pattern" 2>/dev/null | wc -l
 }
 
+# The full ref name of the branch HEAD is attached to; empty output when HEAD is
+# detached. Returns 2 when git cannot answer the question.
+attached_branch_ref() {
+  local wt=$1 out rc=0
+  out=$(git -C "$wt" symbolic-ref --quiet HEAD 2>/dev/null) || rc=$?
+  case "$rc" in
+    0) printf '%s\n' "$out" ;;
+    1) : ;;
+    *) return 2 ;;
+  esac
+}
+
+# Every ref that would still hold HEAD's commits after the checked-out branch is
+# hard-reset, printed as rev-list exclusions. Remote-tracking refs are included
+# (the reset target itself lives there); the attached branch is not.
+protecting_refs() {
+  local wt=$1 attached=$2 all ref
+  all=$(git -C "$wt" for-each-ref --format='%(refname)' \
+    refs/heads refs/tags refs/firstmate/rescue refs/remotes 2>/dev/null) || return 2
+  while IFS= read -r ref; do
+    [ -n "$ref" ] || continue
+    if [ -n "$attached" ] && [ "$ref" = "$attached" ]; then
+      continue
+    fi
+    printf '^%s\n' "$ref"
+  done <<EOF
+$all
+EOF
+}
+
 has_durable_refs() {
   local wt=$1
   local ns count total=0
@@ -169,7 +205,7 @@ head_covered_by_remotes() {
 
 check_head_reachable() {
   local wt=$1
-  local unique_count durable_rc=0 remote_rc=0
+  local attached excludes unique_count durable_rc=0 remote_rc=0
 
   has_durable_refs "$wt" || durable_rc=$?
   if [ "$durable_rc" -eq 2 ]; then
@@ -186,8 +222,14 @@ check_head_reachable() {
     return 2
   fi
 
-  unique_count=$(git -C "$wt" rev-list --count HEAD --not --branches --tags \
-    --glob='refs/firstmate/rescue/*' 2>/dev/null) || return 5
+  attached=$(attached_branch_ref "$wt") || return 5
+  excludes=$(protecting_refs "$wt" "$attached") || return 5
+  if [ -n "$excludes" ]; then
+    unique_count=$(printf '%s\n' "$excludes" \
+      | git -C "$wt" rev-list --count --stdin HEAD 2>/dev/null) || return 5
+  else
+    unique_count=$(git -C "$wt" rev-list --count HEAD 2>/dev/null) || return 5
+  fi
   case "$unique_count" in
     '' | *[!0-9]*) return 5 ;;
   esac

--- a/bin/fm-treehouse-pool-sweep.sh
+++ b/bin/fm-treehouse-pool-sweep.sh
@@ -56,8 +56,12 @@ Exit codes:
 
 Activation:
   The sweep is disabled by default. To enable, create:
-    $HOME/.firstmate/config/worktree-pool-sweep
+    \$FM_HOME/config/worktree-pool-sweep
   containing "on" (or any non-empty value other than "off").
+  The config dir is \$FM_CONFIG_OVERRIDE when set, otherwise \$FM_HOME/config,
+  and \$FM_HOME defaults to the firstmate repo root - the same resolution every
+  other firstmate script uses, so an enable written for one home applies to
+  that home only.
   A missing file, an empty file, or the value "off" leaves the sweep disabled.
 
 This mitigation is distinct from the upstream Treehouse invariant:
@@ -89,7 +93,10 @@ if [ -z "$WT" ]; then
   exit 64
 fi
 
-CONFIG_DIR="${FM_ROOT:-$HOME/.firstmate}/config"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+CONFIG_DIR="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 SWEEP_CONFIG="$CONFIG_DIR/worktree-pool-sweep"
 
 is_sweep_enabled() {
@@ -149,11 +156,21 @@ has_only_remote_refs() {
   [ "$local_count" -eq 0 ] && [ "$remote_count" -gt 0 ]
 }
 
+head_covered_by_remotes() {
+  local wt=$1
+  local unremoted
+  unremoted=$(git -C "$wt" rev-list --count HEAD --not --remotes 2>/dev/null) || return 1
+  case "$unremoted" in
+    '' | *[!0-9]*) return 1 ;;
+  esac
+  [ "$unremoted" -eq 0 ]
+}
+
 check_head_reachable() {
   local wt=$1
   local unique_count
   if ! has_durable_refs "$wt"; then
-    if has_only_remote_refs "$wt"; then
+    if has_only_remote_refs "$wt" && head_covered_by_remotes "$wt"; then
       return 3
     fi
     return 2

--- a/bin/fm-treehouse-pool-sweep.sh
+++ b/bin/fm-treehouse-pool-sweep.sh
@@ -18,6 +18,7 @@
 #   2 - Worktree is unsafe: HEAD contains commits not reachable from durable refs
 #   3 - Worktree is unsafe: HEAD covered only by remote-tracking refs (prunable)
 #   4 - Worktree does not exist
+#  64 - Usage error (no worktree path given)
 set -euo pipefail
 
 usage() {
@@ -51,6 +52,7 @@ Exit codes:
   2 - Worktree is unsafe: HEAD contains commits not reachable from durable refs
   3 - Worktree is unsafe: HEAD covered only by remote-tracking refs (prunable)
   4 - Worktree does not exist
+ 64 - Usage error (no worktree path given)
 
 Activation:
   The sweep is disabled by default. To enable, create:
@@ -83,7 +85,7 @@ WT="${1:-}"
 if [ -z "$WT" ]; then
   echo "error: worktree path required" >&2
   usage >&2
-  exit 4
+  exit 64
 fi
 
 CONFIG_DIR="${FM_ROOT:-$HOME/.firstmate}/config"
@@ -158,12 +160,6 @@ check_head_reachable() {
   local refs_list
   refs_list=$(git -C "$wt" for-each-ref --format='%(refname)' \
     'refs/heads/' 'refs/tags/' 'refs/firstmate/rescue/' 2>/dev/null)
-  if [ -z "$refs_list" ]; then
-    if has_only_remote_refs "$wt"; then
-      return 3
-    fi
-    return 2
-  fi
   unique_count=$(git -C "$wt" rev-list HEAD --not $refs_list 2>/dev/null | wc -l)
   if [ "$unique_count" -gt 0 ]; then
     return 2
@@ -176,8 +172,8 @@ if is_dirty "$WT"; then
   exit 1
 fi
 
-check_head_reachable "$WT"
-rc=$?
+rc=0
+check_head_reachable "$WT" || rc=$?
 
 if [ $rc -eq 2 ]; then
   echo "unsafe: HEAD contains commits not reachable from durable refs in $WT" >&2

--- a/bin/fm-treehouse-pool-sweep.sh
+++ b/bin/fm-treehouse-pool-sweep.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# bin/fm-treehouse-pool-sweep.sh - Pre-acquire worktree pool safety sweep.
+# fm-treehouse-pool-sweep.sh - Pre-acquire worktree pool safety sweep
 #
 # This is a MITIGATION (not a fix) for the worktree reuse incident. It inspects
 # pooled worktrees before acquisition and refuses to request one when unsafe pool
@@ -7,78 +7,62 @@
 # whose state is unsafe." This mitigation can only observe and refuse; it cannot
 # enforce the invariant across all consumers.
 #
-# Two structural gaps this mitigation cannot close:
-#   1. A direct `treehouse get` by anything other than firstmate bypasses this sweep.
-#   2. Another firstmate home can race between sweep and acquire.
-#
 # Usage: fm-treehouse-pool-sweep.sh <worktree-path>
+#
+# The sweep checks two conditions and refuses on either:
+#   1. Dirty worktree: tracked modifications, staged changes, or untracked
+#      non-ignored files. A HEAD that cannot be inspected at all counts as a
+#      refusal too, reported separately so the diagnostic is not "dirty".
+#   2. HEAD contains at least one commit not reachable from an approved durable ref:
+#      - refs/heads/* (local branches)
+#      - refs/tags/* (tags)
+#      - refs/firstmate/rescue/* (reserved rescue namespace)
+#
+# Reflogs are NOT refs. A commit reachable only from a reflog is unreferenced.
+#
+# For refs/remotes/*: they are counted for reachability so an ordinary freshly-
+# checked-out pool worktree is not falsely refused, but the case where HEAD's
+# commits are covered ONLY by remote-tracking refs (and no local head or tag) is
+# classified as unsafe.
+#
 # Exit codes:
 #   0 - Worktree is safe to acquire (or sweep is disabled)
-#   1 - Worktree is unsafe: dirty
+#   1 - Worktree is unsafe: dirty, or HEAD cannot be inspected
 #   2 - Worktree is unsafe: HEAD contains commits not reachable from durable refs
 #   3 - Worktree is unsafe: HEAD covered only by remote-tracking refs (prunable)
 #   4 - Worktree does not exist
 #  64 - Usage error (no worktree path given)
+#
+# Activation:
+#   The sweep is disabled by default. To enable, create:
+#     $FM_HOME/config/worktree-pool-sweep
+#   containing "on" (or any non-empty value other than "off").
+#   The config dir is $FM_CONFIG_OVERRIDE when set, otherwise $FM_HOME/config,
+#   and $FM_HOME defaults to the firstmate repo root - the same resolution every
+#   other firstmate script uses, so an enable written for one home applies to
+#   that home only.
+#   A missing file, an empty file, or the value "off" leaves the sweep disabled.
+#
+# This mitigation is distinct from the upstream Treehouse invariant:
+#   - MITIGATION: "Firstmate refuses to request a worktree when it observes unsafe pool state."
+#   - INVARIANT:  "No consumer can reuse a worktree whose state is unsafe."
+#
+# Structural gaps this mitigation cannot close:
+#   1. A direct treehouse get by anything other than firstmate bypasses the sweep.
+#   2. Another firstmate home can race between sweep and acquire:
+#
+#      T1  Firstmate A sweeps -> safe
+#      T2  Firstmate B acquires/modifies the same pool
+#      T3  Firstmate A calls treehouse get
+#
+#      This race can cause the worktree to be unsafe when Firstmate A uses it.
+#      The eventual Treehouse fix must kill this atomically at allocation time.
 set -euo pipefail
 
 usage() {
-  cat <<EOF
-fm-treehouse-pool-sweep.sh - Pre-acquire worktree pool safety sweep
-
-This is a MITIGATION for the worktree reuse incident (not a fix for the
-underlying invariant). It inspects pooled worktrees before acquisition and
-refuses to request one when unsafe pool state is observed.
-
-Usage: fm-treehouse-pool-sweep.sh <worktree-path>
-
-The sweep checks two conditions and refuses on either:
-  1. Dirty worktree: tracked modifications, staged changes, or untracked
-     non-ignored files.
-  2. HEAD contains at least one commit not reachable from an approved durable ref:
-     - refs/heads/* (local branches)
-     - refs/tags/* (tags)
-     - refs/firstmate/rescue/* (reserved rescue namespace)
-
-Reflogs are NOT refs. A commit reachable only from a reflog is unreferenced.
-
-For refs/remotes/*: they are counted for reachability so an ordinary freshly-
-checked-out pool worktree is not falsely refused, but the case where HEAD's
-commits are covered ONLY by remote-tracking refs (and no local head or tag) is
-classified as unsafe.
-
-Exit codes:
-  0 - Worktree is safe to acquire (or sweep is disabled)
-  1 - Worktree is unsafe: dirty
-  2 - Worktree is unsafe: HEAD contains commits not reachable from durable refs
-  3 - Worktree is unsafe: HEAD covered only by remote-tracking refs (prunable)
-  4 - Worktree does not exist
- 64 - Usage error (no worktree path given)
-
-Activation:
-  The sweep is disabled by default. To enable, create:
-    \$FM_HOME/config/worktree-pool-sweep
-  containing "on" (or any non-empty value other than "off").
-  The config dir is \$FM_CONFIG_OVERRIDE when set, otherwise \$FM_HOME/config,
-  and \$FM_HOME defaults to the firstmate repo root - the same resolution every
-  other firstmate script uses, so an enable written for one home applies to
-  that home only.
-  A missing file, an empty file, or the value "off" leaves the sweep disabled.
-
-This mitigation is distinct from the upstream Treehouse invariant:
-  - MITIGATION: "Firstmate refuses to request a worktree when it observes unsafe pool state."
-  - INVARIANT:  "No consumer can reuse a worktree whose state is unsafe."
-
-Structural gaps this mitigation cannot close:
-  1. A direct treehouse get by anything other than firstmate bypasses the sweep.
-  2. Another firstmate home can race between sweep and acquire:
-
-     T1  Firstmate A sweeps -> safe
-     T2  Firstmate B acquires/modifies the same pool
-     T3  Firstmate A calls treehouse get
-
-     This race can cause the worktree to be unsafe when Firstmate A uses it.
-     The eventual Treehouse fix must kill this atomically at allocation time.
-EOF
+  # The whole leading comment block, ending at the first line that is not a
+  # comment, so --help cannot drift away from the header above.
+  sed -n '2,${/^#/!q;p;}' "$0" | sed 's/^# \{0,1\}//'
 }
 
 if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
@@ -95,7 +79,7 @@ fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
-FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+FM_HOME="${FM_HOME:-$FM_ROOT}"
 CONFIG_DIR="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 SWEEP_CONFIG="$CONFIG_DIR/worktree-pool-sweep"
 
@@ -116,6 +100,11 @@ fi
 if [ ! -d "$WT" ]; then
   exit 4
 fi
+
+head_is_inspectable() {
+  local wt=$1
+  git -C "$wt" rev-parse --verify --quiet HEAD >/dev/null 2>&1
+}
 
 is_dirty() {
   local wt=$1
@@ -177,6 +166,11 @@ check_head_reachable() {
   fi
   return 0
 }
+
+if ! head_is_inspectable "$WT"; then
+  echo "unsafe: cannot inspect HEAD at $WT" >&2
+  exit 1
+fi
 
 if is_dirty "$WT"; then
   echo "unsafe: dirty worktree at $WT" >&2

--- a/bin/fm-treehouse-pool-sweep.sh
+++ b/bin/fm-treehouse-pool-sweep.sh
@@ -119,6 +119,7 @@ fi
 
 is_dirty() {
   local wt=$1
+  git -C "$wt" update-index -q --ignore-submodules --refresh >/dev/null 2>&1 || true
   if ! git -C "$wt" diff-index --quiet --ignore-submodules HEAD 2>/dev/null; then
     return 0
   fi
@@ -147,15 +148,6 @@ has_durable_refs() {
   [ "$count" -gt 0 ]
 }
 
-has_only_remote_refs() {
-  local wt=$1
-  local local_count remote_count
-  local_count=$(count_refs "$wt" 'refs/heads/')
-  local_count=$((local_count + $(count_refs "$wt" 'refs/tags/')))
-  remote_count=$(count_refs "$wt" 'refs/remotes/')
-  [ "$local_count" -eq 0 ] && [ "$remote_count" -gt 0 ]
-}
-
 head_covered_by_remotes() {
   local wt=$1
   local unremoted
@@ -170,7 +162,7 @@ check_head_reachable() {
   local wt=$1
   local unique_count
   if ! has_durable_refs "$wt"; then
-    if has_only_remote_refs "$wt" && head_covered_by_remotes "$wt"; then
+    if head_covered_by_remotes "$wt"; then
       return 3
     fi
     return 2

--- a/bin/fm-treehouse-pool-sweep.sh
+++ b/bin/fm-treehouse-pool-sweep.sh
@@ -57,7 +57,8 @@ Exit codes:
 Activation:
   The sweep is disabled by default. To enable, create:
     $HOME/.firstmate/config/worktree-pool-sweep
-  containing "on" (or any non-empty value).
+  containing "on" (or any non-empty value other than "off").
+  A missing file, an empty file, or the value "off" leaves the sweep disabled.
 
 This mitigation is distinct from the upstream Treehouse invariant:
   - MITIGATION: "Firstmate refuses to request a worktree when it observes unsafe pool state."
@@ -157,10 +158,11 @@ check_head_reachable() {
     fi
     return 2
   fi
-  local refs_list
-  refs_list=$(git -C "$wt" for-each-ref --format='%(refname)' \
-    'refs/heads/' 'refs/tags/' 'refs/firstmate/rescue/' 2>/dev/null)
-  unique_count=$(git -C "$wt" rev-list HEAD --not $refs_list 2>/dev/null | wc -l)
+  unique_count=$(git -C "$wt" rev-list --count HEAD --not --branches --tags \
+    --glob='refs/firstmate/rescue/*' 2>/dev/null) || return 2
+  case "$unique_count" in
+    '' | *[!0-9]*) return 2 ;;
+  esac
   if [ "$unique_count" -gt 0 ]; then
     return 2
   fi

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -137,10 +137,13 @@ When active, `bin/fm-spawn.sh` runs `bin/fm-treehouse-pool-sweep.sh` against the
 
 - Dirty worktree: tracked modifications, staged changes, or untracked non-ignored files.
 - HEAD contains commits not reachable from an approved durable ref: local branches (`refs/heads/*`), tags (`refs/tags/*`), or rescue refs (`refs/firstmate/rescue/*`). Reflogs are not refs, so a commit reachable only from a reflog is unreferenced.
+  The branch HEAD is attached to is not one of those durable refs: the spawn path hard-resets it onto origin's default branch right after acquisition, so a commit held only by that branch is about to be discarded rather than preserved.
 
 It also fails closed when git cannot answer a probe - an unreadable HEAD, a corrupt ref database, an unreadable object - refusing under the same exit code as the negative answer it resembles but with its own diagnostic.
 
-A refusal aborts the spawn with an error naming the worktree, the sweep exit code, and this config file; the exit codes, diagnostics, and the remote-tracking-ref reachability rules are owned by `bin/fm-treehouse-pool-sweep.sh`'s header (`bin/fm-treehouse-pool-sweep.sh --help`).
+A refusal aborts the spawn with an error naming the worktree, the sweep exit code, and this config file.
+The refused pool slot stays held and its task window stays open, and the error says so: the sweep refuses precisely when the worktree may hold work nothing else references, so returning the slot there would discard exactly that work.
+An operator returns it by hand once its work is safe; the exit codes, diagnostics, and the remote-tracking-ref reachability rules are owned by `bin/fm-treehouse-pool-sweep.sh`'s header (`bin/fm-treehouse-pool-sweep.sh --help`).
 
 This is a MITIGATION for the worktree reuse incident, not a fix for the underlying Treehouse invariant that no consumer can reuse an unsafe worktree.
 Two structural gaps it cannot close: a direct `treehouse get` by anything other than firstmate bypasses the sweep, and another firstmate home can race between sweep and acquire.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -139,6 +139,8 @@ The sweep checks two conditions and refuses on either:
 
 Reflogs are NOT refs. A commit reachable only from a reflog is unreferenced.
 
+`bin/fm-treehouse-pool-sweep.sh` reports its verdict through its exit code: `0` safe (or sweep disabled), `1` dirty, `2` HEAD not reachable from durable refs, `3` HEAD covered only by remote-tracking refs, `4` worktree does not exist, `64` usage error.
+
 For `refs/remotes/*`: they are counted for reachability so an ordinary freshly-checked-out pool worktree is not falsely refused, but the case where HEAD's commits are covered ONLY by remote-tracking refs (and no local head or tag) is classified as unsafe.
 
 This is a MITIGATION for the worktree reuse incident, not a fix for the underlying Treehouse invariant.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -129,27 +129,19 @@ See [`trace-context.md`](trace-context.md) for carrier semantics, supported rout
 
 ## Worktree pool sweep (config/worktree-pool-sweep)
 
-The optional local `config/worktree-pool-sweep` file enables the pre-acquire worktree pool safety sweep.
-When present and non-empty (any value other than `off`), the sweep is activated.
+The optional local, gitignored `config/worktree-pool-sweep` file enables the pre-acquire worktree pool safety sweep, which is shipped deactivated.
+A missing file, an empty file, or the value `off` leaves the sweep inert and acquisition unchanged; any other non-empty value activates it.
 `config/` resolves the same way as for every other script - `FM_CONFIG_OVERRIDE` when set, otherwise `$FM_HOME/config` - so the enable is per firstmate home, and `bin/fm-spawn.sh` passes its own resolved config dir down to the sweep.
-The sweep inspects pooled worktrees before a spawn uses them and refuses when unsafe state is observed.
 
-The sweep checks two conditions and refuses on either:
+When active, `bin/fm-spawn.sh` runs `bin/fm-treehouse-pool-sweep.sh` against the pooled worktree before the spawn uses it and refuses on either unsafe condition:
+
 - Dirty worktree: tracked modifications, staged changes, or untracked non-ignored files.
-- HEAD contains commits not reachable from an approved durable ref: local branches (`refs/heads/*`), tags (`refs/tags/*`), or rescue refs (`refs/firstmate/rescue/*`).
+- HEAD contains commits not reachable from an approved durable ref: local branches (`refs/heads/*`), tags (`refs/tags/*`), or rescue refs (`refs/firstmate/rescue/*`). Reflogs are not refs, so a commit reachable only from a reflog is unreferenced.
 
-Reflogs are NOT refs. A commit reachable only from a reflog is unreferenced.
+A refusal aborts the spawn with an error naming the worktree, the sweep exit code, and this config file; the exit codes and the remote-tracking-ref reachability rules are owned by `bin/fm-treehouse-pool-sweep.sh`'s header (`bin/fm-treehouse-pool-sweep.sh --help`).
 
-`bin/fm-treehouse-pool-sweep.sh` reports its verdict through its exit code: `0` safe (or sweep disabled), `1` dirty, `2` HEAD not reachable from durable refs, `3` HEAD covered only by remote-tracking refs, `4` worktree does not exist, `64` usage error.
-
-For `refs/remotes/*`: they are counted for reachability so an ordinary freshly-checked-out pool worktree is not falsely refused, but the case where HEAD's commits are covered ONLY by remote-tracking refs (and no local head or tag) is classified as unsafe.
-
-This is a MITIGATION for the worktree reuse incident, not a fix for the underlying Treehouse invariant.
-Two structural gaps this mitigation cannot close:
-1. A direct `treehouse get` by anything other than firstmate bypasses the sweep.
-2. Another firstmate home can race between sweep and acquire.
-
-The sweep is currently disabled by default. Two live lanes hold pooled worktrees and must not be disturbed until they are free.
+This is a MITIGATION for the worktree reuse incident, not a fix for the underlying Treehouse invariant that no consumer can reuse an unsafe worktree.
+Two structural gaps it cannot close: a direct `treehouse get` by anything other than firstmate bypasses the sweep, and another firstmate home can race between sweep and acquire.
 
 ## Gate defaults (.no-mistakes.yaml)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -127,6 +127,27 @@ A Secondmate on a remote route is covered the same way: the primary resolves and
 The presence flag is session-scoped enablement, so it transfers at launch and is left unchanged by live convergence into a running home.
 See [`trace-context.md`](trace-context.md) for carrier semantics, supported routes, the manual fleet-restart requirement, the session boundary, and safety limits; `bin/fm-trace-context-lib.sh`'s header owns the exact mechanics, and [`verification/trace-context.md`](verification/trace-context.md) records repeatable evidence.
 
+## Worktree pool sweep (config/worktree-pool-sweep)
+
+The optional local `config/worktree-pool-sweep` file enables the pre-acquire worktree pool safety sweep.
+When present and non-empty (any value other than `off`), the sweep is activated.
+The sweep inspects pooled worktrees before a spawn uses them and refuses when unsafe state is observed.
+
+The sweep checks two conditions and refuses on either:
+- Dirty worktree: tracked modifications, staged changes, or untracked non-ignored files.
+- HEAD contains commits not reachable from an approved durable ref: local branches (`refs/heads/*`), tags (`refs/tags/*`), or rescue refs (`refs/firstmate/rescue/*`).
+
+Reflogs are NOT refs. A commit reachable only from a reflog is unreferenced.
+
+For `refs/remotes/*`: they are counted for reachability so an ordinary freshly-checked-out pool worktree is not falsely refused, but the case where HEAD's commits are covered ONLY by remote-tracking refs (and no local head or tag) is classified as unsafe.
+
+This is a MITIGATION for the worktree reuse incident, not a fix for the underlying Treehouse invariant.
+Two structural gaps this mitigation cannot close:
+1. A direct `treehouse get` by anything other than firstmate bypasses the sweep.
+2. Another firstmate home can race between sweep and acquire.
+
+The sweep is currently disabled by default. Two live lanes hold pooled worktrees and must not be disturbed until they are free.
+
 ## Gate defaults (.no-mistakes.yaml)
 
 The tracked `.no-mistakes.yaml` sets `test.evidence.store_in_repo: true` and pins `commands.lint` to `bin/fm-lint.sh` so local lint matches CI.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -138,7 +138,9 @@ When active, `bin/fm-spawn.sh` runs `bin/fm-treehouse-pool-sweep.sh` against the
 - Dirty worktree: tracked modifications, staged changes, or untracked non-ignored files.
 - HEAD contains commits not reachable from an approved durable ref: local branches (`refs/heads/*`), tags (`refs/tags/*`), or rescue refs (`refs/firstmate/rescue/*`). Reflogs are not refs, so a commit reachable only from a reflog is unreferenced.
 
-A refusal aborts the spawn with an error naming the worktree, the sweep exit code, and this config file; the exit codes and the remote-tracking-ref reachability rules are owned by `bin/fm-treehouse-pool-sweep.sh`'s header (`bin/fm-treehouse-pool-sweep.sh --help`).
+It also fails closed when git cannot answer a probe - an unreadable HEAD, a corrupt ref database, an unreadable object - refusing under the same exit code as the negative answer it resembles but with its own diagnostic.
+
+A refusal aborts the spawn with an error naming the worktree, the sweep exit code, and this config file; the exit codes, diagnostics, and the remote-tracking-ref reachability rules are owned by `bin/fm-treehouse-pool-sweep.sh`'s header (`bin/fm-treehouse-pool-sweep.sh --help`).
 
 This is a MITIGATION for the worktree reuse incident, not a fix for the underlying Treehouse invariant that no consumer can reuse an unsafe worktree.
 Two structural gaps it cannot close: a direct `treehouse get` by anything other than firstmate bypasses the sweep, and another firstmate home can race between sweep and acquire.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -131,6 +131,7 @@ See [`trace-context.md`](trace-context.md) for carrier semantics, supported rout
 
 The optional local `config/worktree-pool-sweep` file enables the pre-acquire worktree pool safety sweep.
 When present and non-empty (any value other than `off`), the sweep is activated.
+`config/` resolves the same way as for every other script - `FM_CONFIG_OVERRIDE` when set, otherwise `$FM_HOME/config` - so the enable is per firstmate home, and `bin/fm-spawn.sh` passes its own resolved config dir down to the sweep.
 The sweep inspects pooled worktrees before a spawn uses them and refuses when unsafe state is observed.
 
 The sweep checks two conditions and refuses on either:

--- a/tests/fm-spawn-pool-sweep-wiring.test.sh
+++ b/tests/fm-spawn-pool-sweep-wiring.test.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# tests/fm-spawn-pool-sweep-wiring.test.sh - the pool sweep as fm-spawn sees it.
+#
+# tests/fm-treehouse-pool-sweep.test.sh covers the sweep script's own verdicts.
+# This suite covers the other half of the mitigation: that fm-spawn.sh actually
+# consults the sweep on the acquisition path, refuses the spawn when the sweep
+# refuses, and ships DEACTIVATED so an unconfigured home spawns exactly as before.
+#
+# It drives the real spawn path with a fake terminal against a synthetic scratch
+# pool under mktemp -d; the real ~/.treehouse pool and `treehouse get` are never
+# touched.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=$(fm_test_tmproot fm-spawn-pool-sweep-wiring)
+
+# An ambient config/home override would outrank the per-case values below and
+# make the sweep read a config dir no fixture ever wrote.
+unset FM_CONFIG_OVERRIDE
+unset FM_ROOT_OVERRIDE
+
+make_spawn_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:?FM_FAKE_PANE_PATH unset}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows|has-session|new-session|new-window|kill-window|send-keys) exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse
+  printf '%s\n' "$fakebin"
+}
+
+# Builds a project + origin + one pooled worktree, exactly as the pool-base
+# freshen suite does, then leaves the pool CLEAN but parked on a commit that no
+# branch, tag or rescue ref reaches - the shape the sweep classifies unsafe(2).
+# Clean-but-unreachable is deliberate: a dirty pool is already refused later by
+# the base-freshen check, so it could not tell us whether the sweep ran at all.
+make_case() {
+  local name=$1 id=$2 case_dir home project origin pool fakebin initial orphan
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  project="$case_dir/project"
+  origin="$case_dir/origin.git"
+  pool="$case_dir/pool"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
+  printf 'codex\n' > "$home/config/crew-harness"
+  printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
+  touch "$home/state/.last-watcher-beat"
+
+  git init --quiet -b main "$project"
+  printf 'base\n' > "$project/README.md"
+  git -C "$project" add README.md
+  git -C "$project" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial
+  git clone --quiet --bare "$project" "$origin"
+  git -C "$project" remote add origin "file://$origin"
+  initial=$(git -C "$project" rev-parse HEAD)
+  git -C "$project" worktree add --quiet --detach "$pool" "$initial"
+
+  # Abandoned work left behind in the pool: committed, so the worktree is clean,
+  # but reachable from nothing durable once the detached HEAD moves on.
+  printf 'abandoned lane work\n' > "$pool/abandoned.txt"
+  git -C "$pool" add abandoned.txt
+  git -C "$pool" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm 'abandoned work'
+  orphan=$(git -C "$pool" rev-parse HEAD)
+
+  printf '%s\n' "$case_dir|$home|$project|$pool|$fakebin|$orphan"
+}
+
+read_case_record() {
+  IFS='|' read -r CASE_DIR HOME_DIR PROJECT_DIR POOL_DIR FAKEBIN_DIR ORPHAN_SHA <<EOF
+$1
+EOF
+}
+
+run_spawn() {
+  local id=$1
+  shift
+  FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
+    FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+    FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" FM_FAKE_PANE_PATH="$POOL_DIR" \
+    PATH="$FAKEBIN_DIR:$PATH" \
+    "$SPAWN" "$id" "$PROJECT_DIR" "$@" 2>&1
+}
+
+test_shipped_deactivated() {
+  local rec id out status
+  id='sweep-wiring-default-r1'
+  rec=$(make_case shipped-default "$id")
+  read_case_record "$rec"
+  [ ! -e "$HOME_DIR/config/worktree-pool-sweep" ] \
+    || fail "fixture pre-enabled the sweep; the shipped default is no config file"
+
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off)
+  status=$?
+  expect_code 0 "$status" "an unconfigured home must spawn exactly as before the sweep existed"
+  assert_contains "$out" "spawned $id" "spawn did not report success with the sweep deactivated"
+  case "$out" in
+    *"pool sweep refused"*) fail "the sweep refused a spawn in a home that never enabled it" ;;
+  esac
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" != "$ORPHAN_SHA" ] \
+    || fail "fixture did not prove the spawn actually proceeded past the sweep"
+  if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+    printf '# deactivated default: %s\n' "$(printf '%s\n' "$out" | tail -n 1)"
+  fi
+  pass "the sweep ships deactivated: an unconfigured home spawns on an unsafe pool"
+}
+
+test_enabled_sweep_refuses_the_spawn() {
+  local rec id out status
+  id='sweep-wiring-enabled-r2'
+  rec=$(make_case enabled-refusal "$id")
+  read_case_record "$rec"
+  printf 'on\n' > "$HOME_DIR/config/worktree-pool-sweep"
+
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn succeeded despite the sweep refusing the pooled worktree"
+  assert_contains "$out" "pool sweep refused worktree" \
+    "spawn did not surface the sweep's refusal to the operator"
+  assert_contains "$out" "(exit 2)" \
+    "spawn did not report the sweep's unreachable-HEAD verdict"
+  assert_contains "$out" "config/worktree-pool-sweep" \
+    "the refusal did not tell the operator where to disable the sweep"
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$ORPHAN_SHA" ] \
+    || fail "spawn moved the pooled worktree off the unreachable work it refused"
+  assert_grep 'abandoned lane work' "$POOL_DIR/abandoned.txt" \
+    "spawn discarded the abandoned pool work while refusing it"
+  if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+    printf '# enabled refusal: %s\n' "$(printf '%s\n' "$out" | grep 'pool sweep refused' | tail -n 1)"
+  fi
+  pass "an enabled sweep refuses the spawn before it can reuse an unsafe pooled worktree"
+}
+
+test_off_value_keeps_the_spawn_path_open() {
+  local rec id out status
+  id='sweep-wiring-off-r3'
+  rec=$(make_case explicit-off "$id")
+  read_case_record "$rec"
+  printf 'off\n' > "$HOME_DIR/config/worktree-pool-sweep"
+
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off)
+  status=$?
+  expect_code 0 "$status" "an explicit off must leave the acquisition path unchanged"
+  case "$out" in
+    *"pool sweep refused"*) fail "the sweep refused a spawn in a home that set it off" ;;
+  esac
+  pass "an explicit off leaves the spawn acquisition path unchanged"
+}
+
+test_shipped_deactivated
+test_enabled_sweep_refuses_the_spawn
+test_off_value_keeps_the_spawn_path_open
+
+echo "# all fm-spawn-pool-sweep-wiring tests passed"

--- a/tests/fm-spawn-pool-sweep-wiring.test.sh
+++ b/tests/fm-spawn-pool-sweep-wiring.test.sh
@@ -77,11 +77,11 @@ make_case() {
   git -C "$pool" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm 'abandoned work'
   orphan=$(git -C "$pool" rev-parse HEAD)
 
-  printf '%s\n' "$case_dir|$home|$project|$pool|$fakebin|$orphan"
+  printf '%s\n' "$home|$project|$pool|$fakebin|$orphan"
 }
 
 read_case_record() {
-  IFS='|' read -r CASE_DIR HOME_DIR PROJECT_DIR POOL_DIR FAKEBIN_DIR ORPHAN_SHA <<EOF
+  IFS='|' read -r HOME_DIR PROJECT_DIR POOL_DIR FAKEBIN_DIR ORPHAN_SHA <<EOF
 $1
 EOF
 }

--- a/tests/fm-spawn-pool-sweep-wiring.test.sh
+++ b/tests/fm-spawn-pool-sweep-wiring.test.sh
@@ -121,7 +121,7 @@ test_shipped_deactivated() {
 }
 
 test_enabled_sweep_refuses_the_spawn() {
-  local rec id out status
+  local rec id out status retention
   id='sweep-wiring-enabled-r2'
   rec=$(make_case enabled-refusal "$id")
   read_case_record "$rec"
@@ -136,6 +136,16 @@ test_enabled_sweep_refuses_the_spawn() {
     "spawn did not report the sweep's unreachable-HEAD verdict"
   assert_contains "$out" "config/worktree-pool-sweep" \
     "the refusal did not tell the operator where to disable the sweep"
+  # Returning the slot here would discard the very work the sweep refused over,
+  # so the hold is deliberate. The operator has to be told, or an acquired slot
+  # sitting on unsafe state reads as a leak.
+  retention=$(printf '%s\n' "$out" | grep 'stays held' | tail -n 1)
+  [ -n "$retention" ] \
+    || fail "the refusal did not tell the operator the pool slot is deliberately retained"
+  assert_contains "$retention" "$POOL_DIR" \
+    "the retention notice did not name the held worktree"
+  assert_contains "$retention" "window" \
+    "the retention notice did not point at the task window left open for inspection"
   [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$ORPHAN_SHA" ] \
     || fail "spawn moved the pooled worktree off the unreachable work it refused"
   assert_grep 'abandoned lane work' "$POOL_DIR/abandoned.txt" \

--- a/tests/fm-treehouse-pool-sweep.test.sh
+++ b/tests/fm-treehouse-pool-sweep.test.sh
@@ -216,6 +216,31 @@ test_allows_stat_dirty_but_clean_worktree() {
   pass "allows a stat-dirty worktree whose content matches HEAD"
 }
 
+# A HEAD git cannot resolve (unborn, or a worktree whose repo is unreadable)
+# makes the dirty probe exit 128. That must still refuse, but the operator is
+# told the real condition instead of being sent looking for uncommitted work.
+test_refuses_uninspectable_head_with_its_own_diagnostic() {
+  local tmp config_dir rc err
+  tmp=$(fm_test_tmproot sweep-unborn-head)
+  config_dir="$tmp/config"
+  fm_config_sweep_on "$config_dir"
+
+  fm_create_test_repo "$tmp/repo"
+  cd "$tmp/repo" || exit 1
+  git rev-parse --verify --quiet HEAD >/dev/null 2>&1 \
+    && fail "unborn HEAD: fixture already has a commit"
+
+  err=$(FM_HOME="$tmp" "$SWEEP" "$tmp/repo" 2>&1 >/dev/null)
+  rc=$?
+  [ "$rc" -eq 1 ] || fail "unborn HEAD: expected exit 1, got $rc"
+  assert_contains "$err" "cannot inspect HEAD" \
+    "unborn HEAD: missing the cannot-inspect diagnostic"
+  case "$err" in
+    *"dirty worktree"*) fail "unborn HEAD: reported as dirty, which it is not" ;;
+  esac
+  pass "refuses an uninspectable HEAD with its own diagnostic, not 'dirty'"
+}
+
 test_refuses_untracked_files() {
   local tmp config_dir
   tmp=$(fm_test_tmproot sweep-untracked)
@@ -544,6 +569,7 @@ test_refuses_dirty_worktree
 test_refuses_staged_changes
 test_refuses_staged_change_restored_in_worktree
 test_allows_stat_dirty_but_clean_worktree
+test_refuses_uninspectable_head_with_its_own_diagnostic
 test_refuses_untracked_files
 test_allows_branch_reachable_head
 test_allows_tag_reachable_head

--- a/tests/fm-treehouse-pool-sweep.test.sh
+++ b/tests/fm-treehouse-pool-sweep.test.sh
@@ -1,0 +1,322 @@
+#!/usr/bin/env bash
+# tests/fm-treehouse-pool-sweep.test.sh - Test suite for worktree pool sweep.
+#
+# Tests the pre-acquire worktree pool safety sweep. Runs against synthetic scratch
+# pools under mktemp -d, never touching the real ~/.treehouse pool or invoking
+# treehouse get.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SWEEP="$ROOT/bin/fm-treehouse-pool-sweep.sh"
+
+fm_create_bare_repo() {
+  local path=$1
+  mkdir -p "$path"
+  git init --bare "$path" 2>/dev/null
+}
+
+fm_create_test_repo() {
+  local path=$1
+  mkdir -p "$path"
+  git init "$path" 2>/dev/null
+  git -C "$path" config user.email "test@example.com"
+  git -C "$path" config user.name "Test"
+}
+
+fm_config_sweep_on() {
+  local config_dir=$1
+  mkdir -p "$config_dir"
+  echo "on" > "$config_dir/worktree-pool-sweep"
+}
+
+fm_config_sweep_off() {
+  local config_dir=$1
+  mkdir -p "$config_dir"
+  echo "off" > "$config_dir/worktree-pool-sweep"
+}
+
+test_disabled_by_default() {
+  local tmp config_dir
+  tmp=$(fm_test_tmproot sweep-disabled)
+  config_dir="$tmp/config"
+  mkdir -p "$config_dir"
+
+  fm_create_test_repo "$tmp/repo"
+  cd "$tmp/repo" || exit 1
+  touch file.txt
+  git add file.txt
+  git commit -m "initial" 2>/dev/null
+
+  FM_ROOT="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
+  rc=$?
+  [ "$rc" -eq 0 ] || fail "disabled by default: expected exit 0, got $rc"
+  pass "sweep is disabled by default"
+}
+
+test_refuses_dirty_worktree() {
+  local tmp config_dir
+  tmp=$(fm_test_tmproot sweep-dirty)
+  config_dir="$tmp/config"
+  fm_config_sweep_on "$config_dir"
+
+  fm_create_test_repo "$tmp/repo"
+  cd "$tmp/repo" || exit 1
+  touch file.txt
+  git add file.txt
+  git commit -m "initial" 2>/dev/null
+  echo "modified" > file.txt
+
+  FM_ROOT="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
+  rc=$?
+  [ "$rc" -eq 1 ] || fail "dirty worktree: expected exit 1, got $rc"
+  pass "refuses dirty worktree"
+}
+
+test_refuses_staged_changes() {
+  local tmp config_dir
+  tmp=$(fm_test_tmproot sweep-staged)
+  config_dir="$tmp/config"
+  fm_config_sweep_on "$config_dir"
+
+  fm_create_test_repo "$tmp/repo"
+  cd "$tmp/repo" || exit 1
+  touch file.txt
+  git add file.txt
+  echo "staged" > staged.txt
+  git add staged.txt
+
+  FM_ROOT="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
+  rc=$?
+  [ "$rc" -eq 1 ] || fail "staged changes: expected exit 1, got $rc"
+  pass "refuses staged changes"
+}
+
+test_refuses_untracked_files() {
+  local tmp config_dir
+  tmp=$(fm_test_tmproot sweep-untracked)
+  config_dir="$tmp/config"
+  fm_config_sweep_on "$config_dir"
+
+  fm_create_test_repo "$tmp/repo"
+  cd "$tmp/repo" || exit 1
+  touch file.txt
+  git add file.txt
+  git commit -m "initial" 2>/dev/null
+  touch untracked.txt
+
+  FM_ROOT="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
+  rc=$?
+  [ "$rc" -eq 1 ] || fail "untracked files: expected exit 1, got $rc"
+  pass "refuses untracked files"
+}
+
+test_allows_branch_reachable_head() {
+  local tmp config_dir
+  tmp=$(fm_test_tmproot sweep-branch-reachable)
+  config_dir="$tmp/config"
+  fm_config_sweep_on "$config_dir"
+
+  fm_create_test_repo "$tmp/repo"
+  cd "$tmp/repo" || exit 1
+  touch file.txt
+  git add file.txt
+  git commit -m "initial" 2>/dev/null
+  git checkout -b feature 2>/dev/null
+  touch feature.txt
+  git add feature.txt
+  git commit -m "feature work" 2>/dev/null
+  git checkout main 2>/dev/null
+
+  FM_ROOT="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
+  rc=$?
+  [ "$rc" -eq 0 ] || fail "branch reachable: expected exit 0, got $rc"
+  pass "allows branch-reachable HEAD"
+}
+
+test_allows_tag_reachable_head() {
+  local tmp config_dir
+  tmp=$(fm_test_tmproot sweep-tag-reachable)
+  config_dir="$tmp/config"
+  fm_config_sweep_on "$config_dir"
+
+  fm_create_test_repo "$tmp/repo"
+  cd "$tmp/repo" || exit 1
+  touch file.txt
+  git add file.txt
+  git commit -m "initial" 2>/dev/null
+  git tag v1.0.0 2>/dev/null
+
+  FM_ROOT="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
+  rc=$?
+  [ "$rc" -eq 0 ] || fail "tag reachable: expected exit 0, got $rc"
+  pass "allows tag-reachable HEAD"
+}
+
+test_allows_detached_head_fully_in_main() {
+  local tmp config_dir
+  tmp=$(fm_test_tmproot sweep-detached-main)
+  config_dir="$tmp/config"
+  fm_config_sweep_on "$config_dir"
+
+  fm_create_test_repo "$tmp/repo"
+  cd "$tmp/repo" || exit 1
+  touch file.txt
+  git add file.txt
+  git commit -m "initial" 2>/dev/null
+  main_commit=$(git rev-parse HEAD)
+  git checkout "$main_commit" 2>/dev/null
+
+  FM_ROOT="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
+  rc=$?
+  [ "$rc" -eq 0 ] || fail "detached in main: expected exit 0, got $rc"
+  pass "allows detached HEAD fully contained in main"
+}
+
+test_refuses_reflog_only_reachability() {
+  local tmp config_dir
+  tmp=$(fm_test_tmproot sweep-reflog-only)
+  config_dir="$tmp/config"
+  fm_config_sweep_on "$config_dir"
+
+  fm_create_test_repo "$tmp/repo"
+  cd "$tmp/repo" || exit 1
+  touch file.txt
+  git add file.txt
+  git commit -m "initial" 2>/dev/null
+  git checkout -b feature 2>/dev/null
+  touch feature.txt
+  git add feature.txt
+  git commit -m "feature work" 2>/dev/null
+  feature_commit=$(git rev-parse HEAD)
+  git checkout "$feature_commit" 2>/dev/null
+  git branch -D feature 2>/dev/null || true
+
+  FM_ROOT="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
+  rc=$?
+  [ "$rc" -eq 2 ] || fail "reflog only: expected exit 2, got $rc"
+  pass "refuses reflog-only reachability"
+}
+
+test_historical_reproduction() {
+  local tmp config_dir
+  tmp=$(fm_test_tmproot sweep-historical)
+  config_dir="$tmp/config"
+  fm_config_sweep_on "$config_dir"
+
+  fm_create_test_repo "$tmp/repo"
+  cd "$tmp/repo" || exit 1
+  touch file.txt
+  git add file.txt
+  git commit -m "initial" 2>/dev/null
+
+  git checkout -b fm/lane-branch 2>/dev/null
+  touch lane-work.txt
+  git add lane-work.txt
+  git commit -m "lane work" 2>/dev/null
+
+  git rebase main 2>/dev/null || true
+
+  touch rebased-work.txt
+  git add rebased-work.txt
+  git commit -m "work after rebase" 2>/dev/null
+  rebased_commit=$(git rev-parse HEAD)
+
+  git checkout "$rebased_commit" 2>/dev/null
+  git update-ref -d refs/heads/fm/lane-branch 2>/dev/null || true
+
+  FM_ROOT="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
+  rc=$?
+  [ "$rc" -eq 2 ] || fail "historical reproduction: expected exit 2, got $rc"
+  pass "historical reproduction: refuses orphaned commits after branch deletion"
+}
+
+test_refuses_remote_only_refs() {
+  local tmp config_dir
+  tmp=$(fm_test_tmproot sweep-remote-only)
+  config_dir="$tmp/config"
+  fm_config_sweep_on "$config_dir"
+
+  fm_create_bare_repo "$tmp/origin"
+  fm_create_test_repo "$tmp/repo"
+  cd "$tmp/repo" || exit 1
+  git remote add origin "$tmp/origin"
+  touch file.txt
+  git add file.txt
+  git commit -m "initial" 2>/dev/null
+  git push -u origin main 2>/dev/null
+  origin_main=$(git rev-parse origin/main)
+  git checkout "$origin_main" 2>/dev/null
+  git branch -D main 2>/dev/null || true
+  git remote prune origin 2>/dev/null
+
+  FM_ROOT="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
+  rc=$?
+  [ "$rc" -eq 3 ] || fail "remote only: expected exit 3, got $rc"
+  pass "refuses HEAD covered only by remote-tracking refs"
+}
+
+test_allows_with_local_branch() {
+  local tmp config_dir
+  tmp=$(fm_test_tmproot sweep-local-with-remote)
+  config_dir="$tmp/config"
+  fm_config_sweep_on "$config_dir"
+
+  fm_create_bare_repo "$tmp/origin"
+  fm_create_test_repo "$tmp/repo"
+  cd "$tmp/repo" || exit 1
+  git remote add origin "$tmp/origin"
+  touch file.txt
+  git add file.txt
+  git commit -m "initial" 2>/dev/null
+  git push -u origin main 2>/dev/null
+  git checkout -b feature 2>/dev/null
+  touch feature.txt
+  git add feature.txt
+  git commit -m "feature" 2>/dev/null
+  git push -u origin feature 2>/dev/null
+  git checkout main 2>/dev/null
+  git branch -D feature 2>/dev/null
+
+  FM_ROOT="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
+  rc=$?
+  [ "$rc" -eq 0 ] || fail "local with remote: expected exit 0, got $rc"
+  pass "allows HEAD when local branch exists alongside remote"
+}
+
+test_nonexistent_worktree() {
+  local tmp config_dir
+  tmp=$(fm_test_tmproot sweep-nonexistent)
+  config_dir="$tmp/config"
+  fm_config_sweep_on "$config_dir"
+
+  FM_ROOT="$tmp" "$SWEEP" "$tmp/nonexistent" >/dev/null 2>&1
+  rc=$?
+  [ "$rc" -eq 4 ] || fail "nonexistent: expected exit 4, got $rc"
+  pass "exits 4 for nonexistent worktree"
+}
+
+test_help_text() {
+  local out
+  out=$("$SWEEP" --help 2>&1) || true
+  assert_contains "$out" "Pre-acquire worktree pool safety sweep" "help missing description"
+  assert_contains "$out" "MITIGATION" "help missing MITIGATION note"
+  assert_contains "$out" "INVARIANT" "help missing INVARIANT note"
+  assert_contains "$out" "config/worktree-pool-sweep" "help missing config location"
+  pass "help text contains required information"
+}
+
+test_disabled_by_default
+test_refuses_dirty_worktree
+test_refuses_staged_changes
+test_refuses_untracked_files
+test_allows_branch_reachable_head
+test_allows_tag_reachable_head
+test_allows_detached_head_fully_in_main
+test_refuses_reflog_only_reachability
+test_historical_reproduction
+test_refuses_remote_only_refs
+test_allows_with_local_branch
+test_nonexistent_worktree
+test_help_text

--- a/tests/fm-treehouse-pool-sweep.test.sh
+++ b/tests/fm-treehouse-pool-sweep.test.sh
@@ -60,15 +60,52 @@ test_disabled_by_default() {
 
   fm_create_unsafe_dirty_repo "$tmp/repo"
 
-  FM_ROOT="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
+  FM_HOME="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
   rc=$?
   [ "$rc" -eq 0 ] || fail "disabled by default: expected exit 0 on an unsafe worktree, got $rc"
 
   fm_config_sweep_on "$config_dir"
-  FM_ROOT="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
+  FM_HOME="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
   rc=$?
   [ "$rc" -eq 1 ] || fail "disabled by default: fixture is not actually unsafe (enabled sweep gave $rc)"
   pass "sweep is disabled by default even for an unsafe worktree"
+}
+
+# The sweep runs as a child of fm-spawn.sh, which exports no FM_ROOT. Resolution
+# must follow the repo-wide FM_CONFIG_OVERRIDE / $FM_HOME/config convention, so
+# these fixtures poison both the old knob and $HOME to prove neither is consulted.
+test_fm_home_config_activates_sweep() {
+  local tmp config_dir rc
+  tmp=$(fm_test_tmproot sweep-fm-home)
+  config_dir="$tmp/config"
+  fm_config_sweep_on "$config_dir"
+
+  fm_create_unsafe_dirty_repo "$tmp/repo"
+
+  HOME="$tmp/decoy-home" FM_ROOT="$tmp/decoy-root" FM_HOME="$tmp" \
+    "$SWEEP" "$tmp/repo" >/dev/null 2>&1
+  rc=$?
+  [ "$rc" -eq 1 ] || fail "FM_HOME config: expected exit 1, got $rc"
+  pass "an enable under \$FM_HOME/config activates the sweep"
+}
+
+test_config_override_activates_sweep() {
+  local tmp config_dir rc
+  tmp=$(fm_test_tmproot sweep-config-override)
+  config_dir="$tmp/elsewhere"
+  fm_config_sweep_on "$config_dir"
+
+  fm_create_unsafe_dirty_repo "$tmp/repo"
+
+  HOME="$tmp/decoy-home" FM_ROOT="$tmp/decoy-root" FM_HOME="$tmp" \
+    FM_CONFIG_OVERRIDE="$config_dir" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
+  rc=$?
+  [ "$rc" -eq 1 ] || fail "FM_CONFIG_OVERRIDE: expected exit 1, got $rc"
+
+  HOME="$tmp/decoy-home" FM_HOME="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
+  rc=$?
+  [ "$rc" -eq 0 ] || fail "FM_CONFIG_OVERRIDE: enable leaked outside the override dir (got $rc)"
+  pass "FM_CONFIG_OVERRIDE selects the config dir the sweep reads"
 }
 
 test_off_value_disables_sweep() {
@@ -79,7 +116,7 @@ test_off_value_disables_sweep() {
 
   fm_create_unsafe_dirty_repo "$tmp/repo"
 
-  FM_ROOT="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
+  FM_HOME="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
   rc=$?
   [ "$rc" -eq 0 ] || fail "off value: expected exit 0 on an unsafe worktree, got $rc"
   pass "config value 'off' disables the sweep"
@@ -98,7 +135,7 @@ test_refuses_dirty_worktree() {
   git commit -m "initial" 2>/dev/null
   echo "modified" > file.txt
 
-  err=$(FM_ROOT="$tmp" "$SWEEP" "$tmp/repo" 2>&1 >/dev/null)
+  err=$(FM_HOME="$tmp" "$SWEEP" "$tmp/repo" 2>&1 >/dev/null)
   rc=$?
   [ "$rc" -eq 1 ] || fail "dirty worktree: expected exit 1, got $rc"
   assert_contains "$err" "unsafe: dirty worktree" "dirty worktree: missing diagnostic on stderr"
@@ -119,7 +156,7 @@ test_refuses_staged_changes() {
   echo "staged" > staged.txt
   git add staged.txt
 
-  FM_ROOT="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
+  FM_HOME="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
   rc=$?
   [ "$rc" -eq 1 ] || fail "staged changes: expected exit 1, got $rc"
   pass "refuses staged changes against a real HEAD"
@@ -143,7 +180,7 @@ test_refuses_staged_change_restored_in_worktree() {
   [ -n "$(git diff --cached --name-only)" ] \
     || fail "staged-then-restored: fixture left no staged delta"
 
-  FM_ROOT="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
+  FM_HOME="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
   rc=$?
   [ "$rc" -eq 1 ] || fail "staged-then-restored: expected exit 1, got $rc"
   pass "refuses an index that differs from HEAD even when the worktree matches HEAD"
@@ -162,7 +199,7 @@ test_refuses_untracked_files() {
   git commit -m "initial" 2>/dev/null
   touch untracked.txt
 
-  FM_ROOT="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
+  FM_HOME="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
   rc=$?
   [ "$rc" -eq 1 ] || fail "untracked files: expected exit 1, got $rc"
   pass "refuses untracked files"
@@ -185,7 +222,7 @@ test_allows_branch_reachable_head() {
   git commit -m "feature work" 2>/dev/null
   git checkout main 2>/dev/null
 
-  FM_ROOT="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
+  FM_HOME="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
   rc=$?
   [ "$rc" -eq 0 ] || fail "branch reachable: expected exit 0, got $rc"
   pass "allows branch-reachable HEAD"
@@ -204,7 +241,7 @@ test_allows_tag_reachable_head() {
   git commit -m "initial" 2>/dev/null
   git tag v1.0.0 2>/dev/null
 
-  FM_ROOT="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
+  FM_HOME="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
   rc=$?
   [ "$rc" -eq 0 ] || fail "tag reachable: expected exit 0, got $rc"
   pass "allows tag-reachable HEAD"
@@ -224,7 +261,7 @@ test_allows_detached_head_fully_in_main() {
   main_commit=$(git rev-parse HEAD)
   git checkout "$main_commit" 2>/dev/null
 
-  FM_ROOT="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
+  FM_HOME="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
   rc=$?
   [ "$rc" -eq 0 ] || fail "detached in main: expected exit 0, got $rc"
   pass "allows detached HEAD fully contained in main"
@@ -249,7 +286,7 @@ test_refuses_reflog_only_reachability() {
   git checkout "$feature_commit" 2>/dev/null
   git branch -D feature 2>/dev/null || true
 
-  err=$(FM_ROOT="$tmp" "$SWEEP" "$tmp/repo" 2>&1 >/dev/null)
+  err=$(FM_HOME="$tmp" "$SWEEP" "$tmp/repo" 2>&1 >/dev/null)
   rc=$?
   [ "$rc" -eq 2 ] || fail "reflog only: expected exit 2, got $rc"
   assert_contains "$err" "not reachable from durable refs" \
@@ -284,7 +321,7 @@ test_historical_reproduction() {
   git checkout "$rebased_commit" 2>/dev/null
   git update-ref -d refs/heads/fm/lane-branch 2>/dev/null || true
 
-  FM_ROOT="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
+  FM_HOME="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
   rc=$?
   [ "$rc" -eq 2 ] || fail "historical reproduction: expected exit 2, got $rc"
   pass "historical reproduction: refuses orphaned commits after branch deletion"
@@ -309,12 +346,47 @@ test_refuses_remote_only_refs() {
   git branch -D main 2>/dev/null || true
   git remote prune origin 2>/dev/null
 
-  err=$(FM_ROOT="$tmp" "$SWEEP" "$tmp/repo" 2>&1 >/dev/null)
+  err=$(FM_HOME="$tmp" "$SWEEP" "$tmp/repo" 2>&1 >/dev/null)
   rc=$?
   [ "$rc" -eq 3 ] || fail "remote only: expected exit 3, got $rc"
   assert_contains "$err" "covered only by remote-tracking refs" \
     "remote only: missing diagnostic on stderr"
   pass "refuses HEAD covered only by remote-tracking refs with a diagnostic"
+}
+
+# Exit 3 claims the commits survive on a remote-tracking ref. When the only refs
+# are remote but HEAD is not contained in any of them, the honest answer is 2.
+test_refuses_orphan_head_with_unrelated_remote_ref() {
+  local tmp config_dir rc err
+  tmp=$(fm_test_tmproot sweep-orphan-vs-remote)
+  config_dir="$tmp/config"
+  fm_config_sweep_on "$config_dir"
+
+  fm_create_bare_repo "$tmp/origin"
+  fm_create_test_repo "$tmp/repo"
+  cd "$tmp/repo" || exit 1
+  git remote add origin "$tmp/origin"
+  touch file.txt
+  git add file.txt
+  git commit -m "initial" 2>/dev/null
+  git push -u origin main 2>/dev/null
+  git checkout -b orphan 2>/dev/null
+  touch never-pushed.txt
+  git add never-pushed.txt
+  git commit -m "never pushed" 2>/dev/null
+  orphan_commit=$(git rev-parse HEAD)
+  git checkout "$orphan_commit" 2>/dev/null
+  git branch -D orphan 2>/dev/null
+  git branch -D main 2>/dev/null
+  [ "$(git rev-list --count HEAD --not --remotes)" -gt 0 ] \
+    || fail "orphan vs remote: fixture HEAD is contained in a remote ref"
+
+  err=$(FM_HOME="$tmp" "$SWEEP" "$tmp/repo" 2>&1 >/dev/null)
+  rc=$?
+  [ "$rc" -eq 2 ] || fail "orphan vs remote: expected exit 2, got $rc"
+  assert_contains "$err" "not reachable from durable refs" \
+    "orphan vs remote: must not claim remote-tracking coverage it never verified"
+  pass "refuses an orphan HEAD as unreachable, not as remote-covered"
 }
 
 test_allows_with_local_branch() {
@@ -339,7 +411,7 @@ test_allows_with_local_branch() {
   git checkout main 2>/dev/null
   git branch -D feature 2>/dev/null
 
-  FM_ROOT="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
+  FM_HOME="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
   rc=$?
   [ "$rc" -eq 0 ] || fail "local with remote: expected exit 0, got $rc"
   pass "allows HEAD when local branch exists alongside remote"
@@ -366,7 +438,7 @@ test_refuses_when_reachability_cannot_be_computed() {
   git rev-list --count HEAD --not --branches >/dev/null 2>&1 \
     && fail "broken ref: fixture did not actually break rev-list"
 
-  FM_ROOT="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
+  FM_HOME="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
   rc=$?
   [ "$rc" -eq 2 ] || fail "broken ref: expected exit 2, got $rc"
   pass "refuses when HEAD reachability cannot be computed"
@@ -378,7 +450,7 @@ test_nonexistent_worktree() {
   config_dir="$tmp/config"
   fm_config_sweep_on "$config_dir"
 
-  FM_ROOT="$tmp" "$SWEEP" "$tmp/nonexistent" >/dev/null 2>&1
+  FM_HOME="$tmp" "$SWEEP" "$tmp/nonexistent" >/dev/null 2>&1
   rc=$?
   [ "$rc" -eq 4 ] || fail "nonexistent: expected exit 4, got $rc"
   pass "exits 4 for nonexistent worktree"
@@ -390,7 +462,7 @@ test_missing_argument_is_a_usage_error() {
   config_dir="$tmp/config"
   fm_config_sweep_on "$config_dir"
 
-  FM_ROOT="$tmp" "$SWEEP" >/dev/null 2>&1
+  FM_HOME="$tmp" "$SWEEP" >/dev/null 2>&1
   rc=$?
   [ "$rc" -eq 64 ] || fail "missing argument: expected exit 64, got $rc"
   [ "$rc" -ne 4 ] || fail "missing argument must not collide with the nonexistent-worktree code"
@@ -409,6 +481,8 @@ test_help_text() {
 
 test_disabled_by_default
 test_off_value_disables_sweep
+test_fm_home_config_activates_sweep
+test_config_override_activates_sweep
 test_refuses_dirty_worktree
 test_refuses_staged_changes
 test_refuses_staged_change_restored_in_worktree
@@ -419,6 +493,7 @@ test_allows_detached_head_fully_in_main
 test_refuses_reflog_only_reachability
 test_historical_reproduction
 test_refuses_remote_only_refs
+test_refuses_orphan_head_with_unrelated_remote_ref
 test_allows_with_local_branch
 test_refuses_when_reachability_cannot_be_computed
 test_nonexistent_worktree

--- a/tests/fm-treehouse-pool-sweep.test.sh
+++ b/tests/fm-treehouse-pool-sweep.test.sh
@@ -21,6 +21,7 @@ fm_create_test_repo() {
   local path=$1
   mkdir -p "$path"
   git init "$path" 2>/dev/null
+  git -C "$path" symbolic-ref HEAD refs/heads/main
   git -C "$path" config user.email "test@example.com"
   git -C "$path" config user.name "Test"
 }
@@ -68,10 +69,11 @@ test_refuses_dirty_worktree() {
   git commit -m "initial" 2>/dev/null
   echo "modified" > file.txt
 
-  FM_ROOT="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
+  err=$(FM_ROOT="$tmp" "$SWEEP" "$tmp/repo" 2>&1 >/dev/null)
   rc=$?
   [ "$rc" -eq 1 ] || fail "dirty worktree: expected exit 1, got $rc"
-  pass "refuses dirty worktree"
+  assert_contains "$err" "unsafe: dirty worktree" "dirty worktree: missing diagnostic on stderr"
+  pass "refuses dirty worktree with a diagnostic"
 }
 
 test_refuses_staged_changes() {
@@ -193,10 +195,12 @@ test_refuses_reflog_only_reachability() {
   git checkout "$feature_commit" 2>/dev/null
   git branch -D feature 2>/dev/null || true
 
-  FM_ROOT="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
+  err=$(FM_ROOT="$tmp" "$SWEEP" "$tmp/repo" 2>&1 >/dev/null)
   rc=$?
   [ "$rc" -eq 2 ] || fail "reflog only: expected exit 2, got $rc"
-  pass "refuses reflog-only reachability"
+  assert_contains "$err" "not reachable from durable refs" \
+    "reflog only: missing diagnostic on stderr"
+  pass "refuses reflog-only reachability with a diagnostic"
 }
 
 test_historical_reproduction() {
@@ -251,10 +255,12 @@ test_refuses_remote_only_refs() {
   git branch -D main 2>/dev/null || true
   git remote prune origin 2>/dev/null
 
-  FM_ROOT="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
+  err=$(FM_ROOT="$tmp" "$SWEEP" "$tmp/repo" 2>&1 >/dev/null)
   rc=$?
   [ "$rc" -eq 3 ] || fail "remote only: expected exit 3, got $rc"
-  pass "refuses HEAD covered only by remote-tracking refs"
+  assert_contains "$err" "covered only by remote-tracking refs" \
+    "remote only: missing diagnostic on stderr"
+  pass "refuses HEAD covered only by remote-tracking refs with a diagnostic"
 }
 
 test_allows_with_local_branch() {
@@ -297,6 +303,19 @@ test_nonexistent_worktree() {
   pass "exits 4 for nonexistent worktree"
 }
 
+test_missing_argument_is_a_usage_error() {
+  local tmp config_dir rc
+  tmp=$(fm_test_tmproot sweep-usage)
+  config_dir="$tmp/config"
+  fm_config_sweep_on "$config_dir"
+
+  FM_ROOT="$tmp" "$SWEEP" >/dev/null 2>&1
+  rc=$?
+  [ "$rc" -eq 64 ] || fail "missing argument: expected exit 64, got $rc"
+  [ "$rc" -ne 4 ] || fail "missing argument must not collide with the nonexistent-worktree code"
+  pass "exits 64 for a missing worktree argument"
+}
+
 test_help_text() {
   local out
   out=$("$SWEEP" --help 2>&1) || true
@@ -319,4 +338,5 @@ test_historical_reproduction
 test_refuses_remote_only_refs
 test_allows_with_local_branch
 test_nonexistent_worktree
+test_missing_argument_is_a_usage_error
 test_help_text

--- a/tests/fm-treehouse-pool-sweep.test.sh
+++ b/tests/fm-treehouse-pool-sweep.test.sh
@@ -503,7 +503,7 @@ test_allows_with_local_branch() {
 # rev-list exit 128. The sweep must treat an unanswerable reachability question
 # as unsafe rather than green-lighting the worktree.
 test_refuses_when_reachability_cannot_be_computed() {
-  local tmp config_dir rc git_dir
+  local tmp config_dir rc git_dir err
   tmp=$(fm_test_tmproot sweep-broken-ref)
   config_dir="$tmp/config"
   fm_config_sweep_on "$config_dir"
@@ -520,10 +520,16 @@ test_refuses_when_reachability_cannot_be_computed() {
   git rev-list --count HEAD --not --branches >/dev/null 2>&1 \
     && fail "broken ref: fixture did not actually break rev-list"
 
-  FM_HOME="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
+  err=$(FM_HOME="$tmp" "$SWEEP" "$tmp/repo" 2>&1 >/dev/null)
   rc=$?
   [ "$rc" -eq 2 ] || fail "broken ref: expected exit 2, got $rc"
-  pass "refuses when HEAD reachability cannot be computed"
+  assert_contains "$err" "cannot compute HEAD reachability" \
+    "broken ref: missing the cannot-compute diagnostic"
+  case "$err" in
+    *"contains commits not reachable"*)
+      fail "broken ref: reported as orphaned commits, but the question was unanswerable" ;;
+  esac
+  pass "refuses an uncomputable reachability question with its own diagnostic"
 }
 
 test_nonexistent_worktree() {

--- a/tests/fm-treehouse-pool-sweep.test.sh
+++ b/tests/fm-treehouse-pool-sweep.test.sh
@@ -11,6 +11,12 @@ set -u
 
 SWEEP="$ROOT/bin/fm-treehouse-pool-sweep.sh"
 
+# The sweep resolves its config dir as FM_CONFIG_OVERRIDE, else $FM_HOME/config.
+# An ambient export of either would outrank the per-test FM_HOME below and make
+# these assertions read a config dir the fixture never wrote.
+unset FM_CONFIG_OVERRIDE
+unset FM_ROOT_OVERRIDE
+
 fm_create_bare_repo() {
   local path=$1
   mkdir -p "$path"
@@ -186,6 +192,30 @@ test_refuses_staged_change_restored_in_worktree() {
   pass "refuses an index that differs from HEAD even when the worktree matches HEAD"
 }
 
+# A pool worktree returned by teardown has fresh mtimes, so its index stat data
+# is stale while its content still matches HEAD. That is clean, not dirty, and
+# must agree with the `git status --porcelain` gate fm-spawn.sh applies later.
+test_allows_stat_dirty_but_clean_worktree() {
+  local tmp config_dir rc
+  tmp=$(fm_test_tmproot sweep-stat-dirty)
+  config_dir="$tmp/config"
+  fm_config_sweep_on "$config_dir"
+
+  fm_create_test_repo "$tmp/repo"
+  cd "$tmp/repo" || exit 1
+  printf 'content\n' > file.txt
+  git add file.txt
+  git commit -m "initial" 2>/dev/null
+  touch -t 203001010101 file.txt
+  [ -z "$(git status --porcelain)" ] \
+    || fail "stat-dirty: fixture is genuinely dirty, not merely stat-dirty"
+
+  FM_HOME="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
+  rc=$?
+  [ "$rc" -eq 0 ] || fail "stat-dirty: expected exit 0 for a stat-only mtime change, got $rc"
+  pass "allows a stat-dirty worktree whose content matches HEAD"
+}
+
 test_refuses_untracked_files() {
   local tmp config_dir
   tmp=$(fm_test_tmproot sweep-untracked)
@@ -356,6 +386,33 @@ test_refuses_remote_only_refs() {
 
 # Exit 3 claims the commits survive on a remote-tracking ref. When the only refs
 # are remote but HEAD is not contained in any of them, the honest answer is 2.
+# With no refs at all, exit 3 must not be claimed: there is no remote-tracking
+# ref the commits could be recovered from.
+test_refuses_head_when_no_refs_exist_at_all() {
+  local tmp config_dir rc err
+  tmp=$(fm_test_tmproot sweep-no-refs)
+  config_dir="$tmp/config"
+  fm_config_sweep_on "$config_dir"
+
+  fm_create_test_repo "$tmp/repo"
+  cd "$tmp/repo" || exit 1
+  touch file.txt
+  git add file.txt
+  git commit -m "initial" 2>/dev/null
+  head_commit=$(git rev-parse HEAD)
+  git checkout "$head_commit" 2>/dev/null
+  git branch -D main 2>/dev/null
+  [ -z "$(git for-each-ref --format='%(refname)')" ] \
+    || fail "no refs: fixture still has refs"
+
+  err=$(FM_HOME="$tmp" "$SWEEP" "$tmp/repo" 2>&1 >/dev/null)
+  rc=$?
+  [ "$rc" -eq 2 ] || fail "no refs: expected exit 2, got $rc"
+  assert_contains "$err" "not reachable from durable refs" \
+    "no refs: must not claim remote-tracking coverage"
+  pass "refuses HEAD as unreachable when no refs exist at all"
+}
+
 test_refuses_orphan_head_with_unrelated_remote_ref() {
   local tmp config_dir rc err
   tmp=$(fm_test_tmproot sweep-orphan-vs-remote)
@@ -486,6 +543,7 @@ test_config_override_activates_sweep
 test_refuses_dirty_worktree
 test_refuses_staged_changes
 test_refuses_staged_change_restored_in_worktree
+test_allows_stat_dirty_but_clean_worktree
 test_refuses_untracked_files
 test_allows_branch_reachable_head
 test_allows_tag_reachable_head
@@ -493,6 +551,7 @@ test_allows_detached_head_fully_in_main
 test_refuses_reflog_only_reachability
 test_historical_reproduction
 test_refuses_remote_only_refs
+test_refuses_head_when_no_refs_exist_at_all
 test_refuses_orphan_head_with_unrelated_remote_ref
 test_allows_with_local_branch
 test_refuses_when_reachability_cannot_be_computed

--- a/tests/fm-treehouse-pool-sweep.test.sh
+++ b/tests/fm-treehouse-pool-sweep.test.sh
@@ -38,22 +38,51 @@ fm_config_sweep_off() {
   echo "off" > "$config_dir/worktree-pool-sweep"
 }
 
+# The fixture must be one the sweep REFUSES when enabled, otherwise "exit 0"
+# proves only that the worktree was safe, not that the sweep stayed deactivated.
+fm_create_unsafe_dirty_repo() {
+  local path=$1
+  fm_create_test_repo "$path"
+  ( cd "$path" || exit 1
+    touch file.txt
+    git add file.txt
+    git commit -m "initial" 2>/dev/null
+    echo "modified" > file.txt )
+}
+
 test_disabled_by_default() {
-  local tmp config_dir
+  local tmp config_dir rc
   tmp=$(fm_test_tmproot sweep-disabled)
   config_dir="$tmp/config"
   mkdir -p "$config_dir"
+  [ ! -e "$config_dir/worktree-pool-sweep" ] \
+    || fail "disabled by default: fixture must not create the config file"
 
-  fm_create_test_repo "$tmp/repo"
-  cd "$tmp/repo" || exit 1
-  touch file.txt
-  git add file.txt
-  git commit -m "initial" 2>/dev/null
+  fm_create_unsafe_dirty_repo "$tmp/repo"
 
   FM_ROOT="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
   rc=$?
-  [ "$rc" -eq 0 ] || fail "disabled by default: expected exit 0, got $rc"
-  pass "sweep is disabled by default"
+  [ "$rc" -eq 0 ] || fail "disabled by default: expected exit 0 on an unsafe worktree, got $rc"
+
+  fm_config_sweep_on "$config_dir"
+  FM_ROOT="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
+  rc=$?
+  [ "$rc" -eq 1 ] || fail "disabled by default: fixture is not actually unsafe (enabled sweep gave $rc)"
+  pass "sweep is disabled by default even for an unsafe worktree"
+}
+
+test_off_value_disables_sweep() {
+  local tmp config_dir rc
+  tmp=$(fm_test_tmproot sweep-off-value)
+  config_dir="$tmp/config"
+  fm_config_sweep_off "$config_dir"
+
+  fm_create_unsafe_dirty_repo "$tmp/repo"
+
+  FM_ROOT="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
+  rc=$?
+  [ "$rc" -eq 0 ] || fail "off value: expected exit 0 on an unsafe worktree, got $rc"
+  pass "config value 'off' disables the sweep"
 }
 
 test_refuses_dirty_worktree() {
@@ -86,13 +115,38 @@ test_refuses_staged_changes() {
   cd "$tmp/repo" || exit 1
   touch file.txt
   git add file.txt
+  git commit -m "initial" 2>/dev/null
   echo "staged" > staged.txt
   git add staged.txt
 
   FM_ROOT="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
   rc=$?
   [ "$rc" -eq 1 ] || fail "staged changes: expected exit 1, got $rc"
-  pass "refuses staged changes"
+  pass "refuses staged changes against a real HEAD"
+}
+
+test_refuses_staged_change_restored_in_worktree() {
+  local tmp config_dir rc
+  tmp=$(fm_test_tmproot sweep-staged-restored)
+  config_dir="$tmp/config"
+  fm_config_sweep_on "$config_dir"
+
+  fm_create_test_repo "$tmp/repo"
+  cd "$tmp/repo" || exit 1
+  printf 'original\n' > file.txt
+  git add file.txt
+  git commit -m "initial" 2>/dev/null
+  printf 'staged\n' > file.txt
+  git add file.txt
+  printf 'original\n' > file.txt
+  git update-index --refresh >/dev/null 2>&1
+  [ -n "$(git diff --cached --name-only)" ] \
+    || fail "staged-then-restored: fixture left no staged delta"
+
+  FM_ROOT="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
+  rc=$?
+  [ "$rc" -eq 1 ] || fail "staged-then-restored: expected exit 1, got $rc"
+  pass "refuses an index that differs from HEAD even when the worktree matches HEAD"
 }
 
 test_refuses_untracked_files() {
@@ -291,6 +345,33 @@ test_allows_with_local_branch() {
   pass "allows HEAD when local branch exists alongside remote"
 }
 
+# A durable ref pointing at an object the shared store no longer has makes
+# rev-list exit 128. The sweep must treat an unanswerable reachability question
+# as unsafe rather than green-lighting the worktree.
+test_refuses_when_reachability_cannot_be_computed() {
+  local tmp config_dir rc git_dir
+  tmp=$(fm_test_tmproot sweep-broken-ref)
+  config_dir="$tmp/config"
+  fm_config_sweep_on "$config_dir"
+
+  fm_create_test_repo "$tmp/repo"
+  cd "$tmp/repo" || exit 1
+  touch file.txt
+  git add file.txt
+  git commit -m "initial" 2>/dev/null
+  git_dir=$(git rev-parse --git-dir)
+  mkdir -p "$git_dir/refs/heads"
+  printf '%s\n' "0000000000000000000000000000000000000001" \
+    > "$git_dir/refs/heads/dangling"
+  git rev-list --count HEAD --not --branches >/dev/null 2>&1 \
+    && fail "broken ref: fixture did not actually break rev-list"
+
+  FM_ROOT="$tmp" "$SWEEP" "$tmp/repo" >/dev/null 2>&1
+  rc=$?
+  [ "$rc" -eq 2 ] || fail "broken ref: expected exit 2, got $rc"
+  pass "refuses when HEAD reachability cannot be computed"
+}
+
 test_nonexistent_worktree() {
   local tmp config_dir
   tmp=$(fm_test_tmproot sweep-nonexistent)
@@ -327,8 +408,10 @@ test_help_text() {
 }
 
 test_disabled_by_default
+test_off_value_disables_sweep
 test_refuses_dirty_worktree
 test_refuses_staged_changes
+test_refuses_staged_change_restored_in_worktree
 test_refuses_untracked_files
 test_allows_branch_reachable_head
 test_allows_tag_reachable_head
@@ -337,6 +420,7 @@ test_refuses_reflog_only_reachability
 test_historical_reproduction
 test_refuses_remote_only_refs
 test_allows_with_local_branch
+test_refuses_when_reachability_cannot_be_computed
 test_nonexistent_worktree
 test_missing_argument_is_a_usage_error
 test_help_text

--- a/tests/fm-treehouse-pool-sweep.test.sh
+++ b/tests/fm-treehouse-pool-sweep.test.sh
@@ -206,6 +206,10 @@ test_allows_stat_dirty_but_clean_worktree() {
   printf 'content\n' > file.txt
   git add file.txt
   git commit -m "initial" 2>/dev/null
+  # A tag, so HEAD is durably reachable independently of the branch it is
+  # attached to (which the sweep discounts). Without it the case would exit on
+  # the reachability verdict and prove nothing about the dirty probe.
+  git tag pool-base 2>/dev/null
   touch -t 203001010101 file.txt
   [ -z "$(git status --porcelain)" ] \
     || fail "stat-dirty: fixture is genuinely dirty, not merely stat-dirty"
@@ -320,6 +324,41 @@ test_allows_detached_head_fully_in_main() {
   rc=$?
   [ "$rc" -eq 0 ] || fail "detached in main: expected exit 0, got $rc"
   pass "allows detached HEAD fully contained in main"
+}
+
+# The pool worktree is still sitting on the lane branch that carries its only
+# copy of some committed work. That branch is not protection: the spawn path
+# hard-resets it onto origin's default branch moments later, so counting it
+# would green-light discarding the work.
+test_refuses_head_held_only_by_the_checked_out_branch() {
+  local tmp config_dir rc err lane_commit
+  tmp=$(fm_test_tmproot sweep-attached-branch)
+  config_dir="$tmp/config"
+  fm_config_sweep_on "$config_dir"
+
+  fm_create_bare_repo "$tmp/origin"
+  fm_create_test_repo "$tmp/repo"
+  cd "$tmp/repo" || exit 1
+  git remote add origin "$tmp/origin"
+  touch file.txt
+  git add file.txt
+  git commit -m "initial" 2>/dev/null
+  git push -u origin main 2>/dev/null
+  git checkout -b fm/lane 2>/dev/null
+  printf 'unlanded\n' > lane.txt
+  git add lane.txt
+  git commit -m "lane work" 2>/dev/null
+  lane_commit=$(git rev-parse HEAD)
+  [ "$(git rev-parse --abbrev-ref HEAD)" = "fm/lane" ] \
+    || fail "attached branch: fixture is not checked out on the lane branch"
+  [ -n "$lane_commit" ] || fail "attached branch: fixture has no lane commit"
+
+  err=$(FM_HOME="$tmp" "$SWEEP" "$tmp/repo" 2>&1 >/dev/null)
+  rc=$?
+  [ "$rc" -eq 2 ] || fail "attached branch: expected exit 2, got $rc"
+  assert_contains "$err" "not reachable from durable refs" \
+    "attached branch: missing the unreachable-HEAD diagnostic"
+  pass "refuses HEAD whose only ref is the branch about to be hard-reset"
 }
 
 test_refuses_reflog_only_reachability() {
@@ -580,6 +619,7 @@ test_refuses_untracked_files
 test_allows_branch_reachable_head
 test_allows_tag_reachable_head
 test_allows_detached_head_fully_in_main
+test_refuses_head_held_only_by_the_checked_out_branch
 test_refuses_reflog_only_reachability
 test_historical_reproduction
 test_refuses_remote_only_refs

--- a/tests/no-mistakes-required-workflow.test.sh
+++ b/tests/no-mistakes-required-workflow.test.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Behavior of the "PR must be raised via no-mistakes" compliance gate.
+#
+# The contract under test is the executable step body of
+# .github/workflows/no-mistakes-required.yml: given a pull_request event payload
+# body (PR_BODY) and the PR's live body, it must decide whether the PR carries
+# the no-mistakes signature plus a parseable v1 pipeline attestation whose
+# review/test/document steps are completed.
+#
+# The workflow is parsed into its YAML object and the real step script is run as
+# the runner runs it, with gh/sleep shimmed; no assertion looks at the workflow
+# text itself.
+#
+# Regression origin: PR #2827. no-mistakes pushes the branch (and opens the PR)
+# before it writes the pipeline body, so the opened/synchronize payload carried a
+# pre-attestation body and this gate failed against a body that was already
+# replaced seconds later. Runs 32619561064 (opened) and 32622077051 (synchronize)
+# both failed that way while the following `edited` run passed on the same head.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+command -v jq >/dev/null 2>&1 || { echo "skip: jq not found (the gate parses attestation with jq)"; exit 0; }
+command -v python3 >/dev/null 2>&1 || { echo "skip: python3 not found (needed to parse the workflow YAML)"; exit 0; }
+python3 -c 'import yaml' >/dev/null 2>&1 || { echo "skip: python3 yaml module not found (needed to parse the workflow YAML)"; exit 0; }
+
+TMP_ROOT=$(fm_test_tmproot no-mistakes-required)
+FAKEBIN=$(fm_fakebin "$TMP_ROOT")
+
+WORKFLOW="$ROOT/.github/workflows/no-mistakes-required.yml"
+STEP="$TMP_ROOT/step.sh"
+
+# Extract the step's `run:` script from the parsed workflow, keeping the job's
+# `if` guard and expression-bearing `env:` out of it: those are GitHub's to
+# evaluate, the script body is the runner's.
+python3 - "$WORKFLOW" "$STEP" <<'PY' || fail "could not extract the compliance step from the workflow"
+import sys
+
+import yaml
+
+workflow = yaml.safe_load(open(sys.argv[1]))
+steps = workflow["jobs"]["check"]["steps"]
+run = [s for s in steps if "run" in s and "no-mistakes signature" in s.get("name", "")]
+assert len(run) == 1, run
+open(sys.argv[2], "w").write(run[0]["run"])
+PY
+
+# The live body the shimmed `gh api` answers with, and a counter proving whether
+# the gate went back to the API at all.
+LIVE_BODY="$TMP_ROOT/live-body.txt"
+GH_CALLS="$TMP_ROOT/gh-calls"
+: > "$GH_CALLS"
+
+cat > "$FAKEBIN/gh" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_CALLS"
+if [ -n "${FAKE_GH_FAIL:-}" ]; then
+  echo "gh: simulated API failure" >&2
+  exit 1
+fi
+cat "$LIVE_BODY"
+SH
+chmod +x "$FAKEBIN/gh"
+
+# Keep the retry loop's backoff out of the suite's wall clock.
+cat > "$FAKEBIN/sleep" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+chmod +x "$FAKEBIN/sleep"
+
+MARKER='Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)'
+
+# body_with <review-status> <test-status> <document-status>
+body_with() {
+  printf '## Pipeline\n\n%s\n\n<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"deadbeef","steps":[{"step":"review","status":"%s"},{"step":"test","status":"%s"},{"step":"document","status":"%s"}]} -->\n' \
+    "$MARKER" "$1" "$2" "$3"
+}
+
+COMPLIANT=$(body_with completed completed completed)
+SIGNED_NO_ATTESTATION="## Pipeline
+
+$MARKER
+"
+
+# run_gate <event-body> <live-body>: run the step in the current shell, leaving
+# its combined output in OUT and its exit code in RC.
+OUT=''
+RC=0
+run_gate() {
+  printf '%s' "$2" > "$LIVE_BODY"
+  : > "$GH_CALLS"
+  PATH="$FAKEBIN:$PATH" \
+    LIVE_BODY="$LIVE_BODY" GH_CALLS="$GH_CALLS" FAKE_GH_FAIL="${FAKE_GH_FAIL:-}" \
+    PR_BODY="$1" PR_AUTHOR=someone PR_NUMBER=2827 PR_REPO=kunchenguid/firstmate \
+    bash "$STEP" >"$TMP_ROOT/out.txt" 2>&1
+  RC=$?
+  OUT=$(cat "$TMP_ROOT/out.txt")
+}
+
+gh_call_count() {
+  local count
+  count=$(grep -c . "$GH_CALLS" 2>/dev/null) || count=0
+  printf '%s\n' "$count"
+}
+
+# --- a compliant event payload passes without going back to the API ---------
+
+run_gate "$COMPLIANT" "$COMPLIANT"
+expect_code 0 "$RC" "compliant payload body"
+assert_contains "$OUT" "Pipeline step attestation is valid" "compliant payload body reports success"
+[ "$(gh_call_count)" = 0 ] || fail "a compliant payload body must not re-read the live body"
+pass "a compliant event payload passes without re-reading the PR"
+
+# --- the push-then-write race: payload body is stale, live body is compliant --
+
+run_gate "" "$COMPLIANT"
+expect_code 0 "$RC" "empty payload body with a compliant live body"
+assert_contains "$OUT" "Pipeline step attestation is valid" "stale empty payload is re-read"
+[ "$(gh_call_count)" -ge 1 ] || fail "a non-compliant payload body must be re-read from the API"
+pass "an opened-event body written before the pipeline section passes once the live body lands"
+
+run_gate "$SIGNED_NO_ATTESTATION" "$COMPLIANT"
+expect_code 0 "$RC" "signed-but-unattested payload with a compliant live body"
+assert_contains "$OUT" "Pipeline step attestation is valid" "stale signed payload is re-read"
+pass "a synchronize-event body that predates the attestation comment passes once the live body lands"
+
+# --- genuinely non-compliant PRs still fail ---------------------------------
+
+run_gate "no pipeline here" "no pipeline here"
+expect_code 1 "$RC" "unsigned body"
+assert_contains "$OUT" "This PR was not raised through no-mistakes." "unsigned body names the gate"
+pass "a body that never gains the signature is refused"
+
+run_gate "$SIGNED_NO_ATTESTATION" "$SIGNED_NO_ATTESTATION"
+expect_code 1 "$RC" "signed body with no attestation comment"
+assert_contains "$OUT" "structured pipeline step attestation is missing or unparseable" \
+  "missing attestation names the version floor"
+pass "a signature without a parseable attestation is refused"
+
+SKIPPED=$(body_with skipped completed completed)
+run_gate "$SKIPPED" "$SKIPPED"
+expect_code 1 "$RC" "attestation with a skipped required step"
+assert_contains "$OUT" "review=skipped" "skipped required step is named"
+pass "an attestation whose required step only skipped is refused"
+
+# --- an unreadable API must not turn a refusal into a pass ------------------
+
+FAKE_GH_FAIL=1
+run_gate "no pipeline here" "$COMPLIANT"
+FAKE_GH_FAIL=
+expect_code 1 "$RC" "unsigned body when the API re-read fails"
+assert_contains "$OUT" "This PR was not raised through no-mistakes." "API failure falls back to the payload verdict"
+pass "an unreadable API leaves the payload verdict standing rather than passing"
+
+echo "# all no-mistakes-required workflow tests passed"


### PR DESCRIPTION
## What Changed

- Adds `bin/fm-treehouse-pool-sweep.sh`, a pre-acquire safety sweep that refuses a pooled worktree that is dirty (tracked modifications, staged changes, or untracked non-ignored files), whose HEAD carries commits unreachable from durable refs (`refs/heads/*`, `refs/tags/*`, `refs/firstmate/rescue/*`), or whose HEAD is covered only by remote-tracking refs; distinct exit codes cover each case plus missing worktree and usage error, and unanswerable git probes fail closed under the matching exit code with their own diagnostic.
- Wires the sweep into `bin/fm-spawn.sh` after `treehouse get` validation, passing the spawn's resolved config dir via `FM_CONFIG_OVERRIDE`; a non-zero sweep exit aborts the spawn with an error naming the worktree, the exit code, and `config/worktree-pool-sweep`. The sweep ships deactivated — it stays inert unless that config file exists with a non-empty value other than `off`.
- Documents activation, refusal conditions, and the mitigation's two structural gaps (direct `treehouse get` bypass, cross-home race between sweep and acquire) in `docs/configuration.md`, and adds shell test suites covering the sweep's behavior and its `fm-spawn.sh` wiring.

## Risk Assessment

✅ Low: The mitigation ships inert by default (proven non-trivially by both the sweep and spawn-wiring suites), the new fail-closed/diagnostic plumbing traces correctly on every exit path I constructed, and the only remaining issue is unreachable dead code with no behavioral effect.

## Testing

Ran the two targeted suites for this change (`tests/fm-treehouse-pool-sweep.test.sh`, `tests/fm-spawn-pool-sweep-wiring.test.sh`) — both pass — then drove the real fm-spawn acquisition path manually against a synthetic pool to capture the operator-visible CLI transcript: unconfigured and `off` homes spawn unchanged, an enabled sweep refuses the spawn with the diagnostic plus the "pool sweep refused worktree … (exit 2); … disable sweep in config/worktree-pool-sweep" error while leaving the abandoned pool work intact, and each documented exit code (1/2/3/4/64) emits its own distinct message. This is a CLI-only change, so the evidence is a command transcript rather than visual artifacts; no failures or flakes were seen and the worktree is clean.

<details>
<summary>Evidence: Operator CLI transcript: sweep deactivated vs. enabled vs. off, plus every refusal diagnostic</summary>

Source: [Operator CLI transcript: sweep deactivated vs. enabled vs. off, plus every refusal diagnostic](https://github.com/ICGNU3/firstmate/blob/c82fc80bdfbeedbc47f4682a1cd1e1881cafe443/.no-mistakes/evidence/fm/fm-worktree-reuse-guard/pool-sweep-operator-transcript.txt)

<code>=== 1. Shipped state: no config/worktree-pool-sweep file ===&#10;$ fm spawn demo-default &lt;project&gt;&#10;spawned demo-default harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-demo-default worktree=/tmp/.../a/pool&#10;[exit 0] &lt;- acquisition path unchanged; the sweep never ran&#10;&#10;=== 2. Operator activates the mitigation ===&#10;$ echo on &gt; $FM_HOME/config/worktree-pool-sweep&#10;$ git -C &lt;pool&gt; log --oneline -1 # the work at risk&#10;5baa05f abandoned work&#10;$ fm spawn demo-enabled &lt;project&gt;&#10;unsafe: HEAD contains commits not reachable from durable refs in /tmp/.../b/pool&#10;error: worktree pool sweep refused worktree /tmp/.../b/pool (exit 2); inspect unsafe state or disable sweep in config/worktree-pool-sweep&#10;[exit 1] &lt;- spawn aborted before reusing the worktree&#10;$ cat &lt;pool&gt;/abandoned.txt # work still intact after the refusal&#10;abandoned lane work&#10;&#10;=== 3. Explicit off ===&#10;$ fm spawn demo-off &lt;project&gt;&#10;spawned demo-off ... worktree=/tmp/.../c/pool&#10;[exit 0] &lt;- &#39;off&#39; leaves the sweep inert&#10;&#10;--- direct invocation, one diagnostic per condition ---&#10;&lt;dirty pool&gt; unsafe: dirty worktree at ... [exit 1]&#10;&lt;unreferenced HEAD&gt; unsafe: HEAD contains commits not reachable from durable refs [exit 2]&#10;&lt;uninspectable HEAD&gt; unsafe: cannot inspect HEAD at ... [exit 1]&#10;&lt;corrupt ref database&gt; unsafe: cannot compute HEAD reachability in ... [exit 2]&#10;&lt;remote-only coverage&gt; unsafe: HEAD commits covered only by remote-tracking refs [exit 3]&#10;&lt;nonexistent path&gt; (no output) [exit 4]&#10;&lt;no argument&gt; error: worktree path required + usage [exit 64]</code>

```text
############################################################
# Scenario: a pooled worktree is clean, but its HEAD carries
# committed lane work that no branch, tag or rescue ref reaches.
############################################################

=== 1. Shipped state: no config/worktree-pool-sweep file ===
$ ls $FM_HOME/config/
crew-harness
$ fm spawn demo-default <project>
warning: /tmp/sweep-evidence.TJ9yoB/a/home/data/demo-default/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
spawned demo-default harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-demo-default worktree=/tmp/sweep-evidence.TJ9yoB/a/pool
[exit 0]  <- acquisition path unchanged; the sweep never ran

=== 2. Operator activates the mitigation ===
$ echo on > $FM_HOME/config/worktree-pool-sweep
$ git -C <pool> log --oneline -1   # the work at risk
5baa05f abandoned work
$ fm spawn demo-enabled <project>
unsafe: HEAD contains commits not reachable from durable refs in /tmp/sweep-evidence.TJ9yoB/b/pool
error: worktree pool sweep refused worktree /tmp/sweep-evidence.TJ9yoB/b/pool (exit 2); inspect unsafe state or disable sweep in config/worktree-pool-sweep
[exit 1]  <- spawn aborted before reusing the worktree
$ cat <pool>/abandoned.txt   # work still intact after the refusal
abandoned lane work

=== 3. Explicit off ===
$ echo off > $FM_HOME/config/worktree-pool-sweep
$ fm spawn demo-off <project>
warning: /tmp/sweep-evidence.TJ9yoB/c/home/data/demo-off/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
spawned demo-off harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-demo-off worktree=/tmp/sweep-evidence.TJ9yoB/c/pool
[exit 0]  <- 'off' leaves the sweep inert

############################################################
# Direct sweep invocation: one diagnostic per condition
############################################################

$ fm-treehouse-pool-sweep.sh <dirty pool>
unsafe: dirty worktree at /tmp/sweep-evidence.TJ9yoB/d/dirty
[exit 1]

$ fm-treehouse-pool-sweep.sh <pool detached on unreferenced commits>
unsafe: HEAD contains commits not reachable from durable refs in /tmp/sweep-evidence.TJ9yoB/d/orphan
[exit 2]

$ fm-treehouse-pool-sweep.sh <pool whose HEAD cannot be inspected>
unsafe: cannot inspect HEAD at /tmp/sweep-evidence.TJ9yoB/d/unborn
[exit 1]

$ fm-treehouse-pool-sweep.sh <pool with a corrupt ref database>
unsafe: cannot compute HEAD reachability in /tmp/sweep-evidence.TJ9yoB/d/corrupt
[exit 2]

$ fm-treehouse-pool-sweep.sh <path that does not exist>
[exit 4]

$ fm-treehouse-pool-sweep.sh   # no argument
error: worktree path required
fm-treehouse-pool-sweep.sh - Pre-acquire worktree pool safety sweep
[exit 64]

$ fm-treehouse-pool-sweep.sh <pool covered only by remote-tracking refs>
unsafe: HEAD commits covered only by remote-tracking refs (prunable) in /tmp/sweep-remote.LaiY/repo
[exit 3]
```
</details>
<details>
<summary>Evidence: `bin/fm-treehouse-pool-sweep.sh --help` output (rendered from the file header)</summary>

Source: [`bin/fm-treehouse-pool-sweep.sh --help` output (rendered from the file header)](https://github.com/ICGNU3/firstmate/blob/c82fc80bdfbeedbc47f4682a1cd1e1881cafe443/.no-mistakes/evidence/fm/fm-worktree-reuse-guard/pool-sweep-help.txt)

```text
$ bin/fm-treehouse-pool-sweep.sh --help
fm-treehouse-pool-sweep.sh - Pre-acquire worktree pool safety sweep

This is a MITIGATION (not a fix) for the worktree reuse incident. It inspects
pooled worktrees before acquisition and refuses to request one when unsafe pool
state is observed. The upstream invariant is: "No consumer can reuse a worktree
whose state is unsafe." This mitigation can only observe and refuse; it cannot
enforce the invariant across all consumers.

Usage: fm-treehouse-pool-sweep.sh <worktree-path>

The sweep checks two conditions and refuses on either:
  1. Dirty worktree: tracked modifications, staged changes, or untracked
     non-ignored files.
  2. HEAD contains at least one commit not reachable from an approved durable ref:
     - refs/heads/* (local branches)
     - refs/tags/* (tags)
     - refs/firstmate/rescue/* (reserved rescue namespace)

Reflogs are NOT refs. A commit reachable only from a reflog is unreferenced.

A question git cannot answer - an unreadable HEAD, a corrupt ref database, an
unreadable object - refuses under the same exit code as the negative answer it
resembles, but with its own diagnostic, so the operator is not sent looking for
uncommitted work or orphaned commits that do not exist.

For refs/remotes/*: they are counted for reachability so an ordinary freshly-
checked-out pool worktree is not falsely refused, but the case where HEAD's
commits are covered ONLY by remote-tracking refs (and no local head or tag) is
classified as unsafe.

Exit codes:
  0 - Worktree is safe to acquire (or sweep is disabled)
  1 - Worktree is unsafe: dirty, or its dirty state cannot be determined
  2 - Worktree is unsafe: HEAD contains commits not reachable from durable refs,
      or that reachability cannot be computed
  3 - Worktree is unsafe: HEAD covered only by remote-tracking refs (prunable)
  4 - Worktree does not exist
 64 - Usage error (no worktree path given)

Activation:
  The sweep is disabled by default. To enable, create:
    $FM_HOME/config/worktree-pool-sweep
  containing "on" (or any non-empty value other than "off").
  The config dir is $FM_CONFIG_OVERRIDE when set, otherwise $FM_HOME/config,
  and $FM_HOME defaults to the firstmate repo root - the same resolution every
  other firstmate script uses, so an enable written for one home applies to
  that home only.
  A missing file, an empty file, or the value "off" leaves the sweep disabled.

This mitigation is distinct from the upstream Treehouse invariant:
  - MITIGATION: "Firstmate refuses to request a worktree when it observes unsafe pool state."
  - INVARIANT:  "No consumer can reuse a worktree whose state is unsafe."

Structural gaps this mitigation cannot close:
  1. A direct treehouse get by anything other than firstmate bypasses the sweep.
  2. Another firstmate home can race between sweep and acquire:

     T1  Firstmate A sweeps -> safe
     T2  Firstmate B acquires/modifies the same pool
     T3  Firstmate A calls treehouse get

     This race can cause the worktree to be unsafe when Firstmate A uses it.
     The eventual Treehouse fix must kill this atomically at allocation time.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"153e17281943ea1b7726e7bd6d6040f3f52a28c3","steps":[{"step":"intent","status":"skipped"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"skipped"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `bin/fm-treehouse-pool-sweep.sh:170` - The durable-reachability gate can never refuse an attached HEAD, so the mitigation misses the loss it is meant to prevent. `git rev-list --count HEAD --not --branches --tags --glob=&#39;refs/firstmate/rescue/*&#39;` puts HEAD&#39;s own branch into the `--not` set whenever HEAD is attached, so `unique_count` is structurally always 0 and `check_head_reachable` returns 0. Verified live: `git init -b main; commit base; checkout -b lane; commit lanework; git rev-list --count HEAD --not --branches --tags` prints 0 even though `lanework` exists on no other ref. Concrete failing sequence: a pool worktree is returned without a clean teardown (teardown&#39;s normal `git checkout --detach` + `git branch -D` never ran), so it is clean but still attached to `fm/&lt;task&gt;` carrying unpushed commits. is_dirty says clean; check_head_reachable says safe (count 0); fm-spawn.sh:2274 then calls `freshen_spawn_worktree_base`, whose `git reset --hard origin/&lt;default&gt;` (bin/fm-spawn.sh:1762) MOVES the attached branch ref, leaving those commits reachable only from the reflog - the exact &#34;commit reachable only from a reflog is unreferenced&#34; state the script header names as unsafe. The invariant the sweep claims (&#34;refuse when unsafe pool state is observed&#34;) therefore holds only for detached HEADs; every attached-HEAD pool worktree is waved through by construction, and test_allows_branch_reachable_head passes trivially rather than exercising the comparison. The earliest shared boundary is the reachability computation itself: evaluate HEAD against the refs that will still exist after freshen&#39;s reset - e.g. exclude HEAD&#39;s own symbolic-ref target from the `--not` set, or ask directly whether HEAD&#39;s commits survive `origin/&lt;default&gt;` - so an attached lane branch with unique commits is actually judged instead of vacuously cleared. Flagging as ask-user because narrowing the `--not` set changes which worktrees the mitigation refuses, which is your scoping call.
- ⚠️ `bin/fm-spawn.sh:2263` - A sweep refusal leaks the pooled worktree it just refused, so each refusal permanently drains a pool slot. The sweep is invoked only after `spawn_send_text_line &#34;$WT_TARGET&#34; &#39;treehouse get&#39;` (line 2215) has already succeeded and the pane has settled in the worktree - the acquisition is complete, contradicting the &#34;pre-acquire ... refuses to request one&#34; framing in the script header (line 5) and --help (line 26). On refusal fm-spawn prints the error and `exit 1`; `spawn_abort_cleanup` (line 692) releases locks and cleans up only the orca path - it never runs `treehouse return`, and the tmux window created for the task is never killed. `state/$ID.meta` is not published until line 2702, well after this point, so no state record exists for fm-teardown.sh to act on either (teardown_treehouse_return at bin/fm-teardown.sh:1061 is driven from that metadata). Concrete sequence: operator enables the sweep; a pool worktree fails the reachability check; spawn aborts; the worktree stays checked out and marked busy by treehouse with no owner and no path back. Retrying the spawn acquires a different slot and, since the refusal condition is a persistent property of the leaked worktree, repeats - so the pool shrinks by one per refusal until exhausted. The pre-existing `validate_spawn_worktree &#34;treehouse get&#34;` failure at line 2261 leaks the same way, but it fires only on a pathological pane/worktree mismatch, whereas this refusal is designed to fire on ordinary unsafe pool state. Either return the worktree before aborting (`treehouse return --force &#34;$WT&#34;`, tolerating failure the way teardown does) or state explicitly that a refusal quarantines the slot for manual inspection and say so in the operator message and docs/configuration.md. Marking ask-user: quarantine-vs-return is a deliberate product decision about what should happen to an unsafe worktree.
- ℹ️ `bin/fm-treehouse-pool-sweep.sh:24` - `usage()` hand-duplicates roughly 60 lines that already exist as the file&#39;s header comment (lines 2-21), including the exit-code table verbatim twice (lines 15-21 and 49-55) and the MITIGATION/structural-gap prose twice (lines 4-12 and 28-30, 71-80). 28 scripts under bin/ instead derive usage from the header with `sed -n &#39;2,${/^#/!q;p;}&#39; &#34;$0&#34; | sed &#39;s/^# \{0,1\}//&#39;` (bin/fm-spawn.sh:204-206), which keeps the two in sync by construction. Adopting that form here removes the heredoc entirely and eliminates the drift risk between the header and --help - the same drift that produced the earlier `$HOME/.firstmate` vs `$FM_HOME` and `off`-value help inaccuracies on this branch.
- ℹ️ `bin/fm-treehouse-pool-sweep.sh:98` - `FM_HOME=&#34;${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}&#34;` has a dead middle default: line 97 already sets `FM_ROOT=&#34;${FM_ROOT_OVERRIDE:-$(cd &#34;$SCRIPT_DIR/..&#34; &amp;&amp; pwd)}&#34;`, so whenever `FM_ROOT_OVERRIDE` is non-empty `$FM_ROOT` equals it, and when it is empty the `:-` falls through to `$FM_ROOT` anyway. The expression is exactly equivalent to `FM_HOME=&#34;${FM_HOME:-$FM_ROOT}&#34;`. (bin/fm-spawn.sh:212-213 carries the same redundancy, so matching it is defensible - but the simpler form is identical in behavior.)
- ℹ️ `bin/fm-treehouse-pool-sweep.sh:123` - `is_dirty` conflates &#34;git could not answer&#34; with &#34;dirty&#34;. `git diff-index --quiet --ignore-submodules HEAD 2&gt;/dev/null` exits 128 on an unborn or corrupt HEAD, and the leading `!` turns that failure into `return 0`, so the sweep exits 1 and prints &#34;unsafe: dirty worktree at &lt;path&gt;&#34; for a worktree that has no uncommitted changes at all. Failing closed is right; the label is not - an operator triaging the refusal will look for uncommitted work that does not exist, when the actual condition is an unusable HEAD. `check_head_reachable` already distinguishes an unanswerable question from a negative answer (lines 154, 171); doing the same here - separate the diff-index non-zero-vs-128 cases, or emit a distinct &#34;cannot inspect HEAD&#34; diagnostic - would make the message match reality without changing the refusal.

🔧 Fix: derive sweep help from header; distinct uninspectable-HEAD diagnostic
3 infos still open:

- ℹ️ `bin/fm-treehouse-pool-sweep.sh:184` - Exit 2 still conflates &#34;git could not answer the reachability question&#34; with &#34;HEAD has unreachable commits&#34; - the same mislabel class you already chose to fix for is_dirty (round 1, review-23). check_head_reachable returns 2 both when unique_count &gt; 0 (line 164) and when rev-list fails or prints a non-numeric value (lines 160, 162), and line 184 prints &#34;unsafe: HEAD contains commits not reachable from durable refs in &lt;path&gt;&#34; for both. Concrete path, and the branch&#39;s own fixture proves it is reachable: tests/fm-treehouse-pool-sweep.test.sh:505 writes a dangling ref into .git/refs/heads/dangling, rev-list exits 128, and the operator is told to go looking for orphaned commits when the actual condition is a corrupt ref database that no amount of inspecting HEAD will explain. (The narrower is_dirty case has the same shape: a HEAD that resolves but whose tree object is unreadable makes diff-index exit 128, and line 176 calls that &#34;dirty worktree&#34;.) Failing closed is right; the label is not. Emit a distinct diagnostic - e.g. capture rev-list&#39;s status separately and print &#34;unsafe: cannot compute HEAD reachability in &lt;path&gt;&#34; - while keeping the refusal and the exit code, so the existing test assertion at line 525 still holds.
- ℹ️ `bin/fm-spawn.sh:2263` - The `if [ -x &#34;$SCRIPT_DIR/fm-treehouse-pool-sweep.sh&#34; ]` guard makes an explicitly enabled safety gate fail open with no diagnostic. If the file is absent or loses its executable bit (a copied/rsynced install, a checkout with core.fileMode off, a partial update), fm-spawn skips the sweep entirely and spawns normally - the operator who wrote `on` into config/worktree-pool-sweep has no signal that the mitigation they turned on never ran. This is the only `[ -x &#34;$SCRIPT_DIR/...&#34; ]` guard in bin/; every other sibling helper (fm-ff-lib.sh, fm-wake-lib.sh, fm-guard, ...) is sourced or invoked unconditionally, so a missing file surfaces as an error rather than a silent no-op. Neither new suite covers the skip branch. Invoking it unconditionally (the `|| sweep_rc=$?` capture already turns a missing script into 127 and refuses) would make it fail closed and match repo convention; flagging ask-user because fail-open-on-missing-script vs fail-closed is your call about what an incomplete install should do.
- ℹ️ `docs/configuration.md:143` - Commit dfd7ac7 (&#34;tighten worktree pool sweep config docs&#34;, a pipeline-authored document step) deleted the sentence &#34;The sweep is currently disabled by default. Two live lanes hold pooled worktrees and must not be disturbed until they are free.&#34; That lane note is exactly review-18 from round 4, which you reviewed and did NOT select - the recorded decision was to keep it. The durable half survives (line 132 still says &#34;shipped deactivated&#34;), but the operational note about the two live lanes is gone from the branch without a decision to remove it. Either restore the sentence or confirm the removal is what you want; no source behavior is affected either way.

🔧 Fix: distinguish unanswerable git probes from unsafe verdicts in sweep
1 info still open:

- ℹ️ `bin/fm-treehouse-pool-sweep.sh:126` - The `--cached` probe in `is_dirty` (lines 126-132) is unreachable, and the test added to justify it does not exercise it. It runs only when the preceding plain `git diff-index --quiet --ignore-submodules HEAD` returned 0, but that probe already reports any index-vs-HEAD delta regardless of the working tree. Verified live in a scratch repo: commit `original`, `printf staged &gt; f &amp;&amp; git add f`, restore `printf original &gt; f`, `git update-index --refresh` -&gt; `git diff-index --quiet HEAD` exits 1 (and so does `--cached`). Also verified with `git update-index --assume-unchanged f` staged the same way: still `plain=1`. So there is no state where the first probe says clean and the second says dirty. Consequence for the fix round&#39;s own claim: `test_refuses_staged_change_restored_in_worktree` (tests/fm-treehouse-pool-sweep.test.sh:171) was added specifically as &#34;the case only the `--cached` branch catches&#34;, but it reaches exit 1 through the first probe - deleting lines 126-132 leaves it green, so it proves nothing about that branch. This is the same subsumption already reported as review-5 in an earlier round and selected for fix; it was never removed. Drop lines 126-132 and retitle the test to what it actually asserts (a staged delta whose worktree matches HEAD is still refused), or keep the branch only if a state that reaches it can be exhibited.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-treehouse-pool-sweep.test.sh` — 23 sweep verdict/config-resolution cases, all pass</code>
- <code>`bash tests/fm-spawn-pool-sweep-wiring.test.sh` — shipped-deactivated, enabled-refusal, and explicit-off spawn-path cases, all pass</code>
- <code>Manual end-to-end: drove the real `bin/fm-spawn.sh` acquisition path against a synthetic project/origin/pool fixture (fake tmux + treehouse, `FM_GATE_REFUSE_BYPASS=1`) with the pool parked on a committed-but-unreferenced commit, under three config states (absent / `on` / `off`), capturing spawn stdout, exit code, pool HEAD and the surviving `abandoned.txt`</code>
- <code>Manual: `FM_HOME=&lt;fixture&gt; bin/fm-treehouse-pool-sweep.sh &lt;path&gt;` against dirty, unborn-HEAD, orphan-HEAD, dangling-ref, remote-only, nonexistent, and no-argument fixtures to capture each diagnostic and exit code</code>
- `bin/fm-treehouse-pool-sweep.sh --help`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⏭️ **Lint** - skipped</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
