### PR TITLE
docs(pi): add multi-brain architecture poster

### DIFF
--- a/docs/pi-supervision-branch-poster.svg
+++ b/docs/pi-supervision-branch-poster.svg
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 860" width="1200" height="860" role="img" aria-labelledby="poster-title poster-desc">
+  <title id="poster-title">Multi-brain agent architecture</title>
+  <desc id="poster-desc">One agent. Two branches of attention. Events are commits. A git-graph poster of one fix: silent notes merge with zero turns; only the merge that matters wakes the main brain.</desc>
+  <defs>
+    <pattern id="poster-grid" width="36" height="36" patternUnits="userSpaceOnUse">
+      <path d="M 36 0 L 0 0 0 36" fill="none" stroke="#8CAAE6" stroke-opacity="0.06" stroke-width="1"/>
+    </pattern>
+  </defs>
+  <rect width="1200" height="860" fill="#0D1321"/>
+  <rect width="1200" height="860" fill="url(#poster-grid)"/>
+  <rect x="0.5" y="0.5" width="1199" height="859" fill="none" stroke="#94B4FF" stroke-opacity="0.20" stroke-width="1"/>
+  <g font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">
+    <text x="48" y="56" fill="#E6EDF3" font-size="36" font-weight="700">Multi-brain agent architecture</text>
+    <text x="48" y="86" fill="#8CA3C7" font-size="18">One agent. Two branches of attention. Events are commits.</text>
+    <text x="1152" y="56" text-anchor="end" fill="#8CA3C7" fill-opacity="0.7" font-size="14">fig. 1 - firstmate</text>
+  </g>
+  <g transform="translate(0 100)" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">
+<title id="mb-title">Multi-brain agent architecture drawn as a git graph: one fix's lifecycle. The worker finishes and CI runs (silent note), the captain's merge-when-green instruction is cherry-picked down, a flaky test is rerun (silent note), and when CI goes green the supervision brain merges and one note wakes the main brain.</title>
+        <defs>
+          <marker id="ah-cyan" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7.5" markerHeight="7.5" orient="auto-start-reverse">
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="#56C8FF"></path>
+          </marker>
+          <marker id="ah-amber" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7.5" markerHeight="7.5" orient="auto-start-reverse">
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="#FFB454"></path>
+          </marker>
+          <marker id="ah-time" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+            <path d="M 0 0 L 10 5 L 0 10 z" fill="#8CA3C7"></path>
+          </marker>
+          <linearGradient id="merge-up" x1="0" y1="1" x2="1" y2="0">
+            <stop offset="0" stop-color="#56C8FF"></stop>
+            <stop offset="1" stop-color="#FFB454"></stop>
+          </linearGradient>
+        </defs>
+
+        <!-- ================= LANE LINES ================= -->
+        <line x1="280" y1="210" x2="1140" y2="210" stroke="#FFB454" stroke-width="3" stroke-linecap="round"></line>
+        <path d="M 310 221 C 310 380, 330 490, 420 490" fill="none" stroke="#56C8FF" stroke-width="3" stroke-linecap="round"></path>
+        <line x1="420" y1="490" x2="1140" y2="490" stroke="#56C8FF" stroke-width="3" stroke-linecap="round"></line>
+
+        <!-- ================= LANE LABELS ================= -->
+        <text x="64" y="200" fill="#FFB454" font-size="24" font-weight="700">MAIN SESSION</text>
+        <text x="64" y="230" fill="#E6EDF3" opacity="0.6" font-size="16">talks with the captain</text>
+        <text x="64" y="480" fill="#56C8FF" font-size="24" font-weight="700">SUPERVISION SESSION</text>
+        <text x="64" y="510" fill="#E6EDF3" opacity="0.6" font-size="16">handles the routine,</text>
+        <text x="64" y="534" fill="#E6EDF3" opacity="0.6" font-size="16">decides to wake main brain or not</text>
+
+        <!-- ================= CROSS-LANE ARCS (all arrowed, drawn under chips) ================= -->
+        <path id="arc-quiet-1" d="M 460 479 C 490 400, 520 300, 545 221" fill="none" stroke="#56C8FF" stroke-width="2.5" stroke-dasharray="1 7" stroke-linecap="round" opacity="0.6" marker-end="url(#ah-cyan)"></path>
+        <path id="arc-cherry" d="M 620 221 C 645 300, 675 400, 700 479" fill="none" stroke="#FFB454" stroke-width="2.5" stroke-dasharray="2 8" stroke-linecap="round" opacity="0.8" marker-end="url(#ah-amber)"></path>
+        <path id="arc-quiet-2" d="M 760 479 C 785 400, 810 300, 830 221" fill="none" stroke="#56C8FF" stroke-width="2.5" stroke-dasharray="1 7" stroke-linecap="round" opacity="0.6" marker-end="url(#ah-cyan)"></path>
+        <path id="arc-wake" d="M 940 479 C 975 410, 1015 300, 1038 226" fill="none" stroke="url(#merge-up)" stroke-width="4" stroke-linecap="round" marker-end="url(#ah-amber)"></path>
+
+        <!-- ================= EXAMPLE CHIPS ON THE ARCS ================= -->
+        <g id="chip-quiet-1">
+          <title>A silent note: nothing needs the captain yet</title>
+          <rect x="385" y="312" width="230" height="36" rx="6" fill="#0D1321" stroke="#56C8FF" stroke-width="1.5" opacity="0.95"></rect>
+          <text x="500" y="336" text-anchor="middle" fill="#B9E5FF" font-size="16">&#8220;PR opened, CI running&#8221;</text>
+        </g>
+        <g id="chip-cherry">
+          <title>The captain's own instruction, cherry-picked down as context</title>
+          <rect x="530" y="377" width="260" height="36" rx="6" fill="#0D1321" stroke="#FFB454" stroke-width="1.5" opacity="0.95"></rect>
+          <text x="660" y="401" text-anchor="middle" fill="#FFD9A0" font-size="16">you: &#8220;merge when CI green&#8221;</text>
+        </g>
+        <g id="chip-quiet-2">
+          <title>A silent note: the supervision brain already fixed it</title>
+          <rect x="665" y="272" width="270" height="36" rx="6" fill="#0D1321" stroke="#56C8FF" stroke-width="1.5" opacity="0.95"></rect>
+          <text x="800" y="296" text-anchor="middle" fill="#B9E5FF" font-size="16">&#8220;flaky test: reran, passed&#8221;</text>
+        </g>
+        <g id="chip-wake">
+          <title>The outcome the captain asked for: this note wakes the main brain</title>
+          <rect x="865" y="342" width="250" height="38" rx="6" fill="#0D1321" stroke="#FFB454" stroke-width="2"></rect>
+          <text x="990" y="367" text-anchor="middle" fill="#FFB454" font-size="17" font-weight="600">&#8220;merged: your fix is in&#8221;</text>
+        </g>
+
+        <!-- ================= MAIN COMMITS ================= -->
+        <g id="main-commits">
+          <title>The captain's conversation, commit by commit</title>
+          <circle cx="310" cy="210" r="11" fill="#0D1321" stroke="#FFB454" stroke-width="3.5"></circle>
+          <circle cx="620" cy="210" r="11" fill="#0D1321" stroke="#FFB454" stroke-width="3.5"></circle>
+          <circle cx="1120" cy="210" r="11" fill="#0D1321" stroke="#FFB454" stroke-width="3.5"></circle>
+        </g>
+        <!-- silent-note landings -->
+        <g id="silent-landings">
+          <title>Notes merged silently into the conversation: no one is woken</title>
+          <circle cx="545" cy="210" r="7" fill="#0D1321" stroke="#56C8FF" stroke-width="3" opacity="0.85"></circle>
+          <circle cx="830" cy="210" r="7" fill="#0D1321" stroke="#56C8FF" stroke-width="3" opacity="0.85"></circle>
+        </g>
+        <text x="545" y="174" text-anchor="middle" fill="#56C8FF" opacity="0.8" font-size="13.5">silent merge. zero turns</text>
+        <text x="830" y="174" text-anchor="middle" fill="#56C8FF" opacity="0.8" font-size="13.5">silent merge. zero turns</text>
+        <!-- the merge commit that wakes the main brain -->
+        <g id="merge-commit">
+          <title>Merged and surfaced: the main brain is woken exactly once</title>
+          <circle cx="1040" cy="210" r="13" fill="#FFB454"></circle>
+          <circle cx="1040" cy="210" r="21" fill="none" stroke="#FFB454" stroke-width="1.5" opacity="0.5"></circle>
+          <path d="M 1019 189 A 30 30 0 0 1 1061 189" fill="none" stroke="#FFB454" stroke-width="2.5" stroke-linecap="round" opacity="0.8"></path>
+          <path d="M 1011 181 A 41 41 0 0 1 1069 181" fill="none" stroke="#FFB454" stroke-width="2.5" stroke-linecap="round" opacity="0.5"></path>
+        </g>
+        <text x="1040" y="148" text-anchor="middle" fill="#FFB454" font-size="18" font-weight="700">wakes the main brain</text>
+
+        <!-- ================= BRANCH COMMITS + EVENT EXAMPLES ================= -->
+        <g id="branch-commits">
+          <title>One fix's routine events, handled on the supervision brain</title>
+          <circle cx="460" cy="490" r="10" fill="#0D1321" stroke="#56C8FF" stroke-width="3.5"></circle>
+          <circle cx="760" cy="490" r="10" fill="#0D1321" stroke="#56C8FF" stroke-width="3.5"></circle>
+          <circle cx="940" cy="490" r="10" fill="#0D1321" stroke="#56C8FF" stroke-width="3.5"></circle>
+        </g>
+        <!-- cherry-pick landing -->
+        <circle cx="700" cy="490" r="8" fill="#0D1321" stroke="#FFB454" stroke-width="3"></circle>
+
+        <line x1="460" y1="503" x2="460" y2="530" stroke="#56C8FF" stroke-width="1.5" opacity="0.35"></line>
+        <text x="460" y="554" text-anchor="middle" fill="#E6EDF3" opacity="0.75" font-size="16">worker finishes the fix</text>
+        <line x1="760" y1="503" x2="760" y2="530" stroke="#56C8FF" stroke-width="1.5" opacity="0.35"></line>
+        <text x="760" y="554" text-anchor="middle" fill="#E6EDF3" opacity="0.75" font-size="16">a flaky test fails</text>
+        <line x1="940" y1="503" x2="940" y2="530" stroke="#56C8FF" stroke-width="1.5" opacity="0.35"></line>
+        <text x="940" y="554" text-anchor="middle" fill="#E6EDF3" opacity="0.75" font-size="16">CI goes green</text>
+
+        <!-- ================= TIME AXIS ================= -->
+        <line x1="1010" y1="660" x2="1110" y2="660" stroke="#8CA3C7" stroke-width="2" stroke-linecap="round" marker-end="url(#ah-time)"></line>
+        <text x="1128" y="665" fill="#8CA3C7" font-size="15">time</text>
+
+        <!-- ================= MORAL ================= -->
+        <text x="560" y="700" text-anchor="middle" fill="#E6EDF3" opacity="0.6" font-size="18">Routine merges back silently. Only what needs you wakes the main brain.</text>
+  </g>
+</svg>

--- a/docs/pi-supervision-branch.md
+++ b/docs/pi-supervision-branch.md
@@ -1,5 +1,10 @@
 # Pi supervision branch
 
+![Multi-brain agent architecture: one agent, two branches of attention, events are commits](pi-supervision-branch-poster.svg)
+
+The poster is the visual of the idea.
+This document stays the owner and the contract.
+
 Fleet supervision on the Pi primary harness runs on a second, persistent conversation - the supervision branch - inside the same `pi` process as the captain's chat.
 The branch absorbs ordinary actionable wakes that pass the watcher's unchanged first-stage classifier and resolve wholly to captain-granted projects, handles them with real tools, and merges each outcome back by appending a short note to the captain conversation's tail; fleet-wide, unresolvable, and out-of-scope wakes stay on main, and only captain-relevant branch outcomes open a turn.
 The design source is the captain-approved forked-supervision architecture board, a captain-private fleet record (a self-contained HTML explainer with the measured cache and judgment evidence); this document records the shape it landed as, and the delivering PR cites the board artifact itself.


### PR DESCRIPTION
## Intent

Ship the captain-approved Multi-brain agent architecture poster into Firstmate docs.

Export a still from the approved HTML at data/fm-multi-brain-architecture-diagram-s1/multi-brain-agent-architecture.html (SVG preferred, PNG if SVG is worse). Commit the still next to the doc as docs/pi-supervision-branch-poster.svg (or .png).

Link it near the top of docs/pi-supervision-branch.md as the visual of the idea. That markdown file stays the one owner and the contract. Do not replace the contract with the picture.

Do not add this to the README. Do not create a second architecture doc. Do not commit the live Lavish page as source of truth.

Keep the change small. One sentence per line in markdown. Plain dash, no em dash.

Another Firstmate change may also touch docs/pi-supervision-branch.md (default-on supervision). Rebase if needed.

## What Changed

- Add an accessible SVG poster illustrating the multi-brain agent architecture.
- Link the poster near the top of the supervision branch documentation while retaining the document as the owner and contract.

## Risk Assessment

🚨 High: The new primary visual materially misstates a prohibited supervision-branch capability and requires explicit human resolution before merging.

## Testing

Inspected the focused diff, validated the publication constraints and SVG semantics, then rendered the document through GitHub Markdown and Chrome; the linked poster appears near the top, remains readable, and loads without browser errors.

- Evidence: [GitHub-rendered Pi supervision branch documentation](https://github.com/kunchenguid/firstmate/blob/bbd6ccf70fac8af739ad21dbd86a7f30b9f5840d/.no-mistakes/evidence/fm/fm-multi-brain-poster-docs-r1/pi-supervision-branch-doc-render.png)
- Evidence: [Standalone poster rendered by Chrome](https://github.com/kunchenguid/firstmate/blob/bbd6ccf70fac8af739ad21dbd86a7f30b9f5840d/.no-mistakes/evidence/fm/fm-multi-brain-poster-docs-r1/pi-supervision-branch-poster-render.png)

<details>
<summary>Evidence: GitHub Markdown rendered documentation artifact</summary>

Source: [GitHub Markdown rendered documentation artifact](https://github.com/kunchenguid/firstmate/blob/bbd6ccf70fac8af739ad21dbd86a7f30b9f5840d/.no-mistakes/evidence/fm/fm-multi-brain-poster-docs-r1/pi-supervision-branch.github-render.html)

```text
<!doctype html><meta charset="utf-8"><title>Pi supervision branch - rendered documentation</title>
<style>body{margin:0;background:#fff;color:#1f2328;font:16px -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}.markdown-body{box-sizing:border-box;max-width:1012px;margin:0 auto;padding:32px}.markdown-body h1{font-size:2em;border-bottom:1px solid #d0d7de;padding-bottom:.3em}.markdown-body p{line-height:1.5}.markdown-body img{max-width:100%;box-sizing:content-box;background:#fff}.markdown-body code{background:#afb8c133;padding:.2em .4em;border-radius:6px}</style><article class="markdown-body"><h1>Pi supervision branch</h1>
<p><a target="_blank" rel="noopener noreferrer" href="pi-supervision-branch-poster.svg"><img src="file:///Users/kunchen/.no-mistakes/worktrees/016d88035d58/01M0SEJFM0T41J2CA814X8C68F/docs/pi-supervision-branch-poster.svg" alt="Multi-brain agent architecture: one agent, two branches of attention, events are commits" style="max-width: 100%;"></a></p>
<p>The poster is the visual of the idea.<br>
This document stays the owner and the contract.</p>
<p>Fleet supervision on the Pi primary harness runs on a second, persistent conversation - the supervision branch - inside the same <code class="notranslate">pi</code> process as the captain's chat.<br>
The branch absorbs ordinary actionable wakes that pass the watcher's unchanged first-stage classifier and resolve wholly to captain-granted projects, handles them with real tools, and merges each outcome back by appending a short note to the captain conversation's tail; fleet-wide, unresolvable, and out-of-scope wakes stay on main, and only captain-relevant branch outcomes open a turn.<br>
The design source is the captain-approved forked-supervision architecture board, a captain-private fleet record (a self-contained HTML explainer with the measured cache and judgment evidence); this document records the shape it landed as, and the delivering PR cites the board artifact itself.</p>
<p>This feature is Pi-only by construction and changes nothing anywhere else:</p>
<ul>
<li>The branch lives in <code class="notranslate">.pi/extensions/fm-branch-supervision.ts</code>, which only a Pi primary ever loads; no other harness gains or loses behavior.</li>
<li>The bash-side additions (leases, the outcome store, session-start recovery) are inert in a home that never runs the branch: no lease files exist, no actor variable is set, every guard passes silently, and no new state appears (<code class="notranslate">tests/fm-branch-supervision.test.sh</code> holds this).</li>
<li>It does not change which harness is primary and never moves a home to Pi.</li>
</ul>
<h2>Components and their owners</h2>
<ul>
<li>Wake dispatch: <code class="notranslate">.pi/extensions/fm-primary-pi-watch.ts</code> stays the dispatcher; <code class="notranslate">.pi/extensions/lib/fm-branch-dispatch.ts</code> owns the offer handshake.<br>
An accepted offer transfers wake ownership to the branch; no acceptor (extension absent, branch disabled, away mode, branch broken) keeps today's wake-to-main path, and watcher-failure alarms always go to main because only main can repair the watcher cycle.</li>
<li>The branch itself: <code class="notranslate">.pi/extensions/fm-branch-supervision.ts</code> creates and reopens the persistent branch session, serializes wakes, mirrors dialog, and merges outcomes.<br>
It acts only for the current extension generation while that Pi session owns <code class="notranslate">state/.lock</code>, rechecking both immediately before branch side effects so replacement or lock loss cannot let an old continuation mutate the new session.<br>
Every path that cannot reach a working branch falls back to delivering the wake to main - a broken branch degrades to today's behavior, never to a lost wake.</li>
<li>Branch system prompt: <code class="notranslate">bin/fm-branch-prompt.sh</code>; its header owns the byte-stable-prefix contract (no timestamps, no fleet snapshot, no per-wake content).</li>
<li>Outcome store: <code class="notranslate">bin/fm-branch-outcome.sh</code>; its header owns the append-only format and the read cursor.<br>
Outcomes are written to the store before any note is handed to Pi, and rows that never reach that handoff replay once through the next locked session-start digest.</li>
<li>Consistency: <code class="notranslate">bin/fm-lease-lib.sh</code> owns the per-task lease contract, the main-only role partition, and the deliberate CONFUSED-AGENT-GRADE threat model these guards target (captain-decided; adversarial-grade separation is out of scope and tracked as follow-up design work); <code class="notranslate">bin/fm-lease.sh</code> is the command surface.<br>
The guards are wired into <code class="notranslate">fm-send.sh</code>, <code class="notranslate">fm-control.sh</code>, and <code class="notranslate">fm-teardown.sh</code> (overlap, lease-checked, with claim serialization retained through the mutation) and <code class="notranslate">fm-pr-merge.sh</code>, <code class="notranslate">fm-merge-local.sh</code>, and <code class="notranslate">fm-spawn.sh</code> (main-owned, branch refused; a relaunch through <code class="notranslate">fm-control</code> stays branch-legal recovery).</li>
<li>Captain autonomy grant: <code class="notranslate">config/pi-supervision-branch</code> (docs/configuration.md "Pi supervision branch"). Grants are explicit <code class="notranslate">project=&lt;task-metadata project&gt;</code> lines; the branch accepts a wake only when every unread row resolves wholly inside the listed projects, so sharing a home never broadens authority. Absence, malformed grants, fleet-wide wakes, and mixed-project drains stay on main.</li>
</ul>
<h2>How the branch knows what the captain said</h2>
<p>Main's captain and assistant text - never tool calls, tool results, operational injections, or the branch's own merged notes - is mirrored into the branch as read-only <code class="notranslate">fm-main-mirror</code> messages at main's turn end, before the next wake is handed over.<br>
The mirror cursor is durable (<code class="notranslate">state/.branch-mirror-cursor</code>), so a restart replays only the not-yet-mirrored dialog from main's session file, and a replacement main session re-anchors from its start.<br>
The branch prompt frames mirrored text as context for judgment, never as instructions addressed to the branch; an authorization addressed to main (for example "you may merge when green") does not relax the branch's role limits.</p>
<h2>Two-stage noise filter</h2>
<p>Stage one is unchanged: the bash watcher absorbs everything provably fine at zero token cost.<br>
Stage two is the branch's verdict on each handled event, reported through its <code class="notranslate">fm_branch_report</code> tool: <code class="notranslate">routine</code> merges silently (an idle main gets the appended note immediately, a busy main after the captain's next prompt), <code class="notranslate">captain</code> merges with exactly one follow-up turn.<br>
The verdict criteria in the branch prompt mirror the captain-etiquette escalation list; doubt escalates.<br>
Main can read the durable outcome store on demand through its <code class="notranslate">fm_branch_outcomes</code> tool.</p>
<h2>Cost model and the byte-stable prefix</h2>
<p>The captain accepted the normal provider prompt-caching strategy: a byte-identical branch prefix generated once per firstmate version, the same tool set in the same order on every request, and one shared <code class="notranslate">prompt_cache_key</code> per home for all branch sessions (set in a <code class="notranslate">before_provider_request</code> hook, and only for providers whose requests already carry that field); main keeps its own per-session key.<br>
Budget roughly 60% cache hits on a fresh branch session's first call and 95% on later calls of the persistent session; reuse is best-effort, never guaranteed.<br>
No caching machinery beyond this exists, deliberately: any later dynamic content in the branch prefix silently removes most of the cache benefit, which is why <code class="notranslate">bin/fm-branch-prompt.sh</code>'s header is the contract's single owner and <code class="notranslate">tests/fm-branch-supervision.test.sh</code> pins the output to byte identity.</p>
<h2>Away mode</h2>
<p>Away mode carries over unchanged: while <code class="notranslate">state/.afk</code> exists the away daemon owns supervision, and the branch declines every wake offer for the duration.<br>
What is new is only the attended path: outside away mode, the branch absorbs the routine majority that previously interrupted the captain's conversation, applying the same escalation etiquette the daemon applies while away.</p>
<h2>Verification</h2>
<p>Portable regressions: <code class="notranslate">tests/fm-pi-branch-extension.test.sh</code> (dispatch, gating, fallback, filter, mirror, cache key, persistence), <code class="notranslate">tests/fm-branch-supervision.test.sh</code> (prompt stability, store append-only, leases, guards, non-branch-home invariance), the branch-offer test in <code class="notranslate">tests/fm-pi-watch-extension.test.sh</code>, and the recovery test in <code class="notranslate">tests/fm-session-start.test.sh</code>.<br>
Live guard: <code class="notranslate">FM_PI_BRANCH_LIVE_E2E=1 tests/fm-pi-branch-live-e2e.test.sh</code> exercises the real installed Pi SDK with no credentials and no provider call; run it after every Pi upgrade and record the dated result in <a href="verification/runtime-backends.md">docs/verification/runtime-backends.md</a>.<br>
The strict typecheck in <code class="notranslate">tests/fm-pi-primary-types.test.sh</code> pins the extension against the installed Pi package.</p></article>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"df2d923f8082e3f48e8cf0ca5b711b75fa9cb369","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 error</summary>

- 🚨 `docs/pi-supervision-branch-poster.svg:19` - The poster says the supervision brain merges when CI turns green, reinforced by “merged: your fix is in” at line 87. This contradicts the contract in docs/pi-supervision-branch.md:29 and bin/fm-branch-prompt.sh:75, where the branch is explicitly forbidden from merging PRs or local work. Because the still is captain-approved, ask whether the poster should depict an allowed branch outcome instead or whether this semantic discrepancy is intentional.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --check 52ff62e8253623b4fafd125c52cdd4c13a3a84b1..df2d923f8082e3f48e8cf0ca5b711b75fa9cb369`
- `Focused Python validation of the changed-file scope, README/data exclusions, SVG structure and accessibility metadata, markdown placement, plain-dash requirement, and resolved image path`
- <code>Rendered `docs/pi-supervision-branch.md` through GitHub&#39;s Markdown API and opened the result in Chrome</code>
- `Chrome verification that the poster loaded at its intrinsic 1200x860 dimensions with no console errors`
- `Headless Chrome screenshots of the standalone SVG and rendered documentation surface`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
