### PR TITLE
fix(lock): acquire the session lock on Windows/Git Bash

### DIFF
--- a/bin/fm-session-lock-lib.sh
+++ b/bin/fm-session-lock-lib.sh
@@ -88,6 +88,128 @@ fm_harness_process_matches() {  # <comm> <args>
   return 1
 }
 
+# --- Windows (Git Bash/MSYS) native ancestry --------------------------------
+#
+# The POSIX walk below reads the process tree with `ps -o comm= -p` and climbs by
+# `ps -o ppid= -p`. Neither works under Git Bash/MSYS: its Cygwin `ps` rejects the
+# `-o` fields outright, and even where a process listing is available its parent
+# chain dead-ends at the MSYS boundary (the outermost shell reports ppid 1), so it
+# can never reach the native harness process such as claude.exe that actually owns
+# the session. The result was that fm_harness_ancestry_pid always failed and every
+# Windows session refused the fleet lock as read-only.
+#
+# On Windows these helpers walk the REAL Windows process tree instead, keyed on
+# Windows PIDs throughout, and hand the same (comm, args) evidence to
+# fm_harness_process_matches so the identity contract is exactly the one the POSIX
+# path uses. The current shell's Windows PID is read from /proc/<pid>/winpid, which
+# Git Bash exposes. The process table comes from a single Win32_Process query (a
+# stable WMI/kernel fact, not a release-note-fragile string), captured once per
+# invocation. FM_WIN_PROCTABLE_CMD and FM_WIN_SELF_WINPID override the two sources
+# so the walk is testable against a deterministic tree on any host, and
+# FM_FORCE_WINDOWS forces this path for that test.
+fm_is_windows() {
+  case "${FM_FORCE_WINDOWS:-${OSTYPE:-}}" in
+    1|msys*|mingw*|cygwin*) return 0 ;;
+  esac
+  return 1
+}
+
+# Print the current shell's Windows PID - the pid whose ancestry is walked.
+fm_win_self_winpid() {
+  local wp
+  if [ -n "${FM_WIN_SELF_WINPID:-}" ]; then
+    printf '%s\n' "$FM_WIN_SELF_WINPID"
+    return 0
+  fi
+  wp=$(cat "/proc/$$/winpid" 2>/dev/null) || return 1
+  case "$wp" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  printf '%s\n' "$wp"
+}
+
+# Query the native process table once and emit it as
+# "<pid><TAB><ppid><TAB><name><TAB><commandline>" lines. Command-line tabs and
+# newlines are flattened to spaces so every process stays one parseable line.
+fm_win_proctable_native() {
+  local out
+  # shellcheck disable=SC2016 # single quotes are deliberate: $_/$cl/$t are PowerShell variables, not shell
+  out=$(powershell.exe -NoProfile -NonInteractive -Command '
+$t = [char]9
+Get-CimInstance Win32_Process | ForEach-Object {
+  $cl = $_.CommandLine
+  if ($cl) { $cl = $cl -replace "[\r\n\t]", " " }
+  ($_.ProcessId, $_.ParentProcessId, $_.Name, $cl) -join $t
+}
+' 2>/dev/null) || return 1
+  printf '%s\n' "$out" | tr -d '\r'
+}
+
+FM_WIN_PROCTABLE_CACHE=
+fm_win_proctable() {
+  if [ -n "${FM_WIN_PROCTABLE_CMD:-}" ]; then
+    eval "$FM_WIN_PROCTABLE_CMD"
+    return
+  fi
+  if [ -n "$FM_WIN_PROCTABLE_CACHE" ]; then
+    printf '%s\n' "$FM_WIN_PROCTABLE_CACHE"
+    return 0
+  fi
+  FM_WIN_PROCTABLE_CACHE=$(fm_win_proctable_native) || return 1
+  [ -n "$FM_WIN_PROCTABLE_CACHE" ] || return 1
+  printf '%s\n' "$FM_WIN_PROCTABLE_CACHE"
+}
+
+# A trusted harness anchor for the Windows walk, or return 1.
+#
+# MSYS emulates fork() by spawning through a helper that then exits, so a script
+# launched as a child (fm-session-start.sh spawns fm-lock.sh, which spawns the
+# walk) is routinely orphaned: its recorded Win32 parent pid names an already-dead
+# launcher, and the parent-chain walk cannot climb from it to the harness. Claude
+# Code exports its own pid as CLAUDE_PID into every descendant's environment, which
+# survives that orphaning because it is inherited, not derived from the live tree.
+# When CLAUDE_PID names a process the table still confirms as a live harness we
+# anchor the walk there; a missing, stale, or non-harness value fails closed to the
+# honest parent-chain walk from this shell's own Windows PID.
+fm_win_harness_anchor_pid() {
+  local pid=${CLAUDE_PID:-}
+  case "$pid" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  fm_harness_pid_alive "$pid" || return 1
+  printf '%s\n' "$pid"
+}
+
+# Windows counterpart of fm_harness_ancestry_pids: the same contiguous-run and
+# stop-at-first-gap semantics, walked over the native Windows process tree, but
+# seeded from the trusted harness anchor when one is available.
+fm_win_harness_ancestry_pids() {
+  local pid comm args ppid line table extending=0 printed=0
+  pid=$(fm_win_harness_anchor_pid) || pid=$(fm_win_self_winpid) || return 1
+  table=$(fm_win_proctable) || return 1
+  for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
+    line=$(printf '%s\n' "$table" | awk -F '\t' -v p="$pid" '$1 == p { print; exit }')
+    [ -n "$line" ] || break
+    comm=$(printf '%s' "$line" | cut -f3)
+    args=$(printf '%s' "$line" | cut -f4-)
+    ppid=$(printf '%s' "$line" | cut -f2)
+    if fm_harness_process_matches "$comm" "$args"; then
+      printf '%s\n' "$pid"
+      printed=1
+      [ "$FM_HARNESS_IS_CLAUDE" -eq 1 ] || break
+      extending=1
+    elif [ "$extending" -eq 1 ]; then
+      break
+    fi
+    case "$ppid" in
+      ''|*[!0-9]*) break ;;
+    esac
+    [ "$ppid" -gt 0 ] || break
+    pid=$ppid
+  done
+  [ "$printed" -eq 1 ]
+}
+
 # Walk the current process ancestry (up to 16 hops) and print this session's
 # contiguous verified-harness ancestry, innermost pid first.
 #
@@ -107,6 +229,10 @@ fm_harness_process_matches() {  # <comm> <args>
 # session cannot be read off the ancestry at all, so the whole contiguous run is
 # reported and the callers below decide what they need from it.
 fm_harness_ancestry_pids() {
+  if fm_is_windows; then
+    fm_win_harness_ancestry_pids
+    return
+  fi
   local pid=$$ comm args extending=0 printed=0
   for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
     comm=$(ps -o comm= -p "$pid" 2>/dev/null) || break
@@ -145,7 +271,18 @@ EOF
 
 # True if $1 is a live process that looks like a verified harness.
 fm_harness_pid_alive() {
-  local pid=$1 comm args
+  local pid=$1 comm args line
+  case "$pid" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  if fm_is_windows; then
+    line=$(fm_win_proctable | awk -F '\t' -v p="$pid" '$1 == p { print; exit }')
+    [ -n "$line" ] || return 1
+    comm=$(printf '%s' "$line" | cut -f3)
+    args=$(printf '%s' "$line" | cut -f4-)
+    fm_harness_process_matches "$comm" "$args"
+    return
+  fi
   kill -0 "$pid" 2>/dev/null || return 1
   comm=$(ps -o comm= -p "$pid" 2>/dev/null) || return 1
   args=$(ps -o args= -p "$pid" 2>/dev/null)

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -13,6 +13,25 @@ FM_LOCK_STALE_AFTER="${FM_LOCK_STALE_AFTER:-2}"
 # confirm and 0.5s attach polls, and forking uname per call is a measurable cost on
 # the platform (Git Bash/MSYS) that already pays the highest fork price.
 _FM_UNAME=$(uname 2>/dev/null || echo unknown)
+
+# The lock helpers below build every lock as a symlink (fm_lock_try_create uses
+# `ln -s`). On Windows/MSYS Git Bash's default `ln -s` silently COPIES the target
+# instead of creating a symlink, so fm_lock_try_create can never validate the link
+# it just made, fm_lock_try_acquire always fails, and fm_lock_acquire_wait spins
+# forever - every fleet lock deadlocks. Requesting winsymlinks:nativestrict makes
+# `ln -s` create a real NTFS symlink (needs Developer Mode or admin, i.e. the
+# SeCreateSymbolicLink privilege) and otherwise fail loudly rather than copy. This
+# is a no-op off Windows, where OSTYPE never matches, and it is only appended when
+# no winsymlinks policy is already set so an operator's explicit choice is kept.
+case "${OSTYPE:-}" in
+  msys*|mingw*|cygwin*)
+    case "${MSYS:-}" in
+      *winsymlinks*) : ;;
+      *) export MSYS="${MSYS:+$MSYS }winsymlinks:nativestrict" ;;
+    esac
+    ;;
+esac
+
 mkdir -p "$STATE"
 
 fm_current_pid() {

--- a/tests/fm-session-lock-ancestry.test.sh
+++ b/tests/fm-session-lock-ancestry.test.sh
@@ -35,10 +35,12 @@ NAMED_CLAUDE="$FAKEBIN/claude"
 # --- unit layer: identity behind a deterministic process table ---------------
 
 # Run one library expression with <fakebin> shadowing ps. kill is stubbed so
-# liveness questions are decided by the process table alone.
+# liveness questions are decided by the process table alone. FM_FORCE_WINDOWS=0
+# pins the POSIX path so these fake-ps cases are host-independent (on a Windows
+# host fm_is_windows would otherwise divert them to the native-table path).
 lib_eval() {  # <fakebin> <expression>
   local fakebin=$1 expr=$2
-  PATH="$fakebin:$PATH" bash -c "
+  FM_FORCE_WINDOWS=0 PATH="$fakebin:$PATH" bash -c "
     . \"\$0\"
     kill() { return 0; }
     $expr
@@ -220,6 +222,110 @@ SH
   pass "session-lock: a live version-named session holding the lock is not mistaken for a stale owner"
 }
 
+# --- windows layer: native ancestry over an injected process table ----------
+#
+# The Windows walk cannot use the fake ps above: it reads a native process table
+# and the shell's own Windows PID instead of `ps -o` fields. FM_WIN_PROCTABLE_CMD
+# and FM_WIN_SELF_WINPID inject both and FM_FORCE_WINDOWS forces the path, so the
+# logic is exercised on any host with no Windows and no real ps. CLAUDE_PID is
+# always passed explicitly ('' means unset) so the ambient value under which this
+# suite runs can never leak into a case.
+
+setup_windows_tables() {
+  WIN_TABLE="$TMP_ROOT/win-table.tsv"
+  WIN_TABLE_ORPHAN="$TMP_ROOT/win-table-orphan.tsv"
+  WIN_TABLE_NOHARNESS="$TMP_ROOT/win-table-noharness.tsv"
+  # bash -> bash -> claude.exe -> powershell.exe -> explorer.exe (a full chain).
+  printf '%s\t%s\t%s\t%s\n' \
+    5000 4000 bash.exe bash \
+    4000 3000 bash.exe bash \
+    3000 2000 claude.exe 'claude --resume' \
+    2000 1000 powershell.exe powershell \
+    1000 0 explorer.exe explorer > "$WIN_TABLE"
+  # Same tree with the self's parent (4000) missing: the MSYS orphaning case.
+  printf '%s\t%s\t%s\t%s\n' \
+    5000 4000 bash.exe bash \
+    3000 2000 claude.exe 'claude --resume' \
+    2000 1000 powershell.exe powershell > "$WIN_TABLE_ORPHAN"
+  # A tree whose self (8000) has no harness ancestor, though a claude exists
+  # elsewhere and is NOT reachable from 8000.
+  printf '%s\t%s\t%s\t%s\n' \
+    8000 7000 bash.exe bash \
+    7000 0 bash.exe bash \
+    3000 2000 claude.exe claude > "$WIN_TABLE_NOHARNESS"
+}
+
+# Run one library expression on the Windows path against table file $1, with this
+# shell's Windows PID forced to $2 and CLAUDE_PID set to $3 ('' = unset).
+win_eval() {  # <table-file> <self-winpid> <claude-pid> <expression>
+  CLAUDE_PID="$3" FM_FORCE_WINDOWS=1 FM_WIN_SELF_WINPID="$2" FM_WIN_PROCTABLE_CMD="cat '$1'" \
+    bash -c '. "$0"; '"$4" "$LIB"
+}
+
+test_win_anchor_resolves_and_owns() {
+  setup_windows_tables
+  local got state
+  got=$(win_eval "$WIN_TABLE" 5000 3000 'fm_harness_ancestry_pid') \
+    || fail "windows anchor: the harness was not resolved at all"
+  [ "$got" = 3000 ] || fail "windows anchor: resolved '$got', expected the harness pid 3000"
+  win_eval "$WIN_TABLE" 5000 3000 'fm_harness_pid_alive 3000' \
+    || fail "windows: a live harness pid was not recognized"
+  if win_eval "$WIN_TABLE" 5000 3000 'fm_harness_pid_alive 2000'; then
+    fail "windows: a non-harness pid passed the harness-liveness predicate"
+  fi
+  state="$TMP_ROOT/win-owns/state"
+  mkdir -p "$state"
+  printf '3000\n' > "$state/.lock"
+  win_eval "$WIN_TABLE" 5000 3000 "fm_session_lock_owned_by_self '$state'" \
+    || fail "windows: the session holding the lock did not recognize itself as owner"
+  pass "session-lock windows: the CLAUDE_PID anchor resolves the harness and owns its lock"
+}
+
+test_win_anchor_rescues_orphaned_self() {
+  setup_windows_tables
+  local got
+  if win_eval "$WIN_TABLE_ORPHAN" 5000 '' 'fm_harness_ancestry_pid' >/dev/null; then
+    fail "windows: an orphaned self resolved a harness with no anchor and a broken chain"
+  fi
+  got=$(win_eval "$WIN_TABLE_ORPHAN" 5000 3000 'fm_harness_ancestry_pid') \
+    || fail "windows anchor: an orphaned self was not rescued by CLAUDE_PID"
+  [ "$got" = 3000 ] || fail "windows anchor: rescued to '$got', expected 3000"
+  pass "session-lock windows: CLAUDE_PID rescues a session orphaned from its harness"
+}
+
+test_win_selfwalk_without_anchor() {
+  setup_windows_tables
+  local got
+  got=$(win_eval "$WIN_TABLE" 5000 '' 'fm_harness_ancestry_pid') \
+    || fail "windows self-walk: the harness was not resolved without an anchor"
+  [ "$got" = 3000 ] || fail "windows self-walk: resolved '$got', expected 3000"
+  pass "session-lock windows: the parent-chain walk resolves the harness when the chain is intact"
+}
+
+test_win_invalid_anchor_falls_back_to_walk() {
+  setup_windows_tables
+  local got
+  got=$(win_eval "$WIN_TABLE" 5000 2000 'fm_harness_ancestry_pid') \
+    || fail "windows: a non-harness anchor was not rejected in favor of the walk"
+  [ "$got" = 3000 ] || fail "windows non-harness anchor: resolved '$got', expected 3000"
+  got=$(win_eval "$WIN_TABLE" 5000 999999 'fm_harness_ancestry_pid') \
+    || fail "windows: a stale anchor was not rejected in favor of the walk"
+  [ "$got" = 3000 ] || fail "windows stale anchor: resolved '$got', expected 3000"
+  pass "session-lock windows: an invalid or stale CLAUDE_PID fails closed to the honest walk"
+}
+
+test_win_unrelated_harness_never_owns() {
+  setup_windows_tables
+  local state
+  state="$TMP_ROOT/win-unrelated/state"
+  mkdir -p "$state"
+  printf '3000\n' > "$state/.lock"
+  if win_eval "$WIN_TABLE_NOHARNESS" 8000 '' "fm_session_lock_owned_by_self '$state'"; then
+    fail "windows: a harness outside this ancestry was claimed as this session's lock owner"
+  fi
+  pass "session-lock windows: an unrelated harness is not mistaken for this session's lock owner"
+}
+
 # --- end-to-end layer: the real Stop auto-arm in real process trees ----------
 
 install_autoarm_scripts() {
@@ -360,6 +466,21 @@ test_version_named_session_is_identified_on_both_platforms
 test_ordinary_paths_are_never_harness_processes
 test_harness_beyond_a_gap_never_owns_the_lock
 test_competing_version_named_session_is_seen_as_live
-test_e2e_version_named_session_claims_the_home
-test_e2e_daemon_parented_session_claims_the_home
-test_e2e_daemon_parented_version_named_session_keeps_its_lock
+test_win_anchor_resolves_and_owns
+test_win_anchor_rescues_orphaned_self
+test_win_selfwalk_without_anchor
+test_win_invalid_anchor_falls_back_to_walk
+test_win_unrelated_harness_never_owns
+
+# The e2e fixtures build real POSIX process trees and read them with `ps -o`, so
+# they require a host whose ps supports it. Git Bash/MSYS ps does not (that is the
+# very gap the Windows path exists for), and there the real auto-arm would take
+# the native-table path and anchor on this suite's own harness, not the fixture.
+# Skip them there; CI runs on hosts with a POSIX ps and exercises them fully.
+if ps -o ppid= -p "$$" >/dev/null 2>&1; then
+  test_e2e_version_named_session_claims_the_home
+  test_e2e_daemon_parented_session_claims_the_home
+  test_e2e_daemon_parented_version_named_session_keeps_its_lock
+else
+  pass "session-lock e2e: skipped - host ps lacks POSIX -o support the fixtures require"
+fi

--- a/tests/fm-wake-queue.test.sh
+++ b/tests/fm-wake-queue.test.sh
@@ -994,7 +994,30 @@ test_historical_annotation_skips_announced_status() {
   pass "historical annotations replay nothing already announced and keep everything new"
 }
 
+test_windows_source_requests_native_symlinks() {
+  local lib state got
+  lib="$ROOT/bin/fm-wake-lib.sh"
+  state="$TMP_ROOT/winsymlinks/state"
+  mkdir -p "$state"
+  # OSTYPE is assigned inside the child (bash resets it at startup, so an inherited
+  # value would be overwritten) before the library is sourced.
+  got=$(FM_STATE_OVERRIDE="$state" bash -c 'OSTYPE=msys; unset MSYS; . "$0"; printf "%s" "${MSYS-}"' "$lib") \
+    || fail "sourcing the wake library on a Windows OSTYPE failed"
+  case "$got" in
+    *winsymlinks:nativestrict*) ;;
+    *) fail "Windows source did not request native symlinks (the locks would deadlock); MSYS=[$got]" ;;
+  esac
+  got=$(FM_STATE_OVERRIDE="$state" bash -c 'OSTYPE=msys; MSYS=winsymlinks:native; . "$0"; printf "%s" "$MSYS"' "$lib") \
+    || fail "sourcing with an explicit MSYS policy failed"
+  [ "$got" = "winsymlinks:native" ] || fail "an operator's explicit winsymlinks policy was overridden; MSYS=[$got]"
+  got=$(FM_STATE_OVERRIDE="$state" bash -c 'OSTYPE=linux-gnu; unset MSYS; . "$0"; printf "%s" "${MSYS-UNSET}"' "$lib") \
+    || fail "sourcing the wake library off Windows failed"
+  [ "$got" = "UNSET" ] || fail "a non-Windows source touched MSYS; MSYS=[$got]"
+  pass "wake-lib: a Windows source requests native symlinks so symlink-based locks do not deadlock"
+}
+
 test_self_held_lock_reclaims_instead_of_deadlocking
+test_windows_source_requests_native_symlinks
 test_secondmate_foreign_queue_stall_is_one_shot_and_read_only
 test_secondmate_stall_marker_rejects_symlink
 test_acknowledged_stall_publication_survives_pre_marker_crash


### PR DESCRIPTION
## Problem

On Windows / Git Bash (MSYS), the per-home session lock never acquires, so every session is forced into permanent read-only mode. Three layered platform defects combine to cause it:

1. **Harness-ancestry walk uses unsupported `ps` flags.** `fm_harness_ancestry_pids` reads the process tree with `ps -o comm= -p` and `ps -o ppid= -p`. The MSYS `ps` bundled with Git Bash rejects `-o` ("unknown option -- o"), so the walk fails on its first call and `fm_harness_ancestry_pid` never resolves the harness.

2. **Spawned scripts are orphaned from the harness.** MSYS emulates `fork()` through a helper that then exits, so a script launched as a child (session-start spawns `fm-lock.sh`) has a Win32 parent pid pointing at an already-dead launcher. No parent-chain walk can climb from it to `claude.exe`, even with a native process query.

3. **The symlink-based lock primitive silently copies.** `fm_lock_try_create` builds every lock with `ln -s`. MSYS's default `ln -s` copies the target instead of creating a symlink, so `fm_lock_points_to_owner` never validates and `fm_lock_acquire_wait` spins forever.

## Fix

- **Native Windows ancestry walk** (`fm-session-lock-lib.sh`): read the process tree from a single `Win32_Process` query and climb Windows PIDs, handing the same `(comm, args)` evidence to the existing `fm_harness_process_matches` contract.
- **`CLAUDE_PID` anchor**: Claude Code exports its own pid to every descendant; it survives the orphaning. Anchor the walk there when it names a live harness, falling back to the honest parent-chain walk when absent or stale.
- **Native symlinks** (`fm-wake-lib.sh`): request `winsymlinks:nativestrict` on Windows so `ln -s` creates a real NTFS symlink (needs Developer Mode / `SeCreateSymbolicLink`) instead of copying.

All Windows behavior is gated on `OSTYPE` / `FM_FORCE_WINDOWS`; the POSIX paths are byte-for-byte unchanged.

## Tests

- `tests/fm-session-lock-ancestry.test.sh`: new cases inject a deterministic Windows process table (`FM_WIN_PROCTABLE_CMD` / `FM_WIN_SELF_WINPID` / `FM_FORCE_WINDOWS`) and assert anchor resolution, orphan rescue, parent-walk resolution, fail-closed on an invalid/stale anchor, and that an unrelated harness never owns the lock. Existing POSIX cases are pinned to the POSIX path so they stay host-independent; the POSIX-`ps` e2e fixtures skip on hosts without `ps -o`.
- `tests/fm-wake-queue.test.sh`: asserts a Windows source requests native symlinks, preserves an operator's explicit policy, and is a no-op off Windows.

Verified on Windows 10 / Git Bash: the lock now acquires (`lock acquired: harness pid <n>`), holds idempotently, and reports correct status; the new tests pass, and shellcheck (0.11.0, LF-normalized) is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)