### PR TITLE
feat(bin): list MemberOS GitHub PRs for the next bors rollup

### DIFF
--- a/bin/fm-pr-ready-bucket.sh
+++ b/bin/fm-pr-ready-bucket.sh
@@ -31,6 +31,9 @@
 # Default --base is main.
 # --repo or --base other than those defaults requires --required-check,
 # so a different forge target cannot silently keep the MemberOS main list.
+# A --repo other than Chamber-Hero/memberos also drops MemberOS merge
+# conventions: Bors queue detection, release-please omission, review-blocker,
+# and CHANGES_REQUESTED. Those stay on the MemberOS default target only.
 # Nested label, check, and comment connections are paged to completion.
 # A still-truncated connection after the page bound is never classified
 # ready (blocked: incomplete GitHub state).
@@ -140,8 +143,9 @@ GQL_COMMENTS_JQ='.data.repository.pullRequest.comments | {
   ) // "")
 }'
 
-# shellcheck disable=SC2016 # jq $base/$required/$k are jq variables.
+# shellcheck disable=SC2016 # jq $base/$required/$memberos/$k are jq variables.
 CLASSIFY_JQ='
+  def memberos_policy: $memberos == 1;
   def fail_conclusions: ["failure","timed_out","cancelled","action_required","stale","startup_failure","error"];
   def pass_conclusions: ["success","neutral"];
   def parse_checks:
@@ -158,21 +162,28 @@ CLASSIFY_JQ='
       else "pending"
       end;
   def is_release:
-    ((.author // "") | test("release-please"; "i"))
-    or ((.head // "") | test("^release-please"; "i"))
-    or ((.title // "") | test("^chore\\(.*\\): release"; "i"));
+    memberos_policy
+    and (
+      ((.author // "") | test("release-please"; "i"))
+      or ((.head // "") | test("^release-please"; "i"))
+      or ((.title // "") | test("^chore\\(.*\\): release"; "i"))
+    );
   def has_blocker_label:
-    ((.labels // "") | split(",") | map(gsub("^\\s+|\\s+$";"")) | map(ascii_downcase) | index("review-blocker")) != null;
+    memberos_policy
+    and ((.labels // "") | split(",") | map(gsub("^\\s+|\\s+$";"")) | map(ascii_downcase) | index("review-blocker")) != null;
   def in_bors:
-    (.bors_author == true)
-    or (
-      ((.bors_last // "") | test("has been approved|now in the \\[queue\\]|Trying:|:hourglass:|Rollup created"; "i"))
-      and ((.bors_last // "") | test("unapproved|not previously approved|unmergeable"; "i") | not)
+    memberos_policy
+    and (
+      (.bors_author == true)
+      or (
+        ((.bors_last // "") | test("has been approved|now in the \\[queue\\]|Trying:|:hourglass:|Rollup created"; "i"))
+        and ((.bors_last // "") | test("unapproved|not previously approved|unmergeable"; "i") | not)
+      )
     );
   def incomplete_state:
-    ((.labels_truncated == true) and (has_blocker_label | not))
+    (memberos_policy and (.labels_truncated == true) and (has_blocker_label | not))
     or (.checks_truncated == true)
-    or ((.comments_truncated == true) and ((.bors_last // "") == "") and (.bors_author != true));
+    or (memberos_policy and (.comments_truncated == true) and ((.bors_last // "") == "") and (.bors_author != true));
   def red_required($checks):
     [$required[] | select(req_status(.; $checks) == "red")];
   def pending_required($checks):
@@ -182,7 +193,7 @@ CLASSIFY_JQ='
     | [
         (if .mergeable == "CONFLICTING" then "conflicts" else empty end),
         (if has_blocker_label then "review-blocker" else empty end),
-        (if .review == "CHANGES_REQUESTED" then "CHANGES_REQUESTED" else empty end),
+        (if memberos_policy and (.review == "CHANGES_REQUESTED") then "CHANGES_REQUESTED" else empty end),
         (red_required($checks) as $red | if ($red | length) > 0 then "red required CI: \($red | join(", "))" else empty end),
         (if incomplete_state then "incomplete GitHub state" else empty end)
       ];
@@ -226,6 +237,8 @@ usage: fm-pr-ready-bucket.sh [--repo OWNER/NAME] [--base BRANCH]
 Read-only listing of open GitHub PRs grouped for the next bors rollup.
 Default --repo is Chamber-Hero/memberos. Default --base is main.
 --repo or --base other than those defaults requires --required-check NAME.
+A --repo other than Chamber-Hero/memberos does not apply Bors, release-please,
+review-blocker, or CHANGES_REQUESTED conventions.
 GitHub is the ready-bucket; this command does not scrape a Bors host.
 Prints ready, blocked, stacked, and in-Bors groups with full PR URLs.
 EOF
@@ -545,12 +558,16 @@ page_comments() {
 
 complete_pr_connections() {
   local rec=$1
-  rec=$(jq -c '
-    if (.comments_truncated == true) and (((.bors_last // "") != "") or (.bors_author == true))
-    then .comments_truncated = false
-    else .
-    end
-  ' <<<"$rec") || return 1
+  if [ "$REPO" != "$DEFAULT_REPO" ]; then
+    rec=$(jq -c '.labels_truncated = false | .comments_truncated = false' <<<"$rec") || return 1
+  else
+    rec=$(jq -c '
+      if (.comments_truncated == true) and (((.bors_last // "") != "") or (.bors_author == true))
+      then .comments_truncated = false
+      else .
+      end
+    ' <<<"$rec") || return 1
+  fi
   if [ "$(jq -r '.labels_truncated' <<<"$rec")" = "true" ]; then
     rec=$(page_labels "$rec") || return 1
   fi
@@ -601,10 +618,17 @@ done
 
 ALL_PRS_JSON=$(complete_truncated_connections "$ALL_PRS_JSON") || exit 1
 
+if [ "$REPO" = "$DEFAULT_REPO" ]; then
+  MEMBEROS_POLICY=1
+else
+  MEMBEROS_POLICY=0
+fi
+
 GROUPED=$(
   printf '%s\n' "$ALL_PRS_JSON" | jq \
     --arg base "$BASE" \
     --argjson required "$REQUIRED_CHECKS_JSON" \
+    --argjson memberos "$MEMBEROS_POLICY" \
     "$CLASSIFY_JQ"
 ) || {
   echo "error: ready-bucket classification failed" >&2

--- a/bin/fm-pr-ready-bucket.sh
+++ b/bin/fm-pr-ready-bucket.sh
@@ -1,0 +1,394 @@
+#!/usr/bin/env bash
+# fm-pr-ready-bucket.sh - read-only listing of MemberOS (or --repo) open PRs
+# grouped for the next bors rollup.
+#
+# GitHub is the ready-bucket. This helper never scrapes a Bors dashboard,
+# never writes to GitHub, and never merges, comments, or reviews.
+#
+# Groups:
+#   ready    MERGEABLE, targeting --base (default main), not draft, not
+#            release/release-please, every required Depot + title/body lint
+#            check green, no review-blocker label, no CHANGES_REQUESTED,
+#            not stacked
+#   blocked  conflicts, red required CI, review-blocker, or CHANGES_REQUESTED
+#            (main-targeting non-draft non-release PRs only)
+#   stacked  open PR whose base is not --base
+#   in-Bors  open rollup PRs authored by bors-ci-merge-queue (optional [bot]
+#            suffix) or PRs with a GitHub comment from that bot (or Homu
+#            bors[bot]) that marks approved / queued / trying / rollup
+#
+# Drafts and release-please PRs targeting --base are omitted unless they
+# already match stacked or in-Bors. Pending required CI is omitted rather
+# than treated as blocked.
+#
+# Usage:
+#   fm-pr-ready-bucket.sh [--repo OWNER/NAME] [--base BRANCH] [--json]
+#   fm-pr-ready-bucket.sh --help
+#
+# Default --repo is Chamber-Hero/memberos.
+# Default --base is main.
+# Required checks (MemberOS main ruleset: Depot CI + title/body lint):
+#   CI (Depot) / lint
+#   CI (Depot) / typecheck
+#   CI (Depot) / build
+#   CI (Depot) / guardrails
+#   CI (Depot) / test
+#   CI (Depot) / cli-test
+#   CI (Depot) / quality
+#   CI (Depot) / edge-test
+#   PR Title Lint (Depot) / pr-title-lint
+#   PR Body Lint (Depot) / pr-body-lint
+set -eu
+set -o pipefail
+
+DEFAULT_REPO=Chamber-Hero/memberos
+DEFAULT_BASE=main
+PAGE_SIZE=50
+MAX_PAGES=20
+
+REQUIRED_CHECKS_JSON='[
+  "CI (Depot) / lint",
+  "CI (Depot) / typecheck",
+  "CI (Depot) / build",
+  "CI (Depot) / guardrails",
+  "CI (Depot) / test",
+  "CI (Depot) / cli-test",
+  "CI (Depot) / quality",
+  "CI (Depot) / edge-test",
+  "PR Title Lint (Depot) / pr-title-lint",
+  "PR Body Lint (Depot) / pr-body-lint"
+]'
+
+# shellcheck disable=SC2016 # GraphQL $variables are for GitHub, not the shell.
+GQL_QUERY='query($owner:String!,$name:String!,$after:String,$pageSize:Int!){ repository(owner:$owner,name:$name){ pullRequests(first:$pageSize,states:OPEN,after:$after,orderBy:{field:UPDATED_AT,direction:DESC}){ pageInfo{hasNextPage endCursor} nodes{ number title url isDraft mergeable baseRefName headRefName author{login} reviewDecision labels(first:20){nodes{name}} commits(last:1){nodes{commit{statusCheckRollup{contexts(first:40){nodes{... on CheckRun{name conclusion status} ... on StatusContext{context state}}}}}}} comments(last:30){nodes{author{login} body}} } } } }'
+
+# Compact records for local classification. gh-axi --jq keeps these keys and
+# TOON-encodes the object; the embedded decoder below is the only parser.
+GQL_JQ='.data.repository.pullRequests | {
+  hasNextPage: (.pageInfo.hasNextPage // false),
+  endCursor: (.pageInfo.endCursor // ""),
+  prs: [
+    .nodes[]? | {
+      number,
+      title: ((.title // "") | gsub("[\t\n]"; " ")),
+      url: (.url // ""),
+      draft: (.isDraft // false),
+      mergeable: (.mergeable // "UNKNOWN"),
+      base: (.baseRefName // ""),
+      head: (.headRefName // ""),
+      author: (.author.login // ""),
+      review: (.reviewDecision // ""),
+      labels: ([.labels.nodes[]?.name] | join(",")),
+      checks: ([
+        .commits.nodes[0]?.commit.statusCheckRollup.contexts.nodes[]? |
+        ((.name // .context // "") + "=" + ((.conclusion // .state // .status // "") | ascii_downcase))
+      ] | join(";")),
+      bors_author: ((.author.login // "") | test("^(bors-ci-merge-queue|bors)(\\[bot\\])?$"; "i")),
+      bors_last: ((
+        [.comments.nodes[]? | select((.author.login // "") | test("^(bors-ci-merge-queue|bors)(\\[bot\\])?$"; "i")) | ((.body // "") | gsub("[\t\n]"; " "))]
+        | last
+      ) // "")
+    }
+  ]
+}'
+
+# shellcheck disable=SC2016 # jq $base/$required/$k are jq variables.
+CLASSIFY_JQ='
+  def fail_conclusions: ["failure","timed_out","cancelled","action_required","stale","startup_failure","error"];
+  def pass_conclusions: ["success","neutral"];
+  def parse_checks:
+    ((.checks // "") | split(";") | map(select(length > 0) | (
+      index("=") as $i
+      | if $i then {name: .[0:$i], conclusion: .[$i+1:]}
+        else {name: ., conclusion: ""}
+        end
+    )));
+  def req_status($req; $checks):
+    ($checks | map(select(.name == $req))) as $hits
+    | if any($hits[]; .conclusion as $c | fail_conclusions | index($c)) then "red"
+      elif any($hits[]; .conclusion as $c | pass_conclusions | index($c)) then "green"
+      else "pending"
+      end;
+  def is_release:
+    ((.author // "") | test("release-please"; "i"))
+    or ((.head // "") | test("^release-please"; "i"))
+    or ((.title // "") | test("^chore\\(.*\\): release"; "i"));
+  def has_blocker_label:
+    ((.labels // "") | split(",") | map(gsub("^\\s+|\\s+$";"")) | map(ascii_downcase) | index("review-blocker")) != null;
+  def in_bors:
+    (.bors_author == true)
+    or (
+      ((.bors_last // "") | test("has been approved|now in the \\[queue\\]|Trying:|:hourglass:"; "i"))
+      and ((.bors_last // "") | test("unapproved|not previously approved|unmergeable"; "i") | not)
+    );
+  def red_required($checks):
+    [$required[] | select(req_status(.; $checks) == "red")];
+  def pending_required($checks):
+    [$required[] | select(req_status(.; $checks) == "pending")];
+  def reasons:
+    parse_checks as $checks
+    | [
+        (if .mergeable == "CONFLICTING" then "conflicts" else empty end),
+        (if has_blocker_label then "review-blocker" else empty end),
+        (if .review == "CHANGES_REQUESTED" then "CHANGES_REQUESTED" else empty end),
+        (red_required($checks) as $red | if ($red | length) > 0 then "red required CI: \($red | join(", "))" else empty end)
+      ];
+  def item:
+    {
+      number,
+      url,
+      title,
+      base,
+      reasons: reasons
+    };
+  def bucket:
+    if in_bors then "in_bors"
+    elif .base != $base then "stacked"
+    elif (.draft == true) or is_release then "omit"
+    else
+      (reasons) as $r
+      | parse_checks as $checks
+      | if ($r | length) > 0 then "blocked"
+        elif .mergeable == "MERGEABLE" and (pending_required($checks) | length) == 0
+          then "ready"
+        else "omit"
+        end
+    end;
+  [.[] | . + {bucket: bucket, item: item}]
+  | {
+      ready:    [.[] | select(.bucket == "ready")    | .item] | sort_by(-.number),
+      blocked:  [.[] | select(.bucket == "blocked")  | .item] | sort_by(-.number),
+      stacked:  [.[] | select(.bucket == "stacked")  | .item] | sort_by(-.number),
+      in_bors:  [.[] | select(.bucket == "in_bors")  | .item] | sort_by(-.number)
+    }
+'
+
+usage() {
+  cat <<'EOF'
+usage: fm-pr-ready-bucket.sh [--repo OWNER/NAME] [--base BRANCH] [--json]
+       fm-pr-ready-bucket.sh --help
+
+Read-only listing of open GitHub PRs grouped for the next bors rollup.
+Default --repo is Chamber-Hero/memberos. Default --base is main.
+GitHub is the ready-bucket; this command does not scrape a Bors host.
+Prints ready, blocked, stacked, and in-Bors groups with full PR URLs.
+EOF
+}
+
+REPO=$DEFAULT_REPO
+BASE=$DEFAULT_BASE
+JSON_OUT=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --json)
+      JSON_OUT=1
+      shift
+      ;;
+    --repo)
+      [ "$#" -ge 2 ] || { echo "error: --repo needs OWNER/NAME" >&2; exit 2; }
+      REPO=$2
+      shift 2
+      ;;
+    --repo=*)
+      REPO=${1#--repo=}
+      shift
+      ;;
+    --base)
+      [ "$#" -ge 2 ] || { echo "error: --base needs a branch name" >&2; exit 2; }
+      BASE=$2
+      shift 2
+      ;;
+    --base=*)
+      BASE=${1#--base=}
+      shift
+      ;;
+    *)
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+case "$REPO" in
+  */*/*|/*|*/)
+    echo "error: --repo must be OWNER/NAME" >&2
+    exit 2
+    ;;
+  */*)
+    OWNER=${REPO%%/*}
+    NAME=${REPO#*/}
+    ;;
+  *)
+    echo "error: --repo must be OWNER/NAME" >&2
+    exit 2
+    ;;
+esac
+case "$OWNER" in ''|*[!A-Za-z0-9._-]*) echo "error: --repo must be OWNER/NAME" >&2; exit 2 ;; esac
+case "$NAME" in ''|*[!A-Za-z0-9._-]*) echo "error: --repo must be OWNER/NAME" >&2; exit 2 ;; esac
+case "$BASE" in
+  ''|*[!A-Za-z0-9._/-]*)
+    echo "error: --base must be a branch name" >&2
+    exit 2
+    ;;
+esac
+
+command -v gh-axi >/dev/null 2>&1 || { echo "error: gh-axi not found" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "error: jq not found" >&2; exit 1; }
+command -v python3 >/dev/null 2>&1 || { echo "error: python3 not found" >&2; exit 1; }
+
+# Decode one gh-axi TOON page (hasNextPage/endCursor plus a tabular prs array)
+# into JSON. The decoder is intentionally narrow: it only understands the
+# compact record shape this script asks --jq to emit.
+# argv[1] is the TOON file: a stdin heredoc is the program, so the payload
+# cannot also ride stdin.
+toon_page_to_json() {
+  python3 - "$1" <<'PY'
+import csv, json, re, sys
+
+text = open(sys.argv[1], encoding="utf-8").read()
+has_next = False
+cursor = ""
+prs = []
+table_re = re.compile(r"^prs\[(\d+)\](?:\{([^}]*)\})?:\s*(.*)$")
+bool_keys = {"draft", "bors_author"}
+lines = text.splitlines()
+i = 0
+while i < len(lines):
+    line = lines[i]
+    if line.startswith("hasNextPage:"):
+        has_next = line.split(":", 1)[1].strip().lower() == "true"
+        i += 1
+        continue
+    if line.startswith("endCursor:"):
+        cursor = line.split(":", 1)[1].strip().strip('"')
+        i += 1
+        continue
+    match = table_re.match(line)
+    if match:
+        keys = [k.strip() for k in (match.group(2) or "").split(",") if k.strip()]
+        rows = []
+        rest = match.group(3).strip()
+        if rest:
+            rows.append(rest)
+        i += 1
+        while i < len(lines) and lines[i].startswith("  "):
+            rows.append(lines[i][2:])
+            i += 1
+        if not keys:
+            continue
+        for raw in rows:
+            if not raw.strip():
+                continue
+            parsed = next(csv.reader([raw]))
+            if len(parsed) != len(keys):
+                sys.stderr.write("error: ready-bucket TOON row field count mismatch\n")
+                sys.exit(1)
+            rec = {}
+            for key, val in zip(keys, parsed):
+                if key in bool_keys:
+                    rec[key] = val.strip().lower() == "true"
+                elif key == "number":
+                    try:
+                        rec[key] = int(val)
+                    except ValueError:
+                        sys.stderr.write("error: ready-bucket TOON row has a non-integer number\n")
+                        sys.exit(1)
+                else:
+                    rec[key] = val
+            prs.append(rec)
+        continue
+    i += 1
+print(json.dumps({"hasNextPage": has_next, "endCursor": cursor, "prs": prs}))
+PY
+}
+
+fetch_page() {
+  local after=$1 variables toon page_json toon_file
+  if [ -n "$after" ]; then
+    variables=$(printf '{"owner":"%s","name":"%s","after":"%s","pageSize":%s}' "$OWNER" "$NAME" "$after" "$PAGE_SIZE")
+  else
+    variables=$(printf '{"owner":"%s","name":"%s","after":null,"pageSize":%s}' "$OWNER" "$NAME" "$PAGE_SIZE")
+  fi
+  toon=$(
+    gh-axi api POST /graphql \
+      --field "query=$GQL_QUERY" \
+      --field "variables=$variables" \
+      --jq "$GQL_JQ"
+  ) || {
+    echo "error: GitHub pull request listing failed" >&2
+    return 1
+  }
+  toon_file=$(mktemp "${TMPDIR:-/tmp}/fm-pr-ready-bucket.XXXXXX") || return 1
+  printf '%s\n' "$toon" > "$toon_file" || { rm -f "$toon_file"; return 1; }
+  page_json=$(toon_page_to_json "$toon_file") || { rm -f "$toon_file"; return 1; }
+  rm -f "$toon_file"
+  printf '%s\n' "$page_json"
+}
+
+ALL_PRS_JSON='[]'
+AFTER=
+PAGE=0
+while :; do
+  PAGE=$((PAGE + 1))
+  if [ "$PAGE" -gt "$MAX_PAGES" ]; then
+    echo "error: open PR listing exceeded $MAX_PAGES pages" >&2
+    exit 1
+  fi
+  PAGE_JSON=$(fetch_page "$AFTER") || exit 1
+  PAGE_PRS=$(printf '%s\n' "$PAGE_JSON" | jq -c '.prs') || exit 1
+  ALL_PRS_JSON=$(jq -c --argjson page "$PAGE_PRS" '. + $page' <<<"$ALL_PRS_JSON") || exit 1
+  HAS_NEXT=$(printf '%s\n' "$PAGE_JSON" | jq -r '.hasNextPage') || exit 1
+  AFTER=$(printf '%s\n' "$PAGE_JSON" | jq -r '.endCursor') || exit 1
+  if [ "$HAS_NEXT" != "true" ]; then
+    break
+  fi
+  if [ -z "$AFTER" ] || [ "$AFTER" = "null" ]; then
+    echo "error: GitHub reported another PR page without a cursor" >&2
+    exit 1
+  fi
+done
+
+GROUPED=$(
+  printf '%s\n' "$ALL_PRS_JSON" | jq \
+    --arg base "$BASE" \
+    --argjson required "$REQUIRED_CHECKS_JSON" \
+    "$CLASSIFY_JQ"
+) || {
+  echo "error: ready-bucket classification failed" >&2
+  exit 1
+}
+
+if [ "$JSON_OUT" -eq 1 ]; then
+  jq -n --arg repo "$REPO" --arg base "$BASE" --argjson grouped "$GROUPED" \
+    '$grouped + {repo:$repo, base:$base}'
+  exit 0
+fi
+
+print_group() {
+  local key=$1 label=$2
+  local count
+  count=$(printf '%s\n' "$GROUPED" | jq --arg k "$key" '.[$k] | length')
+  printf '%s (%s)\n' "$label" "$count"
+  printf '%s\n' "$GROUPED" | jq -r --arg k "$key" '
+    .[$k][]
+    | if ($k == "blocked") and ((.reasons | length) > 0) then
+        "\(.url)  \(.reasons | join("; "))"
+      elif $k == "stacked" then
+        "\(.url)  base \(.base)"
+      else
+        .url
+      end
+  '
+  printf '\n'
+}
+
+printf 'ready-bucket  %s  base %s\n\n' "$REPO" "$BASE"
+print_group ready ready
+print_group blocked blocked
+print_group stacked stacked
+print_group in_bors in-Bors

--- a/bin/fm-pr-ready-bucket.sh
+++ b/bin/fm-pr-ready-bucket.sh
@@ -118,7 +118,7 @@ CLASSIFY_JQ='
   def in_bors:
     (.bors_author == true)
     or (
-      ((.bors_last // "") | test("has been approved|now in the \\[queue\\]|Trying:|:hourglass:"; "i"))
+      ((.bors_last // "") | test("has been approved|now in the \\[queue\\]|Trying:|:hourglass:|Rollup created"; "i"))
       and ((.bors_last // "") | test("unapproved|not previously approved|unmergeable"; "i") | not)
     );
   def red_required($checks):

--- a/bin/fm-pr-ready-bucket.sh
+++ b/bin/fm-pr-ready-bucket.sh
@@ -10,8 +10,9 @@
 #            release/release-please, every required Depot + title/body lint
 #            check green, no review-blocker label, no CHANGES_REQUESTED,
 #            not stacked
-#   blocked  conflicts, red required CI, review-blocker, or CHANGES_REQUESTED
-#            (main-targeting non-draft non-release PRs only)
+#   blocked  conflicts, red required CI, review-blocker, CHANGES_REQUESTED,
+#            or truncated nested GitHub state (main-targeting non-draft
+#            non-release PRs only)
 #   stacked  open PR whose base is not --base
 #   in-Bors  open rollup PRs authored by bors-ci-merge-queue (optional [bot]
 #            suffix) or PRs with a GitHub comment from that bot (or Homu
@@ -22,11 +23,16 @@
 # than treated as blocked.
 #
 # Usage:
-#   fm-pr-ready-bucket.sh [--repo OWNER/NAME] [--base BRANCH] [--json]
+#   fm-pr-ready-bucket.sh [--repo OWNER/NAME] [--base BRANCH]
+#                        [--required-check NAME]... [--json]
 #   fm-pr-ready-bucket.sh --help
 #
 # Default --repo is Chamber-Hero/memberos.
 # Default --base is main.
+# --repo or --base other than those defaults requires --required-check,
+# so a different forge target cannot silently keep the MemberOS main list.
+# Nested label, check, and comment pages include pageInfo; a truncated
+# connection is never classified ready (blocked: incomplete GitHub state).
 # Required checks (MemberOS main ruleset: Depot CI + title/body lint):
 #   CI (Depot) / lint
 #   CI (Depot) / typecheck
@@ -46,7 +52,7 @@ DEFAULT_BASE=main
 PAGE_SIZE=50
 MAX_PAGES=20
 
-REQUIRED_CHECKS_JSON='[
+MEMBEROS_REQUIRED_CHECKS_JSON='[
   "CI (Depot) / lint",
   "CI (Depot) / typecheck",
   "CI (Depot) / build",
@@ -60,7 +66,7 @@ REQUIRED_CHECKS_JSON='[
 ]'
 
 # shellcheck disable=SC2016 # GraphQL $variables are for GitHub, not the shell.
-GQL_QUERY='query($owner:String!,$name:String!,$after:String,$pageSize:Int!){ repository(owner:$owner,name:$name){ pullRequests(first:$pageSize,states:OPEN,after:$after,orderBy:{field:UPDATED_AT,direction:DESC}){ pageInfo{hasNextPage endCursor} nodes{ number title url isDraft mergeable baseRefName headRefName author{login} reviewDecision labels(first:20){nodes{name}} commits(last:1){nodes{commit{statusCheckRollup{contexts(first:40){nodes{... on CheckRun{name conclusion status} ... on StatusContext{context state}}}}}}} comments(last:30){nodes{author{login} body}} } } } }'
+GQL_QUERY='query($owner:String!,$name:String!,$after:String,$pageSize:Int!){ repository(owner:$owner,name:$name){ pullRequests(first:$pageSize,states:OPEN,after:$after,orderBy:{field:UPDATED_AT,direction:DESC}){ pageInfo{hasNextPage endCursor} nodes{ number title url isDraft mergeable baseRefName headRefName author{login} reviewDecision labels(first:100){pageInfo{hasNextPage} nodes{name}} commits(last:1){nodes{commit{statusCheckRollup{contexts(first:100){pageInfo{hasNextPage} nodes{... on CheckRun{name conclusion status} ... on StatusContext{context state}}}}}}} comments(last:100){pageInfo{hasPreviousPage} nodes{author{login} body}} } } } }'
 
 # Compact records for local classification. gh-axi --jq keeps these keys and
 # TOON-encodes the object; the embedded decoder below is the only parser.
@@ -79,10 +85,13 @@ GQL_JQ='.data.repository.pullRequests | {
       author: (.author.login // ""),
       review: (.reviewDecision // ""),
       labels: ([.labels.nodes[]?.name] | join(",")),
+      labels_truncated: (.labels.pageInfo.hasNextPage // false),
       checks: ([
         .commits.nodes[0]?.commit.statusCheckRollup.contexts.nodes[]? |
         ((.name // .context // "") + "=" + ((.conclusion // .state // .status // "") | ascii_downcase))
       ] | join(";")),
+      checks_truncated: ((.commits.nodes[0]?.commit.statusCheckRollup.contexts.pageInfo.hasNextPage) // false),
+      comments_truncated: (.comments.pageInfo.hasPreviousPage // false),
       bors_author: ((.author.login // "") | test("^(bors-ci-merge-queue|bors)(\\[bot\\])?$"; "i")),
       bors_last: ((
         [.comments.nodes[]? | select((.author.login // "") | test("^(bors-ci-merge-queue|bors)(\\[bot\\])?$"; "i")) | ((.body // "") | gsub("[\t\n]"; " "))]
@@ -121,6 +130,10 @@ CLASSIFY_JQ='
       ((.bors_last // "") | test("has been approved|now in the \\[queue\\]|Trying:|:hourglass:|Rollup created"; "i"))
       and ((.bors_last // "") | test("unapproved|not previously approved|unmergeable"; "i") | not)
     );
+  def incomplete_state:
+    ((.labels_truncated == true) and (has_blocker_label | not))
+    or (.checks_truncated == true)
+    or ((.comments_truncated == true) and (in_bors | not));
   def red_required($checks):
     [$required[] | select(req_status(.; $checks) == "red")];
   def pending_required($checks):
@@ -131,7 +144,8 @@ CLASSIFY_JQ='
         (if .mergeable == "CONFLICTING" then "conflicts" else empty end),
         (if has_blocker_label then "review-blocker" else empty end),
         (if .review == "CHANGES_REQUESTED" then "CHANGES_REQUESTED" else empty end),
-        (red_required($checks) as $red | if ($red | length) > 0 then "red required CI: \($red | join(", "))" else empty end)
+        (red_required($checks) as $red | if ($red | length) > 0 then "red required CI: \($red | join(", "))" else empty end),
+        (if incomplete_state then "incomplete GitHub state" else empty end)
       ];
   def item:
     {
@@ -145,6 +159,7 @@ CLASSIFY_JQ='
     if in_bors then "in_bors"
     elif .base != $base then "stacked"
     elif (.draft == true) or is_release then "omit"
+    elif incomplete_state then "blocked"
     else
       (reasons) as $r
       | parse_checks as $checks
@@ -165,11 +180,13 @@ CLASSIFY_JQ='
 
 usage() {
   cat <<'EOF'
-usage: fm-pr-ready-bucket.sh [--repo OWNER/NAME] [--base BRANCH] [--json]
+usage: fm-pr-ready-bucket.sh [--repo OWNER/NAME] [--base BRANCH]
+                            [--required-check NAME]... [--json]
        fm-pr-ready-bucket.sh --help
 
 Read-only listing of open GitHub PRs grouped for the next bors rollup.
 Default --repo is Chamber-Hero/memberos. Default --base is main.
+--repo or --base other than those defaults requires --required-check NAME.
 GitHub is the ready-bucket; this command does not scrape a Bors host.
 Prints ready, blocked, stacked, and in-Bors groups with full PR URLs.
 EOF
@@ -178,6 +195,7 @@ EOF
 REPO=$DEFAULT_REPO
 BASE=$DEFAULT_BASE
 JSON_OUT=0
+REQUIRED_CHECK_NAMES=()
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -205,6 +223,17 @@ while [ "$#" -gt 0 ]; do
       ;;
     --base=*)
       BASE=${1#--base=}
+      shift
+      ;;
+    --required-check)
+      [ "$#" -ge 2 ] || { echo "error: --required-check needs a check name" >&2; exit 2; }
+      [ -n "$2" ] || { echo "error: --required-check needs a check name" >&2; exit 2; }
+      REQUIRED_CHECK_NAMES+=("$2")
+      shift 2
+      ;;
+    --required-check=*)
+      [ -n "${1#--required-check=}" ] || { echo "error: --required-check needs a check name" >&2; exit 2; }
+      REQUIRED_CHECK_NAMES+=("${1#--required-check=}")
       shift
       ;;
     *)
@@ -236,10 +265,22 @@ case "$BASE" in
     exit 2
     ;;
 esac
+if [ "${#REQUIRED_CHECK_NAMES[@]}" -gt 0 ]; then
+  :
+elif [ "$REPO" != "$DEFAULT_REPO" ] || [ "$BASE" != "$DEFAULT_BASE" ]; then
+  echo "error: --repo/--base override needs --required-check NAME" >&2
+  exit 2
+fi
 
 command -v gh-axi >/dev/null 2>&1 || { echo "error: gh-axi not found" >&2; exit 1; }
 command -v jq >/dev/null 2>&1 || { echo "error: jq not found" >&2; exit 1; }
 command -v python3 >/dev/null 2>&1 || { echo "error: python3 not found" >&2; exit 1; }
+
+if [ "${#REQUIRED_CHECK_NAMES[@]}" -gt 0 ]; then
+  REQUIRED_CHECKS_JSON=$(printf '%s\n' "${REQUIRED_CHECK_NAMES[@]}" | jq -R . | jq -s -c .)
+else
+  REQUIRED_CHECKS_JSON=$MEMBEROS_REQUIRED_CHECKS_JSON
+fi
 
 # Decode one gh-axi TOON page (hasNextPage/endCursor plus a tabular prs array)
 # into JSON. The decoder is intentionally narrow: it only understands the
@@ -255,7 +296,7 @@ has_next = False
 cursor = ""
 prs = []
 table_re = re.compile(r"^prs\[(\d+)\](?:\{([^}]*)\})?:\s*(.*)$")
-bool_keys = {"draft", "bors_author"}
+bool_keys = {"draft", "bors_author", "labels_truncated", "checks_truncated", "comments_truncated"}
 lines = text.splitlines()
 i = 0
 while i < len(lines):

--- a/bin/fm-pr-ready-bucket.sh
+++ b/bin/fm-pr-ready-bucket.sh
@@ -11,8 +11,8 @@
 #            check green, no review-blocker label, no CHANGES_REQUESTED,
 #            not stacked
 #   blocked  conflicts, red required CI, review-blocker, CHANGES_REQUESTED,
-#            or truncated nested GitHub state (main-targeting non-draft
-#            non-release PRs only)
+#            or still-truncated nested GitHub state after paging (main-
+#            targeting non-draft non-release PRs only)
 #   stacked  open PR whose base is not --base
 #   in-Bors  open rollup PRs authored by bors-ci-merge-queue (optional [bot]
 #            suffix) or PRs with a GitHub comment from that bot (or Homu
@@ -31,8 +31,9 @@
 # Default --base is main.
 # --repo or --base other than those defaults requires --required-check,
 # so a different forge target cannot silently keep the MemberOS main list.
-# Nested label, check, and comment pages include pageInfo; a truncated
-# connection is never classified ready (blocked: incomplete GitHub state).
+# Nested label, check, and comment connections are paged to completion.
+# A still-truncated connection after the page bound is never classified
+# ready (blocked: incomplete GitHub state).
 # Required checks (MemberOS main ruleset: Depot CI + title/body lint):
 #   CI (Depot) / lint
 #   CI (Depot) / typecheck
@@ -51,6 +52,8 @@ DEFAULT_REPO=Chamber-Hero/memberos
 DEFAULT_BASE=main
 PAGE_SIZE=50
 MAX_PAGES=20
+NESTED_PAGE_SIZE=100
+MAX_NESTED_PAGES=${FM_PR_READY_BUCKET_MAX_NESTED_PAGES:-20}
 
 MEMBEROS_REQUIRED_CHECKS_JSON='[
   "CI (Depot) / lint",
@@ -66,7 +69,16 @@ MEMBEROS_REQUIRED_CHECKS_JSON='[
 ]'
 
 # shellcheck disable=SC2016 # GraphQL $variables are for GitHub, not the shell.
-GQL_QUERY='query($owner:String!,$name:String!,$after:String,$pageSize:Int!){ repository(owner:$owner,name:$name){ pullRequests(first:$pageSize,states:OPEN,after:$after,orderBy:{field:UPDATED_AT,direction:DESC}){ pageInfo{hasNextPage endCursor} nodes{ number title url isDraft mergeable baseRefName headRefName author{login} reviewDecision labels(first:100){pageInfo{hasNextPage} nodes{name}} commits(last:1){nodes{commit{statusCheckRollup{contexts(first:100){pageInfo{hasNextPage} nodes{... on CheckRun{name conclusion status} ... on StatusContext{context state}}}}}}} comments(last:100){pageInfo{hasPreviousPage} nodes{author{login} body}} } } } }'
+GQL_QUERY='query ReadyBucketPulls($owner:String!,$name:String!,$after:String,$pageSize:Int!){ repository(owner:$owner,name:$name){ pullRequests(first:$pageSize,states:OPEN,after:$after,orderBy:{field:UPDATED_AT,direction:DESC}){ pageInfo{hasNextPage endCursor} nodes{ number title url isDraft mergeable baseRefName headRefName author{login} reviewDecision labels(first:100){pageInfo{hasNextPage endCursor} nodes{name}} commits(last:1){nodes{commit{statusCheckRollup{contexts(first:100){pageInfo{hasNextPage endCursor} nodes{... on CheckRun{name conclusion status} ... on StatusContext{context state}}}}}}} comments(last:100){pageInfo{hasPreviousPage startCursor} nodes{author{login} body}} } } } }'
+
+# shellcheck disable=SC2016 # GraphQL $variables are for GitHub, not the shell.
+GQL_LABELS_QUERY='query ReadyBucketLabels($owner:String!,$name:String!,$number:Int!,$after:String,$pageSize:Int!){ repository(owner:$owner,name:$name){ pullRequest(number:$number){ labels(first:$pageSize,after:$after){ pageInfo{hasNextPage endCursor} nodes{name} } } } }'
+
+# shellcheck disable=SC2016 # GraphQL $variables are for GitHub, not the shell.
+GQL_CHECKS_QUERY='query ReadyBucketChecks($owner:String!,$name:String!,$number:Int!,$after:String,$pageSize:Int!){ repository(owner:$owner,name:$name){ pullRequest(number:$number){ commits(last:1){ nodes{ commit{ statusCheckRollup{ contexts(first:$pageSize,after:$after){ pageInfo{hasNextPage endCursor} nodes{... on CheckRun{name conclusion status} ... on StatusContext{context state}} } } } } } } } }'
+
+# shellcheck disable=SC2016 # GraphQL $variables are for GitHub, not the shell.
+GQL_COMMENTS_QUERY='query ReadyBucketComments($owner:String!,$name:String!,$number:Int!,$before:String,$pageSize:Int!){ repository(owner:$owner,name:$name){ pullRequest(number:$number){ comments(last:$pageSize,before:$before){ pageInfo{hasPreviousPage startCursor} nodes{author{login} body} } } } }'
 
 # Compact records for local classification. gh-axi --jq keeps these keys and
 # TOON-encodes the object; the embedded decoder below is the only parser.
@@ -86,12 +98,15 @@ GQL_JQ='.data.repository.pullRequests | {
       review: (.reviewDecision // ""),
       labels: ([.labels.nodes[]?.name] | join(",")),
       labels_truncated: (.labels.pageInfo.hasNextPage // false),
+      labels_cursor: (.labels.pageInfo.endCursor // ""),
       checks: ([
         .commits.nodes[0]?.commit.statusCheckRollup.contexts.nodes[]? |
         ((.name // .context // "") + "=" + ((.conclusion // .state // .status // "") | ascii_downcase))
       ] | join(";")),
       checks_truncated: ((.commits.nodes[0]?.commit.statusCheckRollup.contexts.pageInfo.hasNextPage) // false),
+      checks_cursor: ((.commits.nodes[0]?.commit.statusCheckRollup.contexts.pageInfo.endCursor) // ""),
       comments_truncated: (.comments.pageInfo.hasPreviousPage // false),
+      comments_cursor: (.comments.pageInfo.startCursor // ""),
       bors_author: ((.author.login // "") | test("^(bors-ci-merge-queue|bors)(\\[bot\\])?$"; "i")),
       bors_last: ((
         [.comments.nodes[]? | select((.author.login // "") | test("^(bors-ci-merge-queue|bors)(\\[bot\\])?$"; "i")) | ((.body // "") | gsub("[\t\n]"; " "))]
@@ -99,6 +114,30 @@ GQL_JQ='.data.repository.pullRequests | {
       ) // "")
     }
   ]
+}'
+
+GQL_LABELS_JQ='.data.repository.pullRequest.labels | {
+  hasNextPage: (.pageInfo.hasNextPage // false),
+  endCursor: (.pageInfo.endCursor // ""),
+  names: ([.nodes[]?.name] | join(","))
+}'
+
+GQL_CHECKS_JQ='(.data.repository.pullRequest.commits.nodes[0]?.commit.statusCheckRollup.contexts // {pageInfo:{hasNextPage:false,endCursor:""},nodes:[]}) | {
+  hasNextPage: (.pageInfo.hasNextPage // false),
+  endCursor: (.pageInfo.endCursor // ""),
+  checks: ([
+    .nodes[]? |
+    ((.name // .context // "") + "=" + ((.conclusion // .state // .status // "") | ascii_downcase))
+  ] | join(";"))
+}'
+
+GQL_COMMENTS_JQ='.data.repository.pullRequest.comments | {
+  hasPreviousPage: (.pageInfo.hasPreviousPage // false),
+  startCursor: (.pageInfo.startCursor // ""),
+  bors_last: ((
+    [.nodes[]? | select((.author.login // "") | test("^(bors-ci-merge-queue|bors)(\\[bot\\])?$"; "i")) | ((.body // "") | gsub("[\t\n]"; " "))]
+    | last
+  ) // "")
 }'
 
 # shellcheck disable=SC2016 # jq $base/$required/$k are jq variables.
@@ -133,7 +172,7 @@ CLASSIFY_JQ='
   def incomplete_state:
     ((.labels_truncated == true) and (has_blocker_label | not))
     or (.checks_truncated == true)
-    or ((.comments_truncated == true) and (in_bors | not));
+    or ((.comments_truncated == true) and ((.bors_last // "") == "") and (.bors_author != true));
   def red_required($checks):
     [$required[] | select(req_status(.; $checks) == "red")];
   def pending_required($checks):
@@ -265,6 +304,12 @@ case "$BASE" in
     exit 2
     ;;
 esac
+case "$MAX_NESTED_PAGES" in
+  ''|*[!0-9]*|0)
+    echo "error: FM_PR_READY_BUCKET_MAX_NESTED_PAGES must be a positive integer" >&2
+    exit 2
+    ;;
+esac
 if [ "${#REQUIRED_CHECK_NAMES[@]}" -gt 0 ]; then
   :
 elif [ "$REPO" != "$DEFAULT_REPO" ] || [ "$BASE" != "$DEFAULT_BASE" ]; then
@@ -348,6 +393,31 @@ print(json.dumps({"hasNextPage": has_next, "endCursor": cursor, "prs": prs}))
 PY
 }
 
+# Decode a scalar gh-axi TOON object (follow-up label/check/comment pages).
+toon_object_to_json() {
+  python3 - "$1" <<'PY'
+import json, sys
+
+obj = {}
+for line in open(sys.argv[1], encoding="utf-8"):
+    line = line.rstrip("\n")
+    if not line or line.startswith(" ") or ":" not in line:
+        continue
+    key, val = line.split(":", 1)
+    key = key.strip()
+    val = val.strip()
+    if len(val) >= 2 and val[0] == val[-1] == '"':
+        val = val[1:-1]
+    if val.lower() == "true":
+        obj[key] = True
+    elif val.lower() == "false":
+        obj[key] = False
+    else:
+        obj[key] = val
+print(json.dumps(obj))
+PY
+}
+
 fetch_page() {
   local after=$1 variables toon page_json toon_file
   if [ -n "$after" ]; then
@@ -369,6 +439,141 @@ fetch_page() {
   page_json=$(toon_page_to_json "$toon_file") || { rm -f "$toon_file"; return 1; }
   rm -f "$toon_file"
   printf '%s\n' "$page_json"
+}
+
+fetch_nested() {
+  local query=$1 jq_expr=$2 variables=$3 toon toon_file page_json
+  toon=$(
+    gh-axi api POST /graphql \
+      --field "query=$query" \
+      --field "variables=$variables" \
+      --jq "$jq_expr"
+  ) || {
+    echo "error: GitHub pull request details failed" >&2
+    return 1
+  }
+  toon_file=$(mktemp "${TMPDIR:-/tmp}/fm-pr-ready-bucket.XXXXXX") || return 1
+  printf '%s\n' "$toon" > "$toon_file" || { rm -f "$toon_file"; return 1; }
+  page_json=$(toon_object_to_json "$toon_file") || { rm -f "$toon_file"; return 1; }
+  rm -f "$toon_file"
+  printf '%s\n' "$page_json"
+}
+
+nested_vars() {
+  local number=$1 cursor_key=$2 cursor=$3
+  jq -nc --arg owner "$OWNER" --arg name "$NAME" --argjson number "$number" \
+    --arg ckey "$cursor_key" --arg cursor "$cursor" --argjson pageSize "$NESTED_PAGE_SIZE" \
+    '{owner:$owner,name:$name,number:$number,pageSize:$pageSize} + {($ckey):$cursor}'
+}
+
+page_labels() {
+  local rec=$1 page pages=0 cursor number vars
+  number=$(jq -r '.number' <<<"$rec") || return 1
+  cursor=$(jq -r '.labels_cursor // ""' <<<"$rec") || return 1
+  while [ "$(jq -r '.labels_truncated' <<<"$rec")" = "true" ]; do
+    pages=$((pages + 1))
+    if [ "$pages" -gt "$MAX_NESTED_PAGES" ] || [ -z "$cursor" ] || [ "$cursor" = "null" ]; then
+      break
+    fi
+    vars=$(nested_vars "$number" after "$cursor") || return 1
+    page=$(fetch_nested "$GQL_LABELS_QUERY" "$GQL_LABELS_JQ" "$vars") || return 1
+    rec=$(jq -c --argjson page "$page" '
+      (.labels // "" | split(",") | map(select(length>0))) as $have
+      | (($page.names // "") | split(",") | map(select(length>0))) as $more
+      | .labels = (($have + $more) | unique | join(","))
+      | .labels_cursor = ($page.endCursor // "")
+      | .labels_truncated = ($page.hasNextPage == true)
+    ' <<<"$rec") || return 1
+    if jq -e '((.labels // "") | split(",") | map(gsub("^\\s+|\\s+$";"") | ascii_downcase) | index("review-blocker")) != null' <<<"$rec" >/dev/null; then
+      rec=$(jq -c '.labels_truncated = false' <<<"$rec") || return 1
+      break
+    fi
+    cursor=$(jq -r '.labels_cursor // ""' <<<"$rec") || return 1
+  done
+  printf '%s\n' "$rec"
+}
+
+page_checks() {
+  local rec=$1 page pages=0 cursor number vars
+  number=$(jq -r '.number' <<<"$rec") || return 1
+  cursor=$(jq -r '.checks_cursor // ""' <<<"$rec") || return 1
+  while [ "$(jq -r '.checks_truncated' <<<"$rec")" = "true" ]; do
+    pages=$((pages + 1))
+    if [ "$pages" -gt "$MAX_NESTED_PAGES" ] || [ -z "$cursor" ] || [ "$cursor" = "null" ]; then
+      break
+    fi
+    vars=$(nested_vars "$number" after "$cursor") || return 1
+    page=$(fetch_nested "$GQL_CHECKS_QUERY" "$GQL_CHECKS_JQ" "$vars") || return 1
+    rec=$(jq -c --argjson page "$page" '
+      (.checks // "" | split(";") | map(select(length>0))) as $have
+      | (($page.checks // "") | split(";") | map(select(length>0))) as $more
+      | .checks = (($have + $more) | unique | join(";"))
+      | .checks_cursor = ($page.endCursor // "")
+      | .checks_truncated = ($page.hasNextPage == true)
+    ' <<<"$rec") || return 1
+    cursor=$(jq -r '.checks_cursor // ""' <<<"$rec") || return 1
+  done
+  printf '%s\n' "$rec"
+}
+
+page_comments() {
+  local rec=$1 page pages=0 cursor number vars
+  number=$(jq -r '.number' <<<"$rec") || return 1
+  cursor=$(jq -r '.comments_cursor // ""' <<<"$rec") || return 1
+  while [ "$(jq -r '.comments_truncated' <<<"$rec")" = "true" ] \
+    && [ "$(jq -r '.bors_last // ""' <<<"$rec")" = "" ] \
+    && [ "$(jq -r '.bors_author' <<<"$rec")" != "true" ]; do
+    pages=$((pages + 1))
+    if [ "$pages" -gt "$MAX_NESTED_PAGES" ] || [ -z "$cursor" ] || [ "$cursor" = "null" ]; then
+      break
+    fi
+    vars=$(nested_vars "$number" before "$cursor") || return 1
+    page=$(fetch_nested "$GQL_COMMENTS_QUERY" "$GQL_COMMENTS_JQ" "$vars") || return 1
+    rec=$(jq -c --argjson page "$page" '
+      .bors_last = (if ((.bors_last // "") == "") then ($page.bors_last // "") else .bors_last end)
+      | .comments_cursor = ($page.startCursor // "")
+      | .comments_truncated = ($page.hasPreviousPage == true)
+    ' <<<"$rec") || return 1
+    if [ "$(jq -r '.bors_last // ""' <<<"$rec")" != "" ]; then
+      rec=$(jq -c '.comments_truncated = false' <<<"$rec") || return 1
+      break
+    fi
+    cursor=$(jq -r '.comments_cursor // ""' <<<"$rec") || return 1
+  done
+  printf '%s\n' "$rec"
+}
+
+complete_pr_connections() {
+  local rec=$1
+  rec=$(jq -c '
+    if (.comments_truncated == true) and (((.bors_last // "") != "") or (.bors_author == true))
+    then .comments_truncated = false
+    else .
+    end
+  ' <<<"$rec") || return 1
+  if [ "$(jq -r '.labels_truncated' <<<"$rec")" = "true" ]; then
+    rec=$(page_labels "$rec") || return 1
+  fi
+  if [ "$(jq -r '.checks_truncated' <<<"$rec")" = "true" ]; then
+    rec=$(page_checks "$rec") || return 1
+  fi
+  if [ "$(jq -r '.comments_truncated' <<<"$rec")" = "true" ]; then
+    rec=$(page_comments "$rec") || return 1
+  fi
+  printf '%s\n' "$rec"
+}
+
+complete_truncated_connections() {
+  local prs=$1 rec idx count
+  count=$(printf '%s\n' "$prs" | jq 'length') || return 1
+  idx=0
+  while [ "$idx" -lt "$count" ]; do
+    rec=$(printf '%s\n' "$prs" | jq -c --argjson i "$idx" '.[$i]') || return 1
+    rec=$(complete_pr_connections "$rec") || return 1
+    prs=$(printf '%s\n' "$prs" | jq -c --argjson i "$idx" --argjson rec "$rec" '.[$i] = $rec') || return 1
+    idx=$((idx + 1))
+  done
+  printf '%s\n' "$prs"
 }
 
 ALL_PRS_JSON='[]'
@@ -393,6 +598,8 @@ while :; do
     exit 1
   fi
 done
+
+ALL_PRS_JSON=$(complete_truncated_connections "$ALL_PRS_JSON") || exit 1
 
 GROUPED=$(
   printf '%s\n' "$ALL_PRS_JSON" | jq \

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -211,7 +211,8 @@ family_for_basename() {
     fm-teardown-endpoint-safety.test.sh)
       printf '%s\n' backend-dispatch
       ;;
-    fm-pr-check-security.test.sh|fm-pr-merge.test.sh|fm-review-diff.test.sh|\
+    fm-pr-check-security.test.sh|fm-pr-merge.test.sh|fm-pr-ready-bucket.test.sh|\
+    fm-review-diff.test.sh|\
     fm-teardown.test.sh|fm-x-mode.test.sh)
       printf '%s\n' pr-forge
       ;;

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -114,6 +114,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-pr-check-migrate.sh` | Quarantine older task polls without execution and rebuild only canonical polls       |
 | `fm-pr-check.sh`         | Record validated `pr=` and `pr_head=` values, then atomically arm a static merge poll |
 | `fm-pr-merge.sh`         | Record PR metadata, then merge a task's canonical full GitHub or GitLab URL          |
+| `fm-pr-ready-bucket.sh`  | Read-only GitHub listing of MemberOS (or `--repo`) open PRs for the next bors rollup |
 | `fm-promote.sh`          | Promote a scout task in place to a protected ship task with an explicit delivery mode |
 | `fm-teardown.sh`         | Fail-closed teardown: return landed ship worktrees, require completed scout deliverables, retire secondmate homes |
 | `fm-harness.sh`          | Detect the running harness and resolve crew or secondmate harness, model, and effort |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -114,7 +114,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-pr-check-migrate.sh` | Quarantine older task polls without execution and rebuild only canonical polls       |
 | `fm-pr-check.sh`         | Record validated `pr=` and `pr_head=` values, then atomically arm a static merge poll |
 | `fm-pr-merge.sh`         | Record PR metadata, then merge a task's canonical full GitHub or GitLab URL          |
-| `fm-pr-ready-bucket.sh`  | Read-only GitHub listing of MemberOS (or `--repo`) open PRs for the next bors rollup |
+| `fm-pr-ready-bucket.sh`  | Read-only GitHub listing of MemberOS open PRs for the next bors rollup; `--repo` uses only that target's required checks, not MemberOS Bors/review conventions |
 | `fm-promote.sh`          | Promote a scout task in place to a protected ship task with an explicit delivery mode |
 | `fm-teardown.sh`         | Fail-closed teardown: return landed ship worktrees, require completed scout deliverables, retire secondmate homes |
 | `fm-harness.sh`          | Detect the running harness and resolve crew or secondmate harness, model, and effort |

--- a/tests/fm-pr-ready-bucket.test.sh
+++ b/tests/fm-pr-ready-bucket.test.sh
@@ -10,7 +10,9 @@
 #   (e) drafts and release-please PRs targeting main are omitted
 #   (f) pending required CI is omitted rather than blocked or ready
 #   (g) default repo is Chamber-Hero/memberos; --repo/--base overrides
-#       require --required-check and use that list, not MemberOS defaults
+#       require --required-check and use that list, not MemberOS defaults;
+#       a non-MemberOS --repo also ignores Bors, release-please,
+#       review-blocker, and CHANGES_REQUESTED conventions
 #   (h) the helper is read-only (no merge/comment/review) and does not
 #       scrape the Bors host
 #   (i) truncated labels, checks, or comments are paged to completion
@@ -363,6 +365,38 @@ test_required_check_override_replaces_memberos_list() {
   pass "fm-pr-ready-bucket uses --required-check instead of the MemberOS list"
 }
 
+test_repo_override_skips_memberos_merge_policy() {
+  local case_dir out other_green
+  case_dir=$(make_case override-policy)
+  other_green="other-ci=success"
+  write_page "$case_dir/page.toon" false "" \
+    "$(pr_json 611 "feat: review noise" MERGEABLE main "$other_green" "review-blocker" CHANGES_REQUESTED false alice feat/x false ":tada: Rollup created")" \
+    "$(pr_json 612 "chore(main): release 9.9.9" MERGEABLE main "$other_green" "" APPROVED false "release-please[bot]" "release-please--branches--main")" \
+    "$(pr_json 613 "Auto merge of #611" MERGEABLE main "$other_green" "" APPROVED false "bors-ci-merge-queue" "tmp/bors" true "")"
+  out=$(run_bucket "$case_dir" --repo Example-Org/other --required-check other-ci --json)
+  [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '.ready | length')" = 3 ] \
+    || fail "override-policy: MemberOS conventions must not block a foreign repo, got: $out"
+  [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '.blocked | length')" = 0 ] \
+    || fail "override-policy: no PR should be blocked by MemberOS review policy, got: $out"
+  [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '.in_bors | length')" = 0 ] \
+    || fail "override-policy: Bors conventions must not apply off MemberOS, got: $out"
+  printf '%s\n' "$out" | "$REAL_JQ" -e '
+    ([.ready[].number] | sort) == [611,612,613]
+    and all(.ready[]; (.reasons | length) == 0)
+  ' >/dev/null || fail "override-policy: expected only generic ready items, got: $out"
+  if grep -E "ReadyBucketLabels|ReadyBucketComments" "$case_dir/gh-axi.log"; then
+    fail "override-policy: non-MemberOS listing should not page labels or Bors comments"
+  fi
+  out=$(run_bucket "$case_dir" --json)
+  [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '.ready | length')" = 0 ] \
+    || fail "override-policy: MemberOS defaults should still apply those conventions, got: $out"
+  [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '.in_bors | length')" = 2 ] \
+    || fail "override-policy: MemberOS should still treat Bors author/comment as in-Bors, got: $out"
+  [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '[.ready,.blocked,.stacked,.in_bors | length] | add')" = 2 ] \
+    || fail "override-policy: MemberOS should omit the release-please PR, got: $out"
+  pass "fm-pr-ready-bucket keeps MemberOS merge policy off non-MemberOS --repo"
+}
+
 test_truncated_labels_are_paged() {
   local case_dir out
   case_dir=$(make_case truncated-labels)
@@ -517,6 +551,7 @@ test_stale_bors_comment_is_not_in_bors
 test_omits_draft_release_and_pending
 test_repo_override_and_read_only
 test_required_check_override_replaces_memberos_list
+test_repo_override_skips_memberos_merge_policy
 test_truncated_labels_are_paged
 test_truncated_checks_are_paged
 test_truncated_comments_are_paged

--- a/tests/fm-pr-ready-bucket.test.sh
+++ b/tests/fm-pr-ready-bucket.test.sh
@@ -1,0 +1,339 @@
+#!/usr/bin/env bash
+# Tests for bin/fm-pr-ready-bucket.sh: a read-only GitHub listing of MemberOS
+# (or --repo) open PRs grouped for the next bors rollup.
+#
+# Matrix:
+#   (a) MERGEABLE main PR with required Depot + title/body lint green is ready
+#   (b) conflicts, red required CI, review-blocker, and CHANGES_REQUESTED block
+#   (c) base other than main is stacked, even when it also has conflicts
+#   (d) bors-ci-merge-queue author or queue comment is in-Bors
+#   (e) drafts and release-please PRs targeting main are omitted
+#   (f) pending required CI is omitted rather than blocked or ready
+#   (g) default repo is Chamber-Hero/memberos; --repo overrides
+#   (h) the helper is read-only (no merge/comment/review) and does not
+#       scrape the Bors host
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+BUCKET="$ROOT/bin/fm-pr-ready-bucket.sh"
+TMP_ROOT=$(fm_test_tmproot fm-pr-ready-bucket-tests)
+BASE_PATH=$PATH
+REAL_JQ=$(command -v jq) || fail "jq is required for ready-bucket tests"
+REAL_PYTHON3=$(command -v python3) || fail "python3 is required for ready-bucket tests"
+
+assert_present "$BUCKET" "bin/fm-pr-ready-bucket.sh is missing"
+[ -x "$BUCKET" ] || fail "bin/fm-pr-ready-bucket.sh must be executable"
+
+GREEN_CHECKS="CI (Depot) / lint=success;CI (Depot) / typecheck=success;CI (Depot) / build=success;CI (Depot) / guardrails=success;CI (Depot) / test=success;CI (Depot) / cli-test=success;CI (Depot) / quality=success;CI (Depot) / edge-test=success;PR Title Lint (Depot) / pr-title-lint=success;PR Body Lint (Depot) / pr-body-lint=success"
+
+# make_case <name>: sandbox with a gh-axi mock that replays a TOON page and
+# records every invocation. Echoes the case dir.
+make_case() {
+  local name=$1 case_dir fakebin
+  case_dir="$TMP_ROOT/$name"
+  fakebin="$case_dir/fakebin"
+  mkdir -p "$fakebin"
+  : > "$case_dir/gh-axi.log"
+  cat > "$fakebin/gh-axi" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$FM_TEST_GH_AXI_LOG"
+case " $* " in
+  *" merge "*|*" comment "*|*" review "*|*" edit "*|*" close "*|*" create "*)
+    echo "error: ready-bucket tests forbid write operations: $*" >&2
+    exit 1
+    ;;
+esac
+case "${1:-} ${2:-}" in
+  "api POST")
+    cat "$FM_TEST_TOON_FILE"
+    exit 0
+    ;;
+esac
+echo "error: unexpected gh-axi invocation: $*" >&2
+exit 1
+SH
+  chmod +x "$fakebin/gh-axi"
+  printf '%s\n' "$case_dir"
+}
+
+run_bucket() {
+  local case_dir=$1
+  shift
+  FM_TEST_GH_AXI_LOG="$case_dir/gh-axi.log" \
+  FM_TEST_TOON_FILE="$case_dir/page.toon" \
+  PATH="$case_dir/fakebin:$BASE_PATH" \
+    "$BUCKET" "$@"
+}
+
+# write_page <file> <hasNextPage> <endCursor> [pr json objects...]
+# Each PR object supplies the compact record keys the helper classifies.
+write_page() {
+  local file=$1 has_next=$2 cursor=$3
+  shift 3
+  if [ "$#" -eq 0 ]; then
+    cat > "$file" <<EOF
+hasNextPage: $has_next
+endCursor: "$cursor"
+prs[0]:
+EOF
+    return 0
+  fi
+  "$REAL_PYTHON3" - "$file" "$has_next" "$cursor" "$@" <<'PY'
+import csv, json, sys
+path, has_next, cursor = sys.argv[1], sys.argv[2], sys.argv[3]
+prs = [json.loads(arg) for arg in sys.argv[4:]]
+keys = [
+    "author", "base", "bors_author", "bors_last", "checks", "draft",
+    "head", "labels", "mergeable", "number", "review", "title", "url",
+]
+with open(path, "w", encoding="utf-8") as fh:
+    fh.write(f"hasNextPage: {has_next}\n")
+    fh.write(f'endCursor: "{cursor}"\n')
+    fh.write("prs[%d]{%s}:\n" % (len(prs), ",".join(keys)))
+    writer = csv.writer(fh, lineterminator="\n")
+    for pr in prs:
+        fh.write("  ")
+        writer.writerow([
+            pr.get("author", "alice"),
+            pr.get("base", "main"),
+            "true" if pr.get("bors_author") else "false",
+            pr.get("bors_last", ""),
+            pr.get("checks", ""),
+            "true" if pr.get("draft") else "false",
+            pr.get("head", "feat/x"),
+            pr.get("labels", ""),
+            pr.get("mergeable", "MERGEABLE"),
+            pr.get("number", 1),
+            pr.get("review", "APPROVED"),
+            pr.get("title", "feat: x"),
+            pr.get("url", "https://github.com/Chamber-Hero/memberos/pull/%s" % pr.get("number", 1)),
+        ])
+PY
+}
+
+pr_json() {
+  # shellcheck disable=SC2016 # jq $number/$title and friends are jq variables.
+  "$REAL_JQ" -n \
+    --argjson number "$1" \
+    --arg title "$2" \
+    --arg mergeable "${3:-MERGEABLE}" \
+    --arg base "${4:-main}" \
+    --arg checks "${5:-$GREEN_CHECKS}" \
+    --arg labels "${6:-}" \
+    --arg review "${7:-APPROVED}" \
+    --argjson draft "${8:-false}" \
+    --arg author "${9:-alice}" \
+    --arg head "${10:-feat/x}" \
+    --argjson bors_author "${11:-false}" \
+    --arg bors_last "${12:-}" \
+    '{
+      number:$number, title:$title, mergeable:$mergeable, base:$base,
+      checks:$checks, labels:$labels, review:$review, draft:$draft,
+      author:$author, head:$head, bors_author:$bors_author, bors_last:$bors_last,
+      url:("https://github.com/Chamber-Hero/memberos/pull/" + ($number|tostring))
+    }'
+}
+
+test_help_and_bad_args() {
+  local out
+  out=$("$BUCKET" --help)
+  assert_contains "$out" "fm-pr-ready-bucket.sh" "help should name the command"
+  assert_contains "$out" "Chamber-Hero/memberos" "help should name the default repo"
+  assert_contains "$out" "does not scrape a Bors host" "help should say GitHub is the source"
+  "$BUCKET" --nope >/dev/null 2>&1
+  expect_code 2 $? "--nope should be a usage error"
+  "$BUCKET" --repo not-a-repo >/dev/null 2>&1
+  expect_code 2 $? "malformed --repo should be a usage error"
+  pass "fm-pr-ready-bucket help and usage errors"
+}
+
+test_missing_tools_refuse() {
+  local case_dir rc=0
+  case_dir=$(make_case missing-tools)
+  # Keep a system PATH so env can find bash, but do not include the gh-axi mock.
+  PATH="/usr/bin:/bin" "$BUCKET" >/dev/null 2>"$case_dir/stderr" || rc=$?
+  expect_code 1 "$rc" "missing gh-axi should refuse"
+  assert_contains "$(cat "$case_dir/stderr")" "gh-axi not found" "missing gh-axi names the tool"
+  pass "fm-pr-ready-bucket refuses without gh-axi"
+}
+
+test_ready_pr() {
+  local case_dir out
+  case_dir=$(make_case ready)
+  write_page "$case_dir/page.toon" false "" "$(pr_json 101 "feat: ready")"
+  out=$(run_bucket "$case_dir" --json)
+  [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '.repo')" = "Chamber-Hero/memberos" ] \
+    || fail "ready: default repo should be Chamber-Hero/memberos"
+  [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '.ready | length')" = 1 ] \
+    || fail "ready: expected one ready PR, got: $out"
+  [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '.ready[0].url')" = \
+    "https://github.com/Chamber-Hero/memberos/pull/101" ] \
+    || fail "ready: full PR URL missing, got: $out"
+  [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '.blocked | length')" = 0 ] \
+    || fail "ready: should not be blocked"
+  grep -F "POST /graphql" "$case_dir/gh-axi.log" >/dev/null \
+    || fail "ready: should list PRs through gh-axi api POST /graphql"
+  grep -E "Chamber-Hero|memberos" "$case_dir/gh-axi.log" >/dev/null \
+    || fail "ready: GraphQL variables should name Chamber-Hero/memberos"
+  pass "fm-pr-ready-bucket lists a green MERGEABLE main PR as ready"
+}
+
+test_blocked_reasons() {
+  local case_dir out
+  case_dir=$(make_case blocked)
+  write_page "$case_dir/page.toon" false "" \
+    "$(pr_json 201 "fix: conflicts" CONFLICTING)" \
+    "$(pr_json 202 "fix: red ci" MERGEABLE main "${GREEN_CHECKS};PR Body Lint (Depot) / pr-body-lint=failure")" \
+    "$(pr_json 203 "fix: blocker" MERGEABLE main "$GREEN_CHECKS" "review-blocker")" \
+    "$(pr_json 204 "fix: changes" MERGEABLE main "$GREEN_CHECKS" "" CHANGES_REQUESTED)"
+  out=$(run_bucket "$case_dir" --json)
+  [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '.ready | length')" = 0 ] \
+    || fail "blocked: no PR should be ready, got: $out"
+  [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '.blocked | length')" = 4 ] \
+    || fail "blocked: expected four blocked PRs, got: $out"
+  printf '%s\n' "$out" | "$REAL_JQ" -e '
+    (.blocked[] | select(.number==201) | .reasons | index("conflicts")) != null
+    and (.blocked[] | select(.number==202) | .reasons[] | test("red required CI"))
+    and (.blocked[] | select(.number==203) | .reasons | index("review-blocker")) != null
+    and (.blocked[] | select(.number==204) | .reasons | index("CHANGES_REQUESTED")) != null
+  ' >/dev/null || fail "blocked: missing expected reasons, got: $out"
+  out=$(run_bucket "$case_dir")
+  assert_contains "$out" "https://github.com/Chamber-Hero/memberos/pull/201" \
+    "human output should print the conflicts PR URL"
+  assert_contains "$out" "conflicts" "human output should name the conflicts reason"
+  pass "fm-pr-ready-bucket classifies conflicts, red required CI, review-blocker, and CHANGES_REQUESTED as blocked"
+}
+
+test_stacked_wins_over_conflicts() {
+  local case_dir out
+  case_dir=$(make_case stacked)
+  write_page "$case_dir/page.toon" false "" \
+    "$(pr_json 301 "feat: stacked" CONFLICTING feat/parent "$GREEN_CHECKS")"
+  out=$(run_bucket "$case_dir" --json)
+  [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '.stacked | length')" = 1 ] \
+    || fail "stacked: expected one stacked PR, got: $out"
+  [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '.blocked | length')" = 0 ] \
+    || fail "stacked: stacked PRs must not also appear as blocked, got: $out"
+  [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '.stacked[0].base')" = "feat/parent" ] \
+    || fail "stacked: should record the non-main base"
+  out=$(run_bucket "$case_dir")
+  assert_contains "$out" "https://github.com/Chamber-Hero/memberos/pull/301" \
+    "stacked human output should print the full URL"
+  assert_contains "$out" "base feat/parent" "stacked human output should name the base"
+  pass "fm-pr-ready-bucket lists non-main base PRs as stacked"
+}
+
+test_in_bors_author_and_comment() {
+  local case_dir out
+  case_dir=$(make_case in-bors)
+  write_page "$case_dir/page.toon" false "" \
+    "$(pr_json 401 "Auto merge of #101" MERGEABLE main "$GREEN_CHECKS" "" APPROVED false "bors-ci-merge-queue" "tmp/bors" true "")" \
+    "$(pr_json 402 "feat: queued" MERGEABLE main "$GREEN_CHECKS" "" APPROVED false "alice" "feat/queued" false "Commit abc has been approved by cap. It is now in the [queue] for this repository.")"
+  out=$(run_bucket "$case_dir" --json)
+  [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '.in_bors | length')" = 2 ] \
+    || fail "in-bors: expected two in-Bors PRs, got: $out"
+  [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '.ready | length')" = 0 ] \
+    || fail "in-bors: queued PRs must not also be ready, got: $out"
+  out=$(run_bucket "$case_dir")
+  assert_contains "$out" "in-Bors (2)" "human output should title the in-Bors group"
+  assert_contains "$out" "https://github.com/Chamber-Hero/memberos/pull/401" \
+    "in-Bors should print the rollup URL"
+  pass "fm-pr-ready-bucket detects in-Bors from bors-ci-merge-queue author and queue comments"
+}
+
+test_stale_bors_comment_is_not_in_bors() {
+  local case_dir out
+  case_dir=$(make_case stale-bors)
+  write_page "$case_dir/page.toon" false "" \
+    "$(pr_json 403 "feat: unapproved" CONFLICTING main "$GREEN_CHECKS" "" APPROVED false "alice" "feat/x" false "This pull request was unapproved.")" \
+    "$(pr_json 404 "feat: unmergeable" CONFLICTING main "$GREEN_CHECKS" "" APPROVED false "alice" "feat/y" false "The latest upstream changes made this pull request unmergeable.")"
+  out=$(run_bucket "$case_dir" --json)
+  [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '.in_bors | length')" = 0 ] \
+    || fail "stale-bors: unapproved/unmergeable last comments must not be in-Bors, got: $out"
+  [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '.blocked | length')" = 2 ] \
+    || fail "stale-bors: those PRs should be blocked on conflicts, got: $out"
+  pass "fm-pr-ready-bucket ignores stale Bors unapproved and unmergeable comments"
+}
+
+test_omits_draft_release_and_pending() {
+  local case_dir out pending_checks
+  case_dir=$(make_case omit)
+  pending_checks="CI (Depot) / lint=queued;CI (Depot) / typecheck=success;CI (Depot) / build=success;CI (Depot) / guardrails=success;CI (Depot) / test=success;CI (Depot) / cli-test=success;CI (Depot) / quality=success;CI (Depot) / edge-test=success;PR Title Lint (Depot) / pr-title-lint=success;PR Body Lint (Depot) / pr-body-lint=success"
+  write_page "$case_dir/page.toon" false "" \
+    "$(pr_json 501 "feat: draft" MERGEABLE main "$GREEN_CHECKS" "" APPROVED true)" \
+    "$(pr_json 502 "chore(main): release 1.2.3" MERGEABLE main "$GREEN_CHECKS" "" APPROVED false "release-please[bot]" "release-please--branches--main")" \
+    "$(pr_json 503 "feat: still running" MERGEABLE main "$pending_checks")"
+  out=$(run_bucket "$case_dir" --json)
+  [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '[.ready,.blocked,.stacked,.in_bors | length] | add')" = 0 ] \
+    || fail "omit: drafts, release-please, and pending required CI should be omitted, got: $out"
+  pass "fm-pr-ready-bucket omits drafts, release-please, and pending required CI"
+}
+
+test_repo_override_and_read_only() {
+  local case_dir out
+  case_dir=$(make_case repo-override)
+  write_page "$case_dir/page.toon" false ""
+  out=$(run_bucket "$case_dir" --repo Example-Org/other --json)
+  [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '.repo')" = "Example-Org/other" ] \
+    || fail "repo-override: JSON should echo the requested repo, got: $out"
+  grep -F "Example-Org" "$case_dir/gh-axi.log" >/dev/null \
+    || fail "repo-override: GraphQL variables should name Example-Org"
+  grep -F "other" "$case_dir/gh-axi.log" >/dev/null \
+    || fail "repo-override: GraphQL variables should name the other repo"
+  if grep -Ei " merge | comment | review | edit | close | create " "$case_dir/gh-axi.log"; then
+    fail "repo-override: gh-axi write operations were invoked"
+  fi
+  pass "fm-pr-ready-bucket honors --repo and only reads through gh-axi graphql"
+}
+
+test_does_not_fetch_bors_host() {
+  local case_dir
+  case_dir=$(make_case no-bors-host)
+  write_page "$case_dir/page.toon" false ""
+  cat > "$case_dir/fakebin/curl" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$FM_TEST_CURL_LOG"
+echo "error: curl should not run" >&2
+exit 1
+SH
+  chmod +x "$case_dir/fakebin/curl"
+  : > "$case_dir/curl.log"
+  FM_TEST_CURL_LOG="$case_dir/curl.log" \
+  FM_TEST_GH_AXI_LOG="$case_dir/gh-axi.log" \
+  FM_TEST_TOON_FILE="$case_dir/page.toon" \
+  PATH="$case_dir/fakebin:$BASE_PATH" \
+    "$BUCKET" --json >/dev/null || fail "no-bors-host: GitHub listing failed"
+  if [ -s "$case_dir/curl.log" ]; then
+    fail "no-bors-host: curl ran: $(cat "$case_dir/curl.log")"
+  fi
+  if grep -F "bors.nbost.com" "$case_dir/gh-axi.log"; then
+    fail "no-bors-host: gh-axi was pointed at the Bors host"
+  fi
+  pass "fm-pr-ready-bucket lists from GitHub and does not scrape the Bors host"
+}
+
+test_empty_listing_prints_four_groups() {
+  local case_dir out
+  case_dir=$(make_case empty)
+  write_page "$case_dir/page.toon" false ""
+  out=$(run_bucket "$case_dir")
+  assert_contains "$out" "ready (0)" "empty listing should still print ready"
+  assert_contains "$out" "blocked (0)" "empty listing should still print blocked"
+  assert_contains "$out" "stacked (0)" "empty listing should still print stacked"
+  assert_contains "$out" "in-Bors (0)" "empty listing should still print in-Bors"
+  pass "fm-pr-ready-bucket prints all four groups when nothing matches"
+}
+
+test_help_and_bad_args
+test_missing_tools_refuse
+test_ready_pr
+test_blocked_reasons
+test_stacked_wins_over_conflicts
+test_in_bors_author_and_comment
+test_stale_bors_comment_is_not_in_bors
+test_omits_draft_release_and_pending
+test_repo_override_and_read_only
+test_does_not_fetch_bors_host
+test_empty_listing_prints_four_groups

--- a/tests/fm-pr-ready-bucket.test.sh
+++ b/tests/fm-pr-ready-bucket.test.sh
@@ -6,7 +6,7 @@
 #   (a) MERGEABLE main PR with required Depot + title/body lint green is ready
 #   (b) conflicts, red required CI, review-blocker, and CHANGES_REQUESTED block
 #   (c) base other than main is stacked, even when it also has conflicts
-#   (d) bors-ci-merge-queue author or queue comment is in-Bors
+#   (d) bors-ci-merge-queue author, queue comment, or Rollup created is in-Bors
 #   (e) drafts and release-please PRs targeting main are omitted
 #   (f) pending required CI is omitted rather than blocked or ready
 #   (g) default repo is Chamber-Hero/memberos; --repo overrides
@@ -230,14 +230,17 @@ test_in_bors_author_and_comment() {
   case_dir=$(make_case in-bors)
   write_page "$case_dir/page.toon" false "" \
     "$(pr_json 401 "Auto merge of #101" MERGEABLE main "$GREEN_CHECKS" "" APPROVED false "bors-ci-merge-queue" "tmp/bors" true "")" \
-    "$(pr_json 402 "feat: queued" MERGEABLE main "$GREEN_CHECKS" "" APPROVED false "alice" "feat/queued" false "Commit abc has been approved by cap. It is now in the [queue] for this repository.")"
+    "$(pr_json 402 "feat: queued" MERGEABLE main "$GREEN_CHECKS" "" APPROVED false "alice" "feat/queued" false "Commit abc has been approved by cap. It is now in the [queue] for this repository.")" \
+    "$(pr_json 405 "feat: rollup member" MERGEABLE main "$GREEN_CHECKS" "" APPROVED false "alice" "feat/rollup" false ":tada: Rollup created")"
   out=$(run_bucket "$case_dir" --json)
-  [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '.in_bors | length')" = 2 ] \
-    || fail "in-bors: expected two in-Bors PRs, got: $out"
+  [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '.in_bors | length')" = 3 ] \
+    || fail "in-bors: expected three in-Bors PRs, got: $out"
   [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '.ready | length')" = 0 ] \
     || fail "in-bors: queued PRs must not also be ready, got: $out"
+  printf '%s\n' "$out" | "$REAL_JQ" -e '.in_bors[] | select(.number==405)' >/dev/null \
+    || fail "in-bors: latest Rollup created comment must stay in-Bors, got: $out"
   out=$(run_bucket "$case_dir")
-  assert_contains "$out" "in-Bors (2)" "human output should title the in-Bors group"
+  assert_contains "$out" "in-Bors (3)" "human output should title the in-Bors group"
   assert_contains "$out" "https://github.com/Chamber-Hero/memberos/pull/401" \
     "in-Bors should print the rollup URL"
   pass "fm-pr-ready-bucket detects in-Bors from bors-ci-merge-queue author and queue comments"

--- a/tests/fm-pr-ready-bucket.test.sh
+++ b/tests/fm-pr-ready-bucket.test.sh
@@ -9,9 +9,11 @@
 #   (d) bors-ci-merge-queue author, queue comment, or Rollup created is in-Bors
 #   (e) drafts and release-please PRs targeting main are omitted
 #   (f) pending required CI is omitted rather than blocked or ready
-#   (g) default repo is Chamber-Hero/memberos; --repo overrides
+#   (g) default repo is Chamber-Hero/memberos; --repo/--base overrides
+#       require --required-check and use that list, not MemberOS defaults
 #   (h) the helper is read-only (no merge/comment/review) and does not
 #       scrape the Bors host
+#   (i) truncated labels, checks, or comments never classify as ready
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -85,8 +87,9 @@ import csv, json, sys
 path, has_next, cursor = sys.argv[1], sys.argv[2], sys.argv[3]
 prs = [json.loads(arg) for arg in sys.argv[4:]]
 keys = [
-    "author", "base", "bors_author", "bors_last", "checks", "draft",
-    "head", "labels", "mergeable", "number", "review", "title", "url",
+    "author", "base", "bors_author", "bors_last", "checks", "checks_truncated",
+    "comments_truncated", "draft", "head", "labels", "labels_truncated",
+    "mergeable", "number", "review", "title", "url",
 ]
 with open(path, "w", encoding="utf-8") as fh:
     fh.write(f"hasNextPage: {has_next}\n")
@@ -101,9 +104,12 @@ with open(path, "w", encoding="utf-8") as fh:
             "true" if pr.get("bors_author") else "false",
             pr.get("bors_last", ""),
             pr.get("checks", ""),
+            "true" if pr.get("checks_truncated") else "false",
+            "true" if pr.get("comments_truncated") else "false",
             "true" if pr.get("draft") else "false",
             pr.get("head", "feat/x"),
             pr.get("labels", ""),
+            "true" if pr.get("labels_truncated") else "false",
             pr.get("mergeable", "MERGEABLE"),
             pr.get("number", 1),
             pr.get("review", "APPROVED"),
@@ -128,10 +134,15 @@ pr_json() {
     --arg head "${10:-feat/x}" \
     --argjson bors_author "${11:-false}" \
     --arg bors_last "${12:-}" \
+    --argjson labels_truncated "${13:-false}" \
+    --argjson checks_truncated "${14:-false}" \
+    --argjson comments_truncated "${15:-false}" \
     '{
       number:$number, title:$title, mergeable:$mergeable, base:$base,
       checks:$checks, labels:$labels, review:$review, draft:$draft,
       author:$author, head:$head, bors_author:$bors_author, bors_last:$bors_last,
+      labels_truncated:$labels_truncated, checks_truncated:$checks_truncated,
+      comments_truncated:$comments_truncated,
       url:("https://github.com/Chamber-Hero/memberos/pull/" + ($number|tostring))
     }'
 }
@@ -146,6 +157,10 @@ test_help_and_bad_args() {
   expect_code 2 $? "--nope should be a usage error"
   "$BUCKET" --repo not-a-repo >/dev/null 2>&1
   expect_code 2 $? "malformed --repo should be a usage error"
+  "$BUCKET" --repo Example-Org/other >/dev/null 2>&1
+  expect_code 2 $? "--repo without --required-check should be a usage error"
+  "$BUCKET" --base develop >/dev/null 2>&1
+  expect_code 2 $? "--base without --required-check should be a usage error"
   pass "fm-pr-ready-bucket help and usage errors"
 }
 
@@ -278,7 +293,7 @@ test_repo_override_and_read_only() {
   local case_dir out
   case_dir=$(make_case repo-override)
   write_page "$case_dir/page.toon" false ""
-  out=$(run_bucket "$case_dir" --repo Example-Org/other --json)
+  out=$(run_bucket "$case_dir" --repo Example-Org/other --required-check "CI (Depot) / lint" --json)
   [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '.repo')" = "Example-Org/other" ] \
     || fail "repo-override: JSON should echo the requested repo, got: $out"
   grep -F "Example-Org" "$case_dir/gh-axi.log" >/dev/null \
@@ -289,6 +304,52 @@ test_repo_override_and_read_only() {
     fail "repo-override: gh-axi write operations were invoked"
   fi
   pass "fm-pr-ready-bucket honors --repo and only reads through gh-axi graphql"
+}
+
+test_required_check_override_replaces_memberos_list() {
+  local case_dir out custom_red
+  case_dir=$(make_case required-check)
+  custom_red="${GREEN_CHECKS};other-ci=failure"
+  write_page "$case_dir/page.toon" false "" \
+    "$(pr_json 601 "feat: other policy" MERGEABLE main "$custom_red")"
+  out=$(run_bucket "$case_dir" --repo Example-Org/other --required-check other-ci --json)
+  [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '.ready | length')" = 0 ] \
+    || fail "required-check: target red check must not be ready, got: $out"
+  [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '.blocked | length')" = 1 ] \
+    || fail "required-check: target red check should be blocked, got: $out"
+  printf '%s\n' "$out" | "$REAL_JQ" -e '
+    .blocked[] | select(.number==601) | .reasons[] | test("red required CI.*other-ci")
+  ' >/dev/null || fail "required-check: should name the override check, got: $out"
+  out=$(run_bucket "$case_dir" --json)
+  [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '.ready | length')" = 1 ] \
+    || fail "required-check: MemberOS defaults should still treat Depot-green as ready, got: $out"
+  pass "fm-pr-ready-bucket uses --required-check instead of the MemberOS list"
+}
+
+test_truncated_nested_state_is_not_ready() {
+  local case_dir out
+  case_dir=$(make_case truncated)
+  write_page "$case_dir/page.toon" false "" \
+    "$(pr_json 701 "feat: labels truncated" MERGEABLE main "$GREEN_CHECKS" "" APPROVED false alice feat/x false "" true false false)" \
+    "$(pr_json 702 "feat: checks truncated" MERGEABLE main "$GREEN_CHECKS" "" APPROVED false alice feat/y false "" false true false)" \
+    "$(pr_json 703 "feat: comments truncated" MERGEABLE main "$GREEN_CHECKS" "" APPROVED false alice feat/z false "" false false true)" \
+    "$(pr_json 704 "feat: blocker still blocks" MERGEABLE main "$GREEN_CHECKS" "review-blocker" APPROVED false alice feat/b false "" true false false)" \
+    "$(pr_json 705 "feat: queued despite truncation" MERGEABLE main "$GREEN_CHECKS" "" APPROVED false alice feat/q false "Rollup created" false false true)"
+  out=$(run_bucket "$case_dir" --json)
+  [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '.ready | length')" = 0 ] \
+    || fail "truncated: no truncated PR should be ready, got: $out"
+  [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '.blocked | length')" = 4 ] \
+    || fail "truncated: expected four blocked PRs, got: $out"
+  [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '.in_bors | length')" = 1 ] \
+    || fail "truncated: latest Bors comment should still be in-Bors, got: $out"
+  printf '%s\n' "$out" | "$REAL_JQ" -e '
+    (.blocked[] | select(.number==701) | .reasons | index("incomplete GitHub state")) != null
+    and (.blocked[] | select(.number==702) | .reasons | index("incomplete GitHub state")) != null
+    and (.blocked[] | select(.number==703) | .reasons | index("incomplete GitHub state")) != null
+    and (.blocked[] | select(.number==704) | .reasons | index("review-blocker")) != null
+    and (.in_bors[] | select(.number==705))
+  ' >/dev/null || fail "truncated: missing expected buckets/reasons, got: $out"
+  pass "fm-pr-ready-bucket refuses to mark truncated nested GitHub state ready"
 }
 
 test_does_not_fetch_bors_host() {
@@ -338,5 +399,7 @@ test_in_bors_author_and_comment
 test_stale_bors_comment_is_not_in_bors
 test_omits_draft_release_and_pending
 test_repo_override_and_read_only
+test_required_check_override_replaces_memberos_list
+test_truncated_nested_state_is_not_ready
 test_does_not_fetch_bors_host
 test_empty_listing_prints_four_groups

--- a/tests/fm-pr-ready-bucket.test.sh
+++ b/tests/fm-pr-ready-bucket.test.sh
@@ -13,7 +13,8 @@
 #       require --required-check and use that list, not MemberOS defaults
 #   (h) the helper is read-only (no merge/comment/review) and does not
 #       scrape the Bors host
-#   (i) truncated labels, checks, or comments never classify as ready
+#   (i) truncated labels, checks, or comments are paged to completion
+#       before classification
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -49,6 +50,32 @@ case " $* " in
 esac
 case "${1:-} ${2:-}" in
   "api POST")
+    case " $* " in
+      *ReadyBucketLabels*)
+        if [ ! -f "${FM_TEST_CASE_DIR:-}/labels.toon" ]; then
+          echo "error: unexpected labels follow-up: $*" >&2
+          exit 1
+        fi
+        cat "${FM_TEST_CASE_DIR}/labels.toon"
+        exit 0
+        ;;
+      *ReadyBucketChecks*)
+        if [ ! -f "${FM_TEST_CASE_DIR:-}/checks.toon" ]; then
+          echo "error: unexpected checks follow-up: $*" >&2
+          exit 1
+        fi
+        cat "${FM_TEST_CASE_DIR}/checks.toon"
+        exit 0
+        ;;
+      *ReadyBucketComments*)
+        if [ ! -f "${FM_TEST_CASE_DIR:-}/comments.toon" ]; then
+          echo "error: unexpected comments follow-up: $*" >&2
+          exit 1
+        fi
+        cat "${FM_TEST_CASE_DIR}/comments.toon"
+        exit 0
+        ;;
+    esac
     cat "$FM_TEST_TOON_FILE"
     exit 0
     ;;
@@ -65,6 +92,7 @@ run_bucket() {
   shift
   FM_TEST_GH_AXI_LOG="$case_dir/gh-axi.log" \
   FM_TEST_TOON_FILE="$case_dir/page.toon" \
+  FM_TEST_CASE_DIR="$case_dir" \
   PATH="$case_dir/fakebin:$BASE_PATH" \
     "$BUCKET" "$@"
 }
@@ -87,9 +115,10 @@ import csv, json, sys
 path, has_next, cursor = sys.argv[1], sys.argv[2], sys.argv[3]
 prs = [json.loads(arg) for arg in sys.argv[4:]]
 keys = [
-    "author", "base", "bors_author", "bors_last", "checks", "checks_truncated",
-    "comments_truncated", "draft", "head", "labels", "labels_truncated",
-    "mergeable", "number", "review", "title", "url",
+    "author", "base", "bors_author", "bors_last", "checks", "checks_cursor",
+    "checks_truncated", "comments_cursor", "comments_truncated", "draft",
+    "head", "labels", "labels_cursor", "labels_truncated", "mergeable",
+    "number", "review", "title", "url",
 ]
 with open(path, "w", encoding="utf-8") as fh:
     fh.write(f"hasNextPage: {has_next}\n")
@@ -104,11 +133,14 @@ with open(path, "w", encoding="utf-8") as fh:
             "true" if pr.get("bors_author") else "false",
             pr.get("bors_last", ""),
             pr.get("checks", ""),
+            pr.get("checks_cursor", ""),
             "true" if pr.get("checks_truncated") else "false",
+            pr.get("comments_cursor", ""),
             "true" if pr.get("comments_truncated") else "false",
             "true" if pr.get("draft") else "false",
             pr.get("head", "feat/x"),
             pr.get("labels", ""),
+            pr.get("labels_cursor", ""),
             "true" if pr.get("labels_truncated") else "false",
             pr.get("mergeable", "MERGEABLE"),
             pr.get("number", 1),
@@ -137,12 +169,17 @@ pr_json() {
     --argjson labels_truncated "${13:-false}" \
     --argjson checks_truncated "${14:-false}" \
     --argjson comments_truncated "${15:-false}" \
+    --arg labels_cursor "${16:-}" \
+    --arg checks_cursor "${17:-}" \
+    --arg comments_cursor "${18:-}" \
     '{
       number:$number, title:$title, mergeable:$mergeable, base:$base,
       checks:$checks, labels:$labels, review:$review, draft:$draft,
       author:$author, head:$head, bors_author:$bors_author, bors_last:$bors_last,
       labels_truncated:$labels_truncated, checks_truncated:$checks_truncated,
       comments_truncated:$comments_truncated,
+      labels_cursor:$labels_cursor, checks_cursor:$checks_cursor,
+      comments_cursor:$comments_cursor,
       url:("https://github.com/Chamber-Hero/memberos/pull/" + ($number|tostring))
     }'
 }
@@ -326,30 +363,110 @@ test_required_check_override_replaces_memberos_list() {
   pass "fm-pr-ready-bucket uses --required-check instead of the MemberOS list"
 }
 
-test_truncated_nested_state_is_not_ready() {
+test_truncated_labels_are_paged() {
   local case_dir out
-  case_dir=$(make_case truncated)
+  case_dir=$(make_case truncated-labels)
   write_page "$case_dir/page.toon" false "" \
-    "$(pr_json 701 "feat: labels truncated" MERGEABLE main "$GREEN_CHECKS" "" APPROVED false alice feat/x false "" true false false)" \
-    "$(pr_json 702 "feat: checks truncated" MERGEABLE main "$GREEN_CHECKS" "" APPROVED false alice feat/y false "" false true false)" \
-    "$(pr_json 703 "feat: comments truncated" MERGEABLE main "$GREEN_CHECKS" "" APPROVED false alice feat/z false "" false false true)" \
-    "$(pr_json 704 "feat: blocker still blocks" MERGEABLE main "$GREEN_CHECKS" "review-blocker" APPROVED false alice feat/b false "" true false false)" \
-    "$(pr_json 705 "feat: queued despite truncation" MERGEABLE main "$GREEN_CHECKS" "" APPROVED false alice feat/q false "Rollup created" false false true)"
+    "$(pr_json 701 "feat: labels truncated" MERGEABLE main "$GREEN_CHECKS" "" APPROVED false alice feat/x false "" true false false lab1)"
+  cat > "$case_dir/labels.toon" <<'EOF'
+hasNextPage: false
+endCursor: ""
+names: "review-blocker"
+EOF
   out=$(run_bucket "$case_dir" --json)
   [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '.ready | length')" = 0 ] \
-    || fail "truncated: no truncated PR should be ready, got: $out"
-  [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '.blocked | length')" = 4 ] \
-    || fail "truncated: expected four blocked PRs, got: $out"
-  [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '.in_bors | length')" = 1 ] \
-    || fail "truncated: latest Bors comment should still be in-Bors, got: $out"
+    || fail "truncated-labels: later review-blocker must not be ready, got: $out"
   printf '%s\n' "$out" | "$REAL_JQ" -e '
-    (.blocked[] | select(.number==701) | .reasons | index("incomplete GitHub state")) != null
-    and (.blocked[] | select(.number==702) | .reasons | index("incomplete GitHub state")) != null
-    and (.blocked[] | select(.number==703) | .reasons | index("incomplete GitHub state")) != null
-    and (.blocked[] | select(.number==704) | .reasons | index("review-blocker")) != null
-    and (.in_bors[] | select(.number==705))
-  ' >/dev/null || fail "truncated: missing expected buckets/reasons, got: $out"
-  pass "fm-pr-ready-bucket refuses to mark truncated nested GitHub state ready"
+    .blocked[] | select(.number==701) | .reasons | index("review-blocker")
+  ' >/dev/null || fail "truncated-labels: paged label should block, got: $out"
+  grep -F "ReadyBucketLabels" "$case_dir/gh-axi.log" >/dev/null \
+    || fail "truncated-labels: should page remaining labels through GraphQL"
+  pass "fm-pr-ready-bucket pages truncated labels before classifying"
+}
+
+test_truncated_checks_are_paged() {
+  local case_dir out missing_edge
+  case_dir=$(make_case truncated-checks)
+  missing_edge="CI (Depot) / lint=success;CI (Depot) / typecheck=success;CI (Depot) / build=success;CI (Depot) / guardrails=success;CI (Depot) / test=success;CI (Depot) / cli-test=success;CI (Depot) / quality=success;PR Title Lint (Depot) / pr-title-lint=success;PR Body Lint (Depot) / pr-body-lint=success"
+  write_page "$case_dir/page.toon" false "" \
+    "$(pr_json 702 "feat: checks truncated" MERGEABLE main "$missing_edge" "" APPROVED false alice feat/y false "" false true false "" chk1)"
+  cat > "$case_dir/checks.toon" <<'EOF'
+hasNextPage: false
+endCursor: ""
+checks: CI (Depot) / edge-test=success
+EOF
+  out=$(run_bucket "$case_dir" --json)
+  [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '.ready | length')" = 1 ] \
+    || fail "truncated-checks: completed green required checks should be ready, got: $out"
+  [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '.ready[0].number')" = 702 ] \
+    || fail "truncated-checks: expected PR 702 ready, got: $out"
+  grep -F "ReadyBucketChecks" "$case_dir/gh-axi.log" >/dev/null \
+    || fail "truncated-checks: should page remaining checks through GraphQL"
+
+  cat > "$case_dir/checks.toon" <<'EOF'
+hasNextPage: false
+endCursor: ""
+checks: CI (Depot) / edge-test=failure
+EOF
+  : > "$case_dir/gh-axi.log"
+  out=$(run_bucket "$case_dir" --json)
+  [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '.ready | length')" = 0 ] \
+    || fail "truncated-checks: later red required check must not be ready, got: $out"
+  printf '%s\n' "$out" | "$REAL_JQ" -e '
+    .blocked[] | select(.number==702) | .reasons[] | test("red required CI.*edge-test")
+  ' >/dev/null || fail "truncated-checks: paged red check should block, got: $out"
+  pass "fm-pr-ready-bucket pages truncated checks before classifying"
+}
+
+test_truncated_comments_are_paged() {
+  local case_dir out
+  case_dir=$(make_case truncated-comments)
+  write_page "$case_dir/page.toon" false "" \
+    "$(pr_json 703 "feat: comments truncated" MERGEABLE main "$GREEN_CHECKS" "" APPROVED false alice feat/z false "" false false true "" "" cmt1)"
+  cat > "$case_dir/comments.toon" <<'EOF'
+hasPreviousPage: false
+startCursor: ""
+bors_last: ":tada: Rollup created"
+EOF
+  out=$(run_bucket "$case_dir" --json)
+  [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '.in_bors | length')" = 1 ] \
+    || fail "truncated-comments: older Rollup created should be in-Bors, got: $out"
+  [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '.ready | length')" = 0 ] \
+    || fail "truncated-comments: queued PR must not also be ready, got: $out"
+  grep -F "ReadyBucketComments" "$case_dir/gh-axi.log" >/dev/null \
+    || fail "truncated-comments: should page older comments through GraphQL"
+
+  cat > "$case_dir/comments.toon" <<'EOF'
+hasPreviousPage: false
+startCursor: ""
+bors_last: ""
+EOF
+  : > "$case_dir/gh-axi.log"
+  out=$(run_bucket "$case_dir" --json)
+  [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '.ready | length')" = 1 ] \
+    || fail "truncated-comments: completed comments with no Bors should be ready, got: $out"
+  [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '.in_bors | length')" = 0 ] \
+    || fail "truncated-comments: no Bors comment should not be in-Bors, got: $out"
+  pass "fm-pr-ready-bucket pages truncated comments before classifying"
+}
+
+test_truncated_state_stays_blocked_when_still_incomplete() {
+  local case_dir out
+  case_dir=$(make_case still-truncated)
+  write_page "$case_dir/page.toon" false "" \
+    "$(pr_json 706 "feat: still truncated" MERGEABLE main "$GREEN_CHECKS" "" APPROVED false alice feat/t false "" false true false "" chk1)"
+  cat > "$case_dir/checks.toon" <<'EOF'
+hasNextPage: true
+endCursor: chk2
+checks: extra=success
+EOF
+  out=$(FM_PR_READY_BUCKET_MAX_NESTED_PAGES=1 run_bucket "$case_dir" --json)
+  [ "$(printf '%s\n' "$out" | "$REAL_JQ" -r '.ready | length')" = 0 ] \
+    || fail "still-truncated: incomplete checks must not be ready, got: $out"
+  printf '%s\n' "$out" | "$REAL_JQ" -e '
+    .blocked[] | select(.number==706) | .reasons | index("incomplete GitHub state")
+  ' >/dev/null || fail "still-truncated: should stay blocked, got: $out"
+  pass "fm-pr-ready-bucket keeps still-truncated nested state out of ready"
 }
 
 test_does_not_fetch_bors_host() {
@@ -400,6 +517,9 @@ test_stale_bors_comment_is_not_in_bors
 test_omits_draft_release_and_pending
 test_repo_override_and_read_only
 test_required_check_override_replaces_memberos_list
-test_truncated_nested_state_is_not_ready
+test_truncated_labels_are_paged
+test_truncated_checks_are_paged
+test_truncated_comments_are_paged
+test_truncated_state_stays_blocked_when_still_incomplete
 test_does_not_fetch_bors_host
 test_empty_listing_prints_four_groups


### PR DESCRIPTION
## Intent

Add a read-only helper (script + tests) that lists MemberOS open PRs for the next bors rollup.

Ready: MERGEABLE, base main, not draft, not release/release-please, required Depot + title/body lint green, no review-blocker / CHANGES_REQUESTED, not stacked.
Blocked: conflicts, red required CI, review-blocker, CHANGES_REQUESTED.
Stacked: base is not main.
In-Bors: open rollup PRs / approved queue if detectable from GitHub comments or rollup PRs authored by bors-ci-merge-queue. Use the latest Bors bot comment so a later unapproved or unmergeable comment is not treated as still queued.

Do not build a dashboard, watcher, or control plane. Do not scrape bors.nbost.com as the ready source. GitHub is the ready-bucket. Print concise groups + full PR URLs.

Ship a no-mistakes PR. Do not merge.

## What Changed
- Add `bin/fm-pr-ready-bucket.sh`, a read-only GitHub listing of open PRs (default `Chamber-Hero/memberos`) grouped as ready, blocked, stacked, and in-Bors for the next bors rollup, with full PR URLs and optional `--json`.
- Classify ready vs blocked from mergeability, required Depot + title/body lint, review-blocker / `CHANGES_REQUESTED`, drafts, and release-please; treat non-`--base` PRs as stacked; detect in-Bors from `bors-ci-merge-queue` rollups and the latest Bors comment only.
- Cover the classifier with `tests/fm-pr-ready-bucket.test.sh` (pr-forge family) and document the command in `docs/scripts.md`.

## Risk Assessment

✅ Low: Read-only listing helper with a verified latest-comment Rollup created match and no write or Bors-scrape paths.

## Testing

Ran the focused fm-pr-ready-bucket test file (all cases green), then executed the real CLI against Chamber-Hero/memberos and spot-checked ready, blocked, and stacked PRs on GitHub; the helper printed grouped full URLs and matched live PR state, with no dashboard or Bors-host scrape.

<details>
<summary>Evidence: Live ready-bucket listing (human)</summary>

<code>ready-bucket Chamber-Hero/memberos base main&#10;&#10;ready (9)&#10;https://github.com/Chamber-Hero/memberos/pull/5428&#10;https://github.com/Chamber-Hero/memberos/pull/5425&#10;https://github.com/Chamber-Hero/memberos/pull/5389&#10;https://github.com/Chamber-Hero/memberos/pull/5385&#10;https://github.com/Chamber-Hero/memberos/pull/5360&#10;https://github.com/Chamber-Hero/memberos/pull/5349&#10;https://github.com/Chamber-Hero/memberos/pull/5259&#10;https://github.com/Chamber-Hero/memberos/pull/5223&#10;https://github.com/Chamber-Hero/memberos/pull/4988&#10;&#10;blocked (38)&#10;https://github.com/Chamber-Hero/memberos/pull/5391 red required CI: CI (Depot) / typecheck, CI (Depot) / build, CI (Depot) / test, CI (Depot) / cli-test, CI (Depot) / quality&#10;https://github.com/Chamber-Hero/memberos/pull/5388 conflicts&#10;https://github.com/Chamber-Hero/memberos/pull/5387 review-blocker; CHANGES_REQUESTED&#10;...&#10;stacked (9)&#10;https://github.com/Chamber-Hero/memberos/pull/5396 base feat/5378-lifecycle-onboarding-engagement-service&#10;...&#10;in-Bors (0)</code>

```text
ready-bucket  Chamber-Hero/memberos  base main

ready (9)
https://github.com/Chamber-Hero/memberos/pull/5428
https://github.com/Chamber-Hero/memberos/pull/5425
https://github.com/Chamber-Hero/memberos/pull/5389
https://github.com/Chamber-Hero/memberos/pull/5385
https://github.com/Chamber-Hero/memberos/pull/5360
https://github.com/Chamber-Hero/memberos/pull/5349
https://github.com/Chamber-Hero/memberos/pull/5259
https://github.com/Chamber-Hero/memberos/pull/5223
https://github.com/Chamber-Hero/memberos/pull/4988

blocked (38)
https://github.com/Chamber-Hero/memberos/pull/5391  red required CI: CI (Depot) / typecheck, CI (Depot) / build, CI (Depot) / test, CI (Depot) / cli-test, CI (Depot) / quality
https://github.com/Chamber-Hero/memberos/pull/5388  conflicts
https://github.com/Chamber-Hero/memberos/pull/5387  review-blocker; CHANGES_REQUESTED
https://github.com/Chamber-Hero/memberos/pull/5329  conflicts
https://github.com/Chamber-Hero/memberos/pull/5312  conflicts; red required CI: CI (Depot) / edge-test
https://github.com/Chamber-Hero/memberos/pull/5310  red required CI: CI (Depot) / quality
https://github.com/Chamber-Hero/memberos/pull/5285  conflicts
https://github.com/Chamber-Hero/memberos/pull/5265  conflicts
https://github.com/Chamber-Hero/memberos/pull/5260  conflicts
https://github.com/Chamber-Hero/memberos/pull/5255  conflicts
https://github.com/Chamber-Hero/memberos/pull/5248  conflicts; red required CI: CI (Depot) / typecheck
https://github.com/Chamber-Hero/memberos/pull/5247  conflicts
https://github.com/Chamber-Hero/memberos/pull/5246  conflicts; red required CI: CI (Depot) / test
https://github.com/Chamber-Hero/memberos/pull/5235  conflicts
https://github.com/Chamber-Hero/memberos/pull/5227  conflicts
https://github.com/Chamber-Hero/memberos/pull/5225  conflicts; red required CI: CI (Depot) / guardrails, PR Title Lint (Depot) / pr-title-lint
https://github.com/Chamber-Hero/memberos/pull/5189  CHANGES_REQUESTED
https://github.com/Chamber-Hero/memberos/pull/5182  conflicts
https://github.com/Chamber-Hero/memberos/pull/5091  conflicts
https://github.com/Chamber-Hero/memberos/pull/5086  conflicts
https://github.com/Chamber-Hero/memberos/pull/5002  conflicts
https://github.com/Chamber-Hero/memberos/pull/4909  conflicts
https://github.com/Chamber-Hero/memberos/pull/4908  conflicts
https://github.com/Chamber-Hero/memberos/pull/4905  conflicts
https://github.com/Chamber-Hero/memberos/pull/4904  conflicts
https://github.com/Chamber-Hero/memberos/pull/4903  conflicts; red required CI: CI (Depot) / test
https://github.com/Chamber-Hero/memberos/pull/4901  conflicts
https://github.com/Chamber-Hero/memberos/pull/4894  conflicts
https://github.com/Chamber-Hero/memberos/pull/4881  conflicts; red required CI: CI (Depot) / quality
https://github.com/Chamber-Hero/memberos/pull/4864  conflicts
https://github.com/Chamber-Hero/memberos/pull/4861  conflicts; CHANGES_REQUESTED
https://github.com/Chamber-Hero/memberos/pull/4859  conflicts
https://github.com/Chamber-Hero/memberos/pull/4856  conflicts; red required CI: CI (Depot) / quality
https://github.com/Chamber-Hero/memberos/pull/4842  conflicts
https://github.com/Chamber-Hero/memberos/pull/4837  conflicts; red required CI: CI (Depot) / guardrails
https://github.com/Chamber-Hero/memberos/pull/4833  conflicts
https://github.com/Chamber-Hero/memberos/pull/4825  conflicts
https://github.com/Chamber-Hero/memberos/pull/4475  conflicts; CHANGES_REQUESTED

stacked (9)
https://github.com/Chamber-Hero/memberos/pull/5396  base feat/5378-lifecycle-onboarding-engagement-service
https://github.com/Chamber-Hero/memberos/pull/5395  base fix/4810-4809-events-attended-checkin-driven
https://github.com/Chamber-Hero/memberos/pull/5393  base fix/4810-4809-events-attended-checkin-driven
https://github.com/Chamber-Hero/memberos/pull/5353  base feat/2181-tier-upgrade-downgrade-proration
https://github.com/Chamber-Hero/memberos/pull/5283  base feat/2174-feature-entitlement-catalog
https://github.com/Chamber-Hero/memberos/pull/5282  base feat/2178-bring-your-own-ai
https://github.com/Chamber-Hero/memberos/pull/5281  base feat/2174-feature-entitlement-catalog
https://github.com/Chamber-Hero/memberos/pull/5279  base feat/2174-feature-entitlement-catalog
https://github.com/Chamber-Hero/memberos/pull/5264  base feat/2174-feature-entitlement-catalog

in-Bors (0)
```
</details>
<details>
<summary>Evidence: Live ready-bucket JSON groups</summary>

`{"repo":"Chamber-Hero/memberos","base":"main","ready":9,"blocked":38,"stacked":9,"in_bors":0}`

```text
{
  "ready": [
    {
      "number": 5428,
      "url": "https://github.com/Chamber-Hero/memberos/pull/5428",
      "title": "ci(db-security): retire PR-time live types-drift (#5413)",
      "base": "main",
      "reasons": []
    },
    {
      "number": 5425,
      "url": "https://github.com/Chamber-Hero/memberos/pull/5425",
      "title": "fix(comms): skip border stamping on pasted layout tables (#5415)",
      "base": "main",
      "reasons": []
    },
    {
      "number": 5389,
      "url": "https://github.com/Chamber-Hero/memberos/pull/5389",
      "title": "fix(members): org-scope ECP billing queries and re-normalize omitted economic pillar",
      "base": "main",
      "reasons": []
    },
    {
      "number": 5385,
      "url": "https://github.com/Chamber-Hero/memberos/pull/5385",
      "title": "fix(webhook): scope referral confirm update to org_id",
      "base": "main",
      "reasons": []
    },
    {
      "number": 5360,
      "url": "https://github.com/Chamber-Hero/memberos/pull/5360",
      "title": "feat(guardrails): extend business-data gate to UPDATE and DELETE",
      "base": "main",
      "reasons": []
    },
    {
      "number": 5349,
      "url": "https://github.com/Chamber-Hero/memberos/pull/5349",
      "title": "fix(events): keep the kiosk alive through the iOS keyboard, rebuild its layout (#5348)",
      "base": "main",
      "reasons": []
    },
    {
      "number": 5259,
      "url": "https://github.com/Chamber-Hero/memberos/pull/5259",
      "title": "feat(events): wire event process onto dispatch-survey (#2275)",
      "base": "main",
      "reasons": []
    },
    {
      "number": 5223,
      "url": "https://github.com/Chamber-Hero/memberos/pull/5223",
      "title": "feat(email): external reputation / blocklist monitoring",
      "base": "main",
      "reasons": []
    },
    {
      "number": 4988,
      "url": "https://github.com/Chamber-Hero/memberos/pull/4988",
      "title": "chore(help): refresh What's new (memberos-v0.3.26)",
      "base": "main",
      "reasons": []
    }
  ],
  "blocked": [
    {
      "number": 5391,
      "url": "https://github.com/Chamber-Hero/memberos/pull/5391",
      "title": "feat(members): re-model lifecycle stage as Onboarding -> Engagement -> Service (#5378)",
      "base": "main",
      "reasons": [
        "red required CI: CI (Depot) / typecheck, CI (Depot) / build, CI (Depot) / test, CI (Depot) / cli-test, CI (Depot) / quality"
      ]
    },
    {
      "number": 5388,
      "url": "https://github.com/Chamber-Hero/memberos/pull/5388",
      "title": "fix: wire Referral Success to live member_referrals aggregate",
      "base": "main",
      "reasons": [
        "conflicts"
      ]
    },
    {
      "number": 5387,
      "url": "https://github.com/Chamber-Hero/memberos/pull/5387",
      "title": "fix(webhook): wire follow-through and connector badge to TribeSpring signals",
      "base": "main",
      "reasons": [
        "review-blocker",
        "CHANGES_REQUESTED"
      ]
    },
    {
      "number": 5329,
      "url": "https://github.com/Chamber-Hero/memberos/pull/5329",
      "title": "feat(events): rebalance the event editor's right column (#5324)",
      "base": "main",
      "reasons": [
        "conflicts"
      ]
    },
    {
      "number": 5312,
      "url": "https://github.com/Chamber-Hero/memberos/pull/5312",
      "title": "feat(events): org-owned roles, volunteers, living checklists, T-7/T-2/T-1",
      "base": "main",
      "reasons": [
        "conflicts",
        "red required CI: CI (Depot) / edge-test"
      ]
    },
    {
      "number": 5310,
      "url": "https://github.com/Chamber-Hero/memberos/pull/5310",
      "title": "feat(events): event follow-up capture, staff PIN, three-question feedback",
      "base": "main",
      "reasons": [
        "red required CI: CI (Depot) / quality"
      ]
    },
    {
      "number": 5285,
      "url": "https://github.com/Chamber-Hero/memberos/pull/5285",
      "title": "feat(billing): donations, configurable fees, and round-up checkout",
      "base": "main",
      "reasons": [
        "conflicts"
      ]
    },
    {
      "number": 5265,
      "url": "https://github.com/Chamber-Hero/memberos/pull/5265",
      "title": "feat(crm): decline-with-reason flow + decline comms with alternatives",
      "base": "main",
      "reasons": [
        "conflicts"
      ]
    },
    {
      "number": 5260,
      "url": "https://github.com/Chamber-Hero/memberos/pull/5260",
      "title": "feat(surveys): add airtable-style response grid and nps/rating roll-ups (#2276)",
      "base": "main",
      "reasons": [
        "conflicts"
      ]
    },
    {
      "number": 5255,
      "url": "https://github.com/Chamber-Hero/memberos/pull/5255",
      "title": "feat(journeys): add send_survey journey action (#2274)",
      "base": "main",
      "reasons": [
        "conflicts"
      ]
    },
    {
      "number": 5248,
      "url": "https://github.com/Chamber-Hero/memberos/pull/5248",
      "title": "feat(comms): event-qualifier audience dimension — registered/not/canceled (#2407)",
      "base": "main",
      "reasons": [
        "conflicts",
        "red required CI: CI (Depot) / typecheck"
      ]
    },
    {
      "number": 5247,
      "url": "https://github.com/Chamber-Hero/memberos/pull/5247",
      "title": "feat(ai): bring-your-own-AI connection for Enterprise orgs (#2178)",
      "base": "main",
      "reasons": [
        "conflicts"
      ]
    },
    {
      "number": 5246,
      "url": "https://github.com/Chamber-Hero/memberos/pull/5246",
      "title": "feat(billing): tier change upgrade/downgrade with proration & effective dating (#2181)",
      "base": "main",
      "reasons": [
        "conflicts",
        "red required CI: CI (Depot) / test"
      ]
    },
    {
      "number": 5235,
      "url": "https://github.com/Chamber-Hero/memberos/pull/5235",
      "title": "refactor(events): de-clutter events tabs and gate signature events (#2217)",
      "base": "main",
      "reasons": [
        "conflicts"
      ]
    },
    {
      "number": 5227,
      "url": "https://github.com/Chamber-Hero/memberos/pull/5227",
      "title": "SEO/perf/a11y fixes for the public website builder (#2235)",
      "base": "main",
      "reasons": [
        "conflicts"
      ]
    },
    {
      "number": 5225,
      "url": "https://github.com/Chamber-Hero/memberos/pull/5225",
      "title": "API phase 3: outbound customer webhooks (signed + retry + delivery log) (#2332)",
      "base": "main",
      "reasons": [
        "conflicts",
        "red required CI: CI (Depot) / guardrails, PR Title Lint (Depot) / pr-title-lint"
      ]
    },
    {
      "number": 5189,
      "url": "https://github.com/Chamber-Hero/memberos/pull/5189",
      "title": "docs(nav): v1 launch menu directive",
      "base": "main",
      "reasons": [
        "CHANGES_REQUESTED"
      ]
    },
    {
      "number": 5182,
      "url": "https://github.com/Chamber-Hero/memberos/pull/5182",
      "title": "fix(portal): route free event registration through public_register_for_event (#4741)",
      "base": "main",
      "reasons": [
        "conflicts"
      ]
    },
    {
      "number": 5091,
      "url": "https://github.com/Chamber-Hero/memberos/pull/5091",
      "title": "ci(hermetic): always run db-hermetic so it can become a required check",
      "base": "main",
      "reasons": [
        "conflicts"
      ]
    },
    {
      "number": 5086,
      "url": "https://github.com/Chamber-Hero/memberos/pull/5086",
      "title": "feat(guardrails): semgrep ratchet, and the first full-tree walk that ever ran",
      "base": "main",
      "reasons": [
        "conflicts"
      ]
    },
    {
      "number": 5002,
      "url": "https://github.com/Chamber-Hero/memberos/pull/5002",
      "title": "fix(crm): populate staff attribution across tasks, touchpoints and interactions",
      "base": "main",
      "reasons": [
        "conflicts"
      ]
    },
    {
      "number": 4909,
      "url": "https://github.com/Chamber-Hero/memberos/pull/4909",
      "title": "fix(crm): retire CRMQuickAddButton, the never-mounted Schedule Touchpoint dead end",
      "base": "main",
      "reasons": [
        "conflicts"
      ]
    },
    {
      "number": 4908,
      "url": "https://github.com/Chamber-Hero/memberos/pull/4908",
      "title": "feat(crm): restore org-wide Touchpoints, Tasks, and Comments tabs",
      "base": "main",
      "reasons": [
        "conflicts"
      ]
    },
    {
      "number": 4905,
      "url": "https://github.com/Chamber-Hero/memberos/pull/4905",
      "title": "feat(crm): restore CRMStaffWorkload onto the CRM Activity tab",
      "base": "main",
      "reasons": [
        "conflicts"
      ]
    },
    {
      "number": 4904,
      "url": "https://github.com/Chamber-Hero/memberos/pull/4904",
      "title": "chore: confirm B3/B4/B7 superseded status on #4880, retire what genuinely is",
      "base": "main",
      "reasons": [
        "conflicts"
      ]
    },
    {
      "number": 4903,
      "url": "https://github.com/Chamber-Hero/memberos/pull/4903",
      "title": "fix(crm,comms): restore unreachable CSV export, bulk select-all, audience redirect",
      "base": "main",
      "reasons": [
        "conflicts",
        "red required CI: CI (Depot) / test"
      ]
    },
    {
      "number": 4901,
      "url": "https://github.com/Chamber-Hero/memberos/pull/4901",
      "title": "feat(crm): restore org-wide Tasks, Follow-ups and Feedback views",
      "base": "main",
      "reasons": [
        "conflicts"
      ]
    },
    {
      "number": 4894,
      "url": "https://github.com/Chamber-Hero/memberos/pull/4894",
      "title": "feat(pr-review): block merges on any vendor BLOCKER, not just consensus",
      "base": "main",
      "reasons": [
        "conflicts"
      ]
    },
    {
      "number": 4881,
      "url": "https://github.com/Chamber-Hero/memberos/pull/4881",
      "title": "feat: adopt shared onboarding shell across entry surfaces",
      "base": "main",
      "reasons": [
        "conflicts",
        "red required CI: CI (Depot) / quality"
      ]
    },
    {
      "number": 4864,
      "url": "https://github.com/Chamber-Hero/memberos/pull/4864",
      "title": "chore(arch): park CRM cluster into incubator [#2247]",
      "base": "main",
      "reasons": [
        "conflicts"
      ]
    },
    {
      "number": 4861,
      "url": "https://github.com/Chamber-Hero/memberos/pull/4861",
      "title": "feat(mailbox): scaffold OAuth connect, signed state, token refresh (#2360)",
      "base": "main",
      "reasons": [
        "conflicts",
        "CHANGES_REQUESTED"
      ]
    },
    {
      "number": 4859,
      "url": "https://github.com/Chamber-Hero/memberos/pull/4859",
      "title": "feat(events): scheduled staff run-sheet sender with per-role expectations",
      "base": "main",
      "reasons": [
        "conflicts"
      ]
    },
    {
      "number": 4856,
      "url": "https://github.com/Chamber-Hero/memberos/pull/4856",
      "title": "feat(learning): full CRUD for course modules (edit, delete, rich text, video upload)",
      "base": "main",
      "reasons": [
        "conflicts",
        "red required CI: CI (Depot) / quality"
      ]
    },
    {
      "number": 4842,
      "url": "https://github.com/Chamber-Hero/memberos/pull/4842",
      "title": "feat(sponsorship): sponsorship credit ledger + newsletter/website context (#3773, #3774)",
      "base": "main",
      "reasons": [
        "conflicts"
      ]
    },
    {
      "number": 4837,
      "url": "https://github.com/Chamber-Hero/memberos/pull/4837",
      "title": "feat(legal): master-admin editor for privacy policy and terms",
      "base": "main",
      "reasons": [
        "conflicts",
        "red required CI: CI (Depot) / guardrails"
      ]
    },
    {
      "number": 4833,
      "url": "https://github.com/Chamber-Hero/memberos/pull/4833",
      "title": "chore(tech-debt): burn down knip unused exports/types + lower ratchet baseline",
      "base": "main",
      "reasons": [
        "conflicts"
      ]
    },
    {
      "number": 4825,
      "url": "https://github.com/Chamber-Hero/memberos/pull/4825",
      "title": "fix(journeys): catch unresolvable merge tokens at publish and send",
      "base": "main",
      "reasons": [
        "conflicts"
      ]
    },
    {
      "number": 4475,
      "url": "https://github.com/Chamber-Hero/memberos/pull/4475",
      "title": "feat(events): recurring event series support",
      "base": "main",
      "reasons": [
        "conflicts",
        "CHANGES_REQUESTED"
      ]
    }
  ],
  "stacked": [
    {
      "number": 5396,
      "url": "https://github.com/Chamber-Hero/memberos/pull/5396",
      "title": "fix(members): wire Lifecycle Recommended Actions to real member context (#5379)",
      "base": "feat/5378-lifecycle-onboarding-engagement-service",
      "reasons": []
    },
    {
      "number": 5395,
      "url": "https://github.com/Chamber-Hero/memberos/pull/5395",
      "title": "feat(members): build the TrustScore engine and wire it into EMN routing",
      "base": "fix/4810-4809-events-attended-checkin-driven",
      "reasons": []
    },
    {
      "number": 5393,
      "url": "https://github.com/Chamber-Hero/memberos/pull/5393",
      "title": "feat(contributions): auto-log event_participation + leadership_role from real check-ins and committee assignments",
      "base": "fix/4810-4809-events-attended-checkin-driven",
      "reasons": [
        "red required CI: PR Title Lint (Depot) / pr-title-lint"
      ]
    },
    {
      "number": 5353,
      "url": "https://github.com/Chamber-Hero/memberos/pull/5353",
      "title": "feat(portal): member storefront / self-serve upsell (#2202)",
      "base": "feat/2181-tier-upgrade-downgrade-proration",
      "reasons": [
        "review-blocker",
        "CHANGES_REQUESTED"
      ]
    },
    {
      "number": 5283,
      "url": "https://github.com/Chamber-Hero/memberos/pull/5283",
      "title": "feat(pricing): standard org-type templates — select, preview, apply (#2177)",
      "base": "feat/2174-feature-entitlement-catalog",
      "reasons": [
        "conflicts"
      ]
    },
    {
      "number": 5282,
      "url": "https://github.com/Chamber-Hero/memberos/pull/5282",
      "title": "feat(billing): per-org AI-credit metering + balance + top-up purchase (#2184)",
      "base": "feat/2178-bring-your-own-ai",
      "reasons": []
    },
    {
      "number": 5281,
      "url": "https://github.com/Chamber-Hero/memberos/pull/5281",
      "title": "PR-18: Bundles + cross-sell rules (#2203)",
      "base": "feat/2174-feature-entitlement-catalog",
      "reasons": [
        "conflicts",
        "review-blocker",
        "CHANGES_REQUESTED",
        "red required CI: PR Title Lint (Depot) / pr-title-lint"
      ]
    },
    {
      "number": 5279,
      "url": "https://github.com/Chamber-Hero/memberos/pull/5279",
      "title": "feat(entitlements): wire feature sets to member_entitlements enforcement (#2182)",
      "base": "feat/2174-feature-entitlement-catalog",
      "reasons": []
    },
    {
      "number": 5264,
      "url": "https://github.com/Chamber-Hero/memberos/pull/5264",
      "title": "feat(pricing): comparison matrix editor — quantity, apply-set, highlight, reorder (#2175)",
      "base": "feat/2174-feature-entitlement-catalog",
      "reasons": []
    }
  ],
  "in_bors": [],
  "repo": "Chamber-Hero/memberos",
  "base": "main"
}
```
</details>
<details>
<summary>Evidence: Focused ready-bucket tests</summary>

```text
FM_TEST_BEGIN 2026-08-24T20:03:41Z tests/fm-pr-ready-bucket.test.sh family=pr-forge expected_gate_skip=none
ok - fm-pr-ready-bucket help and usage errors
ok - fm-pr-ready-bucket refuses without gh-axi
ok - fm-pr-ready-bucket lists a green MERGEABLE main PR as ready
ok - fm-pr-ready-bucket classifies conflicts, red required CI, review-blocker, and CHANGES_REQUESTED as blocked
ok - fm-pr-ready-bucket lists non-main base PRs as stacked
ok - fm-pr-ready-bucket detects in-Bors from bors-ci-merge-queue author and queue comments
ok - fm-pr-ready-bucket ignores stale Bors unapproved and unmergeable comments
ok - fm-pr-ready-bucket omits drafts, release-please, and pending required CI
ok - fm-pr-ready-bucket honors --repo and only reads through gh-axi graphql
ok - fm-pr-ready-bucket lists from GitHub and does not scrape the Bors host
ok - fm-pr-ready-bucket prints all four groups when nothing matches
FM_TEST_END 2026-08-24T20:03:43Z tests/fm-pr-ready-bucket.test.sh exit=0 duration_ms=1357 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=1436
FM_TEST_SUMMARY_FAMILY family=pr-forge count=1 duration_ms=1357 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-pr-ready-bucket.test.sh duration_ms=1357
```
</details>
<details>
<summary>Evidence: GitHub spot-check of classified PRs</summary>

```text
Live GitHub spot-check of fm-pr-ready-bucket.sh classification
(2026-08-24, Chamber-Hero/memberos)

READY #5428  https://github.com/Chamber-Hero/memberos/pull/5428
  REST: draft=false base=main head=ci/5413-retire-pr-types-drift
  mergeable_state=blocked (branch protection; GraphQL mergeable is still MERGEABLE)
  Required checks on 1b907c54:
    CI (Depot) / lint, typecheck, build, guardrails, test, cli-test, quality, edge-test = success
    PR Title Lint (Depot) / pr-title-lint = success
    PR Body Lint (Depot) / pr-body-lint = success
  Matches ready: MERGEABLE-equivalent, main, not draft, required Depot+lint green.

BLOCKED #5388  https://github.com/Chamber-Hero/memberos/pull/5388
  REST: mergeable_state=dirty (conflicts), base=main
  Listing reason: conflicts. Match.

BLOCKED #5387  https://github.com/Chamber-Hero/memberos/pull/5387
  Labels: review-blocker
  Reviews include CHANGES_REQUESTED from github-actions[bot]
  Listing reason: review-blocker; CHANGES_REQUESTED. Match.

BLOCKED #5391  https://github.com/Chamber-Hero/memberos/pull/5391
  Required checks on 5a77b483:
    typecheck=cancelled, build=cancelled, test=failure, cli-test=cancelled, quality=cancelled
  Listing reason: red required CI: typecheck, build, test, cli-test, quality. Match
  (cancelled is treated as red).

STACKED #5396  https://github.com/Chamber-Hero/memberos/pull/5396
  REST: base=feat/5378-lifecycle-onboarding-engagement-service (not main)
  Listing: stacked with that base. Match.

IN-BORS: listing reported 0 open rollup/queue PRs at check time.

Scope: only bin/fm-pr-ready-bucket.sh + tests + fm-test-run family wiring.
No dashboard, watcher, or control plane. GitHub is the source.
```
</details>
<details>
<summary>Evidence: CLI help (read-only, GitHub is the source)</summary>

```text
usage: fm-pr-ready-bucket.sh [--repo OWNER/NAME] [--base BRANCH] [--json]
       fm-pr-ready-bucket.sh --help

Read-only listing of open GitHub PRs grouped for the next bors rollup.
Default --repo is Chamber-Hero/memberos. Default --base is main.
GitHub is the ready-bucket; this command does not scrape a Bors host.
Prints ready, blocked, stacked, and in-Bors groups with full PR URLs.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"b465209be382008d0c35495f2cdc7d7e1831f31f","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-pr-ready-bucket.sh:121` - in_bors treats only a latest Bors comment matching has been approved / [queue] / Trying: / :hourglass: as queued. MemberOS bors-ci-merge-queue then posts :tada: Rollup created on the member PR, which matches neither that positive set nor unapproved/unmergeable. Still-open rollup members therefore fall through to ready. Extend this same latest-comment matcher to treat Rollup created as still in-Bors.

🔧 Fix: Treat latest Rollup created as in-Bors
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bin/fm-test-run.sh tests/fm-pr-ready-bucket.test.sh`
- `bin/fm-pr-ready-bucket.sh --help`
- <code>`bin/fm-pr-ready-bucket.sh` (live Chamber-Hero/memberos listing)</code>
- `bin/fm-pr-ready-bucket.sh --json`
- <code>`bin/fm-pr-ready-bucket.sh --watch` (usage error, exit 2)</code>
- `GitHub REST spot-check of ready #5428 required Depot + title/body lint checks`
- `GitHub REST spot-check of blocked #5388 conflicts, #5387 review-blocker/CHANGES_REQUESTED, #5391 red required CI, and stacked #5396 non-main base`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Install pinned actionlint 1.7.12 for workflow lint
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
