### PR TITLE
feat(bin): add idle-gated Mac mini self-reboot guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,9 @@ config/cmux-socket-password  optional cmux control-socket password; LOCAL, gitig
 config/wedge-alarm  optional away-mode wedge-alarm active-alert directives; LOCAL, gitignored; absent means auto (macOS Notification Center when available); see docs/wedge-alarm.md
 config/watched-tools.json  optional list of the tools this home depends on, read by the update check armed with bin/fm-tool-update-check.sh; LOCAL, gitignored, firstmate-maintained but human-editable, and NOT inherited by secondmate homes; see docs/configuration.md "Watched tool updates"
 config/x-mode.env    generated Relay watcher cadence; LOCAL, gitignored; source before arming watcher when present
+config/host-role  must equal exactly "mini" to arm bin/fm-mini-reboot-guard.sh's reboot execution on this host; LOCAL, gitignored, and not inherited; see docs/mini-reboot-guard.md
+config/mini-reboot-homes  explicit registry of FM_HOME paths bin/fm-mini-reboot-guard.sh idle-checks before a reboot attempt; LOCAL, gitignored, and not inherited; absent or empty means the guard never reboots; see docs/mini-reboot-guard.md
+config/mini-reboot-helper  path to the root-authorized reboot helper bin/fm-mini-reboot-guard.sh invokes when both conditions hold; LOCAL, gitignored, and not inherited; absent blocks the reboot attempt rather than faking it; see docs/mini-reboot-guard.md
 data/                personal fleet records; LOCAL, gitignored as a whole
   backlog.md         task queue, dependencies, history
   captain.md         this home's domain-local captain preferences and working style; LOCAL, gitignored, canonical even if harness memory mirrors it, and updated with inspect-then-update
@@ -116,6 +119,7 @@ state/               runtime records and signals; gitignored
   procevent-inbox/   private captured results and their durable handled-acknowledgement markers; source output lives here and never in an event line
   decision-bindings/ private records marking a captured-answer source as feeding the keyed-answer intake, with a legacy origin on pre-collapse records; written only by bin/fm-captain-hold.sh bind, dropped by unbind and by source retirement (section 13; docs/captain-hold-lifecycle.md)
   when/              private condition->action watch specs, their trust bindings, and single-fire markers; written only by bin/fm-procevent-when.sh (section 13's process-event-sources trigger)
+  mini-reboot/       host-level (not per-task) samples, idle snapshots, the single-instance check lock, and the reboot-in-progress marker owned by bin/fm-mini-reboot-guard.sh; see docs/mini-reboot-guard.md
   inbox/             captain notes captured out of band by bin/fm-inbox.sh, including the voice handover's queued requests; each note appends one `check` wake and stays pending until acknowledged with `bin/fm-inbox.sh drain --ack <id>`, which moves it to inbox/handled/ (docs/voice-relay.md)
   x-inbox/           generated Relay pending mention payloads; fmx-respond drains it (section 14)
   x-context/         generated Relay durable per-request reply context and one-wake offer markers, keyed by request_id; survives inbox cleanup and expires within seven days (section 14; bin/fm-x-lib.sh)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ config/cmux-socket-password  optional cmux control-socket password; LOCAL, gitig
 config/wedge-alarm  optional away-mode wedge-alarm active-alert directives; LOCAL, gitignored; absent means auto (macOS Notification Center when available); see docs/wedge-alarm.md
 config/watched-tools.json  optional list of the tools this home depends on, read by the update check armed with bin/fm-tool-update-check.sh; LOCAL, gitignored, firstmate-maintained but human-editable, and NOT inherited by secondmate homes; see docs/configuration.md "Watched tool updates"
 config/x-mode.env    generated Relay watcher cadence; LOCAL, gitignored; source before arming watcher when present
-config/host-role  must equal exactly "mini" to arm bin/fm-mini-reboot-guard.sh's reboot execution on this host; LOCAL, gitignored, and not inherited; see docs/mini-reboot-guard.md
+config/host-role  must equal exactly "mini" to arm bin/fm-mini-reboot-guard.sh's captain-authorized, narrowly scoped automatic reboot exception on this host (no per-reboot approval); LOCAL, gitignored, and not inherited; see docs/mini-reboot-guard.md
 config/mini-reboot-homes  explicit registry of FM_HOME paths bin/fm-mini-reboot-guard.sh idle-checks before a reboot attempt; LOCAL, gitignored, and not inherited; absent or empty means the guard never reboots; see docs/mini-reboot-guard.md
 config/mini-reboot-helper  path to the root-authorized reboot helper bin/fm-mini-reboot-guard.sh invokes when both conditions hold; LOCAL, gitignored, and not inherited; absent blocks the reboot attempt rather than faking it; see docs/mini-reboot-guard.md
 data/                personal fleet records; LOCAL, gitignored as a whole

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -573,7 +573,7 @@ A current, explicit, concrete captain instruction overrides any conflicting stan
 The instruction must be specific and recent: it must identify the concrete action, object, or bounded set it governs.
 Never infer an override, broaden its scope, apply it by analogy, carry it to another object or action, or convert one request into standing authority.
 Ambiguous scope or conflict still requires one concise clarification before action.
-Destructive, irreversible, security-sensitive, discard, and merge actions still require the captain to state that concrete action explicitly; once the captain does so and higher-priority instructions permit it, a conflicting Firstmate-written rule must not rigidly block the action.
+Destructive, irreversible, security-sensitive, discard, and merge actions still require the captain to state that concrete action explicitly; once the captain does so and higher-priority instructions permit it, a conflicting Firstmate-written rule must not rigidly block the action. The sole standing exception is a deterministic host-maintenance capability that the captain explicitly authorized and separately provisioned under `VISION.md`; it may perform only its documented action when every fail-closed gate holds.
 Standing `yolo` merge authority is not a substitute for a current explicit captain instruction where an explicit action is required.
 
 ## Maintaining this file

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ state/               runtime records and signals; gitignored
   procevent-inbox/   private captured results and their durable handled-acknowledgement markers; source output lives here and never in an event line
   decision-bindings/ private records marking a captured-answer source as feeding the keyed-answer intake, with a legacy origin on pre-collapse records; written only by bin/fm-captain-hold.sh bind, dropped by unbind and by source retirement (section 13; docs/captain-hold-lifecycle.md)
   when/              private condition->action watch specs, their trust bindings, and single-fire markers; written only by bin/fm-procevent-when.sh (section 13's process-event-sources trigger)
-  mini-reboot/       host-level (not per-task) samples, idle snapshots, the single-instance check lock, and the reboot-in-progress marker owned by bin/fm-mini-reboot-guard.sh; see docs/mini-reboot-guard.md
+  mini-reboot/       host-level (not per-task) samples, idle snapshots, the best-effort overlap check lock, and the reboot-in-progress marker owned by bin/fm-mini-reboot-guard.sh; see docs/mini-reboot-guard.md
   inbox/             captain notes captured out of band by bin/fm-inbox.sh, including the voice handover's queued requests; each note appends one `check` wake and stays pending until acknowledged with `bin/fm-inbox.sh drain --ack <id>`, which moves it to inbox/handled/ (docs/voice-relay.md)
   x-inbox/           generated Relay pending mention payloads; fmx-respond drains it (section 14)
   x-context/         generated Relay durable per-request reply context and one-wake offer markers, keyed by request_id; survives inbox cleanup and expires within seven days (section 14; bin/fm-x-lib.sh)

--- a/VISION.md
+++ b/VISION.md
@@ -23,8 +23,8 @@ Presentation and convenience features that serve that experience are welcome whe
 The captain is the default authority for every gate; autonomy exists only as an explicit grant, never as a default, and new capability ships as an option to enable, never as behavior that assumes consent.
 The first mate reads projects but does not change them; project changes belong to workers in isolated copies, delivered through each project's selected path.
 The first mate stays free to command by never doing the work itself: even the smallest change is a worker's job, because trivial is a guess and command attention does not scale.
-Merging, discarding work, and anything destructive, irreversible, or security-sensitive require the captain's explicit word.
-Standing autonomy is scoped consent granted per project, exercised only within the captain's original request, and it never quietly widens.
+Merging and discarding work always require the captain's explicit word for the concrete action. Destructive, irreversible, or security-sensitive actions do too, except for a deterministic host-maintenance capability the captain has explicitly granted standing autonomy and separately provisioned on that host; such a capability may perform only its documented action when all of its fail-closed gates hold.
+Standing autonomy is scoped consent granted per project or for one narrowly defined host-maintenance capability, exercised only within the captain's original request, and it never quietly widens.
 Evidence is never authorization: a diagnosis, a report, or a recommendation authorizes nothing by itself.
 Initiative beyond a stated request is legitimate only where the captain has committed a vision precise enough to adjudicate it, and even then only as an explicit opt-in.
 A current, explicit captain instruction outranks any standing rule the first mate wrote for itself, exactly as stated and no further.

--- a/bin/fm-mini-reboot-guard.sh
+++ b/bin/fm-mini-reboot-guard.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# fm-mini-reboot-guard.sh - CLI entry point for the mini self-reboot guard.
+#
+# Reboots this mini ONLY when a genuine resource-leak/pressure threshold has
+# been crossed AND the local fleet is robustly idle. No drain, no admission
+# lock, no blocking of new work, no captain-approval-per-reboot step: see
+# bin/fm-mini-reboot-lib.sh for the full design rationale and the captain's
+# 2026-08-24 retarget decision it implements.
+#
+# Usage:
+#   fm-mini-reboot-guard.sh sample                collect and persist one sample
+#   fm-mini-reboot-guard.sh evaluate               print the resource trigger verdict
+#   fm-mini-reboot-guard.sh idle-check             print the idle verdict (single read)
+#   fm-mini-reboot-guard.sh idle-confirm           print the two-snapshot idle-confirm verdict
+#   fm-mini-reboot-guard.sh check                  run one full detect->idle->reboot cycle
+#   fm-mini-reboot-guard.sh status                 human-readable current state summary
+#
+# Intended to be invoked on a recurring schedule (report: every ~5 minutes) by
+# an operator-installed launchd job or cron entry. This script does not
+# install its own schedule - arming the schedule, config/host-role=mini, and
+# config/mini-reboot-helper are all separate, deliberate provisioning steps.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bin/fm-mini-reboot-lib.sh
+. "$SCRIPT_DIR/fm-mini-reboot-lib.sh"
+
+usage() {
+  cat <<'EOF'
+fm-mini-reboot-guard.sh - mini self-reboot guard: reboots this mini ONLY when
+a resource-leak/pressure threshold has been crossed AND the local fleet is
+robustly idle. See bin/fm-mini-reboot-lib.sh for the full design.
+
+Usage:
+  fm-mini-reboot-guard.sh sample         collect and persist one sample
+  fm-mini-reboot-guard.sh evaluate       print the resource trigger verdict
+  fm-mini-reboot-guard.sh idle-check     print the idle verdict (single read)
+  fm-mini-reboot-guard.sh idle-confirm   print the two-snapshot idle-confirm verdict
+  fm-mini-reboot-guard.sh check          run one full detect->idle->reboot cycle
+  fm-mini-reboot-guard.sh status         human-readable current state summary
+EOF
+}
+
+cmd_status() {
+  local homes
+  echo "host-role: $(fm_mrb_host_is_mini && echo mini || echo "not mini (or unconfigured)")"
+  echo "samples recorded: $(fm_mrb_sample_count "$(fm_mrb_samples_file)")"
+  echo "--- evaluate ---"
+  fm_mrb_evaluate
+  echo "--- idle-check-all (single read) ---"
+  fm_mrb_idle_check_all
+  homes=$(fm_mrb_homes_registry)
+  echo "--- registered homes ---"
+  if [ -n "$homes" ]; then
+    printf '%s\n' "$homes"
+  else
+    echo "(none - config/mini-reboot-homes absent or empty)"
+  fi
+  if fm_mrb_reboot_marker_active; then
+    echo "--- reboot marker: ACTIVE (attempt in flight) ---"
+  fi
+}
+
+main() {
+  local sub=${1:-}
+  case "$sub" in
+    sample) fm_mrb_append_sample ;;
+    evaluate) fm_mrb_evaluate ;;
+    idle-check) fm_mrb_idle_check_all ;;
+    idle-confirm) fm_mrb_idle_confirm ;;
+    check) fm_mrb_with_lock fm_mrb_check_cycle ;;
+    status) cmd_status ;;
+    -h|--help|help|"") usage ;;
+    *)
+      echo "fm-mini-reboot-guard: unknown subcommand: $sub" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+}
+
+main "$@"

--- a/bin/fm-mini-reboot-guard.sh
+++ b/bin/fm-mini-reboot-guard.sh
@@ -3,9 +3,8 @@
 #
 # Reboots this mini ONLY when a genuine resource-leak/pressure threshold has
 # been crossed AND the local fleet is robustly idle. No drain, no admission
-# lock, no blocking of new work, no captain-approval-per-reboot step: see
-# bin/fm-mini-reboot-lib.sh for the full design rationale and the captain's
-# 2026-08-24 retarget decision it implements.
+# lock, no blocking of new work, and no captain-approval-per-reboot step.
+# See bin/fm-mini-reboot-lib.sh for the safety invariants.
 #
 # Usage:
 #   fm-mini-reboot-guard.sh sample                collect and persist one sample
@@ -15,7 +14,7 @@
 #   fm-mini-reboot-guard.sh check                  run one full detect->idle->reboot cycle
 #   fm-mini-reboot-guard.sh status                 human-readable current state summary
 #
-# Intended to be invoked on a recurring schedule (report: every ~5 minutes) by
+# Intended to be invoked on a recurring schedule (about every 5 minutes) by
 # an operator-installed launchd job or cron entry. This script does not
 # install its own schedule - arming the schedule, config/host-role=mini, and
 # config/mini-reboot-helper are all separate, deliberate provisioning steps.

--- a/bin/fm-mini-reboot-lib.sh
+++ b/bin/fm-mini-reboot-lib.sh
@@ -330,16 +330,17 @@ fm_mrb_evaluate() {
   fi
 
   # Condition 3: pressure no longer normal and swapouts trending up.
-  local latest_pressure trend_n trend_rows swap_sum=0
+  local latest_pressure trend_n trend_rows first_swapouts latest_swapouts swap_trend=0
   latest_pressure=$(tail -n 1 "$file" | cut -f10)
   trend_n=$(fm_mrb_swap_trend_samples)
   trend_rows=$(tail -n "$trend_n" "$file")
-  while IFS=$'\t' read -r _e _z _w _f _c _p _s _si _so _pr _zd _wd sod; do
-    [ -n "${sod:-}" ] || continue
-    swap_sum=$(( swap_sum + sod ))
-  done <<< "$trend_rows"
+  first_swapouts=$(printf '%s\n' "$trend_rows" | head -n 1 | cut -f9)
+  latest_swapouts=$(printf '%s\n' "$trend_rows" | tail -n 1 | cut -f9)
+  if [[ "$first_swapouts" =~ ^[0-9]+$ ]] && [[ "$latest_swapouts" =~ ^[0-9]+$ ]]; then
+    swap_trend=$(( latest_swapouts - first_swapouts ))
+  fi
   if { [ "$latest_pressure" = warn ] || [ "$latest_pressure" = critical ]; } \
-      && [ "$swap_sum" -gt 0 ]; then
+      && [ "$swap_trend" -gt 0 ]; then
     trigger=yes
     reasons+=("pressure-${latest_pressure}-with-rising-swapouts")
   fi

--- a/bin/fm-mini-reboot-lib.sh
+++ b/bin/fm-mini-reboot-lib.sh
@@ -306,11 +306,9 @@ fm_mrb_evaluate() {
   last_n=$(tail -n "$min_n" "$file")
   local crossed=1
   local rows_seen=0
-  while IFS=$'\t' read -r _epoch zone _w free _c _p _s _si _so _pr _zd _wd _sod; do
+  while IFS=$'\t' read -r _epoch zone wired free _c _p _s _si _so _pr _zd _wd _sod; do
     [ -n "${zone:-}" ] || continue
     rows_seen=$((rows_seen + 1))
-    local wired
-    wired=$(printf '%s\n' "$last_n" | awk -F'\t' -v e="$_epoch" '$1==e{print $3; exit}')
     if ! { [ "$zone" -ge "$maint_zone" ] || [ "${wired:-0}" -ge "$maint_wired" ]; }; then
       crossed=0
     fi

--- a/bin/fm-mini-reboot-lib.sh
+++ b/bin/fm-mini-reboot-lib.sh
@@ -707,10 +707,11 @@ fm_mrb_execute_reboot() {
 
 # --- orchestration ---------------------------------------------------------
 
-# fm_mrb_with_lock <fn> [args...]: runs <fn> under a single-instance mkdir
-# lock so overlapping `check` invocations never run together. A dead recorded
-# owner is reclaimed; a live owner causes this cycle to skip after bounded
-# retries.
+# fm_mrb_with_lock <fn> [args...]: runs <fn> under a best-effort mkdir lock
+# that prevents ordinary redundant overlap but does not guarantee strict mutual
+# exclusion during a genuinely concurrent dead-owner reclaim. Reboot safety
+# comes from the resource-plus-idle gate, not this lock; the normal caller is a
+# single scheduler running about every five minutes.
 fm_mrb_with_lock() {
   local lock owner_file owner_pid tries=0 tmp status=0
   lock=$(fm_mrb_lock_dir)
@@ -719,7 +720,11 @@ fm_mrb_with_lock() {
   while ! mkdir "$lock" 2>/dev/null; do
     owner_pid=$(cat "$owner_file" 2>/dev/null || true)
     case "$owner_pid" in
-      ''|*[!0-9]*) ;;
+      ''|*[!0-9]*)
+        fm_mrb_log "reclaiming lock with missing or invalid owner pid"
+        rm -rf "$lock"
+        continue
+        ;;
       *)
         if ! kill -0 "$owner_pid" 2>/dev/null; then
           fm_mrb_log "reclaiming lock from dead owner pid=$owner_pid"

--- a/bin/fm-mini-reboot-lib.sh
+++ b/bin/fm-mini-reboot-lib.sh
@@ -90,31 +90,41 @@ fm_mrb_vm_stat_field() {
 
 # fm_mrb_zone_bytes: live payload of the two named leaking zones (report
 # section 4: element size * in-use count for data.kalloc.1024 and
-# data_shared.kalloc.1024), in bytes. Empty/zero zprint output yields 0, never
-# an error - a leak detector must not crash the sampler.
+# data_shared.kalloc.1024), in bytes.
 fm_mrb_zone_bytes() {
-  zprint 2>/dev/null | awk '
-    $1 == "data.kalloc.1024" || $1 == "data_shared.kalloc.1024" { sum += $2 * $7 }
-    END { print sum + 0 }
+  local raw
+  raw=$(zprint 2>/dev/null) || return 1
+  printf '%s\n' "$raw" | awk '
+    $1 == "data.kalloc.1024" || $1 == "data_shared.kalloc.1024" {
+      found = 1
+      if ($2 !~ /^[0-9]+$/ || $7 !~ /^[0-9]+$/) invalid = 1
+      sum += $2 * $7
+    }
+    END {
+      if (!found || invalid) exit 1
+      printf "%.0f\n", sum
+    }
   '
 }
 
 # fm_mrb_swap_used_bytes: parses `sysctl vm.swapusage`'s "used = 552.25M"
 # (or ...G) into bytes.
 fm_mrb_swap_used_bytes() {
-  sysctl vm.swapusage 2>/dev/null | awk '
+  local raw
+  raw=$(sysctl vm.swapusage 2>/dev/null) || return 1
+  printf '%s\n' "$raw" | awk '
     {
       for (i = 1; i <= NF; i++) {
         if ($i == "used") { val = $(i + 2); break }
       }
     }
     END {
-      if (val == "") { print 0; exit }
+      if (val !~ /^[0-9]+([.][0-9]+)?[MG]$/) exit 1
       unit = substr(val, length(val), 1)
       num = substr(val, 1, length(val) - 1)
       mult = 1024 * 1024
       if (unit == "G") mult = 1024 * 1024 * 1024
-      printf "%d\n", num * mult
+      printf "%.0f\n", num * mult
     }
   '
 }
@@ -142,29 +152,33 @@ fm_mrb_boot_session_id() {
 # per the sample contract):
 #   epoch  zone_bytes  wired_bytes  free_bytes  compressor_bytes  purgeable_bytes  swap_used_bytes  swapins  swapouts  pressure
 fm_mrb_collect_sample() {
-  local page vmstat wired free compressor purgeable swapins swapouts zone swap pressure
-  page=$(fm_mrb_pagesize_bytes)
-  page=${page:-16384}
-  vmstat=$(vm_stat 2>/dev/null)
+  local page vmstat wired free compressor purgeable swapins swapouts zone swap pressure value
+  page=$(fm_mrb_pagesize_bytes) || return 1
+  case "$page" in ''|*[!0-9]*|0) return 1 ;; esac
+  vmstat=$(vm_stat 2>/dev/null) || return 1
   wired=$(fm_mrb_vm_stat_field "Pages wired down" "$vmstat")
   free=$(fm_mrb_vm_stat_field "Pages free" "$vmstat")
   compressor=$(fm_mrb_vm_stat_field "Pages occupied by compressor" "$vmstat")
   purgeable=$(fm_mrb_vm_stat_field "Pages purgeable" "$vmstat")
   swapins=$(fm_mrb_vm_stat_field "Swapins" "$vmstat")
   swapouts=$(fm_mrb_vm_stat_field "Swapouts" "$vmstat")
-  zone=$(fm_mrb_zone_bytes)
-  swap=$(fm_mrb_swap_used_bytes)
+  for value in "$wired" "$free" "$compressor" "$purgeable" "$swapins" "$swapouts"; do
+    case "$value" in ''|*[!0-9]*) return 1 ;; esac
+  done
+  zone=$(fm_mrb_zone_bytes) || return 1
+  swap=$(fm_mrb_swap_used_bytes) || return 1
+  case "$zone:$swap" in *[!0-9:]*) return 1 ;; esac
   pressure=$(fm_mrb_pressure_level)
   printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
     "$(fm_mrb_now)" \
     "$zone" \
-    "$(( ${wired:-0} * page ))" \
-    "$(( ${free:-0} * page ))" \
-    "$(( ${compressor:-0} * page ))" \
-    "$(( ${purgeable:-0} * page ))" \
+    "$(( wired * page ))" \
+    "$(( free * page ))" \
+    "$(( compressor * page ))" \
+    "$(( purgeable * page ))" \
     "$swap" \
-    "${swapins:-0}" \
-    "${swapouts:-0}" \
+    "$swapins" \
+    "$swapouts" \
     "$pressure"
 }
 
@@ -190,7 +204,10 @@ fm_mrb_append_sample() {
       has_prev=1
     fi
   fi
-  raw=$(fm_mrb_collect_sample)
+  if ! raw=$(fm_mrb_collect_sample); then
+    fm_mrb_log "sample collection failed; leaving history unchanged"
+    return 1
+  fi
   local zone wired swapouts zone_delta wired_delta swapouts_delta
   zone=$(printf '%s' "$raw" | cut -f2)
   wired=$(printf '%s' "$raw" | cut -f3)
@@ -588,7 +605,7 @@ fm_mrb_reboot_marker_active() {
   epoch=$(awk -F'\t' 'NR==1{print $1}' "$file" 2>/dev/null)
   boot_id=$(awk -F'\t' 'NR==1{print $2}' "$file" 2>/dev/null)
   cur_boot=$(fm_mrb_boot_session_id)
-  if [ -n "$cur_boot" ] && [ "$boot_id" != "$cur_boot" ]; then
+  if [ -n "$boot_id" ] && [ -n "$cur_boot" ] && [ "$boot_id" != "$cur_boot" ]; then
     fm_mrb_log "boot-session changed since marker ($boot_id -> $cur_boot): reboot happened, clearing marker"
     rm -f "$file"
     return 1
@@ -603,10 +620,12 @@ fm_mrb_reboot_marker_active() {
 }
 
 fm_mrb_write_reboot_marker() {
-  local file tmp
+  local file tmp boot_id
   file=$(fm_mrb_reboot_marker_file)
+  boot_id=$(fm_mrb_boot_session_id) || return 1
+  case "$boot_id" in ''|*$'\t'*|*$'\n'*|*$'\r'*) return 1 ;; esac
   tmp="$file.tmp.$$"
-  printf '%s\t%s\t%s\n' "$(fm_mrb_now)" "$(fm_mrb_boot_session_id)" "$1" > "$tmp"
+  printf '%s\t%s\t%s\n' "$(fm_mrb_now)" "$boot_id" "$1" > "$tmp" || return 1
   mv "$tmp" "$file"
 }
 
@@ -637,7 +656,11 @@ fm_mrb_execute_reboot() {
     return 3
   fi
 
-  fm_mrb_write_reboot_marker "$reason"
+  if ! fm_mrb_write_reboot_marker "$reason"; then
+    fm_mrb_log "BLOCKED: cannot read a valid macOS boot-session id; reboot marker was not published"
+    printf '%s\tblocked\tno-boot-session-id\n' "$(fm_mrb_now)" >> "$log"
+    return 4
+  fi
   fm_mrb_log "invoking reboot helper: $helper (reason: $reason)"
   local status=0
   "$helper" "$reason" || status=$?
@@ -671,46 +694,76 @@ fm_mrb_lock_mtime() {
   case "$value" in ''|*[!0-9]*) stat -c '%Y' "$1" 2>/dev/null ;; *) echo "$value" ;; esac
 }
 
+fm_mrb_lock_owner() {
+  local lock=$1
+  [ ! -f "$lock" ] || cat "$lock" 2>/dev/null
+}
+
+fm_mrb_lock_owner_stale() {
+  local owner=$1 pid signature live_identity
+  [ -n "$owner" ] || return 1
+  pid=${owner%%$'\t'*}
+  signature=
+  case "$owner" in *$'\t'*) signature=${owner#*$'\t'} ;; esac
+  live_identity=
+  case "$pid" in ''|*[!0-9]*) ;; *) live_identity=$(fm_mrb_process_identity "$pid" 2>/dev/null || true) ;; esac
+  [ -z "$live_identity" ] || { [ -n "$signature" ] && [ "$live_identity" != "$owner" ]; }
+}
+
+fm_mrb_lock_ownerless_stale() {
+  local lock=$1 grace=$2 mtime age
+  mtime=$(fm_mrb_lock_mtime "$lock" || true)
+  [ -n "$mtime" ] || return 1
+  age=$(( $(fm_mrb_now) - mtime ))
+  [ "$age" -ge "$grace" ]
+}
+
+fm_mrb_reclaim_lock() {
+  local lock=$1 expected=$2 grace=$3 reap current reclaimed=1
+  reap="$lock.reap"
+  if [ ! -e "$reap" ]; then
+    ln "$lock" "$reap" 2>/dev/null || return 1
+  fi
+  if [ -f "$lock" ] && [ "$lock" -ef "$reap" ]; then
+    current=$(fm_mrb_lock_owner "$reap")
+    if [ "$current" = "$expected" ]; then
+      if { [ -n "$current" ] && fm_mrb_lock_owner_stale "$current"; } || \
+         { [ -z "$current" ] && fm_mrb_lock_ownerless_stale "$reap" "$grace"; }; then
+        rm -f "$lock"
+        reclaimed=0
+      fi
+    fi
+  fi
+  rm -f "$reap"
+  return "$reclaimed"
+}
+
 fm_mrb_with_lock() {
-  local lock owner_file owner_value owner pid signature live_identity tries=0
-  local mtime age grace=${FM_MRB_LOCK_OWNERLESS_GRACE_SECS:-60}
+  local lock owner_value owner pid tries=0
+  local grace=${FM_MRB_LOCK_OWNERLESS_GRACE_SECS:-60}
   lock=$(fm_mrb_lock_dir)
   owner_value=$(fm_mrb_process_identity "$$") || {
     fm_mrb_log "could not establish lock owner identity"
     return 1
   }
 
-  while ! (set -o noclobber; printf '%s\n' "$owner_value" > "$lock") 2>/dev/null; do
-    if [ -d "$lock" ]; then
-      owner_file="$lock/owner"
-    else
-      owner_file="$lock"
+  while :; do
+    if (set -o noclobber; printf '%s\n' "$owner_value" > "$lock") 2>/dev/null; then
+      break
     fi
-    owner=
-    [ ! -f "$owner_file" ] || owner=$(cat "$owner_file" 2>/dev/null)
-    if [ -n "$owner" ]; then
+    owner=$(fm_mrb_lock_owner "$lock")
+    if fm_mrb_lock_owner_stale "$owner"; then
       pid=${owner%%$'\t'*}
-      signature=
-      case "$owner" in *$'\t'*) signature=${owner#*$'\t'} ;; esac
-      live_identity=
-      case "$pid" in ''|*[!0-9]*) ;; *) live_identity=$(fm_mrb_process_identity "$pid" 2>/dev/null || true) ;; esac
-      if [ -z "$live_identity" ] || { [ -n "$signature" ] && [ "$live_identity" != "$owner" ]; }; then
-        fm_mrb_log "reclaiming lock from stale owner pid=${pid:-unknown}"
-        rm -rf "$lock"
+      if fm_mrb_reclaim_lock "$lock" "$owner" "$grace"; then
+        fm_mrb_log "reclaimed lock from stale owner pid=${pid:-unknown}"
         continue
       fi
     fi
     tries=$((tries + 1))
     if [ "$tries" -ge 3 ]; then
-      if [ -z "$owner" ]; then
-        mtime=$(fm_mrb_lock_mtime "$lock" || true)
-        age=0
-        [ -z "$mtime" ] || age=$(( $(fm_mrb_now) - mtime ))
-        if [ -n "$mtime" ] && [ "$age" -ge "$grace" ]; then
-          fm_mrb_log "reclaiming abandoned ownerless lock"
-          rm -rf "$lock"
-          continue
-        fi
+      if [ -z "$owner" ] && fm_mrb_reclaim_lock "$lock" "$owner" "$grace"; then
+        fm_mrb_log "reclaimed abandoned ownerless lock"
+        continue
       fi
       fm_mrb_log "check already running (lock held), skipping this cycle"
       return 0
@@ -720,7 +773,7 @@ fm_mrb_with_lock() {
 
   local status=0 current_owner
   "$@" || status=$?
-  current_owner=$(cat "$lock" 2>/dev/null || true)
+  current_owner=$(fm_mrb_lock_owner "$lock")
   if [ "$current_owner" = "$owner_value" ]; then
     rm -f "$lock"
   fi
@@ -738,7 +791,10 @@ fm_mrb_check_cycle() {
     return 0
   fi
 
-  fm_mrb_append_sample
+  if ! fm_mrb_append_sample; then
+    fm_mrb_log "current sample is invalid, doing nothing"
+    return 0
+  fi
 
   local eval_out trig_line
   eval_out=$(fm_mrb_evaluate)

--- a/bin/fm-mini-reboot-lib.sh
+++ b/bin/fm-mini-reboot-lib.sh
@@ -1,0 +1,716 @@
+#!/usr/bin/env bash
+# fm-mini-reboot-lib.sh - detect-and-idle-gated self-reboot logic for a single
+# mini host. NOT sourced by fm-spawn.sh, fm-promote.sh, or fm-backlog-handoff.sh:
+# this feature does not touch cross-home admission at all.
+#
+# Design (captain 2026-08-24 retarget): no drain, no admission lock, no
+# blocking or holding new work, no fleet-emptying, no attack resistance, no
+# readiness-receipt machinery. Reboot the mini ONLY when BOTH:
+#   (a) a resource-leak/pressure threshold has genuinely been crossed
+#       (never from a single sample - see fm_mrb_evaluate); AND
+#   (b) the fleet is genuinely, robustly idle (two consecutive confirmed-idle
+#       checks at least 5 minutes apart - see fm_mrb_idle_confirm).
+# If both are not true, do nothing; the machine handles load best-effort.
+#
+# Mini only: fm_mrb_host_is_mini gates every reboot attempt on an explicit
+# config/host-role file that must say exactly "mini". A MacBook (or any host
+# without that file) never reboots through this code, by construction.
+#
+# Reboot EXECUTION is delegated to an external, separately-provisioned
+# executable named by config/mini-reboot-helper. This library never fakes or
+# stubs privileged access: if that file is absent or not executable,
+# fm_mrb_execute_reboot logs a clear diagnostic and returns non-zero rather than
+# attempting anything.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+
+FM_MRB_LOG_PREFIX="${FM_MRB_LOG_PREFIX:-fm-mini-reboot}"
+
+fm_mrb_log() {
+  echo "$FM_MRB_LOG_PREFIX: $*" >&2
+}
+
+fm_mrb_now() {
+  echo "${FM_MRB_NOW:-$(date +%s)}"
+}
+
+# --- paths -------------------------------------------------------------
+
+fm_mrb_config_dir() {
+  echo "${FM_MRB_CONFIG_OVERRIDE:-$FM_HOME/config}"
+}
+
+fm_mrb_state_dir() {
+  local dir
+  dir="${FM_MRB_STATE_OVERRIDE:-$FM_HOME/state/mini-reboot}"
+  mkdir -p "$dir"
+  echo "$dir"
+}
+
+fm_mrb_samples_file() { echo "$(fm_mrb_state_dir)/samples.tsv"; }
+fm_mrb_idle_snapshot_file() { echo "$(fm_mrb_state_dir)/idle-snapshot.tsv"; }
+fm_mrb_lock_dir() { echo "$(fm_mrb_state_dir)/check.lock"; }
+fm_mrb_reboot_marker_file() { echo "$(fm_mrb_state_dir)/reboot-in-progress"; }
+fm_mrb_attempts_log() { echo "$(fm_mrb_state_dir)/reboot-attempts.log"; }
+
+# --- thresholds (mini 64 GiB row, report section 4) ---------------------
+# Overridable only via env, for tests. No persistent tunable config file:
+# keep this minimal and single-purpose rather than growing a generic knob
+# surface.
+
+fm_mrb_maint_zone_bytes()  { echo "${FM_MRB_MAINT_ZONE_BYTES:-$((9  * 1024 * 1024 * 1024))}"; }   # 9 GiB
+fm_mrb_maint_wired_bytes() { echo "${FM_MRB_MAINT_WIRED_BYTES:-$((13 * 1024 * 1024 * 1024))}"; }  # 13 GiB
+fm_mrb_hard_zone_bytes()   { echo "${FM_MRB_HARD_ZONE_BYTES:-$((12 * 1024 * 1024 * 1024))}"; }    # 12 GiB ceiling
+fm_mrb_slope_window_secs() { echo "${FM_MRB_SLOPE_WINDOW_SECS:-21600}"; }    # 6h recent window
+fm_mrb_forecast_horizon_secs() { echo "${FM_MRB_FORECAST_HORIZON_SECS:-86400}"; }  # 24h
+fm_mrb_swap_trend_samples() { echo "${FM_MRB_SWAP_TREND_SAMPLES:-3}"; }
+fm_mrb_min_trigger_samples() { echo "${FM_MRB_MIN_TRIGGER_SAMPLES:-3}"; }
+fm_mrb_prune_window_secs() { echo "${FM_MRB_PRUNE_WINDOW_SECS:-1209600}"; }  # 14 days
+fm_mrb_idle_min_gap_secs() { echo "${FM_MRB_IDLE_MIN_GAP_SECS:-300}"; }   # 5 min, report Phase D
+fm_mrb_idle_max_gap_secs() { echo "${FM_MRB_IDLE_MAX_GAP_SECS:-1800}"; }  # 30 min: stitched, not stale
+fm_mrb_marker_max_age_secs() { echo "${FM_MRB_MARKER_MAX_AGE_SECS:-1200}"; }  # 20 min
+
+# --- metric collection ---------------------------------------------------
+
+fm_mrb_pagesize_bytes() {
+  sysctl -n hw.pagesize 2>/dev/null
+}
+
+# fm_mrb_vm_stat_field <label> <vm_stat output>: prints the raw integer count
+# for a "Label:  12345." line, or empty on no match.
+fm_mrb_vm_stat_field() {
+  local label=$1 raw=$2
+  printf '%s\n' "$raw" | awk -F: -v label="$label" '
+    $1 == label { gsub(/[ .]/, "", $2); print $2; exit }
+  '
+}
+
+# fm_mrb_zone_bytes: live payload of the two named leaking zones (report
+# section 4: element size * in-use count for data.kalloc.1024 and
+# data_shared.kalloc.1024), in bytes. Empty/zero zprint output yields 0, never
+# an error - a leak detector must not crash the sampler.
+fm_mrb_zone_bytes() {
+  zprint 2>/dev/null | awk '
+    $1 == "data.kalloc.1024" || $1 == "data_shared.kalloc.1024" { sum += $2 * $7 }
+    END { print sum + 0 }
+  '
+}
+
+# fm_mrb_swap_used_bytes: parses `sysctl vm.swapusage`'s "used = 552.25M"
+# (or ...G) into bytes.
+fm_mrb_swap_used_bytes() {
+  sysctl vm.swapusage 2>/dev/null | awk '
+    {
+      for (i = 1; i <= NF; i++) {
+        if ($i == "used") { val = $(i + 2); break }
+      }
+    }
+    END {
+      if (val == "") { print 0; exit }
+      unit = substr(val, length(val), 1)
+      num = substr(val, 1, length(val) - 1)
+      mult = 1024 * 1024
+      if (unit == "G") mult = 1024 * 1024 * 1024
+      printf "%d\n", num * mult
+    }
+  '
+}
+
+# fm_mrb_pressure_level: normal|warn|critical|unknown, from
+# kern.memorystatus_vm_pressure_level (1=normal, 2=warn, 4=critical - standard
+# macOS values; any other/unreadable value is unknown, never assumed normal).
+fm_mrb_pressure_level() {
+  local raw
+  raw=$(sysctl -n kern.memorystatus_vm_pressure_level 2>/dev/null)
+  case "$raw" in
+    1) echo normal ;;
+    2) echo warn ;;
+    4) echo critical ;;
+    *) echo unknown ;;
+  esac
+}
+
+fm_mrb_boot_session_id() {
+  sysctl -n kern.bootsessionuuid 2>/dev/null
+}
+
+# fm_mrb_collect_sample: prints one TSV row of RAW metrics (no deltas - those
+# are computed and persisted by fm_mrb_append_sample against the prior row,
+# per the sample contract):
+#   epoch  zone_bytes  wired_bytes  free_bytes  compressor_bytes  purgeable_bytes  swap_used_bytes  swapins  swapouts  pressure
+fm_mrb_collect_sample() {
+  local page vmstat wired free compressor purgeable swapins swapouts zone swap pressure
+  page=$(fm_mrb_pagesize_bytes)
+  page=${page:-16384}
+  vmstat=$(vm_stat 2>/dev/null)
+  wired=$(fm_mrb_vm_stat_field "Pages wired down" "$vmstat")
+  free=$(fm_mrb_vm_stat_field "Pages free" "$vmstat")
+  compressor=$(fm_mrb_vm_stat_field "Pages occupied by compressor" "$vmstat")
+  purgeable=$(fm_mrb_vm_stat_field "Pages purgeable" "$vmstat")
+  swapins=$(fm_mrb_vm_stat_field "Swapins" "$vmstat")
+  swapouts=$(fm_mrb_vm_stat_field "Swapouts" "$vmstat")
+  zone=$(fm_mrb_zone_bytes)
+  swap=$(fm_mrb_swap_used_bytes)
+  pressure=$(fm_mrb_pressure_level)
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$(fm_mrb_now)" \
+    "$zone" \
+    "$(( ${wired:-0} * page ))" \
+    "$(( ${free:-0} * page ))" \
+    "$(( ${compressor:-0} * page ))" \
+    "$(( ${purgeable:-0} * page ))" \
+    "$swap" \
+    "${swapins:-0}" \
+    "${swapouts:-0}" \
+    "$pressure"
+}
+
+# fm_mrb_append_sample: collects one sample, computes deltas against the most
+# recent persisted row (0 when there is none), and appends the full row -
+# raw values AND deltas persisted together, never derived only transiently at
+# evaluation time. Prunes rows older than fm_mrb_prune_window_secs first.
+#
+# Persisted columns:
+#   epoch zone wired free compressor purgeable swap swapins swapouts pressure \
+#   zone_delta wired_delta swapouts_delta
+fm_mrb_append_sample() {
+  local file raw prev_zone=0 prev_wired=0 prev_swapouts=0 has_prev=0
+  file=$(fm_mrb_samples_file)
+  fm_mrb_prune_old_samples
+  if [ -s "$file" ]; then
+    local last
+    last=$(tail -n 1 "$file")
+    if [ -n "$last" ]; then
+      prev_zone=$(printf '%s' "$last" | cut -f2)
+      prev_wired=$(printf '%s' "$last" | cut -f3)
+      prev_swapouts=$(printf '%s' "$last" | cut -f9)
+      has_prev=1
+    fi
+  fi
+  raw=$(fm_mrb_collect_sample)
+  local zone wired swapouts zone_delta wired_delta swapouts_delta
+  zone=$(printf '%s' "$raw" | cut -f2)
+  wired=$(printf '%s' "$raw" | cut -f3)
+  swapouts=$(printf '%s' "$raw" | cut -f9)
+  if [ "$has_prev" = 1 ]; then
+    zone_delta=$(( zone - prev_zone ))
+    wired_delta=$(( wired - prev_wired ))
+    swapouts_delta=$(( swapouts - prev_swapouts ))
+  else
+    zone_delta=0
+    wired_delta=0
+    swapouts_delta=0
+  fi
+  printf '%s\t%s\t%s\t%s\n' "$raw" "$zone_delta" "$wired_delta" "$swapouts_delta" >> "$file"
+}
+
+fm_mrb_prune_old_samples() {
+  local file cutoff tmp
+  file=$(fm_mrb_samples_file)
+  [ -s "$file" ] || return 0
+  cutoff=$(( $(fm_mrb_now) - $(fm_mrb_prune_window_secs) ))
+  tmp="$file.tmp.$$"
+  awk -F'\t' -v cutoff="$cutoff" '$1 >= cutoff' "$file" > "$tmp" && mv "$tmp" "$file"
+}
+
+# fm_mrb_recent_samples <window_secs>: prints rows with epoch within the last
+# <window_secs>, oldest first.
+fm_mrb_recent_samples() {
+  local window=$1 file cutoff
+  file=$(fm_mrb_samples_file)
+  [ -s "$file" ] || return 0
+  cutoff=$(( $(fm_mrb_now) - window ))
+  awk -F'\t' -v cutoff="$cutoff" '$1 >= cutoff' "$file"
+}
+
+fm_mrb_sample_count() {
+  local file=$1
+  [ -s "$file" ] || { echo 0; return; }
+  wc -l < "$file" | tr -d ' '
+}
+
+# --- resource evaluation --------------------------------------------------
+
+# fm_mrb_evaluate: prints "trigger=yes|no" on the first line, followed by one
+# reason line per condition that held. Never triggers with fewer than
+# fm_mrb_min_trigger_samples total samples recorded (never fires from a single
+# sample, or from an as-yet too-short history).
+fm_mrb_evaluate() {
+  local file total maint_zone maint_wired hard_zone
+  file=$(fm_mrb_samples_file)
+  total=$(fm_mrb_sample_count "$file")
+  maint_zone=$(fm_mrb_maint_zone_bytes)
+  maint_wired=$(fm_mrb_maint_wired_bytes)
+  hard_zone=$(fm_mrb_hard_zone_bytes)
+
+  local min_n
+  min_n=$(fm_mrb_min_trigger_samples)
+  if [ "$total" -lt "$min_n" ]; then
+    echo "trigger=no"
+    echo "reason=insufficient-samples($total<$min_n)"
+    return 0
+  fi
+
+  local trigger=no
+  local -a reasons=()
+
+  # Condition 1: maintenance threshold crossed in the last N consecutive
+  # samples.
+  local last_n
+  last_n=$(tail -n "$min_n" "$file")
+  local crossed=1
+  local rows_seen=0
+  while IFS=$'\t' read -r _epoch zone _w free _c _p _s _si _so _pr _zd _wd _sod; do
+    [ -n "${zone:-}" ] || continue
+    rows_seen=$((rows_seen + 1))
+    local wired
+    wired=$(printf '%s\n' "$last_n" | awk -F'\t' -v e="$_epoch" '$1==e{print $3; exit}')
+    if ! { [ "$zone" -ge "$maint_zone" ] || [ "${wired:-0}" -ge "$maint_wired" ]; }; then
+      crossed=0
+    fi
+  done <<< "$last_n"
+  if [ "$rows_seen" -ge "$min_n" ] && [ "$crossed" -eq 1 ]; then
+    trigger=yes
+    reasons+=("maintenance-threshold-crossed-in-${min_n}-samples")
+  fi
+
+  # Condition 2: slope forecast over a recent window predicts the hard
+  # ceiling before the forecast horizon.
+  local window recent oldest_line latest_line
+  window=$(fm_mrb_slope_window_secs)
+  recent=$(fm_mrb_recent_samples "$window")
+  if [ -n "$recent" ] && [ "$(printf '%s\n' "$recent" | wc -l | tr -d ' ')" -ge 2 ]; then
+    oldest_line=$(printf '%s\n' "$recent" | head -n 1)
+    latest_line=$(printf '%s\n' "$recent" | tail -n 1)
+    local o_epoch o_zone l_epoch l_zone dt dz
+    o_epoch=$(printf '%s' "$oldest_line" | cut -f1)
+    o_zone=$(printf '%s' "$oldest_line" | cut -f2)
+    l_epoch=$(printf '%s' "$latest_line" | cut -f1)
+    l_zone=$(printf '%s' "$latest_line" | cut -f2)
+    dt=$(( l_epoch - o_epoch ))
+    dz=$(( l_zone - o_zone ))
+    if [ "$dt" -gt 0 ] && [ "$dz" -gt 0 ] && [ "$l_zone" -lt "$hard_zone" ]; then
+      local remaining forecast_secs horizon
+      remaining=$(( hard_zone - l_zone ))
+      # forecast_secs = remaining / (dz/dt), rearranged to avoid float math.
+      forecast_secs=$(( remaining * dt / dz ))
+      horizon=$(fm_mrb_forecast_horizon_secs)
+      if [ "$forecast_secs" -le "$horizon" ]; then
+        trigger=yes
+        reasons+=("slope-forecast-crosses-hard-ceiling-in-${forecast_secs}s")
+      fi
+    elif [ "$l_zone" -ge "$hard_zone" ]; then
+      trigger=yes
+      reasons+=("zone-already-at-or-past-hard-ceiling")
+    fi
+  fi
+
+  # Condition 3: pressure no longer normal and swapouts trending up.
+  local latest_pressure trend_n trend_rows swap_sum=0
+  latest_pressure=$(tail -n 1 "$file" | cut -f10)
+  trend_n=$(fm_mrb_swap_trend_samples)
+  trend_rows=$(tail -n "$trend_n" "$file")
+  while IFS=$'\t' read -r _e _z _w _f _c _p _s _si _so _pr _zd _wd sod; do
+    [ -n "${sod:-}" ] || continue
+    swap_sum=$(( swap_sum + sod ))
+  done <<< "$trend_rows"
+  if [ -n "$latest_pressure" ] && [ "$latest_pressure" != normal ] && [ "$swap_sum" -gt 0 ]; then
+    trigger=yes
+    reasons+=("pressure-${latest_pressure}-with-rising-swapouts")
+  fi
+
+  echo "trigger=$trigger"
+  local r
+  for r in "${reasons[@]:-}"; do
+    [ -n "$r" ] && echo "reason=$r"
+  done
+}
+
+fm_mrb_evaluate_triggered() {
+  fm_mrb_evaluate | head -n 1 | grep -q '^trigger=yes$'
+}
+
+# --- idleness -------------------------------------------------------------
+# Reuses the existing idleness signals fm-crew-state.sh, tasks-axi, and the
+# documented state/ layout already establish, rather than inventing parallel
+# machinery. Every check fails closed: a missing tool, an unreadable
+# directory, or any command error is treated as "busy", never as "empty".
+
+# fm_mrb_homes_registry: one FM_HOME path per line from config/mini-reboot-homes
+# (blank/'#' lines skipped). Absent or empty registry means no home is
+# configured for idle-checking - idle-check-all then reports busy, so the
+# guard never reboots an unconfigured fleet by default.
+fm_mrb_homes_registry() {
+  local file
+  file="$(fm_mrb_config_dir)/mini-reboot-homes"
+  [ -r "$file" ] || return 0
+  grep -vE '^[[:space:]]*(#|$)' "$file" 2>/dev/null
+}
+
+# fm_mrb_idle_check_home <home>: prints "idle" or "busy: <reason>" for one
+# home. Any read/tool failure blocks (busy), never passes silently.
+fm_mrb_idle_check_home() {
+  local home=$1
+  if [ ! -d "$home" ]; then
+    echo "busy: home path does not exist: $home"
+    return 0
+  fi
+
+  # 1) zero child task metadata - the strongest simple gate (report Phase C).
+  if [ -d "$home/state" ]; then
+    local meta_count
+    meta_count=$(find "$home/state" -maxdepth 1 -name '*.meta' 2>/dev/null | wc -l | tr -d ' ')
+    if [ -z "$meta_count" ]; then
+      echo "busy: could not enumerate $home/state/*.meta"
+      return 0
+    fi
+    if [ "$meta_count" -gt 0 ]; then
+      echo "busy: $meta_count task(s) with metadata in $home/state"
+      return 0
+    fi
+  fi
+
+  # 2) no in-flight backlog item, no open captain decision (tasks-axi held).
+  # tasks-axi silently reports "count: 0" (exit 0) for a NONEXISTENT file
+  # instead of erroring, so a missing backlog for a home whose directory
+  # exists must be treated as busy explicitly - it is never read as "no
+  # obligation". `list`/`public-followup` do not accept --json (that itself
+  # errors as an unknown flag); their plain output's leading "count: N" line
+  # is what is parsed here.
+  local backlog="$home/data/backlog.md"
+  if [ ! -f "$backlog" ]; then
+    echo "busy: no backlog file at $backlog, cannot verify idleness"
+    return 0
+  fi
+  if ! command -v tasks-axi >/dev/null 2>&1; then
+    echo "busy: tasks-axi not available to check $backlog"
+    return 0
+  fi
+  local in_flight held in_flight_n held_n
+  if ! in_flight=$(tasks-axi list --file "$backlog" --state in_flight 2>&1); then
+    echo "busy: tasks-axi in_flight check failed for $backlog: $in_flight"
+    return 0
+  fi
+  in_flight_n=$(printf '%s\n' "$in_flight" | awk -F': ' '/^count:/{print $2; exit}')
+  if ! [[ "$in_flight_n" =~ ^[0-9]+$ ]]; then
+    echo "busy: could not parse tasks-axi in_flight count for $backlog"
+    return 0
+  fi
+  if [ "$in_flight_n" -gt 0 ]; then
+    echo "busy: $in_flight_n in-flight backlog item(s) in $backlog"
+    return 0
+  fi
+  if ! held=$(tasks-axi list --file "$backlog" --state held 2>&1); then
+    echo "busy: tasks-axi held check failed for $backlog: $held"
+    return 0
+  fi
+  held_n=$(printf '%s\n' "$held" | awk -F': ' '/^count:/{print $2; exit}')
+  if ! [[ "$held_n" =~ ^[0-9]+$ ]]; then
+    echo "busy: could not parse tasks-axi held count for $backlog"
+    return 0
+  fi
+  if [ "$held_n" -gt 0 ]; then
+    echo "busy: $held_n open captain decision(s) held in $backlog"
+    return 0
+  fi
+
+  # 3) no unhandled steering-inbox message for any task under this home.
+  if [ -d "$home/state" ]; then
+    local unhandled
+    unhandled=$(find "$home/state" -mindepth 2 -maxdepth 2 -path '*.inbox/*.msg' 2>/dev/null | head -n 1)
+    if [ -n "$unhandled" ]; then
+      echo "busy: unhandled steering inbox message under $home/state"
+      return 0
+    fi
+  fi
+
+  # 4) no pending remote reply.
+  if [ -d "$home/state/pending-replies" ]; then
+    local pr_count
+    pr_count=$(find "$home/state/pending-replies" -mindepth 1 2>/dev/null | wc -l | tr -d ' ')
+    if [ -z "$pr_count" ]; then
+      echo "busy: could not enumerate $home/state/pending-replies"
+      return 0
+    fi
+    if [ "$pr_count" -gt 0 ]; then
+      echo "busy: pending remote reply record(s) in $home/state/pending-replies"
+      return 0
+    fi
+  fi
+
+  # 5) no promised public reply still owed. Both the backlog and tasks-axi
+  # presence were already established above (they are required, not
+  # optional, for this home to be checked at all).
+  local followup followup_n
+  if ! followup=$(tasks-axi public-followup ready --file "$backlog" 2>&1); then
+    echo "busy: tasks-axi public-followup check failed for $backlog: $followup"
+    return 0
+  fi
+  followup_n=$(printf '%s\n' "$followup" | awk -F': ' '/^count:/{print $2; exit}')
+  if ! [[ "$followup_n" =~ ^[0-9]+$ ]]; then
+    echo "busy: could not parse tasks-axi public-followup count for $backlog"
+    return 0
+  fi
+  if [ "$followup_n" -gt 0 ]; then
+    echo "busy: $followup_n promised public reply/replies still owed for $backlog"
+    return 0
+  fi
+
+  # 6) no registered process-event source (presence alone keeps supervision
+  #    required, per AGENTS.md).
+  if [ -d "$home/state/procevent" ]; then
+    local pe_count
+    pe_count=$(find "$home/state/procevent" -mindepth 1 2>/dev/null | wc -l | tr -d ' ')
+    if [ -z "$pe_count" ]; then
+      echo "busy: could not enumerate $home/state/procevent"
+      return 0
+    fi
+    if [ "$pe_count" -gt 0 ]; then
+      echo "busy: registered process-event source(s) in $home/state/procevent"
+      return 0
+    fi
+  fi
+
+  echo idle
+}
+
+# fm_mrb_idle_check_all: prints "idle" only when every registered home reports
+# idle. An empty registry, or any single busy/error home, blocks.
+fm_mrb_idle_check_all() {
+  local homes home verdict any=0
+  homes=$(fm_mrb_homes_registry)
+  if [ -z "$homes" ]; then
+    echo "busy: no homes registered for idle-check (config/mini-reboot-homes)"
+    return 0
+  fi
+  while IFS= read -r home; do
+    [ -n "$home" ] || continue
+    any=1
+    verdict=$(fm_mrb_idle_check_home "$home")
+    if [ "$verdict" != idle ]; then
+      echo "$verdict (home=$home)"
+      return 0
+    fi
+  done <<< "$homes"
+  if [ "$any" -eq 0 ]; then
+    echo "busy: no homes registered for idle-check (config/mini-reboot-homes)"
+    return 0
+  fi
+  echo idle
+}
+
+# fm_mrb_idle_confirm: runs idle-check-all now, persists the snapshot, and
+# compares it with the immediately preceding persisted snapshot. Confirmed
+# only when both snapshots are idle AND the gap between them is within
+# [idle_min_gap_secs, idle_max_gap_secs] - two genuinely back-to-back idle
+# reads, not a momentary gap and not two isolated readings stitched together
+# across an unrelated span (report Phase D: "two identical fleet snapshots at
+# least 5 minutes apart"). Always persists the current snapshot for next time,
+# regardless of the verdict.
+fm_mrb_idle_confirm() {
+  local file now verdict prev_epoch prev_verdict confirmed=no reason
+  file=$(fm_mrb_idle_snapshot_file)
+  now=$(fm_mrb_now)
+  verdict=$(fm_mrb_idle_check_all)
+
+  if [ -s "$file" ]; then
+    local last
+    last=$(tail -n 1 "$file")
+    prev_epoch=$(printf '%s' "$last" | cut -f1)
+    prev_verdict=$(printf '%s' "$last" | cut -f2-)
+  fi
+
+  if [ "$verdict" = idle ] && [ "${prev_verdict:-}" = idle ] && [ -n "${prev_epoch:-}" ]; then
+    local gap min_gap max_gap
+    gap=$(( now - prev_epoch ))
+    min_gap=$(fm_mrb_idle_min_gap_secs)
+    max_gap=$(fm_mrb_idle_max_gap_secs)
+    if [ "$gap" -ge "$min_gap" ] && [ "$gap" -le "$max_gap" ]; then
+      confirmed=yes
+      reason="two-idle-snapshots-${gap}s-apart"
+    else
+      reason="idle-but-gap-out-of-window(${gap}s)"
+    fi
+  else
+    reason="not-both-idle(now=$verdict prev=${prev_verdict:-none})"
+  fi
+
+  printf '%s\t%s\n' "$now" "$verdict" >> "$file"
+
+  echo "confirmed=$confirmed"
+  echo "reason=$reason"
+  echo "verdict=$verdict"
+}
+
+fm_mrb_idle_confirmed() {
+  fm_mrb_idle_confirm | head -n 1 | grep -q '^confirmed=yes$'
+}
+
+# --- mini-only gate and reboot execution ----------------------------------
+
+# fm_mrb_host_is_mini: true only when config/host-role is present and its
+# trimmed content is exactly "mini". Absent-by-default, so a MacBook (or any
+# unconfigured host) never reboots through this code.
+fm_mrb_host_is_mini() {
+  local file content
+  file="$(fm_mrb_config_dir)/host-role"
+  [ -r "$file" ] || return 1
+  content=$(tr -d '[:space:]' < "$file")
+  [ "$content" = mini ]
+}
+
+# fm_mrb_reboot_marker_active: true when a reboot was already attempted and
+# the marker's recorded boot-session id still matches the live one (i.e. the
+# machine has not actually rebooted since) and the marker is not yet stale.
+# A boot-session-id mismatch means the reboot happened - clears the marker and
+# returns false. A same-session marker older than fm_mrb_marker_max_age_secs
+# means the helper evidently did not reboot us - clears it and returns false
+# so evaluation can resume.
+fm_mrb_reboot_marker_active() {
+  local file epoch boot_id now cur_boot
+  file=$(fm_mrb_reboot_marker_file)
+  [ -f "$file" ] || return 1
+  epoch=$(awk -F'\t' 'NR==1{print $1}' "$file" 2>/dev/null)
+  boot_id=$(awk -F'\t' 'NR==1{print $2}' "$file" 2>/dev/null)
+  cur_boot=$(fm_mrb_boot_session_id)
+  if [ -n "$cur_boot" ] && [ "$boot_id" != "$cur_boot" ]; then
+    fm_mrb_log "boot-session changed since marker ($boot_id -> $cur_boot): reboot happened, clearing marker"
+    rm -f "$file"
+    return 1
+  fi
+  now=$(fm_mrb_now)
+  if [ -n "$epoch" ] && [ $(( now - epoch )) -gt "$(fm_mrb_marker_max_age_secs)" ]; then
+    fm_mrb_log "reboot marker stale (age $(( now - epoch ))s): helper apparently did not reboot us, clearing"
+    rm -f "$file"
+    return 1
+  fi
+  return 0
+}
+
+fm_mrb_write_reboot_marker() {
+  local file tmp
+  file=$(fm_mrb_reboot_marker_file)
+  tmp="$file.tmp.$$"
+  printf '%s\t%s\t%s\n' "$(fm_mrb_now)" "$(fm_mrb_boot_session_id)" "$1" > "$tmp"
+  mv "$tmp" "$file"
+}
+
+# fm_mrb_execute_reboot <reason>: refuses off-mini, refuses without a
+# configured+executable helper (never fakes privileged execution - it STOPS
+# and logs the exact requirement instead), and writes the reboot-in-progress
+# marker BEFORE invoking the helper so a hang or crash after the helper starts
+# does not immediately re-fire on the next cycle.
+fm_mrb_execute_reboot() {
+  local reason=$1 helper_path log
+  log=$(fm_mrb_attempts_log)
+
+  if ! fm_mrb_host_is_mini; then
+    fm_mrb_log "refusing reboot: this host is not configured as config/host-role=mini"
+    printf '%s\trefused\tnot-mini\n' "$(fm_mrb_now)" >> "$log"
+    return 1
+  fi
+
+  helper_path="$(fm_mrb_config_dir)/mini-reboot-helper"
+  local helper
+  if [ -r "$helper_path" ]; then
+    helper=$(tr -d '[:space:]' < "$helper_path")
+  fi
+  if [ -z "${helper:-}" ] || [ ! -x "$helper" ]; then
+    fm_mrb_log "BLOCKED: no privileged reboot mechanism configured."
+    fm_mrb_log "Need config/${FM_MRB_CONFIG_OVERRIDE:+(override) }host-role=mini plus config/mini-reboot-helper naming an executable, root-authorized reboot helper (e.g. a signed launchd-privileged-helper, or a narrowly-scoped sudoers NOPASSWD entry for /sbin/shutdown -r now) - not present or not executable at: ${helper:-<unset>}"
+    printf '%s\tblocked\tno-helper-configured\n' "$(fm_mrb_now)" >> "$log"
+    return 3
+  fi
+
+  fm_mrb_write_reboot_marker "$reason"
+  fm_mrb_log "invoking reboot helper: $helper (reason: $reason)"
+  local status=0
+  "$helper" "$reason" || status=$?
+  if [ "$status" -eq 0 ]; then
+    fm_mrb_log "reboot helper exited 0"
+    printf '%s\tinvoked\t%s\n' "$(fm_mrb_now)" "$reason" >> "$log"
+  else
+    fm_mrb_log "reboot helper exited $status"
+    printf '%s\thelper-failed(%s)\t%s\n' "$(fm_mrb_now)" "$status" "$reason" >> "$log"
+  fi
+  return "$status"
+}
+
+# --- orchestration ---------------------------------------------------------
+
+# fm_mrb_with_lock <fn> [args...]: runs <fn> under a single-instance mkdir
+# lock so overlapping `check` invocations (e.g. a hung prior run still active
+# when the next scheduled tick fires) never race. Crash-safe: the owner pid is
+# written to a temp file and atomically renamed into the lock dir, so there is
+# never a window where the lock exists without an identifiable owner. A lock
+# whose recorded owner pid is no longer alive is reclaimed unconditionally by
+# process liveness alone - this is a purely local, single-machine lock with at
+# most one legitimate holder, not the distributed admission boundary the
+# discarded drain design needed, so a simple dead-owner check is sufficient.
+fm_mrb_with_lock() {
+  local lock owner_file pid tries=0
+  lock=$(fm_mrb_lock_dir)
+  owner_file="$lock/owner"
+  while ! mkdir "$lock" 2>/dev/null; do
+    if [ -f "$owner_file" ]; then
+      pid=$(cat "$owner_file" 2>/dev/null)
+      if [ -n "$pid" ] && ! kill -0 "$pid" 2>/dev/null; then
+        fm_mrb_log "reclaiming lock from dead owner pid=$pid"
+        rm -rf "$lock"
+        continue
+      fi
+    fi
+    tries=$((tries + 1))
+    if [ "$tries" -ge 3 ]; then
+      fm_mrb_log "check already running (lock held), skipping this cycle"
+      return 0
+    fi
+    sleep 1
+  done
+  local tmp="$lock/owner.tmp.$$"
+  echo $$ > "$tmp"
+  mv "$tmp" "$owner_file"
+  trap 'rm -rf "$lock"' RETURN
+  "$@"
+}
+
+# fm_mrb_check_cycle: the full detect -> idle -> reboot decision for one
+# invocation of `check`. Short-circuits on an active reboot marker, and skips
+# the (more expensive) idle confirmation entirely unless the resource
+# condition actually triggered - AND requires both, so there is never a
+# reason to pay for idle-checking when resource is fine.
+fm_mrb_check_cycle() {
+  if fm_mrb_reboot_marker_active; then
+    fm_mrb_log "reboot marker active: a reboot attempt is already in flight, skipping this cycle"
+    return 0
+  fi
+
+  fm_mrb_append_sample
+
+  local eval_out trig_line
+  eval_out=$(fm_mrb_evaluate)
+  trig_line=$(printf '%s\n' "$eval_out" | head -n 1)
+  if [ "$trig_line" != "trigger=yes" ]; then
+    fm_mrb_log "resource condition not triggered, doing nothing"
+    return 0
+  fi
+  fm_mrb_log "resource condition triggered:"
+  printf '%s\n' "$eval_out" | tail -n +2 | while IFS= read -r line; do fm_mrb_log "  $line"; done
+
+  local idle_out confirmed_line
+  idle_out=$(fm_mrb_idle_confirm)
+  confirmed_line=$(printf '%s\n' "$idle_out" | head -n 1)
+  if [ "$confirmed_line" != "confirmed=yes" ]; then
+    fm_mrb_log "resource triggered but idle window not confirmed, staying put:"
+    printf '%s\n' "$idle_out" | while IFS= read -r line; do fm_mrb_log "  $line"; done
+    return 0
+  fi
+
+  fm_mrb_log "both conditions hold: resource triggered AND idle window confirmed - executing reboot"
+  local reason
+  reason=$(printf '%s\n' "$eval_out" | tail -n +2 | tr '\n' ';')
+  fm_mrb_execute_reboot "$reason"
+}

--- a/bin/fm-mini-reboot-lib.sh
+++ b/bin/fm-mini-reboot-lib.sh
@@ -317,7 +317,8 @@ fm_mrb_evaluate() {
     [ -n "${sod:-}" ] || continue
     swap_sum=$(( swap_sum + sod ))
   done <<< "$trend_rows"
-  if [ -n "$latest_pressure" ] && [ "$latest_pressure" != normal ] && [ "$swap_sum" -gt 0 ]; then
+  if { [ "$latest_pressure" = warn ] || [ "$latest_pressure" = critical ]; } \
+      && [ "$swap_sum" -gt 0 ]; then
     trigger=yes
     reasons+=("pressure-${latest_pressure}-with-rising-swapouts")
   fi
@@ -359,18 +360,22 @@ fm_mrb_idle_check_home() {
     return 0
   fi
 
+  local state="$home/state"
+  if [ ! -d "$state" ] || [ ! -r "$state" ]; then
+    echo "busy: state directory is missing or unreadable: $state"
+    return 0
+  fi
+
   # 1) zero child task metadata - the strongest simple gate (report Phase C).
-  if [ -d "$home/state" ]; then
-    local meta_count
-    meta_count=$(find "$home/state" -maxdepth 1 -name '*.meta' 2>/dev/null | wc -l | tr -d ' ')
-    if [ -z "$meta_count" ]; then
-      echo "busy: could not enumerate $home/state/*.meta"
-      return 0
-    fi
-    if [ "$meta_count" -gt 0 ]; then
-      echo "busy: $meta_count task(s) with metadata in $home/state"
-      return 0
-    fi
+  local meta_paths meta_count
+  if ! meta_paths=$(find "$state" -maxdepth 1 -name '*.meta' -print 2>&1); then
+    echo "busy: could not enumerate $state/*.meta: $meta_paths"
+    return 0
+  fi
+  meta_count=$(printf '%s\n' "$meta_paths" | awk 'NF { count++ } END { print count + 0 }')
+  if [ "$meta_count" -gt 0 ]; then
+    echo "busy: $meta_count task(s) with metadata in $state"
+    return 0
   fi
 
   # 2) no in-flight backlog item, no open captain decision (tasks-axi held).
@@ -418,25 +423,25 @@ fm_mrb_idle_check_home() {
   fi
 
   # 3) no unhandled steering-inbox message for any task under this home.
-  if [ -d "$home/state" ]; then
-    local unhandled
-    unhandled=$(find "$home/state" -mindepth 2 -maxdepth 2 -path '*.inbox/*.msg' 2>/dev/null | head -n 1)
-    if [ -n "$unhandled" ]; then
-      echo "busy: unhandled steering inbox message under $home/state"
-      return 0
-    fi
+  local unhandled
+  if ! unhandled=$(find "$state" -mindepth 2 -maxdepth 2 -path '*.inbox/*.msg' -print 2>&1); then
+    echo "busy: could not enumerate steering inboxes under $state: $unhandled"
+    return 0
+  fi
+  if [ -n "$unhandled" ]; then
+    echo "busy: unhandled steering inbox message under $state"
+    return 0
   fi
 
   # 4) no pending remote reply.
-  if [ -d "$home/state/pending-replies" ]; then
-    local pr_count
-    pr_count=$(find "$home/state/pending-replies" -mindepth 1 2>/dev/null | wc -l | tr -d ' ')
-    if [ -z "$pr_count" ]; then
-      echo "busy: could not enumerate $home/state/pending-replies"
+  if [ -d "$state/pending-replies" ]; then
+    local pr_paths
+    if ! pr_paths=$(find "$state/pending-replies" -mindepth 1 -print 2>&1); then
+      echo "busy: could not enumerate $state/pending-replies: $pr_paths"
       return 0
     fi
-    if [ "$pr_count" -gt 0 ]; then
-      echo "busy: pending remote reply record(s) in $home/state/pending-replies"
+    if [ -n "$pr_paths" ]; then
+      echo "busy: pending remote reply record(s) in $state/pending-replies"
       return 0
     fi
   fi
@@ -444,14 +449,22 @@ fm_mrb_idle_check_home() {
   # 5) no promised public reply still owed. Both the backlog and tasks-axi
   # presence were already established above (they are required, not
   # optional, for this home to be checked at all).
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "busy: jq not available to inspect public followups for $backlog"
+    return 0
+  fi
   local followup followup_n
-  if ! followup=$(tasks-axi public-followup ready --file "$backlog" 2>&1); then
+  if ! followup=$(tasks-axi public-followup list --file "$backlog" --json 2>&1); then
     echo "busy: tasks-axi public-followup check failed for $backlog: $followup"
     return 0
   fi
-  followup_n=$(printf '%s\n' "$followup" | awk -F': ' '/^count:/{print $2; exit}')
+  if ! followup_n=$(printf '%s\n' "$followup" | jq -er \
+      '(.public_followups // []) | map(select((.state // "") != "done")) | length' 2>/dev/null); then
+    echo "busy: could not parse tasks-axi public-followup list for $backlog"
+    return 0
+  fi
   if ! [[ "$followup_n" =~ ^[0-9]+$ ]]; then
-    echo "busy: could not parse tasks-axi public-followup count for $backlog"
+    echo "busy: invalid tasks-axi public-followup count for $backlog"
     return 0
   fi
   if [ "$followup_n" -gt 0 ]; then
@@ -461,15 +474,14 @@ fm_mrb_idle_check_home() {
 
   # 6) no registered process-event source (presence alone keeps supervision
   #    required, per AGENTS.md).
-  if [ -d "$home/state/procevent" ]; then
-    local pe_count
-    pe_count=$(find "$home/state/procevent" -mindepth 1 2>/dev/null | wc -l | tr -d ' ')
-    if [ -z "$pe_count" ]; then
-      echo "busy: could not enumerate $home/state/procevent"
+  if [ -d "$state/procevent" ]; then
+    local pe_paths
+    if ! pe_paths=$(find "$state/procevent" -mindepth 1 -print 2>&1); then
+      echo "busy: could not enumerate $state/procevent: $pe_paths"
       return 0
     fi
-    if [ "$pe_count" -gt 0 ]; then
-      echo "busy: registered process-event source(s) in $home/state/procevent"
+    if [ -n "$pe_paths" ]; then
+      echo "busy: registered process-event source(s) in $state/procevent"
       return 0
     fi
   fi
@@ -641,40 +653,78 @@ fm_mrb_execute_reboot() {
 
 # --- orchestration ---------------------------------------------------------
 
-# fm_mrb_with_lock <fn> [args...]: runs <fn> under a single-instance mkdir
-# lock so overlapping `check` invocations (e.g. a hung prior run still active
-# when the next scheduled tick fires) never race. Crash-safe: the owner pid is
-# written to a temp file and atomically renamed into the lock dir, so there is
-# never a window where the lock exists without an identifiable owner. A lock
-# whose recorded owner pid is no longer alive is reclaimed unconditionally by
-# process liveness alone - this is a purely local, single-machine lock with at
-# most one legitimate holder, not the distributed admission boundary the
-# discarded drain design needed, so a simple dead-owner check is sufficient.
+# fm_mrb_with_lock <fn> [args...]: runs <fn> under a single-instance lock so
+# overlapping `check` invocations (e.g. a hung prior run still active when the
+# next scheduled tick fires) never race. Creation uses the shell's exclusive
+# noclobber open. The owner identity combines pid and process start time, and
+# an ownerless interrupted write is reclaimed only after a grace period.
+fm_mrb_process_identity() {
+  local pid=$1 start
+  start=$(ps -p "$pid" -o lstart= 2>/dev/null | awk '{$1=$1; print}')
+  [ -n "$start" ] || return 1
+  printf '%s\t%s\n' "$pid" "$start"
+}
+
+fm_mrb_lock_mtime() {
+  local value
+  value=$(stat -f '%m' "$1" 2>/dev/null || true)
+  case "$value" in ''|*[!0-9]*) stat -c '%Y' "$1" 2>/dev/null ;; *) echo "$value" ;; esac
+}
+
 fm_mrb_with_lock() {
-  local lock owner_file pid tries=0
+  local lock owner_file owner_value owner pid signature live_identity tries=0
+  local mtime age grace=${FM_MRB_LOCK_OWNERLESS_GRACE_SECS:-60}
   lock=$(fm_mrb_lock_dir)
-  owner_file="$lock/owner"
-  while ! mkdir "$lock" 2>/dev/null; do
-    if [ -f "$owner_file" ]; then
-      pid=$(cat "$owner_file" 2>/dev/null)
-      if [ -n "$pid" ] && ! kill -0 "$pid" 2>/dev/null; then
-        fm_mrb_log "reclaiming lock from dead owner pid=$pid"
+  owner_value=$(fm_mrb_process_identity "$$") || {
+    fm_mrb_log "could not establish lock owner identity"
+    return 1
+  }
+
+  while ! (set -o noclobber; printf '%s\n' "$owner_value" > "$lock") 2>/dev/null; do
+    if [ -d "$lock" ]; then
+      owner_file="$lock/owner"
+    else
+      owner_file="$lock"
+    fi
+    owner=
+    [ ! -f "$owner_file" ] || owner=$(cat "$owner_file" 2>/dev/null)
+    if [ -n "$owner" ]; then
+      pid=${owner%%$'\t'*}
+      signature=
+      case "$owner" in *$'\t'*) signature=${owner#*$'\t'} ;; esac
+      live_identity=
+      case "$pid" in ''|*[!0-9]*) ;; *) live_identity=$(fm_mrb_process_identity "$pid" 2>/dev/null || true) ;; esac
+      if [ -z "$live_identity" ] || { [ -n "$signature" ] && [ "$live_identity" != "$owner" ]; }; then
+        fm_mrb_log "reclaiming lock from stale owner pid=${pid:-unknown}"
         rm -rf "$lock"
         continue
       fi
     fi
     tries=$((tries + 1))
     if [ "$tries" -ge 3 ]; then
+      if [ -z "$owner" ]; then
+        mtime=$(fm_mrb_lock_mtime "$lock" || true)
+        age=0
+        [ -z "$mtime" ] || age=$(( $(fm_mrb_now) - mtime ))
+        if [ -n "$mtime" ] && [ "$age" -ge "$grace" ]; then
+          fm_mrb_log "reclaiming abandoned ownerless lock"
+          rm -rf "$lock"
+          continue
+        fi
+      fi
       fm_mrb_log "check already running (lock held), skipping this cycle"
       return 0
     fi
     sleep 1
   done
-  local tmp="$lock/owner.tmp.$$"
-  echo $$ > "$tmp"
-  mv "$tmp" "$owner_file"
-  trap 'rm -rf "$lock"' RETURN
-  "$@"
+
+  local status=0 current_owner
+  "$@" || status=$?
+  current_owner=$(cat "$lock" 2>/dev/null || true)
+  if [ "$current_owner" = "$owner_value" ]; then
+    rm -f "$lock"
+  fi
+  return "$status"
 }
 
 # fm_mrb_check_cycle: the full detect -> idle -> reboot decision for one

--- a/bin/fm-mini-reboot-lib.sh
+++ b/bin/fm-mini-reboot-lib.sh
@@ -707,107 +707,44 @@ fm_mrb_execute_reboot() {
 
 # --- orchestration ---------------------------------------------------------
 
-# fm_mrb_with_lock <fn> [args...]: runs <fn> under a single-instance lock so
-# overlapping `check` invocations (e.g. a hung prior run still active when the
-# next scheduled tick fires) never race. Creation uses the shell's exclusive
-# noclobber open. The owner identity combines pid and process start time, and
-# an ownerless interrupted write is reclaimed only after a grace period.
-fm_mrb_process_identity() {
-  local pid=$1 start
-  start=$(ps -p "$pid" -o lstart= 2>/dev/null | awk '{$1=$1; print}')
-  [ -n "$start" ] || return 1
-  printf '%s\t%s\n' "$pid" "$start"
-}
-
-fm_mrb_lock_mtime() {
-  local value
-  value=$(stat -f '%m' "$1" 2>/dev/null || true)
-  case "$value" in ''|*[!0-9]*) stat -c '%Y' "$1" 2>/dev/null ;; *) echo "$value" ;; esac
-}
-
-fm_mrb_lock_owner() {
-  local lock=$1
-  [ ! -f "$lock" ] || cat "$lock" 2>/dev/null
-}
-
-fm_mrb_lock_owner_stale() {
-  local owner=$1 pid signature live_identity
-  [ -n "$owner" ] || return 1
-  pid=${owner%%$'\t'*}
-  signature=
-  case "$owner" in *$'\t'*) signature=${owner#*$'\t'} ;; esac
-  live_identity=
-  case "$pid" in ''|*[!0-9]*) ;; *) live_identity=$(fm_mrb_process_identity "$pid" 2>/dev/null || true) ;; esac
-  [ -z "$live_identity" ] || { [ -n "$signature" ] && [ "$live_identity" != "$owner" ]; }
-}
-
-fm_mrb_lock_ownerless_stale() {
-  local lock=$1 grace=$2 mtime age
-  mtime=$(fm_mrb_lock_mtime "$lock" || true)
-  [ -n "$mtime" ] || return 1
-  age=$(( $(fm_mrb_now) - mtime ))
-  [ "$age" -ge "$grace" ]
-}
-
-fm_mrb_reclaim_lock() {
-  local lock=$1 expected=$2 grace=$3 reap current reclaimed=1
-  reap="$lock.reap"
-  if [ ! -e "$reap" ]; then
-    ln "$lock" "$reap" 2>/dev/null || return 1
-  fi
-  if [ -f "$lock" ] && [ "$lock" -ef "$reap" ]; then
-    current=$(fm_mrb_lock_owner "$reap")
-    if [ "$current" = "$expected" ]; then
-      if { [ -n "$current" ] && fm_mrb_lock_owner_stale "$current"; } || \
-         { [ -z "$current" ] && fm_mrb_lock_ownerless_stale "$reap" "$grace"; }; then
-        rm -f "$lock"
-        reclaimed=0
-      fi
-    fi
-  fi
-  rm -f "$reap"
-  return "$reclaimed"
-}
-
+# fm_mrb_with_lock <fn> [args...]: runs <fn> under a single-instance mkdir
+# lock so overlapping `check` invocations never run together. A dead recorded
+# owner is reclaimed; a live owner causes this cycle to skip after bounded
+# retries.
 fm_mrb_with_lock() {
-  local lock owner_value owner pid tries=0
-  local grace=${FM_MRB_LOCK_OWNERLESS_GRACE_SECS:-60}
+  local lock owner_file owner_pid tries=0 tmp status=0
   lock=$(fm_mrb_lock_dir)
-  owner_value=$(fm_mrb_process_identity "$$") || {
-    fm_mrb_log "could not establish lock owner identity"
-    return 1
-  }
+  owner_file="$lock/owner"
 
-  while :; do
-    if (set -o noclobber; printf '%s\n' "$owner_value" > "$lock") 2>/dev/null; then
-      break
-    fi
-    owner=$(fm_mrb_lock_owner "$lock")
-    if fm_mrb_lock_owner_stale "$owner"; then
-      pid=${owner%%$'\t'*}
-      if fm_mrb_reclaim_lock "$lock" "$owner" "$grace"; then
-        fm_mrb_log "reclaimed lock from stale owner pid=${pid:-unknown}"
-        continue
-      fi
-    fi
+  while ! mkdir "$lock" 2>/dev/null; do
+    owner_pid=$(cat "$owner_file" 2>/dev/null || true)
+    case "$owner_pid" in
+      ''|*[!0-9]*) ;;
+      *)
+        if ! kill -0 "$owner_pid" 2>/dev/null; then
+          fm_mrb_log "reclaiming lock from dead owner pid=$owner_pid"
+          rm -rf "$lock"
+          continue
+        fi
+        ;;
+    esac
     tries=$((tries + 1))
     if [ "$tries" -ge 3 ]; then
-      if [ -z "$owner" ] && fm_mrb_reclaim_lock "$lock" "$owner" "$grace"; then
-        fm_mrb_log "reclaimed abandoned ownerless lock"
-        continue
-      fi
       fm_mrb_log "check already running (lock held), skipping this cycle"
       return 0
     fi
     sleep 1
   done
 
-  local status=0 current_owner
-  "$@" || status=$?
-  current_owner=$(fm_mrb_lock_owner "$lock")
-  if [ "$current_owner" = "$owner_value" ]; then
-    rm -f "$lock"
+  tmp="$lock/owner.tmp.$$"
+  if ! printf '%s\n' "$$" > "$tmp" || ! mv "$tmp" "$owner_file"; then
+    rm -rf "$lock"
+    fm_mrb_log "could not publish lock owner"
+    return 1
   fi
+
+  "$@" || status=$?
+  rm -rf "$lock"
   return "$status"
 }
 

--- a/bin/fm-mini-reboot-lib.sh
+++ b/bin/fm-mini-reboot-lib.sh
@@ -52,6 +52,7 @@ fm_mrb_state_dir() {
 
 fm_mrb_samples_file() { echo "$(fm_mrb_state_dir)/samples.tsv"; }
 fm_mrb_idle_snapshot_file() { echo "$(fm_mrb_state_dir)/idle-snapshot.tsv"; }
+fm_mrb_boot_history_file() { echo "$(fm_mrb_state_dir)/boot-session"; }
 fm_mrb_lock_dir() { echo "$(fm_mrb_state_dir)/check.lock"; }
 fm_mrb_reboot_marker_file() { echo "$(fm_mrb_state_dir)/reboot-in-progress"; }
 fm_mrb_attempts_log() { echo "$(fm_mrb_state_dir)/reboot-attempts.log"; }
@@ -147,6 +148,22 @@ fm_mrb_boot_session_id() {
   sysctl -n kern.bootsessionuuid 2>/dev/null
 }
 
+fm_mrb_sync_boot_history() {
+  local file current recorded tmp
+  file=$(fm_mrb_boot_history_file)
+  current=$(fm_mrb_boot_session_id) || return 1
+  case "$current" in ''|*$'\t'*|*$'\n'*|*$'\r'*) return 1 ;; esac
+  recorded=
+  [ ! -f "$file" ] || recorded=$(cat "$file" 2>/dev/null || true)
+  if [ "$recorded" != "$current" ]; then
+    rm -f "$(fm_mrb_samples_file)" "$(fm_mrb_idle_snapshot_file)"
+    tmp="$file.tmp.$$"
+    printf '%s\n' "$current" > "$tmp" || return 1
+    mv "$tmp" "$file" || return 1
+    [ -z "$recorded" ] || fm_mrb_log "boot session changed; reset sample and idle history"
+  fi
+}
+
 # fm_mrb_collect_sample: prints one TSV row of RAW metrics (no deltas - those
 # are computed and persisted by fm_mrb_append_sample against the prior row,
 # per the sample contract):
@@ -192,6 +209,10 @@ fm_mrb_collect_sample() {
 #   zone_delta wired_delta swapouts_delta
 fm_mrb_append_sample() {
   local file raw prev_zone=0 prev_wired=0 prev_swapouts=0 has_prev=0
+  if ! fm_mrb_sync_boot_history; then
+    fm_mrb_log "boot session unavailable; sample not recorded"
+    return 1
+  fi
   file=$(fm_mrb_samples_file)
   fm_mrb_prune_old_samples
   if [ -s "$file" ]; then
@@ -257,6 +278,11 @@ fm_mrb_sample_count() {
 # sample, or from an as-yet too-short history).
 fm_mrb_evaluate() {
   local file total maint_zone maint_wired hard_zone
+  if ! fm_mrb_sync_boot_history; then
+    echo "trigger=no"
+    echo "reason=boot-session-unavailable"
+    return 0
+  fi
   file=$(fm_mrb_samples_file)
   total=$(fm_mrb_sample_count "$file")
   maint_zone=$(fm_mrb_maint_zone_bytes)
@@ -568,6 +594,12 @@ fm_mrb_idle_check_all() {
 # regardless of the verdict.
 fm_mrb_idle_confirm() {
   local file now verdict prev_epoch prev_verdict confirmed=no reason
+  if ! fm_mrb_sync_boot_history; then
+    echo "confirmed=no"
+    echo "reason=boot-session-unavailable"
+    echo "verdict=busy: boot session unavailable"
+    return 0
+  fi
   file=$(fm_mrb_idle_snapshot_file)
   now=$(fm_mrb_now)
   verdict=$(fm_mrb_idle_check_all)
@@ -638,6 +670,7 @@ fm_mrb_reboot_marker_active() {
   cur_boot=$(fm_mrb_boot_session_id)
   if [ -n "$boot_id" ] && [ -n "$cur_boot" ] && [ "$boot_id" != "$cur_boot" ]; then
     fm_mrb_log "boot-session changed since marker ($boot_id -> $cur_boot): reboot happened, clearing marker"
+    fm_mrb_sync_boot_history >/dev/null 2>&1 || true
     rm -f "$file"
     return 1
   fi

--- a/bin/fm-mini-reboot-lib.sh
+++ b/bin/fm-mini-reboot-lib.sh
@@ -3,8 +3,8 @@
 # mini host. NOT sourced by fm-spawn.sh, fm-promote.sh, or fm-backlog-handoff.sh:
 # this feature does not touch cross-home admission at all.
 #
-# Design (captain 2026-08-24 retarget): no drain, no admission lock, no
-# blocking or holding new work, no fleet-emptying, no attack resistance, no
+# Design: no drain, no admission lock, no blocking or holding new work, no
+# fleet-emptying, no attack resistance, no
 # readiness-receipt machinery. Reboot the mini ONLY when BOTH:
 #   (a) a resource-leak/pressure threshold has genuinely been crossed
 #       (never from a single sample - see fm_mrb_evaluate); AND
@@ -57,7 +57,7 @@ fm_mrb_lock_dir() { echo "$(fm_mrb_state_dir)/check.lock"; }
 fm_mrb_reboot_marker_file() { echo "$(fm_mrb_state_dir)/reboot-in-progress"; }
 fm_mrb_attempts_log() { echo "$(fm_mrb_state_dir)/reboot-attempts.log"; }
 
-# --- thresholds (mini 64 GiB row, report section 4) ---------------------
+# --- thresholds (64 GiB mini defaults) ---------------------------------
 # Overridable only via env, for tests. No persistent tunable config file:
 # keep this minimal and single-purpose rather than growing a generic knob
 # surface.
@@ -70,7 +70,7 @@ fm_mrb_forecast_horizon_secs() { echo "${FM_MRB_FORECAST_HORIZON_SECS:-86400}"; 
 fm_mrb_swap_trend_samples() { echo "${FM_MRB_SWAP_TREND_SAMPLES:-3}"; }
 fm_mrb_min_trigger_samples() { echo "${FM_MRB_MIN_TRIGGER_SAMPLES:-3}"; }
 fm_mrb_prune_window_secs() { echo "${FM_MRB_PRUNE_WINDOW_SECS:-1209600}"; }  # 14 days
-fm_mrb_idle_min_gap_secs() { echo "${FM_MRB_IDLE_MIN_GAP_SECS:-300}"; }   # 5 min, report Phase D
+fm_mrb_idle_min_gap_secs() { echo "${FM_MRB_IDLE_MIN_GAP_SECS:-300}"; }   # 5 min
 fm_mrb_idle_max_gap_secs() { echo "${FM_MRB_IDLE_MAX_GAP_SECS:-1800}"; }  # 30 min: stitched, not stale
 fm_mrb_marker_max_age_secs() { echo "${FM_MRB_MARKER_MAX_AGE_SECS:-1200}"; }  # 20 min
 
@@ -89,8 +89,8 @@ fm_mrb_vm_stat_field() {
   '
 }
 
-# fm_mrb_zone_bytes: live payload of the two named leaking zones (report
-# section 4: element size * in-use count for data.kalloc.1024 and
+# fm_mrb_zone_bytes: live payload of the two named leaking zones (element
+# size * in-use count for data.kalloc.1024 and
 # data_shared.kalloc.1024), in bytes.
 fm_mrb_zone_bytes() {
   local raw
@@ -353,7 +353,7 @@ fm_mrb_evaluate() {
     fi
   fi
 
-  # Condition 3: pressure no longer normal and swapouts trending up.
+  # Condition 3: warning/critical pressure and swapouts trending up.
   local latest_pressure trend_n trend_rows first_swapouts latest_swapouts swap_trend=0
   latest_pressure=$(tail -n 1 "$file" | cut -f10)
   trend_n=$(fm_mrb_swap_trend_samples)
@@ -587,8 +587,7 @@ fm_mrb_idle_check_all() {
 # only when both snapshots are idle AND the gap between them is within
 # [idle_min_gap_secs, idle_max_gap_secs] - two genuinely back-to-back idle
 # reads, not a momentary gap and not two isolated readings stitched together
-# across an unrelated span (report Phase D: "two identical fleet snapshots at
-# least 5 minutes apart"). Always persists the current snapshot for next time,
+# across an unrelated span. Always persists the current snapshot for next time,
 # regardless of the verdict.
 fm_mrb_idle_confirm() {
   local file now verdict prev_epoch prev_verdict confirmed=no reason

--- a/bin/fm-mini-reboot-lib.sh
+++ b/bin/fm-mini-reboot-lib.sh
@@ -499,17 +499,26 @@ fm_mrb_idle_check_home() {
     return 0
   fi
 
-  # 4) no pending remote reply.
+  # 4) no unresolved remote reply. Resolved records are retained as durable
+  # history, so their presence alone is not pending work. Unknown or malformed
+  # records fail closed.
   if [ -d "$state/pending-replies" ]; then
-    local pr_paths
-    if ! pr_paths=$(find "$state/pending-replies" -mindepth 1 -print 2>&1); then
-      echo "busy: could not enumerate $state/pending-replies: $pr_paths"
-      return 0
-    fi
-    if [ -n "$pr_paths" ]; then
-      echo "busy: pending remote reply record(s) in $state/pending-replies"
-      return 0
-    fi
+    local pr_entry pr_phase
+    for pr_entry in "$state/pending-replies"/*; do
+      [ -e "$pr_entry" ] || continue
+      if [ ! -f "$pr_entry" ]; then
+        echo "busy: malformed pending remote reply entry: $pr_entry"
+        return 0
+      fi
+      if ! pr_phase=$(awk -F= '$1 == "phase" { value = $2 } END { print value }' "$pr_entry" 2>/dev/null); then
+        echo "busy: could not read pending remote reply record: $pr_entry"
+        return 0
+      fi
+      if [ "$pr_phase" != resolved ]; then
+        echo "busy: unresolved or malformed pending remote reply record: $pr_entry"
+        return 0
+      fi
+    done
   fi
 
   # 5) no promised public reply still owed. Both the backlog and tasks-axi
@@ -540,12 +549,13 @@ fm_mrb_idle_check_home() {
     return 0
   fi
 
-  # 6) no registered process-event source (presence alone keeps supervision
-  #    required, per AGENTS.md).
+  # 6) no registered process-event source. Registration is represented only
+  #    by state/procevent/*.source; runner and atomic-publication artifacts are
+  #    not registrations and must not keep an otherwise idle fleet busy.
   if [ -d "$state/procevent" ]; then
     local pe_paths
-    if ! pe_paths=$(find "$state/procevent" -mindepth 1 -print 2>&1); then
-      echo "busy: could not enumerate $state/procevent: $pe_paths"
+    if ! pe_paths=$(find "$state/procevent" -mindepth 1 -maxdepth 1 -name '*.source' -print 2>&1); then
+      echo "busy: could not enumerate $state/procevent/*.source: $pe_paths"
       return 0
     fi
     if [ -n "$pe_paths" ]; then

--- a/bin/fm-mini-reboot-lib.sh
+++ b/bin/fm-mini-reboot-lib.sh
@@ -476,7 +476,9 @@ fm_mrb_idle_check_home() {
     return 0
   fi
   if ! followup_n=$(printf '%s\n' "$followup" | jq -er \
-      '(.public_followups // []) | map(select((.state // "") != "done")) | length' 2>/dev/null); then
+      'if (.public_followups | type) == "array" then
+         .public_followups | map(select((.state // "") != "done")) | length
+       else error("public_followups must be an array") end' 2>/dev/null); then
     echo "busy: could not parse tasks-axi public-followup list for $backlog"
     return 0
   fi

--- a/bin/fm-mini-reboot-lib.sh
+++ b/bin/fm-mini-reboot-lib.sh
@@ -319,9 +319,6 @@ fm_mrb_evaluate() {
         trigger=yes
         reasons+=("slope-forecast-crosses-hard-ceiling-in-${forecast_secs}s")
       fi
-    elif [ "$l_zone" -ge "$hard_zone" ]; then
-      trigger=yes
-      reasons+=("zone-already-at-or-past-hard-ceiling")
     fi
   fi
 
@@ -383,17 +380,37 @@ fm_mrb_idle_check_home() {
     return 0
   fi
 
-  # 1) zero child task metadata - the strongest simple gate (report Phase C).
-  local meta_paths meta_count
+  # 1) every child task's reconciled current state is done.
+  local meta_paths crew_state_bin meta task_id current_state
   if ! meta_paths=$(find "$state" -maxdepth 1 -name '*.meta' -print 2>&1); then
     echo "busy: could not enumerate $state/*.meta: $meta_paths"
     return 0
   fi
-  meta_count=$(printf '%s\n' "$meta_paths" | awk 'NF { count++ } END { print count + 0 }')
-  if [ "$meta_count" -gt 0 ]; then
-    echo "busy: $meta_count task(s) with metadata in $state"
+  crew_state_bin=${FM_MRB_CREW_STATE_BIN:-$FM_ROOT/bin/fm-crew-state.sh}
+  if [ -n "$meta_paths" ] && [ ! -x "$crew_state_bin" ]; then
+    echo "busy: fm-crew-state.sh not executable at $crew_state_bin"
     return 0
   fi
+  while IFS= read -r meta; do
+    [ -n "$meta" ] || continue
+    task_id=${meta##*/}
+    task_id=${task_id%.meta}
+    if ! current_state=$(FM_HOME="$home" "$crew_state_bin" "$task_id" 2>&1); then
+      echo "busy: fm-crew-state.sh failed for $task_id: $current_state"
+      return 0
+    fi
+    case "$current_state" in
+      *$'\n'*)
+        echo "busy: malformed multi-line current state for task $task_id"
+        return 0
+        ;;
+      "state: done · source: "*) ;;
+      *)
+        echo "busy: task $task_id current state is not done: $current_state"
+        return 0
+        ;;
+    esac
+  done <<< "$meta_paths"
 
   # 2) no in-flight backlog item, no open captain decision (tasks-axi held).
   # tasks-axi silently reports "count: 0" (exit 0) for a NONEXISTENT file
@@ -585,11 +602,15 @@ fm_mrb_idle_confirmed() {
 # fm_mrb_host_is_mini: true only when config/host-role is present and its
 # trimmed content is exactly "mini". Absent-by-default, so a MacBook (or any
 # unconfigured host) never reboots through this code.
+fm_mrb_trim() {
+  printf '%s' "$1" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//'
+}
+
 fm_mrb_host_is_mini() {
   local file content
   file="$(fm_mrb_config_dir)/host-role"
   [ -r "$file" ] || return 1
-  content=$(tr -d '[:space:]' < "$file")
+  content=$(fm_mrb_trim "$(cat "$file")")
   [ "$content" = mini ]
 }
 
@@ -649,7 +670,7 @@ fm_mrb_execute_reboot() {
   helper_path="$(fm_mrb_config_dir)/mini-reboot-helper"
   local helper
   if [ -r "$helper_path" ]; then
-    helper=$(tr -d '[:space:]' < "$helper_path")
+    helper=$(fm_mrb_trim "$(cat "$helper_path")")
   fi
   if [ -z "${helper:-}" ] || [ ! -x "$helper" ]; then
     fm_mrb_log "BLOCKED: no privileged reboot mechanism configured."

--- a/bin/fm-mini-reboot-lib.sh
+++ b/bin/fm-mini-reboot-lib.sh
@@ -296,20 +296,27 @@ fm_mrb_evaluate() {
 
   # Condition 2: slope forecast over a recent window predicts the hard
   # ceiling before the forecast horizon.
-  local window recent oldest_line latest_line
+  local window recent oldest_line previous_line latest_line
   window=$(fm_mrb_slope_window_secs)
   recent=$(fm_mrb_recent_samples "$window")
   if [ -n "$recent" ] && [ "$(printf '%s\n' "$recent" | wc -l | tr -d ' ')" -ge 2 ]; then
     oldest_line=$(printf '%s\n' "$recent" | head -n 1)
+    previous_line=$(printf '%s\n' "$recent" | tail -n 2 | head -n 1)
     latest_line=$(printf '%s\n' "$recent" | tail -n 1)
-    local o_epoch o_zone l_epoch l_zone dt dz
+    local o_epoch o_zone p_epoch p_zone l_epoch l_zone dt dz recent_dt recent_dz
     o_epoch=$(printf '%s' "$oldest_line" | cut -f1)
     o_zone=$(printf '%s' "$oldest_line" | cut -f2)
+    p_epoch=$(printf '%s' "$previous_line" | cut -f1)
+    p_zone=$(printf '%s' "$previous_line" | cut -f2)
     l_epoch=$(printf '%s' "$latest_line" | cut -f1)
     l_zone=$(printf '%s' "$latest_line" | cut -f2)
     dt=$(( l_epoch - o_epoch ))
     dz=$(( l_zone - o_zone ))
-    if [ "$dt" -gt 0 ] && [ "$dz" -gt 0 ] && [ "$l_zone" -lt "$hard_zone" ]; then
+    recent_dt=$(( l_epoch - p_epoch ))
+    recent_dz=$(( l_zone - p_zone ))
+    if [ "$dt" -gt 0 ] && [ "$dz" -gt 0 ] \
+        && [ "$recent_dt" -gt 0 ] && [ "$recent_dz" -ge 0 ] \
+        && [ "$l_zone" -lt "$hard_zone" ]; then
       local remaining forecast_secs horizon
       remaining=$(( hard_zone - l_zone ))
       # forecast_secs = remaining / (dz/dt), rearranged to avoid float math.

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -142,6 +142,7 @@ family_for_basename() {
     fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
     fm-kimi-harness.test.sh|fm-muse-harness.test.sh|fm-herdr-lab.test.sh|fm-lint.test.sh|\
     fm-lint-workflows.test.sh|\
+    fm-mini-reboot-sampler.test.sh|fm-mini-reboot-idle.test.sh|fm-mini-reboot-guard.test.sh|\
     fm-operational-input.test.sh|fm-pi-primary-types.test.sh|\
     fm-send-popup-settle.test.sh|fm-send-settle.test.sh|\
     fm-subagent-pretool-check.test.sh|\

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -289,6 +289,10 @@
       "audience": "operator-current"
     },
     {
+      "path": "docs/mini-reboot-guard.md",
+      "audience": "operator-current"
+    },
+    {
       "path": "docs/orca-backend.md",
       "audience": "operator-current"
     },

--- a/docs/mini-reboot-guard.md
+++ b/docs/mini-reboot-guard.md
@@ -10,7 +10,7 @@ This is mini-only by construction; a MacBook (or any unconfigured host) never re
 A resource sampler records zone bytes, wired memory, free memory, swap use, pressure, and their deltas.
 It raises the resource condition only when the maintenance threshold is crossed in three consecutive samples, a recent-window slope forecasts the hard ceiling before the forecast horizon, or pressure is no longer normal with swapouts rising.
 It never triggers from a single sample.
-An idle check reuses `fm-crew-state.sh`, `tasks-axi`, and the documented `state/` layout to require zero child task metadata, no in-flight backlog item, no open captain decision, no unhandled steering inbox message, no pending remote reply, no promised public reply owed, and no registered process-event source, for every home in the registry.
+An idle check reuses `fm-crew-state.sh`, `tasks-axi`, and the documented `state/` layout to require every child task's reconciled current state to be done, no in-flight backlog item, no open captain decision, no unhandled steering inbox message, no pending remote reply, no promised public reply owed, and no registered process-event source, for every home in the registry.
 Any read failure, or a missing backlog file, blocks (fails closed) rather than reading as empty.
 Idleness is only confirmed after two consecutive idle reads at least 5 and at most 30 minutes apart, so a single lucky snapshot is never enough.
 Only when the resource condition and the confirmed idle window both hold does the guard attempt to execute a reboot.

--- a/docs/mini-reboot-guard.md
+++ b/docs/mini-reboot-guard.md
@@ -2,6 +2,7 @@
 
 `bin/fm-mini-reboot-guard.sh` and `bin/fm-mini-reboot-lib.sh` detect a genuine memory/kernel-zone leak on a mini host and reboot it, but only when the fleet on that mini is robustly idle.
 The guard has no drain, admission lock, work-blocking behavior, or per-reboot captain approval step.
+This is the captain-directed, narrowly scoped standing-autonomy exception for this host-maintenance action: deliberately provisioning the mini role, fleet registry, privileged helper, and scheduler opts into automatic execution when the two deterministic gates hold; it does not grant autonomy for any other destructive action.
 If both conditions do not hold, the guard does nothing and the machine handles load best-effort.
 This is mini-only by construction; a MacBook (or any unconfigured host) never reboots through this code.
 
@@ -10,7 +11,8 @@ This is mini-only by construction; a MacBook (or any unconfigured host) never re
 A resource sampler records zone bytes, wired memory, free memory, swap use, pressure, and their deltas.
 It raises the resource condition only when the maintenance threshold is crossed in three consecutive samples, a recent-window slope with a non-falling latest segment forecasts the hard ceiling before the forecast horizon, or warning/critical pressure coincides with swapouts rising across the selected trend window.
 It never triggers from a single sample.
-An idle check reuses `fm-crew-state.sh`, `tasks-axi`, and the documented `state/` layout to require every child task's reconciled current state to be done, no in-flight backlog item, no open captain decision, no unhandled steering inbox message, no pending remote reply, no promised public reply owed, and no registered process-event source, for every home in the registry.
+An idle check reuses `fm-crew-state.sh`, `tasks-axi`, and the documented `state/` layout to require every child task's reconciled current state to be done, no in-flight backlog item, no open captain decision, no unhandled steering inbox message, no unresolved remote reply, no promised public reply owed, and no registered `state/procevent/*.source` record, for every home in the registry.
+Resolved pending-reply history and process-event runner/publication artifacts are not outstanding work and do not block idleness.
 Any read failure, or a missing backlog file, blocks (fails closed) rather than reading as empty.
 Idleness is only confirmed after two consecutive idle reads at least 5 and at most 30 minutes apart, so a single lucky snapshot is never enough.
 Only when the resource condition and the confirmed idle window both hold does the guard attempt to execute a reboot.

--- a/docs/mini-reboot-guard.md
+++ b/docs/mini-reboot-guard.md
@@ -1,14 +1,14 @@
 # Mini self-reboot guard
 
 `bin/fm-mini-reboot-guard.sh` and `bin/fm-mini-reboot-lib.sh` detect a genuine memory/kernel-zone leak on a mini host and reboot it, but only when the fleet on that mini is robustly idle.
-This replaces an earlier drain/admission-lock design (captain 2026-08-24): there is no drain, no admission lock, no blocking of new work, and no captain-approval-per-reboot step.
+The guard has no drain, admission lock, work-blocking behavior, or per-reboot captain approval step.
 If both conditions do not hold, the guard does nothing and the machine handles load best-effort.
 This is mini-only by construction; a MacBook (or any unconfigured host) never reboots through this code.
 
 ## What it does
 
 A resource sampler records zone bytes, wired memory, free memory, swap use, pressure, and their deltas.
-It raises the resource condition only when the maintenance threshold is crossed in three consecutive samples, a recent-window slope forecasts the hard ceiling before the forecast horizon, or pressure is no longer normal with swapouts rising.
+It raises the resource condition only when the maintenance threshold is crossed in three consecutive samples, a recent-window slope with a non-falling latest segment forecasts the hard ceiling before the forecast horizon, or warning/critical pressure coincides with swapouts rising across the selected trend window.
 It never triggers from a single sample.
 An idle check reuses `fm-crew-state.sh`, `tasks-axi`, and the documented `state/` layout to require every child task's reconciled current state to be done, no in-flight backlog item, no open captain decision, no unhandled steering inbox message, no pending remote reply, no promised public reply owed, and no registered process-event source, for every home in the registry.
 Any read failure, or a missing backlog file, blocks (fails closed) rather than reading as empty.
@@ -32,12 +32,14 @@ All of the following are LOCAL and gitignored, read from the coordinating home's
 
 `fm-mini-reboot-guard.sh check` runs one full detect-idle-reboot cycle and is meant to be invoked on a recurring schedule, about every 5 minutes, by an operator-installed `launchd` job or cron entry.
 This script does not install its own schedule.
-`fm-mini-reboot-guard.sh status` prints a human-readable summary: the mini-only gate state, the current sampler evaluation, a single idle-check-all read, the registered homes, and whether a reboot attempt is currently in flight.
+`fm-mini-reboot-guard.sh status` prints a human-readable summary: the mini-only gate state, the current sampler evaluation, a single idle-check-all read, the registered homes, and any active reboot marker.
 `fm-mini-reboot-guard.sh sample`, `evaluate`, `idle-check`, and `idle-confirm` run one piece of the pipeline in isolation for troubleshooting.
 
 ## Safety mechanics
 
-`check` uses `state/mini-reboot/check.lock` as best-effort redundancy prevention for overlapping scheduled invocations; a dead or ownerless lock is reclaimed. It is not a strict mutual-exclusion guarantee during concurrent reclamation, and reboot safety comes entirely from the resource-plus-idle gate.
-A successful reboot attempt writes a marker (`state/mini-reboot/reboot-in-progress`) before invoking the helper, so a hung or slow helper cannot cause an immediate re-fire on the next scheduled tick.
+`check` uses `state/mini-reboot/check.lock` as best-effort redundancy prevention for overlapping scheduled invocations; a dead or ownerless lock is reclaimed.
+It is not a strict mutual-exclusion guarantee during concurrent reclamation, and reboot safety comes entirely from the resource-plus-idle gate.
+A reboot attempt writes a marker (`state/mini-reboot/reboot-in-progress`) before invoking the helper, so a hung or slow helper cannot cause an immediate re-fire on the next scheduled tick.
 The marker self-clears once the live boot-session id (`kern.bootsessionuuid`) differs from the recorded one - the reboot actually happened - or once it is older than 20 minutes and the machine evidently did not reboot.
+A boot-session change also clears persisted samples and idle snapshots, so post-reboot evaluation starts with fresh history.
 Nothing in this guard uses `--force`, kills a process, aborts a running validation, or discards a worktree to make a check pass; a blocking condition is meant to block.

--- a/docs/mini-reboot-guard.md
+++ b/docs/mini-reboot-guard.md
@@ -37,7 +37,7 @@ This script does not install its own schedule.
 
 ## Safety mechanics
 
-`check` runs under a single-instance lock (`state/mini-reboot/check.lock`) so an overlapping invocation never races; a lock left behind by a dead owner process is reclaimed, never left wedged.
+`check` uses `state/mini-reboot/check.lock` as best-effort redundancy prevention for overlapping scheduled invocations; a dead or ownerless lock is reclaimed. It is not a strict mutual-exclusion guarantee during concurrent reclamation, and reboot safety comes entirely from the resource-plus-idle gate.
 A successful reboot attempt writes a marker (`state/mini-reboot/reboot-in-progress`) before invoking the helper, so a hung or slow helper cannot cause an immediate re-fire on the next scheduled tick.
 The marker self-clears once the live boot-session id (`kern.bootsessionuuid`) differs from the recorded one - the reboot actually happened - or once it is older than 20 minutes and the machine evidently did not reboot.
 Nothing in this guard uses `--force`, kills a process, aborts a running validation, or discards a worktree to make a check pass; a blocking condition is meant to block.

--- a/docs/mini-reboot-guard.md
+++ b/docs/mini-reboot-guard.md
@@ -1,0 +1,43 @@
+# Mini self-reboot guard
+
+`bin/fm-mini-reboot-guard.sh` and `bin/fm-mini-reboot-lib.sh` detect a genuine memory/kernel-zone leak on a mini host and reboot it, but only when the fleet on that mini is robustly idle.
+This replaces an earlier drain/admission-lock design (captain 2026-08-24): there is no drain, no admission lock, no blocking of new work, and no captain-approval-per-reboot step.
+If both conditions do not hold, the guard does nothing and the machine handles load best-effort.
+This is mini-only by construction; a MacBook (or any unconfigured host) never reboots through this code.
+
+## What it does
+
+A resource sampler records zone bytes, wired memory, free memory, swap use, pressure, and their deltas.
+It raises the resource condition only when the maintenance threshold is crossed in three consecutive samples, a recent-window slope forecasts the hard ceiling before the forecast horizon, or pressure is no longer normal with swapouts rising.
+It never triggers from a single sample.
+An idle check reuses `fm-crew-state.sh`, `tasks-axi`, and the documented `state/` layout to require zero child task metadata, no in-flight backlog item, no open captain decision, no unhandled steering inbox message, no pending remote reply, no promised public reply owed, and no registered process-event source, for every home in the registry.
+Any read failure, or a missing backlog file, blocks (fails closed) rather than reading as empty.
+Idleness is only confirmed after two consecutive idle reads at least 5 and at most 30 minutes apart, so a single lucky snapshot is never enough.
+Only when the resource condition and the confirmed idle window both hold does the guard attempt to execute a reboot.
+
+## Configuration
+
+All of the following are LOCAL and gitignored, read from the coordinating home's `config/` directory (`FM_HOME`, matching every other `bin/fm-*.sh` convention).
+
+- `config/host-role` - must contain exactly `mini`; there is no other way to arm the mini-only gate.
+  Absent or any other content refuses every reboot attempt.
+- `config/mini-reboot-homes` - one `FM_HOME` path per line, the coordinating home's authoritative list of local homes to idle-check.
+  This is a deliberate explicit registry, not a directory glob.
+  Absent or empty means no home is registered, so `idle-check-all` always reports busy and the guard never reboots.
+- `config/mini-reboot-helper` - the path to an executable, root-authorized reboot helper (for example a signed launchd-privileged-helper, or a narrowly-scoped sudoers `NOPASSWD` entry wrapped in a script that calls `/sbin/shutdown -r now`).
+  Provisioning that helper is a separate, deliberate operational step outside this change's scope.
+  Absent, unreadable, or non-executable BLOCKS the reboot attempt with a clear diagnostic; this library never fakes or stubs privileged execution.
+
+## Running it
+
+`fm-mini-reboot-guard.sh check` runs one full detect-idle-reboot cycle and is meant to be invoked on a recurring schedule, about every 5 minutes, by an operator-installed `launchd` job or cron entry.
+This script does not install its own schedule.
+`fm-mini-reboot-guard.sh status` prints a human-readable summary: the mini-only gate state, the current sampler evaluation, a single idle-check-all read, the registered homes, and whether a reboot attempt is currently in flight.
+`fm-mini-reboot-guard.sh sample`, `evaluate`, `idle-check`, and `idle-confirm` run one piece of the pipeline in isolation for troubleshooting.
+
+## Safety mechanics
+
+`check` runs under a single-instance lock (`state/mini-reboot/check.lock`) so an overlapping invocation never races; a lock left behind by a dead owner process is reclaimed, never left wedged.
+A successful reboot attempt writes a marker (`state/mini-reboot/reboot-in-progress`) before invoking the helper, so a hung or slow helper cannot cause an immediate re-fire on the next scheduled tick.
+The marker self-clears once the live boot-session id (`kern.bootsessionuuid`) differs from the recorded one - the reboot actually happened - or once it is older than 20 minutes and the machine evidently did not reboot.
+Nothing in this guard uses `--force`, kills a process, aborts a running validation, or discards a worktree to make a check pass; a blocking condition is meant to block.

--- a/tests/fm-mini-reboot-guard.test.sh
+++ b/tests/fm-mini-reboot-guard.test.sh
@@ -276,10 +276,11 @@ t_lock_reclaims_from_a_dead_owner() {
   fb=$(fake_sysctl_bin "$home")
   local lockdir dead_pid
   lockdir="$home/state/mini-reboot/check.lock"
+  mkdir "$lockdir"
   # A pid that is certainly not alive.
   dead_pid=99999
   while kill -0 "$dead_pid" 2>/dev/null; do dead_pid=$((dead_pid - 1)); done
-  echo "$dead_pid" > "$lockdir"
+  echo "$dead_pid" > "$lockdir/owner"
   ran=$(PATH="$fb:$PATH" FM_HOME="$home" bash -c \
     ". '$LIB'; fm_mrb_with_lock echo ran-ok")
   assert_contains "$ran" "ran-ok" "the guarded function must still run after reclaiming a dead-owner lock"
@@ -290,79 +291,16 @@ t_lock_serializes_a_live_owner() {
   local home fb
   home="$TMP_ROOT/lock-live-owner"; mkdir -p "$home/state/mini-reboot"
   fb=$(fake_sysctl_bin "$home")
-  local lockdir identity
+  local lockdir
   lockdir="$home/state/mini-reboot/check.lock"
-  identity=$(PATH="$fb:$PATH" FM_HOME="$home" bash -c ". '$LIB'; fm_mrb_process_identity '$$'")
-  printf '%s\n' "$identity" > "$lockdir"
+  mkdir "$lockdir"
+  printf '%s\n' "$$" > "$lockdir/owner"
   local out
   out=$(PATH="$fb:$PATH" FM_HOME="$home" bash -c \
     ". '$LIB'; fm_mrb_with_lock echo should-not-run" 2>&1)
   assert_not_contains "$out" "should-not-run" "a live owner's lock must not be reclaimed or bypassed"
-  rm -f "$lockdir"
+  rm -rf "$lockdir"
   pass "a lock held by a live owner is never reclaimed or bypassed"
-}
-
-t_lock_reclaims_an_ownerless_crash() {
-  local home fb out lockdir
-  home="$TMP_ROOT/lock-ownerless"; mkdir -p "$home/state/mini-reboot"
-  fb=$(fake_sysctl_bin "$home")
-  lockdir="$home/state/mini-reboot/check.lock"
-  : > "$lockdir"
-  out=$(PATH="$fb:$PATH" FM_HOME="$home" FM_MRB_LOCK_OWNERLESS_GRACE_SECS=0 bash -c \
-    ". '$LIB'; fm_mrb_with_lock echo ran-after-ownerless-crash" 2>&1)
-  assert_contains "$out" "ran-after-ownerless-crash" "an ownerless crash claim must be reclaimed"
-  pass "an ownerless lock left during publication is reclaimed"
-}
-
-t_lock_reclaims_a_reused_pid_identity() {
-  local home fb out lockdir
-  home="$TMP_ROOT/lock-reused-pid"; mkdir -p "$home/state/mini-reboot"
-  fb=$(fake_sysctl_bin "$home")
-  lockdir="$home/state/mini-reboot/check.lock"
-  printf '%s\t%s\n' "$$" "Mon Jan 1 00:00:00 2001" > "$lockdir"
-  out=$(PATH="$fb:$PATH" FM_HOME="$home" bash -c \
-    ". '$LIB'; fm_mrb_with_lock echo ran-after-pid-reuse" 2>&1)
-  assert_contains "$out" "ran-after-pid-reuse" "a mismatched process identity must be reclaimed"
-  pass "a reused live pid cannot impersonate the original lock owner"
-}
-
-t_lock_recovers_an_interrupted_reclaim() {
-  local home fb lock out
-  home="$TMP_ROOT/lock-interrupted-reclaim"; mkdir -p "$home/state/mini-reboot"
-  fb=$(fake_sysctl_bin "$home")
-  lock="$home/state/mini-reboot/check.lock"
-  printf '99999\tdead-process\n' > "$lock"
-  ln "$lock" "$lock.reap"
-  out=$(PATH="$fb:$PATH" FM_HOME="$home" bash -c \
-    ". '$LIB'; fm_mrb_with_lock echo ran-after-interrupted-reclaim" 2>&1)
-  assert_contains "$out" "ran-after-interrupted-reclaim" "an interrupted exact-claim reclaim must recover"
-  pass "an interrupted stale-lock reclaim is crash-safe"
-}
-
-t_lock_concurrent_stale_reclaim_runs_once() {
-  local home fb lock p1 p2 worker
-  home="$TMP_ROOT/lock-concurrent-reclaim"; mkdir -p "$home/state/mini-reboot"
-  fb=$(fake_sysctl_bin "$home")
-  lock="$home/state/mini-reboot/check.lock"
-  printf '99999\tdead-process\n' > "$lock"
-  worker="$home/worker.sh"
-  cat > "$worker" <<EOF
-#!/usr/bin/env bash
-if mkdir "$home/active" 2>/dev/null; then
-  sleep 1
-  rmdir "$home/active"
-else
-  echo overlap >> "$home/overlap.log"
-fi
-EOF
-  chmod +x "$worker"
-  PATH="$fb:$PATH" FM_HOME="$home" bash -c \
-    ". '$LIB'; fm_mrb_with_lock '$worker'" & p1=$!
-  PATH="$fb:$PATH" FM_HOME="$home" bash -c \
-    ". '$LIB'; fm_mrb_with_lock '$worker'" & p2=$!
-  wait "$p1"; wait "$p2"
-  assert_absent "$home/overlap.log" "concurrent stale-lock reclaim must not overlap guarded execution"
-  pass "concurrent stale-lock reclaim preserves single-instance execution"
 }
 
 t_check_cycle_stops_after_sample_failure() {
@@ -522,10 +460,6 @@ t_marker_clears_when_stale
 t_execute_reboot_blocks_when_boot_session_is_unreadable
 t_lock_reclaims_from_a_dead_owner
 t_lock_serializes_a_live_owner
-t_lock_reclaims_an_ownerless_crash
-t_lock_reclaims_a_reused_pid_identity
-t_lock_recovers_an_interrupted_reclaim
-t_lock_concurrent_stale_reclaim_runs_once
 t_check_cycle_stops_after_sample_failure
 t_check_cycle_does_nothing_when_resource_not_triggered
 t_check_cycle_reboots_only_when_both_conditions_genuinely_hold

--- a/tests/fm-mini-reboot-guard.test.sh
+++ b/tests/fm-mini-reboot-guard.test.sh
@@ -30,6 +30,7 @@ fake_sysctl_bin() {
   cat > "$fb/sysctl" <<'SH'
 #!/usr/bin/env bash
 if [ "$1" = "-n" ] && [ "$2" = "kern.bootsessionuuid" ]; then
+  [ "${FM_FAKE_BOOT_ID_UNREADABLE:-0}" = 1 ] && exit 1
   echo "${FM_FAKE_BOOT_ID:-BOOT-A}"
   exit 0
 fi
@@ -207,20 +208,40 @@ t_marker_clears_when_stale() {
   pass "a stale reboot marker self-clears without manual intervention (never wedges forever)"
 }
 
+t_execute_reboot_blocks_when_boot_session_is_unreadable() {
+  local home fb helper out status
+  home="$TMP_ROOT/marker-no-boot-id"; mkdir -p "$home/config"
+  echo mini > "$home/config/host-role"
+  helper="$home/helper.sh"
+  cat > "$helper" <<EOF
+#!/usr/bin/env bash
+echo invoked > "$home/helper-invoked"
+EOF
+  chmod +x "$helper"
+  echo "$helper" > "$home/config/mini-reboot-helper"
+  fb=$(fake_sysctl_bin "$home")
+  out=$(FM_FAKE_BOOT_ID_UNREADABLE=1 PATH="$fb:$PATH" FM_HOME="$home" \
+    bash -c ". '$LIB'; fm_mrb_execute_reboot test-reason" 2>&1)
+  status=$?
+  [ "$status" -eq 4 ] || fail "unreadable boot-session id should block with exit 4, got $status"
+  assert_contains "$out" "boot-session id" "the refusal should name the unreadable boot-session id"
+  assert_absent "$home/helper-invoked" "the reboot helper must not run without a valid marker boot id"
+  assert_absent "$home/state/mini-reboot/reboot-in-progress" "an invalid marker must not be published"
+  pass "reboot execution blocks when the boot-session id is unreadable"
+}
+
 # --- single-instance lock is crash-safe -------------------------------------
 
 t_lock_reclaims_from_a_dead_owner() {
   local home fb ran
   home="$TMP_ROOT/lock-dead-owner"; mkdir -p "$home/state/mini-reboot"
   fb=$(fake_sysctl_bin "$home")
-  local lockdir owner_file dead_pid
+  local lockdir dead_pid
   lockdir="$home/state/mini-reboot/check.lock"
-  mkdir -p "$lockdir"
   # A pid that is certainly not alive.
   dead_pid=99999
   while kill -0 "$dead_pid" 2>/dev/null; do dead_pid=$((dead_pid - 1)); done
-  owner_file="$lockdir/owner"
-  echo "$dead_pid" > "$owner_file"
+  echo "$dead_pid" > "$lockdir"
   ran=$(PATH="$fb:$PATH" FM_HOME="$home" bash -c \
     ". '$LIB'; fm_mrb_with_lock echo ran-ok")
   assert_contains "$ran" "ran-ok" "the guarded function must still run after reclaiming a dead-owner lock"
@@ -231,17 +252,15 @@ t_lock_serializes_a_live_owner() {
   local home fb
   home="$TMP_ROOT/lock-live-owner"; mkdir -p "$home/state/mini-reboot"
   fb=$(fake_sysctl_bin "$home")
-  local lockdir owner_file identity
+  local lockdir identity
   lockdir="$home/state/mini-reboot/check.lock"
-  mkdir -p "$lockdir"
-  owner_file="$lockdir/owner"
   identity=$(PATH="$fb:$PATH" FM_HOME="$home" bash -c ". '$LIB'; fm_mrb_process_identity '$$'")
-  printf '%s\n' "$identity" > "$owner_file"
+  printf '%s\n' "$identity" > "$lockdir"
   local out
   out=$(PATH="$fb:$PATH" FM_HOME="$home" bash -c \
     ". '$LIB'; fm_mrb_with_lock echo should-not-run" 2>&1)
   assert_not_contains "$out" "should-not-run" "a live owner's lock must not be reclaimed or bypassed"
-  rm -rf "$lockdir"
+  rm -f "$lockdir"
   pass "a lock held by a live owner is never reclaimed or bypassed"
 }
 
@@ -250,7 +269,7 @@ t_lock_reclaims_an_ownerless_crash() {
   home="$TMP_ROOT/lock-ownerless"; mkdir -p "$home/state/mini-reboot"
   fb=$(fake_sysctl_bin "$home")
   lockdir="$home/state/mini-reboot/check.lock"
-  mkdir -p "$lockdir"
+  : > "$lockdir"
   out=$(PATH="$fb:$PATH" FM_HOME="$home" FM_MRB_LOCK_OWNERLESS_GRACE_SECS=0 bash -c \
     ". '$LIB'; fm_mrb_with_lock echo ran-after-ownerless-crash" 2>&1)
   assert_contains "$out" "ran-after-ownerless-crash" "an ownerless crash claim must be reclaimed"
@@ -262,12 +281,63 @@ t_lock_reclaims_a_reused_pid_identity() {
   home="$TMP_ROOT/lock-reused-pid"; mkdir -p "$home/state/mini-reboot"
   fb=$(fake_sysctl_bin "$home")
   lockdir="$home/state/mini-reboot/check.lock"
-  mkdir -p "$lockdir"
-  printf '%s\t%s\n' "$$" "Mon Jan 1 00:00:00 2001" > "$lockdir/owner"
+  printf '%s\t%s\n' "$$" "Mon Jan 1 00:00:00 2001" > "$lockdir"
   out=$(PATH="$fb:$PATH" FM_HOME="$home" bash -c \
     ". '$LIB'; fm_mrb_with_lock echo ran-after-pid-reuse" 2>&1)
   assert_contains "$out" "ran-after-pid-reuse" "a mismatched process identity must be reclaimed"
   pass "a reused live pid cannot impersonate the original lock owner"
+}
+
+t_lock_recovers_an_interrupted_reclaim() {
+  local home fb lock out
+  home="$TMP_ROOT/lock-interrupted-reclaim"; mkdir -p "$home/state/mini-reboot"
+  fb=$(fake_sysctl_bin "$home")
+  lock="$home/state/mini-reboot/check.lock"
+  printf '99999\tdead-process\n' > "$lock"
+  ln "$lock" "$lock.reap"
+  out=$(PATH="$fb:$PATH" FM_HOME="$home" bash -c \
+    ". '$LIB'; fm_mrb_with_lock echo ran-after-interrupted-reclaim" 2>&1)
+  assert_contains "$out" "ran-after-interrupted-reclaim" "an interrupted exact-claim reclaim must recover"
+  pass "an interrupted stale-lock reclaim is crash-safe"
+}
+
+t_lock_concurrent_stale_reclaim_runs_once() {
+  local home fb lock p1 p2 worker
+  home="$TMP_ROOT/lock-concurrent-reclaim"; mkdir -p "$home/state/mini-reboot"
+  fb=$(fake_sysctl_bin "$home")
+  lock="$home/state/mini-reboot/check.lock"
+  printf '99999\tdead-process\n' > "$lock"
+  worker="$home/worker.sh"
+  cat > "$worker" <<EOF
+#!/usr/bin/env bash
+if mkdir "$home/active" 2>/dev/null; then
+  sleep 1
+  rmdir "$home/active"
+else
+  echo overlap >> "$home/overlap.log"
+fi
+EOF
+  chmod +x "$worker"
+  PATH="$fb:$PATH" FM_HOME="$home" bash -c \
+    ". '$LIB'; fm_mrb_with_lock '$worker'" & p1=$!
+  PATH="$fb:$PATH" FM_HOME="$home" bash -c \
+    ". '$LIB'; fm_mrb_with_lock '$worker'" & p2=$!
+  wait "$p1"; wait "$p2"
+  assert_absent "$home/overlap.log" "concurrent stale-lock reclaim must not overlap guarded execution"
+  pass "concurrent stale-lock reclaim preserves single-instance execution"
+}
+
+t_check_cycle_stops_after_sample_failure() {
+  local home out marker
+  home="$TMP_ROOT/cycle-sample-failure"; mkdir -p "$home"
+  marker="$home/evaluate-called"
+  out=$(FM_HOME="$home" bash -c ". '$LIB';
+    fm_mrb_append_sample() { return 1; }
+    fm_mrb_evaluate() { echo called > '$marker'; echo trigger=yes; }
+    fm_mrb_check_cycle" 2>&1)
+  assert_contains "$out" "current sample is invalid" "the cycle should diagnose invalid current metrics"
+  assert_absent "$marker" "stale history must not be evaluated after current sample collection fails"
+  pass "the check cycle stops when current sample collection fails"
 }
 
 # --- the AND-gate: never reboots on either condition alone ------------------
@@ -334,7 +404,7 @@ EOF
   chmod +x "$fb/vm_stat"
   cat > "$fb/zprint" <<'SH'
 #!/usr/bin/env bash
-echo "zone name elem size ... inuse"
+echo "data.kalloc.1024 1 0K 0K 0 0 0 0K 0"
 SH
   chmod +x "$fb/zprint"
   printf '%s\n' "$fb"
@@ -408,10 +478,14 @@ t_execute_reboot_invokes_a_real_configured_helper
 t_marker_active_blocks_a_second_cycle
 t_marker_clears_on_boot_session_change
 t_marker_clears_when_stale
+t_execute_reboot_blocks_when_boot_session_is_unreadable
 t_lock_reclaims_from_a_dead_owner
 t_lock_serializes_a_live_owner
 t_lock_reclaims_an_ownerless_crash
 t_lock_reclaims_a_reused_pid_identity
+t_lock_recovers_an_interrupted_reclaim
+t_lock_concurrent_stale_reclaim_runs_once
+t_check_cycle_stops_after_sample_failure
 t_check_cycle_does_nothing_when_resource_not_triggered
 t_check_cycle_reboots_only_when_both_conditions_genuinely_hold
 t_check_cycle_does_not_reboot_when_only_resource_triggers

--- a/tests/fm-mini-reboot-guard.test.sh
+++ b/tests/fm-mini-reboot-guard.test.sh
@@ -80,28 +80,6 @@ t_cli_unknown_subcommand_errors() {
   pass "the CLI rejects an unknown subcommand with a clear diagnostic"
 }
 
-# --- the discarded drain/admission-lock design is genuinely gone -----------
-
-t_no_drain_or_admission_lock_machinery_remains() {
-  ! grep -rl "FM_HOST_MAINT\|host-maintenance-drain\|fm_host_maint_" \
-    "$ROOT/bin" "$ROOT/AGENTS.md" 2>/dev/null | grep -v '/tests/' \
-    | grep -q . \
-    || fail "leftover discarded drain/admission-lock machinery found in bin/ or AGENTS.md"
-  pass "no leftover drain/admission-lock/barrier machinery remains (captain retarget honored)"
-}
-
-t_no_spawn_promote_handoff_integration_added() {
-  # The new design does not touch cross-home admission at all - unlike the
-  # discarded drain barrier, spawn/promotion/handoff are untouched.
-  ! grep -q "mini-reboot\|fm-mini-reboot" "$ROOT/bin/fm-spawn.sh" 2>/dev/null \
-    || fail "fm-spawn.sh should not reference the mini-reboot guard"
-  ! grep -q "mini-reboot\|fm-mini-reboot" "$ROOT/bin/fm-promote.sh" 2>/dev/null \
-    || fail "fm-promote.sh should not reference the mini-reboot guard"
-  ! grep -q "mini-reboot\|fm-mini-reboot" "$ROOT/bin/fm-backlog-handoff.sh" 2>/dev/null \
-    || fail "fm-backlog-handoff.sh should not reference the mini-reboot guard"
-  pass "spawn/promotion/handoff are untouched - no admission-control coupling in the new design"
-}
-
 # --- mini-only gate ----------------------------------------------------------
 
 t_execute_reboot_refuses_off_mini() {
@@ -253,17 +231,43 @@ t_lock_serializes_a_live_owner() {
   local home fb
   home="$TMP_ROOT/lock-live-owner"; mkdir -p "$home/state/mini-reboot"
   fb=$(fake_sysctl_bin "$home")
-  local lockdir owner_file
+  local lockdir owner_file identity
   lockdir="$home/state/mini-reboot/check.lock"
   mkdir -p "$lockdir"
   owner_file="$lockdir/owner"
-  echo $$ > "$owner_file"   # this test process itself: definitely alive
+  identity=$(PATH="$fb:$PATH" FM_HOME="$home" bash -c ". '$LIB'; fm_mrb_process_identity '$$'")
+  printf '%s\n' "$identity" > "$owner_file"
   local out
   out=$(PATH="$fb:$PATH" FM_HOME="$home" bash -c \
     ". '$LIB'; fm_mrb_with_lock echo should-not-run" 2>&1)
   assert_not_contains "$out" "should-not-run" "a live owner's lock must not be reclaimed or bypassed"
   rm -rf "$lockdir"
   pass "a lock held by a live owner is never reclaimed or bypassed"
+}
+
+t_lock_reclaims_an_ownerless_crash() {
+  local home fb out lockdir
+  home="$TMP_ROOT/lock-ownerless"; mkdir -p "$home/state/mini-reboot"
+  fb=$(fake_sysctl_bin "$home")
+  lockdir="$home/state/mini-reboot/check.lock"
+  mkdir -p "$lockdir"
+  out=$(PATH="$fb:$PATH" FM_HOME="$home" FM_MRB_LOCK_OWNERLESS_GRACE_SECS=0 bash -c \
+    ". '$LIB'; fm_mrb_with_lock echo ran-after-ownerless-crash" 2>&1)
+  assert_contains "$out" "ran-after-ownerless-crash" "an ownerless crash claim must be reclaimed"
+  pass "an ownerless lock left during publication is reclaimed"
+}
+
+t_lock_reclaims_a_reused_pid_identity() {
+  local home fb out lockdir
+  home="$TMP_ROOT/lock-reused-pid"; mkdir -p "$home/state/mini-reboot"
+  fb=$(fake_sysctl_bin "$home")
+  lockdir="$home/state/mini-reboot/check.lock"
+  mkdir -p "$lockdir"
+  printf '%s\t%s\n' "$$" "Mon Jan 1 00:00:00 2001" > "$lockdir/owner"
+  out=$(PATH="$fb:$PATH" FM_HOME="$home" bash -c \
+    ". '$LIB'; fm_mrb_with_lock echo ran-after-pid-reuse" 2>&1)
+  assert_contains "$out" "ran-after-pid-reuse" "a mismatched process identity must be reclaimed"
+  pass "a reused live pid cannot impersonate the original lock owner"
 }
 
 # --- the AND-gate: never reboots on either condition alone ------------------
@@ -396,8 +400,6 @@ EOF
 
 t_cli_status_subcommand_runs_end_to_end
 t_cli_unknown_subcommand_errors
-t_no_drain_or_admission_lock_machinery_remains
-t_no_spawn_promote_handoff_integration_added
 t_execute_reboot_refuses_off_mini
 t_execute_reboot_refuses_wrong_role_value
 t_execute_reboot_blocked_without_helper_configured
@@ -408,6 +410,8 @@ t_marker_clears_on_boot_session_change
 t_marker_clears_when_stale
 t_lock_reclaims_from_a_dead_owner
 t_lock_serializes_a_live_owner
+t_lock_reclaims_an_ownerless_crash
+t_lock_reclaims_a_reused_pid_identity
 t_check_cycle_does_nothing_when_resource_not_triggered
 t_check_cycle_reboots_only_when_both_conditions_genuinely_hold
 t_check_cycle_does_not_reboot_when_only_resource_triggers

--- a/tests/fm-mini-reboot-guard.test.sh
+++ b/tests/fm-mini-reboot-guard.test.sh
@@ -110,6 +110,25 @@ t_execute_reboot_refuses_wrong_role_value() {
   pass "reboot execution refuses when config/host-role names anything other than mini"
 }
 
+t_host_role_rejects_internal_whitespace() {
+  local home
+  home="$TMP_ROOT/role-internal-space"; mkdir -p "$home/config"
+  printf '  m i n i  \n' > "$home/config/host-role"
+  if FM_HOME="$home" bash -c ". '$LIB'; fm_mrb_host_is_mini"; then
+    fail "host-role with internal whitespace must not authorize the mini gate"
+  fi
+  pass "the mini-only gate rejects internal host-role whitespace"
+}
+
+t_host_role_allows_surrounding_whitespace() {
+  local home
+  home="$TMP_ROOT/role-surrounding-space"; mkdir -p "$home/config"
+  printf ' \t mini \t \n' > "$home/config/host-role"
+  FM_HOME="$home" bash -c ". '$LIB'; fm_mrb_host_is_mini" \
+    || fail "surrounding host-role whitespace should be trimmed"
+  pass "the mini-only gate trims only surrounding whitespace"
+}
+
 # --- never fakes privileged execution ---------------------------------------
 
 t_execute_reboot_blocked_without_helper_configured() {
@@ -162,6 +181,25 @@ EOF
   assert_grep "both-conditions-held" "$home/helper-invocations.log" "reason was passed through to the helper"
   assert_present "$home/state/mini-reboot/reboot-in-progress" "reboot marker written before invoking the helper"
   pass "a genuinely configured, executable, mini-role helper is invoked with the trigger reason"
+}
+
+t_execute_reboot_preserves_spaces_in_helper_path() {
+  local home fb out status helper
+  home="$TMP_ROOT/helper-path-space"; mkdir -p "$home/config"
+  echo mini > "$home/config/host-role"
+  helper="$home/reboot helper.sh"
+  cat > "$helper" <<EOF
+#!/usr/bin/env bash
+echo invoked > "$home/helper-invoked"
+EOF
+  chmod +x "$helper"
+  printf ' \t%s \t\n' "$helper" > "$home/config/mini-reboot-helper"
+  fb=$(fake_sysctl_bin "$home")
+  out=$(PATH="$fb:$PATH" FM_HOME="$home" bash -c ". '$LIB'; fm_mrb_execute_reboot test-reason" 2>&1)
+  status=$?
+  [ "$status" -eq 0 ] || fail "helper path containing a space should be preserved, got $status: $out"
+  assert_present "$home/helper-invoked" "the helper whose path contains a space must run"
+  pass "helper configuration trims edges while preserving internal spaces"
 }
 
 # --- reboot marker: prevents re-fire, self-clears -------------------------
@@ -472,9 +510,12 @@ t_cli_status_subcommand_runs_end_to_end
 t_cli_unknown_subcommand_errors
 t_execute_reboot_refuses_off_mini
 t_execute_reboot_refuses_wrong_role_value
+t_host_role_rejects_internal_whitespace
+t_host_role_allows_surrounding_whitespace
 t_execute_reboot_blocked_without_helper_configured
 t_execute_reboot_blocked_with_nonexecutable_helper
 t_execute_reboot_invokes_a_real_configured_helper
+t_execute_reboot_preserves_spaces_in_helper_path
 t_marker_active_blocks_a_second_cycle
 t_marker_clears_on_boot_session_change
 t_marker_clears_when_stale

--- a/tests/fm-mini-reboot-guard.test.sh
+++ b/tests/fm-mini-reboot-guard.test.sh
@@ -1,0 +1,413 @@
+#!/usr/bin/env bash
+# Behavior tests for bin/fm-mini-reboot-guard.sh and the mini-only gate,
+# privileged-execution refusal, reboot marker, and single-instance lock in
+# bin/fm-mini-reboot-lib.sh.
+#
+# These are the direct regressions for the acceptance criteria:
+#   - the generation-scoped host-maintenance-drain machinery this feature
+#     REPLACES no longer exists in this codebase (captain 2026-08-24 retarget)
+#   - NO automatic reboot path exists without BOTH the resource trigger and a
+#     confirmed idle window holding at once
+#   - reboot execution is refused (never faked) off-mini and without a
+#     configured, executable privileged helper
+#   - the reboot marker prevents an immediate re-fire after a reboot attempt,
+#     and self-clears both on a genuine boot-session change and on staleness
+#   - the single-instance lock is crash-safe: a dead owner's lock is reclaimed
+#   - nothing here ever uses --force, kills a process, aborts a validation
+#     run, or discards a worktree
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+LIB="$ROOT/bin/fm-mini-reboot-lib.sh"
+GUARD="$ROOT/bin/fm-mini-reboot-guard.sh"
+TMP_ROOT=$(fm_test_tmproot fm-mini-reboot-guard)
+
+fake_sysctl_bin() {
+  local dir=$1 fb
+  fb=$(fm_fakebin "$dir")
+  cat > "$fb/sysctl" <<'SH'
+#!/usr/bin/env bash
+if [ "$1" = "-n" ] && [ "$2" = "kern.bootsessionuuid" ]; then
+  echo "${FM_FAKE_BOOT_ID:-BOOT-A}"
+  exit 0
+fi
+if [ "$1" = "-n" ]; then echo 0; exit 0; fi
+echo "vm.swapusage: total = 1M used = 0M free = 1M"
+SH
+  chmod +x "$fb/sysctl"
+  printf '%s\n' "$fb"
+}
+
+# --- the CLI dispatches to the same library functions -----------------------
+
+t_cli_status_subcommand_runs_end_to_end() {
+  local home fb out
+  home="$TMP_ROOT/cli-status"; mkdir -p "$home/config"
+  fb=$(fake_sysctl_bin "$home")
+  cat > "$fb/vm_stat" <<'SH'
+#!/usr/bin/env bash
+echo "Mach Virtual Memory Statistics: (page size of 16384 bytes)"
+echo "Pages free: 0."
+echo "Pages wired down: 0."
+echo "Pages purgeable: 0."
+echo "Pages occupied by compressor: 0."
+echo "Swapins: 0."
+echo "Swapouts: 0."
+SH
+  chmod +x "$fb/vm_stat"
+  cat > "$fb/zprint" <<'SH'
+#!/usr/bin/env bash
+echo "zone name elem size ... inuse"
+SH
+  chmod +x "$fb/zprint"
+  out=$(PATH="$fb:$PATH" FM_HOME="$home" "$GUARD" status 2>&1)
+  local status=$?
+  [ "$status" -eq 0 ] || fail "guard status subcommand exited $status: $out"
+  assert_contains "$out" "host-role: not mini" "status reports the mini-only gate state"
+  assert_contains "$out" "trigger=no" "status reports the resource evaluate verdict"
+  assert_contains "$out" "no homes registered" "status reports the idle registry state"
+  pass "the CLI status subcommand runs end-to-end and reports the real guard state"
+}
+
+t_cli_unknown_subcommand_errors() {
+  local out status
+  out=$("$GUARD" bogus-subcommand 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "an unknown subcommand should exit non-zero"
+  assert_contains "$out" "unknown subcommand" "unknown subcommand names itself as such"
+  pass "the CLI rejects an unknown subcommand with a clear diagnostic"
+}
+
+# --- the discarded drain/admission-lock design is genuinely gone -----------
+
+t_no_drain_or_admission_lock_machinery_remains() {
+  ! grep -rl "FM_HOST_MAINT\|host-maintenance-drain\|fm_host_maint_" \
+    "$ROOT/bin" "$ROOT/AGENTS.md" 2>/dev/null | grep -v '/tests/' \
+    | grep -q . \
+    || fail "leftover discarded drain/admission-lock machinery found in bin/ or AGENTS.md"
+  pass "no leftover drain/admission-lock/barrier machinery remains (captain retarget honored)"
+}
+
+t_no_spawn_promote_handoff_integration_added() {
+  # The new design does not touch cross-home admission at all - unlike the
+  # discarded drain barrier, spawn/promotion/handoff are untouched.
+  ! grep -q "mini-reboot\|fm-mini-reboot" "$ROOT/bin/fm-spawn.sh" 2>/dev/null \
+    || fail "fm-spawn.sh should not reference the mini-reboot guard"
+  ! grep -q "mini-reboot\|fm-mini-reboot" "$ROOT/bin/fm-promote.sh" 2>/dev/null \
+    || fail "fm-promote.sh should not reference the mini-reboot guard"
+  ! grep -q "mini-reboot\|fm-mini-reboot" "$ROOT/bin/fm-backlog-handoff.sh" 2>/dev/null \
+    || fail "fm-backlog-handoff.sh should not reference the mini-reboot guard"
+  pass "spawn/promotion/handoff are untouched - no admission-control coupling in the new design"
+}
+
+# --- mini-only gate ----------------------------------------------------------
+
+t_execute_reboot_refuses_off_mini() {
+  local home fb out status
+  home="$TMP_ROOT/off-mini"; mkdir -p "$home/config"
+  fb=$(fake_sysctl_bin "$home")
+  # No config/host-role at all: must refuse.
+  out=$(PATH="$fb:$PATH" FM_HOME="$home" bash -c ". '$LIB'; fm_mrb_execute_reboot test-reason" 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "execute_reboot must fail off-mini, exit was 0"
+  assert_contains "$out" "not configured as config/host-role=mini" "reason for refusal should be recorded"
+  local log
+  log="$home/state/mini-reboot/reboot-attempts.log"
+  assert_present "$log" "attempts log created"
+  assert_grep "not-mini" "$log" "attempts log records the not-mini refusal"
+  pass "reboot execution refuses on a host without config/host-role=mini"
+}
+
+t_execute_reboot_refuses_wrong_role_value() {
+  local home fb out
+  home="$TMP_ROOT/wrong-role"; mkdir -p "$home/config"
+  echo "macbook" > "$home/config/host-role"
+  fb=$(fake_sysctl_bin "$home")
+  out=$(PATH="$fb:$PATH" FM_HOME="$home" bash -c ". '$LIB'; fm_mrb_execute_reboot test-reason" 2>&1)
+  local status=$?
+  [ "$status" -ne 0 ] || fail "execute_reboot must fail with host-role=macbook"
+  pass "reboot execution refuses when config/host-role names anything other than mini"
+}
+
+# --- never fakes privileged execution ---------------------------------------
+
+t_execute_reboot_blocked_without_helper_configured() {
+  local home fb out status
+  home="$TMP_ROOT/no-helper"; mkdir -p "$home/config"
+  echo "mini" > "$home/config/host-role"
+  fb=$(fake_sysctl_bin "$home")
+  # No config/mini-reboot-helper at all.
+  out=$(PATH="$fb:$PATH" FM_HOME="$home" bash -c ". '$LIB'; fm_mrb_execute_reboot test-reason" 2>&1)
+  status=$?
+  [ "$status" -eq 3 ] || fail "expected exit 3 (blocked: no helper), got $status"
+  assert_contains "$out" "BLOCKED" "must log a clear BLOCKED diagnostic, never fake success"
+  assert_contains "$out" "no privileged reboot mechanism" "must name the missing mechanism"
+  local marker
+  marker="$home/state/mini-reboot/reboot-in-progress"
+  assert_absent "$marker" "no reboot marker should be written when execution is blocked"
+  pass "reboot execution is BLOCKED (never faked) without a configured helper"
+}
+
+t_execute_reboot_blocked_with_nonexecutable_helper() {
+  local home fb out status
+  home="$TMP_ROOT/non-exec-helper"; mkdir -p "$home/config"
+  echo "mini" > "$home/config/host-role"
+  echo "$home/helper.sh" > "$home/config/mini-reboot-helper"
+  echo "#!/bin/sh" > "$home/helper.sh"   # deliberately NOT chmod +x
+  fb=$(fake_sysctl_bin "$home")
+  out=$(PATH="$fb:$PATH" FM_HOME="$home" bash -c ". '$LIB'; fm_mrb_execute_reboot test-reason" 2>&1)
+  status=$?
+  [ "$status" -eq 3 ] || fail "expected exit 3 for a non-executable helper, got $status"
+  pass "a configured but non-executable helper path is refused, not silently treated as ready"
+}
+
+t_execute_reboot_invokes_a_real_configured_helper() {
+  local home fb out status helper
+  home="$TMP_ROOT/with-helper"; mkdir -p "$home/config"
+  echo "mini" > "$home/config/host-role"
+  helper="$home/fake-reboot-helper.sh"
+  cat > "$helper" <<EOF
+#!/usr/bin/env bash
+echo "invoked with reason: \$1" >> "$home/helper-invocations.log"
+exit 0
+EOF
+  chmod +x "$helper"
+  echo "$helper" > "$home/config/mini-reboot-helper"
+  fb=$(fake_sysctl_bin "$home")
+  out=$(PATH="$fb:$PATH" FM_HOME="$home" bash -c ". '$LIB'; fm_mrb_execute_reboot both-conditions-held" 2>&1)
+  status=$?
+  [ "$status" -eq 0 ] || fail "expected exit 0 from a successful helper invocation, got $status: $out"
+  assert_present "$home/helper-invocations.log" "helper was actually invoked"
+  assert_grep "both-conditions-held" "$home/helper-invocations.log" "reason was passed through to the helper"
+  assert_present "$home/state/mini-reboot/reboot-in-progress" "reboot marker written before invoking the helper"
+  pass "a genuinely configured, executable, mini-role helper is invoked with the trigger reason"
+}
+
+# --- reboot marker: prevents re-fire, self-clears -------------------------
+
+t_marker_active_blocks_a_second_cycle() {
+  local home fb
+  home="$TMP_ROOT/marker-active"; mkdir -p "$home/state/mini-reboot"
+  fb=$(fake_sysctl_bin "$home")
+  FM_FAKE_BOOT_ID=BOOT-A PATH="$fb:$PATH" FM_HOME="$home" FM_MRB_NOW=1000 \
+    bash -c ". '$LIB'; fm_mrb_write_reboot_marker some-reason"
+  local active
+  active=$(FM_FAKE_BOOT_ID=BOOT-A PATH="$fb:$PATH" FM_HOME="$home" FM_MRB_NOW=1100 \
+    bash -c ". '$LIB'; fm_mrb_reboot_marker_active && echo yes || echo no")
+  [ "$active" = yes ] || fail "marker should still be active shortly after writing, same boot session"
+  pass "an active reboot marker (same boot session, not stale) is reported active"
+}
+
+t_marker_clears_on_boot_session_change() {
+  local home fb active
+  home="$TMP_ROOT/marker-boot-change"; mkdir -p "$home/state/mini-reboot"
+  fb=$(fake_sysctl_bin "$home")
+  FM_FAKE_BOOT_ID=BOOT-A PATH="$fb:$PATH" FM_HOME="$home" FM_MRB_NOW=1000 \
+    bash -c ". '$LIB'; fm_mrb_write_reboot_marker some-reason"
+  # A different boot-session id means the machine actually rebooted.
+  active=$(FM_FAKE_BOOT_ID=BOOT-B PATH="$fb:$PATH" FM_HOME="$home" FM_MRB_NOW=1050 \
+    bash -c ". '$LIB'; fm_mrb_reboot_marker_active && echo yes || echo no")
+  [ "$active" = no ] || fail "marker must clear once the boot-session id changes (the reboot happened)"
+  assert_absent "$home/state/mini-reboot/reboot-in-progress" "marker file removed after boot-session change"
+  pass "the reboot marker self-clears once the boot-session id changes (reboot actually happened)"
+}
+
+t_marker_clears_when_stale() {
+  local home fb active
+  home="$TMP_ROOT/marker-stale"; mkdir -p "$home/state/mini-reboot"
+  fb=$(fake_sysctl_bin "$home")
+  FM_FAKE_BOOT_ID=BOOT-A PATH="$fb:$PATH" FM_HOME="$home" FM_MRB_NOW=1000 \
+    bash -c ". '$LIB'; fm_mrb_write_reboot_marker some-reason"
+  # Same boot session, but far beyond fm_mrb_marker_max_age_secs (1200s
+  # default): the helper evidently did not reboot us.
+  active=$(FM_FAKE_BOOT_ID=BOOT-A PATH="$fb:$PATH" FM_HOME="$home" FM_MRB_NOW=1000000 \
+    bash -c ". '$LIB'; fm_mrb_reboot_marker_active && echo yes || echo no")
+  [ "$active" = no ] || fail "a stale same-session marker must self-clear rather than wedge forever"
+  assert_absent "$home/state/mini-reboot/reboot-in-progress" "stale marker removed"
+  pass "a stale reboot marker self-clears without manual intervention (never wedges forever)"
+}
+
+# --- single-instance lock is crash-safe -------------------------------------
+
+t_lock_reclaims_from_a_dead_owner() {
+  local home fb ran
+  home="$TMP_ROOT/lock-dead-owner"; mkdir -p "$home/state/mini-reboot"
+  fb=$(fake_sysctl_bin "$home")
+  local lockdir owner_file dead_pid
+  lockdir="$home/state/mini-reboot/check.lock"
+  mkdir -p "$lockdir"
+  # A pid that is certainly not alive.
+  dead_pid=99999
+  while kill -0 "$dead_pid" 2>/dev/null; do dead_pid=$((dead_pid - 1)); done
+  owner_file="$lockdir/owner"
+  echo "$dead_pid" > "$owner_file"
+  ran=$(PATH="$fb:$PATH" FM_HOME="$home" bash -c \
+    ". '$LIB'; fm_mrb_with_lock echo ran-ok")
+  assert_contains "$ran" "ran-ok" "the guarded function must still run after reclaiming a dead-owner lock"
+  pass "a lock left behind by a dead owner pid is reclaimed, not left wedged forever"
+}
+
+t_lock_serializes_a_live_owner() {
+  local home fb
+  home="$TMP_ROOT/lock-live-owner"; mkdir -p "$home/state/mini-reboot"
+  fb=$(fake_sysctl_bin "$home")
+  local lockdir owner_file
+  lockdir="$home/state/mini-reboot/check.lock"
+  mkdir -p "$lockdir"
+  owner_file="$lockdir/owner"
+  echo $$ > "$owner_file"   # this test process itself: definitely alive
+  local out
+  out=$(PATH="$fb:$PATH" FM_HOME="$home" bash -c \
+    ". '$LIB'; fm_mrb_with_lock echo should-not-run" 2>&1)
+  assert_not_contains "$out" "should-not-run" "a live owner's lock must not be reclaimed or bypassed"
+  rm -rf "$lockdir"
+  pass "a lock held by a live owner is never reclaimed or bypassed"
+}
+
+# --- the AND-gate: never reboots on either condition alone ------------------
+
+t_check_cycle_does_nothing_when_resource_not_triggered() {
+  local home fb
+  home="$TMP_ROOT/cycle-no-trigger"; mkdir -p "$home/config" "$home/state/mini-reboot"
+  echo "mini" > "$home/config/host-role"
+  local helper="$home/helper.sh"
+  cat > "$helper" <<EOF
+#!/usr/bin/env bash
+echo invoked >> "$home/helper-invocations.log"
+exit 0
+EOF
+  chmod +x "$helper"
+  echo "$helper" > "$home/config/mini-reboot-helper"
+  fb=$(fake_sysctl_bin "$home")
+  cat > "$fb/vm_stat" <<'SH'
+#!/usr/bin/env bash
+echo "Mach Virtual Memory Statistics: (page size of 16384 bytes)"
+echo "Pages free: 0."
+echo "Pages wired down: 0."
+echo "Pages purgeable: 0."
+echo "Pages occupied by compressor: 0."
+echo "Swapins: 0."
+echo "Swapouts: 0."
+SH
+  chmod +x "$fb/vm_stat"
+  cat > "$fb/zprint" <<'SH'
+#!/usr/bin/env bash
+echo "zone name elem size ... inuse"
+SH
+  chmod +x "$fb/zprint"
+  PATH="$fb:$PATH" FM_HOME="$home" FM_MRB_NOW=1000 \
+    bash -c ". '$LIB'; fm_mrb_check_cycle" >/dev/null 2>&1
+  assert_absent "$home/helper-invocations.log" "the reboot helper must never be invoked when resource is not triggered"
+  pass "check cycle with resource NOT triggered never invokes the reboot helper (does nothing)"
+}
+
+# fake_wired_bin <dir> <wired_pages>: page size 1, so wired bytes == wired_pages.
+fake_wired_bin() {
+  local dir=$1 wired=$2 fb
+  fb=$(fake_sysctl_bin "$dir")
+  cat > "$fb/sysctl" <<SH
+#!/usr/bin/env bash
+if [ "\$1" = "-n" ] && [ "\$2" = "kern.bootsessionuuid" ]; then
+  echo "\${FM_FAKE_BOOT_ID:-BOOT-A}"; exit 0
+fi
+if [ "\$1" = "-n" ] && [ "\$2" = "hw.pagesize" ]; then echo 1; exit 0; fi
+if [ "\$1" = "-n" ]; then echo 0; exit 0; fi
+echo "vm.swapusage: total = 1M used = 0M free = 1M"
+SH
+  chmod +x "$fb/sysctl"
+  cat > "$fb/vm_stat" <<EOF
+#!/usr/bin/env bash
+echo "Mach Virtual Memory Statistics: (page size of 1 bytes)"
+echo "Pages free: 0."
+echo "Pages wired down: $wired."
+echo "Pages purgeable: 0."
+echo "Pages occupied by compressor: 0."
+echo "Swapins: 0."
+echo "Swapouts: 0."
+EOF
+  chmod +x "$fb/vm_stat"
+  cat > "$fb/zprint" <<'SH'
+#!/usr/bin/env bash
+echo "zone name elem size ... inuse"
+SH
+  chmod +x "$fb/zprint"
+  printf '%s\n' "$fb"
+}
+
+t_check_cycle_reboots_only_when_both_conditions_genuinely_hold() {
+  local home fb helper other_home over
+  home="$TMP_ROOT/cycle-both"; mkdir -p "$home/config" "$home/state/mini-reboot"
+  other_home="$TMP_ROOT/cycle-both-idle-home"
+  echo "mini" > "$home/config/host-role"
+  helper="$home/helper.sh"
+  cat > "$helper" <<EOF
+#!/usr/bin/env bash
+echo "invoked: \$1" >> "$home/helper-invocations.log"
+exit 0
+EOF
+  chmod +x "$helper"
+  echo "$helper" > "$home/config/mini-reboot-helper"
+  mkdir -p "$other_home/state" "$other_home/data"
+  printf '# Backlog\n\n## Done\n' > "$other_home/data/backlog.md"
+  printf '%s\n' "$other_home" > "$home/config/mini-reboot-homes"
+
+  over=$(( $(FM_HOME="$home" bash -c ". '$LIB'; fm_mrb_maint_wired_bytes") + 1 ))
+  fb=$(fake_wired_bin "$home" "$over")
+
+  # Two prior samples already over threshold (check_cycle's own internal
+  # append will be the third consecutive one), and one prior idle snapshot
+  # far enough back that the internal idle-confirm call completes the
+  # two-snapshot window.
+  PATH="$fb:$PATH" FM_HOME="$home" FM_MRB_NOW=100 bash -c ". '$LIB'; fm_mrb_append_sample"
+  PATH="$fb:$PATH" FM_HOME="$home" FM_MRB_NOW=200 bash -c ". '$LIB'; fm_mrb_append_sample"
+  PATH="$fb:$PATH" FM_HOME="$home" FM_MRB_NOW=300 bash -c ". '$LIB'; fm_mrb_idle_confirm" >/dev/null
+
+  PATH="$fb:$PATH" FM_HOME="$home" FM_MRB_NOW=700 bash -c ". '$LIB'; fm_mrb_check_cycle" >&2
+
+  assert_present "$home/helper-invocations.log" "the reboot helper must be invoked when BOTH conditions genuinely hold"
+  pass "check cycle reboots only once resource is triggered AND idle is confirmed, together"
+}
+
+t_check_cycle_does_not_reboot_when_only_resource_triggers() {
+  local home fb helper over
+  home="$TMP_ROOT/cycle-resource-only"; mkdir -p "$home/config" "$home/state/mini-reboot"
+  echo "mini" > "$home/config/host-role"
+  helper="$home/helper.sh"
+  cat > "$helper" <<EOF
+#!/usr/bin/env bash
+echo invoked >> "$home/helper-invocations.log"
+exit 0
+EOF
+  chmod +x "$helper"
+  echo "$helper" > "$home/config/mini-reboot-helper"
+  # Deliberately NO config/mini-reboot-homes: idle can never be confirmed.
+
+  over=$(( $(FM_HOME="$home" bash -c ". '$LIB'; fm_mrb_maint_wired_bytes") + 1 ))
+  fb=$(fake_wired_bin "$home" "$over")
+  PATH="$fb:$PATH" FM_HOME="$home" FM_MRB_NOW=100 bash -c ". '$LIB'; fm_mrb_append_sample"
+  PATH="$fb:$PATH" FM_HOME="$home" FM_MRB_NOW=200 bash -c ". '$LIB'; fm_mrb_append_sample"
+  PATH="$fb:$PATH" FM_HOME="$home" FM_MRB_NOW=700 bash -c ". '$LIB'; fm_mrb_check_cycle" >&2
+
+  assert_absent "$home/helper-invocations.log" "the resource condition alone, without a confirmed idle window, must never reboot"
+  pass "the resource condition triggering alone (idle never confirmed) never reboots"
+}
+
+t_cli_status_subcommand_runs_end_to_end
+t_cli_unknown_subcommand_errors
+t_no_drain_or_admission_lock_machinery_remains
+t_no_spawn_promote_handoff_integration_added
+t_execute_reboot_refuses_off_mini
+t_execute_reboot_refuses_wrong_role_value
+t_execute_reboot_blocked_without_helper_configured
+t_execute_reboot_blocked_with_nonexecutable_helper
+t_execute_reboot_invokes_a_real_configured_helper
+t_marker_active_blocks_a_second_cycle
+t_marker_clears_on_boot_session_change
+t_marker_clears_when_stale
+t_lock_reclaims_from_a_dead_owner
+t_lock_serializes_a_live_owner
+t_check_cycle_does_nothing_when_resource_not_triggered
+t_check_cycle_reboots_only_when_both_conditions_genuinely_hold
+t_check_cycle_does_not_reboot_when_only_resource_triggers

--- a/tests/fm-mini-reboot-guard.test.sh
+++ b/tests/fm-mini-reboot-guard.test.sh
@@ -287,6 +287,18 @@ t_lock_reclaims_from_a_dead_owner() {
   pass "a lock left behind by a dead owner pid is reclaimed, not left wedged forever"
 }
 
+t_lock_reclaims_ownerless_directory() {
+  local home fb out lockdir
+  home="$TMP_ROOT/lock-ownerless"; mkdir -p "$home/state/mini-reboot"
+  fb=$(fake_sysctl_bin "$home")
+  lockdir="$home/state/mini-reboot/check.lock"
+  mkdir "$lockdir"
+  out=$(PATH="$fb:$PATH" FM_HOME="$home" bash -c \
+    ". '$LIB'; fm_mrb_with_lock echo ran-after-ownerless-crash" 2>&1)
+  assert_contains "$out" "ran-after-ownerless-crash" "an ownerless lock directory must be reclaimed"
+  pass "an ownerless lock directory self-heals on the next invocation"
+}
+
 t_lock_serializes_a_live_owner() {
   local home fb
   home="$TMP_ROOT/lock-live-owner"; mkdir -p "$home/state/mini-reboot"
@@ -459,6 +471,7 @@ t_marker_clears_on_boot_session_change
 t_marker_clears_when_stale
 t_execute_reboot_blocks_when_boot_session_is_unreadable
 t_lock_reclaims_from_a_dead_owner
+t_lock_reclaims_ownerless_directory
 t_lock_serializes_a_live_owner
 t_check_cycle_stops_after_sample_failure
 t_check_cycle_does_nothing_when_resource_not_triggered

--- a/tests/fm-mini-reboot-idle.test.sh
+++ b/tests/fm-mini-reboot-idle.test.sh
@@ -200,6 +200,26 @@ t_process_event_source_blocks() {
   pass "a registered process-event source blocks idleness"
 }
 
+t_malformed_public_followup_response_blocks() {
+  local home fb out
+  home="$TMP_ROOT/followup-malformed"
+  make_clear_home "$home"
+  fb=$(fm_fakebin "$home")
+  cat > "$fb/tasks-axi" <<'SH'
+#!/usr/bin/env bash
+if [ "$1" = public-followup ]; then
+  printf '{}\n'
+else
+  printf 'count: 0\n'
+fi
+SH
+  chmod +x "$fb/tasks-axi"
+  out=$(PATH="$fb:$PATH" bash -c ". '$LIB'; fm_mrb_idle_check_home '$home'")
+  assert_contains "$out" "busy" "a malformed public-followup response must fail closed"
+  assert_contains "$out" "could not parse" "the malformed response should be diagnosed"
+  pass "a malformed public-followup response blocks idleness"
+}
+
 t_promised_public_reply_blocks() {
   local home req exp relation out
   home="$TMP_ROOT/followup"
@@ -352,6 +372,7 @@ t_unhandled_steering_inbox_blocks
 t_handled_steering_inbox_does_not_block
 t_pending_remote_reply_blocks
 t_process_event_source_blocks
+t_malformed_public_followup_response_blocks
 t_promised_public_reply_blocks
 t_empty_registry_is_busy
 t_registered_clear_home_is_idle_via_check_all

--- a/tests/fm-mini-reboot-idle.test.sh
+++ b/tests/fm-mini-reboot-idle.test.sh
@@ -68,6 +68,37 @@ t_child_task_metadata_blocks() {
   pass "child task metadata blocks idleness"
 }
 
+t_missing_state_directory_blocks() {
+  local home out
+  home="$TMP_ROOT/no-state"
+  mkdir -p "$home/data"
+  printf '# Backlog\n\n## Done\n' > "$home/data/backlog.md"
+  out=$(run_idle_check_home "$home")
+  assert_contains "$out" "busy" "a missing state directory must fail closed"
+  assert_contains "$out" "state directory" "the reason should name the missing state directory"
+  pass "a missing state directory blocks idleness"
+}
+
+t_state_enumeration_failure_blocks() {
+  local home fb out
+  home="$TMP_ROOT/state-find-failure"
+  make_clear_home "$home"
+  fb=$(fm_fakebin "$home")
+  cat > "$fb/find" <<EOF
+#!/usr/bin/env bash
+if [ "\$1" = "$home/state" ]; then
+  echo "simulated state read failure" >&2
+  exit 1
+fi
+exec /usr/bin/find "\$@"
+EOF
+  chmod +x "$fb/find"
+  out=$(PATH="$fb:$PATH" bash -c ". '$LIB'; fm_mrb_idle_check_home '$home'")
+  assert_contains "$out" "busy" "a failed state enumeration must fail closed"
+  assert_contains "$out" "could not enumerate" "the enumeration failure should be diagnosed"
+  pass "a state enumeration error blocks idleness"
+}
+
 t_missing_backlog_file_blocks() {
   local home
   home="$TMP_ROOT/no-backlog"
@@ -170,46 +201,32 @@ t_process_event_source_blocks() {
 }
 
 t_promised_public_reply_blocks() {
-  local home
+  local home req exp relation out
   home="$TMP_ROOT/followup"
   make_clear_home "$home"
-  cat > "$home/data/backlog.md" <<'EOF'
-# Backlog
-
-## Done
-EOF
-  if ! command -v tasks-axi >/dev/null 2>&1; then
-    echo "skip - tasks-axi not available" >&2
-    return 0
-  fi
-  # A best-effort real registration through tasks-axi's own public-followup
-  # add path. The typed request_context_binding contract validates several
-  # nested fields deep (context_binding.version must be "ctx1",
-  # context_binding.value must start with "ctx1_" AND satisfy further format
-  # validation this fixture does not reproduce) - that contract is owned by
-  # tasks-axi, not this suite, so a registration failure here skips rather
-  # than asserting a false failure. The count-parsing code path this exercises
-  # is the same one already proven correct (count=0 -> idle) by every other
-  # passing test in this file, since fm_mrb_idle_check_home calls
-  # `public-followup ready` on every clear-home check too.
-  local req exp
-  req="$home/req.json"; exp="$home/exp.json"
-  cat > "$req" <<'EOF2'
-{"request_id":"pf-test-1","platform":"slack","context_binding":{"version":"ctx1","value":"ctx1_c1_1.1"},"public_safe_summary":"test","received_at":"2026-08-24T00:00:00Z","followup_expires_at":"2099-01-01T00:00:00Z","reservation_expires_at":"2099-01-01T00:00:00Z"}
-EOF2
-  cat > "$exp" <<'EOF2'
-{"type":"note","project":"demo","required_deliverables":["reply"],"completion_policy":"manual"}
-EOF2
+  command -v tasks-axi >/dev/null 2>&1 || fail "tasks-axi is required for public-followup coverage"
+  command -v jq >/dev/null 2>&1 || fail "jq is required for public-followup coverage"
+  req="$home/req.json"; exp="$home/exp.json"; relation="$home/relation.json"
+  jq -n '{request_id:"req-pf-test", platform:"discord",
+    context_binding:{version:"ctx1", value:"ctx1_req-pf-test"},
+    public_safe_summary:"test", received_at:"2026-08-24T00:00:00Z",
+    followup_expires_at:"2099-01-01T00:00:00Z",
+    reservation_expires_at:"2099-01-01T00:00:00Z"}' > "$req"
+  jq -n '{type:"report-ready", project:"firstmate", required_deliverables:["report_path"],
+    completion_policy:"all-required"}' > "$exp"
+  jq -n '{relation_id:"rel-test", work_ref:{home_id:"main", task_id:"work-test"},
+    role:"fulfills", required:true, generation:1}' > "$relation"
   tasks-axi public-followup add pf-test-1 --file "$home/data/backlog.md" \
     --request-context-file "$req" --purpose promised-final \
-    --expected-final-file "$exp" --expires-at 2099-01-01T00:00:00Z >/dev/null 2>&1 || {
-    echo "skip - could not register a fixture public-followup obligation" >&2
-    return 0
-  }
-  local out
+    --expected-final-file "$exp" --expires-at 2099-01-01T00:00:00Z >/dev/null 2>&1 \
+    || fail "fixture setup: public-followup add failed"
+  tasks-axi public-followup bind-work pf-test-1 --file "$home/data/backlog.md" \
+    --relation-file "$relation" >/dev/null 2>&1 \
+    || fail "fixture setup: public-followup bind-work failed"
   out=$(run_idle_check_home "$home")
-  assert_contains "$out" "busy" "a promised public reply still owed must block idleness"
-  pass "a promised public reply still owed blocks idleness"
+  assert_contains "$out" "busy" "a pending-work public reply must block idleness"
+  assert_contains "$out" "still owed" "the reason should identify the unresolved public reply"
+  pass "a pending-work promised public reply blocks idleness"
 }
 
 # --- (d) empty/unregistered registry never reads as idle -------------------
@@ -326,6 +343,8 @@ t_busy_reading_between_two_idle_reads_resets_confirmation() {
 
 t_clear_home_is_idle
 t_child_task_metadata_blocks
+t_missing_state_directory_blocks
+t_state_enumeration_failure_blocks
 t_missing_backlog_file_blocks
 t_in_flight_backlog_item_blocks
 t_held_captain_decision_blocks

--- a/tests/fm-mini-reboot-idle.test.sh
+++ b/tests/fm-mini-reboot-idle.test.sh
@@ -57,15 +57,39 @@ t_clear_home_is_idle() {
   pass "a genuinely clear home reports idle"
 }
 
-t_child_task_metadata_blocks() {
-  local home
-  home="$TMP_ROOT/meta"
+t_working_child_current_state_blocks() {
+  local home reader out
+  home="$TMP_ROOT/meta-working"
   make_clear_home "$home"
   fm_write_meta "$home/state/some-task.meta" "kind=ship" "worktree=/tmp/x"
-  local out
-  out=$(run_idle_check_home "$home")
-  assert_contains "$out" "busy" "child task metadata must block idleness"
-  pass "child task metadata blocks idleness"
+  echo "done: stale event" > "$home/state/some-task.status"
+  reader="$home/fm-crew-state.sh"
+  cat > "$reader" <<EOF
+#!/usr/bin/env bash
+echo "\$1" > "$home/crew-state-invoked"
+echo "state: working · source: run-step · active validation"
+EOF
+  chmod +x "$reader"
+  out=$(FM_MRB_CREW_STATE_BIN="$reader" bash -c ". '$LIB'; fm_mrb_idle_check_home '$home'")
+  assert_contains "$out" "busy" "a reconciled working state must block idleness"
+  assert_present "$home/crew-state-invoked" "the current-state owner must be invoked"
+  pass "a reconciled working child blocks despite a stale done event"
+}
+
+t_done_child_current_state_allows_idle() {
+  local home reader out
+  home="$TMP_ROOT/meta-done"
+  make_clear_home "$home"
+  fm_write_meta "$home/state/some-task.meta" "kind=ship" "worktree=/tmp/x"
+  reader="$home/fm-crew-state.sh"
+  cat > "$reader" <<'EOF'
+#!/usr/bin/env bash
+echo "state: done · source: run-step · checks passed"
+EOF
+  chmod +x "$reader"
+  out=$(FM_MRB_CREW_STATE_BIN="$reader" bash -c ". '$LIB'; fm_mrb_idle_check_home '$home'")
+  [ "$out" = idle ] || fail "a reconciled done child should allow idle, got: $out"
+  pass "a child reported done by fm-crew-state allows idleness"
 }
 
 t_missing_state_directory_blocks() {
@@ -362,7 +386,8 @@ t_busy_reading_between_two_idle_reads_resets_confirmation() {
 }
 
 t_clear_home_is_idle
-t_child_task_metadata_blocks
+t_working_child_current_state_blocks
+t_done_child_current_state_allows_idle
 t_missing_state_directory_blocks
 t_state_enumeration_failure_blocks
 t_missing_backlog_file_blocks

--- a/tests/fm-mini-reboot-idle.test.sh
+++ b/tests/fm-mini-reboot-idle.test.sh
@@ -7,7 +7,7 @@
 # Pins:
 #   (a) each documented blocking condition individually blocks: child task
 #       metadata, in-flight backlog item, held captain decision, unhandled
-#       steering inbox, pending remote reply, promised public reply owed,
+#       steering inbox, unresolved remote reply, promised public reply owed,
 #       registered process-event source
 #   (b) a genuinely clear home reports idle
 #   (c) a missing backlog file is treated as busy (fail-closed), never as "no
@@ -205,11 +205,24 @@ t_pending_remote_reply_blocks() {
   home="$TMP_ROOT/pending-reply"
   make_clear_home "$home"
   mkdir -p "$home/state/pending-replies"
-  echo "corr=abc123" > "$home/state/pending-replies/abc123"
+  printf 'schema=fm-pending-reply.v1\nphase=awaiting_report\n' \
+    > "$home/state/pending-replies/abc123"
   local out
   out=$(run_idle_check_home "$home")
-  assert_contains "$out" "busy" "a pending remote reply must block idleness"
-  pass "a pending remote reply record blocks idleness"
+  assert_contains "$out" "busy" "an unresolved remote reply must block idleness"
+  pass "an unresolved pending-reply record blocks idleness"
+}
+
+t_resolved_remote_reply_does_not_block() {
+  local home out
+  home="$TMP_ROOT/resolved-reply"
+  make_clear_home "$home"
+  mkdir -p "$home/state/pending-replies"
+  printf 'schema=fm-pending-reply.v1\nphase=resolved\nresolved_epoch=1234\n' \
+    > "$home/state/pending-replies/abc123"
+  out=$(run_idle_check_home "$home")
+  [ "$out" = idle ] || fail "a retained resolved reply must not block idleness, got: $out"
+  pass "a retained resolved pending-reply record does not block idleness"
 }
 
 t_process_event_source_blocks() {
@@ -217,11 +230,22 @@ t_process_event_source_blocks() {
   home="$TMP_ROOT/procevent"
   make_clear_home "$home"
   mkdir -p "$home/state/procevent"
-  echo "source=github-pr-123" > "$home/state/procevent/github-pr-123"
+  echo "source=github-pr-123" > "$home/state/procevent/github-pr-123.source"
   local out
   out=$(run_idle_check_home "$home")
   assert_contains "$out" "busy" "a registered process-event source must block idleness"
   pass "a registered process-event source blocks idleness"
+}
+
+t_process_event_runner_artifact_does_not_block() {
+  local home out
+  home="$TMP_ROOT/procevent-runner-only"
+  make_clear_home "$home"
+  mkdir -p "$home/state/procevent"
+  printf 'runner\n' > "$home/state/procevent/retired.runner"
+  out=$(run_idle_check_home "$home")
+  [ "$out" = idle ] || fail "a runner artifact without a .source registration must not block idleness, got: $out"
+  pass "a process-event runner artifact alone does not block idleness"
 }
 
 t_malformed_public_followup_response_blocks() {
@@ -315,7 +339,8 @@ t_one_busy_home_blocks_the_whole_registry() {
 
 idle_confirm_at() {
   local coordinator=$1 now=$2
-  FM_HOME="$coordinator" FM_MRB_NOW="$now" bash -c ". '$LIB'; fm_mrb_idle_confirm"
+  FM_HOME="$coordinator" FM_MRB_NOW="$now" bash -c \
+    ". '$LIB'; fm_mrb_boot_session_id() { printf '%s\\n' test-boot-session; }; fm_mrb_idle_confirm"
 }
 
 t_single_idle_read_is_not_confirmed() {
@@ -396,7 +421,9 @@ t_held_captain_decision_blocks
 t_unhandled_steering_inbox_blocks
 t_handled_steering_inbox_does_not_block
 t_pending_remote_reply_blocks
+t_resolved_remote_reply_does_not_block
 t_process_event_source_blocks
+t_process_event_runner_artifact_does_not_block
 t_malformed_public_followup_response_blocks
 t_promised_public_reply_blocks
 t_empty_registry_is_busy

--- a/tests/fm-mini-reboot-idle.test.sh
+++ b/tests/fm-mini-reboot-idle.test.sh
@@ -1,0 +1,344 @@
+#!/usr/bin/env bash
+# Behavior tests for bin/fm-mini-reboot-lib.sh's idle-check and two-snapshot
+# idle-confirm logic (report section 6, Phase C/D adapted for the
+# captain's 2026-08-24 retarget: local-only idleness, no drain, no
+# cross-host receipts).
+#
+# Pins:
+#   (a) each documented blocking condition individually blocks: child task
+#       metadata, in-flight backlog item, held captain decision, unhandled
+#       steering inbox, pending remote reply, promised public reply owed,
+#       registered process-event source
+#   (b) a genuinely clear home reports idle
+#   (c) a missing backlog file is treated as busy (fail-closed), never as "no
+#       obligation" - the direct regression for the tasks-axi
+#       missing-file-reports-count-zero trap
+#   (d) an empty/unregistered homes registry reports busy, never idle, so an
+#       unconfigured guard never reboots
+#   (e) idle-confirm requires TWO consecutive idle reads at least
+#       idle_min_gap_secs apart - a single idle read is never "confirmed"
+#   (f) idle-confirm rejects a gap that is too large (stitching two unrelated
+#       far-apart observations together) as well as too small
+#   (g) never uses --force, never kills, never aborts, never discards
+#       anything - this suite only ever reads state
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+LIB="$ROOT/bin/fm-mini-reboot-lib.sh"
+TMP_ROOT=$(fm_test_tmproot fm-mini-reboot-idle)
+
+# make_clear_home <dir>: a home with an empty backlog (no in_flight/held/
+# followup items), no state/ obligations - the baseline "idle" fixture that
+# each blocking test starts from and mutates exactly one thing.
+make_clear_home() {
+  local home=$1
+  mkdir -p "$home/state" "$home/data"
+  cat > "$home/data/backlog.md" <<'EOF'
+# Backlog
+
+## Done
+EOF
+}
+
+run_idle_check_home() {
+  local home=$1
+  bash -c ". '$LIB'; fm_mrb_idle_check_home '$home'"
+}
+
+t_clear_home_is_idle() {
+  local home
+  home="$TMP_ROOT/clear"
+  make_clear_home "$home"
+  local out
+  out=$(run_idle_check_home "$home")
+  [ "$out" = idle ] || fail "expected idle, got: $out"
+  pass "a genuinely clear home reports idle"
+}
+
+t_child_task_metadata_blocks() {
+  local home
+  home="$TMP_ROOT/meta"
+  make_clear_home "$home"
+  fm_write_meta "$home/state/some-task.meta" "kind=ship" "worktree=/tmp/x"
+  local out
+  out=$(run_idle_check_home "$home")
+  assert_contains "$out" "busy" "child task metadata must block idleness"
+  pass "child task metadata blocks idleness"
+}
+
+t_missing_backlog_file_blocks() {
+  local home
+  home="$TMP_ROOT/no-backlog"
+  mkdir -p "$home/state" "$home/data"
+  # Deliberately do NOT create data/backlog.md - regression for the
+  # tasks-axi trap where a nonexistent file reports "count: 0" (exit 0)
+  # instead of erroring, which would otherwise silently read as idle.
+  local out
+  out=$(run_idle_check_home "$home")
+  assert_contains "$out" "busy" "a missing backlog file must fail closed, not read as empty"
+  assert_contains "$out" "backlog" "the reason should name the backlog"
+  pass "a missing backlog file blocks idleness (fail-closed, not silently empty)"
+}
+
+t_in_flight_backlog_item_blocks() {
+  local home
+  home="$TMP_ROOT/in-flight"
+  make_clear_home "$home"
+  if ! command -v tasks-axi >/dev/null 2>&1; then
+    echo "skip - tasks-axi not available" >&2
+    return 0
+  fi
+  # Built through the real tasks-axi interface, not hand-authored markdown,
+  # so this pins observable behavior rather than an assumed file format.
+  tasks-axi add demo-task "test in-flight task" --file "$home/data/backlog.md" \
+    --kind ship --repo demo --start >/dev/null 2>&1 \
+    || fail "fixture setup: tasks-axi add --start failed"
+  local out
+  out=$(run_idle_check_home "$home")
+  assert_contains "$out" "busy" "an in-flight backlog item must block idleness"
+  pass "an in-flight backlog item blocks idleness"
+}
+
+t_held_captain_decision_blocks() {
+  local home
+  home="$TMP_ROOT/held"
+  make_clear_home "$home"
+  if ! command -v tasks-axi >/dev/null 2>&1; then
+    echo "skip - tasks-axi not available" >&2
+    return 0
+  fi
+  tasks-axi add captain-call "test held task" --file "$home/data/backlog.md" \
+    --kind task --repo demo >/dev/null 2>&1 \
+    || fail "fixture setup: tasks-axi add failed"
+  tasks-axi hold captain-call --file "$home/data/backlog.md" \
+    --reason "need a decision" --kind captain >/dev/null 2>&1 \
+    || fail "fixture setup: tasks-axi hold failed"
+  local out
+  out=$(run_idle_check_home "$home")
+  assert_contains "$out" "busy" "an open captain decision must block idleness"
+  pass "an open captain decision (held) blocks idleness"
+}
+
+t_unhandled_steering_inbox_blocks() {
+  local home
+  home="$TMP_ROOT/inbox"
+  make_clear_home "$home"
+  mkdir -p "$home/state/some-task.inbox"
+  echo "schema=fm-task-inbox.v1" > "$home/state/some-task.inbox/001.msg"
+  local out
+  out=$(run_idle_check_home "$home")
+  assert_contains "$out" "busy" "an unhandled steering inbox message must block idleness"
+  pass "an unhandled steering inbox message blocks idleness"
+}
+
+t_handled_steering_inbox_does_not_block() {
+  local home
+  home="$TMP_ROOT/inbox-handled"
+  make_clear_home "$home"
+  mkdir -p "$home/state/some-task.inbox/handled"
+  echo "schema=fm-task-inbox.v1" > "$home/state/some-task.inbox/handled/001.msg"
+  local out
+  out=$(run_idle_check_home "$home")
+  [ "$out" = idle ] || fail "a HANDLED inbox message must not block idleness, got: $out"
+  pass "an already-handled steering inbox message does not block idleness"
+}
+
+t_pending_remote_reply_blocks() {
+  local home
+  home="$TMP_ROOT/pending-reply"
+  make_clear_home "$home"
+  mkdir -p "$home/state/pending-replies"
+  echo "corr=abc123" > "$home/state/pending-replies/abc123"
+  local out
+  out=$(run_idle_check_home "$home")
+  assert_contains "$out" "busy" "a pending remote reply must block idleness"
+  pass "a pending remote reply record blocks idleness"
+}
+
+t_process_event_source_blocks() {
+  local home
+  home="$TMP_ROOT/procevent"
+  make_clear_home "$home"
+  mkdir -p "$home/state/procevent"
+  echo "source=github-pr-123" > "$home/state/procevent/github-pr-123"
+  local out
+  out=$(run_idle_check_home "$home")
+  assert_contains "$out" "busy" "a registered process-event source must block idleness"
+  pass "a registered process-event source blocks idleness"
+}
+
+t_promised_public_reply_blocks() {
+  local home
+  home="$TMP_ROOT/followup"
+  make_clear_home "$home"
+  cat > "$home/data/backlog.md" <<'EOF'
+# Backlog
+
+## Done
+EOF
+  if ! command -v tasks-axi >/dev/null 2>&1; then
+    echo "skip - tasks-axi not available" >&2
+    return 0
+  fi
+  # A best-effort real registration through tasks-axi's own public-followup
+  # add path. The typed request_context_binding contract validates several
+  # nested fields deep (context_binding.version must be "ctx1",
+  # context_binding.value must start with "ctx1_" AND satisfy further format
+  # validation this fixture does not reproduce) - that contract is owned by
+  # tasks-axi, not this suite, so a registration failure here skips rather
+  # than asserting a false failure. The count-parsing code path this exercises
+  # is the same one already proven correct (count=0 -> idle) by every other
+  # passing test in this file, since fm_mrb_idle_check_home calls
+  # `public-followup ready` on every clear-home check too.
+  local req exp
+  req="$home/req.json"; exp="$home/exp.json"
+  cat > "$req" <<'EOF2'
+{"request_id":"pf-test-1","platform":"slack","context_binding":{"version":"ctx1","value":"ctx1_c1_1.1"},"public_safe_summary":"test","received_at":"2026-08-24T00:00:00Z","followup_expires_at":"2099-01-01T00:00:00Z","reservation_expires_at":"2099-01-01T00:00:00Z"}
+EOF2
+  cat > "$exp" <<'EOF2'
+{"type":"note","project":"demo","required_deliverables":["reply"],"completion_policy":"manual"}
+EOF2
+  tasks-axi public-followup add pf-test-1 --file "$home/data/backlog.md" \
+    --request-context-file "$req" --purpose promised-final \
+    --expected-final-file "$exp" --expires-at 2099-01-01T00:00:00Z >/dev/null 2>&1 || {
+    echo "skip - could not register a fixture public-followup obligation" >&2
+    return 0
+  }
+  local out
+  out=$(run_idle_check_home "$home")
+  assert_contains "$out" "busy" "a promised public reply still owed must block idleness"
+  pass "a promised public reply still owed blocks idleness"
+}
+
+# --- (d) empty/unregistered registry never reads as idle -------------------
+
+t_empty_registry_is_busy() {
+  local coordinator out
+  coordinator="$TMP_ROOT/coordinator-empty"
+  mkdir -p "$coordinator/config"
+  out=$(FM_HOME="$coordinator" bash -c ". '$LIB'; fm_mrb_idle_check_all")
+  assert_contains "$out" "busy" "an empty/absent homes registry must never read as idle"
+  pass "an empty or absent homes registry reports busy (guard never reboots unconfigured)"
+}
+
+t_registered_clear_home_is_idle_via_check_all() {
+  local coordinator home out
+  coordinator="$TMP_ROOT/coordinator-clear"
+  home="$TMP_ROOT/coordinator-clear-home"
+  make_clear_home "$home"
+  mkdir -p "$coordinator/config"
+  printf '%s\n' "$home" > "$coordinator/config/mini-reboot-homes"
+  out=$(FM_HOME="$coordinator" bash -c ". '$LIB'; fm_mrb_idle_check_all")
+  [ "$out" = idle ] || fail "expected idle via check-all, got: $out"
+  pass "idle-check-all reports idle when every registered home is clear"
+}
+
+t_one_busy_home_blocks_the_whole_registry() {
+  local coordinator clear busy out
+  coordinator="$TMP_ROOT/coordinator-mixed"
+  clear="$TMP_ROOT/coordinator-mixed-clear"
+  busy="$TMP_ROOT/coordinator-mixed-busy"
+  make_clear_home "$clear"
+  make_clear_home "$busy"
+  fm_write_meta "$busy/state/some-task.meta" "kind=ship"
+  mkdir -p "$coordinator/config"
+  printf '%s\n%s\n' "$clear" "$busy" > "$coordinator/config/mini-reboot-homes"
+  out=$(FM_HOME="$coordinator" bash -c ". '$LIB'; fm_mrb_idle_check_all")
+  assert_contains "$out" "busy" "one busy home must block the whole registry"
+  pass "any single busy registered home blocks the whole fleet-idle verdict"
+}
+
+# --- (e)/(f) idle-confirm two-snapshot gap logic ----------------------------
+
+idle_confirm_at() {
+  local coordinator=$1 now=$2
+  FM_HOME="$coordinator" FM_MRB_NOW="$now" bash -c ". '$LIB'; fm_mrb_idle_confirm"
+}
+
+t_single_idle_read_is_not_confirmed() {
+  local coordinator home out
+  coordinator="$TMP_ROOT/confirm-single"
+  home="$TMP_ROOT/confirm-single-home"
+  make_clear_home "$home"
+  mkdir -p "$coordinator/config"
+  printf '%s\n' "$home" > "$coordinator/config/mini-reboot-homes"
+  out=$(idle_confirm_at "$coordinator" 1000)
+  assert_contains "$out" "confirmed=no" "a single idle read must not be confirmed"
+  pass "a single idle read alone is never confirmed"
+}
+
+t_two_idle_reads_within_gap_window_confirms() {
+  local coordinator home out
+  coordinator="$TMP_ROOT/confirm-two-ok"
+  home="$TMP_ROOT/confirm-two-ok-home"
+  make_clear_home "$home"
+  mkdir -p "$coordinator/config"
+  printf '%s\n' "$home" > "$coordinator/config/mini-reboot-homes"
+  idle_confirm_at "$coordinator" 1000 >/dev/null
+  out=$(idle_confirm_at "$coordinator" 1400)   # 400s gap: within [300,1800]
+  assert_contains "$out" "confirmed=yes" "two idle reads 400s apart should confirm"
+  pass "two consecutive idle reads within the gap window confirm the idle window"
+}
+
+t_two_idle_reads_too_close_does_not_confirm() {
+  local coordinator home out
+  coordinator="$TMP_ROOT/confirm-too-close"
+  home="$TMP_ROOT/confirm-too-close-home"
+  make_clear_home "$home"
+  mkdir -p "$coordinator/config"
+  printf '%s\n' "$home" > "$coordinator/config/mini-reboot-homes"
+  idle_confirm_at "$coordinator" 1000 >/dev/null
+  out=$(idle_confirm_at "$coordinator" 1100)   # 100s gap: below the 300s min
+  assert_contains "$out" "confirmed=no" "two idle reads only 100s apart must not confirm"
+  pass "two idle reads closer than the minimum gap do not confirm (not a momentary blip)"
+}
+
+t_two_idle_reads_too_far_apart_does_not_confirm() {
+  local coordinator home out
+  coordinator="$TMP_ROOT/confirm-too-far"
+  home="$TMP_ROOT/confirm-too-far-home"
+  make_clear_home "$home"
+  mkdir -p "$coordinator/config"
+  printf '%s\n' "$home" > "$coordinator/config/mini-reboot-homes"
+  idle_confirm_at "$coordinator" 1000 >/dev/null
+  out=$(idle_confirm_at "$coordinator" 100000)  # way beyond the 1800s max
+  assert_contains "$out" "confirmed=no" "two idle reads stitched across an unrelated span must not confirm"
+  pass "two idle reads too far apart do not confirm (not stitched-together isolated reads)"
+}
+
+t_busy_reading_between_two_idle_reads_resets_confirmation() {
+  local coordinator home out
+  coordinator="$TMP_ROOT/confirm-interrupted"
+  home="$TMP_ROOT/confirm-interrupted-home"
+  make_clear_home "$home"
+  mkdir -p "$coordinator/config"
+  printf '%s\n' "$home" > "$coordinator/config/mini-reboot-homes"
+  idle_confirm_at "$coordinator" 1000 >/dev/null   # idle
+  fm_write_meta "$home/state/some-task.meta" "kind=ship"   # now busy
+  idle_confirm_at "$coordinator" 1400 >/dev/null   # busy: breaks the streak
+  rm -f "$home/state/some-task.meta"                # idle again
+  out=$(idle_confirm_at "$coordinator" 1800)
+  assert_contains "$out" "confirmed=no" "a busy reading in between must reset the two-snapshot streak"
+  pass "a busy reading between two idle reads resets the confirmation streak"
+}
+
+t_clear_home_is_idle
+t_child_task_metadata_blocks
+t_missing_backlog_file_blocks
+t_in_flight_backlog_item_blocks
+t_held_captain_decision_blocks
+t_unhandled_steering_inbox_blocks
+t_handled_steering_inbox_does_not_block
+t_pending_remote_reply_blocks
+t_process_event_source_blocks
+t_promised_public_reply_blocks
+t_empty_registry_is_busy
+t_registered_clear_home_is_idle_via_check_all
+t_one_busy_home_blocks_the_whole_registry
+t_single_idle_read_is_not_confirmed
+t_two_idle_reads_within_gap_window_confirms
+t_two_idle_reads_too_close_does_not_confirm
+t_two_idle_reads_too_far_apart_does_not_confirm
+t_busy_reading_between_two_idle_reads_resets_confirmation

--- a/tests/fm-mini-reboot-sampler.test.sh
+++ b/tests/fm-mini-reboot-sampler.test.sh
@@ -161,6 +161,28 @@ t_invalid_zprint_does_not_append_a_sample() {
   pass "malformed zprint output is rejected without appending a sample"
 }
 
+t_boot_change_resets_detection_history() {
+  local dir fb home samples idle out
+  dir="$TMP_ROOT/boot-history"; mkdir -p "$dir"
+  fb=$(fake_bin "$dir"); home="$dir/home"
+  FM_HOME="$home" FM_MRB_NOW=1000 FM_FAKE_BOOT_ID=BOOT-A FM_FAKE_ZONE_BYTES=99999999999 \
+    FM_FAKE_PAGESIZE=1 PATH="$fb:$PATH" bash -c ". '$LIB'; fm_mrb_append_sample"
+  FM_HOME="$home" FM_MRB_NOW=1100 FM_FAKE_BOOT_ID=BOOT-A FM_FAKE_ZONE_BYTES=99999999999 \
+    FM_FAKE_PAGESIZE=1 PATH="$fb:$PATH" bash -c ". '$LIB'; fm_mrb_append_sample"
+  idle="$home/state/mini-reboot/idle-snapshot.tsv"
+  printf '1100\tidle\n' > "$idle"
+  FM_HOME="$home" FM_MRB_NOW=1200 FM_FAKE_BOOT_ID=BOOT-B FM_FAKE_ZONE_BYTES=99999999999 \
+    FM_FAKE_PAGESIZE=1 PATH="$fb:$PATH" bash -c ". '$LIB'; fm_mrb_append_sample"
+  samples="$home/state/mini-reboot/samples.tsv"
+  [ "$(wc -l < "$samples" | tr -d ' ')" -eq 1 ] || fail "a new boot must retain only its new sample"
+  assert_absent "$idle" "a new boot must clear the prior idle snapshot"
+  out=$(FM_HOME="$home" FM_MRB_NOW=1200 FM_FAKE_BOOT_ID=BOOT-B PATH="$fb:$PATH" \
+    bash -c ". '$LIB'; fm_mrb_evaluate")
+  assert_contains "$out" "trigger=no" "one post-boot sample must not combine with prior-boot history"
+  assert_contains "$out" "insufficient-samples" "the post-boot evaluation should start from one sample"
+  pass "a boot-session change resets sample and idle history"
+}
+
 # --- helper: append N samples with per-sample overrides ---------------------
 
 # append_series <dir> <fakebin> <home> "<epoch> <zone> <wired_pages> <pressure> <swapouts>" ...
@@ -178,8 +200,10 @@ append_series() {
 }
 
 evaluate_with() {
-  local home=$1 now=$2
-  FM_HOME="$home" FM_MRB_NOW="$now" bash -c ". '$LIB'; fm_mrb_evaluate"
+  local home=$1 now=$2 fb
+  fb="${home%/home}/fakebin"
+  FM_HOME="$home" FM_MRB_NOW="$now" FM_FAKE_BOOT_ID="${FM_FAKE_BOOT_ID:-BOOT-A}" \
+    PATH="$fb:$PATH" bash -c ". '$LIB'; fm_mrb_evaluate"
 }
 
 # --- (c) never triggers below the minimum sample count ----------------------
@@ -398,6 +422,7 @@ t_collect_sample_parses_metrics
 t_append_sample_persists_deltas
 t_first_sample_has_zero_deltas
 t_invalid_zprint_does_not_append_a_sample
+t_boot_change_resets_detection_history
 t_never_triggers_from_single_sample
 t_two_samples_do_not_trigger_threshold_condition
 t_three_consecutive_over_threshold_triggers

--- a/tests/fm-mini-reboot-sampler.test.sh
+++ b/tests/fm-mini-reboot-sampler.test.sh
@@ -296,6 +296,19 @@ t_slope_forecast_beyond_horizon_does_not_trigger() {
   pass "a shallow recent slope that would only cross far beyond the horizon does not trigger"
 }
 
+t_peak_then_falling_hard_ceiling_does_not_trigger() {
+  local dir fb home out
+  dir="$TMP_ROOT/slope-falling"; mkdir -p "$dir"
+  fb=$(fake_bin "$dir"); home="$dir/home"
+  append_series "$fb" "$home" \
+    "1000 0 0 1 0" \
+    "1100 $((HARD_ZONE + 1024 * 1024 * 1024)) 0 1 0" \
+    "1200 $HARD_ZONE 0 1 0"
+  out=$(evaluate_with "$home" 1200)
+  assert_contains "$out" "trigger=no" "a peak followed by a falling hard-ceiling sample must not trigger"
+  pass "an improving trend at the hard ceiling does not create an extra trigger"
+}
+
 t_lifetime_first_sample_does_not_pollute_recent_slope() {
   local dir fb home out
   dir="$TMP_ROOT/slope-window"; mkdir -p "$dir"
@@ -378,6 +391,7 @@ t_only_two_of_three_consecutive_does_not_trigger
 t_wired_alone_over_threshold_triggers
 t_slope_forecast_within_horizon_triggers
 t_slope_forecast_beyond_horizon_does_not_trigger
+t_peak_then_falling_hard_ceiling_does_not_trigger
 t_lifetime_first_sample_does_not_pollute_recent_slope
 t_pressure_and_rising_swapouts_triggers
 t_pressure_alone_without_rising_swapouts_does_not_trigger

--- a/tests/fm-mini-reboot-sampler.test.sh
+++ b/tests/fm-mini-reboot-sampler.test.sh
@@ -333,6 +333,19 @@ t_rising_swapouts_alone_without_pressure_does_not_trigger() {
   pass "rising swapouts alone under normal pressure does not trigger"
 }
 
+t_unknown_pressure_with_rising_swapouts_does_not_trigger() {
+  local dir fb home out
+  dir="$TMP_ROOT/pressure-unknown"; mkdir -p "$dir"
+  fb=$(fake_bin "$dir"); home="$dir/home"
+  append_series "$fb" "$home" \
+    "1000 0 0 0 10" \
+    "1100 0 0 0 15" \
+    "1200 0 0 0 20"
+  out=$(evaluate_with "$home" 1200)
+  assert_contains "$out" "trigger=no" "unknown pressure must fail closed despite rising swapouts"
+  pass "unknown pressure with rising swapouts does not trigger"
+}
+
 t_collect_sample_parses_metrics
 t_append_sample_persists_deltas
 t_first_sample_has_zero_deltas
@@ -347,3 +360,4 @@ t_lifetime_first_sample_does_not_pollute_recent_slope
 t_pressure_and_rising_swapouts_triggers
 t_pressure_alone_without_rising_swapouts_does_not_trigger
 t_rising_swapouts_alone_without_pressure_does_not_trigger
+t_unknown_pressure_with_rising_swapouts_does_not_trigger

--- a/tests/fm-mini-reboot-sampler.test.sh
+++ b/tests/fm-mini-reboot-sampler.test.sh
@@ -296,17 +296,17 @@ t_slope_forecast_beyond_horizon_does_not_trigger() {
   pass "a shallow recent slope that would only cross far beyond the horizon does not trigger"
 }
 
-t_peak_then_falling_hard_ceiling_does_not_trigger() {
+t_rise_then_fall_below_ceiling_does_not_trigger() {
   local dir fb home out
   dir="$TMP_ROOT/slope-falling"; mkdir -p "$dir"
   fb=$(fake_bin "$dir"); home="$dir/home"
   append_series "$fb" "$home" \
     "1000 0 0 1 0" \
-    "1100 $((HARD_ZONE + 1024 * 1024 * 1024)) 0 1 0" \
-    "1200 $HARD_ZONE 0 1 0"
+    "1100 $((HARD_ZONE - 512 * 1024 * 1024)) 0 1 0" \
+    "1200 $((HARD_ZONE - 1024 * 1024 * 1024)) 0 1 0"
   out=$(evaluate_with "$home" 1200)
-  assert_contains "$out" "trigger=no" "a peak followed by a falling hard-ceiling sample must not trigger"
-  pass "an improving trend at the hard ceiling does not create an extra trigger"
+  assert_contains "$out" "trigger=no" "a below-ceiling falling recent segment must block the net-positive slope forecast"
+  pass "a rise then fall below the hard ceiling does not trigger"
 }
 
 t_lifetime_first_sample_does_not_pollute_recent_slope() {
@@ -391,7 +391,7 @@ t_only_two_of_three_consecutive_does_not_trigger
 t_wired_alone_over_threshold_triggers
 t_slope_forecast_within_horizon_triggers
 t_slope_forecast_beyond_horizon_does_not_trigger
-t_peak_then_falling_hard_ceiling_does_not_trigger
+t_rise_then_fall_below_ceiling_does_not_trigger
 t_lifetime_first_sample_does_not_pollute_recent_slope
 t_pressure_and_rising_swapouts_triggers
 t_pressure_alone_without_rising_swapouts_does_not_trigger

--- a/tests/fm-mini-reboot-sampler.test.sh
+++ b/tests/fm-mini-reboot-sampler.test.sh
@@ -380,6 +380,20 @@ t_unknown_pressure_with_rising_swapouts_does_not_trigger() {
   pass "unknown pressure with rising swapouts does not trigger"
 }
 
+t_pre_window_swapout_delta_does_not_trigger() {
+  local dir fb home out
+  dir="$TMP_ROOT/pressure-pre-window-delta"; mkdir -p "$dir"
+  fb=$(fake_bin "$dir"); home="$dir/home"
+  append_series "$fb" "$home" \
+    "900 0 0 1 0" \
+    "1000 0 0 2 100" \
+    "1100 0 0 2 50" \
+    "1200 0 0 2 50"
+  out=$(evaluate_with "$home" 1200)
+  assert_contains "$out" "trigger=no" "a pre-window increase must not outweigh falling then flat selected swapouts"
+  pass "swapout trend excludes the first selected row's pre-window delta"
+}
+
 t_collect_sample_parses_metrics
 t_append_sample_persists_deltas
 t_first_sample_has_zero_deltas
@@ -397,3 +411,4 @@ t_pressure_and_rising_swapouts_triggers
 t_pressure_alone_without_rising_swapouts_does_not_trigger
 t_rising_swapouts_alone_without_pressure_does_not_trigger
 t_unknown_pressure_with_rising_swapouts_does_not_trigger
+t_pre_window_swapout_delta_does_not_trigger

--- a/tests/fm-mini-reboot-sampler.test.sh
+++ b/tests/fm-mini-reboot-sampler.test.sh
@@ -282,6 +282,19 @@ t_wired_alone_over_threshold_triggers() {
   pass "wired memory alone crossing its threshold for 3 samples triggers (OR, not AND)"
 }
 
+t_duplicate_timestamps_keep_each_wired_sample_distinct() {
+  local dir fb home out
+  dir="$TMP_ROOT/wired-duplicate-time"; mkdir -p "$dir"
+  fb=$(fake_bin "$dir"); home="$dir/home"
+  append_series "$fb" "$home" \
+    "100 0 $((MAINT_WIRED + 1)) 1 0" \
+    "100 0 0 1 0" \
+    "200 0 $((MAINT_WIRED + 1)) 1 0"
+  out=$(evaluate_with "$home" 200)
+  assert_contains "$out" "trigger=no" "duplicate timestamps must not reuse another row's wired value"
+  pass "consecutive thresholds evaluate each duplicate-timestamp sample independently"
+}
+
 # --- (e) slope forecast over a recent window --------------------------------
 
 t_slope_forecast_within_horizon_triggers() {
@@ -428,6 +441,7 @@ t_two_samples_do_not_trigger_threshold_condition
 t_three_consecutive_over_threshold_triggers
 t_only_two_of_three_consecutive_does_not_trigger
 t_wired_alone_over_threshold_triggers
+t_duplicate_timestamps_keep_each_wired_sample_distinct
 t_slope_forecast_within_horizon_triggers
 t_slope_forecast_beyond_horizon_does_not_trigger
 t_rise_then_fall_below_ceiling_does_not_trigger

--- a/tests/fm-mini-reboot-sampler.test.sh
+++ b/tests/fm-mini-reboot-sampler.test.sh
@@ -1,0 +1,349 @@
+#!/usr/bin/env bash
+# Behavior tests for bin/fm-mini-reboot-lib.sh's sampler and resource-trigger
+# evaluation (report section 6, Phase A: detection only).
+#
+# Pins:
+#   (a) metric collection parses fake vm_stat/zprint/sysctl output correctly
+#   (b) deltas are computed and PERSISTED alongside raw values on each append
+#   (c) evaluate() never triggers with fewer than the minimum sample count -
+#       the direct regression for "must not reboot from a single threshold
+#       crossing"
+#   (d) trigger condition 1: maintenance threshold crossed in N CONSECUTIVE
+#       samples (not just any N out of a longer history)
+#   (e) trigger condition 2: slope forecast over a recent window predicts the
+#       hard ceiling within the forecast horizon; a shallower slope that would
+#       cross beyond the horizon does not trigger
+#   (f) trigger condition 3: pressure no longer normal AND swapouts trending
+#       up over the recent window; pressure alone, or swapouts alone, does not
+#       trigger
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+LIB="$ROOT/bin/fm-mini-reboot-lib.sh"
+TMP_ROOT=$(fm_test_tmproot fm-mini-reboot-sampler)
+
+# fake_bin <dir>: a fakebin with deterministic vm_stat/zprint/sysctl, driven by
+# env vars read at call time so each test can vary them per sample.
+fake_bin() {
+  local fb
+  fb=$(fm_fakebin "$1")
+
+  cat > "$fb/vm_stat" <<'SH'
+#!/usr/bin/env bash
+echo "Mach Virtual Memory Statistics: (page size of ${FM_FAKE_PAGESIZE:-16384} bytes)"
+echo "Pages free:                    ${FM_FAKE_FREE_PAGES:-0}."
+echo "Pages wired down:              ${FM_FAKE_WIRED_PAGES:-0}."
+echo "Pages purgeable:               ${FM_FAKE_PURGEABLE_PAGES:-0}."
+echo "Pages occupied by compressor:  ${FM_FAKE_COMPRESSOR_PAGES:-0}."
+echo "Swapins:                       ${FM_FAKE_SWAPINS:-0}."
+echo "Swapouts:                      ${FM_FAKE_SWAPOUTS:-0}."
+SH
+  chmod +x "$fb/vm_stat"
+
+  cat > "$fb/zprint" <<'SH'
+#!/usr/bin/env bash
+echo "                            elem         cur         max        cur         max         cur  alloc  alloc"
+echo "zone name                   size        size        size      #elts       #elts       inuse   size  count"
+echo "-----------------------------------------------------------------------------------------------------------"
+echo "data.kalloc.1024             1          0K          0K           0           0     ${FM_FAKE_ZONE_BYTES:-0}     0K      0"
+SH
+  chmod +x "$fb/zprint"
+
+  cat > "$fb/sysctl" <<'SH'
+#!/usr/bin/env bash
+if [ "$1" = "-n" ]; then
+  case "$2" in
+    hw.pagesize) echo "${FM_FAKE_PAGESIZE:-16384}" ;;
+    kern.memorystatus_vm_pressure_level) echo "${FM_FAKE_PRESSURE:-1}" ;;
+    kern.bootsessionuuid) echo "${FM_FAKE_BOOT_ID:-BOOT-A}" ;;
+    *) echo "0" ;;
+  esac
+  exit 0
+fi
+if [ "$1" = "vm.swapusage" ]; then
+  echo "vm.swapusage: total = 2048.00M  used = ${FM_FAKE_SWAP_USED_M:-0}.00M  free = 1000.00M  (encrypted)"
+  exit 0
+fi
+echo "0"
+SH
+  chmod +x "$fb/sysctl"
+
+  printf '%s\n' "$fb"
+}
+
+# --- (a) metric collection parses fake output correctly ---------------------
+
+t_collect_sample_parses_metrics() {
+  local dir fb out
+  dir="$TMP_ROOT/collect"; mkdir -p "$dir"
+  fb=$(fake_bin "$dir")
+  export FM_HOME="$dir/home" FM_MRB_NOW=1000000000
+  export FM_FAKE_PAGESIZE=16384 FM_FAKE_WIRED_PAGES=100 FM_FAKE_FREE_PAGES=50 \
+         FM_FAKE_ZONE_BYTES=123456789 FM_FAKE_SWAP_USED_M=10 \
+         FM_FAKE_PRESSURE=1 FM_FAKE_SWAPINS=5 FM_FAKE_SWAPOUTS=7
+  out=$(PATH="$fb:$PATH" bash -c ". '$LIB'; fm_mrb_collect_sample")
+  local epoch zone wired free swap si so pr
+  epoch=$(cut -f1 <<< "$out"); zone=$(cut -f2 <<< "$out"); wired=$(cut -f3 <<< "$out")
+  free=$(cut -f4 <<< "$out"); swap=$(cut -f7 <<< "$out"); si=$(cut -f8 <<< "$out")
+  so=$(cut -f9 <<< "$out"); pr=$(cut -f10 <<< "$out")
+  [ "$epoch" = 1000000000 ] || fail "epoch: got $epoch"
+  [ "$zone" = 123456789 ] || fail "zone bytes: got $zone"
+  [ "$wired" = $((100 * 16384)) ] || fail "wired bytes: got $wired"
+  [ "$free" = $((50 * 16384)) ] || fail "free bytes: got $free"
+  [ "$swap" = $((10 * 1024 * 1024)) ] || fail "swap bytes: got $swap"
+  [ "$si" = 5 ] || fail "swapins: got $si"
+  [ "$so" = 7 ] || fail "swapouts: got $so"
+  [ "$pr" = normal ] || fail "pressure: got $pr"
+  pass "collect_sample parses fake vm_stat/zprint/sysctl into correct byte values"
+}
+
+# --- (b) deltas computed and persisted -------------------------------------
+
+t_append_sample_persists_deltas() {
+  local dir fb
+  dir="$TMP_ROOT/deltas"; mkdir -p "$dir"
+  fb=$(fake_bin "$dir")
+  export FM_HOME="$dir/home"
+  export FM_FAKE_PAGESIZE=1 FM_FAKE_SWAP_USED_M=0 FM_FAKE_PRESSURE=1
+
+  FM_MRB_NOW=1000 FM_FAKE_ZONE_BYTES=100 FM_FAKE_WIRED_PAGES=200 FM_FAKE_SWAPOUTS=1 \
+    PATH="$fb:$PATH" bash -c ". '$LIB'; fm_mrb_append_sample"
+  FM_MRB_NOW=1300 FM_FAKE_ZONE_BYTES=150 FM_FAKE_WIRED_PAGES=250 FM_FAKE_SWAPOUTS=4 \
+    PATH="$fb:$PATH" bash -c ". '$LIB'; fm_mrb_append_sample"
+
+  local samples second zone_delta wired_delta swapouts_delta
+  samples="$dir/home/state/mini-reboot/samples.tsv"
+  assert_present "$samples" "samples file created"
+  second=$(tail -n 1 "$samples")
+  zone_delta=$(cut -f11 <<< "$second")
+  wired_delta=$(cut -f12 <<< "$second")
+  swapouts_delta=$(cut -f13 <<< "$second")
+  [ "$zone_delta" = 50 ] || fail "zone_delta: got $zone_delta, want 50"
+  [ "$wired_delta" = 50 ] || fail "wired_delta: got $wired_delta, want 50"
+  [ "$swapouts_delta" = 3 ] || fail "swapouts_delta: got $swapouts_delta, want 3"
+  pass "append_sample computes and persists deltas against the prior row"
+}
+
+t_first_sample_has_zero_deltas() {
+  local dir fb row
+  dir="$TMP_ROOT/first-delta"; mkdir -p "$dir"
+  fb=$(fake_bin "$dir")
+  export FM_HOME="$dir/home"
+  FM_MRB_NOW=1000 FM_FAKE_ZONE_BYTES=999 FM_FAKE_PAGESIZE=1 FM_FAKE_SWAP_USED_M=0 \
+    PATH="$fb:$PATH" bash -c ". '$LIB'; fm_mrb_append_sample"
+  row=$(cat "$dir/home/state/mini-reboot/samples.tsv")
+  [ "$(cut -f11 <<< "$row")" = 0 ] || fail "first-sample zone_delta should be 0"
+  [ "$(cut -f12 <<< "$row")" = 0 ] || fail "first-sample wired_delta should be 0"
+  [ "$(cut -f13 <<< "$row")" = 0 ] || fail "first-sample swapouts_delta should be 0"
+  pass "the very first sample records zero deltas rather than erroring"
+}
+
+# --- helper: append N samples with per-sample overrides ---------------------
+
+# append_series <dir> <fakebin> <home> "<epoch> <zone> <wired_pages> <pressure> <swapouts>" ...
+append_series() {
+  local fb=$1 home=$2
+  shift 2
+  local spec epoch zone wired pressure swapouts
+  for spec in "$@"; do
+    read -r epoch zone wired pressure swapouts <<< "$spec"
+    FM_HOME="$home" FM_MRB_NOW="$epoch" FM_FAKE_ZONE_BYTES="$zone" \
+      FM_FAKE_WIRED_PAGES="$wired" FM_FAKE_PAGESIZE=1 FM_FAKE_SWAP_USED_M=0 \
+      FM_FAKE_PRESSURE="$pressure" FM_FAKE_SWAPOUTS="$swapouts" \
+      PATH="$fb:$PATH" bash -c ". '$LIB'; fm_mrb_append_sample"
+  done
+}
+
+evaluate_with() {
+  local home=$1 now=$2
+  FM_HOME="$home" FM_MRB_NOW="$now" bash -c ". '$LIB'; fm_mrb_evaluate"
+}
+
+# --- (c) never triggers below the minimum sample count ----------------------
+
+t_never_triggers_from_single_sample() {
+  local dir fb home out
+  dir="$TMP_ROOT/single"; mkdir -p "$dir"
+  fb=$(fake_bin "$dir"); home="$dir/home"
+  # One sample already WAY past both maintenance thresholds - must still not
+  # trigger, because fewer than the minimum consecutive samples exist.
+  append_series "$fb" "$home" "1000 99999999999 99999999999 1 0"
+  out=$(evaluate_with "$home" 1000)
+  assert_contains "$out" "trigger=no" "single extreme sample must not trigger"
+  assert_contains "$out" "insufficient-samples" "reason names insufficient samples"
+  pass "a single sample, however extreme, never triggers a reboot condition"
+}
+
+t_two_samples_do_not_trigger_threshold_condition() {
+  local dir fb home out
+  dir="$TMP_ROOT/two"; mkdir -p "$dir"
+  fb=$(fake_bin "$dir"); home="$dir/home"
+  append_series "$fb" "$home" \
+    "1000 99999999999 99999999999 1 0" \
+    "1100 99999999999 99999999999 1 0"
+  out=$(evaluate_with "$home" 1100)
+  assert_contains "$out" "trigger=no" "two samples must not trigger the 3-sample condition"
+  pass "two consecutive over-threshold samples do not trigger (need 3)"
+}
+
+# --- (d) maintenance threshold crossed in 3 CONSECUTIVE samples -------------
+
+MAINT_ZONE=$((9 * 1024 * 1024 * 1024))
+MAINT_WIRED=$((13 * 1024 * 1024 * 1024))
+HARD_ZONE=$((12 * 1024 * 1024 * 1024))
+
+t_three_consecutive_over_threshold_triggers() {
+  local dir fb home out
+  dir="$TMP_ROOT/three-consec"; mkdir -p "$dir"
+  fb=$(fake_bin "$dir"); home="$dir/home"
+  append_series "$fb" "$home" \
+    "1000 $((MAINT_ZONE + 1)) 0 1 0" \
+    "1100 $((MAINT_ZONE + 1)) 0 1 0" \
+    "1200 $((MAINT_ZONE + 1)) 0 1 0"
+  out=$(evaluate_with "$home" 1200)
+  assert_contains "$out" "trigger=yes" "three consecutive over-threshold samples trigger"
+  assert_contains "$out" "maintenance-threshold-crossed" "names the maintenance-threshold reason"
+  pass "maintenance threshold crossed in 3 consecutive samples triggers"
+}
+
+t_only_two_of_three_consecutive_does_not_trigger() {
+  local dir fb home out
+  dir="$TMP_ROOT/two-of-three"; mkdir -p "$dir"
+  fb=$(fake_bin "$dir"); home="$dir/home"
+  # Uses wired memory (not zone) so the slope-forecast condition, which only
+  # tracks zone bytes, cannot also fire and confound this isolated check of
+  # the 3-consecutive-samples condition.
+  append_series "$fb" "$home" \
+    "1000 0 0 1 0" \
+    "1100 0 $((MAINT_WIRED + 1)) 1 0" \
+    "1200 0 $((MAINT_WIRED + 1)) 1 0"
+  out=$(evaluate_with "$home" 1200)
+  assert_contains "$out" "trigger=no" "only 2 of the last 3 over threshold must not trigger"
+  pass "an earlier under-threshold sample in the last-3 window blocks the trigger"
+}
+
+t_wired_alone_over_threshold_triggers() {
+  local dir fb home out
+  dir="$TMP_ROOT/wired"; mkdir -p "$dir"
+  fb=$(fake_bin "$dir"); home="$dir/home"
+  append_series "$fb" "$home" \
+    "1000 0 $((MAINT_WIRED + 1)) 1 0" \
+    "1100 0 $((MAINT_WIRED + 1)) 1 0" \
+    "1200 0 $((MAINT_WIRED + 1)) 1 0"
+  out=$(evaluate_with "$home" 1200)
+  assert_contains "$out" "trigger=yes" "wired-alone over threshold for 3 samples triggers"
+  pass "wired memory alone crossing its threshold for 3 samples triggers (OR, not AND)"
+}
+
+# --- (e) slope forecast over a recent window --------------------------------
+
+t_slope_forecast_within_horizon_triggers() {
+  local dir fb home out
+  dir="$TMP_ROOT/slope-near"; mkdir -p "$dir"
+  fb=$(fake_bin "$dir"); home="$dir/home"
+  # Recent window (last 6h = 21600s): rises from 1 GiB below hard ceiling's
+  # remaining budget fast enough to cross well within the 24h horizon.
+  # dt=3600s, dz = 2 GiB -> slope = 2GiB/hour; remaining to hard ceiling from
+  # the latest sample is well under 2 GiB, so forecast_secs << 24h. A third,
+  # older, well-under-threshold sample outside the recent window pads the
+  # total to the minimum trigger-sample count without disturbing the recent
+  # window's oldest/latest pick or accidentally also satisfying the
+  # 3-consecutive maintenance-threshold condition.
+  append_series "$fb" "$home" \
+    "-30000 0 0 1 0" \
+    "0 $((HARD_ZONE - 3 * 1024 * 1024 * 1024)) 0 1 0" \
+    "3600 $((HARD_ZONE - 1024 * 1024 * 1024)) 0 1 0"
+  out=$(evaluate_with "$home" 3600)
+  assert_contains "$out" "trigger=yes" "steep recent slope forecasts crossing within horizon"
+  assert_contains "$out" "slope-forecast" "names the slope-forecast reason"
+  pass "a steep recent slope predicting the hard ceiling within the horizon triggers"
+}
+
+t_slope_forecast_beyond_horizon_does_not_trigger() {
+  local dir fb home out
+  dir="$TMP_ROOT/slope-far"; mkdir -p "$dir"
+  fb=$(fake_bin "$dir"); home="$dir/home"
+  # Tiny rise over a long recent-window span -> forecast far beyond horizon.
+  append_series "$fb" "$home" \
+    "-30000 0 0 1 0" \
+    "0 $((1024 * 1024 * 1024)) 0 1 0" \
+    "3600 $((1024 * 1024 * 1024 + 1024)) 0 1 0"
+  out=$(evaluate_with "$home" 3600)
+  assert_contains "$out" "trigger=no" "a shallow slope forecasting far beyond the horizon must not trigger"
+  pass "a shallow recent slope that would only cross far beyond the horizon does not trigger"
+}
+
+t_lifetime_first_sample_does_not_pollute_recent_slope() {
+  local dir fb home out
+  dir="$TMP_ROOT/slope-window"; mkdir -p "$dir"
+  fb=$(fake_bin "$dir"); home="$dir/home"
+  # A large jump long ago (outside the 6h recent window), then flat recently:
+  # using the lifetime first-vs-last sample would show a big slope; using
+  # only the recent window must not.
+  append_series "$fb" "$home" \
+    "0 0 0 1 0" \
+    "100000 $((5 * 1024 * 1024 * 1024)) 0 1 0" \
+    "$((100000 + 3600)) $((5 * 1024 * 1024 * 1024 + 1024)) 0 1 0"
+  out=$(evaluate_with "$home" $((100000 + 3600)))
+  assert_contains "$out" "trigger=no" "an old jump outside the recent window must not drive the slope forecast"
+  pass "slope forecast uses the recent window only, not the lifetime first-vs-last sample"
+}
+
+# --- (f) pressure + rising swapouts -----------------------------------------
+
+t_pressure_and_rising_swapouts_triggers() {
+  local dir fb home out
+  dir="$TMP_ROOT/pressure-swap"; mkdir -p "$dir"
+  fb=$(fake_bin "$dir"); home="$dir/home"
+  append_series "$fb" "$home" \
+    "1000 0 0 1 10" \
+    "1100 0 0 2 15" \
+    "1200 0 0 2 20"
+  out=$(evaluate_with "$home" 1200)
+  assert_contains "$out" "trigger=yes" "warn pressure with rising swapouts triggers"
+  assert_contains "$out" "pressure-warn-with-rising-swapouts" "names the pressure/swapout reason"
+  pass "pressure no longer normal with rising swapouts triggers"
+}
+
+t_pressure_alone_without_rising_swapouts_does_not_trigger() {
+  local dir fb home out
+  dir="$TMP_ROOT/pressure-only"; mkdir -p "$dir"
+  fb=$(fake_bin "$dir"); home="$dir/home"
+  append_series "$fb" "$home" \
+    "1000 0 0 2 20" \
+    "1100 0 0 2 20" \
+    "1200 0 0 2 20"
+  out=$(evaluate_with "$home" 1200)
+  assert_contains "$out" "trigger=no" "pressure alone without rising swapouts must not trigger"
+  pass "elevated pressure with flat swapouts does not trigger"
+}
+
+t_rising_swapouts_alone_without_pressure_does_not_trigger() {
+  local dir fb home out
+  dir="$TMP_ROOT/swap-only"; mkdir -p "$dir"
+  fb=$(fake_bin "$dir"); home="$dir/home"
+  append_series "$fb" "$home" \
+    "1000 0 0 1 10" \
+    "1100 0 0 1 15" \
+    "1200 0 0 1 20"
+  out=$(evaluate_with "$home" 1200)
+  assert_contains "$out" "trigger=no" "rising swapouts under normal pressure must not trigger"
+  pass "rising swapouts alone under normal pressure does not trigger"
+}
+
+t_collect_sample_parses_metrics
+t_append_sample_persists_deltas
+t_first_sample_has_zero_deltas
+t_never_triggers_from_single_sample
+t_two_samples_do_not_trigger_threshold_condition
+t_three_consecutive_over_threshold_triggers
+t_only_two_of_three_consecutive_does_not_trigger
+t_wired_alone_over_threshold_triggers
+t_slope_forecast_within_horizon_triggers
+t_slope_forecast_beyond_horizon_does_not_trigger
+t_lifetime_first_sample_does_not_pollute_recent_slope
+t_pressure_and_rising_swapouts_triggers
+t_pressure_alone_without_rising_swapouts_does_not_trigger
+t_rising_swapouts_alone_without_pressure_does_not_trigger

--- a/tests/fm-mini-reboot-sampler.test.sh
+++ b/tests/fm-mini-reboot-sampler.test.sh
@@ -44,10 +44,15 @@ SH
 
   cat > "$fb/zprint" <<'SH'
 #!/usr/bin/env bash
+[ "${FM_FAKE_ZPRINT_FAIL:-0}" = 1 ] && exit 1
 echo "                            elem         cur         max        cur         max         cur  alloc  alloc"
 echo "zone name                   size        size        size      #elts       #elts       inuse   size  count"
 echo "-----------------------------------------------------------------------------------------------------------"
-echo "data.kalloc.1024             1          0K          0K           0           0     ${FM_FAKE_ZONE_BYTES:-0}     0K      0"
+if [ "${FM_FAKE_ZPRINT_MALFORMED:-0}" = 1 ]; then
+  echo "data.kalloc.1024             bad        0K          0K           0           0     bad     0K      0"
+else
+  echo "data.kalloc.1024             1          0K          0K           0           0     ${FM_FAKE_ZONE_BYTES:-0}     0K      0"
+fi
 SH
   chmod +x "$fb/zprint"
 
@@ -138,6 +143,22 @@ t_first_sample_has_zero_deltas() {
   [ "$(cut -f12 <<< "$row")" = 0 ] || fail "first-sample wired_delta should be 0"
   [ "$(cut -f13 <<< "$row")" = 0 ] || fail "first-sample swapouts_delta should be 0"
   pass "the very first sample records zero deltas rather than erroring"
+}
+
+t_invalid_zprint_does_not_append_a_sample() {
+  local dir fb home samples before status
+  dir="$TMP_ROOT/invalid-zprint"; mkdir -p "$dir"
+  fb=$(fake_bin "$dir"); home="$dir/home"
+  FM_HOME="$home" FM_MRB_NOW=1000 FM_FAKE_ZONE_BYTES=100 FM_FAKE_PAGESIZE=1 \
+    PATH="$fb:$PATH" bash -c ". '$LIB'; fm_mrb_append_sample"
+  samples="$home/state/mini-reboot/samples.tsv"
+  before=$(cat "$samples")
+  FM_HOME="$home" FM_MRB_NOW=1100 FM_FAKE_ZPRINT_MALFORMED=1 FM_FAKE_PAGESIZE=1 \
+    PATH="$fb:$PATH" bash -c ". '$LIB'; fm_mrb_append_sample" >/dev/null 2>&1
+  status=$?
+  [ "$status" -ne 0 ] || fail "malformed zprint must make sample collection fail"
+  [ "$(cat "$samples")" = "$before" ] || fail "failed metric collection must leave sample history unchanged"
+  pass "malformed zprint output is rejected without appending a sample"
 }
 
 # --- helper: append N samples with per-sample overrides ---------------------
@@ -349,6 +370,7 @@ t_unknown_pressure_with_rising_swapouts_does_not_trigger() {
 t_collect_sample_parses_metrics
 t_append_sample_persists_deltas
 t_first_sample_has_zero_deltas
+t_invalid_zprint_does_not_append_a_sample
 t_never_triggers_from_single_sample
 t_two_samples_do_not_trigger_threshold_condition
 t_three_consecutive_over_threshold_triggers


### PR DESCRIPTION
## Intent

Build a mini self-reboot capability for the firstmate fleet's Mac mini host. The original design (fleet-memory-health-sustainable-s1 scout report section 6) proposed a generation-scoped host-maintenance drain barrier plus a leak-slope sampler that would refuse new spawn/promotion/handoff work on the mini while draining it, then escalate to the captain for explicit per-reboot approval, never auto-firing a reboot. During implementation, no-mistakes review found the drain/admission-lock primitive was genuinely hard to build correctly: across four consecutive review rounds it kept surfacing new TOCTOU races, forgeable env-var bypasses, and fail-open gaps in the shared lock/lease boundary and the readiness/idleness checks (each round's fix for one race produced a new one in the same area). The captain then explicitly rejected that entire drain/admission-lock/prevent-new-work approach as the wrong product (captain 2026-08-24) and retargeted to a deliberately much simpler design: reboot the mini automatically, with NO captain approval step per reboot, but ONLY when BOTH of two conditions genuinely hold at once - (1) a real memory/kernel-zone leak threshold has been crossed, confirmed over multiple samples (a single sample, however extreme, must never trigger it; the trigger requires three consecutive over-threshold samples, or a slope forecast over a recent window predicting the hard ceiling before the forecast horizon, or pressure no longer normal with swapouts trending up), and (2) the local fleet on that mini is robustly idle, confirmed by two consecutive fully-idle reads at least 5 minutes apart, reusing the existing idleness signals (fm-crew-state.sh's current-state read, tasks-axi backlog state, and the documented state/ layout for steering inboxes, pending replies, promised public followups, and process-event sources) rather than inventing parallel machinery. If either condition does not hold, the guard does nothing; the machine handles load best-effort. This design deliberately has NO drain, NO admission lock, NO blocking or holding of new work, NO fleet-emptying, NO attack-resistant admission boundary, and NO readiness-receipt machinery - it never touches fm-spawn.sh, fm-promote.sh, or fm-backlog-handoff.sh at all. It is mini-only by construction, gated on an explicit config/host-role=mini file; a MacBook or any unconfigured host can never reboot through this code. Reboot execution itself is delegated to a separately-provisioned, root-authorized helper named by config/mini-reboot-helper; this environment has no working passwordless-sudo or other privileged reboot mechanism available (confirmed via sudo -n), so the code deliberately never fakes or stubs privileged execution - it blocks with a clear diagnostic naming the exact missing mechanism when no working helper is configured, and provisioning that helper is an explicit follow-up outside this change's scope. The single-instance check lock and the reboot-in-progress marker are both crash-safe (a dead lock owner is reclaimed; the marker self-clears once the live macOS boot-session id changes, proving the reboot actually happened, or once it goes stale past 20 minutes). Colocated regression tests cover the sampler's three trigger conditions in isolation, every individual idle-blocking condition plus the two-snapshot confirmation gap logic, the mini-only gate, the never-fakes-privileged-execution refusal, the reboot marker's re-fire prevention and self-clearing, the crash-safe lock, and full end-to-end proof that the reboot helper is invoked only when both conditions genuinely hold together and never when only one does. This work was built on a prior branch (fm/fm-safe-auto-reboot-host-drain-barrier-r1) whose no-mistakes run bookkeeping got stuck referencing an old cancelled run's unreachable head; it was cherry-picked cleanly onto this fresh branch (fm/fm-safe-auto-reboot-simple-r1) from current main to get a clean run, with the diff verified to contain only the new design and no leftover drain/lock/barrier code.

## What Changed

- Add a resource sampler and guard that invokes a configured reboot helper only after sustained leak, forecast, or pressure signals coincide with two confirmed idle snapshots.
- Restrict execution to explicitly configured mini hosts, with fail-closed fleet checks, crash-safe overlap handling, and reboot-attempt markers that reset after reboot or expiry.
- Document configuration and operations, and add regression coverage for sampling, idleness, safety gates, and end-to-end reboot decisions.

## Risk Assessment

✅ Low: The reboot capability is sensitive but remains explicitly armed, fail-closed, and gated by independently confirmed resource and idle conditions.

## Testing

Inspected the targeted diff, ran the three focused sampler, idle, and guard behavior suites, and exercised the actual CLI end-to-end with reviewer-visible transcript evidence; the helper ran only after three high-resource samples and two idle reads 400 seconds apart, remained uninvoked with resource pressure alone, and the forbidden spawn/promotion/handoff paths were unchanged.

<details>
<summary>Evidence: Mini reboot guard CLI end-to-end transcript showing the AND gate and helper side effects</summary>

Source: [Mini reboot guard CLI end-to-end transcript showing the AND gate and helper side effects](https://github.com/kunchenguid/firstmate/blob/e4f2adf94c66b7a3af9e4c54a8338e3a0d9a4208/.no-mistakes/evidence/fm/fm-safe-auto-reboot-simple-r1/mini-reboot-cli-e2e.txt)

```text
=== Actual CLI: BOTH resource threshold and two confirmed idle reads ===
--- check at t=100 ---
fm-mini-reboot: resource condition not triggered, doing nothing
--- check at t=200 ---
fm-mini-reboot: resource condition not triggered, doing nothing
--- check at t=300 ---
fm-mini-reboot: resource condition triggered:
fm-mini-reboot:   reason=maintenance-threshold-crossed-in-3-samples
fm-mini-reboot: resource triggered but idle window not confirmed, staying put:
fm-mini-reboot:   confirmed=no
fm-mini-reboot:   reason=not-both-idle(now=idle prev=none)
fm-mini-reboot:   verdict=idle
--- check at t=700 ---
fm-mini-reboot: resource condition triggered:
fm-mini-reboot:   reason=maintenance-threshold-crossed-in-3-samples
fm-mini-reboot: both conditions hold: resource triggered AND idle window confirmed - executing reboot
fm-mini-reboot: invoking reboot helper: /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T//fm-mrb-evidence.Gy5nNc/both/helper (reason: reason=maintenance-threshold-crossed-in-3-samples;)
fm-mini-reboot: reboot helper exited 0
--- observable helper side effect ---
HELPER_INVOKED reason=reason=maintenance-threshold-crossed-in-3-samples;

=== Actual CLI: resource threshold only; idle registry absent ===
--- check at t=100 ---
fm-mini-reboot: resource condition not triggered, doing nothing
--- check at t=200 ---
fm-mini-reboot: resource condition not triggered, doing nothing
--- check at t=300 ---
fm-mini-reboot: resource condition triggered:
fm-mini-reboot:   reason=maintenance-threshold-crossed-in-3-samples
fm-mini-reboot: resource triggered but idle window not confirmed, staying put:
fm-mini-reboot:   confirmed=no
fm-mini-reboot:   reason=not-both-idle(now=busy: no homes registered for idle-check (config/mini-reboot-homes) prev=none)
fm-mini-reboot:   verdict=busy: no homes registered for idle-check (config/mini-reboot-homes)
--- check at t=700 ---
fm-mini-reboot: resource condition triggered:
fm-mini-reboot:   reason=maintenance-threshold-crossed-in-3-samples
fm-mini-reboot: resource triggered but idle window not confirmed, staying put:
fm-mini-reboot:   confirmed=no
fm-mini-reboot:   reason=not-both-idle(now=busy: no homes registered for idle-check (config/mini-reboot-homes) prev=busy: no homes registered for idle-check (config/mini-reboot-homes))
fm-mini-reboot:   verdict=busy: no homes registered for idle-check (config/mini-reboot-homes)
--- observable helper side effect ---
HELPER_NOT_INVOKED
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"43e4001854423b727b971e3c7e098d82ba7f88d4","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 7 issues found → auto-fixed (10) ✅</summary>

- 🚨 `bin/fm-mini-reboot-lib.sh:329` - `latest_pressure != normal` treats `unknown` as confirmed memory pressure. Three samples with an unreadable pressure sysctl and rising swapouts therefore authorize a reboot without evidence that pressure is non-normal. Restrict this trigger to explicit `warn`/`critical` values and fail closed on `unknown`.
- 🚨 `bin/fm-mini-reboot-lib.sh:363` - The idle check skips all state-based blockers when `&lt;home&gt;/state` is absent, so a registered home with only an empty backlog can report idle. Enumeration errors are also hidden by `find | wc/head`, producing zero/empty results. Require a readable state directory and preserve each enumeration command&#39;s failure status before declaring the home idle.
- 🚨 `bin/fm-mini-reboot-lib.sh:448` - `tasks-axi public-followup ready` does not represent every reply still owed: a freshly bound commitment can remain in `pending-work`, as documented and exercised by the existing public-followup lifecycle. With no in-flight/held backlog item, such a promise can be missed and the home declared idle. Query the owned public-followup list/state interface and block on every unresolved owed state. The new test also permits fixture registration failure to skip this required case.
- 🚨 `bin/fm-mini-reboot-lib.sh:657` - The lock is not crash-safe as claimed: `mkdir` publishes the lock before lines 673-675 write its owner. If the process dies in that interval, later checks see an ownerless lock, never reclaim it, and skip forever. Publish an initialized owner atomically at the shared lock boundary, or safely reclaim abandoned ownerless claims; also bind ownership beyond a reusable PID.
- 🚨 `bin/fm-mini-reboot-lib.sh:362` - Intent requires idleness to reuse “fm-crew-state.sh&#39;s current-state read,” but the changed implementation never invokes that owner and instead treats metadata presence alone as busy; docs nevertheless claim the current-state reader is reused. Confirm the intended metadata/current-state semantics and implement the required read or revise the authoritative requirement.
- 🚨 `bin/fm-mini-reboot-lib.sh:561` - The mini-only criterion says `config/host-role` must contain exactly `mini`, but deleting all whitespace accepts malformed values such as `m i n i`. Since this is the reboot authorization gate, ask whether only an exact line with optional surrounding whitespace is intended, then enforce that representation.
- 🚨 `tests/fm-mini-reboot-guard.test.sh:85` - The newly added drain/admission and spawn/promote/handoff tests only grep implementation source for strings. This violates the test-quality rule and cannot prove behavior because matching text may be dead or behavior may exist under different names. Remove these assertions or replace them with executable-interface behavioral checks.

🔧 Fix: Harden reboot pressure, idleness, and locking checks
5 errors still open:

- 🚨 `bin/fm-mini-reboot-lib.sh:369` - Intent requires idleness to reuse “fm-crew-state.sh&#39;s current-state read,” but the implementation only counts `state/*.meta` files and never invokes that current-state owner; documentation nevertheless claims it is reused. Confirm the intended current-state semantics and either implement the required read or revise the authoritative requirement.
- 🚨 `bin/fm-mini-reboot-lib.sh:573` - The mini-only criterion says `config/host-role` must contain exactly `mini`, but deleting all whitespace also accepts malformed values such as `m i n i`. Confirm whether only an exact line with optional surrounding whitespace is intended, then enforce that representation.
- 🚨 `bin/fm-mini-reboot-lib.sh:107` - Metric collection converts an unreadable or malformed `zprint` result to zone_bytes=0. With one older padding sample, that failed zero sample followed by one normal 10 GiB reading appears as a steep recent slope and can authorize a reboot without a genuine leak trend. Reject invalid metric samples at the collection boundary, and make `fm_mrb_check_cycle` stop when appending the current sample fails rather than evaluating stale history.
- 🚨 `bin/fm-mini-reboot-lib.sh:609` - The reboot marker records an empty boot-session ID when `kern.bootsessionuuid` is temporarily unreadable. On the next successful read, empty→current is misclassified as proof of a reboot, so the marker clears and permits another helper invocation in the same boot session. Require a valid boot-session ID before publishing the marker or otherwise distinguish an unknown recorded ID from a changed live ID.
- 🚨 `bin/fm-mini-reboot-lib.sh:699` - Stale-lock reclamation is still racy: after a contender reads stale owner A, A can remove its lock and process B can acquire the same path before this unconditional `rm -rf`; the contender then deletes B&#39;s live lock and enters concurrently. Reclaim through an atomic ownership-preserving boundary so the exact stale claim validated is the one removed.

🔧 Fix: Harden sampling, reboot markers, and lock reclamation
4 issues (3 errors, 1 warning) still open:

- 🚨 `bin/fm-mini-reboot-lib.sh:386` - Intent requires idleness to reuse “fm-crew-state.sh&#39;s current-state read,” but this path only counts `state/*.meta` and never invokes that owner; `docs/mini-reboot-guard.md` nevertheless claims it is reused. Confirm the intended current-state semantics and either implement the required read or revise the requirement.
- 🚨 `bin/fm-mini-reboot-lib.sh:590` - Intent requires `config/host-role=mini` exactly, but deleting all whitespace also authorizes malformed content such as `m i n i`. Confirm whether only an exact line with optional surrounding whitespace is intended, then enforce that representation.
- ⚠️ `bin/fm-mini-reboot-lib.sh:650` - Deleting all whitespace from `config/mini-reboot-helper` corrupts valid executable paths containing spaces, causing a correctly provisioned helper to be reported missing. Preserve the configured path while removing only the line terminator, unless whitespace is intentionally forbidden.
- 🚨 `bin/fm-mini-reboot-lib.sh:478` - The public-followup parser treats a successful but malformed response such as `{}` as an empty obligation list because of `(.public_followups // [])`. With all other signals clear, the home incorrectly reports idle instead of failing closed. Require `public_followups` to exist and be an array before counting unresolved entries.

🔧 Fix: Fail closed on malformed public followup responses
7 issues (4 errors, 3 warnings) still open:

- 🚨 `bin/fm-mini-reboot-lib.sh:386` - The required idle check must reuse “fm-crew-state.sh&#39;s current-state read,” but this implementation only counts `state/*.meta` files and never invokes that owner; `docs/mini-reboot-guard.md` nevertheless claims it is reused. Confirm whether terminal metadata may be idle, then implement the required current-state read or revise the authoritative requirement.
- 🚨 `bin/fm-mini-reboot-lib.sh:592` - The mini-only criterion requires `config/host-role=mini` exactly, but deleting all whitespace also authorizes malformed content such as `m i n i`. Confirm whether only an exact line with optional surrounding whitespace is intended, then enforce that representation.
- ⚠️ `bin/fm-mini-reboot-lib.sh:652` - Deleting all whitespace from `config/mini-reboot-helper` corrupts valid executable paths containing spaces, causing a correctly provisioned helper to be reported missing. Preserve the configured path while removing only its line terminator unless whitespace is intentionally forbidden.
- 🚨 `bin/fm-mini-reboot-lib.sh:287` - The consecutive-threshold loop ignores the wired value already read from each row and looks it up again by epoch. With three samples sharing an epoch—first wired above threshold and the next two below—every lookup returns the first row, incorrectly reporting three consecutive crossings. Use the current row&#39;s `_w` field directly.
- 🚨 `bin/fm-mini-reboot-lib.sh:322` - The required triggers are three consecutive threshold crossings, a positive slope forecast, or pressure plus rising swapouts, but this branch adds an unconditional fourth trigger whenever the latest zone value is at the hard ceiling. For example, samples at 0, 13 GiB, then 12 GiB trigger despite only two over-threshold samples and a falling recent slope. Confirm whether this additional trigger is intended or remove it.
- ⚠️ `bin/fm-mini-reboot-lib.sh:456` - The pending-reply owner deliberately retains records after setting `phase=resolved`, but this check treats every retained file as an outstanding reply. After any normal resolved reply, the home can therefore remain permanently busy. Parse the owned record state, block only unresolved phases, and fail closed on malformed records.
- ⚠️ `bin/fm-mini-reboot-lib.sh:498` - The process-event owner defines registration as the presence of `state/procevent/*.source`, while this recursive enumeration treats any artifact as a live source. An interrupted publication can leave `.source.*` behind and permanently suppress reboot despite no registered source. Reuse the owner&#39;s registration predicate while preserving fail-closed read handling.

🔧 Fix: Honor reconciled idleness and exact reboot configuration
1 error still open:

- 🚨 `bin/fm-mini-reboot-lib.sh:312` - The required fix says the reboot “must never fire on a falling/improving memory trend,” but the slope uses only the window’s oldest and latest samples. For samples 0 GiB, 11.5 GiB, then 11 GiB, the latest trend is falling while oldest-to-latest `dz` remains positive and forecasts the ceiling, incorrectly triggering. Enforce the non-falling invariant in `fm_mrb_evaluate` using the latest segment/recent trend, and strengthen the regression with a below-ceiling falling endpoint.

🔧 Fix: Block slope triggers during falling recent trends
1 error still open:

- 🚨 `bin/fm-mini-reboot-lib.sh:336` - The pressure trigger sums persisted swapout deltas, including the first selected row&#39;s delta from outside the selected window. For counters 0, 100, 50, 50 with warning pressure, the last three rows are falling then flat, but their deltas sum to +50 and incorrectly trigger a reboot. Determine the trend from the selected rows&#39; raw swapout values, excluding the pre-window delta.

🔧 Fix: Compute swapout trends within the selected window
1 error still open:

- 🚨 `bin/fm-mini-reboot-lib.sh:755` - The required invariant says the single-instance lock is “crash-safe” and a dead owner is reclaimed, but a crash after line 763 removes `check.lock` and before line 768 removes `check.lock.reap` leaves an orphan reap inode. A later process can acquire and release a new lock normally; when that process subsequently dies, `fm_mrb_reclaim_lock` sees the old reap path, skips creating a hard link to the current lock, fails the `-ef` check, and never reclaims the dead owner. Handle a reap artifact that does not identify the current lock by safely retiring it and claiming the current lock before evaluating ownership.

🔧 Fix: Simplify reboot locking to mkdir and pid ownership
2 errors still open:

- 🚨 `bin/fm-mini-reboot-lib.sh:719` - The required lock is crash-safe, but acquisition creates the lock directory before publishing its owner at line 740. A crash in that interval leaves an ownerless directory; later invocations retry three times and permanently skip because empty owners are never reclaimed. Reconcile ownerless locks after the bounded publication grace or use an acquisition boundary that publishes ownership atomically.
- 🚨 `bin/fm-mini-reboot-lib.sh:726` - Dead-owner reclamation breaks single-instance execution under concurrent reclaimers. Two invocations can both observe the dead PID; after the first removes and reacquires the directory, the second can execute its previously authorized `rm -rf`, delete the first invocation&#39;s live lock, reacquire it, and run concurrently. Reclamation must conditionally retire only the exact stale lock generation observed, which conflicts with the requested plain unguarded removal and requires user review.

🔧 Fix: Reclaim ownerless locks and document concurrency limits
2 issues (1 error, 1 warning) still open:

- 🚨 `bin/fm-mini-reboot-lib.sh:639` - A detected boot-session change clears only the reboot marker, leaving samples and idle snapshots from the previous boot. After a reboot, one new over-threshold sample can combine with two pre-reboot samples, while one new idle read can combine with the prior boot&#39;s idle snapshot, causing another reboot despite the requirement that a single sample never trigger. Track the boot generation for persisted detection state and reset sample and idle-confirmation history whenever it changes, including after manual reboots.
- ⚠️ `docs/mini-reboot-guard.md:40` - The operator documentation says overlapping invocations “never race,” but the implemented lock explicitly permits concurrent execution during dead-owner reclamation as an accepted limitation. Describe the lock as best-effort redundancy prevention and document that reboot safety comes from the resource-plus-idle gate.

🔧 Fix: Reset reboot evidence across boot sessions
2 errors still open:

- 🚨 `bin/fm-mini-reboot-lib.sh:313` - The consecutive-threshold check ignores each row&#39;s parsed wired value and instead looks it up by epoch. Duplicate timestamps therefore reuse the first row&#39;s wired value: rows `(100, wired=high)`, `(100, wired=low)`, `(200, wired=high)` incorrectly satisfy three consecutive over-threshold samples. Use the `_w` field already read from each row so every sample is evaluated independently.
- 🚨 `tests/fm-mini-reboot-guard.test.sh:333` - The required “full end-to-end proof ... never when only one [condition] does” lacks an idle-only case. This test registers no idle home and its zprint fixture contains no recognized zone, so sampling fails and neither condition holds; it does not prove confirmed idleness alone cannot reboot. Provide valid below-threshold samples plus two confirmed-idle reads, then assert the helper remains uninvoked.

🔧 Fix: Evaluate wired thresholds per persisted sample
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --stat 8fa0505e48a155da78a9aeeb50911719dc558710..d7afce6ad8077f731230731171ceff2bca0083ac` and targeted diff inspection</code>
- `bash tests/fm-mini-reboot-sampler.test.sh`
- `bash tests/fm-mini-reboot-idle.test.sh`
- `bash tests/fm-mini-reboot-guard.test.sh`
- <code>Manual end-to-end execution of `bin/fm-mini-reboot-guard.sh check` across four scheduled samples, once with a registered idle fleet and once with no idle registry; verified the configured helper side effect occurred only in the resource-plus-confirmed-idle scenario</code>
- `git diff --name-only 8fa0505e48a155da78a9aeeb50911719dc558710..HEAD -- bin/fm-spawn.sh bin/fm-promote.sh bin/fm-backlog-handoff.sh`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
