### PR TITLE
feat(bin): execute supported Python tests in canonical runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,9 @@ jobs:
       - run: bin/fm-lint.sh
 
   # Deterministic proof that portable parallel shards + portable serial + Herdr
-  # equal the complete tests/*.test.sh inventory with no missing or duplicates,
-  # and that the portable serial CI shards partition that serial lane exactly.
+  # equal the complete supported shell and Python test inventory with no missing
+  # or duplicates, and that the portable serial CI shards partition that serial
+  # lane exactly.
   test-coverage:
     name: Test coverage guard
     runs-on: ubuntu-latest
@@ -282,8 +283,9 @@ jobs:
         run: |
           set -eu
           mkdir -p "$RUNNER_TEMP/fm-test"
-          # Serial only. Fail if any script reports herdr not found. Live
-          # harness credential tests stay outside this family (opt-in env only).
+          # Serial only. The canonical runner executes both shell and Python
+          # members. Fail if any test reports herdr not found. Live harness
+          # credential tests stay outside this family (opt-in env only).
           bin/fm-test-run.sh --family real-herdr-gated \
             --fail-on-gate-skip 'herdr not found' \
             --json "$RUNNER_TEMP/fm-test/fm-test-timing-herdr.json"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/star
   It does not make `data/` tracked.
 - Helper scripts in `bin/` are plain bash.
   Each starts with a usage header comment; keep it accurate when you change behavior.
-  Test scripts and helpers in `tests/` are plain bash too.
+  Shell test scripts and helpers in `tests/` are plain bash; the canonical runner also supports its documented narrow Python test convention.
   `bin/fm-lint.sh` must pass: it is the single owner of the lint definition (the shellcheck file set, config, pinned shellcheck version, and pinned actionlint workflow lint), and both CI and the no-mistakes pre-push gate run its no-argument full-analysis path.
   Its header and `--help` output own the exact local lint modes and flags.
   A malformed `.github/workflows/*.yml`, including a self-broken `ci.yml`, fails that local lint path before merge because a broken workflow cannot report its own breakage.
@@ -103,9 +103,8 @@ Local no-mistakes Test stays intent-targeted and must not wire `commands.test` t
 Family selection is the ordinary local path; `--all` is deliberate full regression only.
 CI owns broad regression across required portable parallel shards, the portable serial lane's separate-runner shards, the Herdr lane, lint, invariants, the coverage guard, and stock macOS Bash compatibility in [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
 Use `bin/fm-test-run.sh --list-lanes` for exact lane names and `--help` for `--jobs` rules and required gate-skip flags when reproducing a lane locally.
-Shell behavior tests are direct `tests/<subject>.test.sh` files.
-The only supported Python discovery convention is a direct `tests/fm-<subject>.test.py` file; helper modules, packages, and `test_*.py` files are not discovered.
-Pass either supported test path to `bin/fm-test-run.sh` for canonical execution and timing output.
+The runner's `--help` output owns the supported shell and Python discovery conventions, including which Python files remain helpers rather than tests.
+Pass a supported test path to `bin/fm-test-run.sh` for canonical execution and timing output.
 A fixture may shorten a production timeout to keep a failure path prompt, but never below what the real work inside that window costs on a loaded machine: a fork, an exec, a lock acquisition, a beacon publication, or a first-poll check.
 Where a case's assertion is not about the timeout itself, give that window headroom over the measured loaded cost, and bound the test's own waiting with iteration-counted poll loops, which stretch under load where a wall-clock budget does not.
 Tests that need a real optional backend or an explicit opt-in (real herdr/zellij/cmux smoke tests, the live Pi regression) skip themselves and print the tool or environment gate needed to enable them, so the portable suite remains safe on machines without those tools.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ When supervising live crewmates, keep firstmate's own long validation or build c
 Crewmate validation follows the installed no-mistakes version's SKILL.md and live `axi` help instead of duplicating gate mechanics in firstmate docs.
 Firstmate's wrapper still matters: crewmates route every `ask-user` finding to firstmate, which applies `ask-user-authority`, and crewmates avoid `--yes` because it would bypass that check and any required captain escalation.
 `.no-mistakes.yaml` publishes test evidence to the orphan `no-mistakes/evidence` branch, which shares no history with code branches, and pins the gate's lint command to `bin/fm-lint.sh`, matching the Linux CI lint job.
-Local no-mistakes Test is intent-targeted and must not re-run every `tests/*.test.sh`; `.github/workflows/ci.yml` owns the broad behavior suite plus platform-specific compatibility lanes.
+Local no-mistakes Test is intent-targeted and must not re-run the complete supported test inventory; `.github/workflows/ci.yml` owns the broad behavior suite plus platform-specific compatibility lanes.
 The pipeline publishes that evidence itself, so never hand-commit `.no-mistakes/` paths onto a feature branch; CI rejects them as tracked personal fleet paths.
 
 Check and test the toolbelt before pushing:
@@ -99,11 +99,13 @@ tmp=$(mktemp -d) && printf 'done: smoke\n' > "$tmp/smoke.status" && FM_STATE_OVE
 Its header and `--help` own the flags, family labels, lanes, and changed-file map; this section only documents the entry points.
 `bin/fm-test-isolation-proof.sh` remains the single owner of the Phase 2 concurrent isolation proof and the exact proven candidate set; see `docs/fm-test-isolation-proof.md`.
 Portable shard balance evidence lives in `docs/fm-test-portable-shards.md`.
-Local no-mistakes Test stays intent-targeted and must not wire `commands.test` to `--all` or a `tests/*.test.sh` walk.
+Local no-mistakes Test stays intent-targeted and must not wire `commands.test` to `--all` or a complete test-inventory walk.
 Family selection is the ordinary local path; `--all` is deliberate full regression only.
 CI owns broad regression across required portable parallel shards, the portable serial lane's separate-runner shards, the Herdr lane, lint, invariants, the coverage guard, and stock macOS Bash compatibility in [`.github/workflows/ci.yml`](.github/workflows/ci.yml).
 Use `bin/fm-test-run.sh --list-lanes` for exact lane names and `--help` for `--jobs` rules and required gate-skip flags when reproducing a lane locally.
-Discover tests by listing `tests/*.test.sh`: each is a self-contained bash script named `<subject>.test.sh`, and its header comment describes what it covers, so pass one to `bin/fm-test-run.sh` to focus on a subject with canonical timing output.
+Shell behavior tests are direct `tests/<subject>.test.sh` files.
+The only supported Python discovery convention is a direct `tests/fm-<subject>.test.py` file; helper modules, packages, and `test_*.py` files are not discovered.
+Pass either supported test path to `bin/fm-test-run.sh` for canonical execution and timing output.
 A fixture may shorten a production timeout to keep a failure path prompt, but never below what the real work inside that window costs on a loaded machine: a fork, an exec, a lock acquisition, a beacon publication, or a first-poll check.
 Where a case's assertion is not about the timeout itself, give that window headroom over the measured loaded cost, and bound the test's own waiting with iteration-counted poll loops, which stretch under load where a wall-clock budget does not.
 Tests that need a real optional backend or an explicit opt-in (real herdr/zellij/cmux smoke tests, the live Pi regression) skip themselves and print the tool or environment gate needed to enable them, so the portable suite remains safe on machines without those tools.

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -12,6 +12,9 @@
 #   fm-test-run.sh --lane portable-serial-<k>of<n>   (one CI serial shard)
 #   fm-test-run.sh --proven-isolated
 #   fm-test-run.sh tests/<name>.test.sh|tests/fm-<name>.test.py [more tests...]
+# Supported discovery is limited to direct tests/*.test.sh and
+# tests/fm-*.test.py files. Nested files, Python helpers, packages, and
+# conventional test_*.py modules are not discovered.
 #
 # Inspection (no execution):
 #   fm-test-run.sh --list --all

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -11,7 +11,7 @@
 #   fm-test-run.sh --lane portable-parallel-1|portable-parallel-2|portable-serial
 #   fm-test-run.sh --lane portable-serial-<k>of<n>   (one CI serial shard)
 #   fm-test-run.sh --proven-isolated
-#   fm-test-run.sh tests/<name>.test.sh [more scripts...]
+#   fm-test-run.sh tests/<name>.test.sh|tests/fm-<name>.test.py [more tests...]
 #
 # Inspection (no execution):
 #   fm-test-run.sh --list --all
@@ -128,10 +128,14 @@ now_ms() {
   fi
 }
 
-# Primary family for one tests/*.test.sh basename. Unmapped scripts are
-# unclassified so new tests are still runnable and visible in summaries.
+# Primary family for one supported test basename. Unmapped shell tests are
+# unclassified so they remain runnable in portable-serial. Supported Python
+# tests must be mapped into a lane so the coverage guard catches an orphan.
 family_for_basename() {
   case "$1" in
+    fm-backend-herdr-eventwait.test.py)
+      printf '%s\n' real-herdr-gated
+      ;;
     fm-arm-pretool-check.test.sh|fm-ask-user-authority.test.sh|\
     fm-bearings-board.test.sh|\
     fm-brief.test.sh|fm-vendor-auth-probe.test.sh|\
@@ -359,12 +363,16 @@ is_proven_isolated_script() {
 # The portable serial remainder: every tests/*.test.sh that is neither
 # proven-isolated nor real-herdr-gated. Watcher, lock, AFK, real tmux, daemon,
 # secondmate lifecycle, bootstrap, live-harness opt-in, GUI-backend, and other
-# unproven work stays here. Derived rather than enumerated so a newly added test
-# lands here by default instead of falling out of every lane.
+# unproven shell work stays here. Derived rather than enumerated so a newly added
+# shell test lands here by default. Python tests require an intentional family
+# mapping; the coverage guard fails if a supported Python test has no lane.
 list_portable_serial() {
   local s base fam
   while IFS= read -r s; do
     [ -n "$s" ] || continue
+    case "$s" in
+      *.test.py) continue ;;
+    esac
     base=$(basename "$s")
     fam=$(family_for_basename "$base")
     if [ "$fam" = "real-herdr-gated" ]; then
@@ -636,7 +644,9 @@ run_coverage_guard() {
   local -a saved_scripts=()
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-coverage.XXXXXX")
 
-  all_repo_tests | LC_ALL=C sort -u >"$tmp/all"
+  all_repo_shell_tests | LC_ALL=C sort -u >"$tmp/all_shell"
+  all_repo_python_tests | LC_ALL=C sort -u >"$tmp/all_python"
+  cat "$tmp/all_shell" "$tmp/all_python" | LC_ALL=C sort -u >"$tmp/all"
   list_proven_isolated | LC_ALL=C sort -u >"$tmp/proven"
   list_portable_parallel_1 | LC_ALL=C sort -u >"$tmp/s1"
   list_portable_parallel_2 | LC_ALL=C sort -u >"$tmp/s2"
@@ -728,7 +738,7 @@ run_coverage_guard() {
   missing=$(comm -23 "$tmp/all" "$tmp/union" || true)
   extra=$(comm -13 "$tmp/all" "$tmp/union" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
-    log "coverage guard: union of portable shards + portable serial + Herdr must equal tests/*.test.sh"
+    log "coverage guard: union of portable shards + portable serial + Herdr must equal the supported test inventory"
     [ -z "$missing" ] || { log "missing from union:"; printf '%s\n' "$missing" >&2; }
     [ -z "$extra" ] || { log "extra beyond inventory:"; printf '%s\n' "$extra" >&2; }
     rm -rf "$tmp"
@@ -745,8 +755,10 @@ run_coverage_guard() {
     fi
   fi
 
-  printf 'FM_TEST_COVERAGE ok total=%s parallel=%s serial=%s serial_shards=%s herdr=%s\n' \
+  printf 'FM_TEST_COVERAGE ok total=%s shell=%s python=%s parallel=%s serial=%s serial_shards=%s herdr=%s\n' \
     "$(wc -l <"$tmp/all" | tr -d ' ')" \
+    "$(wc -l <"$tmp/all_shell" | tr -d ' ')" \
+    "$(wc -l <"$tmp/all_python" | tr -d ' ')" \
     "$(wc -l <"$tmp/shards_union" | tr -d ' ')" \
     "$(wc -l <"$tmp/serial" | tr -d ' ')" \
     "$PORTABLE_SERIAL_SHARDS" \
@@ -814,14 +826,27 @@ print(f"FM_TEST_AGGREGATE lanes={len(lanes)} total={total} failed={failed} skipp
 PY
 }
 
-all_repo_tests() {
-  # Deterministic lexical order (same as bash glob expansion under LC_ALL=C).
+all_repo_shell_tests() {
   local f
-  # shellcheck disable=SC2035
   for f in tests/*.test.sh; do
     [ -f "$f" ] || continue
     printf '%s\n' "$f"
-  done | LC_ALL=C sort
+  done
+}
+
+all_repo_python_tests() {
+  # Narrow convention: direct tests/fm-*.test.py files only. Python helpers,
+  # packages, and conventional test_*.py modules are intentionally invisible.
+  local f
+  for f in tests/fm-*.test.py; do
+    [ -f "$f" ] || continue
+    printf '%s\n' "$f"
+  done
+}
+
+all_repo_tests() {
+  # Deterministic lexical union of the two supported discovery conventions.
+  { all_repo_shell_tests; all_repo_python_tests; } | LC_ALL=C sort -u
 }
 
 normalize_script_path() {
@@ -832,7 +857,7 @@ normalize_script_path() {
       p=${p#./}
       printf '%s\n' "$p"
       ;;
-    *.test.sh)
+    *.test.sh|fm-*.test.py)
       if [ -f "tests/$p" ]; then
         printf 'tests/%s\n' "$p"
       else
@@ -902,6 +927,9 @@ families_for_changed_path() {
     tests/fm-backend-herdr-eventwait.test.py)
       printf '%s\n' real-herdr-gated
       printf '%s\n' backend-dispatch
+      ;;
+    tests/fm-*.test.py)
+      printf '%s\n' "__script__:$(basename "$path")"
       ;;
     tests/*.test.sh)
       # A single test file change selects only that script via basename family
@@ -1504,6 +1532,14 @@ for s in "${SCRIPTS[@]}"; do
   [ -x "$s" ] || [ -r "$s" ] || die "test script not readable: $s"
 done
 
+for s in "${SCRIPTS[@]}"; do
+  case "$s" in
+    *.test.py)
+      command -v python3 >/dev/null 2>&1 || die "python3 is required to run $s"
+      ;;
+  esac
+done
+
 # --jobs N>1 only for the proven-isolated set. Stateful families stay serial.
 if [ "$JOBS" -gt 1 ]; then
   for s in "${SCRIPTS[@]}"; do
@@ -1607,8 +1643,11 @@ run_one_serial() {
 
   set +e
   # Stream live output while retaining a copy for gate-skip detection.
-  # PIPESTATUS[0] is the test script; tee's exit is ignored for aggregate.
-  bash "$script" 2>&1 | tee "$out"
+  # PIPESTATUS[0] is the test process; tee's exit is ignored for aggregate.
+  case "$script" in
+    *.test.py) python3 "$script" 2>&1 | tee "$out" ;;
+    *) bash "$script" 2>&1 | tee "$out" ;;
+  esac
   rc=${PIPESTATUS[0]}
   set -e
   : "${rc:=1}"
@@ -1715,7 +1754,10 @@ else
         FM_PROJECTS_OVERRIDE FM_CONFIG_OVERRIDE FM_BACKEND 2>/dev/null || true
       cd "$ROOT" || exit 1
       begin_ms=$(now_ms)
-      bash "$script" >"$work/output" 2>&1
+      case "$script" in
+        *.test.py) python3 "$script" >"$work/output" 2>&1 ;;
+        *) bash "$script" >"$work/output" 2>&1 ;;
+      esac
       rc=$?
       end_ms=$(now_ms)
       duration=$((end_ms - begin_ms))

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -146,7 +146,7 @@ See [`trace-context.md`](trace-context.md) for carrier semantics, supported rout
 The tracked `.no-mistakes.yaml` sets `test.evidence.store_in_repo: true` and pins `commands.lint` to `bin/fm-lint.sh` so local lint matches CI.
 Storing evidence in the repo publishes each run's test artifacts to the orphan `no-mistakes/evidence` branch and links them from the PR body, instead of keeping them on local disk under the no-mistakes home.
 That branch shares no history with code branches, so evidence never enters a pushed feature branch or the default branch; the worktree's `.no-mistakes/` stays local and CI rejects tracked entries under that path.
-It does not set `commands.test` to a complete `tests/*.test.sh` walk.
+It does not set `commands.test` to a complete supported-test inventory walk.
 See [CONTRIBUTING.md](../CONTRIBUTING.md) for the firstmate-specific local test policy and entry points.
 Portable shard evidence and coverage rules are in [fm-test-portable-shards.md](fm-test-portable-shards.md); [herdr-backend.md](herdr-backend.md#destructive-lab-safety) owns the real-Herdr lane's isolation boundary, and [runtime-backends.md](verification/runtime-backends.md#herdr) owns active evidence.
 

--- a/docs/fm-test-portable-shards.md
+++ b/docs/fm-test-portable-shards.md
@@ -52,6 +52,8 @@ The two parallel lanes use longest-processing-time assignment from those measure
 `portable-serial` includes every `tests/*.test.sh` that is neither proven-isolated nor `real-herdr-gated`.
 It keeps watcher, lock, AFK, real tmux, daemon, secondmate lifecycle, bootstrap, live-harness opt-in, GUI-backend, and other unproven work serial.
 Membership is derived rather than enumerated, so a newly added test lands here by default.
+Supported Python tests use the narrow direct-file convention `tests/fm-*.test.py` and require an intentional family mapping into an existing lane.
+This prevents helper Python modules from executing accidentally and makes the coverage guard reject an unmapped Python test.
 
 ## Portable serial CI shards
 
@@ -92,7 +94,7 @@ bin/fm-test-run.sh --check-coverage
 ## Coverage guard
 
 `bin/fm-test-run.sh --check-coverage` verifies that both parallel lanes partition the proven-isolated set.
-It also verifies that the parallel lanes, portable serial lane, and real-Herdr family are disjoint and cover every `tests/*.test.sh` script.
+It also verifies that the parallel lanes, portable serial lane, and real-Herdr family are disjoint and cover every supported shell and Python test.
 It separately verifies that the portable serial CI shards are non-empty, disjoint, and together equal the portable serial lane.
 
 ## Timing artifacts

--- a/docs/fm-test-portable-shards.md
+++ b/docs/fm-test-portable-shards.md
@@ -51,9 +51,9 @@ The two parallel lanes use longest-processing-time assignment from those measure
 
 `portable-serial` includes every `tests/*.test.sh` that is neither proven-isolated nor `real-herdr-gated`.
 It keeps watcher, lock, AFK, real tmux, daemon, secondmate lifecycle, bootstrap, live-harness opt-in, GUI-backend, and other unproven work serial.
-Membership is derived rather than enumerated, so a newly added test lands here by default.
-Supported Python tests use the narrow direct-file convention `tests/fm-*.test.py` and require an intentional family mapping into an existing lane.
-This prevents helper Python modules from executing accidentally and makes the coverage guard reject an unmapped Python test.
+Membership is derived rather than enumerated, so a newly added shell test lands here by default.
+Supported Python tests use the narrow direct-file convention owned by `bin/fm-test-run.sh --help` and require an intentional family mapping into an existing lane.
+This keeps helper Python modules outside discovery and makes the coverage guard reject an unmapped supported Python test.
 
 ## Portable serial CI shards
 

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -19,7 +19,7 @@ test_list_all_exact_suite_coverage() {
   local listed expected missing extra f
   listed=$("$RUNNER" --list --all | LC_ALL=C sort)
   expected=$(
-    for f in "$ROOT"/tests/*.test.sh; do
+    for f in "$ROOT"/tests/*.test.sh "$ROOT"/tests/fm-*.test.py; do
       [ -f "$f" ] || continue
       printf 'tests/%s\n' "$(basename "$f")"
     done | LC_ALL=C sort
@@ -33,7 +33,7 @@ test_list_all_exact_suite_coverage() {
   [ "$(printf '%s\n' "$listed" | uniq | wc -l | tr -d ' ')" = \
     "$(printf '%s\n' "$listed" | wc -l | tr -d ' ')" ] \
     || fail "--list --all must not duplicate scripts"
-  pass "exact suite coverage: --all lists every tests/*.test.sh once"
+  pass "exact suite coverage: --all lists every supported shell and Python test once"
 }
 
 test_family_selection() {
@@ -90,7 +90,7 @@ test_changed_file_selection_is_conservative() {
 
 init_changed_fixture_repo() {
   local repo=$1 script
-  mkdir -p "$repo/bin" "$repo/tests"
+  mkdir -p "$repo/bin/backends" "$repo/tests"
   cp "$RUNNER" "$repo/bin/fm-test-run.sh"
   chmod +x "$repo/bin/fm-test-run.sh"
   for script in \
@@ -114,7 +114,9 @@ init_changed_fixture_repo() {
     chmod +x "$repo/tests/$script"
   done
   : >"$repo/tests/lib.sh"
-  : >"$repo/tests/fm-backend-herdr-eventwait.test.py"
+  printf '# herdr-eventwait.py\n' >"$repo/tests/fm-backend-herdr-eventwait.test.py"
+  printf '# herdr-eventwait.py\n' >>"$repo/tests/fm-backend.test.sh"
+  : >"$repo/bin/backends/herdr-eventwait.py"
   : >"$repo/bin/fm-supervisor-target-lib.sh"
   : >"$repo/bin/unmapped-source.sh"
   printf '# .claude/settings.json\n# .pi/extensions/fm-primary-turnend-guard.ts\n' \
@@ -151,6 +153,13 @@ test_changed_dependency_selection_and_unmapped_failure() {
   assert_contains "$listed" "tests/fm-backend.test.sh" "eventwait test selects backend coverage"
   git -C "$repo" add tests/fm-backend-herdr-eventwait.test.py
   git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm eventwait-change
+
+  printf '\n' >>"$repo/bin/backends/herdr-eventwait.py"
+  listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)
+  assert_contains "$listed" "tests/fm-backend-herdr-eventwait.test.py" "eventwait production owner selects Python Herdr coverage"
+  assert_contains "$listed" "tests/fm-backend.test.sh" "eventwait production owner selects backend coverage"
+  git -C "$repo" add bin/backends/herdr-eventwait.py
+  git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm eventwait-owner-change
 
   printf '\n' >>"$repo/bin/fm-supervisor-target-lib.sh"
   listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)
@@ -283,6 +292,95 @@ SH
   pass "aggregate exit reflects any script failure"
 }
 
+test_python_execution_and_failure_propagation() {
+  local tmp out rc fail_f
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-python.XXXXXX")
+  out="$tmp/out.txt"
+  fail_f="$tmp/failing.test.py"
+
+  "$RUNNER" tests/fm-backend-herdr-eventwait.test.py >"$out" 2>"$tmp/err.txt" \
+    || { cat "$out" "$tmp/err.txt"; rm -rf "$tmp"; fail "real Python test must pass through the runner"; }
+  grep -Fq 'Ran 5 tests' "$out" \
+    || { rm -rf "$tmp"; fail "canonical runner did not execute the real five Python tests"; }
+  grep -Fq 'FM_TEST_SUMMARY total=1 failed=0' "$out" \
+    || { rm -rf "$tmp"; fail "passing Python summary is wrong: $(grep FM_TEST_SUMMARY "$out")"; }
+  grep -Fq 'family=real-herdr-gated' "$out" \
+    || { rm -rf "$tmp"; fail "Python test lost its real-herdr-gated family"; }
+
+  cat >"$fail_f" <<'PY'
+import unittest
+
+
+class DeliberateFailure(unittest.TestCase):
+    def test_failure(self):
+        self.fail("deliberate")
+
+
+if __name__ == "__main__":
+    unittest.main()
+PY
+  set +e
+  "$RUNNER" "$fail_f" >"$tmp/fail-out.txt" 2>"$tmp/fail-err.txt"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || { rm -rf "$tmp"; fail "a failing Python test must fail the runner"; }
+  grep -Fq 'FM_TEST_SUMMARY total=1 failed=1' "$tmp/fail-out.txt" \
+    || { rm -rf "$tmp"; fail "failing Python summary is wrong: $(grep FM_TEST_SUMMARY "$tmp/fail-out.txt")"; }
+  rm -rf "$tmp"
+  pass "canonical runner executes all five real Python tests and propagates failures"
+}
+
+test_python_discovery_is_narrow_and_empty_safe() {
+  local tmp repo listed out
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-python-discovery.XXXXXX")
+  repo="$tmp/repo"
+  mkdir -p "$repo/bin" "$repo/tests/pkg"
+  cp "$RUNNER" "$repo/bin/fm-test-run.sh"
+  chmod +x "$repo/bin/fm-test-run.sh"
+  cat >"$repo/tests/only.test.sh" <<'SH'
+#!/usr/bin/env bash
+echo "ok - shell fixture"
+SH
+  chmod +x "$repo/tests/only.test.sh"
+  : >"$repo/tests/fm-helper.py"
+  : >"$repo/tests/helper.test.py"
+  : >"$repo/tests/pkg/fm-nested.test.py"
+
+  listed=$(cd "$repo" && bin/fm-test-run.sh --list --all)
+  [ "$listed" = "tests/only.test.sh" ] \
+    || { rm -rf "$tmp"; fail "Python helper or empty glob leaked into discovery: $listed"; }
+  out=$(cd "$repo" && bin/fm-test-run.sh --all)
+  assert_contains "$out" "FM_TEST_SUMMARY total=1 failed=0" "empty Python glob keeps shell execution intact"
+  rm -rf "$tmp"
+  pass "Python discovery ignores helpers and handles an empty supported glob"
+}
+
+test_orphan_python_test_fails_coverage_inventory() {
+  local tmp repo path rc
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-python-orphan.XXXXXX")
+  repo="$tmp/repo"
+  mkdir -p "$repo/bin" "$repo/tests"
+  cp "$RUNNER" "$repo/bin/fm-test-run.sh"
+  chmod +x "$repo/bin/fm-test-run.sh"
+  while IFS= read -r path; do
+    mkdir -p "$repo/$(dirname "$path")"
+    : >"$repo/$path"
+  done < <("$RUNNER" --list --all)
+
+  (cd "$repo" && bin/fm-test-run.sh --check-coverage) >"$tmp/base-out" 2>"$tmp/base-err" \
+    || { cat "$tmp/base-out" "$tmp/base-err"; rm -rf "$tmp"; fail "coverage fixture baseline must pass"; }
+  : >"$repo/tests/fm-orphan.test.py"
+  set +e
+  (cd "$repo" && bin/fm-test-run.sh --check-coverage) >"$tmp/out" 2>"$tmp/err"
+  rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || { rm -rf "$tmp"; fail "orphan supported Python test must fail coverage"; }
+  grep -Fq 'tests/fm-orphan.test.py' "$tmp/err" \
+    || { rm -rf "$tmp"; fail "coverage failure must name the orphan Python test: $(cat "$tmp/err")"; }
+  rm -rf "$tmp"
+  pass "coverage inventory rejects an orphan supported Python test"
+}
+
 test_gate_skip_accounting() {
   local tmp skip_f out json
   tmp=$(mktemp -d "${TMPDIR:-/tmp}/fm-test-run-skip.XXXXXX")
@@ -370,6 +468,8 @@ test_portable_shard_union_and_coverage_guard() {
     && fail "portable lanes must not include real-herdr-gated smoke"
   printf '%s\n' "$herdr" | grep -Fq 'tests/fm-backend-herdr-smoke.test.sh' \
     || fail "herdr family must include smoke"
+  printf '%s\n' "$herdr" | grep -Fq 'tests/fm-backend-herdr-eventwait.test.py' \
+    || fail "herdr family must include the eventwait Python test"
   out=$("$RUNNER" --check-coverage)
   assert_contains "$out" "FM_TEST_COVERAGE ok" "coverage guard success marker"
   all_count=$("$RUNNER" --list --all | wc -l | tr -d ' ')
@@ -711,6 +811,9 @@ test_changed_dependency_selection_and_unmapped_failure
 test_empty_selection_emits_summary
 test_timing_markers_and_json
 test_aggregate_exit_behavior
+test_python_execution_and_failure_propagation
+test_python_discovery_is_narrow_and_empty_safe
+test_orphan_python_test_fails_coverage_inventory
 test_gate_skip_accounting
 test_fail_on_gate_skip_token
 test_exclude_family


### PR DESCRIPTION
## Intent

Implement audit finding F4 from /home/taimur/work/agent-workspace/data/audit-2026-08-24-code-analysis.md so every Firstmate test matching the supported Python test convention is executed and counted. Wire tests/fm-backend-herdr-eventwait.test.py into the canonical bin/fm-test-run.sh runner and CI without creating a parallel test-command owner. Make the coverage inventory fail whenever a supported .test.py file is invisible to every lane while preserving the existing shell test count and family mapping. Define the narrow supported filename and discovery convention so helper Python modules are never executed accidentally. Preserve real-herdr-gated and backend-dispatch selection for changes to this test and its production owner. Add executable regression coverage showing an orphan Python test fails inventory, the real five tests run, failures propagate, and empty glob behavior is correct. Validate and ship the committed canonical Python test discovery and execution change while preserving the one test-runner owner, exact supported .test.py convention, lane and coverage inventory, CI wiring, failure propagation, and shell-test behavior. Treat the absent Ruby prerequisite as UNRUN with the exact boundary rather than a pass or dependency change. Escalate ask-user findings and never use --yes.

## What Changed

- Extend the canonical test runner to discover and execute direct `tests/fm-*.test.py` files while excluding helpers, packages, nested files, and conventional `test_*.py` modules.
- Add the Herdr event-wait Python suite to the real-Herdr lane and preserve changed-file selection for its backend owner and backend-dispatch coverage.
- Expand CI coverage inventory and regression checks to count supported Python tests, reject unmapped orphans, propagate failures, and preserve shell-test lane behavior.

## Risk Assessment

✅ Low: The change is well-bounded and correctly integrates narrow Python test discovery, execution, coverage inventory, lane selection, and CI through the existing canonical runner without altering shell-test membership.

## Testing

The focused regression demonstrated five-test execution, failure propagation, narrow and empty-safe Python discovery, orphan rejection, lane/changed-file selection, and preserved shell behavior; direct CLI evidence and JSON were captured, while the Ruby-dependent CI workflow semantic check was correctly classified UNRUN because Ruby is absent.

<details>
<summary>Evidence: Canonical Python runner CLI transcript</summary>

Source: [Canonical Python runner CLI transcript](https://github.com/taimurrabuske/firstmate/blob/684b7f345d8dc3272e29556e2d4995f1b413f328/.no-mistakes/evidence/fm/fm-python-test-runner-coverage-t1/canonical-python-runner-cli.txt)

```text
$ bin/fm-test-run.sh tests/fm-backend-herdr-eventwait.test.py --json <evidence>/eventwait.json
FM_TEST_BEGIN 2026-08-24T21:30:04Z tests/fm-backend-herdr-eventwait.test.py family=real-herdr-gated expected_gate_skip=herdr
.....
----------------------------------------------------------------------
Ran 5 tests in 0.001s

OK
FM_TEST_END 2026-08-24T21:30:04Z tests/fm-backend-herdr-eventwait.test.py exit=0 duration_ms=134 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=180
FM_TEST_SUMMARY_FAMILY family=real-herdr-gated count=1 duration_ms=134 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-backend-herdr-eventwait.test.py duration_ms=134
fm-test-run: wrote timing artifact: /home/taimur/.no-mistakes/evidence/01M0TTNHA8KP135GY9Y0EZ72QB/eventwait.json

$ bin/fm-test-run.sh --check-coverage
FM_TEST_COVERAGE ok total=162 shell=161 python=1 parallel=24 serial=125 serial_shards=4 herdr=13

$ bin/fm-test-run.sh --list --family real-herdr-gated
tests/fm-afk-inject-herdr-e2e.test.sh
tests/fm-afk-launch.test.sh
tests/fm-backend-autodetect-smoke.test.sh
tests/fm-backend-herdr-eventwait-smoke.test.sh
tests/fm-backend-herdr-eventwait.test.py
tests/fm-backend-herdr-launcher-workspace-e2e.test.sh
tests/fm-backend-herdr-presentation-e2e.test.sh
tests/fm-backend-herdr-prune-safety-e2e.test.sh
tests/fm-backend-herdr-respawn-idem-e2e.test.sh
tests/fm-backend-herdr-smoke.test.sh
tests/fm-backend-herdr-workspace-per-home-e2e.test.sh
tests/fm-control-herdr-smoke.test.sh
tests/fm-herdr-session-cleanup-e2e.test.sh

$ bin/fm-test-run.sh --list --changed --base 038d0f7ec6ba7238a151722931434dcf06ff37c4
tests/fm-arm-pretool-check.test.sh
tests/fm-ask-user-authority.test.sh
tests/fm-bearings-board.test.sh
tests/fm-brief.test.sh
tests/fm-calm-pi-extension.test.sh
tests/fm-captain-hold-lifecycle.test.sh
tests/fm-cd-pretool-check.test.sh
tests/fm-classify-decision-key.test.sh
tests/fm-composer-ghost.test.sh
tests/fm-composer-lib.test.sh
tests/fm-crew-state.test.sh
tests/fm-documentation-audiences.test.sh
tests/fm-ensure-agents-md.test.sh
tests/fm-grok-harness.test.sh
tests/fm-herdr-lab.test.sh
tests/fm-kimi-harness.test.sh
tests/fm-lint-workflows.test.sh
tests/fm-lint.test.sh
tests/fm-muse-harness.test.sh
tests/fm-operational-input.test.sh
tests/fm-pi-primary-types.test.sh
tests/fm-send-popup-settle.test.sh
tests/fm-send-settle.test.sh
tests/fm-subagent-pretool-check.test.sh
tests/fm-supervision-instructions.test.sh
tests/fm-task-delivery.test.sh
tests/fm-test-isolation-proof.test.sh
tests/fm-test-run.test.sh
tests/fm-tmux-submit-busy.test.sh
tests/fm-trace-context-lib.test.sh
tests/fm-transition-lib.test.sh
tests/fm-vendor-auth-probe.test.sh
tests/fm-afk-inject-herdr-e2e.test.sh
tests/fm-afk-launch.test.sh
tests/fm-backend-autodetect-smoke.test.sh
tests/fm-backend-herdr-eventwait-smoke.test.sh
tests/fm-backend-herdr-eventwait.test.py
tests/fm-backend-herdr-launcher-workspace-e2e.test.sh
tests/fm-backend-herdr-presentation-e2e.test.sh
tests/fm-backend-herdr-prune-safety-e2e.test.sh
tests/fm-backend-herdr-respawn-idem-e2e.test.sh
tests/fm-backend-herdr-smoke.test.sh
tests/fm-backend-herdr-workspace-per-home-e2e.test.sh
tests/fm-control-herdr-smoke.test.sh
tests/fm-herdr-session-cleanup-e2e.test.sh
```
</details>
<details>
<summary>Evidence: Focused runner regression transcript</summary>

Source: [Focused runner regression transcript](https://github.com/taimurrabuske/firstmate/blob/684b7f345d8dc3272e29556e2d4995f1b413f328/.no-mistakes/evidence/fm/fm-python-test-runner-coverage-t1/fm-test-run-targeted.txt)

```text
ok - exact suite coverage: --all lists every supported shell and Python test once
ok - family selection returns a proper subset of the suite
ok - single-script selection lists exactly that path
ok - changed-file selection stays conservative (never silent full suite)
ok - changed selection covers dependents and fails closed for unmapped source
ok - empty changed selection emits deterministic text and JSON summaries
ok - timing markers and JSON artifact are valid
ok - aggregate exit reflects any script failure
ok - canonical runner executes all five real Python tests and propagates failures
ok - Python discovery ignores helpers and handles an empty supported glob
ok - coverage inventory rejects an orphan supported Python test
ok - gate-skip accounting is honest and non-failing
ok - fail-on-gate-skip converts herdr-not-found into a hard failure
ok - exclude-family drops the named primary family after selection
ok - portable shard union, disjointness, and coverage guard hold
ok - portable serial shards are a deterministic disjoint cover of the serial lane
ok - portable serial shard lanes refuse mismatched, out-of-range, and countless names
ok - --jobs refuses non-proven / stateful selections
ok - jobs scheduler runs proven scripts; failure propagates; non-proven refused
not ok - ruby is required to parse .github/workflows/ci.yml as YAML

TEST_PHASE_EXIT=1
```
</details>
<details>
<summary>Evidence: Canonical eventwait timing and result artifact</summary>

Source: [Canonical eventwait timing and result artifact](https://github.com/taimurrabuske/firstmate/blob/684b7f345d8dc3272e29556e2d4995f1b413f328/.no-mistakes/evidence/fm/fm-python-test-runner-coverage-t1/eventwait.json)

```text
{
  "families": [
    {
      "count": 1,
      "duration_ms": 134,
      "failed": 0,
      "name": "real-herdr-gated"
    }
  ],
  "finished_at": "2026-08-24T21:30:04Z",
  "run_id": "fm-test-run-1787607004469-2320079",
  "scripts": [
    {
      "duration_ms": 134,
      "exit": 0,
      "expected_gate_skip": "herdr",
      "family": "real-herdr-gated",
      "gate_skip": false,
      "path": "tests/fm-backend-herdr-eventwait.test.py"
    }
  ],
  "selection": "scripts",
  "started_at": "2026-08-24T21:30:04Z",
  "summary": {
    "duration_ms": 180,
    "failed": 0,
    "skipped_gate": 0,
    "total": 1
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"bd5024fd7eb409a37b09743e4c45dfe4041882ce","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-test-run.test.sh` — all relevant runner, Python discovery, failure-propagation, empty-glob, orphan-inventory, lane, and scheduler checks passed; the later Ruby-backed workflow YAML check was UNRUN because Ruby is absent.</code>
- `bin/fm-test-run.sh tests/fm-backend-herdr-eventwait.test.py --json /home/taimur/.no-mistakes/evidence/01M0TTNHA8KP135GY9Y0EZ72QB/eventwait.json`
- `bin/fm-test-run.sh --check-coverage`
- `bin/fm-test-run.sh --list --family real-herdr-gated`
- `bin/fm-test-run.sh --list --changed --base 038d0f7ec6ba7238a151722931434dcf06ff37c4`
- <code>Compared supported shell-test inventory at the base and target: both contain exactly 161 `tests/*.test.sh` files.</code>
- <code>Verified `git status --short` remained clean after testing.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: Validate lint with pinned actionlint
1 warning still open:

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
