### PR TITLE
fix(bearings): expose full truncated board text

### DIFF
--- a/.agents/skills/bearings/assets/board-template.html
+++ b/.agents/skills/bearings/assets/board-template.html
@@ -190,14 +190,17 @@ a { color: inherit; text-decoration: none; }
 .bb-decision__pad { padding: 18px 20px 16px; display: flex; flex-direction: column; gap: 12px; flex: 1; }
 .bb-decision__top { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
 .bb-decision__repo { font-family: var(--font-mono); font-size: var(--fs-2xs); color: var(--text-faint); white-space: nowrap; }
-.bb-decision__title { margin: 0; font-size: var(--fs-h4); font-weight: 800; color: var(--text-strong); line-height: 1.25; }
-.bb-decision__detail { margin: 0; font-size: var(--fs-sm); color: var(--text-muted); line-height: 1.45; }
+.bb-decision__title { margin: 0; font-size: var(--fs-h4); font-weight: 800; color: var(--text-strong); line-height: 1.25;
+  overflow-wrap: anywhere; }
+.bb-decision__detail { margin: 0; font-size: var(--fs-sm); color: var(--text-muted); line-height: 1.45;
+  overflow-wrap: anywhere; }
 /* about / decide / recommended - three scannable context rows */
 .bb-ctx { display: flex; flex-direction: column; gap: 6px; }
 .bb-ctx__row { display: grid; grid-template-columns: 78px minmax(0,1fr); gap: 8px; align-items: baseline; }
 .bb-ctx__k { font-family: var(--font-mono); font-size: var(--fs-2xs); letter-spacing: 0.04em;
   text-transform: uppercase; color: var(--text-faint); white-space: nowrap; }
-.bb-ctx__v { font-size: var(--fs-sm); color: var(--text-muted); line-height: 1.4; min-width: 0; }
+.bb-ctx__v { font-size: var(--fs-sm); color: var(--text-muted); line-height: 1.4; min-width: 0;
+  overflow-wrap: anywhere; }
 .bb-decision__link { font-family: var(--font-mono); font-size: var(--fs-xs); color: var(--ocean-600); font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: block; }
 .bb-decision__link:hover { text-decoration: underline; }
 /* One rhythm owner: the answer form is a flex column with the same 12px gap as
@@ -213,8 +216,10 @@ a { color: inherit; text-decoration: none; }
 .bb-opt:hover { border-color: var(--ink-300); }
 .bb-opt input { accent-color: var(--rust-500); margin-top: 3px; flex: none; }
 .bb-opt__body { min-width: 0; flex: 1 1 auto; }
-.bb-opt__label { display: block; font-size: var(--fs-sm); font-weight: 700; color: var(--text-strong); line-height: 1.3; }
-.bb-opt__hint { display: block; font-size: var(--fs-xs); color: var(--text-muted); line-height: 1.35; margin-top: 1px; }
+.bb-opt__label { display: block; font-size: var(--fs-sm); font-weight: 700; color: var(--text-strong); line-height: 1.3;
+  overflow-wrap: anywhere; }
+.bb-opt__hint { display: block; font-size: var(--fs-xs); color: var(--text-muted); line-height: 1.35; margin-top: 1px;
+  overflow-wrap: anywhere; }
 .bb-opt__rec { flex: none; align-self: center; font-size: var(--fs-2xs); font-weight: 800; text-transform: uppercase;
   letter-spacing: 0.07em; color: var(--navy-700); background: var(--gold-300);
   border: 1px solid var(--gold-600); border-radius: var(--radius-xs); padding: 3px 7px 2px; }
@@ -273,7 +278,7 @@ a { color: inherit; text-decoration: none; }
 .bb-foot { display: flex; justify-content: flex-end; border-top: 1px solid var(--border-default); padding-top: 14px; }
 
 @media (max-width: 900px) {
-  .bb-cols { grid-template-columns: 1fr; }
+  .bb-cols { grid-template-columns: minmax(0, 1fr); }
 }
 </style>
 </head>
@@ -468,7 +473,7 @@ __FM_BEARINGS_BOARD_DATA__
   function ctxRow(k, v, rec) {
     var row = el("div", "bb-ctx__row" + (rec ? " bb-ctx__row--rec" : ""));
     row.appendChild(el("span", "bb-ctx__k", k));
-    row.appendChild(el("span", "bb-ctx__v", v));
+    row.appendChild(titledEl("span", "bb-ctx__v", v));
     return row;
   }
 
@@ -486,10 +491,10 @@ __FM_BEARINGS_BOARD_DATA__
     }
     pad.appendChild(top);
 
-    pad.appendChild(el("h3", "bb-decision__title", item.title));
+    pad.appendChild(titledEl("h3", "bb-decision__title", item.title));
 
     if (item.type === "merge") {
-      if (item.detail) pad.appendChild(el("p", "bb-decision__detail", item.detail));
+      if (item.detail) pad.appendChild(titledEl("p", "bb-decision__detail", item.detail));
       if (item.pr_url) {
         var pr = titledEl("a", "bb-decision__link", item.pr_url);
         pr.href = item.pr_url; pr.target = "_blank"; pr.rel = "noopener";
@@ -512,8 +517,8 @@ __FM_BEARINGS_BOARD_DATA__
       input.type = "radio"; input.name = "answer"; input.value = o.value;
       lab.appendChild(input);
       var body = el("span", "bb-opt__body");
-      body.appendChild(el("span", "bb-opt__label", o.label));
-      if (o.hint) body.appendChild(el("span", "bb-opt__hint", o.hint));
+      body.appendChild(titledEl("span", "bb-opt__label", o.label));
+      if (o.hint) body.appendChild(titledEl("span", "bb-opt__hint", o.hint));
       lab.appendChild(body);
       if (item.recommend_value && o.value === item.recommend_value) {
         lab.appendChild(el("span", "bb-opt__rec", "rec"));

--- a/.agents/skills/bearings/assets/board-template.html
+++ b/.agents/skills/bearings/assets/board-template.html
@@ -461,7 +461,10 @@ __FM_BEARINGS_BOARD_DATA__
   function utf8ByteLength(text) { return new TextEncoder().encode(text).length; }
   var CHECK_SVG = '<svg class="fm-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>';
 
-  document.getElementById("bb-provenance").textContent = data.schema + " · " + data.generated;
+  var provenance = data.schema + " · " + data.generated;
+  var provenanceNode = document.getElementById("bb-provenance");
+  provenanceNode.textContent = provenance;
+  provenanceNode.title = provenance;
 
   /* stat strip */
   var callTotal = data.captains_call.length;

--- a/.agents/skills/bearings/assets/board-template.html
+++ b/.agents/skills/bearings/assets/board-template.html
@@ -453,7 +453,11 @@ __FM_BEARINGS_BOARD_DATA__
     if (text != null) n.title = text;
     return n;
   }
-  function badge(tone, text) { return titledEl("span", "fm-badge fm-badge--" + tone, text); }
+  function badge(tone, text) { return el("span", "fm-badge fm-badge--" + tone, text); }
+  /* Fixed badge literals are short, nowrap, and always fully drawn, so they
+     stay tooltip-free; payload-derived badge text has no bounded length and
+     carries its exact full value like every other clampable node. */
+  function dynamicBadge(tone, text) { return titledEl("span", "fm-badge fm-badge--" + tone, text); }
   function utf8ByteLength(text) { return new TextEncoder().encode(text).length; }
   var CHECK_SVG = '<svg class="fm-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>';
 
@@ -493,7 +497,7 @@ __FM_BEARINGS_BOARD_DATA__
     var top = el("div", "bb-decision__top");
     if (item.type === "merge") {
       top.appendChild(badge("online", "checks green"));
-      top.appendChild(badge(item.risk === "low" ? "neutral" : "warn", "risk " + item.risk));
+      top.appendChild(dynamicBadge(item.risk === "low" ? "neutral" : "warn", "risk " + item.risk));
     } else {
       top.appendChild(badge("solid", "decision"));
       top.appendChild(titledEl("span", "bb-decision__repo", item.repo));
@@ -540,6 +544,10 @@ __FM_BEARINGS_BOARD_DATA__
       var ff = document.createElement("input");
       ff.type = "text"; ff.name = "note"; ff.className = "bb-freeform";
       ff.placeholder = item.freeform_hint || "or answer in your own words…";
+      /* a single-line field hard-clips its placeholder at the field edge, and
+         freeform_hint is unbounded payload text, so the supplied hint stays
+         reachable in full; the short built-in fallback needs no tooltip */
+      if (item.freeform_hint) ff.title = item.freeform_hint;
       form.appendChild(ff);
     }
 
@@ -624,7 +632,7 @@ __FM_BEARINGS_BOARD_DATA__
   if (!data.underway.length) uw.appendChild(el("div", "bb-empty", "Nothing is underway."));
   data.underway.forEach(function (t) {
     var row = el("div", "bb-row");
-    row.appendChild(badge(t.state === "working" ? "online" : "info", t.state));
+    row.appendChild(dynamicBadge(t.state === "working" ? "online" : "info", t.state));
     var main = el("div", "bb-row__main");
     main.appendChild(titledEl("div", "bb-row__title", t.doing));
     /* captain-facing rows name the repo; the internal task id shows only when

--- a/.agents/skills/bearings/assets/board-template.html
+++ b/.agents/skills/bearings/assets/board-template.html
@@ -443,7 +443,9 @@ __FM_BEARINGS_BOARD_DATA__
      text, so any renderer-produced text node CSS can visually cut also carries
      its exact full text as a native title tooltip - the visible label stays as
      rendered and the complete value stays reachable on hover. Build every such
-     node with titledEl and keep plain el for text that is already fully shown.
+     node with titledEl and keep plain el for text that is already fully shown;
+     a node that already exists in the static markup instead sets .title beside
+     its textContent at the one place that fills it.
      The null guard matters because title reflects a DOMString: assigning a
      missing value would surface the literal "null" as the tooltip.
      tests/fm-bearings-board.test.sh renders a built board and asserts these

--- a/.agents/skills/bearings/assets/board-template.html
+++ b/.agents/skills/bearings/assets/board-template.html
@@ -439,6 +439,15 @@ __FM_BEARINGS_BOARD_DATA__
     if (text != null) n.textContent = text;
     return n;
   }
+  /* The styles above deliberately clamp, ellipsize, or hard-wrap captain-facing
+     text, so any renderer-produced text node CSS can visually cut also carries
+     its exact full text as a native title tooltip - the visible label stays as
+     rendered and the complete value stays reachable on hover. Build every such
+     node with titledEl and keep plain el for text that is already fully shown.
+     The null guard matters because title reflects a DOMString: assigning a
+     missing value would surface the literal "null" as the tooltip.
+     tests/fm-bearings-board.test.sh renders a built board and asserts these
+     exact tooltip values. */
   function titledEl(tag, cls, text) {
     var n = el(tag, cls, text);
     if (text != null) n.title = text;

--- a/.agents/skills/bearings/assets/board-template.html
+++ b/.agents/skills/bearings/assets/board-template.html
@@ -434,7 +434,12 @@ __FM_BEARINGS_BOARD_DATA__
     if (text != null) n.textContent = text;
     return n;
   }
-  function badge(tone, text) { return el("span", "fm-badge fm-badge--" + tone, text); }
+  function titledEl(tag, cls, text) {
+    var n = el(tag, cls, text);
+    n.title = text;
+    return n;
+  }
+  function badge(tone, text) { return titledEl("span", "fm-badge fm-badge--" + tone, text); }
   function utf8ByteLength(text) { return new TextEncoder().encode(text).length; }
   var CHECK_SVG = '<svg class="fm-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>';
 
@@ -477,7 +482,7 @@ __FM_BEARINGS_BOARD_DATA__
       top.appendChild(badge(item.risk === "low" ? "neutral" : "warn", "risk " + item.risk));
     } else {
       top.appendChild(badge("solid", "decision"));
-      top.appendChild(el("span", "bb-decision__repo", item.repo));
+      top.appendChild(titledEl("span", "bb-decision__repo", item.repo));
     }
     pad.appendChild(top);
 
@@ -486,7 +491,7 @@ __FM_BEARINGS_BOARD_DATA__
     if (item.type === "merge") {
       if (item.detail) pad.appendChild(el("p", "bb-decision__detail", item.detail));
       if (item.pr_url) {
-        var pr = el("a", "bb-decision__link", item.pr_url);
+        var pr = titledEl("a", "bb-decision__link", item.pr_url);
         pr.href = item.pr_url; pr.target = "_blank"; pr.rel = "noopener";
         pad.appendChild(pr);
       }
@@ -607,10 +612,10 @@ __FM_BEARINGS_BOARD_DATA__
     var row = el("div", "bb-row");
     row.appendChild(badge(t.state === "working" ? "online" : "info", t.state));
     var main = el("div", "bb-row__main");
-    main.appendChild(el("div", "bb-row__title", t.doing));
+    main.appendChild(titledEl("div", "bb-row__title", t.doing));
     /* captain-facing rows name the repo; the internal task id shows only when
        no repo is known */
-    main.appendChild(el("div", "bb-row__sub", t.kind + " · " + (t.repo || t.id)));
+    main.appendChild(titledEl("div", "bb-row__sub", t.kind + " · " + (t.repo || t.id)));
     row.appendChild(main);
     uw.appendChild(row);
   });
@@ -624,8 +629,8 @@ __FM_BEARINGS_BOARD_DATA__
     chk.innerHTML = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>';
     row.appendChild(chk);
     var main = el("div", "bb-row__main");
-    main.appendChild(el("div", "bb-row__title", t.what));
-    main.appendChild(el("div", "bb-row__sub", (t.repo || t.id) + " · " + t.owner));
+    main.appendChild(titledEl("div", "bb-row__title", t.what));
+    main.appendChild(titledEl("div", "bb-row__sub", (t.repo || t.id) + " · " + t.owner));
     row.appendChild(main);
     if (t.pr_url) {
       var a = el("a", "bb-row__pr", "#" + t.pr_url.split("/").pop());
@@ -672,10 +677,10 @@ __FM_BEARINGS_BOARD_DATA__
       row.appendChild(el("span", "bb-pick-spacer"));
     }
     var main = el("div", "bb-row__main");
-    main.appendChild(el("div", "bb-row__title", t.title));
+    main.appendChild(titledEl("div", "bb-row__title", t.title));
     /* second line keeps the title uncrowded in the half-width column */
     var chSub = t.repo || t.id;
-    main.appendChild(el("div", "bb-row__sub", t.reason ? t.reason + " · " + chSub : chSub));
+    main.appendChild(titledEl("div", "bb-row__sub", t.reason ? t.reason + " · " + chSub : chSub));
     row.appendChild(main);
     if (t.reason) row.appendChild(badge("warn", "waiting"));
     ch.appendChild(row);

--- a/.agents/skills/bearings/assets/board-template.html
+++ b/.agents/skills/bearings/assets/board-template.html
@@ -436,7 +436,7 @@ __FM_BEARINGS_BOARD_DATA__
   }
   function titledEl(tag, cls, text) {
     var n = el(tag, cls, text);
-    n.title = text;
+    if (text != null) n.title = text;
     return n;
   }
   function badge(tone, text) { return titledEl("span", "fm-badge fm-badge--" + tone, text); }

--- a/tests/fm-bearings-board.test.sh
+++ b/tests/fm-bearings-board.test.sh
@@ -271,6 +271,7 @@ render_board_nodes() {  # <board-path>
 # Pass "visible" to also require that the visible text is that same exact value.
 assert_node_title() {  # <render> <class> <want> [visible]
   local also=""
+  # shellcheck disable=SC2016 # $want is a jq variable bound by --arg below, not a shell expansion.
   [ "${4:-}" = visible ] && also=' and .text == $want'
   printf '%s' "$1" | jq -e --arg cls "$2" --arg want "$3" \
     "any(.nodes[]; (.classes | index(\$cls)) != null and .title == \$want$also)" \

--- a/tests/fm-bearings-board.test.sh
+++ b/tests/fm-bearings-board.test.sh
@@ -13,6 +13,14 @@ TMP_ROOT=$(fm_test_tmproot fm-bearings-board)
 
 command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
 
+find_chrome() {
+  local candidate
+  for candidate in google-chrome google-chrome-stable chromium chromium-browser; do
+    command -v "$candidate" 2>/dev/null && return 0
+  done
+  return 1
+}
+
 make_home() {  # <name>
   local home="$TMP_ROOT/$1" fakebin
   mkdir -p "$home/state" "$home/data"
@@ -226,6 +234,63 @@ test_build_injects_binds_then_arms() {
   pass "build injects the payload, binds any-origin, then arms the source"
 }
 
+test_rendered_truncated_text_has_full_native_tooltips() {
+  local home data board chrome dom marker escaped
+  chrome=$(find_chrome) || { printf '%s\n' "skip: Chrome or Chromium not found for rendered tooltip assertions"; return; }
+  home=$(make_home tooltips)
+  data="$home/payload.json"
+  board="$home/.lavish/bearings-board.html"
+  marker='Long & exact "captain-facing" value <must stay text> '
+  write_valid_payload "$data"
+  jq --arg marker "$marker" '
+    .captains_call[0].repo = ($marker + "decision repo") |
+    .captains_call[1].pr_url = "https://github.com/example/sample/pull/12345678901234567890?view=full&mode=review" |
+    .underway = [{
+      "id": ($marker + "underway id"),
+      "repo": "",
+      "kind": "ship",
+      "state": ($marker + "working badge"),
+      "doing": ($marker + "underway title")
+    }] |
+    .landed = [{
+      "id": ($marker + "landed id"),
+      "repo": "",
+      "what": ($marker + "landed title"),
+      "owner": ($marker + "landed owner"),
+      "pr_url": "https://github.com/example/sample/pull/98765432109876543210?view=full&mode=review"
+    }] |
+    .charted[0].repo = "" |
+    .charted[0].id = ($marker + "charted id") |
+    .charted[0].title = ($marker + "charted title") |
+    .charted[0].reason = ($marker + "charted reason")
+  ' "$data" > "$data.tmp" && mv "$data.tmp" "$data"
+
+  run_board "$home" build "$data" >/dev/null || fail "the long-text tooltip board did not build"
+  "$chrome" --headless --disable-gpu --no-sandbox --dump-dom "file://$board" > "$home/dom.html" 2>/dev/null \
+    || fail "Chrome could not render the long-text tooltip board"
+  dom="$home/dom.html"
+
+  for escaped in \
+    'Long &amp; exact &quot;captain-facing&quot; value &lt;must stay text&gt; decision repo' \
+    'https://github.com/example/sample/pull/12345678901234567890?view=full&amp;mode=review' \
+    'Long &amp; exact &quot;captain-facing&quot; value &lt;must stay text&gt; working badge' \
+    'Long &amp; exact &quot;captain-facing&quot; value &lt;must stay text&gt; underway title' \
+    'ship · Long &amp; exact &quot;captain-facing&quot; value &lt;must stay text&gt; underway id' \
+    'Long &amp; exact &quot;captain-facing&quot; value &lt;must stay text&gt; landed title' \
+    'Long &amp; exact &quot;captain-facing&quot; value &lt;must stay text&gt; landed id · Long &amp; exact &quot;captain-facing&quot; value &lt;must stay text&gt; landed owner' \
+    'https://github.com/example/sample/pull/98765432109876543210?view=full&amp;mode=review' \
+    'Long &amp; exact &quot;captain-facing&quot; value &lt;must stay text&gt; charted title' \
+    'Long &amp; exact &quot;captain-facing&quot; value &lt;must stay text&gt; charted reason · Long &amp; exact &quot;captain-facing&quot; value &lt;must stay text&gt; charted id'; do
+    grep -Fq "title=\"$escaped\"" "$dom" \
+      || fail "the rendered board omitted or altered a full native tooltip: $escaped"
+  done
+  grep -Fq '&lt;must stay text&gt;' "$dom" \
+    || fail "the tooltip payload was not HTML-escaped in the rendered board"
+  ! grep -Fq '<must stay text>' "$dom" \
+    || fail "the tooltip payload became live markup in the rendered board"
+  pass "rendered truncation-prone text exposes exact escaped native tooltips"
+}
+
 test_registration_cannot_consume_before_any_origin_binding() {
   local home data runtime origin key hold board sid show
   home=$(make_home order-proof)
@@ -373,6 +438,7 @@ test_build_refuses_a_template_without_exactly_one_slot() {
 test_path_is_stable_and_home_scoped
 test_build_refuses_malformed_payloads_before_touching_the_board
 test_build_injects_binds_then_arms
+test_rendered_truncated_text_has_full_native_tooltips
 test_registration_cannot_consume_before_any_origin_binding
 test_build_does_not_bind_or_arm_when_session_start_fails
 test_rebuild_is_idempotent_and_does_not_double_arm

--- a/tests/fm-bearings-board.test.sh
+++ b/tests/fm-bearings-board.test.sh
@@ -109,10 +109,9 @@ extract_payload() {  # <board-path>
 # asserted from what the renderer actually produced rather than from a headless
 # browser that the runner may not have. The board page is generated public
 # output and the renderer is the real consumer under test.
-render_board_nodes() {  # <board-path>
+render_board_node_json() {  # <board-path>
   local render
-  command -v node >/dev/null 2>&1 \
-    || fail "node is required to render the board for the tooltip assertions"
+  command -v node >/dev/null 2>&1 || return 4
   render=$(BOARD_PAGE="$1" node --input-type=module <<'JS'
 import { readFileSync } from "node:fs";
 
@@ -145,6 +144,7 @@ class Element {
     this.tagName = String(tag).toUpperCase();
     this.children = [];
     this.parentNode = null;
+    this.id = "";
     this.className = "";
     this.attributes = {};
     this.listeners = {};
@@ -198,9 +198,15 @@ class Element {
 }
 
 const byId = new Map();
+/* Each id node hangs off its own root so the collector below reports the id
+   node itself, not just whatever the renderer appends inside it. */
+const idRoots = [];
 for (const m of html.matchAll(/\bid="([^"]+)"/g)) {
   const node = new Element("div");
-  new Element("div").appendChild(node);
+  node.id = m[1];
+  const root = new Element("div");
+  root.appendChild(node);
+  idRoots.push(root);
   byId.set(m[1], node);
 }
 const main = new Element("main");
@@ -221,6 +227,7 @@ const nodes = [];
 const collect = (node) => node.children.forEach((child) => {
   nodes.push({
     tag: child.tagName,
+    id: child.id || null,
     classes: child.className ? child.className.split(/\s+/).filter(Boolean) : [],
     text: child.textContent,
     title: child.titleValue === undefined ? null : child.titleValue,
@@ -231,15 +238,31 @@ const collect = (node) => node.children.forEach((child) => {
 /* anything under .bb-main means the renderer bailed to its fail-closed card */
 const errored = main.children.length > 0;
 collect(main);
-byId.forEach((node) => collect(node));
+idRoots.forEach(collect);
 process.stdout.write(JSON.stringify({ errored, nodes }) + "\n");
 JS
   ) || return 1
+  printf '%s' "$render" | jq -e '.errored == false' >/dev/null || return 3
   # title reflects a DOMString, so absent text left to the DOM would surface as
   # the literal "null" - no rendered node may ever advertise that as its value.
-  printf '%s' "$render" | jq -e 'all(.nodes[]; .title != "null")' >/dev/null \
-    || fail "the rendered board exposed a stringified null as a tooltip"
-  printf '%s\n' "$render"
+  printf '%s' "$render" | jq -e 'all(.nodes[]; .title != "null")' >/dev/null || return 2
+  printf '%s' "$render" | jq -c 'del(.errored)'
+}
+
+# Render <board-path> and publish the node JSON as RENDERED_NODES. The guards
+# above run inside a command substitution, where fail would only exit the
+# subshell and let a generic caller message mask the real cause, so they report
+# through distinct exit codes that this caller turns into the exact diagnostic.
+render_board_nodes() {  # <board-path>
+  local rc
+  RENDERED_NODES=$(render_board_node_json "$1") && return 0
+  rc=$?
+  case "$rc" in
+    2) fail "the rendered board exposed a stringified null as a tooltip" ;;
+    3) fail "the renderer fell back to its fail-closed card instead of rendering the board" ;;
+    4) fail "node is required to render the board for the tooltip assertions" ;;
+    *) fail "the shipped renderer could not run over the built board" ;;
+  esac
 }
 
 # Assert a rendered node of <class> carries <want> as its exact full tooltip.
@@ -386,6 +409,7 @@ test_rendered_truncated_text_has_full_native_tooltips() {
   # repo-bearing rows, and the genuinely-no-repo rows fall back to the routing
   # id, which the charted schema restricts to a slug.
   jq --arg marker "$marker" --arg long_id "$long_id" '
+    .generated = ($marker + "generated stamp") |
     .captains_call[0].repo = ($marker + "decision repo") |
     .captains_call[1].pr_url = "https://github.com/example/sample/pull/12345678901234567890?view=full&mode=review" |
     .captains_call += [{
@@ -452,9 +476,8 @@ test_rendered_truncated_text_has_full_native_tooltips() {
   grep -qF 'value <must stay text>' "$board" \
     && fail "the built board embedded the markup-like tooltip text as live markup"
 
-  render=$(render_board_nodes "$board") || fail "the shipped renderer could not run over the built board"
-  printf '%s' "$render" | jq -e '.errored == false' >/dev/null \
-    || fail "the renderer fell back to its fail-closed card instead of rendering the board"
+  render_board_nodes "$board"
+  render=$RENDERED_NODES
 
   for entry in \
     "bb-decision__repo|${marker}decision repo" \
@@ -472,6 +495,13 @@ test_rendered_truncated_text_has_full_native_tooltips() {
     "bb-row__sub|$long_id"; do
     assert_node_title "$render" "${entry%%|*}" "${entry#*|}"
   done
+
+  # The footer provenance is nowrap inside a flex-end row, so an overlong stamp
+  # escapes past the start edge where no scrolling can reach it.
+  printf '%s' "$render" | jq -e \
+    --arg want "fm-bearings-board.v1 · ${marker}generated stamp" '
+    any(.nodes[]; .id == "bb-provenance" and .text == $want and .title == $want)
+  ' >/dev/null || fail "the footer provenance did not expose its exact full text"
 
   # Tooltips carry the payload text verbatim - the renderer must not smuggle
   # entity-escaped or truncated text into the captain-facing value.
@@ -514,10 +544,8 @@ test_rendered_decision_body_text_exposes_full_values() {
 
   run_board "$home" build "$data" >/dev/null \
     || fail "the unbreakable-token decision board did not build"
-  render=$(render_board_nodes "$board") \
-    || fail "the shipped renderer could not run over the built board"
-  printf '%s' "$render" | jq -e '.errored == false' >/dev/null \
-    || fail "the renderer fell back to its fail-closed card instead of rendering the board"
+  render_board_nodes "$board"
+  render=$RENDERED_NODES
 
   for entry in \
     "bb-decision__title|Adopt the change tracked at $token" \
@@ -561,10 +589,8 @@ test_rendered_freeform_hint_is_reachable_beyond_the_placeholder() {
   grep -qF 'own words \u003ce.g.' "$board" \
     || fail "the markup-like freeform hint was not \\u003c-escaped in the injected payload"
 
-  render=$(render_board_nodes "$board") \
-    || fail "the shipped renderer could not run over the built board"
-  printf '%s' "$render" | jq -e '.errored == false' >/dev/null \
-    || fail "the renderer fell back to its fail-closed card instead of rendering the board"
+  render_board_nodes "$board"
+  render=$RENDERED_NODES
 
   # The visible placeholder keeps the hint and the tooltip carries the same
   # exact value, so the full text is reachable without relying on the browser
@@ -606,10 +632,8 @@ test_rendered_static_badges_stay_tooltip_free() {
 
   run_board "$home" build "$data" >/dev/null \
     || fail "the dynamic-badge board did not build"
-  render=$(render_board_nodes "$board") \
-    || fail "the shipped renderer could not run over the built board"
-  printf '%s' "$render" | jq -e '.errored == false' >/dev/null \
-    || fail "the renderer fell back to its fail-closed card instead of rendering the board"
+  render_board_nodes "$board"
+  render=$RENDERED_NODES
 
   # Payload-derived badge text is unbounded, so it carries its full value.
   printf '%s' "$render" | jq -e --arg risk "risk $risk" --arg state "$state" '

--- a/tests/fm-bearings-board.test.sh
+++ b/tests/fm-bearings-board.test.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 # Behavior tests for bin/fm-bearings-board.sh: fail-closed payload validation,
 # slot-injection round-trip through the built page, bind-before-arm, and
-# idempotent re-arm of the stable board source.
+# idempotent re-arm of the stable board source, plus the built board's
+# full-text tooltip invariant, asserted by running the shipped renderer against
+# a minimal DOM shim so the coverage never depends on a headless browser.
 set -u
 
 # shellcheck source=tests/lib.sh

--- a/tests/fm-bearings-board.test.sh
+++ b/tests/fm-bearings-board.test.sh
@@ -110,7 +110,10 @@ extract_payload() {  # <board-path>
 # browser that the runner may not have. The board page is generated public
 # output and the renderer is the real consumer under test.
 render_board_nodes() {  # <board-path>
-  BOARD_PAGE="$1" node --input-type=module <<'JS'
+  local render
+  command -v node >/dev/null 2>&1 \
+    || fail "node is required to render the board for the tooltip assertions"
+  render=$(BOARD_PAGE="$1" node --input-type=module <<'JS'
 import { readFileSync } from "node:fs";
 
 const html = readFileSync(process.env.BOARD_PAGE, "utf8");
@@ -231,6 +234,22 @@ collect(main);
 byId.forEach((node) => collect(node));
 process.stdout.write(JSON.stringify({ errored, nodes }) + "\n");
 JS
+  ) || return 1
+  # title reflects a DOMString, so absent text left to the DOM would surface as
+  # the literal "null" - no rendered node may ever advertise that as its value.
+  printf '%s' "$render" | jq -e 'all(.nodes[]; .title != "null")' >/dev/null \
+    || fail "the rendered board exposed a stringified null as a tooltip"
+  printf '%s\n' "$render"
+}
+
+# Assert a rendered node of <class> carries <want> as its exact full tooltip.
+# Pass "visible" to also require that the visible text is that same exact value.
+assert_node_title() {  # <render> <class> <want> [visible]
+  local also=""
+  [ "${4:-}" = visible ] && also=' and .text == $want'
+  printf '%s' "$1" | jq -e --arg cls "$2" --arg want "$3" \
+    "any(.nodes[]; (.classes | index(\$cls)) != null and .title == \$want$also)" \
+    >/dev/null || fail "the rendered board hid the full text of .$2: $3"
 }
 
 test_path_is_stable_and_home_scoped() {
@@ -356,9 +375,7 @@ test_build_injects_binds_then_arms() {
 }
 
 test_rendered_truncated_text_has_full_native_tooltips() {
-  local home data board marker long_id render entry cls want
-  command -v node >/dev/null 2>&1 \
-    || fail "node is required to render the board for the tooltip assertions"
+  local home data board marker long_id render entry
   home=$(make_home tooltips)
   data="$home/payload.json"
   board="$home/.lavish/bearings-board.html"
@@ -453,11 +470,7 @@ test_rendered_truncated_text_has_full_native_tooltips() {
     "bb-row__title|${marker}charted title" \
     "bb-row__sub|${marker}charted reason · ${marker}charted repo" \
     "bb-row__sub|$long_id"; do
-    cls=${entry%%|*}
-    want=${entry#*|}
-    printf '%s' "$render" | jq -e --arg cls "$cls" --arg want "$want" \
-      'any(.nodes[]; (.classes | index($cls)) != null and .title == $want)' >/dev/null \
-      || fail "the rendered board omitted the exact full tooltip on .$cls: $want"
+    assert_node_title "$render" "${entry%%|*}" "${entry#*|}"
   done
 
   # Tooltips carry the payload text verbatim - the renderer must not smuggle
@@ -477,16 +490,12 @@ test_rendered_truncated_text_has_full_native_tooltips() {
     any(.nodes[]; (.classes | index("bb-decision__repo")) != null
       and .text == "" and .title == null)
   ' >/dev/null || fail "a repo-less Captain's Call item produced a tooltip for absent text"
-  printf '%s' "$render" | jq -e 'all(.nodes[]; .title != "null")' >/dev/null \
-    || fail "the rendered board exposed a stringified null as a tooltip"
 
   pass "the rendered board exposes exact full tooltips and none for absent text"
 }
 
 test_rendered_decision_body_text_exposes_full_values() {
-  local home data board token render entry cls want
-  command -v node >/dev/null 2>&1 \
-    || fail "node is required to render the board for the tooltip assertions"
+  local home data board token render entry
   home=$(make_home decision-body)
   data="$home/payload.json"
   board="$home/.lavish/bearings-board.html"
@@ -517,14 +526,9 @@ test_rendered_decision_body_text_exposes_full_values() {
     "bb-opt__label|Adopt per $token" \
     "bb-opt__hint|rationale at $token" \
     "bb-decision__detail|validation green, evidence at $token"; do
-    cls=${entry%%|*}
-    want=${entry#*|}
     # The visible label keeps the text and the tooltip carries the same exact
     # value - the affordance adds reach, it never replaces what is on screen.
-    printf '%s' "$render" | jq -e --arg cls "$cls" --arg want "$want" \
-      'any(.nodes[]; (.classes | index($cls)) != null and .title == $want and .text == $want)' \
-      >/dev/null \
-      || fail "the rendered decision card hid the full text of .$cls: $want"
+    assert_node_title "$render" "${entry%%|*}" "${entry#*|}" visible
   done
 
   # Static context keys are fully exposed, so they must stay tooltip-free.
@@ -532,16 +536,12 @@ test_rendered_decision_body_text_exposes_full_values() {
     [.nodes[] | select((.classes | index("bb-ctx__k")) != null)] as $keys
     | ($keys | length) >= 2 and ($keys | all(.title == null))
   ' >/dev/null || fail "a fully exposed context key gained a redundant tooltip"
-  printf '%s' "$render" | jq -e 'all(.nodes[]; .title != "null")' >/dev/null \
-    || fail "the rendered board exposed a stringified null as a tooltip"
 
   pass "decision card body text exposes its exact full value without hiding the label"
 }
 
 test_rendered_freeform_hint_is_reachable_beyond_the_placeholder() {
   local home data board hint render
-  command -v node >/dev/null 2>&1 \
-    || fail "node is required to render the board for the tooltip assertions"
   home=$(make_home freeform-hint)
   data="$home/payload.json"
   board="$home/.lavish/bearings-board.html"
@@ -580,16 +580,12 @@ test_rendered_freeform_hint_is_reachable_beyond_the_placeholder() {
     any(.nodes[]; (.classes | index("bb-freeform")) != null
       and .placeholder == "or answer in your own words\u2026" and .title == null)
   ' >/dev/null || fail "the default freeform placeholder gained a tooltip"
-  printf '%s' "$render" | jq -e 'all(.nodes[]; .title != "null")' >/dev/null \
-    || fail "the rendered board exposed a stringified null as a tooltip"
 
   pass "the freeform input exposes its exact full hint and none for the default"
 }
 
 test_rendered_static_badges_stay_tooltip_free() {
   local home data board risk state render
-  command -v node >/dev/null 2>&1 \
-    || fail "node is required to render the board for the tooltip assertions"
   home=$(make_home badge-tooltips)
   data="$home/payload.json"
   board="$home/.lavish/bearings-board.html"

--- a/tests/fm-bearings-board.test.sh
+++ b/tests/fm-bearings-board.test.sh
@@ -13,14 +13,6 @@ TMP_ROOT=$(fm_test_tmproot fm-bearings-board)
 
 command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
 
-find_chrome() {
-  local candidate
-  for candidate in google-chrome google-chrome-stable chromium chromium-browser; do
-    command -v "$candidate" 2>/dev/null && return 0
-  done
-  return 1
-}
-
 make_home() {  # <name>
   local home="$TMP_ROOT/$1" fakebin
   mkdir -p "$home/state" "$home/data"
@@ -110,6 +102,134 @@ EOF
 extract_payload() {  # <board-path>
   sed -n '/<script id="bearings-data" type="application\/json">/,/<\/script>/p' "$1" \
     | sed '1d;$d'
+}
+
+# Execute the shipped renderer from a built board page against a minimal DOM
+# shim and print the rendered node state as JSON, so tooltip behavior is
+# asserted from what the renderer actually produced rather than from a headless
+# browser that the runner may not have. The board page is generated public
+# output and the renderer is the real consumer under test.
+render_board_nodes() {  # <board-path>
+  BOARD_PAGE="$1" node --input-type=module <<'JS'
+import { readFileSync } from "node:fs";
+
+const html = readFileSync(process.env.BOARD_PAGE, "utf8");
+const dataBlock = html.match(
+  /<script id="bearings-data" type="application\/json">\n([\s\S]*?)\n<\/script>/);
+if (!dataBlock) throw new Error("the built board carries no bearings-data block");
+const rendererBlock = html
+  .slice(dataBlock.index + dataBlock[0].length)
+  .match(/<script>\n([\s\S]*?)\n<\/script>/);
+if (!rendererBlock) throw new Error("the built board carries no renderer script");
+
+class ClassList {
+  constructor(node) { this.node = node; }
+  tokens() {
+    return this.node.className ? this.node.className.split(/\s+/).filter(Boolean) : [];
+  }
+  write(tokens) { this.node.className = tokens.join(" "); }
+  contains(name) { return this.tokens().indexOf(name) !== -1; }
+  add(name) { if (!this.contains(name)) this.write(this.tokens().concat([name])); }
+  remove(name) { this.write(this.tokens().filter((t) => t !== name)); }
+  toggle(name, on) {
+    const want = on === undefined ? !this.contains(name) : !!on;
+    if (want) this.add(name); else this.remove(name);
+  }
+}
+
+class Element {
+  constructor(tag) {
+    this.tagName = String(tag).toUpperCase();
+    this.children = [];
+    this.parentNode = null;
+    this.className = "";
+    this.attributes = {};
+    this.listeners = {};
+    this.ownText = "";
+    this.titleValue = undefined;
+    this.rawHtml = "";
+    this.classList = new ClassList(this);
+  }
+  get textContent() {
+    return this.ownText + this.children.map((c) => c.textContent).join("");
+  }
+  set textContent(value) {
+    this.children = [];
+    this.ownText = value == null ? "" : String(value);
+  }
+  /* title reflects a DOMString, so the DOM stringifies whatever it is given -
+     that is exactly what makes a null value observable as "null". */
+  get title() { return this.titleValue === undefined ? "" : this.titleValue; }
+  set title(value) { this.titleValue = String(value); }
+  get innerHTML() { return this.rawHtml; }
+  set innerHTML(value) {
+    this.rawHtml = value == null ? "" : String(value);
+    this.children = [];
+    this.ownText = "";
+  }
+  appendChild(node) { node.parentNode = this; this.children.push(node); return node; }
+  setAttribute(name, value) { this.attributes[name] = String(value); }
+  getAttribute(name) {
+    return Object.prototype.hasOwnProperty.call(this.attributes, name)
+      ? this.attributes[name] : null;
+  }
+  addEventListener(type, fn) {
+    (this.listeners[type] = this.listeners[type] || []).push(fn);
+  }
+  matches(selector) {
+    const parts = selector.split(":");
+    const cls = parts[0].replace(/^\./, "");
+    if (cls && !this.classList.contains(cls)) return false;
+    return parts.slice(1).every((p) => (p === "checked" ? this.checked === true : false));
+  }
+  querySelectorAll(selector) {
+    const found = [];
+    const walk = (node) => node.children.forEach((child) => {
+      if (child.matches(selector)) found.push(child);
+      walk(child);
+    });
+    walk(this);
+    return found;
+  }
+  querySelector(selector) { return this.querySelectorAll(selector)[0] || null; }
+}
+
+const byId = new Map();
+for (const m of html.matchAll(/\bid="([^"]+)"/g)) {
+  const node = new Element("div");
+  new Element("div").appendChild(node);
+  byId.set(m[1], node);
+}
+const main = new Element("main");
+main.className = "bb-main";
+const dataNode = byId.get("bearings-data");
+if (!dataNode) throw new Error("the built board carries no bearings-data element");
+dataNode.textContent = dataBlock[1];
+
+globalThis.window = {};
+globalThis.document = {
+  createElement: (tag) => new Element(tag),
+  getElementById: (id) => byId.get(id) || null,
+  querySelector: (selector) => (selector === ".bb-main" ? main : null),
+};
+new Function(rendererBlock[1])();
+
+const nodes = [];
+const collect = (node) => node.children.forEach((child) => {
+  nodes.push({
+    tag: child.tagName,
+    classes: child.className ? child.className.split(/\s+/).filter(Boolean) : [],
+    text: child.textContent,
+    title: child.titleValue === undefined ? null : child.titleValue,
+  });
+  collect(child);
+});
+/* anything under .bb-main means the renderer bailed to its fail-closed card */
+const errored = main.children.length > 0;
+collect(main);
+byId.forEach((node) => collect(node));
+process.stdout.write(JSON.stringify({ errored, nodes }) + "\n");
+JS
 }
 
 test_path_is_stable_and_home_scoped() {
@@ -235,60 +355,131 @@ test_build_injects_binds_then_arms() {
 }
 
 test_rendered_truncated_text_has_full_native_tooltips() {
-  local home data board chrome dom marker escaped
-  chrome=$(find_chrome) || { printf '%s\n' "skip: Chrome or Chromium not found for rendered tooltip assertions"; return; }
+  local home data board marker long_id render entry cls want
+  command -v node >/dev/null 2>&1 \
+    || fail "node is required to render the board for the tooltip assertions"
   home=$(make_home tooltips)
   data="$home/payload.json"
   board="$home/.lavish/bearings-board.html"
   marker='Long & exact "captain-facing" value <must stay text> '
+  long_id='long-slug-legal-charted-id-that-overflows-the-half-width-charted-column-and-stays-hoverable'
   write_valid_payload "$data"
-  jq --arg marker "$marker" '
+  # Every row carries a truncation-prone value: markup-like long text on the
+  # repo-bearing rows, and the genuinely-no-repo rows fall back to the routing
+  # id, which the charted schema restricts to a slug.
+  jq --arg marker "$marker" --arg long_id "$long_id" '
     .captains_call[0].repo = ($marker + "decision repo") |
     .captains_call[1].pr_url = "https://github.com/example/sample/pull/12345678901234567890?view=full&mode=review" |
-    .underway = [{
-      "id": ($marker + "underway id"),
-      "repo": "",
-      "kind": "ship",
-      "state": ($marker + "working badge"),
-      "doing": ($marker + "underway title")
+    .captains_call += [{
+      "key": "sample-no-repo-decision",
+      "type": "decision",
+      "repo": null,
+      "title": "A decision that names no repository",
+      "options": [{ "value": "ack", "label": "Acknowledge" }]
     }] |
-    .landed = [{
-      "id": ($marker + "landed id"),
-      "repo": "",
-      "what": ($marker + "landed title"),
-      "owner": ($marker + "landed owner"),
-      "pr_url": "https://github.com/example/sample/pull/98765432109876543210?view=full&mode=review"
-    }] |
-    .charted[0].repo = "" |
-    .charted[0].id = ($marker + "charted id") |
-    .charted[0].title = ($marker + "charted title") |
-    .charted[0].reason = ($marker + "charted reason")
+    .underway = [
+      {
+        "id": "underway-with-repo",
+        "repo": ($marker + "underway repo"),
+        "kind": "ship",
+        "state": ($marker + "working badge"),
+        "doing": ($marker + "underway title")
+      },
+      {
+        "id": ($marker + "underway id"),
+        "repo": "",
+        "kind": "ship",
+        "state": "working",
+        "doing": "a short underway line"
+      }
+    ] |
+    .landed = [
+      {
+        "id": "landed-with-repo",
+        "repo": ($marker + "landed repo"),
+        "what": ($marker + "landed title"),
+        "owner": ($marker + "landed owner"),
+        "pr_url": "https://github.com/example/sample/pull/98765432109876543210?view=full&mode=review"
+      },
+      {
+        "id": ($marker + "landed id"),
+        "repo": "",
+        "what": "a short landed line",
+        "owner": ($marker + "landed owner")
+      }
+    ] |
+    .charted = [
+      {
+        "id": "charted-with-repo",
+        "repo": ($marker + "charted repo"),
+        "title": ($marker + "charted title"),
+        "reason": ($marker + "charted reason"),
+        "dispatchable": true
+      },
+      {
+        "id": $long_id,
+        "repo": "",
+        "title": "a short charted line",
+        "reason": "",
+        "dispatchable": false
+      }
+    ]
   ' "$data" > "$data.tmp" && mv "$data.tmp" "$data"
 
   run_board "$home" build "$data" >/dev/null || fail "the long-text tooltip board did not build"
-  "$chrome" --headless --disable-gpu --no-sandbox --dump-dom "file://$board" > "$home/dom.html" 2>/dev/null \
-    || fail "Chrome could not render the long-text tooltip board"
-  dom="$home/dom.html"
+  # The markup-like text stays inert data in the page, and only the renderer
+  # turns it back into an exact tooltip value.
+  grep -qF 'value \u003cmust stay text>' "$board" \
+    || fail "the markup-like tooltip text was not \\u003c-escaped in the injected payload"
+  grep -qF 'value <must stay text>' "$board" \
+    && fail "the built board embedded the markup-like tooltip text as live markup"
 
-  for escaped in \
-    'Long &amp; exact &quot;captain-facing&quot; value &lt;must stay text&gt; decision repo' \
-    'https://github.com/example/sample/pull/12345678901234567890?view=full&amp;mode=review' \
-    'Long &amp; exact &quot;captain-facing&quot; value &lt;must stay text&gt; working badge' \
-    'Long &amp; exact &quot;captain-facing&quot; value &lt;must stay text&gt; underway title' \
-    'ship · Long &amp; exact &quot;captain-facing&quot; value &lt;must stay text&gt; underway id' \
-    'Long &amp; exact &quot;captain-facing&quot; value &lt;must stay text&gt; landed title' \
-    'Long &amp; exact &quot;captain-facing&quot; value &lt;must stay text&gt; landed id · Long &amp; exact &quot;captain-facing&quot; value &lt;must stay text&gt; landed owner' \
-    'https://github.com/example/sample/pull/98765432109876543210?view=full&amp;mode=review' \
-    'Long &amp; exact &quot;captain-facing&quot; value &lt;must stay text&gt; charted title' \
-    'Long &amp; exact &quot;captain-facing&quot; value &lt;must stay text&gt; charted reason · Long &amp; exact &quot;captain-facing&quot; value &lt;must stay text&gt; charted id'; do
-    grep -Fq "title=\"$escaped\"" "$dom" \
-      || fail "the rendered board omitted or altered a full native tooltip: $escaped"
+  render=$(render_board_nodes "$board") || fail "the shipped renderer could not run over the built board"
+  printf '%s' "$render" | jq -e '.errored == false' >/dev/null \
+    || fail "the renderer fell back to its fail-closed card instead of rendering the board"
+
+  for entry in \
+    "bb-decision__repo|${marker}decision repo" \
+    "bb-decision__link|https://github.com/example/sample/pull/12345678901234567890?view=full&mode=review" \
+    "fm-badge|${marker}working badge" \
+    "bb-row__title|${marker}underway title" \
+    "bb-row__sub|ship · ${marker}underway repo" \
+    "bb-row__sub|ship · ${marker}underway id" \
+    "bb-row__title|${marker}landed title" \
+    "bb-row__sub|${marker}landed repo · ${marker}landed owner" \
+    "bb-row__sub|${marker}landed id · ${marker}landed owner" \
+    "bb-row__pr|https://github.com/example/sample/pull/98765432109876543210?view=full&mode=review" \
+    "bb-row__title|${marker}charted title" \
+    "bb-row__sub|${marker}charted reason · ${marker}charted repo" \
+    "bb-row__sub|$long_id"; do
+    cls=${entry%%|*}
+    want=${entry#*|}
+    printf '%s' "$render" | jq -e --arg cls "$cls" --arg want "$want" \
+      'any(.nodes[]; (.classes | index($cls)) != null and .title == $want)' >/dev/null \
+      || fail "the rendered board omitted the exact full tooltip on .$cls: $want"
   done
-  grep -Fq '&lt;must stay text&gt;' "$dom" \
-    || fail "the tooltip payload was not HTML-escaped in the rendered board"
-  ! grep -Fq '<must stay text>' "$dom" \
-    || fail "the tooltip payload became live markup in the rendered board"
-  pass "rendered truncation-prone text exposes exact escaped native tooltips"
+
+  # Tooltips carry the payload text verbatim - the renderer must not smuggle
+  # entity-escaped or truncated text into the captain-facing value.
+  printf '%s' "$render" | jq -e '
+    [.nodes[] | select(.title != null) | .title | select(test("must stay text"))] as $titles
+    | ($titles | length) >= 8
+      and ($titles | all(contains("<must stay text>")
+        and (contains("&lt;") | not)
+        and (contains("&amp;") | not)
+        and (contains("&quot;") | not)))
+  ' >/dev/null || fail "a rendered tooltip did not carry the exact unescaped payload text"
+
+  # A genuinely-repo-less Captain's Call item shows no repo and must not
+  # advertise a stringified "null" as its hidden full text.
+  printf '%s' "$render" | jq -e '
+    any(.nodes[]; (.classes | index("bb-decision__repo")) != null
+      and .text == "" and .title == null)
+  ' >/dev/null || fail "a repo-less Captain's Call item produced a tooltip for absent text"
+  printf '%s' "$render" | jq -e 'all(.nodes[]; .title != "null")' >/dev/null \
+    || fail "the rendered board exposed a stringified null as a tooltip"
+
+  pass "the rendered board exposes exact full tooltips and none for absent text"
 }
 
 test_registration_cannot_consume_before_any_origin_binding() {

--- a/tests/fm-bearings-board.test.sh
+++ b/tests/fm-bearings-board.test.sh
@@ -221,6 +221,7 @@ const collect = (node) => node.children.forEach((child) => {
     classes: child.className ? child.className.split(/\s+/).filter(Boolean) : [],
     text: child.textContent,
     title: child.titleValue === undefined ? null : child.titleValue,
+    placeholder: child.placeholder === undefined ? null : child.placeholder,
   });
   collect(child);
 });
@@ -537,6 +538,100 @@ test_rendered_decision_body_text_exposes_full_values() {
   pass "decision card body text exposes its exact full value without hiding the label"
 }
 
+test_rendered_freeform_hint_is_reachable_beyond_the_placeholder() {
+  local home data board hint render
+  command -v node >/dev/null 2>&1 \
+    || fail "node is required to render the board for the tooltip assertions"
+  home=$(make_home freeform-hint)
+  data="$home/payload.json"
+  board="$home/.lavish/bearings-board.html"
+  # A hint far wider than a single-line field, with markup-like and unbreakable
+  # runs: the input clips its placeholder at the field edge with no ellipsis.
+  hint='or answer in your own words <e.g. "name the branch"> https://github.com/example/sample/compare/f170ced...aba38e6-and-an-unbreakable-tail'
+  write_valid_payload "$data"
+  jq --arg hint "$hint" '
+    .captains_call[0].allow_freeform = true |
+    .captains_call[0].freeform_hint = $hint |
+    .captains_call[1].allow_freeform = true |
+    del(.captains_call[1].freeform_hint)
+  ' "$data" > "$data.tmp" && mv "$data.tmp" "$data"
+
+  run_board "$home" build "$data" >/dev/null \
+    || fail "the long-freeform-hint board did not build"
+  grep -qF 'own words \u003ce.g.' "$board" \
+    || fail "the markup-like freeform hint was not \\u003c-escaped in the injected payload"
+
+  render=$(render_board_nodes "$board") \
+    || fail "the shipped renderer could not run over the built board"
+  printf '%s' "$render" | jq -e '.errored == false' >/dev/null \
+    || fail "the renderer fell back to its fail-closed card instead of rendering the board"
+
+  # The visible placeholder keeps the hint and the tooltip carries the same
+  # exact value, so the full text is reachable without relying on the browser
+  # drawing the whole placeholder.
+  printf '%s' "$render" | jq -e --arg hint "$hint" '
+    any(.nodes[]; (.classes | index("bb-freeform")) != null
+      and .placeholder == $hint and .title == $hint)
+  ' >/dev/null || fail "the freeform input did not expose its exact full hint"
+
+  # The built-in fallback placeholder is short, fixed, and fully shown, so it
+  # must not gain a tooltip - and an absent hint must never surface as "null".
+  printf '%s' "$render" | jq -e '
+    any(.nodes[]; (.classes | index("bb-freeform")) != null
+      and .placeholder == "or answer in your own words\u2026" and .title == null)
+  ' >/dev/null || fail "the default freeform placeholder gained a tooltip"
+  printf '%s' "$render" | jq -e 'all(.nodes[]; .title != "null")' >/dev/null \
+    || fail "the rendered board exposed a stringified null as a tooltip"
+
+  pass "the freeform input exposes its exact full hint and none for the default"
+}
+
+test_rendered_static_badges_stay_tooltip_free() {
+  local home data board risk state render
+  command -v node >/dev/null 2>&1 \
+    || fail "node is required to render the board for the tooltip assertions"
+  home=$(make_home badge-tooltips)
+  data="$home/payload.json"
+  board="$home/.lavish/bearings-board.html"
+  risk='elevated because the migration touches every tracked payload validator at once'
+  state='waiting on the authenticated fork push before the review gate can advance'
+  write_valid_payload "$data"
+  jq --arg risk "$risk" --arg state "$state" '
+    .captains_call[1].risk = $risk |
+    .underway = [{
+      "id": "underway-dynamic-state",
+      "repo": "sample",
+      "kind": "ship",
+      "state": $state,
+      "doing": "a short underway line"
+    }] |
+    .charted[0].reason = "blocked"
+  ' "$data" > "$data.tmp" && mv "$data.tmp" "$data"
+
+  run_board "$home" build "$data" >/dev/null \
+    || fail "the dynamic-badge board did not build"
+  render=$(render_board_nodes "$board") \
+    || fail "the shipped renderer could not run over the built board"
+  printf '%s' "$render" | jq -e '.errored == false' >/dev/null \
+    || fail "the renderer fell back to its fail-closed card instead of rendering the board"
+
+  # Payload-derived badge text is unbounded, so it carries its full value.
+  printf '%s' "$render" | jq -e --arg risk "risk $risk" --arg state "$state" '
+    ([.nodes[] | select((.classes | index("fm-badge")) != null)]) as $badges
+    | ($badges | any(.text == $risk and .title == $risk))
+      and ($badges | any(.text == $state and .title == $state))
+  ' >/dev/null || fail "a dynamic badge did not expose its exact full text"
+
+  # Fixed short badge literals are always fully drawn, so they stay tooltip-free.
+  printf '%s' "$render" | jq -e '
+    ([.nodes[] | select((.classes | index("fm-badge")) != null)]) as $badges
+    | (["decision", "checks green", "waiting"] | all(. as $literal
+        | $badges | any(.text == $literal) and all(.text != $literal or .title == null)))
+  ' >/dev/null || fail "a fixed, fully visible badge literal gained a redundant tooltip"
+
+  pass "dynamic badges expose full text while fixed badge literals stay tooltip-free"
+}
+
 test_registration_cannot_consume_before_any_origin_binding() {
   local home data runtime origin key hold board sid show
   home=$(make_home order-proof)
@@ -686,6 +781,8 @@ test_build_refuses_malformed_payloads_before_touching_the_board
 test_build_injects_binds_then_arms
 test_rendered_truncated_text_has_full_native_tooltips
 test_rendered_decision_body_text_exposes_full_values
+test_rendered_freeform_hint_is_reachable_beyond_the_placeholder
+test_rendered_static_badges_stay_tooltip_free
 test_registration_cannot_consume_before_any_origin_binding
 test_build_does_not_bind_or_arm_when_session_start_fails
 test_rebuild_is_idempotent_and_does_not_double_arm

--- a/tests/fm-bearings-board.test.sh
+++ b/tests/fm-bearings-board.test.sh
@@ -482,6 +482,61 @@ test_rendered_truncated_text_has_full_native_tooltips() {
   pass "the rendered board exposes exact full tooltips and none for absent text"
 }
 
+test_rendered_decision_body_text_exposes_full_values() {
+  local home data board token render entry cls want
+  command -v node >/dev/null 2>&1 \
+    || fail "node is required to render the board for the tooltip assertions"
+  home=$(make_home decision-body)
+  data="$home/payload.json"
+  board="$home/.lavish/bearings-board.html"
+  # One unbreakable token wider than the single-column card: without a
+  # full-text affordance the card's overflow:hidden clips it outright.
+  token='https://github.com/example/sample/pull/1234#issuecomment-2938471029384-with-an-unbreakable-tail'
+  write_valid_payload "$data"
+  jq --arg token "$token" '
+    .captains_call[0].title = ("Adopt the change tracked at " + $token) |
+    .captains_call[0].about = ("see " + $token) |
+    .captains_call[0].decide = ("compare against " + $token) |
+    .captains_call[0].options[0].label = ("Adopt per " + $token) |
+    .captains_call[0].options[0].hint = ("rationale at " + $token) |
+    .captains_call[1].detail = ("validation green, evidence at " + $token)
+  ' "$data" > "$data.tmp" && mv "$data.tmp" "$data"
+
+  run_board "$home" build "$data" >/dev/null \
+    || fail "the unbreakable-token decision board did not build"
+  render=$(render_board_nodes "$board") \
+    || fail "the shipped renderer could not run over the built board"
+  printf '%s' "$render" | jq -e '.errored == false' >/dev/null \
+    || fail "the renderer fell back to its fail-closed card instead of rendering the board"
+
+  for entry in \
+    "bb-decision__title|Adopt the change tracked at $token" \
+    "bb-ctx__v|see $token" \
+    "bb-ctx__v|compare against $token" \
+    "bb-opt__label|Adopt per $token" \
+    "bb-opt__hint|rationale at $token" \
+    "bb-decision__detail|validation green, evidence at $token"; do
+    cls=${entry%%|*}
+    want=${entry#*|}
+    # The visible label keeps the text and the tooltip carries the same exact
+    # value - the affordance adds reach, it never replaces what is on screen.
+    printf '%s' "$render" | jq -e --arg cls "$cls" --arg want "$want" \
+      'any(.nodes[]; (.classes | index($cls)) != null and .title == $want and .text == $want)' \
+      >/dev/null \
+      || fail "the rendered decision card hid the full text of .$cls: $want"
+  done
+
+  # Static context keys are fully exposed, so they must stay tooltip-free.
+  printf '%s' "$render" | jq -e '
+    [.nodes[] | select((.classes | index("bb-ctx__k")) != null)] as $keys
+    | ($keys | length) >= 2 and ($keys | all(.title == null))
+  ' >/dev/null || fail "a fully exposed context key gained a redundant tooltip"
+  printf '%s' "$render" | jq -e 'all(.nodes[]; .title != "null")' >/dev/null \
+    || fail "the rendered board exposed a stringified null as a tooltip"
+
+  pass "decision card body text exposes its exact full value without hiding the label"
+}
+
 test_registration_cannot_consume_before_any_origin_binding() {
   local home data runtime origin key hold board sid show
   home=$(make_home order-proof)
@@ -630,6 +685,7 @@ test_path_is_stable_and_home_scoped
 test_build_refuses_malformed_payloads_before_touching_the_board
 test_build_injects_binds_then_arms
 test_rendered_truncated_text_has_full_native_tooltips
+test_rendered_decision_body_text_exposes_full_values
 test_registration_cannot_consume_before_any_origin_binding
 test_build_does_not_bind_or_arm_when_session_start_fails
 test_rebuild_is_idempotent_and_does_not_double_arm


### PR DESCRIPTION
## Summary

- expose exact full text through native titles for clipping-prone Bearings board content
- retain visible labels, mobile wrapping, keyboard behavior, and Lavish interactions
- add deterministic headless-free renderer regressions covering long and markup-like payloads

## Validation

- no-mistakes review completed after accepted tooltip decisions
- targeted Bearings board tests passed, including real-browser visual verification
- pinned ShellCheck 0.11.0 and actionlint 1.7.12 passed through `bin/fm-lint.sh`

The branch was pushed by no-mistakes through the authenticated fork. This PR is intentionally not merged.