### PR TITLE
fix(composer): treat an NBSP-padded composer as empty, not pending

### DIFF
--- a/bin/fm-composer-lib.sh
+++ b/bin/fm-composer-lib.sh
@@ -127,11 +127,21 @@ fm_composer_strip_ansi() {
 #   U+202F NARROW NO-BREAK SPACE      U+205F MEDIUM MATHEMATICAL SPACE
 #   U+3000 IDEOGRAPHIC SPACE
 # ASCII whitespace is absent because POSIX `[[:space:]]` already covers it.
-# U+200B ZERO WIDTH SPACE is deliberately absent: Unicode gives it
-# White_Space=No (a format character), so listing it would substitute this
-# owner's own guess for the property it claims to follow. The live harness
-# guard (bin/fm-test-run.sh, live-harness-optin) is what catches a harness
-# that starts drawing its composer with a character outside this property.
+# The zero-width format characters - U+200B ZERO WIDTH SPACE, U+2060 WORD
+# JOINER, U+FEFF ZERO WIDTH NO-BREAK SPACE - are all deliberately absent:
+# Unicode gives every one of them White_Space=No, so listing them would
+# substitute this owner's own guess for the property it claims to follow. Two
+# further reasons hold the line exactly there. Mapping them onto a SPACE would
+# be wrong in substance: this table substitutes rather than deletes precisely
+# because its members occupy width the harness drew, while a zero-width
+# character occupies none and a space would invent a separation that was never
+# rendered. And the failure directions are not symmetric: a row of zero-width
+# characters classifies `pending`, which only DEFERS an injection - the safe
+# direction, and one the max-defer alarm surfaces - whereas admitting an
+# unproven character widens `empty`, the direction that types an escalation
+# over a captain's half-written line. The live harness guard
+# (bin/fm-test-run.sh, live-harness-optin) is what catches a harness that
+# starts drawing its composer with a character outside this property.
 FM_COMPOSER_UNICODE_SPACES=()
 for _fm_composer_space_octal in \
   '\0302\0205' '\0302\0240' '\0341\0232\0200' \

--- a/bin/fm-supervise-daemon.sh
+++ b/bin/fm-supervise-daemon.sh
@@ -1126,6 +1126,22 @@ window_for_task() {  # <task-key> [state]
 #     after dim/faint ghost text and borders are ignored (a human's half-typed
 #     line, or a previous injection's unsent text), defer entirely - injecting
 #     would merge with the human's text.
+# _composer_defer_reason: the deferral cause for ONE composer verdict, in that
+# verdict's own words. The verdicts mean different things and send a reader to
+# different places, so they never share a sentence: this line once read
+# "pending input, dead-shell prompt, or unreadable pane" for every non-empty
+# verdict, and a `pending` pane sent the first reader hunting a dead shell that
+# did not exist. bin/fm-composer-lib.sh owns the verdict vocabulary.
+_composer_defer_reason() {  # <verdict>
+  case "$1" in
+    pending)          printf 'state=pending: real unsubmitted text sits in the composer' ;;
+    pending-unproven) printf 'state=pending-unproven: composer text that an unstyled capture cannot prove is real' ;;
+    unknown)          printf 'state=unknown: dead-shell prompt, unidentified row, or unreadable pane' ;;
+    '')               printf 'state=absent: the backend returned no verdict' ;;
+    *)                printf 'state=%s: unrecognized verdict, refused as unsafe' "$1" ;;
+  esac
+}
+
 inject_msg() {  # <message> [state]
   local msg=$1 state target backend retries sleep_s verdict composer encoded
   state="${2:-$(_state_root)}"
@@ -1164,7 +1180,7 @@ inject_msg() {  # <message> [state]
   #      stays buffered for the next cycle or the catch-up flush.
   composer=$(fm_backend_composer_state "$backend" "$target" 2>/dev/null)
   if [ "$composer" != empty ]; then
-    log "inject deferred: supervisor composer not confirmed-empty (state=${composer:-unknown}: pending input, dead-shell prompt, or unreadable pane)"
+    log "inject deferred: supervisor composer not confirmed-empty ($(_composer_defer_reason "$composer"))"
     return 1
   fi
   # (4) Type the digest ONCE, then submit with Enter (retry Enter only, never

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -170,6 +170,70 @@ assert_screen() {
   [ "$out" = "$want" ] || fail "$label under LC_ALL=C: expected $want, got '$out'"
 }
 
+# --- The Unicode-whitespace boundary ---------------------------------------
+
+# assert_content <label> <want> <bordered> <content>: one content verdict,
+# asserted under the ambient locale AND LC_ALL=C, because the whole defect
+# class this pins is a trim that changed meaning with the ambient locale.
+assert_content() {
+  local label=$1 want=$2 bordered=$3 content=$4 out
+  out=$(classify "$bordered" "$content")
+  [ "$out" = "$want" ] || fail "$label: expected $want, got '$out'"
+  out=$(LC_ALL=C classify "$bordered" "$content")
+  [ "$out" = "$want" ] || fail "$label under LC_ALL=C: expected $want, got '$out'"
+}
+
+test_unicode_whitespace_padding_is_empty() {
+  # Invisible padding a harness draws AROUND nothing is an empty composer. The
+  # away-mode injector types only into an affirmative `empty`, so a false
+  # `pending` here silently disables every escalation (issue #1988).
+  local fig nnbsp
+  fig=$(printf '\342\200\207')    # U+2007 FIGURE SPACE
+  nnbsp=$(printf '\342\200\257')  # U+202F NARROW NO-BREAK SPACE
+  assert_content "bare glyph" empty 1 '❯'
+  assert_content "glyph + ASCII space" empty 1 '❯ '
+  assert_content "glyph + U+00A0" empty 1 "❯$NBSP"
+  assert_content "glyph + U+2007" empty 1 "❯$fig"
+  assert_content "glyph + U+202F" empty 1 "❯$nnbsp"
+  assert_content "glyph + mixed unicode padding" empty 1 "❯$NBSP$fig$nnbsp"
+  # A row that is nothing BUT invisible whitespace, with no glyph at all.
+  assert_content "unicode whitespace only" empty 1 "$NBSP$fig$nnbsp"
+  pass "fm_composer_classify_content: unicode whitespace padding reads empty in both locales (#1988)"
+}
+
+test_unicode_whitespace_around_text_stays_pending() {
+  # The guard in the other direction, and the one that protects a captain's
+  # half-typed line: invisible characters AROUND visible content never make
+  # that content disappear. Widening `empty` to cover these would type an
+  # escalation over real input.
+  local fig nnbsp
+  fig=$(printf '\342\200\207')
+  nnbsp=$(printf '\342\200\257')
+  assert_content "glyph + U+00A0 + text" pending 1 "❯${NBSP}fix the login bug"
+  assert_content "glyph + text + U+00A0" pending 1 "❯ fix the login bug$NBSP"
+  assert_content "text wrapped in unicode padding" pending 1 "❯$fig deploy staging$nnbsp"
+  assert_content "unicode padding around bare text" pending 1 "${NBSP}rerun the failing check${NBSP}"
+  pass "fm_composer_classify_content: unicode whitespace around real text stays pending"
+}
+
+test_zero_width_format_chars_defer() {
+  # The deliberate line (bin/fm-composer-lib.sh's FM_COMPOSER_UNICODE_SPACES):
+  # zero-width format characters are White_Space=No and are NOT admitted, so a
+  # row of them defers rather than claiming to be an injectable empty composer.
+  # Deferring is the safe direction and the max-defer alarm surfaces it; a
+  # false `empty` would not be surfaced at all. Pinned so that admitting one
+  # later has to be a deliberate edit to this expectation, backed by a real
+  # harness that draws it.
+  local wj zwnbsp zwsp
+  wj=$(printf '\342\201\240')      # U+2060 WORD JOINER
+  zwnbsp=$(printf '\357\273\277')  # U+FEFF ZERO WIDTH NO-BREAK SPACE
+  zwsp=$(printf '\342\200\213')    # U+200B ZERO WIDTH SPACE
+  assert_content "glyph + U+2060" pending 1 "❯$wj"
+  assert_content "glyph + U+FEFF" pending 1 "❯$zwnbsp"
+  assert_content "glyph + U+200B" pending 1 "❯$zwsp"
+  pass "fm_composer_classify_content: zero-width format chars defer, never widen empty"
+}
+
 test_matrix_claude_bare_nbsp_row() {
   # Real idle claude: `❯` + U+00A0, borderless, between horizontal rules.
   # The audit's headline defect: this row read `pending` under LC_ALL=C
@@ -612,6 +676,9 @@ test_empty_content_is_empty
 test_idle_placeholder_is_empty
 test_idle_placeholder_case_mode_is_explicit
 test_real_text_is_pending
+test_unicode_whitespace_padding_is_empty
+test_unicode_whitespace_around_text_stays_pending
+test_zero_width_format_chars_defer
 test_matrix_claude_bare_nbsp_row
 test_matrix_codex_dim_hint_row
 test_matrix_muse_truecolor_glyph_survives_signal_loss


### PR DESCRIPTION
## The bug

`fm_composer_classify_content` classifies a composer holding a prompt glyph followed by U+00A0 (non-breaking space) as `pending`, identically to real typed text.

```
$ source bin/fm-composer-lib.sh
$ NBSP=$(printf '\xc2\xa0')
$ fm_composer_classify_content 1 '❯'            -> empty
$ fm_composer_classify_content 1 "❯${NBSP}"     -> pending      # the bug
$ fm_composer_classify_content 1 '❯ '           -> empty
$ fm_composer_classify_content 1 '❯ hello'      -> pending
```

The glyph-stripping `case` matches `'❯ '*` (glyph plus ASCII space), so an NBSP-padded row falls through to the single-character `'❯'*` branch and leaves `\xC2\xA0` behind.
The following trim uses `[![:space:]]`, and bash's `[:space:]` does not match U+00A0 in the C/POSIX locale, so the NBSP survives, the row reads non-empty, and the verdict is `pending`.

## Why it matters

The away-mode daemon injects only on an affirmatively `empty` composer.
A Claude Code pane on the herdr backend renders its idle composer as `❯` followed by U+00A0, verified from a raw ANSI capture:

```
\e[38;2;153;153;153m❯\xC2\xA0
```

That pane can therefore never be injected into, so away-mode supervision is silently dead for it rather than degraded.

Observed on 2026-08-24: an overnight autonomous run stalled with **63,681 seconds (about 17.7 hours) of undelivered escalations**.
Three workers completed and nothing after them started, because the wake path into the supervised session could not be used.
`state/.supervise-daemon.log` repeated:

```
inject deferred: supervisor composer not confirmed-empty (state=pending: pending input, dead-shell prompt, or unreadable pane)
```

The wedge alarm fired correctly and was the only signal that anything was wrong.

## The fix

Treat Unicode whitespace as whitespace when judging composer emptiness, while keeping `pending` protective of real input.

A row of only invisible characters is empty.
Invisible characters around visible content remain `pending`, so a half-typed line is still protected:

```
fm_composer_classify_content 1 "❯${NBSP}"        -> empty
fm_composer_classify_content 1 "❯${NBSP}hello"   -> pending
fm_composer_classify_content 1 '❯ hello'         -> pending
fm_composer_classify_content 1 '❯'               -> empty
```

## Also fixed: the deferral log conflated two verdicts

`state=pending: pending input, dead-shell prompt, or unreadable pane` named three conditions in one string.
Per the classifier's own contract, `pending` means real unsubmitted text, while a dead shell or an unreadable pane is `unknown`.
The conflated message sent the first reader looking for a dead shell that did not exist.
Each verdict now prints only what it actually means.

## Tests

Extended `tests/fm-composer-lib.test.sh` rather than adding a runner.
Cases cover the bare glyph, glyph plus NBSP, glyph plus ASCII space, glyph plus NBSP plus real text, and a row of only invisible characters.
Tests exercise the public interface and assert no implementation bytes.

`bin/fm-lint.sh` passes.
