### PR TITLE
feat: integrate bounded GNHF companion execution

### DIFF
--- a/.agents/skills/gnhf-companion/SKILL.md
+++ b/.agents/skills/gnhf-companion/SKILL.md
@@ -142,11 +142,18 @@ there is no dedicated `fm-brief.sh` flag for this and none is needed.
   this is sufficient and required.
 - **A reviewable branch.** GNHF's incremental per-iteration commits already produce one;
   nothing extra is required beyond the crewmate's own normal report of branch state.
-- **Stops must actually stop.** GNHF already treats a complete no-op iteration as a failure
-  counting toward its own consecutive-failure abort, and aborts immediately on a permanent
-  agent error. The crewmate must never relaunch GNHF with a raised failure tolerance or a
-  reworded prompt to push through a real abort; a GNHF abort is the crewmate's own
-  `blocked:` or `needs-decision:` trigger, carrying the printed run log path as evidence.
+- **Stops must actually stop.** GNHF aborts immediately on a permanent agent error, and
+  that abort is mechanical. Its no-op handling is not: GNHF only *asks* its inner agent, in
+  the iteration prompt, to report a no-op iteration as `success=false` so the run can halt,
+  and never verifies the claim. If the agent instead reports success with nothing staged,
+  GNHF's commit step finds no staged diff and silently makes no commit, yet still counts the
+  iteration as good and resets the consecutive-failure counter to zero - so a misreporting
+  agent can quietly burn the entire `--max-iterations` budget doing nothing and still exit
+  0. Treat the iteration and token caps, plus the crewmate's own diff inspection, as the
+  only mechanical bound on a no-op spin. The crewmate must never relaunch GNHF with a raised
+  failure tolerance or a reworded prompt to push through a real abort; a GNHF abort is the
+  crewmate's own `blocked:` or `needs-decision:` trigger, carrying the printed run log path
+  as evidence.
 
 ## Agent selection
 
@@ -162,6 +169,17 @@ GNHF's own `~/.gnhf/config.yml` agent without checking it agrees with what that 
 resolves to, and do not hard-code which agents GNHF supports - its `--agent` roster comes
 from the installed `gnhf --help` and its own README "Agents" table, discovered live as
 shown above, never a roster pinned in this file.
+
+That precedence names a firstmate harness, which is not the same set as GNHF's `--agent`
+roster, so the value it resolves to is a candidate rather than the flag's value. Pass
+`--agent` only a name present in GNHF's own live-discovered roster: GNHF validates the flag
+fail-closed and exits non-zero on an unknown name, so a firstmate-verified harness GNHF does
+not implement natively makes the run die on a configuration mismatch rather than on anything
+about the task. When the resolved candidate has no direct match in that roster, do not
+invent or assume an `acp:<target>` mapping for it. Fall back instead to the highest-precedence
+candidate from that same resolution which is both a firstmate-verified harness and present
+in GNHF's discovered roster, under the same anti-downgrade boundary; if no candidate
+satisfies both, stop and report rather than guessing.
 
 ## No new supervision surface
 
@@ -219,6 +237,10 @@ Before treating any GNHF-driven branch as ready, whether reviewing between Compa
 or at a Hands-Off task's own `done:`:
 
 1. Inspect branch, status, commits, changed files, and diff - never GNHF's summary alone.
+   Check the run's commit count and branch diff stats against its reported good/failed
+   iteration tally rather than trusting the tally itself: "N good iterations" with fewer
+   than N new commits means iterations were counted good without committing anything, which
+   is a stop-and-investigate signal rather than evidence of progress.
 2. Read GNHF's `notes.md` and debug log as claims, not evidence.
 3. Run the task's own real verification: tests, lint, build, or domain-specific checks.
 4. Compare the result against current intent and the task's stop condition.

--- a/.agents/skills/gnhf-companion/SKILL.md
+++ b/.agents/skills/gnhf-companion/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: gnhf-companion
+description: >-
+  Agent-only procedure for using the installed GNHF tool (good night, have fun) as a
+  bounded, explicitly selected execution technique inside one crewmate's own isolated
+  task worktree. Use before briefing a crewmate to run GNHF in Hands-Off or Companion
+  mode, before authoring or steering a GNHF-driven task, and before treating its branch
+  as ready for delivery. Owns mode selection, the required prompt/cap/stop-condition
+  contract, the worktree and merge-authority boundary, why GNHF is never armed as a
+  process-event source, and how its completion reaches Firstmate's existing status,
+  steering, validation, and merge-authority contracts unchanged.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# gnhf-companion
+
+GNHF ("good night, have fun") is an installed CLI, not a firstmate script: `gnhf --help` and
+the skill the npm package ships at its own `skills/gnhf/SKILL.md` are the version-matched
+authority on its flags, modes, and agent roster. Discover the installed copy rather than
+trusting any flag list below past a version bump:
+
+```sh
+gnhf --help
+gnhf_root="$(dirname "$(dirname "$(readlink -f "$(command -v gnhf)")")")"
+cat "$gnhf_root/skills/gnhf/SKILL.md"
+```
+
+GNHF repeatedly invokes one coding agent (`--agent`) until a natural-language `--stop-when`
+condition is met or a cap is hit, committing each successful iteration and rolling back each
+failed one. It is a bounded execution technique, not a new class of firstmate-managed entity.
+
+## Placement: a crewmate technique, never a firstmate primary action
+
+Firstmate remains the orchestrator. GNHF executes one bounded scope inside a genuine
+isolated worker copy - the crewmate's own task worktree from `bin/fm-spawn.sh` - and only
+a crewmate already inside that worktree may invoke it. AGENTS.md hard rule 1 (never write
+to a project) forbids firstmate's own primary session from running `gnhf` against a
+project directly, and nothing here creates an exception: firstmate's role is to brief,
+steer, and review a crewmate that chooses to use GNHF, exactly as it briefs, steers, and
+reviews any other crewmate.
+
+Because a task worktree is already exclusive to the crewmate that owns it (`fm-spawn`'s
+isolation assertion), no GNHF run can overlap a different worker owning the same scope
+without a second worktree pointed at the same task existing in the first place, which the
+spawn contract already prevents. Nothing new needs to detect that overlap.
+
+## GNHF never grants authority
+
+GNHF completion is not firstmate acceptance. A `--stop-when` match only means the worker
+stopped. Before any `done:` line, the crewmate independently compares the branch to current
+intent and re-verifies with real checks; before delivery, firstmate applies the task's
+selected delivery path exactly as it would for any other crewmate (AGENTS.md section 7).
+GNHF grants no merge authority, no approval authority, no security-sensitive authority, and
+no permission to skip or answer around `no-mistakes`: an ask-user finding surfaced through a
+GNHF-driven task still escalates through `ask-user-authority`, and a red or gated pipeline
+is never treated as done because a GNHF iteration reported success.
+
+## Mode selection
+
+Firstmate chooses the mode once, at brief-authoring time, the same tier as choosing the
+task's delivery mode. Both modes ride the existing crewmate spawn, status, steering,
+validation, and merge-authority contracts unchanged; GNHF only changes how the crewmate
+spends its own foreground turns.
+
+### Hands-Off
+
+Use when the task is bounded and the stop condition is verifiable evidence, not judgment.
+Author one precise brief with the required contract below, spawn the crewmate as normal,
+and wait for its ordinary `done:` / `blocked:` / `needs-decision:` status - no incremental
+steering is expected. The crewmate itself intervenes early only for a hard failure, runaway
+scope, destructive behavior, or an impossible prerequisite, exactly as it would while
+working without GNHF.
+
+### Companion
+
+Use when the task is uncertain, exploratory, or likely to need course correction. Brief the
+crewmate to run GNHF in small bounded slices (a low `--max-iterations` per invocation)
+and report `working:` between slices through the ordinary status protocol. Firstmate
+reviews the branch after each slice the same way it reviews any worker's partial progress,
+then steers the next slice's prompt through ordinary `fm-send` - never mid-invocation, only
+between bounded GNHF calls, so a steer can never race GNHF's own iteration commit or
+rollback. Treat GNHF's own `notes.md` and exit summary as claims, not evidence; inspect
+`git status`, `git log`, and the diff before deciding whether to continue.
+
+Signals worth steering on, adapted from GNHF's own skill:
+
+| Signal | Action |
+| --- | --- |
+| Real blocker found | Stop, or relaunch with blocker-specific instructions |
+| Good partial slice | Let it continue, or tighten the next stop condition |
+| Skipped requested research | Relaunch with research as the explicit first deliverable |
+| Unrelated files changed | Stop and review before continuing |
+| Success claimed without verification | Review immediately; relaunch only with an evidence-based stop condition |
+| Reviewer or captain finds a blocking issue | Relaunch with that finding as the sole bounded correction |
+
+## Required brief contract
+
+Every GNHF invocation a crewmate is briefed to run must satisfy all of the following;
+author it into the task's own `{TASK}` brief content, not as a separate scaffold flag -
+there is no dedicated `fm-brief.sh` flag for this and none is needed.
+
+- **Outcome-based prompt.** State one concrete objective, explicit non-goals, and what
+  "preserve user changes" means for this task (do not touch files outside the stated
+  surface). Never accept a vague prompt like "keep improving this."
+- **Observable stop condition.** Pass `--stop-when "<evidence-based condition>"`. Bad:
+  "looks good." Good: "the target test suite passes and no file outside `src/foo/` changed."
+- **Explicit caps.** Pass `--max-iterations <n>` and `--max-tokens <n>` sized to the task.
+  GNHF has no direct wall-clock flag; treat the iteration and token caps as the runtime
+  bound, and set `--max-rate-limit-wait` explicitly rather than leaving its 24h default when
+  the task needs a tighter window.
+- **Clean starting state.** GNHF itself refuses a dirty working tree; a freshly spawned
+  task worktree already starts clean, so this is satisfied by the ordinary spawn contract
+  as long as GNHF is the first thing the crewmate runs there.
+- **`--current-branch`, never `--worktree`.** The crewmate's task worktree from `fm-spawn`
+  is already the isolated worker copy; GNHF's own `--worktree` mode exists to isolate
+  *multiple* GNHF runs inside one shared checkout, which would nest a second, redundant
+  isolation boundary inside the first and GNHF itself refuses to combine with
+  `--current-branch`. Run GNHF on the crewmate's own current branch instead.
+- **`--push` only when the task's own delivery mode already pushes.** GNHF's `--push` is a
+  crewmate decision under the ordinary delivery contract (`no-mistakes` or `direct-PR`), not
+  a GNHF default; omit it for `local-only` tasks and for any task still under review.
+- **No `&`, no `nohup`, no detached backgrounding.** Run GNHF as an ordinary foreground
+  command inside the crewmate's own turn. See "No new supervision surface" below for why
+  this is sufficient and required.
+- **A reviewable branch.** GNHF's incremental per-iteration commits already produce one;
+  nothing extra is required beyond the crewmate's own normal report of branch state.
+- **Stops must actually stop.** GNHF already treats a complete no-op iteration as a failure
+  counting toward its own consecutive-failure abort, and aborts immediately on a permanent
+  agent error. The crewmate must never relaunch GNHF with a raised failure tolerance or a
+  reworded prompt to push through a real abort; a GNHF abort is the crewmate's own
+  `blocked:` or `needs-decision:` trigger, carrying the printed run log path as evidence.
+
+## Agent selection
+
+Pick GNHF's own `--agent` (the inner coding agent GNHF repeatedly invokes) under the same
+standing preference that already governs crewmate harness/model selection - never a model
+as strong as firstmate's own primary (`data/captain.md`, "Model and runtime"; standing
+routing in `config/crew-dispatch.json`, resolved through `quota-array-dispatch` when more
+than one candidate matches). Do not default to GNHF's own `~/.gnhf/config.yml` agent
+without checking it agrees with that preference, and do not hard-code which agents GNHF
+supports - its `--agent` roster comes from the installed `gnhf --help` and its own README
+"Agents" table, discovered live as shown above, never a roster pinned in this file.
+
+## No new supervision surface
+
+`bin/fm-procevent.sh` (see `process-event-sources`) is scoped to sources this firstmate
+*home* owns and blocks on, with no per-project working-directory concept: arming it to run
+`gnhf` would make firstmate's own background runner the actor executing a project-mutating
+command, which is exactly what hard rule 1 forbids. GNHF is therefore never registered as a
+process-event source, and none of process-event-sources' arming or wake-handling commands
+apply to it.
+
+Instead, GNHF rides the worker path that already exists: a crewmate occupying its own
+foreground turn on a long-running command is not a new situation - it is what a crewmate
+already does for a build, a test suite, or a `no-mistakes` run - and firstmate's existing
+per-task supervision (stale-wake detection, `bin/fm-crew-state.sh`, the crewmate's own
+status file) already covers it without any GNHF-specific change. Completion reaches
+firstmate the same way any other crewmate turn's completion does: the crewmate's own next
+status append.
+
+A crewmate's own harness can itself bound a single foreground tool call (for example,
+Claude Code's own Bash tool caps one call at 10 minutes). This is a property of the acting
+harness, not of GNHF or of firstmate's supervision, and it is not a license to reach for
+shell backgrounding: size `--max-iterations`/`--max-tokens` so one invocation comfortably
+fits inside the acting harness's own foreground budget, and let the crewmate's own
+multi-turn loop invoke GNHF again with `--current-branch` (which resumes automatically) on
+a later turn for a longer overall span. Verify the acting harness's own limit rather than
+assuming one; a harness with no documented cap needs no such splitting.
+
+## Companion review before delivery
+
+Before treating any GNHF-driven branch as ready, whether reviewing between Companion slices
+or at a Hands-Off task's own `done:`:
+
+1. Inspect branch, status, commits, changed files, and diff - never GNHF's summary alone.
+2. Read GNHF's `notes.md` and debug log as claims, not evidence.
+3. Run the task's own real verification: tests, lint, build, or domain-specific checks.
+4. Compare the result against current intent and the task's stop condition.
+5. Decide: continue with another bounded GNHF slice, hand off to ordinary manual work, or
+   proceed to the task's selected delivery path (AGENTS.md section 7) exactly as any other
+   crewmate task - GNHF changes nothing about which path applies or who approves it.

--- a/.agents/skills/gnhf-companion/SKILL.md
+++ b/.agents/skills/gnhf-companion/SKILL.md
@@ -125,9 +125,10 @@ there is no dedicated `fm-brief.sh` flag for this and none is needed.
   the first invocation, but the precondition applies to every later one too: Companion
   mode's own between-slice review runs the task's real verification and may hand off to
   ordinary manual work, either of which can leave scratch notes or interim artifacts
-  behind. Commit or discard everything so `git status --porcelain` is empty before invoking
-  GNHF again, or the next slice dies with "Working tree is not clean" on a self-inflicted
-  precondition rather than on anything about the task.
+  behind. Preserve user changes, commit intentional task changes, and safely remove only
+  disposable artifacts so `git status --porcelain` is empty before invoking GNHF again,
+  or the next slice dies with "Working tree is not clean" on a self-inflicted precondition
+  rather than on anything about the task.
 - **`--current-branch`, never `--worktree`.** The crewmate's task worktree from `fm-spawn`
   is already the isolated worker copy; GNHF's own `--worktree` mode exists to isolate
   *multiple* GNHF runs inside one shared checkout, which would nest a second, redundant
@@ -141,7 +142,8 @@ there is no dedicated `fm-brief.sh` flag for this and none is needed.
   command inside the crewmate's own turn. See "No new supervision surface" below for why
   this is sufficient and required.
 - **A reviewable branch.** GNHF's incremental per-iteration commits already produce one;
-  nothing extra is required beyond the crewmate's own normal report of branch state.
+  preserve all branch history that predates the invocation, and do not rewrite or drop it.
+  Nothing else is required beyond the crewmate's own normal report of branch state.
 - **Stops must actually stop.** GNHF aborts immediately on a permanent agent error, and
   that abort is mechanical. Its no-op handling is not: GNHF only *asks* its inner agent, in
   the iteration prompt, to report a no-op iteration as `success=false` so the run can halt,

--- a/.agents/skills/gnhf-companion/SKILL.md
+++ b/.agents/skills/gnhf-companion/SKILL.md
@@ -166,9 +166,23 @@ Claude Code's own Bash tool caps one call at 10 minutes). This is a property of 
 harness, not of GNHF or of firstmate's supervision, and it is not a license to reach for
 shell backgrounding: size `--max-iterations`/`--max-tokens` so one invocation comfortably
 fits inside the acting harness's own foreground budget, and let the crewmate's own
-multi-turn loop invoke GNHF again with `--current-branch` (which resumes automatically) on
-a later turn for a longer overall span. Verify the acting harness's own limit rather than
-assuming one; a harness with no documented cap needs no such splitting.
+multi-turn loop invoke GNHF again on a later turn for a longer overall span. Verify the
+acting harness's own limit rather than assuming one; a harness with no documented cap needs
+no such splitting.
+
+Re-invoking is not automatically a resume. Verified against the installed gnhf 0.1.45,
+`--current-branch` resume is keyed to a byte-identical prompt string: gnhf hashes the whole
+prompt to derive the run id, so a reworded prompt - even one differing only by a trailing
+space - silently starts a brand-new run with a fresh iteration and token budget and none of
+the accumulated `notes.md` context, and reports no error when it does. To get a true resume
+across a crewmate's own turns, re-invoke with the exact same prompt string, unchanged. A
+crewmate that cannot guarantee a byte-identical re-invocation must instead treat each
+invocation as its own fresh bounded run and account for cumulative iterations and tokens
+across those calls itself, because gnhf's own caps only ever bound one invocation. In
+Companion mode this is not a defect: each steered slice is already intentionally a fresh
+bounded run by design, since new instructions mean a new bounded scope, so firstmate should
+size each slice's caps knowing that slice receives its own full budget rather than a
+continuously draining shared one.
 
 ## Companion review before delivery
 

--- a/.agents/skills/gnhf-companion/SKILL.md
+++ b/.agents/skills/gnhf-companion/SKILL.md
@@ -237,10 +237,18 @@ Before treating any GNHF-driven branch as ready, whether reviewing between Compa
 or at a Hands-Off task's own `done:`:
 
 1. Inspect branch, status, commits, changed files, and diff - never GNHF's summary alone.
-   Check the run's commit count and branch diff stats against its reported good/failed
-   iteration tally rather than trusting the tally itself: "N good iterations" with fewer
-   than N new commits means iterations were counted good without committing anything, which
-   is a stop-and-investigate signal rather than evidence of progress.
+   To catch the silent no-op spin above, measure each invocation's real progress yourself:
+   capture `git rev-parse HEAD` immediately *before* invoking GNHF, and once it exits count
+   only the commits that invocation actually added, with
+   `git rev-list --count <pre-invocation-head>..HEAD`. Compare that against the same
+   invocation's own reported good-iteration count; "N good iterations" having added fewer
+   than N commits means iterations were counted good without committing anything, which is a
+   stop-and-investigate signal rather than evidence of progress. Never compare against
+   GNHF's own printed `branch diff N commits` figure: it is computed from the run's original
+   base commit, so on any resumed invocation it still includes every earlier invocation's
+   commits and would report a clean-looking all-clear for a run that did nothing this time.
+   The printed `iterations N total` is cumulative for the same reason, while the good/failed
+   tally resets each invocation - so those two figures are not on a common base either.
 2. Read GNHF's `notes.md` and debug log as claims, not evidence.
 3. Run the task's own real verification: tests, lint, build, or domain-specific checks.
 4. Compare the result against current intent and the task's stop condition.

--- a/.agents/skills/gnhf-companion/SKILL.md
+++ b/.agents/skills/gnhf-companion/SKILL.md
@@ -109,7 +109,15 @@ there is no dedicated `fm-brief.sh` flag for this and none is needed.
 - **Explicit caps.** Pass `--max-iterations <n>` and `--max-tokens <n>` sized to the task.
   GNHF has no direct wall-clock flag; treat the iteration and token caps as the runtime
   bound, and pass an explicit task-sized `--max-rate-limit-wait <duration>` on every
-  invocation rather than leaving its 24-hour default in effect.
+  invocation rather than leaving its 24-hour default in effect. When re-invoking to resume
+  an existing run, see "No new supervision surface" below: `--max-iterations` is cumulative
+  across a resume and must be raised each call, while `--max-tokens` is not.
+- **`GNHF_TELEMETRY=0`.** By default GNHF reports aggregate usage telemetry to a hard-coded
+  third-party host on every run: the agent name, run mode, final status, iteration, success,
+  failure and commit counts, token totals, duration, and which flags were set. Prompt text,
+  repository paths, and branch names are not included. Set `GNHF_TELEMETRY=0` in the
+  environment for firstmate-driven invocations (`GNHF_TELEMETRY=0 gnhf ...`, or export it
+  before the crewmate's invocation) rather than relying on GNHF's default-on behavior.
 - **Clean starting state.** GNHF itself refuses a dirty working tree; a freshly spawned
   task worktree already starts clean, so this is satisfied by the ordinary spawn contract
   as long as GNHF is the first thing the crewmate runs there.
@@ -178,11 +186,21 @@ the accumulated `notes.md` context, and reports no error when it does. To get a 
 across a crewmate's own turns, re-invoke with the exact same prompt string, unchanged. A
 crewmate that cannot guarantee a byte-identical re-invocation must instead treat each
 invocation as its own fresh bounded run and account for cumulative iterations and tokens
-across those calls itself, because gnhf's own caps only ever bound one invocation. In
-Companion mode this is not a defect: each steered slice is already intentionally a fresh
-bounded run by design, since new instructions mean a new bounded scope, so firstmate should
-size each slice's caps knowing that slice receives its own full budget rather than a
-continuously draining shared one.
+across those calls itself. In Companion mode this is not a defect: each steered slice is
+already intentionally a fresh bounded run by design, since new instructions mean a new
+bounded scope, so firstmate should size each slice's caps knowing that slice receives its
+own full budget rather than a continuously draining shared one.
+
+The two caps behave differently across a true resume, so a resuming crewmate must raise one
+of them by hand. `--max-iterations` carries forward cumulatively: gnhf restores the prior
+run's last iteration number as the starting count and checks it against whatever
+`--max-iterations` the new invocation passes, before doing any work. So re-issuing a
+byte-identical command with an unchanged cap aborts instantly with the same
+`max iterations reached (n)` summary, zero new iterations, and zero tokens - output that is
+indistinguishable from a legitimate cap stop, forever. When resuming to make further
+progress, raise `--max-iterations` on each successive call above the count the prior call
+already reached. `--max-tokens` needs no such adjustment: token totals reset to a fresh
+zero-based per-invocation budget on every call, resume or not.
 
 ## Companion review before delivery
 

--- a/.agents/skills/gnhf-companion/SKILL.md
+++ b/.agents/skills/gnhf-companion/SKILL.md
@@ -118,9 +118,16 @@ there is no dedicated `fm-brief.sh` flag for this and none is needed.
   repository paths, and branch names are not included. Set `GNHF_TELEMETRY=0` in the
   environment for firstmate-driven invocations (`GNHF_TELEMETRY=0 gnhf ...`, or export it
   before the crewmate's invocation) rather than relying on GNHF's default-on behavior.
-- **Clean starting state.** GNHF itself refuses a dirty working tree; a freshly spawned
-  task worktree already starts clean, so this is satisfied by the ordinary spawn contract
-  as long as GNHF is the first thing the crewmate runs there.
+- **Clean tree before every invocation.** GNHF refuses to start on a dirty working tree,
+  on both its resume and its fresh-run path, and its check is `git status --porcelain` with
+  default untracked reporting - so an untracked build artifact or coverage file blocks it
+  exactly as an uncommitted edit does. A freshly spawned task worktree satisfies this for
+  the first invocation, but the precondition applies to every later one too: Companion
+  mode's own between-slice review runs the task's real verification and may hand off to
+  ordinary manual work, either of which can leave scratch notes or interim artifacts
+  behind. Commit or discard everything so `git status --porcelain` is empty before invoking
+  GNHF again, or the next slice dies with "Working tree is not clean" on a self-inflicted
+  precondition rather than on anything about the task.
 - **`--current-branch`, never `--worktree`.** The crewmate's task worktree from `fm-spawn`
   is already the isolated worker copy; GNHF's own `--worktree` mode exists to isolate
   *multiple* GNHF runs inside one shared checkout, which would nest a second, redundant
@@ -143,14 +150,18 @@ there is no dedicated `fm-brief.sh` flag for this and none is needed.
 
 ## Agent selection
 
-Pick GNHF's own `--agent` (the inner coding agent GNHF repeatedly invokes) under the same
-standing preference that already governs crewmate harness/model selection - never a model
-as strong as firstmate's own primary (`data/captain.md`, "Model and runtime"; standing
-routing in `config/crew-dispatch.json`, resolved through `quota-array-dispatch` when more
-than one candidate matches). Do not default to GNHF's own `~/.gnhf/config.yml` agent
-without checking it agrees with that preference, and do not hard-code which agents GNHF
-supports - its `--agent` roster comes from the installed `gnhf --help` and its own README
-"Agents" table, discovered live as shown above, never a roster pinned in this file.
+GNHF's own `--agent` (the inner coding agent GNHF repeatedly invokes) is a crewmate
+harness/model choice like any other, so resolve it through the routing precedence AGENTS.md
+section 4 already defines: an explicit per-task captain override, then the best-fit
+configured rule in `config/crew-dispatch.json` (resolved through `quota-array-dispatch`
+when more than one candidate matches), then this home's own current standing preference,
+then the static crewmate harness. Section 4's own boundary applies unchanged at every step:
+preserve the captain's strongest-reasoning class rather than silently downgrading it solely
+to conserve quota, and stop and report if that class cannot proceed. Do not default to
+GNHF's own `~/.gnhf/config.yml` agent without checking it agrees with what that precedence
+resolves to, and do not hard-code which agents GNHF supports - its `--agent` roster comes
+from the installed `gnhf --help` and its own README "Agents" table, discovered live as
+shown above, never a roster pinned in this file.
 
 ## No new supervision surface
 

--- a/.agents/skills/gnhf-companion/SKILL.md
+++ b/.agents/skills/gnhf-companion/SKILL.md
@@ -41,10 +41,10 @@ project directly, and nothing here creates an exception: firstmate's role is to 
 steer, and review a crewmate that chooses to use GNHF, exactly as it briefs, steers, and
 reviews any other crewmate.
 
-Because a task worktree is already exclusive to the crewmate that owns it (`fm-spawn`'s
-isolation assertion), no GNHF run can overlap a different worker owning the same scope
-without a second worktree pointed at the same task existing in the first place, which the
-spawn contract already prevents. Nothing new needs to detect that overlap.
+The crewmate's task worktree isolates its filesystem writes from every other worker's
+working directory, so GNHF cannot directly collide with another worker's in-progress
+files. This does not serialize overlapping scopes across tasks; ordinary branch review
+and reconciliation still apply when separately spawned workers touch the same subsystem.
 
 ## GNHF never grants authority
 
@@ -108,8 +108,8 @@ there is no dedicated `fm-brief.sh` flag for this and none is needed.
   "looks good." Good: "the target test suite passes and no file outside `src/foo/` changed."
 - **Explicit caps.** Pass `--max-iterations <n>` and `--max-tokens <n>` sized to the task.
   GNHF has no direct wall-clock flag; treat the iteration and token caps as the runtime
-  bound, and set `--max-rate-limit-wait` explicitly rather than leaving its 24h default when
-  the task needs a tighter window.
+  bound, and pass an explicit task-sized `--max-rate-limit-wait <duration>` on every
+  invocation rather than leaving its 24-hour default in effect.
 - **Clean starting state.** GNHF itself refuses a dirty working tree; a freshly spawned
   task worktree already starts clean, so this is satisfied by the ordinary spawn contract
   as long as GNHF is the first thing the crewmate runs there.
@@ -118,9 +118,10 @@ there is no dedicated `fm-brief.sh` flag for this and none is needed.
   *multiple* GNHF runs inside one shared checkout, which would nest a second, redundant
   isolation boundary inside the first and GNHF itself refuses to combine with
   `--current-branch`. Run GNHF on the crewmate's own current branch instead.
-- **`--push` only when the task's own delivery mode already pushes.** GNHF's `--push` is a
-  crewmate decision under the ordinary delivery contract (`no-mistakes` or `direct-PR`), not
-  a GNHF default; omit it for `local-only` tasks and for any task still under review.
+- **`--push` only in direct-PR mode.** GNHF's `--push` is permitted only when the task is
+  already on the direct-PR delivery path and that path authorizes the worker to push.
+  Omit it in `no-mistakes` mode, where the pipeline alone owns push, and in `local-only`
+  mode. Also omit it for any direct-PR task still under review.
 - **No `&`, no `nohup`, no detached backgrounding.** Run GNHF as an ordinary foreground
   command inside the crewmate's own turn. See "No new supervision surface" below for why
   this is sufficient and required.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -536,6 +536,7 @@ These skills are not captain-invocable; load them only at their precise triggers
 - `ask-user-authority` - load before deciding any ask-user finding.
 - `quota-array-dispatch` - load before choosing among a matched crew-dispatch profile array from current quota-axi default TOON.
 - `harness-adapters` - load before spawning or recovering a crewmate or secondmate, handling a trust dialog, sending a harness-specific skill invocation, interrupting or exiting an agent, resuming an exited agent, or verifying a new harness adapter.
+- `gnhf-companion` - load before briefing, steering, or reviewing a crewmate's use of the installed GNHF tool for bounded autonomous iteration inside its own task worktree.
 - `firstmate-orca` - load before switching to Orca, spawning or supervising Orca-backed work, smoke-testing Orca backend behavior, debugging Orca task state, or reconciling Orca-backed task metadata.
 - `project-management` - load before adding, creating, removing, or initializing a project.
   Cloning or registering a project is add intake and uses the same trigger.

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -139,7 +139,8 @@ family_for_basename() {
     fm-classify-decision-key.test.sh|\
     fm-composer-ghost.test.sh|fm-composer-lib.test.sh|\
     fm-crew-state.test.sh|fm-captain-hold-lifecycle.test.sh|\
-    fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
+    fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|\
+    fm-gnhf-companion-skill.test.sh|fm-grok-harness.test.sh|\
     fm-kimi-harness.test.sh|fm-muse-harness.test.sh|fm-herdr-lab.test.sh|fm-lint.test.sh|\
     fm-lint-workflows.test.sh|\
     fm-operational-input.test.sh|fm-pi-primary-types.test.sh|\

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -157,6 +157,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/gnhf-companion/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/harness-adapters/SKILL.md",
       "audience": "agent-runtime"
     },
@@ -354,6 +358,10 @@
     },
     {
       "path": "docs/verification/dispatch-auth.md",
+      "audience": "maintainer-verification"
+    },
+    {
+      "path": "docs/verification/gnhf-companion.md",
       "audience": "maintainer-verification"
     },
     {

--- a/docs/verification/gnhf-companion.md
+++ b/docs/verification/gnhf-companion.md
@@ -1,0 +1,95 @@
+# GNHF companion integration verification
+
+Audience: maintainer verification.
+
+This record holds reusable version-scoped evidence for GNHF's CLI shape and for the
+bounded-execution contract `.agents/skills/gnhf-companion/SKILL.md` depends on.
+That skill owns the operating procedure; `tests/fm-gnhf-companion-skill.test.sh` is the
+portable regression pinning the trigger/loading contract and, when `gnhf` is installed,
+guarding against silent flag drift in the installed CLI.
+
+Verified on 2026-08-24 on Linux with `gnhf` 0.1.45 installed (`npm install -g gnhf`).
+
+```sh
+$ gnhf --version
+0.1.45
+```
+
+## Bounded smoke: completion, stop condition, and preserved history
+
+Run in a disposable scratch repository (never a real project), with `--current-branch`
+exactly as the skill requires, one bounded iteration, and an observable `--stop-when`
+condition:
+
+```sh
+$ git init && git commit --allow-empty -q -m "baseline commit"   # baseline.txt committed
+$ gnhf --agent claude --current-branch --max-iterations 2 --max-tokens 200000 \
+    --prevent-sleep off \
+    --stop-when "smoke-result.txt exists in the repo root containing exactly the text: gnhf smoke ok" \
+    "Create a file named smoke-result.txt ... Do not modify baseline.txt or any other file. ..."
+```
+
+Result: exit 0.
+
+```
+gnhf stopped
+claude ran for 23s before: stop condition met
+
+iterations      1 total       1 good       0 failed
+tokens          53K in        1K out
+branch diff     1 commit      +1           -0
+files           1 added       0 updated    0 deleted
+```
+
+Post-run repo state confirmed the required properties:
+
+- Stayed on `main` (`--current-branch` honored; no `gnhf/` branch created).
+- Exactly one new commit (`gnhf 1: ...`), the prior `baseline commit` untouched -
+  preserved history, not rewritten.
+- `smoke-result.txt` contained exactly `gnhf smoke ok\n` (verified with `xxd`).
+- `git status --short` was empty after the run - clean, reviewable working tree.
+- `.gnhf/` (run notes and debug log) was not tracked by `git ls-files`, matching the
+  upstream README's "Local run metadata" claim.
+
+## Bounded smoke: abort on an unmet prerequisite is not papered over
+
+Same scratch repo, one bounded iteration, a prompt with a stated hard prerequisite that is
+not met:
+
+```sh
+$ gnhf --agent claude --current-branch --max-iterations 1 --max-tokens 200000 \
+    --prevent-sleep off \
+    --stop-when "a file named prereq-confirmed.txt exists containing the word confirmed" \
+    "This task has a hard prerequisite that is NOT met: required-prereq-input.txt must
+     already exist with real prior content. It does not. Do not create it yourself.
+     Verify it is absent, then report this iteration as a failure. Make no file changes."
+```
+
+Result: exit 0 (GNHF's own process exit, not the iteration's outcome).
+
+```
+gnhf stopped
+claude ran for 30s before: max iterations reached (1)
+
+iterations      1 total       0 good       1 failed
+tokens          70K in        2K out
+branch diff     0 commits     +0           -0
+files           0 added       0 updated    0 deleted
+```
+
+No commit was created, no file was left behind, and `git status --short` stayed empty:
+GNHF rolled the failed iteration back rather than fabricating success, exactly as
+`gnhf-companion`'s "Stops must actually stop" rule requires the crewmate to trust.
+
+## CLI flags the skill's brief contract depends on
+
+```sh
+$ gnhf --help | grep -E -- '--agent|--max-iterations|--max-tokens|--max-rate-limit-wait|--stop-when|--current-branch|--worktree|--push'
+```
+
+Confirmed present on 0.1.45: `--agent`, `--max-iterations`, `--max-tokens`,
+`--max-rate-limit-wait`, `--stop-when`, `--current-branch`, `--worktree`, `--push`.
+`tests/fm-gnhf-companion-skill.test.sh`'s `test_gnhf_help_flags_live` re-checks this same
+list on any machine with `gnhf` installed and self-skips otherwise, so a future GNHF
+release that renames or drops one of these flags fails that test instead of silently
+drifting from the skill's documented contract.

--- a/docs/verification/gnhf-companion.md
+++ b/docs/verification/gnhf-companion.md
@@ -34,7 +34,7 @@ $ git commit -q -m "baseline commit"
 Verified 2026-08-24 in the disposable scratch repository:
 
 ```sh
-$ gnhf --agent claude --current-branch --max-iterations 2 --max-tokens 200000 \
+$ GNHF_TELEMETRY=0 gnhf --agent claude --current-branch --max-iterations 2 --max-tokens 200000 \
     --max-rate-limit-wait 10m --prevent-sleep off \
     --stop-when "smoke-result.txt exists in the repo root containing exactly the text: gnhf smoke ok" \
     "Create a file named smoke-result.txt in the repo root containing exactly the text: gnhf smoke ok (with a trailing newline). Do not modify baseline.txt or any other file. Commit the change. Stop only when smoke-result.txt exists with that exact content."
@@ -44,9 +44,9 @@ Exit 0. Summary:
 
 ```text
 gnhf stopped
-claude ran for 18s before: stop condition met
+claude ran for ~20s before: stop condition met
 iterations 1 total 1 good 0 failed
-tokens 69K in 919 out
+tokens 70K in 998 out
 branch diff 1 commit +1 -0
 files 1 added 0 updated 0 deleted
 ```
@@ -55,13 +55,11 @@ Post-run verification:
 
 ```text
 $ git branch --show-current -> main (stayed on --current-branch, no gnhf/ branch)
-$ git log --oneline -> 3e5d1d6 gnhf 1: Created smoke-result.txt ...
-8c75eef baseline commit (prior history preserved)
+$ git log --oneline -> ee71b17 gnhf 1: Created smoke-result.txt in the repo root containing exactly "gnhf smoke ok\n", satisfying the run's stop condition.
+e16d8d5 baseline commit (prior history preserved)
 $ git status --short -> (empty; clean working tree)
 $ cat smoke-result.txt -> gnhf smoke ok
-$ xxd smoke-result.txt | tail -1 -> 00000000: 676e 6866 2073 6d6f 6b65 206f 6b0a gnhf smoke ok.
 $ cat baseline.txt -> baseline file, do not touch (untouched)
-$ git diff --stat 8c75eef..HEAD -> smoke-result.txt | 1 +, 1 file changed, 1 insertion(+)
 $ git ls-files .gnhf -> (empty; .gnhf/ run metadata left untracked)
 ```
 
@@ -70,7 +68,7 @@ $ git ls-files .gnhf -> (empty; .gnhf/ run metadata left untracked)
 Verified 2026-08-24 in the same repository, continuing on the same branch:
 
 ```sh
-$ gnhf --agent claude --current-branch --max-iterations 1 --max-tokens 200000 \
+$ GNHF_TELEMETRY=0 gnhf --agent claude --current-branch --max-iterations 1 --max-tokens 200000 \
     --max-rate-limit-wait 10m --prevent-sleep off \
     --stop-when "a file named prereq-confirmed.txt exists containing the word confirmed" \
     "This task has a hard prerequisite that is NOT met: a file named required-prereq-input.txt must already exist in the repo root with real prior content for you to read and act on. It does not exist. Do not create it yourself and do not fabricate its content. Verify it is absent, then report this iteration as a failure describing the missing prerequisite. Make no file changes."
@@ -80,9 +78,9 @@ Exit 0 (GNHF's own process exit, not the iteration's outcome). Summary:
 
 ```text
 gnhf stopped
-claude ran for 22s before: max iterations reached (1)
+claude ran for 29s before: max iterations reached (1)
 iterations 1 total 0 good 1 failed
-tokens 70K in 1K out
+tokens 70K in 2K out
 branch diff 0 commits +0 -0
 files 0 added 0 updated 0 deleted
 ```

--- a/docs/verification/gnhf-companion.md
+++ b/docs/verification/gnhf-companion.md
@@ -4,9 +4,9 @@ Audience: maintainer verification.
 
 This record holds reusable version-scoped evidence for GNHF's CLI shape and for the
 bounded-execution contract `.agents/skills/gnhf-companion/SKILL.md` depends on.
-That skill owns the operating procedure; `tests/fm-gnhf-companion-skill.test.sh` is the
-portable regression pinning the trigger/loading contract and, when `gnhf` is installed,
-guarding against silent flag drift in the installed CLI.
+That skill owns the operating procedure; `tests/fm-gnhf-companion-skill.test.sh` parses its
+declarative frontmatter and, when `gnhf` is installed, guards against silent flag drift in
+the installed CLI.
 
 Verified on 2026-08-24 on Linux with `gnhf` 0.1.45 installed (`npm install -g gnhf`).
 
@@ -15,71 +15,84 @@ $ gnhf --version
 0.1.45
 ```
 
-## Bounded smoke: completion, stop condition, and preserved history
+## Bounded smoke setup
 
-Run in a disposable scratch repository (never a real project), with `--current-branch`
-exactly as the skill requires, one bounded iteration, and an observable `--stop-when`
-condition:
+The setup was identical before both runs:
 
 ```sh
-$ git init && git commit --allow-empty -q -m "baseline commit"   # baseline.txt committed
+$ mkdir gnhf-smoke-repo && cd gnhf-smoke-repo
+$ git init -q
+$ git config user.email "smoke@example.com"
+$ git config user.name "GNHF Smoke"
+$ printf 'baseline file, do not touch\n' > baseline.txt
+$ git add baseline.txt
+$ git commit -q -m "baseline commit"
+```
+
+## Bounded smoke: completion and stop condition
+
+Verified 2026-08-24 in the disposable scratch repository:
+
+```sh
 $ gnhf --agent claude --current-branch --max-iterations 2 --max-tokens 200000 \
-    --prevent-sleep off \
+    --max-rate-limit-wait 10m --prevent-sleep off \
     --stop-when "smoke-result.txt exists in the repo root containing exactly the text: gnhf smoke ok" \
-    "Create a file named smoke-result.txt ... Do not modify baseline.txt or any other file. ..."
+    "Create a file named smoke-result.txt in the repo root containing exactly the text: gnhf smoke ok (with a trailing newline). Do not modify baseline.txt or any other file. Commit the change. Stop only when smoke-result.txt exists with that exact content."
 ```
 
-Result: exit 0.
+Exit 0. Summary:
 
-```
+```text
 gnhf stopped
-claude ran for 23s before: stop condition met
-
-iterations      1 total       1 good       0 failed
-tokens          53K in        1K out
-branch diff     1 commit      +1           -0
-files           1 added       0 updated    0 deleted
+claude ran for 18s before: stop condition met
+iterations 1 total 1 good 0 failed
+tokens 69K in 919 out
+branch diff 1 commit +1 -0
+files 1 added 0 updated 0 deleted
 ```
 
-Post-run repo state confirmed the required properties:
+Post-run verification:
 
-- Stayed on `main` (`--current-branch` honored; no `gnhf/` branch created).
-- Exactly one new commit (`gnhf 1: ...`), the prior `baseline commit` untouched -
-  preserved history, not rewritten.
-- `smoke-result.txt` contained exactly `gnhf smoke ok\n` (verified with `xxd`).
-- `git status --short` was empty after the run - clean, reviewable working tree.
-- `.gnhf/` (run notes and debug log) was not tracked by `git ls-files`, matching the
-  upstream README's "Local run metadata" claim.
+```text
+$ git branch --show-current -> main (stayed on --current-branch, no gnhf/ branch)
+$ git log --oneline -> 3e5d1d6 gnhf 1: Created smoke-result.txt ...
+8c75eef baseline commit (prior history preserved)
+$ git status --short -> (empty; clean working tree)
+$ cat smoke-result.txt -> gnhf smoke ok
+$ xxd smoke-result.txt | tail -1 -> 00000000: 676e 6866 2073 6d6f 6b65 206f 6b0a gnhf smoke ok.
+$ cat baseline.txt -> baseline file, do not touch (untouched)
+$ git diff --stat 8c75eef..HEAD -> smoke-result.txt | 1 +, 1 file changed, 1 insertion(+)
+$ git ls-files .gnhf -> (empty; .gnhf/ run metadata left untracked)
+```
 
 ## Bounded smoke: abort on an unmet prerequisite is not papered over
 
-Same scratch repo, one bounded iteration, a prompt with a stated hard prerequisite that is
-not met:
+Verified 2026-08-24 in the same repository, continuing on the same branch:
 
 ```sh
 $ gnhf --agent claude --current-branch --max-iterations 1 --max-tokens 200000 \
-    --prevent-sleep off \
+    --max-rate-limit-wait 10m --prevent-sleep off \
     --stop-when "a file named prereq-confirmed.txt exists containing the word confirmed" \
-    "This task has a hard prerequisite that is NOT met: required-prereq-input.txt must
-     already exist with real prior content. It does not. Do not create it yourself.
-     Verify it is absent, then report this iteration as a failure. Make no file changes."
+    "This task has a hard prerequisite that is NOT met: a file named required-prereq-input.txt must already exist in the repo root with real prior content for you to read and act on. It does not exist. Do not create it yourself and do not fabricate its content. Verify it is absent, then report this iteration as a failure describing the missing prerequisite. Make no file changes."
 ```
 
-Result: exit 0 (GNHF's own process exit, not the iteration's outcome).
+Exit 0 (GNHF's own process exit, not the iteration's outcome). Summary:
 
-```
+```text
 gnhf stopped
-claude ran for 30s before: max iterations reached (1)
-
-iterations      1 total       0 good       1 failed
-tokens          70K in        2K out
-branch diff     0 commits     +0           -0
-files           0 added       0 updated    0 deleted
+claude ran for 22s before: max iterations reached (1)
+iterations 1 total 0 good 1 failed
+tokens 70K in 1K out
+branch diff 0 commits +0 -0
+files 0 added 0 updated 0 deleted
 ```
 
-No commit was created, no file was left behind, and `git status --short` stayed empty:
-GNHF rolled the failed iteration back rather than fabricating success, exactly as
-`gnhf-companion`'s "Stops must actually stop" rule requires the crewmate to trust.
+Post-run verification:
+
+```text
+$ git status --short -> (empty; clean)
+$ git log --oneline -> unchanged from Run 1 (no new commit) - GNHF rolled the failed iteration back rather than fabricating success.
+```
 
 ## CLI flags the skill's brief contract depends on
 

--- a/tests/fm-gnhf-companion-skill.test.sh
+++ b/tests/fm-gnhf-companion-skill.test.sh
@@ -7,46 +7,27 @@ set -u
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 SKILL="$ROOT/.agents/skills/gnhf-companion/SKILL.md"
-AGENTS="$ROOT/AGENTS.md"
 
-test_skill_frontmatter_and_trigger() {
+test_skill_frontmatter() {
   assert_present "$SKILL" \
     "gnhf-companion skill file is missing"
   command -v python3 >/dev/null 2>&1 || fail "python3 is required to parse skill metadata"
 
-  python3 - "$SKILL" "$AGENTS" <<'PY' || fail "gnhf-companion declarative metadata or trigger is invalid"
+  python3 - "$SKILL" <<'PY' || fail "gnhf-companion declarative metadata is invalid"
 import pathlib
 import sys
+import yaml
 
 skill_path = pathlib.Path(sys.argv[1])
-agents_path = pathlib.Path(sys.argv[2])
-lines = skill_path.read_text(encoding="utf-8").splitlines()
-if not lines or lines[0] != "---":
+content = skill_path.read_text(encoding="utf-8")
+if not content.startswith("---\n"):
     raise SystemExit("missing frontmatter opener")
 try:
-    end = lines.index("---", 1)
+    frontmatter, _ = content[4:].split("\n---\n", 1)
 except ValueError as error:
     raise SystemExit("missing frontmatter closer") from error
 
-metadata = {}
-section = None
-for line in lines[1:end]:
-    if not line.strip() or line.startswith("  ") and section != "metadata":
-        continue
-    if line == "metadata:":
-        section = "metadata"
-        metadata[section] = {}
-        continue
-    if section == "metadata" and line.startswith("  "):
-        key, value = line.strip().split(":", 1)
-        metadata[section][key] = value.strip() == "true"
-        continue
-    section = None
-    if ":" in line:
-        key, value = line.split(":", 1)
-        value = value.strip()
-        metadata[key] = {"true": True, "false": False}.get(value, value)
-
+metadata = yaml.safe_load(frontmatter)
 expected = {
     "name": "gnhf-companion",
     "user-invocable": False,
@@ -55,16 +36,9 @@ expected = {
 for key, value in expected.items():
     if metadata.get(key) != value:
         raise SystemExit(f"unexpected {key}: {metadata.get(key)!r}")
-
-trigger = "- `gnhf-companion` - load before briefing, steering, or reviewing a crewmate's use of the installed GNHF tool for bounded autonomous iteration inside its own task worktree."
-agents_lines = agents_path.read_text(encoding="utf-8").splitlines()
-start = agents_lines.index("## 13. Agent-only reference skills")
-end = next((i for i in range(start + 1, len(agents_lines)) if agents_lines[i].startswith("## ")), len(agents_lines))
-if agents_lines[start + 1:end].count(trigger) != 1:
-    raise SystemExit("section 13 must contain the exact gnhf-companion trigger once")
 PY
 
-  pass "gnhf-companion skill carries its required frontmatter and AGENTS.md carries its one-line trigger"
+  pass "gnhf-companion skill carries its required frontmatter"
 }
 
 test_gnhf_help_flags_live() {
@@ -86,5 +60,5 @@ test_gnhf_help_flags_live() {
   pass "installed gnhf --help still exposes every flag gnhf-companion's required brief contract assumes"
 }
 
-test_skill_frontmatter_and_trigger
+test_skill_frontmatter
 test_gnhf_help_flags_live

--- a/tests/fm-gnhf-companion-skill.test.sh
+++ b/tests/fm-gnhf-companion-skill.test.sh
@@ -13,30 +13,56 @@ test_skill_frontmatter() {
     "gnhf-companion skill file is missing"
   command -v python3 >/dev/null 2>&1 || fail "python3 is required to parse skill metadata"
 
-  python3 - "$SKILL" <<'PY' || fail "gnhf-companion declarative metadata is invalid"
+  local frontmatter_error
+  if ! frontmatter_error=$(python3 - "$SKILL" 2>&1 <<'PY'
 import pathlib
 import sys
-import yaml
 
-skill_path = pathlib.Path(sys.argv[1])
-content = skill_path.read_text(encoding="utf-8")
-if not content.startswith("---\n"):
+lines = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8").splitlines()
+if not lines or lines[0] != "---":
     raise SystemExit("missing frontmatter opener")
 try:
-    frontmatter, _ = content[4:].split("\n---\n", 1)
+    end = lines.index("---", 1)
 except ValueError as error:
     raise SystemExit("missing frontmatter closer") from error
 
-metadata = yaml.safe_load(frontmatter)
-expected = {
-    "name": "gnhf-companion",
-    "user-invocable": False,
-    "metadata": {"internal": True},
-}
-for key, value in expected.items():
-    if metadata.get(key) != value:
-        raise SystemExit(f"unexpected {key}: {metadata.get(key)!r}")
+parsed = {}
+current_key = None
+for line in lines[1:end]:
+    if not line.strip() or line.lstrip().startswith("#"):
+        continue
+    key, separator, value = line.partition(":")
+    if line[:1] not in (" ", "\t"):
+        if not separator:
+            continue
+        current_key = key.strip()
+        parsed[current_key] = value.strip() or {}
+    elif separator and isinstance(parsed.get(current_key), dict):
+        parsed[current_key][key.strip()] = value.strip()
+
+
+def as_bool(value):
+    return {"true": True, "false": False}.get(value, value)
+
+
+nested = parsed.get("metadata")
+internal = nested.get("internal") if isinstance(nested, dict) else None
+
+failures = []
+if parsed.get("name") != "gnhf-companion":
+    failures.append("name is {!r}, expected 'gnhf-companion'".format(parsed.get("name")))
+if as_bool(parsed.get("user-invocable")) is not False:
+    failures.append(
+        "user-invocable is {!r}, expected false".format(parsed.get("user-invocable"))
+    )
+if as_bool(internal) is not True:
+    failures.append("metadata.internal is {!r}, expected true".format(internal))
+if failures:
+    raise SystemExit("; ".join(failures))
 PY
+  ); then
+    fail "gnhf-companion declarative metadata is invalid: $frontmatter_error"
+  fi
 
   pass "gnhf-companion skill carries its required frontmatter"
 }

--- a/tests/fm-gnhf-companion-skill.test.sh
+++ b/tests/fm-gnhf-companion-skill.test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Behavioral regressions for the gnhf-companion skill's trigger/loading contract
-# and the installed GNHF CLI's flag surface the skill's brief contract depends on.
+# Contract regressions for gnhf-companion's declarative metadata and the installed
+# GNHF CLI flag surface the skill's brief contract depends on.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -12,23 +12,57 @@ AGENTS="$ROOT/AGENTS.md"
 test_skill_frontmatter_and_trigger() {
   assert_present "$SKILL" \
     "gnhf-companion skill file is missing"
-  assert_grep 'name: gnhf-companion' "$SKILL" \
-    "gnhf-companion skill frontmatter lost its name field"
-  assert_grep 'user-invocable: false' "$SKILL" \
-    "gnhf-companion skill is missing the agent-only user-invocable declaration"
-  assert_grep 'internal: true' "$SKILL" \
-    "gnhf-companion skill is missing the internal metadata declaration"
-  assert_grep 'Hands-Off' "$SKILL" \
-    "gnhf-companion skill dropped the Hands-Off mode definition"
-  assert_grep 'Companion' "$SKILL" \
-    "gnhf-companion skill dropped the Companion mode definition"
-  # shellcheck disable=SC2016 # Backticks are literal Markdown, not shell expansion.
-  assert_grep '`--current-branch`, never `--worktree`' "$SKILL" \
-    "gnhf-companion skill dropped the current-branch-not-worktree isolation rule"
+  command -v python3 >/dev/null 2>&1 || fail "python3 is required to parse skill metadata"
 
-  # shellcheck disable=SC2016 # Backticks are literal Markdown, not shell expansion.
-  assert_grep '`gnhf-companion` - load before briefing, steering, or reviewing' "$AGENTS" \
-    "AGENTS.md section 13 is missing the gnhf-companion trigger line"
+  python3 - "$SKILL" "$AGENTS" <<'PY' || fail "gnhf-companion declarative metadata or trigger is invalid"
+import pathlib
+import sys
+
+skill_path = pathlib.Path(sys.argv[1])
+agents_path = pathlib.Path(sys.argv[2])
+lines = skill_path.read_text(encoding="utf-8").splitlines()
+if not lines or lines[0] != "---":
+    raise SystemExit("missing frontmatter opener")
+try:
+    end = lines.index("---", 1)
+except ValueError as error:
+    raise SystemExit("missing frontmatter closer") from error
+
+metadata = {}
+section = None
+for line in lines[1:end]:
+    if not line.strip() or line.startswith("  ") and section != "metadata":
+        continue
+    if line == "metadata:":
+        section = "metadata"
+        metadata[section] = {}
+        continue
+    if section == "metadata" and line.startswith("  "):
+        key, value = line.strip().split(":", 1)
+        metadata[section][key] = value.strip() == "true"
+        continue
+    section = None
+    if ":" in line:
+        key, value = line.split(":", 1)
+        value = value.strip()
+        metadata[key] = {"true": True, "false": False}.get(value, value)
+
+expected = {
+    "name": "gnhf-companion",
+    "user-invocable": False,
+    "metadata": {"internal": True},
+}
+for key, value in expected.items():
+    if metadata.get(key) != value:
+        raise SystemExit(f"unexpected {key}: {metadata.get(key)!r}")
+
+trigger = "- `gnhf-companion` - load before briefing, steering, or reviewing a crewmate's use of the installed GNHF tool for bounded autonomous iteration inside its own task worktree."
+agents_lines = agents_path.read_text(encoding="utf-8").splitlines()
+start = agents_lines.index("## 13. Agent-only reference skills")
+end = next((i for i in range(start + 1, len(agents_lines)) if agents_lines[i].startswith("## ")), len(agents_lines))
+if agents_lines[start + 1:end].count(trigger) != 1:
+    raise SystemExit("section 13 must contain the exact gnhf-companion trigger once")
+PY
 
   pass "gnhf-companion skill carries its required frontmatter and AGENTS.md carries its one-line trigger"
 }

--- a/tests/fm-gnhf-companion-skill.test.sh
+++ b/tests/fm-gnhf-companion-skill.test.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Behavioral regressions for the gnhf-companion skill's trigger/loading contract
+# and the installed GNHF CLI's flag surface the skill's brief contract depends on.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SKILL="$ROOT/.agents/skills/gnhf-companion/SKILL.md"
+AGENTS="$ROOT/AGENTS.md"
+
+test_skill_frontmatter_and_trigger() {
+  assert_present "$SKILL" \
+    "gnhf-companion skill file is missing"
+  assert_grep 'name: gnhf-companion' "$SKILL" \
+    "gnhf-companion skill frontmatter lost its name field"
+  assert_grep 'user-invocable: false' "$SKILL" \
+    "gnhf-companion skill is missing the agent-only user-invocable declaration"
+  assert_grep 'internal: true' "$SKILL" \
+    "gnhf-companion skill is missing the internal metadata declaration"
+  assert_grep 'Hands-Off' "$SKILL" \
+    "gnhf-companion skill dropped the Hands-Off mode definition"
+  assert_grep 'Companion' "$SKILL" \
+    "gnhf-companion skill dropped the Companion mode definition"
+  # shellcheck disable=SC2016 # Backticks are literal Markdown, not shell expansion.
+  assert_grep '`--current-branch`, never `--worktree`' "$SKILL" \
+    "gnhf-companion skill dropped the current-branch-not-worktree isolation rule"
+
+  # shellcheck disable=SC2016 # Backticks are literal Markdown, not shell expansion.
+  assert_grep '`gnhf-companion` - load before briefing, steering, or reviewing' "$AGENTS" \
+    "AGENTS.md section 13 is missing the gnhf-companion trigger line"
+
+  pass "gnhf-companion skill carries its required frontmatter and AGENTS.md carries its one-line trigger"
+}
+
+test_gnhf_help_flags_live() {
+  if ! command -v gnhf >/dev/null 2>&1; then
+    echo "skip: gnhf is not installed on this machine"
+    return 0
+  fi
+
+  local help
+  help=$(gnhf --help 2>&1) || fail "installed gnhf --help exited non-zero"
+
+  local flag
+  for flag in '--agent' '--max-iterations' '--max-tokens' '--max-rate-limit-wait' \
+    '--stop-when' '--current-branch' '--worktree' '--push'; do
+    printf '%s' "$help" | grep -F -- "$flag" >/dev/null ||
+      fail "installed gnhf --help no longer advertises $flag, which gnhf-companion's brief contract assumes"
+  done
+
+  pass "installed gnhf --help still exposes every flag gnhf-companion's required brief contract assumes"
+}
+
+test_skill_frontmatter_and_trigger
+test_gnhf_help_flags_live


### PR DESCRIPTION
## Intent

Integrate the installed GNHF tool into Firstmate as a bounded, explicitly selected long-running execution option that complements rather than competes with Firstmate supervision.

Acceptance criteria the implementation targets:
- Inspected the installed gnhf --help, the authoritative upstream repository (github.com/kunchenguid/gnhf), and the npm package's bundled skills/gnhf/SKILL.md, plus current Firstmate supervision, process-event, worker-isolation, merge-authority, and delivery contracts (harness-adapters, process-event-sources, firstmate-coding-guidelines, AGENTS.md sections 1/4/7/8/11/13). No flags were invented; all were verified live against the installed gnhf 0.1.45 CLI and, where the pipeline's own review flagged a factual claim, against the installed gnhf 0.1.45 source (dist/cli.mjs) directly.
- The full conditional procedure lives in one new JIT-loaded agent-only skill, .agents/skills/gnhf-companion/SKILL.md (metadata.internal: true, user-invocable: false), with exactly one concise trigger line added to AGENTS.md section 13. No installer-facing (public skills/) or README changes were made, since README's Built-in skills table is explicitly scoped to user-invocable slash commands only and gnhf-companion is agent-only.
- Hands-Off and Companion modes are defined precisely. Firstmate remains the orchestrator; GNHF only ever executes inside a crewmate's own already-isolated task worktree (from bin/fm-spawn.sh), run with --current-branch. No Firstmate primary session may invoke gnhf directly against a project - that would violate hard rule 1 (never write to a project) - and the skill is explicit that worktree isolation prevents direct filesystem collision only, not a stronger scope-exclusivity guarantee; ordinary AGENTS.md section 7 overlapping-scope reconciliation applies unchanged.
- The required brief contract firstmate must author into a GNHF-driven task: an outcome-based prompt with explicit non-goals, an observable evidence-based --stop-when condition, explicit --max-iterations/--max-tokens caps plus an explicit task-sized --max-rate-limit-wait on every invocation (never left at GNHF's 24h default), GNHF_TELEMETRY=0 set on every firstmate-driven invocation (GNHF defaults to reporting aggregate usage telemetry - agent, mode, status, counts, durations, no prompt/path/branch content - to a hard-coded third-party host), a clean working tree required before every invocation (not just the first, since GNHF's own clean-tree check re-applies on every resume and Companion mode's own between-slice review can leave scratch state behind), preserved prior branch history, and a reviewable branch. A no-op, repeated failure, runaway scope, destructive behavior, or impossible prerequisite must stop rather than be papered over: the skill is explicit that GNHF's own no-op handling is agent-self-report only with no mechanical detection (verified against the installed source), so the required delivery review checks each invocation's own new commits (captured via git rev-parse HEAD before/after that specific call, never GNHF's own cumulative branch-diff figure, which conflates every resume together) against that invocation's reported good-iteration count, flagging good-iterations-with-fewer-commits as a stop-and-investigate signal rather than trusting the tally alone.
- Completion integrates into Firstmate's existing durable supervision mechanisms with no shell &, no detached fire-and-forget process, no second watcher, and no new control plane. The skill explains explicitly why bin/fm-procevent.sh (process-event-sources) does not apply here: it is scoped to sources this firstmate home owns and blocks on with no per-project working-directory concept, so arming it to run gnhf would make firstmate's own background runner the actor executing a project-mutating command, which hard rule 1 forbids. Instead GNHF rides the existing crewmate worker-supervision path unchanged: a crewmate occupying its own foreground turn on a long-running command is already how it runs any build, test, or no-mistakes invocation, and completion reaches firstmate through the same status-file append every other crewmate turn uses. On a true byte-identical-prompt resume across a crewmate's own turns, --max-iterations is cumulative (verified against source: state.currentIteration carries the prior run's last iteration number) and must be raised each successive call or the run aborts immediately with no progress, while --max-tokens always resets to a fresh per-invocation budget; a reworded prompt does not resume at all (verified: the run id is a hash of the exact prompt string) and silently starts a fresh bounded run instead, which is by design for Companion mode's own steered slices.
- GNHF never grants merge authority, approval authority, security-sensitive authority, or permission to bypass no-mistakes. The skill states explicitly that GNHF completion is not firstmate acceptance, and that before any done: line or delivery the crewmate/firstmate must independently compare the branch to current intent and run fresh verification - GNHF's own exit summary and notes.md are claims, never evidence.
- The installed tool's supported --agent roster is covered generically by pointing at gnhf --help and its own README Agents table (with a live-discovery command shown), never a hard-coded roster. GNHF's own --agent is resolved through the same dispatch precedence AGENTS.md section 4 already gives any crewmate's harness/model choice (captain override, then config/crew-dispatch.json via quota-array-dispatch, then this home's own current standing preference, then the static crewmate harness), constrained to GNHF's own live-discovered --agent roster rather than assuming firstmate's resolved harness has a native GNHF match; if it does not (for example grok or kimi, which are firstmate-verified but not GNHF-native), the skill falls back to the highest-precedence candidate that is GNHF-native rather than inventing an acp: mapping. No specific model or captain preference is hard-coded into tracked material, since that is exactly the kind of instance-specific fact (verified: it lives only in gitignored, untracked data/captain.md) that should not be baked into a tracked skill.
- tests/fm-gnhf-companion-skill.test.sh is a new executable regression, classified into bin/fm-test-run.sh's pure-contract-unit family (matching the family .agents/skills/*/SKILL.md changes already select via --changed) so a future skill-only edit's targeted selection still runs its own guard. One assertion performs a real structured parse of the skill's own YAML frontmatter (a small stdlib-only Python parser, no PyYAML dependency, since no other script in this repo imports yaml and a host without it would otherwise misreport the skill file as invalid) asserting the parsed name/user-invocable/metadata.internal fields, naming the specific mismatched field on failure rather than a generic error - this is the trigger/loading behavior coverage, since AGENTS.md's own trigger prose has no mechanical consumer in this repo to test against. A second assertion runs gnhf --help against the actually-installed CLI and asserts every flag the skill's brief contract depends on (--agent, --max-iterations, --max-tokens, --max-rate-limit-wait, --stop-when, --current-branch, --worktree, --push) is still present, self-skipping cleanly when gnhf is not installed on the running machine.
- A bounded smoke was performed in a disposable scratch git repository outside this worktree (never a real project), using the installed gnhf 0.1.45 with --current-branch, GNHF_TELEMETRY=0, and small iteration/token/rate-limit-wait caps: one run proved completion (stop condition met, exactly one new commit, the prior baseline commit preserved untouched, smoke-result.txt containing the exact expected bytes, a clean working tree afterward, and .gnhf/ run metadata left untracked); a second run proved the abort path (a stated hard prerequisite that was not met produced zero commits and zero file changes rather than a fabricated success). Both runs used the same cheap agent already installed and authenticated on this machine, keeping quota cost minimal, and were re-verified after GNHF_TELEMETRY=0 became a required item of the brief contract so the recorded evidence matches the contract it demonstrates. The exact dated commands and output are recorded as maintainer-verification evidence in docs/verification/gnhf-companion.md, and that new surface plus the new skill file were both added to docs/documentation-audiences.json's inventory (audience: agent-runtime for the skill, maintainer-verification for the evidence doc), which bin/fm-doc-audience-check.sh passes.
- Firstmate lint (bin/fm-lint.sh, ShellCheck 0.11.0 and actionlint 1.7.12, both pinned) is green. The targeted test selection from bin/fm-test-run.sh --changed --base origin/main passes; the only failing assertion encountered in this worktree is a pre-existing, unrelated local-environment gap (ruby is not installed on this machine, which tests/fm-test-run.test.sh's CI-workflow-YAML-parsing check requires) that predates this change, is outside this task's diff, and was left alone per this worktree's do-not-modify-outside-scope constraint rather than installing a system package.
- No bin/ wrapper script beyond the existing bin/fm-test-run.sh classification-table entry needed to route the new test into its correct family, no new fm-brief.sh scaffold flag, and no changes to bin/fm-procevent.sh or any other process-event adapter were added, per explicit direction to prefer the simplest existing worker-supervision path and build no new mechanism unless a concrete unsupported boundary required it - none did.
- This intent reflects the fully reviewed and captain/firstmate-authorized state after eight rounds of no-mistakes review findings, every ask-user finding escalated and decided by firstmate before any fix was applied, and every auto-fix finding decided on the crewmate's own judgment per the standard authority split; a prior run of this same pipeline (01M0SFHAQK14Y14KME4VQM68VF) terminal-failed due to a transient review-agent/session usage-limit interruption unrelated to the content of the change, and custody of its preserved, fully-authorized commits was recovered via no-mistakes axi sync --recover before starting this fresh run.

## What Changed

- Add an internal `gnhf-companion` skill defining bounded Hands-Off and Companion execution within isolated crewmate worktrees.
- Preserve Firstmate's existing supervision, authority, delivery, and verification boundaries while documenting GNHF caps, telemetry opt-out, resume behavior, and review requirements.
- Add maintainer verification evidence and contract tests for skill metadata, required CLI flags, and targeted test-family selection.

## Risk Assessment

✅ Low: The change is documentation- and contract-focused, matches the authoritative intent, and introduces no substantiated correctness or delivery-boundary defects.

## Testing

Scoped diff inspection and targeted tests passed; live GNHF 0.1.45 checks confirmed required flags and changed-test routing, the initial capture setup demonstrated fail-closed dirty-tree behavior, and the corrected bounded E2E run stopped successfully after one iteration with one new commit, exact expected output bytes, preserved history and baseline content, no tracked `.gnhf` metadata, and a clean tracked tree.

<details>
<summary>Evidence: Bounded GNHF E2E verification</summary>

`GNHF 0.1.45 completed one bounded iteration, created exactly one commit, preserved the baseline commit/file, produced the expected bytes, and left tracked state clean.`

```text
GNHF bounded E2E verification
gnhf_version=0.1.45
branch=main
commit_count=2
commit=127c7b8a40850f7ea766be145f1249ff5774ed4b subject=baseline
commit=da867257ce0594386e003fc3784e59cde8fca218 subject=gnhf 1: Created result.txt in the repo root containing exactly "gnhf bounded e2e" plus a newline, verified byte-for-byte.
result_hex=676e686620626f756e646564206532650a
baseline=baseline file, do not touch
tracked_tree_status=0
gnhf_metadata_tracked=0
```
</details>
<details>
<summary>Evidence: Full GNHF CLI transcript</summary>

```text
[?1049h[?25l[H                                                                               
                            [2mg n h f[0m  [2m·[0m  [2mc l a u d e[0m                            
 [1m·[0m                                                                            [1m·[0m
                                                                               
     [1m✧[0m [1m⋆[0m    [1m┏━╸┏━┓┏━┓╺┳┓   ┏┓╻╻┏━╸╻ ╻╺┳╸   ╻ ╻┏━┓╻ ╻┏━╸   ┏━╸╻ ╻┏┓╻[0m            
            [1m┃╺┓┃ ┃┃ ┃ ┃┃   ┃┗┫┃┃╺┓┣━┫ ┃    ┣━┫┣━┫┃┏┛┣╸    ┣╸ ┃ ┃┃┗┫[0m            
            [1m┗━┛┗━┛┗━┛╺┻┛   ╹ ╹╹┗━┛╹ ╹ ╹    ╹ ╹╹ ╹┗┛ ┗━╸   ╹  ┗━┛╹ ╹[0m            
                                                                               
          [2mCreate result.txt in the repository root containing exactly[0m      [1m·[0m   
             [2mgnhf bounded e2e followed by a newline. Do not modify[0m             
        [2mbaseline.txt or any other tracked file. This is the only goal.…[0m        
                                                                               
                                                                               
                   [1m00:00:00[0m  [2m·[0m  0 in  [2m·[0m  0 out  [2m·[0m  0 commits                [1m✧[0m  
                                                                              [1m·[0m
                                                                          [1m⋆[0m    
                                  [2mworking...[0m                                   
  [1m⋆[0m                                                                            
   [1m⋆[0m                                                                     [1m⋆[0m     
                                                                               
                                                                            [1m⋆[0m  
                                      🌑                                       
                     [2m[ctrl+c to stop, gnhf again to resume][0m                     
                                                                                [22;39H[0m🌒[22;39H[0m🌓[22;39H[0m🌔[22;39H[0m🌕[22;39H[0m🌖[14;27H[0m[1m1[22;39H[0m🌗[22;39H[0m🌘[9;77H[0m[2m╱[10;76H╱[11;75H╱[12;74H╱[13;73H╱[14;72H╱[22;39H[0m🌑[9;77H[0m [10;76H [22;39H🌒[11;75H[0m [18;3H[0m[2m⋆[22;39H[0m🌓[12;74H[0m [13;73H [14;27H[0m[1m2[22;39H[0m🌔[14;72H[0m [18;3H [22;39H🌖[22;39H[0m🌗[18;3H[0m[2m⋆[22;39H[0m🌘[3;79H[0m[2m·[5;7H╱[6;6H╱[7;5H╱[8;4H╱[9;3H[0m[1m╱[22;39H[0m🌑[3;79H[0m [5;7H [6;6H [9;3H[0m[2m╱[10;2H╱[11;1H[0m[1m╱[14;27H3[22;39H[0m🌒[3;79H[0m[2m·[7;5H[0m [8;4H [11;1H[0m[2m╱[18;3H[0m[1m⋆[22;39H[0m🌓[3;79H[0m[1m·[9;3H[0m [22;39H🌔[10;2H[0m [11;1H [22;39H🌕[3;2H[0m[2m·[22;39H[0m🌖[14;27H[0m[1m4[22;39H[0m🌗[3;2H[0m [22;39H🌘[5;6H[0m[2m✧[21;77H⋆[22;39H[0m🌑[3;2H[0m[2m·[21;77H[0m [22;39H🌒[5;6H[0m [22;39H🌓[3;2H[0m[1m·[5;6H[0m[2m✧[14;27H[0m[1m5[21;77H[0m[2m⋆[22;39H[0m🌔[5;6H[0m[1m✧[22;39H[0m🌕[5;8H[0m[2m⋆[15;79H·[21;77H[0m[1m⋆[22;39H[0m🌖[15;79H[0m [22;39H🌗[5;8H[0m[1m⋆[22;39H[0m🌘[14;27H[0m[1m6[15;79H[0m[2m·[22;39H[0m🌑[9;76H[0m[2m·[15;79H[0m[1m·[22;39H[0m🌒[9;76H[0m [22;39H🌓[9;76H[0m[2m·[22;39H[0m🌔[9;76H[0m[1m·[14;27H7[22;39H[0m🌕[22;39H[0m🌖[22;39H[0m🌗[22;39H[0m🌘[22;39H[0m🌑[14;18H[0m[1m00:[14;22H0:[14;25H8[0m  [0m[2m·[14;30H[0m 16K[14;42H17 out[14;49H [0m[2m·[14;52H[0m 0 co[14;58Hmits[22;39H🌒[16;75H[0m[2m⋆[22;39H[0m🌓[22;39H[0m🌔[16;75H[0m [22;39H🌕[22;39H[0m🌖[14;25H[0m[1m9[16;75H[0m[2m⋆[22;39H[0m🌗[22;39H[0m🌘[16;75H[0m[1m⋆[22;39H[0m🌑[19;74H[0m[2m⋆[22;39H[0m🌒[14;31H[0m42[14;42H20[19;74H [22;39H🌓[14;24H[0m[1m10[19;74H[0m[2m⋆[22;39H[0m🌔[14;77H[0m[2m✧[19;74H[0m[1m⋆[22;39H[0m🌕[22;39H[0m🌖[14;77H[0m [22;39H🌗[14;77H[0m[2m✧[22;39H[0m🌘[14;25H[0m[1m1[14;77H✧[22;39H[0m🌑[22;39H[0m🌒[22;39H[0m🌓[22;39H[0m🌔[22;39H[0m🌕[14;25H[0m[1m2[22;39H[0m🌖[22;39H[0m🌗[22;39H[0m🌘[22;39H[0m🌑[22;39H[0m🌒[14;25H[0m[1m3[22;39H[0m🌓[22;39H[0m🌔[22;39H[0m🌕[3;79H[0m[2m·[22;39H[0m🌖[22;39H[0m🌗[3;79H[0m[1m·[14;25H4[14;31H[0m69[14;43H3[19;4H[0m[2m⋆[22;39H[0m🌘[22;39H[0m🌑[19;4H[0m [22;39H🌒[19;4H[0m[2m⋆[22;39H[0m🌓[17;11H[0m[2mCreated `result.txt` with exactly `gnhf bounded e2e\n` (17[18;11Hbytes, verified via hexdump). `baseline.txt` and all other[19;9Htracked files are unmodified - `git status` shows only the new…[22;39H[0m🌔[14;25H[0m[1m5[19;4H⋆[22;39H[0m🌕[22;39H[0m🌖[22;39H[0m🌗[22;39H[0m🌘[22;39H[0m🌑[14;25H[0m[1m6[22;39H[0m🌒[22;39H[0m🌓[22;39H[0m🌔[22;39H[0m🌕[22;39H[0m🌖[1;79H[0m[2m·[14;25H[0m[1m7[22;39H[0m🌗[1;79H[0m[1m·[22;39H[0m🌘[5;8H[0m[2m⋆[22;39H[0m🌑[1;79H[0m[2m·[5;8H[0m [22;39H🌒[?25h[?1049l
  gnhf: Run log: /home/rich/.no-mistakes/evidence/01M0T2Q0A96YENMY3ED4XRZVH8/gnhf-e2e/.gnhf/runs/create-result-txt-in-8c5507/gnhf.log


╭────────────────────────────────────────────────────────────╮
│ × gnhf stopped                                             │
│   claude ran for 17s before: stop condition met            │
╰────────────────────────────────────────────────────────────╯

  iterations      1 total       1 good       0 failed
  tokens          69K in        839 out      
  branch diff     1 commit      +1           -0
  files           1 added       0 updated    0 deleted

  notes           /home/rich/.no-mistakes/evidence/01M0T2Q0A96YENMY3ED4XRZVH8/gnhf-e2e/.gnhf/runs/create-result-txt-in-8c5507/notes.md
  debug log       /home/rich/.no-mistakes/evidence/01M0T2Q0A96YENMY3ED4XRZVH8/gnhf-e2e/.gnhf/runs/create-result-txt-in-8c5507/gnhf.log

  next steps      git log --oneline 127c7b8a4085..HEAD
                  git diff --stat 127c7b8a4085..HEAD
                  gh pr create

  too much        git push no-mistakes:
  to review?      https://github.com/kunchenguid/no-mistakes

POST-RUN VERIFICATION
gnhf_exit=0
pre_head=127c7b8a40850f7ea766be145f1249ff5774ed4b
post_head=da867257ce0594386e003fc3784e59cde8fca218
new_commits=1
branch=main
result_hex=676e686620626f756e646564206532650a
baseline=baseline file, do not touch
tracked_status:
tracked_files:
baseline.txt
result.txt
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"99f555eb4dc33f47c0414de7450243b0390a43fc","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --stat 038d0f7ec6ba7238a151722931434dcf06ff37c4..271d75bf14c034574f961e8441717c331b73f810` and scoped diff inspection</code>
- <code>`gnhf --version` (installed version 0.1.45)</code>
- `bin/fm-test-run.sh tests/fm-gnhf-companion-skill.test.sh`
- <code>`bin/fm-test-run.sh --list --changed --base 038d0f7ec6ba7238a151722931434dcf06ff37c4` plus exact selection check for `tests/fm-gnhf-companion-skill.test.sh`</code>
- `bin/fm-test-run.sh tests/fm-documentation-audiences.test.sh`
- <code>Clean-tree failure check: bounded `GNHF_TELEMETRY=0 gnhf ...` invocation with an untracked capture file refused execution with zero commits and zero product changes</code>
- <code>Corrected E2E smoke: `GNHF_TELEMETRY=0 gnhf --agent claude --current-branch --max-iterations 1 --max-tokens 100000 --max-rate-limit-wait 2m --prevent-sleep off --stop-when ...`</code>
- <code>Post-run verification using `git rev-list`, `git log`, `git status --short --untracked-files=no`, `git ls-files .gnhf`, and byte-level `od` inspection</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
