### PR TITLE
feat: gate ship brief Sol exemptions on auditable evidence

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -58,6 +58,10 @@
 #   already filled and to run the exemption gate. FM_TASK is refused on --scout and
 #   --secondmate scaffolds: they are outside the Sol exemption contract, and a
 #   silently dropped task body would be believed recorded.
+#   A filled task body is also refused when it forges a scaffold-owned
+#   machine-readable line ("Delivery contract:" or "Sol exemption:"): those lines
+#   are read back by bin/fm-spawn.sh, and a forged one above the generated line
+#   would win.
 # Ship briefs begin with a worktree-isolation assertion before the branch step.
 # --mode is refused on scout and secondmate scaffolds: a scout's deliverable is a
 # report rather than a merge, and a charter is not a delivery contract.
@@ -208,33 +212,48 @@ fm_brief_wait_is_bounded() {
 }
 
 # One acceptance-command line, and every wait mention bounded with an escape.
-# Prints each missing requirement on stdout; returns 0 only when the text qualifies.
-fm_brief_sol_exemption_errors() {
+# One walk classifies every line, so the validator and the auditable evidence block
+# can never disagree about what counts as evidence. Fills FM_BRIEF_SOL_ERRORS and
+# FM_BRIEF_SOL_EVIDENCE; returns 0 only when the text qualifies.
+fm_brief_sol_line_kind() {
+  FM_BRIEF_SOL_KIND=
+  case "$1" in
+    'Acceptance command: '*) FM_BRIEF_SOL_KIND=acceptance ;;
+    Wait:*) FM_BRIEF_SOL_KIND='wait' ;;
+  esac
+}
+
+# Scaffold-owned machine-readable lines. A filled task body that forges one would
+# be read back by bin/fm-spawn.sh ahead of the line this scaffold actually wrote.
+FM_BRIEF_RESERVED_PREFIXES=('Delivery contract:' 'Sol exemption:')
+
+fm_brief_sol_scan() {
   local text=$1
-  local errors=() acc_lines acc_count line prose saw_unbounded=0
-  # shellcheck disable=SC2016 # Backticks in the grep pattern are literal evidence syntax.
-  acc_lines=$(printf '%s\n' "$text" | grep -E '^Acceptance command: `[^`]+`' || true)
-  acc_count=0
-  if [ -n "$acc_lines" ]; then
-    acc_count=$(printf '%s\n' "$acc_lines" | grep -c . || true)
-  fi
-  if [ "$acc_count" -ne 1 ]; then
-    # shellcheck disable=SC2016 # Backticks in the message document the required syntax.
-    errors+=('missing exactly one Acceptance command: `...` line')
-  fi
+  local line prose prefix acc_count=0 saw_unbounded=0
+  FM_BRIEF_SOL_ERRORS=()
+  FM_BRIEF_SOL_EVIDENCE=()
   while IFS= read -r line || [ -n "$line" ]; do
     [ -z "$line" ] && continue
-    case "$line" in
-      'Acceptance command: '*)
+    for prefix in "${FM_BRIEF_RESERVED_PREFIXES[@]}"; do
+      case "$line" in
+        "$prefix"*)
+          FM_BRIEF_SOL_ERRORS+=("task body must not contain a scaffold-owned '$prefix' line")
+          ;;
+      esac
+    done
+    fm_brief_sol_line_kind "$line"
+    case "$FM_BRIEF_SOL_KIND" in
+      acceptance)
         case "$line" in
-          Acceptance\ command:\ \`*) ;;
-          *) errors+=('Acceptance command must use backticks around the command') ;;
+          Acceptance\ command:\ \`?*\`*) acc_count=$((acc_count + 1)) ;;
+          *) FM_BRIEF_SOL_ERRORS+=('Acceptance command must use backticks around the command') ;;
         esac
+        FM_BRIEF_SOL_EVIDENCE+=("$line")
         ;;
-      Wait:*)
-        if ! fm_brief_wait_is_bounded "$line"; then
-          errors+=('Wait: lines must include non-empty bound=... and escape=... values')
-        fi
+      wait)
+        fm_brief_wait_is_bounded "$line" \
+          || FM_BRIEF_SOL_ERRORS+=('Wait: lines must include non-empty bound=... and escape=... values')
+        FM_BRIEF_SOL_EVIDENCE+=("$line")
         ;;
       *)
         # Backticked spans are literal code, not prose: `wait-for-ci.sh` names a
@@ -243,7 +262,7 @@ fm_brief_sol_exemption_errors() {
         prose=$(printf '%s' "$line" | sed 's/`[^`]*`//g')
         if [ "$saw_unbounded" -eq 0 ] \
            && printf '%s\n' "$prose" | grep -qiE '(^|[^a-z])a?wait(s|ed|ing)?([^a-z]|$)'; then
-          errors+=('unbounded wait mention requires a Wait: line with bound= and escape=')
+          FM_BRIEF_SOL_ERRORS+=('unbounded wait mention requires a Wait: line with bound= and escape=')
           saw_unbounded=1
         fi
         ;;
@@ -251,20 +270,11 @@ fm_brief_sol_exemption_errors() {
   done <<EOF
 $text
 EOF
-  if [ "${#errors[@]}" -gt 0 ]; then
-    printf '%s\n' "${errors[@]}" | sort -u
-    return 1
+  if [ "$acc_count" -ne 1 ]; then
+    # shellcheck disable=SC2016 # Backticks in the message document the required syntax.
+    FM_BRIEF_SOL_ERRORS+=('missing exactly one Acceptance command: `...` line')
   fi
-  return 0
-}
-
-fm_brief_sol_evidence_block() {
-  local text=$1
-  local block
-  # shellcheck disable=SC2016 # Backticks in the grep pattern are literal evidence syntax.
-  block=$(printf '%s\n' "$text" | grep -E '^(Acceptance command: `[^`]+`|Wait: .+)$' || true)
-  [ -n "$block" ] || return 1
-  printf '%s\n' '# Sol exemption evidence' "$block"
+  [ "${#FM_BRIEF_SOL_ERRORS[@]}" -eq 0 ]
 }
 
 # The exemption gate runs before anything is written, so a refused scaffold leaves
@@ -280,15 +290,13 @@ if [ -n "${FM_TASK:-}" ]; then
     exit 1
   }
   SHIP_TASK_BODY=$FM_TASK
-  missing=$(fm_brief_sol_exemption_errors "$SHIP_TASK_BODY" || true)
-  if [ -n "$missing" ]; then
+  if ! fm_brief_sol_scan "$SHIP_TASK_BODY"; then
     echo "error: ship brief cannot earn Sol exemption without auditable evidence:" >&2
-    printf '%s\n' "$missing" | sed 's/^/  - /' >&2
+    printf '%s\n' "${FM_BRIEF_SOL_ERRORS[@]}" | sort -u | sed 's/^/  - /' >&2
     exit 1
   fi
   SOL_EXEMPTION_LINE='Sol exemption: earned'
-  SOL_EXEMPTION_BLOCK=$(fm_brief_sol_evidence_block "$SHIP_TASK_BODY")
-  [ -z "$SOL_EXEMPTION_BLOCK" ] || SOL_EXEMPTION_BLOCK="$SOL_EXEMPTION_BLOCK"$'\n\n'
+  SOL_EXEMPTION_BLOCK=$(printf '%s\n' '# Sol exemption evidence' "${FM_BRIEF_SOL_EVIDENCE[@]}")$'\n\n'
 fi
 
 BRIEF="$DATA/$ID/brief.md"

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -40,6 +40,18 @@
 # "Delivery contract: mode=<mode>" line. bin/fm-spawn.sh reads that line and refuses
 # to launch a ship task whose explicit --mode disagrees, so an adjusted brief and the
 # recorded task metadata cannot drift apart.
+# Ship briefs may earn exemption from the later Sol spec stage only when the filled
+# task text (FM_TASK at scaffold time) carries auditable evidence: exactly one
+#   Acceptance command: `...`
+# line naming a concrete executable command, and every wait mention is expressed as a
+#   Wait: ... bound=... escape=...
+# line. Without both, a filled ship task refuses to scaffold. An unfilled {TASK}
+# placeholder skips this gate and emits no exemption line. When evidence passes,
+# the brief records a fixed machine-readable "Sol exemption: earned" line (read by
+# later spawn/Sol stages) and a scaffold-owned "# Sol exemption evidence" block
+# echoing the acceptance command and any bounded Wait: lines.
+#   Set FM_TASK='<filled task>' to scaffold a ship brief with its task section
+#   already filled and to run the exemption gate.
 # Ship briefs begin with a worktree-isolation assertion before the branch step.
 # --mode is refused on scout and secondmate scaffolds: a scout's deliverable is a
 # report rather than a merge, and a charter is not a delivery contract.
@@ -177,6 +189,67 @@ shell_quote() {
   printf "'"
   printf '%s' "$1" | sed "s/'/'\\\\''/g"
   printf "'"
+}
+
+# Ship Sol-exemption evidence is mechanical: one acceptance-command line and every
+# wait mention bounded with an escape. Prints each missing requirement on stdout;
+# returns 0 only when the text qualifies.
+fm_brief_sol_exemption_errors() {
+  local text=$1
+  local errors=() acc_lines acc_count line saw_unbounded=0
+  # shellcheck disable=SC2016 # Backticks in the grep pattern are literal evidence syntax.
+  acc_lines=$(printf '%s\n' "$text" | grep -E '^Acceptance command: `[^`]+`' || true)
+  acc_count=0
+  if [ -n "$acc_lines" ]; then
+    acc_count=$(printf '%s\n' "$acc_lines" | grep -c . || true)
+  fi
+  if [ "$acc_count" -ne 1 ]; then
+    # shellcheck disable=SC2016 # Backticks in the message document the required syntax.
+    errors+=('missing exactly one Acceptance command: `...` line')
+  fi
+  while IFS= read -r line || [ -n "$line" ]; do
+    [ -z "$line" ] && continue
+    case "$line" in
+      'Acceptance command: '*)
+        case "$line" in
+          Acceptance\ command:\ \`*) ;;
+          *) errors+=('Acceptance command must use backticks around the command') ;;
+        esac
+        ;;
+      Wait:*)
+        case "$line" in
+          Wait:\ *bound=*escape=*|Wait:\ *escape=*bound=*)
+            ;;
+          *)
+            errors+=('Wait: lines must include both bound=... and escape=...')
+            ;;
+        esac
+        ;;
+      *)
+        if [ "$saw_unbounded" -eq 0 ] \
+           && printf '%s\n' "$line" | grep -qiE '(^|[^a-z])wait([^a-z]|$)'; then
+          errors+=('unbounded wait mention requires a Wait: line with bound= and escape=')
+          saw_unbounded=1
+        fi
+        ;;
+    esac
+  done <<EOF
+$text
+EOF
+  if [ "${#errors[@]}" -gt 0 ]; then
+    printf '%s\n' "${errors[@]}" | sort -u
+    return 1
+  fi
+  return 0
+}
+
+fm_brief_sol_evidence_block() {
+  local text=$1
+  local block
+  # shellcheck disable=SC2016 # Backticks in the grep pattern are literal evidence syntax.
+  block=$(printf '%s\n' "$text" | grep -E '^(Acceptance command: `[^`]+`|Wait: .+)$' || true)
+  [ -n "$block" ] || return 1
+  printf '%s\n' '# Sol exemption evidence' "$block"
 }
 
 STATUS_FILE=$(shell_quote "$STATE/$ID.status")
@@ -374,6 +447,20 @@ fi
 # delivery mode, validated above. The generated DOD opens with the fixed
 # "Delivery contract: mode=<mode>" line that bin/fm-spawn.sh checks against its own
 # explicit --mode before launching.
+SHIP_TASK_BODY='{TASK}'
+SOL_EXEMPTION_BLOCK=
+SOL_EXEMPTION_LINE=
+if [ -n "${FM_TASK:-}" ]; then
+  SHIP_TASK_BODY=$FM_TASK
+  missing=$(fm_brief_sol_exemption_errors "$SHIP_TASK_BODY" || true)
+  if [ -n "$missing" ]; then
+    echo "error: ship brief cannot earn Sol exemption without auditable evidence:" >&2
+    printf '%s\n' "$missing" | sed 's/^/  - /' >&2
+    exit 1
+  fi
+  SOL_EXEMPTION_LINE='Sol exemption: earned'
+  SOL_EXEMPTION_BLOCK=$(fm_brief_sol_evidence_block "$SHIP_TASK_BODY")
+fi
 case "$MODE" in
   direct-PR)
     SETUP2=""
@@ -431,13 +518,20 @@ esac
 # $(...) command substitution used to strip. Drop that one newline so generated
 # briefs stay byte-identical to the historical Bash 5 output.
 DOD=${DOD%$'\n'}
+if [ -n "$SOL_EXEMPTION_LINE" ]; then
+  DOD=$(printf '%s\n' "$DOD" | awk '
+    /^Delivery contract: mode=/ { print; print "Sol exemption: earned"; next }
+    { print }
+  ')
+fi
 
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
 
 # Task
-{TASK}
+$SHIP_TASK_BODY
 
+$SOL_EXEMPTION_BLOCK
 $HERDR_SECTION
 
 # Setup
@@ -486,4 +580,8 @@ Keep it proportionate: skip \`AGENTS.md\` edits for trivial tasks that produced 
 
 $DOD
 EOF
-echo "scaffolded: $BRIEF (ship, mode=$MODE; replace {TASK})"
+if [ -n "${FM_TASK:-}" ]; then
+  echo "scaffolded: $BRIEF (ship, mode=$MODE; Sol exemption earned)"
+else
+  echo "scaffolded: $BRIEF (ship, mode=$MODE; replace {TASK})"
+fi

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -49,13 +49,13 @@
 #   Wait: ... bound=... escape=...
 # line whose bound= and escape= both carry a non-empty value. The wait scan covers
 # the whole wait word family (wait/waits/waited/waiting/await/awaits/awaiting) and
-# ignores backticked spans, so `wait-for-ci.sh` reads as a command name rather than
-# as an unbounded wait. Without both kinds of evidence, a filled ship task refuses
-# to scaffold and writes nothing. An unfilled {TASK} placeholder skips this gate and
-# emits no exemption line. When evidence passes, the brief records a fixed
-# machine-readable "Sol exemption: earned" line (read by later spawn/Sol stages) and
-# a scaffold-owned "# Sol exemption evidence" block echoing the acceptance command
-# and any bounded Wait: lines.
+# ignores whitespace-free backticked command or token names, so `wait-for-ci.sh`
+# does not read as an unbounded wait while backticked prose still does. Without both
+# kinds of evidence, a filled ship task refuses to scaffold and writes nothing. An
+# unfilled {TASK} placeholder skips this gate and emits no exemption line. When
+# evidence passes, the brief records a fixed machine-readable "Sol exemption: earned"
+# line for later stage consumption and a scaffold-owned "# Sol exemption evidence"
+# block echoing the acceptance command and any bounded Wait: lines.
 #   Set FM_TASK='<filled task>' to scaffold a ship brief with its task section
 #   already filled and to run the exemption gate. FM_TASK is refused on --scout and
 #   --secondmate scaffolds: they are outside the Sol exemption contract, and a

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -214,17 +214,23 @@ fm_brief_wait_is_bounded() {
 }
 
 fm_brief_acceptance_is_executable() {
-  local line=$1 command
+  local line=$1 command first
   case "$line" in
     Acceptance\ command:\ \`?*\`*) ;;
     *) return 1 ;;
   esac
   command=${line#Acceptance command: \`}
   command=${command%%\`*}
+  command=${command#"${command%%[![:space:]]*}"}
   case "$command" in
-    *[[:alnum:]_]*) return 0 ;;
-    *) return 1 ;;
+    ''|\#*) return 1 ;;
   esac
+  first=${command%%[[:space:]]*}
+  case "$first" in
+    ''|*=*|*[![:alnum:]_./-]*) return 1 ;;
+  esac
+  bash -n -c "$command" >/dev/null 2>&1 || return 1
+  return 0
 }
 
 # Scaffold-owned machine-readable lines. A filled task body that forges one would

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -24,9 +24,11 @@
 #   Set FM_SECONDMATE_SCOPE='<scope>' to write a routing scope distinct from the charter text.
 #   --herdr-lab is mandatory when the task will issue Herdr lifecycle commands.
 #   It adds the hard isolation contract backed by bin/fm-herdr-lab.sh.
-#   The flag must be explicit because {TASK} is filled after scaffolding and the
-#   caller-supplied repo string cannot reliably identify this repo. Briefs made
-#   without it carry a loud declaration so an omitted contract cannot be silent.
+#   The flag must be explicit because no scaffold path ever inspects the task text
+#   for Herdr lifecycle intent - the FM_TASK scan below reads acceptance and wait
+#   evidence only - and the caller-supplied repo string cannot reliably identify
+#   this repo. Briefs made without it carry a loud declaration so an omitted
+#   contract cannot be silent.
 # For ship tasks, --mode is REQUIRED and shapes the definition of done. Firstmate
 # resolves it per task at intake (AGENTS.md section 7); data/projects.md holds the
 # captain's standing posture as context, and this script never reads it:
@@ -211,22 +213,14 @@ fm_brief_wait_is_bounded() {
   return 0
 }
 
-# One acceptance-command line, and every wait mention bounded with an escape.
-# One walk classifies every line, so the validator and the auditable evidence block
-# can never disagree about what counts as evidence. Fills FM_BRIEF_SOL_ERRORS and
-# FM_BRIEF_SOL_EVIDENCE; returns 0 only when the text qualifies.
-fm_brief_sol_line_kind() {
-  FM_BRIEF_SOL_KIND=
-  case "$1" in
-    'Acceptance command: '*) FM_BRIEF_SOL_KIND=acceptance ;;
-    Wait:*) FM_BRIEF_SOL_KIND='wait' ;;
-  esac
-}
-
 # Scaffold-owned machine-readable lines. A filled task body that forges one would
 # be read back by bin/fm-spawn.sh ahead of the line this scaffold actually wrote.
 FM_BRIEF_RESERVED_PREFIXES=('Delivery contract:' 'Sol exemption:')
 
+# One acceptance-command line, and every wait mention bounded with an escape.
+# One walk classifies every line, so the validator and the auditable evidence block
+# can never disagree about what counts as evidence. Fills FM_BRIEF_SOL_ERRORS and
+# FM_BRIEF_SOL_EVIDENCE; returns 0 only when the text qualifies.
 fm_brief_sol_scan() {
   local text=$1
   local line prose prefix acc_count=0 saw_unbounded=0
@@ -241,25 +235,25 @@ fm_brief_sol_scan() {
           ;;
       esac
     done
-    fm_brief_sol_line_kind "$line"
-    case "$FM_BRIEF_SOL_KIND" in
-      acceptance)
+    case "$line" in
+      'Acceptance command: '*)
         case "$line" in
           Acceptance\ command:\ \`?*\`*) acc_count=$((acc_count + 1)) ;;
           *) FM_BRIEF_SOL_ERRORS+=('Acceptance command must use backticks around the command') ;;
         esac
         FM_BRIEF_SOL_EVIDENCE+=("$line")
         ;;
-      wait)
+      Wait:*)
         fm_brief_wait_is_bounded "$line" \
           || FM_BRIEF_SOL_ERRORS+=('Wait: lines must include non-empty bound=... and escape=... values')
         FM_BRIEF_SOL_EVIDENCE+=("$line")
         ;;
       *)
-        # Backticked spans are literal code, not prose: `wait-for-ci.sh` names a
-        # command, so scanning them would refuse legitimate ship tasks.
+        # A whitespace-free backticked span is a command or token name, not prose:
+        # `wait-for-ci.sh` must not read as a wait. A span containing whitespace is
+        # prose and stays in the scan, so `wait for review` cannot hide there.
         # shellcheck disable=SC2016 # Backticks in the sed script are literal evidence syntax.
-        prose=$(printf '%s' "$line" | sed 's/`[^`]*`//g')
+        prose=$(printf '%s' "$line" | sed 's/`[^`[:space:]]*`//g')
         if [ "$saw_unbounded" -eq 0 ] \
            && printf '%s\n' "$prose" | grep -qiE '(^|[^a-z])a?wait(s|ed|ing)?([^a-z]|$)'; then
           FM_BRIEF_SOL_ERRORS+=('unbounded wait mention requires a Wait: line with bound= and escape=')
@@ -270,9 +264,11 @@ fm_brief_sol_scan() {
   done <<EOF
 $text
 EOF
-  if [ "$acc_count" -ne 1 ]; then
+  if [ "$acc_count" -eq 0 ]; then
     # shellcheck disable=SC2016 # Backticks in the message document the required syntax.
     FM_BRIEF_SOL_ERRORS+=('missing exactly one Acceptance command: `...` line')
+  elif [ "$acc_count" -gt 1 ]; then
+    FM_BRIEF_SOL_ERRORS+=("found $acc_count Acceptance command lines; keep exactly one")
   fi
   [ "${#FM_BRIEF_SOL_ERRORS[@]}" -eq 0 ]
 }
@@ -439,13 +435,17 @@ HERDR_SECTION=$(printf '%s\n' \
 'Never bypass the helper, even for a read-only lifecycle probe or cleanup after failure.' \
 'The captain fleet uses the running `default` session.')
 else
-IFS= read -r -d '' HERDR_SECTION <<'EOF' || true
-# Herdr lifecycle declaration - NOT ENABLED
-**HARD SAFETY GATE:** this scaffold cannot inspect the task text filled in above.
-If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
-Do not add Herdr lifecycle commands to this unguarded brief by hand.
-EOF
-HERDR_SECTION=${HERDR_SECTION%$'\n'}
+if [ -n "${FM_TASK:-}" ]; then
+  HERDR_GATE_LINE='**HARD SAFETY GATE:** this scaffold never inspects the task text above for Herdr lifecycle intent.'
+else
+  HERDR_GATE_LINE='**HARD SAFETY GATE:** this scaffold cannot inspect the task text filled in above.'
+fi
+# shellcheck disable=SC2016  # single quotes are deliberate: the backtick-wrapped `--herdr-lab` is literal brief text that must reach the reading agent verbatim.
+HERDR_SECTION=$(printf '%s\n' \
+'# Herdr lifecycle declaration - NOT ENABLED' \
+"$HERDR_GATE_LINE" \
+'If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.' \
+'Do not add Herdr lifecycle commands to this unguarded brief by hand.')
 fi
 
 if [ "$KIND" = scout ]; then
@@ -562,8 +562,8 @@ esac
 # briefs stay byte-identical to the historical Bash 5 output.
 DOD=${DOD%$'\n'}
 if [ -n "$SOL_EXEMPTION_LINE" ]; then
-  DOD=$(printf '%s\n' "$DOD" | awk '
-    /^Delivery contract: mode=/ { print; print "Sol exemption: earned"; next }
+  DOD=$(printf '%s\n' "$DOD" | awk -v exemption="$SOL_EXEMPTION_LINE" '
+    /^Delivery contract: mode=/ { print; print exemption; next }
     { print }
   ')
 fi

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -255,6 +255,7 @@ fm_brief_sol_scan() {
           ;;
       esac
     done
+    prose=$line
     case "$line" in
       'Acceptance command: '*)
         if fm_brief_acceptance_is_executable "$line"; then
@@ -263,11 +264,18 @@ fm_brief_sol_scan() {
           FM_BRIEF_SOL_ERRORS+=('Acceptance command must use backticks around a concrete executable command')
         fi
         FM_BRIEF_SOL_EVIDENCE+=("$line")
+        case "$line" in
+          Acceptance\ command:\ \`*\`*)
+            prose=${line#Acceptance command: \`}
+            prose=${prose#*\`}
+            ;;
+        esac
         ;;
       Wait:*)
         fm_brief_wait_is_bounded "$line" \
           || FM_BRIEF_SOL_ERRORS+=('Wait: lines must include non-empty bound=... and escape=... values')
         FM_BRIEF_SOL_EVIDENCE+=("$line")
+        prose=
         ;;
       *)
         # A whitespace-free backticked span is a command or token name, not prose:
@@ -275,13 +283,13 @@ fm_brief_sol_scan() {
         # prose and stays in the scan, so `wait for review` cannot hide there.
         # shellcheck disable=SC2016 # Backticks in the sed script are literal evidence syntax.
         prose=$(printf '%s' "$line" | sed 's/`[^`[:space:]]*`//g')
-        if [ "$saw_unbounded" -eq 0 ] \
-           && printf '%s\n' "$prose" | grep -qiE '(^|[^a-z])a?wait(s|ed|ing)?([^a-z]|$)'; then
-          FM_BRIEF_SOL_ERRORS+=('unbounded wait mention requires a Wait: line with bound= and escape=')
-          saw_unbounded=1
-        fi
         ;;
     esac
+    if [ "$saw_unbounded" -eq 0 ] \
+       && printf '%s\n' "$prose" | grep -qiE '(^|[^a-z])a?wait(s|ed|ing)?([^a-z]|$)'; then
+      FM_BRIEF_SOL_ERRORS+=('unbounded wait mention requires a Wait: line with bound= and escape=')
+      saw_unbounded=1
+    fi
   done <<EOF
 $text
 EOF

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -213,6 +213,20 @@ fm_brief_wait_is_bounded() {
   return 0
 }
 
+fm_brief_acceptance_is_executable() {
+  local line=$1 command
+  case "$line" in
+    Acceptance\ command:\ \`?*\`*) ;;
+    *) return 1 ;;
+  esac
+  command=${line#Acceptance command: \`}
+  command=${command%%\`*}
+  case "$command" in
+    *[[:alnum:]_]*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 # Scaffold-owned machine-readable lines. A filled task body that forges one would
 # be read back by bin/fm-spawn.sh ahead of the line this scaffold actually wrote.
 FM_BRIEF_RESERVED_PREFIXES=('Delivery contract:' 'Sol exemption:')
@@ -237,10 +251,11 @@ fm_brief_sol_scan() {
     done
     case "$line" in
       'Acceptance command: '*)
-        case "$line" in
-          Acceptance\ command:\ \`?*\`*) acc_count=$((acc_count + 1)) ;;
-          *) FM_BRIEF_SOL_ERRORS+=('Acceptance command must use backticks around the command') ;;
-        esac
+        if fm_brief_acceptance_is_executable "$line"; then
+          acc_count=$((acc_count + 1))
+        else
+          FM_BRIEF_SOL_ERRORS+=('Acceptance command must use backticks around a concrete executable command')
+        fi
         FM_BRIEF_SOL_EVIDENCE+=("$line")
         ;;
       Wait:*)

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -45,13 +45,19 @@
 #   Acceptance command: `...`
 # line naming a concrete executable command, and every wait mention is expressed as a
 #   Wait: ... bound=... escape=...
-# line. Without both, a filled ship task refuses to scaffold. An unfilled {TASK}
-# placeholder skips this gate and emits no exemption line. When evidence passes,
-# the brief records a fixed machine-readable "Sol exemption: earned" line (read by
-# later spawn/Sol stages) and a scaffold-owned "# Sol exemption evidence" block
-# echoing the acceptance command and any bounded Wait: lines.
+# line whose bound= and escape= both carry a non-empty value. The wait scan covers
+# the whole wait word family (wait/waits/waited/waiting/await/awaits/awaiting) and
+# ignores backticked spans, so `wait-for-ci.sh` reads as a command name rather than
+# as an unbounded wait. Without both kinds of evidence, a filled ship task refuses
+# to scaffold and writes nothing. An unfilled {TASK} placeholder skips this gate and
+# emits no exemption line. When evidence passes, the brief records a fixed
+# machine-readable "Sol exemption: earned" line (read by later spawn/Sol stages) and
+# a scaffold-owned "# Sol exemption evidence" block echoing the acceptance command
+# and any bounded Wait: lines.
 #   Set FM_TASK='<filled task>' to scaffold a ship brief with its task section
-#   already filled and to run the exemption gate.
+#   already filled and to run the exemption gate. FM_TASK is refused on --scout and
+#   --secondmate scaffolds: they are outside the Sol exemption contract, and a
+#   silently dropped task body would be believed recorded.
 # Ship briefs begin with a worktree-isolation assertion before the branch step.
 # --mode is refused on scout and secondmate scaffolds: a scout's deliverable is a
 # report rather than a merge, and a charter is not a delivery contract.
@@ -181,22 +187,31 @@ if [ "$NO_PROJECTS" -eq 1 ] && [ "$KIND" != secondmate ]; then
   exit 1
 fi
 
-BRIEF="$DATA/$ID/brief.md"
-[ -e "$BRIEF" ] && { echo "error: $BRIEF already exists" >&2; exit 1; }
-mkdir -p "$DATA/$ID"
-
-shell_quote() {
-  printf "'"
-  printf '%s' "$1" | sed "s/'/'\\\\''/g"
-  printf "'"
+# Ship Sol-exemption evidence is mechanical. A Wait: line is bounded only when it
+# carries non-empty bound= and escape= values; a value that is just the other key
+# (bound=escape=...) is not a bound.
+fm_brief_wait_is_bounded() {
+  local line=$1 field value
+  for field in bound escape; do
+    case "$line" in
+      *[[:space:]]"$field="*) ;;
+      *) return 1 ;;
+    esac
+    value=${line#*[[:space:]]"$field="}
+    value=${value%%[[:space:]]*}
+    [ -n "$value" ] || return 1
+    case "$value" in
+      bound=*|escape=*) return 1 ;;
+    esac
+  done
+  return 0
 }
 
-# Ship Sol-exemption evidence is mechanical: one acceptance-command line and every
-# wait mention bounded with an escape. Prints each missing requirement on stdout;
-# returns 0 only when the text qualifies.
+# One acceptance-command line, and every wait mention bounded with an escape.
+# Prints each missing requirement on stdout; returns 0 only when the text qualifies.
 fm_brief_sol_exemption_errors() {
   local text=$1
-  local errors=() acc_lines acc_count line saw_unbounded=0
+  local errors=() acc_lines acc_count line prose saw_unbounded=0
   # shellcheck disable=SC2016 # Backticks in the grep pattern are literal evidence syntax.
   acc_lines=$(printf '%s\n' "$text" | grep -E '^Acceptance command: `[^`]+`' || true)
   acc_count=0
@@ -217,17 +232,17 @@ fm_brief_sol_exemption_errors() {
         esac
         ;;
       Wait:*)
-        case "$line" in
-          Wait:\ *bound=*escape=*|Wait:\ *escape=*bound=*)
-            ;;
-          *)
-            errors+=('Wait: lines must include both bound=... and escape=...')
-            ;;
-        esac
+        if ! fm_brief_wait_is_bounded "$line"; then
+          errors+=('Wait: lines must include non-empty bound=... and escape=... values')
+        fi
         ;;
       *)
+        # Backticked spans are literal code, not prose: `wait-for-ci.sh` names a
+        # command, so scanning them would refuse legitimate ship tasks.
+        # shellcheck disable=SC2016 # Backticks in the sed script are literal evidence syntax.
+        prose=$(printf '%s' "$line" | sed 's/`[^`]*`//g')
         if [ "$saw_unbounded" -eq 0 ] \
-           && printf '%s\n' "$line" | grep -qiE '(^|[^a-z])wait([^a-z]|$)'; then
+           && printf '%s\n' "$prose" | grep -qiE '(^|[^a-z])a?wait(s|ed|ing)?([^a-z]|$)'; then
           errors+=('unbounded wait mention requires a Wait: line with bound= and escape=')
           saw_unbounded=1
         fi
@@ -250,6 +265,40 @@ fm_brief_sol_evidence_block() {
   block=$(printf '%s\n' "$text" | grep -E '^(Acceptance command: `[^`]+`|Wait: .+)$' || true)
   [ -n "$block" ] || return 1
   printf '%s\n' '# Sol exemption evidence' "$block"
+}
+
+# The exemption gate runs before anything is written, so a refused scaffold leaves
+# the data tree untouched. FM_TASK is a ship-only input: scout reports and
+# secondmate charters are outside the Sol exemption contract, so refuse it there
+# rather than silently dropping a task body the caller believes was recorded.
+SHIP_TASK_BODY='{TASK}'
+SOL_EXEMPTION_BLOCK=
+SOL_EXEMPTION_LINE=
+if [ -n "${FM_TASK:-}" ]; then
+  [ "$KIND" = ship ] || {
+    echo "error: FM_TASK applies only to ship briefs; a scout report and a secondmate charter carry no Sol exemption, so fill their {TASK} section by hand" >&2
+    exit 1
+  }
+  SHIP_TASK_BODY=$FM_TASK
+  missing=$(fm_brief_sol_exemption_errors "$SHIP_TASK_BODY" || true)
+  if [ -n "$missing" ]; then
+    echo "error: ship brief cannot earn Sol exemption without auditable evidence:" >&2
+    printf '%s\n' "$missing" | sed 's/^/  - /' >&2
+    exit 1
+  fi
+  SOL_EXEMPTION_LINE='Sol exemption: earned'
+  SOL_EXEMPTION_BLOCK=$(fm_brief_sol_evidence_block "$SHIP_TASK_BODY")
+  [ -z "$SOL_EXEMPTION_BLOCK" ] || SOL_EXEMPTION_BLOCK="$SOL_EXEMPTION_BLOCK"$'\n\n'
+fi
+
+BRIEF="$DATA/$ID/brief.md"
+[ -e "$BRIEF" ] && { echo "error: $BRIEF already exists" >&2; exit 1; }
+mkdir -p "$DATA/$ID"
+
+shell_quote() {
+  printf "'"
+  printf '%s' "$1" | sed "s/'/'\\\\''/g"
+  printf "'"
 }
 
 STATUS_FILE=$(shell_quote "$STATE/$ID.status")
@@ -447,20 +496,6 @@ fi
 # delivery mode, validated above. The generated DOD opens with the fixed
 # "Delivery contract: mode=<mode>" line that bin/fm-spawn.sh checks against its own
 # explicit --mode before launching.
-SHIP_TASK_BODY='{TASK}'
-SOL_EXEMPTION_BLOCK=
-SOL_EXEMPTION_LINE=
-if [ -n "${FM_TASK:-}" ]; then
-  SHIP_TASK_BODY=$FM_TASK
-  missing=$(fm_brief_sol_exemption_errors "$SHIP_TASK_BODY" || true)
-  if [ -n "$missing" ]; then
-    echo "error: ship brief cannot earn Sol exemption without auditable evidence:" >&2
-    printf '%s\n' "$missing" | sed 's/^/  - /' >&2
-    exit 1
-  fi
-  SOL_EXEMPTION_LINE='Sol exemption: earned'
-  SOL_EXEMPTION_BLOCK=$(fm_brief_sol_evidence_block "$SHIP_TASK_BODY")
-fi
 case "$MODE" in
   direct-PR)
     SETUP2=""
@@ -531,8 +566,7 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 # Task
 $SHIP_TASK_BODY
 
-$SOL_EXEMPTION_BLOCK
-$HERDR_SECTION
+$SOL_EXEMPTION_BLOCK$HERDR_SECTION
 
 # Setup
 You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -726,6 +726,60 @@ test_scout_and_secondmate_load_decision_hold_policy() {
 }
 
 # Scout and secondmate paths still scaffold well-formed briefs.
+test_ship_sol_exemption_refuses_without_evidence() {
+  local home out status
+  home="$TMP_ROOT/sol-refuse-home"
+  mkdir -p "$home/data"
+  out=$(FM_HOME="$home" FM_TASK='Fix the widget and ship it.' \
+    "$ROOT/bin/fm-brief.sh" sol-refuse-1 firstmate --mode no-mistakes 2>&1) || status=$?
+  expect_code 1 "${status:-0}" "filled ship task without exemption evidence must refuse"
+  assert_contains "$out" "Acceptance command" \
+    "refusal must name the missing acceptance command evidence"
+  assert_absent "$home/data/sol-refuse-1/brief.md" \
+    "refused Sol-exemption scaffold must not write a brief"
+  pass "fm-brief.sh: ship scaffold refuses Sol exemption without auditable evidence"
+}
+
+test_ship_sol_exemption_succeeds_with_evidence() {
+  local home brief status task
+  home="$TMP_ROOT/sol-earn-home"
+  mkdir -p "$home/data"
+  # shellcheck disable=SC2016 # Backticks in the task body are literal evidence syntax.
+  task='# Fix widget
+Acceptance command: `bin/fm-lint.sh`
+Wait: CI green bound=30m escape=append blocked: CI timeout'
+  FM_HOME="$home" FM_TASK="$task" \
+    "$ROOT/bin/fm-brief.sh" sol-earn-1 firstmate --mode no-mistakes >/dev/null 2>&1; status=$?
+  expect_code 0 "$status" "filled ship task with exemption evidence must scaffold"
+  brief="$home/data/sol-earn-1/brief.md"
+  assert_present "$brief" "Sol-exempt ship brief was not scaffolded"
+  grep -qx "Sol exemption: earned" "$brief" \
+    || fail "brief missing the machine-readable Sol exemption line"
+  assert_grep "# Sol exemption evidence" "$brief" \
+    "brief missing the scaffold-owned Sol exemption evidence block"
+  assert_grep "Acceptance command: \`bin/fm-lint.sh\`" "$brief" \
+    "brief did not carry the acceptance command in the evidence block"
+  assert_grep "Wait: CI green bound=30m escape=append blocked: CI timeout" "$brief" \
+    "brief did not carry bounded waits in the evidence block"
+  pass "fm-brief.sh: ship scaffold earns Sol exemption with auditable evidence"
+}
+
+test_ship_sol_exemption_refuses_unbounded_wait() {
+  local home out status
+  home="$TMP_ROOT/sol-wait-home"
+  mkdir -p "$home/data"
+  # shellcheck disable=SC2016 # The task body is a literal fixture string.
+  out=$(FM_HOME="$home" FM_TASK='Wait for deploy
+Acceptance command: `make test`' \
+    "$ROOT/bin/fm-brief.sh" sol-wait-1 firstmate --mode direct-PR 2>&1) || status=$?
+  expect_code 1 "${status:-0}" "ship task with unbounded wait must refuse"
+  assert_contains "$out" "unbounded wait" \
+    "refusal must name the unbounded wait"
+  assert_absent "$home/data/sol-wait-1/brief.md" \
+    "refused unbounded-wait scaffold must not write a brief"
+  pass "fm-brief.sh: ship scaffold refuses unbounded waits"
+}
+
 test_scout_and_secondmate_scaffold() {
   local brief
   FM_HOME="$BRIEF_HOME" "$ROOT/bin/fm-brief.sh" brief-scout-q6 alpha --scout >/dev/null 2>&1 \
@@ -767,4 +821,7 @@ test_secondmate_marked_request_reporting_contract
 test_secondmate_directory_paths_are_absolute_and_output_is_stable
 test_pause_verb_override_renders_all_brief_scaffolds
 test_scout_and_secondmate_load_decision_hold_policy
+test_ship_sol_exemption_refuses_without_evidence
+test_ship_sol_exemption_succeeds_with_evidence
+test_ship_sol_exemption_refuses_unbounded_wait
 test_scout_and_secondmate_scaffold

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -958,6 +958,22 @@ Acceptance command: `make test` (from the repo root)'; do
   pass "fm-brief.sh: an acceptance line with trailing text earns exemption and is recorded"
 }
 
+test_ship_sol_exemption_refuses_trailing_acceptance_wait() {
+  local home out status
+  home="$TMP_ROOT/sol-trailing-wait-home"
+  mkdir -p "$home/data"
+  status=0
+  # shellcheck disable=SC2016 # The task body is a literal fixture string.
+  out=$(FM_HOME="$home" FM_TASK='Acceptance command: `make test` then wait forever' \
+    "$ROOT/bin/fm-brief.sh" sol-trailing-wait firstmate --mode no-mistakes 2>&1) || status=$?
+  expect_code 1 "$status" "a trailing unbounded wait on the acceptance line must refuse"
+  assert_contains "$out" "unbounded wait" \
+    "refusal must name the trailing unbounded wait"
+  assert_absent "$home/data/sol-trailing-wait/brief.md" \
+    "refused trailing acceptance-line wait must not write a brief"
+  pass "fm-brief.sh: acceptance-line trailing waits cannot bypass the gate"
+}
+
 # Every refusal must name a cause on stderr; a bare non-zero exit tells the caller
 # nothing about what the scaffold rejected.
 test_ship_sol_exemption_refusals_are_never_silent() {
@@ -1189,6 +1205,7 @@ test_fm_task_refused_on_scout_and_secondmate
 test_refused_scaffold_leaves_no_task_directory
 test_sol_exemption_block_spacing_is_stable
 test_ship_sol_exemption_accepts_trailing_acceptance_text
+test_ship_sol_exemption_refuses_trailing_acceptance_wait
 test_ship_sol_exemption_refusals_are_never_silent
 test_ship_sol_exemption_refuses_non_command_acceptance_payloads
 test_fm_task_cannot_forge_scaffold_owned_contract_lines

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -780,6 +780,148 @@ Acceptance command: `make test`' \
   pass "fm-brief.sh: ship scaffold refuses unbounded waits"
 }
 
+# Regression: the wait scan matched only the bare token `wait`, so an inflected
+# unbounded wait ("keep waiting", "await") earned the exemption anyway.
+test_ship_sol_exemption_refuses_inflected_waits() {
+  local home out status inflection i=0
+  for inflection in 'Keep waiting for CI until it goes green.' \
+                    'Await the deploy indefinitely.' \
+                    'The task awaits review before landing.' \
+                    'We waited for the queue to drain.'; do
+    i=$((i + 1))
+    home="$TMP_ROOT/sol-inflect-home-$i"
+    mkdir -p "$home/data"
+    status=0
+    out=$(FM_HOME="$home" FM_TASK="Ship it.
+Acceptance command: \`make test\`
+$inflection" "$ROOT/bin/fm-brief.sh" "sol-inflect-$i" firstmate --mode no-mistakes 2>&1) || status=$?
+    expect_code 1 "$status" "inflected unbounded wait must refuse: $inflection"
+    assert_contains "$out" "unbounded wait" \
+      "refusal must name the unbounded wait for: $inflection"
+    assert_absent "$home/data/sol-inflect-$i/brief.md" \
+      "refused inflected-wait scaffold must not write a brief"
+  done
+  pass "fm-brief.sh: ship scaffold refuses the whole unbounded wait word family"
+}
+
+# Regression: `bound=escape=` satisfied the old prefix glob, stamping a brief
+# exempt while recording a wait that carries no actual bound.
+test_ship_sol_exemption_refuses_valueless_bound_and_escape() {
+  local home out status wait_line i=0
+  for wait_line in 'Wait: CI bound=escape=' \
+                   'Wait: CI bound= escape=1m' \
+                   'Wait: CI bound=30m escape=' \
+                   'Wait: CI bound=30m'; do
+    i=$((i + 1))
+    home="$TMP_ROOT/sol-bound-home-$i"
+    mkdir -p "$home/data"
+    status=0
+    out=$(FM_HOME="$home" FM_TASK="Acceptance command: \`make test\`
+$wait_line" "$ROOT/bin/fm-brief.sh" "sol-bound-$i" firstmate --mode no-mistakes 2>&1) || status=$?
+    expect_code 1 "$status" "wait without real bound/escape values must refuse: $wait_line"
+    assert_contains "$out" "bound=" "refusal must name the bound/escape requirement"
+    assert_absent "$home/data/sol-bound-$i/brief.md" \
+      "refused valueless-bound scaffold must not write a brief"
+  done
+  pass "fm-brief.sh: ship scaffold refuses Wait: lines with empty bound=/escape= values"
+}
+
+# Regression: any line containing the token `wait` was refused, so a backticked
+# command name such as `wait-for-ci.sh` made a legitimate ship task unscaffoldable.
+test_ship_sol_exemption_ignores_backticked_command_names() {
+  local home brief status
+  home="$TMP_ROOT/sol-backtick-home"
+  mkdir -p "$home/data"
+  status=0
+  # shellcheck disable=SC2016 # The task body is a literal fixture string.
+  FM_HOME="$home" FM_TASK='Acceptance command: `make test`
+Run `wait-for-ci.sh` as part of setup, then land `await-queue.py`.' \
+    "$ROOT/bin/fm-brief.sh" sol-backtick-1 firstmate --mode no-mistakes >/dev/null 2>&1 || status=$?
+  expect_code 0 "$status" "backticked command names containing 'wait' must not refuse"
+  brief="$home/data/sol-backtick-1/brief.md"
+  assert_present "$brief" "backticked-command ship brief was not scaffolded"
+  grep -qx "Sol exemption: earned" "$brief" \
+    || fail "brief missing the machine-readable Sol exemption line"
+  pass "fm-brief.sh: wait scan skips backticked spans"
+}
+
+# FM_TASK is a ship-only input; scout and secondmate must refuse it loudly rather
+# than scaffold a brief whose {TASK} placeholder silently discarded it.
+test_fm_task_refused_on_scout_and_secondmate() {
+  local home out status
+  home="$TMP_ROOT/sol-kind-home"
+  mkdir -p "$home/data"
+  status=0
+  out=$(FM_HOME="$home" FM_TASK='Investigate the flake.' \
+    "$ROOT/bin/fm-brief.sh" sol-kind-scout alpha --scout 2>&1) || status=$?
+  expect_code 1 "$status" "FM_TASK on a scout scaffold must refuse"
+  assert_contains "$out" "FM_TASK applies only to ship briefs" \
+    "scout refusal must name FM_TASK as ship-only"
+  assert_absent "$home/data/sol-kind-scout/brief.md" \
+    "refused scout scaffold must not write a brief"
+
+  status=0
+  out=$(FM_HOME="$home" FM_TASK='Charter the crew.' \
+    "$ROOT/bin/fm-brief.sh" sol-kind-sm alpha --secondmate --no-projects 2>&1) || status=$?
+  expect_code 1 "$status" "FM_TASK on a secondmate scaffold must refuse"
+  assert_contains "$out" "FM_TASK applies only to ship briefs" \
+    "secondmate refusal must name FM_TASK as ship-only"
+  assert_absent "$home/data/sol-kind-sm/brief.md" \
+    "refused secondmate scaffold must not write a brief"
+  pass "fm-brief.sh: FM_TASK is refused on scout and secondmate scaffolds"
+}
+
+# A refused scaffold must leave the data tree exactly as it found it, not an
+# empty data/<id>/ shell from a mkdir that ran before validation.
+test_refused_scaffold_leaves_no_task_directory() {
+  local home status
+  home="$TMP_ROOT/sol-nodir-home"
+  mkdir -p "$home/data"
+  status=0
+  FM_HOME="$home" FM_TASK='Ship the widget.' \
+    "$ROOT/bin/fm-brief.sh" sol-nodir-1 firstmate --mode no-mistakes >/dev/null 2>&1 || status=$?
+  expect_code 1 "$status" "scaffold without evidence must refuse"
+  assert_absent "$home/data/sol-nodir-1" \
+    "refused scaffold must not leave an empty task directory behind"
+  pass "fm-brief.sh: a refused scaffold leaves the data tree untouched"
+}
+
+# The exemption block is a generated section of the brief and owns its own
+# separators: an unfilled {TASK} brief keeps exactly one blank line before the
+# Herdr heading, and a filled one keeps a blank line after the evidence block.
+test_sol_exemption_block_spacing_is_stable() {
+  local home unfilled filled status
+  home="$TMP_ROOT/sol-spacing-home"
+  mkdir -p "$home/data"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" sol-space-plain firstmate --mode no-mistakes >/dev/null 2>&1 \
+    || fail "unfilled ship scaffold failed"
+  unfilled=$(sed -n '3,6p' "$home/data/sol-space-plain/brief.md")
+  [ "$unfilled" = '# Task
+{TASK}
+
+# Herdr lifecycle declaration - NOT ENABLED' ] \
+    || fail "unfilled ship brief must keep one blank line between {TASK} and the Herdr heading, got:"$'\n'"$unfilled"
+
+  status=0
+  # shellcheck disable=SC2016 # The task body is a literal fixture string.
+  FM_HOME="$home" FM_TASK='Fix the widget.
+Acceptance command: `make test`' \
+    "$ROOT/bin/fm-brief.sh" sol-space-filled firstmate --mode no-mistakes >/dev/null 2>&1 || status=$?
+  expect_code 0 "$status" "filled ship scaffold with evidence must succeed"
+  filled=$(sed -n '3,10p' "$home/data/sol-space-filled/brief.md")
+  # shellcheck disable=SC2016 # The expected brief text is a literal fixture.
+  [ "$filled" = '# Task
+Fix the widget.
+Acceptance command: `make test`
+
+# Sol exemption evidence
+Acceptance command: `make test`
+
+# Herdr lifecycle declaration - NOT ENABLED' ] \
+    || fail "filled ship brief evidence block must be blank-line separated, got:"$'\n'"$filled"
+  pass "fm-brief.sh: Sol exemption block owns its own blank-line separators"
+}
+
 test_scout_and_secondmate_scaffold() {
   local brief
   FM_HOME="$BRIEF_HOME" "$ROOT/bin/fm-brief.sh" brief-scout-q6 alpha --scout >/dev/null 2>&1 \
@@ -824,4 +966,10 @@ test_scout_and_secondmate_load_decision_hold_policy
 test_ship_sol_exemption_refuses_without_evidence
 test_ship_sol_exemption_succeeds_with_evidence
 test_ship_sol_exemption_refuses_unbounded_wait
+test_ship_sol_exemption_refuses_inflected_waits
+test_ship_sol_exemption_refuses_valueless_bound_and_escape
+test_ship_sol_exemption_ignores_backticked_command_names
+test_fm_task_refused_on_scout_and_secondmate
+test_refused_scaffold_leaves_no_task_directory
+test_sol_exemption_block_spacing_is_stable
 test_scout_and_secondmate_scaffold

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -985,7 +985,8 @@ Acceptance command: `b`' \
 
 test_ship_sol_exemption_refuses_non_command_acceptance_payloads() {
   local home out status payload i=0
-  for payload in ' ' '&&' '>'; do
+  for payload in ' ' '&&' '>' '# tests not implemented' '   # tests not implemented' \
+                 'FOO=bar' 'make test &&'; do
     i=$((i + 1))
     home="$TMP_ROOT/sol-non-command-home-$i"
     mkdir -p "$home/data"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -726,6 +726,14 @@ test_scout_and_secondmate_load_decision_hold_policy() {
 }
 
 # Scout and secondmate paths still scaffold well-formed briefs.
+# The "# Sol exemption evidence" block is a scaffold-owned generated section of the
+# brief. FM_TASK is also emitted verbatim into the "# Task" section above it, so a
+# whole-file grep cannot tell the two apart; assertions about the block must run
+# against the extracted block alone.
+sol_evidence_block() {
+  sed -n '/^# Sol exemption evidence$/,/^$/p' "$1"
+}
+
 test_ship_sol_exemption_refuses_without_evidence() {
   local home out status
   home="$TMP_ROOT/sol-refuse-home"
@@ -741,7 +749,7 @@ test_ship_sol_exemption_refuses_without_evidence() {
 }
 
 test_ship_sol_exemption_succeeds_with_evidence() {
-  local home brief status task
+  local home brief status task block
   home="$TMP_ROOT/sol-earn-home"
   mkdir -p "$home/data"
   # shellcheck disable=SC2016 # Backticks in the task body are literal evidence syntax.
@@ -755,12 +763,13 @@ Wait: CI green bound=30m escape=append blocked: CI timeout'
   assert_present "$brief" "Sol-exempt ship brief was not scaffolded"
   grep -qx "Sol exemption: earned" "$brief" \
     || fail "brief missing the machine-readable Sol exemption line"
-  assert_grep "# Sol exemption evidence" "$brief" \
+  block=$(sol_evidence_block "$brief")
+  assert_contains "$block" "# Sol exemption evidence" \
     "brief missing the scaffold-owned Sol exemption evidence block"
-  assert_grep "Acceptance command: \`bin/fm-lint.sh\`" "$brief" \
-    "brief did not carry the acceptance command in the evidence block"
-  assert_grep "Wait: CI green bound=30m escape=append blocked: CI timeout" "$brief" \
-    "brief did not carry bounded waits in the evidence block"
+  assert_contains "$block" "Acceptance command: \`bin/fm-lint.sh\`" \
+    "evidence block did not carry the acceptance command"
+  assert_contains "$block" "Wait: CI green bound=30m escape=append blocked: CI timeout" \
+    "evidence block did not carry the bounded wait"
   pass "fm-brief.sh: ship scaffold earns Sol exemption with auditable evidence"
 }
 
@@ -943,7 +952,7 @@ Acceptance command: `make test` (from the repo root)'; do
     assert_present "$brief" "trailing-text acceptance ship brief was not scaffolded"
     grep -qx "Sol exemption: earned" "$brief" \
       || fail "brief missing the machine-readable Sol exemption line"
-    assert_grep "Acceptance command: \`make test\`" "$brief" \
+    assert_contains "$(sol_evidence_block "$brief")" "Acceptance command: \`make test\`" \
       "evidence block dropped the acceptance command"
   done
   pass "fm-brief.sh: an acceptance line with trailing text earns exemption and is recorded"
@@ -1021,7 +1030,7 @@ Acceptance command: `make test`' \
 # the gate validated must appear in it, including one written without a space
 # after the colon.
 test_sol_evidence_block_records_every_validated_wait() {
-  local home brief status
+  local home brief status block
   home="$TMP_ROOT/sol-evidence-home"
   mkdir -p "$home/data"
   status=0
@@ -1032,11 +1041,82 @@ Wait: review bound=1h escape=ping firstmate' \
     "$ROOT/bin/fm-brief.sh" sol-evidence-1 firstmate --mode no-mistakes >/dev/null 2>&1 || status=$?
   expect_code 0 "$status" "bounded waits must scaffold"
   brief="$home/data/sol-evidence-1/brief.md"
-  assert_grep "Wait:CI green bound=30m escape=append blocked" "$brief" \
+  block=$(sol_evidence_block "$brief")
+  assert_contains "$block" "Wait:CI green bound=30m escape=append blocked" \
     "evidence block dropped a validated wait written without a space after the colon"
-  assert_grep "Wait: review bound=1h escape=ping firstmate" "$brief" \
+  assert_contains "$block" "Wait: review bound=1h escape=ping firstmate" \
     "evidence block dropped a validated wait"
   pass "fm-brief.sh: the evidence block records every wait the gate validated"
+}
+
+# Regression: the backtick strip removed any paired span, so an unbounded wait
+# written inside backticks earned the exemption. Only whitespace-free spans are
+# command/token names; prose inside backticks is still prose.
+test_ship_sol_exemption_refuses_backticked_prose_wait() {
+  local home out status body i=0
+  # shellcheck disable=SC2016 # The task bodies are literal fixture strings.
+  for body in 'Acceptance command: `make test`
+Then `wait forever for the human to approve` before shipping.' \
+              'Acceptance command: `make test`
+Do `await the captain sign-off` first.'; do
+    i=$((i + 1))
+    home="$TMP_ROOT/sol-btprose-home-$i"
+    mkdir -p "$home/data"
+    status=0
+    out=$(FM_HOME="$home" FM_TASK="$body" \
+      "$ROOT/bin/fm-brief.sh" "sol-btprose-$i" firstmate --mode no-mistakes 2>&1) || status=$?
+    expect_code 1 "$status" "an unbounded wait inside backticks must not earn exemption"
+    assert_contains "$out" "unbounded wait" "refusal must name the unbounded wait"
+    assert_absent "$home/data/sol-btprose-$i/brief.md" \
+      "refused backticked-prose-wait scaffold must not write a brief"
+  done
+  pass "fm-brief.sh: a backticked prose wait cannot earn the exemption"
+}
+
+# A refusal must name the real cause: two conforming acceptance lines is a
+# too-many problem, not a missing-evidence one.
+test_duplicate_acceptance_refusal_names_the_real_cause() {
+  local home out status
+  home="$TMP_ROOT/sol-dup-home"
+  mkdir -p "$home/data"
+  status=0
+  # shellcheck disable=SC2016 # The task body is a literal fixture string.
+  out=$(FM_HOME="$home" FM_TASK='Acceptance command: `make test`
+Acceptance command: `make lint`' \
+    "$ROOT/bin/fm-brief.sh" sol-dup-1 firstmate --mode no-mistakes 2>&1) || status=$?
+  expect_code 1 "$status" "two acceptance command lines must refuse"
+  assert_contains "$out" "found 2 Acceptance command lines" \
+    "refusal must say how many acceptance lines were found"
+  assert_not_contains "$out" "missing exactly one" \
+    "refusal must not claim evidence is missing when two conforming lines are present"
+  pass "fm-brief.sh: a duplicate acceptance command refusal names the real cause"
+}
+
+# The unguarded Herdr gate is worker-facing generated text; it must not claim the
+# scaffold could not see a task body that was in fact supplied at scaffold time.
+test_herdr_gate_text_matches_scaffold_time_knowledge() {
+  local home unfilled filled
+  home="$TMP_ROOT/herdr-truth-home"
+  mkdir -p "$home/data"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" herdr-truth-plain firstmate --mode no-mistakes >/dev/null 2>&1 \
+    || fail "unfilled ship scaffold failed"
+  unfilled=$(cat "$home/data/herdr-truth-plain/brief.md")
+  assert_contains "$unfilled" "this scaffold cannot inspect the task text filled in above" \
+    "an unfilled {TASK} brief must keep its original hard safety gate wording"
+
+  # shellcheck disable=SC2016 # The task body is a literal fixture string.
+  FM_HOME="$home" FM_TASK='Fix the widget.
+Acceptance command: `make test`' \
+    "$ROOT/bin/fm-brief.sh" herdr-truth-filled firstmate --mode no-mistakes >/dev/null 2>&1 \
+    || fail "filled ship scaffold failed"
+  filled=$(cat "$home/data/herdr-truth-filled/brief.md")
+  assert_not_contains "$filled" "this scaffold cannot inspect the task text filled in above" \
+    "a brief scaffolded from FM_TASK must not claim the scaffold could not inspect the task"
+  assert_contains "$filled" "never inspects the task text above for Herdr lifecycle intent" \
+    "a filled brief must still carry a hard safety gate about Herdr lifecycle intent"
+  assert_contains "$filled" "regenerate the brief with \`--herdr-lab\` before dispatch" \
+    "a filled brief must keep the --herdr-lab remediation instruction"
+  pass "fm-brief.sh: the Herdr gate states only what the scaffold actually knows"
 }
 
 test_scout_and_secondmate_scaffold() {
@@ -1093,4 +1173,7 @@ test_ship_sol_exemption_accepts_trailing_acceptance_text
 test_ship_sol_exemption_refusals_are_never_silent
 test_fm_task_cannot_forge_scaffold_owned_contract_lines
 test_sol_evidence_block_records_every_validated_wait
+test_ship_sol_exemption_refuses_backticked_prose_wait
+test_duplicate_acceptance_refusal_names_the_real_cause
+test_herdr_gate_text_matches_scaffold_time_knowledge
 test_scout_and_secondmate_scaffold

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -862,7 +862,7 @@ test_fm_task_refused_on_scout_and_secondmate() {
 
   status=0
   out=$(FM_HOME="$home" FM_TASK='Charter the crew.' \
-    "$ROOT/bin/fm-brief.sh" sol-kind-sm alpha --secondmate --no-projects 2>&1) || status=$?
+    "$ROOT/bin/fm-brief.sh" sol-kind-sm --secondmate --no-projects 2>&1) || status=$?
   expect_code 1 "$status" "FM_TASK on a secondmate scaffold must refuse"
   assert_contains "$out" "FM_TASK applies only to ship briefs" \
     "secondmate refusal must name FM_TASK as ship-only"
@@ -922,6 +922,123 @@ Acceptance command: `make test`
   pass "fm-brief.sh: Sol exemption block owns its own blank-line separators"
 }
 
+# Regression: the validator accepted an acceptance line with trailing text while
+# the separate evidence grep was end-anchored, so the scaffold exited 1 with no
+# diagnostic at all. One walk now feeds both, and a refusal always names a cause.
+test_ship_sol_exemption_accepts_trailing_acceptance_text() {
+  local home brief status body i=0
+  # shellcheck disable=SC2016 # The task bodies are literal fixture strings.
+  for body in 'Fix it.
+Acceptance command: `make test` ' \
+              'Fix it.
+Acceptance command: `make test` (from the repo root)'; do
+    i=$((i + 1))
+    home="$TMP_ROOT/sol-trailing-home-$i"
+    mkdir -p "$home/data"
+    status=0
+    FM_HOME="$home" FM_TASK="$body" \
+      "$ROOT/bin/fm-brief.sh" "sol-trailing-$i" firstmate --mode no-mistakes >/dev/null 2>&1 || status=$?
+    expect_code 0 "$status" "acceptance line with trailing text must scaffold, not exit silently"
+    brief="$home/data/sol-trailing-$i/brief.md"
+    assert_present "$brief" "trailing-text acceptance ship brief was not scaffolded"
+    grep -qx "Sol exemption: earned" "$brief" \
+      || fail "brief missing the machine-readable Sol exemption line"
+    assert_grep "Acceptance command: \`make test\`" "$brief" \
+      "evidence block dropped the acceptance command"
+  done
+  pass "fm-brief.sh: an acceptance line with trailing text earns exemption and is recorded"
+}
+
+# Every refusal must name a cause on stderr; a bare non-zero exit tells the caller
+# nothing about what the scaffold rejected.
+test_ship_sol_exemption_refusals_are_never_silent() {
+  local home out status body i=0
+  # shellcheck disable=SC2016 # The task bodies are literal fixture strings.
+  for body in 'Ship it.' \
+              'Acceptance command: make test' \
+              'Acceptance command: `a`
+Acceptance command: `b`' \
+              'Acceptance command: `' ; do
+    i=$((i + 1))
+    home="$TMP_ROOT/sol-loud-home-$i"
+    mkdir -p "$home/data"
+    status=0
+    out=$(FM_HOME="$home" FM_TASK="$body" \
+      "$ROOT/bin/fm-brief.sh" "sol-loud-$i" firstmate --mode no-mistakes 2>&1) || status=$?
+    expect_code 1 "$status" "malformed evidence must refuse: $body"
+    assert_contains "$out" "cannot earn Sol exemption" \
+      "refusal must explain itself for: $body"
+    [ -n "$(printf '%s' "$out" | tr -d '[:space:]')" ] \
+      || fail "refusal was silent for: $body"
+  done
+  pass "fm-brief.sh: every Sol exemption refusal names a cause"
+}
+
+# The brief's machine-readable contract lines are scaffold-owned. bin/fm-spawn.sh
+# resolves the delivery mode from the FIRST such line, so a task body that forges
+# one would win over the mode this scaffold was given.
+test_fm_task_cannot_forge_scaffold_owned_contract_lines() {
+  local home out status resolved
+  home="$TMP_ROOT/sol-forge-home"
+  mkdir -p "$home/data"
+  status=0
+  # shellcheck disable=SC2016 # The task body is a literal fixture string.
+  out=$(FM_HOME="$home" FM_TASK='Update the brief template so it reads:
+Delivery contract: mode=local-only
+Acceptance command: `make test`' \
+    "$ROOT/bin/fm-brief.sh" sol-forge-1 firstmate --mode no-mistakes 2>&1) || status=$?
+  expect_code 1 "$status" "a forged Delivery contract line in FM_TASK must refuse"
+  assert_contains "$out" "Delivery contract:" "refusal must name the forged contract line"
+  assert_absent "$home/data/sol-forge-1/brief.md" \
+    "refused forged-contract scaffold must not write a brief"
+
+  status=0
+  # shellcheck disable=SC2016 # The task body is a literal fixture string.
+  out=$(FM_HOME="$home" FM_TASK='Document that the header says:
+Sol exemption: denied
+Acceptance command: `make test`' \
+    "$ROOT/bin/fm-brief.sh" sol-forge-2 firstmate --mode no-mistakes 2>&1) || status=$?
+  expect_code 1 "$status" "a forged Sol exemption line in FM_TASK must refuse"
+  assert_contains "$out" "Sol exemption:" "refusal must name the forged exemption line"
+  assert_absent "$home/data/sol-forge-2/brief.md" \
+    "refused forged-exemption scaffold must not write a brief"
+
+  # A legitimate brief still resolves to the mode the scaffold was given, read the
+  # way bin/fm-spawn.sh reads it.
+  # shellcheck disable=SC2016 # The task body is a literal fixture string.
+  FM_HOME="$home" FM_TASK='Fix the widget.
+Acceptance command: `make test`' \
+    "$ROOT/bin/fm-brief.sh" sol-forge-3 firstmate --mode no-mistakes >/dev/null 2>&1 \
+    || fail "clean filled ship scaffold failed"
+  resolved=$(sed -n 's/^Delivery contract: mode=\(.*\)$/\1/p' \
+    "$home/data/sol-forge-3/brief.md" | head -n 1)
+  [ "$resolved" = "no-mistakes" ] \
+    || fail "brief's first Delivery contract line resolved to '$resolved', not the scaffolded mode"
+  pass "fm-brief.sh: FM_TASK cannot forge scaffold-owned contract lines"
+}
+
+# The evidence block is the auditable artifact the exemption rests on: every wait
+# the gate validated must appear in it, including one written without a space
+# after the colon.
+test_sol_evidence_block_records_every_validated_wait() {
+  local home brief status
+  home="$TMP_ROOT/sol-evidence-home"
+  mkdir -p "$home/data"
+  status=0
+  # shellcheck disable=SC2016 # The task body is a literal fixture string.
+  FM_HOME="$home" FM_TASK='Acceptance command: `make test`
+Wait:CI green bound=30m escape=append blocked
+Wait: review bound=1h escape=ping firstmate' \
+    "$ROOT/bin/fm-brief.sh" sol-evidence-1 firstmate --mode no-mistakes >/dev/null 2>&1 || status=$?
+  expect_code 0 "$status" "bounded waits must scaffold"
+  brief="$home/data/sol-evidence-1/brief.md"
+  assert_grep "Wait:CI green bound=30m escape=append blocked" "$brief" \
+    "evidence block dropped a validated wait written without a space after the colon"
+  assert_grep "Wait: review bound=1h escape=ping firstmate" "$brief" \
+    "evidence block dropped a validated wait"
+  pass "fm-brief.sh: the evidence block records every wait the gate validated"
+}
+
 test_scout_and_secondmate_scaffold() {
   local brief
   FM_HOME="$BRIEF_HOME" "$ROOT/bin/fm-brief.sh" brief-scout-q6 alpha --scout >/dev/null 2>&1 \
@@ -972,4 +1089,8 @@ test_ship_sol_exemption_ignores_backticked_command_names
 test_fm_task_refused_on_scout_and_secondmate
 test_refused_scaffold_leaves_no_task_directory
 test_sol_exemption_block_spacing_is_stable
+test_ship_sol_exemption_accepts_trailing_acceptance_text
+test_ship_sol_exemption_refusals_are_never_silent
+test_fm_task_cannot_forge_scaffold_owned_contract_lines
+test_sol_evidence_block_records_every_validated_wait
 test_scout_and_secondmate_scaffold

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -983,6 +983,24 @@ Acceptance command: `b`' \
   pass "fm-brief.sh: every Sol exemption refusal names a cause"
 }
 
+test_ship_sol_exemption_refuses_non_command_acceptance_payloads() {
+  local home out status payload i=0
+  for payload in ' ' '&&' '>'; do
+    i=$((i + 1))
+    home="$TMP_ROOT/sol-non-command-home-$i"
+    mkdir -p "$home/data"
+    status=0
+    out=$(FM_HOME="$home" FM_TASK="Acceptance command: \`$payload\`" \
+      "$ROOT/bin/fm-brief.sh" "sol-non-command-$i" firstmate --mode no-mistakes 2>&1) || status=$?
+    expect_code 1 "$status" "non-command acceptance payload must refuse"
+    assert_contains "$out" "concrete executable command" \
+      "refusal must name the executable-command requirement"
+    assert_absent "$home/data/sol-non-command-$i/brief.md" \
+      "refused non-command acceptance payload must not write a brief"
+  done
+  pass "fm-brief.sh: non-command acceptance payloads cannot earn Sol exemption"
+}
+
 # The brief's machine-readable contract lines are scaffold-owned. bin/fm-spawn.sh
 # resolves the delivery mode from the FIRST such line, so a task body that forges
 # one would win over the mode this scaffold was given.
@@ -1171,6 +1189,7 @@ test_refused_scaffold_leaves_no_task_directory
 test_sol_exemption_block_spacing_is_stable
 test_ship_sol_exemption_accepts_trailing_acceptance_text
 test_ship_sol_exemption_refusals_are_never_silent
+test_ship_sol_exemption_refuses_non_command_acceptance_payloads
 test_fm_task_cannot_forge_scaffold_owned_contract_lines
 test_sol_evidence_block_records_every_validated_wait
 test_ship_sol_exemption_refuses_backticked_prose_wait


### PR DESCRIPTION
## Intent

Harden bin/fm-brief.sh so a ship brief earns exemption from the Sol spec stage only by already carrying (a) one executable acceptance command and (b) every wait bounded with an escape. The scaffold must refuse otherwise (Fable change 4, adopted 2026-08-25; mechanical, not judgment).

Ship scaffolds (--mode no-mistakes|direct-PR|local-only) refuse to emit an exempt ship brief unless the filled Task section (FM_TASK at scaffold time) or a dedicated exemption block the scaffold owns contains one concrete executable acceptance command and every wait bounded with an escape hatch. Both checks are machine-checkable at scaffold time.

The exemption is an auditable artifact: one machine-readable line the spawn path can later read, following the existing Delivery contract: mode= pattern. Scout and secondmate scaffolds are out of scope. Do not implement the Sol stage itself, spawn refusal on a missing spec, or Sol picking the model (later tasks). Do not add a spec template skill.

Acceptance: (1) bin/fm-brief.sh with FM_TASK lacking acceptance command and bounded waits must refuse, write no brief, name what is missing; (2) same scaffold must succeed when FM_TASK includes one acceptance command and every wait bounded, emitting the machine-readable exemption line; (3) --scout and --secondmate --no-projects still succeed without exemption block. Portable tests in tests/<subject>.test.sh exercising fm-brief.sh; run bin/fm-lint.sh on script changes. Keep flag and refusal mechanics in bin/fm-brief.sh header only; do not restate into AGENTS.md.

## What Changed

- Validate filled ship brief tasks for exactly one executable acceptance command and bounded, escapable waits before writing any scaffold.
- Emit a machine-readable Sol exemption marker and scaffold-owned evidence block for qualifying briefs while protecting generated contract lines from forgery.
- Add portable coverage for valid, malformed, and unbounded evidence plus unchanged scout and secondmate scaffolding.

## Risk Assessment

✅ Low: The change is well-bounded, the current scanner closes the previously identified acceptance-command and wait-detection bypasses, and no additional source-verifiable correctness or intent-conformance issues were found.

## Testing

The focused fm-brief test harness and end-user CLI paths all passed: invalid ship tasks refused without writing briefs, valid bounded evidence produced an auditable exemption contract, trailing unbounded waits were rejected, and scout/secondmate scaffolds remained compatible. Reviewer-visible CLI and generated-brief evidence was captured; lint was not run because this assigned test phase explicitly forbids linters.

<details>
<summary>Evidence: End-to-end Sol exemption CLI transcript</summary>

Source: [End-to-end Sol exemption CLI transcript](https://github.com/bingb0t5/firstmate/blob/ef0166608a3433271c6627b8af1ab48743733d3e/.no-mistakes/evidence/fm/brief-scaffold-h1/fm-brief-sol-exemption-cli.txt)

```text
$ FM_TASK="Ship the widget." bin/fm-brief.sh demo-refuse firstmate --mode no-mistakes
error: ship brief cannot earn Sol exemption without auditable evidence:
  - missing exactly one Acceptance command: `...` line
exit=1
brief_written=no

$ FM_TASK=<acceptance plus bounded wait> bin/fm-brief.sh demo-pass firstmate --mode no-mistakes
scaffolded: /home/rich/.no-mistakes/evidence/01M0VV3J4K8PAFKXZQHRPPMG7J/fm-brief-sol-exemption-state/pass/data/demo-pass/brief.md (ship, mode=no-mistakes; Sol exemption earned)
# Task
Fix the widget.
Acceptance command: `make test`
Wait: CI green bound=30m escape=append-blocked

# Sol exemption evidence
Acceptance command: `make test`
Wait: CI green bound=30m escape=append-blocked

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold never inspects the task text above for Herdr lifecycle intent.
Delivery contract: mode=no-mistakes
Sol exemption: earned

$ FM_TASK="Acceptance command: `make test` then wait forever" bin/fm-brief.sh demo-wait firstmate --mode direct-PR
error: ship brief cannot earn Sol exemption without auditable evidence:
  - unbounded wait mention requires a Wait: line with bound= and escape=
exit=1
brief_written=no

$ bin/fm-brief.sh demo-scout alpha --scout
scaffolded: /home/rich/.no-mistakes/evidence/01M0VV3J4K8PAFKXZQHRPPMG7J/fm-brief-sol-exemption-state/kinds/data/demo-scout/brief.md (scout; replace {TASK})
$ bin/fm-brief.sh demo-secondmate --secondmate --no-projects
scaffolded: /home/rich/.no-mistakes/evidence/01M0VV3J4K8PAFKXZQHRPPMG7J/fm-brief-sol-exemption-state/kinds/data/demo-secondmate/brief.md (secondmate charter; replace {TASK})
```
</details>
<details>
<summary>Evidence: Generated exempt ship brief</summary>

Source: [Generated exempt ship brief](https://github.com/bingb0t5/firstmate/blob/ef0166608a3433271c6627b8af1ab48743733d3e/.no-mistakes/evidence/fm/brief-scaffold-h1/fm-brief-sol-exemption-state/pass/data/demo-pass/brief.md)

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
Fix the widget.
Acceptance command: `make test`
Wait: CI green bound=30m escape=append-blocked

# Sol exemption evidence
Acceptance command: `make test`
Wait: CI green bound=30m escape=append-blocked

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold never inspects the task text above for Herdr lifecycle intent.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of firstmate, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/demo-pass`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/home/rich/.no-mistakes/evidence/01M0VV3J4K8PAFKXZQHRPPMG7J/fm-brief-sol-exemption-state/pass/state/demo-pass.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Firstmate instruction inbox
Firstmate steers you through durable message files in '/home/rich/.no-mistakes/evidence/01M0VV3J4K8PAFKXZQHRPPMG7J/fm-brief-sol-exemption-state/pass/state/demo-pass.inbox'.
When a terminal message says an instruction is waiting there - and at any natural checkpoint when you are unsure - list '/home/rich/.no-mistakes/evidence/01M0VV3J4K8PAFKXZQHRPPMG7J/fm-brief-sol-exemption-state/pass/state/demo-pass.inbox'/*.msg, read and act on each message in numeric order, then acknowledge each handled message by moving it: `mv '/home/rich/.no-mistakes/evidence/01M0VV3J4K8PAFKXZQHRPPMG7J/fm-brief-sol-exemption-state/pass/state/demo-pass.inbox'/NNN.msg '/home/rich/.no-mistakes/evidence/01M0VV3J4K8PAFKXZQHRPPMG7J/fm-brief-sol-exemption-state/pass/state/demo-pass.inbox'/handled/`.
The move IS the acknowledgement: without it firstmate rings again and eventually treats you as stuck. An empty or absent inbox needs no action.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/home/rich/.no-mistakes/worktrees/7ce0540b75f4/01M0VV3J4K8PAFKXZQHRPPMG7J/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/home/rich/.no-mistakes/worktrees/7ce0540b75f4/01M0VV3J4K8PAFKXZQHRPPMG7J/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=no-mistakes
Sol exemption: earned
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies `ask-user-authority` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"7777edc0f0ef9a1a587134d0abb8c0f2543aa347","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 6 issues found → auto-fixed (6) ✅</summary>

- ⚠️ `bin/fm-brief.sh:230` - The unbounded-wait detector matches only the bare token `wait` via `(^|[^a-z])wait([^a-z]|$)`, so common inflections slip through and the brief is stamped exempt while still carrying an unbounded wait. Verified: FM_TASK=&#39;Ship it.\nAcceptance command: `make test`\nKeep waiting for CI until it goes green.&#39; scaffolds with rc=0 and emits `Sol exemption: earned`; same for &#39;Await the deploy indefinitely.&#39;. The intent requires &#39;every wait bounded with an escape&#39;, and the gate&#39;s own fixture (&#39;Wait for deploy&#39;) is the only spelling it catches. Suggest matching the wait word family (wait/waiting/waits/awaiting/await, and arguably sleep/poll until/block until) rather than a single token.
- ⚠️ `bin/fm-brief.sh:221` - `Wait:\ *bound=*escape=*` matches `bound=` and `escape=` as bare prefixes, so a wait with no actual bound or escape value earns the exemption. Verified: FM_TASK=&#39;Acceptance command: `a`\nWait: CI bound=escape=&#39; scaffolds with rc=0 and writes `Sol exemption: earned`, recording a wait that is not in fact bounded. Suggest requiring at least one non-space character after each `=` (e.g. a grep -E check for `bound=[^[:space:]]` and `escape=[^[:space:]]`).
- ℹ️ `bin/fm-brief.sh:534` - The unconditional `$SOL_EXEMPTION_BLOCK` line changes generated ship-brief bytes in both directions. Unfilled `{TASK}`: the variable is empty, so the brief now has two blank lines between `{TASK}` and `# Herdr lifecycle declaration` where it previously had one (verified with cat -A). Filled: the evidence block&#39;s last line abuts the `# Herdr...` heading with no blank separator. The file already documents a byte-stability concern for generated briefs (line 517-519). Suggest building the block with its own leading/trailing newline only when non-empty.
- ℹ️ `bin/fm-brief.sh:230` - The same detector fires on any line containing the token `wait` regardless of context, hard-refusing legitimate tasks. Verified: FM_TASK=&#39;Acceptance command: `make test`\nRun `wait-for-ci.sh` as part of setup.&#39; refuses with &#39;unbounded wait mention requires a Wait: line&#39;. The hyphen in a command name is `[^a-z]`, so backticked command names, file paths, and branch names containing &#39;wait&#39; cannot be described in a filled ship task at all. Fail-closed is the safer direction, but it makes the gate unusable for a real class of tasks; consider skipping backticked spans when scanning.
- ℹ️ `bin/fm-brief.sh:453` - FM_TASK is only read on the ship path; the scout and secondmate paths ignore it silently. Verified: FM_TASK=&#39;Investigate the flake.&#39; with --scout scaffolds a brief whose Task section is still `{TASK}` and prints &#39;replace {TASK}&#39;, so an exported FM_TASK is dropped with no signal. This file&#39;s established convention is to refuse loudly rather than silently drop an input the caller believes was recorded (--yolo at line 148, --mode on scout at line 168, --herdr-lab on secondmate at line 174). Consider refusing FM_TASK on non-ship scaffolds, or documenting the ship-only scope in the header.
- ℹ️ `bin/fm-brief.sh:186` - `mkdir -p &#34;$DATA/$ID&#34;` runs before the exemption gate, so a refused scaffold leaves an empty `data/&lt;id&gt;/` behind (verified). The acceptance criterion &#39;write no brief&#39; still holds and a retry with the same id succeeds, since the overwrite guard keys on brief.md and no consumer enumerates bare task dirs, so this is cleanliness only - an `rmdir` on the refusal path would leave the tree untouched.

🔧 Fix: Tighten Sol exemption gate and validate before writes
5 issues (1 error, 2 warnings, 2 infos) still open:

- 🚨 `bin/fm-brief.sh:290` - A conforming acceptance-command line with any trailing content exits 1 with no diagnostic and no brief. Verified: FM_TASK=&#39;Fix it.\nAcceptance command: `make test` &#39; (a single trailing space; same for &#39;`make test` (from repo root)&#39;) with --mode no-mistakes gives rc=1 and completely empty stdout/stderr. Cause: the counting grep at line 216 is unanchored so acc_count=1 and the loop&#39;s acceptance branch (line 228) accepts the line, but the evidence grep at line 265 is `$`-anchored and matches nothing, so fm_brief_sol_evidence_block returns 1 at line 266 and `set -eu` turns the command substitution at line 290 into a bare exit before the `[ -z &#34;$SOL_EXEMPTION_BLOCK&#34; ] ||` guard on line 291 can run (that guard is unreachable). This both wrongly refuses a task carrying one concrete executable acceptance command and violates the intent&#39;s requirement that a refusal name what is missing. Fix by making the two patterns agree (anchor the counting grep, or drop the `$` anchor from the evidence grep) and by not letting an empty block abort the script silently. No new test covers a trailing-text acceptance line.
- ⚠️ `bin/fm-brief.sh:234` - The unbounded-wait scan only runs in the default case branch, so a wait written on the same line as a bounded Wait: entry is never scanned and the brief is stamped exempt anyway. Verified: FM_TASK=&#39;Acceptance command: `make test`\nWait: CI bound=30m escape=append blocked, and otherwise wait forever for review.&#39; scaffolds rc=0, writes `Sol exemption: earned`, and records that line in the evidence block as bounded. fm_brief_wait_is_bounded only checks that bound= and escape= carry non-empty values; the rest of the line never reaches the grep at line 244. The same hole exists on the `Acceptance command: ` branch (line 228), though that variant currently lands in the silent-exit path above instead. The intent grants exemption only when &#39;every wait bounded with an escape&#39;, so this issues an exemption to a brief that still carries an unbounded wait. A fix would scan the residual text of Wait:/Acceptance lines after stripping the recognized bound=/escape= (and backticked) spans.
- ⚠️ `bin/fm-brief.sh:282` - FM_TASK is emitted verbatim into the Task section (line 567), which sits above the Definition of done, so a task body containing a line starting with &#39;Delivery contract: mode=&#39; subverts the brief/spawn delivery agreement. Verified: FM_TASK=&#39;Update the brief template so it reads:\nDelivery contract: mode=local-only\nAcceptance command: `make test`&#39; with --mode no-mistakes scaffolds rc=0 and produces a brief with &#39;Delivery contract: mode=local-only&#39; at line 5 and &#39;Delivery contract: mode=no-mistakes&#39; at line 65. bin/fm-spawn.sh:1676 reads `sed -n &#39;s/^Delivery contract: mode=...//p&#39; | head -n 1`, so it resolves local-only: `fm-spawn.sh --mode no-mistakes` refuses with a bogus &#39;delivery mismatch&#39;, and `--mode local-only` launches a worker whose definition of done is the no-mistakes pipeline. That is exactly the drift the contract documented at bin/fm-brief.sh:40 exists to prevent, now reachable from a scripted input rather than only a hand edit. Closing it at the scaffold boundary (refuse an FM_TASK body containing a line matching ^Delivery contract: mode=, matching this file&#39;s loud-refusal convention) is the earliest supported point.
- ℹ️ `bin/fm-brief.sh:265` - The evidence grep requires &#39;Wait: &#39; (with a space) while the validator&#39;s case branch accepts any &#39;Wait:&#39; prefix, so a wait the gate validated can be missing from the auditable artifact. Verified: FM_TASK=&#39;Acceptance command: `make test`\nWait:CI green bound=30m escape=append blocked&#39; scaffolds rc=0 with &#39;Sol exemption: earned&#39;, but the generated &#39;# Sol exemption evidence&#39; block contains only the acceptance command - the wait is silently absent from the block the exemption is meant to be auditable through. Align the two patterns (both &#39;Wait:*&#39; or both &#39;Wait: &#39;).
- ℹ️ `tests/fm-brief.test.sh:865` - The secondmate leg of test_fm_task_refused_on_scout_and_secondmate invokes &#39;sol-kind-sm alpha --secondmate --no-projects&#39;, which is itself a rejected combination: without FM_TASK that same command exits 1 with &#39;error: --no-projects cannot be combined with a project list&#39; (bin/fm-brief.sh:328). The assertion holds today only because the FM_TASK gate at line 275 runs first. Dropping the stray &#39;alpha&#39; makes the fixture a legitimate secondmate scaffold and keeps the test pinned to the behavior it names.

🔧 Fix: Unify Sol evidence scan and block contract-line forgery
5 issues (1 warning, 4 infos) still open:

- ⚠️ `tests/fm-brief.test.sh:1035` - The evidence-block assertions are whole-file fixed-string greps, and FM_TASK is emitted verbatim into the `# Task` section of the same brief (bin/fm-brief.sh:567), so they match the Task-section copy regardless of what the evidence block contains. Verified: for this test&#39;s own fixture, `grep -c -F &#39;Wait:CI green bound=30m escape=append blocked&#39;` on the generated brief returns 2 - line 6 of the brief (Task) and line 9 (evidence block). test_sol_evidence_block_records_every_validated_wait is named for the regression where the evidence grep required &#39;Wait: &#39; with a space and dropped the colon-tight wait, but it would still pass with that bug present, because the Task-section copy alone satisfies both assert_grep calls. The same vacuity applies to the assert_grep pair at lines 760/763 in test_ship_sol_exemption_succeeds_with_evidence and to line 946 in test_ship_sol_exemption_accepts_trailing_acceptance_text. Fix by asserting against the extracted evidence block only, the way test_sol_exemption_block_spacing_is_stable already does (e.g. `sed -n &#39;/^# Sol exemption evidence$/,/^$/p&#39;`), so the block&#39;s content is actually pinned.
- ℹ️ `bin/fm-brief.sh:262` - The backtick-stripping sed removes any paired backtick span before the wait scan, so an unbounded wait written inside backticks earns the exemption. Verified: FM_TASK=&#39;Acceptance command: `make test`\nThen `wait forever for the human to approve` before shipping.&#39; scaffolds rc=0 and writes &#39;Sol exemption: earned&#39;, even though the brief carries a plainly unbounded wait. The intent grants exemption only when &#39;every wait bounded with an escape&#39;, so this labels a non-conforming brief exempt without erroring. The round-1 instruction that motivated the skip was specifically about command names (`wait-for-ci.sh`), which contain no whitespace; narrowing the strip to backticked spans with no internal whitespace would still let `wait-for-ci.sh` and `await-queue.py` through (both covered by test_ship_sol_exemption_ignores_backticked_command_names) while closing the prose bypass. Flagging rather than fixing because the backtick skip was an explicit author instruction.
- ℹ️ `bin/fm-brief.sh:275` - `acc_count -ne 1` covers both 0 and &gt;1, but the message only describes the zero case. Verified: FM_TASK=&#39;Acceptance command: `make test`\nAcceptance command: `make lint`&#39; refuses with the sole diagnostic &#39;missing exactly one Acceptance command: `...` line&#39;, telling the caller something is missing when in fact two conforming lines are present and one must be removed. The intent requires a refusal to &#39;name what is missing&#39;; here it names the wrong cause and gives no actionable next step. Branch the message on acc_count (0 -&gt; missing, &gt;1 -&gt; &#39;found N acceptance command lines; exactly one is required&#39;). test_ship_sol_exemption_refusals_are_never_silent exercises the two-line fixture but only asserts the generic &#39;cannot earn Sol exemption&#39; header, so the misleading text is uncaught.
- ℹ️ `bin/fm-brief.sh:218` - Two small cleanups in the last fix round&#39;s code. (1) fm_brief_sol_line_kind exists only to set the global FM_BRIEF_SOL_KIND, which is consumed by the `case` three lines later at 245; folding the two-arm classification directly into that `case` removes a function and a global with no behavior change - and would also relocate the doc comment at lines 210-213, which describes fm_brief_sol_scan (&#39;Fills FM_BRIEF_SOL_ERRORS and FM_BRIEF_SOL_EVIDENCE; returns 0 only when the text qualifies&#39;) but currently sits above fm_brief_sol_line_kind, which does neither. (2) The machine-readable string &#39;Sol exemption: earned&#39; is written twice: as SOL_EXEMPTION_LINE at line 298 and again as an awk literal at line 566, while SOL_EXEMPTION_LINE itself is used only as a boolean at line 564. Pass it in with `awk -v line=&#34;$SOL_EXEMPTION_LINE&#34;` so the contract line has one owner, matching how this file treats its other machine-readable lines.
- ℹ️ `bin/fm-brief.sh:444` - The unguarded Herdr gate in every ship brief still asserts &#39;this scaffold cannot inspect the task text filled in above&#39;, and the header at line 27 justifies requiring an explicit --herdr-lab because &#39;{TASK} is filled after scaffolding&#39;. Both are now false for an FM_TASK brief: the task text is present at scaffold time and is in fact machine-scanned by fm_brief_sol_scan. Verified: `FM_TASK=&#39;Acceptance command: \`make test\`&#39; ... --mode no-mistakes` produces a brief whose Task section holds the real body and whose Herdr gate still claims the scaffold could not see it. This is generated worker-facing text stating something untrue about its own provenance. Adding Herdr detection is out of scope for this change, but the sentence should be conditioned on whether the task was filled at scaffold time.

🔧 Fix: Close backtick wait bypass and pin evidence assertions
1 error still open:

- 🚨 `bin/fm-brief.sh:241` - Intent requires &#34;one concrete executable acceptance command,&#34; but the changed case pattern accepts any single character between backticks. For example, `Acceptance command: ` ` ` (a backticked space) increments `acc_count`, produces no error, and earns `Sol exemption: earned` despite containing no executable command. Tighten the scanner at this boundary to reject whitespace-only and other mechanically non-command payloads before counting the line.

🔧 Fix: Reject non-command Sol acceptance payloads
1 error still open:

- 🚨 `bin/fm-brief.sh:225` - The intent requires “one concrete executable acceptance command,” but the new predicate accepts any payload containing an alphanumeric or underscore, including a shell comment. Concrete path: `FM_TASK=&#39;Acceptance command: `# tests not implemented`&#39;` reaches this branch, matches `*[[:alnum:]_]*`, increments `acc_count`, and emits `Sol exemption: earned`, although executing the payload runs no command. Reject comment-only and other non-command payloads before counting the acceptance line.

🔧 Fix: Reject comment-only Sol acceptance commands
2 errors still open:

- 🚨 `bin/fm-brief.sh:259` - Intent requires &#34;every wait bounded with an escape,&#34; but every `Acceptance command:` line bypasses the wait scan. `Acceptance command: `make test` then wait forever` increments `acc_count`; its trailing prose is never checked, so the scaffold emits `Sol exemption: earned`. Scan trailing acceptance-line content for wait mentions, or apply wait detection independently to every line after excluding only the actual command span.
- 🚨 `bin/fm-brief.sh:232` - Intent requires a &#34;concrete executable acceptance command,&#34; but `bash -n` proves only shell syntax and never resolves the command. For example, `Acceptance command: `definitely-not-an-installed-command`` satisfies the token check and syntax parse, then earns exemption despite naming no executable. Validate the command token at scaffold time through the supported executable-resolution boundary before counting it.

🔧 Fix: Scan acceptance-line prose for unbounded waits
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-brief.test.sh`
- <code>Direct CLI refusal with `FM_TASK=&#39;Ship the widget.&#39;`, verifying exit 1, an actionable missing-acceptance diagnostic, and no brief written</code>
- <code>Direct CLI success with one backticked acceptance command and a bounded `Wait:` line, inspecting the generated brief and machine-readable `Sol exemption: earned` contract</code>
- <code>Direct CLI regression check with trailing `wait forever` on the acceptance line, verifying refusal and no brief written</code>
- <code>Direct `--scout` and `--secondmate --no-projects` scaffold checks without exemption evidence</code>
- <code>Verified the evidence transcript and generated exempt brief exist; `git status --short` confirmed no worktree changes</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
