### PR TITLE
fix(bin): deliver Flowy results through a durable retrying outbox

### DIFF
--- a/bin/fm-completion-outbox.sh
+++ b/bin/fm-completion-outbox.sh
@@ -22,8 +22,22 @@
 # caller on a latency-sensitive path can never be stalled by an unreachable
 # Flowy. Some later --drain is the sole owner of delivering what it recorded.
 #
+# CALLERS. bin/fm-watch.sh uses --no-drain on its signal path, because that path
+# runs immediately before the wake and must never wait on the network. Its
+# per-pass --drain is the sole AUTHORITATIVE delivery owner. Because a wake ends
+# the watcher process, a result recorded on the signal path would otherwise wait
+# for the next watcher generation to deliver it, so the watcher also runs one
+# --drain from its EXIT path after the wake is already durable. That exit drain
+# is a promptness optimization only, and it carries a hard total wall-clock
+# bound of FM_FLOWY_EXIT_DRAIN_SECONDS (default 5), well under the watcher's
+# 15-second poll: without the bound a blackholed endpoint would keep the exiting
+# watcher alive and delay re-arming, which is exactly the stall the record-only
+# signal path removes, moved one step later. Hitting the bound is a normal, safe
+# outcome - the record simply stays pending for the next per-pass drain.
+#
 # DRAIN (--drain, and implicitly after --status). Pending records are drained
-# oldest first and POSTed as JSON to the URL in config/grok-flowy-webhook,
+# oldest first by the monotonic ordinal each record carries, never by filename
+# collation, and POSTed as JSON to the URL in config/grok-flowy-webhook,
 # authenticated with the Keychain Bearer key for service firstmate-flowy-webhook.
 # No environment variable configures the endpoint. A record retires ONLY on
 # HTTP 2xx, at which point its per-record receipt is written to
@@ -63,10 +77,14 @@ CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 # a drain killed mid-POST cannot wedge every later delivery behind its lock.
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
+# The repo's shared millisecond clock, used for the record ordinal below.
+# shellcheck source=bin/fm-timing-lib.sh
+. "$SCRIPT_DIR/fm-timing-lib.sh"
 
 OUTBOX="$STATE/flowy-outbox"
 PENDING_DIR="$OUTBOX/pending"
 DELIVERED_DIR="$OUTBOX/delivered"
+ORDINAL_FILE="$OUTBOX/.ordinal"
 DRAIN_LOCK="$OUTBOX/.drain.lock"
 SNAPSHOT="$STATE/flowy-last.md"
 WEBHOOK_FILE="$CONFIG/grok-flowy-webhook"
@@ -151,16 +169,42 @@ artifact_for() {  # <task> <status-file>
   fi
 }
 
+# A strictly increasing stamp for record creation order, kept separate from the
+# whole-second recorded= field so the payload's meaning does not change.
+# fm_timing_now_ms is the repo's shared millisecond clock, but it degrades to
+# whole seconds on a shell without EPOCHREALTIME (macOS system bash 3.2, which
+# `env bash` still resolves to here), and two records written in one second
+# would then tie and fall back to path collation - exactly the ordering bug the
+# drain order exists to close. Carrying the previous value forward as a floor
+# makes the stamp monotonic however coarse the clock is, and also survives a
+# clock that steps backwards.
+next_ordinal() {
+  local now last tmp
+  now=$(fm_timing_now_ms) || now=0
+  case "$now" in ''|*[!0-9]*) now=0 ;; esac
+  last=$(cat "$ORDINAL_FILE" 2>/dev/null || printf '0')
+  case "$last" in ''|*[!0-9]*) last=0 ;; esac
+  [ "$now" -gt "$last" ] || now=$((last + 1))
+  if tmp=$(umask 077; mktemp "$OUTBOX/.ordinal.XXXXXX"); then
+    printf '%s\n' "$now" > "$tmp"
+    chmod 600 "$tmp"
+    mv -f "$tmp" "$ORDINAL_FILE"
+  fi
+  printf '%s' "$now"
+}
+
 # Oldest recorded result first. A plain glob is collation-ordered, which would
 # let the drain finish on an older record and hand the display snapshot a result
-# that is not the newest one delivered.
+# that is not the newest one delivered. A record written before this field
+# existed sorts first, which is where an older result belongs.
 pending_records() {
-  local record recorded tab
+  local record ordinal tab
   tab=$(printf '\t')
   for record in "$PENDING_DIR"/*; do
     [ -f "$record" ] || continue
-    recorded=$(record_field "$record" recorded)
-    printf '%s%s%s\n' "${recorded:-0}" "$tab" "$record"
+    ordinal=$(record_field "$record" ordinal)
+    case "$ordinal" in ''|*[!0-9]*) ordinal=0 ;; esac
+    printf '%s%s%s\n' "$ordinal" "$tab" "$record"
   done | LC_ALL=C sort -t"$tab" -k1,1n -k2,2 | cut -d"$tab" -f2-
 }
 
@@ -183,7 +227,7 @@ EOF
 }
 
 record_result() {  # <status-file>
-  local file=$1 result task digest record artifact tmp signature
+  local file=$1 result task digest record artifact tmp signature ordinal
   [ -f "$file" ] && [ ! -L "$file" ] || {
     note "status file is unavailable or unsafe: $file"
     return 1
@@ -232,10 +276,12 @@ record_result() {  # <status-file>
     note "cannot create a pending record for $task"
     return 1
   }
+  ordinal=$(next_ordinal)
   {
     printf 'task=%s\n' "$task"
     printf 'digest=%s\n' "$digest"
     printf 'recorded=%s\n' "$(date +%s)"
+    printf 'ordinal=%s\n' "$ordinal"
     printf 'artifact=%s\n' "$artifact"
     printf 'status=%s\n' "$file"
     printf 'result=%s\n' "$result"

--- a/bin/fm-completion-outbox.sh
+++ b/bin/fm-completion-outbox.sh
@@ -2,7 +2,7 @@
 # Durably deliver a captain-visible crew result to Flowy.
 #
 # Usage:
-#   fm-completion-outbox.sh --status STATUS_FILE [--dry-run]
+#   fm-completion-outbox.sh --status STATUS_FILE [--no-drain] [--dry-run]
 #   fm-completion-outbox.sh --drain [--dry-run]
 #
 # Delivery is a two-stage durable outbox, never one best-effort POST.
@@ -11,29 +11,46 @@
 # only done:, failed:, blocked:, and needs-decision: are results; anything else
 # is a silent no-op. A result becomes an immutable record at
 # state/flowy-outbox/pending/<task>.<digest> BEFORE any network call, where
-# <digest> covers the result line. Re-recording an identical result is a no-op,
-# and a second distinct result for the same task gets its own record, so no
-# result can overwrite another. --status then drains.
+# <digest> covers the result line together with the status file's wake
+# signature. Re-observing an unchanged status file is therefore a no-op, while
+# the same result text written again as a genuinely new event gets its own
+# record, as does a second distinct result for the same task, so no result can
+# overwrite another. --status then drains unless --no-drain is given.
 #
-# DRAIN (--drain, and implicitly after --status). Every pending record is
-# POSTed as JSON to the URL in config/grok-flowy-webhook, authenticated with the
-# Keychain Bearer key for service firstmate-flowy-webhook. No environment
-# variable configures the endpoint. A record retires ONLY on HTTP 2xx, at which
-# point its per-record receipt is written to
+# RECORD ONLY (--status --no-drain). Records exactly as above and returns
+# without any network call, Keychain read, or endpoint-configuration read, so a
+# caller on a latency-sensitive path can never be stalled by an unreachable
+# Flowy. Some later --drain is the sole owner of delivering what it recorded.
+#
+# DRAIN (--drain, and implicitly after --status). Pending records are drained
+# oldest first and POSTed as JSON to the URL in config/grok-flowy-webhook,
+# authenticated with the Keychain Bearer key for service firstmate-flowy-webhook.
+# No environment variable configures the endpoint. A record retires ONLY on
+# HTTP 2xx, at which point its per-record receipt is written to
 # state/flowy-outbox/delivered/<task>.<digest>.md. Any other outcome - a non-2xx
 # code, a transport failure, a missing URL file, an unavailable key - leaves the
 # record pending, so the next drain retries it and delivery state survives a
-# restart. A receipt therefore never exists without a 2xx.
+# restart. A receipt therefore never exists without a 2xx. A transport failure
+# is endpoint-wide rather than record-specific, so the first one ends the pass
+# and every remaining record simply stays pending for the next drain; a
+# per-record HTTP code such as 503 keeps the pass going.
 #
-# state/flowy-last.md is refreshed after a delivery as an aggregate DISPLAY
-# snapshot and is never delivery authority. Its pending: line lists the task ids
-# whose results are still undelivered, or (none).
+# state/flowy-last.md is an aggregate DISPLAY snapshot and is never delivery
+# authority. Only a 2xx creates it or moves its files: and status: lines, which
+# then describe the NEWEST result that actually reached Flowy. Its pending: line
+# lists the task ids whose results are still undelivered, or (none), and is
+# refreshed in an existing snapshot whenever the pending set changes, including
+# on a record-only run and on a pass that delivered nothing; every other line is
+# carried forward unchanged, so pending: is the one line that moves without a
+# 2xx.
 #
 # --dry-run reports what it would record and send and writes nothing at all: no
 # record, no receipt, no aggregate snapshot, and no network or Keychain call.
 #
-# Exit 0 when nothing is left pending, 1 when a record is still pending or the
-# run could not complete, 2 on usage.
+# Exit 2 on usage. A draining run exits 0 when nothing is left pending and 1
+# when a record is still pending or the run could not complete. A --no-drain run
+# exits 0 whenever the result is durably recorded, and 1 only when recording
+# itself failed.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -58,7 +75,7 @@ KEYCHAIN_ACCOUNT=flowy
 HTTP_TIMEOUT=${FM_FLOWY_HTTP_TIMEOUT:-20}
 
 usage() {
-  echo "usage: fm-completion-outbox.sh --status STATUS_FILE [--dry-run]" >&2
+  echo "usage: fm-completion-outbox.sh --status STATUS_FILE [--no-drain] [--dry-run]" >&2
   echo "       fm-completion-outbox.sh --drain [--dry-run]" >&2
   exit 2
 }
@@ -75,6 +92,7 @@ note() { echo "fm-completion-outbox: $*" >&2; }
 status_file=
 mode=
 dry_run=0
+no_drain=0
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --status)
@@ -89,6 +107,10 @@ while [ "$#" -gt 0 ]; do
       mode=drain
       shift
       ;;
+    --no-drain)
+      no_drain=1
+      shift
+      ;;
     --dry-run)
       dry_run=1
       shift
@@ -98,6 +120,9 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 [ -n "$mode" ] || usage
+# --no-drain narrows --status to its record stage; it cannot narrow a run whose
+# only stage is the drain.
+[ "$mode" = status ] || [ "$no_drain" -eq 0 ] || usage
 
 digest_of() {  # <text>
   local sum
@@ -126,12 +151,17 @@ artifact_for() {  # <task> <status-file>
   fi
 }
 
+# Oldest recorded result first. A plain glob is collation-ordered, which would
+# let the drain finish on an older record and hand the display snapshot a result
+# that is not the newest one delivered.
 pending_records() {
-  local record
+  local record recorded tab
+  tab=$(printf '\t')
   for record in "$PENDING_DIR"/*; do
     [ -f "$record" ] || continue
-    printf '%s\n' "$record"
-  done
+    recorded=$(record_field "$record" recorded)
+    printf '%s%s%s\n' "${recorded:-0}" "$tab" "$record"
+  done | LC_ALL=C sort -t"$tab" -k1,1n -k2,2 | cut -d"$tab" -f2-
 }
 
 pending_task_ids() {
@@ -153,7 +183,7 @@ EOF
 }
 
 record_result() {  # <status-file>
-  local file=$1 result task digest record artifact tmp
+  local file=$1 result task digest record artifact tmp signature
   [ -f "$file" ] && [ ! -L "$file" ] || {
     note "status file is unavailable or unsafe: $file"
     return 1
@@ -173,7 +203,13 @@ record_result() {  # <status-file>
   esac
 
   task=$(basename "$file" .status)
-  digest=$(digest_of "$result") || {
+  # The digest covers the watcher's own wake signature for this status file as
+  # well as the result line, so re-observing unchanged bytes still de-duplicates
+  # while a genuinely new event that happens to carry identical text - the same
+  # templated blocked: line raised a second time - is recorded and delivered
+  # again instead of being suppressed forever.
+  signature=$(fm_wake_signal_sig "$file") || signature=
+  digest=$(digest_of "$signature|$result") || {
     note "cannot digest the result for $task"
     return 1
   }
@@ -206,6 +242,9 @@ record_result() {  # <status-file>
   } > "$tmp"
   chmod 600 "$tmp"
   mv -f "$tmp" "$record"
+  # The pending set just grew, so the snapshot's pending: line would otherwise
+  # keep claiming this result is already delivered.
+  refresh_snapshot_pending || true
 }
 
 webhook_url() {
@@ -239,10 +278,16 @@ webhook_key() {
 }
 
 # Set by deliver_record on success so the aggregate snapshot describes the last
-# result that actually reached Flowy, never one that merely reached disk.
+# result that actually reached Flowy, never one that merely reached disk. The
+# drain walks its records oldest first, so the last one set here is the newest.
 DELIVERED_TASK=
 DELIVERED_RESULT=
 DELIVERED_ARTIFACT=
+
+# Set by deliver_record when the endpoint gave no HTTP response at all. That is
+# an endpoint-wide condition, not a property of the record being sent, so the
+# drain stops attempting further records for this pass.
+TRANSPORT_FAILED=0
 
 deliver_record() {  # <record> <url> <key>
   local record=$1 url=$2 key=$3 base task digest result artifact recorded payload code receipt tmp
@@ -289,6 +334,7 @@ deliver_record() {  # <record> <url> <key>
   case "$code" in
     2??) ;;
     *)
+      [ -n "$code" ] || TRANSPORT_FAILED=1
       note "Flowy webhook returned ${code:-no response} for $task; result stays pending"
       return 1
       ;;
@@ -331,6 +377,30 @@ write_snapshot() {  # <task> <result> <artifact>
   mv -f "$tmp" "$SNAPSHOT"
 }
 
+# Move ONLY the pending: line of an existing snapshot, carrying every other line
+# forward unchanged. A snapshot that does not exist yet is left alone: creating
+# one here would give the display a files:/status: pair no 2xx ever authorized.
+refresh_snapshot_pending() {
+  local tmp ids
+  [ -f "$SNAPSHOT" ] || return 0
+  ids=$(pending_task_ids)
+  tmp=$(umask 077; mktemp "$STATE/.flowy-last.XXXXXX") || {
+    note "cannot refresh the display snapshot's pending line"
+    return 1
+  }
+  awk -v ids="$ids" '
+    /^pending: / { print "pending: " ids; seen = 1; next }
+    { print }
+    END { if (!seen) print "pending: " ids }
+  ' "$SNAPSHOT" > "$tmp" || {
+    rm -f "$tmp"
+    note "cannot refresh the display snapshot's pending line"
+    return 1
+  }
+  chmod 600 "$tmp"
+  mv -f "$tmp" "$SNAPSHOT"
+}
+
 drain() {
   local records record url key delivered=0 remaining=0 rc=0
 
@@ -368,9 +438,17 @@ EOF
     return 1
   fi
 
+  TRANSPORT_FAILED=0
   while IFS= read -r record; do
     [ -n "$record" ] || continue
     [ -f "$record" ] || continue
+    # The endpoint already proved unreachable this pass, so every further POST
+    # would only buy another full timeout. Count the record as still pending and
+    # leave it untouched for the next drain.
+    if [ "$TRANSPORT_FAILED" -eq 1 ]; then
+      remaining=$((remaining + 1))
+      continue
+    fi
     if deliver_record "$record" "$url" "$key"; then
       delivered=$((delivered + 1))
     else
@@ -380,8 +458,14 @@ EOF
 $records
 EOF
 
+  if [ "$TRANSPORT_FAILED" -eq 1 ] && [ "$remaining" -gt 1 ]; then
+    note "the Flowy endpoint did not respond, so $remaining results stay pending for the next drain"
+  fi
+
   if [ "$delivered" -gt 0 ]; then
     write_snapshot "$DELIVERED_TASK" "$DELIVERED_RESULT" "$DELIVERED_ARTIFACT" || rc=1
+  else
+    refresh_snapshot_pending || rc=1
   fi
   [ "$remaining" -eq 0 ] || rc=1
 
@@ -394,5 +478,7 @@ rc=0
 if [ "$mode" = status ]; then
   record_result "$status_file" || rc=1
 fi
-drain || rc=1
+if [ "$no_drain" -eq 0 ]; then
+  drain || rc=1
+fi
 exit "$rc"

--- a/bin/fm-completion-outbox.sh
+++ b/bin/fm-completion-outbox.sh
@@ -65,7 +65,10 @@
 #
 # state/flowy-last.md is an aggregate DISPLAY snapshot and is never delivery
 # authority. Only a 2xx creates it or moves its files: and status: lines, which
-# then describe the NEWEST result that actually reached Flowy. Its pending: line
+# then describe the NEWEST result that actually reached Flowy. Newest is decided
+# by the record ordinal against the highest one the snapshot has ever named, not
+# by delivery order, because a per-record rejection can hold an older record back
+# into a later pass; retiring such a record moves only its pending: entry. Its pending: line
 # lists the task ids whose results are still undelivered, or (none), and is
 # refreshed in an existing snapshot whenever the pending set changes, including
 # on a record-only run and on a pass that delivered nothing; every other line is
@@ -99,6 +102,7 @@ OUTBOX="$STATE/flowy-outbox"
 PENDING_DIR="$OUTBOX/pending"
 DELIVERED_DIR="$OUTBOX/delivered"
 ORDINAL_FILE="$OUTBOX/.ordinal"
+SNAPSHOT_ORDINAL_FILE="$OUTBOX/.snapshot-ordinal"
 DRAIN_LOCK="$OUTBOX/.drain.lock"
 SNAPSHOT="$STATE/flowy-last.md"
 WEBHOOK_FILE="$CONFIG/grok-flowy-webhook"
@@ -192,18 +196,30 @@ artifact_for() {  # <task> <status-file>
 # drain order exists to close. Carrying the previous value forward as a floor
 # makes the stamp monotonic however coarse the clock is, and also survives a
 # clock that steps backwards.
+# A missing, empty, or non-numeric stamp file reads as 0, which sorts and
+# compares as "older than anything", exactly where an unknown belongs.
+read_ordinal() {  # <file>
+  local value
+  value=$(cat "$1" 2>/dev/null || printf '0')
+  case "$value" in ''|*[!0-9]*) value=0 ;; esac
+  printf '%s' "$value"
+}
+
+write_ordinal() {  # <file> <value>
+  local tmp
+  tmp=$(umask 077; mktemp "$1.XXXXXX") || return 1
+  printf '%s\n' "$2" > "$tmp"
+  chmod 600 "$tmp"
+  mv -f "$tmp" "$1"
+}
+
 next_ordinal() {
-  local now last tmp
+  local now last
   now=$(fm_timing_now_ms) || now=0
   case "$now" in ''|*[!0-9]*) now=0 ;; esac
-  last=$(cat "$ORDINAL_FILE" 2>/dev/null || printf '0')
-  case "$last" in ''|*[!0-9]*) last=0 ;; esac
+  last=$(read_ordinal "$ORDINAL_FILE")
   [ "$now" -gt "$last" ] || now=$((last + 1))
-  if tmp=$(umask 077; mktemp "$OUTBOX/.ordinal.XXXXXX"); then
-    printf '%s\n' "$now" > "$tmp"
-    chmod 600 "$tmp"
-    mv -f "$tmp" "$ORDINAL_FILE"
-  fi
+  write_ordinal "$ORDINAL_FILE" "$now" || true
   printf '%s' "$now"
 }
 
@@ -339,10 +355,14 @@ webhook_key() {
 
 # Set by deliver_record on success so the aggregate snapshot describes the last
 # result that actually reached Flowy, never one that merely reached disk. The
-# drain walks its records oldest first, so the last one set here is the newest.
+# drain walks its records oldest first, so the last one set here is the newest
+# OF THAT PASS - which is not the same as the newest ever delivered, because a
+# per-record failure can hold an older record back into a later pass. The
+# ordinal carries that comparison across passes.
 DELIVERED_TASK=
 DELIVERED_RESULT=
 DELIVERED_ARTIFACT=
+DELIVERED_ORDINAL=0
 
 # Set by deliver_record when the endpoint gave no HTTP response at all. That is
 # an endpoint-wide condition, not a property of the record being sent, so the
@@ -375,13 +395,15 @@ curl_config() {  # <url> <key>
 }
 
 deliver_record() {  # <record> <url> <key>
-  local record=$1 url=$2 key=$3 base task digest result artifact recorded payload code receipt tmp
+  local record=$1 url=$2 key=$3 base task digest result artifact recorded payload code receipt tmp ordinal
   base=$(basename "$record")
   task=$(record_field "$record" task)
   digest=$(record_field "$record" digest)
   result=$(record_field "$record" result)
   artifact=$(record_field "$record" artifact)
   recorded=$(record_field "$record" recorded)
+  ordinal=$(record_field "$record" ordinal)
+  case "$ordinal" in ''|*[!0-9]*) ordinal=0 ;; esac
   if [ -z "$task" ] || [ -z "$result" ]; then
     note "pending record is unreadable and was left in place: $record"
     return 1
@@ -394,6 +416,7 @@ deliver_record() {  # <record> <url> <key>
     DELIVERED_TASK=$task
     DELIVERED_RESULT=$result
     DELIVERED_ARTIFACT=$artifact
+    DELIVERED_ORDINAL=$ordinal
     return 0
   fi
 
@@ -452,10 +475,21 @@ deliver_record() {  # <record> <url> <key>
   DELIVERED_TASK=$task
   DELIVERED_RESULT=$result
   DELIVERED_ARTIFACT=$artifact
+  DELIVERED_ORDINAL=$ordinal
 }
 
-write_snapshot() {  # <task> <result> <artifact>
-  local task=$1 result=$2 artifact=$3 tmp
+write_snapshot() {  # <task> <result> <artifact> <ordinal>
+  local task=$1 result=$2 artifact=$3 ordinal=${4:-0} newest tmp
+  case "$ordinal" in ''|*[!0-9]*) ordinal=0 ;; esac
+  newest=$(read_ordinal "$SNAPSHOT_ORDINAL_FILE")
+  # A per-record rejection can hold an OLDER record back into a later pass, so
+  # the record retiring now is not necessarily newer than the one the display
+  # already names. Retiring it must not drag the captain's view backwards: only
+  # its pending: line moves, exactly as on a pass that delivered nothing.
+  if [ -f "$SNAPSHOT" ] && [ "$ordinal" -lt "$newest" ]; then
+    refresh_snapshot_pending
+    return
+  fi
   tmp=$(umask 077; mktemp "$STATE/.flowy-last.XXXXXX") || {
     note "cannot refresh the display snapshot"
     return 1
@@ -471,6 +505,7 @@ write_snapshot() {  # <task> <result> <artifact>
   } > "$tmp"
   chmod 600 "$tmp"
   mv -f "$tmp" "$SNAPSHOT"
+  [ "$ordinal" -le "$newest" ] || write_ordinal "$SNAPSHOT_ORDINAL_FILE" "$ordinal" || true
 }
 
 # Move ONLY the pending: line of an existing snapshot, carrying every other line
@@ -562,7 +597,7 @@ EOF
   fi
 
   if [ "$delivered" -gt 0 ]; then
-    write_snapshot "$DELIVERED_TASK" "$DELIVERED_RESULT" "$DELIVERED_ARTIFACT" || rc=1
+    write_snapshot "$DELIVERED_TASK" "$DELIVERED_RESULT" "$DELIVERED_ARTIFACT" "$DELIVERED_ORDINAL" || rc=1
   else
     refresh_snapshot_pending || rc=1
   fi

--- a/bin/fm-completion-outbox.sh
+++ b/bin/fm-completion-outbox.sh
@@ -24,22 +24,36 @@
 #
 # CALLERS. bin/fm-watch.sh uses --no-drain on its signal path, because that path
 # runs immediately before the wake and must never wait on the network. Its
-# per-pass --drain is the sole AUTHORITATIVE delivery owner. Because a wake ends
-# the watcher process, a result recorded on the signal path would otherwise wait
-# for the next watcher generation to deliver it, so the watcher also runs one
-# --drain from its EXIT path after the wake is already durable. That exit drain
-# is a promptness optimization only, and it carries a hard total wall-clock
-# bound of FM_FLOWY_EXIT_DRAIN_SECONDS (default 5), well under the watcher's
-# 15-second poll: without the bound a blackholed endpoint would keep the exiting
-# watcher alive and delay re-arming, which is exactly the stall the record-only
-# signal path removes, moved one step later. Hitting the bound is a normal, safe
-# outcome - the record simply stays pending for the next per-pass drain.
+# per-pass --drain is the sole AUTHORITATIVE delivery owner, and it runs under a
+# single total wall-clock ceiling kept strictly below the watcher's poll
+# interval, so a blackholed or slow endpoint can never push the poll loop past
+# its own interval and delay the next signal scan.
+#
+# Because a wake ends the watcher process, a result recorded on the signal path
+# would otherwise wait for the next watcher generation. The watcher therefore
+# also starts one --drain as a DETACHED child right after recording. Detached is
+# the only shape that works here: a wake becomes observable to firstmate only
+# when the watcher PROCESS EXITS, since every consumer redirects the watcher's
+# stdout to a file and reads it after wait, so any synchronous drain - in the
+# poll body or in the exit path - would sit between the wake and firstmate
+# seeing it, and no bound value removes that delay, it only shrinks it.
+#
+# That detached drain is a promptness optimization only. It carries the same
+# hard total wall-clock bound, FM_FLOWY_EXIT_DRAIN_SECONDS (default 5), with a
+# KILL backstop so it cannot outlive the bound even against an endpoint that
+# hangs and a drain that has TERM deferred inside curl. Hitting the bound is a
+# normal, safe outcome: nothing is retired without a 2xx, the record simply
+# stays pending, and the next per-pass drain takes it. Losing the detached drain
+# entirely costs promptness and never durability.
 #
 # DRAIN (--drain, and implicitly after --status). Pending records are drained
 # oldest first by the monotonic ordinal each record carries, never by filename
 # collation, and POSTed as JSON to the URL in config/grok-flowy-webhook,
 # authenticated with the Keychain Bearer key for service firstmate-flowy-webhook.
-# No environment variable configures the endpoint. A record retires ONLY on
+# No environment variable configures the endpoint. The url and the key reach
+# curl only through a -K - config on stdin, so neither ever appears in argv
+# where a local ps could read it, and the key never touches disk. The JSON body
+# takes the short-lived mode-600 file that stdin would otherwise have carried. A record retires ONLY on
 # HTTP 2xx, at which point its per-record receipt is written to
 # state/flowy-outbox/delivered/<task>.<digest>.md. Any other outcome - a non-2xx
 # code, a transport failure, a missing URL file, an unavailable key - leaves the
@@ -335,6 +349,31 @@ DELIVERED_ARTIFACT=
 # drain stops attempting further records for this pass.
 TRANSPORT_FAILED=0
 
+# Staged payload file for the POST in flight, global so the drain's traps can
+# remove it on any path out.
+PAYLOAD_TMP=
+
+outbox_cleanup() {
+  [ -z "$PAYLOAD_TMP" ] || rm -f "$PAYLOAD_TMP"
+  PAYLOAD_TMP=
+}
+
+# The endpoint url and the Bearer key reach curl ONLY through a -K - config on
+# stdin, never through argv, so neither is ever readable in the process table by
+# any local `ps` for the whole life of a POST. Config values are quoted, so a
+# backslash or a double quote inside either has to be escaped for curl's parser.
+# Both substitutions are shell builtins, so the key never becomes an argument to
+# any process here either.
+curl_config() {  # <url> <key>
+  local url=$1 key=$2
+  url=${url//\\/\\\\}
+  url=${url//\"/\\\"}
+  key=${key//\\/\\\\}
+  key=${key//\"/\\\"}
+  printf 'url = "%s"\n' "$url"
+  printf 'header = "Authorization: Bearer %s"\n' "$key"
+}
+
 deliver_record() {  # <record> <url> <key>
   local record=$1 url=$2 key=$3 base task digest result artifact recorded payload code receipt tmp
   base=$(basename "$record")
@@ -371,12 +410,23 @@ deliver_record() {  # <record> <url> <key>
     return 1
   }
 
-  code=$(printf '%s' "$payload" | curl --silent --show-error --max-time "$HTTP_TIMEOUT" \
+  # stdin belongs to the -K - config, so the payload moves to a short-lived
+  # mode-600 file instead. It carries no secret, only the result already bound
+  # for Flowy, and it is removed the moment curl returns.
+  PAYLOAD_TMP=$(umask 077; mktemp "$OUTBOX/.payload.XXXXXX") || {
+    note "cannot stage the payload for $task"
+    return 1
+  }
+  chmod 600 "$PAYLOAD_TMP"
+  printf '%s' "$payload" > "$PAYLOAD_TMP"
+
+  code=$(curl_config "$url" "$key" | curl --silent --show-error --max-time "$HTTP_TIMEOUT" \
     --output /dev/null --write-out '%{http_code}' \
-    --request POST "$url" \
-    --header "Authorization: Bearer $key" \
+    --request POST \
     --header 'Content-Type: application/json' \
-    --data-binary @-) || code=
+    --data-binary "@$PAYLOAD_TMP" \
+    -K -) || code=
+  outbox_cleanup
   case "$code" in
     2??) ;;
     *)
@@ -468,7 +518,10 @@ EOF
     note "another drain holds the outbox lock; results stay pending"
     return 1
   fi
-  trap 'fm_lock_release "$DRAIN_LOCK"' EXIT
+  # A drain cut short by its caller's wall-clock bound must still drop the staged
+  # payload and hand the lock back rather than leaving both for the takeover path.
+  trap 'outbox_cleanup; fm_lock_release "$DRAIN_LOCK"' EXIT
+  trap 'outbox_cleanup; fm_lock_release "$DRAIN_LOCK"; exit 1' HUP INT TERM
 
   # Re-read under the lock so this pass sees every record written since the
   # cheap pre-lock check, including one a concurrent recorder just landed.
@@ -480,7 +533,7 @@ EOF
   fi
   if [ "$rc" -ne 0 ]; then
     fm_lock_release "$DRAIN_LOCK"
-    trap - EXIT
+    trap - EXIT HUP INT TERM
     return 1
   fi
 
@@ -515,8 +568,9 @@ EOF
   fi
   [ "$remaining" -eq 0 ] || rc=1
 
+  outbox_cleanup
   fm_lock_release "$DRAIN_LOCK"
-  trap - EXIT
+  trap - EXIT HUP INT TERM
   return "$rc"
 }
 

--- a/bin/fm-completion-outbox.sh
+++ b/bin/fm-completion-outbox.sh
@@ -1,0 +1,398 @@
+#!/usr/bin/env bash
+# Durably deliver a captain-visible crew result to Flowy.
+#
+# Usage:
+#   fm-completion-outbox.sh --status STATUS_FILE [--dry-run]
+#   fm-completion-outbox.sh --drain [--dry-run]
+#
+# Delivery is a two-stage durable outbox, never one best-effort POST.
+#
+# RECORD (--status). Only the final non-empty status line is considered, and
+# only done:, failed:, blocked:, and needs-decision: are results; anything else
+# is a silent no-op. A result becomes an immutable record at
+# state/flowy-outbox/pending/<task>.<digest> BEFORE any network call, where
+# <digest> covers the result line. Re-recording an identical result is a no-op,
+# and a second distinct result for the same task gets its own record, so no
+# result can overwrite another. --status then drains.
+#
+# DRAIN (--drain, and implicitly after --status). Every pending record is
+# POSTed as JSON to the URL in config/grok-flowy-webhook, authenticated with the
+# Keychain Bearer key for service firstmate-flowy-webhook. No environment
+# variable configures the endpoint. A record retires ONLY on HTTP 2xx, at which
+# point its per-record receipt is written to
+# state/flowy-outbox/delivered/<task>.<digest>.md. Any other outcome - a non-2xx
+# code, a transport failure, a missing URL file, an unavailable key - leaves the
+# record pending, so the next drain retries it and delivery state survives a
+# restart. A receipt therefore never exists without a 2xx.
+#
+# state/flowy-last.md is refreshed after a delivery as an aggregate DISPLAY
+# snapshot and is never delivery authority. Its pending: line lists the task ids
+# whose results are still undelivered, or (none).
+#
+# --dry-run reports what it would record and send and writes nothing at all: no
+# record, no receipt, no aggregate snapshot, and no network or Keychain call.
+#
+# Exit 0 when nothing is left pending, 1 when a record is still pending or the
+# run could not complete, 2 on usage.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
+
+# The portable lock helpers are the repo's one owner of dead-owner takeover, so
+# a drain killed mid-POST cannot wedge every later delivery behind its lock.
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
+
+OUTBOX="$STATE/flowy-outbox"
+PENDING_DIR="$OUTBOX/pending"
+DELIVERED_DIR="$OUTBOX/delivered"
+DRAIN_LOCK="$OUTBOX/.drain.lock"
+SNAPSHOT="$STATE/flowy-last.md"
+WEBHOOK_FILE="$CONFIG/grok-flowy-webhook"
+KEYCHAIN_SERVICE=firstmate-flowy-webhook
+KEYCHAIN_ACCOUNT=flowy
+HTTP_TIMEOUT=${FM_FLOWY_HTTP_TIMEOUT:-20}
+
+usage() {
+  echo "usage: fm-completion-outbox.sh --status STATUS_FILE [--dry-run]" >&2
+  echo "       fm-completion-outbox.sh --drain [--dry-run]" >&2
+  exit 2
+}
+
+# The header comment above is this script's full contract, so --help prints it
+# rather than a second copy that could drift from it.
+help() {
+  sed -n '2,/^set -eu$/p' "${BASH_SOURCE[0]}" | sed -e '$d' -e 's/^# \{0,1\}//'
+  exit 0
+}
+
+note() { echo "fm-completion-outbox: $*" >&2; }
+
+status_file=
+mode=
+dry_run=0
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --status)
+      [ "$#" -ge 2 ] || usage
+      [ -z "$mode" ] || usage
+      mode=status
+      status_file=$2
+      shift 2
+      ;;
+    --drain)
+      [ -z "$mode" ] || usage
+      mode=drain
+      shift
+      ;;
+    --dry-run)
+      dry_run=1
+      shift
+      ;;
+    -h|--help) help ;;
+    *) usage ;;
+  esac
+done
+[ -n "$mode" ] || usage
+
+digest_of() {  # <text>
+  local sum
+  if command -v shasum >/dev/null 2>&1; then
+    sum=$(printf '%s' "$1" | shasum -a 256) || return 1
+  else
+    sum=$(printf '%s' "$1" | sha256sum) || return 1
+  fi
+  printf '%s' "${sum%% *}" | cut -c1-12
+}
+
+# A record field may contain '=' or a tab, so each is read by stripping its own
+# key prefix rather than by splitting the line.
+record_field() {  # <record> <key>
+  sed -n "s/^$2=//p" "$1" | head -n 1
+}
+
+# Prefer a durable deliverable the captain can open over the status log itself,
+# and keep the path home-relative so no fixture or private absolute path is
+# published to Flowy.
+artifact_for() {  # <task> <status-file>
+  if [ -f "$FM_HOME/data/$1/report.md" ]; then
+    printf 'data/%s/report.md' "$1"
+  else
+    printf '%s' "${2#"$FM_HOME"/}"
+  fi
+}
+
+pending_records() {
+  local record
+  for record in "$PENDING_DIR"/*; do
+    [ -f "$record" ] || continue
+    printf '%s\n' "$record"
+  done
+}
+
+pending_task_ids() {
+  local record ids="" task
+  while IFS= read -r record; do
+    [ -n "$record" ] || continue
+    task=$(record_field "$record" task)
+    [ -n "$task" ] || continue
+    case " $ids " in *" $task "*) continue ;; esac
+    ids="$ids $task"
+  done <<EOF
+$(pending_records)
+EOF
+  if [ -z "$ids" ]; then
+    printf '(none)'
+  else
+    printf '%s' "${ids# }" | tr ' ' ','
+  fi
+}
+
+record_result() {  # <status-file>
+  local file=$1 result task digest record artifact tmp
+  [ -f "$file" ] && [ ! -L "$file" ] || {
+    note "status file is unavailable or unsafe: $file"
+    return 1
+  }
+  case "$file" in
+    "$STATE"/*.status) ;;
+    *)
+      note "status file is outside state: $file"
+      return 1
+      ;;
+  esac
+
+  result=$(awk 'NF { line=$0 } END { print line }' "$file")
+  case "$result" in
+    done:*|failed:*|blocked:*|needs-decision:*) ;;
+    *) return 0 ;;
+  esac
+
+  task=$(basename "$file" .status)
+  digest=$(digest_of "$result") || {
+    note "cannot digest the result for $task"
+    return 1
+  }
+  record="$PENDING_DIR/$task.$digest"
+  artifact=$(artifact_for "$task" "$file")
+
+  if [ "$dry_run" -eq 1 ]; then
+    printf 'DRY RUN: would record %s result for %s (%s)\n' "${result%%:*}" "$task" "$artifact" >&2
+    return 0
+  fi
+
+  mkdir -p "$PENDING_DIR" "$DELIVERED_DIR"
+  # Immutable: an existing record or an existing receipt for this exact result
+  # is already the durable truth, and rewriting either would reopen the
+  # overwrite hole this outbox exists to close.
+  if [ -e "$record" ] || [ -e "$DELIVERED_DIR/$task.$digest.md" ]; then
+    return 0
+  fi
+  tmp=$(umask 077; mktemp "$PENDING_DIR/.record.XXXXXX") || {
+    note "cannot create a pending record for $task"
+    return 1
+  }
+  {
+    printf 'task=%s\n' "$task"
+    printf 'digest=%s\n' "$digest"
+    printf 'recorded=%s\n' "$(date +%s)"
+    printf 'artifact=%s\n' "$artifact"
+    printf 'status=%s\n' "$file"
+    printf 'result=%s\n' "$result"
+  } > "$tmp"
+  chmod 600 "$tmp"
+  mv -f "$tmp" "$record"
+}
+
+webhook_url() {
+  local url
+  [ -r "$WEBHOOK_FILE" ] || {
+    note "missing Flowy webhook URL at $WEBHOOK_FILE"
+    return 1
+  }
+  url=$(tr -d '\r\n' < "$WEBHOOK_FILE")
+  case "$url" in
+    https://*|http://*) printf '%s' "$url" ;;
+    *)
+      note "Flowy webhook URL is invalid"
+      return 1
+      ;;
+  esac
+}
+
+# Never printed, never written to state, never recorded in a receipt.
+webhook_key() {
+  local key
+  key=$(security find-generic-password -s "$KEYCHAIN_SERVICE" -a "$KEYCHAIN_ACCOUNT" -w 2>/dev/null || true)
+  # The account-qualified entry is the documented one; the same service without
+  # an account is the older entry and is read only when that is absent.
+  [ -n "$key" ] || key=$(security find-generic-password -s "$KEYCHAIN_SERVICE" -w 2>/dev/null || true)
+  [ -n "$key" ] || {
+    note "Flowy webhook key is unavailable"
+    return 1
+  }
+  printf '%s' "$key"
+}
+
+# Set by deliver_record on success so the aggregate snapshot describes the last
+# result that actually reached Flowy, never one that merely reached disk.
+DELIVERED_TASK=
+DELIVERED_RESULT=
+DELIVERED_ARTIFACT=
+
+deliver_record() {  # <record> <url> <key>
+  local record=$1 url=$2 key=$3 base task digest result artifact recorded payload code receipt tmp
+  base=$(basename "$record")
+  task=$(record_field "$record" task)
+  digest=$(record_field "$record" digest)
+  result=$(record_field "$record" result)
+  artifact=$(record_field "$record" artifact)
+  recorded=$(record_field "$record" recorded)
+  if [ -z "$task" ] || [ -z "$result" ]; then
+    note "pending record is unreadable and was left in place: $record"
+    return 1
+  fi
+  receipt="$DELIVERED_DIR/$base.md"
+  # A crash between writing the receipt and retiring the record must not re-POST
+  # an already-delivered result.
+  if [ -f "$receipt" ]; then
+    rm -f "$record"
+    DELIVERED_TASK=$task
+    DELIVERED_RESULT=$result
+    DELIVERED_ARTIFACT=$artifact
+    return 0
+  fi
+
+  payload=$(jq -cn \
+    --arg source flowy-completion-outbox \
+    --arg event result \
+    --arg task "$task" \
+    --arg digest "$digest" \
+    --arg result "$result" \
+    --arg artifact "$artifact" \
+    --arg recorded "$recorded" \
+    '{source:$source,event:$event,task:$task,digest:$digest,result:$result,artifact:$artifact,recorded:$recorded}') || {
+    note "cannot build the payload for $task"
+    return 1
+  }
+
+  code=$(printf '%s' "$payload" | curl --silent --show-error --max-time "$HTTP_TIMEOUT" \
+    --output /dev/null --write-out '%{http_code}' \
+    --request POST "$url" \
+    --header "Authorization: Bearer $key" \
+    --header 'Content-Type: application/json' \
+    --data-binary @-) || code=
+  case "$code" in
+    2??) ;;
+    *)
+      note "Flowy webhook returned ${code:-no response} for $task; result stays pending"
+      return 1
+      ;;
+  esac
+
+  tmp=$(umask 077; mktemp "$DELIVERED_DIR/.receipt.XXXXXX") || {
+    note "delivered $task but cannot write its receipt"
+    return 1
+  }
+  {
+    printf 'FM->Flowy\n'
+    printf 'files: %s\n' "$artifact"
+    printf 'status: %s: %s\n' "$task" "$result"
+    printf 'delivered: HTTP %s\n' "$code"
+  } > "$tmp"
+  chmod 600 "$tmp"
+  mv -f "$tmp" "$receipt"
+  rm -f "$record"
+  DELIVERED_TASK=$task
+  DELIVERED_RESULT=$result
+  DELIVERED_ARTIFACT=$artifact
+}
+
+write_snapshot() {  # <task> <result> <artifact>
+  local task=$1 result=$2 artifact=$3 tmp
+  tmp=$(umask 077; mktemp "$STATE/.flowy-last.XXXXXX") || {
+    note "cannot refresh the display snapshot"
+    return 1
+  }
+  {
+    printf 'FM->Flowy\n'
+    # Heartbeat state is the Flowy ACK gate's fact, not this script's. The line
+    # is carried through unchanged from the snapshot's existing shape.
+    printf 'HEARTBEAT: OFF (Captain ACK)\n'
+    printf 'files: %s\n' "$artifact"
+    printf 'status: %s: %s\n' "$task" "$result"
+    printf 'pending: %s\n' "$(pending_task_ids)"
+  } > "$tmp"
+  chmod 600 "$tmp"
+  mv -f "$tmp" "$SNAPSHOT"
+}
+
+drain() {
+  local records record url key delivered=0 remaining=0 rc=0
+
+  records=$(pending_records)
+  [ -n "$records" ] || return 0
+
+  if [ "$dry_run" -eq 1 ]; then
+    while IFS= read -r record; do
+      [ -n "$record" ] || continue
+      printf 'DRY RUN: would POST %s\n' "$(basename "$record")" >&2
+    done <<EOF
+$records
+EOF
+    return 0
+  fi
+
+  # One drain at a time, so two passes cannot both POST the same record.
+  if ! fm_lock_try_acquire "$DRAIN_LOCK"; then
+    note "another drain holds the outbox lock; results stay pending"
+    return 1
+  fi
+  trap 'fm_lock_release "$DRAIN_LOCK"' EXIT
+
+  # Re-read under the lock so this pass sees every record written since the
+  # cheap pre-lock check, including one a concurrent recorder just landed.
+  records=$(pending_records)
+
+  url=$(webhook_url) || rc=1
+  if [ "$rc" -eq 0 ]; then
+    key=$(webhook_key) || rc=1
+  fi
+  if [ "$rc" -ne 0 ]; then
+    fm_lock_release "$DRAIN_LOCK"
+    trap - EXIT
+    return 1
+  fi
+
+  while IFS= read -r record; do
+    [ -n "$record" ] || continue
+    [ -f "$record" ] || continue
+    if deliver_record "$record" "$url" "$key"; then
+      delivered=$((delivered + 1))
+    else
+      remaining=$((remaining + 1))
+    fi
+  done <<EOF
+$records
+EOF
+
+  if [ "$delivered" -gt 0 ]; then
+    write_snapshot "$DELIVERED_TASK" "$DELIVERED_RESULT" "$DELIVERED_ARTIFACT" || rc=1
+  fi
+  [ "$remaining" -eq 0 ] || rc=1
+
+  fm_lock_release "$DRAIN_LOCK"
+  trap - EXIT
+  return "$rc"
+}
+
+rc=0
+if [ "$mode" = status ]; then
+  record_result "$status_file" || rc=1
+fi
+drain || rc=1
+exit "$rc"

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -948,8 +948,19 @@ flowy_run_bounded_drain() {  # <bound-seconds>
 # a blackholed endpoint - or several records answering 503 slowly - can never
 # push the poll loop past its own interval and delay the next signal scan.
 flowy_drain_bound() {
-  local bound=${FM_FLOWY_DRAIN_SECONDS:-}
-  [ -n "$bound" ] || bound=$((POLL * 2 / 3))
+  local bound=${FM_FLOWY_DRAIN_SECONDS:-} whole
+  if [ -z "$bound" ]; then
+    # FM_POLL is a documented knob that accepts fractional seconds, and an
+    # arithmetic expansion on one is an expansion ERROR: bash abandons the rest
+    # of this function, so the caller gets an EMPTY ceiling and the guards below
+    # never run. An empty bound makes the deadline the current second, and the
+    # drain is torn down before it can POST anything. So derive the ceiling from
+    # POLL's whole-second part; any sub-second poll lands on the same one-second
+    # floor that POLL=1 already gets.
+    whole=${POLL%%.*}
+    case "$whole" in ''|*[!0-9]*) whole=0 ;; esac
+    bound=$((whole * 2 / 3))
+  fi
   case "$bound" in ''|*[!0-9]*) bound=1 ;; esac
   [ "$bound" -ge 1 ] || bound=1
   printf '%s' "$bound"

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -891,6 +891,65 @@ if [ "${FM_WATCH_HANDLING_SUCCESSOR:-0}" = 1 ]; then
 elif [ "$FM_RECOVERY_MARKER_ACTION" = recover ]; then
   WATCHER_RECOVERY_PENDING=1
 fi
+# Armed by the signal path once it records a terminal result. A wake ends this
+# process, so that record would otherwise sit undelivered until a NEW watcher
+# generation reached the per-pass drain - on a healthy Flowy the captain would
+# lose a whole poll of promptness, and with nothing re-arming it would wait
+# indefinitely. This runs from the EXIT path, after the wake is already
+# published and after the watch lock is released, so it delays neither.
+#
+# THE BOUND IS THE POINT. FM_FLOWY_EXIT_DRAIN_SECONDS (default 5) is a single
+# ceiling on the WHOLE attempt, not a per-record timeout, plus at most a
+# half-second to tear the drain down, and it is deliberately far below POLL
+# (15s) so this can never outlive a re-arm. Without it a
+# blackholed endpoint would keep the exiting watcher alive and delay re-arming,
+# which is precisely the stall --no-drain removed from the signal path, moved
+# one step later. Hitting the bound is normal and safe: the outbox retires
+# nothing without a 2xx, so the record stays pending and the next generation's
+# per-pass drain - which remains the authoritative delivery owner - takes it.
+FLOWY_EXIT_DRAIN_ARMED=0
+flowy_exit_drain() {
+  local bound pid ticks=0 limit
+  [ "$FLOWY_EXIT_DRAIN_ARMED" -eq 1 ] || return 0
+  FLOWY_EXIT_DRAIN_ARMED=0
+  [ -x "$FLOWY_COMPLETION_OUTBOX" ] || return 0
+  bound=${FM_FLOWY_EXIT_DRAIN_SECONDS:-5}
+  case "$bound" in ''|*[!0-9]*) bound=5 ;; esac
+  limit=$((bound * 10))
+  [ "$limit" -gt 0 ] || return 0
+  # Own process group, so the bound kills any curl still in flight rather than
+  # orphaning it. Capping the outbox's own per-request timeout at the bound
+  # keeps a real curl from outliving this even if the signal is missed.
+  set -m
+  FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" FM_FLOWY_HTTP_TIMEOUT="$bound" \
+    "$FLOWY_COMPLETION_OUTBOX" --drain >/dev/null 2>&1 &
+  pid=$!
+  set +m
+  while [ "$ticks" -lt "$limit" ]; do
+    kill -0 "$pid" 2>/dev/null || break
+    sleep 0.1
+    ticks=$((ticks + 1))
+  done
+  if kill -0 "$pid" 2>/dev/null; then
+    # wake() ignores HUP/INT/TERM before exiting, and an IGNORED disposition is
+    # inherited by children, so a TERM here would be silently discarded by the
+    # very drain this bound exists to stop. TERM first anyway for the exit paths
+    # that did not ignore it, then KILL, which nothing can ignore.
+    kill -TERM -- "-$pid" 2>/dev/null || kill -TERM "$pid" 2>/dev/null || true
+    ticks=0
+    while [ "$ticks" -lt 5 ]; do
+      kill -0 "$pid" 2>/dev/null || break
+      sleep 0.1
+      ticks=$((ticks + 1))
+    done
+    if kill -0 "$pid" 2>/dev/null; then
+      kill -KILL -- "-$pid" 2>/dev/null || kill -KILL "$pid" 2>/dev/null || true
+    fi
+  fi
+  wait "$pid" 2>/dev/null || true
+  return 0
+}
+
 watcher_cleanup() {
   local cleanup_status=0 owns_lock=0 transition=release-lock
   if [ "$(cat "$WATCH_LOCK/pid" 2>/dev/null || true)" = "${WATCHER_PID:-}" ]; then
@@ -908,6 +967,7 @@ watcher_cleanup() {
     echo "watcher: recovery state could not be persisted; retaining stale lock evidence" >&2
     cleanup_status=1
   fi
+  flowy_exit_drain
   return "$cleanup_status"
 }
 trap watcher_cleanup EXIT
@@ -1101,8 +1161,9 @@ EOF
     # outbox BEFORE the triage below advances the seen markers. --no-drain keeps
     # this to the local write: it opens no socket and reads no Keychain, so an
     # unreachable Flowy cannot delay the wake below it. The per-pass drain above
-    # is the sole owner of getting a record delivered, so a result is never lost
-    # to one bad POST either.
+    # is the authoritative owner of getting a record delivered, so a result is
+    # never lost to one bad POST either. Recording here arms the bounded EXIT
+    # drain, which restores same-pass promptness without ever preceding a wake.
     flowy_result_files=""
     while IFS=$(printf '\t') read -r sf sig f; do
       [ -n "$sf" ] || continue
@@ -1112,8 +1173,11 @@ EOF
         done:*|failed:*|blocked:*|needs-decision:*)
           flowy_result_files="$flowy_result_files $f"
           if [ -x "$FLOWY_COMPLETION_OUTBOX" ]; then
-            FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" "$FLOWY_COMPLETION_OUTBOX" --status "$f" --no-drain \
-              || triage_log "Flowy completion outbox could not record the result for $(basename "$f")"
+            if FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" "$FLOWY_COMPLETION_OUTBOX" --status "$f" --no-drain; then
+              FLOWY_EXIT_DRAIN_ARMED=1
+            else
+              triage_log "Flowy completion outbox could not record the result for $(basename "$f")"
+            fi
           fi
           ;;
       esac

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -1098,9 +1098,11 @@ $pending
 EOF
     reason="signal:$files"
     # Record every terminal result this signal carries into the durable Flowy
-    # outbox BEFORE the triage below advances the seen markers. Recording is a
-    # local write that cannot fail on the network, and the per-pass drain above
-    # owns getting it delivered, so a result is never lost to one bad POST.
+    # outbox BEFORE the triage below advances the seen markers. --no-drain keeps
+    # this to the local write: it opens no socket and reads no Keychain, so an
+    # unreachable Flowy cannot delay the wake below it. The per-pass drain above
+    # is the sole owner of getting a record delivered, so a result is never lost
+    # to one bad POST either.
     flowy_result_files=""
     while IFS=$(printf '\t') read -r sf sig f; do
       [ -n "$sf" ] || continue
@@ -1110,8 +1112,8 @@ EOF
         done:*|failed:*|blocked:*|needs-decision:*)
           flowy_result_files="$flowy_result_files $f"
           if [ -x "$FLOWY_COMPLETION_OUTBOX" ]; then
-            FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" "$FLOWY_COMPLETION_OUTBOX" --status "$f" \
-              || triage_log "Flowy completion outbox has undelivered results for $(basename "$f")"
+            FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" "$FLOWY_COMPLETION_OUTBOX" --status "$f" --no-drain \
+              || triage_log "Flowy completion outbox could not record the result for $(basename "$f")"
           fi
           ;;
       esac

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -1188,6 +1188,10 @@ EOF
     # never lost to one bad POST either. Recording here arms the DETACHED bounded
     # drain started right after this loop, which restores same-pass promptness
     # while leaving the wake exactly as prompt as it is with no drain at all.
+    # Its stdout goes to /dev/null for the same reason the two drain call sites
+    # do it: this process's stdout IS the wake channel, and a byte written there
+    # would be read back as part of the wake reason. Its stderr is kept, because
+    # that is where a recording diagnostic belongs.
     flowy_result_files=""
     while IFS=$(printf '\t') read -r sf sig f; do
       [ -n "$sf" ] || continue
@@ -1197,7 +1201,7 @@ EOF
         done:*|failed:*|blocked:*|needs-decision:*)
           flowy_result_files="$flowy_result_files $f"
           if [ -x "$FLOWY_COMPLETION_OUTBOX" ]; then
-            if FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" "$FLOWY_COMPLETION_OUTBOX" --status "$f" --no-drain; then
+            if FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" "$FLOWY_COMPLETION_OUTBOX" --status "$f" --no-drain >/dev/null; then
               FLOWY_DETACHED_DRAIN_ARMED=1
             else
               triage_log "Flowy completion outbox could not record the result for $(basename "$f")"

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -900,13 +900,28 @@ fi
 # exiting, which children inherit, so TERM alone can be silently discarded.
 # Hitting the ceiling is normal and safe - the outbox retires nothing without a
 # 2xx, so every unsent record simply stays pending for the next drain.
+#
+# Signalling the GROUP is only safe once the pgid has been read back and equals
+# the pid. If set -m did not make the child a group leader, -$pid names some
+# unrelated group, and that kill would SUCCEED - so no fallback would fire and
+# the backstop would tear down a stranger while the real drain ran on past its
+# ceiling. run_check_capture guards its own backgrounded child the same way.
+flowy_signal_drain() {  # <pid> <pgid-or-empty> <signal>
+  if [ -n "$2" ]; then
+    kill "-$3" -- "-$2" 2>/dev/null && return 0
+  fi
+  kill "-$3" "$1" 2>/dev/null || true
+}
+
 flowy_run_bounded_drain() {  # <bound-seconds>
-  local bound=$1 pid rc=0 deadline ticks=0
+  local bound=$1 pid pgid rc=0 deadline ticks=0
   set -m
   FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" FM_FLOWY_HTTP_TIMEOUT="$bound" \
     "$FLOWY_COMPLETION_OUTBOX" --drain >/dev/null 2>&1 &
   pid=$!
   set +m
+  pgid=$(ps -o pgid= -p "$pid" 2>/dev/null | tr -d '[:space:]')
+  [ "$pgid" = "$pid" ] || pgid=
   # SECONDS is a real elapsed-time deadline. Counting sleep 0.1 ticks instead
   # would drift well past the ceiling, because every tick also pays a fork.
   deadline=$((SECONDS + bound))
@@ -915,14 +930,14 @@ flowy_run_bounded_drain() {  # <bound-seconds>
     sleep 0.1
   done
   if kill -0 "$pid" 2>/dev/null; then
-    kill -TERM -- "-$pid" 2>/dev/null || kill -TERM "$pid" 2>/dev/null || true
+    flowy_signal_drain "$pid" "$pgid" TERM
     while [ "$ticks" -lt 5 ]; do
       kill -0 "$pid" 2>/dev/null || break
       sleep 0.1
       ticks=$((ticks + 1))
     done
     if kill -0 "$pid" 2>/dev/null; then
-      kill -KILL -- "-$pid" 2>/dev/null || kill -KILL "$pid" 2>/dev/null || true
+      flowy_signal_drain "$pid" "$pgid" KILL
     fi
   fi
   wait "$pid" 2>/dev/null || rc=1

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -79,6 +79,8 @@ FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
 STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 mkdir -p "$STATE"
 
+FLOWY_COMPLETION_OUTBOX="$SCRIPT_DIR/fm-completion-outbox.sh"
+
 # The native event fast-path and only its true dependencies have one narrow
 # production owner. The Herdr event-wait smoke test consumes this same owner
 # without sourcing the entire watcher graph.
@@ -971,6 +973,17 @@ while :; do
   # No conversation scraping; unresolved records are never silently expired.
   fm_pending_reply_tick "$STATE" || true
 
+  # Flowy completion delivery is a durable outbox, so retrying belongs on EVERY
+  # pass rather than on the status signal that first recorded a result. The
+  # signal path below only records; a POST that failed there (or in an earlier
+  # watcher generation, or before a restart) is retried from here until it gets
+  # a 2xx, which is why advancing the seen marker after one attempt can no
+  # longer strand a captain-visible result. It is a no-op with nothing pending.
+  if [ -x "$FLOWY_COMPLETION_OUTBOX" ]; then
+    FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" "$FLOWY_COMPLETION_OUTBOX" --drain \
+      || triage_log "Flowy completion outbox has undelivered results"
+  fi
+
   # Process-to-event liveness repair. This never discovers a result by polling:
   # each registered source has its own child blocking on that source, and this
   # only republishes results already captured durably and restarts a source
@@ -1084,6 +1097,27 @@ while :; do
 $pending
 EOF
     reason="signal:$files"
+    # Record every terminal result this signal carries into the durable Flowy
+    # outbox BEFORE the triage below advances the seen markers. Recording is a
+    # local write that cannot fail on the network, and the per-pass drain above
+    # owns getting it delivered, so a result is never lost to one bad POST.
+    flowy_result_files=""
+    while IFS=$(printf '\t') read -r sf sig f; do
+      [ -n "$sf" ] || continue
+      case "$f" in "$STATE"/*.status) ;; *) continue ;; esac
+      case " $flowy_result_files " in *" $f "*) continue ;; esac
+      case "$(last_status_line "$f")" in
+        done:*|failed:*|blocked:*|needs-decision:*)
+          flowy_result_files="$flowy_result_files $f"
+          if [ -x "$FLOWY_COMPLETION_OUTBOX" ]; then
+            FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" "$FLOWY_COMPLETION_OUTBOX" --status "$f" \
+              || triage_log "Flowy completion outbox has undelivered results for $(basename "$f")"
+          fi
+          ;;
+      esac
+    done <<EOF
+$pending
+EOF
     # Triage: a signal is ACTIONABLE when any of these holds (cheapest first):
     #   - the away-mode daemon owns triage (afk) and wants every wake;
     #   - any status file carries a captain-relevant verb;

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -891,52 +891,31 @@ if [ "${FM_WATCH_HANDLING_SUCCESSOR:-0}" = 1 ]; then
 elif [ "$FM_RECOVERY_MARKER_ACTION" = recover ]; then
   WATCHER_RECOVERY_PENDING=1
 fi
-# Armed by the signal path once it records a terminal result. A wake ends this
-# process, so that record would otherwise sit undelivered until a NEW watcher
-# generation reached the per-pass drain - on a healthy Flowy the captain would
-# lose a whole poll of promptness, and with nothing re-arming it would wait
-# indefinitely. This runs from the EXIT path, after the wake is already
-# published and after the watch lock is released, so it delays neither.
-#
-# THE BOUND IS THE POINT. FM_FLOWY_EXIT_DRAIN_SECONDS (default 5) is a single
-# ceiling on the WHOLE attempt, not a per-record timeout, plus at most a
-# half-second to tear the drain down, and it is deliberately far below POLL
-# (15s) so this can never outlive a re-arm. Without it a
-# blackholed endpoint would keep the exiting watcher alive and delay re-arming,
-# which is precisely the stall --no-drain removed from the signal path, moved
-# one step later. Hitting the bound is normal and safe: the outbox retires
-# nothing without a 2xx, so the record stays pending and the next generation's
-# per-pass drain - which remains the authoritative delivery owner - takes it.
-FLOWY_EXIT_DRAIN_ARMED=0
-flowy_exit_drain() {
-  local bound pid ticks=0 limit
-  [ "$FLOWY_EXIT_DRAIN_ARMED" -eq 1 ] || return 0
-  FLOWY_EXIT_DRAIN_ARMED=0
-  [ -x "$FLOWY_COMPLETION_OUTBOX" ] || return 0
-  bound=${FM_FLOWY_EXIT_DRAIN_SECONDS:-5}
-  case "$bound" in ''|*[!0-9]*) bound=5 ;; esac
-  limit=$((bound * 10))
-  [ "$limit" -gt 0 ] || return 0
-  # Own process group, so the bound kills any curl still in flight rather than
-  # orphaning it. Capping the outbox's own per-request timeout at the bound
-  # keeps a real curl from outliving this even if the signal is missed.
+# Run one outbox --drain under a single TOTAL wall-clock ceiling, never a
+# per-record timeout. The drain gets its own process group, so the ceiling tears
+# down any curl still in flight instead of orphaning it, and the outbox's own
+# per-request timeout is capped at the same value so a real curl cannot outlive
+# it either. TERM first, then KILL as the backstop: a drain blocked inside curl
+# defers its TERM handler until curl returns, and wake() ignores TERM before
+# exiting, which children inherit, so TERM alone can be silently discarded.
+# Hitting the ceiling is normal and safe - the outbox retires nothing without a
+# 2xx, so every unsent record simply stays pending for the next drain.
+flowy_run_bounded_drain() {  # <bound-seconds>
+  local bound=$1 pid rc=0 deadline ticks=0
   set -m
   FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" FM_FLOWY_HTTP_TIMEOUT="$bound" \
     "$FLOWY_COMPLETION_OUTBOX" --drain >/dev/null 2>&1 &
   pid=$!
   set +m
-  while [ "$ticks" -lt "$limit" ]; do
+  # SECONDS is a real elapsed-time deadline. Counting sleep 0.1 ticks instead
+  # would drift well past the ceiling, because every tick also pays a fork.
+  deadline=$((SECONDS + bound))
+  while [ "$SECONDS" -lt "$deadline" ]; do
     kill -0 "$pid" 2>/dev/null || break
     sleep 0.1
-    ticks=$((ticks + 1))
   done
   if kill -0 "$pid" 2>/dev/null; then
-    # wake() ignores HUP/INT/TERM before exiting, and an IGNORED disposition is
-    # inherited by children, so a TERM here would be silently discarded by the
-    # very drain this bound exists to stop. TERM first anyway for the exit paths
-    # that did not ignore it, then KILL, which nothing can ignore.
     kill -TERM -- "-$pid" 2>/dev/null || kill -TERM "$pid" 2>/dev/null || true
-    ticks=0
     while [ "$ticks" -lt 5 ]; do
       kill -0 "$pid" 2>/dev/null || break
       sleep 0.1
@@ -946,7 +925,49 @@ flowy_exit_drain() {
       kill -KILL -- "-$pid" 2>/dev/null || kill -KILL "$pid" 2>/dev/null || true
     fi
   fi
-  wait "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || rc=1
+  return "$rc"
+}
+
+# The ceiling for the authoritative per-pass drain, kept strictly below POLL so
+# a blackholed endpoint - or several records answering 503 slowly - can never
+# push the poll loop past its own interval and delay the next signal scan.
+flowy_drain_bound() {
+  local bound=${FM_FLOWY_DRAIN_SECONDS:-}
+  [ -n "$bound" ] || bound=$((POLL * 2 / 3))
+  case "$bound" in ''|*[!0-9]*) bound=1 ;; esac
+  [ "$bound" -ge 1 ] || bound=1
+  printf '%s' "$bound"
+}
+
+# Armed by the signal path once it records a terminal result. A wake ends this
+# process, so that record would otherwise sit undelivered until a NEW watcher
+# generation reached the per-pass drain - on a healthy Flowy the captain would
+# lose a whole poll of promptness, and with nothing re-arming it would wait
+# indefinitely.
+#
+# DETACHED IS THE ONLY WORKING SHAPE. A wake becomes observable to firstmate
+# only when this PROCESS EXITS: every consumer redirects the watcher's stdout to
+# a file and reads it after wait (bin/fm-watch-arm.sh, bin/fm-supervise-daemon.sh).
+# Any synchronous drain - in the poll body or in the EXIT trap - therefore sits
+# between the wake and firstmate seeing it, and no bound value removes that
+# delay, it only shrinks it. A detached child in its own process group decouples
+# delivery from process exit entirely, so the wake and `fm off` are as prompt as
+# they are with no drain at all, and the watcher's own exit never waits on it.
+# The child keeps the same total wall-clock bound and KILL backstop, and its
+# output goes to /dev/null because this process's stdout IS the wake channel.
+FLOWY_DETACHED_DRAIN_ARMED=0
+flowy_detached_drain() {
+  local bound
+  [ "$FLOWY_DETACHED_DRAIN_ARMED" -eq 1 ] || return 0
+  FLOWY_DETACHED_DRAIN_ARMED=0
+  [ -x "$FLOWY_COMPLETION_OUTBOX" ] || return 0
+  bound=${FM_FLOWY_EXIT_DRAIN_SECONDS:-5}
+  case "$bound" in ''|*[!0-9]*) bound=5 ;; esac
+  [ "$bound" -ge 1 ] || return 0
+  set -m
+  ( flowy_run_bounded_drain "$bound" || true ) >/dev/null 2>&1 </dev/null &
+  set +m
   return 0
 }
 
@@ -967,7 +988,6 @@ watcher_cleanup() {
     echo "watcher: recovery state could not be persisted; retaining stale lock evidence" >&2
     cleanup_status=1
   fi
-  flowy_exit_drain
   return "$cleanup_status"
 }
 trap watcher_cleanup EXIT
@@ -1039,8 +1059,11 @@ while :; do
   # watcher generation, or before a restart) is retried from here until it gets
   # a 2xx, which is why advancing the seen marker after one attempt can no
   # longer strand a captain-visible result. It is a no-op with nothing pending.
+  # It is the AUTHORITATIVE delivery owner, so it runs synchronously here, under
+  # a total ceiling strictly below POLL so it can never delay the signal scan
+  # below it by more than a fraction of one poll.
   if [ -x "$FLOWY_COMPLETION_OUTBOX" ]; then
-    FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" "$FLOWY_COMPLETION_OUTBOX" --drain \
+    flowy_run_bounded_drain "$(flowy_drain_bound)" \
       || triage_log "Flowy completion outbox has undelivered results"
   fi
 
@@ -1162,8 +1185,9 @@ EOF
     # this to the local write: it opens no socket and reads no Keychain, so an
     # unreachable Flowy cannot delay the wake below it. The per-pass drain above
     # is the authoritative owner of getting a record delivered, so a result is
-    # never lost to one bad POST either. Recording here arms the bounded EXIT
-    # drain, which restores same-pass promptness without ever preceding a wake.
+    # never lost to one bad POST either. Recording here arms the DETACHED bounded
+    # drain started right after this loop, which restores same-pass promptness
+    # while leaving the wake exactly as prompt as it is with no drain at all.
     flowy_result_files=""
     while IFS=$(printf '\t') read -r sf sig f; do
       [ -n "$sf" ] || continue
@@ -1174,7 +1198,7 @@ EOF
           flowy_result_files="$flowy_result_files $f"
           if [ -x "$FLOWY_COMPLETION_OUTBOX" ]; then
             if FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" "$FLOWY_COMPLETION_OUTBOX" --status "$f" --no-drain; then
-              FLOWY_EXIT_DRAIN_ARMED=1
+              FLOWY_DETACHED_DRAIN_ARMED=1
             else
               triage_log "Flowy completion outbox could not record the result for $(basename "$f")"
             fi
@@ -1184,6 +1208,7 @@ EOF
     done <<EOF
 $pending
 EOF
+    flowy_detached_drain
     # Triage: a signal is ACTIONABLE when any of these holds (cheapest first):
     #   - the away-mode daemon owns triage (afk) and wants every wake;
     #   - any status file carries a captain-relevant verb;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -600,6 +600,14 @@ Each account, model and voice file above is read as its first line that is not b
 The two read files are parsed differently: `config/voice-read-scope` must hold the bare word and nothing but blank space around it, so a comment header there refuses instead of being skipped, while every line of `config/voice-read-deny` that is not blank and not a `#` comment is one more substring.
 `FM_VOICE_RELAY` and `FM_VOICE_PYTHON` belong to the laptop rather than to a home, so they have no config file: `bin/fm-voice-client.py` requires the relay path as a flag or that variable and carries no default path.
 
+## Flowy completion delivery (config/grok-flowy-webhook)
+
+`bin/fm-completion-outbox.sh` delivers captain-visible crew results (`done:`, `failed:`, `blocked:`, and `needs-decision:` status lines) to the captain's Flowy intake, and `bin/fm-watch.sh` is its only production caller.
+The endpoint is the single line in gitignored `config/grok-flowy-webhook`, and the Bearer key is a login-Keychain generic password for service `firstmate-flowy-webhook`, account `flowy`; no environment variable configures either, and neither ever reaches an argv a local `ps` could read.
+Delivery is a durable outbox rather than one best-effort POST: every result is recorded immutably before any network call, and only an HTTP 2xx retires that record into its own receipt, so a failed or unsent POST is retried by a later watcher pass and delivery state survives a restart.
+`state/flowy-last.md` remains an aggregate display snapshot and is never delivery authority.
+The script's header owns the exact record, drain, receipt, and snapshot mechanics, and the `FM_FLOWY_*` bounds below are the only tuning.
+
 ## Environment variables
 
 Runtime tuning via environment variables (defaults shown):
@@ -684,6 +692,9 @@ FM_WORKTREE_WRITE_PRUNE='.git node_modules .venv venv __pycache__ .mypy_cache .p
 FM_WORKTREE_WRITE_MAXDEPTH=6       # depth that same probe walks below the recorded worktree; it runs only at the moment a wedge escalation would otherwise fire, never on every poll; no probe knob applies to a secondmate, whose recorded worktree is a provisioned home the probe skips entirely
 FM_WORKTREE_WRITE_TIMEOUT=10       # wall-clock seconds that one walk may take, so a worktree on a hung mount cannot stall the watcher poll that started it; hitting the bound reads as no write evidence, which leaves the escalation schedule exactly as it was; a value that is not a positive integer falls back to the default
 FM_WATCH_TRIAGE_LOG_MAX_BYTES=262144   # size cap for the watcher's absorbed-wake debug log
+FM_FLOWY_DRAIN_SECONDS=   # total wall-clock seconds for the watcher's per-pass Flowy outbox drain; unset derives two thirds of FM_POLL's whole-second part, minimum 1, so a blackholed endpoint cannot delay the next signal scan
+FM_FLOWY_EXIT_DRAIN_SECONDS=5   # same total bound for the detached drain the watcher starts after a signal records a result; 0 skips only that promptness drain, never delivery itself
+FM_FLOWY_HTTP_TIMEOUT=20   # seconds allowed per Flowy POST; the watcher caps it at the drain bound so one request can never outlive the whole drain
 FM_FLEET_SYNC_BOOTSTRAP_TIMEOUT=     # optional seconds allowed for bootstrap's best-effort clone refresh; unset/blank defaults to max(20, 5 + 3 * origin-backed-project-count)
 FM_FLEET_PRUNE=1        # set to 0 to skip pruning local branches whose upstream is gone
 FM_STALE_WORKTREE_LOCK_AGE_SECS=30       # min mtime age before fm-teardown.sh treats a leftover worktree git index.lock as provably stale

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -74,6 +74,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-watch-checkpoint.sh` | Run one bounded foreground watcher checkpoint for Codex-style supervision            |
 | `fm-watch.sh`            | Singleton-safe always-on watcher: absorb benign wakes, queue and exit on actionable ones |
 | `fm-inactive-reconcile.sh` | Reconcile long-inactive direct crewmate terminal outcomes without forge access |
+| `fm-completion-outbox.sh` | Durable Flowy delivery of captain-visible crew results: record before sending, retire only on HTTP 2xx |
 | `fm-afk-start.sh`        | Run the common sourceable away-mode daemon entry in the foreground                      |
 | `fm-afk-launch.sh`       | Own away-mode entry, exit, rollback, and any backend terminal lifecycle                 |
 | `fm-afk-return.sh`       | Own deterministic return shutdown, catch-up evidence, and the firstmate-actionable blocker gate |

--- a/tests/fm-flowy-completion.test.sh
+++ b/tests/fm-flowy-completion.test.sh
@@ -23,12 +23,23 @@ make_home() {
 printf 'keychain: %s\n' "$1" >> "$FLOWY_TEST_CALLS"
 printf 'fixture-bearer-key\n'
 SH
+  # The endpoint and the Bearer header arrive as a -K - config on stdin, and the
+  # JSON body as a --data-binary @file, so the stub recovers both the way real
+  # curl would. args: is recorded verbatim because it is exactly what a local ps
+  # would see, which is what the no-secret-in-argv case asserts against.
   cat > "$fakebin/curl" <<'SH'
 #!/usr/bin/env bash
 code=$(cat "$FLOWY_TEST_CODE")
-body=$(cat)
+config=$(cat)
+body=
+for arg in "$@"; do
+  case "$arg" in
+    @*) body=$(cat "${arg#@}" 2>/dev/null || true) ;;
+  esac
+done
 {
   printf 'args: %s\n' "$*"
+  printf 'config: %s\n' "$(printf '%s' "$config" | tr '\n' ' ')"
   printf 'body: %s\n' "$body"
 } >> "$FLOWY_TEST_CALLS"
 if [ "$code" = FAIL ]; then
@@ -95,6 +106,35 @@ test_delivers_from_url_file_and_keychain_with_no_env_var() {
   assert_grep 'pending: (none)' "$home/state/flowy-last.md" \
     "display snapshot omitted the required pending: line"
   pass "outbox delivers from the URL file and Keychain with no environment variable"
+}
+
+test_the_bearer_key_never_reaches_the_process_table() {
+  local home rc argv
+  home=$(make_home no-argv-secret)
+  status_line "$home" demo 'done: credentials stay off argv'
+  rc=$(outbox "$home" --status "$home/state/demo.status")
+  expect_code 0 "$rc" "delivery failed"
+
+  # args: is what `ps -ww -axo args` would show for the POST.
+  argv=$(grep '^args: ' "$home/curl.calls" 2>/dev/null || true)
+  [ -n "$argv" ] || fail "the stub recorded no curl invocation to inspect"
+  case "$argv" in
+    *fixture-bearer-key*) fail "the Bearer key reached curl argv, where any local ps can read it" ;;
+  esac
+  case "$argv" in
+    *"$FIXTURE_URL"*) fail "the endpoint url reached curl argv instead of the stdin config" ;;
+  esac
+
+  # Both still actually reach curl, just through stdin.
+  assert_contains "$(calls "$home")" "Authorization: Bearer fixture-bearer-key" \
+    "the Bearer authorization never reached curl at all"
+  assert_contains "$(calls "$home")" "$FIXTURE_URL" "the endpoint url never reached curl at all"
+
+  [ -z "$(grep -rl 'fixture-bearer-key' "$home/state" 2>/dev/null || true)" ] || \
+    fail "the Bearer key was written somewhere under state"
+  [ -z "$(find "$home/state/flowy-outbox" -name '.payload.*' 2>/dev/null)" ] || \
+    fail "the staged payload file outlived the drain"
+  pass "the Bearer key and endpoint reach curl through stdin, never the process table"
 }
 
 test_failed_post_retries_to_success_after_a_restart() {
@@ -395,16 +435,16 @@ test_same_result_text_from_a_new_event_is_delivered_again() {
   pass "identical result text from a genuinely new event is recorded and delivered again"
 }
 
-# Every watcher case drives the real bin/fm-watch.sh. FM_FLOWY_EXIT_DRAIN_SECONDS
-# shortens the exit-path drain's wall-clock bound so a hung endpoint does not make
-# the suite wait out the production default.
+# Every watcher case drives the real bin/fm-watch.sh. The two drain ceilings are
+# shortened so a hung endpoint does not make the suite wait out the production
+# defaults; a later assignment in "$@" overrides either of them.
 start_watcher() {  # <home> [extra env assignments...]
   local home=$1
   shift
   env -u FLOWY_WEBHOOK_URL PATH="$home/fakebin:$PATH" \
     FLOWY_TEST_CODE="$home/http-code" FLOWY_TEST_CALLS="$home/curl.calls" \
     FM_HOME="$home" FM_POLL=1 FM_SIGNAL_GRACE=0 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 \
-    FM_FLOWY_EXIT_DRAIN_SECONDS=2 "$@" \
+    FM_FLOWY_EXIT_DRAIN_SECONDS=2 FM_FLOWY_DRAIN_SECONDS=3 "$@" \
     "$ROOT/bin/fm-watch.sh" >>"$home/watch.out" 2>>"$home/watch.err" &
 }
 
@@ -484,54 +524,118 @@ test_watcher_retries_a_failed_delivery_on_a_later_pass() {
   pass "a later watcher pass retries a failed delivery to success"
 }
 
-test_watcher_delivers_before_the_pass_that_recorded_it_exits() {
-  local home pid
-  home=$(make_home exit-drain-prompt)
+test_watcher_delivers_the_result_it_recorded_without_a_second_generation() {
+  local home pid i=0 receipt
+  home=$(make_home detached-prompt)
   status_line "$home" demo 'done: prompt result'
 
   start_watcher "$home"
   pid=$!
   await_watcher_exit "$pid" 200 "watcher did not surface the terminal result"
 
-  # No second generation runs: if the result is delivered, the exit path of the
-  # very pass that recorded it did it.
-  [ -n "$(sole_receipt "$home")" ] || \
-    fail "the watcher pass that recorded the result exited without delivering it"
-  assert_contains "$(cat "$(sole_receipt "$home")")" "status: demo: done: prompt result" \
-    "the exit drain delivered the wrong result"
+  # No second generation ever runs, so only the drain the recording pass detached
+  # can deliver this. It outlives the watcher by design, hence the short wait.
+  while [ "$i" -lt 100 ]; do
+    receipt=$(sole_receipt "$home")
+    [ -z "$receipt" ] || break
+    sleep 0.1
+    i=$((i + 1))
+  done
+  [ -n "$receipt" ] || fail "the detached drain never delivered the recorded result"
+  assert_contains "$(cat "$receipt")" "status: demo: done: prompt result" \
+    "the detached drain delivered the wrong result"
   [ "$(pending_count "$home")" = 0 ] || fail "a delivered result stayed pending"
-  pass "a result recorded on a watcher pass is delivered before that pass exits"
+  pass "a result recorded on a watcher pass is delivered without a second generation"
 }
 
-test_a_hung_endpoint_cannot_hold_the_watcher_past_the_exit_bound() {
-  local home pid started elapsed
-  home=$(make_home exit-drain-bound)
-  http_code "$home" HANG
+test_a_hung_endpoint_never_delays_the_watcher_exit() {
+  local home pid started elapsed baseline rc i
+  home=$(make_home detached-bound)
   status_line "$home" demo 'done: hung result'
+
+  # Baseline: the same wake with a healthy endpoint, which is the promptness the
+  # hung run must match. A synchronous drain would make the hung run far slower.
+  baseline=$(make_home detached-baseline)
+  status_line "$baseline" demo 'done: baseline result'
+  started=$SECONDS
+  start_watcher "$baseline"
+  pid=$!
+  await_watcher_exit "$pid" 300 "the baseline watcher did not surface its result"
+  baseline=$((SECONDS - started))
+
+  http_code "$home" HANG
+  started=$SECONDS
+  start_watcher "$home" FM_FLOWY_EXIT_DRAIN_SECONDS=8
+  pid=$!
+  # The stub hangs 60s and the detached bound is 8s. If the drain were in the
+  # poll body or the EXIT trap, the wake would be held for one of those.
+  await_watcher_exit "$pid" 300 "a hung endpoint held the watcher process"
+  elapsed=$((SECONDS - started))
+  [ "$elapsed" -lt $((baseline + 5)) ] || \
+    fail "a hung endpoint delayed the watcher exit by ${elapsed}s against a ${baseline}s baseline"
+
+  [ "$(pending_count "$home")" = 1 ] || fail "a hung endpoint lost the recorded result"
+  [ -z "$(sole_receipt "$home")" ] || fail "a hung endpoint wrote a receipt without a 2xx"
+  assert_absent "$home/state/flowy-last.md" "a hung endpoint wrote the display snapshot"
+
+  # The bound tears the hung child down, by its TERM handler or by the KILL
+  # backstop behind it. Either way the lock must come back - released cleanly or
+  # taken over from a dead owner - so a later drain can still deliver. A
+  # permanently wedged lock never satisfies this, it just runs out the window.
+  http_code "$home" 200
+  i=0
+  rc=1
+  while [ "$i" -lt 250 ]; do
+    rc=$(outbox "$home" --drain)
+    [ "$rc" != 0 ] || break
+    sleep 0.1
+    i=$((i + 1))
+  done
+  expect_code 0 "$rc" "a torn-down detached drain wedged the outbox lock against the next drain"
+  [ "$(pending_count "$home")" = 0 ] || fail "the later drain did not deliver the pending result"
+  pass "a hung endpoint never delays the watcher exit and never wedges the next drain"
+}
+
+test_a_hung_endpoint_cannot_stall_the_poll_loop() {
+  local home rc pid started elapsed i
+  home=$(make_home pass-drain-bound)
+  status_line "$home" queued 'done: queued before the outage'
+  rc=$(outbox "$home" --status "$home/state/queued.status" --no-drain)
+  expect_code 0 "$rc" "recording the queued result failed"
+
+  # The per-pass drain now has a record to send and the endpoint hangs 60s per
+  # POST. Its ceiling is what lets the signal scan below it still run this pass.
+  http_code "$home" HANG
+  status_line "$home" demo 'done: new result during the outage'
 
   started=$SECONDS
   start_watcher "$home"
   pid=$!
-  # The stub hangs for 60s. Without the bound the watcher would still be alive
-  # well past this window, so exiting inside it is the whole assertion.
-  await_watcher_exit "$pid" 200 "a hung endpoint held the watcher past its exit-drain bound"
+  await_watcher_exit "$pid" 400 "a hung per-pass drain stalled the watcher's poll loop"
   elapsed=$((SECONDS - started))
-  [ "$elapsed" -lt 20 ] || fail "the exit drain took ${elapsed}s, so its wall-clock bound did not bind"
+  [ "$elapsed" -lt 30 ] || \
+    fail "the per-pass drain took ${elapsed}s, so its wall-clock ceiling did not bind"
 
-  [ -n "$(calls "$home")" ] || fail "the exit drain never reached the endpoint at all"
-  [ "$(pending_count "$home")" = 1 ] || fail "a timed-out exit drain lost the result"
-  [ -z "$(sole_receipt "$home")" ] || fail "a timed-out exit drain wrote a receipt without a 2xx"
-  assert_absent "$home/state/flowy-last.md" "a timed-out exit drain wrote the display snapshot"
+  [ -n "$(calls "$home")" ] || fail "the per-pass drain never reached the endpoint at all"
+  [ "$(pending_count "$home")" = 2 ] || fail "a ceiling-cut drain retired or dropped a record"
+  [ -z "$(sole_receipt "$home")" ] || fail "a ceiling-cut drain wrote a receipt without a 2xx"
 
-  # Timing out is normal: a later pass against a healthy endpoint still delivers.
   http_code "$home" 200
-  local rc
-  rc=$(outbox "$home" --drain)
-  expect_code 0 "$rc" "the result left pending by the bound was not delivered later"
-  pass "a hung endpoint cannot hold the watcher past its exit-drain bound"
+  i=0
+  rc=1
+  while [ "$i" -lt 250 ]; do
+    rc=$(outbox "$home" --drain)
+    [ "$rc" != 0 ] || break
+    sleep 0.1
+    i=$((i + 1))
+  done
+  expect_code 0 "$rc" "the records left pending by the ceiling were not delivered later"
+  [ "$(sole_receipt "$home" | wc -l | tr -d ' ')" = 2 ] || fail "the later drain lost a record"
+  pass "a hung endpoint cannot stall the poll loop past the per-pass drain's ceiling"
 }
 
 test_delivers_from_url_file_and_keychain_with_no_env_var
+test_the_bearer_key_never_reaches_the_process_table
 test_failed_post_retries_to_success_after_a_restart
 test_two_results_never_overwrite_each_other
 test_second_result_for_one_task_gets_its_own_record
@@ -547,5 +651,6 @@ test_snapshot_pending_line_tracks_undelivered_results
 test_a_dead_endpoint_costs_one_attempt_per_drain
 test_same_result_text_from_a_new_event_is_delivered_again
 test_watcher_retries_a_failed_delivery_on_a_later_pass
-test_watcher_delivers_before_the_pass_that_recorded_it_exits
-test_a_hung_endpoint_cannot_hold_the_watcher_past_the_exit_bound
+test_watcher_delivers_the_result_it_recorded_without_a_second_generation
+test_a_hung_endpoint_never_delays_the_watcher_exit
+test_a_hung_endpoint_cannot_stall_the_poll_loop

--- a/tests/fm-flowy-completion.test.sh
+++ b/tests/fm-flowy-completion.test.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+set -eu
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+OUTBOX="$ROOT/bin/fm-completion-outbox.sh"
+TMP_ROOT=$(fm_test_tmproot fm-flowy-completion)
+
+# Every case drives the real executable. The endpoint is a PATH stub, so no test
+# ever reaches a network, and the URL and key are obvious fixtures.
+FIXTURE_URL='https://flowy.invalid/hook'
+
+make_home() {
+  local name=$1 home fakebin
+  home="$TMP_ROOT/$name"
+  mkdir -p "$home/state" "$home/config"
+  printf '%s\n' "$FIXTURE_URL" > "$home/config/grok-flowy-webhook"
+  printf '200' > "$home/http-code"
+  fakebin=$(fm_fakebin "$home")
+  cat > "$fakebin/security" <<'SH'
+#!/usr/bin/env bash
+printf 'fixture-bearer-key\n'
+SH
+  cat > "$fakebin/curl" <<'SH'
+#!/usr/bin/env bash
+code=$(cat "$FLOWY_TEST_CODE")
+body=$(cat)
+{
+  printf 'args: %s\n' "$*"
+  printf 'body: %s\n' "$body"
+} >> "$FLOWY_TEST_CALLS"
+if [ "$code" = FAIL ]; then
+  printf 'curl: (7) failed to connect\n' >&2
+  exit 7
+fi
+printf '%s' "$code"
+SH
+  chmod +x "$fakebin/security" "$fakebin/curl"
+  printf '%s\n' "$home"
+}
+
+http_code() { printf '%s' "$2" > "$1/http-code"; }
+
+calls() { cat "$1/curl.calls" 2>/dev/null || true; }
+
+call_count() { grep -c '^args: ' "$1/curl.calls" 2>/dev/null || true; }
+
+status_line() { printf '%s\n' "$3" > "$1/state/$2.status"; }
+
+sole_receipt() {
+  local home=$1 found
+  found=$(find "$home/state/flowy-outbox/delivered" -name '*.md' 2>/dev/null | LC_ALL=C sort)
+  printf '%s\n' "$found"
+}
+
+pending_count() {
+  find "$1/state/flowy-outbox/pending" -type f ! -name '.*' 2>/dev/null | wc -l | tr -d ' '
+}
+
+# env -u proves the endpoint no longer depends on FLOWY_WEBHOOK_URL even when an
+# ambient value exists.
+outbox() {
+  local home=$1 rc=0
+  shift
+  env -u FLOWY_WEBHOOK_URL \
+    PATH="$home/fakebin:$PATH" \
+    FLOWY_TEST_CODE="$home/http-code" \
+    FLOWY_TEST_CALLS="$home/curl.calls" \
+    FM_HOME="$home" "$OUTBOX" "$@" >>"$home/out.log" 2>>"$home/err.log" || rc=$?
+  printf '%s' "$rc"
+}
+
+test_delivers_from_url_file_and_keychain_with_no_env_var() {
+  local home rc
+  home=$(make_home url-file)
+  status_line "$home" demo 'done: shipped the thing'
+  rc=$(outbox "$home" --status "$home/state/demo.status")
+  expect_code 0 "$rc" "delivery from the URL file failed"
+  assert_contains "$(calls "$home")" "$FIXTURE_URL" "outbox did not POST to the URL file's endpoint"
+  assert_contains "$(calls "$home")" "Authorization: Bearer" "outbox sent no Bearer authorization"
+  assert_contains "$(calls "$home")" "Content-Type: application/json" "outbox did not POST JSON"
+  assert_contains "$(calls "$home")" '"result":"done: shipped the thing"' "payload omitted the result"
+  assert_contains "$(cat "$(sole_receipt "$home")")" "status: demo: done: shipped the thing" \
+    "no delivered receipt after a 2xx"
+  assert_grep 'status: demo: done: shipped the thing' "$home/state/flowy-last.md" \
+    "display snapshot did not record the delivered result"
+  assert_grep 'pending: (none)' "$home/state/flowy-last.md" \
+    "display snapshot omitted the required pending: line"
+  pass "outbox delivers from the URL file and Keychain with no environment variable"
+}
+
+test_failed_post_retries_to_success_after_a_restart() {
+  local home rc record
+  home=$(make_home retry)
+  http_code "$home" 503
+  status_line "$home" demo 'done: benchmark report ready'
+  rc=$(outbox "$home" --status "$home/state/demo.status")
+  expect_code 1 "$rc" "a failed POST reported success"
+  assert_absent "$home/state/flowy-last.md" "a failed POST still wrote the display snapshot"
+  [ "$(pending_count "$home")" = 1 ] || fail "a failed POST left no pending record to retry"
+  [ -z "$(sole_receipt "$home")" ] || fail "a failed POST wrote a delivered receipt"
+
+  # The record is the only thing carried across the restart: this drain runs in a
+  # new process with no status signal and no memory of the first attempt.
+  record=$(find "$home/state/flowy-outbox/pending" -type f ! -name '.*')
+  assert_grep 'result=done: benchmark report ready' "$record" "pending record lost the result"
+  assert_grep 'artifact=' "$record" "pending record lost the artifact path"
+
+  http_code "$home" 200
+  rc=$(outbox "$home" --drain)
+  expect_code 0 "$rc" "the retry drain did not deliver"
+  [ "$(pending_count "$home")" = 0 ] || fail "a delivered result stayed pending"
+  assert_grep 'status: demo: done: benchmark report ready' "$home/state/flowy-last.md" \
+    "the retry did not refresh the display snapshot"
+  pass "a failed POST is retried to success by a later drain after a restart"
+}
+
+test_two_results_never_overwrite_each_other() {
+  local home rc alpha_receipt alpha_bytes
+  home=$(make_home two-results)
+  status_line "$home" alpha 'done: alpha shipped'
+  status_line "$home" beta 'done: beta shipped'
+
+  rc=$(outbox "$home" --status "$home/state/alpha.status")
+  expect_code 0 "$rc" "alpha did not deliver"
+  alpha_receipt=$(sole_receipt "$home")
+  alpha_bytes=$(cat "$alpha_receipt")
+  assert_contains "$alpha_bytes" "status: alpha: done: alpha shipped" "alpha receipt is wrong"
+
+  # Beta fails while alpha is already delivered: alpha's evidence must not move.
+  http_code "$home" 503
+  rc=$(outbox "$home" --status "$home/state/beta.status")
+  expect_code 1 "$rc" "beta's failed POST reported success"
+  [ "$(cat "$alpha_receipt")" = "$alpha_bytes" ] || fail "beta's attempt rewrote alpha's receipt"
+  assert_grep 'status: alpha: done: alpha shipped' "$home/state/flowy-last.md" \
+    "beta's failed attempt replaced alpha in the display snapshot"
+
+  http_code "$home" 200
+  rc=$(outbox "$home" --drain)
+  expect_code 0 "$rc" "beta's retry did not deliver"
+  [ "$(cat "$alpha_receipt")" = "$alpha_bytes" ] || fail "beta's delivery rewrote alpha's receipt"
+  [ "$(sole_receipt "$home" | wc -l | tr -d ' ')" = 2 ] || fail "two results did not leave two receipts"
+  assert_contains "$(calls "$home")" '"task":"alpha"' "alpha was never sent"
+  assert_contains "$(calls "$home")" '"task":"beta"' "beta was never sent"
+  assert_grep 'pending: (none)' "$home/state/flowy-last.md" "delivered tasks stayed in pending:"
+  pass "two completed tasks both deliver and neither result overwrites the other"
+}
+
+test_second_result_for_one_task_gets_its_own_record() {
+  local home rc
+  home=$(make_home same-task)
+  status_line "$home" demo 'blocked: needs a credential'
+  rc=$(outbox "$home" --status "$home/state/demo.status")
+  expect_code 0 "$rc" "the blocked result did not deliver"
+
+  status_line "$home" demo 'done: credential landed, shipped'
+  rc=$(outbox "$home" --status "$home/state/demo.status")
+  expect_code 0 "$rc" "the later result did not deliver"
+
+  [ "$(sole_receipt "$home" | wc -l | tr -d ' ')" = 2 ] || \
+    fail "a second result for one task overwrote the first receipt"
+  assert_contains "$(calls "$home")" '"result":"blocked: needs a credential"' "the blocked result was never sent"
+  assert_contains "$(calls "$home")" '"result":"done: credential landed, shipped"' "the final result was never sent"
+  pass "a second distinct result for one task gets its own record and receipt"
+}
+
+test_re_recording_one_result_does_not_resend_it() {
+  local home rc before
+  home=$(make_home idempotent)
+  status_line "$home" demo 'done: shipped once'
+  rc=$(outbox "$home" --status "$home/state/demo.status")
+  expect_code 0 "$rc" "the first delivery failed"
+  before=$(call_count "$home")
+  rc=$(outbox "$home" --status "$home/state/demo.status")
+  expect_code 0 "$rc" "re-recording a delivered result failed"
+  [ "$(call_count "$home")" = "$before" ] || fail "an already-delivered result was POSTed again"
+  pass "re-recording an already-delivered result never resends it"
+}
+
+test_receipt_is_written_only_after_a_2xx() {
+  local home rc code
+  home=$(make_home only-2xx)
+  status_line "$home" demo 'done: needs a real 2xx'
+  for code in 500 404 302 FAIL; do
+    http_code "$home" "$code"
+    rc=$(outbox "$home" --status "$home/state/demo.status")
+    expect_code 1 "$rc" "HTTP $code was reported as delivered"
+    [ -z "$(sole_receipt "$home")" ] || fail "HTTP $code wrote a delivered receipt"
+    assert_absent "$home/state/flowy-last.md" "HTTP $code wrote the display snapshot"
+    [ "$(pending_count "$home")" = 1 ] || fail "HTTP $code did not keep the result pending"
+  done
+  http_code "$home" 201
+  rc=$(outbox "$home" --drain)
+  expect_code 0 "$rc" "HTTP 201 was not accepted as delivered"
+  assert_contains "$(cat "$(sole_receipt "$home")")" "delivered: HTTP 201" \
+    "the receipt did not record the 2xx that authorized it"
+  pass "a delivered receipt exists only after a 2xx"
+}
+
+test_missing_webhook_config_keeps_the_result_pending() {
+  local home rc
+  home=$(make_home no-config)
+  rm -f "$home/config/grok-flowy-webhook"
+  status_line "$home" demo 'done: nowhere to send yet'
+  rc=$(outbox "$home" --status "$home/state/demo.status")
+  expect_code 1 "$rc" "a missing endpoint reported success"
+  [ "$(pending_count "$home")" = 1 ] || fail "a missing endpoint discarded the result"
+  assert_absent "$home/state/flowy-last.md" "a missing endpoint still wrote the display snapshot"
+  assert_contains "$(cat "$home/err.log")" "missing Flowy webhook URL" "no actionable diagnostic"
+  pass "an unreachable configuration keeps the result pending instead of losing it"
+}
+
+test_empty_drain_is_a_silent_no_op() {
+  local home rc
+  home=$(make_home empty-drain)
+  rm -f "$home/config/grok-flowy-webhook"
+  rc=$(outbox "$home" --drain)
+  expect_code 0 "$rc" "an empty drain failed"
+  [ -z "$(calls "$home")" ] || fail "an empty drain contacted the endpoint"
+  assert_absent "$home/state/flowy-last.md" "an empty drain wrote the display snapshot"
+  pass "an empty drain is a silent no-op that needs no configuration"
+}
+
+test_dry_run_writes_nothing() {
+  local home rc
+  home=$(make_home dry-run)
+  status_line "$home" demo 'done: not really'
+  rc=$(outbox "$home" --status "$home/state/demo.status" --dry-run)
+  expect_code 0 "$rc" "the dry run failed"
+  [ -z "$(calls "$home")" ] || fail "the dry run contacted the endpoint"
+  assert_absent "$home/state/flowy-last.md" "the dry run overwrote the display snapshot"
+  assert_absent "$home/state/flowy-outbox/pending" "the dry run recorded a pending result"
+  pass "a dry run reports without writing a record, a receipt, or the snapshot"
+}
+
+test_non_result_status_is_a_no_op() {
+  local home rc
+  home=$(make_home non-result)
+  status_line "$home" demo 'working: still on it'
+  rc=$(outbox "$home" --status "$home/state/demo.status")
+  expect_code 0 "$rc" "a non-result status failed"
+  [ -z "$(calls "$home")" ] || fail "a non-result status was sent to Flowy"
+  assert_absent "$home/state/flowy-last.md" "a non-result status wrote a receipt"
+  pass "outbox ignores non-result status lines"
+}
+
+# The acceptance path the incident actually needed: the watcher advances its seen
+# markers after one attempt, so the retry can only come from a later pass.
+test_watcher_retries_a_failed_delivery_on_a_later_pass() {
+  local home pid i=0 receipt
+  home=$(make_home watcher)
+  http_code "$home" 503
+  status_line "$home" demo 'done: watcher result'
+
+  run_watcher() {
+    env -u FLOWY_WEBHOOK_URL PATH="$home/fakebin:$PATH" \
+      FLOWY_TEST_CODE="$home/http-code" FLOWY_TEST_CALLS="$home/curl.calls" \
+      FM_HOME="$home" FM_POLL=1 FM_SIGNAL_GRACE=0 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 \
+      "$ROOT/bin/fm-watch.sh" >>"$home/watch.out" 2>>"$home/watch.err" &
+  }
+
+  run_watcher
+  pid=$!
+  while kill -0 "$pid" 2>/dev/null && [ "$i" -lt 200 ]; do
+    sleep 0.1
+    i=$((i + 1))
+  done
+  if kill -0 "$pid" 2>/dev/null; then
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+    fail "watcher did not surface the terminal result"
+  fi
+  wait "$pid" 2>/dev/null || true
+  [ "$(pending_count "$home")" = 1 ] || fail "the watcher's failed delivery left nothing to retry"
+  [ -z "$(sole_receipt "$home")" ] || fail "the watcher wrote a receipt without a 2xx"
+
+  # Second pass: the status signal is already seen, so only the durable outbox
+  # can still deliver this result.
+  http_code "$home" 200
+  run_watcher
+  pid=$!
+  i=0
+  while [ "$i" -lt 200 ]; do
+    receipt=$(sole_receipt "$home")
+    [ -z "$receipt" ] || break
+    sleep 0.1
+    i=$((i + 1))
+  done
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  [ -n "$receipt" ] || fail "a later watcher pass never retried the failed delivery"
+  assert_contains "$(cat "$receipt")" "status: demo: done: watcher result" \
+    "the retried delivery recorded the wrong result"
+  [ "$(pending_count "$home")" = 0 ] || fail "the retried result stayed pending"
+  pass "a later watcher pass retries a failed delivery to success"
+}
+
+test_delivers_from_url_file_and_keychain_with_no_env_var
+test_failed_post_retries_to_success_after_a_restart
+test_two_results_never_overwrite_each_other
+test_second_result_for_one_task_gets_its_own_record
+test_re_recording_one_result_does_not_resend_it
+test_receipt_is_written_only_after_a_2xx
+test_missing_webhook_config_keeps_the_result_pending
+test_empty_drain_is_a_silent_no_op
+test_dry_run_writes_nothing
+test_non_result_status_is_a_no_op
+test_watcher_retries_a_failed_delivery_on_a_later_pass

--- a/tests/fm-flowy-completion.test.sh
+++ b/tests/fm-flowy-completion.test.sh
@@ -718,7 +718,7 @@ test_a_hung_endpoint_cannot_stall_the_poll_loop() {
 # derives one from POLL, so a fractional poll must still leave the per-pass drain
 # enough room to POST rather than tearing it down before it reaches the endpoint.
 test_a_fractional_poll_still_drains_pending_records() {
-  local home rc pid receipt= i=0
+  local home rc pid receipt='' i=0
   home=$(make_home fractional-poll)
   status_line "$home" queued 'done: fractional poll result'
   rc=$(outbox "$home" --status "$home/state/queued.status" --no-drain)

--- a/tests/fm-flowy-completion.test.sh
+++ b/tests/fm-flowy-completion.test.sh
@@ -37,6 +37,14 @@ for arg in "$@"; do
     @*) body=$(cat "${arg#@}" 2>/dev/null || true) ;;
   esac
 done
+# A per-task override lets ONE drain pass answer differently per record, which
+# is how an older record gets held back while a newer one is accepted.
+for override in "$FLOWY_TEST_CODE"-*; do
+  [ -f "$override" ] || continue
+  case "$body" in
+    *"\"task\":\"${override##*/http-code-}\""*) code=$(cat "$override") ;;
+  esac
+done
 {
   printf 'args: %s\n' "$*"
   printf 'config: %s\n' "$(printf '%s' "$config" | tr '\n' ' ')"
@@ -57,6 +65,10 @@ SH
 }
 
 http_code() { printf '%s' "$2" > "$1/http-code"; }
+
+http_code_for() { printf '%s' "$3" > "$1/http-code-$2"; }
+
+clear_http_code_for() { rm -f "$1/http-code-$2"; }
 
 calls() { cat "$1/curl.calls" 2>/dev/null || true; }
 
@@ -344,6 +356,40 @@ test_snapshot_names_the_newest_delivered_result() {
   assert_grep 'status: alpha: done: alpha shipped' "$home/state/flowy-last.md" \
     "the snapshot named an older delivered result than the newest one"
   pass "one drain of several records leaves the newest delivered result in the snapshot"
+}
+
+test_a_held_back_record_never_drags_the_snapshot_backwards() {
+  local home rc
+  home=$(make_home snapshot-monotonic)
+  status_line "$home" zeta 'done: zeta shipped'
+  rc=$(outbox "$home" --status "$home/state/zeta.status" --no-drain)
+  expect_code 0 "$rc" "recording zeta failed"
+  status_line "$home" alpha 'done: alpha shipped'
+  rc=$(outbox "$home" --status "$home/state/alpha.status" --no-drain)
+  expect_code 0 "$rc" "recording alpha failed"
+
+  # One pass, mixed outcomes. zeta is the OLDER record and is rejected per-record
+  # with a 503, which is record-specific, so the pass keeps going and alpha - the
+  # newer result - is accepted.
+  http_code "$home" 200
+  http_code_for "$home" zeta 503
+  rc=$(outbox "$home" --drain)
+  expect_code 1 "$rc" "a pass that left a record pending reported a clean drain"
+  assert_grep 'status: alpha: done: alpha shipped' "$home/state/flowy-last.md" \
+    "the newer delivered result never reached the snapshot"
+  assert_grep 'pending: zeta' "$home/state/flowy-last.md" \
+    "the held-back record is missing from the pending line"
+
+  # The next pass retires zeta. It is genuinely the older result, so the display
+  # must keep naming alpha and only zeta's pending entry may move.
+  clear_http_code_for "$home" zeta
+  rc=$(outbox "$home" --drain)
+  expect_code 0 "$rc" "the retry did not deliver the held-back record"
+  [ "$(sole_receipt "$home" | wc -l | tr -d ' ')" = 2 ] || fail "both results did not leave receipts"
+  assert_grep 'status: alpha: done: alpha shipped' "$home/state/flowy-last.md" \
+    "delivering the older held-back record dragged the snapshot back to it"
+  assert_grep 'pending: (none)' "$home/state/flowy-last.md" "a drained outbox still reported pending work"
+  pass "delivering a held-back older record never drags the snapshot backwards"
 }
 
 test_snapshot_pending_line_tracks_undelivered_results() {
@@ -680,6 +726,7 @@ test_dry_run_writes_nothing
 test_non_result_status_is_a_no_op
 test_record_only_mode_performs_no_network_io
 test_snapshot_names_the_newest_delivered_result
+test_a_held_back_record_never_drags_the_snapshot_backwards
 test_snapshot_pending_line_tracks_undelivered_results
 test_a_dead_endpoint_costs_one_attempt_per_drain
 test_same_result_text_from_a_new_event_is_delivered_again

--- a/tests/fm-flowy-completion.test.sh
+++ b/tests/fm-flowy-completion.test.sh
@@ -713,6 +713,41 @@ test_a_hung_endpoint_cannot_stall_the_poll_loop() {
   pass "a hung endpoint cannot stall the poll loop past the per-pass drain's ceiling"
 }
 
+# FM_POLL is a documented knob that takes fractional seconds, and this repo's own
+# suite runs watchers at FM_POLL=0.2. With no ceiling configured the watcher
+# derives one from POLL, so a fractional poll must still leave the per-pass drain
+# enough room to POST rather than tearing it down before it reaches the endpoint.
+test_a_fractional_poll_still_drains_pending_records() {
+  local home rc pid receipt= i=0
+  home=$(make_home fractional-poll)
+  status_line "$home" queued 'done: fractional poll result'
+  rc=$(outbox "$home" --status "$home/state/queued.status" --no-drain)
+  expect_code 0 "$rc" "recording the queued result failed"
+  [ "$(pending_count "$home")" = 1 ] || fail "nothing was left pending for the drain to deliver"
+
+  # With the status file gone the watcher observes no terminal signal, so nothing
+  # records and nothing detaches a drain. The per-pass drain is then the only
+  # thing that can deliver this record.
+  rm -f "$home/state/queued.status"
+
+  start_watcher "$home" FM_POLL=0.2 FM_FLOWY_DRAIN_SECONDS=
+  pid=$!
+  while [ "$i" -lt 300 ]; do
+    receipt=$(sole_receipt "$home")
+    [ -z "$receipt" ] || break
+    sleep 0.1
+    i=$((i + 1))
+  done
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+
+  [ -n "$receipt" ] || fail "a fractional FM_POLL left the per-pass drain unable to deliver"
+  assert_contains "$(cat "$receipt")" "status: queued: done: fractional poll result" \
+    "the per-pass drain delivered the wrong result"
+  [ "$(pending_count "$home")" = 0 ] || fail "the delivered result stayed pending"
+  pass "a fractional FM_POLL still leaves the per-pass drain a usable ceiling"
+}
+
 test_delivers_from_url_file_and_keychain_with_no_env_var
 test_the_bearer_key_never_reaches_the_process_table
 test_failed_post_retries_to_success_after_a_restart
@@ -734,3 +769,4 @@ test_watcher_retries_a_failed_delivery_on_a_later_pass
 test_watcher_delivers_the_result_it_recorded_without_a_second_generation
 test_a_hung_endpoint_never_delays_the_watcher_exit
 test_a_hung_endpoint_cannot_stall_the_poll_loop
+test_a_fractional_poll_still_drains_pending_records

--- a/tests/fm-flowy-completion.test.sh
+++ b/tests/fm-flowy-completion.test.sh
@@ -437,14 +437,17 @@ test_same_result_text_from_a_new_event_is_delivered_again() {
 
 # Every watcher case drives the real bin/fm-watch.sh. The two drain ceilings are
 # shortened so a hung endpoint does not make the suite wait out the production
-# defaults; a later assignment in "$@" overrides either of them.
+# defaults; a later assignment in "$@" overrides either of them. They stay well
+# above the time a stubbed drain needs to fork, source its libraries, take the
+# lock and POST, because a ceiling that cuts off a HEALTHY stubbed drain would
+# fail the delivery cases under concurrent suite load rather than bound anything.
 start_watcher() {  # <home> [extra env assignments...]
   local home=$1
   shift
   env -u FLOWY_WEBHOOK_URL PATH="$home/fakebin:$PATH" \
     FLOWY_TEST_CODE="$home/http-code" FLOWY_TEST_CALLS="$home/curl.calls" \
     FM_HOME="$home" FM_POLL=1 FM_SIGNAL_GRACE=0 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 \
-    FM_FLOWY_EXIT_DRAIN_SECONDS=2 FM_FLOWY_DRAIN_SECONDS=3 "$@" \
+    FM_FLOWY_EXIT_DRAIN_SECONDS=6 FM_FLOWY_DRAIN_SECONDS=6 "$@" \
     "$ROOT/bin/fm-watch.sh" >>"$home/watch.out" 2>>"$home/watch.err" &
 }
 
@@ -475,6 +478,33 @@ await_call_count_above() {  # <home> <count> <deciseconds>
   return 1
 }
 
+# state/flowy-outbox/.drain.lock is the outbox's own one-drain-at-a-time lock,
+# taken for the whole pass and released at the end of it. Its absence is the
+# observable "no drain is running for this home right now".
+await_drain_lock_clear() {  # <home> <deciseconds>
+  local lock="$1/state/flowy-outbox/.drain.lock" limit=$2 i=0
+  while [ "$i" -lt "$limit" ]; do
+    if [ ! -e "$lock" ] && [ ! -L "$lock" ]; then
+      return 0
+    fi
+    sleep 0.1
+    i=$((i + 1))
+  done
+  return 1
+}
+
+# The signal path detaches its drain on purpose, so it routinely outlives the
+# watcher process that started it. A test that reads a call count or starts a
+# NEW generation before that child is done would otherwise attribute one
+# generation's POST to another, or make the next generation's drain fail on the
+# lock rather than on the response the case is actually exercising. Settled
+# means the POST has landed AND the drain that made it has released the lock.
+await_detached_drain_settled() {  # <home> <floor> <deciseconds>
+  local home=$1 floor=$2 limit=$3
+  await_call_count_above "$home" "$floor" "$limit" || return 1
+  await_drain_lock_clear "$home" "$limit"
+}
+
 # The acceptance path the incident actually needed: the watcher advances its seen
 # markers after one attempt, so the retry can only come from a later pass.
 test_watcher_retries_a_failed_delivery_on_a_later_pass() {
@@ -483,19 +513,22 @@ test_watcher_retries_a_failed_delivery_on_a_later_pass() {
   http_code "$home" 503
   status_line "$home" demo 'done: watcher result'
 
-  # First generation: the signal path records, the wake fires, and the bounded
-  # exit drain makes a REAL POST that the endpoint rejects with 503.
+  # First generation: the signal path records, the wake fires, and the drain it
+  # detached makes a REAL POST that the endpoint rejects with 503. That child is
+  # built to outlive the watcher, so settle it before reading any count.
   start_watcher "$home"
   pid=$!
   await_watcher_exit "$pid" 200 "watcher did not surface the terminal result"
-  after_first=$(call_count "$home")
-  [ -n "$after_first" ] && [ "$after_first" -gt 0 ] || \
+  await_detached_drain_settled "$home" 0 300 || \
     fail "the first watcher generation never attempted a delivery, so nothing failed to retry"
+  after_first=$(call_count "$home")
   [ "$(pending_count "$home")" = 1 ] || fail "the watcher's failed delivery left nothing to retry"
   [ -z "$(sole_receipt "$home")" ] || fail "the watcher wrote a receipt without a 2xx"
 
-  # Second generation: the status signal is already seen, so this is the per-pass
-  # drain retrying on its own - and it fails against 503 exactly as the first did.
+  # Second generation: the status signal is already seen, so nothing records and
+  # nothing detaches. The only POST that can raise the count past the settled
+  # floor above is the per-pass drain retrying on its own - and it fails against
+  # 503 exactly as the first did.
   start_watcher "$home"
   pid=$!
   await_call_count_above "$home" "$after_first" 200 || \
@@ -504,6 +537,8 @@ test_watcher_retries_a_failed_delivery_on_a_later_pass() {
   wait "$pid" 2>/dev/null || true
   [ "$(pending_count "$home")" = 1 ] || fail "a failed per-pass drain discarded the result"
   [ -z "$(sole_receipt "$home")" ] || fail "a failed per-pass drain wrote a receipt without a 2xx"
+  await_drain_lock_clear "$home" 300 || \
+    fail "the second generation's drain never released the outbox lock"
 
   # Third generation: the endpoint recovers and the per-pass drain delivers.
   http_code "$home" 200
@@ -525,7 +560,7 @@ test_watcher_retries_a_failed_delivery_on_a_later_pass() {
 }
 
 test_watcher_delivers_the_result_it_recorded_without_a_second_generation() {
-  local home pid i=0 receipt
+  local home pid receipt
   home=$(make_home detached-prompt)
   status_line "$home" demo 'done: prompt result'
 
@@ -534,13 +569,11 @@ test_watcher_delivers_the_result_it_recorded_without_a_second_generation() {
   await_watcher_exit "$pid" 200 "watcher did not surface the terminal result"
 
   # No second generation ever runs, so only the drain the recording pass detached
-  # can deliver this. It outlives the watcher by design, hence the short wait.
-  while [ "$i" -lt 100 ]; do
-    receipt=$(sole_receipt "$home")
-    [ -z "$receipt" ] || break
-    sleep 0.1
-    i=$((i + 1))
-  done
+  # can deliver this. It outlives the watcher by design, and it retires the record
+  # after writing the receipt, so settle it before reading either.
+  await_detached_drain_settled "$home" 0 300 || \
+    fail "the detached drain never reached the endpoint"
+  receipt=$(sole_receipt "$home")
   [ -n "$receipt" ] || fail "the detached drain never delivered the recorded result"
   assert_contains "$(cat "$receipt")" "status: demo: done: prompt result" \
     "the detached drain delivered the wrong result"

--- a/tests/fm-flowy-completion.test.sh
+++ b/tests/fm-flowy-completion.test.sh
@@ -20,6 +20,7 @@ make_home() {
   fakebin=$(fm_fakebin "$home")
   cat > "$fakebin/security" <<'SH'
 #!/usr/bin/env bash
+printf 'keychain: %s\n' "$1" >> "$FLOWY_TEST_CALLS"
 printf 'fixture-bearer-key\n'
 SH
   cat > "$fakebin/curl" <<'SH'
@@ -45,6 +46,8 @@ http_code() { printf '%s' "$2" > "$1/http-code"; }
 calls() { cat "$1/curl.calls" 2>/dev/null || true; }
 
 call_count() { grep -c '^args: ' "$1/curl.calls" 2>/dev/null || true; }
+
+keychain_count() { grep -c '^keychain: ' "$1/curl.calls" 2>/dev/null || true; }
 
 status_line() { printf '%s\n' "$3" > "$1/state/$2.status"; }
 
@@ -245,6 +248,150 @@ test_non_result_status_is_a_no_op() {
   pass "outbox ignores non-result status lines"
 }
 
+test_record_only_mode_performs_no_network_io() {
+  local home rc calls_before keychain_before
+  home=$(make_home record-only)
+  status_line "$home" alpha 'done: alpha shipped'
+  rc=$(outbox "$home" --status "$home/state/alpha.status")
+  expect_code 0 "$rc" "alpha did not deliver"
+
+  calls_before=$(call_count "$home")
+  keychain_before=$(keychain_count "$home")
+  status_line "$home" beta 'done: beta shipped'
+  rc=$(outbox "$home" --status "$home/state/beta.status" --no-drain)
+  expect_code 0 "$rc" "record-only mode reported a failure for a recorded result"
+  [ "$(call_count "$home")" = "$calls_before" ] || fail "record-only mode contacted the endpoint"
+  [ "$(keychain_count "$home")" = "$keychain_before" ] || fail "record-only mode read the Keychain"
+  [ "$(pending_count "$home")" = 1 ] || fail "record-only mode left no durable record"
+  [ "$(sole_receipt "$home" | wc -l | tr -d ' ')" = 1 ] || fail "record-only mode wrote a receipt"
+  assert_grep 'pending: beta' "$home/state/flowy-last.md" \
+    "record-only mode did not refresh the snapshot's pending line"
+
+  # Recording never depends on the endpoint being configured at all.
+  rm -f "$home/config/grok-flowy-webhook"
+  status_line "$home" gamma 'done: gamma shipped'
+  rc=$(outbox "$home" --status "$home/state/gamma.status" --no-drain)
+  expect_code 0 "$rc" "record-only mode failed without an endpoint configuration"
+  [ "$(pending_count "$home")" = 2 ] || fail "record-only mode dropped a result with no endpoint"
+
+  rc=$(outbox "$home" --drain --no-drain)
+  expect_code 2 "$rc" "--drain --no-drain was accepted as a usable run"
+  pass "record-only mode records durably with no network, Keychain, or endpoint access"
+}
+
+test_snapshot_names_the_newest_delivered_result() {
+  local home rc
+  home=$(make_home newest)
+  status_line "$home" zeta 'done: zeta shipped'
+  rc=$(outbox "$home" --status "$home/state/zeta.status" --no-drain)
+  expect_code 0 "$rc" "recording zeta failed"
+  # A record timestamps itself in whole seconds, so the second result has to land
+  # in a later second for "newest" to be well defined at all.
+  sleep 1
+  status_line "$home" alpha 'done: alpha shipped'
+  rc=$(outbox "$home" --status "$home/state/alpha.status" --no-drain)
+  expect_code 0 "$rc" "recording alpha failed"
+  [ "$(pending_count "$home")" = 2 ] || fail "two recorded results did not leave two pending records"
+
+  # alpha is the newer result but collates first, so a collation-ordered drain
+  # would finish on zeta and hand the snapshot the older of the two.
+  rc=$(outbox "$home" --drain)
+  expect_code 0 "$rc" "the drain did not deliver both records"
+  [ "$(sole_receipt "$home" | wc -l | tr -d ' ')" = 2 ] || fail "one drain did not deliver both records"
+  assert_grep 'status: alpha: done: alpha shipped' "$home/state/flowy-last.md" \
+    "the snapshot named an older delivered result than the newest one"
+  pass "one drain of several records leaves the newest delivered result in the snapshot"
+}
+
+test_snapshot_pending_line_tracks_undelivered_results() {
+  local home rc
+  home=$(make_home pending-line)
+  status_line "$home" alpha 'done: alpha shipped'
+  rc=$(outbox "$home" --status "$home/state/alpha.status")
+  expect_code 0 "$rc" "alpha did not deliver"
+  assert_grep 'pending: (none)' "$home/state/flowy-last.md" "a drained outbox did not report (none)"
+
+  http_code "$home" 503
+  status_line "$home" beta 'done: beta shipped'
+  rc=$(outbox "$home" --status "$home/state/beta.status")
+  expect_code 1 "$rc" "beta's failed POST reported success"
+  assert_grep 'pending: beta' "$home/state/flowy-last.md" \
+    "the snapshot claimed nothing was pending while beta sat undelivered in the outbox"
+  # A pass that delivered nothing may move pending: and nothing else.
+  assert_grep 'status: alpha: done: alpha shipped' "$home/state/flowy-last.md" \
+    "a failed POST moved the snapshot's status line"
+  assert_grep 'files: ' "$home/state/flowy-last.md" "a failed POST dropped the snapshot's files line"
+  assert_grep 'HEARTBEAT:' "$home/state/flowy-last.md" "a failed POST dropped the snapshot's heartbeat line"
+
+  http_code "$home" 200
+  rc=$(outbox "$home" --drain)
+  expect_code 0 "$rc" "beta's retry did not deliver"
+  assert_grep 'pending: (none)' "$home/state/flowy-last.md" "a drained outbox still reported pending work"
+  pass "the snapshot's pending line tracks undelivered results without gaining delivery authority"
+}
+
+test_a_dead_endpoint_costs_one_attempt_per_drain() {
+  local home rc task before
+  home=$(make_home dead-endpoint)
+  for task in alpha beta gamma; do
+    status_line "$home" "$task" "done: $task shipped"
+    rc=$(outbox "$home" --status "$home/state/$task.status" --no-drain)
+    expect_code 0 "$rc" "recording $task failed"
+  done
+  [ "$(pending_count "$home")" = 3 ] || fail "three results did not leave three pending records"
+
+  # A per-record HTTP code is record-specific, so the pass keeps going.
+  http_code "$home" 503
+  before=$(call_count "$home")
+  rc=$(outbox "$home" --drain)
+  expect_code 1 "$rc" "a wholly undelivered drain reported success"
+  [ "$((  $(call_count "$home") - before ))" = 3 ] || fail "a 503 stopped the drain before the last record"
+
+  # A transport failure is endpoint-wide, so one attempt settles the whole pass.
+  http_code "$home" FAIL
+  before=$(call_count "$home")
+  rc=$(outbox "$home" --drain)
+  expect_code 1 "$rc" "a dead endpoint reported a successful drain"
+  [ "$((  $(call_count "$home") - before ))" = 1 ] || \
+    fail "a dead endpoint was retried per record instead of once per drain"
+  [ "$(pending_count "$home")" = 3 ] || fail "a dead endpoint retired or dropped a pending record"
+  [ -z "$(sole_receipt "$home")" ] || fail "a dead endpoint wrote a delivered receipt"
+
+  http_code "$home" 200
+  rc=$(outbox "$home" --drain)
+  expect_code 0 "$rc" "the recovered endpoint did not deliver every record"
+  [ "$(sole_receipt "$home" | wc -l | tr -d ' ')" = 3 ] || fail "the recovered drain lost a record"
+  [ "$(pending_count "$home")" = 0 ] || fail "a delivered result stayed pending"
+  pass "a dead endpoint costs one attempt per drain and retires nothing differently"
+}
+
+test_same_result_text_from_a_new_event_is_delivered_again() {
+  local home rc before
+  home=$(make_home repeat-event)
+  status_line "$home" demo 'blocked: waiting on captain decision'
+  rc=$(outbox "$home" --status "$home/state/demo.status")
+  expect_code 0 "$rc" "the first blocked result did not deliver"
+  before=$(call_count "$home")
+
+  # Re-observing the very same bytes is still a no-op: the de-duplication the
+  # watcher relies on has not been traded away.
+  rc=$(outbox "$home" --status "$home/state/demo.status")
+  expect_code 0 "$rc" "re-observing an unchanged status failed"
+  [ "$(call_count "$home")" = "$before" ] || fail "an unchanged status was POSTed a second time"
+
+  # The captain resolves it, work resumes, and the task blocks again on the
+  # identical templated line. That is a new event, not a re-observation.
+  printf 'working: resumed after the decision\nblocked: waiting on captain decision\n' \
+    > "$home/state/demo.status"
+  rc=$(outbox "$home" --status "$home/state/demo.status")
+  expect_code 0 "$rc" "the second block did not deliver"
+  [ "$(call_count "$home")" -gt "$before" ] || \
+    fail "a new event carrying identical result text was never sent"
+  [ "$(sole_receipt "$home" | wc -l | tr -d ' ')" = 2 ] || \
+    fail "the repeated result did not get its own receipt"
+  pass "identical result text from a genuinely new event is recorded and delivered again"
+}
+
 # The acceptance path the incident actually needed: the watcher advances its seen
 # markers after one attempt, so the retry can only come from a later pass.
 test_watcher_retries_a_failed_delivery_on_a_later_pass() {
@@ -306,4 +453,9 @@ test_missing_webhook_config_keeps_the_result_pending
 test_empty_drain_is_a_silent_no_op
 test_dry_run_writes_nothing
 test_non_result_status_is_a_no_op
+test_record_only_mode_performs_no_network_io
+test_snapshot_names_the_newest_delivered_result
+test_snapshot_pending_line_tracks_undelivered_results
+test_a_dead_endpoint_costs_one_attempt_per_drain
+test_same_result_text_from_a_new_event_is_delivered_again
 test_watcher_retries_a_failed_delivery_on_a_later_pass

--- a/tests/fm-flowy-completion.test.sh
+++ b/tests/fm-flowy-completion.test.sh
@@ -35,6 +35,10 @@ if [ "$code" = FAIL ]; then
   printf 'curl: (7) failed to connect\n' >&2
   exit 7
 fi
+if [ "$code" = HANG ]; then
+  sleep 60
+  exit 7
+fi
 printf '%s' "$code"
 SH
   chmod +x "$fakebin/security" "$fakebin/curl"
@@ -285,9 +289,8 @@ test_snapshot_names_the_newest_delivered_result() {
   status_line "$home" zeta 'done: zeta shipped'
   rc=$(outbox "$home" --status "$home/state/zeta.status" --no-drain)
   expect_code 0 "$rc" "recording zeta failed"
-  # A record timestamps itself in whole seconds, so the second result has to land
-  # in a later second for "newest" to be well defined at all.
-  sleep 1
+  # Back to back on purpose: both records land in the same wall-clock second, so
+  # nothing but the monotonic ordinal can tell which result is the newer one.
   status_line "$home" alpha 'done: alpha shipped'
   rc=$(outbox "$home" --status "$home/state/alpha.status" --no-drain)
   expect_code 0 "$rc" "recording alpha failed"
@@ -392,42 +395,80 @@ test_same_result_text_from_a_new_event_is_delivered_again() {
   pass "identical result text from a genuinely new event is recorded and delivered again"
 }
 
-# The acceptance path the incident actually needed: the watcher advances its seen
-# markers after one attempt, so the retry can only come from a later pass.
-test_watcher_retries_a_failed_delivery_on_a_later_pass() {
-  local home pid i=0 receipt
-  home=$(make_home watcher)
-  http_code "$home" 503
-  status_line "$home" demo 'done: watcher result'
+# Every watcher case drives the real bin/fm-watch.sh. FM_FLOWY_EXIT_DRAIN_SECONDS
+# shortens the exit-path drain's wall-clock bound so a hung endpoint does not make
+# the suite wait out the production default.
+start_watcher() {  # <home> [extra env assignments...]
+  local home=$1
+  shift
+  env -u FLOWY_WEBHOOK_URL PATH="$home/fakebin:$PATH" \
+    FLOWY_TEST_CODE="$home/http-code" FLOWY_TEST_CALLS="$home/curl.calls" \
+    FM_HOME="$home" FM_POLL=1 FM_SIGNAL_GRACE=0 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 \
+    FM_FLOWY_EXIT_DRAIN_SECONDS=2 "$@" \
+    "$ROOT/bin/fm-watch.sh" >>"$home/watch.out" 2>>"$home/watch.err" &
+}
 
-  run_watcher() {
-    env -u FLOWY_WEBHOOK_URL PATH="$home/fakebin:$PATH" \
-      FLOWY_TEST_CODE="$home/http-code" FLOWY_TEST_CALLS="$home/curl.calls" \
-      FM_HOME="$home" FM_POLL=1 FM_SIGNAL_GRACE=0 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 \
-      "$ROOT/bin/fm-watch.sh" >>"$home/watch.out" 2>>"$home/watch.err" &
-  }
-
-  run_watcher
-  pid=$!
-  while kill -0 "$pid" 2>/dev/null && [ "$i" -lt 200 ]; do
+# Wait for a watcher to end on its own, as it does after a wake.
+await_watcher_exit() {  # <pid> <deciseconds> <message>
+  local pid=$1 limit=$2 i=0
+  while kill -0 "$pid" 2>/dev/null && [ "$i" -lt "$limit" ]; do
     sleep 0.1
     i=$((i + 1))
   done
   if kill -0 "$pid" 2>/dev/null; then
     kill "$pid" 2>/dev/null || true
     wait "$pid" 2>/dev/null || true
-    fail "watcher did not surface the terminal result"
+    fail "$3"
   fi
   wait "$pid" 2>/dev/null || true
+}
+
+await_call_count_above() {  # <home> <count> <deciseconds>
+  local home=$1 floor=$2 limit=$3 i=0 seen
+  while [ "$i" -lt "$limit" ]; do
+    seen=$(call_count "$home")
+    [ -n "$seen" ] || seen=0
+    [ "$seen" -le "$floor" ] || return 0
+    sleep 0.1
+    i=$((i + 1))
+  done
+  return 1
+}
+
+# The acceptance path the incident actually needed: the watcher advances its seen
+# markers after one attempt, so the retry can only come from a later pass.
+test_watcher_retries_a_failed_delivery_on_a_later_pass() {
+  local home pid i=0 receipt after_first
+  home=$(make_home watcher)
+  http_code "$home" 503
+  status_line "$home" demo 'done: watcher result'
+
+  # First generation: the signal path records, the wake fires, and the bounded
+  # exit drain makes a REAL POST that the endpoint rejects with 503.
+  start_watcher "$home"
+  pid=$!
+  await_watcher_exit "$pid" 200 "watcher did not surface the terminal result"
+  after_first=$(call_count "$home")
+  [ -n "$after_first" ] && [ "$after_first" -gt 0 ] || \
+    fail "the first watcher generation never attempted a delivery, so nothing failed to retry"
   [ "$(pending_count "$home")" = 1 ] || fail "the watcher's failed delivery left nothing to retry"
   [ -z "$(sole_receipt "$home")" ] || fail "the watcher wrote a receipt without a 2xx"
 
-  # Second pass: the status signal is already seen, so only the durable outbox
-  # can still deliver this result.
-  http_code "$home" 200
-  run_watcher
+  # Second generation: the status signal is already seen, so this is the per-pass
+  # drain retrying on its own - and it fails against 503 exactly as the first did.
+  start_watcher "$home"
   pid=$!
-  i=0
+  await_call_count_above "$home" "$after_first" 200 || \
+    fail "a later watcher pass never retried the failed delivery"
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+  [ "$(pending_count "$home")" = 1 ] || fail "a failed per-pass drain discarded the result"
+  [ -z "$(sole_receipt "$home")" ] || fail "a failed per-pass drain wrote a receipt without a 2xx"
+
+  # Third generation: the endpoint recovers and the per-pass drain delivers.
+  http_code "$home" 200
+  start_watcher "$home"
+  pid=$!
   while [ "$i" -lt 200 ]; do
     receipt=$(sole_receipt "$home")
     [ -z "$receipt" ] || break
@@ -436,11 +477,58 @@ test_watcher_retries_a_failed_delivery_on_a_later_pass() {
   done
   kill "$pid" 2>/dev/null || true
   wait "$pid" 2>/dev/null || true
-  [ -n "$receipt" ] || fail "a later watcher pass never retried the failed delivery"
+  [ -n "$receipt" ] || fail "a later watcher pass never retried the failed delivery to success"
   assert_contains "$(cat "$receipt")" "status: demo: done: watcher result" \
     "the retried delivery recorded the wrong result"
   [ "$(pending_count "$home")" = 0 ] || fail "the retried result stayed pending"
   pass "a later watcher pass retries a failed delivery to success"
+}
+
+test_watcher_delivers_before_the_pass_that_recorded_it_exits() {
+  local home pid
+  home=$(make_home exit-drain-prompt)
+  status_line "$home" demo 'done: prompt result'
+
+  start_watcher "$home"
+  pid=$!
+  await_watcher_exit "$pid" 200 "watcher did not surface the terminal result"
+
+  # No second generation runs: if the result is delivered, the exit path of the
+  # very pass that recorded it did it.
+  [ -n "$(sole_receipt "$home")" ] || \
+    fail "the watcher pass that recorded the result exited without delivering it"
+  assert_contains "$(cat "$(sole_receipt "$home")")" "status: demo: done: prompt result" \
+    "the exit drain delivered the wrong result"
+  [ "$(pending_count "$home")" = 0 ] || fail "a delivered result stayed pending"
+  pass "a result recorded on a watcher pass is delivered before that pass exits"
+}
+
+test_a_hung_endpoint_cannot_hold_the_watcher_past_the_exit_bound() {
+  local home pid started elapsed
+  home=$(make_home exit-drain-bound)
+  http_code "$home" HANG
+  status_line "$home" demo 'done: hung result'
+
+  started=$SECONDS
+  start_watcher "$home"
+  pid=$!
+  # The stub hangs for 60s. Without the bound the watcher would still be alive
+  # well past this window, so exiting inside it is the whole assertion.
+  await_watcher_exit "$pid" 200 "a hung endpoint held the watcher past its exit-drain bound"
+  elapsed=$((SECONDS - started))
+  [ "$elapsed" -lt 20 ] || fail "the exit drain took ${elapsed}s, so its wall-clock bound did not bind"
+
+  [ -n "$(calls "$home")" ] || fail "the exit drain never reached the endpoint at all"
+  [ "$(pending_count "$home")" = 1 ] || fail "a timed-out exit drain lost the result"
+  [ -z "$(sole_receipt "$home")" ] || fail "a timed-out exit drain wrote a receipt without a 2xx"
+  assert_absent "$home/state/flowy-last.md" "a timed-out exit drain wrote the display snapshot"
+
+  # Timing out is normal: a later pass against a healthy endpoint still delivers.
+  http_code "$home" 200
+  local rc
+  rc=$(outbox "$home" --drain)
+  expect_code 0 "$rc" "the result left pending by the bound was not delivered later"
+  pass "a hung endpoint cannot hold the watcher past its exit-drain bound"
 }
 
 test_delivers_from_url_file_and_keychain_with_no_env_var
@@ -459,3 +547,5 @@ test_snapshot_pending_line_tracks_undelivered_results
 test_a_dead_endpoint_costs_one_attempt_per_drain
 test_same_result_text_from_a_new_event_is_delivered_again
 test_watcher_retries_a_failed_delivery_on_a_later_pass
+test_watcher_delivers_before_the_pass_that_recorded_it_exits
+test_a_hung_endpoint_cannot_hold_the_watcher_past_the_exit_bound


### PR DESCRIPTION
## What Changed

- `bin/fm-completion-outbox.sh` becomes a durable delivery path instead of a script that could not deliver at all. It resolves the endpoint from `config/grok-flowy-webhook` and the Bearer key from the Keychain, so a normal invocation needs no environment variable; the URL and the key are handed to `curl -K -` on stdin and the JSON payload goes through a `umask 077` mode-600 file, so neither the endpoint nor the key ever appears in `ps` output.
- Delivery is now record-first. One immutable record per task is written before any network call, carrying the result and its artifact path. A record retires, and its per-task receipt under `state/flowy-outbox/delivered/` is written, only on HTTP 2xx; every other outcome leaves the record pending for a later pass, so a receipt cannot exist without a successful send. Records carry a monotonic ordinal so that same-second results still order correctly, and the aggregate `state/flowy-last.md` stays a display snapshot that never gains delivery authority and keeps its `pending:` line truthful.
- `bin/fm-watch.sh` drains all pending records on every pass under a single wall-clock ceiling, and records terminal results on the signal path without opening a socket. Because the wake only becomes visible when the watcher process exits, the post-record drain is detached into its own process group with a bounded deadline and a TERM-then-KILL backstop, so delivery never delays the wake. The group signal verifies the child's pgid before signalling, matching the existing guard elsewhere in the file.
- `tests/fm-flowy-completion.test.sh` covers the contract through the executable interface with a stubbed endpoint and no real webhook: a failed POST retried to success across watcher generations, two concurrent terminal results that do not overwrite each other, delivery state surviving a restart, the receipt-only-after-2xx rule, snapshot ordering, and that the key never reaches the process table.
- `docs/configuration.md` gains the operator-facing setup and the `FM_FLOWY_*` bounds; `docs/scripts.md` gains the toolbelt row.

## Risk Assessment

⚠️ Medium: The change is well covered and the delivery invariants are enforced at the code path rather than only documented, but it adds a detached child process and a process-group signal on the watcher's exit path, which is the highest-consequence area touched. The bounded deadline, pgid verification, and dead-owner lock takeover are the mitigations, and timing out retires nothing.

## Testing

The validation pipeline's review, test, document, and lint steps all completed on this branch. The focused suite covers the delivery contract end to end against a stubbed endpoint, and each new case was demonstrated to be a genuine regression test by reverting the specific logic it guards. The three adjacent watcher suites that exercise the cleanup and poll paths were re-run because `fm-watch.sh` changed. ShellCheck is clean at the pinned version. The workflow linter reports its binary missing inside the pipeline's own shell; with the pinned `actionlint 1.7.12` on PATH it validates all three workflow files and exits 0, and no workflow file is in scope for this branch.

No screenshot artifact applies: this change has no rendered UI surface. No real webhook was sent from the test suite, and no secret appears in the diff or in any committed file.
