### PR TITLE
feat: require evidence for ship brief Sol exemptions

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -58,6 +58,10 @@
 #   already filled and to run the exemption gate. FM_TASK is refused on --scout and
 #   --secondmate scaffolds: they are outside the Sol exemption contract, and a
 #   silently dropped task body would be believed recorded.
+#   A filled task body is also refused when it forges a scaffold-owned
+#   machine-readable line ("Delivery contract:" or "Sol exemption:"): those lines
+#   are read back by bin/fm-spawn.sh, and a forged one above the generated line
+#   would win.
 # Ship briefs begin with a worktree-isolation assertion before the branch step.
 # --mode is refused on scout and secondmate scaffolds: a scout's deliverable is a
 # report rather than a merge, and a charter is not a delivery contract.
@@ -208,33 +212,48 @@ fm_brief_wait_is_bounded() {
 }
 
 # One acceptance-command line, and every wait mention bounded with an escape.
-# Prints each missing requirement on stdout; returns 0 only when the text qualifies.
-fm_brief_sol_exemption_errors() {
+# One walk classifies every line, so the validator and the auditable evidence block
+# can never disagree about what counts as evidence. Fills FM_BRIEF_SOL_ERRORS and
+# FM_BRIEF_SOL_EVIDENCE; returns 0 only when the text qualifies.
+fm_brief_sol_line_kind() {
+  FM_BRIEF_SOL_KIND=
+  case "$1" in
+    'Acceptance command: '*) FM_BRIEF_SOL_KIND=acceptance ;;
+    Wait:*) FM_BRIEF_SOL_KIND='wait' ;;
+  esac
+}
+
+# Scaffold-owned machine-readable lines. A filled task body that forges one would
+# be read back by bin/fm-spawn.sh ahead of the line this scaffold actually wrote.
+FM_BRIEF_RESERVED_PREFIXES=('Delivery contract:' 'Sol exemption:')
+
+fm_brief_sol_scan() {
   local text=$1
-  local errors=() acc_lines acc_count line prose saw_unbounded=0
-  # shellcheck disable=SC2016 # Backticks in the grep pattern are literal evidence syntax.
-  acc_lines=$(printf '%s\n' "$text" | grep -E '^Acceptance command: `[^`]+`' || true)
-  acc_count=0
-  if [ -n "$acc_lines" ]; then
-    acc_count=$(printf '%s\n' "$acc_lines" | grep -c . || true)
-  fi
-  if [ "$acc_count" -ne 1 ]; then
-    # shellcheck disable=SC2016 # Backticks in the message document the required syntax.
-    errors+=('missing exactly one Acceptance command: `...` line')
-  fi
+  local line prose prefix acc_count=0 saw_unbounded=0
+  FM_BRIEF_SOL_ERRORS=()
+  FM_BRIEF_SOL_EVIDENCE=()
   while IFS= read -r line || [ -n "$line" ]; do
     [ -z "$line" ] && continue
-    case "$line" in
-      'Acceptance command: '*)
+    for prefix in "${FM_BRIEF_RESERVED_PREFIXES[@]}"; do
+      case "$line" in
+        "$prefix"*)
+          FM_BRIEF_SOL_ERRORS+=("task body must not contain a scaffold-owned '$prefix' line")
+          ;;
+      esac
+    done
+    fm_brief_sol_line_kind "$line"
+    case "$FM_BRIEF_SOL_KIND" in
+      acceptance)
         case "$line" in
-          Acceptance\ command:\ \`*) ;;
-          *) errors+=('Acceptance command must use backticks around the command') ;;
+          Acceptance\ command:\ \`?*\`*) acc_count=$((acc_count + 1)) ;;
+          *) FM_BRIEF_SOL_ERRORS+=('Acceptance command must use backticks around the command') ;;
         esac
+        FM_BRIEF_SOL_EVIDENCE+=("$line")
         ;;
-      Wait:*)
-        if ! fm_brief_wait_is_bounded "$line"; then
-          errors+=('Wait: lines must include non-empty bound=... and escape=... values')
-        fi
+      wait)
+        fm_brief_wait_is_bounded "$line" \
+          || FM_BRIEF_SOL_ERRORS+=('Wait: lines must include non-empty bound=... and escape=... values')
+        FM_BRIEF_SOL_EVIDENCE+=("$line")
         ;;
       *)
         # Backticked spans are literal code, not prose: `wait-for-ci.sh` names a
@@ -243,7 +262,7 @@ fm_brief_sol_exemption_errors() {
         prose=$(printf '%s' "$line" | sed 's/`[^`]*`//g')
         if [ "$saw_unbounded" -eq 0 ] \
            && printf '%s\n' "$prose" | grep -qiE '(^|[^a-z])a?wait(s|ed|ing)?([^a-z]|$)'; then
-          errors+=('unbounded wait mention requires a Wait: line with bound= and escape=')
+          FM_BRIEF_SOL_ERRORS+=('unbounded wait mention requires a Wait: line with bound= and escape=')
           saw_unbounded=1
         fi
         ;;
@@ -251,20 +270,11 @@ fm_brief_sol_exemption_errors() {
   done <<EOF
 $text
 EOF
-  if [ "${#errors[@]}" -gt 0 ]; then
-    printf '%s\n' "${errors[@]}" | sort -u
-    return 1
+  if [ "$acc_count" -ne 1 ]; then
+    # shellcheck disable=SC2016 # Backticks in the message document the required syntax.
+    FM_BRIEF_SOL_ERRORS+=('missing exactly one Acceptance command: `...` line')
   fi
-  return 0
-}
-
-fm_brief_sol_evidence_block() {
-  local text=$1
-  local block
-  # shellcheck disable=SC2016 # Backticks in the grep pattern are literal evidence syntax.
-  block=$(printf '%s\n' "$text" | grep -E '^(Acceptance command: `[^`]+`|Wait: .+)$' || true)
-  [ -n "$block" ] || return 1
-  printf '%s\n' '# Sol exemption evidence' "$block"
+  [ "${#FM_BRIEF_SOL_ERRORS[@]}" -eq 0 ]
 }
 
 # The exemption gate runs before anything is written, so a refused scaffold leaves
@@ -280,15 +290,13 @@ if [ -n "${FM_TASK:-}" ]; then
     exit 1
   }
   SHIP_TASK_BODY=$FM_TASK
-  missing=$(fm_brief_sol_exemption_errors "$SHIP_TASK_BODY" || true)
-  if [ -n "$missing" ]; then
+  if ! fm_brief_sol_scan "$SHIP_TASK_BODY"; then
     echo "error: ship brief cannot earn Sol exemption without auditable evidence:" >&2
-    printf '%s\n' "$missing" | sed 's/^/  - /' >&2
+    printf '%s\n' "${FM_BRIEF_SOL_ERRORS[@]}" | sort -u | sed 's/^/  - /' >&2
     exit 1
   fi
   SOL_EXEMPTION_LINE='Sol exemption: earned'
-  SOL_EXEMPTION_BLOCK=$(fm_brief_sol_evidence_block "$SHIP_TASK_BODY")
-  [ -z "$SOL_EXEMPTION_BLOCK" ] || SOL_EXEMPTION_BLOCK="$SOL_EXEMPTION_BLOCK"$'\n\n'
+  SOL_EXEMPTION_BLOCK=$(printf '%s\n' '# Sol exemption evidence' "${FM_BRIEF_SOL_EVIDENCE[@]}")$'\n\n'
 fi
 
 BRIEF="$DATA/$ID/brief.md"

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -248,6 +248,16 @@ fm_brief_strip_backticked_names() {
   printf '%s' "$result$remaining"
 }
 
+fm_brief_count_wait_mentions() {
+  local remaining=${1,,} match
+  FM_BRIEF_WAIT_MENTIONS=0
+  while [[ $remaining =~ (^|[^a-z])a?wait(s|ed|ing)?([^a-z]|$) ]]; do
+    match=${BASH_REMATCH[0]}
+    FM_BRIEF_WAIT_MENTIONS=$((FM_BRIEF_WAIT_MENTIONS + 1))
+    remaining=${remaining#*"$match"}
+  done
+}
+
 fm_brief_acceptance_is_executable() {
   local line=$1 command first
   case "$line" in
@@ -309,6 +319,10 @@ fm_brief_sol_scan() {
       Wait:*)
         fm_brief_wait_is_bounded "$line" \
           || FM_BRIEF_SOL_ERRORS+=('Wait: lines must include non-empty bound=... and escape=... values')
+        prose=$(fm_brief_strip_backticked_names "$line")
+        fm_brief_count_wait_mentions "$prose"
+        [ "$FM_BRIEF_WAIT_MENTIONS" -eq 1 ] \
+          || FM_BRIEF_SOL_ERRORS+=('each Wait: line must contain exactly one wait clause with its own bound= and escape=')
         FM_BRIEF_SOL_EVIDENCE+=("$line")
         prose=
         ;;

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -207,6 +207,10 @@ fm_brief_trim_surrounding_punctuation() {
   done
 }
 
+fm_brief_lowercase() {
+  FM_BRIEF_LOWERCASE=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+}
+
 fm_brief_wait_is_bounded() {
   local line=$1 field value normalized field_tail duplicate_re
   for field in bound escape; do
@@ -224,7 +228,8 @@ fm_brief_wait_is_bounded() {
       bound=*|escape=*) return 1 ;;
     esac
     fm_brief_trim_surrounding_punctuation "$value"
-    normalized=${FM_BRIEF_NORMALIZED,,}
+    fm_brief_lowercase "$FM_BRIEF_NORMALIZED"
+    normalized=$FM_BRIEF_LOWERCASE
     [ -n "$normalized" ] || return 1
     case "$normalized" in
       forever|none|unbounded|never|n/a|infinite|inf) return 1 ;;
@@ -250,7 +255,8 @@ fm_brief_strip_backticked_names() {
       result+="\`$token\`"
     else
       fm_brief_trim_surrounding_punctuation "$token"
-      normalized=${FM_BRIEF_NORMALIZED,,}
+      fm_brief_lowercase "$FM_BRIEF_NORMALIZED"
+      normalized=$FM_BRIEF_LOWERCASE
       if [[ $normalized =~ ^a?wait(s|ed|ing)?$ ]]; then
         result+=$token
       fi
@@ -260,7 +266,9 @@ fm_brief_strip_backticked_names() {
 }
 
 fm_brief_count_wait_mentions() {
-  local remaining=${1,,} match
+  local remaining match
+  fm_brief_lowercase "$1"
+  remaining=$FM_BRIEF_LOWERCASE
   FM_BRIEF_WAIT_MENTIONS=0
   while [[ $remaining =~ (^|[^a-z])a?wait(s|ed|ing)?([^a-z]|$) ]]; do
     match=${BASH_REMATCH[0]}

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -231,19 +231,27 @@ fm_brief_wait_is_bounded() {
 }
 
 fm_brief_strip_backticked_names() {
-  local remaining=$1 result='' token normalized suffix
-  # shellcheck disable=SC2016 # Backticks in the expression are literal evidence delimiters.
-  local backtick_re='^([^`]*)`([^`[:space:]]*)`(.*)$'
-  while [[ $remaining =~ $backtick_re ]]; do
-    result+=${BASH_REMATCH[1]}
-    token=${BASH_REMATCH[2]}
-    suffix=${BASH_REMATCH[3]}
-    fm_brief_trim_surrounding_punctuation "$token"
-    normalized=${FM_BRIEF_NORMALIZED,,}
-    if [[ $normalized =~ ^a?wait(s|ed|ing)?$ ]]; then
-      result+=$token
+  local remaining=$1 result='' prefix after token normalized
+  while [[ $remaining == *\`* ]]; do
+    prefix=${remaining%%\`*}
+    after=${remaining#*\`}
+    if [[ $after != *\`* ]]; then
+      result+=$remaining
+      remaining=
+      break
     fi
-    remaining=$suffix
+    token=${after%%\`*}
+    remaining=${after#*\`}
+    result+=$prefix
+    if [[ $token == *[[:space:]]* ]]; then
+      result+="\`$token\`"
+    else
+      fm_brief_trim_surrounding_punctuation "$token"
+      normalized=${FM_BRIEF_NORMALIZED,,}
+      if [[ $normalized =~ ^a?wait(s|ed|ing)?$ ]]; then
+        result+=$token
+      fi
+    fi
   done
   printf '%s' "$result$remaining"
 }

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -40,6 +40,18 @@
 # "Delivery contract: mode=<mode>" line. bin/fm-spawn.sh reads that line and refuses
 # to launch a ship task whose explicit --mode disagrees, so an adjusted brief and the
 # recorded task metadata cannot drift apart.
+# Ship briefs may earn exemption from the later Sol spec stage only when the filled
+# task text (FM_TASK at scaffold time) carries auditable evidence: exactly one
+#   Acceptance command: `...`
+# line naming a concrete executable command, and every wait mention is expressed as a
+#   Wait: ... bound=... escape=...
+# line. Without both, a filled ship task refuses to scaffold. An unfilled {TASK}
+# placeholder skips this gate and emits no exemption line. When evidence passes,
+# the brief records a fixed machine-readable "Sol exemption: earned" line (read by
+# later spawn/Sol stages) and a scaffold-owned "# Sol exemption evidence" block
+# echoing the acceptance command and any bounded Wait: lines.
+#   Set FM_TASK='<filled task>' to scaffold a ship brief with its task section
+#   already filled and to run the exemption gate.
 # Ship briefs begin with a worktree-isolation assertion before the branch step.
 # --mode is refused on scout and secondmate scaffolds: a scout's deliverable is a
 # report rather than a merge, and a charter is not a delivery contract.
@@ -177,6 +189,67 @@ shell_quote() {
   printf "'"
   printf '%s' "$1" | sed "s/'/'\\\\''/g"
   printf "'"
+}
+
+# Ship Sol-exemption evidence is mechanical: one acceptance-command line and every
+# wait mention bounded with an escape. Prints each missing requirement on stdout;
+# returns 0 only when the text qualifies.
+fm_brief_sol_exemption_errors() {
+  local text=$1
+  local errors=() acc_lines acc_count line saw_unbounded=0
+  # shellcheck disable=SC2016 # Backticks in the grep pattern are literal evidence syntax.
+  acc_lines=$(printf '%s\n' "$text" | grep -E '^Acceptance command: `[^`]+`' || true)
+  acc_count=0
+  if [ -n "$acc_lines" ]; then
+    acc_count=$(printf '%s\n' "$acc_lines" | grep -c . || true)
+  fi
+  if [ "$acc_count" -ne 1 ]; then
+    # shellcheck disable=SC2016 # Backticks in the message document the required syntax.
+    errors+=('missing exactly one Acceptance command: `...` line')
+  fi
+  while IFS= read -r line || [ -n "$line" ]; do
+    [ -z "$line" ] && continue
+    case "$line" in
+      'Acceptance command: '*)
+        case "$line" in
+          Acceptance\ command:\ \`*) ;;
+          *) errors+=('Acceptance command must use backticks around the command') ;;
+        esac
+        ;;
+      Wait:*)
+        case "$line" in
+          Wait:\ *bound=*escape=*|Wait:\ *escape=*bound=*)
+            ;;
+          *)
+            errors+=('Wait: lines must include both bound=... and escape=...')
+            ;;
+        esac
+        ;;
+      *)
+        if [ "$saw_unbounded" -eq 0 ] \
+           && printf '%s\n' "$line" | grep -qiE '(^|[^a-z])wait([^a-z]|$)'; then
+          errors+=('unbounded wait mention requires a Wait: line with bound= and escape=')
+          saw_unbounded=1
+        fi
+        ;;
+    esac
+  done <<EOF
+$text
+EOF
+  if [ "${#errors[@]}" -gt 0 ]; then
+    printf '%s\n' "${errors[@]}" | sort -u
+    return 1
+  fi
+  return 0
+}
+
+fm_brief_sol_evidence_block() {
+  local text=$1
+  local block
+  # shellcheck disable=SC2016 # Backticks in the grep pattern are literal evidence syntax.
+  block=$(printf '%s\n' "$text" | grep -E '^(Acceptance command: `[^`]+`|Wait: .+)$' || true)
+  [ -n "$block" ] || return 1
+  printf '%s\n' '# Sol exemption evidence' "$block"
 }
 
 STATUS_FILE=$(shell_quote "$STATE/$ID.status")
@@ -374,6 +447,20 @@ fi
 # delivery mode, validated above. The generated DOD opens with the fixed
 # "Delivery contract: mode=<mode>" line that bin/fm-spawn.sh checks against its own
 # explicit --mode before launching.
+SHIP_TASK_BODY='{TASK}'
+SOL_EXEMPTION_BLOCK=
+SOL_EXEMPTION_LINE=
+if [ -n "${FM_TASK:-}" ]; then
+  SHIP_TASK_BODY=$FM_TASK
+  missing=$(fm_brief_sol_exemption_errors "$SHIP_TASK_BODY" || true)
+  if [ -n "$missing" ]; then
+    echo "error: ship brief cannot earn Sol exemption without auditable evidence:" >&2
+    printf '%s\n' "$missing" | sed 's/^/  - /' >&2
+    exit 1
+  fi
+  SOL_EXEMPTION_LINE='Sol exemption: earned'
+  SOL_EXEMPTION_BLOCK=$(fm_brief_sol_evidence_block "$SHIP_TASK_BODY")
+fi
 case "$MODE" in
   direct-PR)
     SETUP2=""
@@ -431,13 +518,20 @@ esac
 # $(...) command substitution used to strip. Drop that one newline so generated
 # briefs stay byte-identical to the historical Bash 5 output.
 DOD=${DOD%$'\n'}
+if [ -n "$SOL_EXEMPTION_LINE" ]; then
+  DOD=$(printf '%s\n' "$DOD" | awk '
+    /^Delivery contract: mode=/ { print; print "Sol exemption: earned"; next }
+    { print }
+  ')
+fi
 
 cat > "$BRIEF" <<EOF
 You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.
 
 # Task
-{TASK}
+$SHIP_TASK_BODY
 
+$SOL_EXEMPTION_BLOCK
 $HERDR_SECTION
 
 # Setup
@@ -486,4 +580,8 @@ Keep it proportionate: skip \`AGENTS.md\` edits for trivial tasks that produced 
 
 $DOD
 EOF
-echo "scaffolded: $BRIEF (ship, mode=$MODE; replace {TASK})"
+if [ -n "${FM_TASK:-}" ]; then
+  echo "scaffolded: $BRIEF (ship, mode=$MODE; Sol exemption earned)"
+else
+  echo "scaffolded: $BRIEF (ship, mode=$MODE; replace {TASK})"
+fi

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -49,13 +49,13 @@
 #   Wait: ... bound=... escape=...
 # line whose bound= and escape= both carry a non-empty value. The wait scan covers
 # the whole wait word family (wait/waits/waited/waiting/await/awaits/awaiting) and
-# ignores backticked spans, so `wait-for-ci.sh` reads as a command name rather than
-# as an unbounded wait. Without both kinds of evidence, a filled ship task refuses
-# to scaffold and writes nothing. An unfilled {TASK} placeholder skips this gate and
-# emits no exemption line. When evidence passes, the brief records a fixed
-# machine-readable "Sol exemption: earned" line (read by later spawn/Sol stages) and
-# a scaffold-owned "# Sol exemption evidence" block echoing the acceptance command
-# and any bounded Wait: lines.
+# ignores whitespace-free backticked command or token names, so `wait-for-ci.sh`
+# does not read as an unbounded wait while backticked prose still does. Without both
+# kinds of evidence, a filled ship task refuses to scaffold and writes nothing. An
+# unfilled {TASK} placeholder skips this gate and emits no exemption line. When
+# evidence passes, the brief records a fixed machine-readable "Sol exemption: earned"
+# line for later stage consumption and a scaffold-owned "# Sol exemption evidence"
+# block echoing the acceptance command and any bounded Wait: lines.
 #   Set FM_TASK='<filled task>' to scaffold a ship brief with its task section
 #   already filled and to run the exemption gate. FM_TASK is refused on --scout and
 #   --secondmate scaffolds: they are outside the Sol exemption contract, and a

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -300,6 +300,7 @@ fm_brief_shift_shell_word() {
 
 fm_brief_acceptance_is_executable() {
   local line=$1 command first remaining
+  local substitution_assignment_re='^[[:alpha:]_][[:alnum:]_]*=.*\$\(.+\)[^[:space:]]*[[:space:]]+(.+)$'
   case "$line" in
     Acceptance\ command:\ \`?*\`*) ;;
     *) return 1 ;;
@@ -313,6 +314,13 @@ fm_brief_acceptance_is_executable() {
   bash -n -c "$command" >/dev/null 2>&1 || return 1
   remaining=$command
   while :; do
+    if [[ $remaining =~ $substitution_assignment_re ]]; then
+      remaining=${BASH_REMATCH[1]}
+      continue
+    fi
+    if [[ $remaining =~ ^[[:alpha:]_][[:alnum:]_]*=.*\$\( ]]; then
+      return 1
+    fi
     fm_brief_shift_shell_word "$remaining"
     first=$FM_BRIEF_SHELL_WORD
     if [[ $first =~ ^[[:alpha:]_][[:alnum:]_]*=.*$ ]]; then

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -208,13 +208,17 @@ fm_brief_trim_surrounding_punctuation() {
 }
 
 fm_brief_wait_is_bounded() {
-  local line=$1 field value normalized
+  local line=$1 field value normalized field_tail
   for field in bound escape; do
     case "$line" in
       *[[:space:]]"$field="*) ;;
       *) return 1 ;;
     esac
-    value=${line#*[[:space:]]"$field="}
+    field_tail=${line#*[[:space:]]"$field="}
+    case "$field_tail" in
+      *[[:space:]]"$field="*) return 1 ;;
+    esac
+    value=$field_tail
     value=${value%%[[:space:]]*}
     [ -n "$value" ] || return 1
     case "$value" in
@@ -359,7 +363,9 @@ EOF
 SHIP_TASK_BODY='{TASK}'
 SOL_EXEMPTION_BLOCK=
 SOL_EXEMPTION_LINE=
-if [ -n "${FM_TASK:-}" ]; then
+FM_TASK_IS_SET=0
+[ "${FM_TASK+x}" = x ] && FM_TASK_IS_SET=1
+if [ "$FM_TASK_IS_SET" -eq 1 ]; then
   [ "$KIND" = ship ] || {
     echo "error: FM_TASK applies only to ship briefs; a scout report and a secondmate charter carry no Sol exemption, so fill their {TASK} section by hand" >&2
     exit 1
@@ -514,7 +520,7 @@ HERDR_SECTION=$(printf '%s\n' \
 'Never bypass the helper, even for a read-only lifecycle probe or cleanup after failure.' \
 'The captain fleet uses the running `default` session.')
 else
-if [ -n "${FM_TASK:-}" ]; then
+if [ "$FM_TASK_IS_SET" -eq 1 ]; then
   HERDR_GATE_LINE='**HARD SAFETY GATE:** this scaffold never inspects the task text above for Herdr lifecycle intent.'
 else
   HERDR_GATE_LINE='**HARD SAFETY GATE:** this scaffold cannot inspect the task text filled in above.'
@@ -701,7 +707,7 @@ Keep it proportionate: skip \`AGENTS.md\` edits for trivial tasks that produced 
 
 $DOD
 EOF
-if [ -n "${FM_TASK:-}" ]; then
+if [ "$FM_TASK_IS_SET" -eq 1 ]; then
   echo "scaffolded: $BRIEF (ship, mode=$MODE; Sol exemption earned)"
 else
   echo "scaffolded: $BRIEF (ship, mode=$MODE; replace {TASK})"

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -214,17 +214,23 @@ fm_brief_wait_is_bounded() {
 }
 
 fm_brief_acceptance_is_executable() {
-  local line=$1 command
+  local line=$1 command first
   case "$line" in
     Acceptance\ command:\ \`?*\`*) ;;
     *) return 1 ;;
   esac
   command=${line#Acceptance command: \`}
   command=${command%%\`*}
+  command=${command#"${command%%[![:space:]]*}"}
   case "$command" in
-    *[[:alnum:]_]*) return 0 ;;
-    *) return 1 ;;
+    ''|\#*) return 1 ;;
   esac
+  first=${command%%[[:space:]]*}
+  case "$first" in
+    ''|*=*|*[![:alnum:]_./-]*) return 1 ;;
+  esac
+  bash -n -c "$command" >/dev/null 2>&1 || return 1
+  return 0
 }
 
 # Scaffold-owned machine-readable lines. A filled task body that forges one would

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -24,9 +24,11 @@
 #   Set FM_SECONDMATE_SCOPE='<scope>' to write a routing scope distinct from the charter text.
 #   --herdr-lab is mandatory when the task will issue Herdr lifecycle commands.
 #   It adds the hard isolation contract backed by bin/fm-herdr-lab.sh.
-#   The flag must be explicit because {TASK} is filled after scaffolding and the
-#   caller-supplied repo string cannot reliably identify this repo. Briefs made
-#   without it carry a loud declaration so an omitted contract cannot be silent.
+#   The flag must be explicit because no scaffold path ever inspects the task text
+#   for Herdr lifecycle intent - the FM_TASK scan below reads acceptance and wait
+#   evidence only - and the caller-supplied repo string cannot reliably identify
+#   this repo. Briefs made without it carry a loud declaration so an omitted
+#   contract cannot be silent.
 # For ship tasks, --mode is REQUIRED and shapes the definition of done. Firstmate
 # resolves it per task at intake (AGENTS.md section 7); data/projects.md holds the
 # captain's standing posture as context, and this script never reads it:
@@ -211,22 +213,14 @@ fm_brief_wait_is_bounded() {
   return 0
 }
 
-# One acceptance-command line, and every wait mention bounded with an escape.
-# One walk classifies every line, so the validator and the auditable evidence block
-# can never disagree about what counts as evidence. Fills FM_BRIEF_SOL_ERRORS and
-# FM_BRIEF_SOL_EVIDENCE; returns 0 only when the text qualifies.
-fm_brief_sol_line_kind() {
-  FM_BRIEF_SOL_KIND=
-  case "$1" in
-    'Acceptance command: '*) FM_BRIEF_SOL_KIND=acceptance ;;
-    Wait:*) FM_BRIEF_SOL_KIND='wait' ;;
-  esac
-}
-
 # Scaffold-owned machine-readable lines. A filled task body that forges one would
 # be read back by bin/fm-spawn.sh ahead of the line this scaffold actually wrote.
 FM_BRIEF_RESERVED_PREFIXES=('Delivery contract:' 'Sol exemption:')
 
+# One acceptance-command line, and every wait mention bounded with an escape.
+# One walk classifies every line, so the validator and the auditable evidence block
+# can never disagree about what counts as evidence. Fills FM_BRIEF_SOL_ERRORS and
+# FM_BRIEF_SOL_EVIDENCE; returns 0 only when the text qualifies.
 fm_brief_sol_scan() {
   local text=$1
   local line prose prefix acc_count=0 saw_unbounded=0
@@ -241,25 +235,25 @@ fm_brief_sol_scan() {
           ;;
       esac
     done
-    fm_brief_sol_line_kind "$line"
-    case "$FM_BRIEF_SOL_KIND" in
-      acceptance)
+    case "$line" in
+      'Acceptance command: '*)
         case "$line" in
           Acceptance\ command:\ \`?*\`*) acc_count=$((acc_count + 1)) ;;
           *) FM_BRIEF_SOL_ERRORS+=('Acceptance command must use backticks around the command') ;;
         esac
         FM_BRIEF_SOL_EVIDENCE+=("$line")
         ;;
-      wait)
+      Wait:*)
         fm_brief_wait_is_bounded "$line" \
           || FM_BRIEF_SOL_ERRORS+=('Wait: lines must include non-empty bound=... and escape=... values')
         FM_BRIEF_SOL_EVIDENCE+=("$line")
         ;;
       *)
-        # Backticked spans are literal code, not prose: `wait-for-ci.sh` names a
-        # command, so scanning them would refuse legitimate ship tasks.
+        # A whitespace-free backticked span is a command or token name, not prose:
+        # `wait-for-ci.sh` must not read as a wait. A span containing whitespace is
+        # prose and stays in the scan, so `wait for review` cannot hide there.
         # shellcheck disable=SC2016 # Backticks in the sed script are literal evidence syntax.
-        prose=$(printf '%s' "$line" | sed 's/`[^`]*`//g')
+        prose=$(printf '%s' "$line" | sed 's/`[^`[:space:]]*`//g')
         if [ "$saw_unbounded" -eq 0 ] \
            && printf '%s\n' "$prose" | grep -qiE '(^|[^a-z])a?wait(s|ed|ing)?([^a-z]|$)'; then
           FM_BRIEF_SOL_ERRORS+=('unbounded wait mention requires a Wait: line with bound= and escape=')
@@ -270,9 +264,11 @@ fm_brief_sol_scan() {
   done <<EOF
 $text
 EOF
-  if [ "$acc_count" -ne 1 ]; then
+  if [ "$acc_count" -eq 0 ]; then
     # shellcheck disable=SC2016 # Backticks in the message document the required syntax.
     FM_BRIEF_SOL_ERRORS+=('missing exactly one Acceptance command: `...` line')
+  elif [ "$acc_count" -gt 1 ]; then
+    FM_BRIEF_SOL_ERRORS+=("found $acc_count Acceptance command lines; keep exactly one")
   fi
   [ "${#FM_BRIEF_SOL_ERRORS[@]}" -eq 0 ]
 }
@@ -439,13 +435,17 @@ HERDR_SECTION=$(printf '%s\n' \
 'Never bypass the helper, even for a read-only lifecycle probe or cleanup after failure.' \
 'The captain fleet uses the running `default` session.')
 else
-IFS= read -r -d '' HERDR_SECTION <<'EOF' || true
-# Herdr lifecycle declaration - NOT ENABLED
-**HARD SAFETY GATE:** this scaffold cannot inspect the task text filled in above.
-If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
-Do not add Herdr lifecycle commands to this unguarded brief by hand.
-EOF
-HERDR_SECTION=${HERDR_SECTION%$'\n'}
+if [ -n "${FM_TASK:-}" ]; then
+  HERDR_GATE_LINE='**HARD SAFETY GATE:** this scaffold never inspects the task text above for Herdr lifecycle intent.'
+else
+  HERDR_GATE_LINE='**HARD SAFETY GATE:** this scaffold cannot inspect the task text filled in above.'
+fi
+# shellcheck disable=SC2016  # single quotes are deliberate: the backtick-wrapped `--herdr-lab` is literal brief text that must reach the reading agent verbatim.
+HERDR_SECTION=$(printf '%s\n' \
+'# Herdr lifecycle declaration - NOT ENABLED' \
+"$HERDR_GATE_LINE" \
+'If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.' \
+'Do not add Herdr lifecycle commands to this unguarded brief by hand.')
 fi
 
 if [ "$KIND" = scout ]; then
@@ -562,8 +562,8 @@ esac
 # briefs stay byte-identical to the historical Bash 5 output.
 DOD=${DOD%$'\n'}
 if [ -n "$SOL_EXEMPTION_LINE" ]; then
-  DOD=$(printf '%s\n' "$DOD" | awk '
-    /^Delivery contract: mode=/ { print; print "Sol exemption: earned"; next }
+  DOD=$(printf '%s\n' "$DOD" | awk -v exemption="$SOL_EXEMPTION_LINE" '
+    /^Delivery contract: mode=/ { print; print exemption; next }
     { print }
   ')
 fi

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -269,6 +269,35 @@ fm_brief_count_wait_mentions() {
   done
 }
 
+fm_brief_shift_shell_word() {
+  local input=$1 length=${#1} i=0 char quote='' escaped=0
+  FM_BRIEF_SHELL_WORD=
+  while [ "$i" -lt "$length" ]; do
+    char=${input:i:1}
+    if [ "$escaped" -eq 1 ]; then
+      escaped=0
+    elif [ "$quote" = "'" ]; then
+      [ "$char" = "'" ] && quote=
+    elif [ "$quote" = '"' ]; then
+      case "$char" in
+        '"') quote= ;;
+        \\) escaped=1 ;;
+      esac
+    else
+      case "$char" in
+        [[:space:]]) break ;;
+        "'") quote="'" ;;
+        '"') quote='"' ;;
+        \\) escaped=1 ;;
+      esac
+    fi
+    FM_BRIEF_SHELL_WORD+=$char
+    i=$((i + 1))
+  done
+  FM_BRIEF_SHELL_REMAINDER=${input:i}
+  FM_BRIEF_SHELL_REMAINDER=${FM_BRIEF_SHELL_REMAINDER#"${FM_BRIEF_SHELL_REMAINDER%%[![:space:]]*}"}
+}
+
 fm_brief_acceptance_is_executable() {
   local line=$1 command first remaining
   case "$line" in
@@ -281,13 +310,14 @@ fm_brief_acceptance_is_executable() {
   case "$command" in
     ''|\#*) return 1 ;;
   esac
+  bash -n -c "$command" >/dev/null 2>&1 || return 1
   remaining=$command
   while :; do
-    first=${remaining%%[[:space:]]*}
+    fm_brief_shift_shell_word "$remaining"
+    first=$FM_BRIEF_SHELL_WORD
     if [[ $first =~ ^[[:alpha:]_][[:alnum:]_]*=.*$ ]]; then
-      [ "$remaining" != "$first" ] || return 1
-      remaining=${remaining#"$first"}
-      remaining=${remaining#"${remaining%%[![:space:]]*}"}
+      [ -n "$FM_BRIEF_SHELL_REMAINDER" ] || return 1
+      remaining=$FM_BRIEF_SHELL_REMAINDER
       continue
     fi
     break
@@ -295,7 +325,10 @@ fm_brief_acceptance_is_executable() {
   case "$first" in
     ''|*[![:alnum:]_./-]*) return 1 ;;
   esac
-  bash -n -c "$command" >/dev/null 2>&1 || return 1
+  case "$first" in
+    *[[:alnum:]_]*) ;;
+    *) return 1 ;;
+  esac
   return 0
 }
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -208,16 +208,15 @@ fm_brief_trim_surrounding_punctuation() {
 }
 
 fm_brief_wait_is_bounded() {
-  local line=$1 field value normalized field_tail
+  local line=$1 field value normalized field_tail duplicate_re
   for field in bound escape; do
     case "$line" in
       *[[:space:]]"$field="*) ;;
       *) return 1 ;;
     esac
     field_tail=${line#*[[:space:]]"$field="}
-    case "$field_tail" in
-      *[[:space:]]"$field="*) return 1 ;;
-    esac
+    duplicate_re="(^|[^[:alnum:]_])${field}="
+    [[ $field_tail =~ $duplicate_re ]] && return 1
     value=$field_tail
     value=${value%%[[:space:]]*}
     [ -n "$value" ] || return 1
@@ -271,7 +270,7 @@ fm_brief_count_wait_mentions() {
 }
 
 fm_brief_acceptance_is_executable() {
-  local line=$1 command first
+  local line=$1 command first remaining
   case "$line" in
     Acceptance\ command:\ \`?*\`*) ;;
     *) return 1 ;;
@@ -282,9 +281,19 @@ fm_brief_acceptance_is_executable() {
   case "$command" in
     ''|\#*) return 1 ;;
   esac
-  first=${command%%[[:space:]]*}
+  remaining=$command
+  while :; do
+    first=${remaining%%[[:space:]]*}
+    if [[ $first =~ ^[[:alpha:]_][[:alnum:]_]*=.*$ ]]; then
+      [ "$remaining" != "$first" ] || return 1
+      remaining=${remaining#"$first"}
+      remaining=${remaining#"${remaining%%[![:space:]]*}"}
+      continue
+    fi
+    break
+  done
   case "$first" in
-    ''|*=*|*[![:alnum:]_./-]*) return 1 ;;
+    ''|*[![:alnum:]_./-]*) return 1 ;;
   esac
   bash -n -c "$command" >/dev/null 2>&1 || return 1
   return 0

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -255,6 +255,7 @@ fm_brief_sol_scan() {
           ;;
       esac
     done
+    prose=$line
     case "$line" in
       'Acceptance command: '*)
         if fm_brief_acceptance_is_executable "$line"; then
@@ -263,11 +264,18 @@ fm_brief_sol_scan() {
           FM_BRIEF_SOL_ERRORS+=('Acceptance command must use backticks around a concrete executable command')
         fi
         FM_BRIEF_SOL_EVIDENCE+=("$line")
+        case "$line" in
+          Acceptance\ command:\ \`*\`*)
+            prose=${line#Acceptance command: \`}
+            prose=${prose#*\`}
+            ;;
+        esac
         ;;
       Wait:*)
         fm_brief_wait_is_bounded "$line" \
           || FM_BRIEF_SOL_ERRORS+=('Wait: lines must include non-empty bound=... and escape=... values')
         FM_BRIEF_SOL_EVIDENCE+=("$line")
+        prose=
         ;;
       *)
         # A whitespace-free backticked span is a command or token name, not prose:
@@ -275,13 +283,13 @@ fm_brief_sol_scan() {
         # prose and stays in the scan, so `wait for review` cannot hide there.
         # shellcheck disable=SC2016 # Backticks in the sed script are literal evidence syntax.
         prose=$(printf '%s' "$line" | sed 's/`[^`[:space:]]*`//g')
-        if [ "$saw_unbounded" -eq 0 ] \
-           && printf '%s\n' "$prose" | grep -qiE '(^|[^a-z])a?wait(s|ed|ing)?([^a-z]|$)'; then
-          FM_BRIEF_SOL_ERRORS+=('unbounded wait mention requires a Wait: line with bound= and escape=')
-          saw_unbounded=1
-        fi
         ;;
     esac
+    if [ "$saw_unbounded" -eq 0 ] \
+       && printf '%s\n' "$prose" | grep -qiE '(^|[^a-z])a?wait(s|ed|ing)?([^a-z]|$)'; then
+      FM_BRIEF_SOL_ERRORS+=('unbounded wait mention requires a Wait: line with bound= and escape=')
+      saw_unbounded=1
+    fi
   done <<EOF
 $text
 EOF

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -317,12 +317,7 @@ fm_brief_sol_scan() {
           FM_BRIEF_SOL_ERRORS+=('Acceptance command must use backticks around a concrete executable command')
         fi
         FM_BRIEF_SOL_EVIDENCE+=("$line")
-        case "$line" in
-          Acceptance\ command:\ \`*\`*)
-            prose=${line#Acceptance command: \`}
-            prose=${prose#*\`}
-            ;;
-        esac
+        prose=$(fm_brief_strip_backticked_names "$line")
         ;;
       Wait:*)
         fm_brief_wait_is_bounded "$line" \

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -197,6 +197,16 @@ fi
 # Ship Sol-exemption evidence is mechanical. A Wait: line is bounded only when it
 # carries non-empty, non-vacuous bound= and escape= values; a value that is just
 # the other key (bound=escape=...) is not a bound.
+fm_brief_trim_surrounding_punctuation() {
+  FM_BRIEF_NORMALIZED=$1
+  while [[ $FM_BRIEF_NORMALIZED == [[:punct:]]* ]]; do
+    FM_BRIEF_NORMALIZED=${FM_BRIEF_NORMALIZED#?}
+  done
+  while [[ $FM_BRIEF_NORMALIZED == *[[:punct:]] ]]; do
+    FM_BRIEF_NORMALIZED=${FM_BRIEF_NORMALIZED%?}
+  done
+}
+
 fm_brief_wait_is_bounded() {
   local line=$1 field value normalized
   for field in bound escape; do
@@ -210,7 +220,9 @@ fm_brief_wait_is_bounded() {
     case "$value" in
       bound=*|escape=*) return 1 ;;
     esac
-    normalized=${value,,}
+    fm_brief_trim_surrounding_punctuation "$value"
+    normalized=${FM_BRIEF_NORMALIZED,,}
+    [ -n "$normalized" ] || return 1
     case "$normalized" in
       forever|none|unbounded|never|n/a|infinite|inf) return 1 ;;
     esac
@@ -226,7 +238,8 @@ fm_brief_strip_backticked_names() {
     result+=${BASH_REMATCH[1]}
     token=${BASH_REMATCH[2]}
     suffix=${BASH_REMATCH[3]}
-    normalized=${token,,}
+    fm_brief_trim_surrounding_punctuation "$token"
+    normalized=${FM_BRIEF_NORMALIZED,,}
     if [[ $normalized =~ ^a?wait(s|ed|ing)?$ ]]; then
       result+=$token
     fi

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -47,10 +47,11 @@
 #   Acceptance command: `...`
 # line naming a concrete executable command, and every wait mention is expressed as a
 #   Wait: ... bound=... escape=...
-# line whose bound= and escape= both carry a non-empty value. The wait scan covers
+# line whose bound= and escape= both carry a non-empty, non-vacuous value. The wait scan covers
 # the whole wait word family (wait/waits/waited/waiting/await/awaits/awaiting) and
 # ignores whitespace-free backticked command or token names, so `wait-for-ci.sh`
-# does not read as an unbounded wait while backticked prose still does. Without both
+# does not read as an unbounded wait while an exact backticked wait-family token
+# still does. Without both
 # kinds of evidence, a filled ship task refuses to scaffold and writes nothing. An
 # unfilled {TASK} placeholder skips this gate and emits no exemption line. When
 # evidence passes, the brief records a fixed machine-readable "Sol exemption: earned"
@@ -194,10 +195,10 @@ if [ "$NO_PROJECTS" -eq 1 ] && [ "$KIND" != secondmate ]; then
 fi
 
 # Ship Sol-exemption evidence is mechanical. A Wait: line is bounded only when it
-# carries non-empty bound= and escape= values; a value that is just the other key
-# (bound=escape=...) is not a bound.
+# carries non-empty, non-vacuous bound= and escape= values; a value that is just
+# the other key (bound=escape=...) is not a bound.
 fm_brief_wait_is_bounded() {
-  local line=$1 field value
+  local line=$1 field value normalized
   for field in bound escape; do
     case "$line" in
       *[[:space:]]"$field="*) ;;
@@ -209,8 +210,29 @@ fm_brief_wait_is_bounded() {
     case "$value" in
       bound=*|escape=*) return 1 ;;
     esac
+    normalized=${value,,}
+    case "$normalized" in
+      forever|none|unbounded|never|n/a|infinite|inf) return 1 ;;
+    esac
   done
   return 0
+}
+
+fm_brief_strip_backticked_names() {
+  local remaining=$1 result='' token normalized suffix
+  # shellcheck disable=SC2016 # Backticks in the expression are literal evidence delimiters.
+  local backtick_re='^([^`]*)`([^`[:space:]]*)`(.*)$'
+  while [[ $remaining =~ $backtick_re ]]; do
+    result+=${BASH_REMATCH[1]}
+    token=${BASH_REMATCH[2]}
+    suffix=${BASH_REMATCH[3]}
+    normalized=${token,,}
+    if [[ $normalized =~ ^a?wait(s|ed|ing)?$ ]]; then
+      result+=$token
+    fi
+    remaining=$suffix
+  done
+  printf '%s' "$result$remaining"
 }
 
 fm_brief_acceptance_is_executable() {
@@ -278,11 +300,9 @@ fm_brief_sol_scan() {
         prose=
         ;;
       *)
-        # A whitespace-free backticked span is a command or token name, not prose:
-        # `wait-for-ci.sh` must not read as a wait. A span containing whitespace is
-        # prose and stays in the scan, so `wait for review` cannot hide there.
-        # shellcheck disable=SC2016 # Backticks in the sed script are literal evidence syntax.
-        prose=$(printf '%s' "$line" | sed 's/`[^`[:space:]]*`//g')
+        # A whitespace-free backticked command name is not prose, but an exact
+        # wait-family token remains visible to the wait scan.
+        prose=$(fm_brief_strip_backticked_names "$line")
         ;;
     esac
     if [ "$saw_unbounded" -eq 0 ] \

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -213,6 +213,20 @@ fm_brief_wait_is_bounded() {
   return 0
 }
 
+fm_brief_acceptance_is_executable() {
+  local line=$1 command
+  case "$line" in
+    Acceptance\ command:\ \`?*\`*) ;;
+    *) return 1 ;;
+  esac
+  command=${line#Acceptance command: \`}
+  command=${command%%\`*}
+  case "$command" in
+    *[[:alnum:]_]*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 # Scaffold-owned machine-readable lines. A filled task body that forges one would
 # be read back by bin/fm-spawn.sh ahead of the line this scaffold actually wrote.
 FM_BRIEF_RESERVED_PREFIXES=('Delivery contract:' 'Sol exemption:')
@@ -237,10 +251,11 @@ fm_brief_sol_scan() {
     done
     case "$line" in
       'Acceptance command: '*)
-        case "$line" in
-          Acceptance\ command:\ \`?*\`*) acc_count=$((acc_count + 1)) ;;
-          *) FM_BRIEF_SOL_ERRORS+=('Acceptance command must use backticks around the command') ;;
-        esac
+        if fm_brief_acceptance_is_executable "$line"; then
+          acc_count=$((acc_count + 1))
+        else
+          FM_BRIEF_SOL_ERRORS+=('Acceptance command must use backticks around a concrete executable command')
+        fi
         FM_BRIEF_SOL_EVIDENCE+=("$line")
         ;;
       Wait:*)

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -45,13 +45,19 @@
 #   Acceptance command: `...`
 # line naming a concrete executable command, and every wait mention is expressed as a
 #   Wait: ... bound=... escape=...
-# line. Without both, a filled ship task refuses to scaffold. An unfilled {TASK}
-# placeholder skips this gate and emits no exemption line. When evidence passes,
-# the brief records a fixed machine-readable "Sol exemption: earned" line (read by
-# later spawn/Sol stages) and a scaffold-owned "# Sol exemption evidence" block
-# echoing the acceptance command and any bounded Wait: lines.
+# line whose bound= and escape= both carry a non-empty value. The wait scan covers
+# the whole wait word family (wait/waits/waited/waiting/await/awaits/awaiting) and
+# ignores backticked spans, so `wait-for-ci.sh` reads as a command name rather than
+# as an unbounded wait. Without both kinds of evidence, a filled ship task refuses
+# to scaffold and writes nothing. An unfilled {TASK} placeholder skips this gate and
+# emits no exemption line. When evidence passes, the brief records a fixed
+# machine-readable "Sol exemption: earned" line (read by later spawn/Sol stages) and
+# a scaffold-owned "# Sol exemption evidence" block echoing the acceptance command
+# and any bounded Wait: lines.
 #   Set FM_TASK='<filled task>' to scaffold a ship brief with its task section
-#   already filled and to run the exemption gate.
+#   already filled and to run the exemption gate. FM_TASK is refused on --scout and
+#   --secondmate scaffolds: they are outside the Sol exemption contract, and a
+#   silently dropped task body would be believed recorded.
 # Ship briefs begin with a worktree-isolation assertion before the branch step.
 # --mode is refused on scout and secondmate scaffolds: a scout's deliverable is a
 # report rather than a merge, and a charter is not a delivery contract.
@@ -181,22 +187,31 @@ if [ "$NO_PROJECTS" -eq 1 ] && [ "$KIND" != secondmate ]; then
   exit 1
 fi
 
-BRIEF="$DATA/$ID/brief.md"
-[ -e "$BRIEF" ] && { echo "error: $BRIEF already exists" >&2; exit 1; }
-mkdir -p "$DATA/$ID"
-
-shell_quote() {
-  printf "'"
-  printf '%s' "$1" | sed "s/'/'\\\\''/g"
-  printf "'"
+# Ship Sol-exemption evidence is mechanical. A Wait: line is bounded only when it
+# carries non-empty bound= and escape= values; a value that is just the other key
+# (bound=escape=...) is not a bound.
+fm_brief_wait_is_bounded() {
+  local line=$1 field value
+  for field in bound escape; do
+    case "$line" in
+      *[[:space:]]"$field="*) ;;
+      *) return 1 ;;
+    esac
+    value=${line#*[[:space:]]"$field="}
+    value=${value%%[[:space:]]*}
+    [ -n "$value" ] || return 1
+    case "$value" in
+      bound=*|escape=*) return 1 ;;
+    esac
+  done
+  return 0
 }
 
-# Ship Sol-exemption evidence is mechanical: one acceptance-command line and every
-# wait mention bounded with an escape. Prints each missing requirement on stdout;
-# returns 0 only when the text qualifies.
+# One acceptance-command line, and every wait mention bounded with an escape.
+# Prints each missing requirement on stdout; returns 0 only when the text qualifies.
 fm_brief_sol_exemption_errors() {
   local text=$1
-  local errors=() acc_lines acc_count line saw_unbounded=0
+  local errors=() acc_lines acc_count line prose saw_unbounded=0
   # shellcheck disable=SC2016 # Backticks in the grep pattern are literal evidence syntax.
   acc_lines=$(printf '%s\n' "$text" | grep -E '^Acceptance command: `[^`]+`' || true)
   acc_count=0
@@ -217,17 +232,17 @@ fm_brief_sol_exemption_errors() {
         esac
         ;;
       Wait:*)
-        case "$line" in
-          Wait:\ *bound=*escape=*|Wait:\ *escape=*bound=*)
-            ;;
-          *)
-            errors+=('Wait: lines must include both bound=... and escape=...')
-            ;;
-        esac
+        if ! fm_brief_wait_is_bounded "$line"; then
+          errors+=('Wait: lines must include non-empty bound=... and escape=... values')
+        fi
         ;;
       *)
+        # Backticked spans are literal code, not prose: `wait-for-ci.sh` names a
+        # command, so scanning them would refuse legitimate ship tasks.
+        # shellcheck disable=SC2016 # Backticks in the sed script are literal evidence syntax.
+        prose=$(printf '%s' "$line" | sed 's/`[^`]*`//g')
         if [ "$saw_unbounded" -eq 0 ] \
-           && printf '%s\n' "$line" | grep -qiE '(^|[^a-z])wait([^a-z]|$)'; then
+           && printf '%s\n' "$prose" | grep -qiE '(^|[^a-z])a?wait(s|ed|ing)?([^a-z]|$)'; then
           errors+=('unbounded wait mention requires a Wait: line with bound= and escape=')
           saw_unbounded=1
         fi
@@ -250,6 +265,40 @@ fm_brief_sol_evidence_block() {
   block=$(printf '%s\n' "$text" | grep -E '^(Acceptance command: `[^`]+`|Wait: .+)$' || true)
   [ -n "$block" ] || return 1
   printf '%s\n' '# Sol exemption evidence' "$block"
+}
+
+# The exemption gate runs before anything is written, so a refused scaffold leaves
+# the data tree untouched. FM_TASK is a ship-only input: scout reports and
+# secondmate charters are outside the Sol exemption contract, so refuse it there
+# rather than silently dropping a task body the caller believes was recorded.
+SHIP_TASK_BODY='{TASK}'
+SOL_EXEMPTION_BLOCK=
+SOL_EXEMPTION_LINE=
+if [ -n "${FM_TASK:-}" ]; then
+  [ "$KIND" = ship ] || {
+    echo "error: FM_TASK applies only to ship briefs; a scout report and a secondmate charter carry no Sol exemption, so fill their {TASK} section by hand" >&2
+    exit 1
+  }
+  SHIP_TASK_BODY=$FM_TASK
+  missing=$(fm_brief_sol_exemption_errors "$SHIP_TASK_BODY" || true)
+  if [ -n "$missing" ]; then
+    echo "error: ship brief cannot earn Sol exemption without auditable evidence:" >&2
+    printf '%s\n' "$missing" | sed 's/^/  - /' >&2
+    exit 1
+  fi
+  SOL_EXEMPTION_LINE='Sol exemption: earned'
+  SOL_EXEMPTION_BLOCK=$(fm_brief_sol_evidence_block "$SHIP_TASK_BODY")
+  [ -z "$SOL_EXEMPTION_BLOCK" ] || SOL_EXEMPTION_BLOCK="$SOL_EXEMPTION_BLOCK"$'\n\n'
+fi
+
+BRIEF="$DATA/$ID/brief.md"
+[ -e "$BRIEF" ] && { echo "error: $BRIEF already exists" >&2; exit 1; }
+mkdir -p "$DATA/$ID"
+
+shell_quote() {
+  printf "'"
+  printf '%s' "$1" | sed "s/'/'\\\\''/g"
+  printf "'"
 }
 
 STATUS_FILE=$(shell_quote "$STATE/$ID.status")
@@ -447,20 +496,6 @@ fi
 # delivery mode, validated above. The generated DOD opens with the fixed
 # "Delivery contract: mode=<mode>" line that bin/fm-spawn.sh checks against its own
 # explicit --mode before launching.
-SHIP_TASK_BODY='{TASK}'
-SOL_EXEMPTION_BLOCK=
-SOL_EXEMPTION_LINE=
-if [ -n "${FM_TASK:-}" ]; then
-  SHIP_TASK_BODY=$FM_TASK
-  missing=$(fm_brief_sol_exemption_errors "$SHIP_TASK_BODY" || true)
-  if [ -n "$missing" ]; then
-    echo "error: ship brief cannot earn Sol exemption without auditable evidence:" >&2
-    printf '%s\n' "$missing" | sed 's/^/  - /' >&2
-    exit 1
-  fi
-  SOL_EXEMPTION_LINE='Sol exemption: earned'
-  SOL_EXEMPTION_BLOCK=$(fm_brief_sol_evidence_block "$SHIP_TASK_BODY")
-fi
 case "$MODE" in
   direct-PR)
     SETUP2=""
@@ -531,8 +566,7 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 # Task
 $SHIP_TASK_BODY
 
-$SOL_EXEMPTION_BLOCK
-$HERDR_SECTION
+$SOL_EXEMPTION_BLOCK$HERDR_SECTION
 
 # Setup
 You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -1083,6 +1083,35 @@ test_ship_sol_exemption_refuses_non_command_acceptance_payloads() {
   pass "fm-brief.sh: non-command acceptance payloads cannot earn Sol exemption"
 }
 
+test_ship_sol_exemption_scans_acceptance_command_waits() {
+  local home out status command i=0
+  for command in wait waits waited waiting await awaits awaiting; do
+    i=$((i + 1))
+    home="$TMP_ROOT/sol-acceptance-wait-home-$i"
+    mkdir -p "$home/data"
+    status=0
+    out=$(FM_HOME="$home" FM_TASK="Acceptance command: \`$command\`" \
+      "$ROOT/bin/fm-brief.sh" "sol-acceptance-wait-$i" firstmate --mode no-mistakes 2>&1) || status=$?
+    expect_code 1 "$status" "acceptance command with an exact wait token must refuse"
+    assert_contains "$out" "unbounded wait" \
+      "refusal must name the acceptance command's unbounded wait"
+    assert_absent "$home/data/sol-acceptance-wait-$i/brief.md" \
+      "refused acceptance-command wait must not write a brief"
+  done
+
+  home="$TMP_ROOT/sol-acceptance-wait-command-home"
+  mkdir -p "$home/data"
+  status=0
+  # shellcheck disable=SC2016 # Backticks in the task body are literal evidence syntax.
+  FM_HOME="$home" FM_TASK='Acceptance command: `wait-for-ci.sh`' \
+    "$ROOT/bin/fm-brief.sh" sol-acceptance-wait-command firstmate --mode no-mistakes \
+    >/dev/null 2>&1 || status=$?
+  expect_code 0 "$status" "ordinary acceptance command names containing wait must scaffold"
+  assert_present "$home/data/sol-acceptance-wait-command/brief.md" \
+    "ordinary acceptance command name did not produce a brief"
+  pass "fm-brief.sh: acceptance commands cannot hide exact wait tokens"
+}
+
 # The brief's machine-readable contract lines are scaffold-owned. bin/fm-spawn.sh
 # resolves the delivery mode from the FIRST such line, so a task body that forges
 # one would win over the mode this scaffold was given.
@@ -1276,6 +1305,7 @@ test_ship_sol_exemption_accepts_trailing_acceptance_text
 test_ship_sol_exemption_refuses_trailing_acceptance_wait
 test_ship_sol_exemption_refusals_are_never_silent
 test_ship_sol_exemption_refuses_non_command_acceptance_payloads
+test_ship_sol_exemption_scans_acceptance_command_waits
 test_fm_task_cannot_forge_scaffold_owned_contract_lines
 test_sol_evidence_block_records_every_validated_wait
 test_ship_sol_exemption_refuses_backticked_prose_wait

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -837,7 +837,8 @@ $wait_line" "$ROOT/bin/fm-brief.sh" "sol-bound-$i" firstmate --mode no-mistakes 
 
 test_ship_sol_exemption_refuses_vacuous_bound_and_escape() {
   local home out status value field wait_line i=0
-  for value in forever none unbounded never n/a infinite inf FoReVeR NONE; do
+  for value in forever none unbounded never n/a infinite inf FoReVeR NONE \
+               'forever,' '"none"' "'unbounded'" '(never)' '[n/a]' 'infinite;' 'inf.'; do
     for field in bound escape; do
       i=$((i + 1))
       home="$TMP_ROOT/sol-vacuous-home-$i"
@@ -868,7 +869,7 @@ test_ship_sol_exemption_ignores_backticked_command_names() {
   status=0
   # shellcheck disable=SC2016 # The task body is a literal fixture string.
   FM_HOME="$home" FM_TASK='Acceptance command: `make test`
-Run `wait-for-ci.sh` as part of setup, then land `await-queue.py`.' \
+Run `wait-for-ci.sh`, then land `(await-queue.py)` and archive `wait-for-ci.sh,`.' \
     "$ROOT/bin/fm-brief.sh" sol-backtick-1 firstmate --mode no-mistakes >/dev/null 2>&1 || status=$?
   expect_code 0 "$status" "backticked command names containing 'wait' must not refuse"
   brief="$home/data/sol-backtick-1/brief.md"
@@ -880,7 +881,8 @@ Run `wait-for-ci.sh` as part of setup, then land `await-queue.py`.' \
 
 test_ship_sol_exemption_refuses_backticked_wait_tokens() {
   local home out status token i=0
-  for token in wait waits waited waiting await awaits awaiting WAIT Awaiting; do
+  for token in wait waits waited waiting await awaits awaiting WAIT Awaiting \
+               'wait,' '(awaiting)' '"WAIT"' '[waited]' 'awaits!'; do
     i=$((i + 1))
     home="$TMP_ROOT/sol-backtick-token-home-$i"
     mkdir -p "$home/data"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -835,6 +835,30 @@ $wait_line" "$ROOT/bin/fm-brief.sh" "sol-bound-$i" firstmate --mode no-mistakes 
   pass "fm-brief.sh: ship scaffold refuses Wait: lines with empty bound=/escape= values"
 }
 
+test_ship_sol_exemption_refuses_vacuous_bound_and_escape() {
+  local home out status value field wait_line i=0
+  for value in forever none unbounded never n/a infinite inf FoReVeR NONE; do
+    for field in bound escape; do
+      i=$((i + 1))
+      home="$TMP_ROOT/sol-vacuous-home-$i"
+      mkdir -p "$home/data"
+      status=0
+      if [ "$field" = bound ]; then
+        wait_line="Wait: CI bound=$value escape=append-blocked"
+      else
+        wait_line="Wait: CI bound=30m escape=$value"
+      fi
+      out=$(FM_HOME="$home" FM_TASK="Acceptance command: \`make test\`
+$wait_line" "$ROOT/bin/fm-brief.sh" "sol-vacuous-$i" firstmate --mode no-mistakes 2>&1) || status=$?
+      expect_code 1 "$status" "vacuous $field value must refuse: $value"
+      assert_contains "$out" "bound=" "refusal must name the bound/escape requirement"
+      assert_absent "$home/data/sol-vacuous-$i/brief.md" \
+        "refused vacuous-value scaffold must not write a brief"
+    done
+  done
+  pass "fm-brief.sh: vacuous wait bounds and escapes cannot earn exemption"
+}
+
 # Regression: any line containing the token `wait` was refused, so a backticked
 # command name such as `wait-for-ci.sh` made a legitimate ship task unscaffoldable.
 test_ship_sol_exemption_ignores_backticked_command_names() {
@@ -852,6 +876,24 @@ Run `wait-for-ci.sh` as part of setup, then land `await-queue.py`.' \
   grep -qx "Sol exemption: earned" "$brief" \
     || fail "brief missing the machine-readable Sol exemption line"
   pass "fm-brief.sh: wait scan skips backticked spans"
+}
+
+test_ship_sol_exemption_refuses_backticked_wait_tokens() {
+  local home out status token i=0
+  for token in wait waits waited waiting await awaits awaiting WAIT Awaiting; do
+    i=$((i + 1))
+    home="$TMP_ROOT/sol-backtick-token-home-$i"
+    mkdir -p "$home/data"
+    status=0
+    out=$(FM_HOME="$home" FM_TASK="Acceptance command: \`make test\`
+Then \`$token\` before shipping." \
+      "$ROOT/bin/fm-brief.sh" "sol-backtick-token-$i" firstmate --mode no-mistakes 2>&1) || status=$?
+    expect_code 1 "$status" "backticked wait-family token must refuse: $token"
+    assert_contains "$out" "unbounded wait" "refusal must name the unbounded wait"
+    assert_absent "$home/data/sol-backtick-token-$i/brief.md" \
+      "refused backticked-wait scaffold must not write a brief"
+  done
+  pass "fm-brief.sh: exact backticked wait tokens remain visible to validation"
 }
 
 # FM_TASK is a ship-only input; scout and secondmate must refuse it loudly rather
@@ -1200,7 +1242,9 @@ test_ship_sol_exemption_succeeds_with_evidence
 test_ship_sol_exemption_refuses_unbounded_wait
 test_ship_sol_exemption_refuses_inflected_waits
 test_ship_sol_exemption_refuses_valueless_bound_and_escape
+test_ship_sol_exemption_refuses_vacuous_bound_and_escape
 test_ship_sol_exemption_ignores_backticked_command_names
+test_ship_sol_exemption_refuses_backticked_wait_tokens
 test_fm_task_refused_on_scout_and_secondmate
 test_refused_scaffold_leaves_no_task_directory
 test_sol_exemption_block_spacing_is_stable

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -860,6 +860,27 @@ $wait_line" "$ROOT/bin/fm-brief.sh" "sol-vacuous-$i" firstmate --mode no-mistake
   pass "fm-brief.sh: vacuous wait bounds and escapes cannot earn exemption"
 }
 
+test_ship_sol_exemption_refuses_duplicate_wait_fields() {
+  local home out status wait_line i=0
+  for wait_line in \
+    'Wait: approval bound=30m bound=forever escape=abort' \
+    'Wait: approval bound=30m escape=abort escape=none' \
+    'Wait: approval bound=30m bound=1h escape=abort' \
+    'Wait: approval bound=30m escape=abort escape=notify'; do
+    i=$((i + 1))
+    home="$TMP_ROOT/sol-duplicate-field-home-$i"
+    mkdir -p "$home/data"
+    status=0
+    out=$(FM_HOME="$home" FM_TASK="Acceptance command: \`make test\`
+$wait_line" "$ROOT/bin/fm-brief.sh" "sol-duplicate-field-$i" firstmate --mode no-mistakes 2>&1) || status=$?
+    expect_code 1 "$status" "duplicate wait evidence fields must refuse"
+    assert_contains "$out" "bound=" "refusal must name the wait evidence contract"
+    assert_absent "$home/data/sol-duplicate-field-$i/brief.md" \
+      "refused duplicate-field scaffold must not write a brief"
+  done
+  pass "fm-brief.sh: duplicate wait evidence fields cannot earn exemption"
+}
+
 test_ship_sol_exemption_refuses_multiple_waits_on_one_line() {
   local home out status wait_line i=0
   for wait_line in \
@@ -922,27 +943,44 @@ Then \`$token\` before shipping." \
 # FM_TASK is a ship-only input; scout and secondmate must refuse it loudly rather
 # than scaffold a brief whose {TASK} placeholder silently discarded it.
 test_fm_task_refused_on_scout_and_secondmate() {
-  local home out status
+  local home out status task i=0
   home="$TMP_ROOT/sol-kind-home"
   mkdir -p "$home/data"
-  status=0
-  out=$(FM_HOME="$home" FM_TASK='Investigate the flake.' \
-    "$ROOT/bin/fm-brief.sh" sol-kind-scout alpha --scout 2>&1) || status=$?
-  expect_code 1 "$status" "FM_TASK on a scout scaffold must refuse"
-  assert_contains "$out" "FM_TASK applies only to ship briefs" \
-    "scout refusal must name FM_TASK as ship-only"
-  assert_absent "$home/data/sol-kind-scout/brief.md" \
-    "refused scout scaffold must not write a brief"
+  for task in 'Investigate the flake.' ''; do
+    i=$((i + 1))
+    status=0
+    out=$(FM_HOME="$home" FM_TASK="$task" \
+      "$ROOT/bin/fm-brief.sh" "sol-kind-scout-$i" alpha --scout 2>&1) || status=$?
+    expect_code 1 "$status" "set FM_TASK on a scout scaffold must refuse"
+    assert_contains "$out" "FM_TASK applies only to ship briefs" \
+      "scout refusal must name FM_TASK as ship-only"
+    assert_absent "$home/data/sol-kind-scout-$i/brief.md" \
+      "refused scout scaffold must not write a brief"
 
-  status=0
-  out=$(FM_HOME="$home" FM_TASK='Charter the crew.' \
-    "$ROOT/bin/fm-brief.sh" sol-kind-sm --secondmate --no-projects 2>&1) || status=$?
-  expect_code 1 "$status" "FM_TASK on a secondmate scaffold must refuse"
-  assert_contains "$out" "FM_TASK applies only to ship briefs" \
-    "secondmate refusal must name FM_TASK as ship-only"
-  assert_absent "$home/data/sol-kind-sm/brief.md" \
-    "refused secondmate scaffold must not write a brief"
+    status=0
+    out=$(FM_HOME="$home" FM_TASK="$task" \
+      "$ROOT/bin/fm-brief.sh" "sol-kind-sm-$i" --secondmate --no-projects 2>&1) || status=$?
+    expect_code 1 "$status" "set FM_TASK on a secondmate scaffold must refuse"
+    assert_contains "$out" "FM_TASK applies only to ship briefs" \
+      "secondmate refusal must name FM_TASK as ship-only"
+    assert_absent "$home/data/sol-kind-sm-$i/brief.md" \
+      "refused secondmate scaffold must not write a brief"
+  done
   pass "fm-brief.sh: FM_TASK is refused on scout and secondmate scaffolds"
+}
+
+test_empty_fm_task_refused_on_ship() {
+  local home out status=0
+  home="$TMP_ROOT/sol-empty-task-home"
+  mkdir -p "$home/data"
+  out=$(FM_HOME="$home" FM_TASK='' \
+    "$ROOT/bin/fm-brief.sh" sol-empty-task firstmate --mode no-mistakes 2>&1) || status=$?
+  expect_code 1 "$status" "empty set FM_TASK on a ship scaffold must refuse"
+  assert_contains "$out" "Acceptance command" \
+    "empty ship FM_TASK refusal must name the missing evidence"
+  assert_absent "$home/data/sol-empty-task/brief.md" \
+    "refused empty ship task must not write a brief"
+  pass "fm-brief.sh: empty set FM_TASK is validated, never ignored"
 }
 
 # A refused scaffold must leave the data tree exactly as it found it, not an
@@ -1295,10 +1333,12 @@ test_ship_sol_exemption_refuses_unbounded_wait
 test_ship_sol_exemption_refuses_inflected_waits
 test_ship_sol_exemption_refuses_valueless_bound_and_escape
 test_ship_sol_exemption_refuses_vacuous_bound_and_escape
+test_ship_sol_exemption_refuses_duplicate_wait_fields
 test_ship_sol_exemption_refuses_multiple_waits_on_one_line
 test_ship_sol_exemption_ignores_backticked_command_names
 test_ship_sol_exemption_refuses_backticked_wait_tokens
 test_fm_task_refused_on_scout_and_secondmate
+test_empty_fm_task_refused_on_ship
 test_refused_scaffold_leaves_no_task_directory
 test_sol_exemption_block_spacing_is_stable
 test_ship_sol_exemption_accepts_trailing_acceptance_text

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -1108,9 +1108,10 @@ Acceptance command: `b`' \
 
 test_ship_sol_exemption_refuses_non_command_acceptance_payloads() {
   local home out status payload i=0
+  # shellcheck disable=SC2016 # Command substitution text is a literal acceptance payload.
   for payload in ' ' '&&' '>' '# tests not implemented' '   # tests not implemented' \
                  'FOO=bar' "NODE_OPTIONS='--trace warnings'" 'make test &&' \
-                 '/' './' '//' '///' '../' '../../'; do
+                 'BUILD_ID=$(git rev-parse HEAD)' '/' './' '//' '///' '../' '../../'; do
     i=$((i + 1))
     home="$TMP_ROOT/sol-non-command-home-$i"
     mkdir -p "$home/data"
@@ -1128,11 +1129,14 @@ test_ship_sol_exemption_refuses_non_command_acceptance_payloads() {
 
 test_ship_sol_exemption_accepts_env_prefixed_commands() {
   local home brief status command i=0
+  # shellcheck disable=SC2016 # Command substitution text is a literal acceptance payload.
   for command in 'NODE_ENV=test npm test' \
                  'CI=1 NODE_ENV=test ./bin/test.sh' \
                  '_TRACE= ./scripts/check' \
                  "NODE_OPTIONS='--trace warnings' npm test" \
-                 'FLAGS="one two" MODE=ci ./scripts/check'; do
+                 'FLAGS="one two" MODE=ci ./scripts/check' \
+                 'BUILD_ID=$(git rev-parse HEAD) npm test' \
+                 'A=$(printf one) B=$(printf two words) ./scripts/check'; do
     i=$((i + 1))
     home="$TMP_ROOT/sol-env-command-home-$i"
     mkdir -p "$home/data"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -726,6 +726,60 @@ test_scout_and_secondmate_load_decision_hold_policy() {
 }
 
 # Scout and secondmate paths still scaffold well-formed briefs.
+test_ship_sol_exemption_refuses_without_evidence() {
+  local home out status
+  home="$TMP_ROOT/sol-refuse-home"
+  mkdir -p "$home/data"
+  out=$(FM_HOME="$home" FM_TASK='Fix the widget and ship it.' \
+    "$ROOT/bin/fm-brief.sh" sol-refuse-1 firstmate --mode no-mistakes 2>&1) || status=$?
+  expect_code 1 "${status:-0}" "filled ship task without exemption evidence must refuse"
+  assert_contains "$out" "Acceptance command" \
+    "refusal must name the missing acceptance command evidence"
+  assert_absent "$home/data/sol-refuse-1/brief.md" \
+    "refused Sol-exemption scaffold must not write a brief"
+  pass "fm-brief.sh: ship scaffold refuses Sol exemption without auditable evidence"
+}
+
+test_ship_sol_exemption_succeeds_with_evidence() {
+  local home brief status task
+  home="$TMP_ROOT/sol-earn-home"
+  mkdir -p "$home/data"
+  # shellcheck disable=SC2016 # Backticks in the task body are literal evidence syntax.
+  task='# Fix widget
+Acceptance command: `bin/fm-lint.sh`
+Wait: CI green bound=30m escape=append blocked: CI timeout'
+  FM_HOME="$home" FM_TASK="$task" \
+    "$ROOT/bin/fm-brief.sh" sol-earn-1 firstmate --mode no-mistakes >/dev/null 2>&1; status=$?
+  expect_code 0 "$status" "filled ship task with exemption evidence must scaffold"
+  brief="$home/data/sol-earn-1/brief.md"
+  assert_present "$brief" "Sol-exempt ship brief was not scaffolded"
+  grep -qx "Sol exemption: earned" "$brief" \
+    || fail "brief missing the machine-readable Sol exemption line"
+  assert_grep "# Sol exemption evidence" "$brief" \
+    "brief missing the scaffold-owned Sol exemption evidence block"
+  assert_grep "Acceptance command: \`bin/fm-lint.sh\`" "$brief" \
+    "brief did not carry the acceptance command in the evidence block"
+  assert_grep "Wait: CI green bound=30m escape=append blocked: CI timeout" "$brief" \
+    "brief did not carry bounded waits in the evidence block"
+  pass "fm-brief.sh: ship scaffold earns Sol exemption with auditable evidence"
+}
+
+test_ship_sol_exemption_refuses_unbounded_wait() {
+  local home out status
+  home="$TMP_ROOT/sol-wait-home"
+  mkdir -p "$home/data"
+  # shellcheck disable=SC2016 # The task body is a literal fixture string.
+  out=$(FM_HOME="$home" FM_TASK='Wait for deploy
+Acceptance command: `make test`' \
+    "$ROOT/bin/fm-brief.sh" sol-wait-1 firstmate --mode direct-PR 2>&1) || status=$?
+  expect_code 1 "${status:-0}" "ship task with unbounded wait must refuse"
+  assert_contains "$out" "unbounded wait" \
+    "refusal must name the unbounded wait"
+  assert_absent "$home/data/sol-wait-1/brief.md" \
+    "refused unbounded-wait scaffold must not write a brief"
+  pass "fm-brief.sh: ship scaffold refuses unbounded waits"
+}
+
 test_scout_and_secondmate_scaffold() {
   local brief
   FM_HOME="$BRIEF_HOME" "$ROOT/bin/fm-brief.sh" brief-scout-q6 alpha --scout >/dev/null 2>&1 \
@@ -767,4 +821,7 @@ test_secondmate_marked_request_reporting_contract
 test_secondmate_directory_paths_are_absolute_and_output_is_stable
 test_pause_verb_override_renders_all_brief_scaffolds
 test_scout_and_secondmate_load_decision_hold_policy
+test_ship_sol_exemption_refuses_without_evidence
+test_ship_sol_exemption_succeeds_with_evidence
+test_ship_sol_exemption_refuses_unbounded_wait
 test_scout_and_secondmate_scaffold

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -958,6 +958,22 @@ Acceptance command: `make test` (from the repo root)'; do
   pass "fm-brief.sh: an acceptance line with trailing text earns exemption and is recorded"
 }
 
+test_ship_sol_exemption_refuses_trailing_acceptance_wait() {
+  local home out status
+  home="$TMP_ROOT/sol-trailing-wait-home"
+  mkdir -p "$home/data"
+  status=0
+  # shellcheck disable=SC2016 # The task body is a literal fixture string.
+  out=$(FM_HOME="$home" FM_TASK='Acceptance command: `make test` then wait forever' \
+    "$ROOT/bin/fm-brief.sh" sol-trailing-wait firstmate --mode no-mistakes 2>&1) || status=$?
+  expect_code 1 "$status" "a trailing unbounded wait on the acceptance line must refuse"
+  assert_contains "$out" "unbounded wait" \
+    "refusal must name the trailing unbounded wait"
+  assert_absent "$home/data/sol-trailing-wait/brief.md" \
+    "refused trailing acceptance-line wait must not write a brief"
+  pass "fm-brief.sh: acceptance-line trailing waits cannot bypass the gate"
+}
+
 # Every refusal must name a cause on stderr; a bare non-zero exit tells the caller
 # nothing about what the scaffold rejected.
 test_ship_sol_exemption_refusals_are_never_silent() {
@@ -1189,6 +1205,7 @@ test_fm_task_refused_on_scout_and_secondmate
 test_refused_scaffold_leaves_no_task_directory
 test_sol_exemption_block_spacing_is_stable
 test_ship_sol_exemption_accepts_trailing_acceptance_text
+test_ship_sol_exemption_refuses_trailing_acceptance_wait
 test_ship_sol_exemption_refusals_are_never_silent
 test_ship_sol_exemption_refuses_non_command_acceptance_payloads
 test_fm_task_cannot_forge_scaffold_owned_contract_lines

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -1109,7 +1109,8 @@ Acceptance command: `b`' \
 test_ship_sol_exemption_refuses_non_command_acceptance_payloads() {
   local home out status payload i=0
   for payload in ' ' '&&' '>' '# tests not implemented' '   # tests not implemented' \
-                 'FOO=bar' 'make test &&'; do
+                 'FOO=bar' "NODE_OPTIONS='--trace warnings'" 'make test &&' \
+                 '/' './' '//' '///' '../' '../../'; do
     i=$((i + 1))
     home="$TMP_ROOT/sol-non-command-home-$i"
     mkdir -p "$home/data"
@@ -1129,7 +1130,9 @@ test_ship_sol_exemption_accepts_env_prefixed_commands() {
   local home brief status command i=0
   for command in 'NODE_ENV=test npm test' \
                  'CI=1 NODE_ENV=test ./bin/test.sh' \
-                 '_TRACE= ./scripts/check'; do
+                 '_TRACE= ./scripts/check' \
+                 "NODE_OPTIONS='--trace warnings' npm test" \
+                 'FLAGS="one two" MODE=ci ./scripts/check'; do
     i=$((i + 1))
     home="$TMP_ROOT/sol-env-command-home-$i"
     mkdir -p "$home/data"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -780,6 +780,148 @@ Acceptance command: `make test`' \
   pass "fm-brief.sh: ship scaffold refuses unbounded waits"
 }
 
+# Regression: the wait scan matched only the bare token `wait`, so an inflected
+# unbounded wait ("keep waiting", "await") earned the exemption anyway.
+test_ship_sol_exemption_refuses_inflected_waits() {
+  local home out status inflection i=0
+  for inflection in 'Keep waiting for CI until it goes green.' \
+                    'Await the deploy indefinitely.' \
+                    'The task awaits review before landing.' \
+                    'We waited for the queue to drain.'; do
+    i=$((i + 1))
+    home="$TMP_ROOT/sol-inflect-home-$i"
+    mkdir -p "$home/data"
+    status=0
+    out=$(FM_HOME="$home" FM_TASK="Ship it.
+Acceptance command: \`make test\`
+$inflection" "$ROOT/bin/fm-brief.sh" "sol-inflect-$i" firstmate --mode no-mistakes 2>&1) || status=$?
+    expect_code 1 "$status" "inflected unbounded wait must refuse: $inflection"
+    assert_contains "$out" "unbounded wait" \
+      "refusal must name the unbounded wait for: $inflection"
+    assert_absent "$home/data/sol-inflect-$i/brief.md" \
+      "refused inflected-wait scaffold must not write a brief"
+  done
+  pass "fm-brief.sh: ship scaffold refuses the whole unbounded wait word family"
+}
+
+# Regression: `bound=escape=` satisfied the old prefix glob, stamping a brief
+# exempt while recording a wait that carries no actual bound.
+test_ship_sol_exemption_refuses_valueless_bound_and_escape() {
+  local home out status wait_line i=0
+  for wait_line in 'Wait: CI bound=escape=' \
+                   'Wait: CI bound= escape=1m' \
+                   'Wait: CI bound=30m escape=' \
+                   'Wait: CI bound=30m'; do
+    i=$((i + 1))
+    home="$TMP_ROOT/sol-bound-home-$i"
+    mkdir -p "$home/data"
+    status=0
+    out=$(FM_HOME="$home" FM_TASK="Acceptance command: \`make test\`
+$wait_line" "$ROOT/bin/fm-brief.sh" "sol-bound-$i" firstmate --mode no-mistakes 2>&1) || status=$?
+    expect_code 1 "$status" "wait without real bound/escape values must refuse: $wait_line"
+    assert_contains "$out" "bound=" "refusal must name the bound/escape requirement"
+    assert_absent "$home/data/sol-bound-$i/brief.md" \
+      "refused valueless-bound scaffold must not write a brief"
+  done
+  pass "fm-brief.sh: ship scaffold refuses Wait: lines with empty bound=/escape= values"
+}
+
+# Regression: any line containing the token `wait` was refused, so a backticked
+# command name such as `wait-for-ci.sh` made a legitimate ship task unscaffoldable.
+test_ship_sol_exemption_ignores_backticked_command_names() {
+  local home brief status
+  home="$TMP_ROOT/sol-backtick-home"
+  mkdir -p "$home/data"
+  status=0
+  # shellcheck disable=SC2016 # The task body is a literal fixture string.
+  FM_HOME="$home" FM_TASK='Acceptance command: `make test`
+Run `wait-for-ci.sh` as part of setup, then land `await-queue.py`.' \
+    "$ROOT/bin/fm-brief.sh" sol-backtick-1 firstmate --mode no-mistakes >/dev/null 2>&1 || status=$?
+  expect_code 0 "$status" "backticked command names containing 'wait' must not refuse"
+  brief="$home/data/sol-backtick-1/brief.md"
+  assert_present "$brief" "backticked-command ship brief was not scaffolded"
+  grep -qx "Sol exemption: earned" "$brief" \
+    || fail "brief missing the machine-readable Sol exemption line"
+  pass "fm-brief.sh: wait scan skips backticked spans"
+}
+
+# FM_TASK is a ship-only input; scout and secondmate must refuse it loudly rather
+# than scaffold a brief whose {TASK} placeholder silently discarded it.
+test_fm_task_refused_on_scout_and_secondmate() {
+  local home out status
+  home="$TMP_ROOT/sol-kind-home"
+  mkdir -p "$home/data"
+  status=0
+  out=$(FM_HOME="$home" FM_TASK='Investigate the flake.' \
+    "$ROOT/bin/fm-brief.sh" sol-kind-scout alpha --scout 2>&1) || status=$?
+  expect_code 1 "$status" "FM_TASK on a scout scaffold must refuse"
+  assert_contains "$out" "FM_TASK applies only to ship briefs" \
+    "scout refusal must name FM_TASK as ship-only"
+  assert_absent "$home/data/sol-kind-scout/brief.md" \
+    "refused scout scaffold must not write a brief"
+
+  status=0
+  out=$(FM_HOME="$home" FM_TASK='Charter the crew.' \
+    "$ROOT/bin/fm-brief.sh" sol-kind-sm alpha --secondmate --no-projects 2>&1) || status=$?
+  expect_code 1 "$status" "FM_TASK on a secondmate scaffold must refuse"
+  assert_contains "$out" "FM_TASK applies only to ship briefs" \
+    "secondmate refusal must name FM_TASK as ship-only"
+  assert_absent "$home/data/sol-kind-sm/brief.md" \
+    "refused secondmate scaffold must not write a brief"
+  pass "fm-brief.sh: FM_TASK is refused on scout and secondmate scaffolds"
+}
+
+# A refused scaffold must leave the data tree exactly as it found it, not an
+# empty data/<id>/ shell from a mkdir that ran before validation.
+test_refused_scaffold_leaves_no_task_directory() {
+  local home status
+  home="$TMP_ROOT/sol-nodir-home"
+  mkdir -p "$home/data"
+  status=0
+  FM_HOME="$home" FM_TASK='Ship the widget.' \
+    "$ROOT/bin/fm-brief.sh" sol-nodir-1 firstmate --mode no-mistakes >/dev/null 2>&1 || status=$?
+  expect_code 1 "$status" "scaffold without evidence must refuse"
+  assert_absent "$home/data/sol-nodir-1" \
+    "refused scaffold must not leave an empty task directory behind"
+  pass "fm-brief.sh: a refused scaffold leaves the data tree untouched"
+}
+
+# The exemption block is a generated section of the brief and owns its own
+# separators: an unfilled {TASK} brief keeps exactly one blank line before the
+# Herdr heading, and a filled one keeps a blank line after the evidence block.
+test_sol_exemption_block_spacing_is_stable() {
+  local home unfilled filled status
+  home="$TMP_ROOT/sol-spacing-home"
+  mkdir -p "$home/data"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" sol-space-plain firstmate --mode no-mistakes >/dev/null 2>&1 \
+    || fail "unfilled ship scaffold failed"
+  unfilled=$(sed -n '3,6p' "$home/data/sol-space-plain/brief.md")
+  [ "$unfilled" = '# Task
+{TASK}
+
+# Herdr lifecycle declaration - NOT ENABLED' ] \
+    || fail "unfilled ship brief must keep one blank line between {TASK} and the Herdr heading, got:"$'\n'"$unfilled"
+
+  status=0
+  # shellcheck disable=SC2016 # The task body is a literal fixture string.
+  FM_HOME="$home" FM_TASK='Fix the widget.
+Acceptance command: `make test`' \
+    "$ROOT/bin/fm-brief.sh" sol-space-filled firstmate --mode no-mistakes >/dev/null 2>&1 || status=$?
+  expect_code 0 "$status" "filled ship scaffold with evidence must succeed"
+  filled=$(sed -n '3,10p' "$home/data/sol-space-filled/brief.md")
+  # shellcheck disable=SC2016 # The expected brief text is a literal fixture.
+  [ "$filled" = '# Task
+Fix the widget.
+Acceptance command: `make test`
+
+# Sol exemption evidence
+Acceptance command: `make test`
+
+# Herdr lifecycle declaration - NOT ENABLED' ] \
+    || fail "filled ship brief evidence block must be blank-line separated, got:"$'\n'"$filled"
+  pass "fm-brief.sh: Sol exemption block owns its own blank-line separators"
+}
+
 test_scout_and_secondmate_scaffold() {
   local brief
   FM_HOME="$BRIEF_HOME" "$ROOT/bin/fm-brief.sh" brief-scout-q6 alpha --scout >/dev/null 2>&1 \
@@ -824,4 +966,10 @@ test_scout_and_secondmate_load_decision_hold_policy
 test_ship_sol_exemption_refuses_without_evidence
 test_ship_sol_exemption_succeeds_with_evidence
 test_ship_sol_exemption_refuses_unbounded_wait
+test_ship_sol_exemption_refuses_inflected_waits
+test_ship_sol_exemption_refuses_valueless_bound_and_escape
+test_ship_sol_exemption_ignores_backticked_command_names
+test_fm_task_refused_on_scout_and_secondmate
+test_refused_scaffold_leaves_no_task_directory
+test_sol_exemption_block_spacing_is_stable
 test_scout_and_secondmate_scaffold

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -866,7 +866,11 @@ test_ship_sol_exemption_refuses_duplicate_wait_fields() {
     'Wait: approval bound=30m bound=forever escape=abort' \
     'Wait: approval bound=30m escape=abort escape=none' \
     'Wait: approval bound=30m bound=1h escape=abort' \
-    'Wait: approval bound=30m escape=abort escape=notify'; do
+    'Wait: approval bound=30m escape=abort escape=notify' \
+    'Wait: approval bound=30m,bound=forever escape=abort' \
+    'Wait: approval bound=30m escape=abort;escape=none' \
+    'Wait: approval bound=30m/bound=1h escape=abort' \
+    'Wait: approval bound=30m escape=abort,escape=notify'; do
     i=$((i + 1))
     home="$TMP_ROOT/sol-duplicate-field-home-$i"
     mkdir -p "$home/data"
@@ -1121,6 +1125,27 @@ test_ship_sol_exemption_refuses_non_command_acceptance_payloads() {
   pass "fm-brief.sh: non-command acceptance payloads cannot earn Sol exemption"
 }
 
+test_ship_sol_exemption_accepts_env_prefixed_commands() {
+  local home brief status command i=0
+  for command in 'NODE_ENV=test npm test' \
+                 'CI=1 NODE_ENV=test ./bin/test.sh' \
+                 '_TRACE= ./scripts/check'; do
+    i=$((i + 1))
+    home="$TMP_ROOT/sol-env-command-home-$i"
+    mkdir -p "$home/data"
+    status=0
+    FM_HOME="$home" FM_TASK="Acceptance command: \`$command\`" \
+      "$ROOT/bin/fm-brief.sh" "sol-env-command-$i" firstmate --mode no-mistakes \
+      >/dev/null 2>&1 || status=$?
+    expect_code 0 "$status" "environment-prefixed executable command must scaffold"
+    brief="$home/data/sol-env-command-$i/brief.md"
+    assert_present "$brief" "environment-prefixed acceptance command did not produce a brief"
+    grep -qx "Sol exemption: earned" "$brief" \
+      || fail "environment-prefixed acceptance command did not earn exemption"
+  done
+  pass "fm-brief.sh: environment assignments may prefix an executable acceptance command"
+}
+
 test_ship_sol_exemption_scans_acceptance_command_waits() {
   local home out status command i=0
   for command in wait waits waited waiting await awaits awaiting; do
@@ -1345,6 +1370,7 @@ test_ship_sol_exemption_accepts_trailing_acceptance_text
 test_ship_sol_exemption_refuses_trailing_acceptance_wait
 test_ship_sol_exemption_refusals_are_never_silent
 test_ship_sol_exemption_refuses_non_command_acceptance_payloads
+test_ship_sol_exemption_accepts_env_prefixed_commands
 test_ship_sol_exemption_scans_acceptance_command_waits
 test_fm_task_cannot_forge_scaffold_owned_contract_lines
 test_sol_evidence_block_records_every_validated_wait

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -860,6 +860,27 @@ $wait_line" "$ROOT/bin/fm-brief.sh" "sol-vacuous-$i" firstmate --mode no-mistake
   pass "fm-brief.sh: vacuous wait bounds and escapes cannot earn exemption"
 }
 
+test_ship_sol_exemption_refuses_multiple_waits_on_one_line() {
+  local home out status wait_line i=0
+  for wait_line in \
+    'Wait: CI bound=30m escape=abort; then wait forever for approval' \
+    'Wait: CI bound=30m escape=abort, then awaiting review' \
+    'Wait: CI bound=30m escape=abort; Wait: approval bound=1h escape=ship-without'; do
+    i=$((i + 1))
+    home="$TMP_ROOT/sol-multi-wait-home-$i"
+    mkdir -p "$home/data"
+    status=0
+    out=$(FM_HOME="$home" FM_TASK="Acceptance command: \`make test\`
+$wait_line" "$ROOT/bin/fm-brief.sh" "sol-multi-wait-$i" firstmate --mode no-mistakes 2>&1) || status=$?
+    expect_code 1 "$status" "multiple waits on one Wait: line must refuse"
+    assert_contains "$out" "exactly one wait clause" \
+      "refusal must require independently owned wait evidence"
+    assert_absent "$home/data/sol-multi-wait-$i/brief.md" \
+      "refused multi-wait scaffold must not write a brief"
+  done
+  pass "fm-brief.sh: each Wait line owns exactly one bounded wait clause"
+}
+
 # Regression: any line containing the token `wait` was refused, so a backticked
 # command name such as `wait-for-ci.sh` made a legitimate ship task unscaffoldable.
 test_ship_sol_exemption_ignores_backticked_command_names() {
@@ -1245,6 +1266,7 @@ test_ship_sol_exemption_refuses_unbounded_wait
 test_ship_sol_exemption_refuses_inflected_waits
 test_ship_sol_exemption_refuses_valueless_bound_and_escape
 test_ship_sol_exemption_refuses_vacuous_bound_and_escape
+test_ship_sol_exemption_refuses_multiple_waits_on_one_line
 test_ship_sol_exemption_ignores_backticked_command_names
 test_ship_sol_exemption_refuses_backticked_wait_tokens
 test_fm_task_refused_on_scout_and_secondmate

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -985,7 +985,8 @@ Acceptance command: `b`' \
 
 test_ship_sol_exemption_refuses_non_command_acceptance_payloads() {
   local home out status payload i=0
-  for payload in ' ' '&&' '>'; do
+  for payload in ' ' '&&' '>' '# tests not implemented' '   # tests not implemented' \
+                 'FOO=bar' 'make test &&'; do
     i=$((i + 1))
     home="$TMP_ROOT/sol-non-command-home-$i"
     mkdir -p "$home/data"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -890,7 +890,7 @@ test_ship_sol_exemption_ignores_backticked_command_names() {
   status=0
   # shellcheck disable=SC2016 # The task body is a literal fixture string.
   FM_HOME="$home" FM_TASK='Acceptance command: `make test`
-Run `wait-for-ci.sh`, then land `(await-queue.py)` and archive `wait-for-ci.sh,`.' \
+Run `wait-for-ci.sh`, then archive `artifact.zip`, land `(await-queue.py)`, and save `wait-for-ci.sh,`.' \
     "$ROOT/bin/fm-brief.sh" sol-backtick-1 firstmate --mode no-mistakes >/dev/null 2>&1 || status=$?
   expect_code 0 "$status" "backticked command names containing 'wait' must not refuse"
   brief="$home/data/sol-backtick-1/brief.md"

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -726,6 +726,14 @@ test_scout_and_secondmate_load_decision_hold_policy() {
 }
 
 # Scout and secondmate paths still scaffold well-formed briefs.
+# The "# Sol exemption evidence" block is a scaffold-owned generated section of the
+# brief. FM_TASK is also emitted verbatim into the "# Task" section above it, so a
+# whole-file grep cannot tell the two apart; assertions about the block must run
+# against the extracted block alone.
+sol_evidence_block() {
+  sed -n '/^# Sol exemption evidence$/,/^$/p' "$1"
+}
+
 test_ship_sol_exemption_refuses_without_evidence() {
   local home out status
   home="$TMP_ROOT/sol-refuse-home"
@@ -741,7 +749,7 @@ test_ship_sol_exemption_refuses_without_evidence() {
 }
 
 test_ship_sol_exemption_succeeds_with_evidence() {
-  local home brief status task
+  local home brief status task block
   home="$TMP_ROOT/sol-earn-home"
   mkdir -p "$home/data"
   # shellcheck disable=SC2016 # Backticks in the task body are literal evidence syntax.
@@ -755,12 +763,13 @@ Wait: CI green bound=30m escape=append blocked: CI timeout'
   assert_present "$brief" "Sol-exempt ship brief was not scaffolded"
   grep -qx "Sol exemption: earned" "$brief" \
     || fail "brief missing the machine-readable Sol exemption line"
-  assert_grep "# Sol exemption evidence" "$brief" \
+  block=$(sol_evidence_block "$brief")
+  assert_contains "$block" "# Sol exemption evidence" \
     "brief missing the scaffold-owned Sol exemption evidence block"
-  assert_grep "Acceptance command: \`bin/fm-lint.sh\`" "$brief" \
-    "brief did not carry the acceptance command in the evidence block"
-  assert_grep "Wait: CI green bound=30m escape=append blocked: CI timeout" "$brief" \
-    "brief did not carry bounded waits in the evidence block"
+  assert_contains "$block" "Acceptance command: \`bin/fm-lint.sh\`" \
+    "evidence block did not carry the acceptance command"
+  assert_contains "$block" "Wait: CI green bound=30m escape=append blocked: CI timeout" \
+    "evidence block did not carry the bounded wait"
   pass "fm-brief.sh: ship scaffold earns Sol exemption with auditable evidence"
 }
 
@@ -943,7 +952,7 @@ Acceptance command: `make test` (from the repo root)'; do
     assert_present "$brief" "trailing-text acceptance ship brief was not scaffolded"
     grep -qx "Sol exemption: earned" "$brief" \
       || fail "brief missing the machine-readable Sol exemption line"
-    assert_grep "Acceptance command: \`make test\`" "$brief" \
+    assert_contains "$(sol_evidence_block "$brief")" "Acceptance command: \`make test\`" \
       "evidence block dropped the acceptance command"
   done
   pass "fm-brief.sh: an acceptance line with trailing text earns exemption and is recorded"
@@ -1021,7 +1030,7 @@ Acceptance command: `make test`' \
 # the gate validated must appear in it, including one written without a space
 # after the colon.
 test_sol_evidence_block_records_every_validated_wait() {
-  local home brief status
+  local home brief status block
   home="$TMP_ROOT/sol-evidence-home"
   mkdir -p "$home/data"
   status=0
@@ -1032,11 +1041,82 @@ Wait: review bound=1h escape=ping firstmate' \
     "$ROOT/bin/fm-brief.sh" sol-evidence-1 firstmate --mode no-mistakes >/dev/null 2>&1 || status=$?
   expect_code 0 "$status" "bounded waits must scaffold"
   brief="$home/data/sol-evidence-1/brief.md"
-  assert_grep "Wait:CI green bound=30m escape=append blocked" "$brief" \
+  block=$(sol_evidence_block "$brief")
+  assert_contains "$block" "Wait:CI green bound=30m escape=append blocked" \
     "evidence block dropped a validated wait written without a space after the colon"
-  assert_grep "Wait: review bound=1h escape=ping firstmate" "$brief" \
+  assert_contains "$block" "Wait: review bound=1h escape=ping firstmate" \
     "evidence block dropped a validated wait"
   pass "fm-brief.sh: the evidence block records every wait the gate validated"
+}
+
+# Regression: the backtick strip removed any paired span, so an unbounded wait
+# written inside backticks earned the exemption. Only whitespace-free spans are
+# command/token names; prose inside backticks is still prose.
+test_ship_sol_exemption_refuses_backticked_prose_wait() {
+  local home out status body i=0
+  # shellcheck disable=SC2016 # The task bodies are literal fixture strings.
+  for body in 'Acceptance command: `make test`
+Then `wait forever for the human to approve` before shipping.' \
+              'Acceptance command: `make test`
+Do `await the captain sign-off` first.'; do
+    i=$((i + 1))
+    home="$TMP_ROOT/sol-btprose-home-$i"
+    mkdir -p "$home/data"
+    status=0
+    out=$(FM_HOME="$home" FM_TASK="$body" \
+      "$ROOT/bin/fm-brief.sh" "sol-btprose-$i" firstmate --mode no-mistakes 2>&1) || status=$?
+    expect_code 1 "$status" "an unbounded wait inside backticks must not earn exemption"
+    assert_contains "$out" "unbounded wait" "refusal must name the unbounded wait"
+    assert_absent "$home/data/sol-btprose-$i/brief.md" \
+      "refused backticked-prose-wait scaffold must not write a brief"
+  done
+  pass "fm-brief.sh: a backticked prose wait cannot earn the exemption"
+}
+
+# A refusal must name the real cause: two conforming acceptance lines is a
+# too-many problem, not a missing-evidence one.
+test_duplicate_acceptance_refusal_names_the_real_cause() {
+  local home out status
+  home="$TMP_ROOT/sol-dup-home"
+  mkdir -p "$home/data"
+  status=0
+  # shellcheck disable=SC2016 # The task body is a literal fixture string.
+  out=$(FM_HOME="$home" FM_TASK='Acceptance command: `make test`
+Acceptance command: `make lint`' \
+    "$ROOT/bin/fm-brief.sh" sol-dup-1 firstmate --mode no-mistakes 2>&1) || status=$?
+  expect_code 1 "$status" "two acceptance command lines must refuse"
+  assert_contains "$out" "found 2 Acceptance command lines" \
+    "refusal must say how many acceptance lines were found"
+  assert_not_contains "$out" "missing exactly one" \
+    "refusal must not claim evidence is missing when two conforming lines are present"
+  pass "fm-brief.sh: a duplicate acceptance command refusal names the real cause"
+}
+
+# The unguarded Herdr gate is worker-facing generated text; it must not claim the
+# scaffold could not see a task body that was in fact supplied at scaffold time.
+test_herdr_gate_text_matches_scaffold_time_knowledge() {
+  local home unfilled filled
+  home="$TMP_ROOT/herdr-truth-home"
+  mkdir -p "$home/data"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" herdr-truth-plain firstmate --mode no-mistakes >/dev/null 2>&1 \
+    || fail "unfilled ship scaffold failed"
+  unfilled=$(cat "$home/data/herdr-truth-plain/brief.md")
+  assert_contains "$unfilled" "this scaffold cannot inspect the task text filled in above" \
+    "an unfilled {TASK} brief must keep its original hard safety gate wording"
+
+  # shellcheck disable=SC2016 # The task body is a literal fixture string.
+  FM_HOME="$home" FM_TASK='Fix the widget.
+Acceptance command: `make test`' \
+    "$ROOT/bin/fm-brief.sh" herdr-truth-filled firstmate --mode no-mistakes >/dev/null 2>&1 \
+    || fail "filled ship scaffold failed"
+  filled=$(cat "$home/data/herdr-truth-filled/brief.md")
+  assert_not_contains "$filled" "this scaffold cannot inspect the task text filled in above" \
+    "a brief scaffolded from FM_TASK must not claim the scaffold could not inspect the task"
+  assert_contains "$filled" "never inspects the task text above for Herdr lifecycle intent" \
+    "a filled brief must still carry a hard safety gate about Herdr lifecycle intent"
+  assert_contains "$filled" "regenerate the brief with \`--herdr-lab\` before dispatch" \
+    "a filled brief must keep the --herdr-lab remediation instruction"
+  pass "fm-brief.sh: the Herdr gate states only what the scaffold actually knows"
 }
 
 test_scout_and_secondmate_scaffold() {
@@ -1093,4 +1173,7 @@ test_ship_sol_exemption_accepts_trailing_acceptance_text
 test_ship_sol_exemption_refusals_are_never_silent
 test_fm_task_cannot_forge_scaffold_owned_contract_lines
 test_sol_evidence_block_records_every_validated_wait
+test_ship_sol_exemption_refuses_backticked_prose_wait
+test_duplicate_acceptance_refusal_names_the_real_cause
+test_herdr_gate_text_matches_scaffold_time_knowledge
 test_scout_and_secondmate_scaffold

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -862,7 +862,7 @@ test_fm_task_refused_on_scout_and_secondmate() {
 
   status=0
   out=$(FM_HOME="$home" FM_TASK='Charter the crew.' \
-    "$ROOT/bin/fm-brief.sh" sol-kind-sm alpha --secondmate --no-projects 2>&1) || status=$?
+    "$ROOT/bin/fm-brief.sh" sol-kind-sm --secondmate --no-projects 2>&1) || status=$?
   expect_code 1 "$status" "FM_TASK on a secondmate scaffold must refuse"
   assert_contains "$out" "FM_TASK applies only to ship briefs" \
     "secondmate refusal must name FM_TASK as ship-only"
@@ -922,6 +922,123 @@ Acceptance command: `make test`
   pass "fm-brief.sh: Sol exemption block owns its own blank-line separators"
 }
 
+# Regression: the validator accepted an acceptance line with trailing text while
+# the separate evidence grep was end-anchored, so the scaffold exited 1 with no
+# diagnostic at all. One walk now feeds both, and a refusal always names a cause.
+test_ship_sol_exemption_accepts_trailing_acceptance_text() {
+  local home brief status body i=0
+  # shellcheck disable=SC2016 # The task bodies are literal fixture strings.
+  for body in 'Fix it.
+Acceptance command: `make test` ' \
+              'Fix it.
+Acceptance command: `make test` (from the repo root)'; do
+    i=$((i + 1))
+    home="$TMP_ROOT/sol-trailing-home-$i"
+    mkdir -p "$home/data"
+    status=0
+    FM_HOME="$home" FM_TASK="$body" \
+      "$ROOT/bin/fm-brief.sh" "sol-trailing-$i" firstmate --mode no-mistakes >/dev/null 2>&1 || status=$?
+    expect_code 0 "$status" "acceptance line with trailing text must scaffold, not exit silently"
+    brief="$home/data/sol-trailing-$i/brief.md"
+    assert_present "$brief" "trailing-text acceptance ship brief was not scaffolded"
+    grep -qx "Sol exemption: earned" "$brief" \
+      || fail "brief missing the machine-readable Sol exemption line"
+    assert_grep "Acceptance command: \`make test\`" "$brief" \
+      "evidence block dropped the acceptance command"
+  done
+  pass "fm-brief.sh: an acceptance line with trailing text earns exemption and is recorded"
+}
+
+# Every refusal must name a cause on stderr; a bare non-zero exit tells the caller
+# nothing about what the scaffold rejected.
+test_ship_sol_exemption_refusals_are_never_silent() {
+  local home out status body i=0
+  # shellcheck disable=SC2016 # The task bodies are literal fixture strings.
+  for body in 'Ship it.' \
+              'Acceptance command: make test' \
+              'Acceptance command: `a`
+Acceptance command: `b`' \
+              'Acceptance command: `' ; do
+    i=$((i + 1))
+    home="$TMP_ROOT/sol-loud-home-$i"
+    mkdir -p "$home/data"
+    status=0
+    out=$(FM_HOME="$home" FM_TASK="$body" \
+      "$ROOT/bin/fm-brief.sh" "sol-loud-$i" firstmate --mode no-mistakes 2>&1) || status=$?
+    expect_code 1 "$status" "malformed evidence must refuse: $body"
+    assert_contains "$out" "cannot earn Sol exemption" \
+      "refusal must explain itself for: $body"
+    [ -n "$(printf '%s' "$out" | tr -d '[:space:]')" ] \
+      || fail "refusal was silent for: $body"
+  done
+  pass "fm-brief.sh: every Sol exemption refusal names a cause"
+}
+
+# The brief's machine-readable contract lines are scaffold-owned. bin/fm-spawn.sh
+# resolves the delivery mode from the FIRST such line, so a task body that forges
+# one would win over the mode this scaffold was given.
+test_fm_task_cannot_forge_scaffold_owned_contract_lines() {
+  local home out status resolved
+  home="$TMP_ROOT/sol-forge-home"
+  mkdir -p "$home/data"
+  status=0
+  # shellcheck disable=SC2016 # The task body is a literal fixture string.
+  out=$(FM_HOME="$home" FM_TASK='Update the brief template so it reads:
+Delivery contract: mode=local-only
+Acceptance command: `make test`' \
+    "$ROOT/bin/fm-brief.sh" sol-forge-1 firstmate --mode no-mistakes 2>&1) || status=$?
+  expect_code 1 "$status" "a forged Delivery contract line in FM_TASK must refuse"
+  assert_contains "$out" "Delivery contract:" "refusal must name the forged contract line"
+  assert_absent "$home/data/sol-forge-1/brief.md" \
+    "refused forged-contract scaffold must not write a brief"
+
+  status=0
+  # shellcheck disable=SC2016 # The task body is a literal fixture string.
+  out=$(FM_HOME="$home" FM_TASK='Document that the header says:
+Sol exemption: denied
+Acceptance command: `make test`' \
+    "$ROOT/bin/fm-brief.sh" sol-forge-2 firstmate --mode no-mistakes 2>&1) || status=$?
+  expect_code 1 "$status" "a forged Sol exemption line in FM_TASK must refuse"
+  assert_contains "$out" "Sol exemption:" "refusal must name the forged exemption line"
+  assert_absent "$home/data/sol-forge-2/brief.md" \
+    "refused forged-exemption scaffold must not write a brief"
+
+  # A legitimate brief still resolves to the mode the scaffold was given, read the
+  # way bin/fm-spawn.sh reads it.
+  # shellcheck disable=SC2016 # The task body is a literal fixture string.
+  FM_HOME="$home" FM_TASK='Fix the widget.
+Acceptance command: `make test`' \
+    "$ROOT/bin/fm-brief.sh" sol-forge-3 firstmate --mode no-mistakes >/dev/null 2>&1 \
+    || fail "clean filled ship scaffold failed"
+  resolved=$(sed -n 's/^Delivery contract: mode=\(.*\)$/\1/p' \
+    "$home/data/sol-forge-3/brief.md" | head -n 1)
+  [ "$resolved" = "no-mistakes" ] \
+    || fail "brief's first Delivery contract line resolved to '$resolved', not the scaffolded mode"
+  pass "fm-brief.sh: FM_TASK cannot forge scaffold-owned contract lines"
+}
+
+# The evidence block is the auditable artifact the exemption rests on: every wait
+# the gate validated must appear in it, including one written without a space
+# after the colon.
+test_sol_evidence_block_records_every_validated_wait() {
+  local home brief status
+  home="$TMP_ROOT/sol-evidence-home"
+  mkdir -p "$home/data"
+  status=0
+  # shellcheck disable=SC2016 # The task body is a literal fixture string.
+  FM_HOME="$home" FM_TASK='Acceptance command: `make test`
+Wait:CI green bound=30m escape=append blocked
+Wait: review bound=1h escape=ping firstmate' \
+    "$ROOT/bin/fm-brief.sh" sol-evidence-1 firstmate --mode no-mistakes >/dev/null 2>&1 || status=$?
+  expect_code 0 "$status" "bounded waits must scaffold"
+  brief="$home/data/sol-evidence-1/brief.md"
+  assert_grep "Wait:CI green bound=30m escape=append blocked" "$brief" \
+    "evidence block dropped a validated wait written without a space after the colon"
+  assert_grep "Wait: review bound=1h escape=ping firstmate" "$brief" \
+    "evidence block dropped a validated wait"
+  pass "fm-brief.sh: the evidence block records every wait the gate validated"
+}
+
 test_scout_and_secondmate_scaffold() {
   local brief
   FM_HOME="$BRIEF_HOME" "$ROOT/bin/fm-brief.sh" brief-scout-q6 alpha --scout >/dev/null 2>&1 \
@@ -972,4 +1089,8 @@ test_ship_sol_exemption_ignores_backticked_command_names
 test_fm_task_refused_on_scout_and_secondmate
 test_refused_scaffold_leaves_no_task_directory
 test_sol_exemption_block_spacing_is_stable
+test_ship_sol_exemption_accepts_trailing_acceptance_text
+test_ship_sol_exemption_refusals_are_never_silent
+test_fm_task_cannot_forge_scaffold_owned_contract_lines
+test_sol_evidence_block_records_every_validated_wait
 test_scout_and_secondmate_scaffold

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -983,6 +983,24 @@ Acceptance command: `b`' \
   pass "fm-brief.sh: every Sol exemption refusal names a cause"
 }
 
+test_ship_sol_exemption_refuses_non_command_acceptance_payloads() {
+  local home out status payload i=0
+  for payload in ' ' '&&' '>'; do
+    i=$((i + 1))
+    home="$TMP_ROOT/sol-non-command-home-$i"
+    mkdir -p "$home/data"
+    status=0
+    out=$(FM_HOME="$home" FM_TASK="Acceptance command: \`$payload\`" \
+      "$ROOT/bin/fm-brief.sh" "sol-non-command-$i" firstmate --mode no-mistakes 2>&1) || status=$?
+    expect_code 1 "$status" "non-command acceptance payload must refuse"
+    assert_contains "$out" "concrete executable command" \
+      "refusal must name the executable-command requirement"
+    assert_absent "$home/data/sol-non-command-$i/brief.md" \
+      "refused non-command acceptance payload must not write a brief"
+  done
+  pass "fm-brief.sh: non-command acceptance payloads cannot earn Sol exemption"
+}
+
 # The brief's machine-readable contract lines are scaffold-owned. bin/fm-spawn.sh
 # resolves the delivery mode from the FIRST such line, so a task body that forges
 # one would win over the mode this scaffold was given.
@@ -1171,6 +1189,7 @@ test_refused_scaffold_leaves_no_task_directory
 test_sol_exemption_block_spacing_is_stable
 test_ship_sol_exemption_accepts_trailing_acceptance_text
 test_ship_sol_exemption_refusals_are_never_silent
+test_ship_sol_exemption_refuses_non_command_acceptance_payloads
 test_fm_task_cannot_forge_scaffold_owned_contract_lines
 test_sol_evidence_block_records_every_validated_wait
 test_ship_sol_exemption_refuses_backticked_prose_wait


### PR DESCRIPTION
## Intent

Harden bin/fm-brief.sh so a ship brief earns exemption from the Sol spec stage only by already carrying (a) one executable acceptance command and (b) every wait bounded with an escape. The scaffold must refuse otherwise (Fable change 4, adopted 2026-08-25; mechanical, not judgment).

Ship scaffolds (--mode no-mistakes|direct-PR|local-only) refuse to emit an exempt ship brief unless the filled Task section (FM_TASK at scaffold time) or a dedicated exemption block the scaffold owns contains one concrete executable acceptance command and every wait bounded with an escape hatch. Both checks are machine-checkable at scaffold time.

The exemption is an auditable artifact: one machine-readable line the spawn path can later read, following the existing Delivery contract: mode= pattern. Scout and secondmate scaffolds are out of scope. Do not implement the Sol stage itself, spawn refusal on a missing spec, or Sol picking the model (later tasks). Do not add a spec template skill.

Acceptance command means concrete non-empty, non-comment, syntactically valid command in the brief (bash -n plus token checks), not scaffold-time PATH lookup. Scan trailing acceptance-line text for unbounded waits. Reject whitespace-only, comment-only, and prose-wait-in-backticks cases. Refuse FM_TASK loudly on scout/secondmate.

Portable tests in tests/<subject>.test.sh exercising fm-brief.sh; run bin/fm-lint.sh on script changes. Target bingb0t5/firstmate fork.

## What Changed

- Validate ship brief `FM_TASK` content for exactly one executable acceptance command and require every wait to include non-vacuous bounds and escape hatches.
- Emit auditable Sol exemption metadata and evidence for qualifying ship briefs while loudly refusing invalid, forged, scout, or secondmate inputs before writing files.
- Add comprehensive portable coverage for acceptance-command parsing, wait detection, exemption artifacts, refusal behavior, and scaffold formatting.

## Risk Assessment

✅ Low: The change is well-bounded, the successive fixes now satisfy the stated mechanical exemption invariants, and the full source review found no remaining material issue.

## Testing

No pre-run baseline results were supplied. The focused fm-brief behavioral suite passed, and manual end-to-end scaffold evidence demonstrated the valid exemption artifact plus representative required refusals across ship modes and scout scope. No source changes were needed; `bin/fm-lint.sh` was not run because this assigned test phase explicitly forbids linters.

<details>
<summary>Evidence: End-to-end Sol exemption CLI transcript</summary>

Source: [End-to-end Sol exemption CLI transcript](https://github.com/bingb0t5/firstmate/blob/35123cccb3edb72da0a2303f72c57ea8e6d10af4/.no-mistakes/evidence/fm/brief-scaffold-h1-fork/fm-brief-sol-exemption-e2e.txt)

```text
CASE: valid env-prefixed executable plus bounded wait
exit=0
scaffolded: /tmp/tmp.TajVI3hfNS/data/valid-e2e/brief.md (ship, mode=no-mistakes; Sol exemption earned)
# Task
Acceptance command: `BUILD_ID=$(git rev-parse HEAD) NODE_OPTIONS='--trace warnings' npm test`
Wait: CI bound=30m escape=abort

# Sol exemption evidence
Acceptance command: `BUILD_ID=$(git rev-parse HEAD) NODE_OPTIONS='--trace warnings' npm test`
Wait: CI bound=30m escape=abort

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold never inspects the task text above for Herdr lifecycle intent.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.
Delivery contract: mode=no-mistakes
Sol exemption: earned

CASE: unbounded trailing wait is refused
exit=1
error: ship brief cannot earn Sol exemption without auditable evidence:
  - each Wait: line must contain exactly one wait clause with its own bound= and escape=

CASE: punctuation-separated duplicate is refused
exit=1
error: ship brief cannot earn Sol exemption without auditable evidence:
  - Wait: lines must include non-empty bound=... and escape=... values

CASE: empty FM_TASK on scout is refused
exit=1
error: FM_TASK applies only to ship briefs; a scout report and a secondmate charter carry no Sol exemption, so fill their {TASK} section by hand
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"aba70f237ee0f730b7c37c5026e8e3e22aa83dfb","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (9) ✅</summary>

- 🚨 `bin/fm-brief.sh:285` - Intent requires rejecting &#34;prose-wait-in-backticks cases,&#34; but the new sed rule removes every whitespace-free backticked span. A task containing `Acceptance command: `make test`` followed by `Then `wait` before shipping.` earns the exemption because the bare prose wait is deleted before scanning. Preserve exact wait-family tokens for scanning while still ignoring names such as `wait-for-ci.sh`.
- 🚨 `bin/fm-brief.sh:208` - The required invariant is that every wait is genuinely bounded with an escape hatch, but this check accepts any non-empty token. For example, `Wait: approval bound=forever escape=none` earns `Sol exemption: earned` without either property. Define and validate machine-checkable bound and escape value forms, or explicitly confirm that arbitrary non-empty labels are the intended weaker contract.

🔧 Fix: Harden Sol wait exemption validation
2 errors still open:

- 🚨 `bin/fm-brief.sh:231` - The required fix says to preserve wait-family tokens inside backticks, but punctuation makes such a token disappear. For example, `Then `wait,` before shipping.` passes through `fm_brief_strip_backticked_names`; `wait,` does not match the exact wait-family regex, so the whole span is removed and the brief can earn exemption. Strip surrounding non-letter punctuation before classifying a whitespace-free backticked token, while continuing to ignore command names such as `wait-for-ci.sh`.
- 🚨 `bin/fm-brief.sh:216` - Vacuous wait values are rejected only when the complete token exactly matches the blacklist. Commonly punctuated or quoted forms such as `Wait: approval bound=forever, escape=&#34;none&#34;` are accepted and earn exemption even though neither value provides the required genuine bound or escape. Normalize surrounding quotes and punctuation before comparing against the forbidden values, without adding duration parsing.

🔧 Fix: Normalize decorated Sol wait evidence
1 error still open:

- 🚨 `bin/fm-brief.sh:313` - The required invariant says &#34;every wait bounded with an escape,&#34; but every `Wait:` line is removed from the prose scan after validating only one bound/escape pair. For example, `Wait: CI bound=30m escape=abort; then wait forever for approval` earns the exemption even though the second wait is unbounded. Scan additional wait-family mentions on `Wait:` lines and require each independently bounded, or reject lines containing multiple wait clauses.

🔧 Fix: Require one bounded wait per evidence line
1 error still open:

- 🚨 `bin/fm-brief.sh:236` - Intent requires continuing to ignore command-name backticks such as `wait-for-ci.sh`, but the greedy prefix in this regex processes only the final backticked span. A valid task like `Run `wait-for-ci.sh`, then archive `artifact.zip`.` leaves the first command name in prose, where `wait-for-ci.sh` matches the wait-family scan and wrongly refuses exemption. Parse backticked spans from left to right so every whitespace-free command/token name is removed independently while exact wait-family tokens remain visible.

🔧 Fix: Parse backticked spans left to right
1 error still open:

- 🚨 `bin/fm-brief.sh:322` - The required criterion says &#34;every wait bounded with an escape,&#34; but the acceptance-line branch removes the entire backticked command before scanning waits. `Acceptance command: `wait`` therefore earns `Sol exemption: earned` despite containing an unbounded exact wait-family token. Preserve exact wait-family commands for the wait scan while still excluding ordinary acceptance commands.

🔧 Fix: Scan acceptance commands for unbounded waits
2 errors still open:

- 🚨 `bin/fm-brief.sh:362` - The required criterion says &#34;Refuse FM_TASK loudly on scout/secondmate,&#34; but this condition only detects non-empty values. `FM_TASK=&#39;&#39; bin/fm-brief.sh ... --scout` silently scaffolds instead of refusing. Check whether the variable is set (for example `${FM_TASK+x}`), independently of whether its value is non-empty.
- 🚨 `bin/fm-brief.sh:217` - Only the first occurrence of each field is validated, so contradictory trailing values bypass the vacuous-value rule. For example, `Wait: approval bound=30m bound=forever escape=abort` earns exemption despite carrying `bound=forever`. Reject duplicate bound/escape keys or validate every occurrence before accepting the wait evidence.

🔧 Fix: Harden FM_TASK and wait field ownership
2 errors still open:

- 🚨 `bin/fm-brief.sh:218` - The required duplicate-key rejection remains bypassable when keys are punctuation-separated. `Wait: approval bound=30m,bound=forever escape=abort` is accepted because the duplicate search requires whitespace and the combined first value misses the vacuous blacklist. Detect repeated `bound=`/`escape=` keys across punctuation boundaries or validate every embedded occurrence.
- 🚨 `bin/fm-brief.sh:287` - The intent requires accepting a concrete executable command, but the first-token check rejects valid environment-prefixed commands such as `Acceptance command: `NODE_ENV=test npm test`` because the first token contains `=`. Continue rejecting assignment-only payloads while allowing one or more assignments when followed by an executable command token.

🔧 Fix: Harden wait fields and acceptance commands
2 errors still open:

- 🚨 `bin/fm-brief.sh:295` - The required &#34;concrete executable acceptance command&#34; check still accepts directory-only command words. `Acceptance command: `/`` reaches this character-class check, `/` is allowed, and `bash -n` reports valid syntax, so the brief incorrectly earns exemption even though `/` cannot be executed as a command. Reject command tokens that normalize to a directory-only path such as `/`, `./`, or repeated slashes, without performing PATH lookup.
- 🚨 `bin/fm-brief.sh:286` - The env-prefix fix tokenizes assignments by raw whitespace, so valid quoted assignments are refused. For `Acceptance command: `NODE_OPTIONS=&#39;--trace warnings&#39; npm test``, the loop consumes `NODE_OPTIONS=&#39;--trace`, then treats `warnings&#39;` as the executable and rejects it before `bash -n`, despite the command being syntactically valid and env-prefixed as explicitly required. Parse shell assignment words with quote awareness while retaining the assignment-only rejection and no-PATH-lookup constraint.

🔧 Fix: Parse quoted assignments and reject directory commands
1 error still open:

- 🚨 `bin/fm-brief.sh:288` - The required acceptance-command check still rejects valid environment-prefixed executable commands when an assignment contains an unquoted command substitution with whitespace. For example, `Acceptance command: `BUILD_ID=$(git rev-parse HEAD) npm test`` passes `bash -n`, but this tokenizer splits at the space inside `$()`, consumes `BUILD_ID=$(git` as an assignment, and rejects `rev-parse` as the executable. This contradicts the requirement to accept a syntactically valid concrete executable command and the adopted instruction to allow environment-prefixed commands. Track command-substitution nesting while finding shell-word boundaries, while retaining assignment-only rejection and no PATH lookup.

🔧 Fix: Accept command-substitution environment prefixes
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `tests/fm-brief.test.sh`
- <code>End-to-end CLI matrix invoking `bin/fm-brief.sh`: accepted an env-prefixed executable with command substitution, quoted assignment, and bounded wait; verified the emitted task, evidence block, delivery contract, and `Sol exemption: earned` line</code>
- <code>End-to-end refusal checks for a trailing unbounded wait, punctuation-separated duplicate wait fields, and an empty set `FM_TASK` on a scout scaffold</code>
- <code>`git status --short` after testing to confirm no transient worktree artifacts remained</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
