### PR TITLE
feat(brief): guide scouts to use DeepAPI when installed

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -318,6 +318,11 @@ EOF
 HERDR_SECTION=${HERDR_SECTION%$'\n'}
 fi
 
+DEEPAPI_SECTION=
+if [ -n "${HOME:-}" ] && [ -f "$HOME/.agents/skills/deepapi/SKILL.md" ]; then
+  DEEPAPI_SECTION=$'Use the `deepapi` skill for web searches, page reads, PDF extraction, and platform lookups in preference to ordinary fetching or built-in browsing.\nSpawned workers do not inherit the credentials, so before concluding anything about DeepAPI availability run `source ~/.deepapi/env`; do not report it unavailable without trying that recovery.\nIf a source remains unreachable even with DeepAPI, say so explicitly in your report rather than reasoning around the gap - an unreachable source is itself a finding.'
+fi
+
 if [ "$KIND" = scout ]; then
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
@@ -332,6 +337,7 @@ You are in a disposable git worktree of $REPO, at a detached HEAD on a clean def
 This is a SCOUT task: the deliverable is a written report, not a PR.
 The worktree is your laboratory - install, run, edit, and make scratch commits freely; all of it is discarded at teardown.
 The report is the only thing that survives, so anything worth keeping must be in it.
+$DEEPAPI_SECTION
 
 # Rules
 1. Never push to any remote and never open a PR.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -11,6 +11,9 @@
 #        fm-brief.sh <task-id> --secondmate {<project>...|--no-projects}
 #   --scout writes the scout contract instead: the deliverable is a report at
 #   data/<task-id>/report.md (no branch, no push, no PR) and the worktree is scratch.
+#   When the canonical global `$HOME/.agents/skills/deepapi/SKILL.md` exists,
+#   scout briefs also include concise DeepAPI retrieval guidance; ship and
+#   secondmate briefs do not. The deepapi skill owns its usage details.
 #   --secondmate writes a persistent secondmate charter. The project list
 #   is cloned into the secondmate home, while the natural-language scope
 #   tells the main firstmate when to route work there; routine churn stays in its own home;

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -730,8 +730,10 @@ test_scout_deepapi_guidance_requires_the_skill() {
   home="$TMP_ROOT/deepapi-guidance-home"
   mkdir -p "$home/data"
 
-  HOME="$home" FM_HOME="$home" "$ROOT/bin/fm-brief.sh" deepapi-absent firstmate --scout >/dev/null 2>&1
+  HOME="$home" FM_HOME="$home" "$ROOT/bin/fm-brief.sh" deepapi-absent firstmate --scout >/dev/null 2>&1 \
+    || fail "fm-brief.sh scout scaffold without DeepAPI skill exited non-zero"
   brief="$home/data/deepapi-absent/brief.md"
+  assert_present "$brief" "scout brief without DeepAPI skill was not scaffolded"
   # shellcheck disable=SC2016 # Literal backticks must remain unexpanded.
   assert_no_grep 'Use the `deepapi` skill' "$brief" \
     "scout brief emitted DeepAPI guidance when the skill was absent"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -725,6 +725,39 @@ test_scout_and_secondmate_load_decision_hold_policy() {
   pass "fm-brief.sh: investigation and visual-review completions load the shared decision policy"
 }
 
+test_scout_deepapi_guidance_requires_the_skill() {
+  local home brief
+  home="$TMP_ROOT/deepapi-guidance-home"
+  mkdir -p "$home/data"
+
+  HOME="$home" FM_HOME="$home" "$ROOT/bin/fm-brief.sh" deepapi-absent firstmate --scout >/dev/null 2>&1
+  brief="$home/data/deepapi-absent/brief.md"
+  # shellcheck disable=SC2016 # Literal backticks must remain unexpanded.
+  assert_no_grep 'Use the `deepapi` skill' "$brief" \
+    "scout brief emitted DeepAPI guidance when the skill was absent"
+
+  mkdir -p "$home/.agents/skills/deepapi"
+  : > "$home/.agents/skills/deepapi/SKILL.md"
+  HOME="$home" FM_HOME="$home" "$ROOT/bin/fm-brief.sh" deepapi-present firstmate --scout >/dev/null 2>&1
+  brief="$home/data/deepapi-present/brief.md"
+  # shellcheck disable=SC2016 # Literal backticks must remain unexpanded.
+  assert_grep 'Use the `deepapi` skill for web searches, page reads, PDF extraction, and platform lookups' "$brief" \
+    "scout brief omitted DeepAPI guidance when the skill was present"
+  assert_grep 'source ~/.deepapi/env' "$brief" \
+    "scout brief omitted the spawned-worker credential recovery"
+  assert_grep 'do not report it unavailable without trying that recovery' "$brief" \
+    "scout brief allowed an untried DeepAPI availability conclusion"
+  assert_grep 'an unreachable source is itself a finding' "$brief" \
+    "scout brief omitted the unreachable-source reporting requirement"
+
+  HOME="$home" FM_HOME="$home" "$ROOT/bin/fm-brief.sh" deepapi-ship firstmate --mode no-mistakes >/dev/null 2>&1
+  brief="$home/data/deepapi-ship/brief.md"
+  # shellcheck disable=SC2016 # Literal backticks must remain unexpanded.
+  assert_no_grep 'Use the `deepapi` skill' "$brief" \
+    "ship brief received scout-only DeepAPI guidance"
+  pass "fm-brief.sh: DeepAPI guidance is conditional for scouts and absent from ships"
+}
+
 # Scout and secondmate paths still scaffold well-formed briefs.
 test_scout_and_secondmate_scaffold() {
   local brief
@@ -767,4 +800,5 @@ test_secondmate_marked_request_reporting_contract
 test_secondmate_directory_paths_are_absolute_and_output_is_stable
 test_pause_verb_override_renders_all_brief_scaffolds
 test_scout_and_secondmate_load_decision_hold_policy
+test_scout_deepapi_guidance_requires_the_skill
 test_scout_and_secondmate_scaffold


### PR DESCRIPTION
## Summary
- Scout briefs now point scouts at DeepAPI when the skill is installed, since a spawned worker does not inherit the primary's `DEEPAPI_API_BASE_URL`/`DEEPAPI_API_KEY` and needs to know to `source ~/.deepapi/env` itself.
- Hardens the absent-skill scaffold test assertions.
- Documents the conditional scout DeepAPI guidance.

## Test plan
- Existing `tests/fm-brief.test.sh` covers both the DeepAPI-present and DeepAPI-absent scaffold paths.