### PR TITLE
refactor(bin): give fm-crew-state one owner of the CI-ready verdict

### DIFF
--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -545,21 +545,15 @@ if [ "$HAVE_RUN" = 1 ]; then
     fi
   fi
 
-  if [ "$RUN_STATE" = working ] && log_reports_ci_ready; then
-    if [ "$RUN_SOURCE" = coarse ]; then
-      emit "done" status-log "$(status_line_note "$LOG_LINE")${SEP}run still monitoring PR"
-    fi
-    [ -n "$CI_STEP_STATUS" ] || CI_STEP_STATUS=$(nm_effective_ci_step_status)
-    if [ "$RUN_STATUS" = fixing ]; then
-      CI_LOG_STATE=not-ready
-    elif [ "$CI_STEP_STATUS" = running ] && [ -z "$CI_LOG_STATE" ]; then
-      CI_LOG_STATE=$(nm_ci_checks_state)
-    elif [ "$CI_STEP_STATUS" = fixing ]; then
-      CI_LOG_STATE=not-ready
-    fi
-    if [ "$CI_LOG_STATE" != not-ready ]; then
-      emit "done" status-log "$(status_line_note "$LOG_LINE")${SEP}run still monitoring PR"
-    fi
+  # A crew's own "done: ... checks green" status-log beats a run that is still
+  # monitoring the PR to merge/close. CI readiness is decided once, above: on the
+  # full path RUN_STATE=working reaches here only from the `case "$status"` block,
+  # which already ran the first derivation, so CI_LOG_STATE is final here (never
+  # not-ready without the first block having said so); on the coarse path no step
+  # detail exists, so the done log alone carries the verdict.
+  if [ "$RUN_STATE" = working ] && log_reports_ci_ready \
+     && { [ "$RUN_SOURCE" = coarse ] || [ "$CI_LOG_STATE" != not-ready ]; }; then
+    emit "done" status-log "$(status_line_note "$LOG_LINE")${SEP}run still monitoring PR"
   fi
 
   # Reconcile the status log. A needs-decision/blocked log line that the run-step

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -308,6 +308,22 @@ run:
 EOF
 }
 
+run_running_no_ci_step() {  # <branch>
+  cat <<EOF
+run:
+  id: "01RUN"
+  branch: $1
+  status: running
+  head: "${FM_FAKE_RUN_HEAD:-abc1234}"
+  pr: "https://github.com/o/r/pull/2"
+  findings: none
+  steps[3]{step,status,findings,duration_ms}:
+    intent,completed,0,0
+    review,completed,0,0
+    push,running,0,0
+EOF
+}
+
 run_fixing_ci_running() {  # <branch>
   cat <<EOF
 run:
@@ -455,6 +471,47 @@ test_ci_ready_done_log_beats_monitoring_run() {
   assert_contains "$out" "checks green" "ci-ready detail preserves the report"
   assert_not_contains "$out" "state: working" "ci-ready is not hidden by monitoring run"
   pass "ci-ready status log beats monitoring run"
+}
+
+# Full path, CI_LOG_STATE empty: status=running with no ci step row means the
+# ci-readiness derivation leaves CI_LOG_STATE unset (nm_effective_ci_step_status
+# returns empty), yet the crew's own "checks green" status-log must still surface
+# done. Exercises the surviving CI_LOG_STATE != not-ready emit path with an empty
+# CI_LOG_STATE, the single-owner reduction of the former duplicate derivation.
+test_ci_ready_done_log_no_ci_step_surfaces_done() {
+  reset_fakes
+  local d; d=$(new_case ci-ready-no-step)
+  make_repo_on_branch "$d/wt" fm/feat-cinostep
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-cinostep.meta" "window=fm:fm-feat-cinostep" "worktree=$d/wt" "kind=ship"
+  printf 'done: PR https://github.com/o/r/pull/2 checks green\n' > "$d/state/feat-cinostep.status"
+  FM_FAKE_AXI_STATUS="$(run_running_no_ci_step fm/feat-cinostep)"
+  local out; out=$(run_crew_state "$d" feat-cinostep)
+  assert_contains "$out" "state: done" "done log without ci step -> done"
+  assert_contains "$out" "source: status-log" "done log without ci step comes from the status log"
+  assert_contains "$out" "checks green" "done log without ci step detail preserves the report"
+  assert_not_contains "$out" "state: working" "done log without ci step is not hidden by the run"
+  pass "done log with no ci step row surfaces done"
+}
+
+# Full path, CI_LOG_STATE unknown: status=ci with no recognized ci-log marker
+# leaves CI_LOG_STATE=unknown (not not-ready), and a "checks green" status-log
+# must still surface done. Confirms unknown, like empty, does not block the emit.
+test_ci_ready_done_log_ci_log_unknown_surfaces_done() {
+  reset_fakes
+  local d; d=$(new_case ci-ready-unknown)
+  make_repo_on_branch "$d/wt" fm/feat-ciunknown
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/feat-ciunknown.meta" "window=fm:fm-feat-ciunknown" "worktree=$d/wt" "kind=ship"
+  printf 'done: PR https://github.com/o/r/pull/2 checks green\n' > "$d/state/feat-ciunknown.status"
+  FM_FAKE_AXI_STATUS="$(run_top_level_ci fm/feat-ciunknown)"
+  FM_FAKE_CI_LOGS=""
+  local out; out=$(run_crew_state "$d" feat-ciunknown)
+  assert_contains "$out" "state: done" "done log with unknown ci-log -> done"
+  assert_contains "$out" "source: status-log" "done log with unknown ci-log comes from the status log"
+  assert_contains "$out" "checks green" "done log with unknown ci-log detail preserves the report"
+  assert_not_contains "$out" "state: working" "done log with unknown ci-log is not hidden by the run"
+  pass "done log with unknown ci-log state surfaces done"
 }
 
 # Regression for the PR #252 incident: the crew's own status log never got a
@@ -1415,6 +1472,8 @@ test_genuine_parked_not_superseded
 test_scalar_gate_parked_not_superseded
 test_gate_block_parked_not_superseded
 test_ci_ready_done_log_beats_monitoring_run
+test_ci_ready_done_log_no_ci_step_surfaces_done
+test_ci_ready_done_log_ci_log_unknown_surfaces_done
 test_ci_monitoring_checks_green_surfaces_done
 test_top_level_ci_checks_green_surfaces_done
 test_ci_monitoring_no_checks_terminal_surfaces_done


### PR DESCRIPTION
## Summary

Implements accepted simplification-audit finding **F-S07-2** (P0): `bin/fm-crew-state.sh` derived the CI-readiness verdict twice, and the second derivation was dead code that created a second owner of a safety-relevant rule.

The second block re-ran `nm_effective_ci_step_status` and a three-way `if/elif` that can never change `CI_LOG_STATE` on the full path: `RUN_STATE=working` reaches that block only from the `case "$status"` block, which already ran the first derivation (so `CI_LOG_STATE` is final by then); on the coarse path the block exits at its first `emit` before reaching it. This reduces the second block to its single live decision — a crew's own `done: ... checks green` status-log beats a run still monitoring the PR, unless the ci log reads `not-ready`.

The single-producer invariant was re-verified at HEAD before the change: the outcome branch never yields `working`, the gate branch yields `parked`, and no new `working` producer has appeared.

**Behavior is unchanged**: output line format, states, sources, and emitted detail strings are identical; no caller edits.

## Tests

Adds two colocated cases to `tests/fm-crew-state.test.sh` covering the surviving emit path:
- status=`running` with no ci step row (so `CI_LOG_STATE` is empty) + a done-checks-green log → reports `done`/`status-log`.
- status=`ci` with the green marker absent (`CI_LOG_STATE` unknown) + a done log → reports `done`/`status-log`.

All existing CI and coarse cases pass unchanged. `bin/fm-lint.sh` is green (pinned shellcheck 0.11.0, actionlint 1.7.12).

## Note on the validated run

The no-mistakes validation run for this branch passed every step (review, test, document, lint). Its lint step auto-added one extra commit — an environment-induced PATH fallback for the pinned lint tools (`bin/fm-lint.sh`, `bin/fm-lint-workflows.sh`) — that only appeared because the gate environment lacked shellcheck/actionlint on PATH. That commit is unrelated to this finding and has been **excluded from this PR for scope**; this PR contains only the F-S07-2 change.
