### PR TITLE
fix(bin): prevent teardown failure on stale busy-state locks

### DIFF
--- a/bin/fm-busy-event.sh
+++ b/bin/fm-busy-event.sh
@@ -95,6 +95,19 @@ REC=$(fm_busy_record_path "$STATE" "$ID")
 GEN_FILE=$(fm_busy_gen_path "$STATE" "$ID")
 LOCK="$REC.lock"
 
+# Portable mtime in epoch seconds. macOS (BSD) stat uses `-f <fmt>`; Linux (GNU)
+# stat uses `-c <fmt>`. Do NOT collapse this into `stat -f <fmt> ... || stat -c
+# <fmt> ...`: on GNU `-f` is *filesystem* stat, so it reads the format string as
+# a path, reports that on stderr, prints a partial filesystem dump ("  File:
+# ...") on stdout, and still exits 0 - the fallback never runs and the caller
+# gets a non-numeric token. Detect the platform once and pick the right form,
+# exactly as bin/fm-watch.sh does.
+if [ "$(uname)" = Darwin ]; then
+  lock_mtime() { stat -f %m "$1" 2>/dev/null; }
+else
+  lock_mtime() { stat -c %Y "$1" 2>/dev/null; }
+fi
+
 # Serialize writers. The lock protects seq advancement and the sidecar/record
 # pair; a holder that died mid-write is broken after FM_BUSY_LOCK_STALE_SECS.
 lock_acquire() {
@@ -103,7 +116,11 @@ lock_acquire() {
     tries=$((tries + 1))
     if [ "$tries" -ge 40 ]; then
       now=$(date +%s)
-      mtime=$(stat -f %m "$LOCK" 2>/dev/null || stat -c %Y "$LOCK" 2>/dev/null || echo "$now")
+      mtime=$(lock_mtime "$LOCK" || true)
+      # Anything unreadable or non-numeric reads as "just created", so an
+      # unforeseen stat surprise degrades to a lock-timeout refusal instead of
+      # aborting the writer - and its caller, fm-teardown.sh - under `set -u`.
+      case "$mtime" in ''|*[!0-9]*) mtime=$now ;; esac
       age=$((now - mtime))
       if [ "$age" -ge "${FM_BUSY_LOCK_STALE_SECS:-5}" ]; then
         rmdir "$LOCK" 2>/dev/null || rm -rf "$LOCK" 2>/dev/null || true

--- a/tests/fm-busy-state.test.sh
+++ b/tests/fm-busy-state.test.sh
@@ -107,6 +107,64 @@ test_retire_serializes_and_rejects_stale_gen() {
   pass "retire waits for the writer lock and cannot remove a new incarnation"
 }
 
+# Regression for issue #2625: the writer lock's stale-lock branch resolved the
+# lock's mtime with `stat -f %m ... || stat -c %Y ...`. On GNU coreutils `-f` is
+# *filesystem* stat, so it consumes the format string as a path, complains on
+# stderr, prints "  File: ..." on stdout, and still exits 0 - the GNU form in the
+# fallback never ran. The following `$((now - mtime))` then evaluated the word
+# `File`, which under `set -u` aborted the writer with "File: unbound variable".
+# fm-teardown.sh died there after returning the worktree, leaving state/<id>.meta
+# and friends behind to generate stale wakes forever, and every re-run died
+# identically because the abandoned lock directory was never broken.
+#
+# The stat and uname stubs make this deterministic on any host: the writer must
+# take the Linux path and still break a provably stale lock.
+test_stale_lock_broken_under_gnu_stat() {
+  local state gen fakebin real_uname out status
+  state=$(new_state_dir gnu-stat-lock)
+  gen=$("$EV" arm "$state" t1)
+  fakebin=$(fm_fakebin "$TMP_ROOT/gnu-stat-lock")
+  real_uname=$(command -v uname)
+
+  # GNU coreutils semantics, self-contained so no real stat is consulted.
+  cat > "$fakebin/stat" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = -c ] && [ "${2:-}" = %Y ]; then
+  printf '%s\n' 1000000000   # long-abandoned lock
+  exit 0
+fi
+if [ "${1:-}" = -f ]; then
+  echo "stat: cannot read file system information for '$2': No such file or directory" >&2
+  shift 2
+  printf '  File: "%s"\n' "${1:-}"
+  exit 0
+fi
+exit 1
+SH
+  chmod +x "$fakebin/stat"
+  cat > "$fakebin/uname" <<SH
+#!/usr/bin/env bash
+if [ \$# -eq 0 ]; then printf 'Linux\n'; exit 0; fi
+exec "$real_uname" "\$@"
+SH
+  chmod +x "$fakebin/uname"
+
+  mkdir "$state/t1.busy-state.lock"
+  out=$(PATH="$fakebin:$PATH" "$EV" retire "$state" t1 --gen "$gen" 2>&1) && status=0 || status=$?
+  case "$out" in
+    *'unbound variable'*) fail "the writer still dies on GNU stat output: $out" ;;
+  esac
+  [ "$status" = 0 ] || fail "retire did not break a provably stale writer lock: $out"
+  [ ! -e "$state/t1.busy-state" ] || fail "retire left the record behind"
+  [ ! -e "$state/t1.busy-gen" ] || fail "retire left the gen sidecar behind"
+  [ ! -e "$state/t1.busy-state.lock" ] || fail "retire left the stale lock behind"
+
+  # Teardown must be able to run again over the same task without failing.
+  PATH="$fakebin:$PATH" "$EV" retire "$state" t1 --current-gen \
+    || fail "a repeated retire over already-cleaned state was not idempotent"
+  pass "the writer breaks a stale lock instead of dying on GNU stat output"
+}
+
 test_retire_missing_sidecar_is_idempotent() {
   local state gen
   state=$(new_state_dir retire-missing)
@@ -387,6 +445,7 @@ test_apply_current_gen_reset
 test_apply_unarmed_refused
 test_retire_serializes_and_rejects_stale_gen
 test_retire_missing_sidecar_is_idempotent
+test_stale_lock_broken_under_gnu_stat
 test_stale_gen_event_rejected
 test_stale_gen_record_unknown
 test_missing_record_unknown_not_idle


### PR DESCRIPTION
## Intent

Fix GitHub issue kunchenguid/firstmate#2625: bin/fm-teardown.sh dies with '\''File: unbound variable'\'' on Linux after successfully returning the worktree, leaving state/<id>.meta, .status, .busy-gen, .busy-state, .busy-state.lock/ and .turn-ended behind. Because the metadata survives, the watcher keeps monitoring an endpoint whose agent is gone, so a finished task generates recurring stale wakes forever, and re-running teardown fails identically so it never self-heals.

Root cause, confirmed by reproduction: bin/fm-busy-event.sh:106 resolved the writer lock'\''s mtime in the stale-lock branch with `stat -f %m "$LOCK" 2>/dev/null || stat -c %Y "$LOCK" 2>/dev/null || echo "$now"`. The intent was '\''try the macOS/BSD form, fall back to the GNU form'\'', but the two tools mean different things by -f: on GNU coreutils -f is *filesystem* stat, so it treats the format string %m as a filename argument, reports that failure on stderr (swallowed by 2>/dev/null), still succeeds for the real path, and exits 0 while printing a partial filesystem dump ('\'' File: "/path"'\''). Exit 0 short-circuits the || chain, so mtime became the non-numeric token '\''File: ...'\'', and the following $((now - mtime)) evaluated the word File as an unset variable, aborting the script under `set -u`. The branch is only reached under lock contention (tries >= 40), which is why it surfaced intermittently rather than on every teardown.

Requested fix and the decisions made:
- Correct the unbound reference at its source and make teardown idempotent on re-run. Re-run idempotency follows from the same fix: the abandoned lock directory is now correctly detected as stale and broken, so a second teardown proceeds instead of dying at the same line. fm-busy-event.sh retire was already idempotent for an absent gen sidecar; the stale lock was the only thing blocking re-run.
- Deliberately chose platform detection (`if [ "$(uname)" = Darwin ]` selecting `stat -f %m` vs `stat -c %Y`) over the issue author'\''s suggestion of merely reordering the fallback chain to put -c first. bin/fm-watch.sh and bin/fm-supervise-daemon.sh already carry an explicit repo-level comment saying '\''Do NOT use the `stat -f <fmt> ... || stat -c <fmt> ...` fallback form'\'', and bin/fm-lock-lib.sh, bin/fm-wake-lib.sh and bin/fm-supervision-lib.sh all use the uname-gated form. Matching the pattern the codebase already documents is preferred over relying on the subtler contract that BSD stat happens to reject -c.
- Kept the issue'\''s numeric guard as defense in depth: any empty or non-numeric stat result is treated as '\''just created'\'', so a future portability surprise degrades to a lock-timeout refusal rather than killing teardown mid-way. This is intentional belt-and-braces on top of the platform detection, not redundancy to remove.
- Deliberately did NOT introduce a shared stat helper library or refactor the four existing uname-gated stat sites. The defect is a single-site correctness bug; a cross-cutting refactor would widen the blast radius of a fix meant to land safely.

The issue asked to grep bin/ for the same idiom elsewhere. That grep was done. bin/fm-busy-event.sh:106 was the only crash-capable instance: every other portable-stat site is either uname-gated already or orders the GNU form first. bin/fm-x-lib.sh:421 is the one remaining unordered chain, but it already validates the result numerically and returns non-zero, so on Linux it degrades safely (an optional mtime fallback for a record that normally carries its own recorded_at timestamp) and cannot crash. That is deliberately left out of scope and noted for follow-up rather than bundled into this focused fix.

Regression test first, then the fix. tests/fm-busy-state.test.sh gains test_stale_lock_broken_under_gnu_stat, which plants an abandoned .busy-state.lock directory and shims stat and uname on PATH so the writer deterministically takes the Linux path on any host: the stat stub reproduces GNU semantics exactly (-f prints the '\'' File: ...'\'' dump and exits 0; -c %Y returns a long-past epoch), and the uname stub reports Linux while delegating every other invocation to the real binary. The test was confirmed to fail against the unfixed code with the exact message from the issue report ('\''line 107: File: unbound variable'\'') before the fix was applied, then to pass after. It also asserts that the record, gen sidecar and stale lock are all gone and that a repeated retire over already-cleaned state still succeeds. Self-contained stubs were chosen over exercising the host'\''s real stat so the guard is deterministic on macOS as well as Linux, since this is a portability fix.

Scope: single production file (bin/fm-busy-event.sh) plus its test (tests/fm-busy-state.test.sh). Branch is based on upstream kunchenguid/firstmate main; the PR should target upstream and say Fixes #2625.

## What Changed

- Select the BSD or GNU `stat` form by platform when reading busy-state lock timestamps.
- Guard invalid timestamps so teardown fails safely while still breaking genuinely stale locks and supporting repeated retirement.
- Add deterministic GNU `stat` regression coverage for stale-lock cleanup and idempotent retirement. Fixes #2625.

## Risk Assessment

✅ Low: Captain, the focused change fixes the unsafe stat selection, guards arithmetic against invalid output, and adds behavioral coverage for stale-lock cleanup and idempotent retirement.

## Testing

Captain, targeted testing passed. The focused suite, base-versus-fixed Linux reproduction, idempotent rerun, and nonnumeric-mtime fail-safe all behaved as required, with three CLI/state transcripts captured.

<details>
<summary>Evidence: Fixed stale-lock retirement and idempotent rerun</summary>

Source: [Fixed stale-lock retirement and idempotent rerun](https://github.com/karotkriss/firstmate/blob/ce8b2d613a3238d6a2912a9e64e9285ad1d9333b/.no-mistakes/evidence/fm/fm-2625-teardown-unbound/gnu-stat-stale-lock-retire.txt)

```text
Environment: Linux
stat (uutils coreutils) 0.8.0

Before retire:
task-2625.busy-gen
task-2625.busy-state
task-2625.busy-state.lock
task-2625.meta
task-2625.status
task-2625.turn-ended

First retire with abandoned writer lock:
exit=0
Busy-state artifacts after first retire:
(none means record, generation sidecar, and writer lock were removed)

Second retire over already-clean state:
exit=0

Unrelated teardown-owned state remains for fm-teardown.sh to remove after retire succeeds:
task-2625.meta
task-2625.status
task-2625.turn-ended
```
</details>
<details>
<summary>Evidence: Base counterfactual reproducing File: unbound variable</summary>

Source: [Base counterfactual reproducing File: unbound variable](https://github.com/karotkriss/firstmate/blob/ce8b2d613a3238d6a2912a9e64e9285ad1d9333b/.no-mistakes/evidence/fm/fm-2625-teardown-unbound/base-counterfactual-gnu-stat-failure.txt)

```text
Counterfactual: base commit on the same Linux stat implementation
/tmp/fm-2625-base.qEC3z3/bin/fm-busy-event.sh: line 107: File: unbound variable
exit=1
Surviving busy-state artifacts:
task-2625.busy-gen
task-2625.busy-state
task-2625.busy-state.lock
```
</details>
<details>
<summary>Evidence: Nonnumeric stat output fails safely</summary>

Source: [Nonnumeric stat output fails safely](https://github.com/karotkriss/firstmate/blob/ce8b2d613a3238d6a2912a9e64e9285ad1d9333b/.no-mistakes/evidence/fm/fm-2625-teardown-unbound/nonnumeric-stat-fails-safe.txt)

```text
Injected Linux stat -c result: File: unexpected-portability-output
error: busy-state lock timeout for task-guard
exit=1
State preserved for a safe retry:
task-guard.busy-gen
task-guard.busy-state
task-guard.busy-state.lock
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"27b7749114aa97debc240ddd38a9d1705574ae8f","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-busy-state.test.sh`
- <code>Materialized base commit `8714c9a78c1b4355782fcb9ce1ccf14337478268`, planted a stale writer lock, and reproduced `File: unbound variable` through `fm-busy-event.sh retire`</code>
- <code>Ran the fixed retire command against a stale lock using the host Linux `stat`, inspected persisted state, then repeated it over clean state</code>
- <code>Injected nonnumeric `stat` output and verified lock-timeout refusal without an unbound-variable abort or state loss</code>
</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `bin/fm-x-lib.sh:421` - The GNU-unsafe stat fallback remains in an optional, numerically guarded mtime path. It fails safely and is intentionally deferred.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
