### PR TITLE
fix(bin): detect Oh My Pi harness before Claude-Code marker

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -3,7 +3,7 @@ name: harness-adapters
 description: >-
   Agent-only reference for firstmate harness operations.
   Use before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.
-  Contains verified facts for claude, codex, opencode, pi, pi-signed, grok, kimi, cursor, and muse.
+  Contains verified facts for claude, codex, opencode, pi, pi-signed, grok, kimi, cursor, muse, and partially for omp.
 user-invocable: false
 metadata:
   internal: true
@@ -302,6 +302,36 @@ Pi's primary watcher protocol also requires the tracked `.pi/extensions/fm-prima
 The model arms through `fm_watch_arm_pi`, never a foreground bash arm; the watcher tool result and clean-exit fallback are owned by `docs/supervision-protocols/pi.md`.
 `bin/fm-session-start.sh` reports when the live Pi-family session has not loaded both the turn-end guard and watcher extensions, and points at the selected executable after project trust as the fix, with `-e` as a trust-free fallback.
 When a secondmate is launched on Pi or pi-signed, `fm-spawn.sh --secondmate` launches the selected executable with both `-e .pi/extensions/fm-primary-turnend-guard.ts` and `-e .pi/extensions/fm-primary-pi-watch.ts`, both already present in the secondmate home's git worktree.
+
+## omp / Oh My Pi (PARTIALLY VERIFIED 2026-08-24, omp v18.0.4)
+
+`omp` (Oh My Pi, package `@oh-my-pi/pi-coding-agent`) is a divergent FORK of pi-mono, not the `pi`/`pi-signed` adapter above under a new name.
+It has its own binary name, its own credential store (`agent.db`, sqlite, multi-credential), and its own native extension-discovery root (`.omp/extensions`, not `.pi/extensions`); see `omp://porting-from-pi-mono.md` "Intentional Divergences" for the full divergence list.
+Only the facts below are empirically verified; `bin/fm-spawn.sh` has NO launch template for `omp`, so a spawn naming it fails closed with "no launch template for harness 'omp'" exactly as the unverified-adapter contract requires - crew and secondmate dispatch on omp is NOT yet enabled.
+`bin/fm-harness.sh` DOES correctly detect a primary session running on omp (own-harness detection only).
+
+| Fact | Value |
+|---|---|
+| Binary | `omp`, a Bun-launched script (`bun /path/to/omp`); `ps -o comm=` reports the bare name `omp`, not `bun`, so ancestry matching needs no args probe (unlike node/python bare interpreters). |
+| Env marker | `OMPCODE=1`, set on every bash-tool child process. omp ALSO sets `CLAUDECODE=1` on the same children, deliberately, for Claude-Code bash-tool compatibility - the same "both markers present, ordering decides" hazard already documented for Cursor. `bin/fm-harness.sh` tests `OMPCODE` BEFORE `CLAUDECODE` for this reason. `PI_CODING_AGENT` is NOT set (confirmed absent), so omp is never misread as `pi`. |
+| Launch | Positional prompt (`omp "..."`) or bare interactive `omp`, the Pi/grok shape. |
+| Model flag | `--model <value>` (fuzzy match, e.g. `opus`, `gpt-5.2`, or `openai/gpt-5.2`). |
+| Effort flag | `--thinking <off\|minimal\|low\|medium\|high\|xhigh\|max\|auto>` - the same flag name as Pi's `--thinking`, but with a wider vocabulary (`off`, `minimal`, `auto` are new). |
+| Model discovery | `omp models` (subcommand, not a flag); no `--list-models` flag exists. |
+| Autonomy | `--auto-approve` (auto-approve every tool call) or `--approval-mode yolo`; no live unattended-run smoke was run in this pass. |
+| Extension flag | `-e, --extension <path>` (repeatable) - same flag as Pi. |
+| Exit command | `/exit`, confirmed live (cleanly exits the TUI, process exit 0). This DIFFERS from Pi's `/quit`. |
+| Interrupt | Not yet live-verified in this pass. |
+| Trust dialog | None observed on first launch in a fresh, never-before-seen directory (unlike Pi's per-path `~/.pi/agent/trust.json` gate); no trust-related flag, file, or doc reference found in `omp://*.md` or `omp --help`. Treat as tentative, not exhaustively verified, until a repeat launch and a non-interactive-vs-interactive comparison are captured. |
+| Busy state | NOT verified. The extension-runtime API surface the Pi guard extensions depend on (`isIdle`, `sendUserMessage` with `deliverAs: "followUp"`, `agent_start`/`turn_end` events) is present in the installed bundle, but no live turn-end-guard block/continue cycle was exercised. Keep at `unknown` per `bin/fm-busy-lib.sh`'s verification gate until that cycle is proven. |
+
+**Tracked pi extension compatibility (verified 2026-08-24, omp v18.0.4).**
+omp's native extension auto-discovery moved to `.omp/extensions`; a bare `.pi/extensions/*.ts` file with no `package.json` manifest is NOT auto-discovered (confirmed against `omp://extension-loading.md`).
+Explicit `-e` paths bypass discovery entirely and always load, regardless of source directory.
+Live-verified: `omp -e .pi/extensions/fm-primary-turnend-guard.ts -e .pi/extensions/fm-primary-pi-watch.ts -p "..." --no-session` loaded both tracked Pi primary-guard extensions with zero import or runtime errors and exit 0, including `fm-primary-pi-watch.ts`'s non-type-only `@earendil-works/pi-tui` component imports (`Box`, `Container`, `Text`) - omp's `legacy-pi-compat.ts` rewrites `@mariozechner/*`/`@earendil-works/*` specifiers onto its own host-bundled packages before evaluation, exactly as `omp://extension-loading.md` documents.
+This is evidence the SAME tracked extension files could serve omp via explicit `-e` paths without a fork, but the actual busy-state and turn-end-guard block/continue behavior was not exercised end to end, so this is NOT a substitute for the live guard verification `firstmate-coding-guidelines`'s harness-dependent-check rule requires before wiring it into `bin/fm-spawn.sh` or `bin/fm-busy-lib.sh`.
+
+**Remaining work before omp is a dispatchable crew/secondmate adapter:** an `omp|omp-signed`-shaped `launch_template` entry in `bin/fm-spawn.sh` (model/effort/extension flags above, positional brief, `-e` pointing at the same `.pi/extensions/fm-primary-turnend-guard.ts` and `.pi/extensions/fm-primary-pi-watch.ts` files used for Pi secondmates); a live turn-end-guard block/continue cycle to confirm the busy-state contract in `bin/fm-busy-lib.sh`; the interrupt key; the composer shape/glyph/idle-placeholder for `bin/fm-composer-lib.sh`; and a primary watcher-supervision protocol doc under `docs/supervision-protocols/` (today an omp-detected primary correctly falls back to `unknown.md` rather than misapplying Claude's protocol).
 
 ## grok (VERIFIED 2026-06-29, grok 0.2.73; slash-submit re-verified 2026-07-03 on 0.2.82; reasoning-effort ceiling re-verified 2026-07-13 on 0.2.99; exit paths re-verified 2026-07-19 on grok 0.2.103)
 

--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/project.local.yml

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,169 @@
+# the name by which the project can be referenced within Serena/when chatting with the LLM.
+project_name: "01M0SAHA91QGGCR4EVYDCWFNZH"
+
+# list of language servers to start when using the LSP backend; choose from:
+#   ada                    al                     angular                ansible                bash
+#   bsl                    clojure                cpp                    cpp_ccls               crystal
+#   csharp                 csharp_omnisharp       cue                    dart                   deno
+#   elixir                 elm                    erlang                 fortran                fsharp
+#   gdscript               gleam                  go                     groovy                 haskell
+#   haxe                   hlsl                   html                   java                   json
+#   julia                  kotlin                 latex                  lean4                  lua
+#   luau                   markdown               matlab                 msl                    nextflow
+#   nix                    ocaml                  pascal                 perl                   php
+#   php_phpactor           php_phpantom           powershell             python                 python_basedpyright
+#   python_jedi            python_pyrefly         python_ty              qml                    r
+#   rego                   ruby                   ruby_solargraph        rust                   scala
+#   scss                   solidity               svelte                 swift                  systemverilog
+#   terraform              toml                   typescript             typescript_vts         vue
+#   wolfram                yaml                   zig
+#   (This list may be outdated; generated with scripts/print_language_list.py;
+#   For the current list, see values of the LanguageServerId enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py)
+# For some languages, there are several alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
+#   - For Deno projects, use deno (serves the same .ts/.js files as typescript; requires the deno CLI on PATH)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some language servers require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple language servers, the first language server that supports a given file will be used for that file.
+# The first language server is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+language_servers:
+- bash
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: "utf-8"
+
+# optional shell command to run before the language backend (LSP or JetBrains) is initialised.
+# the command runs in the project root directory and is only executed if the project is trusted
+# (see trusted_project_path_patterns in the global configuration).
+# serena waits for the command to exit: a non-zero exit code is logged as an error but does not
+# abort activation. a per-project timeout (activation_command_timeout, default 180s) is the safety
+# backstop for non-terminating commands; on expiry the process is killed and activation continues.
+# example: activation_command: "npx nx run-many -t build"
+activation_command:
+
+# maximum time in seconds to wait for activation_command to complete before killing it (default 180s).
+# must be a positive number.
+activation_command_timeout: 180.0
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# whether to use project's .gitignore files to ignore files
+ignore_all_files_in_gitignore: true
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# The settings are considered only if the project is trusted (see global configuration to define trusted projects).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#language-server-specific-settings
+ls_specific_settings: {}
+
+# list of workspace folder paths (LSP backend only).
+# These folders will be used to build up Serena's symbol index.
+# Paths must be within the project root and should thus be relative to the project root.
+# Furthermore, the paths should not be filtered by ignore settings.
+# Default setting: The entire project root folder (".") is considered.
+# In (large) monorepos, this can be used to index only subfolders of the project root, e.g.
+#   ls_workspace_folders:
+#     - "./subproject1"
+#     - "./subproject2"
+ls_workspace_folders:
+- "."
+
+# list of additional workspace folder paths for cross-package reference support.
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries, but these folders are not indexed by Serena,
+# i.e. the respective symbols will not be found using Serena's symbol search tools.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+ls_additional_workspace_folders: []
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Important: quote patterns that start with `*`, otherwise YAML treats them as aliases.
+# Example:
+#   ignored_paths:
+#     - "examples/**"
+#     - ".worktrees/**"
+#     - "**/bin/**"
+#     - "**/obj/**"
+# Note: global ignored_paths from serena_config.yml are also applied additively.
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+fixed_tools: []
+
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+default_modes:
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ""
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []

--- a/bin/fm-harness.sh
+++ b/bin/fm-harness.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Detect the agent harness this process tree runs on.
-# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|muse|unknown
+# Usage: fm-harness.sh                  print own harness: claude|codex|opencode|pi|pi-signed|grok|kimi|cursor|muse|omp|unknown
 #        fm-harness.sh crew             print the effective CREWMATE harness
 #                                        (config/crew-harness; "default" resolves to own)
 #        fm-harness.sh secondmate       print the harness the PRIMARY uses to launch
@@ -50,6 +50,15 @@ detect_own() {
   # CURSOR_AGENT=1 is set for the child/tool processes this script runs as.
   [ "${CURSOR_AGENT:-}" = "1" ] && { echo cursor; return; }
   [ "${CURSOR_INVOKED_AS:-}" = "cursor-agent" ] && { echo cursor; return; }
+  # omp (Oh My Pi, @oh-my-pi/pi-coding-agent) is checked BEFORE claude,
+  # deliberately, for the same reason cursor is: omp deliberately sets
+  # CLAUDECODE=1 on every bash-tool child process for Claude-Code
+  # bash-tool-compat, alongside its own unambiguous OMPCODE=1 (verified live,
+  # omp v18.0.4, both env vars observed on the same bash child process).
+  # omp is a divergent fork of pi-mono (own binary name, own credential
+  # store, own native extension-discovery root .omp/extensions rather than
+  # .pi/extensions) and is NOT the pi/pi-signed adapter below.
+  [ "${OMPCODE:-}" = "1" ] && { echo omp; return; }
   [ "${CLAUDECODE:-}" = "1" ] && { echo claude; return; }
   if [ "${PI_CODING_AGENT:-}" = "true" ]; then
     if [ "${FM_PI_HARNESS:-}" = pi-signed ]; then echo pi-signed; else echo pi; fi
@@ -87,6 +96,10 @@ detect_own() {
       *opencode*) echo opencode; return ;;
       *grok*) echo grok; return ;;
       kimi) echo kimi; return ;;
+      # ps reports comm=omp for the bun-launched `bun /path/to/omp` process
+      # (verified live, omp v18.0.4: `ps -o comm=` prints the exact bare name
+      # `omp`, not `bun`), so an exact match is precise and needs no args probe.
+      omp) echo omp; return ;;
       # muse's installed launcher ~/.local/bin/muse execs ~/.local/bin/muse-bin-<version>
       # (verified in the published launcher, muse 0.1.0-R708.1), so the live process
       # name carries the version and CHANGES on every auto-update. Match the stable

--- a/tests/fm-omp-harness.test.sh
+++ b/tests/fm-omp-harness.test.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# tests/fm-omp-harness.test.sh - regression for Oh My Pi (omp) own-harness
+# detection in bin/fm-harness.sh.
+#
+# omp deliberately sets CLAUDECODE=1 on every bash-tool child process for
+# Claude-Code bash-tool compatibility, alongside its own OMPCODE=1. Before this
+# fix, fm-harness.sh tested CLAUDECODE first and silently misidentified every
+# omp session or worker as claude - the exact same precedence hazard already
+# fixed for Cursor. This suite pins:
+#   1. OMPCODE=1 outranks a coexisting CLAUDECODE=1.
+#   2. CLAUDECODE alone (no OMPCODE) still detects claude - omp is not
+#      over-matched.
+#   3. Process-ancestry detection (ps -o comm= reporting the bare name `omp`)
+#      identifies omp even with no env markers at all, as a second layer.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+HARNESS="$ROOT/bin/fm-harness.sh"
+TMP_ROOT=$(fm_test_tmproot fm-omp-harness)
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+test_omp_marker_outranks_coexisting_claudecode() {
+  local out
+  out=$(env -u PI_CODING_AGENT -u CURSOR_AGENT -u CURSOR_INVOKED_AS \
+        OMPCODE=1 CLAUDECODE=1 "$HARNESS")
+  [ "$out" = omp ] \
+    || fail "OMPCODE=1 + CLAUDECODE=1 (omp's own bash-compat coexistence shape) must detect omp, got '$out'"
+  pass "fm-harness.sh: OMPCODE outranks a coexisting CLAUDECODE"
+}
+
+test_claudecode_alone_still_detects_claude() {
+  local out
+  out=$(env -u OMPCODE -u PI_CODING_AGENT -u CURSOR_AGENT -u CURSOR_INVOKED_AS \
+        CLAUDECODE=1 "$HARNESS")
+  [ "$out" = claude ] || fail "CLAUDECODE alone (no OMPCODE) must still detect claude, got '$out'"
+  pass "fm-harness.sh: a plain claude session is unaffected by the omp precedence fix"
+}
+
+test_ancestry_detects_bare_omp_process_name() {
+  local bindir out
+  bindir="$TMP_ROOT/bin"
+  mkdir -p "$bindir"
+  # A real process literally named `omp`, shaped like the bun-launched
+  # `bun /path/to/omp` process that reports comm=omp (verified live, omp
+  # v18.0.4; see .agents/skills/harness-adapters/SKILL.md). It forks the
+  # harness as a CHILD (not exec) so the ancestry walk climbs from the
+  # harness's own pid up to this omp-named parent, with no env markers at all.
+  cat > "$bindir/omp" <<EOF
+#!/bin/sh
+env -u OMPCODE -u CLAUDECODE -u PI_CODING_AGENT -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u GROK_AGENT \
+  "$HARNESS" > "$TMP_ROOT/out"
+EOF
+  chmod +x "$bindir/omp"
+  "$bindir/omp"
+  out=$(cat "$TMP_ROOT/out")
+  [ "$out" = omp ] \
+    || fail "a real ancestor process named 'omp' with no env markers must detect omp via ancestry, got '$out'"
+  pass "fm-harness.sh: process ancestry reporting the bare name 'omp' detects omp as a fallback layer"
+}
+
+test_omp_marker_outranks_coexisting_claudecode
+test_claudecode_alone_still_detects_claude
+test_ancestry_detects_bare_omp_process_name


### PR DESCRIPTION
## Intent

Fix a real harness-misdetection bug in bin/fm-harness.sh: Oh My Pi (omp, package @oh-my-pi/pi-coding-agent, a divergent fork of pi-mono) sets its own identity marker OMPCODE=1 on every command it runs, but deliberately ALSO sets CLAUDECODE=1 on the same commands for Claude-tooling bash-compat, so the existing CLAUDECODE-only check silently misidentified every omp session or worker as claude. Test OMPCODE before CLAUDECODE (the same precedence-fix pattern already used in this file for a similar Cursor marker collision), and add ancestry-based detection (ps -o comm= reporting the bare name omp) as a second layer/fallback. Extend the printed harness-list usage comment to include omp. Also update .agents/skills/harness-adapters/SKILL.md to record the verified-but-partial Oh My Pi adapter facts gathered in the same investigation: binary (Bun-launched, ps -o comm= reports bare 'omp'), env markers (OMPCODE and the coexisting CLAUDECODE), CLI flags (--model, --thinking, --auto-approve/--approval-mode yolo, -e/--extension, omp models for discovery), exit command (/exit, differs from Pi's /quit), and live-confirmed extension-loading compatibility: the tracked .pi/extensions/fm-primary-turnend-guard.ts and .pi/extensions/fm-primary-pi-watch.ts files load and run cleanly under Oh My Pi via explicit -e flags despite omp's native auto-discovery root having moved to .omp/extensions. Explicitly document that bin/fm-spawn.sh has NO launch template for omp yet, so crew/secondmate dispatch on omp remains refused under the unverified-adapter fail-closed contract until further live verification (busy-state hook, interrupt key, composer shape) lands in a dedicated follow-up task. Out of scope for this task, by explicit instruction: do not add an omp launch template, busy-state wiring, or composer-shape entry - that work is deliberately deferred to a follow-up. This is a firstmate-repo self-change (bin/ and .agents/skills/ are shared tracked material), so it followed firstmate-coding-guidelines: knowledge placed at the correct owner tier (agent-only skill fact vs. inline AGENTS.md), one-owner rule preserved, repo style (one sentence per line, plain dash, shellcheck-clean). Verified locally before commit: bash -n bin/fm-harness.sh, bin/fm-lint.sh (targeted and full repo), and bin/fm-doc-audience-check.sh all pass; the new SKILL.md table and prose read cleanly with balanced code spans, matching the prepared patch's exact diffstat (45 insertions, 2 deletions across both files).

## What Changed

- `bin/fm-harness.sh`: check `OMPCODE=1` before `CLAUDECODE=1` in `detect_own`, since Oh My Pi (`omp`) deliberately sets both env vars on its bash-tool children, which previously caused every omp session to be misidentified as `claude`; add a process-ancestry fallback that matches a bare `ps -o comm=` name of `omp`; extend the usage comment's harness list to include `omp`.
- `.agents/skills/harness-adapters/SKILL.md`: add a new "omp / Oh My Pi (PARTIALLY VERIFIED)" section documenting the verified adapter facts (binary/ancestry behavior, env markers, CLI flags, model/effort/extension flags, exit command, tracked `.pi/extensions/*.ts` compatibility via explicit `-e` flags), and explicitly note `bin/fm-spawn.sh` has no launch template for omp yet, so crew/secondmate dispatch stays fail-closed pending further verification.
- `tests/fm-omp-harness.test.sh`: new regression suite covering (1) `OMPCODE` outranking a coexisting `CLAUDECODE`, (2) `CLAUDECODE` alone still resolving to `claude`, and (3) ancestry-based detection via a real process named `omp`.
- `.serena/project.yml` and `.serena/.gitignore`: added (Serena project config/tooling artifacts).

## Risk Assessment

✅ Low: Small, well-scoped precedence fix plus ancestry fallback that mirrors an existing verified pattern (cursor), correctly ordered before the CLAUDECODE check, with matching documentation updates and no launch-template/dispatch changes, exactly as the intent required.

## Testing

Wrote and ran a focused regression test for the OMPCODE/CLAUDECODE precedence fix and the new ps-ancestry omp detection in bin/fm-harness.sh, verified it fails on the pre-fix commit and passes on the fix commit, and reran the neighboring per-harness suites (cursor, grok, muse, kimi) with no regressions.

- Evidence: [New regression test: tests/fm-omp-harness.test.sh](https://github.com/kunchenguid/firstmate/blob/ba6b411cfc8b2a2c33696f106b79c4c3513c6757/tests/fm-omp-harness.test.sh)
<details>
<summary>Evidence: Test run on target commit (fix present)</summary>

```text
ok - fm-harness.sh: OMPCODE outranks a coexisting CLAUDECODE
ok - fm-harness.sh: a plain claude session is unaffected by the omp precedence fix
ok - fm-harness.sh: process ancestry reporting the bare name 'omp' detects omp as a fallback layer
```
</details>
<details>
<summary>Evidence: Same checks against base commit 8b21c99 (pre-fix) — demonstrates the bug</summary>

```text
OMPCODE=1 CLAUDECODE=1 -> claude (misdetected; should be omp)
ancestry-named 'omp' process -> claude (no omp case existed; fell through to a real claude ancestor)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"ba6b411cfc8b2a2c33696f106b79c4c3513c6757","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash -n bin/fm-harness.sh`
- `bash tests/fm-omp-harness.test.sh (new focused regression test, 3/3 pass on target commit a448e06)`
- `same 3 assertions run manually against base commit 8b21c99's bin/fm-harness.sh: OMPCODE+CLAUDECODE misdetects as claude, and the ancestry-named 'omp' process also falls through to claude — confirming the test fails-before/passes-after the fix`
- `bash tests/fm-cursor-harness.test.sh`
- `bash tests/fm-grok-harness.test.sh`
- `bash tests/fm-muse-harness.test.sh`
- `bash tests/fm-kimi-harness.test.sh`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
