### PR TITLE
feat(bin): add fast local lint mode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,8 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
 - Helper scripts in `bin/` are plain bash.
   Each starts with a usage header comment; keep it accurate when you change behavior.
   Test scripts and helpers in `tests/` are plain bash too.
-  `bin/fm-lint.sh` must pass: it is the single owner of the lint definition (the shellcheck file set, config, pinned shellcheck version, and pinned actionlint workflow lint), and both CI and the no-mistakes pre-push gate run it, so local and CI can never diverge.
+  `bin/fm-lint.sh` must pass: it is the single owner of the lint definition (the shellcheck file set, config, pinned shellcheck version, and pinned actionlint workflow lint), and both CI and the no-mistakes pre-push gate run its no-argument full-analysis path.
+  Its header and `--help` output own the exact local lint modes and flags.
   A malformed `.github/workflows/*.yml`, including a self-broken `ci.yml`, fails that local lint path before merge because a broken workflow cannot report its own breakage.
   It pins one exact shellcheck version and one exact actionlint version and refuses to run under any other.
   Print the shellcheck pin with `bin/fm-lint.sh --required-version` and the actionlint pin with `bin/fm-lint-workflows.sh --required-version`.

--- a/bin/fm-lint.sh
+++ b/bin/fm-lint.sh
@@ -108,7 +108,11 @@ if [ "${1:-}" = "--required-version" ]; then
 fi
 
 fm_lint_usage() {
-  sed -n '2,42{s/^# \{0,1\}//;p;}' "$SELF"
+  awk '
+    NR == 1 { next }
+    /^#/ { sub(/^# ?/, ""); print; next }
+    { exit }
+  ' "$SELF"
 }
 
 # Default no-args lint also validates GitHub workflows. Explicit paths stay a

--- a/bin/fm-lint.sh
+++ b/bin/fm-lint.sh
@@ -5,6 +5,9 @@
 # ambient configuration disabled, and one exact ShellCheck version. CI and
 # no-mistakes both invoke this script with no arguments, so the rule set,
 # version, bounded execution, and diagnostics ordering cannot drift.
+# The explicit --fast mode is local-only and disables ShellCheck's extended
+# dataflow analysis while preserving ordinary shell lint checks. CI and
+# no-mistakes keep the full-analysis no-argument default.
 # Tests stop source analysis at imported production modules because every
 # production shell is already a canonical, source-aware root of this same run.
 # The default (no explicit-path) path also runs bin/fm-lint-workflows.sh so a
@@ -34,6 +37,7 @@
 #
 # Usage:
 #   fm-lint.sh                         lint the context-selected file set (see above)
+#   fm-lint.sh --fast [path]...       local lint with extended analysis disabled
 #   fm-lint.sh <path>...               lint explicit roots with the same config
 #   fm-lint.sh --jobs <1|2> [path]...  override bounded worker count
 #   fm-lint.sh --telemetry <path> ...  write a quiet metrics snapshot
@@ -59,7 +63,7 @@ fm_lint_worker_stop() {
 
 fm_lint_worker() {  # <manifest> <output-dir> <shard-index>
   local manifest=$1 output_dir=$2 shard_index=$3 tab index path output rc=0
-  local -a roots
+  local -a roots shellcheck_args
   roots=()
   tab=$(printf '\t')
   while IFS="$tab" read -r index path || [ -n "${index:-}${path:-}" ]; do
@@ -71,7 +75,11 @@ fm_lint_worker() {  # <manifest> <output-dir> <shard-index>
     trap 'fm_lint_worker_stop; exit 129' HUP
     trap 'fm_lint_worker_stop; exit 130' INT
     trap 'fm_lint_worker_stop; exit 143' TERM
-    "$FM_LINT_SHELLCHECK" --norc --external-sources -- "${roots[@]}" > "$output.out" 2>&1 &
+    shellcheck_args=(--norc --external-sources)
+    if [ "${FM_LINT_FAST:-0}" -eq 1 ]; then
+      shellcheck_args+=(--extended-analysis=false)
+    fi
+    "$FM_LINT_SHELLCHECK" "${shellcheck_args[@]}" -- "${roots[@]}" > "$output.out" 2>&1 &
     FM_LINT_WORKER_SHELLCHECK_PID=$!
     wait "$FM_LINT_WORKER_SHELLCHECK_PID" || rc=$?
     FM_LINT_WORKER_SHELLCHECK_PID=
@@ -112,6 +120,12 @@ fm_lint_run_workflows() {
 
 JOBS=${FM_LINT_JOBS:-2}
 TELEMETRY=${FM_LINT_TELEMETRY:-}
+FAST=${FM_LINT_FAST:-0}
+case "$FAST" in
+  1|true) FAST=1 ;;
+  0|false|'') FAST=0 ;;
+  *) printf 'fm-lint.sh: FM_LINT_FAST must be 0 or 1, got %s.\n' "$FAST" >&2; exit 2 ;;
+esac
 LIST_FILES=0
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -131,6 +145,10 @@ while [ "$#" -gt 0 ]; do
       ;;
     --telemetry=*)
       TELEMETRY=${1#*=}
+      shift
+      ;;
+    --fast)
+      FAST=1
       shift
       ;;
     --list-files)
@@ -153,6 +171,11 @@ case "$JOBS" in
   1|2) ;;
   *) printf 'fm-lint.sh: jobs must be 1 or 2, got %s.\n' "$JOBS" >&2; exit 2 ;;
 esac
+
+if [ "$FAST" -eq 1 ] && { [ "${GITHUB_ACTIONS:-}" = true ] || [ "${CI:-}" = true ]; }; then
+  printf 'fm-lint.sh: --fast is local-only; CI uses full ShellCheck analysis.\n' >&2
+  exit 2
+fi
 
 # fm_lint_changed_base_ref prints the ref to diff the working branch against:
 # the local origin/main tracking ref when present, else local main. Returns
@@ -246,6 +269,11 @@ if [ "$resolved" != "$REQUIRED_SHELLCHECK" ]; then
   printf 'fm-lint.sh: ShellCheck %s required for CI parity, found %s. Install %s with bin/fm-install-shellcheck.sh <destination-directory>.\n' \
     "$REQUIRED_SHELLCHECK" "$resolved" "$REQUIRED_SHELLCHECK" >&2
   exit 1
+fi
+if [ "$FAST" -eq 1 ]; then
+  printf 'fm-lint.sh: fast local mode; ShellCheck extended analysis disabled\n' >&2
+else
+  printf 'fm-lint.sh: full ShellCheck extended analysis enabled\n' >&2
 fi
 
 if [ "$CHANGED_MODE" -eq 1 ] && [ "$ROOT_COUNT" -eq 0 ]; then
@@ -379,18 +407,18 @@ fm_lint_run_worker() {  # <worker-index>
     if [ "$(uname)" = Darwin ]; then
       exec "$PERL_BIN" -e 'setpgrp(0, 0) or die "setpgrp: $!"; exec @ARGV or die "exec: $!"' \
         /usr/bin/time -lp -o "$timing" \
-        env FM_LINT_INTERNAL=1 FM_LINT_SHELLCHECK="$SHELLCHECK_BIN" \
+        env FM_LINT_INTERNAL=1 FM_LINT_FAST="$FAST" FM_LINT_SHELLCHECK="$SHELLCHECK_BIN" \
         "${BASH:-bash}" "$SELF" --internal-worker "$manifest" "$OUTPUT_DIR" "$worker_index"
     else
       exec "$PERL_BIN" -e 'setpgrp(0, 0) or die "setpgrp: $!"; exec @ARGV or die "exec: $!"' \
         /usr/bin/time -f 'wall_seconds=%e\nuser_seconds=%U\nsystem_seconds=%S\nmax_rss_kib=%M' -o "$timing" \
-        env FM_LINT_INTERNAL=1 FM_LINT_SHELLCHECK="$SHELLCHECK_BIN" \
+        env FM_LINT_INTERNAL=1 FM_LINT_FAST="$FAST" FM_LINT_SHELLCHECK="$SHELLCHECK_BIN" \
         "${BASH:-bash}" "$SELF" --internal-worker "$manifest" "$OUTPUT_DIR" "$worker_index"
     fi
   else
     [ -z "$TELEMETRY" ] || printf 'timing_unavailable=1\n' > "$timing"
     exec "$PERL_BIN" -e 'setpgrp(0, 0) or die "setpgrp: $!"; exec @ARGV or die "exec: $!"' \
-      env FM_LINT_INTERNAL=1 FM_LINT_SHELLCHECK="$SHELLCHECK_BIN" \
+      env FM_LINT_INTERNAL=1 FM_LINT_FAST="$FAST" FM_LINT_SHELLCHECK="$SHELLCHECK_BIN" \
       "${BASH:-bash}" "$SELF" --internal-worker "$manifest" "$OUTPUT_DIR" "$worker_index"
   fi
 }

--- a/bin/fm-lint.sh
+++ b/bin/fm-lint.sh
@@ -76,7 +76,7 @@ fm_lint_worker() {  # <manifest> <output-dir> <shard-index>
     trap 'fm_lint_worker_stop; exit 130' INT
     trap 'fm_lint_worker_stop; exit 143' TERM
     shellcheck_args=(--norc --external-sources)
-    if [ "${FM_LINT_FAST:-0}" -eq 1 ]; then
+    if [ "${FM_LINT_INTERNAL_FAST:-0}" -eq 1 ]; then
       shellcheck_args+=(--extended-analysis=false)
     fi
     "$FM_LINT_SHELLCHECK" "${shellcheck_args[@]}" -- "${roots[@]}" > "$output.out" 2>&1 &
@@ -124,12 +124,8 @@ fm_lint_run_workflows() {
 
 JOBS=${FM_LINT_JOBS:-2}
 TELEMETRY=${FM_LINT_TELEMETRY:-}
-FAST=${FM_LINT_FAST:-0}
-case "$FAST" in
-  1|true) FAST=1 ;;
-  0|false|'') FAST=0 ;;
-  *) printf 'fm-lint.sh: FM_LINT_FAST must be 0 or 1, got %s.\n' "$FAST" >&2; exit 2 ;;
-esac
+FAST=0
+ANALYSIS_MODE=full
 LIST_FILES=0
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -153,6 +149,7 @@ while [ "$#" -gt 0 ]; do
       ;;
     --fast)
       FAST=1
+      ANALYSIS_MODE=fast
       shift
       ;;
     --list-files)
@@ -411,18 +408,18 @@ fm_lint_run_worker() {  # <worker-index>
     if [ "$(uname)" = Darwin ]; then
       exec "$PERL_BIN" -e 'setpgrp(0, 0) or die "setpgrp: $!"; exec @ARGV or die "exec: $!"' \
         /usr/bin/time -lp -o "$timing" \
-        env FM_LINT_INTERNAL=1 FM_LINT_FAST="$FAST" FM_LINT_SHELLCHECK="$SHELLCHECK_BIN" \
+        env FM_LINT_INTERNAL=1 FM_LINT_INTERNAL_FAST="$FAST" FM_LINT_SHELLCHECK="$SHELLCHECK_BIN" \
         "${BASH:-bash}" "$SELF" --internal-worker "$manifest" "$OUTPUT_DIR" "$worker_index"
     else
       exec "$PERL_BIN" -e 'setpgrp(0, 0) or die "setpgrp: $!"; exec @ARGV or die "exec: $!"' \
         /usr/bin/time -f 'wall_seconds=%e\nuser_seconds=%U\nsystem_seconds=%S\nmax_rss_kib=%M' -o "$timing" \
-        env FM_LINT_INTERNAL=1 FM_LINT_FAST="$FAST" FM_LINT_SHELLCHECK="$SHELLCHECK_BIN" \
+        env FM_LINT_INTERNAL=1 FM_LINT_INTERNAL_FAST="$FAST" FM_LINT_SHELLCHECK="$SHELLCHECK_BIN" \
         "${BASH:-bash}" "$SELF" --internal-worker "$manifest" "$OUTPUT_DIR" "$worker_index"
     fi
   else
     [ -z "$TELEMETRY" ] || printf 'timing_unavailable=1\n' > "$timing"
     exec "$PERL_BIN" -e 'setpgrp(0, 0) or die "setpgrp: $!"; exec @ARGV or die "exec: $!"' \
-      env FM_LINT_INTERNAL=1 FM_LINT_FAST="$FAST" FM_LINT_SHELLCHECK="$SHELLCHECK_BIN" \
+      env FM_LINT_INTERNAL=1 FM_LINT_INTERNAL_FAST="$FAST" FM_LINT_SHELLCHECK="$SHELLCHECK_BIN" \
       "${BASH:-bash}" "$SELF" --internal-worker "$manifest" "$OUTPUT_DIR" "$worker_index"
   fi
 }
@@ -553,6 +550,7 @@ EOF
     printf 'git_head\t%s\n' "$git_head"
     printf 'content_cksum\t%s\n' "$content_cksum"
     printf 'shellcheck_version\t%s\n' "$resolved"
+    printf 'analysis_mode\t%s\n' "$ANALYSIS_MODE"
     printf 'jobs\t%s\n' "$JOBS"
     printf 'root_count\t%s\n' "$ROOT_COUNT"
     printf 'direct_lines\t%s\n' "$direct_lines"

--- a/tests/fm-lint.test.sh
+++ b/tests/fm-lint.test.sh
@@ -266,12 +266,13 @@ SH
 }
 
 test_fast_mode_disables_extended_analysis() {
-  local tmp fakebin log mode_log fixture out
+  local tmp fakebin log mode_log telemetry fixture out
   tmp=$(fm_test_tmproot fm-lint-fast-mode)
   fakebin=$(fm_fakebin "$tmp")
   fixture="$tmp/fixture.sh"
   log="$tmp/shellcheck.log"
   mode_log="$tmp/mode.log"
+  telemetry="$tmp/telemetry.tsv"
   cat > "$fixture" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "${1:-ok}"
@@ -280,12 +281,13 @@ SH
   fm_lint_stub_shellcheck "$fakebin" "$log"
 
   out=$(PATH="$fakebin:$PATH" GITHUB_ACTIONS='' CI='' FM_LINT_JOBS=1 \
-    FM_TEST_MODE_LOG="$mode_log" "$LINT" --fast "$fixture" 2>&1) \
+    FM_TEST_MODE_LOG="$mode_log" "$LINT" --fast --telemetry "$telemetry" "$fixture" 2>&1) \
     || fail "fast lint mode failed"$'\n'"$out"
   [ "$(cat "$mode_log")" = off ] \
     || fail "fast lint mode did not disable extended analysis"
   [ "$(cat "$log")" = "$fixture" ] \
     || fail "fast lint mode did not lint the requested root"
+  assert_grep $'analysis_mode\tfast' "$telemetry" "telemetry did not record fast analysis mode"
   pass "fm-lint.sh --fast disables ShellCheck extended analysis"
 }
 
@@ -303,7 +305,7 @@ SH
   chmod +x "$fixture"
   fm_lint_stub_shellcheck "$fakebin" "$log"
 
-  out=$(PATH="$fakebin:$PATH" CI=true GITHUB_ACTIONS=true FM_LINT_JOBS=1 \
+  out=$(PATH="$fakebin:$PATH" CI=true GITHUB_ACTIONS=true FM_LINT_FAST=1 FM_LINT_JOBS=1 \
     FM_TEST_MODE_LOG="$mode_log" "$LINT" "$fixture" 2>&1) \
     || fail "CI full lint mode failed"$'\n'"$out"
   [ "$(cat "$mode_log")" = on ] \
@@ -801,6 +803,7 @@ SH
     || fail "telemetry-enabled clean lint failed"
   [ "$telemetry_out" = "$out_clean_2" ] || fail "quiet telemetry changed routine lint output"
   assert_grep $'format\tfm-lint-telemetry-v1' "$telemetry" "telemetry format marker is missing"
+  assert_grep $'analysis_mode\tfull' "$telemetry" "telemetry did not record full analysis mode"
   assert_grep $'jobs\t2' "$telemetry" "telemetry did not record bounded jobs"
   assert_grep $'root_count\t1' "$telemetry" "telemetry did not record root count"
   assert_grep $'wall_seconds\t' "$telemetry" "telemetry did not record wall time"

--- a/tests/fm-lint.test.sh
+++ b/tests/fm-lint.test.sh
@@ -227,7 +227,9 @@ fm_lint_write_diff_file() {
 # that answers --version with the pinned version and otherwise logs the file
 # roots it was asked to check (one per line) instead of actually analyzing
 # them, so changed-file mode tests can assert exactly which files fm-lint.sh
-# selected without depending on real ShellCheck findings.
+# selected without depending on real ShellCheck findings. When
+# FM_TEST_MODE_LOG is set, it records the effective analysis mode, treating
+# ShellCheck's default as full analysis.
 fm_lint_stub_shellcheck() {
   local fakebin=$1 log=$2
   : > "$log"
@@ -237,11 +239,88 @@ if [ "\${1:-}" = --version ]; then
   printf 'ShellCheck - shell script analysis tool\nversion: 0.11.0\n'
   exit 0
 fi
-shift 3
+mode=on
+while [ "\$#" -gt 0 ] && [ "\$1" != -- ]; do
+  [ "\$1" = --extended-analysis=false ] && mode=off
+  shift
+done
+if [ -n "\${FM_TEST_MODE_LOG:-}" ]; then
+  printf '%s\n' "\$mode" >> "\$FM_TEST_MODE_LOG"
+fi
+[ "\$#" -eq 0 ] || shift
 printf '%s\n' "\$@" >> "$log"
 exit 0
 SH
   chmod +x "$fakebin/shellcheck"
+}
+
+test_fast_mode_disables_extended_analysis() {
+  local tmp fakebin log mode_log fixture out
+  tmp=$(fm_test_tmproot fm-lint-fast-mode)
+  fakebin=$(fm_fakebin "$tmp")
+  fixture="$tmp/fixture.sh"
+  log="$tmp/shellcheck.log"
+  mode_log="$tmp/mode.log"
+  cat > "$fixture" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "${1:-ok}"
+SH
+  chmod +x "$fixture"
+  fm_lint_stub_shellcheck "$fakebin" "$log"
+
+  out=$(PATH="$fakebin:$PATH" GITHUB_ACTIONS='' CI='' FM_LINT_JOBS=1 \
+    FM_TEST_MODE_LOG="$mode_log" "$LINT" --fast "$fixture" 2>&1) \
+    || fail "fast lint mode failed"$'\n'"$out"
+  [ "$(cat "$mode_log")" = off ] \
+    || fail "fast lint mode did not disable extended analysis"
+  [ "$(cat "$log")" = "$fixture" ] \
+    || fail "fast lint mode did not lint the requested root"
+  pass "fm-lint.sh --fast disables ShellCheck extended analysis"
+}
+
+test_ci_defaults_to_full_analysis() {
+  local tmp fakebin log mode_log fixture out
+  tmp=$(fm_test_tmproot fm-lint-ci-analysis)
+  fakebin=$(fm_fakebin "$tmp")
+  fixture="$tmp/fixture.sh"
+  log="$tmp/shellcheck.log"
+  mode_log="$tmp/mode.log"
+  cat > "$fixture" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "${1:-ok}"
+SH
+  chmod +x "$fixture"
+  fm_lint_stub_shellcheck "$fakebin" "$log"
+
+  out=$(PATH="$fakebin:$PATH" CI=true GITHUB_ACTIONS=true FM_LINT_JOBS=1 \
+    FM_TEST_MODE_LOG="$mode_log" "$LINT" "$fixture" 2>&1) \
+    || fail "CI full lint mode failed"$'\n'"$out"
+  [ "$(cat "$mode_log")" = on ] \
+    || fail "CI default did not keep full ShellCheck analysis"
+  pass "fm-lint.sh keeps full ShellCheck analysis by default in CI"
+}
+
+test_fast_mode_catches_a_real_lint_defect() {
+  if ! pinned_ready; then
+    pass "SKIP (ShellCheck $REQUIRED not resolved): fast lint-defect regression check"
+    return
+  fi
+  local tmp bad out rc
+  tmp=$(fm_test_tmproot fm-lint-fast-bad)
+  bad="$tmp/bad.sh"
+  cat > "$bad" <<'SH'
+#!/usr/bin/env bash
+foo() {
+  local a= b=
+  echo "$a$b"
+}
+foo
+SH
+  rc=0
+  out=$(GITHUB_ACTIONS='' CI='' "$LINT" --fast "$bad" 2>&1) || rc=$?
+  [ "$rc" -ne 0 ] || fail "fast lint mode passed a known-bad fixture"$'\n'"$out"
+  assert_contains "$out" "SC1007" "fast lint mode did not report the expected ShellCheck finding"
+  pass "fm-lint.sh --fast catches an ordinary shell lint defect"
 }
 
 test_changed_mode_lints_only_the_changed_file() {
@@ -878,6 +957,9 @@ SH
 }
 
 test_list_files_reports_the_shell_inventory
+test_fast_mode_disables_extended_analysis
+test_ci_defaults_to_full_analysis
+test_fast_mode_catches_a_real_lint_defect
 test_pins_an_explicit_version
 test_installer_retries_transient_download_failure
 test_installer_selects_platform_archive_url_and_checksum

--- a/tests/fm-lint.test.sh
+++ b/tests/fm-lint.test.sh
@@ -151,6 +151,17 @@ pinned_ready() {
   [ "$(shellcheck --version | awk '/^version:/ {print $2; exit}')" = "$REQUIRED" ]
 }
 
+test_help_reports_the_complete_interface() {
+  local help
+  help=$("$LINT" --help) || fail "fm-lint.sh --help failed"
+  assert_contains "$help" "--telemetry" "fm-lint.sh --help omitted --telemetry"
+  assert_contains "$help" "--required-version" "fm-lint.sh --help omitted --required-version"
+  assert_contains "$help" "--list-files" "fm-lint.sh --help omitted --list-files"
+  assert_contains "$help" "--help" "fm-lint.sh --help omitted --help"
+  assert_contains "$help" "--fast" "fm-lint.sh --help omitted --fast"
+  pass "fm-lint.sh --help reports the complete executable interface"
+}
+
 test_list_files_reports_the_shell_inventory() {
   local listed expected
   # CI=true forces the full canonical set regardless of the ambient branch or
@@ -956,6 +967,7 @@ SH
   pass "seeded dispatcher, adapter, production-owner, and test-local diagnostics preserve parity"
 }
 
+test_help_reports_the_complete_interface
 test_list_files_reports_the_shell_inventory
 test_fast_mode_disables_extended_analysis
 test_ci_defaults_to_full_analysis

--- a/tests/fm-lint.test.sh
+++ b/tests/fm-lint.test.sh
@@ -313,6 +313,30 @@ SH
   pass "fm-lint.sh keeps full ShellCheck analysis by default in CI"
 }
 
+test_ci_rejects_explicit_fast_mode() {
+  local tmp fakebin log fixture out rc
+  tmp=$(fm_test_tmproot fm-lint-ci-reject-fast)
+  fakebin=$(fm_fakebin "$tmp")
+  fixture="$tmp/fixture.sh"
+  log="$tmp/shellcheck.log"
+  cat > "$fixture" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "${1:-ok}"
+SH
+  chmod +x "$fixture"
+  fm_lint_stub_shellcheck "$fakebin" "$log"
+
+  rc=0
+  out=$(PATH="$fakebin:$PATH" CI=true GITHUB_ACTIONS=true FM_LINT_JOBS=1 \
+    "$LINT" --fast "$fixture" 2>&1) || rc=$?
+  [ "$rc" -eq 2 ] \
+    || fail "CI accepted explicit fast lint mode (exit $rc)"$'\n'"$out"
+  assert_contains "$out" "--fast is local-only" \
+    "CI fast-mode rejection did not explain the policy"
+  [ ! -s "$log" ] || fail "CI invoked ShellCheck after rejecting fast mode"
+  pass "fm-lint.sh rejects explicit --fast mode in CI"
+}
+
 test_fast_mode_catches_a_real_lint_defect() {
   if ! pinned_ready; then
     pass "SKIP (ShellCheck $REQUIRED not resolved): fast lint-defect regression check"
@@ -974,6 +998,7 @@ test_help_reports_the_complete_interface
 test_list_files_reports_the_shell_inventory
 test_fast_mode_disables_extended_analysis
 test_ci_defaults_to_full_analysis
+test_ci_rejects_explicit_fast_mode
 test_fast_mode_catches_a_real_lint_defect
 test_pins_an_explicit_version
 test_installer_retries_transient_download_failure


### PR DESCRIPTION
## Intent

Implement the FAST LOCAL lint mode identified by the lint-resource investigation. Add an explicit flag or environment mode on bin/fm-lint.sh that passes ShellCheck --extended-analysis=false for routine local checks, while CI and the no-mistakes gate remain unchanged and default to full analysis. Do not weaken CI or alter unrelated lint behavior. Add executable-interface regressions proving the fast path disables extended analysis, the CI/full path keeps it enabled and is the CI default, and fast mode still catches ordinary shell lint problems. This changes firstmate shared tracked material; note that homes pick it up after merge and a coordinated self-update. Deliver through no-mistakes to one green PR; captain merges it, and do not merge it autonomously.

## What Changed
- Add a local-only `fm-lint.sh --fast` mode that disables ShellCheck extended analysis while preserving full analysis as the default and rejecting fast mode in CI.
- Record the selected analysis mode in telemetry and document the complete lint interface.
- Add executable-interface regressions covering fast mode, CI defaults, help output, telemetry, and ordinary ShellCheck findings.

## Risk Assessment

✅ Low: The change is narrowly scoped, preserves full analysis for default CI and no-mistakes invocations, and includes behavior-level regression coverage for the new mode and prior fixes.

## Testing

The targeted fm-lint executable suite passed, and end-to-end checks with real ShellCheck 0.11.0 demonstrated complete help output, fast-mode telemetry, full CI-default telemetry despite ambient FM_LINT_FAST=1, rejection of --fast in CI, and detection of an ordinary SC1007 defect in fast mode.

<details>
<summary>Evidence: End-to-end fast/full lint mode transcript</summary>

Source: [End-to-end fast/full lint mode transcript](https://github.com/kunchenguid/firstmate/blob/7a8e91d86dafe665725dcf89b1c4538160a1a065/.no-mistakes/evidence/fm/firstmate-lint-fast-mode-r1/fm-lint-fast-mode-transcript.txt)

```text
=== Public help interface ===
Usage:
  fm-lint.sh                         lint the context-selected file set (see above)
  fm-lint.sh --fast [path]...       local lint with extended analysis disabled
  fm-lint.sh <path>...               lint explicit roots with the same config
  fm-lint.sh --jobs <1|2> [path]...  override bounded worker count
  fm-lint.sh --telemetry <path> ...  write a quiet metrics snapshot
  fm-lint.sh --required-version      print the ShellCheck pin
  fm-lint.sh --list-files            print the file set that would be linted
  fm-lint.sh --help                  print this usage

=== Fast local mode with real ShellCheck ===
fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)
fm-lint.sh: fast local mode; ShellCheck extended analysis disabled
format	fm-lint-telemetry-v1
shellcheck_version	0.11.0
analysis_mode	fast
root_count	1

=== CI/default full mode ignores ambient FM_LINT_FAST=1 ===
fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)
fm-lint.sh: full ShellCheck extended analysis enabled
format	fm-lint-telemetry-v1
shellcheck_version	0.11.0
analysis_mode	full
root_count	1

=== Fast mode catches an ordinary ShellCheck defect ===
fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)
fm-lint.sh: fast local mode; ShellCheck extended analysis disabled

In /Users/kunchen/.no-mistakes/evidence/01M0R1NFG9QRR47554HCYND47B/ordinary-defect.sh line 3:
  local a= b=
          ^-- SC1007 (warning): Remove space after = if trying to assign a value (for empty string, use var='' ... ).

For more information:
  https://www.shellcheck.net/wiki/SC1007 -- Remove space after = if trying to...
exit_status=1

=== CI refuses the local-only --fast flag ===
fm-lint.sh: --fast is local-only; CI uses full ShellCheck analysis.
exit_status=2
```
</details>
<details>
<summary>Evidence: Fast-mode telemetry protocol output</summary>

Source: [Fast-mode telemetry protocol output](https://github.com/kunchenguid/firstmate/blob/7a8e91d86dafe665725dcf89b1c4538160a1a065/.no-mistakes/evidence/fm/firstmate-lint-fast-mode-r1/fast-telemetry.tsv)

```text
format	fm-lint-telemetry-v1
git_head	d24e8c073ec727090c148797d2462502fa17edce
content_cksum	1990791522-86
shellcheck_version	0.11.0
analysis_mode	fast
jobs	2
root_count	1
direct_lines	2
direct_bytes	45
source_directives	0
source_boundary_directives	0
source_followed_directives	0
source_target_count	0
shard_1_weight_bytes	45
shard_2_weight_bytes	0
wall_seconds	0
worker_wall_sum_seconds	0.04
max_worker_wall_seconds	0.03
user_seconds	0.00
system_seconds	0.00
max_worker_rss_kib	24096
worker_rss_sum_kib	31376
shellcheck_processes_start	0
shellcheck_processes_end	0
load_average_start	5.13/3.99/3.34
load_average_end	5.13/3.99/3.34
aggregate_cpu_percent_start	70.90
aggregate_cpu_percent_end	70.90
result_exit	0
```
</details>
<details>
<summary>Evidence: CI/default full-mode telemetry protocol output</summary>

Source: [CI/default full-mode telemetry protocol output](https://github.com/kunchenguid/firstmate/blob/7a8e91d86dafe665725dcf89b1c4538160a1a065/.no-mistakes/evidence/fm/firstmate-lint-fast-mode-r1/full-telemetry.tsv)

```text
format	fm-lint-telemetry-v1
git_head	d24e8c073ec727090c148797d2462502fa17edce
content_cksum	1990791522-86
shellcheck_version	0.11.0
analysis_mode	full
jobs	2
root_count	1
direct_lines	2
direct_bytes	45
source_directives	0
source_boundary_directives	0
source_followed_directives	0
source_target_count	0
shard_1_weight_bytes	45
shard_2_weight_bytes	0
wall_seconds	0
worker_wall_sum_seconds	0.05
max_worker_wall_seconds	0.05
user_seconds	0.00
system_seconds	0.00
max_worker_rss_kib	24896
worker_rss_sum_kib	32176
shellcheck_processes_start	0
shellcheck_processes_end	0
load_average_start	5.13/3.99/3.34
load_average_end	5.13/3.99/3.34
aggregate_cpu_percent_start	55.10
aggregate_cpu_percent_end	50.20
result_exit	0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"ddcfc8b2fef68195743b4f57021b15fb66a4aad3","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- 🚨 `bin/fm-lint.sh:40` - The added header/usage lines shift the usage block through line 46, but fm_lint_usage still prints only lines 2–42. Consequently `fm-lint.sh --help` now omits `--telemetry`, `--required-version`, `--list-files`, and `--help`, contradicting “Do not ... alter unrelated lint behavior.” Replace the fixed line range with a boundary-based extraction or update it to cover the complete usage block.

🔧 Fix: Preserve complete fm-lint help output
2 issues (1 error, 1 warning) still open:

- 🚨 `bin/fm-lint.sh:127` - The requirement says “the no-mistakes gate [must] remain unchanged and default to full analysis,” but `FAST=${FM_LINT_FAST:-0}` lets an inherited `FM_LINT_FAST=1` weaken `.no-mistakes.yaml`&#39;s unchanged `bin/fm-lint.sh` invocation because the CI-only guard does not recognize the local gate. Keep fast mode CLI-only or otherwise ensure the gate cannot inherit fast mode.
- ⚠️ `bin/fm-lint.sh:552` - A `--fast --telemetry` snapshot records ShellCheck version and resource measurements but not whether extended analysis was disabled. Fast and full snapshots can therefore appear configuration-equivalent while measuring different workloads; add the effective analysis mode to the telemetry protocol.

🔧 Fix: Isolate fast lint mode and report telemetry
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-lint.test.sh`
- `./bin/fm-lint.sh --help`
- `CI='' GITHUB_ACTIONS='' ./bin/fm-lint.sh --fast --telemetry <fast-telemetry> <clean-fixture>`
- `CI=true GITHUB_ACTIONS=true FM_LINT_FAST=1 ./bin/fm-lint.sh --telemetry <full-telemetry> <clean-fixture>`
- `CI='' GITHUB_ACTIONS='' ./bin/fm-lint.sh --fast <ordinary-defect-fixture>`
- `CI=true GITHUB_ACTIONS=true ./bin/fm-lint.sh --fast <clean-fixture>`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
