### PR TITLE
fix(bin): make inbox queueing portable to BSD sed

### DIFF
--- a/bin/fm-inbox.sh
+++ b/bin/fm-inbox.sh
@@ -168,10 +168,12 @@ queue_note() {
   [ -n "${body//[[:space:]]/}" ] || die "refusing to queue an empty note"
   mkdir -p "$INBOX"
 
-  local tmp id summary
+  local tmp id summary staging_name
   tmp=$(mktemp "$INBOX/.staging-XXXXXX")
+  staging_name=$(basename "$tmp")
+  id="$(date +%s)-${staging_name#.staging-}"
   {
-    printf 'id=PENDING\n'
+    printf 'id=%s\n' "$id"
     printf 'at=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
     printf 'source=%s\n' "$source"
     [ -z "$extra" ] || printf '%s\n' "$extra"
@@ -179,9 +181,7 @@ queue_note() {
     printf '%s\n' "$body"
   } >"$tmp"
 
-  id="$(date +%s)-$(basename "$tmp" | sed 's/^\.staging-//')"
-  # Rewrite the id line now that we know it, then publish atomically.
-  sed -i "s/^id=PENDING$/id=$id/" "$tmp"
+  # Publish the completed note atomically.
   mv "$tmp" "$INBOX/$id.note"
 
   # One-line summary for the wake payload; the full body stays in the file.

--- a/tests/fm-tool-update-check.test.sh
+++ b/tests/fm-tool-update-check.test.sh
@@ -131,7 +131,7 @@ test_path_skew_is_reported_from_every_copy() {
   assert_contains "$report" "0.8.2 is installed at $fresh/$TOOL" "the report does not name the newer installed copy, so no other PATH copy was asked for its version"
   assert_not_contains "$report" "update available" "PATH skew must not be reported as a published update"
   assert_contains "$report" "$(printf 'tool updates:')" "the report is missing its one-line prefix"
-  [ "$(wc -l < "$out")" = 1 ] || fail "the report must be exactly one line for the wake record"
+  [ "$(wc -l < "$out" | tr -d '[:space:]')" = 1 ] || fail "the report must be exactly one line for the wake record"
   pass "PATH skew is reported by asking every copy on PATH for its own version"
 }
 
@@ -311,7 +311,7 @@ test_one_broken_pattern_does_not_blind_the_rest_of_the_sweep() {
   report=$(cat "$out")
   assert_contains "$report" "herdr update not in effect: PATH resolves 0.8.0 at $stale/$TOOL" "a broken pattern on another tool suppressed the PATH skew report"
   assert_contains "$report" "no-mistakes check failed: announce_pattern is not a usable extended regular expression" "the tool whose pattern cannot be used was not named"
-  [ "$(wc -l < "$out")" = 1 ] || fail "the report must stay exactly one line"
+  [ "$(wc -l < "$out" | tr -d '[:space:]')" = 1 ] || fail "the report must stay exactly one line"
   pass "a broken pattern is reported for its own tool and the rest of the sweep still reports"
 }
 
@@ -690,7 +690,7 @@ test_an_overlong_report_says_it_was_cut() {
   run_check "$home" "$PATH" "$out"
   report=$(cat "$out")
   assert_contains "$report" "[truncated]" "an over-long report was cut without saying so"
-  [ "$(wc -l < "$out")" = 1 ] || fail "the cut report must still be exactly one line"
+  [ "$(wc -l < "$out" | tr -d '[:space:]')" = 1 ] || fail "the cut report must still be exactly one line"
   pass "an over-long report is cut with the shared truncation marker"
 }
 

--- a/tests/fm-voice-relay.test.sh
+++ b/tests/fm-voice-relay.test.sh
@@ -3646,7 +3646,7 @@ pass "the configured read scope is honoured"
 # The point of the boundary: real work is queued for firstmate, not done by the
 # voice agent. It reuses bin/fm-inbox.sh rather than carrying a second queue.
 
-before=$(find "$HOME_FIXTURE/state" -maxdepth 2 -name '*.note' | wc -l)
+before=$(find "$HOME_FIXTURE/state" -maxdepth 2 -name '*.note' | wc -l | tr -d '[:space:]')
 [ "$before" = 0 ] || fail "fixture should start with an empty inbox"
 
 handed=$(FM_HOME="$HOME_FIXTURE" python3 "$ROOT/bin/fm_voice_records.py" queue \
@@ -3656,7 +3656,7 @@ assert_contains "$handed" '"queued": true' "handover should report the request q
 assert_contains "$handed" 'did not do the work yourself' \
   "handover should tell the model it handed over rather than acted"
 
-notes=$(find "$HOME_FIXTURE/state/inbox" -maxdepth 1 -name '*.note' | wc -l)
+notes=$(find "$HOME_FIXTURE/state/inbox" -maxdepth 1 -name '*.note' | wc -l | tr -d '[:space:]')
 [ "$notes" = 1 ] || fail "handover should leave exactly one note, found $notes"
 note_file=$(find "$HOME_FIXTURE/state/inbox" -maxdepth 1 -name '*.note' | head -1)
 assert_grep 'Refactor the login module' "$note_file" \
@@ -3687,7 +3687,7 @@ FM_STATE_OVERRIDE="$alt_state" python3 "$ROOT/bin/fm_voice_records.py" queue \
   "Chase the flaky retry test" --home "$alt_home" >/dev/null \
   || fail "handover with an overridden state directory failed"
 
-moved=$(find "$alt_state/inbox" -maxdepth 1 -name '*.note' | wc -l)
+moved=$(find "$alt_state/inbox" -maxdepth 1 -name '*.note' | wc -l | tr -d '[:space:]')
 [ "$moved" = 1 ] || \
   fail "the queue should write into the overridden state directory, found $moved"
 [ ! -e "$alt_home/state/inbox" ] || \


### PR DESCRIPTION
## Intent

Fix the macOS/BSD sed portability defect so the firstmate test suite runs clean locally on macOS. Reproduce the affected fm-voice-relay and fm-tool-update-check failures on macOS, identify the initiating BSD sed incompatibility separately from test symptoms, and make one portable behavior-preserving fix without an OS-specific branch. Keep the fix completely isolated from the forked-supervision Pi implementation, do not weaken assertions, and verify both affected suites on macOS and Linux where feasible. Deliver mode=no-mistakes with one PR, do not merge, and wait for CI green.

## What Changed
- Generate inbox note IDs before writing staging files, removing the non-portable in-place `sed` rewrite while preserving atomic publication.
- Normalize whitespace in line-count assertions across the tool-update and voice-relay test suites for BSD/macOS `wc` output.

## Risk Assessment

✅ Low: The change is narrowly scoped, removes the BSD-incompatible in-place sed call while preserving atomic note publication, and normalizes BSD wc output without weakening assertions.

## Testing

On macOS 26.5.2, the base commit reproduced the initiating BSD sed error and both affected suite failures; the fixed commit passed both targeted suites and an end-to-end inbox queue operation produced one atomic note with matching record/filename IDs and exactly one wake. Linux execution was not feasible because no container runtime was available, and the worktree remained clean.

<details>
<summary>Evidence: macOS baseline reproduction showing the BSD sed incompatibility and both resulting suite failures</summary>

Source: [macOS baseline reproduction showing the BSD sed incompatibility and both resulting suite failures](https://github.com/kunchenguid/firstmate/blob/d1d37ff08100388383e8a9870eb0f93b13296c2a/.no-mistakes/evidence/fm/fm-test-macos-bsd-sed-portability/macos-baseline-reproduction.txt)

```text
macOS/BSD baseline reproduction
platform: macOS 26.5.2

[base fm-inbox note] exit=1
sed: 1: "/var/folders/0k/bf8mwt2 ...": invalid command code f

[base fm-tool-update-check suite] exit=1
not ok - the report must be exactly one line for the wake record

[base fm-voice-relay suite] exit=1
ok - one deny decision per item covers every list that item could appear in
ok - the state verb is a closed vocabulary, so free text cannot ride out on it
ok - the backlog and the state directory always come from the same home
ok - a finished task's pull request is neither counted nor named
ok - a deny substring on an open title removes its pull request and says so
ok - an unknown read scope refuses instead of widening
ok - the configured read scope is honoured
not ok - fixture should start with an empty inbox
```
</details>
<details>
<summary>Evidence: macOS end-to-end inbox note publication and wake verification</summary>

Source: [macOS end-to-end inbox note publication and wake verification](https://github.com/kunchenguid/firstmate/blob/d1d37ff08100388383e8a9870eb0f93b13296c2a/.no-mistakes/evidence/fm/fm-test-macos-bsd-sed-portability/macos-fm-inbox-end-to-end.txt)

```text
macOS end-to-end fm-inbox note verification
platform: macOS 26.5.2

$ FM_HOME=<temporary-home> bin/fm-inbox.sh note "Portable queue smoke test"
queued 1787480581-QzEAhy
  Portable queue smoke test
  firstmate will pick this up at its next check.

published note: state/inbox/1787480581-QzEAhy.note
record id matches filename: yes
record:
id=1787480581-QzEAhy
at=2026-08-23T10:23:01Z
source=text
--
Portable queue smoke test

wake records matching note id: 1
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"47cd82c2458885610e3fea778453d8e7f22b56cf","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-tool-update-check.test.sh`
- `bash tests/fm-voice-relay.test.sh`
- <code>Executed base-commit versions of `fm-inbox.sh`, `fm-tool-update-check.test.sh`, and `fm-voice-relay.test.sh` on macOS to reproduce the initiating BSD sed error and both suite symptoms</code>
- <code>`FM_HOME=&lt;temporary-home&gt; bin/fm-inbox.sh note &#39;Portable queue smoke test&#39;` followed by verification of the published note ID, filename, body, and single wake record</code>
- `Checked for Docker/Podman availability for Linux verification; neither runtime was available`
- <code>`git status --short` to confirm transient baseline scripts and test data were removed</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
