### PR TITLE
fix: preserve Herdr gate during task replacement

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -291,7 +291,7 @@ HERDR_SECTION=$(printf '%s\n' \
 else
 IFS= read -r -d '' HERDR_SECTION <<'EOF' || true
 # Herdr lifecycle declaration - NOT ENABLED
-**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
+**HARD SAFETY GATE:** this scaffold cannot inspect the task text filled in above.
 If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
 Do not add Herdr lifecycle commands to this unguarded brief by hand.
 EOF

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -439,6 +439,41 @@ test_herdr_lab_omission_is_loud_for_ship_and_scout() {
   pass "fm-brief.sh: ship and scout scaffolds make omitted Herdr intent fail-visible"
 }
 
+# Regression (issue #2575): AGENTS.md section 11 and this script's own help tell
+# firstmate to replace EVERY `{TASK}` placeholder. The unguarded Herdr gate used
+# to quote `{TASK}` in its own prose, so that documented global replace spliced
+# the whole task body into the middle of the gate's sentence - silently
+# destroying the one contract that exists precisely because the scaffold cannot
+# see the task text. The placeholder must exist only at the genuine fill site,
+# so the documented fill leaves the gate intact and the body appears once.
+test_documented_global_replace_leaves_the_herdr_gate_intact() {
+  local home id brief kind count content filled body
+  home="$TMP_ROOT/task-fill-site-home"
+  mkdir -p "$home/data"
+  body='Restart the herdr session, then profile it'
+  for kind in ship scout; do
+    id="brief-fill-site-$kind"
+    if [ "$kind" = scout ]; then
+      FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" firstmate --scout >/dev/null 2>&1
+    else
+      FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" firstmate --mode no-mistakes >/dev/null 2>&1
+    fi
+    brief="$home/data/$id/brief.md"
+    assert_present "$brief" "$kind brief was not scaffolded"
+    count=$(grep -c -F '{TASK}' "$brief")
+    [ "$count" = 1 ] \
+      || fail "$kind brief must carry exactly one {TASK} fill site, found $count"
+    content=$(cat "$brief")
+    filled=${content//'{TASK}'/$body}
+    count=$(printf '%s\n' "$filled" | grep -c -F "$body")
+    [ "$count" = 1 ] \
+      || fail "$kind brief: the documented global {TASK} replace duplicated the task body $count times"
+    printf '%s\n' "$filled" | grep -qF 'this scaffold cannot inspect the task text' \
+      || fail "$kind brief: the Herdr safety gate did not survive the documented global replace"
+  done
+  pass "fm-brief.sh: the documented {TASK} fill cannot corrupt the Herdr safety gate"
+}
+
 test_secondmate_no_projects_charter() {
   local home brief status
   home="$TMP_ROOT/no-projects-home"
@@ -725,6 +760,7 @@ test_ship_project_memory_wording
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path
 test_herdr_lab_omission_is_loud_for_ship_and_scout
+test_documented_global_replace_leaves_the_herdr_gate_intact
 test_herdr_lab_contract_applies_to_scouts_but_not_secondmates
 test_secondmate_no_projects_charter
 test_secondmate_marked_request_reporting_contract


### PR DESCRIPTION
## Intent

Fix upstream issue https://github.com/kunchenguid/firstmate/issues/2575 in bin/fm-brief.sh: fm-brief's Herdr safety gate quotes {TASK}, so filling the brief with the documented global replace corrupts the gate.

Defect: AGENTS.md section 11 and fm-brief.sh's own help instruct firstmate to 'replace every {TASK} placeholder'. The unguarded Herdr declaration section then quoted that same placeholder in its prose ('this scaffold cannot inspect the task text that replaces `{TASK}` later.'), so the documented global replace spliced the entire task body into the middle of the safety gate's sentence. The result is a second garbled copy of the task and a destroyed safety contract - the exact failure that gate exists to prevent, and it gets less visible the longer the task body is. Live reproduction: a real triage brief showed the corruption.

Fix chosen: reword the gate so the placeholder exists only at its genuine fill site ('this scaffold cannot inspect the task text filled in above.'). The issue author preferred renaming the fillable token to {TASK_BODY}, but that is deliberately NOT what was done here: renaming would have to propagate through AGENTS.md, the secondmate-provisioning skill, and the unfilled-charter guards in bin/fm-home-seed.sh and bin/fm-remote-home-seed.sh which grep briefs for the literal '{TASK}'. The reword removes the trap entirely in one file with no cross-surface contract change, and the gate's wording stays precise about what it cannot inspect (the task text sits directly above the gate in both the ship and scout scaffolds). The issue explicitly permits either option ('Pick either, but pick one'), and its third option (a duplicate-detection validation pass) was rejected as symptom-catching.

Scope is deliberately minimal and confined to one script plus its colocated test: no rename of the placeholder token, no new validation pass, no changes to AGENTS.md or the seed guards.

Regression test first, then the fix: tests/fm-brief.test.sh gains test_documented_global_replace_leaves_the_herdr_gate_intact, which scaffolds ship and scout briefs, asserts exactly one {TASK} fill site, performs the documented global replace end to end, and asserts the task body lands exactly once and the safety-gate sentence survives. It fails on the pre-fix script ('ship brief must carry exactly one {TASK} fill site, found 2') and passes after. The secondmate charter path is out of scope for that assertion because its two {TASK} occurrences (charter and routing scope) are both genuine fill sites and it carries no Herdr section.

Verification run locally: tests/fm-brief.test.sh passes all 21 checks; shellcheck on both touched files reports only pre-existing SC1091/SC2153 informational notes. Three failures in the broader changed-file selection (fm-lint-workflows, fm-lint, fm-test-run) are environment-only - actionlint and ruby are not installed on this machine - and are unrelated to this diff, which touches no workflows.

Deliverable: a PR to upstream kunchenguid/firstmate with 'Fixes #2575'.

## What Changed

- Reword the unguarded Herdr safety gate so global `{TASK}` replacement preserves the gate and inserts the task body only once. Fixes #2575.
- Add regression coverage for documented task replacement in ship and scout brief scaffolds.

## Risk Assessment

✅ Low: The change is narrowly scoped, removes the only accidental {TASK} occurrence from both affected generated brief paths, and tests the generated brief as an intentional public output contract.

## Testing

The author supplied prior focused and shellcheck verification; this phase independently passed `tests/fm-brief.test.sh` and reproduced the end-user global-replacement workflow for ship and scout briefs. Captured evidence shows the historical output duplicated the task and corrupted the safety gate, while the fixed output contains one task body and an intact gate. No UI surface exists for this CLI-generated Markdown change, so rendered visual evidence was not applicable.

<details>
<summary>Evidence: Baseline versus fixed global replacement comparison</summary>

Source: [Baseline versus fixed global replacement comparison](https://github.com/karotkriss/firstmate/blob/89fb69de4f5af78ab1816c440c114e4789723189/.no-mistakes/evidence/fm/fm-2575-brief-gate/fm-2575/global-replace-comparison.txt)

```text
End-user reproduction: scaffold each brief, then globally replace every documented {TASK} placeholder.
Task body: Restart the Herdr session, then profile it.

baseline ship: task body occurrences=2
4:Restart the Herdr session, then profile it.
7:**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `Restart the Herdr session, then profile it.` later.
7:**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `Restart the Herdr session, then profile it.` later.

baseline scout: task body occurrences=2
4:Restart the Herdr session, then profile it.
7:**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `Restart the Herdr session, then profile it.` later.
7:**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `Restart the Herdr session, then profile it.` later.

current ship: task body occurrences=1
4:Restart the Herdr session, then profile it.
7:**HARD SAFETY GATE:** this scaffold cannot inspect the task text filled in above.

current scout: task body occurrences=1
4:Restart the Herdr session, then profile it.
7:**HARD SAFETY GATE:** this scaffold cannot inspect the task text filled in above.
```
</details>
<details>
<summary>Evidence: Filled ship brief</summary>

Source: [Filled ship brief](https://github.com/karotkriss/firstmate/blob/89fb69de4f5af78ab1816c440c114e4789723189/.no-mistakes/evidence/fm/fm-2575-brief-gate/fm-2575/current-home/data/ship-demo/brief.md)

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
Restart the Herdr session, then profile it.

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text filled in above.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of firstmate, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/ship-demo`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/home/cmckay/.no-mistakes/evidence/01M0PPXM05D3CWST889EWXWYQP/fm-2575/current-home/state/ship-demo.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/home/cmckay/.no-mistakes/worktrees/80aee654c94f/01M0PPXM05D3CWST889EWXWYQP/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/home/cmckay/.no-mistakes/worktrees/80aee654c94f/01M0PPXM05D3CWST889EWXWYQP/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=no-mistakes
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies `ask-user-authority` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Filled scout brief</summary>

Source: [Filled scout brief](https://github.com/karotkriss/firstmate/blob/89fb69de4f5af78ab1816c440c114e4789723189/.no-mistakes/evidence/fm/fm-2575-brief-gate/fm-2575/current-home/data/scout-demo/brief.md)

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
Restart the Herdr session, then profile it.

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text filled in above.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of firstmate, at a detached HEAD on a clean default branch.
This is a SCOUT task: the deliverable is a written report, not a PR.
The worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
The report is the only thing that survives, so anything worth keeping must be in it.

# Rules
1. Never push to any remote and never open a PR.
2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/home/cmckay/.no-mistakes/evidence/01M0PPXM05D3CWST889EWXWYQP/fm-2575/current-home/state/scout-demo.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on and the needs-decision/blocked/paused/done/failed states. No step-by-step
   FYI progress lines; firstmate reads your pane for that.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset):
   firstmate then leaves your idle pane alone and rechecks it on a long cadence instead of
   treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs to a human (product choices, destructive actions),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Definition of done
Write your findings to `/home/cmckay/.no-mistakes/evidence/01M0PPXM05D3CWST889EWXWYQP/fm-2575/current-home/data/scout-demo/report.md`.
The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
If your deliverable is a visual artifact the captain will review and iterate on, you may host the Lavish review loop yourself (poll, revise, re-serve, staying alive) instead of handing it back to firstmate.
Before reporting done, read and follow `/home/cmckay/.no-mistakes/worktrees/80aee654c94f/01M0PPXM05D3CWST889EWXWYQP/.agents/skills/captain-hold-lifecycle/SKILL.md` and pass its shared completion gate for the report and any visual review.
When the report is complete, append `done: {one-line conclusion}` to the status file and stop.
If your findings reveal work that should ship (e.g. you reproduced a bug and the fix is clear), say so in the report; firstmate may promote this task in place, and you would then receive mode-specific ship instructions as a follow-up message.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"6dd7a365ffe06a29095f3860e59183d0e5839a73","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `tests/fm-brief.test.sh`
- <code>Generated ship and scout briefs through `bin/fm-brief.sh`, then performed the documented global `{TASK}` replacement with `Restart the Herdr session, then profile it.`</code>
- `Repeated the same executable reproduction using the pre-fix gate wording and compared the emitted briefs`
- <code>Verified the baseline duplicated the task body and corrupted the gate, while the target produced one task body and the intact sentence `this scaffold cannot inspect the task text filled in above.`</code>
- <code>`git status --short` to confirm testing left no worktree changes</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
