### PR TITLE
fix(bin): reserve gate-refusal exit code so remote leg cannot report it as delivered

### DIFF
--- a/bin/fm-gate-refuse-lib.sh
+++ b/bin/fm-gate-refuse-lib.sh
@@ -60,8 +60,12 @@
 # gate context.
 
 # The exit code every refusal uses, distinct enough to recognize in a caller or
-# test as "the gate refusal fired" rather than an ordinary usage error.
-FM_GATE_REFUSE_EXIT=3
+# test as "the gate refusal fired" rather than an ordinary usage error. 77 is
+# reserved OUTSIDE every fleet-lifecycle script's documented status space: it
+# must never collide with fm-send's delivered-unconfirmed exit 3, which the
+# remote leg maps to "delivered, do not resend" - a gate refusal wearing exit 3
+# would be reported as a delivered steer. Keep this value out of that space.
+FM_GATE_REFUSE_EXIT=77
 
 # fm_is_gate_agent: return 0 without output when this process looks like a
 # no-mistakes gate agent. An optional root anchors the git-common-dir check;

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -54,7 +54,10 @@
 # before any resend, and never re-type blindly; a marked request's
 # pending-reply expectation stays armed because this outcome is not a proven
 # failure); any other nonzero = the send failed and nothing may be assumed
-# delivered. Submission dispatches through the target's recorded backend; the
+# delivered. 77 is reserved for the no-mistakes gate-agent refusal and never
+# means delivered (bin/fm-gate-refuse-lib.sh): it exits before any submit, so
+# nothing was sent and the remote leg treats it as a hard failure, never as the
+# delivered-unconfirmed exit 3. Submission dispatches through the target's recorded backend; the
 # tmux adapter shares its composer/submit core with the away-mode daemon via
 # bin/fm-tmux-lib.sh. Tune with FM_SEND_RETRIES (default 3) / FM_SEND_SLEEP
 # (0.4). Slash commands, and codex `$...` skill invocations resolved through

--- a/tests/fm-gate-refuse.test.sh
+++ b/tests/fm-gate-refuse.test.sh
@@ -14,8 +14,8 @@
 # signal and is completely unaffected.
 #
 # Each entrypoint is exercised in three scenarios, isolating exactly ONE signal:
-#   - env-marker refuse : neutral cwd + NO_MISTAKES_GATE set      -> exit 3, no mutation
-#   - path-backstop refuse: gate-worktree cwd + marker UNSET      -> exit 3, no mutation
+#   - env-marker refuse : neutral cwd + NO_MISTAKES_GATE set      -> refuse, no mutation
+#   - path-backstop refuse: gate-worktree cwd + marker UNSET      -> refuse, no mutation
 #   - no-regression      : neutral cwd + marker UNSET             -> succeeds, no gate error
 # The marker is UNSET explicitly in the no-regression/backstop runs (env -u) and
 # those runs stand in a controlled NON-gate repo, so the suite is hermetic even
@@ -31,6 +31,11 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 GATE_LIB="$ROOT/bin/fm-gate-refuse-lib.sh"
+# Own the refusal code in one place: source it from the library under test so
+# this suite tracks the constant instead of hard-coding the number.
+# shellcheck source=bin/fm-gate-refuse-lib.sh
+. "$GATE_LIB"
+REFUSE_CODE=$FM_GATE_REFUSE_EXIT
 SPAWN="$ROOT/bin/fm-spawn.sh"
 SEND="$ROOT/bin/fm-send.sh"
 TEARDOWN="$ROOT/bin/fm-teardown.sh"
@@ -100,7 +105,7 @@ run_guard_lib() {
 test_helper_env_marker_refuses() {
   local out rc
   out=$(run_guard_lib "$NORMAL_CWD" set); rc=$?
-  expect_code 3 "$rc" "helper: env marker must exit 3"
+  expect_code "$REFUSE_CODE" "$rc" "helper: env marker must refuse"
   assert_contains "$out" "$ENV_MSG" "helper: env-marker refusal message"
   pass "fm-gate-refuse-lib: refuses when NO_MISTAKES_GATE is set"
 }
@@ -108,7 +113,7 @@ test_helper_env_marker_refuses() {
 test_helper_empty_env_marker_refuses() {
   local out rc
   out=$(run_guard_lib "$NORMAL_CWD" empty); rc=$?
-  expect_code 3 "$rc" "helper: empty env marker must exit 3"
+  expect_code "$REFUSE_CODE" "$rc" "helper: empty env marker must refuse"
   assert_contains "$out" "$ENV_MSG" "helper: empty env-marker refusal message"
   pass "fm-gate-refuse-lib: refuses when NO_MISTAKES_GATE is set empty"
 }
@@ -117,7 +122,7 @@ test_helper_path_backstop_refuses() {
   local out rc
   # Marker UNSET: only the git-common-dir backstop can fire here.
   out=$(run_guard_lib "$GATE_WT"); rc=$?
-  expect_code 3 "$rc" "helper: gate worktree must exit 3 even with the marker unset"
+  expect_code "$REFUSE_CODE" "$rc" "helper: gate worktree must refuse even with the marker unset"
   assert_contains "$out" "$PATH_MSG" "helper: path-backstop refusal message"
   assert_not_contains "$out" "$ENV_MSG" "helper: backstop must not be attributed to the env marker"
   pass "fm-gate-refuse-lib: refuses from a gate worktree via git-common-dir (marker unset)"
@@ -181,13 +186,13 @@ test_spawn_refuses_and_admits() {
 
   # env-marker refuse: neutral cwd, marker set.
   out=$(run_spawn "$NORMAL_CWD" "$home" spawn-envmark "$proj" "$wt" "$fakebin" NO_MISTAKES_GATE=1); rc=$?
-  expect_code 3 "$rc" "spawn: NO_MISTAKES_GATE must refuse"
+  expect_code "$REFUSE_CODE" "$rc" "spawn: NO_MISTAKES_GATE must refuse"
   assert_contains "$out" "$ENV_MSG" "spawn: env-marker refusal message"
   assert_absent "$home/state/spawn-envmark.meta" "spawn: refused env-marker launch must not record meta"
 
   # path-backstop refuse: gate-worktree cwd, marker UNSET.
   out=$(run_spawn "$GATE_WT" "$home" spawn-backstop "$proj" "$wt" "$fakebin"); rc=$?
-  expect_code 3 "$rc" "spawn: gate-worktree cwd must refuse with the marker unset"
+  expect_code "$REFUSE_CODE" "$rc" "spawn: gate-worktree cwd must refuse with the marker unset"
   assert_contains "$out" "$PATH_MSG" "spawn: path-backstop refusal message"
   assert_absent "$home/state/spawn-backstop.meta" "spawn: refused backstop launch must not record meta"
 
@@ -256,14 +261,14 @@ test_send_refuses_and_admits() {
   # env-marker refuse.
   : > "$log"
   out=$(run_send "$NORMAL_CWD" "$home" "$fakebin" "$log" fm-lane-ok "hello captain" NO_MISTAKES_GATE=1); rc=$?
-  expect_code 3 "$rc" "send: NO_MISTAKES_GATE must refuse"
+  expect_code "$REFUSE_CODE" "$rc" "send: NO_MISTAKES_GATE must refuse"
   assert_contains "$out" "$ENV_MSG" "send: env-marker refusal message"
   [ ! -s "$log" ] || fail "send: refused env-marker send still typed to the endpoint"$'\n'"$(cat "$log")"
 
   # path-backstop refuse (marker UNSET).
   : > "$log"
   out=$(run_send "$GATE_WT" "$home" "$fakebin" "$log" fm-lane-ok "hello captain"); rc=$?
-  expect_code 3 "$rc" "send: gate-worktree cwd must refuse with the marker unset"
+  expect_code "$REFUSE_CODE" "$rc" "send: gate-worktree cwd must refuse with the marker unset"
   assert_contains "$out" "$PATH_MSG" "send: path-backstop refusal message"
   [ ! -s "$log" ] || fail "send: refused backstop send still typed to the endpoint"$'\n'"$(cat "$log")"
 
@@ -347,14 +352,14 @@ test_teardown_refuses_and_admits() {
   # env-marker refuse: a genuinely-landed task is still refused; nothing is torn down.
   case_dir=$(make_teardown_case teardown-envmark)
   out=$(run_teardown "$NORMAL_CWD" "$case_dir" NO_MISTAKES_GATE=1); rc=$?
-  expect_code 3 "$rc" "teardown: NO_MISTAKES_GATE must refuse"
+  expect_code "$REFUSE_CODE" "$rc" "teardown: NO_MISTAKES_GATE must refuse"
   assert_contains "$out" "$ENV_MSG" "teardown: env-marker refusal message"
   assert_present "$case_dir/state/task-x1.meta" "teardown: refused env-marker teardown must leave the task"
 
   # path-backstop refuse (marker UNSET).
   case_dir=$(make_teardown_case teardown-backstop)
   out=$(run_teardown "$GATE_WT" "$case_dir"); rc=$?
-  expect_code 3 "$rc" "teardown: gate-worktree cwd must refuse with the marker unset"
+  expect_code "$REFUSE_CODE" "$rc" "teardown: gate-worktree cwd must refuse with the marker unset"
   assert_contains "$out" "$PATH_MSG" "teardown: path-backstop refusal message"
   assert_present "$case_dir/state/task-x1.meta" "teardown: refused backstop teardown must leave the task"
 

--- a/tests/fm-send-remote-delivery.test.sh
+++ b/tests/fm-send-remote-delivery.test.sh
@@ -28,12 +28,22 @@
 #   6. A local typed-plane unconfirmed send (a harness-native slash answer)
 #      still never closes a --resolve-key decision, and an unconfirmed typed
 #      secondmate send keeps its reply expectation armed.
+#   7. A gate-agent refusal inside the remote leg (ssh exits the reserved
+#      FM_GATE_REFUSE_EXIT with the gate stderr) is a hard failure, NOT a
+#      delivery: the parent fails loudly, replays the gate diagnostic, discards
+#      the undelivered expectation, and closes no --resolve-key decision. This
+#      is the exact false-positive the reserved code exists to prevent - the
+#      gate refusal must never be confused with the delivered-unconfirmed exit.
 set -u
 
 # shellcheck source=tests/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 # shellcheck source=bin/fm-pending-reply-lib.sh
 . "$ROOT/bin/fm-pending-reply-lib.sh"
+# Source the gate-refusal code from its owning library so this suite drives the
+# remote leg with the real reserved value instead of a hard-coded number.
+# shellcheck source=bin/fm-gate-refuse-lib.sh
+. "$ROOT/bin/fm-gate-refuse-lib.sh"
 
 SEND="$ROOT/bin/fm-send.sh"
 DRAIN="$ROOT/bin/fm-wake-drain.sh"
@@ -215,6 +225,43 @@ test_remote_transport_unknown_preserves_expectation() {
   pass "fm-send remote: ssh 255 still refuses loudly and preserves the expectation as delivery_unknown"
 }
 
+test_remote_gate_refusal_is_hard_failure() {
+  local dir fb log ssh_log home rc err out
+  dir="$TMP_ROOT/remote-gate"; mkdir -p "$dir"
+  fb=$(make_stubs "$dir"); log="$dir/send.log"; ssh_log="$dir/ssh.log"; : > "$ssh_log"
+  home=$(setup_remote_home remote-gate)
+  printf 'needs-decision [key=upgrade-window]: tonight or the weekend\n' > "$home/state/rsm.status"
+
+  # The remote leg's inner fm-send refuses as a no-mistakes gate agent, exiting
+  # the reserved FM_GATE_REFUSE_EXIT with the gate diagnostic on stderr. That
+  # code was once 3, which the parent maps to delivered-unconfirmed; the reserve
+  # keeps a gate refusal - "nothing was sent" - from being reported as a
+  # delivered steer that answers the decision.
+  : > "$log"
+  env PATH="$fb:$PATH" \
+    FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_SEND_LOG="$log" FM_SEND_SETTLE=0 \
+    FM_SSH_BIN="$fb/fake-ssh" FM_SSH_LOG="$ssh_log" FM_FAKE_SSH_RC="$FM_GATE_REFUSE_EXIT" \
+    FM_FAKE_SSH_STDERR='error: no-mistakes gate agent must not drive the fleet (NO_MISTAKES_GATE set)' \
+    "$SEND" rsm --resolve-key upgrade-window "the weekend, freeze Friday" >"$dir/out" 2>"$dir/err"; rc=$?
+  err=$(cat "$dir/err")
+  [ "$rc" -ne 0 ] || fail "a gate refusal inside the remote leg must exit nonzero, not as delivered"
+  assert_contains "$err" "error: text not sent to remote:rsm" \
+    "a gate refusal must report a real failure, never a delivered notice"
+  assert_not_contains "$err" "delivered to remote secondmate rsm" \
+    "a gate refusal must never be reported as delivered"
+  assert_contains "$err" "must not drive the fleet" \
+    "a gate refusal must replay the remote leg's gate diagnostic"
+  [ -z "$(pending_record "$home")" ] \
+    || fail "a gate refusal must discard the undelivered expectation"
+  if grep -F 'resolved' "$home/state/rsm.status" >/dev/null; then
+    fail "a gate refusal must not close the --resolve-key decision: $(cat "$home/state/rsm.status")"
+  fi
+  out=$(drain_out "$home")
+  printf '%s' "$out" | grep -F '[key=upgrade-window]' >/dev/null \
+    || fail "the decision must stay open after a gate-refused send: $out"
+  pass "fm-send remote: a gate refusal fails loudly, discards the expectation, and closes no decision"
+}
+
 test_remote_delivered_unconfirmed_closes_resolve_key() {
   local dir fb log ssh_log home rc out
   dir="$TMP_ROOT/remote-key"; mkdir -p "$dir"
@@ -315,6 +362,7 @@ test_local_pending_does_not_close_resolve_key() {
 test_remote_delivered_unconfirmed_is_not_failure
 test_remote_real_failure_still_fails
 test_remote_transport_unknown_preserves_expectation
+test_remote_gate_refusal_is_hard_failure
 test_remote_delivered_unconfirmed_closes_resolve_key
 test_local_pending_reports_delivered_unconfirmed
 test_local_pending_does_not_close_resolve_key


### PR DESCRIPTION
## Summary

Implements accepted simplification-audit finding **F-S12-1 (P0)**.

`fm-send` exit status `3` was overloaded to mean two contradictory things:
- a no-mistakes gate-agent refusal ("nothing was sent"), and
- a delivered-with-unconfirmed-submit ("do not resend").

The remote send leg maps an inner exit `3` to *delivered*, so a gate refusal inside the remote host's `fm-send` would be wrongly reported as a delivered steer.

## Change

1. `bin/fm-gate-refuse-lib.sh` - move `FM_GATE_REFUSE_EXIT` from `3` to a reserved `77` (outside every lifecycle script's documented status space) and update its header sentence explaining the reservation.
2. `bin/fm-send.sh` - document code `77` in the header exit contract as reserved for the gate-agent refusal, never meaning delivered.
3. `tests/fm-gate-refuse.test.sh` - assert against the sourced `$FM_GATE_REFUSE_EXIT` so the value stays owned in one place; degeneralize stale "exit 3" wording.
4. `tests/fm-send-remote-delivery.test.sh` - add a negative case where the ssh stub exits the reserved gate code with the gate stderr, asserting the parent fails loudly, discards the undelivered pending-reply expectation, and closes no `--resolve-key` decision.

Delivered-unconfirmed exit `3` semantics are intentionally unchanged. Grepped `bin/` and `tests/`: no other caller branches on exit `3` from `fm-spawn`/`fm-send`/`fm-teardown`/`fm-control` as a refusal, matching the audit.

## Validation

`bin/fm-lint.sh` clean (ShellCheck 0.11.0 + actionlint 1.7.12); both affected test suites pass; the remote gate-refusal case was regression-verified (fails when the constant is reverted to 3).