### PR TITLE
fix(herdr): pin immutable primary for lab tripwire

### DIFF
--- a/bin/fm-herdr-lab.sh
+++ b/bin/fm-herdr-lab.sh
@@ -22,9 +22,10 @@
 # Both paths perform a fresh refuse-default check immediately before each
 # destructive call.
 # Provision records the running primary session as a fleet-state tripwire and
-# teardown requires that record to be identical afterward.
-# FM_HERDR_LAB_PRIMARY_SESSION, then inherited HERDR_SESSION, identifies a
-# named primary; absent either record, the primary remains literal default.
+# teardown requires that immutable record to be identical afterward.
+# FM_HERDR_LAB_PRIMARY_SESSION explicitly identifies a named primary; otherwise
+# provision requires exactly one running session outside the fm-lab-* namespace.
+# HERDR_SESSION is deliberately never a primary source because tests mutate it.
 set -u
 
 fm_herdr_lab_error() {
@@ -60,10 +61,16 @@ fm_herdr_lab_session_list() { # <session>
   fm_herdr_lab_raw "$1" session list --json
 }
 
-fm_herdr_lab_primary_session() {
-  local primary=${FM_HERDR_LAB_PRIMARY_SESSION:-${HERDR_SESSION:-default}}
+fm_herdr_lab_primary_session() { # <session-list-json>
+  local sessions=$1 primary=${FM_HERDR_LAB_PRIMARY_SESSION:-}
+  if [ -z "$primary" ]; then
+    primary=$(printf '%s' "$sessions" | jq -r '
+      [.sessions[]? | select(.running == true and (.name | startswith("fm-lab-") | not))]
+      | if length == 1 then .[0].name else empty end
+    ' 2>/dev/null)
+  fi
   [ -n "$primary" ] || {
-    fm_herdr_lab_error "fleet-state tripwire requires a non-empty primary session record"
+    fm_herdr_lab_error "fleet-state tripwire requires exactly one running non-lab primary session or an explicit FM_HERDR_LAB_PRIMARY_SESSION"
     return 1
   }
   case "$primary" in
@@ -75,15 +82,21 @@ fm_herdr_lab_primary_session() {
   printf '%s\n' "$primary"
 }
 
-fm_herdr_lab_fleet_state() { # <session>
-  local name=$1 primary sessions snapshot
-  primary=$(fm_herdr_lab_primary_session) || return 1
-  [ "$primary" != "$name" ] || {
-    fm_herdr_lab_error "fleet-state tripwire refuses the lab session as its own primary"
-    return 1
-  }
+fm_herdr_lab_fleet_state() { # <session> [recorded-primary]
+  local name=$1 primary=${2:-} sessions snapshot
   sessions=$(fm_herdr_lab_session_list "$name" 2>/dev/null) || {
     fm_herdr_lab_error "cannot read Herdr sessions for the fleet-state tripwire"
+    return 1
+  }
+  [ -n "$primary" ] || primary=$(fm_herdr_lab_primary_session "$sessions") || return 1
+  case "$primary" in
+    fm-lab-*|'')
+      fm_herdr_lab_error "fleet-state tripwire refuses invalid recorded primary session '$primary'"
+      return 1
+      ;;
+  esac
+  [ "$primary" != "$name" ] || {
+    fm_herdr_lab_error "fleet-state tripwire refuses the lab session as its own primary"
     return 1
   }
   snapshot=$(printf '%s' "$sessions" | jq -c --arg primary "$primary" '
@@ -240,14 +253,18 @@ fm_herdr_lab_provision() { # <session>
 }
 
 fm_herdr_lab_check_tripwire() { # <session>
-  local name=$1 tripwire before after
+  local name=$1 tripwire before primary after
   tripwire=$(fm_herdr_lab_tripwire_path "$name")
   [ -f "$tripwire" ] || {
     fm_herdr_lab_error "missing fleet-state tripwire for '$name'; refusing unverified teardown"
     return 1
   }
   before=$(cat "$tripwire")
-  after=$(fm_herdr_lab_fleet_state "$name") || return 1
+  primary=$(printf '%s' "$before" | jq -er '.name | select(type == "string" and length > 0)' 2>/dev/null) || {
+    fm_herdr_lab_error "fleet-state tripwire has no valid recorded primary session"
+    return 1
+  }
+  after=$(fm_herdr_lab_fleet_state "$name" "$primary") || return 1
   [ "$before" = "$after" ] || {
     fm_herdr_lab_error "FLEET-STATE TRIPWIRE FAILED: primary session changed during lab work"
     fm_herdr_lab_error "before: $before"

--- a/bin/fm-herdr-lab.sh
+++ b/bin/fm-herdr-lab.sh
@@ -21,8 +21,10 @@
 # delete is available only through teardown.
 # Both paths perform a fresh refuse-default check immediately before each
 # destructive call.
-# Provision records the running default session as a fleet-state tripwire and
+# Provision records the running primary session as a fleet-state tripwire and
 # teardown requires that record to be identical afterward.
+# FM_HERDR_LAB_PRIMARY_SESSION, then inherited HERDR_SESSION, identifies a
+# named primary; absent either record, the primary remains literal default.
 set -u
 
 fm_herdr_lab_error() {
@@ -58,21 +60,41 @@ fm_herdr_lab_session_list() { # <session>
   fm_herdr_lab_raw "$1" session list --json
 }
 
+fm_herdr_lab_primary_session() {
+  local primary=${FM_HERDR_LAB_PRIMARY_SESSION:-${HERDR_SESSION:-default}}
+  [ -n "$primary" ] || {
+    fm_herdr_lab_error "fleet-state tripwire requires a non-empty primary session record"
+    return 1
+  }
+  case "$primary" in
+    fm-lab-*)
+      fm_herdr_lab_error "fleet-state tripwire refuses lab session '$primary' as the primary"
+      return 1
+      ;;
+  esac
+  printf '%s\n' "$primary"
+}
+
 fm_herdr_lab_fleet_state() { # <session>
-  local name=$1 sessions snapshot
+  local name=$1 primary sessions snapshot
+  primary=$(fm_herdr_lab_primary_session) || return 1
+  [ "$primary" != "$name" ] || {
+    fm_herdr_lab_error "fleet-state tripwire refuses the lab session as its own primary"
+    return 1
+  }
   sessions=$(fm_herdr_lab_session_list "$name" 2>/dev/null) || {
     fm_herdr_lab_error "cannot read Herdr sessions for the fleet-state tripwire"
     return 1
   }
-  snapshot=$(printf '%s' "$sessions" | jq -c '
-    [.sessions[]? | select(.default == true)]
-    | if length == 1 and .[0].name == "default" and .[0].running == true
+  snapshot=$(printf '%s' "$sessions" | jq -c --arg primary "$primary" '
+    [.sessions[]? | select(.name == $primary and .running == true)]
+    | if length == 1
       then .[0] | {name, default, running, socket_path}
       else empty
       end
   ' 2>/dev/null)
   [ -n "$snapshot" ] || {
-    fm_herdr_lab_error "fleet-state tripwire requires exactly one running default session"
+    fm_herdr_lab_error "fleet-state tripwire requires exactly one running recorded primary session '$primary'"
     return 1
   }
   printf '%s\n' "$snapshot"
@@ -227,7 +249,7 @@ fm_herdr_lab_check_tripwire() { # <session>
   before=$(cat "$tripwire")
   after=$(fm_herdr_lab_fleet_state "$name") || return 1
   [ "$before" = "$after" ] || {
-    fm_herdr_lab_error "FLEET-STATE TRIPWIRE FAILED: default session changed during lab work"
+    fm_herdr_lab_error "FLEET-STATE TRIPWIRE FAILED: primary session changed during lab work"
     fm_herdr_lab_error "before: $before"
     fm_herdr_lab_error "after:  $after"
     return 1

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -309,7 +309,8 @@ An environment-only session selection can silently reach a different running ser
 It provisions only non-default names beginning with `fm-lab-`, appends an explicit `--session` to allowed task commands, refuses caller-supplied session flags and server/session lifecycle subcommands, and performs destructive stop/delete only through its guarded lifecycle actions.
 Immediately before every destructive call it re-queries the named session and refuses empty, missing, literal `default`, or `default:true` identities.
 Its before/after tripwire requires the recorded running primary-session snapshot to remain byte-identical.
-The helper uses `FM_HERDR_LAB_PRIMARY_SESSION`, then an inherited `HERDR_SESSION`, and otherwise literal `default`; it requires exactly one running session with that exact name and refuses a lab-namespaced, missing, stopped, or ambiguous primary record.
+The helper uses an explicit `FM_HERDR_LAB_PRIMARY_SESSION` or discovers exactly one running session outside the `fm-lab-*` namespace during provisioning, records that choice in the tripwire, and never trusts mutable `HERDR_SESSION` as the primary identity.
+It requires exactly one running session with the recorded name and refuses a lab-namespaced, missing, stopped, or ambiguous primary record.
 
 The helper's header and `--help` own exact commands.
 Tests use thin compatibility wrappers in `tests/herdr-test-safety.sh` and never duplicate the destructive policy.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -308,7 +308,8 @@ An environment-only session selection can silently reach a different running ser
 `bin/fm-herdr-lab.sh` is the sole supported lifecycle helper for isolated verification.
 It provisions only non-default names beginning with `fm-lab-`, appends an explicit `--session` to allowed task commands, refuses caller-supplied session flags and server/session lifecycle subcommands, and performs destructive stop/delete only through its guarded lifecycle actions.
 Immediately before every destructive call it re-queries the named session and refuses empty, missing, literal `default`, or `default:true` identities.
-Its before/after tripwire requires the live default-session snapshot to remain byte-identical.
+Its before/after tripwire requires the recorded running primary-session snapshot to remain byte-identical.
+The helper uses `FM_HERDR_LAB_PRIMARY_SESSION`, then an inherited `HERDR_SESSION`, and otherwise literal `default`; it requires exactly one running session with that exact name and refuses a lab-namespaced, missing, stopped, or ambiguous primary record.
 
 The helper's header and `--help` own exact commands.
 Tests use thin compatibility wrappers in `tests/herdr-test-safety.sh` and never duplicate the destructive policy.
@@ -342,5 +343,5 @@ tests/fm-afk-inject-herdr-e2e.test.sh
 tests/fm-afk-pi-herdr-return-e2e.test.sh
 ```
 
-Real Herdr tests use the named lab helper and default-session tripwire.
+Real Herdr tests use the named lab helper and exact primary-session tripwire.
 [`verification/runtime-backends.md`](verification/runtime-backends.md#herdr) records the active version, CLI, projection, event, and lifecycle evidence without task-specific chronology.

--- a/tests/fm-backend-herdr-focus-flash-e2e.test.sh
+++ b/tests/fm-backend-herdr-focus-flash-e2e.test.sh
@@ -237,7 +237,7 @@ C_SURVIVOR_ORDER=$(printf '%s' "$C_ORDER" | tr ',' '\n' | grep -v "^$C_DOOMED_WS
 
 # One persistent background child of the pane's shell, started outside any
 # worktree so nothing reaps it, is enough to fail the proof on every sample.
-lab pane send-text "$C_DOOMED_PANE" 'cd / && sleep 3000 &' >/dev/null \
+lab pane send-text "$C_DOOMED_PANE" 'cd /; sleep 3000 &' >/dev/null \
   || fail 'could not send the Part C persistent-child command'
 lab pane send-keys "$C_DOOMED_PANE" enter >/dev/null \
   || fail 'could not submit the Part C persistent-child command'

--- a/tests/fm-herdr-lab.test.sh
+++ b/tests/fm-herdr-lab.test.sh
@@ -98,7 +98,7 @@ run_with_fake() {
     FM_FAKE_HERDR_PRIMARY_NAME="${FM_FAKE_HERDR_PRIMARY_NAME:-default}" \
     FM_FAKE_HERDR_PRIMARY_RUNNING="${FM_FAKE_HERDR_PRIMARY_RUNNING:-true}" \
     FM_FAKE_HERDR_DUPLICATE_PRIMARY="${FM_FAKE_HERDR_DUPLICATE_PRIMARY:-false}" \
-    FM_HERDR_LAB_PRIMARY_SESSION="${FM_HERDR_LAB_PRIMARY_SESSION:-default}" \
+    FM_HERDR_LAB_PRIMARY_SESSION="${FM_HERDR_LAB_PRIMARY_SESSION:-}" \
     FM_HERDR_LAB_STATE_DIR="$TRIPWIRES" \
     "$@"
 }
@@ -150,7 +150,8 @@ test_provision_run_and_guarded_teardown() {
   run_with_fake fm_herdr_lab_cli "$name" --remote host workspace list >/dev/null 2>&1 || status=$?
   expect_code 1 "$status" "a leading option subverting session isolation must be refused"
 
-  run_with_fake fm_herdr_lab_teardown "$name" || fail "guarded teardown failed"
+  HERDR_SESSION="$name" run_with_fake fm_herdr_lab_teardown "$name" \
+    || fail "guarded teardown failed after HERDR_SESSION mutated to the lab"
   [ "$(cat "$FAKE_STATE/$name")" = deleted ] || fail "teardown did not delete the lab session"
   assert_absent "$TRIPWIRES/$name.fleet-state.json" "successful teardown left its tripwire behind"
 
@@ -170,7 +171,7 @@ test_provision_run_and_guarded_teardown() {
     || fail "stop was not immediately preceded by a fresh refuse-default session list"
   sed -n "$((delete_line - 1))p" "$FAKE_LOG" | grep -F "session list --json --session $name" >/dev/null \
     || fail "delete was not immediately preceded by a fresh refuse-default session list"
-  pass "fm-herdr-lab: provisioning, scoped calls, guarded teardown, and fleet tripwire are deterministic"
+  pass "fm-herdr-lab: mutable lab HERDR_SESSION cannot replace the recorded primary during guarded teardown"
 }
 
 test_named_primary_is_exact_and_unambiguous() {

--- a/tests/fm-herdr-lab.test.sh
+++ b/tests/fm-herdr-lab.test.sh
@@ -33,14 +33,27 @@ lab_state=absent
 
 case "$1 ${2:-}" in
   "session list")
-    if [ "$lab_state" = absent ] || [ "$lab_state" = deleted ]; then
-      jq -nc --arg socket "$default_socket" '{sessions:[{default:true,name:"default",running:true,socket_path:$socket}]}'
-    else
-      running=false
-      [ "$lab_state" = running ] && running=true
-      jq -nc --arg socket "$default_socket" --arg name "$session" --argjson running "$running" \
-        '{sessions:[{default:true,name:"default",running:true,socket_path:$socket},{default:false,name:$name,running:$running,socket_path:("/tmp/" + $name + ".sock")}]}'
-    fi
+    primary=${FM_FAKE_HERDR_PRIMARY_NAME:-default}
+    primary_running=${FM_FAKE_HERDR_PRIMARY_RUNNING:-true}
+    duplicate_primary=${FM_FAKE_HERDR_DUPLICATE_PRIMARY:-false}
+    running=false
+    [ "$lab_state" = running ] && running=true
+    lab_present=false
+    [ "$lab_state" = absent ] || [ "$lab_state" = deleted ] || lab_present=true
+    jq -nc \
+      --arg socket "$default_socket" \
+      --arg primary "$primary" \
+      --arg name "$session" \
+      --argjson primary_running "$primary_running" \
+      --argjson duplicate_primary "$duplicate_primary" \
+      --argjson running "$running" \
+      --argjson lab_present "$lab_present" '
+      ({default:($primary == "default"),name:$primary,running:$primary_running,socket_path:$socket}) as $primary_session
+      | (if $primary == "default" then [] else [{default:true,name:"default",running:false,socket_path:"/tmp/default.sock"}] end)
+        + [$primary_session]
+        + (if $duplicate_primary then [$primary_session] else [] end)
+        + (if $lab_present then [{default:false,name:$name,running:$running,socket_path:("/tmp/" + $name + ".sock")}] else [] end)
+      | {sessions:.}'
     ;;
   "server --session")
     if [ "${FM_FAKE_HERDR_SERVER_DELAY:-0}" != 0 ]; then
@@ -82,6 +95,10 @@ run_with_fake() {
     FM_FAKE_HERDR_SERVER_DELAY="${FM_FAKE_HERDR_SERVER_DELAY:-0}" \
     FM_FAKE_HERDR_FAST_POLL="${FM_FAKE_HERDR_FAST_POLL:-}" \
     FM_FAKE_HERDR_DELETE_FAIL="${FM_FAKE_HERDR_DELETE_FAIL:-}" \
+    FM_FAKE_HERDR_PRIMARY_NAME="${FM_FAKE_HERDR_PRIMARY_NAME:-default}" \
+    FM_FAKE_HERDR_PRIMARY_RUNNING="${FM_FAKE_HERDR_PRIMARY_RUNNING:-true}" \
+    FM_FAKE_HERDR_DUPLICATE_PRIMARY="${FM_FAKE_HERDR_DUPLICATE_PRIMARY:-false}" \
+    FM_HERDR_LAB_PRIMARY_SESSION="${FM_HERDR_LAB_PRIMARY_SESSION:-default}" \
     FM_HERDR_LAB_STATE_DIR="$TRIPWIRES" \
     "$@"
 }
@@ -154,6 +171,30 @@ test_provision_run_and_guarded_teardown() {
   sed -n "$((delete_line - 1))p" "$FAKE_LOG" | grep -F "session list --json --session $name" >/dev/null \
     || fail "delete was not immediately preceded by a fresh refuse-default session list"
   pass "fm-herdr-lab: provisioning, scoped calls, guarded teardown, and fleet tripwire are deterministic"
+}
+
+test_named_primary_is_exact_and_unambiguous() {
+  local name="fm-lab-named-primary-$$" stopped="fm-lab-stopped-primary-$$" duplicate="fm-lab-duplicate-primary-$$" status=0
+  : > "$FAKE_LOG"
+  FM_HERDR_LAB_PRIMARY_SESSION=fm-wsl-minimal FM_FAKE_HERDR_PRIMARY_NAME=fm-wsl-minimal \
+    run_with_fake fm_herdr_lab_provision "$name" || fail "named primary provision failed"
+  [ "$(jq -r '.name' "$TRIPWIRES/$name.fleet-state.json")" = fm-wsl-minimal ] \
+    || fail "tripwire did not record the exact named primary"
+  FM_HERDR_LAB_PRIMARY_SESSION=fm-wsl-minimal FM_FAKE_HERDR_PRIMARY_NAME=fm-wsl-minimal \
+    run_with_fake fm_herdr_lab_teardown "$name" || fail "named primary teardown failed"
+
+  status=0
+  FM_HERDR_LAB_PRIMARY_SESSION=fm-wsl-minimal FM_FAKE_HERDR_PRIMARY_NAME=fm-wsl-minimal \
+    FM_FAKE_HERDR_PRIMARY_RUNNING=false run_with_fake fm_herdr_lab_prepare "$stopped" >/dev/null 2>&1 || status=$?
+  expect_code 1 "$status" "stopped named primary must be refused"
+  assert_absent "$TRIPWIRES/$stopped.fleet-state.json" "stopped named primary left a tripwire"
+
+  status=0
+  FM_HERDR_LAB_PRIMARY_SESSION=fm-wsl-minimal FM_FAKE_HERDR_PRIMARY_NAME=fm-wsl-minimal \
+    FM_FAKE_HERDR_DUPLICATE_PRIMARY=true run_with_fake fm_herdr_lab_prepare "$duplicate" >/dev/null 2>&1 || status=$?
+  expect_code 1 "$status" "duplicate named primary candidates must be refused"
+  assert_absent "$TRIPWIRES/$duplicate.fleet-state.json" "ambiguous named primary left a tripwire"
+  pass "fm-herdr-lab: a recorded running named primary is accepted only when exact and unambiguous"
 }
 
 test_missing_tripwire_blocks_destruction() {
@@ -236,6 +277,7 @@ SH
 
 test_refuses_unsafe_names
 test_provision_run_and_guarded_teardown
+test_named_primary_is_exact_and_unambiguous
 test_missing_tripwire_blocks_destruction
 test_changed_default_trips_after_teardown
 test_stopped_owned_lab_can_reprovision

--- a/tests/herdr-test-safety.sh
+++ b/tests/herdr-test-safety.sh
@@ -11,9 +11,7 @@ set -u
 export FM_GATE_REFUSE_BYPASS=1
 
 HERDR_TEST_SAFETY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-if [ -z "${FM_HERDR_LAB_PRIMARY_SESSION:-}" ] && [ -n "${HERDR_SESSION:-}" ]; then
-  export FM_HERDR_LAB_PRIMARY_SESSION=$HERDR_SESSION
-fi
+# The helper selects the primary independently of mutable HERDR_SESSION.
 # shellcheck source=/dev/null
 . "$HERDR_TEST_SAFETY_DIR/bin/fm-herdr-lab.sh"
 

--- a/tests/herdr-test-safety.sh
+++ b/tests/herdr-test-safety.sh
@@ -11,6 +11,9 @@ set -u
 export FM_GATE_REFUSE_BYPASS=1
 
 HERDR_TEST_SAFETY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if [ -z "${FM_HERDR_LAB_PRIMARY_SESSION:-}" ] && [ -n "${HERDR_SESSION:-}" ]; then
+  export FM_HERDR_LAB_PRIMARY_SESSION=$HERDR_SESSION
+fi
 # shellcheck source=/dev/null
 . "$HERDR_TEST_SAFETY_DIR/bin/fm-herdr-lab.sh"
 


### PR DESCRIPTION
## Summary
- preserve PR 2820's named-primary compatibility and direct persistent-sleep fixture
- select the protected primary explicitly or by one unambiguous running non-lab session at provisioning
- persist that selection in the tripwire so mutable lab `HERDR_SESSION` cannot replace it during checks or teardown
- preserve running-state, exact-name uniqueness, namespace, byte-identical snapshot, and destructive ownership checks

## Regression
The prior implementation inherited mutable `HERDR_SESSION`. Real Herdr tests then exported their `fm-lab-*` session and caused the helper to misclassify the lab as the protected primary. The focused unit regression now mutates `HERDR_SESSION` to the owned lab before teardown and proves the recorded primary remains authoritative.

## Validation
- `timeout 120s tests/fm-herdr-lab.test.sh`
- `timeout 180s bin/fm-lint.sh --jobs 1 bin/fm-herdr-lab.sh tests/fm-herdr-lab.test.sh tests/herdr-test-safety.sh tests/fm-backend-herdr-focus-flash-e2e.test.sh`
- `git diff --check`

Local real-Herdr E2E was unavailable because the scaffold-bound installed lifecycle helper is the pre-fix component under test. No live session was touched. The required GitHub real-Herdr lane provides environment-level proof.