### PR TITLE
fix(bin): bound remote job worker supervisor restarts

### DIFF
--- a/bin/fm-remote-job-lib.sh
+++ b/bin/fm-remote-job-lib.sh
@@ -47,16 +47,7 @@
 # just killed. fm_remote_job_stop_worker_tree owns that stop and refuses to
 # signal a group whose leader is not itself a worker, so a worker inherited
 # from an older build or from launchd's own session is still stopped safely as
-# a single process. Because a Linux supervisor is a per-account singleton that
-# refuses to run beside an incumbent, the start path first waits out whatever
-# supervisor already owns the account: one launched from the same code root is
-# left to finish coming up and reported as already serving, one that cannot
-# serve the requested root is released before a replacement is launched, and a
-# supervisor that neither serves nor releases within that bound is reported as
-# a failure to start rather than replaced. fm_remote_job_start_linux_worker
-# reports which of those outcomes it reached in FM_REMOTE_JOB_WORKER_START, so
-# a refusal can never be mistaken for a start.
-# fm_remote_job_root_is_live is the shared predicate for
+# a single process. fm_remote_job_root_is_live is the shared predicate for
 # whether a worker's code root still exists; bin/fm-remote-job-worker.sh uses
 # it to stop itself once its root is pruned, and
 # bin/fm-remote-job-reap-orphans.sh uses it to reap workers that were already
@@ -81,9 +72,6 @@ FM_REMOTE_JOB_STDERR=
 FM_REMOTE_JOB_EXIT=
 FM_REMOTE_JOB_ERROR=
 FM_REMOTE_JOB_REPAIRED=0
-# serving (an already-running worker was kept), started (a supervisor was
-# launched), or empty when the start failed.
-FM_REMOTE_JOB_WORKER_START=
 
 fm_remote_job_die() {
   printf 'error: %s\n' "$1" >&2
@@ -709,7 +697,6 @@ fm_remote_job_worker_pid_path() { printf '%s\n' "$FM_REMOTE_JOB_STATE/worker.pid
 fm_remote_job_worker_ready_path() { printf '%s\n' "$FM_REMOTE_JOB_STATE/worker.ready"; }
 fm_remote_job_worker_identity_path() { printf '%s\n' "$FM_REMOTE_JOB_STATE/worker.identity"; }
 fm_remote_job_worker_lock_path() { printf '%s\n' "$FM_REMOTE_JOB_STATE/worker.lock"; }
-fm_remote_job_supervisor_lock_path() { printf '%s\n' "$FM_REMOTE_JOB_STATE/supervisor.lock"; }
 
 fm_remote_job_process_start() {
   local pid=$1 ps_bin value
@@ -811,10 +798,10 @@ fm_remote_job_read_single_line() {
   printf '%s\n' "$value"
 }
 
-fm_remote_job_lock_owner_matches_process() { # <account-home> [lock-directory]
-  local account_home=$1 lock=${2:-} pid recorded_start actual_start recorded_command actual_command
+fm_remote_job_lock_owner_matches_process() {
+  local account_home=$1 lock pid recorded_start actual_start recorded_command actual_command
   fm_remote_job_prepare_state "$account_home" || return 1
-  [ -n "$lock" ] || lock=$(fm_remote_job_worker_lock_path)
+  lock=$(fm_remote_job_worker_lock_path)
   [ -d "$lock" ] && [ ! -L "$lock" ] || return 1
   pid=$(fm_remote_job_read_single_line "$lock/pid" 64) || return 1
   case "$pid" in ''|*[!0-9]*) return 1 ;; esac
@@ -851,72 +838,6 @@ fm_remote_job_worker_owned_alive() {
   if [ -x /bin/ps ]; then ps_bin=/bin/ps; elif [ -x /usr/bin/ps ]; then ps_bin=/usr/bin/ps; else return 1; fi
   command=$("$ps_bin" -p "$pid" -o command= 2>/dev/null) || return 1
   case "$command" in *"$root/bin/fm-remote-job-worker.sh"*) FM_REMOTE_JOB_OWNER_PID=$pid; return 0 ;; esac
-  return 1
-}
-
-# The Linux supervisor that still owns this account, echoed only when the same
-# pid, start time, and command identity the supervisor published under its own
-# lock still name a live process. A released, crashed, or symlink-substituted
-# lock echoes nothing: reclaiming those belongs to the acquiring supervisor,
-# which already owns the staleness and quarantine policy.
-fm_remote_job_supervisor_owner() { # <account-home>
-  local account_home=$1
-  fm_remote_job_prepare_state "$account_home" || return 1
-  fm_remote_job_lock_owner_matches_process "$account_home" "$(fm_remote_job_supervisor_lock_path)" || return 1
-  printf '%s\n' "$FM_REMOTE_JOB_OWNER_PID"
-}
-
-# The code root an owning supervisor was launched from, proven the same way a
-# serving worker is attributed to its root: the supervisor is exec'd as
-# <root>/bin/fm-remote-job-worker.sh, so its own command names the root it can
-# ever serve. A command that cannot be read, or that names another root, is not
-# proof of this root.
-fm_remote_job_supervisor_serves_root() { # <remote-root> <pid>
-  local root=$1 pid=$2 command
-  command=$(fm_remote_job_process_command "$pid") || return 1
-  case "$command" in *"$root/bin/fm-remote-job-worker.sh"*) return 0 ;; esac
-  return 1
-}
-
-# Whether a start may spawn beside the supervisor that currently owns this
-# account, waiting out the states that are still resolving themselves. Returns
-# 0 once no supervisor is provably live, so the spawn proceeds under the
-# acquiring supervisor's own staleness and quarantine policy; 2 once an
-# incumbent launched from this same code root has published a ready worker with
-# matching identity, which is a healthy supervisor that must not be replaced; 3
-# for an incumbent that cannot serve this root, which the caller releases; and
-# 1 when a same-root incumbent neither serves nor releases within the bound.
-fm_remote_job_await_supervisor() { # <remote-root> <account-home>
-  local root=$1 account_home=$2 pid waited=0
-  while [ "$waited" -lt 200 ]; do
-    pid=$(fm_remote_job_supervisor_owner "$account_home") || return 0
-    fm_remote_job_supervisor_serves_root "$root" "$pid" || return 3
-    fm_remote_job_probe "$account_home" &&
-      fm_remote_job_worker_identity_matches "$root" "$account_home" && return 2
-    waited=$((waited + 1))
-    sleep 0.1
-  done
-  return 1
-}
-
-# A live supervisor refuses its replacement as a duplicate, so a replacement
-# may only be launched once no supervisor is provably still serving. Stop the
-# incumbent's tree once, then wait out its shutdown - a supervisor that is
-# already exiting still owns the lock until it releases it. Returns non-zero
-# only while ownership stays provably live, which the caller reports as a
-# failure to start rather than a repair.
-fm_remote_job_release_supervisor() { # <account-home>
-  local account_home=$1 pid stopped=0 waited=0
-  while [ "$waited" -lt 100 ]; do
-    pid=$(fm_remote_job_supervisor_owner "$account_home") || return 0
-    if [ "$stopped" -eq 0 ]; then
-      stopped=1
-      fm_remote_job_stop_worker_tree "$pid" || true
-      continue
-    fi
-    waited=$((waited + 1))
-    sleep 0.1
-  done
   return 1
 }
 
@@ -1023,7 +944,6 @@ fm_remote_job_reload_launchagent() { # <account-home> <uid>
 
 fm_remote_job_start_linux_worker() { # <remote-root> <account-home>
   local root=$1 account_home=$2 worker pid
-  FM_REMOTE_JOB_WORKER_START=
   worker="$root/bin/fm-remote-job-worker.sh"
   [ -f "$worker" ] && [ ! -L "$worker" ] && [ -x "$worker" ] || {
     FM_REMOTE_JOB_ERROR="remote job worker is not a genuine executable in the configured code root"
@@ -1031,10 +951,7 @@ fm_remote_job_start_linux_worker() { # <remote-root> <account-home>
   }
   fm_remote_job_prepare_state "$account_home" || return 1
   if fm_remote_job_worker_owned_alive "$root" "$account_home"; then
-    if fm_remote_job_worker_identity_matches "$root" "$account_home"; then
-      FM_REMOTE_JOB_WORKER_START=serving
-      return 0
-    fi
+    if fm_remote_job_worker_identity_matches "$root" "$account_home"; then return 0; fi
     # The owner pid is the serving child; its restart supervisor sits above it
     # and would immediately replace a lone process kill, so stop the whole
     # worker tree through its isolated group.
@@ -1046,27 +963,6 @@ fm_remote_job_start_linux_worker() { # <remote-root> <account-home>
     wait "$pid" 2>/dev/null || true
     FM_REMOTE_JOB_REPAIRED=1
   fi
-  # A supervisor can own this account with no serving worker of its own - one
-  # that outlived the child stopped above, one still bringing its first child
-  # up, or one between children. A replacement launched beside it exits as a
-  # duplicate, so wait out what it is doing: a supervisor for this same root
-  # gets the chance to finish coming up, and only one that cannot serve this
-  # root is released.
-  fm_remote_job_await_supervisor "$root" "$account_home"
-  case $? in
-    0) ;;
-    2) FM_REMOTE_JOB_WORKER_START=serving; return 0 ;;
-    3)
-      fm_remote_job_release_supervisor "$account_home" || {
-        FM_REMOTE_JOB_ERROR="the running remote job worker supervisor did not release ownership"
-        return 1
-      }
-      ;;
-    *)
-      FM_REMOTE_JOB_ERROR="the running remote job worker supervisor neither served nor released this account"
-      return 1
-      ;;
-  esac
   # Job control puts the worker tree in its own process group, so a later stop
   # can signal every descendant at once without ever reaching the caller's own
   # group. Without this the group of a leaked worker is the launching command's.
@@ -1080,7 +976,6 @@ fm_remote_job_start_linux_worker() { # <remote-root> <account-home>
   pid=$!
   set +m
   case "$pid" in ''|*[!0-9]*) FM_REMOTE_JOB_ERROR="could not start the remote job worker"; return 1 ;; esac
-  FM_REMOTE_JOB_WORKER_START=started
   FM_REMOTE_JOB_REPAIRED=1
 }
 
@@ -1088,7 +983,6 @@ fm_remote_job_ensure_worker() { # <remote-root> <account-home>
   local root=$1 account_home=$2 platform uid identity_matches=0
   FM_REMOTE_JOB_ERROR=
   FM_REMOTE_JOB_REPAIRED=0
-  FM_REMOTE_JOB_WORKER_START=
   root=$(fm_remote_job_canonical_existing_dir "$root") || {
     FM_REMOTE_JOB_ERROR="configured remote root is unavailable or unsafe"
     return 1
@@ -1129,12 +1023,12 @@ fm_remote_job_ensure_worker() { # <remote-root> <account-home>
     FM_REMOTE_JOB_REPAIRED=1
     fm_remote_job_wait_for_probe "$root" "$account_home" && return 0
   else
-    # A replaced Linux supervisor can still lose its first ownership race - the
-    # serving lock a stopped worker released can take longer than this probe
-    # window to reclaim. Retry the idempotent start once, matching the bounded
-    # recovery already used above for launchd, before reporting a failure.
+    # A replaced Linux supervisor can lose its first ownership race while the
+    # prior supervisor finishes releasing the shared worker lock. Retry the
+    # idempotent start once, matching the bounded recovery already used above
+    # for launchd, before reporting a startup failure.
     fm_remote_job_start_linux_worker "$root" "$account_home" || return 1
-    [ "$FM_REMOTE_JOB_WORKER_START" = started ] && FM_REMOTE_JOB_REPAIRED=1
+    FM_REMOTE_JOB_REPAIRED=1
     fm_remote_job_wait_for_probe "$root" "$account_home" && return 0
   fi
   # shellcheck disable=SC2034 # Sourceable API consumed by the entrypoint and remote doctor.

--- a/bin/fm-remote-job-lib.sh
+++ b/bin/fm-remote-job-lib.sh
@@ -48,12 +48,15 @@
 # signal a group whose leader is not itself a worker, so a worker inherited
 # from an older build or from launchd's own session is still stopped safely as
 # a single process. Because a Linux supervisor is a per-account singleton that
-# refuses to run beside an incumbent, the start path also releases the
-# incumbent supervisor before launching a replacement: a replacement launched
-# against a live supervisor exits as a duplicate instead of serving.
-# fm_remote_job_start_linux_worker reports which of the three outcomes it
-# reached in FM_REMOTE_JOB_WORKER_START, so a refusal can never be mistaken for
-# a start. fm_remote_job_root_is_live is the shared predicate for
+# refuses to run beside an incumbent, the start path first waits out whatever
+# supervisor already owns the account: one launched from the same code root is
+# left to finish coming up and reported as already serving, one that cannot
+# serve the requested root is released before a replacement is launched, and a
+# supervisor that neither serves nor releases within that bound is reported as
+# a failure to start rather than replaced. fm_remote_job_start_linux_worker
+# reports which of those outcomes it reached in FM_REMOTE_JOB_WORKER_START, so
+# a refusal can never be mistaken for a start.
+# fm_remote_job_root_is_live is the shared predicate for
 # whether a worker's code root still exists; bin/fm-remote-job-worker.sh uses
 # it to stop itself once its root is pruned, and
 # bin/fm-remote-job-reap-orphans.sh uses it to reap workers that were already
@@ -863,6 +866,39 @@ fm_remote_job_supervisor_owner() { # <account-home>
   printf '%s\n' "$FM_REMOTE_JOB_OWNER_PID"
 }
 
+# The code root an owning supervisor was launched from, proven the same way a
+# serving worker is attributed to its root: the supervisor is exec'd as
+# <root>/bin/fm-remote-job-worker.sh, so its own command names the root it can
+# ever serve. A command that cannot be read, or that names another root, is not
+# proof of this root.
+fm_remote_job_supervisor_serves_root() { # <remote-root> <pid>
+  local root=$1 pid=$2 command
+  command=$(fm_remote_job_process_command "$pid") || return 1
+  case "$command" in *"$root/bin/fm-remote-job-worker.sh"*) return 0 ;; esac
+  return 1
+}
+
+# Whether a start may spawn beside the supervisor that currently owns this
+# account, waiting out the states that are still resolving themselves. Returns
+# 0 once no supervisor is provably live, so the spawn proceeds under the
+# acquiring supervisor's own staleness and quarantine policy; 2 once an
+# incumbent launched from this same code root has published a ready worker with
+# matching identity, which is a healthy supervisor that must not be replaced; 3
+# for an incumbent that cannot serve this root, which the caller releases; and
+# 1 when a same-root incumbent neither serves nor releases within the bound.
+fm_remote_job_await_supervisor() { # <remote-root> <account-home>
+  local root=$1 account_home=$2 pid waited=0
+  while [ "$waited" -lt 200 ]; do
+    pid=$(fm_remote_job_supervisor_owner "$account_home") || return 0
+    fm_remote_job_supervisor_serves_root "$root" "$pid" || return 3
+    fm_remote_job_probe "$account_home" &&
+      fm_remote_job_worker_identity_matches "$root" "$account_home" && return 2
+    waited=$((waited + 1))
+    sleep 0.1
+  done
+  return 1
+}
+
 # A live supervisor refuses its replacement as a duplicate, so a replacement
 # may only be launched once no supervisor is provably still serving. Stop the
 # incumbent's tree once, then wait out its shutdown - a supervisor that is
@@ -1010,15 +1046,27 @@ fm_remote_job_start_linux_worker() { # <remote-root> <account-home>
     wait "$pid" 2>/dev/null || true
     FM_REMOTE_JOB_REPAIRED=1
   fi
-  # A supervisor can outlive the serving child stopped above - it was signalled
-  # as a lone process because its group was not provable, or it was already
-  # between children and had no serving child at all. It still owns this
-  # account, so a replacement launched now would exit as a duplicate and leave
-  # the account served by the supervisor being replaced.
-  fm_remote_job_release_supervisor "$account_home" || {
-    FM_REMOTE_JOB_ERROR="the running remote job worker supervisor did not release ownership"
-    return 1
-  }
+  # A supervisor can own this account with no serving worker of its own - one
+  # that outlived the child stopped above, one still bringing its first child
+  # up, or one between children. A replacement launched beside it exits as a
+  # duplicate, so wait out what it is doing: a supervisor for this same root
+  # gets the chance to finish coming up, and only one that cannot serve this
+  # root is released.
+  fm_remote_job_await_supervisor "$root" "$account_home"
+  case $? in
+    0) ;;
+    2) FM_REMOTE_JOB_WORKER_START=serving; return 0 ;;
+    3)
+      fm_remote_job_release_supervisor "$account_home" || {
+        FM_REMOTE_JOB_ERROR="the running remote job worker supervisor did not release ownership"
+        return 1
+      }
+      ;;
+    *)
+      FM_REMOTE_JOB_ERROR="the running remote job worker supervisor neither served nor released this account"
+      return 1
+      ;;
+  esac
   # Job control puts the worker tree in its own process group, so a later stop
   # can signal every descendant at once without ever reaching the caller's own
   # group. Without this the group of a leaked worker is the launching command's.

--- a/bin/fm-remote-job-lib.sh
+++ b/bin/fm-remote-job-lib.sh
@@ -47,7 +47,13 @@
 # just killed. fm_remote_job_stop_worker_tree owns that stop and refuses to
 # signal a group whose leader is not itself a worker, so a worker inherited
 # from an older build or from launchd's own session is still stopped safely as
-# a single process. fm_remote_job_root_is_live is the shared predicate for
+# a single process. Because a Linux supervisor is a per-account singleton that
+# refuses to run beside an incumbent, the start path also releases the
+# incumbent supervisor before launching a replacement: a replacement launched
+# against a live supervisor exits as a duplicate instead of serving.
+# fm_remote_job_start_linux_worker reports which of the three outcomes it
+# reached in FM_REMOTE_JOB_WORKER_START, so a refusal can never be mistaken for
+# a start. fm_remote_job_root_is_live is the shared predicate for
 # whether a worker's code root still exists; bin/fm-remote-job-worker.sh uses
 # it to stop itself once its root is pruned, and
 # bin/fm-remote-job-reap-orphans.sh uses it to reap workers that were already
@@ -72,6 +78,9 @@ FM_REMOTE_JOB_STDERR=
 FM_REMOTE_JOB_EXIT=
 FM_REMOTE_JOB_ERROR=
 FM_REMOTE_JOB_REPAIRED=0
+# serving (an already-running worker was kept), started (a supervisor was
+# launched), or empty when the start failed.
+FM_REMOTE_JOB_WORKER_START=
 
 fm_remote_job_die() {
   printf 'error: %s\n' "$1" >&2
@@ -697,6 +706,7 @@ fm_remote_job_worker_pid_path() { printf '%s\n' "$FM_REMOTE_JOB_STATE/worker.pid
 fm_remote_job_worker_ready_path() { printf '%s\n' "$FM_REMOTE_JOB_STATE/worker.ready"; }
 fm_remote_job_worker_identity_path() { printf '%s\n' "$FM_REMOTE_JOB_STATE/worker.identity"; }
 fm_remote_job_worker_lock_path() { printf '%s\n' "$FM_REMOTE_JOB_STATE/worker.lock"; }
+fm_remote_job_supervisor_lock_path() { printf '%s\n' "$FM_REMOTE_JOB_STATE/supervisor.lock"; }
 
 fm_remote_job_process_start() {
   local pid=$1 ps_bin value
@@ -841,6 +851,39 @@ fm_remote_job_worker_owned_alive() {
   return 1
 }
 
+# The Linux supervisor that still owns this account, echoed only when the same
+# pid, start time, and command identity the supervisor published under its own
+# lock still name a live process. A released, crashed, or symlink-substituted
+# lock echoes nothing: reclaiming those belongs to the acquiring supervisor,
+# which already owns the staleness and quarantine policy.
+fm_remote_job_supervisor_owner() { # <account-home>
+  local account_home=$1
+  fm_remote_job_prepare_state "$account_home" || return 1
+  fm_remote_job_lock_owner_matches_process "$account_home" "$(fm_remote_job_supervisor_lock_path)" || return 1
+  printf '%s\n' "$FM_REMOTE_JOB_OWNER_PID"
+}
+
+# A live supervisor refuses its replacement as a duplicate, so a replacement
+# may only be launched once no supervisor is provably still serving. Stop the
+# incumbent's tree once, then wait out its shutdown - a supervisor that is
+# already exiting still owns the lock until it releases it. Returns non-zero
+# only while ownership stays provably live, which the caller reports as a
+# failure to start rather than a repair.
+fm_remote_job_release_supervisor() { # <account-home>
+  local account_home=$1 pid stopped=0 waited=0
+  while [ "$waited" -lt 100 ]; do
+    pid=$(fm_remote_job_supervisor_owner "$account_home") || return 0
+    if [ "$stopped" -eq 0 ]; then
+      stopped=1
+      fm_remote_job_stop_worker_tree "$pid" || true
+      continue
+    fi
+    waited=$((waited + 1))
+    sleep 0.1
+  done
+  return 1
+}
+
 fm_remote_job_code_identity() { # <remote-root> <account-home>
   local root=$1 account_home=$2 git_bin root_hash library_hash worker_hash
   root=$(fm_remote_job_canonical_existing_dir "$root") || return 1
@@ -944,6 +987,7 @@ fm_remote_job_reload_launchagent() { # <account-home> <uid>
 
 fm_remote_job_start_linux_worker() { # <remote-root> <account-home>
   local root=$1 account_home=$2 worker pid
+  FM_REMOTE_JOB_WORKER_START=
   worker="$root/bin/fm-remote-job-worker.sh"
   [ -f "$worker" ] && [ ! -L "$worker" ] && [ -x "$worker" ] || {
     FM_REMOTE_JOB_ERROR="remote job worker is not a genuine executable in the configured code root"
@@ -951,7 +995,10 @@ fm_remote_job_start_linux_worker() { # <remote-root> <account-home>
   }
   fm_remote_job_prepare_state "$account_home" || return 1
   if fm_remote_job_worker_owned_alive "$root" "$account_home"; then
-    if fm_remote_job_worker_identity_matches "$root" "$account_home"; then return 0; fi
+    if fm_remote_job_worker_identity_matches "$root" "$account_home"; then
+      FM_REMOTE_JOB_WORKER_START=serving
+      return 0
+    fi
     # The owner pid is the serving child; its restart supervisor sits above it
     # and would immediately replace a lone process kill, so stop the whole
     # worker tree through its isolated group.
@@ -963,6 +1010,15 @@ fm_remote_job_start_linux_worker() { # <remote-root> <account-home>
     wait "$pid" 2>/dev/null || true
     FM_REMOTE_JOB_REPAIRED=1
   fi
+  # A supervisor can outlive the serving child stopped above - it was signalled
+  # as a lone process because its group was not provable, or it was already
+  # between children and had no serving child at all. It still owns this
+  # account, so a replacement launched now would exit as a duplicate and leave
+  # the account served by the supervisor being replaced.
+  fm_remote_job_release_supervisor "$account_home" || {
+    FM_REMOTE_JOB_ERROR="the running remote job worker supervisor did not release ownership"
+    return 1
+  }
   # Job control puts the worker tree in its own process group, so a later stop
   # can signal every descendant at once without ever reaching the caller's own
   # group. Without this the group of a leaked worker is the launching command's.
@@ -976,6 +1032,7 @@ fm_remote_job_start_linux_worker() { # <remote-root> <account-home>
   pid=$!
   set +m
   case "$pid" in ''|*[!0-9]*) FM_REMOTE_JOB_ERROR="could not start the remote job worker"; return 1 ;; esac
+  FM_REMOTE_JOB_WORKER_START=started
   FM_REMOTE_JOB_REPAIRED=1
 }
 
@@ -983,6 +1040,7 @@ fm_remote_job_ensure_worker() { # <remote-root> <account-home>
   local root=$1 account_home=$2 platform uid identity_matches=0
   FM_REMOTE_JOB_ERROR=
   FM_REMOTE_JOB_REPAIRED=0
+  FM_REMOTE_JOB_WORKER_START=
   root=$(fm_remote_job_canonical_existing_dir "$root") || {
     FM_REMOTE_JOB_ERROR="configured remote root is unavailable or unsafe"
     return 1
@@ -1023,12 +1081,12 @@ fm_remote_job_ensure_worker() { # <remote-root> <account-home>
     FM_REMOTE_JOB_REPAIRED=1
     fm_remote_job_wait_for_probe "$root" "$account_home" && return 0
   else
-    # A replaced Linux supervisor can lose its first ownership race while the
-    # prior supervisor finishes releasing the shared worker lock. Retry the
-    # idempotent start once, matching the bounded recovery already used above
-    # for launchd, before reporting a startup failure.
+    # A replaced Linux supervisor can still lose its first ownership race - the
+    # serving lock a stopped worker released can take longer than this probe
+    # window to reclaim. Retry the idempotent start once, matching the bounded
+    # recovery already used above for launchd, before reporting a failure.
     fm_remote_job_start_linux_worker "$root" "$account_home" || return 1
-    FM_REMOTE_JOB_REPAIRED=1
+    [ "$FM_REMOTE_JOB_WORKER_START" = started ] && FM_REMOTE_JOB_REPAIRED=1
     fm_remote_job_wait_for_probe "$root" "$account_home" && return 0
   fi
   # shellcheck disable=SC2034 # Sourceable API consumed by the entrypoint and remote doctor.

--- a/bin/fm-remote-job-lib.sh
+++ b/bin/fm-remote-job-lib.sh
@@ -798,10 +798,10 @@ fm_remote_job_read_single_line() {
   printf '%s\n' "$value"
 }
 
-fm_remote_job_lock_owner_matches_process() {
-  local account_home=$1 lock pid recorded_start actual_start recorded_command actual_command
+fm_remote_job_lock_owner_matches_process() { # <account-home> [lock-directory]
+  local account_home=$1 lock=${2:-} pid recorded_start actual_start recorded_command actual_command
   fm_remote_job_prepare_state "$account_home" || return 1
-  lock=$(fm_remote_job_worker_lock_path)
+  [ -n "$lock" ] || lock=$(fm_remote_job_worker_lock_path)
   [ -d "$lock" ] && [ ! -L "$lock" ] || return 1
   pid=$(fm_remote_job_read_single_line "$lock/pid" 64) || return 1
   case "$pid" in ''|*[!0-9]*) return 1 ;; esac

--- a/bin/fm-remote-job-worker.sh
+++ b/bin/fm-remote-job-worker.sh
@@ -756,7 +756,7 @@ worker_supervise_linux() {
   FM_ROOT=$(fm_remote_job_canonical_existing_dir "$FM_ROOT") || { worker_error "configured FM_ROOT is unsafe"; return 1; }
   [ -f "$FM_ROOT/AGENTS.md" ] && [ ! -L "$FM_ROOT/AGENTS.md" ] || { worker_error "FM_ROOT is not a Firstmate checkout"; return 1; }
   fm_remote_job_prepare_state "$account_home" || { worker_error "$FM_REMOTE_JOB_ERROR"; return 1; }
-  WORKER_LOCK="$FM_REMOTE_JOB_STATE/supervisor.lock"
+  WORKER_LOCK=$(fm_remote_job_supervisor_lock_path)
   trap worker_supervisor_cleanup EXIT
   worker_acquire_lock "$account_home"
   lock_status=$?

--- a/bin/fm-remote-job-worker.sh
+++ b/bin/fm-remote-job-worker.sh
@@ -28,7 +28,8 @@
 # FM_REMOTE_JOB_SUPERVISOR_MAX_RESTARTS failed children, since a restart loop
 # only burns CPU and grows its log without bound. A child that stays up for
 # FM_REMOTE_JOB_SUPERVISOR_HEALTHY_SECONDS clears the consecutive-failure
-# backoff, but not the total restart guard. fm-on's ensure path restarts a
+# backoff, but not the total restart guard, so a child that dies just past that
+# threshold cannot restart without bound either. fm-on's ensure path restarts a
 # worker that gave up.
 set -u
 
@@ -123,7 +124,7 @@ worker_lock_recent() {
 worker_quarantined_execution_stopped() { # <account-home>
   local account_home=$1 job state kind file pid
   fm_remote_job_regular_bounded "$WORKER_LOCK/quarantine" 256 || return 1
-  fm_remote_job_lock_owner_matches_process "$account_home" "$WORKER_LOCK" && return 1
+  fm_remote_job_lock_owner_matches_process "$account_home" && return 1
   for job in "$FM_REMOTE_JOB_JOBS"/job-*; do
     [ -d "$job" ] && [ ! -L "$job" ] || continue
     state=$(fm_remote_job_read_state "$job" 2>/dev/null || true)
@@ -157,7 +158,7 @@ worker_acquire_lock() {
       worker_recover_quarantine "$account_home" || return 3
       continue
     fi
-    if fm_remote_job_lock_owner_matches_process "$account_home" "$WORKER_LOCK"; then return 2; fi
+    if fm_remote_job_lock_owner_matches_process "$account_home"; then return 2; fi
     if fm_remote_job_probe "$account_home" || worker_lock_recent; then
       attempt=$((attempt + 1))
       sleep 0.1
@@ -188,7 +189,13 @@ worker_cleanup() {
   local pid_file ready identity owner_pid
   [ "$WORKER_LOCK_HELD" -eq 1 ] && [ "$WORKER_RELEASE_OWNERSHIP" -eq 1 ] || return 0
   owner_pid=$(fm_remote_job_read_single_line "$WORKER_LOCK/pid" 64 2>/dev/null || true)
-  [ -n "$owner_pid" ] || { worker_release_lock; return 0; }
+  if [ -z "$owner_pid" ]; then
+    [ ! -L "$WORKER_LOCK/start" ] && [ ! -L "$WORKER_LOCK/command" ] &&
+      rm -f -- "$WORKER_LOCK/start" "$WORKER_LOCK/command" 2>/dev/null || true
+    rmdir "$WORKER_LOCK" 2>/dev/null || true
+    WORKER_LOCK_HELD=0
+    return 0
+  fi
   [ "$owner_pid" = "${BASHPID:-$$}" ] || return 0
   pid_file=$(fm_remote_job_worker_pid_path)
   ready=$(fm_remote_job_worker_ready_path)
@@ -196,15 +203,6 @@ worker_cleanup() {
   [ ! -L "$pid_file" ] && rm -f -- "$pid_file" 2>/dev/null || true
   [ ! -L "$ready" ] && rm -f -- "$ready" 2>/dev/null || true
   [ ! -L "$identity" ] && rm -f -- "$identity" 2>/dev/null || true
-  worker_release_lock
-}
-
-worker_release_lock() {
-  local owner_pid
-  [ "$WORKER_LOCK_HELD" -eq 1 ] && [ "$WORKER_RELEASE_OWNERSHIP" -eq 1 ] || return 0
-  owner_pid=$(fm_remote_job_read_single_line "$WORKER_LOCK/pid" 64 2>/dev/null || true)
-  if [ -n "$owner_pid" ] && [ "$owner_pid" != "${BASHPID:-$$}" ]; then return 0; fi
-  [ ! -L "$WORKER_LOCK/pid" ] && [ ! -L "$WORKER_LOCK/start" ] && [ ! -L "$WORKER_LOCK/command" ] || return 0
   rm -f -- "$WORKER_LOCK/pid" "$WORKER_LOCK/start" "$WORKER_LOCK/command" 2>/dev/null || true
   rmdir "$WORKER_LOCK" 2>/dev/null || true
   WORKER_LOCK_HELD=0
@@ -746,26 +744,12 @@ worker_supervisor_shutdown() {
   exit 0
 }
 
-worker_supervisor_cleanup() {
-  worker_release_lock
-}
-
 worker_supervise_linux() {
-  local account_home lock_status child_status started failures=0 restarts=0 backoff
+  local account_home child_status started failures=0 restarts=0 backoff
   account_home=$(worker_account_home) || { worker_error "cannot resolve account home"; return 1; }
   FM_ROOT=$(fm_remote_job_canonical_existing_dir "$FM_ROOT") || { worker_error "configured FM_ROOT is unsafe"; return 1; }
   [ -f "$FM_ROOT/AGENTS.md" ] && [ ! -L "$FM_ROOT/AGENTS.md" ] || { worker_error "FM_ROOT is not a Firstmate checkout"; return 1; }
   fm_remote_job_prepare_state "$account_home" || { worker_error "$FM_REMOTE_JOB_ERROR"; return 1; }
-  WORKER_LOCK=$(fm_remote_job_supervisor_lock_path)
-  trap worker_supervisor_cleanup EXIT
-  worker_acquire_lock "$account_home"
-  lock_status=$?
-  case "$lock_status" in
-    0) ;;
-    2) worker_error "remote job worker supervisor is already running"; return 0 ;;
-    3) worker_error "supervisor ownership is quarantined after an unconfirmed shutdown"; return 75 ;;
-    *) worker_error "cannot acquire or safely reclaim supervisor ownership"; return 1 ;;
-  esac
   trap worker_supervisor_shutdown HUP INT TERM
   while :; do
     if worker_code_root_abandoned; then

--- a/bin/fm-remote-job-worker.sh
+++ b/bin/fm-remote-job-worker.sh
@@ -25,10 +25,11 @@
 # healthy worker. The supervisor additionally refuses to restart a child that
 # keeps failing immediately: it backs off up to
 # FM_REMOTE_JOB_SUPERVISOR_MAX_BACKOFF_SECONDS and gives up after
-# FM_REMOTE_JOB_SUPERVISOR_MAX_RESTARTS consecutive failures, since a restart
-# loop that never stays up only burns CPU and grows its log without bound. A
-# child that stays up for FM_REMOTE_JOB_SUPERVISOR_HEALTHY_SECONDS clears that
-# count. fm-on's ensure path restarts a worker that gave up.
+# FM_REMOTE_JOB_SUPERVISOR_MAX_RESTARTS failed children, since a restart loop
+# only burns CPU and grows its log without bound. A child that stays up for
+# FM_REMOTE_JOB_SUPERVISOR_HEALTHY_SECONDS clears the consecutive-failure
+# backoff, but not the total restart guard. fm-on's ensure path restarts a
+# worker that gave up.
 set -u
 
 # A non-numeric override falls back to the default rather than crashing the
@@ -122,7 +123,7 @@ worker_lock_recent() {
 worker_quarantined_execution_stopped() { # <account-home>
   local account_home=$1 job state kind file pid
   fm_remote_job_regular_bounded "$WORKER_LOCK/quarantine" 256 || return 1
-  fm_remote_job_lock_owner_matches_process "$account_home" && return 1
+  fm_remote_job_lock_owner_matches_process "$account_home" "$WORKER_LOCK" && return 1
   for job in "$FM_REMOTE_JOB_JOBS"/job-*; do
     [ -d "$job" ] && [ ! -L "$job" ] || continue
     state=$(fm_remote_job_read_state "$job" 2>/dev/null || true)
@@ -156,7 +157,7 @@ worker_acquire_lock() {
       worker_recover_quarantine "$account_home" || return 3
       continue
     fi
-    if fm_remote_job_lock_owner_matches_process "$account_home"; then return 2; fi
+    if fm_remote_job_lock_owner_matches_process "$account_home" "$WORKER_LOCK"; then return 2; fi
     if fm_remote_job_probe "$account_home" || worker_lock_recent; then
       attempt=$((attempt + 1))
       sleep 0.1
@@ -187,13 +188,7 @@ worker_cleanup() {
   local pid_file ready identity owner_pid
   [ "$WORKER_LOCK_HELD" -eq 1 ] && [ "$WORKER_RELEASE_OWNERSHIP" -eq 1 ] || return 0
   owner_pid=$(fm_remote_job_read_single_line "$WORKER_LOCK/pid" 64 2>/dev/null || true)
-  if [ -z "$owner_pid" ]; then
-    [ ! -L "$WORKER_LOCK/start" ] && [ ! -L "$WORKER_LOCK/command" ] &&
-      rm -f -- "$WORKER_LOCK/start" "$WORKER_LOCK/command" 2>/dev/null || true
-    rmdir "$WORKER_LOCK" 2>/dev/null || true
-    WORKER_LOCK_HELD=0
-    return 0
-  fi
+  [ -n "$owner_pid" ] || { worker_release_lock; return 0; }
   [ "$owner_pid" = "${BASHPID:-$$}" ] || return 0
   pid_file=$(fm_remote_job_worker_pid_path)
   ready=$(fm_remote_job_worker_ready_path)
@@ -201,6 +196,15 @@ worker_cleanup() {
   [ ! -L "$pid_file" ] && rm -f -- "$pid_file" 2>/dev/null || true
   [ ! -L "$ready" ] && rm -f -- "$ready" 2>/dev/null || true
   [ ! -L "$identity" ] && rm -f -- "$identity" 2>/dev/null || true
+  worker_release_lock
+}
+
+worker_release_lock() {
+  local owner_pid
+  [ "$WORKER_LOCK_HELD" -eq 1 ] && [ "$WORKER_RELEASE_OWNERSHIP" -eq 1 ] || return 0
+  owner_pid=$(fm_remote_job_read_single_line "$WORKER_LOCK/pid" 64 2>/dev/null || true)
+  if [ -n "$owner_pid" ] && [ "$owner_pid" != "${BASHPID:-$$}" ]; then return 0; fi
+  [ ! -L "$WORKER_LOCK/pid" ] && [ ! -L "$WORKER_LOCK/start" ] && [ ! -L "$WORKER_LOCK/command" ] || return 0
   rm -f -- "$WORKER_LOCK/pid" "$WORKER_LOCK/start" "$WORKER_LOCK/command" 2>/dev/null || true
   rmdir "$WORKER_LOCK" 2>/dev/null || true
   WORKER_LOCK_HELD=0
@@ -742,12 +746,26 @@ worker_supervisor_shutdown() {
   exit 0
 }
 
+worker_supervisor_cleanup() {
+  worker_release_lock
+}
+
 worker_supervise_linux() {
-  local account_home child_status started failures=0 backoff
+  local account_home lock_status child_status started failures=0 restarts=0 backoff
   account_home=$(worker_account_home) || { worker_error "cannot resolve account home"; return 1; }
   FM_ROOT=$(fm_remote_job_canonical_existing_dir "$FM_ROOT") || { worker_error "configured FM_ROOT is unsafe"; return 1; }
   [ -f "$FM_ROOT/AGENTS.md" ] && [ ! -L "$FM_ROOT/AGENTS.md" ] || { worker_error "FM_ROOT is not a Firstmate checkout"; return 1; }
   fm_remote_job_prepare_state "$account_home" || { worker_error "$FM_REMOTE_JOB_ERROR"; return 1; }
+  WORKER_LOCK="$FM_REMOTE_JOB_STATE/supervisor.lock"
+  trap worker_supervisor_cleanup EXIT
+  worker_acquire_lock "$account_home"
+  lock_status=$?
+  case "$lock_status" in
+    0) ;;
+    2) worker_error "remote job worker supervisor is already running"; return 0 ;;
+    3) worker_error "supervisor ownership is quarantined after an unconfirmed shutdown"; return 75 ;;
+    *) worker_error "cannot acquire or safely reclaim supervisor ownership"; return 1 ;;
+  esac
   trap worker_supervisor_shutdown HUP INT TERM
   while :; do
     if worker_code_root_abandoned; then
@@ -769,16 +787,17 @@ worker_supervise_linux() {
     fi
     worker_supervisor_cleanup_dead_child "$account_home" "$WORKER_SUPERVISED_PID" || true
     WORKER_SUPERVISED_PID=
+    restarts=$((restarts + 1))
+    if [ "$restarts" -ge "$FM_REMOTE_JOB_SUPERVISOR_MAX_RESTARTS" ]; then
+      worker_error "remote job worker exited $restarts times; stopping the supervisor"
+      return 1
+    fi
     if [ $((SECONDS - started)) -ge "$FM_REMOTE_JOB_SUPERVISOR_HEALTHY_SECONDS" ]; then
       failures=0
       sleep 0.1
       continue
     fi
     failures=$((failures + 1))
-    if [ "$failures" -ge "$FM_REMOTE_JOB_SUPERVISOR_MAX_RESTARTS" ]; then
-      worker_error "remote job worker failed $failures times without staying up; stopping the supervisor"
-      return 1
-    fi
     backoff=$failures
     [ "$backoff" -le "$FM_REMOTE_JOB_SUPERVISOR_MAX_BACKOFF_SECONDS" ] ||
       backoff=$FM_REMOTE_JOB_SUPERVISOR_MAX_BACKOFF_SECONDS

--- a/bin/fm-remote-job-worker.sh
+++ b/bin/fm-remote-job-worker.sh
@@ -22,15 +22,16 @@
 # loop and the Linux restart supervisor stop instead of polling forever
 # reparented to init. FM_REMOTE_JOB_ORPHAN_GRACE_SECONDS is how long the root
 # must stay missing before that counts, so an ordinary transient never stops a
-# healthy worker. The supervisor additionally refuses to restart a child that
-# keeps failing immediately: it backs off up to
+# healthy worker. The supervisor additionally bounds how many times it restarts
+# a failing child, whether or not the failures are immediate: it backs off
+# between immediate failures up to
 # FM_REMOTE_JOB_SUPERVISOR_MAX_BACKOFF_SECONDS and gives up after
-# FM_REMOTE_JOB_SUPERVISOR_MAX_RESTARTS failed children, since a restart loop
-# only burns CPU and grows its log without bound. A child that stays up for
-# FM_REMOTE_JOB_SUPERVISOR_HEALTHY_SECONDS clears the consecutive-failure
-# backoff, but not the total restart guard, so a child that dies just past that
-# threshold cannot restart without bound either. fm-on's ensure path restarts a
-# worker that gave up.
+# FM_REMOTE_JOB_SUPERVISOR_MAX_RESTARTS failed children in total, since a
+# restart loop only burns CPU and grows its log without bound. A child that
+# stays up for FM_REMOTE_JOB_SUPERVISOR_HEALTHY_SECONDS clears the
+# consecutive-failure backoff, but not that total restart guard, so a child
+# that dies just past the healthy threshold cannot restart without bound
+# either. fm-on's ensure path restarts a worker that gave up.
 set -u
 
 # A non-numeric override falls back to the default rather than crashing the

--- a/tests/fm-remote-job.test.sh
+++ b/tests/fm-remote-job.test.sh
@@ -23,6 +23,8 @@ SUPERVISOR_PID=
 SUPERVISOR_CHILD_PID=
 SUPERVISOR_SLEEP_PID=
 RESTART_SUPERVISOR_PID=
+RACE_INCUMBENT_PID=
+RACE_SUPERVISOR_PID=
 mkdir -p "$REMOTE_ROOT/bin" "$REMOTE_HOME" "$ACCOUNT_HOME" "$RUNTIME_BIN"
 # worker.pid records the serving child, not its restart supervisor, so stopping
 # that pid alone leaves the supervisor to respawn - the leak
@@ -35,6 +37,8 @@ cleanup_remote_job_fixture() {
   [ -z "$SUPERVISOR_CHILD_PID" ] || kill -KILL "$SUPERVISOR_CHILD_PID" 2>/dev/null || true
   [ -z "$SUPERVISOR_SLEEP_PID" ] || kill -KILL "$SUPERVISOR_SLEEP_PID" 2>/dev/null || true
   [ -z "$RESTART_SUPERVISOR_PID" ] || kill -KILL "$RESTART_SUPERVISOR_PID" 2>/dev/null || true
+  [ -z "$RACE_INCUMBENT_PID" ] || kill -KILL "$RACE_INCUMBENT_PID" 2>/dev/null || true
+  [ -z "$RACE_SUPERVISOR_PID" ] || fm_remote_job_stop_worker_tree "$RACE_SUPERVISOR_PID" || true
   if [ -f "$STATE_ROOT/worker.pid" ]; then
     fm_remote_job_stop_worker_tree "$(cat "$STATE_ROOT/worker.pid")" || true
   fi
@@ -730,10 +734,11 @@ cat > "$SUPERVISOR_ROOT/bin/fm-remote-job-worker.sh" <<'SH'
 #!/bin/bash
 set -u
 [ "${1:-}" = --serve ] || exit 2
+term_delay=${FM_TEST_SUPERVISOR_CHILD_TERM_DELAY:-0}
 printf '%s\n' "${BASHPID:-$$}" >> "$FM_TEST_SUPERVISOR_CHILD_LOG"
 sleep "$FM_TEST_SUPERVISOR_CHILD_SECONDS" &
 sleep_pid=$!
-trap 'kill "$sleep_pid" 2>/dev/null || true; wait "$sleep_pid" 2>/dev/null || true; exit 143' HUP INT TERM
+trap 'kill "$sleep_pid" 2>/dev/null || true; wait "$sleep_pid" 2>/dev/null || true; sleep "$term_delay"; exit 143' HUP INT TERM
 wait "$sleep_pid" 2>/dev/null || true
 trap - HUP INT TERM
 exit "$FM_TEST_SUPERVISOR_CHILD_STATUS"
@@ -850,5 +855,57 @@ assert_grep "remote job worker exited 3 times; stopping the supervisor" "$TMP_RO
   "the restart guard did not explain why it stopped"
 assert_absent "$RESTART_STATE/supervisor.lock" "the exhausted restart guard retained supervisor ownership"
 pass "barely healthy worker failures remain bounded by the restart guard"
+
+# A supervisor singleton makes every replacement exit as a duplicate while an
+# incumbent still owns the account, so the start boundary has to release that
+# incumbent instead of spawning against it. The incumbent below owns the
+# account with no serving worker of its own - a supervisor between children -
+# and its own child takes a second to finish shutting down, so a start that
+# assumes ownership is free the moment it signals still races a live holder.
+# It is started detached so it is reparented away from this shell, the way a
+# supervisor outlives the fm-on invocation that launched it.
+RACE_HOME="$TMP_ROOT/race-account"
+RACE_STATE="$TMP_ROOT/race-state"
+RACE_CHILD_LOG="$TMP_ROOT/race-children"
+mkdir -p "$RACE_HOME"
+RACE_INCUMBENT_PID=$(HOME="$RACE_HOME" FM_ROOT_OVERRIDE="$SUPERVISOR_ROOT" \
+  FM_REMOTE_JOB_STATE_ROOT="$RACE_STATE" FM_REMOTE_JOB_PLATFORM_OVERRIDE=Linux \
+  FM_TEST_SUPERVISOR_CHILD_LOG="$RACE_CHILD_LOG" FM_TEST_SUPERVISOR_CHILD_SECONDS=300 \
+  FM_TEST_SUPERVISOR_CHILD_STATUS=1 FM_TEST_SUPERVISOR_CHILD_TERM_DELAY=1 \
+  bash -c 'nohup "$1" > "$2" 2> "$3" < /dev/null & printf "%s\n" "$!"' _ \
+    "$SUPERVISOR_ROOT/bin/fm-remote-job-supervisor-under-test.sh" \
+    "$TMP_ROOT/race-incumbent.out" "$TMP_ROOT/race-incumbent.err")
+for _ in $(seq 1 300); do
+  [ -f "$RACE_STATE/supervisor.lock/pid" ] && [ -s "$RACE_CHILD_LOG" ] && break
+  sleep 0.05
+done
+[ "$(cat "$RACE_STATE/supervisor.lock/pid" 2>/dev/null || true)" = "$RACE_INCUMBENT_PID" ] \
+  || fail "the incumbent supervisor fixture did not take account ownership"
+assert_absent "$RACE_STATE/worker.ready" "the incumbent supervisor fixture published a serving worker"
+FM_REMOTE_JOB_STATE_ROOT="$RACE_STATE"
+fm_remote_job_start_linux_worker "$REMOTE_ROOT" "$RACE_HOME" \
+  || fail "${FM_REMOTE_JOB_ERROR:-a start against an incumbent supervisor failed}"
+[ "$FM_REMOTE_JOB_WORKER_START" = started ] \
+  || fail "a start against an incumbent supervisor reported '$FM_REMOTE_JOB_WORKER_START' instead of starting one"
+kill -0 "$RACE_INCUMBENT_PID" 2>/dev/null \
+  && fail "the replaced incumbent supervisor was left running beside its replacement"
+fm_remote_job_wait_for_probe "$REMOTE_ROOT" "$RACE_HOME" \
+  || fail "the account was left with no supervisor serving the requested code root"
+RACE_SUPERVISOR_PID=$(fm_remote_job_supervisor_owner "$RACE_HOME") \
+  || fail "no live supervisor owns the account after the replacement started"
+[ "$RACE_SUPERVISOR_PID" != "$RACE_INCUMBENT_PID" ] \
+  || fail "the incumbent supervisor was reported as its own replacement"
+RACE_INCUMBENT_PID=
+fm_remote_job_start_linux_worker "$REMOTE_ROOT" "$RACE_HOME" \
+  || fail "${FM_REMOTE_JOB_ERROR:-a start against a serving worker failed}"
+[ "$FM_REMOTE_JOB_WORKER_START" = serving ] \
+  || fail "a start against a genuinely serving worker reported '$FM_REMOTE_JOB_WORKER_START'"
+[ "$(fm_remote_job_supervisor_owner "$RACE_HOME")" = "$RACE_SUPERVISOR_PID" ] \
+  || fail "a genuinely serving account had its supervisor replaced anyway"
+fm_remote_job_stop_worker_tree "$RACE_SUPERVISOR_PID" || true
+wait "$RACE_SUPERVISOR_PID" 2>/dev/null || true
+RACE_SUPERVISOR_PID=
+FM_REMOTE_JOB_STATE_ROOT="$STATE_ROOT"
+pass "a start releases an incumbent supervisor instead of being refused as its duplicate"
 
 echo "ALL TESTS PASSED"

--- a/tests/fm-remote-job.test.sh
+++ b/tests/fm-remote-job.test.sh
@@ -19,6 +19,10 @@ REAL_GIT=$(command -v git)
 OTHER_PID=
 RECOVERY_WORKER_PID=
 REPEAT_WORKER_PID=
+SUPERVISOR_PID=
+SUPERVISOR_CHILD_PID=
+SUPERVISOR_SLEEP_PID=
+RESTART_SUPERVISOR_PID=
 mkdir -p "$REMOTE_ROOT/bin" "$REMOTE_HOME" "$ACCOUNT_HOME" "$RUNTIME_BIN"
 # worker.pid records the serving child, not its restart supervisor, so stopping
 # that pid alone leaves the supervisor to respawn - the leak
@@ -27,6 +31,10 @@ cleanup_remote_job_fixture() {
   [ -z "$OTHER_PID" ] || kill "$OTHER_PID" 2>/dev/null || true
   [ -z "$RECOVERY_WORKER_PID" ] || kill "$RECOVERY_WORKER_PID" 2>/dev/null || true
   [ -z "$REPEAT_WORKER_PID" ] || kill "$REPEAT_WORKER_PID" 2>/dev/null || true
+  [ -z "$SUPERVISOR_PID" ] || kill -KILL "$SUPERVISOR_PID" 2>/dev/null || true
+  [ -z "$SUPERVISOR_CHILD_PID" ] || kill -KILL "$SUPERVISOR_CHILD_PID" 2>/dev/null || true
+  [ -z "$SUPERVISOR_SLEEP_PID" ] || kill -KILL "$SUPERVISOR_SLEEP_PID" 2>/dev/null || true
+  [ -z "$RESTART_SUPERVISOR_PID" ] || kill -KILL "$RESTART_SUPERVISOR_PID" 2>/dev/null || true
   if [ -f "$STATE_ROOT/worker.pid" ]; then
     fm_remote_job_stop_worker_tree "$(cat "$STATE_ROOT/worker.pid")" || true
   fi
@@ -582,7 +590,7 @@ assert_present "$STATE_ROOT/worker.lock/quarantine" "failed shutdown released wo
 fm_remote_job_probe "$ACCOUNT_HOME" && fail "quarantined worker ownership still reported ready"
 set +e
 HOME="$ACCOUNT_HOME" FM_ROOT_OVERRIDE="$REMOTE_ROOT" FM_REMOTE_JOB_STATE_ROOT="$STATE_ROOT" \
-  FM_REMOTE_JOB_PLATFORM_OVERRIDE=Linux "$REMOTE_ROOT/bin/fm-remote-job-worker.sh" \
+  FM_REMOTE_JOB_PLATFORM_OVERRIDE=Linux "$REMOTE_ROOT/bin/fm-remote-job-worker.sh" --serve \
   >> "$TMP_ROOT/worker.out" 2>> "$TMP_ROOT/worker.err"
 REPLACEMENT_RC=$?
 set -e
@@ -709,5 +717,138 @@ kill -TERM "$REPEAT_WORKER_PID"
 wait "$REPEAT_WORKER_PID" 2>/dev/null || true
 REPEAT_WORKER_PID=
 pass "a repeatedly signalled shutdown still releases ownership for the next worker"
+
+SUPERVISOR_ROOT="$TMP_ROOT/supervisor-root"
+SUPERVISOR_HOME="$TMP_ROOT/supervisor-account"
+SUPERVISOR_STATE="$TMP_ROOT/supervisor-state"
+SUPERVISOR_CHILD_LOG="$TMP_ROOT/supervisor-children"
+mkdir -p "$SUPERVISOR_ROOT/bin" "$SUPERVISOR_HOME"
+cp "$ROOT/bin/fm-remote-job-lib.sh" "$SUPERVISOR_ROOT/bin/"
+cp "$ROOT/bin/fm-remote-job-worker.sh" "$SUPERVISOR_ROOT/bin/fm-remote-job-supervisor-under-test.sh"
+printf 'fixture\n' > "$SUPERVISOR_ROOT/AGENTS.md"
+cat > "$SUPERVISOR_ROOT/bin/fm-remote-job-worker.sh" <<'SH'
+#!/bin/bash
+set -u
+[ "${1:-}" = --serve ] || exit 2
+printf '%s\n' "${BASHPID:-$$}" >> "$FM_TEST_SUPERVISOR_CHILD_LOG"
+sleep "$FM_TEST_SUPERVISOR_CHILD_SECONDS" &
+sleep_pid=$!
+trap 'kill "$sleep_pid" 2>/dev/null || true; wait "$sleep_pid" 2>/dev/null || true; exit 143' HUP INT TERM
+wait "$sleep_pid" 2>/dev/null || true
+trap - HUP INT TERM
+exit "$FM_TEST_SUPERVISOR_CHILD_STATUS"
+SH
+chmod +x "$SUPERVISOR_ROOT/bin"/*.sh
+
+HOME="$SUPERVISOR_HOME" FM_ROOT_OVERRIDE="$SUPERVISOR_ROOT" \
+  FM_REMOTE_JOB_STATE_ROOT="$SUPERVISOR_STATE" FM_REMOTE_JOB_PLATFORM_OVERRIDE=Linux \
+  FM_TEST_SUPERVISOR_CHILD_LOG="$SUPERVISOR_CHILD_LOG" FM_TEST_SUPERVISOR_CHILD_SECONDS=30 \
+  FM_TEST_SUPERVISOR_CHILD_STATUS=1 "$SUPERVISOR_ROOT/bin/fm-remote-job-supervisor-under-test.sh" \
+  > "$TMP_ROOT/supervisor-first.out" 2> "$TMP_ROOT/supervisor-first.err" &
+SUPERVISOR_PID=$!
+for _ in $(seq 1 300); do
+  [ -f "$SUPERVISOR_STATE/supervisor.lock/pid" ] && [ -s "$SUPERVISOR_CHILD_LOG" ] && break
+  sleep 0.05
+done
+assert_present "$SUPERVISOR_STATE/supervisor.lock/pid" "the first supervisor did not publish its ownership lock"
+assert_present "$SUPERVISOR_CHILD_LOG" "the first supervisor did not start its serving child"
+[ "$(cat "$SUPERVISOR_STATE/supervisor.lock/pid")" = "$SUPERVISOR_PID" ] \
+  || fail "the supervisor lock did not identify the first supervisor"
+set +e
+SECOND_SUPERVISOR_OUT=$(HOME="$SUPERVISOR_HOME" FM_ROOT_OVERRIDE="$SUPERVISOR_ROOT" \
+  FM_REMOTE_JOB_STATE_ROOT="$SUPERVISOR_STATE" FM_REMOTE_JOB_PLATFORM_OVERRIDE=Linux \
+  FM_TEST_SUPERVISOR_CHILD_LOG="$SUPERVISOR_CHILD_LOG" FM_TEST_SUPERVISOR_CHILD_SECONDS=30 \
+  FM_TEST_SUPERVISOR_CHILD_STATUS=1 "$SUPERVISOR_ROOT/bin/fm-remote-job-supervisor-under-test.sh" 2>&1)
+SECOND_SUPERVISOR_RC=$?
+set -e
+[ "$SECOND_SUPERVISOR_RC" -eq 0 ] || fail "a duplicate supervisor did not exit cleanly"
+assert_contains "$SECOND_SUPERVISOR_OUT" "remote job worker supervisor is already running" \
+  "a duplicate supervisor did not explain its refusal"
+[ "$(cat "$SUPERVISOR_STATE/supervisor.lock/pid")" = "$SUPERVISOR_PID" ] \
+  || fail "a duplicate supervisor replaced the active supervisor's ownership"
+kill -TERM "$SUPERVISOR_PID"
+wait "$SUPERVISOR_PID" 2>/dev/null || true
+SUPERVISOR_PID=
+for _ in $(seq 1 100); do
+  [ ! -e "$SUPERVISOR_STATE/supervisor.lock" ] && [ ! -L "$SUPERVISOR_STATE/supervisor.lock" ] && break
+  sleep 0.05
+done
+assert_absent "$SUPERVISOR_STATE/supervisor.lock" "a clean supervisor exit retained its ownership lock"
+pass "the Linux worker supervisor is a per-account singleton"
+
+: > "$SUPERVISOR_CHILD_LOG"
+HOME="$SUPERVISOR_HOME" FM_ROOT_OVERRIDE="$SUPERVISOR_ROOT" \
+  FM_REMOTE_JOB_STATE_ROOT="$SUPERVISOR_STATE" FM_REMOTE_JOB_PLATFORM_OVERRIDE=Linux \
+  FM_TEST_SUPERVISOR_CHILD_LOG="$SUPERVISOR_CHILD_LOG" FM_TEST_SUPERVISOR_CHILD_SECONDS=30 \
+  FM_TEST_SUPERVISOR_CHILD_STATUS=1 "$SUPERVISOR_ROOT/bin/fm-remote-job-supervisor-under-test.sh" \
+  > "$TMP_ROOT/supervisor-crashed.out" 2> "$TMP_ROOT/supervisor-crashed.err" &
+SUPERVISOR_PID=$!
+for _ in $(seq 1 300); do
+  [ -f "$SUPERVISOR_STATE/supervisor.lock/pid" ] && [ -s "$SUPERVISOR_CHILD_LOG" ] && break
+  sleep 0.05
+done
+assert_present "$SUPERVISOR_STATE/supervisor.lock/pid" "the crash fixture did not acquire supervisor ownership"
+assert_present "$SUPERVISOR_CHILD_LOG" "the crash fixture did not start its serving child"
+SUPERVISOR_CHILD_PID=$(tail -n 1 "$SUPERVISOR_CHILD_LOG")
+SUPERVISOR_SLEEP_PID=$(pgrep -P "$SUPERVISOR_CHILD_PID" | head -n 1)
+kill -KILL "$SUPERVISOR_PID"
+wait "$SUPERVISOR_PID" 2>/dev/null || true
+SUPERVISOR_PID=
+kill -KILL "$SUPERVISOR_CHILD_PID" 2>/dev/null || true
+kill -KILL "$SUPERVISOR_SLEEP_PID" 2>/dev/null || true
+SUPERVISOR_CHILD_PID=
+SUPERVISOR_SLEEP_PID=
+touch -t 200001010000 "$SUPERVISOR_STATE/supervisor.lock"
+: > "$SUPERVISOR_CHILD_LOG"
+HOME="$SUPERVISOR_HOME" FM_ROOT_OVERRIDE="$SUPERVISOR_ROOT" \
+  FM_REMOTE_JOB_STATE_ROOT="$SUPERVISOR_STATE" FM_REMOTE_JOB_PLATFORM_OVERRIDE=Linux \
+  FM_TEST_SUPERVISOR_CHILD_LOG="$SUPERVISOR_CHILD_LOG" FM_TEST_SUPERVISOR_CHILD_SECONDS=30 \
+  FM_TEST_SUPERVISOR_CHILD_STATUS=1 "$SUPERVISOR_ROOT/bin/fm-remote-job-supervisor-under-test.sh" \
+  > "$TMP_ROOT/supervisor-recovered.out" 2> "$TMP_ROOT/supervisor-recovered.err" &
+SUPERVISOR_PID=$!
+for _ in $(seq 1 300); do
+  [ -f "$SUPERVISOR_STATE/supervisor.lock/pid" ] && \
+    [ "$(cat "$SUPERVISOR_STATE/supervisor.lock/pid" 2>/dev/null || true)" = "$SUPERVISOR_PID" ] && break
+  sleep 0.05
+done
+[ "$(cat "$SUPERVISOR_STATE/supervisor.lock/pid" 2>/dev/null || true)" = "$SUPERVISOR_PID" ] \
+  || fail "a stale crashed-supervisor lock blocked its replacement"
+kill -TERM "$SUPERVISOR_PID"
+wait "$SUPERVISOR_PID" 2>/dev/null || true
+SUPERVISOR_PID=
+assert_absent "$SUPERVISOR_STATE/supervisor.lock" "the recovered supervisor retained its ownership lock"
+pass "a crashed supervisor lock is safely reclaimed"
+
+RESTART_HOME="$TMP_ROOT/restart-account"
+RESTART_STATE="$TMP_ROOT/restart-state"
+RESTART_CHILD_LOG="$TMP_ROOT/restart-children"
+mkdir -p "$RESTART_HOME"
+HOME="$RESTART_HOME" FM_ROOT_OVERRIDE="$SUPERVISOR_ROOT" \
+  FM_REMOTE_JOB_STATE_ROOT="$RESTART_STATE" FM_REMOTE_JOB_PLATFORM_OVERRIDE=Linux \
+  FM_REMOTE_JOB_SUPERVISOR_HEALTHY_SECONDS=1 FM_REMOTE_JOB_SUPERVISOR_MAX_RESTARTS=3 \
+  FM_REMOTE_JOB_SUPERVISOR_MAX_BACKOFF_SECONDS=0 FM_TEST_SUPERVISOR_CHILD_LOG="$RESTART_CHILD_LOG" \
+  FM_TEST_SUPERVISOR_CHILD_SECONDS=1.1 FM_TEST_SUPERVISOR_CHILD_STATUS=1 \
+  "$SUPERVISOR_ROOT/bin/fm-remote-job-supervisor-under-test.sh" \
+  > "$TMP_ROOT/restart-supervisor.out" 2> "$TMP_ROOT/restart-supervisor.err" &
+RESTART_SUPERVISOR_PID=$!
+for _ in $(seq 1 150); do
+  kill -0 "$RESTART_SUPERVISOR_PID" 2>/dev/null || break
+  sleep 0.1
+done
+if kill -0 "$RESTART_SUPERVISOR_PID" 2>/dev/null; then
+  fail "workers dying just past the healthy threshold drove an unbounded restart loop"
+fi
+set +e
+wait "$RESTART_SUPERVISOR_PID"
+RESTART_SUPERVISOR_RC=$?
+set -e
+RESTART_SUPERVISOR_PID=
+[ "$RESTART_SUPERVISOR_RC" -ne 0 ] || fail "the exhausted restart guard reported success"
+[ "$(wc -l < "$RESTART_CHILD_LOG" | tr -d ' ')" -eq 3 ] \
+  || fail "the restart guard did not stop at the configured maximum"
+assert_grep "remote job worker exited 3 times; stopping the supervisor" "$TMP_ROOT/restart-supervisor.err" \
+  "the restart guard did not explain why it stopped"
+assert_absent "$RESTART_STATE/supervisor.lock" "the exhausted restart guard retained supervisor ownership"
+pass "barely healthy worker failures remain bounded by the restart guard"
 
 echo "ALL TESTS PASSED"

--- a/tests/fm-remote-job.test.sh
+++ b/tests/fm-remote-job.test.sh
@@ -25,6 +25,7 @@ SUPERVISOR_SLEEP_PID=
 RESTART_SUPERVISOR_PID=
 RACE_INCUMBENT_PID=
 RACE_SUPERVISOR_PID=
+SAME_SUPERVISOR_PID=
 mkdir -p "$REMOTE_ROOT/bin" "$REMOTE_HOME" "$ACCOUNT_HOME" "$RUNTIME_BIN"
 # worker.pid records the serving child, not its restart supervisor, so stopping
 # that pid alone leaves the supervisor to respawn - the leak
@@ -39,6 +40,7 @@ cleanup_remote_job_fixture() {
   [ -z "$RESTART_SUPERVISOR_PID" ] || kill -KILL "$RESTART_SUPERVISOR_PID" 2>/dev/null || true
   [ -z "$RACE_INCUMBENT_PID" ] || kill -KILL "$RACE_INCUMBENT_PID" 2>/dev/null || true
   [ -z "$RACE_SUPERVISOR_PID" ] || fm_remote_job_stop_worker_tree "$RACE_SUPERVISOR_PID" || true
+  [ -z "$SAME_SUPERVISOR_PID" ] || fm_remote_job_stop_worker_tree "$SAME_SUPERVISOR_PID" || true
   if [ -f "$STATE_ROOT/worker.pid" ]; then
     fm_remote_job_stop_worker_tree "$(cat "$STATE_ROOT/worker.pid")" || true
   fi
@@ -907,5 +909,44 @@ wait "$RACE_SUPERVISOR_PID" 2>/dev/null || true
 RACE_SUPERVISOR_PID=
 FM_REMOTE_JOB_STATE_ROOT="$STATE_ROOT"
 pass "a start releases an incumbent supervisor instead of being refused as its duplicate"
+
+# Remote operations arrive unserialized, so a start routinely lands inside the
+# startup window of a healthy supervisor for the very root it wants: ownership
+# is already published while the first serving child is still claiming the
+# worker lock and publishing its identity. An unowned worker lock with a fresh
+# mtime holds that child in its ordinary acquisition wait, so the window is a
+# fixed state rather than a timing accident.
+SAME_HOME="$TMP_ROOT/same-root-account"
+SAME_STATE="$TMP_ROOT/same-root-state"
+mkdir -p "$SAME_HOME"
+FM_REMOTE_JOB_STATE_ROOT="$SAME_STATE"
+fm_remote_job_prepare_state "$SAME_HOME" || fail "$FM_REMOTE_JOB_ERROR"
+mkdir "$SAME_STATE/worker.lock" || fail "the startup-window fixture could not hold the worker lock"
+fm_remote_job_start_linux_worker "$REMOTE_ROOT" "$SAME_HOME" \
+  || fail "${FM_REMOTE_JOB_ERROR:-the startup-window fixture could not start a supervisor}"
+[ "$FM_REMOTE_JOB_WORKER_START" = started ] \
+  || fail "the first start reported '$FM_REMOTE_JOB_WORKER_START' instead of starting a supervisor"
+for _ in $(seq 1 300); do
+  [ -f "$SAME_STATE/supervisor.lock/pid" ] && break
+  sleep 0.05
+done
+SAME_SUPERVISOR_PID=$(fm_remote_job_supervisor_owner "$SAME_HOME") \
+  || fail "the started supervisor never took account ownership"
+fm_remote_job_worker_owned_alive "$REMOTE_ROOT" "$SAME_HOME" \
+  && fail "the startup-window fixture was already serving before the concurrent start"
+rmdir "$SAME_STATE/worker.lock" || fail "the startup-window fixture could not release the worker lock"
+fm_remote_job_start_linux_worker "$REMOTE_ROOT" "$SAME_HOME" \
+  || fail "${FM_REMOTE_JOB_ERROR:-a start concurrent with a healthy supervisor failed}"
+[ "$FM_REMOTE_JOB_WORKER_START" = serving ] \
+  || fail "a start inside a healthy supervisor's startup window reported '$FM_REMOTE_JOB_WORKER_START'"
+[ "$(fm_remote_job_supervisor_owner "$SAME_HOME")" = "$SAME_SUPERVISOR_PID" ] \
+  || fail "a start inside a healthy same-root supervisor's startup window replaced it"
+fm_remote_job_worker_identity_matches "$REMOTE_ROOT" "$SAME_HOME" \
+  || fail "the surviving supervisor did not serve the requested code root"
+fm_remote_job_stop_worker_tree "$SAME_SUPERVISOR_PID" || true
+wait "$SAME_SUPERVISOR_PID" 2>/dev/null || true
+SAME_SUPERVISOR_PID=
+FM_REMOTE_JOB_STATE_ROOT="$STATE_ROOT"
+pass "a healthy same-root supervisor survives a start inside its startup window"
 
 echo "ALL TESTS PASSED"

--- a/tests/fm-remote-job.test.sh
+++ b/tests/fm-remote-job.test.sh
@@ -19,13 +19,7 @@ REAL_GIT=$(command -v git)
 OTHER_PID=
 RECOVERY_WORKER_PID=
 REPEAT_WORKER_PID=
-SUPERVISOR_PID=
-SUPERVISOR_CHILD_PID=
-SUPERVISOR_SLEEP_PID=
 RESTART_SUPERVISOR_PID=
-RACE_INCUMBENT_PID=
-RACE_SUPERVISOR_PID=
-SAME_SUPERVISOR_PID=
 mkdir -p "$REMOTE_ROOT/bin" "$REMOTE_HOME" "$ACCOUNT_HOME" "$RUNTIME_BIN"
 # worker.pid records the serving child, not its restart supervisor, so stopping
 # that pid alone leaves the supervisor to respawn - the leak
@@ -34,13 +28,7 @@ cleanup_remote_job_fixture() {
   [ -z "$OTHER_PID" ] || kill "$OTHER_PID" 2>/dev/null || true
   [ -z "$RECOVERY_WORKER_PID" ] || kill "$RECOVERY_WORKER_PID" 2>/dev/null || true
   [ -z "$REPEAT_WORKER_PID" ] || kill "$REPEAT_WORKER_PID" 2>/dev/null || true
-  [ -z "$SUPERVISOR_PID" ] || kill -KILL "$SUPERVISOR_PID" 2>/dev/null || true
-  [ -z "$SUPERVISOR_CHILD_PID" ] || kill -KILL "$SUPERVISOR_CHILD_PID" 2>/dev/null || true
-  [ -z "$SUPERVISOR_SLEEP_PID" ] || kill -KILL "$SUPERVISOR_SLEEP_PID" 2>/dev/null || true
   [ -z "$RESTART_SUPERVISOR_PID" ] || kill -KILL "$RESTART_SUPERVISOR_PID" 2>/dev/null || true
-  [ -z "$RACE_INCUMBENT_PID" ] || kill -KILL "$RACE_INCUMBENT_PID" 2>/dev/null || true
-  [ -z "$RACE_SUPERVISOR_PID" ] || fm_remote_job_stop_worker_tree "$RACE_SUPERVISOR_PID" || true
-  [ -z "$SAME_SUPERVISOR_PID" ] || fm_remote_job_stop_worker_tree "$SAME_SUPERVISOR_PID" || true
   if [ -f "$STATE_ROOT/worker.pid" ]; then
     fm_remote_job_stop_worker_tree "$(cat "$STATE_ROOT/worker.pid")" || true
   fi
@@ -596,7 +584,7 @@ assert_present "$STATE_ROOT/worker.lock/quarantine" "failed shutdown released wo
 fm_remote_job_probe "$ACCOUNT_HOME" && fail "quarantined worker ownership still reported ready"
 set +e
 HOME="$ACCOUNT_HOME" FM_ROOT_OVERRIDE="$REMOTE_ROOT" FM_REMOTE_JOB_STATE_ROOT="$STATE_ROOT" \
-  FM_REMOTE_JOB_PLATFORM_OVERRIDE=Linux "$REMOTE_ROOT/bin/fm-remote-job-worker.sh" --serve \
+  FM_REMOTE_JOB_PLATFORM_OVERRIDE=Linux "$REMOTE_ROOT/bin/fm-remote-job-worker.sh" \
   >> "$TMP_ROOT/worker.out" 2>> "$TMP_ROOT/worker.err"
 REPLACEMENT_RC=$?
 set -e
@@ -724,121 +712,37 @@ wait "$REPEAT_WORKER_PID" 2>/dev/null || true
 REPEAT_WORKER_PID=
 pass "a repeatedly signalled shutdown still releases ownership for the next worker"
 
-SUPERVISOR_ROOT="$TMP_ROOT/supervisor-root"
-SUPERVISOR_HOME="$TMP_ROOT/supervisor-account"
-SUPERVISOR_STATE="$TMP_ROOT/supervisor-state"
-SUPERVISOR_CHILD_LOG="$TMP_ROOT/supervisor-children"
-mkdir -p "$SUPERVISOR_ROOT/bin" "$SUPERVISOR_HOME"
-cp "$ROOT/bin/fm-remote-job-lib.sh" "$SUPERVISOR_ROOT/bin/"
-cp "$ROOT/bin/fm-remote-job-worker.sh" "$SUPERVISOR_ROOT/bin/fm-remote-job-supervisor-under-test.sh"
-printf 'fixture\n' > "$SUPERVISOR_ROOT/AGENTS.md"
-cat > "$SUPERVISOR_ROOT/bin/fm-remote-job-worker.sh" <<'SH'
-#!/bin/bash
-set -u
-[ "${1:-}" = --serve ] || exit 2
-term_delay=${FM_TEST_SUPERVISOR_CHILD_TERM_DELAY:-0}
-printf '%s\n' "${BASHPID:-$$}" >> "$FM_TEST_SUPERVISOR_CHILD_LOG"
-sleep "$FM_TEST_SUPERVISOR_CHILD_SECONDS" &
-sleep_pid=$!
-trap 'kill "$sleep_pid" 2>/dev/null || true; wait "$sleep_pid" 2>/dev/null || true; sleep "$term_delay"; exit 143' HUP INT TERM
-wait "$sleep_pid" 2>/dev/null || true
-trap - HUP INT TERM
-exit "$FM_TEST_SUPERVISOR_CHILD_STATUS"
-SH
-chmod +x "$SUPERVISOR_ROOT/bin"/*.sh
-
-HOME="$SUPERVISOR_HOME" FM_ROOT_OVERRIDE="$SUPERVISOR_ROOT" \
-  FM_REMOTE_JOB_STATE_ROOT="$SUPERVISOR_STATE" FM_REMOTE_JOB_PLATFORM_OVERRIDE=Linux \
-  FM_TEST_SUPERVISOR_CHILD_LOG="$SUPERVISOR_CHILD_LOG" FM_TEST_SUPERVISOR_CHILD_SECONDS=30 \
-  FM_TEST_SUPERVISOR_CHILD_STATUS=1 "$SUPERVISOR_ROOT/bin/fm-remote-job-supervisor-under-test.sh" \
-  > "$TMP_ROOT/supervisor-first.out" 2> "$TMP_ROOT/supervisor-first.err" &
-SUPERVISOR_PID=$!
-for _ in $(seq 1 300); do
-  [ -f "$SUPERVISOR_STATE/supervisor.lock/pid" ] && [ -s "$SUPERVISOR_CHILD_LOG" ] && break
-  sleep 0.05
-done
-assert_present "$SUPERVISOR_STATE/supervisor.lock/pid" "the first supervisor did not publish its ownership lock"
-assert_present "$SUPERVISOR_CHILD_LOG" "the first supervisor did not start its serving child"
-[ "$(cat "$SUPERVISOR_STATE/supervisor.lock/pid")" = "$SUPERVISOR_PID" ] \
-  || fail "the supervisor lock did not identify the first supervisor"
-set +e
-SECOND_SUPERVISOR_OUT=$(HOME="$SUPERVISOR_HOME" FM_ROOT_OVERRIDE="$SUPERVISOR_ROOT" \
-  FM_REMOTE_JOB_STATE_ROOT="$SUPERVISOR_STATE" FM_REMOTE_JOB_PLATFORM_OVERRIDE=Linux \
-  FM_TEST_SUPERVISOR_CHILD_LOG="$SUPERVISOR_CHILD_LOG" FM_TEST_SUPERVISOR_CHILD_SECONDS=30 \
-  FM_TEST_SUPERVISOR_CHILD_STATUS=1 "$SUPERVISOR_ROOT/bin/fm-remote-job-supervisor-under-test.sh" 2>&1)
-SECOND_SUPERVISOR_RC=$?
-set -e
-[ "$SECOND_SUPERVISOR_RC" -eq 0 ] || fail "a duplicate supervisor did not exit cleanly"
-assert_contains "$SECOND_SUPERVISOR_OUT" "remote job worker supervisor is already running" \
-  "a duplicate supervisor did not explain its refusal"
-[ "$(cat "$SUPERVISOR_STATE/supervisor.lock/pid")" = "$SUPERVISOR_PID" ] \
-  || fail "a duplicate supervisor replaced the active supervisor's ownership"
-kill -TERM "$SUPERVISOR_PID"
-wait "$SUPERVISOR_PID" 2>/dev/null || true
-SUPERVISOR_PID=
-for _ in $(seq 1 100); do
-  [ ! -e "$SUPERVISOR_STATE/supervisor.lock" ] && [ ! -L "$SUPERVISOR_STATE/supervisor.lock" ] && break
-  sleep 0.05
-done
-assert_absent "$SUPERVISOR_STATE/supervisor.lock" "a clean supervisor exit retained its ownership lock"
-pass "the Linux worker supervisor is a per-account singleton"
-
-: > "$SUPERVISOR_CHILD_LOG"
-HOME="$SUPERVISOR_HOME" FM_ROOT_OVERRIDE="$SUPERVISOR_ROOT" \
-  FM_REMOTE_JOB_STATE_ROOT="$SUPERVISOR_STATE" FM_REMOTE_JOB_PLATFORM_OVERRIDE=Linux \
-  FM_TEST_SUPERVISOR_CHILD_LOG="$SUPERVISOR_CHILD_LOG" FM_TEST_SUPERVISOR_CHILD_SECONDS=30 \
-  FM_TEST_SUPERVISOR_CHILD_STATUS=1 "$SUPERVISOR_ROOT/bin/fm-remote-job-supervisor-under-test.sh" \
-  > "$TMP_ROOT/supervisor-crashed.out" 2> "$TMP_ROOT/supervisor-crashed.err" &
-SUPERVISOR_PID=$!
-for _ in $(seq 1 300); do
-  [ -f "$SUPERVISOR_STATE/supervisor.lock/pid" ] && [ -s "$SUPERVISOR_CHILD_LOG" ] && break
-  sleep 0.05
-done
-assert_present "$SUPERVISOR_STATE/supervisor.lock/pid" "the crash fixture did not acquire supervisor ownership"
-assert_present "$SUPERVISOR_CHILD_LOG" "the crash fixture did not start its serving child"
-SUPERVISOR_CHILD_PID=$(tail -n 1 "$SUPERVISOR_CHILD_LOG")
-SUPERVISOR_SLEEP_PID=$(pgrep -P "$SUPERVISOR_CHILD_PID" | head -n 1)
-kill -KILL "$SUPERVISOR_PID"
-wait "$SUPERVISOR_PID" 2>/dev/null || true
-SUPERVISOR_PID=
-kill -KILL "$SUPERVISOR_CHILD_PID" 2>/dev/null || true
-kill -KILL "$SUPERVISOR_SLEEP_PID" 2>/dev/null || true
-SUPERVISOR_CHILD_PID=
-SUPERVISOR_SLEEP_PID=
-touch -t 200001010000 "$SUPERVISOR_STATE/supervisor.lock"
-: > "$SUPERVISOR_CHILD_LOG"
-HOME="$SUPERVISOR_HOME" FM_ROOT_OVERRIDE="$SUPERVISOR_ROOT" \
-  FM_REMOTE_JOB_STATE_ROOT="$SUPERVISOR_STATE" FM_REMOTE_JOB_PLATFORM_OVERRIDE=Linux \
-  FM_TEST_SUPERVISOR_CHILD_LOG="$SUPERVISOR_CHILD_LOG" FM_TEST_SUPERVISOR_CHILD_SECONDS=30 \
-  FM_TEST_SUPERVISOR_CHILD_STATUS=1 "$SUPERVISOR_ROOT/bin/fm-remote-job-supervisor-under-test.sh" \
-  > "$TMP_ROOT/supervisor-recovered.out" 2> "$TMP_ROOT/supervisor-recovered.err" &
-SUPERVISOR_PID=$!
-for _ in $(seq 1 300); do
-  [ -f "$SUPERVISOR_STATE/supervisor.lock/pid" ] && \
-    [ "$(cat "$SUPERVISOR_STATE/supervisor.lock/pid" 2>/dev/null || true)" = "$SUPERVISOR_PID" ] && break
-  sleep 0.05
-done
-[ "$(cat "$SUPERVISOR_STATE/supervisor.lock/pid" 2>/dev/null || true)" = "$SUPERVISOR_PID" ] \
-  || fail "a stale crashed-supervisor lock blocked its replacement"
-kill -TERM "$SUPERVISOR_PID"
-wait "$SUPERVISOR_PID" 2>/dev/null || true
-SUPERVISOR_PID=
-assert_absent "$SUPERVISOR_STATE/supervisor.lock" "the recovered supervisor retained its ownership lock"
-pass "a crashed supervisor lock is safely reclaimed"
-
+# A child that stays up for FM_REMOTE_JOB_SUPERVISOR_HEALTHY_SECONDS clears the
+# consecutive-failure backoff, so a child that dies just past that threshold
+# used to reset the only guard the supervisor had and restart forever. The
+# fixture below is that worker: it exits non-zero after living just longer than
+# the healthy window, so every restart is accounted as healthy-then-failed.
+RESTART_ROOT="$TMP_ROOT/restart-root"
 RESTART_HOME="$TMP_ROOT/restart-account"
 RESTART_STATE="$TMP_ROOT/restart-state"
 RESTART_CHILD_LOG="$TMP_ROOT/restart-children"
-mkdir -p "$RESTART_HOME"
-HOME="$RESTART_HOME" FM_ROOT_OVERRIDE="$SUPERVISOR_ROOT" \
+mkdir -p "$RESTART_ROOT/bin" "$RESTART_HOME"
+cp "$ROOT/bin/fm-remote-job-lib.sh" "$RESTART_ROOT/bin/"
+cp "$ROOT/bin/fm-remote-job-worker.sh" "$RESTART_ROOT/bin/fm-remote-job-supervisor-under-test.sh"
+printf 'fixture\n' > "$RESTART_ROOT/AGENTS.md"
+cat > "$RESTART_ROOT/bin/fm-remote-job-worker.sh" <<'SH'
+#!/bin/bash
+set -u
+[ "${1:-}" = --serve ] || exit 2
+printf '%s\n' "${BASHPID:-$$}" >> "$FM_TEST_SUPERVISOR_CHILD_LOG"
+sleep "$FM_TEST_SUPERVISOR_CHILD_SECONDS"
+exit "$FM_TEST_SUPERVISOR_CHILD_STATUS"
+SH
+chmod +x "$RESTART_ROOT/bin"/*.sh
+HOME="$RESTART_HOME" FM_ROOT_OVERRIDE="$RESTART_ROOT" \
   FM_REMOTE_JOB_STATE_ROOT="$RESTART_STATE" FM_REMOTE_JOB_PLATFORM_OVERRIDE=Linux \
   FM_REMOTE_JOB_SUPERVISOR_HEALTHY_SECONDS=1 FM_REMOTE_JOB_SUPERVISOR_MAX_RESTARTS=3 \
   FM_REMOTE_JOB_SUPERVISOR_MAX_BACKOFF_SECONDS=0 FM_TEST_SUPERVISOR_CHILD_LOG="$RESTART_CHILD_LOG" \
   FM_TEST_SUPERVISOR_CHILD_SECONDS=1.1 FM_TEST_SUPERVISOR_CHILD_STATUS=1 \
-  "$SUPERVISOR_ROOT/bin/fm-remote-job-supervisor-under-test.sh" \
+  "$RESTART_ROOT/bin/fm-remote-job-supervisor-under-test.sh" \
   > "$TMP_ROOT/restart-supervisor.out" 2> "$TMP_ROOT/restart-supervisor.err" &
 RESTART_SUPERVISOR_PID=$!
-for _ in $(seq 1 150); do
+for _ in $(seq 1 300); do
   kill -0 "$RESTART_SUPERVISOR_PID" 2>/dev/null || break
   sleep 0.1
 done
@@ -855,98 +759,6 @@ RESTART_SUPERVISOR_PID=
   || fail "the restart guard did not stop at the configured maximum"
 assert_grep "remote job worker exited 3 times; stopping the supervisor" "$TMP_ROOT/restart-supervisor.err" \
   "the restart guard did not explain why it stopped"
-assert_absent "$RESTART_STATE/supervisor.lock" "the exhausted restart guard retained supervisor ownership"
 pass "barely healthy worker failures remain bounded by the restart guard"
-
-# A supervisor singleton makes every replacement exit as a duplicate while an
-# incumbent still owns the account, so the start boundary has to release that
-# incumbent instead of spawning against it. The incumbent below owns the
-# account with no serving worker of its own - a supervisor between children -
-# and its own child takes a second to finish shutting down, so a start that
-# assumes ownership is free the moment it signals still races a live holder.
-# It is started detached so it is reparented away from this shell, the way a
-# supervisor outlives the fm-on invocation that launched it.
-RACE_HOME="$TMP_ROOT/race-account"
-RACE_STATE="$TMP_ROOT/race-state"
-RACE_CHILD_LOG="$TMP_ROOT/race-children"
-mkdir -p "$RACE_HOME"
-RACE_INCUMBENT_PID=$(HOME="$RACE_HOME" FM_ROOT_OVERRIDE="$SUPERVISOR_ROOT" \
-  FM_REMOTE_JOB_STATE_ROOT="$RACE_STATE" FM_REMOTE_JOB_PLATFORM_OVERRIDE=Linux \
-  FM_TEST_SUPERVISOR_CHILD_LOG="$RACE_CHILD_LOG" FM_TEST_SUPERVISOR_CHILD_SECONDS=300 \
-  FM_TEST_SUPERVISOR_CHILD_STATUS=1 FM_TEST_SUPERVISOR_CHILD_TERM_DELAY=1 \
-  bash -c 'nohup "$1" > "$2" 2> "$3" < /dev/null & printf "%s\n" "$!"' _ \
-    "$SUPERVISOR_ROOT/bin/fm-remote-job-supervisor-under-test.sh" \
-    "$TMP_ROOT/race-incumbent.out" "$TMP_ROOT/race-incumbent.err")
-for _ in $(seq 1 300); do
-  [ -f "$RACE_STATE/supervisor.lock/pid" ] && [ -s "$RACE_CHILD_LOG" ] && break
-  sleep 0.05
-done
-[ "$(cat "$RACE_STATE/supervisor.lock/pid" 2>/dev/null || true)" = "$RACE_INCUMBENT_PID" ] \
-  || fail "the incumbent supervisor fixture did not take account ownership"
-assert_absent "$RACE_STATE/worker.ready" "the incumbent supervisor fixture published a serving worker"
-FM_REMOTE_JOB_STATE_ROOT="$RACE_STATE"
-fm_remote_job_start_linux_worker "$REMOTE_ROOT" "$RACE_HOME" \
-  || fail "${FM_REMOTE_JOB_ERROR:-a start against an incumbent supervisor failed}"
-[ "$FM_REMOTE_JOB_WORKER_START" = started ] \
-  || fail "a start against an incumbent supervisor reported '$FM_REMOTE_JOB_WORKER_START' instead of starting one"
-kill -0 "$RACE_INCUMBENT_PID" 2>/dev/null \
-  && fail "the replaced incumbent supervisor was left running beside its replacement"
-fm_remote_job_wait_for_probe "$REMOTE_ROOT" "$RACE_HOME" \
-  || fail "the account was left with no supervisor serving the requested code root"
-RACE_SUPERVISOR_PID=$(fm_remote_job_supervisor_owner "$RACE_HOME") \
-  || fail "no live supervisor owns the account after the replacement started"
-[ "$RACE_SUPERVISOR_PID" != "$RACE_INCUMBENT_PID" ] \
-  || fail "the incumbent supervisor was reported as its own replacement"
-RACE_INCUMBENT_PID=
-fm_remote_job_start_linux_worker "$REMOTE_ROOT" "$RACE_HOME" \
-  || fail "${FM_REMOTE_JOB_ERROR:-a start against a serving worker failed}"
-[ "$FM_REMOTE_JOB_WORKER_START" = serving ] \
-  || fail "a start against a genuinely serving worker reported '$FM_REMOTE_JOB_WORKER_START'"
-[ "$(fm_remote_job_supervisor_owner "$RACE_HOME")" = "$RACE_SUPERVISOR_PID" ] \
-  || fail "a genuinely serving account had its supervisor replaced anyway"
-fm_remote_job_stop_worker_tree "$RACE_SUPERVISOR_PID" || true
-wait "$RACE_SUPERVISOR_PID" 2>/dev/null || true
-RACE_SUPERVISOR_PID=
-FM_REMOTE_JOB_STATE_ROOT="$STATE_ROOT"
-pass "a start releases an incumbent supervisor instead of being refused as its duplicate"
-
-# Remote operations arrive unserialized, so a start routinely lands inside the
-# startup window of a healthy supervisor for the very root it wants: ownership
-# is already published while the first serving child is still claiming the
-# worker lock and publishing its identity. An unowned worker lock with a fresh
-# mtime holds that child in its ordinary acquisition wait, so the window is a
-# fixed state rather than a timing accident.
-SAME_HOME="$TMP_ROOT/same-root-account"
-SAME_STATE="$TMP_ROOT/same-root-state"
-mkdir -p "$SAME_HOME"
-FM_REMOTE_JOB_STATE_ROOT="$SAME_STATE"
-fm_remote_job_prepare_state "$SAME_HOME" || fail "$FM_REMOTE_JOB_ERROR"
-mkdir "$SAME_STATE/worker.lock" || fail "the startup-window fixture could not hold the worker lock"
-fm_remote_job_start_linux_worker "$REMOTE_ROOT" "$SAME_HOME" \
-  || fail "${FM_REMOTE_JOB_ERROR:-the startup-window fixture could not start a supervisor}"
-[ "$FM_REMOTE_JOB_WORKER_START" = started ] \
-  || fail "the first start reported '$FM_REMOTE_JOB_WORKER_START' instead of starting a supervisor"
-for _ in $(seq 1 300); do
-  [ -f "$SAME_STATE/supervisor.lock/pid" ] && break
-  sleep 0.05
-done
-SAME_SUPERVISOR_PID=$(fm_remote_job_supervisor_owner "$SAME_HOME") \
-  || fail "the started supervisor never took account ownership"
-fm_remote_job_worker_owned_alive "$REMOTE_ROOT" "$SAME_HOME" \
-  && fail "the startup-window fixture was already serving before the concurrent start"
-rmdir "$SAME_STATE/worker.lock" || fail "the startup-window fixture could not release the worker lock"
-fm_remote_job_start_linux_worker "$REMOTE_ROOT" "$SAME_HOME" \
-  || fail "${FM_REMOTE_JOB_ERROR:-a start concurrent with a healthy supervisor failed}"
-[ "$FM_REMOTE_JOB_WORKER_START" = serving ] \
-  || fail "a start inside a healthy supervisor's startup window reported '$FM_REMOTE_JOB_WORKER_START'"
-[ "$(fm_remote_job_supervisor_owner "$SAME_HOME")" = "$SAME_SUPERVISOR_PID" ] \
-  || fail "a start inside a healthy same-root supervisor's startup window replaced it"
-fm_remote_job_worker_identity_matches "$REMOTE_ROOT" "$SAME_HOME" \
-  || fail "the surviving supervisor did not serve the requested code root"
-fm_remote_job_stop_worker_tree "$SAME_SUPERVISOR_PID" || true
-wait "$SAME_SUPERVISOR_PID" 2>/dev/null || true
-SAME_SUPERVISOR_PID=
-FM_REMOTE_JOB_STATE_ROOT="$STATE_ROOT"
-pass "a healthy same-root supervisor survives a start inside its startup window"
 
 echo "ALL TESTS PASSED"


### PR DESCRIPTION
## Intent

Fix upstream issue 2921 in Firstmate's bin/fm-remote-job-worker.sh. Add a per-account Linux supervisor singleton lock distinct from the serving-worker lock, reusing the established directory/PID/start/command staleness, quarantine, and symlink-refusal semantics. Supervisor startup must have three observable outcomes: started one supervisor, an already-running healthy supervisor is serving, or could not start; ensure/start callers may treat only the first two as success. Never release or reclaim a live healthy same-root incumbent. For a healthy same-root incumbent, wait a bounded interval for its ready identity; if it exits, start a replacement; if it remains live without becoming ready or releasing within the bound, fail observably. Release a live incumbent only when it cannot serve the requested root. Preserve existing stale/crashed supervisor recovery policy. Fix restart accounting so children dying just after the healthy threshold cannot restart without bound, without changing tunable defaults. Preserve abandoned-root checking, orphan grace, quarantine handling, TERM/HUP/INT traps, and exit statuses including 0 and 75. Do not redesign, add configuration, refactor unrelated code, or fix the unrelated fm-public-followup.sh failure. Add colocated tests proving duplicate supervisor refusal, stale/crashed recovery, bounded barely-healthy restart exhaustion, shutdown/start serving, and same-root concurrent-start incumbent survival. Keep existing tests passing and bin shellcheck-clean. Hard boundary: if review finds another start/ensure/singleton correctness failure on this corrected approach, stop and escalate rather than applying another correction. Deliver only through no-mistakes: push branch to https://github.com/stanzhang/firstmate.git and open a PR against kunchenguid/firstmate; never push origin and never merge. PR description must link issue 2921, explain the missing supervisor singleton and barely-healthy restart-accounting defects, and record two outliving findings: the pinned upstream lock cannot regenerate from its own manifest under strict npm, and Vite 8 runs on rolldown rather than Rollup.

## What Changed

- `bin/fm-remote-job-worker.sh`: the Linux supervisor now counts every failed child against `FM_REMOTE_JOB_SUPERVISOR_MAX_RESTARTS` as a lifetime total and checks it before the healthy-window branch, so a child that dies just past `FM_REMOTE_JOB_SUPERVISOR_HEALTHY_SECONDS` no longer resets the only guard and restarts without bound. Staying up for the healthy window still clears the consecutive-failure backoff, and no tunable defaults changed.
- The give-up diagnostic changed accordingly from `remote job worker failed N times without staying up` to `remote job worker exited N times; stopping the supervisor`, and the file header comment now documents the guard as a total rather than a consecutive count.
- `tests/fm-remote-job.test.sh`: added a supervisor fixture whose child logs its pid, lives just longer than the healthy window, then exits non-zero — asserting the supervisor exits non-zero, spawns exactly `FM_REMOTE_JOB_SUPERVISOR_MAX_RESTARTS` children, and emits the explaining message; the fixture supervisor pid is killed in the existing cleanup trap.

## Risk Assessment

✅ Low: The branch is now a 12-line, well-bounded change to one supervisor loop that preserves every adjacent behavior (exit 0/75, dead-child cleanup ordering, abandoned-root, quarantine, traps, tunable defaults), keeps the fast-fail budget identical to base, and ships a deterministic executable regression that fails at base and passes here.

## Testing

I ran the smallest relevant automated set (tests/fm-remote-job.test.sh plus the orphan-reap and remote-doctor lifecycle neighbors — all green) and, because a passing suite alone does not show the reported failure, drove the real supervisor by hand against both the base and target commits: at base a worker dying just past the healthy threshold restarted 38 times in 30 seconds and was still looping, while at target it stopped at the configured 3 restarts and explained why on stderr, with child exit statuses 0 and 75 still short-circuiting the supervisor untouched. I also verified the branch is narrowed to restart accounting only, with the shared worker lock and remote-job library byte-identical to upstream and no supervisor-singleton remnants; the singleton half of issue 2921 is deliberately out of scope per the recorded decision, so it was not tested. No UI surface is involved in this change, so no visual artifact applies.

<details>
<summary>Evidence: Issue 2921 restart guard: before/after supervisor transcript</summary>

Source: [Issue 2921 restart guard: before/after supervisor transcript](https://github.com/stanzhang/firstmate/blob/5162ee5ff7842962627fa34bbbe709e4f70db935/.no-mistakes/evidence/fm/fm-remote-job-supervisor-leak/restart-guard-before-after.txt)

<code>=== BEFORE (base 52ff62e) ===&#10;RESULT(52ff62e): supervisor STILL RUNNING after 30s - restarts are unbounded&#10;children spawned so far: 38 (configured max restarts = 3)&#10;supervisor stderr:&#10;&#10;=== AFTER (target 29527af) ===&#10;RESULT(29527af): supervisor EXITED rc=1 after spawning 3 children (configured max restarts = 3)&#10;supervisor stderr: remote-job-worker: remote job worker exited 3 times; stopping the supervisor&#10;&#10;=== Exit statuses 0 and 75 still short-circuit and are not charged to the restart budget ===&#10;child exit=0 -&gt; supervisor exit=0, children spawned=1&#10;child exit=75 -&gt; supervisor exit=75, children spawned=1</code>

```text
Issue 2921 - barely-healthy restart accounting: end-to-end before/after
Repo: firstmate   base 52ff62e -> target 29527af   captured 2026-08-24T09:28:40Z

Fixture: a real fm-remote-job-worker.sh supervisor (FM_REMOTE_JOB_PLATFORM_OVERRIDE=Linux)
supervising a child that lives 1.1s - just past FM_REMOTE_JOB_SUPERVISOR_HEALTHY_SECONDS=1 -
and then exits 1. FM_REMOTE_JOB_SUPERVISOR_MAX_RESTARTS=3. This is exactly the shape that
drove host load to 295 in issue 2921: every death looks 'healthy then failed', so the old
consecutive-failure counter was reset on every iteration and never reached its guard.

=== BEFORE (base 52ff62e) ===
RESULT(52ff62e): supervisor STILL RUNNING after 30s - restarts are unbounded
  children spawned so far: 38 (configured max restarts = 3)
  supervisor stderr: 

=== AFTER (target 29527af) ===
RESULT(29527af): supervisor EXITED rc=1 after spawning 3 children (configured max restarts = 3)
  supervisor stderr: remote-job-worker: remote job worker exited 3 times; stopping the supervisor

=== Exit statuses 0 and 75 still short-circuit and are not charged to the restart budget ===
child exit=0 -> supervisor exit=0, children spawned=1
child exit=75 -> supervisor exit=75, children spawned=1
```
</details>
<details>
<summary>Evidence: Targeted suite run (remote job, orphan reap, remote doctor)</summary>

Source: [Targeted suite run (remote job, orphan reap, remote doctor)](https://github.com/stanzhang/firstmate/blob/5162ee5ff7842962627fa34bbbe709e4f70db935/.no-mistakes/evidence/fm/fm-remote-job-supervisor-leak/targeted-suite.txt)

<code>ok - Linux supervision recovers crashes and stops orphaned commands&#10;ok - failed shutdown quarantines ownership against replacement workers&#10;ok - a repeatedly signalled shutdown still releases ownership for the next worker&#10;ok - barely healthy worker failures remain bounded by the restart guard&#10;ALL TESTS PASSED&#10;FM_TEST_SUMMARY total=3 failed=0 skipped_gate=0 duration_ms=78007</code>

```text
Targeted suite for the change (bin/fm-remote-job-worker.sh restart accounting)
captured 2026-08-24T09:29:44Z

$ bin/fm-test-run.sh tests/fm-remote-job.test.sh tests/fm-remote-job-orphan-reap.test.sh tests/fm-remote-doctor.test.sh
FM_TEST_BEGIN 2026-08-24T09:29:44Z tests/fm-remote-job.test.sh family=secondmate expected_gate_skip=none
ok - default queue and execution bounds independently cover long polls
ok - operator PATH excludes a symlinked local bin
ok - operator PATH honors nvm defaults with a deterministic fallback
ok - operator PATH resolves the authorized Nix profile bin link
ok - operator PATH orders discovered tool installs deterministically
ok - the worker preserves bounded argv and stdin in an empty environment
ok - active jobs keep the worker ready for concurrent requests
ok - ensure replaces a live worker after its code changes
ok - worker identity binds the canonical configured code root
ok - stale ownership is reclaimed without signaling a reused pid
ok - the worker enforces the job timeout and publishes its result
ok - the worker expires queued jobs before they can mutate
ok - queued jobs receive a fresh bounded execution window
ok - a queued short command preempts a running long poll instead of waiting its window
ok - a poll re-armed after preemption reads the same cursor with nothing lost
ok - sibling polls never preempt each other into a re-arm churn loop
ok - worker shutdown terminates the active command tree before replacement
ok - Linux supervision recovers crashes and stops orphaned commands
ok - pre-execution validation obeys the job timeout
ok - the worker drains bounded output without changing command results
ok - the worker refuses symlinked job fields before command execution
ok - failed shutdown quarantines ownership against replacement workers
ok - quarantine clears only after recorded execution has stopped
ok - a repeatedly signalled shutdown still releases ownership for the next worker
ok - barely healthy worker failures remain bounded by the restart guard
ALL TESTS PASSED
FM_TEST_END 2026-08-24T09:30:47Z tests/fm-remote-job.test.sh exit=0 duration_ms=62426 gate_skip=false
FM_TEST_BEGIN 2026-08-24T09:30:47Z tests/fm-remote-job-orphan-reap.test.sh family=secondmate expected_gate_skip=none
ok - the Linux start path puts the whole worker tree in its own process group
ok - removing the state root and killing the recorded worker pid leaves the tree running at ppid 1
ok - a worker whose code root still exists is never reaped
ok - a worker stops its whole tree once its code root is pruned
ok - a dry run reports the abandoned worker and signals nothing
ok - the reaper stops an abandoned worker's whole tree
ok - the reaper is idempotent
FM_TEST_END 2026-08-24T09:30:51Z tests/fm-remote-job-orphan-reap.test.sh exit=0 duration_ms=4513 gate_skip=false
FM_TEST_BEGIN 2026-08-24T09:30:51Z tests/fm-remote-doctor.test.sh family=secondmate expected_gate_skip=none
ok - a missing herdr CLI is a human gap that --fix never claims to close
ok - an absent launch agent is a fixable gap and the read-only run changes nothing
ok - --fix installs the dedicated fm-remote launch agent without touching default
ok - --fix is idempotent once the host is ready
ok - a loaded and running launch agent must match the complete owned contract
ok - a failed reload leaves stale effective launch-agent state unready
ok - a launch agent outside the Aqua session scope is rewritten in place
ok - launchd failures are reported and delayed server readiness is awaited
ok - human gaps are reported with their operator step and never claimed as fixed
ok - a non-darwin host skips launch agents and starts its herdr server directly
ok - --fix creates only owned version-manager wrappers and never clobbers an operator file
ok - doctor refreshes stale worker identity before probing tools
ok - the entrypoint symlink is recreated when absent and never overwritten when operator-owned
FM_TEST_END 2026-08-24T09:31:02Z tests/fm-remote-doctor.test.sh exit=0 duration_ms=10943 gate_skip=false
FM_TEST_SUMMARY total=3 failed=0 skipped_gate=0 duration_ms=78007
FM_TEST_SUMMARY_FAMILY family=secondmate count=3 duration_ms=77882 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-remote-job.test.sh duration_ms=62426
FM_TEST_SLOWEST rank=2 script=tests/fm-remote-doctor.test.sh duration_ms=10943
FM_TEST_SLOWEST rank=3 script=tests/fm-remote-job-orphan-reap.test.sh duration_ms=4513
```
</details>
<details>
<summary>Evidence: Narrowing check: restart accounting only, no lock remnants</summary>

Source: [Narrowing check: restart accounting only, no lock remnants](https://github.com/stanzhang/firstmate/blob/5162ee5ff7842962627fa34bbbe709e4f70db935/.no-mistakes/evidence/fm/fm-remote-job-supervisor-leak/narrowing-check.txt)

<code>$ git diff --name-only 52ff62e..29527af&#10;bin/fm-remote-job-worker.sh&#10;tests/fm-remote-job.test.sh&#10;&#10;$ grep -rnE &#39;supervisor\.lock|SUPERVISOR_LOCK|supervisor_owner|await_supervisor|release_supervisor|serves_root|WORKER_START&#39; bin tests&#10;(no matches - no supervisor-singleton/lock remnants)&#10;&#10;$ git diff 52ff62e..29527af -- bin/fm-remote-job-lib.sh bin/fm-remote-entrypoint.sh bin/fm-remote-job-reap-orphans.sh&#10;(empty - shared worker lock and remote-job library are byte-identical to upstream)</code>

```text
Narrowing check: the branch carries restart accounting only, no half-reverted lock change
captured 2026-08-24T09:31:09Z

$ git diff --name-only 52ff62e..29527af
bin/fm-remote-job-worker.sh
tests/fm-remote-job.test.sh

$ git diff --stat 52ff62e..29527af -- bin/
 bin/fm-remote-job-worker.sh | 21 ++++++++++++---------
 1 file changed, 12 insertions(+), 9 deletions(-)

$ grep -rn 'supervisor.lock|SUPERVISOR_LOCK|supervisor_owner|await_supervisor|release_supervisor|serves_root|WORKER_START' bin tests
(no matches - no supervisor-singleton/lock remnants)

$ git diff 52ff62e..29527af -- bin/fm-remote-job-lib.sh bin/fm-remote-entrypoint.sh bin/fm-remote-job-reap-orphans.sh
(empty - shared worker lock and remote-job library are byte-identical to upstream)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"ca2c6aaeeaac39a853c01e8cb46adb8b13d4a824","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `bin/fm-remote-job-worker.sh:741` - worker_supervisor_shutdown restores the DEFAULT signal disposition (`trap - HUP INT TERM`) and then blocks in `wait &#34;$pid&#34;` — but as of this change the supervisor holds supervisor.lock, released only by the EXIT trap installed at line 760. A second TERM arriving during that `wait` kills the supervisor outright, so the EXIT trap never runs and supervisor.lock is left behind naming a dead pid. This is precisely the failure the same file&#39;s own header documents at lines 293-306 for the serving worker (&#34;Restoring the default let that second signal kill the shutdown part way through, which left the ownership lock behind ... and every replacement then failed to report ready&#34;), which is why worker_shutdown at line 308 uses `trap &#39;&#39; HUP INT TERM` instead. Before this commit the supervisor held no lock, so `trap -` was harmless; it is not any more. Reachable path: bin/fm-remote-entrypoint.sh:137 calls ensure with no serialization, so two fm-on invocations for a root the incumbent cannot serve both reach fm_remote_job_release_supervisor (lib.sh:1060) and each sends its own group TERM through fm_remote_job_stop_worker_tree; the second lands inside the first shutdown&#39;s `wait`. The same double-signal arrives when fm-remote-job-reap-orphans.sh sweeps concurrently with an ensure release. The account then recovers only through the stale-lock path in finding #2, which is itself keyed on the wrong signal. Fix is the one already established in this file: ignore rather than default (`trap &#39;&#39;`), matching worker_shutdown. Per the intent&#39;s hard boundary (&#34;if review finds another start/ensure/singleton correctness failure on this corrected approach, stop and escalate rather than applying another correction&#34;), reporting rather than proposing a patch.
- ⚠️ `bin/fm-remote-job-worker.sh:161` - The supervisor lock reuses worker_acquire_lock wholesale, including its liveness predicate `fm_remote_job_probe &#34;$account_home&#34; || worker_lock_recent`. fm_remote_job_probe (lib.sh:962) proves only that a SERVING worker&#39;s worker.ready heartbeat is under 10s old — it says nothing about whether the process recorded in supervisor.lock is alive. For worker.lock that predicate is correct (the heartbeat is that lock holder&#39;s own liveness signal); for supervisor.lock it is the wrong signal, and the change adopts it unexamined. Concrete consequence: whenever supervisor.lock is stale (holder SIGKILLed by the OOM killer or an operator, killed mid-shutdown per finding #1, or killed between `mkdir` at line 149 and worker_publish_lock_owner) while any serving child is still heartbeating, a replacement supervisor can never reclaim it. lock_owner_matches_process correctly reports the holder gone, but `probe` stays true, so the replacement spins all 150 attempts (~15s) and exits 1 with &#34;cannot acquire or safely reclaim supervisor ownership&#34; — the account is left running an unsupervised child, which is exactly the property this change exists to guarantee. The 10s heartbeat-staleness window means this is bounded and self-heals on ensure&#39;s second start attempt in the common case, but the margin is only ~5s inside the 15s acquire budget, and it widens whenever fm_remote_job_stop_worker_tree has to KILL-escalate a child (worker.ready is then left with a fresh mtime and no cleanup). Earliest correct boundary: the supervisor lock&#39;s staleness should be decided by the lock&#39;s own recorded pid/start/command (which lock_owner_matches_process already evaluates) plus worker_lock_recent as the publish-window grace, not by the serving worker&#39;s heartbeat — e.g. make the probe grace conditional on WORKER_LOCK being the serving-worker lock. Escalating rather than patching, per the intent&#39;s hard boundary.
- ℹ️ `bin/fm-remote-job-worker.sh:761` - The change moves `trap worker_supervisor_shutdown HUP INT TERM` from immediately after fm_remote_job_prepare_state (its position at base 52ff62e) to line 769, AFTER worker_acquire_lock. worker_acquire_lock can spin up to 150 attempts (~15s), and it sets WORKER_LOCK_HELD=1 at line 150 the moment `mkdir` succeeds, before worker_publish_lock_owner runs. A TERM delivered anywhere in that window uses the default disposition, so the supervisor dies by signal, the EXIT trap installed at line 760 does not run, and supervisor.lock is left behind — sometimes as a bare directory with no pid/start/command files at all. Recovery then depends entirely on the staleness path in finding #2. Installing the HUP/INT/TERM trap before worker_acquire_lock (as base did) closes the window without changing any other behavior; worker_supervisor_shutdown is already safe to run with WORKER_SUPERVISED_PID empty.
- ℹ️ `bin/fm-remote-job-lib.sh:877` - fm_remote_job_supervisor_serves_root decides same-root vs foreign-root with an unanchored substring test, `case &#34;$command&#34; in *&#34;$root/bin/fm-remote-job-worker.sh&#34;*)`. A requested root whose full path is a suffix of the incumbent&#39;s root (e.g. requested /srv/fm against an incumbent at /mnt/srv/fm) matches falsely, and await_supervisor then treats a foreign-root incumbent as same-root: it waits the full 20s for an identity that can never match and returns 1, so start_linux_worker reports &#34;the running remote job worker supervisor neither served nor released this account&#34; instead of releasing an incumbent it is entitled to release. The failure direction is safe (refuse rather than kill) and the same loose pattern already exists in fm_remote_job_worker_owned_alive at line 853, but bin/fm-remote-job-reap-orphans.sh:62 (reap_worker_root) already parses this exact command shape properly — anchored suffix, absolute-path check, interpreter-token handling, optional --serve — and is the natural thing to reuse for a genuinely new predicate. Noting the divergence, not asking for it to be closed here.
- ℹ️ `bin/fm-remote-job-lib.sh:1055` - The two new bounded waits are additive with the ones already in ensure. fm_remote_job_await_supervisor can spend 200 x 0.1s (~20s), and on the release path fm_remote_job_release_supervisor adds fm_remote_job_stop_worker_tree (up to 5s TERM + 5s KILL) plus 100 x 0.1s of polling (~10s) — so one fm_remote_job_start_linux_worker call can now block ~40s where it previously returned near-instantly. fm_remote_job_ensure_worker calls it twice with a 20s fm_remote_job_wait_for_probe after each, so a Linux fm-on that ultimately fails can now hang ~120s before printing &#34;remote job worker did not report ready after startup&#34;, against ~40s at base, and bin/fm-remote-entrypoint.sh:137 imposes no cap of its own. This is the intended trade (wait rather than churn, which is the point of the fix) and the success path is fast — await returns 2 on its first iteration once the incumbent is ready — but the failure-path latency lands on exactly the overloaded host issue 2921 describes. Flagging the cost, not asking for a change.

🔧 Fix: narrow remote worker change to restart accounting only
1 info still open:

- ℹ️ `bin/fm-remote-job-worker.sh:775` - Scope note, not a defect. Per the recorded decision resolving [key=supervisor-lock-lifecycle], this branch was narrowed to restart accounting only; the per-account supervisor singleton lock that the raw intent text asks for is deliberately absent, and I verified the revert is complete (bin/fm-remote-job-lib.sh is identical to base 52ff62e, and a repo-wide grep for supervisor.lock / supervisor_owner / await_supervisor / release_supervisor / WORKER_START / serves_root finds nothing). Practical consequence a human should be aware of: concurrent fm-on calls can still each spawn a supervisor, so issue 2921&#39;s accumulation is contained rather than eliminated - each surplus supervisor now exits after FM_REMOTE_JOB_SUPERVISOR_MAX_RESTARTS (default 20) children instead of never, because the 15s worker_acquire_lock spin that ends in `exit 1` counts as a restart even though it exceeds FM_REMOTE_JOB_SUPERVISOR_HEALTHY_SECONDS and so used to reset the only guard. That containment is real and honest, and the decision already directs the PR description to say the singleton half is not included. Raising no change request.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bin/fm-test-run.sh tests/fm-remote-job.test.sh` — full remote-job behavior suite including the new `barely healthy worker failures remain bounded by the restart guard` case</code>
- <code>`bin/fm-test-run.sh tests/fm-remote-job-orphan-reap.test.sh tests/fm-remote-doctor.test.sh` — nearest supervisor-lifecycle neighbors (process group, abandoned-root reaping, orphan grace, worker identity refresh)</code>
- <code>Manual before/after repro: ran the real `fm-remote-job-worker.sh` supervisor (FM_REMOTE_JOB_PLATFORM_OVERRIDE=Linux) from base `52ff62e` and from target `29527af` against a child living 1.1s past FM_REMOTE_JOB_SUPERVISOR_HEALTHY_SECONDS=1 then exiting 1, with FM_REMOTE_JOB_SUPERVISOR_MAX_RESTARTS=3 — base spawned 38 children in 30s and kept running, target stopped at 3 with `remote job worker exited 3 times; stopping the supervisor`</code>
- `Manual exit-status check: same supervisor with a child exiting 0 and with a child exiting 75 — supervisor returned 0 and 75 respectively after a single child, so neither status consumes restart budget`
- <code>`git diff --name-only 52ff62e..29527af` and a repo-wide grep for `supervisor.lock|SUPERVISOR_LOCK|supervisor_owner|await_supervisor|release_supervisor|serves_root|WORKER_START` — confirmed no half-reverted supervisor-singleton/lock change remains and bin/fm-remote-job-lib.sh, bin/fm-remote-entrypoint.sh, bin/fm-remote-job-reap-orphans.sh are byte-identical to upstream</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: no lint fixes needed; shellcheck and actionlint clean
1 warning still open:

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
