### PR TITLE
test: handle absent watcher wake queues

### DIFF
--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -1260,7 +1260,7 @@ if (stale.details?.ok !== false || !String(stale.details.message).includes("shut
 }
 if (!pidAlive(activeChild)) throw new Error("active generation child died after stale callback");
 if (existsSync(startupMarker)) throw new Error("startup generation child was resurrected");
-// Model the old generation's PID being recycled for the active child.
+// Model the old generation PID being recycled for the active child.
 // Its retired lifetime marker must keep the historical row from counting live.
 writeFileSync(process.env.FM_ARM_LOG, `arm pid=${activeChild} marker=${startupMarker}\n`, { flag: "a" });
 if (liveArmPids().length !== 1 || liveArmPids()[0] !== activeChild) {

--- a/tests/fm-pi-watch-extension.test.sh
+++ b/tests/fm-pi-watch-extension.test.sh
@@ -1095,24 +1095,31 @@ EOF
 }
 
 test_pi_session_transition_generation_owner() {
-  local repo home plugin child_pid_file arm_log out status
+  local repo home plugin child_pid_file child_marker_file marker_root arm_log out status
   repo="$TMP_ROOT/pi-session-transition-root"
   home="$TMP_ROOT/pi-session-transition-home"
   child_pid_file="$TMP_ROOT/pi-session-transition-child.pid"
+  child_marker_file="$TMP_ROOT/pi-session-transition-child.marker"
+  marker_root="$TMP_ROOT/pi-session-transition-markers"
   arm_log="$TMP_ROOT/pi-session-transition-arm.log"
-  mkdir -p "$repo/bin" "$home/state" "$home/config"
+  mkdir -p "$repo/bin" "$home/state" "$home/config" "$marker_root"
   install_pi_watch_extension_fixture "$repo"
   plugin="$repo/.pi/extensions/fm-primary-pi-watch.ts"
   cat > "$repo/bin/fm-watch-arm.sh" <<'SH'
 #!/usr/bin/env bash
+# The marker identifies this exact process lifetime after its PID is recycled.
+marker=$(mktemp "${FM_MARKER_ROOT:?}/arm.XXXXXX") || exit 1
+cleanup() { rm -f "$marker"; }
+trap cleanup EXIT
+trap 'exit 0' TERM INT
 printf 'watcher: started pid=%s\n' "$$"
 printf '%s\n' "$$" > "${FM_CHILD_PID_FILE:?}"
-printf 'arm pid=%s\n' "$$" >> "${FM_ARM_LOG:?}"
-trap 'exit 0' TERM INT
+printf '%s\n' "$marker" > "${FM_CHILD_MARKER_FILE:?}"
+printf 'arm pid=%s marker=%s\n' "$$" "$marker" >> "${FM_ARM_LOG:?}"
 while :; do sleep 0.2; done
 SH
   chmod +x "$repo/bin/fm-watch-arm.sh"
-  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_CHILD_PID_FILE="$child_pid_file" FM_ARM_LOG="$arm_log" FM_WATCH_REARM_RETRY_BASE_MS=5 FM_WATCH_REARM_RETRY_MAX_MS=10 FM_WATCH_REARM_RETRY_LIMIT=2 node --input-type=module 2>&1 <<'EOF'
+  out=$(PLUGIN="$plugin" FM_HOME="$home" FM_ROOT_OVERRIDE="$repo" FM_CHILD_PID_FILE="$child_pid_file" FM_CHILD_MARKER_FILE="$child_marker_file" FM_MARKER_ROOT="$marker_root" FM_ARM_LOG="$arm_log" FM_WATCH_REARM_RETRY_BASE_MS=5 FM_WATCH_REARM_RETRY_MAX_MS=10 FM_WATCH_REARM_RETRY_LIMIT=2 node --input-type=module 2>&1 <<'EOF'
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
@@ -1150,6 +1157,17 @@ async function waitFor(pred, label, attempts = 250) {
   throw new Error(`timeout waiting for ${label}`);
 }
 
+function currentArm() {
+  try {
+    return {
+      pid: readFileSync(process.env.FM_CHILD_PID_FILE, "utf8").trim(),
+      marker: readFileSync(process.env.FM_CHILD_MARKER_FILE, "utf8").trim(),
+    };
+  } catch {
+    return { pid: "", marker: "" };
+  }
+}
+
 function liveArmPids() {
   if (!existsSync(process.env.FM_ARM_LOG)) return [];
   return readFileSync(process.env.FM_ARM_LOG, "utf8")
@@ -1157,11 +1175,11 @@ function liveArmPids() {
     .split(/\n/)
     .filter(Boolean)
     .map((line) => {
-      const match = /pid=(\d+)/.exec(line);
-      return match ? match[1] : "";
+      const match = /pid=(\d+) marker=(\S+)/.exec(line);
+      return match ? { pid: match[1], marker: match[2] } : { pid: "", marker: "" };
     })
-    .filter(Boolean)
-    .filter(pidAlive);
+    .filter((arm) => arm.pid && arm.marker && existsSync(arm.marker) && pidAlive(arm.pid))
+    .map((arm) => arm.pid);
 }
 
 writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
@@ -1174,18 +1192,19 @@ const first = await startup.getTool().execute("startup", {}, undefined, undefine
 if (!first.details?.ok || !String(first.details.message).includes("started Pi extension arm child")) {
   throw new Error(`startup arm failed: ${JSON.stringify(first.details)}`);
 }
-await waitFor(() => existsSync(process.env.FM_CHILD_PID_FILE), "startup child");
-const startupChild = readFileSync(process.env.FM_CHILD_PID_FILE, "utf8").trim();
+await waitFor(() => {
+  const arm = currentArm();
+  return arm.pid && arm.marker && existsSync(arm.marker) && pidAlive(arm.pid);
+}, "startup child");
+const { pid: startupChild, marker: startupMarker } = currentArm();
 if (!pidAlive(startupChild)) throw new Error("startup child was not alive");
 const staleTool = startup.getTool();
 
 async function replaceSession(previous, reason) {
-  const previousChild = existsSync(process.env.FM_CHILD_PID_FILE)
-    ? readFileSync(process.env.FM_CHILD_PID_FILE, "utf8").trim()
-    : "";
+  const previousArm = currentArm();
   await previous.handlers.get("session_shutdown")?.({ type: "session_shutdown", reason }, {});
-  if (previousChild) {
-    await waitFor(() => !pidAlive(previousChild), `${reason} previous child exit`);
+  if (previousArm.marker) {
+    await waitFor(() => !existsSync(previousArm.marker), `${reason} previous child exit`);
   }
   const next = makePi();
   mod.default(next.pi);
@@ -1202,9 +1221,8 @@ async function replaceSession(previous, reason) {
     throw new Error(`${reason} replacement still refused with shutting-down latch`);
   }
   await waitFor(() => {
-    if (!existsSync(process.env.FM_CHILD_PID_FILE)) return false;
-    const child = readFileSync(process.env.FM_CHILD_PID_FILE, "utf8").trim();
-    return child && child !== previousChild && pidAlive(child) && liveArmPids().includes(child);
+    const arm = currentArm();
+    return arm.pid && arm.marker && arm.marker !== previousArm.marker && existsSync(arm.marker) && pidAlive(arm.pid) && liveArmPids().includes(arm.pid);
   }, `${reason} replacement child and arm record`);
   const live = liveArmPids();
   if (live.length !== 1) {
@@ -1218,31 +1236,33 @@ current = await replaceSession(current, "resume");
 current = await replaceSession(current, "fork");
 
 // Same bound instance: ordinary shutdown then session_start without a fresh factory.
-const sameInstanceChild = readFileSync(process.env.FM_CHILD_PID_FILE, "utf8").trim();
+const sameInstanceArm = currentArm();
 await current.handlers.get("session_shutdown")?.({ type: "session_shutdown", reason: "new" }, {});
 await current.handlers.get("session_start")?.({ type: "session_start", reason: "new" }, {});
-const sameInstanceArm = await current.getTool().execute("same-instance", {}, undefined, undefined, {});
-if (!sameInstanceArm.details?.ok || String(sameInstanceArm.details.message).includes("shutting down")) {
-  throw new Error(`same-instance replacement arm failed: ${JSON.stringify(sameInstanceArm.details)}`);
-}
-await waitFor(() => {
-  if (!existsSync(process.env.FM_CHILD_PID_FILE)) return false;
-  const child = readFileSync(process.env.FM_CHILD_PID_FILE, "utf8").trim();
-  return child !== sameInstanceChild && pidAlive(child) && liveArmPids().includes(child);
-}, "same-instance replacement child and arm record");
-await waitFor(() => !pidAlive(sameInstanceChild), "same-instance previous child exit");
+const sameInstanceResult = await current.getTool().execute("same-instance", {}, undefined, undefined, {});
+if (!sameInstanceResult.details?.ok || String(sameInstanceResult.details.message).includes("shutting down")) {
+  throw new Error(`same-instance replacement arm failed: ${JSON.stringify(sameInstanceResult.details)}`);
+  }
+  await waitFor(() => {
+    const arm = currentArm();
+    return arm.pid && arm.marker && arm.marker !== sameInstanceArm.marker && existsSync(arm.marker) && pidAlive(arm.pid) && liveArmPids().includes(arm.pid);
+  }, "same-instance replacement child and arm record");
+  await waitFor(() => !existsSync(sameInstanceArm.marker), "same-instance previous child exit");
 if (liveArmPids().length !== 1) {
   throw new Error(`same-instance expected one live arm child, got ${liveArmPids().join(",")}`);
 }
 
 // Stale prior-generation callback must not stop, rearm, or clear the active generation.
-const activeChild = readFileSync(process.env.FM_CHILD_PID_FILE, "utf8").trim();
+const activeChild = currentArm().pid;
 const stale = await staleTool.execute("stale-prior-generation", {}, undefined, undefined, {});
 if (stale.details?.ok !== false || !String(stale.details.message).includes("shutting down")) {
   throw new Error(`stale prior generation did not refuse: ${JSON.stringify(stale.details)}`);
 }
 if (!pidAlive(activeChild)) throw new Error("active generation child died after stale callback");
-if (pidAlive(startupChild)) throw new Error("startup generation child was resurrected");
+if (existsSync(startupMarker)) throw new Error("startup generation child was resurrected");
+// Model the old generation's PID being recycled for the active child.
+// Its retired lifetime marker must keep the historical row from counting live.
+writeFileSync(process.env.FM_ARM_LOG, `arm pid=${activeChild} marker=${startupMarker}\n`, { flag: "a" });
 if (liveArmPids().length !== 1 || liveArmPids()[0] !== activeChild) {
   throw new Error(`stale callback mutated live arm set: ${liveArmPids().join(",")}`);
 }
@@ -1257,9 +1277,9 @@ for (const reason of ["resume", "fork", "new", "resume"]) {
 }
 
 // Real terminal shutdown still blocks late rearming.
-const finalChild = readFileSync(process.env.FM_CHILD_PID_FILE, "utf8").trim();
+const finalArm = currentArm();
 await current.handlers.get("session_shutdown")?.({ type: "session_shutdown", reason: "quit" }, {});
-await waitFor(() => !pidAlive(finalChild), "terminal shutdown child exit");
+await waitFor(() => !existsSync(finalArm.marker), "terminal shutdown child exit");
 const quitArm = await current.getTool().execute("after-quit", {}, undefined, undefined, {});
 if (quitArm.details?.ok !== false || quitArm.details.message !== "watcher: not armed - Pi session is shutting down") {
   throw new Error(`terminal quit must keep the shutting-down refusal: ${JSON.stringify(quitArm.details)}`);

--- a/tests/fm-watch-triage.test.sh
+++ b/tests/fm-watch-triage.test.sh
@@ -1034,8 +1034,15 @@ test_exited_declared_pause_is_bounded_but_live_gate_surfaces() {
     fi
     round=$((round + 1))
   done
-  wakes=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w { n++ } END { print n + 0 }' "$state/.wake-queue")
-  bare=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w && $5 == "stale: " w { n++ } END { print n + 0 }' "$state/.wake-queue")
+  # A watcher that queues nothing never creates .wake-queue, so these counts
+  # read a path that may legitimately be absent. awk aborts on a missing file
+  # before END runs, which collapses the count to the empty string and turns the
+  # next comparison into an "integer expression expected" error - reported as a
+  # flood of an unprintable number of wakes instead of the real contract breach
+  # the grep below names. No queue means no wakes, per the drain-count read at
+  # the end of this file.
+  wakes=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w { n++ } END { print n + 0 }' "$state/.wake-queue" 2>/dev/null || echo 0)
+  bare=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w && $5 == "stale: " w { n++ } END { print n + 0 }' "$state/.wake-queue" 2>/dev/null || echo 0)
   [ "$wakes" -le 1 ] || fail "dead-agent declared pause flooded $wakes stale wakes across six unchanged polls"
   [ "$bare" -eq 0 ] || fail "dead-agent declared pause surfaced as $bare bare stopped-crew wakes"
   grep -F "awaiting external" "$state/.wake-queue" >/dev/null \
@@ -1105,8 +1112,8 @@ test_exited_declared_pause_is_bounded_but_live_gate_surfaces() {
   [ -e "$state/.paused-$key" ] || { reap "$pid"; fail "live external-decision gate lost its pause cadence marker"; }
   [ ! -e "$state/.stale-since-$key" ] || { reap "$pid"; fail "live external-decision gate retained the wedge timer"; }
   reap "$pid"
-  wakes=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w { n++ } END { print n + 0 }' "$state/.wake-queue")
-  bare=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w && $5 == "stale: " w { n++ } END { print n + 0 }' "$state/.wake-queue")
+  wakes=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w { n++ } END { print n + 0 }' "$state/.wake-queue" 2>/dev/null || echo 0)
+  bare=$(awk -F '\t' -v w="$window" '$3 == "stale" && $4 == w && $5 == "stale: " w { n++ } END { print n + 0 }' "$state/.wake-queue" 2>/dev/null || echo 0)
   [ "$wakes" -eq 0 ] || fail "acknowledged external-decision surface replayed $wakes wakes"
   [ "$bare" -eq 0 ] || fail "acknowledged external-decision bare stale remained queued"
   pass "exited declared-pause and captain-held panes use bounded pause cadence while a live decision gate still surfaces once"


### PR DESCRIPTION
## Intent

Fix GitHub issue #2628 in kunchenguid/firstmate: the fm-watch-triage test suite's exited-declared-pause case fails when state/.wake-queue is absent.

Reported defect: running tests/fm-watch-triage.test.sh reaches the exited-declared-pause case without state/.wake-queue existing. Two awk reads then fail with "can't open file" for exited-declared-pause/state/.wake-queue, and the suite reports "not ok - dead-agent declared pause flooded stale wakes across six unchanged polls" with no number in the message. The reporter's stated expectation: the test should either create the bounded paused-recheck wake queue it asserts against, or handle an absent queue without producing an empty integer comparison. The reporter also scoped this as reproducing independently of the fm-batch-tooling changes, to be fixed on its own.

Root cause established by direct reproduction, not inference: awk aborts on a missing input path before its END rule runs, so an awk invocation ending in END { print n + 0 } over $state/.wake-queue prints nothing and exits 2 instead of printing 0. The count variable collapses to the empty string, and the following integer comparison fails as a bash "integer expression expected" error rather than a comparison. That error takes the fail branch, so an absent queue is misreported as a wake flood of an unprintable count, masking the real contract breach that the very next grep names correctly. A watcher that correctly absorbs every poll and queues nothing never creates .wake-queue at all, so the file is legitimately optional here.

Chosen resolution and why, binding: of the reporter's two options, take the second, tolerating an absent queue, rather than pre-seeding a fixture queue. Seeding a queue file would pre-empt the very thing the case measures, namely how many stale wakes the watcher itself enqueued, whereas absent-tolerance is already this suite's own established convention for reading a possibly-absent queue. The drain-count assertions at the end of the same file already read the queue with a 2>/dev/null fallback to zero, and the sibling fm-procevent suites read it the same way. The fix therefore reuses the existing in-repo idiom instead of introducing a new helper or abstraction.

Scope decision: the ticket names the two reads in the exited-declared-pause fixture, but the identical unguarded pair appears again later in the same test function for the live external-decision-gate fixture, whose queue an acknowledged drain can also leave behind. All such reads are guarded, because fixing only the pair the ticket names would leave an identical latent failure in the same function. Production watcher and classifier behavior is untouched; this is a test-only correction.

This branch also carries two commits the validation pipeline added for CI failures unrelated to the queue-read fix, which are deliberately retained and documented in the PR body rather than stripped:

- tests/fm-pi-watch-extension.test.sh: the session-transition case identified its arm child by PID alone, so under CI load a recycled PID could make a dead generation look alive, or make one live process count twice. It was replaced with a unique per-arm lifetime marker that the child creates and removes on exit, preserving the overlapping-generation detection the case exists to prove. This is a pre-existing, CI-only, load-sensitive flake, not a consequence of the queue-read change.
- A one-line follow-up removing an apostrophe from a comment introduced by that fix, because stock macOS Bash 3.2 misparses it inside a quoted heredoc nested in command substitution.

tests/fm-watch-triage.test.sh is untouched by both of those.

THIS ROUND IS AN ATTESTATION RE-STAMP ONLY. The code on this branch is already reviewed, tested, and CI-green at 14 of 14 checks, and the maintainer's triage raised no author-fixable code objection beyond the attestation itself. The sole purpose of this run is to produce a no-mistakes-pipeline-attestation:v1 whose head_sha matches the final HEAD, because previous runs' own "apply CI fixes" commits moved HEAD after the body was stamped. Do not restructure, refactor, rename, expand scope, or introduce new capability. Confine any change strictly to a genuine defect that this run's own gates surface; if the gates are clean, change nothing at all.

Binding constraints. This is firstmate's own shared tracked material, so .agents/skills/firstmate-coding-guidelines applies: the knowledge-placement decision tree, one owner per contract with cross-references rather than restatements, one full sentence per line in tracked Markdown, plain dash and never an em dash, never an agent name as commit co-author, bin/*.sh shellcheck-clean through bin/fm-lint.sh which is the single owner of the lint definition, and tests colocated in tests/ extending the existing runner and exercising behavior through the executable interface rather than asserting implementation source bytes. Tests must keep exercising behavior through the executable interface and must not assert implementation-source bytes.

Delivery: update the EXISTING pull request 2845 against kunchenguid/firstmate in place, pushed to the karotkriss fork remote, never to the clone's default branch, and never opening a duplicate PR. The body must cite "Fixes #2628" and nothing else. The pipeline attestation must bind to the final head, so no commits are pushed after the stamp.

## What Changed

- Treat absent watcher wake queues as zero wakes in declared-pause and live decision-gate assertions.
- Track Pi arm process lifetimes with unique markers to avoid recycled-PID failures under CI load.

Fixes #2628

## Risk Assessment

✅ Low: Captain, the changes are test-only, well-bounded, conform to the stated intent, and correctly handle absent wake queues and PID reuse without altering production behavior.

## Testing

Inspected the base-to-target scope and clean baseline, ran the focused triage and Pi watcher suites through their executable interfaces, confirmed the absent wake-queue regression and lifetime-marker stabilization, captured CLI transcripts, verified the former failure text did not recur, and finished with a clean worktree.

<details>
<summary>Evidence: Targeted behavior results</summary>

Source: [Targeted behavior results](https://github.com/karotkriss/firstmate/blob/4277348d95f51c8cc4b70f1a0ba43d3146af2546/.no-mistakes/evidence/fm/fm-2628-triage-test/targeted-behavior-results.txt)

<code>ok - exited declared-pause and captain-held panes use bounded pause cadence while a live decision gate still surfaces once&#10;ok - Pi session transitions use a generation owner across /new /resume /fork, stale callbacks, and quit</code>

```text
ok - Pi session transitions use a generation owner across /new /resume /fork, stale callbacks, and quit
ok - exited declared-pause and captain-held panes use bounded pause cadence while a live decision gate still surfaces once
```
</details>
<details>
<summary>Evidence: fm-watch-triage transcript</summary>

Source: [fm-watch-triage transcript](https://github.com/karotkriss/firstmate/blob/4277348d95f51c8cc4b70f1a0ba43d3146af2546/.no-mistakes/evidence/fm/fm-2628-triage-test/fm-watch-triage-transcript.txt)

```text
ok - signal_reason_is_actionable: benign absorbed, captain verbs and coalesced batches surfaced
ok - stale_is_terminal: terminal status surfaces, non-terminal and no-status are benign
ok - scan_captain_relevant_statuses lists only captain-relevant statuses
ok - classifier primitives: keyed decisions and activity phases, captain relevance, window-to-task, and overrides
ok - crew_is_provably_working: only working+run-step/pane is provable; idle/finished/parked/failed/unknown surface
ok - status_is_paused: only the leading paused verb matches, paused is not captain-relevant, and the two declared-wait verbs stay separable
ok - crew_absorb_class: working/paused/none from one read; crew_is_paused and crew_is_provably_working agree
ok - crew_worktree_written_since: real writes are evidence; no worktree, no anchor, quiet trees, .git churn and a mate's own home are not
ok - an empty FM_WORKTREE_WRITE_PRUNE widens the probe to the whole depth-bounded tree instead of disabling it
ok - an empty FM_WORKTREE_WRITE_PRUNE exported into the environment prunes nothing, widening the probe
ok - the worktree write probe is wall-clock bounded, and hitting the bound reads as no write evidence
ok - signal_crew_provably_working: benign only when every referenced crew is provably working
ok - a secondmate's status signal is never absorbed as provably working; crewmates are unaffected
ok - a no-verb signal whose crew is provably working is absorbed (no exit, no queue, suppressor advanced, beacon present)
ok - a bare turn-end whose crew is provably working (busy pane) is absorbed
ok - a bare turn-end whose crew is not provably working is surfaced (the swallowed-finish fix)
ok - a no-verb working: note whose crew is idle with no running pipeline is surfaced
ok - a secondmate's status note surfaces even while its own agent is busy
ok - a self-announced close never wakes its own home, and the next real note still does
ok - captain-relevant signal is surfaced (queue + exit) and marked surfaced
ok - a stale pane sitting on a terminal status is surfaced (queue + exit)
ok - a stale terminal-looking status is overridden and absorbed while a run is actively working, then wedge-escalated
ok - provably-working non-terminal stale is absorbed on first sight, then wedge-escalated past the threshold
ok - consecutive wedge escalations on the same pane accumulate and demand deep inspection at the threshold
ok - a pane becoming active again resets the consecutive wedge-escalation counter
ok - a busy worker below the turn-age bound remains working with no escalation
ok - a busy worker with a stable pane hash still escalates once its completed-turn age reaches the bound
ok - a busy worker whose pane hash changes every poll still escalates once its completed-turn age reaches the bound
ok - touching a busy worker's completed-turn marker resets the age and prevents an old-age escalation
ok - repeated busy turn-age escalations reuse the existing escalation counter and demand deep inspection at the threshold
ok - the production default busy-turn-age bound is 3600s (5min under does not wedge, 66min over does)
ok - a busy pane under a declared pause is rechecked on the long cadence, and lifting the pause restores the wedge escalation
ok - a not-provably-working non-terminal stale is surfaced immediately (never left to wait out the timer)
ok - a declared pause is absorbed on first sight, then re-surfaced as a recheck past the threshold, never wedge-escalated
ok - exited declared-pause and captain-held panes use bounded pause cadence while a live decision gate still surfaces once
ok - a declared paused secondmate re-surfaces on the bounded normal-mode cadence
ok - a captain-held secondmate re-surfaces on the bounded normal-mode cadence
ok - a non-paused secondmate retains normal stale suppression
ok - a resumed secondmate clears pause and stale tracking before stale exemption
ok - unchanged stale hashes reclassify when a crew enters or leaves pause
ok - a declared pause is periodically rechecked against authoritative active-run state
ok - a paused status overridden by authoritative working preserves its wedge timer and escalates
ok - matching non-terminal stale suppressors repair missing or corrupt stale-since timers
ok - a quiet pane writing its own worktree is deferred, while one writing nothing still wedge-escalates on the unchanged schedule
ok - a write deferral re-surfaces once on the bounded pause cadence, so a churning worktree cannot stay invisible
ok - a secondmate's own home supervision churn is not crew write evidence, so a pane recording that home keeps the unchanged escalation schedule
ok - an idle-window timer repair drops a finished write-deferral chain, so the next deferral gets a fresh re-surface window
ok - both first-sight paths through a captain-relevant status drop a finished write-deferral chain with the idle window
ok - triage log capping handles wc byte counts with leading spaces
ok - a captured process-event result wakes a healthy watcher proactively, with no manual drain
ok - an unacknowledged process-event result re-drains until handling is acknowledged
ok - complete process-event queue keys map to distinct seen markers
WAKE_ACK_REQUIRED: after handling completes run bin/fm-wake-drain.sh --ack-through 1 --recovery-generation 62023.1787545247.ZJW4ke
ok - queue revalidation, proactive output, and marker commit serialize with drain
/home/cmckay/.no-mistakes/worktrees/80aee654c94f/01M0RZP93ND51H1XBDP99YRQNK/bin/fm-push-transition-lib.sh: line 96: echo: write error: Broken pipe
tests/wake-helpers.sh: line 286: 67070 Killed                     PATH="$dir/fakebin:$PATH" FM_HOME="$dir" FM_PROCEVENT_CLAIM_ROOT="$dir/claims" FM_CREW_STATE_BIN="$dir/fakebin/fm-crew-state.sh" FM_POLL=0.2 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out"
tests/wake-helpers.sh: line 286: 69232 Killed                     PATH="$dir/fakebin:$PATH" FM_HOME="$dir" FM_PROCEVENT_CLAIM_ROOT="$dir/claims" FM_CREW_STATE_BIN="$dir/fakebin/fm-crew-state.sh" FM_POLL=0.2 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH" > "$out"
ok - surfacing failures replay until post-handling acknowledgement
ok - marker failure exits through the shared wake owner, releases its lock, and replays later
ok - a heartbeat with no captain-relevant change is absorbed and backs off the cadence
ok - heartbeat backstop fail-safe surfaces a captain-relevant status the per-wake path missed
ok - the liveness beacon stays fresh while the watcher absorbs benign wakes (fm-guard never false-alarms)
ok - with .afk present the watcher reverts to one-shot so the daemon owns triage (no double-triage)
ok - AFK changed paused panes hand off plain stale identities for daemon-owned pause triage
```
</details>
<details>
<summary>Evidence: fm-pi-watch-extension transcript</summary>

Source: [fm-pi-watch-extension transcript](https://github.com/karotkriss/firstmate/blob/4277348d95f51c8cc4b70f1a0ba43d3146af2546/.no-mistakes/evidence/fm/fm-2628-triage-test/fm-pi-watch-extension-transcript.txt)

```text
ok - Pi extension reports external healthy watcher output
ok - Pi custom tool exposes repair-only metadata and returns automatic-continuation guidance
ok - Pi redundant tool call returns ownership guidance and spawns no second child
ok - Pi scheduled retry remains extension-owned after another tool call
ok - Pi actionable close starts one successor before wake delivery settles
ok - Pi dispatcher branch offer owns accepted wakes and falls back to main
ok - Pi refused handling handshake is classified and not swallowed
ok - Pi hung successor falls back to one typed actionable wake
ok - Pi unretired successor falls back without an overlapping retry
ok - Pi late unretired closes resume classified supervision
ok - Pi clean empty close triggers a bounded continuity retry
ok - Pi established clean closes stop at the configured retry limit
ok - Pi close handler verifies session-lock ownership before successor launch
ok - Pi watcher arm distinguishes all session lock ownership states
ok - Pi session transitions use a generation owner across /new /resume /fork, stale callbacks, and quit
ok - Pi process-exit cleanup listener remains singular across session replacement
ok - Pi process-exit cleanup stops the attached arm child
ok - OpenCode plugins have an explicit ESM boundary even under a typeless parent package
ok - OpenCode watcher plugin uses the effective FM_HOME state
ok - OpenCode watcher plugin sources the effective config
ok - OpenCode watcher plugin requires session lock ownership
ok - OpenCode watcher coordinator respects primary scope
ok - OpenCode watcher plugin starts one successor before wake prompt delivery settles
ok - OpenCode pre-ready actionable close preserves its successor
ok - OpenCode hung successor falls back to one typed actionable wake
ok - OpenCode unretired successor falls back without an overlapping retry
ok - OpenCode late unretired closes resume classified supervision
ok - OpenCode clean empty close triggers a bounded continuity retry
ok - OpenCode established clean closes stop at the configured retry limit
ok - OpenCode close handler verifies session-lock ownership before successor launch
ok - OpenCode watcher plugin coordinates with the turn-end guard
ok - OpenCode healthy arm output does not suppress the turn-end guard
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"d47bebf157e13b29f94b82beef3c71b9f6fc51e4","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --stat 7b88520c055408a18f1476ecce08be60b2885fc9..d47bebf157e13b29f94b82beef3c71b9f6fc51e4` and targeted diff inspection</code>
- `tests/fm-watch-triage.test.sh`
- `tests/fm-pi-watch-extension.test.sh`
- <code>Checked the triage transcript for absence of `integer expression expected` and `not ok - dead-agent declared pause`</code>
- <code>`git status --short` after testing</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
