### PR TITLE
fix(bin): stop false-green PR checks and run CI on our fork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,14 @@ name: CI
 # The pull_request trigger stays so upstream keeps validating incoming forks; a
 # same-repository pull request therefore runs the suites twice, which is the
 # accepted cost of a fork never being left without them.
+# branches-ignore rather than a branch list, so a new branch is validated by
+# default and only a namespace deliberately named here escapes. The one
+# exclusion is no-mistakes/**, where the gate publishes each run's test evidence
+# (.no-mistakes.yaml): those are orphan branches carrying evidence and no source
+# tree, so running a source-tree suite against one could only ever fail.
 on:
   push:
-    branches: ['**']
+    branches-ignore: ['no-mistakes/**']
   pull_request:
     branches: [main]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,8 +401,8 @@ jobs:
           bearings_output=$(/bin/bash tests/fm-bearings-snapshot.test.sh)
           printf '%s\n' "$bearings_output"
           bearings_count=$(printf '%s\n' "$bearings_output" | grep -c '^ok - ')
-          [ "$bearings_count" -eq 42 ] || {
-            echo "::error::expected 42 Bearings tests, got $bearings_count"
+          [ "$bearings_count" -eq 43 ] || {
+            echo "::error::expected 43 Bearings tests, got $bearings_count"
             exit 1
           }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,19 @@
 name: CI
 
+# Every branch pushed to this repository is validated here, not only main. A
+# contributor works on a fork, so a fork-branch push is the only event that
+# repository can raise for itself: with main-only push triggers a fork records
+# zero workflow runs and its owner has no validation surface at all, because the
+# pull_request event belongs to the upstream repository and GitHub holds a first-
+# time contributor's upstream run until a maintainer approves it. Validating on
+# push makes a fork self-sufficient, and leaves the upstream pull request free to
+# be a contribution rather than the only place the suites can run.
+# The pull_request trigger stays so upstream keeps validating incoming forks; a
+# same-repository pull request therefore runs the suites twice, which is the
+# accepted cost of a fork never being left without them.
 on:
   push:
-    branches: [main]
+    branches: ['**']
   pull_request:
     branches: [main]
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -363,6 +363,8 @@ The worker reports the PR when CI first becomes green rather than waiting for me
 ### PR ready, landing, and teardown
 
 For PR-based ship tasks, the ready signal depends on mode: `no-mistakes` reports `done: PR <url> checks green` after CI is green, while `direct-PR` reports `done: PR <url>` after opening the PR.
+Never take a green claim on trust: confirm it with `bin/fm-pr-ci-verify.sh <PR url>`, because an all-green check list proves nothing when the repository's own suites never ran, which is exactly what a third-party bot's pass on a held fork run looks like.
+That command accepts a commit our own fork validated while the upstream run is still held, so a held upstream run is a contribution question and never a validation one.
 Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` and the forge's `pr_head=` when available in the task's meta and arms the watcher's merge poll.
 Tell the captain the PR's full URL, always the complete `https://...` link rather than a bare `#number`, a concise outcome summary, and the no-mistakes risk level when applicable.
 A captain instruction to merge is explicit authority; `yolo` is the only standing routine merge authority.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,8 +28,35 @@ GitHub Actions and Dependabot are exempt so their automation keeps working, but 
 6. Run `no-mistakes` to attach to the pipeline, watch findings, authorize auto-fixes, and review ask-user findings as needed.
    Follow the installed no-mistakes version's SKILL.md and live `axi` help for gate mechanics.
 7. Once the pipeline passes, it pushes the branch to your fork and opens the PR against the parent repo for you.
+   That push is what runs the suites on your fork; see "Where your changes are validated" below for reading the result and for why the PR's own checks are a different question.
 
 See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/start-here/quick-start/) for the full first-run walkthrough.
+
+## Where your changes are validated
+
+Your fork validates your work; the pull request here is a contribution.
+These are two separate things, and treating them as one is what leaves a branch waiting on a maintainer who never has to act for you to know your change is sound.
+
+Every branch pushed to your fork runs the full suite there, because [`.github/workflows/ci.yml`](.github/workflows/ci.yml) triggers on a push to any branch.
+Step 7 above already pushes your branch to your fork, so that run happens on its own and needs nobody's approval.
+Read it with `gh run list -R <you>/firstmate`, and treat its conclusion as the answer about your change.
+
+The pull request this repo receives is a separate question, and it is about whether the change gets taken, not whether it works.
+GitHub holds a first-time fork contributor's workflow runs on that pull request until a maintainer approves them, so it can sit with no repository check on it for as long as that takes.
+That is a wait for a decision, not a wait for a result you already have.
+
+**An all-green check list is not evidence that anything ran.**
+A pull request can carry third-party App checks - review bots, coverage services - that report on every commit whether or not a single workflow of this repository ever started.
+Read as a total, that is "1 passed, 0 failed, 1 total", which is indistinguishable from success to anything that only counts passes and failures.
+
+Ask the question directly instead of counting:
+
+```sh
+bin/fm-pr-ci-verify.sh <pr-url>   # did repository suites actually run and pass on this commit?
+```
+
+It reports which suites ran and where, accepts a commit your fork validated while the upstream run is still held, and refuses every outcome that only looks green.
+[`bin/fm-ci-checks-lib.sh`](bin/fm-ci-checks-lib.sh) owns that rule, and everything in this repo that turns checks into a verdict classifies through it.
 
 ## Repo conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,9 @@ These are two separate things, and treating them as one is what leaves a branch 
 
 Every branch pushed to your fork runs the full suite there, because [`.github/workflows/ci.yml`](.github/workflows/ci.yml) triggers on a push to any branch.
 Step 7 above already pushes your branch to your fork, so that run happens on its own and needs nobody's approval.
-Read it with `gh run list -R <you>/firstmate`, and treat its conclusion as the answer about your change.
+Read it with `gh run list -R <you>/firstmate`, but do not stop at the run's conclusion.
+A run concludes `success` whenever no job in it failed, and a job that never ran because it was skipped does not fail, so a run that lost most of its jobs still reports success.
+The answer about your change is the suite roster inside that run, which `bin/fm-pr-ci-verify.sh` below reads for you.
 
 The pull request this repo receives is a separate question, and it is about whether the change gets taken, not whether it works.
 GitHub holds a first-time fork contributor's workflow runs on that pull request until a maintainer approves them, so it can sit with no repository check on it for as long as that takes.

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -69,6 +69,9 @@ FLEET="$SCRIPT_DIR/fm-fleet-snapshot.sh"
 # shellcheck source=bin/fm-timeout-lib.sh
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/fm-timeout-lib.sh"
+# shellcheck source=bin/fm-ci-checks-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-ci-checks-lib.sh"
 
 # Bounds (overridable for tests / large fleets).
 FM_BEARINGS_LANDED=${FM_BEARINGS_LANDED:-6}
@@ -238,7 +241,7 @@ EOF
         --json number,title,url,headRefName,reviewDecision,mergeable,statusCheckRollup 2>/dev/null) \
         || { nwarn=$((nwarn + 1)); continue; }
       [ -n "$out" ] || out='[]'
-      repo_result=$(printf '%s' "$out" | jq --arg repo "$repo" --argjson limit "$FM_BEARINGS_PR_LIMIT" '
+      repo_result=$(printf '%s' "$out" | jq --arg repo "$repo" --argjson limit "$FM_BEARINGS_PR_LIMIT" "$FM_CI_CHECKS_JQ_DEFS"'
         [ .[] | {
           num:(.number|tostring),
           repo:$repo,
@@ -246,12 +249,12 @@ EOF
           url:(.url // "-"),
           review:(.reviewDecision // "none"),
           mergeable:(.mergeable // "UNKNOWN"),
-          checks:(
-            (.statusCheckRollup // []) as $c
-            | if ($c|length) == 0 then "none"
-              elif any($c[]; (.conclusion // .state // "") as $s | ($s=="FAILURE" or $s=="ERROR" or $s=="TIMED_OUT" or $s=="CANCELLED" or $s=="ACTION_REQUIRED")) then "failing"
-              elif any($c[]; ((.status // "") != "COMPLETED") and ((.state // "") != "SUCCESS")) then "pending"
-              else "passing" end)
+          # Classified by the single owner in bin/fm-ci-checks-lib.sh, so a row
+          # carrying only third-party checks reads no-repo-ci rather than
+          # passing. A rollup holding nothing but a review bot pass is exactly
+          # what a pull request whose own suites never started looks like, and
+          # reading that as green is how one gets reported as validated.
+          checks:((.statusCheckRollup // []) | fm_ci_state)
         } ] as $rows | {returned:($rows | length), rows:$rows[:$limit]}') || { nwarn=$((nwarn + 1)); continue; }
       returned=$(printf '%s' "$repo_result" | jq '.returned')
       repo_rows=$(printf '%s' "$repo_result" | jq '.rows')

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -422,7 +422,7 @@ Two firstmate-specific rules layer on top of that guidance:
   When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
 - Avoid \`--yes\`: it would silently bypass firstmate's authority check and any required captain escalation.
 
-After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
+After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), confirm that claim with \`$FM_ROOT/bin/fm-pr-ci-verify.sh {url}\` before reporting it. An all-green check list is not evidence the suites ran: a pull request can carry only a third-party bot's pass while every repository suite is still held unapproved, which reads as "1 passed, 0 failed" to anything that counts conclusions. That command answers the real question and accepts a commit our own fork already validated. If it refuses, report what it says instead of a green result. Once it passes, append \`done: PR {url} checks green\` and stop. You are finished.
 EOF
     ;;
 esac

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -422,7 +422,11 @@ Two firstmate-specific rules layer on top of that guidance:
   When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
 - Avoid \`--yes\`: it would silently bypass firstmate's authority check and any required captain escalation.
 
-After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), confirm that claim with \`$FM_ROOT/bin/fm-pr-ci-verify.sh {url}\` before reporting it. An all-green check list is not evidence the suites ran: a pull request can carry only a third-party bot's pass while every repository suite is still held unapproved, which reads as "1 passed, 0 failed" to anything that counts conclusions. That command answers the real question and accepts a commit our own fork already validated. If it refuses, report what it says instead of a green result. Once it passes, append \`done: PR {url} checks green\` and stop. You are finished.
+After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), confirm that claim with \`$FM_ROOT/bin/fm-pr-ci-verify.sh {url}\` before reporting it.
+An all-green check list is not evidence the suites ran: a pull request can carry only a third-party bot's pass while every repository suite is still held unapproved, which reads as "1 passed, 0 failed" to anything that counts conclusions.
+That command answers the real question, and accepts a commit our own fork already validated.
+If it refuses, report what it says instead of a green result.
+Once it passes, append \`done: PR {url} checks green\` and stop. You are finished.
 EOF
     ;;
 esac

--- a/bin/fm-ci-checks-lib.sh
+++ b/bin/fm-ci-checks-lib.sh
@@ -28,26 +28,50 @@
 # a distinct state from passing and from an empty rollup's none, and no caller
 # can collapse it into success by counting conclusions.
 #
-# GitHub offers this evidence in two shapes and the file owns both. A pull
-# request carries a check rollup, which mixes everyone's checks together and so
-# needs the workflowName discriminator above. A commit in a given repository
-# carries workflow runs, which are that repository's own by construction, but
-# still mix every workflow the repository owns together - the CI workflow
-# alongside a PR-body policy check or a manually dispatched spike - so
-# fm_ci_runs_state applies the same by-name filter to that shape too, rather
-# than accepting any repository-owned run as a stand-in for the one that
-# actually ran the suites. The second shape is what answers "did MY fork
-# validate this commit?" when the first shape says the upstream pull request
-# has no repository check on it.
+# GitHub offers this evidence in two shapes and the file owns both, and both
+# have to establish the same thing: that every required suite ran and passed.
+# A pull request carries a check rollup, which mixes everyone's checks together
+# and so needs the workflowName discriminator above, and whose entries are the
+# individual job check runs the roster is read from directly. A commit in a
+# given repository carries workflow runs, which are that repository's own by
+# construction, but still mix every workflow the repository owns together - the
+# CI workflow alongside a PR-body policy check or a manually dispatched spike -
+# so this file applies the same by-name filter to that shape too, rather than
+# accepting any repository-owned run as a stand-in for the one that actually
+# ran the suites. The second shape is what answers "did MY fork validate this
+# commit?" when the first shape says the upstream pull request has no
+# repository check on it.
 #
-# States, in the order the classifier decides them:
-#   none        the commit carries no checks at all
+# A workflow run's own conclusion is NOT roster evidence, which is why this
+# file reads that shape's JOBS rather than stopping at the run. GitHub
+# concludes a run "success" whenever no job in it failed, and a job that never
+# ran because it was skipped does not fail: cli/cli run 32701833535 concluded
+# success with one job successful and two skipped. A CI run that lost most of
+# its roster - a job that gained an if: condition, a matrix that did not
+# expand, a path filter, or simply a thinner ci.yml on the branch under test -
+# therefore still reports success, and reading only that conclusion is the same
+# false-green shape as the third-party bot above, arriving from inside the
+# repository's own workflow instead of outside it. fm_ci_run_jobs_state takes
+# the run's jobs alongside the runs and applies the roster to them, so this
+# shape refuses a run that cannot show every required suite inside it.
+#
+# States, in the order the classifier decides them. Both shapes use the same
+# set, except no-repo-ci, which only the rollup shape can observe:
+#   none        the commit carries no checks at all, or no CI workflow run
 #   no-repo-ci  checks exist, but the CI workflow itself never produced one
 #   failing     at least one check reached a red conclusion
 #   pending     at least one check has not finished
 #   incomplete  the CI workflow reported, and everything it reported succeeded,
 #               but fewer than its full required roster of suites is in there
 #   passing     the CI workflow ran and every required suite succeeded
+#
+# Only passing is evidence. Read against the three outcomes a caller has to
+# tell apart - the required suites ran and passed, the required suites ran and
+# did not pass, the required suites cannot be shown to have run - passing is
+# the first, failing and pending are the second, and none, no-repo-ci and
+# incomplete are all the third. No caller may collapse any of that third group
+# into the first, which is the whole reason they are distinct states rather
+# than one "not passing".
 #
 # failing and pending are judged over EVERY check, not only the repository's
 # own, so a red third-party check refuses a green verdict instead of hiding
@@ -139,29 +163,51 @@ def fm_ci_state:
     elif any($all[]; fm_ci_check_unfinished) then "pending"
     elif (($all | fm_ci_missing_suites) | length) > 0 then "incomplete"
     else "passing" end;
-# No fm_ci_missing_suites counterpart here: a workflow run entry is an
-# aggregate GitHub computes over the full job graph scheduled for that run -
-# it cannot conclude "success" while any job in it is still missing,
-# unfinished, or red - so the roster is already enforced by the platform for
-# this shape. The rollup shape above has no such guarantee: a
-# statusCheckRollup entry is one job check run, so a rollup that never
-# received a job check run is structurally missing evidence, not
-# disagreeing with it.
+# The REST shapes - a workflow run and a workflow job - carry the same status
+# and conclusion fields in the same lower case, unlike the upper-case GraphQL
+# spelling of the rollup shape, so one pair of predicates classifies both.
 def fm_ci_run_from_ci_workflow:
   ((.name // "") | tostring) == fm_ci_workflow_name;
-def fm_ci_run_red:
+def fm_ci_rest_red:
   (((.conclusion // "") | tostring | ascii_downcase)) as $c
   | $c == "failure" or $c == "cancelled" or $c == "timed_out"
     or $c == "action_required" or $c == "startup_failure" or $c == "stale"
     or $c == "skipped" or $c == "neutral";
-def fm_ci_run_unfinished:
+def fm_ci_rest_unfinished:
   ((.status // "") | tostring | ascii_downcase) != "completed";
+# The run-level judgement on its own: whether the CI workflow ran at all here,
+# and whether the runs it produced are red or unfinished. It deliberately does
+# NOT answer "did the required suites run", because the conclusion of a run
+# cannot answer that - see the header on cli/cli run 32701833535. Every caller that
+# needs a green verdict goes through fm_ci_run_jobs_state instead.
 def fm_ci_runs_state:
   (. // []) as $all
   | [$all[] | select(fm_ci_run_from_ci_workflow)] as $runs
   | if ($runs | length) == 0 then "none"
-    elif any($runs[]; fm_ci_run_red) then "failing"
-    elif any($runs[]; fm_ci_run_unfinished) then "pending"
+    elif any($runs[]; fm_ci_rest_red) then "failing"
+    elif any($runs[]; fm_ci_rest_unfinished) then "pending"
+    else "passing" end;
+# The roster in the jobs shape, the counterpart of fm_ci_missing_suites: the
+# required suites that no job of the CI runs at this commit reported.
+def fm_ci_jobs_missing_suites:
+  (. // []) as $jobs
+  | ([$jobs[] | ((.name // "") | tostring)] | unique) as $job_names
+  | fm_ci_required_suites - $job_names;
+# {runs, jobs} -> the same states the rollup shape produces. jobs are the jobs
+# of the CI runs in runs, so an empty jobs array under a successful run means
+# the roster could not be read at all, which is refused as incomplete rather
+# than inherited from the conclusion of the run itself.
+def fm_ci_run_jobs_state:
+  (.runs // []) as $all
+  | (.jobs // []) as $jobs
+  | [$all[] | select(fm_ci_run_from_ci_workflow)] as $runs
+  | if ($runs | length) == 0 then "none"
+    elif any($runs[]; fm_ci_rest_red) then "failing"
+    elif any($runs[]; fm_ci_rest_unfinished) then "pending"
+    elif ($jobs | length) == 0 then "incomplete"
+    elif any($jobs[]; fm_ci_rest_red) then "failing"
+    elif any($jobs[]; fm_ci_rest_unfinished) then "pending"
+    elif (($jobs | fm_ci_jobs_missing_suites) | length) > 0 then "incomplete"
     else "passing" end;
 '
 
@@ -172,13 +218,33 @@ fm_ci_checks_state() {
   fm_ci_classify "$1" fm_ci_state
 }
 
-# fm_ci_runs_state <workflow-runs-json>: print the state of one repository's own
-# workflow runs at a commit, refusing unreadable input the same way. Every run
-# in that array came from the repository it was read from, but a repository
-# can own more than one workflow, so this still narrows to the CI workflow's
-# own runs before judging red, pending, or passing.
+# fm_ci_runs_state <workflow-runs-json>: print the run-level state of one
+# repository's own workflow runs at a commit, refusing unreadable input the
+# same way. Every run in that array came from the repository it was read from,
+# but a repository can own more than one workflow, so this still narrows to the
+# CI workflow's own runs before judging red, pending, or passing. Its passing
+# means "no CI run here is red or unfinished", NOT "the required suites ran":
+# a caller deciding whether to call a commit green wants fm_ci_run_jobs_state.
 fm_ci_runs_state() {
   fm_ci_classify "$1" fm_ci_runs_state
+}
+
+# fm_ci_run_jobs_state <workflow-runs-json> <ci-jobs-json>: print the state of a
+# repository's own CI runs at a commit judged against the required suite
+# roster, where the second argument is the jobs of those CI runs. This is the
+# workflow-runs answer to the same question the rollup shape answers, and the
+# only one of the two that can return a passing verdict a caller may act on.
+# Either payload being unreadable is refused rather than classified, so a
+# truncated reply can never arrive at passing.
+fm_ci_run_jobs_state() {
+  local runs=$1 jobs=$2 state
+  state=$(jq -rn --argjson runs "$runs" --argjson jobs "$jobs" \
+    "$FM_CI_CHECKS_JQ_DEFS"'
+    if ($runs | type) == "array" and ($jobs | type) == "array"
+    then {runs: $runs, jobs: $jobs} | fm_ci_run_jobs_state
+    else error("payload is not an array") end' 2>/dev/null) || return 1
+  [ -n "$state" ] || return 1
+  printf '%s\n' "$state"
 }
 
 fm_ci_classify() {

--- a/bin/fm-ci-checks-lib.sh
+++ b/bin/fm-ci-checks-lib.sh
@@ -31,54 +31,83 @@
 # GitHub offers this evidence in two shapes and the file owns both. A pull
 # request carries a check rollup, which mixes everyone's checks together and so
 # needs the workflowName discriminator above. A commit in a given repository
-# carries workflow runs, which are that repository's own by construction, so
-# fm_ci_runs_state classifies those without needing to tell producers apart.
-# The second shape is what answers "did MY fork validate this commit?" when the
-# first shape says the upstream pull request has no repository check on it.
+# carries workflow runs, which are that repository's own by construction, but
+# still mix every workflow the repository owns together - the CI workflow
+# alongside a PR-body policy check or a manually dispatched spike - so
+# fm_ci_runs_state applies the same by-name filter to that shape too, rather
+# than accepting any repository-owned run as a stand-in for the one that
+# actually ran the suites. The second shape is what answers "did MY fork
+# validate this commit?" when the first shape says the upstream pull request
+# has no repository check on it.
 #
 # States, in the order the classifier decides them:
 #   none        the commit carries no checks at all
-#   no-repo-ci  checks exist, but none of them came from this repository
+#   no-repo-ci  checks exist, but the CI workflow itself never produced one
 #   failing     at least one check reached a red conclusion
 #   pending     at least one check has not finished
-#   passing     this repository's own checks ran and every check succeeded
+#   passing     the CI workflow ran and every check succeeded
 #
 # failing and pending are judged over EVERY check, not only the repository's
 # own, so a red third-party check refuses a green verdict instead of hiding
 # behind the suites that passed. Deciding no-repo-ci before either of them keeps
 # the missing-suites diagnosis from being reported as an ordinary red or an
 # ordinary wait, which are different problems with different fixes.
+#
+# "Repository-owned" alone is not enough evidence: a commit can carry a
+# passing check from some OTHER workflow this repository owns (the PR-body
+# policy check in .github/workflows/no-mistakes-required.yml, a manually
+# dispatched spike) while .github/workflows/ci.yml - the workflow whose jobs
+# are the actual suites - never ran on it at all, because it did not trigger
+# or its job graph failed to expand. That reads as "1 passed, 0 failed" to
+# anything that only checks "is some repository check green", which is the
+# same false-green shape as a third-party bot, just from inside the
+# repository instead of outside it. fm_ci_workflow_name names the one
+# workflow whose run is the actual evidence, and both classifiers require it
+# by name rather than accepting any repository-owned check as a stand-in.
+#
+# A check or run that finished as SKIPPED, NEUTRAL, or STALE is also refused
+# rather than treated as passing: those conclusions mean the job never
+# actually validated anything, so a CI run that completed with one of its
+# jobs in that state is a partially-skipped workflow, not a clean pass.
 
 # jq function definitions. Prepend to a jq program; the program then calls
 # fm_ci_state on an array of statusCheckRollup entries.
 # $all and $own are jq variables, deliberately not shell expansions.
 # shellcheck disable=SC2016
 FM_CI_CHECKS_JQ_DEFS='
+def fm_ci_workflow_name: "CI";
 def fm_ci_repo_owned:
   ((.__typename // "") == "CheckRun") and (((.workflowName // "") | tostring) != "");
+def fm_ci_from_ci_workflow:
+  fm_ci_repo_owned and (((.workflowName // "") | tostring) == fm_ci_workflow_name);
 def fm_ci_check_red:
   (((.conclusion // .state // "") | tostring | ascii_upcase)) as $s
   | $s == "FAILURE" or $s == "ERROR" or $s == "TIMED_OUT" or $s == "CANCELLED"
-    or $s == "ACTION_REQUIRED" or $s == "STARTUP_FAILURE";
+    or $s == "ACTION_REQUIRED" or $s == "STARTUP_FAILURE" or $s == "SKIPPED"
+    or $s == "NEUTRAL" or $s == "STALE";
 def fm_ci_check_unfinished:
   (((.status // "") | tostring | ascii_upcase) != "COMPLETED")
   and (((.state // "") | tostring | ascii_upcase) != "SUCCESS");
 def fm_ci_state:
   (. // []) as $all
-  | [$all[] | select(fm_ci_repo_owned)] as $own
+  | [$all[] | select(fm_ci_from_ci_workflow)] as $ci
   | if ($all | length) == 0 then "none"
-    elif ($own | length) == 0 then "no-repo-ci"
+    elif ($ci | length) == 0 then "no-repo-ci"
     elif any($all[]; fm_ci_check_red) then "failing"
     elif any($all[]; fm_ci_check_unfinished) then "pending"
     else "passing" end;
+def fm_ci_run_from_ci_workflow:
+  ((.name // "") | tostring) == fm_ci_workflow_name;
 def fm_ci_run_red:
   (((.conclusion // "") | tostring | ascii_downcase)) as $c
   | $c == "failure" or $c == "cancelled" or $c == "timed_out"
-    or $c == "action_required" or $c == "startup_failure" or $c == "stale";
+    or $c == "action_required" or $c == "startup_failure" or $c == "stale"
+    or $c == "skipped" or $c == "neutral";
 def fm_ci_run_unfinished:
   ((.status // "") | tostring | ascii_downcase) != "completed";
 def fm_ci_runs_state:
-  (. // []) as $runs
+  (. // []) as $all
+  | [$all[] | select(fm_ci_run_from_ci_workflow)] as $runs
   | if ($runs | length) == 0 then "none"
     elif any($runs[]; fm_ci_run_red) then "failing"
     elif any($runs[]; fm_ci_run_unfinished) then "pending"
@@ -94,8 +123,9 @@ fm_ci_checks_state() {
 
 # fm_ci_runs_state <workflow-runs-json>: print the state of one repository's own
 # workflow runs at a commit, refusing unreadable input the same way. Every run
-# in that array came from the repository it was read from, so there is no
-# producer to tell apart here.
+# in that array came from the repository it was read from, but a repository
+# can own more than one workflow, so this still narrows to the CI workflow's
+# own runs before judging red, pending, or passing.
 fm_ci_runs_state() {
   fm_ci_classify "$1" fm_ci_runs_state
 }

--- a/bin/fm-ci-checks-lib.sh
+++ b/bin/fm-ci-checks-lib.sh
@@ -1,0 +1,109 @@
+# shellcheck shell=bash
+# Shared classification of a pull request's checks.
+# Usage: . bin/fm-ci-checks-lib.sh; jq "$FM_CI_CHECKS_JQ_DEFS"'<program>'
+#
+# ONE OWNER for the question "did this repository's own suites actually run and
+# pass on this commit?". Everything that reads a pull request's checks and turns
+# them into a verdict - bin/fm-pr-ci-verify.sh for a single pull request,
+# bin/fm-bearings-snapshot.sh for the bearings PR rows - classifies through the
+# jq functions below, so the two can never disagree about what green means.
+#
+# The rule that makes this file necessary: an all-green check list is NOT
+# evidence that this repository validated anything. A repository can receive
+# check runs from third-party GitHub Apps - review bots, coverage services -
+# that report on every commit whether or not a single workflow of this
+# repository's own ever started. GitHub also holds a fork contributor's upstream
+# workflow runs until a maintainer approves them, so a pull request from a fork
+# routinely carries a third-party bot's pass and nothing else. Read as a total,
+# that list is "1 passed, 0 failed, 1 total" - indistinguishable from success to
+# anything that only counts passes and failures, and the reason a green verdict
+# was reported three times for pull requests whose suites had never run.
+#
+# The discriminator is structural rather than a bot name to keep up to date:
+# GitHub records the workflow that produced a check run in workflowName, and
+# only GitHub Actions check runs have one. A check run created by a third-party
+# App has no workflow run behind it and so carries no workflow name at all, and
+# a legacy commit status (StatusContext) is not a check run in the first place.
+# A rollup with no repository-owned check therefore reports no-repo-ci, which is
+# a distinct state from passing and from an empty rollup's none, and no caller
+# can collapse it into success by counting conclusions.
+#
+# GitHub offers this evidence in two shapes and the file owns both. A pull
+# request carries a check rollup, which mixes everyone's checks together and so
+# needs the workflowName discriminator above. A commit in a given repository
+# carries workflow runs, which are that repository's own by construction, so
+# fm_ci_runs_state classifies those without needing to tell producers apart.
+# The second shape is what answers "did MY fork validate this commit?" when the
+# first shape says the upstream pull request has no repository check on it.
+#
+# States, in the order the classifier decides them:
+#   none        the commit carries no checks at all
+#   no-repo-ci  checks exist, but none of them came from this repository
+#   failing     at least one check reached a red conclusion
+#   pending     at least one check has not finished
+#   passing     this repository's own checks ran and every check succeeded
+#
+# failing and pending are judged over EVERY check, not only the repository's
+# own, so a red third-party check refuses a green verdict instead of hiding
+# behind the suites that passed. Deciding no-repo-ci before either of them keeps
+# the missing-suites diagnosis from being reported as an ordinary red or an
+# ordinary wait, which are different problems with different fixes.
+
+# jq function definitions. Prepend to a jq program; the program then calls
+# fm_ci_state on an array of statusCheckRollup entries.
+# $all and $own are jq variables, deliberately not shell expansions.
+# shellcheck disable=SC2016
+FM_CI_CHECKS_JQ_DEFS='
+def fm_ci_repo_owned:
+  ((.__typename // "") == "CheckRun") and (((.workflowName // "") | tostring) != "");
+def fm_ci_check_red:
+  (((.conclusion // .state // "") | tostring | ascii_upcase)) as $s
+  | $s == "FAILURE" or $s == "ERROR" or $s == "TIMED_OUT" or $s == "CANCELLED"
+    or $s == "ACTION_REQUIRED" or $s == "STARTUP_FAILURE";
+def fm_ci_check_unfinished:
+  (((.status // "") | tostring | ascii_upcase) != "COMPLETED")
+  and (((.state // "") | tostring | ascii_upcase) != "SUCCESS");
+def fm_ci_state:
+  (. // []) as $all
+  | [$all[] | select(fm_ci_repo_owned)] as $own
+  | if ($all | length) == 0 then "none"
+    elif ($own | length) == 0 then "no-repo-ci"
+    elif any($all[]; fm_ci_check_red) then "failing"
+    elif any($all[]; fm_ci_check_unfinished) then "pending"
+    else "passing" end;
+def fm_ci_run_red:
+  (((.conclusion // "") | tostring | ascii_downcase)) as $c
+  | $c == "failure" or $c == "cancelled" or $c == "timed_out"
+    or $c == "action_required" or $c == "startup_failure" or $c == "stale";
+def fm_ci_run_unfinished:
+  ((.status // "") | tostring | ascii_downcase) != "completed";
+def fm_ci_runs_state:
+  (. // []) as $runs
+  | if ($runs | length) == 0 then "none"
+    elif any($runs[]; fm_ci_run_red) then "failing"
+    elif any($runs[]; fm_ci_run_unfinished) then "pending"
+    else "passing" end;
+'
+
+# fm_ci_checks_state <rollup-json>: print the state of one statusCheckRollup
+# array. Unreadable input is refused rather than classified, so a malformed or
+# truncated payload can never be reported as passing.
+fm_ci_checks_state() {
+  fm_ci_classify "$1" fm_ci_state
+}
+
+# fm_ci_runs_state <workflow-runs-json>: print the state of one repository's own
+# workflow runs at a commit, refusing unreadable input the same way. Every run
+# in that array came from the repository it was read from, so there is no
+# producer to tell apart here.
+fm_ci_runs_state() {
+  fm_ci_classify "$1" fm_ci_runs_state
+}
+
+fm_ci_classify() {
+  local payload=$1 fn=$2 state
+  state=$(printf '%s' "$payload" | jq -r "$FM_CI_CHECKS_JQ_DEFS"'
+    if type == "array" then '"$fn"' else error("payload is not an array") end' 2>/dev/null) || return 1
+  [ -n "$state" ] || return 1
+  printf '%s\n' "$state"
+}

--- a/bin/fm-ci-checks-lib.sh
+++ b/bin/fm-ci-checks-lib.sh
@@ -45,13 +45,30 @@
 #   no-repo-ci  checks exist, but the CI workflow itself never produced one
 #   failing     at least one check reached a red conclusion
 #   pending     at least one check has not finished
-#   passing     the CI workflow ran and every check succeeded
+#   incomplete  the CI workflow reported, and everything it reported succeeded,
+#               but fewer than its full required roster of suites is in there
+#   passing     the CI workflow ran and every required suite succeeded
 #
 # failing and pending are judged over EVERY check, not only the repository's
 # own, so a red third-party check refuses a green verdict instead of hiding
 # behind the suites that passed. Deciding no-repo-ci before either of them keeps
 # the missing-suites diagnosis from being reported as an ordinary red or an
 # ordinary wait, which are different problems with different fixes.
+#
+# One green CI check is not the same claim as "CI ran": a rollup can carry a
+# single passing Lint job because that is genuinely all that ran - the rest of
+# the workflow's jobs never started or never reported - and read exactly like
+# "1 passed, 0 failed" to anything that only tallies conclusions, the same
+# false-green shape the no-repo-ci and other-workflow cases above already
+# guard against. fm_ci_required_suites is the fix: the full job roster
+# .github/workflows/ci.yml is expected to report, by the display name GitHub
+# renders for each job (matrix jobs expanded, one name per shard). A rollup
+# missing any of them is incomplete rather than passing, even when every check
+# it does carry is green. incomplete is deliberately its own state rather than
+# folded into no-repo-ci, because the two are different findings - "nothing of
+# ours ran" against "some of ours ran, not all of it" - but a caller that only
+# trusts "passing" is safe either way, and fm-pr-ci-verify.sh treats both the
+# same: neither is evidence, so it falls through to ask the head repository.
 #
 # "Repository-owned" alone is not enough evidence: a commit can carry a
 # passing check from some OTHER workflow this repository owns (the PR-body
@@ -70,12 +87,33 @@
 # actually validated anything, so a CI run that completed with one of its
 # jobs in that state is a partially-skipped workflow, not a clean pass.
 
+# The complete roster this repository's CI workflow (.github/workflows/ci.yml)
+# reports for every commit it validates, by the display name GitHub renders
+# for each job - matrix jobs expanded, one name per shard. Kept in sync with
+# that file by hand: a job ci.yml gains, loses, or renames must be mirrored
+# here, or a rollup missing the new job would still read as passing.
+FM_CI_REQUIRED_SUITES='[
+  "Lint",
+  "Test coverage guard",
+  "Behavior portable parallel 1",
+  "Behavior portable parallel 2",
+  "Behavior portable serial 1",
+  "Behavior portable serial 2",
+  "Behavior portable serial 3",
+  "Behavior portable serial 4",
+  "Behavior tests (Herdr)",
+  "Behavior timing aggregate",
+  "Stock macOS Bash snapshot compatibility",
+  "Repo invariants"
+]'
+
 # jq function definitions. Prepend to a jq program; the program then calls
 # fm_ci_state on an array of statusCheckRollup entries.
 # $all and $own are jq variables, deliberately not shell expansions.
 # shellcheck disable=SC2016
 FM_CI_CHECKS_JQ_DEFS='
 def fm_ci_workflow_name: "CI";
+def fm_ci_required_suites: '"$FM_CI_REQUIRED_SUITES"';
 def fm_ci_repo_owned:
   ((.__typename // "") == "CheckRun") and (((.workflowName // "") | tostring) != "");
 def fm_ci_from_ci_workflow:
@@ -88,6 +126,10 @@ def fm_ci_check_red:
 def fm_ci_check_unfinished:
   (((.status // "") | tostring | ascii_upcase) != "COMPLETED")
   and (((.state // "") | tostring | ascii_upcase) != "SUCCESS");
+def fm_ci_missing_suites:
+  (. // []) as $all
+  | ([$all[] | select(fm_ci_from_ci_workflow) | ((.name // .context // "") | tostring)] | unique) as $ci_names
+  | fm_ci_required_suites - $ci_names;
 def fm_ci_state:
   (. // []) as $all
   | [$all[] | select(fm_ci_from_ci_workflow)] as $ci
@@ -95,7 +137,16 @@ def fm_ci_state:
     elif ($ci | length) == 0 then "no-repo-ci"
     elif any($all[]; fm_ci_check_red) then "failing"
     elif any($all[]; fm_ci_check_unfinished) then "pending"
+    elif (($all | fm_ci_missing_suites) | length) > 0 then "incomplete"
     else "passing" end;
+# No fm_ci_missing_suites counterpart here: a workflow run entry is an
+# aggregate GitHub computes over the full job graph scheduled for that run -
+# it cannot conclude "success" while any job in it is still missing,
+# unfinished, or red - so the roster is already enforced by the platform for
+# this shape. The rollup shape above has no such guarantee: a
+# statusCheckRollup entry is one job check run, so a rollup that never
+# received a job check run is structurally missing evidence, not
+# disagreeing with it.
 def fm_ci_run_from_ci_workflow:
   ((.name // "") | tostring) == fm_ci_workflow_name;
 def fm_ci_run_red:

--- a/bin/fm-pr-ci-verify.sh
+++ b/bin/fm-pr-ci-verify.sh
@@ -23,7 +23,8 @@
 #
 # Usage: fm-pr-ci-verify.sh <pr-url>
 # Exit:  0 repository suites ran and passed, upstream or in the head repository
-#        1 they did not: none ran, one is red, or one has not finished
+#        1 they did not: none ran, one is red, one has not finished, or fewer
+#          than the full required roster reported
 #        2 the request or the reply could not be read
 set -eu
 
@@ -89,6 +90,14 @@ own=$(printf '%s' "$rollup" | jq "$FM_CI_CHECKS_JQ_DEFS"'
   [.[] | select(fm_ci_repo_owned)] | length' 2>/dev/null) || own='?'
 printf '%s checks: %s (%s repository-owned)\n' "$BASE_REPO" "$state" "$own"
 
+# An incomplete roster names what it is missing, the same way a red or
+# pending check names its own state above, so the refusal is never just "not
+# passing" with no way to tell what would make it so.
+if [ "$state" = incomplete ]; then
+  missing=$(printf '%s' "$rollup" | jq -r "$FM_CI_CHECKS_JQ_DEFS"'fm_ci_missing_suites | .[]' 2>/dev/null) || missing=''
+  [ -z "$missing" ] || printf 'missing required suites:\n%s\n' "$(printf '%s\n' "$missing" | sed 's/^/  /')"
+fi
+
 if [ "$state" = passing ]; then
   printf 'validated: %s suites passed on %s in %s\n' "$BASE_REPO" "$head_sha" "$BASE_REPO"
   exit 0
@@ -104,18 +113,27 @@ case "$state" in
     ;;
 esac
 
-# Nothing upstream validated this commit. Ask the head repository, which is
-# where an unapproved fork pull request's suites actually ran.
+# Nothing upstream validated this commit: no-repo-ci and incomplete are both
+# "the base repository is not evidence", just for different reasons - nothing
+# of ours ran, or only part of it did - so both fall through the same way to
+# ask the head repository, which is where an unapproved fork pull request's
+# suites actually ran.
+if [ "$state" = incomplete ]; then
+  base_reason="$BASE_REPO checks do not cover the required suite roster"
+else
+  base_reason="no $BASE_REPO suite ran on this commit"
+fi
+
 if [ -z "$head_repo" ] || [ -z "$head_sha" ] || [ "$head_repo" = "$BASE_REPO" ]; then
   {
-    printf 'error: refusing to call %s green: no repository suite ran on this commit.\n' "$URL"
+    printf 'error: refusing to call %s green: %s.\n' "$URL" "$base_reason"
     echo "A third-party check passing is not this repository's CI passing, and there is"
     echo "no separate head repository whose own run could have validated it."
   } >&2
   exit 1
 fi
 
-printf 'no %s suite ran on this commit; reading %s at %s\n' "$BASE_REPO" "$head_repo" "$head_sha"
+printf '%s; reading %s at %s\n' "$base_reason" "$head_repo" "$head_sha"
 runs=$(gh api "repos/$head_repo/actions/runs?head_sha=$head_sha&per_page=100" \
   --jq '[.workflow_runs[] | {id, name, status, conclusion, event}]' 2>/dev/null) \
   || unreadable "the workflow runs in $head_repo"

--- a/bin/fm-pr-ci-verify.sh
+++ b/bin/fm-pr-ci-verify.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Establish that a pull request's change was actually validated by repository
+# suites, and refuse every outcome that only looks like it was.
+# This is the check to run before reporting a pull request green, and the reason
+# an all-green check LIST is never enough on its own: bin/fm-ci-checks-lib.sh
+# owns why, and owns the classification itself.
+#
+# Two places can hold that evidence, and this script reads both in order:
+#
+#   1. The pull request's own checks, in the repository it targets. When those
+#      include this repository's suites and everything passed, that is the
+#      answer and nothing else is consulted.
+#   2. Failing that, the head repository - your fork - at the same commit.
+#      GitHub holds a fork contributor's upstream workflow runs until a
+#      maintainer approves them, so an unapproved pull request routinely carries
+#      no upstream suite at all. The fork ran them on the branch push, and that
+#      run is real validation of the same commit. Accepting it is what makes an
+#      upstream approval a contribution question rather than a validation one.
+#
+# A commit validated only in the fork is reported as exactly that, naming the
+# repository and run, so a green verdict always says where its evidence came
+# from and is never confused with the upstream pull request having been checked.
+#
+# Usage: fm-pr-ci-verify.sh <pr-url>
+# Exit:  0 repository suites ran and passed, upstream or in the head repository
+#        1 they did not: none ran, one is red, or one has not finished
+#        2 the request or the reply could not be read
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bin/fm-ci-checks-lib.sh
+. "$SCRIPT_DIR/fm-ci-checks-lib.sh"
+# shellcheck source=bin/fm-pr-lib.sh
+. "$SCRIPT_DIR/fm-pr-lib.sh"
+
+unreadable() {
+  printf 'error: could not read %s\n' "$1" >&2
+  exit 2
+}
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: fm-pr-ci-verify.sh <pr-url>" >&2
+  exit 2
+fi
+
+# The URL is parsed by the same owner the rest of the pull request path uses, so
+# this script accepts exactly the URLs those scripts accept and never reaches a
+# forge from a string it has not validated.
+if ! fm_pr_url_parse "$1"; then
+  echo "error: not a pull request URL: $1" >&2
+  exit 2
+fi
+if [ "$FM_PR_PROVIDER" != github ]; then
+  # GitLab reports a head pipeline rather than check runs, and bin/fm-pr-merge.sh
+  # already verifies that pipeline at the head it merges.
+  echo "error: fm-pr-ci-verify.sh reads GitHub check runs; $1 is not a GitHub pull request" >&2
+  exit 2
+fi
+URL=$FM_PR_URL
+BASE_REPO="$FM_PR_OWNER/$FM_PR_REPO"
+
+pr=$(gh pr view "$FM_PR_NUMBER" --repo "$BASE_REPO" \
+  --json statusCheckRollup,headRefOid,headRepository,headRepositoryOwner 2>/dev/null) \
+  || unreadable "the pull request $URL"
+
+rollup=$(printf '%s' "$pr" | jq -c '.statusCheckRollup // []' 2>/dev/null) \
+  || unreadable "the checks on $URL"
+head_sha=$(printf '%s' "$pr" | jq -r '.headRefOid // ""' 2>/dev/null) || head_sha=''
+head_repo=$(printf '%s' "$pr" | jq -r '
+  ((.headRepositoryOwner.login // "") | tostring) as $o
+  | ((.headRepository.name // "") | tostring) as $n
+  | if $o == "" or $n == "" then "" else $o + "/" + $n end' 2>/dev/null) || head_repo=''
+
+state=$(fm_ci_checks_state "$rollup") || unreadable "the checks on $URL"
+
+# The roster is printed for every outcome, including the passing one, so the
+# evidence behind a green verdict is on the record rather than only its verdict.
+printf '%s\n' "$URL"
+roster=$(printf '%s' "$rollup" | jq -r "$FM_CI_CHECKS_JQ_DEFS"'
+  def row: "  " + (if fm_ci_repo_owned then "suite " else "other " end)
+    + ((.conclusion // .state // "pending") | tostring)
+    + "\t" + (((.workflowName // "") | tostring) as $w | if $w == "" then "-" else $w end)
+    + " / " + ((.name // .context // "-") | tostring);
+  [.[] | select(fm_ci_repo_owned) | row] + [.[] | select(fm_ci_repo_owned | not) | row]
+  | .[]' 2>/dev/null) || roster=''
+[ -z "$roster" ] || printf '%s\n' "$roster"
+
+own=$(printf '%s' "$rollup" | jq "$FM_CI_CHECKS_JQ_DEFS"'
+  [.[] | select(fm_ci_repo_owned)] | length' 2>/dev/null) || own='?'
+printf '%s checks: %s (%s repository-owned)\n' "$BASE_REPO" "$state" "$own"
+
+if [ "$state" = passing ]; then
+  printf 'validated: %s suites passed on %s in %s\n' "$BASE_REPO" "$head_sha" "$BASE_REPO"
+  exit 0
+fi
+
+# A red or unfinished upstream suite is a real result about this commit, so it
+# is reported as-is rather than looked past in the hope the fork disagrees.
+case "$state" in
+  failing|pending)
+    printf 'error: refusing to call %s green: its %s checks are %s (see the roster above).\n' \
+      "$URL" "$BASE_REPO" "$state" >&2
+    exit 1
+    ;;
+esac
+
+# Nothing upstream validated this commit. Ask the head repository, which is
+# where an unapproved fork pull request's suites actually ran.
+if [ -z "$head_repo" ] || [ -z "$head_sha" ] || [ "$head_repo" = "$BASE_REPO" ]; then
+  {
+    printf 'error: refusing to call %s green: no repository suite ran on this commit.\n' "$URL"
+    echo "A third-party check passing is not this repository's CI passing, and there is"
+    echo "no separate head repository whose own run could have validated it."
+  } >&2
+  exit 1
+fi
+
+printf 'no %s suite ran on this commit; reading %s at %s\n' "$BASE_REPO" "$head_repo" "$head_sha"
+runs=$(gh api "repos/$head_repo/actions/runs?head_sha=$head_sha&per_page=100" \
+  --jq '[.workflow_runs[] | {id, name, status, conclusion, event}]' 2>/dev/null) \
+  || unreadable "the workflow runs in $head_repo"
+[ -n "$runs" ] || unreadable "the workflow runs in $head_repo"
+
+fork_state=$(fm_ci_runs_state "$runs") || unreadable "the workflow runs in $head_repo"
+fork_roster=$(printf '%s' "$runs" | jq -r '
+  .[] | "  run " + ((.id // "-") | tostring) + " " + ((.conclusion // .status) | tostring)
+    + "\t" + ((.name // "-") | tostring) + " (" + ((.event // "-") | tostring) + ")"' 2>/dev/null) \
+  || fork_roster=''
+[ -z "$fork_roster" ] || printf '%s\n' "$fork_roster"
+printf '%s runs: %s\n' "$head_repo" "$fork_state"
+
+case "$fork_state" in
+  passing)
+    # Named as fork-validated so the verdict can never be read as the upstream
+    # pull request having been checked. Upstream approval remains outstanding
+    # and is a contribution question, not a validation one.
+    printf 'validated: %s suites passed on %s in %s; %s has not run its own and does not need to for this to be validated\n' \
+      "$head_repo" "$head_sha" "$head_repo" "$BASE_REPO"
+    exit 0
+    ;;
+  none)
+    {
+      printf 'error: refusing to call %s green: no suite ran on this commit in either %s or %s.\n' \
+        "$URL" "$BASE_REPO" "$head_repo"
+      printf 'Push the branch to %s and let its own run validate the commit.\n' "$head_repo"
+    } >&2
+    exit 1
+    ;;
+  *)
+    printf 'error: refusing to call %s green: the %s runs are %s (see above).\n' \
+      "$URL" "$head_repo" "$fork_state" >&2
+    exit 1
+    ;;
+esac

--- a/bin/fm-pr-ci-verify.sh
+++ b/bin/fm-pr-ci-verify.sh
@@ -16,6 +16,10 @@
 #      no upstream suite at all. The fork ran them on the branch push, and that
 #      run is real validation of the same commit. Accepting it is what makes an
 #      upstream approval a contribution question rather than a validation one.
+#      That acceptance is granted on the run's JOBS, never on the run's own
+#      conclusion: a run concludes success whenever nothing in it failed, which
+#      a run whose jobs were skipped or never expanded also does, so only the
+#      required suite roster appearing green among those jobs is evidence.
 #
 # A commit validated only in the fork is reported as exactly that, naming the
 # repository and run, so a green verdict always says where its evidence came
@@ -139,13 +143,48 @@ runs=$(gh api "repos/$head_repo/actions/runs?head_sha=$head_sha&per_page=100" \
   || unreadable "the workflow runs in $head_repo"
 [ -n "$runs" ] || unreadable "the workflow runs in $head_repo"
 
-fork_state=$(fm_ci_runs_state "$runs") || unreadable "the workflow runs in $head_repo"
+# The run's own conclusion cannot answer whether the required suites ran, so
+# the jobs of every CI run at this commit are read and judged against the same
+# roster the rollup shape uses. bin/fm-ci-checks-lib.sh owns why a successful
+# run is not that evidence.
+ci_run_ids=$(printf '%s' "$runs" | jq -r "$FM_CI_CHECKS_JQ_DEFS"'
+  .[] | select(fm_ci_run_from_ci_workflow) | (.id // empty) | tostring' 2>/dev/null) \
+  || unreadable "the workflow runs in $head_repo"
+
+ci_jobs='[]'
+for run_id in $ci_run_ids; do
+  # A run with more jobs than one page would truncate the roster, which can
+  # only ever lose a required suite and so can only refuse, never pass.
+  run_jobs=$(gh api "repos/$head_repo/actions/runs/$run_id/jobs?per_page=100" \
+    --jq '[.jobs[] | {name, status, conclusion}]' 2>/dev/null) \
+    || unreadable "the jobs of run $run_id in $head_repo"
+  [ -n "$run_jobs" ] || unreadable "the jobs of run $run_id in $head_repo"
+  ci_jobs=$(jq -cn --argjson a "$ci_jobs" --argjson b "$run_jobs" '$a + $b' 2>/dev/null) \
+    || unreadable "the jobs of run $run_id in $head_repo"
+done
+
+fork_state=$(fm_ci_run_jobs_state "$runs" "$ci_jobs") \
+  || unreadable "the workflow runs in $head_repo"
 fork_roster=$(printf '%s' "$runs" | jq -r '
   .[] | "  run " + ((.id // "-") | tostring) + " " + ((.conclusion // .status) | tostring)
     + "\t" + ((.name // "-") | tostring) + " (" + ((.event // "-") | tostring) + ")"' 2>/dev/null) \
   || fork_roster=''
 [ -z "$fork_roster" ] || printf '%s\n' "$fork_roster"
+# The jobs are printed for every outcome, the passing one included, so a green
+# verdict carries the suite names it was granted on rather than only a state.
+job_roster=$(printf '%s' "$ci_jobs" | jq -r '
+  .[] | "  job " + ((.conclusion // .status // "pending") | tostring)
+    + "\t" + ((.name // "-") | tostring)' 2>/dev/null) || job_roster=''
+[ -z "$job_roster" ] || printf '%s\n' "$job_roster"
 printf '%s runs: %s\n' "$head_repo" "$fork_state"
+
+if [ "$fork_state" = incomplete ]; then
+  fork_missing=$(printf '%s' "$ci_jobs" | jq -r "$FM_CI_CHECKS_JQ_DEFS"'
+    fm_ci_jobs_missing_suites | .[]' 2>/dev/null) || fork_missing=''
+  if [ -n "$fork_missing" ]; then
+    printf 'missing required suites:\n%s\n' "$(printf '%s\n' "$fork_missing" | sed 's/^/  /')"
+  fi
+fi
 
 case "$fork_state" in
   passing)
@@ -161,6 +200,15 @@ case "$fork_state" in
       printf 'error: refusing to call %s green: no suite ran on this commit in either %s or %s.\n' \
         "$URL" "$BASE_REPO" "$head_repo"
       printf 'Push the branch to %s and let its own run validate the commit.\n' "$head_repo"
+    } >&2
+    exit 1
+    ;;
+  incomplete)
+    {
+      printf 'error: refusing to call %s green: the %s CI run does not cover the required suite roster (see above).\n' \
+        "$URL" "$head_repo"
+      echo "A workflow run concludes success when no job failed, which a run whose jobs"
+      echo "were skipped or never expanded also does, so that is not evidence the suites ran."
     } >&2
     exit 1
     ;;

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -635,6 +635,10 @@ run_coverage_guard() {
   local -a saved_scripts=()
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-coverage.XXXXXX")
 
+  # Every list here is built with LC_ALL=C sort, so every comm that reads one
+  # must compare under the same collation. Left to the ambient locale, comm
+  # rejects C-sorted input as unsorted on a UTF-8 host, and the guard then
+  # reports a failure that says nothing about the partition it exists to prove.
   all_repo_tests | LC_ALL=C sort -u >"$tmp/all"
   list_proven_isolated | LC_ALL=C sort -u >"$tmp/proven"
   list_portable_parallel_1 | LC_ALL=C sort -u >"$tmp/s1"
@@ -648,8 +652,8 @@ run_coverage_guard() {
     return 1
   fi
   cat "$tmp/s1" "$tmp/s2" | LC_ALL=C sort -u >"$tmp/shards_union"
-  missing=$(comm -23 "$tmp/proven" "$tmp/shards_union" || true)
-  extra=$(comm -13 "$tmp/proven" "$tmp/shards_union" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/proven" "$tmp/shards_union" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/proven" "$tmp/shards_union" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: portable shards must equal the proven-isolated set"
     [ -z "$missing" ] || { log "missing from shards:"; printf '%s\n' "$missing" >&2; }
@@ -693,8 +697,8 @@ run_coverage_guard() {
     return 1
   fi
   LC_ALL=C sort -u "$tmp/serial_shards_raw" >"$tmp/serial_shards"
-  missing=$(comm -23 "$tmp/serial" "$tmp/serial_shards" || true)
-  extra=$(comm -13 "$tmp/serial" "$tmp/serial_shards" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/serial" "$tmp/serial_shards" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/serial" "$tmp/serial_shards" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: portable serial shards must equal the portable serial lane"
     [ -z "$missing" ] || { log "missing from serial shards:"; printf '%s\n' "$missing" >&2; }
@@ -706,7 +710,7 @@ run_coverage_guard() {
   for pair in "shards_union:serial" "shards_union:herdr" "serial:herdr"; do
     a=${pair%%:*}
     b=${pair#*:}
-    comm -12 "$tmp/$a" "$tmp/$b" >"$tmp/overlap"
+    LC_ALL=C comm -12 "$tmp/$a" "$tmp/$b" >"$tmp/overlap"
     if [ -s "$tmp/overlap" ]; then
       log "coverage guard: overlap between $a and $b:"
       cat "$tmp/overlap" >&2
@@ -724,8 +728,8 @@ run_coverage_guard() {
     return 1
   fi
   LC_ALL=C sort -u "$tmp/union_raw" >"$tmp/union"
-  missing=$(comm -23 "$tmp/all" "$tmp/union" || true)
-  extra=$(comm -13 "$tmp/all" "$tmp/union" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/all" "$tmp/union" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/all" "$tmp/union" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: union of portable shards + portable serial + Herdr must equal tests/*.test.sh"
     [ -z "$missing" ] || { log "missing from union:"; printf '%s\n' "$missing" >&2; }
@@ -738,7 +742,7 @@ run_coverage_guard() {
     "$ROOT/bin/fm-test-isolation-proof.sh" --list | LC_ALL=C sort -u >"$tmp/proof_list"
     if ! cmp -s "$tmp/proven" "$tmp/proof_list"; then
       log "coverage guard: embedded proven-isolated set diverges from bin/fm-test-isolation-proof.sh --list"
-      comm -3 "$tmp/proven" "$tmp/proof_list" >&2 || true
+      LC_ALL=C comm -3 "$tmp/proven" "$tmp/proof_list" >&2 || true
       rm -rf "$tmp"
       return 1
     fi

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -342,6 +342,8 @@ The refresh also prunes local branches whose remote is gone and that no worktree
 ## Self-updates stay safe
 
 `/updatefirstmate` fast-forwards the running firstmate repo and registered secondmate homes from `origin`, then re-reads updated instructions and nudges updated secondmates without touching project clones.
+`origin` is whatever remote that home points at, not a fixed repository, so a fleet that carries its own changes points each home's `origin` at the fork it pushes to and updates from the code its own runs validated, rather than from a repository it is waiting on.
+That is the same split [`CONTRIBUTING.md`](../CONTRIBUTING.md) draws for a contributor: the fork answers whether the change is sound, and the upstream pull request answers only whether it gets taken.
 For a remote route, the configured code root updates from its own origin on that host before the persistent home fast-forwards to the code-root commit.
 The update is fast-forward only: dirty, diverged, offline, and off-default targets are reported and left untouched.
 Local homes share the guarded fast-forward helper, while remote updates delegate the same safety decision to the configured host through the generic transport.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -113,6 +113,8 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-pr-poll.sh`          | Provide the byte-static watcher program for validated PR/MR-poll sidecars           |
 | `fm-pr-check-migrate.sh` | Quarantine older task polls without execution and rebuild only canonical polls       |
 | `fm-pr-check.sh`         | Record validated `pr=` and `pr_head=` values, then atomically arm a static merge poll |
+| `fm-ci-checks-lib.sh`    | Single owner of whether a commit's own repository suites actually ran, not just passed |
+| `fm-pr-ci-verify.sh`     | Refuse a PR that only looks green, accepting a fork run that validated the same commit |
 | `fm-pr-merge.sh`         | Record PR metadata, then merge a task's canonical full GitHub or GitLab URL          |
 | `fm-promote.sh`          | Promote a scout task in place to a protected ship task with an explicit delivery mode |
 | `fm-teardown.sh`         | Fail-closed teardown: return landed ship worktrees, require completed scout deliverables, retire secondmate homes |

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -63,8 +63,12 @@ if [ "${FAKE_GH_MANY:-0}" = 1 ]; then
 JSON
   exit 0
 fi
+# The complete required-suite roster (bin/fm-ci-checks-lib.sh
+# FM_CI_REQUIRED_SUITES), all green - the default fixture stands in for a
+# pull request CI genuinely validated, so it must carry evidence that would
+# actually classify as passing rather than one lone suite.
 cat <<'JSON'
-[{"number":9,"title":"Ship the thing","url":"https://github.com/kunchenguid/firstmate/pull/9","headRefName":"fm/ship-task","reviewDecision":"APPROVED","mergeable":"MERGEABLE","statusCheckRollup":[{"__typename":"CheckRun","workflowName":"CI","name":"Lint","conclusion":"SUCCESS","status":"COMPLETED"}]}]
+[{"number":9,"title":"Ship the thing","url":"https://github.com/kunchenguid/firstmate/pull/9","headRefName":"fm/ship-task","reviewDecision":"APPROVED","mergeable":"MERGEABLE","statusCheckRollup":[{"__typename":"CheckRun","workflowName":"CI","name":"Lint","conclusion":"SUCCESS","status":"COMPLETED"},{"__typename":"CheckRun","workflowName":"CI","name":"Test coverage guard","conclusion":"SUCCESS","status":"COMPLETED"},{"__typename":"CheckRun","workflowName":"CI","name":"Behavior portable parallel 1","conclusion":"SUCCESS","status":"COMPLETED"},{"__typename":"CheckRun","workflowName":"CI","name":"Behavior portable parallel 2","conclusion":"SUCCESS","status":"COMPLETED"},{"__typename":"CheckRun","workflowName":"CI","name":"Behavior portable serial 1","conclusion":"SUCCESS","status":"COMPLETED"},{"__typename":"CheckRun","workflowName":"CI","name":"Behavior portable serial 2","conclusion":"SUCCESS","status":"COMPLETED"},{"__typename":"CheckRun","workflowName":"CI","name":"Behavior portable serial 3","conclusion":"SUCCESS","status":"COMPLETED"},{"__typename":"CheckRun","workflowName":"CI","name":"Behavior portable serial 4","conclusion":"SUCCESS","status":"COMPLETED"},{"__typename":"CheckRun","workflowName":"CI","name":"Behavior tests (Herdr)","conclusion":"SUCCESS","status":"COMPLETED"},{"__typename":"CheckRun","workflowName":"CI","name":"Behavior timing aggregate","conclusion":"SUCCESS","status":"COMPLETED"},{"__typename":"CheckRun","workflowName":"CI","name":"Stock macOS Bash snapshot compatibility","conclusion":"SUCCESS","status":"COMPLETED"},{"__typename":"CheckRun","workflowName":"CI","name":"Repo invariants","conclusion":"SUCCESS","status":"COMPLETED"}]}]
 JSON
 SH
   cat > "$fb/gh-axi" <<'SH'

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -49,6 +49,14 @@ SH
 echo "gh $*" >> "$NET_LOG"
 if [ "${FAKE_GH_FAIL:-0}" = 1 ]; then exit 1; fi
 if [ "${FAKE_GH_SLEEP:-0}" = 1 ]; then sleep 30; fi
+if [ "${FAKE_GH_BOT_ONLY:-0}" = 1 ]; then
+  # A pull request whose only check is a third-party App: it has no workflow
+  # behind it, so it carries no workflow name.
+  cat <<'JSON'
+[{"number":9,"title":"Ship the thing","url":"https://github.com/kunchenguid/firstmate/pull/9","headRefName":"fm/ship-task","reviewDecision":"APPROVED","mergeable":"MERGEABLE","statusCheckRollup":[{"__typename":"CheckRun","workflowName":"","name":"Greptile Review","conclusion":"SUCCESS","status":"COMPLETED"}]}]
+JSON
+  exit 0
+fi
 if [ "${FAKE_GH_MANY:-0}" = 1 ]; then
   cat <<'JSON'
 [{"number":1,"title":"One","url":"https://github.com/acme/repo/pull/1","headRefName":"fm/one","reviewDecision":"","mergeable":"MERGEABLE","statusCheckRollup":[]},{"number":2,"title":"Two","url":"https://github.com/acme/repo/pull/2","headRefName":"fm/two","reviewDecision":"","mergeable":"MERGEABLE","statusCheckRollup":[]},{"number":3,"title":"Three","url":"https://github.com/acme/repo/pull/3","headRefName":"fm/three","reviewDecision":"","mergeable":"MERGEABLE","statusCheckRollup":[]}]
@@ -56,7 +64,7 @@ JSON
   exit 0
 fi
 cat <<'JSON'
-[{"number":9,"title":"Ship the thing","url":"https://github.com/kunchenguid/firstmate/pull/9","headRefName":"fm/ship-task","reviewDecision":"APPROVED","mergeable":"MERGEABLE","statusCheckRollup":[{"conclusion":"SUCCESS","status":"COMPLETED"}]}]
+[{"number":9,"title":"Ship the thing","url":"https://github.com/kunchenguid/firstmate/pull/9","headRefName":"fm/ship-task","reviewDecision":"APPROVED","mergeable":"MERGEABLE","statusCheckRollup":[{"__typename":"CheckRun","workflowName":"CI","name":"Lint","conclusion":"SUCCESS","status":"COMPLETED"}]}]
 JSON
 SH
   cat > "$fb/gh-axi" <<'SH'
@@ -1030,6 +1038,18 @@ test_include_prs_is_the_only_fetch_path() {
     .candidate_prs | any(.[]; .num == "9" and .task == "ship-task" and .checks == "passing" and .review == "APPROVED")
   ' >/dev/null || fail "candidate_prs must carry the fetched PR cross-referenced to its task: $json"
   pass "--include-prs is the only path that fetches, and it enriches correctly"
+
+  # The same pull request with only a third-party check must not read as green:
+  # that rollup is what a held fork run looks like, and calling it passing here
+  # is how a bearings row reports a change as validated that nothing ran on.
+  json=$(FAKE_GH_BOT_ONLY=1 run "$home" "$fakebin" --include-prs --json)
+  printf '%s' "$json" | jq -e '
+    .candidate_prs | any(.[]; .num == "9" and .checks == "no-repo-ci")
+  ' >/dev/null || fail "a rollup of only third-party checks must not read as passing: $json"
+  printf '%s' "$json" | jq -e '
+    .candidate_prs | any(.[]; .num == "9" and .checks == "passing") | not
+  ' >/dev/null || fail "a rollup of only third-party checks must never read as passing: $json"
+  pass "a bearings row whose pull request carries only third-party checks reads no-repo-ci, not passing"
 }
 
 test_partial_github_failure_degrades() {

--- a/tests/fm-ci-checks.test.sh
+++ b/tests/fm-ci-checks.test.sh
@@ -65,6 +65,29 @@ WITH_SUITE="[$(suite Lint SUCCESS),$(bot 'Greptile Review' SUCCESS)]"
   || fail "a passing repository suite alongside a passing bot must be passing"
 pass "a repository-owned suite is what makes an all-green rollup passing"
 
+# The second false-green shape: a repository-owned check that is real, but is
+# not the CI workflow - the PR-body policy check can pass while ci.yml never
+# produced a check at all, and that must read the same as no CI having run.
+other_workflow() {
+  printf '{"__typename":"CheckRun","workflowName":"%s","name":"%s","status":"COMPLETED","conclusion":"%s"}' "$1" "$2" "$3"
+}
+ONLY_OTHER_WORKFLOW="[$(other_workflow 'Require no-mistakes' 'PR must be raised via no-mistakes' SUCCESS)]"
+GOT=$(fm_ci_checks_state "$ONLY_OTHER_WORKFLOW")
+[ "$GOT" = no-repo-ci ] \
+  || fail "a passing check from a repository workflow other than CI must be no-repo-ci, got: $GOT"
+pass "a passing check from an unrelated repository-owned workflow is not CI having run"
+
+# A job that finished SKIPPED, NEUTRAL, or STALE never validated anything, so a
+# workflow that completed with one of those among otherwise-green jobs is a
+# partially-skipped run, not a clean pass.
+[ "$(fm_ci_checks_state "[$(suite Lint SUCCESS),$(suite 'Test coverage guard' SKIPPED)]")" = failing ] \
+  || fail "a skipped CI job among passing ones must refuse a passing verdict"
+[ "$(fm_ci_checks_state "[$(suite Lint NEUTRAL)]")" = failing ] \
+  || fail "a neutral CI job must refuse a passing verdict"
+[ "$(fm_ci_checks_state "[$(suite Lint STALE)]")" = failing ] \
+  || fail "a stale CI job must refuse a passing verdict"
+pass "a partially-skipped CI workflow is refused rather than read as passing"
+
 # The missing-suites diagnosis is decided before red and before waiting, so it
 # is never reported as one of those different problems.
 [ "$(fm_ci_checks_state "[$(bot 'Greptile Review' FAILURE)]")" = no-repo-ci ] \
@@ -96,9 +119,10 @@ pass "an unreadable rollup is refused instead of being classified"
 
 # --- the same question in the workflow-runs shape ----------------------------
 
-# A repository reading its OWN workflow runs at a commit has no producer to tell
-# apart: every run in that list is its own by construction.
+# A repository can own more than one workflow, so this shape still narrows to
+# the CI workflow's own runs by name before judging red, pending, or passing.
 run() { printf '{"id":%s,"name":"CI","status":"%s","conclusion":%s,"event":"push"}' "$1" "$2" "$3"; }
+named_run() { printf '{"id":%s,"name":"%s","status":"%s","conclusion":%s,"event":"push"}' "$1" "$2" "$3" "$4"; }
 
 [ "$(fm_ci_runs_state '[]')" = none ] || fail "no workflow runs must be none"
 [ "$(fm_ci_runs_state "[$(run 1 completed '"success"')]")" = passing ] \
@@ -112,6 +136,23 @@ run() { printf '{"id":%s,"name":"CI","status":"%s","conclusion":%s,"event":"push
 [ "$(fm_ci_runs_state "[$(run 1 completed '"success"'),$(run 2 completed '"failure"')]")" = failing ] \
   || fail "one failed run among successes must be failing"
 pass "fm_ci_runs_state classifies a repository own workflow runs at a commit"
+
+# A successful run of some OTHER repository workflow is not evidence the CI
+# workflow ran - the same false-green shape as the rollup's unrelated check.
+ONLY_OTHER_RUN="[$(named_run 1 'Require no-mistakes' completed '"success"')]"
+[ "$(fm_ci_runs_state "$ONLY_OTHER_RUN")" = none ] \
+  || fail "a passing run of a workflow other than CI must not count as CI having run"
+[ "$(fm_ci_runs_state "[$(named_run 1 'Require no-mistakes' completed '"success"'),$(run 2 completed '"success"')]")" = passing ] \
+  || fail "a passing CI run must still be passing alongside an unrelated workflow's run"
+pass "fm_ci_runs_state ignores runs from workflows other than CI"
+
+# A run that completed with a skipped or neutral conclusion never validated
+# anything and must not be read as a clean pass.
+[ "$(fm_ci_runs_state "[$(run 1 completed '"skipped"')]")" = failing ] \
+  || fail "a skipped CI run must refuse a passing verdict"
+[ "$(fm_ci_runs_state "[$(run 1 completed '"neutral"')]")" = failing ] \
+  || fail "a neutral CI run must refuse a passing verdict"
+pass "fm_ci_runs_state refuses a skipped or neutral CI run"
 
 if fm_ci_runs_state '{"workflow_runs":[]}' >/dev/null 2>&1; then
   fail "a non-array runs payload must be refused, not classified"

--- a/tests/fm-ci-checks.test.sh
+++ b/tests/fm-ci-checks.test.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# tests/fm-ci-checks.test.sh - the rule that a check list is only green when
+# this repository's own suites are in it.
+#
+# Two interfaces, one rule (bin/fm-ci-checks-lib.sh): the classifier every
+# reader shares, and bin/fm-pr-ci-verify.sh, the guard run before calling a pull
+# request green. The case that matters is the one that produced three false
+# green verdicts in practice: a pull request whose only check is a third-party
+# review bot reporting success, which counts as "1 passed, 0 failed" to anything
+# that only tallies conclusions.
+#
+# The guard also has to accept the case those three were really in: an upstream
+# pull request with no suite of its own because GitHub is holding the run, whose
+# commit the head repository already validated on the branch push. That has to
+# come back green, and it has to say which repository the evidence came from.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-ci-checks-lib.sh"
+
+TMP=$(fm_test_tmproot fm-ci-checks)
+FAKEBIN=$(fm_fakebin "$TMP")
+
+# A GitHub Actions check run records the workflow that produced it; a check run
+# created by a third-party App has no workflow behind it and so no name.
+suite() {
+  printf '{"__typename":"CheckRun","workflowName":"CI","name":"%s","status":"COMPLETED","conclusion":"%s"}' "$1" "$2"
+}
+bot() {
+  printf '{"__typename":"CheckRun","workflowName":"","name":"%s","status":"COMPLETED","conclusion":"%s"}' "$1" "$2"
+}
+
+# --- the classifier ---------------------------------------------------------
+
+[ "$(fm_ci_checks_state "[]")" = none ] \
+  || fail "an empty rollup must be none"
+pass "a commit with no checks at all classifies as none"
+
+# The regression this file exists for.
+ONLY_BOT="[$(bot 'Greptile Review' SUCCESS)]"
+GOT=$(fm_ci_checks_state "$ONLY_BOT")
+[ "$GOT" = no-repo-ci ] || fail "a lone passing third-party check must be no-repo-ci, got: $GOT"
+[ "$GOT" != passing ] || fail "a lone passing third-party check must never be passing"
+pass "a rollup of nothing but a passing third-party bot classifies as no-repo-ci, not passing"
+
+# Several passing third-party checks are still no evidence: the state must come
+# from where the checks came from, never from how many of them passed.
+MANY_BOTS="[$(bot 'Greptile Review' SUCCESS),$(bot 'Coverage' SUCCESS),$(bot 'Sizebot' SUCCESS)]"
+[ "$(fm_ci_checks_state "$MANY_BOTS")" = no-repo-ci ] \
+  || fail "many passing third-party checks must still be no-repo-ci"
+pass "no number of passing third-party checks adds up to repository CI"
+
+# A legacy commit status is not a check run and cannot stand in for a suite.
+LEGACY='[{"__typename":"StatusContext","context":"ci/external","state":"SUCCESS"}]'
+[ "$(fm_ci_checks_state "$LEGACY")" = no-repo-ci ] \
+  || fail "a passing legacy commit status must be no-repo-ci"
+pass "a legacy commit status does not count as a repository-owned suite"
+
+# One real suite is what changes the answer, and the bot may ride along.
+WITH_SUITE="[$(suite Lint SUCCESS),$(bot 'Greptile Review' SUCCESS)]"
+[ "$(fm_ci_checks_state "$WITH_SUITE")" = passing ] \
+  || fail "a passing repository suite alongside a passing bot must be passing"
+pass "a repository-owned suite is what makes an all-green rollup passing"
+
+# The missing-suites diagnosis is decided before red and before waiting, so it
+# is never reported as one of those different problems.
+[ "$(fm_ci_checks_state "[$(bot 'Greptile Review' FAILURE)]")" = no-repo-ci ] \
+  || fail "a red third-party check with no suites must still be no-repo-ci"
+[ "$(fm_ci_checks_state "[$(bot 'Greptile Review' null)]")" = no-repo-ci ] \
+  || fail "an unfinished third-party check with no suites must still be no-repo-ci"
+pass "no-repo-ci is decided ahead of failing and pending, so missing suites are never mistaken for either"
+
+[ "$(fm_ci_checks_state "[$(suite Lint FAILURE),$(bot 'Greptile Review' SUCCESS)]")" = failing ] \
+  || fail "a red repository suite must be failing"
+[ "$(fm_ci_checks_state "[$(suite Lint SUCCESS),$(bot 'Greptile Review' FAILURE)]")" = failing ] \
+  || fail "a red third-party check alongside passing suites must be failing, not passing"
+pass "any red check refuses a passing verdict, whoever produced it"
+
+UNFINISHED='[{"__typename":"CheckRun","workflowName":"CI","name":"Lint","status":"IN_PROGRESS","conclusion":null}]'
+[ "$(fm_ci_checks_state "$UNFINISHED")" = pending ] \
+  || fail "an unfinished repository suite must be pending"
+pass "a suite still running classifies as pending"
+
+# Unreadable input is refused rather than classified, so a truncated or
+# malformed payload can never arrive at a passing verdict.
+if fm_ci_checks_state '{"not":"an array"}' >/dev/null 2>&1; then
+  fail "a non-array payload must be refused, not classified"
+fi
+if fm_ci_checks_state 'not json at all' >/dev/null 2>&1; then
+  fail "unparseable input must be refused, not classified"
+fi
+pass "an unreadable rollup is refused instead of being classified"
+
+# --- the same question in the workflow-runs shape ----------------------------
+
+# A repository reading its OWN workflow runs at a commit has no producer to tell
+# apart: every run in that list is its own by construction.
+run() { printf '{"id":%s,"name":"CI","status":"%s","conclusion":%s,"event":"push"}' "$1" "$2" "$3"; }
+
+[ "$(fm_ci_runs_state '[]')" = none ] || fail "no workflow runs must be none"
+[ "$(fm_ci_runs_state "[$(run 1 completed '"success"')]")" = passing ] \
+  || fail "a successful workflow run must be passing"
+[ "$(fm_ci_runs_state "[$(run 1 completed '"failure"')]")" = failing ] \
+  || fail "a failed workflow run must be failing"
+[ "$(fm_ci_runs_state "[$(run 1 completed '"cancelled"')]")" = failing ] \
+  || fail "a cancelled workflow run must be failing"
+[ "$(fm_ci_runs_state "[$(run 1 in_progress null)]")" = pending \
+  ] || fail "an unfinished workflow run must be pending"
+[ "$(fm_ci_runs_state "[$(run 1 completed '"success"'),$(run 2 completed '"failure"')]")" = failing ] \
+  || fail "one failed run among successes must be failing"
+pass "fm_ci_runs_state classifies a repository own workflow runs at a commit"
+
+if fm_ci_runs_state '{"workflow_runs":[]}' >/dev/null 2>&1; then
+  fail "a non-array runs payload must be refused, not classified"
+fi
+pass "an unreadable workflow-runs payload is refused instead of being classified"
+
+# --- the guard ---------------------------------------------------------------
+
+# gh is stubbed for both reads the guard makes - the pull request itself and the
+# head repository workflow runs - so the whole path runs without a network call.
+# An empty FM_TEST_HEAD_REPO means the pull request has no separate head
+# repository, which is the same-repository case.
+cat > "$FAKEBIN/gh" <<'SH'
+#!/usr/bin/env bash
+if [ "${1:-}" = api ]; then
+  printf '%s\n' "${FM_TEST_RUNS:-[]}"
+  exit 0
+fi
+if [ -n "${FM_TEST_HEAD_REPO:-}" ]; then
+  printf '{"statusCheckRollup":%s,"headRefOid":"%s","headRepositoryOwner":{"login":"%s"},"headRepository":{"name":"%s"}}\n' \
+    "${FM_TEST_ROLLUP:-[]}" "${FM_TEST_SHA:-deadbeef}" \
+    "${FM_TEST_HEAD_REPO%%/*}" "${FM_TEST_HEAD_REPO#*/}"
+else
+  printf '{"statusCheckRollup":%s,"headRefOid":"%s","headRepositoryOwner":null,"headRepository":null}\n' \
+    "${FM_TEST_ROLLUP:-[]}" "${FM_TEST_SHA:-deadbeef}"
+fi
+SH
+chmod +x "$FAKEBIN/gh"
+PATH="$FAKEBIN:$PATH"
+# The stub is a separate process, so its inputs must be exported rather than
+# only set in this shell.
+FM_TEST_ROLLUP='[]'
+FM_TEST_RUNS='[]'
+FM_TEST_SHA=deadbeef
+FM_TEST_HEAD_REPO=
+export PATH FM_TEST_ROLLUP FM_TEST_RUNS FM_TEST_SHA FM_TEST_HEAD_REPO
+
+URL=https://github.com/example/repo/pull/7
+verify() { "$ROOT/bin/fm-pr-ci-verify.sh" "$URL" 2>&1; }
+
+# The regression, end to end: a lone third-party pass with nothing behind it.
+FM_TEST_ROLLUP="$ONLY_BOT"
+OUT=$(verify); CODE=$?
+[ "$CODE" = 1 ] || fail "the guard must refuse a lone third-party pass, exited $CODE"
+assert_contains "$OUT" "no-repo-ci" "the refusal must name the state"
+assert_contains "$OUT" "Greptile Review" "the refusal must name the check it did see"
+assert_contains "$OUT" "0 repository-owned" "the refusal must say how many suites it found"
+pass "fm-pr-ci-verify.sh refuses a pull request whose only check is a third-party bot"
+
+FM_TEST_ROLLUP="$WITH_SUITE"
+OUT=$(verify); CODE=$?
+[ "$CODE" = 0 ] || fail "the guard must accept a passing repository suite, exited $CODE: $OUT"
+assert_contains "$OUT" "validated" "the accepting run must state the verdict"
+assert_contains "$OUT" "Lint" "the roster must name the suite that ran"
+pass "fm-pr-ci-verify.sh accepts a pull request whose own suites ran and passed"
+
+FM_TEST_ROLLUP="[$(suite Lint FAILURE)]"
+OUT=$(verify); CODE=$?
+[ "$CODE" = 1 ] || fail "the guard must refuse a red suite, exited $CODE"
+assert_contains "$OUT" "failing" "the refusal must name the failing state"
+pass "fm-pr-ci-verify.sh refuses a red suite"
+
+FM_TEST_ROLLUP='[]'
+OUT=$(verify); CODE=$?
+[ "$CODE" = 1 ] || fail "the guard must refuse a commit with no checks, exited $CODE"
+pass "fm-pr-ci-verify.sh refuses a pull request carrying no checks"
+
+# --- the held-upstream-run case the three stuck pull requests were in --------
+
+FM_TEST_HEAD_REPO=example/fork
+FM_TEST_ROLLUP="$ONLY_BOT"
+FM_TEST_RUNS="[$(run 42 completed '"success"')]"
+OUT=$(verify); CODE=$?
+[ "$CODE" = 0 ] || fail "a commit the head repository validated must be accepted, exited $CODE: $OUT"
+assert_contains "$OUT" "example/fork" "the verdict must name the repository the evidence came from"
+assert_contains "$OUT" "42" "the verdict must name the run behind it"
+assert_contains "$OUT" "validated" "the verdict must state that the commit was validated"
+pass "fm-pr-ci-verify.sh accepts a commit the head repository validated while the upstream run is held"
+
+# The evidence is not laundered: a fork-validated commit must never be reported
+# as the upstream pull request having been checked.
+assert_contains "$OUT" "no example/repo suite ran on this commit" \
+  "the verdict must still say the base repository ran nothing"
+pass "a fork-validated verdict still states that the base repository ran no suite of its own"
+
+FM_TEST_RUNS="[$(run 42 completed '"failure"')]"
+OUT=$(verify); CODE=$?
+[ "$CODE" = 1 ] || fail "a red head-repository run must be refused, exited $CODE"
+assert_contains "$OUT" "failing" "the refusal must name the failing head-repository state"
+pass "fm-pr-ci-verify.sh refuses a commit whose head-repository run failed"
+
+FM_TEST_RUNS="[$(run 42 in_progress null)]"
+OUT=$(verify); CODE=$?
+[ "$CODE" = 1 ] || fail "an unfinished head-repository run must be refused, exited $CODE"
+assert_contains "$OUT" "pending" "the refusal must name the pending head-repository state"
+pass "fm-pr-ci-verify.sh refuses a commit whose head-repository run has not finished"
+
+FM_TEST_RUNS='[]'
+OUT=$(verify); CODE=$?
+[ "$CODE" = 1 ] || fail "no run in either repository must be refused, exited $CODE"
+assert_contains "$OUT" "example/fork" "the refusal must name where the branch should be pushed"
+pass "fm-pr-ci-verify.sh refuses a commit no repository has validated and says where to run it"
+
+# A red or unfinished upstream suite is a real result about the commit, so the
+# head repository is never consulted in the hope that it disagrees.
+FM_TEST_ROLLUP="[$(suite Lint FAILURE)]"
+FM_TEST_RUNS="[$(run 42 completed '"success"')]"
+OUT=$(verify); CODE=$?
+[ "$CODE" = 1 ] || fail "a passing fork run must not overturn a red upstream suite, exited $CODE"
+assert_not_contains "$OUT" "example/fork" "a red upstream suite must not fall through to the head repository"
+pass "a passing head-repository run never overturns a red suite in the base repository"
+
+# --- input the guard refuses to interpret ------------------------------------
+
+FM_TEST_HEAD_REPO=
+OUT=$("$ROOT/bin/fm-pr-ci-verify.sh" "https://gitlab.com/group/proj/-/merge_requests/3" 2>&1); CODE=$?
+[ "$CODE" = 2 ] || fail "a GitLab merge request must be refused as unreadable input, exited $CODE"
+pass "fm-pr-ci-verify.sh refuses a GitLab merge request rather than misreading it"
+
+OUT=$("$ROOT/bin/fm-pr-ci-verify.sh" "not-a-url" 2>&1); CODE=$?
+[ "$CODE" = 2 ] || fail "a malformed URL must exit 2, exited $CODE"
+pass "fm-pr-ci-verify.sh refuses a malformed pull request URL"

--- a/tests/fm-ci-checks.test.sh
+++ b/tests/fm-ci-checks.test.sh
@@ -32,6 +32,12 @@ suite() {
 bot() {
   printf '{"__typename":"CheckRun","workflowName":"","name":"%s","status":"COMPLETED","conclusion":"%s"}' "$1" "$2"
 }
+# Every suite fm_ci_required_suites actually requires, all green - the only
+# rollup shape that a real, fully-reported CI run produces.
+complete_suite() {
+  printf '%s' "$FM_CI_REQUIRED_SUITES" \
+    | jq -c '[.[] | {"__typename":"CheckRun","workflowName":"CI","name":.,"status":"COMPLETED","conclusion":"SUCCESS"}]'
+}
 
 # --- the classifier ---------------------------------------------------------
 
@@ -59,11 +65,33 @@ LEGACY='[{"__typename":"StatusContext","context":"ci/external","state":"SUCCESS"
   || fail "a passing legacy commit status must be no-repo-ci"
 pass "a legacy commit status does not count as a repository-owned suite"
 
-# One real suite is what changes the answer, and the bot may ride along.
+# One real suite moves the answer off no-repo-ci, but one suite is not the
+# whole roster: it stays incomplete, never passing, until every required
+# suite has reported. The bot may still ride along either way.
 WITH_SUITE="[$(suite Lint SUCCESS),$(bot 'Greptile Review' SUCCESS)]"
-[ "$(fm_ci_checks_state "$WITH_SUITE")" = passing ] \
-  || fail "a passing repository suite alongside a passing bot must be passing"
-pass "a repository-owned suite is what makes an all-green rollup passing"
+GOT=$(fm_ci_checks_state "$WITH_SUITE")
+[ "$GOT" = incomplete ] \
+  || fail "a passing repository suite short of the full roster must be incomplete, got: $GOT"
+pass "a repository-owned suite short of the full roster classifies as incomplete, not passing"
+
+# The whole required roster, every one of them green, is what actually makes
+# a rollup passing. This is the P1 false-green shape reported against
+# fm_ci_state: a single green CI job read as "CI ran" when most of the
+# roster never reported at all.
+COMPLETE_SUITE=$(complete_suite)
+WITH_COMPLETE_SUITE=$(printf '%s' "$COMPLETE_SUITE" | jq -c ". + [$(bot 'Greptile Review' SUCCESS)]")
+[ "$(fm_ci_checks_state "$WITH_COMPLETE_SUITE")" = passing ] \
+  || fail "every required suite passing alongside a passing bot must be passing"
+pass "the complete required-suite roster is what makes an all-green rollup passing"
+
+# Missing even one required suite out of an otherwise all-green roster is
+# still incomplete, not passing - conclusion-tallying alone cannot tell the
+# two apart, which is exactly why fm_ci_missing_suites exists.
+ALMOST_COMPLETE=$(printf '%s' "$COMPLETE_SUITE" | jq -c '.[1:]')
+GOT=$(fm_ci_checks_state "$ALMOST_COMPLETE")
+[ "$GOT" = incomplete ] \
+  || fail "a roster missing one required suite must be incomplete, got: $GOT"
+pass "a rollup missing part of the required suite roster is incomplete even when everything present is green"
 
 # The second false-green shape: a repository-owned check that is real, but is
 # not the CI workflow - the PR-body policy check can pass while ci.yml never
@@ -202,12 +230,25 @@ assert_contains "$OUT" "Greptile Review" "the refusal must name the check it did
 assert_contains "$OUT" "0 repository-owned" "the refusal must say how many suites it found"
 pass "fm-pr-ci-verify.sh refuses a pull request whose only check is a third-party bot"
 
-FM_TEST_ROLLUP="$WITH_SUITE"
+FM_TEST_ROLLUP="$WITH_COMPLETE_SUITE"
 OUT=$(verify); CODE=$?
-[ "$CODE" = 0 ] || fail "the guard must accept a passing repository suite, exited $CODE: $OUT"
+[ "$CODE" = 0 ] || fail "the guard must accept the complete required-suite roster, exited $CODE: $OUT"
 assert_contains "$OUT" "validated" "the accepting run must state the verdict"
 assert_contains "$OUT" "Lint" "the roster must name the suite that ran"
 pass "fm-pr-ci-verify.sh accepts a pull request whose own suites ran and passed"
+
+# A rollup short of the complete roster is not evidence either, even though
+# every check it does carry is green - this is the P1 false-green shape
+# reported against fm-pr-ci-verify.sh: a lone passing CI job authorizing a
+# validation verdict without establishing the rest of the roster ran.
+FM_TEST_ROLLUP="$WITH_SUITE"
+OUT=$(verify); CODE=$?
+[ "$CODE" = 1 ] || fail "the guard must refuse a rollup short of the required roster, exited $CODE: $OUT"
+assert_contains "$OUT" "incomplete" "the refusal must name the incomplete state"
+assert_contains "$OUT" "required suite roster" "the refusal must say the roster is incomplete"
+assert_contains "$OUT" "missing required suites" "the refusal must list what is missing"
+assert_contains "$OUT" "Test coverage guard" "the missing-suites list must name a suite that never reported"
+pass "fm-pr-ci-verify.sh refuses a pull request whose rollup is short of the required suite roster"
 
 FM_TEST_ROLLUP="[$(suite Lint FAILURE)]"
 OUT=$(verify); CODE=$?
@@ -238,6 +279,19 @@ assert_contains "$OUT" "no example/repo suite ran on this commit" \
   "the verdict must still say the base repository ran nothing"
 pass "a fork-validated verdict still states that the base repository ran no suite of its own"
 
+# incomplete falls through to the head repository exactly like no-repo-ci: a
+# rollup short of the required roster is not evidence either, but the fork
+# may still have validated the commit in full.
+FM_TEST_ROLLUP="$WITH_SUITE"
+FM_TEST_RUNS="[$(run 42 completed '"success"')]"
+OUT=$(verify); CODE=$?
+[ "$CODE" = 0 ] || fail "an incomplete base-repo rollup must still fall through to a validated fork run, exited $CODE: $OUT"
+assert_contains "$OUT" "example/fork" "the verdict must name the repository the evidence came from"
+assert_contains "$OUT" "checks do not cover the required suite roster" \
+  "the verdict must say why the base repository was not evidence"
+pass "fm-pr-ci-verify.sh falls through an incomplete base-repo rollup to a validated head-repository run"
+
+FM_TEST_ROLLUP="$ONLY_BOT"
 FM_TEST_RUNS="[$(run 42 completed '"failure"')]"
 OUT=$(verify); CODE=$?
 [ "$CODE" = 1 ] || fail "a red head-repository run must be refused, exited $CODE"

--- a/tests/fm-ci-checks.test.sh
+++ b/tests/fm-ci-checks.test.sh
@@ -59,6 +59,26 @@ MANY_BOTS="[$(bot 'Greptile Review' SUCCESS),$(bot 'Coverage' SUCCESS),$(bot 'Si
   || fail "many passing third-party checks must still be no-repo-ci"
 pass "no number of passing third-party checks adds up to repository CI"
 
+# The two shapes actually recorded on the pull requests this rule exists for,
+# copied from their own statusCheckRollup rather than reconstructed, so the
+# regression is pinned to what GitHub really served. Both are a lone Greptile
+# check with an empty workflowName and no suite anywhere, and the defect had
+# both polarities: on 2584 the bot PASSED and was read as CI passing, and on
+# 2855 the bot FAILED while the run that produced it still reported passed.
+# Neither may ever classify as passing, and neither is a real CI result.
+PR_2584_ROLLUP='[{"__typename":"CheckRun","completedAt":"2026-08-22T23:25:48Z","conclusion":"SUCCESS","detailsUrl":"https://greptile.com/","name":"Greptile Review","startedAt":"2026-08-22T23:18:08Z","status":"COMPLETED","workflowName":""}]'
+PR_2855_ROLLUP='[{"__typename":"CheckRun","completedAt":"2026-08-23T10:58:04Z","conclusion":"FAILURE","detailsUrl":"https://greptile.com/","name":"Greptile Review","startedAt":"2026-08-23T10:56:06Z","status":"COMPLETED","workflowName":""}]'
+
+GOT=$(fm_ci_checks_state "$PR_2584_ROLLUP")
+[ "$GOT" != passing ] || fail "the recorded PR 2584 rollup must never be passing"
+[ "$GOT" = no-repo-ci ] || fail "the recorded PR 2584 rollup must be no-repo-ci, got: $GOT"
+pass "the passing-bot rollup recorded on PR 2584 classifies as no-repo-ci, not passing"
+
+GOT=$(fm_ci_checks_state "$PR_2855_ROLLUP")
+[ "$GOT" != passing ] || fail "the recorded PR 2855 rollup must never be passing"
+[ "$GOT" = no-repo-ci ] || fail "the recorded PR 2855 rollup must be no-repo-ci, got: $GOT"
+pass "the failing-bot rollup recorded on PR 2855 classifies as no-repo-ci, not passing"
+
 # A legacy commit status is not a check run and cannot stand in for a suite.
 LEGACY='[{"__typename":"StatusContext","context":"ci/external","state":"SUCCESS"}]'
 [ "$(fm_ci_checks_state "$LEGACY")" = no-repo-ci ] \
@@ -187,6 +207,91 @@ if fm_ci_runs_state '{"workflow_runs":[]}' >/dev/null 2>&1; then
 fi
 pass "an unreadable workflow-runs payload is refused instead of being classified"
 
+# --- the roster in the workflow-runs shape ------------------------------------
+#
+# fm_ci_runs_state above answers only "is any CI run here red or unfinished".
+# A run concludes success whenever no job in it failed, and a job that never
+# ran because it was skipped does not fail, so that answer cannot establish
+# that the required suites ran. The shape is real and recorded: cli/cli run
+# 32701833535 concluded success with one job successful and two skipped. That
+# is the P1 false-green reported against this file - a successful head-repository
+# run authorizing a green claim with the roster absent - and fm_ci_run_jobs_state
+# is what closes it, by judging the run JOBS against the same roster the rollup
+# shape uses.
+job() { printf '{"name":"%s","status":"%s","conclusion":%s}' "$1" "$2" "$3"; }
+complete_jobs() {
+  printf '%s' "$FM_CI_REQUIRED_SUITES" \
+    | jq -c '[.[] | {name: ., status: "completed", conclusion: "success"}]'
+}
+GOOD_RUN="[$(run 42 completed '"success"')]"
+COMPLETE_JOBS=$(complete_jobs)
+
+# The demonstration that the run-level answer alone is the defect: the exact
+# same successful run is passing to fm_ci_runs_state and refused once its jobs
+# are read. Without this change the guard acts on the first answer.
+[ "$(fm_ci_runs_state "$GOOD_RUN")" = passing ] \
+  || fail "the run-level classifier must still call a successful CI run passing"
+ONLY_LINT_JOB="[$(job Lint completed '"success"')]"
+GOT=$(fm_ci_run_jobs_state "$GOOD_RUN" "$ONLY_LINT_JOB")
+[ "$GOT" != passing ] || fail "a successful CI run carrying only one job must never be passing"
+[ "$GOT" = incomplete ] \
+  || fail "a successful CI run short of the required roster must be incomplete, got: $GOT"
+pass "a successful head-repository CI run whose jobs are short of the roster is incomplete, not passing"
+
+# The recorded cli/cli 32701833535 shape: the run succeeded, and it succeeded
+# because skipped jobs do not fail a run.
+SKIPPED_JOBS="[$(job Lint completed '"success"'),$(job 'Repo invariants' completed '"skipped"')]"
+GOT=$(fm_ci_run_jobs_state "$GOOD_RUN" "$SKIPPED_JOBS")
+[ "$GOT" != passing ] || fail "a successful CI run with a skipped job must never be passing"
+pass "a successful CI run whose jobs were skipped is refused rather than read as a clean pass"
+
+# The roster read from the jobs is what a passing verdict now rests on.
+[ "$(fm_ci_run_jobs_state "$GOOD_RUN" "$COMPLETE_JOBS")" = passing ] \
+  || fail "a successful CI run carrying the complete green roster must be passing"
+pass "the complete required-suite roster among the run jobs is what makes a head-repository run passing"
+
+ALMOST_JOBS=$(printf '%s' "$COMPLETE_JOBS" | jq -c '.[1:]')
+[ "$(fm_ci_run_jobs_state "$GOOD_RUN" "$ALMOST_JOBS")" = incomplete ] \
+  || fail "a run roster missing one required suite must be incomplete"
+pass "a head-repository run missing one required suite is incomplete even when every job present is green"
+
+# Jobs that could not be read at all are not inherited from the run conclusion.
+[ "$(fm_ci_run_jobs_state "$GOOD_RUN" '[]')" = incomplete ] \
+  || fail "a successful run whose jobs could not be read must be incomplete"
+pass "a run whose jobs are unreadable is incomplete rather than inheriting the verdict of the run itself"
+
+# A red or unfinished job refuses the verdict the same way the rollup does.
+RED_JOBS=$(printf '%s' "$COMPLETE_JOBS" | jq -c '.[0].conclusion = "failure"')
+[ "$(fm_ci_run_jobs_state "$GOOD_RUN" "$RED_JOBS")" = failing ] \
+  || fail "a red job in an otherwise complete roster must be failing"
+PENDING_JOBS=$(printf '%s' "$COMPLETE_JOBS" | jq -c '.[0] = {name: "Lint", status: "in_progress", conclusion: null}')
+[ "$(fm_ci_run_jobs_state "$GOOD_RUN" "$PENDING_JOBS")" = pending ] \
+  || fail "an unfinished job in an otherwise complete roster must be pending"
+pass "a red or unfinished job refuses a passing head-repository verdict"
+
+# The run-level states still decide first, so a red or unfinished run is never
+# reported as a roster problem, and no CI run at all is still none.
+[ "$(fm_ci_run_jobs_state "[$(run 42 completed '"failure"')]" "$COMPLETE_JOBS")" = failing ] \
+  || fail "a red CI run must be failing whatever its jobs say"
+[ "$(fm_ci_run_jobs_state "[$(run 42 in_progress null)]" "$COMPLETE_JOBS")" = pending ] \
+  || fail "an unfinished CI run must be pending whatever its jobs say"
+[ "$(fm_ci_run_jobs_state '[]' "$COMPLETE_JOBS")" = none ] \
+  || fail "no CI run at all must be none"
+[ "$(fm_ci_run_jobs_state "$ONLY_OTHER_RUN" "$COMPLETE_JOBS")" = none ] \
+  || fail "a run of a workflow other than CI must not count as CI having run"
+pass "the run-level states are decided before the roster, so each refusal names its own cause"
+
+if fm_ci_run_jobs_state "$GOOD_RUN" 'not json' >/dev/null 2>&1; then
+  fail "an unreadable jobs payload must be refused, not classified"
+fi
+if fm_ci_run_jobs_state 'not json' "$COMPLETE_JOBS" >/dev/null 2>&1; then
+  fail "an unreadable runs payload must be refused, not classified"
+fi
+if fm_ci_run_jobs_state "$GOOD_RUN" '{"jobs":[]}' >/dev/null 2>&1; then
+  fail "a non-array jobs payload must be refused, not classified"
+fi
+pass "an unreadable runs or jobs payload is refused instead of being classified"
+
 # --- the guard ---------------------------------------------------------------
 
 # gh is stubbed for both reads the guard makes - the pull request itself and the
@@ -196,7 +301,12 @@ pass "an unreadable workflow-runs payload is refused instead of being classified
 cat > "$FAKEBIN/gh" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = api ]; then
-  printf '%s\n' "${FM_TEST_RUNS:-[]}"
+  # The guard makes two different API reads: the workflow runs at the commit,
+  # and then the jobs of each CI run among them.
+  case "${2:-}" in
+    */jobs*) printf '%s\n' "${FM_TEST_JOBS:-[]}" ;;
+    *)       printf '%s\n' "${FM_TEST_RUNS:-[]}" ;;
+  esac
   exit 0
 fi
 if [ -n "${FM_TEST_HEAD_REPO:-}" ]; then
@@ -214,9 +324,12 @@ PATH="$FAKEBIN:$PATH"
 # only set in this shell.
 FM_TEST_ROLLUP='[]'
 FM_TEST_RUNS='[]'
+# The default head-repository run reports its whole roster green, so a test
+# that is not about the roster gets the ordinary validated-fork case.
+FM_TEST_JOBS=$COMPLETE_JOBS
 FM_TEST_SHA=deadbeef
 FM_TEST_HEAD_REPO=
-export PATH FM_TEST_ROLLUP FM_TEST_RUNS FM_TEST_SHA FM_TEST_HEAD_REPO
+export PATH FM_TEST_ROLLUP FM_TEST_RUNS FM_TEST_JOBS FM_TEST_SHA FM_TEST_HEAD_REPO
 
 URL=https://github.com/example/repo/pull/7
 verify() { "$ROOT/bin/fm-pr-ci-verify.sh" "$URL" 2>&1; }
@@ -291,6 +404,43 @@ assert_contains "$OUT" "checks do not cover the required suite roster" \
   "the verdict must say why the base repository was not evidence"
 pass "fm-pr-ci-verify.sh falls through an incomplete base-repo rollup to a validated head-repository run"
 
+# The head-repository false green, end to end: the upstream pull request has
+# only the bot, the fork run concluded success, and its roster is a single job.
+# Before the roster was read from the jobs this exited 0 and reported the commit
+# validated - the P1 finding against this guard.
+FM_TEST_ROLLUP="$ONLY_BOT"
+FM_TEST_RUNS="$GOOD_RUN"
+FM_TEST_JOBS="$ONLY_LINT_JOB"
+OUT=$(verify); CODE=$?
+[ "$CODE" = 1 ] || fail "a successful fork run short of the roster must be refused, exited $CODE: $OUT"
+assert_contains "$OUT" "incomplete" "the refusal must name the incomplete fork state"
+assert_contains "$OUT" "required suite roster" "the refusal must say the fork roster is short"
+assert_contains "$OUT" "Test coverage guard" "the refusal must name a required suite that never ran"
+assert_not_contains "$OUT" "validated:" "a roster-short fork run must not be reported as validated"
+pass "fm-pr-ci-verify.sh refuses a successful head-repository run whose jobs are short of the required roster"
+
+# The same run with a skipped job: still success at the run level, still refused.
+FM_TEST_JOBS="$SKIPPED_JOBS"
+OUT=$(verify); CODE=$?
+[ "$CODE" = 1 ] || fail "a fork run with a skipped job must be refused, exited $CODE: $OUT"
+assert_not_contains "$OUT" "validated:" "a partially-skipped fork run must not be reported as validated"
+pass "fm-pr-ci-verify.sh refuses a head-repository run that concluded success with a skipped job"
+
+# The recorded pull requests, driven through the whole guard. 2584 is the
+# passing bot and 2855 the failing one; with nothing behind either, both are
+# refused, and neither may be reported as validated.
+FM_TEST_JOBS='[]'
+FM_TEST_RUNS='[]'
+for recorded in "$PR_2584_ROLLUP" "$PR_2855_ROLLUP"; do
+  FM_TEST_ROLLUP=$recorded
+  OUT=$(verify); CODE=$?
+  [ "$CODE" = 1 ] || fail "a recorded lone-bot pull request must be refused, exited $CODE: $OUT"
+  assert_contains "$OUT" "Greptile Review" "the refusal must name the check it did see"
+  assert_not_contains "$OUT" "validated:" "a lone-bot pull request must never be reported as validated"
+done
+pass "fm-pr-ci-verify.sh refuses both recorded lone-bot pull requests, whichever way the bot concluded"
+
+FM_TEST_JOBS=$COMPLETE_JOBS
 FM_TEST_ROLLUP="$ONLY_BOT"
 FM_TEST_RUNS="[$(run 42 completed '"failure"')]"
 OUT=$(verify); CODE=$?


### PR DESCRIPTION
## Intent

Make our own fork run our own validation, so upstream maintainer approval stops gating firstmate work.

The problem, in the captain's own framing: he has no relationship with the upstream maintainer (kunchenguid/firstmate, thousands of open pull requests) and no ability to get work integrated. He does NOT want anyone asking upstream for anything. The real question is how we manage firstmate changes in OUR environment while still raising upstream pull requests and hoping, without expecting, that they land. Three completed fixes were stuck because their checks never ran: PRs 2777, 2809 and 2584 each reported "1 passed, 0 failed, 1 total", where the single check was a third-party review bot and all fourteen repository-owned suites never started, because GitHub holds fork-branch workflow runs until a maintainer approves them. That produced three separate FALSE GREEN verdicts where a worker read the bot's pass as CI passing; closing that false-green hole is part of the task, not a footnote.

Three deliverables were required: (1) our fork runs the full suite set on a branch we push to it with nobody's approval, proven by a real run id; (2) the two purposes split explicitly and written down where the next session finds them - our fork is where our changes are VALIDATED and where our homes update FROM, while the upstream pull request becomes a hopeful contribution whose held runs block nothing, updating whatever firstmate material assumed upstream was the validation target; (3) the false-green made impossible to repeat, so whatever reads PR checks must not accept a lone third-party bot as CI and must establish that the repository's own required suites actually ran.

Constraints the captain set: do NOT ask the upstream maintainer for anything and do not open, close or modify any upstream pull request - those three PRs stay exactly as they are. Do not weaken, skip or narrow any suite to make something pass; a suite that genuinely cannot run on the fork is a finding to report, not a suite to remove. Anything changing credentials, repository settings a person must click, or the account's security posture is the captain's decision: report exact steps and stop.

What the work found and did, so the diff is read against it:

Root cause was neither of the two hypotheses offered. The fork's default branch does carry .github/workflows and Actions is enabled on it; ci.yml simply only triggered on push-to-main and pull-request-to-main, so no event our fork ever receives matched a trigger and the fork recorded zero runs. The fix in .github/workflows/ci.yml is therefore a trigger widening: CI now runs on any pushed branch, deliberately excluding the orphan no-mistakes/** evidence branches, which are pipeline artifacts and not source history. This was proven, not assumed: fork run 32617494878 on branch fm/fm-validate-on-our-own-fork at head 0cff881, event=push, attempt 1, conclusion success, no approval required, with all 12 CI suites green.

Deliberate decision (finding 1, reported not fixed): a fork push runs 12 of the 13 repository-owned checks. The "Require no-mistakes" check reads github.event.pull_request.body, so it structurally cannot run on a push event. It is a PR-body contribution policy rather than a source-tree suite, and its substance is enforced by the local no-mistakes pipeline anyway. It was left exactly as it is, per the do-not-narrow constraint. Do not "fix" this by making that workflow run on push or by removing it.

Deliberate decision (finding 2, escalated to the captain, no code change): actually making the fork the source homes update FROM needs x45dev/firstmate main brought current and each home's origin repointed at the fork. Both are outside this worktree - one is a default-branch push, the other edits other checkouts - so neither was performed here. The choice itself is documented in docs/architecture.md rather than implemented.

Reported and deliberately not fixed (finding 3): tests/fm-bearings-snapshot.test.sh 'bad home outcomes' pins FM_SNAPSHOT_SECONDMATE_TIMEOUT=1 and fails on this machine at the base commit in a clean independent clone, and tests/fm-test-run.test.sh needs ruby which this machine lacks. Both are pre-existing and environmental, and both are green on every fork CI run. They are not this change's regressions.

The false-green closure is structural rather than bot-name-based, which is the central design decision in the diff. bin/fm-ci-checks-lib.sh is introduced as the single owner of the question "did this commit's own repository workflows actually run", classifying a check by whether a workflow in the repository produced it rather than by matching known bot names, so a new third-party bot cannot slip through a denylist. bin/fm-pr-ci-verify.sh is the guard built on it: it refuses PRs 2777, 2809 and 2584 today while naming the reason, and it accepts a commit our own fork validated even while the upstream run is still held - which is the point, since a held upstream run is a contribution question and never a validation one. bin/fm-bearings-snapshot.sh was changed to classify through that same owner instead of carrying its own duplicate logic, and its coverage-guard list comparison was fixed to compare under the collation the lists were sorted in. AGENTS.md and the generated ship brief in bin/fm-brief.sh now require that verification before any green claim. The split between validation source and contribution target is documented in CONTRIBUTING.md and docs/architecture.md, with docs/scripts.md indexing the two new scripts. 23 new tests in tests/fm-ci-checks.test.sh plus a bot-only regression case added to tests/fm-bearings-snapshot.test.sh pin the behavior, and the Bearings coverage floor was raised accordingly.

Nothing upstream was contacted or modified, and no suite was weakened, skipped or narrowed.

## What Changed

- Widened `.github/workflows/ci.yml` to trigger on any pushed branch (excluding the orphan `no-mistakes/**` evidence branches), so the fork's own 12 CI suites actually run on a push with no maintainer approval required.
- Added `bin/fm-ci-checks-lib.sh` as the single classifier for whether a commit's own repository workflows produced a given check, and `bin/fm-pr-ci-verify.sh` as the guard built on it: it refuses a PR whose only passing check is a third-party bot or that carries red/pending suites, and accepts a commit the fork has already validated even while the upstream run sits held.
- Updated `bin/fm-bearings-snapshot.sh` to classify through that shared library instead of duplicating logic, and fixed its coverage-guard list comparison to use consistent collation; documented the fork-as-validation-source vs. upstream-as-contribution-target split in `CONTRIBUTING.md` and `docs/architecture.md` (indexed in `docs/scripts.md`), required the new verification before any green claim in `AGENTS.md` and `bin/fm-brief.sh`, and added `tests/fm-ci-checks.test.sh` plus a bot-only-checks regression case in `tests/fm-bearings-snapshot.test.sh`.

## Risk Assessment

✅ Low: The change is a well-bounded, thoroughly tested trigger widening plus a structural (not name-based) classifier and guard for CI check provenance; all new logic (fm-ci-checks-lib.sh, fm-pr-ci-verify.sh) is covered by 23 focused unit/integration tests, the bearings snapshot and coverage-guard fixes are minimal and consistent, and the two deliberately-deferred items are honestly reported per the stated constraints rather than silently resolved or hidden.

## Testing

All targeted tests pass: the 23 new fm-ci-checks.test.sh tests pin the false-green classifier and PR guard exactly against the reported failure mode (lone third-party bot check reading as green), the 43 fm-bearings-snapshot.test.sh tests match the CI-raised floor and include the new bot-only regression case, and the referenced fork CI run (32617494878) independently verifies as a real, unapproved, all-green push-triggered run — the core end-to-end evidence for deliverable 1. No regressions found; nothing to report.

<details>
<summary>Evidence: fm-ci-checks.test.sh full pass (23/23)</summary>

```text
ok - a commit with no checks at all classifies as none
ok - a rollup of nothing but a passing third-party bot classifies as no-repo-ci, not passing
ok - no number of passing third-party checks adds up to repository CI
ok - a legacy commit status does not count as a repository-owned suite
ok - a repository-owned suite is what makes an all-green rollup passing
ok - no-repo-ci is decided ahead of failing and pending, so missing suites are never mistaken for either
ok - any red check refuses a passing verdict, whoever produced it
ok - a suite still running classifies as pending
ok - an unreadable rollup is refused instead of being classified
ok - fm_ci_runs_state classifies a repository own workflow runs at a commit
ok - an unreadable workflow-runs payload is refused instead of being classified
ok - fm-pr-ci-verify.sh refuses a pull request whose only check is a third-party bot
ok - fm-pr-ci-verify.sh accepts a pull request whose own suites ran and passed
ok - fm-pr-ci-verify.sh refuses a red suite
ok - fm-pr-ci-verify.sh refuses a pull request carrying no checks
ok - fm-pr-ci-verify.sh accepts a commit the head repository validated while the upstream run is held
ok - a fork-validated verdict still states that the base repository ran no suite of its own
ok - fm-pr-ci-verify.sh refuses a commit whose head-repository run failed
ok - fm-pr-ci-verify.sh refuses a commit whose head-repository run has not finished
ok - fm-pr-ci-verify.sh refuses a commit no repository has validated and says where to run it
ok - a passing head-repository run never overturns a red suite in the base repository
ok - fm-pr-ci-verify.sh refuses a GitLab merge request rather than misreading it
ok - fm-pr-ci-verify.sh refuses a malformed pull request URL
```
</details>
<details>
<summary>Evidence: gh-axi run view 32617494878 (deliverable-1 evidence)</summary>

```text
run:
id: 32617494878
title: "style(brief): one sentence per line in the green-claim contract"
status: completed
conclusion: success
workflow: CI
branch: fm/fm-validate-on-our-own-fork
created: 5h ago
jobs[12]{id,name,status,conclusion}: all completed/success (Stock macOS Bash snapshot compatibility, Repo invariants, Behavior portable parallel 1/2, Test coverage guard, Behavior portable serial 1-4, Behavior tests (Herdr), Lint, Behavior timing aggregate)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-ci-checks.test.sh — 23/23 pass, covering fm_ci_checks_state/fm_ci_runs_state classification and fm-pr-ci-verify.sh's bot-only-check refusal, red/pending refusal, and fork-validated acceptance paths`
- <code>bash tests/fm-bearings-snapshot.test.sh — 43/43 pass (count via `grep -c &#39;^ok - &#39;`), including the new bot-only-checks regression row and the previously-flagged-as-environment-flaky &#39;bad home outcomes&#39; case, which passed in this run</code>
- `bash bin/fm-test-run.sh --check-coverage — exits 0 under this machine's en_US.UTF-8 locale, confirming the LC_ALL=C comm collation fix (commit b311842)`
- `gh-axi run view 32617494878 --repo x45dev/firstmate — confirms the cited fork CI run is real: branch fm/fm-validate-on-our-own-fork, event push, conclusion success, 12/12 jobs green, no approval gate`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
