### PR TITLE
fix(bin): send the Relay bearer to curl on stdin instead of a temp file

### DIFF
--- a/bin/fm-x-dismiss.sh
+++ b/bin/fm-x-dismiss.sh
@@ -89,18 +89,17 @@ if [ -z "$FMX_TOKEN" ]; then
   exit 1
 fi
 command -v curl >/dev/null 2>&1 || { echo "fm-x-dismiss: curl not found" >&2; exit 1; }
-AUTH_HEADER_FILE=$(fmx_auth_header_file) || {
+CURL_CONFIG=$(fmx_curl_config "$FMX_RELAY/connector/dismiss") || {
   echo "fm-x-dismiss: invalid FMX_PAIRING_TOKEN" >&2
   exit 1
 }
-trap 'rm -f "$AUTH_HEADER_FILE"' EXIT
 
-code=$(curl -m 10 -s -o /dev/null -w '%{http_code}' \
+# URL and bearer header go in on stdin (see fmx_curl_config) so the token is
+# never visible in curl's argv.
+code=$(printf '%s\n' "$CURL_CONFIG" | curl -K - -m 10 -s -o /dev/null -w '%{http_code}' \
   -X POST \
-  -H "@$AUTH_HEADER_FILE" \
   -H 'Content-Type: application/json' \
-  --data "$PAYLOAD" \
-  "$FMX_RELAY/connector/dismiss" 2>/dev/null) || {
+  --data "$PAYLOAD" 2>/dev/null) || {
   echo "fm-x-dismiss: request to relay failed" >&2
   exit 1
 }

--- a/bin/fm-x-lib.sh
+++ b/bin/fm-x-lib.sh
@@ -10,7 +10,8 @@
 #   fmx_env_get <key> <file>   - read one KEY=VALUE from a .env-style file
 #   fmx_load_config            - resolve FMX_TOKEN, FMX_RELAY, FMX_DRY, FMX_MAX,
 #                                and FMX_THREAD_MAX (env wins over .env)
-#   fmx_auth_header_file       - write the bearer header to a 0600 temp file
+#   fmx_curl_config <url>      - emit a `curl -K -` config carrying the request
+#                                URL and the bearer header, for feeding on stdin
 #   fmx_extract_reply_context <json-file> - the single owner of reply-context
 #                                extraction: infer {platform, reply_max_chars}
 #                                from any mention/relay payload file
@@ -730,15 +731,34 @@ fmx_split_thread() {
   '
 }
 
-fmx_auth_header_file() {
-  local file
-  case "$FMX_TOKEN" in
+# Emit a curl config carrying the request URL and the bearer header, to be fed
+# to `curl -K -` on stdin. This is the single owner of how the token reaches
+# curl, and every fm-x-* request must go through it.
+#
+# The token must never appear in curl's argv: process arguments are world
+# readable (ps) for the life of the call, so `-H "Authorization: Bearer $tok"`
+# would leak the credential to any local process. stdin is private to the pipe,
+# and unlike the 0600 temp file this replaces it leaves nothing on disk that can
+# outlive the call - a SIGKILL cannot skip a cleanup trap that no longer exists.
+#
+# Callers must build the config with a shell BUILTIN printf (as below) and pipe
+# it in; passing it as an argument to any external command would reintroduce the
+# exact argv exposure this exists to prevent.
+#
+# Values are emitted in curl's quoted-value syntax, so a literal backslash or
+# double quote is escaped. A token containing a newline is rejected outright:
+# the config is line oriented, so no escaping could keep it one directive.
+fmx_curl_config() {
+  local url=$1 token=${FMX_TOKEN-}
+  case "$token" in
     *$'\n'*|*$'\r'*) return 1 ;;
   esac
-  file=$(umask 077; mktemp "${TMPDIR:-/tmp}/fm-x-auth.XXXXXX") || return 1
-  chmod 600 "$file" 2>/dev/null || { rm -f "$file"; return 1; }
-  printf 'Authorization: Bearer %s\n' "$FMX_TOKEN" > "$file" || { rm -f "$file"; return 1; }
-  printf '%s\n' "$file"
+  token=${token//\\/\\\\}
+  token=${token//\"/\\\"}
+  url=${url//\\/\\\\}
+  url=${url//\"/\\\"}
+  printf 'url = "%s"\n' "$url"
+  printf 'header = "Authorization: Bearer %s"\n' "$token"
 }
 
 fmx_image_media_type_from_path() {
@@ -875,21 +895,18 @@ fmx_reply_outbox_json() {
 }
 
 fmx_post_json() (
-  local endpoint=$1 payload_file=$2 body_file=${3:-/dev/null} auth_header_file code rc
+  local endpoint=$1 payload_file=$2 body_file=${3:-/dev/null} config code rc
   command -v curl >/dev/null 2>&1 || return 127
   [ -r "$payload_file" ] || return 2
-  auth_header_file=$(fmx_auth_header_file) || return 3
-  trap 'rm -f "$auth_header_file"' EXIT
-  trap 'rm -f "$auth_header_file"; exit 143' HUP INT TERM
-  code=$(curl -m 10 -s -o "$body_file" -w '%{http_code}' \
+  config=$(fmx_curl_config "$FMX_RELAY/connector/$endpoint") || return 3
+  # The URL and bearer header arrive on stdin; the payload is read from its own
+  # file, so nothing here contends for stdin. printf is a builtin, so the token
+  # never becomes another process's argv.
+  code=$(printf '%s\n' "$config" | curl -K - -m 10 -s -o "$body_file" -w '%{http_code}' \
     -X POST \
-    -H "@$auth_header_file" \
     -H 'Content-Type: application/json' \
-    --data-binary "@$payload_file" \
-    "$FMX_RELAY/connector/$endpoint" 2>/dev/null)
+    --data-binary "@$payload_file" 2>/dev/null)
   rc=$?
-  rm -f "$auth_header_file"
-  trap - EXIT HUP INT TERM
   [ "$rc" = 0 ] || return 4
   printf '%s\n' "$code"
 )

--- a/bin/fm-x-poll.sh
+++ b/bin/fm-x-poll.sh
@@ -105,17 +105,17 @@ command -v jq   >/dev/null 2>&1 || { emit_error_once "missing jq"; exit 0; }
 fmx_context_registry_prune "$STATE"
 
 BODY_FILE=$(mktemp "${TMPDIR:-/tmp}/fm-x-poll.XXXXXX") || exit 0
-AUTH_HEADER_FILE=
-trap 'rm -f "$BODY_FILE" "$AUTH_HEADER_FILE"' EXIT
-AUTH_HEADER_FILE=$(fmx_auth_header_file) || { emit_error_once "invalid token"; exit 0; }
+trap 'rm -f "$BODY_FILE"' EXIT
+CURL_CONFIG=$(fmx_curl_config "$FMX_RELAY/connector/poll") || { emit_error_once "invalid token"; exit 0; }
 
 # Short, bounded poll: a failure or timeout simply means "no wake this cycle";
 # the next check cycle retries. -m 5 keeps this well inside the watcher's
 # per-check timeout so the supervision loop is never starved.
-code=$(curl -m 5 -s -o "$BODY_FILE" -w '%{http_code}' \
-  -H "@$AUTH_HEADER_FILE" \
-  -H 'Accept: application/json' \
-  "$FMX_RELAY/connector/poll" 2>/dev/null) || exit 0
+#
+# URL and bearer header go in on stdin (see fmx_curl_config) so the token is
+# never visible in curl's argv.
+code=$(printf '%s\n' "$CURL_CONFIG" | curl -K - -m 5 -s -o "$BODY_FILE" -w '%{http_code}' \
+  -H 'Accept: application/json' 2>/dev/null) || exit 0
 
 # 204 (nothing pending) is the common path; only 200 can carry a mention.
 case "$code" in

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -273,6 +273,7 @@ A user enables it by putting `FMX_PAIRING_TOKEN` in the firstmate home's gitigno
 That token is standing authorization for firstmate to answer public mentions and act autonomously on normal reversible mention requests.
 Destructive, irreversible, or security-sensitive asks are escalated for trusted-channel confirmation instead of being executed from a public mention.
 The relay uses owner-only routing: a mention delivered to a home is from that home's owner, while its surrounding conversation context may still include other public accounts.
+`bin/fm-x-lib.sh:fmx_curl_config` is the only thing that hands that token to `curl`: every Relay request feeds its URL and bearer header in on stdin (`curl -K -`), so the credential never enters world-readable process arguments and never lands on disk, and a new request site goes through that helper instead of adding an `-H` argument or a header file.
 On the locked session-start bootstrap step, that token creates the local polling and watcher-cadence artifacts described in the [Relay configuration reference](configuration.md#relay-env).
 Without the token, the locked session-start bootstrap step removes those artifacts on opt-out and otherwise stays silent, so non-Relay users see no behavior change.
 Newly offered mentions are stored as `state/x-inbox/<request_id>.json` and wake firstmate once per retained request ID; the [Relay configuration reference](configuration.md#relay-env) owns the durable offer-marker and re-offer contract.

--- a/tests/fm-x-mode.test.sh
+++ b/tests/fm-x-mode.test.sh
@@ -33,8 +33,36 @@ make_fake_curl() {
 #!/usr/bin/env bash
 ofile="" method=GET data="" url="" auth=""
 argv=$*
+
+# Undo curl's quoted-value escaping (\\ and \") from a -K config directive.
+unesc() {
+  local s=$1 out= c
+  while [ -n "$s" ]; do
+    c=${s:0:1}
+    if [ "$c" = '\' ]; then out=$out${s:1:1}; s=${s:2}; else out=$out$c; s=${s:1}; fi
+  done
+  printf '%s' "$out"
+}
+
+# Parse the url/header directives the client feeds to `curl -K -` on stdin.
+read_config() {
+  local line v
+  while IFS= read -r line; do
+    case "$line" in
+      'url = "'*)
+        v=${line#'url = "'}; v=${v%'"'}; url=$(unesc "$v") ;;
+      'header = "'*)
+        v=${line#'header = "'}; v=${v%'"'}; v=$(unesc "$v")
+        case "$v" in Authorization:*) auth=$v ;; esac ;;
+    esac
+  done
+}
+
 while [ $# -gt 0 ]; do
   case "$1" in
+    -K)
+      if [ "$2" = "-" ]; then read_config; else read_config < "$2"; fi
+      shift 2 ;;
     -o) ofile=$2; shift 2 ;;
     -X) method=$2; shift 2 ;;
     --data) data=$2; shift 2 ;;
@@ -60,7 +88,11 @@ while [ $# -gt 0 ]; do
   esac
 done
 if [ -n "${FAKE_CURL_LOG:-}" ]; then
-  { echo "argv=$argv"; echo "method=$method"; echo "url=$url"; echo "auth=$auth"; echo "data=$data"; } >> "$FAKE_CURL_LOG"
+  # psargv is what ANY other local user's process would see via ps for this
+  # call - the actual exposure the bearer-in-argv defect is about. It is read
+  # from the OS, not reconstructed from "$@", so it cannot be faked by the stub.
+  psargv=$(ps -o args= -p $$ 2>/dev/null | tr '\n' ' ')
+  { echo "argv=$argv"; echo "psargv=$psargv"; echo "method=$method"; echo "url=$url"; echo "auth=$auth"; echo "data=$data"; } >> "$FAKE_CURL_LOG"
 fi
 case "$url" in
   */connector/poll)
@@ -602,40 +634,31 @@ test_reply_non_2xx_fails() {
   pass "fm-x-reply exits non-zero on a non-2xx relay response"
 }
 
-test_reply_auth_header_tempfile_cleans_up_on_interrupted_post() {
-  local home fakebin log out rc auth_file
+# A post killed mid-flight is the case a cleanup trap can lose: the credential
+# now rides stdin, so there is no auth file to leak in the first place. Assert
+# the absence directly against a private TMPDIR rather than trusting a trap.
+test_reply_interrupted_post_writes_no_credential_file() {
+  local home fakebin tmpdir out rc leaked
   home="$TMP_ROOT/reply-auth-interrupt"; mkdir -p "$home"
   fakebin=$(fm_fakebin "$home")
-  log="$home/auth-file.txt"
+  tmpdir="$home/tmp"; mkdir -p "$tmpdir"
   cat > "$fakebin/curl" <<'SH'
 #!/usr/bin/env bash
-auth_file=
-while [ $# -gt 0 ]; do
-  case "$1" in
-    -H)
-      case "$2" in @*) auth_file=${2#@} ;; esac
-      shift 2
-      ;;
-    -o|-w|-X|-m|--data|--data-binary) shift 2 ;;
-    -s) shift ;;
-    *) shift ;;
-  esac
-done
-printf '%s\n' "$auth_file" > "$FAKE_AUTH_FILE_LOG"
+# Die mid-post, exactly where a trap-based cleanup would have to run.
 kill -TERM "$PPID"
 exit 143
 SH
   chmod +x "$fakebin/curl"
   printf 'FMX_PAIRING_TOKEN=tok-clean\n' > "$home/.env"
   out=$(PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FMX_RELAY_URL="https://relay.test" \
-    FAKE_AUTH_FILE_LOG="$log" \
+    TMPDIR="$tmpdir" \
     "$ROOT/bin/fm-x-reply.sh" "req-clean" "Hello." 2>"$home/err"); rc=$?
   [ "$rc" -ne 0 ] || fail "interrupted relay post must fail"
   [ -z "$out" ] || fail "interrupted relay post must not echo the request_id (got: $out)"
-  auth_file=$(cat "$log")
-  [ -n "$auth_file" ] || fail "fake curl must record the auth header temp file"
-  [ ! -e "$auth_file" ] || fail "auth header temp file must be removed after an interrupted post"
-  pass "fm-x-reply cleans up auth header temp files on interrupted posts"
+  leaked=$(grep -rl "tok-clean" "$tmpdir" 2>/dev/null || true)
+  [ -z "$leaked" ] \
+    || fail "interrupted post left the token in a temp file: $leaked"
+  pass "fm-x-reply writes no credential temp file, even on an interrupted post"
 }
 
 test_reply_usage_error() {
@@ -2863,6 +2886,94 @@ test_followup_usage_errors() {
   pass "fm-x-followup rejects malformed invocations"
 }
 
+# --- the bearer must never reach curl's argv --------------------------------
+#
+# Process arguments are world readable: any local process can read them from ps
+# for the life of the call, so a bearer passed as `-H "Authorization: Bearer
+# $tok"` leaks the credential. Every fm-x-* request must hand curl its URL and
+# auth header on stdin (`curl -K -`) instead.
+#
+# This asserts against psargv - the command line read back from the OS by the
+# fake curl itself - so it measures the real exposure rather than restating what
+# the source says. Each case also asserts the token DID arrive in the auth
+# header, so a client that simply stopped authenticating could not pass.
+assert_token_off_argv() {
+  local log=$1 token=$2 label=$3 psargv
+  # Exact string compare, not a pattern: a token may contain regex metacharacters.
+  [ "$(grep '^auth=' "$log" | tail -1)" = "auth=Authorization: Bearer $token" ] \
+    || fail "$label must still send the bearer token (else this check is vacuous)"
+  psargv=$(grep '^psargv=' "$log" | tail -1)
+  [ -n "$psargv" ] || fail "$label: fake curl recorded no OS-visible command line"
+  if printf '%s' "$psargv" | grep -Fq "$token"; then
+    fail "$label leaked the bearer token into curl argv (visible via ps): $psargv"
+  fi
+  if grep '^argv=' "$log" | grep -Fq "$token"; then
+    fail "$label leaked the bearer token into curl argv"
+  fi
+}
+
+test_poll_keeps_bearer_off_curl_argv() {
+  local home fakebin log
+  home="$TMP_ROOT/argv-poll"; mkdir -p "$home"
+  fakebin=$(make_fake_curl "$home")
+  log="$home/curl.log"
+  printf 'FMX_PAIRING_TOKEN=tok-argv-poll\n' > "$home/.env"
+  PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FMX_RELAY_URL="https://relay.test" \
+    FAKE_CURL_LOG="$log" FAKE_POLL_CODE=204 \
+    "$ROOT/bin/fm-x-poll.sh" >/dev/null 2>&1
+  assert_grep "url=https://relay.test/connector/poll" "$log" "poll must still reach the relay"
+  assert_token_off_argv "$log" "tok-argv-poll" "poll"
+  pass "fm-x-poll keeps the bearer token out of curl argv"
+}
+
+test_reply_keeps_bearer_off_curl_argv() {
+  local home fakebin log
+  home="$TMP_ROOT/argv-reply"; mkdir -p "$home"
+  fakebin=$(make_fake_curl "$home")
+  log="$home/curl.log"
+  printf 'FMX_PAIRING_TOKEN=tok-argv-reply\n' > "$home/.env"
+  PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FMX_RELAY_URL="https://relay.test" \
+    FAKE_CURL_LOG="$log" FAKE_ANSWER_CODE=200 \
+    "$ROOT/bin/fm-x-reply.sh" "req-argv" "Aye." >/dev/null 2>&1
+  assert_grep "url=https://relay.test/connector/answer" "$log" "reply must still reach the relay"
+  assert_token_off_argv "$log" "tok-argv-reply" "reply"
+  pass "fm-x-reply keeps the bearer token out of curl argv"
+}
+
+test_dismiss_keeps_bearer_off_curl_argv() {
+  local home fakebin log
+  home="$TMP_ROOT/argv-dismiss"; mkdir -p "$home"
+  fakebin=$(make_fake_curl "$home")
+  log="$home/curl.log"
+  printf 'FMX_PAIRING_TOKEN=tok-argv-dismiss\n' > "$home/.env"
+  PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FMX_RELAY_URL="https://relay.test" \
+    FAKE_CURL_LOG="$log" FAKE_DISMISS_CODE=200 \
+    "$ROOT/bin/fm-x-dismiss.sh" "req-argv" >/dev/null 2>&1
+  assert_grep "url=https://relay.test/connector/dismiss" "$log" "dismiss must still reach the relay"
+  assert_token_off_argv "$log" "tok-argv-dismiss" "dismiss"
+  pass "fm-x-dismiss keeps the bearer token out of curl argv"
+}
+
+# A token carrying curl config metacharacters must survive the stdin config
+# round trip intact, or the escaping could silently corrupt or truncate auth.
+test_curl_config_escapes_awkward_token() {
+  local home fakebin log token
+  home="$TMP_ROOT/argv-escape"; mkdir -p "$home"
+  fakebin=$(make_fake_curl "$home")
+  log="$home/curl.log"
+  token='tok "quoted" \and\ slashed'
+  printf 'FMX_PAIRING_TOKEN=%s\n' "$token" > "$home/.env"
+  PATH="$fakebin:$BASE_PATH" FM_HOME="$home" FMX_RELAY_URL="https://relay.test" \
+    FAKE_CURL_LOG="$log" FAKE_POLL_CODE=204 \
+    "$ROOT/bin/fm-x-poll.sh" >/dev/null 2>&1
+  assert_token_off_argv "$log" "$token" "poll (awkward token)"
+  pass "the curl stdin config escapes quotes and backslashes in a token"
+}
+
+test_poll_keeps_bearer_off_curl_argv
+test_reply_keeps_bearer_off_curl_argv
+test_dismiss_keeps_bearer_off_curl_argv
+test_curl_config_escapes_awkward_token
 test_poll_no_token_is_hard_noop
 test_poll_empty_env_token_overrides_env_file
 test_poll_204_is_silent
@@ -2880,7 +2991,7 @@ test_poll_rejects_unsafe_request_id
 test_reply_success_posts_request_bound_only
 test_reply_text_file_and_stdin
 test_reply_non_2xx_fails
-test_reply_auth_header_tempfile_cleans_up_on_interrupted_post
+test_reply_interrupted_post_writes_no_credential_file
 test_reply_usage_error
 test_reply_help_mentions_image
 test_reply_whitespace_text_rejected


### PR DESCRIPTION
## Intent

Keep the Bearer key out of curl argv in the Relay scripts.

THE DEFECT AS BRIEFED: process arguments are world-readable via ps, so -H "Authorization: Bearer $key" exposes the credential to any local process for the life of the call. A standing captain rule from today makes the ONLY allowed shape 'curl -K -', reading url and header from stdin.

IMPORTANT PREMISE CORRECTION FOUND WHILE WORKING (deliberate, not an oversight): the fm-x-* scripts were NOT passing the bearer in argv. All three request sites already routed the header through -H "@tempfile" (a mode-600 temp file written by fmx_auth_header_file). There is no -H "Authorization: Bearer $key" anywhere in this family. This was verified by tracing every FMX_TOKEN reference and every curl call site. The work was still done because the captain's rule mandates the 'curl -K -' shape regardless, and it is a genuine improvement: it removes a credential from disk whose cleanup depended on traps, and traps do not survive SIGKILL. Reviewers should not expect to find a removed argv leak in this diff.

SCOPE FENCE (non-negotiable, explicitly imposed): fix ONLY the bin/fm-x-*.sh family. Do NOT touch, for any reason: bin/flowy-fleet-watch.sh and bin/flowy-fleet-nudge.sh (another owner runs these), bin/fm-completion-outbox.sh (a live crew is fixing exactly this defect there right now), AGENTS.md, data/captain.md, .agents/skills/flowy-collab/ (firstmate is editing those). If a fix seems to need one of those, STOP and report instead of editing. Any finding that proposes editing those files must be escalated, not applied.

REQUIREMENTS AS ACCEPTED:
- Never print, echo or log the key, and avoid a file that outlives the call - avoid a file at all if possible.
- Prefer ONE shared helper over repeating the pattern per script (explicitly requested).
- Add a colocated test proving the key is absent from argv - a real behavioural check, NOT an assertion about source bytes.
- Full lint gate green on both pinned linters (bin/fm-lint.sh: shellcheck + actionlint).
- Do not add an agent name as a commit co-author. Do not merge.

WHAT WAS BUILT AND WHY: a single shared owner, fmx_curl_config, emits curl's url and header directives for 'curl -K -' to read on stdin. Callers build it with the printf BUILTIN and pipe it in, so the token never becomes any process's argv and never touches disk. Converted all three request sites: fmx_post_json (answer/followup/request-context), fm-x-poll.sh, fm-x-dismiss.sh. Values use curl's quoted-value syntax with backslash and double-quote escaped; a newline-bearing token is still refused outright (kept from the old helper) because the config is line-oriented.

DELIBERATE DESIGN DECISIONS a reviewer might otherwise flag:
- The trailing newline in printf '%s\n' "$config" is load-bearing: command substitution strips it, and a final unterminated config line is fragile to parse.
- The auth temp file and its EXIT/HUP/INT/TERM cleanup traps were deleted on purpose; there is no longer a file to clean up. That is the point of the change, not a dropped safeguard.
- fmx_curl_config uses ${FMX_TOKEN-} so it is safe under set -u.
- 'curl -K -' consuming stdin does not conflict with any call site: payloads are passed via --data-binary @file or --data, never stdin.
- 'curl -K -' behaviour was verified empirically against a real local listener before building on it, including a token containing a double quote and a backslash.

TESTING APPROACH (deliberate): tests/fm-x-mode.test.sh's fake curl now records psargv - the command line it reads back FROM THE OS via ps - and the new tests assert the token is absent from it. This measures the actual exposure rather than restating the source, satisfying the explicit 'behavioural, not source bytes' requirement. Each case ALSO asserts the bearer still arrived in the auth header, so a client that simply stopped authenticating could not pass vacuously. This was mutation-tested: reintroducing the argv form makes the tests fail with the real leaked command line. An awkward-token case pins the quote/backslash escaping round trip. The pre-existing interrupted-post test previously asserted that a trap REMOVED the auth temp file; since no such file is created any more, it was rewritten to prove the stronger property - no credential file is written at all, checked against a private TMPDIR. That rewrite is intentional, not a weakened test.

KNOWN PRE-EXISTING FAILURES, NOT CAUSED BY THIS CHANGE: tests/fm-public-followup.test.sh ('could not register the public commitment') and tests/fm-gotmp.test.sh ('teardown did not remove the tasktmp dir') each fail one test. Both were baselined by stashing this change and re-running on the clean base, where they fail identically. They are broken on main and are out of scope for this task.

## What Changed

- Replaced `fmx_auth_header_file` with `fmx_curl_config <url>` in `bin/fm-x-lib.sh`: it emits `url` and `header` directives in curl's quoted-value syntax (escaping `\` and `"`, still rejecting a token containing a newline or carriage return) and reads `${FMX_TOKEN-}` so it is safe under `set -u`. The 0600 auth temp file and its `EXIT`/`HUP`/`INT`/`TERM` cleanup traps are gone — there is no longer a credential file to clean up.
- Converted all three Relay request sites — `fmx_post_json`, `bin/fm-x-poll.sh`, and `bin/fm-x-dismiss.sh` — to pipe that config into `curl -K -` via builtin `printf`, dropping the `-H "@file"` argument and the inline URL argument. Payloads still travel via `--data`/`--data-binary @file`, so nothing else contends for stdin. `docs/architecture.md` now names `fmx_curl_config` as the single owner of how the token reaches curl.
- `tests/fm-x-mode.test.sh`: the fake curl parses `-K` config from stdin or a file and records `psargv`, its own command line read back from the OS via `ps`. New poll/reply/dismiss cases assert the token is absent from that command line while the bearer still arrives in the auth header, plus a case pinning the quote/backslash escaping round trip. The interrupted-post test was rewritten to assert no credential file is written at all, checked against a private `TMPDIR`.

## Risk Assessment

✅ Low: A well-bounded, single-purpose hardening of three curl call sites behind one shared helper: the escaping round-trips correctly against curl's actual config-value unescaping, exit-status and stdin semantics are unchanged (no pipefail, stdin consumed before the request), no stale references to the removed temp-file helper remain, the scope fence and commit-metadata constraints are honored, and both findings are minor robustness improvements rather than reachable defects.

## Testing

Ran the colocated suite `tests/fm-x-mode.test.sh` (110 ok, 0 not ok), then went past unit-level evidence: I drove the shipped `fm-x-poll.sh` and `fm-x-reply.sh` with real curl against a real local HTTP listener while sampling `ps` from a separate process, and the bearer never appeared in curl's command line on either the GET or the POST path while the listener still received the correct `Authorization: Bearer` header and an intact JSON body. A control run of the briefed defective `-H "Authorization: Bearer $tok"` shape against the same listener did show the credential in `ps`, so the check is measuring the real exposure. A private TMPDIR watched throughout the call held no credential file, whereas the same harness against the base commit caught the old mode-0600 `fm-x-auth.*` file on disk — the concrete improvement this change makes. I also mutation-tested the new tests by reintroducing the argv form, which made them fail with the actual leaked command line, then reverted. The two test files the author flagged as broken on main fail identically after reverting this change's files to the base commit, so they are pre-existing and unrelated. No visual artifacts apply: this is a shell CLI and credential-handling change with no rendered surface. The transient harness was removed and the worktree is clean at the target commit.

<details>
<summary>Evidence: End-to-end: bearer absent from curl argv, present in the relay&#39;s auth header (real curl, real listener, real ps)</summary>

Source: [End-to-end: bearer absent from curl argv, present in the relay&#39;s auth header (real curl, real listener, real ps)](https://github.com/cedmos/firstmate/blob/7fa835aa7a56c1b708299f25b7a7ae1e910921bb/.no-mistakes/evidence/fm/fmx-bearer-argv-leak/relay-bearer-argv-e2e.txt)

<code>=== 1. SHIPPED CLIENT: bin/fm-x-poll.sh against http://127.0.0.1 (a real listener) ===&#10;curl processes sampled from the OS (ps -A -o comm=,args=) for the life of the call:&#10;&#10;curl -K - -m 5 -s -o /…/fm-x-poll.BD4hjY -w %{http_code} -H Accept: application/json&#10;&#10;grep -c &#34;s3cr3t-relay-bearer-DO-NOT-LEAK&#34; &lt;ps sample&gt; -&gt; 0&#10;=&gt; the bearer is NOT in curl argv.&#10;&#10;=== 2. ...and the request still authenticated (relay-side view) ===&#10;GET /connector/poll&#10;authorization: Bearer s3cr3t-relay-bearer-DO-NOT-LEAK&#10;&#10;=== 3. CONTROL: the briefed defective shape, same listener, same sampler ===&#10;curl -m 5 -s -o /dev/null -w control http_code=%{http_code}\n -H Authorization: Bearer s3cr3t-relay-bearer-DO-NOT-LEAK -H Accept: application/json http://127.0.0.1:60222/connector/poll&#10;=&gt; ps DOES expose the credential for that shape. The measurement is real.&#10;&#10;=== 4. Nothing on disk: private TMPDIR polled every 100ms for the whole call ===&#10;files containing the token: (none)&#10;&#10;=== 5. CONTRAST at base commit 822a990 (same harness) ===&#10;-rw-------@ /…/tmp-base/fm-x-auth.al9NLA&#10;=&gt; the base client wrote a mode-0600 credential file to disk for the call.&#10;The target commit writes none at all.&#10;&#10;=== 6. THE POST PATH: bin/fm-x-reply.sh -&gt; POST /connector/answer (real socket) ===&#10;$ fm-x-reply.sh req-e2e-001 &#34;Aye captain - relay reply over a real socket.&#34;&#10;req-e2e-001 (exit 0)&#10;curl -K - -m 10 -s -o /…/fm-x-reply.CMTOcO -w %{http_code} -X POST -H Content-Type: application/json --data-binary @/…/fm-x-reply.FnBaiI&#10;token occurrences in that ps sample: 0&#10;relay-side:&#10;POST /connector/answer&#10;authorization: Bearer s3cr3t-relay-bearer-DO-NOT-LEAK&#10;body: {&#34;request_id&#34;:&#34;req-e2e-001&#34;,&#34;text&#34;:&#34;Aye captain - relay reply over a real socket.&#34;}&#10;=&gt; bearer absent from argv, bearer present in the header, JSON body intact -&#10;&#39;curl -K -&#39; reading stdin does not contend with --data-binary @file.</code>

```text
Real curl, real local HTTP relay, real ps. Token used: s3cr3t-relay-bearer-DO-NOT-LEAK

=== 1. SHIPPED CLIENT: bin/fm-x-poll.sh against http://127.0.0.1 (a real listener) ===
curl processes sampled from the OS (ps -A -o comm=,args=) for the life of the call,
exactly what any other local process could read:

    curl -K - -m 5 -s -o /Users/cedmo/.no-mistakes/worktrees/263c604673df/01M0R1DSK5XVBR6DAMZ1Y3EGDY/tmp/fmx-e2e/tmp/fm-x-poll.BD4hjY -w %{http_code} -H Accept: application/json

    grep -c "s3cr3t-relay-bearer-DO-NOT-LEAK" <ps sample>  ->  0
    => the bearer is NOT in curl argv.

=== 2. ...and the request still authenticated (relay-side view) ===
    GET /connector/poll
    authorization: Bearer s3cr3t-relay-bearer-DO-NOT-LEAK
    GET /connector/poll
    authorization: Bearer s3cr3t-relay-bearer-DO-NOT-LEAK
    (two GETs: the shipped client, then the control below)

=== 3. CONTROL: the briefed defective shape, same listener, same sampler ===
    curl -m 5 ... -H "Authorization: Bearer $TOKEN" http://127.0.0.1:PORT/connector/poll

    curl -m 5 -s -o /dev/null -w control http_code=%{http_code}\n -H Authorization: Bearer s3cr3t-relay-bearer-DO-NOT-LEAK -H Accept: application/json http://127.0.0.1:60222/connector/poll
    => ps DOES expose the credential for that shape. The measurement is real;
       the shipped client simply does not produce such a line.

=== 4. Nothing on disk: private TMPDIR polled every 100ms for the whole call ===
    files containing the token: (none)
    TMPDIR after the run:
    total 0
    drwxr-xr-x@  2 cedmo  staff   64 Aug 23 21:36 .
    drwxr-xr-x@ 11 cedmo  staff  352 Aug 23 21:37 ..

=== 5. CONTRAST at base commit 822a990 (same harness, base bin/fm-x-{lib,poll}.sh) ===
    -rw-------@  /Users/cedmo/.no-mistakes/worktrees/263c604673df/01M0R1DSK5XVBR6DAMZ1Y3EGDY/tmp/fmx-e2e/tmp-base/fm-x-auth.al9NLA
    => the base client wrote a mode-0600 credential file to disk for the call.
       The target commit writes none at all.

=== 6. THE POST PATH: bin/fm-x-reply.sh -> POST /connector/answer (real socket) ===
    $ fm-x-reply.sh req-e2e-001 "Aye captain - relay reply over a real socket."
    req-e2e-001            (exit 0)

    curl process as ps sees it:
      curl -K - -m 10 -s -o /Users/cedmo/.no-mistakes/worktrees/263c604673df/01M0R1DSK5XVBR6DAMZ1Y3EGDY/tmp/fmx-e2e/tmp-r/fm-x-reply.CMTOcO -w %{http_code} -X POST -H Content-Type: application/json --data-binary @/Users/cedmo/.no-mistakes/worktrees/263c604673df/01M0R1DSK5XVBR6DAMZ1Y3EGDY/tmp/fmx-e2e/tmp-r/fm-x-reply.FnBaiI
      token occurrences in that ps sample: 0

    relay-side:
      POST /connector/answer
      authorization: Bearer s3cr3t-relay-bearer-DO-NOT-LEAK
      body: {"request_id":"req-e2e-001","text":"Aye captain - relay reply over a real socket."}
      

    => bearer absent from argv, bearer present in the header, and the JSON body
       arrived intact - so 'curl -K -' reading stdin does not contend with
       --data-binary @file. No credential file appeared under the private TMPDIR.
```
</details>
<details>
<summary>Evidence: Mutation check + pre-existing-failure baseline</summary>

Source: [Mutation check + pre-existing-failure baseline](https://github.com/cedmos/firstmate/blob/7fa835aa7a56c1b708299f25b7a7ae1e910921bb/.no-mistakes/evidence/fm/fmx-bearer-argv-leak/mutation-and-baseline.txt)

<code>MUTATION CHECK - do the new tests actually catch the leak?&#10;Reintroduced `-H &#34;Authorization: Bearer $FMX_TOKEN&#34;` in bin/fm-x-poll.sh, re-ran the suite:&#10;&#10;not ok - poll leaked the bearer token into curl argv (visible via ps): psargv=bash&#10;/var/.../argv-poll/fakebin/curl -m 5 -s -o /var/.../fm-x-poll.fGk3d4 -w %{http_code}&#10;-H Authorization: Bearer tok-argv-poll -H Accept: application/json&#10;https://relay.test/connector/poll&#10;&#10;The failure carries the REAL leaked command line read back from the OS, not a&#10;source-text assertion. Mutation reverted; worktree restored to the target commit.&#10;&#10;TARGETED SUITE AT THE TARGET COMMIT: 110 ok, 0 not ok&#10;ok - fm-x-poll keeps the bearer token out of curl argv&#10;ok - fm-x-reply keeps the bearer token out of curl argv&#10;ok - fm-x-dismiss keeps the bearer token out of curl argv&#10;ok - the curl stdin config escapes quotes and backslashes in a token&#10;ok - fm-x-reply writes no credential temp file, even on an interrupted post&#10;&#10;PRE-EXISTING FAILURES, VERIFIED NOT CAUSED BY THIS CHANGE&#10;(the four changed files reverted to 822a990, same two test files re-run)&#10;tests/fm-gotmp.test.sh&#10;target: not ok - teardown did not remove the tasktmp dir&#10;base: not ok - teardown did not remove the tasktmp dir&#10;tests/fm-public-followup.test.sh&#10;target: PF_REGISTRY_LOCK_IDS[@]: unbound variable / not ok - could not register the public commitment&#10;base: PF_REGISTRY_LOCK_IDS[@]: unbound variable / not ok - could not register the public commitment</code>

```text
MUTATION CHECK - do the new tests actually catch the leak?

Reintroduced the briefed defective shape in bin/fm-x-poll.sh:
    code=$(curl -m 5 -s -o "$BODY_FILE" -w %{http_code} \
      -H "Authorization: Bearer $FMX_TOKEN" \
      -H "Accept: application/json" "$FMX_RELAY/connector/poll" ...)

then re-ran bash tests/fm-x-mode.test.sh:

    not ok - poll leaked the bearer token into curl argv (visible via ps): psargv=bash
    /var/.../argv-poll/fakebin/curl -m 5 -s -o /var/.../fm-x-poll.fGk3d4 -w %{http_code}
    -H Authorization: Bearer tok-argv-poll -H Accept: application/json
    https://relay.test/connector/poll

The failure message carries the REAL leaked command line read back from the OS,
not a source-text assertion. Mutation reverted; worktree restored to the target commit.

==================================================================
TARGETED SUITE AT THE TARGET COMMIT: bash tests/fm-x-mode.test.sh
  110 ok, 0 not ok. The cases that pin this change:

    ok - fm-x-poll keeps the bearer token out of curl argv
    ok - fm-x-reply keeps the bearer token out of curl argv
    ok - fm-x-dismiss keeps the bearer token out of curl argv
    ok - the curl stdin config escapes quotes and backslashes in a token
    ok - fm-x-reply writes no credential temp file, even on an interrupted post
    ok - fm-x-reply streams large image payloads outside curl argv

==================================================================
PRE-EXISTING FAILURES, VERIFIED NOT CAUSED BY THIS CHANGE
(bin/fm-x-{lib,poll,dismiss}.sh + tests/fm-x-mode.test.sh reverted to 822a990,
 same two files re-run -> identical failures)

    tests/fm-gotmp.test.sh
      target: not ok - teardown did not remove the tasktmp dir
      base:   not ok - teardown did not remove the tasktmp dir
    tests/fm-public-followup.test.sh
      target: bin/fm-public-followup.sh: line 142: PF_REGISTRY_LOCK_IDS[@]: unbound variable
              not ok - could not register the public commitment
      base:   bin/fm-public-followup.sh: line 142: PF_REGISTRY_LOCK_IDS[@]: unbound variable
              not ok - could not register the public commitment
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"b6cc08ea15683fbe7060ace731637ec02d2cc815","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `bin/fm-x-lib.sh:758` - fmx_curl_config rejects a newline/CR in the token (line 753) but applies no such guard to the URL, which is emitted into the same line-oriented `curl -K -` config. A newline in FMX_RELAY_URL splits the config into extra lines that curl parses as additional directives (e.g. `output = ...`, `proxy = ...`, a second `header = ...`). Reachability is limited: the .env path (fmx_env_get, bin/fm-x-lib.sh:56) is line-based and cannot yield a newline, and `&#34;` is already escaped, so it requires an operator-set env var containing a literal newline - not a privilege-boundary crossing. Since this function is documented as the single owner of how the request reaches curl, extend the existing `case &#34;$token&#34; in *$&#39;\n&#39;*|*$&#39;\r&#39;*) return 1` guard to cover $url as well.
- ℹ️ `tests/fm-x-mode.test.sh:2905` - assert_token_off_argv takes `tail -1` of the `^psargv=` lines, so the OS-derived command line - the evidence the intent designates as the real behavioural check - is inspected for only the final relay call, while the weaker stub-reconstructed `^argv=` check (line 2910) scans every call. This is currently harmless: all four new cases issue exactly one relay call, because fmx_resolve_reply_context only reaches fmx_request_relay_context when allow_relay=1, which requires --followup, and none of these tests pass it. But the helper reads as general-purpose, so a follow-up-path case added later (request-context POST followed by the followup POST) would have its first call covered only by the `$*`-reconstructed string. Drop the `tail -1` and assert that no `^psargv=` line contains the token.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-x-mode.test.sh` — 110 ok, 0 not ok, including `fm-x-poll/fm-x-reply/fm-x-dismiss keeps the bearer token out of curl argv`, `the curl stdin config escapes quotes and backslashes in a token`, and `fm-x-reply writes no credential temp file, even on an interrupted post`</code>
- <code>Mutation check: reintroduced `-H &#34;Authorization: Bearer $FMX_TOKEN&#34;` in `bin/fm-x-poll.sh`, re-ran `bash tests/fm-x-mode.test.sh` → `not ok - poll leaked the bearer token into curl argv (visible via ps)` carrying the real leaked command line; mutation reverted via `git checkout -- bin/fm-x-poll.sh`</code>
- <code>Manual E2E (GET path): ran the shipped `bin/fm-x-poll.sh` with real `curl` against a python3 HTTP listener on 127.0.0.1 that holds the response 2s, while sampling `ps -A -o comm=,args=` every 100ms — sampled argv was `curl -K - -m 5 -s -o … -w %{http_code} -H Accept: application/json`, zero token occurrences, and the listener received `Authorization: Bearer &lt;token&gt;`</code>
- <code>Manual E2E (POST path): ran `bin/fm-x-reply.sh req-e2e-001 &#34;…&#34;` against the same listener — argv contained `curl -K - … -X POST … --data-binary @file` with zero token occurrences, listener received the bearer header and the intact JSON body (proves `-K -` stdin does not contend with the payload file)</code>
- <code>Control run: `curl -m 5 -s -o /dev/null -w &#39;%{http_code}&#39; -H &#34;Authorization: Bearer $TOKEN&#34; http://127.0.0.1:$PORT/connector/poll` under the same sampler — `ps` DOES expose the full credential, confirming the measurement is real</code>
- <code>On-disk check: polled a private `TMPDIR` with `grep -rl &#34;$TOKEN&#34;` every 100ms for the whole call — no credential file at any point, and the directory was empty afterward</code>
- <code>Base contrast: ran base-commit `822a990` copies of `bin/fm-x-{lib,poll}.sh` under the same harness — a `-rw-------` `fm-x-auth.*` credential file appeared on disk during the call</code>
- <code>Baseline of known failures: `bash tests/fm-gotmp.test.sh` and `bash tests/fm-public-followup.test.sh` at the target commit, then again after reverting `bin/fm-x-{lib,poll,dismiss}.sh` and `tests/fm-x-mode.test.sh` to `822a990` — identical single-test failures both times</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
