### PR TITLE
feat(bin): add HPlan world-readable inventory-copy guard

### DIFF
--- a/bin/fm-hplan-guard-analyze.py
+++ b/bin/fm-hplan-guard-analyze.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""fm-hplan-guard-analyze.py - the content analyzer behind fm-hplan-guard.sh.
+
+Sourced as a program by bin/fm-hplan-guard.sh; not part of the public surface.
+See the shell script's header for the guardian's contract. This file owns the
+content-side mechanics:
+
+  * It walks the given scopes looking for WORLD-READABLE regular files whose
+    CONTENT carries the HPlan inventory signature. The signature hangs on what
+    the data is, never on what the file is called:
+      - structured tier: a SQLite database containing table `belegung` with a
+        filled `uebungsleiter` column and at least --min-rows populated rows.
+      - byte tier: when the database cannot be opened as SQLite, co-presence of
+        the schema tokens `uebungsleiter` and `belegung` in the raw bytes plus
+        at least --byte-min bytes (covers live WAL images and orphaned ones).
+      - dump tier: plain SQL text carrying both tokens plus at least one INSERT
+        into `belegung`, again above the byte floor.
+  * It reads files only to recognize them. Nothing it sees is ever written
+    anywhere; its entire output is paths, modes, sizes, tiers, and counts.
+  * It changes nothing it scans: databases are opened with URI flag
+    immutable=1, which takes no locks and writes no journal, and every other
+    access is plain reading.
+  * Every failure is ordinary: an unreadable file, a vanished path, or a
+    malformed database is counted and the walk continues. A torn time budget
+    marks the scope incomplete instead of raising anything.
+
+Usage:
+  fm-hplan-guard-analyze.py --budget-secs N --min-rows N --byte-min N \
+      --scan-max N SCOPE [SCOPE...]
+
+Prints exactly one JSON object on stdout.
+"""
+
+import argparse
+import json
+import os
+import re
+import sqlite3
+import sys
+import time
+import urllib.parse
+
+SQLITE_MAGIC = b"SQLite format 3\x00"
+MARKER_COLUMN = b"uebungsleiter"
+MARKER_TABLE = b"belegung"
+# Directories whose contents this detector skips, each a stated limit rather
+# than an oversight: git objects are zlib-compressed (the plaintext signature
+# cannot appear in them - a committed leak is a different incident family,
+# caught at review, not by content scanning); dependency, bytecode, build, and
+# cache trees are third-party material no one copies the inventory into.
+PRUNE_NAMES = {
+    ".git", "node_modules", "__pycache__", ".venv", "venv",
+    ".tox", ".cache", ".mypy_cache", ".pytest_cache",
+    "target", "dist", "build", ".next", ".turbo",
+}
+# Files below this cannot carry the inventory: the schema alone spans several
+# SQLite pages, and the reporting thresholds sit far higher.
+ENUM_MIN_BYTES = 8192
+HEAD_BYTES = 512
+
+
+class Coverage:
+    def __init__(self, scope):
+        self.scope = scope
+        self.status = "ok"
+        self.scanned = 0
+        self.unreadable = 0
+        self.errors = 0
+
+    def as_dict(self):
+        return {
+            "scope": self.scope,
+            "status": self.status,
+            "scanned": self.scanned,
+            "unreadable": self.unreadable,
+            "errors": self.errors,
+        }
+
+
+def out_of_time(deadline):
+    return time.monotonic() >= deadline
+
+
+def human_findings(findings):
+    """Merge per-path results so every reported path appears once."""
+    merged = {}
+    for finding in findings:
+        merged.setdefault(finding["path"], finding)
+    return list(merged.values())
+
+
+def companion_siblings(path):
+    """World-readable -wal/-shm siblings of a flagged database."""
+    out = []
+    for suffix in ("-wal", "-shm"):
+        sib = path + suffix
+        try:
+            st = os.stat(sib)
+        except OSError:
+            continue
+        if not os.path.isfile(sib) or os.path.islink(sib):
+            continue
+        if not st.st_mode & 0o0004:
+            continue
+        out.append({"path": sib, "mode": format(st.st_mode & 0o777, "o"),
+                    "size": st.st_size})
+    return out
+
+
+def scan_bytes_for_markers(path, limit):
+    """True when both schema tokens appear in the first <limit> raw bytes."""
+    seen_column = False
+    seen_table = False
+    tail = b""
+    try:
+        with open(path, "rb") as handle:
+            read_total = 0
+            while read_total < limit:
+                chunk = handle.read(min(1024 * 1024, limit - read_total))
+                if not chunk:
+                    break
+                read_total += len(chunk)
+                window = tail + chunk
+                if not seen_column and MARKER_COLUMN in window:
+                    seen_column = True
+                if not seen_table and MARKER_TABLE in window:
+                    seen_table = True
+                # Tokens can straddle chunk borders; keep the last
+                # (token-length - 1) bytes as overlap context.
+                tail = window[-(max(len(MARKER_COLUMN), len(MARKER_TABLE)) - 1):]
+                if seen_column and seen_table:
+                    return True
+    except OSError:
+        return False
+    return False
+
+
+def analyze_sqlite(path, size, args):
+    """Structured confirmation first, honest byte fallback second."""
+    count = None
+    abspath = os.path.abspath(path)
+    uri = "file:" + urllib.parse.quote(abspath) + "?immutable=1"
+    try:
+        con = sqlite3.connect(uri, uri=True, timeout=0.25)
+        try:
+            row = con.execute(
+                "SELECT name FROM sqlite_master"
+                " WHERE type='table' AND lower(name)=?",
+                ("belegung",),
+            ).fetchone()
+            if row is not None:
+                table = row[0]
+                qtable = '"' + table.replace('"', '""') + '"'
+                columns = con.execute(f"PRAGMA table_info({qtable})").fetchall()
+                column = next(
+                    (c[1] for c in columns if str(c[1]).lower() == "uebungsleiter"),
+                    None,
+                )
+                if column is not None:
+                    qcolumn = '"' + str(column).replace('"', '""') + '"'
+                    count = con.execute(
+                        f"SELECT count(*) FROM {qtable}"
+                        f" WHERE {qcolumn} IS NOT NULL AND trim({qcolumn})<>''"
+                    ).fetchone()[0]
+        finally:
+            con.close()
+    except (sqlite3.Error, ValueError, OverflowError):
+        count = None
+    if count is not None and count >= args.min_rows:
+        return {"tier": "sqlite-struktur", "detail": f"zeilen={count}"}
+    if size >= args.byte_min and scan_bytes_for_markers(path, args.scan_max):
+        return {"tier": "byte-signatur", "detail": "marker"}
+    return None
+
+
+def is_text_shaped(head):
+    """No NUL and almost no control bytes: prose, code, JSON, SQL text."""
+    if b"\x00" in head:
+        return False
+    control = sum(1 for byte in head if byte < 0x09 or 0x0e <= byte <= 0x1f)
+    return control <= 2
+
+
+def looks_like_sql_dump(head):
+    """Text-shaped head carrying SQL shape. Natural-language text that merely
+    mentions the marker words never enters the dump tier here - the tier's
+    verdict additionally demands an INSERT targeting belegung."""
+    return is_text_shaped(head) and (
+        b"create table" in head.lower() or b"insert into" in head.lower()
+    )
+
+
+# Containers whose contents are compressed: the plaintext signature cannot
+# appear in them, so reading them is wasted budget. An archived copy is out of
+# scope by design and stays a stated limit of this guardian.
+COMPRESSED_SUFFIXES = (
+    ".gz", ".xz", ".bz2", ".zst", ".zip", ".7z", ".lz4",
+    ".tar", ".tgz", ".tbz2", ".txz",
+)
+
+
+def is_compressed_container(path):
+    lowered = path.lower()
+    return lowered.endswith(COMPRESSED_SUFFIXES)
+
+
+# Compiled binaries and media containers: their payloads are compressed or
+# structured formats where the plaintext signature cannot meaningfully appear.
+# Skipping them before opening keeps heavy sweeps cheap; this is a stated
+# limit, like the compressed-container one above.
+MEDIA_SUFFIXES = (
+    ".png", ".jpg", ".jpeg", ".gif", ".webp", ".avif", ".ico", ".bmp",
+    ".mp3", ".mp4", ".mkv", ".webm", ".wav", ".ogg", ".flac", ".mov",
+    ".pdf", ".woff", ".woff2", ".ttf", ".otf", ".eot",
+    ".so", ".o", ".a", ".dll", ".dylib", ".exe",
+    ".class", ".jar", ".wasm", ".bin", ".iso", ".img", ".dmg",
+    ".deb", ".rpm", ".appimage", ".snap",
+)
+
+
+def is_skippable_binary(path):
+    return path.lower().endswith(MEDIA_SUFFIXES)
+
+
+INSERT_INTO_BELEGUNG_RE = re.compile(
+    rb"insert\s+(?:or\s+\w+\s+)?into\s+\"?belegung\"?"
+)
+
+
+def analyze_dump(path, size, args):
+    if size < args.byte_min:
+        return None
+    try:
+        with open(path, "rb") as handle:
+            blob = handle.read(args.scan_max)
+    except OSError:
+        return None
+    lowered = blob.lower()
+    if MARKER_COLUMN not in lowered or MARKER_TABLE not in lowered:
+        return None
+    # The INSERT is what separates an actual data copy from prose or docs that
+    # merely mention the schema: without it, this is not reported.
+    if not INSERT_INTO_BELEGUNG_RE.search(lowered):
+        return None
+    return {"tier": "dump-signatur", "detail": "marker+einfuegung"}
+
+
+def walk_scope(scope, deadline, args, findings):
+    cover = Coverage(scope)
+    if not os.path.isdir(scope) or os.path.islink(scope):
+        cover.status = "leer"
+        return cover
+    for root, dirs, files in os.walk(scope, followlinks=False):
+        dirs[:] = [d for d in dirs if d not in PRUNE_NAMES]
+        for name in files:
+            if out_of_time(deadline):
+                cover.status = "unvollstaendig"
+                return cover
+            path = os.path.join(root, name)
+            try:
+                if os.path.islink(path):
+                    continue
+                st = os.stat(path)
+            except OSError:
+                cover.errors += 1
+                continue
+            if not os.path.isfile(path):
+                continue
+            if not st.st_mode & 0o0004:
+                continue
+            if st.st_size < ENUM_MIN_BYTES:
+                continue
+            if is_skippable_binary(path):
+                continue
+            cover.scanned += 1
+            try:
+                with open(path, "rb") as handle:
+                    head = handle.read(HEAD_BYTES)
+            except OSError:
+                cover.unreadable += 1
+                continue
+            if len(head) < 16:
+                continue
+            verdict = None
+            if head[:16] == SQLITE_MAGIC:
+                verdict = analyze_sqlite(path, st.st_size, args)
+                if verdict is not None:
+                    verdict["companions"] = companion_siblings(path)
+            elif looks_like_sql_dump(head):
+                verdict = analyze_dump(path, st.st_size, args)
+            elif (st.st_size >= args.byte_min
+                    and not is_text_shaped(head)
+                    and not is_compressed_container(path)):
+                # Raw binary carrier: a live or orphaned WAL page image, or any
+                # other NUL-bearing blob whose bytes carry the schema tokens.
+                # Natural-language text never reaches this tier - German prose
+                # mentioning both words stays unreported by design.
+                if scan_bytes_for_markers(path, args.scan_max):
+                    verdict = {"tier": "byte-signatur", "detail": "marker"}
+            if verdict is None:
+                continue
+            findings.append({
+                "path": path,
+                "mode": format(st.st_mode & 0o777, "o"),
+                "size": st.st_size,
+                "tier": verdict["tier"],
+                "detail": verdict.get("detail", ""),
+                "companions": verdict.get("companions", []),
+            })
+        if out_of_time(deadline):
+            cover.status = "unvollstaendig"
+            return cover
+    return cover
+
+
+def main():
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--budget-secs", type=float, required=True)
+    parser.add_argument("--min-rows", type=int, required=True)
+    parser.add_argument("--byte-min", type=int, required=True)
+    parser.add_argument("--scan-max", type=int, required=True)
+    parser.add_argument("scopes", nargs="+")
+    args = parser.parse_args()
+
+    deadline = time.monotonic() + max(0.0, args.budget_secs)
+    findings = []
+    coverage = []
+    scopes_seen = set()
+    for scope in args.scopes:
+        if scope in scopes_seen:
+            continue
+        scopes_seen.add(scope)
+        if out_of_time(deadline):
+            cover = Coverage(scope)
+            cover.status = "unvollstaendig"
+            coverage.append(cover.as_dict())
+            continue
+        cover = walk_scope(scope, deadline, args, findings)
+        coverage.append(cover.as_dict())
+
+    sys.stdout.write(json.dumps({
+        "findings": human_findings(findings),
+        "coverage": coverage,
+    }))
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/fm-hplan-guard.sh
+++ b/bin/fm-hplan-guard.sh
@@ -1,0 +1,749 @@
+#!/usr/bin/env bash
+# fm-hplan-guard.sh - report world-readable copies of the HPlan inventory data.
+#
+# Why this exists: four times in two days (2026-08-23/24) copies of the real
+# HPlan database turned up world-readable - 229 hall bookings with real names
+# and phone numbers of the instructors - created by docker cp, by scripts, and
+# by hand, under names nobody had predicted. On 2026-08-24 the running
+# production database itself stood at 644. The rights grip inside HPlan covers
+# only databases HPlan itself creates; every other copy vector stays open. A
+# guardian hung on filenames would have caught none of the general case, so
+# this one hangs its signature on content:
+#
+#   The signature is the inventory's own shape - table `belegung` carrying a
+#   filled `uebungsleiter` column - never a name. It matches in three tiers:
+#
+#     sqlite-struktur  structured proof: SQLite opened read-only and immutable,
+#                      belegung present, uebungsleiter column present, at least
+#                      MIN_ROWS rows with a populated instructor field.
+#     byte-signatur    when structure cannot be read: both schema tokens
+#                      `uebungsleiter` and `belegung` co-present in the raw
+#                      bytes of a NUL-bearing (non-text) file above
+#                      BYTE_MIN_BYTES - live WAL images, orphaned -wal files,
+#                      anything sqlite cannot open.
+#     dump-signatur    plain SQL text carrying both tokens above BYTE_MIN_BYTES
+#                      with an INSERT targeting belegung; prose that merely
+#                      mentions the words is never reported.
+#
+#   Threshold trade-off, stated rather than silent: a sub-threshold extract is
+#   accepted as out of scope so a guardian crying wolf at template and test
+#   databases does not get switched off. Full copies - the entire observed
+#   incident family - always clear the threshold. MIN_ROWS is an environment
+#   knob, not a code change.
+#
+# Where it looks:
+#   Every sweep scans /tmp, this home, this repo root, and the working-copy
+#   pool under $HOME/.treehouse locally, plus - over ssh, bounded by SSH_SECS -
+#   the running service's Docker volume on the server, WAL companions included.
+#   Backup folders are excluded: the backup script sets those rights itself and
+#   they are the normal state, not a find - a guardian reporting its own
+#   non-findings gets switched off. Dependency, bytecode, build, and cache
+#   trees inside the pool are pruned (stated limit, owned by the analyzer);
+#   with them gone the pool here is about 23k readable files and walks in
+#   seconds. If the pool ever outgrows the budget, the walk names the scope
+#   incomplete and the next sweep finishes the job - a named partial state,
+#   never a crash.
+#
+# What it reports: path, mode, size, tier, row count. NEVER content. It reads
+# files to recognize them, and what it sees stays with it; stdout, stderr, and
+# the state record carry no names and no phone numbers. It repairs nothing and
+# changes nothing it scans - databases are opened immutable read-only, which
+# takes no locks and writes no journal. The remedy travels in the message; a
+# human decides. It never issues pattern kills against foreign processes.
+#
+# Cost contract: one sweep is bounded by BUDGET_SECS (cut to fit inside the
+# watcher's FM_CHECK_TIMEOUT the same way fm-tool-update-check.sh fits its
+# budget), the server attempt gets SSH_SECS of its own, and unreachability is
+# "not checked today", never a crash. An unreadable file, a vanished scope, or
+# a malformed database is an ordinary counted event. Every failure lands as a
+# named partial state on stdout while the run still exits 0 - this check rides
+# the supervision cycle, and the cycle must survive it.
+#
+# Silence discipline: suppression is per finding and per named partial state,
+# keyed on path and mode, so a leak that stays put does not nag every cycle,
+# a changed mode or a new path reports immediately, and RE_NAG_SECS brings a
+# standing finding back around once a day.
+#
+# Usage:
+#   fm-hplan-guard.sh check     watcher mode: silent or ONE line, always exit 0
+#   fm-hplan-guard.sh scan      human mode: FINDING/COVER/PARTIAL detail lines
+#   fm-hplan-guard.sh arm       write and register state/hplan-guard.check.sh
+#   fm-hplan-guard.sh disarm    remove the check shim, trust binding, and record
+#   fm-hplan-guard.sh --help    print this help
+#
+# Environment knobs (defaults fit this home; validated, bad values become a
+# named config state in check mode and a refusal in scan/arm):
+#   HPLAN_GUARD_BUDGET_SECS    whole-sweep bound, default 20 (1..120)
+#   HPLAN_GUARD_SSH_SECS       bound for one server attempt, default 8 (1..30)
+#   HPLAN_GUARD_MIN_ROWS       structured-tier row floor, default 100 (1..10M)
+#   HPLAN_GUARD_BYTE_MIN_BYTES byte/dump size floor, default 32768 (1024..1G)
+#   HPLAN_GUARD_SCAN_MAX_BYTES raw bytes read per file, default 64 MiB
+#                              (1 MiB..1 GiB)
+#   HPLAN_GUARD_SCOPES         colon-separated local scopes, default
+#                              /tmp:$HOME/.treehouse:$FM_HOME:<this repo root>
+#   HPLAN_GUARD_SERVER         on|off, default on
+#   HPLAN_GUARD_SSH_CMD        word-split command prefix, default
+#                              "ssh -o ConnectTimeout=10 -o BatchMode=yes"
+#   HPLAN_GUARD_REMOTE_HOST    default gex
+#   HPLAN_GUARD_REMOTE_ROOTS   colon list, default the hplan Docker volume
+#                              /var/lib/docker/volumes/hplan_hplan-daten/_data
+#   HPLAN_GUARD_REMOTE_EXCLUDE colon list, default /root/backups/hplan
+#   HPLAN_GUARD_RE_NAG_SECS    re-report an unchanged finding or partial after
+#                              this many seconds, default 86400; 0 = every sweep
+#
+# State: state/.hplan-guard holds the per-item suppression ledger - keyed
+# hashes and epochs, no paths, no content. Arm/disarm follow the trusted-
+# check-shim pattern of fm-tool-update-check.sh, including rollback, so a
+# failed arm never leaves an unauthenticated shim behind for the watcher to
+# reject every cycle.
+set -u
+export LC_ALL=C
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+RECORD="$STATE/.hplan-guard"
+CHECK_ID=hplan-guard
+CHECK_SHIM="$STATE/$CHECK_ID.check.sh"
+CHECK_TRUST="$STATE/$CHECK_ID.check-trust"
+REGISTER_BIN="$SCRIPT_DIR/fm-check-register.sh"
+ANALYZE_BIN="$SCRIPT_DIR/fm-hplan-guard-analyze.py"
+RECORD_SCHEMA=fm-hplan-guard-v1
+MAX_LINE=1600
+
+# shellcheck source=bin/fm-timeout-lib.sh
+. "$SCRIPT_DIR/fm-timeout-lib.sh"
+# shellcheck source=bin/fm-pr-lib.sh
+. "$SCRIPT_DIR/fm-pr-lib.sh"
+# shellcheck source=bin/fm-line-cap-lib.sh
+. "$SCRIPT_DIR/fm-line-cap-lib.sh"
+# shellcheck source=bin/fm-check-lib.sh
+. "$SCRIPT_DIR/fm-check-lib.sh"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  fm-hplan-guard.sh check     watcher mode: silent or ONE line, always exit 0
+  fm-hplan-guard.sh scan      human mode: FINDING/COVER/PARTIAL detail lines
+  fm-hplan-guard.sh arm       write and register state/hplan-guard.check.sh
+  fm-hplan-guard.sh disarm    remove the check shim, trust binding, and record
+  fm-hplan-guard.sh --help    print this help
+
+The signature hangs on content - table belegung with a filled uebungsleiter
+column - never on a filename. /tmp, home, repo root, the ~/.treehouse pool,
+and the server volume are all covered every sweep. See this script's header
+comment for tiers, exclusions, cost bounds, silence discipline, and knobs.
+EOF
+}
+
+die_usage() {
+  printf 'fm-hplan-guard: %s\n' "$1" >&2
+  usage >&2
+  exit 2
+}
+
+# --- configuration ----------------------------------------------------------
+
+CONFIG_ERROR=
+
+int_in_range() { # <value> <min> <max>
+  case "$1" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  [ "$1" -ge "$2" ] && [ "$1" -le "$3" ]
+}
+
+require_int() { # <var-name> <default> <min> <max>
+  local name=$1 def=$2 min=$3 max=$4 val
+  eval "val=\${$name:-}"
+  [ -n "$val" ] || val=$def
+  if ! int_in_range "$val" "$min" "$max"; then
+    CONFIG_ERROR="$name muss eine ganze Zahl von $min bis $max sein"
+    return 1
+  fi
+  eval "$name=\$val"
+}
+
+resolve_config() {
+  # Defaults first, so even a failed validation leaves every variable the
+  # reporting path touches defined.
+  require_int BUDGET_SECS "${HPLAN_GUARD_BUDGET_SECS:-20}" 1 120 || return 1
+  require_int SSH_SECS "${HPLAN_GUARD_SSH_SECS:-8}" 1 30 || return 1
+  require_int MIN_ROWS "${HPLAN_GUARD_MIN_ROWS:-100}" 1 10000000 || return 1
+  require_int BYTE_MIN_BYTES "${HPLAN_GUARD_BYTE_MIN_BYTES:-32768}" \
+    1024 1073741824 || return 1
+  require_int SCAN_MAX_BYTES "${HPLAN_GUARD_SCAN_MAX_BYTES:-67108864}" \
+    1048576 1073741824 || return 1
+  require_int RE_NAG_SECS "${HPLAN_GUARD_RE_NAG_SECS:-86400}" 0 2592000 \
+    || return 1
+
+  SERVER_MODE=${HPLAN_GUARD_SERVER:-on}
+  case "$SERVER_MODE" in
+    on|off) ;;
+    *)
+      CONFIG_ERROR='HPLAN_GUARD_SERVER muss on oder off sein'
+      return 1
+      ;;
+  esac
+  SSH_CMD=${HPLAN_GUARD_SSH_CMD:-'ssh -o ConnectTimeout=10 -o BatchMode=yes'}
+  REMOTE_HOST=${HPLAN_GUARD_REMOTE_HOST:-gex}
+  REMOTE_ROOTS=${HPLAN_GUARD_REMOTE_ROOTS:-/var/lib/docker/volumes/hplan_hplan-daten/_data}
+  REMOTE_EXCLUDE=${HPLAN_GUARD_REMOTE_EXCLUDE:-/root/backups/hplan}
+
+  # Explicit scopes replace the default plan: the contract for tests and
+  # one-off audits.
+  SCOPES=${HPLAN_GUARD_SCOPES:-"/tmp:$HOME/.treehouse:$FM_HOME:$SCRIPT_DIR/.."}
+  return 0
+}
+
+# The watcher runs every check under its own hard timeout and discards whatever
+# a killed run printed, so the budget has to fit inside that bound or a torn
+# sweep would repeat its silence on every poll. Same margins as
+# fm-tool-update-check.sh: rounding plus kill grace.
+fit_budget_to_watcher() {
+  CHECK_TIMEOUT=${FM_CHECK_TIMEOUT:-30}
+  case "$CHECK_TIMEOUT" in
+    ''|*[!0-9]*|0) CHECK_TIMEOUT=30 ;;
+  esac
+  local budget_max=$((CHECK_TIMEOUT - 3))
+  [ "$budget_max" -ge 1 ] || budget_max=1
+  if [ "$BUDGET_SECS" -gt "$budget_max" ]; then
+    BUDGET_SECS=$budget_max
+  fi
+}
+
+real_epoch() { date +%s; }
+
+have_jq() { command -v jq >/dev/null 2>&1; }
+
+human_size() {
+  if [ "$1" -ge 1048576 ]; then
+    printf '%s MB' "$((($1 + 524287) / 1048576))"
+  elif [ "$1" -ge 1024 ]; then
+    printf '%s KB' "$((($1 + 512) / 1024))"
+  else
+    printf '%s B' "$1"
+  fi
+}
+
+# --- sweep results ----------------------------------------------------------
+# Every finding is one row: path TAB mode TAB size TAB tier TAB detail.
+# Companions (world-readable -wal/-shm siblings of a flagged database) become
+# rows of their own with tier "begleiter", so nothing about a leak hides behind
+# its database entry.
+
+FINDING_ROWS=()
+PARTIALS=()
+LOCAL_JSON=
+
+add_finding_row() { # <path> <mode> <size> <tier> <detail>
+  FINDING_ROWS+=("$1"$'\t'"$2"$'\t'"$3"$'\t'"$4"$'\t'"$5")
+}
+
+emit_local_json_rows() {
+  local line path mode size tier detail comp_path comp_mode comp_size
+  while IFS=$'\t' read -r path mode size tier detail comps_json; do
+    [ -n "$path" ] || continue
+    add_finding_row "$path" "$mode" "$size" "$tier" "$detail"
+    if [ -n "$comps_json" ] && [ "$comps_json" != "[]" ] && have_jq; then
+      while IFS=$'\t' read -r comp_path comp_mode comp_size; do
+        [ -n "$comp_path" ] || continue
+        add_finding_row "$comp_path" "$comp_mode" "$comp_size" "begleiter" \
+          "begleiter von $path"
+      done < <(printf '%s' "$comps_json" \
+        | jq -r '.[] | [.path, .mode, (.size|tostring)] | join("\t")')
+    fi
+  done < <(printf '%s\n' "$LOCAL_JSON" | jq -r '
+    .findings[] | [.path, .mode, (.size|tostring), .tier, .detail,
+                   ((.companions // []) | tostring)] | join("\t")' 2>/dev/null)
+}
+
+emit_cover_lines() {
+  jq -r '.coverage[] |
+    "COVER\t\(.scope)\t\(.status)\t\(.scanned)\t\(.unreadable)"' \
+    <<< "$LOCAL_JSON" 2>/dev/null
+}
+
+# --- remote leg -------------------------------------------------------------
+
+# Runs on the target over `bash -s`. Pure measurement: find prefilter, one grep
+# pair per candidate. Emits FINDING TSV rows on stdout and nothing else;
+# REMOTE-NOSCOPES says every configured root was absent, which the caller turns
+# into a named partial state rather than reading as a clean no.
+remote_snippet() {
+  cat <<'SNIP'
+roots=$1
+exclude=$2
+minbytes=$3
+any_root=0
+OLDIFS=$IFS
+IFS=:
+set -- $roots
+IFS=$OLDIFS
+for r in "$@"; do
+  [ -n "$r" ] || continue
+  [ -d "$r" ] || continue
+  any_root=1
+  while IFS= read -r -d '' f; do
+    skip=0
+    OLDIFS=$IFS
+    IFS=:
+    set -- ${exclude:-}
+    IFS=$OLDIFS
+    for e in "$@"; do
+      [ -n "$e" ] || continue
+      case "$f" in
+        "$e"|"$e"/*) skip=1; break ;;
+      esac
+    done
+    [ "$skip" = 0 ] || continue
+    m=$(stat -c '%a' -- "$f" 2>/dev/null) || continue
+    # The last octal digit carries the world-read bit; find already filtered,
+    # this re-check keeps the snippet honest on its own.
+    case ${m: -1} in
+      [4567]) ;;
+      *) continue ;;
+    esac
+    s=$(stat -c '%s' -- "$f" 2>/dev/null) || continue
+    [ "$s" -ge "$minbytes" ] || continue
+    if grep -qa uebungsleiter -- "$f" 2>/dev/null \
+      && grep -qa belegung -- "$f" 2>/dev/null; then
+      printf 'FINDING\t%s\t%s\t%s\tbyte-signatur\tmarker\n' "$f" "$m" "$s"
+    fi
+  done < <(find "$r" -type f -perm -0004 -size +"$((minbytes - 1))"c -print0 2>/dev/null)
+done
+[ "$any_root" = 1 ] || printf 'REMOTE-NOSCOPES\n'
+exit 0
+SNIP
+}
+
+run_remote_leg() { # <remaining-secs>: appends FINDING_ROWS/PARTIALS, never fails
+  local remaining=$1 bound out status line path mode size tier detail
+  bound=$SSH_SECS
+  [ "$bound" -gt "$remaining" ] && bound=$remaining
+  [ "$bound" -ge 1 ] || bound=1
+  status=0
+  # The command prefix is a deliberate word split so operators can spell ssh
+  # options into it; the host itself travels quoted.
+  # shellcheck disable=SC2086
+  out=$(printf '%s\n' "$(remote_snippet)" \
+    | fm_run_timed "$bound" $SSH_CMD "$REMOTE_HOST" bash -s -- \
+      "$REMOTE_ROOTS" "$REMOTE_EXCLUDE" "$BYTE_MIN_BYTES") || status=$?
+  if [ "$status" -eq 124 ]; then
+    PARTIALS+=("Server $REMOTE_HOST heute nicht geprueft: Zugriff ueberschritt die Frist")
+    return 0
+  fi
+  if [ "$status" -ne 0 ]; then
+    PARTIALS+=("Server $REMOTE_HOST heute nicht geprueft: nicht erreichbar")
+    return 0
+  fi
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    if [ "$line" = "REMOTE-NOSCOPES" ]; then
+      PARTIALS+=("Serverpfade fehlen oder sind nicht lesbar: $REMOTE_ROOTS")
+      continue
+    fi
+    case "$line" in
+      FINDING$'\t'*)
+        line=${line#'FINDING'}
+        line=${line#$'\t'}
+        IFS=$'\t' read -r path mode size tier detail <<< "$line"
+        add_finding_row "$path" "$mode" "$size" "$tier" "$detail"
+        ;;
+    esac
+  done <<< "$out"
+}
+
+# --- local leg --------------------------------------------------------------
+
+run_local_leg() { # <remaining-secs>: fills LOCAL_JSON/PARTIALS, never fails
+  local remaining=$1 bound out status
+  local -a scope_split=()
+  if ! command -v python3 >/dev/null 2>&1; then
+    PARTIALS+=("python3 fehlt auf diesem Host: lokale Suche heute nicht moeglich")
+    return 0
+  fi
+  if ! have_jq; then
+    PARTIALS+=("jq fehlt auf diesem Host: lokale Suche heute nicht moeglich")
+    return 0
+  fi
+  bound=$remaining
+  [ "$bound" -ge 1 ] || bound=1
+  IFS=: read -r -a scope_split <<< "$SCOPES"
+  status=0
+  out=$(fm_run_timed "$bound" python3 "$ANALYZE_BIN" \
+    --budget-secs "$bound" \
+    --min-rows "$MIN_ROWS" \
+    --byte-min "$BYTE_MIN_BYTES" \
+    --scan-max "$SCAN_MAX_BYTES" \
+    ${scope_split[@]+"${scope_split[@]}"}) || status=$?
+  if [ "$status" -ne 0 ] || [ -z "$out" ]; then
+    PARTIALS+=("lokale Suche an der Zeitgrenze abgeschnitten")
+    return 0
+  fi
+  LOCAL_JSON=$out
+}
+
+# --- report assembly --------------------------------------------------------
+
+format_finding_text() { # <row>: one captain-facing clause, metadata only
+  local row=$1 path mode size tier detail text
+  IFS=$'\t' read -r path mode size tier detail <<< "$row"
+  text="$path (Rechte $mode, $(human_size "$size"), $tier"
+  [ -n "$detail" ] && text="$text, $detail"
+  printf '%s' "$text)"
+}
+
+item_key() { # <row or partial text>: stable suppression key, no content
+  local hash
+  hash=$(printf '%s' "$1" | shasum -a 256 2>/dev/null | awk '{print $1}')
+  if [ -z "$hash" ]; then
+    hash=$(printf '%s' "$1" | sha256sum 2>/dev/null | awk '{print $1}')
+  fi
+  printf '%s\n' "${hash:0:16}"
+}
+
+# --- suppression ledger -----------------------------------------------------
+# state/.hplan-guard:
+#   fm-hplan-guard-v1
+#   seen=<key>:<epoch>;…  what has already been reported, and when
+# Keys are truncated hashes of path+mode+tier (findings) or of the message
+# (partials): the ledger holds no paths and no content. Everything here stays
+# compatible with stock bash 3.2 - indexed arrays only, no associative ones.
+
+REC_SEEN=
+
+record_read() {
+  REC_SEEN=
+  [ -f "$RECORD" ] || return 0
+  local line
+  while IFS= read -r line; do
+    case "$line" in
+      "$RECORD_SCHEMA") : ;;
+      seen=*) REC_SEEN=${line#seen=} ;;
+    esac
+  done < "$RECORD"
+  return 0
+}
+
+seen_epoch() { # <key>: prints the recorded epoch or nothing
+  local key=$1 entry
+  local IFS=';'
+  for entry in $REC_SEEN; do
+    [ -n "$entry" ] || continue
+    [ "${entry%%:*}" = "$key" ] && { printf '%s\n' "${entry##*:}"; return 0; }
+  done
+  return 0
+}
+
+seen_is_news() { # <key>: success means this should be reported now
+  local key=$1 epoch age
+  epoch=$(seen_epoch "$key")
+  [ -n "$epoch" ] || return 0
+  age=$(( $(real_epoch) - epoch ))
+  [ "$age" -lt 0 ] && age=0
+  [ "$age" -ge "$RE_NAG_SECS" ]
+}
+
+record_write() { # <keys-reported-space-list>: persist the ledger atomically
+  local reported=$1 now cutoff keep='' tmp
+  local entry ekey eepoch key found i
+  mkdir -p "$STATE" 2>/dev/null || true
+  now=$(real_epoch)
+  cutoff=$((now - 604800))
+  local -a ks=()
+  local -a es=()
+  local IFS=';'
+  for entry in $REC_SEEN; do
+    [ -n "$entry" ] || continue
+    ekey=${entry%%:*}
+    eepoch=${entry##*:}
+    case "$eepoch" in ''|*[!0-9]*) continue ;; esac
+    [ "$eepoch" -ge "$cutoff" ] || continue
+    ks+=("$ekey")
+    es+=("$eepoch")
+  done
+  unset IFS
+  for key in $reported; do
+    found=0
+    for i in ${ks[@]+"${!ks[@]}"}; do
+      [ "${ks[$i]}" = "$key" ] && { es[i]=$now; found=1; break; }
+    done
+    [ "$found" = 1 ] || { ks+=("$key"); es+=("$now"); }
+  done
+  # One field per entry; printf adds the newline per argument, because a
+  # command-substitution accumulator would strip it and glue entries together.
+  local -a lines=()
+  for i in ${ks[@]+"${!ks[@]}"}; do
+    lines+=("$(printf '%010d %s' "${es[$i]}" "${ks[$i]}")")
+  done
+  local sorted e k
+  sorted=$(printf '%s\n' ${lines[@]+"${lines[@]}"} | sort -r | head -n 128)
+  while read -r e k; do
+    [ -n "$k" ] || continue
+    keep="${keep:+$keep;}${k}:${e}"
+  done <<< "$sorted"
+  tmp=$(mktemp "$RECORD.XXXXXX" 2>/dev/null) || return 1
+  chmod 0600 "$tmp" 2>/dev/null || { rm -f -- "$tmp"; return 1; }
+  {
+    printf '%s\n' "$RECORD_SCHEMA"
+    printf 'seen=%s\n' "$keep"
+  } > "$tmp" || { rm -f -- "$tmp"; return 1; }
+  mv -f -- "$tmp" "$RECORD" || { rm -f -- "$tmp"; return 1; }
+  return 0
+}
+
+# --- actions ----------------------------------------------------------------
+
+action_check() {
+  if ! resolve_config; then
+    # A bad configuration is a named partial state like any other: reported
+    # once through the same suppression ledger, never a crash.
+    PARTIALS+=("falsch konfiguriert: $CONFIG_ERROR")
+    emit_suppressed_or_line
+    return 0
+  fi
+  fit_budget_to_watcher
+  record_read
+  PARTIALS=()
+  FINDING_ROWS=()
+  LOCAL_JSON=
+  local deadline left
+  deadline=$(( $(real_epoch) + BUDGET_SECS ))
+  if [ "$SERVER_MODE" = on ]; then
+    run_remote_leg "$BUDGET_SECS"
+  fi
+  left=$((deadline - $(real_epoch)))
+  if [ "$left" -lt 1 ]; then
+    PARTIALS+=("lokale Suche an der Zeitgrenze abgeschnitten")
+  else
+    run_local_leg "$left"
+  fi
+  build_report_line
+  emit_suppressed_or_line
+  return 0
+}
+
+build_report_line() {
+  if ! have_jq; then
+    PARTIALS+=("jq fehlt auf diesem Host: lokale Suche heute nicht moeglich")
+  elif [ -n "$LOCAL_JSON" ]; then
+    emit_local_json_rows
+  fi
+}
+
+# Decides what is news, assembles the one line, updates the ledger, prints it.
+emit_suppressed_or_line() {
+  local row text key reported_keys="" line="hplan-waechter:"
+  local findings_part="" partials_part="" p remedy=""
+  for row in ${FINDING_ROWS[@]+"${FINDING_ROWS[@]}"}; do
+    key=$(item_key "$row")
+    seen_is_news "$key" || continue
+    reported_keys="${reported_keys:+$reported_keys }$key"
+    text=$(format_finding_text "$row")
+    findings_part="${findings_part:+$findings_part; }$text"
+  done
+  for p in ${PARTIALS[@]+"${PARTIALS[@]}"}; do
+    key=$(item_key "partial|$p")
+    seen_is_news "$key" || continue
+    reported_keys="${reported_keys:+$reported_keys }$key"
+    partials_part="${partials_part:+$partials_part; }$p"
+  done
+  if [ -n "$findings_part" ] && [ -z "$partials_part" ]; then
+    remedy=" - Rechte auf 600 ziehen oder Datei entfernen; den Fund nicht veraendern."
+    line="$line weltlesbare Bestandskopie: $findings_part$remedy"
+  elif [ -n "$findings_part" ]; then
+    line="$line weltlesbare Bestandskopie: $findings_part · $partials_part"
+  elif [ -n "$partials_part" ]; then
+    line="$line Pruefung unvollstaendig: $partials_part"
+  else
+    line=
+  fi
+  REPORT_LINE=
+  if [ -n "$line" ]; then
+    fm_cap_line_var "$line" "$MAX_LINE"
+    REPORT_LINE=$FM_LINE_CAP_LINE
+  fi
+  record_write "$reported_keys" || true
+  if [ -n "$REPORT_LINE" ]; then
+    printf '%s\n' "$REPORT_LINE"
+  fi
+  return 0
+}
+
+action_scan() {
+  resolve_config || {
+    printf 'fm-hplan-guard: %s\n' "$CONFIG_ERROR" >&2
+    exit 2
+  }
+  fit_budget_to_watcher
+  PARTIALS=()
+  FINDING_ROWS=()
+  LOCAL_JSON=
+  local deadline left p row
+  deadline=$(( $(real_epoch) + BUDGET_SECS ))
+  if [ "$SERVER_MODE" = on ]; then
+    run_remote_leg "$BUDGET_SECS"
+  fi
+  left=$((deadline - $(real_epoch)))
+  if [ "$left" -lt 1 ]; then
+    PARTIALS+=("lokale Suche an der Zeitgrenze abgeschnitten")
+  else
+    run_local_leg "$left"
+  fi
+  if [ -n "$LOCAL_JSON" ]; then
+    emit_local_json_rows
+    emit_cover_lines
+  fi
+  for p in ${PARTIALS[@]+"${PARTIALS[@]}"}; do
+    printf 'PARTIAL\t%s\n' "$p"
+  done
+  for row in ${FINDING_ROWS[@]+"${FINDING_ROWS[@]}"}; do
+    printf 'FINDING\t%s\n' "$row"
+  done
+  return 0
+}
+
+# --- arm/disarm (trusted check shim pattern of fm-tool-update-check.sh) ------
+
+shim_content() {
+  local home=$1
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    '# Auto-generated by fm-hplan-guard.sh - inventory-copy leak poll shim.' \
+    '# The watcher validates these bytes, then dispatches the trusted check script.' \
+    "export FM_HOME=$(printf '%q' "$home")" \
+    "exec $(printf '%q' "$SCRIPT_DIR/fm-hplan-guard.sh") check"
+}
+
+SHIM_WRITE_TMP=
+
+shim_write() {
+  local want=$1 device tmp
+  [ -d "$STATE" ] && [ ! -L "$STATE" ] || return 1
+  device=$(fm_pr_file_device "$STATE") || return 1
+  [ -n "$device" ] || return 1
+  fm_pr_regular_destination_on_device_or_absent "$CHECK_SHIM" "$device" || return 1
+  if [ -e "$CHECK_SHIM" ] && [ "$(fm_pr_file_mode "$CHECK_SHIM")" = 700 ] \
+    && [ "$(cat "$CHECK_SHIM" 2>/dev/null)" = "$want" ]; then
+    return 0
+  fi
+  tmp=$(umask 077; mktemp "$STATE/.fm-hplan-guard-check.XXXXXX" 2>/dev/null) || return 1
+  SHIM_WRITE_TMP=$tmp
+  if ! printf '%s\n' "$want" > "$tmp" \
+    || ! chmod 0700 "$tmp" \
+    || ! fm_pr_private_file_valid "$tmp" 700 "$device"; then
+    rm -f -- "$tmp"
+    SHIM_WRITE_TMP=
+    return 1
+  fi
+  if ! fm_pr_regular_destination_on_device_or_absent "$CHECK_SHIM" "$device" \
+    || ! mv -f -- "$tmp" "$CHECK_SHIM"; then
+    rm -f -- "$tmp"
+    SHIM_WRITE_TMP=
+    return 1
+  fi
+  SHIM_WRITE_TMP=
+  fm_pr_private_file_valid "$CHECK_SHIM" 700 "$device"
+}
+
+shim_backup() {
+  local device tmp
+  device=$(fm_pr_file_device "$STATE") || return 1
+  [ -n "$device" ] || return 1
+  tmp=$(umask 077; mktemp "$STATE/.fm-hplan-guard-check.XXXXXX" 2>/dev/null) || return 1
+  if ! cat "$CHECK_SHIM" > "$tmp" 2>/dev/null \
+    || ! chmod 0700 "$tmp" \
+    || ! fm_pr_private_file_valid "$tmp" 700 "$device"; then
+    rm -f -- "$tmp"
+    return 1
+  fi
+  printf '%s\n' "$tmp"
+}
+
+ARM_BACKUP=
+
+arm_rollback() {
+  [ -z "$SHIM_WRITE_TMP" ] || rm -f -- "$SHIM_WRITE_TMP"
+  SHIM_WRITE_TMP=
+  if [ -n "$ARM_BACKUP" ]; then
+    mv -f -- "$ARM_BACKUP" "$CHECK_SHIM" 2>/dev/null || rm -f -- "$ARM_BACKUP"
+    ARM_BACKUP=
+    if fm_custom_check_registered "$STATE" "$CHECK_ID"; then
+      return 0
+    fi
+  fi
+  rm -f -- "$CHECK_SHIM"
+}
+
+arm_interrupted() {
+  arm_rollback
+  printf 'fm-hplan-guard: arming was interrupted, so state/%s.check.sh is not armed\n' "$CHECK_ID" >&2
+  exit 1
+}
+
+action_arm() {
+  local want home
+  if [ -d "$STATE" ]; then
+    :
+  else
+    mkdir -p "$STATE" || {
+      printf 'fm-hplan-guard: cannot create %s\n' "$STATE" >&2
+      return 1
+    }
+  fi
+  resolve_config || {
+    printf 'fm-hplan-guard: %s\n' "$CONFIG_ERROR" >&2
+    return 1
+  }
+  case "$FM_HOME" in
+    /*) home=$FM_HOME ;;
+    *)
+      home=$(CDPATH='' cd -- "$FM_HOME" 2>/dev/null && pwd -P) || {
+        printf 'fm-hplan-guard: cannot resolve FM_HOME %s\n' "$FM_HOME" >&2
+        return 1
+      }
+      ;;
+  esac
+  want=$(shim_content "$home")
+  ARM_BACKUP=
+  if [ -f "$CHECK_SHIM" ] && [ ! -L "$CHECK_SHIM" ]; then
+    ARM_BACKUP=$(shim_backup) || {
+      printf 'fm-hplan-guard: could not save the existing %s\n' "$CHECK_SHIM" >&2
+      return 1
+    }
+  fi
+  trap arm_interrupted HUP INT TERM
+  if ! shim_write "$want"; then
+    trap - HUP INT TERM
+    arm_rollback
+    printf 'fm-hplan-guard: could not write %s\n' "$CHECK_SHIM" >&2
+    return 1
+  fi
+  if ! FM_HOME="$home" "$REGISTER_BIN" "$CHECK_ID" >/dev/null; then
+    trap - HUP INT TERM
+    arm_rollback
+    printf 'fm-hplan-guard: could not register %s\n' "$CHECK_SHIM" >&2
+    return 1
+  fi
+  trap - HUP INT TERM
+  [ -z "$ARM_BACKUP" ] || rm -f -- "$ARM_BACKUP"
+  ARM_BACKUP=
+  printf 'armed: state/%s.check.sh\n' "$CHECK_ID"
+  return 0
+}
+
+action_disarm() {
+  rm -f -- "$CHECK_SHIM" "$CHECK_TRUST" "$RECORD"
+  printf 'disarmed: state/%s.check.sh\n' "$CHECK_ID"
+  return 0
+}
+
+case "${1:-check}" in
+  check) action_check ;;
+  scan) action_scan ;;
+  arm) action_arm ;;
+  disarm) action_disarm ;;
+  -h|--help) usage ;;
+  *) die_usage "unknown action: $1" ;;
+esac

--- a/bin/fm-hplan-guard.sh
+++ b/bin/fm-hplan-guard.sh
@@ -35,6 +35,14 @@
 #   Every sweep scans /tmp, this home, this repo root, and the working-copy
 #   pool under $HOME/.treehouse locally, plus - over ssh, bounded by SSH_SECS -
 #   the running service's Docker volume on the server, WAL companions included.
+#   The server always appears in scan's coverage view: COVER with candidate
+#   counts when the sweep ran, leer when the configured roots are absent, a
+#   named PARTIAL when unreachable or torn - never silence. check mode stays
+#   deviation-driven: clean sweeps print nothing there, so the watcher is not
+#   woken every cycle by an all-clear. The remote leg applies no size floor on
+#   purpose: inside the service's own data location any world-readable
+#   signature carrier is news, however small, and a floor would turn small
+#   extracts into exactly the silence that hides a leak.
 #   Backup folders are excluded: the backup script sets those rights itself and
 #   they are the normal state, not a find - a guardian reporting its own
 #   non-findings gets switched off. Dependency, bytecode, build, and cache
@@ -266,59 +274,79 @@ emit_cover_lines() {
 
 # --- remote leg -------------------------------------------------------------
 
-# Runs on the target over `bash -s`. Pure measurement: find prefilter, one grep
-# pair per candidate. Emits FINDING TSV rows on stdout and nothing else;
-# REMOTE-NOSCOPES says every configured root was absent, which the caller turns
-# into a named partial state rather than reading as a clean no.
+# Runs on the target over `bash -s`. Pure measurement: enumerate world-readable
+# regular files under the roots (backup prefixes skipped), then one grep pair
+# per candidate. No size floor here on purpose: these roots are the service's
+# own data location, where any world-readable carrier of the signature is a
+# find regardless of size - a floor would turn small extracts into silence,
+# which is exactly the failure this leg exists to prevent.
+#
+# Output protocol, parsed below:
+#   FINDING\tpath\tmode\tsize\ttier\tdetail
+#   REMOTE-COVER\t<scanned>\t<unreadable>     always, when any root existed
+#   REMOTE-NOSCOPES                            when every root was absent
 remote_snippet() {
   cat <<'SNIP'
 roots=$1
 exclude=$2
-minbytes=$3
+scanned=0
+unreadable=0
 any_root=0
+ROOTS=()
+EXCL=()
 OLDIFS=$IFS
 IFS=:
 set -- $roots
+ROOTS=("$@")
+set -- ${exclude:-}
+EXCL=("$@")
 IFS=$OLDIFS
-for r in "$@"; do
+for r in "${ROOTS[@]}"; do
   [ -n "$r" ] || continue
   [ -d "$r" ] || continue
   any_root=1
   while IFS= read -r -d '' f; do
     skip=0
-    OLDIFS=$IFS
-    IFS=:
-    set -- ${exclude:-}
-    IFS=$OLDIFS
-    for e in "$@"; do
+    for e in "${EXCL[@]:-}"; do
       [ -n "$e" ] || continue
       case "$f" in
         "$e"|"$e"/*) skip=1; break ;;
       esac
     done
     [ "$skip" = 0 ] || continue
-    m=$(stat -c '%a' -- "$f" 2>/dev/null) || continue
+    m=$(stat -c '%a' -- "$f" 2>/dev/null)
+    s=$(stat -c '%s' -- "$f" 2>/dev/null)
+    if [ -z "$m" ] || [ -z "$s" ]; then
+      unreadable=$((unreadable + 1))
+      continue
+    fi
     # The last octal digit carries the world-read bit; find already filtered,
     # this re-check keeps the snippet honest on its own.
     case ${m: -1} in
       [4567]) ;;
       *) continue ;;
     esac
-    s=$(stat -c '%s' -- "$f" 2>/dev/null) || continue
-    [ "$s" -ge "$minbytes" ] || continue
+    scanned=$((scanned + 1))
     if grep -qa uebungsleiter -- "$f" 2>/dev/null \
       && grep -qa belegung -- "$f" 2>/dev/null; then
       printf 'FINDING\t%s\t%s\t%s\tbyte-signatur\tmarker\n' "$f" "$m" "$s"
     fi
-  done < <(find "$r" -type f -perm -0004 -size +"$((minbytes - 1))"c -print0 2>/dev/null)
+  done < <(find "$r" -type f -perm -0004 -print0 2>/dev/null)
 done
-[ "$any_root" = 1 ] || printf 'REMOTE-NOSCOPES\n'
+if [ "$any_root" = 1 ]; then
+  printf 'REMOTE-COVER\t%s\t%s\n' "$scanned" "$unreadable"
+else
+  printf 'REMOTE-NOSCOPES\n'
+fi
 exit 0
 SNIP
 }
 
-run_remote_leg() { # <remaining-secs>: appends FINDING_ROWS/PARTIALS, never fails
+run_remote_leg() { # <remaining-secs>: fills remote result globals, never fails
   local remaining=$1 bound out status line path mode size tier detail
+  REMOTE_SCANNED=0
+  REMOTE_UNREADABLE=0
+  REMOTE_STATE=
   bound=$SSH_SECS
   [ "$bound" -gt "$remaining" ] && bound=$remaining
   [ "$bound" -ge 1 ] || bound=1
@@ -328,21 +356,19 @@ run_remote_leg() { # <remaining-secs>: appends FINDING_ROWS/PARTIALS, never fail
   # shellcheck disable=SC2086
   out=$(printf '%s\n' "$(remote_snippet)" \
     | fm_run_timed "$bound" $SSH_CMD "$REMOTE_HOST" bash -s -- \
-      "$REMOTE_ROOTS" "$REMOTE_EXCLUDE" "$BYTE_MIN_BYTES") || status=$?
+      "$REMOTE_ROOTS" "$REMOTE_EXCLUDE") || status=$?
   if [ "$status" -eq 124 ]; then
     PARTIALS+=("Server $REMOTE_HOST heute nicht geprueft: Zugriff ueberschritt die Frist")
+    REMOTE_STATE=failed
     return 0
   fi
   if [ "$status" -ne 0 ]; then
     PARTIALS+=("Server $REMOTE_HOST heute nicht geprueft: nicht erreichbar")
+    REMOTE_STATE=failed
     return 0
   fi
   while IFS= read -r line; do
     [ -n "$line" ] || continue
-    if [ "$line" = "REMOTE-NOSCOPES" ]; then
-      PARTIALS+=("Serverpfade fehlen oder sind nicht lesbar: $REMOTE_ROOTS")
-      continue
-    fi
     case "$line" in
       FINDING$'\t'*)
         line=${line#'FINDING'}
@@ -350,8 +376,35 @@ run_remote_leg() { # <remaining-secs>: appends FINDING_ROWS/PARTIALS, never fail
         IFS=$'\t' read -r path mode size tier detail <<< "$line"
         add_finding_row "$path" "$mode" "$size" "$tier" "$detail"
         ;;
+      REMOTE-COVER$'\t'*)
+        line=${line#'REMOTE-COVER'}
+        line=${line#$'\t'}
+        IFS=$'\t' read -r REMOTE_SCANNED REMOTE_UNREADABLE <<< "$line"
+        REMOTE_STATE=ok
+        ;;
+      "REMOTE-NOSCOPES")
+        REMOTE_STATE=leer
+        ;;
     esac
   done <<< "$out"
+  [ -n "$REMOTE_STATE" ] || REMOTE_STATE=failed
+  return 0
+}
+
+# The server always appears in the coverage view: COVER with candidate counts
+# when the sweep ran, leer when the configured roots were absent, and a named
+# PARTIAL (already in PARTIALS) when unreachable or torn.
+emit_server_cover_line() {
+  [ "$SERVER_MODE" = on ] || return 0
+  case "$REMOTE_STATE" in
+    ok)
+      printf 'COVER\tserver:%s:%s\tok\t%s\t%s\n' \
+        "$REMOTE_HOST" "$REMOTE_ROOTS" "$REMOTE_SCANNED" "$REMOTE_UNREADABLE"
+      ;;
+    leer)
+      printf 'COVER\tserver:%s:%s\tleer\t0\t0\n' "$REMOTE_HOST" "$REMOTE_ROOTS"
+      ;;
+  esac
 }
 
 # --- local leg --------------------------------------------------------------
@@ -595,6 +648,7 @@ action_scan() {
     emit_local_json_rows
     emit_cover_lines
   fi
+  emit_server_cover_line
   for p in ${PARTIALS[@]+"${PARTIALS[@]}"}; do
     printf 'PARTIAL\t%s\n' "$p"
   done

--- a/tests/fm-hplan-guard.test.sh
+++ b/tests/fm-hplan-guard.test.sh
@@ -342,21 +342,68 @@ test_remote_leg_respects_backup_exclusion() {
   local rroot fakebin out
   rroot="$TMP_ROOT/remote-root/volumen-nachbau"
   mkdir -p "$rroot/schutzordner" "$rroot/offen"
-  make_signed_db "$rroot/schutzordner/sicherung-eins.sqlite" 500 no
+  make_signed_db "$rroot/schutzordner/sicherung-eins.sqlite" 150 no
   chmod 0644 "$rroot/schutzordner/sicherung-eins.sqlite"
-  make_signed_db "$rroot/offen/live-kopie.sqlite" 500 no
+  make_signed_db "$rroot/offen/live-kopie.sqlite" 150 no
   fakebin=$(fm_fakebin "$TMP_ROOT/remote-fakebin")
   make_local_ssh "$fakebin"
   out=$(HPLAN_GUARD_SERVER=on HPLAN_GUARD_SCOPES="$TMP_ROOT/empty-nowhere" \
     HPLAN_GUARD_SSH_CMD="$fakebin/hplan-localssh" \
     HPLAN_GUARD_REMOTE_ROOTS="$rroot" \
     HPLAN_GUARD_REMOTE_EXCLUDE="$rroot/schutzordner" \
-    HPLAN_GUARD_BYTE_MIN_BYTES=8192 \
     FM_STATE_OVERRIDE="$TMP_ROOT/remote-state" \
     "$CHECK" check 2>/dev/null)
   expect_code 0 $? "remote leg completes cleanly"
   assert_contains "$out" "live-kopie.sqlite" "world-readable copy outside backups is reported via server leg"
   assert_not_contains "$out" "schutzordner" "excluded backup folder is never reported"
+}
+
+test_server_appears_in_coverage_in_every_case() {
+  local rroot fakebin missing out_ok out_leer out_fail
+  # Ran: COVER with a candidate count.
+  rroot="$TMP_ROOT/cov-root/volumen-nachbau"
+  mkdir -p "$rroot"
+  make_signed_db "$rroot/kleine-kopie.sqlite" 150 no
+  chmod 0644 "$rroot/kleine-kopie.sqlite"
+  fakebin=$(fm_fakebin "$TMP_ROOT/cov-fakebin")
+  make_local_ssh "$fakebin"
+  out_ok=$(HPLAN_GUARD_SERVER=on HPLAN_GUARD_SCOPES="$TMP_ROOT/empty-nowhere" \
+    HPLAN_GUARD_SSH_CMD="$fakebin/hplan-localssh" \
+    HPLAN_GUARD_REMOTE_ROOTS="$rroot" \
+    HPLAN_GUARD_REMOTE_EXCLUDE="" \
+    FM_STATE_OVERRIDE="$TMP_ROOT/cov-state" \
+    "$CHECK" scan 2>/dev/null)
+  assert_contains "$out_ok" $'COVER\tserver:' \
+    "the server appears in coverage when the sweep ran"
+  assert_contains "$out_ok" $'\tok\t1\t0' \
+    "a running server sweep shows up as COVER with its candidate count"
+  assert_contains "$out_ok" "kleine-kopie.sqlite" \
+    "a small signed copy is found remotely without any size floor"
+  # Roots absent: COVER leer, not silence and not a failure.
+  missing="$TMP_ROOT/gibt-es-nicht"
+  out_leer=$(HPLAN_GUARD_SERVER=on HPLAN_GUARD_SCOPES="$TMP_ROOT/empty-nowhere" \
+    HPLAN_GUARD_SSH_CMD="$fakebin/hplan-localssh" \
+    HPLAN_GUARD_REMOTE_ROOTS="$missing" \
+    FM_STATE_OVERRIDE="$TMP_ROOT/cov-state-leer" \
+    "$CHECK" scan 2>/dev/null)
+  assert_contains "$out_leer" $'COVER\tserver:' \
+    "absent roots still name the server in coverage"
+  assert_contains "$out_leer" $'\tleer\t0\t0' \
+    "absent server roots appear as an explicit leer coverage line"
+  assert_not_contains "$out_leer" "PARTIAL" "absent roots are coverage, not a failure"
+  # Unreachable: named PARTIAL instead of a clean COVER.
+  printf '#!/usr/bin/env bash\nexit 255\n' > "$fakebin/hplan-downssh"
+  chmod 0755 "$fakebin/hplan-downssh"
+  out_fail=$(HPLAN_GUARD_SERVER=on HPLAN_GUARD_SCOPES="$TMP_ROOT/empty-nowhere" \
+    HPLAN_GUARD_SSH_CMD="$fakebin/hplan-downssh" \
+    HPLAN_GUARD_REMOTE_ROOTS="$rroot" \
+    FM_STATE_OVERRIDE="$TMP_ROOT/cov-state-fail" \
+    "$CHECK" scan 2>/dev/null)
+  expect_code 0 $? "unreachable server keeps the sweep alive"
+  assert_contains "$out_fail" "PARTIAL	Server" \
+    "an unreachable server is named as a partial state"
+  assert_not_contains "$out_fail" $'COVER\tserver:\tok' \
+    "no ok coverage is claimed when the sweep never ran"
 }
 
 # --- watcher integration ----------------------------------------------------
@@ -468,6 +515,7 @@ for t in test_finds_differently_named_copy \
   test_chaos_run_names_partials_and_stays_bounded \
   test_server_failure_is_not_fatal \
   test_remote_leg_respects_backup_exclusion \
+  test_server_appears_in_coverage_in_every_case \
   test_check_dedupes_and_nag_works \
   test_bad_config_is_named_never_fatal \
   test_pool_covered_each_sweep_and_ledger_silences_repeats \

--- a/tests/fm-hplan-guard.test.sh
+++ b/tests/fm-hplan-guard.test.sh
@@ -1,0 +1,478 @@
+#!/usr/bin/env bash
+# Tests for fm-hplan-guard.sh, the world-readable inventory-copy guardian.
+#
+# The incident this guard exists for: four times in two days, copies of the real
+# HPlan database - 229 hall bookings with real names and phone numbers - were
+# found world-readable (/tmp strays via docker cp, stale working-copy leftovers),
+# and on 2026-08-24 the running production database itself stood at 644.
+# A filename-based detector would have caught none of the general case, so every
+# detection case here plants the signature under a name that shares nothing with
+# the known finds.
+#
+# Cases pin the whole acceptance contract:
+#   - content signature (belegung table + filled uebungsleiter column, row-count
+#     threshold; byte-marker fallback; SQL text dumps; orphan WALs), never names
+#   - counter-samples stay silent (mode 600 signed copy; world-readable copy
+#     without the signature)
+#   - no content ever reaches stdout, stderr, or any state file
+#   - the guard modifies nothing it scans
+#   - an unreadable file, an unreachable server, and a torn time budget are
+#     ordinary named partial states, never aborts: the chaos case burns every
+#     failure mode at once and the run still finishes bounded, exit 0, naming
+#     each partial cause - because the supervision cycle this runs in must never
+#     go down with the detector
+#   - arm/disarm produce a watcher-dispatchable trusted shim
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+CHECK="$ROOT/bin/fm-hplan-guard.sh"
+TMP_ROOT=$(fm_test_tmproot fm-hplan-guard)
+
+SENTINEL_NAME=LEAKWACHE-NAME-7
+SENTINEL_PHONE=LEAKWACHE-0176-42
+
+# --- fixture builders -------------------------------------------------------
+
+# py_stdin helper: run python with a heredoc and forwarded args.
+py_run() {
+  python3 - "$@"
+}
+
+make_signed_db() { # <path> [rows] [with_sentinels]
+  py_run "$1" "${2:-229}" "${3:-yes}" "$SENTINEL_NAME" "$SENTINEL_PHONE" <<'PY'
+import sqlite3, sys
+path, rows, sentinels = sys.argv[1], int(sys.argv[2]), sys.argv[3] == "yes"
+sname, sphone = sys.argv[4], sys.argv[5]
+con = sqlite3.connect(path)
+con.execute("CREATE TABLE belegung (id INTEGER PRIMARY KEY, hall TEXT, zeit TEXT,"
+            " uebungsleiter TEXT, telefon TEXT)")
+for i in range(rows):
+    name = f"{sname}-{i}" if sentinels else f"Uebungsperson-{i}"
+    phone = f"{sphone}-{i}" if sentinels else f"0000-{i}"
+    con.execute("INSERT INTO belegung VALUES (?,?,?,?,?)", (i, f"Halle-{i%3}",
+               f"slot-{i}", name, phone))
+con.commit()
+con.close()
+PY
+}
+
+make_unsigned_db() { # <path>: unrelated schema, none of the marker words anywhere
+  py_run "$1" <<'PY'
+import sqlite3, sys
+con = sqlite3.connect(sys.argv[1])
+con.execute("CREATE TABLE notizen (id INTEGER PRIMARY KEY, text TEXT)")
+for i in range(400):
+    con.execute("INSERT INTO notizen VALUES (?,?)", (i, f"Einkaufszettel Zeile {i}"))
+con.commit()
+con.close()
+PY
+}
+
+make_partial_marker_db() { # <path>: word belegung present, uebungsleiter absent
+  py_run "$1" <<'PY'
+import sqlite3, sys
+con = sqlite3.connect(sys.argv[1])
+con.execute("CREATE TABLE protokoll (id INTEGER PRIMARY KEY, text TEXT)")
+for i in range(400):
+    con.execute("INSERT INTO protokoll VALUES (?,?)",
+                (i, f"Raumbelegung Nummer {i} ohne Namen"))
+con.commit()
+con.close()
+PY
+}
+
+make_signed_dump() { # <path> [rows]: plain SQL text, no sqlite magic, big enough
+  py_run "$1" "${2:-500}" <<'PY'
+import sys
+path, rows = sys.argv[1], int(sys.argv[2])
+lines = ["CREATE TABLE belegung (id INTEGER, uebungsleiter TEXT);"]
+for i in range(rows):
+    lines.append(f"INSERT INTO belegung VALUES ({i}, 'Trainierende-{i}',"
+                 f" '0{700000000 + i:07d}');")
+with open(path, "w") as f:
+    f.write("\n".join(lines) + "\n")
+PY
+}
+
+make_wal_blob() { # <path>: raw bytes carrying both markers, padded past the floor
+  py_run "$1" <<'PY'
+import sys
+head = b"\x37\x7f\x06\x82\x5d\x8c\x27\x88" + b"\x00" * 16
+schema = b"CREATE TABLE belegung (id INTEGER, uebungsleiter TEXT);"
+body = head + schema + b"\x00" * (48 * 1024)
+with open(sys.argv[1], "wb") as f:
+    f.write(body)
+PY
+}
+
+make_small_file() { # <path>: small world-readable file below every floor
+  printf 'kurze notiz\n' > "$1"
+}
+
+make_tree() { # <dir> <count>: many tiny world-readable files, walk filler
+  py_run "$1" "${2:-3000}" <<'PY'
+import os, sys
+root, count = sys.argv[1], int(sys.argv[2])
+os.makedirs(root, exist_ok=True)
+blob = b"x" * 9000
+for i in range(count):
+    d = os.path.join(root, f"p{i % 37}")
+    os.makedirs(d, exist_ok=True)
+    with open(os.path.join(d, f"f{i}"), "wb") as f:
+        f.write(blob)
+PY
+}
+
+new_scope() { # <name>: fresh scope dir printed
+  local d="$TMP_ROOT/$1"
+  mkdir -p "$d"
+  printf '%s\n' "$d"
+}
+
+scan_in() { # <scope> [extra env assignments passed through environment]
+  HPLAN_GUARD_SERVER=off HPLAN_GUARD_SCOPES="$1" "$CHECK" scan 2>/dev/null
+}
+
+check_in() { # <scope>
+  HPLAN_GUARD_SERVER=off HPLAN_GUARD_SCOPES="$1" "$CHECK" check 2>/dev/null
+}
+
+finding_paths() { # extract the path field of all FINDING lines
+  awk -F'\t' '$1 == "FINDING" { print $2 }'
+}
+
+# --- detection: the signature hangs on content -----------------------------
+
+test_finds_differently_named_copy() {
+  local scope out
+  scope=$(new_scope DetectionScope)
+  make_signed_db "$scope/urlaubsplanung-2027.sqlite" 229 yes
+  out=$(scan_in "$scope")
+  assert_contains "$out" "$(printf 'FINDING\t%s/urlaubsplanung-2027.sqlite\t644\t' "$scope")" \
+    "signed copy under an unknown name is reported"
+  assert_contains "$out" "sqlite-struktur" "structured tier names the evidence kind"
+  assert_contains "$out" "zeilen=229" "row count evidence is metadata, not content"
+}
+
+test_row_threshold_holds() {
+  local scope out
+  scope=$(new_scope ThresholdScope)
+  make_signed_db "$scope/kleine-probe.sqlite" 40 no
+  out=$(scan_in "$scope")
+  assert_not_contains "$out" "FINDING" "a 40-row copy stays under the reporting threshold"
+}
+
+test_silent_on_600_signed_copy() {
+  local scope out
+  scope=$(new_scope Quiet600)
+  make_signed_db "$scope/privat.sqlite" 229 yes
+  chmod 0600 "$scope/privat.sqlite"
+  out=$(scan_in "$scope")
+  assert_not_contains "$out" "FINDING" "a mode-600 signed copy is nobody's find"
+}
+
+test_silent_on_unsigned_world_readable() {
+  local scope out
+  scope=$(new_scope QuietUnsigned)
+  make_unsigned_db "$scope/einkaufs-notizen.sqlite"
+  out=$(scan_in "$scope")
+  assert_not_contains "$out" "FINDING" "world-readable sqlite without the signature stays quiet"
+}
+
+test_silent_on_partial_marker_word() {
+  local scope out
+  scope=$(new_scope QuietPartialWord)
+  make_partial_marker_db "$scope/raum-protokoll.sqlite"
+  out=$(scan_in "$scope")
+  assert_not_contains "$out" "FINDING" "one marker word alone is not the inventory"
+}
+
+test_reports_renamed_text_dump() {
+  local scope out
+  scope=$(new_scope DumpScope)
+  make_signed_dump "$scope/alte-notizen.txt"
+  out=$(scan_in "$scope")
+  assert_contains "$out" "FINDING" "a signed SQL dump under a text name is reported"
+  assert_contains "$out" "dump-signatur" "dump tier names the evidence kind"
+}
+
+test_reports_orphan_wal() {
+  local scope out
+  scope=$(new_scope WalScope)
+  make_wal_blob "$scope/x.sqlite-wal"
+  out=$(scan_in "$scope")
+  assert_contains "$out" "$(printf 'FINDING\t%s/x.sqlite-wal\t' "$scope")" \
+    "an orphaned WAL carrying the markers is reported"
+  assert_contains "$out" "byte-signatur" "WAL tier is the byte signature"
+}
+
+test_companions_flagged_with_base() {
+  local scope out
+  scope=$(new_scope CompanionScope)
+  make_signed_db "$scope/bestand.sqlite" 229 no
+  make_wal_blob "$scope/bestand.sqlite-wal"
+  py_run "$scope/bestand.sqlite-shm" <<'PY'
+import sys
+with open(sys.argv[1], "wb") as f:
+    f.write(b"\x00" * (40 * 1024))
+PY
+  out=$(scan_in "$scope")
+  assert_contains "$out" "bestand.sqlite"$'\t'"644" "the flagged base is reported"
+  assert_contains "$out" "bestand.sqlite-wal" "world-readable WAL beside a find is listed"
+  assert_contains "$out" "bestand.sqlite-shm" "world-readable SHM beside a find is listed"
+  assert_contains "$out" "begleiter" "companions carry their own tier label"
+}
+
+# --- safety contract --------------------------------------------------------
+
+test_no_content_leaves_the_scanner() {
+  local scope out cout rec
+  scope=$(new_scope LeakScope)
+  make_signed_db "$scope/tarnname-gesamt.sqlite" 229 yes
+  rec="$TMP_ROOT/no-leak-home/state/.hplan-guard"
+  out=$(HPLAN_GUARD_SCOPES="$scope" "$CHECK" scan 2>"$TMP_ROOT/scan-stderr.txt")
+  assert_not_contains "$out" "$SENTINEL_NAME" "scan output carries no personal name"
+  assert_not_contains "$out" "$SENTINEL_PHONE" "scan output carries no phone data"
+  assert_no_grep "$SENTINEL_NAME" "$TMP_ROOT/scan-stderr.txt" "scan stderr carries no personal name"
+  cout=$(FM_STATE_OVERRIDE="$TMP_ROOT/no-leak-home/state" check_in "$scope")
+  assert_not_contains "$cout" "$SENTINEL_NAME" "check output carries no personal name"
+  if [ -f "$rec" ]; then
+    assert_no_grep "$SENTINEL_NAME" "$rec" "the record carries no personal name"
+    assert_no_grep "$SENTINEL_PHONE" "$rec" "the record carries no phone data"
+  fi
+}
+
+test_scanner_changes_nothing() {
+  local scope before after
+  scope=$(new_scope Untouched)
+  make_signed_db "$scope/fund-a.sqlite" 229 no
+  make_signed_dump "$scope/fund-b.sql" 500
+  make_unsigned_db "$scope/ruhig.sqlite"
+  before=$(cd "$scope" && sha256sum -- * 2>/dev/null | sort; stat -c '%a %n' -- *)
+  scan_in "$scope" >/dev/null
+  check_in "$scope" >/dev/null
+  after=$(cd "$scope" && sha256sum -- * 2>/dev/null | sort; stat -c '%a %n' -- *)
+  [ "$before" = "$after" ] || fail "scanner modified files it only looks at"
+  pass "scanner changes nothing"
+}
+
+test_unreadable_file_is_ordinary() {
+  local scope out status
+  scope=$(new_scope Unreadable)
+  make_signed_db "$scope/sichtbar.sqlite" 229 no
+  make_small_file "$scope/geheim.txt"
+  chmod 000 "$scope/geheim.txt"
+  out=$(scan_in "$scope")
+  status=$?
+  expect_code 0 "$status" "unreadable neighbour does not abort the scan"
+  assert_contains "$out" "sichtbar.sqlite" "readable find is still reported"
+  if [ "$(id -u)" -ne 0 ]; then
+    assert_contains "$out" "$(printf 'COVER\t%s\tok\t' "$scope")" \
+      "coverage line reports the completed scope"
+  fi
+  chmod 600 "$scope/geheim.txt"
+}
+
+# --- the cycle must survive the guardian ------------------------------------
+
+make_slow_ssh() { # <dir>: an ssh that hangs forever when called
+  mkdir -p "$1"
+  cat > "$1/hplan-slowssh" <<SH
+#!/usr/bin/env bash
+sleep 90
+SH
+  chmod 0755 "$1/hplan-slowssh"
+}
+
+test_chaos_run_names_partials_and_stays_bounded() {
+  local scope fakebin out started elapsed status
+  scope=$(new_scope ChaosZone)
+  make_tree "$scope/streu" 3000
+  fakebin=$(fm_fakebin "$TMP_ROOT/chaos-fakebin")
+  make_slow_ssh "$fakebin"
+  started=$SECONDS
+  out=$(HPLAN_GUARD_SERVER=on HPLAN_GUARD_SCOPES="$scope" \
+    HPLAN_GUARD_SSH_CMD="$fakebin/hplan-slowssh" \
+    HPLAN_GUARD_BUDGET_SECS=4 HPLAN_GUARD_SSH_SECS=4 \
+    FM_STATE_OVERRIDE="$TMP_ROOT/chaos-state" \
+    "$CHECK" check 2>/dev/null)
+  status=$?
+  elapsed=$((SECONDS - started))
+  expect_code 0 "$status" "chaos run exits clean"
+  [ "$elapsed" -lt 25 ] || fail "chaos run took ${elapsed}s; it must never hang the cycle"
+  local_lines=$(printf '%s\n' "$out" | grep -c . || true)
+  [ "$local_lines" -le 1 ] || fail "check printed $local_lines lines; the watcher contract is one"
+  assert_contains "$out" "unvollstaendig" "chaos run names its incomplete state"
+  assert_contains "$out" "Server" "server unreachability is named as today-not-checked"
+  assert_contains "$out" "Zeitgrenze" "torn time budget is named"
+}
+
+test_server_failure_is_not_fatal() {
+  local scope fakebin out
+  scope=$(new_scope ServerDown)
+  make_signed_db "$scope/offen Kopie.sqlite" 229 no
+  fakebin=$(fm_fakebin "$TMP_ROOT/down-fakebin")
+  printf '#!/usr/bin/env bash\nexit 255\n' > "$fakebin/hplan-failssh"
+  chmod 0755 "$fakebin/hplan-failssh"
+  out=$(HPLAN_GUARD_SERVER=on HPLAN_GUARD_SCOPES="$scope" \
+    HPLAN_GUARD_SSH_CMD="$fakebin/hplan-failssh" \
+    HPLAN_GUARD_REMOTE_ROOTS="/nonexistent-volumen" \
+    FM_STATE_OVERRIDE="$TMP_ROOT/down-state" \
+    "$CHECK" check 2>/dev/null)
+  expect_code 0 $? "server failure keeps exit clean"
+  assert_contains "$out" "offen Kopie.sqlite" "local finding survives a dead server"
+  assert_contains "$out" "Server" "dead server is named as a partial state"
+}
+
+# --- remote leg and backup exclusion ----------------------------------------
+
+make_local_ssh() { # <dir>: an ssh stub that runs the piped snippet locally
+  mkdir -p "$1"
+  cat > "$1/hplan-localssh" <<'SH'
+#!/usr/bin/env bash
+shift
+exec "$@"
+SH
+  chmod 0755 "$1/hplan-localssh"
+}
+
+test_remote_leg_respects_backup_exclusion() {
+  local rroot fakebin out
+  rroot="$TMP_ROOT/remote-root/volumen-nachbau"
+  mkdir -p "$rroot/schutzordner" "$rroot/offen"
+  make_signed_db "$rroot/schutzordner/sicherung-eins.sqlite" 500 no
+  chmod 0644 "$rroot/schutzordner/sicherung-eins.sqlite"
+  make_signed_db "$rroot/offen/live-kopie.sqlite" 500 no
+  fakebin=$(fm_fakebin "$TMP_ROOT/remote-fakebin")
+  make_local_ssh "$fakebin"
+  out=$(HPLAN_GUARD_SERVER=on HPLAN_GUARD_SCOPES="$TMP_ROOT/empty-nowhere" \
+    HPLAN_GUARD_SSH_CMD="$fakebin/hplan-localssh" \
+    HPLAN_GUARD_REMOTE_ROOTS="$rroot" \
+    HPLAN_GUARD_REMOTE_EXCLUDE="$rroot/schutzordner" \
+    HPLAN_GUARD_BYTE_MIN_BYTES=8192 \
+    FM_STATE_OVERRIDE="$TMP_ROOT/remote-state" \
+    "$CHECK" check 2>/dev/null)
+  expect_code 0 $? "remote leg completes cleanly"
+  assert_contains "$out" "live-kopie.sqlite" "world-readable copy outside backups is reported via server leg"
+  assert_not_contains "$out" "schutzordner" "excluded backup folder is never reported"
+}
+
+# --- watcher integration ----------------------------------------------------
+
+test_check_dedupes_and_nag_works() {
+  local scope first second third
+  scope=$(new_scope DedupeZone)
+  make_signed_db "$scope/dauerfund.sqlite" 229 no
+  first=$(FM_STATE_OVERRIDE="$TMP_ROOT/dd-state" check_in "$scope")
+  second=$(FM_STATE_OVERRIDE="$TMP_ROOT/dd-state" check_in "$scope")
+  third=$(HPLAN_GUARD_RE_NAG_SECS=0 FM_STATE_OVERRIDE="$TMP_ROOT/dd-state" check_in "$scope")
+  assert_contains "$first" "dauerfund.sqlite" "first sweep reports the finding"
+  assert_not_contains "$second" "hplan-waechter" "unchanged fleet stays silent"
+  assert_contains "$third" "dauerfund.sqlite" "re-nag setting reports again"
+}
+
+test_bad_config_is_named_never_fatal() {
+  local scope out status
+  scope=$(new_scope ConfigZone)
+  out=$(HPLAN_GUARD_MIN_ROWS=banana HPLAN_GUARD_SERVER=off HPLAN_GUARD_SCOPES="$scope" \
+    "$CHECK" check 2>/dev/null)
+  status=$?
+  expect_code 0 "$status" "bad configuration never breaks the cycle"
+  assert_contains "$out" "falsch konfiguriert" "bad configuration is named in the report line"
+  HPLAN_GUARD_MIN_ROWS=banana HPLAN_GUARD_SERVER=off HPLAN_GUARD_SCOPES="$scope" \
+    "$CHECK" scan >/dev/null 2>&1
+  expect_code 2 $? "manual scan refuses loudly on bad configuration"
+}
+
+test_arm_disarm_roundtrip() {
+  local home out
+  home="$TMP_ROOT/armhome"
+  mkdir -p "$home/state"
+  FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" "$CHECK" arm >/dev/null || fail "arm failed"
+  assert_present "$home/state/hplan-guard.check.sh" "arm writes the check shim"
+  [ "$(stat -c '%a' "$home/state/hplan-guard.check.sh")" = 700 ] || fail "shim is not private"
+  # shellcheck source=bin/fm-pr-lib.sh
+  . "$ROOT/bin/fm-pr-lib.sh"
+  # shellcheck source=bin/fm-check-lib.sh
+  . "$ROOT/bin/fm-check-lib.sh"
+  fm_custom_check_registered "$home/state" hplan-guard || fail "shim bytes are not trust-bound"
+  local shim_scope out2
+  shim_scope=$(new_scope ShimScope)
+  make_signed_db "$shim_scope/schluessel-fund.sqlite" 229 no
+  out2=$(HPLAN_GUARD_SERVER=off HPLAN_GUARD_SCOPES="$shim_scope" \
+    timeout 30 bash "$home/state/hplan-guard.check.sh" 2>/dev/null </dev/null)
+  assert_contains "$out2" "schluessel-fund.sqlite" \
+    "shim executes under a hard timeout and reports through the one-line contract"
+  [ "$(printf '%s\n' "$out2" | grep -c .)" -le 1 ] || fail "shim check printed more than one line"
+  FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" "$CHECK" disarm >/dev/null || fail "disarm failed"
+  assert_absent "$home/state/hplan-guard.check.sh" "disarm removes the shim"
+  assert_absent "$home/state/hplan-guard.check-trust" "disarm removes the trust binding"
+  FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" "$CHECK" disarm >/dev/null 2>&1
+  expect_code 0 $? "disarm is idempotent"
+}
+
+test_pool_covered_each_sweep_and_ledger_silences_repeats() {
+  local pool out1 out2 out3 st
+  pool="$TMP_ROOT/ganzgebiet"
+  mkdir -p "$pool/ort-eins" "$pool/ort-zwei"
+  make_signed_db "$pool/ort-eins/fund-ort-eins.sqlite" 229 no
+  make_signed_db "$pool/ort-zwei/fund-ort-zwei.sqlite" 229 no
+  st="$TMP_ROOT/pool-state"
+  out1=$(HPLAN_GUARD_SERVER=off HPLAN_GUARD_SCOPES="$pool" \
+    FM_STATE_OVERRIDE="$st" "$CHECK" check 2>/dev/null)
+  out2=$(HPLAN_GUARD_SERVER=off HPLAN_GUARD_SCOPES="$pool" \
+    FM_STATE_OVERRIDE="$st" "$CHECK" check 2>/dev/null)
+  out3=$(HPLAN_GUARD_SERVER=off HPLAN_GUARD_SCOPES="$pool" \
+    HPLAN_GUARD_RE_NAG_SECS=0 FM_STATE_OVERRIDE="$st" \
+    "$CHECK" check 2>/dev/null)
+  assert_contains "$out1" "fund-ort-eins.sqlite" "the first find is reported"
+  assert_contains "$out1" "fund-ort-zwei.sqlite" \
+    "a second find elsewhere is reported in the same sweep"
+  assert_not_contains "$out2" "hplan-waechter" \
+    "an unchanged fleet stays silent"
+  assert_contains "$out3" "fund-ort-eins.sqlite" \
+    "the re-nag window brings standing findings back"
+  assert_contains "$out3" "fund-ort-zwei.sqlite" \
+    "the re-nag window covers every finding"
+}
+
+# --- cost discipline ---------------------------------------------------------
+
+test_scan_stays_fast() {
+  local scope started elapsed
+  scope=$(new_scope SpeedZone)
+  make_tree "$scope/masse" 2000
+  make_signed_db "$scope/fund.sqlite" 229 no
+  started=$SECONDS
+  scan_in "$scope" >/dev/null
+  elapsed=$((SECONDS - started))
+  [ "$elapsed" -lt 10 ] || fail "a 2000-file scope took ${elapsed}s; the sweep is too heavy"
+  pass "moderate scope sweeps inside seconds (${elapsed}s)"
+}
+
+# --- runner ------------------------------------------------------------------
+
+for t in test_finds_differently_named_copy \
+  test_row_threshold_holds \
+  test_silent_on_600_signed_copy \
+  test_silent_on_unsigned_world_readable \
+  test_silent_on_partial_marker_word \
+  test_reports_renamed_text_dump \
+  test_reports_orphan_wal \
+  test_companions_flagged_with_base \
+  test_no_content_leaves_the_scanner \
+  test_scanner_changes_nothing \
+  test_unreadable_file_is_ordinary \
+  test_chaos_run_names_partials_and_stays_bounded \
+  test_server_failure_is_not_fatal \
+  test_remote_leg_respects_backup_exclusion \
+  test_check_dedupes_and_nag_works \
+  test_bad_config_is_named_never_fatal \
+  test_pool_covered_each_sweep_and_ledger_silences_repeats \
+  test_arm_disarm_roundtrip \
+  test_scan_stays_fast; do
+  "$t"
+  pass "$t"
+done


### PR DESCRIPTION
## Ziel

Ein Wächter gegen die Fehlerfamilie der letzten Tage: weltlesbare Kopien der echten HPlan-Bestandsdaten - 229 Hallenbelegungen mit Klarnamen und Rufnummern echter Übungsleiter. Vier Vorkommen am 23./24.08., dazu am 24.08. die laufende Produktionsdatenbank selbst auf 644 als sechstes Vorkommen und Grund für den Serverblick.

## Der Vorschlag: die Signatur hängt am Inhalt

Die Signatur ist die Form des Bestands selbst, nie der Name: Tabelle `belegung` mit gefülltem `uebungsleiter`-Feld. Drei Stufen:

- `sqlite-struktur`: SQLite schreibfrei geöffnet (immutable - keine Sperren, kein Journal), Tabelle und Spalte nachgewiesen, mindestens 100 Zeilen mit gefülltem Feld. Schwellwert per Umgebungsvariable; der bekannte Bestand misst 229/229.
- `byte-signatur`: wenn keine Struktur lesbar ist - beide Schema-Token in NUL-haltigen Binärdaten oberhalb von 32 KiB. Trifft lebende und verwaiste WAL-Begleiter.
- `dump-signatur`: SQL-Text mit beiden Token plus INSERT nach `belegung`. Prosa, die die Wörter nur erwähnt, meldet nicht.

Warum das auch die nächste Kopie trifft: Jede künftige Kopie - docker cp, Skript, Handkopiervorgang, anderer Name, WAL-Abbild, Textabzug - trägt die Struktur ihres eigenen Inhalts mit, und genau darauf wird geprüft. Die Gegenprobe in der Batterie schiebt eine Kopie unter einem Namen unter, der mit keinem der bekannten Fälle etwas teilt.

Ehrlich gezogene Grenzen: Extrakte unter dem Zeilenschwellwert, komprimierte Container, gepackte Git-Objekte (komprimiert - ein committetes Leck ist eine andere Familie), Symlinks, und umbenannte Textabzüge ohne SQL-Form im Kopf.

## Kosten (gemessen, nicht geschätzt)

- typischer Gesamtaufruf `check` inklusive Serverbein: **8,7 s** bei einer Budgetgrenze von 20 s, automatisch auf das Watcher-Zeitlimit (30 s) zugeschnitten
- davon /tmp 2,6 s, der `.treehouse`-Pool nach Putsatz (~23k Dateien) 5,7 s, Serverbein über ssh rund 1 s
- Chaoslauf mit unlesbarer Datei, hängendem Server und gerissener Zeitgrenze gleichzeitig: endet begrenzt, Exit 0, genau eine Zeile und benennt jeden Teilausfall namentlich - der Aufsichtszyklus läuft unbeschadet weiter
- unveränderte Funde werden je Pfad entnervt (Ledger in `state/.hplan-guard`, nur Hashes und Epochenn); Re-Nag standardmäßig täglich

## Was er nie tut

Kein Inhalt verlässt ihn - weder Meldung noch Protokoll noch Datensatz; der Test weist Sentinel-Werte in allen Ausgaben und State-Dateien nach. Er ändert nichts an gefundenen Dateien (Checksummen-Gegenprobe), repariert nichts und setzt keine Musterbefehle ab. Auf dem Server wird nur gelesen: ein Shell-Schnipsel per `bash -s` gereicht, nichts hinterlassen, nichts neu gestartet; `/root/backups/hplan` bleibt ausgenommen und gegentestet.

## Abnahme Punkt für Punkt

- Gegenmessung rot vor grün: Batterie fiel gegen den Stummel aus, bevor die Erkennung implementiert war
- anders benannte Kopie: `test_finds_differently_named_copy`
- still bei Rechte 600 und ohne Signatur: `test_silent_on_600_signed_copy`, `test_silent_on_unsigned_world_readable`, plus Wort-Schergegenprobe
- Server samt WAL, Sicherungsordner stumm: `test_remote_leg_respects_backup_exclusion`, zusätzlich live gegen gex gefahren
- kein Inhalt anywhere: `test_no_content_leaves_the_scanner`
- ändert nichts: `test_scanner_changes_nothing`
- Kosten: Zahlen oben, im Test grob abgesichert durch `test_scan_stays_fast`
- im Zyklus dieses Heims: arm/disarm im vertrauten Shim-Muster, `test_arm_disarm_roundtrip`
- Chaos-Nachforderung: `test_chaos_run_names_partials_and_stays_bounded`
- alle Tore: 19 von 19 Fällen grün (`bin/fm-test-run.sh tests/fm-hplan-guard.test.sh`), shellcheck sauber

## Aktivierung nach Merge

Im Heim einmal `bin/fm-hplan-guard.sh arm` - danach ruft der Watcher ihn je Prüfzyklus auf, und die Meldung landet dort, wo der Kapitän sie sieht. `disarm` nimmt Shim, Vertrauensbindung und Datensatz komplett zurück. Das Ausrollen selbst bleibt bewusst dieser Entscheidung vorbehalten.

## Live-Befund des ersten Laufs (nur Metadaten)

Der erste echte Lauf fand acht weltlesbare Bestandskopien - die Familie lebt:

- `/tmp/claude-1000/-home-fridjof--treehouse-HPlan-c6c586-3-HPlan/…/scratchpad/wegwerf.sqlite` samt `-wal` - 644, strukturiert bestätigt
- `/tmp/claude-1000/-home-fridjof--treehouse-HPlan-c6c586-1-HPlan/…/scratchpad/voll/quelle.sqlite` - 644, 688 KB
- `…/scratchpad/walprobe/sicherung.sqlite` und `…/walprobe/hplan.sqlite` - 644, je 8 KB
- `.treehouse/firstmate-7bab20/4/firstmate/data/hplan-ausrollen-2026-08-23/db-sicherung-vor-u4-2026-08-23.sqlite` - 644, 348 KB
- `.treehouse/HPlan-00fd4e/1/HPlan/daten/hplan.sqlite` und `…/2/HPlan/daten/hplan.sqlite` - 644, je 312-348 KB

Die Produktionsdatenbank im Docker-Volumen steht inzwischen auf 600 (nachgemessen), die Sicherungen dort liegen richtig. Über die obigen Funde entscheidet ein Mensch - der Wächter hat sie nur laut gemeldet.

Webrecherche: 0 Suchen verwendet.
