### PR TITLE
fix(bin): bind each second mate to its own Claude account store

### DIFF
--- a/.agents/skills/secondmate-provisioning/SKILL.md
+++ b/.agents/skills/secondmate-provisioning/SKILL.md
@@ -30,10 +30,22 @@ A whole-home remote route uses:
 - <id> - <one-sentence charter summary> (host: <ssh-alias>; root: <absolute-remote-code-root>; home: <absolute-remote-home>; scope: <natural-language responsibility>; projects: <project-a>, <project-b>; added <date>)
 ```
 
+A local route may also carry one OPTIONAL field, `claude-config-dir:`, placed immediately before `added`:
+
+```markdown
+- <id> - <one-sentence charter summary> (home: <absolute-home-path>; scope: <natural-language responsibility>; projects: <project-a>; claude-config-dir: <absolute-claude-store-path>; added <date>)
+```
+
+It binds that ONE second mate to a durable Claude config store, so the account it and its own workers authenticate and bill against is a recorded fact rather than whatever store the launching process happened to carry.
+Use it for a domain that must run on a different Claude account from this home's - a client's team account beside a personal one - and leave it out entirely for the ordinary single-account case.
+It is per second mate on purpose, and there is no fleet-wide equivalent, because one global setting cannot express two mates on two accounts.
+An entry without the field parses and behaves exactly as it always has, inheriting the ambient store, so no existing line needs rewriting.
+
 Each registry entry stays concise and single-line: the summary is one sentence naming the durable charter, `scope:` is the natural-language intake responsibility, `projects:` is the non-exclusive clone list, and any extra prose is limited to genuinely domain-specific hard rules that change routing or safety for that secondmate.
 Natural-language summary and `scope:` text may contain parentheses and semicolons; keep the generated `(home: ...; scope: ...; projects: ...; added ...)` suffix intact so operational consumers resolve its explicit field markers.
 The `home:` path points to the seeded home containing `data/charter.md`; no extra registry pointer field is needed.
 For a remote route, `host:` is an OpenSSH config alias and `root:` is that host's separate tracked Firstmate code root.
+A remote route accepts no `claude-config-dir:`: that second mate's account store lives on its own host, beyond the reach of this home's launch, so the field is refused rather than recorded and silently ignored.
 A remote second-mate agent always runs on the Herdr backend and every seed, launch, and liveness relaunch first gates its host on `bin/fm-remote-doctor.sh` readiness, so an unready host refuses with that doctor's own gap text rather than half-creating a route; the workers that second mate supervises keep the home's ordinary backend selection.
 This release places whole secondmate homes remotely and never individual workers.
 [`docs/remote-secondmates.md`](../../../docs/remote-secondmates.md) owns current operator setup and transport behavior.
@@ -82,6 +94,11 @@ It may only seed a home with no project clones or project-registry entries, and 
 The lease survives with no live process and is never recycled by later `treehouse get` or `prune`.
 The slot stays reserved across restarts until the lease is released.
 Release happens only on explicit retirement or seed rollback, never on routine restart or recovery.
+
+Set `FM_SECONDMATE_CLAUDE_CONFIG_DIR='<absolute-store-path>'` on the `bin/fm-home-seed.sh` call to record the `claude-config-dir:` binding described above.
+The seed refuses a relative path, a path carrying registry delimiters or traversal components, and a path that is not already an existing directory, rolling the whole seed back under its ordinary transactional contract rather than registering a route no launch could honor.
+`bin/fm-remote-home-seed.sh` refuses the variable outright, and `bin/fm-home-seed.sh validate` refuses a structurally invalid or remote-route binding alongside the rest of the registry contract.
+To add or change the binding on an already-seeded second mate, edit its registry line, run `bin/fm-home-seed.sh validate`, then relaunch that mate so the new account takes effect.
 
 `bin/fm-home-seed.sh` copies the charter into the secondmate home as `data/charter.md`.
 It also writes the gitignored `.fm-secondmate-parent` durable binding before the required `.fm-secondmate-home` identity marker; the parser header in [`bin/fm-secondmate-parent-lib.sh`](../../../bin/fm-secondmate-parent-lib.sh) owns the record contract, and both files must remain in place.
@@ -219,6 +236,9 @@ For a remote route, the same command probes and relaunches only on the configure
 An SSH transport failure or unreadable remote endpoint remains unknown and must be reconciled on that host; never launch a local replacement.
 `stuck-crewmate-recovery`'s remote-secondmate note owns why the endpoint-dead and send-failed verdicts that seem to justify this are themselves unreliable.
 Respawn re-resolves the secondmate harness from current config, uses the same guarded pre-launch sync, and re-propagates inherited local material, so recovered secondmates converge inherited config items and shared captain preferences whenever their home validates; tracked-file sync remains guarded separately.
+It also re-resolves any recorded `claude-config-dir:` binding from the registry, so a mate recovered from a primary session running on a different Claude account still comes back on its own account instead of the relauncher's.
+That resolution fails closed: a recorded store that is no longer an existing directory, or a spawn whose harness resolves to anything but claude, refuses the launch naming the path or harness rather than quietly starting the mate on the ambient account.
+Treat such a refusal as an account-configuration problem to fix, never as a reason to strip the field to get the mate running.
 If the secondmate is already running and only inherited local material changed, prefer `bin/fm-config-push.sh` over respawning.
 To move a live LOCAL secondmate onto a newly pinned harness, model, or effort without a full recovery, set `config/secondmate-harness` and then relaunch it with `bin/fm-control.sh <id> relaunch`, which re-resolves that pin, stops the agent, and launches the replacement in the same home ([`docs/agent-control.md`](../../../docs/agent-control.md)).
 That plane refuses a remotely placed secondmate by name, because its agent runs on another host where none of the plane's postconditions can be read; use the remote route's own relaunch path for those.

--- a/.agents/skills/secondmate-provisioning/SKILL.md
+++ b/.agents/skills/secondmate-provisioning/SKILL.md
@@ -242,6 +242,7 @@ Treat such a refusal as an account-configuration problem to fix, never as a reas
 If the secondmate is already running and only inherited local material changed, prefer `bin/fm-config-push.sh` over respawning.
 To move a live LOCAL secondmate onto a newly pinned harness, model, or effort without a full recovery, set `config/secondmate-harness` and then relaunch it with `bin/fm-control.sh <id> relaunch`, which re-resolves that pin, stops the agent, and launches the replacement in the same home ([`docs/agent-control.md`](../../../docs/agent-control.md)).
 That plane refuses a remotely placed secondmate by name, because its agent runs on another host where none of the plane's postconditions can be read; use the remote route's own relaunch path for those.
+For a mate carrying a `claude-config-dir:` binding, that relaunch asks both account questions before it stops anything, so an incompatible harness or a missing store refuses while the mate is still running instead of costing it its agent.
 
 Do not reconstruct a secondmate's whole tree from the main home.
 The main firstmate reconciles only direct reports.

--- a/.agents/skills/secondmate-provisioning/SKILL.md
+++ b/.agents/skills/secondmate-provisioning/SKILL.md
@@ -242,7 +242,7 @@ Treat such a refusal as an account-configuration problem to fix, never as a reas
 If the secondmate is already running and only inherited local material changed, prefer `bin/fm-config-push.sh` over respawning.
 To move a live LOCAL secondmate onto a newly pinned harness, model, or effort without a full recovery, set `config/secondmate-harness` and then relaunch it with `bin/fm-control.sh <id> relaunch`, which re-resolves that pin, stops the agent, and launches the replacement in the same home ([`docs/agent-control.md`](../../../docs/agent-control.md)).
 That plane refuses a remotely placed secondmate by name, because its agent runs on another host where none of the plane's postconditions can be read; use the remote route's own relaunch path for those.
-For a mate carrying a `claude-config-dir:` binding, that relaunch asks both account questions before it stops anything, so an incompatible harness or a missing store refuses while the mate is still running instead of costing it its agent.
+For a mate carrying a `claude-config-dir:` binding, that relaunch resolves the binding through the same registry validation the launch owner uses before it stops anything, so an incompatible harness, a missing store, or a registry that cannot be resolved refuses while the mate is still running instead of costing it its agent.
 
 Do not reconstruct a secondmate's whole tree from the main home.
 The main firstmate reconciles only direct reports.

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -80,6 +80,11 @@
 #     classifier (tmux, herdr), because without one the "the agent stopped"
 #     postcondition cannot be proven. zellij, orca, and cmux are refused rather
 #     than reported as successful blind.
+#   - A second mate bound to a Claude account store (its registry entry's
+#     claude-config-dir) is refused a relaunch onto a non-claude harness, or
+#     with that store missing, BEFORE its agent is stopped - the launch owner
+#     refuses both, but only after the stop, which would cost a healthy mate
+#     its agent for a launch that must be refused.
 #   - An ambiguous or unreadable endpoint state refuses; only a positively
 #     classified state acts.
 #
@@ -132,6 +137,8 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 . "$SCRIPT_DIR/fm-control-lib.sh"
 # shellcheck source=bin/fm-pr-lib.sh
 . "$SCRIPT_DIR/fm-pr-lib.sh"
+# shellcheck source=bin/fm-secondmate-registry-lib.sh
+. "$SCRIPT_DIR/fm-secondmate-registry-lib.sh"
 # shellcheck source=bin/fm-wake-lib.sh
 . "$SCRIPT_DIR/fm-wake-lib.sh"
 
@@ -597,6 +604,30 @@ relaunch_rollback() {
   return 0
 }
 
+# preflight_bound_store: ask the launch owner's per-mate Claude account
+# questions BEFORE anything is stopped. bin/fm-spawn.sh stays the fail-closed
+# owner of both refusals for a direct spawn, but a relaunch reaches it only
+# after the old agent is gone, so a refusal there would kill a healthy second
+# mate and then leave it down - and automated recovery would repeat that same
+# refusal forever. Asking the same two questions on this side of the
+# transaction makes an incompatible transition cost nothing.
+preflight_bound_store() {
+  local registry ccd
+  [ "$KIND" = secondmate ] || return 0
+  registry="$DATA/secondmates.md"
+  if [ ! -f "$registry" ] || [ -L "$registry" ]; then
+    return 0
+  fi
+  ccd=$(secondmate_registry_field "$registry" "$ID" claude-config-dir 2>/dev/null || true)
+  [ -n "$ccd" ] || return 0
+  if [ "$TARGET_HARNESS" != claude ]; then
+    die "secondmate $ID records claude-config-dir $ccd, but this relaunch resolves harness '$TARGET_HARNESS', which has no Claude config store to bind; relaunching onto it would stop the running agent for a launch that must be refused. Pass --harness claude, or remove that field from its registry entry"
+  fi
+  if [ ! -d "$ccd" ]; then
+    die "secondmate $ID records claude-config-dir $ccd, which is not an existing directory, so relaunching would stop the running agent for a launch that must be refused. Restore that store or correct the registry entry"
+  fi
+}
+
 resolve_relaunch_profile() {
   PRIOR_HARNESS=$HARNESS
   PRIOR_RECORDED_HARNESS=$RECORDED_HARNESS
@@ -647,6 +678,9 @@ resolve_relaunch_profile() {
   # transaction, where nothing has changed yet.
   fm_control_harness_supports_kind "$TARGET_HARNESS" "$KIND" \
     || die "'$TARGET_HARNESS' is not verified to run a $KIND task, so relaunching $ID onto it would stop the running agent for a launch that must be refused; choose an adapter verified for this kind"
+  # Same pre-stop placement, for the same reason, on this second mate's durable
+  # Claude account binding.
+  preflight_bound_store
   # A model or effort chosen for the previous harness does not transfer to a
   # different one, so an explicit harness change resets both axes unless the
   # caller names them too.

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -80,11 +80,12 @@
 #     classifier (tmux, herdr), because without one the "the agent stopped"
 #     postcondition cannot be proven. zellij, orca, and cmux are refused rather
 #     than reported as successful blind.
-#   - A second mate bound to a Claude account store (its registry entry's
-#     claude-config-dir) is refused a relaunch onto a non-claude harness, or
-#     with that store missing, BEFORE its agent is stopped - the launch owner
-#     refuses both, but only after the stop, which would cost a healthy mate
-#     its agent for a launch that must be refused.
+#   - A second mate's Claude account binding (its registry entry's
+#     claude-config-dir) is resolved BEFORE its agent is stopped, through the
+#     launch owner's own registry validation. A non-claude harness, a missing
+#     store, and a registry that cannot be resolved at all are each refused
+#     there, because the launch owner refuses all of them only AFTER the stop,
+#     which would cost a healthy mate its agent for a launch destined to fail.
 #   - An ambiguous or unreadable endpoint state refuses; only a positively
 #     classified state acts.
 #
@@ -606,19 +607,31 @@ relaunch_rollback() {
 
 # preflight_bound_store: ask the launch owner's per-mate Claude account
 # questions BEFORE anything is stopped. bin/fm-spawn.sh stays the fail-closed
-# owner of both refusals for a direct spawn, but a relaunch reaches it only
+# owner of these refusals for a direct spawn, but a relaunch reaches it only
 # after the old agent is gone, so a refusal there would kill a healthy second
 # mate and then leave it down - and automated recovery would repeat that same
-# refusal forever. Asking the same two questions on this side of the
-# transaction makes an incompatible transition cost nothing.
+# refusal forever. Asking the same questions on this side of the transaction
+# makes a refused transition cost nothing.
+#
+# It must ask them the SAME way, which means resolving the binding through the
+# launch owner's own registry validation rather than a bare field lookup. A
+# lookup that merely returns nothing cannot tell "this mate records no store"
+# from "this registry is malformed, duplicated, or unreadable" - and the launch
+# owner refuses every one of the latter. Degrading them to an empty binding
+# here would wave the relaunch past the stop and straight into that refusal,
+# reintroducing the same outage through a narrower door.
 preflight_bound_store() {
   local registry ccd
   [ "$KIND" = secondmate ] || return 0
   registry="$DATA/secondmates.md"
-  if [ ! -f "$registry" ] || [ -L "$registry" ]; then
+  # Same trigger as the launch owner: a registry that is present in any form is
+  # validated, and one that does not exist at all leaves the binding unset.
+  if [ ! -e "$registry" ] && [ ! -L "$registry" ]; then
     return 0
   fi
-  ccd=$(secondmate_registry_field "$registry" "$ID" claude-config-dir 2>/dev/null || true)
+  secondmate_registry_validate_bindings "$registry" secondmate_registry_path_key "$ID" "$WT" \
+    || die "secondmate $ID's registry cannot be resolved, so relaunching would stop the running agent for a launch the spawn must refuse: $SECONDMATE_REGISTRY_ERROR"
+  ccd=$SECONDMATE_REGISTRY_MATCH_CLAUDE_CONFIG_DIR
   [ -n "$ccd" ] || return 0
   if [ "$TARGET_HARNESS" != claude ]; then
     die "secondmate $ID records claude-config-dir $ccd, but this relaunch resolves harness '$TARGET_HARNESS', which has no Claude config store to bind; relaunching onto it would stop the running agent for a launch that must be refused. Pass --harness claude, or remove that field from its registry entry"

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -897,8 +897,8 @@ BASH
         | select(startswith("- "))
         | (capture("^- (?<id>[^[:space:]]+)")?) as $id
         | select($id != null)
-        | ([capture("^.*\\(host:[[:space:]]*(?<host>[^;)]*);[[:space:]]*root:[[:space:]]*(?<root>[^;)]*);[[:space:]]*home:[[:space:]]*(?<home>[^;)]*);[[:space:]]*scope:[[:space:]]*.*;[[:space:]]*projects:[[:space:]]*[^;)]*;[[:space:]]*added[[:space:]]+[0-9]{4}-[0-9]{2}-[0-9]{2}\\)[[:space:]]*$")?][0] // null) as $remote
-        | ([capture("^.*\\(home:[[:space:]]*(?<home>[^;)]*);[[:space:]]*scope:[[:space:]]*.*;[[:space:]]*projects:[[:space:]]*[^;)]*;[[:space:]]*added[[:space:]]+[0-9]{4}-[0-9]{2}-[0-9]{2}\\)[[:space:]]*$")?][0] // null) as $local
+        | ([capture("^.*\\(host:[[:space:]]*(?<host>[^;)]*);[[:space:]]*root:[[:space:]]*(?<root>[^;)]*);[[:space:]]*home:[[:space:]]*(?<home>[^;)]*);[[:space:]]*scope:[[:space:]]*.*;[[:space:]]*projects:[[:space:]]*[^;)]*;[[:space:]]*(claude-config-dir:[[:space:]]*[^;)]*;[[:space:]]*)?added[[:space:]]+[0-9]{4}-[0-9]{2}-[0-9]{2}\\)[[:space:]]*$")?][0] // null) as $remote
+        | ([capture("^.*\\(home:[[:space:]]*(?<home>[^;)]*);[[:space:]]*scope:[[:space:]]*.*;[[:space:]]*projects:[[:space:]]*[^;)]*;[[:space:]]*(claude-config-dir:[[:space:]]*[^;)]*;[[:space:]]*)?added[[:space:]]+[0-9]{4}-[0-9]{2}-[0-9]{2}\\)[[:space:]]*$")?][0] // null) as $local
         | ($local // $remote) as $route
         | (($local == null) and ($remote != null)) as $is_remote
         | {id:$id.id,home:($route.home // null),host:(if $is_remote then $remote.host else null end),root:(if $is_remote then $remote.root else null end),

--- a/bin/fm-home-seed.sh
+++ b/bin/fm-home-seed.sh
@@ -26,10 +26,20 @@
 #       when no filled charter brief exists. Set FM_SECONDMATE_SCOPE='<scope>'
 #       to override the registry routing scope. Otherwise the registry summary
 #       and scope are derived from the filled charter brief.
+#       Set FM_SECONDMATE_CLAUDE_CONFIG_DIR='<absolute-store-path>' to bind this
+#       one second mate to a durable Claude config store, recorded as the
+#       optional claude-config-dir: registry field. Every launch and relaunch
+#       re-resolves it, so the account this second mate and its own workers
+#       authenticate and bill against cannot silently follow whichever store the
+#       relaunching process happened to carry. The path must be absolute and
+#       must already exist as a directory at seed time; anything else refuses
+#       and rolls the seed back. Leave it unset for the ordinary single-account
+#       case, which records no field and inherits the ambient store as before.
 #   fm-home-seed.sh validate
 #       Refuse records that operational consumers cannot parse, unavailable or
 #       unsafe registry files when present, non-absolute or unresolvable homes,
-#       duplicate ids or homes, and nested or overlapping homes.
+#       duplicate ids or homes, nested or overlapping homes, and a
+#       claude-config-dir that is non-absolute, traversing, or on a remote route.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -63,6 +73,38 @@ validate_registry_home_text() {
       return 1
       ;;
   esac
+}
+
+# The optional per-mate Claude config-store binding, validated as a SEED-time
+# input. Structure (absolute, delimiter-free, local-route-only) is re-validated
+# on every registry read by secondmate_registry_validate_bindings; existence is
+# checked here and again at launch, because a store can be removed between the
+# two and only the launch can refuse meaningfully.
+validate_claude_config_dir_input() {
+  local ccd=$1
+  case "$ccd" in
+    /*) ;;
+    *)
+      echo "error: FM_SECONDMATE_CLAUDE_CONFIG_DIR must be an absolute path: $ccd" >&2
+      return 1
+      ;;
+  esac
+  case "$ccd" in
+    *';'*|*')'*|*$'\n'*|*$'\t'*|*$'\r'*)
+      echo "error: FM_SECONDMATE_CLAUDE_CONFIG_DIR contains registry delimiters: $ccd" >&2
+      return 1
+      ;;
+  esac
+  case "/$ccd/" in
+    */../*|*/./*)
+      echo "error: FM_SECONDMATE_CLAUDE_CONFIG_DIR contains traversal components: $ccd" >&2
+      return 1
+      ;;
+  esac
+  if [ ! -d "$ccd" ]; then
+    echo "error: FM_SECONDMATE_CLAUDE_CONFIG_DIR is not an existing directory: $ccd" >&2
+    return 1
+  fi
 }
 
 normalize_joined_path() {
@@ -729,10 +771,11 @@ initialize_no_mistakes_project() {
 }
 
 write_registry() {
-  local id=$1 home=$2 projects_csv=$3 brief=$4 scope summary tmp today
+  local id=$1 home=$2 projects_csv=$3 brief=$4 scope summary tmp today ccd
   mkdir -p "$DATA"
   scope=$(registry_scope_for_brief "$brief")
   summary=$(registry_summary_for_brief "$brief")
+  ccd=${FM_SECONDMATE_CLAUDE_CONFIG_DIR:-}
   today=$(date +%F)
   tmp="$REG.tmp.$$"
   if [ -f "$REG" ]; then
@@ -740,7 +783,13 @@ write_registry() {
   else
     : > "$tmp"
   fi
-  printf -- '- %s - %s (home: %s; scope: %s; projects: %s; added %s)\n' "$id" "$summary" "$home" "$scope" "$projects_csv" "$today" >> "$tmp"
+  # An unset binding writes the record byte-identically to before this field
+  # existed, so an ordinary single-account seed produces no new bytes at all.
+  if [ -n "$ccd" ]; then
+    printf -- '- %s - %s (home: %s; scope: %s; projects: %s; claude-config-dir: %s; added %s)\n' "$id" "$summary" "$home" "$scope" "$projects_csv" "$ccd" "$today" >> "$tmp"
+  else
+    printf -- '- %s - %s (home: %s; scope: %s; projects: %s; added %s)\n' "$id" "$summary" "$home" "$scope" "$projects_csv" "$today" >> "$tmp"
+  fi
   mv "$tmp" "$REG"
 }
 
@@ -830,6 +879,9 @@ seed_home() {
   trap seed_exit_cleanup EXIT
 
   validate_registry
+  if [ -n "${FM_SECONDMATE_CLAUDE_CONFIG_DIR:-}" ]; then
+    validate_claude_config_dir_input "$FM_SECONDMATE_CLAUDE_CONFIG_DIR" || return 1
+  fi
   for project in "$@"; do
     validate_seed_project "$project"
   done

--- a/bin/fm-remote-home-seed.sh
+++ b/bin/fm-remote-home-seed.sh
@@ -62,6 +62,12 @@ cleanup() {
 trap cleanup EXIT
 
 [ "$#" -ge 5 ] || usage
+# The per-mate Claude config-store binding is a local-route capability: a remote
+# second mate's account store lives on its own host, out of reach of this home's
+# launch path. Refuse the variable here rather than accepting a seed whose
+# binding would never be honored.
+[ -z "${FM_SECONDMATE_CLAUDE_CONFIG_DIR:-}" ] \
+  || die "FM_SECONDMATE_CLAUDE_CONFIG_DIR applies only to local secondmate routes; a remote second mate's Claude account store must be selected on its own host"
 ID=$1
 HOST=$2
 REMOTE_ROOT=$3

--- a/bin/fm-secondmate-registry-lib.sh
+++ b/bin/fm-secondmate-registry-lib.sh
@@ -6,6 +6,14 @@
 #   (home: ...; scope: ...; projects: ...; added YYYY-MM-DD)
 # A remote record adds its host placement before the existing fields:
 #   (host: ...; root: ...; home: ...; scope: ...; projects: ...; added YYYY-MM-DD)
+# An OPTIONAL claude-config-dir: field may precede `added` in either form:
+#   (home: ...; scope: ...; projects: ...; claude-config-dir: ...; added YYYY-MM-DD)
+# It binds that one second mate to a durable Claude config store so a relaunch
+# cannot silently inherit whichever store the launching process happened to
+# carry. A record without the field parses and behaves exactly as before, so no
+# existing line needs rewriting. This parser validates only its structure
+# (absolute, delimiter-free, local routes only); store existence is a launch-
+# and seed-time check owned by bin/fm-spawn.sh and bin/fm-home-seed.sh.
 # Summary text and scope text are natural language and may contain parentheses
 # and semicolons, so field boundaries are anchored to the suffix markers rather
 # than to the first incidental punctuation.
@@ -17,6 +25,7 @@ SECONDMATE_REGISTRY_ROOT=
 SECONDMATE_REGISTRY_HOME=
 SECONDMATE_REGISTRY_SCOPE=
 SECONDMATE_REGISTRY_PROJECTS=
+SECONDMATE_REGISTRY_CLAUDE_CONFIG_DIR=
 SECONDMATE_REGISTRY_ADDED=
 SECONDMATE_REGISTRY_REMOTE=0
 SECONDMATE_REGISTRY_LINE=
@@ -25,6 +34,7 @@ SECONDMATE_REGISTRY_MATCH_ROOT=
 SECONDMATE_REGISTRY_MATCH_HOME=
 SECONDMATE_REGISTRY_MATCH_HOME_KEY=
 SECONDMATE_REGISTRY_MATCH_PROJECTS=
+SECONDMATE_REGISTRY_MATCH_CLAUDE_CONFIG_DIR=
 SECONDMATE_REGISTRY_MATCH_REMOTE=0
 SECONDMATE_REGISTRY_ERROR=
 
@@ -33,8 +43,12 @@ secondmate_reply_lifecycle_lock_path() { printf '%s/.remote-reply-lifecycle-%s.l
 
 secondmate_registry_parse_line() {
   local line=$1
-  local local_re='^- ([A-Za-z0-9._-]+) - (.+) \(home:[[:space:]]*([^;)]*);[[:space:]]*scope:[[:space:]]*(.*);[[:space:]]*projects:[[:space:]]*([^;)]*);[[:space:]]*added[[:space:]]+([0-9]{4}-[0-9]{2}-[0-9]{2})\)[[:space:]]*$'
-  local remote_re='^- ([A-Za-z0-9._-]+) - (.+) \(host:[[:space:]]*([^;)]*);[[:space:]]*root:[[:space:]]*([^;)]*);[[:space:]]*home:[[:space:]]*([^;)]*);[[:space:]]*scope:[[:space:]]*(.*);[[:space:]]*projects:[[:space:]]*([^;)]*);[[:space:]]*added[[:space:]]+([0-9]{4}-[0-9]{2}-[0-9]{2})\)[[:space:]]*$'
+  # The claude-config-dir group is optional in BOTH forms. A non-participating
+  # optional group still occupies its BASH_REMATCH index and yields an empty
+  # string, so the surrounding indices stay fixed whether or not it matched.
+  local ccd_re='(claude-config-dir:[[:space:]]*([^;)]*);[[:space:]]*)?'
+  local local_re='^- ([A-Za-z0-9._-]+) - (.+) \(home:[[:space:]]*([^;)]*);[[:space:]]*scope:[[:space:]]*(.*);[[:space:]]*projects:[[:space:]]*([^;)]*);[[:space:]]*'"$ccd_re"'added[[:space:]]+([0-9]{4}-[0-9]{2}-[0-9]{2})\)[[:space:]]*$'
+  local remote_re='^- ([A-Za-z0-9._-]+) - (.+) \(host:[[:space:]]*([^;)]*);[[:space:]]*root:[[:space:]]*([^;)]*);[[:space:]]*home:[[:space:]]*([^;)]*);[[:space:]]*scope:[[:space:]]*(.*);[[:space:]]*projects:[[:space:]]*([^;)]*);[[:space:]]*'"$ccd_re"'added[[:space:]]+([0-9]{4}-[0-9]{2}-[0-9]{2})\)[[:space:]]*$'
   SECONDMATE_REGISTRY_ID=
   SECONDMATE_REGISTRY_SUMMARY=
   SECONDMATE_REGISTRY_HOST=
@@ -42,6 +56,7 @@ secondmate_registry_parse_line() {
   SECONDMATE_REGISTRY_HOME=
   SECONDMATE_REGISTRY_SCOPE=
   SECONDMATE_REGISTRY_PROJECTS=
+  SECONDMATE_REGISTRY_CLAUDE_CONFIG_DIR=
   SECONDMATE_REGISTRY_ADDED=
   SECONDMATE_REGISTRY_REMOTE=0
   # Parse the legacy local form first so summary prose that happens to mention
@@ -52,7 +67,8 @@ secondmate_registry_parse_line() {
     SECONDMATE_REGISTRY_HOME=${BASH_REMATCH[3]}
     SECONDMATE_REGISTRY_SCOPE=${BASH_REMATCH[4]}
     SECONDMATE_REGISTRY_PROJECTS=${BASH_REMATCH[5]}
-    SECONDMATE_REGISTRY_ADDED=${BASH_REMATCH[6]}
+    SECONDMATE_REGISTRY_CLAUDE_CONFIG_DIR=${BASH_REMATCH[7]}
+    SECONDMATE_REGISTRY_ADDED=${BASH_REMATCH[8]}
   elif [[ "$line" =~ $remote_re ]]; then
     SECONDMATE_REGISTRY_ID=${BASH_REMATCH[1]}
     SECONDMATE_REGISTRY_SUMMARY=${BASH_REMATCH[2]}
@@ -61,7 +77,8 @@ secondmate_registry_parse_line() {
     SECONDMATE_REGISTRY_HOME=${BASH_REMATCH[5]}
     SECONDMATE_REGISTRY_SCOPE=${BASH_REMATCH[6]}
     SECONDMATE_REGISTRY_PROJECTS=${BASH_REMATCH[7]}
-    SECONDMATE_REGISTRY_ADDED=${BASH_REMATCH[8]}
+    SECONDMATE_REGISTRY_CLAUDE_CONFIG_DIR=${BASH_REMATCH[9]}
+    SECONDMATE_REGISTRY_ADDED=${BASH_REMATCH[10]}
     SECONDMATE_REGISTRY_REMOTE=1
   else
     return 1
@@ -98,6 +115,7 @@ secondmate_registry_field() {
     home) printf '%s\n' "$SECONDMATE_REGISTRY_HOME" ;;
     scope) printf '%s\n' "$SECONDMATE_REGISTRY_SCOPE" ;;
     projects) printf '%s\n' "$SECONDMATE_REGISTRY_PROJECTS" ;;
+    claude-config-dir) printf '%s\n' "$SECONDMATE_REGISTRY_CLAUDE_CONFIG_DIR" ;;
     remote) printf '%s\n' "$SECONDMATE_REGISTRY_REMOTE" ;;
     *) return 1 ;;
   esac
@@ -117,12 +135,13 @@ secondmate_registry_path_key() {
 
 secondmate_registry_validate_bindings() {
   local reg=$1 resolver=$2 expected_id=${3:-} expected_home=${4:-}
-  local tmp snapshot bindings line id host root home home_key duplicate_homes duplicate_ids overlaps expected_home_key
+  local tmp snapshot bindings line id host root home ccd home_key duplicate_homes duplicate_ids overlaps expected_home_key
   SECONDMATE_REGISTRY_MATCH_HOST=
   SECONDMATE_REGISTRY_MATCH_ROOT=
   SECONDMATE_REGISTRY_MATCH_HOME=
   SECONDMATE_REGISTRY_MATCH_HOME_KEY=
   SECONDMATE_REGISTRY_MATCH_PROJECTS=
+  SECONDMATE_REGISTRY_MATCH_CLAUDE_CONFIG_DIR=
   SECONDMATE_REGISTRY_MATCH_REMOTE=0
   SECONDMATE_REGISTRY_ERROR=
   case "$expected_id" in *[!A-Za-z0-9._-]*) SECONDMATE_REGISTRY_ERROR="invalid secondmate id: $expected_id"; return 1 ;; esac
@@ -153,6 +172,7 @@ secondmate_registry_validate_bindings() {
         host=$SECONDMATE_REGISTRY_HOST
         root=$SECONDMATE_REGISTRY_ROOT
         home=$SECONDMATE_REGISTRY_HOME
+        ccd=$SECONDMATE_REGISTRY_CLAUDE_CONFIG_DIR
         case "$home" in
           /*) ;;
           *)
@@ -161,13 +181,40 @@ secondmate_registry_validate_bindings() {
             return 1
             ;;
         esac
-        case "$home$host$root" in
+        case "$home$host$root$ccd" in
           *$'\t'*|*$'\n'*|*$'\r'*)
             rm -rf -- "$tmp"
             SECONDMATE_REGISTRY_ERROR="unsafe secondmate route for $id"
             return 1
             ;;
         esac
+        # Structural validation of the optional per-mate Claude config-store
+        # binding. Whether the store actually exists is deliberately NOT checked
+        # here: this parser also runs on hosts and in sweeps that never launch
+        # that second mate, so an absent store must refuse the launch, not every
+        # read of the registry.
+        if [ -n "$ccd" ]; then
+          if [ "$SECONDMATE_REGISTRY_REMOTE" -eq 1 ]; then
+            rm -rf -- "$tmp"
+            SECONDMATE_REGISTRY_ERROR="claude-config-dir is not supported on a remote secondmate route for $id: the account store lives on $host and is bound there, not from this home"
+            return 1
+          fi
+          case "$ccd" in
+            /*) ;;
+            *)
+              rm -rf -- "$tmp"
+              SECONDMATE_REGISTRY_ERROR="unsafe non-absolute claude-config-dir for $id: $ccd"
+              return 1
+              ;;
+          esac
+          case "/$ccd/" in
+            */../*|*/./*)
+              rm -rf -- "$tmp"
+              SECONDMATE_REGISTRY_ERROR="claude-config-dir contains traversal components for $id: $ccd"
+              return 1
+              ;;
+          esac
+        fi
         if [ "$SECONDMATE_REGISTRY_REMOTE" -eq 1 ]; then
           case "$host" in ''|-*|*[!A-Za-z0-9._-]*)
             rm -rf -- "$tmp"
@@ -233,6 +280,7 @@ secondmate_registry_validate_bindings() {
           SECONDMATE_REGISTRY_MATCH_HOME=$home
           SECONDMATE_REGISTRY_MATCH_HOME_KEY=$home_key
           SECONDMATE_REGISTRY_MATCH_PROJECTS=$SECONDMATE_REGISTRY_PROJECTS
+          SECONDMATE_REGISTRY_MATCH_CLAUDE_CONFIG_DIR=$ccd
           SECONDMATE_REGISTRY_MATCH_REMOTE=$SECONDMATE_REGISTRY_REMOTE
         fi
         ;;

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -122,6 +122,16 @@
 #   the file governs the spawn, its model/effort tokens are re-resolved on every
 #   respawn exactly like the harness axis, and explicit --model/--effort flags
 #   still win over the file's tokens.
+#   A local --secondmate spawn also re-resolves the optional per-mate
+#   claude-config-dir: field from that second mate's data/secondmates.md entry
+#   and launches under that Claude config store instead of this process's ambient
+#   CLAUDE_CONFIG_DIR, so the account it and its own workers authenticate and bill
+#   against is DURABLE across every respawn rather than inherited from whoever
+#   relaunched it. It fails closed: a recorded store that is not an existing
+#   directory, a resolved harness other than claude, or a remote route refuses the
+#   launch rather than falling back to the ambient store. With no such field, the
+#   ambient CLAUDE_CONFIG_DIR is inherited exactly as before, which stays the
+#   behavior for every crewmate and scout spawn.
 #   A --secondmate spawn also propagates the primary's declared inherited local
 #   material, so the secondmate's OWN crewmates inherit primary config and the
 #   secondmate receives the primary's read-only shared captain-preference file
@@ -397,7 +407,7 @@ else
 fi
 
 spawn_remote_secondmate() {
-  local id=$1 remote host root home harness positional model effort backend out rc meta tmp
+  local id=$1 remote host root home claude_config_dir harness positional model effort backend out rc meta tmp
   local remote_backend remote_target remote_harness remote_herdr_session registry_lock remote_lock remote_generation
   local remote_traceparent remote_recorded_traceparent
   local -a launch_args
@@ -424,6 +434,17 @@ spawn_remote_secondmate() {
   host=$(secondmate_registry_field "$DATA/secondmates.md" "$id" host)
   root=$(secondmate_registry_field "$DATA/secondmates.md" "$id" root)
   home=$(secondmate_registry_field "$DATA/secondmates.md" "$id" home)
+  # The per-mate Claude config-store binding is a LOCAL-route capability. A
+  # remote second mate's account store lives on its own host, where this launch
+  # prefix never reaches, so honoring the field here would bind nothing while
+  # reading as if it had. Refuse instead of half-applying it.
+  claude_config_dir=$(secondmate_registry_field "$DATA/secondmates.md" "$id" claude-config-dir)
+  if [ -n "$claude_config_dir" ]; then
+    fm_lock_release "$registry_lock" || true
+    fm_lock_release "$SPAWN_TASK_LOCK" || true
+    echo "error: secondmate $id is a remote route, and claude-config-dir is supported only on local routes; its Claude account store must be selected on $host, so remove that field from the registry entry" >&2
+    return 1
+  fi
   positional=${POS[1]:-}
   if [ "${#POS[@]}" -gt 2 ]; then
     fm_lock_release "$registry_lock" || true
@@ -1571,6 +1592,12 @@ validate_firstmate_operational_dirs() {
   done
 }
 
+# The Claude config store this launch will carry. It starts as firstmate's own
+# ambient store (today's inheritance, unchanged for every kind) and is replaced
+# below only by a local secondmate's durable registry binding.
+SPAWN_CLAUDE_CONFIG_DIR=${CLAUDE_CONFIG_DIR:-}
+SPAWN_CLAUDE_CONFIG_DIR_SOURCE=
+
 if [ "$KIND" = secondmate ]; then
   if [ -z "$FIRSTMATE_HOME" ] && [ -f "$STATE/$ID.meta" ]; then
     FIRSTMATE_HOME=$(grep '^home=' "$STATE/$ID.meta" | cut -d= -f2- || true)
@@ -1589,6 +1616,26 @@ if [ "$KIND" = secondmate ]; then
       exit 1
     fi
     SECONDMATE_PROJECTS=$SECONDMATE_REGISTRY_MATCH_PROJECTS
+    SPAWN_CLAUDE_CONFIG_DIR_SOURCE=$SECONDMATE_REGISTRY_MATCH_CLAUDE_CONFIG_DIR
+  fi
+  # Per-mate Claude account binding. The registry entry is the durable record,
+  # so re-resolving it here means EVERY launch and relaunch - including the
+  # session-start liveness respawn, which runs from the primary's own session
+  # with the primary's own ambient store - lands on this second mate's recorded
+  # account instead of whichever store the launching process happened to carry.
+  # Fail closed on both axes: an absent store directory and a harness that has
+  # no Claude store to bind are refusals, never a quiet fall back to ambient,
+  # because a silent fallback is the exact drift this binding exists to stop.
+  if [ -n "$SPAWN_CLAUDE_CONFIG_DIR_SOURCE" ]; then
+    if [ "$HARNESS" != claude ]; then
+      echo "error: secondmate $ID records claude-config-dir $SPAWN_CLAUDE_CONFIG_DIR_SOURCE, but this launch resolves harness '$HARNESS', which has no Claude config store to bind; select the claude harness for this secondmate or remove that field from its registry entry" >&2
+      exit 1
+    fi
+    if [ ! -d "$SPAWN_CLAUDE_CONFIG_DIR_SOURCE" ]; then
+      echo "error: secondmate $ID records claude-config-dir $SPAWN_CLAUDE_CONFIG_DIR_SOURCE, which is not an existing directory; refusing to launch it against a different account. Restore that store or correct the registry entry." >&2
+      exit 1
+    fi
+    SPAWN_CLAUDE_CONFIG_DIR=$SPAWN_CLAUDE_CONFIG_DIR_SOURCE
   fi
   WT="$PROJ_ABS"
   # Local-HEAD sync: before launch, fast-forward this secondmate's worktree to the
@@ -2736,11 +2783,17 @@ esac
 # inherit firstmate's current environment, so a bare `claude` in the pane falls
 # back to the default ~/.claude store even when firstmate itself runs under a
 # different CLAUDE_CONFIG_DIR (for example a work-vs-personal subscription split).
-# Forward firstmate's own resolved store onto the claude launch so the crewmate
-# uses the same credential/config firstmate is authenticated with. Only when set;
-# an unset value is the single-store default and needs no prefix.
-if [ "$HARNESS" = claude ] && [ -n "${CLAUDE_CONFIG_DIR:-}" ]; then
-  LAUNCH="CLAUDE_CONFIG_DIR=$(shell_quote "$CLAUDE_CONFIG_DIR") $LAUNCH"
+# Forward the resolved store onto the claude launch so the launched agent uses
+# the credential/config it is meant to. Only when set; an unset value is the
+# single-store default and needs no prefix.
+#
+# SPAWN_CLAUDE_CONFIG_DIR is firstmate's own ambient store for every kind, which
+# is the right inheritance for a crewmate or scout: it works alongside firstmate
+# on firstmate's account. A secondmate is an independent firstmate that may
+# belong to a different account entirely, so its registry binding replaces the
+# ambient value above rather than inheriting it.
+if [ "$HARNESS" = claude ] && [ -n "$SPAWN_CLAUDE_CONFIG_DIR" ]; then
+  LAUNCH="CLAUDE_CONFIG_DIR=$(shell_quote "$SPAWN_CLAUDE_CONFIG_DIR") $LAUNCH"
 fi
 if [ "$KIND" = secondmate ]; then
   sq_home=$(shell_quote "$PROJ_ABS")

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -92,6 +92,9 @@ Switching harness is therefore one ordinary relaunch rather than a separate mech
 - An implicit relaunch from a prefixed raw-command basename is refused before the agent or durable state is touched because its original launch command cannot be reconstructed.
 - An adapter that is not verified for this task's kind is refused **before** the running agent is stopped, not after.
   Muse is a crewmate and scout adapter only, so relaunching a secondmate onto it refuses while its agent is still up rather than leaving that secondmate with no agent when the launch owner refuses.
+- A secondmate bound to a Claude account store is refused **before** the running agent is stopped, on the same two questions the launch owner asks.
+  A `claude-config-dir:` registry binding needs a claude harness to carry it and a store that is actually there, so relaunching onto another adapter, or with that store gone, refuses while the agent is still up.
+  Refusing after the stop would kill a healthy secondmate for a launch that must be refused, and automated recovery would repeat that refusal indefinitely.
 - A backend that cannot deliver the harness's interrupt key, or the composer clear that key needs, is refused rather than sent a different key.
   Orca's terminal API exposes only an interrupt and an Enter, so it can deliver neither Escape nor Ctrl+U.
 - `exit` and `relaunch` require a backend with a recovery-grade agent-state classifier - tmux and herdr - because without one the "the agent stopped" postcondition cannot be proven.

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -92,8 +92,9 @@ Switching harness is therefore one ordinary relaunch rather than a separate mech
 - An implicit relaunch from a prefixed raw-command basename is refused before the agent or durable state is touched because its original launch command cannot be reconstructed.
 - An adapter that is not verified for this task's kind is refused **before** the running agent is stopped, not after.
   Muse is a crewmate and scout adapter only, so relaunching a secondmate onto it refuses while its agent is still up rather than leaving that secondmate with no agent when the launch owner refuses.
-- A secondmate bound to a Claude account store is refused **before** the running agent is stopped, on the same two questions the launch owner asks.
-  A `claude-config-dir:` registry binding needs a claude harness to carry it and a store that is actually there, so relaunching onto another adapter, or with that store gone, refuses while the agent is still up.
+- A secondmate's Claude account binding is resolved **before** the running agent is stopped, through the same registry validation the launch owner uses.
+  A `claude-config-dir:` binding needs a claude harness to carry it and a store that is actually there, so relaunching onto another adapter, or with that store gone, refuses while the agent is still up.
+  A registry that cannot be resolved at all - malformed, duplicated, or unreadable - refuses there too, because the launch owner refuses every one of those and a bare field lookup cannot tell them apart from a mate that simply records no store.
   Refusing after the stop would kill a healthy secondmate for a launch that must be refused, and automated recovery would repeat that refusal indefinitely.
 - A backend that cannot deliver the harness's interrupt key, or the composer clear that key needs, is refused rather than sent a different key.
   Orca's terminal API exposes only an interrupt and an Enter, so it can deliver neither Escape nor Ctrl+U.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -178,6 +178,7 @@ The skill text owns the marker spelling, the tick order, and the reinforcement r
 Persistent secondmate routes live locally in `data/secondmates.md`.
 The concise single-line route contract is owned by the [`secondmate-provisioning` skill](../.agents/skills/secondmate-provisioning/SKILL.md#routing-table), including the parser-compatible fields, one-sentence summary requirement, `home:` pointer to the seeded charter, and limit on extra registry prose.
 A remote route adds `host:` and `root:` before the existing fields and places the whole secondmate home on that SSH host; it does not make ordinary workers remotely placeable.
+A local route may additionally carry the optional `claude-config-dir:` field, which binds that one second mate to a durable Claude config store so the account it and its own workers authenticate and bill against survives every relaunch instead of following the launching process's ambient `CLAUDE_CONFIG_DIR`; the skill above owns its position in the line, its per-mate-only scope, its remote-route refusal, and the fail-closed launch behavior.
 [`remote-secondmates.md`](remote-secondmates.md) owns current remote setup, operation, and safety behavior.
 Use `fm-home-seed.sh validate` to check the complete operational registry contract documented by the command itself.
 The main first mate routes by reading those scopes with judgment; the project list is provisioning data, not exclusive ownership.
@@ -194,6 +195,7 @@ For `no-mistakes` projects, seeding initializes only projects newly cloned into 
 After creating a secondmate, move existing main-backlog queued items that you have judged in-scope with `fm-backlog-handoff.sh <secondmate-id> <item-key>...`; it refuses In flight, Done, or non-secondmate homes, and a new move succeeds only after waking the recorded receiver.
 If the wake is known to have failed, the moved item remains durable and rerunning the same handoff retries it idempotently; an unresolved delivery is reported and never blindly resent.
 Set `FM_SECONDMATE_CHARTER` to seed from inline charter text when no filled charter brief exists; set `FM_SECONDMATE_SCOPE` when the routing scope should differ from the charter text.
+Set `FM_SECONDMATE_CLAUDE_CONFIG_DIR` to an absolute, already-existing store directory to record the optional `claude-config-dir:` binding at seed time; leaving it unset writes the record exactly as before.
 The seeded home's `data/charter.md` owns the standard secondmate lifecycle and escalation contract; the route file points to it through the existing `home:` field instead of adding another pointer.
 Each seed writes an `.fm-secondmate-home` identity marker at the home root, alongside a durable `.fm-secondmate-parent` record of the home's route to its parent (see "Provision a route" in [`docs/remote-secondmates.md`](remote-secondmates.md)).
 The tracked root `.gitignore` ignores both markers, so validation can read them without making a freshly seeded home appear dirty to porcelain-based safety checks.

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -830,6 +830,7 @@ test_bound_secondmate_relaunch_refuses_a_malformed_registry_before_stop() {
   # A second entry whose suffix the parser cannot resolve at all.
   printf -- '- other - other domain (home: not-absolute; scope: x; added 2026-08-23)\n' \
     >> "$dir/home/data/secondmates.md"
+  printf 'claude\n' > "$dir/home/config/secondmate-harness"
   out=$(run_control "$dir" sm11 relaunch); rc=$?
   expect_code 1 "$rc" "an unusable registry should refuse the relaunch"
   assert_contains "$out" "registry cannot be resolved" \
@@ -851,6 +852,7 @@ test_bound_secondmate_relaunch_refuses_a_duplicate_registry_entry_before_stop() 
   write_bound_secondmate "$dir" sm12 "$store"
   # The same id twice: which entry binds this mate's account is unresolvable.
   write_bound_secondmate_append "$dir" sm12 "$store"
+  printf 'claude\n' > "$dir/home/config/secondmate-harness"
   out=$(run_control "$dir" sm12 relaunch); rc=$?
   expect_code 1 "$rc" "a duplicated registry id should refuse the relaunch"
   assert_contains "$out" "registry cannot be resolved" \

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -769,6 +769,14 @@ write_bound_secondmate() {
   fi
 }
 
+# Same line, appended instead of written, so a case can register one id twice.
+write_bound_secondmate_append() {
+  local dir=$1 id=$2 store=$3 abs
+  abs=$(cd "$dir/smhome" && pwd -P)
+  printf -- '- %s - %s domain (home: %s; scope: %s work; projects: alpha; claude-config-dir: %s; added 2026-08-23)\n' \
+    "$id" "$id" "$abs" "$id" "$store" >> "$dir/home/data/secondmates.md"
+}
+
 test_bound_secondmate_relaunch_onto_a_non_claude_harness_refuses_before_stop() {
   local dir store out rc
   dir=$(new_case smbound sm8)
@@ -806,6 +814,52 @@ test_bound_secondmate_relaunch_with_a_missing_store_refuses_before_stop() {
   [ "$(meta_field "$dir" sm9 harness)" = claude ] \
     || fail "a refused relaunch must leave the durable record on the recorded harness"
   pass "fm-control relaunch: a missing bound store refuses before the agent is stopped"
+}
+
+# A registry the launch owner would refuse must be refused HERE, not waved past
+# the stop. A bare field lookup cannot tell "records no store" from "this
+# registry is unusable", and the launch owner refuses every unusable form - so
+# degrading one to the other would stop a healthy agent for a launch destined to
+# fail. These drive the two unusable shapes an operator actually produces.
+test_bound_secondmate_relaunch_refuses_a_malformed_registry_before_stop() {
+  local dir store out rc
+  dir=$(new_case smbad sm11)
+  store="$dir/claude-client"
+  mkdir -p "$store"
+  write_bound_secondmate "$dir" sm11 "$store"
+  # A second entry whose suffix the parser cannot resolve at all.
+  printf -- '- other - other domain (home: not-absolute; scope: x; added 2026-08-23)\n' \
+    >> "$dir/home/data/secondmates.md"
+  out=$(run_control "$dir" sm11 relaunch); rc=$?
+  expect_code 1 "$rc" "an unusable registry should refuse the relaunch"
+  assert_contains "$out" "registry cannot be resolved" \
+    "the refusal should say the registry could not be resolved"
+  [ "$(cat "$dir/fake/command")" = claude ] \
+    || fail "a registry the launch owner would refuse must not cost the mate its agent"
+  [ ! -e "$dir/home/state/sm11.control-relaunch" ] \
+    || fail "a refusal on this side of the transaction must not open one"
+  [ "$(meta_field "$dir" sm11 harness)" = claude ] \
+    || fail "a refused relaunch must leave the durable record on the recorded harness"
+  pass "fm-control relaunch: a malformed registry refuses before the agent is stopped"
+}
+
+test_bound_secondmate_relaunch_refuses_a_duplicate_registry_entry_before_stop() {
+  local dir store out rc
+  dir=$(new_case smdup sm12)
+  store="$dir/claude-client"
+  mkdir -p "$store"
+  write_bound_secondmate "$dir" sm12 "$store"
+  # The same id twice: which entry binds this mate's account is unresolvable.
+  write_bound_secondmate_append "$dir" sm12 "$store"
+  out=$(run_control "$dir" sm12 relaunch); rc=$?
+  expect_code 1 "$rc" "a duplicated registry id should refuse the relaunch"
+  assert_contains "$out" "registry cannot be resolved" \
+    "the refusal should say the registry could not be resolved"
+  [ "$(cat "$dir/fake/command")" = claude ] \
+    || fail "an ambiguous binding must not cost the mate its agent"
+  [ ! -e "$dir/home/state/sm12.control-relaunch" ] \
+    || fail "a refusal on this side of the transaction must not open one"
+  pass "fm-control relaunch: a duplicated registry entry refuses before the agent is stopped"
 }
 
 # The preflight must refuse only the two cases fm-spawn refuses. A bound second
@@ -1441,6 +1495,8 @@ test_secondmate_relaunch_ignores_invalid_configured_effort_before_stop
 test_secondmate_relaunch_onto_a_crewmate_only_adapter_refuses_before_stop
 test_bound_secondmate_relaunch_onto_a_non_claude_harness_refuses_before_stop
 test_bound_secondmate_relaunch_with_a_missing_store_refuses_before_stop
+test_bound_secondmate_relaunch_refuses_a_malformed_registry_before_stop
+test_bound_secondmate_relaunch_refuses_a_duplicate_registry_entry_before_stop
 test_bound_secondmate_relaunches_normally_on_claude
 test_explicit_secondmate_harness_ignores_configured_profile_axes
 test_ship_relaunch_ignores_the_crew_harness_config

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -720,6 +720,113 @@ test_secondmate_relaunch_onto_a_crewmate_only_adapter_refuses_before_stop() {
   pass "fm-control relaunch: an adapter unverified for this task kind refuses before the agent is stopped"
 }
 
+# --- 2b. a bound second mate's account survives a refused relaunch -----------
+#
+# A second mate whose registry entry records a claude-config-dir is bound to one
+# Claude account. bin/fm-spawn.sh refuses to launch it on a harness with no
+# Claude store to bind, and refuses a store that is not there - both correct,
+# both fail-closed, and both reached only AFTER the old agent has been stopped.
+# On a relaunch that ordering is the whole defect: the healthy agent is killed
+# for a launch that must be refused, the exited|launching rollback leaves the
+# mate down, and automated recovery re-runs the identical refusal forever. The
+# control plane therefore asks both questions before it touches anything.
+#
+# write_bound_secondmate <case-dir> <id> [store]
+# A secondmate task recorded in this home, plus its registry entry, carrying the
+# optional store binding only when one is supplied.
+write_bound_secondmate() {
+  local dir=$1 id=$2 store=${3:-} abs reg
+  local home="$dir/home"
+  mkdir -p "$home/config" "$home/data/$id"
+  printf '# secondmate brief\n' > "$home/data/$id/brief.md"
+  fm_git_worktree "$dir/proj" "$dir/smhome" sm-branch
+  mkdir -p "$dir/smhome/state" "$dir/smhome/data" "$dir/smhome/bin"
+  printf '%s\n' "$id" > "$dir/smhome/.fm-secondmate-home"
+  printf '# agents\n' > "$dir/smhome/AGENTS.md"
+  {
+    echo "window=fmses:fm-$id"
+    echo "endpoint_task_id=$id"
+    echo "worktree=$dir/smhome"
+    echo "project=$dir/smhome"
+    echo "harness=claude"
+    echo "kind=secondmate"
+    echo "mode=secondmate"
+    echo "yolo=off"
+    echo "model=default"
+    echo "effort=default"
+    echo "home=$dir/smhome"
+  } > "$home/state/$id.meta"
+  printf '%s\n' "fm-$id" > "$dir/fake/windows"
+  printf '%s' "$dir/smhome" > "$dir/fake/cwd"
+  abs=$(cd "$dir/smhome" && pwd -P)
+  reg="$home/data/secondmates.md"
+  if [ -n "$store" ]; then
+    printf -- '- %s - %s domain (home: %s; scope: %s work; projects: alpha; claude-config-dir: %s; added 2026-08-23)\n' \
+      "$id" "$id" "$abs" "$id" "$store" > "$reg"
+  else
+    printf -- '- %s - %s domain (home: %s; scope: %s work; projects: alpha; added 2026-08-23)\n' \
+      "$id" "$id" "$abs" "$id" > "$reg"
+  fi
+}
+
+test_bound_secondmate_relaunch_onto_a_non_claude_harness_refuses_before_stop() {
+  local dir store out rc
+  dir=$(new_case smbound sm8)
+  store="$dir/claude-client"
+  mkdir -p "$store"
+  write_bound_secondmate "$dir" sm8 "$store"
+  out=$(run_control "$dir" sm8 relaunch --harness codex); rc=$?
+  expect_code 1 "$rc" "a bound second mate should refuse a harness with no Claude store"
+  assert_contains "$out" "records claude-config-dir $store" \
+    "the refusal should name the recorded store"
+  assert_contains "$out" "codex" "the refusal should name the harness that cannot carry it"
+  [ "$(cat "$dir/fake/command")" = claude ] \
+    || fail "the bound second mate's agent must still be running after the refusal"
+  [ ! -e "$dir/home/state/sm8.control-relaunch" ] \
+    || fail "a refusal on this side of the transaction must not open one"
+  [ "$(meta_field "$dir" sm8 harness)" = claude ] \
+    || fail "a refused relaunch must leave the durable record on the recorded harness"
+  pass "fm-control relaunch: an incompatible harness for a bound second mate refuses before the agent is stopped"
+}
+
+test_bound_secondmate_relaunch_with_a_missing_store_refuses_before_stop() {
+  local dir store out rc
+  dir=$(new_case smgone sm9)
+  store="$dir/claude-client-gone"
+  write_bound_secondmate "$dir" sm9 "$store"
+  out=$(run_control "$dir" sm9 relaunch); rc=$?
+  expect_code 1 "$rc" "a recorded store that is not there should refuse the relaunch"
+  assert_contains "$out" "$store" "the refusal should name the missing store"
+  assert_contains "$out" "not an existing directory" "the refusal should say what is wrong with it"
+  [ "$(cat "$dir/fake/command")" = claude ] \
+    || fail "a missing store must not cost the second mate its running agent"
+  [ ! -e "$dir/home/state/sm9.control-relaunch" ] \
+    || fail "a refusal on this side of the transaction must not open one"
+  [ "$(meta_field "$dir" sm9 harness)" = claude ] \
+    || fail "a refused relaunch must leave the durable record on the recorded harness"
+  pass "fm-control relaunch: a missing bound store refuses before the agent is stopped"
+}
+
+# The preflight must refuse only the two cases fm-spawn refuses. A bound second
+# mate relaunching onto claude with its store present is the ordinary path and
+# must still go all the way through.
+test_bound_secondmate_relaunches_normally_on_claude() {
+  local dir store out rc
+  dir=$(new_case smok sm10)
+  store="$dir/claude-client"
+  mkdir -p "$store"
+  write_bound_secondmate "$dir" sm10 "$store"
+  printf 'claude\n' > "$dir/home/config/secondmate-harness"
+  printf 'claude' > "$dir/fake/becomes"
+  out=$(run_control "$dir" sm10 relaunch); rc=$?
+  expect_code 0 "$rc" "a bound second mate on claude should relaunch"$'\n'"$out"
+  assert_not_contains "$out" "claude-config-dir" \
+    "a satisfied binding should not surface a refusal"
+  [ "$(journal_field "$dir" sm10 to_harness)" = claude ] \
+    || fail "the replacement should stay on claude"
+  pass "fm-control relaunch: a bound second mate whose store is present relaunches normally"
+}
+
 test_explicit_secondmate_harness_ignores_configured_profile_axes() {
   local dir home out rc
   dir=$(new_case smexplicit sm4)
@@ -1331,6 +1438,9 @@ test_turnend_auth_paths_are_owned_by_the_control_adapter
 test_secondmate_relaunch_picks_up_the_configured_harness_pin
 test_secondmate_relaunch_ignores_invalid_configured_effort_before_stop
 test_secondmate_relaunch_onto_a_crewmate_only_adapter_refuses_before_stop
+test_bound_secondmate_relaunch_onto_a_non_claude_harness_refuses_before_stop
+test_bound_secondmate_relaunch_with_a_missing_store_refuses_before_stop
+test_bound_secondmate_relaunches_normally_on_claude
 test_explicit_secondmate_harness_ignores_configured_profile_axes
 test_ship_relaunch_ignores_the_crew_harness_config
 test_spawn_relaunch_without_a_harness_reuses_the_recorded_one

--- a/tests/fm-control-relaunch.test.sh
+++ b/tests/fm-control-relaunch.test.sh
@@ -794,6 +794,7 @@ test_bound_secondmate_relaunch_with_a_missing_store_refuses_before_stop() {
   dir=$(new_case smgone sm9)
   store="$dir/claude-client-gone"
   write_bound_secondmate "$dir" sm9 "$store"
+  printf 'claude\n' > "$dir/home/config/secondmate-harness"
   out=$(run_control "$dir" sm9 relaunch); rc=$?
   expect_code 1 "$rc" "a recorded store that is not there should refuse the relaunch"
   assert_contains "$out" "$store" "the refusal should name the missing store"

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -41,6 +41,15 @@
 #      spawn only when the harness also resolves from that file, so the pin is
 #      durable across every respawn while explicit per-spawn harness/model/effort
 #      flags still win.
+#   D) Per-mate Claude account binding. A local route in data/secondmates.md may
+#      carry an optional claude-config-dir: field. fm-spawn.sh re-resolves it on
+#      every --secondmate launch and uses it instead of the launching process's
+#      ambient CLAUDE_CONFIG_DIR, so the account a second mate and its own
+#      workers bill against is durable rather than inherited from whoever
+#      relaunched it. Unlike (A) and (C) this is PER second mate, never global.
+#      It fails closed: a store that is not an existing directory, a harness
+#      other than claude, and a remote route each refuse the launch instead of
+#      falling back to the ambient store. An entry with no field is unchanged.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -2547,6 +2556,190 @@ SH
   pass "B25 spawn quarantines stale rereads without blocking relaunch"
 }
 
+
+# ===========================================================================
+# D) Per-secondmate Claude account binding (data/secondmates.md
+#    claude-config-dir:)
+# ===========================================================================
+# Same durability shape as the harness/model/effort pin in (A) and (C), but
+# PER second mate rather than global: the store is recorded in that mate's own
+# registry entry and re-resolved on every spawn, so the account it and its own
+# workers authenticate and bill against cannot follow whichever CLAUDE_CONFIG_DIR
+# the launching process happened to carry. It fails closed on a missing store, a
+# non-claude harness, and a remote route.
+
+# write_registry_entry <world> <id> <home> [store]
+# One local route line, with the optional claude-config-dir: field only when a
+# store is supplied. The home is resolved so the spawn's own binding check (which
+# compares resolved paths) matches the home it is handed.
+write_registry_entry() {
+  local world=$1 id=$2 home=$3 store=${4:-} reg abs
+  reg="$world/home/data/secondmates.md"
+  mkdir -p "$world/home/data"
+  abs=$(cd "$home" && pwd -P)
+  if [ -n "$store" ]; then
+    printf -- '- %s - %s domain (home: %s; scope: %s work; projects: alpha; claude-config-dir: %s; added 2026-08-23)\n' \
+      "$id" "$id" "$abs" "$id" "$store" >> "$reg"
+  else
+    printf -- '- %s - %s domain (home: %s; scope: %s work; projects: alpha; added 2026-08-23)\n' \
+      "$id" "$id" "$abs" "$id" >> "$reg"
+  fi
+}
+
+# A recorded store wins over the launching process's own CLAUDE_CONFIG_DIR. This
+# is the whole point: the primary here is authenticated against one account and
+# the second mate must still come up on its own.
+test_spawn_registry_claude_config_dir_wins_over_ambient() {
+  local w sm store launchlog launch out status
+  w="$TMP_ROOT/ccd-registry-wins"
+  sm="$w/sm"
+  store="$w/claude-client"
+  launchlog="$w/launch.log"
+  mkdir -p "$w/home/config" "$store" "$w/ambient"
+  printf 'claude\n' > "$w/home/config/secondmate-harness"
+  make_seeded_home "$sm" sm
+  write_registry_entry "$w" sm "$sm" "$store"
+
+  out=$(CLAUDE_CONFIG_DIR="$w/ambient" \
+    spawn_secondmate_capture "$w" sm "$sm" "$launchlog" 2>&1); status=$?
+  expect_code 0 "$status" "a secondmate spawn with a recorded store should succeed"$'\n'"$out"
+
+  launch=$(cat "$launchlog")
+  assert_contains "$launch" "CLAUDE_CONFIG_DIR='$store'" \
+    "the launch must carry the second mate's own recorded Claude store"
+  assert_not_contains "$launch" "$w/ambient" \
+    "the launching process's ambient store must not reach a bound second mate"
+  pass "D1 spawn: a recorded claude-config-dir binds the launch, overriding the launcher's ambient store"
+}
+
+# Backward compatibility: an entry with no field behaves exactly as before,
+# inheriting the ambient store, and an unset ambient store still adds no prefix.
+test_spawn_registry_without_claude_config_dir_inherits_ambient() {
+  local w sm launchlog launch out status
+  w="$TMP_ROOT/ccd-absent-field"
+  sm="$w/sm"
+  launchlog="$w/launch.log"
+  mkdir -p "$w/home/config" "$w/ambient"
+  printf 'claude\n' > "$w/home/config/secondmate-harness"
+  make_seeded_home "$sm" sm
+  write_registry_entry "$w" sm "$sm"
+
+  out=$(CLAUDE_CONFIG_DIR="$w/ambient" \
+    spawn_secondmate_capture "$w" sm "$sm" "$launchlog" 2>&1); status=$?
+  expect_code 0 "$status" "a fieldless registry entry must still spawn"$'\n'"$out"
+  launch=$(cat "$launchlog")
+  assert_contains "$launch" "CLAUDE_CONFIG_DIR='$w/ambient'" \
+    "a fieldless entry must keep inheriting the launcher's ambient store"
+
+  out=$(CLAUDE_CONFIG_DIR='' \
+    spawn_secondmate_capture "$w" sm "$sm" "$launchlog" 2>&1); status=$?
+  expect_code 0 "$status" "a fieldless entry with no ambient store must still spawn"$'\n'"$out"
+  launch=$(cat "$launchlog")
+  assert_not_contains "$launch" "CLAUDE_CONFIG_DIR=" \
+    "a fieldless entry with no ambient store must add no config-dir prefix at all"
+  pass "D2 spawn: an entry with no claude-config-dir behaves exactly as before (ambient inheritance)"
+}
+
+# Fail closed: a recorded store that is not an existing directory refuses the
+# launch naming the path, and never silently falls back to the ambient store -
+# silent fallback is the exact defect the binding exists to prevent.
+test_spawn_missing_claude_config_dir_refuses_without_fallback() {
+  local w sm store launchlog out status
+  w="$TMP_ROOT/ccd-missing-store"
+  sm="$w/sm"
+  store="$w/claude-gone"
+  launchlog="$w/launch.log"
+  mkdir -p "$w/home/config" "$w/ambient"
+  printf 'claude\n' > "$w/home/config/secondmate-harness"
+  make_seeded_home "$sm" sm
+  write_registry_entry "$w" sm "$sm" "$store"
+
+  out=$(CLAUDE_CONFIG_DIR="$w/ambient" \
+    spawn_secondmate_capture "$w" sm "$sm" "$launchlog" 2>&1); status=$?
+  [ "$status" -ne 0 ] || fail "a recorded store that does not exist must refuse the launch"
+  assert_contains "$out" "$store" "the refusal must name the missing store path"
+  [ ! -s "$launchlog" ] || fail "a refused spawn must not launch anything: $(cat "$launchlog")"
+  [ ! -f "$w/home/state/sm.meta" ] || fail "a refused spawn must not publish a task record"
+  pass "D3 spawn: a nonexistent recorded store refuses the launch by name instead of falling back"
+}
+
+# Fail closed on the other axis: the binding names a CLAUDE store, so a launch
+# that resolves any other harness has nothing to bind and must refuse rather
+# than start the mate with the account silently unbound.
+test_spawn_claude_config_dir_refuses_non_claude_harness() {
+  local w sm store launchlog out status
+  w="$TMP_ROOT/ccd-wrong-harness"
+  sm="$w/sm"
+  store="$w/claude-client"
+  launchlog="$w/launch.log"
+  mkdir -p "$w/home/config" "$store"
+  printf 'codex\n' > "$w/home/config/secondmate-harness"
+  make_seeded_home "$sm" sm
+  write_registry_entry "$w" sm "$sm" "$store"
+
+  out=$(spawn_secondmate_capture "$w" sm "$sm" "$launchlog" 2>&1); status=$?
+  [ "$status" -ne 0 ] || fail "a bound second mate must not launch on a harness with no Claude store"
+  assert_contains "$out" "codex" "the refusal must name the harness that resolved"
+  [ ! -s "$launchlog" ] || fail "a refused spawn must not launch anything: $(cat "$launchlog")"
+  pass "D4 spawn: a recorded store refuses a non-claude harness rather than leaving the account unbound"
+}
+
+# Per-mate, not global: two second mates with two recorded stores each launch on
+# their own, and neither sees the other's or the launcher's.
+test_spawn_two_secondmates_keep_separate_stores() {
+  local w one two store_one store_two log_one log_two launch out status
+  w="$TMP_ROOT/ccd-two-mates"
+  one="$w/sm-one"
+  two="$w/sm-two"
+  store_one="$w/claude-personal"
+  store_two="$w/claude-client"
+  log_one="$w/one.log"
+  log_two="$w/two.log"
+  mkdir -p "$w/home/config" "$store_one" "$store_two" "$w/ambient"
+  printf 'claude\n' > "$w/home/config/secondmate-harness"
+  make_seeded_home "$one" sm-one
+  make_seeded_home "$two" sm-two
+  write_registry_entry "$w" sm-one "$one" "$store_one"
+  write_registry_entry "$w" sm-two "$two" "$store_two"
+
+  out=$(CLAUDE_CONFIG_DIR="$w/ambient" \
+    spawn_secondmate_capture "$w" sm-one "$one" "$log_one" 2>&1); status=$?
+  expect_code 0 "$status" "first bound secondmate should spawn"$'\n'"$out"
+  out=$(CLAUDE_CONFIG_DIR="$w/ambient" \
+    spawn_secondmate_capture "$w" sm-two "$two" "$log_two" 2>&1); status=$?
+  expect_code 0 "$status" "second bound secondmate should spawn"$'\n'"$out"
+
+  launch=$(cat "$log_one")
+  assert_contains "$launch" "CLAUDE_CONFIG_DIR='$store_one'" "sm-one did not get its own store"
+  assert_not_contains "$launch" "$store_two" "sm-one leaked sm-two's store"
+  launch=$(cat "$log_two")
+  assert_contains "$launch" "CLAUDE_CONFIG_DIR='$store_two'" "sm-two did not get its own store"
+  assert_not_contains "$launch" "$store_one" "sm-two leaked sm-one's store"
+  pass "D5 spawn: two second mates with two recorded stores stay on their own accounts"
+}
+
+# A remote route's account store lives on its own host, where this launch prefix
+# never reaches, so the field is refused rather than half-applied.
+test_spawn_remote_route_refuses_claude_config_dir() {
+  local w sm launchlog out status reg
+  w="$TMP_ROOT/ccd-remote-refused"
+  sm="$w/sm"
+  launchlog="$w/launch.log"
+  mkdir -p "$w/home/config" "$w/home/data" "$w/claude-client"
+  printf 'claude\n' > "$w/home/config/secondmate-harness"
+  make_seeded_home "$sm" sm
+  reg="$w/home/data/secondmates.md"
+  printf -- '- sm - remote domain (host: box; root: /srv/firstmate; home: /srv/sm; scope: remote work; projects: alpha; claude-config-dir: %s; added 2026-08-23)\n' \
+    "$w/claude-client" > "$reg"
+
+  out=$(spawn_secondmate_capture "$w" sm "$sm" "$launchlog" 2>&1); status=$?
+  [ "$status" -ne 0 ] || fail "a remote route carrying claude-config-dir must refuse the launch"
+  assert_contains "$out" "claude-config-dir" "the refusal must name the unsupported field"
+  assert_contains "$out" "local routes" "the refusal must explain that the field is local-route only"
+  [ ! -s "$launchlog" ] || fail "a refused remote spawn must not launch anything: $(cat "$launchlog")"
+  pass "D6 spawn: a remote route refuses claude-config-dir instead of recording a binding it cannot honor"
+}
+
 test_harness_resolution
 test_cursor_marker_detection
 test_secondmate_model_effort_tokens
@@ -2596,5 +2789,11 @@ test_config_reread_bootstrap_path_and_spawn_flexibility
 test_bootstrap_respawns_before_config_reread
 test_spawn_quarantines_pending_rereads_on_cleanup_failure
 test_bootstrap_detect_only_does_not_create_state
+test_spawn_registry_claude_config_dir_wins_over_ambient
+test_spawn_registry_without_claude_config_dir_inherits_ambient
+test_spawn_missing_claude_config_dir_refuses_without_fallback
+test_spawn_claude_config_dir_refuses_non_claude_harness
+test_spawn_two_secondmates_keep_separate_stores
+test_spawn_remote_route_refuses_claude_config_dir
 
 echo "# all fm-secondmate-harness tests passed"

--- a/tests/fm-secondmate-liveness.test.sh
+++ b/tests/fm-secondmate-liveness.test.sh
@@ -25,6 +25,10 @@
 #   - The sweep converges: once a secondmate reads alive, a later run never
 #     re-touches it (idempotent by construction, not by remembering what it
 #     already did).
+#   - A relaunch re-resolves the second mate's own recorded Claude config store
+#     from data/secondmates.md, so a sweep driven from a primary session on a
+#     different Claude account cannot silently move that mate onto the
+#     primary's; an unbound mate still inherits the primary's store.
 #   - The sweep is skipped entirely under FM_BOOTSTRAP_DETECT_ONLY=1 (the
 #     read-only session path), matching the other mutating sweeps.
 #   - The sweep is naturally scoped to the primary: with no kind=secondmate
@@ -300,6 +304,18 @@ case "${1:-}" in
     [ "${1:-}" = new-window ] && rm -f "${FM_TMUX_CALL_LOG}.killed"
     exit 0
     ;;
+  send-keys)
+    # Only when a caller opts in, so every window-op assertion elsewhere keeps
+    # reading an unchanged FM_TMUX_CALL_LOG.
+    if [ -n "${FM_FAKE_LAUNCH_LOG:-}" ]; then
+      prev=
+      for a in "$@"; do
+        [ "$prev" = "-l" ] && printf '%s\n' "$a" >> "$FM_FAKE_LAUNCH_LOG"
+        prev=$a
+      done
+    fi
+    exit 0
+    ;;
   has-session) exit 0 ;;
 esac
 exit 0
@@ -504,6 +520,62 @@ test_sweep_converges_no_retouch_once_alive() {
   pass "sweep: idempotent by construction - a live secondmate is never re-touched on a later run"
 }
 
+# The regression the per-mate account binding exists for: the sweep relaunches a
+# dead second mate by calling `fm-spawn.sh <id> --secondmate` bare, from the
+# PRIMARY's session, so before the binding a mate deliberately started on another
+# Claude account came back on the primary's, with nothing in the pane to show it.
+# Here the primary is authenticated against one store and the mate records
+# another; the relaunch must land on the mate's own.
+test_sweep_relaunch_uses_the_secondmates_own_claude_store() {
+  local w fb tmuxfb log launchlog store out launch
+  w=$(new_world sweep-claude-store)
+  add_sm_home "$w" sm1 firstmate:fm-sm1
+  printf 'claude\n' > "$w/home/config/secondmate-harness"
+  store="$w/claude-client"
+  mkdir -p "$store" "$w/claude-personal" "$w/home/data"
+  printf -- '- sm1 - client domain (home: %s; scope: client work; projects: alpha; claude-config-dir: %s; added 2026-08-23)\n' \
+    "$(cd "$w/sm1" && pwd -P)" "$store" > "$w/home/data/secondmates.md"
+  fb=$(make_toolchain "$w"); tmuxfb=$(make_liveness_tmux "$w")
+  log="$w/calls.log"; : > "$log"
+  launchlog="$w/launch.log"; : > "$launchlog"
+
+  out=$(run_bootstrap "$tmuxfb:$fb" "$w/home" zsh "$log" \
+    CLAUDE_CONFIG_DIR="$w/claude-personal" FM_FAKE_LAUNCH_LOG="$launchlog")
+
+  launch=$(cat "$launchlog")
+  assert_contains "$launch" "CLAUDE_CONFIG_DIR='$store'" \
+    "the sweep relaunch must use the second mate's own recorded Claude store"$'\n'"$out"
+  assert_not_contains "$launch" "claude-personal" \
+    "the primary session's own Claude store must not reach a bound second mate on relaunch"
+  assert_contains "$(cat "$log")" "new-window" \
+    "the confirmed-dead second mate should still be relaunched"$'\n'"$out"
+  pass "sweep: a relaunch from a primary on a different Claude account still lands the second mate on its own"
+}
+
+# The unbound case is unchanged: with no recorded store the relaunch still
+# inherits the primary's ambient one.
+test_sweep_relaunch_without_binding_inherits_primary_store() {
+  local w fb tmuxfb log launchlog out
+  w=$(new_world sweep-claude-store-absent)
+  add_sm_home "$w" sm1 firstmate:fm-sm1
+  printf 'claude\n' > "$w/home/config/secondmate-harness"
+  mkdir -p "$w/claude-personal" "$w/home/data"
+  printf -- '- sm1 - client domain (home: %s; scope: client work; projects: alpha; added 2026-08-23)\n' \
+    "$(cd "$w/sm1" && pwd -P)" > "$w/home/data/secondmates.md"
+  fb=$(make_toolchain "$w"); tmuxfb=$(make_liveness_tmux "$w")
+  log="$w/calls.log"; : > "$log"
+  launchlog="$w/launch.log"; : > "$launchlog"
+
+  out=$(run_bootstrap "$tmuxfb:$fb" "$w/home" zsh "$log" \
+    CLAUDE_CONFIG_DIR="$w/claude-personal" FM_FAKE_LAUNCH_LOG="$launchlog")
+
+  assert_contains "$(cat "$log")" "new-window" \
+    "the confirmed-dead second mate should still be relaunched"$'\n'"$out"
+  assert_contains "$(cat "$launchlog")" "CLAUDE_CONFIG_DIR='$w/claude-personal'" \
+    "an unbound second mate must keep inheriting the primary's ambient Claude store"$'\n'"$out"
+  pass "sweep: an unbound second mate still inherits the primary's store on relaunch"
+}
+
 test_sweep_skipped_under_detect_only() {
   local w fb tmuxfb log out
   w=$(new_world sweep-detect-only)
@@ -553,6 +625,8 @@ test_sweep_never_acts_on_transient_unreadability
 test_sweep_reports_missing_endpoint_relaunch_failure
 test_sweep_never_acts_on_unverified_harness_dead_reading
 test_sweep_converges_no_retouch_once_alive
+test_sweep_relaunch_uses_the_secondmates_own_claude_store
+test_sweep_relaunch_without_binding_inherits_primary_store
 test_sweep_skipped_under_detect_only
 test_sweep_noop_with_no_secondmate_meta
 

--- a/tests/fm-secondmate-safety.test.sh
+++ b/tests/fm-secondmate-safety.test.sh
@@ -135,6 +135,151 @@ EOF
   pass "seed allows overlapping project clone lists and drops the owns/owner routing"
 }
 
+# The optional per-mate Claude account binding, as a SEED input. A supplied
+# store is recorded as the claude-config-dir: field, and the resulting registry
+# still satisfies the full operational contract.
+test_home_seed_records_claude_config_dir_binding() {
+  local home sub store
+  home="$TMP_ROOT/ccd-seed-main"
+  sub="$TMP_ROOT/ccd-seed-sub"
+  store="$TMP_ROOT/ccd-seed-store"
+  mkdir -p "$home/projects" "$home/data" "$home/state" "$store"
+  fm_git_init_commit "$home/projects/alpha"
+  fm_git_add_origin "$home/projects/alpha" "$TMP_ROOT/remotes/ccd-alpha.git"
+  printf -- '- alpha [direct-PR] - alpha project (added 2026-08-23)\n' > "$home/data/projects.md"
+
+  FM_HOME="$home" FM_SECONDMATE_CHARTER='client domain' \
+    FM_SECONDMATE_SCOPE='client work' \
+    FM_SECONDMATE_CLAUDE_CONFIG_DIR="$store" \
+    "$ROOT/bin/fm-home-seed.sh" client "$sub" alpha >/dev/null \
+    || fail "seed refused a valid claude-config-dir binding"
+  assert_grep "claude-config-dir: $store; added " "$home/data/secondmates.md" \
+    "the seeded registry line did not record the Claude store binding"
+  FM_HOME="$home" "$ROOT/bin/fm-home-seed.sh" validate >/dev/null \
+    || fail "registry validation rejected a seeded claude-config-dir binding"
+  pass "home seeding records the per-mate Claude store binding and validates it"
+}
+
+# An unset binding must leave the record exactly as it was before the field
+# existed, so no existing seed changes shape.
+test_home_seed_without_claude_config_dir_records_no_field() {
+  local home sub
+  home="$TMP_ROOT/ccd-seed-absent-main"
+  sub="$TMP_ROOT/ccd-seed-absent-sub"
+  mkdir -p "$home/projects" "$home/data" "$home/state"
+  fm_git_init_commit "$home/projects/alpha"
+  fm_git_add_origin "$home/projects/alpha" "$TMP_ROOT/remotes/ccd-absent-alpha.git"
+  printf -- '- alpha [direct-PR] - alpha project (added 2026-08-23)\n' > "$home/data/projects.md"
+
+  FM_HOME="$home" FM_SECONDMATE_CHARTER='plain domain' \
+    FM_SECONDMATE_SCOPE='plain work' \
+    "$ROOT/bin/fm-home-seed.sh" plain "$sub" alpha >/dev/null \
+    || fail "an ordinary seed should still succeed"
+  assert_no_grep 'claude-config-dir' "$home/data/secondmates.md" \
+    "an unset binding must add no field to the registry record"
+  pass "home seeding without a binding writes the record exactly as before"
+}
+
+# Fail closed at seed time, and roll the whole seed back: a store that is not an
+# absolute, existing directory must never become a registered route.
+test_home_seed_refuses_invalid_claude_config_dir() {
+  local home sub err label bad
+  home="$TMP_ROOT/ccd-seed-bad-main"
+  err="$TMP_ROOT/ccd-seed-bad.err"
+  mkdir -p "$home/projects" "$home/data" "$home/state"
+  fm_git_init_commit "$home/projects/alpha"
+  fm_git_add_origin "$home/projects/alpha" "$TMP_ROOT/remotes/ccd-bad-alpha.git"
+  printf -- '- alpha [direct-PR] - alpha project (added 2026-08-23)\n' > "$home/data/projects.md"
+
+  while IFS='^' read -r label bad; do
+    [ -n "$label" ] || continue
+    sub="$TMP_ROOT/ccd-seed-bad-sub-$label"
+    if FM_HOME="$home" FM_SECONDMATE_CHARTER='client domain' \
+      FM_SECONDMATE_SCOPE='client work' \
+      FM_SECONDMATE_CLAUDE_CONFIG_DIR="$bad" \
+      "$ROOT/bin/fm-home-seed.sh" "client$label" "$sub" alpha >/dev/null 2>"$err"; then
+      fail "seed accepted an invalid claude-config-dir ($label): $bad"
+    fi
+    grep -F 'FM_SECONDMATE_CLAUDE_CONFIG_DIR' "$err" >/dev/null \
+      || fail "seed did not explain the invalid claude-config-dir ($label): $(cat "$err")"
+    [ ! -e "$sub" ] || fail "seed provisioned a home before refusing an invalid claude-config-dir ($label)"
+    [ ! -e "$home/data/secondmates.md" ] \
+      || fail "seed registered a route before refusing an invalid claude-config-dir ($label)"
+    [ ! -e "$home/data/client$label" ] \
+      || fail "seed left a brief behind after refusing an invalid claude-config-dir ($label)"
+  done <<ROWS
+relative^some/relative/store
+missing^$TMP_ROOT/ccd-seed-nonexistent-store
+ROWS
+  pass "home seeding refuses a relative or nonexistent Claude store and rolls the seed back"
+}
+
+# `validate` owns the structural half of the contract on hand-edited records.
+test_home_seed_validate_rejects_bad_claude_config_dir() {
+  local home err sub_abs
+  home="$TMP_ROOT/ccd-validate-home"
+  err="$TMP_ROOT/ccd-validate.err"
+  mkdir -p "$home/data" "$TMP_ROOT/ccd-validate-sub"
+  sub_abs=$(cd "$TMP_ROOT/ccd-validate-sub" && pwd -P)
+
+  printf -- '- client - client domain (home: %s; scope: client work; projects: alpha; claude-config-dir: %s; added 2026-08-23)\n' \
+    "$sub_abs" "$TMP_ROOT" > "$home/data/secondmates.md"
+  FM_HOME="$home" "$ROOT/bin/fm-home-seed.sh" validate >/dev/null 2>"$err" \
+    || fail "registry validation rejected a well-formed claude-config-dir: $(cat "$err")"
+
+  printf -- '- client - client domain (home: %s; scope: client work; projects: alpha; claude-config-dir: relative/store; added 2026-08-23)\n' \
+    "$sub_abs" > "$home/data/secondmates.md"
+  if FM_HOME="$home" "$ROOT/bin/fm-home-seed.sh" validate >/dev/null 2>"$err"; then
+    fail "registry validation accepted a non-absolute claude-config-dir"
+  fi
+  grep -F 'unsafe non-absolute claude-config-dir' "$err" >/dev/null \
+    || fail "registry validation did not explain the non-absolute claude-config-dir: $(cat "$err")"
+
+  printf -- '- client - client domain (home: %s; scope: client work; projects: alpha; claude-config-dir: /store/../escape; added 2026-08-23)\n' \
+    "$sub_abs" > "$home/data/secondmates.md"
+  if FM_HOME="$home" "$ROOT/bin/fm-home-seed.sh" validate >/dev/null 2>"$err"; then
+    fail "registry validation accepted a traversing claude-config-dir"
+  fi
+  grep -F 'claude-config-dir contains traversal components' "$err" >/dev/null \
+    || fail "registry validation did not explain the traversing claude-config-dir: $(cat "$err")"
+  pass "home seed validation accepts a well-formed Claude store binding and refuses malformed ones"
+}
+
+# The binding is local-route only: a remote record naming a store is refused
+# rather than accepted as a route whose account nothing here can bind.
+test_home_seed_validate_rejects_remote_claude_config_dir() {
+  local home err
+  home="$TMP_ROOT/ccd-remote-validate-home"
+  err="$TMP_ROOT/ccd-remote-validate.err"
+  mkdir -p "$home/data"
+  printf -- '- client - client domain (host: box; root: /srv/firstmate; home: /srv/client; scope: client work; projects: alpha; claude-config-dir: /srv/.claude-client; added 2026-08-23)\n' \
+    > "$home/data/secondmates.md"
+  if FM_HOME="$home" "$ROOT/bin/fm-home-seed.sh" validate >/dev/null 2>"$err"; then
+    fail "registry validation accepted claude-config-dir on a remote route"
+  fi
+  grep -F 'claude-config-dir is not supported on a remote secondmate route' "$err" >/dev/null \
+    || fail "registry validation did not explain the remote claude-config-dir: $(cat "$err")"
+  pass "home seed validation refuses a Claude store binding on a remote route"
+}
+
+# The remote seed refuses the variable outright rather than dropping it silently.
+test_remote_home_seed_refuses_claude_config_dir_env() {
+  local home err
+  home="$TMP_ROOT/ccd-remote-seed-home"
+  err="$TMP_ROOT/ccd-remote-seed.err"
+  mkdir -p "$home/data" "$home/state" "$home/projects" "$TMP_ROOT/ccd-remote-seed-store"
+  if FM_HOME="$home" FM_SECONDMATE_CHARTER='client domain' \
+    FM_SECONDMATE_CLAUDE_CONFIG_DIR="$TMP_ROOT/ccd-remote-seed-store" \
+    "$ROOT/bin/fm-remote-home-seed.sh" client box /srv/firstmate /srv/client alpha \
+    >/dev/null 2>"$err"; then
+    fail "remote seeding accepted a local-only Claude store binding"
+  fi
+  grep -F 'applies only to local secondmate routes' "$err" >/dev/null \
+    || fail "remote seeding did not explain the refused binding: $(cat "$err")"
+  [ ! -e "$home/data/secondmates.md" ] || fail "remote seeding registered a route before refusing"
+  pass "remote home seeding refuses the local-only Claude store binding"
+}
+
 test_home_seed_validate_rejects_unparseable_registry_entry() {
   local home err
   home="$TMP_ROOT/unparseable-registry-home"
@@ -2957,6 +3102,12 @@ test_fm_home_parameterization
 test_lock_status_is_per_home
 test_seed_allows_overlapping_clones_and_drops_owner
 test_home_seed_validate_rejects_unparseable_registry_entry
+test_home_seed_records_claude_config_dir_binding
+test_home_seed_without_claude_config_dir_records_no_field
+test_home_seed_refuses_invalid_claude_config_dir
+test_home_seed_validate_rejects_bad_claude_config_dir
+test_home_seed_validate_rejects_remote_claude_config_dir
+test_remote_home_seed_refuses_claude_config_dir_env
 test_home_seed_refuses_broken_registry_symlink
 test_home_seed_refuses_unreadable_registry
 test_home_seed_validate_rejects_duplicate_homes


### PR DESCRIPTION
## Intent

Bind each second mate's home to a durable Claude account (config store), so a restart cannot silently change which account it and its workers authenticate and bill against.

VERIFIED PROBLEM. bin/fm-spawn.sh prefixed the claude launch line with whatever CLAUDE_CONFIG_DIR happened to be set in fm-spawn's OWN environment at the moment it ran. For a --secondmate launch that made the account a second mate runs under ambient, not recorded anywhere. The automatic relaunch path in bin/fm-bootstrap.sh calls `bin/fm-spawn.sh <id> --secondmate` bare, from the primary firstmate's session, so a second mate deliberately started under a different store came back under the PRIMARY's store after any recovery relaunch, with no visible difference in the pane and no diagnostic. The launch line begins with `env`, which skips shell alias expansion and resolves the real binary on PATH, so any shell-alias guard the operator has against mixing accounts did not protect this path at all.

WHY IT MATTERS. The operator runs two Claude accounts selected by shell aliases: ~/.claude (personal) and ~/.claude-utm (a client's team account). A second mate is about to be created for that client's domain, and its work must never authenticate or bill against the personal account. This binding is the precondition for creating it.

DESIGN, DECIDED IN ADVANCE BY THE USER AND IMPLEMENTED AS SPECIFIED.
- Store the binding as an OPTIONAL field in the data/secondmates.md registry entry, alongside home:, scope:, projects:, named claude-config-dir:. Rationale: the primary is what launches the mate; the registry is the durable routing record already consulted on recovery when metadata is missing; remote routes already carry launch-target fields (host:, root:) there; and data/secondmates.md is printed in full in the session-start digest, so the binding becomes visible rather than silent.
- Resolution: bin/fm-spawn.sh --secondmate resolves the field for that id and uses it for the launch prefix instead of the ambient value. Every respawn re-resolves it, exactly like the harness pin does.
- Precedence: an explicit per-spawn override wins if one is added; otherwise the registry field; otherwise today's ambient-inheritance behavior, unchanged.
- Backward compatibility was REQUIRED: an entry with no claude-config-dir: field must parse and behave exactly as it does today, and existing registry lines must not need rewriting.
- Fail closed: if the field names a store directory that does not exist or is not a directory, refuse the launch with a concrete diagnostic naming the missing path. Do NOT silently fall back to the ambient store; silent fallback is the exact defect being fixed.
- Scope: local routes and the claude harness. For a remote route the account lives on that host: either carry the field through the remote path if genuinely straightforward, or explicitly refuse it with a clear diagnostic. Half-implementing it was explicitly ruled out.
- Seeding: bin/fm-home-seed.sh must be able to record the binding at seed time, following that script's existing option/env conventions, validating that the path is absolute and exists at seed time, and rolling back per the script's existing transactional contract on failure. bin/fm-home-seed.sh validate must validate the new field.
- Precedent to follow: config/secondmate-harness already solves this same class of problem (a durable launch attribute re-resolved on every spawn that survives every respawn: recovery, /updatefirstmate, restart). Match that shape and its backward-compatibility discipline. The one difference that matters: the harness pin is GLOBAL to all second mates, whereas this binding is PER second mate and must not be global.

ACCEPTANCE CRITERIA THE USER SET.
1. A second mate whose registry entry records a store launches under that store, and bin/fm-spawn.sh produces a launch line carrying it.
2. The same holds on a relaunch driven through the bootstrap liveness path from a primary session whose own CLAUDE_CONFIG_DIR is DIFFERENT. This is the actual regression being fixed and had to be covered explicitly with a test that would fail before the change.
3. An entry with no field behaves exactly as today (ambient inheritance), proven by test.
4. A field naming a nonexistent directory refuses the launch with a diagnostic naming the path, and does not fall back.
5. Two second mates with different recorded stores each get their own; no cross-contamination.
6. bin/fm-home-seed.sh can record the binding, and validate accepts good records and refuses malformed ones.
7. Tests live in tests/ and follow the conventions of the existing tests there.
8. Docs updated at their owners: docs/configuration.md for the schema, and .agents/skills/secondmate-provisioning/SKILL.md for the registry format plus the seed and recovery contract. Deliberately NOT restated in AGENTS.md, which points at the skill instead.

CONSTRAINTS THE USER SET.
- The firstmate-coding-guidelines skill had to be loaded before editing anything, because this is firstmate's shared tracked material. It was.
- Do not change the primary's own crewmate launch behavior; ambient inheritance is correct there today and is left untouched.
- Do not add a global "all second mates use store X" knob. Per-mate only.
- Do not touch anything under projects/.

DECISIONS AND TRADEOFFS MADE WHILE IMPLEMENTING, which a reviewer reading only the diff would not know.
- NO per-spawn override flag was added, even though the design permitted one ("an explicit per-spawn override wins if you add one"). A flag that firstmate must remember to pass on every relaunch is the same drift class this change exists to eliminate, and the bootstrap relaunch path deliberately passes no such flag. The registry is therefore the single source. This is a deliberate omission, not an oversight.
- A recorded binding on a launch whose harness resolves to anything other than claude REFUSES rather than being silently ignored. The specification scoped the feature to the claude harness but did not state this case. Silently ignoring would leak: a second mate running a non-claude harness still spawns its OWN crewmates through fm-spawn, which would then inherit the primary's ambient CLAUDE_CONFIG_DIR, which is exactly the drift being fixed. Refusing with a diagnostic naming the resolved harness is the fail-closed reading. The accepted consequence is that switching config/secondmate-harness away from claude while a mate is bound makes that mate's relaunch refuse until the conflict is resolved.
- For the remote route the choice offered was "carry it through or explicitly refuse". REFUSE was chosen deliberately: a remote second mate's account store lives on its own host, where this home's launch prefix never reaches, so honoring the field locally would bind nothing while reading as if it had. The refusal is enforced in three places: the shared registry validator rejects the field on a remote record, bin/fm-spawn.sh's remote secondmate path refuses the launch, and bin/fm-remote-home-seed.sh refuses the FM_SECONDMATE_CLAUDE_CONFIG_DIR variable outright rather than silently dropping it.
- Validation was split deliberately. STRUCTURAL validation (absolute, delimiter-free, no traversal components, local-route-only) lives in the shared parser bin/fm-secondmate-registry-lib.sh, so every registry read enforces it. EXISTENCE of the store directory is checked only at seed time and at launch time, NOT in the shared validator, because that parser also runs in sweeps and on hosts that never launch that particular second mate; an absent store must refuse the launch rather than break every read of the registry.
- The optional field is expressed as an optional regex group placed immediately before `added` in BOTH the local and remote line forms. A non-participating optional group still occupies its BASH_REMATCH index and yields an empty string, so the surrounding capture indices stay fixed whether or not the field matched; this is what preserves byte-identical parsing of existing fieldless lines. Adding the group to the remote form as well is what allows the remote refusal to produce a precise diagnostic instead of a generic "malformed entry".
- An unset binding at seed time writes the registry record byte-identically to before the field existed, so an ordinary single-account seed produces no new bytes at all.
- bin/fm-fleet-snapshot.sh carries a SECOND, independent jq-based parser of the same registry lines. It was updated with the same optional group. Without that, a bound record would have been read there as having no home. This file was not named in the specification; it was found by grepping for other parsers of the same contract.
- Tests EXTEND three existing suites rather than adding a new test file, per the repo's coding guidelines ("extend an existing script rather than inventing a new one"): the launch-binding, backward-compat, missing-store refusal, non-claude-harness refusal, two-mate isolation, and remote-refusal cases went into tests/fm-secondmate-harness.test.sh alongside the existing harness/model/effort durable-pin coverage it already owns; the bootstrap-sweep relaunch regression went into tests/fm-secondmate-liveness.test.sh, which already owns the sweep scaffolding; and the seed/validate coverage went into tests/fm-secondmate-safety.test.sh, which already owns the registry-validation cases. All three are already registered in the runner's secondmate family, so no runner change was needed and the coverage guard still passes.
- The liveness suite's shared fake tmux gained a send-keys branch that captures the launch command only when a caller opts in via FM_FAKE_LAUNCH_LOG, so every existing window-op assertion in that file keeps reading an unchanged call log.
- The bootstrap-relaunch regression test was verified to FAIL against the pre-change bin/ and pass after, by temporarily restoring the previous bin/fm-spawn.sh and bin/fm-secondmate-registry-lib.sh from HEAD and re-running the suite.

VERIFICATION ALREADY RUN LOCALLY: bin/fm-lint.sh clean (shellcheck 0.11.0 and actionlint 1.7.12, both pinned), bin/fm-doc-audience-check.sh ok, bin/fm-test-run.sh --check-coverage ok, and bin/fm-test-run.sh --changed green at 66 scripts with 0 failures (2 gate skips are pre-existing environment gaps for an uninstalled Pi package, unrelated to this change).

## What Changed

- Added an optional `claude-config-dir:` field to the `data/secondmates.md` registry (local routes only), parsed by `bin/fm-secondmate-registry-lib.sh` and the second jq-based parser in `bin/fm-fleet-snapshot.sh`, with fieldless entries parsing byte-identically to before.
- `bin/fm-spawn.sh` resolves this field for `--secondmate` launches and uses it in place of the ambient `CLAUDE_CONFIG_DIR`, so a relaunch (including through the bootstrap liveness/recovery path) re-resolves and honors the bound store instead of inheriting whatever account the primary firstmate happens to be running under. Launch refuses with a diagnostic if the named store directory doesn't exist, if the resolved harness isn't `claude`, or if the record is a remote route.
- `bin/fm-home-seed.sh` gains support for recording the binding at seed time (validating the path is absolute and exists, with rollback on failure), and its `validate` subcommand checks the new field; `bin/fm-remote-home-seed.sh` explicitly refuses the corresponding remote env var.
- Extended `tests/fm-secondmate-harness.test.sh`, `tests/fm-secondmate-liveness.test.sh`, and `tests/fm-secondmate-safety.test.sh` with coverage for bound-launch, backward compatibility, missing-store refusal, non-claude-harness refusal, multi-mate isolation, remote refusal, and the bootstrap-relaunch regression.
- Updated `docs/configuration.md` and `.agents/skills/secondmate-provisioning/SKILL.md` to document the registry field, seed behavior, and recovery contract.

## Risk Assessment

✅ Low: The change is well-bounded, thoroughly tested against real observable behavior (captured launch commands, not source-text matching), fails closed on every documented edge case (missing store, non-claude harness, remote route), preserves backward compatibility via a verified BASH_REMATCH index calculation, and matches every acceptance criterion and design decision stated in the user intent with no contradictions found.

## Testing

Targeted test suites (harness, liveness, safety) all pass, exercising every numbered acceptance criterion end-to-end via real fm-spawn.sh launch-line inspection rather than source-text matching, including the specific bootstrap-relaunch-under-a-different-ambient-account regression the intent calls out; docs were confirmed updated at their named owners; no findings.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"0f1a6f4134d940436b6be44fea919de7785a4c06","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `./bin/fm-test-run.sh tests/fm-secondmate-harness.test.sh tests/fm-secondmate-liveness.test.sh tests/fm-secondmate-safety.test.sh - 3/3 suites pass, 0 failures`
- `Inspected tests/fm-secondmate-harness.test.sh D1-D6 cases directly to confirm they call fm-spawn.sh --secondmate and assert on the captured launch line (real behavior), not a source-text grep`
- `git diff 505c819..0f1a6f4 -- docs/configuration.md .agents/skills/secondmate-provisioning/SKILL.md - confirmed doc updates land at the specified owners`
- `git status --short - confirmed a clean working tree after testing, no cleanup needed`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

