### PR TITLE
fix(bootstrap): lower no-mistakes version floor from 1.31.2 to 0.40.0

### DIFF
--- a/.agents/skills/bootstrap-diagnostics/SKILL.md
+++ b/.agents/skills/bootstrap-diagnostics/SKILL.md
@@ -18,7 +18,7 @@ When any diagnostic needs captain attention, report the plain consequence and re
 
 - `MISSING: <tool> (install: <command>)` - list the missing tools to the captain with a one-line purpose each plus the printed install commands, wait for consent (one approval may cover the list), then run `bin/fm-bootstrap.sh install <approved tools...>`.
   For `treehouse`, this also covers an installed version whose `treehouse get` lacks `--lease`; treat it as an upgrade request.
-  For `no-mistakes`, this also covers an installed version older than 1.31.2, because crewmate validation briefs delegate gate mechanics to no-mistakes' version-matched guidance.
+  For `no-mistakes`, this also covers an installed version older than 0.40.0, because crewmate validation briefs delegate gate mechanics to no-mistakes' version-matched guidance.
   For any axi-family tool - `gh-axi`, `lavish-axi`, `tasks-axi`, `quota-axi` - an installed version below its floor is a plain upgrade request; [`bin/fm-bootstrap.sh`](../../../bin/fm-bootstrap.sh) owns the floor policy, and never argue the floor down to whatever the home happens to have installed.
   For `tasks-axi`, this additionally covers an installed build that fails the separate feature probe (`bin/fm-tasks-axi-lib.sh` owns the definition); `config/backlog-backend=manual` only suppresses the verbose `BOOTSTRAP_INFO: tasks-axi available` fact, not this missing-tool report.
   For `quota-axi`, bootstrap requires it because firstmate reads its current output directly before resolving every crew-dispatch profile array; without it, report the missing requirement and do not choose around an unexamined candidate.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ GitHub Actions and Dependabot are exempt so their automation keeps working, but 
 
 1. Fork the repo, then clone the parent repo or set your local `origin` back to the parent (`git@github.com:kunchenguid/firstmate.git`).
 2. Create a branch and make your changes.
-3. Initialize the gate with your fork as the push target: `no-mistakes init --fork-url git@github.com:<you>/firstmate.git` (firstmate expects **no-mistakes v1.31.2+**; without a fork, plain `no-mistakes init` still works for maintainers with push access).
+3. Initialize the gate with your fork as the push target: `no-mistakes init --fork-url git@github.com:<you>/firstmate.git` (firstmate expects **no-mistakes v0.40.0+**; without a fork, plain `no-mistakes init` still works for maintainers with push access).
 4. Commit your changes.
 5. Push through the gate instead of pushing to `origin`:
 

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -792,6 +792,11 @@ if ! BACKEND_TOOLS=$(fm_backend_required_tools "$BACKEND"); then
   BACKEND_TOOLS=""
 fi
 TOOLS="$BACKEND_TOOLS $COMMON_TOOLS"
+# NO_MISTAKES_MIN is the minimum-compatibility floor: the oldest no-mistakes
+# release that supports firstmate's crewmate-validation workflow. Unlike the
+# axi-family floors below, it is NOT bumped to the latest release on each
+# captain update; it moves only when firstmate requires a newer no-mistakes
+# capability and the install base has had time to catch up.
 NO_MISTAKES_MIN=0.40.0
 # AXI-FAMILY FLOOR POLICY. Every axi-family floor is the CURRENT LATEST published
 # version of that tool, captain-bumped periodically to keep the whole fleet on the

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -792,7 +792,7 @@ if ! BACKEND_TOOLS=$(fm_backend_required_tools "$BACKEND"); then
   BACKEND_TOOLS=""
 fi
 TOOLS="$BACKEND_TOOLS $COMMON_TOOLS"
-NO_MISTAKES_MIN=1.31.2
+NO_MISTAKES_MIN=0.40.0
 # AXI-FAMILY FLOOR POLICY. Every axi-family floor is the CURRENT LATEST published
 # version of that tool, captain-bumped periodically to keep the whole fleet on the
 # newest axi tools. It is NOT the minimum feature-introduced version. These floors

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -51,7 +51,7 @@
 #          treehouse is also MISSING when its installed version lacks
 #          "treehouse get --lease" support.
 #          no-mistakes is also MISSING when its installed version is older than
-#          1.31.2.
+#          0.40.0.
 #          The AXI-family floor policy is owned beside GH_AXI_MIN and
 #          LAVISH_AXI_MIN below; the per-tool owners point there. An installed
 #          build below its floor reports MISSING like no-mistakes, so the operator

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -315,7 +315,7 @@ Secondmate homes inherit this file from the primary, so a secondmate's own crewm
 On session start the first mate detects what its required toolchain is missing or too old and lists each problem with either an exact install command or manual instructions.
 It installs automatically supported tools only after you say go; manual-only tools remain for you to install from the printed instructions.
 Required tools come in two parts: a universal toolchain every home needs regardless of backend, and a per-backend delta that follows the runtime backend actually resolved for this home.
-The universal toolchain is node, git, gh with GitHub auth via `gh auth login`, no-mistakes v1.31.2 or newer, compatible gh-axi, chrome-devtools-axi, compatible lavish-axi, compatible tasks-axi per "Backlog backend" above, and compatible quota-axi.
+The universal toolchain is node, git, gh with GitHub auth via `gh auth login`, no-mistakes v0.40.0 or newer, compatible gh-axi, chrome-devtools-axi, compatible lavish-axi, compatible tasks-axi per "Backlog backend" above, and compatible quota-axi.
 [`bin/fm-bootstrap.sh`](../bin/fm-bootstrap.sh) owns the axi-family floor policy and the gh-axi and lavish-axi floors, while [`bin/fm-tasks-axi-lib.sh`](../bin/fm-tasks-axi-lib.sh) and [`bin/fm-quota-axi-lib.sh`](../bin/fm-quota-axi-lib.sh) hold their own tools' floor constants.
 This section is the single owner of that universal toolchain list; backend guides' prerequisites point here and add only their backend-specific tools.
 In that list, no-mistakes runs the validation pipeline, gh-axi, chrome-devtools-axi, and lavish-axi cover GitHub, browser, and rich-review operations, and tasks-axi plus quota-axi back backlog mutations and quota-aware array dispatch.

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -79,7 +79,7 @@ SH
   cat > "$fakebin/no-mistakes" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = --version ]; then
-  printf '%s\n' "${FM_FAKE_NO_MISTAKES_VERSION:-no-mistakes version v1.31.2 (fake) 2026-06-27T00:02:18Z}"
+  printf '%s\n' "${FM_FAKE_NO_MISTAKES_VERSION:-no-mistakes version v0.40.0 (fake) 2026-06-27T00:02:18Z}"
   exit 0
 fi
 exit 0
@@ -332,10 +332,10 @@ test_no_mistakes_min_version() {
         [ "$out" = "$missing" ] || fail "$label: expected '$missing', got: $out" ;;
     esac
   done <<'ROWS'
-minimum no-mistakes version is accepted^no-mistakes version v1.31.2 (fake)^empty
-newer no-mistakes minor is accepted^no-mistakes version v1.32.0 (fake)^empty
-newer no-mistakes major is accepted^no-mistakes version v2.0.0 (fake)^empty
-older no-mistakes patch reports an upgrade^no-mistakes version v1.31.1 (fake)^missing
+minimum no-mistakes version is accepted^no-mistakes version v0.40.0 (fake)^empty
+newer no-mistakes minor is accepted^no-mistakes version v0.41.0 (fake)^empty
+newer no-mistakes major is accepted^no-mistakes version v1.0.0 (fake)^empty
+older no-mistakes patch reports an upgrade^no-mistakes version v0.39.9 (fake)^missing
 unparseable no-mistakes version reports an upgrade^no-mistakes development build^missing
 ROWS
   pass "bootstrap enforces no-mistakes minimum version"

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -1088,7 +1088,7 @@ SH
   cat > "$fakebin/no-mistakes" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = --version ]; then
-  printf '%s\n' 'no-mistakes version v1.31.2 (fake)'
+  printf '%s\n' 'no-mistakes version v0.40.0 (fake)'
   exit 0
 fi
 exit 0

--- a/tests/fm-secondmate-liveness.test.sh
+++ b/tests/fm-secondmate-liveness.test.sh
@@ -233,7 +233,7 @@ SH
   cat > "$fakebin/no-mistakes" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = --version ]; then
-  printf '%s\n' 'no-mistakes version v1.31.2 (fake)'
+  printf '%s\n' 'no-mistakes version v0.40.0 (fake)'
   exit 0
 fi
 exit 0

--- a/tests/fm-secondmate-sync.test.sh
+++ b/tests/fm-secondmate-sync.test.sh
@@ -340,7 +340,7 @@ SH
   cat > "$fakebin/no-mistakes" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = --version ]; then
-  printf '%s\n' 'no-mistakes version v1.31.2 (fake)'
+  printf '%s\n' 'no-mistakes version v0.40.0 (fake)'
   exit 0
 fi
 exit 0

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -99,7 +99,7 @@ SH
   cat > "$fakebin/no-mistakes" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = --version ]; then
-  printf '%s\n' 'no-mistakes version v1.31.2 (fake) 2026-06-27T00:02:18Z'
+  printf '%s\n' 'no-mistakes version v0.40.0 (fake) 2026-06-27T00:02:18Z'
   exit 0
 fi
 exit 0

--- a/tests/fm-shared-captain-inheritance.test.sh
+++ b/tests/fm-shared-captain-inheritance.test.sh
@@ -232,7 +232,7 @@ SH
   cat > "$fakebin/no-mistakes" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = --version ]; then
-  printf '%s\n' 'no-mistakes version v1.31.2 (fake)'
+  printf '%s\n' 'no-mistakes version v0.40.0 (fake)'
   exit 0
 fi
 exit 0

--- a/tests/fm-startup-memory-budget.test.sh
+++ b/tests/fm-startup-memory-budget.test.sh
@@ -44,7 +44,7 @@ SH
   cat > "$fakebin/no-mistakes" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = --version ]; then
-  printf '%s\n' 'no-mistakes version v1.31.2 (fake)'
+  printf '%s\n' 'no-mistakes version v0.40.0 (fake)'
 fi
 SH
   cat > "$fakebin/tasks-axi" <<'SH'


### PR DESCRIPTION
## Intent

Lower the no-mistakes version floor constant NO_MISTAKES_MIN from 1.31.2 to 0.40.0 in bin/fm-bootstrap.sh, and update all version references throughout the codebase including comments, documentation, bootstrap-diagnostics SKILL.md, and all test files from 1.31.2 to 0.40.0 so bootstrap no longer reports the installed no-mistakes 0.40.0 binary as MISSING.

## What Changed

- Lowered `NO_MISTAKES_MIN` constant in `bin/fm-bootstrap.sh` from `1.31.2` to `0.40.0` so bootstrap correctly recognises installed no-mistakes `0.40.0` binaries as present rather than reporting them as MISSING.
- Updated all version references (comments, documentation, `CONTRIBUTING.md`, `docs/configuration.md`, and `bootstrap-diagnostics/SKILL.md`) from `1.31.2` to `0.40.0`.
- Updated fake no-mistakes version fixtures in all test files to `0.40.0` to match the new floor.

## Risk Assessment

✅ Low: All version references from 1.31.2 to 0.40.0 are consistently updated across source, docs, and tests; the integer-based comparison function handles the new 0.x floor correctly; and all four round-1 findings have been properly resolved.

## Testing

Ran `test_no_mistakes_min_version` in isolation (5 cases: v0.40.0 exact floor → silent, v0.41.0 → silent, v1.0.0 → silent, v0.39.9 below floor → MISSING message, unparseable → MISSING message). All cases passed. No `1.31.2` references remain anywhere in the codebase. A pre-existing `test_routine_bootstrap_confirmations_are_silent` failure due to GPG signing not being available in the gate worktree environment is unrelated to this change.

<details>
<summary>Evidence: test_no_mistakes_min_version output</summary>

Source: [test_no_mistakes_min_version output](https://github.com/desnor/firstmate/blob/f89d5ede00567fc88f72aae14fa33f3e623fd37e/.no-mistakes/evidence/fm/fix-no-mistakes-version-floor-in-bootstr-ec/test-no-mistakes-min-version.txt)

```text
=== test_no_mistakes_min_version ===

Test cases exercised:
  1. minimum no-mistakes version is accepted   -> v0.40.0 (exact floor) -> expects silence
  2. newer no-mistakes minor is accepted       -> v0.41.0               -> expects silence
  3. newer no-mistakes major is accepted       -> v1.0.0                -> expects silence
  4. older no-mistakes patch reports upgrade   -> v0.39.9 (below floor) -> expects MISSING message
  5. unparseable version reports upgrade       -> 'development build'   -> expects MISSING message

=== Result ===
ok - bootstrap enforces no-mistakes minimum version
Exit: 0

=== NO_MISTAKES_MIN in bin/fm-bootstrap.sh ===
NO_MISTAKES_MIN=0.40.0
  if command -v no-mistakes >/dev/null 2>&1 && ! tool_version_at_least no-mistakes "$NO_MISTAKES_MIN"; then
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"2434b4cce7116d659394833900cf1d8a3a32c4b9","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"skipped"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-bootstrap.test.sh` (targeted via awk-extracted runner calling only `test_no_mistakes_min_version`)</code>
- <code>Manual grep confirming zero remaining `1.31.2` references across all 11 changed files</code>
</details>

<details>
<summary>⏭️ **Document** - skipped</summary>

Step was skipped.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
