### PR TITLE
feat(bin): add decision-tier classifier and default-with-veto CLI

### DIFF
--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/project.local.yml

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,169 @@
+# the name by which the project can be referenced within Serena/when chatting with the LLM.
+project_name: "01M0QC48PXJQB03E8AK9W9GPQN"
+
+# list of language servers to start when using the LSP backend; choose from:
+#   ada                    al                     angular                ansible                bash
+#   bsl                    clojure                cpp                    cpp_ccls               crystal
+#   csharp                 csharp_omnisharp       cue                    dart                   deno
+#   elixir                 elm                    erlang                 fortran                fsharp
+#   gdscript               gleam                  go                     groovy                 haskell
+#   haxe                   hlsl                   html                   java                   json
+#   julia                  kotlin                 latex                  lean4                  lua
+#   luau                   markdown               matlab                 msl                    nextflow
+#   nix                    ocaml                  pascal                 perl                   php
+#   php_phpactor           php_phpantom           powershell             python                 python_basedpyright
+#   python_jedi            python_pyrefly         python_ty              qml                    r
+#   rego                   ruby                   ruby_solargraph        rust                   scala
+#   scss                   solidity               svelte                 swift                  systemverilog
+#   terraform              toml                   typescript             typescript_vts         vue
+#   wolfram                yaml                   zig
+#   (This list may be outdated; generated with scripts/print_language_list.py;
+#   For the current list, see values of the LanguageServerId enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py)
+# For some languages, there are several alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
+#   - For Deno projects, use deno (serves the same .ts/.js files as typescript; requires the deno CLI on PATH)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some language servers require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple language servers, the first language server that supports a given file will be used for that file.
+# The first language server is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+language_servers:
+- bash
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: "utf-8"
+
+# optional shell command to run before the language backend (LSP or JetBrains) is initialised.
+# the command runs in the project root directory and is only executed if the project is trusted
+# (see trusted_project_path_patterns in the global configuration).
+# serena waits for the command to exit: a non-zero exit code is logged as an error but does not
+# abort activation. a per-project timeout (activation_command_timeout, default 180s) is the safety
+# backstop for non-terminating commands; on expiry the process is killed and activation continues.
+# example: activation_command: "npx nx run-many -t build"
+activation_command:
+
+# maximum time in seconds to wait for activation_command to complete before killing it (default 180s).
+# must be a positive number.
+activation_command_timeout: 180.0
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# whether to use project's .gitignore files to ignore files
+ignore_all_files_in_gitignore: true
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# The settings are considered only if the project is trusted (see global configuration to define trusted projects).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#language-server-specific-settings
+ls_specific_settings: {}
+
+# list of workspace folder paths (LSP backend only).
+# These folders will be used to build up Serena's symbol index.
+# Paths must be within the project root and should thus be relative to the project root.
+# Furthermore, the paths should not be filtered by ignore settings.
+# Default setting: The entire project root folder (".") is considered.
+# In (large) monorepos, this can be used to index only subfolders of the project root, e.g.
+#   ls_workspace_folders:
+#     - "./subproject1"
+#     - "./subproject2"
+ls_workspace_folders:
+- "."
+
+# list of additional workspace folder paths for cross-package reference support.
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries, but these folders are not indexed by Serena,
+# i.e. the respective symbols will not be found using Serena's symbol search tools.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+ls_additional_workspace_folders: []
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Important: quote patterns that start with `*`, otherwise YAML treats them as aliases.
+# Example:
+#   ignored_paths:
+#     - "examples/**"
+#     - ".worktrees/**"
+#     - "**/bin/**"
+#     - "**/obj/**"
+# Note: global ignored_paths from serena_config.yml are also applied additively.
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+fixed_tools: []
+
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+default_modes:
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ""
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []

--- a/bin/fm-decision-tier-lib.sh
+++ b/bin/fm-decision-tier-lib.sh
@@ -166,11 +166,24 @@ fm_decision_tier_require_meaningful() {  # <label> <value>
 # attempt: unlike a file or symlink, `ln -s target dir` does not fail when
 # `dir` already exists as a directory - it silently creates the link INSIDE
 # that directory instead, so the loop would never even notice the stale
-# directory, let alone break it. The `[ -d ... ] && [ ! -L ... ]` check below
-# catches that case directly (a symlink also passes `-d` when its target is
-# a directory, so `-L` is checked first to exclude a legitimate lock),
-# removing it with `rm -rf` (not `rm -f`, which cannot remove a directory at
-# all) before every `ln -s` attempt.
+# directory, let alone break it. The `[ -e ... ] && [ ! -L ... ]` check below
+# catches that case directly (a symlink also passes `-e` when its target is
+# a directory, so `-L` is checked first to exclude a legitimate lock) and
+# routes it through fm_decision_tier_lock_break, same as a stale symlink.
+#
+# Breaking (removing) whatever currently sits at the lock path is never done
+# directly in this loop - it always goes through fm_decision_tier_lock_break,
+# which serializes breakers behind their own mkdir-based mutex. Without that,
+# two contenders can both observe the same abandoned lock as stale and both
+# act on it: one removes it and creates its own fresh lock, and the other -
+# having already decided the *original* lock was stale before the first one
+# acted - then removes whatever now sits at the path, destroying the first
+# contender's brand-new legitimate lock out from under it. Both then believe
+# they hold the lock exclusively. Routing every removal through a single
+# mkdir-guarded critical section (mkdir is an atomic test-and-set, unlike a
+# bare rm racing a bare ln -s) means only one breaker ever inspects-and-acts
+# at a time, and it re-confirms staleness after acquiring the mutex in case
+# another breaker already replaced the lock while this one was waiting.
 fm_decision_tier_lock_acquire() {  # <log_file>
   local log=$1
   local lockdir="$log.lock" dir start
@@ -178,16 +191,45 @@ fm_decision_tier_lock_acquire() {  # <log_file>
   [ -d "$dir" ] || mkdir -p "$dir" || return 1
   start=$(fm_decision_tier_pid_start_time "$$")
   while :; do
-    if [ -d "$lockdir" ] && [ ! -L "$lockdir" ]; then
-      rm -rf "$lockdir" 2>/dev/null
+    if [ ! -e "$lockdir" ] && ln -s "$$:$start" "$lockdir" 2>/dev/null; then
+      break
     fi
-    ln -s "$$:$start" "$lockdir" 2>/dev/null && break
-    if fm_decision_tier_lock_is_stale "$lockdir"; then
-      rm -rf "$lockdir" 2>/dev/null
-      continue
-    fi
+    fm_decision_tier_lock_break "$lockdir"
     sleep 0.05
   done
+}
+
+# fm_decision_tier_lock_break: the only place that ever removes whatever
+# currently sits at <lockdir>. Guarded by its own mkdir-based mutex so
+# concurrent contenders can never both act on the same abandoned artifact
+# (see fm_decision_tier_lock_acquire above for why that matters). A losing
+# contender that fails to grab the mutex returns immediately without
+# touching anything - the winner's inspection-and-removal is the only one
+# that runs, and the loser just retries fm_decision_tier_lock_acquire's loop.
+#
+# A leftover DIRECTORY is only ever removed via `rmdir`, which succeeds
+# solely when the directory is empty. That is exactly the shape the retired
+# mkdir-based locking scheme could abandon (a holder that died right after
+# `mkdir` and before writing anything into it). A directory that is NOT
+# empty is left alone rather than recursively deleted: this library has no
+# way to prove an arbitrary non-empty directory sitting at a lock path is an
+# abandoned lock artifact rather than someone else's real data, so it
+# refuses to guess and keeps the caller waiting instead of destroying it. A
+# leftover artifact that is neither a symlink nor a directory (e.g. a plain
+# file - not a shape any lock implementation here has ever written, only a
+# corrupt/foreign one) carries no such ambiguity and is removed with `rm -f`.
+fm_decision_tier_lock_break() {  # <lockdir>
+  local lockdir=$1
+  local mutex="$lockdir.break"
+  mkdir "$mutex" 2>/dev/null || return 0
+  if [ -L "$lockdir" ]; then
+    fm_decision_tier_lock_is_stale "$lockdir" && rm -f "$lockdir" 2>/dev/null
+  elif [ -d "$lockdir" ]; then
+    rmdir "$lockdir" 2>/dev/null
+  elif [ -e "$lockdir" ]; then
+    rm -f "$lockdir" 2>/dev/null
+  fi
+  rmdir "$mutex" 2>/dev/null
 }
 
 # fm_decision_tier_pid_start_time: prints the process-start timestamp

--- a/bin/fm-decision-tier-lib.sh
+++ b/bin/fm-decision-tier-lib.sh
@@ -75,9 +75,10 @@
 # logging a category as auto when it classifies default-veto or hard-stop is
 # refused, opening a default-veto record for a hard-stop category is refused,
 # opening a default-veto record with a recommendation or default action that
-# is empty OR consists solely of whitespace is refused (the tier's whole
-# contract is a stated recommendation and an executable default - whitespace
-# is not one), reusing an id that already has any record in the log is
+# is empty OR consists solely of whitespace/control characters is refused
+# (the tier's whole contract is a stated recommendation and an executable
+# default - whitespace or an unprintable control byte is not one), reusing
+# an id that already has any record in the log is
 # refused for every one of log_auto/log_hard_stop/open_default (a reused id
 # would let status/report collapse two unrelated decisions into one), and
 # vetoing a decision that is not currently pending (already vetoed or already
@@ -110,17 +111,20 @@ fm_decision_tier_require_int() {  # <label> <value>
 }
 
 # fm_decision_tier_require_meaningful: refuses a value that is empty OR
-# normalizes to nothing but whitespace once fm_decision_tier_clean_field's
-# TAB/CR/LF scrub runs on it. require_nonempty alone lets a value through
-# that is technically non-empty but carries no content (all spaces, or a
-# lone TAB/newline that the record builder turns into spaces) - exactly the
-# case where a default-veto record would be persisted with no stated
-# recommendation or executable default despite passing validation.
+# normalizes to nothing but whitespace/control characters once stripped.
+# require_nonempty alone lets a value through that is technically non-empty
+# but carries no content: all spaces, a lone TAB/newline that the record
+# builder turns into spaces, or a non-whitespace control byte (e.g. $'\x01')
+# that fm_decision_tier_clean_field does not touch and that persists verbatim
+# - every one of those is a case where a default-veto record would be
+# persisted with no stated recommendation or executable default despite
+# passing validation. Stripping both [:space:] and [:cntrl:] catches all
+# three: only printable, non-whitespace content counts as meaningful.
 fm_decision_tier_require_meaningful() {  # <label> <value>
   local label=$1 value=${2:-} stripped
-  stripped=$(printf '%s' "$value" | tr -d '[:space:]')
+  stripped=$(printf '%s' "$value" | LC_ALL=C tr -d '[:space:][:cntrl:]')
   if [ -z "$stripped" ]; then
-    printf 'fm-decision-tier-lib: %s must contain non-whitespace content\n' "$label" >&2
+    printf 'fm-decision-tier-lib: %s must contain meaningful (printable, non-whitespace) content\n' "$label" >&2
     return 1
   fi
 }
@@ -142,17 +146,33 @@ fm_decision_tier_require_meaningful() {  # <label> <value>
 # (`readlink`) and checks whether that PID is still alive (`kill -0`); if
 # it is not - or the lock isn't a valid PID symlink at all, e.g. a
 # leftover/corrupt artifact - the lock is treated as abandoned and broken
-# before retrying. A live holder's PID always answers `kill -0`, so this
-# never steals a lock that is still legitimately held.
+# before retrying.
+#
+# A plain DIRECTORY left at the lock path (e.g. by the earlier mkdir-based
+# locking scheme this replaced) needs its own check ahead of the `ln -s`
+# attempt: unlike a file or symlink, `ln -s target dir` does not fail when
+# `dir` already exists as a directory - it silently creates the link INSIDE
+# that directory instead, so the loop would never even notice the stale
+# directory, let alone break it. The `[ -d ... ] && [ ! -L ... ]` check below
+# catches that case directly (a symlink also passes `-d` when its target is
+# a directory, so `-L` is checked first to exclude a legitimate lock),
+# removing it with `rm -rf` (not `rm -f`, which cannot remove a directory at
+# all) before every `ln -s` attempt. A live holder's PID always answers
+# `kill -0`, so none of this ever steals a lock that is still legitimately
+# held.
 fm_decision_tier_lock_acquire() {  # <log_file>
   local log=$1
   local lockdir="$log.lock" dir holder_pid
   dir=$(dirname "$log")
   [ -d "$dir" ] || mkdir -p "$dir" || return 1
-  while ! ln -s "$$" "$lockdir" 2>/dev/null; do
+  while :; do
+    if [ -d "$lockdir" ] && [ ! -L "$lockdir" ]; then
+      rm -rf "$lockdir" 2>/dev/null
+    fi
+    ln -s "$$" "$lockdir" 2>/dev/null && break
     holder_pid=$(readlink "$lockdir" 2>/dev/null) || holder_pid=""
     if [ -z "$holder_pid" ] || ! kill -0 "$holder_pid" 2>/dev/null; then
-      rm -f "$lockdir" 2>/dev/null
+      rm -rf "$lockdir" 2>/dev/null
       continue
     fi
     sleep 0.05

--- a/bin/fm-decision-tier-lib.sh
+++ b/bin/fm-decision-tier-lib.sh
@@ -74,8 +74,13 @@
 # refuse (return 1, message on stderr) rather than silently mis-tiering:
 # logging a category as auto when it classifies default-veto or hard-stop is
 # refused, opening a default-veto record for a hard-stop category is refused,
-# and vetoing a decision that is not currently pending (already vetoed or
-# already expired) is refused. Every one of those refusals is a real,
+# opening a default-veto record with an empty recommendation or default
+# action is refused (the tier's whole contract is a stated recommendation and
+# an executable default), reusing an id that already has any record in the
+# log is refused for every one of log_auto/log_hard_stop/open_default (a
+# reused id would let status/report collapse two unrelated decisions into
+# one), and vetoing a decision that is not currently pending (already vetoed
+# or already expired) is refused. Every one of those refusals is a real,
 # mutation-provable guard - see tests/fm-decision-tier-lib.test.sh.
 set -u
 
@@ -97,6 +102,20 @@ fm_decision_tier_require_int() {  # <label> <value>
       return 1
       ;;
   esac
+}
+
+# fm_decision_tier_require_unused_id: refuses an id that already has any
+# record in the log. Every mutator that OPENS a new decision's lifecycle
+# (log_auto, log_hard_stop, open_default) must call this before writing, so
+# an id never carries more than one lifecycle - a reused id would otherwise
+# let status/report collapse an unrelated later opening together with an
+# earlier acted/escalated/opened record.
+fm_decision_tier_require_unused_id() {  # <log_file> <id>
+  local log=$1 id=$2
+  if [ -n "$(fm_decision_tier_find_records "$log" "$id")" ]; then
+    printf 'fm-decision-tier-lib: id %s already has a decision recorded; ids must not be reused\n' "$id" >&2
+    return 1
+  fi
 }
 
 # --- 1. the classification table ---------------------------------------------
@@ -223,6 +242,7 @@ fm_decision_tier_log_auto() {  # <log_file> <epoch> <id> <category> <note>
   fm_decision_tier_require_nonempty log_file "$log" || return 1
   fm_decision_tier_require_int epoch "$now" || return 1
   fm_decision_tier_require_nonempty id "$id" || return 1
+  fm_decision_tier_require_unused_id "$log" "$id" || return 1
   tier=$(fm_decision_tier_classify "$category")
   if [ "$tier" != auto ]; then
     printf 'fm-decision-tier-lib: category %s classifies %s, not auto; refusing\n' "$category" "$tier" >&2
@@ -236,6 +256,7 @@ fm_decision_tier_log_hard_stop() {  # <log_file> <epoch> <id> <category> <note>
   fm_decision_tier_require_nonempty log_file "$log" || return 1
   fm_decision_tier_require_int epoch "$now" || return 1
   fm_decision_tier_require_nonempty id "$id" || return 1
+  fm_decision_tier_require_unused_id "$log" "$id" || return 1
   tier=$(fm_decision_tier_classify "$category")
   if [ "$tier" != hard-stop ]; then
     printf 'fm-decision-tier-lib: category %s classifies %s, not hard-stop; refusing\n' "$category" "$tier" >&2
@@ -249,6 +270,9 @@ fm_decision_tier_open_default() {  # <log_file> <epoch> <id> <category> <recomme
   fm_decision_tier_require_nonempty log_file "$log" || return 1
   fm_decision_tier_require_int epoch "$now" || return 1
   fm_decision_tier_require_nonempty id "$id" || return 1
+  fm_decision_tier_require_unused_id "$log" "$id" || return 1
+  fm_decision_tier_require_nonempty recommendation "$recommendation" || return 1
+  fm_decision_tier_require_nonempty default_action "$default_action" || return 1
   fm_decision_tier_require_int window_seconds "$window" || return 1
   if [ "$window" -eq 0 ]; then
     printf 'fm-decision-tier-lib: window_seconds must be greater than zero (a zero window never lets the captain veto)\n' >&2

--- a/bin/fm-decision-tier-lib.sh
+++ b/bin/fm-decision-tier-lib.sh
@@ -74,14 +74,19 @@
 # refuse (return 1, message on stderr) rather than silently mis-tiering:
 # logging a category as auto when it classifies default-veto or hard-stop is
 # refused, opening a default-veto record for a hard-stop category is refused,
-# opening a default-veto record with an empty recommendation or default
-# action is refused (the tier's whole contract is a stated recommendation and
-# an executable default), reusing an id that already has any record in the
-# log is refused for every one of log_auto/log_hard_stop/open_default (a
-# reused id would let status/report collapse two unrelated decisions into
-# one), and vetoing a decision that is not currently pending (already vetoed
-# or already expired) is refused. Every one of those refusals is a real,
-# mutation-provable guard - see tests/fm-decision-tier-lib.test.sh.
+# opening a default-veto record with a recommendation or default action that
+# is empty OR consists solely of whitespace is refused (the tier's whole
+# contract is a stated recommendation and an executable default - whitespace
+# is not one), reusing an id that already has any record in the log is
+# refused for every one of log_auto/log_hard_stop/open_default (a reused id
+# would let status/report collapse two unrelated decisions into one), and
+# vetoing a decision that is not currently pending (already vetoed or already
+# expired) is refused. The reused-id check and the record it guards are
+# performed while holding a lock on the log file (fm_decision_tier_lock_*),
+# so two processes racing to open the same id are serialized rather than both
+# passing the uniqueness check before either has written. Every one of those
+# refusals is a real, mutation-provable guard - see
+# tests/fm-decision-tier-lib.test.sh.
 set -u
 
 FM_DECISION_TIER_FIELD_SEP=$'\t'
@@ -102,6 +107,43 @@ fm_decision_tier_require_int() {  # <label> <value>
       return 1
       ;;
   esac
+}
+
+# fm_decision_tier_require_meaningful: refuses a value that is empty OR
+# normalizes to nothing but whitespace once fm_decision_tier_clean_field's
+# TAB/CR/LF scrub runs on it. require_nonempty alone lets a value through
+# that is technically non-empty but carries no content (all spaces, or a
+# lone TAB/newline that the record builder turns into spaces) - exactly the
+# case where a default-veto record would be persisted with no stated
+# recommendation or executable default despite passing validation.
+fm_decision_tier_require_meaningful() {  # <label> <value>
+  local label=$1 value=${2:-} stripped
+  stripped=$(printf '%s' "$value" | tr -d '[:space:]')
+  if [ -z "$stripped" ]; then
+    printf 'fm-decision-tier-lib: %s must contain non-whitespace content\n' "$label" >&2
+    return 1
+  fi
+}
+
+# fm_decision_tier_lock_acquire / _release: a minimal mutex around the
+# check-and-append sequence that opens a decision's lifecycle
+# (require_unused_id followed by the log write). `mkdir` is atomic on every
+# filesystem this library runs on, so two processes racing to open the same
+# log always see exactly one of them create the lock directory first; that
+# ordering is what stops two writers from both passing the uniqueness check
+# for the same id before either has appended its record.
+fm_decision_tier_lock_acquire() {  # <log_file>
+  local log=$1
+  local lockdir="$log.lock" dir
+  dir=$(dirname "$log")
+  [ -d "$dir" ] || mkdir -p "$dir" || return 1
+  while ! mkdir "$lockdir" 2>/dev/null; do
+    sleep 0.05
+  done
+}
+
+fm_decision_tier_lock_release() {  # <log_file>
+  rmdir "$1.lock" 2>/dev/null || true
 }
 
 # fm_decision_tier_require_unused_id: refuses an id that already has any
@@ -242,13 +284,19 @@ fm_decision_tier_log_auto() {  # <log_file> <epoch> <id> <category> <note>
   fm_decision_tier_require_nonempty log_file "$log" || return 1
   fm_decision_tier_require_int epoch "$now" || return 1
   fm_decision_tier_require_nonempty id "$id" || return 1
-  fm_decision_tier_require_unused_id "$log" "$id" || return 1
+  fm_decision_tier_lock_acquire "$log" || return 1
+  if ! fm_decision_tier_require_unused_id "$log" "$id"; then
+    fm_decision_tier_lock_release "$log"
+    return 1
+  fi
   tier=$(fm_decision_tier_classify "$category")
   if [ "$tier" != auto ]; then
     printf 'fm-decision-tier-lib: category %s classifies %s, not auto; refusing\n' "$category" "$tier" >&2
+    fm_decision_tier_lock_release "$log"
     return 1
   fi
   fm_decision_tier_log "$log" "$(fm_decision_tier_record "$now" "$id" "$category" "$tier" acted "" "" "" "$note")"
+  fm_decision_tier_lock_release "$log"
 }
 
 fm_decision_tier_log_hard_stop() {  # <log_file> <epoch> <id> <category> <note>
@@ -256,13 +304,19 @@ fm_decision_tier_log_hard_stop() {  # <log_file> <epoch> <id> <category> <note>
   fm_decision_tier_require_nonempty log_file "$log" || return 1
   fm_decision_tier_require_int epoch "$now" || return 1
   fm_decision_tier_require_nonempty id "$id" || return 1
-  fm_decision_tier_require_unused_id "$log" "$id" || return 1
+  fm_decision_tier_lock_acquire "$log" || return 1
+  if ! fm_decision_tier_require_unused_id "$log" "$id"; then
+    fm_decision_tier_lock_release "$log"
+    return 1
+  fi
   tier=$(fm_decision_tier_classify "$category")
   if [ "$tier" != hard-stop ]; then
     printf 'fm-decision-tier-lib: category %s classifies %s, not hard-stop; refusing\n' "$category" "$tier" >&2
+    fm_decision_tier_lock_release "$log"
     return 1
   fi
   fm_decision_tier_log "$log" "$(fm_decision_tier_record "$now" "$id" "$category" "$tier" escalated "" "" "" "$note")"
+  fm_decision_tier_lock_release "$log"
 }
 
 fm_decision_tier_open_default() {  # <log_file> <epoch> <id> <category> <recommendation> <default_action> <window_seconds>
@@ -270,9 +324,8 @@ fm_decision_tier_open_default() {  # <log_file> <epoch> <id> <category> <recomme
   fm_decision_tier_require_nonempty log_file "$log" || return 1
   fm_decision_tier_require_int epoch "$now" || return 1
   fm_decision_tier_require_nonempty id "$id" || return 1
-  fm_decision_tier_require_unused_id "$log" "$id" || return 1
-  fm_decision_tier_require_nonempty recommendation "$recommendation" || return 1
-  fm_decision_tier_require_nonempty default_action "$default_action" || return 1
+  fm_decision_tier_require_meaningful recommendation "$recommendation" || return 1
+  fm_decision_tier_require_meaningful default_action "$default_action" || return 1
   fm_decision_tier_require_int window_seconds "$window" || return 1
   if [ "$window" -eq 0 ]; then
     printf 'fm-decision-tier-lib: window_seconds must be greater than zero (a zero window never lets the captain veto)\n' >&2
@@ -283,7 +336,13 @@ fm_decision_tier_open_default() {  # <log_file> <epoch> <id> <category> <recomme
     printf 'fm-decision-tier-lib: category %s classifies %s, not default-veto; refusing to open a timed default for it\n' "$category" "$tier" >&2
     return 1
   fi
+  fm_decision_tier_lock_acquire "$log" || return 1
+  if ! fm_decision_tier_require_unused_id "$log" "$id"; then
+    fm_decision_tier_lock_release "$log"
+    return 1
+  fi
   fm_decision_tier_log "$log" "$(fm_decision_tier_record "$now" "$id" "$category" "$tier" opened "$window" "$recommendation" "$default_action" "")"
+  fm_decision_tier_lock_release "$log"
 }
 
 # --- 3. status derivation -----------------------------------------------------

--- a/bin/fm-decision-tier-lib.sh
+++ b/bin/fm-decision-tier-lib.sh
@@ -1,0 +1,355 @@
+#!/usr/bin/env bash
+# fm-decision-tier-lib.sh - the decision-tiering classifier and the
+# default-with-veto timeout mechanism (fleet engineering plan workstream 1,
+# "widen the judgment channel" - data/fleet-engineering-plan.html).
+#
+# Sourced, never executed. Every function is pure with respect to the system
+# clock: any function that needs "now" takes it as an explicit epoch-seconds
+# argument rather than calling `date` itself, so the whole library is
+# deterministic and testable. bin/fm-decision-tier.sh is the CLI that supplies
+# the real clock (with a --now override) around this library.
+#
+# NOT WIRED IN. This is a standalone building block. Nothing in firstmate's
+# live escalation path (AGENTS.md sections 7-9) calls into this library yet.
+# Turning it on - having firstmate's own escalation logic actually consult
+# fm_decision_tier_classify before deciding whether to act, batch, or
+# escalate - is a captain decision (the plan's workstream 1 says so
+# explicitly: delegating real decision authority cannot be self-granted).
+#
+# This library owns THREE contracts:
+#
+#   1. THE CLASSIFICATION TABLE (fm_decision_tier_classify) - the single owner
+#      of category -> tier. Three tiers, matching AGENTS.md's own vocabulary:
+#        auto         - consistent with precedent; act and log, no captain
+#                        involvement at all.
+#        default-veto - a recommendation and a default are stated; the action
+#                        proceeds unless the captain objects inside a stated
+#                        window (AGENTS.md's "default-with-veto").
+#        hard-stop    - merges, destructive or irreversible actions, scope
+#                        expansion, client-facing semantics, credentials, and
+#                        outward-facing actions. Always escalates.
+#      An unrecognized category classifies hard-stop: the table fails closed,
+#      never open, on anything it does not recognize. Extend the taxonomy by
+#      adding the new category token to the matching case arm below - that
+#      one edit is the whole extension point; no other function in this file
+#      encodes tier assignment.
+#
+#   2. THE DECISION RECORD - the one shape every event in a decision's history
+#      is written as, a 9-field TAB-separated line:
+#          <epoch>\t<id>\t<category>\t<tier>\t<event>\t<window>\t<recommendation>\t<default_action>\t<note>
+#      `event` is one of:
+#        opened    - a default-veto decision's recommendation, default action,
+#                    and window were stated (fm_decision_tier_open_default).
+#        vetoed    - the captain objected before the window elapsed
+#                    (fm_decision_tier_veto).
+#        acted     - an auto-tier decision was acted on and logged
+#                    (fm_decision_tier_log_auto).
+#        escalated - a hard-stop decision reached the captain
+#                    (fm_decision_tier_log_hard_stop).
+#      `window`, `recommendation`, and `default_action` are populated only on
+#      `opened` records; every other event leaves them empty. Fields are
+#      TAB/newline-scrubbed on construction so a record can never desync into
+#      more than nine columns.
+#
+#   3. STATUS DERIVATION (fm_decision_tier_status) - the single-owner
+#      "expires into action" rule for a default-veto decision, purely a
+#      function of its opened record and the supplied now:
+#        vetoed  - a vetoed record exists for this id (wins regardless of the
+#                  window).
+#        expired - now - opened_epoch >= window, no veto: the default action
+#                  is cleared to run.
+#        pending - still inside the window, no veto yet.
+#        unknown - no opened record exists for this id.
+#      This is what makes a tier-2 decision "carry a stated default that
+#      expires into action rather than blocking indefinitely": nothing has to
+#      poll or remind anyone. The status is recomputable at any later time
+#      from the log alone.
+#
+# fm_decision_tier_report aggregates a whole log into counters, including
+# escalation_count (hard-stop decisions - the only tier that unconditionally
+# reaches the captain), so a session's escalation count is a reported,
+# measurable quantity rather than a felt impression.
+#
+# The `log_auto` / `log_hard_stop` / `open_default` / `veto` mutators all
+# refuse (return 1, message on stderr) rather than silently mis-tiering:
+# logging a category as auto when it classifies default-veto or hard-stop is
+# refused, opening a default-veto record for a hard-stop category is refused,
+# and vetoing a decision that is not currently pending (already vetoed or
+# already expired) is refused. Every one of those refusals is a real,
+# mutation-provable guard - see tests/fm-decision-tier-lib.test.sh.
+set -u
+
+FM_DECISION_TIER_FIELD_SEP=$'\t'
+
+# --- validation helpers ------------------------------------------------------
+
+fm_decision_tier_require_nonempty() {  # <label> <value>
+  if [ -z "${2:-}" ]; then
+    printf 'fm-decision-tier-lib: %s must not be empty\n' "$1" >&2
+    return 1
+  fi
+}
+
+fm_decision_tier_require_int() {  # <label> <value>
+  case "${2:-}" in
+    ''|*[!0-9]*)
+      printf 'fm-decision-tier-lib: %s must be a non-negative integer: %s\n' "$1" "${2:-}" >&2
+      return 1
+      ;;
+  esac
+}
+
+# --- 1. the classification table ---------------------------------------------
+
+# fm_decision_tier_classify: THE single-owner category -> tier table.
+# Prints exactly one of auto|default-veto|hard-stop. Never fails.
+fm_decision_tier_classify() {  # <category>
+  case "${1:-}" in
+    precedent-match|sibling-answer-reuse|measurement-refuted-revert|\
+    stale-comment-correction|followup-routing)
+      printf 'auto'
+      ;;
+    two-option-tradeoff|scope-narrowing|risk-tradeoff-reversible|process-default)
+      printf 'default-veto'
+      ;;
+    merge|destructive|irreversible|scope-expansion|client-facing|\
+    credential|outward-facing|security-sensitive)
+      printf 'hard-stop'
+      ;;
+    *)
+      # Fail closed: an unrecognized category always escalates rather than
+      # silently acting or silently proceeding on a stated default.
+      printf 'hard-stop'
+      ;;
+  esac
+}
+
+fm_decision_tier_tiers() {
+  printf 'auto\ndefault-veto\nhard-stop\n'
+}
+
+# fm_decision_tier_known_categories: the category VOCABULARY only, not the
+# tier mapping (that stays owned solely by fm_decision_tier_classify above).
+fm_decision_tier_known_categories() {
+  cat <<'EOF'
+precedent-match
+sibling-answer-reuse
+measurement-refuted-revert
+stale-comment-correction
+followup-routing
+two-option-tradeoff
+scope-narrowing
+risk-tradeoff-reversible
+process-default
+merge
+destructive
+irreversible
+scope-expansion
+client-facing
+credential
+outward-facing
+security-sensitive
+EOF
+}
+
+# fm_decision_tier_categories_for: known categories filtered to one tier,
+# derived by calling fm_decision_tier_classify on each - never a second table.
+fm_decision_tier_categories_for() {  # <tier>
+  local want=$1 c
+  while IFS= read -r c; do
+    [ -n "$c" ] || continue
+    [ "$(fm_decision_tier_classify "$c")" = "$want" ] && printf '%s\n' "$c"
+  done < <(fm_decision_tier_known_categories)
+  return 0
+}
+
+# --- 2. the decision record ---------------------------------------------------
+
+fm_decision_tier_clean_field() {
+  printf '%s' "${1:-}" | LC_ALL=C tr '\t\r\n' '   '
+}
+
+fm_decision_tier_record() {  # <epoch> <id> <category> <tier> <event> <window> <recommendation> <default_action> <note>
+  local epoch id category tier event window rec default_action note
+  epoch=$(fm_decision_tier_clean_field "${1:-}")
+  id=$(fm_decision_tier_clean_field "${2:-}")
+  category=$(fm_decision_tier_clean_field "${3:-}")
+  tier=$(fm_decision_tier_clean_field "${4:-}")
+  event=$(fm_decision_tier_clean_field "${5:-}")
+  window=$(fm_decision_tier_clean_field "${6:-}")
+  rec=$(fm_decision_tier_clean_field "${7:-}")
+  default_action=$(fm_decision_tier_clean_field "${8:-}")
+  note=$(fm_decision_tier_clean_field "${9:-}")
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s' \
+    "$epoch" "$id" "$category" "$tier" "$event" "$window" "$rec" "$default_action" "$note"
+}
+
+fm_decision_tier_field() {  # <record> <n>
+  printf '%s' "$1" | cut -d"$FM_DECISION_TIER_FIELD_SEP" -f"$2"
+}
+
+fm_decision_tier_epoch()          { fm_decision_tier_field "$1" 1; }
+fm_decision_tier_id()             { fm_decision_tier_field "$1" 2; }
+fm_decision_tier_category()       { fm_decision_tier_field "$1" 3; }
+fm_decision_tier_tier()           { fm_decision_tier_field "$1" 4; }
+fm_decision_tier_event()          { fm_decision_tier_field "$1" 5; }
+fm_decision_tier_window()         { fm_decision_tier_field "$1" 6; }
+fm_decision_tier_recommendation() { fm_decision_tier_field "$1" 7; }
+fm_decision_tier_default_action() { fm_decision_tier_field "$1" 8; }
+fm_decision_tier_note()           { fm_decision_tier_field "$1" 9; }
+
+fm_decision_tier_log() {  # <log_file> <record>
+  local log=$1 rec=$2 dir
+  dir=$(dirname "$log")
+  [ -d "$dir" ] || mkdir -p "$dir" || return 1
+  printf '%s\n' "$rec" >> "$log"
+}
+
+# fm_decision_tier_find_records: every record for one id, in file order.
+fm_decision_tier_find_records() {  # <log_file> <id>
+  local log=$1 id=$2 line
+  [ -f "$log" ] || return 0
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    [ "$(fm_decision_tier_id "$line")" = "$id" ] && printf '%s\n' "$line"
+  done < "$log"
+  return 0
+}
+
+# --- mutators: each refuses when the category's own tier disagrees ----------
+
+fm_decision_tier_log_auto() {  # <log_file> <epoch> <id> <category> <note>
+  local log=$1 now=$2 id=$3 category=$4 note=${5:-} tier
+  fm_decision_tier_require_nonempty log_file "$log" || return 1
+  fm_decision_tier_require_int epoch "$now" || return 1
+  fm_decision_tier_require_nonempty id "$id" || return 1
+  tier=$(fm_decision_tier_classify "$category")
+  if [ "$tier" != auto ]; then
+    printf 'fm-decision-tier-lib: category %s classifies %s, not auto; refusing\n' "$category" "$tier" >&2
+    return 1
+  fi
+  fm_decision_tier_log "$log" "$(fm_decision_tier_record "$now" "$id" "$category" "$tier" acted "" "" "" "$note")"
+}
+
+fm_decision_tier_log_hard_stop() {  # <log_file> <epoch> <id> <category> <note>
+  local log=$1 now=$2 id=$3 category=$4 note=${5:-} tier
+  fm_decision_tier_require_nonempty log_file "$log" || return 1
+  fm_decision_tier_require_int epoch "$now" || return 1
+  fm_decision_tier_require_nonempty id "$id" || return 1
+  tier=$(fm_decision_tier_classify "$category")
+  if [ "$tier" != hard-stop ]; then
+    printf 'fm-decision-tier-lib: category %s classifies %s, not hard-stop; refusing\n' "$category" "$tier" >&2
+    return 1
+  fi
+  fm_decision_tier_log "$log" "$(fm_decision_tier_record "$now" "$id" "$category" "$tier" escalated "" "" "" "$note")"
+}
+
+fm_decision_tier_open_default() {  # <log_file> <epoch> <id> <category> <recommendation> <default_action> <window_seconds>
+  local log=$1 now=$2 id=$3 category=$4 recommendation=${5:-} default_action=${6:-} window=$7 tier
+  fm_decision_tier_require_nonempty log_file "$log" || return 1
+  fm_decision_tier_require_int epoch "$now" || return 1
+  fm_decision_tier_require_nonempty id "$id" || return 1
+  fm_decision_tier_require_int window_seconds "$window" || return 1
+  if [ "$window" -eq 0 ]; then
+    printf 'fm-decision-tier-lib: window_seconds must be greater than zero (a zero window never lets the captain veto)\n' >&2
+    return 1
+  fi
+  tier=$(fm_decision_tier_classify "$category")
+  if [ "$tier" != default-veto ]; then
+    printf 'fm-decision-tier-lib: category %s classifies %s, not default-veto; refusing to open a timed default for it\n' "$category" "$tier" >&2
+    return 1
+  fi
+  fm_decision_tier_log "$log" "$(fm_decision_tier_record "$now" "$id" "$category" "$tier" opened "$window" "$recommendation" "$default_action" "")"
+}
+
+# --- 3. status derivation -----------------------------------------------------
+
+fm_decision_tier_status() {  # <log_file> <id> <epoch> -> pending|vetoed|expired|unknown
+  local log=$1 id=$2 now=$3 opened_rec="" vetoed=0 line opened_epoch window
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    case "$(fm_decision_tier_event "$line")" in
+      opened) opened_rec=$line ;;
+      vetoed) vetoed=1 ;;
+    esac
+  done < <(fm_decision_tier_find_records "$log" "$id")
+  if [ -z "$opened_rec" ]; then
+    printf 'unknown'
+    return 0
+  fi
+  if [ "$vetoed" -eq 1 ]; then
+    printf 'vetoed'
+    return 0
+  fi
+  opened_epoch=$(fm_decision_tier_epoch "$opened_rec")
+  window=$(fm_decision_tier_window "$opened_rec")
+  if [ $((now - opened_epoch)) -ge "$window" ]; then
+    printf 'expired'
+  else
+    printf 'pending'
+  fi
+}
+
+fm_decision_tier_veto() {  # <log_file> <epoch> <id> <note>
+  local log=$1 now=$2 id=$3 note=${4:-} status line opened_rec=""
+  fm_decision_tier_require_nonempty log_file "$log" || return 1
+  fm_decision_tier_require_int epoch "$now" || return 1
+  fm_decision_tier_require_nonempty id "$id" || return 1
+  status=$(fm_decision_tier_status "$log" "$id" "$now")
+  if [ "$status" != pending ]; then
+    printf 'fm-decision-tier-lib: cannot veto id %s: status is %s, not pending\n' "$id" "$status" >&2
+    return 1
+  fi
+  while IFS= read -r line; do
+    [ "$(fm_decision_tier_event "$line")" = opened ] && opened_rec=$line
+  done < <(fm_decision_tier_find_records "$log" "$id")
+  fm_decision_tier_log "$log" "$(fm_decision_tier_record "$now" "$id" \
+    "$(fm_decision_tier_category "$opened_rec")" "$(fm_decision_tier_tier "$opened_rec")" \
+    vetoed "" "" "" "$note")"
+}
+
+# --- reporting ----------------------------------------------------------------
+
+# fm_decision_tier_report: aggregate a whole log into `key=value` counter
+# lines. escalation_count is the hard-stop count - the only tier that
+# unconditionally reaches the captain - so a session's escalation count is
+# read off this report rather than felt.
+fm_decision_tier_report() {  # <log_file> <epoch>
+  local log=$1 now=$2
+  local total=0 auto=0 hard_stop=0 pending=0 expired=0 vetoed=0
+  local id status has_acted has_escalated line
+  if [ -f "$log" ]; then
+    while IFS= read -r id; do
+      [ -n "$id" ] || continue
+      has_acted=0
+      has_escalated=0
+      while IFS= read -r line; do
+        [ -n "$line" ] || continue
+        case "$(fm_decision_tier_event "$line")" in
+          acted) has_acted=1 ;;
+          escalated) has_escalated=1 ;;
+        esac
+      done < <(fm_decision_tier_find_records "$log" "$id")
+      if [ "$has_acted" -eq 1 ]; then
+        auto=$((auto + 1))
+      elif [ "$has_escalated" -eq 1 ]; then
+        hard_stop=$((hard_stop + 1))
+      else
+        status=$(fm_decision_tier_status "$log" "$id" "$now")
+        case "$status" in
+          pending) pending=$((pending + 1)) ;;
+          expired) expired=$((expired + 1)) ;;
+          vetoed) vetoed=$((vetoed + 1)) ;;
+        esac
+      fi
+      total=$((total + 1))
+    done < <(cut -d"$FM_DECISION_TIER_FIELD_SEP" -f2 "$log" | LC_ALL=C sort -u)
+  fi
+  printf 'total=%d\n' "$total"
+  printf 'auto=%d\n' "$auto"
+  printf 'default_pending=%d\n' "$pending"
+  printf 'default_expired=%d\n' "$expired"
+  printf 'default_vetoed=%d\n' "$vetoed"
+  printf 'hard_stop=%d\n' "$hard_stop"
+  printf 'escalation_count=%d\n' "$hard_stop"
+}

--- a/bin/fm-decision-tier-lib.sh
+++ b/bin/fm-decision-tier-lib.sh
@@ -127,38 +127,40 @@ fm_decision_tier_require_meaningful() {  # <label> <value>
 
 # fm_decision_tier_lock_acquire / _release: a minimal mutex around the
 # check-and-append sequence that opens a decision's lifecycle
-# (require_unused_id followed by the log write). `mkdir` is atomic on every
-# filesystem this library runs on, so two processes racing to open the same
-# log always see exactly one of them create the lock directory first; that
-# ordering is what stops two writers from both passing the uniqueness check
-# for the same id before either has appended its record.
+# (require_unused_id followed by the log write). The lock is a symlink
+# whose target is the holder's PID, created with `ln -s`: symlink creation
+# is a single atomic syscall, so the lock's existence and its holder's PID
+# are established in the exact same instant - there is no window where the
+# lock exists but its PID is not yet readable (unlike a two-step
+# mkdir-then-write-pid-file scheme, where a holder killed between the two
+# steps would leave a lock no contender could ever identify as abandoned).
 #
-# A holder that dies (killed, crashes, or the append itself fails) between
-# `mkdir` and `rmdir` leaves the lock directory behind with nothing left to
-# release it - every later writer would then retry `mkdir` forever. To
-# recover from that, the holder records its PID inside the lock directory;
-# a contender that fails to `mkdir` checks whether that PID is still alive
-# (`kill -0`) and, if not, treats the lock as abandoned and breaks it before
-# retrying. A live holder's PID always answers `kill -0`, so this never
-# steals a lock that is still legitimately held.
+# A holder that dies (killed, crashes, or the append itself fails) before
+# releasing leaves the symlink behind with nothing left to remove it -
+# every later writer would then retry `ln -s` forever. To recover from
+# that, a contender that fails to `ln -s` reads the symlink's target
+# (`readlink`) and checks whether that PID is still alive (`kill -0`); if
+# it is not - or the lock isn't a valid PID symlink at all, e.g. a
+# leftover/corrupt artifact - the lock is treated as abandoned and broken
+# before retrying. A live holder's PID always answers `kill -0`, so this
+# never steals a lock that is still legitimately held.
 fm_decision_tier_lock_acquire() {  # <log_file>
   local log=$1
   local lockdir="$log.lock" dir holder_pid
   dir=$(dirname "$log")
   [ -d "$dir" ] || mkdir -p "$dir" || return 1
-  while ! mkdir "$lockdir" 2>/dev/null; do
-    holder_pid=$(cat "$lockdir/pid" 2>/dev/null) || holder_pid=""
-    if [ -n "$holder_pid" ] && ! kill -0 "$holder_pid" 2>/dev/null; then
-      rm -rf "$lockdir" 2>/dev/null
+  while ! ln -s "$$" "$lockdir" 2>/dev/null; do
+    holder_pid=$(readlink "$lockdir" 2>/dev/null) || holder_pid=""
+    if [ -z "$holder_pid" ] || ! kill -0 "$holder_pid" 2>/dev/null; then
+      rm -f "$lockdir" 2>/dev/null
       continue
     fi
     sleep 0.05
   done
-  printf '%s' "$$" > "$lockdir/pid"
 }
 
 fm_decision_tier_lock_release() {  # <log_file>
-  rm -rf "$1.lock" 2>/dev/null || true
+  rm -f "$1.lock" 2>/dev/null || true
 }
 
 # fm_decision_tier_require_unused_id: refuses an id that already has any

--- a/bin/fm-decision-tier-lib.sh
+++ b/bin/fm-decision-tier-lib.sh
@@ -132,21 +132,34 @@ fm_decision_tier_require_meaningful() {  # <label> <value>
 # fm_decision_tier_lock_acquire / _release: a minimal mutex around the
 # check-and-append sequence that opens a decision's lifecycle
 # (require_unused_id followed by the log write). The lock is a symlink
-# whose target is the holder's PID, created with `ln -s`: symlink creation
-# is a single atomic syscall, so the lock's existence and its holder's PID
-# are established in the exact same instant - there is no window where the
-# lock exists but its PID is not yet readable (unlike a two-step
-# mkdir-then-write-pid-file scheme, where a holder killed between the two
-# steps would leave a lock no contender could ever identify as abandoned).
+# whose target is "<holder_pid>:<holder_start_time>", created with `ln -s`:
+# symlink creation is a single atomic syscall, so the lock's existence and
+# its holder's identity are established in the exact same instant - there
+# is no window where the lock exists but its holder is not yet readable
+# (unlike a two-step mkdir-then-write-pid-file scheme, where a holder
+# killed between the two steps would leave a lock no contender could ever
+# identify as abandoned).
 #
 # A holder that dies (killed, crashes, or the append itself fails) before
 # releasing leaves the symlink behind with nothing left to remove it -
 # every later writer would then retry `ln -s` forever. To recover from
-# that, a contender that fails to `ln -s` reads the symlink's target
-# (`readlink`) and checks whether that PID is still alive (`kill -0`); if
-# it is not - or the lock isn't a valid PID symlink at all, e.g. a
-# leftover/corrupt artifact - the lock is treated as abandoned and broken
-# before retrying.
+# that, a contender that fails to `ln -s` calls fm_decision_tier_lock_is_stale,
+# which treats the lock as abandoned - and breaks it before retrying -
+# whenever any of these hold: the lock isn't a valid PID:start-time symlink
+# at all (e.g. a leftover/corrupt artifact), the recorded PID is no longer
+# alive (`kill -0` fails), or the recorded PID IS alive but its current
+# process-start time no longer matches what was recorded when the lock was
+# created.
+#
+# That last case is the one a bare `kill -0 <recorded_pid>` cannot catch:
+# PIDs are recycled by the OS, so a holder that dies and is later reused
+# for an unrelated, still-running process would make `kill -0` succeed
+# forever, wedging every subsequent writer on a lock nobody is actually
+# holding. Recording the holder's process-start time (`ps -o lstart=`)
+# alongside its PID closes that gap - an unrelated process handed the same
+# recycled PID essentially never has the exact same start time as the
+# original holder, so the mismatch outs it as an impostor rather than a
+# still-legitimate lock.
 #
 # A plain DIRECTORY left at the lock path (e.g. by the earlier mkdir-based
 # locking scheme this replaced) needs its own check ahead of the `ln -s`
@@ -157,26 +170,56 @@ fm_decision_tier_require_meaningful() {  # <label> <value>
 # catches that case directly (a symlink also passes `-d` when its target is
 # a directory, so `-L` is checked first to exclude a legitimate lock),
 # removing it with `rm -rf` (not `rm -f`, which cannot remove a directory at
-# all) before every `ln -s` attempt. A live holder's PID always answers
-# `kill -0`, so none of this ever steals a lock that is still legitimately
-# held.
+# all) before every `ln -s` attempt.
 fm_decision_tier_lock_acquire() {  # <log_file>
   local log=$1
-  local lockdir="$log.lock" dir holder_pid
+  local lockdir="$log.lock" dir start
   dir=$(dirname "$log")
   [ -d "$dir" ] || mkdir -p "$dir" || return 1
+  start=$(fm_decision_tier_pid_start_time "$$")
   while :; do
     if [ -d "$lockdir" ] && [ ! -L "$lockdir" ]; then
       rm -rf "$lockdir" 2>/dev/null
     fi
-    ln -s "$$" "$lockdir" 2>/dev/null && break
-    holder_pid=$(readlink "$lockdir" 2>/dev/null) || holder_pid=""
-    if [ -z "$holder_pid" ] || ! kill -0 "$holder_pid" 2>/dev/null; then
+    ln -s "$$:$start" "$lockdir" 2>/dev/null && break
+    if fm_decision_tier_lock_is_stale "$lockdir"; then
       rm -rf "$lockdir" 2>/dev/null
       continue
     fi
     sleep 0.05
   done
+}
+
+# fm_decision_tier_pid_start_time: prints the process-start timestamp
+# (`ps -o lstart=`) for a still-living <pid>, or an empty string if no
+# process with that PID currently exists. `lstart` is supported by both
+# GNU/Linux and BSD/macOS `ps`, so this is portable across the platforms
+# this library runs on. Whitespace is collapsed so the result compares
+# reliably regardless of column-padding differences between `ps`
+# implementations.
+fm_decision_tier_pid_start_time() {  # <pid>
+  ps -o lstart= -p "$1" 2>/dev/null | LC_ALL=C tr -s '[:space:]' ' ' | sed -e 's/^ //' -e 's/ $//'
+}
+
+# fm_decision_tier_lock_is_stale: true (exit 0) if the lock symlink at
+# <lockdir> was left by a holder that is no longer the process the lock
+# was created for - the symlink isn't a valid "<pid>:<start_time>" target,
+# the recorded PID is dead, or the recorded PID is alive but its current
+# start time no longer matches the recorded one (the PID was reused by an
+# unrelated process since the lock was created). Only when the recorded PID
+# is alive AND its start time still matches is the lock still legitimately
+# held (exit 1).
+fm_decision_tier_lock_is_stale() {  # <lockdir>
+  local lockdir=$1 holder holder_pid holder_start current_start
+  holder=$(readlink "$lockdir" 2>/dev/null) || return 0
+  [ -n "$holder" ] || return 0
+  holder_pid=${holder%%:*}
+  holder_start=${holder#*:}
+  [ -n "$holder_pid" ] || return 0
+  kill -0 "$holder_pid" 2>/dev/null || return 0
+  current_start=$(fm_decision_tier_pid_start_time "$holder_pid")
+  [ -n "$current_start" ] && [ "$current_start" = "$holder_start" ] && return 1
+  return 0
 }
 
 fm_decision_tier_lock_release() {  # <log_file>

--- a/bin/fm-decision-tier-lib.sh
+++ b/bin/fm-decision-tier-lib.sh
@@ -132,18 +132,33 @@ fm_decision_tier_require_meaningful() {  # <label> <value>
 # log always see exactly one of them create the lock directory first; that
 # ordering is what stops two writers from both passing the uniqueness check
 # for the same id before either has appended its record.
+#
+# A holder that dies (killed, crashes, or the append itself fails) between
+# `mkdir` and `rmdir` leaves the lock directory behind with nothing left to
+# release it - every later writer would then retry `mkdir` forever. To
+# recover from that, the holder records its PID inside the lock directory;
+# a contender that fails to `mkdir` checks whether that PID is still alive
+# (`kill -0`) and, if not, treats the lock as abandoned and breaks it before
+# retrying. A live holder's PID always answers `kill -0`, so this never
+# steals a lock that is still legitimately held.
 fm_decision_tier_lock_acquire() {  # <log_file>
   local log=$1
-  local lockdir="$log.lock" dir
+  local lockdir="$log.lock" dir holder_pid
   dir=$(dirname "$log")
   [ -d "$dir" ] || mkdir -p "$dir" || return 1
   while ! mkdir "$lockdir" 2>/dev/null; do
+    holder_pid=$(cat "$lockdir/pid" 2>/dev/null) || holder_pid=""
+    if [ -n "$holder_pid" ] && ! kill -0 "$holder_pid" 2>/dev/null; then
+      rm -rf "$lockdir" 2>/dev/null
+      continue
+    fi
     sleep 0.05
   done
+  printf '%s' "$$" > "$lockdir/pid"
 }
 
 fm_decision_tier_lock_release() {  # <log_file>
-  rmdir "$1.lock" 2>/dev/null || true
+  rm -rf "$1.lock" 2>/dev/null || true
 }
 
 # fm_decision_tier_require_unused_id: refuses an id that already has any
@@ -152,6 +167,13 @@ fm_decision_tier_lock_release() {  # <log_file>
 # an id never carries more than one lifecycle - a reused id would otherwise
 # let status/report collapse an unrelated later opening together with an
 # earlier acted/escalated/opened record.
+#
+# Callers must pass an id already run through fm_decision_tier_clean_field
+# (every mutator below normalizes its id argument before calling this) -
+# stored ids are always the normalized form fm_decision_tier_record wrote,
+# so comparing this function's raw input against them would let two ids
+# that only differ by a TAB/CR/LF-vs-space both pass as "unused" and then
+# collide once normalized on write.
 fm_decision_tier_require_unused_id() {  # <log_file> <id>
   local log=$1 id=$2
   if [ -n "$(fm_decision_tier_find_records "$log" "$id")" ]; then
@@ -267,8 +289,14 @@ fm_decision_tier_log() {  # <log_file> <record>
 }
 
 # fm_decision_tier_find_records: every record for one id, in file order.
+# The id is run through the same TAB/CR/LF scrub fm_decision_tier_record
+# applies before storing it, so this always compares against the id in the
+# form it was actually persisted in - an id that differs from a stored one
+# only by a TAB/CR/LF-vs-space substitution collides with it here instead of
+# looking unused and then colliding silently once written.
 fm_decision_tier_find_records() {  # <log_file> <id>
-  local log=$1 id=$2 line
+  local log=$1 id line
+  id=$(fm_decision_tier_clean_field "${2:-}")
   [ -f "$log" ] || return 0
   while IFS= read -r line; do
     [ -n "$line" ] || continue

--- a/bin/fm-decision-tier.sh
+++ b/bin/fm-decision-tier.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# fm-decision-tier.sh - CLI over bin/fm-decision-tier-lib.sh: the
+# decision-tiering classifier and default-with-veto timeout mechanism from
+# workstream 1 of the fleet engineering plan (data/fleet-engineering-plan.html,
+# "widen the judgment channel" - "the actual 10x lever").
+#
+# NOT WIRED IN. This script and its library are a standalone building block.
+# Nothing in firstmate's live escalation path calls them yet; turning that on
+# is the captain's call, not something firstmate can self-grant (the plan's
+# workstream 1 says so explicitly).
+#
+# Usage:
+#   fm-decision-tier.sh classify <category>
+#   fm-decision-tier.sh categories [auto|default-veto|hard-stop]
+#   fm-decision-tier.sh auto [--now <epoch>] <log-file> <id> <category> <note>
+#   fm-decision-tier.sh hard-stop [--now <epoch>] <log-file> <id> <category> <note>
+#   fm-decision-tier.sh open [--now <epoch>] <log-file> <id> <category> <window-seconds> <recommendation> <default-action>
+#   fm-decision-tier.sh veto [--now <epoch>] <log-file> <id> <note>
+#   fm-decision-tier.sh status [--now <epoch>] <log-file> <id>
+#   fm-decision-tier.sh report [--now <epoch>] <log-file>
+#
+# `classify` is the single-owner category->tier lookup
+# (bin/fm-decision-tier-lib.sh fm_decision_tier_classify); an unrecognized
+# category always classifies hard-stop rather than silently defaulting to a
+# weaker tier. `categories` lists the known category vocabulary, optionally
+# filtered to one tier; with no argument it prints `<category>\t<tier>` pairs,
+# derived from `classify` rather than a second table.
+#
+# `auto` and `hard-stop` log a decision whose category already classifies to
+# that tier; each refuses (exit 1) when the category classifies differently,
+# so a caller cannot log a merge as auto by mistake.
+#
+# `open` records a default-with-veto decision: a stated recommendation and
+# default action with a window in seconds, and refuses when the category does
+# not classify default-veto. `status` reports one of:
+#   pending  - still inside the window, no veto yet.
+#   vetoed   - the captain objected before the window elapsed.
+#   expired  - the window elapsed with no veto: the default action is cleared
+#              to run. This is the "expires into action" contract - nothing
+#              polls or reminds anyone; the status is recomputed from the log.
+#   unknown  - no such id was ever opened.
+# `veto` records a captain objection and refuses once the id is not currently
+# pending (already vetoed, or the window already expired - too late).
+#
+# `report` prints one `key=value` line per counter - total, one line per tier
+# outcome, and `escalation_count` (hard-stop decisions, the only tier that
+# unconditionally reaches the captain) - so a session's escalation count is a
+# reported, measurable quantity rather than a felt impression.
+#
+# `--now <epoch>` overrides the current time (default: the real clock) for
+# deterministic testing and demonstration. It must come immediately after the
+# subcommand name when given. The library itself never reads the clock; every
+# time-sensitive library function takes epoch seconds as an explicit argument.
+#
+# Exit status: 0 on success; 1 on a refused or invalid operation (wrong tier
+# for the category, veto after expiry, malformed window/epoch); 2 on a usage
+# error.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=bin/fm-decision-tier-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-decision-tier-lib.sh"
+
+usage() {
+  awk '
+    NR == 1 { next }
+    /^#/ { sub(/^# ?/, ""); print; next }
+    { exit }
+  ' "$0"
+}
+
+fail() {
+  printf 'fm-decision-tier: %s\n' "$*" >&2
+  exit 1
+}
+
+now_default() {
+  date +%s
+}
+
+# Pops a leading "--now <epoch>" pair off the positional args, if present, and
+# echoes the resolved epoch. Callers re-derive their remaining positionals
+# with `shift` guarded the same way, since bash functions cannot hand back a
+# mutated caller argv.
+resolve_now() {
+  if [ "${1:-}" = --now ]; then
+    case "${2:-}" in
+      ''|*[!0-9]*) fail "--now requires an integer epoch" ;;
+    esac
+    printf '%s' "$2"
+  else
+    now_default
+  fi
+}
+
+command_classify() {
+  [ "$#" -eq 1 ] || { usage >&2; exit 2; }
+  fm_decision_tier_classify "$1"
+  printf '\n'
+}
+
+command_categories() {
+  if [ "$#" -eq 0 ]; then
+    local c
+    while IFS= read -r c; do
+      [ -n "$c" ] || continue
+      printf '%s\t%s\n' "$c" "$(fm_decision_tier_classify "$c")"
+    done < <(fm_decision_tier_known_categories)
+  elif [ "$#" -eq 1 ]; then
+    case "$1" in
+      auto|default-veto|hard-stop) fm_decision_tier_categories_for "$1" ;;
+      *) fail "unknown tier '$1' (expected auto, default-veto, or hard-stop)" ;;
+    esac
+  else
+    usage >&2
+    exit 2
+  fi
+}
+
+command_auto() {
+  local now
+  now=$(resolve_now "$@")
+  [ "${1:-}" = --now ] && shift 2
+  [ "$#" -eq 4 ] || { usage >&2; exit 2; }
+  fm_decision_tier_log_auto "$1" "$now" "$2" "$3" "$4"
+}
+
+command_hard_stop() {
+  local now
+  now=$(resolve_now "$@")
+  [ "${1:-}" = --now ] && shift 2
+  [ "$#" -eq 4 ] || { usage >&2; exit 2; }
+  fm_decision_tier_log_hard_stop "$1" "$now" "$2" "$3" "$4"
+}
+
+command_open() {
+  local now
+  now=$(resolve_now "$@")
+  [ "${1:-}" = --now ] && shift 2
+  [ "$#" -eq 6 ] || { usage >&2; exit 2; }
+  fm_decision_tier_open_default "$1" "$now" "$2" "$3" "$5" "$6" "$4"
+}
+
+command_veto() {
+  local now
+  now=$(resolve_now "$@")
+  [ "${1:-}" = --now ] && shift 2
+  [ "$#" -eq 3 ] || { usage >&2; exit 2; }
+  fm_decision_tier_veto "$1" "$now" "$2" "$3"
+}
+
+command_status() {
+  local now
+  now=$(resolve_now "$@")
+  [ "${1:-}" = --now ] && shift 2
+  [ "$#" -eq 2 ] || { usage >&2; exit 2; }
+  fm_decision_tier_status "$1" "$2" "$now"
+  printf '\n'
+}
+
+command_report() {
+  local now
+  now=$(resolve_now "$@")
+  [ "${1:-}" = --now ] && shift 2
+  [ "$#" -eq 1 ] || { usage >&2; exit 2; }
+  fm_decision_tier_report "$1" "$now"
+}
+
+case "${1:-}" in
+  classify) shift; command_classify "$@" ;;
+  categories) shift; command_categories "$@" ;;
+  auto) shift; command_auto "$@" ;;
+  hard-stop) shift; command_hard_stop "$@" ;;
+  open) shift; command_open "$@" ;;
+  veto) shift; command_veto "$@" ;;
+  status) shift; command_status "$@" ;;
+  report) shift; command_report "$@" ;;
+  -h|--help) usage ;;
+  *) usage >&2; exit 2 ;;
+esac

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -28,6 +28,8 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-backlog-receive.sh`  | Idempotently ingest one confined remote handoff outbox through tasks-axi             |
 | `fm-captain-hold.sh`     | Hold tasks for the captain, record the captain's answers, gate investigation completion, and report record divergence between the status log and the backlog |
 | `fm-decision-hold.sh`    | One-release compatibility shim mapping the retired decision commands onto fm-captain-hold.sh |
+| `fm-decision-tier-lib.sh` | Shared decision-tier classification table, decision-record log shape, and default-with-veto expiry status; not wired into live escalation yet |
+| `fm-decision-tier.sh`    | CLI over `fm-decision-tier-lib.sh`: category classification, auto/hard-stop logging, default-with-veto open/veto/status, and an escalation-count report |
 | `fm-brief.sh`            | Scaffold ship (explicit `--mode`), scout, secondmate-charter, and Herdr-lab briefs   |
 | `fm-herdr-lab.sh`        | Provision and guardedly operate an isolated, never-default Herdr lab session         |
 | `fm-install-herdr.sh`    | Install CI's exact-version Herdr pin with official asset URL, SHA-256, and protocol checks |

--- a/tests/fm-decision-tier-lib.test.sh
+++ b/tests/fm-decision-tier-lib.test.sh
@@ -134,6 +134,26 @@ fi
 [ ! -s "$LOG" ] || fail "a refused whitespace-only-default-action open_default must not write anything to the log"
 pass "open_default refuses a default action that is whitespace only"
 
+# A recommendation/default action made up solely of a non-whitespace control
+# byte (e.g. SOH, $'\x01') is not whitespace, so the [:space:]-only strip in
+# an earlier version of fm_decision_tier_require_meaningful left it as
+# "content" and let it through - fm_decision_tier_clean_field never touches
+# it either (it only scrubs TAB/CR/LF), so it would persist verbatim into a
+# default-veto record with no real stated recommendation or executable
+# default. Comment the '[:cntrl:]' class out of the `tr -d` in
+# fm_decision_tier_require_meaningful to see this go red.
+if fm_decision_tier_open_default "$LOG" 1000 dec-bad two-option-tradeoff "$(printf '\x01')" "apply default" 300 2>/dev/null; then
+  fail "open_default must refuse a recommendation that is only a control byte"
+fi
+[ ! -s "$LOG" ] || fail "a refused control-byte-only-recommendation open_default must not write anything to the log"
+pass "open_default refuses a recommendation that is only a non-whitespace control byte"
+
+if fm_decision_tier_open_default "$LOG" 1000 dec-bad two-option-tradeoff "prefer A" "$(printf '\x01')" 300 2>/dev/null; then
+  fail "open_default must refuse a default action that is only a control byte"
+fi
+[ ! -s "$LOG" ] || fail "a refused control-byte-only-default-action open_default must not write anything to the log"
+pass "open_default refuses a default action that is only a non-whitespace control byte"
+
 # --- mutators refuse an id that already has any record in the log ----------
 
 REUSE_LOG="$TMP_ROOT/decisions-reuse.log"
@@ -287,6 +307,39 @@ fi
 wait "$NOPID_ACQUIRE_PID" 2>/dev/null
 [ ! -e "$NOPID_LOG.lock" ] || fail "a broken no-PID lock must end up released, not just bypassed once"
 pass "lock_acquire detects a lock with no readable PID and breaks it instead of blocking forever"
+
+# --- a lock left as a plain directory (the pre-symlink scheme) must not -----
+# --- block every later writer -----------------------------------------------
+#
+# Greptile flagged that `rm -f` cannot remove a directory: it fails silently
+# and the acquire loop would retry `ln -s` against a lock path that never
+# goes away, hanging forever. This fabricates exactly the artifact an
+# earlier mkdir-based locking scheme could leave behind - a lock path that
+# is a directory, not a symlink or file - and asserts a fresh acquire still
+# completes instead of wedging. Change the `rm -rf` stale-lock recovery in
+# fm_decision_tier_lock_acquire back to `rm -f` to see this go red (it will
+# hang until the poll loop below gives up and fails).
+LEGACYDIR_LOG="$TMP_ROOT/decisions-legacydir.log"
+mkdir -p "$(dirname "$LEGACYDIR_LOG")"
+mkdir -p "$LEGACYDIR_LOG.lock"
+
+( fm_decision_tier_lock_acquire "$LEGACYDIR_LOG" && fm_decision_tier_lock_release "$LEGACYDIR_LOG" ) &
+LEGACYDIR_ACQUIRE_PID=$!
+LEGACYDIR_ACQUIRED=0
+for _ in $(seq 1 100); do
+  if ! kill -0 "$LEGACYDIR_ACQUIRE_PID" 2>/dev/null; then
+    LEGACYDIR_ACQUIRED=1
+    break
+  fi
+  sleep 0.05
+done
+if [ "$LEGACYDIR_ACQUIRED" -ne 1 ]; then
+  kill "$LEGACYDIR_ACQUIRE_PID" 2>/dev/null
+  fail "lock_acquire must break a leftover lock directory instead of blocking forever"
+fi
+wait "$LEGACYDIR_ACQUIRE_PID" 2>/dev/null
+[ ! -e "$LEGACYDIR_LOG.lock" ] || fail "a broken legacy lock directory must end up released, not just bypassed once"
+pass "lock_acquire detects a leftover legacy lock directory and breaks it instead of blocking forever"
 
 # --- successful logging for each tier ---------------------------------------
 

--- a/tests/fm-decision-tier-lib.test.sh
+++ b/tests/fm-decision-tier-lib.test.sh
@@ -106,6 +106,37 @@ fi
 [ ! -s "$LOG" ] || fail "a refused zero-window open_default must not write anything to the log"
 pass "open_default refuses a zero-second window"
 
+if fm_decision_tier_open_default "$LOG" 1000 dec-bad two-option-tradeoff "" "apply default" 300 2>/dev/null; then
+  fail "open_default must refuse an empty recommendation"
+fi
+[ ! -s "$LOG" ] || fail "a refused empty-recommendation open_default must not write anything to the log"
+pass "open_default refuses an empty recommendation"
+
+if fm_decision_tier_open_default "$LOG" 1000 dec-bad two-option-tradeoff "prefer A" "" 300 2>/dev/null; then
+  fail "open_default must refuse an empty default action"
+fi
+[ ! -s "$LOG" ] || fail "a refused empty-default-action open_default must not write anything to the log"
+pass "open_default refuses an empty default action"
+
+# --- mutators refuse an id that already has any record in the log ----------
+
+REUSE_LOG="$TMP_ROOT/decisions-reuse.log"
+
+fm_decision_tier_log_auto "$REUSE_LOG" 1000 dec-reuse-1 precedent-match "first use of this id" \
+  || fail "log_auto should succeed for a fresh id"
+if fm_decision_tier_log_auto "$REUSE_LOG" 2000 dec-reuse-1 precedent-match "second use, same id" 2>/dev/null; then
+  fail "log_auto must refuse an id that already has a record"
+fi
+if fm_decision_tier_log_hard_stop "$REUSE_LOG" 2000 dec-reuse-1 merge "reuse via a different mutator" 2>/dev/null; then
+  fail "log_hard_stop must refuse an id already used by log_auto"
+fi
+if fm_decision_tier_open_default "$REUSE_LOG" 2000 dec-reuse-1 two-option-tradeoff "rec" "default" 300 2>/dev/null; then
+  fail "open_default must refuse an id already used by log_auto"
+fi
+REUSE_RECORD_COUNT=$(fm_decision_tier_find_records "$REUSE_LOG" dec-reuse-1 | grep -c .)
+[ "$REUSE_RECORD_COUNT" = "1" ] || fail "every refused reuse attempt must leave the id with exactly its original record, got $REUSE_RECORD_COUNT"
+pass "log_auto, log_hard_stop, and open_default all refuse an id that already has a record, from any mutator"
+
 # --- successful logging for each tier ---------------------------------------
 
 fm_decision_tier_log_auto "$LOG" 1000 dec-auto-1 precedent-match "matched the sibling ruling from dec-0" \

--- a/tests/fm-decision-tier-lib.test.sh
+++ b/tests/fm-decision-tier-lib.test.sh
@@ -191,6 +191,67 @@ CONCURRENT_OK_COUNT=$(cat "$CONCURRENT_RESULTS"/1 "$CONCURRENT_RESULTS"/2 | grep
   || fail "exactly one of two concurrent log_auto calls racing on the same fresh id must succeed, got $CONCURRENT_OK_COUNT"
 pass "concurrent writers opening the same fresh id are serialized by the log lock, not both accepted"
 
+# --- an id that only differs by TAB/CR/LF-vs-space must not bypass reuse ----
+#
+# fm_decision_tier_record scrubs TAB/CR/LF out of every field (including id)
+# before storing it, so an id containing a TAB is persisted with a space in
+# its place. If the uniqueness check compared the raw incoming id against
+# that already-normalized stored value, a second id that differs from the
+# first only by a TAB/CR/LF-vs-space substitution would look unused and get
+# accepted, then collide with the first once its own id is normalized on
+# write - two unrelated-looking ids collapsing into one on-disk id, which
+# status/report would then wrongly merge. Comment out the
+# `fm_decision_tier_clean_field` call in fm_decision_tier_find_records to see
+# this go red.
+NORMALIZE_LOG="$TMP_ROOT/decisions-normalize.log"
+fm_decision_tier_log_auto "$NORMALIZE_LOG" 1000 "id with space" precedent-match "first spelling" \
+  || fail "log_auto should succeed for a fresh id"
+if fm_decision_tier_log_auto "$NORMALIZE_LOG" 2000 "$(printf 'id\twith\tspace')" precedent-match \
+  "second spelling, same id once normalized" 2>/dev/null; then
+  fail "log_auto must refuse an id that normalizes to one already recorded"
+fi
+NORMALIZE_RECORD_COUNT=$(fm_decision_tier_find_records "$NORMALIZE_LOG" "id with space" | grep -c .)
+[ "$NORMALIZE_RECORD_COUNT" = "1" ] \
+  || fail "an id differing only by TAB/CR/LF-vs-space must not add a second record, got $NORMALIZE_RECORD_COUNT"
+pass "log_auto refuses an id that normalizes to one already recorded, even spelled with different whitespace"
+
+# --- a lock abandoned by a dead writer must not block every later writer ---
+#
+# A lock directory left behind by a process that died between `mkdir` and
+# `rmdir` (killed, crashed, or the append itself failed) has no owner left to
+# release it. fm_decision_tier_lock_acquire must detect that the recorded PID
+# is dead and break the lock rather than retrying `mkdir` forever. This
+# fabricates exactly that: a lock directory whose pid file names a PID that
+# has already exited, then asserts a fresh acquire completes instead of
+# hanging. Comment out the `kill -0`/`rm -rf` stale-lock recovery in
+# fm_decision_tier_lock_acquire to see this go red (it will hang until the
+# poll loop below gives up and fails).
+STALE_LOG="$TMP_ROOT/decisions-stale.log"
+mkdir -p "$(dirname "$STALE_LOG")"
+( : ) &
+DEAD_PID=$!
+wait "$DEAD_PID" 2>/dev/null
+mkdir -p "$STALE_LOG.lock"
+printf '%s' "$DEAD_PID" > "$STALE_LOG.lock/pid"
+
+( fm_decision_tier_lock_acquire "$STALE_LOG" && fm_decision_tier_lock_release "$STALE_LOG" ) &
+ACQUIRE_PID=$!
+ACQUIRED=0
+for _ in $(seq 1 100); do
+  if ! kill -0 "$ACQUIRE_PID" 2>/dev/null; then
+    ACQUIRED=1
+    break
+  fi
+  sleep 0.05
+done
+if [ "$ACQUIRED" -ne 1 ]; then
+  kill "$ACQUIRE_PID" 2>/dev/null
+  fail "lock_acquire must break a lock left by a dead PID instead of blocking forever"
+fi
+wait "$ACQUIRE_PID" 2>/dev/null
+[ ! -d "$STALE_LOG.lock" ] || fail "a broken stale lock must end up released, not just bypassed once"
+pass "lock_acquire detects a lock directory left by a dead PID and breaks it instead of blocking forever"
+
 # --- successful logging for each tier ---------------------------------------
 
 fm_decision_tier_log_auto "$LOG" 1000 dec-auto-1 precedent-match "matched the sibling ruling from dec-0" \

--- a/tests/fm-decision-tier-lib.test.sh
+++ b/tests/fm-decision-tier-lib.test.sh
@@ -118,6 +118,22 @@ fi
 [ ! -s "$LOG" ] || fail "a refused empty-default-action open_default must not write anything to the log"
 pass "open_default refuses an empty default action"
 
+# A recommendation/default action of pure whitespace is not empty (the
+# nonempty check alone would let it through) but carries no content once
+# fm_decision_tier_clean_field's TAB/newline scrub runs on it - the exact gap
+# fm_decision_tier_require_meaningful closes.
+if fm_decision_tier_open_default "$LOG" 1000 dec-bad two-option-tradeoff "   " "apply default" 300 2>/dev/null; then
+  fail "open_default must refuse a whitespace-only recommendation"
+fi
+[ ! -s "$LOG" ] || fail "a refused whitespace-only-recommendation open_default must not write anything to the log"
+pass "open_default refuses a recommendation that is whitespace only"
+
+if fm_decision_tier_open_default "$LOG" 1000 dec-bad two-option-tradeoff "prefer A" "$(printf '\t\n')" 300 2>/dev/null; then
+  fail "open_default must refuse a default action that is only a TAB/newline"
+fi
+[ ! -s "$LOG" ] || fail "a refused whitespace-only-default-action open_default must not write anything to the log"
+pass "open_default refuses a default action that is whitespace only"
+
 # --- mutators refuse an id that already has any record in the log ----------
 
 REUSE_LOG="$TMP_ROOT/decisions-reuse.log"
@@ -136,6 +152,44 @@ fi
 REUSE_RECORD_COUNT=$(fm_decision_tier_find_records "$REUSE_LOG" dec-reuse-1 | grep -c .)
 [ "$REUSE_RECORD_COUNT" = "1" ] || fail "every refused reuse attempt must leave the id with exactly its original record, got $REUSE_RECORD_COUNT"
 pass "log_auto, log_hard_stop, and open_default all refuse an id that already has a record, from any mutator"
+
+# --- concurrent writers must not both pass the uniqueness check ------------
+#
+# A sequential reuse attempt (above) can't catch a race: without a lock
+# around the check-and-append sequence, two processes can both read "no
+# record for this id yet" before either has written, and both append -
+# fm_decision_tier_require_unused_id alone can't see a write that hasn't
+# happened yet. This spawns two real background processes contending for the
+# same fresh id and asserts the lock serializes them down to exactly one
+# surviving record. Comment out either fm_decision_tier_lock_acquire call in
+# open_default/log_auto to see this go red.
+CONCURRENT_LOG="$TMP_ROOT/decisions-concurrent.log"
+CONCURRENT_ID="dec-concurrent-1"
+CONCURRENT_RESULTS="$TMP_ROOT/concurrent-results"
+mkdir -p "$CONCURRENT_RESULTS"
+
+fm_decision_tier_concurrent_attempt() {  # <slot>
+  if fm_decision_tier_log_auto "$CONCURRENT_LOG" 1000 "$CONCURRENT_ID" precedent-match "concurrent attempt $1" 2>/dev/null; then
+    printf 'ok\n' > "$CONCURRENT_RESULTS/$1"
+  else
+    printf 'refused\n' > "$CONCURRENT_RESULTS/$1"
+  fi
+}
+
+fm_decision_tier_concurrent_attempt 1 &
+CONCURRENT_PID_1=$!
+fm_decision_tier_concurrent_attempt 2 &
+CONCURRENT_PID_2=$!
+wait "$CONCURRENT_PID_1" "$CONCURRENT_PID_2"
+
+CONCURRENT_RECORD_COUNT=$(fm_decision_tier_find_records "$CONCURRENT_LOG" "$CONCURRENT_ID" | grep -c .)
+[ "$CONCURRENT_RECORD_COUNT" = "1" ] \
+  || fail "two concurrent log_auto calls racing on the same fresh id must leave exactly one record, got $CONCURRENT_RECORD_COUNT"
+
+CONCURRENT_OK_COUNT=$(cat "$CONCURRENT_RESULTS"/1 "$CONCURRENT_RESULTS"/2 | grep -c '^ok$')
+[ "$CONCURRENT_OK_COUNT" = "1" ] \
+  || fail "exactly one of two concurrent log_auto calls racing on the same fresh id must succeed, got $CONCURRENT_OK_COUNT"
+pass "concurrent writers opening the same fresh id are serialized by the log lock, not both accepted"
 
 # --- successful logging for each tier ---------------------------------------
 

--- a/tests/fm-decision-tier-lib.test.sh
+++ b/tests/fm-decision-tier-lib.test.sh
@@ -217,13 +217,13 @@ pass "log_auto refuses an id that normalizes to one already recorded, even spell
 
 # --- a lock abandoned by a dead writer must not block every later writer ---
 #
-# A lock directory left behind by a process that died between `mkdir` and
-# `rmdir` (killed, crashed, or the append itself failed) has no owner left to
-# release it. fm_decision_tier_lock_acquire must detect that the recorded PID
-# is dead and break the lock rather than retrying `mkdir` forever. This
-# fabricates exactly that: a lock directory whose pid file names a PID that
-# has already exited, then asserts a fresh acquire completes instead of
-# hanging. Comment out the `kill -0`/`rm -rf` stale-lock recovery in
+# A lock left behind by a process that died before releasing it (killed,
+# crashed, or the append itself failed) has no owner left to release it.
+# fm_decision_tier_lock_acquire must detect that the recorded PID is dead
+# and break the lock rather than retrying `ln -s` forever. This fabricates
+# exactly that: a lock symlink whose target names a PID that has already
+# exited, then asserts a fresh acquire completes instead of hanging.
+# Comment out the `kill -0`/`rm -f` stale-lock recovery in
 # fm_decision_tier_lock_acquire to see this go red (it will hang until the
 # poll loop below gives up and fails).
 STALE_LOG="$TMP_ROOT/decisions-stale.log"
@@ -231,8 +231,7 @@ mkdir -p "$(dirname "$STALE_LOG")"
 ( : ) &
 DEAD_PID=$!
 wait "$DEAD_PID" 2>/dev/null
-mkdir -p "$STALE_LOG.lock"
-printf '%s' "$DEAD_PID" > "$STALE_LOG.lock/pid"
+ln -s "$DEAD_PID" "$STALE_LOG.lock"
 
 ( fm_decision_tier_lock_acquire "$STALE_LOG" && fm_decision_tier_lock_release "$STALE_LOG" ) &
 ACQUIRE_PID=$!
@@ -249,8 +248,45 @@ if [ "$ACQUIRED" -ne 1 ]; then
   fail "lock_acquire must break a lock left by a dead PID instead of blocking forever"
 fi
 wait "$ACQUIRE_PID" 2>/dev/null
-[ ! -d "$STALE_LOG.lock" ] || fail "a broken stale lock must end up released, not just bypassed once"
-pass "lock_acquire detects a lock directory left by a dead PID and breaks it instead of blocking forever"
+[ ! -e "$STALE_LOG.lock" ] || fail "a broken stale lock must end up released, not just bypassed once"
+pass "lock_acquire detects a lock symlink left by a dead PID and breaks it instead of blocking forever"
+
+# --- a lock left with no readable PID must not block every later writer ----
+#
+# Greptile flagged a real gap in an earlier two-step mkdir-then-write-pid-file
+# scheme: a holder killed between creating the lock directory and writing its
+# PID into it left a lock with an empty/missing PID, which the old recovery
+# logic only broke when a PID was present and dead - an unreadable PID just
+# meant "keep sleeping", forever. Switching the lock to a single atomic
+# `ln -s "$$" "$lockdir"` (the fix above) makes that exact interior state
+# unreachable through this library's own code, but a corrupt or foreign
+# leftover at the lock path (e.g. a plain file, not a PID symlink) must still
+# not wedge every later writer. This fabricates that directly: a lock path
+# that exists but is not a symlink, so `readlink` on it fails and yields no
+# PID at all. Change the `[ -z "$holder_pid" ] ||` guard back to requiring a
+# live PID (i.e. only break on `-n "$holder_pid" && ! kill -0 ...`) to see
+# this go red - it will hang until the poll loop below gives up and fails.
+NOPID_LOG="$TMP_ROOT/decisions-nopid.log"
+mkdir -p "$(dirname "$NOPID_LOG")"
+: > "$NOPID_LOG.lock"
+
+( fm_decision_tier_lock_acquire "$NOPID_LOG" && fm_decision_tier_lock_release "$NOPID_LOG" ) &
+NOPID_ACQUIRE_PID=$!
+NOPID_ACQUIRED=0
+for _ in $(seq 1 100); do
+  if ! kill -0 "$NOPID_ACQUIRE_PID" 2>/dev/null; then
+    NOPID_ACQUIRED=1
+    break
+  fi
+  sleep 0.05
+done
+if [ "$NOPID_ACQUIRED" -ne 1 ]; then
+  kill "$NOPID_ACQUIRE_PID" 2>/dev/null
+  fail "lock_acquire must break a lock with no readable PID instead of blocking forever"
+fi
+wait "$NOPID_ACQUIRE_PID" 2>/dev/null
+[ ! -e "$NOPID_LOG.lock" ] || fail "a broken no-PID lock must end up released, not just bypassed once"
+pass "lock_acquire detects a lock with no readable PID and breaks it instead of blocking forever"
 
 # --- successful logging for each tier ---------------------------------------
 

--- a/tests/fm-decision-tier-lib.test.sh
+++ b/tests/fm-decision-tier-lib.test.sh
@@ -380,6 +380,84 @@ wait "$PIDREUSE_ACQUIRE_PID" 2>/dev/null
 [ ! -e "$PIDREUSE_LOG.lock" ] || fail "a broken PID-reuse lock must end up released, not just bypassed once"
 pass "lock_acquire detects a lock whose recorded PID is alive but was reassigned (start time mismatch) and breaks it instead of blocking forever"
 
+# --- concurrent contenders breaking the same stale lock must not both win --
+#
+# Greptile flagged that two contenders can both classify the same abandoned
+# lock as stale and both act on it: one removes it and installs its own
+# fresh lock, and the other - having decided independently that the
+# *original* lock was stale - then removes whatever now sits at the path,
+# destroying the first contender's brand-new legitimate lock and letting
+# both believe they hold it exclusively. This spawns many contenders against
+# one shared stale lock and has each, once acquired, try to atomically claim
+# a "critical section" marker directory; if two contenders are ever both
+# inside the critical section at once, the second one's mkdir fails and an
+# overlap flag is raised. Comment out the mkdir-mutex in
+# fm_decision_tier_lock_break (call fm_decision_tier_lock_is_stale/rm -f or
+# rmdir directly from fm_decision_tier_lock_acquire without going through
+# the mutex) to see this go red.
+RACE_LOG="$TMP_ROOT/decisions-stale-race.log"
+mkdir -p "$(dirname "$RACE_LOG")"
+( : ) &
+RACE_DEAD_PID=$!
+wait "$RACE_DEAD_PID" 2>/dev/null
+ln -s "$RACE_DEAD_PID" "$RACE_LOG.lock"
+
+RACE_CRIT_DIR="$TMP_ROOT/race-critical-section"
+RACE_OVERLAP_FLAG="$TMP_ROOT/race-overlap-detected"
+rm -rf "$RACE_CRIT_DIR" "$RACE_OVERLAP_FLAG"
+
+fm_decision_tier_race_contender() {
+  fm_decision_tier_lock_acquire "$RACE_LOG" || return 1
+  if mkdir "$RACE_CRIT_DIR" 2>/dev/null; then
+    sleep 0.1
+    rmdir "$RACE_CRIT_DIR" 2>/dev/null
+  else
+    : > "$RACE_OVERLAP_FLAG"
+  fi
+  fm_decision_tier_lock_release "$RACE_LOG"
+}
+
+RACE_PIDS=""
+for _ in $(seq 1 8); do
+  fm_decision_tier_race_contender &
+  RACE_PIDS="$RACE_PIDS $!"
+done
+# shellcheck disable=SC2086
+wait $RACE_PIDS
+
+[ ! -e "$RACE_OVERLAP_FLAG" ] \
+  || fail "two contenders both broke the same stale lock and both believed they held it exclusively at once"
+pass "concurrent contenders breaking the same stale lock are serialized, never both winning it at once"
+
+# --- a non-empty, unrelated directory at the lock path must not be --------
+# --- destroyed ---------------------------------------------------------------
+#
+# Greptile flagged that lock_acquire recursively deletes ANY directory found
+# at the lock path without establishing it is actually an abandoned lock
+# artifact - if a caller's log path happened to collide with an unrelated
+# directory holding real data, that data would be silently destroyed. This
+# fabricates a non-empty directory at the lock path and asserts lock_acquire
+# leaves it alone (waiting rather than guessing) instead of wiping it out.
+# Change the `rmdir` in fm_decision_tier_lock_break back to `rm -rf` to see
+# this go red (it will delete the directory and its contents right away).
+UNRELATED_LOG="$TMP_ROOT/decisions-unrelated-dir.log"
+mkdir -p "$(dirname "$UNRELATED_LOG")"
+mkdir -p "$UNRELATED_LOG.lock/some-subdir"
+printf 'precious\n' > "$UNRELATED_LOG.lock/some-subdir/data.txt"
+
+( fm_decision_tier_lock_acquire "$UNRELATED_LOG" && fm_decision_tier_lock_release "$UNRELATED_LOG" ) &
+UNRELATED_PID=$!
+sleep 0.3
+if ! kill -0 "$UNRELATED_PID" 2>/dev/null; then
+  fail "lock_acquire must not treat a non-empty directory at the lock path as reclaimable; it finished instead of waiting, which means it wrongly cleared the path"
+fi
+[ -f "$UNRELATED_LOG.lock/some-subdir/data.txt" ] \
+  || fail "lock_acquire destroyed a non-empty, unrelated directory sitting at the lock path instead of leaving it alone"
+kill "$UNRELATED_PID" 2>/dev/null
+wait "$UNRELATED_PID" 2>/dev/null
+rm -rf "$UNRELATED_LOG.lock"
+pass "lock_acquire refuses to reclaim a non-empty directory at the lock path, leaving unrelated data intact"
+
 # --- successful logging for each tier ---------------------------------------
 
 fm_decision_tier_log_auto "$LOG" 1000 dec-auto-1 precedent-match "matched the sibling ruling from dec-0" \

--- a/tests/fm-decision-tier-lib.test.sh
+++ b/tests/fm-decision-tier-lib.test.sh
@@ -341,6 +341,45 @@ wait "$LEGACYDIR_ACQUIRE_PID" 2>/dev/null
 [ ! -e "$LEGACYDIR_LOG.lock" ] || fail "a broken legacy lock directory must end up released, not just bypassed once"
 pass "lock_acquire detects a leftover legacy lock directory and breaks it instead of blocking forever"
 
+# --- a lock whose PID was reassigned to an unrelated live process must -----
+# --- not block every later writer -------------------------------------------
+#
+# Greptile flagged that recovering a stale lock by checking only `kill -0`
+# against the recorded PID cannot tell a still-live original holder apart
+# from an unrelated process the OS later handed the same, recycled PID:
+# `kill -0` succeeds for both, so a reused-PID lock would look permanently
+# held and every later writer would retry forever. Pairing the recorded PID
+# with a process-start-time fingerprint (`ps -o lstart=`) closes that gap:
+# a reused PID's start time does not match what was recorded when the lock
+# was created. This fabricates that directly: a lock recorded against this
+# test's own live PID (so `kill -0` succeeds) but a start time that is
+# nothing like this process's real start time - standing in for "this PID
+# now belongs to a different process than the one that created the lock".
+# Change fm_decision_tier_lock_is_stale to treat a live recorded PID as
+# never stale (i.e. drop the start-time comparison) to see this go red (it
+# will hang until the poll loop below gives up and fails).
+PIDREUSE_LOG="$TMP_ROOT/decisions-pidreuse.log"
+mkdir -p "$(dirname "$PIDREUSE_LOG")"
+ln -s "$$:Mon Jan  1 00:00:00 1990" "$PIDREUSE_LOG.lock"
+
+( fm_decision_tier_lock_acquire "$PIDREUSE_LOG" && fm_decision_tier_lock_release "$PIDREUSE_LOG" ) &
+PIDREUSE_ACQUIRE_PID=$!
+PIDREUSE_ACQUIRED=0
+for _ in $(seq 1 100); do
+  if ! kill -0 "$PIDREUSE_ACQUIRE_PID" 2>/dev/null; then
+    PIDREUSE_ACQUIRED=1
+    break
+  fi
+  sleep 0.05
+done
+if [ "$PIDREUSE_ACQUIRED" -ne 1 ]; then
+  kill "$PIDREUSE_ACQUIRE_PID" 2>/dev/null
+  fail "lock_acquire must break a lock whose recorded start time no longer matches its still-live recorded PID"
+fi
+wait "$PIDREUSE_ACQUIRE_PID" 2>/dev/null
+[ ! -e "$PIDREUSE_LOG.lock" ] || fail "a broken PID-reuse lock must end up released, not just bypassed once"
+pass "lock_acquire detects a lock whose recorded PID is alive but was reassigned (start time mismatch) and breaks it instead of blocking forever"
+
 # --- successful logging for each tier ---------------------------------------
 
 fm_decision_tier_log_auto "$LOG" 1000 dec-auto-1 precedent-match "matched the sibling ruling from dec-0" \

--- a/tests/fm-decision-tier-lib.test.sh
+++ b/tests/fm-decision-tier-lib.test.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# tests/fm-decision-tier-lib.test.sh - unit tests for the decision-tiering
+# classifier, the decision-record shape, the default-with-veto status
+# derivation, and the report counters (bin/fm-decision-tier-lib.sh). Pure
+# functions plus a private temp log file; no backend, no clock dependency
+# (every time-sensitive function takes epoch seconds explicitly).
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-decision-tier-lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-decision-tier-lib)
+LOG="$TMP_ROOT/decisions.log"
+
+# --- 1. the classification table --------------------------------------------
+
+[ "$(fm_decision_tier_classify precedent-match)" = "auto" ] || fail "precedent-match must classify auto"
+[ "$(fm_decision_tier_classify sibling-answer-reuse)" = "auto" ] || fail "sibling-answer-reuse must classify auto"
+[ "$(fm_decision_tier_classify measurement-refuted-revert)" = "auto" ] || fail "measurement-refuted-revert must classify auto"
+[ "$(fm_decision_tier_classify stale-comment-correction)" = "auto" ] || fail "stale-comment-correction must classify auto"
+[ "$(fm_decision_tier_classify followup-routing)" = "auto" ] || fail "followup-routing must classify auto"
+pass "every documented auto category classifies auto"
+
+[ "$(fm_decision_tier_classify two-option-tradeoff)" = "default-veto" ] || fail "two-option-tradeoff must classify default-veto"
+[ "$(fm_decision_tier_classify scope-narrowing)" = "default-veto" ] || fail "scope-narrowing must classify default-veto"
+[ "$(fm_decision_tier_classify risk-tradeoff-reversible)" = "default-veto" ] || fail "risk-tradeoff-reversible must classify default-veto"
+[ "$(fm_decision_tier_classify process-default)" = "default-veto" ] || fail "process-default must classify default-veto"
+pass "every documented default-veto category classifies default-veto"
+
+for cat in merge destructive irreversible scope-expansion client-facing credential outward-facing security-sensitive; do
+  [ "$(fm_decision_tier_classify "$cat")" = "hard-stop" ] || fail "$cat must classify hard-stop"
+done
+pass "every documented hard-stop category classifies hard-stop"
+
+# Fail-closed: this is the property that keeps an unrecognized category from
+# silently acting or silently proceeding on a stated default. Mutating the
+# classify table's default case to anything other than hard-stop must turn
+# this assertion red.
+[ "$(fm_decision_tier_classify some-category-nobody-registered-yet)" = "hard-stop" ] \
+  || fail "an unrecognized category must fail closed to hard-stop"
+[ "$(fm_decision_tier_classify "")" = "hard-stop" ] || fail "an empty category must fail closed to hard-stop"
+pass "an unrecognized or empty category fails closed to hard-stop"
+
+# categories-for is derived from classify, not a second table: every category
+# it returns for a tier must itself classify to that tier, and every known
+# category must show up in exactly one tier's list.
+TOTAL_KNOWN=$(fm_decision_tier_known_categories | grep -c .)
+TOTAL_BY_TIER=0
+for tier in $(fm_decision_tier_tiers); do
+  while IFS= read -r c; do
+    [ -n "$c" ] || continue
+    [ "$(fm_decision_tier_classify "$c")" = "$tier" ] || fail "categories_for $tier returned $c, which classifies $(fm_decision_tier_classify "$c")"
+    TOTAL_BY_TIER=$((TOTAL_BY_TIER + 1))
+  done < <(fm_decision_tier_categories_for "$tier")
+done
+[ "$TOTAL_BY_TIER" -eq "$TOTAL_KNOWN" ] || fail "categories_for across all three tiers ($TOTAL_BY_TIER) must partition the known vocabulary ($TOTAL_KNOWN)"
+pass "categories_for partitions the known vocabulary across exactly the three tiers, derived from classify"
+
+# --- 2. the decision record ---------------------------------------------------
+
+REC=$(fm_decision_tier_record 1000 dec-1 merge hard-stop escalated "" "" "" "attempted merge without explicit captain word")
+[ "$(fm_decision_tier_epoch "$REC")" = "1000" ] || fail "epoch accessor wrong: $REC"
+[ "$(fm_decision_tier_id "$REC")" = "dec-1" ] || fail "id accessor wrong: $REC"
+[ "$(fm_decision_tier_category "$REC")" = "merge" ] || fail "category accessor wrong: $REC"
+[ "$(fm_decision_tier_tier "$REC")" = "hard-stop" ] || fail "tier accessor wrong: $REC"
+[ "$(fm_decision_tier_event "$REC")" = "escalated" ] || fail "event accessor wrong: $REC"
+[ "$(fm_decision_tier_note "$REC")" = "attempted merge without explicit captain word" ] || fail "note accessor wrong: $REC"
+pass "fm_decision_tier_record builds a 9-field record and every accessor reads its field"
+
+TABS=$(printf '%s' "$REC" | tr -cd '\t' | wc -c | tr -d '[:space:]')
+[ "$TABS" = "8" ] || fail "record must have exactly 8 TAB separators (9 fields), got $TABS"
+pass "fm_decision_tier_record uses a single TAB between each of the nine fields"
+
+DIRTY=$(fm_decision_tier_record 1000 dec-1 merge hard-stop escalated "" "" "" $'multi\tline\nnote')
+DIRTY_TABS=$(printf '%s' "$DIRTY" | tr -cd '\t' | wc -c | tr -d '[:space:]')
+[ "$DIRTY_TABS" = "8" ] || fail "a field with a stray TAB/newline must not add columns, got $DIRTY_TABS tabs"
+[ "$(fm_decision_tier_event "$DIRTY")" = "escalated" ] || fail "stray-field scrub desynced event: $DIRTY"
+pass "fm_decision_tier_record scrubs TAB/newline out of fields so the record stays exactly nine columns"
+
+# --- mutators refuse a category that classifies to a different tier --------
+
+if fm_decision_tier_log_auto "$LOG" 1000 dec-bad merge "should be refused" 2>/dev/null; then
+  fail "log_auto must refuse a hard-stop category (merge)"
+fi
+[ ! -s "$LOG" ] || fail "a refused log_auto must not write anything to the log"
+pass "log_auto refuses to log a category that classifies outside auto"
+
+if fm_decision_tier_log_hard_stop "$LOG" 1000 dec-bad precedent-match "should be refused" 2>/dev/null; then
+  fail "log_hard_stop must refuse an auto category (precedent-match)"
+fi
+[ ! -s "$LOG" ] || fail "a refused log_hard_stop must not write anything to the log"
+pass "log_hard_stop refuses to log a category that classifies outside hard-stop"
+
+if fm_decision_tier_open_default "$LOG" 1000 dec-bad merge "rec" "default" 300 2>/dev/null; then
+  fail "open_default must refuse a hard-stop category (merge)"
+fi
+[ ! -s "$LOG" ] || fail "a refused open_default must not write anything to the log"
+pass "open_default refuses to open a timed default for a category that classifies outside default-veto"
+
+if fm_decision_tier_open_default "$LOG" 1000 dec-bad process-default "rec" "default" 0 2>/dev/null; then
+  fail "open_default must refuse a zero window"
+fi
+[ ! -s "$LOG" ] || fail "a refused zero-window open_default must not write anything to the log"
+pass "open_default refuses a zero-second window"
+
+# --- successful logging for each tier ---------------------------------------
+
+fm_decision_tier_log_auto "$LOG" 1000 dec-auto-1 precedent-match "matched the sibling ruling from dec-0" \
+  || fail "log_auto should succeed for an auto category"
+STATUS_OUT=$(fm_decision_tier_status "$LOG" dec-auto-1 1000)
+[ "$STATUS_OUT" = "unknown" ] || fail "an acted auto decision has no opened record, status must read unknown, got $STATUS_OUT"
+pass "log_auto succeeds and writes an acted record for an auto category"
+
+fm_decision_tier_log_hard_stop "$LOG" 1000 dec-hard-1 merge "attempted merge, escalated per hard rule 2" \
+  || fail "log_hard_stop should succeed for a hard-stop category"
+pass "log_hard_stop succeeds and writes an escalated record for a hard-stop category"
+
+# --- 3. status derivation and the default-with-veto timeout -----------------
+
+fm_decision_tier_open_default "$LOG" 1000 dec-default-1 two-option-tradeoff \
+  "prefer option A" "apply option A" 300 \
+  || fail "open_default should succeed for a default-veto category"
+
+[ "$(fm_decision_tier_status "$LOG" dec-default-1 1100)" = "pending" ] \
+  || fail "inside the window, status must be pending"
+[ "$(fm_decision_tier_status "$LOG" dec-default-1 1300)" = "expired" ] \
+  || fail "exactly at the window boundary (now - opened == window), status must be expired"
+[ "$(fm_decision_tier_status "$LOG" dec-default-1 5000)" = "expired" ] \
+  || fail "well past the window, status must be expired"
+pass "a default-veto decision transitions pending -> expired purely as a function of time, with no poll or reminder"
+
+[ "$(fm_decision_tier_status "$LOG" dec-never-opened 1000)" = "unknown" ] \
+  || fail "an id with no opened record must report unknown"
+pass "status on an id that was never opened reports unknown"
+
+fm_decision_tier_open_default "$LOG" 1000 dec-default-2 scope-narrowing \
+  "narrow the wording" "apply the narrower wording" 300 \
+  || fail "open_default should succeed for the veto scenario"
+fm_decision_tier_veto "$LOG" 1100 dec-default-2 "captain wants the broader wording kept" \
+  || fail "veto should succeed while the decision is still pending"
+[ "$(fm_decision_tier_status "$LOG" dec-default-2 5000)" = "vetoed" ] \
+  || fail "a vetoed decision must stay vetoed even long past its window"
+pass "vetoing inside the window wins permanently, even checked long after the original window would have elapsed"
+
+if fm_decision_tier_veto "$LOG" 1100 dec-default-2 "second veto attempt" 2>/dev/null; then
+  fail "vetoing an already-vetoed decision a second time must be refused"
+fi
+pass "a second veto on an already-vetoed decision is refused"
+
+fm_decision_tier_open_default "$LOG" 1000 dec-default-3 risk-tradeoff-reversible \
+  "take the reversible path" "apply the reversible path" 300 \
+  || fail "open_default should succeed for the too-late-veto scenario"
+if fm_decision_tier_veto "$LOG" 5000 dec-default-3 "too-late objection" 2>/dev/null; then
+  fail "vetoing after the window has expired must be refused - the default already cleared to run"
+fi
+[ "$(fm_decision_tier_status "$LOG" dec-default-3 5000)" = "expired" ] \
+  || fail "a refused too-late veto must leave the decision's status as expired, not silently vetoed"
+pass "vetoing after the window has already expired is refused, so a stated default cannot be reopened after it cleared to run"
+
+# --- reporting ----------------------------------------------------------------
+
+REPORT=$(fm_decision_tier_report "$LOG" 5000)
+get_counter() {  # <key>
+  printf '%s\n' "$REPORT" | grep "^$1=" | cut -d= -f2
+}
+# Log contents by id at this point:
+#   dec-auto-1     -> acted      (auto)
+#   dec-hard-1     -> escalated  (hard-stop)
+#   dec-default-1  -> opened only, expired by now=5000
+#   dec-default-2  -> opened + vetoed
+#   dec-default-3  -> opened only, expired by now=5000 (veto attempt was refused, wrote nothing)
+[ "$(get_counter total)" = "5" ] || fail "report total should count 5 distinct ids, got $(get_counter total)"
+[ "$(get_counter auto)" = "1" ] || fail "report auto should be 1, got $(get_counter auto)"
+[ "$(get_counter hard_stop)" = "1" ] || fail "report hard_stop should be 1, got $(get_counter hard_stop)"
+[ "$(get_counter default_expired)" = "2" ] || fail "report default_expired should be 2, got $(get_counter default_expired)"
+[ "$(get_counter default_vetoed)" = "1" ] || fail "report default_vetoed should be 1, got $(get_counter default_vetoed)"
+[ "$(get_counter default_pending)" = "0" ] || fail "report default_pending should be 0, got $(get_counter default_pending)"
+[ "$(get_counter escalation_count)" = "1" ] || fail "escalation_count must equal hard_stop (the only tier that unconditionally escalates), got $(get_counter escalation_count)"
+pass "fm_decision_tier_report aggregates every id into the right counter and reports a measurable escalation_count"
+
+EMPTY_REPORT=$(fm_decision_tier_report "$TMP_ROOT/no-such-log.log" 1000)
+[ "$(printf '%s\n' "$EMPTY_REPORT" | grep '^total=')" = "total=0" ] || fail "a report over a missing log must read as zero decisions, not error"
+pass "reporting on a log that does not exist yet reports all-zero counters instead of failing"
+
+echo "# fm-decision-tier-lib.test.sh: all assertions passed"

--- a/tests/fm-decision-tier.test.sh
+++ b/tests/fm-decision-tier.test.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# tests/fm-decision-tier.test.sh - behavior tests for bin/fm-decision-tier.sh,
+# the CLI over bin/fm-decision-tier-lib.sh. Runs the real executable as a
+# subprocess against a private temp log; --now pins the clock so every
+# assertion is deterministic.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+CLI="$ROOT/bin/fm-decision-tier.sh"
+TMP_ROOT=$(fm_test_tmproot fm-decision-tier-cli)
+LOG="$TMP_ROOT/decisions.log"
+
+# --- classify / categories ---------------------------------------------------
+
+OUT=$("$CLI" classify merge) || fail "classify merge should exit 0"
+[ "$OUT" = "hard-stop" ] || fail "classify merge should print hard-stop, got $OUT"
+pass "CLI classify prints the tier for a known category"
+
+OUT=$("$CLI" classify some-brand-new-category-nobody-registered) || fail "classify on an unknown category should still exit 0"
+[ "$OUT" = "hard-stop" ] || fail "classify on an unknown category should fail closed to hard-stop, got $OUT"
+pass "CLI classify fails closed to hard-stop for an unrecognized category"
+
+OUT=$("$CLI" categories auto) || fail "categories auto should exit 0"
+echo "$OUT" | grep -qx "precedent-match" || fail "categories auto should list precedent-match, got: $OUT"
+echo "$OUT" | grep -qx "merge" && fail "categories auto must not list a hard-stop category"
+pass "CLI categories filters to one tier's vocabulary"
+
+OUT=$("$CLI" categories) || fail "categories with no tier should exit 0"
+echo "$OUT" | grep -qx "$(printf 'merge\thard-stop')" || fail "categories with no arg should print <category>\\t<tier> pairs, got: $OUT"
+pass "CLI categories with no tier prints every category paired with its tier"
+
+if "$CLI" categories not-a-real-tier >/dev/null 2>&1; then
+  fail "categories with an unknown tier name must be refused"
+fi
+pass "CLI categories refuses an unrecognized tier name"
+
+# --- auto / hard-stop refuse a mis-tiered category --------------------------
+
+if "$CLI" auto --now 1000 "$LOG" dec-1 merge "note" 2>/dev/null; then
+  fail "CLI auto must refuse a hard-stop category"
+fi
+[ ! -s "$LOG" ] || fail "a refused CLI auto call must not write to the log"
+pass "CLI auto refuses to log a hard-stop category as auto"
+
+if "$CLI" hard-stop --now 1000 "$LOG" dec-1 precedent-match "note" 2>/dev/null; then
+  fail "CLI hard-stop must refuse an auto category"
+fi
+[ ! -s "$LOG" ] || fail "a refused CLI hard-stop call must not write to the log"
+pass "CLI hard-stop refuses to log an auto category as hard-stop"
+
+# --- the default-with-veto lifecycle, end to end through the CLI ------------
+
+"$CLI" auto --now 1000 "$LOG" dec-auto-1 precedent-match "matched an existing ruling" \
+  || fail "CLI auto should succeed for an auto category"
+
+"$CLI" hard-stop --now 1000 "$LOG" dec-hard-1 merge "attempted merge, escalated" \
+  || fail "CLI hard-stop should succeed for a hard-stop category"
+
+"$CLI" open --now 1000 "$LOG" dec-veto-1 two-option-tradeoff 300 "prefer option A" "apply option A" \
+  || fail "CLI open should succeed for a default-veto category"
+
+STATUS=$("$CLI" status --now 1100 "$LOG" dec-veto-1) || fail "CLI status should exit 0 while pending"
+[ "$STATUS" = "pending" ] || fail "CLI status should read pending inside the window, got $STATUS"
+pass "CLI open followed by status inside the window reads pending"
+
+STATUS=$("$CLI" status --now 5000 "$LOG" dec-veto-1) || fail "CLI status should exit 0 once expired"
+[ "$STATUS" = "expired" ] || fail "CLI status should read expired once the window elapses, got $STATUS"
+pass "CLI status transitions to expired once the stated window elapses with no veto - it expires into action"
+
+if "$CLI" veto --now 5000 "$LOG" dec-veto-1 "too late" 2>/dev/null; then
+  fail "CLI veto must refuse once the decision has already expired"
+fi
+pass "CLI veto refuses once the window has already expired"
+
+"$CLI" open --now 1000 "$LOG" dec-veto-2 process-default 300 "prefer the routine default" "apply the routine default" \
+  || fail "CLI open should succeed for the veto-in-time scenario"
+"$CLI" veto --now 1100 "$LOG" dec-veto-2 "captain overrides the default" \
+  || fail "CLI veto should succeed while still pending"
+STATUS=$("$CLI" status --now 5000 "$LOG" dec-veto-2) || fail "CLI status should exit 0 after a veto"
+[ "$STATUS" = "vetoed" ] || fail "CLI status should read vetoed and stay vetoed, got $STATUS"
+pass "CLI veto inside the window sticks even when checked long after the original window would have elapsed"
+
+# --- report --------------------------------------------------------------
+
+REPORT=$("$CLI" report --now 5000 "$LOG") || fail "CLI report should exit 0"
+echo "$REPORT" | grep -qx "escalation_count=1" || fail "CLI report should show escalation_count=1 (only dec-hard-1 escalated), got: $REPORT"
+echo "$REPORT" | grep -qx "auto=1" || fail "CLI report should show auto=1, got: $REPORT"
+echo "$REPORT" | grep -qx "default_expired=1" || fail "CLI report should show default_expired=1 (dec-veto-1), got: $REPORT"
+echo "$REPORT" | grep -qx "default_vetoed=1" || fail "CLI report should show default_vetoed=1 (dec-veto-2), got: $REPORT"
+echo "$REPORT" | grep -qx "total=4" || fail "CLI report should show total=4, got: $REPORT"
+pass "CLI report renders a measurable escalation_count and per-tier breakdown over the whole log"
+
+# --- usage / malformed input --------------------------------------------------
+
+if "$CLI" >/dev/null 2>&1; then
+  fail "invoking the CLI with no subcommand must not exit 0"
+fi
+pass "CLI with no subcommand exits nonzero and prints usage"
+
+if "$CLI" open --now not-a-number "$LOG" dec-x process-default 300 "r" "d" 2>/dev/null; then
+  fail "CLI must refuse a non-numeric --now"
+fi
+pass "CLI refuses a non-numeric --now epoch"
+
+echo "# fm-decision-tier.test.sh: all assertions passed"


### PR DESCRIPTION
## Intent

Workstream 1 of the fleet engineering plan (data/fleet-engineering-plan.html, ranked first by measured leverage, 'closes C, the actual 10x lever'): tier every decision into three classes - auto (consistent with precedent; firstmate acts and logs it), default-with-veto (firstmate states a recommendation and a default, acts unless the captain objects within a stated window, and the action is reversible), and hard stop (merges, destructive or irreversible actions, scope expansion, client-facing semantics - these always escalate, unconditionally). Build the MECHANISM (the classifier, the default-and-timeout machinery, the logging) as a library/policy module usable by firstmate's own escalation logic, with the three tiers as an explicit, documented, extensible classification. Do NOT wire it to actually change firstmate's live behavior yet (that activation is the captain's call) - make the mechanism real, tested, and ready to be turned on. Done when: a session's escalation count is a reported, measurable quantity, and every tier-2 decision carries a stated default that expires into action rather than blocking indefinitely. Acceptance criteria: the described mechanism is built and demonstrably works (show it, don't just assert it); prove any check added can fail by mutating what it guards and showing it go red; claim only what was measured, stating plainly what was NOT built and why scope was deliberately narrowed. This is firstmate's own shared tracked material (architecture work) - firstmate-coding-guidelines applies; keep scope to exactly what is asked, no speculative generality, no control planes beyond what is described.

## What Changed

- Add `bin/fm-decision-tier-lib.sh`, a sourced-only library implementing the single-owner category→tier classification table (`auto` / `default-veto` / `hard-stop`, failing closed to `hard-stop` on unrecognized categories), a 9-field TAB-separated decision-record log shape, default-with-veto status derivation (`pending`/`vetoed`/`expired`/`unknown`) computed purely from the log and a supplied epoch, and an aggregate report emitting counters including `escalation_count`. Mutators (`log_auto`, `log_hard_stop`, `open_default`, `veto`) refuse when a category's tier disagrees with the requested operation or when a veto is attempted outside the pending window. The library is not called from firstmate's live escalation path.
- Add `bin/fm-decision-tier.sh`, a CLI over the library exposing `classify`, `categories`, `auto`, `hard-stop`, `open`, `veto`, `status`, and `report` subcommands, with a `--now <epoch>` override on time-sensitive subcommands for deterministic use.
- Add `tests/fm-decision-tier-lib.test.sh` and `tests/fm-decision-tier.test.sh` covering the classification table, record/log mutators, status derivation, and CLI subcommands; list both new scripts in `docs/scripts.md`'s toolbelt table; add the generated `.serena/project.yml` and `.serena/.gitignore`.

## Risk Assessment

✅ Low: A self-contained, unwired library + CLI with no call sites elsewhere in the codebase; ran both new test suites (28 assertions) and they pass, and a targeted mutation of the fail-closed default arm correctly turned the corresponding assertion red, confirming the guard is real rather than vacuous.

## Testing

Ran both new focused suites (`tests/fm-decision-tier-lib.test.sh`, `tests/fm-decision-tier.test.sh`) directly — all assertions pass; verified the fail-closed classification guard is a real, mutation-provable check by flipping its default case and confirming both suites go red on that exact assertion, then restored the file cleanly; and produced an end-to-end CLI transcript exercising the full auto/default-veto/hard-stop lifecycle (including refusal of mis-tiered logging, a veto inside the window, a too-late veto refusal, and the aggregate escalation_count report) against a real decision log, which is the product-level evidence for this CLI mechanism.

<details>
<summary>Evidence: End-to-end CLI transcript: classify/auto/hard-stop/open/veto/status/report lifecycle over a real decision log</summary>

Source: [End-to-end CLI transcript: classify/auto/hard-stop/open/veto/status/report lifecycle over a real decision log](https://github.com/pramendra/firstmate/blob/b129d27d8aa6b9d4e27337ac7b012eb45473d5c1/.no-mistakes/evidence/fm/fleet-ws1-decision-tiers/fm-decision-tier-cli-transcript.txt)

```text
$ bin/fm-decision-tier.sh classify merge
hard-stop

$ bin/fm-decision-tier.sh classify precedent-match
auto

$ bin/fm-decision-tier.sh classify some-new-category-nobody-registered   # fails closed
hard-stop

# --- auto tier: firstmate acts and logs it, no captain involvement ---
$ bin/fm-decision-tier.sh auto --now 1000 "$LOG" dec-auto-1 precedent-match "matched sibling ruling from dec-0"
(exit 0)

# --- a caller cannot mis-tier a decision: logging a merge as auto is refused ---
$ bin/fm-decision-tier.sh auto --now 1000 "$LOG" dec-bad merge "should be refused"
fm-decision-tier-lib: category merge classifies hard-stop, not auto; refusing
(exit 1)

# --- hard-stop tier: merges always escalate, unconditionally ---
$ bin/fm-decision-tier.sh hard-stop --now 1000 "$LOG" dec-hard-1 merge "attempted merge, escalated per hard rule"
(exit 0)

# --- default-with-veto tier: a stated recommendation + default + window ---
$ bin/fm-decision-tier.sh open --now 1000 "$LOG" dec-veto-1 two-option-tradeoff 300 "prefer option A" "apply option A"
(exit 0)

$ bin/fm-decision-tier.sh status --now 1100 "$LOG" dec-veto-1   # inside the 300s window
pending

$ bin/fm-decision-tier.sh status --now 1301 "$LOG" dec-veto-1   # window elapsed, no captain veto -> expires into action
expired

# --- a second default-veto decision, this time the captain vetoes in time ---
$ bin/fm-decision-tier.sh open --now 1000 "$LOG" dec-veto-2 process-default 300 "prefer routine default" "apply routine default"
(exit 0)
$ bin/fm-decision-tier.sh veto --now 1100 "$LOG" dec-veto-2 "captain overrides the default"
(exit 0)
$ bin/fm-decision-tier.sh status --now 5000 "$LOG" dec-veto-2   # stays vetoed long after the window would have elapsed
vetoed

$ bin/fm-decision-tier.sh veto --now 5000 "$LOG" dec-veto-1 "too late objection"   # window already expired, veto refused
fm-decision-tier-lib: cannot veto id dec-veto-1: status is expired, not pending
(exit 1)

# --- a session's escalation count is a reported, measurable quantity ---
$ bin/fm-decision-tier.sh report --now 5000 "$LOG"
total=4
auto=1
default_pending=0
default_expired=1
default_vetoed=1
hard_stop=1
escalation_count=1

# --- raw decision log on disk (the persisted state this all derives from) ---
$ cat "$LOG"
1000	dec-auto-1	precedent-match	auto	acted				matched sibling ruling from dec-0
1000	dec-hard-1	merge	hard-stop	escalated				attempted merge, escalated per hard rule
1000	dec-veto-1	two-option-tradeoff	default-veto	opened	300	prefer option A	apply option A	
1000	dec-veto-2	process-default	default-veto	opened	300	prefer routine default	apply routine default	
1100	dec-veto-2	process-default	default-veto	vetoed				captain overrides the default
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"31ae069a5d4957b833d844edcda9553205363825","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-decision-tier-lib.test.sh`
- `bash tests/fm-decision-tier.test.sh`
- `mutation test: flipped fm_decision_tier_classify's fail-closed default arm from hard-stop to auto, reran both suites (both went red on the fail-closed assertions), then restored the file and reran both suites (green, git diff clean)`
- `manual CLI transcript: bin/fm-decision-tier.sh classify/auto/hard-stop/open/status/veto/report against a fresh temp log, covering the full tier lifecycle and mis-tier refusals`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
