### PR TITLE
test: remove watcher lock timing flake

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,6 +103,8 @@ Family selection is the ordinary local path; `--all` is deliberate full regressi
 CI owns broad regression across required portable parallel shards, the portable serial lane's separate-runner shards, the Herdr lane, lint, invariants, the coverage guard, and stock macOS Bash compatibility in [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
 Use `bin/fm-test-run.sh --list-lanes` for exact lane names and `--help` for `--jobs` rules and required gate-skip flags when reproducing a lane locally.
 Discover tests by listing `tests/*.test.sh`: each is a self-contained bash script named `<subject>.test.sh`, and its header comment describes what it covers, so pass one to `bin/fm-test-run.sh` to focus on a subject with canonical timing output.
+A fixture may shorten a production timeout to keep a failure path prompt, but never below what the real work inside that window costs on a loaded machine: a fork, an exec, a lock acquisition, a beacon publication, or a first-poll check.
+Where a case's assertion is not about the timeout itself, give that window headroom over the measured loaded cost, and bound the test's own waiting with iteration-counted poll loops, which stretch under load where a wall-clock budget does not.
 Tests that need a real optional backend or an explicit opt-in (real herdr/zellij/cmux smoke tests, the live Pi regression) skip themselves and print the tool or environment gate needed to enable them, so the portable suite remains safe on machines without those tools.
 The [Herdr backend guide](docs/herdr-backend.md#destructive-lab-safety) owns the lane's isolation boundary, while [runtime backend verification](docs/verification/runtime-backends.md#herdr) owns active empirical evidence; live harness credential tests remain opt-in.
 

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -13,6 +13,13 @@ WATCH_ARM="$ROOT/bin/fm-watch-arm.sh"
 DRAIN="$ROOT/bin/fm-wake-drain.sh"
 LIB="$ROOT/bin/fm-wake-lib.sh"
 
+# An arm only reports its typed failure after wait_for_healthy_successor has
+# spent the whole confirmation budget, so cases that wait for that failure must
+# outlast the largest production default (30s on MSYS, 10s elsewhere - see
+# ARM_CONFIRM_DEFAULT in bin/fm-watch-arm.sh). This is a ceiling spent only when
+# an arm genuinely fails to exit; a passing case returns as soon as it does.
+ARM_FAIL_EXIT_POLLS=400
+
 TMP_ROOT=$(fm_test_tmproot fm-watcher-lock-tests)
 
 mark_pr_check_migration_complete() {
@@ -536,7 +543,14 @@ test_arm_self_eviction_is_loud_without_successor() {
   fakebin="$dir/fakebin"
   armout="$dir/arm.out"
   mark_pr_check_migration_complete "$state"
-  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=0.2 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 FM_ARM_CONFIRM_TIMEOUT=1 "$WATCH_ARM" > "$armout" &
+  # The arm's confirmation budget bounds a REAL child startup (fork, exec, lock
+  # acquisition, beacon publication), so this case holds the arm to production's
+  # own budget rather than a shrunken fixture one: a one-second budget turned
+  # ordinary CPU contention into an honest "FAILED - no live watcher with a fresh
+  # beacon" and broke this case's premise under full-suite load (issue #2844).
+  # It stays at the production default rather than something roomier because the
+  # same budget bounds the successor wait this case deliberately spends below.
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_POLL=0.2 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 "$WATCH_ARM" > "$armout" &
   armpid=$!
   i=0
   while [ "$i" -lt 80 ]; do
@@ -551,7 +565,7 @@ test_arm_self_eviction_is_loud_without_successor() {
   # self-evict normally. With no verified successor, the arm must turn that
   # otherwise clean empty close into the typed nonzero failure.
   printf '%s\n' "$$" > "$state/.watch.lock/pid"
-  wait_for_exit "$armpid" 80
+  wait_for_exit "$armpid" "$ARM_FAIL_EXIT_POLLS"
   status=$?
   [ "$status" -ne 0 ] && [ "$status" -ne 124 ] || fail "self-evicted arm did not fail nonzero (status $status)"
   grep -qF 'watcher: FAILED - cycle ended without an actionable reason' "$armout" || fail "self-evicted arm omitted the typed cycle-end failure"
@@ -742,7 +756,13 @@ SH
   FM_STATE_OVERRIDE="$state" "$ROOT/bin/fm-check-register.sh" task >/dev/null \
     || fail "could not register immediate-wake custom check"
   rc=0
-  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_GUARD_GRACE=0 FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=0 FM_HEARTBEAT=999999 "$WATCH_ARM" > "$armout" || rc=$?
+  # This case asserts wake propagation, not the confirmation deadline, and its
+  # child must also run the registered check before exiting: measured at 1.9-2.3s
+  # idle but 9.1-13.1s at 3x CPU oversubscription, against an 11s production
+  # budget. An explicit budget takes the deadline out of the assertion and costs
+  # nothing on a passing run, because the arm returns as soon as the child
+  # settles (issue #2844).
+  PATH="$fakebin:$PATH" FM_STATE_OVERRIDE="$state" FM_GUARD_GRACE=0 FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=0 FM_HEARTBEAT=999999 FM_ARM_CONFIRM_TIMEOUT=60 "$WATCH_ARM" > "$armout" || rc=$?
   [ "$rc" -eq 0 ] || fail "arm returned non-zero for an immediate wake (status $rc): $(cat "$armout")"
   grep -F "check: $check_file: merged: https://example.test/pr/7" "$armout" >/dev/null || fail "arm did not propagate the immediate check wake"
   ! grep -qF 'watcher: FAILED' "$armout" || fail "arm printed FAILED after a valid immediate wake"
@@ -766,12 +786,15 @@ test_arm_waits_for_peer_beacon_after_child_stands_down() {
   printf '%s\n' "$dir" > "$state/.watch.lock/fm-home"
   printf '%s\n' "$WATCH" > "$state/.watch.lock/watcher-path"
   printf '%s\n' "$identity" > "$state/.watch.lock/pid-identity"
-  PATH="$fakebin:$PATH" FM_HOME="$dir" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 FM_ARM_CONFIRM_TIMEOUT=1 FM_ARM_ATTACH_POLL=0.1 "$WATCH_ARM" > "$armout" &
+  # Same budget contract as the self-eviction case: the owned child's real
+  # startup and stand-down happen inside the arm's confirmation window, so the
+  # window stays production-sized (issue #2844).
+  PATH="$fakebin:$PATH" FM_HOME="$dir" FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 FM_ARM_ATTACH_POLL=0.1 "$WATCH_ARM" > "$armout" &
   armpid=$!
   # Synchronize on the owned child declining the live peer lock before making
-  # the peer healthy. Sleeping for the same one-second budget as the arm made
-  # this regression fixture race the confirmation deadline under full-suite
-  # load, rather than testing the intended successor-handshake boundary.
+  # the peer healthy. Sleeping for the same budget the arm spends made this
+  # regression fixture race the confirmation deadline under full-suite load,
+  # rather than testing the intended successor-handshake boundary.
   i=0
   while [ "$i" -lt 80 ]; do
     grep -qF "watcher: already running pid $peer" "$state"/.watch-arm-output.* 2>/dev/null && break
@@ -793,7 +816,7 @@ test_arm_waits_for_peer_beacon_after_child_stands_down() {
   # After the peer dies without a successor, the attached arm must fail loudly.
   kill "$peer" 2>/dev/null || true
   wait "$peer" 2>/dev/null || true
-  wait_for_exit "$armpid" 80
+  wait_for_exit "$armpid" "$ARM_FAIL_EXIT_POLLS"
   status=$?
   [ "$status" -ne 0 ] && [ "$status" -ne 124 ] || fail "attached arm did not fail after peer died (status $status): $(cat "$armout")"
   grep -qF 'watcher: FAILED - cycle ended without an actionable reason' "$armout" || fail "peer-attached arm did not emit the typed cycle-end failure"


### PR DESCRIPTION
## Intent

Fix the load-sensitive flake in tests/fm-watcher-lock.test.sh (GitHub issue #2844): the suite passes in isolation every time but fails intermittently under full-suite / ambient concurrent load, which taxes every full-suite run and blocks widening test parallelism.

Required approach (investigation first): reproduce under instrumented co-scheduled load and name the exact tripping assertion, then remove the timing sensitivity - event/condition waits over fixed sleeps, or tolerances derived from the component's own configured grace - WITHOUT loosening the watcher lock's fail-closed semantics (SIGSTOP handling and stale-heartbeat detection are safety code). The issue's fallback of quarantining the test from parallel lanes is acceptable only if the sensitivity is irreducible; the PR must state which was chosen and why.

Root cause established by repro (3/3 failures under 2x CPU oversubscription, identical assertion "arm did not start before self-eviction check"): two fixtures set FM_ARM_CONFIRM_TIMEOUT=1, and bin/fm-watch-arm.sh computes its confirmation deadline immediately AFTER forking the real child watcher, so a real fork + exec + lock acquisition + beacon publication had a 2-second wall-clock budget. Measured real startup under that load is 3.1-3.6s, so the arm correctly reported "FAILED - no live watcher with a fresh beacon" and killed the child, destroying the fixture's premise. The production code behaved honestly; the fixture was asking a real process startup to beat a one-second clock.

Re-running the fixed suite at 3x oversubscription surfaced a second case on the same mechanism: `test_arm_propagates_immediate_wake_before_confirmation` returned non-zero after printing the wake it already held. That child must also execute a registered check before exiting, and it runs on the production budget - measured at 1.9-2.3s idle but 9.1-13.1s under load, against 11s. It was a coin flip, not a fixed cost.

Fix (test-only, no production change, no default-behavior change):

- The two cases that must confirm a REAL child startup hold the arm to production's own budget instead of a shrunken fixture one. They stay at the production default rather than something roomier because the same budget also bounds the successor wait they deliberately spend, so the suite stays quick.
- The immediate-wake case gets an explicit budget with headroom over its measured loaded cost. That costs nothing on a passing run, because the arm returns as soon as the child settles.
- The two waits for the arm's typed failure are sized off the largest production default (30s on MSYS, 10s elsewhere) through a shared ceiling that is only spent when an arm genuinely fails to exit, instead of a fixed eight seconds.

The suite's own waits stay iteration-counted poll loops, which stretch under load where a wall-clock budget does not. CONTRIBUTING.md records the convention so the pattern does not come back.

Verification: 3/3 red before the change at 2x oversubscription, then 4/4 green at 3x (loadavg 75-80) with the whole suite completing, plus a clean unloaded run. The remaining fixed sleeps in the 40-way lock-contention cases were probed to 6x oversubscription without tripping, so they are left alone rather than rewritten speculatively.

Quarantine was rejected on evidence, not preference: bin/fm-test-isolation-proof.sh already excludes the watcher/wake/lock family, and bin/fm-test-run.sh already refuses --jobs > 1 for this script, yet the reporter's failure happened at --jobs 1 under ambient machine load. Quarantine was already in force and could not have prevented it.

VISION.md alignment: "This repository ships through its own discipline: firstmate work is validated like any other project's, and field incidents become regression coverage" - a flaky red trains contributors to ignore red. "Scripts stop safely and report when the world surprises them" - the arm's refusal was correct, so the test was corrected rather than the safety code weakened. Deliberately no default-behavior change anywhere in bin/.


## What Changed

- Remove one-second confirmation budgets from two fixtures that launch real child watchers, so their startup windows are production-sized under load.
- Give the immediate-wake fixture an explicit confirmation budget with headroom over its measured loaded cost, since its child must also run a registered check inside that window.
- Bound typed-failure waits with a shared iteration-counted polling ceiling derived from the largest production confirmation default, without changing watcher safety behavior.
- Document the load-safe timeout and polling convention for test fixtures in CONTRIBUTING.md.

Fixes #2844

## Risk Assessment

✅ Low: the test-only change directly addresses the reproduced timing race while preserving production watcher safety behavior and platform-specific confirmation defaults.

## Testing

The real-process watcher-lock suite passed normally in 80 seconds and under 2x CPU oversubscription in 225 seconds, including the formerly failing self-eviction startup assertion, real-child peer handoff, immediate wake propagation, typed arm failure, stale-heartbeat detection, and SIGSTOP fail-closed behavior. Reviewer-visible CLI transcripts were captured, production scripts were unchanged, and no transient processes or worktree artifacts remained.

<details>
<summary>Evidence: Focused watcher-lock test transcript</summary>

Source: [Focused watcher-lock test transcript](https://github.com/karotkriss/firstmate/blob/003975d752b41158db83afa0b5adae55d7d36ab2/.no-mistakes/evidence/fm/fm-2844-lock-test-flake/fm-watcher-lock-focused.txt)

```text
Command: bin/fm-test-run.sh tests/fm-watcher-lock.test.sh
Commit: 0d73e0e309fd845f55d16fc4ba9107ed0cf86039
Started: 2026-08-23T11:27:35-04:00
FM_TEST_BEGIN 2026-08-23T15:27:36Z tests/fm-watcher-lock.test.sh family=watcher-wake-lock expected_gate_skip=none
ok - simultaneous watcher starts leave exactly one live process
ok - fm_pid_identity real ps fallback is locale-invariant
ok - fm_pid_identity is locale-invariant across LC_ALL/LC_TIME
ok - /proc process identity ignores simulated btime changes
ok - /proc process identity detects pid reuse
ok - MSYS /proc process identity regression skipped on non-Windows host
ok - killed watcher stale lock is reclaimed
tests/fm-watcher-lock.test.sh: line 1061: 24589 Killed                     FM_STATE_OVERRIDE="$state" bash -c '
    . "$1"
    fm_lock_remove_path() {
      if [ "$1" = "$STATE/.watch.lock" ]; then
        kill -KILL "${BASHPID:-$$}"
      fi
      return 1
    }
    fm_lock_try_acquire "$2"
  ' _ "$LIB" "$lockdir" > /dev/null 2>&1
ok - stale watcher reclaim publishes durable recovery evidence before clear
ok - live watcher lock with stale heartbeat is actionable
ok - guard banner leads when down with pending wakes (repair-after-drain) and stays silent when live and fresh
ok - concurrent fm_lock_try_acquire yields exactly one winner
ok - dead-pid stale lock is reclaimed by a single acquirer
ok - concurrent stale-lock steal yields exactly one winner
ok - live steal mutex is not reclaimed
ok - live-held lock is not stolen
ok - empty mid-acquire lock keeps a minimum grace
ok - late original claimant cannot claim a recreated lock
ok - paused mid-acquire claimant backs off to active stealer
ok - watch restart preserves recovery without signaling a reused pid
ok - watch restart attaches to a verified healthy peer and later surfaces a successor gap
ok - watcher self-evicts when the lock pid no longer names it
ok - arm turns clean self-eviction without a successor into a typed failure
ok - arm attaches to a live fresh watcher and fails loudly when that cycle has no successor
ok - attached arm signals record a classified lifecycle entry
ok - arm starts cleanly and resurfaces recovery after a dead-pid lock
ok - arm cleans child watcher and temp output on HUP
WAKE_ACK_REQUIRED: after handling completes run bin/fm-wake-drain.sh --ack-through 1 --recovery-generation 63961.1787498901.bdQdaP
ok - arm propagates an immediate watcher wake before confirmation
ok - arm attaches to a peer watcher after child stands down and surfaces a missing successor
watcher: lock held by live pid 73276 but heartbeat is stale for 840799714s (>300s); inspect or stop that watcher before re-arming.
ok - arm reports FAILED and exits non-zero when no fresh watcher can be confirmed
ok - cycle-exit ledger links a verified successor and remains size-capped
ok - SIGSTOP distinguishes live PID from stale beacon and termination records the exit class
FM_TEST_END 2026-08-23T15:28:55Z tests/fm-watcher-lock.test.sh exit=0 duration_ms=79884 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=79978
FM_TEST_SUMMARY_FAMILY family=watcher-wake-lock count=1 duration_ms=79884 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-watcher-lock.test.sh duration_ms=79884
Elapsed: 1:20.18
Max RSS: 43040 KB
Exit: 0
Finished: 2026-08-23T11:28:56-04:00
```
</details>
<details>
<summary>Evidence: Watcher-lock test under 2x CPU oversubscription</summary>

Source: [Watcher-lock test under 2x CPU oversubscription](https://github.com/karotkriss/firstmate/blob/003975d752b41158db83afa0b5adae55d7d36ab2/.no-mistakes/evidence/fm/fm-2844-lock-test-flake/fm-watcher-lock-2x-cpu-load.txt)

```text
Command: 40 CPU burners (2x 20 logical CPUs) plus bin/fm-test-run.sh tests/fm-watcher-lock.test.sh
Commit: 0d73e0e309fd845f55d16fc4ba9107ed0cf86039
Logical CPUs: 20
Load workers: 40
Started: 2026-08-23T11:29:29-04:00
Pre-test loadavg: 4.07 22.14 61.33 49/1421 31215
FM_TEST_BEGIN 2026-08-23T15:29:29Z tests/fm-watcher-lock.test.sh family=watcher-wake-lock expected_gate_skip=none
ok - simultaneous watcher starts leave exactly one live process
ok - fm_pid_identity real ps fallback is locale-invariant
ok - fm_pid_identity is locale-invariant across LC_ALL/LC_TIME
ok - /proc process identity ignores simulated btime changes
ok - /proc process identity detects pid reuse
ok - MSYS /proc process identity regression skipped on non-Windows host
ok - killed watcher stale lock is reclaimed
tests/fm-watcher-lock.test.sh: line 1061: 33812 Killed                     FM_STATE_OVERRIDE="$state" bash -c '
    . "$1"
    fm_lock_remove_path() {
      if [ "$1" = "$STATE/.watch.lock" ]; then
        kill -KILL "${BASHPID:-$$}"
      fi
      return 1
    }
    fm_lock_try_acquire "$2"
  ' _ "$LIB" "$lockdir" > /dev/null 2>&1
ok - stale watcher reclaim publishes durable recovery evidence before clear
ok - live watcher lock with stale heartbeat is actionable
ok - guard banner leads when down with pending wakes (repair-after-drain) and stays silent when live and fresh
ok - concurrent fm_lock_try_acquire yields exactly one winner
ok - dead-pid stale lock is reclaimed by a single acquirer
ok - concurrent stale-lock steal yields exactly one winner
ok - live steal mutex is not reclaimed
ok - live-held lock is not stolen
ok - empty mid-acquire lock keeps a minimum grace
ok - late original claimant cannot claim a recreated lock
ok - paused mid-acquire claimant backs off to active stealer
ok - watch restart preserves recovery without signaling a reused pid
ok - watch restart attaches to a verified healthy peer and later surfaces a successor gap
ok - watcher self-evicts when the lock pid no longer names it
ok - arm turns clean self-eviction without a successor into a typed failure
ok - arm attaches to a live fresh watcher and fails loudly when that cycle has no successor
ok - attached arm signals record a classified lifecycle entry
ok - arm starts cleanly and resurfaces recovery after a dead-pid lock
ok - arm cleans child watcher and temp output on HUP
WAKE_ACK_REQUIRED: after handling completes run bin/fm-wake-drain.sh --ack-through 1 --recovery-generation 91600.1787499073.y7trbf
ok - arm propagates an immediate watcher wake before confirmation
ok - arm attaches to a peer watcher after child stands down and surfaces a missing successor
watcher: lock held by live pid 4052 but heartbeat is stale for 840799894s (>300s); inspect or stop that watcher before re-arming.
ok - arm reports FAILED and exits non-zero when no fresh watcher can be confirmed
ok - cycle-exit ledger links a verified successor and remains size-capped
ok - SIGSTOP distinguishes live PID from stale beacon and termination records the exit class
FM_TEST_END 2026-08-23T15:33:14Z tests/fm-watcher-lock.test.sh exit=0 duration_ms=225231 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=225697
FM_TEST_SUMMARY_FAMILY family=watcher-wake-lock count=1 duration_ms=225231 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-watcher-lock.test.sh duration_ms=225231
Elapsed: 3:46.07
Max RSS: 42880 KB
Post-test loadavg: 48.82 36.88 58.88 54/1442 53947
Exit: 0
Finished: 2026-08-23T11:33:15-04:00
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"0d73e0e309fd845f55d16fc4ba9107ed0cf86039","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-test-run.sh tests/fm-watcher-lock.test.sh`
- <code>Started 40 `yes` CPU workers across 20 logical CPUs, then ran `bin/fm-test-run.sh tests/fm-watcher-lock.test.sh`</code>
- <code>Verified `git diff --exit-code -- bin` and confirmed no production script changes</code>
- `Verified all 40 load workers exited and the worktree remained clean`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
