### PR TITLE
fix(spawn): unset CLAUDE_CODE_CHILD_SESSION for all Claude launches

### DIFF
--- a/.agents/skills/bootstrap-diagnostics/SKILL.md
+++ b/.agents/skills/bootstrap-diagnostics/SKILL.md
@@ -18,7 +18,7 @@ When any diagnostic needs captain attention, report the plain consequence and re
 
 - `MISSING: <tool> (install: <command>)` - list the missing tools to the captain with a one-line purpose each plus the printed install commands, wait for consent (one approval may cover the list), then run `bin/fm-bootstrap.sh install <approved tools...>`.
   For `treehouse`, this also covers an installed version whose `treehouse get` lacks `--lease`; treat it as an upgrade request.
-  For `no-mistakes`, this also covers an installed version older than 1.31.2, because crewmate validation briefs delegate gate mechanics to no-mistakes' version-matched guidance.
+  For `no-mistakes`, this also covers an installed version older than 1.46.0, because crewmate validation briefs delegate gate mechanics to no-mistakes' version-matched guidance.
   For any axi-family tool - `gh-axi`, `lavish-axi`, `tasks-axi`, `quota-axi` - an installed version below its floor is a plain upgrade request; [`bin/fm-bootstrap.sh`](../../../bin/fm-bootstrap.sh) owns the floor policy, and never argue the floor down to whatever the home happens to have installed.
   For `tasks-axi`, this additionally covers an installed build that fails the separate feature probe (`bin/fm-tasks-axi-lib.sh` owns the definition); `config/backlog-backend=manual` only suppresses the verbose `BOOTSTRAP_INFO: tasks-axi available` fact, not this missing-tool report.
   For `quota-axi`, bootstrap requires it because firstmate reads its current output directly before resolving every crew-dispatch profile array; without it, report the missing requirement and do not choose around an unexamined candidate.

--- a/.agents/skills/bootstrap-diagnostics/SKILL.md
+++ b/.agents/skills/bootstrap-diagnostics/SKILL.md
@@ -18,7 +18,7 @@ When any diagnostic needs captain attention, report the plain consequence and re
 
 - `MISSING: <tool> (install: <command>)` - list the missing tools to the captain with a one-line purpose each plus the printed install commands, wait for consent (one approval may cover the list), then run `bin/fm-bootstrap.sh install <approved tools...>`.
   For `treehouse`, this also covers an installed version whose `treehouse get` lacks `--lease`; treat it as an upgrade request.
-  For `no-mistakes`, this also covers an installed version older than 1.46.0, because crewmate validation briefs delegate gate mechanics to no-mistakes' version-matched guidance.
+  For `no-mistakes`, this also covers an installed version older than 1.57.0, because crewmate validation briefs delegate gate mechanics to no-mistakes' version-matched guidance.
   For any axi-family tool - `gh-axi`, `lavish-axi`, `tasks-axi`, `quota-axi` - an installed version below its floor is a plain upgrade request; [`bin/fm-bootstrap.sh`](../../../bin/fm-bootstrap.sh) owns the floor policy, and never argue the floor down to whatever the home happens to have installed.
   For `tasks-axi`, this additionally covers an installed build that fails the separate feature probe (`bin/fm-tasks-axi-lib.sh` owns the definition); `config/backlog-backend=manual` only suppresses the verbose `BOOTSTRAP_INFO: tasks-axi available` fact, not this missing-tool report.
   For `quota-axi`, bootstrap requires it because firstmate reads its current output directly before resolving every crew-dispatch profile array; without it, report the missing requirement and do not choose around an unexamined candidate.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ GitHub Actions and Dependabot are exempt so their automation keeps working, but 
 
 1. Fork the repo, then clone the parent repo or set your local `origin` back to the parent (`git@github.com:kunchenguid/firstmate.git`).
 2. Create a branch and make your changes.
-3. Initialize the gate with your fork as the push target: `no-mistakes init --fork-url git@github.com:<you>/firstmate.git` (firstmate expects **no-mistakes v1.31.2+**; without a fork, plain `no-mistakes init` still works for maintainers with push access).
+3. Initialize the gate with your fork as the push target: `no-mistakes init --fork-url git@github.com:<you>/firstmate.git` (firstmate expects **no-mistakes v1.46.0+**; without a fork, plain `no-mistakes init` still works for maintainers with push access).
 4. Commit your changes.
 5. Push through the gate instead of pushing to `origin`:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ GitHub Actions and Dependabot are exempt so their automation keeps working, but 
 
 1. Fork the repo, then clone the parent repo or set your local `origin` back to the parent (`git@github.com:kunchenguid/firstmate.git`).
 2. Create a branch and make your changes.
-3. Initialize the gate with your fork as the push target: `no-mistakes init --fork-url git@github.com:<you>/firstmate.git` (firstmate expects **no-mistakes v1.46.0+**; without a fork, plain `no-mistakes init` still works for maintainers with push access).
+3. Initialize the gate with your fork as the push target: `no-mistakes init --fork-url git@github.com:<you>/firstmate.git` (firstmate expects **no-mistakes v1.57.0+**; without a fork, plain `no-mistakes init` still works for maintainers with push access).
 4. Commit your changes.
 5. Push through the gate instead of pushing to `origin`:
 

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -51,7 +51,7 @@
 #          treehouse is also MISSING when its installed version lacks
 #          "treehouse get --lease" support.
 #          no-mistakes is also MISSING when its installed version is older than
-#          1.31.2.
+#          1.46.0.
 #          The AXI-family floor policy is owned beside GH_AXI_MIN and
 #          LAVISH_AXI_MIN below; the per-tool owners point there. An installed
 #          build below its floor reports MISSING like no-mistakes, so the operator
@@ -872,7 +872,7 @@ if ! BACKEND_TOOLS=$(fm_backend_required_tools "$BACKEND"); then
   BACKEND_TOOLS=""
 fi
 TOOLS="$BACKEND_TOOLS $COMMON_TOOLS"
-NO_MISTAKES_MIN=1.31.2
+NO_MISTAKES_MIN=1.46.0
 # AXI-FAMILY FLOOR POLICY. Every axi-family floor is the CURRENT LATEST published
 # version of that tool, captain-bumped periodically to keep the whole fleet on the
 # newest axi tools. It is NOT the minimum feature-introduced version. These floors

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -51,7 +51,7 @@
 #          treehouse is also MISSING when its installed version lacks
 #          "treehouse get --lease" support.
 #          no-mistakes is also MISSING when its installed version is older than
-#          1.46.0.
+#          1.57.0.
 #          The AXI-family floor policy is owned beside GH_AXI_MIN and
 #          LAVISH_AXI_MIN below; the per-tool owners point there. An installed
 #          build below its floor reports MISSING like no-mistakes, so the operator
@@ -872,7 +872,7 @@ if ! BACKEND_TOOLS=$(fm_backend_required_tools "$BACKEND"); then
   BACKEND_TOOLS=""
 fi
 TOOLS="$BACKEND_TOOLS $COMMON_TOOLS"
-NO_MISTAKES_MIN=1.46.0
+NO_MISTAKES_MIN=1.57.0
 # AXI-FAMILY FLOOR POLICY. Every axi-family floor is the CURRENT LATEST published
 # version of that tool, captain-bumped periodically to keep the whole fleet on the
 # newest axi tools. It is NOT the minimum feature-introduced version. These floors

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2743,7 +2743,12 @@ case "$HARNESS" in
 esac
 LAUNCH=${LAUNCH//__WORKTREE__/$sq_worktree}
 case "$HARNESS" in
-  claude|codex|opencode|pi|pi-signed|grok|kimi|muse)
+  claude)
+    # Claude disables transcript saving when it inherits this Herdr child-session
+    # marker, so remove it at the same per-launch environment boundary.
+    LAUNCH="env -u CLAUDE_CODE_CHILD_SESSION -u CURSOR_AGENT -u CURSOR_INVOKED_AS $LAUNCH"
+    ;;
+  codex|opencode|pi|pi-signed|grok|kimi|muse)
     LAUNCH="env -u CURSOR_AGENT -u CURSOR_INVOKED_AS $LAUNCH"
     ;;
 esac

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -318,7 +318,7 @@ Secondmate homes inherit this file from the primary, so a secondmate's own crewm
 On session start the first mate detects what its required toolchain is missing or too old and lists each problem with either an exact install command or manual instructions.
 It installs automatically supported tools only after you say go; manual-only tools remain for you to install from the printed instructions.
 Required tools come in two parts: a universal toolchain every home needs regardless of backend, and a per-backend delta that follows the runtime backend actually resolved for this home.
-The universal toolchain is node, git, gh with GitHub auth via `gh auth login`, no-mistakes v1.31.2 or newer, compatible gh-axi, chrome-devtools-axi, compatible lavish-axi, compatible tasks-axi per "Backlog backend" above, and compatible quota-axi.
+The universal toolchain is node, git, gh with GitHub auth via `gh auth login`, no-mistakes v1.46.0 or newer, compatible gh-axi, chrome-devtools-axi, compatible lavish-axi, compatible tasks-axi per "Backlog backend" above, and compatible quota-axi.
 [`bin/fm-bootstrap.sh`](../bin/fm-bootstrap.sh) owns the axi-family floor policy and the gh-axi and lavish-axi floors, while [`bin/fm-tasks-axi-lib.sh`](../bin/fm-tasks-axi-lib.sh) and [`bin/fm-quota-axi-lib.sh`](../bin/fm-quota-axi-lib.sh) hold their own tools' floor constants.
 This section is the single owner of that universal toolchain list; backend guides' prerequisites point here and add only their backend-specific tools.
 In that list, no-mistakes runs the validation pipeline, gh-axi, chrome-devtools-axi, and lavish-axi cover GitHub, browser, and rich-review operations, and tasks-axi plus quota-axi back backlog mutations and quota-aware array dispatch.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -318,7 +318,7 @@ Secondmate homes inherit this file from the primary, so a secondmate's own crewm
 On session start the first mate detects what its required toolchain is missing or too old and lists each problem with either an exact install command or manual instructions.
 It installs automatically supported tools only after you say go; manual-only tools remain for you to install from the printed instructions.
 Required tools come in two parts: a universal toolchain every home needs regardless of backend, and a per-backend delta that follows the runtime backend actually resolved for this home.
-The universal toolchain is node, git, gh with GitHub auth via `gh auth login`, no-mistakes v1.46.0 or newer, compatible gh-axi, chrome-devtools-axi, compatible lavish-axi, compatible tasks-axi per "Backlog backend" above, and compatible quota-axi.
+The universal toolchain is node, git, gh with GitHub auth via `gh auth login`, no-mistakes v1.57.0 or newer, compatible gh-axi, chrome-devtools-axi, compatible lavish-axi, compatible tasks-axi per "Backlog backend" above, and compatible quota-axi.
 [`bin/fm-bootstrap.sh`](../bin/fm-bootstrap.sh) owns the axi-family floor policy and the gh-axi and lavish-axi floors, while [`bin/fm-tasks-axi-lib.sh`](../bin/fm-tasks-axi-lib.sh) and [`bin/fm-quota-axi-lib.sh`](../bin/fm-quota-axi-lib.sh) hold their own tools' floor constants.
 This section is the single owner of that universal toolchain list; backend guides' prerequisites point here and add only their backend-specific tools.
 In that list, no-mistakes runs the validation pipeline, gh-axi, chrome-devtools-axi, and lavish-axi cover GitHub, browser, and rich-review operations, and tasks-axi plus quota-axi back backlog mutations and quota-aware array dispatch.

--- a/tests/fm-bootstrap-network-parallel.test.sh
+++ b/tests/fm-bootstrap-network-parallel.test.sh
@@ -73,6 +73,12 @@ case "$command_name" in
 esac
 if [ "$slow" -eq 1 ]; then
   printf 'START %s %s %s\n' "$host" "$command_name" "$subcommand" >> "$log"
+  : > "$FM_FAKE_OVERLAP_DIR/remote-active"
+  overlap_wait=0
+  while [ ! -e "$FM_FAKE_OVERLAP_DIR/fleet-active" ] && [ "$overlap_wait" -lt 80 ]; do
+    sleep 0.05
+    overlap_wait=$((overlap_wait + 1))
+  done
   sleep "$sleep_s"
   printf 'END %s %s %s\n' "$host" "$command_name" "$subcommand" >> "$log"
 else
@@ -137,6 +143,12 @@ for arg in "\$@"; do
 done
 if [ "\$slow" -eq 1 ]; then
   printf 'START fleet-fetch git fetch\n' >> '$log'
+  : > "\$FM_FAKE_OVERLAP_DIR/fleet-active"
+  overlap_wait=0
+  while [ ! -e "\$FM_FAKE_OVERLAP_DIR/remote-active" ] && [ "\$overlap_wait" -lt 80 ]; do
+    sleep 0.05
+    overlap_wait=\$((overlap_wait + 1))
+  done
   sleep "\${FM_FAKE_GIT_FETCH_SLEEP:-0.4}"
   printf 'END fleet-fetch git fetch\n' >> '$log'
 fi
@@ -174,6 +186,7 @@ test_remote_probe_scheduling_keeps_per_mate_lines() { # <parallel|fallback>
   fm_fake_exit0 "$fakebin" gh treehouse tmux node
   log="$dir/probe.log"
   : > "$log"
+  mkdir -p "$dir/overlap"
   install_fake_ssh "$fakebin"
   install_slow_git "$fakebin" "$REAL_GIT" "$log"
   if [ "$mode" = fallback ]; then
@@ -215,6 +228,7 @@ SH
     FM_BOOTSTRAP_NETWORK=only \
     FM_SSH_BIN="$fakebin/fake-ssh" \
     FM_FAKE_SSH_LOG="$log" \
+    FM_FAKE_OVERLAP_DIR="$dir/overlap" \
     FM_FAKE_SSH_SLEEP=0.4 \
     FM_FAKE_SSH_UNREACHABLE_HOST=host-bravo \
     FM_FAKE_SSH_FAIL_HOST=host-alpha \

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -79,7 +79,7 @@ SH
   cat > "$fakebin/no-mistakes" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = --version ]; then
-  printf '%s\n' "${FM_FAKE_NO_MISTAKES_VERSION:-no-mistakes version v1.31.2 (fake) 2026-06-27T00:02:18Z}"
+  printf '%s\n' "${FM_FAKE_NO_MISTAKES_VERSION:-no-mistakes version v1.46.0 (fake) 2026-06-27T00:02:18Z}"
   exit 0
 fi
 exit 0
@@ -332,10 +332,10 @@ test_no_mistakes_min_version() {
         [ "$out" = "$missing" ] || fail "$label: expected '$missing', got: $out" ;;
     esac
   done <<'ROWS'
-minimum no-mistakes version is accepted^no-mistakes version v1.31.2 (fake)^empty
-newer no-mistakes minor is accepted^no-mistakes version v1.32.0 (fake)^empty
+minimum no-mistakes version is accepted^no-mistakes version v1.46.0 (fake)^empty
+newer no-mistakes minor is accepted^no-mistakes version v1.47.0 (fake)^empty
 newer no-mistakes major is accepted^no-mistakes version v2.0.0 (fake)^empty
-older no-mistakes patch reports an upgrade^no-mistakes version v1.31.1 (fake)^missing
+older no-mistakes patch reports an upgrade^no-mistakes version v1.45.9 (fake)^missing
 unparseable no-mistakes version reports an upgrade^no-mistakes development build^missing
 ROWS
   pass "bootstrap enforces no-mistakes minimum version"

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -79,7 +79,7 @@ SH
   cat > "$fakebin/no-mistakes" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = --version ]; then
-  printf '%s\n' "${FM_FAKE_NO_MISTAKES_VERSION:-no-mistakes version v1.46.0 (fake) 2026-06-27T00:02:18Z}"
+  printf '%s\n' "${FM_FAKE_NO_MISTAKES_VERSION:-no-mistakes version v1.57.0 (fake) 2026-06-27T00:02:18Z}"
   exit 0
 fi
 exit 0
@@ -332,11 +332,11 @@ test_no_mistakes_min_version() {
         [ "$out" = "$missing" ] || fail "$label: expected '$missing', got: $out" ;;
     esac
   done <<'ROWS'
-minimum no-mistakes version is accepted^no-mistakes version v1.46.0 (fake)^empty
-newer no-mistakes minor is accepted^no-mistakes version v1.47.0 (fake)^empty
+minimum no-mistakes version is accepted^no-mistakes version v1.57.0 (fake)^empty
+newer no-mistakes minor is accepted^no-mistakes version v1.58.0 (fake)^empty
 newer no-mistakes major is accepted^no-mistakes version v2.0.0 (fake)^empty
 pre-attestation no-mistakes reports an upgrade^no-mistakes version v1.37.0 (fake)^missing
-older no-mistakes patch reports an upgrade^no-mistakes version v1.45.9 (fake)^missing
+older no-mistakes patch reports an upgrade^no-mistakes version v1.56.9 (fake)^missing
 unparseable no-mistakes version reports an upgrade^no-mistakes development build^missing
 ROWS
   pass "bootstrap enforces no-mistakes minimum version"

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -335,6 +335,7 @@ test_no_mistakes_min_version() {
 minimum no-mistakes version is accepted^no-mistakes version v1.46.0 (fake)^empty
 newer no-mistakes minor is accepted^no-mistakes version v1.47.0 (fake)^empty
 newer no-mistakes major is accepted^no-mistakes version v2.0.0 (fake)^empty
+pre-attestation no-mistakes reports an upgrade^no-mistakes version v1.37.0 (fake)^missing
 older no-mistakes patch reports an upgrade^no-mistakes version v1.45.9 (fake)^missing
 unparseable no-mistakes version reports an upgrade^no-mistakes development build^missing
 ROWS

--- a/tests/fm-bootstrap.test.sh
+++ b/tests/fm-bootstrap.test.sh
@@ -336,6 +336,7 @@ minimum no-mistakes version is accepted^no-mistakes version v1.57.0 (fake)^empty
 newer no-mistakes minor is accepted^no-mistakes version v1.58.0 (fake)^empty
 newer no-mistakes major is accepted^no-mistakes version v2.0.0 (fake)^empty
 pre-attestation no-mistakes reports an upgrade^no-mistakes version v1.37.0 (fake)^missing
+last pre-attestation no-mistakes reports an upgrade^no-mistakes version v1.45.9 (fake)^missing
 older no-mistakes patch reports an upgrade^no-mistakes version v1.56.9 (fake)^missing
 unparseable no-mistakes version reports an upgrade^no-mistakes development build^missing
 ROWS

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -1817,7 +1817,19 @@ TS
       fail "Pi follow-up $label case did not process the monitoring notification"
     fi
 
-    pane=$(tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" -S - 2>/dev/null || true)
+    # Persistence can complete just before Pi reconciles its current surface.
+    # Wait for that bounded UI transition and ignore redraw artifacts retained
+    # in tmux scrollback while the two completed turns settle.
+    i=0
+    while [ "$i" -lt 120 ]; do
+      pane=$(tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" 2>/dev/null || true)
+      if [ "$(printf '%s\n' "$pane" | grep -Fc "CAPTAIN_ANSWER_$label" || true)" -eq 1 ] \
+         && printf '%s\n' "$pane" | grep -Fq "MONITOR_HANDLED_${label}_ONE"; then
+        break
+      fi
+      sleep 0.05
+      i=$((i + 1))
+    done
     [ "$(printf '%s\n' "$pane" | grep -Fc "CAPTAIN_ANSWER_$label" || true)" -eq 1 ] \
       || fail "Pi follow-up $label case rendered a duplicate captain answer"
     assert_contains "$pane" "CAPTAIN_PROMPT_$label" "Pi follow-up $label case hid the genuine captain prompt"

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -1088,7 +1088,7 @@ SH
   cat > "$fakebin/no-mistakes" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = --version ]; then
-  printf '%s\n' 'no-mistakes version v1.31.2 (fake)'
+  printf '%s\n' 'no-mistakes version v1.46.0 (fake)'
   exit 0
 fi
 exit 0

--- a/tests/fm-secondmate-harness.test.sh
+++ b/tests/fm-secondmate-harness.test.sh
@@ -1088,7 +1088,7 @@ SH
   cat > "$fakebin/no-mistakes" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = --version ]; then
-  printf '%s\n' 'no-mistakes version v1.46.0 (fake)'
+  printf '%s\n' 'no-mistakes version v1.57.0 (fake)'
   exit 0
 fi
 exit 0

--- a/tests/fm-secondmate-liveness.test.sh
+++ b/tests/fm-secondmate-liveness.test.sh
@@ -233,7 +233,7 @@ SH
   cat > "$fakebin/no-mistakes" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = --version ]; then
-  printf '%s\n' 'no-mistakes version v1.31.2 (fake)'
+  printf '%s\n' 'no-mistakes version v1.46.0 (fake)'
   exit 0
 fi
 exit 0

--- a/tests/fm-secondmate-liveness.test.sh
+++ b/tests/fm-secondmate-liveness.test.sh
@@ -233,7 +233,7 @@ SH
   cat > "$fakebin/no-mistakes" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = --version ]; then
-  printf '%s\n' 'no-mistakes version v1.46.0 (fake)'
+  printf '%s\n' 'no-mistakes version v1.57.0 (fake)'
   exit 0
 fi
 exit 0

--- a/tests/fm-secondmate-sync.test.sh
+++ b/tests/fm-secondmate-sync.test.sh
@@ -359,7 +359,7 @@ SH
   cat > "$fakebin/no-mistakes" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = --version ]; then
-  printf '%s\n' 'no-mistakes version v1.31.2 (fake)'
+  printf '%s\n' 'no-mistakes version v1.46.0 (fake)'
   exit 0
 fi
 exit 0

--- a/tests/fm-secondmate-sync.test.sh
+++ b/tests/fm-secondmate-sync.test.sh
@@ -359,7 +359,7 @@ SH
   cat > "$fakebin/no-mistakes" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = --version ]; then
-  printf '%s\n' 'no-mistakes version v1.46.0 (fake)'
+  printf '%s\n' 'no-mistakes version v1.57.0 (fake)'
   exit 0
 fi
 exit 0

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -99,7 +99,7 @@ SH
   cat > "$fakebin/no-mistakes" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = --version ]; then
-  printf '%s\n' 'no-mistakes version v1.31.2 (fake) 2026-06-27T00:02:18Z'
+  printf '%s\n' 'no-mistakes version v1.46.0 (fake) 2026-06-27T00:02:18Z'
   exit 0
 fi
 exit 0

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -99,7 +99,7 @@ SH
   cat > "$fakebin/no-mistakes" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = --version ]; then
-  printf '%s\n' 'no-mistakes version v1.46.0 (fake) 2026-06-27T00:02:18Z'
+  printf '%s\n' 'no-mistakes version v1.57.0 (fake) 2026-06-27T00:02:18Z'
   exit 0
 fi
 exit 0

--- a/tests/fm-shared-captain-inheritance.test.sh
+++ b/tests/fm-shared-captain-inheritance.test.sh
@@ -232,7 +232,7 @@ SH
   cat > "$fakebin/no-mistakes" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = --version ]; then
-  printf '%s\n' 'no-mistakes version v1.31.2 (fake)'
+  printf '%s\n' 'no-mistakes version v1.46.0 (fake)'
   exit 0
 fi
 exit 0

--- a/tests/fm-shared-captain-inheritance.test.sh
+++ b/tests/fm-shared-captain-inheritance.test.sh
@@ -232,7 +232,7 @@ SH
   cat > "$fakebin/no-mistakes" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = --version ]; then
-  printf '%s\n' 'no-mistakes version v1.46.0 (fake)'
+  printf '%s\n' 'no-mistakes version v1.57.0 (fake)'
   exit 0
 fi
 exit 0

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -165,7 +165,7 @@ test_no_profile_keeps_claude_profile_defaults() {
   assert_meta_profile "$HOME_DIR/state/$id.meta" claude default default
 
   launch=$(cat "$LAUNCH_LOG")
-  expected="env -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/brief.md')\""
+  expected="env -u CLAUDE_CODE_CHILD_SESSION -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \"\$('${ROOT}/bin/fm-operational-input.sh' encode launch-brief < '$HOME_DIR/data/$id/brief.md')\""
   [ "$launch" = "$expected" ] || fail "no-profile claude launch did not use the canonical launch kind"$'\n'"expected: $expected"$'\n'"actual:   $launch"
   pass "no --model/--effort records defaults and types the claude launch instructions"
 }
@@ -181,9 +181,50 @@ test_non_cursor_launch_clears_inherited_cursor_markers() {
   status=$?
   expect_code 0 "$status" "claude spawn under Cursor markers should succeed"
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "env -u CURSOR_AGENT -u CURSOR_INVOKED_AS" \
+  assert_contains "$launch" "-u CURSOR_AGENT -u CURSOR_INVOKED_AS" \
     "non-cursor launch must clear both inherited Cursor identity markers"
   pass "non-cursor launches clear inherited Cursor identity markers"
+}
+
+test_claude_launches_clear_inherited_child_session_marker() {
+  local rec crew_id secondmate_id codex_id sm out status launch
+  crew_id=profile-claude-child-session-crew-z1c
+  secondmate_id=profile-claude-child-session-secondmate-z1d
+  codex_id=profile-claude-child-session-codex-z1e
+  rec=$(make_spawn_case profile-claude-child-session claude \
+    "$crew_id" "$secondmate_id" "$codex_id")
+  read_case_record "$rec"
+
+  out=$(CLAUDE_CODE_CHILD_SESSION=1 \
+    run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+      "$crew_id" "$PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "Claude crewmate spawn under a child-session marker should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "env -u CLAUDE_CODE_CHILD_SESSION" \
+    "Claude crewmate launch must clear the inherited child-session marker"
+
+  printf '%s\n' claude > "$HOME_DIR/config/secondmate-harness"
+  sm="$CASE_DIR/secondmate-home"
+  make_seeded_secondmate_home "$sm" "$secondmate_id"
+  out=$(CLAUDE_CODE_CHILD_SESSION=1 \
+    run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+      "$secondmate_id" "$sm" --secondmate)
+  status=$?
+  expect_code 0 "$status" "Claude secondmate spawn under a child-session marker should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "env -u CLAUDE_CODE_CHILD_SESSION" \
+    "Claude secondmate launch must clear the inherited child-session marker"
+
+  out=$(CLAUDE_CODE_CHILD_SESSION=1 \
+    run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+      "$codex_id" "$PROJ_DIR" --harness codex)
+  status=$?
+  expect_code 0 "$status" "Codex spawn under a Claude child-session marker should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_not_contains "$launch" "CLAUDE_CODE_CHILD_SESSION" \
+    "non-Claude launch must not receive the Claude-specific child-session scrub"
+  pass "Claude crewmate and secondmate launches clear the inherited child-session marker only for Claude"
 }
 
 test_relative_home_overrides_launch_with_absolute_cross_process_paths() {
@@ -770,7 +811,7 @@ test_claude_forwards_firstmate_config_dir_when_set() {
   status=$?
   expect_code 0 "$status" "claude spawn with CLAUDE_CONFIG_DIR set should succeed"
   launch=$(cat "$LAUNCH_LOG")
-  assert_contains "$launch" "CLAUDE_CONFIG_DIR='/opt/test/claude-work' env -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude" \
+  assert_contains "$launch" "CLAUDE_CONFIG_DIR='/opt/test/claude-work' env -u CLAUDE_CODE_CHILD_SESSION -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude" \
     "claude launch did not forward firstmate's CLAUDE_CONFIG_DIR to the crewmate pane"
   pass "claude forwards firstmate's CLAUDE_CONFIG_DIR so the crewmate uses the same credential store"
 }
@@ -828,6 +869,7 @@ test_active_dispatch_profile_does_not_block_secondmate_launch() {
 
 test_no_profile_keeps_claude_profile_defaults
 test_non_cursor_launch_clears_inherited_cursor_markers
+test_claude_launches_clear_inherited_child_session_marker
 test_relative_home_overrides_launch_with_absolute_cross_process_paths
 test_home_defaults_preserve_absolute_or_resolve_relative_paths
 test_absolute_override_spelling_is_preserved_in_launch_paths

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -187,12 +187,13 @@ test_non_cursor_launch_clears_inherited_cursor_markers() {
 }
 
 test_claude_launches_clear_inherited_child_session_marker() {
-  local rec crew_id secondmate_id codex_id sm out status launch
+  local rec crew_id scout_id secondmate_id codex_id sm out status launch
   crew_id=profile-claude-child-session-crew-z1c
-  secondmate_id=profile-claude-child-session-secondmate-z1d
-  codex_id=profile-claude-child-session-codex-z1e
+  scout_id=profile-claude-child-session-scout-z1d
+  secondmate_id=profile-claude-child-session-secondmate-z1e
+  codex_id=profile-claude-child-session-codex-z1f
   rec=$(make_spawn_case profile-claude-child-session claude \
-    "$crew_id" "$secondmate_id" "$codex_id")
+    "$crew_id" "$scout_id" "$secondmate_id" "$codex_id")
   read_case_record "$rec"
 
   out=$(CLAUDE_CODE_CHILD_SESSION=1 \
@@ -203,6 +204,15 @@ test_claude_launches_clear_inherited_child_session_marker() {
   launch=$(cat "$LAUNCH_LOG")
   assert_contains "$launch" "env -u CLAUDE_CODE_CHILD_SESSION" \
     "Claude crewmate launch must clear the inherited child-session marker"
+
+  out=$(CLAUDE_CODE_CHILD_SESSION=1 \
+    run_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" \
+      "$scout_id" "$PROJ_DIR" --scout)
+  status=$?
+  expect_code 0 "$status" "Claude scout spawn under a child-session marker should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "env -u CLAUDE_CODE_CHILD_SESSION" \
+    "Claude scout launch must clear the inherited child-session marker"
 
   printf '%s\n' claude > "$HOME_DIR/config/secondmate-harness"
   sm="$CASE_DIR/secondmate-home"
@@ -224,7 +234,7 @@ test_claude_launches_clear_inherited_child_session_marker() {
   launch=$(cat "$LAUNCH_LOG")
   assert_not_contains "$launch" "CLAUDE_CODE_CHILD_SESSION" \
     "non-Claude launch must not receive the Claude-specific child-session scrub"
-  pass "Claude crewmate and secondmate launches clear the inherited child-session marker only for Claude"
+  pass "Claude crewmate, scout, and secondmate launches clear the inherited child-session marker only for Claude"
 }
 
 test_relative_home_overrides_launch_with_absolute_cross_process_paths() {

--- a/tests/fm-startup-memory-budget.test.sh
+++ b/tests/fm-startup-memory-budget.test.sh
@@ -44,7 +44,7 @@ SH
   cat > "$fakebin/no-mistakes" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = --version ]; then
-  printf '%s\n' 'no-mistakes version v1.31.2 (fake)'
+  printf '%s\n' 'no-mistakes version v1.46.0 (fake)'
 fi
 SH
   cat > "$fakebin/tasks-axi" <<'SH'

--- a/tests/fm-startup-memory-budget.test.sh
+++ b/tests/fm-startup-memory-budget.test.sh
@@ -44,7 +44,7 @@ SH
   cat > "$fakebin/no-mistakes" <<'SH'
 #!/usr/bin/env bash
 if [ "${1:-}" = --version ]; then
-  printf '%s\n' 'no-mistakes version v1.46.0 (fake)'
+  printf '%s\n' 'no-mistakes version v1.57.0 (fake)'
 fi
 SH
   cat > "$fakebin/tasks-axi" <<'SH'


### PR DESCRIPTION
## Intent

Extend bin/fm-spawn.sh so every verified Claude launch it constructs, for crewmates and scouts as well as --secondmate launches, unsets CLAUDE_CODE_CHILD_SESSION with env -u CLAUDE_CODE_CHILD_SESSION so Herdr child panes no longer disable transcript saving. Scope the change strictly to the claude harness with no behavior change for other harnesses. Do not scrub unrelated markers, including FM_PENDING_REPLY_EXISTING_CORR, and do not change the Main dotfiles launcher or relaunch running agents. Add colocated public-interface test coverage that captures the constructed launch command without a live Herdr spawn and proves both Claude worker kinds scrub the marker while a non-Claude launch does not. Keep bin/fm-spawn.sh shellcheck-clean and consistent with its existing launch environment handling. The broader fm-secondmate-harness crew-harness propagation failure was reproduced unchanged on the clean base and is pre-existing, so do not expand this task to fix it. The CI repair must also prevent pre-attestation no-mistakes clients from producing PR bodies that fail the repository's structured pipeline-attestation requirement, while preserving the repository policy that bootstrap tool floors track the latest stable release.

## What Changed

- Split the `claude` harness into its own launch case in `bin/fm-spawn.sh` that prepends `env -u CLAUDE_CODE_CHILD_SESSION -u CURSOR_AGENT -u CURSOR_INVOKED_AS`, so every Claude crewmate, scout, and secondmate pane drops the Herdr child-session marker that had disabled transcript saving; other harnesses keep the existing Cursor-only scrub.
- Raised the bootstrap `NO_MISTAKES_MIN` floor from 1.31.2 to 1.57.0 in `bin/fm-bootstrap.sh` and updated the matching references in `.agents/skills/bootstrap-diagnostics/SKILL.md`, `CONTRIBUTING.md`, and `docs/configuration.md`, so pre-attestation no-mistakes clients report as needing an upgrade.
- Added `test_claude_launches_clear_inherited_child_session_marker` to capture the constructed launch command for all three Claude worker kinds and confirm a Codex launch is untouched, refreshed the version fixtures and min-version rows across the bootstrap tests, and de-flaked the parallel remote-probe and Pi follow-up tests with bounded synchronization waits.

## Risk Assessment

✅ Low: The change is a tightly-scoped, additive env-scrub for the claude harness only, plus a consistent bootstrap floor bump and test-only CI synchronization fixes, all covered by behavior tests that capture the constructed launch command, with no source-verifiable intent contradiction or wrong-value path found.

## Testing

I first read the diff to understand the two parts of the change (Claude child-session scrub in fm-spawn.sh; no-mistakes floor bump to 1.57.0 in fm-bootstrap.sh) and confirmed the scope negatively: only those two source files change, FM_PENDING_REPLY_EXISTING_CORR is not touched, no dotfiles launcher is modified, and non-Claude harnesses keep their existing Cursor-only scrub. I ran the colocated public-interface test tests/fm-spawn-dispatch-profile.test.sh (whole file passes, including the new child-session test that captures the constructed launch command from the fake tmux send-keys sink with no live Herdr spawn) and the targeted bootstrap version-gate test test_no_mistakes_min_version (passes: current/newer versions accepted, pre-attestation v1.37.0 and older-patch v1.56.9 rejected). To show the behavior as an end user experiences it, I drove the real fm-spawn.sh and fm-bootstrap.sh through the test helpers and saved two CLI-transcript artifacts: the exact launch commands the Herdr pane would execute (crewmate, scout, and secondmate all begin with `env -u CLAUDE_CODE_CHILD_SESSION -u CURSOR_AGENT -u CURSOR_INVOKED_AS ... claude ...`, while the codex control has no CLAUDE_CODE_CHILD_SESSION), and the bootstrap stdout report (silent/accepted for 1.57.0 and 1.58.0, MISSING upgrade for the pre-attestation 1.37.0 and below-floor 1.56.9). There is no UI/renderer surface for this change - it is shell launch-string construction and a bootstrap CLI report - so the reviewer-visible artifacts are the captured command strings and CLI output, which are exactly the end-user surfaces; no screenshot applies. I did not run the fm-secondmate-harness crew-harness propagation test because the intent states that failure is pre-existing and reproduced unchanged on the clean base and is explicitly out of scope. I did not run linters/shellcheck per the phase rules (CI owns that). I removed all transient test/evidence-collection scripts; the worktree is clean (git status empty) and only the two evidence files remain in the evidence directory.

<details>
<summary>Evidence: Constructed launch commands per Claude worker kind + codex control (real fm-spawn.sh output)</summary>

Source: [Constructed launch commands per Claude worker kind + codex control (real fm-spawn.sh output)](https://github.com/jjames27th-eng/firstmate/blob/fa9e250e521cc91da239758b5c6275ddce2963f0/.no-mistakes/evidence/fm/extend-transcript-scrub-to-spawn/launch-commands.txt)

<code>Claude CREWMATE: env -u CLAUDE_CODE_CHILD_SESSION -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions ...&#10;Claude SCOUT (--scout): env -u CLAUDE_CODE_CHILD_SESSION -u CURSOR_AGENT -u CURSOR_INVOKED_AS ... claude ...&#10;Claude SECONDMATE (--secondmate): ...FM_SUPERVISION_MODEL=autoarm env -u CLAUDE_CODE_CHILD_SESSION -u CURSOR_AGENT -u CURSOR_INVOKED_AS ... claude ...&#10;Codex (--harness codex, control): env -u CURSOR_AGENT -u CURSOR_INVOKED_AS codex ... &lt;-- NO CLAUDE_CODE_CHILD_SESSION&#10;Verification: PASS crewmate/scout/secondmate scrub the marker; PASS codex does not receive the Claude-specific scrub</code>

```text
# Constructed launch commands captured from bin/fm-spawn.sh
# Environment injected: CLAUDE_CODE_CHILD_SESSION=1 (as a Herdr child pane would inherit)
# Captured from the fake tmux send-keys -l sink (no live Herdr spawn).

=== Claude CREWMATE launch (crew-harness=claude) ===
env -u CLAUDE_CODE_CHILD_SESSION -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions "$('/Users/james/.no-mistakes/worktrees/03f7a29d4e35/01M0VHSZRCJMN20J5DK9R03391/state/n/worktrees/55783a7fd2ac/01M0VVG7RPVH9ZX4YE8BPYE2RR/bin/fm-operational-input.sh' encode launch-brief < '/var/folders/k5/bgghp9854wz092fxzzx84skm0000gn/T//fm-spawn-dispatch-profile.0xI6pt/evid-child-session/home/data/evid-claude-crew/brief.md')"


=== Claude SCOUT launch (--scout) ===
env -u CLAUDE_CODE_CHILD_SESSION -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions "$('/Users/james/.no-mistakes/worktrees/03f7a29d4e35/01M0VHSZRCJMN20J5DK9R03391/state/n/worktrees/55783a7fd2ac/01M0VVG7RPVH9ZX4YE8BPYE2RR/bin/fm-operational-input.sh' encode launch-brief < '/var/folders/k5/bgghp9854wz092fxzzx84skm0000gn/T//fm-spawn-dispatch-profile.0xI6pt/evid-child-session/home/data/evid-claude-scout/brief.md')"


=== Claude SECONDMATE launch (--secondmate) ===
FM_ROOT_OVERRIDE= FM_STATE_OVERRIDE= FM_DATA_OVERRIDE= FM_PROJECTS_OVERRIDE= FM_CONFIG_OVERRIDE= FM_PUBLIC_FOLLOWUP_PRIMARY_HOME='/var/folders/k5/bgghp9854wz092fxzzx84skm0000gn/T//fm-spawn-dispatch-profile.0xI6pt/evid-child-session/home' FM_HOME='/private/var/folders/k5/bgghp9854wz092fxzzx84skm0000gn/T/fm-spawn-dispatch-profile.0xI6pt/evid-child-session/secondmate-home' FM_TRACE_CONTEXT=off FM_SUPERVISION_MODEL=autoarm env -u CLAUDE_CODE_CHILD_SESSION -u CURSOR_AGENT -u CURSOR_INVOKED_AS CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions "$('/Users/james/.no-mistakes/worktrees/03f7a29d4e35/01M0VHSZRCJMN20J5DK9R03391/state/n/worktrees/55783a7fd2ac/01M0VVG7RPVH9ZX4YE8BPYE2RR/bin/fm-operational-input.sh' encode launch-brief < '/private/var/folders/k5/bgghp9854wz092fxzzx84skm0000gn/T/fm-spawn-dispatch-profile.0xI6pt/evid-child-session/secondmate-home/data/charter.md')"


=== Codex launch (--harness codex, NON-Claude control) ===
env -u CURSOR_AGENT -u CURSOR_INVOKED_AS codex --dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch '/private/var/folders/k5/bgghp9854wz092fxzzx84skm0000gn/T/fm-spawn-dispatch-profile.0xI6pt/evid-child-session/home/state/evid-codex.turn-ended'\"]" "$('/Users/james/.no-mistakes/worktrees/03f7a29d4e35/01M0VHSZRCJMN20J5DK9R03391/state/n/worktrees/55783a7fd2ac/01M0VVG7RPVH9ZX4YE8BPYE2RR/bin/fm-operational-input.sh' encode launch-brief < '/var/folders/k5/bgghp9854wz092fxzzx84skm0000gn/T//fm-spawn-dispatch-profile.0xI6pt/evid-child-session/home/data/evid-codex/brief.md')"


--- Verification ---
PASS  Claude CREWMATE   scrubs CLAUDE_CODE_CHILD_SESSION
PASS  Claude SCOUT      scrubs CLAUDE_CODE_CHILD_SESSION
PASS  Claude SECONDMATE scrubs CLAUDE_CODE_CHILD_SESSION
PASS  Codex (non-Claude) does NOT receive the Claude-specific scrub
```
</details>
<details>
<summary>Evidence: Bootstrap toolchain report by no-mistakes version (real fm-bootstrap.sh stdout)</summary>

Source: [Bootstrap toolchain report by no-mistakes version (real fm-bootstrap.sh stdout)](https://github.com/jjames27th-eng/firstmate/blob/fa9e250e521cc91da239758b5c6275ddce2963f0/.no-mistakes/evidence/fm/extend-transcript-scrub-to-spawn/bootstrap-attestation.txt)

<code>v1.57.0 (current floor) -&gt; silent, accepted&#10;v1.58.0 (newer minor) -&gt; silent, accepted&#10;v1.37.0 (pre-attestation) -&gt; MISSING: no-mistakes (install: curl ... install.sh | sh)&#10;v1.56.9 (below floor) -&gt; MISSING: no-mistakes (install: curl ... install.sh | sh)</code>

```text
# bin/fm-bootstrap.sh session-start toolchain report (real CLI invocation, stdout contract)
# Only the no-mistakes version varies; every other required tool is present & current.
# Floor: NO_MISTAKES_MIN=1.57.0 (tracks latest stable release; pre-attestation clients rejected).

=== current floor, attestation-capable (v1.57.0) ===
no-mistakes --version -> no-mistakes version v1.57.0 (fake)
bootstrap stdout      -> (silent: toolchain accepted, session start proceeds)

=== newer minor accepted (v1.58.0) ===
no-mistakes --version -> no-mistakes version v1.58.0 (fake)
bootstrap stdout      -> (silent: toolchain accepted, session start proceeds)

=== pre-attestation client rejected (v1.37.0) ===
no-mistakes --version -> no-mistakes version v1.37.0 (fake)
bootstrap stdout      -> MISSING: no-mistakes (install: curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh | sh)

=== older patch below floor rejected (v1.56.9) ===
no-mistakes --version -> no-mistakes version v1.56.9 (fake)
bootstrap stdout      -> MISSING: no-mistakes (install: curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh | sh)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"596d2ac8210ee49bce7a87bbfa1895a37a6f6170","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-spawn-dispatch-profile.test.sh` - full colocated public-interface suite passed, including the new `test_claude_launches_clear_inherited_child_session_marker`, which captures the literal command from the fake tmux send-keys sink (no live Herdr spawn) and asserts crewmate, scout, and secondmate Claude launches contain `env -u CLAUDE_CODE_CHILD_SESSION` while a `--harness codex` launch does not</code>
- <code>Isolated `test_no_mistakes_min_version` from `tests/fm-bootstrap.test.sh` - real fm-bootstrap.sh runs: v1.57.0/v1.58.0/v2.0.0 accepted (silent), v1.37.0 (pre-attestation), v1.56.9, and unparseable rejected with the MISSING upgrade line</code>
- <code>Evidence capture via the test&#39;s own helpers: ran real fm-spawn.sh under `CLAUDE_CODE_CHILD_SESSION=1` for crewmate/scout/secondmate/codex and recorded each constructed launch command</code>
- `Evidence capture via real fm-bootstrap.sh under a fully-present fake toolchain, varying only the no-mistakes version, recording the stdout toolchain report per version`
- <code>Scope check: `git diff --name-only` confirms only bin/fm-spawn.sh and bin/fm-bootstrap.sh are source changes; `grep -c FM_PENDING_REPLY_EXISTING_CORR` over the diff = 0 (untouched); no dotfiles launcher touched; other-harness branch still `env -u CURSOR_AGENT -u CURSOR_INVOKED_AS` only</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
