### PR TITLE
fix(bin): let spawns proceed on projects with no origin remote

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -138,6 +138,9 @@
 #   origin, resolves the current remote default branch, and resets to its tip.
 #   An unreachable origin, unresolved default branch, or non-clean worktree
 #   refuses the spawn rather than risking a PR based on stale history.
+#   A repository with no origin remote configured has no upstream to be stale
+#   against, so that refresh is skipped with a loud notice and the spawn
+#   continues; only a configured remote can make a base unverifiable.
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
@@ -1727,8 +1730,28 @@ validate_spawn_worktree() {  # <source> <inspect-target>
   fi
 }
 
+# Freshening asks one question: is this worktree's base stale against its
+# upstream? A repository with no origin configured has no upstream, so that
+# question is meaningless rather than failed, and the spawn proceeds from the
+# base it already has. A project that lives only on one machine is a supported
+# shape, so refusing it would strand every fresh task worktree on that project.
+# The distinction is drawn on whether a remote is CONFIGURED, read from git's own
+# local remote list, which makes no network call. A configured origin that cannot
+# be reached still falls through to the strict path below and refuses loudly, so a
+# network outage on an ordinary project is never reclassified as "no remote".
+# This belongs inside the freshening function, not at its call site: the
+# freshening contract - including when it does not apply - stays with its one
+# owner, so no caller has to know what makes a base refresh meaningful.
 freshen_spawn_worktree_base() {  # <worktree>
-  local worktree=$1 default target expected actual status
+  local worktree=$1 default target expected actual status remotes
+  remotes=$(git -C "$worktree" remote) || {
+    echo "error: could not read the configured remotes of pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
+    return 1
+  }
+  if ! printf '%s\n' "$remotes" | grep -qx origin; then
+    echo "notice: pooled worktree '$worktree' has no origin remote configured; skipping the base refresh because there is no upstream it can be stale against" >&2
+    return 0
+  fi
   if ! git -C "$worktree" fetch --quiet origin; then
     echo "error: could not fetch origin for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
     return 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -142,7 +142,10 @@
 #   against, so that refresh is skipped with a loud notice and the spawn
 #   continues; only a configured remote can make a base unverifiable. A pooled
 #   worktree carrying uncommitted work is still refused on that path, because a
-#   new task must never start on top of another task's unlanded work.
+#   new task must never start on top of another task's unlanded work, and so is
+#   one whose HEAD has left the local default branch tip, which is how committed
+#   leftovers show up. That refusal names the worktree, the commit it sits on,
+#   and the branch tip expected, and never discards those commits itself.
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
@@ -1755,6 +1758,10 @@ spawn_worktree_is_clean() {  # <worktree>
 # Skipping the refresh never skips the unlanded-work refusal: a pooled worktree
 # carrying uncommitted files must not silently become the base of a new task,
 # and that risk is identical with or without an upstream.
+# Committed leftovers read as clean, so the no-origin path also requires HEAD to
+# sit on the local default branch tip. It refuses rather than resetting: with no
+# remote, a leftover commit may be the only copy of that work anywhere, so a
+# person decides its fate instead of a pool slot being tidied at its expense.
 freshen_spawn_worktree_base() {  # <worktree>
   local worktree=$1 default target expected actual remotes
   remotes=$(git -C "$worktree" remote) || {
@@ -1773,6 +1780,19 @@ freshen_spawn_worktree_base() {  # <worktree>
         return 1
         ;;
     esac
+    default=$(default_branch "$worktree") || {
+      echo "error: could not determine the local default branch for pooled worktree '$worktree'; refusing to launch from an unverifiable base" >&2
+      return 1
+    }
+    expected=$(git -C "$worktree" rev-parse --verify --quiet "refs/heads/$default^{commit}" 2>/dev/null) || {
+      echo "error: local default branch '$default' is not a commit for pooled worktree '$worktree'; refusing to launch from an unverifiable base" >&2
+      return 1
+    }
+    actual=$(git -C "$worktree" rev-parse --verify --quiet HEAD 2>/dev/null || true)
+    if [ "$actual" != "$expected" ]; then
+      echo "error: pooled worktree '$worktree' is sitting on commit '${actual:-unknown}', not the tip of its local default branch '$default' ('$expected'); refusing to start a new task on top of commits that are not on '$default'. Inspect that worktree and decide what to do with those commits before it is reused" >&2
+      return 1
+    fi
     echo "notice: pooled worktree '$worktree' has no origin remote configured; skipping the base refresh because there is no upstream it can be stale against" >&2
     return 0
   fi

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1743,6 +1743,27 @@ spawn_worktree_is_clean() {  # <worktree>
   [ -z "$status" ]
 }
 
+# The local default branch of a repository with no origin remote.
+# origin/HEAD can never exist there, so the shared resolver's main/master
+# fallback is the first attempt, and a custom-named default then falls back to
+# the branch the repository's own HEAD names, read from the shared git dir so a
+# detached pooled worktree still resolves it.
+# Both readings are local; no network call is made.
+spawn_local_default_branch() {  # <worktree>
+  local worktree=$1 common ref
+  if default_branch "$worktree"; then
+    return 0
+  fi
+  common=$(git -C "$worktree" rev-parse --git-common-dir 2>/dev/null) || return 1
+  case $common in
+    /*) ;;
+    *) common="$worktree/$common" ;;
+  esac
+  ref=$(git --git-dir "$common" symbolic-ref --quiet --short HEAD 2>/dev/null) || return 1
+  [ -n "$ref" ] || return 1
+  printf '%s\n' "$ref"
+}
+
 # Freshening asks one question: is this worktree's base stale against its
 # upstream? A repository with no origin configured has no upstream, so that
 # question is meaningless rather than failed, and the spawn proceeds from the
@@ -1780,7 +1801,7 @@ freshen_spawn_worktree_base() {  # <worktree>
         return 1
         ;;
     esac
-    default=$(default_branch "$worktree") || {
+    default=$(spawn_local_default_branch "$worktree") || {
       echo "error: could not determine the local default branch for pooled worktree '$worktree'; refusing to launch from an unverifiable base" >&2
       return 1
     }

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -140,7 +140,9 @@
 #   refuses the spawn rather than risking a PR based on stale history.
 #   A repository with no origin remote configured has no upstream to be stale
 #   against, so that refresh is skipped with a loud notice and the spawn
-#   continues; only a configured remote can make a base unverifiable.
+#   continues; only a configured remote can make a base unverifiable. A pooled
+#   worktree carrying uncommitted work is still refused on that path, because a
+#   new task must never start on top of another task's unlanded work.
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
@@ -1730,6 +1732,14 @@ validate_spawn_worktree() {  # <source> <inspect-target>
   fi
 }
 
+# One reading of a pooled worktree's uncommitted state, shared by both the
+# refresh path and the no-origin skip: 0 clean, 1 dirty, 2 unreadable.
+spawn_worktree_is_clean() {  # <worktree>
+  local status
+  status=$(git -C "$1" status --porcelain) || return 2
+  [ -z "$status" ]
+}
+
 # Freshening asks one question: is this worktree's base stale against its
 # upstream? A repository with no origin configured has no upstream, so that
 # question is meaningless rather than failed, and the spawn proceeds from the
@@ -1742,13 +1752,27 @@ validate_spawn_worktree() {  # <source> <inspect-target>
 # This belongs inside the freshening function, not at its call site: the
 # freshening contract - including when it does not apply - stays with its one
 # owner, so no caller has to know what makes a base refresh meaningful.
+# Skipping the refresh never skips the unlanded-work refusal: a pooled worktree
+# carrying uncommitted files must not silently become the base of a new task,
+# and that risk is identical with or without an upstream.
 freshen_spawn_worktree_base() {  # <worktree>
-  local worktree=$1 default target expected actual status remotes
+  local worktree=$1 default target expected actual remotes
   remotes=$(git -C "$worktree" remote) || {
     echo "error: could not read the configured remotes of pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
     return 1
   }
   if ! printf '%s\n' "$remotes" | grep -qx origin; then
+    spawn_worktree_is_clean "$worktree"
+    case $? in
+      1)
+        echo "error: pooled worktree '$worktree' has uncommitted work; refusing to start a new task on top of it" >&2
+        return 1
+        ;;
+      2)
+        echo "error: could not inspect pooled worktree '$worktree' for uncommitted work; refusing to launch" >&2
+        return 1
+        ;;
+    esac
     echo "notice: pooled worktree '$worktree' has no origin remote configured; skipping the base refresh because there is no upstream it can be stale against" >&2
     return 0
   fi
@@ -1773,14 +1797,17 @@ freshen_spawn_worktree_base() {  # <worktree>
     echo "error: '$target' is not a commit for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
     return 1
   }
-  status=$(git -C "$worktree" status --porcelain) || {
-    echo "error: could not inspect pooled worktree '$worktree' before refreshing its base" >&2
-    return 1
-  }
-  if [ -n "$status" ]; then
-    echo "error: pooled worktree '$worktree' is not clean; refusing to discard uncommitted work while refreshing its base" >&2
-    return 1
-  fi
+  spawn_worktree_is_clean "$worktree"
+  case $? in
+    1)
+      echo "error: pooled worktree '$worktree' is not clean; refusing to discard uncommitted work while refreshing its base" >&2
+      return 1
+      ;;
+    2)
+      echo "error: could not inspect pooled worktree '$worktree' before refreshing its base" >&2
+      return 1
+      ;;
+  esac
   if ! git -C "$worktree" reset --hard "$target" >/dev/null; then
     echo "error: could not reset pooled worktree '$worktree' to '$target'; refusing to launch from a potentially stale base" >&2
     return 1

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1745,23 +1745,27 @@ spawn_worktree_is_clean() {  # <worktree>
 
 # The local default branch of a repository with no origin remote.
 # origin/HEAD can never exist there, so the shared resolver's main/master
-# fallback is the first attempt, and a custom-named default then falls back to
-# the branch the repository's own HEAD names, read from the shared git dir so a
-# detached pooled worktree still resolves it.
+# fallback is the first attempt, and a custom-named default then resolves only
+# when the repository has exactly one local branch, because that lone branch is
+# the only thing "default" can mean without an upstream.
+# The primary checkout's HEAD is deliberately not consulted: it names whatever
+# branch happens to be checked out, so a primary stranded on a feature branch
+# would bless that feature tip as the default and let a pooled worktree sitting
+# on prior committed feature work slip past the leftover refusal below.
+# Several branches with no main or master is genuinely ambiguous, so it returns
+# nonzero and the caller refuses loudly instead of guessing.
 # Both readings are local; no network call is made.
 spawn_local_default_branch() {  # <worktree>
-  local worktree=$1 common ref
+  local worktree=$1 heads
   if default_branch "$worktree"; then
     return 0
   fi
-  common=$(git -C "$worktree" rev-parse --git-common-dir 2>/dev/null) || return 1
-  case $common in
-    /*) ;;
-    *) common="$worktree/$common" ;;
+  heads=$(git -C "$worktree" for-each-ref --format='%(refname:short)' refs/heads 2>/dev/null) || return 1
+  [ -n "$heads" ] || return 1
+  case $heads in
+    *$'\n'*) return 1 ;;
   esac
-  ref=$(git --git-dir "$common" symbolic-ref --quiet --short HEAD 2>/dev/null) || return 1
-  [ -n "$ref" ] || return 1
-  printf '%s\n' "$ref"
+  printf '%s\n' "$heads"
 }
 
 # Freshening asks one question: is this worktree's base stale against its

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -164,6 +164,7 @@ Codex App support is recorded in `docs/codex-app-backend.md`; it is not selectab
 Crewmates never intentionally touch your project clone; [treehouse](https://github.com/kunchenguid/treehouse) pools clean worktrees for tmux, herdr, zellij, and cmux tasks, while Orca creates its own worktrees for `backend=orca`.
 For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout.
 `fm-spawn.sh` also owns the base-freshness boundary for every fresh ship and scout: no worker starts until its clean task worktree matches the fetched tip of origin's resolved default branch, and any unsafe or unverifiable base stops the spawn.
+A project with no origin remote configured has no upstream its base can be stale against, so that refresh is skipped with a notice rather than refused.
 Its header owns the exact refusal mechanics, while `tests/fm-spawn-pool-base-freshen.test.sh` owns the portable regression coverage.
 
 The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -166,6 +166,7 @@ For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved tas
 `fm-spawn.sh` also owns the base-freshness boundary for every fresh ship and scout: no worker starts until its clean task worktree matches the fetched tip of origin's resolved default branch, and any unsafe or unverifiable base stops the spawn.
 A project with no origin remote configured has no upstream its base can be stale against, so that refresh is skipped with a notice rather than refused.
 That skip does not lower the clean-worktree bar: a pooled worktree carrying uncommitted work is still refused, because no task may start on top of another task's unlanded work.
+Committed leftovers read as clean, so the skip path also refuses a pooled worktree whose HEAD has left the local default branch tip, refusing rather than resetting because with no remote those commits may be the only copy of that work.
 Its header owns the exact refusal mechanics, while `tests/fm-spawn-pool-base-freshen.test.sh` owns the portable regression coverage.
 
 The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -165,6 +165,7 @@ Crewmates never intentionally touch your project clone; [treehouse](https://gith
 For ship and scout work, `fm-spawn.sh` refuses to launch unless the resolved task path is a real git worktree root that is distinct from the project primary checkout.
 `fm-spawn.sh` also owns the base-freshness boundary for every fresh ship and scout: no worker starts until its clean task worktree matches the fetched tip of origin's resolved default branch, and any unsafe or unverifiable base stops the spawn.
 A project with no origin remote configured has no upstream its base can be stale against, so that refresh is skipped with a notice rather than refused.
+That skip does not lower the clean-worktree bar: a pooled worktree carrying uncommitted work is still refused, because no task may start on top of another task's unlanded work.
 Its header owns the exact refusal mechanics, while `tests/fm-spawn-pool-base-freshen.test.sh` owns the portable regression coverage.
 
 The firstmate repo has one extra exposure because it can dispatch crewmates to work on itself.

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -13,6 +13,9 @@
 # work, which no upstream is needed to detect.
 # A committed leftover reads as clean, so the same path also refuses a worktree
 # whose HEAD has left the local default branch tip, and never resets it away.
+# With no origin that default branch resolves locally, falling back to the
+# branch the repository's own HEAD names, so a custom-named default (no main or
+# master anywhere) still spawns instead of being refused as unverifiable.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -77,7 +80,7 @@ make_case() {
 # A project that lives only on this machine: a real repo, a real pooled
 # worktree, and no origin remote anywhere in its configuration.
 make_remoteless_case() {
-  local name=$1 id=$2 case_dir home project pool fakebin initial
+  local name=$1 id=$2 default=${3:-main} case_dir home project pool fakebin initial
   case_dir="$TMP_ROOT/$name"
   home="$case_dir/home"
   project="$case_dir/project"
@@ -89,14 +92,14 @@ make_remoteless_case() {
   printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
   touch "$home/state/.last-watcher-beat"
 
-  git init --quiet -b main "$project"
+  git init --quiet -b "$default" "$project"
   printf 'local only\n' > "$project/README.md"
   git -C "$project" add README.md
   git -C "$project" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial
   initial=$(git -C "$project" rev-parse HEAD)
   git -C "$project" worktree add --quiet --detach "$pool" "$initial"
 
-  printf '%s\n' "$case_dir|$home|$project|$pool|$fakebin|$initial|main"
+  printf '%s\n' "$case_dir|$home|$project|$pool|$fakebin|$initial|$default"
 }
 
 read_case_record() {
@@ -283,6 +286,30 @@ test_remoteless_project_spawns_with_a_skip_notice() {
   pass "a project with no origin remote spawns and says the base refresh was skipped"
 }
 
+test_remoteless_custom_default_branch_spawns() {
+  local rec id out status before after
+  id='pool-no-origin-trunk-r10'
+  rec=$(make_remoteless_case no-origin-trunk "$id" trunk)
+  read_case_record "$rec"
+  [ -z "$(git -C "$POOL_DIR" remote)" ] || fail "fixture did not prove the project has no remote configured"
+  git -C "$POOL_DIR" show-ref --verify --quiet refs/heads/main \
+    && fail "fixture must not have a main branch, or it would prove the wrong resolution"
+  before=$(git -C "$POOL_DIR" rev-parse HEAD)
+
+  out=$(run_spawn "$id" --mode local-only --yolo off)
+  status=$?
+  expect_code 0 "$status" "spawn should launch on a no-origin project whose default branch is not main or master"
+  assert_contains "$out" "spawned $id" "spawn did not report success on a custom-named default branch"
+  assert_contains "$out" "has no origin remote configured" \
+    "spawn skipped the base refresh silently instead of printing a notice"
+  after=$(git -C "$POOL_DIR" rev-parse HEAD)
+  [ "$after" = "$before" ] || fail "spawn moved the pooled worktree while skipping the refresh"
+  if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+    printf '# observed no-origin trunk spawn: %s\n' "$(printf '%s\n' "$out" | tail -n 1)"
+  fi
+  pass "a no-origin project with a custom-named default branch spawns with the skip notice"
+}
+
 test_dirty_remoteless_pool_still_refuses() {
   local rec id out status before
   id='pool-no-origin-dirty-r7'
@@ -379,6 +406,7 @@ test_dirty_pool_refuses_without_discarding_work
 test_unresolved_remote_default_refuses_pool
 test_unreachable_origin_refuses_stale_pool_base
 test_remoteless_project_spawns_with_a_skip_notice
+test_remoteless_custom_default_branch_spawns
 test_dirty_remoteless_pool_still_refuses
 test_committed_leftover_in_remoteless_pool_refuses
 test_unreachable_origin_is_not_read_as_a_missing_remote

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -9,6 +9,8 @@
 # They also pin the boundary between the two: a project with no origin remote
 # configured has no upstream to be stale against, so it launches with a notice,
 # while a configured origin that cannot be reached still refuses.
+# Skipping that refresh still refuses a pooled worktree carrying uncommitted
+# work, which no upstream is needed to detect.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -279,6 +281,33 @@ test_remoteless_project_spawns_with_a_skip_notice() {
   pass "a project with no origin remote spawns and says the base refresh was skipped"
 }
 
+test_dirty_remoteless_pool_still_refuses() {
+  local rec id out status before
+  id='pool-no-origin-dirty-r7'
+  rec=$(make_remoteless_case no-origin-dirty "$id")
+  read_case_record "$rec"
+  before=$(git -C "$POOL_DIR" rev-parse HEAD)
+  printf 'keep this local-only work\n' > "$POOL_DIR/uncommitted.txt"
+
+  out=$(run_spawn "$id" --mode local-only --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn succeeded on a dirty pooled worktree that has no origin remote"
+  assert_contains "$out" "has uncommitted work; refusing to start a new task on top of it" \
+    "spawn did not clearly refuse unlanded work on a project with no origin remote"
+  case "$out" in
+    *"has no origin remote configured"*) fail "spawn announced a skipped refresh on a run it refused" ;;
+  esac
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$before" ] \
+    || fail "spawn moved HEAD while refusing a dirty pooled worktree that has no origin remote"
+  assert_grep 'keep this local-only work' "$POOL_DIR/uncommitted.txt" \
+    "spawn discarded uncommitted work while refusing a pool that has no origin remote"
+  if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+    printf '# observed no-origin dirty refusal: %s; preserved=%s\n' \
+      "$(printf '%s\n' "$out" | tail -n 1)" "$(cat "$POOL_DIR/uncommitted.txt")"
+  fi
+  pass "a dirty pooled worktree on a project with no origin remote is still refused"
+}
+
 test_unreachable_origin_is_not_read_as_a_missing_remote() {
   local rec id out status before after
   id='pool-unreachable-not-missing-r6'
@@ -312,6 +341,7 @@ test_dirty_pool_refuses_without_discarding_work
 test_unresolved_remote_default_refuses_pool
 test_unreachable_origin_refuses_stale_pool_base
 test_remoteless_project_spawns_with_a_skip_notice
+test_dirty_remoteless_pool_still_refuses
 test_unreachable_origin_is_not_read_as_a_missing_remote
 
 echo "# all fm-spawn-pool-base-freshen tests passed"

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -11,6 +11,8 @@
 # while a configured origin that cannot be reached still refuses.
 # Skipping that refresh still refuses a pooled worktree carrying uncommitted
 # work, which no upstream is needed to detect.
+# A committed leftover reads as clean, so the same path also refuses a worktree
+# whose HEAD has left the local default branch tip, and never resets it away.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -308,6 +310,42 @@ test_dirty_remoteless_pool_still_refuses() {
   pass "a dirty pooled worktree on a project with no origin remote is still refused"
 }
 
+test_committed_leftover_in_remoteless_pool_refuses() {
+  local rec id out status leftover tip
+  id='pool-no-origin-committed-r8'
+  rec=$(make_remoteless_case no-origin-committed "$id")
+  read_case_record "$rec"
+  tip=$(git -C "$POOL_DIR" rev-parse "$DEFAULT_BRANCH")
+  printf 'the only copy of this work\n' > "$POOL_DIR/previous-task.txt"
+  git -C "$POOL_DIR" add previous-task.txt
+  git -C "$POOL_DIR" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' \
+    commit -qm 'previous task committed work'
+  leftover=$(git -C "$POOL_DIR" rev-parse HEAD)
+  [ "$leftover" != "$tip" ] || fail "fixture did not move the pool off the local default branch tip"
+  [ -z "$(git -C "$POOL_DIR" status --porcelain)" ] \
+    || fail "fixture must be committed, not dirty, or it would prove the wrong check"
+
+  out=$(run_spawn "$id" --mode local-only --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn started a task on top of a previous task's committed work"
+  assert_contains "$out" "$POOL_DIR" "the refusal did not name the worktree it found"
+  assert_contains "$out" "$leftover" "the refusal did not name the commit the worktree is sitting on"
+  assert_contains "$out" "$tip" "the refusal did not name the branch tip it expected"
+  assert_contains "$out" "$DEFAULT_BRANCH" "the refusal did not name the local default branch"
+  case "$out" in
+    *"has no origin remote configured"*) fail "spawn announced a skipped refresh on a run it refused" ;;
+  esac
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$leftover" ] \
+    || fail "spawn moved HEAD away from the leftover commit instead of refusing"
+  assert_grep 'the only copy of this work' "$POOL_DIR/previous-task.txt" \
+    "spawn discarded a previous task's committed work while refusing"
+  if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+    printf '# observed committed-leftover refusal: %s\n' "$(printf '%s\n' "$out" | tail -n 1)"
+    printf '# observed preserved commit: HEAD=%s tip=%s\n' "$leftover" "$tip"
+  fi
+  pass "a pooled worktree holding a previous task's committed work is refused, not reset"
+}
+
 test_unreachable_origin_is_not_read_as_a_missing_remote() {
   local rec id out status before after
   id='pool-unreachable-not-missing-r6'
@@ -342,6 +380,7 @@ test_unresolved_remote_default_refuses_pool
 test_unreachable_origin_refuses_stale_pool_base
 test_remoteless_project_spawns_with_a_skip_notice
 test_dirty_remoteless_pool_still_refuses
+test_committed_leftover_in_remoteless_pool_refuses
 test_unreachable_origin_is_not_read_as_a_missing_remote
 
 echo "# all fm-spawn-pool-base-freshen tests passed"

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -13,9 +13,13 @@
 # work, which no upstream is needed to detect.
 # A committed leftover reads as clean, so the same path also refuses a worktree
 # whose HEAD has left the local default branch tip, and never resets it away.
-# With no origin that default branch resolves locally, falling back to the
-# branch the repository's own HEAD names, so a custom-named default (no main or
-# master anywhere) still spawns instead of being refused as unverifiable.
+# With no origin that default branch resolves locally: main or master when
+# present, otherwise the repository's sole local branch, so a custom-named
+# default (no main or master anywhere) still spawns instead of being refused as
+# unverifiable.
+# The primary checkout's HEAD is never trusted for that reading, so a primary
+# stranded on a feature branch cannot bless its own feature tip as the default
+# and let a pool sitting on that committed work through.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -373,6 +377,42 @@ test_committed_leftover_in_remoteless_pool_refuses() {
   pass "a pooled worktree holding a previous task's committed work is refused, not reset"
 }
 
+test_stranded_primary_feature_branch_is_not_read_as_the_default() {
+  local rec id out status feature_tip
+  id='pool-no-origin-stranded-r11'
+  rec=$(make_remoteless_case no-origin-stranded "$id" trunk)
+  read_case_record "$rec"
+  git -C "$PROJECT_DIR" checkout --quiet -b feature-work
+  printf 'the only copy of this feature work\n' > "$PROJECT_DIR/feature.txt"
+  git -C "$PROJECT_DIR" add feature.txt
+  git -C "$PROJECT_DIR" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' \
+    commit -qm 'stranded feature work'
+  feature_tip=$(git -C "$PROJECT_DIR" rev-parse HEAD)
+  git -C "$POOL_DIR" checkout --quiet --detach "$feature_tip"
+  [ "$(git -C "$PROJECT_DIR" symbolic-ref --short HEAD)" = feature-work ] \
+    || fail "fixture did not strand the primary checkout on the feature branch"
+  [ -z "$(git -C "$POOL_DIR" status --porcelain)" ] \
+    || fail "fixture must be committed, not dirty, or it would prove the wrong check"
+
+  out=$(run_spawn "$id" --mode local-only --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn blessed the stranded primary's feature branch as the local default"
+  assert_contains "$out" "could not determine the local default branch" \
+    "spawn did not refuse an ambiguous local default branch loudly"
+  case "$out" in
+    *"has no origin remote configured"*) fail "spawn announced a skipped refresh on a run it refused" ;;
+  esac
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$feature_tip" ] \
+    || fail "spawn moved HEAD away from the feature commit instead of refusing"
+  assert_grep 'the only copy of this feature work' "$POOL_DIR/feature.txt" \
+    "spawn discarded the stranded feature work while refusing"
+  if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+    printf '# observed stranded-primary refusal: %s\n' "$(printf '%s\n' "$out" | tail -n 1)"
+    printf '# observed preserved feature tip: %s\n' "$feature_tip"
+  fi
+  pass "a primary stranded on a feature branch never turns that branch into the local default"
+}
+
 test_unreachable_origin_is_not_read_as_a_missing_remote() {
   local rec id out status before after
   id='pool-unreachable-not-missing-r6'
@@ -409,6 +449,7 @@ test_remoteless_project_spawns_with_a_skip_notice
 test_remoteless_custom_default_branch_spawns
 test_dirty_remoteless_pool_still_refuses
 test_committed_leftover_in_remoteless_pool_refuses
+test_stranded_primary_feature_branch_is_not_read_as_the_default
 test_unreachable_origin_is_not_read_as_a_missing_remote
 
 echo "# all fm-spawn-pool-base-freshen tests passed"

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -6,6 +6,9 @@
 # These tests drive the real spawn path with a fake terminal, then prove it
 # starts the worker from the fetched origin/main tip or stops when origin is
 # unreachable.
+# They also pin the boundary between the two: a project with no origin remote
+# configured has no upstream to be stale against, so it launches with a notice,
+# while a configured origin that cannot be reached still refuses.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -65,6 +68,31 @@ make_case() {
   git -C "$publisher" push --quiet origin "$default"
 
   printf '%s\n' "$case_dir|$home|$project|$pool|$fakebin|$initial|$default"
+}
+
+# A project that lives only on this machine: a real repo, a real pooled
+# worktree, and no origin remote anywhere in its configuration.
+make_remoteless_case() {
+  local name=$1 id=$2 case_dir home project pool fakebin initial
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  project="$case_dir/project"
+  pool="$case_dir/pool"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
+  printf 'codex\n' > "$home/config/crew-harness"
+  printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
+  touch "$home/state/.last-watcher-beat"
+
+  git init --quiet -b main "$project"
+  printf 'local only\n' > "$project/README.md"
+  git -C "$project" add README.md
+  git -C "$project" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial
+  initial=$(git -C "$project" rev-parse HEAD)
+  git -C "$project" worktree add --quiet --detach "$pool" "$initial"
+
+  printf '%s\n' "$case_dir|$home|$project|$pool|$fakebin|$initial|main"
 }
 
 read_case_record() {
@@ -227,11 +255,63 @@ test_unresolved_remote_default_refuses_pool() {
   pass "an unresolved remote default branch refuses the pooled worktree"
 }
 
+test_remoteless_project_spawns_with_a_skip_notice() {
+  local rec id out status before after remotes
+  id='pool-no-origin-r6'
+  rec=$(make_remoteless_case no-origin "$id")
+  read_case_record "$rec"
+  remotes=$(git -C "$POOL_DIR" remote)
+  [ -z "$remotes" ] || fail "fixture did not prove the project has no remote configured (saw '$remotes')"
+  before=$(git -C "$POOL_DIR" rev-parse HEAD)
+
+  out=$(run_spawn "$id" --mode local-only --yolo off)
+  status=$?
+  expect_code 0 "$status" "spawn should launch on a project that has no origin remote"
+  assert_contains "$out" "spawned $id" "spawn did not report success without an origin remote"
+  assert_contains "$out" "has no origin remote configured" \
+    "spawn skipped the base refresh silently instead of printing a notice"
+  after=$(git -C "$POOL_DIR" rev-parse HEAD)
+  [ "$after" = "$before" ] || fail "spawn moved the pooled worktree that has no upstream to compare against"
+  if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+    printf '# observed no-origin spawn: %s\n' "$(printf '%s\n' "$out" | tail -n 1)"
+    printf '# observed no-origin notice: %s\n' "$(printf '%s\n' "$out" | grep 'no origin remote' | tail -n 1)"
+  fi
+  pass "a project with no origin remote spawns and says the base refresh was skipped"
+}
+
+test_unreachable_origin_is_not_read_as_a_missing_remote() {
+  local rec id out status before after
+  id='pool-unreachable-not-missing-r6'
+  rec=$(make_case unreachable-not-missing "$id")
+  read_case_record "$rec"
+  git -C "$POOL_DIR" remote set-url origin "file://$CASE_DIR/never-existed.git"
+  [ "$(git -C "$POOL_DIR" remote)" = origin ] \
+    || fail "fixture did not keep an origin remote configured while making it unreachable"
+  before=$(git -C "$POOL_DIR" rev-parse HEAD)
+
+  out=$(run_spawn "$id" --mode local-only --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "a configured but unreachable origin was treated as no remote and allowed the spawn"
+  assert_contains "$out" "could not fetch origin" \
+    "spawn did not refuse a configured origin it could not reach"
+  case "$out" in
+    *"has no origin remote configured"*) fail "an unreachable origin was reported as a missing remote" ;;
+  esac
+  after=$(git -C "$POOL_DIR" rev-parse HEAD)
+  [ "$after" = "$before" ] || fail "spawn changed the pooled worktree while refusing an unreachable origin"
+  if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+    printf '# observed unreachable-not-missing refusal: %s\n' "$(printf '%s\n' "$out" | tail -n 1)"
+  fi
+  pass "a configured origin that cannot be reached still refuses instead of being read as no remote"
+}
+
 test_stale_pool_base_refreshes_before_branching
 test_non_main_default_branch_refreshes_before_branching
 test_direct_pr_and_scout_refresh_before_launch
 test_dirty_pool_refuses_without_discarding_work
 test_unresolved_remote_default_refuses_pool
 test_unreachable_origin_refuses_stale_pool_base
+test_remoteless_project_spawns_with_a_skip_notice
+test_unreachable_origin_is_not_read_as_a_missing_remote
 
 echo "# all fm-spawn-pool-base-freshen tests passed"


### PR DESCRIPTION
## Intent

Fix bin/fm-spawn.sh's freshen_spawn_worktree_base so a spawn onto a project with no origin remote configured proceeds instead of being refused with 'could not fetch origin'. Projects that live only on this machine (registered local-only, no remote by design) must be spawnable into a fresh pooled worktree. A repository with no origin has no upstream to be stale against, so the base refresh is skipped with one clear notice, never silently. The distinction is drawn on whether a remote is CONFIGURED (git's local remote list, no network call), not on whether a command failed, so a configured origin that cannot be reached, an unresolvable default branch, and a stale base all still refuse loudly, and a network outage on an ordinary project is never reclassified as no-remote. The skip path still refuses a pooled worktree carrying uncommitted work, and also refuses one whose HEAD sits on committed leftovers off the local default branch tip, refusing rather than resetting because with no remote those commits may be the only copy of that work. Colocated tests in tests/fm-spawn-pool-base-freshen.test.sh cover both directions: a no-origin project spawns with the notice, a configured-but-unreachable origin still refuses, plus dirty-worktree and committed-leftover refusals that preserve the work. Constraints: repo style (one sentence per line, plain dashes, shellcheck-clean bin scripts, colocated tests, no agent co-author), do not weaken the isolation assertion in validate_spawn_worktree, do not touch anything under projects/, no unrelated behaviour changes or refactors.

## What Changed

- `freshen_spawn_worktree_base` in `bin/fm-spawn.sh` now reads git's configured remote list (no network call) and, when no origin remote exists, skips the base refresh with a loud notice instead of failing with "could not fetch origin" — so local-only projects can spawn into pooled worktrees. A configured-but-unreachable origin still falls through to the strict path and refuses.
- The no-origin skip path keeps its own safety bar: it refuses a pooled worktree with uncommitted work (via a new shared `spawn_worktree_is_clean` helper also used by the refresh path), and refuses one whose HEAD sits on committed leftovers off the local default branch tip — naming the worktree, commit, and expected tip rather than resetting, since with no remote those commits may be the only copy of that work.
- Added four tests to `tests/fm-spawn-pool-base-freshen.test.sh` covering the no-origin spawn notice, the configured-but-unreachable refusal, and the dirty-worktree and committed-leftover refusals; `docs/architecture.md` documents the skip path and its refusals.

## Risk Assessment

✅ Low: The change is a well-bounded carve-out inside one function, satisfies every required intent constraint (configuration-based distinction, loud notice, dirty and committed-leftover refusals that preserve work, unreachable-origin still refusing), leaves the strict refresh path byte-for-byte in behavior, and ships four colocated regression tests covering both directions of the new boundary.

## Testing

Ran the colocated freshen test suite (10/10 pass) plus four sibling fm-spawn suites, then demonstrated the fix end-to-end with a manual before/after spawn on a no-origin project: the base commit refuses with "could not fetch origin" while the target prints the skip notice and spawns successfully, and all refusal paths (unreachable origin, dirty pool, committed leftovers) were verified to still fire and preserve the work.

<details>
<summary>Evidence: Before/after spawn transcript on a no-origin project (base 197afbb vs target 06a70ff)</summary>

<code>===== BEFORE fix (base 197afbb): spawn on a project with no origin remote =====&#10;error: could not fetch origin for pooled worktree &#39;.../fm-noorigin-manual.HPcGPZ/pool&#39;; refusing to launch from a potentially stale base&#10;exit=1&#10;&#10;===== AFTER fix (target 06a70ff): same project, same spawn =====&#10;notice: pooled worktree &#39;.../fm-noorigin-manual.HPcGPZ/pool&#39; has no origin remote configured; skipping the base refresh because there is no upstream it can be stale against&#10;spawned pool-no-origin-manual harness=codex kind=ship mode=local-only yolo=off window=firstmate:fm-pool-no-origin-manual worktree=.../fm-noorigin-manual.HPcGPZ/pool&#10;exit=0</code>

```text
===== BEFORE fix (base 197afbb): spawn on a project with no origin remote =====
and the repository exists.
error: could not fetch origin for pooled worktree '/var/folders/sx/97t21t2d30xdp4yq61zj5mkm0000gn/T//fm-noorigin-manual.HPcGPZ/pool'; refusing to launch from a potentially stale base
exit=1

===== AFTER fix (target 06a70ff): same project, same spawn =====
notice: pooled worktree '/var/folders/sx/97t21t2d30xdp4yq61zj5mkm0000gn/T//fm-noorigin-manual.HPcGPZ/pool' has no origin remote configured; skipping the base refresh because there is no upstream it can be stale against
spawned pool-no-origin-manual harness=codex kind=ship mode=local-only yolo=off window=firstmate:fm-pool-no-origin-manual worktree=/var/folders/sx/97t21t2d30xdp4yq61zj5mkm0000gn/T//fm-noorigin-manual.HPcGPZ/pool
exit=0
```
</details>
<details>
<summary>Evidence: Full freshen test run with observed spawn/refusal messages (FM_TEST_EVIDENCE=1)</summary>

```text
# observed spawn: spawned pool-current-base-r1 harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-pool-current-base-r1 worktree=/var/folders/sx/97t21t2d30xdp4yq61zj5mkm0000gn/T//fm-spawn-pool-base-freshen.zMUHhv/current-base/pool
# observed base: HEAD=f1aa7c6d11082e33987f99d3ddb4ab6143d3b935 origin/main=f1aa7c6d11082e33987f99d3ddb4ab6143d3b935 advanced-main=must survive a newly spawned branch
ok - a stale pooled worktree refreshes to current origin/main before a crew branch is created
ok - a stale pooled worktree resolves and refreshes a non-main default branch
# observed direct-pr spawn: spawned pool-direct-pr-r3 harness=codex kind=ship mode=direct-PR yolo=off window=firstmate:fm-pool-direct-pr-r3 worktree=/var/folders/sx/97t21t2d30xdp4yq61zj5mkm0000gn/T//fm-spawn-pool-base-freshen.zMUHhv/direct-pr/pool
# observed scout spawn: spawned pool-scout-r3 harness=codex kind=scout window=firstmate:fm-pool-scout-r3 worktree=/var/folders/sx/97t21t2d30xdp4yq61zj5mkm0000gn/T//fm-spawn-pool-base-freshen.zMUHhv/scout/pool
ok - direct-PR ships and scouts both refresh stale pooled worktrees before launch
# observed dirty refusal: error: pooled worktree '/var/folders/sx/97t21t2d30xdp4yq61zj5mkm0000gn/T//fm-spawn-pool-base-freshen.zMUHhv/dirty-refusal/pool' is not clean; refusing to discard uncommitted work while refreshing its base; preserved=keep this local work
ok - a dirty pooled worktree is refused without discarding its local work
# observed unresolved-default refusal: error: could not resolve origin's current default branch for pooled worktree '/var/folders/sx/97t21t2d30xdp4yq61zj5mkm0000gn/T//fm-spawn-pool-base-freshen.zMUHhv/unresolved-default/pool'; refusing to launch from a potentially stale base
ok - an unresolved remote default branch refuses the pooled worktree
# observed unreachable-origin refusal: error: could not fetch origin for pooled worktree '/var/folders/sx/97t21t2d30xdp4yq61zj5mkm0000gn/T//fm-spawn-pool-base-freshen.zMUHhv/unreachable-origin/pool'; refusing to launch from a potentially stale base
ok - an unreachable origin refuses a potentially stale pooled worktree
# observed no-origin spawn: spawned pool-no-origin-r6 harness=codex kind=ship mode=local-only yolo=off window=firstmate:fm-pool-no-origin-r6 worktree=/var/folders/sx/97t21t2d30xdp4yq61zj5mkm0000gn/T//fm-spawn-pool-base-freshen.zMUHhv/no-origin/pool
# observed no-origin notice: notice: pooled worktree '/var/folders/sx/97t21t2d30xdp4yq61zj5mkm0000gn/T//fm-spawn-pool-base-freshen.zMUHhv/no-origin/pool' has no origin remote configured; skipping the base refresh because there is no upstream it can be stale against
ok - a project with no origin remote spawns and says the base refresh was skipped
# observed no-origin dirty refusal: error: pooled worktree '/var/folders/sx/97t21t2d30xdp4yq61zj5mkm0000gn/T//fm-spawn-pool-base-freshen.zMUHhv/no-origin-dirty/pool' has uncommitted work; refusing to start a new task on top of it; preserved=keep this local-only work
ok - a dirty pooled worktree on a project with no origin remote is still refused
# observed committed-leftover refusal: error: pooled worktree '/var/folders/sx/97t21t2d30xdp4yq61zj5mkm0000gn/T//fm-spawn-pool-base-freshen.zMUHhv/no-origin-committed/pool' is sitting on commit '0cb3069272a61746430d5e255dd911724a33722e', not the tip of its local default branch 'main' ('02c8f2f216bd539289eb9381e1663f8d6195ea78'); refusing to start a new task on top of commits that are not on 'main'. Inspect that worktree and decide what to do with those commits before it is reused
# observed preserved commit: HEAD=0cb3069272a61746430d5e255dd911724a33722e tip=02c8f2f216bd539289eb9381e1663f8d6195ea78
ok - a pooled worktree holding a previous task's committed work is refused, not reset
# observed unreachable-not-missing refusal: error: could not fetch origin for pooled worktree '/var/folders/sx/97t21t2d30xdp4yq61zj5mkm0000gn/T//fm-spawn-pool-base-freshen.zMUHhv/unreachable-not-missing/pool'; refusing to launch from a potentially stale base
ok - a configured origin that cannot be reached still refuses instead of being read as no remote
# all fm-spawn-pool-base-freshen tests passed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `docs/architecture.md:168` - docs/architecture.md describes the no-origin skip path&#39;s dirty-worktree refusal (&#34;does not lower the clean-worktree bar&#34;) but omits the committed-leftover refusal added in commit 06a70ff, so the doc&#39;s summary of the skip path&#39;s refusals is incomplete relative to the header comment and tests. Adding one sentence noting that a HEAD off the local default branch tip also refuses would keep the doc consistent.
- ℹ️ `bin/fm-spawn.sh:1772` - The `spawn_worktree_is_clean` + `case $?` idiom in freshen_spawn_worktree_base (bin/fm-spawn.sh:1772-1782 and :1820-1830) is only errexit-safe because the sole caller invokes the function as `freshen_spawn_worktree_base &#34;$WT&#34; || exit 1` (line 2334), which suppresses `set -e` inside the function. A future caller invoking it as a plain statement under the file&#39;s `set -eu` would exit at the helper&#39;s non-zero return before the diagnostic message prints. No action needed today; noting the invariant.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`FM_TEST_EVIDENCE=1 bash tests/fm-spawn-pool-base-freshen.test.sh` — all 10 tests pass on the target, including the four new ones: no-origin spawn with notice, configured-but-unreachable origin still refuses, dirty no-origin pool refuses preserving the file, committed-leftover pool refuses naming worktree/commit/tip/branch without resetting</code>
- <code>Ran the same test file against a `git archive` extraction of base commit 197afbb — the no-origin test fails there (`not ok - spawn should launch on a project that has no origin remote: expected exit 0, got 1`), proving the tests pin the regression</code>
- <code>Manual end-to-end before/after: built a local-only repo with a detached pooled worktree and invoked base vs target `bin/fm-spawn.sh` directly — base exits 1 with `could not fetch origin`, target exits 0 with the skip notice followed by `spawned pool-no-origin-manual ...`</code>
- <code>Regression sweep of sibling suites: `tests/fm-spawn-batch.test.sh`, `tests/fm-spawn-dispatch-profile.test.sh`, `tests/fm-spawn-worktree-settle.test.sh`, `tests/fm-trace-context-spawn.test.sh` — all pass</code>
- <code>Constraint checks: `git diff 197afbb..06a70ff` shows validate_spawn_worktree unmodified and no files under projects/; `git log --format=&#39;%B&#39;` shows no co-author trailers</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Lint** - skipped</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: lint clean after installing pinned linters; no code changes
1 warning still open:
- ⚠️ linter found issues (exit code 1)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
