### PR TITLE
feat(bin): refuse primary-home spawns into secondmate-owned projects

### DIFF
--- a/.agents/skills/secondmate-provisioning/SKILL.md
+++ b/.agents/skills/secondmate-provisioning/SKILL.md
@@ -30,7 +30,7 @@ A whole-home remote route uses:
 - <id> - <one-sentence charter summary> (host: <ssh-alias>; root: <absolute-remote-code-root>; home: <absolute-remote-home>; scope: <natural-language responsibility>; projects: <project-a>, <project-b>; added <date>)
 ```
 
-Each registry entry stays concise and single-line: the summary is one sentence naming the durable charter, `scope:` is the natural-language intake responsibility, `projects:` is the non-exclusive clone list, and any extra prose is limited to genuinely domain-specific hard rules that change routing or safety for that secondmate.
+Each registry entry stays concise and single-line: the summary is one sentence naming the durable charter, `scope:` is the natural-language intake responsibility, `projects:` is the clone list that also claims spawn ownership of those projects, and any extra prose is limited to genuinely domain-specific hard rules that change routing or safety for that secondmate.
 Natural-language summary and `scope:` text may contain parentheses and semicolons; keep the generated `(home: ...; scope: ...; projects: ...; added ...)` suffix intact so operational consumers resolve its explicit field markers.
 The `home:` path points to the seeded home containing `data/charter.md`; no extra registry pointer field is needed.
 For a remote route, `host:` is an OpenSSH config alias and `root:` is that host's separate tracked Firstmate code root.
@@ -39,7 +39,7 @@ This release places whole secondmate homes remotely and never individual workers
 [`docs/remote-secondmates.md`](../../../docs/remote-secondmates.md) owns current operator setup and transport behavior.
 The home-seeded `data/charter.md` is the sole owner of boilerplate idle-by-default behavior, the normal delegation lifecycle, and standard escalation contracts, so point to that charter rather than restating those contracts in the registry entry.
 The `scope:` field is used during intake.
-The `projects:` field is a non-exclusive clone list, not ownership.
+The `projects:` field is the clone list and the spawn-ownership claim: [`fm-spawn.sh`](../../../bin/fm-spawn.sh) refuses a fresh primary-home crewmate or scout into a listed project unless `--allow-primary-spawn` states a deliberate exception, while scope text is never matched at spawn time.
 
 ## Charter and seed
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,7 +238,7 @@ That skill owns registry syntax, delivery-mode selection, outward-facing consent
 Project creation never authorizes an unmentioned remote, and project removal never bypasses that preflight or unlanded-work checks; hard rule 1's concrete captain-approved project operation exception remains available when its exact conditions are met.
 
 Load `secondmate-provisioning` before creating, seeding, validating, launching, handing backlog to, recovering, pushing inherited local material into, or retiring a secondmate home, and before editing `data/secondmates.md`.
-Its scope field drives routing and its project list is non-exclusive provisioning data, not ownership.
+Its scope field drives routing, and its project list is that secondmate's spawn ownership: `bin/fm-spawn.sh` refuses a fresh primary-home crewmate or scout into a listed project unless `--allow-primary-spawn` states a deliberate exception.
 Keep `local-only` work in the main home.
 
 A secondmate is idle by default and acts only on work routed by the main firstmate.
@@ -269,7 +269,7 @@ Resolve the project independently for every request.
 An explicit project wins, a clear follow-up inherits its referent, and otherwise match the request against the registry, work under way, and project code or README.
 Proceed on one confident match while naming the project in plain language; ask one concise question when multiple or no projects plausibly match.
 
-Route by the nature of the work against each registered secondmate scope, not by a non-exclusive clone list.
+Route by the nature of the work against each registered secondmate scope; a project on a secondmate's clone list is also spawn-owned by it, so primary-home work there needs the deliberate `--allow-primary-spawn` exception.
 Keep `local-only` work in the main home.
 Send in-scope work to the fitting secondmate unless it is blocked or the captain explicitly redirects it; do not read the secondmate's chat because marked routed replies return through its status or referenced document.
 If no secondmate scope fits, use the main home or discuss creating an appropriate persistent secondmate.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -214,7 +214,7 @@ if [ "$NO_PROJECTS" -eq 1 ]; then
   PROJECT_CLONES_NOTE="This domain has no separate project clones: its subject is the firstmate repo this home lives in, and its crews take pooled worktrees of that repo."
 else
   PROJECT_CLONES_BODY=$(printf '%s\n' "$SECONDMATE_PROJECTS" | tr ' ' '\n' | sed 's/^/- /')
-  PROJECT_CLONES_NOTE="The projects above are local clones for work you supervise; they are not an exclusive ownership claim."
+  PROJECT_CLONES_NOTE="The projects above are local clones for work you supervise, and the main firstmate refuses to spawn its own crewmates or scouts into them without a deliberate override."
 fi
 cat > "$BRIEF" <<EOF
 You are a persistent second mate managed by the main firstmate. Work on your own; do not wait for a human.

--- a/bin/fm-home-seed.sh
+++ b/bin/fm-home-seed.sh
@@ -9,9 +9,10 @@
 #       no live process and is never recycled until the lease is released with
 #       "treehouse return". Projects are cloned
 #       from the active home into the secondmate home's projects/ directory.
-#       That project list is non-exclusive provisioning data. Pass --no-projects
-#       instead of a project list to seed a project-less home for a domain whose
-#       subject is the firstmate repo itself; it is mutually exclusive with a
+#       That project list also claims spawn ownership: fm-spawn.sh refuses a
+#       fresh primary-home crewmate or scout into a listed project by default.
+#       Pass --no-projects instead of a project list to seed a project-less home
+#       for a domain whose subject is the firstmate repo itself; it is mutually exclusive with a
 #       project list, and omitting both still fails loudly. A project-less seed
 #       refuses a home with project clones or project-registry entries, so it
 #       never converts populated homes in place. The charter brief

--- a/bin/fm-secondmate-registry-lib.sh
+++ b/bin/fm-secondmate-registry-lib.sh
@@ -313,13 +313,24 @@ secondmate_registry_validate_bindings() {
 }
 
 # The generated field is comma-joined, but a hand-edited list separated by
-# whitespace still states a claim, so both separators split it.
+# whitespace still states a claim, so both separators split it. Each entry is
+# then reduced to its path basename, so a bare `alpha`, a `projects/alpha`, and
+# an absolute clone path all state the same claim the spawn side derives from
+# its own project argument. The split reads into an array instead of
+# word-splitting an unquoted expansion: pathname expansion would otherwise
+# resolve a metacharacter in the field against the caller's working directory
+# and silently rewrite the ownership set in either direction.
 secondmate_registry_projects_field_has() {
   local field=$1 project=$2 entry
-  local IFS=$', \t'
+  local -a entries=()
   [ -n "$project" ] || return 1
   [ -n "$field" ] || return 1
-  for entry in $field; do
+  IFS=$', \t' read -ra entries <<< "$field"
+  for entry in "${entries[@]+"${entries[@]}"}"; do
+    while [ "$entry" != "${entry%/}" ]; do
+      entry=${entry%/}
+    done
+    entry=${entry##*/}
     [ -n "$entry" ] || continue
     [ "$entry" = "$project" ] && return 0
   done

--- a/bin/fm-secondmate-registry-lib.sh
+++ b/bin/fm-secondmate-registry-lib.sh
@@ -28,6 +28,7 @@ SECONDMATE_REGISTRY_MATCH_PROJECTS=
 SECONDMATE_REGISTRY_MATCH_REMOTE=0
 SECONDMATE_REGISTRY_ERROR=
 SECONDMATE_REGISTRY_ENTRIES=
+SECONDMATE_REGISTRY_FIELD_SEP=$'\x1f'
 
 secondmate_registry_lock_path() { printf '%s/.secondmate-registry.lock\n' "$1"; }
 secondmate_reply_lifecycle_lock_path() { printf '%s/.remote-reply-lifecycle-%s.lock\n' "$1" "$2"; }
@@ -312,11 +313,7 @@ secondmate_registry_validate_bindings() {
 }
 
 secondmate_registry_project_basename() {
-  local path=$1
-  case "$path" in
-    projects/*) path=${path#projects/} ;;
-  esac
-  basename "$path"
+  basename "$1"
 }
 
 # The generated field is comma-joined, but a hand-edited list separated by
@@ -334,13 +331,17 @@ secondmate_registry_projects_field_has() {
 }
 
 # Collect every registry record into SECONDMATE_REGISTRY_ENTRIES, one
-# `id<TAB>projects<TAB>scope` line per entry, so a caller reads the registry
-# once. Status: 0 records collected, 1 no registry file or no records, 2 the
-# registry cannot be trusted (unsafe path, unreadable, or an entry no
-# operational parser can consume) with the reason in SECONDMATE_REGISTRY_ERROR.
-# A caller that acts on ownership must treat 2 as unresolved ownership rather
-# than as an absent claim; silently skipping an unparseable entry would void
-# that secondmate's claim exactly when the registry is least trustworthy.
+# `id<SEP>projects<SEP>scope` line per entry, so a caller reads the registry
+# once. The separator is SECONDMATE_REGISTRY_FIELD_SEP, deliberately not IFS
+# whitespace: a project-less secondmate has an empty projects field, and a
+# whitespace separator would let `read` collapse it and hand the scope text to
+# the next field. Read a record back with `IFS=$SECONDMATE_REGISTRY_FIELD_SEP`.
+# Status: 0 records collected, 1 no registry file or no records, 2 the registry
+# cannot be trusted (unsafe path, unreadable, or an entry no operational parser
+# can consume) with the reason in SECONDMATE_REGISTRY_ERROR. A caller that acts
+# on ownership must treat 2 as unresolved ownership rather than as an absent
+# claim; silently skipping an unparseable entry would void that secondmate's
+# claim exactly when the registry is least trustworthy.
 secondmate_registry_entries() {
   local reg=$1 line found=0
   SECONDMATE_REGISTRY_ENTRIES=
@@ -360,14 +361,14 @@ secondmate_registry_entries() {
           SECONDMATE_REGISTRY_ERROR="malformed secondmate registry entry: $line"
           return 2
         fi
-        case "$SECONDMATE_REGISTRY_PROJECTS" in
-          *$'\t'*)
+        case "$SECONDMATE_REGISTRY_ID$SECONDMATE_REGISTRY_PROJECTS$SECONDMATE_REGISTRY_SCOPE" in
+          *"$SECONDMATE_REGISTRY_FIELD_SEP"*)
             SECONDMATE_REGISTRY_ENTRIES=
-            SECONDMATE_REGISTRY_ERROR="unsafe secondmate project list for $SECONDMATE_REGISTRY_ID"
+            SECONDMATE_REGISTRY_ERROR="unsafe secondmate registry entry for $SECONDMATE_REGISTRY_ID"
             return 2
             ;;
         esac
-        SECONDMATE_REGISTRY_ENTRIES="${SECONDMATE_REGISTRY_ENTRIES}${SECONDMATE_REGISTRY_ID}"$'\t'"${SECONDMATE_REGISTRY_PROJECTS}"$'\t'"${SECONDMATE_REGISTRY_SCOPE}"$'\n'
+        SECONDMATE_REGISTRY_ENTRIES="${SECONDMATE_REGISTRY_ENTRIES}${SECONDMATE_REGISTRY_ID}${SECONDMATE_REGISTRY_FIELD_SEP}${SECONDMATE_REGISTRY_PROJECTS}${SECONDMATE_REGISTRY_FIELD_SEP}${SECONDMATE_REGISTRY_SCOPE}"$'\n'
         found=1
         ;;
     esac

--- a/bin/fm-secondmate-registry-lib.sh
+++ b/bin/fm-secondmate-registry-lib.sh
@@ -309,3 +309,58 @@ secondmate_registry_validate_bindings() {
   fi
   return 0
 }
+
+secondmate_registry_project_basename() {
+  local path=$1
+  case "$path" in
+    projects/*) path=${path#projects/} ;;
+  esac
+  basename "$path"
+}
+
+secondmate_registry_projects_field_has() {
+  local field=$1 project=$2 entry
+  local IFS=,
+  [ -n "$project" ] || return 1
+  [ -n "$field" ] || return 1
+  for entry in $field; do
+    entry=${entry#"${entry%%[![:space:]]*}"}
+    entry=${entry%"${entry##*[![:space:]]}"}
+    [ -n "$entry" ] || continue
+    [ "$entry" = "$project" ] && return 0
+  done
+  return 1
+}
+
+secondmate_registry_has_entries() {
+  local reg=$1 line
+  [ -f "$reg" ] || return 1
+  [ ! -L "$reg" ] || return 1
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+      "- "*)
+        secondmate_registry_parse_line "$line" && return 0
+        ;;
+    esac
+  done < "$reg"
+  return 1
+}
+
+# Print one owner id per line for a project basename. Returns 0 when any match.
+secondmate_registry_project_owners() {
+  local reg=$1 project=$2 line found=0
+  [ -f "$reg" ] || return 1
+  [ ! -L "$reg" ] || return 1
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+      "- "*)
+        secondmate_registry_parse_line "$line" || continue
+        if secondmate_registry_projects_field_has "$SECONDMATE_REGISTRY_PROJECTS" "$project"; then
+          printf '%s\n' "$SECONDMATE_REGISTRY_ID"
+          found=1
+        fi
+        ;;
+    esac
+  done < "$reg"
+  [ "$found" -eq 1 ]
+}

--- a/bin/fm-secondmate-registry-lib.sh
+++ b/bin/fm-secondmate-registry-lib.sh
@@ -27,6 +27,7 @@ SECONDMATE_REGISTRY_MATCH_HOME_KEY=
 SECONDMATE_REGISTRY_MATCH_PROJECTS=
 SECONDMATE_REGISTRY_MATCH_REMOTE=0
 SECONDMATE_REGISTRY_ERROR=
+SECONDMATE_REGISTRY_ENTRIES=
 
 secondmate_registry_lock_path() { printf '%s/.secondmate-registry.lock\n' "$1"; }
 secondmate_reply_lifecycle_lock_path() { printf '%s/.remote-reply-lifecycle-%s.lock\n' "$1" "$2"; }
@@ -318,49 +319,59 @@ secondmate_registry_project_basename() {
   basename "$path"
 }
 
+# The generated field is comma-joined, but a hand-edited list separated by
+# whitespace still states a claim, so both separators split it.
 secondmate_registry_projects_field_has() {
   local field=$1 project=$2 entry
-  local IFS=,
+  local IFS=$', \t'
   [ -n "$project" ] || return 1
   [ -n "$field" ] || return 1
   for entry in $field; do
-    entry=${entry#"${entry%%[![:space:]]*}"}
-    entry=${entry%"${entry##*[![:space:]]}"}
     [ -n "$entry" ] || continue
     [ "$entry" = "$project" ] && return 0
   done
   return 1
 }
 
-secondmate_registry_has_entries() {
-  local reg=$1 line
-  [ -f "$reg" ] || return 1
-  [ ! -L "$reg" ] || return 1
+# Collect every registry record into SECONDMATE_REGISTRY_ENTRIES, one
+# `id<TAB>projects<TAB>scope` line per entry, so a caller reads the registry
+# once. Status: 0 records collected, 1 no registry file or no records, 2 the
+# registry cannot be trusted (unsafe path, unreadable, or an entry no
+# operational parser can consume) with the reason in SECONDMATE_REGISTRY_ERROR.
+# A caller that acts on ownership must treat 2 as unresolved ownership rather
+# than as an absent claim; silently skipping an unparseable entry would void
+# that secondmate's claim exactly when the registry is least trustworthy.
+secondmate_registry_entries() {
+  local reg=$1 line found=0
+  SECONDMATE_REGISTRY_ENTRIES=
+  SECONDMATE_REGISTRY_ERROR=
+  if [ ! -e "$reg" ] && [ ! -L "$reg" ]; then
+    return 1
+  fi
+  if [ -L "$reg" ] || [ ! -f "$reg" ] || [ ! -r "$reg" ]; then
+    SECONDMATE_REGISTRY_ERROR="secondmate registry is unavailable or unsafe: $reg"
+    return 2
+  fi
   while IFS= read -r line || [ -n "$line" ]; do
     case "$line" in
       "- "*)
-        secondmate_registry_parse_line "$line" && return 0
-        ;;
-    esac
-  done < "$reg"
-  return 1
-}
-
-# Print one owner id per line for a project basename. Returns 0 when any match.
-secondmate_registry_project_owners() {
-  local reg=$1 project=$2 line found=0
-  [ -f "$reg" ] || return 1
-  [ ! -L "$reg" ] || return 1
-  while IFS= read -r line || [ -n "$line" ]; do
-    case "$line" in
-      "- "*)
-        secondmate_registry_parse_line "$line" || continue
-        if secondmate_registry_projects_field_has "$SECONDMATE_REGISTRY_PROJECTS" "$project"; then
-          printf '%s\n' "$SECONDMATE_REGISTRY_ID"
-          found=1
+        if ! secondmate_registry_parse_line "$line"; then
+          SECONDMATE_REGISTRY_ENTRIES=
+          SECONDMATE_REGISTRY_ERROR="malformed secondmate registry entry: $line"
+          return 2
         fi
+        case "$SECONDMATE_REGISTRY_PROJECTS" in
+          *$'\t'*)
+            SECONDMATE_REGISTRY_ENTRIES=
+            SECONDMATE_REGISTRY_ERROR="unsafe secondmate project list for $SECONDMATE_REGISTRY_ID"
+            return 2
+            ;;
+        esac
+        SECONDMATE_REGISTRY_ENTRIES="${SECONDMATE_REGISTRY_ENTRIES}${SECONDMATE_REGISTRY_ID}"$'\t'"${SECONDMATE_REGISTRY_PROJECTS}"$'\t'"${SECONDMATE_REGISTRY_SCOPE}"$'\n'
+        found=1
         ;;
     esac
   done < "$reg"
-  [ "$found" -eq 1 ]
+  [ "$found" -eq 1 ] || return 1
+  return 0
 }

--- a/bin/fm-secondmate-registry-lib.sh
+++ b/bin/fm-secondmate-registry-lib.sh
@@ -312,10 +312,6 @@ secondmate_registry_validate_bindings() {
   return 0
 }
 
-secondmate_registry_project_basename() {
-  basename "$1"
-}
-
 # The generated field is comma-joined, but a hand-edited list separated by
 # whitespace still states a claim, so both separators split it.
 secondmate_registry_projects_field_has() {

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1342,7 +1342,7 @@ spawn_secondmate_ownership_guard() {
   fi
   [ "$rc" -eq 0 ] || return 0
   scope_line=
-  while IFS=$'\t' read -r id projects scope; do
+  while IFS=$SECONDMATE_REGISTRY_FIELD_SEP read -r id projects scope; do
     [ -n "$id" ] || continue
     if secondmate_registry_projects_field_has "$projects" "$proj_name"; then
       owner_ids+=("$id")

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Spawn a direct report: a crewmate in a treehouse or Orca worktree, or a
 # secondmate in its isolated firstmate home.
-# Usage: fm-spawn.sh <task-id> <project-dir> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>]
-#        fm-spawn.sh <task-id> <project-dir> --scout [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>]
+# Usage: fm-spawn.sh <task-id> <project-dir> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] [--allow-primary-spawn]
+#        fm-spawn.sh <task-id> <project-dir> --scout [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] [--allow-primary-spawn]
 #        fm-spawn.sh <task-id> [<firstmate-home>] [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] --secondmate
 #   --mode and --yolo are this task's delivery contract, REQUIRED for every ship
 #   spawn and refused on --scout and --secondmate spawns. Firstmate resolves both
@@ -17,19 +17,6 @@
 #   no-mistakes-prod-only is a registry policy rather than a task mode and is
 #   refused as a flag value.
 #        fm-spawn.sh <task-id> --relaunch [--harness <name>] [--model <name>] [--effort <level>]
-#   --allow-primary-spawn is a deliberate override for a fresh ship or scout spawn
-#   when data/secondmates.md lists the target project on a secondmate's projects:
-#   field. Without it, those spawns REFUSE rather than drift a secondmate-owned
-#   repository into the primary home. The refusal names every registered owner and
-#   is checked before any task metadata exists. With it, the spawn continues,
-#   prints a loud stderr notice naming the bypassed owner(s), and records
-#   primary_spawn_override=1 plus primary_spawn_override_owners=<ids> on the task.
-#   Scope text is never matched; when the project is on no projects: list but the
-#   registry is non-empty, a stderr warning names every registered secondmate and
-#   its scope for judgment, then the spawn continues. A registry that cannot be
-#   read, or any entry no operational parser can consume, refuses the spawn
-#   rather than silently voiding that secondmate's claim. Missing or empty
-#   registries, --secondmate spawns, and --relaunch are unaffected.
 #   --relaunch launches a replacement agent for an EXISTING task into that
 #   task's own recorded endpoint and worktree instead of creating either. It is
 #   the launch half of the control plane (bin/fm-control.sh relaunch), which
@@ -45,6 +32,19 @@
 #   or herdr), refuses unless the endpoint's shell is sitting in the recorded
 #   worktree, and clears the previous harness's per-task wiring before arming
 #   the new incarnation.
+#   --allow-primary-spawn is a deliberate override for a fresh ship or scout spawn
+#   when data/secondmates.md lists the target project on a secondmate's projects:
+#   field. Without it, those spawns REFUSE rather than drift a secondmate-owned
+#   repository into the primary home. The refusal names every registered owner and
+#   is checked before any task metadata exists. With it, the spawn continues,
+#   prints a loud stderr notice naming the bypassed owner(s), and records
+#   primary_spawn_override=1 plus primary_spawn_override_owners=<ids> on the task.
+#   Scope text is never matched; when the project is on no projects: list but the
+#   registry is non-empty, a stderr warning names every registered secondmate and
+#   its scope for judgment, then the spawn continues. A registry that cannot be
+#   read, or any entry no operational parser can consume, refuses the spawn
+#   rather than silently voiding that secondmate's claim. Missing or empty
+#   registries, --secondmate spawns, and --relaunch are unaffected.
 #   --harness <name> is the explicit per-spawn harness/profile adapter. The old
 #   positional harness arg still works for back-compat.
 #   --model <name> and --effort <low|medium|high|xhigh|max> are concrete profile
@@ -1333,7 +1333,7 @@ secondmate_registry_value() {
 spawn_secondmate_ownership_guard() {
   local proj_abs=$1 proj_name reg=$DATA/secondmates.md owners scope_line id projects scope rc=0
   local -a owner_ids=()
-  proj_name=$(secondmate_registry_project_basename "$proj_abs")
+  proj_name=$(basename "$proj_abs")
   secondmate_registry_entries "$reg" || rc=$?
   if [ "$rc" -eq 2 ]; then
     echo "error: ${SECONDMATE_REGISTRY_ERROR:-secondmate registry is unusable: $reg}" >&2

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1354,19 +1354,14 @@ spawn_secondmate_ownership_guard() {
     fi
   done <<< "$SECONDMATE_REGISTRY_ENTRIES"
   if [ "${#owner_ids[@]}" -gt 0 ]; then
+    owners=$(IFS=,; printf '%s' "${owner_ids[*]}")
     if [ "$ALLOW_PRIMARY_SPAWN" -eq 1 ]; then
-      owners=$(IFS=,; printf '%s' "${owner_ids[*]}")
       echo "notice: --allow-primary-spawn bypasses secondmate ownership for $proj_name (registered owner(s): $owners); route future work to that secondmate unless this exception remains deliberate" >&2
       PRIMARY_SPAWN_OVERRIDE=1
       PRIMARY_SPAWN_OVERRIDE_OWNERS=$owners
       return 0
     fi
-    case "${#owner_ids[@]}" in
-      1) owners=${owner_ids[0]} ;;
-      2) owners="${owner_ids[0]} and ${owner_ids[1]}" ;;
-      *) owners=$(printf '%s, ' "${owner_ids[@]}" | sed 's/, $//') ;;
-    esac
-    echo "error: project $proj_name is registered to secondmate $owners; spawn the worker in that secondmate home or pass --allow-primary-spawn for a deliberate primary-home exception" >&2
+    echo "error: project $proj_name is registered to secondmate(s) $owners; spawn the worker in a registered secondmate home or pass --allow-primary-spawn for a deliberate primary-home exception" >&2
     return 1
   fi
   [ -n "$scope_line" ] || return 0

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -24,14 +24,14 @@
 #   transaction; call fm-control rather than this flag directly unless you are
 #   deliberately re-launching an already-stopped task. Every identity axis -
 #   backend, kind, project or home, worktree, endpoint - comes from the task's
-#   validated state/<id>.meta, so --backend, --scout, --secondmate, a project
-#   positional, and batch pairs are all refused alongside it; only harness,
-#   model, and effort may change, which is what makes a harness switch one
-#   ordinary relaunch. It refuses unless the recorded endpoint is positively
-#   agent-free on a backend with a recovery-grade agent-state classifier (tmux
-#   or herdr), refuses unless the endpoint's shell is sitting in the recorded
-#   worktree, and clears the previous harness's per-task wiring before arming
-#   the new incarnation.
+#   validated state/<id>.meta, so --backend, --scout, --secondmate,
+#   --allow-primary-spawn, a project positional, and batch pairs are all refused
+#   alongside it; only harness, model, and effort may change, which is what
+#   makes a harness switch one ordinary relaunch. It refuses unless the recorded
+#   endpoint is positively agent-free on a backend with a recovery-grade
+#   agent-state classifier (tmux or herdr), refuses unless the endpoint's shell
+#   is sitting in the recorded worktree, and clears the previous harness's
+#   per-task wiring before arming the new incarnation.
 #   --allow-primary-spawn is a deliberate override for a fresh ship or scout spawn
 #   when data/secondmates.md lists the target project on a secondmate's projects:
 #   field. Without it, those spawns REFUSE rather than drift a secondmate-owned
@@ -48,8 +48,10 @@
 #   rather than a way to spawn while ownership is unresolvable, so repair the
 #   registry instead. A projects: entry matches on its path basename, so a bare
 #   name, a projects/<name>, and an absolute clone path all state one claim.
-#   Missing or empty registries, --secondmate spawns, and --relaunch are
-#   unaffected.
+#   Missing or empty registries spawn normally. The guard itself runs only on a
+#   fresh ship or scout create, so --secondmate spawns and --relaunch are
+#   unaffected; passing this flag on either is refused rather than ignored, so a
+#   meaningless override can never look accepted.
 #   --harness <name> is the explicit per-spawn harness/profile adapter. The old
 #   positional harness arg still works for back-compat.
 #   --model <name> and --effort <low|medium|high|xhigh|max> are concrete profile

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -17,6 +17,17 @@
 #   no-mistakes-prod-only is a registry policy rather than a task mode and is
 #   refused as a flag value.
 #        fm-spawn.sh <task-id> --relaunch [--harness <name>] [--model <name>] [--effort <level>]
+#   --allow-primary-spawn is a deliberate override for a fresh ship or scout spawn
+#   when data/secondmates.md lists the target project on a secondmate's projects:
+#   field. Without it, those spawns REFUSE rather than drift a secondmate-owned
+#   repository into the primary home. The refusal names every registered owner and
+#   is checked before any task metadata exists. With it, the spawn continues,
+#   prints a loud stderr notice naming the bypassed owner(s), and records
+#   primary_spawn_override=1 plus primary_spawn_override_owners=<ids> on the task.
+#   Scope text is never matched; when the project is on no projects: list but the
+#   registry is non-empty, a stderr warning names every registered secondmate and
+#   its scope for judgment, then the spawn continues. Missing or empty registries,
+#   --secondmate spawns, and --relaunch are unaffected.
 #   --relaunch launches a replacement agent for an EXISTING task into that
 #   task's own recorded endpoint and worktree instead of creating either. It is
 #   the launch half of the control plane (bin/fm-control.sh relaunch), which
@@ -283,6 +294,7 @@ MODE_SET=0
 YOLO_SET=0
 TRACEPARENT_SET=0
 RELAUNCH=0
+ALLOW_PRIMARY_SPAWN=0
 POS=()
 want_value=
 for a in "$@"; do
@@ -307,6 +319,7 @@ for a in "$@"; do
     --scout) KIND=scout; KIND_SET=1 ;;
     --secondmate) KIND=secondmate; KIND_SET=1 ;;
     --relaunch) RELAUNCH=1 ;;
+    --allow-primary-spawn) ALLOW_PRIMARY_SPAWN=1 ;;
     --harness) want_value=harness ;;
     --harness=*) HARNESS_ARG=${a#--harness=}; HARNESS_SET=1 ;;
     --model) want_value=model ;;
@@ -359,7 +372,15 @@ if [ "$RELAUNCH" -eq 1 ]; then
   [ "$KIND_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded kind; --scout/--secondmate cannot override it" >&2; exit 1; }
   [ "$MODE_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded delivery mode; --mode cannot override it" >&2; exit 1; }
   [ "$YOLO_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded yolo posture; --yolo cannot override it" >&2; exit 1; }
+  [ "$ALLOW_PRIMARY_SPAWN" -eq 0 ] || {
+    echo "error: --allow-primary-spawn applies only to fresh ship or scout spawns" >&2
+    exit 1
+  }
 else
+  [ "$ALLOW_PRIMARY_SPAWN" -eq 0 ] || [ "$KIND" != secondmate ] || {
+    echo "error: --allow-primary-spawn applies only to fresh ship or scout spawns" >&2
+    exit 1
+  }
   # Delivery contract (AGENTS.md section 7). A ship task's mode and yolo are
   # firstmate's per-task decision, so they are required and closed-set validated
   # here rather than resolved from the project registry. Scouts deliver a report
@@ -1299,6 +1320,48 @@ secondmate_registry_value() {
   secondmate_registry_field "$DATA/secondmates.md" "$1" "$2"
 }
 
+spawn_secondmate_ownership_guard() {
+  local proj_abs=$1 proj_name reg=$DATA/secondmates.md owners owner scope_line line
+  local -a owner_ids=()
+  proj_name=$(secondmate_registry_project_basename "$proj_abs")
+  secondmate_registry_has_entries "$reg" || return 0
+  while IFS= read -r owner; do
+    [ -n "$owner" ] || continue
+    owner_ids+=("$owner")
+  done < <(secondmate_registry_project_owners "$reg" "$proj_name" && true)
+  if [ "${#owner_ids[@]}" -gt 0 ]; then
+    if [ "$ALLOW_PRIMARY_SPAWN" -eq 1 ]; then
+      owners=$(IFS=,; printf '%s' "${owner_ids[*]}")
+      echo "notice: --allow-primary-spawn bypasses secondmate ownership for $proj_name (registered owner(s): $owners); route future work to that secondmate unless this exception remains deliberate" >&2
+      PRIMARY_SPAWN_OVERRIDE=1
+      PRIMARY_SPAWN_OVERRIDE_OWNERS=$owners
+      return 0
+    fi
+    case "${#owner_ids[@]}" in
+      1) owners=${owner_ids[0]} ;;
+      2) owners="${owner_ids[0]} and ${owner_ids[1]}" ;;
+      *) owners=$(printf '%s, ' "${owner_ids[@]}" | sed 's/, $//') ;;
+    esac
+    echo "error: project $proj_name is registered to secondmate $owners; spawn the worker in that secondmate home or pass --allow-primary-spawn for a deliberate primary-home exception" >&2
+    return 1
+  fi
+  scope_line=
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+      "- "*)
+        secondmate_registry_parse_line "$line" || continue
+        if [ -n "$scope_line" ]; then
+          scope_line="$scope_line; $SECONDMATE_REGISTRY_ID (scope: $SECONDMATE_REGISTRY_SCOPE)"
+        else
+          scope_line="$SECONDMATE_REGISTRY_ID (scope: $SECONDMATE_REGISTRY_SCOPE)"
+        fi
+        ;;
+    esac
+  done < "$reg"
+  [ -n "$scope_line" ] || return 0
+  echo "warning: project $proj_name is not on any registered secondmate projects: list; confirm primary-home work or route in-scope work to a secondmate - registered: $scope_line" >&2
+}
+
 resolve_kimi_binary() {
   local candidate dir fallback
   candidate=$(command -v kimi 2>/dev/null || true)
@@ -1657,6 +1720,10 @@ else
   BRIEF="$DATA/$ID/brief.md"
 fi
 [ -f "$BRIEF" ] || { echo "error: no brief at $BRIEF" >&2; exit 1; }
+
+if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ]; then
+  spawn_secondmate_ownership_guard "$PROJ_ABS" || exit 1
+fi
 
 delivery_rigor_rank() {  # <mode> -> 3 (most rigor) .. 1 (least); 0 = not a task mode
   case "$1" in
@@ -2694,6 +2761,10 @@ preserve_relaunch_meta() {
   if [ "$KIND" = secondmate ]; then
     echo "home=$PROJ_ABS"
     echo "projects=$SECONDMATE_PROJECTS"
+  fi
+  if [ "${PRIMARY_SPAWN_OVERRIDE:-0}" = 1 ]; then
+    echo "primary_spawn_override=1"
+    echo "primary_spawn_override_owners=$PRIMARY_SPAWN_OVERRIDE_OWNERS"
   fi
   if [ "$RELAUNCH" -eq 1 ]; then
     preserve_relaunch_meta

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -26,8 +26,10 @@
 #   primary_spawn_override=1 plus primary_spawn_override_owners=<ids> on the task.
 #   Scope text is never matched; when the project is on no projects: list but the
 #   registry is non-empty, a stderr warning names every registered secondmate and
-#   its scope for judgment, then the spawn continues. Missing or empty registries,
-#   --secondmate spawns, and --relaunch are unaffected.
+#   its scope for judgment, then the spawn continues. A registry that cannot be
+#   read, or any entry no operational parser can consume, refuses the spawn
+#   rather than silently voiding that secondmate's claim. Missing or empty
+#   registries, --secondmate spawns, and --relaunch are unaffected.
 #   --relaunch launches a replacement agent for an EXISTING task into that
 #   task's own recorded endpoint and worktree instead of creating either. It is
 #   the launch half of the control plane (bin/fm-control.sh relaunch), which
@@ -153,8 +155,9 @@
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
 #   source of truth; shared --scout/--harness/--model/--effort/--backend/--mode/--yolo
-#   applies to every pair. A ship batch therefore carries one delivery contract, and each
-#   pair still checks it against its own brief; a batch spanning modes is two invocations.
+#   and --allow-primary-spawn apply to every pair. A ship batch therefore carries
+#   one delivery contract, and each pair still checks it against its own brief;
+#   a batch spanning modes is two invocations.
 #   If config/crew-dispatch.json exists, shared --harness is required for crewmate
 #   and scout batches. The loop lives here, in bash, so callers never hand-write a
 #   multi-task shell loop (the tool shell is zsh, which does not word-split unquoted
@@ -295,6 +298,10 @@ YOLO_SET=0
 TRACEPARENT_SET=0
 RELAUNCH=0
 ALLOW_PRIMARY_SPAWN=0
+# Guard outputs, never inherited from the environment: only the ownership guard
+# below sets them, and the meta write reads them verbatim.
+PRIMARY_SPAWN_OVERRIDE=0
+PRIMARY_SPAWN_OVERRIDE_OWNERS=
 POS=()
 want_value=
 for a in "$@"; do
@@ -889,6 +896,9 @@ if [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart" ] && case "$idpart" in *
   # spanning several modes is two invocations rather than a silent mixed dispatch.
   [ "$MODE_SET" -eq 0 ] || shared_args+=(--mode "$MODE")
   [ "$YOLO_SET" -eq 0 ] || shared_args+=(--yolo "$YOLO")
+  # The deliberate ownership exception is decided once for the batch and must
+  # reach each pair's own guard, or the operator's explicit override is dropped.
+  [ "$ALLOW_PRIMARY_SPAWN" -eq 0 ] || shared_args+=(--allow-primary-spawn)
   for pair in "${POS[@]}"; do
     case "$pair" in
       *=*) : ;;
@@ -1321,14 +1331,28 @@ secondmate_registry_value() {
 }
 
 spawn_secondmate_ownership_guard() {
-  local proj_abs=$1 proj_name reg=$DATA/secondmates.md owners owner scope_line line
+  local proj_abs=$1 proj_name reg=$DATA/secondmates.md owners scope_line id projects scope rc=0
   local -a owner_ids=()
   proj_name=$(secondmate_registry_project_basename "$proj_abs")
-  secondmate_registry_has_entries "$reg" || return 0
-  while IFS= read -r owner; do
-    [ -n "$owner" ] || continue
-    owner_ids+=("$owner")
-  done < <(secondmate_registry_project_owners "$reg" "$proj_name" && true)
+  secondmate_registry_entries "$reg" || rc=$?
+  if [ "$rc" -eq 2 ]; then
+    echo "error: ${SECONDMATE_REGISTRY_ERROR:-secondmate registry is unusable: $reg}" >&2
+    echo "error: refusing this spawn because secondmate project ownership cannot be resolved from $reg; repair the registry (bin/fm-home-seed.sh validate reports the same records) and retry" >&2
+    return 1
+  fi
+  [ "$rc" -eq 0 ] || return 0
+  scope_line=
+  while IFS=$'\t' read -r id projects scope; do
+    [ -n "$id" ] || continue
+    if secondmate_registry_projects_field_has "$projects" "$proj_name"; then
+      owner_ids+=("$id")
+    fi
+    if [ -n "$scope_line" ]; then
+      scope_line="$scope_line; $id (scope: $scope)"
+    else
+      scope_line="$id (scope: $scope)"
+    fi
+  done <<< "$SECONDMATE_REGISTRY_ENTRIES"
   if [ "${#owner_ids[@]}" -gt 0 ]; then
     if [ "$ALLOW_PRIMARY_SPAWN" -eq 1 ]; then
       owners=$(IFS=,; printf '%s' "${owner_ids[*]}")
@@ -1345,19 +1369,6 @@ spawn_secondmate_ownership_guard() {
     echo "error: project $proj_name is registered to secondmate $owners; spawn the worker in that secondmate home or pass --allow-primary-spawn for a deliberate primary-home exception" >&2
     return 1
   fi
-  scope_line=
-  while IFS= read -r line || [ -n "$line" ]; do
-    case "$line" in
-      "- "*)
-        secondmate_registry_parse_line "$line" || continue
-        if [ -n "$scope_line" ]; then
-          scope_line="$scope_line; $SECONDMATE_REGISTRY_ID (scope: $SECONDMATE_REGISTRY_SCOPE)"
-        else
-          scope_line="$SECONDMATE_REGISTRY_ID (scope: $SECONDMATE_REGISTRY_SCOPE)"
-        fi
-        ;;
-    esac
-  done < "$reg"
   [ -n "$scope_line" ] || return 0
   echo "warning: project $proj_name is not on any registered secondmate projects: list; confirm primary-home work or route in-scope work to a secondmate - registered: $scope_line" >&2
 }
@@ -2762,7 +2773,7 @@ preserve_relaunch_meta() {
     echo "home=$PROJ_ABS"
     echo "projects=$SECONDMATE_PROJECTS"
   fi
-  if [ "${PRIMARY_SPAWN_OVERRIDE:-0}" = 1 ]; then
+  if [ "$PRIMARY_SPAWN_OVERRIDE" = 1 ]; then
     echo "primary_spawn_override=1"
     echo "primary_spawn_override_owners=$PRIMARY_SPAWN_OVERRIDE_OWNERS"
   fi

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -43,8 +43,13 @@
 #   registry is non-empty, a stderr warning names every registered secondmate and
 #   its scope for judgment, then the spawn continues. A registry that cannot be
 #   read, or any entry no operational parser can consume, refuses the spawn
-#   rather than silently voiding that secondmate's claim. Missing or empty
-#   registries, --secondmate spawns, and --relaunch are unaffected.
+#   rather than silently voiding that secondmate's claim; that refusal is
+#   independent of this flag, which is a deliberate exception to a NAMED owner
+#   rather than a way to spawn while ownership is unresolvable, so repair the
+#   registry instead. A projects: entry matches on its path basename, so a bare
+#   name, a projects/<name>, and an absolute clone path all state one claim.
+#   Missing or empty registries, --secondmate spawns, and --relaunch are
+#   unaffected.
 #   --harness <name> is the explicit per-spawn harness/profile adapter. The old
 #   positional harness arg still works for back-compat.
 #   --model <name> and --effort <low|medium|high|xhigh|max> are concrete profile

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -1035,7 +1035,13 @@ families_for_changed_path() {
       ;;
     bin/fm-lint.sh|bin/fm-lint-workflows.sh|bin/fm-install-shellcheck.sh|\
     bin/fm-install-actionlint.sh|\
-    bin/fm-brief.sh|bin/fm-ensure-agents-md.sh|bin/fm-crew-state.sh|\
+    bin/fm-brief.sh)
+      # Scaffolds both crew briefs and the secondmate charter whose generated
+      # note the secondmate suite pins verbatim.
+      printf '%s\n' pure-contract-unit
+      printf '%s\n' secondmate
+      ;;
+    bin/fm-ensure-agents-md.sh|bin/fm-crew-state.sh|\
     bin/fm-captain-hold.sh|bin/fm-decision-hold.sh|bin/fm-supervision*|bin/fm-transition-lib.sh|\
     bin/fm-tmux-lib.sh|bin/fm-marker-lib.sh|bin/fm-operational-input.sh|bin/fm-tasks-axi-lib.sh|\
     bin/fm-vendor-auth-probe.sh|\

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -957,6 +957,13 @@ families_for_changed_path() {
       printf '%s\n' secondmate
       printf '%s\n' session-bootstrap
       ;;
+    bin/fm-secondmate-registry-lib.sh)
+      # The registry parser behind both the secondmate route surface and
+      # fm-spawn's primary-home ownership guard, whose only coverage is the
+      # pure-contract-unit ownership suite.
+      printf '%s\n' secondmate
+      printf '%s\n' pure-contract-unit
+      ;;
     bin/fm-secondmate*|bin/fm-remote*|bin/fm-on.sh|bin/fm-home-seed.sh|\
     bin/fm-backlog-handoff.sh|bin/fm-backlog-receive.sh|bin/fm-procevent-remote-reply.sh|\
     bin/fm-config-inherit-lib.sh|bin/fm-config-push.sh|bin/fm-shared*|\

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -146,6 +146,7 @@ family_for_basename() {
     fm-send-popup-settle.test.sh|fm-send-settle.test.sh|\
     fm-subagent-pretool-check.test.sh|\
     fm-supervision-instructions.test.sh|fm-task-delivery.test.sh|\
+    fm-spawn-secondmate-ownership.test.sh|\
     fm-tmux-submit-busy.test.sh|fm-trace-context-lib.test.sh|\
     fm-transition-lib.test.sh|\
     fm-test-run.test.sh|fm-test-isolation-proof.test.sh)
@@ -472,6 +473,7 @@ tests/fm-sessionstart-instruction-refresh-live-e2e.test.sh 21
 tests/fm-sessionstart-nudge.test.sh 26684
 tests/fm-shared-captain-inheritance.test.sh 10672
 tests/fm-spawn-dispatch-profile.test.sh 57765
+tests/fm-spawn-secondmate-ownership.test.sh 3500
 tests/fm-spawn-pool-base-freshen.test.sh 13257
 tests/fm-spawn-worktree-settle.test.sh 4828
 tests/fm-startup-memory-budget.test.sh 6550

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -1034,7 +1034,9 @@ families_for_changed_path() {
       printf '%s\n' real-herdr-gated
       ;;
     bin/fm-lint.sh|bin/fm-lint-workflows.sh|bin/fm-install-shellcheck.sh|\
-    bin/fm-install-actionlint.sh|\
+    bin/fm-install-actionlint.sh)
+      printf '%s\n' pure-contract-unit
+      ;;
     bin/fm-brief.sh)
       # Scaffolds both crew briefs and the secondmate charter whose generated
       # note the secondmate suite pins verbatim.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -194,7 +194,7 @@ The concise single-line route contract is owned by the [`secondmate-provisioning
 A remote route adds `host:` and `root:` before the existing fields and places the whole secondmate home on that SSH host; it does not make ordinary workers remotely placeable.
 [`remote-secondmates.md`](remote-secondmates.md) owns current remote setup, operation, and safety behavior.
 Use `fm-home-seed.sh validate` to check the complete operational registry contract documented by the command itself.
-The main first mate routes by reading those scopes with judgment; the project list is provisioning data, not exclusive ownership.
+The main first mate routes by reading those scopes with judgment; [`fm-spawn.sh`](../bin/fm-spawn.sh) hard-refuses a fresh primary-home ship or scout into any project listed on a secondmate's `projects:` field unless `--allow-primary-spawn` is passed deliberately, while scope text is never matched at spawn time.
 Use `fm-home-seed.sh <id> - {<project>...|--no-projects}` to lease a fresh local firstmate worktree for the secondmate home.
 For remote provisioning, including supplied project origins, follow [Remote second mates](remote-secondmates.md#provision-a-route).
 Use the deliberate `--no-projects` signal only for a firstmate-repo domain that needs no separate project clones.

--- a/tests/fm-secondmate-safety.test.sh
+++ b/tests/fm-secondmate-safety.test.sh
@@ -646,7 +646,7 @@ test_home_seed_refuses_projectful_reused_charter_for_projectless_home() {
 
   scaffold_secondmate_charter "$home" stale 'firstmate self-development. None. This is a project-less domain.' alpha \
     || fail "projectful charter scaffold failed"
-  sed 's/The projects above are local clones for work you supervise; they are not an exclusive ownership claim./Project clone details are customized for this domain./' \
+  sed 's/The projects above are local clones for work you supervise, and the main firstmate refuses to spawn its own crewmates or scouts into them without a deliberate override./Project clone details are customized for this domain./' \
     "$stale_brief" > "$stale_brief_before"
   mv "$stale_brief_before" "$stale_brief"
   cp "$stale_brief" "$stale_brief_before"

--- a/tests/fm-spawn-secondmate-ownership.test.sh
+++ b/tests/fm-spawn-secondmate-ownership.test.sh
@@ -157,6 +157,38 @@ EOF
   pass "fm-spawn: --allow-primary-spawn bypasses the ownership guard on an owned project"
 }
 
+test_allow_primary_spawn_is_refused_outside_a_fresh_ship_or_scout_spawn() {
+  local rec home proj fakebin smhome out status line
+  line="- design - design domain (home: $TMP_ROOT/misuse/smhome; scope: design domain; projects: ownedproj; added 2026-06-22)"
+  rec=$(make_home misuse "$line")
+  IFS='|' read -r home proj fakebin smhome <<EOF
+$rec
+EOF
+  write_brief "$home" own-misuse-e1 no-mistakes
+  fm_write_meta "$home/state/own-misuse-e1.meta" \
+    "window=firstmate:fm-own-misuse-e1" \
+    "endpoint_task_id=own-misuse-e1" \
+    "worktree=$proj/ownedproj" \
+    "project=$proj/ownedproj" \
+    "harness=claude" \
+    "kind=ship" \
+    "mode=no-mistakes" \
+    "yolo=off"
+  out=$(run_spawn "$home" "$fakebin" own-misuse-e1 --relaunch --allow-primary-spawn)
+  status=$?
+  [ "$status" -ne 0 ] || fail "--relaunch with --allow-primary-spawn should exit non-zero"
+  assert_contains "$out" "--allow-primary-spawn applies only to fresh ship or scout spawns" \
+    "relaunch did not refuse the misapplied override"
+
+  out=$(run_spawn "$home" "$fakebin" design "$smhome" --secondmate --allow-primary-spawn)
+  status=$?
+  [ "$status" -ne 0 ] || fail "--secondmate with --allow-primary-spawn should exit non-zero"
+  assert_contains "$out" "--allow-primary-spawn applies only to fresh ship or scout spawns" \
+    "secondmate spawn did not refuse the misapplied override"
+  assert_not_contains "$out" "$BACKEND_REACHED" "the misapplied override still reached the backend"
+  pass "fm-spawn: --allow-primary-spawn is refused on --relaunch and --secondmate spawns"
+}
+
 test_secondmate_spawn_is_unaffected_by_the_ownership_guard() {
   local rec home proj fakebin smhome out line
   # The home directory's basename is itself on the registry's projects list, so
@@ -350,6 +382,7 @@ EOF
 test_fresh_spawn_into_owned_project_refuses_and_writes_no_meta
 test_refusal_names_every_owner_when_several_claim_the_project
 test_allow_primary_spawn_override_passes_the_ownership_guard
+test_allow_primary_spawn_is_refused_outside_a_fresh_ship_or_scout_spawn
 test_secondmate_spawn_is_unaffected_by_the_ownership_guard
 test_relaunch_is_unaffected_by_the_ownership_guard
 test_override_spawn_records_every_bypassed_owner_on_the_task_record

--- a/tests/fm-spawn-secondmate-ownership.test.sh
+++ b/tests/fm-spawn-secondmate-ownership.test.sh
@@ -140,9 +140,68 @@ EOF
   pass "fm-spawn: unowned projects and missing registries pass the ownership guard"
 }
 
+test_unparseable_registry_entry_refuses_instead_of_voiding_ownership() {
+  local rec home proj fakebin out status good bad
+  good="- design - design domain (home: $TMP_ROOT/malformed/smhome; scope: design domain; projects: ownedproj; added 2026-06-22)"
+  bad="- triage - typo entry (home: $TMP_ROOT/malformed/smhome2; scope: triage; projects: freeproj)"
+  rec=$(make_home malformed "$good" "$bad")
+  IFS='|' read -r home proj fakebin _smhome <<EOF
+$rec
+EOF
+  write_brief "$home" own-broken-e1 no-mistakes
+  out=$(run_spawn "$home" "$fakebin" own-broken-e1 "$proj/freeproj" claude --mode no-mistakes --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn against an unparseable registry entry should exit non-zero"
+  assert_contains "$out" "malformed secondmate registry entry" "refusal did not name the unusable registry record"
+  assert_contains "$out" "- triage - typo entry" "refusal did not quote the offending registry line"
+  assert_not_contains "$out" "not on any registered secondmate projects: list" \
+    "an unresolvable registry still claimed the project is unowned"
+  assert_absent "$home/state/own-broken-e1.meta" "refused spawn wrote task metadata"
+  pass "fm-spawn: an unparseable registry entry refuses rather than silently voiding its ownership claim"
+}
+
+test_unreadable_registry_symlink_refuses_the_spawn() {
+  local rec home proj fakebin out status
+  rec=$(make_home symlinked)
+  IFS='|' read -r home proj fakebin _smhome <<EOF
+$rec
+EOF
+  ln -s "$home/data/missing-secondmates.md" "$home/data/secondmates.md"
+  write_brief "$home" own-link-f1 no-mistakes
+  out=$(run_spawn "$home" "$fakebin" own-link-f1 "$proj/freeproj" claude --mode no-mistakes --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn against an unsafe registry path should exit non-zero"
+  assert_contains "$out" "secondmate registry is unavailable or unsafe" "refusal did not name the unsafe registry path"
+  assert_absent "$home/state/own-link-f1.meta" "refused spawn wrote task metadata"
+  pass "fm-spawn: an unsafe registry path refuses rather than reading as an empty registry"
+}
+
+test_batch_dispatch_carries_the_deliberate_override_to_every_pair() {
+  local rec home proj fakebin out
+  local line
+  line="- design - design domain (home: $TMP_ROOT/batch/smhome; scope: design domain; projects: ownedproj; added 2026-06-22)"
+  rec=$(make_home batch "$line")
+  IFS='|' read -r home proj fakebin _smhome <<EOF
+$rec
+EOF
+  write_brief "$home" own-batch-g1 no-mistakes
+  out=$(run_spawn "$home" "$fakebin" "own-batch-g1=$proj/ownedproj" --mode no-mistakes --yolo off)
+  assert_contains "$out" "registered to secondmate design" "batch pair did not hit the ownership guard"
+
+  write_brief "$home" own-batch-g2 no-mistakes
+  out=$(run_spawn "$home" "$fakebin" "own-batch-g2=$proj/ownedproj" --mode no-mistakes --yolo off --allow-primary-spawn)
+  assert_contains "$out" "--allow-primary-spawn bypasses secondmate ownership" \
+    "batch dispatch dropped the deliberate override before the per-pair guard"
+  assert_not_contains "$out" "registered to secondmate design" "batch pair refused despite the deliberate override"
+  pass "fm-spawn: batch dispatch forwards --allow-primary-spawn to every pair"
+}
+
 test_fresh_spawn_into_owned_project_refuses_and_writes_no_meta
 test_allow_primary_spawn_override_passes_the_ownership_guard
 test_secondmate_spawn_is_unaffected_by_the_ownership_guard
 test_relaunch_is_unaffected_by_the_ownership_guard
 test_unowned_project_or_missing_registry_spawns_past_the_guard
+test_unparseable_registry_entry_refuses_instead_of_voiding_ownership
+test_unreadable_registry_symlink_refuses_the_spawn
+test_batch_dispatch_carries_the_deliberate_override_to_every_pair
 echo "# all fm-spawn-secondmate-ownership tests passed"

--- a/tests/fm-spawn-secondmate-ownership.test.sh
+++ b/tests/fm-spawn-secondmate-ownership.test.sh
@@ -124,6 +124,44 @@ EOF
   pass "fm-spawn: a fresh crewmate spawn into a secondmate-owned project refuses before metadata exists"
 }
 
+test_registry_entry_path_forms_state_the_same_ownership_claim() {
+  local rec home proj fakebin out status
+  rec=$(make_home pathforms \
+    "- design - design domain (home: $TMP_ROOT/pathforms/smhome; scope: design domain; projects: projects/ownedproj; added 2026-06-22)" \
+    "- triage - triage domain (home: $TMP_ROOT/pathforms/smhome2; scope: triage; projects: $TMP_ROOT/pathforms/projects/ownedproj; added 2026-06-22)")
+  IFS='|' read -r home proj fakebin _smhome <<EOF
+$rec
+EOF
+  write_brief "$home" own-path-j1 no-mistakes
+  out=$(run_spawn "$home" "$fakebin" own-path-j1 "$proj/ownedproj" claude --mode no-mistakes --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "a projects/<name> or absolute-path registry entry should still refuse"
+  assert_contains "$out" "registered to secondmate(s) design,triage" \
+    "path-form registry entries did not state the same ownership claim as a bare name"
+  assert_absent "$home/state/own-path-j1.meta" "refused spawn wrote task metadata"
+  pass "fm-spawn: a projects: entry claims its project as a bare name, projects/<name>, or absolute path"
+}
+
+test_projects_field_metacharacter_is_never_expanded_against_the_working_directory() {
+  local rec home proj fakebin cwd out status line
+  line="- design - design domain (home: $TMP_ROOT/glob/smhome; scope: design domain; projects: owned*; added 2026-06-22)"
+  rec=$(make_home glob "$line")
+  IFS='|' read -r home proj fakebin _smhome <<EOF
+$rec
+EOF
+  cwd="$TMP_ROOT/glob/cwd"
+  mkdir -p "$cwd"
+  : > "$cwd/ownedproj"
+  write_brief "$home" own-glob-k1 no-mistakes
+  out=$(cd "$cwd" && run_spawn "$home" "$fakebin" own-glob-k1 "$proj/ownedproj" claude --mode no-mistakes --yolo off)
+  status=$?
+  assert_not_contains "$out" "registered to secondmate" \
+    "a projects: glob expanded against the working directory and invented an ownership claim"
+  assert_contains "$out" "$BACKEND_REACHED" "the invented ownership claim stopped the spawn before the backend"
+  [ "$status" -ne 0 ] || fail "the refusing fake backend should still fail the spawn"
+  pass "fm-spawn: a projects: metacharacter is compared literally, never expanded against the caller's cwd"
+}
+
 test_refusal_names_every_owner_when_several_claim_the_project() {
   local rec home proj fakebin out status
   rec=$(make_home multiowner \
@@ -381,6 +419,8 @@ EOF
 
 test_fresh_spawn_into_owned_project_refuses_and_writes_no_meta
 test_refusal_names_every_owner_when_several_claim_the_project
+test_registry_entry_path_forms_state_the_same_ownership_claim
+test_projects_field_metacharacter_is_never_expanded_against_the_working_directory
 test_allow_primary_spawn_override_passes_the_ownership_guard
 test_allow_primary_spawn_is_refused_outside_a_fresh_ship_or_scout_spawn
 test_secondmate_spawn_is_unaffected_by_the_ownership_guard

--- a/tests/fm-spawn-secondmate-ownership.test.sh
+++ b/tests/fm-spawn-secondmate-ownership.test.sh
@@ -118,10 +118,29 @@ EOF
   out=$(run_spawn "$home" "$fakebin" own-refuse-a1 "$proj/ownedproj" claude --mode no-mistakes --yolo off)
   status=$?
   [ "$status" -ne 0 ] || fail "owned-project spawn should exit non-zero"
-  assert_contains "$out" "registered to secondmate design" "refusal did not name the owning secondmate"
+  assert_contains "$out" "registered to secondmate(s) design" "refusal did not name the owning secondmate"
   assert_contains "$out" "--allow-primary-spawn" "refusal did not name the deliberate override"
   assert_absent "$home/state/own-refuse-a1.meta" "refused spawn wrote task metadata"
   pass "fm-spawn: a fresh crewmate spawn into a secondmate-owned project refuses before metadata exists"
+}
+
+test_refusal_names_every_owner_when_several_claim_the_project() {
+  local rec home proj fakebin out status
+  rec=$(make_home multiowner \
+    "- design - design domain (home: $TMP_ROOT/multiowner/smhome; scope: design domain; projects: ownedproj; added 2026-06-22)" \
+    "- triage - triage domain (home: $TMP_ROOT/multiowner/smhome2; scope: triage; projects: ownedproj, other; added 2026-06-22)" \
+    "- docs - docs domain (home: $TMP_ROOT/multiowner/smhome3; scope: docs; projects: ownedproj; added 2026-06-22)")
+  IFS='|' read -r home proj fakebin _smhome <<EOF
+$rec
+EOF
+  write_brief "$home" own-refuse-a2 no-mistakes
+  out=$(run_spawn "$home" "$fakebin" own-refuse-a2 "$proj/ownedproj" claude --mode no-mistakes --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "multi-owner spawn should exit non-zero"
+  assert_contains "$out" "registered to secondmate(s) design,triage,docs" \
+    "refusal did not name every owner in one consistently joined list"
+  assert_absent "$home/state/own-refuse-a2.meta" "refused spawn wrote task metadata"
+  pass "fm-spawn: a refusal names every registered owner the same way at any arity"
 }
 
 test_allow_primary_spawn_override_passes_the_ownership_guard() {
@@ -304,17 +323,18 @@ $rec
 EOF
   write_brief "$home" own-batch-g1 no-mistakes
   out=$(run_spawn "$home" "$fakebin" "own-batch-g1=$proj/ownedproj" --mode no-mistakes --yolo off)
-  assert_contains "$out" "registered to secondmate design" "batch pair did not hit the ownership guard"
+  assert_contains "$out" "registered to secondmate(s) design" "batch pair did not hit the ownership guard"
 
   write_brief "$home" own-batch-g2 no-mistakes
   out=$(run_spawn "$home" "$fakebin" "own-batch-g2=$proj/ownedproj" --mode no-mistakes --yolo off --allow-primary-spawn)
   assert_contains "$out" "--allow-primary-spawn bypasses secondmate ownership" \
     "batch dispatch dropped the deliberate override before the per-pair guard"
-  assert_not_contains "$out" "registered to secondmate design" "batch pair refused despite the deliberate override"
+  assert_not_contains "$out" "registered to secondmate(s) design" "batch pair refused despite the deliberate override"
   pass "fm-spawn: batch dispatch forwards --allow-primary-spawn to every pair"
 }
 
 test_fresh_spawn_into_owned_project_refuses_and_writes_no_meta
+test_refusal_names_every_owner_when_several_claim_the_project
 test_allow_primary_spawn_override_passes_the_ownership_guard
 test_secondmate_spawn_is_unaffected_by_the_ownership_guard
 test_relaunch_is_unaffected_by_the_ownership_guard

--- a/tests/fm-spawn-secondmate-ownership.test.sh
+++ b/tests/fm-spawn-secondmate-ownership.test.sh
@@ -103,7 +103,7 @@ run_spawn() {  # <home> <fakebin> <spawn-args...>
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$TMP_ROOT/projects-unused" FM_CONFIG_OVERRIDE="$home/config" \
     FM_SPAWN_NO_GUARD=1 FM_BACKEND=tmux FM_FAKE_DIR="${FM_FAKE_DIR:-}" \
-    PATH="$fakebin:$PATH" \
+    TMUX='' PATH="$fakebin:$PATH" \
     "$SPAWN" "$@" 2>&1
 }
 
@@ -238,14 +238,28 @@ test_override_spawn_records_every_bypassed_owner_on_the_task_record() {
 }
 
 test_unowned_project_or_missing_registry_spawns_past_the_guard() {
-  local rec home proj fakebin out
+  local rec home proj fakebin out line
   rec=$(make_home unowned)
   IFS='|' read -r home proj fakebin _smhome <<EOF
 $rec
 EOF
+  assert_absent "$home/data/secondmates.md" "the missing-registry fixture wrote a registry"
   write_brief "$home" own-free-d1 no-mistakes
   out=$(run_spawn "$home" "$fakebin" own-free-d1 "$proj/freeproj" claude --mode no-mistakes --yolo off)
   assert_not_contains "$out" "registered to secondmate" "unowned spawn with no registry hit the ownership guard"
+  assert_contains "$out" "$BACKEND_REACHED" "a missing registry stopped the spawn before the backend"
+  assert_not_contains "$out" "not on any registered secondmate" "a missing registry warned about registered scopes"
+
+  rec=$(make_home empty-reg)
+  IFS='|' read -r home proj fakebin _smhome <<EOF
+$rec
+EOF
+  printf '%s\n' '# Second mates' > "$home/data/secondmates.md"
+  write_brief "$home" own-free-d3 no-mistakes
+  out=$(run_spawn "$home" "$fakebin" own-free-d3 "$proj/freeproj" claude --mode no-mistakes --yolo off)
+  assert_not_contains "$out" "registered to secondmate" "unowned spawn with an entry-less registry hit the ownership guard"
+  assert_contains "$out" "$BACKEND_REACHED" "an entry-less registry stopped the spawn before the backend"
+  assert_not_contains "$out" "not on any registered secondmate" "an entry-less registry warned about registered scopes"
 
   line="- design - design domain (home: $TMP_ROOT/unowned/smhome; scope: design domain; projects: ownedproj; added 2026-06-22)"
   rec=$(make_home unowned-reg "$line")
@@ -256,7 +270,7 @@ EOF
   out=$(run_spawn "$home" "$fakebin" own-free-d2 "$proj/freeproj" claude --mode no-mistakes --yolo off)
   assert_not_contains "$out" "registered to secondmate" "unowned spawn with a registry hit the ownership guard"
   assert_contains "$out" "not on any registered secondmate projects: list" "unowned spawn did not warn about registered scopes"
-  pass "fm-spawn: unowned projects and missing registries pass the ownership guard"
+  pass "fm-spawn: unowned projects and missing or entry-less registries pass the ownership guard"
 }
 
 test_project_less_secondmate_never_claims_ownership_through_its_scope_text() {

--- a/tests/fm-spawn-secondmate-ownership.test.sh
+++ b/tests/fm-spawn-secondmate-ownership.test.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 # Behavior tests for fm-spawn.sh's secondmate project-ownership guard on fresh
-# ship and scout spawns. Every case stops before any endpoint exists: the guard
-# runs ahead of backend creation, and a fake tmux that exits non-zero backstops
-# cases meant to get past it.
+# ship and scout spawns. Refusal cases stop before any endpoint exists. Cases
+# that must get PAST the guard prove it: the refusing fake backend announces its
+# window-creation attempt, which fm-spawn only reaches well after the guard, and
+# the override and relaunch cases drive a lifecycle-modelling backend all the way
+# to a published state/<id>.meta record.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -11,23 +13,78 @@ set -u
 SPAWN="$ROOT/bin/fm-spawn.sh"
 TMP_ROOT=$(fm_test_tmproot fm-spawn-secondmate-ownership)
 
+# The refusing backend fails every request, but announces a window-creation
+# attempt on stderr. fm-spawn only asks a backend for a window long after the
+# ownership guard, so BACKEND_REACHED is a marker no pre-guard exit can print.
+BACKEND_REACHED="fake-backend: refusing to create a window"
+
+scaffold_secondmate_home() {  # <path>
+  local smhome=$1
+  mkdir -p "$smhome/state" "$smhome/bin" "$smhome/data"
+  printf '%s\n' 'fixture' > "$smhome/AGENTS.md"
+  printf '%s\n' design > "$smhome/.fm-secondmate-home"
+  printf '%s\n' 'You are a persistent second mate.' > "$smhome/data/charter.md"
+}
+
 make_home() {  # <name> [<secondmate-registry-line>...]
   local name=$1 home projects fakebin smhome
   shift
   home="$TMP_ROOT/$name/home"
   projects="$TMP_ROOT/$name/projects"
-  smhome="$TMP_ROOT/$name/secondmate-home"
+  smhome="$TMP_ROOT/$name/smhome"
   fakebin="$TMP_ROOT/$name/bin"
   mkdir -p "$home/data" "$home/state" "$home/config" "$projects/ownedproj" "$projects/freeproj" "$fakebin"
-  mkdir -p "$smhome/state" "$smhome/bin"
-  printf '%s\n' 'fixture' > "$smhome/AGENTS.md"
-  printf '%s\n' design > "$smhome/.fm-secondmate-home"
-  printf '#!/bin/sh\nexit 1\n' > "$fakebin/tmux"
+  scaffold_secondmate_home "$smhome"
+  cat > "$fakebin/tmux" <<SH
+#!/bin/sh
+case "\${1:-}" in
+  new-window) printf '%s\\n' "$BACKEND_REACHED" >&2 ;;
+esac
+exit 1
+SH
   chmod +x "$fakebin/tmux"
   if [ "$#" -gt 0 ]; then
     printf '%s\n' "$@" > "$home/data/secondmates.md"
   fi
   printf '%s\n' "$home|$projects|$fakebin|$smhome"
+}
+
+# A backend that models the pane lifecycle instead of refusing, so a spawn can
+# run to a published state/<id>.meta. Shaped after the stub in
+# tests/fm-control-relaunch.test.sh: FM_FAKE_DIR/command is the pane's current
+# command (the agent-liveness read a relaunch requires) and FM_FAKE_DIR/cwd is
+# the worktree treehouse is pretending to have entered.
+make_live_backend() {  # <dir> <worktree> <pane-command> [<existing-window>] -> echoes fakebin dir
+  local dir=$1 wt=$2 command=$3 window=${4:-}
+  local fb="$dir/fakebin" fake="$dir/fake"
+  mkdir -p "$fb" "$fake"
+  printf '%s' "$command" > "$fake/command"
+  printf '%s' "$wt" > "$fake/cwd"
+  : > "$fake/windows"
+  [ -z "$window" ] || printf '%s\n' "$window" > "$fake/windows"
+  cat > "$fb/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+D=$FM_FAKE_DIR
+case "${1:-}" in
+  new-window) printf 'fakewin1\n'; exit 0 ;;
+  display-message)
+    for a in "$@"; do
+      case "$a" in
+        *pane_current_command*) cat "$D/command"; printf '\n'; exit 0 ;;
+        *pane_current_path*) cat "$D/cwd"; printf '\n'; exit 0 ;;
+        *cursor_y*) printf '1\n'; exit 0 ;;
+      esac
+    done
+    printf 'firstmate\n'; exit 0 ;;
+  capture-pane) printf 'pane\n'; exit 0 ;;
+  list-windows) [ -f "$D/windows" ] && cat "$D/windows"; exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fb/tmux"
+  fm_fake_exit0 "$fb" treehouse
+  printf '%s\n' "$fb"
 }
 
 write_brief() {  # <home> <id> [<mode>]
@@ -45,7 +102,8 @@ run_spawn() {  # <home> <fakebin> <spawn-args...>
   FM_ROOT_OVERRIDE='' FM_HOME="$home" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$TMP_ROOT/projects-unused" FM_CONFIG_OVERRIDE="$home/config" \
-    FM_SPAWN_NO_GUARD=1 FM_BACKEND=tmux PATH="$fakebin:$PATH" \
+    FM_SPAWN_NO_GUARD=1 FM_BACKEND=tmux FM_FAKE_DIR="${FM_FAKE_DIR:-}" \
+    PATH="$fakebin:$PATH" \
     "$SPAWN" "$@" 2>&1
 }
 
@@ -81,41 +139,83 @@ EOF
 }
 
 test_secondmate_spawn_is_unaffected_by_the_ownership_guard() {
-  local rec home proj fakebin smhome out
-  line="- design - design domain (home: $TMP_ROOT/secondmate/smhome; scope: design domain; projects: ownedproj; added 2026-06-22)"
+  local rec home proj fakebin smhome out line
+  # The home directory's basename is itself on the registry's projects list, so
+  # a guard that did not exempt --secondmate would refuse this very spawn.
+  smhome="$TMP_ROOT/secondmate/design"
+  line="- design - design domain (home: $smhome; scope: design domain; projects: design, ownedproj; added 2026-06-22)"
   rec=$(make_home secondmate "$line")
-  IFS='|' read -r home proj fakebin smhome <<EOF
+  IFS='|' read -r home proj fakebin _unused <<EOF
 $rec
 EOF
-  out=$(run_spawn "$home" "$fakebin" design "$smhome" --secondmate 2>&1)
+  scaffold_secondmate_home "$smhome"
+  out=$(run_spawn "$home" "$fakebin" design "$smhome" --secondmate)
+  assert_contains "$out" "$BACKEND_REACHED" "secondmate spawn never reached the backend, so it never reached the guard position"
   assert_not_contains "$out" "registered to secondmate" "secondmate spawn hit the crewmate ownership guard"
   assert_not_contains "$out" "--allow-primary-spawn bypasses" "secondmate spawn required the primary override"
   pass "fm-spawn: --secondmate spawns are unaffected by the ownership guard"
 }
 
 test_relaunch_is_unaffected_by_the_ownership_guard() {
-  local rec home proj fakebin smhome out status
-  line="- design - design domain (home: $TMP_ROOT/relaunch/smhome; scope: design domain; projects: ownedproj; added 2026-06-22)"
-  rec=$(make_home relaunch "$line")
-  IFS='|' read -r home proj fakebin smhome <<EOF
-$rec
-EOF
-  mkdir -p "$home/worktrees/owned"
-  cat > "$home/state/own-relaunch-c1.meta" <<EOF
-window=fm-own-relaunch-c1
-endpoint_task_id=own-relaunch-c1
-worktree=$home/worktrees/owned
-project=$proj/ownedproj
-harness=claude
-kind=ship
-mode=no-mistakes
-yolo=off
-EOF
-  out=$(run_spawn "$home" "$fakebin" own-relaunch-c1 --relaunch claude)
-  status=$?
+  local dir home wt fakebin out line
+  dir="$TMP_ROOT/own-relaunch-c1"
+  home="$dir/home"
+  wt="$dir/wt"
+  mkdir -p "$home/data/own-relaunch-c1" "$home/state" "$home/config"
+  fm_git_worktree "$dir/ownedproj" "$wt" task-own-relaunch-c1
+  line="- design - design domain (home: $dir/smhome; scope: design domain; projects: ownedproj; added 2026-06-22)"
+  printf '%s\n' "$line" > "$home/data/secondmates.md"
+  printf '# brief\n\nDo the thing.\n' > "$home/data/own-relaunch-c1/brief.md"
+  fakebin=$(make_live_backend "$dir" "$wt" zsh fm-own-relaunch-c1)
+  fm_write_meta "$home/state/own-relaunch-c1.meta" \
+    "window=firstmate:fm-own-relaunch-c1" \
+    "endpoint_task_id=own-relaunch-c1" \
+    "worktree=$wt" \
+    "project=$dir/ownedproj" \
+    "harness=claude" \
+    "kind=ship" \
+    "mode=no-mistakes" \
+    "yolo=off" \
+    "tasktmp=/tmp/fm-own-relaunch-c1" \
+    "model=default" \
+    "effort=default"
+  FM_FAKE_DIR="$dir/fake"
+  out=$(run_spawn "$home" "$fakebin" own-relaunch-c1 --relaunch --harness claude)
   assert_not_contains "$out" "registered to secondmate" "relaunch hit the crewmate ownership guard"
-  [ "$status" -ne 0 ] || fail "relaunch should still fail later on the refusing fake backend"
-  pass "fm-spawn: --relaunch is unaffected by the ownership guard"
+  assert_contains "$out" "spawned own-relaunch-c1" "relaunch did not complete into its recorded endpoint"
+  assert_present "$home/state/own-relaunch-c1.meta" "relaunch did not keep the task record"
+  unset FM_FAKE_DIR
+  rm -rf /tmp/fm-own-relaunch-c1
+  pass "fm-spawn: --relaunch into a secondmate-owned project is unaffected by the ownership guard"
+}
+
+test_override_spawn_records_every_bypassed_owner_on_the_task_record() {
+  local dir home wt fakebin out status meta
+  dir="$TMP_ROOT/own-override-b2"
+  home="$dir/home"
+  wt="$dir/wt"
+  meta="$home/state/own-override-b2.meta"
+  mkdir -p "$home/data/own-override-b2" "$home/state" "$home/config"
+  fm_git_worktree "$dir/ownedproj" "$wt" task-own-override-b2
+  {
+    printf -- '- design - design domain (home: %s/smhome; scope: design domain; projects: ownedproj; added 2026-06-22)\n' "$dir"
+    printf -- '- triage - triage domain (home: %s/smhome2; scope: triage; projects: ownedproj, other; added 2026-06-22)\n' "$dir"
+  } > "$home/data/secondmates.md"
+  printf '# brief\n\n# Definition of done\nDelivery contract: mode=no-mistakes\n' > "$home/data/own-override-b2/brief.md"
+  fakebin=$(make_live_backend "$dir" "$wt" claude)
+  FM_FAKE_DIR="$dir/fake"
+  out=$(run_spawn "$home" "$fakebin" own-override-b2 "$dir/ownedproj" claude \
+    --mode no-mistakes --yolo off --allow-primary-spawn)
+  status=$?
+  unset FM_FAKE_DIR
+  [ "$status" -eq 0 ] || fail "override spawn should complete"$'\n'"$out"
+  assert_contains "$out" "--allow-primary-spawn bypasses secondmate ownership" "override did not print a loud notice"
+  assert_present "$meta" "override spawn published no task record"
+  assert_grep 'primary_spawn_override=1' "$meta" "task record did not record the deliberate override"
+  assert_grep 'primary_spawn_override_owners=design,triage' "$meta" \
+    "task record did not name every bypassed owner"
+  rm -rf /tmp/fm-own-override-b2
+  pass "fm-spawn: a deliberate override records every bypassed owner on the task record"
 }
 
 test_unowned_project_or_missing_registry_spawns_past_the_guard() {
@@ -138,6 +238,24 @@ EOF
   assert_not_contains "$out" "registered to secondmate" "unowned spawn with a registry hit the ownership guard"
   assert_contains "$out" "not on any registered secondmate projects: list" "unowned spawn did not warn about registered scopes"
   pass "fm-spawn: unowned projects and missing registries pass the ownership guard"
+}
+
+test_project_less_secondmate_never_claims_ownership_through_its_scope_text() {
+  local rec home proj fakebin out status line
+  line="- design - design domain (home: $TMP_ROOT/projectless/smhome; scope: docs, freeproj, release notes; projects: ; added 2026-06-22)"
+  rec=$(make_home projectless "$line")
+  IFS='|' read -r home proj fakebin _smhome <<EOF
+$rec
+EOF
+  write_brief "$home" own-scope-h1 no-mistakes
+  out=$(run_spawn "$home" "$fakebin" own-scope-h1 "$proj/freeproj" claude --mode no-mistakes --yolo off)
+  status=$?
+  assert_not_contains "$out" "registered to secondmate" "a project-less secondmate claimed ownership through its scope text"
+  assert_contains "$out" "$BACKEND_REACHED" "the spawn was stopped before the backend despite no ownership claim"
+  assert_contains "$out" "design (scope: docs, freeproj, release notes)" \
+    "the unowned-project warning dropped the scope it exists to surface"
+  [ "$status" -ne 0 ] || fail "the refusing fake backend should still fail the spawn"
+  pass "fm-spawn: a project-less secondmate's scope text is never an ownership claim"
 }
 
 test_unparseable_registry_entry_refuses_instead_of_voiding_ownership() {
@@ -200,7 +318,9 @@ test_fresh_spawn_into_owned_project_refuses_and_writes_no_meta
 test_allow_primary_spawn_override_passes_the_ownership_guard
 test_secondmate_spawn_is_unaffected_by_the_ownership_guard
 test_relaunch_is_unaffected_by_the_ownership_guard
+test_override_spawn_records_every_bypassed_owner_on_the_task_record
 test_unowned_project_or_missing_registry_spawns_past_the_guard
+test_project_less_secondmate_never_claims_ownership_through_its_scope_text
 test_unparseable_registry_entry_refuses_instead_of_voiding_ownership
 test_unreadable_registry_symlink_refuses_the_spawn
 test_batch_dispatch_carries_the_deliberate_override_to_every_pair

--- a/tests/fm-spawn-secondmate-ownership.test.sh
+++ b/tests/fm-spawn-secondmate-ownership.test.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Behavior tests for fm-spawn.sh's secondmate project-ownership guard on fresh
+# ship and scout spawns. Every case stops before any endpoint exists: the guard
+# runs ahead of backend creation, and a fake tmux that exits non-zero backstops
+# cases meant to get past it.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=$(fm_test_tmproot fm-spawn-secondmate-ownership)
+
+make_home() {  # <name> [<secondmate-registry-line>...]
+  local name=$1 home projects fakebin smhome
+  shift
+  home="$TMP_ROOT/$name/home"
+  projects="$TMP_ROOT/$name/projects"
+  smhome="$TMP_ROOT/$name/secondmate-home"
+  fakebin="$TMP_ROOT/$name/bin"
+  mkdir -p "$home/data" "$home/state" "$home/config" "$projects/ownedproj" "$projects/freeproj" "$fakebin"
+  mkdir -p "$smhome/state" "$smhome/bin"
+  printf '%s\n' 'fixture' > "$smhome/AGENTS.md"
+  printf '%s\n' design > "$smhome/.fm-secondmate-home"
+  printf '#!/bin/sh\nexit 1\n' > "$fakebin/tmux"
+  chmod +x "$fakebin/tmux"
+  if [ "$#" -gt 0 ]; then
+    printf '%s\n' "$@" > "$home/data/secondmates.md"
+  fi
+  printf '%s\n' "$home|$projects|$fakebin|$smhome"
+}
+
+write_brief() {  # <home> <id> [<mode>]
+  local home=$1 id=$2 mode=${3:-}
+  mkdir -p "$home/data/$id"
+  {
+    printf 'You are a crewmate.\n\n# Definition of done\n'
+    [ -z "$mode" ] || printf 'Delivery contract: mode=%s\n' "$mode"
+  } > "$home/data/$id/brief.md"
+}
+
+run_spawn() {  # <home> <fakebin> <spawn-args...>
+  local home=$1 fakebin=$2
+  shift 2
+  FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$TMP_ROOT/projects-unused" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SPAWN_NO_GUARD=1 FM_BACKEND=tmux PATH="$fakebin:$PATH" \
+    "$SPAWN" "$@" 2>&1
+}
+
+test_fresh_spawn_into_owned_project_refuses_and_writes_no_meta() {
+  local rec home proj fakebin smhome out status line
+  line="- design - design domain (home: $TMP_ROOT/refuse/smhome; scope: design domain; projects: ownedproj; added 2026-06-22)"
+  rec=$(make_home refuse "$line")
+  IFS='|' read -r home proj fakebin smhome <<EOF
+$rec
+EOF
+  write_brief "$home" own-refuse-a1 no-mistakes
+  out=$(run_spawn "$home" "$fakebin" own-refuse-a1 "$proj/ownedproj" claude --mode no-mistakes --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "owned-project spawn should exit non-zero"
+  assert_contains "$out" "registered to secondmate design" "refusal did not name the owning secondmate"
+  assert_contains "$out" "--allow-primary-spawn" "refusal did not name the deliberate override"
+  assert_absent "$home/state/own-refuse-a1.meta" "refused spawn wrote task metadata"
+  pass "fm-spawn: a fresh crewmate spawn into a secondmate-owned project refuses before metadata exists"
+}
+
+test_allow_primary_spawn_override_passes_the_ownership_guard() {
+  local rec home proj fakebin smhome out
+  line="- design - design domain (home: $TMP_ROOT/override/smhome; scope: design domain; projects: ownedproj; added 2026-06-22)"
+  rec=$(make_home override "$line")
+  IFS='|' read -r home proj fakebin smhome <<EOF
+$rec
+EOF
+  write_brief "$home" own-override-b1 no-mistakes
+  out=$(run_spawn "$home" "$fakebin" own-override-b1 "$proj/ownedproj" claude --mode no-mistakes --yolo off --allow-primary-spawn)
+  assert_not_contains "$out" "registered to secondmate" "override spawn was blocked by the ownership guard"
+  assert_contains "$out" "--allow-primary-spawn bypasses secondmate ownership" "override did not print a loud notice"
+  pass "fm-spawn: --allow-primary-spawn bypasses the ownership guard on an owned project"
+}
+
+test_secondmate_spawn_is_unaffected_by_the_ownership_guard() {
+  local rec home proj fakebin smhome out
+  line="- design - design domain (home: $TMP_ROOT/secondmate/smhome; scope: design domain; projects: ownedproj; added 2026-06-22)"
+  rec=$(make_home secondmate "$line")
+  IFS='|' read -r home proj fakebin smhome <<EOF
+$rec
+EOF
+  out=$(run_spawn "$home" "$fakebin" design "$smhome" --secondmate 2>&1)
+  assert_not_contains "$out" "registered to secondmate" "secondmate spawn hit the crewmate ownership guard"
+  assert_not_contains "$out" "--allow-primary-spawn bypasses" "secondmate spawn required the primary override"
+  pass "fm-spawn: --secondmate spawns are unaffected by the ownership guard"
+}
+
+test_relaunch_is_unaffected_by_the_ownership_guard() {
+  local rec home proj fakebin smhome out status
+  line="- design - design domain (home: $TMP_ROOT/relaunch/smhome; scope: design domain; projects: ownedproj; added 2026-06-22)"
+  rec=$(make_home relaunch "$line")
+  IFS='|' read -r home proj fakebin smhome <<EOF
+$rec
+EOF
+  mkdir -p "$home/worktrees/owned"
+  cat > "$home/state/own-relaunch-c1.meta" <<EOF
+window=fm-own-relaunch-c1
+endpoint_task_id=own-relaunch-c1
+worktree=$home/worktrees/owned
+project=$proj/ownedproj
+harness=claude
+kind=ship
+mode=no-mistakes
+yolo=off
+EOF
+  out=$(run_spawn "$home" "$fakebin" own-relaunch-c1 --relaunch claude)
+  status=$?
+  assert_not_contains "$out" "registered to secondmate" "relaunch hit the crewmate ownership guard"
+  [ "$status" -ne 0 ] || fail "relaunch should still fail later on the refusing fake backend"
+  pass "fm-spawn: --relaunch is unaffected by the ownership guard"
+}
+
+test_unowned_project_or_missing_registry_spawns_past_the_guard() {
+  local rec home proj fakebin out
+  rec=$(make_home unowned)
+  IFS='|' read -r home proj fakebin _smhome <<EOF
+$rec
+EOF
+  write_brief "$home" own-free-d1 no-mistakes
+  out=$(run_spawn "$home" "$fakebin" own-free-d1 "$proj/freeproj" claude --mode no-mistakes --yolo off)
+  assert_not_contains "$out" "registered to secondmate" "unowned spawn with no registry hit the ownership guard"
+
+  line="- design - design domain (home: $TMP_ROOT/unowned/smhome; scope: design domain; projects: ownedproj; added 2026-06-22)"
+  rec=$(make_home unowned-reg "$line")
+  IFS='|' read -r home proj fakebin _smhome <<EOF
+$rec
+EOF
+  write_brief "$home" own-free-d2 no-mistakes
+  out=$(run_spawn "$home" "$fakebin" own-free-d2 "$proj/freeproj" claude --mode no-mistakes --yolo off)
+  assert_not_contains "$out" "registered to secondmate" "unowned spawn with a registry hit the ownership guard"
+  assert_contains "$out" "not on any registered secondmate projects: list" "unowned spawn did not warn about registered scopes"
+  pass "fm-spawn: unowned projects and missing registries pass the ownership guard"
+}
+
+test_fresh_spawn_into_owned_project_refuses_and_writes_no_meta
+test_allow_primary_spawn_override_passes_the_ownership_guard
+test_secondmate_spawn_is_unaffected_by_the_ownership_guard
+test_relaunch_is_unaffected_by_the_ownership_guard
+test_unowned_project_or_missing_registry_spawns_past_the_guard
+echo "# all fm-spawn-secondmate-ownership tests passed"

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -109,6 +109,7 @@ init_changed_fixture_repo() {
     fm-bearings-snapshot.test.sh \
     fm-backend-cmux.test.sh \
     fm-backend-zellij.test.sh \
+    fm-spawn-secondmate-ownership.test.sh \
     fm-backend-orca.test.sh; do
     printf '#!/usr/bin/env bash\n# tests/lib.sh\n' >"$repo/tests/$script"
     chmod +x "$repo/tests/$script"
@@ -116,6 +117,7 @@ init_changed_fixture_repo() {
   : >"$repo/tests/lib.sh"
   : >"$repo/tests/fm-backend-herdr-eventwait.test.py"
   : >"$repo/bin/fm-supervisor-target-lib.sh"
+  : >"$repo/bin/fm-secondmate-registry-lib.sh"
   : >"$repo/bin/unmapped-source.sh"
   printf '# .claude/settings.json\n# .pi/extensions/fm-primary-turnend-guard.ts\n' \
     >>"$repo/tests/fm-cd-pretool-check.test.sh"
@@ -158,6 +160,14 @@ test_changed_dependency_selection_and_unmapped_failure() {
   assert_contains "$listed" "tests/fm-afk-return.test.sh" "supervisor target selects afk coverage"
   git -C "$repo" add bin/fm-supervisor-target-lib.sh
   git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm supervisor-change
+
+  printf '\n' >>"$repo/bin/fm-secondmate-registry-lib.sh"
+  listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)
+  assert_contains "$listed" "tests/fm-secondmate-safety.test.sh" "registry parser selects secondmate coverage"
+  assert_contains "$listed" "tests/fm-spawn-secondmate-ownership.test.sh" \
+    "registry parser selects the ownership-guard coverage that consumes it"
+  git -C "$repo" add bin/fm-secondmate-registry-lib.sh
+  git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm registry-lib-change
 
   printf '\n' >>"$repo/.agents/skills/example/SKILL.md"
   printf '\n' >>"$repo/.claude/settings.json"

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -119,6 +119,7 @@ init_changed_fixture_repo() {
   : >"$repo/bin/fm-supervisor-target-lib.sh"
   : >"$repo/bin/fm-secondmate-registry-lib.sh"
   : >"$repo/bin/fm-brief.sh"
+  : >"$repo/bin/fm-lint.sh"
   : >"$repo/bin/unmapped-source.sh"
   printf '# .claude/settings.json\n# .pi/extensions/fm-primary-turnend-guard.ts\n' \
     >>"$repo/tests/fm-cd-pretool-check.test.sh"
@@ -177,6 +178,15 @@ test_changed_dependency_selection_and_unmapped_failure() {
     "brief scaffolder selects the secondmate coverage that pins its generated charter note"
   git -C "$repo" add bin/fm-brief.sh
   git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm brief-change
+
+  printf '\n' >>"$repo/bin/fm-lint.sh"
+  listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)
+  assert_contains "$listed" "tests/fm-brief.test.sh" "lint script selects its own contract coverage"
+  if printf '%s\n' "$listed" | grep -Fqx "tests/fm-secondmate-safety.test.sh"; then
+    fail "lint script over-selected the secondmate family it cannot affect"
+  fi
+  git -C "$repo" add bin/fm-lint.sh
+  git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm lint-change
 
   printf '\n' >>"$repo/.agents/skills/example/SKILL.md"
   printf '\n' >>"$repo/.claude/settings.json"

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -118,6 +118,7 @@ init_changed_fixture_repo() {
   : >"$repo/tests/fm-backend-herdr-eventwait.test.py"
   : >"$repo/bin/fm-supervisor-target-lib.sh"
   : >"$repo/bin/fm-secondmate-registry-lib.sh"
+  : >"$repo/bin/fm-brief.sh"
   : >"$repo/bin/unmapped-source.sh"
   printf '# .claude/settings.json\n# .pi/extensions/fm-primary-turnend-guard.ts\n' \
     >>"$repo/tests/fm-cd-pretool-check.test.sh"
@@ -168,6 +169,14 @@ test_changed_dependency_selection_and_unmapped_failure() {
     "registry parser selects the ownership-guard coverage that consumes it"
   git -C "$repo" add bin/fm-secondmate-registry-lib.sh
   git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm registry-lib-change
+
+  printf '\n' >>"$repo/bin/fm-brief.sh"
+  listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)
+  assert_contains "$listed" "tests/fm-brief.test.sh" "brief scaffolder selects its own contract coverage"
+  assert_contains "$listed" "tests/fm-secondmate-safety.test.sh" \
+    "brief scaffolder selects the secondmate coverage that pins its generated charter note"
+  git -C "$repo" add bin/fm-brief.sh
+  git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm brief-change
 
   printf '\n' >>"$repo/.agents/skills/example/SKILL.md"
   printf '\n' >>"$repo/.claude/settings.json"


### PR DESCRIPTION
## Intent

Make bin/fm-spawn.sh refuse to create an ordinary crewmate or scout when a registered secondmate already owns that work. Derive ownership from data/secondmates.md using bin/fm-secondmate-registry-lib.sh; hard-refuse when the spawn project basename matches a secondmate projects: list (including projects/<name> and absolute-path forms), naming every owner when multiple match. Refusal must be actionable (name the secondmate to route to). Provide deliberate override via explicit spawn flag --allow-primary-spawn (never default), record it on task metadata plus loud stderr notice, document flag in fm-spawn.sh header. Do not hard-refuse on scope text; for unowned projects with a non-empty registry emit loud stderr warning naming candidate owners and continue. Do not break --secondmate spawns, --relaunch, or recovery paths; guard applies only to fresh ordinary crewmate or scout create. Missing or empty data/secondmates.md or unowned project spawns normally. Portable tests in tests/ following fm-task-delivery refusal-test shape covering refusal, override past guard, --secondmate unaffected, --relaunch unaffected, unowned/no-registry passes guard. Target bingb0t5/firstmate fork; do not merge.

## What Changed

- `bin/fm-spawn.sh` now runs a secondmate ownership guard on fresh crewmate and scout creates: it reads `data/secondmates.md`, matches the spawn project's basename against each entry's `projects:` field (bare name, `projects/<name>`, and absolute clone paths all state one claim), and hard-refuses while naming every registered owner to route to. An unowned project with a non-empty registry only emits a stderr warning listing each secondmate and its scope, then continues; a missing/empty registry spawns normally, while an unreadable or unparseable registry refuses rather than silently voiding a claim. `--secondmate` spawns and `--relaunch` skip the guard entirely.
- Added the deliberate `--allow-primary-spawn` override (never default): it passes the guard with a loud stderr notice, records `primary_spawn_override=1` and `primary_spawn_override_owners=<ids>` on the task meta, propagates to every pair in a batch dispatch, and is refused outright on `--relaunch` and `--secondmate` so a meaningless override never looks accepted. Documented in the `fm-spawn.sh` usage header.
- `bin/fm-secondmate-registry-lib.sh` gained `secondmate_registry_entries` (single-pass record collection over a non-whitespace field separator, with a distinct status for an untrustworthy registry) and `secondmate_registry_projects_field_has` (basename matching with array-based splitting so a metacharacter in the field is never glob-expanded). Routing docs in `AGENTS.md`, `docs/configuration.md`, the `secondmate-provisioning` skill, `fm-home-seed.sh`, and the generated charter note in `fm-brief.sh` now describe `projects:` as a spawn-ownership claim instead of non-exclusive provisioning data.
- New `tests/fm-spawn-secondmate-ownership.test.sh` covers refusal (with no meta written), multi-owner naming, path-form equivalence, override pass-through and meta recording, batch override propagation, `--secondmate`/`--relaunch` non-interference, unowned/no-registry passes, scope text never claiming ownership, and unparseable/unreadable registry refusals; `bin/fm-test-run.sh` maps the new suite into the pure-contract-unit family and refines change-to-family mapping for the registry lib, `fm-brief.sh`, and the lint scripts, with matching assertions in `tests/fm-test-run.test.sh`.

## Risk Assessment

✅ Low: The guard is a well-bounded, fail-closed read that runs only on fresh ship/scout spawns; I traced its ownership matching, glob-safety, empty-projects field handling, and malformed-registry refusal against the real library code and each produced the intended result, the override is recorded and correctly restricted, recovery/--relaunch/--secondmate paths are provably untouched, and the one broad-blast behavior (a malformed registry line blocking every fresh spawn) is the author-affirmed decision from a prior round and is now documented in the fm-spawn.sh header.

## Testing

Ran the change's own targeted suites (fm-spawn-secondmate-ownership, fm-test-run selection, fm-secondmate-safety) plus a from-scratch operator transcript that drives the real fm-spawn.sh through ten ownership scenarios; everything demonstrating the intent passes, the new tests were proven load-bearing by two reverted mutations, and the only failure is the pre-existing ruby-dependent Herdr CI timeout check that is unrelated to this change and unfixable in this sandbox.

<details>
<summary>Evidence: fm-spawn ownership guard - operator CLI transcript (10 scenarios)</summary>

Source: [fm-spawn ownership guard - operator CLI transcript (10 scenarios)](https://github.com/bingb0t5/firstmate/blob/84de34975cc457bb993522d77805ae130fdfe7ac/.no-mistakes/evidence/fm/spawn-own-g7/fm-spawn-ownership-guard-transcript.txt)

<code>$ fm-spawn.sh fix-nav-a1 projects/orca-ui claude --mode no-mistakes --yolo off&#10;error: project orca-ui is registered to secondmate(s) design,triage; spawn the worker in a registered secondmate home or pass --allow-primary-spawn for a deliberate primary-home exception&#10;[exit status: 1]&#10;&#10;$ ls $FM_HOME/state/&#10;(no fix-nav-a1.meta: the refusal lands before any task record exists)&#10;&#10;$ fm-spawn.sh fix-nav-a1 projects/orca-ui claude --mode no-mistakes --yolo off --allow-primary-spawn&#10;notice: --allow-primary-spawn bypasses secondmate ownership for orca-ui (registered owner(s): design,triage); route future work to that secondmate unless this exception remains deliberate&#10;spawned fix-nav-a1 harness=claude kind=ship mode=no-mistakes yolo=off window=firstmate:fm-fix-nav-a1 worktree=$TMP/wt-fix-nav-a1&#10;[exit status: 0]&#10;&#10;$ grep primary_spawn_override $FM_HOME/state/fix-nav-a1.meta&#10;primary_spawn_override=1&#10;primary_spawn_override_owners=design,triage&#10;&#10;$ fm-spawn.sh add-rate-b2 projects/api-gateway claude --mode no-mistakes --yolo off&#10;warning: project api-gateway is not on any registered secondmate projects: list; confirm primary-home work or route in-scope work to a secondmate - registered: design (scope: design system, component library); triage (scope: incident triage and on-call)&#10;spawned add-rate-b2 harness=claude kind=ship mode=no-mistakes yolo=off window=firstmate:fm-add-rate-b2 worktree=$TMP/wt-add-rate-b2&#10;[exit status: 0]&#10;&#10;$ fm-spawn.sh design $TMP/homes/design --secondmate&#10;spawned design harness=claude kind=secondmate mode=secondmate yolo=off window=firstmate:fm-design worktree=$TMP/homes/design&#10;[exit status: 0]&#10;&#10;$ fm-spawn.sh design $TMP/homes/design --secondmate --allow-primary-spawn&#10;error: --allow-primary-spawn applies only to fresh ship or scout spawns&#10;[exit status: 1]&#10;&#10;$ fm-spawn.sh look-d4 projects/marketing-site claude --scout&#10;error: project marketing-site is registered to secondmate(s) design; spawn the worker in a registered secondmate home or pass --allow-primary-spawn for a deliberate primary-home exception&#10;[exit status: 1]&#10;&#10;$ fm-spawn.sh fix-nav-a1 --relaunch --harness claude&#10;spawned fix-nav-a1 harness=claude kind=ship mode=no-mistakes yolo=off window=firstmate:fm-fix-nav-a1 worktree=$TMP/wt-fix-nav-a1&#10;[exit status: 0]&#10;&#10;$ fm-spawn.sh doc-c3 projects/billing-svc claude --mode no-mistakes --yolo off&#10;error: malformed secondmate registry entry: - triage - typo entry (home: $TMP/homes/triage; scope: triage; projects: api-gateway)&#10;error: refusing this spawn because secondmate project ownership cannot be resolved from $TMP/firstmate/data/secondmates.md; repair the registry (bin/fm-home-seed.sh validate reports the same records) and retry&#10;[exit status: 1]&#10;&#10;$ rm $FM_HOME/data/secondmates.md &amp;&amp; fm-spawn.sh doc-c3 projects/billing-svc claude --mode no-mistakes --yolo off&#10;spawned doc-c3 harness=claude kind=ship mode=no-mistakes yolo=off window=firstmate:fm-doc-c3 worktree=$TMP/wt-doc-c3&#10;[exit status: 0]</code>

```text
==============================================================
 1. The registry that states who owns what
==============================================================

$ cat $FM_HOME/data/secondmates.md
# Second mates

- design - design system (home: $TMP/homes/design; scope: design system, component library; projects: orca-ui, marketing-site; added 2026-06-22)
- triage - incident triage (home: $TMP/homes/triage; scope: incident triage and on-call; projects: projects/orca-ui; added 2026-07-02)

==============================================================
 2. Fresh crewmate spawn into a secondmate-owned project: REFUSED
==============================================================

$ fm-spawn.sh fix-nav-a1 projects/orca-ui claude --mode no-mistakes --yolo off
error: project orca-ui is registered to secondmate(s) design,triage; spawn the worker in a registered secondmate home or pass --allow-primary-spawn for a deliberate primary-home exception
[exit status: 1]

$ ls $FM_HOME/state/
(no fix-nav-a1.meta: the refusal lands before any task record exists)

==============================================================
 3. Same spawn with the deliberate override: allowed, loud, recorded
==============================================================

$ fm-spawn.sh fix-nav-a1 projects/orca-ui claude --mode no-mistakes --yolo off --allow-primary-spawn
notice: --allow-primary-spawn bypasses secondmate ownership for orca-ui (registered owner(s): design,triage); route future work to that secondmate unless this exception remains deliberate
spawned fix-nav-a1 harness=claude kind=ship mode=no-mistakes yolo=off window=firstmate:fm-fix-nav-a1 worktree=$TMP/wt-fix-nav-a1
[exit status: 0]

$ grep primary_spawn_override $FM_HOME/state/fix-nav-a1.meta
primary_spawn_override=1
primary_spawn_override_owners=design,triage

==============================================================
 4. Unowned project, non-empty registry: warns, then spawns
==============================================================

$ fm-spawn.sh add-rate-b2 projects/api-gateway claude --mode no-mistakes --yolo off
warning: project api-gateway is not on any registered secondmate projects: list; confirm primary-home work or route in-scope work to a secondmate - registered: design (scope: design system, component library); triage (scope: incident triage and on-call)
spawned add-rate-b2 harness=claude kind=ship mode=no-mistakes yolo=off window=firstmate:fm-add-rate-b2 worktree=$TMP/wt-add-rate-b2
[exit status: 0]

$ grep -c primary_spawn_override $FM_HOME/state/add-rate-b2.meta
0

==============================================================
 5. A --secondmate spawn is untouched by the guard
==============================================================

$ fm-spawn.sh design $TMP/homes/design --secondmate
warning: secondmate design sync skipped before launch: primary default-branch commit cannot be resolved
spawned design harness=claude kind=secondmate mode=secondmate yolo=off window=firstmate:fm-design worktree=$TMP/homes/design
[exit status: 0]

==============================================================
 6. Misusing the override outside a fresh ship/scout spawn: refused
==============================================================

$ fm-spawn.sh design $TMP/homes/design --secondmate --allow-primary-spawn
error: --allow-primary-spawn applies only to fresh ship or scout spawns
[exit status: 1]

==============================================================
 7. A scout spawn into an owned project refuses the same way
==============================================================

$ fm-spawn.sh look-d4 projects/marketing-site claude --scout
error: project marketing-site is registered to secondmate(s) design; spawn the worker in a registered secondmate home or pass --allow-primary-spawn for a deliberate primary-home exception
[exit status: 1]

==============================================================
 8. --relaunch into an owned project is unaffected by the guard
==============================================================

$ fm-spawn.sh fix-nav-a1 --relaunch --harness claude
spawned fix-nav-a1 harness=claude kind=ship mode=no-mistakes yolo=off window=firstmate:fm-fix-nav-a1 worktree=$TMP/wt-fix-nav-a1
[exit status: 0]

==============================================================
 9. A malformed registry line refuses instead of voiding a claim
==============================================================

$ fm-spawn.sh doc-c3 projects/billing-svc claude --mode no-mistakes --yolo off
error: malformed secondmate registry entry: - triage - typo entry (home: $TMP/homes/triage; scope: triage; projects: api-gateway)
error: refusing this spawn because secondmate project ownership cannot be resolved from $TMP/firstmate/data/secondmates.md; repair the registry (bin/fm-home-seed.sh validate reports the same records) and retry
[exit status: 1]

==============================================================
 10. No registry at all: the guard is silent and the spawn proceeds
==============================================================

$ rm $FM_HOME/data/secondmates.md && fm-spawn.sh doc-c3 projects/billing-svc claude --mode no-mistakes --yolo off
spawned doc-c3 harness=claude kind=ship mode=no-mistakes yolo=off window=firstmate:fm-doc-c3 worktree=$TMP/wt-doc-c3
[exit status: 0]
```
</details>
<details>
<summary>Evidence: Transcript generator (reproduces the evidence above from a clean checkout)</summary>

Source: [Transcript generator (reproduces the evidence above from a clean checkout)](https://github.com/bingb0t5/firstmate/blob/84de34975cc457bb993522d77805ae130fdfe7ac/.no-mistakes/evidence/fm/spawn-own-g7/fm-spawn-ownership-guard-transcript.gen.sh)

```text
#!/usr/bin/env bash
# Operator-perspective transcript for the fm-spawn secondmate-ownership guard.
set -u
ROOT=${ROOT:?}
TMP=$(mktemp -d /tmp/fm-own-evidence.XXXXXX)
HOME_DIR="$TMP/firstmate"
PROJ="$TMP/projects"
mkdir -p "$HOME_DIR/data" "$HOME_DIR/state" "$HOME_DIR/config" "$PROJ"

FB="$TMP/fakebin"; FAKE="$TMP/fake"; mkdir -p "$FB" "$FAKE"
printf 'claude' > "$FAKE/command"
: > "$FAKE/windows"
cat > "$FB/tmux" <<'SH'
#!/usr/bin/env bash
set -u
D=$FM_FAKE_DIR
case "${1:-}" in
  new-window) printf 'fakewin1\n'; exit 0 ;;
  display-message)
    for a in "$@"; do
      case "$a" in
        *pane_current_command*) cat "$D/command"; printf '\n'; exit 0 ;;
        *pane_current_path*) cat "$D/cwd"; printf '\n'; exit 0 ;;
        *cursor_y*) printf '1\n'; exit 0 ;;
      esac
    done
    printf 'firstmate\n'; exit 0 ;;
  capture-pane) printf 'pane\n'; exit 0 ;;
  list-windows) [ -f "$D/windows" ] && cat "$D/windows"; exit 0 ;;
esac
exit 0
SH
printf '#!/usr/bin/env bash\nexit 0\n' > "$FB/treehouse"
chmod +x "$FB/tmux" "$FB/treehouse"

mkproj() {  # <name> <task-id>
  local p="$PROJ/$1" wt="$TMP/wt-$2"
  mkdir -p "$p"
  git -C "$p" init -q
  git -C "$p" config user.email t@example.invalid
  git -C "$p" config user.name t
  printf 'x\n' > "$p/README.md"
  git -C "$p" add -A && git -C "$p" -c commit.gpgsign=false commit -qm init
  git clone --quiet --bare "$p" "$p.origin.git"
  git -C "$p" remote add origin "file://$(cd "$p.origin.git" && pwd)"
  git -C "$p" worktree add --quiet -b "task-$2" "$wt"
  printf '%s' "$wt" > "$FAKE/cwd"
}

brief() { mkdir -p "$HOME_DIR/data/$1"; printf 'You are a crewmate.\n\n# Definition of done\nDelivery contract: mode=no-mistakes\n' > "$HOME_DIR/data/$1/brief.md"; }

spawn() {
  FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
    FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
    FM_PROJECTS_OVERRIDE="$PROJ" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
    FM_GATE_REFUSE_BYPASS=1 FM_SPAWN_NO_GUARD=1 FM_BACKEND=tmux FM_FAKE_DIR="$FAKE" TMUX='' \
    PATH="$FB:$PATH" "$ROOT/bin/fm-spawn.sh" "$@" 2>&1
}

show() { printf '\n$ %s\n' "$1"; }

cat > "$HOME_DIR/data/secondmates.md" <<REG
# Second mates

- design - design system (home: $TMP/homes/design; scope: design system, component library; projects: orca-ui, marketing-site; added 2026-06-22)
- triage - incident triage (home: $TMP/homes/triage; scope: incident triage and on-call; projects: projects/orca-ui; added 2026-07-02)
REG
mkdir -p "$TMP/homes/design" "$TMP/homes/triage"

echo "=============================================================="
echo " 1. The registry that states who owns what"
echo "=============================================================="
show "cat \$FM_HOME/data/secondmates.md"
sed "s#$TMP#\$TMP#g" "$HOME_DIR/data/secondmates.md"

echo
echo "=============================================================="
echo " 2. Fresh crewmate spawn into a secondmate-owned project: REFUSED"
echo "=============================================================="
mkproj orca-ui fix-nav-a1; brief fix-nav-a1
show "fm-spawn.sh fix-nav-a1 projects/orca-ui claude --mode no-mistakes --yolo off"
out=$(spawn fix-nav-a1 "$PROJ/orca-ui" claude --mode no-mistakes --yolo off); rc=$?
printf '%s\n' "$out" | sed "s#$TMP#\$TMP#g"
printf '[exit status: %s]\n' "$rc"
show "ls \$FM_HOME/state/"
ls "$HOME_DIR/state/" 2>/dev/null || true
printf '(no fix-nav-a1.meta: the refusal lands before any task record exists)\n'

echo
echo "=============================================================="
echo " 3. Same spawn with the deliberate override: allowed, loud, recorded"
echo "=============================================================="
show "fm-spawn.sh fix-nav-a1 projects/orca-ui claude --mode no-mistakes --yolo off --allow-primary-spawn"
out=$(spawn fix-nav-a1 "$PROJ/orca-ui" claude --mode no-mistakes --yolo off --allow-primary-spawn); rc=$?
printf '%s\n' "$out" | sed "s#$TMP#\$TMP#g"
printf '[exit status: %s]\n' "$rc"
show "grep primary_spawn_override \$FM_HOME/state/fix-nav-a1.meta"
grep primary_spawn_override "$HOME_DIR/state/fix-nav-a1.meta" || echo "(none)"

echo
echo "=============================================================="
echo " 4. Unowned project, non-empty registry: warns, then spawns"
echo "=============================================================="
mkproj api-gateway add-rate-b2; brief add-rate-b2
show "fm-spawn.sh add-rate-b2 projects/api-gateway claude --mode no-mistakes --yolo off"
out=$(spawn add-rate-b2 "$PROJ/api-gateway" claude --mode no-mistakes --yolo off); rc=$?
printf '%s\n' "$out" | sed "s#$TMP#\$TMP#g"
printf '[exit status: %s]\n' "$rc"
show "grep -c primary_spawn_override \$FM_HOME/state/add-rate-b2.meta"
grep -c primary_spawn_override "$HOME_DIR/state/add-rate-b2.meta" || true

echo
echo "=============================================================="
echo " 5. A --secondmate spawn is untouched by the guard"
echo "=============================================================="
SM="$TMP/homes/design"
mkdir -p "$SM/state" "$SM/bin" "$SM/data"
printf 'fixture\n' > "$SM/AGENTS.md"
printf 'design\n' > "$SM/.fm-secondmate-home"
printf 'You are a persistent second mate.\n' > "$SM/data/charter.md"
printf '%s' "$SM" > "$FAKE/cwd"
show "fm-spawn.sh design \$TMP/homes/design --secondmate"
out=$(spawn design "$SM" --secondmate); rc=$?
printf '%s\n' "$out" | sed "s#$TMP#\$TMP#g"
printf '[exit status: %s]\n' "$rc"

echo
echo "=============================================================="
echo " 6. Misusing the override outside a fresh ship/scout spawn: refused"
echo "=============================================================="
show "fm-spawn.sh design \$TMP/homes/design --secondmate --allow-primary-spawn"
out=$(spawn design "$SM" --secondmate --allow-primary-spawn); rc=$?
printf '%s\n' "$out" | sed "s#$TMP#\$TMP#g"
printf '[exit status: %s]\n' "$rc"

echo
echo "=============================================================="
echo " 7. A scout spawn into an owned project refuses the same way"
echo "=============================================================="
mkproj marketing-site look-d4; brief look-d4
show "fm-spawn.sh look-d4 projects/marketing-site claude --scout"
out=$(spawn look-d4 "$PROJ/marketing-site" claude --scout); rc=$?
printf '%s\n' "$out" | sed "s#$TMP#\$TMP#g"
printf '[exit status: %s]\n' "$rc"

echo
echo "=============================================================="
echo " 8. --relaunch into an owned project is unaffected by the guard"
echo "=============================================================="
printf 'zsh' > "$FAKE/command"
printf '%s' "$TMP/wt-fix-nav-a1" > "$FAKE/cwd"
printf 'fm-fix-nav-a1\n' > "$FAKE/windows"
show "fm-spawn.sh fix-nav-a1 --relaunch --harness claude"
out=$(spawn fix-nav-a1 --relaunch --harness claude); rc=$?
printf '%s\n' "$out" | sed "s#$TMP#\$TMP#g"
printf '[exit status: %s]\n' "$rc"

echo
echo "=============================================================="
echo " 9. A malformed registry line refuses instead of voiding a claim"
echo "=============================================================="
printf -- '- triage - typo entry (home: %s/homes/triage; scope: triage; projects: api-gateway)\n' "$TMP" >> "$HOME_DIR/data/secondmates.md"
mkproj billing-svc doc-c3; brief doc-c3
show "fm-spawn.sh doc-c3 projects/billing-svc claude --mode no-mistakes --yolo off"
out=$(spawn doc-c3 "$PROJ/billing-svc" claude --mode no-mistakes --yolo off); rc=$?
printf '%s\n' "$out" | sed "s#$TMP#\$TMP#g"
printf '[exit status: %s]\n' "$rc"

echo
echo "=============================================================="
echo " 10. No registry at all: the guard is silent and the spawn proceeds"
echo "=============================================================="
rm -f "$HOME_DIR/data/secondmates.md"
show "rm \$FM_HOME/data/secondmates.md && fm-spawn.sh doc-c3 projects/billing-svc claude --mode no-mistakes --yolo off"
printf 'claude' > "$FAKE/command"
printf '%s' "$TMP/wt-doc-c3" > "$FAKE/cwd"
: > "$FAKE/windows"
out=$(spawn doc-c3 "$PROJ/billing-svc" claude --mode no-mistakes --yolo off); rc=$?
printf '%s\n' "$out" | sed "s#$TMP#\$TMP#g"
printf '[exit status: %s]\n' "$rc"

rm -rf "$TMP" /tmp/fm-fix-nav-a1 /tmp/fm-add-rate-b2 /tmp/fm-doc-c3
```
</details>
<details>
<summary>Evidence: Mutation check: tests fail without the guard / without registry-side basename normalization</summary>

```text
# guard call removed from bin/fm-spawn.sh
not ok - refusal did not name the owning secondmate (missing: 'registered to secondmate(s) design')
--- output ---
fake-backend: refusing to create a window

# basename reduction removed from secondmate_registry_projects_field_has
ok - fm-spawn: a fresh crewmate spawn into a secondmate-owned project refuses before metadata exists
ok - fm-spawn: a refusal names every registered owner the same way at any arity
not ok - path-form registry entries did not state the same ownership claim as a bare name (missing: 'registered to secondmate(s) design,triage')
--- output ---
warning: project ownedproj is not on any registered secondmate projects: list; ...

# both mutations reverted; `git status --porcelain` clean
```
</details>
- Outcome: ⚠️ 1 info across 1 run (5m33s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"e7f5c0f7251eb3d87c145760617e373e025902a0","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 5 issues found → auto-fixed (6) ✅</summary>

- ⚠️ `bin/fm-spawn.sh:882` - Batch dispatch does not forward --allow-primary-spawn to the per-pair re-exec, so the deliberate override is unreachable on a documented spawn path. `shared_args` forwards --harness/--model/--effort/--backend/--mode/--yolo (lines 883-891) but not the new flag; the parent parses it (line 322), passes the --secondmate/--relaunch validation at line 380, then re-execs each pair at lines 902/904 without it. Concrete path: `fm-spawn.sh fix-a-k3=projects/ownedproj --mode no-mistakes --yolo off --allow-primary-spawn` with `ownedproj` on a secondmate&#39;s projects: list -&gt; the child spawn hits spawn_secondmate_ownership_guard with ALLOW_PRIMARY_SPAWN=0 and refuses, printing `batch: FAILED to spawn fix-a-k3`, so the operator&#39;s explicit exception is silently discarded. Fix by adding `[ &#34;$ALLOW_PRIMARY_SPAWN&#34; -eq 0 ] || shared_args+=(--allow-primary-spawn)` next to the other shared flags and listing it in the batch header note at line 155.
- ⚠️ `bin/fm-spawn.sh:1362` - A registry entry that fails to parse silently loses its ownership claim AND makes the fallback warning assert something false. secondmate_registry_project_owners (bin/fm-secondmate-registry-lib.sh:357) and the scope loop (bin/fm-spawn.sh:1352) both `continue` on an unparseable `- ` line, and secondmate_registry_has_entries returns success as soon as any one line parses. Verified by executing the helpers against a registry whose third line is `- broken - typo entry (home: /tmp/c; scope: x; projects: gamma)` (missing the `added &lt;date&gt;` field): has_entries=yes, owners(gamma)=empty. A fresh spawn into `gamma` therefore prints `warning: project gamma is not on any registered secondmate projects: list` - a wrong statement, since gamma IS listed - and proceeds into the primary home with no refusal. The same silent miss occurs for a hand-edited space-separated list (`projects: alpha beta`), because secondmate_registry_projects_field_has splits on comma only. secondmate_registry_validate_bindings hard-errors on exactly this malformed line, so the guard is the only consumer that fails open; a symlinked registry is likewise treated as `no entries` (lib lines 338/353) rather than as the unsafe condition every other caller reports. Decide whether an unparseable `- ` line should refuse or at minimum warn loudly naming the line, instead of silently voiding that secondmate&#39;s ownership.
- ⚠️ `AGENTS.md:241` - The always-loaded routing contract now states the opposite of what fm-spawn.sh enforces, and was not updated with the change. AGENTS.md:241 says &#34;Its scope field drives routing and its project list is non-exclusive provisioning data, not ownership&#34; and AGENTS.md:272 says &#34;Route by the nature of the work against each registered secondmate scope, not by a non-exclusive clone list&#34;; .agents/skills/secondmate-provisioning/SKILL.md:33 and :42 (&#34;The `projects:` field is a non-exclusive clone list, not ownership.&#34;) repeat it, and bin/fm-brief.sh:217 bakes &#34;they are not an exclusive ownership claim&#34; into every generated secondmate charter. Only docs/configuration.md:197 was updated. A primary firstmate following AGENTS.md will spawn a crewmate into a listed project and hit an unexplained hard refusal. Reconcile the wording in AGENTS.md, SKILL.md, and the fm-brief.sh charter note with the enforced refusal (or state explicitly that the clone list is now spawn-exclusive while scope still drives routing judgment).
- ℹ️ `bin/fm-spawn.sh:1336` - PRIMARY_SPAWN_OVERRIDE and PRIMARY_SPAWN_OVERRIDE_OWNERS are only ever assigned inside the guard&#39;s override branch; unlike ALLOW_PRIMARY_SPAWN (line 297) they are not initialized with the other spawn flags, so their values can be inherited from the environment. With PRIMARY_SPAWN_OVERRIDE=1 exported and the guard not taking the override branch, line 2765 writes a bogus `primary_spawn_override=1` line and line 2767 dereferences the unset PRIMARY_SPAWN_OVERRIDE_OWNERS under `set -u`, aborting mid meta-write after the backend window and worktree already exist. Initialize both to `0` / empty next to ALLOW_PRIMARY_SPAWN=0.
- ℹ️ `bin/fm-spawn.sh:1348` - spawn_secondmate_ownership_guard reads data/secondmates.md three times (has_entries, project_owners, then the scope loop) and the scope loop at lines 1348-1360 re-implements verbatim the `- `-prefix / parse_line / skip-unparseable iteration that the new lib helper already owns. A single lib helper emitting `id&lt;TAB&gt;projects&lt;TAB&gt;scope` per parsed entry would collapse all three passes into one and give the malformed-line handling above a single place to live.

🔧 Fix: harden secondmate ownership guard and reconcile routing docs
4 issues (1 error, 1 warning, 2 infos) still open:

- 🚨 `bin/fm-spawn.sh:1345` - An entry with an empty `projects:` field makes the guard match SCOPE TEXT and hard-refuse, which the intent explicitly forbids (&#34;Do not hard-refuse on scope text&#34;). `secondmate_registry_entries` (bin/fm-secondmate-registry-lib.sh:370) serializes each record as `id&lt;TAB&gt;projects&lt;TAB&gt;scope`; a project-less secondmate has an empty projects field, so the line is `id\t\tscope`. In `while IFS=$&#39;\t&#39; read -r id projects scope` (line 1345) tab is IFS *whitespace*, so the two adjacent tabs collapse into one delimiter and `projects` receives the scope text while `scope` becomes empty. Executed against the real lib with the generated shape `- design - design domain (home: /tmp/owntest/d; scope: docs, tooling, release notes; projects: ; added 2026-06-22)`: `id=[design] projects=[docs, tooling, release notes] scope=[]`, and `secondmate_registry_projects_field_has &#34;$projects&#34; tooling` returns 0. A fresh `fm-spawn.sh fix-a-k3 projects/tooling claude --mode ... --yolo off` therefore prints `error: project tooling is registered to secondmate design` - a false statement - and refuses. This shape is first-class generated output, not hand-editing: `fm-home-seed.sh --no-projects` reaches `write_registry` with an empty `&#34;$@&#34;`, so `join_projects` returns &#34;&#34; (bin/fm-home-seed.sh:949,744), and bin/fm-remote-home-seed.sh:213 has the same format. Second symptom from the same line: even when nothing matches, the fallback warning renders `design (scope: )` (line 1353/1373) - it drops the scope it was written to surface. Fix by not letting `read` collapse empty fields, e.g. split explicitly (`id=${line%%$&#39;\t&#39;*}; rest=${line#*$&#39;\t&#39;}; projects=${rest%%$&#39;\t&#39;*}; scope=${rest#*$&#39;\t&#39;}`) or serialize with a non-IFS-whitespace delimiter.
- ⚠️ `tests/fm-spawn-secondmate-ownership.test.sh:83` - Both &#34;unaffected&#34; cases pass vacuously: neither spawn ever reaches the guard, so they cannot detect the regression they are named for. fm-spawn.sh checks `[ -f &#34;$BRIEF&#34; ] || { echo &#34;error: no brief at $BRIEF&#34;; exit 1; }` at line 1732, and the guard is called at line 1735. (a) `test_secondmate_spawn_is_unaffected_by_the_ownership_guard` (line 83) passes `$smhome` = `$TMP_ROOT/secondmate/secondmate-home` (make_home line 18) while its registry line records `home: $TMP_ROOT/secondmate/smhome` - a different path - so `secondmate_registry_validate_bindings` at fm-spawn.sh:1676 already exits 1; even past that, smhome has no `data/charter.md` and no `$home/data/design/brief.md`, so line 1732 exits first. (b) `test_relaunch_is_unaffected_by_the_ownership_guard` (line 96) never calls `write_brief` for `own-relaunch-c1`, so BRIEF (`$DATA/own-relaunch-c1/brief.md`, line 1731) is missing and the run exits at 1732 - the non-zero status the test asserts comes from the missing brief, not from &#34;the refusing fake backend&#34; its comment claims. Delete the guard-condition `[ &#34;$KIND&#34; != secondmate ]` or `[ &#34;$RELAUNCH&#34; -eq 0 ]` and both tests still pass. Fix the secondmate fixture&#39;s `home:` path (and add `$smhome/data/charter.md`), add `write_brief &#34;$home&#34; own-relaunch-c1`, and assert a marker that only appears after the guard position so the cases are load-bearing.
- ℹ️ `tests/fm-spawn-secondmate-ownership.test.sh:78` - The intent requires the override to be &#34;record[ed] on task metadata plus loud stderr notice&#34;, but only the notice is asserted. `test_allow_primary_spawn_override_passes_the_ownership_guard` stops at the fake tmux, so `$home/state/own-override-b1.meta` is never written and the `primary_spawn_override=1` / `primary_spawn_override_owners=&lt;ids&gt;` lines (bin/fm-spawn.sh:2776-2778) have zero coverage - including the multi-owner comma-join at line 1358 and their survival through `preserve_relaunch_meta` on a later relaunch. A case that drives an override spawn to a published meta (or a relaunch over a meta that already carries those keys) would pin the recorded value.
- ℹ️ `bin/fm-secondmate-registry-lib.sh:314` - `secondmate_registry_project_basename` strips a leading `projects/` before calling `basename`, but `basename` already yields the same result for that form (`basename projects/foo` = `foo`), and the sole caller passes `$PROJ_ABS`, an absolute path, so the `case` arm never fires. The three lines can be dropped for a plain `basename &#34;$1&#34;` without changing any outcome.

🔧 Fix: fix registry field splitting and make guard tests load-bearing
2 issues (1 warning, 1 info) still open:

- ⚠️ `bin/fm-test-run.sh:149` - The new test is classified `pure-contract-unit`, but `bin/fm-secondmate-registry-lib.sh` - which now owns the two helpers the guard&#39;s whole correctness rests on (`secondmate_registry_entries`, `secondmate_registry_projects_field_has`) - maps only to the `secondmate` family in `families_for_changed_path` (bin/fm-test-run.sh:960, via the `bin/fm-secondmate*` arm; no earlier case arm matches it). `tests/fm-spawn-secondmate-ownership.test.sh` is the ONLY test in the repo referencing either helper (grep over tests/ returns just that file), and no test in the `secondmate` family touches them. Concrete consequence: a future edit to bin/fm-secondmate-registry-lib.sh alone - for example reverting the `$&#39;\x1f&#39;` separator back to a tab, which is exactly the round-2 error - selects the `secondmate` family only and runs zero coverage of the ownership guard, so the change-selected shard reports green. It only passes today because this change happens to touch bin/fm-spawn.sh too (which selects backend-dispatch + pure-contract-unit). Fix by giving bin/fm-secondmate-registry-lib.sh its own arm in `families_for_changed_path` that emits both `secondmate` and `pure-contract-unit`, the same shape already used for bin/fm-timeout-lib.sh and bin/fm-composer-lib.sh.
- ℹ️ `bin/fm-spawn.sh:1364` - The three-arm `case &#34;${#owner_ids[@]}&#34;` produces an inconsistent label and duplicates a join the function already computes elsewhere. With 2 owners the refusal reads `registered to secondmate design and triage`; with 3 it reads `registered to secondmate design, triage, docs` - the singular noun in front of a bare comma list parses as one secondmate whose name contains commas, and the 3+ arm silently drops the `and` the 2-arm establishes. The override branch at line 1358 already builds a comma-joined list with `owners=$(IFS=,; printf &#39;%s&#39; &#34;${owner_ids[*]}&#34;)`; reusing that single join for the refusal (and pluralising the noun, e.g. `registered to secondmate(s) &lt;a,b,c&gt;`) removes five lines and makes every arity read the same way. Non-functional: the test only asserts the single-owner string `registered to secondmate design` and the comma-joined meta value `primary_spawn_override_owners=design,triage`, neither of which this touches.

🔧 Fix: map registry lib to guard tests, unify owner list
5 issues (1 error, 1 warning, 3 infos) still open:

- 🚨 `tests/fm-spawn-secondmate-ownership.test.sh:105` - `run_spawn` does not pin `TMUX`, so the two `BACKEND_REACHED` assertions fail whenever the suite runs from inside a tmux session - which is exactly how this repo&#39;s own crewmates run (bin/fm-spawn.sh launches every worker in a tmux window). Path: with `$TMUX` set, `fm_backend_tmux_container_ensure` (bin/backends/tmux.sh:66-67) takes the `tmux display-message -p &#39;#S&#39;` branch; the refusing fake (line 38-44) exits 1 for every subcommand, and that is a bare simple command, so `SES=$(fm_backend_tmux_container_ensure)` at bin/fm-spawn.sh:1951 trips `set -eu` (line 211) and fm-spawn exits before `fm_backend_tmux_create_task` ever calls `new-window`. `assert_contains &#34;$out&#34; &#34;$BACKEND_REACHED&#34;` at line 172 (`test_secondmate_spawn_is_unaffected_by_the_ownership_guard`) and line 273 (`test_project_less_secondmate_never_claims_ownership_through_its_scope_text`) then both fail. With `$TMUX` unset the `has-session || new-session` branch is taken; I confirmed empirically (bash 5.2) that errexit does not fire for that `||` list, so `printf &#39;firstmate&#39;` runs, the spawn continues, and `new-window` prints the marker - which is why these tests pass only in a tmux-less shell. 45 existing call sites across tests/ pin `TMUX` explicitly for this reason (e.g. tests/fm-spawn-dispatch-profile.test.sh:127 uses `TMUX=&#34;fake,1,0&#34;`, tests/fm-secondmate-harness.test.sh:457 uses `TMUX=&#39;&#39;`). Fix: add `TMUX=&#39;&#39;` to run_spawn&#39;s env prefix - it forces the failure-tolerant branch and is also correct for the `make_live_backend` cases, whose fake exits 0 on an unmatched `has-session`.
- ⚠️ `tests/fm-spawn-secondmate-ownership.test.sh:248` - The intent requires &#34;Missing or empty data/secondmates.md ... spawns normally&#34;, but the only case for it cannot detect a regression. `test_unowned_project_or_missing_registry_spawns_past_the_guard`&#39;s first half (lines 246-248) runs `make_home unowned` with no registry line, so `$home/data/secondmates.md` never exists, and its single assertion is `assert_not_contains &#34;$out&#34; &#34;registered to secondmate&#34;`. If `secondmate_registry_entries` (bin/fm-secondmate-registry-lib.sh:345) were changed to return 2 for a missing file, the guard would refuse with &#34;error: secondmate registry is unavailable or unsafe&#34; plus &#34;refusing this spawn because secondmate project ownership cannot be resolved&#34; - neither contains the substring &#34;registered to secondmate&#34;, so this case still passes while the required behavior is gone. The second half is load-bearing only because it asserts the guard&#39;s own warning text. Separately, the empty-registry variant the intent names alongside missing (file present, zero `- ` entries, the `found=0` -&gt; return 1 path at bin/fm-secondmate-registry-lib.sh:369) has no case at all. Fix: assert `$BACKEND_REACHED` in the missing-registry half - the same marker the project-less case already proves is reachable with a non-git `freeproj` - and add an empty-file case that asserts the same marker plus the absence of the unowned warning.
- ℹ️ `bin/fm-secondmate-registry-lib.sh:315` - After the round-3 fix stripped its `projects/` case arm, `secondmate_registry_project_basename` is `basename &#34;$1&#34;` and nothing else, with exactly one caller (bin/fm-spawn.sh:1336). The indirection now costs a lib export and a name to keep in sync while adding no behavior; inlining `proj_name=$(basename &#34;$proj_abs&#34;)` at the call site removes the function and the shared-surface obligation.
- ℹ️ `bin/fm-spawn.sh:20` - The `--allow-primary-spawn` paragraph (lines 20-32) is inserted between the `--relaunch` usage synopsis line (line 19) and the `--relaunch` prose that explains it (lines 33-47), so the header now reads as if the new flag belongs to `--relaunch` - the opposite of what it does. The flag is also absent from every Usage synopsis line (lines 4-6), even though those lines enumerate the other optional ship/scout flags (`[--harness ...]`, `[--model ...]`, `[--effort ...]`, `[--backend ...]`) and this one applies to both the ship and scout forms. Moving the paragraph below the `--relaunch` block and adding `[--allow-primary-spawn]` to the ship and scout synopsis lines keeps the intent&#39;s &#34;document flag in fm-spawn.sh header&#34; requirement while restoring the header&#39;s flag-follows-its-synopsis structure.
- ℹ️ `bin/fm-test-run.sh:1038` - This change edits the generated charter note in bin/fm-brief.sh:217 and, in lockstep, the literal copy of that sentence in tests/fm-secondmate-safety.test.sh:649. But `bin/fm-brief.sh` maps only to `pure-contract-unit` in `families_for_changed_path` (line 1038), while fm-secondmate-safety.test.sh is in the `secondmate` family - so a future edit to that note alone selects a shard that never runs the test which hard-codes it, and the change-selected run reports green while the secondmate suite is broken. It passes today only because this change also touches bin/fm-home-seed.sh, which does select `secondmate`. This is the same defect class as the registry-lib mapping just fixed in round 3, and the coupling predates this change; adding `secondmate` alongside `pure-contract-unit` for bin/fm-brief.sh (its own case arm, as bin/fm-secondmate-registry-lib.sh now has) closes it.

🔧 Fix: pin TMUX in spawn tests, harden registry coverage
2 issues (1 warning, 1 info) still open:

- ⚠️ `bin/fm-test-run.sh:1042` - Folding `bin/fm-brief.sh` into the pre-existing lint/install `case` arm makes four unrelated files select the whole `secondmate` family. `bin/fm-lint.sh`, `bin/fm-lint-workflows.sh`, `bin/fm-install-shellcheck.sh`, and `bin/fm-install-actionlint.sh` share the arm at lines 1036-1043 and previously emitted only `pure-contract-unit`; they now also emit `secondmate`. Concrete consequence: `printf &#39;\n&#39; &gt;&gt; bin/fm-lint.sh` followed by `bin/fm-test-run.sh --list --changed` now selects all 18 scripts in the `secondmate` family - including `tests/fm-remote-secondmate-lifecycle-e2e.test.sh` (170240ms) and `tests/fm-secondmate-harness.test.sh` (123471ms) - for a change that cannot affect any of them, adding roughly 500s+ to every change-selected run touching a lint or install script. The arm&#39;s own comment (&#34;Scaffolds both crew briefs and the secondmate charter&#34;) describes only `fm-brief.sh`, confirming the other four members were swept in incidentally. Fix by giving `bin/fm-brief.sh` its own arm emitting `pure-contract-unit` + `secondmate` (the exact shape `bin/fm-secondmate-registry-lib.sh` already got at lines 960-966) and restoring the lint/install group to `pure-contract-unit` only. The new assertions in tests/fm-test-run.test.sh:172-177 only exercise `bin/fm-brief.sh`, so they keep passing after the split.
- ℹ️ `bin/fm-spawn.sh:382` - The two new refusals that reject `--allow-primary-spawn` outside a fresh ship/scout spawn have no coverage. Line 382 refuses it alongside `--relaunch`; line 387 refuses it alongside `--secondmate`. `tests/fm-spawn-secondmate-ownership.test.sh` exercises `--relaunch` and `--secondmate` only *without* the flag, so both branches could be deleted (or their conditions inverted, e.g. `-eq 1` instead of `-eq 0`, which would refuse every legitimate override) and the suite would stay green - the existing override cases never pass `--relaunch`/`--secondmate`, and the existing relaunch/secondmate cases never pass the flag. Two cases in the same refusal shape as `test_fresh_spawn_into_owned_project_refuses_and_writes_no_meta` (non-zero exit plus the literal &#34;--allow-primary-spawn applies only to fresh ship or scout spawns&#34;) would make them load-bearing.

🔧 Fix: split brief test-family arm, cover override misuse refusals
3 warnings still open:

- ⚠️ `bin/fm-secondmate-registry-lib.sh:322` - `for entry in $field` in `secondmate_registry_projects_field_has` splits with a custom IFS but leaves pathname expansion enabled, so any glob metacharacter in a `projects:` field is expanded against fm-spawn&#39;s current working directory before the comparison at line 324. Reproduced (bash 5.2): with CWD containing files `alpha-notes` and `alphaX`, a registry entry `projects: alpha*` makes `f &#34;alpha*&#34; &#34;alpha&#34;` return 1 (the secondmate&#39;s claim on `alpha` is silently voided, so `spawn_secondmate_ownership_guard` falls through to the &#34;not on any registered secondmate projects: list&#34; warning and the spawn proceeds), while `f &#34;alpha*&#34; &#34;alphaX&#34;` returns 0 (an ownership claim is invented for a project the registry never listed, hard-refusing that spawn). Both outcomes are a wrong ownership set with no error, and both depend on the operator&#39;s CWD rather than on the registry. The comparison is intended to be literal - the function&#39;s own comment only claims separator flexibility, not pattern matching. Fix by disabling globbing for the split, e.g. `local -` plus `set -f` before the loop (or `IFS=... read -ra` into an array), leaving the `[ &#34;$entry&#34; = &#34;$project&#34; ]` comparison unchanged.
- ⚠️ `bin/fm-secondmate-registry-lib.sh:324` - The intent requires: &#34;hard-refuse when the spawn project basename matches a secondmate projects: list (including projects/&lt;name&gt; and absolute-path forms)&#34;. Only the SPAWN side of that match normalizes path forms: bin/fm-spawn.sh:1336 does `proj_name=$(basename &#34;$proj_abs&#34;)` on a PROJ_ABS that `resolve_project_dir_arg` (bin/fm-spawn.sh:1554-1560) already turned into an absolute path, so `projects/foo` and `/abs/path/foo` both reduce to `foo`. The REGISTRY side compares raw: line 324 is `[ &#34;$entry&#34; = &#34;$project&#34; ]`. Concrete case: `data/secondmates.md` holding `- design - d (home: /h/design; scope: s; projects: projects/alpha; added 2026-06-22)` and a spawn of `fm-spawn.sh t1 projects/alpha claude --mode no-mistakes --yolo off` computes proj_name=`alpha`, compares `projects/alpha` != `alpha`, records no owner, and lets the spawn through with only the unowned-project warning - the exact drift the guard exists to prevent, silently. The same holds for an absolute-path entry. Note this is not dead ambiguity the earlier rounds settled: round 3 stripped the `projects/*` case arm from `secondmate_registry_project_basename` and round 4 inlined the rest, and both were correct for the spawn side (PROJ_ABS is always absolute), but neither added the equivalent normalization on the registry side. The parenthetical attaches grammatically to &#34;a secondmate projects: list&#34;, and the lib already deliberately tolerates hand-edited registries (line 315-316: &#34;a hand-edited list separated by whitespace still states a claim&#34;), which argues the same tolerance was meant for path-form entries. Because the two readings of the criterion produce materially different behavior, this needs the author&#39;s decision rather than a unilateral fix: either normalize each registry entry with the same basename reduction before comparing, or state that the criterion only ever described the spawn-side argument forms.
- ⚠️ `bin/fm-spawn.sh:1338` - A single unparseable `- ` line in data/secondmates.md now hard-refuses EVERY fresh crewmate and scout spawn in the primary home, and `--allow-primary-spawn` does not release it. Path: `secondmate_registry_entries` (bin/fm-secondmate-registry-lib.sh:365-370) returns 2 on the first line that `secondmate_registry_parse_line` rejects; the guard&#39;s rc==2 arm at bin/fm-spawn.sh:1338-1342 returns 1 before ever reading ALLOW_PRIMARY_SPAWN (which is only consulted at line 1358, inside the owner-found branch), so line 1731&#39;s `spawn_secondmate_ownership_guard &#34;$PROJ_ABS&#34; || exit 1` aborts the spawn. A registry with a well-formed entry for `design` plus one typo&#39;d line (e.g. a missing `; added YYYY-MM-DD` suffix) blocks a spawn into an entirely unrelated project. This is a behavior change the fix rounds introduced, not the author&#39;s: commit 32ad190&#39;s `secondmate_registry_project_owners` did `secondmate_registry_parse_line &#34;$line&#34; || continue`, so a malformed sibling line never affected other projects. The escalation itself is defensible - it matches what `secondmate_registry_validate_bindings` already does for --secondmate spawns, and the second error line names the repair command - but it leaves the operator with no deliberate escape hatch on the path that already has one for the stronger case (a known, named owner). Deciding whether `--allow-primary-spawn` should also cover &#34;ownership is unresolvable&#34; is a product call about the override&#39;s scope, so it belongs to the author rather than to an automated fix.

🔧 Fix: match registry project entries literally by basename
✅ Re-checked - no issues remain.
</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `tests/fm-test-run.test.sh:664` - Pre-existing environment gap, unrelated to this change: tests/fm-test-run.test.sh&#39;s `test_herdr_ci_family_run_has_a_step_timeout` fails with &#34;ruby is required to parse .github/workflows/ci.yml as YAML&#34; because ruby is not installed in this sandbox. The same test and the same hard `fail` on missing ruby exist unchanged at the base commit 038d0f7, and installing a system package is outside the worktree boundary, so I could not fix it here. All assertions in that file that this change adds or touches pass.
- <code>`bash tests/fm-spawn-secondmate-ownership.test.sh` - 14/14 pass</code>
- <code>`TMUX=&#34;/tmp/fake-tmux-sock,1234,0&#34; bash tests/fm-spawn-secondmate-ownership.test.sh` - confirms the suite is tmux-session independent</code>
- <code>`bash tests/fm-test-run.test.sh` - new change-selection assertions for bin/fm-secondmate-registry-lib.sh, bin/fm-brief.sh and bin/fm-lint.sh all pass</code>
- <code>`bash tests/fm-secondmate-safety.test.sh` - passes (pins the edited charter note)</code>
- <code>`bin/fm-test-run.sh --list --changed --base 038d0f7` - this change&#39;s diff selects tests/fm-spawn-secondmate-ownership.test.sh</code>
- <code>Mutation check: deleted the `spawn_secondmate_ownership_guard &#34;$PROJ_ABS&#34; || exit 1` call in bin/fm-spawn.sh, confirmed the suite fails at the first refusal case, restored the file</code>
- <code>Mutation check: removed the trailing-slash strip + `entry=${entry##*/}` basename reduction in `secondmate_registry_projects_field_has`, confirmed the projects/&lt;name&gt; and absolute-path case fails, restored the file</code>
- <code>Manual end-to-end transcript: scaffolded a firstmate home, registry, git projects and a fake tmux backend, then ran real `bin/fm-spawn.sh` for refusal, --allow-primary-spawn override + meta record, unowned-project warning, --secondmate, --relaunch, scout refusal, misused override, malformed registry line, and missing registry</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
