### PR TITLE
Recognize oh-my-pi engine (omp) as the Pi harness

### DIFF
--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -50,6 +50,15 @@ detect_own() {
   # CURSOR_AGENT=1 is set for the child/tool processes this script runs as.
   [ "${CURSOR_AGENT:-}" = "1" ] && { echo cursor; return; }
   [ "${CURSOR_INVOKED_AS:-}" = "cursor-agent" ] && { echo cursor; return; }
+  # Pi (oh-my-pi) engine binary is `omp`. It appears only in Pi sessions, so an
+  # omp process anywhere in the ancestry is authoritative Pi and must outrank any
+  # foreign CLAUDECODE marker leaked into the pane (the precedence hazard above).
+  omp_pid=$$
+  for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
+    [ "$(ps -o comm= -p "$omp_pid" 2>/dev/null)" = "omp" ] && { echo pi; return; }
+    omp_pid=$(ps -o ppid= -p "$omp_pid" 2>/dev/null | tr -d ' ')
+    [ -n "$omp_pid" ] && [ "$omp_pid" -gt 1 ] || break
+  done
   [ "${CLAUDECODE:-}" = "1" ] && { echo claude; return; }
   if [ "${PI_CODING_AGENT:-}" = "true" ]; then
     if [ "${FM_PI_HARNESS:-}" = pi-signed ]; then echo pi-signed; else echo pi; fi
@@ -94,7 +103,7 @@ detect_own() {
       # unrelated commands (musescore, amuse) cannot be misread as this harness.
       muse|muse-bin-*) echo muse; return ;;
       pi-signed) echo pi; return ;;
-      pi) echo pi; return ;;
+      pi|omp) echo pi; return ;;
       node*|python*)
         # Bare interpreter: match the harness name in its script path.
         args=$(ps -o args= -p "$pid" 2>/dev/null)

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -17,13 +17,13 @@
 . "$(dirname -- "${BASH_SOURCE[0]}")/fm-cursor-lib.sh"
 
 # Known harness command names; extend when a new adapter is verified.
-FM_HARNESS_RE='claude|codex|opencode|grok|kimi|^pi$|^pi-signed$'
+FM_HARNESS_RE='claude|codex|opencode|grok|kimi|^pi$|^pi-signed$|^omp$'
 
 # The same harnesses as exact executable names. Keep in sync with
 # FM_HARNESS_RE. Used only for the stricter path evidence below, where the
 # loose regex would also match ordinary firstmate paths such as
 # bin/fm-claude-stop-autoarm.sh.
-FM_HARNESS_NAMES=(claude codex opencode grok kimi pi-signed pi)
+FM_HARNESS_NAMES=(claude codex opencode grok kimi pi-signed pi omp)
 
 # Print the exact harness name carried by executable path $1 - its own basename
 # or any directory component - or return 1.


### PR DESCRIPTION
## Problem

The Pi runtime "oh-my-pi" (installed via mise) launches its session engine as the `omp` binary, but firstmate's harness identity tables only listed `pi` / `pi-signed`.

- The session-lock ancestry walk found no verified harness, so every firstmate session under this runtime started read-only.
- A leaked `CLAUDECODE=1` marker in the pane environment additionally mislabeled the harness as `claude`.

## Fix

Two small changes:

- `bin/fm-session-lock-lib.sh`: add `^omp$` to `FM_HARNESS_RE` and `omp` to `FM_HARNESS_NAMES` so the lock ancestry walk recognizes the engine.
- `bin/fm-harness.sh`: detect an `omp` process in the ancestry as authoritative Pi (outranking any foreign `CLAUDECODE` marker), and match `omp` in the Layer 2 basename case.

`omp` appears only inside Pi sessions, so the ancestry signal is unambiguous.

## Verification

- `bin/fm-harness.sh` now prints `pi` under oh-my-pi.
- `bin/fm-lock.sh` acquires `state/.lock` with the `omp` pid.
- Sessions under this runtime no longer start read-only.
