### PR TITLE
fix(bin): skip the PR-poll mode assertion only where the filesystem cannot express modes

### DIFF
--- a/bin/fm-pr-lib.sh
+++ b/bin/fm-pr-lib.sh
@@ -273,20 +273,32 @@ fm_pr_sha256() {
 FM_PR_MODE_PROBE_DIR=
 FM_PR_MODE_PROBE_RESULT=
 fm_pr_mode_capable() {
-  local dir=$1 tmp observed
+  local dir=$1 tmp first= second=
   [ "$dir" = "$FM_PR_MODE_PROBE_DIR" ] && return "$FM_PR_MODE_PROBE_RESULT"
   tmp=$(mktemp "$dir/.fm-pr-mode-probe.XXXXXX" 2>/dev/null) || return 0
-  # Probe both directions. Checking a single chmod would be fooled by the
-  # caller's umask already creating the file at the target mode - callers here
-  # run under `umask 077`, so a fresh file reads 600 whether or not chmod works.
-  chmod 0600 "$tmp" 2>/dev/null
-  observed=$(fm_pr_file_mode "$tmp")
-  chmod 0644 "$tmp" 2>/dev/null
-  observed=$observed/$(fm_pr_file_mode "$tmp")
+  # Probe both directions. A single chmod would be fooled by the caller's umask
+  # already creating the file at the target mode - callers here run under
+  # `umask 077`, so a fresh file reads 600 whether or not chmod works.
+  if chmod 0600 "$tmp" 2>/dev/null; then first=$(fm_pr_file_mode "$tmp"); fi
+  if chmod 0644 "$tmp" 2>/dev/null; then second=$(fm_pr_file_mode "$tmp"); fi
   rm -f -- "$tmp"
-  FM_PR_MODE_PROBE_DIR=$dir
-  if [ "$observed" = 600/644 ]; then FM_PR_MODE_PROBE_RESULT=0; else FM_PR_MODE_PROBE_RESULT=1; fi
-  return "$FM_PR_MODE_PROBE_RESULT"
+  # Only a complete, unambiguous observation may relax anything. A capable
+  # filesystem reports both requested modes. An incapable one reports the same
+  # unchanged mode twice, which is chmod demonstrably doing nothing. Every other
+  # outcome - a failed chmod, an unreadable mode, a partial change - is not
+  # understood, so it reports capable, keeps the strict assertion, and is not
+  # cached, so a transient failure cannot be remembered as evidence.
+  if [ "$first" = 600 ] && [ "$second" = 644 ]; then
+    FM_PR_MODE_PROBE_DIR=$dir
+    FM_PR_MODE_PROBE_RESULT=0
+    return 0
+  fi
+  if [ -n "$first" ] && [ "$first" = "$second" ]; then
+    FM_PR_MODE_PROBE_DIR=$dir
+    FM_PR_MODE_PROBE_RESULT=1
+    return 1
+  fi
+  return 0
 }
 
 fm_pr_private_file_valid() {

--- a/bin/fm-pr-lib.sh
+++ b/bin/fm-pr-lib.sh
@@ -273,7 +273,9 @@ fm_pr_sha256() {
 FM_PR_MODE_PROBE_DIR=
 FM_PR_MODE_PROBE_RESULT=
 fm_pr_mode_capable() {
-  local dir=$1 tmp first= second=
+  local dir=$1 tmp first second
+  first=''
+  second=''
   [ "$dir" = "$FM_PR_MODE_PROBE_DIR" ] && return "$FM_PR_MODE_PROBE_RESULT"
   tmp=$(mktemp "$dir/.fm-pr-mode-probe.XXXXXX" 2>/dev/null) || return 0
   # Probe both directions. A single chmod would be fooled by the caller's umask

--- a/bin/fm-pr-lib.sh
+++ b/bin/fm-pr-lib.sh
@@ -263,10 +263,40 @@ fm_pr_sha256() {
   fi
 }
 
+# Some filesystems cannot represent POSIX modes at all, so chmod there is a
+# silent no-op and any mode assertion is guaranteed to fail: Git Bash mounts
+# NTFS with `noacl` by default, where `chmod 0600` leaves stat reporting 644.
+# Probe the actual directory rather than guessing from `uname` or mount flags -
+# the same host can hold both mode-capable and mode-incapable filesystems.
+# A probe that cannot complete reports capable, so an unexplained failure keeps
+# the strict assertion instead of silently relaxing it.
+FM_PR_MODE_PROBE_DIR=
+FM_PR_MODE_PROBE_RESULT=
+fm_pr_mode_capable() {
+  local dir=$1 tmp observed
+  [ "$dir" = "$FM_PR_MODE_PROBE_DIR" ] && return "$FM_PR_MODE_PROBE_RESULT"
+  tmp=$(mktemp "$dir/.fm-pr-mode-probe.XXXXXX" 2>/dev/null) || return 0
+  # Probe both directions. Checking a single chmod would be fooled by the
+  # caller's umask already creating the file at the target mode - callers here
+  # run under `umask 077`, so a fresh file reads 600 whether or not chmod works.
+  chmod 0600 "$tmp" 2>/dev/null
+  observed=$(fm_pr_file_mode "$tmp")
+  chmod 0644 "$tmp" 2>/dev/null
+  observed=$observed/$(fm_pr_file_mode "$tmp")
+  rm -f -- "$tmp"
+  FM_PR_MODE_PROBE_DIR=$dir
+  if [ "$observed" = 600/644 ]; then FM_PR_MODE_PROBE_RESULT=0; else FM_PR_MODE_PROBE_RESULT=1; fi
+  return "$FM_PR_MODE_PROBE_RESULT"
+}
+
 fm_pr_private_file_valid() {
   local path=$1 mode=$2 device=$3
   [ -f "$path" ] && [ ! -L "$path" ] || return 1
-  [ "$(fm_pr_file_mode "$path")" = "$mode" ] || return 1
+  # The mode assertion is skipped only where the filesystem provably cannot
+  # express modes; the checks below carry the substantive guarantees there.
+  if fm_pr_mode_capable "$(dirname "$path")"; then
+    [ "$(fm_pr_file_mode "$path")" = "$mode" ] || return 1
+  fi
   [ "$(fm_pr_file_device "$path")" = "$device" ] || return 1
   [ "$(fm_pr_file_link_count "$path")" = 1 ]
 }


### PR DESCRIPTION
## Problem

Git for Windows mounts NTFS with `noacl`, where `chmod` is a silent no-op and
the mode is decided solely by the umask at creation time. `fm_pr_private_file_valid`
asserts mode `600`, so on that platform the assertion can never hold and
`fm-pr-check.sh` always exits with `error: could not prepare PR poll`.

The consequence is not cosmetic: no merge poll is ever armed on Windows.
Finished ship tasks go stale instead of being tracked to landing, the merged-PR
wake never fires, and teardown never runs.

## Fix

Probe the actual directory rather than inferring capability from `uname` or
mount flags, since one host can hold both mode-capable and mode-incapable
filesystems.

The probe checks both directions (`600` then `644`). A single `chmod` check is
not sufficient: `fm_pr_poll_prepare` runs under `umask 077`, so a fresh
`mktemp` file already reads `600` and a one-way check cannot distinguish a
working `chmod` from a no-op. This was found by running the real path, not in
review.

A probe that cannot complete reports capable, so an unexplained failure keeps
the strict assertion rather than silently relaxing it. The other three
guarantees in `fm_pr_private_file_valid` (regular file and not a symlink, same
device, single hard link) are untouched, and they carry the substantive
protection where modes cannot be expressed.

## This is not the only mode assertion affected

`fm_backend_herdr_presentation_lock_namespace_valid` requires mode `700` on
`/tmp/firstmate-herdr-presentation`. Git Bash mounts `/tmp` with `noacl` too, so
`mkdir -m 700` is a no-op there and the directory reads `755`, which is why
`herdr presentation focus lock unavailable` is reported on every spawn on this
host. That one is out of scope here, but it suggests the pattern is worth a
shared helper if you would prefer that shape.

## Testing

- `bin/fm-lint.sh bin/fm-pr-lib.sh` clean.
- On Windows 11 / Git for Windows: `fm-pr-check.sh` now arms the poll, the poll
  reported `merged` for a real PR, and the artifacts retired.
- Regression check with the probe cache forced to "capable": a file whose mode
  does not match is still rejected, and a matching one is still accepted, so
  behaviour on mode-capable filesystems is unchanged.
- `tests/fm-pr-check-security.test.sh` fails on this host with
  `not ok - parser accepted a rejected raw-byte URL class`. That failure
  reproduces identically on unpatched `main` here, so it is pre-existing and
  unrelated to this change, not introduced by it.

I did not add a test, because simulating a mode-incapable filesystem portably
is not obvious and a misleading test seemed worse than none. Happy to add one
in whatever shape you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)