### PR TITLE
fix(pi): collapse branch outcome output in Calm

### DIFF
--- a/.pi/extensions/fm-branch-supervision.ts
+++ b/.pi/extensions/fm-branch-supervision.ts
@@ -50,18 +50,26 @@ import {
   createBashToolDefinition,
   DefaultResourceLoader,
   getAgentDir,
+  keyHint,
   SessionManager,
   type AgentSession,
   type ExtensionAPI,
+  type Theme,
   type ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
-import { Text } from "@earendil-works/pi-tui";
+import { Box, Container, Text, type Component } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import {
   FM_BRANCH_DISPATCH_EVENT,
   scopeForUnreadWake,
   type BranchDispatchOffer,
 } from "./lib/fm-branch-dispatch.ts";
+import { calmBranchOutcomeAttention } from "./lib/fm-calm-branch-outcomes.ts";
+import {
+  calmTranscriptClassIsVisible,
+  FIRSTMATE_CALM_PRESENTATION_EVENT,
+  type CalmPresentationState,
+} from "./lib/fm-calm-visibility.ts";
 import { encodeFirstmateOperationalInput } from "./lib/fm-operational-input.ts";
 
 const extensionFile = fileURLToPath(import.meta.url);
@@ -90,7 +98,61 @@ const BRANCH_TOOL_NAMES = ["read", "bash", "fm_branch_report"] as const;
 const branchCacheKey = `fm-branch-${createHash("sha256").update(fmHome).digest("hex").slice(0, 24)}`;
 
 const MIRROR_MESSAGE_CAP = 4000;
-const MERGE_NOTE_BOAT = "⛵";
+// The supervision branch's own glyph: on every merged note it prints, and on
+// each line Calm keeps when it collapses a branch-outcome read.
+const BRANCH_BOAT = "⛵";
+
+// Pi renders a tool row whose definition supplies no render slot through its
+// own call and result fallbacks: the bold tool name, then the result text
+// clipped to this many lines with an expand hint, inside a Box(1, 1) shell that
+// one blank line precedes. Calm's collapse needs renderShell "self", because a
+// self-rendered row that draws nothing is the only shape Pi removes from the
+// transcript entirely - so the slots below have to reproduce that stock shape
+// themselves for every path where Calm is not hiding. The live guard is what
+// proves the reproduction still matches the Pi actually installed.
+const OUTCOMES_FALLBACK_PREVIEW_LINES = 10;
+
+type OutcomesShellState = {
+  shell?: Box;
+  call?: Component;
+  result?: Component;
+};
+
+type OutcomesRenderContext = {
+  isError: boolean;
+  isPartial: boolean;
+};
+
+function refreshOutcomesShell(
+  state: OutcomesShellState,
+  theme: Theme,
+  context: OutcomesRenderContext,
+): Box {
+  const background = context.isPartial
+    ? (text: string) => theme.bg("toolPendingBg", text)
+    : context.isError
+      ? (text: string) => theme.bg("toolErrorBg", text)
+      : (text: string) => theme.bg("toolSuccessBg", text);
+  const shell = state.shell ?? new Box(1, 1, background);
+  state.shell = shell;
+  shell.setBgFn(background);
+  shell.clear();
+  if (state.call) shell.addChild(state.call);
+  if (state.result) shell.addChild(state.result);
+  return shell;
+}
+
+function stockOutcomesResultText(theme: Theme, output: string, expanded: boolean): string {
+  const lines = output.split("\n");
+  const displayLines = expanded ? lines : lines.slice(0, OUTCOMES_FALLBACK_PREVIEW_LINES);
+  const remaining = lines.length - displayLines.length;
+  let text = displayLines.map((line) => theme.fg("toolOutput", line)).join("\n");
+  if (remaining > 0) {
+    text += `${theme.fg("muted", `\n... (${remaining} more lines,`)} ${keyHint("app.tools.expand", "to expand")}${theme.fg("muted", ")")}`;
+  }
+  return text;
+}
+
 type MirrorItem = { tag: "captain" | "main"; text: string };
 type MirrorCursor = { file: string; index: number };
 type Verdict = "routine" | "captain";
@@ -253,6 +315,27 @@ export default function (pi: ExtensionAPI) {
   const pendingMirror: MirrorItem[] = [];
   const mirrorCollection: MirrorCollectionState = { collectAnchor: null, pendingCursor: null };
 
+  // Calm's presentation state reaches this extension over its published event
+  // rather than through shared module state, the same way the watcher extension
+  // reads it: Pi loads each extension independently, so the event is the only
+  // supported coupling. No Calm extension in this home means no event, which
+  // leaves the tool on its stock presentation.
+  let calmPresentation: CalmPresentationState = {
+    active: false,
+    stockExportRendering: false,
+  };
+  pi.events?.on?.(FIRSTMATE_CALM_PRESENTATION_EVENT, (data) => {
+    const next = data as Partial<CalmPresentationState>;
+    calmPresentation = {
+      active: next.active === true,
+      stockExportRendering: next.stockExportRendering === true,
+    };
+  });
+  const calmHides = (itemClass: Parameters<typeof calmTranscriptClassIsVisible>[0]): boolean =>
+    calmPresentation.active &&
+    !calmPresentation.stockExportRendering &&
+    !calmTranscriptClassIsVisible(itemClass);
+
   function generationOwnsLock(expectedGeneration: number): boolean {
     return !shuttingDown && expectedGeneration === generation && lockOwnership() === "owned";
   }
@@ -341,7 +424,7 @@ export default function (pi: ExtensionAPI) {
       const message = { customType: "fm-branch-merge", content: `${task}: ${summary}`, display: false };
       pi.sendMessage(message, { triggerTurn: true, deliverAs: "followUp" });
     } else {
-      const message = { customType: "fm-branch-merge", content: `${MERGE_NOTE_BOAT} ${task}: ${summary}`, display: !(task === "fleet" && silent) };
+      const message = { customType: "fm-branch-merge", content: `${BRANCH_BOAT} ${task}: ${summary}`, display: !(task === "fleet" && silent) };
       if (mainStreaming) {
         pi.sendMessage(message, { deliverAs: "nextTurn" });
       } else {
@@ -703,6 +786,56 @@ ${context.command}
     parameters: Type.Object({
       recent: Type.Optional(Type.Number({ description: "How many most-recent outcomes to read (default 20)" })),
     }),
+    // Calm reaches this row through the same visibility owner as every other
+    // collapsed tool row; lib/fm-calm-branch-outcomes.ts owns the one exception
+    // Calm makes inside that collapse. Calm off and Pi's own stock export
+    // rendering both keep the raw store records exactly as Pi would render them.
+    renderShell: "self",
+    renderCall: (_args, theme, context) => {
+      if (calmHides("assistant-tool-call")) return new Container();
+      const title = new Text(theme.fg("toolTitle", theme.bold("fm_branch_outcomes")), 0, 0);
+      // Pi's HTML exporter renders the call and result slots independently and
+      // keeps only what each one hands back, so an export must return its own
+      // component instead of folding it into the shared on-screen shell.
+      if (calmPresentation.stockExportRendering) return title;
+      const shellState = context.state as OutcomesShellState;
+      shellState.call = title;
+      return refreshOutcomesShell(shellState, theme, context);
+    },
+    renderResult: (result, options, theme, context) => {
+      const output = result.content
+        .filter((item) => item.type === "text")
+        .map((item) => item.text)
+        .join("\n");
+      if (calmHides("tool-result")) {
+        // The call slot already returned an empty component, so an empty result
+        // here is what removes the whole row; anything the collapse must not
+        // swallow comes back as its own dim line instead, carrying the branch's
+        // glyph exactly as its merged notes do.
+        const attention = calmBranchOutcomeAttention(output, context.isError === true);
+        if (attention.length === 0) return new Container();
+        const outputPad = 1;
+        return new Text(
+          attention
+            .map((line) =>
+              line.glyph
+                ? `${theme.fg("customMessageText", BRANCH_BOAT)}${theme.fg("dim", ` ${line.text}`)}`
+                : theme.fg("dim", line.text),
+            )
+            .join("\n"),
+          outputPad,
+          0,
+        );
+      }
+      const resultText = output
+        ? new Text(stockOutcomesResultText(theme, output, options.expanded === true), 0, 0)
+        : new Container();
+      if (calmPresentation.stockExportRendering) return resultText;
+      const shellState = context.state as OutcomesShellState;
+      shellState.result = resultText;
+      refreshOutcomesShell(shellState, theme, context);
+      return new Container();
+    },
     execute: async (_toolCallId, params) => {
       const recentRaw = (params as { recent?: unknown }).recent;
       const recent = typeof recentRaw === "number" && recentRaw >= 1 ? String(Math.floor(recentRaw)) : "20";
@@ -726,11 +859,11 @@ ${context.command}
   // fleet heartbeat; captain-facing notes are never printed or rendered here.
   pi.registerMessageRenderer?.("fm-branch-merge", (message, _options, theme) => {
     const note = textOfContent(message.content);
-    const hasGlyph = note.startsWith(MERGE_NOTE_BOAT);
-    const rest = hasGlyph ? note.slice(MERGE_NOTE_BOAT.length) : note;
+    const hasGlyph = note.startsWith(BRANCH_BOAT);
+    const rest = hasGlyph ? note.slice(BRANCH_BOAT.length) : note;
     const outputPad = 1;
     return new Text(
-      `${hasGlyph ? theme.fg("customMessageText", MERGE_NOTE_BOAT) : ""}${theme.fg("dim", rest)}`,
+      `${hasGlyph ? theme.fg("customMessageText", BRANCH_BOAT) : ""}${theme.fg("dim", rest)}`,
       outputPad,
       0,
     );

--- a/.pi/extensions/lib/fm-calm-branch-outcomes.ts
+++ b/.pi/extensions/lib/fm-calm-branch-outcomes.ts
@@ -15,11 +15,9 @@
 // The tool's own empty-store text (fm-branch-supervision.ts owns the string).
 const NO_OUTCOMES_TEXT = "(no branch outcomes recorded)";
 
-// One line Calm keeps on screen in place of the collapsed row. `glyph` marks the
-// lines Calm authored from a recognized record, which the caller prints with the
-// supervision branch's own glyph; a line Calm did not recognize is carried
-// through unchanged and unmarked. The glyph itself stays with the branch
-// extension that owns it, so this module never has to name it.
+// One line Calm keeps on screen in place of the collapsed row. `glyph` tells the
+// caller to print the supervision branch's own glyph. The glyph itself stays
+// with the branch extension that owns it, so this module never has to name it.
 export type CalmBranchOutcomeLine = {
   glyph: boolean;
   text: string;
@@ -31,6 +29,8 @@ type BranchOutcomeRecord = {
   summary: string;
 };
 
+const OUTCOME_KEYS = new Set(["seq", "epoch", "task", "wake", "verdict", "summary", "silent"]);
+
 function parseOutcomeRecord(line: string): BranchOutcomeRecord | undefined {
   let parsed: unknown;
   try {
@@ -40,8 +40,17 @@ function parseOutcomeRecord(line: string): BranchOutcomeRecord | undefined {
   }
   if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return undefined;
   const record = parsed as Record<string, unknown>;
-  if (typeof record.task !== "string" || typeof record.summary !== "string") return undefined;
+  const hasSilent = Object.prototype.hasOwnProperty.call(record, "silent");
+  const keys = Object.keys(record);
+  if (keys.length !== (hasSilent ? 7 : 6) || keys.some((key) => !OUTCOME_KEYS.has(key))) {
+    return undefined;
+  }
+  if (typeof record.seq !== "number" || !Number.isInteger(record.seq) || record.seq < 1) return undefined;
+  if (typeof record.epoch !== "number" || !Number.isInteger(record.epoch) || record.epoch < 0) return undefined;
+  if (typeof record.task !== "string" || typeof record.wake !== "string") return undefined;
+  if (typeof record.summary !== "string") return undefined;
   if (record.verdict !== "routine" && record.verdict !== "captain") return undefined;
+  if (hasSilent && typeof record.silent !== "boolean") return undefined;
   return { task: record.task, verdict: record.verdict, summary: record.summary };
 }
 
@@ -59,18 +68,18 @@ export function calmBranchOutcomeAttention(
   output: string,
   isError: boolean,
 ): CalmBranchOutcomeLine[] {
-  const text = output.trim();
+  const trimmedOutput = output.trim();
   if (isError) {
-    return [{ glyph: true, text: text || "could not read the outcome store" }];
+    return [{ glyph: true, text: trimmedOutput || "could not read the outcome store" }];
   }
-  if (!text || text === NO_OUTCOMES_TEXT) return [];
+  if (!trimmedOutput || trimmedOutput === NO_OUTCOMES_TEXT) return [];
 
   const lines: CalmBranchOutcomeLine[] = [];
-  for (const rawLine of text.split("\n")) {
+  for (const rawLine of output.split("\n")) {
     if (rawLine.trim() === "") continue;
     const record = parseOutcomeRecord(rawLine.trim());
     if (!record) {
-      lines.push({ glyph: false, text: rawLine });
+      lines.push({ glyph: true, text: rawLine });
       continue;
     }
     if (record.verdict !== "captain") continue;

--- a/.pi/extensions/lib/fm-calm-branch-outcomes.ts
+++ b/.pi/extensions/lib/fm-calm-branch-outcomes.ts
@@ -1,0 +1,80 @@
+// Calm's collapsed presentation for the supervision branch's outcome-store
+// reader (the fm_branch_outcomes tool of .pi/extensions/fm-branch-supervision.ts).
+//
+// Calm already hides the "assistant-tool-call" and "tool-result" classes, so
+// this module adds no second hiding path: ./fm-calm-visibility.ts stays the one
+// owner of whether Calm hides a class. What lives here is the single exception
+// Calm makes inside that collapse - the part of a branch-outcome read that must
+// survive it, so a failure or a captain-relevant outcome is never hidden.
+//
+// Deliberately free of every Pi and pi-tui import: the collapse decision is a
+// pure function of the tool's own output text, which is what lets the portable
+// regression pin it with real store rows and no harness at all.
+// bin/fm-branch-outcome.sh's header owns the record format read below.
+
+// The tool's own empty-store text (fm-branch-supervision.ts owns the string).
+const NO_OUTCOMES_TEXT = "(no branch outcomes recorded)";
+
+// One line Calm keeps on screen in place of the collapsed row. `glyph` marks the
+// lines Calm authored from a recognized record, which the caller prints with the
+// supervision branch's own glyph; a line Calm did not recognize is carried
+// through unchanged and unmarked. The glyph itself stays with the branch
+// extension that owns it, so this module never has to name it.
+export type CalmBranchOutcomeLine = {
+  glyph: boolean;
+  text: string;
+};
+
+type BranchOutcomeRecord = {
+  task: string;
+  verdict: "routine" | "captain";
+  summary: string;
+};
+
+function parseOutcomeRecord(line: string): BranchOutcomeRecord | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    return undefined;
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return undefined;
+  const record = parsed as Record<string, unknown>;
+  if (typeof record.task !== "string" || typeof record.summary !== "string") return undefined;
+  if (record.verdict !== "routine" && record.verdict !== "captain") return undefined;
+  return { task: record.task, verdict: record.verdict, summary: record.summary };
+}
+
+// What must stay visible when Calm collapses one fm_branch_outcomes row.
+// An empty result means the row collapses to nothing, exactly like every other
+// tool row Calm hides. A non-empty result is what Calm shows instead.
+//
+// Three things are never collapsed away, in this order:
+//   1. A failed read, because a captain who cannot see the fleet must be told.
+//   2. Output Calm does not recognize as the store's records, carried through
+//      byte-for-byte rather than silently swallowed by a format change.
+//   3. A captain-verdict outcome, which is the store's own marker for an event
+//      that needs the captain; a routine outcome is one the branch handled.
+export function calmBranchOutcomeAttention(
+  output: string,
+  isError: boolean,
+): CalmBranchOutcomeLine[] {
+  const text = output.trim();
+  if (isError) {
+    return [{ glyph: true, text: text || "could not read the outcome store" }];
+  }
+  if (!text || text === NO_OUTCOMES_TEXT) return [];
+
+  const lines: CalmBranchOutcomeLine[] = [];
+  for (const rawLine of text.split("\n")) {
+    if (rawLine.trim() === "") continue;
+    const record = parseOutcomeRecord(rawLine.trim());
+    if (!record) {
+      lines.push({ glyph: false, text: rawLine });
+      continue;
+    }
+    if (record.verdict !== "captain") continue;
+    lines.push({ glyph: true, text: `${record.task}: ${record.summary}` });
+  }
+  return lines;
+}

--- a/.pi/extensions/lib/fm-calm-branch-outcomes.ts
+++ b/.pi/extensions/lib/fm-calm-branch-outcomes.ts
@@ -75,8 +75,7 @@ export function calmBranchOutcomeAttention(
   if (!trimmedOutput || trimmedOutput === NO_OUTCOMES_TEXT) return [];
 
   const lines: CalmBranchOutcomeLine[] = [];
-  for (const rawLine of output.split("\n")) {
-    if (rawLine.trim() === "") continue;
+  for (const rawLine of trimmedOutput.split("\n")) {
     const record = parseOutcomeRecord(rawLine.trim());
     if (!record) {
       lines.push({ glyph: true, text: rawLine });

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -135,6 +135,7 @@ family_for_basename() {
     fm-arm-pretool-check.test.sh|fm-ask-user-authority.test.sh|\
     fm-bearings-board.test.sh|\
     fm-brief.test.sh|fm-vendor-auth-probe.test.sh|\
+    fm-calm-branch-outcomes.test.sh|\
     fm-calm-pi-extension.test.sh|fm-cd-pretool-check.test.sh|\
     fm-classify-decision-key.test.sh|\
     fm-composer-ghost.test.sh|fm-composer-lib.test.sh|\
@@ -186,6 +187,7 @@ family_for_basename() {
       printf '%s\n' session-bootstrap
       ;;
     fm-afk-pi-herdr-return-e2e.test.sh|\
+    fm-calm-branch-outcomes-live-e2e.test.sh|\
     fm-cmux-claude-composer-live-e2e.test.sh|\
     fm-composer-matrix-live-e2e.test.sh|\
     fm-codex-continuity-live-e2e.test.sh|fm-grok-continuity-live-e2e.test.sh|\

--- a/docs/calm-mode-feasibility.md
+++ b/docs/calm-mode-feasibility.md
@@ -264,7 +264,7 @@ Only Pi's Calm presentation implementation changed; every producer and non-Pi tr
 
 `tests/fm-calm-pi-extension.test.sh` compares wrapped and stock renderers, verifies all seven built-ins plus `fm_watch_arm_pi`, exercises redraw of already-rendered tool, thinking, current operational-user, and legacy synthetic rows, and covers every policy class.
 `tests/fm-calm-branch-outcomes.test.sh` and `tests/fm-calm-branch-outcomes-live-e2e.test.sh` cover the one taught custom tool whose collapsed row can leave something behind.
-It covers persisted preference restoration across every session-start reason and a real restart, proves the working-ship presentation and Calm-off stock `Working...` row through a delayed deterministic provider, asserts no Calm status row, verifies operational messages remain exact ordinary user-role session entries and complete exports, and drives genuine 100 by 44, 160 by 36, and 180 by 44 terminal fixtures.
+`tests/fm-calm-pi-extension.test.sh` also covers persisted preference restoration across every session-start reason and a real restart, proves the working-ship presentation and Calm-off stock `Working...` row through a delayed deterministic provider, asserts no Calm status row, verifies operational messages remain exact ordinary user-role session entries and complete exports, and drives genuine 100 by 44, 160 by 36, and 180 by 44 terminal fixtures.
 A native deterministic `/skill:ahoy` turn produces thinking, tool-call, and tool-result blocks, asserts that the collapsed skill-to-final gap equals the two-row visible-only baseline, expands and re-collapses original thinking, restores Calm-off rendering, verifies persisted hidden history, and repeats the geometry assertion after restart with `terminal.clearOnShrink` explicitly off.
 The operational provider path covers Calm loaded on, loaded off, default preference, extension absent, exact watcher delivery, narrow bare-marker legacy input, persisted restart replay, a genuine captain prompt, and adjacent notifications coalesced into one intended processing turn.
 It asserts one persisted and rendered captain answer, exact user-role operational envelopes in order, no replacement custom messages, one processing result, zero operational transcript rows, and the two-row neighboring-assistant geometry for live, adjacent, and restart paths.
@@ -276,7 +276,9 @@ The relevant commands are:
 
 ```sh
 tests/fm-calm-pi-extension.test.sh
+tests/fm-calm-branch-outcomes.test.sh
 FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh
+FM_CALM_BRANCH_OUTCOMES_LIVE_E2E=1 tests/fm-calm-branch-outcomes-live-e2e.test.sh
 tests/fm-pi-primary-types.test.sh
 ```
 

--- a/docs/calm-mode-feasibility.md
+++ b/docs/calm-mode-feasibility.md
@@ -207,8 +207,8 @@ The test fixture enumerates every class below through the centralized policy, an
 | `genuine-agent-response` | Assistant text in `AssistantMessageComponent` | Visible. |
 | `assistant-working-note` | Assistant text in an `AssistantMessageComponent` message the model did not end its response with, identified by its own `stopReason` of `toolUse`, or of `length` with tool calls present | The text blocks are removed from the shallow presentation copy before layout, so a `toolUse` message carrying only narration occupies zero rows (verified on Pi 0.84.1); a still-streaming `pending` message is never filtered, so narration is briefly visible before the marker flips. |
 | `assistant-thinking` | Thinking content in `AssistantMessageComponent` | Collapsed reasoning is removed from the shallow presentation copy before layout and occupies zero rows; explicit expansion renders the original reasoning. |
-| `assistant-tool-call` | `ToolExecutionComponent` | Seven built-ins and `fm_watch_arm_pi` hidden; arbitrary custom tools remain an unsupported boundary. |
-| `tool-result` | `ToolExecutionComponent` | Text results for the controlled tools hidden; arbitrary custom results remain an unsupported boundary. |
+| `assistant-tool-call` | `ToolExecutionComponent` | Seven built-ins, `fm_watch_arm_pi`, and `fm_branch_outcomes` hidden; a custom tool Calm has not been taught remains an unsupported boundary. |
+| `tool-result` | `ToolExecutionComponent` | Text results for the controlled tools hidden, except that a `fm_branch_outcomes` read keeps one dim line for a failed read, a captain-relevant outcome, or output Calm does not recognize; a custom result Calm has not been taught remains an unsupported boundary. |
 | `tool-image` | Image children appended outside tool renderer slots | Unsupported boundary; remains visible. |
 | `user-bash` | `BashExecutionComponent` for `!` and `!!` | Unsupported boundary; remains visible. |
 | `skill-invocation` | `SkillInvocationMessageComponent` plus parsed user text | Unsupported boundary; remains visible. |
@@ -263,6 +263,7 @@ Only Pi's Calm presentation implementation changed; every producer and non-Pi tr
 ## Regression coverage
 
 `tests/fm-calm-pi-extension.test.sh` compares wrapped and stock renderers, verifies all seven built-ins plus `fm_watch_arm_pi`, exercises redraw of already-rendered tool, thinking, current operational-user, and legacy synthetic rows, and covers every policy class.
+`tests/fm-calm-branch-outcomes.test.sh` and `tests/fm-calm-branch-outcomes-live-e2e.test.sh` cover the one taught custom tool whose collapsed row can leave something behind.
 It covers persisted preference restoration across every session-start reason and a real restart, proves the working-ship presentation and Calm-off stock `Working...` row through a delayed deterministic provider, asserts no Calm status row, verifies operational messages remain exact ordinary user-role session entries and complete exports, and drives genuine 100 by 44, 160 by 36, and 180 by 44 terminal fixtures.
 A native deterministic `/skill:ahoy` turn produces thinking, tool-call, and tool-result blocks, asserts that the collapsed skill-to-final gap equals the two-row visible-only baseline, expands and re-collapses original thinking, restores Calm-off rendering, verifies persisted hidden history, and repeats the geometry assertion after restart with `terminal.clearOnShrink` explicitly off.
 The operational provider path covers Calm loaded on, loaded off, default preference, extension absent, exact watcher delivery, narrow bare-marker legacy input, persisted restart replay, a genuine captain prompt, and adjacent notifications coalesced into one intended processing turn.

--- a/docs/calm.md
+++ b/docs/calm.md
@@ -13,7 +13,9 @@ Hidden elapsed time does not advance the animation, and a resize while hidden cl
 A fresh Pi session or new Calm extension lifetime starts at the normal initial position.
 Very narrow terminals fall back to a smaller deterministic sprite.
 While Calm is off, Pi's stock working row is left exactly as Pi renders it.
-Calm hides collapsed thinking labels, mid-turn assistant working notes, the shells for the Pi built-in tool names Calm owns, the `fm_watch_arm_pi` tool shell, and canonically classified Firstmate operational user rows.
+Calm hides collapsed thinking labels, mid-turn assistant working notes, the shells for the Pi built-in tool names Calm owns, the `fm_watch_arm_pi` and `fm_branch_outcomes` tool shells, and canonically classified Firstmate operational user rows.
+A `fm_branch_outcomes` read is the one Calm-collapsed row that can leave something behind: an outcome the supervision branch already handled collapses with the row, while a failed read, an outcome the branch marked captain-relevant, and any output Calm does not recognize as the store's records each stay on screen as one dim line carrying the branch's own sailboat glyph.
+That exception exists so a fleet failure is never hidden; the raw records themselves are gone from the live transcript only, and remain in the message, model context, session storage, and `/export` artifacts.
 A mid-turn working note is assistant text in a message the model did not end its response with, identified by that message's own `stopReason` of `toolUse`, or of `length` with tool calls present.
 Hiding it removes the narration a model emits alongside its tool calls, while the genuine reply that ends a response stays visible.
 Text that is still streaming is never hidden, because suppressing it would also stop a genuine reply from streaming, so a working note is briefly visible before its row collapses.
@@ -28,7 +30,7 @@ Legacy operational custom messages remain in session data and Pi's sidebar tree,
 Toggling Calm off restores ordinary rendering, and `Ctrl+O` expansion state is preserved.
 
 Pi's supported presentation API does not expose a global transcript filter.
-Expanded reasoning and its reserved spacing, built-in tool images, user-bash rows, skill and summary rows, generic status notices, and arbitrary custom-tool or extension rows remain visible.
+Expanded reasoning and its reserved spacing, built-in tool images, user-bash rows, skill and summary rows, generic status notices, and every custom-tool or extension row Calm has not been taught remain visible.
 These are supported-API boundaries rather than hidden-content failures.
 
 ## Pi compatibility
@@ -47,12 +49,14 @@ If the other extension wins, a session-start console diagnostic names the tool a
 
 [`calm-mode-feasibility.md`](calm-mode-feasibility.md) owns the version-scoped renderer taxonomy, built-in override constraints, and empirical evidence.
 [`configuration.md`](configuration.md#pi-calm-preference-configcalm) owns the persisted preference file and resolution rules.
-`.pi/extensions/lib/fm-calm-visibility.ts` owns the visibility policy, `.pi/extensions/lib/fm-calm-operational-user-layout.ts` owns the zero-height operational-user row adapter, and `.pi/extensions/lib/fm-calm-working-ship.ts` owns the animated working presentation.
+`.pi/extensions/lib/fm-calm-visibility.ts` owns the visibility policy, `.pi/extensions/lib/fm-calm-operational-user-layout.ts` owns the zero-height operational-user row adapter, `.pi/extensions/lib/fm-calm-branch-outcomes.ts` owns what survives the collapsed branch-outcome row, and `.pi/extensions/lib/fm-calm-working-ship.ts` owns the animated working presentation.
 
 Regression entry points:
 
 ```sh
 tests/fm-calm-pi-extension.test.sh
+tests/fm-calm-branch-outcomes.test.sh
 tests/fm-pi-primary-types.test.sh
 FM_PI_LIVE_E2E=1 tests/fm-pi-primary-live-e2e.test.sh
+FM_CALM_BRANCH_OUTCOMES_LIVE_E2E=1 tests/fm-calm-branch-outcomes-live-e2e.test.sh
 ```

--- a/docs/pi-supervision-branch.md
+++ b/docs/pi-supervision-branch.md
@@ -48,6 +48,7 @@ The follow-up turn a `captain` verdict opens is itself the captain-visible outco
 A no-change heartbeat outcome explicitly reported with `task=fleet` and `silent=true` is also delivered silently with no rendered note, while every other `routine` outcome stays rendered with its sailboat prefix.
 The verdict criteria in the branch prompt mirror the captain-etiquette escalation list; doubt escalates.
 Main can read the durable outcome store on demand through its `fm_branch_outcomes` tool.
+That read is a Calm-collapsed row: with Calm on, an outcome the branch already handled collapses with the row, while a failed read, a captain-relevant outcome, and any unrecognized output stay on screen ([docs/calm.md](calm.md) owns the behavior, `.pi/extensions/lib/fm-calm-branch-outcomes.ts` owns what survives).
 
 ## Heartbeat routing
 
@@ -73,4 +74,5 @@ What is new is only the attended path: outside away mode, the branch absorbs the
 
 Portable regressions: `tests/fm-pi-branch-extension.test.sh` (dispatch, default-on eligibility, fallback, filter, mirror, cache key, persistence), `tests/fm-branch-supervision.test.sh` (prompt stability, store append-only, leases, guards, non-branch-home invariance), the branch-offer and heartbeat-offer tests in `tests/fm-pi-watch-extension.test.sh`, and the recovery test in `tests/fm-session-start.test.sh`.
 Live guard: `FM_PI_BRANCH_LIVE_E2E=1 tests/fm-pi-branch-live-e2e.test.sh` exercises the real installed Pi SDK with no credentials and no provider call; run it after every Pi upgrade and record the dated result in [docs/verification/runtime-backends.md](verification/runtime-backends.md).
+How the outcome read actually renders is Pi's own verdict, so it has its own pair: `tests/fm-calm-branch-outcomes.test.sh` pins the collapse decision with real store records and no harness, and `FM_CALM_BRANCH_OUTCOMES_LIVE_E2E=1 tests/fm-calm-branch-outcomes-live-e2e.test.sh` proves the rendered row against the real `pi` binary in a real terminal.
 The strict typecheck in `tests/fm-pi-primary-types.test.sh` pins the extension against the installed Pi package.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -955,3 +955,26 @@ Evidence produced 2026-08-23 on macOS 26.5.0 arm64, Node v24.14.1:
 
 Scope of this evidence: the installed signed `pi` CLI (0.84.1 at verification time) is a compiled binary whose bundled SDK is not importable from Node, so the importable npm package is the only surface the guard and the typecheck can pin.
 The extension executes inside the signed CLI's own runtime, so a CLI upgrade can drift ahead of the pinned npm surface; refresh this record after every Pi upgrade by re-running both commands above (point `FM_PI_PACKAGE_DIR` at a matching npm install when one exists) and by watching the branch's own fallback line - every branch failure degrades to the pre-branch wake-to-main path by construction, which `tests/fm-pi-branch-extension.test.sh` holds with a broken generator and the live guard holds with the real SDK.
+
+### Calm branch-outcome row
+
+Whether Calm's collapsed `fm_branch_outcomes` row disappears, and what is left on screen when it does not, is Pi's own rendering verdict, so it is proven against the real `pi` binary in a real terminal rather than against the importable SDK.
+
+Evidence produced 2026-08-24 on macOS 15.7.3 arm64, Node v26.5.0, tmux on a private socket:
+
+```sh
+FM_CALM_BRANCH_OUTCOMES_LIVE_E2E=1 bin/fm-test-run.sh tests/fm-calm-branch-outcomes-live-e2e.test.sh
+```
+
+Observed output:
+
+```text
+ok - real Pi 0.84.3 keeps the whole stock branch-outcome row, raw records and clip-and-expand shape included, while Calm is off
+ok - real Pi 0.84.3 collapses a branch-outcome read under Calm to one dim line per outcome that still needs the captain, and nothing else
+ok - real Pi 0.84.3 keeps a failed branch-outcome read visible under Calm instead of collapsing it to nothing
+```
+
+The guard reads no credentials and makes no provider call: a local fixture provider answers the fixture model, and `PI_OFFLINE` is set.
+It refuses to pass having checked nothing, failing by name when `pi` or `tmux` is absent or when `pi` reports no version.
+Every assertion is anchored to a Calm-collapsed built-in row in the same transcript, so a session where Calm was not actually collapsing anything fails rather than reporting a false pass.
+Re-run it after every Pi upgrade; the collapse decision itself is separately pinned with real store records and no harness by `tests/fm-calm-branch-outcomes.test.sh`.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -971,6 +971,7 @@ Observed output:
 ```text
 ok - real Pi 0.84.3 keeps the whole stock branch-outcome row, raw records and clip-and-expand shape included, while Calm is off
 ok - real Pi 0.84.3 collapses a branch-outcome read under Calm to one dim line per outcome that still needs the captain, and nothing else
+ok - real Pi 0.84.3 exports every branch-outcome record from a session where Calm collapsed that row on screen
 ok - real Pi 0.84.3 keeps a failed branch-outcome read visible under Calm instead of collapsing it to nothing
 ```
 

--- a/tests/fm-calm-branch-outcomes-live-e2e.test.sh
+++ b/tests/fm-calm-branch-outcomes-live-e2e.test.sh
@@ -1,0 +1,306 @@
+#!/usr/bin/env bash
+# Opt-in live guard for Calm's collapsed presentation of a supervision-branch
+# outcome read, against the REAL installed pi binary in a real terminal.
+#
+# The verdict this guard answers is harness-dependent by construction: whether a
+# row disappears, and what is left on screen when it does not, is decided by Pi's
+# own renderer, so no stub can confirm it. A fixture provider makes the real
+# model surface ask for the real fm_branch_outcomes tool, which reads a real
+# store written by bin/fm-branch-outcome.sh, and the assertions read what Pi
+# actually painted.
+#
+# No credentials are read and no provider call leaves the machine: the fixture
+# provider answers locally and PI_OFFLINE is set.
+#
+# Run after every Pi upgrade and before trusting refreshed Calm evidence
+# (docs/verification/runtime-backends.md).
+set -u
+
+if [ "${FM_CALM_BRANCH_OUTCOMES_LIVE_E2E:-0}" != 1 ]; then
+  echo "skip: set FM_CALM_BRANCH_OUTCOMES_LIVE_E2E=1 to run the real-Pi Calm branch-outcome guard"
+  exit 0
+fi
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+export NODE_NO_WARNINGS=1
+
+command -v pi >/dev/null 2>&1 || fail "pi absent: the live Calm branch-outcome guard needs the real pi binary and refuses to pass having checked nothing"
+command -v tmux >/dev/null 2>&1 || fail "tmux absent: the live Calm branch-outcome guard needs a real terminal and refuses to pass having checked nothing"
+PI_VERSION=$(pi --version 2>/dev/null || true)
+[ -n "$PI_VERSION" ] || fail "pi did not report a version: the live Calm branch-outcome guard refuses to record evidence it cannot attribute"
+
+TMP_ROOT=$(fm_test_tmproot fm-calm-branch-outcomes-live)
+TMUX_SOCKET="fm-calm-outcomes-$$"
+cleanup() {
+  tmux -L "$TMUX_SOCKET" kill-server 2>/dev/null || true
+  fm_test_cleanup
+}
+trap cleanup EXIT
+
+project="$TMP_ROOT/project"
+home="$TMP_ROOT/home"
+config="$TMP_ROOT/pi-config"
+broken_root="$TMP_ROOT/no-firstmate-scripts"
+mkdir -p "$project/.pi/extensions/lib" "$home/state" "$home/config" "$config" "$broken_root/bin"
+fm_git_init_commit "$project"
+cp "$ROOT/.pi/extensions/fm-branch-supervision.ts" "$project/.pi/extensions/fm-branch-supervision.ts"
+cp "$ROOT/.pi/extensions/fm-calm.ts" "$project/.pi/extensions/fm-calm.ts"
+# Named one by one rather than globbed so a change to any of them selects this
+# guard through bin/fm-test-run.sh's changed-path reference scan.
+cp "$ROOT/.pi/extensions/lib/fm-branch-dispatch.ts" "$project/.pi/extensions/lib/fm-branch-dispatch.ts"
+cp "$ROOT/.pi/extensions/lib/fm-calm-assistant-layout.ts" "$project/.pi/extensions/lib/fm-calm-assistant-layout.ts"
+cp "$ROOT/.pi/extensions/lib/fm-calm-branch-outcomes.ts" "$project/.pi/extensions/lib/fm-calm-branch-outcomes.ts"
+cp "$ROOT/.pi/extensions/lib/fm-calm-operational-user-layout.ts" "$project/.pi/extensions/lib/fm-calm-operational-user-layout.ts"
+cp "$ROOT/.pi/extensions/lib/fm-calm-visibility.ts" "$project/.pi/extensions/lib/fm-calm-visibility.ts"
+cp "$ROOT/.pi/extensions/lib/fm-calm-working-ship.ts" "$project/.pi/extensions/lib/fm-calm-working-ship.ts"
+cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" "$project/.pi/extensions/lib/fm-operational-input.ts"
+printf '%s\n' '{"tui.input.submit":"alt+s"}' >"$config/keybindings.json"
+
+# One fixture model that calls a Calm-collapsed built-in first and the tool under
+# test second, so a single transcript proves Calm was actually on (the built-in
+# row is gone) at the same moment it shows what became of the outcome read.
+cat >"$project/.pi/extensions/fm-calm-outcomes-e2e.ts" <<'TS'
+import {
+  type AssistantMessage,
+  createAssistantMessageEventStream,
+} from "@earendil-works/pi-ai";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+export default function (pi: ExtensionAPI): void {
+  pi.registerProvider("calm-outcomes-e2e", {
+    baseUrl: "http://127.0.0.1/unused",
+    apiKey: "test-only",
+    api: "calm-outcomes-e2e-api",
+    models: [
+      {
+        id: "call-outcomes",
+        name: "Calm branch-outcome row fixture",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 8192,
+        maxTokens: 128,
+      },
+    ],
+    streamSimple(model, context) {
+      const stream = createAssistantMessageEventStream();
+      const priorResults = (context.messages ?? []).filter(
+        (message: { role?: string }) => message.role === "toolResult",
+      ).length;
+      const output: AssistantMessage = {
+        role: "assistant",
+        content: [],
+        api: model.api,
+        provider: model.provider,
+        model: model.id,
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: "stop",
+        timestamp: Date.now(),
+      };
+      void (async () => {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        stream.push({ type: "start", partial: output });
+        if (priorResults >= 2) {
+          const block = { type: "text" as const, text: "" };
+          output.content.push(block);
+          stream.push({ type: "text_start", contentIndex: 0, partial: output });
+          block.text = "CALM_OUTCOMES_E2E_DONE";
+          stream.push({ type: "text_delta", contentIndex: 0, delta: block.text, partial: output });
+          stream.push({ type: "text_end", contentIndex: 0, content: block.text, partial: output });
+          stream.push({ type: "done", reason: "stop", message: output });
+          stream.end();
+          return;
+        }
+        const call =
+          priorResults === 0
+            ? {
+                type: "toolCall" as const,
+                id: "call_calm_outcomes_bash",
+                name: "bash",
+                arguments: { command: "printf 'CALM_OUTCOMES_E2E_BASH\\n'" },
+              }
+            : {
+                type: "toolCall" as const,
+                id: "call_calm_outcomes_read",
+                name: "fm_branch_outcomes",
+                arguments: { recent: 16 },
+              };
+        output.content.push(call);
+        output.stopReason = "toolUse";
+        stream.push({ type: "toolCall_start", contentIndex: 0, partial: output });
+        stream.push({ type: "toolCall_end", contentIndex: 0, content: call, partial: output });
+        stream.push({ type: "done", reason: "toolUse", message: output });
+        stream.end();
+      })();
+      return stream;
+    },
+  });
+
+  pi.registerCommand("calm-outcomes-e2e", {
+    description: "Ask the fixture model to read the branch outcome store.",
+    handler: async (_args, ctx) => {
+      const model = ctx.modelRegistry.find("calm-outcomes-e2e", "call-outcomes");
+      if (!model || !(await pi.setModel(model))) {
+        throw new Error("could not select the Calm branch-outcome fixture model");
+      }
+      await pi.sendUserMessage("CALM_OUTCOMES_E2E_PROMPT");
+    },
+  });
+}
+TS
+
+outcome() { # <verdict> <task> <summary>
+  FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$home/state" \
+    bash "$ROOT/bin/fm-branch-outcome.sh" append \
+      --task "$2" --verdict "$1" --summary "$3" --wake "signal: $2" >/dev/null \
+    || fail "the real outcome writer refused a $1 record for $2"
+}
+
+# More records than Pi previews unexpanded, so the Calm-off path also proves the
+# stock clip-and-expand shape survived taking the render slots over.
+outcome captain task-12 "PR https://example.com/pr/12 checks green, ready for review"
+i=1
+while [ "$i" -le 14 ]; do
+  outcome routine "task-r$i" "CALM_OUTCOMES_ROUTINE_$i"
+  i=$((i + 1))
+done
+outcome captain task-4 "blocked: cannot reach the forge, credentials rejected"
+
+# Capture one full fixture turn from a fresh real Pi session, optionally taking
+# Pi's own HTML export of that same turn before the session ends.
+# capture_turn <calm-preference> <firstmate-root> <snapshot-path> [export-path]
+capture_turn() {
+  local calm=$1 fm_root=$2 snapshot=$3 export_path=${4:-} waited=0
+  printf '%s\n' "$calm" >"$home/config/calm"
+  tmux -L "$TMUX_SOCKET" kill-server 2>/dev/null || true
+  tmux -L "$TMUX_SOCKET" new-session -d -s live -x 180 -y 44 \
+    "cd '$project' && env FM_HOME='$home' FM_ROOT_OVERRIDE='$fm_root' PI_CODING_AGENT_DIR='$config' PI_OFFLINE=1 pi --approve --no-skills --no-prompt-templates --no-context-files; sleep 120"
+  waited=0
+  while [ "$waited" -lt 400 ]; do
+    tmux -L "$TMUX_SOCKET" capture-pane -p -t live -S -400 >"$snapshot" 2>/dev/null || true
+    grep -Fq "Pi can explain its own features" "$snapshot" && break
+    sleep 0.05
+    waited=$((waited + 1))
+  done
+  grep -Fq "Pi can explain its own features" "$snapshot" \
+    || fail "pi $PI_VERSION never reached its prompt for the live Calm branch-outcome guard"
+  tmux -L "$TMUX_SOCKET" send-keys -t live -l "/calm-outcomes-e2e"
+  tmux -L "$TMUX_SOCKET" send-keys -t live M-s
+  waited=0
+  while [ "$waited" -lt 600 ]; do
+    tmux -L "$TMUX_SOCKET" capture-pane -p -t live -S -400 >"$snapshot" 2>/dev/null || true
+    grep -Fq "CALM_OUTCOMES_E2E_DONE" "$snapshot" && break
+    sleep 0.05
+    waited=$((waited + 1))
+  done
+  grep -Fq "CALM_OUTCOMES_E2E_DONE" "$snapshot" \
+    || fail "pi $PI_VERSION never completed the fixture turn for the live Calm branch-outcome guard (calm=$calm)"
+  if [ -n "$export_path" ]; then
+    tmux -L "$TMUX_SOCKET" send-keys -t live -l "/export $export_path"
+    tmux -L "$TMUX_SOCKET" send-keys -t live M-s
+    waited=0
+    while [ "$waited" -lt 600 ]; do
+      tmux -L "$TMUX_SOCKET" capture-pane -p -t live -S -400 >"$snapshot.export" 2>/dev/null || true
+      grep -Fq "Session exported to: $export_path" "$snapshot.export" && break
+      sleep 0.05
+      waited=$((waited + 1))
+    done
+    grep -Fq "Session exported to: $export_path" "$snapshot.export" \
+      || fail "pi $PI_VERSION never completed the export for the live Calm branch-outcome guard (calm=$calm)"
+  fi
+  tmux -L "$TMUX_SOCKET" kill-server 2>/dev/null || true
+}
+
+test_calm_off_keeps_the_stock_row() {
+  local snapshot="$TMP_ROOT/calm-off.txt"
+  capture_turn off "$ROOT" "$snapshot"
+  assert_grep 'CALM_OUTCOMES_E2E_BASH' "$snapshot" \
+    "pi $PI_VERSION hid an ordinary tool row while Calm was off, so this snapshot cannot judge the branch-outcome row"
+  assert_grep 'fm_branch_outcomes' "$snapshot" \
+    "pi $PI_VERSION dropped the branch-outcome tool row while Calm was off"
+  assert_grep '"verdict":"routine"' "$snapshot" \
+    "pi $PI_VERSION no longer shows the raw branch-outcome records while Calm is off"
+  assert_grep 'more lines,' "$snapshot" \
+    "pi $PI_VERSION lost the stock clip-and-expand shape for a long branch-outcome read while Calm was off"
+  pass "real Pi $PI_VERSION keeps the whole stock branch-outcome row, raw records and clip-and-expand shape included, while Calm is off"
+}
+
+test_calm_on_collapses_to_what_needs_attention() {
+  local snapshot="$TMP_ROOT/calm-on.txt"
+  capture_turn on "$ROOT" "$snapshot" "$TMP_ROOT/calm-on-export.html"
+  assert_no_grep 'CALM_OUTCOMES_E2E_BASH' "$snapshot" \
+    "Calm was not actually collapsing tool rows in this pi $PI_VERSION session, so its branch-outcome result proves nothing"
+  assert_no_grep 'fm_branch_outcomes' "$snapshot" \
+    "pi $PI_VERSION left the branch-outcome tool row's own shell on screen while Calm was on"
+  assert_no_grep '"verdict":"routine"' "$snapshot" \
+    "pi $PI_VERSION still dumps the raw branch-outcome records into the transcript while Calm is on"
+  assert_no_grep 'CALM_OUTCOMES_ROUTINE_' "$snapshot" \
+    "Calm kept an outcome the supervision branch already handled on screen in pi $PI_VERSION"
+  assert_grep 'task-12: PR https://example.com/pr/12 checks green, ready for review' "$snapshot" \
+    "Calm collapsed away a captain-relevant branch outcome in pi $PI_VERSION"
+  assert_grep 'task-4: blocked: cannot reach the forge, credentials rejected' "$snapshot" \
+    "Calm collapsed away a branch outcome reporting a blocker in pi $PI_VERSION"
+  assert_grep '⛵' "$snapshot" \
+    "Calm dropped the supervision glyph from what it kept in pi $PI_VERSION"
+  pass "real Pi $PI_VERSION collapses a branch-outcome read under Calm to one dim line per outcome that still needs the captain, and nothing else"
+}
+
+test_calm_on_export_keeps_every_record() {
+  # Same session, same collapsed row: Calm's presentation must not reach what
+  # /export writes, which is the copy the captain keeps.
+  local export_file="$TMP_ROOT/calm-on-export.html"
+  [ -s "$export_file" ] || fail "pi $PI_VERSION wrote no export for the live Calm branch-outcome guard"
+  node - "$export_file" "$PI_VERSION" <<'JS' || fail "Calm's collapse reached the HTML export in the pi run above, so the exported copy lost branch-outcome records"
+const { readFileSync } = require("node:fs");
+const html = readFileSync(process.argv[2], "utf8");
+const version = process.argv[3];
+const match = html.match(/<script id="session-data" type="application\/json">([^<]+)<\/script>/);
+if (!match) {
+  console.error(`pi ${version} export carried no session data`);
+  process.exit(1);
+}
+const session = JSON.parse(Buffer.from(match[1], "base64").toString("utf8"));
+const entries = JSON.stringify(session.session?.entries ?? session.entries ?? []);
+const rowsIn = (text) => (String(text).match(/&quot;verdict&quot;/g) || []).length;
+const rendered = session.renderedTools?.call_calm_outcomes_read;
+const problems = [];
+if (!entries.includes('\\"verdict\\":\\"routine\\"') && !entries.includes('"verdict":"routine"')) {
+  problems.push("the exported session entries lost the raw outcome records");
+}
+if (!rendered?.resultHtmlExpanded) {
+  problems.push("the export rendered no result for the branch-outcome row");
+} else if (rowsIn(rendered.resultHtmlExpanded) !== 16) {
+  problems.push(`the exported branch-outcome row carried ${rowsIn(rendered.resultHtmlExpanded)} of 16 records`);
+}
+if (problems.length > 0) {
+  console.error(`pi ${version}: ${problems.join("; ")}`);
+  process.exit(1);
+}
+JS
+  pass "real Pi $PI_VERSION exports every branch-outcome record from a session where Calm collapsed that row on screen"
+}
+
+test_calm_on_never_hides_a_failed_read() {
+  local snapshot="$TMP_ROOT/calm-on-failure.txt"
+  # No fm-branch-outcome.sh under this root, so the real tool takes its real
+  # failure path and the row must survive the collapse.
+  capture_turn on "$broken_root" "$snapshot"
+  assert_no_grep 'CALM_OUTCOMES_E2E_BASH' "$snapshot" \
+    "Calm was not actually collapsing tool rows in this pi $PI_VERSION session, so its branch-outcome result proves nothing"
+  assert_grep 'could not read the outcome store' "$snapshot" \
+    "Calm hid a failed branch-outcome read in pi $PI_VERSION, leaving the captain unable to see the fleet with no sign of it"
+  pass "real Pi $PI_VERSION keeps a failed branch-outcome read visible under Calm instead of collapsing it to nothing"
+}
+
+test_calm_off_keeps_the_stock_row
+test_calm_on_collapses_to_what_needs_attention
+test_calm_on_export_keeps_every_record
+test_calm_on_never_hides_a_failed_read

--- a/tests/fm-calm-branch-outcomes.test.sh
+++ b/tests/fm-calm-branch-outcomes.test.sh
@@ -72,7 +72,7 @@ const check = (label, actual, expected) => {
 
 // A read the captain never has to act on collapses to nothing, exactly like
 // every other tool row Calm hides.
-check("routine-only store", calmBranchOutcomeAttention(routineOnly, false), []);
+check("routine-only store with trailing newline", calmBranchOutcomeAttention(routineOnly, false), []);
 check("empty output", calmBranchOutcomeAttention("", false), []);
 check("blank output", calmBranchOutcomeAttention("   \n\n", false), []);
 check(
@@ -102,25 +102,31 @@ check("failed read with no detail", calmBranchOutcomeAttention("", true), [
 // Output Calm does not recognize as the store's records is carried through
 // byte-for-byte rather than swallowed by a format it has not been taught.
 const unrecognized = [
-  "  not json at all",
   '{"seq":9}',
+  "  not json at all",
   '["task-1","captain","summary"]',
   '{"task":"task-7","verdict":"escalate","summary":"unknown verdict"}',
   '{"task":"task-8","verdict":"captain","summary":42}',
   '{"task":"task-9","verdict":"routine","summary":"ok"}',
-  "  ",
 ].join("\n");
 check(
   "unrecognized output",
   calmBranchOutcomeAttention(unrecognized, false),
   [
-    { glyph: true, text: "  not json at all" },
     { glyph: true, text: '{"seq":9}' },
+    { glyph: true, text: "  not json at all" },
     { glyph: true, text: '["task-1","captain","summary"]' },
     { glyph: true, text: '{"task":"task-7","verdict":"escalate","summary":"unknown verdict"}' },
     { glyph: true, text: '{"task":"task-8","verdict":"captain","summary":42}' },
     { glyph: true, text: '{"task":"task-9","verdict":"routine","summary":"ok"}' },
   ],
+);
+
+const routineRecords = routineOnly.trim().split("\n");
+check(
+  "interior whitespace-only output",
+  calmBranchOutcomeAttention(`${routineRecords[0]}\n  \n${routineRecords[1]}\n`, false),
+  [{ glyph: true, text: "  " }],
 );
 
 // A legacy record written before the store carried `silent` is still a valid

--- a/tests/fm-calm-branch-outcomes.test.sh
+++ b/tests/fm-calm-branch-outcomes.test.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Portable regression for Calm's collapsed presentation of a supervision-branch
+# outcome read (.pi/extensions/lib/fm-calm-branch-outcomes.ts).
+#
+# Every input below is a real record produced by the real store writer
+# (bin/fm-branch-outcome.sh), and the module under test is exercised through its
+# own exported function with no Pi package present at all - the module takes no
+# Pi import precisely so this can run anywhere CI runs node. What the rendered
+# row then LOOKS like against real Pi is a harness-dependent verdict this test
+# cannot answer; tests/fm-calm-branch-outcomes-live-e2e.test.sh owns that half.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+command -v node >/dev/null 2>&1 || { echo "skip: node not found for the Calm branch-outcome collapse regression"; exit 0; }
+
+TMP_ROOT=$(fm_test_tmproot fm-calm-branch-outcomes)
+trap fm_test_cleanup EXIT
+
+home="$TMP_ROOT/home"
+mkdir -p "$home/state"
+
+# Import the module from a directory with no node_modules of its own and none
+# above it, so a Pi dependency added to it would fail this test loudly instead
+# of quietly making the portable half unrunnable where CI runs.
+MODULE="$TMP_ROOT/fm-calm-branch-outcomes.ts"
+cp "$ROOT/.pi/extensions/lib/fm-calm-branch-outcomes.ts" "$MODULE"
+
+outcome() { # <verdict> <task> <summary>
+  FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$home/state" \
+    bash "$ROOT/bin/fm-branch-outcome.sh" append \
+      --task "$2" --verdict "$1" --summary "$3" --wake "signal: $2" >/dev/null \
+    || fail "the real outcome writer refused a $1 record for $2"
+}
+
+store_listing() { # <recent>
+  FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" FM_STATE_OVERRIDE="$home/state" \
+    bash "$ROOT/bin/fm-branch-outcome.sh" list --recent "$1"
+}
+
+# Real records, written by the real store writer: two the branch handled itself
+# and two that name the captain.
+outcome routine task-9 "worker healthy, no action needed"
+outcome captain task-12 "PR https://example.com/pr/12 checks green, ready for review"
+outcome routine task-14 "worker healthy, no action needed"
+outcome captain task-4 "blocked: cannot reach the forge, credentials rejected"
+
+routine_only="$TMP_ROOT/routine-only.txt"
+store_listing 1 > "$TMP_ROOT/latest.txt"
+grep -q '"verdict":"captain"' "$TMP_ROOT/latest.txt" \
+  || fail "the store fixture did not end on a captain record"
+store_listing 4 > "$TMP_ROOT/mixed.txt"
+[ "$(wc -l < "$TMP_ROOT/mixed.txt")" -eq 4 ] || fail "the store fixture did not produce 4 records"
+grep '"verdict":"routine"' "$TMP_ROOT/mixed.txt" > "$routine_only" \
+  || fail "the store fixture produced no routine records"
+
+test_collapse_and_preserve() {
+  local out status
+  out=$(MODULE="$MODULE" MIXED="$TMP_ROOT/mixed.txt" ROUTINE="$routine_only" node --input-type=module <<'JS'
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const { calmBranchOutcomeAttention } = await import(pathToFileURL(process.env.MODULE).href);
+const mixed = readFileSync(process.env.MIXED, "utf8");
+const routineOnly = readFileSync(process.env.ROUTINE, "utf8");
+const check = (label, actual, expected) => {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a !== e) throw new Error(`${label}: expected ${e}, got ${a}`);
+};
+
+// A read the captain never has to act on collapses to nothing, exactly like
+// every other tool row Calm hides.
+check("routine-only store", calmBranchOutcomeAttention(routineOnly, false), []);
+check("empty output", calmBranchOutcomeAttention("", false), []);
+check("blank output", calmBranchOutcomeAttention("   \n\n", false), []);
+check(
+  "empty-store sentinel",
+  calmBranchOutcomeAttention("(no branch outcomes recorded)", false),
+  [],
+);
+
+// A captain-verdict outcome survives the collapse as one line; the routine
+// records around it do not.
+check("mixed store", calmBranchOutcomeAttention(mixed, false), [
+  { glyph: true, text: "task-12: PR https://example.com/pr/12 checks green, ready for review" },
+  { glyph: true, text: "task-4: blocked: cannot reach the forge, credentials rejected" },
+]);
+
+// A failed read is never collapsed away: the captain who cannot see the fleet
+// has to be told, and the tool's own message is what says why.
+check(
+  "failed read",
+  calmBranchOutcomeAttention("could not read the outcome store: exit 2", true),
+  [{ glyph: true, text: "could not read the outcome store: exit 2" }],
+);
+check("failed read with no detail", calmBranchOutcomeAttention("", true), [
+  { glyph: true, text: "could not read the outcome store" },
+]);
+
+// Output Calm does not recognize as the store's records is carried through
+// byte-for-byte rather than swallowed by a format it has not been taught.
+const unrecognized = [
+  "not json at all",
+  '{"seq":9}',
+  '["task-1","captain","summary"]',
+  '{"task":"task-7","verdict":"escalate","summary":"unknown verdict"}',
+  '{"task":"task-8","verdict":"captain","summary":42}',
+  "  ",
+].join("\n");
+check(
+  "unrecognized output",
+  calmBranchOutcomeAttention(unrecognized, false),
+  [
+    { glyph: false, text: "not json at all" },
+    { glyph: false, text: '{"seq":9}' },
+    { glyph: false, text: '["task-1","captain","summary"]' },
+    { glyph: false, text: '{"task":"task-7","verdict":"escalate","summary":"unknown verdict"}' },
+    { glyph: false, text: '{"task":"task-8","verdict":"captain","summary":42}' },
+  ],
+);
+
+// A legacy record written before the store carried `silent` is still a valid
+// record, and `silent` never decides what the captain gets to see.
+check(
+  "legacy record without silent",
+  calmBranchOutcomeAttention(
+    '{"seq":1,"epoch":1,"task":"task-3","wake":"stale: task-3","verdict":"captain","summary":"needs a decision"}',
+    false,
+  ),
+  [{ glyph: true, text: "task-3: needs a decision" }],
+);
+check(
+  "silent captain record",
+  calmBranchOutcomeAttention(
+    '{"seq":2,"epoch":1,"task":"fleet","wake":"heartbeat","verdict":"captain","summary":"still needs a decision","silent":true}',
+    false,
+  ),
+  [{ glyph: true, text: "fleet: still needs a decision" }],
+);
+
+// Unrecognized output mixed in with real records keeps both.
+check(
+  "partial recognition",
+  calmBranchOutcomeAttention(`${routineOnly.trim()}\nstore truncated`, false),
+  [{ glyph: false, text: "store truncated" }],
+);
+console.log("COLLAPSE_OK");
+JS
+  )
+  status=$?
+  [ "$status" -eq 0 ] || fail "Calm branch-outcome collapse regression failed: $out"
+  assert_contains "$out" "COLLAPSE_OK" "Calm branch-outcome collapse regression did not run to completion"
+  pass "Calm collapses a handled branch-outcome read to nothing and never swallows a failure, a captain-relevant outcome, or output it does not recognize"
+}
+
+test_collapse_and_preserve

--- a/tests/fm-calm-branch-outcomes.test.sh
+++ b/tests/fm-calm-branch-outcomes.test.sh
@@ -102,22 +102,24 @@ check("failed read with no detail", calmBranchOutcomeAttention("", true), [
 // Output Calm does not recognize as the store's records is carried through
 // byte-for-byte rather than swallowed by a format it has not been taught.
 const unrecognized = [
-  "not json at all",
+  "  not json at all",
   '{"seq":9}',
   '["task-1","captain","summary"]',
   '{"task":"task-7","verdict":"escalate","summary":"unknown verdict"}',
   '{"task":"task-8","verdict":"captain","summary":42}',
+  '{"task":"task-9","verdict":"routine","summary":"ok"}',
   "  ",
 ].join("\n");
 check(
   "unrecognized output",
   calmBranchOutcomeAttention(unrecognized, false),
   [
-    { glyph: false, text: "not json at all" },
-    { glyph: false, text: '{"seq":9}' },
-    { glyph: false, text: '["task-1","captain","summary"]' },
-    { glyph: false, text: '{"task":"task-7","verdict":"escalate","summary":"unknown verdict"}' },
-    { glyph: false, text: '{"task":"task-8","verdict":"captain","summary":42}' },
+    { glyph: true, text: "  not json at all" },
+    { glyph: true, text: '{"seq":9}' },
+    { glyph: true, text: '["task-1","captain","summary"]' },
+    { glyph: true, text: '{"task":"task-7","verdict":"escalate","summary":"unknown verdict"}' },
+    { glyph: true, text: '{"task":"task-8","verdict":"captain","summary":42}' },
+    { glyph: true, text: '{"task":"task-9","verdict":"routine","summary":"ok"}' },
   ],
 );
 
@@ -144,7 +146,7 @@ check(
 check(
   "partial recognition",
   calmBranchOutcomeAttention(`${routineOnly.trim()}\nstore truncated`, false),
-  [{ glyph: false, text: "store truncated" }],
+  [{ glyph: true, text: "store truncated" }],
 );
 console.log("COLLAPSE_OK");
 JS

--- a/tests/fm-pi-branch-extension.test.sh
+++ b/tests/fm-pi-branch-extension.test.sh
@@ -26,6 +26,8 @@ install_pi_branch_extension_fixture() {
     "$repo/node_modules/typebox"
   cp "$EXT" "$repo/.pi/extensions/fm-branch-supervision.ts"
   cp "$ROOT/.pi/extensions/lib/fm-branch-dispatch.ts" "$repo/.pi/extensions/lib/fm-branch-dispatch.ts"
+  cp "$ROOT/.pi/extensions/lib/fm-calm-branch-outcomes.ts" "$repo/.pi/extensions/lib/fm-calm-branch-outcomes.ts"
+  cp "$ROOT/.pi/extensions/lib/fm-calm-visibility.ts" "$repo/.pi/extensions/lib/fm-calm-visibility.ts"
   cp "$ROOT/.pi/extensions/lib/fm-operational-input.ts" "$repo/.pi/extensions/lib/fm-operational-input.ts"
   mkdir -p "$repo/bin"
   cp "$ROOT/bin/fm-operational-input.sh" "$repo/bin/fm-operational-input.sh"
@@ -38,6 +40,17 @@ import { writeFileSync } from "node:fs";
 
 export function getAgentDir() {
   return "/stub-agent-dir";
+}
+
+export function keyHint(_keybinding, description) {
+  return description;
+}
+
+export function getMarkdownTheme() { return {}; }
+
+export class UserMessageComponent {
+  render() { return []; }
+  invalidate() {}
 }
 
 export class DefaultResourceLoader {
@@ -124,6 +137,28 @@ export class Text {
     this.text = text;
     this.paddingX = paddingX;
     this.paddingY = paddingY;
+  }
+}
+export class Container {
+  constructor() {
+    this.children = [];
+  }
+  addChild(child) {
+    this.children.push(child);
+  }
+  clear() {
+    this.children = [];
+  }
+}
+export class Box extends Container {
+  constructor(paddingX, paddingY, bgFn) {
+    super();
+    this.paddingX = paddingX;
+    this.paddingY = paddingY;
+    this.bgFn = bgFn;
+  }
+  setBgFn(bgFn) {
+    this.bgFn = bgFn;
   }
 }
 JS

--- a/tests/fm-pi-primary-types.test.sh
+++ b/tests/fm-pi-primary-types.test.sh
@@ -32,6 +32,7 @@ cp "$ROOT/.pi/extensions/fm-primary-pi-watch.ts" "$TMP_ROOT/fm-primary-pi-watch.
 cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$TMP_ROOT/fm-primary-turnend-guard.ts"
 cp "$ROOT/.pi/extensions/lib/fm-branch-dispatch.ts" "$TMP_ROOT/lib/fm-branch-dispatch.ts"
 cp "$ROOT/.pi/extensions/lib/fm-calm-assistant-layout.ts" "$TMP_ROOT/lib/fm-calm-assistant-layout.ts"
+cp "$ROOT/.pi/extensions/lib/fm-calm-branch-outcomes.ts" "$TMP_ROOT/lib/fm-calm-branch-outcomes.ts"
 cp "$ROOT/.pi/extensions/lib/fm-calm-operational-user-layout.ts" "$TMP_ROOT/lib/fm-calm-operational-user-layout.ts"
 cp "$ROOT/.pi/extensions/lib/fm-calm-visibility.ts" "$TMP_ROOT/lib/fm-calm-visibility.ts"
 cp "$ROOT/.pi/extensions/lib/fm-calm-working-ship.ts" "$TMP_ROOT/lib/fm-calm-working-ship.ts"


### PR DESCRIPTION
## Intent

Give the `fm_branch_outcomes` custom tool a Calm-aware collapsed renderer in the firstmate Pi extension, so Calm stops dumping its raw branch-outcome JSON into the transcript. Extend Calm - the existing owner of transcript presentation - rather than adding a second, parallel hiding mechanism.

Merge authority: origin is kunchenguid/firstmate, which we do not own. This is a generic upstream fix to firstmate's own Calm and branch-supervision behavior, so it goes upstream. The PR awaits Kun; neither the captain nor firstmate can merge it, so it must never be framed as captain-mergeable or "ready to merge" without naming Kun as the merge authority.

Required approach and constraints, all of which were followed:
- Reproduce first, before designing the fix: turn Calm on and drive the REAL Pi interface until an actual fm_branch_outcomes tool call renders in the transcript, and capture proof that the raw branch-outcome JSON is currently dumped there. This was done against real Pi 0.84.3 in tmux with a local fixture provider that makes the real model surface call the real tool against a real store written by bin/fm-branch-outcome.sh: in one Calm-on turn a built-in bash row was collapsed to nothing while the outcome read printed every store record verbatim as raw JSONL.
- Give fm_branch_outcomes a Calm-aware collapsed renderer that follows the way Calm already collapses other tool output. Do not add a parallel hiding path; teach Calm this tool. Implemented by giving the tool render slots that consult Calm's existing visibility owner (calmTranscriptClassIsVisible over Calm's published FIRSTMATE_CALM_PRESENTATION_EVENT), exactly the coupling fm-primary-pi-watch.ts already uses for fm_watch_arm_pi, because Pi loads each extension independently and the event is the only supported coupling. A new Calm lib module .pi/extensions/lib/fm-calm-branch-outcomes.ts owns only the one exception Calm makes inside that collapse.
- Preserve stock behavior (Calm off) and export behavior exactly: the raw content must remain fully present in the stock and export paths. Collapsing a row to nothing requires renderShell "self" (the only shape Pi removes from the transcript entirely), which means the slots must reproduce Pi's own call/result fallbacks themselves, including the unexpanded 10-line clip and the expand hint, inside the same Box(1,1) shell. This was verified against real Pi by diffing the Calm-off transcript before and after the change at both 3 and 18 records: byte-identical. The HTML export was verified to carry every record in both the session entries and the rendered expanded HTML.
- Preserve useful failure visibility: a branch outcome carrying an error or an actionable state must NOT collapse to nothing; the collapsed form must still show that something needs attention, so a real failure is never hidden. Implemented as: a failed read, an outcome the store itself marked with the captain verdict, and any output Calm does not recognize as the store's records each survive as one dim line carrying the supervision branch's own sailboat glyph, while an outcome the branch already handled (routine verdict) collapses with the row. The store's own verdict field is the structural actionable marker - no keyword guessing on summary text. Unrecognized output is carried through byte-for-byte rather than swallowed by a format change.
- Review EVERY affected supported presentation surface (assistant layout, operational-user layout, working-ship, visibility) and confirm none regress. None of those four modules are touched; the collapse consumes the existing visibility policy without changing its class allowlist, and tests/fm-calm-pi-extension.test.sh still passes in full.
- Deliberate design choice worth knowing: the glyph constant was renamed from MERGE_NOTE_BOAT to BRANCH_BOAT and reused rather than duplicated, so the branch's glyph has one owner across its merged notes and its collapsed line, and the new Calm lib module never names it.
- Deliberate design choice worth knowing: the new Calm lib module takes no Pi or pi-tui import at all, so the portable regression can load it with no harness installed; the portable test copies it into a directory with no node_modules so a Pi dependency added later fails loudly.

Tests - harness-dependent, so two are required per the firstmate-coding-guidelines skill, and both were written:
- tests/fm-calm-branch-outcomes.test.sh, a portable regression extending the existing colocated tests/ pattern, pinning the collapse-and-preserve logic with real store records produced by the real bin/fm-branch-outcome.sh writer, with no harness, exercised through the module's own exported function and never asserting implementation-source bytes.
- tests/fm-calm-branch-outcomes-live-e2e.test.sh, an opt-in live-harness-optin guard (FM_CALM_BRANCH_OUTCOMES_LIVE_E2E=1, registered in that family in bin/fm-test-run.sh) that proves the collapsed rendering end to end against the real pi binary in a real terminal and fails loudly naming the harness and version. It refuses to pass having checked nothing when pi or tmux is absent, and every assertion is anchored to a Calm-collapsed built-in row in the same transcript so a session where Calm was not actually collapsing anything fails rather than reporting a false pass. Both guards were proved non-vacuous by re-running them against the pre-change code and against a deliberately clipped export path; each failed with the harness and version named.
- The dated result is recorded in the docs/verification/ owner that holds Calm/Pi evidence (docs/verification/runtime-backends.md, "Calm branch-outcome row"), pointing at the live guard as the command that refreshes it.

Repo style rules from firstmate-coding-guidelines were followed: one full sentence per physical line in tracked Markdown, plain dash rather than em dash, one owner per contract with cross-references rather than restatements, shellcheck-clean bin scripts, and bin/fm-lint.sh run clean (ShellCheck 0.11.0 and actionlint 1.7.12) before treating the script change as done.

One thing that needs the captain's word rather than mine: the collapsed row puts new words on the captain's screen. The strings are deliberately built from vocabulary that already exists - the branch's own "<glyph> <task>: <summary>" merge-note shape and the tool's own existing "could not read the outcome store: ..." message - so no new user-facing prose was invented, but the captain still owns approval of on-screen copy.

## What Changed

- Add a Calm-aware `fm_branch_outcomes` renderer that collapses routine records while preserving failed reads, captain-verdict outcomes, and unrecognized output.
- Preserve stock Calm-off rendering and complete HTML exports, including Pi’s clipped preview and expanded output.
- Add portable and opt-in real Pi/tmux regressions, test-runner registration, and documentation for the new presentation behavior.

## Risk Assessment

✅ Low: The change is well-bounded, the prior schema and glyph fixes now conform to the accepted intent, and no additional source-verifiable defects were found.

## Testing

At the target commit, focused portable, Calm presentation, branch-extension, compatibility, and real Pi 0.84.3/tmux 3.7b checks succeeded. The captured end-user surface shows Calm hiding raw routine JSON while preserving sailboat-marked actionable outcomes, and the corresponding HTML export retains every record; the worktree remained clean.

- Evidence: [Real Pi 0.84.3 Calm-on terminal showing only sailboat-marked actionable branch outcomes](https://github.com/zachlandes/firstmate/blob/f4fec3b61539a06c1ac62b585ed53ff04fcb512b/.no-mistakes/evidence/fm/calm-branch-outcomes-renderer/calm-on-terminal.png)

<details>
<summary>Evidence: Rendered HTML of the real Pi Calm-on terminal capture</summary>

Source: [Rendered HTML of the real Pi Calm-on terminal capture](https://github.com/zachlandes/firstmate/blob/f4fec3b61539a06c1ac62b585ed53ff04fcb512b/.no-mistakes/evidence/fm/calm-branch-outcomes-renderer/calm-on-terminal.html)

```text
<!doctype html><meta charset="utf-8"><title>Calm branch outcomes - real Pi 0.84.3 terminal capture</title><style>html{background:#111827}body{margin:0;padding:28px;color:#d1d5db;font:15px/1.35 ui-monospace,SFMono-Regular,Menlo,monospace}header{color:#93c5fd;margin-bottom:18px;font:600 16px system-ui}pre{margin:0;white-space:pre;}</style><header>Real Pi 0.84.3 terminal capture - Calm on</header><pre>
 pi v0.84.3
 escape interrupt · ctrl+c/ctrl+d clear/exit · / commands · ! bash · ctrl+o more
 Press ctrl+o to show full startup help and loaded resources.

 Pi can explain its own features and look up its docs. Ask it how to use or extend Pi.

[Extensions]
  fm-branch-supervision.ts, fm-calm-outcomes-e2e.ts, fm-calm.ts


 Warning: tmux extended-keys is off. Modified Enter keys may not work. Add `set -g extended-keys on` to ~/.tmux.conf and restart tmux.


 CALM_OUTCOMES_E2E_PROMPT


 ⛵ task-12: PR https://example.com/pr/12 checks green, ready for review
 ⛵ task-4: blocked: cannot reach the forge, credentials rejected

 CALM_OUTCOMES_E2E_DONE

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
&lt;isolated-fixture&gt;/project (main)
7.7%/8.2k (auto)                                                                                                                                                       call-outcomes

















</pre>
```
</details>
<details>
<summary>Evidence: Real Pi HTML export retaining all branch-outcome records from the collapsed session</summary>

Source: [Real Pi HTML export retaining all branch-outcome records from the collapsed session](https://github.com/zachlandes/firstmate/blob/f4fec3b61539a06c1ac62b585ed53ff04fcb512b/.no-mistakes/evidence/fm/calm-branch-outcomes-renderer/calm-on-export.html)

```text
<!DOCTYPE html>
<html lang="en">
<head>
  <meta charset="UTF-8">
  <meta name="viewport" content="width=device-width, initial-scale=1.0">
  <title>Session Export</title>
  <style>
    :root {
      --accent: #8abeb7;
      --border: #5f87ff;
      --borderAccent: #00d7ff;
      --borderMuted: #505050;
      --success: #b5bd68;
      --error: #cc6666;
      --warning: #ffff00;
      --muted: #808080;
      --dim: #666666;
      --text: #d4d4d4;
      --thinkingText: #808080;
      --selectedBg: #3a3a4a;
      --scrollbarThumb: #3a3a4a;
      --searchMatchBg: #3a3a4a;
      --searchMatchText: #d4d4d4;
      --userMessageBg: #343541;
      --userMessageText: #d4d4d4;
      --customMessageBg: #2d2838;
      --customMessageText: #d4d4d4;
      --customMessageLabel: #9575cd;
      --toolPendingBg: #282832;
      --toolSuccessBg: #283228;
      --toolErrorBg: #3c2828;
      --toolTitle: #d4d4d4;
      --toolOutput: #808080;
      --mdHeading: #f0c674;
      --mdLink: #81a2be;
      --mdLinkUrl: #666666;
      --mdCode: #8abeb7;
      --mdCodeBlock: #b5bd68;
      --mdCodeBlockBorder: #808080;
      --mdQuote: #808080;
      --mdQuoteBorder: #808080;
      --mdHr: #808080;
      --mdListBullet: #8abeb7;
      --toolDiffAdded: #b5bd68;
      --toolDiffRemoved: #cc6666;
      --toolDiffContext: #808080;
      --syntaxComment: #6A9955;
      --syntaxKeyword: #569CD6;
      --syntaxFunction: #DCDCAA;
      --syntaxVariable: #9CDCFE;
      --syntaxString: #CE9178;
      --syntaxNumber: #B5CEA8;
      --syntaxType: #4EC9B0;
      --syntaxOperator: #D4D4D4;
      --syntaxPunctuation: #D4D4D4;
      --thinkingOff: #505050;
      --thinkingMinimal: #6e6e6e;
      --thinkingLow: #5f87af;
      --thinkingMedium: #81a2be;
      --thinkingHigh: #b294bb;
      --thinkingXhigh: #d183e8;
      --thinkingMax: #ff5fff;
      --bashMode: #b5bd68;
      --exportPageBg: #18181e;
      --exportCardBg: #1e1e24;
      --exportInfoBg: #3c3728;
      --body-bg: #18181e;
      --container-bg: #1e1e24;
      --info-bg: #3c3728;
    }

    * { margin: 0; padding: 0; box-sizing: border-box; }

    :root {
      --line-height: 18px; /* 12px font * 1.5 */
      --sidebar-width: 400px;
      --sidebar-min-width: 240px;
      --sidebar-max-width: 840px;
      --sidebar-resizer-width: 6px;
    }

    body {
      font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
      font-size: 12px;
      line-height: var(--line-height);
      color: var(--text);
      background: var(--body-bg);
    }

    body.sidebar-resizing {
      cursor: col-resize;
      user-select: none;
    }

    #app {
      display: flex;
      min-height: 100vh;
    }

    /* Sidebar */
    #sidebar {
      width: var(--sidebar-width);
      min-width: var(--sidebar-width);
      max-width: var(--sidebar-width);
      background: var(--container-bg);
      flex-shrink: 0;
      display: flex;
      flex-direction: column;
      position: sticky;
      top: 0;
      height: 100vh;
      border-right: 1px solid var(--dim);
    }

    #sidebar-resizer {
      width: var(--sidebar-resizer-width);
      flex-shrink: 0;
      position: sticky;
      top: 0;
      height: 100vh;
      cursor: col-resize;
      touch-action: none;
      background: transparent;
      border-right: 1px solid transparent;
    }

    #sidebar-resizer:hover,
    body.sidebar-resizing #sidebar-resizer {
      background: var(--selectedBg);
      border-right-color: var(--dim);
    }

    .sidebar-header {
      padding: 8px 12px;
      flex-shrink: 0;
    }

    .sidebar-controls {
      padding: 8px 8px 4px 8px;
    }

    .sidebar-search {
      width: 100%;
      box-sizing: border-box;
      padding: 4px 8px;
      font-size: 11px;
      font-family: inherit;
      background: var(--body-bg);
      color: var(--text);
      border: 1px solid var(--dim);
      border-radius: 3px;
    }

    .sidebar-filters {
      display: flex;
      padding: 4px 8px 8px 8px;
      gap: 4px;
      align-items: center;
      flex-wrap: wrap;
    }

    .sidebar-search:focus {
      outline: none;
      border-color: var(--accent);
    }

    .sidebar-search::placeholder {
      color: var(--muted);
    }

    .filter-btn {
      padding: 3px 8px;
      font-size: 10px;
      font-family: inherit;
      background: transparent;
      color: var(--muted);
      border: 1px solid var(--dim);
      border-radius: 3px;
      cursor: pointer;
    }

    .filter-btn:hover {
      color: var(--text);
      border-color: var(--text);
    }

    .filter-btn.active {
      background: var(--accent);
      color: var(--body-bg);
      border-color: var(--accent);
    }

    .sidebar-close {
      display: none;
      padding: 3px 8px;
      font-size: 12px;
      font-family: inherit;
      background: transparent;
      color: var(--muted);
      border: 1px solid var(--dim);
      border-radius: 3px;
      cursor: pointer;
      margin-left: auto;
    }

    .sidebar-close:hover {
      color: var(--text);
      border-color: var(--text);
    }

    .tree-container {
      flex: 1;
      overflow: auto;
      padding: 4px 0;
    }

    .tree-node {
      padding: 0 8px;
      cursor: pointer;
      display: flex;
      align-items: baseline;
      font-size: 11px;
      line-height: 13px;
      white-space: nowrap;
    }

    .tree-node:hover {
      background: var(--selectedBg);
    }

    .tree-node.active {
      background: var(--selectedBg);
    }

    .tree-node.active .tree-content {
      font-weight: bold;
    }

    .tree-node.in-path {
      background: color-mix(in srgb, var(--accent) 10%, transparent);
    }

    .tree-node:not(.in-path) {
      opacity: 0.5;
    }

    .tree-node:not(.in-path):hover {
      opacity: 1;
    }

    .tree-prefix {
      color: var(--muted);
      flex-shrink: 0;
      font-family: monospace;
      white-space: pre;
    }

    .tree-marker {
      color: var(--accent);
      flex-shrink: 0;
    }

    .tree-content {
      color: var(--text);
    }

    .tree-role-user {
      color: var(--accent);
    }

    .tree-role-skill {
      color: var(--customMessageLabel);
    }

    .tree-role-assistant {
      color: var(--success);
    }

    .tree-role-tool {
      color: var(--muted);
    }

    .tree-muted {
      color: var(--muted);
    }

    .tree-error {
      color: var(--error);
    }

    .tree-compaction {
      color: var(--borderAccent);
    }

    .tree-branch-summary {
      color: var(--warning);
    }

    .tree-custom-message {
      color: var(--customMessageLabel);
    }

    .tree-status {
      padding: 4px 12px;
      font-size: 10px;
      color: var(--muted);
      flex-shrink: 0;
    }

    /* Main content */
    #content {
      flex: 1;
      min-width: 0;
      overflow-y: auto;
      padding: var(--line-height) calc(var(--line-height) * 2);
      display: flex;
      flex-direction: column;
      align-items: center;
    }

    #content > * {
      width: 100%;
      max-width: 800px;
    }

    /* Help bar */
    .help-bar {
      font-size: 11px;
      color: var(--warning);
      margin-bottom: var(--line-height);
      display: flex;
      align-items: center;
      justify-content: space-between;
      flex-wrap: wrap;
      gap: 12px;
    }

    .help-hint {
      flex: 1 1 240px;
    }

    .help-actions {
      display: flex;
      align-items: center;
      flex-wrap: wrap;
      gap: 8px;
    }

    .header-toggle-btn,
    .download-json-btn {
      font-size: 10px;
      padding: 2px 8px;
      background: var(--container-bg);
      border: 1px solid var(--border);
      border-radius: 3px;
      color: var(--text);
      cursor: pointer;
      font-family: inherit;
    }

    .header-toggle-btn:hover,
    .download-json-btn:hover {
      background: var(--hover);
      border-color: var(--borderAccent);
    }

    /* Header */
    .header {
      background: var(--container-bg);
      border-radius: 4px;
      padding: var(--line-height);
      margin-bottom: var(--line-height);
    }

    .header h1 {
      font-size: 12px;
      font-weight: bold;
      color: var(--borderAccent);
      margin-bottom: var(--line-height

... [287749 bytes truncated] ...

ine code: escape HTML
          codespan(token) {
            return `<code>${escapeHtml(token.text)}</code>`;
          }
        }
      });

      // Simple marked parse (escaping handled in renderers)
      function safeMarkedParse(text) {
        return marked.parse(text);
      }

      // Search input
      const searchInput = document.getElementById('tree-search');
      searchInput.addEventListener('input', (e) => {
        searchQuery = e.target.value;
        forceTreeRerender();
      });

      // Filter buttons
      document.querySelectorAll('.filter-btn').forEach(btn => {
        btn.addEventListener('click', () => {
          document.querySelectorAll('.filter-btn').forEach(b => b.classList.remove('active'));
          btn.classList.add('active');
          filterMode = btn.dataset.filter;
          forceTreeRerender();
        });
      });

      // Sidebar toggle
      const sidebar = document.getElementById('sidebar');
      const overlay = document.getElementById('sidebar-overlay');
      const hamburger = document.getElementById('hamburger');
      const sidebarResizer = document.getElementById('sidebar-resizer');
      const SIDEBAR_WIDTH_STORAGE_KEY = 'pi-share:v1:sidebar-width';
      const MIN_CONTENT_WIDTH = 320;

      function isMobileLayout() {
        return window.matchMedia('(max-width: 900px)').matches;
      }

      function getSidebarBounds() {
        const rootStyles = getComputedStyle(document.documentElement);
        const minWidth = parseFloat(rootStyles.getPropertyValue('--sidebar-min-width')) || 240;
        const maxWidth = parseFloat(rootStyles.getPropertyValue('--sidebar-max-width')) || 720;
        const viewportMaxWidth = window.innerWidth - MIN_CONTENT_WIDTH;
        return {
          minWidth,
          maxWidth: Math.max(minWidth, Math.min(maxWidth, viewportMaxWidth))
        };
      }

      function clampSidebarWidth(width) {
        const { minWidth, maxWidth } = getSidebarBounds();
        return Math.max(minWidth, Math.min(maxWidth, width));
      }

      function applySidebarWidth(width) {
        document.documentElement.style.setProperty('--sidebar-width', `${Math.round(clampSidebarWidth(width))}px`);
      }

      function loadSidebarWidth() {
        try {
          const raw = localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY);
          if (raw === null) return null;
          const width = Number(raw);
          return Number.isFinite(width) ? width : null;
        } catch {
          return null;
        }
      }

      function saveSidebarWidth(width) {
        try {
          localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, String(Math.round(clampSidebarWidth(width))));
        } catch {
          // Ignore storage failures (e.g. private browsing restrictions)
        }
      }

      function setupSidebarResize() {
        const savedWidth = loadSidebarWidth();
        if (savedWidth !== null) {
          applySidebarWidth(savedWidth);
        }

        if (!sidebarResizer) return;

        let cleanupDrag = null;

        const stopDrag = (pointerId) => {
          if (cleanupDrag) {
            cleanupDrag(pointerId);
            cleanupDrag = null;
          }
        };

        sidebarResizer.addEventListener('pointerdown', (e) => {
          if (isMobileLayout()) return;

          e.preventDefault();
          const startX = e.clientX;
          const startWidth = sidebar.getBoundingClientRect().width;
          document.body.classList.add('sidebar-resizing');
          sidebarResizer.setPointerCapture?.(e.pointerId);

          const onPointerMove = (event) => {
            applySidebarWidth(startWidth + (event.clientX - startX));
          };

          cleanupDrag = (pointerIdToRelease) => {
            document.body.classList.remove('sidebar-resizing');
            sidebarResizer.releasePointerCapture?.(pointerIdToRelease);
            window.removeEventListener('pointermove', onPointerMove);
            window.removeEventListener('pointerup', onPointerUp);
            window.removeEventListener('pointercancel', onPointerCancel);
            saveSidebarWidth(sidebar.getBoundingClientRect().width);
          };

          const onPointerUp = (event) => stopDrag(event.pointerId);
          const onPointerCancel = (event) => stopDrag(event.pointerId);

          window.addEventListener('pointermove', onPointerMove);
          window.addEventListener('pointerup', onPointerUp);
          window.addEventListener('pointercancel', onPointerCancel);
        });

        sidebarResizer.addEventListener('dblclick', () => {
          if (isMobileLayout()) return;
          applySidebarWidth(400);
          saveSidebarWidth(400);
        });

        window.addEventListener('resize', () => {
          if (isMobileLayout()) return;
          applySidebarWidth(sidebar.getBoundingClientRect().width);
        });
      }

      setupSidebarResize();

      hamburger.addEventListener('click', () => {
        sidebar.classList.add('open');
        overlay.classList.add('open');
        hamburger.style.display = 'none';
      });

      const closeSidebar = () => {
        sidebar.classList.remove('open');
        overlay.classList.remove('open');
        hamburger.style.display = '';
      };

      overlay.addEventListener('click', closeSidebar);
      document.getElementById('sidebar-close').addEventListener('click', closeSidebar);

      // Toggle states
      let thinkingExpanded = true;
      let toolOutputsExpanded = false;

      const toggleThinking = () => {
        thinkingExpanded = !thinkingExpanded;
        document.querySelectorAll('.thinking-text').forEach(el => {
          el.style.display = thinkingExpanded ? '' : 'none';
        });
        document.querySelectorAll('.thinking-collapsed').forEach(el => {
          el.style.display = thinkingExpanded ? 'none' : 'block';
        });
      };

      const toggleToolOutputs = () => {
        toolOutputsExpanded = !toolOutputsExpanded;
        document.querySelectorAll('.tool-output.expandable').forEach(el => {
          el.classList.toggle('expanded', toolOutputsExpanded);
        });
        document.querySelectorAll('.compaction').forEach(el => {
          el.classList.toggle('expanded', toolOutputsExpanded);
        });
        document.querySelectorAll('.skill-invocation').forEach(el => {
          el.classList.toggle('expanded', toolOutputsExpanded);
        });
      };

      const attachHeaderHandlers = () => {
        document.querySelector('[data-action="toggle-thinking"]')?.addEventListener('click', toggleThinking);
        document.querySelector('[data-action="toggle-tools"]')?.addEventListener('click', toggleToolOutputs);
      };

      const isEditableTarget = (element) => {
        if (!element) return false;
        const tagName = element.tagName;
        if (tagName === 'INPUT' || tagName === 'TEXTAREA' || tagName === 'SELECT' || tagName === 'BUTTON') {
          return true;
        }
        return element.isContentEditable || Boolean(element.closest?.('[contenteditable="true"]'));
      };

      // Keyboard shortcuts
      document.addEventListener('keydown', (e) => {
        if (e.key === 'Escape') {
          searchInput.value = '';
          searchQuery = '';
          navigateTo(leafId, 'bottom');
        }

        if (isEditableTarget(document.activeElement)) {
          return;
        }

        const key = e.key.toLowerCase();
        if (key === 't') {
          e.preventDefault();
          toggleThinking();
        } else if (key === 'o') {
          e.preventDefault();
          toggleToolOutputs();
        }
      });

      // Initial render
      // If URL has targetId, scroll to that specific message; otherwise stay at top
      if (leafId) {
        if (urlTargetId && byId.has(urlTargetId)) {
          // Deep link: navigate to leaf and scroll to target message
          navigateTo(leafId, 'target', urlTargetId);
        } else {
          navigateTo(leafId, 'none');
        }
      } else if (entries.length > 0) {
        // Fallback: use last entry if no leafId
        navigateTo(entries[entries.length - 1].id, 'none');
      }
    })();

  </script>
</body>
</html>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"666c2339a147e66cc7887a6f136e23fe18849862","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (2) ✅</summary>

- 🚨 `.pi/extensions/lib/fm-calm-branch-outcomes.ts:43` - Intent requires that “any output Calm does not recognize as the store&#39;s records” remain visible, but this parser accepts only task/summary/verdict. For example, `{&#34;task&#34;:&#34;task-9&#34;,&#34;verdict&#34;:&#34;routine&#34;,&#34;summary&#34;:&#34;ok&#34;}` lacks the required seq, epoch, and wake fields, yet is treated as a routine store record and silently collapsed. Validate the complete current/legacy store schema before suppressing a record.
- 🚨 `.pi/extensions/fm-branch-supervision.ts:821` - Intent requires unrecognized output to survive “as one dim line carrying the supervision branch&#39;s own sailboat glyph,” but unrecognized lines have `glyph: false` and this branch renders them without `BRANCH_BOAT`. Confirm whether the glyph requirement or the implementation should prevail.
- 🚨 `.pi/extensions/fm-branch-supervision.ts:822` - The intent explicitly reserves approval of the new captain-screen copy for the captain. Obtain that approval for the rendered `⛵ &lt;task&gt;: &lt;summary&gt;` and failed-read lines before merging.

🔧 Fix: Validate Calm outcome records and preserve glyphs
1 error still open:

- 🚨 `.pi/extensions/lib/fm-calm-branch-outcomes.ts:79` - The required criterion says any output not recognized as a complete store record must stay visible byte-for-byte, but whitespace-only lines are skipped before validation. A reachable listing such as a routine record followed by an interior line containing two spaces collapses completely, silently hiding malformed store output. Pass every non-empty-output line through validation and preserve failed lines rather than special-casing whitespace.

🔧 Fix: Preserve interior unrecognized whitespace in Calm outcomes
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Baseline: `pi --version; tmux -V; node --version; git rev-parse HEAD; git status --short`</code>
- `tests/fm-calm-branch-outcomes.test.sh`
- `tests/fm-calm-pi-extension.test.sh`
- `bash tests/fm-pi-branch-extension.test.sh`
- `tests/fm-pi-primary-types.test.sh`
- `FM_CALM_BRANCH_OUTCOMES_LIVE_E2E=1 bash tests/fm-calm-branch-outcomes-live-e2e.test.sh`
- `Repeated the live guard with an evidence-copy hook to retain its real Pi terminal capture and HTML export`
- `Semantically inspected the captured terminal and exported session data: the terminal omitted raw routine JSON and showed two sailboat attention lines, while the expanded export retained all 16 records`
- `Rendered the captured terminal as HTML, captured it with headless Chrome, and opened the resulting PNG for visual verification`
- <code>Final cleanup check: `git status --short` and tmux fixture-session check</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
