### PR TITLE
fix(bin): require a verified run and confirmed PR base in generated briefs

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -383,7 +383,7 @@ case "$MODE" in
 Delivery contract: mode=direct-PR
 This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
 The task is complete only when committed on your branch.
-When it is implemented and committed, push your branch and, before opening the PR, verify its target branch is correct, then append \`done: PR {url}\` to the status file and stop.
+When it is implemented and committed, push your branch, confirm the PR base is the base branch this task names - the repo's default branch when it names none - and open a PR with \`gh-axi\` against that base, then append \`done: PR {url}\` to the status file and stop.
 Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
 EOF
     ;;
@@ -407,8 +407,9 @@ EOF
     IFS= read -r -d '' DOD <<EOF || true
 # Definition of done
 Delivery contract: mode=no-mistakes
-The task is complete only when committed on your branch.
-When it is implemented and committed, run /no-mistakes to validate and ship a PR.
+Committing on your branch starts validation; it never completes the task.
+When the implementation is committed, append \`done: {summary}\` to the status file and stop.
+Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
 Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
@@ -421,7 +422,7 @@ Two firstmate-specific rules layer on top of that guidance:
   When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
 - Avoid \`--yes\`: it would silently bypass firstmate's authority check and any required captain escalation.
 
-Before appending \`done:\`, verify the no-mistakes run is for your branch and all checks are green.
+Before appending the final \`done: PR {url} checks green\`, verify the no-mistakes run is for your branch and all checks are green - a commit or manual tests are never enough.
 After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
 EOF
     ;;

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -383,7 +383,7 @@ case "$MODE" in
 Delivery contract: mode=direct-PR
 This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
 The task is complete only when committed on your branch.
-When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
+When it is implemented and committed, push your branch and, before opening the PR, verify its target branch is correct, then append \`done: PR {url}\` to the status file and stop.
 Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
 EOF
     ;;
@@ -408,8 +408,7 @@ EOF
 # Definition of done
 Delivery contract: mode=no-mistakes
 The task is complete only when committed on your branch.
-When you believe it is complete, append \`done: {summary}\` to the status file and stop.
-Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.
+When it is implemented and committed, run /no-mistakes to validate and ship a PR.
 
 You drive no-mistakes by responding to its gates, not by implementing fixes.
 Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and \`no-mistakes axi run --help\` plus the \`help\` lines in each \`axi\` response are authoritative and version-matched to the installed binary.
@@ -422,6 +421,7 @@ Two firstmate-specific rules layer on top of that guidance:
   When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
 - Avoid \`--yes\`: it would silently bypass firstmate's authority check and any required captain escalation.
 
+Before appending \`done:\`, verify the no-mistakes run is for your branch and all checks are green.
 After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
 EOF
     ;;

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -256,7 +256,7 @@ test_ship_mode_is_explicit_not_registry() {
   brief="$home/data/brief-explicit-a5/brief.md"
   grep -qx "Delivery contract: mode=no-mistakes" "$brief" \
     || fail "registered direct-PR posture overrode the explicit --mode"
-  assert_grep "When it is implemented and committed, run /no-mistakes to validate and ship a PR." "$brief" \
+  assert_grep "Firstmate will then instruct you to run /no-mistakes" "$brief" \
     "explicit no-mistakes brief did not render the pipeline definition of done"
 
   # An unregistered project is not a blocker either, because nothing is looked up.
@@ -345,10 +345,12 @@ test_no_mistakes_dod_wording() {
     "no-mistakes DOD must keep direct requirements and exclude generic scaffold boilerplate from --intent"
   assert_grep "exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific" "$brief" \
     "no-mistakes DOD must exclude non-task-specific scaffold boilerplate from --intent"
-  assert_grep "Before appending \`done:\`, verify the no-mistakes run is for your branch and all checks are green." "$brief" \
-    "no-mistakes DOD must require a green run for the worker's own branch before done:"
-  assert_no_grep "When you believe it is complete, append \`done:" "$brief" \
-    "no-mistakes DOD must not treat a committed implementation as done"
+  assert_grep "Before appending the final \`done: PR {url} checks green\`, verify the no-mistakes run is for your branch and all checks are green - a commit or manual tests are never enough." "$brief" \
+    "no-mistakes DOD must require a green run for the worker's own branch before the final done:"
+  assert_no_grep "The task is complete only when committed on your branch." "$brief" \
+    "no-mistakes DOD must not treat a committed implementation as a complete task"
+  assert_grep "Firstmate will then instruct you to run /no-mistakes to validate and ship a PR." "$brief" \
+    "no-mistakes DOD must keep firstmate as the trigger for the validation run"
   # The apostrophe in "firstmate's authority check" is now structurally safe
   # (no `$(...)` wrapper around the heredoc), so it renders verbatim instead of
   # being reworded or escaped away. test_no_heredoc_in_command_substitution
@@ -365,9 +367,9 @@ test_direct_pr_confirms_target_branch_before_opening() {
   id="brief-pr-target-b2"
   FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode direct-PR >/dev/null 2>&1
   brief="$home/data/$id/brief.md"
-  assert_grep "before opening the PR, verify its target branch is correct" "$brief" \
-    "direct-PR DOD must require confirming the PR target branch before opening it"
-  pass "fm-brief.sh: direct-PR DOD confirms the target branch before opening a PR"
+  assert_grep "confirm the PR base is the base branch this task names - the repo's default branch when it names none - and open a PR with \`gh-axi\` against that base" "$brief" \
+    "direct-PR DOD must require confirming the PR base against the task's named base before opening it"
+  pass "fm-brief.sh: direct-PR DOD confirms the PR base before opening a PR"
 }
 
 test_ship_project_memory_wording() {

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -256,7 +256,7 @@ test_ship_mode_is_explicit_not_registry() {
   brief="$home/data/brief-explicit-a5/brief.md"
   grep -qx "Delivery contract: mode=no-mistakes" "$brief" \
     || fail "registered direct-PR posture overrode the explicit --mode"
-  assert_grep "Firstmate will then instruct you to run /no-mistakes" "$brief" \
+  assert_grep "When it is implemented and committed, run /no-mistakes to validate and ship a PR." "$brief" \
     "explicit no-mistakes brief did not render the pipeline definition of done"
 
   # An unregistered project is not a blocker either, because nothing is looked up.
@@ -345,6 +345,10 @@ test_no_mistakes_dod_wording() {
     "no-mistakes DOD must keep direct requirements and exclude generic scaffold boilerplate from --intent"
   assert_grep "exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific" "$brief" \
     "no-mistakes DOD must exclude non-task-specific scaffold boilerplate from --intent"
+  assert_grep "Before appending \`done:\`, verify the no-mistakes run is for your branch and all checks are green." "$brief" \
+    "no-mistakes DOD must require a green run for the worker's own branch before done:"
+  assert_no_grep "When you believe it is complete, append \`done:" "$brief" \
+    "no-mistakes DOD must not treat a committed implementation as done"
   # The apostrophe in "firstmate's authority check" is now structurally safe
   # (no `$(...)` wrapper around the heredoc), so it renders verbatim instead of
   # being reworded or escaped away. test_no_heredoc_in_command_substitution
@@ -352,6 +356,18 @@ test_no_mistakes_dod_wording() {
   assert_grep "firstmate's authority check" "$brief" \
     "no-mistakes DOD lost the apostrophe prose that the structural fix makes parse-safe"
   pass "fm-brief.sh: no-mistakes DOD keeps its apostrophe prose, now parse-safe"
+}
+
+test_direct_pr_confirms_target_branch_before_opening() {
+  local home id brief
+  home="$TMP_ROOT/pr-target-home"
+  mkdir -p "$home/data"
+  id="brief-pr-target-b2"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode direct-PR >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_grep "before opening the PR, verify its target branch is correct" "$brief" \
+    "direct-PR DOD must require confirming the PR target branch before opening it"
+  pass "fm-brief.sh: direct-PR DOD confirms the target branch before opening a PR"
 }
 
 test_ship_project_memory_wording() {
@@ -756,6 +772,7 @@ test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
+test_direct_pr_confirms_target_branch_before_opening
 test_ship_project_memory_wording
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path


### PR DESCRIPTION
## Intent

Endurecer el andamiaje de instrucciones que genera bin/fm-brief.sh para cerrar dos agujeros repetidos: en briefs mode=no-mistakes, done: solo puede informarse tras verificar que existe una corrida de no-mistakes de la propia rama y todas las verificaciones están verdes, nunca solo por haber hecho commit o correr pruebas manuales. En el andamiaje que indica abrir un PR, exigir verificar el destino correcto antes de abrirlo, sin codificar reglas específicas de proyectos. Cambios mínimos y quirúrgicos únicamente en bin/fm-brief.sh y sus pruebas existentes; no tocar AGENTS.md, scouts ni charters, ni añadir condiciones ajenas. Las condiciones deben ser breves y verificables.

## What Changed

- `bin/fm-brief.sh`: the `mode=no-mistakes` definition of done now states that committing on the branch starts validation instead of completing the task, and adds a check before the final `done: PR {url} checks green` — the no-mistakes run must be for the worker's own branch with all checks green, so a commit or manual tests never suffice. The intermediate `done: {summary}` handshake that lets firstmate trigger the validation run is kept.
- `bin/fm-brief.sh`: the `mode=direct-PR` definition of done now requires confirming the PR base before opening it — the base branch the task names, or the repo's default branch when it names none — stated without encoding project-specific rules.
- `tests/fm-brief.test.sh`: extends `test_no_mistakes_dod_wording` with three assertions (new verification sentence present, old commit-equals-done phrasing absent, firstmate-triggered validation preserved) and adds `test_direct_pr_confirms_target_branch_before_opening`; the suite runs 22 green cases, and the Review gate left one open warning asking the author to confirm that the intent's `done:` constraint refers to the terminal ready signal, plus one informational note about direct-PR wording parity.

## Risk Assessment

⚠️ Medium: El cambio es texto de andamiaje bien acotado, con pruebas actualizadas en paralelo y sin referencias colgantes, pero el criterio central del intent —que `done:` nunca se informe solo por haber commiteado— sigue sin cumplirse literalmente para la señal intermedia, que el nuevo texto exceptúa de forma explícita.

## Testing

Ejecuté la suite dirigida `tests/fm-brief.test.sh` (verde, con los casos nuevos para ambos agujeros) y comprobé que esas pruebas fallan contra el script del commit base, de modo que realmente protegen el cambio; además corrí las dos suites vecinas que generan briefs (`fm-ask-user-authority`, `fm-tangle-guard`), también verdes. Como evidencia de producto generé briefs reales con `bin/fm-brief.sh` bajo un FM_HOME temporal para `mode=no-mistakes` y `mode=direct-PR` y adjunté la comparación antes/después de la sección «Definition of done», que es exactamente el texto que lee el agente trabajador: se ve que el commit ya no cierra la tarea y que se exige una corrida verde de la propia rama, y que abrir PR exige confirmar la base correcta sin reglas específicas de proyectos. El cambio no tiene superficie de UI, por lo que la evidencia visual aplicable es el markdown renderizado del brief generado. El árbol de trabajo quedó limpio tras la validación.

<details>
<summary>Evidence: Comparación antes/después de la sección «Definition of done» generada (ambos modos)</summary>

<code>### ANTES (base 038d0f7) — mode=no-mistakes&#10;The task is complete only when committed on your branch.&#10;When you believe it is complete, append `done: {summary}` to the status file and stop.&#10;...&#10;After /no-mistakes reports CI green ... append `done: PR {url} checks green` and stop.&#10;&#10;### DESPUÉS (5c32f9a) — mode=no-mistakes&#10;Committing on your branch starts validation; it never completes the task.&#10;When the implementation is committed, append `done: {summary}` to the status file and stop.&#10;...&#10;Before appending the final `done: PR {url} checks green`, verify the no-mistakes run is for your branch and all checks are green - a commit or manual tests are never enough.&#10;After /no-mistakes reports CI green ... append `done: PR {url} checks green` and stop.&#10;&#10;### ANTES (base 038d0f7) — mode=direct-PR&#10;When it is implemented and committed, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` to the status file and stop.&#10;&#10;### DESPUÉS (5c32f9a) — mode=direct-PR&#10;When it is implemented and committed, push your branch, confirm the PR base is the base branch this task names - the repo&#39;s default branch when it names none - and open a PR with `gh-axi` against that base, then append `done: PR {url}` to the status file and stop.</code>

```text
### ANTES (base 038d0f7) — mode=no-mistakes
`` `
# Definition of done
Delivery contract: mode=no-mistakes
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies `ask-user-authority` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
`` `

### DESPUÉS (5c32f9a) — mode=no-mistakes
`` `
# Definition of done
Delivery contract: mode=no-mistakes
Committing on your branch starts validation; it never completes the task.
When the implementation is committed, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies `ask-user-authority` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

Before appending the final `done: PR {url} checks green`, verify the no-mistakes run is for your branch and all checks are green - a commit or manual tests are never enough.
After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
`` `

### ANTES (base 038d0f7) — mode=direct-PR
`` `
# Definition of done
Delivery contract: mode=direct-PR
This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
The task is complete only when committed on your branch.
When it is implemented and committed, push your branch and open a PR with `gh-axi`, then append `done: PR {url}` to the status file and stop.
Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
`` `

### DESPUÉS (5c32f9a) — mode=direct-PR
`` `
# Definition of done
Delivery contract: mode=direct-PR
This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
The task is complete only when committed on your branch.
When it is implemented and committed, push your branch, confirm the PR base is the base branch this task names - the repo's default branch when it names none - and open a PR with `gh-axi` against that base, then append `done: PR {url}` to the status file and stop.
Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
`` `
```
</details>
<details>
<summary>Evidence: Brief generado end-to-end para mode=no-mistakes</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text filled in above.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of firstmate, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/demo-nm`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/8q/s7sl96nn6mg9vp5_6t335qqr0000gp/T/no-mistakes-evidence/01M0TYTT79CFCZ35JXKMJ5N9Y8/brief-home/state/demo-nm.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Firstmate instruction inbox
Firstmate steers you through durable message files in '/var/folders/8q/s7sl96nn6mg9vp5_6t335qqr0000gp/T/no-mistakes-evidence/01M0TYTT79CFCZ35JXKMJ5N9Y8/brief-home/state/demo-nm.inbox'.
When a terminal message says an instruction is waiting there - and at any natural checkpoint when you are unsure - list '/var/folders/8q/s7sl96nn6mg9vp5_6t335qqr0000gp/T/no-mistakes-evidence/01M0TYTT79CFCZ35JXKMJ5N9Y8/brief-home/state/demo-nm.inbox'/*.msg, read and act on each message in numeric order, then acknowledge each handled message by moving it: `mv '/var/folders/8q/s7sl96nn6mg9vp5_6t335qqr0000gp/T/no-mistakes-evidence/01M0TYTT79CFCZ35JXKMJ5N9Y8/brief-home/state/demo-nm.inbox'/NNN.msg '/var/folders/8q/s7sl96nn6mg9vp5_6t335qqr0000gp/T/no-mistakes-evidence/01M0TYTT79CFCZ35JXKMJ5N9Y8/brief-home/state/demo-nm.inbox'/handled/`.
The move IS the acknowledgement: without it firstmate rings again and eventually treats you as stuck. An empty or absent inbox needs no action.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/M-matiascordova/.no-mistakes/worktrees/5e4f0607c2e2/01M0TYTT79CFCZ35JXKMJ5N9Y8/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/M-matiascordova/.no-mistakes/worktrees/5e4f0607c2e2/01M0TYTT79CFCZ35JXKMJ5N9Y8/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=no-mistakes
Committing on your branch starts validation; it never completes the task.
When the implementation is committed, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
  Firstmate applies `ask-user-authority` and obtains any required captain decision.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

Before appending the final `done: PR {url} checks green`, verify the no-mistakes run is for your branch and all checks are green - a commit or manual tests are never enough.
After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>
<details>
<summary>Evidence: Brief generado end-to-end para mode=direct-PR</summary>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text filled in above.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of firstmate, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/demo-pr`

# Rules
1. Never push to the default branch (push only your `fm/demo-pr` branch). Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/8q/s7sl96nn6mg9vp5_6t335qqr0000gp/T/no-mistakes-evidence/01M0TYTT79CFCZ35JXKMJ5N9Y8/brief-home/state/demo-pr.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Firstmate instruction inbox
Firstmate steers you through durable message files in '/var/folders/8q/s7sl96nn6mg9vp5_6t335qqr0000gp/T/no-mistakes-evidence/01M0TYTT79CFCZ35JXKMJ5N9Y8/brief-home/state/demo-pr.inbox'.
When a terminal message says an instruction is waiting there - and at any natural checkpoint when you are unsure - list '/var/folders/8q/s7sl96nn6mg9vp5_6t335qqr0000gp/T/no-mistakes-evidence/01M0TYTT79CFCZ35JXKMJ5N9Y8/brief-home/state/demo-pr.inbox'/*.msg, read and act on each message in numeric order, then acknowledge each handled message by moving it: `mv '/var/folders/8q/s7sl96nn6mg9vp5_6t335qqr0000gp/T/no-mistakes-evidence/01M0TYTT79CFCZ35JXKMJ5N9Y8/brief-home/state/demo-pr.inbox'/NNN.msg '/var/folders/8q/s7sl96nn6mg9vp5_6t335qqr0000gp/T/no-mistakes-evidence/01M0TYTT79CFCZ35JXKMJ5N9Y8/brief-home/state/demo-pr.inbox'/handled/`.
The move IS the acknowledgement: without it firstmate rings again and eventually treats you as stuck. An empty or absent inbox needs no action.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/M-matiascordova/.no-mistakes/worktrees/5e4f0607c2e2/01M0TYTT79CFCZ35JXKMJ5N9Y8/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/M-matiascordova/.no-mistakes/worktrees/5e4f0607c2e2/01M0TYTT79CFCZ35JXKMJ5N9Y8/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=direct-PR
This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
The task is complete only when committed on your branch.
When it is implemented and committed, push your branch, confirm the PR base is the base branch this task names - the repo's default branch when it names none - and open a PR with `gh-axi` against that base, then append `done: PR {url}` to the status file and stop.
Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
```
</details>
<details>
<summary>Evidence: Suite dirigida tests/fm-brief.test.sh</summary>

```text
$ bash tests/fm-brief.test.sh
ok - fm-brief.sh: no-mistakes DOD keeps its apostrophe prose, now parse-safe
ok - fm-brief.sh: direct-PR DOD confirms the PR base before opening a PR
(22 casos, todos ok)

# Con bin/fm-brief.sh revertido al commit base:
not ok - no-mistakes DOD must require a green run for the worker's own branch before the final done:
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 issues (1 warning, 1 info)</summary>

- ⚠️ `bin/fm-brief.sh:410` - En el bloque mode=no-mistakes queda la frase heredada «The task is complete only when committed on your branch.» (bin/fm-brief.sh:410) inmediatamente antes del nuevo flujo. El intent exige cerrar exactamente ese agujero: «done: solo puede informarse tras verificar que existe una corrida de no-mistakes de la propia rama y todas las verificaciones están verdes, nunca solo por haber hecho commit o correr pruebas manuales». La nueva condición de la línea 424 lo contrarresta, pero la misma sección sigue afirmando que la tarea está completa al commitear, dando al worker una lectura autocontenida para reportar done: antes de la corrida verde. En direct-PR y local-only esa frase es coherente porque el commit sí es el criterio; en no-mistakes ya no lo es. Conviene alinear esa línea con el gate real (p. ej. que el commit es solo el punto de partida de la validación) o eliminarla del bloque no-mistakes.
- ⚠️ `bin/fm-brief.sh:411` - El cambio no solo añade la condición pedida: reescribe el handshake de entrega. Antes el worker apendaba `done: {summary}` y firstmate le ordenaba correr /no-mistakes; ahora bin/fm-brief.sh:411 dice «When it is implemented and committed, run /no-mistakes to validate and ship a PR.», es decir el worker se auto-dispara. AGENTS.md:340 sigue asignando esa acción a firstmate («For a no-mistakes ship, trigger validation on the same worker after its implementation commit, using the harness invocation owned by `harness-adapters`»), y con el intermedio eliminado firstmate ya no recibe ninguna señal en la frontera del commit de implementación, por lo que esa instrucción queda inalcanzable. El intent pide «cambios mínimos y quirúrgicos» y «no tocar AGENTS.md», así que esta divergencia queda sin resolver por diseño. Nota a favor del cambio: el `done: {summary}` intermedio sí chocaba con AGENTS.md:364, que define una única señal ready (`done: PR &lt;url&gt; checks green`). Confirmar con el autor si el auto-disparo es la intención y si AGENTS.md §Validate debe seguirlo en un cambio aparte.
- ℹ️ `bin/fm-brief.sh:386` - La condición de direct-PR («push your branch and, before opening the PR, verify its target branch is correct») cumple con no codificar reglas de proyecto, pero el intent también exige que las condiciones sean «breves y verificables» y aquí no se dice contra qué se compara «correct», a diferencia de la condición hermana de no-mistakes («is for your branch and all checks are green»), que sí es comprobable. Además, al reordenar la frase el imperativo de abrir el PR quedó degradado a cláusula subordinada («before opening the PR»), mientras que los verbos principales pasaron a ser «push» y «append»; en un andamiaje cuyo propósito es dar instrucciones inequívocas conviene mantenerlo como acción explícita. Una formulación neutral respecto al proyecto sería exigir contrastar la base del PR con la rama base indicada por la tarea o, en su defecto, la rama por defecto del repositorio.

🔧 Fix: restore firstmate-triggered validation and verifiable PR base
2 issues (1 warning, 1 info) still open:
- ⚠️ `bin/fm-brief.sh:411` - Conformidad con el intent. El criterio autoritativo dice: «en briefs mode=no-mistakes, done: solo puede informarse tras verificar que existe una corrida de no-mistakes de la propia rama y todas las verificaciones están verdes, nunca solo por haber hecho commit o correr pruebas manuales». El código actual mantiene lo contrario en el hunk restaurado: bin/fm-brief.sh:411 «When the implementation is committed, append `done: {summary}` to the status file and stop.», es decir se reporta `done:` únicamente por haber commiteado; y bin/fm-brief.sh:425 acota deliberadamente la nueva verificación a «Before appending the final `done: PR {url} checks green`», exceptuando de forma explícita ese `done:` intermedio. Contexto honesto: esta forma es la que instruiste en la ronda 1 («Restore the original firstmate-triggered validation handshake: after implementation and commit, the worker reports done and stops»), y hay una restricción estructural real: la regla 4 del propio brief declara `working:` no terminal («A mid-task `working:` line ... is nonterminal: do not end the turn after it»), así que `done:` es hoy el único estado que detiene al worker y despierta a firstmate (bin/fm-classify-lib.sh:64 clasifica `done:` como evento relevante). Además ese `done:` intermedio no coincide con la señal ready única que define AGENTS.md:364 (`done: PR &lt;url&gt; checks green`). Decisión que te corresponde: (a) confirmar que el intent se lee como referido a la señal ready terminal y dejarlo así, o (b) sustituir el handshake intermedio por un estado distinto de `done:` — lo que obligaría a tocar la gramática de estados de la regla 4 y excede «cambios mínimos y quirúrgicos».
- ℹ️ `bin/fm-brief.sh:385` - Nota informativa sobre una asimetría que dejó la corrección, fuera del alcance del intent. El bloque no-mistakes reemplazó «The task is complete only when committed on your branch.» por «Committing on your branch starts validation; it never completes the task.», pero el bloque direct-PR conserva la frase original en bin/fm-brief.sh:385 aunque ahí la tarea tampoco está completa al commitear: la línea 386 exige además push, confirmación de base y apertura del PR. La línea 386 hace explícito el gate real y la redacción «only when» es una condición necesaria, no suficiente, así que no hay un hueco reportable; el intent solo pide para direct-PR la verificación del destino, que sí está cumplida. Se registra por si quieres paridad de redacción en un cambio posterior; no requiere acción en este.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-brief.test.sh` — 22 casos verdes, incluidos `test_no_mistakes_dod_wording` (3 aserciones nuevas) y `test_direct_pr_confirms_target_branch_before_opening`</code>
- <code>Prueba de significancia: `git show 038d0f7:bin/fm-brief.sh &gt; bin/fm-brief.sh &amp;&amp; bash tests/fm-brief.test.sh` → falla en «no-mistakes DOD must require a green run for the worker&#39;s own branch before the final done:»; luego `git checkout HEAD -- bin/fm-brief.sh` y `git status --porcelain` limpio</code>
- <code>Verificación manual end-to-end: `FM_HOME=&lt;tmp&gt; bin/fm-brief.sh demo-nm firstmate --mode no-mistakes` y `--mode direct-PR`, extrayendo la sección `# Definition of done` del brief.md generado</code>
- `Comparación antes/después generando los mismos briefs con la copia del script del commit base (038d0f7) para mostrar el texto que realmente cambia en el brief`
- <code>`grep -rn &#34;complete only when committed on your branch&#34;` sobre el repo para confirmar que ningún otro consumidor depende del texto antiguo de no-mistakes</code>
- <code>`bash tests/fm-ask-user-authority.test.sh` — suite vecina que genera briefs, verde</code>
- <code>`bash tests/fm-tangle-guard.test.sh` — incluye `fm-brief: ship brief asserts worktree isolation before the branch step`, verde</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `bin/fm-brief.sh:385` - Judgment call left for follow-up: the direct-PR definition of done still opens with &#34;The task is complete only when committed on your branch.&#34; immediately before the sentence that requires push, base confirmation, and PR before `done: PR {url}`. This change removed exactly that commit-equals-done framing from the no-mistakes contract, so direct-PR now carries the residual ambiguity alone. Resolving it means rewording generated contract prose and its existing assertions in tests/fm-brief.test.sh, which is outside this documentation phase (generated agent-runtime text plus test changes) and outside the author&#39;s declared surgical scope. Proposed follow-up: align the direct-PR opener with the no-mistakes phrasing so committing is stated as a precondition rather than completion.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: lint passes clean; no source changes needed
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
