### PR TITLE
Auto-close terminal workers safely

### DIFF
--- a/bin/fm-auto-close-lib.sh
+++ b/bin/fm-auto-close-lib.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Shared receipt contract for automatic terminal worker cleanup.
+# fm-control writes one only after it proves an ordinary worker terminal and
+# stopped; fm-teardown consumes it only while the same incarnation and status
+# signature remain unchanged.
+
+fm_auto_close_token_valid() { # <token>
+  case "$1" in ''|*[!A-Za-z0-9._-]*) return 1 ;; esac
+}
+
+fm_auto_close_receipt_path() { # <state> <task-id>
+  printf '%s/%s.auto-close\n' "$1" "$2"
+}
+
+fm_auto_close_receipt_write() { # <state> <task-id> <incarnation> <terminal-state> <status-signature>
+  local state=$1 id=$2 incarnation=$3 terminal=$4 signature=$5 path tmp
+  fm_auto_close_token_valid "$id" || return 1
+  fm_auto_close_token_valid "$incarnation" || return 1
+  case "$terminal" in done|failed) ;; *) return 1 ;; esac
+  case "$signature" in ''|*$'\n'*) return 1 ;; esac
+  path=$(fm_auto_close_receipt_path "$state" "$id")
+  [ ! -e "$path" ] && [ ! -L "$path" ] || return 1
+  tmp=$(umask 077; mktemp "$state/.auto-close.XXXXXX") || return 1
+  {
+    printf 'schema=fm-auto-close.v1\n'
+    printf 'task_id=%s\n' "$id"
+    printf 'incarnation=%s\n' "$incarnation"
+    printf 'terminal_state=%s\n' "$terminal"
+    printf 'status_signature=%s\n' "$signature"
+  } > "$tmp" || { rm -f "$tmp"; return 1; }
+  chmod 600 "$tmp" || { rm -f "$tmp"; return 1; }
+  mv -- "$tmp" "$path" || { rm -f "$tmp"; return 1; }
+}
+
+fm_auto_close_receipt_validate() { # <path> <task-id> <incarnation> <status-signature>
+  local path=$1 id=$2 incarnation=$3 signature=$4 terminal expected actual
+  [ -f "$path" ] && [ ! -L "$path" ] || return 1
+  terminal=$(sed -n 's/^terminal_state=//p' "$path")
+  case "$terminal" in done|failed) ;; *) return 1 ;; esac
+  expected=$(printf 'schema=fm-auto-close.v1\ntask_id=%s\nincarnation=%s\nterminal_state=%s\nstatus_signature=%s' \
+    "$id" "$incarnation" "$terminal" "$signature")
+  actual=$(cat "$path") || return 1
+  [ "$actual" = "$expected" ] || return 1
+}

--- a/bin/fm-auto-close.sh
+++ b/bin/fm-auto-close.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Stop and clean up one ordinary worker after its terminal outcome is confirmed.
+#
+# Usage: fm-auto-close.sh maybe <task-id>
+#        fm-auto-close.sh finish <task-id>
+#
+# `maybe` accepts only an unchanged done/failed status whose authoritative
+# fm-crew-state result matches, with no open decision and no secondmate record.
+# It exits the agent through fm-control, records the exact spawn/status identity,
+# then calls `finish`.
+# `finish` retries cleanup from that receipt. fm-teardown revalidates the receipt
+# under its lifecycle locks and remains the owner of landed-work safety.
+# Ordinary dirty work is preserved. The sole exception is residual dirt after
+# the recorded PR is proved merged; fm-teardown's --auto-terminal path owns that
+# narrow discard proof.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+[ -n "${FM_HOME:-}" ] || { echo "error: FM_HOME is required" >&2; exit 1; }
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+CREW_STATE_BIN="${FM_AUTO_CLOSE_CREW_STATE_BIN:-$SCRIPT_DIR/fm-crew-state.sh}"
+CONTROL_BIN="${FM_AUTO_CLOSE_CONTROL_BIN:-$SCRIPT_DIR/fm-control.sh}"
+TEARDOWN_BIN="${FM_AUTO_CLOSE_TEARDOWN_BIN:-$SCRIPT_DIR/fm-teardown.sh}"
+
+# shellcheck source=bin/fm-auto-close-lib.sh
+. "$SCRIPT_DIR/fm-auto-close-lib.sh"
+# shellcheck source=bin/fm-classify-lib.sh
+. "$SCRIPT_DIR/fm-classify-lib.sh"
+# shellcheck source=bin/fm-backend.sh
+. "$SCRIPT_DIR/fm-backend.sh"
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
+
+mode=${1:-}
+id=${2:-}
+if [ "$#" -ne 2 ] || ! fm_auto_close_token_valid "$id"; then
+  printf 'usage: fm-auto-close.sh maybe|finish <task-id>\n' >&2
+  exit 2
+fi
+meta="$STATE/$id.meta"
+status="$STATE/$id.status"
+receipt=$(fm_auto_close_receipt_path "$STATE" "$id")
+
+meta_value() { fm_meta_get "$meta" "$1"; }
+
+finish() {
+  [ -f "$receipt" ] && [ ! -L "$receipt" ] || return 0
+  FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" \
+    "$TEARDOWN_BIN" "$id" --auto-terminal
+}
+
+maybe() {
+  local kind incarnation signature line terminal current current_signature
+  [ -f "$meta" ] && [ ! -L "$meta" ] || return 0
+  [ -f "$status" ] && [ ! -L "$status" ] || return 0
+  kind=$(meta_value kind)
+  [ "$kind" != secondmate ] || return 0
+  [ -z "$(status_open_decisions "$status")" ] || return 0
+  line=$(last_status_line "$status")
+  terminal=$(status_line_verb "$line")
+  case "$terminal" in done|failed) ;; *) return 0 ;; esac
+  signature=$(fm_wake_signal_sig "$status") || return 0
+  current=$(FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" \
+    "$CREW_STATE_BIN" "$id" 2>/dev/null) || return 0
+  case "$current" in "state: $terminal "*) ;; *) return 0 ;; esac
+  current_signature=$(fm_wake_signal_sig "$status") || return 0
+  [ "$current_signature" = "$signature" ] || return 0
+  incarnation=$(meta_value spawn_gen)
+  fm_auto_close_token_valid "$incarnation" || return 0
+  FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" \
+    "$CONTROL_BIN" "$id" exit >/dev/null || return 1
+  current_signature=$(fm_wake_signal_sig "$status") || return 1
+  [ "$current_signature" = "$signature" ] || return 0
+  [ "$(meta_value spawn_gen)" = "$incarnation" ] || return 0
+  fm_auto_close_receipt_write "$STATE" "$id" "$incarnation" "$terminal" "$signature" || return 1
+  finish
+}
+
+case "$mode" in
+  maybe) maybe ;;
+  finish) finish ;;
+  *) printf 'usage: fm-auto-close.sh maybe|finish <task-id>\n' >&2; exit 2 ;;
+esac

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -58,10 +58,14 @@
 # releases its durable treehouse lease so the pool slot is freed,
 # never left leased forever. If the treehouse return fails, teardown leaves the
 # leased home and state in place instead of hiding a still-held lease.
-# Usage: fm-teardown.sh <task-id> [--force]
+# Usage: fm-teardown.sh <task-id> [--force|--auto-terminal]
 #   --force skips ordinary-task dirty and landed-work checks, skips scout report
 #   checks, and discards secondmate child work for kind=secondmate. Only use it
 #   when the captain has explicitly said to discard the work.
+#   --auto-terminal requires bin/fm-auto-close.sh's exact incarnation/status
+#   receipt. It keeps every ordinary safety check, except that residual dirty
+#   files may be discarded only after the recorded PR is proved merged and the
+#   committed work is proved contained in that PR or the default branch.
 #
 # Transient / stale worktree git lock recovery (teardown-lock-race): a crew process
 # killed mid-git-operation can leave a .git/worktrees/<wt>/index.lock (or, for a
@@ -152,6 +156,8 @@ SUB_HOME_PARENT_MARKER=".fm-secondmate-parent"
 . "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
 # shellcheck source=bin/fm-backend.sh
 . "$SCRIPT_DIR/fm-backend.sh"
+# shellcheck source=bin/fm-auto-close-lib.sh
+. "$SCRIPT_DIR/fm-auto-close-lib.sh"
 # shellcheck source=bin/fm-control-lib.sh
 . "$SCRIPT_DIR/fm-control-lib.sh"
 # shellcheck source=bin/fm-lock-lib.sh
@@ -180,6 +186,11 @@ if [ "$#" -lt 1 ] || ! fm_task_id_path_safe "$1"; then
 fi
 ID=$1
 FORCE=${2:-}
+AUTO_TERMINAL=0
+if [ "$FORCE" = --auto-terminal ]; then
+  AUTO_TERMINAL=1
+  FORCE=
+fi
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
 CONTROL_LOCK="$STATE/.control-$ID.lock"
@@ -231,7 +242,7 @@ CONTROL_LOCK_HELD=1
 # Fail closed before any fleet mutation: a no-mistakes gate agent must never tear
 # down a worktree (see bin/fm-gate-refuse-lib.sh).
 fm_refuse_if_gate_agent
-FM_LOCK_LOG_PREFIX=teardown
+export FM_LOCK_LOG_PREFIX=teardown
 
 META="$STATE/$ID.meta"
 [ -f "$META" ] || { echo "error: no meta for task $ID at $META" >&2; exit 1; }
@@ -665,6 +676,19 @@ if [ "${FM_TEARDOWN_GUARD_DONE:-0}" != 1 ]; then
 fi
 HOME_PATH=$(grep '^home=' "$META" | cut -d= -f2- || true)
 PR_URL=$(grep '^pr=' "$META" | tail -1 | cut -d= -f2- || true)
+AUTO_CLOSE_RECEIPT=$(fm_auto_close_receipt_path "$STATE" "$ID")
+AUTO_CLOSE_STATUS_SIGNATURE=
+if [ "$AUTO_TERMINAL" = 1 ]; then
+  AUTO_CLOSE_STATUS_SIGNATURE=$(fm_wake_signal_sig "$STATE/$ID.status") || {
+    echo "REFUSED: automatic cleanup status for $ID is missing or unreadable" >&2
+    exit 1
+  }
+  fm_auto_close_receipt_validate "$AUTO_CLOSE_RECEIPT" "$ID" \
+    "$(fm_meta_get "$META" spawn_gen)" "$AUTO_CLOSE_STATUS_SIGNATURE" || {
+    echo "REFUSED: automatic cleanup receipt for $ID is missing, malformed, or stale" >&2
+    exit 1
+  }
+fi
 # tasktmp is recorded by fm-spawn for tasks that set up a per-task temp root
 # (/tmp/fm-<id>/); absent for tasks spawned before that change, so tolerate empty.
 TASK_TMP=$(grep '^tasktmp=' "$META" | cut -d= -f2- || true)
@@ -1056,6 +1080,24 @@ EOF
 # for both the PR state and head. Returns non-zero when the PR is not merged, the
 # current work is not contained in the PR head, no PR is found, or any gh error
 # occurs - the caller then falls back to the content check.
+pr_state_is_merged() {
+  local target view state
+  target=${1:-$PR_URL}
+  fm_pr_url_parse "$target" || return 1
+  case "$FM_PR_PROVIDER" in
+    github)
+      state=$(cd "$WT" && gh pr view "$target" --json state -q .state 2>/dev/null) || return 1
+      ;;
+    gitlab)
+      view=$(glab mr view "$FM_PR_NUMBER" -R "https://$FM_PR_HOST/$FM_PR_PATH" 2>/dev/null) || return 1
+      state=$(printf '%s\n' "$view" | sed -n 's/^state:[[:space:]]*//p' | head -1)
+      ;;
+    *) return 1 ;;
+  esac
+  case "$state" in MERGED|merged) return 0 ;; esac
+  return 1
+}
+
 pr_is_merged() {
   local branch=$1 target view state head current
   if [ -n "$PR_URL" ]; then
@@ -1374,6 +1416,23 @@ validate_worktree_teardown_safety() {
     return 1
   fi
   dirty=$(printf '%s\n' "$dirty_raw" | grep -vE '^\?\? (\.claude/|\.fm-(grok|kimi)-turnend$)' | head -1 || true)
+  if [ -n "$dirty" ] && [ "$AUTO_TERMINAL" = 1 ]; then
+    branch=${TEARDOWN_WORKTREE_BRANCH_FOR_SAFETY:-}
+    if [ -z "$branch" ]; then
+      branch=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)
+      TEARDOWN_WORKTREE_BRANCH_FOR_SAFETY=$branch
+    fi
+    if pr_state_is_merged "$PR_URL" && work_is_landed "$branch"; then
+      echo "teardown: discarding residual worker-copy changes after confirmed merged PR containing the committed work for $ID" >&2
+      git -C "$WT" reset --hard -q || return 1
+      git -C "$WT" clean -fdq || return 1
+      dirty=
+    else
+      echo "REFUSED: worktree $WT has uncommitted changes and its recorded PR is not confirmed merged." >&2
+      echo "uncommitted changes present" >&2
+      return 1
+    fi
+  fi
 
   if ! unpushed_raw=$(git -C "$WT" log --oneline HEAD --not --remotes -- 2>/dev/null); then
     if worktree_safety_blocked_by_lock "commits not on a remote"; then
@@ -2797,7 +2856,7 @@ fm_backend_clear_transition "$BACKEND" "$STATE" "$T" || true
 remove_pr_poll_artifacts "$STATE" "$ID" || exit 1
 retire_busy_state "$STATE" "$ID" "$BUSY_GEN" || exit 1
 status_retire_presentation_task "$STATE" "$ID" || exit 1
-rm -f "$STATE/$ID.turn-ended" "$STATE/$ID.meta" \
+rm -f "$STATE/$ID.turn-ended" "$STATE/$ID.meta" "$AUTO_CLOSE_RECEIPT" \
   "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token" \
   "$STATE/$ID.kimi-turnend-token" "$STATE/$ID.muse-session" \
   "$STATE/$ID.muse-session-current" "$STATE/$ID.cursor-session" \

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -75,6 +75,9 @@
 #   check: inactive-outcome bounded poll-loop reconciliation found a suspicious
 #                          inactive terminal outcome that still lacks its durable
 #                          upstream receipt
+# Confirmed done/failed status signals also trigger bin/fm-auto-close.sh after
+# the actionable wake is durable. It stops only ordinary workers and delegates
+# cleanup to fm-teardown's unchanged safety checks.
 #   check: secondmate wake-loop stalled: mate=<id> row=<seq> age=<seconds>s
 #                          the oldest valid row in an endpoint-recorded local
 #                          secondmate home's durable wake queue exceeded
@@ -1224,6 +1227,9 @@ while :; do
           else
             triage_log "merged PR poll retirement deferred because its canonical snapshot changed for $id"
           fi
+          FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" \
+            "$SCRIPT_DIR/fm-auto-close.sh" finish "$id" >/dev/null 2>&1 || \
+            triage_log "automatic merged-PR cleanup deferred for $id"
         fi
         touch "$STATE/.last-check"
         wake "$reason"
@@ -1270,9 +1276,16 @@ EOF
     # ordering evaluates it ONLY for a non-afk, no-captain-verb signal.
     # shellcheck disable=SC2086  # $files is a space-separated status-path list (ids carry no spaces)
     if afk_present || signal_reason_is_actionable $files || ! signal_crew_provably_working $files; then
+      auto_close_tasks=
       while IFS=$(printf '\t') read -r sf sig f; do
         [ -n "$sf" ] || continue
         fm_wake_append signal "$(basename "$f")" "$reason" || exit 1
+        case "$f" in
+          "$STATE"/*.status)
+            id=$(basename "$f" .status)
+            case " $auto_close_tasks " in *" $id "*) ;; *) auto_close_tasks="$auto_close_tasks $id" ;; esac
+            ;;
+        esac
       done <<EOF
 $pending
 EOF
@@ -1283,6 +1296,11 @@ EOF
       done <<EOF
 $pending
 EOF
+      for id in $auto_close_tasks; do
+        FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" \
+          "$SCRIPT_DIR/fm-auto-close.sh" maybe "$id" >/dev/null 2>&1 || \
+          triage_log "automatic terminal cleanup deferred for $id"
+      done
       wake "$reason"
     else
       while IFS=$(printf '\t') read -r sf sig f; do

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,6 +38,8 @@ No-change heartbeats are also benign.
 Separately from heartbeat backoff and wedge handling, the watcher poll runs `bin/fm-inactive-reconcile.sh` on its own bounded cadence, while locked session start performs the same bounded local scan immediately.
 In each home the scan considers only that home's long-inactive direct ordinary crewmates, excludes captain-held work, and accepts only `done` or `failed` from `bin/fm-crew-state.sh`.
 A secondmate retains a durable receipt for its idempotent report through the established parent route, and main-home captain presentation retains a separate receipt; neither path performs a forge or PR check.
+For a direct ordinary worker whose unchanged status and authoritative current-state result both say `done` or `failed`, the watcher first durably queues the terminal notification, then `bin/fm-auto-close.sh` stops the worker through the control plane and delegates cleanup to `bin/fm-teardown.sh`.
+The automatic path refuses open decisions, secondmates, active or ambiguous state, changed incarnations or status, and all ordinary dirty or unlanded work; only a recorded PR proved merged and containing the committed work permits discarding residual changes in that isolated worker copy.
 Absorbed wakes advance their suppression markers, log to `state/.watch-triage.log`, and keep the watcher blocking without a queue record or LLM turn.
 Each `fm-wake-drain.sh` presentation runs the same liveness guard as the supervision scripts, so a lapsed watcher chain surfaces even on a turn that only handles queued wakes.
 Routine watcher polling, supervision no-ops, elapsed waiting time, and absorbed benign wakes stay silent.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -74,6 +74,8 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-watch-arm.sh`        | Verified home-scoped watcher arm wrapper with loud cycle endings and bounded lifecycle ledger |
 | `fm-watch-checkpoint.sh` | Run one bounded foreground watcher checkpoint for Codex-style supervision            |
 | `fm-watch.sh`            | Singleton-safe watcher: absorb benign wakes, detect stalled local-secondmate wake queues, and exit on actionable ones |
+| `fm-auto-close.sh`       | Stop and safely clean up an ordinary worker after an unchanged confirmed terminal outcome |
+| `fm-auto-close-lib.sh`   | Own exact-incarnation automatic-cleanup receipts shared by auto-close and teardown |
 | `fm-inactive-reconcile.sh` | Reconcile long-inactive direct crewmate terminal outcomes without forge access |
 | `fm-afk-start.sh`        | Run the common sourceable away-mode daemon entry in the foreground                      |
 | `fm-afk-launch.sh`       | Own away-mode entry, exit, rollback, and any backend terminal lifecycle                 |

--- a/tests/fm-auto-close.test.sh
+++ b/tests/fm-auto-close.test.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Behavioral coverage for confirmed terminal worker automatic cleanup.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+AUTO_CLOSE="$ROOT/bin/fm-auto-close.sh"
+DONE_STATE=$(printf '%s' 'done')
+TMP_ROOT=$(fm_test_tmproot fm-auto-close)
+
+make_world() { # <name>
+  WORLD="$TMP_ROOT/$1"
+  HOME_DIR="$WORLD/home"
+  STATE="$HOME_DIR/state"
+  FAKE="$WORLD/fakebin"
+  mkdir -p "$STATE" "$HOME_DIR/data" "$FAKE"
+  : > "$WORLD/control.log"
+  : > "$WORLD/teardown.log"
+  cat > "$FAKE/fm-crew-state.sh" <<'SH'
+#!/usr/bin/env bash
+printf 'state: %s · source: fake\n' "${FM_FAKE_STATE:-unknown}"
+SH
+  cat > "$FAKE/fm-control.sh" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${FM_CONTROL_LOG:?}"
+exit "${FM_CONTROL_RC:-0}"
+SH
+  cat > "$FAKE/fm-teardown.sh" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${FM_TEARDOWN_LOG:?}"
+exit "${FM_TEARDOWN_RC:-0}"
+SH
+  chmod +x "$FAKE"/*
+}
+
+write_task() { # <kind> <status> [spawn-gen]
+  local kind=$1 status=$2 spawn=${3:-spawn-one}
+  fm_write_meta "$STATE/task.meta" \
+    'window=firstmate:fm-task' 'endpoint_task_id=task' \
+    'worktree=/tmp/task' 'project=/tmp/project' 'harness=codex' \
+    "kind=$kind" 'mode=direct-PR' "spawn_gen=$spawn"
+  printf '%s\n' "$status" > "$STATE/task.status"
+}
+
+run_auto() { # <mode>
+  PATH="$FAKE:$PATH" FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$STATE" \
+    FM_AUTO_CLOSE_CREW_STATE_BIN="$FAKE/fm-crew-state.sh" \
+    FM_AUTO_CLOSE_CONTROL_BIN="$FAKE/fm-control.sh" \
+    FM_AUTO_CLOSE_TEARDOWN_BIN="$FAKE/fm-teardown.sh" \
+    FM_CONTROL_LOG="$WORLD/control.log" FM_TEARDOWN_LOG="$WORLD/teardown.log" \
+    FM_CONTROL_RC="${FM_CONTROL_RC:-0}" FM_TEARDOWN_RC="${FM_TEARDOWN_RC:-0}" \
+    "$AUTO_CLOSE" "$1" task
+}
+
+assert_quiet() {
+  [ ! -s "$WORLD/control.log" ] || fail "$1 sent worker control"
+  [ ! -s "$WORLD/teardown.log" ] || fail "$1 attempted cleanup"
+  [ ! -e "$STATE/task.auto-close" ] || fail "$1 wrote cleanup receipt"
+}
+
+test_confirmed_terminal_stops_then_cleans() {
+  make_world terminal
+  write_task ship 'done: PR https://example.test/o/r/pull/1'
+  FM_FAKE_STATE=$DONE_STATE
+  export FM_FAKE_STATE
+  run_auto maybe
+  [ "$(cat "$WORLD/control.log")" = 'task exit' ] || fail "terminal worker was not exited exactly once"
+  [ "$(cat "$WORLD/teardown.log")" = 'task --auto-terminal' ] || fail "terminal worker was not cleaned through auto-terminal teardown"
+  grep -Fxq 'terminal_state=done' "$STATE/task.auto-close" || fail "terminal receipt missing"
+  pass "confirmed terminal worker exits before safe cleanup"
+}
+
+test_active_ambiguous_and_open_work_stay_untouched() {
+  local label kind status state
+  for label in working unknown held secondmate; do
+    make_world "$label"
+    kind=ship
+    status='done: terminal'
+    state=$DONE_STATE
+    case "$label" in
+      working) status='working: active'; state=working ;;
+      unknown) state=unknown ;;
+      held) status=$'blocked [key=choice]: need answer\ndone: terminal' ;;
+      secondmate) kind=secondmate ;;
+    esac
+    write_task "$kind" "$status"
+    FM_FAKE_STATE="$state" run_auto maybe
+    assert_quiet "$label"
+  done
+  pass "active, ambiguous, captain-held, and secondmate work is untouched"
+}
+
+test_changed_status_after_exit_refuses_receipt() {
+  make_world changed-status
+  write_task ship 'done: terminal'
+  cat > "$FAKE/fm-control.sh" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${FM_CONTROL_LOG:?}"
+printf 'working: replacement resumed\n' >> "${FM_STATE_OVERRIDE:?}/task.status"
+SH
+  chmod +x "$FAKE/fm-control.sh"
+  FM_FAKE_STATE="${DONE_STATE}"
+  export FM_FAKE_STATE
+  run_auto maybe
+  [ "$(cat "$WORLD/control.log")" = 'task exit' ] || fail "changed-status case did not exit worker"
+  [ ! -s "$WORLD/teardown.log" ] || fail "changed status reached cleanup"
+  [ ! -e "$STATE/task.auto-close" ] || fail "changed status received cleanup receipt"
+  pass "status change after exit prevents automatic cleanup"
+}
+
+test_receipt_retry_uses_teardown_owner() {
+  make_world retry
+  write_task ship 'failed: terminal'
+  FM_TEARDOWN_RC=1 FM_FAKE_STATE='failed' run_auto maybe >/dev/null 2>&1 || true
+  : > "$WORLD/teardown.log"
+  FM_TEARDOWN_RC=0 run_auto finish
+  [ "$(cat "$WORLD/teardown.log")" = 'task --auto-terminal' ] || fail "receipt retry bypassed teardown owner"
+  pass "failed cleanup remains safely retryable from receipt"
+}
+
+test_confirmed_terminal_stops_then_cleans
+test_active_ambiguous_and_open_work_stay_untouched
+test_changed_status_after_exit_refuses_receipt
+test_receipt_retry_uses_teardown_owner
+
+echo "all fm-auto-close tests passed"

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -30,6 +30,8 @@
 #   (g) no-mistakes + squash-merged PR, exact PR head          -> ALLOW  (squash fix)
 #   (h) no-mistakes + no PR but content already in default     -> ALLOW  (content fallback)
 #   (i) no-mistakes + dirty worktree, even when work landed     -> REFUSE (dirty wins)
+#   (i2) auto-terminal + dirty + merged recorded PR             -> ALLOW (residual only)
+#   (i3) auto-terminal + dirty + unmerged recorded PR           -> REFUSE (preserve)
 #   (j) no-mistakes + gh lookup errors + content not in default -> REFUSE (fail-safe)
 #   (k) no-mistakes + merged PR but HEAD moved afterward        -> REFUSE (stale PR)
 #   (l) no-mistakes + stale origin/main but fetched content     -> ALLOW  (fresh fetch)
@@ -274,6 +276,7 @@ case "\${1:-} \${2:-}" in
   "pr view")
     case " \$* " in
       *"state,headRefOid"*) printf '%s\t%s\n' 'MERGED' '$head' ; exit 0 ;;
+      *"--json state -q .state"*) printf '%s\n' 'MERGED' ; exit 0 ;;
       *"headRefOid"*) printf '%s\n' '$head' ; exit 0 ;;
     esac
     ;;
@@ -929,6 +932,68 @@ test_dirty_worktree_refuses() {
   grep -q REFUSED "$case_dir/stderr" || fail "dirty-wt: no REFUSED line in stderr"
   grep -q "uncommitted changes" "$case_dir/stderr" || fail "dirty-wt: refusal did not cite uncommitted changes"
   pass "dirty worktree is refused even when its committed work has landed (dirty always wins)"
+}
+
+test_auto_terminal_dirty_requires_merged_recorded_pr() {
+  local case_dir rc signature
+  case_dir=$(make_case auto-terminal-dirty-merged)
+  write_meta "$case_dir" no-mistakes ship
+  printf '%s\n' 'spawn_gen=spawn-one' 'pr=https://github.com/example/repo/pull/7' \
+    >> "$case_dir/state/task-x1.meta"
+  printf 'done: merged\n' > "$case_dir/state/task-x1.status"
+  wt_commit_file "$case_dir" feature.txt hello "add feature"
+  git -C "$case_dir/wt" push -q origin fm/task-x1
+  add_gh_pr_merged_for_head "$case_dir" "$(git -C "$case_dir/wt" rev-parse HEAD)"
+  printf '%s\n' residual > "$case_dir/wt/residual.txt"
+  git -C "$case_dir/wt" config remote.origin.url https://github.com/example/repo
+  signature=$(bash -c '. "$1/bin/fm-wake-lib.sh"; fm_wake_signal_sig "$2"' _ \
+    "$ROOT" "$case_dir/state/task-x1.status")
+  bash -c '. "$1/bin/fm-auto-close-lib.sh"; fm_auto_close_receipt_write "$2" task-x1 spawn-one done "$3"' _ \
+    "$ROOT" "$case_dir/state" "$signature"
+
+  set +e
+  run_teardown "$case_dir" --auto-terminal > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+  expect_code 0 "$rc" "auto-terminal merged PR should allow residual dirty cleanup"
+  grep -Fq 'discarding residual worker-copy changes after confirmed merged PR' "$case_dir/stderr" \
+    || fail "auto-terminal merged PR did not report narrow residual discard"
+
+  case_dir=$(make_case auto-terminal-dirty-open)
+  write_meta "$case_dir" no-mistakes ship
+  printf '%s\n' 'spawn_gen=spawn-one' 'pr=https://github.com/example/repo/pull/7' \
+    >> "$case_dir/state/task-x1.meta"
+  printf 'done: PR open\n' > "$case_dir/state/task-x1.status"
+  printf '%s\n' residual > "$case_dir/wt/residual.txt"
+  signature=$(bash -c '. "$1/bin/fm-wake-lib.sh"; fm_wake_signal_sig "$2"' _ \
+    "$ROOT" "$case_dir/state/task-x1.status")
+  bash -c '. "$1/bin/fm-auto-close-lib.sh"; fm_auto_close_receipt_write "$2" task-x1 spawn-one done "$3"' _ \
+    "$ROOT" "$case_dir/state" "$signature"
+  set +e
+  run_teardown "$case_dir" --auto-terminal > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "auto-terminal open PR must preserve dirty work"
+  [ -f "$case_dir/wt/residual.txt" ] || fail "auto-terminal open PR discarded residual work"
+  [ -f "$case_dir/state/task-x1.meta" ] || fail "auto-terminal open PR removed task identity"
+  pass "automatic cleanup discards residual dirt only for a confirmed merged recorded PR"
+}
+
+test_auto_terminal_stale_receipt_refuses() {
+  local case_dir rc
+  case_dir=$(make_case auto-terminal-stale)
+  write_meta "$case_dir" no-mistakes ship
+  printf '%s\n' 'spawn_gen=spawn-new' >> "$case_dir/state/task-x1.meta"
+  printf 'done: terminal\n' > "$case_dir/state/task-x1.status"
+  bash -c '. "$1/bin/fm-auto-close-lib.sh"; fm_auto_close_receipt_write "$2" task-x1 spawn-old done 1:1' _ \
+    "$ROOT" "$case_dir/state"
+  set +e
+  run_teardown "$case_dir" --auto-terminal > "$case_dir/stdout" 2> "$case_dir/stderr"
+  rc=$?
+  set -e
+  expect_code 1 "$rc" "stale automatic cleanup receipt must refuse"
+  [ -f "$case_dir/state/task-x1.meta" ] || fail "stale receipt removed task identity"
+  pass "automatic cleanup receipt is bound to exact worker incarnation and status"
 }
 
 test_gh_error_and_content_absent_refuses() {
@@ -2621,6 +2686,8 @@ test_pr_check_records_remote_head_when_local_lags
 test_content_in_default_fallback_allows
 test_content_fallback_refreshes_stale_origin_ref
 test_dirty_worktree_refuses
+test_auto_terminal_dirty_requires_merged_recorded_pr
+test_auto_terminal_stale_receipt_refuses
 test_gh_error_and_content_absent_refuses
 test_stale_index_lock_cleared_and_teardown_succeeds
 test_live_index_lock_is_never_removed_and_teardown_refuses


### PR DESCRIPTION
## Summary
- stop ordinary workers after unchanged authoritative done/failed outcomes
- bind cleanup to exact worker incarnation and status receipts
- preserve dirty/unlanded work; discard residual worker-copy dirt only after merged PR containment proof
- retry cleanup when merge confirmation arrives

## Validation
- `tests/fm-auto-close.test.sh`
- focused auto-terminal cases in `tests/fm-teardown.test.sh`
- `bin/fm-test-run.sh tests/fm-inactive-reconcile.test.sh`
- `bin/fm-lint.sh` with pinned ShellCheck 0.11.0 and actionlint 1.7.12
- named non-default Herdr lab lifecycle validation through `bin/fm-herdr-lab.sh`
