### PR TITLE
fix: add YAML frontmatter to two firstmate-loaded skills

### DIFF
--- a/.agents/skills/captain-illustration-style/SKILL.md
+++ b/.agents/skills/captain-illustration-style/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: captain-illustration-style
+description: >-
+  The captain's default illustration/image style.
+  Load before generating, commissioning, or prompting any illustration or image for the captain, when the subject fits this look.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# captain-illustration-style
+
+The captain's default illustration/image style. Load before generating, commissioning, or prompting any illustration or image for the captain, when the subject fits this look.
+
+## Default style prompt
+
+When the subject fits, request the illustration with this style:
+
+"Render this as a 1970s live-action TV commercial poster: real people, practical sets, warm faded film colors, soft studio lighting, slight grain, analog print texture, chunky rounded retro headline lettering, cream/orange/yellow ad panels, bold bordered magazine-ad layout, playful overacted expressions, and a slightly cheesy vintage sitcom-commercial vibe. Fold in the first-mate nautical theme as the recurring house motif wherever the scene allows: crew in captain's caps and sailor uniforms, ship-deck / harbor / bridge sets, rope coils, brass portholes, signal flags, spyglasses, anchors - nautical props staged like the products in the ad. Make it meme-able, instantly readable, and not anime, not comic book, not modern cinematic."
+
+Omit the nautical layer when the content is not Firstmate-flavored.

--- a/.agents/skills/windows-native-firstmate/SKILL.md
+++ b/.agents/skills/windows-native-firstmate/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: windows-native-firstmate
+description: >-
+  Firstmate on native Windows: the measured Herdr-on-windows-latest findings, why a Bash->Node rewrite is not the fix, the remaining custody-primitive punch-list, and WSL2 as today's answer.
+  Load only before evaluating, planning, spiking, or discussing running Firstmate natively on Windows (not WSL2).
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# windows-native-firstmate
+
+Firstmate on native Windows: the measured Herdr-on-windows-latest findings, why a Bash->Node rewrite is not the fix, the remaining custody-primitive punch-list, and WSL2 as today's answer. Load only before evaluating, planning, spiking, or discussing running Firstmate natively on Windows (not WSL2).
+
+## What is known
+
+- Firstmate's Bash tooling does not run on native Windows as-is, but a Bash->Node rewrite is NOT the fix: the binding constraints are OS primitives (PTY/terminal, process custody, signals, symlinks, SSH), not the language. Git Bash runs the script logic + coreutils, but not those primitives.
+- MEASURED 2026-08-10 on a real windows-latest GitHub runner: Herdr's automation CORE works (bounded spawn->steer->capture->teardown, no hard boundary). Native Windows via Herdr is a measured, bounded punch-list, not a dead end. Remaining FAIL/DEGRADED custody primitives to close before an unattended Windows fleet: symlink lock, lsof, ANSI/cwd/events. WSL2 is today's Windows answer; headless CI proves automation primitives, not the interactive desktop UX.
+- Re-runnable via the merged windows-smoke workflow (`workflow_dispatch` on windows-latest, PR #2100).
+
+## Where the detail lives
+
+- Reports `fm-windows-herdr-ci-spike-r1` and `fm-herdr-windows-native-path-followup-s1` in the fmdev-f1 secondmate home, plus the #2100 PR body.
+- Open punch-list tracked as backlog item `fm-windows-native-herdr-punchlist-r1`.


### PR DESCRIPTION
## Summary
- Pi prints `[Skill conflicts]` at session start when a loaded skill has no YAML `description`.
- Add the same frontmatter every other `.agents/skills/` skill already has (`name`, `description`, `user-invocable: false`, `metadata.internal: true`) to `captain-illustration-style` and `windows-native-firstmate`.
- Descriptions are taken from each skill's first paragraph so the load trigger stays accurate. Skill bodies are unchanged.

These two skills were previously present only as locally excluded copies. Tracking them with frontmatter is what lets Pi load them without the conflict warning.

## Test plan
- [ ] Confirm both files start with valid YAML frontmatter and a non-empty `description`.
- [ ] Confirm the markdown bodies below the frontmatter match the previous local copies.
- [ ] On a Pi session that loads firstmate skills, confirm `[Skill conflicts]` no longer names these two skills.

Merge stays with the captain (instruction-surface).