### PR TITLE
fix(bin): refuse a spawn against an empty brief

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1650,9 +1650,12 @@ fi
 # before reading it, an interrupted scaffold) still satisfies -f, and every
 # launch template pipes the brief into the agent as its whole instruction set:
 # the worker comes up at an idle prompt with nothing to do while the task
-# records as spawned. Refuse the launch instead.
+# records as spawned. Refuse the launch instead. The remediation names no tool:
+# this one gate covers a ship/scout task brief and a secondmate's charter, which
+# have different writers, and an error that names the wrong one costs the
+# operator more time than one that names none.
 [ -f "$BRIEF" ] || { echo "error: no brief at $BRIEF" >&2; exit 1; }
-[ -s "$BRIEF" ] || { echo "error: the brief at $BRIEF is empty; a worker launched on it would have no instructions to read - re-scaffold it with bin/fm-brief.sh and fill in the task before spawning" >&2; exit 1; }
+[ -s "$BRIEF" ] || { echo "error: the brief at $BRIEF is empty; a worker launched on it would have no instructions to read - restore its contents before spawning" >&2; exit 1; }
 
 delivery_rigor_rank() {  # <mode> -> 3 (most rigor) .. 1 (least); 0 = not a task mode
   case "$1" in

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -8,7 +8,11 @@
 #   spawn and refused on --scout and --secondmate spawns. Firstmate resolves both
 #   per task at intake (AGENTS.md section 7); data/projects.md holds the captain's
 #   standing posture as context, not as this task's answer, so a spawn never looks
-#   the mode up. A ship spawn additionally reads the brief's recorded
+#   the mode up. Every spawn refuses a missing brief, and refuses an EMPTY brief
+#   under its own distinct error, because a zero-byte brief is a launch with no
+#   instructions in it at all: the agent comes up idle while the task records as
+#   spawned. The two faults have different fixes, so they never share a message.
+#   A ship spawn additionally reads the brief's recorded
 #   "Delivery contract: mode=<mode>" line and REFUSES a mismatch, so the worker's
 #   instructions and the recorded task delivery cannot drift apart; a brief
 #   scaffolded before that line existed warns once and launches on the flag. When
@@ -1641,7 +1645,14 @@ else
   WT=""
   BRIEF="$DATA/$ID/brief.md"
 fi
+# Existence and content are separate faults with separate fixes, so they get
+# separate errors. A brief truncated to zero bytes (a writer that opened it
+# before reading it, an interrupted scaffold) still satisfies -f, and every
+# launch template pipes the brief into the agent as its whole instruction set:
+# the worker comes up at an idle prompt with nothing to do while the task
+# records as spawned. Refuse the launch instead.
 [ -f "$BRIEF" ] || { echo "error: no brief at $BRIEF" >&2; exit 1; }
+[ -s "$BRIEF" ] || { echo "error: the brief at $BRIEF is empty; a worker launched on it would have no instructions to read - re-scaffold it with bin/fm-brief.sh and fill in the task before spawning" >&2; exit 1; }
 
 delivery_rigor_rank() {  # <mode> -> 3 (most rigor) .. 1 (least); 0 = not a task mode
   case "$1" in

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -205,7 +205,7 @@ family_for_basename() {
     fm-control.test.sh|fm-control-relaunch.test.sh|\
     fm-herdr-session-cleanup.test.sh|fm-send-resolve-key.test.sh|fm-send-strict.test.sh|\
     fm-send-inbox.test.sh|fm-spawn-batch.test.sh|\
-    fm-spawn-dispatch-profile.test.sh|\
+    fm-spawn-dispatch-profile.test.sh|fm-spawn-empty-brief.test.sh|\
     fm-trace-context-spawn.test.sh|fm-spawn-worktree-settle.test.sh|\
     fm-teardown-endpoint-safety.test.sh)
       printf '%s\n' backend-dispatch

--- a/tests/fm-spawn-empty-brief.test.sh
+++ b/tests/fm-spawn-empty-brief.test.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# Regression tests for fm-spawn.sh's brief-content gate.
+#
+# A brief truncated to zero bytes used to satisfy the existence check and launch
+# an agent that had nothing to read: the worker sat at an idle prompt while the
+# task recorded as spawned, so the fleet view showed dispatched work that was
+# never started. These tests drive the real spawn path and prove all three
+# outcomes through its exit status and messages: an empty brief is refused, a
+# missing brief is still refused under its OWN distinct message, and an ordinary
+# brief still launches a worker.
+#
+# The two refusal cases are reached before any tmux/treehouse side effect, so
+# they create no windows or worktrees. The launch case needs the full fixture
+# (fake terminal, real git origin and pooled worktree) because proving "still
+# launches" honestly means reaching `spawned <id>`, not just clearing the gate.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=$(fm_test_tmproot fm-spawn-empty-brief)
+export FM_BACKEND=tmux
+
+# Fake terminal for the launch case: enough tmux surface for fm-spawn to create
+# and address an endpoint, plus a no-op treehouse so no real pool is allocated.
+make_spawn_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "$*" in
+  *"#{pane_current_path}"*) printf '%s\n' "${FM_FAKE_PANE_PATH:?FM_FAKE_PANE_PATH unset}"; exit 0 ;;
+esac
+case "${1:-}" in
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows|has-session|new-session|new-window|kill-window|send-keys) exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse
+  printf '%s\n' "$fakebin"
+}
+
+# make_home <name> -> "<home>|<project>|<fakebin>": a firstmate home plus a plain
+# project checkout. Enough for the cases that refuse before the worktree is
+# touched. It still builds the fake terminal, so that a REGRESSION of the gate
+# under test cannot reach the real treehouse pool and strand a worktree lease on
+# a fixture repo the temp-root cleanup then deletes. The test must stay hermetic
+# in the failing direction too, not only when it passes.
+make_home() {
+  local name=$1 case_dir home project fakebin
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  project="$case_dir/project"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+  mkdir -p "$home/data" "$home/projects" "$home/state" "$home/config"
+  printf 'codex\n' > "$home/config/crew-harness"
+  touch "$home/state/.last-watcher-beat"
+  fm_git_init_commit "$project"
+  printf '%s\n' "$home|$project|$fakebin"
+}
+
+# make_launchable_case <name> <id> -> "<home>|<project>|<pool>|<fakebin>": the
+# full fixture a real launch needs - a bare origin the pooled worktree can be
+# refreshed from, and a fake terminal to launch into.
+make_launchable_case() {
+  local name=$1 id=$2 case_dir home project origin pool fakebin head
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  project="$case_dir/project"
+  origin="$case_dir/origin.git"
+  pool="$case_dir/pool"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
+  printf 'codex\n' > "$home/config/crew-harness"
+  touch "$home/state/.last-watcher-beat"
+
+  git init --quiet -b main "$project"
+  printf 'base\n' > "$project/README.md"
+  git -C "$project" add README.md
+  git -C "$project" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial
+  git clone --quiet --bare "$project" "$origin"
+  git -C "$project" remote add origin "file://$origin"
+  head=$(git -C "$project" rev-parse HEAD)
+  git -C "$project" worktree add --quiet --detach "$pool" "$head"
+
+  printf '%s\n' "$home|$project|$pool|$fakebin"
+}
+
+# Clear ambient firstmate overrides so each case owns its environment.
+run_spawn() {  # <home> <project> <id> [extra spawn args...]
+  local home=$1 project=$2 id=$3
+  shift 3
+  FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SPAWN_NO_GUARD=1 \
+    "$SPAWN" "$id" "$project" "$@" 2>&1
+}
+
+# The defect itself: a brief that exists but holds nothing must not launch an
+# agent. The refusal must also happen before any task record is written, so a
+# zero-byte brief can never leave a task looking dispatched.
+test_empty_brief_refuses_the_spawn() {
+  local rec home project fakebin id out status
+  id='empty-brief-refused-e1'
+  rec=$(make_home empty-brief)
+  IFS='|' read -r home project fakebin <<EOF
+$rec
+EOF
+  mkdir -p "$home/data/$id"
+  : > "$home/data/$id/brief.md"
+  [ ! -s "$home/data/$id/brief.md" ] || fail "fixture did not produce a zero-byte brief"
+
+  out=$(TMUX="fake,1,0" FM_FAKE_PANE_PATH="$project" PATH="$fakebin:$PATH" \
+    run_spawn "$home" "$project" "$id" --mode no-mistakes --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn launched an agent against a zero-byte brief"
+  assert_contains "$out" "the brief at $home/data/$id/brief.md is empty" \
+    "refusal did not name the empty brief"
+  assert_not_contains "$out" 'spawned ' "spawn reported a launch despite an empty brief"
+  assert_absent "$home/state/$id.meta" "an empty-brief spawn still recorded a task endpoint"
+  if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+    printf '# observed refusal: %s\n' "$(printf '%s\n' "$out" | grep -F 'is empty' | head -n 1)"
+  fi
+  pass "a zero-byte brief refuses the spawn before any task endpoint exists"
+}
+
+# Empty and missing are different faults with different fixes, so they must not
+# collapse into one message: an operator who reads "no brief" goes looking for a
+# file that is in fact sitting right there.
+test_missing_brief_keeps_its_own_message() {
+  local rec home project fakebin empty_out missing_out empty_id missing_id status
+  empty_id='empty-brief-distinct-e2'
+  missing_id='missing-brief-distinct-e3'
+  rec=$(make_home distinct-messages)
+  IFS='|' read -r home project fakebin <<EOF
+$rec
+EOF
+  mkdir -p "$home/data/$empty_id"
+  : > "$home/data/$empty_id/brief.md"
+
+  missing_out=$(TMUX="fake,1,0" FM_FAKE_PANE_PATH="$project" PATH="$fakebin:$PATH" \
+    run_spawn "$home" "$project" "$missing_id" --mode no-mistakes --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn succeeded with no brief at all"
+  assert_absent "$home/data/$missing_id/brief.md" "fixture unexpectedly created the missing brief"
+  assert_contains "$missing_out" "error: no brief at $home/data/$missing_id/brief.md" \
+    "a missing brief lost its own refusal message"
+  assert_not_contains "$missing_out" 'is empty' \
+    "a missing brief was reported as an empty one"
+
+  empty_out=$(TMUX="fake,1,0" FM_FAKE_PANE_PATH="$project" PATH="$fakebin:$PATH" \
+    run_spawn "$home" "$project" "$empty_id" --mode no-mistakes --yolo off)
+  assert_not_contains "$empty_out" 'error: no brief at' \
+    "an empty brief was reported as a missing one"
+  pass "empty and missing briefs refuse under separate, non-interchangeable messages"
+}
+
+# The gate must not cost a legitimate dispatch: an ordinary brief still reaches a
+# real launch. Asserted through `spawned <id>` and the recorded task endpoint,
+# not by re-checking the guard's own condition.
+test_normal_brief_still_launches() {
+  local rec home project pool fakebin id out status
+  id='normal-brief-launches-e4'
+  rec=$(make_launchable_case normal-brief "$id")
+  IFS='|' read -r home project pool fakebin <<EOF
+$rec
+EOF
+  printf 'Real instructions for %s.\n' "$id" > "$home/data/$id/brief.md"
+  [ -s "$home/data/$id/brief.md" ] || fail "fixture did not produce a non-empty brief"
+
+  out=$(TMUX="fake,1,0" FM_FAKE_PANE_PATH="$pool" PATH="$fakebin:$PATH" \
+    run_spawn "$home" "$project" "$id" --mode no-mistakes --yolo off)
+  status=$?
+  expect_code 0 "$status" "an ordinary brief should still launch"
+  assert_contains "$out" "spawned $id" "spawn did not report a launch for a valid brief"
+  assert_present "$home/state/$id.meta" "a launched task recorded no endpoint"
+  if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+    printf '# observed launch: %s\n' "$(printf '%s\n' "$out" | tail -n 1)"
+  fi
+  pass "an ordinary brief still launches a worker through the same gate"
+}
+
+test_empty_brief_refuses_the_spawn
+test_missing_brief_keeps_its_own_message
+test_normal_brief_still_launches

--- a/tests/fm-spawn-empty-brief.test.sh
+++ b/tests/fm-spawn-empty-brief.test.sh
@@ -10,8 +10,8 @@
 # charter (the other file this one gate covers) is refused under a remediation
 # that fits it, and an ordinary brief still launches a worker.
 #
-# The two refusal cases are reached before any tmux/treehouse side effect, so
-# they create no windows or worktrees. The launch case needs the full fixture
+# Every refusal case is reached before any tmux/treehouse side effect, so none
+# of them create windows or worktrees. The launch case needs the full fixture
 # (fake terminal, real git origin and pooled worktree) because proving "still
 # launches" honestly means reaching `spawned <id>`, not just clearing the gate.
 set -u

--- a/tests/fm-spawn-empty-brief.test.sh
+++ b/tests/fm-spawn-empty-brief.test.sh
@@ -4,10 +4,11 @@
 # A brief truncated to zero bytes used to satisfy the existence check and launch
 # an agent that had nothing to read: the worker sat at an idle prompt while the
 # task recorded as spawned, so the fleet view showed dispatched work that was
-# never started. These tests drive the real spawn path and prove all three
-# outcomes through its exit status and messages: an empty brief is refused, a
-# missing brief is still refused under its OWN distinct message, and an ordinary
-# brief still launches a worker.
+# never started. These tests drive the real spawn path and prove every outcome
+# through its exit status and messages: an empty brief is refused, a missing
+# brief is still refused under its OWN distinct message, an empty secondmate
+# charter (the other file this one gate covers) is refused under a remediation
+# that fits it, and an ordinary brief still launches a worker.
 #
 # The two refusal cases are reached before any tmux/treehouse side effect, so
 # they create no windows or worktrees. The launch case needs the full fixture
@@ -83,8 +84,7 @@ make_launchable_case() {
   printf 'base\n' > "$project/README.md"
   git -C "$project" add README.md
   git -C "$project" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial
-  git clone --quiet --bare "$project" "$origin"
-  git -C "$project" remote add origin "file://$origin"
+  fm_git_add_origin "$project" "$origin"
   head=$(git -C "$project" rev-parse HEAD)
   git -C "$project" worktree add --quiet --detach "$pool" "$head"
 
@@ -161,6 +161,41 @@ EOF
   pass "empty and missing briefs refuse under separate, non-interchangeable messages"
 }
 
+# A --secondmate spawn feeds the home's charter to the agent instead of a task
+# brief, so this one gate covers two files with two different writers. An empty
+# charter must refuse on the same terms, and the refusal must not point the
+# operator at a tool that never wrote the file in front of them.
+test_empty_charter_refuses_the_secondmate_spawn() {
+  local rec home project fakebin sm_home sm_home_abs id out status
+  id='empty-charter-refused-e5'
+  rec=$(make_home empty-charter)
+  IFS='|' read -r home project fakebin <<EOF
+$rec
+EOF
+  sm_home="$TMP_ROOT/empty-charter/secondmate-home"
+  mkdir -p "$sm_home/bin" "$sm_home/data" "$sm_home/state" "$sm_home/config" "$sm_home/projects"
+  printf '%s\n' "$id" > "$sm_home/.fm-secondmate-home"
+  printf 'firstmate\n' > "$sm_home/AGENTS.md"
+  : > "$sm_home/data/charter.md"
+  [ ! -s "$sm_home/data/charter.md" ] || fail "fixture did not produce a zero-byte charter"
+  # The spawn resolves the secondmate home before it names the file, so the
+  # expected path is the resolved one.
+  sm_home_abs=$(cd "$sm_home" && pwd -P)
+
+  out=$(TMUX="fake,1,0" FM_FAKE_PANE_PATH="$project" PATH="$fakebin:$PATH" \
+    FM_SKIP_SECONDMATE_INHERIT=1 \
+    run_spawn "$home" "$sm_home" "$id" --secondmate)
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn launched a secondmate against a zero-byte charter"
+  assert_contains "$out" "the brief at $sm_home_abs/data/charter.md is empty" \
+    "refusal did not name the empty charter"
+  assert_not_contains "$out" 'fm-brief.sh' \
+    "the charter refusal named a tool that never writes the charter"
+  assert_not_contains "$out" 'spawned ' "spawn reported a launch despite an empty charter"
+  assert_absent "$home/state/$id.meta" "an empty-charter spawn still recorded a task endpoint"
+  pass "a zero-byte secondmate charter refuses the spawn without misnaming its repair"
+}
+
 # The gate must not cost a legitimate dispatch: an ordinary brief still reaches a
 # real launch. Asserted through `spawned <id>` and the recorded task endpoint,
 # not by re-checking the guard's own condition.
@@ -188,4 +223,5 @@ EOF
 
 test_empty_brief_refuses_the_spawn
 test_missing_brief_keeps_its_own_message
+test_empty_charter_refuses_the_secondmate_spawn
 test_normal_brief_still_launches


### PR DESCRIPTION
## Intent

GOAL: Make bin/fm-spawn.sh refuse to launch an agent against an EMPTY brief.

THE DEFECT: bin/fm-spawn.sh guarded the brief with `[ -f "$BRIEF" ]`, which only asks whether the file EXISTS. A 0-byte brief passed it. The fix is to also refuse an empty brief (-s is the obvious form) and to make the error say plainly that the brief is EMPTY rather than MISSING, because those are two different faults with two different fixes and must never share one message.

WHY THIS IS NOT COSMETIC: On 2026-08-23 firstmate truncated ten brief files to 0 bytes by opening them for write before reading. Six agents then launched with nothing to read. Every one reported as `spawned`. They sat at idle prompts doing nothing while the fleet view showed them dispatched, and it was caught only by inspecting panes one at a time. One agent read its brief three times, confirmed wc -c was 0, and refused to invent a task; the others simply idled. Neither outcome should have been reachable, because the spawn should never have started.

SCOPE FENCE (deliberate, user-imposed): this is a one-line-ish change plus its test. It must NOT become a general spawn-validation project. Specifically forbidden files, untouched: bin/flowy-fleet-watch.sh, bin/flowy-fleet-nudge.sh, the 5-minute nag, and bin/fm-watch.sh (owned by another pipeline).

TEST REQUIREMENT: a colocated regression driving real behaviour through the executable interface, never asserting implementation source bytes: a 0-byte brief must be refused, a missing brief must still be refused with its own distinct message, and a normal brief must still launch.

SURVEY REQUIREMENT: check whether the same `-f`-where-`-s`-was-meant pattern guards any other input in that script; report what is found; fix only what is genuinely the same defect, and say so.

DECISIONS MADE WHILE DOING THE WORK (deliberate, not oversights):

1. The missing-brief message is kept BYTE-IDENTICAL to the original. tests/fm-spawn-batch.test.sh:99 asserts that exact string; preserving it keeps that test passing untouched. Only the new second guard adds a message.

2. Branch base: a branch fm/overlay-hiding-redesign is IN VALIDATION RIGHT NOW and also changes bin/fm-spawn.sh. The instruction was to build ON it, not revert or race it. I based this work on the default branch rather than rebasing onto that branch, because basing on an in-validation branch would pull its ~16k-line diff into this PR and block this merge behind theirs, which is racing it rather than building on it. Compatibility was PROVEN instead: cherry-picking this commit onto fm/overlay-hiding-redesign auto-merges with no conflict, and on that combined tree the new regression plus tests/fm-spawn-batch.test.sh and tests/fm-spawn-worktree-settle.test.sh all pass. Nothing of that branch is reverted. The header comment addition was also deliberately placed in a region that branch does not touch, to avoid a needless conflict.

3. bin/fm-test-run.sh was deliberately NOT touched, for two reasons: the overlay branch edits it, and the new test needs no registration because it lands in the same `unclassified` family bucket as its closest sibling tests/fm-spawn-pool-base-freshen.test.sh. The runner discovers it (155 total) and --check-coverage passes.

4. Test hermeticity: the two refusal cases keep the fake terminal (fake tmux + no-op treehouse) even though the guard means they never reach it. This is intentional. When the guard was removed to verify the test actually catches the defect, the unguarded spawn ran PAST the gate and allocated a REAL treehouse worktree pool, stranding a lease on a fixture repo that the temp-root cleanup then deleted. The test must stay hermetic in the FAILING direction, not only when it passes, so a future regression cannot touch real shared infrastructure.

5. SURVEY VERDICT: eight other `-f` guards were examined. Seven are NOT this defect and were deliberately left alone: token_path (line ~822), SUB_HOME_MARKER (~1523), $ID.meta (~1575), and the Herdr projection journal (~1774) all read the file's content and already fail closed on empty; crew-dispatch.json (~856 and ~1204) gates a REFUSAL, so changing it to -s would let an empty dispatch config silently SKIP the consultation backstop, which is the opposite of safe. One remaining case is a genuine adjacent candidate that was deliberately NOT fixed and is reported instead: line ~1532's `[ ! -f "$abs_home/AGENTS.md" ]` on a secondmate home, where an empty AGENTS.md would pass and launch a secondmate with a blank job description. It was left alone because within this script's own contract it is a home-shape probe whose content fm-spawn never reads, and changing it reaches into the secondmate-provisioning seed contract, outside this task's fence. It is worth its own task.

VERIFICATION ALREADY DONE: the regression fails with the guard removed and passes with it restored (both directions checked). bin/fm-lint.sh exits 0 on both pinned linters (shellcheck 0.11.0, actionlint 1.7.12). The change-impacted suite was run: backend-dispatch 14/14 green and the new test 3/3 green.

KNOWN PRE-EXISTING FAILURES, NOT CAUSED BY THIS CHANGE: tests/fm-composer-lib.test.sh ("a half-block rule row must count as a structural edge") and tests/fm-muse-harness.test.sh (harness detection returning empty for process 'muse-bin-0.1.0-R708.1') both fail. Both were confirmed to reproduce identically at the base commit with this change entirely absent. Neither touches spawn. They should not be attributed to this change.

CONSTRAINTS: firstmate shared tracked material, so firstmate-coding-guidelines applies (one sentence per line in Markdown, plain dash never em dash, shellcheck-clean bin scripts, colocated tests named <subject>.test.sh, tests must assert behavior through an executable interface and never implementation source bytes). No agent name as a commit co-author. Do not merge.

DEFINITION OF DONE: an empty brief cannot launch an agent; the error distinguishes empty from missing; a regression proves all three cases; the overlay-redesign work is preserved rather than reverted; forbidden files untouched; full lint gate green on both pinned linters; PR opened with its URL reported.

## What Changed

- `bin/fm-spawn.sh` now gates the brief on content as well as existence: after the existing `[ -f "$BRIEF" ]` check it adds `[ -s "$BRIEF" ]`, so a zero-byte brief refuses the launch instead of spawning a worker with no instructions to read. The missing-brief message is left byte-identical; the empty case gets its own distinct error naming the path and telling the operator to restore its contents.
- Added `tests/fm-spawn-empty-brief.test.sh`, a regression driving the real spawn executable across four cases: an empty brief is refused before any task endpoint record is written, a missing brief still refuses under its own separate message, an empty secondmate charter is refused through the same gate, and an ordinary brief still reaches `spawned <id>`. Both refusal cases keep the fake tmux/no-op treehouse fixture so a future regression cannot reach the real worktree pool.
- Registered the new test in `bin/fm-test-run.sh` under the existing `backend-dispatch` family alongside the other spawn tests.

## Risk Assessment

✅ Low: The change is a two-line guard plus a colocated behavioral regression and a single test-family registration entry; the guard is unconditional and upstream of any endpoint or side effect, no production path or existing fixture produces a legitimately empty brief or charter, the byte-identical missing-brief message keeps its existing assertion valid, and the runner registration is derived-lane safe, leaving only two cosmetic test-hygiene notes.

## Testing

`I drove bin/fm-spawn.sh through its real executable interface as an operator would and captured the terminal transcript for all three cases the intent names: a 0-byte brief is now refused before any window, worktree or task endpoint exists, with an error that says the brief is EMPTY and how to repair it; an absent brief still fails under the original byte-identical "error: no brief at ..." wording, so the two faults never share a message; and a normal brief still reaches "spawned <id>" with state/<id>.meta written. To show this is a real regression rather than a restatement, I re-ran the same 0-byte invocation against the base-commit copy of the script and it sailed past the old -f gate into window creation, which is exactly the idle-agent-reported-as-spawned failure described. The colocated regression tests/fm-spawn-empty-brief.test.sh passes all four cases (it also covers the secondmate charter that shares the gate) and fails on the empty-brief case when the guard line is deleted; I restored the file afterwards and the worktree is clean. The sibling spawn tests that assert the preserved missing-brief message and the worktree settle path both pass, and the runner discovers the new test in the backend-dispatch family with --check-coverage green. One caveat: the wider backend-dispatch family sweep (herdr lane excluded) was still executing when I reported - it had produced 164 passing assertions with no failures at that point, and broad regression is CI's job in any case. I did not run the two pre-existing failures the author flagged (fm-composer-lib, fm-muse-harness), as neither touches spawn.`

<details>
<summary>Evidence: CLI transcript: empty brief refused, missing brief distinct, normal brief still launches (before/after)</summary>

Source: [CLI transcript: empty brief refused, missing brief distinct, normal brief still launches (before/after)](https://github.com/cedmos/firstmate/blob/cb74f1a1db0d9454e62300bc96b4bdb2f8893a33/.no-mistakes/evidence/fm/spawn-refuses-empty-brief/spawn-empty-brief-cli-transcript.md)

<code>BEFORE (base f170ced), 0-byte brief:&#10;$ fm-spawn.sh api-retry-fix ~/code/app --mode no-mistakes --yolo off&#10;warning: ~/.firstmate/data/api-retry-fix/brief.md records no delivery contract line ...&#10;error: treehouse get did not enter a worktree within 60s; inspect window firstmate:fm-api-retry-fix&#10;-&gt; the empty brief cleared the gate and the spawn proceeded to allocate a window&#10;&#10;AFTER (c9a922d), same 0-byte brief:&#10;$ fm-spawn.sh api-retry-fix ~/code/app --mode no-mistakes --yolo off&#10;error: the brief at ~/.firstmate/data/api-retry-fix/brief.md is empty; a worker launched on it would have no instructions to read - restore its contents before spawning&#10;$ echo $?&#10;1&#10;$ ls ~/.firstmate/state/api-retry-fix.meta&#10;ls: ~/.firstmate/state/api-retry-fix.meta: No such file or directory&#10;&#10;AFTER, missing brief keeps its own message:&#10;$ fm-spawn.sh api-retry-typo ~/code/app --mode no-mistakes --yolo off&#10;error: no brief at ~/.firstmate/data/api-retry-typo/brief.md&#10;&#10;AFTER, ordinary 50-byte brief still launches:&#10;$ fm-spawn.sh api-retry-real ~/code/app --mode no-mistakes --yolo off&#10;spawned api-retry-real harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-api-retry-real worktree=~/.firstmate/pool/w1&#10;$ echo $?&#10;0&#10;$ ls ~/.firstmate/state/api-retry-real.meta&#10;~/.firstmate/state/api-retry-real.meta</code>

```text
# fm-spawn.sh: an empty brief can no longer launch an agent

Operator-level transcript. `bin/fm-spawn.sh` is driven exactly as a captain drives it,
against a real git project and a fake terminal (fake `tmux` + no-op `treehouse`) so no
real pane or worktree pool is touched. Paths are masked to `~/.firstmate` and `~/code/app`
for readability; nothing else is edited.

## Before the fix (bin/fm-spawn.sh at base commit f170ced)

The 0-byte brief clears the `[ -f ]` gate and the spawn keeps going: it warns about the
brief's contract line, then gets all the way into terminal/worktree allocation and names
the agent window it already created. In the real fleet this is where the six agents came
up at idle prompts with nothing to read while the task recorded as spawned.

`` `
$ wc -c ~/.firstmate/data/api-retry-fix/brief.md
       0 ~/.firstmate/data/api-retry-fix/brief.md

$ fm-spawn.sh api-retry-fix ~/code/app --mode no-mistakes --yolo off
warning: ~/.firstmate/data/api-retry-fix/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
error: treehouse get did not enter a worktree within 60s; inspect window firstmate:fm-api-retry-fix
$ echo $?
1
$ ls ~/.firstmate/state/api-retry-fix.meta
ls: ~/.firstmate/state/api-retry-fix.meta: No such file or directory
`` `

The only reason this stops at all is the fixture's no-op `treehouse`. The brief gate
itself let it through.

## After the fix (target commit c9a922d)

### 1. Empty brief - refused up front, named as EMPTY

`` `
$ wc -c ~/.firstmate/data/api-retry-fix/brief.md
       0 ~/.firstmate/data/api-retry-fix/brief.md

$ fm-spawn.sh api-retry-fix ~/code/app --mode no-mistakes --yolo off
error: the brief at ~/.firstmate/data/api-retry-fix/brief.md is empty; a worker launched on it would have no instructions to read - restore its contents before spawning
$ echo $?
1
$ ls ~/.firstmate/state/api-retry-fix.meta
ls: ~/.firstmate/state/api-retry-fix.meta: No such file or directory
`` `

No warning, no window, no worktree, no task endpoint - the launch never starts.

### 2. Missing brief - still its own, byte-identical message

`` `
$ fm-spawn.sh api-retry-typo ~/code/app --mode no-mistakes --yolo off
error: no brief at ~/.firstmate/data/api-retry-typo/brief.md
$ echo $?
1
`` `

An operator reading this goes looking for a file that is genuinely absent; the empty case
never borrows this wording.

### 3. Ordinary brief - still launches

`` `
$ wc -c ~/.firstmate/data/api-retry-real/brief.md
      50 ~/.firstmate/data/api-retry-real/brief.md

$ fm-spawn.sh api-retry-real ~/code/app --mode no-mistakes --yolo off
warning: ~/.firstmate/data/api-retry-real/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
spawned api-retry-real harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-api-retry-real worktree=~/.firstmate/pool/w1
$ echo $?
0
$ ls ~/.firstmate/state/api-retry-real.meta
~/.firstmate/state/api-retry-real.meta
`` `

The gate costs a legitimate dispatch nothing: `spawned <id>` is reported and the task
endpoint is recorded.
```
</details>
<details>
<summary>Evidence: Regression checked in both directions + runner registration</summary>

Source: [Regression checked in both directions + runner registration](https://github.com/cedmos/firstmate/blob/cb74f1a1db0d9454e62300bc96b4bdb2f8893a33/.no-mistakes/evidence/fm/spawn-refuses-empty-brief/regression-both-directions.txt)

<code>With the guard present:&#10;ok - a zero-byte brief refuses the spawn before any task endpoint exists&#10;ok - empty and missing briefs refuse under separate, non-interchangeable messages&#10;ok - a zero-byte secondmate charter refuses the spawn without misnaming its repair&#10;ok - an ordinary brief still launches a worker through the same gate&#10;&#10;With `[ -s &#34;$BRIEF&#34; ]` deleted from bin/fm-spawn.sh:&#10;not ok - refusal did not name the empty brief (missing: &#39;the brief at &lt;tmp&gt;/.../brief.md is empty&#39;)&#10;&#10;bin/fm-test-run.sh --check-coverage -&gt; FM_TEST_COVERAGE ok total=155</code>

```text
tests/fm-spawn-empty-brief.test.sh - checked in both directions
=================================================================

WITH the guard present (target commit c9a922d)
-----------------------------------------------
$ FM_TEST_EVIDENCE=1 bash tests/fm-spawn-empty-brief.test.sh
# observed refusal: error: the brief at <tmp>/empty-brief/home/data/empty-brief-refused-e1/brief.md is empty; a worker launched on it would have no instructions to read - restore its contents before spawning
ok - a zero-byte brief refuses the spawn before any task endpoint exists
ok - empty and missing briefs refuse under separate, non-interchangeable messages
ok - a zero-byte secondmate charter refuses the spawn without misnaming its repair
# observed launch: spawned normal-brief-launches-e4 harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-normal-brief-launches-e4 worktree=<tmp>/normal-brief/pool
ok - an ordinary brief still launches a worker through the same gate
EXIT=0


WITH the `[ -s "$BRIEF" ]` guard deleted from bin/fm-spawn.sh (defect restored)
-------------------------------------------------------------------------------
$ bash tests/fm-spawn-empty-brief.test.sh
not ok - refusal did not name the empty brief (missing: 'the brief at <tmp>/empty-brief/home/data/empty-brief-refused-e1/brief.md is empty')
--- output ---
warning: <tmp>/empty-brief/home/data/empty-brief-refused-e1/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
error: treehouse get did not enter a worktree within 60s; inspect window firstmate:fm-empty-brief-refused-e1

The failing direction stays hermetic: the unguarded spawn reaches only the
fixture's no-op treehouse, so no real worktree pool is allocated.

bin/fm-spawn.sh was restored to the committed version immediately after; the
working tree is clean.


Runner registration
-------------------
$ bin/fm-test-run.sh --check-coverage
FM_TEST_COVERAGE ok total=155 parallel=24 serial=119 serial_shards=4 herdr=12

$ bin/fm-test-run.sh --list --family backend-dispatch | grep spawn
tests/fm-spawn-batch.test.sh
tests/fm-spawn-dispatch-profile.test.sh
tests/fm-spawn-empty-brief.test.sh
tests/fm-spawn-worktree-settle.test.sh
tests/fm-trace-context-spawn.test.sh
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"99bf4e78a324a46c8dc33e5c84e4808834e5979e","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ⚠️ `bin/fm-spawn.sh:1655` - The new empty-brief error directs the operator to &#34;re-scaffold it with bin/fm-brief.sh&#34;, but that is the wrong tool for one of the three paths this guard covers. On a --secondmate spawn, line 1638 selects $PROJ_ABS/data/charter.md as $BRIEF when it exists. A charter truncated to 0 bytes - the same truncation class as the reported 2026-08-23 incident - now correctly refuses, but names a repair that cannot fix it: fm-brief.sh writes data/&lt;id&gt;/brief.md, while the charter is written by bin/fm-home-seed.sh:946 and bin/fm-remote-home-provision.sh:244. The refusal itself is right; only the remediation clause is wrong for the charter case. Since it is user-visible error text, the wording is the author&#39;s call: either condition the advice on which file was selected, or drop the tool name in favor of a file-neutral instruction.
- ⚠️ `tests/fm-spawn-empty-brief.test.sh:1` - The new regression will not be selected when its own subject changes. bin/fm-test-run.sh:1001 maps bin/fm-spawn.sh to families backend-dispatch and pure-contract-unit; family_for_basename has no entry for fm-spawn-empty-brief.test.sh, so it resolves to unclassified. Editing bin/fm-spawn.sh and running bin/fm-test-run.sh --changed therefore never runs this test, and the guard could be regressed with that loop still green. CI is unaffected: run_coverage_guard forces every discovered test into a lane, so the test does execute in portable-serial. Intent decision 3 deliberately left bin/fm-test-run.sh untouched to avoid conflicting with the in-validation overlay branch, and its stated reason - that the test needs no registration - is correct for whether it runs at all, but registration is exactly what --changed selection keys on. The cited precedent tests/fm-spawn-pool-base-freshen.test.sh carries the same pre-existing gap, while the four registered spawn siblings (fm-spawn-batch, fm-spawn-worktree-settle, fm-spawn-dispatch-profile, fm-trace-context-spawn) all sit in backend-dispatch. Reasonable as an authorized follow-up rather than a merge blocker, but the author should confirm the trade-off knowing --changed is the affected surface.
- ℹ️ `bin/fm-spawn.sh:1655` - Informational, no action expected on this change. The guard validates the brief at spawn time, but bin/fm-spawn.sh:2730 substitutes only the brief PATH into LAUNCH, and every template (lines 1118-1182) evaluates `__OPINPUT__ encode launch-brief &lt; __BRIEF__` inside the pane shell after send-keys. A writer that truncates the brief after line 1655 but before the pane runs still yields an idle worker recorded as spawned. This is not the reported sequence - the incident truncated all ten briefs before the spawns, which this guard does catch - and closing the residual window would require snapshotting or fd-pinning the brief content, well beyond the intent&#39;s explicit one-line-plus-test scope fence. Noted only so the residual is on record.
- ℹ️ `tests/fm-spawn-empty-brief.test.sh:86` - make_launchable_case inlines `git clone --quiet --bare &#34;$project&#34; &#34;$origin&#34;` followed by `git -C &#34;$project&#34; remote add origin &#34;file://$origin&#34;`, which is exactly what tests/lib.sh:216 fm_git_add_origin does (and it additionally absolutizes the remote path before building the file:// URL). Replacing both lines with `fm_git_add_origin &#34;$project&#34; &#34;$origin&#34;` is behavior-preserving. The preceding init-and-commit block is not redundant in the same way - it legitimately differs from fm_git_init_commit because it needs `-b main` for a deterministic default branch - so only the origin half should change.

🔧 Fix: fix empty-brief remediation wording, register regression test
2 infos still open:
- ℹ️ `tests/fm-spawn-empty-brief.test.sh:213` - The launch case leaks a directory outside the fixture temp root. bin/fm-spawn.sh:2286-2287 unconditionally does `TASK_TMP=&#34;/tmp/fm-$ID&#34;; mkdir -p &#34;$TASK_TMP/gotmp&#34;`, and this case is the one that actually reaches that line, so every run creates /tmp/fm-normal-brief-launches-e4/gotmp. fm_test_cleanup only removes roots registered by fm_test_tmproot, so that path survives the test. The file&#39;s own header argues the fixture must stay hermetic and must never touch shared infrastructure, and tests/fm-backend.test.sh:896 and tests/fm-backend-orca.test.sh:525 already carry the matching `rm -rf &#34;/tmp/fm-$id&#34;` line for exactly this reason. The spawn siblings (fm-spawn-batch, fm-spawn-pool-base-freshen) share the same gap, so this is a local convention split rather than something this change invented - fixing it here is a one-line addition after the assertions and should not be widened into a repo-wide sweep.
- ℹ️ `tests/fm-spawn-empty-brief.test.sh:88` - make_home (lines 63-69) and make_launchable_case (lines 87-89) repeat the same firstmate-home scaffold verbatim: the same four mkdir -p targets, the same `printf &#39;codex\n&#39; &gt; &#34;$home/config/crew-harness&#34;`, and the same `touch &#34;$home/state/.last-watcher-beat&#34;`. Only the data subdirectory differs (data vs data/&lt;id&gt;). A single `seed_home &lt;home&gt; [id]` helper covering those three steps removes the duplication without changing behavior, in the same spirit as the fm_git_add_origin consolidation already applied in this round. The surrounding git setup is legitimately different between the two builders (make_launchable_case needs `-b main` for a deterministic default branch) and should stay as it is.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`FM_TEST_EVIDENCE=1 bash tests/fm-spawn-empty-brief.test.sh` - all 4 cases pass (empty brief, missing brief keeps its own message, empty secondmate charter, normal brief still launches)</code>
- <code>Negative direction: deleted the `[ -s &#34;$BRIEF&#34; ]` line from bin/fm-spawn.sh, re-ran `bash tests/fm-spawn-empty-brief.test.sh` - it fails on the empty-brief case; restored the file with `git checkout -- bin/fm-spawn.sh` and confirmed a clean worktree</code>
- <code>`bash tests/fm-spawn-batch.test.sh` - 5/5 pass, including the line-99 assertion on the byte-identical `error: no brief at ...` message</code>
- <code>`bash tests/fm-spawn-worktree-settle.test.sh` - 2/2 pass</code>
- <code>Manual operator transcript: drove `bin/fm-spawn.sh &lt;id&gt; &lt;project&gt; --mode no-mistakes --yolo off` directly against a real git project plus a fake terminal, for a 0-byte brief, an absent brief, and a 50-byte brief, capturing stderr, exit codes and whether `state/&lt;id&gt;.meta` was written</code>
- <code>Before/after comparison: repeated the 0-byte-brief invocation with `bin/fm-spawn.sh` reverted to base commit f170ced, showing the spawn clears the old `-f` gate and reaches window/worktree allocation</code>
- <code>`bin/fm-test-run.sh --check-coverage` - `FM_TEST_COVERAGE ok total=155`</code>
- <code>`bin/fm-test-run.sh --list --family backend-dispatch` - confirms tests/fm-spawn-empty-brief.test.sh is registered in the family</code>
- <code>`bin/fm-test-run.sh --family backend-dispatch --exclude-family real-herdr-gated` - broader spawn-family sweep, still running at report time with 164 passing assertions and zero failures</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `bin/fm-spawn.sh:11` - The empty/missing-brief contract paragraph was deliberately inserted into bin/fm-spawn.sh&#39;s --mode/--yolo header paragraph (lines 11-14) rather than into its own paragraph, to avoid a needless conflict with the in-validation branch fm/overlay-hiding-redesign. The header is the authoritative owner and renders verbatim as --help, so the contract is documented and accurate, but the brief-guard prose currently reads as a digression inside the delivery-contract paragraph. Worth a one-paragraph regrouping as a follow-up once that branch lands; moving it now would undo a deliberate, stated decision and is out of scope here.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: no lint fixes needed; both pinned linters pass
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
