### PR TITLE
fix(bin): forbid administering the shared worktree pool in crewmate briefs

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -48,6 +48,10 @@
 # to launch a ship task whose explicit --mode disagrees, so an adjusted brief and the
 # recorded task metadata cannot drift apart.
 # Ship briefs begin with a worktree-isolation assertion before the branch step.
+# Both crewmate scaffolds carry one shared rule against administering the
+# infrastructure every lane shares - the no-mistakes daemon and the worktree pool
+# their own slot came from - so ship and scout cannot drift apart. A secondmate
+# charter omits it: that home allocates and returns slots for its own crewmates.
 # --mode is refused on scout and secondmate scaffolds: a scout's deliverable is a
 # report rather than a merge, and a charter is not a delivery contract.
 # There is no --yolo flag here. The worker never owns merge decisions, so yolo is
@@ -353,6 +357,39 @@ IFS= read -r -d '' TASK_SECTION <<'EOF' || true
 EOF
 TASK_SECTION=${TASK_SECTION%$'\n'}
 
+# One shared string for both crewmate scaffolds (issue #2340): a crewmate
+# destroyed five pooled worktrees, four under live tasks, because "stay inside
+# this worktree" is a rule about files and never reached pool administration.
+# Ship and scout must carry the identical rule, so it is written once here
+# rather than copied into each heredoc where the two could drift apart. The
+# secondmate charter deliberately does not carry it: a secondmate runs its own
+# home and legitimately allocates and returns slots for its own crewmates.
+IFS= read -r -d '' SHARED_INFRA_RULE <<'EOF' || true
+7. Never administer infrastructure that every lane shares. Two things are shared:
+   - The `no-mistakes` daemon - one instance serving every lane/home, so stopping, restarting, or
+     updating it kills other lanes' in-flight pipeline runs; only firstmate manages the daemon.
+     Before you append `blocked:` about the pipeline, run `no-mistakes daemon status` and
+     `no-mistakes axi status`. If the daemon socket refuses connections or is missing, append
+     `blocked: {the daemon error}` and stop even when the local run record still says running or
+     fixing, because that record can be stale after the daemon exits. A run record failed with a
+     daemon error is also a real block.
+     Only after ruling out socket refusal, if the run is still running or fixing, reattach and keep
+     going. A drive-call error, timeout, slow read, or generic unreachability is NOT a daemon error:
+     the daemon accepts `respond` immediately and runs the round in the background, so a killed or
+     timed-out call was only waiting for a read while the run kept working.
+   - The worktree pool your own worktree came from, and the repository every lane's worktree
+     shares. Never create, remove, return, prune, move, or reassign a worktree or pool slot, and
+     never write into a sibling slot's directory. Rule 2 does not cover this: removing a worktree
+     is administration rather than an edit outside your directory, and it lands on lanes that are
+     running right now. The act is the rule and commands are only examples of it - `treehouse`
+     get/return/remove/prune, the equivalent operations on any other worktree provider or runtime
+     backend, and `git worktree add|remove|move|prune`. A slot that looks unused is not evidence
+     that it is free, and returning your own worktree is firstmate's job at cleanup, not yours.
+   If you genuinely need a second checkout, another slot, or the daemon touched, append
+   `blocked: {what you need}` and stop; firstmate arranges it.
+EOF
+SHARED_INFRA_RULE=${SHARED_INFRA_RULE%$'\n'}
+
 if [ "$KIND" = scout ]; then
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
@@ -391,18 +428,7 @@ The report is the only thing that survives, so anything worth keeping must be in
    append \`needs-decision: {summary of options}\` and stop. Firstmate will reply with the decision.
    A decision or blocker you opened stays open until a \`resolved\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
    Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved: {how it cleared}\` yourself (same \`[key=<slug>]\` if you opened it with one) as you resume.
-7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
-   every lane/home, so restarting it kills other lanes' in-flight pipeline runs; only firstmate
-   manages the daemon.
-   Before you append \`blocked:\` about the pipeline, run \`no-mistakes daemon status\` and
-   \`no-mistakes axi status\`. If the daemon socket refuses connections or is missing, append
-   \`blocked: {the daemon error}\` and stop even when the local run record still says running or
-   fixing, because that record can be stale after the daemon exits. A run record failed with a
-   daemon error is also a real block.
-   Only after ruling out socket refusal, if the run is still running or fixing, reattach and keep
-   going. A drive-call error, timeout, slow read, or generic unreachability is NOT a daemon error:
-   the daemon accepts \`respond\` immediately and runs the round in the background, so a killed or
-   timed-out call was only waiting for a read while the run kept working.
+$SHARED_INFRA_RULE
 
 $INBOX_SECTION
 
@@ -482,18 +508,7 @@ $RULE1
 $ASK_USER_BLOCK
    A decision or blocker you opened stays open until a \`resolved\` line carrying its exact key lands; a later \`done:\` or \`working:\` line never closes it, even when the answer is what started that work.
    Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append \`resolved: {how it cleared}\` yourself (same \`[key=<slug>]\` if you opened it with one) as you resume.
-7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
-   every lane/home, so restarting it kills other lanes' in-flight pipeline runs; only firstmate
-   manages the daemon.
-   Before you append \`blocked:\` about the pipeline, run \`no-mistakes daemon status\` and
-   \`no-mistakes axi status\`. If the daemon socket refuses connections or is missing, append
-   \`blocked: {the daemon error}\` and stop even when the local run record still says running or
-   fixing, because that record can be stale after the daemon exits. A run record failed with a
-   daemon error is also a real block.
-   Only after ruling out socket refusal, if the run is still running or fixing, reattach and keep
-   going. A drive-call error, timeout, slow read, or generic unreachability is NOT a daemon error:
-   the daemon accepts \`respond\` immediately and runs the round in the background, so a killed or
-   timed-out call was only waiting for a read while the run kept working.
+$SHARED_INFRA_RULE
 
 $INBOX_SECTION
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -357,13 +357,10 @@ IFS= read -r -d '' TASK_SECTION <<'EOF' || true
 EOF
 TASK_SECTION=${TASK_SECTION%$'\n'}
 
-# One shared string for both crewmate scaffolds (issue #2340): a crewmate
-# destroyed five pooled worktrees, four under live tasks, because "stay inside
-# this worktree" is a rule about files and never reached pool administration.
-# Ship and scout must carry the identical rule, so it is written once here
-# rather than copied into each heredoc where the two could drift apart. The
-# secondmate charter deliberately does not carry it: a secondmate runs its own
-# home and legitimately allocates and returns slots for its own crewmates.
+# One shared string keeps the ship and scout infrastructure rule identical.
+# Rule 2 governs file edits, so it does not prohibit pool administration.
+# The secondmate charter deliberately omits this rule because a secondmate
+# legitimately allocates and returns slots for crewmates in its own home.
 IFS= read -r -d '' SHARED_INFRA_RULE <<'EOF' || true
 7. Never administer infrastructure that every lane shares. Two things are shared:
    - The `no-mistakes` daemon - one instance serving every lane/home, so stopping, restarting, or

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -869,6 +869,75 @@ test_worker_role_scope() {
 }
 
 test_worker_role_scope
+
+# Issue #2340: a crewmate ran a `git worktree remove` loop over the treehouse pool
+# its own worktree came from and destroyed five worktrees, four under live
+# mid-pipeline tasks. Rule 2 ("stay inside this worktree") is a rule about files
+# and never reached the act, so every crewmate scaffold must name pool
+# administration itself. The rule is emitted from ONE shared string so the ship
+# and scout copies cannot drift apart.
+test_crewmate_scaffolds_forbid_pool_administration() {
+  local home id brief mode ship_rule scout_rule
+  home="$TMP_ROOT/pool-admin-home"
+  mkdir -p "$home/data"
+
+  for mode in no-mistakes direct-PR local-only; do
+    id="brief-pool-$mode"
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" alpha --mode "$mode" >/dev/null 2>&1 \
+      || fail "fm-brief.sh --mode $mode exited non-zero"
+    brief="$home/data/$id/brief.md"
+    assert_grep "worktree pool" "$brief" \
+      "$mode ship brief did not name the shared worktree pool"
+    assert_grep "create, remove, return, prune, move, or reassign" "$brief" \
+      "$mode ship brief did not state the prohibition around the act"
+    # shellcheck disable=SC2016 # Literal command text must remain unexpanded.
+    assert_grep 'git worktree add|remove|move|prune' "$brief" \
+      "$mode ship brief did not name the concrete git worktree commands"
+    assert_grep "treehouse" "$brief" \
+      "$mode ship brief did not name the treehouse mutation commands"
+    assert_grep "any other worktree provider" "$brief" \
+      "$mode ship brief pinned one provider instead of covering every provider"
+    assert_grep "sibling slot" "$brief" \
+      "$mode ship brief did not forbid writing into a sibling slot"
+    # shellcheck disable=SC2016 # Literal backticks and braces must remain unexpanded.
+    assert_grep 'blocked: {what you need}' "$brief" \
+      "$mode ship brief gave the prohibition no exit for a genuine second-checkout need"
+  done
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-pool-scout alpha --scout >/dev/null 2>&1 \
+    || fail "fm-brief.sh --scout exited non-zero"
+  brief="$home/data/brief-pool-scout/brief.md"
+  assert_grep "worktree pool" "$brief" "scout brief did not name the shared worktree pool"
+  # shellcheck disable=SC2016 # Literal backticks and braces must remain unexpanded.
+  assert_grep 'blocked: {what you need}' "$brief" "scout brief gave the prohibition no exit"
+
+  # One shared string, not two copies: the emitted rule must be byte-identical
+  # across the ship and scout scaffolds so a later edit cannot fix one and miss
+  # the other.
+  ship_rule=$(awk '/^7\. Never administer/,/^$/' "$home/data/brief-pool-no-mistakes/brief.md")
+  scout_rule=$(awk '/^7\. Never administer/,/^$/' "$brief")
+  [ -n "$ship_rule" ] || fail "ship brief emitted no shared-infrastructure rule to compare"
+  [ "$ship_rule" = "$scout_rule" ] \
+    || fail "ship and scout shared-infrastructure rules have drifted apart"
+
+  # The daemon half of the rule survived the fold.
+  assert_grep "no-mistakes" "$brief" "scout brief lost the shared no-mistakes daemon rule"
+  # shellcheck disable=SC2016 # Literal backticks and braces must remain unexpanded.
+  assert_grep 'blocked: {the daemon error}' "$brief" \
+    "scout brief lost the daemon-error reporting instruction"
+
+  # A secondmate runs its own home and legitimately allocates and returns slots
+  # for its own crewmates, so the crewmate prohibition must NOT reach its charter.
+  FM_SECONDMATE_CHARTER='Supervise the alpha domain.' \
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-pool-mate --secondmate alpha >/dev/null 2>&1 \
+    || fail "fm-brief.sh --secondmate exited non-zero"
+  assert_no_grep "create, remove, return, prune, move, or reassign" \
+    "$home/data/brief-pool-mate/brief.md" \
+    "secondmate charter must not inherit the crewmate pool-administration prohibition"
+
+  pass "fm-brief.sh: every crewmate scaffold forbids administering the shared worktree pool"
+}
+
 test_script_parses
 test_no_heredoc_in_command_substitution
 test_help_includes_entire_header
@@ -891,3 +960,4 @@ test_secondmate_directory_paths_are_absolute_and_output_is_stable
 test_pause_verb_override_renders_all_brief_scaffolds
 test_scout_and_secondmate_load_decision_hold_policy
 test_scout_and_secondmate_scaffold
+test_crewmate_scaffolds_forbid_pool_administration

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -870,12 +870,9 @@ test_worker_role_scope() {
 
 test_worker_role_scope
 
-# Issue #2340: a crewmate ran a `git worktree remove` loop over the treehouse pool
-# its own worktree came from and destroyed five worktrees, four under live
-# mid-pipeline tasks. Rule 2 ("stay inside this worktree") is a rule about files
-# and never reached the act, so every crewmate scaffold must name pool
-# administration itself. The rule is emitted from ONE shared string so the ship
-# and scout copies cannot drift apart.
+# Rule 2 governs file edits rather than pool administration, so every crewmate
+# scaffold must prohibit the administrative act itself. The rule is emitted from
+# one shared string so the ship and scout copies cannot drift apart.
 test_crewmate_scaffolds_forbid_pool_administration() {
   local home id brief mode ship_rule scout_rule
   home="$TMP_ROOT/pool-admin-home"


### PR DESCRIPTION
## Intent

Fix issue #2340 on the existing PR #2868 branch: generated crewmate briefs never forbade administering the shared worktree pool. Rebase the branch onto current origin/main and drive the pipeline to a green PR, keeping the change to exactly bin/fm-brief.sh and tests/fm-brief.test.sh.

## What Changed

- Folded the ship and scout daemon rule into one shared `SHARED_INFRA_RULE` string in `bin/fm-brief.sh` and extended it to also prohibit administering the shared worktree pool (create/remove/return/prune/move/reassign a slot, write into a sibling slot, or run `treehouse`/`git worktree` mutations), with a `blocked` exit for genuine second-checkout needs.
- Emitted the single shared rule into both crewmate scaffolds so their copies cannot drift, while deliberately omitting it from the secondmate charter, which legitimately allocates and returns slots for its own crewmates.
- Added `test_crewmate_scaffolds_forbid_pool_administration` to `tests/fm-brief.test.sh`, asserting every ship mode and the scout brief carry the pool prohibition, the rule is byte-identical across ship and scout, the daemon half survives the fold, and the secondmate charter does not inherit the prohibition.

## Risk Assessment

✅ Low: A well-bounded prompt-text change confined to the two intended files that consolidates a duplicated rule and adds the required pool prohibition; the emitted briefs and every test assertion were verified against actual generated output.

## Testing

I generated real briefs by running bin/fm-brief.sh in an isolated FM_HOME for all three ship modes, the scout scaffold, and the secondmate charter, then inspected the emitted brief.md (the generated agent-facing interface). Every ship mode and the scout brief name the shared worktree pool, state the prohibited acts, name the concrete git worktree and treehouse commands, cover any other provider, forbid sibling-slot writes, and give the blocked-exit clause; the daemon half survives the fold. The ship and scout rule 7 are byte-identical, and the secondmate charter omits the crewmate prohibition. The repository's own targeted test also drives this end-to-end and passes. This is a text-generation CLI with no visual surface, so evidence is the rendered brief output rather than screenshots.

- Live validation: ✅ go - 4 of 4 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Ship briefs (all three modes) forbid pool administration | ✅ pass | live | Ran bin/fm-brief.sh --mode no-mistakes\|direct-PR\|local-only; each emitted brief.md names the shared worktree pool, the prohibited acts, git worktree/treehouse commands, any-other-provider coverage, si… |
| Scout brief forbids pool administration and keeps daemon rule | ✅ pass | live | Ran bin/fm-brief.sh --scout; emitted brief.md carries the pool prohibition, the no-mistakes daemon rule, and the blocked-exit clause |
| Ship and scout rules are byte-identical (no drift) | ✅ pass | live | diff of the awk-extracted rule 7 slices from ship and scout briefs shows no difference (len 2018) |
| Secondmate charter omits the crewmate pool prohibition | ✅ pass | live | Ran bin/fm-brief.sh --secondmate; generated charter contains neither &#39;create, remove, return, prune...&#39; nor a worktree-pool rule |

<details>
<summary>Evidence: Emitted rule 7 - ship brief</summary>

Source: [Emitted rule 7 - ship brief](https://github.com/karotkriss/firstmate/blob/12ddf326f6674cc23543a7eab35d9079e556d1f5/.no-mistakes/evidence/fm/fm-2340-pool-prohibition/emitted-rule7-ship.md)

```text
7. Never administer infrastructure that every lane shares. Two things are shared:
   - The `no-mistakes` daemon - one instance serving every lane/home, so stopping, restarting, or
     updating it kills other lanes' in-flight pipeline runs; only firstmate manages the daemon.
     Before you append `blocked:` about the pipeline, run `no-mistakes daemon status` and
     `no-mistakes axi status`. If the daemon socket refuses connections or is missing, append
     `blocked [at=<epoch>]: {the daemon error}` and stop even when the local run record still says running or
     fixing, because that record can be stale after the daemon exits. A run record failed with a
     daemon error is also a real block.
     Only after ruling out socket refusal, if the run is still running or fixing, reattach and keep
     going. A drive-call error, timeout, slow read, or generic unreachability is NOT a daemon error:
     the daemon accepts `respond` immediately and runs the round in the background, so a killed or
     timed-out call was only waiting for a read while the run kept working.
   - The worktree pool your own worktree came from, and the repository every lane's worktree
     shares. Never create, remove, return, prune, move, or reassign a worktree or pool slot, and
     never write into a sibling slot's directory. Rule 2 does not cover this: removing a worktree
     is administration rather than an edit outside your directory, and it lands on lanes that are
     running right now. The act is the rule and commands are only examples of it - `treehouse`
     get/return/remove/prune, the equivalent operations on any other worktree provider or runtime
     backend, and `git worktree add|remove|move|prune`. A slot that looks unused is not evidence
     that it is free, and returning your own worktree is firstmate's job at cleanup, not yours.
   If you genuinely need a second checkout, another slot, or the daemon touched, append
   `blocked [at=<epoch>]: {what you need}` and stop; firstmate arranges it.
```
</details>
<details>
<summary>Evidence: Emitted rule 7 - scout brief</summary>

Source: [Emitted rule 7 - scout brief](https://github.com/karotkriss/firstmate/blob/12ddf326f6674cc23543a7eab35d9079e556d1f5/.no-mistakes/evidence/fm/fm-2340-pool-prohibition/emitted-rule7-scout.md)

```text
7. Never administer infrastructure that every lane shares. Two things are shared:
   - The `no-mistakes` daemon - one instance serving every lane/home, so stopping, restarting, or
     updating it kills other lanes' in-flight pipeline runs; only firstmate manages the daemon.
     Before you append `blocked:` about the pipeline, run `no-mistakes daemon status` and
     `no-mistakes axi status`. If the daemon socket refuses connections or is missing, append
     `blocked [at=<epoch>]: {the daemon error}` and stop even when the local run record still says running or
     fixing, because that record can be stale after the daemon exits. A run record failed with a
     daemon error is also a real block.
     Only after ruling out socket refusal, if the run is still running or fixing, reattach and keep
     going. A drive-call error, timeout, slow read, or generic unreachability is NOT a daemon error:
     the daemon accepts `respond` immediately and runs the round in the background, so a killed or
     timed-out call was only waiting for a read while the run kept working.
   - The worktree pool your own worktree came from, and the repository every lane's worktree
     shares. Never create, remove, return, prune, move, or reassign a worktree or pool slot, and
     never write into a sibling slot's directory. Rule 2 does not cover this: removing a worktree
     is administration rather than an edit outside your directory, and it lands on lanes that are
     running right now. The act is the rule and commands are only examples of it - `treehouse`
     get/return/remove/prune, the equivalent operations on any other worktree provider or runtime
     backend, and `git worktree add|remove|move|prune`. A slot that looks unused is not evidence
     that it is free, and returning your own worktree is firstmate's job at cleanup, not yours.
   If you genuinely need a second checkout, another slot, or the daemon touched, append
   `blocked [at=<epoch>]: {what you need}` and stop; firstmate arranges it.
```
</details>
<details>
<summary>Evidence: Driven-scenario transcript</summary>

Source: [Driven-scenario transcript](https://github.com/karotkriss/firstmate/blob/12ddf326f6674cc23543a7eab35d9079e556d1f5/.no-mistakes/evidence/fm/fm-2340-pool-prohibition/driven-scenarios.txt)

```text
Driven against bin/fm-brief.sh at HEAD 12f4ed7 (isolated FM_HOME)

ship modes carrying pool+daemon+exit rule:
  - ship-no-mistakes: pool='1' daemon-present, exit-present
  - ship-direct-PR: pool='1' daemon-present, exit-present
  - ship-local-only: pool='1' daemon-present, exit-present
  - scout-1: pool='1' daemon-present, exit-present

byte-identity ship rule7 vs scout rule7:
  IDENTICAL

secondmate charter omission:
  OK charter omits prohibition
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"12f4ed799c1c584f16c2a57abc2e033cb7454b6b","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}],"live_validation":{"verdict":"go","live":4,"total":4}} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-brief.sh` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `tests/fm-brief.test.sh:1005` - Three new assertions grepped for the fixed string `blocked: {what you need}` and `blocked: {the daemon error}`, but the emitted rule text is `blocked [at=&lt;epoch&gt;]: {what you need}` / `blocked [at=&lt;epoch&gt;]: {the daemon error}`. assert_grep uses `grep -F`, so these substrings never match and the test always fails, breaking CI. Verified against the actual generated brief. Fixed by including the `[at=&lt;epoch&gt;]` segment in the three patterns; re-verified all assertions and secondmate assert_no_grep pass and the file parses. The remedy is a mechanical test-pattern correction, no product behavior change.

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 4 of 4 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Ship briefs (all three modes) forbid pool administration | ✅ pass | live | Ran bin/fm-brief.sh --mode no-mistakes\|direct-PR\|local-only; each emitted brief.md names the shared worktree pool, the prohibited acts, git worktree/treehouse commands, any-other-provider coverage, si… |
| Scout brief forbids pool administration and keeps daemon rule | ✅ pass | live | Ran bin/fm-brief.sh --scout; emitted brief.md carries the pool prohibition, the no-mistakes daemon rule, and the blocked-exit clause |
| Ship and scout rules are byte-identical (no drift) | ✅ pass | live | diff of the awk-extracted rule 7 slices from ship and scout briefs shows no difference (len 2018) |
| Secondmate charter omits the crewmate pool prohibition | ✅ pass | live | Ran bin/fm-brief.sh --secondmate; generated charter contains neither &#39;create, remove, return, prune...&#39; nor a worktree-pool rule |

- <code>`bash tests/fm-brief.test.sh` (full file, exit 0; new test_crewmate_scaffolds_forbid_pool_administration passes)</code>
- <code>Drove `FM_HOME=&lt;tmp&gt; bin/fm-brief.sh &lt;id&gt; alpha --mode &lt;no-mistakes|direct-PR|local-only&gt;` and inspected emitted data/&lt;id&gt;/brief.md rule 7</code>
- <code>Drove `bin/fm-brief.sh scout-1 alpha --scout` and inspected emitted rule 7</code>
- <code>Drove `FM_SECONDMATE_CHARTER=... bin/fm-brief.sh mate-1 --secondmate alpha` and grepped for the pool prohibition</code>
- <code>`diff` of `awk &#39;/^7\. Never administer/,/^$/&#39;` slices from ship vs scout briefs (byte-identical, len 2018)</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
