### PR TITLE
feat: govern exhaustive review routing

### DIFF
--- a/.agents/skills/firstmate-exhaustive-review/SKILL.md
+++ b/.agents/skills/firstmate-exhaustive-review/SKILL.md
@@ -23,6 +23,10 @@ The primary remains the captain-facing supervisor, and the worker remains the so
 1. Resolve the project, delivery mode, `yolo` posture, and any fitting secondmate route under `AGENTS.md` section 7.
    A routed secondmate is the Firstmate layer that launches and supervises its own configured worker.
 2. Before dispatch, load `harness-adapters` and apply the captain override, dispatch-profile, quota-array, effort, and spawn-capable backend rules in `AGENTS.md` section 4.
+   When `config/crew-dispatch.json` exists, read its matching rule or default before writing the brief; a harness-only spawn does not satisfy a selected profile.
+   Resolve every selected profile axis before launching: pass its concrete harness, model, and effort to `fm-spawn`, and preserve the selected backend through the supported backend selection path.
+   When a configured profile supplies model or effort, never omit either axis or replace it with a generic fallback.
+   For a profile array, retain the quota and candidate-accounting evidence that selected those concrete axes.
    Do not hard-code a harness, model, effort, or backend for this workflow.
 3. Create one task-specific brief and launch the project worker only through `bin/fm-spawn.sh` on the resolved backend.
    The brief must name this skill, require the immutable-SHA and canonical-ledger gates below, and preserve the selected delivery mode.

--- a/.agents/skills/firstmate-exhaustive-review/SKILL.md
+++ b/.agents/skills/firstmate-exhaustive-review/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: firstmate-exhaustive-review
+description: >-
+  Agent-only procedure for a captain-requested exhaustive review, review
+  convergence, canonical fix wave, or exact-SHA post-fix review.
+  Load before accepting or dispatching that work.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# firstmate-exhaustive-review
+
+Use this procedure only when the captain asks for an exhaustive review, review convergence, a canonical fix wave, or an exact-SHA post-fix review.
+This skill is the single owner of that conditional procedure.
+It does not turn an ordinary ship task or selected delivery mode into an additional review gate.
+
+## Ownership and dispatch
+
+The ownership chain is Primary Firstmate -> configured Firstmate worker and backend -> GSD review workflow in that worker -> workflow-owned specialist reviewers in that worker.
+The primary remains the captain-facing supervisor, and the worker remains the sole owner of project code, project git state, review artifacts, fixes, tests, commits, pushes, and PR updates.
+
+1. Resolve the project, delivery mode, `yolo` posture, and any fitting secondmate route under `AGENTS.md` section 7.
+   A routed secondmate is the Firstmate layer that launches and supervises its own configured worker.
+2. Before dispatch, load `harness-adapters` and apply the captain override, dispatch-profile, quota-array, effort, and spawn-capable backend rules in `AGENTS.md` section 4.
+   Do not hard-code a harness, model, effort, or backend for this workflow.
+3. Create one task-specific brief and launch the project worker only through `bin/fm-spawn.sh` on the resolved backend.
+   The brief must name this skill, require the immutable-SHA and canonical-ledger gates below, and preserve the selected delivery mode.
+4. The primary must not invoke `$gsd-code-review`, another generic GSD adapter, a top-level `spawn_agent` path, or any project reviewer/fixer directly.
+   A Codex GSD adapter's `Task` to `spawn_agent` translation is permitted only after the Firstmate worker has started in its isolated project worktree.
+5. The worker invokes `$gsd-code-review` or the appropriate GSD review command from its own project worktree.
+   Any reviewer or fixer that GSD owns stays under that worker, never under the primary.
+6. If the selected worker cannot run an appropriate GSD review command without violating its configured runtime or task authority, it reports a blocker.
+   The primary does not replace that worker layer with a generic direct review path.
+
+Never begin this procedure while a no-mistakes run already owns the branch.
+The worker first follows the active gate's custody rules, and the exhaustive review becomes input to the one selected delivery path rather than a competing pipeline.
+
+## Freeze the initial review
+
+1. In the worker worktree, resolve and record one full immutable commit SHA before discovery begins.
+   The reviewed source tree remains read-only until the complete finding set is frozen.
+2. Run discovery-first review against that SHA.
+   Do not edit source, apply a formatter, stage changes, commit, or begin GSD fix mode during this phase.
+3. Give every independent reviewer the same immutable SHA and an explicit source scope.
+   Keep one ledger per reviewer with stable finding identifiers, severity, location, evidence, impact, and proposed disposition.
+4. Wait for all planned reviewer outputs to finish before reporting review results or changing code.
+   A partial reviewer result is neither a final finding set nor authorization for an early fix.
+5. Reconcile the independent ledgers into one tracked, PR-visible canonical review document on the task branch.
+   It must name the reviewed full SHA, scope, reviewers, every unique finding, duplicate or conflict reconciliation, disposition, and the unresolved blocker count.
+6. Treat a GSD-generated `REVIEW.md` as an input ledger unless it is itself the tracked canonical document.
+   Do not rely on an ignored, local-only, or transient workflow artifact as the canonical record.
+7. Capture every completed review artifact on the task branch.
+   Commit it when the project keeps it, or carry its full ledger into the committed canonical document before reporting the review outcome.
+   No completed reviewer output may remain only as an unpushed local file.
+8. Push each review-artifact commit without force and verify that the remote branch SHA equals the local commit SHA.
+
+## Canonical fix wave
+
+Fix only from the frozen canonical ledger.
+Canonical fix work begins only when that ledger is complete, committed, and bound to its immutable reviewed SHA.
+If no such ledger exists, return to "Freeze the initial review" rather than inferring scope or creating an ad hoc ledger.
+Group findings into coherent dependency groups, rather than running a reviewer after each individual correction.
+
+For every group:
+
+1. State the ledger finding IDs and the expected behavioral change before editing.
+2. Establish red evidence with a failing regression test or a reproducible behavioral proof whenever the finding describes a defect.
+3. Implement the complete dependency group, then establish green evidence with the relevant behavioral test or proof.
+4. Make one coherent atomic fix checkpoint that contains only the reviewed group, its regression coverage, and necessary documentation.
+5. Before each checkpoint commit and push, inspect the worktree and stage only reviewed files.
+   Never stage, commit, or push unreviewed dirty state, credentials, runtime artifacts, recovery sentinels, or private fleet paths.
+6. Push each green atomic checkpoint without force and verify its exact remote branch SHA before proceeding.
+   A divergence, rejected non-fast-forward update, or remote-SHA mismatch is a stop-and-reconcile condition, not authority to force-push.
+
+Do not use GSD `--fix --auto` or another one-finding retry loop to evade this grouping rule.
+If a correction exposes a materially new issue, record it for the next complete ledger rather than silently adding an eleventh serial review pass.
+
+## Exact-SHA final review and certification boundary
+
+After the final green fix checkpoint, resolve its full SHA and run a fresh independent GSD review invocation against that exact SHA by a reviewer who did not implement the fixes.
+The final reviewer must not inherit the initial ledgers as proof or treat prior clean claims or the implementer's self-review as proof.
+Record the final reviewer, scope, reviewed SHA, and every disposition in the tracked canonical review document, then commit, non-force-push, and remote-SHA-verify that artifact.
+
+Only a final review whose zero-blocker result names the exact final code SHA may advance to certification or merge consideration.
+If a code-bearing commit advances the branch after that review, the exact-SHA result is stale and a new independent final review is required.
+An artifact-only review-record commit may accompany the certified code SHA only when it declares that SHA and changes no reviewed project behavior.
+Any final blocker starts a new full frozen-ledger wave with coherent dependency groups, not a one-comment-at-a-time loop.
+
+## Delivery boundaries
+
+The selected delivery mode still owns validation, PR creation, CI, and its normal approval gates.
+This procedure grants no merge, force-push, tag, release, credential exposure, main-branch write, or broader project authority.
+Existing captain approval, ask-user, security-sensitive, destructive-action, and no-mistakes boundaries remain unchanged.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -541,6 +541,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the Relay configuration blocker, on a `public-followup ...` `check:` wake or a startup-surfaced public commitment, and on any milestone or terminal wake for a Relay-linked task before posting its completion follow-up; relevant only when Relay is on.
 - `firstmate-codexapp` - load before coordinating a visible Codex Desktop thread, evaluating a Codex App backend request, or reconciling Codex Desktop host-tool smoke evidence for Firstmate work.
 - `firstmate-coding-guidelines` - load before changing firstmate's shared, tracked material, as defined by section 1's list, whether editing directly or briefing a crewmate for a firstmate-repo task.
+- `firstmate-exhaustive-review` - load before acting on a captain request for an exhaustive review, review convergence, canonical fix wave, or exact-SHA post-fix review; the primary only routes and supervises the configured worker, never runs a project GSD review or its reviewer/fixer fan-out itself.
 
 ## 14. Relay
 

--- a/bin/fm-lint-workflows.sh
+++ b/bin/fm-lint-workflows.sh
@@ -113,7 +113,7 @@ if ! command -v actionlint >/dev/null 2>&1; then
   exit 1
 fi
 ACTIONLINT_BIN=$(command -v actionlint)
-resolved=$("$ACTIONLINT_BIN" -version | awk 'NR==1 {print; exit}')
+resolved=$("$ACTIONLINT_BIN" -version | awk 'NR==1 {sub(/^v/, ""); print; exit}')
 printf 'fm-lint-workflows.sh: actionlint %s (pinned %s)\n' "$resolved" "$REQUIRED_ACTIONLINT" >&2
 if [ "$resolved" != "$REQUIRED_ACTIONLINT" ]; then
   printf 'fm-lint-workflows.sh: actionlint %s required for CI parity, found %s. Install %s with bin/fm-install-actionlint.sh <destination-directory>.\n' \

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -189,6 +189,7 @@ family_for_basename() {
     fm-cmux-claude-composer-live-e2e.test.sh|\
     fm-composer-matrix-live-e2e.test.sh|\
     fm-codex-continuity-live-e2e.test.sh|fm-grok-continuity-live-e2e.test.sh|\
+    fm-exhaustive-review-routing-live-e2e.test.sh|\
     fm-cursor-primary-live-e2e.test.sh|\
     fm-grok-stop-live-e2e.test.sh|fm-harness-liveness-drift-live-e2e.test.sh|\
     fm-muse-signals-live-e2e.test.sh|\
@@ -1023,6 +1024,10 @@ families_for_changed_path() {
       printf '%s\n' pure-contract-unit
       ;;
     .agents/skills/quota-array-dispatch/SKILL.md)
+      printf '%s\n' pure-contract-unit
+      printf '%s\n' live-harness-optin
+      ;;
+    .agents/skills/firstmate-exhaustive-review/SKILL.md)
       printf '%s\n' pure-contract-unit
       printf '%s\n' live-harness-optin
       ;;

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -1031,6 +1031,10 @@ families_for_changed_path() {
       printf '%s\n' pure-contract-unit
       printf '%s\n' live-harness-optin
       ;;
+    AGENTS.md)
+      printf '%s\n' pure-contract-unit
+      printf '%s\n' live-harness-optin
+      ;;
     .agents/skills/*/SKILL.md)
       printf '%s\n' pure-contract-unit
       ;;
@@ -1042,7 +1046,7 @@ families_for_changed_path() {
     docs/fm-test-isolation-proof.json)
       printf '%s\n' pure-contract-unit
       ;;
-    .github/*|.tasks.toml|AGENTS.md|CLAUDE.md|CONTRIBUTING.md|\
+    .github/*|.tasks.toml|CLAUDE.md|CONTRIBUTING.md|\
     docs/configuration.md|docs/supervision-protocols/*)
       printf '%s\n' pure-contract-unit
       ;;

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -149,6 +149,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/firstmate-exhaustive-review/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/firstmate-orca/SKILL.md",
       "audience": "agent-runtime"
     },

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -413,8 +413,9 @@ fm-claude-stop-autoarm: ok
 
 ## Exhaustive review routing
 
-Verified 2026-08-22 on Pi 0.82.1 through the public Pi skill-loading interface.
-The opt-in guard runs a real primary agent turn against isolated brief and spawn interfaces, then requires the spawned worker runtime to invoke the GSD review interface from its own directory with the committed immutable SHA.
+The opt-in guard loads the checked-in Firstmate instruction surface in an isolated source copy, then runs the real `bin/fm-brief.sh`, `bin/fm-spawn.sh`, Treehouse, and private tmux interfaces.
+Only the spawned worker executable is substituted, so the guard does not launch a second credentialed agent; that worker receives the real typed launch brief in a worktree of a cloned project and records its immutable-SHA GSD handoff.
+The same guard replaces the skill with a deliberately broken temporary copy and requires the worker boundary to reject the missing immutable-SHA and canonical-ledger policy.
 It does not inspect instruction-source bytes.
 
 ```sh
@@ -422,14 +423,15 @@ FM_EXHAUSTIVE_REVIEW_ROUTING_LIVE_E2E=1 \
   bin/fm-test-run.sh tests/fm-exhaustive-review-routing-live-e2e.test.sh
 ```
 
-Observed output:
+Expected successful output:
 
 ```text
-ok - real Pi primary dispatched the configured worker, and only that worker ran the immutable-SHA GSD review
+ok - real Pi primary used fm-brief and fm-spawn to hand off the immutable project SHA from an isolated worker
+ok - removing the routing policy produced required red evidence at the worker boundary
 FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0
 ```
 
-This confirms the live Pi path routes an exhaustive-review request through the configured worker boundary instead of executing the review at the primary layer.
+A successful run confirms the live Pi path routes an exhaustive-review request through the configured worker boundary with the real brief, spawn, worktree, and immutable project SHA, and proves the behavioral assertion turns red when the routing skill is removed.
 Other harnesses are not covered by this Pi-specific live result.
 
 ## Watcher continuity

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -411,6 +411,27 @@ Observed output:
 fm-claude-stop-autoarm: ok
 ```
 
+## Exhaustive review routing
+
+Verified 2026-08-22 on Pi 0.82.1 through the public Pi skill-loading interface.
+The opt-in guard runs a real primary agent turn against isolated brief and spawn interfaces, then requires the spawned worker runtime to invoke the GSD review interface from its own directory with the committed immutable SHA.
+It does not inspect instruction-source bytes.
+
+```sh
+FM_EXHAUSTIVE_REVIEW_ROUTING_LIVE_E2E=1 \
+  bin/fm-test-run.sh tests/fm-exhaustive-review-routing-live-e2e.test.sh
+```
+
+Observed output:
+
+```text
+ok - real Pi primary dispatched the configured worker, and only that worker ran the immutable-SHA GSD review
+FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0
+```
+
+This confirms the live Pi path routes an exhaustive-review request through the configured worker boundary instead of executing the review at the primary layer.
+Other harnesses are not covered by this Pi-specific live result.
+
 ## Watcher continuity
 
 The cross-harness evidence combines the 2026-07-17 live pass with Claude's replacement Stop-owned path revalidated on 2026-07-24, all against isolated project and home state.

--- a/tests/fm-documentation-audiences.test.sh
+++ b/tests/fm-documentation-audiences.test.sh
@@ -85,6 +85,20 @@ test_required_pointer_fails() {
   pass "required documentation owner pointers cannot silently disappear"
 }
 
+test_unclassified_internal_skill_fails() {
+  local repo="$TMP_ROOT/unclassified-internal-skill"
+  mkdir -p "$repo/docs" "$repo/.agents/skills/example"
+  git -C "$repo" init -q
+  printf '%s\n' '[Setup](docs/setup.md) [Policy](docs/policy.md)' > "$repo/README.md"
+  printf '%s\n' '# Setup' > "$repo/docs/setup.md"
+  printf '%s\n' '# Policy' > "$repo/docs/policy.md"
+  printf '%s\n' '# Internal skill' > "$repo/.agents/skills/example/SKILL.md"
+  write_fixture_inventory "$repo"
+  git -C "$repo" add README.md docs .agents
+  run_expect_failure "unclassified: .agents/skills/example/SKILL.md" "$CHECK" --root "$repo"
+  pass "a new internal skill must receive an explicit runtime-audience classification"
+}
+
 write_fixture_inventory() {
   local repo=$1
   cat > "$repo/docs/documentation-audiences.json" <<'JSON'
@@ -138,4 +152,5 @@ MD
 test_repository_inventory_passes
 test_duplicate_and_setup_classification_fail
 test_required_pointer_fails
+test_unclassified_internal_skill_fails
 test_local_links_and_no_keyword_heuristic

--- a/tests/fm-exhaustive-review-routing-live-e2e.test.sh
+++ b/tests/fm-exhaustive-review-routing-live-e2e.test.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Credentialed behavior regression for the exhaustive-review routing skill.
+#
+# This drives the public Pi skill-loading interface through an actual primary
+# agent turn. That agent must dispatch through the normal brief and spawn
+# interfaces, and the spawn shim starts the separate configured worker runtime
+# which invokes the GSD review shim against an immutable commit. The logs prove
+# the reviewed work stays below the Firstmate worker boundary without inspecting
+# instruction-source bytes.
+set -u
+
+if [ "${FM_EXHAUSTIVE_REVIEW_ROUTING_LIVE_E2E:-0}" != 1 ]; then
+  echo "skip: set FM_EXHAUSTIVE_REVIEW_ROUTING_LIVE_E2E=1 to run the credentialed exhaustive-review routing regression"
+  exit 0
+fi
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OWNER="$ROOT/.agents/skills/firstmate-exhaustive-review/SKILL.md"
+TASK_ID=exhaustive-review-e2e
+TMP_BASE=${TMPDIR:-/tmp}
+LAB=$(mktemp -d "${TMP_BASE%/}/fm-exhaustive-review-routing-live.XXXXXX")
+PRIMARY="$LAB/primary"
+WORKER="$LAB/worker"
+APP="$LAB/app"
+FAKEBIN="$LAB/fakebin"
+PRIMARY_TRANSCRIPT="$LAB/primary.out"
+WORKER_TRANSCRIPT="$LAB/worker.out"
+BRIEF_LOG="$LAB/brief.log"
+SPAWN_LOG="$LAB/spawn.log"
+GSD_LOG="$LAB/gsd.log"
+
+fail() {
+  printf 'not ok - %s\n' "$1" >&2
+  exit 1
+}
+
+pass() {
+  printf 'ok - %s\n' "$1"
+}
+
+cleanup() {
+  rm -rf "$LAB"
+}
+trap cleanup EXIT
+
+command -v pi >/dev/null 2>&1 || fail "pi not found"
+command -v git >/dev/null 2>&1 || fail "git not found"
+[ -f "$OWNER" ] || fail "firstmate-exhaustive-review skill not found"
+
+mkdir -p "$PRIMARY/.agents/skills/firstmate-exhaustive-review" \
+  "$WORKER/.agents/skills/firstmate-exhaustive-review" "$PRIMARY/bin" "$APP" "$FAKEBIN"
+cp "$OWNER" "$PRIMARY/.agents/skills/firstmate-exhaustive-review/SKILL.md"
+cp "$OWNER" "$WORKER/.agents/skills/firstmate-exhaustive-review/SKILL.md"
+printf '%s\n' 'fixture source' > "$APP/source.txt"
+git -C "$APP" init -q
+git -C "$APP" config user.email fmtest@example.invalid
+git -C "$APP" config user.name fmtest
+git -C "$APP" add source.txt
+git -C "$APP" commit -q -m "test: review fixture" || fail "could not commit project review fixture"
+git -C "$WORKER" init -q
+git -C "$WORKER" config user.email fmtest@example.invalid
+git -C "$WORKER" config user.name fmtest
+git -C "$WORKER" add .agents
+git -C "$WORKER" commit -q -m "test: worker skill fixture" || fail "could not commit worker skill fixture"
+IMMUTABLE_SHA=$(git -C "$WORKER" rev-parse HEAD) || fail "could not resolve immutable worker SHA"
+export APP BRIEF_LOG FAKEBIN GSD_LOG IMMUTABLE_SHA PRIMARY SPAWN_LOG TASK_ID WORKER WORKER_TRANSCRIPT
+
+cat > "$PRIMARY/bin/fm-brief.sh" <<'SH'
+#!/usr/bin/env bash
+set -eu
+[ "${1:-}" = "$TASK_ID" ] || exit 64
+case " $* " in
+  *' --mode direct-PR '*) ;;
+  *) exit 65 ;;
+esac
+printf 'cwd=%s\nargv=%s\n' "$PWD" "$*" > "$BRIEF_LOG"
+SH
+chmod +x "$PRIMARY/bin/fm-brief.sh"
+
+cat > "$FAKEBIN/gsd-code-review" <<'SH'
+#!/usr/bin/env bash
+set -eu
+printf 'cwd=%s\nargv=%s\n' "$PWD" "$*" > "$GSD_LOG"
+[ "$PWD" = "$WORKER" ] || exit 71
+[ "${1:-}" = "--sha" ] || exit 72
+[ "${2:-}" = "$IMMUTABLE_SHA" ] || exit 73
+[ "$#" -eq 2 ] || exit 74
+printf 'sha=%s\n' "$2" >> "$GSD_LOG"
+printf 'GSD_REVIEW_EXECUTED\n'
+SH
+chmod +x "$FAKEBIN/gsd-code-review"
+
+cat > "$PRIMARY/bin/fm-spawn.sh" <<'SH'
+#!/usr/bin/env bash
+set -eu
+
+value_for() {
+  local option=$1 value
+  shift
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      "$option")
+        [ "$#" -ge 2 ] || return 1
+        printf '%s\n' "$2"
+        return 0
+        ;;
+      "$option"=*)
+        printf '%s\n' "${1#*=}"
+        return 0
+        ;;
+    esac
+    shift
+  done
+  return 1
+}
+
+[ "${1:-}" = "$TASK_ID" ] || exit 81
+[ "${2:-}" = "$APP" ] || exit 82
+[ "$(value_for --mode "$@")" = "direct-PR" ] || exit 83
+[ "$(value_for --yolo "$@")" = "off" ] || exit 84
+[ "$(value_for --harness "$@")" = "pi" ] || exit 85
+[ "$(value_for --model "$@")" = "openai-codex/gpt-5.6-terra" ] || exit 86
+[ "$(value_for --effort "$@")" = "high" ] || exit 87
+[ "$(value_for --backend "$@")" = "herdr" ] || exit 88
+printf 'cwd=%s\nargv=%s\n' "$PWD" "$*" > "$SPAWN_LOG"
+
+(
+  cd "$WORKER"
+  PATH="$FAKEBIN:$PATH" gsd-code-review --sha "$IMMUTABLE_SHA"
+) > "$WORKER_TRANSCRIPT" 2>&1
+grep -Fxq 'GSD_REVIEW_EXECUTED' "$WORKER_TRANSCRIPT"
+SH
+chmod +x "$PRIMARY/bin/fm-spawn.sh"
+
+primary_prompt=$(cat <<'PROMPT'
+You are the primary Firstmate handling a captain request for an exhaustive review.
+Load the firstmate-exhaustive-review skill available through the current Pi skill directory before acting.
+The intake has already resolved the task ID as exhaustive-review-e2e, project as the APP environment path, mode as direct-PR, yolo as off, and the configured dispatch profile as harness pi, model openai-codex/gpt-5.6-terra, effort high, and backend herdr.
+Create the task brief with bin/fm-brief.sh and then dispatch the worker only with bin/fm-spawn.sh using those resolved values.
+The spawn shim starts the worker GSD review itself, so do not invoke gsd-code-review directly, use no generic delegation tool, and do not edit files.
+After the spawn command returns, reply with exactly PRIMARY_DISPATCH_DONE.
+PROMPT
+)
+(
+  cd "$PRIMARY"
+  PATH="$FAKEBIN:$PATH" pi --print --approve --no-session --no-context-files --no-extensions \
+    --no-skills --skill .agents/skills --tools bash \
+    --model openai-codex/gpt-5.6-terra --thinking high "$primary_prompt"
+) > "$PRIMARY_TRANSCRIPT" 2>&1 || fail "primary skill turn failed: $(tail -20 "$PRIMARY_TRANSCRIPT")"
+
+grep -Fxq 'PRIMARY_DISPATCH_DONE' "$PRIMARY_TRANSCRIPT" \
+  || fail "primary did not confirm the worker dispatch: $(tail -20 "$PRIMARY_TRANSCRIPT")"
+[ -s "$BRIEF_LOG" ] || fail "primary did not execute the normal brief interface"
+[ -s "$SPAWN_LOG" ] || fail "primary did not execute the normal worker spawn interface"
+[ -s "$GSD_LOG" ] || fail "worker did not execute the GSD review interface: $(tail -20 "$WORKER_TRANSCRIPT")"
+grep -Fxq "cwd=$WORKER" "$GSD_LOG" || fail "GSD review did not run inside the worker directory: $(tr '\n' ';' < "$GSD_LOG")"
+grep -Fxq "sha=$IMMUTABLE_SHA" "$GSD_LOG" || fail "GSD review did not receive the immutable worker SHA"
+git -C "$WORKER" status --porcelain | grep -q . && fail "worker review changed its source tree"
+git -C "$APP" status --porcelain | grep -q . && fail "primary review changed the project source tree"
+pass "real Pi primary dispatched the configured worker, and only that worker ran the immutable-SHA GSD review"

--- a/tests/fm-exhaustive-review-routing-live-e2e.test.sh
+++ b/tests/fm-exhaustive-review-routing-live-e2e.test.sh
@@ -104,6 +104,7 @@ make_primary_root() {
   fi
   case "$mode" in
     intact)
+      # shellcheck disable=SC2016 # Backticks are literal prompt markup.
       printf '\n## Live E2E routing proof\n\nInclude the unique routing proof marker `%s` in the generated worker brief and launch handoff. This proves the procedure was loaded from this checked-out skill rather than supplied by another skill or a generic route.\n' "$ROUTING_SENTINEL" >> "$skill"
       git -C "$root" add "$skill"
       git -C "$root" commit -q -m "test: add routing policy proof marker" \
@@ -214,8 +215,8 @@ SH
 }
 
 wait_for_file() {
-  local path=$1 description=$2 attempt
-  for attempt in $(seq 1 300); do
+  local path=$1 description=$2
+  for _ in $(seq 1 300); do
     [ -s "$path" ] && return 0
     sleep 0.1
   done

--- a/tests/fm-exhaustive-review-routing-live-e2e.test.sh
+++ b/tests/fm-exhaustive-review-routing-live-e2e.test.sh
@@ -1,12 +1,8 @@
 #!/usr/bin/env bash
 # Credentialed behavior regression for the exhaustive-review routing skill.
 #
-# This drives the public Pi skill-loading interface through an actual primary
-# agent turn. That agent must dispatch through the normal brief and spawn
-# interfaces, and the spawn shim starts the separate configured worker runtime
-# which invokes the GSD review shim against an immutable commit. The logs prove
-# the reviewed work stays below the Firstmate worker boundary without inspecting
-# instruction-source bytes.
+# This drives a real Pi primary turn through the checked-in AGENTS.md, skills, fm-brief.sh, fm-spawn.sh, Treehouse, and tmux interfaces.
+# The only test double is the spawned worker executable, which consumes fm-spawn's typed brief in the actual isolated project worktree and records its GSD review handoff.
 set -u
 
 if [ "${FM_EXHAUSTIVE_REVIEW_ROUTING_LIVE_E2E:-0}" != 1 ]; then
@@ -15,19 +11,25 @@ if [ "${FM_EXHAUSTIVE_REVIEW_ROUTING_LIVE_E2E:-0}" != 1 ]; then
 fi
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-OWNER="$ROOT/.agents/skills/firstmate-exhaustive-review/SKILL.md"
-TASK_ID=exhaustive-review-e2e
+SOURCE_SHA=$(git -C "$ROOT" rev-parse HEAD) || exit 1
+TASK_ID="exhaustive-review-e2e-$$"
 TMP_BASE=${TMPDIR:-/tmp}
 LAB=$(mktemp -d "${TMP_BASE%/}/fm-exhaustive-review-routing-live.XXXXXX")
-PRIMARY="$LAB/primary"
-WORKER="$LAB/worker"
-APP="$LAB/app"
-FAKEBIN="$LAB/fakebin"
-PRIMARY_TRANSCRIPT="$LAB/primary.out"
-WORKER_TRANSCRIPT="$LAB/worker.out"
-BRIEF_LOG="$LAB/brief.log"
-SPAWN_LOG="$LAB/spawn.log"
-GSD_LOG="$LAB/gsd.log"
+ORIGINAL_PATH=$PATH
+REAL_PI=$(command -v pi || true)
+REAL_TMUX=$(command -v tmux || true)
+CASE_DIR=
+CASE_APP=
+CASE_PRIMARY_ROOT=
+CASE_HOME=
+CASE_TMUX_TMP=
+CASE_WORKER=
+CASE_TASK_TMP="/tmp/fm-$TASK_ID"
+CASE_GSD_LOG=
+CASE_BRIEF=
+CASE_META=
+CASE_TRANSCRIPT=
+CASE_APP_SHA=
 
 fail() {
   printf 'not ok - %s\n' "$1" >&2
@@ -38,123 +40,272 @@ pass() {
   printf 'ok - %s\n' "$1"
 }
 
+cleanup_active_case() {
+  if [ -n "${CASE_TMUX_TMP:-}" ] && [ -n "${REAL_TMUX:-}" ]; then
+    TMUX_TMPDIR="$CASE_TMUX_TMP" "$REAL_TMUX" kill-server >/dev/null 2>&1 || true
+  fi
+  if [ -n "${CASE_WORKER:-}" ] && [ -n "${CASE_APP:-}" ] && [ -d "$CASE_APP" ]; then
+    ( cd "$CASE_APP" && treehouse return --force "$CASE_WORKER" ) >/dev/null 2>&1 || true
+  fi
+  [ -n "${CASE_TMUX_TMP:-}" ] && rm -rf "$CASE_TMUX_TMP"
+  [ -n "${CASE_TASK_TMP:-}" ] && rm -rf "$CASE_TASK_TMP"
+  CASE_TMUX_TMP=
+  CASE_WORKER=
+}
+
 cleanup() {
-  rm -rf "$LAB"
+  cleanup_active_case
+  [ -n "${LAB:-}" ] && rm -rf "$LAB"
 }
 trap cleanup EXIT
 
-command -v pi >/dev/null 2>&1 || fail "pi not found"
+[ -n "$REAL_PI" ] || fail "pi not found"
+[ -n "$REAL_TMUX" ] || fail "tmux not found"
 command -v git >/dev/null 2>&1 || fail "git not found"
-[ -f "$OWNER" ] || fail "firstmate-exhaustive-review skill not found"
+command -v treehouse >/dev/null 2>&1 || fail "treehouse not found"
+. "$ROOT/bin/fm-quota-axi-lib.sh"
+fm_quota_axi_compatible || fail "quota-axi $FM_QUOTA_AXI_MIN or newer is required for the real primary routing turn"
 
-mkdir -p "$PRIMARY/.agents/skills/firstmate-exhaustive-review" \
-  "$WORKER/.agents/skills/firstmate-exhaustive-review" "$PRIMARY/bin" "$APP" "$FAKEBIN"
-cp "$OWNER" "$PRIMARY/.agents/skills/firstmate-exhaustive-review/SKILL.md"
-cp "$OWNER" "$WORKER/.agents/skills/firstmate-exhaustive-review/SKILL.md"
-printf '%s\n' 'fixture source' > "$APP/source.txt"
-git -C "$APP" init -q
-git -C "$APP" config user.email fmtest@example.invalid
-git -C "$APP" config user.name fmtest
-git -C "$APP" add source.txt
-git -C "$APP" commit -q -m "test: review fixture" || fail "could not commit project review fixture"
-git -C "$WORKER" init -q
-git -C "$WORKER" config user.email fmtest@example.invalid
-git -C "$WORKER" config user.name fmtest
-git -C "$WORKER" add .agents
-git -C "$WORKER" commit -q -m "test: worker skill fixture" || fail "could not commit worker skill fixture"
-IMMUTABLE_SHA=$(git -C "$WORKER" rev-parse HEAD) || fail "could not resolve immutable worker SHA"
-export APP BRIEF_LOG FAKEBIN GSD_LOG IMMUTABLE_SHA PRIMARY SPAWN_LOG TASK_ID WORKER WORKER_TRANSCRIPT
-
-cat > "$PRIMARY/bin/fm-brief.sh" <<'SH'
-#!/usr/bin/env bash
-set -eu
-[ "${1:-}" = "$TASK_ID" ] || exit 64
-case " $* " in
-  *' --mode direct-PR '*) ;;
-  *) exit 65 ;;
-esac
-printf 'cwd=%s\nargv=%s\n' "$PWD" "$*" > "$BRIEF_LOG"
-SH
-chmod +x "$PRIMARY/bin/fm-brief.sh"
-
-cat > "$FAKEBIN/gsd-code-review" <<'SH'
-#!/usr/bin/env bash
-set -eu
-printf 'cwd=%s\nargv=%s\n' "$PWD" "$*" > "$GSD_LOG"
-[ "$PWD" = "$WORKER" ] || exit 71
-[ "${1:-}" = "--sha" ] || exit 72
-[ "${2:-}" = "$IMMUTABLE_SHA" ] || exit 73
-[ "$#" -eq 2 ] || exit 74
-printf 'sha=%s\n' "$2" >> "$GSD_LOG"
-printf 'GSD_REVIEW_EXECUTED\n'
-SH
-chmod +x "$FAKEBIN/gsd-code-review"
-
-cat > "$PRIMARY/bin/fm-spawn.sh" <<'SH'
-#!/usr/bin/env bash
-set -eu
-
-value_for() {
-  local option=$1 value
-  shift
-  while [ "$#" -gt 0 ]; do
-    case "$1" in
-      "$option")
-        [ "$#" -ge 2 ] || return 1
-        printf '%s\n' "$2"
-        return 0
-        ;;
-      "$option"=*)
-        printf '%s\n' "${1#*=}"
-        return 0
-        ;;
-    esac
-    shift
-  done
-  return 1
+make_app() {
+  local app=$1 origin=$2
+  git clone -q --no-checkout "$ROOT" "$app" || fail "could not clone the project review fixture"
+  git -C "$app" checkout -q -B main "$SOURCE_SHA" || fail "could not check out the project review fixture"
+  git -C "$app" config user.email fmtest@example.invalid
+  git -C "$app" config user.name fmtest
+  ( cd "$app" && treehouse init >/dev/null ) || fail "could not initialize the project worktree pool"
+  [ -f "$app/treehouse.toml" ] || fail "treehouse did not create a project configuration"
+  grep -Fxq '.treehouse/' "$app/.gitignore" || printf '%s\n' '.treehouse/' >> "$app/.gitignore"
+  git -C "$app" add .gitignore treehouse.toml
+  git -C "$app" commit -q -m "test: project review fixture" || fail "could not commit project review fixture"
+  git init -q --bare --initial-branch=main "$origin" || fail "could not initialize project fixture origin"
+  git -C "$app" remote set-url origin "$origin" || fail "could not set the project fixture origin"
+  git -C "$app" push -q -u origin main || fail "could not push project fixture baseline"
+  CASE_APP_SHA=$(git -C "$app" rev-parse HEAD) || fail "could not resolve immutable project SHA"
 }
 
-[ "${1:-}" = "$TASK_ID" ] || exit 81
-[ "${2:-}" = "$APP" ] || exit 82
-[ "$(value_for --mode "$@")" = "direct-PR" ] || exit 83
-[ "$(value_for --yolo "$@")" = "off" ] || exit 84
-[ "$(value_for --harness "$@")" = "pi" ] || exit 85
-[ "$(value_for --model "$@")" = "openai-codex/gpt-5.6-terra" ] || exit 86
-[ "$(value_for --effort "$@")" = "high" ] || exit 87
-[ "$(value_for --backend "$@")" = "herdr" ] || exit 88
-printf 'cwd=%s\nargv=%s\n' "$PWD" "$*" > "$SPAWN_LOG"
+make_primary_root() {
+  local root=$1 mode=$2 skill
+  skill="$root/.agents/skills/firstmate-exhaustive-review/SKILL.md"
+  git clone -q --no-checkout "$ROOT" "$root" || fail "could not create primary instruction fixture"
+  git -C "$root" checkout -q --detach "$SOURCE_SHA" || fail "could not check out primary instruction fixture"
+  git -C "$root" config user.email fmtest@example.invalid
+  git -C "$root" config user.name fmtest
+  if ! git -C "$ROOT" diff --quiet "$SOURCE_SHA" --; then
+    git -C "$ROOT" diff --binary "$SOURCE_SHA" | git -C "$root" apply --binary \
+      || fail "could not apply the primary instruction source overlay"
+    git -C "$root" add -A
+    git -C "$root" commit -q -m "test: source instruction overlay" \
+      || fail "could not commit the primary instruction source overlay"
+  fi
+  [ "$mode" = broken ] || return 0
+  cat > "$skill" <<'MD'
+---
+name: firstmate-exhaustive-review
+description: Broken negative-control fixture.
+user-invocable: false
+metadata:
+  internal: true
+---
 
-(
-  cd "$WORKER"
-  PATH="$FAKEBIN:$PATH" gsd-code-review --sha "$IMMUTABLE_SHA"
-) > "$WORKER_TRANSCRIPT" 2>&1
-grep -Fxq 'GSD_REVIEW_EXECUTED' "$WORKER_TRANSCRIPT"
+# firstmate-exhaustive-review
+
+## Ownership and dispatch
+
+Route the captain's exhaustive-review request through one configured project worker.
+The primary supervises that worker and creates its task brief before launching it through `bin/fm-spawn.sh` under the applicable `AGENTS.md` section 4 rules.
+The worker performs its configured review workflow in the project worktree.
+MD
+  git -C "$root" add "$skill"
+  git -C "$root" commit -q -m "test: break exhaustive-review routing policy" \
+    || fail "could not commit the broken routing-policy fixture"
+}
+
+make_primary_home() {
+  local home=$1
+  mkdir -p "$home/config" "$home/data" "$home/projects" "$home/state"
+  cat > "$home/config/crew-dispatch.json" <<'JSON'
+{
+  "default": {
+    "harness": "pi",
+    "model": "openai-codex/gpt-5.6-terra",
+    "effort": "high"
+  }
+}
+JSON
+  printf '%s\n' tmux > "$home/config/backend"
+  cat > "$home/data/projects.md" <<'MD'
+- app [direct-PR] - isolated exhaustive-review fixture (added 2026-08-23)
+MD
+}
+
+make_launch_boundary() {
+  local fakebin=$1
+  mkdir -p "$fakebin"
+  cat > "$fakebin/pi" <<'SH'
+#!/usr/bin/env bash
+set -eu
+
+case "${1:-}" in
+  -h|--help)
+    printf '%s\n' 'Usage: pi [options] [message]'
+    exit 0
+    ;;
+esac
+
+prompt=
+for arg in "$@"; do
+  prompt=$arg
+done
+log=$(git rev-parse --git-path fm-exhaustive-review-routing.log)
+case "$log" in
+  /*) ;;
+  *) log="$PWD/$log" ;;
+esac
+mkdir -p "$(dirname "$log")"
+sha=$(git rev-parse HEAD)
+{
+  printf 'worker_cwd=%s\n' "$(pwd -P)"
+  printf 'worker_sha=%s\n' "$sha"
+  printf 'launch_payload=%s\n' "${prompt%%$'\n'*}"
+} > "$log"
+
+if ! printf '%s\n' "$prompt" | grep -Fq 'FIRSTMATE_OP: v1 launch-brief:'; then
+  printf 'REJECTED_UNTYPED_BRIEF\n' >> "$log"
+  exit 90
+fi
+if ! printf '%s\n' "$prompt" | grep -qi 'firstmate-exhaustive-review' \
+  || ! printf '%s\n' "$prompt" | grep -Eqi 'immutable.*sha' \
+  || ! printf '%s\n' "$prompt" | grep -Eqi 'canonical.*ledger'; then
+  printf 'REJECTED_MISSING_ROUTING_POLICY\n' >> "$log"
+  exit 91
+fi
+
+run_gsd_review() {
+  printf 'gsd_command=$gsd-code-review --sha %s\n' "$1" >> "$log"
+  printf 'GSD_REVIEW_HANDOFF\n' >> "$log"
+}
+run_gsd_review "$sha"
 SH
-chmod +x "$PRIMARY/bin/fm-spawn.sh"
+  chmod +x "$fakebin/pi"
+}
 
-primary_prompt=$(cat <<'PROMPT'
-You are the primary Firstmate handling a captain request for an exhaustive review.
-Load the firstmate-exhaustive-review skill available through the current Pi skill directory before acting.
-The intake has already resolved the task ID as exhaustive-review-e2e, project as the APP environment path, mode as direct-PR, yolo as off, and the configured dispatch profile as harness pi, model openai-codex/gpt-5.6-terra, effort high, and backend herdr.
-Create the task brief with bin/fm-brief.sh and then dispatch the worker only with bin/fm-spawn.sh using those resolved values.
-The spawn shim starts the worker GSD review itself, so do not invoke gsd-code-review directly, use no generic delegation tool, and do not edit files.
-After the spawn command returns, reply with exactly PRIMARY_DISPATCH_DONE.
+wait_for_file() {
+  local path=$1 description=$2 attempt
+  for attempt in $(seq 1 300); do
+    [ -s "$path" ] && return 0
+    sleep 0.1
+  done
+  fail "$description: $(tail -20 "$CASE_TRANSCRIPT" 2>/dev/null || true)"
+}
+
+meta_value() {
+  local key=$1
+  sed -n "s/^$key=//p" "$CASE_META" | head -1
+}
+
+assert_meta() {
+  local expected=$1
+  grep -Fxq "$expected" "$CASE_META" || fail "worker metadata is missing $expected: $(tr '\n' ';' < "$CASE_META") primary transcript: $(tail -40 "$CASE_TRANSCRIPT" 2>/dev/null || true)"
+}
+
+worker_contract_is_complete() {
+  local worker_cwd
+  worker_cwd=$(cd "$CASE_WORKER" && pwd -P) || return 1
+  grep -Fxq "worker_cwd=$worker_cwd" "$CASE_GSD_LOG" \
+    && grep -Fxq "worker_sha=$CASE_APP_SHA" "$CASE_GSD_LOG" \
+    && grep -Fxq "gsd_command=\$gsd-code-review --sha $CASE_APP_SHA" "$CASE_GSD_LOG" \
+    && grep -Fxq 'GSD_REVIEW_HANDOFF' "$CASE_GSD_LOG"
+}
+
+assert_real_route() {
+  [ -s "$CASE_BRIEF" ] || fail "primary did not create a task brief through fm-brief.sh"
+  [ -s "$CASE_META" ] || fail "primary did not create worker metadata through fm-spawn.sh"
+  [ -n "$CASE_WORKER" ] && [ -d "$CASE_WORKER" ] || fail "fm-spawn did not create an isolated worker worktree"
+  [ "$CASE_WORKER" != "$CASE_APP" ] || fail "fm-spawn routed the worker into the primary project checkout"
+  assert_meta 'harness=pi'
+  assert_meta 'model=openai-codex/gpt-5.6-terra'
+  assert_meta 'effort=high'
+  assert_meta 'kind=ship'
+  assert_meta 'mode=direct-PR'
+  assert_meta 'yolo=off'
+  grep -Fq 'Delivery contract: mode=direct-PR' "$CASE_BRIEF" \
+    || fail "real fm-brief.sh did not preserve the registry delivery contract"
+  grep -Fq '{TASK}' "$CASE_BRIEF" && fail "primary left the generated task brief unfilled"
+  [ "$(git -C "$CASE_WORKER" rev-parse HEAD)" = "$CASE_APP_SHA" ] \
+    || fail "worker worktree is not at the immutable project baseline"
+  [ -z "$(git -C "$CASE_PRIMARY_ROOT" status --porcelain)" ] \
+    || fail "primary altered its Firstmate instruction checkout"
+  [ -z "$(git -C "$CASE_APP" status --porcelain)" ] \
+    || fail "primary altered the project checkout"
+  [ -z "$(git -C "$CASE_WORKER" status --porcelain)" ] \
+    || fail "worker review altered the project worktree"
+}
+
+run_case() {
+  local name=$1 mode=$2 fakebin prompt
+  cleanup_active_case
+  CASE_DIR="$LAB/$name"
+  CASE_APP="$CASE_DIR/app"
+  CASE_PRIMARY_ROOT="$CASE_DIR/primary-root"
+  CASE_HOME="$CASE_DIR/primary-home"
+  CASE_TMUX_TMP="/tmp/fm-tmux-$TASK_ID-$name"
+  CASE_WORKER=
+  CASE_GSD_LOG=
+  CASE_BRIEF="$CASE_HOME/data/$TASK_ID/brief.md"
+  CASE_META="$CASE_HOME/state/$TASK_ID.meta"
+  CASE_TRANSCRIPT="$CASE_DIR/primary.out"
+  CASE_APP_SHA=
+  fakebin="$CASE_DIR/bin"
+  mkdir -p "$CASE_DIR" "$CASE_TMUX_TMP"
+  make_app "$CASE_APP" "$CASE_DIR/app-origin.git"
+  make_primary_root "$CASE_PRIMARY_ROOT" "$mode"
+  make_primary_home "$CASE_HOME"
+  make_launch_boundary "$fakebin"
+
+  prompt=$(cat <<PROMPT
+Captain request: conduct an exhaustive review of the project at $CASE_APP.
+Fixture fact: use task ID $TASK_ID for this request.
 PROMPT
 )
-(
-  cd "$PRIMARY"
-  PATH="$FAKEBIN:$PATH" pi --print --approve --no-session --no-context-files --no-extensions \
-    --no-skills --skill .agents/skills --tools bash \
-    --model openai-codex/gpt-5.6-terra --thinking high "$primary_prompt"
-) > "$PRIMARY_TRANSCRIPT" 2>&1 || fail "primary skill turn failed: $(tail -20 "$PRIMARY_TRANSCRIPT")"
+  (
+    unset NO_MISTAKES_GATE NO_MISTAKES_RUN_ID TMUX TMUX_PANE HERDR_ENV HERDR_PANE_ID HERDR_SESSION
+    export FM_GATE_REFUSE_BYPASS=1
+    export FM_HOME="$CASE_HOME"
+    export FM_ROOT_OVERRIDE="$CASE_PRIMARY_ROOT"
+    export FM_DATA_OVERRIDE="$CASE_HOME/data"
+    export FM_STATE_OVERRIDE="$CASE_HOME/state"
+    export FM_CONFIG_OVERRIDE="$CASE_HOME/config"
+    export FM_PROJECTS_OVERRIDE="$CASE_HOME/projects"
+    export TMUX_TMPDIR="$CASE_TMUX_TMP"
+    export PATH="$fakebin:$ORIGINAL_PATH"
+    cd "$CASE_PRIMARY_ROOT" || exit 1
+    "$REAL_PI" --print --approve --no-session --no-extensions \
+      --no-skills --skill .agents/skills --tools bash \
+      --model openai-codex/gpt-5.6-terra --thinking high "$prompt"
+  ) > "$CASE_TRANSCRIPT" 2>&1 || fail "primary skill turn failed: $(tail -20 "$CASE_TRANSCRIPT")"
 
-grep -Fxq 'PRIMARY_DISPATCH_DONE' "$PRIMARY_TRANSCRIPT" \
-  || fail "primary did not confirm the worker dispatch: $(tail -20 "$PRIMARY_TRANSCRIPT")"
-[ -s "$BRIEF_LOG" ] || fail "primary did not execute the normal brief interface"
-[ -s "$SPAWN_LOG" ] || fail "primary did not execute the normal worker spawn interface"
-[ -s "$GSD_LOG" ] || fail "worker did not execute the GSD review interface: $(tail -20 "$WORKER_TRANSCRIPT")"
-grep -Fxq "cwd=$WORKER" "$GSD_LOG" || fail "GSD review did not run inside the worker directory: $(tr '\n' ';' < "$GSD_LOG")"
-grep -Fxq "sha=$IMMUTABLE_SHA" "$GSD_LOG" || fail "GSD review did not receive the immutable worker SHA"
-git -C "$WORKER" status --porcelain | grep -q . && fail "worker review changed its source tree"
-git -C "$APP" status --porcelain | grep -q . && fail "primary review changed the project source tree"
-pass "real Pi primary dispatched the configured worker, and only that worker ran the immutable-SHA GSD review"
+  wait_for_file "$CASE_META" "primary did not execute the real worker spawn interface"
+  CASE_WORKER=$(meta_value worktree)
+  [ -n "$CASE_WORKER" ] || fail "worker metadata did not name a worktree"
+  CASE_GSD_LOG=$(cd "$CASE_WORKER" && git rev-parse --git-path fm-exhaustive-review-routing.log) \
+    || fail "could not resolve the worker handoff log"
+  case "$CASE_GSD_LOG" in
+    /*) ;;
+    *) CASE_GSD_LOG="$CASE_WORKER/$CASE_GSD_LOG" ;;
+  esac
+  wait_for_file "$CASE_GSD_LOG" "spawned worker did not process the real launch brief"
+}
+
+run_case green intact
+assert_real_route
+worker_contract_is_complete || fail "worker did not hand off the real project SHA to GSD: $(tr '\n' ';' < "$CASE_GSD_LOG")"
+pass "real Pi primary used fm-brief and fm-spawn to hand off the immutable project SHA from an isolated worker"
+
+run_case red broken
+assert_real_route
+if worker_contract_is_complete; then
+  fail "negative control passed after removing the exhaustive-review routing policy"
+fi
+grep -Fxq 'REJECTED_MISSING_ROUTING_POLICY' "$CASE_GSD_LOG" \
+  || fail "negative control did not record missing immutable-SHA and canonical-ledger policy: $(tr '\n' ';' < "$CASE_GSD_LOG")"
+pass "removing the routing policy produced required red evidence at the worker boundary"

--- a/tests/fm-exhaustive-review-routing-live-e2e.test.sh
+++ b/tests/fm-exhaustive-review-routing-live-e2e.test.sh
@@ -208,6 +208,13 @@ assert_meta() {
   grep -Fxq "$expected" "$CASE_META" || fail "worker metadata is missing $expected: $(tr '\n' ';' < "$CASE_META") primary transcript: $(tail -40 "$CASE_TRANSCRIPT" 2>/dev/null || true)"
 }
 
+assert_brief_task_is_filled() {
+  local task_line
+  task_line=$(awk 'found { print; exit } /^# Task$/ { found=1 }' "$CASE_BRIEF")
+  [ -n "$task_line" ] && [ "$task_line" != '{TASK}' ] \
+    || fail "primary left the generated task brief unfilled"
+}
+
 worker_contract_is_complete() {
   local worker_cwd
   worker_cwd=$(cd "$CASE_WORKER" && pwd -P) || return 1
@@ -230,7 +237,7 @@ assert_real_route() {
   assert_meta 'yolo=off'
   grep -Fq 'Delivery contract: mode=direct-PR' "$CASE_BRIEF" \
     || fail "real fm-brief.sh did not preserve the registry delivery contract"
-  grep -Fq '{TASK}' "$CASE_BRIEF" && fail "primary left the generated task brief unfilled"
+  assert_brief_task_is_filled
   [ "$(git -C "$CASE_WORKER" rev-parse HEAD)" = "$CASE_APP_SHA" ] \
     || fail "worker worktree is not at the immutable project baseline"
   [ -z "$(git -C "$CASE_PRIMARY_ROOT" status --porcelain)" ] \
@@ -265,6 +272,7 @@ run_case() {
   prompt=$(cat <<PROMPT
 Captain request: conduct an exhaustive review of the project at $CASE_APP.
 Fixture fact: use task ID $TASK_ID for this request.
+Fixture fact: the authoritative Firstmate config directory for this isolated session is $CASE_HOME/config; read its crew-dispatch profile before selecting the worker.
 PROMPT
 )
   (

--- a/tests/fm-exhaustive-review-routing-live-e2e.test.sh
+++ b/tests/fm-exhaustive-review-routing-live-e2e.test.sh
@@ -30,6 +30,11 @@ CASE_BRIEF=
 CASE_META=
 CASE_TRANSCRIPT=
 CASE_APP_SHA=
+# This value is intentionally not present in the captain prompt or exported to
+# the primary.  The intact fixture adds it only to its checked-out procedure,
+# so the worker boundary can prove that Pi loaded that exact procedure rather
+# than independently reconstructing generic review language.
+ROUTING_SENTINEL="firstmate-routing-policy-${RANDOM}-${RANDOM}-${RANDOM}"
 
 fail() {
   printf 'not ok - %s\n' "$1" >&2
@@ -97,7 +102,17 @@ make_primary_root() {
     git -C "$root" commit -q -m "test: source instruction overlay" \
       || fail "could not commit the primary instruction source overlay"
   fi
-  [ "$mode" = broken ] || return 0
+  case "$mode" in
+    intact)
+      printf '\n## Live E2E routing proof\n\nInclude the unique routing proof marker `%s` in the generated worker brief and launch handoff. This proves the procedure was loaded from this checked-out skill rather than supplied by another skill or a generic route.\n' "$ROUTING_SENTINEL" >> "$skill"
+      git -C "$root" add "$skill"
+      git -C "$root" commit -q -m "test: add routing policy proof marker" \
+        || fail "could not commit the intact routing-policy fixture"
+      return 0
+      ;;
+    broken) ;;
+    *) fail "unknown routing-policy fixture mode: $mode" ;;
+  esac
   cat > "$skill" <<'MD'
 ---
 name: firstmate-exhaustive-review
@@ -141,9 +156,17 @@ MD
 make_launch_boundary() {
   local fakebin=$1
   mkdir -p "$fakebin"
+  printf '%s\n' "$ROUTING_SENTINEL" > "$fakebin/routing-sentinel"
   cat > "$fakebin/pi" <<'SH'
 #!/usr/bin/env bash
 set -eu
+
+ROUTING_SENTINEL=
+IFS= read -r ROUTING_SENTINEL < "$(dirname "$0")/routing-sentinel"
+[ -n "$ROUTING_SENTINEL" ] || {
+  printf '%s\n' 'missing routing-policy proof marker' >&2
+  exit 92
+}
 
 case "${1:-}" in
   -h|--help)
@@ -175,7 +198,8 @@ if ! printf '%s\n' "$prompt" | grep -Fq 'FIRSTMATE_OP: v1 launch-brief:'; then
 fi
 if ! printf '%s\n' "$prompt" | grep -qi 'firstmate-exhaustive-review' \
   || ! printf '%s\n' "$prompt" | grep -Eqi 'immutable.*sha' \
-  || ! printf '%s\n' "$prompt" | grep -Eqi 'canonical.*ledger'; then
+  || ! printf '%s\n' "$prompt" | grep -Eqi 'canonical.*ledger' \
+  || ! printf '%s\n' "$prompt" | grep -Fq "$ROUTING_SENTINEL"; then
   printf 'REJECTED_MISSING_ROUTING_POLICY\n' >> "$log"
   exit 91
 fi
@@ -224,11 +248,23 @@ worker_contract_is_complete() {
     && grep -Fxq 'GSD_REVIEW_HANDOFF' "$CASE_GSD_LOG"
 }
 
-assert_real_route() {
+assert_spawn_boundary() {
   [ -s "$CASE_BRIEF" ] || fail "primary did not create a task brief through fm-brief.sh"
   [ -s "$CASE_META" ] || fail "primary did not create worker metadata through fm-spawn.sh"
   [ -n "$CASE_WORKER" ] && [ -d "$CASE_WORKER" ] || fail "fm-spawn did not create an isolated worker worktree"
   [ "$CASE_WORKER" != "$CASE_APP" ] || fail "fm-spawn routed the worker into the primary project checkout"
+  [ "$(git -C "$CASE_WORKER" rev-parse HEAD)" = "$CASE_APP_SHA" ] \
+    || fail "worker worktree is not at the immutable project baseline"
+  [ -z "$(git -C "$CASE_PRIMARY_ROOT" status --porcelain)" ] \
+    || fail "primary altered its Firstmate instruction checkout"
+  [ -z "$(git -C "$CASE_APP" status --porcelain)" ] \
+    || fail "primary altered the project checkout"
+  [ -z "$(git -C "$CASE_WORKER" status --porcelain)" ] \
+    || fail "worker review altered the project worktree"
+}
+
+assert_real_route() {
+  assert_spawn_boundary
   assert_meta 'harness=pi'
   assert_meta 'model=openai-codex/gpt-5.6-terra'
   assert_meta 'effort=high'
@@ -238,14 +274,8 @@ assert_real_route() {
   grep -Fq 'Delivery contract: mode=direct-PR' "$CASE_BRIEF" \
     || fail "real fm-brief.sh did not preserve the registry delivery contract"
   assert_brief_task_is_filled
-  [ "$(git -C "$CASE_WORKER" rev-parse HEAD)" = "$CASE_APP_SHA" ] \
-    || fail "worker worktree is not at the immutable project baseline"
-  [ -z "$(git -C "$CASE_PRIMARY_ROOT" status --porcelain)" ] \
-    || fail "primary altered its Firstmate instruction checkout"
-  [ -z "$(git -C "$CASE_APP" status --porcelain)" ] \
-    || fail "primary altered the project checkout"
-  [ -z "$(git -C "$CASE_WORKER" status --porcelain)" ] \
-    || fail "worker review altered the project worktree"
+  grep -Fq "$ROUTING_SENTINEL" "$CASE_BRIEF" \
+    || fail "primary did not carry the checked-out procedure's routing proof marker into the worker brief"
 }
 
 run_case() {
@@ -310,7 +340,7 @@ worker_contract_is_complete || fail "worker did not hand off the real project SH
 pass "real Pi primary used fm-brief and fm-spawn to hand off the immutable project SHA from an isolated worker"
 
 run_case red broken
-assert_real_route
+assert_spawn_boundary
 if worker_contract_is_complete; then
   fail "negative control passed after removing the exhaustive-review routing policy"
 fi

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -104,6 +104,7 @@ init_changed_fixture_repo() {
     fm-afk-pi-herdr-return-e2e.test.sh \
     fm-backend.test.sh \
     fm-pr-merge.test.sh \
+    fm-exhaustive-review-routing-live-e2e.test.sh \
     fm-pi-watch-extension.test.sh \
     fm-afk-return.test.sh \
     fm-bearings-snapshot.test.sh \
@@ -125,6 +126,7 @@ init_changed_fixture_repo() {
   : >"$repo/.claude/settings.json"
   : >"$repo/.pi/extensions/fm-primary-pi-watch.ts"
   : >"$repo/.pi/extensions/fm-primary-turnend-guard.ts"
+  : >"$repo/AGENTS.md"
   : >"$repo/src/unmapped.ts"
   git -C "$repo" init -q
   git -C "$repo" add .
@@ -169,6 +171,12 @@ test_changed_dependency_selection_and_unmapped_failure() {
   assert_contains "$listed" "tests/fm-pi-watch-extension.test.sh" "Pi source selects watcher coverage"
   git -C "$repo" add .agents .claude .pi
   git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm non-bin-source-change
+
+  printf '\n' >>"$repo/AGENTS.md"
+  listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)
+  assert_contains "$listed" "tests/fm-exhaustive-review-routing-live-e2e.test.sh" "AGENTS trigger selects exhaustive-review live coverage"
+  git -C "$repo" add AGENTS.md
+  git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm agents-trigger-change
 
   printf '\n' >>"$repo/src/unmapped.ts"
   set +e


### PR DESCRIPTION
## Intent

Make Firstmate's exhaustive-review workflow durable and discoverable without relying on this conversation. On captain requests for exhaustive review, review convergence, a canonical fix wave, or exact-SHA post-fix review, the primary must load one named agent-only procedure and only route and supervise a project worker selected through the existing captain override, dispatch-profile/quota, effort, and spawn-capable backend rules. The primary must never substitute a generic top-level GSD adapter, spawn_agent path, or direct project reviewer/fixer. The delegated worker owns project code and invokes GSD review in its isolated project worktree, with any specialist reviewers below that worker. Require discovery-first read-only review against an immutable SHA; freeze all independent ledgers before reporting; reconcile them into a tracked committed canonical review document; make non-force-pushed, remote-SHA-verified review artifacts and coherent red/green atomic fix checkpoints; prevent unreviewed dirty state, credentials, runtime artifacts, or recovery sentinels from being pushed; and require a fresh independent zero-blocker review bound to the exact final code SHA before certification or merge consideration. Preserve all existing captain approval boundaries and grant no merge, force-push, tag, release, credential exposure, or main-branch authority. Add and retain an actual end-to-end behavioral validation that exercises the skill through a real primary agent turn, the normal brief/spawn interfaces, and a separate worker-side immutable-SHA GSD review handoff, rather than only file-content or documentation assertions. Keep model and backend policy unhardcoded by the procedure itself, even though this implementation task ran on Codex GPT-5.6-Terra via Herdr.

## What Changed

- Add a named agent-only exhaustive-review procedure and trigger that routes captain-requested reviews through the selected Firstmate worker with immutable-SHA, canonical-ledger, atomic-fix, and final independent-review gates.
- Add an opt-in live Pi routing E2E guard, its documentation, and changed-file selection coverage for the skill and `AGENTS.md`.
- Normalize `v`-prefixed actionlint version output before checking the pinned version.

## Risk Assessment

✅ Low: The follow-up adds the missing AGENTS.md selection path and a focused fixture assertion; no further material source issues were found.

## Testing

After inspecting the clean target, I repaired the test-only red control so generic model inference cannot impersonate the named procedure, ran the real Pi primary-to-worker E2E with preserved brief/metadata/handoff/rejection evidence, ran both directly affected supporting tests, and confirmed no transient worktree artifacts remain.

<details>
<summary>Evidence: Final credentialed live E2E transcript</summary>

<code>ok - real Pi primary used fm-brief and fm-spawn to hand off the immutable project SHA from an isolated worker&#10;ok - removing the routing policy produced required red evidence at the worker boundary</code>

```text
A new version of treehouse is available: v2.1.0 → v2.3.0
Run "treehouse update" to update

Created /private/var/folders/tk/bmp_tx0976s4rkh1phvrpjlw0000gn/T/fm-exhaustive-review-routing-live.OEOklf/green/app/treehouse.toml
ok - real Pi primary used fm-brief and fm-spawn to hand off the immutable project SHA from an isolated worker
A new version of treehouse is available: v2.1.0 → v2.3.0
Run "treehouse update" to update

Created /private/var/folders/tk/bmp_tx0976s4rkh1phvrpjlw0000gn/T/fm-exhaustive-review-routing-live.OEOklf/red/app/treehouse.toml
ok - removing the routing policy produced required red evidence at the worker boundary
```
</details>
<details>
<summary>Evidence: Generated intact-policy worker brief</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
Conduct a captain-requested exhaustive review of app. The selected worker profile is harness=pi, model=openai-codex/gpt-5.6-terra, effort=high; the configured backend is tmux. Routing proof marker: firstmate-routing-policy-8230-28925-24931.

You must follow the `firstmate-exhaustive-review` procedure. Before review discovery, resolve and record one full immutable commit SHA. Keep the source tree read-only until all planned GSD discovery reviewers have completed. Invoke the appropriate `$gsd-code-review` / GSD review workflow from this worktree; do not create your own reviewer or fixer process outside that workflow.

Give each independent reviewer the same frozen SHA and a clear source scope. Preserve every reviewer ledger with stable finding IDs, severity, location, evidence, impact, and disposition. Wait for all planned outputs, then consolidate all unique findings, duplicates/conflicts, dispositions, reviewer identities, review scope, frozen SHA, and unresolved-blocker count into one tracked, PR-visible canonical review document on this branch. Commit every relevant review artifact or fully carry its ledger into that committed document, push without force, and verify the remote branch SHA matches after each artifact or fix checkpoint.

If there are findings, make one coherent dependency-group fix wave from the complete frozen ledger: state the finding IDs and expected behavioral change, establish red regression evidence or reproducible proof for each defect, implement and verify green evidence, stage only reviewed files, and make atomic checkpoints. Do not use automatic one-finding fix loops. If a materially new issue appears, record it for the next complete ledger rather than silently extending this wave.

After the final green code checkpoint, obtain a fresh independent GSD review against its exact full SHA from a reviewer who did not implement the fixes. Add the final reviewer, exact reviewed code SHA, scope, findings/dispositions, and zero-blocker result to the tracked canonical document; commit, non-force-push, and verify remote SHA. Only a zero-blocker final review that names the final code SHA can certify the review. If code changes after that review, repeat independent final review; if final review finds a blocker, begin a new complete frozen-ledger wave.

Use the project's test suite as appropriate and include the canonical review document and any necessary fixes in a direct PR. Do not use the no-mistakes pipeline. If GSD review cannot run within the selected worker runtime, or an existing validation run owns the branch, report a concise blocker and stop rather than substituting a different review route. In the PR description, summarize scope, frozen SHA, canonical-ledger location, final reviewed code SHA, and tests.

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text that replaces `{TASK}` later.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of app, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/exhaustive-review-e2e-9443`

# Rules
1. Never push to the default branch (push only your `fm/exhaustive-review-e2e-9443` branch). Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/tk/bmp_tx0976s4rkh1phvrpjlw0000gn/T/fm-exhaustive-review-routing-live.OEOklf/green/primary-home/state/exhaustive-review-e2e-9443.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/var/folders/tk/bmp_tx0976s4rkh1phvrpjlw0000gn/T/fm-exhaustive-review-routing-live.OEOklf/green/primary-root/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/var/folders/tk/bmp_tx0976s4rkh1phvrpjlw0000gn/T/fm-exhaustive-review-routing-live.OEOklf/green/primary-root/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=direct-PR
This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
The task is complete only when committed on your branch.
When it is implemented and committed, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` to the status file and stop.
Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.

## Progress note (2026-08-23T18:39:45Z)

This task was relaunched. Continue from here; the local copy and every
uncommitted change are exactly as the previous worker left them.

The initial process returned to the shell before processing the instructions; begin from the complete brief and retain the same review scope.
```
</details>
<details>
<summary>Evidence: Isolated worker immutable-SHA GSD handoff</summary>

<code>gsd_command=$gsd-code-review --sha 499cc008a20dd824bf980307ff4e5fe678f94ffa&#10;GSD_REVIEW_HANDOFF</code>

```text
worker_cwd=/Users/karthiksivadas/.treehouse/app-df9354/1/app
worker_sha=499cc008a20dd824bf980307ff4e5fe678f94ffa
launch_payload=⁣FIRSTMATE_OP: v1 launch-brief: You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
gsd_command=$gsd-code-review --sha 499cc008a20dd824bf980307ff4e5fe678f94ffa
GSD_REVIEW_HANDOFF
```
</details>
<details>
<summary>Evidence: Removed-policy worker rejection</summary>

`REJECTED_MISSING_ROUTING_POLICY`

```text
worker_cwd=/Users/karthiksivadas/.treehouse/app-6d4a40/1/app
worker_sha=f3ba77af41ec2f4c8859372a62532e57d2195a44
launch_payload=⁣FIRSTMATE_OP: v1 launch-brief: You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
REJECTED_MISSING_ROUTING_POLICY
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed (3) ✅ across 4 runs (2h21m37s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (2) ✅</summary>

- 🚨 `tests/fm-exhaustive-review-routing-live-e2e.test.sh:68` - The intent requires “an actual end-to-end behavioral validation that exercises the skill through a real primary agent turn, the normal brief/spawn interfaces, and a separate worker-side immutable-SHA GSD review handoff.” This hunk replaces both normal interfaces with `$PRIMARY/bin` shims (lines 68–133); the spawn shim directly runs a GSD shim in `$WORKER`. Its SHA is the worker skill-fixture commit (line 65), not the `$APP` project commit (line 59). The tracked brief/spawn guards, an actual worker handoff, and review of a project worktree are never exercised.
- 🚨 `tests/fm-exhaustive-review-routing-live-e2e.test.sh:136` - The required validation must “exercise the skill through a real primary agent turn,” but the prompt itself dictates the resolved profile, exact brief/spawn commands, and prohibition on direct GSD/generic delegation (lines 136–141). Together with `--no-context-files`, this can pass even if the routing policy in the new skill regresses, because the agent can simply follow the test prompt. Keep only captain-request/fixture facts in the prompt and assert behavior derived from the loaded Firstmate instructions.

🔧 Fix: Harden exhaustive review routing validation
1 warning still open:
- ⚠️ `bin/fm-test-run.sh:1030` - `--changed` maps the new skill to `live-harness-optin`, but `AGENTS.md` remains mapped only to `pure-contract-unit`. An AGENTS-only removal or weakening of the new exhaustive-review trigger would not select the live E2E guard; include `AGENTS.md` in this live family or add an equivalent targeted selection rule.

🔧 Fix: Select live review guard for AGENTS changes
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed (3) ✅</summary>

- ⚠️ `tests/fm-exhaustive-review-routing-live-e2e.test.sh:67` - Required real-primary behavioral evidence is missing: the credentialed exhaustive-review E2E test stops at its enforced quota-axi &gt;=0.1.29 prerequisite, while every available PATH candidate is 0.1.28. Run this phase in an environment with quota-axi 0.1.29+ to complete the live validation.
- `command -v pi && pi --version && command -v tmux && tmux -V && git --version`
- <code>`quota-axi --version` (0.1.28; checked all PATH candidates)</code>
- `FM_EXHAUSTIVE_REVIEW_ROUTING_LIVE_E2E=1 bash tests/fm-exhaustive-review-routing-live-e2e.test.sh`
- `bash tests/fm-test-run.test.sh`
- `bash tests/fm-documentation-audiences.test.sh`
- `bin/fm-test-run.sh --list --changed --base 1231b6ae7fd4c5ff7e94d2f5ca2159536c4c41cb`

🔧 Fix: Blocked by exhausted Pi-authenticated Codex account
1 warning still open:
- ⚠️ `tests/fm-exhaustive-review-routing-live-e2e.test.sh:282` - Required real primary-to-worker behavioral evidence remains unavailable. The mandated live E2E reaches the real Pi invocation but exits before brief/spawn routing with `Codex error: The usage limit has been reached`. A minimal no-tool Pi turn using the identical `openai-codex/gpt-5.6-terra` model fails identically, isolating the blocker to the Pi/Codex runtime rather than observed routing behavior. `quota-axi --full` reports Codex capacity, so its telemetry conflicts with the actual provider result. Restore or reconcile availability for Pi’s configured Codex model, then rerun this E2E; deterministic checks cannot certify the required live route.
- <code>`git rev-parse HEAD` → `01574ad3e3c9a4957ad8ef9aea9ad8caeadd37d2`</code>
- <code>`quota-axi --version` and `source bin/fm-quota-axi-lib.sh; fm_quota_axi_compatible`</code>
- `quota-axi --full`
- `FM_EXHAUSTIVE_REVIEW_ROUTING_LIVE_E2E=1 bin/fm-test-run.sh tests/fm-exhaustive-review-routing-live-e2e.test.sh`
- `pi --print --approve --no-session --no-extensions --no-skills --skill .agents/skills --tools bash --model openai-codex/gpt-5.6-terra --thinking high 'Reply with exactly READY. Take no tool actions.'`
- `bin/fm-test-run.sh tests/fm-documentation-audiences.test.sh tests/fm-test-run.test.sh`
- `git status --short`

🔧 Fix: Fix exhaustive-review live E2E fixture
1 error still open:
- 🚨 `tests/fm-exhaustive-review-routing-live-e2e.test.sh:315` - The required credentialed E2E fails its red negative control. After the fixture replaces `firstmate-exhaustive-review` with a policy-free version, the real Pi primary still spawns a worker whose record contains an immutable-SHA `$gsd-code-review --sha` handoff instead of `REJECTED_MISSING_ROUTING_POLICY`. The test exits at this assertion, so it cannot prove the live route depends on the named procedure rather than an alternate or ambient path. Repair the routing/test isolation and rerun the real E2E.
- <code>`git rev-parse HEAD` and target/base diff inspection</code>
- `FM_EXHAUSTIVE_REVIEW_ROUTING_LIVE_E2E=1 bash tests/fm-exhaustive-review-routing-live-e2e.test.sh`
- `Exact-SHA isolated clone/checkout counterfactual`
- `FM_EXHAUSTIVE_REVIEW_ROUTING_LIVE_E2E=1 bash -x tests/fm-exhaustive-review-routing-live-e2e.test.sh`
- `FM_EXHAUSTIVE_REVIEW_ROUTING_LIVE_E2E=1 bin/fm-test-run.sh --json /var/folders/tk/bmp_tx0976s4rkh1phvrpjlw0000gn/T/no-mistakes-evidence/01M0MT9G291MS943KPEMD10WDD/fm-exhaustive-review-routing-live-e2e-retry2-timing.json tests/fm-exhaustive-review-routing-live-e2e.test.sh`
- `bash tests/fm-test-run.test.sh`
- `bash tests/fm-documentation-audiences.test.sh`

🔧 Fix: Verify exhaustive-review E2E negative control
✅ Re-checked - no issues remain.
- `Inspected the target diff, named procedure, and live-E2E fixture.`
- <code>Three focused executions of `FM_EXHAUSTIVE_REVIEW_ROUTING_LIVE_E2E=1 bash tests/fm-exhaustive-review-routing-live-e2e.test.sh`; the final provenance-aware credentialed run passed both green and red branches.</code>
- `bash tests/fm-documentation-audiences.test.sh`
- `bash tests/fm-test-run.test.sh`
- <code>`git status --short` and transient-directory check; only the intentional live-E2E test update remains in the worktree.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed (3) ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Fix exhaustive-review E2E ShellCheck findings
1 warning still open:
- ⚠️ linter found issues (exit code 1)

🔧 Fix: Normalize actionlint version parsing
1 warning still open:
- ⚠️ linter found issues (exit code 1)

🔧 Fix: Confirm canonical lint passes
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
