### PR TITLE
test: stabilize Pi follow-up duplicate-answer assertion

### DIFF
--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -1771,6 +1771,7 @@ TS
     local session_arg=${5:-}
     local shape=${6:-single}
     local extensions
+    local peak_captain_answer_count captain_answer_count
 
     tmux -L "$TMUX_SOCKET" kill-session -t "$TMUX_SESSION" 2>/dev/null || true
     if [ "$calm_state" = absent ]; then
@@ -1817,7 +1818,31 @@ TS
       fail "Pi follow-up $label case did not process the monitoring notification"
     fi
 
-    pane=$(tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" -S - 2>/dev/null || true)
+    # The session file above is the authoritative record of what Pi processed and
+    # settles as soon as the model turn completes; the pane is a separate, later
+    # redraw of that same state. Two adjacent followUp deliveries queue more
+    # presentation work (an extra operational-user row plus its Calm-hiding
+    # invalidation) than a single one, so the redraw that finally paints the
+    # already-settled captain answer can still be in flight the instant the
+    # session file confirms processing. Poll the same way the session-file wait
+    # above does rather than reading one immediate, possibly pre-redraw snapshot,
+    # and track the highest count seen along the way so a captain answer that
+    # is genuinely rendered twice for even one intermediate frame still fails
+    # this assertion even if a later redraw were to self-correct down to one.
+    i=0
+    peak_captain_answer_count=0
+    while [ "$i" -lt 100 ]; do
+      pane=$(tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" -S - 2>/dev/null || true)
+      captain_answer_count=$(printf '%s\n' "$pane" | grep -Fc "CAPTAIN_ANSWER_$label" || true)
+      [ "$captain_answer_count" -gt "$peak_captain_answer_count" ] && peak_captain_answer_count=$captain_answer_count
+      if printf '%s\n' "$pane" | grep -Fq "MONITOR_HANDLED_${label}_ONE"; then
+        break
+      fi
+      sleep 0.05
+      i=$((i + 1))
+    done
+    [ "$peak_captain_answer_count" -le 1 ] \
+      || fail "Pi follow-up $label case rendered a duplicate captain answer"
     [ "$(printf '%s\n' "$pane" | grep -Fc "CAPTAIN_ANSWER_$label" || true)" -eq 1 ] \
       || fail "Pi follow-up $label case rendered a duplicate captain answer"
     assert_contains "$pane" "CAPTAIN_PROMPT_$label" "Pi follow-up $label case hid the genuine captain prompt"


### PR DESCRIPTION
## Intent

Fix the pre-existing Firstmate main-branch failure where tests/fm-calm-pi-extension.test.sh's Pi follow-up adjacent case (two followUp deliveries queued back-to-back in message_start) intermittently reported a rendered duplicate captain answer. Diagnosis via repeated E2E reproduction and fine-grained pane probing (many runs, up to 150 probes at 10-20ms granularity) showed the underlying session file was always correct (exactly one CAPTAIN_ANSWER, one merged MONITOR_HANDLED_..._ONE_TWO turn) and the rendered pane count never exceeded 1 -- it only ever raced between 0 (not yet redrawn) and 1 (settled), never 2. Git history confirmed the pane capture for this specific assertion has been a single, unpolled snapshot taken immediately after the session-file readiness loop since the check was introduced in commit 65ad47b, unlike every other readiness check in this test which polls. Sending two adjacent followUp deliveries queues more Calm presentation work (an extra operational-user row plus its Calm-hiding invalidation) than a single delivery, so the already-correct captain answer's TUI redraw could still be in flight the instant the session file confirmed processing, making this one assertion flaky specifically in the adjacent case. The fix polls the pane the same way the adjacent session-file wait already does (same idiom, bounded iterations, same sleep granularity) before evaluating the duplicate-answer count, and additionally tracks the peak count observed during that poll so a genuine transient duplicate frame would still fail the assertion even if a later redraw self-corrected -- this strengthens the check rather than weakening it. The original exactly-one assertion and its failure message are unchanged; no product/extension code (fm-calm.ts, fm-calm-assistant-layout.ts, fm-calm-visibility.ts, fm-calm-operational-user-layout.ts, fm-calm-working-ship.ts) was touched, since the defect was entirely in the test's own settle-wait omission. Reviewed pi and pi-signed integration surfaces: pi-signed execs the identical Pi engine/TUI as pi (per harness-adapters skill) and has no separate Calm extension surface, so this test (which already runs against whatever pi binary is installed) covers both; no separate pi-signed test path exists or is needed. Verified the fix with 8+ consecutive clean runs of the full tests/fm-calm-pi-extension.test.sh file (all sub-cases, not just adjacent) and a clean bin/fm-lint.sh pass on the changed file.

## What Changed

- Poll the Pi pane until the adjacent follow-up result is rendered before checking the captain answer count.
- Track the peak captain answer count during polling so transient duplicate frames still fail the assertion.
- Preserve the final exactly-one captain answer check and existing failure message.

## Risk Assessment

✅ Low: The change is narrowly scoped to test synchronization, preserves the exactly-one pane assertion, records the peak observed captain-answer count to catch sampled transient duplicates, and conforms to the stated durable test-fix intent without changing product code.

## Testing

Three consecutive full `fm-calm-pi-extension` E2E runs passed against the installed Pi binary, exercising the real tmux TUI, adjacent back-to-back follow-ups, peak and settled duplicate-answer detection, persisted session semantics, Calm visibility, and restart behavior. Two executable transcripts were retained as evidence. No screenshot was captured because the terminal test automatically tears down its ephemeral tmux session; its pane contents and JSONL session state are asserted directly before teardown.

<details>
<summary>Evidence: Pi Calm E2E run 2 transcript</summary>

Source: [Pi Calm E2E run 2 transcript](https://github.com/bingb0t5/firstmate/blob/617093241a79060d1a97fc0634e0c3e2ad90e093/.no-mistakes/evidence/fm/fm-pi-followup-duplicate-answer/pi-calm-followup-e2e-run-2.log)

```text
ok - Pi calm resolves its persistent home independently of Pi's launch directory
ok - Pi calm compatibility evidence never rejects a Pi version for being newer than 0.82.0, and still fails closed on a missing or malformed version
ok - a missing collapsed-thinking presentation API degrades only that Calm adapter with a clear skip reason, while the rest of Calm still registers
ok - missing Pi presentation class exports reach the independent adapter degradation path
ok - Calm registers none of its 7 built-in tool wrappers at load while config/calm is off, and all 7 synchronously at load while config/calm is on
ok - Calm's first same-session /calm activation claims every uncontested built-in, leaves a foreign bash tool fully intact and callable, warns prominently and logs the contested name, and only rows constructed before that activation - the documented bound - fail to retroactively collapse
ok - Pi calm centralizes transcript visibility, preserves execution/export data, keeps Pi's stock working row visible while no run is active, and persists its choice across session starts
ok - Pi calm on collapses mid-turn assistant working notes to zero height while Calm off keeps them, leaves streaming, truncated-final, and genuine final replies untouched, never mutates the messages, ignores every /calm argument, and restores a legacy persisted max as ordinary Calm on
ok - Pi operational follow-up E2E processes exact user-role notifications once while Calm hides current and adjacent rows, Calm off and absent render them, and restart preserves semantics
ok - Pi Calm native /skill:ahoy geometry keeps every collapsed thinking and tool block at zero height while preserving expansion, history, restart, and Calm-off rendering
ok - Pi Calm working ship moves on a slow independent cadence over faster fixed-cell blue water, paints the complete boat standard yellow with balanced resets, keeps ANSI-stripped width exact, flips the directional sail on the exact bounce at both edges and every width, clamps visible and hidden resizes, falls back deterministically when narrow, freezes and resumes column/direction across settle/start without hidden-time jumps or duplicate timers, resets only on a fresh session, and installs and removes one scheduler-owning widget across starts, settle, abort, failure, shutdown, reload, replacement, and Calm toggles while leaving Calm-off visibility untouched
ok - Pi calm native E2E replaces the stock working row with a moving, resize-clamped working ship that freezes and resumes across two working periods in one Pi session, clears on abort, keeps captain turns visible, hides exact operational user rows without changing persistence, restores stock rendering Calm-off, survives restart, and preserves export plus Ctrl+O behavior
```
</details>
<details>
<summary>Evidence: Pi Calm E2E run 3 transcript</summary>

Source: [Pi Calm E2E run 3 transcript](https://github.com/bingb0t5/firstmate/blob/617093241a79060d1a97fc0634e0c3e2ad90e093/.no-mistakes/evidence/fm/fm-pi-followup-duplicate-answer/pi-calm-followup-e2e-run-3.log)

```text
ok - Pi calm resolves its persistent home independently of Pi's launch directory
ok - Pi calm compatibility evidence never rejects a Pi version for being newer than 0.82.0, and still fails closed on a missing or malformed version
ok - a missing collapsed-thinking presentation API degrades only that Calm adapter with a clear skip reason, while the rest of Calm still registers
ok - missing Pi presentation class exports reach the independent adapter degradation path
ok - Calm registers none of its 7 built-in tool wrappers at load while config/calm is off, and all 7 synchronously at load while config/calm is on
ok - Calm's first same-session /calm activation claims every uncontested built-in, leaves a foreign bash tool fully intact and callable, warns prominently and logs the contested name, and only rows constructed before that activation - the documented bound - fail to retroactively collapse
ok - Pi calm centralizes transcript visibility, preserves execution/export data, keeps Pi's stock working row visible while no run is active, and persists its choice across session starts
ok - Pi calm on collapses mid-turn assistant working notes to zero height while Calm off keeps them, leaves streaming, truncated-final, and genuine final replies untouched, never mutates the messages, ignores every /calm argument, and restores a legacy persisted max as ordinary Calm on
ok - Pi operational follow-up E2E processes exact user-role notifications once while Calm hides current and adjacent rows, Calm off and absent render them, and restart preserves semantics
ok - Pi Calm native /skill:ahoy geometry keeps every collapsed thinking and tool block at zero height while preserving expansion, history, restart, and Calm-off rendering
ok - Pi Calm working ship moves on a slow independent cadence over faster fixed-cell blue water, paints the complete boat standard yellow with balanced resets, keeps ANSI-stripped width exact, flips the directional sail on the exact bounce at both edges and every width, clamps visible and hidden resizes, falls back deterministically when narrow, freezes and resumes column/direction across settle/start without hidden-time jumps or duplicate timers, resets only on a fresh session, and installs and removes one scheduler-owning widget across starts, settle, abort, failure, shutdown, reload, replacement, and Calm toggles while leaving Calm-off visibility untouched
ok - Pi calm native E2E replaces the stock working row with a moving, resize-clamped working ship that freezes and resumes across two working periods in one Pi session, clears on abort, keeps captain turns visible, hides exact operational user rows without changing persistence, restores stock rendering Calm-off, survives restart, and preserves export plus Ctrl+O behavior
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"f5c983cb389874995f1bc7fd48cf64456784e962","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"skipped"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff 52ff62e8253623b4fafd125c52cdd4c13a3a84b1..f5c983cb389874995f1bc7fd48cf64456784e962 -- tests/fm-calm-pi-extension.test.sh`</code>
- <code>Ran `bash tests/fm-calm-pi-extension.test.sh` three consecutive times</code>
- <code>Captured runs 2 and 3 with `bash tests/fm-calm-pi-extension.test.sh 2&gt;&amp;1 | tee &lt;evidence-log&gt;`</code>
- <code>Verified cleanup with `git status --short`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Lint** - skipped</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Verify lint with pinned toolchain
1 warning still open:
- ⚠️ linter found issues (exit code 1)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
