### PR TITLE
refactor(bin): collapse fm-pr-check-migrate legacy classifier into one function

### DIFF
--- a/bin/fm-pr-check-migrate.sh
+++ b/bin/fm-pr-check-migrate.sh
@@ -76,18 +76,35 @@ scan_marker_content_valid() {
   [ "$value" = "$SCAN_MARKER_VALUE" ]
 }
 
+# Classify one watcher check file by today's evaluation order: a valid current
+# X-mode shim, then a registered custom check, then a canonical PR poll, else a
+# legacy check to migrate. Prints exactly one of x-shim|custom|poll|legacy.
+classify_check() {
+  local check=$1 id
+  if [ "$(basename "$check")" = x-watch.check.sh ] \
+    && fmx_poll_shim_valid "$check" "$FM_HOME" "$FM_ROOT"; then
+    printf 'x-shim\n'
+    return 0
+  fi
+  id=$(basename "$check" .check.sh)
+  if fm_custom_check_registered "$STATE" "$id"; then
+    printf 'custom\n'
+    return 0
+  fi
+  if fm_pr_poll_artifacts_valid "$STATE" "$id" "$TEMPLATE"; then
+    printf 'poll\n'
+    return 0
+  fi
+  printf 'legacy\n'
+}
+
 current_checks_authenticated() {
-  local check id
+  local check
   for check in "$STATE"/*.check.sh; do
     [ -e "$check" ] || [ -L "$check" ] || continue
-    if [ "$(basename "$check")" = x-watch.check.sh ] \
-      && fmx_poll_shim_valid "$check" "$FM_HOME" "$FM_ROOT"; then
-      continue
-    fi
-    id=$(basename "$check" .check.sh)
-    fm_custom_check_registered "$STATE" "$id" && continue
-    fm_pr_poll_artifacts_valid "$STATE" "$id" "$TEMPLATE" || return 1
+    [ "$(classify_check "$check")" = legacy ] && return 1
   done
+  return 0
 }
 
 private_migration_boundaries_valid() {
@@ -381,35 +398,14 @@ if [ -e "$SCAN_MARKER" ] || [ -L "$SCAN_MARKER" ]; then
   rm -f -- "$SCAN_MARKER" || exit 1
   [ ! -e "$SCAN_MARKER" ] && [ ! -L "$SCAN_MARKER" ] || exit 1
 fi
+# Migration is needed exactly when some check is not already authenticated.
 migration_needed() {
-  local check id
-  for check in "$STATE"/*.check.sh; do
-    [ -e "$check" ] || [ -L "$check" ] || continue
-    if [ "$(basename "$check")" = x-watch.check.sh ] \
-      && fmx_poll_shim_valid "$check" "$FM_HOME" "$FM_ROOT"; then
-      continue
-    fi
-    id=$(basename "$check" .check.sh)
-    fm_custom_check_registered "$STATE" "$id" && continue
-    if ! fm_pr_poll_artifacts_valid "$STATE" "$id" "$TEMPLATE"; then
-      return 0
-    fi
-  done
-  return 1
+  ! current_checks_authenticated
 }
 
+# Byte-identical to current_checks_authenticated: no legacy check remains armed.
 unsafe_checks_absent() {
-  local check id
-  for check in "$STATE"/*.check.sh; do
-    [ -e "$check" ] || [ -L "$check" ] || continue
-    if [ "$(basename "$check")" = x-watch.check.sh ] \
-      && fmx_poll_shim_valid "$check" "$FM_HOME" "$FM_ROOT"; then
-      continue
-    fi
-    id=$(basename "$check" .check.sh)
-    fm_custom_check_registered "$STATE" "$id" && continue
-    fm_pr_poll_artifacts_valid "$STATE" "$id" "$TEMPLATE" || return 1
-  done
+  current_checks_authenticated
 }
 
 revoke_migration_marker() {
@@ -1034,13 +1030,8 @@ if migration_needed; then
 
   for check in "$STATE"/*.check.sh; do
     [ -e "$check" ] || [ -L "$check" ] || continue
-    if [ "$(basename "$check")" = x-watch.check.sh ] \
-      && fmx_poll_shim_valid "$check" "$FM_HOME" "$FM_ROOT"; then
-      continue
-    fi
+    [ "$(classify_check "$check")" = legacy ] || continue
     id=$(basename "$check" .check.sh)
-    fm_custom_check_registered "$STATE" "$id" && continue
-    fm_pr_poll_artifacts_valid "$STATE" "$id" "$TEMPLATE" && continue
 
     if fm_pr_task_id_valid "$id"; then
       prefix=$id

--- a/tests/fm-pr-check-security.test.sh
+++ b/tests/fm-pr-check-security.test.sh
@@ -3372,6 +3372,64 @@ test_gitlab_merged_poll_retires() {
   pass "GitHub and GitLab exact merged results share one retirement path"
 }
 
+test_migration_classifies_each_check_kind() {
+  local dir state x_before x_after custom_before custom_after poll_before poll_after
+  dir=$(make_case migration-four-kinds)
+  state="$dir/home/state"
+
+  # Kind 1: a valid current X-mode shim.
+  fmx_poll_shim_content "$dir/home" "$ROOT" > "$state/x-watch.check.sh"
+  chmod 0700 "$state/x-watch.check.sh"
+
+  # Kind 2: a registered custom check.
+  printf 'trusted custom check bytes\n' > "$state/custom.check.sh"
+  chmod 0700 "$state/custom.check.sh"
+  FM_HOME="$dir/home" "$REGISTER" custom >/dev/null \
+    || fail "could not register the custom check"
+
+  # Kind 3: a canonical armed PR poll.
+  write_poll_meta "$state" task-poll https://github.com/o/r/pull/30
+  seed_canonical_poll "$dir" task-poll https://github.com/o/r/pull/30
+  fm_pr_poll_artifacts_valid "$state" task-poll "$POLL" \
+    || fail "canonical poll fixture was not armed"
+
+  # Kind 4: a legacy check whose metadata is ambiguous, so migration quarantines
+  # and disarms it rather than rebuilding a canonical poll.
+  fm_write_meta "$state/task-legacy.meta" \
+    'window=fm-task-legacy' \
+    'pr=https://github.com/o/r/pull/31' \
+    'window=injected-after-pr'
+  printf 'legacy bytes\n' > "$state/task-legacy.check.sh"
+  chmod 0644 "$state/task-legacy.check.sh"
+
+  x_before=$(state_snapshot "$state" | grep 'x-watch.check.sh')
+  custom_before=$(state_snapshot "$state" | grep 'custom.check.sh')
+  poll_before=$(poll_artifact_snapshot "$state" task-poll)
+
+  FM_HOME="$dir/home" "$MIGRATE" > "$dir/migrate.out" 2> "$dir/migrate.err" \
+    || fail "four-kind migration failed: $(cat "$dir/migrate.err")"
+
+  # Only the legacy check is quarantined and disarmed.
+  [ ! -e "$state/task-legacy.check.sh" ] || fail "legacy check remained armed after migration"
+  find "$state/.pr-check-quarantine" -name 'task-legacy.check.*' -type f | grep . >/dev/null \
+    || fail "legacy check was not quarantined"
+
+  # The other three kinds are untouched, and none of them was quarantined.
+  x_after=$(state_snapshot "$state" | grep 'x-watch.check.sh')
+  [ "$x_after" = "$x_before" ] || fail "migration changed the X-mode shim"
+  custom_after=$(state_snapshot "$state" | grep 'custom.check.sh')
+  [ "$custom_after" = "$custom_before" ] || fail "migration changed the registered custom check"
+  fm_pr_poll_artifacts_valid "$state" task-poll "$POLL" \
+    || fail "migration disarmed the canonical poll"
+  poll_after=$(poll_artifact_snapshot "$state" task-poll)
+  [ "$poll_after" = "$poll_before" ] || fail "migration changed the canonical poll artifacts"
+  [ -z "$(find "$state/.pr-check-quarantine" \
+    \( -name 'custom.*' -o -name 'task-poll.*' -o -name 'x-watch.*' \) -type f)" ] \
+    || fail "migration quarantined a non-legacy check kind"
+
+  pass "migration quarantines only the legacy check when all four check kinds coexist"
+}
+
 test_parser_matrix
 test_gitlab_merge_watch
 test_merged_poll_retires_once
@@ -3407,4 +3465,5 @@ test_bootstrap_migrates_before_other_mutations
 test_bootstrap_isolates_incomplete_poll_migration
 test_custom_snapshot_cleanup_on_signal
 test_returned_custom_check_descendants_are_drained
+test_migration_classifies_each_check_kind
 test_teardown_removes_poll_artifacts


### PR DESCRIPTION
## Summary

Implements accepted simplification-audit finding **F-S09-2 (P0)**: the legacy-check classification loop in `bin/fm-pr-check-migrate.sh` was written four times.

- `current_checks_authenticated` and `unsafe_checks_absent` were byte-identical.
- `migration_needed` was the same loop, negated.
- The main migration loop repeated the classification preamble a fourth time.

### Change

Introduce one `classify_check <path>` that evaluates a check file in today's exact order — valid X-mode shim, then registered custom check, then canonical PR poll (`fm_pr_poll_artifacts_valid`), else legacy — and prints exactly one of `x-shim|custom|poll|legacy`. Then:

- `current_checks_authenticated` scans for any legacy check via the classifier.
- `unsafe_checks_absent` is a one-line alias of it (both names kept because callers use each).
- `migration_needed` is its negation.
- The main migration loop dispatches on the classifier.

Behavior is byte-identical: same outputs, diagnostics, and exit codes. The classifier runs the three validators in a command-substitution subshell, which is safe because they are read-only predicates whose globals the callers do not consume (the main loop recomputes canonical metadata via `metadata_pr_is_canonical`).

### Tests

Adds one `tests/fm-pr-check-security.test.sh` case that seeds all four check kinds in one state dir and asserts only the legacy one is quarantined. Full suite passes (37 ok) and `shellcheck` 0.11.0 is clean.

### Validation

Validated through the no-mistakes pipeline: intent, rebase, review (0 findings), test (passed), document (no changes), and lint all green. The pipeline injected no commits; this PR contains only the single authored commit. Delivered via fork because the pipeline's push to upstream returned 403 (read-only on upstream); the lint step's local "ShellCheck not found" was an environment gap in the pipeline runner, not a code issue.