### PR TITLE
fix(bin): re-project a task whose projected workspace was lost

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,8 +84,11 @@ data/                personal fleet records; LOCAL, gitignored as a whole
   learnings.md       fleet-local operational facts and gotchas; LOCAL, gitignored; dated, evidence-backed, curated, and updated with inspect-then-update - rewrite and prune rather than append forever, the same contract as captain.md; created lazily, absent until this home has a learning to store
   projects.md        thin fleet navigation registry recording each project's standing delivery posture; firstmate-private, parsed for mechanical sync and seeding by fm-project-mode.sh (section 6)
   secondmates.md      local and remote secondmate routing table; firstmate-private, maintained by the secondmate seed helpers (section 6)
-  <id>/brief.md      per-task crewmate brief, or per-secondmate charter brief when kind=secondmate
-  <id>/report.md     scout task deliverable, written by the crewmate; survives teardown
+  tasks/<project>/<id>/   per-task durable folder, grouped by project registry name so a project's records can be listed, archived, or pruned as one body of work; a task with no project uses the literal `_none`; bin/fm-task-data-lib.sh owns this path and the read-only fallback to the legacy `data/<id>/` folders that predate it
+    brief.md         per-task crewmate brief, or per-secondmate charter brief when kind=secondmate
+    report.md        scout task deliverable, written by the crewmate; survives teardown
+    task.meta        project, title, kind, and creation date recorded at scaffold time, so grouping never depends on parsing brief prose
+    .protected       presence marks the folder as never pruned without an explicit override (bin/fm-task-data.sh)
 projects/            cloned repos; gitignored; read-only except under hard rule 1's concrete captain-approved project operation exception
 state/               runtime records and signals; gitignored
   <id>.status        appended by crewmates: "<state>: <note>" wake-event lines, not current-state truth
@@ -275,7 +278,7 @@ Before commissioning an investigation, consult existing reports and established 
 Classify the deliverable:
 
 - **Ship** is the default and produces a project change through the selected delivery mode; once implementation is authorized, dispatch a ship and keep any remaining bounded research inside it unless unresolved uncertainty could materially change whether or what to build.
-- **Scout** produces knowledge in `data/<id>/report.md`, never a PR, and is appropriate for investigation, diagnosis, planning, reproduction, or audit work when the captain explicitly requests a separate knowledge or design deliverable or unresolved uncertainty could materially change whether or what to build.
+- **Scout** produces knowledge in `report.md` inside the task's durable data folder, never a PR, and is appropriate for investigation, diagnosis, planning, reproduction, or audit work when the captain explicitly requests a separate knowledge or design deliverable or unresolved uncertainty could materially change whether or what to build.
 
 If established evidence already answers an informational question, relay it without a design-only scout; when implementation intent is unclear, answer and ask one concise implementation question when useful rather than dispatching speculative design work.
 Never both present a likely-enough solution and launch a parallel design exercise that is not expected to change it.

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Setup guides for tmux (the default) and every other supported backend (herdr, ze
      │
      ├─ ship: project mode ► PR/local merge ► teardown
      │
-     └─ scout: report at data/<id>/report.md ► decision inventory ► relay findings ► teardown
+     └─ scout: report in the task data folder ► decision inventory ► relay findings ► teardown
 ```
 
 You chat with the first mate.

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2420,11 +2420,20 @@ fm_backend_herdr_projection_reclaim_task() {  # <session> <journal> <task-id> <h
 # fm_backend_herdr_projection_recovery_allows_flat: inspect an existing
 # journal's exact token matches without adopting, reusing, renaming, closing,
 # or deleting anything.
-# Missing matches safely degrade to the normal flat workspace.
+# Missing matches safely degrade: nothing survives to reclaim, so the caller may
+# retire the orphaned journal and project afresh.
 # One or more matches allow flat fallback only when every pane is positively
 # dead or agent-free; a live or unknown pane refuses a duplicate launch.
+# Sets FM_BACKEND_HERDR_PROJECTION_RECOVERY_MATCHES to the surviving count on a
+# 0 return, and to the empty string on every refusal.
 fm_backend_herdr_projection_recovery_allows_flat() {  # <session> <journal> <task-id>
   local session=$1 journal=$2 id=$3 token list wsids count wsid panes pane_ids pane state
+  # How many token-bearing workspaces survive, for a caller that must tell an
+  # orphaned journal (0 - nothing to reclaim, so a fresh projection is the only
+  # way back to a nested space) from a reclaimable husk. Left unset on every
+  # refusal so a stale count can never be read as a verdict.
+  # shellcheck disable=SC2034  # bin/fm-spawn.sh consumes this out-parameter
+  FM_BACKEND_HERDR_PROJECTION_RECOVERY_MATCHES=""
   token=$(fm_backend_herdr_projection_journal_token "$journal" "$id") || {
     echo "error: malformed herdr presentation journal for $id; refusing duplicate launch" >&2
     return 1
@@ -2445,7 +2454,9 @@ fm_backend_herdr_projection_recovery_allows_flat() {  # <session> <journal> <tas
     '.result.workspaces[]? | select((.label | type) == "string" and (.label | endswith($suffix))) | .workspace_id' 2>/dev/null)
   count=$(printf '%s\n' "$wsids" | awk 'NF { n += 1 } END { print n + 0 }')
   if [ "$count" -eq 0 ]; then
-    echo "warning: no exact herdr presentation token match for $id; leaving any stale space untouched and spawning flat" >&2
+    echo "warning: no exact herdr presentation token match for $id; its projected space is gone and the journal is orphaned" >&2
+    # shellcheck disable=SC2034  # bin/fm-spawn.sh consumes this out-parameter
+    FM_BACKEND_HERDR_PROJECTION_RECOVERY_MATCHES=0
     return 0
   fi
   if [ "$count" -gt 1 ]; then
@@ -2479,6 +2490,8 @@ EOF
 $wsids
 EOF
   echo "warning: quarantined herdr presentation for $id is dead or agent-free; exact bound reclaim may proceed, otherwise spawning flat" >&2
+  # shellcheck disable=SC2034  # bin/fm-spawn.sh consumes this out-parameter
+  FM_BACKEND_HERDR_PROJECTION_RECOVERY_MATCHES=$count
   return 0
 }
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -54,6 +54,9 @@
 # it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers
 # over copied detail) and has the crewmate add the fm-ensure-agents-md.sh
 # self-governance section when a touched project AGENTS.md lacks it.
+# Every ship mode also carries a durable-report and saved-evidence requirement in
+# its definition of done, and rule 2 permits writes to the task's own data
+# directory so both survive teardown of the disposable worktree.
 # Refuses to overwrite an existing brief.
 set -eu
 
@@ -429,7 +432,7 @@ If the top-level path is the primary checkout or not the worktree you were launc
 
 # Rules
 $RULE1
-2. Stay inside this worktree; modify nothing outside it.
+2. Stay inside this worktree; the only files you may write outside it are the status file in rule 4 and anything under your task data directory \`$DATA/$ID/\` (the report and saved evidence below).
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
@@ -461,5 +464,16 @@ If you touch a project \`AGENTS.md\` that lacks \`## Maintaining this file\`, ad
 Keep it proportionate: skip \`AGENTS.md\` edits for trivial tasks that produced no durable project knowledge.
 
 $DOD
+
+## Durable report
+Write \`$DATA/$ID/report.md\` if this task uncovered a **transferable cause** - something that would bite a future task on this repo or another.
+Worth a report: a build or dependency-resolution trap, a branch or merge hazard, a failure mode that produces no error, or a test or assertion pattern that was wrong for a reason others will repeat.
+The report is the only artifact that outlives the PR and the worktree; the PR body is not a substitute, because working notes are deleted at cleanup.
+Task size is not the test: a one-file fix with a transferable cause gets a report, and a large task with none does not need one.
+The report must stand alone: what was done, what was found, the evidence, and what a future worker should do differently.
+
+## Saved evidence
+Write any screenshot or recording you take to support a claim in the PR body into \`$DATA/$ID/\`, naming each file for what it shows.
+A scratch or temp path is deleted at cleanup, so evidence left there stops existing when the task closes.
 EOF
 echo "scaffolded: $BRIEF (ship, mode=$MODE; replace {TASK})"

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -1,16 +1,20 @@
 #!/usr/bin/env bash
 # Scaffold a crewmate brief or persistent secondmate charter at
-# data/<task-id>/brief.md under the active firstmate home.
+# data/tasks/<project>/<task-id>/brief.md under the active firstmate home
+# (bin/fm-task-data-lib.sh owns that path and its legacy data/<task-id>/
+# fallback), and write the task.meta grouping marker beside it.
+# --title <t> records a human title in that marker; it defaults to the task id
+#   and never appears in the path, so a reworded title never moves a folder.
 # For ordinary tasks, the standard Setup/Rules/Definition-of-done contract is
 # filled in. Firstmate then replaces the {TASK} placeholder with the task
 # description, acceptance criteria, and context, and may adjust other sections
 # when the task genuinely deviates (e.g. working an existing external PR instead
 # of shipping a new one).
-# Usage: fm-brief.sh <task-id> <repo-name> --mode <no-mistakes|direct-PR|local-only> [--herdr-lab]
-#        fm-brief.sh <task-id> <repo-name> --scout [--herdr-lab]
+# Usage: fm-brief.sh <task-id> <repo-name> --mode <no-mistakes|direct-PR|local-only> [--title <t>] [--herdr-lab]
+#        fm-brief.sh <task-id> <repo-name> --scout [--title <t>] [--herdr-lab]
 #        fm-brief.sh <task-id> --secondmate {<project>...|--no-projects}
 #   --scout writes the scout contract instead: the deliverable is a report at
-#   data/<task-id>/report.md (no branch, no push, no PR) and the worktree is scratch.
+#   report.md in that directory (no branch, no push, no PR) and the worktree is scratch.
 #   --secondmate writes a persistent secondmate charter. The project list
 #   is cloned into the secondmate home, while the natural-language scope
 #   tells the main firstmate when to route work there; routine churn stays in its own home;
@@ -78,6 +82,8 @@ esac
 . "$SCRIPT_DIR/fm-marker-lib.sh"
 # shellcheck source=bin/fm-classify-lib.sh
 . "$SCRIPT_DIR/fm-classify-lib.sh"
+# shellcheck source=bin/fm-task-data-lib.sh
+. "$SCRIPT_DIR/fm-task-data-lib.sh"
 PAUSED_VERB=${FM_CLASSIFY_PAUSED_VERB:-$FM_CLASSIFY_PAUSED_VERB_DEFAULT}
 
 resolve_directory_input() {
@@ -109,6 +115,7 @@ HERDR_LAB=0
 NO_PROJECTS=0
 MODE=
 MODE_SET=0
+TITLE=
 POS=()
 want_value=
 for a in "$@"; do
@@ -118,6 +125,7 @@ for a in "$@"; do
     esac
     case "$want_value" in
       mode) MODE=$a; MODE_SET=1 ;;
+      title) TITLE=$a ;;
       *) echo "error: internal parser state for --$want_value" >&2; exit 1 ;;
     esac
     want_value=
@@ -130,6 +138,8 @@ for a in "$@"; do
     --no-projects) NO_PROJECTS=1 ;;
     --mode) want_value=mode ;;
     --mode=*) MODE=${a#--mode=}; MODE_SET=1 ;;
+    --title) want_value=title ;;
+    --title=*) TITLE=${a#--title=} ;;
     # yolo never reaches the worker: it is firstmate's merge authority, not a
     # brief input. Refuse it loudly so it is never silently dropped here and then
     # believed to have been recorded.
@@ -169,9 +179,19 @@ if [ "$NO_PROJECTS" -eq 1 ] && [ "$KIND" != secondmate ]; then
   exit 1
 fi
 
-BRIEF="$DATA/$ID/brief.md"
+# The task's durable data directory, project-grouped by bin/fm-task-data-lib.sh.
+# A secondmate charter has no single project, and a ship or scout brief names its
+# repo positionally.
+if [ "$KIND" = secondmate ]; then
+  TASK_PROJECT=
+else
+  TASK_PROJECT=${POS[1]:-}
+fi
+TASK_DIR=$(fm_task_data_dir "$DATA" "$ID" "$TASK_PROJECT") || exit 1
+BRIEF="$TASK_DIR/brief.md"
 [ -e "$BRIEF" ] && { echo "error: $BRIEF already exists" >&2; exit 1; }
-mkdir -p "$DATA/$ID"
+mkdir -p "$TASK_DIR"
+fm_task_data_write_marker "$TASK_DIR" "$TASK_PROJECT" "${TITLE:-$ID}" "$KIND" || exit 1
 
 shell_quote() {
   printf "'"
@@ -340,7 +360,7 @@ The report is the only thing that survives, so anything worth keeping must be in
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
 
 # Definition of done
-Write your findings to \`$DATA/$ID/report.md\`.
+Write your findings to \`$TASK_DIR/report.md\`.
 The report must stand alone: what you did, what you found, the evidence (commands run, output, file:line references), and what you recommend.
 If your deliverable is a visual artifact the captain will review and iterate on, you may host the Lavish review loop yourself (poll, revise, re-serve, staying alive) instead of handing it back to firstmate.
 Before reporting done, read and follow \`$FM_ROOT/.agents/skills/captain-hold-lifecycle/SKILL.md\` and pass its shared completion gate for the report and any visual review.
@@ -432,7 +452,7 @@ If the top-level path is the primary checkout or not the worktree you were launc
 
 # Rules
 $RULE1
-2. Stay inside this worktree; the only files you may write outside it are the status file in rule 4 and anything under your task data directory \`$DATA/$ID/\` (the report and saved evidence below).
+2. Stay inside this worktree; the only files you may write outside it are the status file in rule 4 and anything under your task data directory \`$TASK_DIR/\` (the report and saved evidence below).
 3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
@@ -466,14 +486,14 @@ Keep it proportionate: skip \`AGENTS.md\` edits for trivial tasks that produced 
 $DOD
 
 ## Durable report
-Write \`$DATA/$ID/report.md\` if this task uncovered a **transferable cause** - something that would bite a future task on this repo or another.
+Write \`$TASK_DIR/report.md\` if this task uncovered a **transferable cause** - something that would bite a future task on this repo or another.
 Worth a report: a build or dependency-resolution trap, a branch or merge hazard, a failure mode that produces no error, or a test or assertion pattern that was wrong for a reason others will repeat.
 The report is the only artifact that outlives the PR and the worktree; the PR body is not a substitute, because working notes are deleted at cleanup.
 Task size is not the test: a one-file fix with a transferable cause gets a report, and a large task with none does not need one.
 The report must stand alone: what was done, what was found, the evidence, and what a future worker should do differently.
 
 ## Saved evidence
-Write any screenshot or recording you take to support a claim in the PR body into \`$DATA/$ID/\`, naming each file for what it shows.
+Write any screenshot or recording you take to support a claim in the PR body into \`$TASK_DIR/\`, naming each file for what it shows.
 A scratch or temp path is deleted at cleanup, so evidence left there stops existing when the task closes.
 EOF
 echo "scaffolded: $BRIEF (ship, mode=$MODE; replace {TASK})"

--- a/bin/fm-captain-hold.sh
+++ b/bin/fm-captain-hold.sh
@@ -134,6 +134,9 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 # shellcheck source=bin/fm-classify-lib.sh
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/fm-classify-lib.sh"
+# shellcheck source=bin/fm-task-data-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-task-data-lib.sh"
 # shellcheck source=bin/fm-tasks-axi-lib.sh
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
@@ -259,7 +262,7 @@ show_field_value() {  # <show-output> <field>
 
 origin_exists_here() {  # <origin-id>
   [ -f "$STATE/$1.meta" ] && return 0
-  [ -f "$DATA/$1/report.md" ] && return 0
+  [ -f "$(fm_task_data_find "$DATA" "$1" || true)/report.md" ] && return 0
   task_show "$1" >/dev/null 2>&1
 }
 

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -130,6 +130,8 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 . "$SCRIPT_DIR/fm-busy-lib.sh"
 # shellcheck source=bin/fm-control-lib.sh
 . "$SCRIPT_DIR/fm-control-lib.sh"
+# shellcheck source=bin/fm-task-data-lib.sh
+. "$SCRIPT_DIR/fm-task-data-lib.sh"
 # shellcheck source=bin/fm-pr-lib.sh
 . "$SCRIPT_DIR/fm-pr-lib.sh"
 # shellcheck source=bin/fm-wake-lib.sh
@@ -774,7 +776,7 @@ do_relaunch() {
 
   case "$KIND" in
     ship|scout)
-      RELAUNCH_BRIEF="$DATA/$ID/brief.md"
+      RELAUNCH_BRIEF="$(fm_task_data_dir "$DATA" "$ID")/brief.md"
       [ -f "$RELAUNCH_BRIEF" ] \
         || die "task $ID has no instructions at $RELAUNCH_BRIEF; refusing to relaunch a worker with nothing to work from"
       [ "$NOTE_SET" = 1 ] && [ -n "$NOTE" ] \

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -42,7 +42,8 @@
 #     endpoint.exists is the cheap backend endpoint-presence read.
 #     endpoint.agent_alive is populated for secondmates only, where it is useful
 #     return-channel supervision data; other tasks use "not_checked".
-#   scout_reports[]: present data/<id>/report.md pointers.
+#   scout_reports[]: present task-data report.md pointers, in both the
+#     project-grouped and legacy layouts (bin/fm-task-data-lib.sh).
 #   main_inventory: {valid,reason,orphan_in_flight[],unstructured_current_count} -
 #     main-home current-inventory checks shared with secondmate_home_summary_json
 #     (orphan structured in-flight ids with no state/<id>.meta, and unstructured
@@ -146,6 +147,9 @@ validate_positive_bound FM_SNAPSHOT_REGISTRY_TIMEOUT "$FM_SNAPSHOT_REGISTRY_TIME
 # shellcheck source=bin/fm-backend.sh
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/fm-backend.sh"
+# shellcheck source=bin/fm-task-data-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-task-data-lib.sh"
 # shellcheck source=bin/fm-classify-lib.sh
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/fm-classify-lib.sh"
@@ -455,7 +459,7 @@ task_json_lines() {
       target=$(fm_backend_target_of_meta "$meta")
     fi
     status_log="$STATE/$id.status"
-    report_path="$DATA/$id/report.md"
+    report_path="$(fm_task_data_dir "$DATA" "$id")/report.md"
     pr=$(meta_value "$meta" pr)
     pr_source=meta
     if [ -z "$pr" ]; then
@@ -1364,7 +1368,15 @@ scout_report_lines() {
     jq -n '[]'
     return 0
   fi
-  LC_ALL=C find "$DATA" -mindepth 2 -maxdepth 2 -type f -name report.md -print \
+  # Both layouts: the legacy <id>/report.md and the project-grouped
+  # tasks/<project>/<id>/report.md that replaced it (bin/fm-task-data-lib.sh).
+  {
+    LC_ALL=C find "$DATA" -mindepth 2 -maxdepth 2 -type f -name report.md -print
+    if [ -d "$DATA/$FM_TASK_DATA_SUBDIR" ]; then
+      LC_ALL=C find "$DATA/$FM_TASK_DATA_SUBDIR" -mindepth 3 -maxdepth 3 \
+        -type f -name report.md -print
+    fi
+  } \
     | sort \
     | while IFS= read -r report; do
       id=$(basename "$(dirname "$report")")

--- a/bin/fm-home-seed.sh
+++ b/bin/fm-home-seed.sh
@@ -47,6 +47,8 @@ SUB_HOME_PARENT_MARKER=".fm-secondmate-parent"
 . "$SCRIPT_DIR/fm-secondmate-parent-lib.sh"
 # shellcheck source=bin/fm-secondmate-charter-lib.sh
 . "$SCRIPT_DIR/fm-secondmate-charter-lib.sh"
+# shellcheck source=bin/fm-task-data-lib.sh
+. "$SCRIPT_DIR/fm-task-data-lib.sh"
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
 
@@ -845,7 +847,7 @@ seed_home() {
   SEED_CREATED_PROJECTS_FILE="$SEED_BACKUP_DIR/created-projects"
   : > "$SEED_CREATED_PROJECTS_FILE"
   SEED_PARENT_REG_EXISTED=0
-  SEED_PARENT_BRIEF="$DATA/$id/brief.md"
+  SEED_PARENT_BRIEF="$(fm_task_data_dir "$DATA" "$id")/brief.md"
   SEED_PARENT_BRIEF_CREATED=0
   SEED_PARENT_BRIEF_DIR_CREATED=0
   SEED_SUB_REG_EXISTED=0
@@ -905,7 +907,7 @@ seed_home() {
       echo "error: no filled secondmate charter brief at $SEED_PARENT_BRIEF; set FM_SECONDMATE_CHARTER or scaffold one and replace {TASK}" >&2
       return 1
     }
-    [ -d "$DATA/$id" ] || SEED_PARENT_BRIEF_DIR_CREATED=1
+    [ -d "$(dirname -- "$SEED_PARENT_BRIEF")" ] || SEED_PARENT_BRIEF_DIR_CREATED=1
     if [ "$no_projects" -eq 1 ]; then
       "$FM_ROOT/bin/fm-brief.sh" "$id" --secondmate --no-projects
     else

--- a/bin/fm-remote-home-seed.sh
+++ b/bin/fm-remote-home-seed.sh
@@ -37,6 +37,8 @@ MAX_MANIFEST_BYTES=1048576
 . "$SCRIPT_DIR/fm-secondmate-registry-lib.sh"
 # shellcheck source=bin/fm-secondmate-charter-lib.sh
 . "$SCRIPT_DIR/fm-secondmate-charter-lib.sh"
+# shellcheck source=bin/fm-task-data-lib.sh
+. "$SCRIPT_DIR/fm-task-data-lib.sh"
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
 # shellcheck source=bin/fm-remote-readiness-lib.sh
@@ -123,7 +125,7 @@ if [ -e "$REG" ] || [ -L "$REG" ]; then
 fi
 
 mkdir -p "$DATA"
-BRIEF="$DATA/$ID/brief.md"
+BRIEF="$(fm_task_data_dir "$DATA" "$ID")/brief.md"
 BRIEF_CREATED=0
 if [ ! -f "$BRIEF" ]; then
   [ -n "${FM_SECONDMATE_CHARTER:-}" ] || die "no filled charter at $BRIEF; set FM_SECONDMATE_CHARTER or scaffold one first"

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1642,7 +1642,10 @@ if [ "$KIND" = secondmate ]; then
 else
   PROJ_ABS="$(cd "$(resolve_project_dir_arg "$PROJ")" && pwd)"
   WT=""
-  BRIEF="$(fm_task_data_dir "$DATA" "$ID")/brief.md"
+  # The registry name, from the resolved clone rather than the caller's argument,
+  # which may be a path. Spawn never writes here; naming the project only makes a
+  # missing-brief error point at the directory the brief would actually live in.
+  BRIEF="$(fm_task_data_dir "$DATA" "$ID" "$(basename -- "$PROJ_ABS")")/brief.md"
 fi
 [ -f "$BRIEF" ] || { echo "error: no brief at $BRIEF" >&2; exit 1; }
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -149,7 +149,8 @@
 #   multi-task shell loop (the tool shell is zsh, which does not word-split unquoted
 #   $vars and silently breaks ad-hoc `for ... in $pairs` loops).
 #   Launch templates live in launch_template() below; placeholders replaced before launch:
-#     __BRIEF__    absolute path to data/<task-id>/brief.md
+#     __BRIEF__    absolute path to the task brief in its durable data
+#                  directory (bin/fm-task-data-lib.sh)
 #     __PIBIN__    quoted concrete Pi-family executable path resolved from PATH
 #     __PITUIMODE__ optional --tui-mode regular when that executable advertises it
 #     __TURNEND__  absolute path to state/<task-id>.turn-ended (for harnesses whose
@@ -244,6 +245,8 @@ SUB_HOME_MARKER=".fm-secondmate-home"
 . "$SCRIPT_DIR/fm-secondmate-nudge-lib.sh"
 # shellcheck source=bin/fm-config-inherit-lib.sh
 . "$SCRIPT_DIR/fm-config-inherit-lib.sh"
+# shellcheck source=bin/fm-task-data-lib.sh
+. "$SCRIPT_DIR/fm-task-data-lib.sh"
 # shellcheck source=bin/fm-backend.sh
 . "$SCRIPT_DIR/fm-backend.sh"
 # shellcheck source=bin/fm-control-lib.sh
@@ -1634,12 +1637,12 @@ if [ "$KIND" = secondmate ]; then
   if [ -f "$PROJ_ABS/data/charter.md" ]; then
     BRIEF="$PROJ_ABS/data/charter.md"
   else
-    BRIEF="$DATA/$ID/brief.md"
+    BRIEF="$(fm_task_data_dir "$DATA" "$ID")/brief.md"
   fi
 else
   PROJ_ABS="$(cd "$(resolve_project_dir_arg "$PROJ")" && pwd)"
   WT=""
-  BRIEF="$DATA/$ID/brief.md"
+  BRIEF="$(fm_task_data_dir "$DATA" "$ID")/brief.md"
 fi
 [ -f "$BRIEF" ] || { echo "error: no brief at $BRIEF" >&2; exit 1; }
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -77,6 +77,10 @@
 #   upgrades its attempt journal with exact home, session, workspace, tab, pane,
 #   parent, and label bindings. On a same-identity restart, that complete binding
 #   plus authoritative metadata may replace one exact agent-free husk in place.
+#   When no workspace bearing that journal's token survives at all, the orphaned
+#   journal is retired and the task projects a new nested space exactly as a
+#   first spawn does, so a projected workspace lost outside exact-pane teardown
+#   does not strand the task in the flat layout for good.
 #   The journal, visible token, and labels alone are never endpoint or ownership
 #   authority, and every ambiguous recovery stays on the flat fallback after
 #   duplicate-agent risk is independently absent. Treehouse allocation and task
@@ -1904,6 +1908,7 @@ case "$BACKEND" in
     fi
     HERDR_PRESENTATION_JOURNAL=$(fm_backend_herdr_projection_journal_path "$STATE" "$ID")
     HERDR_PROJECTED=0
+    HERDR_PROJECT_FRESH=0
     if [ "$KIND" != secondmate ] && fm_backend_herdr_presentation_enabled "$CONFIG" "$STATE"; then
       HERDR_SES=$(fm_backend_herdr_session)
       HERDR_PARENT_LABEL=$(FM_HOME="$HERDR_LABEL_HOME" fm_backend_herdr_workspace_label)
@@ -1921,7 +1926,18 @@ case "$BACKEND" in
         fi
         fm_backend_herdr_projection_recovery_allows_flat \
           "$HERDR_SES" "$HERDR_PRESENTATION_JOURNAL" "$ID" || exit 1
-        if [ "${HERDR_RECOVERY_BACKEND:-}" = herdr ]; then
+        if [ "${FM_BACKEND_HERDR_PROJECTION_RECOVERY_MATCHES:-}" = 0 ]; then
+          # Nothing bearing this journal's token survives, so there is no husk to
+          # reclaim and no ambiguity to preserve: the two guards above already
+          # proved the recorded endpoint and every token match agent-free. Retire
+          # the orphaned journal and take the ordinary fresh-projection path, or
+          # this task spends the rest of its life as a flat tab inside whichever
+          # workspace its home owns - the first spawn's nesting is unrecoverable
+          # once its projected workspace is gone.
+          rm -f "$HERDR_PRESENTATION_JOURNAL"
+          HERDR_PROJECT_FRESH=1
+          spawn_herdr_presentation_order_lock_release
+        elif [ "${HERDR_RECOVERY_BACKEND:-}" = herdr ]; then
           set +e
           FM_HOME="$HERDR_LABEL_HOME" fm_backend_herdr_projection_reclaim_task \
             "$HERDR_SES" "$HERDR_PRESENTATION_JOURNAL" "$ID" "$HERDR_LABEL_HOME" \
@@ -1950,6 +1966,9 @@ case "$BACKEND" in
           spawn_herdr_presentation_order_lock_release
         fi
       elif [ ! -e "$STATE/$ID.meta" ] && [ ! -L "$STATE/$ID.meta" ]; then
+        HERDR_PROJECT_FRESH=1
+      fi
+      if [ "$HERDR_PROJECT_FRESH" = 1 ]; then
         # Session lock path resolution and exact parent binding both need a
         # live named-session socket before journal publication.
         if ! fm_backend_herdr_server_ensure "$HERDR_SES"; then

--- a/bin/fm-subagent-pretool-check.sh
+++ b/bin/fm-subagent-pretool-check.sh
@@ -3,7 +3,7 @@
 #
 # A firstmate primary that delegates through a harness's own delegation,
 # scheduling, or background-work tool creates work with no `state/<id>.meta` and
-# no `data/<id>/brief.md`. Only `bin/fm-spawn.sh` writes that metadata, and
+# no task-data `brief.md`. Only `bin/fm-spawn.sh` writes that metadata, and
 # untracked project work contributes nothing to the in-flight branch of
 # bin/fm-supervision-lib.sh or bin/fm-turnend-guard.sh. So such work is not
 # merely unsupervised: absent an independent X-mode need, it makes the whole

--- a/bin/fm-task-data-lib.sh
+++ b/bin/fm-task-data-lib.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# fm-task-data-lib.sh - single owner of a task's durable data directory path.
+#
+# Current layout, project-grouped so a whole project's records can be listed,
+# archived, or pruned without parsing prose out of every brief:
+#
+#   <data>/tasks/<project>/<task-id>/
+#
+# <project> is the project's registry name as it appears in data/projects.md
+# (front-client, vega-ui, ...), never a path. A task with no project - a
+# firstmate-repo task or a secondmate charter - uses the literal
+# FM_TASK_DATA_NO_PROJECT ("_none"). Registry names cannot begin with an
+# underscore, so that literal can never collide with a real project.
+#
+# Legacy layout, still fully readable and never migrated by these helpers:
+#
+#   <data>/<task-id>/
+#
+# Read resolution is new-first, then legacy. Writes use the new layout EXCEPT
+# for a task that already has a legacy directory: that task keeps using it, so
+# one task's record is never split across two locations.
+#
+# The marker file FM_TASK_DATA_MARKER ("task.meta") records the project, title,
+# kind, and creation date at scaffold time, in the same `key=value` shape as
+# state/<id>.meta, so grouping never depends on parsing brief.md prose. A folder
+# containing FM_TASK_DATA_PROTECTED (".protected") is never removed by
+# bin/fm-task-data.sh without its explicit override.
+#
+# No side effects on source. set -u / set -e safe.
+
+FM_TASK_DATA_SUBDIR=tasks
+FM_TASK_DATA_NO_PROJECT=_none
+FM_TASK_DATA_MARKER=task.meta
+FM_TASK_DATA_PROTECTED=.protected
+
+# Validate a task id used as one path component. Refuses anything that could
+# escape the data root or shadow the tasks/ container itself.
+fm_task_data_valid_id() {  # <task-id>
+  local id=$1
+  case "$id" in
+    ''|.|..|"$FM_TASK_DATA_SUBDIR") return 1 ;;
+    */*|*$'\n'*) return 1 ;;
+    -*) return 1 ;;
+  esac
+  return 0
+}
+
+# Normalize a project name into its path component. An empty project resolves to
+# the documented no-project literal. Anything that is not a single safe path
+# component is refused rather than silently rewritten, so a malformed registry
+# name cannot quietly scatter task data.
+fm_task_data_project_slug() {  # <project>
+  local project=${1:-}
+  if [ -z "$project" ]; then
+    printf '%s\n' "$FM_TASK_DATA_NO_PROJECT"
+    return 0
+  fi
+  case "$project" in
+    .|..) ;;
+    */*|*$'\n'*|-*) ;;
+    *) printf '%s\n' "$project"; return 0 ;;
+  esac
+  echo "error: '$project' is not a usable project name for a task data directory" >&2
+  return 1
+}
+
+# Print the legacy directory for a task. Existence is not checked.
+fm_task_data_legacy_dir() {  # <data-root> <task-id>
+  printf '%s\n' "$1/$2"
+}
+
+# Print the existing durable data directory for a task, or fail with no output.
+# New layout wins over legacy so a migrated task is never read from both.
+fm_task_data_find() {  # <data-root> <task-id>
+  local data=$1 id=$2 candidate
+  fm_task_data_valid_id "$id" || return 1
+  for candidate in "$data/$FM_TASK_DATA_SUBDIR"/*/"$id"; do
+    [ -d "$candidate" ] || continue
+    printf '%s\n' "$candidate"
+    return 0
+  done
+  if [ -d "$data/$id" ]; then
+    printf '%s\n' "$data/$id"
+    return 0
+  fi
+  return 1
+}
+
+# Print the durable data directory a caller should use for a task: the existing
+# one when the task already has records anywhere, otherwise the new-layout path
+# under the given project. Creates nothing.
+fm_task_data_dir() {  # <data-root> <task-id> [project]
+  local data=$1 id=$2 project=${3:-} slug found
+  fm_task_data_valid_id "$id" || {
+    echo "error: '$id' is not a usable task id for a data directory" >&2
+    return 1
+  }
+  if found=$(fm_task_data_find "$data" "$id"); then
+    printf '%s\n' "$found"
+    return 0
+  fi
+  slug=$(fm_task_data_project_slug "$project") || return 1
+  printf '%s\n' "$data/$FM_TASK_DATA_SUBDIR/$slug/$id"
+}
+
+# fm_task_data_dir, then create the directory.
+fm_task_data_ensure_dir() {  # <data-root> <task-id> [project]
+  local dir
+  dir=$(fm_task_data_dir "$@") || return 1
+  mkdir -p "$dir" || return 1
+  printf '%s\n' "$dir"
+}
+
+# Write the grouping marker. Idempotent: rewritten in place on every scaffold so
+# a re-scaffold cannot leave a stale project or title behind.
+fm_task_data_write_marker() {  # <dir> <project> <title> <kind>
+  local dir=$1 project=${2:-} title=${3:-} kind=${4:-} slug tmp
+  slug=$(fm_task_data_project_slug "$project") || return 1
+  # Newlines would break the one-key-per-line shape the reader relies on.
+  title=$(printf '%s' "$title" | tr '\n\r' '  ')
+  tmp="$dir/$FM_TASK_DATA_MARKER.tmp.$$"
+  {
+    printf 'project=%s\n' "$slug"
+    printf 'title=%s\n' "$title"
+    printf 'kind=%s\n' "$kind"
+    printf 'created=%s\n' "$(date -u +%Y-%m-%d)"
+  } > "$tmp" || return 1
+  mv -f -- "$tmp" "$dir/$FM_TASK_DATA_MARKER"
+}
+
+# Read one marker key, printing nothing when the marker or key is absent.
+fm_task_data_marker_value() {  # <dir> <key>
+  local marker="$1/$FM_TASK_DATA_MARKER" key=$2
+  [ -f "$marker" ] || return 0
+  awk -v k="$key" '
+    index($0, k "=") == 1 { print substr($0, length(k) + 2); exit }
+  ' "$marker"
+}
+
+# The project a directory belongs to: its marker first, then its position in the
+# new layout, and the no-project literal for a legacy folder that records
+# neither. A folder whose marker is unreadable is still identifiable this way.
+fm_task_data_project_of_dir() {  # <data-root> <dir>
+  local data=$1 dir=$2 project parent
+  project=$(fm_task_data_marker_value "$dir" project)
+  if [ -n "$project" ]; then
+    printf '%s\n' "$project"
+    return 0
+  fi
+  parent=$(dirname -- "$dir")
+  if [ "$(dirname -- "$parent")" = "$data/$FM_TASK_DATA_SUBDIR" ]; then
+    printf '%s\n' "$(basename -- "$parent")"
+    return 0
+  fi
+  printf '%s\n' "$FM_TASK_DATA_NO_PROJECT"
+}

--- a/bin/fm-task-data-lib.sh
+++ b/bin/fm-task-data-lib.sh
@@ -31,6 +31,7 @@
 FM_TASK_DATA_SUBDIR=tasks
 FM_TASK_DATA_NO_PROJECT=_none
 FM_TASK_DATA_MARKER=task.meta
+# shellcheck disable=SC2034 # Read by bin/fm-task-data.sh, not by this library.
 FM_TASK_DATA_PROTECTED=.protected
 
 # Validate a task id used as one path component. Refuses anything that could
@@ -62,11 +63,6 @@ fm_task_data_project_slug() {  # <project>
   esac
   echo "error: '$project' is not a usable project name for a task data directory" >&2
   return 1
-}
-
-# Print the legacy directory for a task. Existence is not checked.
-fm_task_data_legacy_dir() {  # <data-root> <task-id>
-  printf '%s\n' "$1/$2"
 }
 
 # Print the existing durable data directory for a task, or fail with no output.

--- a/bin/fm-task-data.sh
+++ b/bin/fm-task-data.sh
@@ -17,7 +17,8 @@
 # Filters (repeatable, and they compose - a folder must match every filter kind
 # that was given, and any one value within a kind):
 #   --project <name>      registry name, or _none for the no-project literal
-#   --task <task-id>      exact task id
+#   --task <pattern>      task id, or a shell glob over task ids such as
+#                         'cvui-*'; quote it so the shell does not expand it
 #   --older-than <days>   folder last modified more than <days> days ago
 #
 # prune options:
@@ -150,6 +151,8 @@ esac
 # the legacy top level is one only if it holds task content, because data/ also
 # holds firstmate's own directories (handoff/ and friends) and this is the one
 # tool that deletes things. An unrecognized folder is skipped, never removed.
+# The protection marker counts as content, so marking an otherwise unrecognized
+# folder is what makes it both visible here and permanently safe.
 is_legacy_task_dir() {  # <dir>
   local dir=$1 name
   for name in brief.md report.md "$FM_TASK_DATA_MARKER" "$FM_TASK_DATA_PROTECTED"; do
@@ -159,15 +162,21 @@ is_legacy_task_dir() {  # <dir>
 }
 
 # Every task data directory in both layouts, one per line.
-all_task_dirs() {
-  local dir
+#
+# "all" includes legacy folders that hold no recognized task content. Only the
+# protect path uses it: marking is not destructive, and a body of work can
+# include folders that are neither a brief nor a report - the migration
+# retrospective's own index is one - which must still be markable, and which
+# become visible and permanently safe once marked.
+all_task_dirs() {  # [all]
+  local dir mode=${1:-recognized}
   [ -d "$DATA" ] || return 0
   {
     for dir in "$DATA"/*/; do
       [ -d "$dir" ] || continue
       dir=${dir%/}
       [ "$(basename -- "$dir")" != "$FM_TASK_DATA_SUBDIR" ] || continue
-      is_legacy_task_dir "$dir" || continue
+      [ "$mode" = all ] || is_legacy_task_dir "$dir" || continue
       printf '%s\n' "$dir"
     done
     for dir in "$DATA/$FM_TASK_DATA_SUBDIR"/*/*/; do
@@ -186,13 +195,30 @@ list_contains() {  # <needle> <values...>
   return 1
 }
 
+# --task matches by shell glob, because a body of work is usually named by a
+# shared id prefix rather than by its project: the migration reports on the
+# captain's home are cvui-* inside front-client, which also holds unrelated
+# tasks, and some legacy folders record no usable project at all. An exact id is
+# its own glob, so plain ids keep working.
+list_matches_pattern() {  # <needle> <patterns...>
+  local needle=$1 pattern
+  shift
+  for pattern in "$@"; do
+    # shellcheck disable=SC2254 # The pattern is a deliberate caller-supplied glob.
+    case "$needle" in
+      $pattern) return 0 ;;
+    esac
+  done
+  return 1
+}
+
 matches_filters() {  # <dir> <task-id> <project>
   local dir=$1 id=$2 project=$3
   if [ "${#FILTER_PROJECTS[@]}" -gt 0 ]; then
     list_contains "$project" "${FILTER_PROJECTS[@]}" || return 1
   fi
   if [ "${#FILTER_TASKS[@]}" -gt 0 ]; then
-    list_contains "$id" "${FILTER_TASKS[@]}" || return 1
+    list_matches_pattern "$id" "${FILTER_TASKS[@]}" || return 1
   fi
   if [ -n "$OLDER_THAN" ]; then
     [ -n "$(find "$dir" -maxdepth 0 -mtime "+$OLDER_THAN" -print 2>/dev/null)" ] || return 1
@@ -229,7 +255,7 @@ if [ "$COMMAND" = protect ] || [ "$COMMAND" = unprotect ]; then
         "$(fm_task_data_project_of_dir "$DATA" "$dir")" || continue
       set_protection "$dir"
       marked=$((marked + 1))
-    done < <(all_task_dirs)
+    done < <(all_task_dirs all)
   fi
   printf '%s folder(s) %sed.\n' "$marked" "$COMMAND"
   exit 0

--- a/bin/fm-task-data.sh
+++ b/bin/fm-task-data.sh
@@ -1,0 +1,368 @@
+#!/usr/bin/env bash
+# fm-task-data.sh - list, archive, or prune the durable task data directories
+# under a firstmate home's data/ (bin/fm-task-data-lib.sh owns their layout).
+#
+# Nothing else in firstmate ever deletes these folders, which is deliberate: the
+# brief, the report, and the saved evidence are what outlive a task. This is the
+# one tool that removes them, so every destructive path prints its plan first and
+# does nothing without --yes.
+#
+# Usage:
+#   fm-task-data.sh list [filters]
+#   fm-task-data.sh prune [filters] [--images-only] [--archive <dir>] [--yes]
+#                         [--include-protected]
+#   fm-task-data.sh protect <task-id>...
+#   fm-task-data.sh unprotect <task-id>...
+#
+# Filters (repeatable, and they compose - a folder must match every filter kind
+# that was given, and any one value within a kind):
+#   --project <name>      registry name, or _none for the no-project literal
+#   --task <task-id>      exact task id
+#   --older-than <days>   folder last modified more than <days> days ago
+#
+# prune options:
+#   --images-only         remove only image files (png, jpg, jpeg, gif, webp,
+#                         svg, bmp, tiff, avif, heic) and leave the folder and
+#                         every other file, so the words survive and the bulk
+#                         does not
+#   --archive <dir>       move instead of delete, into <dir>/<project>/<task-id>/
+#                         preserving the relative path; reversible
+#   --yes                 actually do it; without this, prune is a dry run that
+#                         prints the plan and changes nothing
+#   --include-protected   also act on protected folders (see below)
+#
+# Always skipped, and named in the output when skipped:
+#   - a task still in flight, identified by a live state/<task-id>.meta record;
+#     work under way owns its folder
+#   - a protected folder, identified by a `.protected` marker file inside it.
+#     Use `protect` to add one and `unprotect` to remove it. A marker rather than
+#     a list of ids because the protected body of work grows, and a folder
+#     carries its own protection wherever it is moved or archived.
+#
+# Safe to run twice and safe to interrupt: every removal and move is per-file
+# and idempotent, an already-removed file is not an error, and an interrupted
+# run leaves a partially pruned folder that the next identical run finishes.
+#
+# Exit status is 0 on success, 1 on a usage or runtime error.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+usage() {
+  awk '
+    NR == 1 { next }
+    /^#/ { sub(/^# ?/, ""); print; next }
+    { exit }
+  ' "$0"
+}
+
+# shellcheck source=bin/fm-task-data-lib.sh
+. "$SCRIPT_DIR/fm-task-data-lib.sh"
+
+die() {
+  printf 'fm-task-data: %s\n' "$*" >&2
+  exit 1
+}
+
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-$FM_ROOT}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+
+IMAGE_EXTENSIONS='png jpg jpeg gif webp svg bmp tif tiff avif heic'
+
+COMMAND=${1:-}
+case "$COMMAND" in
+  -h|--help|'') usage; exit 0 ;;
+  list|prune|protect|unprotect) shift ;;
+  *) die "unknown command '$COMMAND' (expected list, prune, protect, or unprotect)" ;;
+esac
+
+FILTER_PROJECTS=()
+FILTER_TASKS=()
+OLDER_THAN=
+IS_IMAGES_ONLY=0
+ARCHIVE_DIR=
+IS_CONFIRMED=0
+SHOULD_INCLUDE_PROTECTED=0
+POSITIONAL=()
+
+want_value=
+for arg in "$@"; do
+  if [ -n "$want_value" ]; then
+    case "$arg" in
+      --*) die "--$want_value requires a value" ;;
+    esac
+    case "$want_value" in
+      project) FILTER_PROJECTS+=("$arg") ;;
+      task) FILTER_TASKS+=("$arg") ;;
+      older-than) OLDER_THAN=$arg ;;
+      archive) ARCHIVE_DIR=$arg ;;
+    esac
+    want_value=
+    continue
+  fi
+  case "$arg" in
+    --project) want_value=project ;;
+    --project=*) FILTER_PROJECTS+=("${arg#--project=}") ;;
+    --task) want_value=task ;;
+    --task=*) FILTER_TASKS+=("${arg#--task=}") ;;
+    --older-than) want_value=older-than ;;
+    --older-than=*) OLDER_THAN=${arg#--older-than=} ;;
+    --archive) want_value=archive ;;
+    --archive=*) ARCHIVE_DIR=${arg#--archive=} ;;
+    --images-only) IS_IMAGES_ONLY=1 ;;
+    --yes) IS_CONFIRMED=1 ;;
+    --include-protected) SHOULD_INCLUDE_PROTECTED=1 ;;
+    -h|--help) usage; exit 0 ;;
+    --*) die "unknown option '$arg'" ;;
+    *) POSITIONAL+=("$arg") ;;
+  esac
+done
+[ -z "$want_value" ] || die "--$want_value requires a value"
+
+if [ -n "$OLDER_THAN" ]; then
+  case "$OLDER_THAN" in
+    ''|*[!0-9]*) die "--older-than takes a whole number of days (got '$OLDER_THAN')" ;;
+  esac
+fi
+
+case "$COMMAND" in
+  protect|unprotect)
+    [ "${#POSITIONAL[@]}" -gt 0 ] || die "$COMMAND requires at least one task id"
+    ;;
+  *)
+    [ "${#POSITIONAL[@]}" -eq 0 ] || die "unexpected argument '${POSITIONAL[0]}'"
+    ;;
+esac
+
+# --- protect / unprotect ----------------------------------------------------
+
+if [ "$COMMAND" = protect ] || [ "$COMMAND" = unprotect ]; then
+  for id in "${POSITIONAL[@]}"; do
+    dir=$(fm_task_data_find "$DATA" "$id") \
+      || die "no task data directory for '$id' under $DATA"
+    if [ "$COMMAND" = protect ]; then
+      : > "$dir/$FM_TASK_DATA_PROTECTED"
+      printf 'protected: %s\n' "$dir"
+    else
+      rm -f -- "$dir/$FM_TASK_DATA_PROTECTED"
+      printf 'unprotected: %s\n' "$dir"
+    fi
+  done
+  exit 0
+fi
+
+# --- collection -------------------------------------------------------------
+
+# A directory under the new layout is a task folder by position. A directory at
+# the legacy top level is one only if it holds task content, because data/ also
+# holds firstmate's own directories (handoff/ and friends) and this is the one
+# tool that deletes things. An unrecognized folder is skipped, never removed.
+is_legacy_task_dir() {  # <dir>
+  local dir=$1 name
+  for name in brief.md report.md "$FM_TASK_DATA_MARKER" "$FM_TASK_DATA_PROTECTED"; do
+    [ -e "$dir/$name" ] && return 0
+  done
+  return 1
+}
+
+# Every task data directory in both layouts, one per line.
+all_task_dirs() {
+  local dir
+  [ -d "$DATA" ] || return 0
+  {
+    for dir in "$DATA"/*/; do
+      [ -d "$dir" ] || continue
+      dir=${dir%/}
+      [ "$(basename -- "$dir")" != "$FM_TASK_DATA_SUBDIR" ] || continue
+      is_legacy_task_dir "$dir" || continue
+      printf '%s\n' "$dir"
+    done
+    for dir in "$DATA/$FM_TASK_DATA_SUBDIR"/*/*/; do
+      [ -d "$dir" ] || continue
+      printf '%s\n' "${dir%/}"
+    done
+  } | LC_ALL=C sort
+}
+
+list_contains() {  # <needle> <values...>
+  local needle=$1 value
+  shift
+  for value in "$@"; do
+    [ "$value" = "$needle" ] && return 0
+  done
+  return 1
+}
+
+matches_filters() {  # <dir> <task-id> <project>
+  local dir=$1 id=$2 project=$3
+  if [ "${#FILTER_PROJECTS[@]}" -gt 0 ]; then
+    list_contains "$project" "${FILTER_PROJECTS[@]}" || return 1
+  fi
+  if [ "${#FILTER_TASKS[@]}" -gt 0 ]; then
+    list_contains "$id" "${FILTER_TASKS[@]}" || return 1
+  fi
+  if [ -n "$OLDER_THAN" ]; then
+    [ -n "$(find "$dir" -maxdepth 0 -mtime "+$OLDER_THAN" -print 2>/dev/null)" ] || return 1
+  fi
+  return 0
+}
+
+# Kilobytes a prune would actually reclaim from one folder.
+reclaimable_kb() {  # <dir>
+  local dir=$1 total=0 size
+  if [ "$IS_IMAGES_ONLY" -eq 1 ]; then
+    while read -r size _; do
+      [ -n "$size" ] || continue
+      total=$((total + size))
+    done < <(image_files_of "$dir" -exec du -k -- {} + 2>/dev/null || true)
+    printf '%s\n' "$total"
+    return 0
+  fi
+  du -sk -- "$dir" 2>/dev/null | awk 'NR == 1 { print $1 }'
+}
+
+image_files_of() {  # <dir> [find actions...]
+  local dir=$1
+  shift
+  local -a expr=()
+  local ext
+  for ext in $IMAGE_EXTENSIONS; do
+    [ "${#expr[@]}" -eq 0 ] || expr+=(-o)
+    expr+=(-iname "*.$ext")
+  done
+  find "$dir" -type f \( "${expr[@]}" \) "$@"
+}
+
+human_kb() {  # <kilobytes>
+  awk -v kb="$1" 'BEGIN {
+    if (kb >= 1048576) { printf "%.1f GB\n", kb / 1048576 }
+    else if (kb >= 1024) { printf "%.1f MB\n", kb / 1024 }
+    else { printf "%d KB\n", kb }
+  }'
+}
+
+# Rows are TAB-separated: project, task-id, dir, kilobytes, disposition.
+SELECTED=()
+SKIPPED=()
+while IFS= read -r dir; do
+  [ -n "$dir" ] || continue
+  task_id=$(basename -- "$dir")
+  task_project=$(fm_task_data_project_of_dir "$DATA" "$dir")
+  matches_filters "$dir" "$task_id" "$task_project" || continue
+  size_kb=$(reclaimable_kb "$dir")
+  [ -n "$size_kb" ] || size_kb=0
+  if [ -f "$STATE/$task_id.meta" ]; then
+    SKIPPED+=("$task_project	$task_id	$dir	$size_kb	in flight: this task is still working and owns its folder")
+    continue
+  fi
+  if [ -f "$dir/$FM_TASK_DATA_PROTECTED" ] && [ "$SHOULD_INCLUDE_PROTECTED" -eq 0 ]; then
+    SKIPPED+=("$task_project	$task_id	$dir	$size_kb	protected: marked with $FM_TASK_DATA_PROTECTED (pass --include-protected to override)")
+    continue
+  fi
+  SELECTED+=("$task_project	$task_id	$dir	$size_kb	")
+done < <(all_task_dirs)
+
+# --- reporting --------------------------------------------------------------
+
+print_rows() {  # <heading> <rows...>
+  local heading=$1 row project last_project= total=0 count=0
+  shift
+  [ "$#" -gt 0 ] || return 0
+  printf '%s\n' "$heading"
+  for row in "$@"; do
+    IFS=$'\t' read -r project task_id dir size_kb note <<<"$row"
+    if [ "$project" != "$last_project" ]; then
+      printf '  %s\n' "$project"
+      last_project=$project
+    fi
+    printf '    %-40s %10s  %s\n' "$task_id" "$(human_kb "$size_kb")" "$note"
+    total=$((total + size_kb))
+    count=$((count + 1))
+  done
+  printf '  %s folder(s), %s\n\n' "$count" "$(human_kb "$total")"
+}
+
+if [ "$IS_IMAGES_ONLY" -eq 1 ]; then
+  SIZE_LABEL="images"
+else
+  SIZE_LABEL="folder"
+fi
+
+if [ "$COMMAND" = list ]; then
+  print_rows "Task data under $DATA ($SIZE_LABEL size):" \
+    "${SELECTED[@]+"${SELECTED[@]}"}"
+  print_rows "Skipped:" "${SKIPPED[@]+"${SKIPPED[@]}"}"
+  exit 0
+fi
+
+# --- prune ------------------------------------------------------------------
+
+if [ -n "$ARCHIVE_DIR" ]; then
+  ACTION_LABEL="archive into $ARCHIVE_DIR"
+else
+  ACTION_LABEL="remove"
+fi
+if [ "$IS_IMAGES_ONLY" -eq 1 ]; then
+  ACTION_LABEL="$ACTION_LABEL (images only; every other file stays)"
+fi
+
+if [ "$IS_CONFIRMED" -eq 1 ]; then
+  print_rows "About to $ACTION_LABEL:" "${SELECTED[@]+"${SELECTED[@]}"}"
+else
+  print_rows "DRY RUN - would $ACTION_LABEL (nothing is changed; pass --yes to do it):" \
+    "${SELECTED[@]+"${SELECTED[@]}"}"
+fi
+print_rows "Skipped:" "${SKIPPED[@]+"${SKIPPED[@]}"}"
+
+if [ "${#SELECTED[@]}" -eq 0 ]; then
+  echo "fm-task-data: nothing selected."
+  exit 0
+fi
+
+if [ "$IS_CONFIRMED" -eq 0 ]; then
+  echo "fm-task-data: dry run, nothing was changed."
+  exit 0
+fi
+
+# Move one file under <dir> to the same relative place under the archive root.
+archive_file() {  # <task-dir> <archive-root> <file>
+  local dir=$1 root=$2 file=$3 relative dest
+  relative=${file#"$dir"/}
+  dest="$root/$relative"
+  mkdir -p -- "$(dirname -- "$dest")"
+  mv -f -- "$file" "$dest"
+}
+
+for row in "${SELECTED[@]}"; do
+  IFS=$'\t' read -r project task_id dir size_kb note <<<"$row"
+  archive_root=
+  if [ -n "$ARCHIVE_DIR" ]; then
+    archive_root="$ARCHIVE_DIR/$project/$task_id"
+    mkdir -p -- "$archive_root"
+  fi
+  if [ "$IS_IMAGES_ONLY" -eq 1 ]; then
+    while IFS= read -r -d '' file; do
+      if [ -n "$archive_root" ]; then
+        archive_file "$dir" "$archive_root" "$file"
+      else
+        rm -f -- "$file"
+      fi
+    done < <(image_files_of "$dir" -print0)
+    printf 'pruned images: %s\n' "$dir"
+    continue
+  fi
+  if [ -n "$archive_root" ]; then
+    while IFS= read -r -d '' file; do
+      archive_file "$dir" "$archive_root" "$file"
+    done < <(find "$dir" -type f -print0)
+    # Interrupted runs can leave the source half-moved; the next identical run
+    # finishes it, and only an emptied tree is discarded.
+    find "$dir" -depth -type d -empty -exec rmdir -- {} + 2>/dev/null || true
+    printf 'archived: %s -> %s\n' "$dir" "$archive_root"
+  else
+    rm -rf -- "$dir"
+    printf 'removed: %s\n' "$dir"
+  fi
+done

--- a/bin/fm-task-data.sh
+++ b/bin/fm-task-data.sh
@@ -11,8 +11,8 @@
 #   fm-task-data.sh list [filters]
 #   fm-task-data.sh prune [filters] [--images-only] [--archive <dir>] [--yes]
 #                         [--include-protected]
-#   fm-task-data.sh protect <task-id>...
-#   fm-task-data.sh unprotect <task-id>...
+#   fm-task-data.sh protect {<task-id>...|<filters>}
+#   fm-task-data.sh unprotect {<task-id>...|<filters>}
 #
 # Filters (repeatable, and they compose - a folder must match every filter kind
 # that was given, and any one value within a kind):
@@ -35,9 +35,11 @@
 #   - a task still in flight, identified by a live state/<task-id>.meta record;
 #     work under way owns its folder
 #   - a protected folder, identified by a `.protected` marker file inside it.
-#     Use `protect` to add one and `unprotect` to remove it. A marker rather than
-#     a list of ids because the protected body of work grows, and a folder
-#     carries its own protection wherever it is moved or archived.
+#     Use `protect` to add one and `unprotect` to remove it; both take the same
+#     filters as prune, so a whole project is marked in one command. A marker
+#     rather than a hard-coded list of ids because the protected body of work
+#     grows, and a folder carries its own protection wherever it is moved or
+#     archived.
 #
 # Safe to run twice and safe to interrupt: every removal and move is per-file
 # and idempotent, an already-removed file is not an error, and an interrupted
@@ -129,29 +131,18 @@ fi
 
 case "$COMMAND" in
   protect|unprotect)
-    [ "${#POSITIONAL[@]}" -gt 0 ] || die "$COMMAND requires at least one task id"
+    # Either explicit ids or filters, because a body of work worth protecting is
+    # usually a whole project rather than a list someone has to keep up to date.
+    [ "${#POSITIONAL[@]}" -gt 0 ] \
+      || [ "${#FILTER_PROJECTS[@]}" -gt 0 ] \
+      || [ "${#FILTER_TASKS[@]}" -gt 0 ] \
+      || [ -n "$OLDER_THAN" ] \
+      || die "$COMMAND requires at least one task id or filter"
     ;;
   *)
     [ "${#POSITIONAL[@]}" -eq 0 ] || die "unexpected argument '${POSITIONAL[0]}'"
     ;;
 esac
-
-# --- protect / unprotect ----------------------------------------------------
-
-if [ "$COMMAND" = protect ] || [ "$COMMAND" = unprotect ]; then
-  for id in "${POSITIONAL[@]}"; do
-    dir=$(fm_task_data_find "$DATA" "$id") \
-      || die "no task data directory for '$id' under $DATA"
-    if [ "$COMMAND" = protect ]; then
-      : > "$dir/$FM_TASK_DATA_PROTECTED"
-      printf 'protected: %s\n' "$dir"
-    else
-      rm -f -- "$dir/$FM_TASK_DATA_PROTECTED"
-      printf 'unprotected: %s\n' "$dir"
-    fi
-  done
-  exit 0
-fi
 
 # --- collection -------------------------------------------------------------
 
@@ -208,6 +199,41 @@ matches_filters() {  # <dir> <task-id> <project>
   fi
   return 0
 }
+
+# --- protect / unprotect ----------------------------------------------------
+
+# Marking is never destructive, so it reaches in-flight and already-marked
+# folders too; only the prune path cares about those classifications.
+set_protection() {  # <dir>
+  if [ "$COMMAND" = protect ]; then
+    : > "$1/$FM_TASK_DATA_PROTECTED"
+    printf 'protected: %s\n' "$1"
+  else
+    rm -f -- "$1/$FM_TASK_DATA_PROTECTED"
+    printf 'unprotected: %s\n' "$1"
+  fi
+}
+
+if [ "$COMMAND" = protect ] || [ "$COMMAND" = unprotect ]; then
+  marked=0
+  for id in "${POSITIONAL[@]+"${POSITIONAL[@]}"}"; do
+    dir=$(fm_task_data_find "$DATA" "$id") \
+      || die "no task data directory for '$id' under $DATA"
+    set_protection "$dir"
+    marked=$((marked + 1))
+  done
+  if [ "${#POSITIONAL[@]}" -eq 0 ]; then
+    while IFS= read -r dir; do
+      [ -n "$dir" ] || continue
+      matches_filters "$dir" "$(basename -- "$dir")" \
+        "$(fm_task_data_project_of_dir "$DATA" "$dir")" || continue
+      set_protection "$dir"
+      marked=$((marked + 1))
+    done < <(all_task_dirs)
+  fi
+  printf '%s folder(s) %sed.\n' "$marked" "$COMMAND"
+  exit 0
+fi
 
 # Kilobytes a prune would actually reclaim from one folder.
 reclaimable_kb() {  # <dir>
@@ -267,7 +293,8 @@ done < <(all_task_dirs)
 # --- reporting --------------------------------------------------------------
 
 print_rows() {  # <heading> <rows...>
-  local heading=$1 row project last_project= total=0 count=0
+  local heading=$1 row project task_id dir size_kb note
+  local last_project='' total=0 count=0
   shift
   [ "$#" -gt 0 ] || return 0
   printf '%s\n' "$heading"

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -26,7 +26,7 @@
 # branch (firstmate performs that merge after configured approval) as a fallback
 # for the common case where there is no remote at all.
 # Scout tasks (kind=scout in meta) carve out of that check: their worktree is
-# declared scratch and the report at data/<task-id>/report.md is the work
+# declared scratch and the report in the task data directory is the work
 # product. Teardown proceeds only once the report exists and the shared
 # unresolved-decision completion gate verifies its captain-held inventory.
 # Before destructive cleanup, teardown validates task check artifacts and any
@@ -150,6 +150,8 @@ SUB_HOME_PARENT_MARKER=".fm-secondmate-parent"
 . "$SCRIPT_DIR/fm-backend.sh"
 # shellcheck source=bin/fm-control-lib.sh
 . "$SCRIPT_DIR/fm-control-lib.sh"
+# shellcheck source=bin/fm-task-data-lib.sh
+. "$SCRIPT_DIR/fm-task-data-lib.sh"
 # shellcheck source=bin/fm-lock-lib.sh
 . "$SCRIPT_DIR/fm-lock-lib.sh"
 # shellcheck source=bin/fm-classify-lib.sh
@@ -898,7 +900,7 @@ backlog_refresh_reminder() {
   if fm_tasks_axi_backend_available "$CONFIG"; then
     case "$KIND" in
       scout)
-        report_path="data/$ID/report.md"
+        report_path=$(fm_task_data_dir "$DATA" "$ID")/report.md
         done_cmd="tasks-axi done $ID --report $report_path"
         ;;
       *)
@@ -2315,7 +2317,7 @@ if [ "$KIND" = secondmate ] && [ "$FORCE" = "--force" ]; then
 fi
 
 if [ "$KIND" = scout ] && [ "$FORCE" != "--force" ]; then
-  REPORT="$DATA/$ID/report.md"
+  REPORT="$(fm_task_data_dir "$DATA" "$ID")/report.md"
   if [ ! -f "$REPORT" ]; then
     echo "REFUSED: scout task $ID has no report at $REPORT." >&2
     echo "The report is the work product. Have the crewmate write it, or use --force after explicit discard approval." >&2

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -186,7 +186,7 @@ The helper's header owns the exact signal detection, relocated-home limitation, 
 
 ## Two task shapes
 
-Ship tasks change projects and ship by project mode (`no-mistakes`, `direct-PR`, or `local-only`); scout tasks leave standalone investigation reports at `data/<id>/report.md` and never push.
+Ship tasks change projects and ship by project mode (`no-mistakes`, `direct-PR`, or `local-only`); scout tasks leave standalone investigation reports at `report.md` in the task data folder (`bin/fm-task-data-lib.sh`) and never push.
 The intake and authority contract in `AGENTS.md` owns when separate scout research is warranted.
 
 ## Dispatch profiles

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -90,7 +90,8 @@ A secondmate agent itself always stays in its ordinary parent workspace; only ch
 An unconverged opt-out keeps the default projection in that home until convergence.
 
 Presentation is a best-effort visual projection, never task ownership or lifecycle authority.
-Only a fresh task with neither metadata nor an existing presentation journal is eligible for projected creation.
+A fresh task with neither metadata nor an existing presentation journal is eligible for projected creation.
+So is a task whose journal is orphaned, meaning no workspace bearing its token survives: that journal is retired and the task projects afresh, because a projected workspace lost outside exact-pane cleanup would otherwise leave the task flat for the rest of its life.
 Firstmate atomically publishes a three-field version 1 journal containing a random 128-bit base64url token before asking Herdr to create anything.
 After the new workspace converges to one exact task endpoint beneath one exact parent workspace id, the journal advances to a version 2 binding that records the physical home, named session, endpoint, parent, and immutable expected labels.
 Another parent with the same presentation label does not prevent publication or participate in restart reclaim.
@@ -129,13 +130,14 @@ Missing or malformed endpoint identity and missing confirmation machinery are am
 If lock, snapshot, pane identity, or restoration is ambiguous, cleanup warns and preserves the journal for manual inspection.
 
 Recovery is deliberately conservative and presentation-only.
-An existing journal suppresses another projected create.
+An existing journal suppresses another projected create for as long as a workspace bearing its token survives.
 Before any recovery mutation, Firstmate holds both the task spawn lock and the named-session presentation lock.
 A same-identity version 2 binding may replace one exact agent-free restart husk in place only when the physical home, session, metadata endpoint, unique token match, workspace shape and labels, parent identity and placement, and non-target focus snapshot all agree.
 The replacement tab and pane are created and verified before the old pane is rechecked and closed, then the journal advances atomically to the replacement endpoint before metadata publication.
 The reclaim path never moves, closes, deletes, or renames a workspace and never touches a parent, sibling, captain, or foreign pane.
 A failed replacement rolls back only the exact response-derived new pane when focus-safe verification permits it.
-Version 1 journals, dead or missing panes, duplicate or absent tokens, renamed or detached spaces, cross-home mismatches, inconsistent endpoint bindings, active target tabs, and ambiguous identity or focus fall back flat without mutating the old projection when duplicate-agent risk is positively absent.
+Version 1 journals, dead or missing panes, duplicate tokens, renamed or detached spaces, cross-home mismatches, inconsistent endpoint bindings, active target tabs, and ambiguous identity or focus fall back flat without mutating the old projection when duplicate-agent risk is positively absent.
+An absent token is the one recovery outcome that re-projects rather than falling back, and only after the same duplicate-agent proof: nothing bearing the token is left to preserve, adopt, or contradict.
 A live or unknown recorded or token-matched endpoint refuses duplicate launch.
 
 Locked session start has one narrower cleanup for a restored projected child that is no longer current task state.

--- a/docs/remote-secondmates.md
+++ b/docs/remote-secondmates.md
@@ -131,7 +131,7 @@ The primary validates every resolved origin before transport, and the receiving 
 The project's registered delivery mode still comes from this machine's `data/projects.md`, so an unregistered or `local-only` project is refused rather than provisioned.
 
 The seed records `host:`, `root:`, and `home:` in `data/secondmates.md`, gates the host on readiness, sends a bounded manifest, and lets the remote host clone its own Firstmate home and project origins.
-In the primary home, its durable registration effects are limited to that route and the charter brief under `data/<id>`; launch records are created only when the secondmate is launched.
+In the primary home, its durable registration effects are limited to that route and the charter brief in the task data folder (`bin/fm-task-data-lib.sh`); launch records are created only when the secondmate is launched.
 Readiness starts with a read-only check; when that check reports a gap, it runs `--fix` and then a second read-only check whose verdict decides, so the operator never has to run the repair by hand and a repair is never trusted on its own word.
 A host that stays red prints the doctor's remaining gaps and their operator steps, restores the registry, and creates nothing on the remote host.
 It does not copy project trees or the primary process environment.

--- a/docs/subagent-guard.md
+++ b/docs/subagent-guard.md
@@ -11,7 +11,7 @@ That deny list must not ship in tracked `.claude/settings.json` because it is Cl
 On 2026-07-22 a firstmate primary ran four workers through Claude Code's built-in subagent tool instead of `bin/fm-spawn.sh`.
 Three consequences were observed, not hypothesized.
 
-- The fleet view showed zero work under way for the whole run, because no `state/<id>.meta` and no `data/<id>/brief.md` were ever created.
+- The fleet view showed zero work under way for the whole run, because no `state/<id>.meta` and no task-data `brief.md` were ever created.
 - When the primary session restarted, two of those workers died mid-flight and their work was lost.
   A real crewmate lives in its own backend session with durable state and survives a primary restart.
 - The supervision cycle then stayed down for 73 minutes unnoticed, which silently killed the captain's Workflowy intake channel, since that channel only fires while a watch cycle runs.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -408,6 +408,22 @@ The projected spawn in that run used the historical empty opt-in file, so a home
 One concurrent cross-home recovery case refused under contention on a loaded machine and passed on an immediate rerun; recovery-path presentation lock contention is a deliberate hard refusal rather than a flat fallback, which default-on now makes reachable from any Herdr home.
 That run measured the default-on projection on Herdr 0.8.0 only, while the focus-flash regression below was last run on 0.7.5 before the flip, so neither run covered a defective release under default-on projection; the version floor and the focus-flash suite's Part C close that gap.
 
+The projection suite ran again on 2026-08-23 against Herdr 0.8.2 protocol 20, for the orphaned-journal re-projection guarantee: a projected workspace lost outside exact-pane cleanup leaves its journal behind, and the next spawn of that task must project a new nested space under its own parent instead of degrading to the flat layout permanently.
+
+```sh
+HERDR_LAB_HELPER=bin/fm-herdr-lab.sh \
+  tests/fm-backend-herdr-presentation-e2e.test.sh
+```
+
+Observed guarantee, exercised in a primary home and in a secondmate home in the same run:
+
+```text
+ok - real Herdr lab: a lost projected workspace re-projects under its own parent in primary and secondmate homes
+ok - real Herdr lab validation completed on Herdr 0.8.2 with the default-session tripwire intact
+```
+
+Before that change the same fixture recorded `respawn landed in: w1 firstmate` for the primary home, proving the degradation was never secondmate-specific.
+
 The restored-shell session-start cleanup ran on 2026-07-24 against Herdr 0.7.5 protocol 17:
 
 ```sh

--- a/tests/fm-ask-user-authority.test.sh
+++ b/tests/fm-ask-user-authority.test.sh
@@ -15,7 +15,7 @@ test_primary_and_secondmate_instruction_generation() {
 
   FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
     "$BRIEF" authority-worker sample --mode no-mistakes >/dev/null 2>&1
-  ship="$home/data/authority-worker/brief.md"
+  ship="$home/data/tasks/sample/authority-worker/brief.md"
   assert_grep 'ask-user findings are never yours to answer' "$ship" \
     "generated implementation brief lets the worker own an ask-user decision"
   assert_grep "Firstmate applies \`ask-user-authority\` and obtains any required captain decision" "$ship" \
@@ -27,7 +27,7 @@ test_primary_and_secondmate_instruction_generation() {
 
   FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" FM_SECONDMATE_CHARTER='Handle sample work.' \
     "$BRIEF" authority-mate --secondmate --no-projects >/dev/null 2>&1
-  charter="$home/data/authority-mate/brief.md"
+  charter="$home/data/tasks/_none/authority-mate/brief.md"
   # shellcheck disable=SC2016 # Backticks are literal generated Markdown.
   assert_grep 'The local `AGENTS.md` is your job description' "$charter" \
     "generated secondmate charter does not load the tracked authority boundary"

--- a/tests/fm-backend-herdr-presentation-e2e.test.sh
+++ b/tests/fm-backend-herdr-presentation-e2e.test.sh
@@ -1271,6 +1271,80 @@ teardown_task "$CROSS_RESTART_ID" "$SECOND_HOME_A" > "$TMP_ROOT/cross-restart-te
 "$REAL_TREEHOUSE" return --force "$CROSS_NEW_WT" >/dev/null 2>&1 || true
 pass "real Herdr lab: secondmate restart binding and reclaim stay isolated to the exact child home and parent"
 
+# A projected workspace can vanish while its task record survives: the captain
+# closes it, or Herdr drops it when its last pane dies outside the exact-pane
+# teardown path. Teardown then cannot correlate the endpoint with the journal,
+# so it retains the journal and warns. The next fresh spawn of that id must
+# project a NEW nested child under the same owning parent - in a primary and in
+# a secondmate home alike - instead of degrading to a flat tab in the parent
+# workspace for the rest of that task's life.
+for ORPHAN_PAIR in "orphan-primary|$HOME_DIR|firstmate" "orphan-second|$SECOND_HOME_A|2ndmate-alpha"; do
+  ORPHAN_ID=${ORPHAN_PAIR%%|*}
+  ORPHAN_REST=${ORPHAN_PAIR#*|}
+  ORPHAN_HOME=${ORPHAN_REST%%|*}
+  ORPHAN_PARENT_LABEL=${ORPHAN_REST#*|}
+  mkdir -p "$ORPHAN_HOME/data/$ORPHAN_ID"
+  printf 'Orphaned projection fixture.\n' > "$ORPHAN_HOME/data/$ORPHAN_ID/brief.md"
+  spawn_task "$ORPHAN_ID" "$ORPHAN_HOME" "$PROJECT_DIR" > "$TMP_ROOT/$ORPHAN_ID-first.out" 2> "$TMP_ROOT/$ORPHAN_ID-first.err" \
+    || fail "$ORPHAN_ID projected spawn failed: $(cat "$TMP_ROOT/$ORPHAN_ID-first.err")"
+  ORPHAN_META="$ORPHAN_HOME/state/$ORPHAN_ID.meta"
+  ORPHAN_JOURNAL="$ORPHAN_HOME/state/$ORPHAN_ID.herdr-presentation"
+  ORPHAN_OLD_WT=$(remember_meta_worktree "$ORPHAN_META")
+  ORPHAN_OLD_WSID=$(grep '^herdr_workspace_id=' "$ORPHAN_META" | cut -d= -f2-)
+  ORPHAN_OLD_LABEL=$(lab workspace get "$ORPHAN_OLD_WSID" | jq -r '.result.workspace.label')
+  case "$ORPHAN_OLD_LABEL" in
+    "└ $ORPHAN_ID · p:"*) ;;
+    *) fail "$ORPHAN_ID first spawn was not projected: $ORPHAN_OLD_LABEL" ;;
+  esac
+  ORPHAN_OLD_TOKEN=${ORPHAN_OLD_LABEL##*' · p:'}
+
+  # Lose the projected workspace out from under the still-recorded task.
+  lab workspace close "$ORPHAN_OLD_WSID" >/dev/null 2>&1 \
+    || fail "$ORPHAN_ID fixture could not close its projected workspace"
+  if lab workspace get "$ORPHAN_OLD_WSID" >/dev/null 2>&1; then
+    fail "$ORPHAN_ID fixture did not actually lose its projected workspace"
+  fi
+  [ -f "$ORPHAN_JOURNAL" ] || fail "$ORPHAN_ID fixture lost the orphaned journal before the respawn"
+  [ -f "$ORPHAN_META" ] || fail "$ORPHAN_ID fixture lost its metadata before the respawn"
+
+  ORPHAN_FOCUS=$(focus_snapshot)
+  spawn_task "$ORPHAN_ID" "$ORPHAN_HOME" "$PROJECT_DIR" > "$TMP_ROOT/$ORPHAN_ID-respawn.out" 2> "$TMP_ROOT/$ORPHAN_ID-respawn.err" \
+    || fail "$ORPHAN_ID respawn over an orphaned journal failed: $(cat "$TMP_ROOT/$ORPHAN_ID-respawn.err")"
+  ORPHAN_NEW_WT=$(remember_meta_worktree "$ORPHAN_META")
+  ORPHAN_NEW_WSID=$(grep '^herdr_workspace_id=' "$ORPHAN_META" | cut -d= -f2-)
+  ORPHAN_NEW_LABEL=$(lab workspace get "$ORPHAN_NEW_WSID" | jq -r '.result.workspace.label')
+  [ "$ORPHAN_NEW_WSID" != "$ORPHAN_OLD_WSID" ] \
+    || fail "$ORPHAN_ID respawn claimed the closed workspace id"
+  case "$ORPHAN_NEW_LABEL" in
+    "└ $ORPHAN_ID · p:"*) ;;
+    *) fail "$ORPHAN_ID respawn fell back to the flat $ORPHAN_PARENT_LABEL container instead of a new nested space: $ORPHAN_NEW_LABEL" ;;
+  esac
+  ORPHAN_NEW_TOKEN=${ORPHAN_NEW_LABEL##*' · p:'}
+  [ "$ORPHAN_NEW_TOKEN" != "$ORPHAN_OLD_TOKEN" ] \
+    || fail "$ORPHAN_ID respawn reused the orphaned projection token"
+  [ "$(grep '^version=' "$ORPHAN_JOURNAL")" = version=2 ] \
+    || fail "$ORPHAN_ID respawn did not publish a fresh exact restart binding"
+  [ "$(grep '^projection_id=' "$ORPHAN_JOURNAL" | cut -d= -f2-)" = "$ORPHAN_NEW_TOKEN" ] \
+    || fail "$ORPHAN_ID respawn left the journal bound to the orphaned projection"
+  ORPHAN_LIST_LABELS=$(lab workspace list | jq -r '.result.workspaces[].label')
+  printf '%s\n' "$ORPHAN_LIST_LABELS" \
+    | grep -Fx "$ORPHAN_PARENT_LABEL" >/dev/null 2>&1 \
+    || fail "$ORPHAN_ID respawn lost its owning parent workspace $ORPHAN_PARENT_LABEL"
+  ORPHAN_PARENT_INDEX=$(printf '%s\n' "$ORPHAN_LIST_LABELS" | grep -nFx "$ORPHAN_PARENT_LABEL" | cut -d: -f1)
+  ORPHAN_CHILD_INDEX=$(printf '%s\n' "$ORPHAN_LIST_LABELS" | grep -nFx "$ORPHAN_NEW_LABEL" | cut -d: -f1)
+  [ -n "$ORPHAN_PARENT_INDEX" ] && [ -n "$ORPHAN_CHILD_INDEX" ] && [ "$ORPHAN_CHILD_INDEX" -gt "$ORPHAN_PARENT_INDEX" ] \
+    || fail "$ORPHAN_ID respawn was not ordered under its owning parent $ORPHAN_PARENT_LABEL"
+  assert_focus_is "$ORPHAN_FOCUS" "$ORPHAN_ID respawn over an orphaned journal"
+
+  teardown_task "$ORPHAN_ID" "$ORPHAN_HOME" > "$TMP_ROOT/$ORPHAN_ID-teardown.out" 2> "$TMP_ROOT/$ORPHAN_ID-teardown.err" \
+    || fail "$ORPHAN_ID teardown after re-projection failed: $(cat "$TMP_ROOT/$ORPHAN_ID-teardown.err")"
+  [ ! -e "$ORPHAN_JOURNAL" ] \
+    || fail "$ORPHAN_ID teardown after re-projection did not retire its journal"
+  "$REAL_TREEHOUSE" return --force "$ORPHAN_OLD_WT" >/dev/null 2>&1 || true
+  "$REAL_TREEHOUSE" return --force "$ORPHAN_NEW_WT" >/dev/null 2>&1 || true
+done
+pass "real Herdr lab: a lost projected workspace re-projects under its own parent in primary and secondmate homes"
+
 # Two homes recovering concurrently serialize on the named session lock and
 # each replace only their own exact husk.
 PRIMARY_WAVE_ID=resume-wave-primary

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -19,6 +19,12 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 TMP_ROOT=$(fm_test_tmproot fm-brief)
+
+# A scaffolded task's durable data directory. bin/fm-task-data-lib.sh groups it
+# by the project the brief names; a task with no project uses the _none literal.
+task_dir() {  # <home> <project> <task-id>
+  printf '%s\n' "$1/data/tasks/$2/$3"
+}
 BRIEF_HOME="$TMP_ROOT/home"
 mkdir -p "$BRIEF_HOME/data"
 
@@ -204,7 +210,7 @@ test_ship_modes_generate_clean_briefs() {
     mode=${id_mode##*:}
     FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode "$mode" >/dev/null 2>&1; status=$?
     expect_code 0 "$status" "fm-brief.sh $id --mode $mode should exit 0"
-    brief="$home/data/$id/brief.md"
+    brief="$(task_dir "$home" some-proj "$id")/brief.md"
     assert_present "$brief" "$id: brief was not scaffolded"
     assert_grep "# Definition of done" "$brief" "$id: brief missing Definition of done section"
     grep -qx "Delivery contract: mode=$mode" "$brief" \
@@ -216,15 +222,15 @@ test_ship_modes_generate_clean_briefs() {
     # Report and evidence must outlive the disposable worktree, so every mode
     # carves the task data directory out of the stay-in-your-worktree rule and
     # requires both artifacts there.
-    assert_grep "anything under your task data directory \`$home/data/$id/\`" "$brief" \
+    assert_grep "anything under your task data directory \`$(task_dir "$home" some-proj "$id")/\`" "$brief" \
       "$id: rule 2 lost the task data-directory carve-out"
-    assert_grep "Write \`$home/data/$id/report.md\` if this task uncovered a **transferable cause**" "$brief" \
+    assert_grep "Write \`$(task_dir "$home" some-proj "$id")/report.md\` if this task uncovered a **transferable cause**" "$brief" \
       "$id: definition of done lost the transferable-cause report requirement"
     assert_grep "the PR body is not a substitute, because working notes are deleted at cleanup" "$brief" \
       "$id: report requirement lost the PR-body-is-not-a-substitute rule"
     assert_grep "Task size is not the test" "$brief" \
       "$id: report requirement lost the size-is-not-the-test rule"
-    assert_grep "Write any screenshot or recording you take to support a claim in the PR body into \`$home/data/$id/\`" "$brief" \
+    assert_grep "Write any screenshot or recording you take to support a claim in the PR body into \`$(task_dir "$home" some-proj "$id")/\`" "$brief" \
       "$id: definition of done lost the saved-visual-evidence requirement"
   done
   pass "fm-brief.sh: every ship mode generates cleanly and requires a durable report plus saved evidence"
@@ -247,7 +253,8 @@ test_ship_mode_is_required_and_closed_set() {
     status=$?
     [ "$status" -ne 0 ] || fail "$label: expected a non-zero exit"
     assert_contains "$out" "$expect" "$label: refusal did not explain the contract"
-    assert_absent "$home/data/brief-required-$id/brief.md" "$label: refused scaffold still wrote a brief"
+    assert_absent "$(task_dir "$home" some-proj "brief-required-$id")/brief.md" \
+      "$label: refused scaffold still wrote a brief"
   done <<'ROWS'
 missing --mode||ship briefs require --mode
 empty --mode value|--mode|requires a value
@@ -266,7 +273,7 @@ test_ship_mode_is_explicit_not_registry() {
   write_registry "$home"
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-explicit-a5 direct-proj --mode no-mistakes >/dev/null 2>&1 \
     || fail "explicit no-mistakes brief on a direct-PR project should scaffold"
-  brief="$home/data/brief-explicit-a5/brief.md"
+  brief="$(task_dir "$home" direct-proj brief-explicit-a5)/brief.md"
   grep -qx "Delivery contract: mode=no-mistakes" "$brief" \
     || fail "registered direct-PR posture overrode the explicit --mode"
   assert_grep "Firstmate will then instruct you to run /no-mistakes" "$brief" \
@@ -275,7 +282,8 @@ test_ship_mode_is_explicit_not_registry() {
   # An unregistered project is not a blocker either, because nothing is looked up.
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-explicit-a6 never-registered --mode local-only >/dev/null 2>&1 \
     || fail "unregistered project should still scaffold from the explicit mode"
-  grep -qx "Delivery contract: mode=local-only" "$home/data/brief-explicit-a6/brief.md" \
+  grep -qx "Delivery contract: mode=local-only" \
+    "$(task_dir "$home" never-registered brief-explicit-a6)/brief.md" \
     || fail "unregistered project did not honour the explicit --mode"
   pass "fm-brief.sh: the explicit ship mode wins over the registered posture"
 }
@@ -309,25 +317,26 @@ test_faster_paths_use_configured_authority_without_stacked_review() {
   write_registry "$home"
   id="brief-direct-authority-a4"
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" direct-proj --mode direct-PR >/dev/null 2>&1
-  brief="$home/data/$id/brief.md"
+  brief="$(task_dir "$home" direct-proj "$id")/brief.md"
   assert_grep "The configured merge authority decides whether to merge the PR; firstmate relays the outcome." "$brief" \
     "direct-PR brief lost configured merge authority"
   assert_no_grep "The captain reviews and merges the PR" "$brief" \
     "direct-PR brief hard-coded captain-only authority"
   id="brief-local-authority-a4"
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" local-proj --mode local-only >/dev/null 2>&1
-  brief="$home/data/$id/brief.md"
+  brief="$(task_dir "$home" local-proj "$id")/brief.md"
   assert_grep "The configured merge authority approves the ready branch, then firstmate merges it into local \`main\` through the guarded fast-forward path." "$brief" \
     "local-only brief lost configured merge authority and guarded landing"
   assert_no_grep "The captain approves the ready branch" "$brief" \
     "local-only brief hard-coded captain-only authority"
   assert_no_grep "Firstmate then reviews your branch diff" "$brief" \
     "local-only brief retained a personal review stacked on the selected delivery path"
-  assert_no_grep "make \`--intent\` preserve all relevant content from this brief" "$home/data/$id/brief.md" \
+  assert_no_grep "make \`--intent\` preserve all relevant content from this brief" "$brief" \
     "local-only brief must not include the no-mistakes --intent contract"
   id="brief-direct-intent-a4"
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" direct-proj --mode direct-PR >/dev/null 2>&1
-  assert_no_grep "make \`--intent\` preserve all relevant content from this brief" "$home/data/$id/brief.md" \
+  assert_no_grep "make \`--intent\` preserve all relevant content from this brief" \
+    "$(task_dir "$home" direct-proj "$id")/brief.md" \
     "direct-PR brief must not include the no-mistakes --intent contract"
   pass "fm-brief.sh: faster paths use configured authority without stacked review"
 }
@@ -340,7 +349,7 @@ test_no_mistakes_dod_wording() {
   mkdir -p "$home/data"
   id="brief-wording-b1"
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
-  brief="$home/data/$id/brief.md"
+  brief="$(task_dir "$home" some-proj "$id")/brief.md"
   assert_present "$brief" "brief was not scaffolded"
   assert_grep "no-mistakes itself provides for the mechanics" "$brief" \
     "no-mistakes DOD lost its guidance-reference sentence"
@@ -373,7 +382,7 @@ test_ship_project_memory_wording() {
   mkdir -p "$home/data"
   id="brief-memory-c1"
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
-  brief="$home/data/$id/brief.md"
+  brief="$(task_dir "$home" some-proj "$id")/brief.md"
   assert_present "$brief" "brief was not scaffolded"
   assert_grep "Record only project knowledge useful to almost every future session." "$brief" \
     "project-memory contract lost the durable-knowledge bar"
@@ -390,7 +399,7 @@ test_herdr_lab_contract_is_explicit_and_complete() {
   mkdir -p "$home/data"
   id="brief-herdr-lab-d1"
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" firstmate --mode no-mistakes --herdr-lab >/dev/null 2>&1
-  brief="$home/data/$id/brief.md"
+  brief="$(task_dir "$home" firstmate "$id")/brief.md"
   assert_present "$brief" "Herdr lab brief was not scaffolded"
   assert_grep "# Herdr isolation - HARD SAFETY CONTRACT" "$brief" \
     "Herdr lab brief missing its hard safety contract"
@@ -424,7 +433,7 @@ test_herdr_lab_contract_quotes_foreign_firstmate_path() {
   helper=$(printf '%s' "$foreign_root/bin/fm-herdr-lab.sh" | sed "s/'/'\\\\''/g")
   helper="'$helper'"
   FM_HOME="$home" FM_ROOT_OVERRIDE="$foreign_root" "$ROOT/bin/fm-brief.sh" "$id" foreign --scout --herdr-lab >/dev/null 2>&1
-  brief="$home/data/$id/brief.md"
+  brief="$(task_dir "$home" foreign "$id")/brief.md"
   assert_grep "HERDR_LAB_HELPER=$helper" "$brief" \
     "Herdr lab brief must shell-quote an absolute Firstmate helper path"
   assert_no_grep "bin/fm-herdr-lab.sh name $id" "$brief" \
@@ -443,7 +452,7 @@ test_herdr_lab_omission_is_loud_for_ship_and_scout() {
     else
       FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" firstmate --mode no-mistakes >/dev/null 2>&1
     fi
-    brief="$home/data/$id/brief.md"
+    brief="$(task_dir "$home" firstmate "$id")/brief.md"
     assert_grep "# Herdr lifecycle declaration - NOT ENABLED" "$brief" \
       "$kind brief silently omitted the Herdr declaration"
     assert_grep "regenerate the brief with \`--herdr-lab\` before dispatch" "$brief" \
@@ -463,7 +472,7 @@ test_secondmate_no_projects_charter() {
     FM_SECONDMATE_SCOPE='firstmate repo work' \
     "$ROOT/bin/fm-brief.sh" fdev --secondmate --no-projects >/dev/null 2>&1; status=$?
   expect_code 0 "$status" "--no-projects secondmate brief should exit 0"
-  brief="$home/data/fdev/brief.md"
+  brief="$(task_dir "$home" _none fdev)/brief.md"
   assert_present "$brief" "project-less charter was not scaffolded"
   assert_grep "# Project clones" "$brief" "project-less charter dropped the Project clones heading"
   assert_grep "None. This is a project-less domain" "$brief" \
@@ -485,7 +494,8 @@ test_secondmate_no_projects_charter() {
   # Accidental omission (no projects, no signal) still fails loudly, writing nothing.
   FM_HOME="$home" FM_SECONDMATE_CHARTER='x' "$ROOT/bin/fm-brief.sh" oops --secondmate >/dev/null 2>&1; status=$?
   expect_code 1 "$status" "secondmate brief with no projects and no --no-projects must fail"
-  assert_absent "$home/data/oops/brief.md" "loud-failure secondmate brief still wrote a file"
+  assert_absent "$(task_dir "$home" _none oops)/brief.md" \
+    "loud-failure secondmate brief still wrote a file"
 
   # --no-projects is mutually exclusive with a project list.
   FM_HOME="$home" FM_SECONDMATE_CHARTER='x' "$ROOT/bin/fm-brief.sh" oops2 --secondmate --no-projects alpha >/dev/null 2>&1; status=$?
@@ -505,7 +515,7 @@ test_secondmate_marked_request_reporting_contract() {
   FM_HOME="$home" FM_CLASSIFY_PAUSED_VERB=paused \
     FM_SECONDMATE_CHARTER='Handle routed domain work.' \
     "$ROOT/bin/fm-brief.sh" marked-request-reporting --secondmate --no-projects >/dev/null 2>&1
-  brief="$home/data/marked-request-reporting/brief.md"
+  brief="$(task_dir "$home" _none marked-request-reporting)/brief.md"
 
   assert_grep 'A marked request requires one correlated answer after the work' "$brief" \
     "secondmate charter did not require the correlated answer after the work"
@@ -551,7 +561,7 @@ test_secondmate_directory_paths_are_absolute_and_output_is_stable() {
     "$root/cdpath/home/data" "$root/cdpath/home/state" \
     "$root/cdpath/data-override" "$root/cdpath/state-override"
 
-  brief="$home/data/relative-home/brief.md"
+  brief="$(task_dir "$home" _none relative-home)/brief.md"
   FM_HOME="$home" FM_SECONDMATE_CHARTER=x \
     "$ROOT/bin/fm-brief.sh" relative-home --secondmate --no-projects >/dev/null 2>&1
   baseline="$root/absolute-home-charter"
@@ -567,7 +577,7 @@ test_secondmate_directory_paths_are_absolute_and_output_is_stable() {
   assert_grep ">> '$home/state/relative-home.status'" "$brief" \
     "relative FM_HOME did not render an absolute secondmate status path"
 
-  brief="$home/data/relative-state/brief.md"
+  brief="$(task_dir "$home" _none relative-state)/brief.md"
   FM_HOME="$home" FM_STATE_OVERRIDE="$state_override" FM_SECONDMATE_CHARTER=x \
     "$ROOT/bin/fm-brief.sh" relative-state --secondmate --no-projects >/dev/null 2>&1
   baseline="$root/absolute-state-charter"
@@ -583,7 +593,7 @@ test_secondmate_directory_paths_are_absolute_and_output_is_stable() {
   assert_grep ">> '$state_override/relative-state.status'" "$brief" \
     "relative FM_STATE_OVERRIDE did not render an absolute secondmate status path"
 
-  brief="$data_override/relative-data/brief.md"
+  brief="$data_override/tasks/_none/relative-data/brief.md"
   FM_HOME="$home" FM_DATA_OVERRIDE="$data_override" FM_SECONDMATE_CHARTER=x \
     "$ROOT/bin/fm-brief.sh" relative-data --secondmate --no-projects >/dev/null 2>&1
   baseline="$root/absolute-data-charter"
@@ -635,13 +645,13 @@ test_herdr_lab_contract_applies_to_scouts_but_not_secondmates() {
   home="$TMP_ROOT/herdr-kind-home"
   mkdir -p "$home/data"
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" herdr-scout firstmate --scout --herdr-lab >/dev/null 2>&1
-  brief="$home/data/herdr-scout/brief.md"
+  brief="$(task_dir "$home" firstmate herdr-scout)/brief.md"
   assert_grep "# Herdr isolation - HARD SAFETY CONTRACT" "$brief" \
     "scout --herdr-lab brief missing the contract"
 
   FM_HOME="$home" FM_SECONDMATE_CHARTER=ops "$ROOT/bin/fm-brief.sh" herdr-secondmate --secondmate firstmate --herdr-lab >/dev/null 2>&1 || status=$?
   expect_code 1 "$status" "secondmate --herdr-lab must be rejected"
-  assert_absent "$home/data/herdr-secondmate/brief.md" \
+  assert_absent "$(task_dir "$home" _none herdr-secondmate)/brief.md" \
     "rejected secondmate --herdr-lab still wrote a brief"
   pass "fm-brief.sh: Herdr lab contract covers scouts and rejects secondmate misuse"
 }
@@ -667,7 +677,11 @@ test_pause_verb_override_renders_all_brief_scaffolds() {
           "$ROOT/bin/fm-brief.sh" "$id" --secondmate --no-projects >/dev/null 2>&1
         ;;
     esac
-    brief="$home/data/$id/brief.md"
+    if [ "$kind" = secondmate ]; then
+      brief="$(task_dir "$home" _none "$id")/brief.md"
+    else
+      brief="$(task_dir "$home" firstmate "$id")/brief.md"
+    fi
     assert_grep "States: working, needs-decision, blocked, awaiting, done, failed." "$brief" \
       "$kind brief did not render the configured pause verb in its states list"
     # shellcheck disable=SC2016 # Literal backticks and braces must remain unexpanded.
@@ -690,14 +704,14 @@ test_scout_and_secondmate_load_decision_hold_policy() {
   mkdir -p "$home/data"
   FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
     "$ROOT/bin/fm-brief.sh" sample-investigation sample --scout >/dev/null 2>&1
-  scout="$home/data/sample-investigation/brief.md"
+  scout="$(task_dir "$home" sample sample-investigation)/brief.md"
   assert_grep "$ROOT/.agents/skills/captain-hold-lifecycle/SKILL.md" "$scout" \
     "scout brief did not load the captain-call policy before done"
   assert_grep "pass its shared completion gate for the report and any visual review" "$scout" \
     "scout brief did not cross-reference visual-review completion"
   FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" FM_SECONDMATE_CHARTER='sample reviews' \
     "$ROOT/bin/fm-brief.sh" sample-mate --secondmate --no-projects >/dev/null 2>&1
-  charter="$home/data/sample-mate/brief.md"
+  charter="$(task_dir "$home" _none sample-mate)/brief.md"
   assert_grep "load \`captain-hold-lifecycle\`" "$charter" \
     "secondmate charter did not load the shared captain-call policy for detailed investigations"
   pass "fm-brief.sh: investigation and visual-review completions load the shared decision policy"
@@ -708,7 +722,7 @@ test_scout_and_secondmate_scaffold() {
   local brief
   FM_HOME="$BRIEF_HOME" "$ROOT/bin/fm-brief.sh" brief-scout-q6 alpha --scout >/dev/null 2>&1 \
     || fail "fm-brief.sh scout scaffold exited non-zero"
-  brief="$BRIEF_HOME/data/brief-scout-q6/brief.md"
+  brief="$(task_dir "$BRIEF_HOME" alpha brief-scout-q6)/brief.md"
   assert_present "$brief" "scout brief was not scaffolded"
   assert_grep "SCOUT task" "$brief" "scout brief must declare itself a scout task"
   assert_grep "report.md" "$brief" "scout brief must point at the report deliverable"
@@ -718,7 +732,7 @@ test_scout_and_secondmate_scaffold() {
   FM_SECONDMATE_CHARTER='Supervise the alpha domain.' \
     FM_HOME="$BRIEF_HOME" "$ROOT/bin/fm-brief.sh" brief-sm-q6 --secondmate alpha >/dev/null 2>&1 \
     || fail "fm-brief.sh secondmate scaffold exited non-zero"
-  brief="$BRIEF_HOME/data/brief-sm-q6/brief.md"
+  brief="$(task_dir "$BRIEF_HOME" _none brief-sm-q6)/brief.md"
   assert_present "$brief" "secondmate charter was not scaffolded"
   assert_grep "persistent second mate" "$brief" \
     "secondmate charter must declare its role"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -213,8 +213,21 @@ test_ship_modes_generate_clean_briefs() {
     assert_grep "mid-task \`working:\` line (including setup complete) is nonterminal" "$brief" \
       "$id: brief missing nonterminal working:/setup-complete gate protection"
     assert_no_grep "EOF" "$brief" "$id: brief leaked a heredoc EOF marker (unterminated heredoc)"
+    # Report and evidence must outlive the disposable worktree, so every mode
+    # carves the task data directory out of the stay-in-your-worktree rule and
+    # requires both artifacts there.
+    assert_grep "anything under your task data directory \`$home/data/$id/\`" "$brief" \
+      "$id: rule 2 lost the task data-directory carve-out"
+    assert_grep "Write \`$home/data/$id/report.md\` if this task uncovered a **transferable cause**" "$brief" \
+      "$id: definition of done lost the transferable-cause report requirement"
+    assert_grep "the PR body is not a substitute, because working notes are deleted at cleanup" "$brief" \
+      "$id: report requirement lost the PR-body-is-not-a-substitute rule"
+    assert_grep "Task size is not the test" "$brief" \
+      "$id: report requirement lost the size-is-not-the-test rule"
+    assert_grep "Write any screenshot or recording you take to support a claim in the PR body into \`$home/data/$id/\`" "$brief" \
+      "$id: definition of done lost the saved-visual-evidence requirement"
   done
-  pass "fm-brief.sh: no-mistakes/direct-PR/local-only briefs generate cleanly"
+  pass "fm-brief.sh: every ship mode generates cleanly and requires a durable report plus saved evidence"
 }
 
 # A ship task's delivery mode is firstmate's per-task decision, so a missing or

--- a/tests/fm-remote-secondmate-lifecycle-e2e.test.sh
+++ b/tests/fm-remote-secondmate-lifecycle-e2e.test.sh
@@ -389,7 +389,7 @@ assert_grep 'remote readiness completion is unknown' "$TMP_ROOT/seed-unknown.out
   "unknown readiness did not report its distinct completion state"
 assert_grep '- seed-unknown ' "$TMP_ROOT/seed-parent/data/secondmates.md" \
   "unknown readiness removed the registered route"
-assert_present "$TMP_ROOT/seed-parent/data/seed-unknown/brief.md" \
+assert_present "$TMP_ROOT/seed-parent/data/tasks/_none/seed-unknown/brief.md" \
   "unknown readiness removed the scaffolded brief"
 assert_absent "$TMP_ROOT/seed-unknown-home" \
   "unknown readiness proceeded into remote home provisioning"
@@ -416,7 +416,7 @@ assert_grep 'remote runtime preflight failed' "$TMP_ROOT/seed-toolless.out" \
 assert_absent "$TMP_ROOT/seed-toolless-home" "the seed provisioned a home despite a failing preflight"
 assert_no_grep '- seed-toolless ' "$TMP_ROOT/seed-parent/data/secondmates.md" \
   "the refused route survived the preflight rollback"
-assert_absent "$TMP_ROOT/seed-parent/data/seed-toolless/brief.md" \
+assert_absent "$TMP_ROOT/seed-parent/data/tasks/_none/seed-toolless/brief.md" \
   "the refused route left its scaffolded charter behind"
 [ "$(cat "$DOCTOR_LOG")" = 'doctor-human -
 doctor-human --fix

--- a/tests/fm-secondmate-safety.test.sh
+++ b/tests/fm-secondmate-safety.test.sh
@@ -60,17 +60,17 @@ test_fm_home_parameterization() {
   [ "$out" = "no-mistakes off" ] || fail "fm-project-mode did not isolate missing registry by home"
 
   FM_HOME="$home_one" "$ROOT/bin/fm-brief.sh" task-a app --mode no-mistakes >/dev/null || fail "brief scaffold failed under FM_HOME"
-  brief="$home_one/data/task-a/brief.md"
+  brief="$home_one/data/tasks/app/task-a/brief.md"
   [ -f "$brief" ] || fail "brief was not written under FM_HOME/data"
   grep -F ">> '$home_one/state/task-a.status'" "$brief" >/dev/null || fail "brief did not shell-quote FM_HOME state path"
 
   FM_HOME="$home_one" "$ROOT/bin/fm-brief.sh" task-b app --scout >/dev/null || fail "scout brief scaffold failed under FM_HOME"
-  brief="$home_one/data/task-b/brief.md"
+  brief="$home_one/data/tasks/app/task-b/brief.md"
   grep -F ">> '$home_one/state/task-b.status'" "$brief" >/dev/null || fail "scout brief did not shell-quote FM_HOME state path"
 
   FM_HOME="$home_one" FM_SECONDMATE_CHARTER='ops domain' "$ROOT/bin/fm-brief.sh" task-c --secondmate app >/dev/null \
     || fail "secondmate brief scaffold failed under FM_HOME"
-  brief="$home_one/data/task-c/brief.md"
+  brief="$home_one/data/tasks/_none/task-c/brief.md"
   grep -F ">> '$home_one/state/task-c.status'" "$brief" >/dev/null || fail "secondmate brief did not shell-quote FM_HOME state path"
 
   printf 'project=x\n' > "$home_one/state/task-a.meta"
@@ -169,7 +169,7 @@ test_home_seed_refuses_broken_registry_symlink() {
   [ -L "$home/data/secondmates.md" ] || fail "home seeding replaced the broken registry symlink"
   [ ! -e "$target" ] || fail "home seeding wrote through the broken registry symlink"
   [ ! -e "$sub" ] || fail "home seeding provisioned a home before broken registry refusal"
-  [ ! -e "$home/data/design" ] || fail "home seeding created a brief before broken registry refusal"
+  [ ! -e "$home/data/tasks/_none/design" ] || fail "home seeding created a brief before broken registry refusal"
   pass "home seeding refuses broken registry symlinks before provisioning"
 }
 
@@ -197,7 +197,7 @@ test_home_seed_refuses_unreadable_registry() {
   fi
   chmod 600 "$registry"
   [ ! -e "$sub" ] || fail "home seeding provisioned a home before unreadable registry refusal"
-  [ ! -e "$home/data/design" ] || fail "home seeding created a brief before unreadable registry refusal"
+  [ ! -e "$home/data/tasks/_none/design" ] || fail "home seeding created a brief before unreadable registry refusal"
   pass "home seeding refuses unreadable registries before provisioning"
 }
 
@@ -629,7 +629,7 @@ test_home_seed_refuses_projectful_reused_charter_for_projectless_home() {
   home="$TMP_ROOT/no-projects-reused-charter-home"
   reusable_sub="$TMP_ROOT/no-projects-reused-charter-valid-subhome"
   stale_sub="$TMP_ROOT/no-projects-reused-charter-stale-subhome"
-  stale_brief="$home/data/stale/brief.md"
+  stale_brief="$home/data/tasks/_none/stale/brief.md"
   stale_brief_before="$TMP_ROOT/no-projects-reused-charter.before"
   err="$TMP_ROOT/no-projects-reused-charter.err"
   mkdir -p "$home/data" "$home/state" "$reusable_sub/data" "$stale_sub/data"
@@ -638,7 +638,7 @@ test_home_seed_refuses_projectful_reused_charter_for_projectless_home() {
 
   scaffold_secondmate_charter "$home" reusable 'firstmate self-development' --no-projects \
     || fail "project-less charter scaffold failed"
-  printf '\n# Custom note\nThe projects above are local clones for work you supervise.\n' >> "$home/data/reusable/brief.md"
+  printf '\n# Custom note\nThe projects above are local clones for work you supervise.\n' >> "$home/data/tasks/_none/reusable/brief.md"
   FM_HOME="$home" "$ROOT/bin/fm-home-seed.sh" reusable "$reusable_sub" --no-projects >/dev/null \
     || fail "project-less seed rejected a reused project-less charter"
   assert_grep 'None. This is a project-less domain' "$reusable_sub/data/charter.md" \
@@ -2813,7 +2813,7 @@ test_secondmate_charter_brief_is_idle_by_default() {
   home="$TMP_ROOT/idle-charter-home"
   mkdir -p "$home/data" "$home/state"
   scaffold_secondmate_charter "$home" idle-sm 'feature work for alpha' alpha
-  brief="$home/data/idle-sm/brief.md"
+  brief="$home/data/tasks/_none/idle-sm/brief.md"
   [ -f "$brief" ] || fail "secondmate charter brief was not scaffolded"
   # Idle contract: waits for routed work, never self-initiates.
   grep -F 'go idle and wait silently for the main firstmate' "$brief" >/dev/null \

--- a/tests/fm-spawn-batch.test.sh
+++ b/tests/fm-spawn-batch.test.sh
@@ -96,7 +96,9 @@ test_projects_path_scoping() {
     fi
     status=$?
     [ "$status" -ne 0 ] || fail "$label: spawn with missing brief should fail"
-    expected="error: no brief at $home/data/$id/brief.md"
+    # Project-grouped by bin/fm-task-data-lib.sh; the clone is projects/alpha, so
+    # the brief the error names belongs to project "alpha".
+    expected="error: no brief at $home/data/tasks/alpha/$id/brief.md"
     printf '%s\n' "$out" | grep -F "$expected" >/dev/null \
       || fail "$label: projects/alpha was not resolved through the home before the brief check"
     printf '%s\n' "$out" | grep -F 'cd: projects/alpha' >/dev/null \

--- a/tests/fm-task-data.test.sh
+++ b/tests/fm-task-data.test.sh
@@ -253,6 +253,97 @@ test_protect_accepts_a_whole_project() {
   pass "fm-task-data.sh: protect and unprotect accept a whole project"
 }
 
+# Shaped like the captain's real home: the migration reports are ~169 LEGACY
+# folders sharing the id prefix cvui-, sitting inside the same front-client
+# project as unrelated tasks, and some legacy folders record no usable project
+# at all. The project is therefore the wrong key for that body of work and the
+# id prefix is the right one, so the protected set must be selectable by it.
+build_migration_fixture() {  # <name>
+  local home id
+  home=$(new_home "$1")
+  for id in cvui-vd28085-a1 cvui-font-pr-images cvui-token-refresh; do
+    mkdir -p "$home/data/$id"
+    printf 'migration report for %s\n' "$id" > "$home/data/$id/report.md"
+    printf 'PNGDATA\n' > "$home/data/$id/evidence.png"
+  done
+  # A legacy folder whose brief recorded no usable project, like cv4-a1 does.
+  mkdir -p "$home/data/cvui-unknown-project"
+  printf 'report\n' > "$home/data/cvui-unknown-project/report.md"
+  # The retrospective's own index: part of the body of work, but neither a brief
+  # nor a report, exactly like data/cvui-migration-retrospective/ on the real home.
+  mkdir -p "$home/data/cvui-migration-retrospective"
+  printf '# Index\n' > "$home/data/cvui-migration-retrospective/INDEX.md"
+  printf 'curation\n' > "$home/data/cvui-migration-retrospective/CURATION.md"
+  # An unrelated front-client task that must stay prunable.
+  scaffold_ship "$home" ab-density-fix front-client >/dev/null 2>&1 \
+    || fail "scaffold ab-density-fix failed"
+  printf '%s\n' "$home"
+}
+
+test_migration_reports_are_protectable_by_id_prefix() {
+  local home out
+  home=$(build_migration_fixture migration)
+
+  # The project is not the key: front-client holds both bodies of work, and one
+  # migration folder records no project at all.
+  out=$(run_tool "$home" list)
+  assert_contains "$out" "ab-density-fix" "the unrelated front-client task must be listed"
+  assert_contains "$out" "cvui-vd28085-a1" "a legacy migration folder must be listed"
+
+  # It is not listed before it is marked: it holds no brief and no report, and
+  # this tool deletes things, so an unrecognized folder stays out of the plan.
+  out=$(run_tool "$home" list)
+  assert_not_contains "$out" "cvui-migration-retrospective" \
+    "an unrecognized folder must not appear in a destructive tool's plan unmarked"
+
+  out=$(run_tool "$home" protect --task 'cvui-*')
+  assert_contains "$out" "5 folder(s) protected" \
+    "the id-prefix glob must reach every migration folder, including the one with no project and the index"
+  assert_present "$home/data/cvui-migration-retrospective/.protected" \
+    "the retrospective index must be markable even though it is neither brief nor report"
+  assert_present "$home/data/cvui-unknown-project/.protected" \
+    "a folder with no usable project must still be protectable"
+  assert_absent "$home/data/tasks/front-client/ab-density-fix/.protected" \
+    "an unrelated task in the same project must not be swept in"
+
+  # A prune of everything must leave the whole protected body of work standing.
+  out=$(run_tool "$home" prune --yes)
+  assert_contains "$out" "protected:" "the skip must be stated plainly"
+  assert_present "$home/data/cvui-vd28085-a1/report.md" "a migration report must survive"
+  assert_present "$home/data/cvui-token-refresh/report.md" "every migration report must survive"
+  assert_present "$home/data/cvui-unknown-project/report.md" \
+    "the no-project migration folder must survive"
+  assert_present "$home/data/cvui-migration-retrospective/INDEX.md" \
+    "the retrospective index must survive"
+  # Marking made it visible, so it is now accounted for rather than merely unseen.
+  out=$(run_tool "$home" list)
+  assert_contains "$out" "cvui-migration-retrospective" \
+    "a marked folder must become visible in the listing"
+  assert_absent "$home/data/tasks/front-client/ab-density-fix" \
+    "the unrelated task must still be pruned"
+
+  # Even a deliberate project-wide prune cannot take them.
+  out=$(run_tool "$home" prune --project front-client --yes)
+  assert_present "$home/data/cvui-font-pr-images/report.md" \
+    "a project-wide prune must not take the protected migration reports"
+  pass "fm-task-data.sh: the migration reports are protectable by their id prefix and survive a prune"
+}
+
+# The images are the bulk and age fastest; the reports are the deliverable. This
+# must work on the protected set too, since dropping pictures is not pruning the
+# body of work.
+test_images_only_on_protected_migration_keeps_every_report() {
+  local home out
+  home=$(build_migration_fixture migrationimages)
+  run_tool "$home" protect --task 'cvui-*' >/dev/null
+  out=$(run_tool "$home" prune --task 'cvui-*' --images-only --include-protected --yes)
+  assert_absent "$home/data/cvui-vd28085-a1/evidence.png" "the image must go"
+  assert_present "$home/data/cvui-vd28085-a1/report.md" "the report must stay"
+  assert_present "$home/data/cvui-font-pr-images/report.md" "every report must stay"
+  assert_present "$home/data/cvui-vd28085-a1/.protected" "the marker must stay"
+  pass "fm-task-data.sh: images-only on the protected migration set keeps every report"
+}
+
 test_images_only_leaves_every_md_intact() {
   local home out
   home=$(build_fixture imagesonly)
@@ -330,6 +421,8 @@ test_dry_run_removes_nothing
 test_in_flight_task_is_refused
 test_protected_folder_needs_the_override
 test_protect_accepts_a_whole_project
+test_migration_reports_are_protectable_by_id_prefix
+test_images_only_on_protected_migration_keeps_every_report
 test_images_only_leaves_every_md_intact
 test_filters_compose
 test_archive_moves_instead_of_deleting

--- a/tests/fm-task-data.test.sh
+++ b/tests/fm-task-data.test.sh
@@ -1,0 +1,310 @@
+#!/usr/bin/env bash
+# Behavior tests for the project-grouped task data layout (bin/fm-task-data-lib.sh)
+# and the list/archive/prune tool built on it (bin/fm-task-data.sh).
+#
+# The layout change is a read-path compatibility problem: an existing home has
+# hundreds of folders at the legacy data/<task-id>/ location and they must keep
+# resolving, while every new write lands under data/tasks/<project>/<task-id>/.
+# These tests drive that through the executable interfaces only.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-task-data)
+
+# A fresh home with both layouts populated: two project-grouped folders written
+# by the real scaffold, and one legacy folder placed by hand the way an existing
+# home already holds them.
+new_home() {  # <name>
+  local home="$TMP_ROOT/$1"
+  rm -rf "$home"
+  mkdir -p "$home/data" "$home/state" "$home/config" "$home/projects"
+  printf '%s\n' "$home"
+}
+
+scaffold_ship() {  # <home> <task-id> <project> [title]
+  FM_HOME="$1" FM_DATA_OVERRIDE="$1/data" FM_STATE_OVERRIDE="$1/state" \
+    "$ROOT/bin/fm-brief.sh" "$2" "$3" --mode direct-PR --title "${4:-$2}"
+}
+
+run_tool() {  # <home> <args...>
+  local home=$1
+  shift
+  FM_HOME="$home" FM_DATA_OVERRIDE="$home/data" FM_STATE_OVERRIDE="$home/state" \
+    "$ROOT/bin/fm-task-data.sh" "$@"
+}
+
+# --- Part 1: layout and backward compatibility ------------------------------
+
+test_scaffold_writes_project_grouped_path() {
+  local home out
+  home=$(new_home scaffold)
+  out=$(scaffold_ship "$home" alpha-task front-client "Fix the grid" 2>&1) \
+    || fail "scaffold failed: $out"
+  assert_present "$home/data/tasks/front-client/alpha-task/brief.md" \
+    "a fresh scaffold must write under data/tasks/<project>/<task-id>/"
+  assert_absent "$home/data/alpha-task/brief.md" \
+    "a fresh scaffold must not write the legacy path"
+  pass "fm-brief.sh: a fresh scaffold writes the project-grouped path"
+}
+
+test_marker_records_project_title_and_date() {
+  local home marker
+  home=$(new_home marker)
+  scaffold_ship "$home" beta-task vega-ui "Port the dialog" >/dev/null 2>&1 \
+    || fail "scaffold failed"
+  marker="$home/data/tasks/vega-ui/beta-task/task.meta"
+  assert_present "$marker" "the scaffold must write the grouping marker"
+  assert_grep 'project=vega-ui' "$marker" "marker must record the project"
+  assert_grep 'title=Port the dialog' "$marker" "marker must record the title"
+  assert_grep "created=$(date -u +%Y-%m-%d)" "$marker" \
+    "marker must record the creation date"
+  pass "fm-brief.sh: the marker records project, title, and creation date"
+}
+
+test_title_never_enters_the_path() {
+  local home
+  home=$(new_home titlepath)
+  scaffold_ship "$home" gamma-task front-client "A Title With Spaces" >/dev/null 2>&1 \
+    || fail "scaffold failed"
+  assert_present "$home/data/tasks/front-client/gamma-task/brief.md" \
+    "the path must be the task id alone, never the title"
+  pass "fm-brief.sh: a reworded title cannot move the folder"
+}
+
+test_project_less_task_uses_the_documented_literal() {
+  local home
+  home=$(new_home noproject)
+  FM_SECONDMATE_CHARTER='A charter.' \
+  FM_HOME="$home" FM_DATA_OVERRIDE="$home/data" FM_STATE_OVERRIDE="$home/state" \
+    "$ROOT/bin/fm-brief.sh" delta-mate --secondmate --no-projects >/dev/null 2>&1 \
+    || fail "secondmate scaffold failed"
+  assert_present "$home/data/tasks/_none/delta-mate/brief.md" \
+    "a task with no project must use the _none literal"
+  pass "fm-brief.sh: a project-less task uses the documented _none literal"
+}
+
+# Every read-path caller must find a task whose data exists only at the legacy
+# location, and none of them may create a second copy at the new path.
+test_legacy_folder_is_found_by_every_reader() {
+  local home out rc
+  home=$(new_home legacy)
+  mkdir -p "$home/data/legacy-task"
+  printf 'legacy brief\n' > "$home/data/legacy-task/brief.md"
+  printf 'legacy report\n' > "$home/data/legacy-task/report.md"
+
+  # fm-spawn.sh resolves the brief before it validates anything else, so an
+  # unresolvable brief is the distinguishable failure this asserts against.
+  out=$(FM_HOME="$home" FM_DATA_OVERRIDE="$home/data" FM_STATE_OVERRIDE="$home/state" \
+    "$ROOT/bin/fm-spawn.sh" legacy-task nonexistent-project --mode direct-PR 2>&1); rc=$?
+  [ "$rc" -eq 0 ] && fail "fm-spawn.sh unexpectedly succeeded"
+  assert_not_contains "$out" "no brief at" \
+    "fm-spawn.sh must resolve a legacy task data directory"
+
+  # fm-control.sh relaunch reaches the same brief resolution.
+  out=$(FM_HOME="$home" FM_DATA_OVERRIDE="$home/data" FM_STATE_OVERRIDE="$home/state" \
+    "$ROOT/bin/fm-control.sh" legacy-task relaunch 2>&1 || true)
+  assert_not_contains "$out" "has no instructions at" \
+    "fm-control.sh must resolve a legacy task data directory"
+
+  # fm-captain-hold.sh treats a present report as proof the origin exists here.
+  out=$(FM_HOME="$home" FM_DATA_OVERRIDE="$home/data" FM_STATE_OVERRIDE="$home/state" \
+    FM_CONFIG_OVERRIDE="$home/config" \
+    "$ROOT/bin/fm-captain-hold.sh" verify legacy-task 2>&1 || true)
+  assert_not_contains "$out" "unknown origin" \
+    "fm-captain-hold.sh must resolve a legacy task data directory"
+
+  # fm-teardown.sh refuses a scout with no report; the legacy report satisfies it.
+  out=$(FM_HOME="$home" FM_DATA_OVERRIDE="$home/data" FM_STATE_OVERRIDE="$home/state" \
+    FM_CONFIG_OVERRIDE="$home/config" \
+    "$ROOT/bin/fm-teardown.sh" legacy-task 2>&1 || true)
+  assert_not_contains "$out" "has no report at" \
+    "fm-teardown.sh must resolve a legacy task data directory"
+
+  # The listing tool is the fifth reader and must see the folder as one task.
+  out=$(run_tool "$home" list)
+  assert_contains "$out" "legacy-task" "the tool must list a legacy folder"
+
+  assert_absent "$home/data/tasks/legacy-task" \
+    "no reader may duplicate a legacy task into the new layout"
+  [ ! -d "$home/data/tasks" ] || [ -z "$(find "$home/data/tasks" -name legacy-task -print -quit)" ] \
+    || fail "a legacy task was duplicated under data/tasks/"
+  pass "layout: a legacy-only task is found by every reader and never duplicated"
+}
+
+test_write_reuses_an_existing_legacy_directory() {
+  local home out
+  home=$(new_home legacywrite)
+  mkdir -p "$home/data/split-task"
+  printf 'evidence\n' > "$home/data/split-task/screenshot-note.md"
+  out=$(scaffold_ship "$home" split-task front-client 2>&1) || fail "scaffold failed: $out"
+  assert_present "$home/data/split-task/brief.md" \
+    "a task with legacy data must keep writing there"
+  assert_present "$home/data/split-task/task.meta" \
+    "the marker must join the existing folder, not a second one"
+  assert_absent "$home/data/tasks/front-client/split-task" \
+    "one task's record must never be split across two locations"
+  pass "layout: a task with legacy data keeps using it rather than splitting"
+}
+
+test_top_level_data_files_are_untouched() {
+  local home out
+  home=$(new_home toplevel)
+  printf '## In flight\n' > "$home/data/backlog.md"
+  printf 'captain\n' > "$home/data/captain.md"
+  mkdir -p "$home/data/handoff"
+  scaffold_ship "$home" epsilon-task vega-ui >/dev/null 2>&1 || fail "scaffold failed"
+  out=$(run_tool "$home" list)
+  assert_not_contains "$out" "backlog.md" "top-level data files are not task folders"
+  assert_not_contains "$out" "handoff" "data/handoff/ is not a task folder"
+  assert_present "$home/data/backlog.md" "backlog.md must be untouched"
+  pass "layout: data/ keeps its own top-level files and directories"
+}
+
+# --- Part 3: the prune tool -------------------------------------------------
+
+# One fixture home with folders in both layouts, an in-flight task, a protected
+# folder, and images alongside words.
+build_fixture() {  # <name>
+  local home
+  home=$(new_home "$1")
+  scaffold_ship "$home" ship-a front-client >/dev/null 2>&1 || fail "scaffold ship-a failed"
+  scaffold_ship "$home" ship-b vega-ui >/dev/null 2>&1 || fail "scaffold ship-b failed"
+  scaffold_ship "$home" ship-live front-client >/dev/null 2>&1 || fail "scaffold ship-live failed"
+  mkdir -p "$home/data/old-legacy"
+  printf 'legacy report\n' > "$home/data/old-legacy/report.md"
+  printf 'PNGDATA\n' > "$home/data/old-legacy/shot.PNG"
+
+  printf 'report words\n' > "$home/data/tasks/front-client/ship-a/report.md"
+  printf 'PNGDATA\n' > "$home/data/tasks/front-client/ship-a/before.png"
+  printf 'JPGDATA\n' > "$home/data/tasks/front-client/ship-a/after.jpeg"
+  printf 'report words\n' > "$home/data/tasks/vega-ui/ship-b/report.md"
+
+  # ship-live is still working: teardown removes this record, so its presence is
+  # what marks a task as unfinished.
+  printf 'kind=ship\n' > "$home/state/ship-live.meta"
+  printf '%s\n' "$home"
+}
+
+test_dry_run_removes_nothing() {
+  local home out
+  home=$(build_fixture dryrun)
+  out=$(run_tool "$home" prune)
+  assert_contains "$out" "DRY RUN" "prune must default to a dry run"
+  assert_contains "$out" "nothing was changed" "the dry run must say it changed nothing"
+  assert_present "$home/data/tasks/front-client/ship-a/report.md" "dry run must keep new-layout data"
+  assert_present "$home/data/tasks/front-client/ship-a/before.png" "dry run must keep images"
+  assert_present "$home/data/old-legacy/report.md" "dry run must keep legacy-layout data"
+  assert_contains "$out" "ship-a" "the dry run must print what it would remove"
+  assert_contains "$out" "old-legacy" "the dry run must cover both layouts"
+  pass "fm-task-data.sh: the dry run is the default and removes nothing"
+}
+
+test_in_flight_task_is_refused() {
+  local home out
+  home=$(build_fixture inflight)
+  out=$(run_tool "$home" prune --yes)
+  assert_contains "$out" "in flight" "an unfinished task must be named as skipped"
+  assert_present "$home/data/tasks/front-client/ship-live/brief.md" \
+    "an unfinished task's folder must survive"
+  pass "fm-task-data.sh: a task that is not finished is refused and named"
+}
+
+test_protected_folder_needs_the_override() {
+  local home out
+  home=$(build_fixture protected)
+  out=$(run_tool "$home" protect ship-a)
+  assert_contains "$out" "protected:" "protect must report what it marked"
+
+  out=$(run_tool "$home" prune --project front-client --yes)
+  assert_contains "$out" "protected:" "a protected skip must be stated plainly"
+  assert_present "$home/data/tasks/front-client/ship-a/report.md" \
+    "a protected folder must survive without the override"
+
+  out=$(run_tool "$home" prune --project front-client --include-protected --yes)
+  assert_absent "$home/data/tasks/front-client/ship-a" \
+    "--include-protected must remove a protected folder"
+  pass "fm-task-data.sh: a protected folder is skipped without the override and removed with it"
+}
+
+test_images_only_leaves_every_md_intact() {
+  local home out
+  home=$(build_fixture imagesonly)
+  out=$(run_tool "$home" prune --images-only --yes)
+  assert_contains "$out" "images only" "the plan must say images only"
+  assert_absent "$home/data/tasks/front-client/ship-a/before.png" "png must go"
+  assert_absent "$home/data/tasks/front-client/ship-a/after.jpeg" "jpeg must go"
+  assert_absent "$home/data/old-legacy/shot.PNG" "an uppercase extension must go"
+  assert_present "$home/data/tasks/front-client/ship-a/report.md" "report.md must stay"
+  assert_present "$home/data/tasks/front-client/ship-a/brief.md" "brief.md must stay"
+  assert_present "$home/data/tasks/vega-ui/ship-b/report.md" "every other report must stay"
+  assert_present "$home/data/old-legacy/report.md" "a legacy report must stay"
+  assert_present "$home/data/tasks/front-client/ship-a/task.meta" "the marker must stay"
+  [ -z "$(find "$home/data" -name '*.md' -newer "$home/data" -size 0 -print -quit)" ] \
+    || fail "an .md file was emptied"
+  pass "fm-task-data.sh: images-only leaves every .md intact"
+}
+
+test_filters_compose() {
+  local home out
+  home=$(build_fixture filters)
+  out=$(run_tool "$home" prune --project vega-ui)
+  assert_contains "$out" "ship-b" "the project filter must select its own project"
+  assert_not_contains "$out" "ship-a" "the project filter must exclude other projects"
+
+  out=$(run_tool "$home" prune --task ship-a)
+  assert_contains "$out" "ship-a" "the task filter must select its task"
+  assert_not_contains "$out" "ship-b" "the task filter must exclude other tasks"
+
+  # Nothing in the fixture is older than a day, so age composes to an empty set.
+  out=$(run_tool "$home" prune --project vega-ui --older-than 1)
+  assert_contains "$out" "nothing selected" "composed filters must intersect"
+  pass "fm-task-data.sh: project, task, and age filters compose"
+}
+
+test_archive_moves_instead_of_deleting() {
+  local home out archive
+  home=$(build_fixture archive)
+  archive="$TMP_ROOT/archive-store"
+  rm -rf "$archive"
+  out=$(run_tool "$home" prune --task ship-b --archive "$archive" --yes)
+  assert_contains "$out" "archived:" "archiving must report what it moved"
+  assert_absent "$home/data/tasks/vega-ui/ship-b/report.md" "the source file must move"
+  assert_present "$archive/vega-ui/ship-b/report.md" "the archive must hold the file"
+  pass "fm-task-data.sh: --archive moves instead of deleting"
+}
+
+test_second_run_is_safe() {
+  local home first second
+  home=$(build_fixture idempotent)
+  first=$(run_tool "$home" prune --task ship-a --yes 2>&1) || fail "first run failed: $first"
+  second=$(run_tool "$home" prune --task ship-a --yes 2>&1) || fail "second run failed: $second"
+  assert_contains "$second" "nothing selected" "a repeated prune must be a no-op"
+  pass "fm-task-data.sh: running twice is safe"
+}
+
+test_scripts_parse() {
+  local out rc
+  for script in bin/fm-task-data-lib.sh bin/fm-task-data.sh; do
+    out=$(bash -n "$ROOT/$script" 2>&1); rc=$?
+    expect_code 0 "$rc" "bash -n $script must parse cleanly (got: $out)"
+  done
+  pass "fm-task-data: both scripts parse cleanly"
+}
+
+test_scripts_parse
+test_scaffold_writes_project_grouped_path
+test_marker_records_project_title_and_date
+test_title_never_enters_the_path
+test_project_less_task_uses_the_documented_literal
+test_legacy_folder_is_found_by_every_reader
+test_write_reuses_an_existing_legacy_directory
+test_top_level_data_files_are_untouched
+test_dry_run_removes_nothing
+test_in_flight_task_is_refused
+test_protected_folder_needs_the_override
+test_images_only_leaves_every_md_intact
+test_filters_compose
+test_archive_moves_instead_of_deleting
+test_second_run_is_safe

--- a/tests/fm-task-data.test.sh
+++ b/tests/fm-task-data.test.sh
@@ -228,6 +228,31 @@ test_protected_folder_needs_the_override() {
   pass "fm-task-data.sh: a protected folder is skipped without the override and removed with it"
 }
 
+# The captain's standing rule is that a whole body of work (the co-invest
+# migration reports) is never pruned, so protection must be settable across a
+# project in one command rather than id by id.
+test_protect_accepts_a_whole_project() {
+  local home out
+  home=$(build_fixture protectproject)
+  out=$(run_tool "$home" protect --project front-client)
+  assert_contains "$out" "folder(s) protected" "bulk protect must report a count"
+  assert_present "$home/data/tasks/front-client/ship-a/.protected" \
+    "every folder in the project must be marked"
+  assert_absent "$home/data/tasks/vega-ui/ship-b/.protected" \
+    "another project must not be marked"
+
+  out=$(run_tool "$home" prune --yes)
+  assert_present "$home/data/tasks/front-client/ship-a/report.md" \
+    "a bulk-protected project must survive a prune"
+  assert_absent "$home/data/tasks/vega-ui/ship-b" \
+    "an unprotected project must still be pruned"
+
+  out=$(run_tool "$home" unprotect --project front-client)
+  assert_absent "$home/data/tasks/front-client/ship-a/.protected" \
+    "unprotect must clear the marker across the project"
+  pass "fm-task-data.sh: protect and unprotect accept a whole project"
+}
+
 test_images_only_leaves_every_md_intact() {
   local home out
   home=$(build_fixture imagesonly)
@@ -304,6 +329,7 @@ test_top_level_data_files_are_untouched
 test_dry_run_removes_nothing
 test_in_flight_task_is_refused
 test_protected_folder_needs_the_override
+test_protect_accepts_a_whole_project
 test_images_only_leaves_every_md_intact
 test_filters_compose
 test_archive_moves_instead_of_deleting


### PR DESCRIPTION
## The reported problem was not the real one

The report was that a crewmate spawned by a **secondmate** gets no nested Herdr projection workspace, while a crewmate spawned by the **primary** does.

That asymmetry does not exist. `tests/fm-backend-herdr-presentation-e2e.test.sh` already proved, before this change, that a secondmate home's crewmates get nested workspaces (`└ a1 · p:<token>` under `2ndmate-alpha`), and the live secondmate's own journal recorded a fully bound version 2 projection into `w34` under `w32` - a binding only written after the workspace, tab, pane, parent and label are all verified live. Its first spawn projected correctly.

## Confirmed cause

**Once a task's projected workspace disappears while its task record survives, that task can never be projected again.** Every later spawn of that id lands as a flat tab in whichever workspace its home owns.

The chain:

1. A task's first spawn projects into its own workspace and publishes a version 2 journal binding it.
2. The projected workspace goes away **outside** the exact-pane cleanup path - the captain closes it, or Herdr removes it when its last pane dies.
3. `bin/fm-teardown.sh` retires the journal only when `fm_backend_herdr_projection_endpoint_matches_journal` can still correlate the recorded endpoint with a live token-bearing workspace. With the workspace gone, that correlation fails, so teardown warns and **keeps** the journal.
4. In `bin/fm-spawn.sh`, the presence of a journal was the sole gate between two arms. An existing journal took the recovery arm; only a task with neither journal nor metadata could reach the fresh-projection arm.
5. The recovery arm can only **reclaim an existing husk**. With no husk left, `fm_backend_herdr_projection_reclaim_task` returns 2 (non-mutating refusal) and the spawn falls back flat - while leaving the orphaned journal in place, so the next spawn repeats step 4. Forever.

`bin/fm-herdr-session-cleanup.sh` does not rescue this: it retires a journal only when the workspace still exists **and** task metadata is absent. Here the workspace is gone and the metadata is present, so it never matches.

### Evidence establishing it

Live secondmate records, 2026-08-23:

- `state/shadowtorch-build-a.herdr-presentation` (mtime 10:34) - a complete version 2 binding to `w34` under `parent_workspace_id=w32`.
- `state/shadowtorch-build-a.meta` - `spawn_gen=s1787478578` (10:49:38), `window=default:w32:p5`. A **fresh spawn 15 minutes later**, landing flat inside the secondmate's own workspace.
- `w34` absent from `herdr workspace list`.

The 15-minute gap between the bound journal and the metadata's spawn incarnation is what identifies this as a re-spawn over a lost workspace, not a first spawn that failed to project.

### The disconfirming test

The leading explanation predicts the **primary** path should fail identically under the same condition. It does. In the lab fixture the primary home fails first:

```
not ok - orphan-primary respawn fell back to the flat firstmate container instead of a new nested space: firstmate
```

`herdr workspace list` around that respawn, on unmodified code:

```
=== orphan-primary: workspace list BEFORE the respawn (its projected space is gone) ===
w1      firstmate
wJ      └ p1 · p:tZjzzKdcmd60sb3Mdakpxw
wK      └ p2 · p:WNEcO9pxaAhngHg042ROng
wR      └ pcw · p:1wSx-5OZDNDKHu4yZqDoEQ
w3      2ndmate-alpha
...
=== orphan-primary: workspace list AFTER the respawn ===
w1      firstmate
wJ      └ p1 · p:tZjzzKdcmd60sb3Mdakpxw
wK      └ p2 · p:WNEcO9pxaAhngHg042ROng
wR      └ pcw · p:1wSx-5OZDNDKHu4yZqDoEQ
w3      2ndmate-alpha
...
respawn landed in: w1   firstmate
```

No new workspace at all - the worker landed in the primary's own container. That rules out the secondmate-specific explanation.

## The fix

`fm_backend_herdr_projection_recovery_allows_flat` already distinguished "no token-bearing workspace survives" (count 0) from "an agent-free husk exists" (count >= 1), but used the distinction only for its own warning text. It now publishes that count as `FM_BACKEND_HERDR_PROJECTION_RECOVERY_MATCHES`, left empty on every refusal so a stale count can never be read as a verdict.

`bin/fm-spawn.sh` consumes it: when the count is 0, it retires the orphaned journal and takes the ordinary fresh-projection path instead of the flat fallback.

This is safe because both existing guards have already run at that point:

- `herdr_projection_existing_meta_allows_flat` proved the recorded endpoint dead or agent-free.
- `fm_backend_herdr_projection_recovery_allows_flat` proved no token match survives - so there is nothing left to preserve, adopt, or contradict.

Those are exactly the guards that already authorized the flat fallback. Every other recovery outcome is unchanged, and the structural change is only that the fresh-projection body moved from an `elif` arm to its own `if` guarded by a flag both arms can set.

## Verification

Real Herdr 0.8.2 protocol 20, isolated non-default lab session via `bin/fm-herdr-lab.sh`, real spawn/teardown, real Treehouse. New scenario in `tests/fm-backend-herdr-presentation-e2e.test.sh` runs the same fixture in a primary home **and** a secondmate home.

After the fix, both re-project under their own parent:

```
=== orphan-primary: workspace list AFTER the respawn ===
w1      firstmate
wJ      └ p1 · p:SPUXoSq5OXPu1fWOFCXD7g
wK      └ p2 · p:zYF7R4-YXq3tP-TB083XHw
wR      └ pcw · p:D7BA0k08Eud_gCI9q0Azzg
wY      └ orphan-primary · p:sHVC1J9sVCIn3MBjcHSnkw
w3      2ndmate-alpha
...
respawn landed in: wY   └ orphan-primary · p:sHVC1J9sVCIn3MBjcHSnkw

=== orphan-second: workspace list AFTER the respawn ===
w3      2ndmate-alpha
wM      └ a1 · p:HdaMBKRQSicSVhmyh7VPBg
wN      └ a2 · p:VNLNWezzOsWkfqOgE2m8aQ
w0      └ orphan-second · p:p5_Fl_W2iPz1Xb3Uro8TxA
w4      2ndmate-bravo
...
respawn landed in: w0   └ orphan-second · p:p5_Fl_W2iPz1Xb3Uro8TxA
```

The primary path is proven by the same fixture in the same run, so this is not a trade of one path for the other. The suite's own pre-existing primary scenarios (contiguous child blocks, same-identity reclaim, ordering, focus preservation, teardown) all still pass.

```
$ bash tests/fm-backend-herdr-presentation-e2e.test.sh
24 ok, 0 not ok
ok - real Herdr lab: a lost projected workspace re-projects under its own parent in primary and secondmate homes
ok - real Herdr lab validation completed on Herdr 0.8.2 with the default-session tripwire intact
```

Lint, with both pinned linters present:

```
fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)
fm-lint-workflows.sh: actionlint 1.7.12 (pinned 1.7.12)
fm-lint-workflows.sh: 3 workflow files valid
```

`bin/fm-doc-audience-check.sh: ok surfaces=73 local_links=266`.

The wider `--changed` selection (58 scripts) passes apart from two failures that reproduce identically on unmodified `origin/main` with the same two source files restored - see below.

The live captain fleet was never touched: every lifecycle call went through the guarded lab helper against a named non-`default` session, and each run ended with the default-session tripwire verified intact.

## Docs

- `docs/herdr-backend.md` - the "existing journal suppresses another projected create" and "absent tokens fall back flat" statements were the contract this change alters; both corrected in place, with the new re-projection case stated once.
- `docs/verification/runtime-backends.md` - dated 2026-08-23 record of the guarantee on Herdr 0.8.2 protocol 20, including the before-fix `respawn landed in: w1 firstmate` observation.
- `bin/fm-spawn.sh` header - the projection contract it owns.

## Not fixed here

**Two pre-existing test failures**, both reproducing on unmodified `origin/main` and both outside this change's subsystem. They appear only because `--changed` selects a wide net.

- `tests/fm-backend-tmux-smoke.test.sh` - `the tmux task shell did not complete setup`. The test sends `cd /tmp && PS1='smoke$ ' && clear && ...` as POSIX shell syntax; on a machine whose tmux default shell is fish that assignment errors (`fish: Unsupported use of '='`). The preceding shell-readiness probe passes because it is a bare `printf`. Environment-portability bug in that test, not a product defect.
- `tests/fm-calm-pi-extension.test.sh` - `Pi follow-up loaded-on case (loaded_on) did not reach the ready composer`. Live Pi harness; not investigated further.

**Migration for already-orphaned records.** This change fixes the next spawn of an affected task, which is enough to recover the live secondmate's worker on its next start. It does not sweep existing orphaned journals; the live stale `w34` record was deliberately left untouched, as the task instructed. A sweep would belong in `bin/fm-herdr-session-cleanup.sh`, whose current match requires the workspace to exist and the metadata to be absent - it would need to also accept "workspace gone, metadata present". Worth deciding separately.

**Recovery-path lock contention.** One concurrent cross-home recovery run refused under load with `could not acquire its session lock`. Already recorded in `docs/verification/runtime-backends.md` as a deliberate hard refusal, unchanged and unaffected by this work.
