### PR TITLE
fix(bin): support Windows/MSYS session-lock harness identity

### DIFF
--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -19,6 +19,69 @@
 # Known harness command names; extend when a new adapter is verified.
 FM_HARNESS_RE='claude|codex|opencode|grok|kimi|^pi$|^pi-signed$'
 
+# Resolved once at source time, mirroring bin/fm-wake-lib.sh: process identity
+# runs in hot hook paths and forking uname per call is a measurable cost on the
+# platform (Git Bash/MSYS) that already pays the highest fork price. The
+# override exists so the platform-specific branches below are testable from any
+# host, exactly like FM_PROC_ROOT_OVERRIDE.
+_FM_SLOCK_UNAME=${FM_SLOCK_UNAME_OVERRIDE:-$(uname -s 2>/dev/null || echo unknown)}
+
+# True on a Windows bash host (Git Bash/MSYS/Cygwin), where the bundled ps
+# rejects -o entirely and only sees MSYS-side processes: the harness itself is
+# a NATIVE Windows process (for example claude.exe run from npm), invisible to
+# that ps, so the POSIX ancestry walk below can never find it. The Windows
+# branches read the native process tree through PowerShell CIM instead.
+fm_slock_windows() {
+  case "$_FM_SLOCK_UNAME" in
+    MINGW*|MSYS*|CYGWIN*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Print "pid<TAB>name<TAB>command line" for native Windows process $1 and each
+# of its native ancestors, innermost first, up to 16 hops, using ONE PowerShell
+# child so the walk pays a single interpreter startup. MSYS processes are real
+# Windows processes too, so this one native walk covers the whole chain with
+# correct Windows parent pids - unlike the MSYS ps view, whose ppid says 1 the
+# moment the parent is native. Any failure prints nothing and the callers fail
+# closed.
+fm_win_ancestry_lines() {  # <start-winpid>
+  local start=$1 ps_bin
+  case "$start" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  ps_bin=$(command -v powershell.exe 2>/dev/null) || ps_bin=$(command -v pwsh 2>/dev/null) || return 1
+  # shellcheck disable=SC2016 # the single-quoted $ names are PowerShell variables, not shell expansions
+  "$ps_bin" -NoProfile -NonInteractive -Command '
+    $ErrorActionPreference = "SilentlyContinue"
+    $cur = [int]"'"$start"'"
+    $seen = @{}
+    for ($i = 0; $i -lt 16 -and $cur -gt 0 -and -not $seen.ContainsKey($cur); $i++) {
+      $seen[$cur] = $true
+      $p = Get-CimInstance Win32_Process -Filter "ProcessId = $cur"
+      if (-not $p) { break }
+      Write-Output ("{0}`t{1}`t{2}" -f $p.ProcessId, $p.Name, $p.CommandLine)
+      $cur = [int]$p.ParentProcessId
+    }' 2>/dev/null | tr -d '\r'
+}
+
+# Print "name<TAB>command line" for native Windows process $1, or return 1 when
+# no such process exists. A returned row is the liveness proof itself.
+fm_win_process_line() {  # <winpid>
+  local pid=$1 ps_bin out
+  case "$pid" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  ps_bin=$(command -v powershell.exe 2>/dev/null) || ps_bin=$(command -v pwsh 2>/dev/null) || return 1
+  # shellcheck disable=SC2016 # the single-quoted $ names are PowerShell variables, not shell expansions
+  out=$("$ps_bin" -NoProfile -NonInteractive -Command '
+    $ErrorActionPreference = "SilentlyContinue"
+    $p = Get-CimInstance Win32_Process -Filter "ProcessId = '"$pid"'"
+    if ($p) { Write-Output ("{0}`t{1}" -f $p.Name, $p.CommandLine) }' 2>/dev/null | tr -d '\r')
+  [ -n "$out" ] || return 1
+  printf '%s\n' "$out"
+}
+
 # The same harnesses as exact executable names. Keep in sync with
 # FM_HARNESS_RE. Used only for the stricter path evidence below, where the
 # loose regex would also match ordinary firstmate paths such as
@@ -106,8 +169,81 @@ fm_harness_process_matches() {  # <comm> <args>
 # claude), with no non-harness process between them. Which pid in that run is the
 # session cannot be read off the ancestry at all, so the whole contiguous run is
 # reported and the callers below decide what they need from it.
+# The Windows shape of the same walk, in two segments that meet at the MSYS
+# root. The MSYS segment is climbed through the emulated /proc, because MSYS
+# fork emulation routinely leaves a DEAD native parent above any script-invoked
+# child (the fork copy's Windows process exits when the child execs), so a
+# purely native ppid walk from a nested shell dead-ends below the harness. The
+# MSYS pid chain survives that emulation intact. The native segment then starts
+# from the MSYS root's Windows pid - that root was spawned natively by the
+# harness itself, so its native parent chain is whole - and is fetched in one
+# PowerShell call. Both segments feed the identical first-match/contiguity/
+# Claude-extends decision, with reported pids always NATIVE Windows pids so the
+# written lock is checkable from any later process. Backslashes in native
+# command lines are normalized to slashes only for matching, so the
+# path-component evidence works on Windows install paths.
+fm_win_harness_ancestry_pids() {
+  local proc_root pid winpid root_winpid='' ppid exe args lines line name cmdline
+  local extending=0 printed=0 run_ended=0 hops=0
+  proc_root=${FM_PROC_ROOT_OVERRIDE:-/proc}
+  pid=$$
+  while [ "$hops" -lt 16 ]; do
+    hops=$((hops + 1))
+    winpid=$(cat "$proc_root/$pid/winpid" 2>/dev/null | tr -d '[:space:]')
+    case "$winpid" in
+      ''|*[!0-9]*) return 1 ;;
+    esac
+    root_winpid=$winpid
+    exe=$(cat "$proc_root/$pid/exename" 2>/dev/null || true)
+    args=$(tr '\0' ' ' < "$proc_root/$pid/cmdline" 2>/dev/null || true)
+    if fm_harness_process_matches "$exe" "$args"; then
+      printf '%s\n' "$winpid"
+      printed=1
+      if [ "$FM_HARNESS_IS_CLAUDE" -ne 1 ]; then
+        run_ended=1
+        break
+      fi
+      extending=1
+    elif [ "$extending" -eq 1 ]; then
+      run_ended=1
+      break
+    fi
+    ppid=$(cat "$proc_root/$pid/ppid" 2>/dev/null | tr -d '[:space:]')
+    case "$ppid" in
+      ''|*[!0-9]*) break ;;
+    esac
+    [ "$ppid" -gt 1 ] || break
+    pid=$ppid
+  done
+  if [ "$run_ended" -eq 0 ]; then
+    lines=$(fm_win_ancestry_lines "$root_winpid") || lines=''
+    while IFS=$'\t' read -r line name cmdline; do
+      case "$line" in
+        ''|*[!0-9]*) continue ;;
+      esac
+      # The MSYS root itself was already judged from its /proc evidence.
+      [ "$line" = "$root_winpid" ] && continue
+      if fm_harness_process_matches "$name" "${cmdline//\\//}"; then
+        printf '%s\n' "$line"
+        printed=1
+        [ "$FM_HARNESS_IS_CLAUDE" -eq 1 ] || break
+        extending=1
+      elif [ "$extending" -eq 1 ]; then
+        break
+      fi
+    done <<EOF
+$lines
+EOF
+  fi
+  [ "$printed" -eq 1 ]
+}
+
 fm_harness_ancestry_pids() {
   local pid=$$ comm args extending=0 printed=0
+  if fm_slock_windows; then
+    fm_win_harness_ancestry_pids
+    return
+  fi
   for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
     args=$(ps -o args= -p "$pid" 2>/dev/null)
@@ -145,7 +281,16 @@ EOF
 
 # True if $1 is a live process that looks like a verified harness.
 fm_harness_pid_alive() {
-  local pid=$1 comm args
+  local pid=$1 comm args line
+  if fm_slock_windows; then
+    # The lock holds a NATIVE Windows pid, which MSYS kill and ps cannot see;
+    # one CIM row is both the liveness proof and the identity evidence.
+    line=$(fm_win_process_line "$pid") || return 1
+    comm=${line%%$'\t'*}
+    args=${line#*$'\t'}
+    fm_harness_process_matches "$comm" "${args//\\//}"
+    return
+  fi
   kill -0 "$pid" 2>/dev/null || return 1
   comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
   args=$(ps -o args= -p "$pid" 2>/dev/null)

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -13,6 +13,23 @@ FM_LOCK_STALE_AFTER="${FM_LOCK_STALE_AFTER:-2}"
 # confirm and 0.5s attach polls, and forking uname per call is a measurable cost on
 # the platform (Git Bash/MSYS) that already pays the highest fork price.
 _FM_UNAME=$(uname 2>/dev/null || echo unknown)
+# The lock primitives below publish a claim with an atomic `ln -s` and verify
+# it with readlink. Git Bash/MSYS silently emulates `ln -s` as a COPY unless
+# the MSYS runtime is told to create native symlinks, which turns the claim
+# into an unverifiable plain directory and the acquire path into an endless
+# retry. Native symlink creation without elevation requires Windows Developer
+# Mode; with it off, `ln -s` fails with "Operation not permitted", which the
+# claim path reports as a lock failure instead of spinning on a false copy.
+# Exported here, at source time, so every child `ln` a lock helper forks
+# inherits the request; an operator's own winsymlinks choice is preserved.
+case "$_FM_UNAME" in
+  MINGW*|MSYS*|CYGWIN*)
+    case "${MSYS:-}" in
+      *winsymlinks*) ;;
+      *) export MSYS="${MSYS:+$MSYS }winsymlinks:nativestrict" ;;
+    esac
+    ;;
+esac
 mkdir -p "$STATE"
 
 fm_current_pid() {

--- a/tests/fm-session-lock-ancestry.test.sh
+++ b/tests/fm-session-lock-ancestry.test.sh
@@ -35,14 +35,88 @@ NAMED_CLAUDE="$FAKEBIN/claude"
 # --- unit layer: identity behind a deterministic process table ---------------
 
 # Run one library expression with <fakebin> shadowing ps. kill is stubbed so
-# liveness questions are decided by the process table alone.
+# liveness questions are decided by the process table alone. The platform is
+# pinned to the POSIX branch so these cases stay deterministic on a Windows
+# host, whose real uname would otherwise divert the walk to the native branch.
 lib_eval() {  # <fakebin> <expression>
   local fakebin=$1 expr=$2
-  PATH="$fakebin:$PATH" bash -c "
+  PATH="$fakebin:$PATH" FM_SLOCK_UNAME_OVERRIDE=Linux bash -c "
     . \"\$0\"
     kill() { return 0; }
     $expr
   " "$LIB"
+}
+
+# Run one library expression on the WINDOWS branch: a fake MSYS /proc supplies
+# the emulated-side chain (this shell as an msys root whose winpid is 4100),
+# and a fake powershell.exe in <fakebin> supplies the native process table for
+# the current FM_TEST_WIN_SHAPE. The expression's shell registers itself in the
+# fake proc, so the walk starts exactly where a real session's walk starts.
+win_eval() {  # <fakebin> <procroot> <expression>
+  local fakebin=$1 procroot=$2 expr=$3
+  PATH="$fakebin:$PATH" FM_SLOCK_UNAME_OVERRIDE=MINGW64_NT-10.0 \
+    FM_PROC_ROOT_OVERRIDE="$procroot" bash -c "
+    . \"\$0\"
+    kill() { return 0; }
+    mkdir -p \"\$FM_PROC_ROOT_OVERRIDE/\$\$\"
+    printf '%s\n' 4100 > \"\$FM_PROC_ROOT_OVERRIDE/\$\$/winpid\"
+    printf '%s\n' /usr/bin/bash > \"\$FM_PROC_ROOT_OVERRIDE/\$\$/exename\"
+    printf 'bash\0-c\0fixture\0' > \"\$FM_PROC_ROOT_OVERRIDE/\$\$/cmdline\"
+    printf '%s\n' 1 > \"\$FM_PROC_ROOT_OVERRIDE/\$\$/ppid\"
+    $expr
+  " "$LIB"
+}
+
+# One fake powershell.exe serves every Windows shape: the ancestry-walk script
+# is recognized by its \$seen hashtable, anything else is the single-process
+# query, answered from the same canned native table. Output uses CRLF exactly
+# as the real PowerShell child does, so the CR stripping stays exercised.
+make_win_fakebin() {  # <dir>
+  local fakebin
+  fakebin=$(fm_fakebin "$1")
+  cat > "$fakebin/powershell.exe" <<'SH'
+#!/usr/bin/env bash
+set -u
+cmd="$*"
+shape=${FM_TEST_WIN_SHAPE:-claude}
+walk_table() {
+  case "$shape" in
+    claude)
+      printf '4100\tbash.exe\t"C:\\Program Files\\Git\\usr\\bin\\bash.exe" -c fixture\r\n'
+      printf '4200\tclaude.exe\t"C:\\Users\\u\\AppData\\Roaming\\npm\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe"\r\n'
+      printf '4300\tpowershell.exe\tC:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\powershell.exe -NoExit\r\n'
+      ;;
+    node)
+      printf '4100\tbash.exe\t"C:\\Program Files\\Git\\usr\\bin\\bash.exe" -c fixture\r\n'
+      printf '4200\tnode.exe\t"C:\\Program Files\\nodejs\\node.exe" "C:\\Users\\u\\AppData\\Roaming\\npm\\node_modules\\@anthropic-ai\\claude-code\\cli.js"\r\n'
+      printf '4300\tpowershell.exe\tC:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\powershell.exe -NoExit\r\n'
+      ;;
+    gap)
+      printf '4100\tbash.exe\t"C:\\Program Files\\Git\\usr\\bin\\bash.exe" -c fixture\r\n'
+      printf '4200\tclaude.exe\t"C:\\Users\\u\\AppData\\Roaming\\npm\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe"\r\n'
+      printf '4300\tbash.exe\t"C:\\Program Files\\Git\\usr\\bin\\bash.exe" tests/run.sh\r\n'
+      printf '4400\tclaude.exe\t"C:\\Users\\u\\AppData\\Roaming\\npm\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe"\r\n'
+      ;;
+    none)
+      printf '4100\tbash.exe\t"C:\\Program Files\\Git\\usr\\bin\\bash.exe" -c fixture\r\n'
+      printf '4300\tpowershell.exe\tC:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\powershell.exe -NoExit\r\n'
+      ;;
+  esac
+}
+if printf '%s' "$cmd" | grep -q 'seen'; then
+  walk_table
+else
+  pid=$(printf '%s' "$cmd" | grep -o 'ProcessId = [0-9][0-9]*' | grep -o '[0-9][0-9]*')
+  walk_table | while IFS=$'\t' read -r row_pid row_name row_args; do
+    row_pid=${row_pid//$'\r'/}
+    if [ "$row_pid" = "$pid" ]; then
+      printf '%s\t%s' "$row_name" "$row_args"
+    fi
+  done
+fi
+SH
+  chmod +x "$fakebin/powershell.exe"
+  printf '%s\n' "$fakebin"
 }
 
 test_version_named_session_is_identified_on_both_platforms() {
@@ -220,6 +294,63 @@ SH
   pass "session-lock: a live version-named session holding the lock is not mistaken for a stale owner"
 }
 
+test_windows_native_session_is_identified() {
+  local dir fakebin shape got
+  dir="$TMP_ROOT/win-native"
+  fakebin=$(make_win_fakebin "$dir")
+  mkdir -p "$dir/state"
+  printf '4200\n' > "$dir/state/.lock"
+
+  # claude: the harness runs as a native claude.exe above the MSYS root.
+  # node: the same session shape when the harness is a bare node.exe running
+  # the claude-code script, identified from its command line.
+  for shape in claude node; do
+    got=$(FM_TEST_WIN_SHAPE="$shape" win_eval "$fakebin" "$dir/proc-$shape" 'fm_harness_ancestry_pid') \
+      || fail "$shape: the native harness was not found through the MSYS root bridge"
+    [ "$got" = 4200 ] || fail "$shape: ancestry resolved '$got', expected the native harness pid 4200"
+    FM_TEST_WIN_SHAPE="$shape" win_eval "$fakebin" "$dir/proc-$shape" 'fm_harness_pid_alive 4200' \
+      || fail "$shape: a live native harness was not recognized by the liveness predicate"
+    FM_TEST_WIN_SHAPE="$shape" win_eval "$fakebin" "$dir/proc-$shape" "fm_session_lock_owned_by_self '$dir/state'" \
+      || fail "$shape: the session holding the lock did not recognize itself as the owner"
+  done
+  pass "session-lock win: a native harness above the MSYS root is identified and owns its lock"
+}
+
+test_windows_harness_beyond_a_gap_never_owns_the_lock() {
+  local dir fakebin got
+  dir="$TMP_ROOT/win-gap"
+  fakebin=$(make_win_fakebin "$dir")
+  mkdir -p "$dir/state"
+
+  got=$(FM_TEST_WIN_SHAPE=gap win_eval "$fakebin" "$dir/proc" 'fm_harness_ancestry_pid') \
+    || fail "the contiguous native harness run was not resolved"
+  [ "$got" = 4200 ] || fail "ancestry crossed a native non-harness gap, resolved '$got' instead of 4200"
+  printf '4400\n' > "$dir/state/.lock"
+  if FM_TEST_WIN_SHAPE=gap win_eval "$fakebin" "$dir/proc" "fm_session_lock_owned_by_self '$dir/state'"; then
+    fail "an unrelated native harness beyond a non-harness gap was accepted as this session's lock owner"
+  fi
+  # The unrelated harness is alive, so its lock must read as held, not stale.
+  FM_TEST_WIN_SHAPE=gap win_eval "$fakebin" "$dir/proc" 'fm_harness_pid_alive 4400' \
+    || fail "a live competing native session was classified as a dead lock owner"
+  pass "session-lock win: ownership stops at the first native non-harness gap"
+}
+
+test_windows_no_harness_in_ancestry_fails_closed() {
+  local dir fakebin
+  dir="$TMP_ROOT/win-none"
+  fakebin=$(make_win_fakebin "$dir")
+  mkdir -p "$dir/state"
+  printf '4300\n' > "$dir/state/.lock"
+
+  if FM_TEST_WIN_SHAPE=none win_eval "$fakebin" "$dir/proc" 'fm_harness_ancestry_pid'; then
+    fail "an all-ordinary native chain produced a harness pid"
+  fi
+  if FM_TEST_WIN_SHAPE=none win_eval "$fakebin" "$dir/proc" "fm_session_lock_owned_by_self '$dir/state'"; then
+    fail "a session with no harness in its ancestry claimed the home's session lock"
+  fi
+  pass "session-lock win: no harness in the native chain fails closed"
+}
+
 # --- end-to-end layer: the real Stop auto-arm in real process trees ----------
 
 install_autoarm_scripts() {
@@ -360,6 +491,20 @@ test_version_named_session_is_identified_on_both_platforms
 test_ordinary_paths_are_never_harness_processes
 test_harness_beyond_a_gap_never_owns_the_lock
 test_competing_version_named_session_is_seen_as_live
-test_e2e_version_named_session_claims_the_home
-test_e2e_daemon_parented_session_claims_the_home
-test_e2e_daemon_parented_version_named_session_keeps_its_lock
+test_windows_native_session_is_identified
+test_windows_harness_beyond_a_gap_never_owns_the_lock
+test_windows_no_harness_in_ancestry_fails_closed
+case "$(uname -s 2>/dev/null)" in
+  MINGW*|MSYS*|CYGWIN*)
+    # The e2e fixtures orphan POSIX process trees and watch them with
+    # `ps -o ppid=`, which the MSYS ps does not support; the Windows branch is
+    # covered by the deterministic win-shape cases above, and the e2e layer
+    # stays authoritative on the POSIX CI hosts.
+    echo "note: MSYS host; skipping the POSIX process-tree e2e layer" >&2
+    ;;
+  *)
+    test_e2e_version_named_session_claims_the_home
+    test_e2e_daemon_parented_session_claims_the_home
+    test_e2e_daemon_parented_version_named_session_keeps_its_lock
+    ;;
+esac


### PR DESCRIPTION
## Problem

On Windows (Git Bash/MSYS) every session start refuses the fleet lock as read-only with `error: cannot locate harness process in ancestry`. Two independent platform gaps cause this:

1. **Harness ancestry is unresolvable.** The walk uses `ps -o comm=/args=/ppid=`, but the MSYS `ps` implements none of the `-o` fields, and the harness itself (e.g. `claude.exe`) is a native Windows process invisible to the MSYS process table. A purely native ppid walk also fails from nested shells, because MSYS fork emulation leaves a dead native parent above any script-invoked child.
2. **The claim lock cannot publish.** `fm_lock_try_create` publishes with an atomic `ln -s`, which Git Bash silently emulates as a directory COPY, so `readlink` verification always fails and the acquire path retries forever (a hang, where the ancestry failure at least failed loudly).

## Fix

- `fm-session-lock-lib.sh`: on MSYS hosts, walk the MSYS-side `/proc` chain (which survives fork emulation) to its root, then continue through the native process tree with one PowerShell `Get-CimInstance Win32_Process` child. The identical first-match / contiguity / Claude-extends decision applies across both segments, and reported pids are always native Windows pids so the written lock is checkable from any later process. Holder liveness reads one CIM row as both liveness proof and identity evidence.
- `fm-wake-lib.sh`: on MSYS hosts, export `MSYS=winsymlinks:nativestrict` at source time (preserving an operator's own winsymlinks choice) so lock symlinks are real. With Windows Developer Mode off, `ln -s` then fails loudly with `Operation not permitted` instead of spinning on a false copy.

## Verification (Windows 11, Git Bash, Claude Code harness)

- `bin/fm-lock.sh` acquires, verifies, re-acquires idempotently, and `status` reports the live harness pid; `fm_session_lock_owned_by_self` recognizes the session (all previously impossible on this platform).
- `tests/fm-session-lock-ancestry.test.sh`: existing unit cases pinned to the POSIX branch pass; three new Windows-shape cases (native harness, node-run harness script, gap containment, fail-closed no-harness chain) pass behind deterministic `powershell.exe`/proc fakes; the POSIX process-tree e2e layer is explicitly skipped on MSYS hosts where its `ps -o` fixtures cannot run (both layers verified passing on this host, e2e skip noted).
- `bin/fm-lint.sh` clean (ShellCheck 0.11.0, actionlint 1.7.12).

Requires Windows Developer Mode for native symlink creation; without it the lock now reports a concrete failure instead of hanging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013C8w97fbJUPN5j64iUPSQv
