### PR TITLE
fix(bin): parallelize startup network sweeps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 projects/
 state/
 data/
-scratchpad/
+scratchpad*
 .no-mistakes/
 .lavish/
 .fm-secondmate-home

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,7 +159,7 @@ If the session lock cannot be acquired and verified, report its exact diagnostic
 A lock-refused session must not spawn, steer, merge, drain the wake queue, repair supervision, repair a checkout, or perform any other fleet mutation.
 
 The digest itself makes no external-network call and never waits for one.
-Every network check a session start owes - GitHub auth, dead-secondmate relaunch, secondmate convergence, pending handoff delivery, and project clone refresh - runs concurrently in a bounded worker owned by `bin/fm-startup-network.sh` and is reported in the digest's own `NETWORK CHECKS` section.
+Every network check a session start owes - GitHub auth, dead-secondmate relaunch, secondmate convergence, pending handoff delivery, and project clone refresh - runs off the digest's blocking path in a bounded worker owned by `bin/fm-startup-network.sh` and is reported in the digest's own `NETWORK CHECKS` section.
 When that section reports its checks still in progress it names exactly what is unconfirmed; treat none of those as passed until the result lands, either from `bin/fm-startup-network.sh report` or as a `check: startup-network` wake.
 
 1. **Lock** - acquires the per-home session lock first, before anything mutates shared state, then starts the deferred network stage above.

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -89,13 +89,13 @@
 #          the fleet lock, so a second concurrent session never race-mutates
 #          PR-check artifacts, secondmate homes, pending handoff outboxes,
 #          X-mode artifacts, project clones, or repair instructions.
-#          Unset/0 (the default) runs every sweep exactly as before - this flag
-#          is purely additive.
+#          Unset/0 (the default) runs all six sweeps - this flag is purely
+#          additive.
 #          Set FM_BOOTSTRAP_NETWORK to split this run by whether a step talks to
 #          the network, so a session start can print its digest from local reads
-#          alone and run the network half concurrently:
-#            all  (default, and any unrecognized value) - everything, exactly as
-#                 before. Unrecognized values fall back here on purpose: a typo
+#          alone and run the network half off the digest's blocking path:
+#            all  (default, and any unrecognized value) - every local and network
+#                 step. Unrecognized values fall back here on purpose: a typo
 #                 must never silently skip a safety sweep.
 #            skip - every LOCAL step, and none of the network ones. Skips
 #                 `gh auth status`, secondmate_liveness_sweep, secondmate_sync,
@@ -108,7 +108,13 @@
 #          bin/fm-startup-network.sh owns the deferral: it runs the `only` phase
 #          in a detached bounded worker and publishes the result. This file stays
 #          the single owner of every sweep, and the split changes only WHEN each
-#          runs, never WHETHER.
+#          runs, never WHETHER. During the network phase, project clone refresh
+#          overlaps the independent secondmate work. Per-secondmate remote
+#          liveness workers run concurrently and finish before per-secondmate
+#          remote convergence workers run concurrently, because convergence
+#          consumes respawned ids. Worker output is captured separately and
+#          replayed in spawn order; failure to create that private capture
+#          directory selects the sequential fallback.
 #          A relaunch that the liveness sweep performs during an `only` run is
 #          always reported, because a digest composed before that run already
 #          printed the superseded endpoint record.

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -185,6 +185,55 @@ network_sweep_authorized() {
   return 1
 }
 
+# Concurrent per-item runner for the deferred network sweeps. Each worker's
+# stdout and stderr are captured to private files and replayed in original
+# order after every worker finishes, so concurrent probes cannot interleave
+# or mis-attribute SECONDMATE_LIVENESS / SECONDMATE_SYNC lines. Respawned ids
+# are collected from per-id files because background workers cannot mutate
+# the parent's SECONDMATE_RESPAWNED_IDS.
+bootstrap_parallel_begin() {
+  BOOTSTRAP_PAR_DIR=$(mktemp -d "${TMPDIR:-/tmp}/fm-bootstrap-par.XXXXXX") || return 1
+  BOOTSTRAP_PAR_N=0
+  FM_BOOTSTRAP_PARALLEL_DIR=$BOOTSTRAP_PAR_DIR
+  export FM_BOOTSTRAP_PARALLEL_DIR
+}
+
+bootstrap_parallel_spawn() {
+  BOOTSTRAP_PAR_N=$((BOOTSTRAP_PAR_N + 1))
+  (
+    "$@"
+  ) >"$BOOTSTRAP_PAR_DIR/$BOOTSTRAP_PAR_N.out" 2>"$BOOTSTRAP_PAR_DIR/$BOOTSTRAP_PAR_N.err" &
+  printf '%s\n' "$!" > "$BOOTSTRAP_PAR_DIR/$BOOTSTRAP_PAR_N.pid"
+}
+
+bootstrap_parallel_finish() {
+  local i pid f
+  i=1
+  while [ "$i" -le "$BOOTSTRAP_PAR_N" ]; do
+    pid=$(cat "$BOOTSTRAP_PAR_DIR/$i.pid")
+    wait "$pid" || true
+    i=$((i + 1))
+  done
+  i=1
+  while [ "$i" -le "$BOOTSTRAP_PAR_N" ]; do
+    cat "$BOOTSTRAP_PAR_DIR/$i.out"
+    cat "$BOOTSTRAP_PAR_DIR/$i.err" >&2
+    i=$((i + 1))
+  done
+  for f in "$BOOTSTRAP_PAR_DIR"/respawned.*; do
+    [ -f "$f" ] || continue
+    SECONDMATE_RESPAWNED_IDS="$SECONDMATE_RESPAWNED_IDS $(tr -d '\n' < "$f")"
+  done
+  rm -rf "$BOOTSTRAP_PAR_DIR"
+  unset FM_BOOTSTRAP_PARALLEL_DIR BOOTSTRAP_PAR_DIR BOOTSTRAP_PAR_N
+}
+
+secondmate_note_respawned() {  # <id>
+  SECONDMATE_RESPAWNED_IDS="$SECONDMATE_RESPAWNED_IDS $1"
+  [ -n "${FM_BOOTSTRAP_PARALLEL_DIR:-}" ] || return 0
+  printf '%s\n' "$1" > "$FM_BOOTSTRAP_PARALLEL_DIR/respawned.$1"
+}
+
 fleet_sync_origin_backed_project_count() {
   local count proj
   count=0
@@ -549,17 +598,30 @@ secondmate_sync() {
     return 0
   }
 
+  secondmate_sync_remote_one_timed() {  # <id> <home> <remote-host>
+    local id=$1 home=$2 remote_host=$3 __fm_timing_stamp
+    __fm_timing_stamp=$(fm_timing_now_ms)
+    secondmate_sync_remote_one "$id" "$home" "$remote_host"
+    fm_timing_record secondmate convergence "$__fm_timing_stamp" "$id@$remote_host"
+  }
+
   # Remote routes converge through the generic transport. Their code root and
   # inherited files are authoritative on that host; no local path probe or
   # local fast-forward is attempted for them.
-  local remote_host __fm_timing_stamp
+  local remote_host __fm_timing_stamp parallel=0
+  if bootstrap_parallel_begin; then
+    parallel=1
+  fi
   while IFS='|' read -r id _home _window meta; do
     remote_host=$(fm_meta_get "$meta" remote_host)
     [ -n "$remote_host" ] || continue
-    __fm_timing_stamp=$(fm_timing_now_ms)
-    secondmate_sync_remote_one "$id" "$_home" "$remote_host"
-    fm_timing_record secondmate convergence "$__fm_timing_stamp" "$id@$remote_host"
+    if [ "$parallel" -eq 1 ]; then
+      bootstrap_parallel_spawn secondmate_sync_remote_one_timed "$id" "$_home" "$remote_host"
+    else
+      secondmate_sync_remote_one_timed "$id" "$_home" "$remote_host"
+    fi
   done < <(live_secondmate_meta_records "$STATE" "$DATA/secondmates.md")
+  [ "$parallel" -eq 0 ] || bootstrap_parallel_finish
   return 0
 }
 
@@ -586,8 +648,11 @@ secondmate_liveness_sweep() {
   # primary-only no-op there. Mid-session liveness remains explicitly out of
   # scope and requires a separate periodic signal.
   [ -d "$STATE" ] || return 0
-  local meta id remote_host label __fm_timing_stamp
+  local meta id remote_host label __fm_timing_stamp parallel=0
   SECONDMATE_RESPAWNED_IDS=""
+  if bootstrap_parallel_begin; then
+    parallel=1
+  fi
   for meta in "$STATE"/*.meta; do
     [ -f "$meta" ] || continue
     grep -q '^kind=secondmate$' "$meta" 2>/dev/null || continue
@@ -597,18 +662,27 @@ secondmate_liveness_sweep() {
     remote_host=$(fm_meta_get "$meta" remote_host)
     label=$id
     [ -z "$remote_host" ] || label="$id@$remote_host"
-    __fm_timing_stamp=$(fm_timing_now_ms)
-    secondmate_liveness_one "$meta" "$id"
-    fm_timing_record secondmate liveness "$__fm_timing_stamp" "$label"
+    if [ "$parallel" -eq 1 ]; then
+      bootstrap_parallel_spawn secondmate_liveness_one_timed "$meta" "$id" "$label"
+    else
+      secondmate_liveness_one_timed "$meta" "$id" "$label"
+    fi
   done
+  [ "$parallel" -eq 0 ] || bootstrap_parallel_finish
   return 0
+}
+
+secondmate_liveness_one_timed() {  # <meta> <id> <label>
+  local meta=$1 id=$2 label=$3 __fm_timing_stamp
+  __fm_timing_stamp=$(fm_timing_now_ms)
+  secondmate_liveness_one "$meta" "$id"
+  fm_timing_record secondmate liveness "$__fm_timing_stamp" "$label"
 }
 
 # One secondmate's liveness check. Split out of the sweep so each is individually
 # timed; every `return` here was a `continue` in the loop and means exactly the
-# same thing - move on to the next secondmate. SECONDMATE_RESPAWNED_IDS stays a
-# global that this appends to, so the sweep's hand-off to secondmate_sync is
-# unchanged.
+# same thing - move on to the next secondmate. Respawned ids are recorded through
+# secondmate_note_respawned so a concurrent sweep can collect them after wait.
 secondmate_liveness_one() {  # <meta> <id>
   local meta=$1 id=$2
   local window harness backend target agent_state out cause remote_host remote_rc readiness_reason route_out remote_backend
@@ -670,7 +744,7 @@ secondmate_liveness_one() {  # <meta> <id>
       dead|missing)
         cause="remote endpoint $agent_state on its configured host"
         if out=$(FM_SPAWN_NO_GUARD=1 "$FM_ROOT/bin/fm-spawn.sh" "$id" --secondmate 2>&1); then
-          SECONDMATE_RESPAWNED_IDS="$SECONDMATE_RESPAWNED_IDS $id"
+          secondmate_note_respawned "$id"
           report_relaunch "$id" "$cause" "host=$remote_host"
         else
           echo "SECONDMATE_LIVENESS: secondmate $id: respawn failed after $cause: $(first_line "$out")"
@@ -707,7 +781,7 @@ secondmate_liveness_one() {  # <meta> <id>
         cause="recorded endpoint confidently missing"
       fi
       if out=$(FM_SPAWN_NO_GUARD=1 "$FM_ROOT/bin/fm-spawn.sh" "$id" --secondmate 2>&1); then
-        SECONDMATE_RESPAWNED_IDS="$SECONDMATE_RESPAWNED_IDS $id"
+        secondmate_note_respawned "$id"
         report_relaunch "$id" "$cause" "backend=$backend"
       else
         echo "SECONDMATE_LIVENESS: secondmate $id: respawn failed after $cause: $(first_line "$out")"
@@ -1200,8 +1274,9 @@ detect_local_config() {
 # Each network owner below is bracketed by an elapsed-time record, so a deferred
 # stage that ran long can be attributed to the phase that spent the time.
 # fm-timing-lib.sh discards the record unless the caller asked for timings, and
-# every sweep is still called directly and in the same order, so nothing about
-# what runs, in what sequence, or what it returns changes.
+# every sweep is still called directly. Per-secondmate remote probes run
+# concurrently; clone refresh overlaps them. Diagnostic lines are replayed in
+# original order so attribution is unchanged.
 # The stamp variable is named for the library rather than `start` on purpose:
 # fleet_sync and others assign plain names like `start` without `local`, and
 # bash's dynamic scoping would let them overwrite a stamp held by a caller.
@@ -1215,7 +1290,25 @@ local_phase && detect_local_config
 
 if [ "${FM_BOOTSTRAP_DETECT_ONLY:-0}" != 1 ]; then
   # secondmate_sync consumes SECONDMATE_RESPAWNED_IDS from the liveness sweep, so
-  # those two always run together in the same phase.
+  # those two always run together in the same phase. Clone refresh does not
+  # depend on them, so it starts in the background and overlaps their wall clock.
+  fleet_sync_pid=
+  fleet_sync_out=
+  if network_phase && network_sweep_authorized 'project clone refresh'; then
+    fleet_sync_out=$(mktemp "${TMPDIR:-/tmp}/fm-bootstrap-fleet.XXXXXX") || fleet_sync_out=
+    if [ -n "$fleet_sync_out" ]; then
+      (
+        __fm_timing_stamp=$(fm_timing_now_ms)
+        fleet_sync
+        fm_timing_record phase fleet-sync "$__fm_timing_stamp"
+      ) >"$fleet_sync_out" 2>&1 &
+      fleet_sync_pid=$!
+    else
+      __fm_timing_stamp=$(fm_timing_now_ms)
+      fleet_sync
+      fm_timing_record phase fleet-sync "$__fm_timing_stamp"
+    fi
+  fi
   if network_phase; then
     if network_sweep_authorized 'dead-secondmate relaunch'; then
       __fm_timing_stamp=$(fm_timing_now_ms)
@@ -1235,10 +1328,10 @@ if [ "${FM_BOOTSTRAP_DETECT_ONLY:-0}" != 1 ]; then
   fi
   # x_mode_setup writes local Relay artifacts only and never leaves the machine.
   local_phase && x_mode_setup
-  if network_phase && network_sweep_authorized 'project clone refresh'; then
-    __fm_timing_stamp=$(fm_timing_now_ms)
-    fleet_sync
-    fm_timing_record phase fleet-sync "$__fm_timing_stamp"
+  if [ -n "$fleet_sync_pid" ]; then
+    wait "$fleet_sync_pid" || true
+    cat "$fleet_sync_out"
+    rm -f "$fleet_sync_out"
   fi
 fi
 local_phase && secondmate_handoff_detect

--- a/bin/fm-startup-network.sh
+++ b/bin/fm-startup-network.sh
@@ -3,8 +3,8 @@
 #
 # WHY THIS EXISTS. Every external-network call a session start makes used to run
 # BEFORE the digest printed, on a hook that blocks session initialization: `gh
-# auth status`, the secondmate liveness and convergence sweeps (11 sequential,
-# individually unbounded SSH connections per REMOTE secondmate), pending remote
+# auth status`, the secondmate liveness and convergence sweeps (per-secondmate
+# remote probes, which bootstrap runs concurrently), pending remote
 # handoff delivery, and the fleet-sync fetch of every project clone. None of
 # those calls is individually bounded, so one unreachable host could consume the
 # whole FM_SESSION_START_TIMEOUT budget and truncate the digest outright, turning

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -180,7 +180,7 @@ family_for_basename() {
     fm-send-secondmate-marker.test.sh|fm-shared-captain-inheritance.test.sh)
       printf '%s\n' secondmate
       ;;
-    fm-bootstrap.test.sh|fm-fleet-sync.test.sh|fm-gate-refuse.test.sh|fm-gotmp.test.sh|\
+    fm-bootstrap.test.sh|fm-bootstrap-network-parallel.test.sh|fm-fleet-sync.test.sh|fm-gate-refuse.test.sh|fm-gotmp.test.sh|\
     fm-session-start.test.sh|fm-sessionstart-nudge.test.sh|fm-startup-network.test.sh|\
     fm-tangle-guard.test.sh|fm-update.test.sh)
       printf '%s\n' session-bootstrap
@@ -399,6 +399,7 @@ tests/fm-backend.test.sh 17169
 tests/fm-backlog-handoff.test.sh 4157
 tests/fm-bearings-board.test.sh 3385
 tests/fm-bearings-snapshot.test.sh 68659
+tests/fm-bootstrap-network-parallel.test.sh 8000
 tests/fm-bootstrap.test.sh 38417
 tests/fm-busy-adapter-wiring.test.sh 14880
 tests/fm-busy-state.test.sh 714

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -536,8 +536,10 @@ wedge_timer_check() {  # <window> <since-file> <triage-label> <escalation-count-
   since=$(cat "$since_file" 2>/dev/null || true)
   case "$since" in
     ''|*[!0-9]*)
-      date +%s > "$since_file"
+      # Publish the repaired timer only after its old write-deferral chain is
+      # gone, so observers cannot mistake a new idle window for the old chain.
       clear_write_tracking "$(window_key "$win")"
+      date +%s > "$since_file"
       triage_log "absorbed $label timer reset: $win"
       ;;
     *)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,6 +13,7 @@ The tracked code root contains the shared instruction, skill, documentation, wor
 `data/` holds durable private fleet records such as the project and secondmate registries, captain preferences, optional shared captain preferences, learnings, backlog, briefs, and scout reports.
 `state/` holds runtime records such as task metadata, append-only status events, endpoint signals, watcher and wake-queue coordination, inactive terminal-outcome receipts under `state/terminal-outcomes/`, away-mode state, generated Relay artifacts, private secondmate config-reread generations with their retry and quarantine state, per-task steering-inbox records under `state/<id>.inbox/` (`bin/fm-task-inbox-lib.sh`), and parent-owned secondmate pending-reply records under `state/pending-replies/` (`bin/fm-pending-reply-lib.sh`).
 `config/` holds local gitignored operating choices, and `projects/` holds the local project clones that Firstmate reads but changes only through the narrow guarded and concrete captain-approved exceptions in `AGENTS.md`.
+Untracked files and directories whose names begin with `scratchpad` are also gitignored, so temporary scratch does not make porcelain-based secondmate sync guards treat a home as dirty.
 
 `bin/fm-spawn.sh` owns the base task-metadata fields it emits, while the runtime-backend section below owns backend-specific fields and selector interpretation.
 The producing PR and Relay helpers own the fields they append, `bin/fm-classify-lib.sh` owns status-event vocabulary, and `bin/fm-crew-state.sh` owns current-state reconciliation.
@@ -334,14 +335,14 @@ An absent or incompatible `lavish-axi` reports `MISSING: lavish-axi (install: np
 An absent or too-old `quota-axi` reports `MISSING: quota-axi (install: npm install -g quota-axi)`; firstmate cannot resolve a profile array without a compatible binary.
 Bootstrap also reports a `TANGLE:` line when `FM_ROOT` is on a named non-default branch; follow the printed checkout remediation rather than treating it as an installable tool problem.
 In a read-only session that did not get the fleet lock, the same line is advisory and omits the checkout command.
-The locked session-start deferred network stage runs bootstrap's best-effort project clone refresh through `fm-fleet-sync.sh`.
+The locked session-start deferred network stage runs bootstrap's best-effort project clone refresh through `fm-fleet-sync.sh`; [`fm-bootstrap.sh`'s header](../bin/fm-bootstrap.sh) owns the exact clone-refresh overlap, liveness-before-convergence, per-mate concurrency, ordered diagnostic replay, and sequential-fallback contract.
 It emits `FLEET_SYNC:` for skipped refreshes that may matter, recovered self-heals, and `STUCK:` alarms.
 Normal completed runs keep local-only and no-origin skips silent.
 If bootstrap kills a timed-out refresh, it replays any completed `fm-fleet-sync.sh` output before the aggregate timeout skip so no finished result is lost.
 A killed refresh (or a teardown process kill) can leave an orphaned `.git/packed-refs.lock` in a clone, which makes the next refresh's fetch fail with Git's `Unable to create '...packed-refs.lock': File exists`.
 On that signature only, `fm-fleet-sync.sh` retries the fetch with a bounded wait for the lock to self-clear, then removes the lock and retries once more only when it can prove the lock stale, exactly like the `fm-teardown.sh` `index.lock` recovery.
 It never removes a live lock, leaves any other failure shape untouched, and prints every wait, retry, and removal to stderr plus a one-line `recovered:` summary to stdout on success so that this session-start relay still surfaces the recovery.
-The same deferred network stage runs bootstrap's guarded secondmate sync for recorded live homes, then propagates declared inherited local material into each validated live home.
+The same deferred network stage performs guarded tracked-file sync and propagates declared inherited local material into each validated live home under that sequencing contract.
 Local routes use direct guarded filesystem operations, while remote routes delegate sync and allowlisted transfer through their configured SSH host without probing any unconfigured fleet.
 It emits `SECONDMATE_SYNC:` only when a home was skipped for an actionable sync reason, inheritance failed, or a divergent shared captain-preference copy was quarantined.
 When a running home advances and its loaded instruction surface (`AGENTS.md`, `bin/`, or `.agents/skills/`) changed, bootstrap sends the re-read nudge itself through the stable `fm-<id>` selector and reports the exact completed send as `BOOTSTRAP_INFO:`.

--- a/docs/sessionstart-nudge.md
+++ b/docs/sessionstart-nudge.md
@@ -41,7 +41,7 @@ On a run-tier harness the nudge cannot also fire: `resume`, `reload`, and `fork`
 ## Runtime bound
 
 The run tier blocks session initialization while the digest runs, so `bin/fm-session-start.sh` bounds itself rather than betting on each harness's own hook timeout.
-The digest makes no external-network call at all: every one it owes runs concurrently in the separately bounded deferred stage owned by `bin/fm-startup-network.sh`, so an unreachable host can no longer consume this budget.
+The digest makes no external-network call at all: every one it owes runs off the blocking path in the separately bounded deferred stage owned by `bin/fm-startup-network.sh`, so an unreachable host can no longer consume this budget.
 What remains is still not individually bounded - tool version probes, the backlog listing, and the per-task endpoint reads are all local but unbounded subprocesses - so the whole digest runs as one bounded child, default 120s via `FM_SESSION_START_TIMEOUT`.
 The shared timeout owner falls back to a pure-Bash process-group watchdog when timeout, gtimeout, and perl are unavailable, so no supported host runs the digest unbounded.
 Because the child writes straight to the hook's stdout, everything emitted before the bound was hit is already delivered; the parent then prints a `STARTUP TRUNCATED` banner naming the stage that did not finish and the stages that were therefore never emitted, and still exits 0.

--- a/tests/fm-bootstrap-network-parallel.test.sh
+++ b/tests/fm-bootstrap-network-parallel.test.sh
@@ -26,7 +26,10 @@ command -v python3 >/dev/null 2>&1 \
   || fail "python3 is required to decode the fm-on.sh argv payload"
 
 REAL_GIT=$(command -v git) || fail "git is required"
+REAL_MKTEMP=$(command -v mktemp) || fail "mktemp is required"
 fm_git_identity fmtest fmtest@example.invalid
+
+[ -z "${FM_TEST_EVIDENCE_FILE:-}" ] || : > "$FM_TEST_EVIDENCE_FILE"
 
 write_remote_registry_line() { # <file> <id> <host> <root> <home>
   printf -- '- %s - %s delivery (host: %s; root: %s; home: %s; scope: test work; projects: alpha; added 2026-08-02)\n' \
@@ -96,6 +99,10 @@ case "$command_name" in
         ;;
       sync)
         case "$host" in
+          "${FM_FAKE_SSH_FAIL_HOST:-host-alpha}")
+            printf 'synthetic tracked-file sync refusal for %s\n' "$host"
+            exit 1
+            ;;
           "${FM_FAKE_SSH_DIRTY_HOST:-host-charlie}")
             printf 'remote secondmate checkout is dirty; sync skipped\n'
             exit 1
@@ -150,18 +157,33 @@ starts_before_first_end() { # <log> <pattern>
   ' "$1"
 }
 
-test_concurrent_remote_probes_keep_per_mate_lines() {
-  local dir home fakebin log out n doctor_overlap overlap liveness_starts fetch_starts
+test_remote_probe_scheduling_keeps_per_mate_lines() { # <parallel|fallback>
+  local mode=$1
+  local dir home primary fakebin log out n doctor_overlap liveness_starts fetch_starts
   local alpha_root alpha_home bravo_root bravo_home charlie_root charlie_home
-  dir="$TMP_ROOT/parallel-lines"
+  dir="$TMP_ROOT/parallel-lines-$mode"
   home="$dir/home"
-  mkdir -p "$home/state" "$home/data" "$home/config" "$home/projects"
+  primary="$dir/primary"
+  mkdir -p "$home/state" "$home/data" "$home/config" "$home/projects" "$primary"
+  git init -q -b main "$primary"
+  cp -R "$ROOT/bin" "$primary/bin"
+  printf 'test primary\n' > "$primary/AGENTS.md"
+  git -C "$primary" add AGENTS.md bin
+  git -C "$primary" commit -qm 'seed primary default branch'
   fakebin=$(fm_fakebin "$dir")
   fm_fake_exit0 "$fakebin" gh treehouse tmux node
   log="$dir/probe.log"
   : > "$log"
   install_fake_ssh "$fakebin"
   install_slow_git "$fakebin" "$REAL_GIT" "$log"
+  if [ "$mode" = fallback ]; then
+    cat > "$fakebin/mktemp" <<SH
+#!/usr/bin/env bash
+case "\$*" in *fm-bootstrap-par.XXXXXX*) exit 1 ;; esac
+exec '$REAL_MKTEMP' "\$@"
+SH
+    chmod +x "$fakebin/mktemp"
+  fi
 
   alpha_root="$dir/remote/alpha/root"
   alpha_home="$dir/remote/alpha/home"
@@ -189,11 +211,13 @@ test_concurrent_remote_probes_keep_per_mate_lines() {
   out=$(
     PATH="$fakebin:$BASE_PATH" \
     FM_HOME="$home" \
+    FM_ROOT_OVERRIDE="$primary" \
     FM_BOOTSTRAP_NETWORK=only \
     FM_SSH_BIN="$fakebin/fake-ssh" \
     FM_FAKE_SSH_LOG="$log" \
     FM_FAKE_SSH_SLEEP=0.4 \
     FM_FAKE_SSH_UNREACHABLE_HOST=host-bravo \
+    FM_FAKE_SSH_FAIL_HOST=host-alpha \
     FM_FAKE_SSH_DIRTY_HOST=host-charlie \
     FM_FAKE_GIT_FETCH_SLEEP=0.4 \
     FM_INHERITABLE_CONFIG= \
@@ -217,13 +241,19 @@ test_concurrent_remote_probes_keep_per_mate_lines() {
   [ "$n" -eq 1 ] || fail "bravo liveness line was lost or duplicated (count=$n)"$'\n'"$out"
   n=$(printf '%s\n' "$out" | grep -c 'SECONDMATE_SYNC: secondmate charlie:' || true)
   [ "$n" -eq 1 ] || fail "charlie sync line was lost or duplicated (count=$n)"$'\n'"$out"
+  n=$(printf '%s\n' "$out" | sed -n 's/^SECONDMATE_SYNC: secondmate \([^:]*\):.*/\1/p' | tr '\n' ' ')
+  [ "$n" = "alpha bravo bravo charlie " ] \
+    || fail "sync diagnostics were lost, duplicated, or replayed outside spawn order: $n"$'\n'"$out"
 
   assert_not_contains "$out" \
     "SECONDMATE_LIVENESS: secondmate alpha: skipped: remote host unavailable or endpoint state unknown" \
     "a reachable mate must not inherit the unreachable mate's liveness skip"
+  assert_contains "$out" \
+    "SECONDMATE_SYNC: secondmate alpha: skipped: remote tracked-file sync failed on host-alpha: synthetic tracked-file sync refusal for host-alpha" \
+    "the first worker's diagnostic must retain its own host and complete message"
   assert_not_contains "$out" \
-    "SECONDMATE_SYNC: secondmate alpha: skipped: remote tracked-file sync failed" \
-    "a clean reachable mate must not inherit the dirty mate's sync skip"
+    "SECONDMATE_SYNC: secondmate alpha: skipped: remote tracked-file sync failed on host-alpha: remote secondmate checkout is dirty" \
+    "the first worker must not inherit the dirty mate's reason"
 
   while IFS= read -r line; do
     [ -n "$line" ] || continue
@@ -241,8 +271,13 @@ $(printf '%s\n' "$out" | grep '^SECONDMATE_' || true)
 EOF
 
   doctor_overlap=$(starts_before_first_end "$log" 'fm-remote-doctor.sh')
-  [ "$doctor_overlap" -ge 2 ] \
-    || fail "remote liveness probes did not overlap (starts before first doctor end=$doctor_overlap)"$'\n'"$(cat "$log")"
+  if [ "$mode" = parallel ]; then
+    [ "$doctor_overlap" -ge 2 ] \
+      || fail "remote liveness probes did not overlap (starts before first doctor end=$doctor_overlap)"$'\n'"$(cat "$log")"
+  else
+    [ "$doctor_overlap" -eq 1 ] \
+      || fail "mktemp failure did not select sequential liveness fallback (starts before first doctor end=$doctor_overlap)"$'\n'"$(cat "$log")"
+  fi
 
   liveness_starts=$(grep -c '^START .* fm-remote-secondmate-control.sh state$' "$log" || true)
   [ "$liveness_starts" -ge 2 ] \
@@ -251,15 +286,31 @@ EOF
   fetch_starts=$(grep -c '^START fleet-fetch ' "$log" || true)
   [ "$fetch_starts" -ge 1 ] \
     || fail "clone refresh did not start a fetch to overlap with secondmate probes"$'\n'"$(cat "$log")"
-  overlap=$(awk '
-    $1 == "START" { starts++ }
-    $1 == "END" { print starts + 0; exit }
-  ' "$log")
-  [ "$overlap" -ge 2 ] \
-    || fail "clone refresh did not overlap the secondmate sweeps (starts before first end=$overlap)"$'\n'"$(cat "$log")"
+  awk '
+    /^START fleet-fetch / { fleet = 1; if (remote) overlap = 1; next }
+    /^END fleet-fetch / { fleet = 0; next }
+    /^START host-/ { remote++; if (fleet) overlap = 1; next }
+    /^END host-/ { remote-- }
+    END { exit !overlap }
+  ' "$log" || fail "clone refresh did not overlap the secondmate sweeps"$'\n'"$(cat "$log")"
 
-  pass "bootstrap network: concurrent remote probes keep per-mate lines and fail closed"
+  awk '
+    /END .* fm-remote-secondmate-control.sh state$/ { last_liveness = NR }
+    /START .* fm-remote-secondmate-control.sh sync$/ && !first_sync { first_sync = NR }
+    END { exit !(last_liveness && first_sync && last_liveness < first_sync) }
+  ' "$log" || fail "convergence began before all liveness probes finished"$'\n'"$(cat "$log")"
+
+  if [ -n "${FM_TEST_EVIDENCE_FILE:-}" ]; then
+    {
+      printf '=== %s bootstrap network output ===\n%s\n' "$mode" "$out"
+      printf '=== %s remote operation timeline ===\n' "$mode"
+      cat "$log"
+    } >> "$FM_TEST_EVIDENCE_FILE"
+  fi
+
+  pass "bootstrap network ($mode): per-mate output stays intact, fail-closed, and correctly sequenced"
 }
 
-test_concurrent_remote_probes_keep_per_mate_lines
+test_remote_probe_scheduling_keeps_per_mate_lines parallel
+test_remote_probe_scheduling_keeps_per_mate_lines fallback
 echo "# all fm-bootstrap-network-parallel tests passed"

--- a/tests/fm-bootstrap-network-parallel.test.sh
+++ b/tests/fm-bootstrap-network-parallel.test.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+# Concurrent deferred-network secondmate probes must keep every per-mate
+# diagnostic complete, attributed, and fail-closed.
+#
+# The session-start network stage used to walk remote secondmates one after
+# another. The public contract that must survive concurrency is not a particular
+# worker scheduler: it is that each mate still emits its own SECONDMATE_LIVENESS
+# / SECONDMATE_SYNC line, that those lines cannot splice into each other, and
+# that a dirty or unreachable mate still refuses rather than proceeding. This
+# suite drives bin/fm-bootstrap.sh's network-only phase through FM_SSH_BIN, so
+# it exercises the same remote probe path a real session start uses.
+set -u
+
+# shellcheck source=tests/lib.sh disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+BASE_PATH=${FM_TEST_BASE_PATH:-/usr/bin:/bin:/usr/sbin:/sbin}
+TMP_ROOT=$(fm_test_tmproot fm-bootstrap-network-parallel)
+TMP_ROOT=$(cd "$TMP_ROOT" && pwd)
+export FM_BACKEND_CMUX_BUNDLE_BIN="$TMP_ROOT/no-bundled-cmux"
+unset TMUX TMUX_PANE HERDR_ENV HERDR_PANE_ID HERDR_SESSION HERDR_SOCKET_PATH \
+  CMUX_WORKSPACE_ID CMUX_SURFACE_ID CMUX_SOCKET_PATH CMUX_TAB_ID CMUX_PANEL_ID \
+  2>/dev/null || true
+
+command -v python3 >/dev/null 2>&1 \
+  || fail "python3 is required to decode the fm-on.sh argv payload"
+
+REAL_GIT=$(command -v git) || fail "git is required"
+fm_git_identity fmtest fmtest@example.invalid
+
+write_remote_registry_line() { # <file> <id> <host> <root> <home>
+  printf -- '- %s - %s delivery (host: %s; root: %s; home: %s; scope: test work; projects: alpha; added 2026-08-02)\n' \
+    "$2" "$2" "$3" "$4" "$5" >> "$1"
+}
+
+install_fake_ssh() {
+  local fakebin=$1
+  cat > "$fakebin/fake-ssh" <<'SH'
+#!/usr/bin/env bash
+set -eu
+log=${FM_FAKE_SSH_LOG:?}
+sleep_s=${FM_FAKE_SSH_SLEEP:-0.4}
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) shift 2 ;;
+    --) shift; break ;;
+    *) exit 90 ;;
+  esac
+done
+host=${1:-}
+entry=${2:-}
+shift 2 || true
+[ "$entry" = fm-remote-entrypoint.sh ] || exit 92
+argv_b64=${4:-}
+cmd=$(python3 -c 'import sys, base64
+raw = base64.b64decode(sys.argv[1])
+parts = [p.decode() for p in raw.split(b"\0") if p]
+print(parts[0] if parts else "")
+print(parts[1] if len(parts) > 1 else "")
+print(parts[2] if len(parts) > 2 else "")
+' "$argv_b64")
+command_name=$(printf '%s\n' "$cmd" | sed -n '1p')
+subcommand=$(printf '%s\n' "$cmd" | sed -n '2p')
+slow=0
+case "$command_name" in
+  fm-remote-doctor.sh) slow=1 ;;
+  fm-remote-secondmate-control.sh)
+    case "$subcommand" in state|sync) slow=1 ;; esac
+    ;;
+esac
+if [ "$slow" -eq 1 ]; then
+  printf 'START %s %s %s\n' "$host" "$command_name" "$subcommand" >> "$log"
+  sleep "$sleep_s"
+  printf 'END %s %s %s\n' "$host" "$command_name" "$subcommand" >> "$log"
+else
+  printf 'QUICK %s %s %s\n' "$host" "$command_name" "$subcommand" >> "$log"
+fi
+case "$host" in
+  "${FM_FAKE_SSH_UNREACHABLE_HOST:-host-bravo}")
+    exit 255
+    ;;
+esac
+case "$command_name" in
+  fm-remote-doctor.sh)
+    exit 0
+    ;;
+  fm-remote-secondmate-control.sh)
+    case "$subcommand" in
+      state)
+        printf 'alive\n'
+        exit 0
+        ;;
+      route)
+        printf 'backend=herdr\n'
+        exit 0
+        ;;
+      sync)
+        case "$host" in
+          "${FM_FAKE_SSH_DIRTY_HOST:-host-charlie}")
+            printf 'remote secondmate checkout is dirty; sync skipped\n'
+            exit 1
+            ;;
+        esac
+        printf 'current: test\n'
+        exit 0
+        ;;
+    esac
+    exit 0
+    ;;
+  fm-remote-inherit.sh)
+    exit 0
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/fake-ssh"
+}
+
+install_slow_git() {
+  local fakebin=$1 real_git=$2 log=$3
+  cat > "$fakebin/git" <<SH
+#!/usr/bin/env bash
+set -eu
+slow=0
+for arg in "\$@"; do
+  if [ "\$arg" = fetch ]; then
+    slow=1
+    break
+  fi
+done
+if [ "\$slow" -eq 1 ]; then
+  printf 'START fleet-fetch git fetch\n' >> '$log'
+  sleep "\${FM_FAKE_GIT_FETCH_SLEEP:-0.4}"
+  printf 'END fleet-fetch git fetch\n' >> '$log'
+fi
+exec '$real_git' "\$@"
+SH
+  chmod +x "$fakebin/git"
+}
+
+starts_before_first_end() { # <log> <pattern>
+  awk -v pat="$2" '
+    $0 ~ pat && $1 == "START" { starts++ }
+    $0 ~ pat && $1 == "END" {
+      print starts + 0
+      found = 1
+      exit
+    }
+    END { if (!found) print starts + 0 }
+  ' "$1"
+}
+
+test_concurrent_remote_probes_keep_per_mate_lines() {
+  local dir home fakebin log out n doctor_overlap overlap liveness_starts fetch_starts
+  local alpha_root alpha_home bravo_root bravo_home charlie_root charlie_home
+  dir="$TMP_ROOT/parallel-lines"
+  home="$dir/home"
+  mkdir -p "$home/state" "$home/data" "$home/config" "$home/projects"
+  fakebin=$(fm_fakebin "$dir")
+  fm_fake_exit0 "$fakebin" gh treehouse tmux node
+  log="$dir/probe.log"
+  : > "$log"
+  install_fake_ssh "$fakebin"
+  install_slow_git "$fakebin" "$REAL_GIT" "$log"
+
+  alpha_root="$dir/remote/alpha/root"
+  alpha_home="$dir/remote/alpha/home"
+  bravo_root="$dir/remote/bravo/root"
+  bravo_home="$dir/remote/bravo/home"
+  charlie_root="$dir/remote/charlie/root"
+  charlie_home="$dir/remote/charlie/home"
+  mkdir -p "$alpha_root" "$alpha_home" "$bravo_root" "$bravo_home" "$charlie_root" "$charlie_home"
+
+  : > "$home/data/secondmates.md"
+  write_remote_registry_line "$home/data/secondmates.md" alpha host-alpha "$alpha_root" "$alpha_home"
+  write_remote_registry_line "$home/data/secondmates.md" bravo host-bravo "$bravo_root" "$bravo_home"
+  write_remote_registry_line "$home/data/secondmates.md" charlie host-charlie "$charlie_root" "$charlie_home"
+
+  fm_write_secondmate_meta "$home/state/alpha.meta" "$alpha_home"
+  printf 'remote_host=host-alpha\n' >> "$home/state/alpha.meta"
+  fm_write_secondmate_meta "$home/state/bravo.meta" "$bravo_home"
+  printf 'remote_host=host-bravo\n' >> "$home/state/bravo.meta"
+  fm_write_secondmate_meta "$home/state/charlie.meta" "$charlie_home"
+  printf 'remote_host=host-charlie\n' >> "$home/state/charlie.meta"
+
+  fm_git_init_commit "$home/projects/alpha"
+  fm_git_add_origin "$home/projects/alpha" "$dir/alpha.origin.git"
+
+  out=$(
+    PATH="$fakebin:$BASE_PATH" \
+    FM_HOME="$home" \
+    FM_BOOTSTRAP_NETWORK=only \
+    FM_SSH_BIN="$fakebin/fake-ssh" \
+    FM_FAKE_SSH_LOG="$log" \
+    FM_FAKE_SSH_SLEEP=0.4 \
+    FM_FAKE_SSH_UNREACHABLE_HOST=host-bravo \
+    FM_FAKE_SSH_DIRTY_HOST=host-charlie \
+    FM_FAKE_GIT_FETCH_SLEEP=0.4 \
+    FM_INHERITABLE_CONFIG= \
+    FM_FAKE_TREEHOUSE_LEASE_HELP=1 \
+    "$ROOT/bin/fm-bootstrap.sh" 2>&1
+  )
+
+  assert_contains "$out" \
+    "SECONDMATE_LIVENESS: secondmate bravo: skipped: remote host unavailable or endpoint state unknown; route preserved on host-bravo" \
+    "an unreachable mate must fail closed with its own liveness line"
+  assert_contains "$out" \
+    "SECONDMATE_SYNC: secondmate bravo: skipped:" \
+    "an unreachable mate must also fail closed on convergence rather than disappearing"
+  assert_contains "$out" \
+    "SECONDMATE_SYNC: secondmate charlie: skipped: remote tracked-file sync failed on host-charlie:" \
+    "a dirty remote mate must fail closed with its own sync line"
+  assert_contains "$out" "dirty" \
+    "the dirty mate's skip line must still name dirtiness"
+
+  n=$(printf '%s\n' "$out" | grep -c 'SECONDMATE_LIVENESS: secondmate bravo:' || true)
+  [ "$n" -eq 1 ] || fail "bravo liveness line was lost or duplicated (count=$n)"$'\n'"$out"
+  n=$(printf '%s\n' "$out" | grep -c 'SECONDMATE_SYNC: secondmate charlie:' || true)
+  [ "$n" -eq 1 ] || fail "charlie sync line was lost or duplicated (count=$n)"$'\n'"$out"
+
+  assert_not_contains "$out" \
+    "SECONDMATE_LIVENESS: secondmate alpha: skipped: remote host unavailable or endpoint state unknown" \
+    "a reachable mate must not inherit the unreachable mate's liveness skip"
+  assert_not_contains "$out" \
+    "SECONDMATE_SYNC: secondmate alpha: skipped: remote tracked-file sync failed" \
+    "a clean reachable mate must not inherit the dirty mate's sync skip"
+
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    case "$line" in
+      SECONDMATE_LIVENESS:\ secondmate\ [A-Za-z0-9._-]*:*|SECONDMATE_SYNC:\ secondmate\ [A-Za-z0-9._-]*:*) ;;
+      *) fail "a per-mate line was interleave-corrupted: $line" ;;
+    esac
+    n=0
+    case "$line" in *" secondmate alpha:"*) n=$((n + 1)) ;; esac
+    case "$line" in *" secondmate bravo:"*) n=$((n + 1)) ;; esac
+    case "$line" in *" secondmate charlie:"*) n=$((n + 1)) ;; esac
+    [ "$n" -le 1 ] || fail "a per-mate line named more than one mate: $line"
+  done <<EOF
+$(printf '%s\n' "$out" | grep '^SECONDMATE_' || true)
+EOF
+
+  doctor_overlap=$(starts_before_first_end "$log" 'fm-remote-doctor.sh')
+  [ "$doctor_overlap" -ge 2 ] \
+    || fail "remote liveness probes did not overlap (starts before first doctor end=$doctor_overlap)"$'\n'"$(cat "$log")"
+
+  liveness_starts=$(grep -c '^START .* fm-remote-secondmate-control.sh state$' "$log" || true)
+  [ "$liveness_starts" -ge 2 ] \
+    || fail "expected concurrent remote state probes, got $liveness_starts"$'\n'"$(cat "$log")"
+
+  fetch_starts=$(grep -c '^START fleet-fetch ' "$log" || true)
+  [ "$fetch_starts" -ge 1 ] \
+    || fail "clone refresh did not start a fetch to overlap with secondmate probes"$'\n'"$(cat "$log")"
+  overlap=$(awk '
+    $1 == "START" { starts++ }
+    $1 == "END" { print starts + 0; exit }
+  ' "$log")
+  [ "$overlap" -ge 2 ] \
+    || fail "clone refresh did not overlap the secondmate sweeps (starts before first end=$overlap)"$'\n'"$(cat "$log")"
+
+  pass "bootstrap network: concurrent remote probes keep per-mate lines and fail closed"
+}
+
+test_concurrent_remote_probes_keep_per_mate_lines
+echo "# all fm-bootstrap-network-parallel tests passed"

--- a/tests/fm-bootstrap-network-parallel.test.sh
+++ b/tests/fm-bootstrap-network-parallel.test.sh
@@ -220,7 +220,7 @@ SH
     FM_FAKE_SSH_FAIL_HOST=host-alpha \
     FM_FAKE_SSH_DIRTY_HOST=host-charlie \
     FM_FAKE_GIT_FETCH_SLEEP=0.4 \
-    FM_INHERITABLE_CONFIG= \
+    FM_INHERITABLE_CONFIG='' \
     FM_FAKE_TREEHOUSE_LEASE_HELP=1 \
     "$ROOT/bin/fm-bootstrap.sh" 2>&1
   )

--- a/tests/fm-gitignore-config.test.sh
+++ b/tests/fm-gitignore-config.test.sh
@@ -43,5 +43,47 @@ test_unrelated_path_stays_visible() {
   pass "an unrelated path outside config/ remains visible to git"
 }
 
+test_scratchpad_prefix_is_ignored() {
+  local sample
+  for sample in scratchpad scratchpad2/file scratchpad-foo scratchpad/tmp; do
+    git -C "$ROOT" check-ignore -q "$sample" \
+      || fail "git does not ignore $sample (names starting with scratchpad must be ignored)"
+  done
+  git -C "$ROOT" check-ignore -q not-scratchpad \
+    && fail "git unexpectedly ignores not-scratchpad (must not match the scratchpad* prefix)"
+  pass "names starting with scratchpad are gitignored"
+}
+
+test_scratchpad_prefix_ignores_no_tracked_path() {
+  local tracked
+  tracked=$(git -C "$ROOT" ls-files | grep -E '(^|/)scratchpad' || true)
+  [ -z "$tracked" ] \
+    || fail "a currently tracked path would be newly ignored by scratchpad*: $tracked"
+  pass "no currently tracked path starts with scratchpad"
+}
+
+test_scratchpad2_does_not_dirty_porcelain() {
+  # Remote sync uses git status --porcelain. A scratchpad2/ directory must not
+  # make a home look dirty once scratchpad* is gitignored.
+  local repo status
+  repo=$(mktemp -d "${TMPDIR:-/tmp}/fm-scratchpad-ignore.XXXXXX")
+  git init -q "$repo"
+  cp "$ROOT/.gitignore" "$repo/.gitignore"
+  git -C "$repo" add .gitignore
+  git -C "$repo" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' \
+    commit -qm 'seed gitignore'
+  mkdir -p "$repo/scratchpad2"
+  printf 'notes\n' > "$repo/scratchpad2/notes.txt"
+  printf 'loose\n' > "$repo/scratchpad"
+  printf 'named\n' > "$repo/scratchpad-foo"
+  status=$(git -C "$repo" status --porcelain)
+  rm -rf "$repo"
+  [ -z "$status" ] || fail "scratchpad* paths still dirty porcelain: $status"
+  pass "scratchpad2/ does not make git status --porcelain dirty"
+}
+
 test_config_dir_ignored_as_category
 test_unrelated_path_stays_visible
+test_scratchpad_prefix_is_ignored
+test_scratchpad_prefix_ignores_no_tracked_path
+test_scratchpad2_does_not_dirty_porcelain

--- a/tests/fm-secondmate-sync.test.sh
+++ b/tests/fm-secondmate-sync.test.sh
@@ -51,7 +51,7 @@ new_world() {
   git init -q -b main "$w/main"
   # Mirror the real repo: the gitignored operational dirs never dirty a worktree,
   # so a secondmate home's data/state/projects can never block its fast-forward.
-  printf 'projects/\nstate/\ndata/\n.no-mistakes/\nconfig/crew-harness\n' > "$w/main/.gitignore"
+  printf 'projects/\nstate/\ndata/\n.no-mistakes/\nconfig/crew-harness\nscratchpad*\n' > "$w/main/.gitignore"
   printf 'v1\n' > "$w/main/AGENTS.md"
   printf 'r1\n' > "$w/main/README.md"
   mkdir -p "$w/main/bin" "$w/main/.agents/skills"
@@ -186,6 +186,25 @@ test_ff_dirty() {
   [ "$(head_of "$w/sm")" = "$before" ] || fail "dirty home HEAD moved"
   grep -q 'uncommitted local edit' "$w/sm/AGENTS.md" || fail "dirty edit was discarded"
   pass "T3 dirty: an uncommitted home is skipped, its edit preserved"
+}
+
+# --- scratchpad2 must not trip the dirty-home sync guard ----------------------
+test_scratchpad2_does_not_dirty_home() {
+  local w c1 base
+  w=$(new_world scratchpad2-clean)
+  c1=$(head_of "$w/main")
+  git -C "$w/main" worktree add -q --detach "$w/sm" "$c1"
+  mkdir -p "$w/sm/scratchpad2"
+  printf 'notes\n' > "$w/sm/scratchpad2/notes.txt"
+  bump_primary "$w" instr
+  base=$(primary_head_commit "$w/main")
+
+  run_ff "$w/sm" "$base"
+
+  [ "$FF_STATUS" = updated ] || fail "FF_STATUS: expected updated, got '$FF_STATUS' (scratchpad2/ must not dirty the home)"
+  [ "$(head_of "$w/sm")" = "$base" ] || fail "home did not fast-forward past an ignored scratchpad2/ directory"
+  grep -q notes "$w/sm/scratchpad2/notes.txt" || fail "scratchpad2 contents were discarded"
+  pass "scratchpad2/ does not mark a secondmate home dirty for the sync guard"
 }
 
 # --- T4: diverged - a home with its own commit is skipped, commit preserved --
@@ -872,6 +891,7 @@ test_seed_marker_does_not_mask_real_dirt() {
 test_ff_updated
 test_ff_current
 test_ff_dirty
+test_scratchpad2_does_not_dirty_home
 test_ff_diverged
 test_ff_inflight_feature_branch
 test_no_fetch_in_local_path


### PR DESCRIPTION
## Intent

Parallelize session-start network sweeps in bin/fm-startup-network.sh and bin/fm-bootstrap.sh: run per-secondmate remote liveness/relaunch concurrently rather than a sequential for-loop; run per-secondmate convergence sync concurrently; overlap project-clone refresh (fleet_sync) with those sweeps where they are independent. Keep the 120-second overall stage bound and the existing fail-closed guards (dirty worktree, unknown remote, unreachable remote; never force, stash, or discard unlanded work). Every per-mate SECONDMATE_LIVENESS: and SECONDMATE_SYNC: line must still be emitted, attributed to the correct mate, and not lost, duplicated, or interleave-corrupted under concurrency. Liveness must finish before sync because sync consumes respawned ids; do not overlap liveness with sync. Gitignore files and directories whose names start with scratchpad (scratchpad, scratchpad2/, scratchpad-foo) so untracked scratch no longer trips the remote-secondmate dirty-sync guard, without newly ignoring any currently-tracked path. Include a concurrency-safety regression test and keep colocated tests updated. Worker output is captured per-mate and replayed in original spawn order so concurrent probes cannot interleave or mis-attribute lines; respawned ids are recorded via files because background subshells cannot mutate parent state; sequential fallback remains if mktemp -d fails; the parent waits on explicit PIDs, never a bare wait.

## What Changed

- Run per-secondmate liveness and convergence probes concurrently while preserving liveness-before-sync ordering, respawned IDs, ordered diagnostics, and a sequential fallback.
- Overlap project clone refresh with independent secondmate sweeps using explicit PID waits.
- Ignore `scratchpad*` paths and add regression coverage for concurrency safety, fail-closed behavior, and dirty-sync guards.

## Risk Assessment

✅ Low: The implementation is well-bounded, preserves liveness-before-sync ordering and fail-closed behavior, captures per-mate output deterministically, retains explicit-PID waits and sequential fallback, and includes behavioral concurrency coverage.

## Testing

Exercised the network-only bootstrap through fake remote endpoints in parallel and with forced `mktemp -d` failure, demonstrating concurrent liveness and sync sweeps, fleet-fetch overlap, strict liveness-before-sync ordering, spawn-order output replay, and preserved dirty/unreachable fail-closed diagnostics. Gitignore behavior, secondmate dirty-work guards, fleet-sync safety, and the startup stage bound also passed targeted tests; an exploratory broad bootstrap run exceeded its local 180-second limit after the relevant assertions had passed.

<details>
<summary>Evidence: Bootstrap parallel/fallback output and remote-operation timeline</summary>

Source: [Bootstrap parallel/fallback output and remote-operation timeline](https://github.com/kunchenguid/firstmate/blob/80f892073a34bcd7f548e1b0a283f92bc89b9346/.no-mistakes/evidence/fm/fm-startup-network-parallel-r1/bootstrap-network-parallel-transcript.txt)

```text
=== parallel bootstrap network output ===
SECONDMATE_LIVENESS: secondmate bravo: skipped: remote host unavailable or endpoint state unknown; route preserved on host-bravo
SECONDMATE_SYNC: secondmate alpha: skipped: remote tracked-file sync failed on host-alpha: synthetic tracked-file sync refusal for host-alpha
SECONDMATE_SYNC: secondmate bravo: skipped: remote tracked-file sync failed on host-bravo: 
SECONDMATE_SYNC: secondmate bravo: skipped: remote inheritance failed on host-bravo: 
SECONDMATE_SYNC: secondmate charlie: skipped: remote tracked-file sync failed on host-charlie: remote secondmate checkout is dirty; sync skipped
=== parallel remote operation timeline ===
START host-alpha fm-remote-doctor.sh 
START host-charlie fm-remote-doctor.sh 
START host-bravo fm-remote-doctor.sh 
END host-bravo fm-remote-doctor.sh 
END host-alpha fm-remote-doctor.sh 
END host-charlie fm-remote-doctor.sh 
START host-alpha fm-remote-secondmate-control.sh state
START host-charlie fm-remote-secondmate-control.sh state
START fleet-fetch git fetch
END host-charlie fm-remote-secondmate-control.sh state
END host-alpha fm-remote-secondmate-control.sh state
QUICK host-charlie fm-remote-secondmate-control.sh route
QUICK host-alpha fm-remote-secondmate-control.sh route
END fleet-fetch git fetch
START host-alpha fm-remote-secondmate-control.sh sync
START host-bravo fm-remote-secondmate-control.sh sync
START host-charlie fm-remote-secondmate-control.sh sync
END host-bravo fm-remote-secondmate-control.sh sync
END host-alpha fm-remote-secondmate-control.sh sync
END host-charlie fm-remote-secondmate-control.sh sync
QUICK host-bravo fm-remote-inherit.sh absent
QUICK host-alpha fm-remote-inherit.sh absent
QUICK host-charlie fm-remote-inherit.sh absent
QUICK host-charlie fm-remote-inherit.sh absent
QUICK host-alpha fm-remote-inherit.sh absent
QUICK host-charlie fm-remote-inherit.sh absent
QUICK host-alpha fm-remote-inherit.sh absent
QUICK host-charlie fm-remote-inherit.sh absent
QUICK host-alpha fm-remote-inherit.sh absent
QUICK host-alpha fm-remote-inherit.sh absent
QUICK host-charlie fm-remote-inherit.sh absent
QUICK host-charlie fm-remote-inherit.sh absent
QUICK host-alpha fm-remote-inherit.sh absent
QUICK host-alpha fm-remote-inherit.sh absent
QUICK host-charlie fm-remote-inherit.sh absent
=== fallback bootstrap network output ===
SECONDMATE_LIVENESS: secondmate bravo: skipped: remote host unavailable or endpoint state unknown; route preserved on host-bravo
SECONDMATE_SYNC: secondmate alpha: skipped: remote tracked-file sync failed on host-alpha: synthetic tracked-file sync refusal for host-alpha
SECONDMATE_SYNC: secondmate bravo: skipped: remote tracked-file sync failed on host-bravo: 
SECONDMATE_SYNC: secondmate bravo: skipped: remote inheritance failed on host-bravo: 
SECONDMATE_SYNC: secondmate charlie: skipped: remote tracked-file sync failed on host-charlie: remote secondmate checkout is dirty; sync skipped
=== fallback remote operation timeline ===
START host-alpha fm-remote-doctor.sh 
END host-alpha fm-remote-doctor.sh 
START host-alpha fm-remote-secondmate-control.sh state
START fleet-fetch git fetch
END host-alpha fm-remote-secondmate-control.sh state
QUICK host-alpha fm-remote-secondmate-control.sh route
END fleet-fetch git fetch
START host-bravo fm-remote-doctor.sh 
END host-bravo fm-remote-doctor.sh 
START host-charlie fm-remote-doctor.sh 
END host-charlie fm-remote-doctor.sh 
START host-charlie fm-remote-secondmate-control.sh state
END host-charlie fm-remote-secondmate-control.sh state
QUICK host-charlie fm-remote-secondmate-control.sh route
START host-alpha fm-remote-secondmate-control.sh sync
END host-alpha fm-remote-secondmate-control.sh sync
QUICK host-alpha fm-remote-inherit.sh absent
QUICK host-alpha fm-remote-inherit.sh absent
QUICK host-alpha fm-remote-inherit.sh absent
QUICK host-alpha fm-remote-inherit.sh absent
QUICK host-alpha fm-remote-inherit.sh absent
QUICK host-alpha fm-remote-inherit.sh absent
QUICK host-alpha fm-remote-inherit.sh absent
START host-bravo fm-remote-secondmate-control.sh sync
END host-bravo fm-remote-secondmate-control.sh sync
QUICK host-bravo fm-remote-inherit.sh absent
START host-charlie fm-remote-secondmate-control.sh sync
END host-charlie fm-remote-secondmate-control.sh sync
QUICK host-charlie fm-remote-inherit.sh absent
QUICK host-charlie fm-remote-inherit.sh absent
QUICK host-charlie fm-remote-inherit.sh absent
QUICK host-charlie fm-remote-inherit.sh absent
QUICK host-charlie fm-remote-inherit.sh absent
QUICK host-charlie fm-remote-inherit.sh absent
QUICK host-charlie fm-remote-inherit.sh absent
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"f29bda2be833711a6f4659721f117df377bbf6ef","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-bootstrap-network-parallel.test.sh`
- `FM_TEST_EVIDENCE_FILE=/Users/kunchen/.no-mistakes/evidence/01M0S38M6EC9BH7VZ9W4PBJVD8/bootstrap-network-parallel-transcript.txt bash tests/fm-bootstrap-network-parallel.test.sh`
- `bash tests/fm-gitignore-config.test.sh`
- `bash tests/fm-secondmate-sync.test.sh`
- `bash tests/fm-startup-network.test.sh`
- `bash tests/fm-fleet-sync.test.sh`
- <code>`bash tests/fm-bootstrap.test.sh` — exploratory broad run stopped at the 180-second local timeout after its relevant network partition, lock-ownership, and timing checks passed</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed (2) ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Fix empty environment assignment lint warning
1 warning still open:

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Confirm lint passes with pinned actionlint
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
