### PR TITLE
fix(bin): let a spawn proceed on a project with no origin remote

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -138,6 +138,9 @@
 #   origin, resolves the current remote default branch, and resets to its tip.
 #   An unreachable origin, unresolved default branch, or non-clean worktree
 #   refuses the spawn rather than risking a PR based on stale history.
+#   A repository with no origin remote configured has no upstream to be stale
+#   against, so that refresh is skipped with a loud notice and the spawn
+#   continues; only a configured remote can make a base unverifiable.
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
@@ -1727,8 +1730,28 @@ validate_spawn_worktree() {  # <source> <inspect-target>
   fi
 }
 
+# Freshening asks one question: is this worktree's base stale against its
+# upstream? A repository with no origin configured has no upstream, so that
+# question is meaningless rather than failed, and the spawn proceeds from the
+# base it already has. A project that lives only on one machine is a supported
+# shape, so refusing it would strand every fresh task worktree on that project.
+# The distinction is drawn on whether a remote is CONFIGURED, read from git's own
+# local remote list, which makes no network call. A configured origin that cannot
+# be reached still falls through to the strict path below and refuses loudly, so a
+# network outage on an ordinary project is never reclassified as "no remote".
+# This belongs inside the freshening function, not at its call site: the
+# freshening contract - including when it does not apply - stays with its one
+# owner, so no caller has to know what makes a base refresh meaningful.
 freshen_spawn_worktree_base() {  # <worktree>
-  local worktree=$1 default target expected actual status
+  local worktree=$1 default target expected actual status remotes
+  remotes=$(git -C "$worktree" remote) || {
+    echo "error: could not read the configured remotes of pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+    return 1
+  }
+  if ! printf '%s\n' "$remotes" | grep -qx origin; then
+    echo "notice: pooled worktree '$worktree' has no origin remote configured; skipping the base refresh because there is no upstream it can be stale against" >&2
+    return 0
+  fi
   if ! git -C "$worktree" fetch --quiet origin; then
     echo "error: could not fetch origin for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
     return 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -140,7 +140,9 @@
 #   refuses the spawn rather than risking a PR based on stale history.
 #   A repository with no origin remote configured has no upstream to be stale
 #   against, so that refresh is skipped with a loud notice and the spawn
-#   continues; only a configured remote can make a base unverifiable.
+#   continues; only a configured remote can make a base unverifiable. A pooled
+#   worktree carrying uncommitted work is still refused on that path, because a
+#   new task must never start on top of another task's unlanded work.
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
@@ -1730,6 +1732,14 @@ validate_spawn_worktree() {  # <source> <inspect-target>
   fi
 }
 
+# One reading of a pooled worktree's uncommitted state, shared by both the
+# refresh path and the no-origin skip: 0 clean, 1 dirty, 2 unreadable.
+spawn_worktree_is_clean() {  # <worktree>
+  local status
+  status=$(git -C "$1" status --porcelain) || return 2
+  [ -z "$status" ]
+}
+
 # Freshening asks one question: is this worktree's base stale against its
 # upstream? A repository with no origin configured has no upstream, so that
 # question is meaningless rather than failed, and the spawn proceeds from the
@@ -1742,13 +1752,27 @@ validate_spawn_worktree() {  # <source> <inspect-target>
 # This belongs inside the freshening function, not at its call site: the
 # freshening contract - including when it does not apply - stays with its one
 # owner, so no caller has to know what makes a base refresh meaningful.
+# Skipping the refresh never skips the unlanded-work refusal: a pooled worktree
+# carrying uncommitted files must not silently become the base of a new task,
+# and that risk is identical with or without an upstream.
 freshen_spawn_worktree_base() {  # <worktree>
-  local worktree=$1 default target expected actual status remotes
+  local worktree=$1 default target expected actual remotes
   remotes=$(git -C "$worktree" remote) || {
     echo "error: could not read the configured remotes of pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
     return 1
   }
   if ! printf '%s\n' "$remotes" | grep -qx origin; then
+    spawn_worktree_is_clean "$worktree"
+    case $? in
+      1)
+        echo "error: pooled worktree '$worktree' has uncommitted work; refusing to start a new task on top of it" >&2
+        return 1
+        ;;
+      2)
+        echo "error: could not inspect pooled worktree '$worktree' for uncommitted work; refusing to launch" >&2
+        return 1
+        ;;
+    esac
     echo "notice: pooled worktree '$worktree' has no origin remote configured; skipping the base refresh because there is no upstream it can be stale against" >&2
     return 0
   fi
@@ -1773,14 +1797,17 @@ freshen_spawn_worktree_base() {  # <worktree>
     echo "error: '$target' is not a commit for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
     return 1
   }
-  status=$(git -C "$worktree" status --porcelain) || {
-    echo "error: could not inspect pooled worktree '$worktree' before refreshing its base" >&2
-    return 1
-  }
-  if [ -n "$status" ]; then
-    echo "error: pooled worktree '$worktree' is not clean; refusing to discard uncommitted work while refreshing its base" >&2
-    return 1
-  fi
+  spawn_worktree_is_clean "$worktree"
+  case $? in
+    1)
+      echo "error: pooled worktree '$worktree' is not clean; refusing to discard uncommitted work while refreshing its base" >&2
+      return 1
+      ;;
+    2)
+      echo "error: could not inspect pooled worktree '$worktree' before refreshing its base" >&2
+      return 1
+      ;;
+  esac
   if ! git -C "$worktree" reset --hard "$target" >/dev/null; then
     echo "error: could not reset pooled worktree '$worktree' to '$target'; refusing to launch from a potentially stale base" >&2
     return 1

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -164,6 +164,7 @@ Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectab
 Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees for tmux, herdr, zellij, and cmux tasks, while Orca creates its own worktrees for `backend=orca`.
 For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout.
 `fm-spawn.sh` also owns the base-freshness boundary for every fresh ship and scout: no worker starts until its clean task worktree matches the fetched tip of origin's resolved default branch, and any unsafe or unverifiable base stops the spawn.
+A project with no origin remote configured has no upstream its base can be stale against, so that refresh is skipped with a notice rather than refused.
 Its header owns the exact refusal mechanics, while `tests/fm-spawn-pool-base-freshen.test.sh` owns the portable regression coverage.
 
 The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -165,6 +165,7 @@ Crewmates never intentionally touch your project clone; [treehouse](https://gith
 For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout.
 `fm-spawn.sh` also owns the base-freshness boundary for every fresh ship and scout: no worker starts until its clean task worktree matches the fetched tip of origin's resolved default branch, and any unsafe or unverifiable base stops the spawn.
 A project with no origin remote configured has no upstream its base can be stale against, so that refresh is skipped with a notice rather than refused.
+That skip does not lower the clean-worktree bar: a pooled worktree carrying uncommitted work is still refused, because no task may start on top of another task's unlanded work.
 Its header owns the exact refusal mechanics, while `tests/fm-spawn-pool-base-freshen.test.sh` owns the portable regression coverage.
 
 The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -9,6 +9,8 @@
 # They also pin the boundary between the two: a project with no origin remote
 # configured has no upstream to be stale against, so it launches with a notice,
 # while a configured origin that cannot be reached still refuses.
+# Skipping that refresh still refuses a pooled worktree carrying uncommitted
+# work, which no upstream is needed to detect.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -279,6 +281,33 @@ test_remoteless_project_spawns_with_a_skip_notice() {
   pass "a project with no origin remote spawns and says the base refresh was skipped"
 }
 
+test_dirty_remoteless_pool_still_refuses() {
+  local rec id out status before
+  id='pool-no-origin-dirty-r7'
+  rec=$(make_remoteless_case no-origin-dirty "$id")
+  read_case_record "$rec"
+  before=$(git -C "$POOL_DIR" rev-parse HEAD)
+  printf 'keep this local-only work\n' > "$POOL_DIR/uncommitted.txt"
+
+  out=$(run_spawn "$id" --mode local-only --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn succeeded on a dirty pooled worktree that has no origin remote"
+  assert_contains "$out" "has uncommitted work; refusing to start a new task on top of it" \
+    "spawn did not clearly refuse unlanded work on a project with no origin remote"
+  case "$out" in
+    *"has no origin remote configured"*) fail "spawn announced a skipped refresh on a run it refused" ;;
+  esac
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$before" ] \
+    || fail "spawn moved HEAD while refusing a dirty pooled worktree that has no origin remote"
+  assert_grep 'keep this local-only work' "$POOL_DIR/uncommitted.txt" \
+    "spawn discarded uncommitted work while refusing a pool that has no origin remote"
+  if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+    printf '# observed no-origin dirty refusal: %s; preserved=%s\n' \
+      "$(printf '%s\n' "$out" | tail -n 1)" "$(cat "$POOL_DIR/uncommitted.txt")"
+  fi
+  pass "a dirty pooled worktree on a project with no origin remote is still refused"
+}
+
 test_unreachable_origin_is_not_read_as_a_missing_remote() {
   local rec id out status before after
   id='pool-unreachable-not-missing-r6'
@@ -312,6 +341,7 @@ test_dirty_pool_refuses_without_discarding_work
 test_unresolved_remote_default_refuses_pool
 test_unreachable_origin_refuses_stale_pool_base
 test_remoteless_project_spawns_with_a_skip_notice
+test_dirty_remoteless_pool_still_refuses
 test_unreachable_origin_is_not_read_as_a_missing_remote
 
 echo "# all fm-spawn-pool-base-freshen tests passed"

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -6,6 +6,9 @@
 # These tests drive the real spawn path with a fake terminal, then prove it
 # starts the worker from the fetched origin/main tip or stops when origin is
 # unreachable.
+# They also pin the boundary between the two: a project with no origin remote
+# configured has no upstream to be stale against, so it launches with a notice,
+# while a configured origin that cannot be reached still refuses.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -65,6 +68,31 @@ make_case() {
   git -C "$publisher" push --quiet origin "$default"
 
   printf '%s\n' "$case_dir|$home|$project|$pool|$fakebin|$initial|$default"
+}
+
+# A project that lives only on this machine: a real repo, a real pooled
+# worktree, and no origin remote anywhere in its configuration.
+make_remoteless_case() {
+  local name=$1 id=$2 case_dir home project pool fakebin initial
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  project="$case_dir/project"
+  pool="$case_dir/pool"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
+  printf 'codex\n' > "$home/config/crew-harness"
+  printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
+  touch "$home/state/.last-watcher-beat"
+
+  git init --quiet -b main "$project"
+  printf 'local only\n' > "$project/README.md"
+  git -C "$project" add README.md
+  git -C "$project" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial
+  initial=$(git -C "$project" rev-parse HEAD)
+  git -C "$project" worktree add --quiet --detach "$pool" "$initial"
+
+  printf '%s\n' "$case_dir|$home|$project|$pool|$fakebin|$initial|main"
 }
 
 read_case_record() {
@@ -227,11 +255,63 @@ test_unresolved_remote_default_refuses_pool() {
   pass "an unresolved remote default branch refuses the pooled worktree"
 }
 
+test_remoteless_project_spawns_with_a_skip_notice() {
+  local rec id out status before after remotes
+  id='pool-no-origin-r6'
+  rec=$(make_remoteless_case no-origin "$id")
+  read_case_record "$rec"
+  remotes=$(git -C "$POOL_DIR" remote)
+  [ -z "$remotes" ] || fail "fixture did not prove the project has no remote configured (saw '$remotes')"
+  before=$(git -C "$POOL_DIR" rev-parse HEAD)
+
+  out=$(run_spawn "$id" --mode local-only --yolo off)
+  status=$?
+  expect_code 0 "$status" "spawn should launch on a project that has no origin remote"
+  assert_contains "$out" "spawned $id" "spawn did not report success without an origin remote"
+  assert_contains "$out" "has no origin remote configured" \
+    "spawn skipped the base refresh silently instead of printing a notice"
+  after=$(git -C "$POOL_DIR" rev-parse HEAD)
+  [ "$after" = "$before" ] || fail "spawn moved the pooled worktree that has no upstream to compare against"
+  if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+    printf '# observed no-origin spawn: %s\n' "$(printf '%s\n' "$out" | tail -n 1)"
+    printf '# observed no-origin notice: %s\n' "$(printf '%s\n' "$out" | grep 'no origin remote' | tail -n 1)"
+  fi
+  pass "a project with no origin remote spawns and says the base refresh was skipped"
+}
+
+test_unreachable_origin_is_not_read_as_a_missing_remote() {
+  local rec id out status before after
+  id='pool-unreachable-not-missing-r6'
+  rec=$(make_case unreachable-not-missing "$id")
+  read_case_record "$rec"
+  git -C "$POOL_DIR" remote set-url origin "file://$CASE_DIR/never-existed.git"
+  [ "$(git -C "$POOL_DIR" remote)" = origin ] \
+    || fail "fixture did not keep an origin remote configured while making it unreachable"
+  before=$(git -C "$POOL_DIR" rev-parse HEAD)
+
+  out=$(run_spawn "$id" --mode local-only --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "a configured but unreachable origin was treated as no remote and allowed the spawn"
+  assert_contains "$out" "could not fetch origin" \
+    "spawn did not refuse a configured origin it could not reach"
+  case "$out" in
+    *"has no origin remote configured"*) fail "an unreachable origin was reported as a missing remote" ;;
+  esac
+  after=$(git -C "$POOL_DIR" rev-parse HEAD)
+  [ "$after" = "$before" ] || fail "spawn changed the pooled worktree while refusing an unreachable origin"
+  if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+    printf '# observed unreachable-not-missing refusal: %s\n' "$(printf '%s\n' "$out" | tail -n 1)"
+  fi
+  pass "a configured origin that cannot be reached still refuses instead of being read as no remote"
+}
+
 test_stale_pool_base_refreshes_before_branching
 test_non_main_default_branch_refreshes_before_branching
 test_direct_pr_and_scout_refresh_before_launch
 test_dirty_pool_refuses_without_discarding_work
 test_unresolved_remote_default_refuses_pool
 test_unreachable_origin_refuses_stale_pool_base
+test_remoteless_project_spawns_with_a_skip_notice
+test_unreachable_origin_is_not_read_as_a_missing_remote
 
 echo "# all fm-spawn-pool-base-freshen tests passed"


### PR DESCRIPTION
## The defect

`bin/fm-spawn.sh`'s `freshen_spawn_worktree_base()` unconditionally ran `git -C "$worktree" fetch --quiet origin` and returned a hard error when that failed.

A project with no `origin` remote configured, such as a purely local checkout that has never been pushed anywhere, therefore could not be spawned into a fresh pooled worktree at all. The fetch cannot succeed because there is no remote to fetch from, so every such spawn was refused with:

```
error: could not fetch origin for pooled worktree '<path>'; refusing to launch from a potentially stale base
```

### Exact reproduction

Against the current default branch (`f170ced`), with a repository that has no `origin` remote:

```
$ git init -b main localonly && cd localonly
$ git commit -m initial          # any commit
$ git worktree add --detach ../pool HEAD
$ git -C ../pool remote          # prints nothing: no remote configured
$ freshen_spawn_worktree_base ../pool
fatal: 'origin' does not appear to be a git repository
fatal: Could not read from remote repository.
error: could not fetch origin for pooled worktree '.../pool'; refusing to launch from a potentially stale base
```

Work already running in previously initialised worktrees was unaffected, which is why this only surfaced once a fresh pool slot was needed.

## The fix

Freshening asks one question: is this worktree's base stale against its upstream? A repository with no origin configured has no upstream, so that question is meaningless rather than failed.

`freshen_spawn_worktree_base()` now reads git's own local remote list first, which makes no network call, and skips the refresh with a loud notice when `origin` is not configured:

```
notice: pooled worktree '<path>' has no origin remote configured; skipping the base refresh because there is no upstream it can be stale against
```

The distinction is drawn on whether a remote is **configured**, never on whether a command **failed**. Every existing protection is unchanged for a repository that does have an origin: an origin that cannot be reached, a default branch that cannot be resolved, a dirty worktree, a failed reset, and a post-reset SHA mismatch all still refuse exactly as before. A network outage on an ordinary project is never reclassified as "no remote". A failure to read the remote list itself is also treated as a refusal, so the unsafe direction stays closed.

Skipping the refresh does **not** skip the unlanded-work protection. A pooled worktree carrying uncommitted work is still refused on the no-origin path, because a new task must never silently start on top of another task's unlanded work, and that risk is identical with or without an upstream. That path gets its own accurate message, since it is refusing to launch onto unlanded work rather than refusing to discard while refreshing:

```
error: pooled worktree '<path>' has uncommitted work; refusing to start a new task on top of it
```

The origin path's existing wording is untouched.

### Placement

The check lives inside `freshen_spawn_worktree_base()` rather than at its call site, so the freshening contract, including when it does not apply, stays with its one owner and no caller has to know what makes a base refresh meaningful.

## Tests

Colocated in the existing `tests/fm-spawn-pool-base-freshen.test.sh`, covering both directions plus the retained protection:

- a repository with no origin spawns and prints the skip notice
- a configured but unreachable origin still refuses, and explicitly must not be reported as a missing remote
- a dirty worktree with no origin still refuses, does not announce a skipped refresh, does not move HEAD, and preserves the uncommitted file

The no-origin test was proven to fail on the unfixed script (`expected exit 0, got 1`) and pass with the fix.

## Scope

`validate_spawn_worktree()`'s isolation assertion is untouched, and nothing under `projects/` is touched. `bin/fm-spawn.sh`'s header and one paragraph in `docs/architecture.md` are updated because the fix makes their previous wording inaccurate.
