### PR TITLE
feat: enforce secondmate project ownership on spawn

### DIFF
--- a/.agents/skills/secondmate-provisioning/SKILL.md
+++ b/.agents/skills/secondmate-provisioning/SKILL.md
@@ -30,7 +30,7 @@ A whole-home remote route uses:
 - <id> - <one-sentence charter summary> (host: <ssh-alias>; root: <absolute-remote-code-root>; home: <absolute-remote-home>; scope: <natural-language responsibility>; projects: <project-a>, <project-b>; added <date>)
 ```
 
-Each registry entry stays concise and single-line: the summary is one sentence naming the durable charter, `scope:` is the natural-language intake responsibility, `projects:` is the non-exclusive clone list, and any extra prose is limited to genuinely domain-specific hard rules that change routing or safety for that secondmate.
+Each registry entry stays concise and single-line: the summary is one sentence naming the durable charter, `scope:` is the natural-language intake responsibility, `projects:` is the clone list that also claims spawn ownership of those projects, and any extra prose is limited to genuinely domain-specific hard rules that change routing or safety for that secondmate.
 Natural-language summary and `scope:` text may contain parentheses and semicolons; keep the generated `(home: ...; scope: ...; projects: ...; added ...)` suffix intact so operational consumers resolve its explicit field markers.
 The `home:` path points to the seeded home containing `data/charter.md`; no extra registry pointer field is needed.
 For a remote route, `host:` is an OpenSSH config alias and `root:` is that host's separate tracked Firstmate code root.
@@ -39,7 +39,7 @@ This release places whole secondmate homes remotely and never individual workers
 [`docs/remote-secondmates.md`](../../../docs/remote-secondmates.md) owns current operator setup and transport behavior.
 The home-seeded `data/charter.md` is the sole owner of boilerplate idle-by-default behavior, the normal delegation lifecycle, and standard escalation contracts, so point to that charter rather than restating those contracts in the registry entry.
 The `scope:` field is used during intake.
-The `projects:` field is a non-exclusive clone list, not ownership.
+The `projects:` field is the clone list and the spawn-ownership claim: [`fm-spawn.sh`](../../../bin/fm-spawn.sh) refuses a fresh primary-home crewmate or scout into a listed project unless `--allow-primary-spawn` states a deliberate exception, while scope text is never matched at spawn time.
 
 ## Charter and seed
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,7 +240,7 @@ That skill owns registry syntax, delivery-mode selection, outward-facing consent
 Project creation never authorizes an unmentioned remote, and project removal never bypasses that preflight or unlanded-work checks; hard rule 1's concrete captain-approved project operation exception remains available when its exact conditions are met.
 
 Load `secondmate-provisioning` before creating, seeding, validating, launching, handing backlog to, recovering, pushing inherited local material into, or retiring a secondmate home, and before editing `data/secondmates.md`.
-Its scope field drives routing and its project list is non-exclusive provisioning data, not ownership.
+Its scope field drives routing, and its project list is that secondmate's spawn ownership: `bin/fm-spawn.sh` refuses a fresh primary-home crewmate or scout into a listed project unless `--allow-primary-spawn` states a deliberate exception.
 Keep `local-only` work in the main home.
 
 A secondmate is idle by default and acts only on work routed by the main firstmate.
@@ -271,7 +271,7 @@ Resolve the project independently for every request.
 An explicit project wins, a clear follow-up inherits its referent, and otherwise match the request against the registry, work under way, and project code or README.
 Proceed on one confident match while naming the project in plain language; ask one concise question when multiple or no projects plausibly match.
 
-Route by the nature of the work against each registered secondmate scope, not by a non-exclusive clone list.
+Route by the nature of the work against each registered secondmate scope; a project on a secondmate's clone list is also spawn-owned by it, so primary-home work there needs the deliberate `--allow-primary-spawn` exception.
 Keep `local-only` work in the main home.
 Send in-scope work to the fitting secondmate unless it is blocked or the captain explicitly redirects it; do not read the secondmate's chat because marked routed replies return through its status or referenced document.
 If no secondmate scope fits, use the main home or discuss creating an appropriate persistent secondmate.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -214,7 +214,7 @@ if [ "$NO_PROJECTS" -eq 1 ]; then
   PROJECT_CLONES_NOTE="This domain has no separate project clones: its subject is the firstmate repo this home lives in, and its crews take pooled worktrees of that repo."
 else
   PROJECT_CLONES_BODY=$(printf '%s\n' "$SECONDMATE_PROJECTS" | tr ' ' '\n' | sed 's/^/- /')
-  PROJECT_CLONES_NOTE="The projects above are local clones for work you supervise; they are not an exclusive ownership claim."
+  PROJECT_CLONES_NOTE="The projects above are local clones for work you supervise, and the main firstmate refuses to spawn its own crewmates or scouts into them without a deliberate override."
 fi
 cat > "$BRIEF" <<EOF
 You are a persistent second mate managed by the main firstmate. Work on your own; do not wait for a human.

--- a/bin/fm-home-seed.sh
+++ b/bin/fm-home-seed.sh
@@ -9,9 +9,10 @@
 #       no live process and is never recycled until the lease is released with
 #       "treehouse return". Projects are cloned
 #       from the active home into the secondmate home's projects/ directory.
-#       That project list is non-exclusive provisioning data. Pass --no-projects
-#       instead of a project list to seed a project-less home for a domain whose
-#       subject is the firstmate repo itself; it is mutually exclusive with a
+#       That project list also claims spawn ownership: fm-spawn.sh refuses a
+#       fresh primary-home crewmate or scout into a listed project by default.
+#       Pass --no-projects instead of a project list to seed a project-less home
+#       for a domain whose subject is the firstmate repo itself; it is mutually exclusive with a
 #       project list, and omitting both still fails loudly. A project-less seed
 #       refuses a home with project clones or project-registry entries, so it
 #       never converts populated homes in place. The charter brief

--- a/bin/fm-secondmate-registry-lib.sh
+++ b/bin/fm-secondmate-registry-lib.sh
@@ -364,6 +364,7 @@ secondmate_registry_entries() {
   fi
   while IFS= read -r line || [ -n "$line" ]; do
     case "$line" in
+      ''|'#'*) continue ;;
       "- "*)
         if ! secondmate_registry_parse_line "$line"; then
           SECONDMATE_REGISTRY_ENTRIES=
@@ -379,6 +380,11 @@ secondmate_registry_entries() {
         esac
         SECONDMATE_REGISTRY_ENTRIES="${SECONDMATE_REGISTRY_ENTRIES}${SECONDMATE_REGISTRY_ID}${SECONDMATE_REGISTRY_FIELD_SEP}${SECONDMATE_REGISTRY_PROJECTS}${SECONDMATE_REGISTRY_FIELD_SEP}${SECONDMATE_REGISTRY_SCOPE}"$'\n'
         found=1
+        ;;
+      *)
+        SECONDMATE_REGISTRY_ENTRIES=
+        SECONDMATE_REGISTRY_ERROR="malformed secondmate registry entry: $line"
+        return 2
         ;;
     esac
   done < "$reg"

--- a/bin/fm-secondmate-registry-lib.sh
+++ b/bin/fm-secondmate-registry-lib.sh
@@ -313,13 +313,24 @@ secondmate_registry_validate_bindings() {
 }
 
 # The generated field is comma-joined, but a hand-edited list separated by
-# whitespace still states a claim, so both separators split it.
+# whitespace still states a claim, so both separators split it. Each entry is
+# then reduced to its path basename, so a bare `alpha`, a `projects/alpha`, and
+# an absolute clone path all state the same claim the spawn side derives from
+# its own project argument. The split reads into an array instead of
+# word-splitting an unquoted expansion: pathname expansion would otherwise
+# resolve a metacharacter in the field against the caller's working directory
+# and silently rewrite the ownership set in either direction.
 secondmate_registry_projects_field_has() {
   local field=$1 project=$2 entry
-  local IFS=$', \t'
+  local -a entries=()
   [ -n "$project" ] || return 1
   [ -n "$field" ] || return 1
-  for entry in $field; do
+  IFS=$', \t' read -ra entries <<< "$field"
+  for entry in "${entries[@]+"${entries[@]}"}"; do
+    while [ "$entry" != "${entry%/}" ]; do
+      entry=${entry%/}
+    done
+    entry=${entry##*/}
     [ -n "$entry" ] || continue
     [ "$entry" = "$project" ] && return 0
   done

--- a/bin/fm-secondmate-registry-lib.sh
+++ b/bin/fm-secondmate-registry-lib.sh
@@ -28,6 +28,7 @@ SECONDMATE_REGISTRY_MATCH_PROJECTS=
 SECONDMATE_REGISTRY_MATCH_REMOTE=0
 SECONDMATE_REGISTRY_ERROR=
 SECONDMATE_REGISTRY_ENTRIES=
+SECONDMATE_REGISTRY_FIELD_SEP=$'\x1f'
 
 secondmate_registry_lock_path() { printf '%s/.secondmate-registry.lock\n' "$1"; }
 secondmate_reply_lifecycle_lock_path() { printf '%s/.remote-reply-lifecycle-%s.lock\n' "$1" "$2"; }
@@ -312,11 +313,7 @@ secondmate_registry_validate_bindings() {
 }
 
 secondmate_registry_project_basename() {
-  local path=$1
-  case "$path" in
-    projects/*) path=${path#projects/} ;;
-  esac
-  basename "$path"
+  basename "$1"
 }
 
 # The generated field is comma-joined, but a hand-edited list separated by
@@ -334,13 +331,17 @@ secondmate_registry_projects_field_has() {
 }
 
 # Collect every registry record into SECONDMATE_REGISTRY_ENTRIES, one
-# `id<TAB>projects<TAB>scope` line per entry, so a caller reads the registry
-# once. Status: 0 records collected, 1 no registry file or no records, 2 the
-# registry cannot be trusted (unsafe path, unreadable, or an entry no
-# operational parser can consume) with the reason in SECONDMATE_REGISTRY_ERROR.
-# A caller that acts on ownership must treat 2 as unresolved ownership rather
-# than as an absent claim; silently skipping an unparseable entry would void
-# that secondmate's claim exactly when the registry is least trustworthy.
+# `id<SEP>projects<SEP>scope` line per entry, so a caller reads the registry
+# once. The separator is SECONDMATE_REGISTRY_FIELD_SEP, deliberately not IFS
+# whitespace: a project-less secondmate has an empty projects field, and a
+# whitespace separator would let `read` collapse it and hand the scope text to
+# the next field. Read a record back with `IFS=$SECONDMATE_REGISTRY_FIELD_SEP`.
+# Status: 0 records collected, 1 no registry file or no records, 2 the registry
+# cannot be trusted (unsafe path, unreadable, or an entry no operational parser
+# can consume) with the reason in SECONDMATE_REGISTRY_ERROR. A caller that acts
+# on ownership must treat 2 as unresolved ownership rather than as an absent
+# claim; silently skipping an unparseable entry would void that secondmate's
+# claim exactly when the registry is least trustworthy.
 secondmate_registry_entries() {
   local reg=$1 line found=0
   SECONDMATE_REGISTRY_ENTRIES=
@@ -360,14 +361,14 @@ secondmate_registry_entries() {
           SECONDMATE_REGISTRY_ERROR="malformed secondmate registry entry: $line"
           return 2
         fi
-        case "$SECONDMATE_REGISTRY_PROJECTS" in
-          *$'\t'*)
+        case "$SECONDMATE_REGISTRY_ID$SECONDMATE_REGISTRY_PROJECTS$SECONDMATE_REGISTRY_SCOPE" in
+          *"$SECONDMATE_REGISTRY_FIELD_SEP"*)
             SECONDMATE_REGISTRY_ENTRIES=
-            SECONDMATE_REGISTRY_ERROR="unsafe secondmate project list for $SECONDMATE_REGISTRY_ID"
+            SECONDMATE_REGISTRY_ERROR="unsafe secondmate registry entry for $SECONDMATE_REGISTRY_ID"
             return 2
             ;;
         esac
-        SECONDMATE_REGISTRY_ENTRIES="${SECONDMATE_REGISTRY_ENTRIES}${SECONDMATE_REGISTRY_ID}"$'\t'"${SECONDMATE_REGISTRY_PROJECTS}"$'\t'"${SECONDMATE_REGISTRY_SCOPE}"$'\n'
+        SECONDMATE_REGISTRY_ENTRIES="${SECONDMATE_REGISTRY_ENTRIES}${SECONDMATE_REGISTRY_ID}${SECONDMATE_REGISTRY_FIELD_SEP}${SECONDMATE_REGISTRY_PROJECTS}${SECONDMATE_REGISTRY_FIELD_SEP}${SECONDMATE_REGISTRY_SCOPE}"$'\n'
         found=1
         ;;
     esac

--- a/bin/fm-secondmate-registry-lib.sh
+++ b/bin/fm-secondmate-registry-lib.sh
@@ -309,3 +309,58 @@ secondmate_registry_validate_bindings() {
   fi
   return 0
 }
+
+secondmate_registry_project_basename() {
+  local path=$1
+  case "$path" in
+    projects/*) path=${path#projects/} ;;
+  esac
+  basename "$path"
+}
+
+secondmate_registry_projects_field_has() {
+  local field=$1 project=$2 entry
+  local IFS=,
+  [ -n "$project" ] || return 1
+  [ -n "$field" ] || return 1
+  for entry in $field; do
+    entry=${entry#"${entry%%[![:space:]]*}"}
+    entry=${entry%"${entry##*[![:space:]]}"}
+    [ -n "$entry" ] || continue
+    [ "$entry" = "$project" ] && return 0
+  done
+  return 1
+}
+
+secondmate_registry_has_entries() {
+  local reg=$1 line
+  [ -f "$reg" ] || return 1
+  [ ! -L "$reg" ] || return 1
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+      "- "*)
+        secondmate_registry_parse_line "$line" && return 0
+        ;;
+    esac
+  done < "$reg"
+  return 1
+}
+
+# Print one owner id per line for a project basename. Returns 0 when any match.
+secondmate_registry_project_owners() {
+  local reg=$1 project=$2 line found=0
+  [ -f "$reg" ] || return 1
+  [ ! -L "$reg" ] || return 1
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+      "- "*)
+        secondmate_registry_parse_line "$line" || continue
+        if secondmate_registry_projects_field_has "$SECONDMATE_REGISTRY_PROJECTS" "$project"; then
+          printf '%s\n' "$SECONDMATE_REGISTRY_ID"
+          found=1
+        fi
+        ;;
+    esac
+  done < "$reg"
+  [ "$found" -eq 1 ]
+}

--- a/bin/fm-secondmate-registry-lib.sh
+++ b/bin/fm-secondmate-registry-lib.sh
@@ -312,21 +312,23 @@ secondmate_registry_validate_bindings() {
   return 0
 }
 
-# The generated field is comma-joined, but a hand-edited list separated by
-# whitespace still states a claim, so both separators split it. Each entry is
-# then reduced to its path basename, so a bare `alpha`, a `projects/alpha`, and
-# an absolute clone path all state the same claim the spawn side derives from
-# its own project argument. The split reads into an array instead of
-# word-splitting an unquoted expansion: pathname expansion would otherwise
-# resolve a metacharacter in the field against the caller's working directory
-# and silently rewrite the ownership set in either direction.
+# The projects field is comma-delimited. Each complete entry is trimmed and
+# then reduced to its path basename, so whitespace within a project name is
+# preserved while a bare `alpha`, a `projects/alpha`, and an absolute clone path
+# all state the same claim the spawn side derives from its own project argument.
+# The split reads into an array instead of word-splitting an unquoted expansion:
+# pathname expansion would otherwise resolve a metacharacter in the field
+# against the caller's working directory and silently rewrite the ownership set
+# in either direction.
 secondmate_registry_projects_field_has() {
   local field=$1 project=$2 entry
   local -a entries=()
   [ -n "$project" ] || return 1
   [ -n "$field" ] || return 1
-  IFS=$', \t' read -ra entries <<< "$field"
+  IFS=, read -ra entries <<< "$field"
   for entry in "${entries[@]+"${entries[@]}"}"; do
+    entry=${entry#"${entry%%[![:space:]]*}"}
+    entry=${entry%"${entry##*[![:space:]]}"}
     while [ "$entry" != "${entry%/}" ]; do
       entry=${entry%/}
     done

--- a/bin/fm-secondmate-registry-lib.sh
+++ b/bin/fm-secondmate-registry-lib.sh
@@ -27,6 +27,7 @@ SECONDMATE_REGISTRY_MATCH_HOME_KEY=
 SECONDMATE_REGISTRY_MATCH_PROJECTS=
 SECONDMATE_REGISTRY_MATCH_REMOTE=0
 SECONDMATE_REGISTRY_ERROR=
+SECONDMATE_REGISTRY_ENTRIES=
 
 secondmate_registry_lock_path() { printf '%s/.secondmate-registry.lock\n' "$1"; }
 secondmate_reply_lifecycle_lock_path() { printf '%s/.remote-reply-lifecycle-%s.lock\n' "$1" "$2"; }
@@ -318,49 +319,59 @@ secondmate_registry_project_basename() {
   basename "$path"
 }
 
+# The generated field is comma-joined, but a hand-edited list separated by
+# whitespace still states a claim, so both separators split it.
 secondmate_registry_projects_field_has() {
   local field=$1 project=$2 entry
-  local IFS=,
+  local IFS=$', \t'
   [ -n "$project" ] || return 1
   [ -n "$field" ] || return 1
   for entry in $field; do
-    entry=${entry#"${entry%%[![:space:]]*}"}
-    entry=${entry%"${entry##*[![:space:]]}"}
     [ -n "$entry" ] || continue
     [ "$entry" = "$project" ] && return 0
   done
   return 1
 }
 
-secondmate_registry_has_entries() {
-  local reg=$1 line
-  [ -f "$reg" ] || return 1
-  [ ! -L "$reg" ] || return 1
+# Collect every registry record into SECONDMATE_REGISTRY_ENTRIES, one
+# `id<TAB>projects<TAB>scope` line per entry, so a caller reads the registry
+# once. Status: 0 records collected, 1 no registry file or no records, 2 the
+# registry cannot be trusted (unsafe path, unreadable, or an entry no
+# operational parser can consume) with the reason in SECONDMATE_REGISTRY_ERROR.
+# A caller that acts on ownership must treat 2 as unresolved ownership rather
+# than as an absent claim; silently skipping an unparseable entry would void
+# that secondmate's claim exactly when the registry is least trustworthy.
+secondmate_registry_entries() {
+  local reg=$1 line found=0
+  SECONDMATE_REGISTRY_ENTRIES=
+  SECONDMATE_REGISTRY_ERROR=
+  if [ ! -e "$reg" ] && [ ! -L "$reg" ]; then
+    return 1
+  fi
+  if [ -L "$reg" ] || [ ! -f "$reg" ] || [ ! -r "$reg" ]; then
+    SECONDMATE_REGISTRY_ERROR="secondmate registry is unavailable or unsafe: $reg"
+    return 2
+  fi
   while IFS= read -r line || [ -n "$line" ]; do
     case "$line" in
       "- "*)
-        secondmate_registry_parse_line "$line" && return 0
-        ;;
-    esac
-  done < "$reg"
-  return 1
-}
-
-# Print one owner id per line for a project basename. Returns 0 when any match.
-secondmate_registry_project_owners() {
-  local reg=$1 project=$2 line found=0
-  [ -f "$reg" ] || return 1
-  [ ! -L "$reg" ] || return 1
-  while IFS= read -r line || [ -n "$line" ]; do
-    case "$line" in
-      "- "*)
-        secondmate_registry_parse_line "$line" || continue
-        if secondmate_registry_projects_field_has "$SECONDMATE_REGISTRY_PROJECTS" "$project"; then
-          printf '%s\n' "$SECONDMATE_REGISTRY_ID"
-          found=1
+        if ! secondmate_registry_parse_line "$line"; then
+          SECONDMATE_REGISTRY_ENTRIES=
+          SECONDMATE_REGISTRY_ERROR="malformed secondmate registry entry: $line"
+          return 2
         fi
+        case "$SECONDMATE_REGISTRY_PROJECTS" in
+          *$'\t'*)
+            SECONDMATE_REGISTRY_ENTRIES=
+            SECONDMATE_REGISTRY_ERROR="unsafe secondmate project list for $SECONDMATE_REGISTRY_ID"
+            return 2
+            ;;
+        esac
+        SECONDMATE_REGISTRY_ENTRIES="${SECONDMATE_REGISTRY_ENTRIES}${SECONDMATE_REGISTRY_ID}"$'\t'"${SECONDMATE_REGISTRY_PROJECTS}"$'\t'"${SECONDMATE_REGISTRY_SCOPE}"$'\n'
+        found=1
         ;;
     esac
   done < "$reg"
-  [ "$found" -eq 1 ]
+  [ "$found" -eq 1 ] || return 1
+  return 0
 }

--- a/bin/fm-secondmate-registry-lib.sh
+++ b/bin/fm-secondmate-registry-lib.sh
@@ -312,10 +312,6 @@ secondmate_registry_validate_bindings() {
   return 0
 }
 
-secondmate_registry_project_basename() {
-  basename "$1"
-}
-
 # The generated field is comma-joined, but a hand-edited list separated by
 # whitespace still states a claim, so both separators split it.
 secondmate_registry_projects_field_has() {

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1342,7 +1342,7 @@ spawn_secondmate_ownership_guard() {
   fi
   [ "$rc" -eq 0 ] || return 0
   scope_line=
-  while IFS=$'\t' read -r id projects scope; do
+  while IFS=$SECONDMATE_REGISTRY_FIELD_SEP read -r id projects scope; do
     [ -n "$id" ] || continue
     if secondmate_registry_projects_field_has "$projects" "$proj_name"; then
       owner_ids+=("$id")

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Spawn a direct report: a crewmate in a treehouse or Orca worktree, or a
 # secondmate in its isolated firstmate home.
-# Usage: fm-spawn.sh <task-id> <project-dir> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>]
-#        fm-spawn.sh <task-id> <project-dir> --scout [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>]
+# Usage: fm-spawn.sh <task-id> <project-dir> --mode <no-mistakes|direct-PR|local-only> --yolo <on|off> [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] [--allow-primary-spawn]
+#        fm-spawn.sh <task-id> <project-dir> --scout [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] [--allow-primary-spawn]
 #        fm-spawn.sh <task-id> [<firstmate-home>] [--harness <name>|harness|launch-command] [--model <name>] [--effort <level>] [--backend <name>] --secondmate
 #   --mode and --yolo are this task's delivery contract, REQUIRED for every ship
 #   spawn and refused on --scout and --secondmate spawns. Firstmate resolves both
@@ -17,19 +17,6 @@
 #   no-mistakes-prod-only is a registry policy rather than a task mode and is
 #   refused as a flag value.
 #        fm-spawn.sh <task-id> --relaunch [--harness <name>] [--model <name>] [--effort <level>]
-#   --allow-primary-spawn is a deliberate override for a fresh ship or scout spawn
-#   when data/secondmates.md lists the target project on a secondmate's projects:
-#   field. Without it, those spawns REFUSE rather than drift a secondmate-owned
-#   repository into the primary home. The refusal names every registered owner and
-#   is checked before any task metadata exists. With it, the spawn continues,
-#   prints a loud stderr notice naming the bypassed owner(s), and records
-#   primary_spawn_override=1 plus primary_spawn_override_owners=<ids> on the task.
-#   Scope text is never matched; when the project is on no projects: list but the
-#   registry is non-empty, a stderr warning names every registered secondmate and
-#   its scope for judgment, then the spawn continues. A registry that cannot be
-#   read, or any entry no operational parser can consume, refuses the spawn
-#   rather than silently voiding that secondmate's claim. Missing or empty
-#   registries, --secondmate spawns, and --relaunch are unaffected.
 #   --relaunch launches a replacement agent for an EXISTING task into that
 #   task's own recorded endpoint and worktree instead of creating either. It is
 #   the launch half of the control plane (bin/fm-control.sh relaunch), which
@@ -45,6 +32,19 @@
 #   or herdr), refuses unless the endpoint's shell is sitting in the recorded
 #   worktree, and clears the previous harness's per-task wiring before arming
 #   the new incarnation.
+#   --allow-primary-spawn is a deliberate override for a fresh ship or scout spawn
+#   when data/secondmates.md lists the target project on a secondmate's projects:
+#   field. Without it, those spawns REFUSE rather than drift a secondmate-owned
+#   repository into the primary home. The refusal names every registered owner and
+#   is checked before any task metadata exists. With it, the spawn continues,
+#   prints a loud stderr notice naming the bypassed owner(s), and records
+#   primary_spawn_override=1 plus primary_spawn_override_owners=<ids> on the task.
+#   Scope text is never matched; when the project is on no projects: list but the
+#   registry is non-empty, a stderr warning names every registered secondmate and
+#   its scope for judgment, then the spawn continues. A registry that cannot be
+#   read, or any entry no operational parser can consume, refuses the spawn
+#   rather than silently voiding that secondmate's claim. Missing or empty
+#   registries, --secondmate spawns, and --relaunch are unaffected.
 #   --harness <name> is the explicit per-spawn harness/profile adapter. The old
 #   positional harness arg still works for back-compat.
 #   --model <name> and --effort <low|medium|high|xhigh|max> are concrete profile
@@ -1333,7 +1333,7 @@ secondmate_registry_value() {
 spawn_secondmate_ownership_guard() {
   local proj_abs=$1 proj_name reg=$DATA/secondmates.md owners scope_line id projects scope rc=0
   local -a owner_ids=()
-  proj_name=$(secondmate_registry_project_basename "$proj_abs")
+  proj_name=$(basename "$proj_abs")
   secondmate_registry_entries "$reg" || rc=$?
   if [ "$rc" -eq 2 ]; then
     echo "error: ${SECONDMATE_REGISTRY_ERROR:-secondmate registry is unusable: $reg}" >&2

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1354,19 +1354,14 @@ spawn_secondmate_ownership_guard() {
     fi
   done <<< "$SECONDMATE_REGISTRY_ENTRIES"
   if [ "${#owner_ids[@]}" -gt 0 ]; then
+    owners=$(IFS=,; printf '%s' "${owner_ids[*]}")
     if [ "$ALLOW_PRIMARY_SPAWN" -eq 1 ]; then
-      owners=$(IFS=,; printf '%s' "${owner_ids[*]}")
       echo "notice: --allow-primary-spawn bypasses secondmate ownership for $proj_name (registered owner(s): $owners); route future work to that secondmate unless this exception remains deliberate" >&2
       PRIMARY_SPAWN_OVERRIDE=1
       PRIMARY_SPAWN_OVERRIDE_OWNERS=$owners
       return 0
     fi
-    case "${#owner_ids[@]}" in
-      1) owners=${owner_ids[0]} ;;
-      2) owners="${owner_ids[0]} and ${owner_ids[1]}" ;;
-      *) owners=$(printf '%s, ' "${owner_ids[@]}" | sed 's/, $//') ;;
-    esac
-    echo "error: project $proj_name is registered to secondmate $owners; spawn the worker in that secondmate home or pass --allow-primary-spawn for a deliberate primary-home exception" >&2
+    echo "error: project $proj_name is registered to secondmate(s) $owners; spawn the worker in a registered secondmate home or pass --allow-primary-spawn for a deliberate primary-home exception" >&2
     return 1
   fi
   [ -n "$scope_line" ] || return 0

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -24,14 +24,14 @@
 #   transaction; call fm-control rather than this flag directly unless you are
 #   deliberately re-launching an already-stopped task. Every identity axis -
 #   backend, kind, project or home, worktree, endpoint - comes from the task's
-#   validated state/<id>.meta, so --backend, --scout, --secondmate, a project
-#   positional, and batch pairs are all refused alongside it; only harness,
-#   model, and effort may change, which is what makes a harness switch one
-#   ordinary relaunch. It refuses unless the recorded endpoint is positively
-#   agent-free on a backend with a recovery-grade agent-state classifier (tmux
-#   or herdr), refuses unless the endpoint's shell is sitting in the recorded
-#   worktree, and clears the previous harness's per-task wiring before arming
-#   the new incarnation.
+#   validated state/<id>.meta, so --backend, --scout, --secondmate,
+#   --allow-primary-spawn, a project positional, and batch pairs are all refused
+#   alongside it; only harness, model, and effort may change, which is what
+#   makes a harness switch one ordinary relaunch. It refuses unless the recorded
+#   endpoint is positively agent-free on a backend with a recovery-grade
+#   agent-state classifier (tmux or herdr), refuses unless the endpoint's shell
+#   is sitting in the recorded worktree, and clears the previous harness's
+#   per-task wiring before arming the new incarnation.
 #   --allow-primary-spawn is a deliberate override for a fresh ship or scout spawn
 #   when data/secondmates.md lists the target project on a secondmate's projects:
 #   field. Without it, those spawns REFUSE rather than drift a secondmate-owned
@@ -48,8 +48,10 @@
 #   rather than a way to spawn while ownership is unresolvable, so repair the
 #   registry instead. A projects: entry matches on its path basename, so a bare
 #   name, a projects/<name>, and an absolute clone path all state one claim.
-#   Missing or empty registries, --secondmate spawns, and --relaunch are
-#   unaffected.
+#   Missing or empty registries spawn normally. The guard itself runs only on a
+#   fresh ship or scout create, so --secondmate spawns and --relaunch are
+#   unaffected; passing this flag on either is refused rather than ignored, so a
+#   meaningless override can never look accepted.
 #   --harness <name> is the explicit per-spawn harness/profile adapter. The old
 #   positional harness arg still works for back-compat.
 #   --model <name> and --effort <low|medium|high|xhigh|max> are concrete profile

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -17,6 +17,17 @@
 #   no-mistakes-prod-only is a registry policy rather than a task mode and is
 #   refused as a flag value.
 #        fm-spawn.sh <task-id> --relaunch [--harness <name>] [--model <name>] [--effort <level>]
+#   --allow-primary-spawn is a deliberate override for a fresh ship or scout spawn
+#   when data/secondmates.md lists the target project on a secondmate's projects:
+#   field. Without it, those spawns REFUSE rather than drift a secondmate-owned
+#   repository into the primary home. The refusal names every registered owner and
+#   is checked before any task metadata exists. With it, the spawn continues,
+#   prints a loud stderr notice naming the bypassed owner(s), and records
+#   primary_spawn_override=1 plus primary_spawn_override_owners=<ids> on the task.
+#   Scope text is never matched; when the project is on no projects: list but the
+#   registry is non-empty, a stderr warning names every registered secondmate and
+#   its scope for judgment, then the spawn continues. Missing or empty registries,
+#   --secondmate spawns, and --relaunch are unaffected.
 #   --relaunch launches a replacement agent for an EXISTING task into that
 #   task's own recorded endpoint and worktree instead of creating either. It is
 #   the launch half of the control plane (bin/fm-control.sh relaunch), which
@@ -283,6 +294,7 @@ MODE_SET=0
 YOLO_SET=0
 TRACEPARENT_SET=0
 RELAUNCH=0
+ALLOW_PRIMARY_SPAWN=0
 POS=()
 want_value=
 for a in "$@"; do
@@ -307,6 +319,7 @@ for a in "$@"; do
     --scout) KIND=scout; KIND_SET=1 ;;
     --secondmate) KIND=secondmate; KIND_SET=1 ;;
     --relaunch) RELAUNCH=1 ;;
+    --allow-primary-spawn) ALLOW_PRIMARY_SPAWN=1 ;;
     --harness) want_value=harness ;;
     --harness=*) HARNESS_ARG=${a#--harness=}; HARNESS_SET=1 ;;
     --model) want_value=model ;;
@@ -359,7 +372,15 @@ if [ "$RELAUNCH" -eq 1 ]; then
   [ "$KIND_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded kind; --scout/--secondmate cannot override it" >&2; exit 1; }
   [ "$MODE_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded delivery mode; --mode cannot override it" >&2; exit 1; }
   [ "$YOLO_SET" -eq 0 ] || { echo "error: --relaunch reuses the task's recorded yolo posture; --yolo cannot override it" >&2; exit 1; }
+  [ "$ALLOW_PRIMARY_SPAWN" -eq 0 ] || {
+    echo "error: --allow-primary-spawn applies only to fresh ship or scout spawns" >&2
+    exit 1
+  }
 else
+  [ "$ALLOW_PRIMARY_SPAWN" -eq 0 ] || [ "$KIND" != secondmate ] || {
+    echo "error: --allow-primary-spawn applies only to fresh ship or scout spawns" >&2
+    exit 1
+  }
   # Delivery contract (AGENTS.md section 7). A ship task's mode and yolo are
   # firstmate's per-task decision, so they are required and closed-set validated
   # here rather than resolved from the project registry. Scouts deliver a report
@@ -1299,6 +1320,48 @@ secondmate_registry_value() {
   secondmate_registry_field "$DATA/secondmates.md" "$1" "$2"
 }
 
+spawn_secondmate_ownership_guard() {
+  local proj_abs=$1 proj_name reg=$DATA/secondmates.md owners owner scope_line line
+  local -a owner_ids=()
+  proj_name=$(secondmate_registry_project_basename "$proj_abs")
+  secondmate_registry_has_entries "$reg" || return 0
+  while IFS= read -r owner; do
+    [ -n "$owner" ] || continue
+    owner_ids+=("$owner")
+  done < <(secondmate_registry_project_owners "$reg" "$proj_name" && true)
+  if [ "${#owner_ids[@]}" -gt 0 ]; then
+    if [ "$ALLOW_PRIMARY_SPAWN" -eq 1 ]; then
+      owners=$(IFS=,; printf '%s' "${owner_ids[*]}")
+      echo "notice: --allow-primary-spawn bypasses secondmate ownership for $proj_name (registered owner(s): $owners); route future work to that secondmate unless this exception remains deliberate" >&2
+      PRIMARY_SPAWN_OVERRIDE=1
+      PRIMARY_SPAWN_OVERRIDE_OWNERS=$owners
+      return 0
+    fi
+    case "${#owner_ids[@]}" in
+      1) owners=${owner_ids[0]} ;;
+      2) owners="${owner_ids[0]} and ${owner_ids[1]}" ;;
+      *) owners=$(printf '%s, ' "${owner_ids[@]}" | sed 's/, $//') ;;
+    esac
+    echo "error: project $proj_name is registered to secondmate $owners; spawn the worker in that secondmate home or pass --allow-primary-spawn for a deliberate primary-home exception" >&2
+    return 1
+  fi
+  scope_line=
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+      "- "*)
+        secondmate_registry_parse_line "$line" || continue
+        if [ -n "$scope_line" ]; then
+          scope_line="$scope_line; $SECONDMATE_REGISTRY_ID (scope: $SECONDMATE_REGISTRY_SCOPE)"
+        else
+          scope_line="$SECONDMATE_REGISTRY_ID (scope: $SECONDMATE_REGISTRY_SCOPE)"
+        fi
+        ;;
+    esac
+  done < "$reg"
+  [ -n "$scope_line" ] || return 0
+  echo "warning: project $proj_name is not on any registered secondmate projects: list; confirm primary-home work or route in-scope work to a secondmate - registered: $scope_line" >&2
+}
+
 resolve_kimi_binary() {
   local candidate dir fallback
   candidate=$(command -v kimi 2>/dev/null || true)
@@ -1657,6 +1720,10 @@ else
   BRIEF="$DATA/$ID/brief.md"
 fi
 [ -f "$BRIEF" ] || { echo "error: no brief at $BRIEF" >&2; exit 1; }
+
+if [ "$RELAUNCH" -eq 0 ] && [ "$KIND" != secondmate ]; then
+  spawn_secondmate_ownership_guard "$PROJ_ABS" || exit 1
+fi
 
 delivery_rigor_rank() {  # <mode> -> 3 (most rigor) .. 1 (least); 0 = not a task mode
   case "$1" in
@@ -2694,6 +2761,10 @@ preserve_relaunch_meta() {
   if [ "$KIND" = secondmate ]; then
     echo "home=$PROJ_ABS"
     echo "projects=$SECONDMATE_PROJECTS"
+  fi
+  if [ "${PRIMARY_SPAWN_OVERRIDE:-0}" = 1 ]; then
+    echo "primary_spawn_override=1"
+    echo "primary_spawn_override_owners=$PRIMARY_SPAWN_OVERRIDE_OWNERS"
   fi
   if [ "$RELAUNCH" -eq 1 ]; then
     preserve_relaunch_meta

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -26,8 +26,10 @@
 #   primary_spawn_override=1 plus primary_spawn_override_owners=<ids> on the task.
 #   Scope text is never matched; when the project is on no projects: list but the
 #   registry is non-empty, a stderr warning names every registered secondmate and
-#   its scope for judgment, then the spawn continues. Missing or empty registries,
-#   --secondmate spawns, and --relaunch are unaffected.
+#   its scope for judgment, then the spawn continues. A registry that cannot be
+#   read, or any entry no operational parser can consume, refuses the spawn
+#   rather than silently voiding that secondmate's claim. Missing or empty
+#   registries, --secondmate spawns, and --relaunch are unaffected.
 #   --relaunch launches a replacement agent for an EXISTING task into that
 #   task's own recorded endpoint and worktree instead of creating either. It is
 #   the launch half of the control plane (bin/fm-control.sh relaunch), which
@@ -153,8 +155,9 @@
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
 #   source of truth; shared --scout/--harness/--model/--effort/--backend/--mode/--yolo
-#   applies to every pair. A ship batch therefore carries one delivery contract, and each
-#   pair still checks it against its own brief; a batch spanning modes is two invocations.
+#   and --allow-primary-spawn apply to every pair. A ship batch therefore carries
+#   one delivery contract, and each pair still checks it against its own brief;
+#   a batch spanning modes is two invocations.
 #   If config/crew-dispatch.json exists, shared --harness is required for crewmate
 #   and scout batches. The loop lives here, in bash, so callers never hand-write a
 #   multi-task shell loop (the tool shell is zsh, which does not word-split unquoted
@@ -295,6 +298,10 @@ YOLO_SET=0
 TRACEPARENT_SET=0
 RELAUNCH=0
 ALLOW_PRIMARY_SPAWN=0
+# Guard outputs, never inherited from the environment: only the ownership guard
+# below sets them, and the meta write reads them verbatim.
+PRIMARY_SPAWN_OVERRIDE=0
+PRIMARY_SPAWN_OVERRIDE_OWNERS=
 POS=()
 want_value=
 for a in "$@"; do
@@ -889,6 +896,9 @@ if [ "${#POS[@]}" -gt 0 ] && [ "${POS[0]}" != "$idpart" ] && case "$idpart" in *
   # spanning several modes is two invocations rather than a silent mixed dispatch.
   [ "$MODE_SET" -eq 0 ] || shared_args+=(--mode "$MODE")
   [ "$YOLO_SET" -eq 0 ] || shared_args+=(--yolo "$YOLO")
+  # The deliberate ownership exception is decided once for the batch and must
+  # reach each pair's own guard, or the operator's explicit override is dropped.
+  [ "$ALLOW_PRIMARY_SPAWN" -eq 0 ] || shared_args+=(--allow-primary-spawn)
   for pair in "${POS[@]}"; do
     case "$pair" in
       *=*) : ;;
@@ -1321,14 +1331,28 @@ secondmate_registry_value() {
 }
 
 spawn_secondmate_ownership_guard() {
-  local proj_abs=$1 proj_name reg=$DATA/secondmates.md owners owner scope_line line
+  local proj_abs=$1 proj_name reg=$DATA/secondmates.md owners scope_line id projects scope rc=0
   local -a owner_ids=()
   proj_name=$(secondmate_registry_project_basename "$proj_abs")
-  secondmate_registry_has_entries "$reg" || return 0
-  while IFS= read -r owner; do
-    [ -n "$owner" ] || continue
-    owner_ids+=("$owner")
-  done < <(secondmate_registry_project_owners "$reg" "$proj_name" && true)
+  secondmate_registry_entries "$reg" || rc=$?
+  if [ "$rc" -eq 2 ]; then
+    echo "error: ${SECONDMATE_REGISTRY_ERROR:-secondmate registry is unusable: $reg}" >&2
+    echo "error: refusing this spawn because secondmate project ownership cannot be resolved from $reg; repair the registry (bin/fm-home-seed.sh validate reports the same records) and retry" >&2
+    return 1
+  fi
+  [ "$rc" -eq 0 ] || return 0
+  scope_line=
+  while IFS=$'\t' read -r id projects scope; do
+    [ -n "$id" ] || continue
+    if secondmate_registry_projects_field_has "$projects" "$proj_name"; then
+      owner_ids+=("$id")
+    fi
+    if [ -n "$scope_line" ]; then
+      scope_line="$scope_line; $id (scope: $scope)"
+    else
+      scope_line="$id (scope: $scope)"
+    fi
+  done <<< "$SECONDMATE_REGISTRY_ENTRIES"
   if [ "${#owner_ids[@]}" -gt 0 ]; then
     if [ "$ALLOW_PRIMARY_SPAWN" -eq 1 ]; then
       owners=$(IFS=,; printf '%s' "${owner_ids[*]}")
@@ -1345,19 +1369,6 @@ spawn_secondmate_ownership_guard() {
     echo "error: project $proj_name is registered to secondmate $owners; spawn the worker in that secondmate home or pass --allow-primary-spawn for a deliberate primary-home exception" >&2
     return 1
   fi
-  scope_line=
-  while IFS= read -r line || [ -n "$line" ]; do
-    case "$line" in
-      "- "*)
-        secondmate_registry_parse_line "$line" || continue
-        if [ -n "$scope_line" ]; then
-          scope_line="$scope_line; $SECONDMATE_REGISTRY_ID (scope: $SECONDMATE_REGISTRY_SCOPE)"
-        else
-          scope_line="$SECONDMATE_REGISTRY_ID (scope: $SECONDMATE_REGISTRY_SCOPE)"
-        fi
-        ;;
-    esac
-  done < "$reg"
   [ -n "$scope_line" ] || return 0
   echo "warning: project $proj_name is not on any registered secondmate projects: list; confirm primary-home work or route in-scope work to a secondmate - registered: $scope_line" >&2
 }
@@ -2762,7 +2773,7 @@ preserve_relaunch_meta() {
     echo "home=$PROJ_ABS"
     echo "projects=$SECONDMATE_PROJECTS"
   fi
-  if [ "${PRIMARY_SPAWN_OVERRIDE:-0}" = 1 ]; then
+  if [ "$PRIMARY_SPAWN_OVERRIDE" = 1 ]; then
     echo "primary_spawn_override=1"
     echo "primary_spawn_override_owners=$PRIMARY_SPAWN_OVERRIDE_OWNERS"
   fi

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -43,8 +43,13 @@
 #   registry is non-empty, a stderr warning names every registered secondmate and
 #   its scope for judgment, then the spawn continues. A registry that cannot be
 #   read, or any entry no operational parser can consume, refuses the spawn
-#   rather than silently voiding that secondmate's claim. Missing or empty
-#   registries, --secondmate spawns, and --relaunch are unaffected.
+#   rather than silently voiding that secondmate's claim; that refusal is
+#   independent of this flag, which is a deliberate exception to a NAMED owner
+#   rather than a way to spawn while ownership is unresolvable, so repair the
+#   registry instead. A projects: entry matches on its path basename, so a bare
+#   name, a projects/<name>, and an absolute clone path all state one claim.
+#   Missing or empty registries, --secondmate spawns, and --relaunch are
+#   unaffected.
 #   --harness <name> is the explicit per-spawn harness/profile adapter. The old
 #   positional harness arg still works for back-compat.
 #   --model <name> and --effort <low|medium|high|xhigh|max> are concrete profile

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -1035,7 +1035,13 @@ families_for_changed_path() {
       ;;
     bin/fm-lint.sh|bin/fm-lint-workflows.sh|bin/fm-install-shellcheck.sh|\
     bin/fm-install-actionlint.sh|\
-    bin/fm-brief.sh|bin/fm-ensure-agents-md.sh|bin/fm-crew-state.sh|\
+    bin/fm-brief.sh)
+      # Scaffolds both crew briefs and the secondmate charter whose generated
+      # note the secondmate suite pins verbatim.
+      printf '%s\n' pure-contract-unit
+      printf '%s\n' secondmate
+      ;;
+    bin/fm-ensure-agents-md.sh|bin/fm-crew-state.sh|\
     bin/fm-captain-hold.sh|bin/fm-decision-hold.sh|bin/fm-supervision*|bin/fm-transition-lib.sh|\
     bin/fm-tmux-lib.sh|bin/fm-marker-lib.sh|bin/fm-operational-input.sh|bin/fm-tasks-axi-lib.sh|\
     bin/fm-vendor-auth-probe.sh|\

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -957,6 +957,13 @@ families_for_changed_path() {
       printf '%s\n' secondmate
       printf '%s\n' session-bootstrap
       ;;
+    bin/fm-secondmate-registry-lib.sh)
+      # The registry parser behind both the secondmate route surface and
+      # fm-spawn's primary-home ownership guard, whose only coverage is the
+      # pure-contract-unit ownership suite.
+      printf '%s\n' secondmate
+      printf '%s\n' pure-contract-unit
+      ;;
     bin/fm-secondmate*|bin/fm-remote*|bin/fm-on.sh|bin/fm-home-seed.sh|\
     bin/fm-backlog-handoff.sh|bin/fm-backlog-receive.sh|bin/fm-procevent-remote-reply.sh|\
     bin/fm-config-inherit-lib.sh|bin/fm-config-push.sh|bin/fm-shared*|\

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -146,6 +146,7 @@ family_for_basename() {
     fm-send-popup-settle.test.sh|fm-send-settle.test.sh|\
     fm-subagent-pretool-check.test.sh|\
     fm-supervision-instructions.test.sh|fm-task-delivery.test.sh|\
+    fm-spawn-secondmate-ownership.test.sh|\
     fm-tmux-submit-busy.test.sh|fm-trace-context-lib.test.sh|\
     fm-transition-lib.test.sh|\
     fm-test-run.test.sh|fm-test-isolation-proof.test.sh)
@@ -472,6 +473,7 @@ tests/fm-sessionstart-instruction-refresh-live-e2e.test.sh 21
 tests/fm-sessionstart-nudge.test.sh 26684
 tests/fm-shared-captain-inheritance.test.sh 10672
 tests/fm-spawn-dispatch-profile.test.sh 57765
+tests/fm-spawn-secondmate-ownership.test.sh 3500
 tests/fm-spawn-pool-base-freshen.test.sh 13257
 tests/fm-spawn-worktree-settle.test.sh 4828
 tests/fm-startup-memory-budget.test.sh 6550

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -1034,7 +1034,9 @@ families_for_changed_path() {
       printf '%s\n' real-herdr-gated
       ;;
     bin/fm-lint.sh|bin/fm-lint-workflows.sh|bin/fm-install-shellcheck.sh|\
-    bin/fm-install-actionlint.sh|\
+    bin/fm-install-actionlint.sh)
+      printf '%s\n' pure-contract-unit
+      ;;
     bin/fm-brief.sh)
       # Scaffolds both crew briefs and the secondmate charter whose generated
       # note the secondmate suite pins verbatim.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -193,7 +193,7 @@ The concise single-line route contract is owned by the [`secondmate-provisioning
 A remote route adds `host:` and `root:` before the existing fields and places the whole secondmate home on that SSH host; it does not make ordinary workers remotely placeable.
 [`remote-secondmates.md`](remote-secondmates.md) owns current remote setup, operation, and safety behavior.
 Use `fm-home-seed.sh validate` to check the complete operational registry contract documented by the command itself.
-The main first mate routes by reading those scopes with judgment; the project list is provisioning data, not exclusive ownership.
+The main first mate routes by reading those scopes with judgment; [`fm-spawn.sh`](../bin/fm-spawn.sh) hard-refuses a fresh primary-home ship or scout into any project listed on a secondmate's `projects:` field unless `--allow-primary-spawn` is passed deliberately, while scope text is never matched at spawn time.
 Use `fm-home-seed.sh <id> - {<project>...|--no-projects}` to lease a fresh local firstmate worktree for the secondmate home.
 For remote provisioning, including supplied project origins, follow [Remote second mates](remote-secondmates.md#provision-a-route).
 Use the deliberate `--no-projects` signal only for a firstmate-repo domain that needs no separate project clones.

--- a/docs/fm-test-portable-shards.md
+++ b/docs/fm-test-portable-shards.md
@@ -66,6 +66,7 @@ Each shard is still strictly serial in itself, and separate runners mean no two 
 Assignment is longest-processing-time bin packing over per-script duration hints embedded in `bin/fm-test-run.sh`.
 The hints came from the `fm-test-timing-portable-serial-*` artifacts of green CI run [32491999845](https://github.com/kunchenguid/firstmate/actions/runs/32491999845) on 2026-08-21, where the lane ran 116 scripts in 2541548 ms of serial work.
 `tests/fm-tool-update-check.test.sh` did not exist on that run, so its 12846 ms hint comes from the shard 3 artifact of run [32461816719](https://github.com/kunchenguid/firstmate/actions/runs/32461816719), which is the first run that measured it.
+`tests/fm-spawn-secondmate-ownership.test.sh` postdates both runs, so its 3500 ms hint is an authored estimate rather than a measured value until the next refresh.
 A script with no hint gets the conservative `PORTABLE_SERIAL_DEFAULT_WEIGHT_MS` default.
 Hints only affect balance: the coverage guard keeps the partition complete and disjoint whatever they say, so a stale hint costs a slower shard rather than lost coverage.
 Balance is still worth keeping current, because enough unmeasured scripts let one shard carry more than twice another shard's real work and reach the job cap while another runner sits idle.
@@ -73,11 +74,11 @@ Refresh the hints whenever the serial lane gains scripts, rather than waiting fo
 
 | Lane | Script count | Estimated duration |
 |---|---:|---:|
-| `portable-serial-1of4` | 29 | 638602 ms (~638.6 s) |
-| `portable-serial-2of4` | 28 | 638594 ms (~638.6 s) |
-| `portable-serial-3of4` | 30 | 638607 ms (~638.6 s) |
-| `portable-serial-4of4` | 30 | 638591 ms (~638.6 s) |
-| imbalance | | 16 ms |
+| `portable-serial-1of4` | 31 | 676483 ms (~676.5 s) |
+| `portable-serial-2of4` | 32 | 676481 ms (~676.5 s) |
+| `portable-serial-3of4` | 31 | 676465 ms (~676.5 s) |
+| `portable-serial-4of4` | 32 | 676465 ms (~676.5 s) |
+| imbalance | | 18 ms |
 
 The single longest script, `tests/fm-pr-check-security.test.sh` at 250417 ms, is the floor for any shard count.
 

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -1817,7 +1817,20 @@ TS
       fail "Pi follow-up $label case did not process the monitoring notification"
     fi
 
-    pane=$(tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" -S - 2>/dev/null || true)
+    # The session log is durable before Pi's streaming row has necessarily
+    # converged into its settled transcript row. Wait on the public terminal
+    # surface itself so this remains a rendering assertion, while a persistent
+    # duplicate still exhausts the bound and fails below.
+    i=0
+    while [ "$i" -lt 120 ]; do
+      pane=$(tmux -L "$TMUX_SOCKET" capture-pane -p -t "$TMUX_SESSION" -S - 2>/dev/null || true)
+      if [ "$(printf '%s\n' "$pane" | grep -Fc "CAPTAIN_ANSWER_$label" || true)" -eq 1 ] \
+        && printf '%s\n' "$pane" | grep -Fq "MONITOR_HANDLED_${label}_ONE"; then
+        break
+      fi
+      sleep 0.05
+      i=$((i + 1))
+    done
     [ "$(printf '%s\n' "$pane" | grep -Fc "CAPTAIN_ANSWER_$label" || true)" -eq 1 ] \
       || fail "Pi follow-up $label case rendered a duplicate captain answer"
     assert_contains "$pane" "CAPTAIN_PROMPT_$label" "Pi follow-up $label case hid the genuine captain prompt"

--- a/tests/fm-secondmate-safety.test.sh
+++ b/tests/fm-secondmate-safety.test.sh
@@ -646,7 +646,7 @@ test_home_seed_refuses_projectful_reused_charter_for_projectless_home() {
 
   scaffold_secondmate_charter "$home" stale 'firstmate self-development. None. This is a project-less domain.' alpha \
     || fail "projectful charter scaffold failed"
-  sed 's/The projects above are local clones for work you supervise; they are not an exclusive ownership claim./Project clone details are customized for this domain./' \
+  sed 's/The projects above are local clones for work you supervise, and the main firstmate refuses to spawn its own crewmates or scouts into them without a deliberate override./Project clone details are customized for this domain./' \
     "$stale_brief" > "$stale_brief_before"
   mv "$stale_brief_before" "$stale_brief"
   cp "$stale_brief" "$stale_brief_before"

--- a/tests/fm-spawn-secondmate-ownership.test.sh
+++ b/tests/fm-spawn-secondmate-ownership.test.sh
@@ -397,6 +397,30 @@ EOF
   pass "fm-spawn: an unsafe registry path refuses rather than reading as an empty registry"
 }
 
+test_fresh_scout_spawn_is_guarded_and_overridable_like_a_ship_spawn() {
+  local rec home proj fakebin out status line
+  line="- design - design domain (home: $TMP_ROOT/scout/smhome; scope: design domain; projects: ownedproj; added 2026-06-22)"
+  rec=$(make_home scout "$line")
+  IFS='|' read -r home proj fakebin _smhome <<EOF
+$rec
+EOF
+  write_brief "$home" own-scout-i1
+  out=$(run_spawn "$home" "$fakebin" own-scout-i1 "$proj/ownedproj" claude --scout)
+  status=$?
+  [ "$status" -ne 0 ] || fail "owned-project scout spawn should exit non-zero"
+  assert_contains "$out" "registered to secondmate(s) design" "scout refusal did not name the owning secondmate"
+  assert_not_contains "$out" "$BACKEND_REACHED" "the refused scout spawn still reached the backend"
+  assert_absent "$home/state/own-scout-i1.meta" "refused scout spawn wrote task metadata"
+
+  write_brief "$home" own-scout-i2
+  out=$(run_spawn "$home" "$fakebin" own-scout-i2 "$proj/ownedproj" claude --scout --allow-primary-spawn)
+  assert_contains "$out" "--allow-primary-spawn bypasses secondmate ownership" \
+    "scout override did not print a loud notice"
+  assert_not_contains "$out" "registered to secondmate" "scout override was blocked by the ownership guard"
+  assert_contains "$out" "$BACKEND_REACHED" "the overridden scout spawn never reached the backend"
+  pass "fm-spawn: a fresh scout spawn is refused on an owned project and passes with the deliberate override"
+}
+
 test_batch_dispatch_carries_the_deliberate_override_to_every_pair() {
   local rec home proj fakebin out
   local line
@@ -421,6 +445,7 @@ test_fresh_spawn_into_owned_project_refuses_and_writes_no_meta
 test_refusal_names_every_owner_when_several_claim_the_project
 test_registry_entry_path_forms_state_the_same_ownership_claim
 test_projects_field_metacharacter_is_never_expanded_against_the_working_directory
+test_fresh_scout_spawn_is_guarded_and_overridable_like_a_ship_spawn
 test_allow_primary_spawn_override_passes_the_ownership_guard
 test_allow_primary_spawn_is_refused_outside_a_fresh_ship_or_scout_spawn
 test_secondmate_spawn_is_unaffected_by_the_ownership_guard

--- a/tests/fm-spawn-secondmate-ownership.test.sh
+++ b/tests/fm-spawn-secondmate-ownership.test.sh
@@ -157,6 +157,38 @@ EOF
   pass "fm-spawn: --allow-primary-spawn bypasses the ownership guard on an owned project"
 }
 
+test_allow_primary_spawn_is_refused_outside_a_fresh_ship_or_scout_spawn() {
+  local rec home proj fakebin smhome out status line
+  line="- design - design domain (home: $TMP_ROOT/misuse/smhome; scope: design domain; projects: ownedproj; added 2026-06-22)"
+  rec=$(make_home misuse "$line")
+  IFS='|' read -r home proj fakebin smhome <<EOF
+$rec
+EOF
+  write_brief "$home" own-misuse-e1 no-mistakes
+  fm_write_meta "$home/state/own-misuse-e1.meta" \
+    "window=firstmate:fm-own-misuse-e1" \
+    "endpoint_task_id=own-misuse-e1" \
+    "worktree=$proj/ownedproj" \
+    "project=$proj/ownedproj" \
+    "harness=claude" \
+    "kind=ship" \
+    "mode=no-mistakes" \
+    "yolo=off"
+  out=$(run_spawn "$home" "$fakebin" own-misuse-e1 --relaunch --allow-primary-spawn)
+  status=$?
+  [ "$status" -ne 0 ] || fail "--relaunch with --allow-primary-spawn should exit non-zero"
+  assert_contains "$out" "--allow-primary-spawn applies only to fresh ship or scout spawns" \
+    "relaunch did not refuse the misapplied override"
+
+  out=$(run_spawn "$home" "$fakebin" design "$smhome" --secondmate --allow-primary-spawn)
+  status=$?
+  [ "$status" -ne 0 ] || fail "--secondmate with --allow-primary-spawn should exit non-zero"
+  assert_contains "$out" "--allow-primary-spawn applies only to fresh ship or scout spawns" \
+    "secondmate spawn did not refuse the misapplied override"
+  assert_not_contains "$out" "$BACKEND_REACHED" "the misapplied override still reached the backend"
+  pass "fm-spawn: --allow-primary-spawn is refused on --relaunch and --secondmate spawns"
+}
+
 test_secondmate_spawn_is_unaffected_by_the_ownership_guard() {
   local rec home proj fakebin smhome out line
   # The home directory's basename is itself on the registry's projects list, so
@@ -350,6 +382,7 @@ EOF
 test_fresh_spawn_into_owned_project_refuses_and_writes_no_meta
 test_refusal_names_every_owner_when_several_claim_the_project
 test_allow_primary_spawn_override_passes_the_ownership_guard
+test_allow_primary_spawn_is_refused_outside_a_fresh_ship_or_scout_spawn
 test_secondmate_spawn_is_unaffected_by_the_ownership_guard
 test_relaunch_is_unaffected_by_the_ownership_guard
 test_override_spawn_records_every_bypassed_owner_on_the_task_record

--- a/tests/fm-spawn-secondmate-ownership.test.sh
+++ b/tests/fm-spawn-secondmate-ownership.test.sh
@@ -140,9 +140,68 @@ EOF
   pass "fm-spawn: unowned projects and missing registries pass the ownership guard"
 }
 
+test_unparseable_registry_entry_refuses_instead_of_voiding_ownership() {
+  local rec home proj fakebin out status good bad
+  good="- design - design domain (home: $TMP_ROOT/malformed/smhome; scope: design domain; projects: ownedproj; added 2026-06-22)"
+  bad="- triage - typo entry (home: $TMP_ROOT/malformed/smhome2; scope: triage; projects: freeproj)"
+  rec=$(make_home malformed "$good" "$bad")
+  IFS='|' read -r home proj fakebin _smhome <<EOF
+$rec
+EOF
+  write_brief "$home" own-broken-e1 no-mistakes
+  out=$(run_spawn "$home" "$fakebin" own-broken-e1 "$proj/freeproj" claude --mode no-mistakes --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn against an unparseable registry entry should exit non-zero"
+  assert_contains "$out" "malformed secondmate registry entry" "refusal did not name the unusable registry record"
+  assert_contains "$out" "- triage - typo entry" "refusal did not quote the offending registry line"
+  assert_not_contains "$out" "not on any registered secondmate projects: list" \
+    "an unresolvable registry still claimed the project is unowned"
+  assert_absent "$home/state/own-broken-e1.meta" "refused spawn wrote task metadata"
+  pass "fm-spawn: an unparseable registry entry refuses rather than silently voiding its ownership claim"
+}
+
+test_unreadable_registry_symlink_refuses_the_spawn() {
+  local rec home proj fakebin out status
+  rec=$(make_home symlinked)
+  IFS='|' read -r home proj fakebin _smhome <<EOF
+$rec
+EOF
+  ln -s "$home/data/missing-secondmates.md" "$home/data/secondmates.md"
+  write_brief "$home" own-link-f1 no-mistakes
+  out=$(run_spawn "$home" "$fakebin" own-link-f1 "$proj/freeproj" claude --mode no-mistakes --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn against an unsafe registry path should exit non-zero"
+  assert_contains "$out" "secondmate registry is unavailable or unsafe" "refusal did not name the unsafe registry path"
+  assert_absent "$home/state/own-link-f1.meta" "refused spawn wrote task metadata"
+  pass "fm-spawn: an unsafe registry path refuses rather than reading as an empty registry"
+}
+
+test_batch_dispatch_carries_the_deliberate_override_to_every_pair() {
+  local rec home proj fakebin out
+  local line
+  line="- design - design domain (home: $TMP_ROOT/batch/smhome; scope: design domain; projects: ownedproj; added 2026-06-22)"
+  rec=$(make_home batch "$line")
+  IFS='|' read -r home proj fakebin _smhome <<EOF
+$rec
+EOF
+  write_brief "$home" own-batch-g1 no-mistakes
+  out=$(run_spawn "$home" "$fakebin" "own-batch-g1=$proj/ownedproj" --mode no-mistakes --yolo off)
+  assert_contains "$out" "registered to secondmate design" "batch pair did not hit the ownership guard"
+
+  write_brief "$home" own-batch-g2 no-mistakes
+  out=$(run_spawn "$home" "$fakebin" "own-batch-g2=$proj/ownedproj" --mode no-mistakes --yolo off --allow-primary-spawn)
+  assert_contains "$out" "--allow-primary-spawn bypasses secondmate ownership" \
+    "batch dispatch dropped the deliberate override before the per-pair guard"
+  assert_not_contains "$out" "registered to secondmate design" "batch pair refused despite the deliberate override"
+  pass "fm-spawn: batch dispatch forwards --allow-primary-spawn to every pair"
+}
+
 test_fresh_spawn_into_owned_project_refuses_and_writes_no_meta
 test_allow_primary_spawn_override_passes_the_ownership_guard
 test_secondmate_spawn_is_unaffected_by_the_ownership_guard
 test_relaunch_is_unaffected_by_the_ownership_guard
 test_unowned_project_or_missing_registry_spawns_past_the_guard
+test_unparseable_registry_entry_refuses_instead_of_voiding_ownership
+test_unreadable_registry_symlink_refuses_the_spawn
+test_batch_dispatch_carries_the_deliberate_override_to_every_pair
 echo "# all fm-spawn-secondmate-ownership tests passed"

--- a/tests/fm-spawn-secondmate-ownership.test.sh
+++ b/tests/fm-spawn-secondmate-ownership.test.sh
@@ -142,6 +142,24 @@ EOF
   pass "fm-spawn: a projects: entry claims its project as a bare name, projects/<name>, or absolute path"
 }
 
+test_project_name_whitespace_is_preserved_within_comma_delimited_entries() {
+  local rec home proj fakebin out status line
+  line="- design - design domain (home: $TMP_ROOT/whitespace/smhome; scope: design domain; projects: My Project, other; added 2026-06-22)"
+  rec=$(make_home whitespace "$line")
+  IFS='|' read -r home proj fakebin _smhome <<EOF
+$rec
+EOF
+  mkdir -p "$proj/My Project"
+  write_brief "$home" own-space-l1 no-mistakes
+  out=$(run_spawn "$home" "$fakebin" own-space-l1 "$proj/My Project" claude --mode no-mistakes --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "a project with whitespace in its basename should refuse"
+  assert_contains "$out" "registered to secondmate(s) design" \
+    "whitespace within a comma-delimited project entry broke its ownership claim"
+  assert_absent "$home/state/own-space-l1.meta" "refused whitespace-project spawn wrote task metadata"
+  pass "fm-spawn: whitespace within a comma-delimited project name is preserved"
+}
+
 test_projects_field_metacharacter_is_never_expanded_against_the_working_directory() {
   local rec home proj fakebin cwd out status line
   line="- design - design domain (home: $TMP_ROOT/glob/smhome; scope: design domain; projects: owned*; added 2026-06-22)"
@@ -444,6 +462,7 @@ EOF
 test_fresh_spawn_into_owned_project_refuses_and_writes_no_meta
 test_refusal_names_every_owner_when_several_claim_the_project
 test_registry_entry_path_forms_state_the_same_ownership_claim
+test_project_name_whitespace_is_preserved_within_comma_delimited_entries
 test_projects_field_metacharacter_is_never_expanded_against_the_working_directory
 test_fresh_scout_spawn_is_guarded_and_overridable_like_a_ship_spawn
 test_allow_primary_spawn_override_passes_the_ownership_guard

--- a/tests/fm-spawn-secondmate-ownership.test.sh
+++ b/tests/fm-spawn-secondmate-ownership.test.sh
@@ -124,6 +124,44 @@ EOF
   pass "fm-spawn: a fresh crewmate spawn into a secondmate-owned project refuses before metadata exists"
 }
 
+test_registry_entry_path_forms_state_the_same_ownership_claim() {
+  local rec home proj fakebin out status
+  rec=$(make_home pathforms \
+    "- design - design domain (home: $TMP_ROOT/pathforms/smhome; scope: design domain; projects: projects/ownedproj; added 2026-06-22)" \
+    "- triage - triage domain (home: $TMP_ROOT/pathforms/smhome2; scope: triage; projects: $TMP_ROOT/pathforms/projects/ownedproj; added 2026-06-22)")
+  IFS='|' read -r home proj fakebin _smhome <<EOF
+$rec
+EOF
+  write_brief "$home" own-path-j1 no-mistakes
+  out=$(run_spawn "$home" "$fakebin" own-path-j1 "$proj/ownedproj" claude --mode no-mistakes --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "a projects/<name> or absolute-path registry entry should still refuse"
+  assert_contains "$out" "registered to secondmate(s) design,triage" \
+    "path-form registry entries did not state the same ownership claim as a bare name"
+  assert_absent "$home/state/own-path-j1.meta" "refused spawn wrote task metadata"
+  pass "fm-spawn: a projects: entry claims its project as a bare name, projects/<name>, or absolute path"
+}
+
+test_projects_field_metacharacter_is_never_expanded_against_the_working_directory() {
+  local rec home proj fakebin cwd out status line
+  line="- design - design domain (home: $TMP_ROOT/glob/smhome; scope: design domain; projects: owned*; added 2026-06-22)"
+  rec=$(make_home glob "$line")
+  IFS='|' read -r home proj fakebin _smhome <<EOF
+$rec
+EOF
+  cwd="$TMP_ROOT/glob/cwd"
+  mkdir -p "$cwd"
+  : > "$cwd/ownedproj"
+  write_brief "$home" own-glob-k1 no-mistakes
+  out=$(cd "$cwd" && run_spawn "$home" "$fakebin" own-glob-k1 "$proj/ownedproj" claude --mode no-mistakes --yolo off)
+  status=$?
+  assert_not_contains "$out" "registered to secondmate" \
+    "a projects: glob expanded against the working directory and invented an ownership claim"
+  assert_contains "$out" "$BACKEND_REACHED" "the invented ownership claim stopped the spawn before the backend"
+  [ "$status" -ne 0 ] || fail "the refusing fake backend should still fail the spawn"
+  pass "fm-spawn: a projects: metacharacter is compared literally, never expanded against the caller's cwd"
+}
+
 test_refusal_names_every_owner_when_several_claim_the_project() {
   local rec home proj fakebin out status
   rec=$(make_home multiowner \
@@ -381,6 +419,8 @@ EOF
 
 test_fresh_spawn_into_owned_project_refuses_and_writes_no_meta
 test_refusal_names_every_owner_when_several_claim_the_project
+test_registry_entry_path_forms_state_the_same_ownership_claim
+test_projects_field_metacharacter_is_never_expanded_against_the_working_directory
 test_allow_primary_spawn_override_passes_the_ownership_guard
 test_allow_primary_spawn_is_refused_outside_a_fresh_ship_or_scout_spawn
 test_secondmate_spawn_is_unaffected_by_the_ownership_guard

--- a/tests/fm-spawn-secondmate-ownership.test.sh
+++ b/tests/fm-spawn-secondmate-ownership.test.sh
@@ -118,10 +118,29 @@ EOF
   out=$(run_spawn "$home" "$fakebin" own-refuse-a1 "$proj/ownedproj" claude --mode no-mistakes --yolo off)
   status=$?
   [ "$status" -ne 0 ] || fail "owned-project spawn should exit non-zero"
-  assert_contains "$out" "registered to secondmate design" "refusal did not name the owning secondmate"
+  assert_contains "$out" "registered to secondmate(s) design" "refusal did not name the owning secondmate"
   assert_contains "$out" "--allow-primary-spawn" "refusal did not name the deliberate override"
   assert_absent "$home/state/own-refuse-a1.meta" "refused spawn wrote task metadata"
   pass "fm-spawn: a fresh crewmate spawn into a secondmate-owned project refuses before metadata exists"
+}
+
+test_refusal_names_every_owner_when_several_claim_the_project() {
+  local rec home proj fakebin out status
+  rec=$(make_home multiowner \
+    "- design - design domain (home: $TMP_ROOT/multiowner/smhome; scope: design domain; projects: ownedproj; added 2026-06-22)" \
+    "- triage - triage domain (home: $TMP_ROOT/multiowner/smhome2; scope: triage; projects: ownedproj, other; added 2026-06-22)" \
+    "- docs - docs domain (home: $TMP_ROOT/multiowner/smhome3; scope: docs; projects: ownedproj; added 2026-06-22)")
+  IFS='|' read -r home proj fakebin _smhome <<EOF
+$rec
+EOF
+  write_brief "$home" own-refuse-a2 no-mistakes
+  out=$(run_spawn "$home" "$fakebin" own-refuse-a2 "$proj/ownedproj" claude --mode no-mistakes --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "multi-owner spawn should exit non-zero"
+  assert_contains "$out" "registered to secondmate(s) design,triage,docs" \
+    "refusal did not name every owner in one consistently joined list"
+  assert_absent "$home/state/own-refuse-a2.meta" "refused spawn wrote task metadata"
+  pass "fm-spawn: a refusal names every registered owner the same way at any arity"
 }
 
 test_allow_primary_spawn_override_passes_the_ownership_guard() {
@@ -304,17 +323,18 @@ $rec
 EOF
   write_brief "$home" own-batch-g1 no-mistakes
   out=$(run_spawn "$home" "$fakebin" "own-batch-g1=$proj/ownedproj" --mode no-mistakes --yolo off)
-  assert_contains "$out" "registered to secondmate design" "batch pair did not hit the ownership guard"
+  assert_contains "$out" "registered to secondmate(s) design" "batch pair did not hit the ownership guard"
 
   write_brief "$home" own-batch-g2 no-mistakes
   out=$(run_spawn "$home" "$fakebin" "own-batch-g2=$proj/ownedproj" --mode no-mistakes --yolo off --allow-primary-spawn)
   assert_contains "$out" "--allow-primary-spawn bypasses secondmate ownership" \
     "batch dispatch dropped the deliberate override before the per-pair guard"
-  assert_not_contains "$out" "registered to secondmate design" "batch pair refused despite the deliberate override"
+  assert_not_contains "$out" "registered to secondmate(s) design" "batch pair refused despite the deliberate override"
   pass "fm-spawn: batch dispatch forwards --allow-primary-spawn to every pair"
 }
 
 test_fresh_spawn_into_owned_project_refuses_and_writes_no_meta
+test_refusal_names_every_owner_when_several_claim_the_project
 test_allow_primary_spawn_override_passes_the_ownership_guard
 test_secondmate_spawn_is_unaffected_by_the_ownership_guard
 test_relaunch_is_unaffected_by_the_ownership_guard

--- a/tests/fm-spawn-secondmate-ownership.test.sh
+++ b/tests/fm-spawn-secondmate-ownership.test.sh
@@ -103,7 +103,7 @@ run_spawn() {  # <home> <fakebin> <spawn-args...>
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$TMP_ROOT/projects-unused" FM_CONFIG_OVERRIDE="$home/config" \
     FM_SPAWN_NO_GUARD=1 FM_BACKEND=tmux FM_FAKE_DIR="${FM_FAKE_DIR:-}" \
-    PATH="$fakebin:$PATH" \
+    TMUX='' PATH="$fakebin:$PATH" \
     "$SPAWN" "$@" 2>&1
 }
 
@@ -238,14 +238,28 @@ test_override_spawn_records_every_bypassed_owner_on_the_task_record() {
 }
 
 test_unowned_project_or_missing_registry_spawns_past_the_guard() {
-  local rec home proj fakebin out
+  local rec home proj fakebin out line
   rec=$(make_home unowned)
   IFS='|' read -r home proj fakebin _smhome <<EOF
 $rec
 EOF
+  assert_absent "$home/data/secondmates.md" "the missing-registry fixture wrote a registry"
   write_brief "$home" own-free-d1 no-mistakes
   out=$(run_spawn "$home" "$fakebin" own-free-d1 "$proj/freeproj" claude --mode no-mistakes --yolo off)
   assert_not_contains "$out" "registered to secondmate" "unowned spawn with no registry hit the ownership guard"
+  assert_contains "$out" "$BACKEND_REACHED" "a missing registry stopped the spawn before the backend"
+  assert_not_contains "$out" "not on any registered secondmate" "a missing registry warned about registered scopes"
+
+  rec=$(make_home empty-reg)
+  IFS='|' read -r home proj fakebin _smhome <<EOF
+$rec
+EOF
+  printf '%s\n' '# Second mates' > "$home/data/secondmates.md"
+  write_brief "$home" own-free-d3 no-mistakes
+  out=$(run_spawn "$home" "$fakebin" own-free-d3 "$proj/freeproj" claude --mode no-mistakes --yolo off)
+  assert_not_contains "$out" "registered to secondmate" "unowned spawn with an entry-less registry hit the ownership guard"
+  assert_contains "$out" "$BACKEND_REACHED" "an entry-less registry stopped the spawn before the backend"
+  assert_not_contains "$out" "not on any registered secondmate" "an entry-less registry warned about registered scopes"
 
   line="- design - design domain (home: $TMP_ROOT/unowned/smhome; scope: design domain; projects: ownedproj; added 2026-06-22)"
   rec=$(make_home unowned-reg "$line")
@@ -256,7 +270,7 @@ EOF
   out=$(run_spawn "$home" "$fakebin" own-free-d2 "$proj/freeproj" claude --mode no-mistakes --yolo off)
   assert_not_contains "$out" "registered to secondmate" "unowned spawn with a registry hit the ownership guard"
   assert_contains "$out" "not on any registered secondmate projects: list" "unowned spawn did not warn about registered scopes"
-  pass "fm-spawn: unowned projects and missing registries pass the ownership guard"
+  pass "fm-spawn: unowned projects and missing or entry-less registries pass the ownership guard"
 }
 
 test_project_less_secondmate_never_claims_ownership_through_its_scope_text() {

--- a/tests/fm-spawn-secondmate-ownership.test.sh
+++ b/tests/fm-spawn-secondmate-ownership.test.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 # Behavior tests for fm-spawn.sh's secondmate project-ownership guard on fresh
-# ship and scout spawns. Every case stops before any endpoint exists: the guard
-# runs ahead of backend creation, and a fake tmux that exits non-zero backstops
-# cases meant to get past it.
+# ship and scout spawns. Refusal cases stop before any endpoint exists. Cases
+# that must get PAST the guard prove it: the refusing fake backend announces its
+# window-creation attempt, which fm-spawn only reaches well after the guard, and
+# the override and relaunch cases drive a lifecycle-modelling backend all the way
+# to a published state/<id>.meta record.
 set -u
 
 # shellcheck source=tests/lib.sh
@@ -11,23 +13,78 @@ set -u
 SPAWN="$ROOT/bin/fm-spawn.sh"
 TMP_ROOT=$(fm_test_tmproot fm-spawn-secondmate-ownership)
 
+# The refusing backend fails every request, but announces a window-creation
+# attempt on stderr. fm-spawn only asks a backend for a window long after the
+# ownership guard, so BACKEND_REACHED is a marker no pre-guard exit can print.
+BACKEND_REACHED="fake-backend: refusing to create a window"
+
+scaffold_secondmate_home() {  # <path>
+  local smhome=$1
+  mkdir -p "$smhome/state" "$smhome/bin" "$smhome/data"
+  printf '%s\n' 'fixture' > "$smhome/AGENTS.md"
+  printf '%s\n' design > "$smhome/.fm-secondmate-home"
+  printf '%s\n' 'You are a persistent second mate.' > "$smhome/data/charter.md"
+}
+
 make_home() {  # <name> [<secondmate-registry-line>...]
   local name=$1 home projects fakebin smhome
   shift
   home="$TMP_ROOT/$name/home"
   projects="$TMP_ROOT/$name/projects"
-  smhome="$TMP_ROOT/$name/secondmate-home"
+  smhome="$TMP_ROOT/$name/smhome"
   fakebin="$TMP_ROOT/$name/bin"
   mkdir -p "$home/data" "$home/state" "$home/config" "$projects/ownedproj" "$projects/freeproj" "$fakebin"
-  mkdir -p "$smhome/state" "$smhome/bin"
-  printf '%s\n' 'fixture' > "$smhome/AGENTS.md"
-  printf '%s\n' design > "$smhome/.fm-secondmate-home"
-  printf '#!/bin/sh\nexit 1\n' > "$fakebin/tmux"
+  scaffold_secondmate_home "$smhome"
+  cat > "$fakebin/tmux" <<SH
+#!/bin/sh
+case "\${1:-}" in
+  new-window) printf '%s\\n' "$BACKEND_REACHED" >&2 ;;
+esac
+exit 1
+SH
   chmod +x "$fakebin/tmux"
   if [ "$#" -gt 0 ]; then
     printf '%s\n' "$@" > "$home/data/secondmates.md"
   fi
   printf '%s\n' "$home|$projects|$fakebin|$smhome"
+}
+
+# A backend that models the pane lifecycle instead of refusing, so a spawn can
+# run to a published state/<id>.meta. Shaped after the stub in
+# tests/fm-control-relaunch.test.sh: FM_FAKE_DIR/command is the pane's current
+# command (the agent-liveness read a relaunch requires) and FM_FAKE_DIR/cwd is
+# the worktree treehouse is pretending to have entered.
+make_live_backend() {  # <dir> <worktree> <pane-command> [<existing-window>] -> echoes fakebin dir
+  local dir=$1 wt=$2 command=$3 window=${4:-}
+  local fb="$dir/fakebin" fake="$dir/fake"
+  mkdir -p "$fb" "$fake"
+  printf '%s' "$command" > "$fake/command"
+  printf '%s' "$wt" > "$fake/cwd"
+  : > "$fake/windows"
+  [ -z "$window" ] || printf '%s\n' "$window" > "$fake/windows"
+  cat > "$fb/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+D=$FM_FAKE_DIR
+case "${1:-}" in
+  new-window) printf 'fakewin1\n'; exit 0 ;;
+  display-message)
+    for a in "$@"; do
+      case "$a" in
+        *pane_current_command*) cat "$D/command"; printf '\n'; exit 0 ;;
+        *pane_current_path*) cat "$D/cwd"; printf '\n'; exit 0 ;;
+        *cursor_y*) printf '1\n'; exit 0 ;;
+      esac
+    done
+    printf 'firstmate\n'; exit 0 ;;
+  capture-pane) printf 'pane\n'; exit 0 ;;
+  list-windows) [ -f "$D/windows" ] && cat "$D/windows"; exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fb/tmux"
+  fm_fake_exit0 "$fb" treehouse
+  printf '%s\n' "$fb"
 }
 
 write_brief() {  # <home> <id> [<mode>]
@@ -45,7 +102,8 @@ run_spawn() {  # <home> <fakebin> <spawn-args...>
   FM_ROOT_OVERRIDE='' FM_HOME="$home" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$TMP_ROOT/projects-unused" FM_CONFIG_OVERRIDE="$home/config" \
-    FM_SPAWN_NO_GUARD=1 FM_BACKEND=tmux PATH="$fakebin:$PATH" \
+    FM_SPAWN_NO_GUARD=1 FM_BACKEND=tmux FM_FAKE_DIR="${FM_FAKE_DIR:-}" \
+    PATH="$fakebin:$PATH" \
     "$SPAWN" "$@" 2>&1
 }
 
@@ -81,41 +139,83 @@ EOF
 }
 
 test_secondmate_spawn_is_unaffected_by_the_ownership_guard() {
-  local rec home proj fakebin smhome out
-  line="- design - design domain (home: $TMP_ROOT/secondmate/smhome; scope: design domain; projects: ownedproj; added 2026-06-22)"
+  local rec home proj fakebin smhome out line
+  # The home directory's basename is itself on the registry's projects list, so
+  # a guard that did not exempt --secondmate would refuse this very spawn.
+  smhome="$TMP_ROOT/secondmate/design"
+  line="- design - design domain (home: $smhome; scope: design domain; projects: design, ownedproj; added 2026-06-22)"
   rec=$(make_home secondmate "$line")
-  IFS='|' read -r home proj fakebin smhome <<EOF
+  IFS='|' read -r home proj fakebin _unused <<EOF
 $rec
 EOF
-  out=$(run_spawn "$home" "$fakebin" design "$smhome" --secondmate 2>&1)
+  scaffold_secondmate_home "$smhome"
+  out=$(run_spawn "$home" "$fakebin" design "$smhome" --secondmate)
+  assert_contains "$out" "$BACKEND_REACHED" "secondmate spawn never reached the backend, so it never reached the guard position"
   assert_not_contains "$out" "registered to secondmate" "secondmate spawn hit the crewmate ownership guard"
   assert_not_contains "$out" "--allow-primary-spawn bypasses" "secondmate spawn required the primary override"
   pass "fm-spawn: --secondmate spawns are unaffected by the ownership guard"
 }
 
 test_relaunch_is_unaffected_by_the_ownership_guard() {
-  local rec home proj fakebin smhome out status
-  line="- design - design domain (home: $TMP_ROOT/relaunch/smhome; scope: design domain; projects: ownedproj; added 2026-06-22)"
-  rec=$(make_home relaunch "$line")
-  IFS='|' read -r home proj fakebin smhome <<EOF
-$rec
-EOF
-  mkdir -p "$home/worktrees/owned"
-  cat > "$home/state/own-relaunch-c1.meta" <<EOF
-window=fm-own-relaunch-c1
-endpoint_task_id=own-relaunch-c1
-worktree=$home/worktrees/owned
-project=$proj/ownedproj
-harness=claude
-kind=ship
-mode=no-mistakes
-yolo=off
-EOF
-  out=$(run_spawn "$home" "$fakebin" own-relaunch-c1 --relaunch claude)
-  status=$?
+  local dir home wt fakebin out line
+  dir="$TMP_ROOT/own-relaunch-c1"
+  home="$dir/home"
+  wt="$dir/wt"
+  mkdir -p "$home/data/own-relaunch-c1" "$home/state" "$home/config"
+  fm_git_worktree "$dir/ownedproj" "$wt" task-own-relaunch-c1
+  line="- design - design domain (home: $dir/smhome; scope: design domain; projects: ownedproj; added 2026-06-22)"
+  printf '%s\n' "$line" > "$home/data/secondmates.md"
+  printf '# brief\n\nDo the thing.\n' > "$home/data/own-relaunch-c1/brief.md"
+  fakebin=$(make_live_backend "$dir" "$wt" zsh fm-own-relaunch-c1)
+  fm_write_meta "$home/state/own-relaunch-c1.meta" \
+    "window=firstmate:fm-own-relaunch-c1" \
+    "endpoint_task_id=own-relaunch-c1" \
+    "worktree=$wt" \
+    "project=$dir/ownedproj" \
+    "harness=claude" \
+    "kind=ship" \
+    "mode=no-mistakes" \
+    "yolo=off" \
+    "tasktmp=/tmp/fm-own-relaunch-c1" \
+    "model=default" \
+    "effort=default"
+  FM_FAKE_DIR="$dir/fake"
+  out=$(run_spawn "$home" "$fakebin" own-relaunch-c1 --relaunch --harness claude)
   assert_not_contains "$out" "registered to secondmate" "relaunch hit the crewmate ownership guard"
-  [ "$status" -ne 0 ] || fail "relaunch should still fail later on the refusing fake backend"
-  pass "fm-spawn: --relaunch is unaffected by the ownership guard"
+  assert_contains "$out" "spawned own-relaunch-c1" "relaunch did not complete into its recorded endpoint"
+  assert_present "$home/state/own-relaunch-c1.meta" "relaunch did not keep the task record"
+  unset FM_FAKE_DIR
+  rm -rf /tmp/fm-own-relaunch-c1
+  pass "fm-spawn: --relaunch into a secondmate-owned project is unaffected by the ownership guard"
+}
+
+test_override_spawn_records_every_bypassed_owner_on_the_task_record() {
+  local dir home wt fakebin out status meta
+  dir="$TMP_ROOT/own-override-b2"
+  home="$dir/home"
+  wt="$dir/wt"
+  meta="$home/state/own-override-b2.meta"
+  mkdir -p "$home/data/own-override-b2" "$home/state" "$home/config"
+  fm_git_worktree "$dir/ownedproj" "$wt" task-own-override-b2
+  {
+    printf -- '- design - design domain (home: %s/smhome; scope: design domain; projects: ownedproj; added 2026-06-22)\n' "$dir"
+    printf -- '- triage - triage domain (home: %s/smhome2; scope: triage; projects: ownedproj, other; added 2026-06-22)\n' "$dir"
+  } > "$home/data/secondmates.md"
+  printf '# brief\n\n# Definition of done\nDelivery contract: mode=no-mistakes\n' > "$home/data/own-override-b2/brief.md"
+  fakebin=$(make_live_backend "$dir" "$wt" claude)
+  FM_FAKE_DIR="$dir/fake"
+  out=$(run_spawn "$home" "$fakebin" own-override-b2 "$dir/ownedproj" claude \
+    --mode no-mistakes --yolo off --allow-primary-spawn)
+  status=$?
+  unset FM_FAKE_DIR
+  [ "$status" -eq 0 ] || fail "override spawn should complete"$'\n'"$out"
+  assert_contains "$out" "--allow-primary-spawn bypasses secondmate ownership" "override did not print a loud notice"
+  assert_present "$meta" "override spawn published no task record"
+  assert_grep 'primary_spawn_override=1' "$meta" "task record did not record the deliberate override"
+  assert_grep 'primary_spawn_override_owners=design,triage' "$meta" \
+    "task record did not name every bypassed owner"
+  rm -rf /tmp/fm-own-override-b2
+  pass "fm-spawn: a deliberate override records every bypassed owner on the task record"
 }
 
 test_unowned_project_or_missing_registry_spawns_past_the_guard() {
@@ -138,6 +238,24 @@ EOF
   assert_not_contains "$out" "registered to secondmate" "unowned spawn with a registry hit the ownership guard"
   assert_contains "$out" "not on any registered secondmate projects: list" "unowned spawn did not warn about registered scopes"
   pass "fm-spawn: unowned projects and missing registries pass the ownership guard"
+}
+
+test_project_less_secondmate_never_claims_ownership_through_its_scope_text() {
+  local rec home proj fakebin out status line
+  line="- design - design domain (home: $TMP_ROOT/projectless/smhome; scope: docs, freeproj, release notes; projects: ; added 2026-06-22)"
+  rec=$(make_home projectless "$line")
+  IFS='|' read -r home proj fakebin _smhome <<EOF
+$rec
+EOF
+  write_brief "$home" own-scope-h1 no-mistakes
+  out=$(run_spawn "$home" "$fakebin" own-scope-h1 "$proj/freeproj" claude --mode no-mistakes --yolo off)
+  status=$?
+  assert_not_contains "$out" "registered to secondmate" "a project-less secondmate claimed ownership through its scope text"
+  assert_contains "$out" "$BACKEND_REACHED" "the spawn was stopped before the backend despite no ownership claim"
+  assert_contains "$out" "design (scope: docs, freeproj, release notes)" \
+    "the unowned-project warning dropped the scope it exists to surface"
+  [ "$status" -ne 0 ] || fail "the refusing fake backend should still fail the spawn"
+  pass "fm-spawn: a project-less secondmate's scope text is never an ownership claim"
 }
 
 test_unparseable_registry_entry_refuses_instead_of_voiding_ownership() {
@@ -200,7 +318,9 @@ test_fresh_spawn_into_owned_project_refuses_and_writes_no_meta
 test_allow_primary_spawn_override_passes_the_ownership_guard
 test_secondmate_spawn_is_unaffected_by_the_ownership_guard
 test_relaunch_is_unaffected_by_the_ownership_guard
+test_override_spawn_records_every_bypassed_owner_on_the_task_record
 test_unowned_project_or_missing_registry_spawns_past_the_guard
+test_project_less_secondmate_never_claims_ownership_through_its_scope_text
 test_unparseable_registry_entry_refuses_instead_of_voiding_ownership
 test_unreadable_registry_symlink_refuses_the_spawn
 test_batch_dispatch_carries_the_deliberate_override_to_every_pair

--- a/tests/fm-spawn-secondmate-ownership.test.sh
+++ b/tests/fm-spawn-secondmate-ownership.test.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Behavior tests for fm-spawn.sh's secondmate project-ownership guard on fresh
+# ship and scout spawns. Every case stops before any endpoint exists: the guard
+# runs ahead of backend creation, and a fake tmux that exits non-zero backstops
+# cases meant to get past it.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=$(fm_test_tmproot fm-spawn-secondmate-ownership)
+
+make_home() {  # <name> [<secondmate-registry-line>...]
+  local name=$1 home projects fakebin smhome
+  shift
+  home="$TMP_ROOT/$name/home"
+  projects="$TMP_ROOT/$name/projects"
+  smhome="$TMP_ROOT/$name/secondmate-home"
+  fakebin="$TMP_ROOT/$name/bin"
+  mkdir -p "$home/data" "$home/state" "$home/config" "$projects/ownedproj" "$projects/freeproj" "$fakebin"
+  mkdir -p "$smhome/state" "$smhome/bin"
+  printf '%s\n' 'fixture' > "$smhome/AGENTS.md"
+  printf '%s\n' design > "$smhome/.fm-secondmate-home"
+  printf '#!/bin/sh\nexit 1\n' > "$fakebin/tmux"
+  chmod +x "$fakebin/tmux"
+  if [ "$#" -gt 0 ]; then
+    printf '%s\n' "$@" > "$home/data/secondmates.md"
+  fi
+  printf '%s\n' "$home|$projects|$fakebin|$smhome"
+}
+
+write_brief() {  # <home> <id> [<mode>]
+  local home=$1 id=$2 mode=${3:-}
+  mkdir -p "$home/data/$id"
+  {
+    printf 'You are a crewmate.\n\n# Definition of done\n'
+    [ -z "$mode" ] || printf 'Delivery contract: mode=%s\n' "$mode"
+  } > "$home/data/$id/brief.md"
+}
+
+run_spawn() {  # <home> <fakebin> <spawn-args...>
+  local home=$1 fakebin=$2
+  shift 2
+  FM_ROOT_OVERRIDE='' FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_PROJECTS_OVERRIDE="$TMP_ROOT/projects-unused" FM_CONFIG_OVERRIDE="$home/config" \
+    FM_SPAWN_NO_GUARD=1 FM_BACKEND=tmux PATH="$fakebin:$PATH" \
+    "$SPAWN" "$@" 2>&1
+}
+
+test_fresh_spawn_into_owned_project_refuses_and_writes_no_meta() {
+  local rec home proj fakebin smhome out status line
+  line="- design - design domain (home: $TMP_ROOT/refuse/smhome; scope: design domain; projects: ownedproj; added 2026-06-22)"
+  rec=$(make_home refuse "$line")
+  IFS='|' read -r home proj fakebin smhome <<EOF
+$rec
+EOF
+  write_brief "$home" own-refuse-a1 no-mistakes
+  out=$(run_spawn "$home" "$fakebin" own-refuse-a1 "$proj/ownedproj" claude --mode no-mistakes --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "owned-project spawn should exit non-zero"
+  assert_contains "$out" "registered to secondmate design" "refusal did not name the owning secondmate"
+  assert_contains "$out" "--allow-primary-spawn" "refusal did not name the deliberate override"
+  assert_absent "$home/state/own-refuse-a1.meta" "refused spawn wrote task metadata"
+  pass "fm-spawn: a fresh crewmate spawn into a secondmate-owned project refuses before metadata exists"
+}
+
+test_allow_primary_spawn_override_passes_the_ownership_guard() {
+  local rec home proj fakebin smhome out
+  line="- design - design domain (home: $TMP_ROOT/override/smhome; scope: design domain; projects: ownedproj; added 2026-06-22)"
+  rec=$(make_home override "$line")
+  IFS='|' read -r home proj fakebin smhome <<EOF
+$rec
+EOF
+  write_brief "$home" own-override-b1 no-mistakes
+  out=$(run_spawn "$home" "$fakebin" own-override-b1 "$proj/ownedproj" claude --mode no-mistakes --yolo off --allow-primary-spawn)
+  assert_not_contains "$out" "registered to secondmate" "override spawn was blocked by the ownership guard"
+  assert_contains "$out" "--allow-primary-spawn bypasses secondmate ownership" "override did not print a loud notice"
+  pass "fm-spawn: --allow-primary-spawn bypasses the ownership guard on an owned project"
+}
+
+test_secondmate_spawn_is_unaffected_by_the_ownership_guard() {
+  local rec home proj fakebin smhome out
+  line="- design - design domain (home: $TMP_ROOT/secondmate/smhome; scope: design domain; projects: ownedproj; added 2026-06-22)"
+  rec=$(make_home secondmate "$line")
+  IFS='|' read -r home proj fakebin smhome <<EOF
+$rec
+EOF
+  out=$(run_spawn "$home" "$fakebin" design "$smhome" --secondmate 2>&1)
+  assert_not_contains "$out" "registered to secondmate" "secondmate spawn hit the crewmate ownership guard"
+  assert_not_contains "$out" "--allow-primary-spawn bypasses" "secondmate spawn required the primary override"
+  pass "fm-spawn: --secondmate spawns are unaffected by the ownership guard"
+}
+
+test_relaunch_is_unaffected_by_the_ownership_guard() {
+  local rec home proj fakebin smhome out status
+  line="- design - design domain (home: $TMP_ROOT/relaunch/smhome; scope: design domain; projects: ownedproj; added 2026-06-22)"
+  rec=$(make_home relaunch "$line")
+  IFS='|' read -r home proj fakebin smhome <<EOF
+$rec
+EOF
+  mkdir -p "$home/worktrees/owned"
+  cat > "$home/state/own-relaunch-c1.meta" <<EOF
+window=fm-own-relaunch-c1
+endpoint_task_id=own-relaunch-c1
+worktree=$home/worktrees/owned
+project=$proj/ownedproj
+harness=claude
+kind=ship
+mode=no-mistakes
+yolo=off
+EOF
+  out=$(run_spawn "$home" "$fakebin" own-relaunch-c1 --relaunch claude)
+  status=$?
+  assert_not_contains "$out" "registered to secondmate" "relaunch hit the crewmate ownership guard"
+  [ "$status" -ne 0 ] || fail "relaunch should still fail later on the refusing fake backend"
+  pass "fm-spawn: --relaunch is unaffected by the ownership guard"
+}
+
+test_unowned_project_or_missing_registry_spawns_past_the_guard() {
+  local rec home proj fakebin out
+  rec=$(make_home unowned)
+  IFS='|' read -r home proj fakebin _smhome <<EOF
+$rec
+EOF
+  write_brief "$home" own-free-d1 no-mistakes
+  out=$(run_spawn "$home" "$fakebin" own-free-d1 "$proj/freeproj" claude --mode no-mistakes --yolo off)
+  assert_not_contains "$out" "registered to secondmate" "unowned spawn with no registry hit the ownership guard"
+
+  line="- design - design domain (home: $TMP_ROOT/unowned/smhome; scope: design domain; projects: ownedproj; added 2026-06-22)"
+  rec=$(make_home unowned-reg "$line")
+  IFS='|' read -r home proj fakebin _smhome <<EOF
+$rec
+EOF
+  write_brief "$home" own-free-d2 no-mistakes
+  out=$(run_spawn "$home" "$fakebin" own-free-d2 "$proj/freeproj" claude --mode no-mistakes --yolo off)
+  assert_not_contains "$out" "registered to secondmate" "unowned spawn with a registry hit the ownership guard"
+  assert_contains "$out" "not on any registered secondmate projects: list" "unowned spawn did not warn about registered scopes"
+  pass "fm-spawn: unowned projects and missing registries pass the ownership guard"
+}
+
+test_fresh_spawn_into_owned_project_refuses_and_writes_no_meta
+test_allow_primary_spawn_override_passes_the_ownership_guard
+test_secondmate_spawn_is_unaffected_by_the_ownership_guard
+test_relaunch_is_unaffected_by_the_ownership_guard
+test_unowned_project_or_missing_registry_spawns_past_the_guard
+echo "# all fm-spawn-secondmate-ownership tests passed"

--- a/tests/fm-spawn-secondmate-ownership.test.sh
+++ b/tests/fm-spawn-secondmate-ownership.test.sh
@@ -399,6 +399,25 @@ EOF
   pass "fm-spawn: an unparseable registry entry refuses rather than silently voiding its ownership claim"
 }
 
+test_nonrecord_registry_line_refuses_instead_of_looking_empty() {
+  local rec home proj fakebin out status
+  rec=$(make_home malformed-nonrecord "this is not a secondmate registry record")
+  IFS='|' read -r home proj fakebin _smhome <<EOF
+$rec
+EOF
+  write_brief "$home" own-malformed-m1 no-mistakes
+  out=$(run_spawn "$home" "$fakebin" own-malformed-m1 "$proj/freeproj" claude --mode no-mistakes --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "a non-record registry line should exit non-zero"
+  assert_contains "$out" "malformed secondmate registry entry" \
+    "a non-record registry line was silently treated as an empty registry"
+  assert_not_contains "$out" "$BACKEND_REACHED" \
+    "a non-record registry line reached the backend instead of failing closed"
+  assert_absent "$home/state/own-malformed-m1.meta" \
+    "spawn against a non-record registry line wrote task metadata"
+  pass "fm-spawn: every non-empty malformed registry line fails closed"
+}
+
 test_unreadable_registry_symlink_refuses_the_spawn() {
   local rec home proj fakebin out status
   rec=$(make_home symlinked)
@@ -473,6 +492,7 @@ test_override_spawn_records_every_bypassed_owner_on_the_task_record
 test_unowned_project_or_missing_registry_spawns_past_the_guard
 test_project_less_secondmate_never_claims_ownership_through_its_scope_text
 test_unparseable_registry_entry_refuses_instead_of_voiding_ownership
+test_nonrecord_registry_line_refuses_instead_of_looking_empty
 test_unreadable_registry_symlink_refuses_the_spawn
 test_batch_dispatch_carries_the_deliberate_override_to_every_pair
 echo "# all fm-spawn-secondmate-ownership tests passed"

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -109,6 +109,7 @@ init_changed_fixture_repo() {
     fm-bearings-snapshot.test.sh \
     fm-backend-cmux.test.sh \
     fm-backend-zellij.test.sh \
+    fm-spawn-secondmate-ownership.test.sh \
     fm-backend-orca.test.sh; do
     printf '#!/usr/bin/env bash\n# tests/lib.sh\n' >"$repo/tests/$script"
     chmod +x "$repo/tests/$script"
@@ -116,6 +117,7 @@ init_changed_fixture_repo() {
   : >"$repo/tests/lib.sh"
   : >"$repo/tests/fm-backend-herdr-eventwait.test.py"
   : >"$repo/bin/fm-supervisor-target-lib.sh"
+  : >"$repo/bin/fm-secondmate-registry-lib.sh"
   : >"$repo/bin/unmapped-source.sh"
   printf '# .claude/settings.json\n# .pi/extensions/fm-primary-turnend-guard.ts\n' \
     >>"$repo/tests/fm-cd-pretool-check.test.sh"
@@ -158,6 +160,14 @@ test_changed_dependency_selection_and_unmapped_failure() {
   assert_contains "$listed" "tests/fm-afk-return.test.sh" "supervisor target selects afk coverage"
   git -C "$repo" add bin/fm-supervisor-target-lib.sh
   git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm supervisor-change
+
+  printf '\n' >>"$repo/bin/fm-secondmate-registry-lib.sh"
+  listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)
+  assert_contains "$listed" "tests/fm-secondmate-safety.test.sh" "registry parser selects secondmate coverage"
+  assert_contains "$listed" "tests/fm-spawn-secondmate-ownership.test.sh" \
+    "registry parser selects the ownership-guard coverage that consumes it"
+  git -C "$repo" add bin/fm-secondmate-registry-lib.sh
+  git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm registry-lib-change
 
   printf '\n' >>"$repo/.agents/skills/example/SKILL.md"
   printf '\n' >>"$repo/.claude/settings.json"

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -660,11 +660,10 @@ test_herdr_ci_family_run_has_a_step_timeout() {
   # The required Herdr lane's hang tripwire is the family-run *step* bound, not
   # the 75-minute job cap. Parse the workflow as YAML so nested `with.name`
   # artifact keys cannot masquerade as the step contract.
-  local json job_timeout step_timeout
+  local timeouts job_timeout step_timeout
   if command -v python3 >/dev/null 2>&1 \
     && python3 -c 'import yaml' >/dev/null 2>&1; then
-    json=$(python3 -c '
-import json
+    timeouts=$(python3 -c '
 import sys
 import yaml
 
@@ -678,14 +677,11 @@ step = next(
 )
 if "timeout-minutes" not in step:
     raise KeyError("family-run step has no timeout-minutes")
-print(json.dumps({
-    "job_timeout": job["timeout-minutes"],
-    "step_timeout": step["timeout-minutes"],
-}))
+print(job["timeout-minutes"], step["timeout-minutes"])
 ' "$ROOT/.github/workflows/ci.yml") \
       || fail "could not parse tests-herdr timeouts from ci.yml"
   elif command -v ruby >/dev/null 2>&1; then
-    json=$(ruby -ryaml -rjson -e '
+    timeouts=$(ruby -ryaml -e '
 doc = YAML.load_file(ARGV[0])
 job = doc.fetch("jobs").fetch("tests-herdr")
 step = job.fetch("steps").find { |candidate|
@@ -693,19 +689,13 @@ step = job.fetch("steps").find { |candidate|
 }
 raise "missing family-run step" if step.nil?
 raise "family-run step has no timeout-minutes" unless step.key?("timeout-minutes")
-puts JSON.generate(
-  "job_timeout" => job.fetch("timeout-minutes"),
-  "step_timeout" => step.fetch("timeout-minutes")
-)
+puts "#{job.fetch("timeout-minutes")} #{step.fetch("timeout-minutes")}"
 ' "$ROOT/.github/workflows/ci.yml") \
       || fail "could not parse tests-herdr timeouts from ci.yml"
   else
     fail "python3 with PyYAML or ruby is required to parse .github/workflows/ci.yml as YAML"
   fi
-  job_timeout=$(python3 -c 'import json,sys; print(json.load(sys.stdin)["job_timeout"])' <<<"$json") \
-    || fail "could not read job timeout from parsed workflow"
-  step_timeout=$(python3 -c 'import json,sys; print(json.load(sys.stdin)["step_timeout"])' <<<"$json") \
-    || fail "could not read step timeout from parsed workflow"
+  read -r job_timeout step_timeout <<<"$timeouts"
   [ "$job_timeout" = 75 ] \
     || fail "tests-herdr job backstop must stay 75 minutes, got $job_timeout"
   [ "$step_timeout" = 20 ] \

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -119,6 +119,7 @@ init_changed_fixture_repo() {
   : >"$repo/bin/fm-supervisor-target-lib.sh"
   : >"$repo/bin/fm-secondmate-registry-lib.sh"
   : >"$repo/bin/fm-brief.sh"
+  : >"$repo/bin/fm-lint.sh"
   : >"$repo/bin/unmapped-source.sh"
   printf '# .claude/settings.json\n# .pi/extensions/fm-primary-turnend-guard.ts\n' \
     >>"$repo/tests/fm-cd-pretool-check.test.sh"
@@ -177,6 +178,15 @@ test_changed_dependency_selection_and_unmapped_failure() {
     "brief scaffolder selects the secondmate coverage that pins its generated charter note"
   git -C "$repo" add bin/fm-brief.sh
   git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm brief-change
+
+  printf '\n' >>"$repo/bin/fm-lint.sh"
+  listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)
+  assert_contains "$listed" "tests/fm-brief.test.sh" "lint script selects its own contract coverage"
+  if printf '%s\n' "$listed" | grep -Fqx "tests/fm-secondmate-safety.test.sh"; then
+    fail "lint script over-selected the secondmate family it cannot affect"
+  fi
+  git -C "$repo" add bin/fm-lint.sh
+  git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm lint-change
 
   printf '\n' >>"$repo/.agents/skills/example/SKILL.md"
   printf '\n' >>"$repo/.claude/settings.json"

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -660,14 +660,36 @@ test_herdr_ci_family_run_has_a_step_timeout() {
   # The required Herdr lane's hang tripwire is the family-run *step* bound, not
   # the 75-minute job cap. Parse the workflow as YAML so nested `with.name`
   # artifact keys cannot masquerade as the step contract.
-  command -v ruby >/dev/null 2>&1 \
-    || fail "ruby is required to parse .github/workflows/ci.yml as YAML"
   local json job_timeout step_timeout
-  json=$(ruby -ryaml -rjson -e '
+  if command -v python3 >/dev/null 2>&1 \
+    && python3 -c 'import yaml' >/dev/null 2>&1; then
+    json=$(python3 -c '
+import json
+import sys
+import yaml
+
+with open(sys.argv[1], encoding="utf-8") as workflow:
+    doc = yaml.safe_load(workflow)
+job = doc["jobs"]["tests-herdr"]
+step = next(
+    candidate for candidate in job["steps"]
+    if isinstance(candidate, dict)
+    and candidate.get("name") == "Run real-Herdr family (serial, required)"
+)
+if "timeout-minutes" not in step:
+    raise KeyError("family-run step has no timeout-minutes")
+print(json.dumps({
+    "job_timeout": job["timeout-minutes"],
+    "step_timeout": step["timeout-minutes"],
+}))
+' "$ROOT/.github/workflows/ci.yml") \
+      || fail "could not parse tests-herdr timeouts from ci.yml"
+  elif command -v ruby >/dev/null 2>&1; then
+    json=$(ruby -ryaml -rjson -e '
 doc = YAML.load_file(ARGV[0])
 job = doc.fetch("jobs").fetch("tests-herdr")
-step = job.fetch("steps").find { |s|
-  s.is_a?(Hash) && s["name"] == "Run real-Herdr family (serial, required)"
+step = job.fetch("steps").find { |candidate|
+  candidate.is_a?(Hash) && candidate["name"] == "Run real-Herdr family (serial, required)"
 }
 raise "missing family-run step" if step.nil?
 raise "family-run step has no timeout-minutes" unless step.key?("timeout-minutes")
@@ -676,7 +698,10 @@ puts JSON.generate(
   "step_timeout" => step.fetch("timeout-minutes")
 )
 ' "$ROOT/.github/workflows/ci.yml") \
-    || fail "could not parse tests-herdr timeouts from ci.yml"
+      || fail "could not parse tests-herdr timeouts from ci.yml"
+  else
+    fail "python3 with PyYAML or ruby is required to parse .github/workflows/ci.yml as YAML"
+  fi
   job_timeout=$(python3 -c 'import json,sys; print(json.load(sys.stdin)["job_timeout"])' <<<"$json") \
     || fail "could not read job timeout from parsed workflow"
   step_timeout=$(python3 -c 'import json,sys; print(json.load(sys.stdin)["step_timeout"])' <<<"$json") \

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -118,6 +118,7 @@ init_changed_fixture_repo() {
   : >"$repo/tests/fm-backend-herdr-eventwait.test.py"
   : >"$repo/bin/fm-supervisor-target-lib.sh"
   : >"$repo/bin/fm-secondmate-registry-lib.sh"
+  : >"$repo/bin/fm-brief.sh"
   : >"$repo/bin/unmapped-source.sh"
   printf '# .claude/settings.json\n# .pi/extensions/fm-primary-turnend-guard.ts\n' \
     >>"$repo/tests/fm-cd-pretool-check.test.sh"
@@ -168,6 +169,14 @@ test_changed_dependency_selection_and_unmapped_failure() {
     "registry parser selects the ownership-guard coverage that consumes it"
   git -C "$repo" add bin/fm-secondmate-registry-lib.sh
   git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm registry-lib-change
+
+  printf '\n' >>"$repo/bin/fm-brief.sh"
+  listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)
+  assert_contains "$listed" "tests/fm-brief.test.sh" "brief scaffolder selects its own contract coverage"
+  assert_contains "$listed" "tests/fm-secondmate-safety.test.sh" \
+    "brief scaffolder selects the secondmate coverage that pins its generated charter note"
+  git -C "$repo" add bin/fm-brief.sh
+  git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm brief-change
 
   printf '\n' >>"$repo/.agents/skills/example/SKILL.md"
   printf '\n' >>"$repo/.claude/settings.json"


### PR DESCRIPTION
## Intent

Make bin/fm-spawn.sh refuse to create an ordinary crewmate or scout when a registered secondmate already owns that work. Derive ownership from data/secondmates.md using bin/fm-secondmate-registry-lib.sh; hard-refuse when the spawn project basename matches a secondmate projects: list (including projects/<name> and absolute-path forms), naming every owner when multiple match. Refusal must be actionable (name the secondmate to route to). Provide deliberate override via explicit spawn flag --allow-primary-spawn (never default), record it on task metadata plus loud stderr notice, document flag in fm-spawn.sh header. Malformed registry entries fail closed on any bad line; override does not bypass parse failure. Do not hard-refuse on scope text; for unowned projects with a non-empty registry emit loud stderr warning naming candidate owners and continue. Do not break --secondmate or --relaunch. Update AGENTS.md, secondmate-provisioning skill, fm-brief.sh, and docs/configuration.md to point at fm-spawn.sh instead of false ownership prose. Add portable tests in tests/fm-spawn-secondmate-ownership.test.sh registered in fm-test-run.sh. Delivery: push and open PR on bingb0t5/firstmate fork via fm/spawn-own-g7-fork branch (not upstream kunchenguid). Do not merge.

## What Changed

- Enforce registered secondmate project ownership for fresh primary-home crewmate and scout spawns, including fail-closed registry parsing and multi-owner reporting.
- Add `--allow-primary-spawn` as an explicit override with loud notices and task metadata, while leaving secondmate spawns and relaunches unaffected.
- Add portable ownership coverage, test-shard registration, and updated secondmate routing documentation.

## Risk Assessment

✅ Low: The ownership guard is well-bounded, preserves whitespace in comma-delimited project names, fails closed on unusable registry entries, exempts relaunch and secondmate paths, and records deliberate overrides as required.

## Testing

The focused ownership suite passed directly and through the registered test runner, covering ordinary and scout refusal, path forms, whitespace, multiple owners, malformed-registry fail-closed behavior, unowned warnings, override persistence, batch dispatch, relaunch, and secondmate exemptions. A CLI transcript demonstrates actionable refusal with no metadata and a successful explicit override with persisted owner metadata.

<details>
<summary>Evidence: CLI refusal and deliberate override transcript</summary>

Source: [CLI refusal and deliberate override transcript](https://github.com/bingb0t5/firstmate/blob/4864059c18af30c68fe1ac7e4e9c0032d994fb2a/.no-mistakes/evidence/fm/spawn-own-g7-fork/fm-spawn-secondmate-ownership-cli.txt)

```text
ok - fm-spawn: a fresh crewmate spawn into a secondmate-owned project refuses before metadata exists
COMMAND: fm-spawn.sh evidence-refusal /tmp/fm-spawn-secondmate-ownership.u9eGt3/evidence/projects/ownedproj claude --mode no-mistakes --yolo off
error: project ownedproj is registered to secondmate(s) design; spawn the worker in a registered secondmate home or pass --allow-primary-spawn for a deliberate primary-home exception
EXIT: 1
METADATA_CREATED: no

COMMAND: fm-spawn.sh evidence-override /tmp/fm-spawn-secondmate-ownership.u9eGt3/evidence-override/ownedproj claude --mode no-mistakes --yolo off --allow-primary-spawn
notice: --allow-primary-spawn bypasses secondmate ownership for ownedproj (registered owner(s): design); route future work to that secondmate unless this exception remains deliberate
spawned evidence-override harness=claude kind=ship mode=no-mistakes yolo=off window=firstmate:fm-evidence-override worktree=/tmp/fm-spawn-secondmate-ownership.u9eGt3/evidence-override/wt
EXIT: 0
PERSISTED OVERRIDE METADATA:
primary_spawn_override=1
primary_spawn_override_owners=design
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"2040744188b579d22169659c1006b9f0c3369c38","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `bin/fm-secondmate-registry-lib.sh:328` - The projects field is comma-delimited, but this splits on spaces and tabs too. A valid project basename containing whitespace, such as `My Project`, becomes separate entries (`My`, `Project`), so spawning into `/repos/My Project` finds no owner and continues with only the unowned-project warning. Split on commas and trim each complete entry before taking its basename, preserving whitespace within project paths.

🔧 Fix: Preserve whitespace in registered project names
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-spawn-secondmate-ownership.test.sh`
- `bin/fm-test-run.sh tests/fm-spawn-secondmate-ownership.test.sh`
- <code>Manual end-to-end `fm-spawn.sh` refusal and `--allow-primary-spawn` checks using registered ownership, including exit status, absent refusal metadata, successful spawn notice, and persisted override-owner metadata</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
