### PR TITLE
Clear inherited PI_CODING_AGENT from prime-agent launches

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -84,7 +84,7 @@ The daemon constructs every current injection as the `away-supervisor` kind owne
 The bare `FM_INJECT_MARK` form remains accepted for legacy daemon escalations during rollout.
 U+2063 has no normal keyboard keystroke and survives terminal transport as UTF-8 text.
 This is how firstmate tells a daemon escalation apart from a real message in the same pane.
-The operational prefix travels with the message text; it does not rely on harness-level typed-vs-injected detection, which is not portable across claude, codex, opencode, pi, pi-signed, grok, and kimi.
+The operational prefix travels with the message text; it does not rely on harness-level typed-vs-injected detection, which is not portable across claude, codex, opencode, pi, pi-signed, prime-agent, grok, and kimi.
 
 ## Busy-guard and composer guard
 

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -323,6 +323,7 @@ Firstmate keeps it crewmate/scout-only because Prime 0.8.0 does not emit Pi's `a
 | Detection | Exact `prime-agent` executable or package ancestry precedes the shared `PI_CODING_AGENT=true` fallback because `AI_AGENT=pi` is not an identity signal. |
 
 Keep the brief as one positional argument through the canonical `fm-operational-input.sh encode launch-brief` envelope.
+The launch clears stale foreign markers (`PI_MODEL`, `PI_CODING_AGENT`, `AI_AGENT`, `FM_PI_HARNESS`) that a Pi-family primary leaks into the spawn environment, because a worker inherited the primary's `PI_MODEL` and self-reported the wrong model (verified live 2026-08-24); Prime sets its own `PI_CODING_AGENT=true` for children, so clearing the inherited value cannot blind ancestry-based detection.
 Prime accepts `--model <id>`, repeatable `-e`, and `--thinking off|minimal|low|medium|high|xhigh|max`; Firstmate routes only its shared low-through-max effort axis.
 A live `--thinking low` launch rendered `high` in Prime's footer, so treat the 0.8.0 effective-level behavior as unconfirmed even though the CLI accepts and Firstmate preserves the flag.
 The 2026-08-23 supervised Symphony trial inherited six Jurisfera-specific continual-harness memories, which is cross-project global-memory leakage inside Prime rather than Firstmate task context.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -3,7 +3,7 @@ name: harness-adapters
 description: >-
   Agent-only reference for firstmate harness operations.
   Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.
-  Contains verified facts for claude, codex, opencode, pi, pi-signed, grok, kimi, cursor, and muse.
+  Contains verified facts for claude, codex, opencode, pi, pi-signed, prime-agent, grok, kimi, cursor, and muse.
 user-invocable: false
 metadata:
   internal: true
@@ -45,8 +45,9 @@ If the captain asks for a new harness, propose verifying it first: spawn a trivi
 
 ## Detection
 
-`bin/fm-harness.sh` prints firstmate's own harness, using verified env markers first and then process ancestry.
+`bin/fm-harness.sh` prints firstmate's own harness, using unambiguous env markers first, narrow ancestry disambiguation for shared markers, and then the remaining markers and ancestry.
 Within the Pi family, only the exact launch-boundary marker `FM_PI_HARNESS=pi-signed` alongside `PI_CODING_AGENT=true` selects the signed identity; unmarked shared launcher ancestry remains `pi`.
+Prime Agent also sets `PI_CODING_AGENT=true` and reports `AI_AGENT=pi`, so `bin/fm-harness.sh` checks exact `prime-agent` executable ancestry before falling back to Pi's shared marker.
 `bin/fm-harness.sh crew` resolves the effective crewmate harness from `config/crew-harness` (absent or `default` -> own).
 `bin/fm-harness.sh secondmate` resolves the secondmate-launch harness through the chain `config/secondmate-harness` -> `config/crew-harness` -> own, so an unset `config/secondmate-harness` matches the crew harness.
 `bin/fm-spawn.sh` uses `crew` mode for a crewmate/scout launch and `secondmate` mode for a `--secondmate` launch, re-resolving on every spawn so the split is durable across respawns; an explicit per-spawn harness arg overrides either.
@@ -129,6 +130,7 @@ The supported launch-profile flags below are verified locally; each row records 
 | codex | `--model <model>` | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh>"'` | Verified on codex-cli 0.142.1. The installed binary schema contains `model_reasoning_effort`, the active config uses it, and the bundled model catalog advertises only low/medium/high/xhigh. `max` is omitted. |
 | grok | `--model <model>` | `--reasoning-effort <low\|medium\|high>` | Verified on grok 0.2.99 (2026-07-13). `--effort` is an alias, but firstmate's profile axis is reasoning effort. As of 0.2.99 the ceiling is `high`; both `xhigh` and `max` are rejected with `use one of: high, medium, low`, so firstmate omits them. |
 | pi / pi-signed | `--model <model>` | `--thinking <low\|medium\|high\|xhigh\|max>` | Verified 2026-07-27 on Pi and pi-signed 0.82.0. Both expose the same accepted thinking levels and completed the same model-qualified max-thinking smoke. |
+| prime-agent | `--model <model>` | `--thinking <low\|medium\|high\|xhigh\|max>` | Verified 2026-08-23 on Prime Agent 0.8.0; `off` and `minimal` stay outside Firstmate's shared vocabulary, and the Prime section records the effective-level caveat. |
 | opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |
 | kimi | `--model <model>` | none | Verified 2026-07-25 on Kimi Code CLI 0.29.1. |
 | cursor | `--model <model>` | none | Verified 2026-08-11 on Cursor Agent CLI 2026.08.11-e8db854. No effort flag exists, so firstmate records the requested effort in task metadata and omits it from the launch. Validate ids against `cursor-agent --list-models` rather than assuming a low/medium/high family: the live catalog carries only `-high` Grok ids. |
@@ -149,6 +151,7 @@ Use the discovery surface in the current authenticated environment because suppo
 | codex | Open the current interactive session's `/model` picker. |
 | opencode | Run `opencode models [provider]`, which lists available provider/model identifiers. |
 | pi / pi-signed | Run the selected executable as `<executable> --list-models [search]`; Pi's installed `docs/models.md` owns how built-in, extension-registered, and custom provider/model entries reach that list. |
+| prime-agent | Run `prime-agent model list`; `prime-agent --help` owns the accepted `--model <id>` input shape. |
 | grok | Run `grok models`, which lists the models available to the current Grok installation and account. |
 | kimi | Run `kimi provider list --json`, which lists the current provider and model configuration. |
 | cursor | Run `cursor-agent --list-models` (or the legacy `agent --list-models`), which lists the ids available to the current Cursor account. `cursor` is not the CLI name. |
@@ -170,6 +173,7 @@ Natural language is acceptable if uncertain.
 - codex: `$<skill>`, for example `$no-mistakes`; `/<skill>` is claude-only and codex rejects it as "Unrecognized command".
 - opencode: no separate verified skill invocation beyond normal slash-command behavior; use natural language if the exact skill command is uncertain.
 - pi and pi-signed: no separate verified skill invocation beyond normal command behavior; use natural language if the exact skill command is uncertain.
+- prime-agent: `/skill:<name>`, for example `/skill:no-mistakes`; it discovers Agent Skills from `~/.agents/skills` and project `.agents/skills` roots.
 - grok: `/<skill>`, for example `/no-mistakes` (same form as claude). Verified end to end: grok discovers the user-level `no-mistakes` skill, `/no-mistakes` invokes it, and grok drives a real `no-mistakes axi run`. Like codex's `$`/`/` popups, typing `/<skill>` opens grok's slash-autocomplete, so a too-fast Enter selects the popup entry instead of sending, and for an argument-taking command (like `/no-mistakes`'s optional task-first argument) that first Enter only expands the popup selection into an argument-hint placeholder rather than submitting - a genuine second Enter is required (see the grok section below for the 2026-07-03 incident and fix). `fm_tmux_submit_core`'s retried Enter (used by `fm-send` on the tmux backend) handles this through the shared structural composer classifier; the herdr backend needed a dedicated fix (`fm_backend_herdr_composer_state`, docs/herdr-backend.md) because its prior delta-based verification false-positived on that same popup-close content change.
 - kimi: `/<skill>`, for example `/no-mistakes`.
 - cursor: `/<skill>`, for example `/no-mistakes`. Cursor discovers firstmate's user-level skills. Its slash popup swallows the first Enter, so a genuine second Enter submits; the shared submit retry handles it.
@@ -302,6 +306,27 @@ Pi's primary watcher protocol also requires the tracked `.pi/extensions/fm-prima
 The model arms through `fm_watch_arm_pi`, never a foreground bash arm; the watcher tool result and clean-exit fallback are owned by `docs/supervision-protocols/pi.md`.
 `bin/fm-session-start.sh` reports when the live Pi-family session has not loaded both the turn-end guard and watcher extensions, and points at the selected executable after project trust as the fix, with `-e` as a trust-free fallback.
 When a secondmate is launched on Pi or pi-signed, `fm-spawn.sh --secondmate` launches the selected executable with both `-e .pi/extensions/fm-primary-turnend-guard.ts` and `-e .pi/extensions/fm-primary-pi-watch.ts`, both already present in the secondmate home's git worktree.
+
+## prime-agent (VERIFIED CREWMATE/SCOUT 2026-08-23, Prime Agent 0.8.0)
+
+Prime Agent is a Pi-family CLI with its own executable identity and lifecycle surface.
+Firstmate keeps it crewmate/scout-only because Prime 0.8.0 does not emit Pi's `agent_settled` event and its primary watcher extensions have not been verified against Prime's `agent_end` boundary.
+`bin/fm-spawn.sh` refuses `--secondmate` rather than assuming Pi's primary supervision contract.
+
+| Fact | Value |
+|---|---|
+| Busy state | The Firstmate-owned `prime-ext` extension records `agent_start` as busy and Prime's `agent_end` as idle, while `turn_end` remains the watcher notification touch; Prime 0.8.0 loaded the absolute `-e` extension from outside the project without a trust dialog and did not emit `agent_settled`. |
+| Exit command | `/quit`; a session-enabled exit prints `Resume this session with: prime-agent --resume <id>`. |
+| Interrupt | Single Escape; a live Python tool call stopped and the extension emitted `turn_end` followed by `agent_end`. |
+| Skill invocation | `/skill:<name>`, for example `/skill:no-mistakes`. |
+| Composer | A bordered shell-glyph composer with `>` and a dark truecolor idle suggestion such as `Try "refactor @<filepath>"` is already covered by the shared bordered-placeholder classifier, while elapsed `Thinking · Ns`, `Waiting · Ns`, and `Executing · Ns` spinners are delivery acknowledgements rather than worker state. |
+| Detection | Exact `prime-agent` executable or package ancestry precedes the shared `PI_CODING_AGENT=true` fallback because `AI_AGENT=pi` is not an identity signal. |
+
+Keep the brief as one positional argument through the canonical `fm-operational-input.sh encode launch-brief` envelope.
+Prime accepts `--model <id>`, repeatable `-e`, and `--thinking off|minimal|low|medium|high|xhigh|max`; Firstmate routes only its shared low-through-max effort axis.
+A live `--thinking low` launch rendered `high` in Prime's footer, so treat the 0.8.0 effective-level behavior as unconfirmed even though the CLI accepts and Firstmate preserves the flag.
+The 2026-08-23 supervised Symphony trial inherited six Jurisfera-specific continual-harness memories, which is cross-project global-memory leakage inside Prime rather than Firstmate task context.
+Treat Prime memory as potentially cross-project until Prime scopes or filters that store, and rely on the task brief plus repository evidence for project facts.
 
 ## grok (VERIFIED 2026-06-29, grok 0.2.73; slash-submit re-verified 2026-07-03 on 0.2.82; reasoning-effort ceiling re-verified 2026-07-13 on 0.2.99; exit paths re-verified 2026-07-19 on grok 0.2.103)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,7 +189,7 @@ A silent bootstrap section needs no action; for any printed actionable diagnosti
 ## 4. Harness and runtime dispatch
 
 Load `harness-adapters` before every spawn or recovery and before trust handling, skill invocation, interrupt, exit, resume, or adapter verification.
-The verified harnesses are `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, `kimi`, and `cursor`, plus `muse` for crewmates and scouts only; never dispatch on an unverified adapter.
+The verified harnesses are `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, `kimi`, and `cursor`, plus `prime-agent` and `muse` for crewmates and scouts only; never dispatch on an unverified adapter.
 If static `config/crew-harness` or `config/secondmate-harness` names an unverified adapter, report it and fall back only to a verified adapter rather than launching it.
 
 `docs/configuration.md` owns dispatch-profile and runtime-backend schemas, `bin/fm-harness.sh` owns static resolution, and `bin/fm-spawn.sh` owns launch flags and fail-closed validation.

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -170,7 +170,7 @@ fm_backend_tmux_classify_process_name() {  # <path> [argv0] -> agent|shell|other
     # cannot carry it either: ~/.local/bin/muse-bin-<version> has no `muse` path
     # COMPONENT, so the fm_harness_path_name fallback below never fires for it.
     muse|muse-bin-*) printf 'agent' ;;
-    *claude*|*codex*|*opencode*|*grok*|*kimi*|pi|pi-signed|pi-launcher|Pi) printf 'agent' ;;
+    *claude*|*codex*|*opencode*|*grok*|*kimi*|prime-agent|pi|pi-signed|pi-launcher|Pi) printf 'agent' ;;
     zsh|bash|sh|dash|ash|ksh|mksh|tcsh|csh|fish) printf 'shell' ;;
     *)
       if fm_harness_path_name "$path" >/dev/null || fm_harness_path_name "$argv0" >/dev/null; then

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -1000,14 +1000,14 @@ crew_dispatch_validate() {
     return 0
   fi
   err=$(jq -r '
-    def verified($h): ["claude","codex","opencode","pi","pi-signed","grok","kimi","cursor","muse"] | index($h);
+    def verified($h): ["claude","codex","opencode","pi","pi-signed","prime-agent","grok","kimi","cursor","muse"] | index($h);
     def effort_ok($h; $e):
       if $e == null then true
       elif ($e | type) != "string" then false
       elif $h == "claude" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "codex" then (["low","medium","high","xhigh"] | index($e))
       elif $h == "grok" then (["low","medium","high"] | index($e))
-      elif $h == "pi" or $h == "pi-signed" then (["low","medium","high","xhigh","max"] | index($e))
+      elif $h == "pi" or $h == "pi-signed" or $h == "prime-agent" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "muse" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "opencode" or $h == "kimi" or $h == "cursor" then false
       else true

--- a/bin/fm-busy-lib.sh
+++ b/bin/fm-busy-lib.sh
@@ -29,6 +29,7 @@
 # task's recorded harness classifies unknown, so one adapter's writer can
 # never classify another adapter):
 #   pi-ext           Pi/pi-signed per-task extension (agent_start/agent_settled)
+#   prime-ext        Prime Agent per-task extension (agent_start/agent_end)
 #   opencode-plugin  OpenCode per-task plugin (session.status)
 #   claude-hook      Claude lifecycle hooks (UserPromptSubmit/Stop/StopFailure/SessionEnd)
 #   codex-hook, codex-appserver  reserved: Codex, gated by
@@ -192,6 +193,7 @@ fm_busy_sources_for_harness() {  # <harness>
       ;;
     opencode*) adapter=opencode-plugin ;;
     pi|pi-signed) adapter=pi-ext ;;
+    prime-agent) adapter=prime-ext ;;
     kimi*)
       fm_busy_kimi_verified || { printf ''; return 0; }
       adapter='kimi-wire kimi-hook'

--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -311,11 +311,12 @@ fm_composer_strip_ghost() {
 # part of that union for the same reason the others are: without it a cursor
 # submit could never be acknowledged, because cursor parks its terminal cursor
 # outside its composer and the composer verdict is therefore always `unknown`.
-FM_DELIVERY_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel|ctrl\+c to stop'
+FM_DELIVERY_BUSY_REGEX_DEFAULT='esc (to )?interrupt|Working\.\.\.|Ctrl\+c:cancel|ctrl\+c to stop|(Thinking|Waiting|Executing)[[:space:]]+·[[:space:]]+[0-9]+[smh]'
 FM_DELIVERY_CLAUDE_BUSY_REGEX_DEFAULT='esc to interrupt|…[[:space:]]+\([0-9]+[smh]'
 FM_DELIVERY_CODEX_BUSY_REGEX_DEFAULT='esc to interrupt'
 FM_DELIVERY_OPENCODE_BUSY_REGEX_DEFAULT='esc interrupt'
 FM_DELIVERY_PI_BUSY_REGEX_DEFAULT='Working\.\.\.'
+FM_DELIVERY_PRIME_BUSY_REGEX_DEFAULT='(Thinking|Waiting|Executing)[[:space:]]+·[[:space:]]+[0-9]+[smh]'
 FM_DELIVERY_GROK_BUSY_REGEX_DEFAULT='Ctrl\+c:cancel'
 # cursor-agent's busy footer. The TOKEN is matched, not the spinner verb: the
 # same version rendered both `Working` and `Running` beside its braille spinner
@@ -338,6 +339,7 @@ fm_busy_lines_match() {  # [harness]
       codex) regex=$FM_DELIVERY_CODEX_BUSY_REGEX_DEFAULT ;;
       opencode) regex=$FM_DELIVERY_OPENCODE_BUSY_REGEX_DEFAULT ;;
       pi|pi-signed) regex=$FM_DELIVERY_PI_BUSY_REGEX_DEFAULT ;;
+      prime-agent) regex=$FM_DELIVERY_PRIME_BUSY_REGEX_DEFAULT ;;
       grok) regex=$FM_DELIVERY_GROK_BUSY_REGEX_DEFAULT ;;
       kimi) regex=$FM_DELIVERY_KIMI_BUSY_REGEX_DEFAULT ;;
       cursor) regex=$FM_DELIVERY_CURSOR_BUSY_REGEX_DEFAULT ;;

--- a/bin/fm-control-lib.sh
+++ b/bin/fm-control-lib.sh
@@ -35,10 +35,11 @@
 #      backend is refused rather than performed blind.
 #
 # `resume` is deliberately NOT a verb. It is not deterministic across the
-# verified adapters: codex and grok resume only from a session id printed at
-# exit, opencode resumes the most recent session for the cwd with --continue,
-# and claude, pi, pi-signed, and kimi have no verified pane-resume contract at
-# all. `relaunch` covers the same need deterministically for every adapter,
+# verified adapters: codex, grok, and prime-agent resume only from a session id
+# printed at exit, opencode resumes the most recent session for the cwd with
+# --continue, while claude, pi, pi-signed, and kimi have no verified pane-resume
+# contract at all. `relaunch` covers the same
+# need deterministically for every adapter,
 # because the brief on disk - not a harness-private session - is the durable
 # instruction.
 
@@ -63,7 +64,7 @@ fm_control_verb_allowed() {  # <verb>
 # than guessed at, exactly as a spawn on it would be.
 fm_control_harness_supported() {  # <harness>
   case "${1-}" in
-    claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|muse) return 0 ;;
+    claude|codex|opencode|pi|pi-signed|prime-agent|grok|kimi|cursor|muse) return 0 ;;
   esac
   return 1
 }
@@ -80,6 +81,7 @@ fm_control_harness_family() {  # <recorded-harness>
   case "${1-}" in
     pi) printf 'pi' ;;
     pi-signed) printf 'pi-signed' ;;
+    prime-agent) printf 'prime-agent' ;;
     claude*) printf 'claude' ;;
     codex*) printf 'codex' ;;
     opencode*) printf 'opencode' ;;
@@ -91,9 +93,10 @@ fm_control_harness_family() {  # <recorded-harness>
   esac
 }
 
-# Which task kinds an adapter is verified to run. muse is a crewmate/scout
-# adapter only: it has no primary supervision protocol, and bin/fm-spawn.sh
-# refuses a --secondmate launch on it. The control plane
+# Which task kinds an adapter is verified to run. muse and prime-agent are
+# crewmate/scout adapters only: neither has a verified primary supervision
+# protocol, and bin/fm-spawn.sh refuses a --secondmate launch on either.
+# The control plane
 # asks this BEFORE it stops anything, so an incompatible relaunch target is
 # refused while the current agent is still running rather than after it has
 # been stopped.
@@ -101,7 +104,7 @@ fm_control_harness_supports_kind() {  # <harness> <kind>
   local harness=${1-} kind=${2-}
   fm_control_harness_supported "$harness" || return 1
   case "$harness" in
-    muse) [ "$kind" != secondmate ] || return 1 ;;
+    muse|prime-agent) [ "$kind" != secondmate ] || return 1 ;;
   esac
   return 0
 }
@@ -110,7 +113,7 @@ fm_control_harness_supports_kind() {  # <harness> <kind>
 # whose Esc only moves focus to the scrollback; grok cancels on Ctrl+C.
 fm_control_interrupt_key() {  # <harness>
   case "${1-}" in
-    claude|codex|opencode|pi|pi-signed|kimi|cursor|muse) printf 'Escape' ;;
+    claude|codex|opencode|pi|pi-signed|prime-agent|kimi|cursor|muse) printf 'Escape' ;;
     grok) printf 'C-c' ;;
     *) return 1 ;;
   esac
@@ -121,7 +124,7 @@ fm_control_interrupt_key() {  # <harness>
 fm_control_interrupt_repeat() {  # <harness>
   case "${1-}" in
     opencode) printf '2' ;;
-    claude|codex|pi|pi-signed|grok|kimi|cursor|muse) printf '1' ;;
+    claude|codex|pi|pi-signed|prime-agent|grok|kimi|cursor|muse) printf '1' ;;
     *) return 1 ;;
   esac
 }
@@ -139,7 +142,7 @@ fm_control_interrupt_repeat() {  # <harness>
 fm_control_interrupt_clear_key() {  # <harness>
   case "${1-}" in
     muse) printf 'C-u' ;;
-    claude|codex|opencode|pi|pi-signed|grok|kimi|cursor) ;;
+    claude|codex|opencode|pi|pi-signed|prime-agent|grok|kimi|cursor) ;;
     *) return 1 ;;
   esac
 }
@@ -151,7 +154,7 @@ fm_control_interrupt_ack_source() {  # <harness>
     # after an interrupt was measured as variable - sometimes seconds, sometimes
     # not within 20 - so a cancellation claim built on it would be unreliable.
     # Normal turn completion is prompt, which is what the busy fold depends on.
-    claude|codex|opencode|pi|pi-signed|grok|kimi|cursor) printf 'none' ;;
+    claude|codex|opencode|pi|pi-signed|prime-agent|grok|kimi|cursor) printf 'none' ;;
     *) return 1 ;;
   esac
 }
@@ -160,7 +163,7 @@ fm_control_interrupt_ack_source() {  # <harness>
 fm_control_exit_command() {  # <harness>
   case "${1-}" in
     claude|opencode|grok|kimi|cursor|muse) printf '/exit' ;;
-    codex|pi|pi-signed) printf '/quit' ;;
+    codex|pi|pi-signed|prime-agent) printf '/quit' ;;
     *) return 1 ;;
   esac
 }
@@ -207,6 +210,7 @@ fm_control_harness_wiring_paths() {  # <harness> <worktree> <state-dir> <id>
     claude) printf '%s\n' "$wt/.claude/settings.local.json" ;;
     opencode) printf '%s\n' "$wt/.opencode/plugins/fm-busy-state.js" ;;
     pi|pi-signed) printf '%s\n' "$state/$id.pi-ext.ts" ;;
+    prime-agent) printf '%s\n' "$state/$id.prime-ext.ts" ;;
     grok)
       printf '%s\n' "$wt/.fm-grok-turnend"
       printf '%s\n' "$state/$id.grok-turnend-token"

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -174,7 +174,7 @@ shift 2
 if ! fm_control_verb_allowed "$VERB"; then
   {
     if [ "$VERB" = resume ]; then
-      echo "error: 'resume' is not a control verb: resuming an exited agent is not deterministic across the verified adapters (codex and grok need a session id printed at exit, opencode continues the most recent session for the cwd, and claude, pi, pi-signed, and kimi have no verified pane-resume contract). Use 'relaunch', which carries the brief plus a progress note into a fresh agent on any adapter."
+      echo "error: 'resume' is not a control verb: resuming an exited agent is not deterministic across the verified adapters (codex, grok, and prime-agent need a session id printed at exit, opencode continues the most recent session for the cwd, and claude, pi, pi-signed, and kimi have no verified pane-resume contract). Use 'relaunch', which carries the brief plus a progress note into a fresh agent on any adapter."
     else
       echo "error: '$VERB' is not a control verb"
     fi

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Detect the agent harness this process tree runs on.
-# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|muse|unknown
+# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|pi-signed|prime-agent|grok|kimi|cursor|muse|unknown
 #        fm-harness.sh crew             print the effective CREWMATE harness
 #                                        (config/crew-harness; "default" resolves to own)
 #        fm-harness.sh secondmate       print the harness the PRIMARY uses to launch
@@ -18,8 +18,9 @@
 # harness only, no model/effort. Only the first non-empty, non-comment line is parsed.
 # Model/effort come ONLY from this file - config/crew-harness stays a bare adapter
 # name and is never parsed for a model.
-# Detection layers: verified environment markers first, then process ancestry.
-# Record each newly verified env marker here.
+# Detection layers: unambiguous environment markers first, narrow ancestry
+# disambiguation for shared markers, then the remaining markers and ancestry.
+# Record each newly verified identity signal here.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -31,8 +32,8 @@ CONFIG="${FM_CONFIG_OVERRIDE:-$FM_HOME/config}"
 . "$SCRIPT_DIR/fm-cursor-lib.sh"
 
 detect_own() {
-  # Layer 1: environment markers for verified harnesses.
-  # Keep marker detection before ancestry detection as an explicit precedence rule.
+  # Layer 1: unambiguous environment markers for verified harnesses, followed
+  # by narrow ancestry disambiguation before any shared marker fallback.
   # Claude, Pi, Grok, and Cursor set verified markers of their own; codex,
   # opencode, Kimi, and Muse are markerless, so a foreign marker retained in a terminal
   # multiplexer's stored environment can silently misidentify one of them before
@@ -50,6 +51,33 @@ detect_own() {
   # CURSOR_AGENT=1 is set for the child/tool processes this script runs as.
   [ "${CURSOR_AGENT:-}" = "1" ] && { echo cursor; return; }
   [ "${CURSOR_INVOKED_AS:-}" = "cursor-agent" ] && { echo cursor; return; }
+  # Prime Agent deliberately shares Pi's PI_CODING_AGENT=true marker and also
+  # reports AI_AGENT=pi, so neither variable can identify it. Its executable
+  # identity is the exact prime-agent name (or that package path under a bare
+  # node interpreter). Check that narrow ancestry fact BEFORE Pi's shared
+  # marker fallback or every Prime child/tool process is misreported as pi.
+  local prime_pid=$$ prime_comm prime_base prime_args
+  for _ in 1 2 3 4 5 6 7 8; do
+    prime_comm=$(ps -o comm= -p "$prime_pid" 2>/dev/null) || break
+    prime_base=${prime_comm##*/}
+    prime_base=${prime_base#-}
+    if [ "$prime_base" = prime-agent ]; then
+      echo prime-agent
+      return
+    fi
+    case "$prime_base" in
+      node*)
+        prime_args=$(ps -o args= -p "$prime_pid" 2>/dev/null)
+        case "$prime_args" in
+          *'/prime-agent/'*) echo prime-agent; return ;;
+        esac
+        ;;
+    esac
+    prime_pid=$(ps -o ppid= -p "$prime_pid" 2>/dev/null | tr -d ' ')
+    if [ -z "$prime_pid" ] || [ "$prime_pid" -le 1 ]; then
+      break
+    fi
+  done
   [ "${CLAUDECODE:-}" = "1" ] && { echo claude; return; }
   if [ "${PI_CODING_AGENT:-}" = "true" ]; then
     if [ "${FM_PI_HARNESS:-}" = pi-signed ]; then echo pi-signed; else echo pi; fi
@@ -85,6 +113,7 @@ detect_own() {
       *claude*) echo claude; return ;;
       *codex*) echo codex; return ;;
       *opencode*) echo opencode; return ;;
+      prime-agent) echo prime-agent; return ;;
       *grok*) echo grok; return ;;
       kimi) echo kimi; return ;;
       # muse's installed launcher ~/.local/bin/muse execs ~/.local/bin/muse-bin-<version>
@@ -102,6 +131,7 @@ detect_own() {
           *claude*) echo claude; return ;;
           *codex*) echo codex; return ;;
           *opencode*) echo opencode; return ;;
+          *'/prime-agent/'*) echo prime-agent; return ;;
           *grok*) echo grok; return ;;
           *" pi "*|*/pi) echo pi; return ;;
         esac ;;

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -104,7 +104,7 @@
 #   profile consultation. A --secondmate spawn is exempt and resolves the SECONDMATE
 #   harness (config/secondmate-harness -> config/crew-harness -> own), so the
 #   secondmate-vs-crewmate split is DURABLE across every respawn (recovery,
-#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|muse)
+#   /updatefirstmate, restart). A bare adapter name (claude|codex|opencode|pi|pi-signed|prime-agent|grok|kimi|cursor|muse)
 #   overrides it for this spawn (either kind). A non-flag string containing
 #   whitespace is treated as a RAW launch command - the escape hatch for verifying
 #   new adapters. For pi and pi-signed, fm-spawn resolves the selected executable
@@ -113,6 +113,8 @@
 #   a failed or inconclusive probe omits it so older Pi versions remain launchable.
 #   A missing selected executable refuses before endpoint creation, and pi-signed
 #   never falls back to pi.
+#   For prime-agent, fm-spawn likewise resolves and launches one concrete PATH
+#   executable, without Pi's version-dependent --tui-mode probe.
 #   config/secondmate-harness may also carry an optional model and effort as extra
 #   whitespace-separated tokens ("<harness> [<model>] [<effort>]"). For a
 #   --secondmate spawn, those tokens apply only when this spawn also resolves its
@@ -168,7 +170,7 @@
 # plus a gitignored .fm-grok-turnend worktree pointer and a state token.
 # muse installs no hook at all - its plugin engine is off in the default build - so
 # it writes state/<id>.muse-session to bind the pane to muse's own session event
-# log; muse is crewmate/scout only and is refused for --secondmate.
+# log; prime-agent and muse are crewmate/scout only and are refused for --secondmate.
 # cursor installs no per-task hook either: it writes state/<id>.cursor-session to
 # bind the pane to cursor's own conversation transcript (projects root, the exact
 # workspace path cursor records in .workspace-trusted, and the conversations that
@@ -1046,7 +1048,7 @@ if [ "$RELAUNCH" -eq 1 ]; then
   }
 elif [ "$KIND" = secondmate ]; then
   case "${POS[1]:-}" in
-    ''|claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|muse)
+    ''|claude|codex|opencode|pi|pi-signed|prime-agent|grok|kimi|cursor|muse)
       ARG3=${POS[1]:-}
       ;;
     *' '*)
@@ -1074,7 +1076,7 @@ shell_quote() {
   printf "'"
 }
 
-resolve_pi_executable() {
+resolve_pi_family_executable() {
   local candidate dir
   candidate=$(type -P -- "$1" 2>/dev/null) || return 1
   [ -x "$candidate" ] || return 1
@@ -1127,6 +1129,9 @@ launch_template() {
       else
         printf '%s' ' __MODELFLAG____EFFORTFLAG__-e __PIEXT__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       fi
+      ;;
+    prime-agent)
+      printf '%s' '__PRIMEBIN__ __MODELFLAG____EFFORTFLAG__-e __PRIMEEXT__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       ;;
     # grok (Grok Build TUI): a positional prompt starts the supervised interactive
     # session. --always-approve auto-approves every tool execution (verified: the
@@ -1216,20 +1221,20 @@ case "$ARG3" in
     ;;
 esac
 
-# muse is verified as a CREWMATE/SCOUT adapter only. A secondmate is a firstmate
+# muse and prime-agent are verified as CREWMATE/SCOUT adapters only. A secondmate is a firstmate
 # instance, so it needs a primary supervision protocol; muse has none, and its
 # Claude-compatible hook dialect explicitly rejects the model-reawakening and
 # asyncRewake handlers that firstmate's primary turn-end supervision is built on
 # (muse 0.1.0-R708.1). Refusing here keeps that gap loud instead of standing up a
 # secondmate whose supervision cycle could never be armed.
-if [ "$KIND" = secondmate ] && [ "$HARNESS" = muse ]; then
-  echo "error: muse is a verified crewmate/scout adapter only and cannot run a secondmate; it has no primary supervision protocol. Select a harness verified for secondmates." >&2
+if [ "$KIND" = secondmate ] && { [ "$HARNESS" = muse ] || [ "$HARNESS" = prime-agent ]; }; then
+  echo "error: $HARNESS is a verified crewmate/scout adapter only and cannot run a secondmate; it has no verified primary supervision protocol. Select a harness verified for secondmates." >&2
   exit 1
 fi
 
 case "$HARNESS" in
   pi|pi-signed)
-    PI_BIN=$(resolve_pi_executable "$HARNESS") || {
+    PI_BIN=$(resolve_pi_family_executable "$HARNESS") || {
       echo "error: $HARNESS executable not found on PATH; install it or select a different verified harness" >&2
       exit 1
     }
@@ -1239,6 +1244,12 @@ case "$HARNESS" in
     fi
     LAUNCH=${LAUNCH//__PITUIMODE__/$PI_TUI_MODE}
     LAUNCH="FM_PI_HARNESS=$HARNESS $LAUNCH"
+    ;;
+  prime-agent)
+    PRIME_BIN=$(resolve_pi_family_executable prime-agent) || {
+      echo "error: prime-agent executable not found on PATH; install it or select a different verified harness" >&2
+      exit 1
+    }
     ;;
   cursor)
     # `cursor` is not the CLI name, and the legacy alias `agent` is far too
@@ -1361,7 +1372,7 @@ model_flag_for_harness() {
   local harness=$1 model=$2
   [ -n "$model" ] && [ "$model" != default ] || return 0
   case "$harness" in
-    claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|muse)
+    claude|codex|opencode|pi|pi-signed|prime-agent|grok|kimi|cursor|muse)
       printf -- '--model %s ' "$(shell_quote "$model")"
       ;;
   esac
@@ -1393,9 +1404,10 @@ effort_flag_for_harness() {
         low|medium|high) printf -- '--reasoning-effort %s ' "$(shell_quote "$effort")" ;;
       esac
       ;;
-    pi|pi-signed)
-      # Pi 0.80.6 accepts the full shared effort vocabulary, including max, through
-      # its --thinking flag.
+    pi|pi-signed|prime-agent)
+      # Pi 0.80.6 and Prime Agent 0.8.0 accept the full shared effort vocabulary,
+      # including max, through --thinking. Prime also accepts off and minimal,
+      # which sit outside Firstmate's shared dispatch axis and are not remapped.
       case "$effort" in
         low|medium|high|xhigh|max) printf -- '--thinking %s ' "$(shell_quote "$effort")" ;;
       esac
@@ -2319,7 +2331,7 @@ if [ "$KIND" != secondmate ]; then
       ;;
   esac
   case "$HARNESS" in
-    claude*|opencode*|pi|pi-signed)
+    claude*|opencode*|pi|pi-signed|prime-agent)
       BUSY_GEN=$("$FM_ROOT/bin/fm-busy-event.sh" arm "$STATE_REAL" "$ID") || {
         echo "error: failed to arm the busy-state contract for $ID" >&2
         exit 1
@@ -2443,6 +2455,28 @@ export default function (pi: any) {
     return busyEvent("idle", "agent-settled");
   });
   pi.on("turn_end", () => execFile("touch", ["$TURNEND"]));
+}
+EOF
+      ;;
+    prime-agent)
+      # Prime accepts Pi-style explicit -e extensions outside the project
+      # without a trust dialog. Prime 0.8.0 emits agent_end rather than Pi's
+      # agent_settled, so that verified lifecycle edge closes the busy record.
+      cat > "$STATE/$ID.prime-ext.ts" <<EOF
+// Firstmate semantic busy-state events + turn-end notification for Prime Agent;
+// written by fm-spawn under the contract owned by bin/fm-busy-lib.sh.
+import { execFile } from "node:child_process";
+const busyEvent = (state: string, event: string) =>
+  new Promise<void>((resolve) => {
+    execFile("$FM_ROOT/bin/fm-busy-event.sh", [
+      "apply", "$STATE_REAL", "$ID", state,
+      "--gen", "$BUSY_GEN", "--source", "prime-ext", "--event", event,
+    ], () => resolve());
+  });
+export default function (prime: any) {
+  prime.on("agent_start", () => busyEvent("busy", "agent-start"));
+  prime.on("agent_end", () => busyEvent("idle", "agent-end"));
+  prime.on("turn_end", () => execFile("touch", ["$TURNEND"]));
 }
 EOF
       ;;
@@ -2708,6 +2742,7 @@ fi
 sq_brief=$(shell_quote "$BRIEF")
 sq_turnend=$(shell_quote "$TURNEND")
 sq_piext=$(shell_quote "$STATE/$ID.pi-ext.ts")
+sq_primeext=$(shell_quote "$STATE/$ID.prime-ext.ts")
 sq_piturnend=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-turnend-guard.ts")
 sq_piwatch=$(shell_quote "$PROJ_ABS/.pi/extensions/fm-primary-pi-watch.ts")
 sq_opinput=$(shell_quote "$FM_ROOT/bin/fm-operational-input.sh")
@@ -2719,16 +2754,18 @@ LAUNCH=${LAUNCH//__EFFORTFLAG__/$EFFORTFLAG}
 LAUNCH=${LAUNCH//__BRIEF__/$sq_brief}
 LAUNCH=${LAUNCH//__TURNEND__/$sq_turnend}
 LAUNCH=${LAUNCH//__PIEXT__/$sq_piext}
+LAUNCH=${LAUNCH//__PRIMEEXT__/$sq_primeext}
 LAUNCH=${LAUNCH//__PITURNEND__/$sq_piturnend}
 LAUNCH=${LAUNCH//__PIWATCH__/$sq_piwatch}
 LAUNCH=${LAUNCH//__OPINPUT__/$sq_opinput}
 case "$HARNESS" in
   pi|pi-signed) LAUNCH=${LAUNCH//__PIBIN__/"$(shell_quote "$PI_BIN")"} ;;
+  prime-agent) LAUNCH=${LAUNCH//__PRIMEBIN__/"$(shell_quote "$PRIME_BIN")"} ;;
   cursor) LAUNCH=${LAUNCH//__CURSORBIN__/"$(shell_quote "$CURSOR_BIN")"} ;;
 esac
 LAUNCH=${LAUNCH//__WORKTREE__/$sq_worktree}
 case "$HARNESS" in
-  claude|codex|opencode|pi|pi-signed|grok|kimi|muse)
+  claude|codex|opencode|pi|pi-signed|prime-agent|grok|kimi|muse)
     LAUNCH="env -u CURSOR_AGENT -u CURSOR_INVOKED_AS $LAUNCH"
     ;;
 esac

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1131,7 +1131,12 @@ launch_template() {
       fi
       ;;
     prime-agent)
-      printf '%s' '__PRIMEBIN__ __MODELFLAG____EFFORTFLAG__-e __PRIMEEXT__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
+      # Clear foreign PI-family markers a Pi-family primary leaks into the spawn
+      # environment: a worker inherited PI_MODEL from the primary session and
+      # self-reported the wrong model (verified live 2026-08-24). Prime sets its
+      # own PI_CODING_AGENT=true for its children, so clearing the inherited
+      # value here cannot blind ancestry-based harness detection.
+      printf '%s' 'env -u PI_MODEL -u PI_CODING_AGENT -u AI_AGENT -u FM_PI_HARNESS __PRIMEBIN__ __MODELFLAG____EFFORTFLAG__-e __PRIMEEXT__ "$(__OPINPUT__ encode launch-brief < __BRIEF__)"'
       ;;
     # grok (Grok Build TUI): a positional prompt starts the supervised interactive
     # session. --always-approve auto-approves every tool execution (verified: the

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -2483,6 +2483,7 @@ cleanup_firstmate_home_children() {
     status_retire_presentation_task "$sub_state" "$child_id" || return 1
     rm -f "$sub_state/$child_id.turn-ended" \
       "$sub_state/$child_id.meta" "$sub_state/$child_id.pi-ext.ts" \
+      "$sub_state/$child_id.prime-ext.ts" \
       "$sub_state/$child_id.grok-turnend-token" "$sub_state/$child_id.kimi-turnend-token" \
       "$sub_state/$child_id.muse-session" "$sub_state/$child_id.muse-session-current" \
       "$sub_state/$child_id.cursor-session"
@@ -2798,7 +2799,8 @@ remove_pr_poll_artifacts "$STATE" "$ID" || exit 1
 retire_busy_state "$STATE" "$ID" "$BUSY_GEN" || exit 1
 status_retire_presentation_task "$STATE" "$ID" || exit 1
 rm -f "$STATE/$ID.turn-ended" "$STATE/$ID.meta" \
-  "$STATE/$ID.pi-ext.ts" "$STATE/$ID.grok-turnend-token" \
+  "$STATE/$ID.pi-ext.ts" "$STATE/$ID.prime-ext.ts" \
+  "$STATE/$ID.grok-turnend-token" \
   "$STATE/$ID.kimi-turnend-token" "$STATE/$ID.muse-session" \
   "$STATE/$ID.muse-session-current" "$STATE/$ID.cursor-session" \
   "$STATE/$ID.control-relaunch" "$STATE/$ID.control-relaunch.meta-prior" \

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -48,7 +48,7 @@ The clear is refused before anything is sent when the recorded backend cannot de
 Removing a worktree, closing an endpoint, or discarding work stays with [`bin/fm-teardown.sh`](../bin/fm-teardown.sh), which owns the landed-work test.
 
 **`resume` is not a verb.**
-It is not deterministic across the verified adapters: codex and grok resume only from a session id printed at exit, opencode continues the most recent session for the cwd, and claude, pi, pi-signed, and kimi have no verified pane-resume contract.
+It is not deterministic across the verified adapters: codex, grok, and prime-agent resume only from a session id printed at exit, opencode continues the most recent session for the cwd, and claude, pi, pi-signed, and kimi have no verified pane-resume contract.
 `relaunch` covers the same need on every adapter, because the brief on disk - not a harness-private session - is the durable instruction.
 
 ## Transactional relaunch

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -125,7 +125,7 @@ Text for a worker to read and commands that drive a worker's process are separat
 `bin/fm-busy-lib.sh` is the single owner of what "this worker is busy" means, and `bin/fm-busy-event.sh` is the only writer of the per-task records it reads.
 Every classification returns a verdict of busy, idle, unknown, or dead together with the source that produced it, so a consumer or a diagnostic can never confuse semantic state with a fallback.
 
-Each converted adapter reports its own turn lifecycle through a machine-readable contract the vendor already exposes, rather than through rendered footer text: Pi and pi-signed through the Firstmate-owned extension's `agent_start` and `agent_settled` confirmed by `ctx.isIdle()`, OpenCode through its plugin's semantic `session.status`, Claude through owned `UserPromptSubmit`, `Stop`, `StopFailure`, and `SessionEnd` hooks, Muse through its session log, and Cursor through its conversation transcript.
+Each converted adapter reports its own turn lifecycle through a machine-readable contract the vendor already exposes, rather than through rendered footer text: Pi and pi-signed through the Firstmate-owned extension's `agent_start` and `agent_settled` confirmed by `ctx.isIdle()`, Prime Agent through its extension's `agent_start` and `agent_end`, OpenCode through its plugin's semantic `session.status`, Claude through owned `UserPromptSubmit`, `Stop`, `StopFailure`, and `SessionEnd` hooks, Muse through its session log, and Cursor through its conversation transcript.
 Kimi behind Pi inherits Pi's lifecycle.
 Codex and standalone Kimi classify unknown behind explicit probes until a semantic source is live-verified for them, and Grok keeps one clearly isolated rendered-tail fallback that can only ever classify a Grok task.
 
@@ -203,7 +203,7 @@ The session-start bootstrap step keeps valid dispatch configuration silent unles
 When the file exists, `fm-spawn.sh` refuses crewmate and scout launches without an explicit harness, so `config/crew-harness` is only automatic when no dispatch profile file is active.
 Secondmate launches are exempt because they resolve the secondmate harness and any optional secondmate model or effort tokens instead.
 Unsupported effort values are still recorded in task meta when passed to `fm-spawn.sh`, but the launch template omits any effort flag that the selected harness does not accept.
-That keeps spawn launch compatible across claude, codex, opencode, pi, pi-signed, grok, kimi, cursor, and muse while preserving the requested profile for later audit.
+That keeps spawn launch compatible across claude, codex, opencode, pi, pi-signed, prime-agent, grok, kimi, cursor, and muse while preserving the requested profile for later audit.
 
 ## Optional secondmates
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -220,10 +220,12 @@ The full cmux home label also includes a short hash of the resolved `FM_ROOT` pa
 ## Harness support
 
 claude, codex, opencode, pi, pi-signed, grok, kimi, and cursor are empirically verified for crewmate and secondmate launches; [README requirements](../README.md#requirements) own the set supported for the primary session.
+prime-agent and muse are verified for crewmate and scout launches only, and `fm-spawn.sh` refuses either for a secondmate because neither has a verified primary supervision protocol.
 A cursor secondmate or primary runs the tracked project-scope `.cursor/hooks.json` in its own home and must be launched with `--trust`, or no project hook loads; [`docs/supervision-protocols/cursor.md`](supervision-protocols/cursor.md) owns its supervision protocol.
 Cursor typed-submit confirmation is verified on tmux and Herdr only.
 On Zellij, cmux, and Orca a typed-plane Cursor send (a harness-native invocation or an explicit backend target; ordinary text steers ride the durable inbox and exit 0 at enqueue) lands, but `fm-send` reports delivery unconfirmed and exits non-zero because their shared submit core does not consult the busy footer; [runtime backend verification](verification/runtime-backends.md#cursor-agent-cli) owns the evidence and transcript-state boundary.
 muse is verified for crewmate and scout launches ONLY, and `fm-spawn.sh` refuses it for a secondmate, because muse ships no usable hook surface for a primary session's turn-end supervision; [`docs/verification/muse.md`](verification/muse.md) owns that evidence.
+prime-agent is likewise crewmate/scout-only because Prime 0.8.0 exposes `agent_end` instead of Pi's primary `agent_settled` boundary; the harness-adapters skill owns the verified lifecycle facts.
 muse also needs a worker-reachable credential before spawning, and the portable fleet path is the `<config>/muse/auth.json` credential stored by `muse login`, because a caller-only `META_API_KEY` does not cross a long-lived backend daemon.
 New harnesses get verified through a supervised trial task before joining the set.
 The verified adapter evidence - each harness's busy-state source, interrupt and exit behavior, skill-invocation syntax, and per-harness quirks - lives in [`.agents/skills/harness-adapters/SKILL.md`](../.agents/skills/harness-adapters/SKILL.md).

--- a/docs/tmux-backend.md
+++ b/docs/tmux-backend.md
@@ -48,7 +48,7 @@ Verify setup by spawning a small task and confirming its `fm-<id>` window appear
 
 A target-existence check proves only that the pane exists.
 The deeper tmux agent-liveness probe first verifies exact window membership, then reads process names to distinguish a running harness from a bare idle shell.
-It classifies recognized Claude, Codex, OpenCode, Pi, pi-signed, Grok, Kimi, Cursor, and Muse process identities as `alive`, common shells as `dead`, an authoritatively absent window as `missing`, unreadable state as `unreadable`, and every other process as `ambiguous`.
+It classifies recognized Claude, Codex, OpenCode, Pi, pi-signed, Prime Agent, Grok, Kimi, Cursor, and Muse process identities as `alive`, common shells as `dead`, an authoritatively absent window as `missing`, unreadable state as `unreadable`, and every other process as `ambiguous`.
 Only `dead` and `missing` authorize recovery because a false dead result could launch a duplicate agent.
 
 For positive attribution, the probe combines two independent name sources rather than making either one load-bearing.

--- a/docs/trace-context.md
+++ b/docs/trace-context.md
@@ -23,7 +23,7 @@ When enabled, for each spawn Firstmate resolves one W3C `traceparent` carrier fo
 This feature parents no SDK span by itself.
 
 Because the injected carrier and the recorded carrier are the same string, an observer that reads the metadata reconstructs exactly the identity the child received.
-The injection sits at the unconditional pre-launch export site, so it covers ship and scout spawns across `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, `kimi`, `cursor`, and `muse`, plus Secondmate spawns across that same set except the deliberately crewmate-only `muse` adapter.
+The injection sits at the unconditional pre-launch export site, so it covers ship and scout spawns across `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `prime-agent`, `grok`, `kimi`, `cursor`, and `muse`, plus Secondmate spawns across that same set except the deliberately crewmate-only `prime-agent` and `muse` adapters.
 This is the same coverage `GOTMPDIR` already has and requires no trace-specific `launch_template()` behavior.
 Ship and scout spawns reach that site on every spawn backend (`tmux`, `herdr`, `zellij`, `orca`, `cmux`); a Secondmate reaches it on every backend that accepts a Secondmate spawn (`tmux`, `herdr`, `zellij`), because `bin/fm-spawn.sh` rejects a Secondmate on `orca` and `cmux`.
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -76,6 +76,34 @@ fm_backend_agent_state tmux museliv:zsh
 alive
 ```
 
+The crewmate-only Prime Agent 0.8.0 adapter was verified separately on 2026-08-23 against tmux 3.6a on macOS arm64.
+
+```sh
+prime-agent --version
+tmux -L fm-prime-verify display-message -p -t prime-live '#{pane_pid} #{pane_current_command}'
+ps -o pid=,ppid=,comm=,args= -p "$pane_pid"
+```
+
+Observed bounded output:
+
+```text
+0.8.0
+94666 prime-agent
+94666 83227 prime-agent prime-agent
+```
+
+An explicit absolute `-e` extension outside a nested disposable project recorded `agent_start`, `turn_end`, and `agent_end` during a real `deepseek-v4-flash` turn.
+The same extension invoked `bin/fm-harness.sh` from Prime's process and recorded `identity:prime-agent` despite `PI_CODING_AGENT=true` and `AI_AGENT=pi`.
+Prime did not emit Pi's `agent_settled` event, so the adapter uses `agent_end` as its idle edge and remains crewmate/scout-only.
+A live launch carried `--thinking low` but rendered `high` in Prime's footer, so this record proves flag parsing and transport rather than the effective runtime thinking level.
+A second live run wrote through `bin/fm-busy-event.sh` and read the stored contract through `fm_busy_classify`.
+
+```text
+during=busy prime-ext
+after=idle prime-ext
+state=idle source=prime-ext event=agent-end
+```
+
 `#{pane_current_command}` and foreground `ps -o comm=` read different name fields, but which one preserves executable identity is platform-dependent.
 On macOS the pane command reflected the rewritable title while the full install path could survive in `ps -o comm=`; in the Linux portable regression those roles reversed for the version-named native executable, with the identifying path retained in argv[0].
 The classifier therefore accepts a harness basename first, then an exact harness path component in the full executable path, then the same component in argv[0], without depending on which field carries it on a given platform.
@@ -137,7 +165,7 @@ Firstmate therefore sets the exact `FM_PI_HARNESS` selection marker on both work
 Both recorded runtime identities now classify the exact `pi-launcher` foreground command as `alive`.
 
 Backend applicability was reviewed across every spawn adapter.
-Tmux needs the exact `pi-launcher`, `pi-signed`, `pi`, and `Pi` process identities for recovery-grade liveness.
+Tmux needs the exact `pi-launcher`, `pi-signed`, `pi`, `Pi`, and `prime-agent` process identities for recovery-grade liveness.
 Herdr uses native registered-agent state and needs no process-name branch.
 Zellij has no verified recovery-grade agent process probe, while Orca and cmux do not support secondmate spawns, so those three retain their existing generic ordinary-launch semantics without a new liveness matcher.
 
@@ -171,7 +199,7 @@ ok - fm-teardown: dedicated-socket invalid cleanup preserves target/control and 
 The dedicated tmux cell removed ambient tmux variables, required a socket-bound wrapper, kept one target and one independent control window, and proved the wrapper was not called for invalid metadata or a direct empty target.
 Valid cleanup removed only the exact task-bound target and left the control window live.
 The metadata-only validation covers tmux, Herdr, Zellij, Orca, and cmux before backend dispatch.
-Claude, Codex, OpenCode, Pi, pi-signed, Grok, Kimi, Cursor, and Muse share that backend cleanup boundary; their harness-specific hook files, tokens, transcript bindings, and session-log sidecars are cleaned only after it, so no harness needs a separate endpoint parser.
+Claude, Codex, OpenCode, Pi, pi-signed, Prime Agent, Grok, Kimi, Cursor, and Muse share that backend cleanup boundary; their harness-specific hook files, tokens, transcript bindings, and session-log sidecars are cleaned only after it, so no harness needs a separate endpoint parser.
 
 ## Composer classification matrix
 

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -1123,6 +1123,7 @@ unsupported grok max effort is flagged^{"rules":[{"when":"deep current work","us
 unsupported grok xhigh effort is flagged^{"rules":[{"when":"deep current work","use":{"harness":"grok","model":"grok-4","effort":"xhigh"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:xhigh
 pi max effort is accepted^{"rules":[{"when":"deep coding","use":{"harness":"pi","model":"openai-codex/gpt-5.6-sol","effort":"max"}}]}^empty^
 pi-signed max effort is accepted^{"rules":[{"when":"signed coding","use":{"harness":"pi-signed","model":"openai-codex/gpt-5.6-sol","effort":"max"}}]}^empty^
+prime-agent max effort is accepted^{"rules":[{"when":"Prime coding","use":{"harness":"prime-agent","model":"deepseek-v4-flash","effort":"max"}}]}^empty^
 muse shared efforts are accepted^{"rules":[{"when":"muse low","use":{"harness":"muse","effort":"low"}},{"when":"muse medium","use":{"harness":"muse","effort":"medium"}},{"when":"muse high","use":{"harness":"muse","effort":"high"}},{"when":"muse xhigh","use":{"harness":"muse","effort":"xhigh"}},{"when":"muse max","use":{"harness":"muse","effort":"max"}}]}^empty^
 unsupported muse ultra effort is flagged^{"rules":[{"when":"muse ultra","use":{"harness":"muse","effort":"ultra"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: muse:ultra
 unsupported opencode effort is flagged^{"rules":[{"when":"opencode work","use":{"harness":"opencode","model":"anthropic/claude-sonnet-4-5","effort":"high"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: opencode:high

--- a/tests/fm-busy-state.test.sh
+++ b/tests/fm-busy-state.test.sh
@@ -218,7 +218,7 @@ test_stale_gen_record_unknown() {
 test_missing_record_unknown_not_idle() {
   local state out h
   state=$(new_state_dir missing)
-  for h in claude opencode pi pi-signed; do
+  for h in claude opencode pi pi-signed prime-agent; do
     out=$(fm_busy_classify tmux w1 "$h" t1 "$state")
     [ "$out" = "unknown missing" ] || fail "$h with no record must be 'unknown missing', got '$out'"
   done
@@ -268,6 +268,13 @@ test_source_mismatch_cross_adapter() {
   [ "$out" = "unknown source-mismatch" ] || fail "pi-ext record on a claude task must be untrusted, got '$out'"
   out=$(fm_busy_classify tmux w1 pi t1 "$state")
   [ "$out" = "busy pi-ext" ] || fail "pi-ext record on a pi task must classify, got '$out'"
+  out=$(fm_busy_classify tmux w1 prime-agent t1 "$state")
+  [ "$out" = "unknown source-mismatch" ] || fail "prime-agent must not trust Pi's source, got '$out'"
+  "$EV" apply "$state" t1 idle --gen "$gen" --source prime-ext --event agent-end
+  out=$(fm_busy_classify tmux w1 prime-agent t1 "$state")
+  [ "$out" = "idle prime-ext" ] || fail "prime-agent must trust only its own semantic source, got '$out'"
+  out=$(fm_busy_classify tmux w1 pi t1 "$state")
+  [ "$out" = "unknown source-mismatch" ] || fail "pi must not trust Prime's source, got '$out'"
   out=$(fm_busy_classify tmux w1 grok t1 "$state")
   [ "$out" = "unknown source-mismatch" ] || fail "grok trusts no semantic source, got '$out'"
   pass "a record is trusted only by the adapter whose source wrote it"
@@ -280,7 +287,7 @@ test_converted_adapters_ignore_footer_text() {
    ■■■■⬝⬝⬝⬝  esc interrupt
 Working...
 Ctrl+c:cancel'
-  for h in claude opencode pi pi-signed; do
+  for h in claude opencode pi pi-signed prime-agent; do
     out=$(fm_busy_classify tmux w1 "$h" t1 "$state" "$tail")
     [ "$out" = "unknown missing" ] || fail "$h must never classify from footer text, got '$out'"
   done

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -661,6 +661,21 @@ test_queued_enter_verdict_does_not_convert_other_states() {
   pass "fm_composer_queued_enter_verdict: only proven pending is converted"
 }
 
+test_prime_delivery_busy_spinner_is_adapter_scoped() {
+  printf '%s\n' ' ⠸ Thinking · 3s' | fm_busy_lines_match prime-agent \
+    || fail "Prime's observed Thinking spinner must acknowledge delivery"
+  printf '%s\n' ' ⠼ Waiting · 1s' | fm_busy_lines_match prime-agent \
+    || fail "Prime's observed Waiting spinner must acknowledge delivery"
+  printf '%s\n' ' ⠼ Executing · 2s · ↑ 80 tokens' | fm_busy_lines_match prime-agent \
+    || fail "Prime's observed Executing spinner must acknowledge delivery"
+  printf '%s\n' 'Thinking...' | fm_busy_lines_match prime-agent \
+    && fail "Prime's static thinking transcript heading is not a live spinner"
+  printf '%s\n' 'Working...' | fm_busy_lines_match prime-agent \
+    && fail "Prime must not borrow Pi's delivery signature"
+  pass "Prime delivery busy matching is scoped to its elapsed spinner shapes"
+}
+
 test_queued_enter_verdict_busy_pending_is_empty
 test_queued_enter_verdict_idle_pending_stays_pending
 test_queued_enter_verdict_does_not_convert_other_states
+test_prime_delivery_busy_spinner_is_adapter_scoped

--- a/tests/fm-control.test.sh
+++ b/tests/fm-control.test.sh
@@ -35,7 +35,7 @@ mkdir -p "$TMP_ROOT"
 TMP_ROOT=$(cd "$TMP_ROOT" && pwd)
 trap 'rm -rf "$TMP_ROOT"' EXIT
 
-VERIFIED_HARNESSES="claude codex opencode pi pi-signed grok kimi cursor muse"
+VERIFIED_HARNESSES="claude codex opencode pi pi-signed prime-agent grok kimi cursor muse"
 
 # The expectation table, written out independently of the implementation so a
 # silent change to either side shows up here. The fourth field is the composer
@@ -48,6 +48,7 @@ verified_adapter_contract() {  # <harness> -> exit command, interrupt key, repea
     opencode) printf '/exit\tEscape\t2\t\n' ;;
     pi) printf '/quit\tEscape\t1\t\n' ;;
     pi-signed) printf '/quit\tEscape\t1\t\n' ;;
+    prime-agent) printf '/quit\tEscape\t1\t\n' ;;
     grok) printf '/exit\tC-c\t1\t\n' ;;
     kimi) printf '/exit\tEscape\t1\t\n' ;;
     cursor) printf '/exit\tEscape\t1\t\n' ;;
@@ -267,7 +268,7 @@ test_harness_family_resolution() {
   for pair in claude:claude claude-latest:claude codex:codex codex-cli:codex \
       opencode:opencode grok:grok grok-2:grok kimi:kimi cursor:cursor \
       cursor-agent:cursor muse:muse muse-bin-0.1.0:muse pi:pi \
-      pi-signed:pi-signed; do
+      pi-signed:pi-signed prime-agent:prime-agent; do
     recorded=${pair%%:*}
     want=${pair#*:}
     got=$(fm_control_harness_family "$recorded") \
@@ -361,8 +362,9 @@ test_backend_key_capability_matrix() {
 }
 
 # A verified adapter is not automatically verified for every task kind, and the
-# check has to sit on the pre-stop side of a relaunch: muse has no primary
-# supervision protocol, so bin/fm-spawn.sh refuses it for a secondmate, and
+# check has to sit on the pre-stop side of a relaunch: muse and prime-agent have
+# no verified primary supervision protocol, so bin/fm-spawn.sh refuses either
+# for a secondmate, and
 # discovering that only after the running agent was stopped would strand the
 # secondmate with no agent at all.
 test_harness_kind_capability() {
@@ -375,6 +377,8 @@ test_harness_kind_capability() {
   done
   fm_control_harness_supports_kind muse secondmate \
     && fail "muse has no primary supervision protocol and must not claim a secondmate"
+  fm_control_harness_supports_kind prime-agent secondmate \
+    && fail "prime-agent has no verified primary supervision protocol and must not claim a secondmate"
   for harness in claude codex opencode pi pi-signed grok kimi; do
     fm_control_harness_supports_kind "$harness" secondmate \
       || fail "$harness should be able to run a secondmate"

--- a/tests/fm-harness-liveness-drift-live-e2e.test.sh
+++ b/tests/fm-harness-liveness-drift-live-e2e.test.sh
@@ -100,7 +100,7 @@ SKIPPED=
 # cursor matters for the same reason muse does, from the other direction: it
 # runs as a bundled node script, so its pane title is a bare `node` that no name
 # pattern can own, and identity has to come from its install path or argv[0].
-for harness in claude codex opencode pi pi-signed grok kimi cursor muse; do
+for harness in claude codex opencode pi pi-signed prime-agent grok kimi cursor muse; do
   if ! bin_path=$(resolve_harness_binary "$harness"); then
     SKIPPED="$SKIPPED $harness"
     note "skip: $harness is not installed on this machine, so its classification is unverified here"

--- a/tests/fm-prime-agent.test.sh
+++ b/tests/fm-prime-agent.test.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Prime Agent harness identity regression tests.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-prime-agent)
+trap 'rm -rf "$TMP_ROOT"' EXIT
+FAKEBIN=$(fm_fakebin "$TMP_ROOT")
+BASE_PATH=$PATH
+
+cat > "$FAKEBIN/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+field=
+pid=
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -o) field=$2; shift 2 ;;
+    -p) pid=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+case "$field:$pid:${FM_TEST_PRIME_SHAPE:-exact}" in
+  comm=:200:exact) printf '%s\n' '/opt/prime/bin/prime-agent' ;;
+  comm=:200:node) printf '%s\n' '/opt/node/bin/node' ;;
+  args=:200:node) printf '%s\n' '/opt/node/bin/node /opt/node/lib/node_modules/prime-agent/dist/cli.js' ;;
+  comm=:200:decoy) printf '%s\n' '/opt/prime/bin/prime-agent-helper' ;;
+  args=:200:decoy) printf '%s\n' 'prime-agent-helper' ;;
+  comm=:*) printf '%s\n' bash ;;
+  args=:*) printf '%s\n' bash ;;
+  ppid=:200:*) printf '%s\n' 1 ;;
+  ppid=:*) printf '%s\n' 200 ;;
+  *) exit 1 ;;
+esac
+SH
+chmod +x "$FAKEBIN/ps"
+
+detect() {
+  env -u CLAUDECODE -u GROK_AGENT PATH="$FAKEBIN:$BASE_PATH" \
+    PI_CODING_AGENT=true FM_TEST_PRIME_SHAPE=$1 "$ROOT/bin/fm-harness.sh"
+}
+
+got=$(detect exact)
+[ "$got" = prime-agent ] \
+  || fail "exact prime-agent ancestry resolved '$got', expected prime-agent"
+
+got=$(detect node)
+[ "$got" = prime-agent ] \
+  || fail "Prime's node package ancestry resolved '$got', expected prime-agent"
+
+got=$(detect decoy)
+[ "$got" = pi ] \
+  || fail "prime-agent-helper decoy resolved '$got', expected shared-marker Pi fallback"
+
+pass "Prime ancestry outranks its shared Pi marker without widening to similar names"

--- a/tests/fm-prime-agent.test.sh
+++ b/tests/fm-prime-agent.test.sh
@@ -39,7 +39,7 @@ chmod +x "$FAKEBIN/ps"
 
 detect() {
   env -u CLAUDECODE -u GROK_AGENT PATH="$FAKEBIN:$BASE_PATH" \
-    PI_CODING_AGENT=true FM_TEST_PRIME_SHAPE=$1 "$ROOT/bin/fm-harness.sh"
+    PI_CODING_AGENT=true FM_TEST_PRIME_SHAPE="$1" "$ROOT/bin/fm-harness.sh"
 }
 
 got=$(detect exact)

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -76,6 +76,7 @@ SH
   chmod +x "$fakebin/timeout" "$fakebin/cursor-agent"
   make_spawn_pi_probe "$fakebin" pi
   make_spawn_pi_probe "$fakebin" pi-signed
+  make_spawn_pi_probe "$fakebin" prime-agent
   printf '%s\n' "$fakebin"
 }
 
@@ -665,6 +666,45 @@ test_pi_signed_threads_shared_pi_profile_and_preserves_identity() {
   pass "pi-signed shares Pi launch semantics while preserving its configured and recorded identity"
 }
 
+test_prime_agent_threads_model_thinking_and_semantic_extension() {
+  local rec id out status launch ext gen
+  id=profile-prime-agent-z8c
+  rec=$(make_spawn_case profile-prime-agent prime-agent "$id")
+  read_case_record "$rec"
+
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" \
+    --model deepseek-v4-flash --effort max)
+  status=$?
+  expect_code 0 "$status" "prime-agent spawn with model and max effort should succeed"
+  assert_contains "$out" "spawned $id harness=prime-agent" \
+    "prime-agent spawn did not preserve its adapter identity"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" prime-agent deepseek-v4-flash max
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "'$FAKEBIN_DIR/prime-agent' --model 'deepseek-v4-flash' --thinking 'max' -e '$HOME_DIR/state/$id.prime-ext.ts'" \
+    "prime-agent launch dropped its model, thinking, or explicit extension flag"
+  assert_contains "$launch" "fm-operational-input.sh' encode launch-brief" \
+    "prime-agent launch lost the canonical typed launch-brief envelope"
+  assert_present "$HOME_DIR/state/$id.prime-ext.ts" \
+    "prime-agent launch did not install its semantic lifecycle extension"
+  assert_present "$HOME_DIR/state/$id.busy-gen" \
+    "prime-agent spawn did not arm the busy-state contract"
+  ext=$(cat "$HOME_DIR/state/$id.prime-ext.ts")
+  gen=$(cat "$HOME_DIR/state/$id.busy-gen")
+  assert_contains "$ext" 'prime.on("agent_start"' \
+    "Prime extension lost its verified agent_start busy edge"
+  assert_contains "$ext" 'prime.on("agent_end"' \
+    "Prime extension lost its verified agent_end idle edge"
+  assert_not_contains "$ext" 'agent_settled' \
+    "Prime extension trusts Pi's unobserved agent_settled event"
+  assert_contains "$ext" 'prime.on("turn_end"' \
+    "Prime extension lost its turn-end notification touch"
+  assert_contains "$ext" '"--source", "prime-ext"' \
+    "Prime extension does not attribute its own semantic source"
+  assert_contains "$ext" "\"--gen\", \"$gen\"" \
+    "Prime extension does not carry the armed incarnation gen"
+  pass "prime-agent receives --model, --thinking, and its verified semantic extension"
+}
+
 test_pi_tui_mode_probe_is_safe_for_old_and_new_pi() {
   local harness version rec id out status launch
   for harness in pi pi-signed; do
@@ -850,6 +890,7 @@ test_opencode_threads_model_and_ignores_effort_axis
 test_pi_threads_model_and_max_effort
 test_pi_tui_mode_probe_is_safe_for_old_and_new_pi
 test_pi_signed_threads_shared_pi_profile_and_preserves_identity
+test_prime_agent_threads_model_thinking_and_semantic_extension
 test_pi_signed_missing_binary_refuses_before_endpoint_or_metadata
 test_pi_signed_persistent_secondmate_uses_pi_extensions_and_identity
 test_batch_forwards_shared_profile_flags

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -680,7 +680,7 @@ test_prime_agent_threads_model_thinking_and_semantic_extension() {
     "prime-agent spawn did not preserve its adapter identity"
   assert_meta_profile "$HOME_DIR/state/$id.meta" prime-agent deepseek-v4-flash max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "'$FAKEBIN_DIR/prime-agent' --model 'deepseek-v4-flash' --thinking 'max' -e '$HOME_DIR/state/$id.prime-ext.ts'" \
+  assert_contains "$launch" "env -u PI_MODEL -u PI_CODING_AGENT -u AI_AGENT -u FM_PI_HARNESS '$FAKEBIN_DIR/prime-agent' --model 'deepseek-v4-flash' --thinking 'max' -e '$HOME_DIR/state/$id.prime-ext.ts'" \
     "prime-agent launch dropped its model, thinking, or explicit extension flag"
   assert_contains "$launch" "fm-operational-input.sh' encode launch-brief" \
     "prime-agent launch lost the canonical typed launch-brief envelope"

--- a/tests/fm-tmux-agent-liveness.test.sh
+++ b/tests/fm-tmux-agent-liveness.test.sh
@@ -53,6 +53,7 @@ export PATH
 # the executable identity, which is exactly the signal under test.
 ln -s "$SLEEP_BIN" "$LAB/bin/claude-link"
 ln -s "$SLEEP_BIN" "$LAB/bin/pi"
+ln -s "$SLEEP_BIN" "$LAB/bin/prime-agent"
 ln -s "$SLEEP_BIN" "$LAB/bin/notaharness"
 # muse's installed binary is muse-bin-<version>: the launcher execs it, so the
 # version is the LIVE process name and it changes on every auto-update. Unlike
@@ -154,6 +155,11 @@ new_window agent "$LAB/bin/claude-link" 900
 wait_for_state "$SESSION:agent" alive \
   || fail "a running harness-named foreground process must classify alive"
 pass "tmux liveness: a harness-named foreground process classifies alive"
+
+new_window prime-agent "$LAB/bin/prime-agent" 900
+wait_for_state "$SESSION:prime-agent" alive \
+  || fail "a running prime-agent process must classify alive"
+pass "tmux liveness: prime-agent's exact executable identity classifies alive"
 
 # --- muse's version-suffixed binary name ------------------------------------
 # A muse crewmate pane misclassified here reads as a dead endpoint, so a healthy


### PR DESCRIPTION
## Summary
- Extends the prime-agent launch template to strip inherited PI_CODING_AGENT along with PI_MODEL, AI_AGENT, and FM_PI_HARNESS, so a Pi-family primary leaks no stale markers into a spawned Prime worker.
- A probe worker inherited the primary's PI_MODEL and self-reported the wrong model (verified live 2026-08-24).
- Prime sets its own PI_CODING_AGENT=true for children and harness detection keys off exact prime-agent ancestry first, so clearing only the inherited value cannot blind detection.
- Updates the pinned regression assertion and the harness-adapters skill fact.
- Quotes FM_TEST_PRIME_SHAPE in tests/fm-prime-agent.test.sh to clear a pre-existing shellcheck SC2086 finding so fm-lint runs clean.

## Verification
- bin/fm-lint.sh clean (ShellCheck 0.11.0 pinned, actionlint 1.7.12).
- bash tests/fm-prime-agent.test.sh: all passed.
- bash tests/fm-spawn-dispatch-profile.test.sh: all passed.