### PR TITLE
fix(bin): read growing snapshot values from files instead of jq argv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,16 +377,16 @@ jobs:
           snapshot_output=$(/bin/bash tests/fm-fleet-snapshot-view.test.sh)
           printf '%s\n' "$snapshot_output"
           snapshot_count=$(printf '%s\n' "$snapshot_output" | grep -c '^ok - ')
-          [ "$snapshot_count" -eq 15 ] || {
-            echo "::error::expected 15 snapshot/fleet-view tests, got $snapshot_count"
+          [ "$snapshot_count" -eq 16 ] || {
+            echo "::error::expected 16 snapshot/fleet-view tests, got $snapshot_count"
             exit 1
           }
 
           bearings_output=$(/bin/bash tests/fm-bearings-snapshot.test.sh)
           printf '%s\n' "$bearings_output"
           bearings_count=$(printf '%s\n' "$bearings_output" | grep -c '^ok - ')
-          [ "$bearings_count" -eq 42 ] || {
-            echo "::error::expected 42 Bearings tests, got $bearings_count"
+          [ "$bearings_count" -eq 44 ] || {
+            echo "::error::expected 44 Bearings tests, got $bearings_count"
             exit 1
           }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,8 +385,8 @@ jobs:
           bearings_output=$(/bin/bash tests/fm-bearings-snapshot.test.sh)
           printf '%s\n' "$bearings_output"
           bearings_count=$(printf '%s\n' "$bearings_output" | grep -c '^ok - ')
-          [ "$bearings_count" -eq 44 ] || {
-            echo "::error::expected 44 Bearings tests, got $bearings_count"
+          [ "$bearings_count" -eq 45 ] || {
+            echo "::error::expected 45 Bearings tests, got $bearings_count"
             exit 1
           }
 

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -61,7 +61,9 @@
 #   --all-pr-repos   query every discovered repository under --include-prs
 #   -h,--help        usage
 #
-# Output contract: `fm-bearings.v1`. Read-only; no locks, no mutation, no reports.
+# Output contract: `fm-bearings.v1`. Read-only over fleet state: no locks, no
+# mutation, no reports; its only write is one private temporary directory of jq
+# input, removed on every exit path.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -299,10 +299,15 @@ EOF
       npr=$((npr + cnt))
       rows_file=$(jq_blob_file pr_rows "$rows") || exit 1
       repo_rows_file=$(jq_blob_file pr_repo_rows "$repo_rows") || exit 1
+      # A failed accumulation loses every row gathered so far, so it cannot join the
+      # loop's soft per-repo degrade: continuing would keep counting rows that no
+      # longer exist. Announce it here instead of leaving the next iteration to
+      # report the emptied accumulator as an empty jq input.
       rows=$(jq -n --slurpfile a_blob "$rows_file" --slurpfile b_blob "$repo_rows_file" '
         ($a_blob[0]) as $a
         | ($b_blob[0]) as $b
-        | $a + $b')
+        | $a + $b') \
+        || { echo "fm-bearings-snapshot: pull request row accumulation failed" >&2; exit 1; }
     done
     PR_REPOS_SHOWN=$nrepos
     PR_ROWS_CAPPED=$ncapped

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -168,6 +168,42 @@ done
 
 command -v jq >/dev/null 2>&1 || { echo "fm-bearings-snapshot: jq not found" >&2; exit 1; }
 
+# jq input plumbing for values that grow with the fleet, mirroring
+# bin/fm-fleet-snapshot.sh, which owns this pattern and documents it in full.
+# Linux caps a SINGLE argv string at MAX_ARG_STRLEN (131072 bytes), so the live
+# PR rows, whose size tracks the number of repositories and the per-repository
+# open-PR limit, reach jq from a file instead of from a command-line value.
+# One private directory per process, so concurrent bearings runs cannot collide.
+BEARINGS_TMPDIR=$(mktemp -d "${TMPDIR:-/tmp}/fm-bearings-snapshot.XXXXXX") || {
+  echo "fm-bearings-snapshot: cannot create a private directory for jq input" >&2
+  exit 1
+}
+bearings_cleanup() {
+  rm -rf "$BEARINGS_TMPDIR"
+}
+trap bearings_cleanup EXIT
+trap 'bearings_cleanup; exit 129' HUP
+trap 'bearings_cleanup; exit 130' INT
+trap 'bearings_cleanup; exit 143' TERM
+
+# Write <blob> to this process's private file for <slot> and echo that path.
+# An empty blob is refused rather than slurped, because --slurpfile on an empty
+# file yields [] and would silently bind null where --argjson used to fail.
+jq_blob_file() {  # <slot> <blob>
+  local file="$BEARINGS_TMPDIR/$1.json"
+  case $2 in
+    '')
+      printf 'fm-bearings-snapshot: empty jq input for %s\n' "$1" >&2
+      return 1
+      ;;
+  esac
+  printf '%s' "$2" > "$file" || {
+    printf 'fm-bearings-snapshot: cannot write jq input for %s\n' "$1" >&2
+    return 1
+  }
+  printf '%s' "$file"
+}
+
 # The deterministic return-catch-up owner must clear before this or any other
 # ordinary captain request proceeds. Bearings does not reproduce that policy;
 # it only consults the shared read-only gate.
@@ -259,7 +295,12 @@ EOF
       cnt=$(printf '%s' "$repo_rows" | jq 'length')
       [ "$returned" -gt "$FM_BEARINGS_PR_LIMIT" ] && ncapped=$((ncapped + 1))
       npr=$((npr + cnt))
-      rows=$(jq -n --argjson a "$rows" --argjson b "$repo_rows" '$a + $b')
+      rows_file=$(jq_blob_file pr_rows "$rows") || exit 1
+      repo_rows_file=$(jq_blob_file pr_repo_rows "$repo_rows") || exit 1
+      rows=$(jq -n --slurpfile a_blob "$rows_file" --slurpfile b_blob "$repo_rows_file" '
+        ($a_blob[0]) as $a
+        | ($b_blob[0]) as $b
+        | $a + $b')
     done
     PR_REPOS_SHOWN=$nrepos
     PR_ROWS_CAPPED=$ncapped
@@ -283,6 +324,7 @@ case "$BEARINGS_TODAY" in
   [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]) : ;;
   *) BEARINGS_TODAY=$(date -u +%Y-%m-%d) ;;
 esac
+CANDIDATE_PRS_FILE=$(jq_blob_file candidate_prs "$CANDIDATE_PRS") || exit 1
 MODEL=$(printf '%s' "$SNAP" | jq \
   --arg home "$HOME_LABEL" \
   --arg now "$NOW" \
@@ -311,8 +353,9 @@ MODEL=$(printf '%s' "$SNAP" | jq \
   --argjson pr_repos_shown "$PR_REPOS_SHOWN" \
   --argjson pr_rows_capped "$PR_ROWS_CAPPED" \
   --argjson pr_rows_min_total "$PR_ROWS_MIN_TOTAL" \
-  --argjson candidate_prs "$CANDIDATE_PRS" '
-  def trunc($n): if . == null then null else
+  --slurpfile candidate_prs_blob "$CANDIDATE_PRS_FILE" '
+  ($candidate_prs_blob[0]) as $candidate_prs
+  | def trunc($n): if . == null then null else
     (tostring | gsub("\\s+"; " ") | if (length > $n) then (.[:$n] + "…") else . end) end;
   def round_robin_landed($n):
     . as $groups

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -201,6 +201,51 @@ esac
 
 command -v jq >/dev/null 2>&1 || { echo "fm-fleet-snapshot: jq not found" >&2; exit 1; }
 
+# jq input plumbing for blobs that grow with the fleet.
+#
+# Linux caps a SINGLE argv string at MAX_ARG_STRLEN (131072 bytes) independently
+# of the much larger total ARG_MAX, so a --arg/--argjson value cannot carry
+# anything whose size tracks the data. Once the parsed backlog, the task
+# inventory, or a cross-home aggregation crosses that cap, execve of jq fails
+# outright with "Argument list too long" and the whole snapshot dies.
+#
+# Every blob whose size tracks the backlog, the task inventory, the scout-report
+# inventory, a status-log decision fold, or a registered-secondmate aggregation
+# is therefore handed to jq with --slurpfile, which reads the value from a file
+# and has no argv ceiling. Each such filter binds the slurped value back to its
+# original name up front, so the filter bodies stay unchanged. Bounded scalars
+# and fixed-shape per-task objects stay on --arg/--argjson.
+#
+# The blob files live in one private mktemp directory per process, so several
+# snapshot runs in flight on the same home cannot collide, and one file per
+# named slot keeps a loop from growing a file per iteration.
+SNAPSHOT_TMPDIR=$(mktemp -d "${TMPDIR:-/tmp}/fm-fleet-snapshot.XXXXXX") || {
+  echo "fm-fleet-snapshot: cannot create a private directory for jq input" >&2
+  exit 1
+}
+snapshot_cleanup() {
+  rm -rf "$SNAPSHOT_TMPDIR"
+}
+trap snapshot_cleanup EXIT
+trap 'snapshot_cleanup; exit 129' HUP
+trap 'snapshot_cleanup; exit 130' INT
+trap 'snapshot_cleanup; exit 143' TERM
+
+# Write <blob> to this process's private file for <slot> and echo that path.
+# An empty blob is refused rather than slurped, because --slurpfile on an empty
+# file yields [] and would silently bind null where --argjson used to fail.
+jq_blob_file() {  # <slot> <blob>
+  local file="$SNAPSHOT_TMPDIR/$1.json"
+  case $2 in
+    '')
+      printf 'fm-fleet-snapshot: empty jq input for %s\n' "$1" >&2
+      return 1
+      ;;
+  esac
+  printf '%s' "$2" > "$file" || return 1
+  printf '%s' "$file"
+}
+
 bool_json() {
   if [ "$1" = 1 ]; then printf 'true'; else printf 'false'; fi
 }
@@ -558,7 +603,9 @@ task_json_lines() {
       home_json=$(jq -n '{path:null,present:false}')
     fi
 
-    jq -n \
+    # The keyed open-decision set grows with an append-only status log, so it
+    # arrives on stdin rather than as an argv string with a 128KB ceiling.
+    printf '%s' "$open_decisions_json" | jq \
       --arg id "$id" \
       --arg kind "$kind" \
       --arg harness "$harness" \
@@ -585,11 +632,11 @@ task_json_lines() {
       --argjson worktree_path "$worktree_json" \
       --argjson home_path "$home_json" \
       --argjson endpoint_exists "$endpoint_exists" \
-      --argjson open_decisions "$open_decisions_json" \
       --argjson pending_decision "$(bool_json "$pending_decision")" \
       --argjson blocked_event "$(bool_json "$blocked_event")" \
       --argjson report_present "$(bool_json "$report_present")" \
-      '{
+      '. as $open_decisions
+      | {
         id:$id,
         kind:$kind,
         harness:($harness // ""),
@@ -640,10 +687,15 @@ task_json_lines() {
 # Meta inventory remains the sole source of live workers; this object only
 # discloses backlog↔task inconsistency for renderers (Bearings omitted/gates).
 main_inventory_json() {  # <backlog-json> <tasks-json>
+  local backlog_file tasks_file
+  backlog_file=$(jq_blob_file main_inventory_backlog "$1") || return 1
+  tasks_file=$(jq_blob_file main_inventory_tasks "$2") || return 1
   jq -n \
-    --argjson backlog "$1" \
-    --argjson tasks "$2" '
-    ([ $backlog.records[]?
+    --slurpfile backlog_blob "$backlog_file" \
+    --slurpfile tasks_blob "$tasks_file" '
+    ($backlog_blob[0]) as $backlog
+    | ($tasks_blob[0]) as $tasks
+    | ([ $backlog.records[]?
        | select((.state == "in_flight" or .state == "queued") and (.structured | not)) ]) as $unstructured_current
     | ([ $backlog.records[]?
          | select(.state == "in_flight" and .structured and .requires_child_metadata) ]) as $owned_in_flight
@@ -668,6 +720,9 @@ main_inventory_json() {  # <backlog-json> <tasks-json>
 # This mode never reads parent events or terminal text and never aggregates
 # nested secondmates.
 secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
+  local backlog_file tasks_file
+  backlog_file=$(jq_blob_file home_summary_backlog "$1") || return 1
+  tasks_file=$(jq_blob_file home_summary_tasks "$2") || return 1
   jq -n \
     --arg generated "$SNAPSHOT_NOW" \
     --arg home "$FM_HOME" \
@@ -675,9 +730,11 @@ secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
     --argjson queued_n "$FM_SNAPSHOT_SECONDMATE_QUEUED" \
     --argjson decisions_n "$FM_SNAPSHOT_SECONDMATE_DECISIONS" \
     --argjson landed_n "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" \
-    --argjson backlog "$1" \
-    --argjson tasks "$2" '
-    def trunc($n):
+    --slurpfile backlog_blob "$backlog_file" \
+    --slurpfile tasks_blob "$tasks_file" '
+    ($backlog_blob[0]) as $backlog
+    | ($tasks_blob[0]) as $tasks
+    | def trunc($n):
       tostring | gsub("\\s+"; " ")
       | if length > $n then .[:$n] + "…" else . end;
     ([ $backlog.records[]?
@@ -1091,8 +1148,18 @@ terminal_evidence_json() {  # <parent-task-json> <event-note> <evidence-contradi
 }
 
 parent_evidence_reconciliation_json() {  # <summary-json> <activities-json> <decisions-json>
-  jq -n --argjson summary "$1" --argjson activities "$2" --argjson decisions "$3" '
-    def keyed: . != null and . != "" and . != "default";
+  local summary_file activities_file decisions_file
+  summary_file=$(jq_blob_file reconcile_summary "$1") || return 1
+  activities_file=$(jq_blob_file reconcile_activities "$2") || return 1
+  decisions_file=$(jq_blob_file reconcile_decisions "$3") || return 1
+  jq -n \
+    --slurpfile summary_blob "$summary_file" \
+    --slurpfile activities_blob "$activities_file" \
+    --slurpfile decisions_blob "$decisions_file" '
+    ($summary_blob[0]) as $summary
+    | ($activities_blob[0]) as $activities
+    | ($decisions_blob[0]) as $decisions
+    | def keyed: . != null and . != "" and . != "default";
     def result($e; $matches; $complete; $surface):
       $e + {
         verdict:(if ($e.key | keyed | not) then "inconclusive"
@@ -1155,9 +1222,15 @@ secondmate_current_json() {  # <parent-tasks-json>
   local row id home host remote registered registry_error task sampled_spawn_gen status_file event_raw event_note event_epoch event_age
   local activity_scan activities decisions reconciliation provenance freshness reason summary summary_rc summary_bytes summary_sampled summary_valid summary_reason summary_invalidity state current_reason terminal terminal_contradiction contradiction
   local records='[]' seen_homes=''
+  local registry_file tasks_file summary_file decisions_file activities_file activity_scan_file reconciliation_file
+  local records_file record_file
   registry=$(registry_secondmates_json) || return 1
-  union=$(jq -n --argjson registry "$registry" --argjson tasks "$tasks" '
-    ($registry.records // []) as $registered
+  registry_file=$(jq_blob_file union_registry "$registry") || return 1
+  tasks_file=$(jq_blob_file union_tasks "$tasks") || return 1
+  union=$(jq -n --slurpfile registry_blob "$registry_file" --slurpfile tasks_blob "$tasks_file" '
+    ($registry_blob[0]) as $registry
+    | ($tasks_blob[0]) as $tasks
+    | ($registry.records // []) as $registered
     | (($registered | map(.id)) // []) as $registered_ids
     | ([ $registered[] as $r
          | $r + {parent_task:([$tasks[] | select(.id == $r.id)][0] // null)} ]
@@ -1300,14 +1373,28 @@ secondmate_current_json() {  # <parent-tasks-json>
           '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"not-collected",reason:"no useful contradiction check",lines:0,bytes:0,event_note_seen:false,contradiction:false}')
       fi
       if printf '%s' "$terminal" | jq -e '.contradiction == true' >/dev/null; then contradiction=true; fi
+      summary_file=$(jq_blob_file current_summary "$summary") || return 1
+      decisions_file=$(jq_blob_file current_decisions "$decisions") || return 1
+      activities_file=$(jq_blob_file current_activities "$activities") || return 1
+      activity_scan_file=$(jq_blob_file current_activity_scan "$activity_scan") || return 1
+      reconciliation_file=$(jq_blob_file current_reconciliation "$reconciliation") || return 1
       record=$(jq -n \
         --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg state "$state" --arg current_reason "$current_reason" --arg observed "$SNAPSHOT_NOW" \
         --arg spawn_gen "$sampled_spawn_gen" \
-        --argjson registered "$registered" --argjson summary "$summary" --argjson summary_valid "$summary_valid" --argjson decisions "$decisions" \
-        --argjson activities "$activities" --argjson activity_scan "$activity_scan" \
-        --argjson reconciliation "$reconciliation" --argjson terminal "$terminal" --argjson contradiction "$contradiction" \
-        --arg event_raw "$event_raw" --arg event_note "$event_note" --argjson event_age "$event_age" '
-        {id:$id,home:$home,host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
+        --argjson registered "$registered" --argjson summary_valid "$summary_valid" \
+        --argjson terminal "$terminal" --argjson contradiction "$contradiction" \
+        --arg event_raw "$event_raw" --arg event_note "$event_note" --argjson event_age "$event_age" \
+        --slurpfile summary_blob "$summary_file" \
+        --slurpfile decisions_blob "$decisions_file" \
+        --slurpfile activities_blob "$activities_file" \
+        --slurpfile activity_scan_blob "$activity_scan_file" \
+        --slurpfile reconciliation_blob "$reconciliation_file" '
+        ($summary_blob[0]) as $summary
+        | ($decisions_blob[0]) as $decisions
+        | ($activities_blob[0]) as $activities
+        | ($activity_scan_blob[0]) as $activity_scan
+        | ($reconciliation_blob[0]) as $reconciliation
+        | {id:$id,home:$home,host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
          spawn_gen:($spawn_gen | if . == "" then null else . end),
          current:{state:$state,reason:($current_reason | if . == "" then null else . end)},invalidity:$summary.invalidity,
          reconcile_inventory:$summary.invalidity,
@@ -1333,13 +1420,27 @@ secondmate_current_json() {  # <parent-tasks-json>
         terminal=$(jq -n --arg observed "$SNAPSHOT_NOW" \
           '{provenance:"parent-direct-report-terminal",trust:"untrusted-supplement",captured:false,observed_at:$observed,freshness:"not-collected",reason:"no parent event to compare",lines:0,bytes:0,event_note_seen:false,contradiction:false}')
       fi
+      activities_file=$(jq_blob_file fallback_activities "$activities") || return 1
+      activity_scan_file=$(jq_blob_file fallback_activity_scan "$activity_scan") || return 1
+      decisions_file=$(jq_blob_file fallback_decisions "$decisions") || return 1
+      # The sampled home summary reaches here unbounded too: the byte-limit rejection
+      # keeps the oversized text it just measured, so it cannot ride argv either.
+      summary_file=$(jq_blob_file fallback_summary "$summary") || return 1
       record=$(jq -n \
         --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg reason "$reason" --arg observed "$SNAPSHOT_NOW" \
         --arg spawn_gen "$sampled_spawn_gen" \
         --arg provenance "$provenance" --arg freshness "$freshness" --arg event_raw "$event_raw" --arg event_note "$event_note" \
-        --argjson registered "$registered" --argjson event_age "$event_age" --argjson activities "$activities" --argjson activity_scan "$activity_scan" \
-        --argjson decisions "$decisions" --argjson terminal "$terminal" --argjson summary "$summary" --argjson summary_sampled "$summary_sampled" '
-        {id:$id,home:($home | if . == "" then null else . end),host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
+        --argjson registered "$registered" --argjson event_age "$event_age" --argjson terminal "$terminal" \
+        --argjson summary_sampled "$summary_sampled" \
+        --slurpfile activities_blob "$activities_file" \
+        --slurpfile activity_scan_blob "$activity_scan_file" \
+        --slurpfile decisions_blob "$decisions_file" \
+        --slurpfile summary_blob "$summary_file" '
+        ($activities_blob[0]) as $activities
+        | ($activity_scan_blob[0]) as $activity_scan
+        | ($decisions_blob[0]) as $decisions
+        | ($summary_blob[0]) as $summary
+        | {id:$id,home:($home | if . == "" then null else . end),host:($host | if . == "" then null else . end),remote:$remote,registered:$registered,
          spawn_gen:($spawn_gen | if . == "" then null else . end),
          current:{state:"unknown",reason:$reason},invalidity:null,
          reconcile_inventory:(if $summary_sampled then $summary.invalidity else null end),
@@ -1349,23 +1450,36 @@ secondmate_current_json() {  # <parent-tasks-json>
          parent_event:{raw:$event_raw,note:$event_note,age_seconds:$event_age,open_activities:$activities,open_decisions:$decisions,activity_scan:$activity_scan},
          terminal_evidence:$terminal,contradiction:false}')
     fi
-    records=$(jq -n --argjson records "$records" --argjson record "$record" '$records + [$record]')
+    records_file=$(jq_blob_file accumulated_records "$records") || return 1
+    record_file=$(jq_blob_file accumulated_record "$record") || return 1
+    records=$(jq -n --slurpfile records_blob "$records_file" --slurpfile record_blob "$record_file" '
+      ($records_blob[0]) as $records
+      | ($record_blob[0]) as $record
+      | $records + [$record]') || return 1
   done <<EOF
 $rows
 EOF
+  registry=$(printf '%s' "$union" | jq '.registry') || return 1
+  registry_file=$(jq_blob_file aggregate_registry "$registry") || return 1
+  records_file=$(jq_blob_file aggregate_records "$records") || return 1
   jq -n \
-    --argjson registry "$(printf '%s' "$union" | jq '.registry')" \
-    --argjson records "$records" \
+    --slurpfile registry_blob "$registry_file" \
+    --slurpfile records_blob "$records_file" \
     --argjson total_registered "$total_registered" \
     --argjson total "$total" \
     --argjson shown "$shown" \
     --argjson truncated "$truncated" \
-    '{registry:$registry,records:$records,total_registered:$total_registered,total:$total,shown:$shown,truncated:$truncated}'
+    '($registry_blob[0]) as $registry
+    | ($records_blob[0]) as $records
+    | {registry:$registry,records:$records,total_registered:$total_registered,total:$total,shown:$shown,truncated:$truncated}'
 }
 
 secondmate_landed_from_current_json() {  # <secondmate-current-json>
-  jq -n --argjson current "$1" '
-    {records:[ $current.records[]
+  local current_file
+  current_file=$(jq_blob_file landed_current "$1") || return 1
+  jq -n --slurpfile current_blob "$current_file" '
+    ($current_blob[0]) as $current
+    | {records:[ $current.records[]
       | select(.provenance.selected == "structured-home") as $mate
       | $mate.landed[]
       | . + {home:$mate.home,home_id:$mate.id}],
@@ -1413,6 +1527,13 @@ SECONDMATE_CURRENT_JSON=$(secondmate_current_json "$TASKS_JSON") \
 SECONDMATE_LANDED_JSON=$(secondmate_landed_from_current_json "$SECONDMATE_CURRENT_JSON") \
   || { echo "fm-fleet-snapshot: secondmate landed projection failed" >&2; exit 1; }
 
+RENDER_BACKLOG_FILE=$(jq_blob_file render_backlog "$BACKLOG_JSON") || exit 1
+RENDER_TASKS_FILE=$(jq_blob_file render_tasks "$TASKS_JSON") || exit 1
+RENDER_MAIN_INVENTORY_FILE=$(jq_blob_file render_main_inventory "$MAIN_INVENTORY_JSON") || exit 1
+RENDER_SCOUT_REPORTS_FILE=$(jq_blob_file render_scout_reports "$SCOUT_REPORTS_JSON") || exit 1
+RENDER_SECONDMATE_CURRENT_FILE=$(jq_blob_file render_secondmate_current "$SECONDMATE_CURRENT_JSON") || exit 1
+RENDER_SECONDMATE_LANDED_FILE=$(jq_blob_file render_secondmate_landed "$SECONDMATE_LANDED_JSON") || exit 1
+
 jq -n \
   --arg generated "$SNAPSHOT_NOW" \
   --arg fm_home "$FM_HOME" \
@@ -1421,13 +1542,19 @@ jq -n \
   --arg data "$DATA" \
   --arg config "$CONFIG" \
   --arg projects "$PROJECTS" \
-  --argjson backlog "$BACKLOG_JSON" \
-  --argjson tasks "$TASKS_JSON" \
-  --argjson main_inventory "$MAIN_INVENTORY_JSON" \
-  --argjson scout_reports "$SCOUT_REPORTS_JSON" \
-  --argjson secondmate_current "$SECONDMATE_CURRENT_JSON" \
-  --argjson secondmate_landed "$SECONDMATE_LANDED_JSON" \
-  'def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
+  --slurpfile backlog_blob "$RENDER_BACKLOG_FILE" \
+  --slurpfile tasks_blob "$RENDER_TASKS_FILE" \
+  --slurpfile main_inventory_blob "$RENDER_MAIN_INVENTORY_FILE" \
+  --slurpfile scout_reports_blob "$RENDER_SCOUT_REPORTS_FILE" \
+  --slurpfile secondmate_current_blob "$RENDER_SECONDMATE_CURRENT_FILE" \
+  --slurpfile secondmate_landed_blob "$RENDER_SECONDMATE_LANDED_FILE" \
+  '($backlog_blob[0]) as $backlog
+   | ($tasks_blob[0]) as $tasks
+   | ($main_inventory_blob[0]) as $main_inventory
+   | ($scout_reports_blob[0]) as $scout_reports
+   | ($secondmate_current_blob[0]) as $secondmate_current
+   | ($secondmate_landed_blob[0]) as $secondmate_landed
+   | def backlog_by_id($id): ($backlog.records[]? | select(.structured == true and .id == $id) | .) // null;
    def task_by_id($id): ($tasks[]? | select(.id == $id) | .) // null;
    def report_kind($id): (task_by_id($id).kind // backlog_by_id($id).kind // "scout");
    {

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -5,6 +5,8 @@
 # `fm-fleet-snapshot.v1`.
 # The command is read-only: it does not acquire the session lock, drain wakes,
 # arm watchers, mutate backlog state, or write reports.
+# Its only write is one private temporary directory of jq input, created per
+# process and removed on every exit path, so `mktemp` is required beside `jq`.
 #
 # Top-level fields:
 #   schema: stable schema id.

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -244,7 +244,10 @@ jq_blob_file() {  # <slot> <blob>
       return 1
       ;;
   esac
-  printf '%s' "$2" > "$file" || return 1
+  printf '%s' "$2" > "$file" || {
+    printf 'fm-fleet-snapshot: cannot write jq input for %s\n' "$1" >&2
+    return 1
+  }
   printf '%s' "$file"
 }
 
@@ -255,7 +258,10 @@ jq_blob_file() {  # <slot> <blob>
 # written with no trailing newline, because --rawfile keeps one.
 jq_raw_file() {  # <slot> <value>
   local file="$SNAPSHOT_TMPDIR/$1.txt"
-  printf '%s' "$2" > "$file" || return 1
+  printf '%s' "$2" > "$file" || {
+    printf 'fm-fleet-snapshot: cannot write jq input for %s\n' "$1" >&2
+    return 1
+  }
   printf '%s' "$file"
 }
 
@@ -699,13 +705,10 @@ task_json_lines() {
 # used by secondmate_home_summary_json, without inventing live task rows.
 # Meta inventory remains the sole source of live workers; this object only
 # discloses backlog↔task inconsistency for renderers (Bearings omitted/gates).
-main_inventory_json() {  # <backlog-json> <tasks-json>
-  local backlog_file tasks_file
-  backlog_file=$(jq_blob_file main_inventory_backlog "$1") || return 1
-  tasks_file=$(jq_blob_file main_inventory_tasks "$2") || return 1
+main_inventory_json() {  # <backlog-file> <tasks-file>
   jq -n \
-    --slurpfile backlog_blob "$backlog_file" \
-    --slurpfile tasks_blob "$tasks_file" '
+    --slurpfile backlog_blob "$1" \
+    --slurpfile tasks_blob "$2" '
     ($backlog_blob[0]) as $backlog
     | ($tasks_blob[0]) as $tasks
     | ([ $backlog.records[]?
@@ -732,10 +735,7 @@ main_inventory_json() {  # <backlog-json> <tasks-json>
 # validated parent read needs.
 # This mode never reads parent events or terminal text and never aggregates
 # nested secondmates.
-secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
-  local backlog_file tasks_file
-  backlog_file=$(jq_blob_file home_summary_backlog "$1") || return 1
-  tasks_file=$(jq_blob_file home_summary_tasks "$2") || return 1
+secondmate_home_summary_json() {  # <backlog-file> <tasks-file>
   jq -n \
     --arg generated "$SNAPSHOT_NOW" \
     --arg home "$FM_HOME" \
@@ -743,8 +743,8 @@ secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
     --argjson queued_n "$FM_SNAPSHOT_SECONDMATE_QUEUED" \
     --argjson decisions_n "$FM_SNAPSHOT_SECONDMATE_DECISIONS" \
     --argjson landed_n "$FM_SNAPSHOT_SECONDMATE_LANDED_PER_HOME" \
-    --slurpfile backlog_blob "$backlog_file" \
-    --slurpfile tasks_blob "$tasks_file" '
+    --slurpfile backlog_blob "$1" \
+    --slurpfile tasks_blob "$2" '
     ($backlog_blob[0]) as $backlog
     | ($tasks_blob[0]) as $tasks
     | def trunc($n):
@@ -1230,16 +1230,15 @@ parent_evidence_reconciliation_json() {  # <summary-json> <activities-json> <dec
        inconclusive:any(($activity_results + $decision_results)[]; .verdict == "inconclusive")}'
 }
 
-secondmate_current_json() {  # <parent-tasks-json>
-  local tasks=$1 registry union rows total_registered total shown truncated
+secondmate_current_json() {  # <parent-tasks-file>
+  local tasks_file=$1 registry union rows total_registered total shown truncated
   local row id home host remote registered registry_error task sampled_spawn_gen status_file event_raw event_note event_epoch event_age
   local activity_scan activities decisions reconciliation provenance freshness reason summary summary_rc summary_bytes summary_sampled summary_valid summary_reason summary_invalidity state current_reason terminal terminal_contradiction contradiction
   local records='[]' seen_homes=''
-  local registry_file tasks_file summary_file decisions_file activities_file activity_scan_file reconciliation_file
+  local registry_file summary_file decisions_file activities_file activity_scan_file reconciliation_file
   local records_file record_file current_reason_file reason_file
   registry=$(registry_secondmates_json) || return 1
   registry_file=$(jq_blob_file union_registry "$registry") || return 1
-  tasks_file=$(jq_blob_file union_tasks "$tasks") || return 1
   union=$(jq -n --slurpfile registry_blob "$registry_file" --slurpfile tasks_blob "$tasks_file" '
     ($registry_blob[0]) as $registry
     | ($tasks_blob[0]) as $tasks
@@ -1532,22 +1531,26 @@ scout_report_lines() {
 BACKLOG_JSON=$(backlog_json) || { echo "fm-fleet-snapshot: backlog read failed" >&2; exit 1; }
 TASKS_JSON=$(task_json_lines) || { echo "fm-fleet-snapshot: task snapshot failed" >&2; exit 1; }
 
+# The parsed backlog and the task inventory are each computed once and never
+# reassigned, and both are read by several filters, so each one owns a single
+# slot that every consumer reads by path.
+BACKLOG_FILE=$(jq_blob_file backlog "$BACKLOG_JSON") || exit 1
+TASKS_FILE=$(jq_blob_file tasks "$TASKS_JSON") || exit 1
+
 if [ "$OUTPUT_MODE" = secondmate-home-summary ]; then
-  secondmate_home_summary_json "$BACKLOG_JSON" "$TASKS_JSON" \
+  secondmate_home_summary_json "$BACKLOG_FILE" "$TASKS_FILE" \
     || { echo "fm-fleet-snapshot: secondmate home summary failed" >&2; exit 1; }
   exit 0
 fi
 
 SCOUT_REPORTS_JSON=$(scout_report_lines)
-MAIN_INVENTORY_JSON=$(main_inventory_json "$BACKLOG_JSON" "$TASKS_JSON") \
+MAIN_INVENTORY_JSON=$(main_inventory_json "$BACKLOG_FILE" "$TASKS_FILE") \
   || { echo "fm-fleet-snapshot: main inventory summary failed" >&2; exit 1; }
-SECONDMATE_CURRENT_JSON=$(secondmate_current_json "$TASKS_JSON") \
+SECONDMATE_CURRENT_JSON=$(secondmate_current_json "$TASKS_FILE") \
   || { echo "fm-fleet-snapshot: registered secondmate aggregation failed" >&2; exit 1; }
 SECONDMATE_LANDED_JSON=$(secondmate_landed_from_current_json "$SECONDMATE_CURRENT_JSON") \
   || { echo "fm-fleet-snapshot: secondmate landed projection failed" >&2; exit 1; }
 
-RENDER_BACKLOG_FILE=$(jq_blob_file render_backlog "$BACKLOG_JSON") || exit 1
-RENDER_TASKS_FILE=$(jq_blob_file render_tasks "$TASKS_JSON") || exit 1
 RENDER_MAIN_INVENTORY_FILE=$(jq_blob_file render_main_inventory "$MAIN_INVENTORY_JSON") || exit 1
 RENDER_SCOUT_REPORTS_FILE=$(jq_blob_file render_scout_reports "$SCOUT_REPORTS_JSON") || exit 1
 RENDER_SECONDMATE_CURRENT_FILE=$(jq_blob_file render_secondmate_current "$SECONDMATE_CURRENT_JSON") || exit 1
@@ -1561,8 +1564,8 @@ jq -n \
   --arg data "$DATA" \
   --arg config "$CONFIG" \
   --arg projects "$PROJECTS" \
-  --slurpfile backlog_blob "$RENDER_BACKLOG_FILE" \
-  --slurpfile tasks_blob "$RENDER_TASKS_FILE" \
+  --slurpfile backlog_blob "$BACKLOG_FILE" \
+  --slurpfile tasks_blob "$TASKS_FILE" \
   --slurpfile main_inventory_blob "$RENDER_MAIN_INVENTORY_FILE" \
   --slurpfile scout_reports_blob "$RENDER_SCOUT_REPORTS_FILE" \
   --slurpfile secondmate_current_blob "$RENDER_SECONDMATE_CURRENT_FILE" \

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -212,9 +212,11 @@ command -v jq >/dev/null 2>&1 || { echo "fm-fleet-snapshot: jq not found" >&2; e
 # Every blob whose size tracks the backlog, the task inventory, the scout-report
 # inventory, a status-log decision fold, or a registered-secondmate aggregation
 # is therefore handed to jq with --slurpfile, which reads the value from a file
-# and has no argv ceiling. Each such filter binds the slurped value back to its
-# original name up front, so the filter bodies stay unchanged. Bounded scalars
-# and fixed-shape per-task objects stay on --arg/--argjson.
+# and has no argv ceiling. A raw string whose length tracks the data, such as a
+# child home summary's own reason, travels the same way through --rawfile. Each
+# such filter binds the file-read value back to its original name up front, so
+# the filter bodies stay unchanged. Bounded scalars and fixed-shape per-task
+# objects stay on --arg/--argjson.
 #
 # The blob files live in one private mktemp directory per process, so several
 # snapshot runs in flight on the same home cannot collide, and one file per
@@ -242,6 +244,17 @@ jq_blob_file() {  # <slot> <blob>
       return 1
       ;;
   esac
+  printf '%s' "$2" > "$file" || return 1
+  printf '%s' "$file"
+}
+
+# Write raw string <value> to this process's private file for <slot> and echo that
+# path, for a value read back with --rawfile. An empty value is written rather than
+# refused: --rawfile on an empty file binds the empty string, which is exactly what
+# --arg bound, and an empty reason is a meaningful "no reason" here. The value is
+# written with no trailing newline, because --rawfile keeps one.
+jq_raw_file() {  # <slot> <value>
+  local file="$SNAPSHOT_TMPDIR/$1.txt"
   printf '%s' "$2" > "$file" || return 1
   printf '%s' "$file"
 }
@@ -1223,7 +1236,7 @@ secondmate_current_json() {  # <parent-tasks-json>
   local activity_scan activities decisions reconciliation provenance freshness reason summary summary_rc summary_bytes summary_sampled summary_valid summary_reason summary_invalidity state current_reason terminal terminal_contradiction contradiction
   local records='[]' seen_homes=''
   local registry_file tasks_file summary_file decisions_file activities_file activity_scan_file reconciliation_file
-  local records_file record_file
+  local records_file record_file current_reason_file reason_file
   registry=$(registry_secondmates_json) || return 1
   registry_file=$(jq_blob_file union_registry "$registry") || return 1
   tasks_file=$(jq_blob_file union_tasks "$tasks") || return 1
@@ -1378,18 +1391,21 @@ secondmate_current_json() {  # <parent-tasks-json>
       activities_file=$(jq_blob_file current_activities "$activities") || return 1
       activity_scan_file=$(jq_blob_file current_activity_scan "$activity_scan") || return 1
       reconciliation_file=$(jq_blob_file current_reconciliation "$reconciliation") || return 1
+      current_reason_file=$(jq_raw_file current_reason "$current_reason") || return 1
       record=$(jq -n \
-        --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg state "$state" --arg current_reason "$current_reason" --arg observed "$SNAPSHOT_NOW" \
+        --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg state "$state" --arg observed "$SNAPSHOT_NOW" \
         --arg spawn_gen "$sampled_spawn_gen" \
         --argjson registered "$registered" --argjson summary_valid "$summary_valid" \
         --argjson terminal "$terminal" --argjson contradiction "$contradiction" \
         --arg event_raw "$event_raw" --arg event_note "$event_note" --argjson event_age "$event_age" \
+        --rawfile current_reason_raw "$current_reason_file" \
         --slurpfile summary_blob "$summary_file" \
         --slurpfile decisions_blob "$decisions_file" \
         --slurpfile activities_blob "$activities_file" \
         --slurpfile activity_scan_blob "$activity_scan_file" \
         --slurpfile reconciliation_blob "$reconciliation_file" '
-        ($summary_blob[0]) as $summary
+        ($current_reason_raw) as $current_reason
+        | ($summary_blob[0]) as $summary
         | ($decisions_blob[0]) as $decisions
         | ($activities_blob[0]) as $activities
         | ($activity_scan_blob[0]) as $activity_scan
@@ -1426,17 +1442,20 @@ secondmate_current_json() {  # <parent-tasks-json>
       # The sampled home summary reaches here unbounded too: the byte-limit rejection
       # keeps the oversized text it just measured, so it cannot ride argv either.
       summary_file=$(jq_blob_file fallback_summary "$summary") || return 1
+      reason_file=$(jq_raw_file fallback_reason "$reason") || return 1
       record=$(jq -n \
-        --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg reason "$reason" --arg observed "$SNAPSHOT_NOW" \
+        --arg id "$id" --arg home "$home" --arg host "$host" --argjson remote "$remote" --arg observed "$SNAPSHOT_NOW" \
         --arg spawn_gen "$sampled_spawn_gen" \
         --arg provenance "$provenance" --arg freshness "$freshness" --arg event_raw "$event_raw" --arg event_note "$event_note" \
         --argjson registered "$registered" --argjson event_age "$event_age" --argjson terminal "$terminal" \
         --argjson summary_sampled "$summary_sampled" \
+        --rawfile reason_raw "$reason_file" \
         --slurpfile activities_blob "$activities_file" \
         --slurpfile activity_scan_blob "$activity_scan_file" \
         --slurpfile decisions_blob "$decisions_file" \
         --slurpfile summary_blob "$summary_file" '
-        ($activities_blob[0]) as $activities
+        ($reason_raw) as $reason
+        | ($activities_blob[0]) as $activities
         | ($activity_scan_blob[0]) as $activity_scan
         | ($decisions_blob[0]) as $decisions
         | ($summary_blob[0]) as $summary

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -910,6 +910,47 @@ test_default_is_bounded_and_local_only() {
   pass "default output is bounded, local-only, and marks omitted surfaces"
 }
 
+# Bearings is what the captain actually asks for, and it dies with the canonical
+# snapshot underneath it. A parsed backlog past the kernel's per-argv-string ceiling
+# used to take out the whole chart, so pin the chain end to end here as well.
+# tests/lib.sh owns the ceiling and the fixture.
+test_oversized_backlog_still_charts_bearings() {
+  local home fakebin toon json canon backlog_bytes
+  home=$(make_home oversized-bearings)
+  fm_write_oversized_backlog "$home"
+  mkdir -p "$home/projects/filler-001"
+  fm_write_meta "$home/state/filler-001.meta" \
+    "window=firstmate:fm-filler-001" \
+    "worktree=$home/projects/filler-001" \
+    "project=alpha" \
+    "harness=claude" \
+    "kind=ship" \
+    "mode=no-mistakes"
+  record_claude_state "$home/state" filler-001 busy
+  printf 'working: widening the backlog\n' > "$home/state/filler-001.status"
+  fakebin=$(make_fakebin "$home"); : > "$home/net.log"
+
+  canon=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$ROOT/bin/fm-fleet-snapshot.sh" --json) \
+    || fail "the canonical snapshot must survive a backlog wider than one argv string"
+  # Assert the size the fixture actually reached, so a narrower parser output cannot
+  # let this case pass without ever crossing the ceiling.
+  backlog_bytes=$(printf '%s' "$canon" | jq -c '.backlog' | LC_ALL=C wc -c | tr -d ' ')
+  [ "$backlog_bytes" -gt "$(fm_argv_string_ceiling)" ] \
+    || fail "fixture never crossed the ceiling: parsed backlog is only $backlog_bytes bytes"
+
+  toon=$(run "$home" "$fakebin") \
+    || fail "bearings TOON must survive a backlog wider than one argv string"
+  assert_contains "$toon" 'schema: fm-bearings.v1' "oversized-backlog TOON must still carry its schema"
+  assert_contains "$toon" 'filler-001' "oversized-backlog TOON must still chart the live task"
+  json=$(run "$home" "$fakebin" --json) \
+    || fail "bearings JSON must survive a backlog wider than one argv string"
+  printf '%s' "$json" | jq -e '
+    .schema == "fm-bearings.v1"
+    and ([.in_flight[] | select(.id == "filler-001")] | length) == 1
+  ' >/dev/null || fail "oversized-backlog bearings JSON is malformed: $json"
+  pass "bearings still charts a backlog wider than one argv string ($backlog_bytes parsed bytes)"
+}
+
 test_toon_json_parity() {
   local home fakebin toon json keys k
   home=$(make_home parity); write_fixture "$home"
@@ -1062,7 +1103,11 @@ test_perl_fallback_bounds_github_call() {
   fakebin=$(make_fakebin "$home")
   toolbin="$home/toolbin"
   mkdir -p "$toolbin"
-  for cmd in bash dirname basename jq date sed git grep tail cut tr head sort wc perl sleep cat find; do
+  # A deliberately minimal toolset: `timeout` is absent, which is the whole point.
+  # `mktemp` and `rm` are present because the canonical snapshot creates and removes a
+  # private directory for its jq input, the same coreutils baseline the session lock
+  # already requires.
+  for cmd in bash dirname basename jq date sed git grep tail cut tr head sort wc perl sleep cat find mktemp rm; do
     ln -s "$(command -v "$cmd")" "$toolbin/$cmd"
   done
   started=$(date +%s)
@@ -1988,3 +2033,4 @@ test_collapsed_captain_call_deferral_and_landed
 test_pr_repository_cap_and_expansion
 test_per_repository_pr_cap_is_disclosed
 test_projection_and_toon_fail_closed
+test_oversized_backlog_still_charts_bearings

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -49,6 +49,19 @@ SH
 echo "gh $*" >> "$NET_LOG"
 if [ "${FAKE_GH_FAIL:-0}" = 1 ]; then exit 1; fi
 if [ "${FAKE_GH_SLEEP:-0}" = 1 ]; then sleep 30; fi
+if [ -n "${FAKE_GH_WIDE:-}" ]; then
+  pad=$(printf '%0400d' 0 | tr '0' 'w')
+  i=1
+  printf '['
+  while [ "$i" -le "$FAKE_GH_WIDE" ]; do
+    [ "$i" -gt 1 ] && printf ','
+    printf '{"number":%d,"title":"Wide %d","url":"https://github.com/acme/wide/pull/%d","headRefName":"fm/wide-%d-%s","reviewDecision":"","mergeable":"MERGEABLE","statusCheckRollup":[]}' \
+      "$i" "$i" "$i" "$i" "$pad"
+    i=$((i + 1))
+  done
+  printf ']\n'
+  exit 0
+fi
 if [ "${FAKE_GH_MANY:-0}" = 1 ]; then
   cat <<'JSON'
 [{"number":1,"title":"One","url":"https://github.com/acme/repo/pull/1","headRefName":"fm/one","reviewDecision":"","mergeable":"MERGEABLE","statusCheckRollup":[]},{"number":2,"title":"Two","url":"https://github.com/acme/repo/pull/2","headRefName":"fm/two","reviewDecision":"","mergeable":"MERGEABLE","statusCheckRollup":[]},{"number":3,"title":"Three","url":"https://github.com/acme/repo/pull/3","headRefName":"fm/three","reviewDecision":"","mergeable":"MERGEABLE","statusCheckRollup":[]}]
@@ -1257,6 +1270,37 @@ test_per_repository_pr_cap_is_disclosed() {
   pass "per-repository open-PR caps are disclosed with an expansion knob"
 }
 
+# Live PR enrichment accumulates one row per open PR across every candidate
+# repository, and --all-pr-repos removes the repository cap outright, so those rows
+# cross the same per-argv-string ceiling the parsed backlog does. Two repositories at
+# a raised per-repository limit put each half over the ceiling on its own, so both the
+# per-repository page and the accumulated set are covered. tests/lib.sh owns the
+# ceiling.
+test_wide_live_pr_rows_survive_the_argv_string_ceiling() {
+  local home fakebin json prs_bytes
+  home=$(make_home wide-prs); write_large_fixture "$home" 2
+  fakebin=$(make_fakebin "$home"); : > "$home/net.log"
+
+  json=$(FM_BEARINGS_PR_LIMIT=300 FAKE_GH_WIDE=300 \
+    run "$home" "$fakebin" --include-prs --all-pr-repos --json) \
+    || fail "bearings must survive live PR rows wider than one argv string"
+  [ "$(grep -c '^gh pr list ' "$home/net.log")" = 2 ] \
+    || fail "the wide-PR fixture did not enrich both candidate repositories"
+  printf '%s' "$json" | jq -e '
+    .schema == "fm-bearings.v1"
+    and (.candidate_prs | length) == 600
+    and (.prs | startswith("checked (2 repos, 600 open"))
+    and ([.omitted[] | select(.surface | startswith("candidate_prs showing"))] | length) == 0
+  ' >/dev/null || fail "wide live PR enrichment lost rows or disclosure: $(printf '%s' "$json" | jq -c '{prs,n:(.candidate_prs|length)}')"
+  # Assert the size the fixture actually reached. Twice the ceiling means each
+  # single-repository page and the mid-loop accumulator both crossed it on their own,
+  # so neither conversion can pass vacuously.
+  prs_bytes=$(printf '%s' "$json" | jq -c '.candidate_prs' | LC_ALL=C wc -c | tr -d ' ')
+  [ "$prs_bytes" -gt $((FM_ARGV_STRING_CEILING * 2)) ] \
+    || fail "fixture never crossed the ceiling twice over: live PR rows are only $prs_bytes bytes"
+  pass "live PR rows wider than one argv string still reach the bearings model ($prs_bytes bytes)"
+}
+
 install_failing_jq() {  # <fakebin> <model|toon>
   local fakebin=$1 phase=$2 real
   real=$(command -v jq)
@@ -2088,3 +2132,4 @@ test_per_repository_pr_cap_is_disclosed
 test_projection_and_toon_fail_closed
 test_oversized_backlog_still_charts_bearings
 test_oversized_child_summary_reason_survives_the_ceiling
+test_wide_live_pr_rows_survive_the_argv_string_ceiling

--- a/tests/fm-bearings-snapshot.test.sh
+++ b/tests/fm-bearings-snapshot.test.sh
@@ -935,7 +935,7 @@ test_oversized_backlog_still_charts_bearings() {
   # Assert the size the fixture actually reached, so a narrower parser output cannot
   # let this case pass without ever crossing the ceiling.
   backlog_bytes=$(printf '%s' "$canon" | jq -c '.backlog' | LC_ALL=C wc -c | tr -d ' ')
-  [ "$backlog_bytes" -gt "$(fm_argv_string_ceiling)" ] \
+  [ "$backlog_bytes" -gt "$FM_ARGV_STRING_CEILING" ] \
     || fail "fixture never crossed the ceiling: parsed backlog is only $backlog_bytes bytes"
 
   toon=$(run "$home" "$fakebin") \
@@ -949,6 +949,59 @@ test_oversized_backlog_still_charts_bearings() {
     and ([.in_flight[] | select(.id == "filler-001")] | length) == 1
   ' >/dev/null || fail "oversized-backlog bearings JSON is malformed: $json"
   pass "bearings still charts a backlog wider than one argv string ($backlog_bytes parsed bytes)"
+}
+
+# The other unbounded value on this path is the child home summary's own reason, which
+# the parent splices into the record it builds for that child. It carries one id per
+# offending child, so it crosses the same per-argv-string ceiling a wide backlog does.
+# In-flight child rows with long ids and no child metadata make orphan_in_flight the
+# summary's first strict invalidity, and its reason is what the parent then has to
+# carry. tests/lib.sh owns the ceiling.
+test_oversized_child_summary_reason_survives_the_ceiling() {
+  local home mate fakebin canon record pad last_id reason_len count=300 i=1
+  home=$(make_home oversized-child-reason)
+  mate="$TMP_ROOT/oversized-child-reason-home"
+  make_valid_secondmate_home orphaned "$mate"
+  append_secondmate_registry "$home" orphaned "$mate"
+  write_parent_secondmate_event "$home" orphaned "$mate" "old orphan work"
+  pad=$(printf '%0489d' 0 | tr '0' 'x')
+  last_id=$(printf 'orphan-%03d-%s' "$count" "$pad")
+  {
+    printf '## In flight\n'
+    while [ "$i" -le "$count" ]; do
+      printf -- '- [ ] orphan-%03d-%s - Orphaned child %03d (repo: sample) (kind: ship) (since 2026-07-13)\n' \
+        "$i" "$pad" "$i"
+      i=$((i + 1))
+    done
+    printf '\n## Queued\n\n## Done\n'
+  } > "$mate/data/backlog.md"
+  fakebin=$(make_fakebin "$home"); : > "$home/net.log"
+
+  canon=$(PATH="$fakebin:$PATH" FM_HOME="$home" \
+    FM_SNAPSHOT_SECONDMATE_MAX_BYTES=1048576 FM_SNAPSHOT_SECONDMATE_TIMEOUT=60 \
+    "$ROOT/bin/fm-fleet-snapshot.sh" --json) \
+    || fail "the canonical snapshot must survive a child summary reason wider than one argv string"
+  # Project the one record down first, so a failure reports the mismatch instead of a
+  # third of a megabyte of snapshot.
+  record=$(printf '%s' "$canon" | jq -c --arg last "$last_id" '
+    [ .secondmate_current.records[] | select(.id == "orphaned")
+      | {state:.current.state,provenance:.provenance.selected,trust:.provenance.trust,
+         reason_prefixed:((.current.reason // "")
+           | startswith("structured home state invalid: in-flight backlog item has no child metadata: ")),
+         reason_carries_last_id:((.current.reason // "") | contains($last)),
+         reason_length:((.current.reason // "") | length)} ]')
+  printf '%s' "$record" | jq -e '
+    length == 1
+    and (.[0] | .state == "no_active_work" and .provenance == "structured-home"
+      and .trust == "partial-structured"
+      and .reason_prefixed and .reason_carries_last_id)
+  ' >/dev/null || fail "the parent lost an oversized child summary reason: $record"
+  # Assert the length the fixture actually reached, so a shorter reason cannot let this
+  # case pass without ever crossing the ceiling.
+  reason_len=$(printf '%s' "$record" | jq '.[0].reason_length')
+  [ "$reason_len" -gt "$FM_ARGV_STRING_CEILING" ] \
+    || fail "fixture never crossed the ceiling: child summary reason is only $reason_len bytes"
+  pass "a child summary reason wider than one argv string still reaches its record ($reason_len bytes)"
 }
 
 test_toon_json_parity() {
@@ -2034,3 +2087,4 @@ test_pr_repository_cap_and_expansion
 test_per_repository_pr_cap_is_disclosed
 test_projection_and_toon_fail_closed
 test_oversized_backlog_still_charts_bearings
+test_oversized_child_summary_reason_survives_the_ceiling

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -743,6 +743,47 @@ test_open_decision_clears_on_keyed_resolution() {
 # defect: a terminal single-owner task's stale, never-keyed-resolved needs-decision
 # must not linger as pending. Decisions come purely from the keyed fold reconciled
 # against the crew lifecycle; report prose never opens or reopens a decision.
+# A parsed backlog past the kernel's per-argv-string ceiling cannot travel to jq as
+# a command-line value at all: execve fails and every snapshot mode dies with it.
+# tests/lib.sh owns the ceiling and the fixture.
+test_oversized_backlog_survives_the_argv_string_ceiling() {
+  local home fakebin json summary backlog_bytes
+  home=$(make_home oversized-backlog)
+  fm_write_oversized_backlog "$home"
+  mkdir -p "$home/projects/filler-001"
+  fm_write_meta "$home/state/filler-001.meta" \
+    "window=firstmate:fm-filler-001" \
+    "worktree=$home/projects/filler-001" \
+    "project=alpha" \
+    "harness=claude" \
+    "kind=ship" \
+    "mode=ship"
+  record_claude_idle "$home/state" filler-001
+  fakebin=$(make_fakebin "$home")
+
+  json=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$SNAPSHOT" --json) \
+    || fail "the fleet snapshot must survive a backlog wider than one argv string"
+  # Assert the size the fixture actually reached, so a narrower parser output cannot
+  # let this case pass without ever crossing the ceiling.
+  backlog_bytes=$(printf '%s' "$json" | jq -c '.backlog' | LC_ALL=C wc -c | tr -d ' ')
+  [ "$backlog_bytes" -gt "$(fm_argv_string_ceiling)" ] \
+    || fail "fixture never crossed the ceiling: parsed backlog is only $backlog_bytes bytes"
+  printf '%s' "$json" | jq -e --argjson want "$FM_OVERSIZED_BACKLOG_ITEMS" '
+    .schema == "fm-fleet-snapshot.v1"
+    and (.backlog.records | length) == $want
+    and (.backlog.records | map(select(.structured == true)) | length) == $want
+    and ([.tasks[] | select(.id == "filler-001" and .backlog.id == "filler-001")] | length) == 1
+  ' >/dev/null || fail "an oversized backlog must still render every record and its task join: $json"
+
+  summary=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$SNAPSHOT" --secondmate-home-summary) \
+    || fail "the home summary must survive a backlog wider than one argv string"
+  printf '%s' "$summary" | jq -e '
+    .schema == "fm-secondmate-home-summary.v1"
+    and (.queued | type) == "array" and (.counts | type) == "object"
+  ' >/dev/null || fail "oversized-backlog home summary is malformed: $summary"
+  pass "a backlog wider than one argv string still renders both snapshot modes ($backlog_bytes parsed bytes)"
+}
+
 test_completed_scout_report_is_pointer_not_pending() {
   local home fakebin out
   home=$(make_home completed-scout)
@@ -814,3 +855,4 @@ test_scout_reports_include_teardown_reports
 test_backlog_tasks_axi_forms_and_overrides
 test_view_renders_snapshot
 test_view_renders_dead_secondmate_agent_status
+test_oversized_backlog_survives_the_argv_string_ceiling

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -743,47 +743,6 @@ test_open_decision_clears_on_keyed_resolution() {
 # defect: a terminal single-owner task's stale, never-keyed-resolved needs-decision
 # must not linger as pending. Decisions come purely from the keyed fold reconciled
 # against the crew lifecycle; report prose never opens or reopens a decision.
-# A parsed backlog past the kernel's per-argv-string ceiling cannot travel to jq as
-# a command-line value at all: execve fails and every snapshot mode dies with it.
-# tests/lib.sh owns the ceiling and the fixture.
-test_oversized_backlog_survives_the_argv_string_ceiling() {
-  local home fakebin json summary backlog_bytes
-  home=$(make_home oversized-backlog)
-  fm_write_oversized_backlog "$home"
-  mkdir -p "$home/projects/filler-001"
-  fm_write_meta "$home/state/filler-001.meta" \
-    "window=firstmate:fm-filler-001" \
-    "worktree=$home/projects/filler-001" \
-    "project=alpha" \
-    "harness=claude" \
-    "kind=ship" \
-    "mode=ship"
-  record_claude_idle "$home/state" filler-001
-  fakebin=$(make_fakebin "$home")
-
-  json=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$SNAPSHOT" --json) \
-    || fail "the fleet snapshot must survive a backlog wider than one argv string"
-  # Assert the size the fixture actually reached, so a narrower parser output cannot
-  # let this case pass without ever crossing the ceiling.
-  backlog_bytes=$(printf '%s' "$json" | jq -c '.backlog' | LC_ALL=C wc -c | tr -d ' ')
-  [ "$backlog_bytes" -gt "$FM_ARGV_STRING_CEILING" ] \
-    || fail "fixture never crossed the ceiling: parsed backlog is only $backlog_bytes bytes"
-  printf '%s' "$json" | jq -e --argjson want "$FM_OVERSIZED_BACKLOG_ITEMS" '
-    .schema == "fm-fleet-snapshot.v1"
-    and (.backlog.records | length) == $want
-    and (.backlog.records | map(select(.structured == true)) | length) == $want
-    and ([.tasks[] | select(.id == "filler-001" and .backlog.id == "filler-001")] | length) == 1
-  ' >/dev/null || fail "an oversized backlog must still render every record and its task join: $json"
-
-  summary=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$SNAPSHOT" --secondmate-home-summary) \
-    || fail "the home summary must survive a backlog wider than one argv string"
-  printf '%s' "$summary" | jq -e '
-    .schema == "fm-secondmate-home-summary.v1"
-    and (.queued | type) == "array" and (.counts | type) == "object"
-  ' >/dev/null || fail "oversized-backlog home summary is malformed: $summary"
-  pass "a backlog wider than one argv string still renders both snapshot modes ($backlog_bytes parsed bytes)"
-}
-
 test_completed_scout_report_is_pointer_not_pending() {
   local home fakebin out
   home=$(make_home completed-scout)
@@ -838,6 +797,47 @@ test_parked_scout_decision_stays_pending() {
       and .hints.open_decisions[0].key == "q1"
   ' >/dev/null || fail "a scout still parked at a decision must stay pending: $out"
   pass "a scout still parked at a decision stays pending (terminal clear does not over-fire)"
+}
+
+# A parsed backlog past the kernel's per-argv-string ceiling cannot travel to jq as
+# a command-line value at all: execve fails and every snapshot mode dies with it.
+# tests/lib.sh owns the ceiling and the fixture.
+test_oversized_backlog_survives_the_argv_string_ceiling() {
+  local home fakebin json summary backlog_bytes
+  home=$(make_home oversized-backlog)
+  fm_write_oversized_backlog "$home"
+  mkdir -p "$home/projects/filler-001"
+  fm_write_meta "$home/state/filler-001.meta" \
+    "window=firstmate:fm-filler-001" \
+    "worktree=$home/projects/filler-001" \
+    "project=alpha" \
+    "harness=claude" \
+    "kind=ship" \
+    "mode=ship"
+  record_claude_idle "$home/state" filler-001
+  fakebin=$(make_fakebin "$home")
+
+  json=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$SNAPSHOT" --json) \
+    || fail "the fleet snapshot must survive a backlog wider than one argv string"
+  # Assert the size the fixture actually reached, so a narrower parser output cannot
+  # let this case pass without ever crossing the ceiling.
+  backlog_bytes=$(printf '%s' "$json" | jq -c '.backlog' | LC_ALL=C wc -c | tr -d ' ')
+  [ "$backlog_bytes" -gt "$FM_ARGV_STRING_CEILING" ] \
+    || fail "fixture never crossed the ceiling: parsed backlog is only $backlog_bytes bytes"
+  printf '%s' "$json" | jq -e --argjson want "$FM_OVERSIZED_BACKLOG_ITEMS" '
+    .schema == "fm-fleet-snapshot.v1"
+    and (.backlog.records | length) == $want
+    and (.backlog.records | map(select(.structured == true)) | length) == $want
+    and ([.tasks[] | select(.id == "filler-001" and .backlog.id == "filler-001")] | length) == 1
+  ' >/dev/null || fail "an oversized backlog must still render every record and its task join: $json"
+
+  summary=$(PATH="$fakebin:$PATH" FM_HOME="$home" "$SNAPSHOT" --secondmate-home-summary) \
+    || fail "the home summary must survive a backlog wider than one argv string"
+  printf '%s' "$summary" | jq -e '
+    .schema == "fm-secondmate-home-summary.v1"
+    and (.queued | type) == "array" and (.counts | type) == "object"
+  ' >/dev/null || fail "oversized-backlog home summary is malformed: $summary"
+  pass "a backlog wider than one argv string still renders both snapshot modes ($backlog_bytes parsed bytes)"
 }
 
 test_empty_fleet_json

--- a/tests/fm-fleet-snapshot-view.test.sh
+++ b/tests/fm-fleet-snapshot-view.test.sh
@@ -766,7 +766,7 @@ test_oversized_backlog_survives_the_argv_string_ceiling() {
   # Assert the size the fixture actually reached, so a narrower parser output cannot
   # let this case pass without ever crossing the ceiling.
   backlog_bytes=$(printf '%s' "$json" | jq -c '.backlog' | LC_ALL=C wc -c | tr -d ' ')
-  [ "$backlog_bytes" -gt "$(fm_argv_string_ceiling)" ] \
+  [ "$backlog_bytes" -gt "$FM_ARGV_STRING_CEILING" ] \
     || fail "fixture never crossed the ceiling: parsed backlog is only $backlog_bytes bytes"
   printf '%s' "$json" | jq -e --argjson want "$FM_OVERSIZED_BACKLOG_ITEMS" '
     .schema == "fm-fleet-snapshot.v1"

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -226,6 +226,39 @@ fm_git_worktree() {
   git -C "$repo" worktree add --quiet -b "$branch" "$worktree"
 }
 
+# --- oversized-backlog fixture ----------------------------------------------
+#
+# Linux caps a SINGLE argv string at MAX_ARG_STRLEN, 131072 bytes, independently of
+# the much larger total ARG_MAX. Anything that hands a whole parsed backlog to a
+# child process as a command-line value therefore breaks outright once a real
+# captain backlog grows past that size, so the suites that read the backlog pin the
+# behavior with a fixture whose PARSED form clears the ceiling with margin.
+#
+# fm_argv_string_ceiling echoes the ceiling, and fm_write_oversized_backlog writes
+# the fixture. The items are ordinary in-flight rows plus the retained note line
+# each one carries: wide, not unusual. A consuming test asserts the parsed size it
+# actually reached, so a narrower parser output cannot make the case vacuous.
+FM_ARGV_STRING_CEILING=131072
+FM_OVERSIZED_BACKLOG_ITEMS=240
+
+fm_argv_string_ceiling() {
+  printf '%s\n' "$FM_ARGV_STRING_CEILING"
+}
+
+# fm_write_oversized_backlog <home> [count]: write <home>/data/backlog.md with
+# <count> in-flight items (default FM_OVERSIZED_BACKLOG_ITEMS).
+fm_write_oversized_backlog() {
+  local home=$1 count=${2:-$FM_OVERSIZED_BACKLOG_ITEMS} i=1
+  {
+    printf '## In flight\n'
+    while [ "$i" -le "$count" ]; do
+      printf -- '- [ ] filler-%03d - Synthetic entry %03d widening the parsed backlog past the single-argument ceiling (repo: alpha) (kind: ship) (priority: 2) (since 2026-08-01)\n' "$i" "$i"
+      printf '  Retained note %03d, kept wide so each parsed record carries real body text.\n' "$i"
+      i=$((i + 1))
+    done
+  } > "$home/data/backlog.md"
+}
+
 # --- state/<id>.meta writers ------------------------------------------------
 
 # fm_write_meta <file> <key=val> ...: write the given key=val lines to a meta

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -234,16 +234,13 @@ fm_git_worktree() {
 # captain backlog grows past that size, so the suites that read the backlog pin the
 # behavior with a fixture whose PARSED form clears the ceiling with margin.
 #
-# fm_argv_string_ceiling echoes the ceiling, and fm_write_oversized_backlog writes
-# the fixture. The items are ordinary in-flight rows plus the retained note line
-# each one carries: wide, not unusual. A consuming test asserts the parsed size it
-# actually reached, so a narrower parser output cannot make the case vacuous.
+# FM_ARGV_STRING_CEILING is the ceiling, and fm_write_oversized_backlog writes the
+# fixture. The items are ordinary in-flight rows plus the retained note line each one
+# carries: wide, not unusual. A consuming test asserts the parsed size it actually
+# reached, so a narrower parser output cannot make the case vacuous.
+# shellcheck disable=SC2034 # Read by the suites that source this lib, not by the lib.
 FM_ARGV_STRING_CEILING=131072
 FM_OVERSIZED_BACKLOG_ITEMS=240
-
-fm_argv_string_ceiling() {
-  printf '%s\n' "$FM_ARGV_STRING_CEILING"
-}
 
 # fm_write_oversized_backlog <home> [count]: write <home>/data/backlog.md with
 # <count> in-flight items (default FM_OVERSIZED_BACKLOG_ITEMS).


### PR DESCRIPTION
## Intent

Fix status reporting on this firstmate home, which was dead: bin/fm-bearings-snapshot.sh, /bearings, and the interactive fleet board all sit on bin/fm-fleet-snapshot.sh, and that script failed on EVERY invocation with "/usr/bin/jq: Argument list too long" followed by "fm-fleet-snapshot: main inventory summary failed". Root cause: the script built the whole parsed backlog into one shell variable and handed it to jq as a single command-line value. Linux caps a SINGLE argv string at MAX_ARG_STRLEN, 131072 bytes, independently of the much larger total ARG_MAX, so once the captain's backlog crossed that cap execve of jq failed outright. The captain's backlog is legitimately 178789 bytes and will keep growing, so the fix must scale with it.

Constraints the captain set explicitly, all deliberate: (1) plumbing repair only, do NOT restructure the snapshot, change its field set, its bounds, its output contract, or its help text; (2) do NOT work around the limit by truncating, sampling, or bounding the backlog; (3) fix EVERY site that passes a potentially unbounded value, not just the first reported line, because repairing one site only moves the failure to the next; (4) a regression test that fails before the fix and passes after it, driving a synthetic backlog whose parsed JSON exceeds 131072 bytes, proven non-vacuous by reverting the fix and watching it fail; (5) output content byte-identical for a small backlog, captured before and compared after; (6) any temp file made safely, cleaned up on every exit path including failure, and placed where a concurrent snapshot run cannot collide with it; (7) no em-dashes anywhere in code, comments, tests, or commit messages; (8) firstmate's own shared tracked material, so the firstmate-coding-guidelines skill applies: shellcheck-clean bin scripts, tests colocated in tests/ extending an existing runner, tests exercising behavior through an executable interface and never asserting implementation-source bytes, and the one-owner rule for every contract.

Decisions and tradeoffs I made while doing the work, so they are not mistaken for accidents. Every blob whose size tracks the data now reaches jq through --slurpfile from a file, which arrives on a file descriptor with no argv ceiling; each converted filter is prefixed with "($x_blob[0]) as $x |" bindings so the original filter bodies stay unchanged, which is what keeps the output contract identical. Bounded scalars and fixed-shape per-task objects deliberately STAY on --arg/--argjson: converting them would add temp-file churn for no benefit. One site, the per-task keyed open-decision set, deliberately uses jq stdin rather than a temp file, because that jq call sits in a "for ... done | jq" pipeline whose subshell would swallow a "return 1" from the temp-file helper, so a write failure could not propagate; stdin keeps that call's failure loud. jq_blob_file deliberately REFUSES an empty blob rather than writing it, because --slurpfile on an empty file yields [] and $x[0] would then silently bind null where --argjson previously failed loudly; preserving that loud failure is also why I rejected process substitution as the mechanism even though it needs no mktemp. The temp directory is one private mktemp -d (mode 0700, unique name) per process with one file per named slot, removed by traps on normal exit, failure, HUP, INT, and TERM; it is created eagerly in the main shell rather than lazily because a $(...) subshell would lose both the assignment and the trap. A SIGKILL still leaks that directory, which is untrappable by definition and matches the convention tests/lib.sh already documents for its own fixture roots; I deliberately did NOT add an orphan reaper, because that is scope growth for a 40KB leak and an unowned-directory reaper could delete a concurrent run's live input.

Test decisions: tests/lib.sh is the single owner of both the ceiling constant and the oversized-backlog fixture, per the one-owner rule, rather than duplicating either into two suites. The two new cases each assert the parsed size they actually reached, so a narrower parser output can never make them vacuously pass. I added mktemp and rm to the deliberately minimal toolbin list in test_perl_fallback_bounds_github_call, because the snapshot now needs them; timeout stays absent there on purpose since bounding without coreutils timeout is that test's whole point. That is a real new dependency and it is intentional: mktemp is already an unconditional firstmate runtime requirement through bin/fm-lock.sh, which every session hits, and tests/fm-teardown.test.sh already lists both tools in its equivalent minimal list.

Verified before committing: all four output modes succeed on the real 178789-byte backlog where all four previously failed; small-fixture output is byte-identical apart from the recorded repo root path, which differs only because the two compared trees live at different paths; both touched suites are green; bin/fm-lint.sh is clean. One unrelated pre-existing failure exists in tests/fm-bearings-board.test.sh on this host: tasks-axi has no mise version set, so a fixture cannot create its captain hold. I proved that failure reproduces identically on a pristine copy of the default branch, so it is environmental and not part of this change.

## What Changed

- `bin/fm-fleet-snapshot.sh` and `bin/fm-bearings-snapshot.sh` now pass every jq input whose size tracks fleet data (parsed backlog, task inventory, scout reports, secondmate registry/records/reason, reconciliation blobs, live PR rows and their accumulator) via `--slurpfile`/`--rawfile` from a per-process `mktemp -d` directory instead of `--arg`/`--argjson`, which `execve` rejects past the 131072-byte per-argv-string cap. New `jq_blob_file`/`jq_raw_file` helpers write one file per named slot and refuse an empty JSON blob so the old loud failure is preserved; the directory is removed by EXIT, HUP, INT, and TERM traps. Filter bodies are unchanged, with each converted call prefixed by `($x_blob[0]) as $x` bindings; bounded scalars and fixed-shape per-task objects stay on argv, and the per-task open-decision set moves to jq stdin so its write failure still propagates out of the `for ... done | jq` pipeline.
- `tests/lib.sh` becomes the single owner of the `FM_ARGV_STRING_CEILING` constant and the `fm_write_oversized_backlog` fixture. Four new cases across `tests/fm-fleet-snapshot-view.test.sh` and `tests/fm-bearings-snapshot.test.sh` drive an oversized backlog, an oversized child-home summary reason, and wide live PR rows through the executable interfaces, each asserting the parsed byte size it actually reached so it cannot pass vacuously.
- CI expected test counts move from 15 to 16 for the snapshot/fleet-view suite and 42 to 45 for Bearings; `mktemp` and `rm` join the deliberately minimal toolbin list in `test_perl_fallback_bounds_github_call`, and both scripts' read-only headers now note the one private temp directory they write.

## Risk Assessment

✅ Low: Well-bounded plumbing: every converted jq filter parses and runs, output is byte-identical to the base commit across all five invocation modes I exercised, the three new regression fixtures provably cross the 131072-byte ceiling, and the CI count pins match what the suites actually emit; the only finding is a misattached doc comment in a test file.

## Testing

I ran the two touched suites from the worktree (fm-fleet-snapshot-view: 16 ok; fm-bearings-snapshot: 45 ok, matching the updated CI counts) plus fm-crew-state as a smoke check on the shared tests/lib.sh edit, then proved each of the three new cases non-vacuous by re-running them against a tree where only the two bin scripts were reverted to the base commit, where they fail with the exact reported "jq: Argument list too long" / "main inventory summary failed" pair. For end-user evidence I drove the real commands on a 194478-byte backlog (captain's real one is 178789): pre-fix all five captain-facing surfaces exit 1, post-fix all five render, and a separate fixture shows a registered secondmate's 353KB validated summary silently losing 400 landed rows pre-fix and carrying them post-fix. I also verified the captain's explicit side constraints: small-backlog output byte-identical across all four modes with the clock and recorded root pinned, and the private temp directory 0700, unique per process under concurrency, and removed on success, on a mid-run projection failure, and on TERM/HUP/INT (INT needed a foreground child, since bash ignores it for background jobs), with no leak on the product's own timeout-kill path either. No UI, HTML, or rendered surface changed in this diff, so there is no screenshot: the end-user surfaces are CLI text, captured as before/after transcripts, and building the lavish HTML fleet board would have required arming a live Lavish session and answer source, an outward-facing side effect I did not trigger. I did not run tests/fm-bearings-board.test.sh, the pre-existing environmental failure named in the intent: it is outside the touched set and does not invoke either changed script. Everything passed and the worktree is clean.

<details>
<summary>Evidence: Before/after CLI transcript of all five captain-facing surfaces on a 194478-byte backlog</summary>

<code>BEFORE (base f170ced):&#10;fm-fleet-snapshot.sh --json exit=1 jq: Argument list too long / fm-fleet-snapshot: main inventory summary failed&#10;fm-fleet-snapshot.sh --secondmate-home-summary exit=1 fm-fleet-snapshot: secondmate home summary failed&#10;fm-bearings-snapshot.sh (the /bearings chart) exit=1&#10;fm-bearings-snapshot.sh --json exit=1&#10;fm-fleet-view.sh (human fleet board) exit=1&#10;&#10;AFTER (target 1a3a67b):&#10;fm-fleet-snapshot.sh --json exit=0 {&#34;schema&#34;:&#34;fm-fleet-snapshot.v1&#34;,&#34;backlog_records&#34;:745,&#34;tasks&#34;:1,&#34;parsed_backlog_bytes&#34;:769593}&#10;fm-fleet-snapshot.sh --secondmate-home-summary exit=0 {&#34;schema&#34;:&#34;fm-secondmate-home-summary.v1&#34;,...}&#10;fm-bearings-snapshot.sh exit=0&#10;schema: fm-bearings.v1&#10;home: demo/home&#10;prs: &#34;not_requested (run: /bearings include PRs)&#34;&#10;in_flight[1]{id,kind,state,doing}:&#10;filler-001,ship,working,harness busy (claude-hook)&#10;gates[1]{id,title,blocked_by,reason,owner}:&#10;(main-inventory),in-flight backlog item has no child metadata,&#34;-&#34;,main inventory,(main)&#10;fm-bearings-snapshot.sh --json exit=0 {&#34;schema&#34;:&#34;fm-bearings.v1&#34;,&#34;in_flight&#34;:1,&#34;first_in_flight&#34;:&#34;filler-001&#34;}&#10;fm-fleet-view.sh exit=0 # Fleet View / ## Under Way | filler-001 | working / pane | ship | alpha | tmux | present |</code>

```text
=== demo home ===
FM_HOME            /tmp/no-mistakes-evidence/01M0QJD8RT6J1XJ98AJED1SSN2/demo/home
backlog.md bytes   194478 (captain real-world size: 178789)
kernel MAX_ARG_STRLEN ceiling for one argv string: 131072 bytes

######################## BEFORE the fix: base commit f170ced ########################
--- $ fm-fleet-snapshot.sh --json   (canonical snapshot: /bearings, the fleet board, and fm-fleet-view all sit on it)
exit=1
/tmp/no-mistakes-evidence/01M0QJD8RT6J1XJ98AJED1SSN2/baseline/bin/fm-fleet-snapshot.sh: line 635: /usr/bin/jq: Argument list too long
fm-fleet-snapshot: main inventory summary failed

--- $ fm-fleet-snapshot.sh --secondmate-home-summary   (what a parent home reads from this one)
exit=1
/tmp/no-mistakes-evidence/01M0QJD8RT6J1XJ98AJED1SSN2/baseline/bin/fm-fleet-snapshot.sh: line 663: /usr/bin/jq: Argument list too long
fm-fleet-snapshot: secondmate home summary failed

--- $ fm-bearings-snapshot.sh   (the TOON chart the captain gets from /bearings)
exit=1
/tmp/no-mistakes-evidence/01M0QJD8RT6J1XJ98AJED1SSN2/baseline/bin/fm-fleet-snapshot.sh: line 635: /usr/bin/jq: Argument list too long
fm-fleet-snapshot: main inventory summary failed
[...]

--- $ fm-bearings-snapshot.sh --json   (the model the interactive fleet board payload is composed from)
exit=1
/tmp/no-mistakes-evidence/01M0QJD8RT6J1XJ98AJED1SSN2/baseline/bin/fm-fleet-snapshot.sh: line 635: /usr/bin/jq: Argument list too long
fm-fleet-snapshot: main inventory summary failed

--- $ fm-fleet-view.sh   (the human fleet board renderer)
exit=1
/tmp/no-mistakes-evidence/01M0QJD8RT6J1XJ98AJED1SSN2/baseline/bin/fm-fleet-snapshot.sh: line 635: /usr/bin/jq: Argument list too long
fm-fleet-snapshot: main inventory summary failed
[...]

######################## AFTER the fix: target commit 1a3a67b ########################
--- $ fm-fleet-snapshot.sh --json   (canonical snapshot: /bearings, the fleet board, and fm-fleet-view all sit on it)
exit=0  {"schema":"fm-fleet-snapshot.v1","backlog_records":745,"tasks":1,"main_inventory_valid":false,"parsed_backlog_bytes":769593}

--- $ fm-fleet-snapshot.sh --secondmate-home-summary   (what a parent home reads from this one)
exit=0  {"schema":"fm-secondmate-home-summary.v1","state":null,"counts":{"active_children":1,"decisions_open":0,"holds":0,"queued":0,"landed":0,"endpoints":1}}

--- $ fm-bearings-snapshot.sh   (the TOON chart the captain gets from /bearings)
exit=0
schema: fm-bearings.v1
home: demo/home
generated: "2026-08-23T18:00:00Z"
prs: "not_requested (run: /bearings include PRs)"
in_flight[1]{id,kind,state,doing}:
  filler-001,ship,working,harness busy (claude-hook)
secondmates: []
decisions_open: []
landed: []
gates[1]{id,title,blocked_by,reason,owner}:
  (main-inventory),in-flight backlog item has no child metadata,"-",main inventory,(main)
reports: []
recorded_prs: []
omitted[8]{surface,reveal}:
  backlog item bodies,"--fields bodies"
  task paths,"--fields paths"
  watch/steer actions,"--fields actions"
  healthy endpoint detail,"--fields endpoints"
  full scout-report inventory,"--all-reports"
  superseded or prose-deferred queued items,"--all-queued"
  "main in-flight backlog item(s) have no child metadata: 744",inspect main data/backlog.md In flight vs state/*.meta
  live PR discovery + checks,"--include-prs"
[...]

--- $ fm-bearings-snapshot.sh --json   (the model the interactive fleet board payload is composed from)
exit=0  {"schema":"fm-bearings.v1","in_flight":1,"first_in_flight":"filler-001","queued":0,"prs":"not_requested (run: /bearings include PRs)"}

--- $ fm-fleet-view.sh   (the human fleet board renderer)
exit=0
# Fleet View

Schema: fm-fleet-snapshot.v1
Home: /tmp/no-mistakes-evidence/01M0QJD8RT6J1XJ98AJED1SSN2/demo/home

## Under Way
| ID | Current | Kind | Repo/Project | Backend | Endpoint | Artifact | Path | Watch / return channel |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| filler-001 | working / pane | ship | alpha | tmux | present | - | /tmp/no-mistakes-evidence/01M0QJD8RT6J1XJ98AJED1SSN2/demo/home/projects/filler-001 | bin/fm-peek.sh fm-filler-001 |

## Queued
No queued backlog records found.

## Done
[...]
```
</details>
<details>
<summary>Evidence: Silent loss of a secondmate&#39;s landed work pre-fix vs full roll-up post-fix</summary>

<code>child summary: 353253 bytes, {&#34;schema&#34;:&#34;fm-secondmate-home-summary.v1&#34;,&#34;valid&#34;:true,&#34;landed&#34;:400}&#10;&#10;PRE-FIX --json exit=0 {&#34;provenance&#34;:&#34;parent-event-fallback&#34;,&#34;trust&#34;:null,&#34;state&#34;:&#34;unknown&#34;,&#34;landed_in_record&#34;:0,&#34;landed_rollup&#34;:0,&#34;spliced_record_bytes&#34;:1406}&#10;bearings: landed: []&#10;POST-FIX --json exit=0 {&#34;provenance&#34;:&#34;structured-home&#34;,&#34;trust&#34;:&#34;complete&#34;,&#34;state&#34;:&#34;no_active_work&#34;,&#34;landed_in_record&#34;:400,&#34;landed_rollup&#34;:400,&#34;spliced_record_bytes&#34;:273201}&#10;bearings: landed[400]{id,what,artifact,owner}:</code>

```text
=== the child home summary the parent must splice (child home, its own mode) ===
child summary: 353253 bytes, {"schema":"fm-secondmate-home-summary.v1","valid":true,"decisions":0,"landed":400}

--- PRE-FIX (baseline) ---
fm-fleet-snapshot.sh --json exit=0  {"provenance":"parent-event-fallback","trust":null,"state":"unknown","decisions_open":0,"landed_in_record":0,"landed_rollup":0,"spliced_record_bytes":1406}
fm-bearings-snapshot.sh (all secondmate surfaces) exit=0
schema: fm-bearings.v1
secondmates[1]{id,state,doing,provenance,freshness,age_seconds,contradiction,reason}:
decisions_open: []
landed: []

--- POST-FIX (fixed) ---
fm-fleet-snapshot.sh --json exit=0  {"provenance":"structured-home","trust":"complete","state":"no_active_work","decisions_open":0,"landed_in_record":400,"landed_rollup":400,"spliced_record_bytes":273201}
fm-bearings-snapshot.sh (all secondmate surfaces) exit=0
schema: fm-bearings.v1
secondmates[1]{id,state,doing,provenance,freshness,age_seconds,contradiction,reason}:
decisions_open: []
landed[400]{id,what,artifact,owner}:

leftover private directories in TMPDIR: 0
```
</details>
<details>
<summary>Evidence: Each remaining new test run against both trees (fails before, passes after)</summary>

<code>test_oversized_child_summary_reason_survives_the_ceiling&#10;BEFORE not ok - the parent lost an oversized child summary reason: [{&#34;state&#34;:&#34;unknown&#34;,&#34;provenance&#34;:&#34;parent-event-fallback&#34;,&#34;reason_prefixed&#34;:false,&#34;reason_carries_last_id&#34;:false,&#34;reason_length&#34;:31}]&#10;AFTER ok - a child summary reason wider than one argv string still reaches its record (150675 bytes)&#10;&#10;test_wide_live_pr_rows_survive_the_argv_string_ceiling&#10;BEFORE fm-bearings-snapshot.sh: line 261: /usr/bin/jq: Argument list too long / fm-bearings-snapshot: projection failed&#10;not ok - bearings must survive live PR rows wider than one argv string&#10;AFTER ok - live PR rows wider than one argv string still reach the bearings model (330554 bytes)</code>

```text
########## test_oversized_child_summary_reason_survives_the_ceiling ##########
--- BEFORE (base commit f170ced bin scripts) ---
not ok - the parent lost an oversized child summary reason: [{"state":"unknown","provenance":"parent-event-fallback","reason_prefixed":false,"reason_carries_last_id":false,"reason_length":31}]
exit=
--- AFTER (target commit 1a3a67b) ---
ok - a child summary reason wider than one argv string still reaches its record (150675 bytes)
exit=
########## test_wide_live_pr_rows_survive_the_argv_string_ceiling ##########
--- BEFORE (base commit f170ced bin scripts) ---
/tmp/no-mistakes-evidence/01M0QJD8RT6J1XJ98AJED1SSN2/baseline/bin/fm-bearings-snapshot.sh: line 261: /usr/bin/jq: Argument list too long
jq: invalid JSON text passed to --argjson
Use jq --help for help with command-line options,
or see the jq manpage, or online docs  at https://jqlang.org
fm-bearings-snapshot: projection failed
not ok - bearings must survive live PR rows wider than one argv string
exit=
--- AFTER (target commit 1a3a67b) ---
ok - live PR rows wider than one argv string still reach the bearings model (330554 bytes)
exit=
```
</details>
<details>
<summary>Evidence: Byte-identical small-backlog output and private temp-directory hygiene</summary>

<code>IDENTICAL fm-fleet-snapshot.sh --json 9496 bytes sha256[0:16] before=73b44ab80e700da5 after=73b44ab80e700da5&#10;IDENTICAL fm-fleet-snapshot.sh --secondmate-home-summary 2075 bytes before=13fe4be9a18e0517 after=13fe4be9a18e0517&#10;IDENTICAL fm-bearings-snapshot.sh 1080 bytes before=5ec54f9e5d463203 after=5ec54f9e5d463203&#10;IDENTICAL fm-bearings-snapshot.sh --json 1828 bytes before=01682678894f29f3 after=01682678894f29f3&#10;&#10;two concurrent snapshots in one TMPDIR: exit 0 and 0; identical output: yes&#10;700 inthuson .../tmp/fm-fleet-snapshot.KuxXqr&#10;700 inthuson .../tmp/fm-fleet-snapshot.uuHsnd&#10;leftover directories after success: 0&#10;mid-run projection failure: exit=1 stderr=fm-bearings-snapshot: projection failed leftover: 0&#10;SIGTERM mid-run: exit=143 leftover: 0&#10;SIGHUP mid-run: exit=129 leftover: 0&#10;SIGINT to the foreground snapshot: exit=130 leftover: 0</code>

```text
=== (5) small-backlog output, byte-for-byte before vs after ===
pinned: FM_SNAPSHOT_NOW, FM_SNAPSHOT_NOW_EPOCH, FM_BEARINGS_NOW, FM_ROOT_OVERRIDE

IDENTICAL  fm-fleet-snapshot.sh --json                             9496 bytes  sha256[0:16] before=73b44ab80e700da5 after=73b44ab80e700da5  (rc 0/0)
IDENTICAL  fm-fleet-snapshot.sh --secondmate-home-summary          2075 bytes  sha256[0:16] before=13fe4be9a18e0517 after=13fe4be9a18e0517  (rc 0/0)
IDENTICAL  fm-bearings-snapshot.sh                                 1080 bytes  sha256[0:16] before=5ec54f9e5d463203 after=5ec54f9e5d463203  (rc 0/0)
IDENTICAL  fm-bearings-snapshot.sh --json                          1828 bytes  sha256[0:16] before=01682678894f29f3 after=01682678894f29f3  (rc 0/0)

=== (6) private temp directory: mode, uniqueness, cleanup on every exit path ===
two concurrent snapshots in one TMPDIR: exit 0 and 0; identical output: yes
distinct private directories observed while they ran (mode owner name):
  700 inthuson /tmp/no-mistakes-evidence/01M0QJD8RT6J1XJ98AJED1SSN2/contract/tmp/fm-fleet-snapshot.KuxXqr
  700 inthuson /tmp/no-mistakes-evidence/01M0QJD8RT6J1XJ98AJED1SSN2/contract/tmp/fm-fleet-snapshot.uuHsnd
leftover directories after success: 0

mid-run projection failure: exit=1  stderr=fm-bearings-snapshot: projection failed
leftover directories after failure: 0
SIGINT  mid-run: exit=0  leftover directories: 0
SIGTERM mid-run: exit=143  leftover directories: 0
SIGHUP  mid-run: exit=129  leftover directories: 0

TMPDIR contents at the end: 
SIGINT delivered while 1 private directory existed: exit=0  leftover directories: 0
watcher: private directory /tmp/no-mistakes-evidence/01M0QJD8RT6J1XJ98AJED1SSN2/contract/tmp/fm-fleet-snapshot.f6Hnrc exists, sending SIGINT to pid 3303988
SIGINT to the foreground snapshot: exit=0  leftover directories: 0
private directory while running: /tmp/no-mistakes-evidence/01M0QJD8RT6J1XJ98AJED1SSN2/contract/tmp/fm-fleet-snapshot.JoNjvW
SIGINT to the foreground snapshot: exit=130  leftover directories: 0
```
</details>
<details>
<summary>Evidence: Post-fix suite runs (16 ok fleet-view, 45 ok bearings) and their pre-fix counterparts</summary>

<code>fleet-snapshot-view.log: ok - a backlog wider than one argv string still renders both snapshot modes (236394 parsed bytes)&#10;bearings-snapshot.log: ok - bearings still charts a backlog wider than one argv string (236389 parsed bytes)&#10;ok - a child summary reason wider than one argv string still reaches its record (150675 bytes)&#10;ok - live PR rows wider than one argv string still reach the bearings model (330554 bytes)&#10;baseline-fleet-snapshot-view.log / baseline-bearings-snapshot.log: same cases fail pre-fix at bin/fm-fleet-snapshot.sh line 635</code>

```text
ok - empty fleet snapshot and view use explicit absence markers
ok - fixture snapshot covers task rows, backlog rows, pointers, and stable ordering
ok - main_inventory discloses orphan/unstructured and clears when inventory is consistent
ok - backlog normalization preserves strict roles and resolves every blocker compatibly
ok - snapshot event hints follow reconciled current state
ok - durable fold keeps an open decision past a later unrelated event
ok - a live secondmate endpoint preserves unrelated open decisions
ok - durable captain-held transfer closes the duplicate live status decision
ok - durable fold clears a decision only on a keyed resolution
ok - a completed scout's stale decision surfaces as a report pointer, not pending
ok - a scout still parked at a decision stays pending (terminal clear does not over-fire)
ok - snapshot includes durable scout reports after teardown
ok - snapshot parses tasks-axi rows and respects operational overrides
ok - fleet view renders the snapshot without secondmate peek guidance
ok - fleet view renders secondmate agent liveness
ok - a backlog wider than one argv string still renders both snapshot modes (236394 parsed bytes)
```
</details>
<details>
<summary>Evidence: Evidence index with the full method, sizes, and reproduction scripts</summary>

```text
# Test evidence: bearings/fleet snapshot off the jq argv ceiling

Branch `fm/bearings-snapshot-argv-limit-a1`, base `f170ced`, target `1a3a67b`.

Two scratch trees drive every before/after comparison here:

- `fixed/`    = `git archive 1a3a67b | tar -x` (identical to the worktree HEAD)
- `baseline/` = the same tree with ONLY `bin/fm-fleet-snapshot.sh` and
  `bin/fm-bearings-snapshot.sh` restored from `f170ced`, so the post-fix tests run
  against the pre-fix scripts and nothing else differs.

## 1. The reported failure, and the same commands after the fix

`demo-e2e.sh` -> `demo-e2e.log`. One home, `data/backlog.md` = 194478 bytes
(the captain's real one is 178789), parsed backlog 769593 bytes.

| surface | pre-fix | post-fix |
| --- | --- | --- |
| `fm-fleet-snapshot.sh --json` | exit 1, `jq: Argument list too long` + `main inventory summary failed` | exit 0, 745 records, task join intact |
| `fm-fleet-snapshot.sh --secondmate-home-summary` | exit 1, `secondmate home summary failed` | exit 0, `fm-secondmate-home-summary.v1` |
| `fm-bearings-snapshot.sh` (the `/bearings` TOON chart) | exit 1 | exit 0, full chart with `in_flight`, gates, `omitted[]` |
| `fm-bearings-snapshot.sh --json` (the fleet board's model) | exit 1 | exit 0, `fm-bearings.v1` |
| `fm-fleet-view.sh` (human fleet board) | exit 1 | exit 0, Under Way / Queued / Done tables |

## 2. Silent data loss on the aggregation path, not only a crash

`demo-structured-child.sh` -> `structured-child.log`. A registered secondmate whose
validated home summary is 353253 bytes:

- pre-fix: `provenance=parent-event-fallback`, `state=unknown`, **0** landed rows;
  bearings printed `landed: []`.
- post-fix: `provenance=structured-home`, `trust=complete`, 400 landed rows in the
  record and in the roll-up; bearings printed `landed[400]{...}`.

## 3. Each new regression test fails before the fix and passes after it

- `tests/fm-fleet-snapshot-view.test.sh` (16 ok post-fix) -> pre-fix the new case dies
  at `bin/fm-fleet-snapshot.sh: line 635: /usr/bin/jq: Argument list too long`
  (`baseline-fleet-snapshot-view.log` vs `fleet-snapshot-view.log`).
- `tests/fm-bearings-snapshot.test.sh` (45 ok post-fix) -> pre-fix the first new case
  dies the same way (`baseline-bearings-snapshot.log` vs `bearings-snapshot.log`).
- The other two new bearings cases, run one at a time against both trees
  (`regression-before-after.log`): the child-summary-reason case loses the reason
  pre-fix (`reason_length: 31`) and carries 150675 bytes post-fix; the wide-PR case
  dies at `fm-bearings-snapshot.sh: line 261` pre-fix and carries 330554 bytes post-fix.

## 4. Output contract and temp-file hygiene

`demo-contract-and-tempdir.sh` -> `contract-and-tempdir.log`.

- Small ordinary backlog, pinned clock and pinned recorded repo root: all four output
  modes are byte-identical pre-fix vs post-fix (same sha256 prefixes).
- Two concurrent snapshots in one TMPDIR: both exit 0 with identical output, each in
  its own `0700` private directory.
- No leftover directory after success, after a mid-run projection failure (exit 1),
  after SIGTERM (143), after SIGHUP (129), and after SIGINT (130, sent to a
  foreground child via `sigint-check.py`; the earlier background attempt could not
  test INT at all because bash ignores SIGINT for asynchronous jobs).
- The product's own child-summary bound (`timeout -k 1`) does not leak either: with
  `FM_SNAPSHOT_SECONDMATE_TIMEOUT` of 1s, 8s and 20s against a child home whose jq
  runs for minutes, the killed child left 0 directories, because the bound signals
  the whole process group so the deferred TERM trap still runs before the KILL.

## 5. Cost of the new plumbing

Small fixture, 3 runs each: pre-fix 0.197/0.196/0.196 s, post-fix 0.205/0.207/0.208 s.
Captain-sized 194478-byte backlog, post-fix: 1.439/1.442/1.444 s.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"cf121c06b7f2465f9d64dc33466a4454384c6144","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- 🚨 `.github/workflows/ci.yml:380` - The `macos-stock-bash` CI job hard-pins the number of `ok - ` lines each touched suite emits: `[ &#34;$snapshot_count&#34; -eq 15 ]` (line 380) and `[ &#34;$bearings_count&#34; -eq 42 ]` (line 388). `tests/lib.sh:pass()` prints exactly one `ok - ` per call and every test function calls it once, and the base commit had exactly 15 invoked tests in tests/fm-fleet-snapshot-view.test.sh and 42 in tests/fm-bearings-snapshot.test.sh -- matching those pins exactly. This change appends `test_oversized_backlog_survives_the_argv_string_ceiling` and `test_oversized_backlog_still_charts_bearings`, taking the counts to 16 and 43, but does not update the workflow. The job fails with `::error::expected 15 snapshot/fleet-view tests, got 16` and `::error::expected 42 Bearings tests, got 43`. Fix: bump 15 -&gt; 16 and 42 -&gt; 43 (both the comparison and the message text on lines 380-381 and 388-389).
- ⚠️ `bin/fm-fleet-snapshot.sh:1407` - `--arg reason &#34;$reason&#34;` (line 1407) and `--arg current_reason &#34;$current_reason&#34;` (line 1365) still carry a value whose length tracks the data, contradicting the intent&#39;s classification that every remaining `--arg` is a bounded scalar. Both derive from the child home summary&#39;s `.reason`, which `secondmate_home_summary_json` builds as `&#34;&lt;prefix&gt;: &#34; + (ids | join(&#34;, &#34;))` for the `orphan_in_flight`, `unowned_current`, `terminal_in_flight` and `child_current_unavailable` shapes (lines 770-782, 813-816) -- one entry per offending id, with no cap. The parent splices it at line 1335 (`reason=&#34;structured home state invalid: $summary_reason&#34;`) / line 1346 and passes it as one argv string. Its only bound is `FM_SNAPSHOT_SECONDMATE_MAX_BYTES` (default 262144, a documented knob), i.e. 2x the 131072 ceiling. Concrete arithmetic for `unowned_current` with 8-char ids and state `unknown`: the summary carries `invalidity.ids` at ~11 bytes/id and the reason at ~18 bytes/id, so at ~7300 unowned children the summary is ~211KB (passes the 256KB gate) while `.reason` alone is ~131KB and execve of the record jq fails with E2BIG -- the snapshot then dies with `registered secondmate aggregation failed`, the same authorized failure class. I could not prove this reachable at default bounds: the child snapshot runs under `fm_run_timed &#34;$FM_SNAPSHOT_SECONDMATE_TIMEOUT&#34;` (8s), which a home with 7000+ task metas would blow long before returning, so `reason` collapses to the short `structured home snapshot timed out` string. Confirm the bounded-scalar classification for these two, or route them via `jq --rawfile` (output-identical, since `printf &#39;%s&#39;` writes no trailing newline).
- ℹ️ `tests/lib.sh:244` - `fm_argv_string_ceiling()` is an accessor over the `FM_ARGV_STRING_CEILING` constant declared two lines above it, while its sibling constant `FM_OVERSIZED_BACKLOG_ITEMS` is read directly (`--argjson want &#34;$FM_OVERSIZED_BACKLOG_ITEMS&#34;` in tests/fm-fleet-snapshot-view.test.sh:771). Two access styles for two constants owned by the same block, plus a command substitution per assertion for no benefit. Reading `&#34;$FM_ARGV_STRING_CEILING&#34;` directly at both call sites (tests/fm-fleet-snapshot-view.test.sh:769, tests/fm-bearings-snapshot.test.sh:929) drops the function and makes the two constants consistent.

🔧 Fix: route unbounded secondmate reasons off jq argv
4 issues (1 warning, 3 infos) still open:
- ⚠️ `bin/fm-fleet-snapshot.sh:242` - A temp-file write failure is completely silent. `jq_blob_file` (line 242) and `jq_raw_file` (line 253) return 1 with no diagnostic when `printf &#39;%s&#39; &#34;$2&#34; &gt; &#34;$file&#34;` fails; only the empty-blob case prints anything (line 238). At lines 1520-1525 the callers are `|| exit 1` with no message of their own, so with /tmp full or TMPDIR removed mid-run the snapshot exits 1 emitting nothing at all on stderr, and `/bearings`, `bin/fm-fleet-view.sh`, and the board all report a bare failure with no cause. Every other failure in this script announces itself (`main inventory summary failed`, `registered secondmate aggregation failed`, `cannot create a private directory for jq input`), and this change is specifically about a status surface that had been silently dead. Fix: print one line on write failure in both helpers, mirroring the existing `fm-fleet-snapshot: empty jq input for %s` message (e.g. `fm-fleet-snapshot: cannot write jq input for %s`), which also covers the bare `|| exit 1` render sites.
- ℹ️ `bin/fm-fleet-snapshot.sh:1443` - The per-secondmate accumulator now writes two temp files and spawns a jq process per iteration just to append one element: `accumulated_records` re-serializes the whole growing array on every row (lines 1443-1448), which is O(n^2) bytes written and O(n) extra jq execs. `--slurpfile` reads a stream of values into an array, so the whole accumulator collapses to appending `$record` to one JSONL slot inside the loop and binding `$records_blob` (not `$records_blob[0]`) at the final aggregate on line 1457 - I confirmed `--slurpfile` on a two-value file yields a 2-element array in document order, and on an empty file yields `[]`, which is exactly the `records=&#39;[]&#39;` seed. That removes the `records` shell variable, the `accumulated_record`/`accumulated_records` slots, and the per-iteration jq, with identical output. Still one file per named slot, so it does not conflict with the stated no-file-per-iteration rule.
- ℹ️ `bin/fm-fleet-snapshot.sh:1520` - `BACKLOG_JSON` and `TASKS_JSON` are computed once (lines 1503-1504) and never change, but each is written to disk several times per run under different slot names: backlog to `main_inventory_backlog` (696), `home_summary_backlog` (729), and `render_backlog` (1520); tasks to `main_inventory_tasks` (697), `home_summary_tasks` (730), `union_tasks` (1230), and `render_tasks` (1521). On the captain&#39;s real home that is roughly a megabyte of redundant temp I/O per snapshot, on a surface the fleet board re-runs on refresh, and it spreads ownership of one immutable value across four slots. Writing each once next to lines 1503-1504 and passing the path into `main_inventory_json`, `secondmate_home_summary_json`, and the union filter would leave one owner per blob. It does mean changing those helpers to take paths instead of JSON strings, so it is a follow-up rather than something to squeeze in here.
- ℹ️ `bin/fm-bearings-snapshot.sh:261` - Informational, not a blocker, and consistent with the stated decision to leave knob-bounded values on argv. One value on the /bearings surface still reaches jq as a single argv string and scales with fleet size: the PR row accumulator `jq -n --argjson a &#34;$rows&#34; --argjson b &#34;$repo_rows&#34;` (line 261) and the projection&#39;s `--argjson candidate_prs &#34;$CANDIDATE_PRS&#34;` (line 313). At defaults it is capped at FM_BEARINGS_PR_REPOS=10 x FM_BEARINGS_PR_LIMIT=20 = 200 rows at roughly 200 bytes, well under the ceiling. It crosses 131072 bytes at around 650 rows, reachable either with `--all-pr-repos` on a fleet spanning ~33 repos with full PR pages, or by raising FM_BEARINGS_PR_LIMIT past ~650 on a single repo, and the failure would be the same `Argument list too long` from the same surface. Both are documented knobs and both bound the value, so this matches the intent&#39;s own bounded-value classification; recording it only so the residual path is on the record against the fix-every-site constraint.

🔧 Fix: route bearings PR rows off argv and announce write failures
1 info still open:
- ℹ️ `tests/fm-fleet-snapshot-view.test.sh:746` - The new test was spliced in between an existing comment block and the function that block documents. Lines 738-745 are the Lavish-103 explanation for `test_completed_scout_report_is_pointer_not_pending` (&#34;a terminal single-owner task&#39;s stale, never-keyed-resolved needs-decision must not linger as pending&#34;), and the new argv-ceiling comment was appended to it at lines 746-748, so `test_oversized_backlog_survives_the_argv_string_ceiling` at line 749 now inherits both paragraphs while `test_completed_scout_report_is_pointer_not_pending` at line 787 is left with no doc at all. Nothing executable is affected. Fix: move the new function plus its own three-line comment below `test_completed_scout_report_is_pointer_not_pending`, or move lines 738-745 back down so they sit directly above the function they describe.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`/bin/bash tests/fm-fleet-snapshot-view.test.sh` (16 ok, includes the new test_oversized_backlog_survives_the_argv_string_ceiling)</code>
- <code>`/bin/bash tests/fm-bearings-snapshot.test.sh` (45 ok, includes the three new oversized cases and the mktemp/rm toolbin change in test_perl_fallback_bounds_github_call)</code>
- <code>`/bin/bash tests/fm-crew-state.test.sh` (53 ok) as a smoke check that the shared tests/lib.sh edit did not break other consumers</code>
- <code>Non-vacuity: both suites re-run in a tree where only bin/fm-fleet-snapshot.sh and bin/fm-bearings-snapshot.sh were restored from f170ced -&gt; new cases fail at `line 635` / `line 261` with `jq: Argument list too long`</code>
- <code>Non-vacuity per test: single-case drivers `tests/only-test_oversized_child_summary_reason_survives_the_ceiling.test.sh` and `tests/only-test_wide_live_pr_rows_survive_the_argv_string_ceiling.test.sh` run against both trees (fail before, pass after)</code>
- <code>Manual e2e: `demo-e2e.sh` runs `fm-fleet-snapshot.sh --json`, `fm-fleet-snapshot.sh --secondmate-home-summary`, `fm-bearings-snapshot.sh`, `fm-bearings-snapshot.sh --json`, and `fm-fleet-view.sh` on a 194478-byte backlog against the pre-fix and post-fix trees</code>
- <code>Manual e2e: `demo-structured-child.sh` drives a registered secondmate whose validated home summary is 353253 bytes through `fm-fleet-snapshot.sh --json` and `fm-bearings-snapshot.sh --all-secondmates --all-landed --all-decisions` on both trees</code>
- <code>Output contract: `demo-contract-and-tempdir.sh` diffs all four output modes pre/post on a small backlog with FM_SNAPSHOT_NOW, FM_SNAPSHOT_NOW_EPOCH, FM_BEARINGS_NOW and FM_ROOT_OVERRIDE pinned (`cmp`/sha256, byte-identical)</code>
- <code>Temp-dir hygiene: same script checks 0700 mode, distinct directories under two concurrent snapshots in one TMPDIR, and leftovers after success, after a mid-run jq projection failure, and after SIGTERM/SIGHUP; `sigint-check.py` sends SIGINT to a foreground snapshot (exit 130, 0 leftovers)</code>
- <code>Timeout-kill probe: `FM_SNAPSHOT_SECONDMATE_TIMEOUT` of 1s, 8s and 20s against a child home whose summary jq runs for minutes -&gt; parent exits 0, killed child leaves 0 private directories</code>
- `Runtime cost: 3 timed runs each of the small fixture pre-fix (0.197/0.196/0.196 s) and post-fix (0.205/0.207/0.208 s), plus the 194478-byte backlog post-fix (1.439/1.442/1.444 s)`
- <code>`git status --porcelain` before and after all testing (clean; every fixture and scratch tree lives under /tmp/no-mistakes-evidence)</code>

</details>

<details>
<summary>⚠️ **Document** - 2 infos</summary>

- ℹ️ `docs/configuration.md:309` - docs/configuration.md&#39;s &#34;Toolchain&#34; section is the single owner of the universal toolchain list, but that list covers only bootstrap-detected installable tools (node, git, gh, no-mistakes, the axi family). The snapshot&#39;s new mktemp/rm dependency is not in that class and mktemp was already an unconditional runtime requirement through bin/fm-lock.sh before this change, so I recorded the requirement in the fm-fleet-snapshot.sh header (its mechanics owner) rather than widening the bootstrap toolchain list. Flagging the placement call in case the captain wants a coreutils baseline sentence added to that owner as separate work.
- ℹ️ `bin/fm-bearings-snapshot.sh:170` - bin/fm-bearings-snapshot.sh&#39;s new comment names fm-fleet-snapshot.sh as the owner that &#34;documents it in full&#34; and then still restates the MAX_ARG_STRLEN 131072 rationale locally; tests/lib.sh states the constant a third time as FM_ARGV_STRING_CEILING. I left all three as written: the bearings copy already points at the owner and its extra sentence is the allowed one-line reinforcement at a genuine risk point, and the real owner of the number is the kernel. No prose surface duplicates it, so there is nothing stale to consolidate here.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
