### PR TITLE
feat(bin): add fleet-wide PR merge conflict watcher

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,7 @@ state/               runtime records and signals; gitignored
   .pr-check-migration-scan-v1  private marker proving the non-executing scan disabled every unsafe legacy check; .pr-check-migration-v1 separately records completed private repairs
   x-watch.check.sh   generated Relay poll shim; present only when opted in (section 14)
   tool-updates.check.sh  generated watched-tool update poll shim and its .check-trust binding; present only after bin/fm-tool-update-check.sh arm; its report record .tool-updates is what keeps one pending update from being reported on every poll
+  pr-conflict-watch.check.sh  generated open-PR merge-conflict poll shim and its .check-trust binding; present only after bin/fm-pr-conflict-watch.sh arm; its dedupe record .pr-conflict-watch is what keeps one conflicted head from waking on every poll, and it is cut back to the conflicts each sweep still observes
   pending-replies/   parent-owned secondmate pending-reply records (correlation id, delivery vs reply, recovery, escalation); fm-pending-reply-lib.sh
   procevent/         registered process-to-event sources, one private record per canonical source id; written only by bin/fm-procevent.sh, and their presence alone keeps supervision required (section 13)
   procevent-inbox/   private captured results and their durable handled-acknowledgement markers; source output lives here and never in an event line

--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -69,6 +69,9 @@ FLEET="$SCRIPT_DIR/fm-fleet-snapshot.sh"
 # shellcheck source=bin/fm-timeout-lib.sh
 # shellcheck disable=SC1091
 . "$SCRIPT_DIR/fm-timeout-lib.sh"
+# shellcheck source=bin/fm-repo-slug-lib.sh
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/fm-repo-slug-lib.sh"
 
 # Bounds (overridable for tests / large fleets).
 FM_BEARINGS_LANDED=${FM_BEARINGS_LANDED:-6}
@@ -193,11 +196,6 @@ PR_REPOS_SHOWN=0
 PR_ROWS_CAPPED=0
 PR_ROWS_MIN_TOTAL=0
 
-# Parse owner/repo from an https or ssh GitHub remote/PR URL; empty if not GitHub.
-repo_slug() {  # <url>
-  printf '%s' "$1" | sed -n 's#.*github\.com[:/]\([^/]*/[^/]*\)#\1#p' | sed 's#\.git$##; s#/pull/.*$##; s#/$##'
-}
-
 # Bounded gh call; prints stdout, non-zero on timeout/failure. gh only.
 # bin/fm-timeout-lib.sh owns the bound itself.
 gh_bounded() {  # <args...>
@@ -213,7 +211,7 @@ if [ "$INCLUDE_PRS" = 1 ]; then
     repos=""
     while IFS= read -r u; do
       [ -n "$u" ] || continue
-      s=$(repo_slug "$u"); [ -n "$s" ] || continue
+      s=$(fm_repo_slug "$u"); [ -n "$s" ] || continue
       case " $repos " in *" $s "*) : ;; *) repos="$repos $s" ;; esac
     done <<EOF
 $(printf '%s' "$SNAP" | jq -r '.tasks[].pr.url // empty')
@@ -222,7 +220,7 @@ EOF
       [ -n "$wt" ] || continue
       [ -d "$wt" ] || continue
       u=$(git -C "$wt" remote get-url origin 2>/dev/null) || continue
-      s=$(repo_slug "$u"); [ -n "$s" ] || continue
+      s=$(fm_repo_slug "$u"); [ -n "$s" ] || continue
       case " $repos " in *" $s "*) : ;; *) repos="$repos $s" ;; esac
     done <<EOF
 $(printf '%s' "$SNAP" | jq -r '.tasks[] | select(.kind != "secondmate") | .paths.worktree.path // empty')

--- a/bin/fm-pr-conflict-watch.sh
+++ b/bin/fm-pr-conflict-watch.sh
@@ -484,7 +484,9 @@ record_remove_key() {
 # that page carried; a repository the sweep did not finish keeps all of its
 # keys, because absence there means unread rather than resolved. Keys for
 # repositories this fleet no longer works in are dropped only when the sweep
-# reached every discovered repository.
+# reached every discovered repository and discovery named at least one: a sweep
+# that discovered nothing inspected nothing, so its empty repository set is a
+# failed read rather than proof the fleet stopped working in those repositories.
 seen_key() {
   local key=$1
   case ";$SEEN_KEYS;" in
@@ -505,7 +507,7 @@ record_prune() {
         esac
         ;;
       *)
-        if [ "$SWEEP_COMPLETE" -eq 1 ]; then
+        if [ "$SWEEP_COMPLETE" -eq 1 ] && [ -n "$DISCOVERED_REPOS" ]; then
           case " $DISCOVERED_REPOS " in
             *" $repo "*) ;;
             *) continue ;;

--- a/bin/fm-pr-conflict-watch.sh
+++ b/bin/fm-pr-conflict-watch.sh
@@ -19,7 +19,10 @@
 #
 # Dedupe keys are owner/repo, PR number, and head SHA. A force-updated head that
 # conflicts again is a new event; the same conflict on the same head stays silent
-# after the first wake.
+# after the first wake. A key is recorded only for a conflict that reached the
+# printed line, so conflicts cut by the line cap are disclosed as omitted and
+# wake on a later sweep instead of being silenced. The record is cut back to the
+# conflicts each sweep still observes, so it cannot grow without bound.
 #
 # GitHub computes mergeability lazily. A single read that returns UNKNOWN is
 # never treated as clean or conflicted; the check polls with short waits until
@@ -46,10 +49,13 @@ REGISTER_BIN="$SCRIPT_DIR/fm-check-register.sh"
 RECORD_SCHEMA=fm-pr-conflict-watch-v1
 GH_AXI=${FM_PR_CONFLICT_GH_AXI:-gh-axi}
 MAX_LINE=1000
+FINDING_PREFIX='pr-conflict: '
 MAIN_OWNER=main
 
 # shellcheck source=bin/fm-timeout-lib.sh
 . "$SCRIPT_DIR/fm-timeout-lib.sh"
+# shellcheck source=bin/fm-repo-slug-lib.sh
+. "$SCRIPT_DIR/fm-repo-slug-lib.sh"
 # shellcheck source=bin/fm-pr-lib.sh
 . "$SCRIPT_DIR/fm-pr-lib.sh"
 # shellcheck source=bin/fm-line-cap-lib.sh
@@ -182,16 +188,80 @@ real_epoch() { date +%s; }
 DEADLINE=0
 REPORTED_KEYS=
 RECORD_EPOCH=0
-FINDINGS=
+FINDING_TEXTS=()
+FINDING_KEYS=()
+FINDING_LINE=
+FINDING_LINE_KEYS=
+FINDING_OMITTED=0
+DISCOVERED_REPOS=
+REPO_OWNER_MAP=
+PROJECT_OWNER_MAP=
+FIRSTMATE_SLUG=
+SWEPT_REPOS=
+SEEN_KEYS=
+SWEEP_COMPLETE=1
+RESOLVED_STATE=
+RESOLVED_HEAD=
 
-emit_finding() {
+# Split a delimited accumulator into one part per line. `read -r -a` is not used
+# anywhere here because expanding a declared-but-empty array under `set -u` is a
+# fatal unbound-variable error on bash 3.2, and an empty record is the normal
+# state of a clean fleet.
+list_parts() {
+  local rest=$1 sep=$2 part
+  while [ -n "$rest" ]; do
+    part=${rest%%"$sep"*}
+    if [ "$part" = "$rest" ]; then
+      rest=
+    else
+      rest=${rest#*"$sep"}
+    fi
+    [ -n "$part" ] || continue
+    printf '%s\n' "$part"
+  done
+}
+
+# A finding is queued together with the dedupe key that would suppress its
+# repeat, and that key is recorded only once the finding survives the line cap.
+# A finding cut from the printed line was never reported, so recording it would
+# silence that conflict for good: its head does not change, so no later sweep
+# re-triggers it.
+queue_finding() {
   local text
   text=$(printf '%s' "$1" | tr '\t\r\n' '   ')
-  if [ -z "$FINDINGS" ]; then
-    FINDINGS=$text
-  else
-    FINDINGS="$FINDINGS; $text"
-  fi
+  FINDING_TEXTS+=("$text")
+  FINDING_KEYS+=("${2:-}")
+}
+
+# Fill the line in queue order up to <reserve> characters short of the cap, and
+# collect the keys of exactly the findings that fit. The first finding is always
+# taken, so a single over-long finding still reports something - the title is
+# the only unbounded field and it is last, so the final cut takes that tail -
+# rather than leaving the sweep permanently silent.
+build_finding_line() {
+  local reserve=$1 total i text key candidate room
+  FINDING_LINE=
+  FINDING_LINE_KEYS=
+  FINDING_OMITTED=0
+  total=${#FINDING_TEXTS[@]}
+  room=$((MAX_LINE - reserve))
+  i=0
+  while [ "$i" -lt "$total" ]; do
+    text=${FINDING_TEXTS[$i]}
+    key=${FINDING_KEYS[$i]}
+    if [ -z "$FINDING_LINE" ]; then
+      candidate="$FINDING_PREFIX$text"
+    else
+      candidate="$FINDING_LINE; $text"
+    fi
+    if [ "$i" -eq 0 ] || [ "${#candidate}" -le "$room" ]; then
+      FINDING_LINE=$candidate
+      [ -z "$key" ] || FINDING_LINE_KEYS="${FINDING_LINE_KEYS:+$FINDING_LINE_KEYS;}$key"
+    else
+      FINDING_OMITTED=$((FINDING_OMITTED + 1))
+    fi
+    i=$((i + 1))
+  done
 }
 
 budget_exhausted() {
@@ -214,14 +284,10 @@ gh_bounded() {
   fm_run_timed "$(probe_bound)" env GH_PROMPT_DISABLED=1 GH_NO_UPDATE_NOTIFIER=1 "$GH_AXI" "$@"
 }
 
-repo_slug() {
-  printf '%s' "$1" | sed -n 's#.*github\.com[:/]\([^/]*/[^/]*\)#\1#p' | sed 's#\.git$##; s#/pull/.*$##; s#/$##'
-}
-
 firstmate_repo_slug() {
   local url
   url=$(git -C "$FM_ROOT" remote get-url origin 2>/dev/null) || return 1
-  repo_slug "$url"
+  fm_repo_slug "$url"
 }
 
 project_names() {
@@ -234,32 +300,9 @@ resolve_project_repo() {
   dir="$PROJECTS/$project"
   [ -d "$dir" ] || return 1
   url=$(git -C "$dir" remote get-url origin 2>/dev/null) || return 1
-  slug=$(repo_slug "$url")
+  slug=$(fm_repo_slug "$url")
   [ -n "$slug" ] || return 1
   printf '%s\n' "$slug"
-}
-
-discover_repos() {
-  local project slug repos='' fm_slug
-  while IFS= read -r project; do
-    [ -n "$project" ] || continue
-    slug=$(resolve_project_repo "$project" 2>/dev/null) || continue
-    case " $repos " in
-      *" $slug "*) ;;
-      *) repos="$repos $slug" ;;
-    esac
-  done < <(project_names)
-  fm_slug=$(firstmate_repo_slug 2>/dev/null) || fm_slug=
-  if [ -n "$fm_slug" ]; then
-    case " $repos " in
-      *" $fm_slug "*) ;;
-      *) repos="$repos $fm_slug" ;;
-    esac
-  fi
-  for slug in $repos; do
-    [ -n "$slug" ] || continue
-    printf '%s\n' "$slug"
-  done
 }
 
 trim_field() {
@@ -269,49 +312,95 @@ trim_field() {
   printf '%s\n' "$value"
 }
 
-owner_for_project() {
-  local project=$1 reg line id projects part
+# The registry is read once per sweep into a project -> owning secondmate map.
+# First registration wins, which is the order a linear scan of the file would
+# have answered in.
+load_project_owners() {
+  local reg line id rest part
+  PROJECT_OWNER_MAP=
   reg="$DATA/secondmates.md"
-  [ -f "$reg" ] || return 1
+  [ -f "$reg" ] || return 0
   while IFS= read -r line || [ -n "$line" ]; do
     case "$line" in
-      "- "*)
-        secondmate_registry_parse_line "$line" || continue
-        id=$SECONDMATE_REGISTRY_ID
-        projects=$SECONDMATE_REGISTRY_PROJECTS
-        IFS=',' read -r -a _parts <<< "$projects"
-        for part in "${_parts[@]}"; do
-          part=$(trim_field "$part")
-          [ "$part" = "$project" ] || continue
-          printf '%s\n' "$id"
-          return 0
-        done
-        ;;
+      "- "*) ;;
+      *) continue ;;
     esac
+    secondmate_registry_parse_line "$line" || continue
+    id=$SECONDMATE_REGISTRY_ID
+    rest=$SECONDMATE_REGISTRY_PROJECTS
+    while IFS= read -r part; do
+      part=$(trim_field "$part")
+      [ -n "$part" ] || continue
+      case "$part" in *[[:space:]]*) continue ;; esac
+      case "
+$PROJECT_OWNER_MAP" in
+        *"
+$part "*) continue ;;
+      esac
+      PROJECT_OWNER_MAP="$PROJECT_OWNER_MAP$part $id
+"
+    done < <(list_parts "$rest" ',')
   done < "$reg"
+}
+
+map_lookup() {
+  local map=$1 key=$2 line
+  while IFS= read -r line; do
+    [ "${line%% *}" = "$key" ] || continue
+    printf '%s\n' "${line#* }"
+    return 0
+  done <<EOF
+$map
+EOF
   return 1
 }
 
-owner_for_repo() {
-  local repo=$1 project slug owner fm_slug
-  fm_slug=$(firstmate_repo_slug 2>/dev/null) || fm_slug=
-  if [ -n "$fm_slug" ] && [ "$repo" = "$fm_slug" ]; then
-    printf '%s\n' "$MAIN_OWNER"
-    return 0
-  fi
+owner_for_project() {
+  map_lookup "$PROJECT_OWNER_MAP" "$1"
+}
+
+# Repositories and their owning targets are derived together, once per sweep, so
+# neither the origin remotes nor the registry are re-read per repository while
+# the same budget is paying for GitHub probes.
+discover_repos() {
+  local project slug owner
+  DISCOVERED_REPOS=
+  REPO_OWNER_MAP=
+  load_project_owners
+  FIRSTMATE_SLUG=$(firstmate_repo_slug 2>/dev/null) || FIRSTMATE_SLUG=
   while IFS= read -r project; do
     [ -n "$project" ] || continue
     slug=$(resolve_project_repo "$project" 2>/dev/null) || continue
-    [ "$slug" = "$repo" ] || continue
-    owner=$(owner_for_project "$project" 2>/dev/null) || owner=
-    if [ -n "$owner" ]; then
-      printf '%s\n' "$owner"
+    case " $DISCOVERED_REPOS " in
+      *" $slug "*) continue ;;
+    esac
+    if [ -n "$FIRSTMATE_SLUG" ] && [ "$slug" = "$FIRSTMATE_SLUG" ]; then
+      owner=$MAIN_OWNER
     else
-      printf '%s\n' "$MAIN_OWNER"
+      owner=$(owner_for_project "$project") || owner=
+      [ -n "$owner" ] || owner=$MAIN_OWNER
     fi
-    return 0
+    DISCOVERED_REPOS="$DISCOVERED_REPOS $slug"
+    REPO_OWNER_MAP="$REPO_OWNER_MAP$slug $owner
+"
   done < <(project_names)
-  printf '%s\n' "$MAIN_OWNER"
+  if [ -n "$FIRSTMATE_SLUG" ]; then
+    case " $DISCOVERED_REPOS " in
+      *" $FIRSTMATE_SLUG "*) ;;
+      *)
+        DISCOVERED_REPOS="$DISCOVERED_REPOS $FIRSTMATE_SLUG"
+        REPO_OWNER_MAP="$REPO_OWNER_MAP$FIRSTMATE_SLUG $MAIN_OWNER
+"
+        ;;
+    esac
+  fi
+}
+
+owner_for_repo() {
+  local owner
+  owner=$(map_lookup "$REPO_OWNER_MAP" "$1") || owner=
+  [ -n "$owner" ] || owner=$MAIN_OWNER
+  printf '%s\n' "$owner"
 }
 
 conflict_key() {
@@ -373,18 +462,59 @@ record_add_key() {
   fi
 }
 
+record_add_keys() {
+  local part
+  while IFS= read -r part; do
+    record_add_key "$part"
+  done < <(list_parts "$1" ';')
+}
+
 record_remove_key() {
   local key=$1 out='' part
-  IFS=';' read -r -a _parts <<< "$REPORTED_KEYS"
-  for part in "${_parts[@]}"; do
-    [ -n "$part" ] || continue
+  while IFS= read -r part; do
     [ "$part" = "$key" ] && continue
-    if [ -z "$out" ]; then
-      out=$part
-    else
-      out="$out;$part"
-    fi
-  done
+    out="${out:+$out;}$part"
+  done < <(list_parts "$REPORTED_KEYS" ';')
+  REPORTED_KEYS=$out
+}
+
+# Every open pull request this sweep read is remembered, so the record can be
+# cut back to the live conflict set instead of accumulating one key per head
+# forever. A repository whose whole open-PR page was read keeps only the keys
+# that page carried; a repository the sweep did not finish keeps all of its
+# keys, because absence there means unread rather than resolved. Keys for
+# repositories this fleet no longer works in are dropped only when the sweep
+# reached every discovered repository.
+seen_key() {
+  local key=$1
+  case ";$SEEN_KEYS;" in
+    *";$key;"*) return 0 ;;
+  esac
+  SEEN_KEYS="${SEEN_KEYS:+$SEEN_KEYS;}$key"
+}
+
+record_prune() {
+  local out='' part repo
+  while IFS= read -r part; do
+    repo=${part%%#*}
+    case " $SWEPT_REPOS " in
+      *" $repo "*)
+        case ";$SEEN_KEYS;" in
+          *";$part;"*) ;;
+          *) continue ;;
+        esac
+        ;;
+      *)
+        if [ "$SWEEP_COMPLETE" -eq 1 ]; then
+          case " $DISCOVERED_REPOS " in
+            *" $repo "*) ;;
+            *) continue ;;
+          esac
+        fi
+        ;;
+    esac
+    out="${out:+$out;}$part"
+  done < <(list_parts "$REPORTED_KEYS" ';')
   REPORTED_KEYS=$out
 }
 
@@ -394,24 +524,57 @@ json_field() {
   printf '%s' "$json" | jq -er "$query" 2>/dev/null
 }
 
+# Resolve one pull request's lazily computed mergeability into RESOLVED_STATE,
+# with the head RESOLVED_STATE describes in RESOLVED_HEAD - the read that
+# settled the state is also what names the head it was settled for, so a head
+# force-updated between the list and this read is reported under the SHA that
+# was actually judged.
+#
+# The retry loop is bounded by the sweep deadline as well as by the attempt
+# count: overrunning FM_CHECK_TIMEOUT gets the process group killed, and this
+# check prints and records only at the end, so an overrun sweep loses every
+# finding it made and repeats that loss on every poll. An unsettled read stays
+# unknown, which is silent, and never becomes clean or conflicted.
 pr_mergeable_resolved() {
-  local repo=$1 number=$2 mergeable='' attempt=0 json
+  local repo=$1 number=$2 mergeable='' attempt=0 json head
+  RESOLVED_STATE=unknown
+  RESOLVED_HEAD=
   while :; do
+    if budget_exhausted; then
+      RESOLVED_STATE=unknown
+      return 0
+    fi
     json=$(gh_bounded pr view "$number" --repo "$repo" \
       --json mergeable,mergeStateStatus,number,title,url,headRefOid,isDraft 2>/dev/null) || return 2
     mergeable=$(json_field "$json" '.mergeable // "UNKNOWN"') || return 2
+    head=$(json_field "$json" '.headRefOid // ""') || head=
     case "$mergeable" in
-      MERGEABLE) printf 'clean\n'; return 0 ;;
-      CONFLICTING) printf 'conflicted\n'; return 0 ;;
+      MERGEABLE)
+        RESOLVED_STATE=clean
+        RESOLVED_HEAD=$head
+        return 0
+        ;;
+      CONFLICTING)
+        RESOLVED_STATE=conflicted
+        RESOLVED_HEAD=$head
+        return 0
+        ;;
       UNKNOWN)
         attempt=$((attempt + 1))
         if [ "$attempt" -ge "$UNKNOWN_ATTEMPTS" ]; then
-          printf 'unknown\n'
+          RESOLVED_STATE=unknown
+          return 0
+        fi
+        if [ $((DEADLINE - $(real_epoch))) -le $((UNKNOWN_WAIT + PROBE_MIN_SECS)) ]; then
+          RESOLVED_STATE=unknown
           return 0
         fi
         [ "$UNKNOWN_WAIT" -eq 0 ] || sleep "$UNKNOWN_WAIT"
         ;;
-      *) printf 'unknown\n'; return 0 ;;
+      *)
+        RESOLVED_STATE=unknown
+        return 0
+        ;;
     esac
   done
 }
@@ -426,7 +589,7 @@ format_finding() {
 }
 
 evaluate_repo() {
-  local repo=$1 owner_team=$2 json count i row number title head draft url mergeable key resolved
+  local repo=$1 owner_team=$2 json count i row number title head draft url mergeable key state
   budget_exhausted && return 1
   json=$(gh_bounded pr list --repo "$repo" --state open --limit "$PR_LIMIT" \
     --json number,title,url,headRefOid,isDraft,mergeable 2>/dev/null) || return 0
@@ -444,35 +607,43 @@ evaluate_repo() {
     mergeable=$(json_field "$row" '.mergeable // "UNKNOWN"') || mergeable=UNKNOWN
     i=$((i + 1))
     [ -n "$head" ] || continue
-    key=$(conflict_key "$repo" "$number" "$head")
+    seen_key "$(conflict_key "$repo" "$number" "$head")"
     case "$mergeable" in
-      MERGEABLE)
+      MERGEABLE) state=clean ;;
+      CONFLICTING) state=conflicted ;;
+      UNKNOWN)
+        pr_mergeable_resolved "$repo" "$number" || continue
+        state=$RESOLVED_STATE
+        if [ -n "$RESOLVED_HEAD" ] && [ "$RESOLVED_HEAD" != "$head" ]; then
+          record_remove_key "$(conflict_key "$repo" "$number" "$head")"
+          head=$RESOLVED_HEAD
+          seen_key "$(conflict_key "$repo" "$number" "$head")"
+        fi
+        ;;
+      *) continue ;;
+    esac
+    key=$(conflict_key "$repo" "$number" "$head")
+    case "$state" in
+      conflicted) ;;
+      clean)
         record_remove_key "$key"
         continue
-        ;;
-      CONFLICTING) ;;
-      UNKNOWN)
-        resolved=$(pr_mergeable_resolved "$repo" "$number") || continue
-        case "$resolved" in
-          conflicted) ;;
-          clean)
-            record_remove_key "$key"
-            continue
-            ;;
-          *) continue ;;
-        esac
         ;;
       *) continue ;;
     esac
     record_has_key "$key" && continue
-    emit_finding "$(format_finding "$owner_team" "$repo" "$number" "$head" "$draft" "$url" "$title")"
-    record_add_key "$key"
+    queue_finding "$(format_finding "$owner_team" "$repo" "$number" "$head" "$draft" "$url" "$title")" "$key"
   done
+  # Only a page that was not itself cut short by PR_LIMIT can be read as the
+  # repository's whole open set, which is what pruning its stale keys relies on.
+  if [ "$count" -lt "$PR_LIMIT" ]; then
+    SWEPT_REPOS="$SWEPT_REPOS $repo"
+  fi
   return 0
 }
 
 action_check() {
-  local repo owner_team line now
+  local repo owner_team line now notice
   if ! command -v jq >/dev/null 2>&1; then
     return 0
   fi
@@ -490,21 +661,40 @@ action_check() {
   DEADLINE=$(($(real_epoch) + BUDGET_SECS))
 
   if [ -n "$BUDGET_CUT_FROM" ]; then
-    emit_finding "sweep budget ${BUDGET_CUT_FROM}s cut to ${BUDGET_SECS}s to stay inside the watcher check timeout of ${CHECK_TIMEOUT}s"
+    queue_finding "sweep budget ${BUDGET_CUT_FROM}s cut to ${BUDGET_SECS}s to stay inside the watcher check timeout of ${CHECK_TIMEOUT}s"
   fi
 
-  while IFS= read -r repo; do
+  discover_repos
+  for repo in $DISCOVERED_REPOS; do
     [ -n "$repo" ] || continue
-    budget_exhausted && break
+    if budget_exhausted; then
+      SWEEP_COMPLETE=0
+      break
+    fi
     owner_team=$(owner_for_repo "$repo")
-    evaluate_repo "$repo" "$owner_team" || break
-  done < <(discover_repos)
+    evaluate_repo "$repo" "$owner_team" || { SWEEP_COMPLETE=0; break; }
+  done
 
   line=
-  if [ -n "$FINDINGS" ]; then
-    fm_cap_line_var "pr-conflict: $FINDINGS" "$MAX_LINE"
+  if [ "${#FINDING_TEXTS[@]}" -gt 0 ]; then
+    build_finding_line 0
+    if [ "$FINDING_OMITTED" -gt 0 ]; then
+      # Reserve the widest the disclosure can be, so the second pass cannot be
+      # invalidated by the count it is making room for.
+      notice="; ${#FINDING_TEXTS[@]} more omitted (line cap)"
+      build_finding_line "${#notice}"
+      if [ "$FINDING_OMITTED" -gt 0 ]; then
+        FINDING_LINE="$FINDING_LINE; $FINDING_OMITTED more omitted (line cap)"
+      fi
+    fi
+    # A last cut through the shared rule, so an over-long single finding ends
+    # with the same visible truncation marker the digests use.
+    fm_cap_line_var "$FINDING_LINE" "$MAX_LINE"
     line=$FM_LINE_CAP_LINE
   fi
+
+  record_prune
+  record_add_keys "$FINDING_LINE_KEYS"
 
   if [ -n "$line" ]; then
     printf '%s\n' "$line"

--- a/bin/fm-pr-conflict-watch.sh
+++ b/bin/fm-pr-conflict-watch.sh
@@ -200,6 +200,7 @@ FIRSTMATE_SLUG=
 SWEPT_REPOS=
 SEEN_KEYS=
 SWEEP_COMPLETE=1
+DISCOVERY_COMPLETE=1
 RESOLVED_STATE=
 RESOLVED_HEAD=
 
@@ -366,11 +367,16 @@ discover_repos() {
   local project slug owner
   DISCOVERED_REPOS=
   REPO_OWNER_MAP=
+  DISCOVERY_COMPLETE=1
   load_project_owners
   FIRSTMATE_SLUG=$(firstmate_repo_slug 2>/dev/null) || FIRSTMATE_SLUG=
+  [ -n "$FIRSTMATE_SLUG" ] || DISCOVERY_COMPLETE=0
   while IFS= read -r project; do
     [ -n "$project" ] || continue
-    slug=$(resolve_project_repo "$project" 2>/dev/null) || continue
+    # A project whose clone or origin cannot be read names no slug, so the sweep
+    # cannot tell which repository went unread. That leaves the whole discovery
+    # partial rather than this one entry skippable.
+    slug=$(resolve_project_repo "$project" 2>/dev/null) || { DISCOVERY_COMPLETE=0; continue; }
     case " $DISCOVERED_REPOS " in
       *" $slug "*) continue ;;
     esac
@@ -483,10 +489,13 @@ record_remove_key() {
 # forever. A repository whose whole open-PR page was read keeps only the keys
 # that page carried; a repository the sweep did not finish keeps all of its
 # keys, because absence there means unread rather than resolved. Keys for
-# repositories this fleet no longer works in are dropped only when the sweep
-# reached every discovered repository and discovery named at least one: a sweep
-# that discovered nothing inspected nothing, so its empty repository set is a
-# failed read rather than proof the fleet stopped working in those repositories.
+# repositories this fleet no longer works in are dropped only when discovery
+# resolved every project it enumerated and the sweep then reached every
+# repository discovery named. A discovery that skipped a project whose clone or
+# origin could not be read - including the degenerate case where it resolved
+# nothing at all - left behind an unread repository it cannot even name, so
+# absence from its repository set is a failed read rather than proof the fleet
+# stopped working in those repositories.
 seen_key() {
   local key=$1
   case ";$SEEN_KEYS;" in
@@ -507,7 +516,8 @@ record_prune() {
         esac
         ;;
       *)
-        if [ "$SWEEP_COMPLETE" -eq 1 ] && [ -n "$DISCOVERED_REPOS" ]; then
+        if [ "$SWEEP_COMPLETE" -eq 1 ] && [ "$DISCOVERY_COMPLETE" -eq 1 ] \
+          && [ -n "$DISCOVERED_REPOS" ]; then
           case " $DISCOVERED_REPOS " in
             *" $repo "*) ;;
             *) continue ;;

--- a/bin/fm-pr-conflict-watch.sh
+++ b/bin/fm-pr-conflict-watch.sh
@@ -1,0 +1,652 @@
+#!/usr/bin/env bash
+# fm-pr-conflict-watch.sh - detect open PR merge conflicts across the fleet.
+#
+# Usage:
+#   fm-pr-conflict-watch.sh [check]
+#   fm-pr-conflict-watch.sh arm
+#   fm-pr-conflict-watch.sh disarm
+#   fm-pr-conflict-watch.sh --help
+#
+# `check` prints one line when a newly conflicted open PR is found and prints
+# nothing otherwise. `arm` writes state/pr-conflict-watch.check.sh and binds
+# its bytes with fm-check-register.sh so the watcher polls on its normal
+# cadence. `disarm` removes the shim, trust binding, and dedupe record.
+#
+# Repositories come from data/projects.md project clones under projects/, plus
+# this firstmate checkout's own origin remote. Owning targets come from
+# data/secondmates.md project lists, with the firstmate repository mapped to
+# main. Nothing is hardcoded to a fleet-specific name.
+#
+# Dedupe keys are owner/repo, PR number, and head SHA. A force-updated head that
+# conflicts again is a new event; the same conflict on the same head stays silent
+# after the first wake.
+#
+# GitHub computes mergeability lazily. A single read that returns UNKNOWN is
+# never treated as clean or conflicted; the check polls with short waits until
+# the state settles or stays unknown.
+#
+# Detection and routing only: this script never resolves conflicts.
+set -u
+export LC_ALL=C
+export GH_PROMPT_DISABLED=1
+export GH_NO_UPDATE_NOTIFIER=1
+export GIT_TERMINAL_PROMPT=0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-${FM_ROOT_OVERRIDE:-$FM_ROOT}}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+PROJECTS="${FM_PROJECTS_OVERRIDE:-$FM_HOME/projects}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+RECORD="$STATE/.pr-conflict-watch"
+CHECK_ID=pr-conflict-watch
+CHECK_SHIM="$STATE/$CHECK_ID.check.sh"
+CHECK_TRUST="$STATE/$CHECK_ID.check-trust"
+REGISTER_BIN="$SCRIPT_DIR/fm-check-register.sh"
+RECORD_SCHEMA=fm-pr-conflict-watch-v1
+GH_AXI=${FM_PR_CONFLICT_GH_AXI:-gh-axi}
+MAX_LINE=1000
+MAIN_OWNER=main
+
+# shellcheck source=bin/fm-timeout-lib.sh
+. "$SCRIPT_DIR/fm-timeout-lib.sh"
+# shellcheck source=bin/fm-pr-lib.sh
+. "$SCRIPT_DIR/fm-pr-lib.sh"
+# shellcheck source=bin/fm-line-cap-lib.sh
+. "$SCRIPT_DIR/fm-line-cap-lib.sh"
+# shellcheck source=bin/fm-check-lib.sh
+. "$SCRIPT_DIR/fm-check-lib.sh"
+# shellcheck source=bin/fm-secondmate-registry-lib.sh
+. "$SCRIPT_DIR/fm-secondmate-registry-lib.sh"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  fm-pr-conflict-watch.sh [check]   report newly conflicted open PRs (silent when clear)
+  fm-pr-conflict-watch.sh arm       write and register state/pr-conflict-watch.check.sh
+  fm-pr-conflict-watch.sh disarm    remove the check shim, trust binding, and record
+  fm-pr-conflict-watch.sh --help    print this help
+
+Repositories are derived from data/projects.md clones under projects/ plus this
+firstmate checkout's origin remote. Owning targets are derived from
+data/secondmates.md project lists, with the firstmate repository mapped to main.
+
+Arm once per home. The watcher polls on its normal FM_CHECK_INTERVAL cadence.
+See docs/configuration.md for tuning knobs.
+EOF
+}
+
+die_usage() {
+  printf 'fm-pr-conflict-watch: %s\n' "$1" >&2
+  usage >&2
+  exit 2
+}
+
+INTERVAL=${FM_PR_CONFLICT_INTERVAL:-300}
+case "$INTERVAL" in
+  ''|*[!0-9]*)
+    printf 'fm-pr-conflict-watch: FM_PR_CONFLICT_INTERVAL must be 0 or a whole number from 60 to 86400\n' >&2
+    exit 2
+    ;;
+esac
+if [ "$INTERVAL" -ne 0 ] && { [ "$INTERVAL" -lt 60 ] || [ "$INTERVAL" -gt 86400 ]; }; then
+  printf 'fm-pr-conflict-watch: FM_PR_CONFLICT_INTERVAL must be 0 or a whole number from 60 to 86400\n' >&2
+  exit 2
+fi
+
+PROBE_SECS=${FM_PR_CONFLICT_PROBE_SECS:-5}
+case "$PROBE_SECS" in
+  ''|*[!0-9]*|0)
+    printf 'fm-pr-conflict-watch: FM_PR_CONFLICT_PROBE_SECS must be a whole number from 1 to 30\n' >&2
+    exit 2
+    ;;
+esac
+if [ "$PROBE_SECS" -gt 30 ]; then
+  printf 'fm-pr-conflict-watch: FM_PR_CONFLICT_PROBE_SECS must be a whole number from 1 to 30\n' >&2
+  exit 2
+fi
+
+BUDGET_SECS=${FM_PR_CONFLICT_BUDGET_SECS:-20}
+case "$BUDGET_SECS" in
+  ''|*[!0-9]*|0)
+    printf 'fm-pr-conflict-watch: FM_PR_CONFLICT_BUDGET_SECS must be a whole number from 1 to 120\n' >&2
+    exit 2
+    ;;
+esac
+if [ "$BUDGET_SECS" -gt 120 ]; then
+  printf 'fm-pr-conflict-watch: FM_PR_CONFLICT_BUDGET_SECS must be a whole number from 1 to 120\n' >&2
+  exit 2
+fi
+
+UNKNOWN_ATTEMPTS=${FM_PR_CONFLICT_UNKNOWN_ATTEMPTS:-3}
+case "$UNKNOWN_ATTEMPTS" in
+  ''|*[!0-9]*|0)
+    printf 'fm-pr-conflict-watch: FM_PR_CONFLICT_UNKNOWN_ATTEMPTS must be a whole number from 1 to 10\n' >&2
+    exit 2
+    ;;
+esac
+if [ "$UNKNOWN_ATTEMPTS" -gt 10 ]; then
+  printf 'fm-pr-conflict-watch: FM_PR_CONFLICT_UNKNOWN_ATTEMPTS must be a whole number from 1 to 10\n' >&2
+  exit 2
+fi
+
+UNKNOWN_WAIT=${FM_PR_CONFLICT_UNKNOWN_WAIT:-1}
+case "$UNKNOWN_WAIT" in
+  ''|*[!0-9]*)
+    printf 'fm-pr-conflict-watch: FM_PR_CONFLICT_UNKNOWN_WAIT must be a whole number from 0 to 5\n' >&2
+    exit 2
+    ;;
+esac
+if [ "$UNKNOWN_WAIT" -gt 5 ]; then
+  printf 'fm-pr-conflict-watch: FM_PR_CONFLICT_UNKNOWN_WAIT must be a whole number from 0 to 5\n' >&2
+  exit 2
+fi
+
+PR_LIMIT=${FM_PR_CONFLICT_PR_LIMIT:-30}
+case "$PR_LIMIT" in
+  ''|*[!0-9]*|0)
+    printf 'fm-pr-conflict-watch: FM_PR_CONFLICT_PR_LIMIT must be a whole number from 1 to 100\n' >&2
+    exit 2
+    ;;
+esac
+if [ "$PR_LIMIT" -gt 100 ]; then
+  printf 'fm-pr-conflict-watch: FM_PR_CONFLICT_PR_LIMIT must be a whole number from 1 to 100\n' >&2
+  exit 2
+fi
+
+PROBE_MIN_SECS=1
+CLOCK_ROUNDING_SECS=1
+KILL_GRACE_SECS=1
+
+CHECK_TIMEOUT=${FM_CHECK_TIMEOUT:-30}
+case "$CHECK_TIMEOUT" in
+  ''|*[!0-9]*|0) CHECK_TIMEOUT=30 ;;
+esac
+BUDGET_MAX=$((CHECK_TIMEOUT - PROBE_MIN_SECS - CLOCK_ROUNDING_SECS - KILL_GRACE_SECS))
+[ "$BUDGET_MAX" -ge 1 ] || BUDGET_MAX=1
+BUDGET_CUT_FROM=
+if [ "$BUDGET_SECS" -gt "$BUDGET_MAX" ]; then
+  BUDGET_CUT_FROM=$BUDGET_SECS
+  BUDGET_SECS=$BUDGET_MAX
+fi
+
+record_epoch_now() {
+  case "${FM_PR_CONFLICT_NOW:-}" in
+    ''|*[!0-9]*) date +%s ;;
+    *) printf '%s\n' "$FM_PR_CONFLICT_NOW" ;;
+  esac
+}
+
+real_epoch() { date +%s; }
+
+DEADLINE=0
+REPORTED_KEYS=
+RECORD_EPOCH=0
+FINDINGS=
+
+emit_finding() {
+  local text
+  text=$(printf '%s' "$1" | tr '\t\r\n' '   ')
+  if [ -z "$FINDINGS" ]; then
+    FINDINGS=$text
+  else
+    FINDINGS="$FINDINGS; $text"
+  fi
+}
+
+budget_exhausted() {
+  [ "$(real_epoch)" -ge "$DEADLINE" ]
+}
+
+probe_bound() {
+  local left
+  left=$((DEADLINE - $(real_epoch)))
+  if [ "$left" -lt "$PROBE_MIN_SECS" ]; then
+    printf '%s\n' "$PROBE_MIN_SECS"
+  elif [ "$left" -lt "$PROBE_SECS" ]; then
+    printf '%s\n' "$left"
+  else
+    printf '%s\n' "$PROBE_SECS"
+  fi
+}
+
+gh_bounded() {
+  fm_run_timed "$(probe_bound)" env GH_PROMPT_DISABLED=1 GH_NO_UPDATE_NOTIFIER=1 "$GH_AXI" "$@"
+}
+
+repo_slug() {
+  printf '%s' "$1" | sed -n 's#.*github\.com[:/]\([^/]*/[^/]*\)#\1#p' | sed 's#\.git$##; s#/pull/.*$##; s#/$##'
+}
+
+firstmate_repo_slug() {
+  local url
+  url=$(git -C "$FM_ROOT" remote get-url origin 2>/dev/null) || return 1
+  repo_slug "$url"
+}
+
+project_names() {
+  [ -f "$DATA/projects.md" ] || return 0
+  awk '$1 == "-" && $2 != "" { print $2 }' "$DATA/projects.md"
+}
+
+resolve_project_repo() {
+  local project=$1 dir url slug
+  dir="$PROJECTS/$project"
+  [ -d "$dir" ] || return 1
+  url=$(git -C "$dir" remote get-url origin 2>/dev/null) || return 1
+  slug=$(repo_slug "$url")
+  [ -n "$slug" ] || return 1
+  printf '%s\n' "$slug"
+}
+
+discover_repos() {
+  local project slug repos='' fm_slug
+  while IFS= read -r project; do
+    [ -n "$project" ] || continue
+    slug=$(resolve_project_repo "$project" 2>/dev/null) || continue
+    case " $repos " in
+      *" $slug "*) ;;
+      *) repos="$repos $slug" ;;
+    esac
+  done < <(project_names)
+  fm_slug=$(firstmate_repo_slug 2>/dev/null) || fm_slug=
+  if [ -n "$fm_slug" ]; then
+    case " $repos " in
+      *" $fm_slug "*) ;;
+      *) repos="$repos $fm_slug" ;;
+    esac
+  fi
+  for slug in $repos; do
+    [ -n "$slug" ] || continue
+    printf '%s\n' "$slug"
+  done
+}
+
+trim_field() {
+  local value=$1
+  value=${value#"${value%%[![:space:]]*}"}
+  value=${value%"${value##*[![:space:]]}"}
+  printf '%s\n' "$value"
+}
+
+owner_for_project() {
+  local project=$1 reg line id projects part
+  reg="$DATA/secondmates.md"
+  [ -f "$reg" ] || return 1
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+      "- "*)
+        secondmate_registry_parse_line "$line" || continue
+        id=$SECONDMATE_REGISTRY_ID
+        projects=$SECONDMATE_REGISTRY_PROJECTS
+        IFS=',' read -r -a _parts <<< "$projects"
+        for part in "${_parts[@]}"; do
+          part=$(trim_field "$part")
+          [ "$part" = "$project" ] || continue
+          printf '%s\n' "$id"
+          return 0
+        done
+        ;;
+    esac
+  done < "$reg"
+  return 1
+}
+
+owner_for_repo() {
+  local repo=$1 project slug owner fm_slug
+  fm_slug=$(firstmate_repo_slug 2>/dev/null) || fm_slug=
+  if [ -n "$fm_slug" ] && [ "$repo" = "$fm_slug" ]; then
+    printf '%s\n' "$MAIN_OWNER"
+    return 0
+  fi
+  while IFS= read -r project; do
+    [ -n "$project" ] || continue
+    slug=$(resolve_project_repo "$project" 2>/dev/null) || continue
+    [ "$slug" = "$repo" ] || continue
+    owner=$(owner_for_project "$project" 2>/dev/null) || owner=
+    if [ -n "$owner" ]; then
+      printf '%s\n' "$owner"
+    else
+      printf '%s\n' "$MAIN_OWNER"
+    fi
+    return 0
+  done < <(project_names)
+  printf '%s\n' "$MAIN_OWNER"
+}
+
+conflict_key() {
+  local repo=$1 number=$2 head=$3
+  printf '%s#%s#%s' "$repo" "$number" "$head"
+}
+
+record_read() {
+  local line first=1
+  RECORD_EPOCH=0
+  REPORTED_KEYS=
+  [ -f "$RECORD" ] || return 0
+  while IFS= read -r line; do
+    if [ "$first" = 1 ]; then
+      first=0
+      [ "$line" = "$RECORD_SCHEMA" ] || return 0
+      continue
+    fi
+    case "$line" in
+      epoch=*)
+        line=${line#epoch=}
+        case "$line" in
+          ''|*[!0-9]*) RECORD_EPOCH=0 ;;
+          *) RECORD_EPOCH=$line ;;
+        esac
+        ;;
+      reported=*) REPORTED_KEYS=${line#reported=} ;;
+    esac
+  done < "$RECORD"
+}
+
+record_write() {
+  local reported=$1 tmp
+  tmp=$(mktemp "$RECORD.XXXXXX" 2>/dev/null) || return 1
+  chmod 0600 "$tmp" 2>/dev/null || { rm -f -- "$tmp"; return 1; }
+  {
+    printf '%s\n' "$RECORD_SCHEMA"
+    printf 'epoch=%s\n' "$(record_epoch_now)"
+    printf 'reported=%s\n' "$reported"
+  } > "$tmp" || { rm -f -- "$tmp"; return 1; }
+  mv -f -- "$tmp" "$RECORD" || { rm -f -- "$tmp"; return 1; }
+}
+
+record_has_key() {
+  local key=$1
+  case ";$REPORTED_KEYS;" in
+    *";$key;"*) return 0 ;;
+  esac
+  return 1
+}
+
+record_add_key() {
+  local key=$1
+  record_has_key "$key" && return 0
+  if [ -z "$REPORTED_KEYS" ]; then
+    REPORTED_KEYS=$key
+  else
+    REPORTED_KEYS="$REPORTED_KEYS;$key"
+  fi
+}
+
+record_remove_key() {
+  local key=$1 out='' part
+  IFS=';' read -r -a _parts <<< "$REPORTED_KEYS"
+  for part in "${_parts[@]}"; do
+    [ -n "$part" ] || continue
+    [ "$part" = "$key" ] && continue
+    if [ -z "$out" ]; then
+      out=$part
+    else
+      out="$out;$part"
+    fi
+  done
+  REPORTED_KEYS=$out
+}
+
+json_field() {
+  local json=$1 query=$2
+  command -v jq >/dev/null 2>&1 || return 1
+  printf '%s' "$json" | jq -er "$query" 2>/dev/null
+}
+
+pr_mergeable_resolved() {
+  local repo=$1 number=$2 mergeable='' attempt=0 json
+  while :; do
+    json=$(gh_bounded pr view "$number" --repo "$repo" \
+      --json mergeable,mergeStateStatus,number,title,url,headRefOid,isDraft 2>/dev/null) || return 2
+    mergeable=$(json_field "$json" '.mergeable // "UNKNOWN"') || return 2
+    case "$mergeable" in
+      MERGEABLE) printf 'clean\n'; return 0 ;;
+      CONFLICTING) printf 'conflicted\n'; return 0 ;;
+      UNKNOWN)
+        attempt=$((attempt + 1))
+        if [ "$attempt" -ge "$UNKNOWN_ATTEMPTS" ]; then
+          printf 'unknown\n'
+          return 0
+        fi
+        [ "$UNKNOWN_WAIT" -eq 0 ] || sleep "$UNKNOWN_WAIT"
+        ;;
+      *) printf 'unknown\n'; return 0 ;;
+    esac
+  done
+}
+
+format_finding() {
+  local owner_team=$1 repo=$2 number=$3 head=$4 draft=$5 url=$6 title=$7
+  local draft_label=no
+  [ "$draft" = true ] && draft_label=yes
+  title=$(printf '%s' "$title" | tr '\t\r\n' '   ')
+  printf 'owner-team=%s repo=%s number=%s head=%s draft=%s url=%s title=%s' \
+    "$owner_team" "$repo" "$number" "$head" "$draft_label" "$url" "$title"
+}
+
+evaluate_repo() {
+  local repo=$1 owner_team=$2 json count i row number title head draft url mergeable key resolved
+  budget_exhausted && return 1
+  json=$(gh_bounded pr list --repo "$repo" --state open --limit "$PR_LIMIT" \
+    --json number,title,url,headRefOid,isDraft,mergeable 2>/dev/null) || return 0
+  [ -n "$json" ] || json='[]'
+  count=$(json_field "$json" 'length' 2>/dev/null) || return 0
+  i=0
+  while [ "$i" -lt "$count" ]; do
+    budget_exhausted && return 1
+    row=$(json_field "$json" ".[$i]" 2>/dev/null) || { i=$((i + 1)); continue; }
+    number=$(json_field "$row" '.number') || { i=$((i + 1)); continue; }
+    title=$(json_field "$row" '.title // ""') || title=
+    url=$(json_field "$row" '.url // ""') || url=
+    head=$(json_field "$row" '.headRefOid // ""') || head=
+    draft=$(json_field "$row" '.isDraft // false') || draft=false
+    mergeable=$(json_field "$row" '.mergeable // "UNKNOWN"') || mergeable=UNKNOWN
+    i=$((i + 1))
+    [ -n "$head" ] || continue
+    key=$(conflict_key "$repo" "$number" "$head")
+    case "$mergeable" in
+      MERGEABLE)
+        record_remove_key "$key"
+        continue
+        ;;
+      CONFLICTING) ;;
+      UNKNOWN)
+        resolved=$(pr_mergeable_resolved "$repo" "$number") || continue
+        case "$resolved" in
+          conflicted) ;;
+          clean)
+            record_remove_key "$key"
+            continue
+            ;;
+          *) continue ;;
+        esac
+        ;;
+      *) continue ;;
+    esac
+    record_has_key "$key" && continue
+    emit_finding "$(format_finding "$owner_team" "$repo" "$number" "$head" "$draft" "$url" "$title")"
+    record_add_key "$key"
+  done
+  return 0
+}
+
+action_check() {
+  local repo owner_team line now
+  if ! command -v jq >/dev/null 2>&1; then
+    return 0
+  fi
+  if ! command -v "$GH_AXI" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  record_read
+  now=$(record_epoch_now)
+  if [ "$INTERVAL" -ne 0 ] && [ "$RECORD_EPOCH" -gt 0 ] \
+    && [ "$now" -ge "$RECORD_EPOCH" ] && [ $((now - RECORD_EPOCH)) -lt "$INTERVAL" ]; then
+    return 0
+  fi
+
+  DEADLINE=$(($(real_epoch) + BUDGET_SECS))
+
+  if [ -n "$BUDGET_CUT_FROM" ]; then
+    emit_finding "sweep budget ${BUDGET_CUT_FROM}s cut to ${BUDGET_SECS}s to stay inside the watcher check timeout of ${CHECK_TIMEOUT}s"
+  fi
+
+  while IFS= read -r repo; do
+    [ -n "$repo" ] || continue
+    budget_exhausted && break
+    owner_team=$(owner_for_repo "$repo")
+    evaluate_repo "$repo" "$owner_team" || break
+  done < <(discover_repos)
+
+  line=
+  if [ -n "$FINDINGS" ]; then
+    fm_cap_line_var "pr-conflict: $FINDINGS" "$MAX_LINE"
+    line=$FM_LINE_CAP_LINE
+  fi
+
+  if [ -n "$line" ]; then
+    printf '%s\n' "$line"
+  fi
+  record_write "$REPORTED_KEYS" || true
+  return 0
+}
+
+shim_content() {
+  local home=$1
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    '# Auto-generated by fm-pr-conflict-watch.sh - PR merge conflict poll shim.' \
+    '# The watcher validates these bytes, then dispatches the trusted check script.' \
+    "export FM_HOME=$(printf '%q' "$home")" \
+    "exec $(printf '%q' "$SCRIPT_DIR/fm-pr-conflict-watch.sh") check"
+}
+
+SHIM_WRITE_TMP=
+
+shim_write() {
+  local want=$1 device tmp
+  [ -d "$STATE" ] && [ ! -L "$STATE" ] || return 1
+  device=$(fm_pr_file_device "$STATE") || return 1
+  [ -n "$device" ] || return 1
+  fm_pr_regular_destination_on_device_or_absent "$CHECK_SHIM" "$device" || return 1
+  if [ -e "$CHECK_SHIM" ] && [ "$(fm_pr_file_mode "$CHECK_SHIM")" = 700 ] \
+    && [ "$(cat "$CHECK_SHIM" 2>/dev/null)" = "$want" ]; then
+    return 0
+  fi
+  tmp=$(umask 077; mktemp "$STATE/.fm-pr-conflict-watch-check.XXXXXX" 2>/dev/null) || return 1
+  SHIM_WRITE_TMP=$tmp
+  if ! printf '%s\n' "$want" > "$tmp" \
+    || ! chmod 0700 "$tmp" \
+    || ! fm_pr_private_file_valid "$tmp" 700 "$device"; then
+    rm -f -- "$tmp"
+    SHIM_WRITE_TMP=
+    return 1
+  fi
+  if ! fm_pr_regular_destination_on_device_or_absent "$CHECK_SHIM" "$device" \
+    || ! mv -f -- "$tmp" "$CHECK_SHIM"; then
+    rm -f -- "$tmp"
+    SHIM_WRITE_TMP=
+    return 1
+  fi
+  SHIM_WRITE_TMP=
+  fm_pr_private_file_valid "$CHECK_SHIM" 700 "$device"
+}
+
+shim_backup() {
+  local device tmp
+  device=$(fm_pr_file_device "$STATE") || return 1
+  [ -n "$device" ] || return 1
+  tmp=$(umask 077; mktemp "$STATE/.fm-pr-conflict-watch-check.XXXXXX" 2>/dev/null) || return 1
+  if ! cat "$CHECK_SHIM" > "$tmp" 2>/dev/null \
+    || ! chmod 0700 "$tmp" \
+    || ! fm_pr_private_file_valid "$tmp" 700 "$device"; then
+    rm -f -- "$tmp"
+    return 1
+  fi
+  printf '%s\n' "$tmp"
+}
+
+ARM_BACKUP=
+
+arm_rollback() {
+  [ -z "$SHIM_WRITE_TMP" ] || rm -f -- "$SHIM_WRITE_TMP"
+  SHIM_WRITE_TMP=
+  if [ -n "$ARM_BACKUP" ]; then
+    mv -f -- "$ARM_BACKUP" "$CHECK_SHIM" 2>/dev/null || rm -f -- "$ARM_BACKUP"
+    ARM_BACKUP=
+    if fm_custom_check_registered "$STATE" "$CHECK_ID"; then
+      return 0
+    fi
+  fi
+  rm -f -- "$CHECK_SHIM"
+}
+
+arm_interrupted() {
+  arm_rollback
+  printf 'fm-pr-conflict-watch: arming was interrupted, so state/%s.check.sh is not armed\n' "$CHECK_ID" >&2
+  exit 1
+}
+
+action_arm() {
+  local want home
+  if ! command -v jq >/dev/null 2>&1; then
+    printf 'fm-pr-conflict-watch: jq is required\n' >&2
+    return 1
+  fi
+  if ! command -v "$GH_AXI" >/dev/null 2>&1; then
+    printf 'fm-pr-conflict-watch: %s is required\n' "$GH_AXI" >&2
+    return 1
+  fi
+  mkdir -p "$STATE" || return 1
+  case "$FM_HOME" in
+    /*) home=$FM_HOME ;;
+    *)
+      home=$(CDPATH='' cd -- "$FM_HOME" 2>/dev/null && pwd -P) || {
+        printf 'fm-pr-conflict-watch: cannot resolve FM_HOME %s\n' "$FM_HOME" >&2
+        return 1
+      }
+      ;;
+  esac
+  want=$(shim_content "$home")
+  ARM_BACKUP=
+  if [ -f "$CHECK_SHIM" ] && [ ! -L "$CHECK_SHIM" ]; then
+    ARM_BACKUP=$(shim_backup) || {
+      printf 'fm-pr-conflict-watch: could not save the existing %s\n' "$CHECK_SHIM" >&2
+      return 1
+    }
+  fi
+  trap arm_interrupted HUP INT TERM
+  if ! shim_write "$want"; then
+    trap - HUP INT TERM
+    arm_rollback
+    printf 'fm-pr-conflict-watch: could not write %s\n' "$CHECK_SHIM" >&2
+    return 1
+  fi
+  if ! FM_HOME="$home" "$REGISTER_BIN" "$CHECK_ID" >/dev/null; then
+    trap - HUP INT TERM
+    arm_rollback
+    printf 'fm-pr-conflict-watch: could not register %s\n' "$CHECK_SHIM" >&2
+    return 1
+  fi
+  trap - HUP INT TERM
+  [ -z "$ARM_BACKUP" ] || rm -f -- "$ARM_BACKUP"
+  ARM_BACKUP=
+  printf 'armed: state/%s.check.sh\n' "$CHECK_ID"
+  return 0
+}
+
+action_disarm() {
+  rm -f -- "$CHECK_SHIM" "$CHECK_TRUST" "$RECORD"
+  printf 'disarmed: state/%s.check.sh\n' "$CHECK_ID"
+  return 0
+}
+
+case "${1:-check}" in
+  check) action_check ;;
+  arm) action_arm ;;
+  disarm) action_disarm ;;
+  -h|--help) usage ;;
+  *) die_usage "unknown action: $1" ;;
+esac

--- a/bin/fm-pr-conflict-watch.sh
+++ b/bin/fm-pr-conflict-watch.sh
@@ -291,8 +291,11 @@ firstmate_repo_slug() {
   fm_repo_slug "$url"
 }
 
+# A registry that cannot be read enumerates nothing, which reads exactly like a
+# home that registered no projects. The difference matters to record pruning, so
+# the unreadable case is reported as a failure rather than as an empty list.
 project_names() {
-  [ -f "$DATA/projects.md" ] || return 0
+  [ -r "$DATA/projects.md" ] || return 1
   awk '$1 == "-" && $2 != "" { print $2 }' "$DATA/projects.md"
 }
 
@@ -364,13 +367,16 @@ owner_for_project() {
 # neither the origin remotes nor the registry are re-read per repository while
 # the same budget is paying for GitHub probes.
 discover_repos() {
-  local project slug owner
+  local project slug owner names
   DISCOVERED_REPOS=
   REPO_OWNER_MAP=
   DISCOVERY_COMPLETE=1
   load_project_owners
   FIRSTMATE_SLUG=$(firstmate_repo_slug 2>/dev/null) || FIRSTMATE_SLUG=
   [ -n "$FIRSTMATE_SLUG" ] || DISCOVERY_COMPLETE=0
+  # An unread registry leaves every project repository unnamed, so the firstmate
+  # origin still resolving does not make this discovery complete.
+  names=$(project_names 2>/dev/null) || { names=; DISCOVERY_COMPLETE=0; }
   while IFS= read -r project; do
     [ -n "$project" ] || continue
     # A project whose clone or origin cannot be read names no slug, so the sweep
@@ -389,7 +395,9 @@ discover_repos() {
     DISCOVERED_REPOS="$DISCOVERED_REPOS $slug"
     REPO_OWNER_MAP="$REPO_OWNER_MAP$slug $owner
 "
-  done < <(project_names)
+  done <<EOF
+$names
+EOF
   if [ -n "$FIRSTMATE_SLUG" ]; then
     case " $DISCOVERED_REPOS " in
       *" $FIRSTMATE_SLUG "*) ;;
@@ -490,12 +498,13 @@ record_remove_key() {
 # that page carried; a repository the sweep did not finish keeps all of its
 # keys, because absence there means unread rather than resolved. Keys for
 # repositories this fleet no longer works in are dropped only when discovery
-# resolved every project it enumerated and the sweep then reached every
-# repository discovery named. A discovery that skipped a project whose clone or
-# origin could not be read - including the degenerate case where it resolved
-# nothing at all - left behind an unread repository it cannot even name, so
-# absence from its repository set is a failed read rather than proof the fleet
-# stopped working in those repositories.
+# read the project registry, resolved every project it enumerated, and the sweep
+# then reached every repository discovery named. A discovery that could not read
+# the registry, or that skipped a project whose clone or origin could not be
+# read - including the degenerate case where it resolved nothing at all - left
+# behind an unread repository it cannot even name, so absence from its
+# repository set is a failed read rather than proof the fleet stopped working in
+# those repositories.
 seen_key() {
   local key=$1
   case ";$SEEN_KEYS;" in

--- a/bin/fm-repo-slug-lib.sh
+++ b/bin/fm-repo-slug-lib.sh
@@ -1,0 +1,19 @@
+# shellcheck shell=bash
+# Shared GitHub owner/repo parser.
+# Usage: . bin/fm-repo-slug-lib.sh; fm_repo_slug "<url>"
+#
+# ONE OWNER for turning a GitHub remote or PR URL into its owner/repo slug.
+# Two callers need the same answer from the same inputs: the bearings snapshot
+# derives candidate repositories from recorded pr= URLs and live worktree
+# origins (bin/fm-bearings-snapshot.sh), and the PR conflict watcher derives
+# them from project clone origins (bin/fm-pr-conflict-watch.sh). A repository
+# that one of them names differently than the other would route the same pull
+# request two ways, so the parse lives here rather than in each caller.
+#
+# Both the https and ssh spellings are accepted, a trailing .git, a trailing
+# slash, and a /pull/<n> tail are dropped, and a URL that is not GitHub yields
+# the empty string rather than a guess.
+
+fm_repo_slug() {  # <url>
+  printf '%s' "$1" | sed -n 's#.*github\.com[:/]\([^/]*/[^/]*\)#\1#p' | sed 's#\.git$##; s#/pull/.*$##; s#/$##'
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -426,13 +426,13 @@ It is detection and routing only: it never resolves conflicts, rebases branches,
 
 Repositories are derived from `data/projects.md` by reading each registered project's clone under `projects/` and parsing its `origin` remote into an `owner/repo` slug.
 The firstmate checkout's own `origin` remote is included too, so the captain's firstmate fork is covered without hardcoding its name.
-Owning targets come from `data/secondmates.md`: each secondmate's `projects:` list maps registered project names to that secondmate's id, and the firstmate repository maps to `main`.
-Unmapped projects fall back to `main`.
+The `owner-team` a wake is routed to comes from `data/secondmates.md`: a registered project named in a secondmate's `projects:` list routes to that secondmate's id, the firstmate repository routes to `main`, and anything unmapped falls back to `main`.
+That list stays the non-exclusive clone list the [`secondmate-provisioning` skill](../.agents/skills/secondmate-provisioning/SKILL.md#routing-table) defines; it decides where a conflict wake is delivered first, not who exclusively owns the work.
 
 Arm once per home with `bin/fm-pr-conflict-watch.sh arm`.
 That writes `state/pr-conflict-watch.check.sh` and binds its bytes with `bin/fm-check-register.sh`, so the watcher polls on its normal cadence and turns a newly conflicted pull request into one `check:` wake line.
 `bin/fm-pr-conflict-watch.sh disarm` removes the shim, trust binding, and dedupe record.
-The check prints nothing when no new conflict exists.
+The check prints nothing when no new conflict exists, apart from the cut-budget disclosure described below.
 Draft pull requests are included; a conflicted draft is reported with `draft=yes`.
 
 Each wake line begins with `pr-conflict:` and carries `owner-team`, `repo`, `number`, `head`, `draft`, `url`, and `title` so firstmate can route without re-deriving ownership.
@@ -441,13 +441,18 @@ GitHub computes mergeability lazily; the check polls short rereads when `mergeab
 A reread that settles the state also names the head it settled for, so a branch force-updated between the listing and the reread is reported and deduped under the SHA that was actually judged.
 A sweep that finds more conflicts than one line can carry reports the ones that fit and discloses the rest as `N more omitted (line cap)`; an omitted conflict is not marked as reported, so it wakes on a later sweep instead of being lost.
 The dedupe record is cut back to the conflicts each sweep still observes, so it stays the size of the live conflict set rather than growing one entry per head forever.
+A repository the sweep never reached, or whose open list was cut short by `FM_PR_CONFLICT_PR_LIMIT`, keeps its recorded keys instead: unread is not the same as resolved, and dropping those keys would re-report every one of them.
 
 This is a safety net, not a cure: conflicts happen because pull requests wait unmerged while the default branch moves underneath them.
+Silence is not a proof that every repository was checked, either.
+A sweep that runs out of budget stops where it is and says nothing about the repositories it did not reach, and the sweep order is fixed, so a fleet too large for one budget leaves the same tail of repositories unswept on every poll.
+Raise `FM_PR_CONFLICT_BUDGET_SECS` with `FM_CHECK_TIMEOUT` when the fleet outgrows one sweep.
 
 `FM_PR_CONFLICT_INTERVAL` (default 300 seconds, `0` to probe on every run) sets how often sweeps run, `FM_PR_CONFLICT_PROBE_SECS` (default 5) bounds one GitHub call, and `FM_PR_CONFLICT_BUDGET_SECS` (default 20) bounds a whole sweep.
 `FM_PR_CONFLICT_UNKNOWN_ATTEMPTS` (default 3) and `FM_PR_CONFLICT_UNKNOWN_WAIT` (default 1 second) control lazy mergeability polling.
 `FM_PR_CONFLICT_PR_LIMIT` (default 30) caps open pull requests read per repository.
 The sweep must finish inside `FM_CHECK_TIMEOUT` (default 30); a larger budget is cut to fit rather than refused, and the `UNKNOWN` reread loop stops at the sweep deadline too, because a run the watcher kills prints and records nothing at all.
+A cut budget is disclosed at the head of the line, and it is the one thing this check reports without a conflict behind it; because it describes a setting rather than an event, it repeats on every sweep until the two settings agree.
 
 ## Relay (.env)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -442,7 +442,7 @@ A reread that settles the state also names the head it settled for, so a branch 
 A sweep that finds more conflicts than one line can carry reports the ones that fit and discloses the rest as `N more omitted (line cap)`; an omitted conflict is not marked as reported, so it wakes on a later sweep instead of being lost.
 The dedupe record is cut back to the conflicts each sweep still observes, so it stays the size of the live conflict set rather than growing one entry per head forever.
 A repository the sweep never reached, or whose open list was cut short by `FM_PR_CONFLICT_PR_LIMIT`, keeps its recorded keys instead: unread is not the same as resolved, and dropping those keys would re-report every one of them.
-A sweep whose repository discovery was incomplete keeps the whole record for the same reason: a registered project whose clone or `origin` remote could not be read this sweep names no repository at all, so the repositories discovery did name are not the full set this home works in.
+A sweep whose repository discovery was incomplete keeps the whole record for the same reason: an unreadable `data/projects.md`, or a registered project whose clone or `origin` remote could not be read this sweep, names no repository at all, so the repositories discovery did name are not the full set this home works in.
 That covers the degenerate case where discovery reads nothing as well as the partial case where it reads some clones and fails on others.
 
 This is a safety net, not a cure: conflicts happen because pull requests wait unmerged while the default branch moves underneath them.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -442,7 +442,8 @@ A reread that settles the state also names the head it settled for, so a branch 
 A sweep that finds more conflicts than one line can carry reports the ones that fit and discloses the rest as `N more omitted (line cap)`; an omitted conflict is not marked as reported, so it wakes on a later sweep instead of being lost.
 The dedupe record is cut back to the conflicts each sweep still observes, so it stays the size of the live conflict set rather than growing one entry per head forever.
 A repository the sweep never reached, or whose open list was cut short by `FM_PR_CONFLICT_PR_LIMIT`, keeps its recorded keys instead: unread is not the same as resolved, and dropping those keys would re-report every one of them.
-A sweep that discovers no repositories at all keeps the whole record for the same reason: an empty repository set means discovery failed to read anything, not that this home stopped working in those repositories.
+A sweep whose repository discovery was incomplete keeps the whole record for the same reason: a registered project whose clone or `origin` remote could not be read this sweep names no repository at all, so the repositories discovery did name are not the full set this home works in.
+That covers the degenerate case where discovery reads nothing as well as the partial case where it reads some clones and fails on others.
 
 This is a safety net, not a cure: conflicts happen because pull requests wait unmerged while the default branch moves underneath them.
 Silence is not a proof that every repository was checked, either.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -419,6 +419,33 @@ The sweep must finish inside `FM_CHECK_TIMEOUT` (default 30), because a run the 
 So a budget larger than that timeout allows is cut down to what fits instead of being refused, and the cut is reported in the report line.
 A budget that is not a whole number from 1 to 120 is still refused outright.
 
+## PR merge conflict watch
+
+`bin/fm-pr-conflict-watch.sh` polls open GitHub pull requests for merge conflicts across the repositories this home works in.
+It is detection and routing only: it never resolves conflicts, rebases branches, or calls GitHub's update-branch API.
+
+Repositories are derived from `data/projects.md` by reading each registered project's clone under `projects/` and parsing its `origin` remote into an `owner/repo` slug.
+The firstmate checkout's own `origin` remote is included too, so the captain's firstmate fork is covered without hardcoding its name.
+Owning targets come from `data/secondmates.md`: each secondmate's `projects:` list maps registered project names to that secondmate's id, and the firstmate repository maps to `main`.
+Unmapped projects fall back to `main`.
+
+Arm once per home with `bin/fm-pr-conflict-watch.sh arm`.
+That writes `state/pr-conflict-watch.check.sh` and binds its bytes with `bin/fm-check-register.sh`, so the watcher polls on its normal cadence and turns a newly conflicted pull request into one `check:` wake line.
+`bin/fm-pr-conflict-watch.sh disarm` removes the shim, trust binding, and dedupe record.
+The check prints nothing when no new conflict exists.
+Draft pull requests are included; a conflicted draft is reported with `draft=yes`.
+
+Each wake line begins with `pr-conflict:` and carries `owner-team`, `repo`, `number`, `head`, `draft`, `url`, and `title` so firstmate can route without re-deriving ownership.
+Dedupe keys are repository, pull request number, and head SHA: the same conflict on the same head is reported once, while a force-updated head that conflicts again is a new event.
+GitHub computes mergeability lazily; the check polls short rereads when `mergeable` is `UNKNOWN` and treats a persistent `UNKNOWN` as unknown rather than clean or conflicted.
+
+This is a safety net, not a cure: conflicts happen because pull requests wait unmerged while the default branch moves underneath them.
+
+`FM_PR_CONFLICT_INTERVAL` (default 300 seconds, `0` to probe on every run) sets how often sweeps run, `FM_PR_CONFLICT_PROBE_SECS` (default 5) bounds one GitHub call, and `FM_PR_CONFLICT_BUDGET_SECS` (default 20) bounds a whole sweep.
+`FM_PR_CONFLICT_UNKNOWN_ATTEMPTS` (default 3) and `FM_PR_CONFLICT_UNKNOWN_WAIT` (default 1 second) control lazy mergeability polling.
+`FM_PR_CONFLICT_PR_LIMIT` (default 30) caps open pull requests read per repository.
+The sweep must finish inside `FM_CHECK_TIMEOUT` (default 30); a larger budget is cut to fit rather than refused.
+
 ## Relay (.env)
 
 Relay lets a firstmate instance answer public mentions and act on normal reversible mention requests through firstmate's normal lifecycle.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -442,6 +442,7 @@ A reread that settles the state also names the head it settled for, so a branch 
 A sweep that finds more conflicts than one line can carry reports the ones that fit and discloses the rest as `N more omitted (line cap)`; an omitted conflict is not marked as reported, so it wakes on a later sweep instead of being lost.
 The dedupe record is cut back to the conflicts each sweep still observes, so it stays the size of the live conflict set rather than growing one entry per head forever.
 A repository the sweep never reached, or whose open list was cut short by `FM_PR_CONFLICT_PR_LIMIT`, keeps its recorded keys instead: unread is not the same as resolved, and dropping those keys would re-report every one of them.
+A sweep that discovers no repositories at all keeps the whole record for the same reason: an empty repository set means discovery failed to read anything, not that this home stopped working in those repositories.
 
 This is a safety net, not a cure: conflicts happen because pull requests wait unmerged while the default branch moves underneath them.
 Silence is not a proof that every repository was checked, either.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -438,13 +438,16 @@ Draft pull requests are included; a conflicted draft is reported with `draft=yes
 Each wake line begins with `pr-conflict:` and carries `owner-team`, `repo`, `number`, `head`, `draft`, `url`, and `title` so firstmate can route without re-deriving ownership.
 Dedupe keys are repository, pull request number, and head SHA: the same conflict on the same head is reported once, while a force-updated head that conflicts again is a new event.
 GitHub computes mergeability lazily; the check polls short rereads when `mergeable` is `UNKNOWN` and treats a persistent `UNKNOWN` as unknown rather than clean or conflicted.
+A reread that settles the state also names the head it settled for, so a branch force-updated between the listing and the reread is reported and deduped under the SHA that was actually judged.
+A sweep that finds more conflicts than one line can carry reports the ones that fit and discloses the rest as `N more omitted (line cap)`; an omitted conflict is not marked as reported, so it wakes on a later sweep instead of being lost.
+The dedupe record is cut back to the conflicts each sweep still observes, so it stays the size of the live conflict set rather than growing one entry per head forever.
 
 This is a safety net, not a cure: conflicts happen because pull requests wait unmerged while the default branch moves underneath them.
 
 `FM_PR_CONFLICT_INTERVAL` (default 300 seconds, `0` to probe on every run) sets how often sweeps run, `FM_PR_CONFLICT_PROBE_SECS` (default 5) bounds one GitHub call, and `FM_PR_CONFLICT_BUDGET_SECS` (default 20) bounds a whole sweep.
 `FM_PR_CONFLICT_UNKNOWN_ATTEMPTS` (default 3) and `FM_PR_CONFLICT_UNKNOWN_WAIT` (default 1 second) control lazy mergeability polling.
 `FM_PR_CONFLICT_PR_LIMIT` (default 30) caps open pull requests read per repository.
-The sweep must finish inside `FM_CHECK_TIMEOUT` (default 30); a larger budget is cut to fit rather than refused.
+The sweep must finish inside `FM_CHECK_TIMEOUT` (default 30); a larger budget is cut to fit rather than refused, and the `UNKNOWN` reread loop stops at the sweep deadline too, because a run the watcher kills prints and records nothing at all.
 
 ## Relay (.env)
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -84,6 +84,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-nm-run-lib.sh`       | Shared branch-and-code-identity attribution for no-mistakes runs                    |
 | `fm-tangle-lib.sh`       | Shared default-branch resolution and primary-checkout tangle classification          |
 | `fm-timeout-lib.sh`      | Single owner of hard-bounded command execution and its fallback watchdog |
+| `fm-repo-slug-lib.sh`    | Single owner of the GitHub remote/PR URL to `owner/repo` parse shared by bearings and the PR conflict watch |
 | `fm-timing-lib.sh`       | Single owner of the deferred network stage's per-step elapsed-time records, inert unless a run asks for them |
 | `fm-supervision-lib.sh`  | Shared in-flight-work-without-fresh-watcher-beacon predicate                         |
 | `fm-ff-lib.sh`           | Shared guarded fast-forward helper for origin pulls and local secondmate syncs       |
@@ -109,6 +110,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-check-register.sh`   | Bind an intentional custom watcher check to its current bytes                       |
 | `fm-check-lib.sh`        | Validate custom-check registrations and prepare private execution snapshots          |
 | `fm-tool-update-check.sh` | Report watched tooling with an update available, and updates installed but left inert by PATH order |
+| `fm-pr-conflict-watch.sh` | Report newly conflicted open pull requests across the fleet's repositories, routed to their owning target |
 | `fm-pr-lib.sh`           | Own canonical task and PR validation plus private atomic PR-poll publication and identity-bound retirement |
 | `fm-pr-poll.sh`          | Provide the byte-static watcher program for validated PR/MR-poll sidecars           |
 | `fm-pr-check-migrate.sh` | Quarantine older task polls without execution and rebuild only canonical polls       |

--- a/tests/fm-pr-conflict-watch.test.sh
+++ b/tests/fm-pr-conflict-watch.test.sh
@@ -387,6 +387,31 @@ test_partial_discovery_keeps_the_record() {
   pass "a partial discovery sweep does not erase the unread repository's record"
 }
 
+# A registry that cannot be read this sweep enumerates no projects, which is
+# indistinguishable from a home that registered none. The firstmate origin still
+# resolving does not make that a complete discovery: every project repository
+# went unread, so pruning their keys would re-wake each unchanged conflict as
+# soon as the registry returned.
+test_unreadable_registry_keeps_the_record() {
+  local home out
+  home=$(make_home discovery-registry-gone)
+  write_list "$home" "$REPO_A" "[{\"number\":7,\"title\":\"Broken A\",\"url\":\"https://github.com/$REPO_A/pull/7\",\"headRefOid\":\"$HEAD_ONE\",\"isDraft\":false,\"mergeable\":\"CONFLICTING\"}]"
+  out="$home/out.txt"
+  run_check "$home" "$out"
+  assert_contains "$(cat "$out")" "repo=$REPO_A" "first poll should wake for alpha"
+  # The project registry goes away while the firstmate checkout keeps resolving
+  # its origin, exactly as a transient unreadable data directory would leave it.
+  mv "$home/data/projects.md" "$home/data/projects.md.away"
+  : > "$out"
+  run_check "$home" "$out"
+  [ ! -s "$out" ] || fail "a sweep with no readable registry must stay silent: $(cat "$out")"
+  mv "$home/data/projects.md.away" "$home/data/projects.md"
+  : > "$out"
+  run_check "$home" "$out"
+  [ ! -s "$out" ] || fail "the unchanged alpha conflict must not wake again after the registry returns: $(cat "$out")"
+  pass "a sweep with an unreadable project registry does not erase the record"
+}
+
 # The other side of the same rule: when discovery resolved every project it
 # enumerated, a repository missing from the result is one this home genuinely
 # stopped working in, and its keys are dropped so the record stays the size of
@@ -489,6 +514,7 @@ test_conflicts_past_the_line_cap_wake_on_a_later_sweep
 test_resolved_conflicts_leave_the_record
 test_empty_discovery_keeps_the_record
 test_partial_discovery_keeps_the_record
+test_unreadable_registry_keeps_the_record
 test_deregistered_project_leaves_the_record
 test_unknown_rereads_stop_at_the_sweep_deadline
 test_clean_fleet_is_silent

--- a/tests/fm-pr-conflict-watch.test.sh
+++ b/tests/fm-pr-conflict-watch.test.sh
@@ -148,6 +148,33 @@ run_check() {
   expect_code 0 "$status" "check exit"
 }
 
+# The watcher and the bearings snapshot must name the same repository from the
+# same remote, so the shared parser they both source is exercised directly here:
+# a slug that differed between them would route one pull request two ways.
+test_repo_slug_parses_github_remotes() {
+  local got
+  # shellcheck source=bin/fm-repo-slug-lib.sh
+  # shellcheck disable=SC1091
+  . "$ROOT/bin/fm-repo-slug-lib.sh"
+  local url expected
+  while IFS='|' read -r url expected; do
+    [ -n "$url" ] || continue
+    got=$(fm_repo_slug "$url")
+    [ "$got" = "$expected" ] \
+      || fail "fm_repo_slug '$url' expected '$expected', got '$got'"
+  done <<'CASES'
+https://github.com/acme/alpha.git|acme/alpha
+https://github.com/acme/alpha|acme/alpha
+https://github.com/acme/alpha/|acme/alpha
+https://github.com/acme/alpha/pull/12|acme/alpha
+git@github.com:acme/alpha.git|acme/alpha
+ssh://git@github.com/acme/alpha.git|acme/alpha
+https://gitlab.com/acme/alpha.git|
+/home/example/projects/alpha|
+CASES
+  pass "the shared remote parser resolves GitHub slugs and refuses to guess"
+}
+
 test_newly_conflicted_wakes() {
   local home out
   home=$(make_home wake-new)
@@ -388,6 +415,7 @@ test_arm_registers_check() {
   pass "arm writes and registers the watcher check"
 }
 
+test_repo_slug_parses_github_remotes
 test_newly_conflicted_wakes
 test_same_head_stays_silent
 test_new_head_after_force_update_wakes_again

--- a/tests/fm-pr-conflict-watch.test.sh
+++ b/tests/fm-pr-conflict-watch.test.sh
@@ -310,6 +310,29 @@ test_resolved_conflicts_leave_the_record() {
   pass "keys for conflicts the sweep no longer observes leave the record"
 }
 
+# A sweep that discovers no repositories at all read nothing, so it must not be
+# taken as proof that the fleet stopped working in the repositories the record
+# names. Erasing the record there would re-wake every unchanged conflict as soon
+# as discovery recovered.
+test_empty_discovery_keeps_the_record() {
+  local home out
+  home=$(make_home discovery-outage)
+  write_list "$home" "$REPO_A" "[{\"number\":7,\"title\":\"Broken\",\"url\":\"https://github.com/$REPO_A/pull/7\",\"headRefOid\":\"$HEAD_ONE\",\"isDraft\":false,\"mergeable\":\"CONFLICTING\"}]"
+  out="$home/out.txt"
+  run_check "$home" "$out"
+  [ -s "$out" ] || fail "first poll should wake"
+  # Discovery yields nothing: no projects.md to read and no firstmate checkout
+  # to take an origin from. Both reads fail, exactly as a transient outage would.
+  : > "$out"
+  run_check "$home" "$out" env FM_DATA_OVERRIDE="$home/data-gone" \
+    FM_ROOT_OVERRIDE="$home/root-gone"
+  [ ! -s "$out" ] || fail "a sweep that discovered nothing must stay silent: $(cat "$out")"
+  : > "$out"
+  run_check "$home" "$out"
+  [ ! -s "$out" ] || fail "the unchanged conflict must not wake again after discovery recovers: $(cat "$out")"
+  pass "an empty discovery sweep does not erase the dedupe record"
+}
+
 # A run the watcher kills prints and records nothing, so the reread loop has to
 # end at the sweep deadline rather than at its attempt count.
 test_unknown_rereads_stop_at_the_sweep_deadline() {
@@ -373,6 +396,7 @@ test_unknown_resolving_to_conflicting_wakes
 test_unknown_wake_uses_the_head_the_reread_judged
 test_conflicts_past_the_line_cap_wake_on_a_later_sweep
 test_resolved_conflicts_leave_the_record
+test_empty_discovery_keeps_the_record
 test_unknown_rereads_stop_at_the_sweep_deadline
 test_clean_fleet_is_silent
 test_draft_conflicts_are_reported

--- a/tests/fm-pr-conflict-watch.test.sh
+++ b/tests/fm-pr-conflict-watch.test.sh
@@ -121,16 +121,18 @@ write_list() {
 }
 
 write_view() {
-  local home=$1 repo=$2 number=$3 json
+  local home=$1 repo=$2 number=$3 json=$4
   slug=${repo//\//__}
   printf '%s\n' "$json" > "$home/fixture/views/${slug}-${number}.json"
 }
 
+# The fake gh-axi reads a scripted view sequence by array index, so the payloads
+# are stored as one JSON array rather than as a stream of objects.
 write_view_sequence() {
   local home=$1 repo=$2 number=$3
   slug=${repo//\//__}
   shift 3
-  printf '%s\n' "$@" > "$home/fixture/views/${slug}-${number}.json"
+  printf '%s\n' "$@" | jq -s '.' > "$home/fixture/views/${slug}-${number}.json"
   printf '0\n' > "$home/fixture/views/${slug}-${number}.seq"
 }
 
@@ -201,7 +203,130 @@ test_unknown_never_reported() {
   out="$home/out.txt"
   run_check "$home" "$out" env FM_PR_CONFLICT_UNKNOWN_ATTEMPTS=3
   [ ! -s "$out" ] || fail "persistent UNKNOWN must stay silent: $(cat "$out")"
+  # The fake's cursor is how many rereads the check actually made, so a silent
+  # run that never reread is not mistaken for UNKNOWN being handled.
+  [ "$(cat "$home/fixture/views/acme__alpha-7.seq")" = 3 ] \
+    || fail "UNKNOWN should be reread up to the attempt limit, got $(cat "$home/fixture/views/acme__alpha-7.seq")"
   pass "persistent UNKNOWN is never reported as conflicted or clean"
+}
+
+test_unknown_resolving_to_conflicting_wakes() {
+  local home out
+  home=$(make_home wake-unknown-conflict)
+  write_list "$home" "$REPO_A" "[{\"number\":7,\"title\":\"Maybe\",\"url\":\"https://github.com/$REPO_A/pull/7\",\"headRefOid\":\"$HEAD_ONE\",\"isDraft\":false,\"mergeable\":\"UNKNOWN\"}]"
+  write_view_sequence "$home" "$REPO_A" 7 \
+    "{\"mergeable\":\"UNKNOWN\",\"number\":7,\"title\":\"Maybe\",\"url\":\"https://github.com/$REPO_A/pull/7\",\"headRefOid\":\"$HEAD_ONE\",\"isDraft\":false}" \
+    "{\"mergeable\":\"CONFLICTING\",\"number\":7,\"title\":\"Maybe\",\"url\":\"https://github.com/$REPO_A/pull/7\",\"headRefOid\":\"$HEAD_ONE\",\"isDraft\":false}"
+  out="$home/out.txt"
+  run_check "$home" "$out" env FM_PR_CONFLICT_UNKNOWN_ATTEMPTS=3
+  assert_contains "$(cat "$out")" "number=7" "settled CONFLICTING must wake"
+  assert_contains "$(cat "$out")" "head=$HEAD_ONE" "settled wake carries the head"
+  : > "$out"
+  run_check "$home" "$out" env FM_PR_CONFLICT_UNKNOWN_ATTEMPTS=3
+  [ ! -s "$out" ] || fail "a settled conflict must stay silent on the next poll: $(cat "$out")"
+  pass "UNKNOWN that settles on CONFLICTING wakes once"
+}
+
+test_unknown_wake_uses_the_head_the_reread_judged() {
+  local home out
+  home=$(make_home wake-unknown-head)
+  write_list "$home" "$REPO_A" "[{\"number\":7,\"title\":\"Maybe\",\"url\":\"https://github.com/$REPO_A/pull/7\",\"headRefOid\":\"$HEAD_ONE\",\"isDraft\":false,\"mergeable\":\"UNKNOWN\"}]"
+  write_view "$home" "$REPO_A" 7 \
+    "{\"mergeable\":\"CONFLICTING\",\"number\":7,\"title\":\"Maybe\",\"url\":\"https://github.com/$REPO_A/pull/7\",\"headRefOid\":\"$HEAD_TWO\",\"isDraft\":false}"
+  out="$home/out.txt"
+  run_check "$home" "$out"
+  assert_contains "$(cat "$out")" "head=$HEAD_TWO" "the wake must name the head the reread judged"
+  assert_not_contains "$(cat "$out")" "head=$HEAD_ONE" "the stale listed head must not label the wake"
+  # The next sweep sees the force-updated head as the listed one, and it is the
+  # same conflict that already woke, so it must not wake a second time.
+  write_list "$home" "$REPO_A" "[{\"number\":7,\"title\":\"Maybe\",\"url\":\"https://github.com/$REPO_A/pull/7\",\"headRefOid\":\"$HEAD_TWO\",\"isDraft\":false,\"mergeable\":\"CONFLICTING\"}]"
+  : > "$out"
+  run_check "$home" "$out"
+  [ ! -s "$out" ] || fail "the reread head must be what was recorded: $(cat "$out")"
+  pass "a reread wake is labelled and deduped by the head it judged"
+}
+
+# A sweep that finds more conflicts than one line can carry must not record the
+# ones it never printed: their heads do not change, so nothing would ever
+# re-trigger them and they would be lost for good.
+test_conflicts_past_the_line_cap_wake_on_a_later_sweep() {
+  local home out i rows='' seen='' round total=12 number
+  home=$(make_home wake-cap)
+  i=1
+  while [ "$i" -le "$total" ]; do
+    [ -z "$rows" ] || rows="$rows,"
+    rows="$rows{\"number\":$i,\"title\":\"Conflicted branch $i\",\"url\":\"https://github.com/$REPO_A/pull/$i\",\"headRefOid\":\"$HEAD_ONE\",\"isDraft\":false,\"mergeable\":\"CONFLICTING\"}"
+    i=$((i + 1))
+  done
+  write_list "$home" "$REPO_A" "[$rows]"
+  out="$home/out.txt"
+  round=0
+  while [ "$round" -lt 6 ]; do
+    : > "$out"
+    run_check "$home" "$out"
+    [ -s "$out" ] || break
+    [ "$(wc -l < "$out" | tr -d '[:space:]')" = 1 ] || fail "every wake must be one line"
+    while IFS= read -r number; do
+      seen="$seen $number"
+    done < <(tr ' ' '\n' < "$out" | sed -n 's/^number=\([0-9][0-9]*\)$/\1/p')
+    round=$((round + 1))
+  done
+  [ "$round" -gt 1 ] || fail "12 conflicts cannot fit in one capped line; expected more than one wake"
+  i=1
+  while [ "$i" -le "$total" ]; do
+    case " $seen " in
+      *" $i "*) ;;
+      *) fail "conflict $i was never reported across $round wakes" ;;
+    esac
+    i=$((i + 1))
+  done
+  [ ! -s "$out" ] || fail "the fleet should fall silent once every conflict has woken"
+  pass "conflicts cut by the line cap wake on a later sweep instead of being lost"
+}
+
+# The dedupe record is not accumulate-only: a conflict the sweep no longer
+# observes is dropped, so the record stays the size of the live conflict set.
+# The proof is behavioural - a dropped key cannot suppress the same conflict if
+# it comes back.
+test_resolved_conflicts_leave_the_record() {
+  local home out
+  home=$(make_home record-prune)
+  write_list "$home" "$REPO_A" "[{\"number\":7,\"title\":\"Broken\",\"url\":\"https://github.com/$REPO_A/pull/7\",\"headRefOid\":\"$HEAD_ONE\",\"isDraft\":false,\"mergeable\":\"CONFLICTING\"}]"
+  out="$home/out.txt"
+  run_check "$home" "$out"
+  [ -s "$out" ] || fail "first poll should wake"
+  write_list "$home" "$REPO_A" '[]'
+  : > "$out"
+  run_check "$home" "$out"
+  [ ! -s "$out" ] || fail "a closed pull request must not wake: $(cat "$out")"
+  # state/.pr-conflict-watch is this script's own persisted record; its
+  # fm-pr-conflict-watch-v1 shape is the contract being asserted.
+  assert_not_contains "$(cat "$home/state/.pr-conflict-watch")" "$HEAD_ONE" \
+    "the record must not keep a key for a pull request it no longer sees"
+  write_list "$home" "$REPO_A" "[{\"number\":7,\"title\":\"Broken\",\"url\":\"https://github.com/$REPO_A/pull/7\",\"headRefOid\":\"$HEAD_ONE\",\"isDraft\":false,\"mergeable\":\"CONFLICTING\"}]"
+  : > "$out"
+  run_check "$home" "$out"
+  assert_contains "$(cat "$out")" "number=7" "a conflict that comes back must wake again"
+  pass "keys for conflicts the sweep no longer observes leave the record"
+}
+
+# A run the watcher kills prints and records nothing, so the reread loop has to
+# end at the sweep deadline rather than at its attempt count.
+test_unknown_rereads_stop_at_the_sweep_deadline() {
+  local home out started elapsed
+  home=$(make_home unknown-deadline)
+  write_list "$home" "$REPO_A" "[{\"number\":7,\"title\":\"Maybe\",\"url\":\"https://github.com/$REPO_A/pull/7\",\"headRefOid\":\"$HEAD_ONE\",\"isDraft\":false,\"mergeable\":\"UNKNOWN\"}]"
+  write_view "$home" "$REPO_A" 7 \
+    "{\"mergeable\":\"UNKNOWN\",\"number\":7,\"title\":\"Maybe\",\"url\":\"https://github.com/$REPO_A/pull/7\",\"headRefOid\":\"$HEAD_ONE\",\"isDraft\":false}"
+  out="$home/out.txt"
+  started=$(date +%s)
+  # Ten attempts five seconds apart is 55s of rereads on a one second budget.
+  run_check "$home" "$out" env FM_PR_CONFLICT_BUDGET_SECS=1 \
+    FM_PR_CONFLICT_UNKNOWN_ATTEMPTS=10 FM_PR_CONFLICT_UNKNOWN_WAIT=5
+  elapsed=$(( $(date +%s) - started ))
+  [ "$elapsed" -lt 15 ] || fail "the reread loop ran past the sweep deadline: ${elapsed}s"
+  [ ! -s "$out" ] || fail "an unsettled pull request must stay silent: $(cat "$out")"
+  pass "UNKNOWN rereads stop at the sweep deadline"
 }
 
 test_clean_fleet_is_silent() {
@@ -244,6 +369,11 @@ test_newly_conflicted_wakes
 test_same_head_stays_silent
 test_new_head_after_force_update_wakes_again
 test_unknown_never_reported
+test_unknown_resolving_to_conflicting_wakes
+test_unknown_wake_uses_the_head_the_reread_judged
+test_conflicts_past_the_line_cap_wake_on_a_later_sweep
+test_resolved_conflicts_leave_the_record
+test_unknown_rereads_stop_at_the_sweep_deadline
 test_clean_fleet_is_silent
 test_draft_conflicts_are_reported
 test_arm_registers_check

--- a/tests/fm-pr-conflict-watch.test.sh
+++ b/tests/fm-pr-conflict-watch.test.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# Tests for fm-pr-conflict-watch.sh merge-conflict detection and dedupe.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+WATCH="$ROOT/bin/fm-pr-conflict-watch.sh"
+TMP_ROOT=$(fm_test_tmproot fm-pr-conflict-watch)
+BASE_PATH=$PATH
+JQ_BIN=$(command -v jq) || fail "jq is required for these tests"
+
+fm_git_identity fmtest fmtest@example.invalid
+
+REPO_A=acme/alpha
+REPO_B=acme/beta
+HEAD_ONE=1111111111111111111111111111111111111111
+HEAD_TWO=2222222222222222222222222222222222222222
+
+make_home() {
+  local name=$1 home fakebin fixture
+  home="$TMP_ROOT/$name"
+  fixture="$home/fixture"
+  fakebin="$home/fakebin"
+  mkdir -p "$home/state" "$home/data" "$home/projects/alpha" "$home/projects/beta" \
+    "$fixture/lists" "$fixture/views" "$fakebin"
+  cat > "$home/data/projects.md" <<'MD'
+# Projects
+
+- alpha - alpha repo (added 2026-08-25)
+- beta - beta repo (added 2026-08-25)
+MD
+  cat > "$home/data/secondmates.md" <<'MD'
+# Second mates
+
+- team-a - owns alpha (home: /tmp/team-a; scope: alpha; projects: alpha; added 2026-08-25)
+- team-b - owns beta (home: /tmp/team-b; scope: beta; projects: beta; added 2026-08-25)
+MD
+  git -C "$home/projects/alpha" init -q
+  git -C "$home/projects/alpha" remote add origin "https://github.com/$REPO_A.git"
+  git -C "$home/projects/beta" init -q
+  git -C "$home/projects/beta" remote add origin "https://github.com/$REPO_B.git"
+  fm_slug=$(git -C "$ROOT" remote get-url origin 2>/dev/null | sed -n 's#.*github\.com[:/]\([^/]*/[^/]*\)#\1#p' | sed 's#\.git$##')
+  cat > "$fakebin/gh-axi" <<'SH'
+#!/usr/bin/env bash
+set -u
+fixture="$FM_TEST_PR_CONFLICT_FIXTURE"
+repo=
+number=
+mode=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    pr)
+      mode=$2
+      shift 2
+      ;;
+    --repo)
+      repo=$2
+      shift 2
+      ;;
+    --repo=*)
+      repo=${1#--repo=}
+      shift
+      ;;
+    --json|--state)
+      shift
+      ;;
+    --limit)
+      shift 2
+      ;;
+    [0-9]*)
+      number=$1
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+slug=${repo//\//__}
+case "$mode" in
+  list)
+    file="$fixture/lists/${slug}.json"
+    if [ -f "$file" ]; then
+      cat "$file"
+    else
+      printf '[]\n'
+    fi
+    exit 0
+    ;;
+  view)
+    file="$fixture/views/${slug}-${number}.json"
+    seqfile="$fixture/views/${slug}-${number}.seq"
+    if [ -f "$seqfile" ]; then
+      idx=$(cat "$seqfile")
+      idx=$((idx + 1))
+      printf '%s\n' "$idx" > "$seqfile"
+      jq -c ".[$((idx - 1))]" "$file"
+      exit 0
+    fi
+    if [ -f "$file" ]; then
+      cat "$file"
+    fi
+    exit 0
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/gh-axi"
+  ln -sf "$JQ_BIN" "$fakebin/jq"
+  if [ -n "$fm_slug" ]; then
+    write_list "$home" "$fm_slug" '[]'
+  fi
+  printf '%s\n' "$home"
+}
+
+write_list() {
+  local home=$1 repo=$2 json=$3
+  slug=${repo//\//__}
+  printf '%s\n' "$json" > "$home/fixture/lists/${slug}.json"
+}
+
+write_view() {
+  local home=$1 repo=$2 number=$3 json
+  slug=${repo//\//__}
+  printf '%s\n' "$json" > "$home/fixture/views/${slug}-${number}.json"
+}
+
+write_view_sequence() {
+  local home=$1 repo=$2 number=$3
+  slug=${repo//\//__}
+  shift 3
+  printf '%s\n' "$@" > "$home/fixture/views/${slug}-${number}.json"
+  printf '0\n' > "$home/fixture/views/${slug}-${number}.seq"
+}
+
+run_check() {
+  local home=$1 out=$2
+  shift 2
+  local status=0
+  env FM_CHECK_TIMEOUT=30 FM_PR_CONFLICT_INTERVAL=0 FM_PR_CONFLICT_UNKNOWN_WAIT=0 \
+    FM_HOME="$home" FM_ROOT="$ROOT" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_STATE_OVERRIDE="$home/state" \
+    FM_TEST_PR_CONFLICT_FIXTURE="$home/fixture" \
+    PATH="$home/fakebin:$BASE_PATH" "$@" "$WATCH" >"$out" 2>&1 || status=$?
+  expect_code 0 "$status" "check exit"
+}
+
+test_newly_conflicted_wakes() {
+  local home out
+  home=$(make_home wake-new)
+  write_list "$home" "$REPO_A" "[{\"number\":7,\"title\":\"Broken\",\"url\":\"https://github.com/$REPO_A/pull/7\",\"headRefOid\":\"$HEAD_ONE\",\"isDraft\":false,\"mergeable\":\"CONFLICTING\"}]"
+  out="$home/out.txt"
+  run_check "$home" "$out"
+  assert_contains "$(cat "$out")" "pr-conflict:" "missing wake prefix"
+  assert_contains "$(cat "$out")" "owner-team=team-a" "missing owner team"
+  assert_contains "$(cat "$out")" "repo=$REPO_A" "missing repo"
+  assert_contains "$(cat "$out")" "number=7" "missing number"
+  assert_contains "$(cat "$out")" "head=$HEAD_ONE" "missing head"
+  assert_contains "$(cat "$out")" "draft=no" "missing draft flag"
+  assert_contains "$(cat "$out")" "title=Broken" "missing title"
+  [ "$(wc -l < "$out" | tr -d '[:space:]')" = 1 ] || fail "wake must be one line"
+  pass "newly conflicted PR wakes once with routing fields"
+}
+
+test_same_head_stays_silent() {
+  local home out
+  home=$(make_home wake-silent)
+  write_list "$home" "$REPO_A" "[{\"number\":7,\"title\":\"Broken\",\"url\":\"https://github.com/$REPO_A/pull/7\",\"headRefOid\":\"$HEAD_ONE\",\"isDraft\":false,\"mergeable\":\"CONFLICTING\"}]"
+  out="$home/out.txt"
+  run_check "$home" "$out"
+  [ -s "$out" ] || fail "first poll should wake"
+  : > "$out"
+  run_check "$home" "$out"
+  [ ! -s "$out" ] || fail "second poll with same head should stay silent: $(cat "$out")"
+  pass "same conflicted head stays silent on the next poll"
+}
+
+test_new_head_after_force_update_wakes_again() {
+  local home out
+  home=$(make_home wake-new-head)
+  write_list "$home" "$REPO_A" "[{\"number\":7,\"title\":\"Broken\",\"url\":\"https://github.com/$REPO_A/pull/7\",\"headRefOid\":\"$HEAD_ONE\",\"isDraft\":false,\"mergeable\":\"CONFLICTING\"}]"
+  out="$home/out.txt"
+  run_check "$home" "$out"
+  [ -s "$out" ] || fail "first head should wake"
+  write_list "$home" "$REPO_A" "[{\"number\":7,\"title\":\"Broken again\",\"url\":\"https://github.com/$REPO_A/pull/7\",\"headRefOid\":\"$HEAD_TWO\",\"isDraft\":false,\"mergeable\":\"CONFLICTING\"}]"
+  : > "$out"
+  run_check "$home" "$out"
+  assert_contains "$(cat "$out")" "head=$HEAD_TWO" "force-updated head should wake again"
+  pass "new head after force-update wakes again"
+}
+
+test_unknown_never_reported() {
+  local home out
+  home=$(make_home wake-unknown)
+  write_list "$home" "$REPO_A" "[{\"number\":7,\"title\":\"Maybe\",\"url\":\"https://github.com/$REPO_A/pull/7\",\"headRefOid\":\"$HEAD_ONE\",\"isDraft\":false,\"mergeable\":\"UNKNOWN\"}]"
+  write_view_sequence "$home" "$REPO_A" 7 \
+    '{"mergeable":"UNKNOWN","mergeStateStatus":"UNKNOWN","number":7,"title":"Maybe","url":"https://github.com/acme/alpha/pull/7","headRefOid":"1111111111111111111111111111111111111111","isDraft":false}' \
+    '{"mergeable":"UNKNOWN","mergeStateStatus":"UNKNOWN","number":7,"title":"Maybe","url":"https://github.com/acme/alpha/pull/7","headRefOid":"1111111111111111111111111111111111111111","isDraft":false}' \
+    '{"mergeable":"UNKNOWN","mergeStateStatus":"UNKNOWN","number":7,"title":"Maybe","url":"https://github.com/acme/alpha/pull/7","headRefOid":"1111111111111111111111111111111111111111","isDraft":false}'
+  out="$home/out.txt"
+  run_check "$home" "$out" env FM_PR_CONFLICT_UNKNOWN_ATTEMPTS=3
+  [ ! -s "$out" ] || fail "persistent UNKNOWN must stay silent: $(cat "$out")"
+  pass "persistent UNKNOWN is never reported as conflicted or clean"
+}
+
+test_clean_fleet_is_silent() {
+  local home out
+  home=$(make_home wake-clean)
+  write_list "$home" "$REPO_A" "[{\"number\":7,\"title\":\"Fine\",\"url\":\"https://github.com/$REPO_A/pull/7\",\"headRefOid\":\"$HEAD_ONE\",\"isDraft\":false,\"mergeable\":\"MERGEABLE\"}]"
+  write_list "$home" "$REPO_B" '[]'
+  out="$home/out.txt"
+  run_check "$home" "$out"
+  [ ! -s "$out" ] || fail "clean fleet should print nothing: $(cat "$out")"
+  pass "clean fleet output is empty"
+}
+
+test_draft_conflicts_are_reported() {
+  local home out
+  home=$(make_home wake-draft)
+  write_list "$home" "$REPO_B" "[{\"number\":3,\"title\":\"Draft broken\",\"url\":\"https://github.com/$REPO_B/pull/3\",\"headRefOid\":\"$HEAD_ONE\",\"isDraft\":true,\"mergeable\":\"CONFLICTING\"}]"
+  out="$home/out.txt"
+  run_check "$home" "$out"
+  assert_contains "$(cat "$out")" "draft=yes" "draft conflict must be marked"
+  assert_contains "$(cat "$out")" "owner-team=team-b" "draft repo routes to owning team"
+  pass "conflicted draft PRs are reported"
+}
+
+test_arm_registers_check() {
+  local home out status=0
+  home=$(make_home arm)
+  env FM_HOME="$home" FM_ROOT="$ROOT" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$home/projects" FM_STATE_OVERRIDE="$home/state" \
+    PATH="$home/fakebin:$BASE_PATH" "$WATCH" arm >"$home/arm.out" 2>&1 || status=$?
+  expect_code 0 "$status" "arm exit"
+  assert_present "$home/state/pr-conflict-watch.check.sh" "arm must write check shim"
+  assert_present "$home/state/pr-conflict-watch.check-trust" "arm must bind trust"
+  FM_STATE_OVERRIDE="$home/state" "$ROOT/bin/fm-check-register.sh" pr-conflict-watch >/dev/null \
+    || fail "trust binding must match shim bytes"
+  pass "arm writes and registers the watcher check"
+}
+
+test_newly_conflicted_wakes
+test_same_head_stays_silent
+test_new_head_after_force_update_wakes_again
+test_unknown_never_reported
+test_clean_fleet_is_silent
+test_draft_conflicts_are_reported
+test_arm_registers_check

--- a/tests/fm-pr-conflict-watch.test.sh
+++ b/tests/fm-pr-conflict-watch.test.sh
@@ -360,6 +360,69 @@ test_empty_discovery_keeps_the_record() {
   pass "an empty discovery sweep does not erase the dedupe record"
 }
 
+# Discovery that reads some repositories and fails on others is partial, not
+# empty: a clone whose origin cannot be read this sweep was never inspected, so
+# its absence from the discovered set says nothing about whether the fleet still
+# works in it. Pruning its keys there would re-wake every unchanged conflict it
+# holds as soon as the clone resolves again.
+test_partial_discovery_keeps_the_record() {
+  local home out
+  home=$(make_home discovery-partial)
+  write_list "$home" "$REPO_A" "[{\"number\":7,\"title\":\"Broken A\",\"url\":\"https://github.com/$REPO_A/pull/7\",\"headRefOid\":\"$HEAD_ONE\",\"isDraft\":false,\"mergeable\":\"CONFLICTING\"}]"
+  write_list "$home" "$REPO_B" "[{\"number\":9,\"title\":\"Broken B\",\"url\":\"https://github.com/$REPO_B/pull/9\",\"headRefOid\":\"$HEAD_TWO\",\"isDraft\":false,\"mergeable\":\"CONFLICTING\"}]"
+  out="$home/out.txt"
+  run_check "$home" "$out"
+  assert_contains "$(cat "$out")" "repo=$REPO_A" "first poll should wake for alpha"
+  assert_contains "$(cat "$out")" "repo=$REPO_B" "first poll should wake for beta"
+  # The beta clone goes away while the alpha clone still resolves, exactly as a
+  # transient unreadable checkout would leave it.
+  mv "$home/projects/beta" "$home/projects/beta.away"
+  : > "$out"
+  run_check "$home" "$out"
+  [ ! -s "$out" ] || fail "a partial discovery sweep must stay silent: $(cat "$out")"
+  mv "$home/projects/beta.away" "$home/projects/beta"
+  : > "$out"
+  run_check "$home" "$out"
+  [ ! -s "$out" ] || fail "the unchanged beta conflict must not wake again after its clone resolves: $(cat "$out")"
+  pass "a partial discovery sweep does not erase the unread repository's record"
+}
+
+# The other side of the same rule: when discovery resolved every project it
+# enumerated, a repository missing from the result is one this home genuinely
+# stopped working in, and its keys are dropped so the record stays the size of
+# the live conflict set. Retaining them for an unread repository must not turn
+# into retaining them forever.
+test_deregistered_project_leaves_the_record() {
+  local home out
+  home=$(make_home discovery-deregistered)
+  write_list "$home" "$REPO_A" "[{\"number\":7,\"title\":\"Broken A\",\"url\":\"https://github.com/$REPO_A/pull/7\",\"headRefOid\":\"$HEAD_ONE\",\"isDraft\":false,\"mergeable\":\"CONFLICTING\"}]"
+  write_list "$home" "$REPO_B" "[{\"number\":9,\"title\":\"Broken B\",\"url\":\"https://github.com/$REPO_B/pull/9\",\"headRefOid\":\"$HEAD_TWO\",\"isDraft\":false,\"mergeable\":\"CONFLICTING\"}]"
+  out="$home/out.txt"
+  run_check "$home" "$out"
+  assert_contains "$(cat "$out")" "repo=$REPO_B" "first poll should wake for beta"
+  # beta is deregistered while every project still listed resolves, so discovery
+  # is complete and beta is genuinely gone rather than unread.
+  cat > "$home/data/projects.md" <<'MD'
+# Projects
+
+- alpha - alpha repo (added 2026-08-25)
+MD
+  : > "$out"
+  run_check "$home" "$out"
+  [ ! -s "$out" ] || fail "a deregistered project must not wake: $(cat "$out")"
+  cat > "$home/data/projects.md" <<'MD'
+# Projects
+
+- alpha - alpha repo (added 2026-08-25)
+- beta - beta repo (added 2026-08-25)
+MD
+  : > "$out"
+  run_check "$home" "$out"
+  assert_contains "$(cat "$out")" "repo=$REPO_B" \
+    "a re-registered project's conflict is a fresh event and must wake again"
+  pass "keys for a repository this home stopped working in leave the record"
+}
+
 # A run the watcher kills prints and records nothing, so the reread loop has to
 # end at the sweep deadline rather than at its attempt count.
 test_unknown_rereads_stop_at_the_sweep_deadline() {
@@ -425,6 +488,8 @@ test_unknown_wake_uses_the_head_the_reread_judged
 test_conflicts_past_the_line_cap_wake_on_a_later_sweep
 test_resolved_conflicts_leave_the_record
 test_empty_discovery_keeps_the_record
+test_partial_discovery_keeps_the_record
+test_deregistered_project_leaves_the_record
 test_unknown_rereads_stop_at_the_sweep_deadline
 test_clean_fleet_is_silent
 test_draft_conflicts_are_reported


### PR DESCRIPTION
## Intent

Build automatic detection and routing of pull-request merge conflicts across every repository this fleet works in. Add a registered watcher check that polls open PRs for repos derived from data/projects.md clones, data/secondmates.md ownership, and the firstmate checkout origin (no hardcoded repo list). Route each wake with owner-team from secondmates.md (firstmate repo -> main). Dedupe on repo+number+head SHA so the same conflict wakes once and a force-updated head wakes again. Poll GitHub lazy mergeability: never treat UNKNOWN as clean or conflicted. Print one wake line only when firstmate should wake; stay silent otherwise; finish inside FM_CHECK_TIMEOUT; use gh-axi; include drafts; register with fm-check-register.sh via arm/disarm. Detection only - no conflict resolution, rebase, or update-branch. One script, one registration. Prove with fixture tests covering newly conflicted wakes, same-head silence, new-head re-wake, unknown never reported, and empty output when clean. Document what this does NOT solve (safety net, not cure).

## What Changed

- Added `bin/fm-pr-conflict-watch.sh`, a registered watcher check (`check`/`arm`/`disarm` via `fm-check-register.sh`) that sweeps open GitHub PRs - drafts included - across repositories derived from `data/projects.md` clone origins and this firstmate checkout's own origin, routes each wake to an `owner-team` resolved from `data/secondmates.md` (firstmate repo and unmapped projects fall back to `main`), and prints a single `pr-conflict:` line only when a new conflict appears. It polls lazy `mergeable` state so a persistent `UNKNOWN` is never reported as clean or conflicted, dedupes on repo + PR number + head SHA so a force-updated head wakes again, bounds each probe and the whole sweep inside `FM_CHECK_TIMEOUT`, discloses conflicts cut by the line cap as `N more omitted` without recording them, and prunes the dedupe record back to the conflicts each sweep still observes. Detection and routing only - no rebase, update-branch, or conflict resolution.
- Extracted the GitHub remote/PR URL to `owner/repo` parse out of `bin/fm-bearings-snapshot.sh` into a new shared `bin/fm-repo-slug-lib.sh` (`fm_repo_slug`) so the bearings snapshot and the new watcher name the same repository the same way.
- Added `tests/fm-pr-conflict-watch.test.sh` (12 fixture cases covering new-conflict wakes, same-head silence, new-head re-wake, unknown never reported, unknown-reread head attribution and deadline, line-cap deferral, record pruning, draft reporting, clean-fleet silence, and `arm` registration), and documented the watcher's routing, dedupe, tunables, and explicit non-goals in `docs/configuration.md`, `docs/scripts.md`, and `AGENTS.md`.

## Risk Assessment

⚠️ Medium: The three prior substantive defects are genuinely fixed and backed by regression tests that fail against the pre-fix code, and the change satisfies every source-verifiable intent criterion, but it is an 842-line new watcher whose dedupe record still grows without bound for repos at PR_LIMIT and can be wiped wholesale on an empty discovery - both safe to merge and address as follow-ups.

## Testing

I ran the change's own fixture suite (12 cases, twice, no flakiness) plus the bearings-snapshot suite that shares the newly extracted repo-slug library, then built and ran an end-to-end demo that drives the real `bin/fm-watch.sh` against an armed `pr-conflict-watch.check.sh` in a throwaway FM_HOME with only GitHub faked, so repository discovery, owner routing, the trust-bound check sweep, the durable wake queue, and the drain are all production code. The captured transcript shows a clean fleet producing no wake at all, three conflicts across two project clones and the firstmate repo surfacing as one wake line routed to team-a, team-b and main with the draft flagged, silence on subsequent sweeps with unchanged heads, a fresh wake after a force-updated head, an UNKNOWN pull request re-read and never reported either way, and disarm leaving no artifacts behind. The change is a shell/CLI watcher with no rendered surface, so the reviewer-visible evidence is the operator transcript rather than a screenshot. Everything passed and I found no issues.

<details>
<summary>Evidence: End-to-end operator transcript: arm, eight watcher sweeps, drained wake lines, disarm</summary>

Source: [End-to-end operator transcript: arm, eight watcher sweeps, drained wake lines, disarm](https://github.com/bingb0t5/firstmate/blob/63d02b3271e405e5da00c13979f5b571f08fdc06/.no-mistakes/evidence/fm/fm-pr-conflict-watch/pr-conflict-watch-e2e.txt)

<code>=== 3. main moves: two PRs conflict (one a draft) plus one in the firstmate repo ===&#10;watcher exited to wake firstmate. what firstmate reads out of the durable wake queue:&#10;| check: &lt;home&gt;/state/pr-conflict-watch.check.sh: pr-conflict: owner-team=team-a repo=acme/alpha number=7 head=1111111111111111111111111111111111111111 draft=no url=https://github.com/acme/alpha/pull/7 title=Add retry budget to the worker; owner-team=team-b repo=acme/beta number=3 head=1111111111111111111111111111111111111111 draft=yes url=https://github.com/acme/beta/pull/3 title=WIP: split the ingest queue; owner-team=main repo=kunchenguid/firstmate number=2942 head=1111111111111111111111111111111111111111 draft=no url=https://github.com/kunchenguid/firstmate/pull/2942 title=bound remote job worker supervisor restarts&#10;&#10;=== 4. the same heads are still conflicting: the fleet stays quiet ===&#10;no wake: the watcher kept supervising for 12s and printed nothing.&#10;&#10;=== 5. PR 7&#39;s head is force-updated and still conflicts: wake again ===&#10;| check: &lt;home&gt;/state/pr-conflict-watch.check.sh: pr-conflict: owner-team=team-a repo=acme/alpha number=7 head=2222222222222222222222222222222222222222 draft=no url=https://github.com/acme/alpha/pull/7 title=Add retry budget to the worker&#10;&#10;=== 6. GitHub has not computed mergeability yet (UNKNOWN): never guessed either way ===&#10;no wake: the watcher kept supervising for 12s and printed nothing.&#10;| 11x gh-axi pr view --repo acme/alpha 9</code>

```text

=== 1. arm the watcher check (an operator runs this once per home) ===
armed: state/pr-conflict-watch.check.sh
  total 8
  -rw------- 1 rich rich  84 Aug 25 10:23 pr-conflict-watch.check-trust
  -rwx------ 1 rich rich 335 Aug 25 10:23 pr-conflict-watch.check.sh
  trust binding verifies against the armed shim bytes
  repositories this fleet works in (projects.md clones + firstmate origin): acme/alpha, acme/beta, kunchenguid/firstmate

=== 2. clean fleet: nothing conflicts, so firstmate is never woken ===
no wake: the watcher kept supervising for 12s and printed nothing.
GitHub reads this round (gh-axi, bounded by the sweep budget):
  | 5x gh-axi pr list --repo acme/alpha 
  | 5x gh-axi pr list --repo acme/beta 
  | 5x gh-axi pr list --repo kunchenguid/firstmate 

=== 3. main moves: two PRs conflict (one a draft) plus one in the firstmate repo ===
watcher exited to wake firstmate. reason printed to the supervision loop:
  | check: /tmp/pr-conflict-e2e.Np3xIt/home/state/pr-conflict-watch.check.sh: pr-conflict: 
  | owner-team=team-a repo=acme/alpha number=7 head=1111111111111111111111111111111111111111 draft=no 
  | url=https://github.com/acme/alpha/pull/7 title=Add retry budget to the worker; owner-team=team-b 
  | repo=acme/beta number=3 head=1111111111111111111111111111111111111111 draft=yes 
  | url=https://github.com/acme/beta/pull/3 title=WIP: split the ingest queue; owner-team=main 
  | repo=kunchenguid/firstmate number=2942 head=1111111111111111111111111111111111111111 draft=no 
  | url=https://github.com/kunchenguid/firstmate/pull/2942 title=bound remote job worker supervisor 
  | restarts
what firstmate reads out of the durable wake queue:
  | check: /tmp/pr-conflict-e2e.Np3xIt/home/state/pr-conflict-watch.check.sh: pr-conflict: owner-team=team-a repo=acme/alpha number=7 head=1111111111111111111111111111111111111111 draft=no url=https://github.com/acme/alpha/pull/7 title=Add retry budget to the worker; owner-team=team-b repo=acme/beta number=3 head=1111111111111111111111111111111111111111 draft=yes url=https://github.com/acme/beta/pull/3 title=WIP: split the ingest queue; owner-team=main repo=kunchenguid/firstmate number=2942 head=1111111111111111111111111111111111111111 draft=no url=https://github.com/kunchenguid/firstmate/pull/2942 title=bound remote job worker supervisor restarts
GitHub reads this round (gh-axi, bounded by the sweep budget):
  | 1x gh-axi pr list --repo acme/alpha 
  | 1x gh-axi pr list --repo acme/beta 
  | 1x gh-axi pr list --repo kunchenguid/firstmate 

=== 4. the same heads are still conflicting: the fleet stays quiet ===
no wake: the watcher kept supervising for 12s and printed nothing.
GitHub reads this round (gh-axi, bounded by the sweep budget):
  | 7x gh-axi pr list --repo acme/alpha 
  | 7x gh-axi pr list --repo acme/beta 
  | 7x gh-axi pr list --repo kunchenguid/firstmate 

=== 5. PR 7's head is force-updated and still conflicts: wake again ===
watcher exited to wake firstmate. reason printed to the supervision loop:
  | check: /tmp/pr-conflict-e2e.Np3xIt/home/state/pr-conflict-watch.check.sh: pr-conflict: 
  | owner-team=team-a repo=acme/alpha number=7 head=2222222222222222222222222222222222222222 draft=no 
  | url=https://github.com/acme/alpha/pull/7 title=Add retry budget to the worker
what firstmate reads out of the durable wake queue:
  | check: /tmp/pr-conflict-e2e.Np3xIt/home/state/pr-conflict-watch.check.sh: pr-conflict: owner-team=team-a repo=acme/alpha number=7 head=2222222222222222222222222222222222222222 draft=no url=https://github.com/acme/alpha/pull/7 title=Add retry budget to the worker
GitHub reads this round (gh-axi, bounded by the sweep budget):
  | 1x gh-axi pr list --repo acme/alpha 
  | 1x gh-axi pr list --repo acme/beta 
  | 1x gh-axi pr list --repo kunchenguid/firstmate 

=== 6. GitHub has not computed mergeability yet (UNKNOWN): never guessed either way ===
no wake: the watcher kept supervising for 12s and printed nothing.
GitHub reads this round (gh-axi, bounded by the sweep budget):
  | 4x gh-axi pr list --repo acme/alpha 
  | 3x gh-axi pr list --repo acme/beta 
  | 3x gh-axi pr list --repo kunchenguid/firstmate 
  | 11x gh-axi pr view --repo acme/alpha 9

=== 7. every conflict is resolved upstream: the fleet is quiet again ===
no wake: the watcher kept supervising for 12s and printed nothing.
GitHub reads this round (gh-axi, bounded by the sweep budget):
  | 9x gh-axi pr list --repo acme/alpha 
  | 9x gh-axi pr list --repo acme/beta 
  | 9x gh-axi pr list --repo kunchenguid/firstmate 

=== 8. disarm removes the shim, the trust binding, and the dedupe record ===
disarmed: state/pr-conflict-watch.check.sh
  pr-conflict-watch artifacts left in state/: 0
```
</details>
<details>
<summary>Evidence: Reproducible end-to-end script (fake GitHub only; real watcher, wake queue and drain)</summary>

Source: [Reproducible end-to-end script (fake GitHub only; real watcher, wake queue and drain)](https://github.com/bingb0t5/firstmate/blob/63d02b3271e405e5da00c13979f5b571f08fdc06/.no-mistakes/evidence/fm/fm-pr-conflict-watch/pr-conflict-watch-e2e.sh)

```text
#!/usr/bin/env bash
# End-to-end demo of the fleet PR merge-conflict watcher as an operator sees it:
# arm the check, let the REAL bin/fm-watch.sh poll it on its own cadence, and
# show the wake text that reaches firstmate through the durable wake queue.
#
# GitHub is the only thing faked (a canned gh-axi). Repository discovery,
# owner routing, the check shim + trust binding, the watcher check sweep, the
# wake queue, and the drain are all the production code paths.
set -u
ROOT=${FM_E2E_ROOT:?set FM_E2E_ROOT to the firstmate checkout}
WORK=$(mktemp -d "${TMPDIR:-/tmp}/pr-conflict-e2e.XXXXXX")
HOME_DIR="$WORK/home"
FIXTURE="$HOME_DIR/fixture"
FAKEBIN="$HOME_DIR/fakebin"
TANGLE="$WORK/tangle"
REPO_A=acme/alpha
REPO_B=acme/beta
FM_SLUG=$(git -C "$ROOT" remote get-url origin | sed -n 's#.*github\.com[:/]\([^/]*/[^/]*\)#\1#p' | sed 's#\.git$##')
HEAD_ONE=1111111111111111111111111111111111111111
HEAD_TWO=2222222222222222222222222222222222222222

mkdir -p "$HOME_DIR/state" "$HOME_DIR/data" "$HOME_DIR/projects/alpha" "$HOME_DIR/projects/beta" \
  "$FIXTURE/lists" "$FIXTURE/views" "$FAKEBIN" "$TANGLE"

cat > "$HOME_DIR/data/projects.md" <<'MD'
# Projects

- alpha - alpha service (added 2026-08-25)
- beta - beta service (added 2026-08-25)
MD
cat > "$HOME_DIR/data/secondmates.md" <<'MD'
# Second mates

- team-a - owns alpha (home: /tmp/team-a; scope: alpha; projects: alpha; added 2026-08-25)
- team-b - owns beta (home: /tmp/team-b; scope: beta; projects: beta; added 2026-08-25)
MD

for p in alpha beta; do git -C "$HOME_DIR/projects/$p" init -q; done
git -C "$HOME_DIR/projects/alpha" remote add origin "https://github.com/$REPO_A.git"
git -C "$HOME_DIR/projects/beta" remote add origin "https://github.com/$REPO_B.git"

cat > "$FAKEBIN/gh-axi" <<'SH'
#!/usr/bin/env bash
set -u
fixture="$FM_E2E_FIXTURE"
repo=; number=; mode=
while [ "$#" -gt 0 ]; do
  case "$1" in
    pr) mode=$2; shift 2 ;;
    --repo) repo=$2; shift 2 ;;
    --json|--state) shift ;;
    --limit) shift 2 ;;
    [0-9]*) number=$1; shift ;;
    *) shift ;;
  esac
done
printf 'pr %s --repo %s %s\n' "$mode" "$repo" "$number" >> "$FM_E2E_GHLOG"
slug=${repo//\//__}
case "$mode" in
  list) f="$fixture/lists/${slug}.json"; if [ -f "$f" ]; then cat "$f"; else printf '[]\n'; fi ;;
  view) f="$fixture/views/${slug}-${number}.json"; [ -f "$f" ] && cat "$f" ;;
esac
exit 0
SH
chmod +x "$FAKEBIN/gh-axi"
printf '#!/usr/bin/env bash\nprintf "state: unknown - source: none - e2e fake\\n"\n' > "$FAKEBIN/fm-crew-state.sh"
chmod +x "$FAKEBIN/fm-crew-state.sh"
export FM_E2E_FIXTURE="$FIXTURE"
export FM_E2E_GHLOG="$WORK/gh-calls.log"
: > "$FM_E2E_GHLOG"

list() { local slug=${1//\//__}; printf '%s\n' "$2" > "$FIXTURE/lists/${slug}.json"; }
list "$REPO_A" '[]'; list "$REPO_B" '[]'; list "$FM_SLUG" '[]'

hr() { printf '\n=== %s ===\n' "$1"; }

drain_payload() {  # print what firstmate reads, then acknowledge it
  local err="$WORK/drain.err" seq gen
  FM_ROOT_OVERRIDE="$TANGLE" FM_STATE_OVERRIDE="$HOME_DIR/state" \
    "$ROOT/bin/fm-wake-drain.sh" 2> "$err" | cut -f5- | sed 's/^/  | /'
  seq=$(sed -n 's/.*--ack-through \([0-9][0-9]*\) .*/\1/p' "$err")
  gen=$(sed -n 's/.*--recovery-generation \([A-Za-z0-9._-]*\)$/\1/p' "$err")
  [ -n "$seq" ] && [ -n "$gen" ] && FM_ROOT_OVERRIDE="$TANGLE" FM_STATE_OVERRIDE="$HOME_DIR/state" \
    "$ROOT/bin/fm-wake-drain.sh" --ack-through "$seq" --recovery-generation "$gen" >/dev/null 2>&1
  return 0
}

run_watcher() {  # <out> <max-wait-secs>; 0 = woke, 1 = kept supervising
  local out=$1 limit=$2 pid i=0
  ( PATH="$FAKEBIN:$PATH" FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$HOME_DIR/state" \
      FM_CREW_STATE_BIN="$FAKEBIN/fm-crew-state.sh" FM_POLL=1 FM_CHECK_INTERVAL=1 \
      FM_HEARTBEAT=999999 FM_SIGNAL_GRACE=1 FM_PR_CONFLICT_INTERVAL=0 \
      bash "$ROOT/bin/fm-watch.sh" > "$out" 2>&1 ) &
  pid=$!
  while [ "$i" -lt $((limit * 4)) ]; do
    kill -0 "$pid" 2>/dev/null || { wait "$pid" 2>/dev/null; return 0; }
    sleep 0.25; i=$((i + 1))
  done
  kill "$pid" 2>/dev/null; wait "$pid" 2>/dev/null
  return 1
}

# One observation round. A watcher restarted after downtime first announces
# "check: rearm-resurface" (a watcher-lifecycle wake, nothing to do with PRs);
# that is consumed and the round is then observed on a warm watcher.
watch_round() {  # <label> <max-wait-secs>
  local label=$1 limit=$2 out before after
  out="$WORK/$label.watch"
  before=$(wc -l < "$FM_E2E_GHLOG")
  if run_watcher "$out" "$limit" && [ "$(cat "$out")" = "check: rearm-resurface" ]; then
    drain_payload >/dev/null
    before=$(wc -l < "$FM_E2E_GHLOG")
    run_watcher "$out" "$limit" || true
  fi
  after=$(wc -l < "$FM_E2E_GHLOG")
  if [ -s "$out" ]; then
    printf 'watcher exited to wake firstmate. reason printed to the supervision loop:\n'
    fold -s -w 100 "$out" | sed 's/^/  | /'
    printf 'what firstmate reads out of the durable wake queue:\n'
    drain_payload
  else
    printf 'no wake: the watcher kept supervising for %ss and printed nothing.\n' "$limit"
  fi
  printf 'GitHub reads this round (gh-axi, bounded by the sweep budget):\n'
  sed -n "$((before + 1)),${after}p" "$FM_E2E_GHLOG" | sort | uniq -c \
    | sed 's/^ *\([0-9][0-9]*\) /  | \1x gh-axi /'
}

hr "1. arm the watcher check (an operator runs this once per home)"
PATH="$FAKEBIN:$PATH" FM_HOME="$HOME_DIR" "$ROOT/bin/fm-pr-conflict-watch.sh" arm
ls -l "$HOME_DIR/state" | sed 's/^/  /'
FM_STATE_OVERRIDE="$HOME_DIR/state" "$ROOT/bin/fm-check-register.sh" pr-conflict-watch >/dev/null \
  && printf '  trust binding verifies against the armed shim bytes\n'
printf '  repositories this fleet works in (projects.md clones + firstmate origin): %s, %s, %s\n' \
  "$REPO_A" "$REPO_B" "$FM_SLUG"

hr "2. clean fleet: nothing conflicts, so firstmate is never woken"
watch_round clean 12

hr "3. main moves: two PRs conflict (one a draft) plus one in the firstmate repo"
list "$REPO_A" "[{\"number\":7,\"title\":\"Add retry budget to the worker\",\"url\":\"https://github.com/$REPO_A/pull/7\",\"headRefOid\":\"$HEAD_ONE\",\"isDraft\":false,\"mergeable\":\"CONFLICTING\"}]"
list "$REPO_B" "[{\"number\":3,\"title\":\"WIP: split the ingest queue\",\"url\":\"https://github.com/$REPO_B/pull/3\",\"headRefOid\":\"$HEAD_ONE\",\"isDraft\":true,\"mergeable\":\"CONFLICTING\"}]"
list "$FM_SLUG" "[{\"number\":2942,\"title\":\"bound remote job worker supervisor restarts\",\"url\":\"https://github.com/$FM_SLUG/pull/2942\",\"headRefOid\":\"$HEAD_ONE\",\"isDraft\":false,\"mergeable\":\"CONFLICTING\"}]"
watch_round conflict 20

hr "4. the same heads are still conflicting: the fleet stays quiet"
watch_round repeat 12

hr "5. PR 7's head is force-updated and still conflicts: wake again"
list "$REPO_A" "[{\"number\":7,\"title\":\"Add retry budget to the worker\",\"url\":\"https://github.com/$REPO_A/pull/7\",\"headRefOid\":\"$HEAD_TWO\",\"isDraft\":false,\"mergeable\":\"CONFLICTING\"}]"
watch_round forced 20

hr "6. GitHub has not computed mergeability yet (UNKNOWN): never guessed either way"
list "$REPO_A" "[{\"number\":9,\"title\":\"Lazy mergeability\",\"url\":\"https://github.com/$REPO_A/pull/9\",\"headRefOid\":\"$HEAD_TWO\",\"isDraft\":false,\"mergeable\":\"UNKNOWN\"}]"
list "$REPO_B" '[]'; list "$FM_SLUG" '[]'
printf '%s\n' "{\"mergeable\":\"UNKNOWN\",\"number\":9,\"title\":\"Lazy mergeability\",\"url\":\"https://github.com/$REPO_A/pull/9\",\"headRefOid\":\"$HEAD_TWO\",\"isDraft\":false}" \
  > "$FIXTURE/views/acme__alpha-9.json"
watch_round unknown 12

hr "7. every conflict is resolved upstream: the fleet is quiet again"
list "$REPO_A" '[]'
watch_round resolved 12

hr "8. disarm removes the shim, the trust binding, and the dedupe record"
FM_HOME="$HOME_DIR" "$ROOT/bin/fm-pr-conflict-watch.sh" disarm
printf '  pr-conflict-watch artifacts left in state/: %s\n' \
  "$(ls "$HOME_DIR/state" 2>/dev/null | grep -c 'pr-conflict-watch')"

rm -rf "$WORK"
```
</details>
<details>
<summary>Evidence: Fixture-test transcript naming the behaviours the intent requires</summary>

Source: [Fixture-test transcript naming the behaviours the intent requires](https://github.com/bingb0t5/firstmate/blob/63d02b3271e405e5da00c13979f5b571f08fdc06/.no-mistakes/evidence/fm/fm-pr-conflict-watch/fixture-tests.txt)

```text
ok - newly conflicted PR wakes once with routing fields
ok - same conflicted head stays silent on the next poll
ok - new head after force-update wakes again
ok - persistent UNKNOWN is never reported as conflicted or clean
ok - UNKNOWN that settles on CONFLICTING wakes once
ok - a reread wake is labelled and deduped by the head it judged
ok - conflicts cut by the line cap wake on a later sweep instead of being lost
ok - keys for conflicts the sweep no longer observes leave the record
ok - UNKNOWN rereads stop at the sweep deadline
ok - clean fleet output is empty
ok - conflicted draft PRs are reported
ok - arm writes and registers the watcher check
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"fdc681b6894663fd0f1aaa8e3130530895e15d95","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 5 infos</summary>

- 🚨 `bin/fm-pr-conflict-watch.sh:469` - Every emitted finding is recorded as reported (`record_add_key`) even when it never made it into the printed line. `emit_finding` concatenates all findings into one string and `action_check` cuts it to MAX_LINE=1000 with `fm_cap_line_var`, but nothing ties the recorded keys to what survived the cut. Concrete sequence: main moves and 8 open PRs go CONFLICTING in one sweep. A realistic finding is ~220 chars (`owner-team=main repo=kunchenguid/firstmate number=2942 head=&lt;40 hex&gt; draft=no url=https://github.com/kunchenguid/firstmate/pull/2942 title=...`), so after the 13-char `pr-conflict: ` prefix only ~4 findings fit; findings 5-8 are replaced by ` [truncated]`. All 8 keys are still persisted by `record_write`, so on the next sweep `record_has_key` skips them and those 4 conflicts never wake firstmate at all - the heads are unchanged, so nothing ever re-triggers them. This defeats the intent&#39;s &#34;the same conflict wakes once&#34; for exactly the mass-conflict scenario the watcher exists for. Fix: only record keys for findings actually present in the printed line, or cap the finding count and disclose &#34;N more omitted&#34; while leaving the omitted keys unrecorded (the sibling `bin/fm-tool-update-check.sh:735` handles the same hazard by comparing the whole finding set rather than the cut line).
- ⚠️ `bin/fm-pr-conflict-watch.sh:500` - When the sweep runs out of budget the loop just breaks, and repos never reached are indistinguishable from clean in the output. `discover_repos` emits a fixed order (projects.md order, with the firstmate repo appended last), so the same tail repos starve on every sweep, forever. With BUDGET_SECS=20 and one `gh pr list` per repo (plus up to UNKNOWN_ATTEMPTS extra `pr view` calls per UNKNOWN PR, and PR_LIMIT=30 PRs per repo), a fleet with more than ~15 repos - or one busy repo early in the list - permanently silences everything after the cut point, including the firstmate repo itself. Intent requires detection &#34;across every repository this fleet works in&#34;; the established sibling contract in `bin/fm-tool-update-check.sh:216` (`budget_allows`) emits &#34;check incomplete: the time budget ran out before &lt;name&gt;&#34; precisely so an unfinished sweep says so instead of reading as clean. Same applies to the other silent-failure paths that return without a word: `gh pr list` failure or timeout (:432), missing jq (:477), missing gh-axi (:480). Since the fix adds a user-visible line, confirm the desired shape.
- ⚠️ `bin/fm-pr-conflict-watch.sh:399` - `pr_mergeable_resolved` never checks `budget_exhausted` and its total cost is not bounded by DEADLINE. Once the deadline passes, `probe_bound` floors at PROBE_MIN_SECS=1, so the loop can still spend UNKNOWN_ATTEMPTS gh calls plus (UNKNOWN_ATTEMPTS-1) sleeps of UNKNOWN_WAIT past the deadline. BUDGET_MAX only reserves PROBE_MIN_SECS+CLOCK_ROUNDING+KILL_GRACE = 3s of headroom. Concrete: FM_PR_CONFLICT_UNKNOWN_ATTEMPTS=10 and FM_PR_CONFLICT_UNKNOWN_WAIT=5 are both inside the documented valid ranges (:121-143) and yield up to 10*1 + 9*5 = 55s of overshoot on top of the 20s budget; FM_PR_CONFLICT_BUDGET_SECS=30 with the default FM_CHECK_TIMEOUT=30 gives 27+6=33s at default knobs. Either exceeds the watcher&#39;s CHECK_TIMEOUT (bin/fm-watch.sh:153), which kills the process group - and because the script only prints and records at the very end (:509-512), a killed run prints nothing and records nothing, so the same sweep dies identically on every poll and no conflict is ever reported. Fix: cut the retry loop short on `budget_exhausted`, and/or fold UNKNOWN_ATTEMPTS*(PROBE_MIN_SECS+UNKNOWN_WAIT) into the BUDGET_MAX reserve.
- ⚠️ `bin/fm-pr-conflict-watch.sh:492` - The budget-cut notice is pushed into FINDINGS on every sweep but is never deduped against the record (REPORTED_KEYS only holds conflict keys), so a non-empty line is printed every cadence even when no PR is conflicted. Concrete: FM_PR_CONFLICT_BUDGET_SECS=30 passes validation (1..120 at :109-119); with the default FM_CHECK_TIMEOUT=30, BUDGET_MAX=27, so BUDGET_CUT_FROM is set and every poll prints `pr-conflict: sweep budget 30s cut to 27s to stay inside the watcher check timeout of 30s`, waking firstmate every FM_CHECK_INTERVAL indefinitely with no new information. This contradicts the intent&#39;s &#34;Print one wake line only when firstmate should wake; stay silent otherwise&#34; and &#34;empty output when clean&#34;. The sibling avoids this by gating the print on `[ &#34;$FINDINGS&#34; != &#34;$RECORD_REPORTED&#34; ]` (bin/fm-tool-update-check.sh:735). Fix: report the cut once (record it), or only attach it to a line that already carries a conflict.
- ⚠️ `tests/fm-pr-conflict-watch.test.sh:133` - `write_view_sequence` writes the three view payloads as newline-delimited JSON objects, but the fake gh-axi reads them with `jq -c &#34;.[$((idx - 1))]&#34; &#34;$file&#34;` (:98), which is array indexing. I verified: `printf &#39;%s\n&#39; &#39;{&#34;a&#34;:1}&#39; &#39;{&#34;a&#34;:2}&#39; | jq -c &#39;.[0]&#39;` fails with &#34;Cannot index object with number&#34; and exit 5. The fake then falls through to `exit 0` with empty stdout, so `gh_bounded pr view` succeeds with no output, `json_field` on empty input exits 4, and `pr_mergeable_resolved` takes its `return 2` probe-failure branch at :402 - the UNKNOWN retry loop, the attempt counter, and the &#34;persistent UNKNOWN stays unknown&#34; decision at :406-413 are never executed. `test_unknown_never_reported` therefore passes because empty gh output is silent, not because UNKNOWN is handled, leaving the intent-required &#34;never treat UNKNOWN as clean or conflicted&#34; behavior unproven (and the whole `pr_mergeable_resolved` path, including UNKNOWN -&gt; CONFLICTING resolution, untested). Fix: write the sequence as a single JSON array so `jq &#39;.[i]&#39;` resolves, and add a case where the retries settle on CONFLICTING.
- ⚠️ `bin/fm-pr-conflict-watch.sh:378` - `IFS=&#39;;&#39; read -r -a _parts &lt;&lt;&lt; &#34;$REPORTED_KEYS&#34;` followed by `for part in &#34;${_parts[@]}&#34;` expands a declared-but-empty array under `set -u` (:29). On bash before 4.4 (including macOS&#39;s system bash 3.2, which this repo supports elsewhere - see the gtimeout/shasum-first fallbacks in bin/fm-timeout-lib.sh and bin/fm-check-lib.sh) that is an &#34;unbound variable&#34; fatal error and the non-interactive shell exits, so the check dies before printing or recording anything. Reachable on the most common path: a clean fleet on the first run has REPORTED_KEYS empty, a MERGEABLE PR calls `record_remove_key` (:449), and the array is empty. Same pattern at :282 in `owner_for_project` when a secondmate&#39;s `projects:` field is empty. The repo already uses the guard idiom for exactly this (`&#34;${arr[@]+\&#34;${arr[@]}\&#34;}&#34;` in bin/fm-pr-merge.sh:254, bin/fm-test-run.sh:664); apply it here or return early when the source string is empty.
- ℹ️ `bin/fm-pr-conflict-watch.sh:366` - REPORTED_KEYS only ever shrinks when an open PR is observed MERGEABLE (:449). Keys for PRs that are merged, closed, or drop out of the PR_LIMIT window are never removed, and keys for repos the sweep no longer visits persist forever, so `state/.pr-conflict-watch` grows without bound (~60 bytes per conflicted head, forever). Unlike the sibling, whose record is the current finding set rebuilt each sweep, this record is accumulate-only. Consider dropping keys whose repo was fully evaluated and whose PR no longer appeared, or aging entries out via the recorded epoch.
- ℹ️ `bin/fm-pr-conflict-watch.sh:217` - `repo_slug` is a byte-for-byte copy of `repo_slug` in bin/fm-bearings-snapshot.sh:197-199, including the identical two-stage sed pipeline. Two independent copies of the same GitHub URL -&gt; owner/repo parser will drift (e.g. when GHES hosts or a new URL form need handling), and the repo&#39;s own convention for shared shape is a single owner (see the &#34;ONE OWNER&#34; headers in bin/fm-timeout-lib.sh and bin/fm-line-cap-lib.sh). Move it into a sourced lib - bin/fm-pr-lib.sh already owns provider/path parsing - and have both callers use it.
- ℹ️ `bin/fm-pr-conflict-watch.sh:295` - `owner_for_repo` is called once per repo inside the sweep loop, and each call re-runs `firstmate_repo_slug` (one git invocation) plus `resolve_project_repo` for every project until it matches (one git invocation each), re-deriving work `discover_repos` already did. For N projects that is O(N^2) git spawns per sweep, all charged against the same BUDGET_SECS the GitHub probes need, and none of it is bounded by `fm_run_timed`. Build the repo-&gt;owner map once while discovering repos and look it up, which also removes the second `firstmate_repo_slug` call site.
- ℹ️ `bin/fm-pr-conflict-watch.sh:455` - On the UNKNOWN path the dedupe key and the reported `head=` come from the `pr list` response, but the resolution re-reads the PR with `pr view` and already requests `headRefOid` (:401) without using it. If the head is force-updated between the list and the view, the mergeability that gets reported belongs to the new head while the wake line labels it with the old SHA, and the key is recorded against the old head - a wrong `head=` value routed to the owning team, with no error. Use the view&#39;s `headRefOid` when the view is what resolved the state.
- ℹ️ `docs/configuration.md:422` - The new configuration section is thorough and does document what this does NOT solve, but the repo&#39;s two maintained inventories were not updated for the new artifacts: AGENTS.md&#39;s state/ catalog has a line for the sibling (`tool-updates.check.sh ... its report record .tool-updates ...` at AGENTS.md:113) and needs the equivalent for `pr-conflict-watch.check.sh`, its `.check-trust` binding, and the `.pr-conflict-watch` record; docs/scripts.md&#39;s bin/ table has a row for `fm-tool-update-check.sh` (docs/scripts.md:111) and none for `fm-pr-conflict-watch.sh`.

🔧 Fix: fix PR conflict watch cap suppression, budget overrun, record pruning
5 infos still open:

- ℹ️ `bin/fm-pr-conflict-watch.sh:639` - `SWEPT_REPOS` only gains a repo when `count &lt; PR_LIMIT`, so pruning is disabled entirely for any repo whose open-PR page filled the limit, and `record_prune` then keeps every one of that repo&#39;s keys (the repo is still in DISCOVERED_REPOS, so the else branch preserves them). Concrete: a repo with 30+ open PRs (default FM_PR_CONFLICT_PR_LIMIT=30); PR #5 conflicts at head A -&gt; key `owner/repo#5#A` recorded; the author force-pushes, it conflicts again at head B -&gt; key `#5#B` recorded; A is never removed, and every subsequent force-push adds another permanent key. `state/.pr-conflict-watch` grows one line-entry per historical head forever, which contradicts the claim the fix round added at bin/fm-pr-conflict-watch.sh:24-25 (&#34;cannot grow without bound&#34;) and docs/configuration.md:445 (&#34;stays the size of the live conflict set&#34;). The conservative gate is right for *absence*-based pruning, but a per-number rule is safe even on a truncated page: for any repo+number the page did return, a recorded key with the same repo+number and a different head is definitionally stale (a PR has exactly one head), so those can be dropped regardless of whether the page was complete.
- ℹ️ `bin/fm-pr-conflict-watch.sh:508` - When `discover_repos` resolves no repositories, the `for repo in $DISCOVERED_REPOS` loop body never runs, so `SWEEP_COMPLETE` stays 1 while `SWEPT_REPOS` and `SEEN_KEYS` are both empty. `record_prune` then sends every recorded key down the else branch, finds its repo absent from the empty `DISCOVERED_REPOS`, and drops it - the whole dedupe record is wiped and rewritten as `reported=`. The next sweep re-wakes every still-conflicted PR in the fleet, contradicting the intent&#39;s &#34;the same conflict wakes once&#34;. Reachable whenever discovery fails wholesale rather than per repo: `action_check` probes only `jq` (:647) and `$GH_AXI` (:650), not `git`, so a watcher PATH without `git` makes `firstmate_repo_slug` and every `resolve_project_repo` return 1; likewise if `$PROJECTS` is transiently unavailable (stale mount, home being relocated). An unread fleet is not a resolved fleet - gate the DISCOVERED_REPOS-based drop on `[ -n &#34;$DISCOVERED_REPOS&#34; ]`, or set `SWEEP_COMPLETE=0` when discovery yields nothing.
- ℹ️ `tests/fm-pr-conflict-watch.test.sh:324` - `test_unknown_rereads_stop_at_the_sweep_deadline` sets FM_PR_CONFLICT_BUDGET_SECS=1, but `DEADLINE` is computed at bin/fm-pr-conflict-watch.sh:661 *before* `discover_repos` runs, and `discover_repos` spawns several unbounded `git remote get-url` calls plus two file reads. If that takes over one second (plausible on a loaded CI box), `budget_exhausted` fires at the top of the repo loop, `evaluate_repo` is never entered, the reread loop is never reached, and the test&#39;s only assertions - `elapsed &lt; 15` and empty output - both hold even if the entire deadline guard were reverted. Unlike `test_unknown_never_reported`, which pins behaviour with the fake&#39;s `.seq` cursor, this test has no evidence the loop was entered at all. Use `write_view_sequence` here too and assert the cursor advanced but stayed below FM_PR_CONFLICT_UNKNOWN_ATTEMPTS=10, so the test proves the loop ran and was cut short by the deadline rather than never running.
- ℹ️ `bin/fm-pr-conflict-watch.sh:472` - `record_remove_key` is called for every MERGEABLE PR (:629) and unconditionally runs `while ... done &lt; &lt;(list_parts &#34;$REPORTED_KEYS&#34; &#39;;&#39;)`, which forks a subshell even when `REPORTED_KEYS` is empty - the normal state of a clean fleet. With the default PR_LIMIT=30 across a multi-repo fleet that is one wasted fork per open PR on every sweep, charged against the same `BUDGET_SECS` the GitHub probes need and inside the deadline the fix round just tightened. `record_has_key &#34;$key&#34; || return 0` at the top makes the no-op case free and leaves behaviour identical.
- ℹ️ `bin/fm-pr-conflict-watch.sh:302` - `DEADLINE` is set at :661 and `discover_repos` runs after it, but the `git -C &#34;$dir&#34; remote get-url origin` call it makes per project (and the one in `firstmate_repo_slug`, :289) is the only external command in the sweep not wrapped in `fm_run_timed`, and there is no `budget_exhausted` check between projects. The fix round&#39;s own rationale for bounding the UNKNOWN loop applies identically here: this check prints and records only at the very end (:699-702), so a discovery phase that stalls past FM_CHECK_TIMEOUT gets the process group killed and the sweep loses everything, repeating identically on every poll. A clone on a hung or stale mount is enough. The script already sources bin/fm-timeout-lib.sh, so wrapping the two origin reads in `fm_run_timed &#34;$(probe_bound)&#34;` (and breaking discovery on `budget_exhausted`) closes it with no new machinery.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-pr-conflict-watch.test.sh` (12 fixture cases: newly conflicted wake with routing fields, same-head silence, new-head re-wake, persistent UNKNOWN never reported, UNKNOWN settling on CONFLICTING, reread-head labelling/dedupe, line-cap conflicts waking on a later sweep, record pruning, UNKNOWN rereads stopping at the sweep deadline, clean-fleet silence, draft conflicts, arm registration) - run twice to check for flakiness, all pass both times</code>
- <code>`bash tests/fm-bearings-snapshot.test.sh` (31 cases) - the other consumer of the newly extracted `bin/fm-repo-slug-lib.sh`, all pass</code>
- <code>Manual end-to-end: `/home/rich/.no-mistakes/evidence/01M0VCRA29HFS9SR262BP9YW00/pr-conflict-watch-e2e.sh` - arms the check in a throwaway FM_HOME, then runs the real `bin/fm-watch.sh` check sweep against a fake `gh-axi` over eight scenarios (clean fleet, three routed conflicts including a draft and the firstmate repo, same-head silence, force-updated head, UNKNOWN, resolved, disarm), draining each wake through `bin/fm-wake-drain.sh`</code>
- <code>`FM_STATE_OVERRIDE=&lt;home&gt;/state bin/fm-check-register.sh pr-conflict-watch` - verified the armed shim bytes against the trust binding</code>
</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/fm-test-portable-shards.md:76` - This change adds tests/fm-pr-conflict-watch.test.sh, which lands in the portable serial lane (it appears in portable-serial-2of4) with no duration hint, so it takes PORTABLE_SERIAL_DEFAULT_WEIGHT_MS. The doc&#39;s shard table still reads 29/28/30/30 scripts while the lanes now hold 30/32/32/32, and the doc&#39;s own rule says &#34;Refresh the hints whenever the serial lane gains scripts&#34;. I did not fix it: the table was already stale by eight scripts at the base commit (this change accounts for one of them), and a correct refresh needs measured per-script timings downloaded from a green CI run plus an edit to the portable_serial_weight_hints table in bin/fm-test-run.sh, which is executable code this documentation phase must not touch. Coverage is unaffected (the coverage guard keeps the partition complete and disjoint); only shard balance drifts. Worth a follow-up that runs the refresh procedure the doc already spells out.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
