### PR TITLE
fix(codex): switch hook wrappers to non-login bash to silence profile noise

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -lc 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-sessionstart-run.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.SessionStart[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-sessionstart-run.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; printf \"%s\" \"$payload\" | \"$root/bin/fm-sessionstart-run.sh\"'",
+            "command": "bash -c 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-sessionstart-run.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.SessionStart[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-sessionstart-run.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; printf \"%s\" \"$payload\" | \"$root/bin/fm-sessionstart-run.sh\"'",
             "timeout": 180
           }
         ]
@@ -17,12 +17,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -lc 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-arm-pretool-check.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.PreToolUse[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-arm-pretool-check.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; printf \"%s\" \"$payload\" | \"$root/bin/fm-arm-pretool-check.sh\"'",
+            "command": "bash -c 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-arm-pretool-check.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.PreToolUse[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-arm-pretool-check.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; printf \"%s\" \"$payload\" | \"$root/bin/fm-arm-pretool-check.sh\"'",
             "timeout": 10
           },
           {
             "type": "command",
-            "command": "bash -lc 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-cd-pretool-check.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.PreToolUse[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-cd-pretool-check.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; printf \"%s\" \"$payload\" | \"$root/bin/fm-cd-pretool-check.sh\"'",
+            "command": "bash -c 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-cd-pretool-check.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.PreToolUse[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-cd-pretool-check.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; printf \"%s\" \"$payload\" | \"$root/bin/fm-cd-pretool-check.sh\"'",
             "timeout": 10
           }
         ]
@@ -33,7 +33,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -lc 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-turnend-guard.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.Stop[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-turnend-guard.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; printf \"%s\" \"$payload\" | \"$root/bin/fm-turnend-guard.sh\"'",
+            "command": "bash -c 'payload=$(cat 2>/dev/null || true); [ -n \"$payload\" ] || exit 0; command -v jq >/dev/null 2>&1 || exit 0; root=$(pwd -P) || exit 0; [ -x \"$root/bin/fm-turnend-guard.sh\" ] || exit 0; [ -f \"$root/AGENTS.md\" ] || exit 0; [ -f \"$root/.codex/hooks.json\" ] || exit 0; jq -e \"any(.hooks.Stop[]?.hooks[]?.command?; type == \\\"string\\\" and contains(\\\"fm-turnend-guard.sh\\\"))\" \"$root/.codex/hooks.json\" >/dev/null 2>&1 || exit 0; printf \"%s\" \"$payload\" | \"$root/bin/fm-turnend-guard.sh\"'",
             "timeout": 30
           }
         ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,7 +185,8 @@ When that section reports its checks still in progress it names exactly what is 
 
 Bootstrap detects first, asks for consent, and installs only after the captain approves in the current session.
 Do not dispatch until the required tools are present and GitHub authentication is good.
-Use `gh-axi` for GitHub, `chrome-devtools-axi` for browser work, and `lavish-axi` for structured decisions or reports; consult current help rather than memorizing flags.
+Use `gh-axi` for GitHub and `chrome-devtools-axi` for browser automation.
+Use `lavish-axi` for structured decisions or reports; consult current help rather than memorizing flags.
 A silent bootstrap section needs no action; for any printed actionable diagnostic line, load `bootstrap-diagnostics` and follow its owner procedure.
 `BOOTSTRAP_INFO:` lines are completed no-action facts and do not require loading a skill.
 `secondmate-provisioning` owns startup secondmate sync, liveness, and inherited local-material convergence.

--- a/tests/fm-codex-continuity-live-e2e.test.sh
+++ b/tests/fm-codex-continuity-live-e2e.test.sh
@@ -48,6 +48,9 @@ PROMPT='Run exactly `bin/fm-watch-checkpoint.sh --seconds 1` as one foreground s
 
 grep -F 'checkpoint: no actionable wake within 1s' "$TRANSCRIPT" >/dev/null \
   || fail "Codex transcript omitted the real foreground checkpoint result"
+if grep -F 'invalid stop hook JSON output' "$TRANSCRIPT" >/dev/null; then
+  fail "Codex rejected the tracked Stop hook's output as invalid JSON"
+fi
 if grep -F 'watcher: started pid=' "$TRANSCRIPT" >/dev/null; then
   fail "Codex switched to the background arm path"
 fi

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -846,6 +846,61 @@ test_tracked_claude_entries_inert_under_grok() {
   pass "tracked .claude/settings.json entries: $guarded inert under grok, the documented subagent exception still armed, all live under Claude"
 }
 
+test_codex_hook_wrappers_ignore_noisy_bash_login_profile() {
+  local settings dir home target command payload stdout stderr status wrapper_count login_output
+  settings="$ROOT/.codex/hooks.json"
+  [ -f "$settings" ] || fail "tracked .codex/hooks.json is missing"
+  dir="$TMP_ROOT/codex-hooks-nonlogin"
+  home="$dir/noisy-bash-home"
+  mkdir -p "$dir/bin" "$dir/.codex" "$home"
+  cp "$settings" "$dir/.codex/hooks.json"
+  : > "$dir/AGENTS.md"
+  cat > "$home/.bash_profile" <<'EOF'
+printf '%s\n' BASH_LOGIN_PROFILE_NOISE
+EOF
+
+  login_output=$(HOME="$home" bash -lc ':')
+  assert_contains "$login_output" "BASH_LOGIN_PROFILE_NOISE" "the noisy Bash login-profile fixture did not emit stdout"
+
+  for target in \
+    fm-sessionstart-run.sh \
+    fm-arm-pretool-check.sh \
+    fm-cd-pretool-check.sh \
+    fm-turnend-guard.sh
+  do
+    cat > "$dir/bin/$target" <<'EOF'
+#!/usr/bin/env bash
+cat >/dev/null
+EOF
+    chmod +x "$dir/bin/$target"
+  done
+
+  wrapper_count=0
+  while IFS=$'\t' read -r target command; do
+    [ -n "$command" ] || fail "Codex hook wrapper for $target is missing"
+    payload=$(jq -cn --arg target "$target" '{hook_event_name:"test",target:$target}')
+    stdout="$dir/$target.stdout"
+    stderr="$dir/$target.stderr"
+    printf '%s' "$payload" | (cd "$dir" && HOME="$home" bash -c "$command") > "$stdout" 2> "$stderr"
+    status=$?
+    expect_code 0 "$status" "Codex hook wrapper for $target must execute under a noisy Bash login profile"
+    [ ! -s "$stdout" ] \
+      || fail "Codex hook wrapper for $target wrote stdout under a noisy Bash login profile: $(cat "$stdout")"
+    wrapper_count=$((wrapper_count + 1))
+  done < <(
+    jq -r '
+      [
+        ["fm-sessionstart-run.sh", .hooks.SessionStart[0].hooks[0].command],
+        ["fm-arm-pretool-check.sh", .hooks.PreToolUse[0].hooks[0].command],
+        ["fm-cd-pretool-check.sh", .hooks.PreToolUse[0].hooks[1].command],
+        ["fm-turnend-guard.sh", .hooks.Stop[0].hooks[0].command]
+      ][] | @tsv
+    ' "$settings"
+  )
+  [ "$wrapper_count" -eq 4 ] || fail "expected four Codex hook wrappers, ran $wrapper_count"
+  pass ".codex/hooks.json: all four wrappers stay silent under a noisy Bash login profile"
+}
+
 test_codex_hook_uses_process_pwd_when_payload_cwd_is_outside_root() {
   local settings command dir expected_root outside payload out status
   settings="$ROOT/.codex/hooks.json"
@@ -1719,6 +1774,7 @@ test_grok_adapter_snake_case_native_and_camel_precedence
 test_grok_adapter_invalid_inputs_start_neither_path
 test_grok_adapter_missing_jq_and_no_supervision_allow
 test_tracked_claude_entries_inert_under_grok
+test_codex_hook_wrappers_ignore_noisy_bash_login_profile
 test_codex_hook_uses_process_pwd_when_payload_cwd_is_outside_root
 test_codex_hook_ignores_nested_git_root_guard
 test_opencode_plugin_anchors_guard_to_worktree


### PR DESCRIPTION
## Summary

- Codex hook wrappers in `.codex/hooks.json` used `bash -lc` (login shell), which sources `~/.bash_profile` and can emit stdout that the Codex harness then rejects as invalid stop-hook JSON
- Switched all four wrappers to `bash -c` (non-login) to keep them profile-silent
- Added hermetic test `test_codex_hook_wrappers_ignore_noisy_bash_login_profile` confirming all four wrappers stay silent under a noisy login profile
- Added e2e regression guard checking the Stop hook output isn't rejected as invalid JSON

## Test plan

- [x] `bash tests/fm-turnend-guard.test.sh` - all 68 tests pass, including new `test_codex_hook_wrappers_ignore_noisy_bash_login_profile`
- [x] `tests/fm-codex-continuity-live-e2e.test.sh` - opt-in; new guard added but requires live Codex session (`FM_CODEX_LIVE_E2E=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)