### PR TITLE
fix(bin): pass max reasoning to Codex launches

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -126,7 +126,7 @@ The supported launch-profile flags below are verified locally; each row records 
 | Harness | Model flag | Effort flag | Notes |
 |---|---|---|---|
 | claude | `--model <model>` | `--effort <low\|medium\|high\|xhigh\|max>` | Verified on Claude Code 2.1.196. |
-| codex | `--model <model>` | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh>"'` | Verified on codex-cli 0.142.1. The installed binary schema contains `model_reasoning_effort`, the active config uses it, and the bundled model catalog advertises only low/medium/high/xhigh. `max` is omitted. |
+| codex | `--model <model>` | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh\|max>"'` | Verified on 2026-08-24 with codex-cli 0.149.0. A real `gpt-5.6-luna` launch accepted `max` and completed its foreground-checkpoint guard. |
 | grok | `--model <model>` | `--reasoning-effort <low\|medium\|high>` | Verified on grok 0.2.99 (2026-07-13). `--effort` is an alias, but firstmate's profile axis is reasoning effort. As of 0.2.99 the ceiling is `high`; both `xhigh` and `max` are rejected with `use one of: high, medium, low`, so firstmate omits them. |
 | pi / pi-signed | `--model <model>` | `--thinking <low\|medium\|high\|xhigh\|max>` | Verified 2026-07-27 on Pi and pi-signed 0.82.0. Both expose the same accepted thinking levels and completed the same model-qualified max-thinking smoke. |
 | opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |

--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -126,7 +126,7 @@ The supported launch-profile flags below are verified locally; each row records 
 | Harness | Model flag | Effort flag | Notes |
 |---|---|---|---|
 | claude | `--model <model>` | `--effort <low\|medium\|high\|xhigh\|max>` | Verified on Claude Code 2.1.196. |
-| codex | `--model <model>` | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh\|max>"'` | Verified on 2026-08-24 with codex-cli 0.149.0. A real `gpt-5.6-luna` launch accepted `max` and completed its foreground-checkpoint guard. |
+| codex | `--model <model>` | `-c 'model_reasoning_effort="<low\|medium\|high\|xhigh\|max>"'` | [`runtime-backends.md`](../../../docs/verification/runtime-backends.md#codex-max-reasoning-profile) owns the current runtime verification. |
 | grok | `--model <model>` | `--reasoning-effort <low\|medium\|high>` | Verified on grok 0.2.99 (2026-07-13). `--effort` is an alias, but firstmate's profile axis is reasoning effort. As of 0.2.99 the ceiling is `high`; both `xhigh` and `max` are rejected with `use one of: high, medium, low`, so firstmate omits them. |
 | pi / pi-signed | `--model <model>` | `--thinking <low\|medium\|high\|xhigh\|max>` | Verified 2026-07-27 on Pi and pi-signed 0.82.0. Both expose the same accepted thinking levels and completed the same model-qualified max-thinking smoke. |
 | opencode | `--model <provider/model>` | none for firstmate's interactive launch | Verified on opencode 1.17.6. `opencode run` has `--variant`, but firstmate launches the interactive `opencode --prompt` path, which has no verified effort flag. |

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -1085,7 +1085,7 @@ crew_dispatch_validate() {
       if $e == null then true
       elif ($e | type) != "string" then false
       elif $h == "claude" then (["low","medium","high","xhigh","max"] | index($e))
-      elif $h == "codex" then (["low","medium","high","xhigh"] | index($e))
+      elif $h == "codex" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "grok" then (["low","medium","high"] | index($e))
       elif $h == "pi" or $h == "pi-signed" then (["low","medium","high","xhigh","max"] | index($e))
       elif $h == "muse" then (["low","medium","high","xhigh","max"] | index($e))

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1392,11 +1392,9 @@ effort_flag_for_harness() {
       esac
       ;;
     codex)
-      # The installed codex config schema uses model_reasoning_effort, and the
-      # bundled model catalog advertises low|medium|high|xhigh. Omit max rather
-      # than passing an unsupported value.
+      # Codex config uses model_reasoning_effort for every supported profile level.
       case "$effort" in
-        low|medium|high|xhigh) printf -- '-c %s ' "$(shell_quote "model_reasoning_effort=\"$effort\"")" ;;
+        low|medium|high|xhigh|max) printf -- '-c %s ' "$(shell_quote "model_reasoning_effort=\"$effort\"")" ;;
       esac
       ;;
     grok)

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -38,6 +38,9 @@
 #   axes chosen by firstmate at intake. They are only threaded into harnesses whose
 #   installed CLIs were verified to support that axis; unsupported axes are omitted
 #   from that harness's launch rather than guessed.
+#   Codex max is threaded only when `codex --version` reports 0.149.0 or newer;
+#   older or unparseable runtimes retain the requested effort in task metadata but
+#   omit the unsupported config from the launch.
 #   --backend <name> is the explicit runtime session-provider backend for this
 #   exact task only (docs/configuration.md "Runtime backend" owns when that flag
 #   is authorized). Without it, the script resolves FM_BACKEND, then
@@ -1111,6 +1114,24 @@ pi_supports_tui_mode() {
   printf '%s\n' "$help" | grep -Eq -- '(^|[[:space:]])--tui-mode([[:space:]=]|$)'
 }
 
+# Codex 0.149.0 is the first locally verified runtime that accepts max reasoning.
+# Treat an unreadable or unparseable version as unsupported so an older worker can
+# still launch with its model while preserving the requested effort in metadata.
+codex_supports_max_effort() {
+  local output version major minor patch extra
+  output=$(codex --version 2>/dev/null) || return 1
+  version=$(printf '%s\n' "$output" \
+    | sed -nE 's/.*[vV]?([0-9]+)\.([0-9]+)\.([0-9]+).*/\1.\2.\3/p' \
+    | head -n 1)
+  IFS='.' read -r major minor patch extra <<< "$version"
+  [ -n "$major" ] && [ -n "$minor" ] && [ -n "$patch" ] && [ -z "$extra" ] || return 1
+  [ "$major" -gt 0 ] && return 0
+  [ "$major" -eq 0 ] || return 1
+  [ "$minor" -gt 149 ] && return 0
+  [ "$minor" -eq 149 ] || return 1
+  [ "$patch" -ge 0 ]
+}
+
 # The verified launch command per adapter. The knowledge half of each adapter
 # (busy-state source, exit command, dialogs, quirks) lives in the harness-adapters skill.
 launch_template() {
@@ -1392,9 +1413,13 @@ effort_flag_for_harness() {
       esac
       ;;
     codex)
-      # Codex config uses model_reasoning_effort for every supported profile level.
       case "$effort" in
-        low|medium|high|xhigh|max) printf -- '-c %s ' "$(shell_quote "model_reasoning_effort=\"$effort\"")" ;;
+        low|medium|high|xhigh) printf -- '-c %s ' "$(shell_quote "model_reasoning_effort=\"$effort\"")" ;;
+        max)
+          if codex_supports_max_effort; then
+            printf -- '-c %s ' "$(shell_quote 'model_reasoning_effort="max"')"
+          fi
+          ;;
       esac
       ;;
     grok)

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -21,6 +21,8 @@ ok - codex-cli 0.149.0 live E2E preserved the max-reasoning foreground checkpoin
 ```
 
 The env-gated guard makes a real credentialed Codex launch with `--model gpt-5.6-luna -c 'model_reasoning_effort="max"'` and then proves it returns from a foreground watcher checkpoint.
+`fm-spawn` therefore forwards Codex `max` only when `codex --version` reports 0.149.0 or newer, and omits the config on older or unparseable runtimes so those workers remain launchable.
+The portable `tests/fm-spawn-dispatch-profile.test.sh` regression covers both forwarding at the verified floor and omission on an older runtime.
 
 ## tmux
 

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -6,6 +6,22 @@ This record contains reusable version-scoped evidence for active runtime guarant
 The backend guides own current setup, safety boundaries, and limitations.
 Exact task chronology, branch names, temporary homes, local paths, process ids, thread ids, and delivery transcripts remain in private reports or PR evidence.
 
+## Codex max reasoning profile
+
+Codex's `model_reasoning_effort=max` launch profile was verified on 2026-08-24 with codex-cli 0.149.0 on macOS arm64.
+
+```sh
+FM_CODEX_LIVE_E2E=1 bin/fm-test-run.sh tests/fm-codex-continuity-live-e2e.test.sh
+```
+
+Observed output:
+
+```text
+ok - codex-cli 0.149.0 live E2E preserved the max-reasoning foreground checkpoint path
+```
+
+The env-gated guard makes a real credentialed Codex launch with `--model gpt-5.6-luna -c 'model_reasoning_effort="max"'` and then proves it returns from a foreground watcher checkpoint.
+
 ## tmux
 
 Foreground-process behavior was verified on 2026-07-07 with tmux 3.6a on macOS.

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -1118,7 +1118,7 @@ test_crew_dispatch_validation() {
   done <<'ROWS'
 malformed dispatch config is flagged^{"rules":[^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - malformed JSON
 unverified dispatch harness is flagged^{"rules":[{"when":"anything","use":{"harness":"spaceship"}}],"default":{"harness":"codex"}}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - unverified harness: spaceship
-unsupported codex max effort is flagged^{"rules":[{"when":"big feature","use":{"harness":"codex","model":"gpt-5","effort":"max"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:max
+codex max effort is accepted^{"rules":[{"when":"big feature","use":{"harness":"codex","model":"gpt-5","effort":"max"}}]}^empty^
 unsupported grok max effort is flagged^{"rules":[{"when":"deep current work","use":{"harness":"grok","model":"grok-4","effort":"max"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:max
 unsupported grok xhigh effort is flagged^{"rules":[{"when":"deep current work","use":{"harness":"grok","model":"grok-4","effort":"xhigh"}}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: grok:xhigh
 pi max effort is accepted^{"rules":[{"when":"deep coding","use":{"harness":"pi","model":"openai-codex/gpt-5.6-sol","effort":"max"}}]}^empty^
@@ -1139,7 +1139,7 @@ empty array use is flagged^{"rules":[{"when":"big feature","use":[]}]}^exact^CRE
 array profile without harness is flagged^{"rules":[{"when":"big feature","use":[{"model":"gpt-5.5"}]}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - each use profile needs harness
 array profile with malformed model is flagged^{"rules":[{"when":"big feature","use":[{"harness":"codex","model":5}]}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - use profile model and effort must be non-empty strings when present
 unknown select is flagged^{"rules":[{"when":"big feature","use":[{"harness":"claude"},{"harness":"codex"}],"select":"mystery"}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - unknown select: mystery
-array profile unsupported effort is flagged^{"rules":[{"when":"big feature","use":[{"harness":"codex","effort":"max"}]}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:max
+array profile unsupported effort is flagged^{"rules":[{"when":"big feature","use":[{"harness":"codex","effort":"ultra"}]}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - invalid effort: codex:ultra
 empty default array is flagged^{"default":[]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - default needs at least one profile
 non-object default array entry is flagged^{"default":["codex"]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - each default profile must be an object
 default array profile without harness is flagged^{"default":[{"model":"gpt-5.5"}]}^exact^CREW_DISPATCH: invalid config/crew-dispatch.json - each default profile needs harness

--- a/tests/fm-codex-continuity-live-e2e.test.sh
+++ b/tests/fm-codex-continuity-live-e2e.test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Opt-in credentialed Codex regression proving the continuity changes preserve
-# Codex's bounded foreground-checkpoint supervision path.
+# Opt-in credentialed Codex regression proving max reasoning preserves Codex's
+# bounded foreground-checkpoint supervision path.
 set -u
 
 if [ "${FM_CODEX_LIVE_E2E:-0}" != 1 ]; then
@@ -41,7 +41,8 @@ PROMPT='Run exactly `bin/fm-watch-checkpoint.sh --seconds 1` as one foreground s
     --dangerously-bypass-hook-trust \
     --dangerously-bypass-approvals-and-sandbox \
     --skip-git-repo-check \
-    -c 'model_reasoning_effort="low"' \
+    --model gpt-5.6-luna \
+    -c 'model_reasoning_effort="max"' \
     --json \
     "$PROMPT"
 ) > "$TRANSCRIPT" 2>&1 || fail "Codex credentialed checkpoint turn failed: $(tail -20 "$TRANSCRIPT")"
@@ -52,4 +53,4 @@ if grep -F 'watcher: started pid=' "$TRANSCRIPT" >/dev/null; then
   fail "Codex switched to the background arm path"
 fi
 
-printf 'ok - %s live E2E preserved the one-second foreground checkpoint path\n' "$CODEX_VERSION"
+printf 'ok - %s live E2E preserved the max-reasoning foreground checkpoint path\n' "$CODEX_VERSION"

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -451,7 +451,7 @@ test_codex_threads_model_and_effort() {
   pass "codex receives --model and model_reasoning_effort profile flags"
 }
 
-test_codex_omits_invalid_max_effort() {
+test_codex_threads_max_effort() {
   local rec id out status launch
   id=profile-codex-max-z4
   rec=$(make_spawn_case profile-codex-max codex "$id")
@@ -459,13 +459,12 @@ test_codex_omits_invalid_max_effort() {
 
   out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model gpt-5 --effort max)
   status=$?
-  expect_code 0 "$status" "codex spawn with unsupported max effort should omit the effort flag"
+  expect_code 0 "$status" "codex spawn with max effort should succeed"
   assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' --dangerously-bypass-approvals-and-sandbox" \
-    "codex launch did not preserve the model flag when max effort was omitted"
-  assert_not_contains "$launch" "model_reasoning_effort" "codex launch must omit unsupported max reasoning effort"
-  pass "codex omits unsupported max effort instead of passing a bad config value"
+  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"max\"' --dangerously-bypass-approvals-and-sandbox" \
+    "codex launch did not thread max reasoning effort config"
+  pass "codex receives max model_reasoning_effort profile flag"
 }
 
 test_grok_threads_model_and_reasoning_effort() {
@@ -839,7 +838,7 @@ test_active_dispatch_profile_allows_positional_harness
 test_active_dispatch_profile_allows_raw_launch_command
 test_claude_threads_model_and_effort
 test_codex_threads_model_and_effort
-test_codex_omits_invalid_max_effort
+test_codex_threads_max_effort
 test_grok_threads_model_and_reasoning_effort
 test_grok_omits_invalid_max_reasoning_effort
 test_grok_omits_invalid_xhigh_reasoning_effort

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -74,6 +74,7 @@ fi
 exit 0
 SH
   chmod +x "$fakebin/timeout" "$fakebin/cursor-agent"
+  fm_fake_version_tool "$fakebin" codex FM_FAKE_CODEX_VERSION 'codex-cli 0.149.0'
   make_spawn_pi_probe "$fakebin" pi
   make_spawn_pi_probe "$fakebin" pi-signed
   printf '%s\n' "$fakebin"
@@ -126,7 +127,8 @@ run_spawn() {
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
     FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
     CLAUDE_CONFIG_DIR="${FM_TEST_CLAUDE_CONFIG_DIR:-}" \
-    FM_FAKE_LAUNCH_LOG="$launchlog" FM_FAKE_PI_VERSION="${FM_TEST_PI_VERSION:-0.84.0}" \
+    FM_FAKE_LAUNCH_LOG="$launchlog" FM_FAKE_CODEX_VERSION="${FM_TEST_CODEX_VERSION:-codex-cli 0.149.0}" \
+    FM_FAKE_PI_VERSION="${FM_TEST_PI_VERSION:-0.84.0}" \
     FM_FAKE_CURSOR_MODELS="${FM_TEST_CURSOR_MODELS:-}" \
     FM_FAKE_CURSOR_LIST_STATUS="${FM_TEST_CURSOR_LIST_STATUS:-0}" \
     GROK_HOME="$home/grok-home" PATH="$fakebin:$PATH" \
@@ -452,19 +454,43 @@ test_codex_threads_model_and_effort() {
 }
 
 test_codex_threads_max_effort() {
+  local model suffix rec id out status launch
+  for model in gpt-5.6-sol gpt-5.6-luna; do
+    suffix=${model##*-}
+    id="profile-codex-max-$suffix-z4"
+    rec=$(make_spawn_case "profile-codex-max-$suffix" codex "$id")
+    read_case_record "$rec"
+
+    out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+      "$id" "$PROJ_DIR" --model "$model" --effort max)
+    status=$?
+    expect_code 0 "$status" "codex $model spawn with max effort should succeed"
+    assert_meta_profile "$HOME_DIR/state/$id.meta" codex "$model" max
+    launch=$(cat "$LAUNCH_LOG")
+    assert_contains "$launch" "codex --model '$model' -c 'model_reasoning_effort=\"max\"' --dangerously-bypass-approvals-and-sandbox" \
+      "codex $model launch did not thread max reasoning effort config"
+  done
+  pass "codex sol and luna receive max model_reasoning_effort profile flags"
+}
+
+test_codex_omits_max_before_verified_version() {
   local rec id out status launch
-  id=profile-codex-max-z4
-  rec=$(make_spawn_case profile-codex-max codex "$id")
+  id=profile-codex-old-max-z4b
+  rec=$(make_spawn_case profile-codex-old-max codex "$id")
   read_case_record "$rec"
 
-  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR" --model gpt-5 --effort max)
+  out=$(FM_TEST_CODEX_VERSION='codex-cli 0.148.1' \
+    run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+      "$id" "$PROJ_DIR" --model gpt-5.6-luna --effort max)
   status=$?
-  expect_code 0 "$status" "codex spawn with max effort should succeed"
-  assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5 max
+  expect_code 0 "$status" "older codex spawn with max effort should preserve launch compatibility"
+  assert_meta_profile "$HOME_DIR/state/$id.meta" codex gpt-5.6-luna max
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "codex --model 'gpt-5' -c 'model_reasoning_effort=\"max\"' --dangerously-bypass-approvals-and-sandbox" \
-    "codex launch did not thread max reasoning effort config"
-  pass "codex receives max model_reasoning_effort profile flag"
+  assert_contains "$launch" "codex --model 'gpt-5.6-luna' --dangerously-bypass-approvals-and-sandbox" \
+    "older codex launch did not preserve the model when max was omitted"
+  assert_not_contains "$launch" "model_reasoning_effort" \
+    "older codex launch must omit max reasoning effort"
+  pass "codex omits max below the verified runtime floor"
 }
 
 test_grok_threads_model_and_reasoning_effort() {
@@ -839,6 +865,7 @@ test_active_dispatch_profile_allows_raw_launch_command
 test_claude_threads_model_and_effort
 test_codex_threads_model_and_effort
 test_codex_threads_max_effort
+test_codex_omits_max_before_verified_version
 test_grok_threads_model_and_reasoning_effort
 test_grok_omits_invalid_max_reasoning_effort
 test_grok_omits_invalid_xhigh_reasoning_effort


### PR DESCRIPTION
## Intent

Captain asked to repair Firstmate so Codex gpt-5.6-sol and gpt-5.6-luna can use max reasoning after current-runtime validation. Make max accepted by dispatch validation and passed through fm-spawn, retain Codex gpt-5.6-sol at xhigh for review and audit work, and update the captain local dispatch preferences from their temporary xhigh fallback to max. Deliver through a PR to the captain-owned fork without automatically merging it.

## What Changed

- Accept `max` effort in Codex dispatch profiles and forward it through `fm-spawn` as `model_reasoning_effort="max"`.
- Update bootstrap, spawn, and credentialed continuity coverage to exercise Codex max reasoning with `gpt-5.6-luna`.
- Document the verified Codex max-reasoning runtime and synchronize the harness adapter support matrix.

## Risk Assessment

✅ Low: Captain, the change is narrow and consistently enables Codex max reasoning across validation, launch rendering, documentation, and behavioral coverage without altering the xhigh selection policy.

## Testing

The base regression reproduced max-effort omission; target validator/spawn checks, real Luna/max and Sol/max runtime launches, and the exact redacted local-preference comparison demonstrated the requested behavior. Six reviewer-visible artifacts were retained and sanitized, with the worktree clean and no issues found.

<details>
<summary>Evidence: Before-fix spawn regression</summary>

Source: [Before-fix spawn regression](https://github.com/WangShen007/firstmate/blob/17f80ee71db2d55485b4926a2e922ae9e71751f3/.no-mistakes/evidence/fix/codex-max-reasoning/base-spawn-regression.log)

```text
FM_TEST_BEGIN 2026-08-24T14:58:14Z tests/fm-spawn-dispatch-profile.test.sh family=backend-dispatch expected_gate_skip=none
ok - no --model/--effort records defaults and types the claude launch instructions
ok - non-cursor launches clear inherited Cursor identity markers
ok - relative home overrides ignore CDPATH and become absolute before spawn launch construction
ok - FM_HOME defaults resolve relative paths and preserve absolute spellings
ok - absolute override spellings are preserved in spawn launch paths
ok - unresolvable relative spawn overrides fail with named diagnostics
ok - active crew-dispatch profile requires an explicit harness for ship spawns
ok - active crew-dispatch profile requires an explicit harness for scout spawns
ok - active crew-dispatch profile allows an explicit resolved harness
ok - active crew-dispatch profile allows the legacy positional harness form
ok - active crew-dispatch profile allows the raw launch-command escape hatch
ok - claude receives --model and --effort profile flags
ok - codex receives --model and model_reasoning_effort profile flags
ok - codex omits unsupported max effort instead of passing a bad config value
ok - grok receives --model and --reasoning-effort profile flags
ok - grok omits unsupported max reasoning effort
ok - grok omits unsupported xhigh reasoning effort
ok - cursor receives its model-qualified reasoning class and exact task workspace
ok - cursor refuses model ids absent from its resolved binary's live catalog
ok - cursor preserves the requested model when its live catalog is unreachable
ok - opencode receives --model and omits the unsupported effort axis
ok - pi receives --model and --thinking max profile flags
ok - Pi launch probing omits --tui-mode on older Pi and preserves it on supporting Pi
ok - pi-signed shares Pi launch semantics while preserving its configured and recorded identity
ok - pi-signed refuses safely and actionably when the selected executable is unavailable
ok - pi-signed is a distinct persistent secondmate runtime with shared Pi supervision semantics
ok - batch dispatch forwards shared --harness, --model, and --effort to every pair
ok - claude forwards firstmate's CLAUDE_CONFIG_DIR so the crewmate uses the same credential store
ok - claude omits the config-dir prefix when firstmate runs with the single-store default
ok - non-claude harnesses do not receive the claude CLAUDE_CONFIG_DIR prefix
ok - active crew-dispatch profile does not block secondmate launches
# all fm-spawn-dispatch-profile tests passed
FM_TEST_END 2026-08-24T14:59:43Z tests/fm-spawn-dispatch-profile.test.sh exit=0 duration_ms=88289 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=88346
FM_TEST_SUMMARY_FAMILY family=backend-dispatch count=1 duration_ms=88289 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-spawn-dispatch-profile.test.sh duration_ms=88289
```
</details>
<details>
<summary>Evidence: Dispatch validation transcript</summary>

Source: [Dispatch validation transcript](https://github.com/WangShen007/firstmate/blob/17f80ee71db2d55485b4926a2e922ae9e71751f3/.no-mistakes/evidence/fix/codex-max-reasoning/dispatch-validation-transcript.log)

```text
Acceptance-profile fixture supplied to fm-bootstrap:
{
  "rules": [
    {
      "when": "review or audit work",
      "use": {
        "harness": "codex",
        "model": "gpt-5.6-sol",
        "effort": "xhigh"
      }
    },
    {
      "when": "explicit max-reasoning work on sol",
      "use": {
        "harness": "codex",
        "model": "gpt-5.6-sol",
        "effort": "max"
      }
    }
  ],
  "default": {
    "harness": "codex",
    "model": "gpt-5.6-luna",
    "effort": "max"
  }
}

fm-bootstrap verbose dispatch surface:
BOOTSTRAP_INFO: crew dispatch active config/crew-dispatch.json
BOOTSTRAP_INFO: crew dispatch rule: review or audit work -> codex/gpt-5.6-sol/xhigh
BOOTSTRAP_INFO: crew dispatch rule: explicit max-reasoning work on sol -> codex/gpt-5.6-sol/max
BOOTSTRAP_INFO: crew dispatch default: codex/gpt-5.6-luna/max
```
</details>
<details>
<summary>Evidence: Sanitized Codex spawn-profile transcript</summary>

Source: [Sanitized Codex spawn-profile transcript](https://github.com/WangShen007/firstmate/blob/17f80ee71db2d55485b4926a2e922ae9e71751f3/.no-mistakes/evidence/fix/codex-max-reasoning/fm-spawn-codex-profile-transcript.log)

```text
fm-spawn request: --harness codex --model gpt-5.6-sol --effort xhigh
warning: <redacted-fixture-home>/data/sol-review/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
spawned sol-review harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-sol-review worktree=<redacted-fixture-worktree>
persisted profile:
harness=codex
model=gpt-5.6-sol
effort=xhigh
launch delivered to tmux:
env -u CURSOR_AGENT -u CURSOR_INVOKED_AS codex --model 'gpt-5.6-sol' -c 'model_reasoning_effort="xhigh"' --dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch '<redacted-fixture-home>/state/sol-review.turn-ended'\"]" "$('<worktree-root>/bin/fm-operational-input.sh' encode launch-brief < '<redacted-fixture-home>/data/sol-review/brief.md')"

fm-spawn request: --harness codex --model gpt-5.6-sol --effort max
warning: <redacted-fixture-home>/data/sol-max/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
spawned sol-max harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-sol-max worktree=<redacted-fixture-worktree>
persisted profile:
harness=codex
model=gpt-5.6-sol
effort=max
launch delivered to tmux:
env -u CURSOR_AGENT -u CURSOR_INVOKED_AS codex --model 'gpt-5.6-sol' -c 'model_reasoning_effort="max"' --dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch '<redacted-fixture-home>/state/sol-max.turn-ended'\"]" "$('<worktree-root>/bin/fm-operational-input.sh' encode launch-brief < '<redacted-fixture-home>/data/sol-max/brief.md')"

fm-spawn request: --harness codex --model gpt-5.6-luna --effort max
warning: <redacted-fixture-home>/data/luna-max/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
spawned luna-max harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-luna-max worktree=<redacted-fixture-worktree>
persisted profile:
harness=codex
model=gpt-5.6-luna
effort=max
launch delivered to tmux:
env -u CURSOR_AGENT -u CURSOR_INVOKED_AS codex --model 'gpt-5.6-luna' -c 'model_reasoning_effort="max"' --dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch '<redacted-fixture-home>/state/luna-max.turn-ended'\"]" "$('<worktree-root>/bin/fm-operational-input.sh' encode launch-brief < '<redacted-fixture-home>/data/luna-max/brief.md')"
```
</details>
<details>
<summary>Evidence: Codex Luna max live E2E</summary>

Source: [Codex Luna max live E2E](https://github.com/WangShen007/firstmate/blob/17f80ee71db2d55485b4926a2e922ae9e71751f3/.no-mistakes/evidence/fix/codex-max-reasoning/codex-luna-max-live-e2e.log)

```text
FM_TEST_BEGIN 2026-08-24T14:54:49Z tests/fm-codex-continuity-live-e2e.test.sh family=live-harness-optin expected_gate_skip=optin-env
Note: switching to 'b68ee43bdf9dbe6bee900a6b7bf3d6cc062cdac0'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

ok - codex-cli 0.149.0 live E2E preserved the max-reasoning foreground checkpoint path
FM_TEST_END 2026-08-24T14:55:20Z tests/fm-codex-continuity-live-e2e.test.sh exit=0 duration_ms=30589 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=30672
FM_TEST_SUMMARY_FAMILY family=live-harness-optin count=1 duration_ms=30589 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-codex-continuity-live-e2e.test.sh duration_ms=30589
```
</details>
<details>
<summary>Evidence: Codex Sol max runtime check</summary>

Source: [Codex Sol max runtime check](https://github.com/WangShen007/firstmate/blob/17f80ee71db2d55485b4926a2e922ae9e71751f3/.no-mistakes/evidence/fix/codex-max-reasoning/codex-sol-max-runtime.log)

```text
Command: codex exec --ephemeral --ignore-user-config --ignore-rules --skip-git-repo-check --sandbox read-only --model gpt-5.6-sol -c 'model_reasoning_effort="max"' --json 'Reply with exactly MAX_REASONING_ACCEPTED and do not call tools.'

Reading additional input from stdin...
{"type":"thread.started","thread_id":"01a03445-1558-7941-ac4a-620e1b9b17f1"}
{"type":"turn.started"}
{"type":"item.completed","item":{"id":"item_0","type":"error","message":"Skill descriptions were shortened to fit the skills context budget. Codex can still see every skill, but some descriptions are shorter. Disable unused skills or plugins to leave more room for the rest."}}
{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"MAX_REASONING_ACCEPTED"}}
{"type":"turn.completed","usage":{"input_tokens":26936,"cached_input_tokens":6912,"cache_write_input_tokens":0,"output_tokens":9,"reasoning_output_tokens":0}}
```
</details>
<details>
<summary>Evidence: Redacted captain-local dispatch snapshot</summary>

Source: [Redacted captain-local dispatch snapshot](https://github.com/WangShen007/firstmate/blob/17f80ee71db2d55485b4926a2e922ae9e71751f3/.no-mistakes/evidence/fix/codex-max-reasoning/captain-dispatch-semantic-snapshot.json)

```text
{
  "architecture": {
    "harness": "codex",
    "model": "gpt-5.6-sol",
    "effort": "max"
  },
  "routine_implementation": {
    "harness": "codex",
    "model": "gpt-5.6-luna",
    "effort": "max"
  },
  "review_audit": {
    "harness": "codex",
    "model": "gpt-5.6-sol",
    "effort": "xhigh"
  }
}
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (21m8s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"e3de72e7ecdd7484b523401873e57e6857de2953","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `config/crew-dispatch.json` - The target commit contains no captain-local config/crew-dispatch.json. The isolated fixture proves validation and launch behavior, but cannot prove the actual review/audit rule remains gpt-5.6-sol/xhigh or that the captain’s temporary fallback was changed to max. Have the outer executor attach a redacted semantic snapshot from the captain home, or explicitly accept source/runtime proof without local-preference evidence.
- <code>Baseline reproduction: extracted commit `038d0f7ec6ba7238a151722931434dcf06ff37c4` and ran `bin/fm-test-run.sh tests/fm-spawn-dispatch-profile.test.sh`, confirming Codex max was previously omitted.</code>
- `bin/fm-test-run.sh tests/fm-spawn-dispatch-profile.test.sh tests/fm-bootstrap.test.sh`
- `FM_CODEX_LIVE_E2E=1 bin/fm-test-run.sh tests/fm-codex-continuity-live-e2e.test.sh`
- `codex exec --ephemeral --ignore-user-config --ignore-rules --skip-git-repo-check --sandbox read-only --model gpt-5.6-sol -c 'model_reasoning_effort="max"' --json 'Reply with exactly MAX_REASONING_ACCEPTED and do not call tools.'`
- <code>Manual isolated `fm-bootstrap.sh` check with Sol/xhigh review, Sol/max explicit, and Luna/max default profiles using `FM_BOOTSTRAP_VERBOSE_FACTS=1`.</code>
- <code>Manual isolated `fm-spawn.sh` checks for `gpt-5.6-sol/xhigh`, `gpt-5.6-sol/max`, and `gpt-5.6-luna/max`, inspecting persisted metadata and tmux launch commands.</code>
- <code>Cleanup audit with `git status --short --branch`, `git diff --exit-code`, and transient-fixture search.</code>

🔧 Fix: Verify captain dispatch preferences with redacted evidence
✅ Re-checked - no issues remain.
- <code>At base commit `038d0f7ec6ba7238a151722931434dcf06ff37c4`, `bin/fm-test-run.sh tests/fm-spawn-dispatch-profile.test.sh` reproduced Codex max-effort omission.</code>
- <code>`FM_CODEX_LIVE_E2E=1 bin/fm-test-run.sh tests/fm-codex-continuity-live-e2e.test.sh` exercised a credentialed `gpt-5.6-luna` launch with `model_reasoning_effort=&#34;max&#34;` and the foreground checkpoint path.</code>
- <code>`codex exec --ephemeral --ignore-user-config --ignore-rules --model gpt-5.6-sol -c &#39;model_reasoning_effort=&#34;max&#34;&#39; ...` confirmed Sol accepts max reasoning.</code>
- <code>An isolated `fm-bootstrap.sh` consumer run accepted Sol/max, Luna/max, and retained Sol/xhigh for review/audit.</code>
- <code>Isolated `fm-spawn.sh` launches verified persisted metadata and emitted flags for `gpt-5.6-sol/xhigh`, `gpt-5.6-sol/max`, and `gpt-5.6-luna/max`.</code>
- <code>`jq -e` plus normalized `diff -u` verified the redacted snapshot exactly matches the three current captain-local semantic profiles.</code>
- <code>`rg` privacy scan confirmed evidence contains no private absolute paths; `git status --short` confirmed a clean worktree.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
