### PR TITLE
fix: restore supervision integrity across lanes and wake handling

### DIFF
--- a/bin/fm-backend.sh
+++ b/bin/fm-backend.sh
@@ -598,6 +598,7 @@ fm_backend_source() {  # <name>
   case "$name" in
     tmux)
       if [ -z "${_FM_BACKEND_TMUX_SOURCED:-}" ]; then
+        [ -f "$FM_BACKEND_LIB_DIR/backends/tmux.sh" ] || return 1
         # shellcheck source=/dev/null
         . "$FM_BACKEND_LIB_DIR/backends/tmux.sh" || return 1
         _FM_BACKEND_TMUX_SOURCED=1
@@ -605,6 +606,7 @@ fm_backend_source() {  # <name>
       ;;
     herdr)
       if [ -z "${_FM_BACKEND_HERDR_SOURCED:-}" ]; then
+        [ -f "$FM_BACKEND_LIB_DIR/backends/herdr.sh" ] || return 1
         # shellcheck source=/dev/null
         . "$FM_BACKEND_LIB_DIR/backends/herdr.sh" || return 1
         _FM_BACKEND_HERDR_SOURCED=1
@@ -612,6 +614,7 @@ fm_backend_source() {  # <name>
       ;;
     zellij)
       if [ -z "${_FM_BACKEND_ZELLIJ_SOURCED:-}" ]; then
+        [ -f "$FM_BACKEND_LIB_DIR/backends/zellij.sh" ] || return 1
         # shellcheck source=/dev/null
         . "$FM_BACKEND_LIB_DIR/backends/zellij.sh" || return 1
         _FM_BACKEND_ZELLIJ_SOURCED=1
@@ -619,6 +622,7 @@ fm_backend_source() {  # <name>
       ;;
     orca)
       if [ -z "${_FM_BACKEND_ORCA_SOURCED:-}" ]; then
+        [ -f "$FM_BACKEND_LIB_DIR/backends/orca.sh" ] || return 1
         # shellcheck source=/dev/null
         . "$FM_BACKEND_LIB_DIR/backends/orca.sh" || return 1
         _FM_BACKEND_ORCA_SOURCED=1
@@ -626,6 +630,7 @@ fm_backend_source() {  # <name>
       ;;
     cmux)
       if [ -z "${_FM_BACKEND_CMUX_SOURCED:-}" ]; then
+        [ -f "$FM_BACKEND_LIB_DIR/backends/cmux.sh" ] || return 1
         # shellcheck source=/dev/null
         . "$FM_BACKEND_LIB_DIR/backends/cmux.sh" || return 1
         _FM_BACKEND_CMUX_SOURCED=1

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -219,7 +219,7 @@ crew_busy_verdict() {  # <target>
 trim() { fm_nm_trim "$@"; }
 strip_quotes() { fm_nm_strip_quotes "$@"; }
 nm_run() {  # <args...>
-  fm_nm_run "$WT" "$NM_TIMEOUT" "$@"
+  fm_nm_run_bounded "$WT" "$NM_TIMEOUT" "$@"
 }
 
 # Scalar value of a TOON key in the captured run output ($RUN_OUT).
@@ -373,7 +373,20 @@ if [ "$KIND" = ship ] && [ -n "$CREW_BRANCH" ] && command -v no-mistakes >/dev/n
   fi
   RUN_ID=$FM_NM_RUN_ID
   RUN_OUT=
-  [ -z "$RUN_ID" ] || RUN_OUT=$(nm_run axi status --run "$RUN_ID")
+  if [ -n "$RUN_ID" ]; then
+    run_out_file=$(mktemp "${TMPDIR:-/tmp}/fm-crew-state.XXXXXX")
+    if nm_run axi status --run "$RUN_ID" >"$run_out_file" 2>/dev/null; then
+      RUN_OUT=$(cat "$run_out_file")
+      rm -f "$run_out_file"
+    else
+      nm_status=$?
+      RUN_OUT=$(cat "$run_out_file")
+      rm -f "$run_out_file"
+      if [ "$nm_status" -eq 124 ]; then
+        emit unknown run-step "run-step lookup timed out after ${NM_TIMEOUT}s (no-mistakes axi status --run $RUN_ID)"
+      fi
+    fi
+  fi
   if [ -n "$RUN_OUT" ]; then
     run_id=$(strip_quotes "$(nm_field id)")
     run_branch=$(strip_quotes "$(nm_field branch)")

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -364,7 +364,14 @@ HAVE_RUN=0
 # Scouts and secondmates never drive a no-mistakes validation of their own
 # worktree, so skip the lookup for them and read state from pane/log directly.
 if [ "$KIND" = ship ] && [ -n "$CREW_BRANCH" ] && command -v no-mistakes >/dev/null 2>&1; then
-  RUN_ID=$(fm_nm_run_id_for_worktree "$WT" "$CREW_BRANCH")
+  # A durable source that cannot be consulted is NOT an answer: guessing from
+  # the ambient resolver, or falling through to the pane/status-log path as if
+  # no run existed, is what hid a genuinely parked run. Report unknown and name
+  # the missing source instead.
+  if ! fm_nm_run_id_for_worktree "$WT" "$CREW_BRANCH"; then
+    emit unknown run-step "run attribution unavailable: ${FM_NM_RUN_ID_UNAVAILABLE_REASON:-no durable source}"
+  fi
+  RUN_ID=$FM_NM_RUN_ID
   RUN_OUT=
   [ -z "$RUN_ID" ] || RUN_OUT=$(nm_run axi status --run "$RUN_ID")
   if [ -n "$RUN_OUT" ]; then

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -28,8 +28,8 @@
 #      unreachable or unreadable remote reports unknown-remote, never a false
 #      gone/dead.
 #   2. Matching no-mistakes run for this crew's branch AND current code identity,
-#      active or terminal (from `axi status`, or the coarse `no-mistakes runs`
-#      fallback)? Branch name alone is not enough: a historical run on a reused
+#      active or terminal (from the durable run registry, then `axi status --run`)?
+#      Branch name alone is not enough: a historical run on a reused
 #      branch whose head was rewritten or diverged must not be attributed.
 #      A run matches when its head equals the worktree HEAD, or the worktree HEAD
 #      is an ancestor of the run head (pipeline fix commits advanced the run on
@@ -81,12 +81,6 @@ META="$STATE/$ID.meta"
 LOG="$STATE/$ID.status"
 NM_TIMEOUT=${FM_CREW_STATE_NM_TIMEOUT:-10}
 case "$NM_TIMEOUT" in ''|*[!0-9]*) NM_TIMEOUT=10 ;; esac
-# How many of the most recent `no-mistakes runs` rows the cross-branch fallback
-# (nm_runs_status_for_branch, below) scans. Generous enough to still find a
-# branch's own run on a busy multi-crew fleet without listing the entire
-# history every call.
-FM_CREW_STATE_RUNS_LIMIT=${FM_CREW_STATE_RUNS_LIMIT:-200}
-case "$FM_CREW_STATE_RUNS_LIMIT" in ''|*[!0-9]*) FM_CREW_STATE_RUNS_LIMIT=200 ;; esac
 SEP=' · '
 
 # Emit the one canonical line and exit 0. Detail is optional.
@@ -353,63 +347,6 @@ nm_ci_checks_state() {
     *) printf 'unknown' ;;
   esac
 }
-# Coarse fallback for cross-branch attribution. `no-mistakes axi status` (bare)
-# reports the active-or-most-recent run for the CURRENT branch when one
-# exists, else falls back to some other branch's run purely as informational
-# display (verified empirically: querying a worktree with its own active run
-# reliably returns that run, even under concurrent load from several other
-# validating crews on the same underlying repo). A crew whose branch genuinely
-# has no run yet therefore sees another branch's answer here.
-#
-# This fallback used to shell out to `no-mistakes axi` (bare, no subcommand)
-# expecting a `runs[N]{id,branch,status,...}:` TOON table and re-query the
-# matched id via `axi status --run <id>`. Verified against the real installed
-# CLI (v1.32.2): the `axi` surface exposes only abort/logs/respond/run/status -
-# there is no runs-listing subcommand under `axi` at all, so that table never
-# appears and the lookup was silently dead code; whenever the bare `axi
-# status` answer was not this crew's own branch, attribution always failed and
-# the caller fell straight through to the pane/log fallback below. (The
-# PRIMARY cause of the 2026-07 herdr false-surface incidents turned out to be
-# a separate bug in bin/fm-watch.sh's stale_is_terminal precedence - see that
-# file's history - but this cross-branch path was independently confirmed
-# dead code and is worth having actually work.)
-#
-# The real run-listing command is the top-level `no-mistakes runs` (verified:
-# `no-mistakes --help` lists it separately from `axi`). It is plain, human-
-# oriented text - no run id, no JSON/TOON, newest-first, columns
-# "<status> <branch> <short-sha> <date> [<pr-url>]" separated by runs of
-# spaces (verified: no quoting, so splitting on the first two whitespace runs
-# is exact) - but branch + coarse status is exactly what this predicate needs:
-# is a run for THIS branch active right now. Echoes the first (most recent)
-# matching row's status word (running/completed/cancelled/failed), or empty
-# when the branch has no run within FM_CREW_STATE_RUNS_LIMIT rows.
-nm_runs_status_for_branch() {  # <branch>
-  local branch=$1 out row st rest br sha
-  out=$(nm_run runs --limit "$FM_CREW_STATE_RUNS_LIMIT")
-  [ -n "$out" ] || return 0
-  while IFS= read -r row; do
-    row=$(trim "$row")
-    [ -n "$row" ] || continue
-    st=${row%% *}
-    rest=${row#* }
-    rest=$(trim "$rest")
-    br=${rest%% *}
-    rest=${rest#* }
-    rest=$(trim "$rest")
-    sha=${rest%% *}
-    if [ "$br" = "$branch" ]; then
-      # Same code-identity rule as axi status: skip a same-branch row whose
-      # short-sha does not match this worktree (rewritten or advanced tip).
-      if ! nm_coarse_head_matches_worktree "$sha"; then
-        continue
-      fi
-      printf '%s' "$st"
-      return 0
-    fi
-  done <<< "$out"
-  return 0
-}
-
 # CREW_BRANCH is empty at detached HEAD (a just-spawned crew, or a scout's
 # scratch worktree); with no branch there is no run to attribute to this crew.
 CREW_BRANCH=$(git -C "$WT" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
@@ -423,41 +360,19 @@ nm_run_head_matches_worktree() {
   fm_nm_head_matches_worktree "$WT" "$run_head"
 }
 
-# Coarse runs-list rows are "<status> <branch> <short-sha> ...". 0 if the short
-# sha for this branch row matches the worktree head under the same rules as
-# nm_run_head_matches_worktree (equal, or local is ancestor of run tip).
-nm_coarse_head_matches_worktree() {  # <short-sha>
-  fm_nm_head_matches_worktree "$WT" "$1"
-}
-
 HAVE_RUN=0
-# RUN_SOURCE distinguishes the two ways HAVE_RUN=1 can happen: "full" means
-# $RUN_OUT is real `axi status` TOON with step/gate detail; "coarse" means only
-# a bare status word came back from the runs-list fallback above, so the
-# run-step block below skips the TOON field parsing entirely for this crew.
-RUN_SOURCE=full
-COARSE_STATUS=""
 # Scouts and secondmates never drive a no-mistakes validation of their own
 # worktree, so skip the lookup for them and read state from pane/log directly.
 if [ "$KIND" = ship ] && [ -n "$CREW_BRANCH" ] && command -v no-mistakes >/dev/null 2>&1; then
-  RUN_OUT=$(nm_run axi status)
+  RUN_ID=$(fm_nm_run_id_for_worktree "$WT" "$CREW_BRANCH")
+  RUN_OUT=
+  [ -z "$RUN_ID" ] || RUN_OUT=$(nm_run axi status --run "$RUN_ID")
   if [ -n "$RUN_OUT" ]; then
+    run_id=$(strip_quotes "$(nm_field id)")
     run_branch=$(strip_quotes "$(nm_field branch)")
-    if [ -n "$run_branch" ] && [ "$run_branch" = "$CREW_BRANCH" ] && nm_run_head_matches_worktree; then
+    if [ "$run_id" = "$RUN_ID" ] && [ -n "$run_branch" ] \
+      && [ "$run_branch" = "$CREW_BRANCH" ] && nm_run_head_matches_worktree; then
       HAVE_RUN=1
-    else
-      # The active-or-most-recent run is for another branch, or same branch with
-      # a rewritten/diverged head (the CLI is alive and answered; only the
-      # attribution missed) - try the coarse fallback.
-      # Deliberately nested inside `[ -n "$RUN_OUT" ]`: an empty/timed-out
-      # primary call means the CLI itself did not respond, so retrying it
-      # immediately with a second bounded call would just double the wait
-      # for no better answer.
-      COARSE_STATUS=$(nm_runs_status_for_branch "$CREW_BRANCH")
-      if [ -n "$COARSE_STATUS" ]; then
-        HAVE_RUN=1
-        RUN_SOURCE=coarse
-      fi
     fi
   fi
 fi
@@ -470,23 +385,7 @@ if [ "$HAVE_RUN" = 1 ]; then
   CI_STEP_STATUS=""
   CI_LOG_STATE=""
   RUN_STATUS=""
-  if [ "$RUN_SOURCE" = coarse ]; then
-    # No step/gate detail is available from the plain runs list - only ever
-    # true/working, done, or failed. A crew genuinely parked at a gate still
-    # gets full detail once `axi status` reports its own branch again (e.g.
-    # once its own step is the most-recently-touched one), and its own
-    # needs-decision/blocked status-log append (a captain-relevant VERB) is
-    # surfaced through signal_reason_is_actionable regardless of this
-    # coarse-vs-full distinction, so a real gate is never silently missed.
-    case "$COARSE_STATUS" in
-      running)   RUN_STATE=working; RUN_DETAIL="validating (background run)" ;;
-      completed) RUN_STATE="done";  RUN_DETAIL="run completed" ;;
-      failed)    RUN_STATE=failed;  RUN_DETAIL="run failed" ;;
-      cancelled) RUN_STATE=failed;  RUN_DETAIL="run cancelled" ;;
-      *)         RUN_STATE=unknown; RUN_DETAIL="runs list status: $COARSE_STATUS" ;;
-    esac
-  else
-    status=$(strip_quotes "$(nm_field status)")
+  status=$(strip_quotes "$(nm_field status)")
     RUN_STATUS=$status
     outcome=$(strip_quotes "$(nm_field outcome)")
     awaiting=$(printf '%s\n' "$RUN_OUT" | grep -E '^[[:space:]]*awaiting_agent:' | head -1 || true)
@@ -543,12 +442,7 @@ if [ "$HAVE_RUN" = 1 ]; then
         esac
       fi
     fi
-  fi
-
   if [ "$RUN_STATE" = working ] && log_reports_ci_ready; then
-    if [ "$RUN_SOURCE" = coarse ]; then
-      emit "done" status-log "$(status_line_note "$LOG_LINE")${SEP}run still monitoring PR"
-    fi
     [ -n "$CI_STEP_STATUS" ] || CI_STEP_STATUS=$(nm_effective_ci_step_status)
     if [ "$RUN_STATUS" = fixing ]; then
       CI_LOG_STATE=not-ready

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -96,7 +96,10 @@ esac
 # Cross-home bounds are explicit so one broken or unexpectedly large home cannot
 # hang or explode the parent snapshot.
 FM_SNAPSHOT_SECONDMATES=${FM_SNAPSHOT_SECONDMATES:-20}
-FM_SNAPSHOT_SECONDMATE_TIMEOUT=${FM_SNAPSHOT_SECONDMATE_TIMEOUT:-8}
+# Attribution now reports missing durable sources instead of guessing; the
+# digest allows extra time for that honest read and still reports timeout when
+# the bound is exhausted.
+FM_SNAPSHOT_SECONDMATE_TIMEOUT=${FM_SNAPSHOT_SECONDMATE_TIMEOUT:-20}
 FM_SNAPSHOT_SECONDMATE_MAX_BYTES=${FM_SNAPSHOT_SECONDMATE_MAX_BYTES:-262144}
 FM_SNAPSHOT_SECONDMATE_CHILDREN=${FM_SNAPSHOT_SECONDMATE_CHILDREN:-20}
 FM_SNAPSHOT_SECONDMATE_QUEUED=${FM_SNAPSHOT_SECONDMATE_QUEUED:-20}

--- a/bin/fm-fleet-snapshot.sh
+++ b/bin/fm-fleet-snapshot.sh
@@ -228,6 +228,7 @@ crew_state_json() {  # <id>
       FM_DATA_OVERRIDE="$DATA" \
       FM_PROJECTS_OVERRIDE="$PROJECTS" \
       FM_CONFIG_OVERRIDE="$CONFIG" \
+      FM_CREW_STATE_NM_TIMEOUT="${FM_CREW_STATE_NM_TIMEOUT:-$FM_SNAPSHOT_SECONDMATE_TIMEOUT}" \
       "$SCRIPT_DIR/fm-crew-state.sh" "$id" 2>/dev/null || true
   )
   raw=$(printf '%s\n' "$raw" | head -1)
@@ -696,7 +697,8 @@ secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
             report_path:((.report_path // null) | if . == null then null else trunc(500) end),
             local_note:((.local_note // null) | if . == null then null else trunc(120) end),completion} ]
        | sort_by([(.completion.date // ""), .id]) | reverse) as $landed_all
-    | ([ $tasks[] | select(.current_state.state == "unknown") ]) as $unknown_children
+    | ([ $tasks[] | select(.current_state.state == "unknown")
+        | {id,detail:(.current_state.detail // "attribution source unavailable")} ]) as $unknown_children
     | ([ $owned_in_flight[]
          | select(.requires_child_metadata)
          | select(.id as $id | [$tasks[].id] | index($id) | not) ]) as $orphan_in_flight
@@ -758,7 +760,7 @@ secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
        and ($terminal_in_flight | length) == 0) as $valid
     | (if ($strict_invalidities | length) > 0 then $strict_invalidities[0].reason
        elif ($unknown_children | length) > 0 then
-         "child current state unavailable: " + ($unknown_children | map(.id) | join(", "))
+       "child current state unavailable: " + ($unknown_children | map(.id + " (" + .detail + ")") | join(", "))
        else null end) as $reason
     | (if ($strict_invalidities | length) > 0 then $strict_invalidities[0] | del(.reason)
        elif ($unknown_children | length) > 0 then {kind:"child_current_unavailable",ids:($unknown_children | map(.id))}
@@ -792,8 +794,11 @@ secondmate_home_summary_json() {  # <backlog-json> <tasks-json>
           repo:((.repo // null) | if . == null then null else trunc(120) end),
           kind:((.kind // null) | if . == null then null else trunc(40) end)}][:$queued_n]),
         landed:(if $landed_n == 0 then $landed_all else $landed_all[:$landed_n] end),
-        endpoints:([$tasks[] | {id,state:.current_state.state,source:.current_state.source,
-          endpoint:(.endpoint + {target:((.endpoint.target // null) | if . == null then null else trunc(240) end)})}][:$child_n]),
+        endpoints:([ $tasks[] | {id,state:.current_state.state,source:.current_state.source,
+          endpoint:(.endpoint + {target:((.endpoint.target // null) | if . == null then null else trunc(240) end)})} ]
+          + [ $backlog.records[]? | select(.state == "in_flight" and (.id as $id | [$tasks[].id] | index($id) | not))
+              | {id, state:"unknown", source:"durable-record", endpoint:{target:null,exists:true,agent_alive:"unknown",status:"unknown",observed_at:$generated,freshness:"fresh",reason:"durable endpoint record absent from child summary"}} ]
+          | .[:$child_n]),
         counts:{
           active_children:($active_all | length),
           decisions_open:($decisions_all | length),
@@ -1230,6 +1235,7 @@ secondmate_current_json() {  # <parent-tasks-json>
           FM_DATA_OVERRIDE="$home/data" \
           FM_CONFIG_OVERRIDE="$home/config" \
           FM_PROJECTS_OVERRIDE="$home/projects" \
+          FM_CREW_STATE_NM_TIMEOUT="$FM_SNAPSHOT_SECONDMATE_TIMEOUT" \
           FM_SNAPSHOT_NOW="$SNAPSHOT_NOW" \
           FM_SNAPSHOT_NOW_EPOCH="$SNAPSHOT_EPOCH" \
           FM_SNAPSHOT_SECONDMATE_CHILDREN="$FM_SNAPSHOT_SECONDMATE_CHILDREN" \
@@ -1242,6 +1248,16 @@ secondmate_current_json() {  # <parent-tasks-json>
       if [ "$summary_rc" -ne 0 ]; then
         [ "$summary_rc" -eq 124 ] && reason="structured home snapshot timed out" || reason="structured home snapshot failed"
       else
+        expected_endpoints=$(for meta in "$home/state"/*.meta; do
+          [ -e "$meta" ] || continue
+          basename "$meta" .meta
+        done | jq -Rsc 'split("\n") | map(select(length > 0))')
+        summary=$(printf '%s' "$summary" | jq --argjson expected "$expected_endpoints" '
+          . as $root |
+          ($root.endpoints // []) as $known |
+          .endpoints = ($known + [$expected[] as $id |
+            select([$known[]?.id] | index($id) | not) |
+            {id:$id,state:"unknown",source:"durable-record",endpoint:{target:null,exists:true,agent_alive:"unknown",status:"unknown",observed_at:$root.generated,freshness:"fresh",reason:"durable endpoint record absent from child summary"}}])')
         summary_bytes=$(printf '%s' "$summary" | LC_ALL=C wc -c | tr -d ' ')
         if [ "$summary_bytes" -gt "$FM_SNAPSHOT_SECONDMATE_MAX_BYTES" ]; then
           reason="structured home snapshot exceeded byte limit"
@@ -1273,7 +1289,16 @@ secondmate_current_json() {  # <parent-tasks-json>
       state=$(printf '%s' "$summary" | jq -r '.state')
       current_reason=
       if [ "$summary_valid" != true ]; then
-        current_reason="structured home state invalid: $(printf '%s' "$summary" | jq -r '.reason // "unknown reason"')"
+        summary_kind=$(printf '%s' "$summary" | jq -r '.invalidity.kind // ""')
+        summary_reason=$(printf '%s' "$summary" | jq -r '.reason // "unknown reason"')
+        if [ "$summary_kind" = child_current_unavailable ]; then
+          case "$summary_reason" in
+            *"run attribution unavailable"*) current_reason="child current state lookup timed out or attribution unavailable: $summary_reason" ;;
+            *) current_reason="$summary_reason" ;;
+          esac
+        else
+          current_reason="structured home state invalid: $summary_reason"
+        fi
       fi
       reconciliation=$(parent_evidence_reconciliation_json "$summary" "$activities" "$decisions")
       contradiction=$(printf '%s' "$reconciliation" | jq -r '.contradiction')

--- a/bin/fm-nm-run-lib.sh
+++ b/bin/fm-nm-run-lib.sh
@@ -64,26 +64,63 @@ fm_nm_sql_literal() {  # <value>
 # Resolve the private no-mistakes state database without changing it.
 # FM_NM_STATE_DB gives hermetic callers an explicit path.
 # Production uses the same NM_HOME location the no-mistakes CLI owns.
-fm_nm_state_db() {
+# The _path form prints where the database is expected regardless of whether it
+# exists, so an unavailability report can name the concrete path it looked at.
+fm_nm_state_db_path() {
   local db=${FM_NM_STATE_DB:-}
   if [ -z "$db" ]; then
     db="${NM_HOME:-${HOME}/.no-mistakes}/state.sqlite"
   fi
+  printf '%s\n' "$db"
+}
+
+fm_nm_state_db() {
+  local db
+  db=$(fm_nm_state_db_path)
   [ -f "$db" ] || return 1
   printf '%s\n' "$db"
 }
 
-# Print the exact no-mistakes run id this worktree owns, or nothing when no matching run can be proved.
+# Resolve the no-mistakes run id this worktree owns into FM_NM_RUN_ID.
 # The CLI's bare `axi status` resolver is process-ambient and may name another concurrent branch, so it is never an attribution source.
 # The durable registry includes ids, branch, repo, head, status, and creation order; active rows win over terminal siblings, then newest starts win.
-# The caller must read the returned id with `axi status --run <id>`.
+# Three outcomes, kept distinct so a caller never reads "the source was missing" as "there is no run":
+#   0 with FM_NM_RUN_ID set    - this worktree owns that run; read it with `axi status --run <id>`.
+#   0 with FM_NM_RUN_ID empty  - the registry was read and proves no run matches this worktree.
+#   2                          - no durable source could be consulted; FM_NM_RUN_ID_UNAVAILABLE_REASON names the missing one.
+# The result is assigned rather than printed so both halves survive without a
+# second lookup; callers must not run it in a command substitution.
+FM_NM_RUN_ID=
+FM_NM_RUN_ID_UNAVAILABLE_REASON=
+
+fm_nm_run_id_unavailable() {  # <reason>
+  # shellcheck disable=SC2034 # Output globals are consumed by sourcing callers.
+  FM_NM_RUN_ID=
+  # shellcheck disable=SC2034 # Output globals are consumed by sourcing callers.
+  FM_NM_RUN_ID_UNAVAILABLE_REASON=$1
+  return 2
+}
+
 fm_nm_run_id_for_worktree() {  # <worktree> <branch>
-  local wt=$1 branch=$2 db upstream query rows id run_head _status
+  local wt=$1 branch=$2 db upstream query rows id run_head _status branch_query branch_rows
+  # shellcheck disable=SC2034 # Output globals are consumed by sourcing callers.
+  FM_NM_RUN_ID=
+  # shellcheck disable=SC2034 # Output globals are consumed by sourcing callers.
+  FM_NM_RUN_ID_UNAVAILABLE_REASON=
   [ -d "$wt" ] && [ -n "$branch" ] || return 0
-  command -v sqlite3 >/dev/null 2>&1 || return 0
-  db=$(fm_nm_state_db) || return 0
+  if ! command -v sqlite3 >/dev/null 2>&1; then
+    fm_nm_run_id_unavailable "sqlite3 is not installed, so the no-mistakes run registry cannot be read"
+    return 2
+  fi
+  if ! db=$(fm_nm_state_db); then
+    fm_nm_run_id_unavailable "no no-mistakes state database at $(fm_nm_state_db_path)"
+    return 2
+  fi
   upstream=$(git -C "$wt" config --get remote.origin.url 2>/dev/null || true)
-  [ -n "$upstream" ] || return 0
+  if [ -z "$upstream" ]; then
+    fm_nm_run_id_unavailable "no remote.origin.url in $wt, so no registry repo can be matched"
+    return 2
+  fi
   query="SELECT r.id, r.head_sha, r.status
 FROM runs r
 JOIN repos p ON p.id = r.repo_id
@@ -91,11 +128,34 @@ WHERE r.branch = $(fm_nm_sql_literal "$branch")
   AND p.upstream_url = $(fm_nm_sql_literal "$upstream")
 ORDER BY CASE WHEN r.status IN ('pending', 'running', 'fixing', 'awaiting_approval', 'fix_review', 'ci') THEN 0 ELSE 1 END,
          r.created_at DESC;"
-  rows=$(sqlite3 -noheader -separator $'\t' "$db" "$query" 2>/dev/null) || return 0
+  if ! rows=$(sqlite3 -noheader -separator $'\t' "$db" "$query" 2>/dev/null); then
+    fm_nm_run_id_unavailable "no-mistakes state database $db could not be queried"
+    return 2
+  fi
+  if [ -z "$rows" ]; then
+    # The registry records one upstream spelling per repo row, so the same
+    # remote written as git@ here and https:// there matches nothing above.
+    # A branch row whose head is this worktree's own code identity proves the
+    # registry does hold this repo, so the miss is an unmatched upstream
+    # string - an unavailable source, not proof that no run exists.
+    branch_query="SELECT r.head_sha FROM runs r WHERE r.branch = $(fm_nm_sql_literal "$branch");"
+    branch_rows=$(sqlite3 -noheader "$db" "$branch_query" 2>/dev/null) || branch_rows=
+    if [ -n "$branch_rows" ]; then
+      while IFS= read -r run_head; do
+        [ -n "$run_head" ] || continue
+        if fm_nm_head_matches_worktree "$wt" "$run_head"; then
+          fm_nm_run_id_unavailable "no registry repo matches upstream $upstream (the run registry spells this remote differently)"
+          return 2
+        fi
+      done <<< "$branch_rows"
+    fi
+    return 0
+  fi
   while IFS=$'\t' read -r id run_head _status; do
     case "$id" in ''|*[!A-Za-z0-9._-]*) continue ;; esac
     fm_nm_head_matches_worktree "$wt" "$run_head" || continue
-    printf '%s\n' "$id"
+    # shellcheck disable=SC2034 # Output globals are consumed by sourcing callers.
+    FM_NM_RUN_ID=$id
     return 0
   done <<< "$rows"
   return 0

--- a/bin/fm-nm-run-lib.sh
+++ b/bin/fm-nm-run-lib.sh
@@ -55,6 +55,52 @@ fm_nm_field() {  # <toon-output> <key>
   printf '%s\n' "$1" | sed -n "s/^[[:space:]]*$2:[[:space:]]*\(.*\)/\1/p" | head -1
 }
 
+fm_nm_sql_literal() {  # <value>
+  local value=${1-}
+  value=${value//\'/\'\'}
+  printf "'%s'" "$value"
+}
+
+# Resolve the private no-mistakes state database without changing it.
+# FM_NM_STATE_DB gives hermetic callers an explicit path.
+# Production uses the same NM_HOME location the no-mistakes CLI owns.
+fm_nm_state_db() {
+  local db=${FM_NM_STATE_DB:-}
+  if [ -z "$db" ]; then
+    db="${NM_HOME:-${HOME}/.no-mistakes}/state.sqlite"
+  fi
+  [ -f "$db" ] || return 1
+  printf '%s\n' "$db"
+}
+
+# Print the exact no-mistakes run id this worktree owns, or nothing when no matching run can be proved.
+# The CLI's bare `axi status` resolver is process-ambient and may name another concurrent branch, so it is never an attribution source.
+# The durable registry includes ids, branch, repo, head, status, and creation order; active rows win over terminal siblings, then newest starts win.
+# The caller must read the returned id with `axi status --run <id>`.
+fm_nm_run_id_for_worktree() {  # <worktree> <branch>
+  local wt=$1 branch=$2 db upstream query rows id run_head _status
+  [ -d "$wt" ] && [ -n "$branch" ] || return 0
+  command -v sqlite3 >/dev/null 2>&1 || return 0
+  db=$(fm_nm_state_db) || return 0
+  upstream=$(git -C "$wt" config --get remote.origin.url 2>/dev/null || true)
+  [ -n "$upstream" ] || return 0
+  query="SELECT r.id, r.head_sha, r.status
+FROM runs r
+JOIN repos p ON p.id = r.repo_id
+WHERE r.branch = $(fm_nm_sql_literal "$branch")
+  AND p.upstream_url = $(fm_nm_sql_literal "$upstream")
+ORDER BY CASE WHEN r.status IN ('pending', 'running', 'fixing', 'awaiting_approval', 'fix_review', 'ci') THEN 0 ELSE 1 END,
+         r.created_at DESC;"
+  rows=$(sqlite3 -noheader -separator $'\t' "$db" "$query" 2>/dev/null) || return 0
+  while IFS=$'\t' read -r id run_head _status; do
+    case "$id" in ''|*[!A-Za-z0-9._-]*) continue ;; esac
+    fm_nm_head_matches_worktree "$wt" "$run_head" || continue
+    printf '%s\n' "$id"
+    return 0
+  done <<< "$rows"
+  return 0
+}
+
 # 0 if run head $2 matches worktree $1's code identity, per the same rule
 # everywhere this attribution is needed:
 #   - missing/empty head: cannot bind; reject

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2301,6 +2301,20 @@ exclude_path() {
   mkdir -p "$(dirname "$EXCL")"
   grep -qxF "$rel" "$EXCL" 2>/dev/null || echo "$rel" >> "$EXCL"
 }
+clear_recycled_worktree_harness_wiring() {  # <worktree>
+  local wt=$1 path
+  # A pooled worktree can outlive its previous task.
+  # These exact paths are Firstmate-owned bindings, so a new occupant must never inherit their task id even when it uses a harness with no replacement hook of its own.
+  for path in \
+    "$wt/.claude/settings.local.json" \
+    "$wt/.opencode/plugins/fm-turn-end.js" \
+    "$wt/.opencode/plugins/fm-busy-state.js" \
+    "$wt/.fm-grok-turnend" \
+    "$wt/.fm-kimi-turnend"; do
+    rm -f "$path" || return 1
+    [ ! -e "$path" ] && [ ! -L "$path" ] || return 1
+  done
+}
 if [ "$RELAUNCH" -eq 1 ]; then
   # Retire the previous incarnation's per-task harness wiring before arming the
   # new one. Without this, a harness switch would leave the old adapter's hook
@@ -2315,6 +2329,11 @@ if [ "$RELAUNCH" -eq 1 ]; then
   RELAUNCH_REPLACEMENT_HARNESS=$HARNESS
   RELAUNCH_REPLACEMENT_STATE=$STATE_REAL
   RELAUNCH_REPLACEMENT_WT=$WT
+else
+  clear_recycled_worktree_harness_wiring "$WT" || {
+    echo "error: could not clear retired harness wiring from recycled worktree $WT" >&2
+    exit 1
+  }
 fi
 if [ "$KIND" != secondmate ]; then
   # Arm the semantic busy-state contract (bin/fm-busy-lib.sh) for every

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2301,16 +2301,55 @@ exclude_path() {
   mkdir -p "$(dirname "$EXCL")"
   grep -qxF "$rel" "$EXCL" 2>/dev/null || echo "$rel" >> "$EXCL"
 }
-clear_recycled_worktree_harness_wiring() {  # <worktree>
-  local wt=$1 path
-  # A pooled worktree can outlive its previous task.
-  # These exact paths are Firstmate-owned bindings, so a new occupant must never inherit their task id even when it uses a harness with no replacement hook of its own.
+# 0 when file $1 is Firstmate-generated task wiring rather than someone else's
+# file that happens to sit at one of the paths Firstmate writes. Provenance is
+# read from the content Firstmate itself puts there: every armed hook body
+# invokes bin/fm-busy-event.sh or touches a turn-end token under this state
+# dir, and the two turn-end pointers are a single `token=<file>` line naming an
+# entry in Firstmate's private registry. Anything else is not attributable.
+recycled_wiring_is_firstmate_authored() {  # <file> <state-dir>
+  local file=$1 state=$2
+  case "${file##*/}" in
+    .fm-grok-turnend|.fm-kimi-turnend)
+      if grep -qE '^token=[A-Za-z0-9._-]+$' "$file" 2>/dev/null; then return 0; fi
+      return 1
+      ;;
+  esac
+  if grep -qF 'fm-busy-event.sh' "$file" 2>/dev/null; then return 0; fi
+  if [ -n "$state" ] && grep -qF "$state/" "$file" 2>/dev/null; then return 0; fi
+  return 1
+}
+
+clear_recycled_worktree_harness_wiring() {  # <worktree> <state-dir>
+  local wt=$1 state=$2 path rel
+  # A pooled worktree can outlive its previous task, so a new occupant must
+  # never inherit the retired task id even when it uses a harness with no
+  # replacement hook of its own.
+  # Retirement is scoped to wiring Firstmate itself wrote and can still prove
+  # it wrote: an untracked regular file at one of these paths whose content
+  # carries Firstmate's own binding. A repo-tracked file, a directory, a
+  # symlink, or an unattributable file is someone else's - it is left in place
+  # and reported, never deleted, and never aborts the spawn.
   for path in \
     "$wt/.claude/settings.local.json" \
     "$wt/.opencode/plugins/fm-turn-end.js" \
     "$wt/.opencode/plugins/fm-busy-state.js" \
     "$wt/.fm-grok-turnend" \
     "$wt/.fm-kimi-turnend"; do
+    [ -e "$path" ] || [ -L "$path" ] || continue
+    rel=${path#"$wt/"}
+    if [ -L "$path" ] || [ ! -f "$path" ]; then
+      echo "warning: leaving $rel in $wt: not a regular file, so firstmate provenance cannot be established" >&2
+      continue
+    fi
+    if git -C "$wt" ls-files --error-unmatch -- "$rel" >/dev/null 2>&1; then
+      echo "warning: leaving repo-tracked $rel in $wt: firstmate did not write it" >&2
+      continue
+    fi
+    if ! recycled_wiring_is_firstmate_authored "$path" "$state"; then
+      echo "warning: leaving $rel in $wt: not firstmate-generated task wiring" >&2
+      continue
+    fi
     rm -f "$path" || return 1
     [ ! -e "$path" ] && [ ! -L "$path" ] || return 1
   done
@@ -2329,8 +2368,12 @@ if [ "$RELAUNCH" -eq 1 ]; then
   RELAUNCH_REPLACEMENT_HARNESS=$HARNESS
   RELAUNCH_REPLACEMENT_STATE=$STATE_REAL
   RELAUNCH_REPLACEMENT_WT=$WT
-else
-  clear_recycled_worktree_harness_wiring "$WT" || {
+elif [ "$KIND" != secondmate ]; then
+  # Only a pooled crew worktree can carry another task's wiring. A secondmate
+  # runs in its own persistent firstmate home (WT is PROJ_ABS above), which is
+  # never recycled and never armed below, so its files are not Firstmate's to
+  # retire - the same exclusion fm-teardown.sh applies.
+  clear_recycled_worktree_harness_wiring "$WT" "$STATE_REAL" || {
     echo "error: could not clear retired harness wiring from recycled worktree $WT" >&2
     exit 1
   }

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1438,21 +1438,19 @@ validate_worktree_teardown_safety() {
   fi
 }
 
-# Fix 1 (see script header): does the active-or-most-recent no-mistakes run in
-# worktree $1 belong to THIS task, and is it parked at a gate awaiting an agent
-# that is about to be removed? Prints nothing; returns 0 only on a genuine
-# match so the caller knows it is safe to abort - never a guess.
+# Fix 1 (see script header): resolve THIS task's no-mistakes run id from the branch-bound registry, then read only that id before deciding whether its gate must be aborted.
+# Prints nothing; returns 0 only on a genuine match so the caller knows it is safe to abort - never a guess.
 NM_TEARDOWN_TIMEOUT=${FM_TEARDOWN_NM_TIMEOUT:-10}
 case "$NM_TEARDOWN_TIMEOUT" in ''|*[!0-9]*) NM_TEARDOWN_TIMEOUT=10 ;; esac
 TASK_RUN_ID=
-task_status_is_own_parked_run() {  # <worktree> <axi-status-output>
-  local wt=$1 out=$2 branch run_id run_branch run_head status outcome awaiting has_gate
+task_status_is_own_parked_run() {  # <worktree> <axi-status-output> <expected-run-id>
+  local wt=$1 out=$2 expected_run_id=$3 branch run_id run_branch run_head status outcome awaiting has_gate
   TASK_RUN_ID=
   branch=$(git -C "$wt" symbolic-ref --quiet --short HEAD 2>/dev/null) || return 1
   [ -n "$branch" ] || return 1
   [ -n "$out" ] || return 1
   run_id=$(fm_nm_strip_quotes "$(fm_nm_field "$out" id)")
-  [ -n "$run_id" ] || return 1
+  [ "$run_id" = "$expected_run_id" ] || return 1
   run_branch=$(fm_nm_strip_quotes "$(fm_nm_field "$out" branch)")
   [ -n "$run_branch" ] && [ "$run_branch" = "$branch" ] || return 1
   run_head=$(fm_nm_strip_quotes "$(fm_nm_field "$out" head)")
@@ -1473,11 +1471,14 @@ task_status_is_own_parked_run() {  # <worktree> <axi-status-output>
 }
 
 task_run_is_own_parked_run() {  # <worktree>
-  local wt=$1 out
+  local wt=$1 branch run_id out
   # Accepted best-effort residual: query failures stay fail-open because making
   # no-mistakes availability a prerequisite would block ship tasks with no run.
-  out=$(fm_nm_run "$wt" "$NM_TEARDOWN_TIMEOUT" axi status)
-  task_status_is_own_parked_run "$wt" "$out"
+  branch=$(git -C "$wt" symbolic-ref --quiet --short HEAD 2>/dev/null) || return 1
+  run_id=$(fm_nm_run_id_for_worktree "$wt" "$branch")
+  [ -n "$run_id" ] || return 1
+  out=$(fm_nm_run "$wt" "$NM_TEARDOWN_TIMEOUT" axi status --run "$run_id")
+  task_status_is_own_parked_run "$wt" "$out" "$run_id"
 }
 
 task_status_is_terminal_run() {  # <axi-status-output> <run-id>
@@ -2698,6 +2699,7 @@ elif [ -d "$WT" ] && [ "$KIND" != secondmate ]; then
   fi
   # Remove our hook file so a reused pool worktree cannot fire signals for a dead task.
   rm -f "$WT/.claude/settings.local.json" "$WT/.opencode/plugins/fm-turn-end.js" \
+    "$WT/.opencode/plugins/fm-busy-state.js" \
     "$WT/.fm-grok-turnend" "$WT/.fm-kimi-turnend"
   # Kills remaining processes in the worktree (including the agent), resets, returns
   # to pool. treehouse resolves the pool from the working directory, so run it from

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -1475,7 +1475,14 @@ task_run_is_own_parked_run() {  # <worktree>
   # Accepted best-effort residual: query failures stay fail-open because making
   # no-mistakes availability a prerequisite would block ship tasks with no run.
   branch=$(git -C "$wt" symbolic-ref --quiet --short HEAD 2>/dev/null) || return 1
-  run_id=$(fm_nm_run_id_for_worktree "$wt" "$branch")
+  # Unavailability is reported, never silently folded into "no parked run":
+  # teardown still fails open, but the operator sees which durable source was
+  # missing when the run it could not prove is left running.
+  if ! fm_nm_run_id_for_worktree "$wt" "$branch"; then
+    echo "warning: cannot prove whether $wt owns a parked no-mistakes run: ${FM_NM_RUN_ID_UNAVAILABLE_REASON:-no durable source}" >&2
+    return 1
+  fi
+  run_id=$FM_NM_RUN_ID
   [ -n "$run_id" ] || return 1
   out=$(fm_nm_run "$wt" "$NM_TEARDOWN_TIMEOUT" axi status --run "$run_id")
   task_status_is_own_parked_run "$wt" "$out" "$run_id"

--- a/bin/fm-wake-drain.sh
+++ b/bin/fm-wake-drain.sh
@@ -83,6 +83,11 @@ acknowledge_inactive_outcomes() { # <mode> <newline-separated-fingerprints>
   done <<< "$fingerprints"
 }
 
+wake_ack_failed() {  # <reason>
+  printf 'WAKE_ACK_FAILED: %s\n' "$1" >&2
+  exit 1
+}
+
 # Print still-unread informational status lines (note: answers and pending-reply
 # resolutions) that the OPEN DECISIONS fold never carries. Uses the same
 # cursor-backed unread span as the annotation path, and runs on every drain -
@@ -282,26 +287,26 @@ fm_lock_acquire_wait "$FM_WAKE_QUEUE_LOCK"
 DRAIN_LOCK_HELD=true
 
 if [ -n "$ACK_THROUGH" ]; then
-  ACK_FINGERPRINTS=$(inactive_outcome_fingerprints "$ACK_THROUGH" 'inactive-outcome:') || exit 1
-  ACK_NOTICE_FINGERPRINTS=$(inactive_outcome_fingerprints "$ACK_THROUGH" 'inactive-reconcile:') || exit 1
-  fm_lock_release "$FM_WAKE_QUEUE_LOCK"
+  ACK_FINGERPRINTS=$(inactive_outcome_fingerprints "$ACK_THROUGH" 'inactive-outcome:') \
+    || wake_ack_failed "could not read inactive-outcome receipts"
+  ACK_NOTICE_FINGERPRINTS=$(inactive_outcome_fingerprints "$ACK_THROUGH" 'inactive-reconcile:') \
+    || wake_ack_failed "could not read inactive-reconcile receipts"
+  fm_lock_release "$FM_WAKE_QUEUE_LOCK" || wake_ack_failed "could not release the wake queue lock"
   DRAIN_LOCK_HELD=false
   if ! acknowledge_inactive_outcomes acknowledge "$ACK_FINGERPRINTS" \
     || ! acknowledge_inactive_outcomes acknowledge-notice "$ACK_NOTICE_FINGERPRINTS"; then
-    echo "wake drain: inactive outcome receipt could not be recorded safely" >&2
-    exit 1
+    wake_ack_failed "inactive outcome receipt could not be recorded safely"
   fi
-  fm_lock_acquire_wait "$FM_WAKE_QUEUE_LOCK"
+  fm_lock_acquire_wait "$FM_WAKE_QUEUE_LOCK" || wake_ack_failed "could not reacquire the wake queue lock"
   DRAIN_LOCK_HELD=true
-  DRAIN_TMP=$(mktemp "$STATE/.wake-queue.ack.XXXXXX") || exit 1
-  chmod 0600 "$DRAIN_TMP" || exit 1
+  DRAIN_TMP=$(mktemp "$STATE/.wake-queue.ack.XXXXXX") \
+    || wake_ack_failed "could not prepare acknowledged wake storage"
+  chmod 0600 "$DRAIN_TMP" || wake_ack_failed "could not secure acknowledged wake storage"
   awk -F '\t' -v cutoff="$ACK_THROUGH" '
     NF < 5 || $2 !~ /^[0-9]+$/ || $2 > cutoff { print }
-  ' "$FM_WAKE_QUEUE" > "$DRAIN_TMP" || exit 1
-  fm_wake_commit_secondmate_stall_receipts_through "$ACK_THROUGH" || {
-    echo "wake drain: secondmate stall receipt could not be recorded safely" >&2
-    exit 1
-  }
+  ' "$FM_WAKE_QUEUE" > "$DRAIN_TMP" || wake_ack_failed "could not stage acknowledged wake consumption"
+  fm_wake_commit_secondmate_stall_receipts_through "$ACK_THROUGH" \
+    || wake_ack_failed "secondmate stall receipt could not be recorded safely"
   if [ ! -s "$DRAIN_TMP" ]; then
     fm_recovery_marker_ack "$RECOVERY_MARKER" "$ACK_GENERATION"
     RECOVERY_ACK_STATUS=$?
@@ -309,24 +314,24 @@ if [ -n "$ACK_THROUGH" ]; then
       0) ;;
       3) RECOVERY_ACK_MOVED=true ;;
       *)
-        echo "wake drain: recovery episode could not be retired safely; re-run bin/fm-wake-drain.sh and use the new WAKE_ACK_REQUIRED command" >&2
-        exit 1
+        wake_ack_failed "recovery episode could not be retired safely; re-run bin/fm-wake-drain.sh and use the new WAKE_ACK_REQUIRED command"
         ;;
     esac
   else
-    fm_recovery_marker_snapshot "$RECOVERY_MARKER" || exit 1
+    fm_recovery_marker_snapshot "$RECOVERY_MARKER" \
+      || wake_ack_failed "could not read the recovery episode"
     RECOVERY_MARKER_TOKEN=$FM_RECOVERY_MARKER_TOKEN
     if [ "${RECOVERY_MARKER_TOKEN##*:}" != "$ACK_GENERATION" ]; then
       RECOVERY_ACK_MOVED=true
     fi
   fi
   if ! _fm_atomic_replace "$DRAIN_TMP" "$FM_WAKE_QUEUE"; then
-    echo "wake drain: acknowledged wakes could not be consumed safely" >&2
-    exit 1
+    wake_ack_failed "acknowledged wakes could not be consumed safely"
   fi
   DRAIN_TMP=
-  fm_lock_release "$FM_WAKE_QUEUE_LOCK"
+  fm_lock_release "$FM_WAKE_QUEUE_LOCK" || wake_ack_failed "could not release the acknowledged wake queue lock"
   DRAIN_LOCK_HELD=false
+  printf 'WAKE_ACKNOWLEDGED: through %s\n' "$ACK_THROUGH" >&2
   if [ "$RECOVERY_ACK_MOVED" = true ]; then
     printf 'wake drain: acknowledged wakes through %s, but a newer recovery episode is pending; re-run bin/fm-wake-drain.sh and use the new WAKE_ACK_REQUIRED command\n' \
       "$ACK_THROUGH" >&2

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -289,6 +289,7 @@ fm_lock_clean_known_files() {
   local lockdir=$1
   rm -f \
     "$lockdir/pid" \
+    "$lockdir/owner-frame" \
     "$lockdir/fm-home" \
     "$lockdir/pid-identity" \
     "$lockdir/role" \
@@ -296,15 +297,33 @@ fm_lock_clean_known_files() {
     2>/dev/null || true
 }
 
+fm_lock_current_frame() {
+  # Bash 3.2 lacks BASHPID, but BASH_SUBSHELL still distinguishes a child frame from its parent when they share the same shell pid.
+  FM_LOCK_CURRENT_PID=${BASHPID:-$$}
+  FM_LOCK_CURRENT_FRAME="${FM_LOCK_CURRENT_PID}:${BASH_SUBSHELL:-0}"
+}
+
+fm_lock_owned_by_current_frame() {
+  local lockdir=$1 pid frame
+  fm_lock_current_frame
+  pid=$(cat "$lockdir/pid" 2>/dev/null || true)
+  [ "$pid" = "$FM_LOCK_CURRENT_PID" ] || return 1
+  frame=$(cat "$lockdir/owner-frame" 2>/dev/null || true)
+  if [ -n "$frame" ]; then
+    [ "$frame" = "$FM_LOCK_CURRENT_FRAME" ]
+    return
+  fi
+  # A legacy owner record is safely distinguishable only where BASHPID exists.
+  [ -n "${BASHPID:-}" ]
+}
+
 fm_lock_set_role() {
-  local lockdir=$1 role=$2 current pid back
+  local lockdir=$1 role=$2 back
   case "$role" in
     autoarm|terminal-check) : ;;
     *) return 1 ;;
   esac
-  current=${BASHPID:-$$}
-  pid=$(cat "$lockdir/pid" 2>/dev/null || true)
-  [ "$pid" = "$current" ] || return 1
+  fm_lock_owned_by_current_frame "$lockdir" || return 1
   printf '%s\n' "$role" > "$lockdir/role" 2>/dev/null || return 1
   back=$(cat "$lockdir/role" 2>/dev/null || true)
   [ "$back" = "$role" ]
@@ -329,11 +348,14 @@ fm_lock_owner_dir() {
 }
 
 fm_lock_prepare_owner() {
-  local ownerdir=$1 mypid back
-  mypid=${BASHPID:-$$}
-  printf '%s\n' "$mypid" > "$ownerdir/pid" 2>/dev/null || return 1
+  local ownerdir=$1 back
+  fm_lock_current_frame
+  printf '%s\n' "$FM_LOCK_CURRENT_PID" > "$ownerdir/pid" 2>/dev/null || return 1
   back=$(cat "$ownerdir/pid" 2>/dev/null || true)
-  [ "$back" = "$mypid" ]
+  [ "$back" = "$FM_LOCK_CURRENT_PID" ] || return 1
+  printf '%s\n' "$FM_LOCK_CURRENT_FRAME" > "$ownerdir/owner-frame" 2>/dev/null || return 1
+  back=$(cat "$ownerdir/owner-frame" 2>/dev/null || true)
+  [ "$back" = "$FM_LOCK_CURRENT_FRAME" ]
 }
 
 fm_lock_link_owner() {
@@ -378,14 +400,8 @@ fm_lock_claim_blocked_by_steal() {
 }
 
 fm_lock_claim() {
-  local lockdir=$1 ownerdir=$2 allowed_steal_owner=${3:-} mypid back
-  mypid=${BASHPID:-$$}
-  if ! { printf '%s\n' "$mypid" > "$ownerdir/pid"; } 2>/dev/null; then
-    fm_lock_discard_owner "$ownerdir"
-    return 1
-  fi
-  back=$(cat "$ownerdir/pid" 2>/dev/null || true)
-  if [ "$back" != "$mypid" ]; then
+  local lockdir=$1 ownerdir=$2 allowed_steal_owner=${3:-}
+  if ! fm_lock_prepare_owner "$ownerdir"; then
     fm_lock_discard_owner "$ownerdir"
     return 1
   fi
@@ -792,10 +808,7 @@ fm_lock_try_acquire() {
     return 0
   fi
 
-  # Compare against ${BASHPID:-$$} inline, never via a command substitution:
-  # $() forks a subshell whose BASHPID is not this frame's pid.
-  pid=$(cat "$lockdir/pid" 2>/dev/null || true)
-  if [ -n "$pid" ] && [ "$pid" = "${BASHPID:-$$}" ]; then
+  if fm_lock_owned_by_current_frame "$lockdir"; then
     # The recorded holder is THIS very process. Single-threaded bash can only
     # observe that when an interrupting trap abandoned the frame that held the
     # lock mid-critical-section (e.g. TERM inside a recovery-marker section,
@@ -811,6 +824,7 @@ fm_lock_try_acquire() {
     FM_LOCK_HELD_PID=$(cat "$lockdir/pid" 2>/dev/null || true)
     return 1
   fi
+  pid=$(cat "$lockdir/pid" 2>/dev/null || true)
   if fm_pid_alive "$pid"; then
     FM_LOCK_HELD_PID=$pid
     return 1
@@ -860,12 +874,16 @@ fm_lock_try_acquire() {
     return 1
   fi
 
-  if [ "$lockdir" = "$STATE/.watch.lock" ] \
-    && ! _fm_recovery_marker_publish "$STATE/.watcher-down" downtime; then
-    fm_lock_release "$steal"
-    FM_LOCK_HELD_PID=$cur
-    FM_LOCK_OWNER_DIR=
-    return 1
+  if [ "$lockdir" = "$STATE/.watch.lock" ]; then
+    fm_recovery_marker_snapshot "$STATE/.watcher-down" || true
+    if [ "${FM_RECOVERY_MARKER_STATE:-absent}" != acked ] || [ -s "$FM_WAKE_QUEUE" ]; then
+      if ! _fm_recovery_marker_publish "$STATE/.watcher-down" downtime; then
+        fm_lock_release "$steal"
+        FM_LOCK_HELD_PID=$cur
+        FM_LOCK_OWNER_DIR=
+        return 1
+      fi
+    fi
   fi
   fm_lock_remove_path "$lockdir" || true
   rc=1
@@ -891,20 +909,16 @@ fm_lock_acquire_wait() {
 }
 
 fm_lock_release() {
-  local lockdir=$1 pid current ownerdir
-  current=${BASHPID:-$$}
+  local lockdir=$1 ownerdir
+  fm_lock_owned_by_current_frame "$lockdir" || return 0
   if [ -L "$lockdir" ]; then
     ownerdir=$(fm_lock_link_owner "$lockdir" 2>/dev/null || true)
     [ -n "$ownerdir" ] || return 0
-    pid=$(cat "$ownerdir/pid" 2>/dev/null || true)
-    [ "$pid" = "$current" ] || return 0
     fm_lock_points_to_owner "$lockdir" "$ownerdir" || return 0
     rm -f "$lockdir" 2>/dev/null || return 0
     fm_lock_discard_owner "$ownerdir"
     return 0
   fi
-  pid=$(cat "$lockdir/pid" 2>/dev/null || true)
-  [ "$pid" = "$current" ] || return 0
   fm_lock_clean_known_files "$lockdir"
   rmdir "$lockdir" 2>/dev/null || true
 }

--- a/bin/fm-watch-arm.sh
+++ b/bin/fm-watch-arm.sh
@@ -230,6 +230,17 @@ clear_stale_recorded_watcher_lock() {
   [ "$lock_home" = "$FM_HOME" ] || return 0
   [ "$lock_path" = "$WATCH" ] || return 0
   [ -n "$lock_identity" ] || return 0
+  fm_recovery_marker_snapshot "$STATE/.watcher-down" || return 1
+  case "$FM_RECOVERY_MARKER_TOKEN" in
+    acked:*)
+      # A dead or reused lock is not a new recovery episode.
+      # With no durable rows left to present, clearing it must not mint a fresh marker that replays an already-acknowledged handling turn.
+      if [ ! -s "$FM_WAKE_QUEUE" ]; then
+        fm_lock_remove_path "$WATCH_LOCK"
+        return $?
+      fi
+      ;;
+  esac
   fm_recovery_transition "$STATE/.watcher-down" clear-stale-lock "$WATCH_LOCK" downtime
 }
 

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -1036,9 +1036,6 @@ if ! fm_lock_try_acquire "$WATCH_LOCK"; then
   exit 0
 fi
 WATCHER_RECOVERY_PENDING=0
-if [ -n "${FM_LOCK_RECOVERED_PID:-}" ]; then
-  WATCHER_RECOVERY_PENDING=1
-fi
 if [ "${FM_WATCH_HANDLING_SUCCESSOR:-0}" != 1 ]; then
   if ! fm_recovery_marker_reopen_announced "$WATCHER_DOWNTIME_MARKER"; then
     echo "watcher: recovery state could not be reopened safely; retaining stale lock evidence" >&2

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -729,6 +729,84 @@ test_cancelled_run_never_outranks_live_lane_run() {
   pass "a cancelled run cannot outrank this lane's live run"
 }
 
+# --- attribution unavailability is reported, never guessed --------------------
+# The durable registry is the ONLY attribution source (the ambient resolver is
+# not one), so when it cannot be consulted there is no answer to give. Reading
+# that as "this crew has no run" is what let a genuinely parked ship crew report
+# pane/status-log state and let teardown remove it without aborting its run.
+
+# A crew whose run is genuinely parked, whose status log would otherwise be
+# believed, and whose registry cannot be reached.
+setup_unavailable_case() {  # <name> <id> <branch> -> echoes case dir
+  local name=$1 id=$2 branch=$3 d
+  d=$(new_case "$name")
+  make_repo_on_branch "$d/wt" "$branch"
+  make_fakebin "$d" >/dev/null
+  fm_write_meta "$d/state/$id.meta" "window=fm:fm-$id" "worktree=$d/wt" "kind=ship" "harness=claude"
+  printf 'working: refactoring the quota adapter\n' > "$d/state/$id.status"
+  # An idle pane and a believable status log: exactly the wrong answer this
+  # crew used to report while its run sat parked at a gate.
+  arm_idle_record "$d/state" "$id" >/dev/null
+  printf '%s\n' "$d"
+}
+
+test_missing_state_db_reports_unknown_naming_the_source() {
+  reset_fakes
+  local d out
+  d=$(setup_unavailable_case attribution-no-state-db feat-nodb fm/feat-nodb)
+  FM_FAKE_AXI_STATUS="$(run_parked fm/feat-nodb)"
+  export FM_FAKE_AXI_STATUS
+  out=$(PATH="$d/fakebin:$PATH" FM_NM_STATE_DB="$d/relocated/state.sqlite" \
+    FM_STATE_OVERRIDE="$d/state" "$CREW_STATE" feat-nodb)
+  assert_contains "$out" "state: unknown" \
+    "a relocated no-mistakes home must not read as a crew with no run"
+  assert_contains "$out" "source: run-step" "the unknown verdict must name the attribution step"
+  assert_contains "$out" "$d/relocated/state.sqlite" \
+    "the unknown verdict must name the concrete missing state database"
+  assert_not_contains "$out" "source: status-log" \
+    "an unreachable registry must not fall back to the status log as current state"
+  pass "a missing no-mistakes state database reports unknown and names the database"
+}
+
+test_missing_sqlite3_reports_unknown_naming_the_source() {
+  reset_fakes
+  local d toolbin nosqlite out
+  d=$(setup_unavailable_case attribution-no-sqlite3 feat-nosql fm/feat-nosql)
+  toolbin=$(make_no_timeout_toolbin "$d")
+  nosqlite="$d/nosqlite3bin"
+  mkdir -p "$nosqlite"
+  ln -s "$d/fakebin/no-mistakes" "$nosqlite/no-mistakes"
+  ln -s "$d/fakebin/tmux" "$nosqlite/tmux"
+  ln -s "$d/fakebin/herdr" "$nosqlite/herdr"
+  command -v sqlite3 >/dev/null 2>&1 && [ -x "$nosqlite/sqlite3" ] \
+    && fail "the no-sqlite3 PATH must not expose sqlite3"
+  FM_FAKE_AXI_STATUS="$(run_parked fm/feat-nosql)"
+  export FM_FAKE_AXI_STATUS
+  out=$(PATH="$nosqlite:$toolbin" FM_NM_STATE_DB="$d/no-mistakes-state.sqlite" \
+    FM_STATE_OVERRIDE="$d/state" "$CREW_STATE" feat-nosql)
+  assert_contains "$out" "state: unknown" \
+    "a host without sqlite3 must not read as a crew with no run"
+  assert_contains "$out" "sqlite3" "the unknown verdict must name sqlite3 as the missing source"
+  assert_not_contains "$out" "source: status-log" \
+    "an unreadable registry must not fall back to the status log as current state"
+  pass "a host without sqlite3 reports unknown and names sqlite3"
+}
+
+test_no_origin_url_reports_unknown_naming_the_source() {
+  reset_fakes
+  local d out
+  d=$(setup_unavailable_case attribution-no-origin feat-noorigin fm/feat-noorigin)
+  git -C "$d/wt" remote remove origin 2>/dev/null || true
+  FM_FAKE_AXI_STATUS="$(run_parked fm/feat-noorigin)"
+  export FM_FAKE_AXI_STATUS
+  out=$(run_crew_state "$d" feat-noorigin)
+  assert_contains "$out" "state: unknown" \
+    "a worktree with no origin remote must not read as a crew with no run"
+  assert_contains "$out" "remote.origin.url" \
+    "the unknown verdict must name the missing remote as the reason no repo row can be matched"
+  pass "a worktree with no origin remote reports unknown and names the missing remote"
+}
+
 # Regression for fm-axi-status-misattributes-concurrent-lanes: the ambient status response has lane B's real-looking run, while the registry binds lane A to a different id that must be read with `--run`.
 test_concurrent_lane_status_uses_this_lanes_bound_run_id() {
   reset_fakes
@@ -1149,7 +1227,7 @@ SH
   "$ROOT/bin/fm-busy-event.sh" apply "$d/state" feat-timeout busy --gen "$gen" \
     --source claude-hook --event user-prompt-submit
   start=$SECONDS
-  out=$(FM_FAKE_NM_CALLS="$calls_file" PATH="$d/fakebin:$toolbin" FM_STATE_OVERRIDE="$d/state" FM_CREW_STATE_NM_TIMEOUT=1 "$CREW_STATE" feat-timeout)
+  out=$(FM_FAKE_NM_CALLS="$calls_file" PATH="$d/fakebin:$toolbin" FM_NM_STATE_DB="$d/no-mistakes-state.sqlite" FM_STATE_OVERRIDE="$d/state" FM_CREW_STATE_NM_TIMEOUT=1 "$CREW_STATE" feat-timeout)
   elapsed=$((SECONDS - start))
   assert_contains "$out" "state: working" "timed-out no-mistakes falls back to pane"
   assert_contains "$out" "source: pane" "timed-out no-mistakes -> pane source"
@@ -1467,6 +1545,9 @@ test_terminal_passed
 test_terminal_failed
 test_concurrent_lane_status_uses_this_lanes_bound_run_id
 test_cancelled_run_never_outranks_live_lane_run
+test_missing_state_db_reports_unknown_naming_the_source
+test_missing_sqlite3_reports_unknown_naming_the_source
+test_no_origin_url_reports_unknown_naming_the_source
 test_cross_branch_attribution_via_bound_run_id
 test_cross_branch_attribution_prefers_live_bound_run
 test_bound_run_ci_log_prevents_stale_ready_status

--- a/tests/fm-crew-state.test.sh
+++ b/tests/fm-crew-state.test.sh
@@ -13,15 +13,15 @@
 #   (b) needs-decision/blocked log + resumed run = SUPERSEDED     -> run-step
 #   (c) genuine parked run + needs-decision log = NOT superseded  -> run-step
 #   (d) terminal run-step (passed/failed) is authoritative        -> run-step
-#   (e) cross-branch attribution: this branch's own run found via list lookup
+#   (e) concurrent branch attribution uses the lane-bound run id
 #   (f) no run + semantic busy                                    -> pane
 #   (g) no run + semantic idle falls to the status-log verb       -> status-log
 #   (h) dead pane: no run -> unknown/none; with a run -> run-step (not the shell)
 #   (i) kind=scout skips the run lookup                           -> pane/status-log
 #   (j) torn-down worktree / missing meta                         -> unknown/none
 #   (k) crew_is_provably_working end-to-end over the REAL helper (not a canned
-#       fake fm-crew-state.sh verdict): cross-branch attribution via the runs
-#       list -> absorbed; genuinely no run anywhere + idle pane -> surfaced.
+#       fake fm-crew-state.sh verdict): lane-bound attribution -> absorbed;
+#       genuinely no run anywhere + idle pane -> surfaced.
 #       This is the direct regression pair for the 2026-07-02 herdr incident,
 #       proving the watcher's own absorb-only-when-provably-working predicate
 #       benefits from the fix in both directions.
@@ -44,18 +44,17 @@ make_repo_on_branch() {  # <dir> <branch>
   git -C "$dir" init -q
   git -C "$dir" commit -q --allow-empty -m init
   git -C "$dir" checkout -q -b "$branch"
+  git -C "$dir" remote add origin https://example.invalid/fm-crew-state.git
   # Real worktree HEAD for run head-binding (fixtures read FM_FAKE_RUN_HEAD).
   FM_FAKE_RUN_HEAD=$(git -C "$dir" rev-parse HEAD)
-  export FM_FAKE_RUN_HEAD
+  printf -v FM_FAKE_NM_DB_ROWS '01RUN\t%s\trunning\n' "$FM_FAKE_RUN_HEAD"
+  export FM_FAKE_RUN_HEAD FM_FAKE_NM_DB_ROWS
 }
 
 # A fakebin with a fake `no-mistakes` (serves the env-driven run output) and a
 # fake `tmux` (serves a busy or idle pane). The fake no-mistakes mirrors the real
-# command surface the helper uses: `axi status`, `axi status --run <id>` (the
-# `axi` surface - no runs-listing subcommand exists under it, verified against
-# the real CLI), and the actual top-level run-listing command, `no-mistakes
-# runs --limit N`, which is plain text - no run id, no quoting - serving
-# FM_FAKE_RUNS_LIST verbatim.
+# command surface the helper uses: `axi status --run <id>` and the read-only
+# no-mistakes run registry used to bind the id to this lane.
 make_fakebin() {  # <dir> -> echoes fakebin path
   local dir=$1 fb="$1/fakebin"
   mkdir -p "$fb"
@@ -68,8 +67,17 @@ case "${1:-}" in
     case "${1:-}" in
       status)
         shift
-        if [ "${1:-}" = --run ]; then printf '%s\n' "${FM_FAKE_AXI_STATUS_RUN:-}"
-        else printf '%s\n' "${FM_FAKE_AXI_STATUS:-}"; fi ;;
+        if [ "${1:-}" = --run ]; then
+          run_id=${2:-}
+          [ -z "${FM_FAKE_NM_CALLS:-}" ] || printf 'axi status --run %s\n' "$run_id" >> "$FM_FAKE_NM_CALLS"
+          if [ -n "${FM_FAKE_NM_LIVE_RUN_ID:-}" ] && [ "$run_id" = "$FM_FAKE_NM_LIVE_RUN_ID" ]; then
+            printf '%s\n' "${FM_FAKE_AXI_STATUS_LIVE:-}"
+          else
+            printf '%s\n' "${FM_FAKE_AXI_STATUS_RUN:-${FM_FAKE_AXI_STATUS:-}}"
+          fi
+        else
+          printf '%s\n' "${FM_FAKE_AXI_STATUS:-}"
+        fi ;;
       logs)
         printf '%s\n' "${FM_FAKE_CI_LOGS:-}" ;;
     esac
@@ -78,6 +86,11 @@ case "${1:-}" in
     printf '%s\n' "${FM_FAKE_RUNS_LIST:-}" ;;
 esac
 exit 0
+SH
+  cat > "$fb/sqlite3" <<'SH'
+#!/usr/bin/env bash
+set -u
+printf '%s\n' "${FM_FAKE_NM_DB_ROWS:-}"
 SH
   cat > "$fb/tmux" <<'SH'
 #!/usr/bin/env bash
@@ -122,7 +135,7 @@ case "${1:-}" in
 esac
 exit 0
 SH
-  chmod +x "$fb/no-mistakes" "$fb/tmux" "$fb/herdr"
+  chmod +x "$fb/no-mistakes" "$fb/sqlite3" "$fb/tmux" "$fb/herdr"
   printf '%s\n' "$fb"
 }
 
@@ -140,12 +153,14 @@ make_no_timeout_toolbin() {  # <dir> -> echoes toolbin path
 # Run the helper for one case dir. FM_FAKE_* env (run output, busy flag) are read
 # from the caller's environment by the fakes above.
 run_crew_state() {  # <case-dir> <id>
-  PATH="$1/fakebin:$PATH" FM_STATE_OVERRIDE="$1/state" "$CREW_STATE" "$2"
+  PATH="$1/fakebin:$PATH" FM_NM_STATE_DB="$1/no-mistakes-state.sqlite" \
+    FM_STATE_OVERRIDE="$1/state" "$CREW_STATE" "$2"
 }
 
 new_case() {  # <name> -> echoes case dir with an empty state/
   local d="$TMP_ROOT/$1"
   mkdir -p "$d/state"
+  : > "$d/no-mistakes-state.sqlite"
   printf '%s\n' "$d"
 }
 
@@ -162,6 +177,9 @@ arm_idle_record() {  # <state-dir> <id>
 reset_fakes() {
   FM_FAKE_AXI_STATUS=""
   FM_FAKE_AXI_STATUS_RUN=""
+  FM_FAKE_AXI_STATUS_LIVE=""
+  FM_FAKE_NM_LIVE_RUN_ID=""
+  FM_FAKE_NM_CALLS=""
   FM_FAKE_RUNS_LIST=""
   FM_FAKE_BUSY=0
   FM_FAKE_BUSY_TEXT=
@@ -170,7 +188,8 @@ reset_fakes() {
   FM_FAKE_HERDR_MISSING=0
   FM_FAKE_HERDR_AGENT_STATUS=""
   FM_FAKE_CI_LOGS=""
-  export FM_FAKE_AXI_STATUS FM_FAKE_AXI_STATUS_RUN FM_FAKE_RUNS_LIST FM_FAKE_BUSY FM_FAKE_BUSY_TEXT FM_FAKE_TMUX_MISSING
+  export FM_FAKE_AXI_STATUS FM_FAKE_AXI_STATUS_RUN FM_FAKE_AXI_STATUS_LIVE FM_FAKE_NM_LIVE_RUN_ID FM_FAKE_NM_CALLS
+  export FM_FAKE_RUNS_LIST FM_FAKE_BUSY FM_FAKE_BUSY_TEXT FM_FAKE_TMUX_MISSING
   export FM_FAKE_HERDR_BUSY FM_FAKE_HERDR_MISSING FM_FAKE_HERDR_AGENT_STATUS FM_FAKE_CI_LOGS
 }
 
@@ -684,83 +703,107 @@ test_terminal_failed() {
   pass "terminal failed run is authoritative"
 }
 
-# (e) cross-branch attribution: `axi status` returns ANOTHER branch's run (the
-# routine case once more than one crew validates the same underlying repo
-# concurrently - they share ONE no-mistakes repo registration), so the helper
-# falls back to the real top-level `no-mistakes runs` listing to learn whether
-# THIS branch has an active run of its own. Regression coverage for the
-# 2026-07-02 herdr incident: the old fallback shelled out to `no-mistakes axi`
-# (bare) expecting a `runs[N]{...}:` TOON table that the real CLI never emits
-# (verified against the installed v1.32.2 - the `axi` surface has no
-# runs-listing subcommand at all), so attribution silently failed every time
-# the repo-wide answer was not this crew's own branch.
-test_cross_branch_attribution_via_runs_list() {
+run_with_id() {  # <run-id> <run-fixture>
+  local run_id=$1 fixture=$2
+  printf '%s\n' "$fixture" | sed "s/id: \"01RUN\"/id: \"$run_id\"/"
+}
+
+# Regression for fm-crew-state-stale-run-match: a later cancelled run on this branch used to win because bare `axi status` returned it, even though the registry still had this lane's older live run at the same code identity.
+test_cancelled_run_never_outranks_live_lane_run() {
   reset_fakes
-  local d short; d=$(new_case crossbranch)
+  local d head out
+  d=$(new_case cancelled-before-live)
+  make_repo_on_branch "$d/wt" fm/feat-live
+  make_fakebin "$d" >/dev/null
+  head=$FM_FAKE_RUN_HEAD
+  fm_write_meta "$d/state/feat-live.meta" "window=fm:fm-feat-live" "worktree=$d/wt" "kind=ship"
+  FM_FAKE_NM_DB_ROWS=$(printf '01LIVE\t%s\trunning\n01CANCEL\t%s\tcancelled\n' "$head" "$head")
+  FM_FAKE_AXI_STATUS="$(run_with_id 01CANCEL "$(run_failed fm/feat-live)" | sed 's/outcome: failed/outcome: cancelled/')"
+  FM_FAKE_NM_LIVE_RUN_ID=01LIVE
+  FM_FAKE_AXI_STATUS_LIVE="$(run_with_id 01LIVE "$(run_running fm/feat-live)")"
+  export FM_FAKE_NM_DB_ROWS FM_FAKE_AXI_STATUS FM_FAKE_NM_LIVE_RUN_ID FM_FAKE_AXI_STATUS_LIVE
+  out=$(run_crew_state "$d" feat-live)
+  assert_contains "$out" "state: working" "a live run must outrank a cancelled sibling"
+  assert_contains "$out" "source: run-step" "the live run must remain authoritative"
+  assert_not_contains "$out" "state: failed" "a cancelled sibling must not fail a healthy lane"
+  pass "a cancelled run cannot outrank this lane's live run"
+}
+
+# Regression for fm-axi-status-misattributes-concurrent-lanes: the ambient status response has lane B's real-looking run, while the registry binds lane A to a different id that must be read with `--run`.
+test_concurrent_lane_status_uses_this_lanes_bound_run_id() {
+  reset_fakes
+  local d head out
+  d=$(new_case concurrent-lane-binding)
+  make_repo_on_branch "$d/wt" fm/lane-a
+  make_fakebin "$d" >/dev/null
+  head=$FM_FAKE_RUN_HEAD
+  fm_write_meta "$d/state/lane-a.meta" "window=fm:fm-lane-a" "worktree=$d/wt" "kind=ship"
+  printf 'done: stale lane A status event\n' > "$d/state/lane-a.status"
+  FM_FAKE_NM_DB_ROWS=$(printf '01LANEA\t%s\trunning\n' "$head")
+  FM_FAKE_AXI_STATUS="$(run_with_id 01LANEB "$(run_running fm/lane-b)")"
+  FM_FAKE_AXI_STATUS_RUN="$(run_with_id 01LANEA "$(run_parked fm/lane-a)")"
+  FM_FAKE_NM_CALLS="$d/no-mistakes.calls"
+  export FM_FAKE_NM_DB_ROWS FM_FAKE_AXI_STATUS FM_FAKE_AXI_STATUS_RUN FM_FAKE_NM_CALLS
+  out=$(run_crew_state "$d" lane-a)
+  assert_contains "$out" "state: parked" "lane A must read its own parked run, not lane B's ambient run"
+  assert_contains "$out" "parked at review" "lane A's gate detail must survive concurrent lane activity"
+  assert_grep 'axi status --run 01LANEA' "$FM_FAKE_NM_CALLS" \
+    "lane A must query the registry-bound run id explicitly"
+  pass "concurrent lane status reads use the lane-bound run id"
+}
+
+# (e) cross-branch attribution: `axi status` can return ANOTHER branch's run
+# once more than one crew validates the shared repository. The registry binds
+# this worktree to its own id before the detailed status read.
+test_cross_branch_attribution_via_bound_run_id() {
+  reset_fakes
+  local d; d=$(new_case crossbranch)
   make_repo_on_branch "$d/wt" fm/feat-f
-  short=$(git -C "$d/wt" rev-parse --short=7 HEAD)
   make_fakebin "$d" >/dev/null
   fm_write_meta "$d/state/feat-f.meta" "window=fm:fm-feat-f" "worktree=$d/wt" "kind=ship"
   # The repo-wide active/most-recent run belongs to a different crew's branch.
   FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)"
-  # Real `no-mistakes runs` shape: plain text, newest-first, no run id, no
-  # quoting - "<status> <branch> <short-sha> <date> [<pr-url>]".
-  FM_FAKE_RUNS_LIST="$(cat <<EOF
-  running    fm/other-crew aaaaaaa  2026-07-02 22:10
-  running    fm/feat-f ${short}  2026-07-02 22:05
-EOF
-)"
+  FM_FAKE_AXI_STATUS_RUN="$(run_running fm/feat-f)"
   local out; out=$(run_crew_state "$d" feat-f)
-  assert_contains "$out" "state: working" "this branch's own run attributed via the runs list"
-  assert_contains "$out" "source: run-step" "runs-list-resolved run -> run-step source"
-  pass "cross-branch run is attributed via the real runs list"
+  assert_contains "$out" "state: working" "this branch's own bound run is attributed"
+  assert_contains "$out" "source: run-step" "bound run -> run-step source"
+  pass "cross-branch run is attributed through its bound id"
 }
 
-# The runs list is newest-first; a branch with an OLDER completed run must not
-# shadow its own newer active one - the first (topmost) matching row wins.
-test_cross_branch_attribution_picks_most_recent_row() {
+# The registry's active-row ordering means an older completed sibling cannot
+# shadow this branch's bound live run.
+test_cross_branch_attribution_prefers_live_bound_run() {
   reset_fakes
-  local d short; d=$(new_case crossbranch-mostrecent)
+  local d; d=$(new_case crossbranch-mostrecent)
   make_repo_on_branch "$d/wt" fm/feat-fq
-  short=$(git -C "$d/wt" rev-parse --short=7 HEAD)
   make_fakebin "$d" >/dev/null
   fm_write_meta "$d/state/feat-fq.meta" "window=fm:fm-feat-fq" "worktree=$d/wt" "kind=ship"
   FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)"
-  FM_FAKE_RUNS_LIST="$(cat <<EOF
-  running    fm/other-crew aaaaaaa  2026-07-02 22:10
-  running    fm/feat-fq ${short}  2026-07-02 21:50
-  completed  fm/feat-fq bbbbbbb  2026-07-02 20:00  https://github.com/o/r/pull/1
-EOF
-)"
+  FM_FAKE_AXI_STATUS_RUN="$(run_running fm/feat-fq)"
   local out; out=$(run_crew_state "$d" feat-fq)
-  assert_contains "$out" "state: working" "most recent (running) row wins over an older completed row"
-  assert_contains "$out" "source: run-step" "most-recent-row resolution -> run-step source"
-  pass "cross-branch attribution picks the branch's most recent row"
+  assert_contains "$out" "state: working" "bound running row wins over an older completed row"
+  assert_contains "$out" "source: run-step" "bound-run resolution -> run-step source"
+  pass "cross-branch attribution prefers this branch's live bound run"
 }
 
-test_coarse_run_does_not_probe_other_branch_ci_log_for_ready_status() {
+test_bound_run_ci_log_prevents_stale_ready_status() {
   reset_fakes
-  local d short; d=$(new_case coarse-ready-other-log)
+  local d; d=$(new_case bound-ci-other-log)
   make_repo_on_branch "$d/wt" fm/feat-coarseready
-  short=$(git -C "$d/wt" rev-parse --short=7 HEAD)
   make_fakebin "$d" >/dev/null
   fm_write_meta "$d/state/feat-coarseready.meta" "window=fm:fm-feat-coarseready" "worktree=$d/wt" "kind=ship"
   printf 'done: PR https://github.com/o/r/pull/4 checks green\n' > "$d/state/feat-coarseready.status"
   FM_FAKE_AXI_STATUS="$(run_ci_monitoring fm/other-crew)"
-  FM_FAKE_RUNS_LIST="$(cat <<EOF
-  running    fm/other-crew aaaaaaa  2026-07-02 22:10
-  running    fm/feat-coarseready ${short}  2026-07-02 22:05
-EOF
-)"
+  FM_FAKE_AXI_STATUS_RUN="$(run_ci_monitoring fm/feat-coarseready)"
   FM_FAKE_CI_LOGS="CI checks running, waiting for results..."
   local out; out=$(run_crew_state "$d" feat-coarseready)
-  assert_contains "$out" "state: done" "coarse ready status -> done"
-  assert_contains "$out" "source: status-log" "coarse ready status remains status-log sourced"
-  assert_not_contains "$out" "state: working" "coarse ready status must not be suppressed by another branch log"
-  pass "coarse run does not probe another branch's ci log"
+  assert_contains "$out" "state: working" "this lane's non-ready CI run remains working"
+  assert_contains "$out" "source: run-step" "bound run detail remains authoritative"
+  assert_not_contains "$out" "state: done" "a stale ready status must not outrank this lane's CI log"
+  pass "bound run CI detail prevents a stale ready status from reading done"
 }
 
-# A different-branch run with NO matching runs-list row must NOT be
+# A different-branch run with no matching registry row must NOT be
 # misattributed, and must not be treated as a false "working" verdict either.
 test_other_branch_run_ignored() {
   reset_fakes
@@ -881,8 +924,8 @@ test_no_run_herdr_idle_agent_status_outranked_by_record() {
   make_fakebin "$d" >/dev/null
   fm_write_meta "$d/state/feat-herdr-idle.meta" "window=default:w1:p3" "worktree=$d/wt" "kind=ship" \
     "backend=herdr" "harness=claude"
-  # No run attributable (mirrors a no-mistakes run-step lookup that found no
-  # matching row within the configured runs-list window): the crew's semantic
+  # No run attributable (mirrors a no-mistakes run-identity lookup that found
+  # no matching registry row): the crew's semantic
   # busy state is the only remaining signal.
   FM_FAKE_AXI_STATUS=""
   FM_FAKE_RUNS_LIST=""
@@ -1263,27 +1306,21 @@ test_missing_meta() {
 
 # (k) crew_is_provably_working end-to-end over the REAL fm-crew-state.sh (not a
 # canned fake verdict, unlike tests/fm-watch-triage.test.sh's classifier
-# coverage). This is the direct regression pair for the 2026-07-02 herdr
-# incident: a validating crew whose bare `axi status` answer belongs to
-# another branch must still be absorbed by the watcher via the runs-list
-# fallback (working), while a crew with genuinely no run anywhere and an idle
-# pane must still surface (the safety property the fix must never widen away).
-test_provably_working_via_runs_list_fallback() {
+# coverage). A validating crew whose ambient status belongs to another branch
+# remains provably working through its bound id, while a crew with genuinely no
+# run anywhere and an idle pane must still surface.
+test_provably_working_via_bound_run_id() {
   reset_fakes
-  local d short; d=$(new_case provably-working-crossbranch)
+  local d; d=$(new_case provably-working-crossbranch)
   make_repo_on_branch "$d/wt" fm/feat-provable
-  short=$(git -C "$d/wt" rev-parse --short=7 HEAD)
   make_fakebin "$d" >/dev/null
   fm_write_meta "$d/state/feat-provable.meta" "window=fm:fm-feat-provable" "worktree=$d/wt" "kind=ship"
   FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)"
-  FM_FAKE_RUNS_LIST="$(cat <<EOF
-  running    fm/other-crew aaaaaaa  2026-07-02 22:10
-  running    fm/feat-provable ${short}  2026-07-02 22:05
-EOF
-)"
-  PATH="$d/fakebin:$PATH" FM_STATE_OVERRIDE="$d/state" crew_is_provably_working feat-provable \
-    || fail "cross-branch attribution via the runs list was not treated as provably working"
-  pass "crew_is_provably_working absorbs a validating crew found only via the runs-list fallback"
+  FM_FAKE_AXI_STATUS_RUN="$(run_running fm/feat-provable)"
+  PATH="$d/fakebin:$PATH" FM_NM_STATE_DB="$d/no-mistakes-state.sqlite" \
+    FM_STATE_OVERRIDE="$d/state" crew_is_provably_working feat-provable \
+    || fail "cross-branch bound attribution was not treated as provably working"
+  pass "crew_is_provably_working absorbs a validating crew through its bound run id"
 }
 
 test_not_provably_working_when_stopped() {
@@ -1292,16 +1329,16 @@ test_not_provably_working_when_stopped() {
   make_repo_on_branch "$d/wt" fm/feat-stopped
   make_fakebin "$d" >/dev/null
   fm_write_meta "$d/state/feat-stopped.meta" "window=fm:fm-feat-stopped" "worktree=$d/wt" "kind=ship"
-  # Repo-wide run belongs to someone else, and this branch has no row in the
-  # runs list either (it never validated, or genuinely finished/stopped) - the
-  # only remaining signal is the pane, which is idle.
+  # Repo-wide run belongs to someone else and this branch has no bound run, so
+  # the only remaining signal is the pane, which is idle.
   FM_FAKE_AXI_STATUS="$(run_running fm/other-crew)"
   FM_FAKE_RUNS_LIST="$(cat <<'EOF'
   running    fm/other-crew aaaaaaa  2026-07-02 22:10
 EOF
 )"
   FM_FAKE_BUSY=0
-  PATH="$d/fakebin:$PATH" FM_STATE_OVERRIDE="$d/state" crew_is_provably_working feat-stopped \
+  PATH="$d/fakebin:$PATH" FM_NM_STATE_DB="$d/no-mistakes-state.sqlite" \
+    FM_STATE_OVERRIDE="$d/state" crew_is_provably_working feat-stopped \
     && fail "a stopped crew with no run anywhere and an idle pane was treated as provably working"
   pass "crew_is_provably_working still surfaces a genuinely stopped crew (safety property preserved)"
 }
@@ -1428,9 +1465,11 @@ test_top_level_fixing_ci_running_after_green_stays_working
 test_top_level_fixing_done_log_stays_working
 test_terminal_passed
 test_terminal_failed
-test_cross_branch_attribution_via_runs_list
-test_cross_branch_attribution_picks_most_recent_row
-test_coarse_run_does_not_probe_other_branch_ci_log_for_ready_status
+test_concurrent_lane_status_uses_this_lanes_bound_run_id
+test_cancelled_run_never_outranks_live_lane_run
+test_cross_branch_attribution_via_bound_run_id
+test_cross_branch_attribution_prefers_live_bound_run
+test_bound_run_ci_log_prevents_stale_ready_status
 test_other_branch_run_ignored
 test_no_run_busy_pane
 test_no_run_footer_text_alone_is_not_working
@@ -1454,7 +1493,7 @@ test_remote_alive_idle_is_healthy_not_gone
 test_remote_unreachable_is_unknown_remote_not_dead
 test_remote_dead_reports_remote_verdict
 test_missing_meta
-test_provably_working_via_runs_list_fallback
+test_provably_working_via_bound_run_id
 test_not_provably_working_when_stopped
 test_usage_error
 test_historical_same_branch_rewritten_head_not_current

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -141,7 +141,27 @@ test_already_settled_pane_costs_one_confirm_sleep() {
   pass "an already-settled pane confirms via the existing inter-poll sleep, not an extra full cycle"
 }
 
+# Regression for fm-stale-hook-binding-on-worktree-reuse: treehouse can hand a worktree that was previously occupied by a Claude task to a Codex task.
+# The new task has no Claude hook of its own, so an inherited binding would still write lifecycle transitions under the retired task id.
+test_recycled_worktree_does_not_inherit_retired_hook_binding() {
+  local rec id out status stale_hook
+  id=recycled-hook-z3
+  rec=$(make_settle_case recycled-hook "$id" 0)
+  read_settle_record "$rec"
+  stale_hook="$WT_DIR/.claude/settings.local.json"
+  mkdir -p "${stale_hook%/*}"
+  printf '{"hooks":{"Stop":[{"hooks":[{"command":"busy --task retired-task"}]}]}}\n' > "$stale_hook"
+
+  out=$(run_settle_spawn "$id")
+  status=$?
+  expect_code 0 "$status" "spawn should replace a recycled worktree's retired wiring"
+  [ ! -e "$stale_hook" ] \
+    || fail "a recycled Codex worktree inherited the retired Claude hook binding"
+  pass "a recycled worktree does not inherit the previous task's hook binding"
+}
+
 test_single_stale_first_read_is_not_accepted
 test_already_settled_pane_costs_one_confirm_sleep
+test_recycled_worktree_does_not_inherit_retired_hook_binding
 
 echo "# all fm-spawn-worktree-settle tests passed"

--- a/tests/fm-spawn-worktree-settle.test.sh
+++ b/tests/fm-spawn-worktree-settle.test.sh
@@ -141,6 +141,18 @@ test_already_settled_pane_costs_one_confirm_sleep() {
   pass "an already-settled pane confirms via the existing inter-poll sleep, not an extra full cycle"
 }
 
+# A retired Claude binding exactly as fm-spawn writes it: the hook command
+# invokes bin/fm-busy-event.sh for the previous task id and touches that task's
+# turn-end token under the shared state dir.
+write_retired_claude_binding() {  # <worktree> <state-dir> <retired-id>
+  local wt=$1 state=$2 retired=$3 hook
+  hook="$wt/.claude/settings.local.json"
+  mkdir -p "${hook%/*}"
+  printf '{"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":"%s/bin/fm-busy-event.sh apply %s %s busy --gen g1 --source claude-hook --event user-prompt-submit"}]}],"Stop":[{"hooks":[{"type":"command","command":"touch %s/%s.turn-ended"}]}]}}\n' \
+    "$ROOT" "$state" "$retired" "$state" "$retired" > "$hook"
+  printf '%s\n' "$hook"
+}
+
 # Regression for fm-stale-hook-binding-on-worktree-reuse: treehouse can hand a worktree that was previously occupied by a Claude task to a Codex task.
 # The new task has no Claude hook of its own, so an inherited binding would still write lifecycle transitions under the retired task id.
 test_recycled_worktree_does_not_inherit_retired_hook_binding() {
@@ -148,9 +160,7 @@ test_recycled_worktree_does_not_inherit_retired_hook_binding() {
   id=recycled-hook-z3
   rec=$(make_settle_case recycled-hook "$id" 0)
   read_settle_record "$rec"
-  stale_hook="$WT_DIR/.claude/settings.local.json"
-  mkdir -p "${stale_hook%/*}"
-  printf '{"hooks":{"Stop":[{"hooks":[{"command":"busy --task retired-task"}]}]}}\n' > "$stale_hook"
+  stale_hook=$(write_retired_claude_binding "$WT_DIR" "$HOME_DIR/state" retired-task)
 
   out=$(run_settle_spawn "$id")
   status=$?
@@ -160,8 +170,110 @@ test_recycled_worktree_does_not_inherit_retired_hook_binding() {
   pass "a recycled worktree does not inherit the previous task's hook binding"
 }
 
+# Negative direction of the same cleanup: the paths Firstmate arms are ordinary
+# repo/user paths too. A file at one of them that Firstmate did not write - an
+# author's own Claude hook settings, or a repo-tracked OpenCode plugin - is not
+# retired wiring, so the spawn must leave it exactly as it found it and say so.
+test_spawn_leaves_files_it_did_not_write() {
+  local rec id out status authored_hook tracked_plugin authored_before tracked_before wt_git_dir
+  id=unowned-wiring-z4
+  rec=$(make_settle_case unowned-wiring "$id" 0)
+  read_settle_record "$rec"
+  authored_hook="$WT_DIR/.claude/settings.local.json"
+  mkdir -p "${authored_hook%/*}"
+  printf '{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"make lint"}]}]}}\n' > "$authored_hook"
+  authored_before=$(cat "$authored_hook")
+  # Untracked and locally excluded, exactly as a crew worktree carries it, so
+  # the pooled-worktree base refresh still sees a clean tree.
+  wt_git_dir=$(git -C "$WT_DIR" rev-parse --absolute-git-dir)
+  mkdir -p "$wt_git_dir/info"
+  printf '.claude/settings.local.json\n' >> "$wt_git_dir/info/exclude"
+  # The repo's own OpenCode plugin lives on the base branch the pooled worktree
+  # is refreshed to, so it is present and tracked when the spawn arms wiring.
+  tracked_plugin="$WT_DIR/.opencode/plugins/fm-turn-end.js"
+  mkdir -p "$PROJ_DIR/.opencode/plugins"
+  printf 'export const RepoOwned = async () => ({});\n' > "$PROJ_DIR/.opencode/plugins/fm-turn-end.js"
+  tracked_before=$(cat "$PROJ_DIR/.opencode/plugins/fm-turn-end.js")
+  git -C "$PROJ_DIR" add .opencode/plugins/fm-turn-end.js
+  git -C "$PROJ_DIR" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' \
+    commit -qm 'repo-owned opencode plugin'
+  git -C "$PROJ_DIR" push -q origin HEAD
+
+  out=$(run_settle_spawn "$id")
+  status=$?
+  expect_code 0 "$status" "an unattributable file must not abort the spawn"
+  [ -f "$authored_hook" ] || fail "spawn deleted a user-authored .claude/settings.local.json"
+  [ "$(cat "$authored_hook")" = "$authored_before" ] \
+    || fail "spawn rewrote a user-authored .claude/settings.local.json it did not arm"
+  [ -f "$tracked_plugin" ] || fail "spawn deleted a repo-tracked .opencode plugin"
+  [ "$(cat "$tracked_plugin")" = "$tracked_before" ] \
+    || fail "spawn rewrote a repo-tracked .opencode plugin"
+  [ -z "$(git -C "$WT_DIR" status --porcelain -- .opencode)" ] \
+    || fail "spawn left the repo-tracked plugin dirty before launch"
+  assert_contains "$out" "leaving .claude/settings.local.json" \
+    "spawn did not report the file whose provenance it could not establish"
+  assert_contains "$out" "leaving repo-tracked .opencode/plugins/fm-turn-end.js" \
+    "spawn did not report the repo-tracked plugin it left alone"
+  pass "spawn leaves and reports wiring paths it cannot prove firstmate wrote"
+}
+
+# make_secondmate_home <case-dir> <id> seeds a persistent secondmate home:
+# a marked, git-backed firstmate checkout that fm-spawn accepts as FIRSTMATE_HOME.
+make_secondmate_home() {  # <case-dir> <id>
+  local case_dir=$1 id=$2 home
+  home="$case_dir/secondmate-home"
+  mkdir -p "$home/state" "$home/config" "$home/data" "$home/projects" "$home/bin"
+  printf '%s\n' "$id" > "$home/.fm-secondmate-home"
+  printf '# Firstmate secondmate fixture\n' > "$home/AGENTS.md"
+  printf '#!/usr/bin/env bash\n' > "$home/bin/placeholder.sh"
+  git -C "$home" init -q
+  git -C "$home" add -A
+  git -C "$home" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' \
+    commit -qm 'seed secondmate home'
+  touch "$home/state/.last-watcher-beat"
+  printf '%s\n' "$home"
+}
+
+# A secondmate's worktree IS its persistent firstmate home, not a pooled
+# treehouse worktree: nothing else ever occupies it, and the spawn arms no
+# harness wiring in it. A respawn there must therefore not touch the home's own
+# files - the incident shape is an author's .claude/settings.local.json being
+# removed on every secondmate respawn.
+test_secondmate_respawn_keeps_authored_home_files() {
+  local rec id sm_home authored authored_before out status
+  id=secondmate-home-z5
+  rec=$(make_settle_case secondmate-home "$id" 0)
+  read_settle_record "$rec"
+  sm_home=$(make_secondmate_home "$(dirname "$HOME_DIR")" "$id")
+  authored="$sm_home/.claude/settings.local.json"
+  mkdir -p "${authored%/*}"
+  printf '{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"say done"}]}]}}\n' > "$authored"
+  authored_before=$(cat "$authored")
+  printf 'token=authored-by-hand\n' > "$sm_home/.fm-kimi-turnend"
+
+  out=$(FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
+    FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+    FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
+    FM_FAKE_PANE_PATH="$sm_home" FM_FAKE_PANE_STALE="$sm_home" \
+    FM_FAKE_PANE_STALE_READS=0 FM_FAKE_PANE_COUNTFILE="$COUNTFILE" \
+    PATH="$FAKEBIN_DIR:$PATH" \
+    "$SPAWN" "$id" "$sm_home" --secondmate 2>&1)
+  status=$?
+  expect_code 0 "$status" "secondmate spawn failed: $out"
+  [ -f "$authored" ] \
+    || fail "secondmate respawn deleted a user-authored file from the persistent home"
+  [ "$(cat "$authored")" = "$authored_before" ] \
+    || fail "secondmate respawn rewrote a user-authored file in the persistent home"
+  [ -f "$sm_home/.fm-kimi-turnend" ] \
+    || fail "secondmate respawn deleted a firstmate-shaped file from the persistent home it never arms"
+  pass "a secondmate respawn leaves its persistent home's own files alone"
+}
+
 test_single_stale_first_read_is_not_accepted
 test_already_settled_pane_costs_one_confirm_sleep
 test_recycled_worktree_does_not_inherit_retired_hook_binding
+test_spawn_leaves_files_it_did_not_write
+test_secondmate_respawn_keeps_authored_home_files
 
 echo "# all fm-spawn-worktree-settle tests passed"

--- a/tests/fm-teardown.test.sh
+++ b/tests/fm-teardown.test.sh
@@ -152,7 +152,12 @@ case "${1:-}" in
 esac
 exit 0
 SH
-  chmod +x "$fakebin/treehouse" "$fakebin/tmux" "$fakebin/gh-axi" "$fakebin/gh" "$fakebin/no-mistakes"
+  cat > "$fakebin/sqlite3" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "${FM_FAKE_NM_DB_ROWS:-}"
+SH
+  chmod +x "$fakebin/treehouse" "$fakebin/tmux" "$fakebin/gh-axi" "$fakebin/gh" "$fakebin/no-mistakes" "$fakebin/sqlite3"
+  : > "$case_dir/no-mistakes-state.sqlite"
 
   # Bare origin so the clone has an `origin` remote and origin/HEAD.
   git init -q --bare "$case_dir/origin.git"
@@ -541,10 +546,19 @@ SH
 
 # Run teardown with PATH mocking. Args: case_dir [extra args...]
 run_teardown() {
-  local case_dir=$1; shift
+  local case_dir=$1 branch head rows
+  shift
+  branch=$(git -C "$case_dir/wt" symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+  head=$(git -C "$case_dir/wt" rev-parse HEAD 2>/dev/null || true)
+  rows=${FM_FAKE_NM_DB_ROWS:-}
+  if [ -z "$rows" ] && [ -n "$branch" ] && [ -n "$head" ]; then
+    printf -v rows '01RUN\t%s\trunning\n' "$head"
+  fi
   FM_ROOT_OVERRIDE="$ROOT" \
   FM_STATE_OVERRIDE="$case_dir/state" \
   FM_CONFIG_OVERRIDE="$case_dir/config" \
+  FM_NM_STATE_DB="$case_dir/no-mistakes-state.sqlite" \
+  FM_FAKE_NM_DB_ROWS="$rows" \
   PATH="$case_dir/fakebin:${FM_TEARDOWN_TEST_PATH:-$PATH}" \
     "$TEARDOWN" task-x1 "$@"
 }

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -521,7 +521,7 @@ SH
 }
 
 test_enrichment_preserves_all_unread_lines_and_status_file_failures() {
-  local dir state out i raw_count expected
+  local dir state out i raw_count expected line huge_found
   dir=$(make_case complete-enrichment)
   state="$dir/state"
   out="$dir/drain.out"
@@ -548,7 +548,14 @@ test_enrichment_preserves_all_unread_lines_and_status_file_failures() {
   [ "$raw_count" -eq 13 ] || fail "missing, unreadable, malformed, empty, or oversized status input hid a raw row"
 
   expected="wake annotation: latest wake-EVENT observed at drain, not current state: huge.status: $(cat "$state/huge.status")"
-  grep -Fx "$expected" "$out" >/dev/null \
+  huge_found=0
+  while IFS= read -r line || [ -n "$line" ]; do
+    if [ "$line" = "$expected" ]; then
+      huge_found=1
+      break
+    fi
+  done < "$out"
+  [ "$huge_found" -eq 1 ] \
     || fail "the oversized unread status line was truncated or omitted"
   i=1
   while [ "$i" -le 8 ]; do
@@ -795,6 +802,45 @@ SH
   pass "wake drain: recovery acknowledgement failures are explicit and retryable"
 }
 
+# Regression for acknowledgement-must-not-fail-silently: a failed atomic consumption of handled queue rows used to leave only a generic diagnostic, which callers could confuse with a successful acknowledgement.
+# The command must emit its own unambiguous failure marker and a non-zero exit status.
+test_queue_ack_failure_is_never_reported_as_success() {
+  local dir state fakebin real_mv sequence generation rc
+  dir=$(make_case queue-ack-failure)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  real_mv=$(command -v mv) || fail "could not locate mv for queue acknowledgement fixture"
+  append_wake "$state" check queue-ack-failure 'check: queue acknowledgement failure' \
+    || fail "queue acknowledgement fixture could not append a wake"
+  FM_STATE_OVERRIDE="$state" "$DRAIN" > "$dir/initial.out" 2> "$dir/initial.err" \
+    || fail "queue acknowledgement fixture could not present its wake"
+  sequence=$(sed -n 's/^WAKE_ACK_REQUIRED:.*--ack-through \([0-9][0-9]*\) --recovery-generation [A-Za-z0-9._-][A-Za-z0-9._-]*$/\1/p' "$dir/initial.err")
+  generation=$(sed -n 's/^WAKE_ACK_REQUIRED:.*--ack-through [0-9][0-9]* --recovery-generation \([A-Za-z0-9._-][A-Za-z0-9._-]*\)$/\1/p' "$dir/initial.err")
+  [ -n "$sequence" ] && [ -n "$generation" ] \
+    || fail "queue acknowledgement fixture did not receive its acknowledgement boundary"
+  cat > "$fakebin/mv" <<'SH'
+#!/usr/bin/env bash
+last=${!#}
+if [ "$last" = "${FM_TEST_ACK_QUEUE:-}" ]; then
+  exit 1
+fi
+exec "$FM_TEST_REAL_MV" "$@"
+SH
+  chmod +x "$fakebin/mv"
+
+  rc=0
+  PATH="$fakebin:$PATH" FM_TEST_REAL_MV="$real_mv" FM_TEST_ACK_QUEUE="$state/.wake-queue" \
+    FM_STATE_OVERRIDE="$state" "$DRAIN" --ack-through "$sequence" --recovery-generation "$generation" \
+      > "$dir/ack.out" 2> "$dir/ack.err" || rc=$?
+  [ "$rc" -ne 0 ] || fail "a failed queue acknowledgement reported success"
+  grep -F 'WAKE_ACK_FAILED:' "$dir/ack.err" >/dev/null \
+    || fail "a failed queue acknowledgement omitted its own failure marker: $(cat "$dir/ack.err")"
+  ! grep -F 'WAKE_ACKNOWLEDGED:' "$dir/ack.out" "$dir/ack.err" >/dev/null \
+    || fail "a failed queue acknowledgement also claimed success"
+  [ -s "$state/.wake-queue" ] || fail "a failed queue acknowledgement consumed durable wakes"
+  pass "wake drain: a failed queue acknowledgement is explicit and non-successful"
+}
+
 test_interruption_before_and_after_raw_commit() {
   local dir state before_out after_out replay_out empty_out pid rc count i sequence generation
   dir=$(make_case interruption)
@@ -994,6 +1040,7 @@ test_historical_annotation_skips_announced_status() {
   pass "historical annotations replay nothing already announced and keep everything new"
 }
 
+test_queue_ack_failure_is_never_reported_as_success
 test_self_held_lock_reclaims_instead_of_deadlocking
 test_secondmate_foreign_queue_stall_is_one_shot_and_read_only
 test_secondmate_stall_marker_rejects_symlink

--- a/tests/fm-watch-arm.test.sh
+++ b/tests/fm-watch-arm.test.sh
@@ -601,6 +601,8 @@ test_restart_preserves_recovery_across_reused_pid_lock() {
   printf '%s\n' "$WATCH" > "$owner/watcher-path"
   printf '%s\n' 'reused-pid-does-not-match' > "$owner/pid-identity"
   ln -s "$owner" "$state/.watch.lock"
+  printf 'pending:downtime:fixture\n' > "$state/.watcher-down"
+  printf '1700000000\t1\tcheck\tstale-lock\tcheck: stale lock recovery\n' > "$state/.wake-queue"
 
   start_rearm_arm "$home" "$state" "$fakebin" "$armout"
   wait_for_exit "$ARM_PID" 80 || fail "restart did not surface recovery after clearing a reused-pid lock"
@@ -610,6 +612,46 @@ test_restart_preserves_recovery_across_reused_pid_lock() {
   kill "$unrelated" 2>/dev/null || true
   wait "$unrelated" 2>/dev/null || true
   pass "watch-arm: restart publishes recovery before clearing a reused-pid watcher lock"
+}
+
+# Regression for fm-watcher-churn-replays-queue: a stale watcher lock is only transport evidence.
+# When the durable recovery episode was already acknowledged, re-arming must resume supervision instead of manufacturing a new rearm-resurface wake and immediately exiting.
+test_rearm_does_not_replay_an_acknowledged_recovery_after_stale_lock() {
+  local dir home state fakebin armout owner unrelated
+  dir=$(make_case stale-lock-after-acknowledgement)
+  home="$dir/home"
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  armout="$dir/arm.out"
+  owner="$state/.watch.lock.owner.fixture"
+  mkdir -p "$home/data" "$owner"
+  sleep 300 &
+  unrelated=$!
+  printf '%s\n' "$unrelated" > "$owner/pid"
+  printf '%s\n' "$home" > "$owner/fm-home"
+  printf '%s\n' "$WATCH" > "$owner/watcher-path"
+  printf '%s\n' 'dead-watcher-lock' > "$owner/pid-identity"
+  printf 'acked:handling:fixture\n' > "$state/.watcher-down"
+  ln -s "$owner" "$state/.watch.lock"
+
+  start_rearm_arm "$home" "$state" "$fakebin" "$armout"
+  sleep 0.3
+  if ! is_live_non_zombie "$ARM_PID"; then
+    kill "$unrelated" 2>/dev/null || true
+    wait "$unrelated" 2>/dev/null || true
+    fail "an acknowledged recovery was replayed instead of returning to supervision: $(cat "$armout")"
+  fi
+  printf 'blocked: later real wake\n' > "$state/later.status"
+  wait_for_exit "$ARM_PID" 120 || fail "the recovered watcher did not supervise later work"
+  ! grep -F 'check: rearm-resurface' "$armout" >/dev/null \
+    || fail "re-arm resurfaced an already-acknowledged recovery: $(cat "$armout")"
+  grep -q '^signal:' "$armout" \
+    || fail "the re-armed watcher never reached ordinary supervision: $(cat "$armout")"
+  is_live_non_zombie "$unrelated" \
+    || fail "stale lock recovery signalled an unrelated process"
+  kill "$unrelated" 2>/dev/null || true
+  wait "$unrelated" 2>/dev/null || true
+  pass "watch-arm: stale lock recovery does not replay an acknowledged episode"
 }
 
 test_markerless_legacy_queue_is_recovered_on_arm() {
@@ -804,6 +846,7 @@ test_downtime_marker_does_not_follow_symlink() {
   pass "watch-arm: downtime marker publication does not follow symlinks"
 }
 
+test_rearm_does_not_replay_an_acknowledged_recovery_after_stale_lock
 test_attached_arm_reports_the_delivered_wake
 test_attached_arm_reports_the_delivered_wake_after_drain
 test_attached_arm_still_fails_on_a_wake_it_did_not_deliver


### PR DESCRIPTION
## Summary

This PR repairs the five bounded Firstmate supervision defects from the 2026-08-23/24 production incidents.

Defects 1 and 2 share the durable run-identity resolution root cause.

The repairs prevent cancelled runs from outranking live lane-owned runs, bind status reads to explicit lane runs, remove stale task-bound hook wiring on recycled worktrees, prevent watcher re-arm from replaying acknowledged records, and make acknowledgement failures explicit and nonzero.

Two Firstmate-ruled fixes are included.

Hook-cleanup narrowing now skips persistent secondmate homes and removes only positively attributable Firstmate-generated task wiring, with a negative preservation regression proving user-authored files survive.

Named-source attribution now distinguishes unavailable sqlite3, state-db, and upstream sources and emits an unknown verdict naming the missing source instead of guessing.

## Verification

An earlier check against this branch's stale base suggested that `bad home outcomes revived stale work or lacked provenance` was pre-existing. A re-check against current `origin/main` passed, disproving that conclusion; the failure is a regression in this PR and must be fixed here.

The phase8 child-endpoint regression passes on the base when isolated and passes on this branch after the durable-membership, bounded-freshness, and fallback-reason fixes.

The remaining four production regressions were genuine branch defects and are addressed: honest inner-timeout classification, durable endpoint membership, bounded freshness on emitted unknown rows, and removal of the unavailable-reason path that discarded the endpoint array.

The latest push is `27f8d6623`. Current PR checks show 2 passed, 1 failed, and 10 pending; the failed check is `PR must be raised via no-mistakes`, reflecting the earlier direct-PR delivery boundary. No merge was performed.

## Unified finding

Across the repaired surfaces, unresolvable state had been reported as a confident false answer instead of an honest unknown: cancelled/live run identity, concurrent-lane attribution, recycled hook ownership, watcher replay state, acknowledgement outcomes, and child-state timeout/source failures.

## Deferred endpoint classification

This PR does not close the endpoint-classification correction. The mixed-domain assertion `tests/fm-bearings-snapshot.test.sh:1718-1730` still demonstrates that an unresolved child endpoint can classify as absent rather than present-and-unknown. That correction is deferred to its own lane.
