### PR TITLE
test(bin): isolate behavior-test runs from the live fleet home

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,7 @@ tmp=$(mktemp -d) && printf 'done: smoke\n' > "$tmp/smoke.status" && FM_STATE_OVE
 `bin/fm-test-run.sh` is the single owner of behavior-suite selection, portable CI lane composition, optional local `--jobs` for the proven-isolated set only, per-script timing markers, family totals, the coverage guard, and the optional JSON timing artifact.
 Its header and `--help` own the flags, family labels, lanes, and changed-file map; this section only documents the entry points.
 `bin/fm-test-isolation-proof.sh` remains the single owner of the Phase 2 concurrent isolation proof and the exact proven candidate set; see `docs/fm-test-isolation-proof.md`.
+Both runners clear the ambient fleet environment once per run through `bin/fm-test-env-lib.sh`, the single owner of that pointer list, so no run path can hand a test the live firstmate home and no test has to clear the pointers itself; a runner that cannot clear them refuses to run.
 Portable shard balance evidence lives in `docs/fm-test-portable-shards.md`.
 Local no-mistakes Test stays intent-targeted and must not wire `commands.test` to `--all` or a `tests/*.test.sh` walk.
 Family selection is the ordinary local path; `--all` is deliberate full regression only.

--- a/bin/fm-test-env-lib.sh
+++ b/bin/fm-test-env-lib.sh
@@ -22,8 +22,16 @@
 # It returns non-zero if any pointer survives, so a runner that cannot isolate
 # refuses instead of running the suite against the live home.
 
-# Every environment variable a Firstmate script consults to locate a home or its
-# durable records. Extend this list, not a runner.
+# Every environment variable a live Firstmate session puts into a worker's
+# environment and a Firstmate script then consults: the home and its durable
+# records, plus the runtime control variables a session start creates. Extend
+# this list, not a runner, whenever Firstmate starts exporting another one.
+#
+# FM_SESSION_START_STAGE_FILE is in the second class and matters as much as the
+# home pointers: bin/fm-session-start.sh treats its presence as "I am already
+# the bounded child" and skips its own runtime bound, so a leaked one removes
+# the bound a test is asserting and the suite hangs on the fixture instead of
+# failing.
 FM_TEST_ENV_FLEET_POINTERS="\
 FM_HOME \
 FM_ROOT \
@@ -36,7 +44,8 @@ FM_PENDING_REPLY_DIR_OVERRIDE \
 FM_PUBLIC_FOLLOWUP_PRIMARY_HOME \
 FM_WAKE_QUEUE \
 FM_WAKE_QUEUE_LOCK \
-FM_BACKEND"
+FM_BACKEND \
+FM_SESSION_START_STAGE_FILE"
 
 fm_test_env_isolate() {
   local name rc=0

--- a/bin/fm-test-env-lib.sh
+++ b/bin/fm-test-env-lib.sh
@@ -27,11 +27,23 @@
 # records, plus the runtime control variables a session start creates. Extend
 # this list, not a runner, whenever Firstmate starts exporting another one.
 #
-# FM_SESSION_START_STAGE_FILE is in the second class and matters as much as the
-# home pointers: bin/fm-session-start.sh treats its presence as "I am already
-# the bounded child" and skips its own runtime bound, so a leaked one removes
-# the bound a test is asserting and the suite hangs on the fixture instead of
-# failing.
+# The second class is every runtime control variable a live session exports to
+# tell a child what it already is or already decided, because a Firstmate script
+# then honors it ahead of its own detection - so a leaked one silently replaces
+# the very thing a test asserts:
+#   FM_SESSION_START_STAGE_FILE  bin/fm-session-start.sh treats its presence as
+#     "I am already the bounded child" and skips its own runtime bound, so a
+#     leaked one removes the bound a test is asserting and the suite hangs on
+#     the fixture instead of failing.
+#   FM_SUPERVISION_MODEL  bin/fm-wake-lib.sh returns it verbatim instead of
+#     detecting the harness, so a leaked autoarm from a secondmate worker makes
+#     the watcher verdict short-circuit and a supervision-health assertion pass
+#     without ever checking watcher health.
+#   FM_TRACE_CONTEXT  bin/fm-trace-context-lib.sh lets a non-empty value beat
+#     config/trace-context, so a leaked one decides the capability a test set
+#     that file to control.
+# bin/fm-spawn.sh exports both of the latter on the same secondmate launch line
+# that carries FM_HOME and FM_PUBLIC_FOLLOWUP_PRIMARY_HOME.
 FM_TEST_ENV_FLEET_POINTERS="\
 FM_HOME \
 FM_ROOT \
@@ -45,7 +57,9 @@ FM_PUBLIC_FOLLOWUP_PRIMARY_HOME \
 FM_WAKE_QUEUE \
 FM_WAKE_QUEUE_LOCK \
 FM_BACKEND \
-FM_SESSION_START_STAGE_FILE"
+FM_SESSION_START_STAGE_FILE \
+FM_SUPERVISION_MODEL \
+FM_TRACE_CONTEXT"
 
 fm_test_env_isolate() {
   local name rc=0

--- a/bin/fm-test-env-lib.sh
+++ b/bin/fm-test-env-lib.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# fm-test-env-lib.sh - single owner of the ambient fleet environment that
+# Firstmate's behavior-test processes must not inherit.
+#
+# Firstmate launches a worker with the live home exported (bin/fm-spawn.sh sets
+# FM_HOME=<home> in the launch command), so a suite started from inside a worker
+# carries pointers at the real fleet home. Any test that resolves a home the
+# ordinary way - bin/fm-wake-lib.sh and friends read these variables - would then
+# read and write the live locks, wake queue, and task records.
+#
+# fm_test_env_isolate clears those pointers in the CALLING process. A runner
+# calls it once, before it starts any test script, so every child inherits the
+# cleared environment whichever path the run takes: serial, a --jobs worker, or
+# an isolation-proof worker. Isolation therefore cannot depend on a flag, and no
+# runner keeps its own copy of the list - two copies drift apart the moment one
+# of them is edited.
+#
+# Usage (source, then call once, early):
+#   . "$ROOT/bin/fm-test-env-lib.sh"
+#   fm_test_env_isolate || exit 2
+#
+# It returns non-zero if any pointer survives, so a runner that cannot isolate
+# refuses instead of running the suite against the live home.
+
+# Every environment variable a Firstmate script consults to locate a home or its
+# durable records. Extend this list, not a runner.
+FM_TEST_ENV_FLEET_POINTERS="\
+FM_HOME \
+FM_ROOT \
+FM_ROOT_OVERRIDE \
+FM_STATE_OVERRIDE \
+FM_DATA_OVERRIDE \
+FM_PROJECTS_OVERRIDE \
+FM_CONFIG_OVERRIDE \
+FM_PENDING_REPLY_DIR_OVERRIDE \
+FM_PUBLIC_FOLLOWUP_PRIMARY_HOME \
+FM_WAKE_QUEUE \
+FM_WAKE_QUEUE_LOCK \
+FM_BACKEND"
+
+fm_test_env_isolate() {
+  local name rc=0
+  for name in $FM_TEST_ENV_FLEET_POINTERS; do
+    unset "$name" 2>/dev/null || true
+  done
+  for name in $FM_TEST_ENV_FLEET_POINTERS; do
+    if [ -n "${!name:-}" ]; then
+      printf 'fm-test-env: could not clear %s from the environment\n' "$name" >&2
+      rc=1
+    fi
+  done
+  return "$rc"
+}

--- a/bin/fm-test-isolation-proof.sh
+++ b/bin/fm-test-isolation-proof.sh
@@ -29,7 +29,8 @@
 # Isolation contract for each concurrent worker:
 #   - distinct mode-0700 temporary root under a proof-owned parent
 #   - TMPDIR/TMP point only at that root so mktemp/fm_test_tmproot stay private
-#   - ambient FM_HOME / FM_*_OVERRIDE cleared so no shared home is reused
+#   - the ambient fleet environment cleared once for this process, so no worker
+#     can reach a live home (bin/fm-test-env-lib.sh owns that pointer list)
 #   - no global git config mutation (snapshot before/after)
 #   - no production sharding and no retry-until-green
 #
@@ -47,6 +48,16 @@ set -eu
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT" || exit 1
+
+# Clear the ambient fleet environment once here, so every candidate worker
+# inherits it and no candidate can share a live home.
+# bin/fm-test-env-lib.sh owns the pointer list.
+# shellcheck source=bin/fm-test-env-lib.sh
+. "$ROOT/bin/fm-test-env-lib.sh"
+fm_test_env_isolate || {
+  printf 'fm-isolation-proof: refusing to run: the live fleet home is still reachable\n' >&2
+  exit 2
+}
 
 JOBS=4
 JSON_PATH=
@@ -424,9 +435,6 @@ for script in "${CANDIDATES[@]}"; do
     set +e
     export TMPDIR="$work/tmp"
     export TMP="$work/tmp"
-    # Clear ambient fleet overrides so candidates cannot share a live home.
-    unset FM_HOME FM_STATE_OVERRIDE FM_DATA_OVERRIDE FM_ROOT_OVERRIDE \
-      FM_PROJECTS_OVERRIDE FM_CONFIG_OVERRIDE FM_BACKEND 2>/dev/null || true
     cd "$ROOT" || exit 1
     begin_ms=$(now_ms)
     bash "$script" >"$work/out/stdout" 2>"$work/out/stderr"

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -68,10 +68,25 @@
 # configured shard count is refused, so a CI matrix cannot silently drop a shard.
 # --changed is conservative: it over-selects related families rather than
 # under-selecting, and never expands to the complete suite unless --all.
+#
+# Every run, by every path, clears the ambient fleet environment before it starts
+# a script, so a suite started from inside a worker cannot reach the live home.
+# bin/fm-test-env-lib.sh owns that contract.
 set -eu
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT" || exit 1
+
+# Clear the ambient fleet environment once, in this process, before anything can
+# start a test script. Every selected script - serial or --jobs worker - is a
+# child of this process, so no run path can hand a test the live home and no
+# caller has to remember a flag. bin/fm-test-env-lib.sh owns the pointer list.
+# shellcheck source=bin/fm-test-env-lib.sh
+. "$ROOT/bin/fm-test-env-lib.sh"
+fm_test_env_isolate || {
+  printf 'fm-test-run: refusing to run: the live fleet home is still reachable\n' >&2
+  exit 2
+}
 
 MODE=
 LIST_ONLY=0
@@ -910,7 +925,7 @@ families_for_changed_path() {
       # resolution in the caller; emit a marker family of __script__
       printf '%s\n' "__script__:$(basename "$path")"
       ;;
-    bin/fm-test-run.sh|bin/fm-test-isolation-proof.sh)
+    bin/fm-test-run.sh|bin/fm-test-isolation-proof.sh|bin/fm-test-env-lib.sh)
       printf '%s\n' pure-contract-unit
       ;;
     bin/backends/herdr*|bin/fm-herdr-lab.sh|tests/herdr-test-safety.sh)
@@ -1630,8 +1645,10 @@ if [ "$JOBS" -eq 1 ]; then
   done
 else
   # Bounded concurrent execution for proven-isolated scripts only. Each worker
-  # gets a private mode-0700 TMPDIR so mktemp roots cannot collide. Retries are
-  # never used as a green strategy.
+  # gets a private mode-0700 TMPDIR so mktemp roots cannot collide - that is
+  # collision avoidance between concurrent workers; fleet-home isolation is
+  # already inherited from this process. Retries are never used as a green
+  # strategy.
   declare -a WORKER_PIDS=()
   declare -a WORKER_IDX=()
   declare -a WORKER_SCRIPTS=()
@@ -1713,8 +1730,6 @@ else
       set +e
       export TMPDIR="$work/tmp"
       export TMP="$work/tmp"
-      unset FM_HOME FM_STATE_OVERRIDE FM_DATA_OVERRIDE FM_ROOT_OVERRIDE \
-        FM_PROJECTS_OVERRIDE FM_CONFIG_OVERRIDE FM_BACKEND 2>/dev/null || true
       cd "$ROOT" || exit 1
       begin_ms=$(now_ms)
       bash "$script" >"$work/output" 2>&1

--- a/docs/fm-test-isolation-proof.md
+++ b/docs/fm-test-isolation-proof.md
@@ -79,7 +79,8 @@ This record is the concurrent isolation proof for the portable parallel candidat
 ## Scope
 
 Each worker used a separate mode-`0700` temporary root and private `TMPDIR` and `TMP`.
-The harness cleared ambient `FM_HOME` and `FM_*_OVERRIDE` values for every worker and verified that global Git configuration was unchanged.
+The harness clears the ambient fleet environment once for the whole run, so every worker inherits an environment with no pointer at a live home (`bin/fm-test-env-lib.sh` owns that pointer list).
+The proof run also verified that global Git configuration was unchanged.
 A candidate failure fails the aggregate run and requires investigation rather than a retry.
 
 ## Re-run

--- a/docs/fm-test-isolation-proof.md
+++ b/docs/fm-test-isolation-proof.md
@@ -79,7 +79,6 @@ This record is the concurrent isolation proof for the portable parallel candidat
 ## Scope
 
 Each worker used a separate mode-`0700` temporary root and private `TMPDIR` and `TMP`.
-The harness clears the ambient fleet environment once for the whole run, so every worker inherits an environment with no pointer at a live home (`bin/fm-test-env-lib.sh` owns that pointer list).
 The proof run also verified that global Git configuration was unchanged.
 A candidate failure fails the aggregate run and requires investigation rather than a retry.
 

--- a/docs/fm-test-isolation-proof.md
+++ b/docs/fm-test-isolation-proof.md
@@ -79,7 +79,7 @@ This record is the concurrent isolation proof for the portable parallel candidat
 ## Scope
 
 Each worker used a separate mode-`0700` temporary root and private `TMPDIR` and `TMP`.
-The proof run also verified that global Git configuration was unchanged.
+The harness cleared ambient `FM_HOME` and `FM_*_OVERRIDE` values for every worker and verified that global Git configuration was unchanged.
 A candidate failure fails the aggregate run and requires investigation rather than a retry.
 
 ## Re-run

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -36,6 +36,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-herdr-ci-cleanup.sh` | Snapshot and tear down only job-owned `fm-lab-*` sessions in the Herdr CI lane       |
 | `fm-test-run.sh`         | Behavior-test runner: selection, portable lanes, proven-isolated `--jobs`, coverage guard, timing/JSON |
 | `fm-test-isolation-proof.sh` | Concurrent isolation proof and proven-isolated candidate set owner |
+| `fm-test-env-lib.sh`     | Single owner of the ambient fleet environment a behavior-test process must not inherit; both test runners clear it once per run |
 | `fm-ensure-agents-md.sh` | Ensure a project's real `AGENTS.md`, its `CLAUDE.md` `@AGENTS.md` pointer, and the canonical self-governance section |
 | `fm-guard.sh`            | Warn on primary-checkout tangles, pending queued wakes, and unhealthy supervision    |
 | `fm-primary-scope-lib.sh` | Shared marker-or-plain-checkout primary-home predicate for tracked hooks             |

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -731,6 +731,7 @@ set -u
 fm_wake_append check live-home-probe probe >/dev/null 2>&1 || true
 printf 'PROBE_HOME=%s\n' "$FM_HOME"
 printf 'PROBE_STATE=%s\n' "$STATE"
+printf 'PROBE_STAGE_FILE=%s\n' "${FM_SESSION_START_STAGE_FILE:-none}"
 echo "ok - probe"
 SH
   chmod +x "$repo/bin/fm-test-run.sh" "$repo/$probe"
@@ -746,6 +747,10 @@ SH
     export FM_STATE_OVERRIDE="$sentinel/state"
     export FM_DATA_OVERRIDE="$sentinel/data"
     export FM_ROOT="$sentinel"
+    # A live session start leaves this behind in a worker's environment, and
+    # bin/fm-session-start.sh reads its presence as "the runtime bound is
+    # already applied", so a test that inherits one loses the bound it asserts.
+    export FM_SESSION_START_STAGE_FILE="$sentinel/stage"
     bin/fm-test-run.sh "$probe"
   ) >"$tmp/out" 2>"$tmp/err"
   rc=$?
@@ -759,6 +764,8 @@ SH
     || fail "probe resolved a home outside its own repo: $(grep PROBE_ "$tmp/out")"
   grep -Fq "PROBE_STATE=$repo/state" "$tmp/out" \
     || fail "probe resolved a state directory outside its own repo: $(grep PROBE_ "$tmp/out")"
+  grep -Fq "PROBE_STAGE_FILE=none" "$tmp/out" \
+    || fail "a live session's control variable reached a test script: $(grep PROBE_STAGE "$tmp/out")"
 
   [ "$(cat "$sentinel/state/.wake-queue")" = "sentinel" ] \
     || fail "a test script wrote to the live home's durable queue"
@@ -781,11 +788,11 @@ test_env_isolation_helper_clears_every_pointer() {
     FM_PUBLIC_FOLLOWUP_PRIMARY_HOME=/live \
     FM_WAKE_QUEUE=/live/state/.wake-queue \
     FM_WAKE_QUEUE_LOCK=/live/state/.wake-queue.lock \
-    FM_BACKEND=tmux \
+    FM_BACKEND=tmux FM_SESSION_START_STAGE_FILE=/live/stage \
     bash -c '. "$1/bin/fm-test-env-lib.sh"; fm_test_env_isolate || exit 1; env' \
     _ "$ROOT"
   ) || fail "fm_test_env_isolate refused with a clearable environment"
-  survivors=$(printf '%s\n' "$out" | grep -E '^(FM_HOME|FM_ROOT|FM_ROOT_OVERRIDE|FM_STATE_OVERRIDE|FM_DATA_OVERRIDE|FM_PROJECTS_OVERRIDE|FM_CONFIG_OVERRIDE|FM_PENDING_REPLY_DIR_OVERRIDE|FM_PUBLIC_FOLLOWUP_PRIMARY_HOME|FM_WAKE_QUEUE|FM_WAKE_QUEUE_LOCK|FM_BACKEND)=' || true)
+  survivors=$(printf '%s\n' "$out" | grep -E '^(FM_HOME|FM_ROOT|FM_ROOT_OVERRIDE|FM_STATE_OVERRIDE|FM_DATA_OVERRIDE|FM_PROJECTS_OVERRIDE|FM_CONFIG_OVERRIDE|FM_PENDING_REPLY_DIR_OVERRIDE|FM_PUBLIC_FOLLOWUP_PRIMARY_HOME|FM_WAKE_QUEUE|FM_WAKE_QUEUE_LOCK|FM_BACKEND|FM_SESSION_START_STAGE_FILE)=' || true)
   [ -z "$survivors" ] || fail "fleet pointers survived isolation: $survivors"
   pass "the shared isolation helper clears every fleet pointer it owns"
 }

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -777,22 +777,23 @@ SH
 }
 
 test_env_isolation_helper_clears_every_pointer() {
-  local out survivors
+  local out survivors name pattern
+  # Drive the assertion from the lib's own list, so a pointer added there is
+  # exported and asserted here without a second copy to keep in step.
+  . "$ROOT/bin/fm-test-env-lib.sh"
+  [ -n "${FM_TEST_ENV_FLEET_POINTERS:-}" ] \
+    || fail "the shared library published no fleet pointer list"
   # The helper is what both runners call; drive it directly with every pointer
   # exported and confirm nothing survives into a child process.
   out=$(
-    FM_HOME=/live FM_ROOT=/live FM_ROOT_OVERRIDE=/live \
-    FM_STATE_OVERRIDE=/live/state FM_DATA_OVERRIDE=/live/data \
-    FM_PROJECTS_OVERRIDE=/live/projects FM_CONFIG_OVERRIDE=/live/config \
-    FM_PENDING_REPLY_DIR_OVERRIDE=/live/state/pending-replies \
-    FM_PUBLIC_FOLLOWUP_PRIMARY_HOME=/live \
-    FM_WAKE_QUEUE=/live/state/.wake-queue \
-    FM_WAKE_QUEUE_LOCK=/live/state/.wake-queue.lock \
-    FM_BACKEND=tmux FM_SESSION_START_STAGE_FILE=/live/stage \
+    for name in $FM_TEST_ENV_FLEET_POINTERS; do
+      export "$name=/live-sentinel"
+    done
     bash -c '. "$1/bin/fm-test-env-lib.sh"; fm_test_env_isolate || exit 1; env' \
-    _ "$ROOT"
+      _ "$ROOT"
   ) || fail "fm_test_env_isolate refused with a clearable environment"
-  survivors=$(printf '%s\n' "$out" | grep -E '^(FM_HOME|FM_ROOT|FM_ROOT_OVERRIDE|FM_STATE_OVERRIDE|FM_DATA_OVERRIDE|FM_PROJECTS_OVERRIDE|FM_CONFIG_OVERRIDE|FM_PENDING_REPLY_DIR_OVERRIDE|FM_PUBLIC_FOLLOWUP_PRIMARY_HOME|FM_WAKE_QUEUE|FM_WAKE_QUEUE_LOCK|FM_BACKEND|FM_SESSION_START_STAGE_FILE)=' || true)
+  pattern=$(printf '%s\n' $FM_TEST_ENV_FLEET_POINTERS | paste -sd'|' -)
+  survivors=$(printf '%s\n' "$out" | grep -E "^($pattern)=" || true)
   [ -z "$survivors" ] || fail "fleet pointers survived isolation: $survivors"
   pass "the shared isolation helper clears every fleet pointer it owns"
 }

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -92,6 +92,7 @@ init_changed_fixture_repo() {
   local repo=$1 script
   mkdir -p "$repo/bin" "$repo/tests"
   cp "$RUNNER" "$repo/bin/fm-test-run.sh"
+  cp "$ROOT/bin/fm-test-env-lib.sh" "$repo/bin/fm-test-env-lib.sh"
   chmod +x "$repo/bin/fm-test-run.sh"
   for script in \
     fm-brief.test.sh \
@@ -507,6 +508,7 @@ test_jobs_parallel_scheduler_and_failure_propagation() {
   d=tests/fm-supervision-instructions.test.sh
   mkdir -p "$repo/bin" "$repo/tests" "$evidence" "$fake_bin"
   cp "$RUNNER" "$runner"
+  cp "$ROOT/bin/fm-test-env-lib.sh" "$repo/bin/fm-test-env-lib.sh"
   cat >"$fake_bin/stat" <<'SH'
 #!/usr/bin/env bash
 if [ "$1" = "-c" ] && [ "$2" = "%a" ]; then
@@ -703,6 +705,91 @@ assert len(doc["scripts"])==3
   pass "aggregate-json merges lane timing artifacts"
 }
 
+test_run_cannot_reach_the_live_home() {
+  local tmp repo sentinel probe out rc leaked
+  tmp=$(fm_test_tmproot fm-test-run-live-home)
+  repo="$tmp/repo"
+  sentinel="$tmp/live-home"
+  probe=tests/fm-live-home-probe.test.sh
+
+  # A home-shaped sentinel with one durable record already in it, so both a new
+  # write and a modified byte count are visible afterwards.
+  mkdir -p "$sentinel/state" "$sentinel/data"
+  printf 'sentinel\n' >"$sentinel/state/.wake-queue"
+
+  mkdir -p "$repo/bin" "$repo/tests"
+  cp "$RUNNER" "$repo/bin/fm-test-run.sh"
+  cp "$ROOT/bin/fm-test-env-lib.sh" "$repo/bin/fm-test-env-lib.sh"
+  cp "$ROOT/bin/fm-wake-lib.sh" "$repo/bin/fm-wake-lib.sh"
+  # The probe resolves its home the way every Firstmate script does, through the
+  # real shared library, and then writes a durable record there.
+  cat >"$repo/$probe" <<'SH'
+#!/usr/bin/env bash
+set -u
+# shellcheck source=/dev/null
+. "$(cd "$(dirname "$0")/../bin" && pwd)/fm-wake-lib.sh"
+fm_wake_append check live-home-probe probe >/dev/null 2>&1 || true
+printf 'PROBE_HOME=%s\n' "$FM_HOME"
+printf 'PROBE_STATE=%s\n' "$STATE"
+echo "ok - probe"
+SH
+  chmod +x "$repo/bin/fm-test-run.sh" "$repo/$probe"
+  # The probe reports a resolved path, so compare against a resolved one.
+  repo=$(cd "$repo" && pwd -P)
+
+  find "$sentinel" | LC_ALL=C sort >"$tmp/sentinel-before"
+
+  set +e
+  (
+    cd "$repo" || exit 1
+    export FM_HOME="$sentinel"
+    export FM_STATE_OVERRIDE="$sentinel/state"
+    export FM_DATA_OVERRIDE="$sentinel/data"
+    export FM_ROOT="$sentinel"
+    bin/fm-test-run.sh "$probe"
+  ) >"$tmp/out" 2>"$tmp/err"
+  rc=$?
+  set -e
+  [ "$rc" -eq 0 ] || fail "probe run failed ($rc): $(cat "$tmp/err")"
+
+  # Positive assertion, not "anywhere but the sentinel": a partial fix that
+  # cleared only FM_HOME would still resolve the state directory from an
+  # inherited override, and that must not read as a pass.
+  grep -Fq "PROBE_HOME=$repo" "$tmp/out" \
+    || fail "probe resolved a home outside its own repo: $(grep PROBE_ "$tmp/out")"
+  grep -Fq "PROBE_STATE=$repo/state" "$tmp/out" \
+    || fail "probe resolved a state directory outside its own repo: $(grep PROBE_ "$tmp/out")"
+
+  [ "$(cat "$sentinel/state/.wake-queue")" = "sentinel" ] \
+    || fail "a test script wrote to the live home's durable queue"
+  find "$sentinel" | LC_ALL=C sort >"$tmp/sentinel-after"
+  leaked=$(comm -13 "$tmp/sentinel-before" "$tmp/sentinel-after" || true)
+  [ -z "$leaked" ] || fail "a test script created entries in the live home: $leaked"
+
+  pass "no run path hands a test script the live fleet home"
+}
+
+test_env_isolation_helper_clears_every_pointer() {
+  local out survivors
+  # The helper is what both runners call; drive it directly with every pointer
+  # exported and confirm nothing survives into a child process.
+  out=$(
+    FM_HOME=/live FM_ROOT=/live FM_ROOT_OVERRIDE=/live \
+    FM_STATE_OVERRIDE=/live/state FM_DATA_OVERRIDE=/live/data \
+    FM_PROJECTS_OVERRIDE=/live/projects FM_CONFIG_OVERRIDE=/live/config \
+    FM_PENDING_REPLY_DIR_OVERRIDE=/live/state/pending-replies \
+    FM_PUBLIC_FOLLOWUP_PRIMARY_HOME=/live \
+    FM_WAKE_QUEUE=/live/state/.wake-queue \
+    FM_WAKE_QUEUE_LOCK=/live/state/.wake-queue.lock \
+    FM_BACKEND=tmux \
+    bash -c '. "$1/bin/fm-test-env-lib.sh"; fm_test_env_isolate || exit 1; env' \
+    _ "$ROOT"
+  ) || fail "fm_test_env_isolate refused with a clearable environment"
+  survivors=$(printf '%s\n' "$out" | grep -E '^(FM_HOME|FM_ROOT|FM_ROOT_OVERRIDE|FM_STATE_OVERRIDE|FM_DATA_OVERRIDE|FM_PROJECTS_OVERRIDE|FM_CONFIG_OVERRIDE|FM_PENDING_REPLY_DIR_OVERRIDE|FM_PUBLIC_FOLLOWUP_PRIMARY_HOME|FM_WAKE_QUEUE|FM_WAKE_QUEUE_LOCK|FM_BACKEND)=' || true)
+  [ -z "$survivors" ] || fail "fleet pointers survived isolation: $survivors"
+  pass "the shared isolation helper clears every fleet pointer it owns"
+}
+
 test_list_all_exact_suite_coverage
 test_family_selection
 test_single_script_selection
@@ -721,3 +808,5 @@ test_jobs_requires_proven_isolated
 test_jobs_parallel_scheduler_and_failure_propagation
 test_herdr_ci_family_run_has_a_step_timeout
 test_aggregate_json
+test_run_cannot_reach_the_live_home
+test_env_isolation_helper_clears_every_pointer

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -778,6 +778,7 @@ SH
 
 test_env_isolation_helper_clears_every_pointer() {
   local out survivors name pattern
+  local -a pointers
   # Drive the assertion from the lib's own list, so a pointer added there is
   # exported and asserted here without a second copy to keep in step.
   . "$ROOT/bin/fm-test-env-lib.sh"
@@ -792,7 +793,8 @@ test_env_isolation_helper_clears_every_pointer() {
     bash -c '. "$1/bin/fm-test-env-lib.sh"; fm_test_env_isolate || exit 1; env' \
       _ "$ROOT"
   ) || fail "fm_test_env_isolate refused with a clearable environment"
-  pattern=$(printf '%s\n' $FM_TEST_ENV_FLEET_POINTERS | paste -sd'|' -)
+  read -r -a pointers <<<"$FM_TEST_ENV_FLEET_POINTERS"
+  pattern=$(IFS='|'; printf '%s' "${pointers[*]}")
   survivors=$(printf '%s\n' "$out" | grep -E "^($pattern)=" || true)
   [ -z "$survivors" ] || fail "fleet pointers survived isolation: $survivors"
   pass "the shared isolation helper clears every fleet pointer it owns"


### PR DESCRIPTION
## Intent

Rescue an open pull request from upstream's staleness close. Upstream kunchenguid closes a pull request after 14 days with no push or comment from its author: a maintainer comment, a maintainer rebase, and a CI run do not reset that clock, and the close is irreversible - a previously closed pull request could not be reopened, its work had to be re-raised as a new pull request, and its whole review thread was orphaned. The work is not judged wrong, it is judged silent. This pull request, kunchenguid/firstmate#3026, has now been silent 22.3 days and conflicts with current upstream main, so it cannot merge and a stacked follow-up pull request is blocked behind it. Get the existing branch fm/fm-test-run-serial-leaks-live-state onto current upstream main, resolve every conflict on the merits, keep this existing pull request rather than raising a replacement, and push so the staleness clock resets. The change itself stops firstmate's behavior-test runner reaching the live fleet home on any execution path.

## What Changed

- Adds `bin/fm-test-env-lib.sh` as the single owner of the ambient fleet pointer list (`FM_HOME`, the `FM_*_OVERRIDE` set, wake-queue paths, and the runtime control variables `FM_SESSION_START_STAGE_FILE`, `FM_SUPERVISION_MODEL`, `FM_TRACE_CONTEXT`); `fm_test_env_isolate` unsets them in the calling process and returns non-zero if any survives.
- `bin/fm-test-run.sh` and `bin/fm-test-isolation-proof.sh` now source that helper and clear the environment once at startup, refusing to run with exit 2 if it cannot be cleared, replacing the per-worker `unset` that only covered the `--jobs` and proof-worker paths; `fm-test-run.sh` also maps changes to the new library onto the `pure-contract-unit` family plus `fm-test-fixtures.test.sh`.
- Adds two tests in `tests/fm-test-run.test.sh`: one runs a probe that resolves its home through `fm-wake-lib.sh` under an exported home-shaped sentinel and asserts the probe lands in its own repo with the sentinel untouched, and one drives `fm_test_env_isolate` from the library's own published pointer list; the runner fixtures in `tests/fm-test-run.test.sh`, `tests/fm-test-fixtures.test.sh`, and `tests/fm-test-isolation-proof.test.sh` now copy the helper alongside the runner.
- Documents the shared isolation owner in `CONTRIBUTING.md` and `docs/scripts.md`.

## Risk Assessment

✅ Low: A well-bounded test-harness isolation change: the pointer list matches every variable bin/fm-spawn.sh and bin/fm-session-start.sh actually export, neither runner nor any caller consults a cleared name, every runner fixture now installs the helper, the new tests are real behavioural regressions, and the upstream merge preserved both sides in full.

## Testing

I first reproduced the defect: a probe test resolving its home through the real bin/fm-wake-lib.sh, run directly with a worker's exported environment, resolved the sentinel live home and wrote three durable records into it. Running the identical probe through bin/fm-test-run.sh - serially, through a --jobs 2 worker, and through bin/fm-test-isolation-proof.sh with 24 concurrent candidates - resolved the home to the sandbox repo instead, reported none for the session-start stage file, supervision model, trace context and backend, and left the sentinel home's file list and durable queue byte-identical. Adversarially, making FM_HOME unclearable (readonly via BASH_ENV) made both runners print the refusal and exit 2 rather than run the suite against a reachable live home. The three suites touched by the change - fm-test-run, fm-test-fixtures and fm-test-isolation-proof - also ran through the runner and all passed, slowly only because the host was heavily loaded by other sessions. There is no UI surface in this change, so the evidence is a CLI transcript.

- Live validation: ✅ go - 7 of 7 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| A test script run directly from a worker environment reaches the live fleet home (defect reproduction) | ✅ pass | live | Section 1 of live-home-isolation.txt: PROBE_HOME/PROBE_STATE resolved to the sentinel home and the probe created .wake-queue.seq and .watcher-down there |
| Serial run through bin/fm-test-run.sh cannot reach the live home | ✅ pass | live | Section 2: PROBE_HOME=&lt;sandbox repo&gt;, PROBE_STAGE_FILE=none, sentinel file list and .wake-queue unchanged, rc=0 |
| Bounded-concurrency (--jobs 2) worker path cannot reach the live home after the per-worker unset was removed | ✅ pass | live | Section 3: both concurrent scripts report the sandbox home and none for every control variable; sentinel home unchanged |
| bin/fm-test-isolation-proof.sh workers cannot reach the live home | ✅ pass | live | Section 4: FM_ISOLATION_SUMMARY total=24 failed=0 concurrency=4 with the sentinel home&#39;s file list and durable queue unchanged |
| Leaked session-start, supervision-model and trace-context control variables do not survive into a test script | ✅ pass | live | Sections 2 and 3: PROBE_STAGE_FILE=none, PROBE_SUPERVISION_MODEL=none, PROBE_TRACE_CONTEXT=none, PROBE_BACKEND=none, against autoarm/on/herdr in the baseline |
| A runner that cannot clear a pointer refuses instead of running the suite | ✅ pass | live | Section 5: readonly FM_HOME via BASH_ENV makes both bin/fm-test-run.sh and bin/fm-test-isolation-proof.sh print the refusal and exit 2 |
| Existing runner and fixture suites still pass with the helper installed in every fixture | ✅ pass | live | `bash bin/fm-test-run.sh tests/fm-test-run.test.sh tests/fm-test-fixtures.test.sh tests/fm-test-isolation-proof.test.sh` -&gt; FM_TEST_SUMMARY total=3 failed=0 skipped_gate=0, rc=0 |

<details>
<summary>Evidence: Live fleet-home isolation transcript: baseline leak, serial, --jobs, isolation proof, and both refusals</summary>

Source: [Live fleet-home isolation transcript: baseline leak, serial, --jobs, isolation proof, and both refusals](https://github.com/AgardnerAU/firstmate/blob/958bba1becdf8732e9097edb487fce070444f370/.no-mistakes/evidence/fm/fm-test-run-serial-leaks-live-state/live-home-isolation.txt)

```text
# Live fleet-home isolation transcript (bin/fm-test-run.sh)

Sandbox repo: /tmp/fmlive.JjT050/repo    Sentinel 'live' home: /tmp/fmlive.JjT050/live

## 1. BASELINE - the probe run directly, inheriting a worker's environment
$ env FM_HOME=$LIVE FM_ROOT=$LIVE FM_STATE_OVERRIDE=... FM_SESSION_START_STAGE_FILE=... FM_SUPERVISION_MODEL=autoarm FM_TRACE_CONTEXT=on FM_BACKEND=herdr bash tests/fm-live-probe.test.sh
PROBE_HOME=/tmp/fmlive.JjT050/live
PROBE_STATE=/tmp/fmlive.JjT050/live/state
PROBE_STAGE_FILE=/tmp/fmlive.JjT050/live/stage
PROBE_SUPERVISION_MODEL=autoarm
PROBE_TRACE_CONTEXT=on
PROBE_BACKEND=herdr
ok - probe
--- the live home was written to ---
/tmp/fmlive.JjT050/live
/tmp/fmlive.JjT050/live/data
/tmp/fmlive.JjT050/live/state
/tmp/fmlive.JjT050/live/state/.wake-queue
/tmp/fmlive.JjT050/live/state/.wake-queue.seq
/tmp/fmlive.JjT050/live/state/.watcher-down
--- durable queue ---
sentinel
1789742280	1	check	live-home-probe	probe

## 2. SERIAL - same environment, run through bin/fm-test-run.sh
FM_TEST_BEGIN 2026-09-18T14:38:00Z tests/fm-live-probe.test.sh family=unclassified expected_gate_skip=none
PROBE_HOME=/tmp/fmlive.JjT050/repo
PROBE_STATE=/tmp/fmlive.JjT050/repo/state
PROBE_STAGE_FILE=none
PROBE_SUPERVISION_MODEL=none
PROBE_TRACE_CONTEXT=none
PROBE_BACKEND=none
ok - probe
FM_TEST_END 2026-09-18T14:38:02Z tests/fm-live-probe.test.sh exit=0 duration_ms=936 gate_skip=false
FM_TEST_SUMMARY total=1 failed=0 skipped_gate=0 duration_ms=1316
FM_TEST_SUMMARY_FAMILY family=unclassified count=1 duration_ms=936 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-live-probe.test.sh duration_ms=936
rc=0
--- live home untouched ---
/tmp/fmlive.JjT050/live
/tmp/fmlive.JjT050/live/data
/tmp/fmlive.JjT050/live/state
/tmp/fmlive.JjT050/live/state/.wake-queue
sentinel

## 3. PARALLEL (--jobs 2) - same environment
FM_TEST_BEGIN 2026-09-18T14:38:02Z tests/fm-brief.test.sh family=pure-contract-unit expected_gate_skip=none
FM_TEST_BEGIN 2026-09-18T14:38:02Z tests/fm-crew-state.test.sh family=pure-contract-unit expected_gate_skip=none
PROBE_HOME=/tmp/fmlive.JjT050/repo
PROBE_STATE=/tmp/fmlive.JjT050/repo/state
PROBE_STAGE_FILE=none
PROBE_SUPERVISION_MODEL=none
PROBE_TRACE_CONTEXT=none
PROBE_BACKEND=none
ok - probe
FM_TEST_END 2026-09-18T14:38:04Z tests/fm-brief.test.sh exit=0 duration_ms=1199 gate_skip=false
PROBE_HOME=/tmp/fmlive.JjT050/repo
PROBE_STATE=/tmp/fmlive.JjT050/repo/state
PROBE_STAGE_FILE=none
PROBE_SUPERVISION_MODEL=none
PROBE_TRACE_CONTEXT=none
PROBE_BACKEND=none
ok - probe
FM_TEST_END 2026-09-18T14:38:04Z tests/fm-crew-state.test.sh exit=0 duration_ms=1612 gate_skip=false
FM_TEST_SUMMARY total=2 failed=0 skipped_gate=0 duration_ms=2311
FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=2 duration_ms=2811 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-crew-state.test.sh duration_ms=1612
FM_TEST_SLOWEST rank=2 script=tests/fm-brief.test.sh duration_ms=1199
rc=0
/tmp/fmlive.JjT050/live
/tmp/fmlive.JjT050/live/data
/tmp/fmlive.JjT050/live/state
/tmp/fmlive.JjT050/live/state/.wake-queue
sentinel

## 4. ISOLATION-PROOF HARNESS (--jobs 4, 24 candidates) - same environment
   1 FM_ISOLATION_SUMMARY total=24 failed=0 concurrency=4 duration_ms=17445
--- live home untouched ---
/tmp/fmlive.JjT050/live
/tmp/fmlive.JjT050/live/data
/tmp/fmlive.JjT050/live/state
/tmp/fmlive.JjT050/live/state/.wake-queue
sentinel

## 5. ADVERSARIAL - a pointer that cannot be cleared (readonly FM_HOME via BASH_ENV)
fm-test-env: could not clear FM_HOME from the environment
fm-test-run: refusing to run: the live fleet home is still reachable
fm-test-run rc=2
fm-test-env: could not clear FM_HOME from the environment
fm-isolation-proof: refusing to run: the live fleet home is still reachable
fm-test-isolation-proof rc=2
```
</details>
<details>
<summary>Evidence: Baseline leak vs isolated run (excerpt)</summary>

```text
# direct run, worker environment inherited
PROBE_HOME=/tmp/fmlive.JjT050/live
PROBE_STATE=/tmp/fmlive.JjT050/live/state
PROBE_STAGE_FILE=/tmp/fmlive.JjT050/live/stage
PROBE_SUPERVISION_MODEL=autoarm
PROBE_TRACE_CONTEXT=on
--- live home was written to ---
.../live/state/.wake-queue.seq
.../live/state/.watcher-down

# same environment, through bin/fm-test-run.sh
PROBE_HOME=/tmp/fmlive.JjT050/repo
PROBE_STATE=/tmp/fmlive.JjT050/repo/state
PROBE_STAGE_FILE=none
PROBE_SUPERVISION_MODEL=none
PROBE_TRACE_CONTEXT=none
--- live home untouched ---

# unclearable pointer
fm-test-env: could not clear FM_HOME from the environment
fm-test-run: refusing to run: the live fleet home is still reachable
fm-test-run rc=2
fm-isolation-proof: refusing to run: the live fleet home is still reachable
fm-test-isolation-proof rc=2
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"2a0314b3fe11bf1eaf0e15727802b69c1bf5040b","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}],"live_validation":{"verdict":"go","live":7,"total":7}} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 7 of 7 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| A test script run directly from a worker environment reaches the live fleet home (defect reproduction) | ✅ pass | live | Section 1 of live-home-isolation.txt: PROBE_HOME/PROBE_STATE resolved to the sentinel home and the probe created .wake-queue.seq and .watcher-down there |
| Serial run through bin/fm-test-run.sh cannot reach the live home | ✅ pass | live | Section 2: PROBE_HOME=&lt;sandbox repo&gt;, PROBE_STAGE_FILE=none, sentinel file list and .wake-queue unchanged, rc=0 |
| Bounded-concurrency (--jobs 2) worker path cannot reach the live home after the per-worker unset was removed | ✅ pass | live | Section 3: both concurrent scripts report the sandbox home and none for every control variable; sentinel home unchanged |
| bin/fm-test-isolation-proof.sh workers cannot reach the live home | ✅ pass | live | Section 4: FM_ISOLATION_SUMMARY total=24 failed=0 concurrency=4 with the sentinel home&#39;s file list and durable queue unchanged |
| Leaked session-start, supervision-model and trace-context control variables do not survive into a test script | ✅ pass | live | Sections 2 and 3: PROBE_STAGE_FILE=none, PROBE_SUPERVISION_MODEL=none, PROBE_TRACE_CONTEXT=none, PROBE_BACKEND=none, against autoarm/on/herdr in the baseline |
| A runner that cannot clear a pointer refuses instead of running the suite | ✅ pass | live | Section 5: readonly FM_HOME via BASH_ENV makes both bin/fm-test-run.sh and bin/fm-test-isolation-proof.sh print the refusal and exit 2 |
| Existing runner and fixture suites still pass with the helper installed in every fixture | ✅ pass | live | `bash bin/fm-test-run.sh tests/fm-test-run.test.sh tests/fm-test-fixtures.test.sh tests/fm-test-isolation-proof.test.sh` -&gt; FM_TEST_SUMMARY total=3 failed=0 skipped_gate=0, rc=0 |

- <code>`bash tests/fm-live-probe.test.sh` with FM_HOME/FM_ROOT/FM_STATE_OVERRIDE/FM_DATA_OVERRIDE/FM_SESSION_START_STAGE_FILE/FM_SUPERVISION_MODEL/FM_TRACE_CONTEXT/FM_BACKEND exported (baseline reproduction: the probe wrote .wake-queue, .wake-queue.seq and .watcher-down into the sentinel home)</code>
- <code>`bash bin/fm-test-run.sh tests/fm-live-probe.test.sh` under the same environment (serial path)</code>
- <code>`bash bin/fm-test-run.sh --jobs 2 tests/fm-brief.test.sh tests/fm-crew-state.test.sh` under the same environment (bounded-concurrency worker path, where the per-worker unset was deleted)</code>
- <code>`bash bin/fm-test-isolation-proof.sh --jobs 4` under the same environment (24 candidates, isolation-proof worker path)</code>
- <code>`env BASH_ENV=&lt;readonly FM_HOME&gt; bash bin/fm-test-run.sh tests/fm-live-probe.test.sh` and the same against `bin/fm-test-isolation-proof.sh` (adversarial: an unclearable pointer)</code>
- <code>`bash bin/fm-test-run.sh tests/fm-test-run.test.sh tests/fm-test-fixtures.test.sh tests/fm-test-isolation-proof.test.sh` - total=3 failed=0, rc=0</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
