### PR TITLE
fix(afk): deliver away-mode escalations past a false busy signal and verify entry delivery

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -225,7 +225,7 @@ the operational prefix lets firstmate distinguish it from a real captain message
 
 ## Stale-artifact lifecycle
 
-Treat `state/.subsuper-escalations`, its `.since` sidecar, and `state/.subsuper-inject-wedged` as session-scoped delivery artifacts, not as the durable work record.
+Treat `state/.subsuper-escalations`, its `.since` sidecar, `state/.subsuper-delivery-selftest`, and `state/.subsuper-inject-wedged` as session-scoped delivery artifacts, not as the durable work record.
 Always enter through `bin/fm-afk-launch.sh`, which clears prior-session artifacts only for a fresh entry and preserves the current session's buffer on refresh.
 Always exit through `bin/fm-afk-launch.sh stop`, which keeps `state/.afk` present through the daemon's shutdown flush and clears it last.
 `docs/herdr-backend.md` "Away-mode supervisor support" owns the current mechanism, and `docs/verification/runtime-backends.md` "Away-mode transport" owns active evidence.

--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -49,10 +49,16 @@ batched digest rather than per-wake injections.
    The daemon is **presence-gated**: it injects escalations only while
    `state/.afk` exists, and stays quiet otherwise.
 
-3. **Do not separately arm `fm-watch.sh`.** The daemon manages the watcher as
+3. **Prove delivery before believing away mode is on.** Run
+   `bin/fm-afk-launch.sh verify` after either start path.
+   The daemon injects one marked no-op into the captain pane at startup and records the verdict durably; `verify` waits for it and exits non-zero when delivery could not be proven.
+   On failure, run `bin/fm-afk-launch.sh stop` to roll entry back and report the blocker instead of acknowledging away mode.
+   Away mode whose delivery path was never exercised is worse than no away mode: it buys silence without buying supervision.
+
+4. **Do not separately arm `fm-watch.sh`.** The daemon manages the watcher as
    its child; the singleton lock no-ops a stray arm harmlessly.
 
-4. **Acknowledge** in `AGENTS.md` section 9 language: "Captain, away mode is active; I will batch routine updates and surface only decisions, failures, credentials, or review-ready work until you return."
+5. **Acknowledge** in `AGENTS.md` section 9 language: "Captain, away mode is active; I will batch routine updates and surface only decisions, failures, credentials, or review-ready work until you return."
 
 ## How to exit afk
 
@@ -92,7 +98,9 @@ The daemon never injects into an in-use pane. Two checks run before every
 injection, dispatched through `bin/fm-backend.sh` for the supervisor's own
 backend (tmux or herdr; see "Auto-discovered supervisor pane" below):
 
-- **Primary-pane busy guard** - `pane_is_busy` trusts Herdr native `busy` when available, otherwise matches rendered output against only the detected primary harness's signature.
+- **Primary-pane busy guard** - `pane_is_busy` reads both available signals, native agent-state and the detected primary harness's rendered signature, and calls the pane busy only when neither legible signal contradicts the other.
+  A legible idle on either signal wins, because one source is otherwise enough to veto delivery forever and both can over-report (upstream #2917).
+  The deferral is logged with the signal that produced it, so a repeat wedge names its cause.
   This narrow delivery guard never classifies a recorded worker task and never uses a global union of vendor patterns.
 - **Composer-state guard** - `inject_msg` reads the full `empty`/`pending`/`pending-unproven`/`unknown` verdict from `fm_backend_composer_state` and injects only when it is affirmatively `empty`.
   Every other or future verdict defers, including an unreadable pane, ambiguous geometry, a blank unidentified row, and a bare shell prompt left after the agent exits.
@@ -105,7 +113,8 @@ In afk mode the composer guard is belt-and-suspenders (no human is typing), but 
 
 **Max-defer escape (the daemon must never silently wedge).**
 If anything stays buffered past `FM_MAX_DEFER_SECS` (default 300), the daemon
-attempts one normal flush, which still requires an idle pane and an affirmatively empty composer.
+attempts one flush in which the busy guard no longer holds a veto, because past max-defer a queued digest is strictly better than continued silence.
+The composer guard still applies, so nothing merges with unsent text.
 The alarm is defense in depth rather than a substitute for keeping every genuinely idle supported composer injectable.
 If that submit cannot be confirmed, it raises a loud, rate-limited wedge alarm:
 an ERROR in the daemon log, a durable
@@ -168,7 +177,7 @@ the operational prefix lets firstmate distinguish it from a real captain message
 - **Single-line digest** - embedded newlines are collapsed to a literal
   separator before injection, so submission is unambiguous regardless of
   harness.
-- **Busy and composer guards on the supervisor pane** - before injecting, the daemon runs the detected-primary-harness rendered busy guard and reads `fm_backend_composer_state` directly.
+- **Busy and composer guards on the supervisor pane** - before injecting, the daemon runs the corroborated busy guard described under "Busy-guard and composer guard" above and reads `fm_backend_composer_state` directly.
   Only `empty` permits injection; `pending` protects half-typed or swallowed input, and `unknown` protects unreadable panes and bare dead-shell prompts.
   Every other result preserves the buffer for retry, so the daemon never merges its digest into the captain's half-typed line or types it into a shell.
 - The active backend passes its capture plus declarative styled, cursor, identity, and row capabilities to the shared screen classifier; all structural recognition and verdict logic remains in `bin/fm-composer-lib.sh`.
@@ -179,7 +188,7 @@ the operational prefix lets firstmate distinguish it from a real captain message
   A blank or otherwise unidentified input row carries no positive container proof and defers injection, so a modal dialog or a mid-redraw pane is never an injection target.
 - **Max-defer escape** - the daemon must never silently wedge. If anything stays
   buffered past `FM_MAX_DEFER_SECS` (default 300s), the daemon attempts one
-  normal flush, which still requires an idle pane and an affirmatively empty composer. If that
+  flush in which the busy guard loses its veto while the composer guard still applies. If that
   cannot confirm a submit, it raises a loud, rate-limited wedge alarm: ERROR log,
   durable `state/.subsuper-inject-wedged` marker, a tmux status-line flash when
   applicable, and a backend-independent active alert. A

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ config/stow-pass-horizon  optional presence flag opting this home in to /stow's 
 config/herdr-presentation-spaces  optional "off" opt-out from, or "on" opt-in to, Herdr's default-on disposable single-task visual projection, which is unconfigured-default-on only at or above a Herdr version floor; LOCAL, gitignored; inherited by secondmate homes; see docs/herdr-backend.md "Presentation spaces"
 config/trace-context  optional presence flag enabling default-off native W3C trace-context propagation to spawned agents; LOCAL, gitignored; inherited by secondmate homes; see docs/configuration.md "Trace context propagation" and docs/trace-context.md
 config/cmux-socket-password  optional cmux control-socket password; LOCAL, gitignored; read fresh on every cmux CLI call and passed through without ever overriding an operator's own ambient CMUX_SOCKET_PASSWORD when absent (docs/cmux-backend.md "Setup")
-config/wedge-alarm  optional away-mode wedge-alarm active-alert directives; LOCAL, gitignored; absent means auto (macOS Notification Center when available); see docs/wedge-alarm.md
+config/wedge-alarm  optional away-mode wedge-alarm active-alert directives; LOCAL, gitignored; absent means auto (macOS Notification Center, else the herdr CLI when installed); see docs/wedge-alarm.md
 config/watched-tools.json  optional list of the tools this home depends on, read by the update check armed with bin/fm-tool-update-check.sh; LOCAL, gitignored, firstmate-maintained but human-editable, and NOT inherited by secondmate homes; see docs/configuration.md "Watched tool updates"
 config/x-mode.env    generated Relay watcher cadence; LOCAL, gitignored; source before arming watcher when present
 data/                personal fleet records; LOCAL, gitignored as a whole

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -164,7 +164,9 @@ fm_afk_launch_verify() {
   local record="$FM_AFK_LAUNCH_STATE/.subsuper-delivery-selftest" \
         timeout=${FM_AFK_VERIFY_TIMEOUT_SECS:-90} waited=0 verdict
   case "$timeout" in ''|*[!0-9]*) timeout=90 ;; esac
-  while [ "$waited" -lt "$timeout" ]; do
+  # Read the record before honoring the timeout so a zero timeout still
+  # accepts an already-present verdict instead of rejecting a verified entry.
+  while :; do
     if [ -s "$record" ]; then
       read -r verdict _ detail < "$record" || verdict=
       case "$verdict" in
@@ -179,6 +181,7 @@ fm_afk_launch_verify() {
           return 1 ;;
       esac
     fi
+    [ "$waited" -lt "$timeout" ] || break
     sleep 1
     waited=$((waited + 1))
   done

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -166,7 +166,7 @@ fm_afk_launch_verify() {
   case "$timeout" in ''|*[!0-9]*) timeout=90 ;; esac
   while [ "$waited" -lt "$timeout" ]; do
     if [ -s "$record" ]; then
-      read -r verdict _ < "$record" || verdict=
+      read -r verdict _ detail < "$record" || verdict=
       case "$verdict" in
         ok)
           fm_afk_launch_log "away-mode delivery verified: one escalation confirmed into the captain pane"
@@ -175,7 +175,7 @@ fm_afk_launch_verify() {
           echo "afk: delivery self-test was skipped (away-mode flag absent when the daemon started); away mode is NOT verified" >&2
           return 1 ;;
         failed)
-          echo "afk: away-mode delivery self-test FAILED - escalations cannot reach the captain pane. Run 'bin/fm-afk-launch.sh stop' to roll entry back, then see state/.supervise-daemon.log." >&2
+          echo "afk: away-mode delivery self-test FAILED - ${detail:-escalations cannot reach the captain pane}. Run 'bin/fm-afk-launch.sh stop' to roll entry back, then see state/.supervise-daemon.log." >&2
           return 1 ;;
       esac
     fi

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -29,6 +29,12 @@
 #   fm-afk-launch.sh start-native
 #                              Prepare lifecycle state for a harness-native
 #                              background job and record that no terminal exists.
+#   fm-afk-launch.sh verify    Wait (FM_AFK_VERIFY_TIMEOUT_SECS, default 90) for
+#                              the daemon's durable delivery self-test verdict and
+#                              exit non-zero when one injection could not be
+#                              proven to reach the captain pane. Run this after
+#                              either start path and BEFORE reporting away mode
+#                              active; on failure run `stop` to roll entry back.
 #   fm-afk-launch.sh stop      Correct-ordered exit: SIGTERM the daemon so its
 #                              cleanup flushes WHILE state/.afk is still present,
 #                              wait for it, close the recorded terminal by exact
@@ -146,7 +152,38 @@ fm_afk_launch_lock_release() {
 }
 
 fm_afk_launch_usage() {
-  sed -n '2,34p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  sed -n '2,43p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+# fm_afk_launch_verify: away-mode entry is only real once ONE escalation has been
+# proven to land in the captain pane. The daemon writes that verdict durably
+# (delivery_selftest in bin/fm-supervise-daemon.sh); this waits for it and fails
+# loudly rather than letting away mode be reported active on an untested delivery
+# path (upstream #2917: five days of away mode, 39 escalations, 0 delivered).
+fm_afk_launch_verify() {
+  local record="$FM_AFK_LAUNCH_STATE/.subsuper-delivery-selftest" \
+        timeout=${FM_AFK_VERIFY_TIMEOUT_SECS:-90} waited=0 verdict
+  case "$timeout" in ''|*[!0-9]*) timeout=90 ;; esac
+  while [ "$waited" -lt "$timeout" ]; do
+    if [ -s "$record" ]; then
+      read -r verdict _ < "$record" || verdict=
+      case "$verdict" in
+        ok)
+          fm_afk_launch_log "away-mode delivery verified: one escalation confirmed into the captain pane"
+          return 0 ;;
+        skipped)
+          echo "afk: delivery self-test was skipped (away-mode flag absent when the daemon started); away mode is NOT verified" >&2
+          return 1 ;;
+        failed)
+          echo "afk: away-mode delivery self-test FAILED - escalations cannot reach the captain pane. Run 'bin/fm-afk-launch.sh stop' to roll entry back, then see state/.supervise-daemon.log." >&2
+          return 1 ;;
+      esac
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+  echo "afk: away-mode delivery self-test did not report within ${timeout}s; away mode is NOT verified. Run 'bin/fm-afk-launch.sh stop' to roll entry back." >&2
+  return 1
 }
 
 # The command run inside the created terminal. Real launch runs the shared
@@ -626,6 +663,13 @@ fm_afk_launch_stop() {
 
 fm_afk_launch_main() {
   local result
+  # `verify` only polls a durable record, so it deliberately skips the launcher
+  # lock: holding it for the whole verify timeout would block the very `stop`
+  # rollback a failed verdict tells the caller to run.
+  if [ "${1:-start}" = verify ]; then
+    fm_afk_launch_verify
+    return
+  fi
   # Traps first, lock second. Acquiring before the handlers exist leaves a
   # window where a signal terminates this process by default action and leaks
   # the lock directory, which then blocks the next away-mode launch until the

--- a/bin/fm-afk-start.sh
+++ b/bin/fm-afk-start.sh
@@ -63,6 +63,7 @@ fm_afk_clear_stale_artifacts() {  # <state-dir>
   local state=$1
   rm -f "$state/.subsuper-escalations" \
         "$state/.subsuper-escalations.since" \
+        "$state/.subsuper-delivery-selftest" \
         "$state/.subsuper-inject-wedged" 2>/dev/null
 }
 

--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -835,7 +835,9 @@ fm_backend_target_exists() {  # <backend> <target> [expected-label]
   local backend=$1 target=$2 expected_label=${3:-} session pane
   case "$backend" in
     tmux)
-      tmux display-message -p -t "$target" '#{pane_id}' >/dev/null 2>&1
+      # Exit status alone is not a liveness read: tmux 3.4 exits 0 with EMPTY
+      # output for a target that resolves to nothing, so require the pane id.
+      [ -n "$(tmux display-message -p -t "$target" '#{pane_id}' 2>/dev/null)" ]
       ;;
     herdr)
       fm_backend_source herdr || return 1

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -108,6 +108,16 @@
 #                                   undelivered before one normal flush attempt;
 #                                   if that cannot confirm a submit, a wedge
 #                                   alarm fires (default 300; 0 disables)
+#          FM_INJECT_IGNORE_BUSY    when 1, the busy guard cannot veto this
+#                                   injection (the max-defer escape and the
+#                                   startup delivery self-test); the composer
+#                                   guard and submit confirmation still apply
+#          FM_DELIVERY_SELFTEST_SECS window the startup delivery self-test keeps
+#                                   retrying before recording failure (default
+#                                   45), and FM_DELIVERY_SELFTEST_SLEEP the gap
+#                                   between attempts (default 3). The verdict
+#                                   lands in state/.subsuper-delivery-selftest,
+#                                   which bin/fm-afk-launch.sh verify reads.
 #          FM_WEDGE_ALARM_CHANNEL   override config/wedge-alarm with a single
 #                                   active-alert directive for that wedge alarm
 #                                   (off|auto|osascript|herdr|command:<cmd>). An
@@ -588,16 +598,56 @@ fm_daemon_primary_harness() {
   printf '%s' "$FM_DAEMON_PRIMARY_HARNESS"
 }
 
-pane_is_busy() {  # <target> [backend]
-  local target=$1 backend=${2:-tmux} native tail40 harness
+# pane_busy_verdict: "<busy|idle> <source>" from BOTH available signals, never
+# from one uncorroborated source that the other legible source contradicts.
+#
+# Incident (2026-08-24, upstream #2917): a claude-on-herdr primary pane sat
+# verifiably idle for 7h16m - zero turns in the session record - while this guard
+# deferred 1836 consecutive times with one reason and delivered nothing. A single
+# source is enough to veto delivery forever, and both sources can over-report:
+# native agent-state is derived per-backend and can stay submit-active after a
+# turn ends, and the rendered signature scans a 12-row tail that can still hold a
+# previous turn's elapsed-duration row. Requiring corroboration removes both
+# false positives without weakening a real mid-turn verdict, which shows busy on
+# both signals. A legible idle on either signal wins because the composer guard
+# below and the submit confirmation in step (4) are the checks that actually
+# protect the pane's contents; this one only picks the moment.
+#
+# tmux is unaffected: it exposes no native agent-state, so its verdict still
+# comes from the rendered signature alone.
+pane_busy_verdict() {  # <target> [backend] -> "<busy|idle> <source>"
+  local target=$1 backend=${2:-tmux} native rendered tail40 harness
   harness=$(fm_daemon_primary_harness)
   native=$(fm_backend_busy_state "$backend" "$target" 2>/dev/null)
-  case "$native" in
-    busy) return 0 ;;
+  case "$native" in busy|idle) ;; *) native=unknown ;; esac
+  if tail40=$(fm_backend_capture "$backend" "$target" 40 2>/dev/null); then
+    if printf '%s' "$tail40" | grep -v '^[[:space:]]*$' | tail -12 \
+         | fm_busy_lines_match "$harness"; then
+      rendered=busy
+    else
+      rendered=idle
+    fi
+  else
+    rendered=unknown
+  fi
+  case "$native/$rendered" in
+    busy/busy)    printf 'busy native+rendered' ;;
+    busy/unknown) printf 'busy native-only (pane unreadable)' ;;
+    unknown/busy) printf 'busy rendered-only (no native agent-state)' ;;
+    busy/idle)    printf 'idle native-busy contradicted by rendered idle' ;;
+    idle/busy)    printf 'idle rendered-busy contradicted by native idle' ;;
+    *)            printf 'idle native=%s rendered=%s' "$native" "$rendered" ;;
   esac
-  tail40=$(fm_backend_capture "$backend" "$target" 40 2>/dev/null) || return 1
-  printf '%s' "$tail40" | grep -v '^[[:space:]]*$' | tail -12 \
-    | fm_busy_lines_match "$harness"
+}
+
+# pane_is_busy stays the single predicate every caller uses; PANE_BUSY_SOURCE
+# carries the signal behind the last verdict so a deferral can name its cause.
+PANE_BUSY_SOURCE=''
+pane_is_busy() {  # <target> [backend]
+  local verdict
+  verdict=$(pane_busy_verdict "$@")
+  PANE_BUSY_SOURCE=${verdict#* }
+  [ "${verdict%% *}" = busy ]
 }
 
 # pane_input_pending dispatches through fm_backend_composer_state and treats
@@ -712,13 +762,16 @@ wedge_alarm_configured_channels() {
 }
 
 # Resolve the platform's default OS-level channel for `auto`. macOS reaches the
-# captain via an osascript Notification Center banner; other platforms have no
-# built-in OS channel (the captain wires a command: directive), so this prints
-# nothing and wedge_alarm_notify logs that the marker is the only signal.
+# captain via an osascript Notification Center banner. Everywhere else the only
+# already-supported channel outside the pane is herdr's own notification surface,
+# so `auto` uses it when the herdr CLI is installed; upstream #2917 spent 86
+# alarms logging that Linux had no channel at all while herdr was right there.
+# With neither binary present this prints nothing and wedge_alarm_notify logs
+# that the durable marker is the only signal.
 wedge_alarm_platform_default() {
   case "$(uname)" in
     Darwin) command -v osascript >/dev/null 2>&1 && printf 'osascript' ;;
-    *) : ;;
+    *) command -v herdr >/dev/null 2>&1 && printf 'herdr' ;;
   esac
 }
 
@@ -939,6 +992,49 @@ inject_wedge_alarm() {  # <state> <age-seconds>
   fi
 }
 
+# --- startup delivery self-test ---------------------------------------------
+# Prove ONE injection round-trips into the supervisor pane before away mode is
+# reported active. Away mode's whole promise is that escalations reach the
+# captain's session; upstream #2917 kept that promise for five days while
+# delivering zero of 39 escalations, because nothing ever exercised the delivery
+# path at entry. The payload is a marked no-op the captain's session recognises
+# as operational input and can discard.
+#
+# The busy guard is bypassed deliberately: the daemon is started from inside the
+# launching turn, so the pane is legitimately mid-turn at this exact moment and
+# the harness queues the text until that turn ends. The composer guard still
+# runs, so nothing merges with unsent text.
+#
+# The result is durable, not a log line: bin/fm-afk-launch.sh's `verify` reads it
+# and fails away-mode entry loudly when delivery could not be proven.
+delivery_selftest() {  # <state>
+  local state=$1 record="$1/.subsuper-delivery-selftest" target backend
+  target="${FM_SUPERVISOR_TARGET:-$FM_SUPERVISOR_TARGET_DEFAULT}"
+  backend="${FM_SUPERVISOR_BACKEND:-tmux}"
+  local deadline attempt=0
+  rm -f "$record" 2>/dev/null || true
+  afk_active "$state" || { printf 'skipped afk-inactive\n' > "$record"; return 0; }
+  # Bounded retry, not one shot: at entry the captain's own composer can still
+  # hold an unsent line, which the composer guard correctly defers on. Retrying
+  # for a short window distinguishes "not this instant" from "cannot deliver".
+  deadline=$(( $(date +%s) + ${FM_DELIVERY_SELFTEST_SECS:-45} ))
+  while :; do
+    attempt=$((attempt + 1))
+    if FM_INJECT_IGNORE_BUSY=1 inject_msg \
+         'away-mode delivery self-test - no action needed, discard this line' "$state"; then
+      printf 'ok %s\n' "$(_now)" > "$record"
+      log "delivery self-test passed: one injection confirmed into $target (attempt $attempt)"
+      return 0
+    fi
+    [ "$(date +%s)" -lt "$deadline" ] || break
+    sleep "${FM_DELIVERY_SELFTEST_SLEEP:-3}"
+  done
+  printf 'failed %s\n' "$(_now)" > "$record"
+  log "ERROR: delivery self-test FAILED: could not confirm an injection into $target (backend=$backend); away mode cannot deliver escalations"
+  wedge_alarm_notify "away-mode entry FAILED its delivery self-test - escalations cannot reach $target" "$record"
+  return 1
+}
+
 _oldest_line_age() {  # <buf> -> seconds since the oldest buffered item first arrived (sidecar epoch)
   local f=$1 since
   [ -s "$f" ] || { echo 999999; return; }
@@ -991,7 +1087,10 @@ housekeeping() {  # <state>
     # and waits.
     if [ "$oldest" -ge "$max_defer" ] \
        && [ "$(_file_age "$state/.subsuper-inject-wedged")" -ge "$max_defer" ]; then
-      if escalate_flush "$state"; then
+      # The escape must not re-run the guard that caused the deferral: past
+      # max-defer the busy verdict loses its veto (upstream #2917 - the escape
+      # re-ran the same false-positive guard 223 times and delivered nothing).
+      if FM_INJECT_IGNORE_BUSY=1 escalate_flush "$state"; then
         log "inject recovered: max-defer flush succeeded after ${oldest}s undelivered"
         rm -f "$state/.subsuper-inject-wedged"
       else
@@ -1148,10 +1247,21 @@ inject_msg() {  # <message> [state]
   # discovery), matching this function's pre-existing default assumption.
   backend="${FM_SUPERVISOR_BACKEND:-tmux}"
   fm_backend_target_exists "$backend" "$target" || return 1
-  # (3) Busy-guard: never inject into an in-use supervisor pane.
+  # (3) Busy-guard: never inject into an in-use supervisor pane. The verdict's
+  # source is logged so a repeat wedge names the signal that vetoed delivery
+  # instead of leaving one indistinguishable reason in the log (upstream #2917).
+  # FM_INJECT_IGNORE_BUSY is the bounded max-defer escape and the startup
+  # delivery self-test: past FM_MAX_DEFER_SECS a busy verdict is no longer
+  # allowed to veto delivery, because an unbounded silent no-op is strictly worse
+  # than a digest queued behind the current turn. The composer guard below still
+  # runs, so the pane's own text is never merged with.
   if pane_is_busy "$target" "$backend"; then
-    log "inject deferred: supervisor pane busy (agent mid-turn)"
-    return 1
+    if [ "${FM_INJECT_IGNORE_BUSY:-0}" = 1 ]; then
+      log "inject proceeding past busy guard (bounded escape): ${PANE_BUSY_SOURCE:-unspecified}"
+    else
+      log "inject deferred: supervisor pane busy (agent mid-turn; source=${PANE_BUSY_SOURCE:-unspecified})"
+      return 1
+    fi
   fi
   #   b) Composer-guard: inject ONLY into a confirmed-empty GENUINE agent
   #      composer. The shared classifier (fm_backend_composer_state ->
@@ -1458,6 +1568,9 @@ fm_super_main() {
   afk_active "$STATE" && afk_status="on"
   log "daemon starting (pid $$); target=$TARGET; target_source=$target_source; backend=$BACKEND; backend_source=$backend_source; afk=$afk_status; inject_skip='${FM_INJECT_SKIP:-$INJECT_SKIP_DEFAULT}'; stale_escalate=${FM_STALE_ESCALATE_SECS:-$STALE_ESCALATE_SECS_DEFAULT}s; batch=${FM_ESCALATE_BATCH_SECS:-$ESCALATE_BATCH_SECS_DEFAULT}s"
   migrate_watcher_pause_markers "$STATE"
+  # A failed self-test records durably and alarms; the daemon stays up so
+  # bin/fm-afk-launch.sh's `verify` can read the verdict and roll entry back.
+  delivery_selftest "$STATE" || true
 
   # --- shutdown: flush buffered escalations, reap child, release lock -------
   local WATCHER_PID="" CUR_TMP=""

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -1015,12 +1015,13 @@ delivery_selftest() {  # <state>
   window=${FM_DELIVERY_SELFTEST_SECS:-45}
   case "$window" in
     ''|*[!0-9]*) window=45 ;;
-    *) [ "$window" -gt 0 ] 2>/dev/null || window=45 ;;
+    # 10# strips leading zeros so "09" is decimal 9, not invalid octal.
+    *) window=$((10#$window)); [ "$window" -gt 0 ] || window=45 ;;
   esac
   sleep_secs=${FM_DELIVERY_SELFTEST_SLEEP:-3}
   case "$sleep_secs" in
     ''|*[!0-9]*) sleep_secs=3 ;;
-    *) [ "$sleep_secs" -gt 0 ] 2>/dev/null || sleep_secs=3 ;;
+    *) sleep_secs=$((10#$sleep_secs)); [ "$sleep_secs" -gt 0 ] || sleep_secs=3 ;;
   esac
   rm -f "$record" 2>/dev/null || true
   afk_active "$state" || { printf 'skipped afk-inactive\n' > "$record"; return 0; }

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -1011,13 +1011,23 @@ delivery_selftest() {  # <state>
   local state=$1 record="$1/.subsuper-delivery-selftest" target backend
   target="${FM_SUPERVISOR_TARGET:-$FM_SUPERVISOR_TARGET_DEFAULT}"
   backend="${FM_SUPERVISOR_BACKEND:-tmux}"
-  local deadline attempt=0
+  local deadline attempt=0 window sleep_secs
+  window=${FM_DELIVERY_SELFTEST_SECS:-45}
+  case "$window" in
+    ''|*[!0-9]*) window=45 ;;
+    *) [ "$window" -gt 0 ] 2>/dev/null || window=45 ;;
+  esac
+  sleep_secs=${FM_DELIVERY_SELFTEST_SLEEP:-3}
+  case "$sleep_secs" in
+    ''|*[!0-9]*) sleep_secs=3 ;;
+    *) [ "$sleep_secs" -gt 0 ] 2>/dev/null || sleep_secs=3 ;;
+  esac
   rm -f "$record" 2>/dev/null || true
   afk_active "$state" || { printf 'skipped afk-inactive\n' > "$record"; return 0; }
   # Bounded retry, not one shot: at entry the captain's own composer can still
   # hold an unsent line, which the composer guard correctly defers on. Retrying
   # for a short window distinguishes "not this instant" from "cannot deliver".
-  deadline=$(( $(date +%s) + ${FM_DELIVERY_SELFTEST_SECS:-45} ))
+  deadline=$(( $(date +%s) + window ))
   while :; do
     attempt=$((attempt + 1))
     if FM_INJECT_IGNORE_BUSY=1 inject_msg \
@@ -1027,7 +1037,7 @@ delivery_selftest() {  # <state>
       return 0
     fi
     [ "$(date +%s)" -lt "$deadline" ] || break
-    sleep "${FM_DELIVERY_SELFTEST_SLEEP:-3}"
+    sleep "$sleep_secs"
   done
   printf 'failed %s could not confirm an injection into %s (backend=%s)\n' \
     "$(_now)" "$target" "$backend" > "$record"

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -1029,7 +1029,8 @@ delivery_selftest() {  # <state>
     [ "$(date +%s)" -lt "$deadline" ] || break
     sleep "${FM_DELIVERY_SELFTEST_SLEEP:-3}"
   done
-  printf 'failed %s\n' "$(_now)" > "$record"
+  printf 'failed %s could not confirm an injection into %s (backend=%s)\n' \
+    "$(_now)" "$target" "$backend" > "$record"
   log "ERROR: delivery self-test FAILED: could not confirm an injection into $target (backend=$backend); away mode cannot deliver escalations"
   wedge_alarm_notify "away-mode entry FAILED its delivery self-test - escalations cannot reach $target" "$record"
   return 1
@@ -1521,6 +1522,8 @@ fm_super_main() {
   if ! fm_backend_list_contains "$FM_SUPERVISOR_SUPPORTED_BACKENDS" "$BACKEND"; then
     echo "error: away-mode daemon does not support supervisor backend '$BACKEND' yet (supported: $FM_SUPERVISOR_SUPPORTED_BACKENDS); set FM_SUPERVISOR_BACKEND=tmux|herdr and FM_SUPERVISOR_TARGET to run firstmate's own pane under a supported backend" >&2
     log "startup failed: unsupported supervisor backend '$BACKEND' (source=$backend_source)"
+    printf 'failed %s unsupported supervisor backend %s\n' "$(_now)" "$BACKEND" \
+      > "$STATE/.subsuper-delivery-selftest" 2>/dev/null || true
     fm_lock_release "$LOCK" 2>/dev/null || true
     rm -f "$PIDFILE" 2>/dev/null || true
     exit 1
@@ -1559,6 +1562,8 @@ fm_super_main() {
   if ! fm_backend_target_exists "$BACKEND" "$TARGET"; then
     echo "error: supervisor target '$TARGET' does not resolve to a $BACKEND pane; set FM_SUPERVISOR_TARGET" >&2
     log "startup failed: target '$TARGET' not found (backend=$BACKEND)"
+    printf 'failed %s supervisor target %s does not resolve to a %s pane\n' \
+      "$(_now)" "$TARGET" "$BACKEND" > "$STATE/.subsuper-delivery-selftest" 2>/dev/null || true
     fm_lock_release "$LOCK" 2>/dev/null || true
     rm -f "$PIDFILE" 2>/dev/null || true
     exit 1
@@ -1568,9 +1573,6 @@ fm_super_main() {
   afk_active "$STATE" && afk_status="on"
   log "daemon starting (pid $$); target=$TARGET; target_source=$target_source; backend=$BACKEND; backend_source=$backend_source; afk=$afk_status; inject_skip='${FM_INJECT_SKIP:-$INJECT_SKIP_DEFAULT}'; stale_escalate=${FM_STALE_ESCALATE_SECS:-$STALE_ESCALATE_SECS_DEFAULT}s; batch=${FM_ESCALATE_BATCH_SECS:-$ESCALATE_BATCH_SECS_DEFAULT}s"
   migrate_watcher_pause_markers "$STATE"
-  # A failed self-test records durably and alarms; the daemon stays up so
-  # bin/fm-afk-launch.sh's `verify` can read the verdict and roll entry back.
-  delivery_selftest "$STATE" || true
 
   # --- shutdown: flush buffered escalations, reap child, release lock -------
   local WATCHER_PID="" CUR_TMP=""
@@ -1591,6 +1593,12 @@ fm_super_main() {
     exit 0
   }
   trap cleanup TERM INT
+
+  # A failed self-test records durably and alarms; the daemon stays up so
+  # bin/fm-afk-launch.sh's `verify` can read the verdict and roll entry back.
+  # Runs under the trap above: a stop rollback arriving mid-retry must release
+  # the lock and pidfile, not die by default signal action.
+  delivery_selftest "$STATE" || true
 
   # --- crash-loop guard -----------------------------------------------------
   local crash_times=() backoff_secs=$CRASH_NORMAL_SLEEP

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -127,7 +127,7 @@ Beyond the durable `state/.subsuper-inject-wedged` marker and the tmux status-li
 `config/wedge-alarm` (local, gitignored) lists channel directives, one per non-empty, non-comment line; every listed non-`off` channel fires, best-effort.
 `FM_WEDGE_ALARM_CHANNEL` overrides the file with a single directive.
 Directives are `off` (a position-independent kill switch that disables every active alert), `auto`/`default`, `osascript` (macOS Notification Center banner), `herdr` (herdr UI notification), and `command:<cmd>` (run `<cmd>` via `sh -c`, summary on `$1` and stdin).
-An absent file means `auto`, i.e. default-on on macOS: the alarm exists precisely so a wedged away-mode primary is never silent, and it fires at most once per max-defer window after a genuine wedge.
+An absent file means `auto`, which resolves to `osascript` on macOS and to `herdr` elsewhere when the `herdr` CLI is installed: the alarm exists precisely so a wedged away-mode primary is never silent, and it fires at most once per max-defer window after a genuine wedge.
 A missing or failing channel logs and falls through to the next, never crashing the daemon.
 See [`wedge-alarm.md`](wedge-alarm.md) for the current channel reference, [`verification/supervision.md`](verification/supervision.md#wedge-alarm-channels) for active evidence, and [`examples/wedge-alarm`](examples/wedge-alarm) for a copyable config.
 
@@ -740,9 +740,12 @@ FM_SUPERVISOR_TARGET=              # optional supervisor pane target override; t
 FM_INJECT_SKIP=heartbeat           # |-prefixes force-self-handled bypassing classification; empty disables
 FM_ESCALATE_BATCH_SECS=90          # buffer window for batched escalation digests; 0 = flush immediately
 FM_MAX_DEFER_SECS=300              # max buffered escalation age before retry plus wedge alarm; 0 disables
-FM_WEDGE_ALARM_CHANNEL=            # override config/wedge-alarm with one active-alert directive for the wedge alarm; off|auto|osascript|herdr|command:<cmd>; absent = auto (macOS -> an OS notification)
+FM_WEDGE_ALARM_CHANNEL=            # override config/wedge-alarm with one active-alert directive for the wedge alarm; off|auto|osascript|herdr|command:<cmd>; absent = auto (osascript on macOS, herdr elsewhere when installed)
 FM_WEDGE_ALARM_EXEC=              # notifier seam: route every channel (osascript, herdr, command:) through this command as `<cmd> <channel> <summary>`; "discard" fires nothing; unset in production; the daemon defaults it to "discard" when sourced so no test posts a real notification (docs/wedge-alarm.md)
 FM_WEDGE_ALARM_TIMEOUT_SECS=10    # maximum seconds for each osascript, herdr, override, or command: notifier before its watchdog terminates it and continues to the next channel; invalid or zero values use 10
+FM_INJECT_IGNORE_BUSY=             # internal: the daemon sets this itself for the bounded max-defer escape and the startup delivery self-test so the busy guard cannot veto that one injection; the composer guard and submit confirmation still apply; never set it in config
+FM_DELIVERY_SELFTEST_SECS=45       # window the startup delivery self-test keeps retrying before recording failure in state/.subsuper-delivery-selftest, which bin/fm-afk-launch.sh verify reads
+FM_DELIVERY_SELFTEST_SLEEP=3       # seconds between startup delivery self-test attempts
 FM_INJECT_FAIL_SLEEP=30            # seconds to back off when the supervisor pane is unavailable
 FM_INJECT_CONFIRM_RETRIES=3        # daemon Enter-retry attempts after typing a digest once
 FM_INJECT_CONFIRM_SLEEP=0.5        # seconds between daemon submit checks

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -76,7 +76,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-watch.sh`            | Singleton-safe watcher: absorb benign wakes, detect stalled local-secondmate wake queues, and exit on actionable ones |
 | `fm-inactive-reconcile.sh` | Reconcile long-inactive direct crewmate terminal outcomes without forge access |
 | `fm-afk-start.sh`        | Run the common sourceable away-mode daemon entry in the foreground                      |
-| `fm-afk-launch.sh`       | Own away-mode entry, exit, rollback, and any backend terminal lifecycle                 |
+| `fm-afk-launch.sh`       | Own away-mode entry, delivery verification, exit, rollback, and any backend terminal lifecycle |
 | `fm-afk-return.sh`       | Own deterministic return shutdown, catch-up evidence, and the firstmate-actionable blocker gate |
 | `fm-supervisor-target-lib.sh` | Resolve the shared supervisor target and backend for the daemon and launcher       |
 | `fm-supervise-daemon.sh` | Presence-gated away-mode sub-supervisor: self-handle routine wakes, guard injection by the detected primary harness, escalate batched digests, alert on failed delivery |

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -534,4 +534,5 @@ ok - Scenario D: away-mode entry proves one delivery and refuses when it cannot
 ```
 
 The proven case records `ok`, the payload appears in the pane's submitted log, and `verify` exits 0.
-With the recorded captain pane absent, the verdict is `failed`, nothing is submitted, and `verify` exits non-zero naming the rollback command.
+With the recorded captain pane gone, the daemon records the `failed` verdict with the concrete reason at startup target validation and exits non-zero, nothing is submitted, and `verify` exits non-zero naming the rollback command.
+With the pane present but its composer holding an unsent human line for the whole bounded window, the self-test cannot confirm an injection, records `failed`, submits nothing, and `verify` exits non-zero the same way.

--- a/docs/verification/supervision.md
+++ b/docs/verification/supervision.md
@@ -507,3 +507,31 @@ Observed output:
 ```
 
 The safe command-channel contract is covered without a notification by `tests/fm-daemon.test.sh`: the summary reaches both `$1` and stdin, every channel is process-group bounded, and a failed channel falls through.
+
+### Linux `auto` channel, 2026-08-24
+
+`auto` resolves to `herdr` off macOS when the CLI is installed, so a Linux host is no longer alarm-silent.
+Verified on Ubuntu (Linux 7.0.0-1010-aws) with Herdr 0.7.5 installed at `/home/ubuntu/.local/bin/herdr`:
+
+```sh
+$ uname
+Linux
+$ command -v herdr
+/home/ubuntu/.local/bin/herdr
+```
+
+`tests/fm-daemon.test.sh` asserts the resolution both ways without posting a notification: `auto` selects the installed `herdr` notifier off macOS, and selects nothing when neither notifier binary exists.
+
+## Away-mode entry delivery self-test
+
+Verified 2026-08-24 on Ubuntu (Linux 7.0.0-1010-aws) with tmux as the supervisor backend.
+The daemon injects one marked no-op into the captain pane at startup and records the verdict in `state/.subsuper-delivery-selftest`; `bin/fm-afk-launch.sh verify` gates away-mode entry on it.
+
+`tests/fm-afk-inject-e2e.test.sh` Scenario D proves both directions end to end against a real tmux pane and a real daemon in an isolated state directory:
+
+```
+ok - Scenario D: away-mode entry proves one delivery and refuses when it cannot
+```
+
+The proven case records `ok`, the payload appears in the pane's submitted log, and `verify` exits 0.
+With the recorded captain pane absent, the verdict is `failed`, nothing is submitted, and `verify` exits non-zero naming the rollback command.

--- a/docs/wedge-alarm.md
+++ b/docs/wedge-alarm.md
@@ -12,14 +12,21 @@ It lists channel directives, one per non-empty, non-comment line, and every list
 `FM_WEDGE_ALARM_CHANNEL` overrides the file with one directive for focused testing.
 
 - `off` disables every active alert while retaining the durable marker and tmux flash.
-- `auto` or `default` resolves to `osascript` on macOS.
-  Other platforms have no built-in OS channel, so configure `command:` when a durable marker alone is insufficient.
+- `auto` or `default` resolves to `osascript` on macOS, and to `herdr` on every other platform when the `herdr` CLI is installed.
+  A Linux host without the `herdr` CLI has no built-in OS channel, so configure `command:` there when a durable marker alone is insufficient.
 - `osascript` posts a macOS Notification Center banner outside the terminal pane.
 - `herdr` calls `herdr notification show` outside the supervised pane.
 - `command:<cmd>` runs `<cmd>` through `sh -c` with the alarm summary as `$1` and on stdin, allowing delivery to a phone or pager service.
 
-An absent `config/wedge-alarm` behaves as `auto`, which is default-on on macOS.
+An absent `config/wedge-alarm` behaves as `auto`, which is default-on wherever `auto` resolves to an installed binary.
 This is deliberate because the alarm fires only after a genuine max-defer wedge and is rate-limited to at most once per max-defer window.
+When `auto` resolves to nothing, the daemon logs that the durable marker is the only signal; on a Linux host with no `herdr` CLI, write a `command:` directive into `config/wedge-alarm` so the wedge reaches someone off-host.
+
+## Entry verification
+
+An alarm only helps once away mode is already running.
+`bin/fm-afk-launch.sh verify` closes the gap at entry: the daemon proves one injection reaches the captain pane and records the verdict in `state/.subsuper-delivery-selftest`, and `verify` fails away-mode entry when that proof is absent.
+Away mode must not be reported active before that verdict is `ok`.
 
 Each channel is best-effort.
 A missing binary or non-zero exit logs a warning and continues to the next channel without crashing the daemon loop.

--- a/docs/wedge-alarm.md
+++ b/docs/wedge-alarm.md
@@ -22,18 +22,18 @@ An absent `config/wedge-alarm` behaves as `auto`, which is default-on wherever `
 This is deliberate because the alarm fires only after a genuine max-defer wedge and is rate-limited to at most once per max-defer window.
 When `auto` resolves to nothing, the daemon logs that the durable marker is the only signal; on a Linux host with no `herdr` CLI, write a `command:` directive into `config/wedge-alarm` so the wedge reaches someone off-host.
 
-## Entry verification
-
-An alarm only helps once away mode is already running.
-`bin/fm-afk-launch.sh verify` closes the gap at entry: the daemon proves one injection reaches the captain pane and records the verdict in `state/.subsuper-delivery-selftest`, and `verify` fails away-mode entry when that proof is absent.
-Away mode must not be reported active before that verdict is `ok`.
-
 Each channel is best-effort.
 A missing binary or non-zero exit logs a warning and continues to the next channel without crashing the daemon loop.
 Every invocation is process-group bounded by `FM_WEDGE_ALARM_TIMEOUT_SECS`, which defaults to 10 seconds, including `command:`, `osascript`, `herdr`, and the test seam.
 On timeout or daemon shutdown, the notifier process group is terminated and the next configured channel may run.
 AppleScript receives the summary as an argv item rather than interpolated source, so summary text cannot alter the script.
 See [`examples/wedge-alarm`](examples/wedge-alarm) for a copyable config.
+
+## Entry verification
+
+An alarm only helps once away mode is already running.
+`bin/fm-afk-launch.sh verify` closes the gap at entry: the daemon proves one injection reaches the captain pane and records the verdict in `state/.subsuper-delivery-selftest`, and `verify` fails away-mode entry when that proof is absent.
+Away mode must not be reported active before that verdict is `ok`.
 
 ## Test safety
 

--- a/tests/fm-afk-inject-e2e.test.sh
+++ b/tests/fm-afk-inject-e2e.test.sh
@@ -165,7 +165,7 @@ chmod +x "$TMUX_SHIM_DIR/tmux"
 start_daemon() {
   PATH="$TMUX_SHIM_DIR:$PATH" \
   FM_STATE_OVERRIDE="$STATE_DIR" \
-  FM_SUPERVISOR_TARGET="$SUPERVISOR_PANE" \
+  FM_SUPERVISOR_TARGET="${SUPERVISOR_TARGET_OVERRIDE:-$SUPERVISOR_PANE}" \
   FM_SUPERVISOR_BACKEND=tmux \
   FM_ESCALATE_BATCH_SECS=0 \
   FM_HOUSEKEEPING_TICK=1 \
@@ -189,6 +189,31 @@ start_daemon() {
     echo "daemon stderr:" >&2; cat "$STATE_DIR/daemon.err" >&2
     fail "daemon did not start (no pid file after 6s)"
   }
+  # The daemon proves delivery once at startup before away mode may be reported
+  # active. That is a real injection into this pane, so wait for its verdict and
+  # then clear the submitted log, leaving each scenario the clean slate it
+  # asserts on. Scenarios that need the self-test itself assert before this.
+  [ "${SKIP_SELFTEST_WAIT:-0}" = 1 ] && return 0
+  wait_for_selftest_verdict ok || {
+    echo "daemon stderr:" >&2; cat "$STATE_DIR/daemon.err" >&2
+    fail "startup delivery self-test did not confirm an injection into the supervisor pane"
+  }
+  : > "$LOG_FILE"
+}
+
+# wait_for_selftest_verdict: poll the daemon's durable delivery verdict.
+wait_for_selftest_verdict() {  # <expected-verdict>
+  local want=$1 i=0 got
+  while [ "$i" -lt 60 ]; do
+    if [ -s "$STATE_DIR/.subsuper-delivery-selftest" ]; then
+      read -r got _ < "$STATE_DIR/.subsuper-delivery-selftest" || got=
+      [ "$got" = "$want" ] && return 0
+      [ -n "$got" ] && [ "$got" != ok ] && [ "$want" = ok ] && return 1
+    fi
+    sleep 0.5
+    i=$((i + 1))
+  done
+  return 1
 }
 
 stop_daemon() {
@@ -337,10 +362,12 @@ test_scenario_b() {
   reset_state
   afk_enter "$STATE_DIR"
 
-  # Arm the swallow: the daemon's first Enter will be dropped by the shim.
-  touch "$STATE_DIR/.swallow-enter"
-
   start_daemon
+
+  # Arm the swallow AFTER startup so it drops the DIGEST's Enter: the daemon's
+  # startup delivery self-test is an earlier real injection and would otherwise
+  # absorb the swallow.
+  touch "$STATE_DIR/.swallow-enter"
 
   # Write a captain-relevant status to trigger a real escalation.
   echo "done: PR https://example.test/pr/200" > "$STATE_DIR/fake-c1.status"
@@ -421,8 +448,45 @@ test_scenario_c() {
   pass "Scenario C: a normal captain status injects exactly one clean single-line sentinel digest"
 }
 
+# --- Scenario D: away-mode entry delivery self-test -------------------------
+# Away mode must prove one injection reaches the captain pane BEFORE it is
+# reported active, and abort loudly when it cannot (upstream #2917: five days of
+# away mode, 39 escalations raised, none delivered). This owns the end-to-end
+# contract across the daemon's durable verdict and the launcher's verify gate.
+
+test_scenario_d() {
+  reset_state
+  afk_enter "$STATE_DIR"
+  SKIP_SELFTEST_WAIT=1 start_daemon
+
+  wait_for_selftest_verdict ok \
+    || fail "Scenario D: the startup self-test did not record a proven delivery"
+  grep -q 'delivery self-test' "$LOG_FILE" \
+    || fail "Scenario D: the self-test payload never reached the supervisor pane"
+  FM_STATE_OVERRIDE="$STATE_DIR" FM_AFK_VERIFY_TIMEOUT_SECS=10 "$ROOT/bin/fm-afk-launch.sh" verify \
+    || fail "Scenario D: verify rejected a proven delivery"
+  : > "$LOG_FILE"
+  stop_daemon
+
+  # Now the undeliverable case: the recorded captain pane no longer exists, so
+  # nothing can land and entry must refuse rather than report away mode active.
+  reset_state
+  afk_enter "$STATE_DIR"
+  SUPERVISOR_TARGET_OVERRIDE='%99999' SKIP_SELFTEST_WAIT=1 \
+    FM_DELIVERY_SELFTEST_SECS=2 FM_DELIVERY_SELFTEST_SLEEP=1 start_daemon
+  wait_for_selftest_verdict failed \
+    || fail "Scenario D: an unreachable captain pane did not record a failed verdict"
+  [ ! -s "$LOG_FILE" ] || fail "Scenario D: something was submitted to an unreachable pane"
+  if FM_STATE_OVERRIDE="$STATE_DIR" FM_AFK_VERIFY_TIMEOUT_SECS=5 "$ROOT/bin/fm-afk-launch.sh" verify >/dev/null 2>&1; then
+    fail "Scenario D: verify accepted an entry whose delivery could not be proven"
+  fi
+  stop_daemon
+  pass "Scenario D: away-mode entry proves one delivery and refuses when it cannot"
+}
+
 test_scenario_a
 test_scenario_b
 test_scenario_c
+test_scenario_d
 
 echo "all e2e injection tests passed"

--- a/tests/fm-afk-inject-e2e.test.sh
+++ b/tests/fm-afk-inject-e2e.test.sh
@@ -468,19 +468,45 @@ test_scenario_d() {
   : > "$LOG_FILE"
   stop_daemon
 
-  # Now the undeliverable case: the recorded captain pane no longer exists, so
-  # nothing can land and entry must refuse rather than report away mode active.
+  # Gone-pane case: the recorded captain pane does not exist on this backend, so
+  # the daemon refuses at startup target validation, records the failed verdict
+  # durably, and exits non-zero without submitting anything. Run it in the
+  # foreground: this startup failure has no daemon left to poll a pidfile for.
   reset_state
   afk_enter "$STATE_DIR"
-  SUPERVISOR_TARGET_OVERRIDE='%99999' SKIP_SELFTEST_WAIT=1 \
-    FM_DELIVERY_SELFTEST_SECS=2 FM_DELIVERY_SELFTEST_SLEEP=1 start_daemon
+  if PATH="$TMUX_SHIM_DIR:$PATH" FM_STATE_OVERRIDE="$STATE_DIR" \
+    FM_SUPERVISOR_TARGET='%99999' FM_SUPERVISOR_BACKEND=tmux \
+    "$DAEMON" >"$STATE_DIR/daemon.out" 2>"$STATE_DIR/daemon.err"; then
+    fail "Scenario D: the daemon reported success for a target the backend cannot resolve"
+  fi
+  local got
+  read -r got _ < "$STATE_DIR/.subsuper-delivery-selftest" 2>/dev/null || got=
+  [ "$got" = failed ] \
+    || fail "Scenario D: a gone captain pane did not record a failed verdict (got: '${got:-<none>}')"
+  [ ! -s "$LOG_FILE" ] || fail "Scenario D: something was submitted to a gone pane"
+  if FM_STATE_OVERRIDE="$STATE_DIR" FM_AFK_VERIFY_TIMEOUT_SECS=5 "$ROOT/bin/fm-afk-launch.sh" verify >/dev/null 2>&1; then
+    fail "Scenario D: verify accepted an entry whose target the backend cannot resolve"
+  fi
+
+  # Undeliverable-injection case: the pane resolves, but its composer holds an
+  # unsent human line for the whole bounded window, so no injection can ever be
+  # confirmed and entry must refuse too.
+  reset_state
+  afk_enter "$STATE_DIR"
+  "$REAL_TMUX" -L "$SOCKET" send-keys -t "$SUPERVISOR_PANE" -l "unsent human line"
+  wait_for_pane_input_pending \
+    || fail "Scenario D: pending composer text did not become detectable"
+  SKIP_SELFTEST_WAIT=1 FM_DELIVERY_SELFTEST_SECS=2 FM_DELIVERY_SELFTEST_SLEEP=1 \
+    FM_WEDGE_ALARM_CHANNEL=off start_daemon
   wait_for_selftest_verdict failed \
-    || fail "Scenario D: an unreachable captain pane did not record a failed verdict"
-  [ ! -s "$LOG_FILE" ] || fail "Scenario D: something was submitted to an unreachable pane"
+    || fail "Scenario D: an unconfirmable injection did not record a failed verdict"
+  [ ! -s "$LOG_FILE" ] || fail "Scenario D: something was submitted past a pending composer"
   if FM_STATE_OVERRIDE="$STATE_DIR" FM_AFK_VERIFY_TIMEOUT_SECS=5 "$ROOT/bin/fm-afk-launch.sh" verify >/dev/null 2>&1; then
     fail "Scenario D: verify accepted an entry whose delivery could not be proven"
   fi
   stop_daemon
+  "$REAL_TMUX" -L "$SOCKET" send-keys -t "$SUPERVISOR_PANE" Enter
+  sleep 0.3
   pass "Scenario D: away-mode entry proves one delivery and refuses when it cannot"
 }
 

--- a/tests/fm-daemon.test.sh
+++ b/tests/fm-daemon.test.sh
@@ -1358,6 +1358,7 @@ test_delivery_selftest_records_failure_and_alarms() {
   WEDGE_ALARM_LAST_EPOCH=0
   if PATH="$fakebin:$PATH" FM_FAKE_TMUX_PANE_ALIVE=0 FM_FAKE_TMUX_SENT="$sent" \
     FM_WEDGE_ALARM_LOG="$log" FM_WEDGE_ALARM_CHANNEL=osascript \
+    FM_DELIVERY_SELFTEST_SECS=1 FM_DELIVERY_SELFTEST_SLEEP=1 \
     FM_DAEMON_PRIMARY_HARNESS=claude delivery_selftest "$state"; then
     fail "delivery_selftest must fail when the captain pane cannot be reached"
   fi

--- a/tests/fm-daemon.test.sh
+++ b/tests/fm-daemon.test.sh
@@ -1266,6 +1266,130 @@ test_max_defer_pending_composer_alarms_without_typing() {
   pass "max-defer on a pending composer alarms without typing"
 }
 
+# Upstream #2917: past max-defer the escape re-ran the SAME busy guard that had
+# been deferring, so a false-positive busy verdict suppressed delivery for hours
+# while the alarm dutifully fired. Past max-defer the busy verdict must lose its
+# veto; the composer guard must not.
+test_max_defer_delivers_past_a_busy_pane() {
+  local dir state fakebin sent
+  dir=$(make_bordered_case maxdefer-busy-pane)
+  state="$dir/state"; fakebin="$dir/fakebin"
+  sent="$dir/sent.log"; : > "$sent"
+  # A rendered busy footer under an empty composer: the pane reads busy, yet
+  # its composer holds no text, exactly the shape the incident wedged on.
+  printf '╭─────╮\n│ >   │\n╰─────╯\nesc to interrupt\n' > "$dir/composer"
+  escalate_add "$state" "needs-decision: pick A"
+  echo $(( $(date +%s) - 600 )) > "$state/.subsuper-escalations.since"
+  afk_enter "$state"
+  PATH="$fakebin:$PATH" FM_FAKE_COMPOSER="$dir/composer" FM_FAKE_SENT="$sent" \
+    FM_DAEMON_PRIMARY_HARNESS=claude FM_ESCALATE_BATCH_SECS=99999 FM_MAX_DEFER_SECS=60 \
+    FM_INJECT_CONFIRM_SLEEP=0.05 housekeeping "$state"
+  grep -F 'Supervisor escalate' "$sent" >/dev/null \
+    || fail "max-defer did not deliver past a busy pane: $(cat "$sent")"
+  [ ! -s "$state/.subsuper-escalations" ] || fail "buffer not cleared after the max-defer escape delivered"
+  [ ! -e "$state/.subsuper-inject-wedged" ] || fail "wedge alarm fired even though the escape delivered"
+  pass "max-defer escape delivers past a busy verdict instead of re-running the guard that deferred"
+}
+
+test_busy_guard_veto_is_bounded_not_permanent() {
+  local dir state fakebin sent
+  dir=$(make_bordered_case busy-guard-bounded)
+  state="$dir/state"; fakebin="$dir/fakebin"
+  sent="$dir/sent.log"; : > "$sent"
+  printf '╭─────╮\n│ >   │\n╰─────╯\nesc to interrupt\n' > "$dir/composer"
+  afk_enter "$state"
+  if PATH="$fakebin:$PATH" FM_FAKE_COMPOSER="$dir/composer" FM_FAKE_SENT="$sent" \
+    FM_DAEMON_PRIMARY_HARNESS=claude FM_INJECT_CONFIRM_SLEEP=0.05 \
+    inject_msg "routine digest" "$state"; then
+    fail "an ordinary injection must still defer while the pane reads busy"
+  fi
+  [ ! -s "$sent" ] || fail "ordinary injection typed into a busy pane"
+  PATH="$fakebin:$PATH" FM_FAKE_COMPOSER="$dir/composer" FM_FAKE_SENT="$sent" \
+    FM_DAEMON_PRIMARY_HARNESS=claude FM_INJECT_CONFIRM_SLEEP=0.05 \
+    FM_INJECT_IGNORE_BUSY=1 inject_msg "escape digest" "$state" \
+    || fail "the bounded escape must deliver into the same busy-but-empty pane"
+  grep -F 'escape digest' "$sent" >/dev/null || fail "escape digest never reached the pane: $(cat "$sent")"
+  pass "busy guard vetoes an ordinary injection but yields to the bounded escape on the same pane"
+}
+
+# The escape must not weaken the guard that protects the pane's CONTENTS: a
+# busy pane whose composer holds human text is still never typed into.
+test_busy_guard_escape_still_respects_a_pending_composer() {
+  local dir state fakebin sent
+  dir=$(make_bordered_case busy-escape-pending)
+  state="$dir/state"; fakebin="$dir/fakebin"
+  sent="$dir/sent.log"; : > "$sent"
+  printf '╭─────────────────╮\n│ > human draft   │\n╰─────────────────╯\nesc to interrupt\n' > "$dir/composer"
+  afk_enter "$state"
+  if PATH="$fakebin:$PATH" FM_FAKE_COMPOSER="$dir/composer" FM_FAKE_SENT="$sent" \
+    FM_DAEMON_PRIMARY_HARNESS=claude FM_INJECT_CONFIRM_SLEEP=0.05 \
+    FM_INJECT_IGNORE_BUSY=1 inject_msg "escape digest" "$state"; then
+    fail "the bounded escape must not inject into a pending composer"
+  fi
+  [ ! -s "$sent" ] || fail "the bounded escape typed into a pending composer"
+  grep -F 'human draft' "$dir/composer" >/dev/null || fail "pending composer content changed"
+  pass "bounded busy-guard escape still defers on a pending composer"
+}
+
+# Layer 3: away mode must prove one injection round-trips before it is reported
+# active. Upstream #2917 kept away mode "on" for five days while delivering none
+# of 39 escalations, because nothing ever exercised the delivery path at entry.
+test_delivery_selftest_records_a_durable_ok() {
+  local dir state fakebin sent
+  dir=$(make_bordered_case selftest-ok)
+  state="$dir/state"; fakebin="$dir/fakebin"
+  sent="$dir/sent.log"; : > "$sent"
+  afk_enter "$state"
+  PATH="$fakebin:$PATH" FM_FAKE_COMPOSER="$dir/composer" FM_FAKE_SENT="$sent" \
+    FM_DAEMON_PRIMARY_HARNESS=claude FM_INJECT_CONFIRM_SLEEP=0.05 \
+    delivery_selftest "$state" || fail "delivery_selftest failed on a deliverable pane"
+  grep -q '^ok ' "$state/.subsuper-delivery-selftest" \
+    || fail "delivery_selftest did not record a durable ok verdict: $(cat "$state/.subsuper-delivery-selftest" 2>/dev/null)"
+  [ -s "$sent" ] || fail "delivery_selftest recorded ok without sending anything"
+  pass "delivery_selftest proves one injection and records a durable ok"
+}
+
+test_delivery_selftest_records_failure_and_alarms() {
+  local dir state fakebin sent log
+  dir=$(make_supercase selftest-undeliverable)
+  state="$dir/state"; fakebin="$dir/fakebin"
+  sent="$dir/sent.log"; : > "$sent"; log="$dir/alert.log"
+  afk_enter "$state"
+  WEDGE_ALARM_LAST_EPOCH=0
+  if PATH="$fakebin:$PATH" FM_FAKE_TMUX_PANE_ALIVE=0 FM_FAKE_TMUX_SENT="$sent" \
+    FM_WEDGE_ALARM_LOG="$log" FM_WEDGE_ALARM_CHANNEL=osascript \
+    FM_DAEMON_PRIMARY_HARNESS=claude delivery_selftest "$state"; then
+    fail "delivery_selftest must fail when the captain pane cannot be reached"
+  fi
+  grep -q '^failed ' "$state/.subsuper-delivery-selftest" \
+    || fail "delivery_selftest did not record a durable failure verdict"
+  [ ! -s "$sent" ] || fail "delivery_selftest typed into an unreachable pane"
+  grep -F 'self-test' "$log" >/dev/null \
+    || fail "a failed delivery self-test did not raise the active alert: $(cat "$log" 2>/dev/null)"
+  pass "delivery_selftest records a durable failure and alarms when delivery cannot be proven"
+}
+
+test_afk_launch_verify_reads_the_durable_verdict() {
+  local dir state out
+  dir=$(make_supercase afk-launch-verify); state="$dir/state"
+
+  printf 'ok 1756000000\n' > "$state/.subsuper-delivery-selftest"
+  FM_STATE_OVERRIDE="$state" FM_AFK_VERIFY_TIMEOUT_SECS=2 "$ROOT/bin/fm-afk-launch.sh" verify >/dev/null 2>&1 \
+    || fail "verify should succeed on a recorded ok verdict"
+
+  printf 'failed 1756000000\n' > "$state/.subsuper-delivery-selftest"
+  if out=$(FM_STATE_OVERRIDE="$state" FM_AFK_VERIFY_TIMEOUT_SECS=2 "$ROOT/bin/fm-afk-launch.sh" verify 2>&1); then
+    fail "verify must exit non-zero on a recorded failure"
+  fi
+  case "$out" in *stop*) : ;; *) fail "a failed verify must name the rollback command: $out" ;; esac
+
+  rm -f "$state/.subsuper-delivery-selftest"
+  if FM_STATE_OVERRIDE="$state" FM_AFK_VERIFY_TIMEOUT_SECS=1 "$ROOT/bin/fm-afk-launch.sh" verify >/dev/null 2>&1; then
+    fail "verify must exit non-zero when no verdict is ever recorded"
+  fi
+  pass "fm-afk-launch verify passes on a proven delivery and fails loudly otherwise"
+}
+
 test_normal_flush_clears_stale_wedge_marker() {
   local dir state fakebin sent
   dir=$(make_bordered_case normal-clears-wedge)
@@ -1500,13 +1624,27 @@ test_wedge_alarm_auto_darwin_selects_osascript() {
   pass "auto resolves to the macOS osascript notifier on Darwin (default-on)"
 }
 
-test_wedge_alarm_auto_non_darwin_has_no_os_channel() {
-  local dir log
-  dir=$(make_wedge_case wedge-auto-linux); log="$dir/alert.log"
-  PATH="$dir/fakebin:$PATH" FM_WEDGE_ALARM_LOG="$log" FM_FAKE_UNAME=Linux FM_WEDGE_ALARM_CHANNEL=auto \
+# Upstream #2917 spent 86 alarms logging that Linux had no channel at all while
+# the herdr CLI was installed the whole time, so `auto` now uses herdr's own
+# notification surface off macOS and only reports "no channel" when neither
+# notifier binary exists.
+test_wedge_alarm_auto_non_darwin_uses_herdr_when_installed() {
+  local dir log fakebin
+  dir=$(make_wedge_case wedge-auto-linux); log="$dir/alert.log"; fakebin="$dir/fakebin"
+  printf '#!/bin/sh\nexit 0\n' > "$fakebin/herdr"; chmod +x "$fakebin/herdr"
+  PATH="$fakebin:$PATH" FM_WEDGE_ALARM_LOG="$log" FM_FAKE_UNAME=Linux FM_WEDGE_ALARM_CHANNEL=auto \
     wedge_alarm_notify "away-mode WEDGED 900s" "/s/.marker"
-  [ ! -s "$log" ] || fail "auto selected a built-in OS channel on a non-macOS platform: $(cat "$log")"
-  pass "auto on a non-macOS platform selects no built-in OS channel (the marker or a configured command carries it)"
+  grep -F 'herdr' "$log" >/dev/null \
+    || fail "auto did not resolve to the installed herdr notifier off macOS: $(cat "$log")"
+
+  # With neither notifier binary present, auto selects nothing and the daemon
+  # says so rather than pretending an alert went out.
+  rm -f "$fakebin/herdr"
+  : > "$log"
+  PATH="$fakebin:/usr/bin:/bin" FM_WEDGE_ALARM_LOG="$log" FM_FAKE_UNAME=Linux FM_WEDGE_ALARM_CHANNEL=auto \
+    wedge_alarm_notify "away-mode WEDGED 900s" "/s/.marker"
+  [ ! -s "$log" ] || fail "auto emitted an alert with no notifier binary installed: $(cat "$log")"
+  pass "auto off macOS uses an installed herdr notifier and selects nothing when none exists"
 }
 
 test_wedge_alarm_config_file_multi_channel() {
@@ -1760,16 +1898,71 @@ test_discover_supervisor_target_herdr() {
   pass "discover_supervisor_target: override > TMUX_PANE > herdr '<session>:<pane-id>' composition > firstmate:0 fallback"
 }
 
-test_pane_is_busy_herdr_native_busy_state() {
+# Upstream #2917: a single uncorroborated busy signal vetoed delivery for 7h16m
+# against a pane that was verifiably idle. Both signals can over-report, so a
+# busy verdict now needs corroboration and a legible idle on either signal wins.
+# Each case drives the two signals apart deliberately and asserts the verdict
+# names the signal it came from, so no case can go quietly vacuous.
+test_pane_busy_verdict_requires_corroboration() {
+  local dir busy_row idle_row
+  dir=$(make_supercase primary-busy-corroboration)
+  busy_row='esc to interrupt'
+  idle_row='> ready'
+
+  # want_native/want_row are deliberately named so they cannot be shadowed by
+  # pane_busy_verdict's own locals when bash resolves them inside these stubs.
+  _verdict() {  # <native-signal> <rendered-row>
+    local want_native=$1 want_row=$2
+    (
+      fm_backend_busy_state() { [ "$1" = herdr ] && [ "$2" = "default:w1:p2" ] || fail "unexpected busy_state args: $1 $2"; printf '%s' "$want_native"; }
+      fm_backend_capture() { [ -n "$want_row" ] || return 1; printf '%s\n' "$want_row"; }
+      FM_STATE_OVERRIDE="$dir/state" FM_DAEMON_PRIMARY_HARNESS=claude pane_busy_verdict "default:w1:p2" herdr
+    )
+  }
+
+  local out
+  out=$(_verdict busy "$busy_row")
+  case "$out" in busy*native*rendered*) : ;; *) fail "both signals busy should read busy from both: $out" ;; esac
+
+  out=$(_verdict busy "$idle_row")
+  case "$out" in idle*native-busy*rendered*idle*) : ;; *) fail "a native busy contradicted by a rendered idle must read idle: $out" ;; esac
+
+  out=$(_verdict idle "$busy_row")
+  case "$out" in idle*rendered-busy*native*idle*) : ;; *) fail "a rendered busy contradicted by a native idle must read idle: $out" ;; esac
+
+  out=$(_verdict busy '')
+  case "$out" in busy*native-only*) : ;; *) fail "an unreadable pane must not cancel a native busy: $out" ;; esac
+
+  out=$(_verdict unknown "$busy_row")
+  case "$out" in busy*rendered-only*) : ;; *) fail "a rendered busy with no native agent-state must read busy (the tmux path): $out" ;; esac
+
+  out=$(_verdict unknown "$idle_row")
+  case "$out" in idle*) : ;; *) fail "no busy signal at all must read idle: $out" ;; esac
+
+  unset -f _verdict
+  pass "pane_busy_verdict: busy needs corroboration, a legible idle on either signal wins, and each verdict names its signal"
+}
+
+# pane_is_busy is the predicate every caller uses; it must agree with the verdict
+# and publish the signal so a deferral log can name what vetoed delivery.
+test_pane_is_busy_publishes_verdict_source() {
   local dir
-  dir=$(make_supercase primary-herdr-busy)
+  dir=$(make_supercase primary-busy-source)
   (
-    fm_backend_busy_state() { [ "$1" = herdr ] && [ "$2" = "default:w1:p2" ] || fail "unexpected busy_state args: $1 $2"; printf 'busy'; }
-    fm_backend_capture() { fail "capture should not be consulted when busy_state is conclusive"; }
+    fm_backend_busy_state() { printf 'busy'; }
+    fm_backend_capture() { printf 'esc to interrupt\n'; }
     FM_STATE_OVERRIDE="$dir/state" FM_DAEMON_PRIMARY_HARNESS=claude pane_is_busy "default:w1:p2" herdr \
-      || fail "pane_is_busy should report busy from herdr's native busy_state"
-  ) || fail "herdr native-busy pane_is_busy subshell failed"
-  pass "pane_is_busy: herdr native busy_state='busy' short-circuits without a capture fallback"
+      || fail "pane_is_busy should report busy when both signals agree"
+    [ -n "$PANE_BUSY_SOURCE" ] || fail "pane_is_busy did not publish the verdict source"
+
+    fm_backend_busy_state() { printf 'busy'; }
+    fm_backend_capture() { printf '> ready\n'; }
+    if FM_STATE_OVERRIDE="$dir/state" FM_DAEMON_PRIMARY_HARNESS=claude pane_is_busy "default:w1:p2" herdr; then
+      fail "pane_is_busy must report idle when a native busy is contradicted by a rendered idle"
+    fi
+    case "$PANE_BUSY_SOURCE" in *contradicted*) : ;; *) fail "verdict source should name the contradiction: $PANE_BUSY_SOURCE" ;; esac
+  ) || fail "pane_is_busy verdict-source subshell failed"
+  pass "pane_is_busy: agrees with pane_busy_verdict and publishes its signal for the deferral log"
 }
 
 test_primary_busy_guard_is_harness_scoped() {
@@ -1987,6 +2180,12 @@ test_submit_ack_confirms_on_bordered_empty_composer
 test_submit_ack_reports_pending_on_persistent_swallow
 test_max_defer_empty_swallow_types_once_and_alarms
 test_max_defer_flushes_empty_idle_pane
+test_max_defer_delivers_past_a_busy_pane
+test_busy_guard_veto_is_bounded_not_permanent
+test_busy_guard_escape_still_respects_a_pending_composer
+test_delivery_selftest_records_a_durable_ok
+test_delivery_selftest_records_failure_and_alarms
+test_afk_launch_verify_reads_the_durable_verdict
 test_max_defer_pending_composer_alarms_without_typing
 test_normal_flush_clears_stale_wedge_marker
 test_below_max_defer_does_nothing
@@ -2002,7 +2201,7 @@ test_wedge_alarm_command_failure_hides_configured_command
 test_wedge_alarm_unknown_channel_hides_configured_directive
 test_wedge_alarm_off_disables_active_alert_regardless_of_position
 test_wedge_alarm_auto_darwin_selects_osascript
-test_wedge_alarm_auto_non_darwin_has_no_os_channel
+test_wedge_alarm_auto_non_darwin_uses_herdr_when_installed
 test_wedge_alarm_config_file_multi_channel
 test_wedge_alarm_failing_channel_degrades_gracefully
 test_wedge_alarm_hung_channel_times_out_and_falls_through
@@ -2016,7 +2215,8 @@ test_fm_send_exits_nonzero_on_initial_send_failure
 test_fm_send_exits_nonzero_on_unproven_submit
 test_discover_supervisor_backend_precedence
 test_discover_supervisor_target_herdr
-test_pane_is_busy_herdr_native_busy_state
+test_pane_busy_verdict_requires_corroboration
+test_pane_is_busy_publishes_verdict_source
 test_primary_busy_guard_is_harness_scoped
 test_pane_is_busy_defaults_to_tmux_when_backend_omitted
 test_pane_input_pending_herdr_dispatch

--- a/tests/fm-daemon.test.sh
+++ b/tests/fm-daemon.test.sh
@@ -1349,6 +1349,28 @@ test_delivery_selftest_records_a_durable_ok() {
   pass "delivery_selftest proves one injection and records a durable ok"
 }
 
+test_delivery_selftest_survives_leading_zero_timing() {
+  local dir state fakebin sent errs
+  dir=$(make_bordered_case selftest-leading-zero)
+  state="$dir/state"; fakebin="$dir/fakebin"
+  sent="$dir/sent.log"; : > "$sent"; errs="$dir/selftest.err"
+  afk_enter "$state"
+  # "09" is all digits but invalid octal in $((...)); the deadline arithmetic
+  # must coerce it to decimal instead of erroring and losing the retry window.
+  # Subshell: a bash arithmetic error unwinds the calling function, so without
+  # it the failure would silently skip this test's own pass/fail reporting.
+  ( PATH="$fakebin:$PATH" FM_FAKE_COMPOSER="$dir/composer" FM_FAKE_SENT="$sent" \
+    FM_DELIVERY_SELFTEST_SECS=09 FM_DELIVERY_SELFTEST_SLEEP=01 \
+    FM_DAEMON_PRIMARY_HARNESS=claude FM_INJECT_CONFIRM_SLEEP=0.05 \
+    delivery_selftest "$state" ) 2> "$errs" \
+    || fail "delivery_selftest choked on leading-zero timing values (octal parse): $(cat "$errs")"
+  grep -q 'value too great\|arithmetic' "$errs" \
+    && fail "leading-zero timing hit an arithmetic error: $(cat "$errs")"
+  grep -q '^ok ' "$state/.subsuper-delivery-selftest" \
+    || fail "leading-zero timing did not record ok: $(cat "$state/.subsuper-delivery-selftest" 2>/dev/null)"
+  pass "delivery_selftest treats leading-zero timing values as decimal"
+}
+
 test_delivery_selftest_records_failure_and_alarms() {
   local dir state fakebin sent log
   dir=$(make_supercase selftest-undeliverable)
@@ -2188,6 +2210,7 @@ test_max_defer_delivers_past_a_busy_pane
 test_busy_guard_veto_is_bounded_not_permanent
 test_busy_guard_escape_still_respects_a_pending_composer
 test_delivery_selftest_records_a_durable_ok
+test_delivery_selftest_survives_leading_zero_timing
 test_delivery_selftest_records_failure_and_alarms
 test_afk_launch_verify_reads_the_durable_verdict
 test_max_defer_pending_composer_alarms_without_typing

--- a/tests/fm-daemon.test.sh
+++ b/tests/fm-daemon.test.sh
@@ -1378,6 +1378,9 @@ test_afk_launch_verify_reads_the_durable_verdict() {
   FM_STATE_OVERRIDE="$state" FM_AFK_VERIFY_TIMEOUT_SECS=2 "$ROOT/bin/fm-afk-launch.sh" verify >/dev/null 2>&1 \
     || fail "verify should succeed on a recorded ok verdict"
 
+  FM_STATE_OVERRIDE="$state" FM_AFK_VERIFY_TIMEOUT_SECS=0 "$ROOT/bin/fm-afk-launch.sh" verify >/dev/null 2>&1 \
+    || fail "verify with a zero timeout must still accept an already-present ok verdict"
+
   printf 'failed 1756000000\n' > "$state/.subsuper-delivery-selftest"
   if out=$(FM_STATE_OVERRIDE="$state" FM_AFK_VERIFY_TIMEOUT_SECS=2 "$ROOT/bin/fm-afk-launch.sh" verify 2>&1); then
     fail "verify must exit non-zero on a recorded failure"


### PR DESCRIPTION
## Intent

Fix the away-mode escalation delivery wedge in firstmate: on a live home the away-mode sub-supervisor buffered 39 escalations over 7h16m and delivered zero of them into the captain pane, matching upstream issue #2917 (4721 consecutive busy-guard deferrals, 0 sent). Three layers were requested and all three are in this commit.

(1) Root cause. The pre-injection busy guard (pane_is_busy) was an unbounded single-source veto, and the max-defer escape re-ran the very same guard, so one false-positive busy reading blocked every delivery forever against a verifiably idle pane with an empty composer. The fix adds pane_busy_verdict, which corroborates the harness native agent-state against the rendered pane signature: busy requires corroboration, and a legible idle on either signal wins. pane_is_busy is deliberately kept as the single predicate every caller uses (rather than callers calling pane_busy_verdict directly) because six existing tests stub pane_is_busy as their seam; it now publishes PANE_BUSY_SOURCE so a deferral log can name the signal that vetoed it. tmux is intentionally unchanged because it exposes no native agent-state (always unknown), so its verdict still comes from the rendered signal alone. The max-defer flush now sets FM_INJECT_IGNORE_BUSY=1 so the escape bypasses the guard that deferred - a deliberate weakening of that guard, justified because the composer guard (which must read affirmatively empty) and the verified type-once submit protect the pane contents, while the busy guard only picks the moment; a digest queued behind the current turn beats 7h16m of silence. That safety boundary is pinned by test_busy_guard_escape_still_respects_a_pending_composer.

(2) Alarm channel. The max-defer wedge alarm defaulted to macOS Notification Center, so on Linux it silently went nowhere while firing 86 times. The requested constraint was to not invent new notification infrastructure if a supported channel already exists, so auto/default now resolves to the already-supported herdr channel off macOS when the herdr CLI is installed, rather than adding a new notifier.

(3) Entry verification. Away-mode entry now proves delivery instead of assuming it: the daemon injects one marked no-op operational message at startup and records ok/failed/skipped in state/.subsuper-delivery-selftest, and bin/fm-afk-launch.sh verify fails away-mode entry (naming the stop rollback command) when that proof is absent, so away mode is never reported active on an undeliverable path. The self-test deliberately retries within a bounded window (FM_DELIVERY_SELFTEST_SECS) because at entry the captain composer can legitimately hold an unsent line, which the composer guard correctly defers on; retrying distinguishes "not this instant" from "cannot deliver". The daemon does not exit on a failed self-test - it stays up as a passive recorder so verify can read the verdict - and verify deliberately skips the launcher lock because holding it for the whole timeout would block the very stop rollback a failed verdict tells the caller to run.

Deliberate scope decisions: upstream #2917 also suggested a floor on consecutive identical deferrals, which was skipped as redundant now that the time-based escape actually works. tests/fm-afk-launch.test.sh has one pre-existing herdr-lab e2e failure (could not prepare isolated lab session) that reproduces identically on baseline HEAD; it is out of scope and was deliberately not touched, because this task was explicitly dispatched without Herdr lifecycle authorization.

Evidence and repo conventions: root cause is proven failing-then-passing (with the daemon reverted to HEAD the suite fails at "max-defer did not deliver past a busy pane"), regression coverage lives in tests/fm-daemon.test.sh (110 assertions green), and end-to-end proof of both entry outcomes is tests/fm-afk-inject-e2e.test.sh Scenario D against a real tmux pane and a real daemon in an isolated state directory. Per this repo firstmate-coding-guidelines, harness-dependent behavior also gets a dated maintainer-verification record, which is the docs/verification/supervision.md addition; docs/wedge-alarm.md and the /afk skill were updated as the affected contract owners. bin/fm-lint.sh and bin/fm-doc-audience-check.sh are clean.

## What Changed

- Replaced the unbounded single-source busy veto in `bin/fm-supervise-daemon.sh` with `pane_busy_verdict`, which corroborates the harness agent-state against the rendered pane signature (busy requires corroboration; a legible idle on either signal wins) and publishes `PANE_BUSY_SOURCE` for deferral logs. The max-defer escape now flushes with `FM_INJECT_IGNORE_BUSY=1` so it bypasses the same guard that deferred, while the empty-composer guard and verified type-once submit still protect pane contents (pinned by `test_busy_guard_escape_still_respects_a_pending_composer`).
- The max-defer wedge alarm's `auto`/`default` channel now resolves to the existing herdr channel off macOS when the herdr CLI is installed, instead of silently firing into macOS Notification Center on Linux.
- Away-mode entry now proves delivery: the daemon injects a marked no-op self-test message at startup (retried within a bounded `FM_DELIVERY_SELFTEST_SECS` window, with the shutdown trap installed before the self-test runs) and records ok/failed/skipped in `state/.subsuper-delivery-selftest`; `bin/fm-afk-launch.sh verify` fails away-mode entry and names the stop rollback when that proof is absent. Covered by new `tests/fm-daemon.test.sh` assertions and e2e Scenario D in `tests/fm-afk-inject-e2e.test.sh`, with docs updated in `docs/wedge-alarm.md`, `docs/verification/supervision.md`, and the `/afk` skill.

## Risk Assessment

✅ Low: All three prior findings were fixed exactly as instructed (durable failed verdict on startup validation failure with a hardened non-vacuous tmux probe, trap installed before the self-test window, bounded unit-test retry), and a sweep of every fake-tmux consumer of the stricter fm_backend_target_exists probe plus the verify/clear/docs contract owners found no new issues.</risk_rationale>

## Testing

Ran the targeted daemon unit suite (110 assertions green), reproduced the wedge by reverting only the daemon to baseline (suite fails exactly at "max-defer did not deliver past a busy pane") then confirmed the fix passes, ran the real-tmux end-to-end injection suite where Scenario D demonstrates both away-mode entry outcomes including the operator-visible delivery-verified message, and confirmed the one fm-afk-launch herdr-lab failure reproduces identically on baseline HEAD so it is pre-existing and out of scope as stated; no UI surface is involved, so evidence is CLI transcripts and durable state verdicts rather than screenshots.

<details>
<summary>Evidence: Failing-then-passing proof: fm-daemon suite against baseline daemon fails at the wedge</summary>

<code>ok - max-defer flushes and clears the buffer on an empty bordered pane&#10;not ok - max-defer did not deliver past a busy pane:&#10;(exit=1; same suite on the fixed daemon: exit=0, 110 ok)</code>

```text
ok - fm-afk-start.sh fails before daemon startup when the afk flag cannot be written
ok - fm-afk-start.sh ignores stale pidfile-only live pids
ok - fm-afk-start.sh reclaims stale daemon locks whose live pid identity no longer matches
ok - supervise daemon state root is scoped by FM_HOME
ok - routine signal self-handles
ok - captain-relevant status verbs escalate
ok - check + unknown escalate; heartbeat self-handles
ok - transient stale self-handles and records a persistence marker
ok - enriched stale wedges bypass status absorption without disturbing busy workers
ok - stale + terminal status escalates immediately
ok - paused reasons with captain phrases remain pause-classified
ok - a captain-held transfer classifies as pause, not as a wedge candidate
ok - handle_wake on a paused stale records a pause marker, drops the wedge marker, and does not escalate
ok - handle_wake records a declared pause from a routine signal for long-cadence rechecks
ok - a terminal signal clears pause and stale tracking across both supervisors
ok - housekeeping migrates a normal-watcher's declared pause into daemon tracking
ok - housekeeping clears an already-resumed watcher pause across both supervisors
ok - housekeeping seeds pause tracking from status without a watcher marker
ok - persistent stale escalates after threshold and clears its marker
ok - resumed (busy) stale clears its marker without escalating
ok - housekeeping re-surfaces a stale declared pause on the long cadence and resets its window
ok - housekeeping re-surfaces a forgotten captain hold on the long cadence and resets its window
ok - housekeeping clears a paused marker whose pane became busy again, without escalating
ok - housekeeping clears a paused marker once the crew is no longer declaring the pause
ok - housekeeping clears the pause marker once a captain hold is answered
ok - housekeeping moves an existing stale marker to pause before wedge escalation
ok - housekeeping moves a captain hold's existing stale marker to pause before wedge escalation
ok - housekeeping clears tracking when a crew leaves pause
ok - persistent herdr stale resolves the target from metadata and escalates
ok - herdr idle busy-footer stale clears through capture corroboration
ok - resumed herdr stale clears through backend-aware busy state
ok - persistent Orca stale resolves the terminal from metadata
ok - multiple escalations flush as a single batched digest
ok - batch flush measures max-delay from the first append, not the last
ok - catch-all scan escalates a missed terminal once, not twice
ok - handle_wake routes routine->self and captain->escalate
ok - INJECT_SKIP forces self-handle, bypassing captain-relevant classification
ok - is_wake_reason distinguishes watcher wake reasons from singleton-status stdout
ok - terminal-stale escalate removes its marker so housekeeping does not re-escalate
ok - captain signal escalate marks seen so the catch-all scan does not re-fire
ok - _collapse_newlines replaces newlines with literal separator
ok - afk flag absent: daemon does not inject, buffer preserved
ok - busy-guard defers injection when supervisor pane is busy
ok - marker detection: marker -> stay afk, no marker -> exit afk
ok - /afk invocation is exempt from afk exit (no self-cancel)
ok - should_exit_afk returns false when afk is not active
ok - strip_injection_marker removes the sentinel marker cleanly
ok - pane_input_pending detects partial input on the cursor line
ok - pane_input_pending: a blank unidentified cursor row defers (strict container-proof rule)
ok - pane_input_pending: only proven empty agent prompts pass
ok - fm_tmux_composer_state: a bare shell prompt ($/%/#/>) reads unknown, never empty (dead-shell injection safety)
ok - fm_tmux_composer_state: a bordered composer box and bare agent glyphs (❯/›) still read empty
ok - fm_tmux_composer_state: only matching edge borders form a composer box
ok - pane_input_pending preserves bright placeholder-like drafts in styled captures
ok - classify_signal dedupes against the catch-all scan seen marker
ok - classify_stale dedupes against the signal path seen marker
ok - AFK nonterminal working:+merged keeps wedge aging and re-escalates at bound
ok - genuine done: and merge-check events still escalate
ok - pane_input_pending: an idle bordered composer is NOT pending (afk-invx-i5)
ok - pane_input_pending: text inside a bordered composer is still pending
ok - submit-ACK confirms a submit when the composer returns to a bordered-empty box
ok - submit-ACK reports pending on a persistently swallowed Enter (type-once)
ok - max-defer on an empty stuck pane types once, alarms, and preserves the buffer
ok - max-defer flushes and clears the buffer on an empty bordered pane
not ok - max-defer did not deliver past a busy pane: 
```
</details>
<details>
<summary>Evidence: E2E: real tmux pane, real daemon — Scenario D proves both away-mode entry outcomes</summary>

<code>ok - Scenario A: partial input defers injection; digest arrives clean after idle&#10;ok - Scenario B: swallowed Enter produces exactly one clean digest&#10;ok - Scenario C: a normal captain status injects exactly one clean single-line sentinel digest&#10;fm-afk-launch: away-mode delivery verified: one escalation confirmed into the captain pane&#10;ok - Scenario D: away-mode entry proves one delivery and refuses when it cannot&#10;all e2e injection tests passed</code>

```text
ok - Scenario A: partial input defers injection; digest arrives clean after idle
ok - Scenario B: swallowed Enter produces exactly one clean digest
ok - Scenario C: a normal captain status injects exactly one clean single-line sentinel digest
fm-afk-launch: away-mode delivery verified: one escalation confirmed into the captain pane
ok - Scenario D: away-mode entry proves one delivery and refuses when it cannot
all e2e injection tests passed
```
</details>
<details>
<summary>Evidence: fm-daemon suite on target commit (110 assertions, exit 0)</summary>

```text
ok - fm-afk-start.sh fails before daemon startup when the afk flag cannot be written
ok - fm-afk-start.sh ignores stale pidfile-only live pids
ok - fm-afk-start.sh reclaims stale daemon locks whose live pid identity no longer matches
ok - supervise daemon state root is scoped by FM_HOME
ok - routine signal self-handles
ok - captain-relevant status verbs escalate
ok - check + unknown escalate; heartbeat self-handles
ok - transient stale self-handles and records a persistence marker
ok - enriched stale wedges bypass status absorption without disturbing busy workers
ok - stale + terminal status escalates immediately
ok - paused reasons with captain phrases remain pause-classified
ok - a captain-held transfer classifies as pause, not as a wedge candidate
ok - handle_wake on a paused stale records a pause marker, drops the wedge marker, and does not escalate
ok - handle_wake records a declared pause from a routine signal for long-cadence rechecks
ok - a terminal signal clears pause and stale tracking across both supervisors
ok - housekeeping migrates a normal-watcher's declared pause into daemon tracking
ok - housekeeping clears an already-resumed watcher pause across both supervisors
ok - housekeeping seeds pause tracking from status without a watcher marker
ok - persistent stale escalates after threshold and clears its marker
ok - resumed (busy) stale clears its marker without escalating
ok - housekeeping re-surfaces a stale declared pause on the long cadence and resets its window
ok - housekeeping re-surfaces a forgotten captain hold on the long cadence and resets its window
ok - housekeeping clears a paused marker whose pane became busy again, without escalating
ok - housekeeping clears a paused marker once the crew is no longer declaring the pause
ok - housekeeping clears the pause marker once a captain hold is answered
ok - housekeeping moves an existing stale marker to pause before wedge escalation
ok - housekeeping moves a captain hold's existing stale marker to pause before wedge escalation
ok - housekeeping clears tracking when a crew leaves pause
ok - persistent herdr stale resolves the target from metadata and escalates
ok - herdr idle busy-footer stale clears through capture corroboration
ok - resumed herdr stale clears through backend-aware busy state
ok - persistent Orca stale resolves the terminal from metadata
ok - multiple escalations flush as a single batched digest
ok - batch flush measures max-delay from the first append, not the last
ok - catch-all scan escalates a missed terminal once, not twice
ok - handle_wake routes routine->self and captain->escalate
ok - INJECT_SKIP forces self-handle, bypassing captain-relevant classification
ok - is_wake_reason distinguishes watcher wake reasons from singleton-status stdout
ok - terminal-stale escalate removes its marker so housekeeping does not re-escalate
ok - captain signal escalate marks seen so the catch-all scan does not re-fire
ok - _collapse_newlines replaces newlines with literal separator
ok - afk flag absent: daemon does not inject, buffer preserved
ok - busy-guard defers injection when supervisor pane is busy
ok - marker detection: marker -> stay afk, no marker -> exit afk
ok - /afk invocation is exempt from afk exit (no self-cancel)
ok - should_exit_afk returns false when afk is not active
ok - strip_injection_marker removes the sentinel marker cleanly
ok - pane_input_pending detects partial input on the cursor line
ok - pane_input_pending: a blank unidentified cursor row defers (strict container-proof rule)
ok - pane_input_pending: only proven empty agent prompts pass
ok - fm_tmux_composer_state: a bare shell prompt ($/%/#/>) reads unknown, never empty (dead-shell injection safety)
ok - fm_tmux_composer_state: a bordered composer box and bare agent glyphs (❯/›) still read empty
ok - fm_tmux_composer_state: only matching edge borders form a composer box
ok - pane_input_pending preserves bright placeholder-like drafts in styled captures
ok - classify_signal dedupes against the catch-all scan seen marker
ok - classify_stale dedupes against the signal path seen marker
ok - AFK nonterminal working:+merged keeps wedge aging and re-escalates at bound
ok - genuine done: and merge-check events still escalate
ok - pane_input_pending: an idle bordered composer is NOT pending (afk-invx-i5)
ok - pane_input_pending: text inside a bordered composer is still pending
ok - submit-ACK confirms a submit when the composer returns to a bordered-empty box
ok - submit-ACK reports pending on a persistently swallowed Enter (type-once)
ok - max-defer on an empty stuck pane types once, alarms, and preserves the buffer
ok - max-defer flushes and clears the buffer on an empty bordered pane
ok - max-defer escape delivers past a busy verdict instead of re-running the guard that deferred
ok - busy guard vetoes an ordinary injection but yields to the bounded escape on the same pane
ok - bounded busy-guard escape still defers on a pending composer
ok - delivery_selftest proves one injection and records a durable ok
ok - delivery_selftest records a durable failure and alarms when delivery cannot be proven
ok - fm-afk-launch verify passes on a proven delivery and fails loudly otherwise
ok - max-defer on a pending composer alarms without typing
ok - normal flush clears a stale wedge marker
ok - below MAX_DEFER: no inject, no alarm, buffer preserved
ok - max-defer does not flush or alarm while afk is inactive
ok - library mode: sourcing the daemon defaults FM_WEDGE_ALARM_EXEC to discard (no test can fire a real notification)
ok - wake helpers replace inherited notifier overrides with the safe recorder
ok - the discard seam suppresses every notifier, including command: (fires nothing)
ok - direct notifier helpers honor the discard seam, including command:
ok - osascript channel routes through the notifier seam with the summary (never a real notification)
ok - herdr channel routes through the notifier seam with the summary (never a real notification)
ok - command channel runs the captain command with the summary on $1 and on stdin
ok - command channel failures redact configured commands while logging their exit status
ok - unknown channel directives are redacted while the alarm keeps running
ok - off disables every active alert regardless of directive position (marker and tmux flash are unaffected)
ok - auto resolves to the macOS osascript notifier on Darwin (default-on)
ok - auto off macOS uses an installed herdr notifier and selects nothing when none exists
ok - config/wedge-alarm selects every configured channel and skips comment and blank lines
ok - a failing channel logs and falls back to the next channel, never crashing the alarm
ok - a hung notifier is bounded, logged, and falls through to the next channel
ok - a backgrounded command notifier remains bounded until its process group is reaped
ok - a hung notifier override is bounded, logged, and proceeds to the next channel
[1]+  Terminated              sh -c 'sleep 30 & printf "%s" "$!" > "$1"; wait' sh "$child_file"
ok - daemon shutdown stops and reaps the active notifier process group
ok - inject_wedge_alarm writes the marker AND emits the active alert even with no tmux status-line (herdr backend)
ok - in-process wedge throttle prevents alert spam when the marker cannot persist
ok - fm-send returns 3 with a non-error no-resend warning when confirmation stays pending
ok - fm-send exits non-zero when initial text send fails
ok - fm-send exits non-zero unless delivery is proven empty
ok - discover_supervisor_backend: override > TMUX_PANE > HERDR_ENV+HERDR_PANE_ID > tmux fallback
ok - discover_supervisor_target: override > TMUX_PANE > herdr '<session>:<pane-id>' composition > firstmate:0 fallback
ok - pane_busy_verdict: busy needs corroboration, a legible idle on either signal wins, and each verdict names its signal
ok - pane_is_busy: agrees with pane_busy_verdict and publishes its signal for the deferral log
ok - primary busy guard isolates rendered signatures by detected harness
ok - pane_is_busy: omitted backend defaults to tmux for Grok's isolated fallback
ok - pane_input_pending: dispatches through fm_backend_composer_state for backend=herdr
ok - inject_msg: herdr busy-guard defers before ever attempting a submit
ok - inject_msg: herdr composer-guard defers before ever attempting a submit
ok - inject_msg: herdr pane-gone check defers before any busy/composer/submit call
ok - inject_msg: dispatches busy-guard/composer-guard/submit through the herdr backend and succeeds on a confirmed empty composer
ok - inject_msg: defers on a dead-shell/unreadable composer (unknown), never typing the escalation into a shell
ok - inject_msg: unrecognized composer states defer by default
```
</details>
<details>
<summary>Evidence: fm-afk-launch suite on target — sole failure is the herdr-lab prep</summary>

```text
ok - clear-stale: removes escalations buffer, sidecar, and wedge marker
ok - clear-stale: leaves the durable wake-queue intact (no pending work dropped)
ok - launcher paths: relative home and state ignore CDPATH before daemon command construction
ok - launcher paths: absolute symlink spellings are preserved
ok - launcher paths: unresolved relative FM_HOME fails loudly
ok - launcher paths: unresolved relative FM_STATE_OVERRIDE fails loudly
ok - refresh: daemon already alive - stale artifacts preserved (current session's buffer kept)
ok - stop-ordering: daemon SIGTERM'd while .afk still present (flush is not a no-op)
ok - stop-ordering: .afk cleared last
ok - stop-ordering: daemon-terminal record removed
ok - stop identity: stale lock cannot signal an unrelated live process
ok - failed start: away flag and delivery artifacts roll back
ok - concurrent start: one serialized daemon terminal remains tracked
ok - launcher lock: incomplete publication receives initialization grace
ok - launcher signal: TERM exits and releases the lifecycle lock
fm-afk-launch: daemon launched in non-visible herdr workspace ws-partial (pane lab:pane-exact), supervising lab:captain
ok - herdr create: malformed response recovers durable exact ownership
fm-afk-launch: herdr create failed after returning exact ids; closing lab:pane-exact
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - herdr create error: unconfirmed exact id is persisted for reconciliation
fm-afk-launch: failed to run daemon in herdr pane lab:pane-exact; closing it
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - herdr run failure: unconfirmed exact id remains reconcilable
fm-afk-launch: failed to persist daemon terminal record; closing tmux:exact-session
ok - record failure: newly created terminal is closed by exact id
fm-afk-launch: daemon did not become ready; closing tmux:exact-session
ok - readiness failure: exact terminal and durable record roll back
fm-afk-launch: daemon did not become ready; closing tmux:exact-session
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - readiness failure: unconfirmed terminal retains its reconciliation id
ok - tmux absence: clean missing differs from transport probe failure
ok - native lifecycle: launcher owns state with no terminal
ok - native lifecycle: uniform stop clears state without closing a terminal
ok - native entry: launcher-prepared lifecycle state is not rewritten
fm-afk-launch: reconciling leaked daemon terminal tmux:exact-session
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - teardown failure: exact terminal record is preserved
ok - record publication: failed atomic rename preserves the complete prior record
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
ok - record read: malformed record fails closed without acting on a partial id
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
fm-afk-launch: malformed daemon terminal record; refusing to stop away mode
ok - stop: malformed terminal record preserves away state and fails closed
fm-afk-launch: failed to create detached tmux daemon session 'fm-afk-daemon-1797726036-940723-11365-1787573978'
ok - tmux launch: planned exact target is recorded before creation and removed on failure
fm-afk-launch: failed to create detached tmux daemon session 'fm-afk-daemon-235536195-940754-24711-1787573978'
ok - tmux launch: unique names eliminate collision teardown
ok - stop validation: malformed record causes no daemon or state side effects
ok - launcher lock: incomplete metadata fails acquisition and releases lock
fm-afk-launch: failed to clear away-mode flag
fm-afk-launch: away mode stopped; terminal teardown remains recorded for retry
ok - stop state: away-flag removal failure is surfaced
fm-afk-launch: away-mode daemon did not exit after SIGTERM; preserving lifecycle state
ok - stop liveness: captured live daemon preserves lifecycle state after lock release
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
ok - refresh record: malformed terminal identity fails closed
fm-afk-launch: failed to clear stale away-mode artifacts
ok - clear failure: native entry aborts and restores prior state
fm-afk-launch: reconciling leaked daemon terminal tmux:exact-session
fm-afk-launch: terminal close command failed, but exact absence was confirmed
ok - confirmed absence: cleanup succeeds and removes the stale record
fm-afk-launch: rollback restoration incomplete; backup retained at /tmp/fm-afk-restore-fail.9Ey4Si/state/.afk-launch-backup.VP5iL5
ok - rollback restore: incomplete restoration retains its recovery backup
ok - flag failure: lifecycle aborts without active state
fm-herdr-lab: fleet-state tripwire requires exactly one running default session
not ok - herdr e2e: could not prepare isolated lab session
ok - tmux e2e: captain window pane count unchanged after start (no split-window)
ok - tmux e2e: daemon launched in a separate detached session
ok - tmux e2e: captain window pane count unchanged after stop
ok - tmux e2e: daemon session killed by exact id on stop
ok - tmux e2e: record + .afk cleared on stop
```
</details>
<details>
<summary>Evidence: fm-afk-launch suite on baseline 038d0f7 — identical sole failure (pre-existing)</summary>

<code>not ok - herdr e2e: could not prepare isolated lab session&#10;(exit=1, 45 ok — identical to target commit run)</code>

```text
ok - clear-stale: removes escalations buffer, sidecar, and wedge marker
ok - clear-stale: leaves the durable wake-queue intact (no pending work dropped)
ok - launcher paths: relative home and state ignore CDPATH before daemon command construction
ok - launcher paths: absolute symlink spellings are preserved
ok - launcher paths: unresolved relative FM_HOME fails loudly
ok - launcher paths: unresolved relative FM_STATE_OVERRIDE fails loudly
ok - refresh: daemon already alive - stale artifacts preserved (current session's buffer kept)
ok - stop-ordering: daemon SIGTERM'd while .afk still present (flush is not a no-op)
ok - stop-ordering: .afk cleared last
ok - stop-ordering: daemon-terminal record removed
ok - stop identity: stale lock cannot signal an unrelated live process
ok - failed start: away flag and delivery artifacts roll back
ok - concurrent start: one serialized daemon terminal remains tracked
ok - launcher lock: incomplete publication receives initialization grace
ok - launcher signal: TERM exits and releases the lifecycle lock
fm-afk-launch: daemon launched in non-visible herdr workspace ws-partial (pane lab:pane-exact), supervising lab:captain
ok - herdr create: malformed response recovers durable exact ownership
fm-afk-launch: herdr create failed after returning exact ids; closing lab:pane-exact
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - herdr create error: unconfirmed exact id is persisted for reconciliation
fm-afk-launch: failed to run daemon in herdr pane lab:pane-exact; closing it
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - herdr run failure: unconfirmed exact id remains reconcilable
fm-afk-launch: failed to persist daemon terminal record; closing tmux:exact-session
ok - record failure: newly created terminal is closed by exact id
fm-afk-launch: daemon did not become ready; closing tmux:exact-session
ok - readiness failure: exact terminal and durable record roll back
fm-afk-launch: daemon did not become ready; closing tmux:exact-session
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - readiness failure: unconfirmed terminal retains its reconciliation id
ok - tmux absence: clean missing differs from transport probe failure
ok - native lifecycle: launcher owns state with no terminal
ok - native lifecycle: uniform stop clears state without closing a terminal
ok - native entry: launcher-prepared lifecycle state is not rewritten
fm-afk-launch: reconciling leaked daemon terminal tmux:exact-session
fm-afk-launch: recorded terminal teardown is unconfirmed; preserving exact id
ok - teardown failure: exact terminal record is preserved
ok - record publication: failed atomic rename preserves the complete prior record
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
ok - record read: malformed record fails closed without acting on a partial id
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
fm-afk-launch: malformed daemon terminal record; refusing to stop away mode
ok - stop: malformed terminal record preserves away state and fails closed
fm-afk-launch: failed to create detached tmux daemon session 'fm-afk-daemon-2142599072-961178-10719-1787574040'
ok - tmux launch: planned exact target is recorded before creation and removed on failure
fm-afk-launch: failed to create detached tmux daemon session 'fm-afk-daemon-3874677644-961209-30792-1787574040'
ok - tmux launch: unique names eliminate collision teardown
ok - stop validation: malformed record causes no daemon or state side effects
ok - launcher lock: incomplete metadata fails acquisition and releases lock
fm-afk-launch: failed to clear away-mode flag
fm-afk-launch: away mode stopped; terminal teardown remains recorded for retry
ok - stop state: away-flag removal failure is surfaced
fm-afk-launch: away-mode daemon did not exit after SIGTERM; preserving lifecycle state
ok - stop liveness: captured live daemon preserves lifecycle state after lock release
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
fm-afk-launch: daemon terminal record is malformed; refusing to act on it
ok - refresh record: malformed terminal identity fails closed
fm-afk-launch: failed to clear stale away-mode artifacts
ok - clear failure: native entry aborts and restores prior state
fm-afk-launch: reconciling leaked daemon terminal tmux:exact-session
fm-afk-launch: terminal close command failed, but exact absence was confirmed
ok - confirmed absence: cleanup succeeds and removes the stale record
fm-afk-launch: rollback restoration incomplete; backup retained at /tmp/fm-afk-restore-fail.GxX2Db/state/.afk-launch-backup.Y3LT9d
ok - rollback restore: incomplete restoration retains its recovery backup
ok - flag failure: lifecycle aborts without active state
fm-herdr-lab: fleet-state tripwire requires exactly one running default session
not ok - herdr e2e: could not prepare isolated lab session
ok - tmux e2e: captain window pane count unchanged after start (no split-window)
ok - tmux e2e: daemon launched in a separate detached session
ok - tmux e2e: captain window pane count unchanged after stop
ok - tmux e2e: daemon session killed by exact id on stop
ok - tmux e2e: record + .afk cleared on stop
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- 🚨 `tests/fm-afk-inject-e2e.test.sh:475` - Scenario D&#39;s undeliverable-pane half cannot pass as written: it starts the daemon with SUPERVISOR_TARGET_OVERRIDE=&#39;%99999&#39;, but the daemon validates the target at startup (bin/fm-supervise-daemon.sh:1559, `fm_backend_target_exists` -&gt; `tmux display-message -p -t %99999`, which fails through the e2e shim against the real private-socket tmux) and exits before `delivery_selftest` at line 1573 ever runs. No `failed` verdict is written, so `wait_for_selftest_verdict failed` times out, and the pidfile is removed on that exit so `start_daemon` usually fails first at &#39;daemon did not start&#39;. This contradicts the intent&#39;s evidence claim that Scenario D &#39;proves both directions end to end&#39;. It also means the daemon&#39;s `failed` verdict path is unreachable for a nonexistent-pane entry in production (verify still fails safe, but only via its 90s timeout with the generic &#39;did not report&#39; message). The failure half needs a shape the daemon can survive startup with, e.g. a pane killed after startup validation or a permanently pending composer.
- ⚠️ `bin/fm-supervise-daemon.sh:1573` - delivery_selftest runs before the shutdown trap is installed: it is called at bin/fm-supervise-daemon.sh:1573 while the singleton lock and pidfile are held, but `trap cleanup TERM INT` is not installed until line 1593. The self-test retries for up to FM_DELIVERY_SELFTEST_SECS (default 45s), so a SIGTERM in that window - including the `fm-afk-launch.sh stop` rollback prescribed on entry failure, arriving during a slow entry - kills the daemon by default action, leaking the lock directory and pidfile and skipping the shutdown flush. Before this change the unprotected lock-to-trap window was microseconds. Fix: move the `delivery_selftest &#34;$STATE&#34; || true` call below `trap cleanup TERM INT` (cleanup already tolerates empty WATCHER_PID/CUR_TMP).
- ℹ️ `tests/fm-daemon.test.sh:1359` - test_delivery_selftest_records_failure_and_alarms never overrides FM_DELIVERY_SELFTEST_SECS/FM_DELIVERY_SELFTEST_SLEEP, so delivery_selftest retries the unreachable-pane injection for the full 45s default window (15 attempts at 3s intervals) before recording `failed` - adding ~45s of wall-clock to every fm-daemon.test.sh run. Passing FM_DELIVERY_SELFTEST_SECS=1 FM_DELIVERY_SELFTEST_SLEEP=1 in the test keeps the assertions identical and fast (the e2e Scenario D already does exactly this).

🔧 Fix: record startup delivery failures, trap before selftest, fix vacuous tmux probe
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-daemon.test.sh` on target commit — exit 0, 110 assertions, covering pane_busy_verdict corroboration, PANE_BUSY_SOURCE deferral logging, bounded max-defer escape, escape-respects-pending-composer safety boundary, delivery_selftest ok/failed verdicts, fm-afk-launch verify gate, and herdr auto-channel resolution off macOS</code>
- <code>Failing-then-passing proof: `git checkout 038d0f7 -- bin/fm-supervise-daemon.sh &amp;&amp; bash tests/fm-daemon.test.sh` — exit 1 failing at `not ok - max-defer did not deliver past a busy pane`, then restored daemon passes</code>
- <code>`bash tests/fm-afk-inject-e2e.test.sh` — real tmux pane + real daemon on a private socket; Scenarios A–C plus Scenario D (entry self-test ok path with operator-visible verify success message, gone-pane failed verdict, pending-composer failed verdict, verify rejecting both failure paths); exit 0</code>
- <code>`bash tests/fm-afk-launch.test.sh` on target (exit 1, sole failure `herdr e2e: could not prepare isolated lab session`, 45 ok) and on a pristine baseline-038d0f7 extraction (identical sole failure, 45 ok) — confirms the failure is pre-existing and not a regression</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
