### PR TITLE
fix(bin): recognize omp's Claude identity for session-lock ownership

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -57,6 +57,10 @@ When verifying a new adapter, record its env marker and command name in `bin/fm-
 For stuck recovery, the target window's harness is recorded as `harness=` in `state/<id>.meta`.
 Use that value for interrupt, exit, resume, and skill-invocation facts.
 
+`bin/fm-session-lock-lib.sh` separately recognizes an `omp` (Oh My Pi) process as Claude-identified for session-lock ownership only, gated strictly on `CLAUDECODE=1` (never a bare `omp` name match), because omp runs on the same underlying Claude Agent SDK but is not itself a verified harness.
+This is scoped narrowly to lock identity: omp's Stop/PreToolUse hook firing, watcher auto-rearm, and busy-state detection are unverified, and `omp` is not added to `FM_HARNESS_RE`/`FM_HARNESS_NAMES` or any verified-harness table used for spawning crewmates/secondmates.
+See `bin/fm-session-lock-lib.sh` and `tests/fm-session-lock-ancestry.test.sh`.
+
 ## Primary turn-end guard
 
 The primary integrations for `claude`, `codex`, `opencode`, `pi`, `pi-signed`, `grok`, and `cursor` have empirically validated hook paths for the "no turn ends blind" guard.

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -58,8 +58,9 @@ For stuck recovery, the target window's harness is recorded as `harness=` in `st
 Use that value for interrupt, exit, resume, and skill-invocation facts.
 
 `bin/fm-session-lock-lib.sh` separately recognizes an `omp` (Oh My Pi) process as Claude-identified for session-lock ownership only, gated strictly on `CLAUDECODE=1` (never a bare `omp` name match), because omp runs on the same underlying Claude Agent SDK but is not itself a verified harness.
+`CLAUDECODE` is only ever read from the calling process's own environment, so the gate applies only while identifying the caller's own ancestry (`self=1`); a foreign lock-holder pid is verified against the persisted marker `bin/fm-lock.sh` records at acquisition time, never the checker's own ambient environment, and the ancestry walk deliberately does not extend past omp's own process.
 This is scoped narrowly to lock identity: omp's Stop/PreToolUse hook firing, watcher auto-rearm, and busy-state detection are unverified, and `omp` is not added to `FM_HARNESS_RE`/`FM_HARNESS_NAMES` or any verified-harness table used for spawning crewmates/secondmates.
-See `bin/fm-session-lock-lib.sh` and `tests/fm-session-lock-ancestry.test.sh`.
+See `bin/fm-session-lock-lib.sh`, `tests/fm-session-lock-ancestry.test.sh`, the live guard `tests/fm-omp-session-lock-live-e2e.test.sh`, and [`docs/verification/runtime-backends.md`](../../../docs/verification/runtime-backends.md) "omp (session-lock identity)".
 
 ## Primary turn-end guard
 

--- a/bin/fm-claude-stop-autoarm.sh
+++ b/bin/fm-claude-stop-autoarm.sh
@@ -112,7 +112,7 @@ if ! fm_session_lock_owned_by_self "$STATE"; then
   case "$LOCK_PID" in
     ''|*[!0-9]*) exit 0 ;;
   esac
-  fm_harness_pid_alive "$LOCK_PID" && exit 0
+  fm_harness_pid_alive "$LOCK_PID" "$STATE" && exit 0
   RECOVER_SESSION_LOCK=1
 fi
 

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -107,7 +107,16 @@ fi
 # identity (see fm_harness_pid_alive), so persist that verification now, in
 # the one context - the writer's own environment, immediately after winning
 # the lock - where it is sound evidence. Runs on every acquisition, omp or
-# not, so a non-omp session correctly clears any stale prior record.
-fm_harness_record_omp_claude "$STATE" "$me"
+# not, so a non-omp session correctly clears any stale prior record. A write
+# failure here means no foreign session can ever prove $me alive, so it must
+# fail the whole acquisition rather than leave $LOCK claiming an identity
+# nothing else can verify - and $LOCK is removed rather than left in place,
+# so a later invocation from this same session cannot short-circuit past the
+# broken marker write via the "$old" = "$me" fast path above.
+if ! fm_harness_record_omp_claude "$STATE" "$me"; then
+  rm -f "$LOCK" 2>/dev/null || true
+  echo "error: cannot persist omp session-lock identity marker; operate read-only until resolved" >&2
+  exit 1
+fi
 release_claim_lock
 echo "lock acquired: harness pid $me"

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -29,7 +29,7 @@ if [ "${1:-}" = "status" ]; then
     echo "lock: unreadable"
     exit 0
   }
-  if fm_harness_pid_alive "$old"; then echo "lock: held by live harness pid $old"; else echo "lock: stale (pid $old dead or not a harness)"; fi
+  if fm_harness_pid_alive "$old" "$STATE"; then echo "lock: held by live harness pid $old"; else echo "lock: stale (pid $old dead or not a harness)"; fi
   exit 0
 fi
 
@@ -61,7 +61,7 @@ if [ -f "$LOCK" ] && [ ! -L "$LOCK" ]; then
     echo "lock acquired: harness pid $me"
     exit 0
   fi
-  if fm_harness_pid_alive "$old"; then
+  if fm_harness_pid_alive "$old" "$STATE"; then
     echo "error: another live firstmate session holds the lock (pid $old); operate read-only until resolved" >&2
     exit 1
   fi
@@ -86,7 +86,7 @@ if [ -e "$LOCK" ] || [ -L "$LOCK" ]; then
     echo "error: session lock is unreadable; operate read-only until resolved" >&2
     exit 1
   }
-  if [ "$old" != "$me" ] && fm_harness_pid_alive "$old"; then
+  if [ "$old" != "$me" ] && fm_harness_pid_alive "$old" "$STATE"; then
     echo "error: another live firstmate session holds the lock (pid $old); operate read-only until resolved" >&2
     exit 1
   fi
@@ -103,5 +103,11 @@ if [ ! -f "$LOCK" ] || [ -L "$LOCK" ] || [ "$written" != "$me" ]; then
   echo "error: session lock ownership verification failed; operate read-only until resolved" >&2
   exit 1
 fi
+# A foreign session cannot later read $me's own $CLAUDECODE to verify an omp
+# identity (see fm_harness_pid_alive), so persist that verification now, in
+# the one context - the writer's own environment, immediately after winning
+# the lock - where it is sound evidence. Runs on every acquisition, omp or
+# not, so a non-omp session correctly clears any stale prior record.
+fm_harness_record_omp_claude "$STATE" "$me"
 release_claim_lock
 echo "lock acquired: harness pid $me"

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -46,7 +46,23 @@ rm -f "$probe" 2>/dev/null || {
 . "$SCRIPT_DIR/fm-wake-lib.sh"
 CLAIM_LOCK="$STATE/.lock.acquire"
 CLAIM_LOCK_HELD=0
+# Set the moment $LOCK is written with $me, cleared only once the whole
+# publication contract (ownership verification and, for an omp holder, the
+# fm_harness_record_omp_claude marker) has completed. If this script is
+# interrupted anywhere in between - a signal, an unexpected error, a crash -
+# the EXIT trap below still fires and must not leave that half-published
+# $LOCK behind: a foreign checker has no way to tell a genuinely interrupted
+# write apart from a legitimately live one, and for an omp holder specifically
+# it cannot verify liveness at all without the marker this invocation never
+# got to write (see fm_harness_pid_alive). Rolling the write back makes an
+# interrupted acquisition look exactly like one that never started.
+LOCK_PUBLISHED_BY_ME=0
+LOCK_PUBLISH_COMPLETE=0
 release_claim_lock() {
+  if [ "$LOCK_PUBLISHED_BY_ME" -eq 1 ] && [ "$LOCK_PUBLISH_COMPLETE" -ne 1 ]; then
+    rm -f "$LOCK" 2>/dev/null || true
+    LOCK_PUBLISHED_BY_ME=0
+  fi
   if [ "$CLAIM_LOCK_HELD" -eq 1 ]; then
     fm_lock_release "$CLAIM_LOCK"
     CLAIM_LOCK_HELD=0
@@ -95,6 +111,7 @@ if ! { printf '%s\n' "$me" > "$LOCK"; } 2>/dev/null; then
   echo "error: cannot write session lock; operate read-only until resolved" >&2
   exit 1
 fi
+LOCK_PUBLISHED_BY_ME=1
 written=$(cat "$LOCK" 2>/dev/null) || {
   echo "error: cannot verify session lock ownership; operate read-only until resolved" >&2
   exit 1
@@ -110,13 +127,15 @@ fi
 # not, so a non-omp session correctly clears any stale prior record. A write
 # failure here means no foreign session can ever prove $me alive, so it must
 # fail the whole acquisition rather than leave $LOCK claiming an identity
-# nothing else can verify - and $LOCK is removed rather than left in place,
-# so a later invocation from this same session cannot short-circuit past the
+# nothing else can verify. LOCK_PUBLISH_COMPLETE stays unset on this path, so
+# the EXIT trap's rollback removes $LOCK - the same rollback that also covers
+# a signal or crash landing anywhere between the write above and here - and a
+# later invocation from this same session cannot short-circuit past the
 # broken marker write via the "$old" = "$me" fast path above.
 if ! fm_harness_record_omp_claude "$STATE" "$me"; then
-  rm -f "$LOCK" 2>/dev/null || true
   echo "error: cannot persist omp session-lock identity marker; operate read-only until resolved" >&2
   exit 1
 fi
+LOCK_PUBLISH_COMPLETE=1
 release_claim_lock
 echo "lock acquired: harness pid $me"

--- a/bin/fm-lock.sh
+++ b/bin/fm-lock.sh
@@ -46,16 +46,17 @@ rm -f "$probe" 2>/dev/null || {
 . "$SCRIPT_DIR/fm-wake-lib.sh"
 CLAIM_LOCK="$STATE/.lock.acquire"
 CLAIM_LOCK_HELD=0
-# Set the moment $LOCK is written with $me, cleared only once the whole
-# publication contract (ownership verification and, for an omp holder, the
-# fm_harness_record_omp_claude marker) has completed. If this script is
-# interrupted anywhere in between - a signal, an unexpected error, a crash -
-# the EXIT trap below still fires and must not leave that half-published
-# $LOCK behind: a foreign checker has no way to tell a genuinely interrupted
-# write apart from a legitimately live one, and for an omp holder specifically
-# it cannot verify liveness at all without the marker this invocation never
-# got to write (see fm_harness_pid_alive). Rolling the write back makes an
-# interrupted acquisition look exactly like one that never started.
+# Set the moment $LOCK is written with $me, cleared only once ownership of
+# that write has been verified. fm_harness_record_omp_claude runs BEFORE
+# $LOCK is ever written (see below) specifically so that $LOCK's own
+# visibility is the single moment publication completes: an untrappable
+# termination (SIGKILL, a crash) can only land before that marker exists, in
+# which case $LOCK itself was never written either, or after both exist. There
+# is no ordering in which $LOCK is visible while the marker a foreign omp
+# checker needs is still missing, so that gap cannot depend on the EXIT trap
+# below. The trap still rolls $LOCK back for the narrower case of a signal or
+# crash landing during the write or its own readback verification, so an
+# interrupted acquisition still looks exactly like one that never started.
 LOCK_PUBLISHED_BY_ME=0
 LOCK_PUBLISH_COMPLETE=0
 release_claim_lock() {
@@ -107,6 +108,21 @@ if [ -e "$LOCK" ] || [ -L "$LOCK" ]; then
     exit 1
   fi
 fi
+# A foreign session cannot later read $me's own $CLAUDECODE to verify an omp
+# identity (see fm_harness_pid_alive), so persist that verification now, in
+# the one context - the writer's own environment, immediately after the
+# no-live-foreign-holder checks above - where it is sound evidence. Runs on
+# every acquisition, omp or not, so a non-omp session correctly clears any
+# stale prior record. Written BEFORE $LOCK: $LOCK is what makes $me
+# discoverable to every other session, so the marker a foreign omp checker
+# needs to verify $me must already exist by the time that happens, not
+# racing to catch up afterward. A write failure here means no foreign
+# session could ever prove $me alive, so it fails the whole acquisition
+# before $LOCK is touched at all - nothing to roll back.
+if ! fm_harness_record_omp_claude "$STATE" "$me"; then
+  echo "error: cannot persist omp session-lock identity marker; operate read-only until resolved" >&2
+  exit 1
+fi
 if ! { printf '%s\n' "$me" > "$LOCK"; } 2>/dev/null; then
   echo "error: cannot write session lock; operate read-only until resolved" >&2
   exit 1
@@ -118,22 +134,6 @@ written=$(cat "$LOCK" 2>/dev/null) || {
 }
 if [ ! -f "$LOCK" ] || [ -L "$LOCK" ] || [ "$written" != "$me" ]; then
   echo "error: session lock ownership verification failed; operate read-only until resolved" >&2
-  exit 1
-fi
-# A foreign session cannot later read $me's own $CLAUDECODE to verify an omp
-# identity (see fm_harness_pid_alive), so persist that verification now, in
-# the one context - the writer's own environment, immediately after winning
-# the lock - where it is sound evidence. Runs on every acquisition, omp or
-# not, so a non-omp session correctly clears any stale prior record. A write
-# failure here means no foreign session can ever prove $me alive, so it must
-# fail the whole acquisition rather than leave $LOCK claiming an identity
-# nothing else can verify. LOCK_PUBLISH_COMPLETE stays unset on this path, so
-# the EXIT trap's rollback removes $LOCK - the same rollback that also covers
-# a signal or crash landing anywhere between the write above and here - and a
-# later invocation from this same session cannot short-circuit past the
-# broken marker write via the "$old" = "$me" fast path above.
-if ! fm_harness_record_omp_claude "$STATE" "$me"; then
-  echo "error: cannot persist omp session-lock identity marker; operate read-only until resolved" >&2
   exit 1
 fi
 LOCK_PUBLISH_COMPLETE=1

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -30,8 +30,10 @@ FM_HARNESS_NAMES=(claude codex opencode grok kimi pi-signed pi)
 # would misclaim an omp session running a different backend. Its Claude
 # identity is instead recognized in fm_harness_process_matches() below, gated
 # strictly on the CLAUDECODE=1 marker the same way fm-harness.sh's own
-# detect_own() already trusts it (env markers before ancestry). Do not widen
-# this to a bare name match.
+# detect_own() already trusts it (env markers before ancestry), and only while
+# identifying the caller's own ancestry - never for an arbitrary foreign pid
+# such as a recorded lock holder, whose actual backend the caller's own
+# environment cannot describe. Do not widen this to a bare name match.
 
 # Print the exact harness name carried by executable path $1 - its own basename
 # or any directory component - or return 1.
@@ -63,11 +65,13 @@ fm_harness_path_name() {  # <path>
 #      argv[0] in `ps -o comm=`, while procps on Linux reports the kernel exec
 #      name and ignores argv[0] entirely, so a version-named Claude Code binary
 #      is identified by its install path on macOS and by argv[0] on Linux.
-#   3. a bare interpreter (node, python) running a harness script path.
-#   4. Cursor's own structural identity, owned by bin/fm-cursor-lib.sh.
+#   3. omp (Oh My Pi), but only when $3 marks this as the caller's own
+#      ancestry walk - see the note below.
+#   4. a bare interpreter (node, python) running a harness script path.
+#   5. Cursor's own structural identity, owned by bin/fm-cursor-lib.sh.
 FM_HARNESS_IS_CLAUDE=0
-fm_harness_process_matches() {  # <comm> <args>
-  local comm=$1 args=$2 base argv0 name
+fm_harness_process_matches() {  # <comm> <args> [self=0]
+  local comm=$1 args=$2 self=${3:-0} base argv0 name
   FM_HARNESS_IS_CLAUDE=0
   base=$(basename -- "$comm")
   if printf '%s' "$base" | grep -qE "$FM_HARNESS_RE"; then
@@ -83,12 +87,19 @@ fm_harness_process_matches() {  # <comm> <args>
   # underlying Claude Agent SDK and sets CLAUDECODE=1 for downstream
   # compatibility, but its own process name is "omp" with no separate
   # "claude"-named process anywhere in its ancestry - there is no nested
-  # worker chain to climb the way native Claude Code has one. Every caller in
-  # this file runs as a descendant of the primary session's own process tree
-  # (the Stop/PreToolUse hook scripts, fm-lock.sh, fm-session-start.sh), so
-  # the marker is reliably inherited here too. Gate strictly on the marker,
-  # never the bare name alone (see the FM_HARNESS_NAMES comment above).
-  if [ "$base" = omp ] && [ "${CLAUDECODE:-}" = "1" ]; then
+  # worker chain to climb the way native Claude Code has one. Gate strictly on
+  # the marker, never the bare name alone (see the FM_HARNESS_NAMES comment
+  # above) - AND gate on $self=1. $CLAUDECODE is always read from the CALLING
+  # process's environment, never the examined pid's: that is sound evidence
+  # only while the examined pid is a verified member of the caller's own
+  # ancestry, since env vars are inherited top-down and the caller would then
+  # carry the same value that pid set. Every caller is responsible for that
+  # verification: fm_harness_ancestry_pids's own walk always passes self=1
+  # because it discovers $pid by climbing $$'s kernel-reported ppid chain, and
+  # fm_harness_pid_alive checks membership in that same walk before passing
+  # self=1 for a lock-file pid, so a pid from a genuinely different session
+  # never borrows the caller's marker.
+  if [ "$base" = omp ] && [ "$self" -eq 1 ] && [ "${CLAUDECODE:-}" = "1" ]; then
     FM_HARNESS_IS_CLAUDE=1
     return 0
   fi
@@ -132,7 +143,10 @@ fm_harness_ancestry_pids() {
   for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
     args=$(ps -o args= -p "$pid" 2>/dev/null)
-    if fm_harness_process_matches "$comm" "$args"; then
+    # self=1: $pid was reached by walking $$'s own kernel-reported ppid chain,
+    # so it is a verified ancestor of the caller - the one case where the
+    # caller's own $CLAUDECODE is sound evidence about $pid's backend.
+    if fm_harness_process_matches "$comm" "$args" 1; then
       printf '%s\n' "$pid"
       printed=1
       [ "$FM_HARNESS_IS_CLAUDE" -eq 1 ] || break
@@ -165,12 +179,30 @@ EOF
 }
 
 # True if $1 is a live process that looks like a verified harness.
-fm_harness_pid_alive() {
-  local pid=$1 comm args
+#
+# $1 is read from a lock file and may belong to an entirely different session
+# than the caller - the whole point of this check is telling a live competing
+# session apart from a dead one. fm_harness_process_matches's omp branch trusts
+# the caller's own $CLAUDECODE, which is sound only when $1 actually IS a
+# verified ancestor of the caller (env vars are inherited top-down, so the
+# caller would carry the same value that ancestor set); it says nothing about
+# an unrelated pid that merely happens to be recorded in the lock file. So
+# self is computed here by checking $1 for membership in this process's own
+# fm_harness_ancestry_pids(), the same membership test fm_session_lock_owned_by_self
+# already uses to answer the identical question - never assumed from the
+# caller's context.
+fm_harness_pid_alive() {  # <pid>
+  local pid=$1 comm args self=0 ancestry ap
   kill -0 "$pid" 2>/dev/null || return 1
   comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
   args=$(ps -o args= -p "$pid" 2>/dev/null)
-  fm_harness_process_matches "$comm" "$args"
+  ancestry=$(fm_harness_ancestry_pids 2>/dev/null) || true
+  while IFS= read -r ap; do
+    [ "$ap" = "$pid" ] && { self=1; break; }
+  done <<EOF
+$ancestry
+EOF
+  fm_harness_process_matches "$comm" "$args" "$self"
 }
 
 # True when state dir $1 holds a session lock whose pid is ANY harness ancestor

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -25,6 +25,14 @@ FM_HARNESS_RE='claude|codex|opencode|grok|kimi|^pi$|^pi-signed$'
 # bin/fm-claude-stop-autoarm.sh.
 FM_HARNESS_NAMES=(claude codex opencode grok kimi pi-signed pi)
 
+# omp (Oh My Pi) is deliberately NOT added to the tables above. It is not
+# exclusively a Claude Agent SDK harness, so a bare process-name match here
+# would misclaim an omp session running a different backend. Its Claude
+# identity is instead recognized in fm_harness_process_matches() below, gated
+# strictly on the CLAUDECODE=1 marker the same way fm-harness.sh's own
+# detect_own() already trusts it (env markers before ancestry). Do not widen
+# this to a bare name match.
+
 # Print the exact harness name carried by executable path $1 - its own basename
 # or any directory component - or return 1.
 #
@@ -69,6 +77,19 @@ fm_harness_process_matches() {  # <comm> <args>
   argv0=${args%% *}
   if name=$(fm_harness_path_name "$comm") || name=$(fm_harness_path_name "$argv0"); then
     case "$name" in claude) FM_HARNESS_IS_CLAUDE=1 ;; esac
+    return 0
+  fi
+  # omp (Oh My Pi), treated as claude 2026-08-23: omp runs on the same
+  # underlying Claude Agent SDK and sets CLAUDECODE=1 for downstream
+  # compatibility, but its own process name is "omp" with no separate
+  # "claude"-named process anywhere in its ancestry - there is no nested
+  # worker chain to climb the way native Claude Code has one. Every caller in
+  # this file runs as a descendant of the primary session's own process tree
+  # (the Stop/PreToolUse hook scripts, fm-lock.sh, fm-session-start.sh), so
+  # the marker is reliably inherited here too. Gate strictly on the marker,
+  # never the bare name alone (see the FM_HARNESS_NAMES comment above).
+  if [ "$base" = omp ] && [ "${CLAUDECODE:-}" = "1" ]; then
+    FM_HARNESS_IS_CLAUDE=1
     return 0
   fi
   # Bare interpreter (e.g. node): match the harness name in its script path.

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -248,7 +248,7 @@ fm_harness_omp_pid_identity() {  # <pid>
 fm_harness_record_omp_claude() {  # <state> <pid>
   local state=$1 pid=$2 comm marker identity
   marker=$(fm_harness_omp_claude_marker_path "$state")
-  comm=$(ps -o comm= -p "$pid" 2>/dev/null) || comm=""
+  comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
   if [ "$(basename -- "$comm")" = omp ] && [ "${CLAUDECODE:-}" = "1" ]; then
     identity=$(fm_harness_omp_pid_identity "$pid") || return 1
     { printf '%s\n' "$pid" && printf '%s\n' "$identity"; } > "$marker" 2>/dev/null

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -205,15 +205,23 @@ fm_harness_omp_claude_marker_path() {  # <state>
 # path. Always called on every lock write, omp or not, so a later non-omp
 # acquisition clears a stale marker rather than leaving it pointing at a pid
 # some unrelated future process could reuse.
+#
+# Returns failure when a genuine omp holder's marker write fails. That case
+# is fatal for the caller, not merely logged: without the persisted marker no
+# foreign session can ever prove this pid alive (fm_harness_pid_alive has no
+# other evidence for a foreign omp pid), so it would treat this live holder
+# as stale and overwrite the lock out from under it. fm-lock.sh must fail the
+# whole acquisition rather than report success with unverifiable identity.
 fm_harness_record_omp_claude() {  # <state> <pid>
   local state=$1 pid=$2 comm marker
   marker=$(fm_harness_omp_claude_marker_path "$state")
   comm=$(ps -o comm= -p "$pid" 2>/dev/null) || comm=""
   if [ "$(basename -- "$comm")" = omp ] && [ "${CLAUDECODE:-}" = "1" ]; then
-    printf '%s\n' "$pid" > "$marker" 2>/dev/null || true
-  else
-    rm -f "$marker" 2>/dev/null || true
+    printf '%s\n' "$pid" > "$marker" 2>/dev/null
+    return $?
   fi
+  rm -f "$marker" 2>/dev/null || true
+  return 0
 }
 
 # True if $1 is a live process that looks like a verified harness. $2 is the

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -194,6 +194,34 @@ fm_harness_omp_claude_marker_path() {  # <state>
   printf '%s/.lock.omp-claude' "$1"
 }
 
+# Process-identity fingerprint for pid $1, immune to the pid being recycled by
+# an unrelated later process: prefers /proc's numeric starttime (clock ticks
+# since boot, Linux-only) and falls back to `ps -o lstart=` elsewhere. Mirrors
+# bin/fm-teardown.sh's task_process_identity and bin/fm-wake-lib.sh's
+# fm_pid_identity so all three independently-verified pid-reuse guards agree
+# on format; duplicated rather than sourced because this file has no side
+# effects on source (see header) and must not adopt fm-wake-lib.sh's
+# mkdir -p "$STATE" as a side effect of merely being sourced.
+fm_harness_omp_pid_identity() {  # <pid>
+  local pid=$1 proc_root stat_line starttime value
+  local -a stat_fields
+  proc_root=${FM_PROC_ROOT_OVERRIDE:-/proc}
+  if [ -r "$proc_root/$pid/stat" ]; then
+    stat_line=$(cat "$proc_root/$pid/stat" 2>/dev/null) || return 1
+    read -r -a stat_fields <<< "${stat_line##*)}"
+    [ "${#stat_fields[@]}" -ge 20 ] || return 1
+    starttime=${stat_fields[19]}
+    case "$starttime" in ''|*[!0-9]*) return 1 ;; esac
+    printf 'starttime=%s\n' "$starttime"
+    return 0
+  fi
+  value=$(LC_ALL=C ps -p "$pid" -o lstart= 2>/dev/null) || return 1
+  value=$(printf '%s' "$value" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+  [ -n "$value" ] || return 1
+  case "$value" in *$'\n'*|*$'\r'*) return 1 ;; esac
+  printf 'lstart=%s\n' "$value"
+}
+
 # Record whether $2 - the pid fm-lock.sh just wrote into state dir $1's session
 # lock - is an omp process, so a foreign checker can later trust that this
 # exact pid was CLAUDECODE-verified without needing to read $2's own
@@ -212,12 +240,18 @@ fm_harness_omp_claude_marker_path() {  # <state>
 # other evidence for a foreign omp pid), so it would treat this live holder
 # as stale and overwrite the lock out from under it. fm-lock.sh must fail the
 # whole acquisition rather than report success with unverifiable identity.
+#
+# The marker's second line is $2's fm_harness_omp_pid_identity fingerprint,
+# captured in the same breath as the pid so fm_harness_pid_alive can tell this
+# exact process apart from an unrelated later process that reused pid $2 -
+# see fm_harness_pid_alive for why a bare pid match is not enough.
 fm_harness_record_omp_claude() {  # <state> <pid>
-  local state=$1 pid=$2 comm marker
+  local state=$1 pid=$2 comm marker identity
   marker=$(fm_harness_omp_claude_marker_path "$state")
   comm=$(ps -o comm= -p "$pid" 2>/dev/null) || comm=""
   if [ "$(basename -- "$comm")" = omp ] && [ "${CLAUDECODE:-}" = "1" ]; then
-    printf '%s\n' "$pid" > "$marker" 2>/dev/null
+    identity=$(fm_harness_omp_pid_identity "$pid") || return 1
+    { printf '%s\n' "$pid" && printf '%s\n' "$identity"; } > "$marker" 2>/dev/null
     return $?
   fi
   rm -f "$marker" 2>/dev/null || true
@@ -245,11 +279,17 @@ fm_harness_record_omp_claude() {  # <state> <pid>
 # evidence can prove it was CLAUDECODE-verified: that marker lives only in
 # $1's own environment, which this process cannot read. The lock-writing
 # session already did that verification before it ever became the lock
-# holder, so trust its persisted fm_harness_record_omp_claude record instead -
-# requiring an exact pid match guards against a later, unrelated process
-# reusing $1's old pid number after the verified session has exited.
+# holder, so trust its persisted fm_harness_record_omp_claude record instead.
+# A pid match alone is not enough: the verified session can exit and the
+# kernel can hand $1's old pid number to an unrelated later process before
+# this marker is ever refreshed, and that reused pid would otherwise pass
+# kill -0 and the marker's bare pid line. So the marker's second line - $1's
+# fm_harness_omp_pid_identity fingerprint at the moment fm-lock.sh verified
+# it - must also match $1's identity right now; a reused pid almost certainly
+# has a different start time and fails this second check.
 fm_harness_pid_alive() {  # <pid> <state>
   local pid=$1 state=${2:-} comm args self=0 ancestry ap base marker
+  local recorded_pid recorded_identity current_identity
   kill -0 "$pid" 2>/dev/null || return 1
   comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
   args=$(ps -o args= -p "$pid" 2>/dev/null)
@@ -263,7 +303,12 @@ EOF
   base=$(basename -- "$comm")
   [ "$base" = omp ] && [ -n "$state" ] || return 1
   marker=$(fm_harness_omp_claude_marker_path "$state")
-  [ "$(cat "$marker" 2>/dev/null || true)" = "$pid" ]
+  recorded_pid=$(sed -n '1p' "$marker" 2>/dev/null) || return 1
+  [ "$recorded_pid" = "$pid" ] || return 1
+  recorded_identity=$(sed -n '2p' "$marker" 2>/dev/null)
+  [ -n "$recorded_identity" ] || return 1
+  current_identity=$(fm_harness_omp_pid_identity "$pid") || return 1
+  [ "$recorded_identity" = "$current_identity" ]
 }
 
 # True when state dir $1 holds a session lock whose pid is ANY harness ancestor

--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -99,8 +99,16 @@ fm_harness_process_matches() {  # <comm> <args> [self=0]
   # fm_harness_pid_alive checks membership in that same walk before passing
   # self=1 for a lock-file pid, so a pid from a genuinely different session
   # never borrows the caller's marker.
+  #
+  # Deliberately do NOT set FM_HARNESS_IS_CLAUDE here even though omp is
+  # Claude-backed: that flag tells fm_harness_ancestry_pids to keep climbing
+  # past this match the way native Claude Code's nested worker chain requires,
+  # and the comment above is explicit that omp has no such chain to climb. Omp
+  # is its own session boundary, exactly like every other non-Claude harness -
+  # setting the flag would let the walk continue into whatever unrelated
+  # process happens to be omp's parent (a launcher or daemon) and report that
+  # outer pid as the lock identity instead of omp's own.
   if [ "$base" = omp ] && [ "$self" -eq 1 ] && [ "${CLAUDECODE:-}" = "1" ]; then
-    FM_HARNESS_IS_CLAUDE=1
     return 0
   fi
   # Bare interpreter (e.g. node): match the harness name in its script path.
@@ -178,7 +186,40 @@ EOF
   printf '%s\n' "$outermost"
 }
 
-# True if $1 is a live process that looks like a verified harness.
+# Path to the sibling record of state dir $1's session lock naming the one
+# omp pid, if any, that fm-lock.sh verified as CLAUDECODE=1 at the moment it
+# wrote that exact pid into state/.lock. See fm_harness_record_omp_claude and
+# fm_harness_pid_alive below for why this exists.
+fm_harness_omp_claude_marker_path() {  # <state>
+  printf '%s/.lock.omp-claude' "$1"
+}
+
+# Record whether $2 - the pid fm-lock.sh just wrote into state dir $1's session
+# lock - is an omp process, so a foreign checker can later trust that this
+# exact pid was CLAUDECODE-verified without needing to read $2's own
+# environment (see fm_harness_pid_alive). Callable only from the writer's own
+# context immediately after a successful lock write, because that is the one
+# place $CLAUDECODE is sound evidence about $2: fm_harness_ancestry_pid (which
+# produced $2) never returns an omp pid unless this same environment's
+# CLAUDECODE=1 already gated it in via fm_harness_process_matches's self=1
+# path. Always called on every lock write, omp or not, so a later non-omp
+# acquisition clears a stale marker rather than leaving it pointing at a pid
+# some unrelated future process could reuse.
+fm_harness_record_omp_claude() {  # <state> <pid>
+  local state=$1 pid=$2 comm marker
+  marker=$(fm_harness_omp_claude_marker_path "$state")
+  comm=$(ps -o comm= -p "$pid" 2>/dev/null) || comm=""
+  if [ "$(basename -- "$comm")" = omp ] && [ "${CLAUDECODE:-}" = "1" ]; then
+    printf '%s\n' "$pid" > "$marker" 2>/dev/null || true
+  else
+    rm -f "$marker" 2>/dev/null || true
+  fi
+}
+
+# True if $1 is a live process that looks like a verified harness. $2 is the
+# state dir the lock naming $1 lives in, so a persisted omp record can be
+# consulted; pass "" when no such state dir applies (only the non-omp
+# evidence in fm_harness_process_matches is then available).
 #
 # $1 is read from a lock file and may belong to an entirely different session
 # than the caller - the whole point of this check is telling a live competing
@@ -191,8 +232,16 @@ EOF
 # fm_harness_ancestry_pids(), the same membership test fm_session_lock_owned_by_self
 # already uses to answer the identical question - never assumed from the
 # caller's context.
-fm_harness_pid_alive() {  # <pid>
-  local pid=$1 comm args self=0 ancestry ap
+#
+# When $1 is a genuinely foreign omp pid (self=0), no amount of local
+# evidence can prove it was CLAUDECODE-verified: that marker lives only in
+# $1's own environment, which this process cannot read. The lock-writing
+# session already did that verification before it ever became the lock
+# holder, so trust its persisted fm_harness_record_omp_claude record instead -
+# requiring an exact pid match guards against a later, unrelated process
+# reusing $1's old pid number after the verified session has exited.
+fm_harness_pid_alive() {  # <pid> <state>
+  local pid=$1 state=${2:-} comm args self=0 ancestry ap base marker
   kill -0 "$pid" 2>/dev/null || return 1
   comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
   args=$(ps -o args= -p "$pid" 2>/dev/null)
@@ -202,7 +251,11 @@ fm_harness_pid_alive() {  # <pid>
   done <<EOF
 $ancestry
 EOF
-  fm_harness_process_matches "$comm" "$args" "$self"
+  fm_harness_process_matches "$comm" "$args" "$self" && return 0
+  base=$(basename -- "$comm")
+  [ "$base" = omp ] && [ -n "$state" ] || return 1
+  marker=$(fm_harness_omp_claude_marker_path "$state")
+  [ "$(cat "$marker" 2>/dev/null || true)" = "$pid" ]
 }
 
 # True when state dir $1 holds a session lock whose pid is ANY harness ancestor

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -193,6 +193,7 @@ family_for_basename() {
     fm-grok-stop-live-e2e.test.sh|fm-harness-liveness-drift-live-e2e.test.sh|\
     fm-muse-signals-live-e2e.test.sh|\
     fm-herdr-version-floor-live-e2e.test.sh|\
+    fm-omp-session-lock-live-e2e.test.sh|\
     fm-opencode-primary-live-e2e.test.sh|fm-pi-branch-live-e2e.test.sh|\
     fm-pi-primary-live-e2e.test.sh|\
     fm-sessionstart-hook-live-e2e.test.sh|fm-sessionstart-instruction-refresh-live-e2e.test.sh|\

--- a/bin/fm-turnend-guard-cursor.sh
+++ b/bin/fm-turnend-guard-cursor.sh
@@ -241,7 +241,7 @@ current_session_still_ours() {
 if ! fm_session_lock_owned_by_self "$STATE"; then
   LOCK_PID=$(cat "$STATE/.lock" 2>/dev/null || true)
   case "$LOCK_PID" in ''|*[!0-9]*) exit 0 ;; esac
-  fm_harness_pid_alive "$LOCK_PID" && exit 0
+  fm_harness_pid_alive "$LOCK_PID" "$STATE" && exit 0
   "$SCRIPT_DIR/fm-lock.sh" >/dev/null 2>&1 || exit 0
   fm_session_lock_owned_by_self "$STATE" || exit 0
 fi

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -955,3 +955,23 @@ Evidence produced 2026-08-23 on macOS 26.5.0 arm64, Node v24.14.1:
 
 Scope of this evidence: the installed signed `pi` CLI (0.84.1 at verification time) is a compiled binary whose bundled SDK is not importable from Node, so the importable npm package is the only surface the guard and the typecheck can pin.
 The extension executes inside the signed CLI's own runtime, so a CLI upgrade can drift ahead of the pinned npm surface; refresh this record after every Pi upgrade by re-running both commands above (point `FM_PI_PACKAGE_DIR` at a matching npm install when one exists) and by watching the branch's own fallback line - every branch failure degrades to the pre-branch wake-to-main path by construction, which `tests/fm-pi-branch-extension.test.sh` holds with a broken generator and the live guard holds with the real SDK.
+
+## omp (session-lock identity)
+
+`bin/fm-session-lock-lib.sh`'s recognition of omp (Oh My Pi) as Claude-identified, scoped to session-lock ownership only, depends on two vendor-controlled facts: that a real omp process's own `comm`/`argv[0]` report base name `omp`, and that a real omp session's own process environment carries `CLAUDECODE=1`.
+
+Evidence produced 2026-08-25 on macOS 26.5.0 arm64, omp 18.0.4:
+
+```sh
+FM_OMP_LOCK_LIVE_E2E=1 bin/fm-test-run.sh tests/fm-omp-session-lock-live-e2e.test.sh
+```
+
+```text
+ok - omp session-lock live guard: a real omp session's own process environment carries CLAUDECODE=1
+ok - omp session-lock live guard: a real omp process's own comm reports base name 'omp'
+ok - omp session-lock live guard: the real (unfaked) classifier recognizes a live omp process from its own ancestry without extending past it
+```
+
+The observed live process reported `comm=/opt/homebrew/bin/omp` and its own bash tool echoed `CLAUDECODE=1` back from its own environment.
+macOS `ps` does not expose another process's environment (neither `ps -wwE` nor `ps eww` show it for a child spawned by this same guard), so the `CLAUDECODE` fact can only be confirmed by asking omp itself, through its own bash tool, to report it - a genuine bounded model turn, not a static read.
+Refresh this record after every omp upgrade by re-running the command above.

--- a/tests/fm-omp-session-lock-live-e2e.test.sh
+++ b/tests/fm-omp-session-lock-live-e2e.test.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# tests/fm-omp-session-lock-live-e2e.test.sh - opt-in live guard proving the
+# two vendor-controlled facts bin/fm-session-lock-lib.sh's omp recognition
+# depends on: that a real omp process's own comm/args report base name "omp"
+# (the shape fm_harness_process_matches matches on), and that a real omp
+# session's own process environment genuinely carries CLAUDECODE=1 (the
+# marker the whole recognition is gated on).
+#
+# Why this file exists: both facts are vendor behavior that can change without
+# notice - a rename, or omp dropping the compatibility marker - and the
+# portable regression in tests/fm-session-lock-ancestry.test.sh only replays
+# those facts through an injected fake `ps`, which cannot detect a real
+# vendor change. This guard drives the real omp binary and feeds the real
+# fm_harness_process_matches its actual observed comm/args, so a vendor
+# change that breaks the assumption fails here first.
+#
+# CLAUDECODE cannot be read from a live omp process by an external observer:
+# macOS `ps` does not expose another process's environment (verified: neither
+# `ps -wwE` nor `ps eww` show env for a child this same test spawned), and
+# there is no /proc on macOS to fall back to. The only real proof available is
+# to ask omp itself, through its own bash tool, to report its own $CLAUDECODE
+# - which is a genuine model turn and spends a small, bounded amount of
+# tokens. That spend is explicitly sanctioned for exactly this class of check
+# (firstmate-coding-guidelines, "Harness-dependent checks"): the cost is small
+# against a check that silently stops working.
+#
+# Standard CI has no omp binary or credentials, so this guard is opt-in and
+# on-demand, mirroring tests/fm-harness-liveness-drift-live-e2e.test.sh. Run
+# it after any omp upgrade and before trusting refreshed evidence.
+# shellcheck disable=SC2016 # single quotes are deliberate: $CLAUDECODE must expand inside omp's own bash tool, not this shell
+set -u
+
+if [ "${FM_OMP_LOCK_LIVE_E2E:-0}" != 1 ]; then
+  echo "skip: set FM_OMP_LOCK_LIVE_E2E=1 to run the live omp session-lock identity guard"
+  exit 0
+fi
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+fail() { printf 'not ok - %s\n' "$1" >&2; cleanup_all; exit 1; }
+pass() { printf 'ok - %s\n' "$1"; }
+note() { printf '# %s\n' "$1"; }
+
+if ! OMP_BIN=$(command -v omp 2>/dev/null); then
+  echo "skip: omp is not installed on this machine, so its classification is unverified here"
+  exit 0
+fi
+
+OUT=$(mktemp "${TMPDIR:-/tmp}/fm-omp-lock-live.XXXXXX")
+cleanup_all() {
+  if [ -n "${OMP_PID:-}" ] && kill -0 "$OMP_PID" 2>/dev/null; then
+    kill -9 "$OMP_PID" 2>/dev/null || true
+  fi
+  [ -n "${OUT:-}" ] && rm -f "$OUT"
+}
+trap cleanup_all EXIT
+
+version=$("$OMP_BIN" --version 2>/dev/null | head -1 | tr -d '\r') || version=
+[ -n "$version" ] || version="unknown"
+
+# A real, non-interactive omp turn that uses its own bash tool to report its
+# own environment, then holds briefly so `ps` can observe it mid-run. No
+# --no-session flag would change what CLAUDECODE the tool subprocess sees;
+# --no-session only skips persisting the transcript.
+"$OMP_BIN" -p --no-session \
+  'Run this exact bash command using your tool and output only its result, nothing else: echo -n "OMPCLAUDECODE=$CLAUDECODE"; sleep 3' \
+  > "$OUT" 2>&1 &
+OMP_PID=$!
+
+# Sample the real process's identity while it is still alive.
+REAL_COMM=
+REAL_ARGS=
+for _ in $(seq 1 30); do
+  kill -0 "$OMP_PID" 2>/dev/null || break
+  REAL_COMM=$(ps -p "$OMP_PID" -o comm= 2>/dev/null | tr -d ' ')
+  REAL_ARGS=$(ps -p "$OMP_PID" -o args= 2>/dev/null)
+  [ -n "$REAL_COMM" ] && break
+  sleep 0.2
+done
+[ -n "$REAL_COMM" ] || fail \
+  "omp $version: could not observe the live process's own comm/args before it exited"
+
+# Let the turn finish (bounded wait; no portable `timeout`/`gtimeout` on this
+# machine, so poll-and-kill instead).
+for _ in $(seq 1 60); do
+  kill -0 "$OMP_PID" 2>/dev/null || break
+  sleep 1
+done
+if kill -0 "$OMP_PID" 2>/dev/null; then
+  kill -9 "$OMP_PID" 2>/dev/null || true
+  fail "omp $version: the live probe turn did not finish within the bounded wait"
+fi
+wait "$OMP_PID" 2>/dev/null
+OMP_PID=
+
+OUTPUT=$(cat "$OUT")
+
+case "$OUTPUT" in
+  *OMPCLAUDECODE=1*) ;;
+  *) fail "OMP DRIFT: omp $version's own bash tool did not report CLAUDECODE=1 in its own process environment (observed output: $OUTPUT). The whole session-lock recognition in bin/fm-session-lock-lib.sh is gated on this marker; teach it whatever this release actually sets, or stop trusting the marker for omp." ;;
+esac
+note "omp $version: its own bash tool reported CLAUDECODE=1 in its own environment"
+pass "omp session-lock live guard: a real omp session's own process environment carries CLAUDECODE=1"
+
+base=$(basename -- "$REAL_COMM")
+[ "$base" = omp ] || fail \
+  "OMP DRIFT: omp $version's own process reports comm='$REAL_COMM' (basename '$base'), not 'omp'. bin/fm-session-lock-lib.sh's fm_harness_process_matches matches on exactly base='omp'; teach it the name this release actually uses."
+note "omp $version: live process comm='$REAL_COMM' args='$REAL_ARGS'"
+pass "omp session-lock live guard: a real omp process's own comm reports base name 'omp'"
+
+# Feed the REAL observed comm/args into the real (unfaked) library function,
+# with CLAUDECODE=1 set in this shell exactly as a genuine omp session's own
+# self=1 ancestry check would see it.
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-cursor-lib.sh"
+# shellcheck source=/dev/null
+. "$ROOT/bin/fm-session-lock-lib.sh"
+
+CLAUDECODE=1 fm_harness_process_matches "$REAL_COMM" "$REAL_ARGS" 1 \
+  || fail "the real (unfaked) fm_harness_process_matches did not recognize this live omp process's own comm/args as a harness with self=1 and CLAUDECODE=1"
+[ "$FM_HARNESS_IS_CLAUDE" -eq 0 ] || fail \
+  "fm_harness_process_matches set FM_HARNESS_IS_CLAUDE=1 for a live omp process; it must stay 0 so the ancestry walk stops at omp's own session boundary instead of climbing into its parent"
+pass "omp session-lock live guard: the real (unfaked) classifier recognizes a live omp process from its own ancestry without extending past it"
+
+cleanup_all
+trap - EXIT

--- a/tests/fm-session-lock-ancestry.test.sh
+++ b/tests/fm-session-lock-ancestry.test.sh
@@ -363,26 +363,34 @@ SH
 }
 
 test_persisted_omp_claude_marker_lets_a_foreign_checker_see_a_live_omp_session() {
-  local dir fakebin marker
+  local dir fakebin marker no_proc lstart_original lstart_reused
   dir="$TMP_ROOT/omp-persisted-marker"
   fakebin=$(fm_fakebin "$dir")
   mkdir -p "$dir/state"
   marker="$dir/state/.lock.omp-claude"
-  cat > "$fakebin/ps" <<'SH'
+  # A nonexistent /proc root forces fm_harness_omp_pid_identity onto its
+  # `ps -o lstart=` fallback on every platform, including Linux CI where a
+  # real /proc would otherwise take the numeric-starttime branch this fixture
+  # cannot fake through `ps`.
+  no_proc="$dir/no-proc"
+  lstart_original='Mon Jan  1 00:00:00 2024'
+  lstart_reused='Tue Jan  2 00:00:00 2024'
+  cat > "$fakebin/ps" <<SH
 #!/usr/bin/env bash
 set -u
 field= pid=
-while [ "$#" -gt 0 ]; do
-  case "$1" in
-    -o) field=$2; shift 2 ;;
-    -p) pid=$2; shift 2 ;;
+while [ "\$#" -gt 0 ]; do
+  case "\$1" in
+    -o) field=\$2; shift 2 ;;
+    -p) pid=\$2; shift 2 ;;
     *) shift ;;
   esac
 done
-case "$pid:$field" in
+case "\$pid:\$field" in
   500:comm=) printf '%s\n' omp ;;
   500:args=) printf '%s\n' omp ;;
   500:ppid=) printf '%s\n' 1 ;;
+  500:lstart=) printf '%s\n' "\${FM_TEST_PID500_LSTART:-$lstart_original}" ;;
   650:comm=) printf '%s\n' claude ;;
   650:args=) printf '%s\n' claude ;;
   650:ppid=) printf '%s\n' 1 ;;
@@ -402,40 +410,54 @@ SH
 
   # fm_harness_record_omp_claude, called from the writer's own context where
   # CLAUDECODE=1 is sound evidence about pid 500, is what produces that record.
-  CLAUDECODE=1 lib_eval "$fakebin" "fm_harness_record_omp_claude '$dir/state' 500"
-  [ "$(cat "$marker" 2>/dev/null || true)" = 500 ] \
+  FM_PROC_ROOT_OVERRIDE="$no_proc" CLAUDECODE=1 lib_eval "$fakebin" "fm_harness_record_omp_claude '$dir/state' 500"
+  [ "$(sed -n '1p' "$marker" 2>/dev/null || true)" = 500 ] \
     || fail "fm_harness_record_omp_claude did not persist the verified omp pid"
+  [ "$(sed -n '2p' "$marker" 2>/dev/null || true)" = "lstart=$lstart_original" ] \
+    || fail "fm_harness_record_omp_claude did not persist a pid-reuse identity fingerprint alongside the pid"
 
   # Without the marker, this foreign checker correctly still cannot confirm
   # pid 500 - this is the pre-existing fail-closed behavior and must not
   # regress.
   rm -f "$marker"
-  if lib_eval "$fakebin" "fm_harness_pid_alive 500 '$dir/state'"; then
+  if FM_PROC_ROOT_OVERRIDE="$no_proc" lib_eval "$fakebin" "fm_harness_pid_alive 500 '$dir/state'"; then
     fail "a foreign omp pid was seen as alive with no persisted marker present"
   fi
 
   # With the persisted marker in place, this foreign checker now correctly
   # sees the live omp session as alive, without needing its own CLAUDECODE.
-  printf '500\n' > "$marker"
-  lib_eval "$fakebin" "fm_harness_pid_alive 500 '$dir/state'" \
+  printf '500\nlstart=%s\n' "$lstart_original" > "$marker"
+  FM_PROC_ROOT_OVERRIDE="$no_proc" lib_eval "$fakebin" "fm_harness_pid_alive 500 '$dir/state'" \
     || fail "a live, marker-verified omp session held by a different session tree was classified as stale"
 
   # A marker naming a different pid than the one being checked - the
   # signature of a reused pid number after the verified session exited -
   # must never be trusted for this pid.
-  printf '999\n' > "$marker"
-  if lib_eval "$fakebin" "fm_harness_pid_alive 500 '$dir/state'"; then
+  printf '999\nlstart=%s\n' "$lstart_original" > "$marker"
+  if FM_PROC_ROOT_OVERRIDE="$no_proc" lib_eval "$fakebin" "fm_harness_pid_alive 500 '$dir/state'"; then
     fail "a marker naming a different pid was accepted as evidence for pid 500"
+  fi
+
+  # The kernel can hand pid 500 to an unrelated later process before this
+  # marker is ever refreshed: a bare pid match must not be enough. The marker
+  # still names pid 500 with the ORIGINAL verified session's start time, but
+  # the live process ps now reports for pid 500 carries a different start
+  # time - the signature of that reuse - so it must be rejected even though
+  # the pid number itself matches.
+  printf '500\nlstart=%s\n' "$lstart_original" > "$marker"
+  if FM_TEST_PID500_LSTART="$lstart_reused" FM_PROC_ROOT_OVERRIDE="$no_proc" \
+    lib_eval "$fakebin" "fm_harness_pid_alive 500 '$dir/state'"; then
+    fail "a pid whose live start time no longer matches the marker's recorded identity was accepted as the verified session"
   fi
 
   # fm_harness_record_omp_claude must also clear a stale marker when the pid
   # it is now given is not omp, so a later non-omp acquisition never leaves a
   # foreign checker trusting a leftover record for a reused pid number.
-  printf '500\n' > "$marker"
-  lib_eval "$fakebin" "fm_harness_record_omp_claude '$dir/state' 650"
+  printf '500\nlstart=%s\n' "$lstart_original" > "$marker"
+  FM_PROC_ROOT_OVERRIDE="$no_proc" lib_eval "$fakebin" "fm_harness_record_omp_claude '$dir/state' 650"
   [ -e "$marker" ] && fail "fm_harness_record_omp_claude left a stale marker after a non-omp pid was recorded"
 
-  pass "session-lock: a foreign checker trusts the lock writer's persisted omp+CLAUDECODE record, never its own ambient marker"
+  pass "session-lock: a foreign checker trusts the lock writer's persisted omp+CLAUDECODE record, never its own ambient marker, and rejects a reused pid whose identity no longer matches"
 }
 
 # --- end-to-end layer: the real Stop auto-arm in real process trees ----------
@@ -598,6 +620,7 @@ case "$field" in
   comm=) printf '%s\n' omp ;;
   args=) printf '%s\n' omp ;;
   ppid=) printf '%s\n' 1 ;;
+  lstart=) printf '%s\n' 'Mon Jan  1 00:00:00 2024' ;;
 esac
 SH
   chmod +x "$fakebin/ps"
@@ -616,6 +639,71 @@ SH
   pass "session-lock e2e: a failed omp-identity marker write fails the whole acquisition instead of leaving an unverifiable lock"
 }
 
+# A real fm-lock.sh is run to a controlled stopping point - the ps call
+# fm_harness_record_omp_claude issues right after $LOCK is written - and
+# killed there with SIGTERM, the same signal an interrupted terminal or a
+# supervisor's graceful shutdown would send. The fake ps only sleeps once
+# state/.lock already exists, so the delay lands exactly in the publication
+# gap between writing $LOCK and persisting its omp-identity marker, never
+# during the earlier ancestry walk that resolves $me.
+test_e2e_interrupted_omp_publication_does_not_leave_an_unverifiable_lock() {
+  local dir fakebin pid i rc lock_after
+  dir="$TMP_ROOT/e2e-omp-interrupted-publication"
+  mkdir -p "$dir/state"
+  install_autoarm_scripts "$dir"
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+field=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) field=$2; shift 2 ;;
+    -p) shift 2 ;;
+    *) shift ;;
+  esac
+done
+if [ "$field" = comm= ] && [ -f "$FM_HOME/state/.lock" ]; then
+  sleep 0.5
+fi
+case "$field" in
+  comm=) printf '%s\n' omp ;;
+  args=) printf '%s\n' omp ;;
+  ppid=) printf '%s\n' 1 ;;
+  lstart=) printf '%s\n' 'Mon Jan  1 00:00:00 2024' ;;
+esac
+SH
+  chmod +x "$fakebin/ps"
+
+  CLAUDECODE=1 PATH="$fakebin:$PATH" FM_HOME="$dir" "$dir/bin/fm-lock.sh" \
+    >"$dir/out" 2>&1 &
+  pid=$!
+
+  i=0
+  while [ "$i" -lt 200 ] && [ ! -f "$dir/state/.lock" ]; do
+    sleep 0.02
+    i=$((i + 1))
+  done
+  if [ ! -f "$dir/state/.lock" ]; then
+    kill -TERM "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+    fail "fm-lock.sh never reached the session-lock write within the timeout"
+  fi
+
+  kill -TERM "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null
+  rc=$?
+
+  [ "$rc" -ne 0 ] \
+    || fail "an interrupted fm-lock.sh acquisition reported success: $(cat "$dir/out" 2>/dev/null)"
+  lock_after=$(cat "$dir/state/.lock" 2>/dev/null || true)
+  [ -z "$lock_after" ] \
+    || fail "an omp acquisition interrupted before its identity marker was persisted left the session lock claiming pid $lock_after, unverifiable by any foreign session"
+  [ -e "$dir/state/.lock.omp-claude" ] \
+    && fail "an interrupted omp acquisition left a stale omp-identity marker behind"
+  pass "session-lock e2e: an omp acquisition interrupted between writing the lock and persisting its identity marker rolls the lock back instead of leaving it unverifiable"
+}
+
 test_version_named_session_is_identified_on_both_platforms
 test_ordinary_paths_are_never_harness_processes
 test_omp_is_claude_identified_only_with_claudecode_marker
@@ -628,3 +716,4 @@ test_e2e_version_named_session_claims_the_home
 test_e2e_daemon_parented_session_claims_the_home
 test_e2e_daemon_parented_version_named_session_keeps_its_lock
 test_e2e_omp_marker_write_failure_fails_the_whole_acquisition
+test_e2e_interrupted_omp_publication_does_not_leave_an_unverifiable_lock

--- a/tests/fm-session-lock-ancestry.test.sh
+++ b/tests/fm-session-lock-ancestry.test.sh
@@ -134,6 +134,61 @@ SH
   pass "session-lock: ordinary script paths under a harness directory are not harness processes"
 }
 
+test_omp_is_claude_identified_only_with_claudecode_marker() {
+  local dir fakebin got
+  dir="$TMP_ROOT/omp-marker"
+  fakebin=$(fm_fakebin "$dir")
+  mkdir -p "$dir/state"
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+field= pid=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) field=$2; shift 2 ;;
+    -p) pid=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+case "$pid:$field" in
+  500:comm=) printf '%s\n' omp ;;
+  500:args=) printf '%s\n' omp ;;
+  500:ppid=) printf '%s\n' 1 ;;
+  *:comm=) printf '%s\n' bash ;;
+  *:args=) printf '%s\n' bash ;;
+  *:ppid=) printf '%s\n' 500 ;;
+esac
+SH
+  chmod +x "$fakebin/ps"
+  printf '500\n' > "$dir/state/.lock"
+
+  # Positive: an omp process carrying the CLAUDECODE=1 marker is Claude-identified,
+  # and the omp process's own pid is what the ancestry resolves to.
+  got=$(CLAUDECODE=1 lib_eval "$fakebin" 'fm_harness_ancestry_pid') \
+    || fail "an omp process with CLAUDECODE=1 was not recognized as a harness process"
+  [ "$got" = 500 ] || fail "ancestry resolved '$got', expected the omp process's own pid 500"
+  CLAUDECODE=1 lib_eval "$fakebin" 'fm_harness_pid_alive 500' \
+    || fail "a live omp process with CLAUDECODE=1 was not recognized as a harness"
+  CLAUDECODE=1 lib_eval "$fakebin" "fm_session_lock_owned_by_self '$dir/state'" \
+    || fail "an omp session with CLAUDECODE=1 did not recognize itself as the lock owner"
+
+  # Negative: the identical omp-named process WITHOUT the marker must be rejected,
+  # proving this is marker-gated rather than a bare name match. CLAUDECODE is
+  # explicitly overridden to empty here rather than merely left unset, because
+  # this suite may itself be running inside a Claude Code session that already
+  # exports CLAUDECODE=1 into the ambient environment.
+  if CLAUDECODE='' lib_eval "$fakebin" 'fm_harness_ancestry_pid'; then
+    fail "an omp process without CLAUDECODE=1 was treated as a harness process"
+  fi
+  if CLAUDECODE='' lib_eval "$fakebin" 'fm_harness_pid_alive 500'; then
+    fail "an omp process without CLAUDECODE=1 passed the harness-liveness predicate"
+  fi
+  if CLAUDECODE='' lib_eval "$fakebin" "fm_session_lock_owned_by_self '$dir/state'"; then
+    fail "an omp process without CLAUDECODE=1 claimed the home's session lock"
+  fi
+  pass "session-lock: omp is Claude-identified for lock ownership only when CLAUDECODE=1 is set, never on bare name"
+}
+
 test_harness_beyond_a_gap_never_owns_the_lock() {
   local dir fakebin got
   dir="$TMP_ROOT/gap"
@@ -358,6 +413,7 @@ test_e2e_daemon_parented_version_named_session_keeps_its_lock() {
 
 test_version_named_session_is_identified_on_both_platforms
 test_ordinary_paths_are_never_harness_processes
+test_omp_is_claude_identified_only_with_claudecode_marker
 test_harness_beyond_a_gap_never_owns_the_lock
 test_competing_version_named_session_is_seen_as_live
 test_e2e_version_named_session_claims_the_home

--- a/tests/fm-session-lock-ancestry.test.sh
+++ b/tests/fm-session-lock-ancestry.test.sh
@@ -574,6 +574,48 @@ test_e2e_daemon_parented_version_named_session_keeps_its_lock() {
   pass "session-lock e2e: a version-named session under a harness-named daemon keeps its own lock"
 }
 
+# A directory in place of the marker file makes fm_harness_record_omp_claude's
+# write fail deterministically and cross-platform, without relying on chmod
+# (which root - a common CI container user - ignores).
+test_e2e_omp_marker_write_failure_fails_the_whole_acquisition() {
+  local dir fakebin out rc lock_after
+  dir="$TMP_ROOT/e2e-omp-marker-write-failure"
+  mkdir -p "$dir/state"
+  install_autoarm_scripts "$dir"
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+field=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) field=$2; shift 2 ;;
+    -p) shift 2 ;;
+    *) shift ;;
+  esac
+done
+case "$field" in
+  comm=) printf '%s\n' omp ;;
+  args=) printf '%s\n' omp ;;
+  ppid=) printf '%s\n' 1 ;;
+esac
+SH
+  chmod +x "$fakebin/ps"
+  mkdir -p "$dir/state/.lock.omp-claude"
+
+  out=$(CLAUDECODE=1 PATH="$fakebin:$PATH" FM_HOME="$dir" "$dir/bin/fm-lock.sh" 2>&1)
+  rc=$?
+  [ "$rc" -ne 0 ] \
+    || fail "fm-lock.sh reported success despite a failed omp-identity marker write: $out"
+  case "$out" in
+    *"lock acquired"*) fail "fm-lock.sh printed lock-acquired despite a failed marker write: $out" ;;
+  esac
+  lock_after=$(cat "$dir/state/.lock" 2>/dev/null || true)
+  [ -z "$lock_after" ] \
+    || fail "the session lock was left claiming pid $lock_after with no persisted omp-identity marker for a foreign session to verify"
+  pass "session-lock e2e: a failed omp-identity marker write fails the whole acquisition instead of leaving an unverifiable lock"
+}
+
 test_version_named_session_is_identified_on_both_platforms
 test_ordinary_paths_are_never_harness_processes
 test_omp_is_claude_identified_only_with_claudecode_marker
@@ -585,3 +627,4 @@ test_persisted_omp_claude_marker_lets_a_foreign_checker_see_a_live_omp_session
 test_e2e_version_named_session_claims_the_home
 test_e2e_daemon_parented_session_claims_the_home
 test_e2e_daemon_parented_version_named_session_keeps_its_lock
+test_e2e_omp_marker_write_failure_fails_the_whole_acquisition

--- a/tests/fm-session-lock-ancestry.test.sh
+++ b/tests/fm-session-lock-ancestry.test.sh
@@ -640,12 +640,15 @@ SH
 }
 
 # A real fm-lock.sh is run to a controlled stopping point - the ps call
-# fm_harness_record_omp_claude issues right after $LOCK is written - and
-# killed there with SIGTERM, the same signal an interrupted terminal or a
-# supervisor's graceful shutdown would send. The fake ps only sleeps once
-# state/.lock already exists, so the delay lands exactly in the publication
-# gap between writing $LOCK and persisting its omp-identity marker, never
-# during the earlier ancestry walk that resolves $me.
+# fm_harness_record_omp_claude issues to persist the omp-identity marker,
+# which fm-lock.sh now runs BEFORE $LOCK is written so that $LOCK's own
+# visibility can never precede the marker a foreign checker needs (an
+# untrappable SIGKILL landing between the old write order could otherwise
+# leave a live, unverifiable lock behind) - and killed there with SIGTERM,
+# the same signal an interrupted terminal or a supervisor's graceful shutdown
+# would send. The fake ps only sleeps once the claim lock is held, so the
+# delay lands exactly in that marker-persistence gap, before $LOCK exists and
+# never during the earlier ancestry walk that resolves $me.
 test_e2e_interrupted_omp_publication_does_not_leave_an_unverifiable_lock() {
   local dir fakebin pid i rc lock_after
   dir="$TMP_ROOT/e2e-omp-interrupted-publication"
@@ -663,7 +666,7 @@ while [ "$#" -gt 0 ]; do
     *) shift ;;
   esac
 done
-if [ "$field" = comm= ] && [ -f "$FM_HOME/state/.lock" ]; then
+if [ "$field" = comm= ] && [ -L "$FM_HOME/state/.lock.acquire" ] && [ ! -f "$FM_HOME/state/.lock" ]; then
   sleep 0.5
 fi
 case "$field" in
@@ -680,14 +683,14 @@ SH
   pid=$!
 
   i=0
-  while [ "$i" -lt 200 ] && [ ! -f "$dir/state/.lock" ]; do
+  while [ "$i" -lt 200 ] && [ ! -L "$dir/state/.lock.acquire" ]; do
     sleep 0.02
     i=$((i + 1))
   done
-  if [ ! -f "$dir/state/.lock" ]; then
+  if [ ! -L "$dir/state/.lock.acquire" ]; then
     kill -TERM "$pid" 2>/dev/null || true
     wait "$pid" 2>/dev/null || true
-    fail "fm-lock.sh never reached the session-lock write within the timeout"
+    fail "fm-lock.sh never reached the claim-lock acquisition within the timeout"
   fi
 
   kill -TERM "$pid" 2>/dev/null || true
@@ -701,7 +704,7 @@ SH
     || fail "an omp acquisition interrupted before its identity marker was persisted left the session lock claiming pid $lock_after, unverifiable by any foreign session"
   [ -e "$dir/state/.lock.omp-claude" ] \
     && fail "an interrupted omp acquisition left a stale omp-identity marker behind"
-  pass "session-lock e2e: an omp acquisition interrupted between writing the lock and persisting its identity marker rolls the lock back instead of leaving it unverifiable"
+  pass "session-lock e2e: an omp acquisition interrupted while persisting its identity marker leaves no lock behind instead of publishing an unverifiable one"
 }
 
 test_version_named_session_is_identified_on_both_platforms

--- a/tests/fm-session-lock-ancestry.test.sh
+++ b/tests/fm-session-lock-ancestry.test.sh
@@ -322,6 +322,122 @@ SH
   pass "session-lock: a foreign omp pid outside this ancestry is never classified as alive from the checker's own CLAUDECODE marker"
 }
 
+test_omp_ancestry_stops_at_omp_and_does_not_extend_into_a_claude_parent() {
+  local dir fakebin got
+  dir="$TMP_ROOT/omp-no-extend"
+  fakebin=$(fm_fakebin "$dir")
+  mkdir -p "$dir/state"
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+field= pid=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) field=$2; shift 2 ;;
+    -p) pid=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+case "$pid:$field" in
+  500:comm=) printf '%s\n' omp ;;
+  500:args=) printf '%s\n' omp ;;
+  500:ppid=) printf '%s\n' 600 ;;
+  600:comm=) printf '%s\n' claude ;;
+  600:args=) printf '%s\n' claude ;;
+  600:ppid=) printf '%s\n' 1 ;;
+  *:comm=) printf '%s\n' bash ;;
+  *:args=) printf '%s\n' bash ;;
+  *:ppid=) printf '%s\n' 500 ;;
+esac
+SH
+  chmod +x "$fakebin/ps"
+  # omp (pid 500) is directly parented by an unrelated claude-named launcher
+  # (pid 600). omp's own comment states it has no nested worker chain to
+  # climb the way native Claude Code does, so the walk must stop at 500 and
+  # never report the launcher's pid - reporting 600 would make the lock look
+  # held for as long as the launcher lives, even after omp itself exits.
+  got=$(CLAUDECODE=1 lib_eval "$fakebin" 'fm_harness_ancestry_pid') \
+    || fail "an omp session parented by a claude-named launcher was not recognized as a harness process"
+  [ "$got" = 500 ] || fail "ancestry resolved '$got', expected omp to be its own session boundary at pid 500, not its claude-named parent"
+  pass "session-lock: the ancestry walk stops at omp and never extends into a claude-named parent"
+}
+
+test_persisted_omp_claude_marker_lets_a_foreign_checker_see_a_live_omp_session() {
+  local dir fakebin marker
+  dir="$TMP_ROOT/omp-persisted-marker"
+  fakebin=$(fm_fakebin "$dir")
+  mkdir -p "$dir/state"
+  marker="$dir/state/.lock.omp-claude"
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+field= pid=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) field=$2; shift 2 ;;
+    -p) pid=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+case "$pid:$field" in
+  500:comm=) printf '%s\n' omp ;;
+  500:args=) printf '%s\n' omp ;;
+  500:ppid=) printf '%s\n' 1 ;;
+  650:comm=) printf '%s\n' claude ;;
+  650:args=) printf '%s\n' claude ;;
+  650:ppid=) printf '%s\n' 1 ;;
+  *:comm=) printf '%s\n' bash ;;
+  *:args=) printf '%s\n' bash ;;
+  *:ppid=) printf '%s\n' 650 ;;
+esac
+SH
+  chmod +x "$fakebin/ps"
+  # pid 500 is a genuinely live, CLAUDECODE-verified omp session in an
+  # entirely different session tree - this checker descends from the
+  # unrelated harness 650 instead, and carries no CLAUDECODE of its own. No
+  # amount of local evidence can prove pid 500's own environment from here,
+  # so fm-lock.sh must have persisted that verification when it wrote pid 500
+  # into the lock; only that persisted record can make this checker trust it.
+  printf '500\n' > "$dir/state/.lock"
+
+  # fm_harness_record_omp_claude, called from the writer's own context where
+  # CLAUDECODE=1 is sound evidence about pid 500, is what produces that record.
+  CLAUDECODE=1 lib_eval "$fakebin" "fm_harness_record_omp_claude '$dir/state' 500"
+  [ "$(cat "$marker" 2>/dev/null || true)" = 500 ] \
+    || fail "fm_harness_record_omp_claude did not persist the verified omp pid"
+
+  # Without the marker, this foreign checker correctly still cannot confirm
+  # pid 500 - this is the pre-existing fail-closed behavior and must not
+  # regress.
+  rm -f "$marker"
+  if lib_eval "$fakebin" "fm_harness_pid_alive 500 '$dir/state'"; then
+    fail "a foreign omp pid was seen as alive with no persisted marker present"
+  fi
+
+  # With the persisted marker in place, this foreign checker now correctly
+  # sees the live omp session as alive, without needing its own CLAUDECODE.
+  printf '500\n' > "$marker"
+  lib_eval "$fakebin" "fm_harness_pid_alive 500 '$dir/state'" \
+    || fail "a live, marker-verified omp session held by a different session tree was classified as stale"
+
+  # A marker naming a different pid than the one being checked - the
+  # signature of a reused pid number after the verified session exited -
+  # must never be trusted for this pid.
+  printf '999\n' > "$marker"
+  if lib_eval "$fakebin" "fm_harness_pid_alive 500 '$dir/state'"; then
+    fail "a marker naming a different pid was accepted as evidence for pid 500"
+  fi
+
+  # fm_harness_record_omp_claude must also clear a stale marker when the pid
+  # it is now given is not omp, so a later non-omp acquisition never leaves a
+  # foreign checker trusting a leftover record for a reused pid number.
+  printf '500\n' > "$marker"
+  lib_eval "$fakebin" "fm_harness_record_omp_claude '$dir/state' 650"
+  [ -e "$marker" ] && fail "fm_harness_record_omp_claude left a stale marker after a non-omp pid was recorded"
+
+  pass "session-lock: a foreign checker trusts the lock writer's persisted omp+CLAUDECODE record, never its own ambient marker"
+}
+
 # --- end-to-end layer: the real Stop auto-arm in real process trees ----------
 
 install_autoarm_scripts() {
@@ -464,6 +580,8 @@ test_omp_is_claude_identified_only_with_claudecode_marker
 test_harness_beyond_a_gap_never_owns_the_lock
 test_competing_version_named_session_is_seen_as_live
 test_foreign_omp_pid_does_not_borrow_the_checkers_own_claudecode_marker
+test_omp_ancestry_stops_at_omp_and_does_not_extend_into_a_claude_parent
+test_persisted_omp_claude_marker_lets_a_foreign_checker_see_a_live_omp_session
 test_e2e_version_named_session_claims_the_home
 test_e2e_daemon_parented_session_claims_the_home
 test_e2e_daemon_parented_version_named_session_keeps_its_lock

--- a/tests/fm-session-lock-ancestry.test.sh
+++ b/tests/fm-session-lock-ancestry.test.sh
@@ -275,6 +275,53 @@ SH
   pass "session-lock: a live version-named session holding the lock is not mistaken for a stale owner"
 }
 
+test_foreign_omp_pid_does_not_borrow_the_checkers_own_claudecode_marker() {
+  local dir fakebin
+  dir="$TMP_ROOT/foreign-omp"
+  fakebin=$(fm_fakebin "$dir")
+  mkdir -p "$dir/state"
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+field= pid=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) field=$2; shift 2 ;;
+    -p) pid=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+case "$pid:$field" in
+  500:comm=) printf '%s\n' omp ;;
+  500:args=) printf '%s\n' omp ;;
+  500:ppid=) printf '%s\n' 1 ;;
+  650:comm=) printf '%s\n' claude ;;
+  650:args=) printf '%s\n' claude ;;
+  650:ppid=) printf '%s\n' 1 ;;
+  *:comm=) printf '%s\n' bash ;;
+  *:args=) printf '%s\n' bash ;;
+  *:ppid=) printf '%s\n' 650 ;;
+esac
+SH
+  chmod +x "$fakebin/ps"
+  # pid 500 is an omp process outside this ancestry entirely - this checking
+  # process descends from the unrelated harness 650 instead. $CLAUDECODE=1
+  # here describes THIS session's own backend, not pid 500's: trusting it
+  # would let any Claude-marked checker treat an unrelated omp process (which
+  # may not even be Claude-backed - omp is also the name of an unrelated
+  # popular shell-prompt tool) as a live competing session forever, and
+  # trusting its absence would let an unmarked checker declare a genuinely
+  # live Claude-backed omp session stale and steal its lock.
+  printf '500\n' > "$dir/state/.lock"
+  if CLAUDECODE=1 lib_eval "$fakebin" "fm_session_lock_owned_by_self '$dir/state'"; then
+    fail "a foreign omp pid outside this ancestry was claimed as this session's own"
+  fi
+  if CLAUDECODE=1 lib_eval "$fakebin" 'fm_harness_pid_alive 500'; then
+    fail "a foreign omp pid was classified as alive using the checker's own CLAUDECODE marker instead of its own"
+  fi
+  pass "session-lock: a foreign omp pid outside this ancestry is never classified as alive from the checker's own CLAUDECODE marker"
+}
+
 # --- end-to-end layer: the real Stop auto-arm in real process trees ----------
 
 install_autoarm_scripts() {
@@ -416,6 +463,7 @@ test_ordinary_paths_are_never_harness_processes
 test_omp_is_claude_identified_only_with_claudecode_marker
 test_harness_beyond_a_gap_never_owns_the_lock
 test_competing_version_named_session_is_seen_as_live
+test_foreign_omp_pid_does_not_borrow_the_checkers_own_claudecode_marker
 test_e2e_version_named_session_claims_the_home
 test_e2e_daemon_parented_session_claims_the_home
 test_e2e_daemon_parented_version_named_session_keeps_its_lock


### PR DESCRIPTION
## Intent

Add the live-harness-optin guard test for omp's session-lock recognition that firstmate-coding-guidelines requires for any harness-dependent check (a verdict from a process name plus an env marker needs both a portable regression AND a live guard against the real vendor binary). The prior run's review found the portable regression alone (against a stubbed ps) was insufficient. This follow-up, authorized by the captain after reviewing options for how to proceed given the already-CI-green PR, adds tests/fm-omp-session-lock-live-e2e.test.sh: it drives the real installed omp binary (opt-in via FM_OMP_LOCK_LIVE_E2E=1, mirroring tests/fm-harness-liveness-drift-live-e2e.test.sh's pattern) and uses omp's own bash tool to empirically confirm the two vendor facts the session-lock recognition depends on - that a real omp process's own comm/argv0 report base name 'omp', and that a real omp session's own process environment genuinely carries CLAUDECODE=1 - then exercises the real (unfaked) fm_harness_process_matches against that real observed data. I verified this live guard actually passes against the installed omp 18.0.4 before committing. I also registered the new test in bin/fm-test-run.sh's family_for_basename so it classifies as live-harness-optin (not unclassified), recorded the dated verification evidence in docs/verification/runtime-backends.md under a new 'omp (session-lock identity)' section per the coding guidelines' requirement to record and point at the live guard as the refresh command, and updated the existing harness-adapters SKILL.md note to describe the self-vs-foreign-pid distinction that bin/fm-session-lock-lib.sh and bin/fm-lock.sh already implement (a foreign lock-holder pid is verified against a persisted marker recorded at lock-acquisition time, never the checking session's own ambient CLAUDECODE, and the ancestry walk does not extend past omp's own process). This is a pure test/doc addition on top of the existing, already-validated fix commits; no production logic changed in this commit. Do not re-litigate the marker-gated design - that choice was already made and confirmed by the captain over the alternative bare-name-harness-table mechanism.

## What Changed

- `bin/fm-session-lock-lib.sh` adds marker-gated recognition of `omp` (Oh My Pi) as Claude-identified for session-lock ownership: `fm_harness_process_matches` now accepts a `self` argument and only trusts the caller's own `CLAUDECODE=1` when the examined pid is a verified ancestor of the caller (never a bare `omp` name match, and never for an arbitrary foreign pid); `fm_harness_ancestry_pids` passes `self=1` for its own ppid-chain walk, and `fm_harness_pid_alive` now takes a state-dir argument and falls back to a persisted `.lock.omp-claude` marker (written by the new `fm_harness_record_omp_claude`) to verify a foreign omp lock holder without reading that process's own environment.
- `bin/fm-lock.sh` calls `fm_harness_record_omp_claude` on every successful lock acquisition (clearing the marker for non-omp holders) and fails the acquisition, removing the lock, if the marker write fails; `bin/fm-lock.sh`, `bin/fm-claude-stop-autoarm.sh`, and `bin/fm-turnend-guard-cursor.sh` are updated to pass the state dir into `fm_harness_pid_alive`.
- `bin/fm-test-run.sh` classifies the new `fm-omp-session-lock-live-e2e.test.sh` under the `live-harness-optin` family.
- Adds `tests/fm-omp-session-lock-live-e2e.test.sh`, an opt-in (`FM_OMP_LOCK_LIVE_E2E=1`) live guard that drives the real installed `omp` binary to confirm its `comm`/argv0 reports base name `omp` and that its own process environment carries `CLAUDECODE=1`, then exercises the real `fm_harness_process_matches` against that observed data; extends `tests/fm-session-lock-ancestry.test.sh` with portable regressions covering marker-gated recognition, foreign-pid non-borrowing, and related ancestry edge cases.
- Updates `.agents/skills/harness-adapters/SKILL.md` and adds an "omp (session-lock identity)" section to `docs/verification/runtime-backends.md` documenting the self-vs-foreign-pid distinction and dated live-verification evidence (omp 18.0.4, macOS 26.5.0 arm64).

## Risk Assessment

✅ Low: This commit is a pure test/doc addition (no production logic changes) that adds an opt-in live guard correctly mirroring the existing fm-harness-liveness-drift-live-e2e.test.sh pattern, calls the real fm_harness_process_matches with the correct signature and self=1 semantics matching the library's documented contract, is correctly registered in fm-test-run.sh's live-harness-optin family, and its doc/SKILL.md updates accurately describe already-shipped library behavior verified by reading bin/fm-session-lock-lib.sh directly.

## Testing

Ran the portable ancestry regression and then actually exercised the new opt-in live guard against the real installed omp 18.0.4 binary — it passed all three assertions, reproducing verbatim the evidence recorded in docs/verification/runtime-backends.md, which is the strongest available end-to-end proof for a live-harness-optin test. Confirmed via inspection-only fm-test-run.sh commands that the test is correctly registered as live-harness-optin (not unclassified) and that coverage accounting still balances. Verified the commit itself changes only tests/docs/registration, no production logic. No issues found; worktree left clean with no stray processes or temp files.

<details>
<summary>Evidence: Live omp session-lock guard run (FM_OMP_LOCK_LIVE_E2E=1) against installed omp 18.0.4</summary>

```text
$ FM_OMP_LOCK_LIVE_E2E=1 bash tests/fm-omp-session-lock-live-e2e.test.sh
# omp omp/18.0.4: its own bash tool reported CLAUDECODE=1 in its own environment
ok - omp session-lock live guard: a real omp session's own process environment carries CLAUDECODE=1
# omp omp/18.0.4: live process comm='/opt/homebrew/bin/omp' args='/opt/homebrew/bin/omp -p --no-session Run this exact bash command using your tool and output only its result, nothing else: echo -n "OMPCLAUDECODE=$CLAUDECODE"; sleep 3'
ok - omp session-lock live guard: a real omp process's own comm reports base name 'omp'
ok - omp session-lock live guard: the real (unfaked) classifier recognizes a live omp process from its own ancestry without extending past it
EXIT:0
```
</details>
<details>
<summary>Evidence: Live guard correctly skips without opt-in</summary>

```text
$ bash tests/fm-omp-session-lock-live-e2e.test.sh
skip: set FM_OMP_LOCK_LIVE_E2E=1 to run the live omp session-lock identity guard
```
</details>
<details>
<summary>Evidence: New test classified as live-harness-optin (not unclassified)</summary>

```text
$ bin/fm-test-run.sh --list --family live-harness-optin | grep omp
tests/fm-omp-session-lock-live-e2e.test.sh

$ bin/fm-test-run.sh --list --family unclassified | grep omp
(no output)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"bbe7645ae380f2eac609baa100303b1407616f28","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-session-lock-ancestry.test.sh (portable regression, 12/12 ok)`
- `bash tests/fm-omp-session-lock-live-e2e.test.sh (no opt-in — confirms correct skip behavior)`
- `FM_OMP_LOCK_LIVE_E2E=1 bash tests/fm-omp-session-lock-live-e2e.test.sh (live guard against real installed omp 18.0.4 — all 3 assertions pass)`
- `bin/fm-test-run.sh --list --family live-harness-optin | grep omp (confirms family registration)`
- `bin/fm-test-run.sh --list --family unclassified | grep omp (confirms it is NOT unclassified)`
- `bin/fm-test-run.sh --check-coverage (coverage guard still balances, no execution)`
- `git show --stat bbe7645 (confirms commit touches only test/doc files, no production logic)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
