### PR TITLE
fix(bin): print git switch instead of git checkout for branch commands

### DIFF
--- a/.agents/skills/bootstrap-diagnostics/SKILL.md
+++ b/.agents/skills/bootstrap-diagnostics/SKILL.md
@@ -30,7 +30,7 @@ When any diagnostic needs captain attention, report the plain consequence and re
   Rerun the printed command; it is idempotent and re-derives every finding.
   A `hit the ...s bound` line means one of those checks is slow or unreachable - most often a remote secondmate host - and the stage stopped rather than letting it wedge; a `lock was no longer held` line means the session that asked for the sweeps no longer owns them, so leave them to the session that does.
 - `TANGLE: <remediation>` - the primary checkout is stranded on a feature branch instead of its default branch; `AGENTS.md` section 8 explains why this guard exists and what it protects.
-  The work is safe on that branch ref; restore the primary to its default branch with the printed `git -C <root> checkout <default>`, then re-validate that branch in a proper worktree.
+  The work is safe on that branch ref; restore the primary to its default branch with the printed `git -C <root> switch <default>`, then re-validate that branch in a proper worktree.
   This is the only sanctioned firstmate-initiated git write to the primary, and it is a non-destructive branch switch that strands nothing.
 - `STARTUP_MEMORY_BUDGET: invalid config/startup-memory-budget - <reason>` - the visible startup-memory budget is not a safe one-line positive decimal file; do not infer the default or propagate it.
   Correct the local primary file, then rerun session start so the normal convergence path can deliver the validated value to secondmate homes.

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -84,7 +84,7 @@
 #          secondmate_handoff_resume, x_mode_setup, fleet_sync) while still
 #          printing every read-only detect line
 #          above; the TANGLE line switches to advisory-only wording with no
-#          checkout command. Used by
+#          branch-restore command. Used by
 #          fm-session-start.sh's read-only path when another live session holds
 #          the fleet lock, so a second concurrent session never race-mutates
 #          PR-check artifacts, secondmate homes, pending handoff outboxes,

--- a/bin/fm-bootstrap.sh
+++ b/bin/fm-bootstrap.sh
@@ -1250,7 +1250,7 @@ detect_local_config() {
     if [ "${FM_BOOTSTRAP_DETECT_ONLY:-0}" = 1 ] && [ "${FM_BOOTSTRAP_LOCKED:-0}" != 1 ]; then
       echo "TANGLE: primary checkout on feature branch '$tangle_branch' (expected '$tangle_default'); the work is safe on that ref - read-only session must leave restore work to the session holding the fleet lock"
     else
-      echo "TANGLE: primary checkout on feature branch '$tangle_branch' (expected '$tangle_default'); the work is safe on that ref - restore the primary with: git -C $FM_ROOT checkout $tangle_default, then re-validate the branch in a proper worktree"
+      echo "TANGLE: primary checkout on feature branch '$tangle_branch' (expected '$tangle_default'); the work is safe on that ref - restore the primary with: git -C $FM_ROOT switch $tangle_default, then re-validate the branch in a proper worktree"
     fi
   fi
   crew=

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -447,7 +447,7 @@ You are in a disposable git worktree of $REPO, at a detached HEAD on a clean def
 The path check is authoritative: \`git rev-parse --git-dir\` and \`git rev-parse --git-common-dir\` can help inspect the repo, but they do not prove you are outside the primary checkout.
 If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append \`blocked: launched in primary checkout, not an isolated worktree\` to the status file and stop.
 
-1. First action: create your branch: \`git checkout -b fm/$ID\`$SETUP2
+1. First action: create your branch: \`git switch -c fm/$ID\`$SETUP2
 
 # Rules
 $RULE1

--- a/bin/fm-guard.sh
+++ b/bin/fm-guard.sh
@@ -141,7 +141,7 @@ if [ -n "$tangle_branch" ]; then
       printf '●  This read-only session must leave restore work to a session with verified fleet-lock ownership.\n'
     else
       printf "●  Restore the primary to '%s':\n" "$tangle_default"
-      printf '●      git -C %s checkout %s\n' "$FM_ROOT" "$tangle_default"
+      printf '●      git -C %s switch %s\n' "$FM_ROOT" "$tangle_default"
       printf "●  then re-validate '%s' in a proper isolated worktree.\n" "$tangle_branch"
     fi
     printf '●%s\n' "$trule"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -336,7 +336,7 @@ An absent or incompatible `gh-axi` reports `MISSING: gh-axi (install: npm instal
 An absent or incompatible `lavish-axi` reports `MISSING: lavish-axi (install: npm install -g lavish-axi && lavish-axi setup hooks)`.
 An absent or too-old `quota-axi` reports `MISSING: quota-axi (install: npm install -g quota-axi)`; firstmate cannot resolve a profile array without a compatible binary.
 Bootstrap also reports a `TANGLE:` line when `FM_ROOT` is on a named non-default branch; follow the printed checkout remediation rather than treating it as an installable tool problem.
-In a read-only session that did not get the fleet lock, the same line is advisory and omits the checkout command.
+In a read-only session that did not get the fleet lock, the same line is advisory and omits the branch-restore command.
 The locked session-start deferred network stage runs bootstrap's best-effort project clone refresh through `fm-fleet-sync.sh`; [`fm-bootstrap.sh`'s header](../bin/fm-bootstrap.sh) owns the exact clone-refresh overlap, liveness-before-convergence, per-mate concurrency, ordered diagnostic replay, and sequential-fallback contract.
 It emits `FLEET_SYNC:` for skipped refreshes that may matter, recovered self-heals, and `STUCK:` alarms.
 Normal completed runs keep local-only and no-origin skips silent.

--- a/tests/fm-session-start.test.sh
+++ b/tests/fm-session-start.test.sh
@@ -779,7 +779,7 @@ EOF
   assert_not_contains "$out" "drain them with bin/fm-wake-drain.sh" "read-only guard printed a mutating drain instruction"
   assert_not_contains "$out" "After draining queued wakes" "read-only guard printed a drain-then-rearm instruction"
   assert_not_contains "$out" "run bin/fm-watch-arm.sh" "read-only guard printed a mutating watcher-arm instruction"
-  assert_not_contains "$out" "git -C $root checkout main" "read-only bootstrap printed a state-changing checkout remediation"
+  assert_not_contains "$out" "git -C $root switch main" "read-only bootstrap printed a state-changing checkout remediation"
 
   # Detect-only bootstrap diagnostics still ran (the fakebin's PATH excludes
   # tasks-axi, so bootstrap's own read-only tool-detection line fires
@@ -2219,7 +2219,7 @@ EOF
 
   # A re-emit skips the sweeps because it ALREADY ran them, not because it lacks
   # the lock, so it must still own repair rather than deferring to a lock holder.
-  assert_contains "$reemit" "restore the primary with: git -C $root checkout main" \
+  assert_contains "$reemit" "restore the primary with: git -C $root switch main" \
     "--reemit disowned a repair it is entitled to perform"
   assert_not_contains "$reemit" "must leave restore work to the session holding the fleet lock" \
     "--reemit misreported itself as an unlocked read-only session"

--- a/tests/fm-tangle-guard.test.sh
+++ b/tests/fm-tangle-guard.test.sh
@@ -83,11 +83,11 @@ test_guard_banner() {
   out=$(run_guard "$repo")
   assert_contains "$out" "WORKTREE TANGLE" "guard did not alarm on a feature branch in the primary"
   assert_contains "$out" "fm/tangle-aa1" "guard banner did not name the offending branch"
-  assert_contains "$out" "checkout main" "guard banner did not print the restore remediation"
+  assert_contains "$out" "switch main" "guard banner did not print the restore remediation"
   out=$(FM_GUARD_READ_ONLY=1 run_guard "$repo")
   assert_contains "$out" "WORKTREE TANGLE" "read-only guard did not keep the tangle alarm"
   assert_contains "$out" "read-only session must leave restore work" "read-only guard did not explain restore ownership"
-  assert_not_contains "$out" "checkout main" "read-only guard printed a state-changing restore command"
+  assert_not_contains "$out" "switch main" "read-only guard printed a state-changing restore command"
   pass "fm-guard: bordered tangle banner fires only for a feature branch and suppresses repair commands in read-only mode"
 }
 
@@ -112,18 +112,18 @@ test_bootstrap_line() {
   git -C "$repo" checkout -q -B fm/tangle-bb2
   out=$(run_bootstrap "$repo" | grep '^TANGLE:' || true)
   assert_contains "$out" "fm/tangle-bb2" "bootstrap did not report the tangled branch"
-  assert_contains "$out" "checkout main" "bootstrap TANGLE line lacked the restore remediation"
+  assert_contains "$out" "switch main" "bootstrap TANGLE line lacked the restore remediation"
   out=$(FM_ROOT_OVERRIDE="$repo" FM_HOME="$repo" FM_BOOTSTRAP_DETECT_ONLY=1 "$ROOT/bin/fm-bootstrap.sh" 2>/dev/null | grep '^TANGLE:' || true)
   assert_contains "$out" "fm/tangle-bb2" "detect-only bootstrap did not report the tangled branch"
   assert_contains "$out" "read-only session must leave restore work" "detect-only bootstrap did not explain restore ownership"
-  assert_not_contains "$out" "checkout main" "detect-only bootstrap printed a state-changing restore command"
+  assert_not_contains "$out" "switch main" "detect-only bootstrap printed a state-changing restore command"
   pass "fm-bootstrap: TANGLE problem line fires only for a feature branch and suppresses repair commands in detect-only mode"
 }
 
 # --- GUARD 1a: brief isolation assertion ------------------------------------
 
 # The generated ship brief must carry the isolation assertion AHEAD of the
-# `git checkout -b` step, so the crewmate verifies its worktree before branching.
+# `git switch -c` step, so the crewmate verifies its worktree before branching.
 test_brief_assertion_precedes_branch() {
   local home brief iso br
   home="$TMP_ROOT/brief-home"
@@ -140,7 +140,7 @@ test_brief_assertion_precedes_branch() {
   assert_no_grep "they are identical in the primary checkout" "$brief" \
     "brief must not claim the primary checkout has identical git dirs"
   iso=$(grep -n 'launched in primary checkout, not an isolated worktree' "$brief" | head -1 | cut -d: -f1)
-  br=$(grep -n 'git checkout -b fm/' "$brief" | head -1 | cut -d: -f1)
+  br=$(grep -n 'git switch -c fm/' "$brief" | head -1 | cut -d: -f1)
   if [ -z "$iso" ] || [ -z "$br" ]; then
     fail "brief missing assertion ($iso) or branch step ($br)"
   fi


### PR DESCRIPTION
## Intent

Replace every INSTRUCTION this repository prints that tells an agent to run 'git checkout' with the equivalent 'git switch' form. Scope: three confirmed printed-instruction sites - bin/fm-brief.sh's generated ship-brief setup step ('git checkout -b fm/$ID' -> 'git switch -c fm/$ID'), bin/fm-guard.sh's tangle remediation printf, and bin/fm-bootstrap.sh's TANGLE diagnostic remediation echo - plus every tracked prose site that quotes those printed commands (found: .agents/skills/bootstrap-diagnostics/SKILL.md) and every test assertion matching the old printed strings (found and updated: tests/fm-tangle-guard.test.sh, tests/fm-session-start.test.sh). Reason for the change, for the PR description: git permission policies commonly deny git checkout outright because its file-restoring forms discard uncommitted work, which would block the very first instruction this repo prints to an agent (git checkout -b) and stop all work; git switch -c / git switch <branch> are the purpose-built modern equivalents (Git 2.23+, 2019) and are strictly safer since they refuse rather than discard conflicting local modifications, with destructive behavior gated behind explicit --force/--discard-changes flags a permission policy can deny on its own - so this is the objectively correct command for what these lines do, not a workaround. Explicitly OUT of scope, left untouched on purpose: git checkout calls a script EXECUTES itself (never printed as an instruction to an agent) in bin/fm-teardown.sh:2682 and :2695 and bin/fm-remote-secondmate-control.sh:277, since those run inside a script process and are never subject to an agent permission layer; bin/fm-tangle-lib.sh's comment, which uses 'checkout' as a noun, not a command; and every 'git checkout' invocation inside tests/ that is test-fixture setup executing the command itself rather than asserting on printed output (e.g. tests/fm-bearings-snapshot.test.sh, tests/fm-fleet-sync.test.sh, tests/fm-crew-state.test.sh, tests/fm-tangle-guard.test.sh's own repo-state helpers). No renaming, no restructuring, no unrelated fixes - diff is exactly these 6 files, 12 changed lines. Verification already performed by me: ran tests/fm-tangle-guard.test.sh, tests/fm-session-start.test.sh, tests/fm-bootstrap.test.sh, and tests/fm-brief.test.sh individually and via bin/fm-test-run.sh (all pass, 0 failures); ran bin/fm-lint.sh with pinned ShellCheck 0.11.0 and actionlint 1.7.12 installed locally (clean, exit 0); ran bin/fm-doc-audience-check.sh (ok). This PR targets a fork (push remote https://github.com/joaodiniz99/firstmate.git, PR opens against upstream kunchenguid/firstmate) - the PR description must stand alone for a maintainer with none of this context, state the defect and the general git-switch-is-correct/safer argument, and must NOT mention any individual machine's permission configuration as the motivation.

## What Changed

- The three sites that print a branch command for an agent to run now emit the `git switch` form: the generated ship brief's first setup step (`git switch -c fm/$ID` in `bin/fm-brief.sh`), the tangle remediation banner in `bin/fm-guard.sh`, and the `TANGLE:` diagnostic remediation in `bin/fm-bootstrap.sh` (`git -C <root> switch <default>`).
- Prose that quotes those printed commands was aligned: `.agents/skills/bootstrap-diagnostics/SKILL.md` now quotes `git -C <root> switch <default>`, and `docs/configuration.md` describes the omitted remediation as the "branch-restore command" rather than "the checkout command" (same wording fix in the `bin/fm-bootstrap.sh` header comment).
- Test assertions matching the old printed strings were updated in `tests/fm-tangle-guard.test.sh` and `tests/fm-session-start.test.sh`, including the brief guard that locates the branch step by `git switch -c fm/`. `git checkout` calls that a script executes itself, and test-fixture setup that runs the command directly, are unchanged: only printed instructions moved.

## Risk Assessment

✅ Low: A mechanical, semantically equivalent 12-line substitution of `git checkout` with the purpose-built `git switch` form in three printed-instruction sites plus their prose and test assertions, with no consumer coupled to the old strings and no behavioral difference reachable given how the default branch name is resolved.

## Testing

<code>Ran the four targeted suites named in the intent (fm-tangle-guard, fm-session-start, fm-brief, fm-bootstrap) individually — all pass, zero failures — and then produced product-level evidence rather than relying on those assertions: I generated a real ship brief and executed its printed first action (`git switch -c fm/switch-demo-e2e`) verbatim inside a detached-HEAD worktree, and I stranded a temp primary on a feature branch to trigger both the fm-guard banner and the fm-bootstrap TANGLE diagnostic, then ran the printed `git -C &lt;primary&gt; switch main` and confirmed the primary was restored with the feature branch intact. A before/after run of the base-commit scripts against identical inputs shows all three sites moving from `checkout` to `switch`, and a small git demo backs the PR&#39;s safety argument by showing `git checkout -- &lt;file&gt;` silently discards uncommitted work while `git switch` has no such form. This change has no UI, HTML, or rendered surface — the end-user surface is CLI and generated-Markdown text, so the evidence is captured as command transcripts and the generated brief section. I also confirmed the intent&#39;s out-of-scope claim holds: every remaining `git checkout` in bin/ and tests/ is a command a script executes itself or test-fixture setup, never an instruction printed to an agent. The worktree is clean; all scratch repos were created under /tmp.</code>

<details>
<summary>Evidence: Generated ship brief: the Setup section a crewmate agent reads</summary>

Source: [Generated ship brief: the Setup section a crewmate agent reads](https://github.com/joaodiniz99/firstmate/blob/66c2b8e01c62ed1eeb2b21b8b4bd39600a7ead2c/.no-mistakes/evidence/fm/brief-branch-cmd/01-ship-brief-printed-instruction.txt)

<code># Setup&#10;You are in a disposable git worktree of alpha, at a detached HEAD on a clean default branch.&#10;&#10;**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in...&#10;&#10;1. First action: create your branch: `git switch -c fm/switch-demo-e2e`&#10;2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.</code>

```text
=== 1. Generate a REAL ship brief with bin/fm-brief.sh ===
brief: /tmp/fm-switch-evidence.DnNhpR/home/data/switch-demo-e2e/brief.md

--- the Setup section the crewmate agent actually reads ---
# Setup
You are in a disposable git worktree of alpha, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git switch -c fm/switch-demo-e2e`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
```
</details>
<details>
<summary>Evidence: Agent follows the printed instruction verbatim (end-to-end)</summary>

Source: [Agent follows the printed instruction verbatim (end-to-end)](https://github.com/joaodiniz99/firstmate/blob/66c2b8e01c62ed1eeb2b21b8b4bd39600a7ead2c/.no-mistakes/evidence/fm/brief-branch-cmd/02-agent-runs-printed-instruction.txt)

<code>$ disposable worktree state before the first action:&#10;## HEAD (no branch)&#10;&#10;$ # command copied verbatim out of the generated brief&#10;$ git switch -c fm/switch-demo-e2e&#10;Switched to a new branch &#39;fm/switch-demo-e2e&#39;&#10;&#10;$ git -C &lt;worktree&gt; status -sb&#10;## fm/switch-demo-e2e&#10;&#10;RESULT: the first instruction the repo prints to an agent executes cleanly and creates the task branch.</code>

```text
=== 2. An agent follows that printed instruction verbatim, in the state the brief describes ===
$ disposable worktree state before the first action:
## HEAD (no branch)

$ # command copied verbatim out of the generated brief
$ git switch -c fm/switch-demo-e2e
Switched to a new branch 'fm/switch-demo-e2e'

$ git -C <worktree> status -sb
## fm/switch-demo-e2e
$ git -C <worktree> rev-parse --abbrev-ref HEAD
fm/switch-demo-e2e

RESULT: the first instruction the repo prints to an agent executes cleanly and creates the task branch.
```
</details>
<details>
<summary>Evidence: Tangle remediation: fm-guard banner + fm-bootstrap diagnostic, then the printed command run</summary>

Source: [Tangle remediation: fm-guard banner + fm-bootstrap diagnostic, then the printed command run](https://github.com/joaodiniz99/firstmate/blob/66c2b8e01c62ed1eeb2b21b8b4bd39600a7ead2c/.no-mistakes/evidence/fm/brief-branch-cmd/03-tangle-remediation.txt)

<code>$ bin/fm-guard.sh # what the captain sees&#10;● WORKTREE TANGLE - PRIMARY CHECKOUT IS ON A FEATURE BRANCH&#10;● &lt;primary&gt; is on &#39;fm/readme-restructure-d3&#39;, not its default branch &#39;main&#39;.&#10;● The work is SAFE on the &#39;fm/readme-restructure-d3&#39; ref.&#10;● Restore the primary to &#39;main&#39;:&#10;● git -C &lt;primary&gt; switch main&#10;● then re-validate &#39;fm/readme-restructure-d3&#39; in a proper isolated worktree.&#10;&#10;$ bin/fm-bootstrap.sh # the TANGLE diagnostic line&#10;TANGLE: primary checkout on feature branch &#39;fm/readme-restructure-d3&#39; (expected &#39;main&#39;); the work is safe on that ref - restore the primary with: git -C &lt;primary&gt; switch main, then re-validate the branch in a proper worktree&#10;&#10;$ # captain copies the printed restore command verbatim and runs it&#10;$ git -C &lt;primary&gt; switch main&#10;Switched to branch &#39;main&#39;&#10;$ git -C &lt;primary&gt; branch --list fm/readme-restructure-d3 # the work is still there&#10;fm/readme-restructure-d3</code>

```text
=== 3. Tangle remediation: fm-guard.sh banner + fm-bootstrap.sh diagnostic ===
$ # primary checkout stranded on a feature branch (the 'tangle')
fm/readme-restructure-d3

$ bin/fm-guard.sh   # what the captain sees
●  WORKTREE TANGLE - PRIMARY CHECKOUT IS ON A FEATURE BRANCH
●  /tmp/fm-switch-evidence.DnNhpR/primary is on 'fm/readme-restructure-d3', not its default branch 'main'.
●  A crewmate likely branched/committed in the primary instead of its own worktree.
●  The work is SAFE on the 'fm/readme-restructure-d3' ref.
●  Restore the primary to 'main':
●      git -C /tmp/fm-switch-evidence.DnNhpR/primary switch main
●  then re-validate 'fm/readme-restructure-d3' in a proper isolated worktree.
●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

$ bin/fm-bootstrap.sh   # the TANGLE diagnostic line
TANGLE: primary checkout on feature branch 'fm/readme-restructure-d3' (expected 'main'); the work is safe on that ref - restore the primary with: git -C /tmp/fm-switch-evidence.DnNhpR/primary switch main, then re-validate the branch in a proper worktree

$ # captain copies the printed restore command verbatim and runs it
$ git -C /tmp/fm-switch-evidence.DnNhpR/primary switch main
Switched to branch 'main'
$ git -C <primary> rev-parse --abbrev-ref HEAD
main
$ git -C <primary> branch --list fm/readme-restructure-d3   # the work is still there, nothing stranded
  fm/readme-restructure-d3

RESULT: both remediation surfaces print 'git switch', and the printed command restores the primary.
```
</details>
<details>
<summary>Evidence: Before/after on identical inputs (base 6a2cd6c vs this change)</summary>

Source: [Before/after on identical inputs (base 6a2cd6c vs this change)](https://github.com/joaodiniz99/firstmate/blob/66c2b8e01c62ed1eeb2b21b8b4bd39600a7ead2c/.no-mistakes/evidence/fm/brief-branch-cmd/05-before-after.txt)

<code>[BEFORE] ship brief, step 1:&#10;1. First action: create your branch: `git checkout -b fm/ba-demo-77`&#10;[BEFORE] fm-guard.sh tangle banner:&#10;● git -C &lt;primary&gt; checkout main&#10;[BEFORE] fm-bootstrap.sh TANGLE diagnostic:&#10;git -C &lt;primary&gt; checkout main&#10;&#10;[AFTER] ship brief, step 1:&#10;1. First action: create your branch: `git switch -c fm/ba-demo-77`&#10;[AFTER] fm-guard.sh tangle banner:&#10;● git -C &lt;primary&gt; switch main&#10;[AFTER] fm-bootstrap.sh TANGLE diagnostic:&#10;git -C &lt;primary&gt; switch main</code>

```text
=== 5. Before / after, same inputs (base 6a2cd6c vs this change) ===

[BEFORE] ship brief, step 1 (what the crewmate agent is told to run first):
      1. First action: create your branch: `git checkout -b fm/ba-demo-77`
[BEFORE] fm-guard.sh tangle banner, restore command:
      ●      git -C <primary> checkout main
[BEFORE] fm-bootstrap.sh TANGLE diagnostic, restore command:
      git -C <primary> checkout main

[AFTER] ship brief, step 1 (what the crewmate agent is told to run first):
      1. First action: create your branch: `git switch -c fm/ba-demo-77`
[AFTER] fm-guard.sh tangle banner, restore command:
      ●      git -C <primary> switch main
[AFTER] fm-bootstrap.sh TANGLE diagnostic, restore command:
      git -C <primary> switch main

RESULT: all three printed-instruction sites changed from 'git checkout' to 'git switch'.
```
</details>
<details>
<summary>Evidence: Why git switch is the correct command, demonstrated</summary>

Source: [Why git switch is the correct command, demonstrated](https://github.com/joaodiniz99/firstmate/blob/66c2b8e01c62ed1eeb2b21b8b4bd39600a7ead2c/.no-mistakes/evidence/fm/brief-branch-cmd/04-why-git-switch.txt)

<code>git version 2.50.1&#10;&#10;$ git -C &lt;repo&gt; checkout -- f.txt # the file-restoring form: silently destroys it&#10;exit=0&#10;f.txt is now: committed &lt;-- work gone, no prompt, no confirmation&#10;&#10;$ git -C &lt;repo&gt; switch -- f.txt # git switch has no such form at all&#10;fatal: invalid reference: f.txt&#10;exit=128&#10;f.txt is still: UNCOMMITTED WORK &lt;-- work intact</code>

```text
=== 4. Why 'git switch' is the correct command, not a workaround ===
git version: git version 2.50.1 (Apple Git-155)

$ # uncommitted work in the tree:
 M f.txt
UNCOMMITTED WORK

$ git -C <repo> checkout -- f.txt      # the file-restoring form: silently destroys it
  exit=0
  f.txt is now: committed   <-- work gone, no prompt, no confirmation

$ git -C <repo> switch -- f.txt       # git switch has no such form at all
fatal: invalid reference: f.txt
  exit=128
  f.txt is still: UNCOMMITTED WORK   <-- work intact

RESULT: 'git checkout' is one CLI verb covering both branch switching and destructive file
restore, so a policy can only allow or deny the whole verb. 'git switch' does only the branch
operation; its destructive behavior sits behind explicit --force/--discard-changes flags.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"806c51da8717f071c69de68a645483fb7a6fa468","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `docs/configuration.md:338` - docs/configuration.md:338-339 still describe the TANGLE remediation as &#34;the printed checkout remediation&#34; and &#34;omits the checkout command&#34;, but the printed command is now `git -C &lt;root&gt; switch &lt;default&gt;`. These lines describe the command rather than quoting it, so they fall outside the intent&#39;s stated prose scope (&#34;every tracked prose site that quotes those printed commands&#34;) and the intent explicitly caps the diff at these 6 files. Noting only; no change recommended in this change.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-tangle-guard.test.sh` (6 assertions, exit 0) - covers the guard banner, bootstrap TANGLE line, and brief branch-step ordering</code>
- <code>`bash tests/fm-session-start.test.sh` (49 assertions, exit 0) - covers the read-only bootstrap and --reemit restore-remediation assertions</code>
- <code>`bash tests/fm-brief.test.sh` (exit 0) - full ship-brief scaffolding suite</code>
- <code>`bash tests/fm-bootstrap.test.sh` (28 assertions, exit 0)</code>
- <code>Manual E2E: generated a real brief via `FM_HOME=&lt;tmp&gt; bin/fm-brief.sh switch-demo-e2e alpha --mode no-mistakes`, then ran its printed step 1 (`git switch -c fm/switch-demo-e2e`) verbatim inside a detached-HEAD linked worktree and confirmed the branch was created</code>
- <code>Manual E2E: stranded a temp primary on `fm/readme-restructure-d3`, ran `FM_ROOT_OVERRIDE=&lt;repo&gt; bin/fm-guard.sh` and `bin/fm-bootstrap.sh`, then executed the printed `git -C &lt;primary&gt; switch main` and confirmed the primary was restored with the feature branch intact</code>
- <code>Manual before/after: ran base-commit (`6a2cd6c`) copies of fm-brief.sh, fm-guard.sh and fm-bootstrap.sh against identical inputs and diffed the printed commands against the current versions</code>
- <code>Manual rationale check: demonstrated that `git checkout -- &lt;file&gt;` silently discards uncommitted work while `git switch -- &lt;file&gt;` refuses (exit 128, file intact)</code>
- <code>Scope sweep: `grep -rn &#34;git checkout&#34;` over bin/, .agents/, docs and tests to confirm every remaining occurrence is script-executed or test-fixture setup rather than a printed instruction</code>
</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/configuration.md:338` - Judgment call, left intentionally unchanged: `docs/configuration.md:338` (&#34;follow the printed checkout remediation&#34;), `AGENTS.md:168` and `:176` (&#34;without a checkout repair command&#34;), and `docs/configuration.md:655` (&#34;suppress ... checkout repair commands&#34;) all use &#34;checkout&#34; as a noun meaning the primary working copy, matching `bin/fm-tangle-lib.sh`&#39;s comment that the change deliberately left alone. They remain accurate and were not reworded. Only the two bare &#34;the checkout command&#34; phrasings, which read as naming the `git checkout` command itself, were corrected.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: no lint fixes needed; linter clean with pinned tools
1 warning still open:

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
