### PR TITLE
feat(bin): make a bound Linear issue part of task completion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,7 @@ config/stow-pass-horizon  optional presence flag opting this home in to /stow's 
 config/herdr-presentation-spaces  optional "off" opt-out from, or "on" opt-in to, Herdr's default-on disposable single-task visual projection, which is unconfigured-default-on only at or above a Herdr version floor; LOCAL, gitignored; inherited by secondmate homes; see docs/herdr-backend.md "Presentation spaces"
 config/trace-context  optional presence flag enabling default-off native W3C trace-context propagation to spawned agents; LOCAL, gitignored; inherited by secondmate homes; see docs/configuration.md "Trace context propagation" and docs/trace-context.md
 config/cmux-socket-password  optional cmux control-socket password; LOCAL, gitignored; read fresh on every cmux CLI call and passed through without ever overriding an operator's own ambient CMUX_SOCKET_PASSWORD when absent (docs/cmux-backend.md "Setup")
+config/linear.env    optional Linear credential and endpoint; LOCAL, gitignored; presence plus a task binding is the only activation, and docs/linear-sync.md owns the contract
 config/wedge-alarm  optional away-mode wedge-alarm active-alert directives; LOCAL, gitignored; absent means auto (macOS Notification Center when available); see docs/wedge-alarm.md
 config/watched-tools.json  optional list of the tools this home depends on, read by the update check armed with bin/fm-tool-update-check.sh; LOCAL, gitignored, firstmate-maintained but human-editable, and NOT inherited by secondmate homes; see docs/configuration.md "Watched tool updates"
 config/x-mode.env    generated Relay watcher cadence; LOCAL, gitignored; source before arming watcher when present
@@ -114,6 +115,7 @@ state/               runtime records and signals; gitignored
   x-watch.check.sh   generated Relay poll shim; present only when opted in (section 14)
   tool-updates.check.sh  generated watched-tool update poll shim and its .check-trust binding; present only after bin/fm-tool-update-check.sh arm; its report record .tool-updates is what keeps one pending update from being reported on every poll
   pending-replies/   parent-owned secondmate pending-reply records (correlation id, delivery vs reply, recovery, escalation); fm-pending-reply-lib.sh
+  linear/            private Linear bindings, typed handback outbox, receipts, and refusals; created only by fm-linear-sync.sh bind, absent in a home that never bound an issue
   procevent/         registered process-to-event sources, one private record per canonical source id; written only by bin/fm-procevent.sh, and their presence alone keeps supervision required (section 13)
   procevent-inbox/   private captured results and their durable handled-acknowledgement markers; source output lives here and never in an event line
   decision-bindings/ private records marking a captured-answer source as feeding the keyed-answer intake, with a legacy origin on pre-collapse records; written only by bin/fm-captain-hold.sh bind, dropped by unbind and by source retirement (section 13; docs/captain-hold-lifecycle.md)
@@ -370,6 +372,7 @@ A captain instruction to merge is explicit authority; `yolo` is the only standin
 For any custom `state/<id>.check.sh` you write yourself, keep it an ordinary single-link mode-`0700` file, print one line only when firstmate should wake, print nothing otherwise, finish before `FM_CHECK_TIMEOUT`, then bind its current bytes with `bin/fm-check-register.sh <id>` before the watcher may execute it.
 
 Tear down a ship task only after landing is confirmed.
+A task bound to a Linear issue is not complete until that issue is current, and teardown refuses while it still owes a handback; load `docs/linear-sync.md` before binding, queueing, or delivering one.
 A teardown refusal for uncommitted or unlanded work is a stop-and-investigate result, never an obstacle to bypass.
 Never force teardown without explicit discard authority.
 After successful teardown, record completion, retain only the configured recent Done history, and re-evaluate queued work whose blockers and time gates have cleared.

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Firstmate's skills live in two separate places with different audiences:
 - [docs/calm.md](docs/calm.md) - current Pi `/calm` behavior and supported presentation limits.
 - [docs/voice-relay.md](docs/voice-relay.md) - the optional spoken interface: setup on both machines, measured round-trip cost, what a spoken answer may read, and what this build does not do yet.
 - [docs/wedge-alarm.md](docs/wedge-alarm.md) - configure the active alert for an away-mode escalation delivery that gets stuck.
+- [docs/linear-sync.md](docs/linear-sync.md) - current setup, guarantees, and limits for keeping a task's Linear issue current.
 - [docs/tmux-backend.md](docs/tmux-backend.md) - current setup and limits for the tmux reference backend.
 - [docs/herdr-backend.md](docs/herdr-backend.md) - current setup, safety boundaries, and limits for the experimental Herdr backend.
 - [docs/zellij-backend.md](docs/zellij-backend.md) - current setup and limits for the experimental Zellij backend.
@@ -214,6 +215,7 @@ Firstmate's skills live in two separate places with different audiences:
 - [docs/gitlab-merge-watch.md](docs/gitlab-merge-watch.md) - maintainer verification for watching and merging GitLab merge requests on arbitrary instances.
 - [docs/turnend-guard.md](docs/turnend-guard.md) - the primary session's current "no turn ends blind" backstop, scope, loop safety, and compatibility limits.
 - [docs/verification/supervision.md](docs/verification/supervision.md) - active maintainer verification for session-start, guard, continuity, and wedge integrations.
+- [docs/verification/linear-sync.md](docs/verification/linear-sync.md) - active maintainer verification for the durable Linear synchronization guarantees.
 - [docs/supervision-protocols/](docs/supervision-protocols/) - rendered primary-harness watcher protocols for Claude, Codex, OpenCode, Pi and `pi-signed`, Grok, Cursor, and unknown harness fallback.
 - [docs/scripts.md](docs/scripts.md) - the `bin/` toolbelt reference.
 - [docs/documentation-audiences.md](docs/documentation-audiences.md) - documentation audiences and the machine-checked placement boundary.

--- a/bin/fm-linear-lib.sh
+++ b/bin/fm-linear-lib.sh
@@ -1,0 +1,422 @@
+# shellcheck shell=bash
+# fm-linear-lib.sh - shared gates, private-transport layout, and identity helpers
+# for firstmate's durable Linear synchronization.
+#
+# The captain's rule this serves: work is not complete until the corresponding
+# Linear issue is current. That rule is enforced mechanically, not by memory - a
+# task is explicitly BOUND to one or more Linear issues, every handback is a
+# typed durable OUTBOX record, delivery writes a RECEIPT, and cleanup refuses
+# while a bound task still owes one.
+#
+# Sourced, never executed. No side effects on source (it creates nothing), which
+# is what keeps a home with no Linear bindings free of Linear artifacts.
+# set -u / set -e safe.
+#
+# GATE ORDER - the acceptance criterion for homes that never use Linear:
+#   1. fm_linear_present <state>     one [ -d ] test on <state>/linear, the
+#                                    directory only `fm-linear-sync.sh bind`
+#                                    ever creates. A home with no binding stops
+#                                    here: no git call, no config read, no
+#                                    directory scan, and no artifact.
+#   2. fm_linear_home_scoped         bin/fm-primary-scope-lib.sh's genuine
+#      <home> <state>                primary-home predicate, so the whole feature
+#                                    is inert inside an ordinary project repo and
+#                                    inside a crewmate/scout task worktree, and
+#                                    stays active in a main home or a marked
+#                                    secondmate home.
+#   3. credentials                   fm_linear_config_load, only on a path that
+#                                    actually needs to reach Linear. Binding,
+#                                    queueing, listing, and the cleanup gate all
+#                                    work with no credential at all, which is what
+#                                    lets a disconnected home preserve a pending
+#                                    handback instead of losing it.
+#
+# Private transport layout, all under <state>/linear (mode 0700, created only by
+# `fm-linear-sync.sh bind`):
+#   bindings/<task-id>          the durable task -> issue binding. Nothing may be
+#                               delivered for a task with no binding, and an
+#                               ambiguous binding refuses rather than guessing.
+#   outbox/<delivery-id>.json   typed pending deliveries, one file per delivery.
+#                               Immutable once written: the record IS the
+#                               identity, so re-queueing the same handback
+#                               resolves to the same path and changes nothing.
+#   sent/<delivery-id>          the receipt ledger. Presence means this exact
+#                               handback is confirmed on the issue.
+#   attempts/<delivery-id>      mutable retry state for a delivery that is held,
+#                               kept beside the record rather than inside it so
+#                               the identity never moves.
+#   refused/<delivery-id>.json  a delivery Linear refused, preserved with a
+#   refused/<delivery-id>.reason one-line reason. Still blocks cleanup: a refusal
+#                               is an unfinished handback, not a discarded one.
+#   discarded/<delivery-id>     explicit captain-authorized discards, recorded so
+#                               a dropped handback stays inspectable.
+#   .lock.<delivery-id>         a delivery in progress. Serializes the read-then-
+#                               post sequence, which is the one duplicate the
+#                               read-back cannot prevent on its own; taken over
+#                               after FM_LINEAR_LOCK_STALE_SECS so a crashed
+#                               delivery stays retryable rather than stranded.
+#
+# Delivery identity is DERIVED, never random: fm_linear_delivery_id hashes the
+# exact handback content (task, issue, comment bytes, status). Re-queueing the
+# identical handback after a crash, a retry, or a restart therefore lands on the
+# same path, and delivery converges without a second comment.
+#
+# The lost-ack interval is NOT covered by the local receipt. A comment can be
+# committed by Linear and the response lost before this side records anything.
+# Every delivery therefore embeds fm_linear_marker <delivery-id> in the comment
+# body and reads the issue's existing comments back BEFORE posting: an existing
+# marker means already delivered. bin/fm-linear-sync.sh owns that sequence.
+#
+# Depends on bin/fm-x-lib.sh for .env-style reading and the private-artifact
+# publication primitives (atomic, single-link, mode-validated), and on
+# bin/fm-primary-scope-lib.sh for the primary-home predicate. Those remain those
+# files' contracts and are not restated here.
+
+_FM_LINEAR_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null)" || _FM_LINEAR_LIB_DIR="."
+# shellcheck source=bin/fm-x-lib.sh
+. "$_FM_LINEAR_LIB_DIR/fm-x-lib.sh"
+# shellcheck source=bin/fm-primary-scope-lib.sh
+. "$_FM_LINEAR_LIB_DIR/fm-primary-scope-lib.sh"
+
+FM_LINEAR_DIRNAME='linear'
+# Consumed by the sourcing scripts, not by this library.
+# shellcheck disable=SC2034
+FM_LINEAR_DELIVERY_SCHEMA='fm-linear-delivery-v1'
+# The read-back marker prefix. Public-safe by construction: it carries a content
+# hash and nothing else, never a token, a path, or a task note.
+FM_LINEAR_MARKER_PREFIX='fm-linear-sync:'
+FM_LINEAR_DEFAULT_API_URL='https://api.linear.app/graphql'
+# Bounded so one handback cannot become an unbounded upload, and so a single
+# outbox record stays cheap to read and validate.
+FM_LINEAR_COMMENT_MAX=${FM_LINEAR_COMMENT_MAX:-6000}
+# How many comment pages the read-back walks before it gives up. Truncated
+# read-back never posts: an unproven absence is treated as unknown, not as new.
+FM_LINEAR_COMMENT_PAGE_MAX=${FM_LINEAR_COMMENT_PAGE_MAX:-10}
+FM_LINEAR_COMMENT_PAGE_SIZE=${FM_LINEAR_COMMENT_PAGE_SIZE:-100}
+# Seconds before a held delivery is retried. Advisory: `deliver` always retries
+# when asked explicitly, this only paces an unattended sweep.
+FM_LINEAR_RETRY_BACKOFF_SECS=${FM_LINEAR_RETRY_BACKOFF_SECS:-900}
+# How long a per-delivery lock may sit before a later run treats it as abandoned
+# and takes it over. A crashed delivery is exactly the case that must stay
+# retryable, so this bound matters more than the lock it releases.
+FM_LINEAR_LOCK_STALE_SECS=${FM_LINEAR_LOCK_STALE_SECS:-300}
+
+# Resolved by fm_linear_config_load. Never printed, never passed in argv.
+FM_LINEAR_API_KEY=
+FM_LINEAR_API_URL=
+FM_LINEAR_CONFIG_ERROR=
+
+# --- gate 1: O(1) presence, the zero-overhead path --------------------------
+
+fm_linear_root()          { printf '%s\n' "$1/$FM_LINEAR_DIRNAME"; }
+fm_linear_bindings_dir()  { printf '%s\n' "$1/$FM_LINEAR_DIRNAME/bindings"; }
+fm_linear_outbox_dir()    { printf '%s\n' "$1/$FM_LINEAR_DIRNAME/outbox"; }
+fm_linear_sent_dir()      { printf '%s\n' "$1/$FM_LINEAR_DIRNAME/sent"; }
+fm_linear_attempts_dir()  { printf '%s\n' "$1/$FM_LINEAR_DIRNAME/attempts"; }
+fm_linear_refused_dir()   { printf '%s\n' "$1/$FM_LINEAR_DIRNAME/refused"; }
+fm_linear_discarded_dir() { printf '%s\n' "$1/$FM_LINEAR_DIRNAME/discarded"; }
+
+# fm_linear_present <state>: 0 when this home has ever bound a Linear issue.
+# One [ -d ] test. Every caller outside bin/fm-linear-sync.sh starts here.
+fm_linear_present() {
+  local root
+  root=$(fm_linear_root "$1")
+  [ -d "$root" ] && [ ! -L "$root" ]
+}
+
+# fm_linear_dir_has_entry <dir>: 0 when <dir> is a real directory holding at
+# least one non-dot entry. Stops at the first hit, so cost does not grow with
+# the directory's size.
+fm_linear_dir_has_entry() {
+  local dir=$1 entry
+  [ -d "$dir" ] && [ ! -L "$dir" ] || return 1
+  for entry in "$dir"/*; do
+    [ -e "$entry" ] || continue
+    return 0
+  done
+  return 1
+}
+
+# fm_linear_has_pending <state>: 0 when this home still owes at least one Linear
+# handback. A refused delivery counts: a refusal is unfinished work that needs a
+# decision, never a silent discard.
+fm_linear_has_pending() {
+  fm_linear_dir_has_entry "$(fm_linear_outbox_dir "$1")" \
+    || fm_linear_dir_has_entry "$(fm_linear_refused_dir "$1")"
+}
+
+# --- gate 2: genuine primary home -------------------------------------------
+
+# fm_linear_home_scoped <home> <state>: the shared primary-home predicate. A
+# linked task worktree and a plain project clone both fail it, so every Linear
+# entrypoint is a silent no-op there even when invoked by absolute path.
+fm_linear_home_scoped() {
+  fm_primary_scope_matches "$1" "$2"
+}
+
+# --- gate 3: credentials ----------------------------------------------------
+
+fm_linear_config_file() { printf '%s\n' "$1/config/linear.env"; }
+
+# fm_linear_config_load <home>: resolve FM_LINEAR_API_KEY and FM_LINEAR_API_URL
+# from the one gitignored home-local credential owner, <home>/config/linear.env.
+#
+# Returns 1 and sets FM_LINEAR_CONFIG_ERROR to a one-line reason when the file
+# is missing or fails validation; that reason names the requirement, never the
+# value. It prints NOTHING, so callers read the resolved key from the global
+# rather than from a command substitution that would discard it. The key itself
+# is never printed by this library and never reaches a command line: the real
+# transport writes it to a 0600 header file and hands curl the file.
+#
+# FM_LINEAR_API_KEY_OVERRIDE wins when set, matching how every other firstmate
+# client lets a direct invocation override the file.
+fm_linear_config_load() {
+  local home=$1 file key url mode
+  FM_LINEAR_API_KEY=
+  FM_LINEAR_API_URL=
+  FM_LINEAR_CONFIG_ERROR=
+  file=$(fm_linear_config_file "$home")
+  if [ -n "${FM_LINEAR_API_KEY_OVERRIDE-}" ]; then
+    key=$FM_LINEAR_API_KEY_OVERRIDE
+    url=${FM_LINEAR_API_URL_OVERRIDE-}
+  else
+    if [ -L "$file" ] || [ ! -f "$file" ]; then
+      FM_LINEAR_CONFIG_ERROR="no Linear credential at $file"
+      return 1
+    fi
+    if ! fmx_single_link_file_valid "$file"; then
+      FM_LINEAR_CONFIG_ERROR="Linear credential $file must be a plain single-link file"
+      return 1
+    fi
+    mode=$(fm_linear_file_mode "$file") || mode=
+    if [ "$mode" != 600 ]; then
+      FM_LINEAR_CONFIG_ERROR="Linear credential $file must be mode 0600 (found ${mode:-unknown})"
+      return 1
+    fi
+    key=$(fmx_env_get LINEAR_API_KEY "$file")
+    url=$(fmx_env_get LINEAR_API_URL "$file")
+  fi
+  if [ -z "$key" ]; then
+    FM_LINEAR_CONFIG_ERROR="LINEAR_API_KEY is empty in $file"
+    return 1
+  fi
+  if ! fm_linear_secret_shape_valid "$key"; then
+    FM_LINEAR_CONFIG_ERROR="LINEAR_API_KEY in $file is not a single-line credential"
+    return 1
+  fi
+  [ -n "$url" ] || url=$FM_LINEAR_DEFAULT_API_URL
+  if ! fm_linear_api_url_valid "$url"; then
+    # Consumed by the sourcing scripts, not by this library.
+    # shellcheck disable=SC2034
+    FM_LINEAR_CONFIG_ERROR='LINEAR_API_URL must be an https:// endpoint'
+    return 1
+  fi
+  # Consumed by the sourcing scripts, not by this library.
+  # shellcheck disable=SC2034
+  FM_LINEAR_API_KEY=$key
+  # shellcheck disable=SC2034
+  FM_LINEAR_API_URL=$url
+}
+
+# A credential must be one line of printable non-space bytes. That rejects a
+# pasted multi-line block, a stray CR, and anything that could smuggle a second
+# header into the request.
+fm_linear_secret_shape_valid() {
+  local v=$1
+  [ -n "$v" ] || return 1
+  [ "${#v}" -le 512 ] || return 1
+  case "$v" in
+    *[[:space:]]*|*[[:cntrl:]]*) return 1 ;;
+  esac
+  return 0
+}
+
+fm_linear_api_url_valid() {
+  local v=$1
+  case "$v" in
+    https://*) ;;
+    *) return 1 ;;
+  esac
+  case "$v" in
+    *[[:space:]]*|*[[:cntrl:]]*) return 1 ;;
+  esac
+  [ "${#v}" -le 512 ]
+}
+
+fm_linear_file_mode() {
+  local file=$1
+  if [ "$(uname)" = Darwin ]; then
+    stat -f %Lp "$file" 2>/dev/null
+  else
+    stat -c %a "$file" 2>/dev/null
+  fi
+}
+
+# --- identifiers ------------------------------------------------------------
+
+# Task ids and delivery ids compose filenames, so both are checked against a
+# conservative slug before any path is built from them.
+fm_linear_slug_valid() {
+  local v=$1
+  case "$v" in
+    ''|.*|*[!A-Za-z0-9._-]*) return 1 ;;
+  esac
+  [ "${#v}" -le 128 ]
+}
+
+# fm_linear_issue_ref_valid <ref>: a Linear issue reference is either the human
+# identifier a captain actually types (TEAM-123) or the API UUID. Anything else
+# refuses, so a prose fragment can never be mistaken for a target.
+fm_linear_issue_ref_valid() {
+  local v=$1
+  [ "${#v}" -le 64 ] || return 1
+  if [[ "$v" =~ ^[A-Z][A-Z0-9]{0,9}-[0-9]{1,7}$ ]]; then
+    return 0
+  fi
+  if [[ "$v" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
+    return 0
+  fi
+  return 1
+}
+
+# fm_linear_status_valid <name>: a Linear workflow state NAME as it appears in
+# the team's workflow ("In Progress", "Done"). Single line, bounded, printable.
+fm_linear_status_valid() {
+  local v=$1
+  [ -n "$v" ] || return 1
+  [ "${#v}" -le 64 ] || return 1
+  case "$v" in
+    *[[:cntrl:]]*) return 1 ;;
+  esac
+  return 0
+}
+
+fm_linear_sha256() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 2>/dev/null | awk '{print $1}'
+  elif command -v sha256sum >/dev/null 2>&1; then
+    sha256sum 2>/dev/null | awk '{print $1}'
+  else
+    return 1
+  fi
+}
+
+# fm_linear_delivery_id <task-id> <issue-ref> <status> <comment-file>
+# The stable idempotency identity: the exact handback content and nothing else.
+# The comment bytes are hashed from the file rather than passed as an argument,
+# so a long handback never rides an argument list.
+fm_linear_delivery_id() {
+  local task=$1 issue=$2 status=$3 comment_file=$4
+  {
+    printf '%s\037%s\037%s\037%s\037' \
+      "$FM_LINEAR_DELIVERY_SCHEMA" "$task" "$issue" "$status"
+    cat -- "$comment_file"
+  } | fm_linear_sha256
+}
+
+# fm_linear_marker <delivery-id>: the authoritative read-back key embedded in
+# the posted comment. Linear's own copy of this string is what proves delivery
+# across the lost-ack interval; the local receipt alone never does.
+fm_linear_marker() {
+  printf '%s%s' "$FM_LINEAR_MARKER_PREFIX" "$1"
+}
+
+# fm_linear_comment_body_suffix <delivery-id>: the exact bytes appended to the
+# captain-authored comment. An HTML comment so it renders as nothing in Linear
+# while staying a plain substring of the stored body.
+fm_linear_comment_body_suffix() {
+  printf '\n\n<!-- %s -->' "$(fm_linear_marker "$1")"
+}
+
+# --- record readers ---------------------------------------------------------
+
+# fm_linear_binding_issues <state> <task-id>: every issue bound to <task-id>,
+# one per line. Prints nothing and succeeds when the task has no binding.
+fm_linear_binding_issues() {
+  local state=$1 task=$2 file line
+  fm_linear_slug_valid "$task" || return 1
+  file="$(fm_linear_bindings_dir "$state")/$task"
+  [ -f "$file" ] && [ ! -L "$file" ] || return 0
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+      issue=*) ;;
+      *) continue ;;
+    esac
+    line=${line#issue=}
+    fm_linear_issue_ref_valid "$line" || continue
+    printf '%s\n' "$line"
+  done < "$file"
+}
+
+# fm_linear_bound_tasks <state>: every task id with a binding, one per line.
+fm_linear_bound_tasks() {
+  local dir entry
+  dir=$(fm_linear_bindings_dir "$1")
+  [ -d "$dir" ] && [ ! -L "$dir" ] || return 0
+  for entry in "$dir"/*; do
+    [ -f "$entry" ] && [ ! -L "$entry" ] || continue
+    basename "$entry"
+  done
+}
+
+# fm_linear_record_field <file> <key>: read one TOP-LEVEL string or null field
+# from a typed delivery record with no jq dependency, so the cleanup gate keeps
+# working on a home where jq is missing.
+#
+# The match is anchored to the start of a line because a delivery record embeds
+# the captain's comment as a JSON string: every character of it, newlines
+# included, is escaped onto the single `"comment":` line. A comment that itself
+# contains `"status": "Done"` therefore cannot be mistaken for the record's own
+# status field. The reader is deliberately narrow and only understands the exact
+# shape bin/fm-linear-sync.sh writes.
+fm_linear_record_field() {
+  local file=$1 key=$2 line
+  [ -f "$file" ] && [ ! -L "$file" ] || return 1
+  line=$(grep -m1 -E "^[[:space:]]*\"$key\":" "$file" 2>/dev/null) || return 1
+  [ -n "$line" ] || return 1
+  line=${line#*\""$key"\":}
+  line=${line#"${line%%[![:space:]]*}"}
+  case "$line" in
+    null*) printf '' ; return 0 ;;
+    \"*) ;;
+    *) return 1 ;;
+  esac
+  line=${line#\"}
+  line=${line%%\"*}
+  printf '%s' "$line"
+}
+
+# fm_linear_pending_deliveries <state> [task-id]: pending delivery ids, one per
+# line, optionally filtered to one task. Outbox first, then refused, so the
+# actionable set reads before the stuck set.
+fm_linear_pending_deliveries() {
+  local state=$1 task=${2-} dir entry id
+  for dir in "$(fm_linear_outbox_dir "$state")" "$(fm_linear_refused_dir "$state")"; do
+    [ -d "$dir" ] && [ ! -L "$dir" ] || continue
+    for entry in "$dir"/*.json; do
+      [ -f "$entry" ] && [ ! -L "$entry" ] || continue
+      id=$(basename "$entry" .json)
+      if [ -n "$task" ]; then
+        [ "$(fm_linear_record_field "$entry" task_id)" = "$task" ] || continue
+      fi
+      printf '%s\n' "$id"
+    done
+  done
+}
+
+# --- bounded single-line text ----------------------------------------------
+
+# fm_linear_clean_line: read stdin, drop control characters, collapse every
+# whitespace run to one space, trim. Used only for lines that are PRINTED (a
+# refusal reason, a pending summary), never for the comment body itself, which
+# must reach Linear byte-exact as the captain wrote it.
+fm_linear_clean_line() {
+  LC_ALL=C tr -d '\000-\010\013\014\016-\037\177' \
+    | LC_ALL=C tr '\011\012\015' '   ' \
+    | LC_ALL=C tr -s ' ' \
+    | sed 's/^ //; s/ $//'
+}
+
+fm_linear_bound_bytes() {
+  LC_ALL=C cut -b "1-$1"
+}

--- a/bin/fm-linear-sync.sh
+++ b/bin/fm-linear-sync.sh
@@ -538,16 +538,25 @@ hold_delivery() {  # <delivery-id> <reason>
 }
 
 refuse_delivery() {  # <delivery-id> <reason>
-  local id=$1 reason=$2 outbox refused_dir
+  local id=$1 reason=$2 outbox refused_dir clean_reason
   outbox="$(fm_linear_outbox_dir "$STATE")/$id.json"
   refused_dir=$(fm_linear_refused_dir "$STATE")
+  clean_reason=$(printf '%s' "$reason" | fm_linear_clean_line | fm_linear_bound_bytes 300)
   if [ -f "$outbox" ] && [ ! -L "$outbox" ]; then
-    fmx_private_artifact_publish_stdin "$refused_dir" "$id.json" 600 < "$outbox" || true
-    rm -f -- "$outbox"
+    if fmx_private_artifact_publish_stdin "$refused_dir" "$id.json" 600 < "$outbox" \
+      && fmx_private_artifact_file_valid "$refused_dir" "$id.json" 600 \
+      && printf '%s\n' "$clean_reason" | fmx_private_artifact_publish_stdin "$refused_dir" "$id.reason" 600 \
+      && fmx_private_artifact_file_valid "$refused_dir" "$id.reason" 600; then
+      rm -f -- "$outbox" "$(fm_linear_attempts_dir "$STATE")/$id"
+      return 0
+    fi
+    rm -f -- "$refused_dir/$id.json" "$refused_dir/$id.reason"
+    hold_delivery "$id" "$reason"
+    return 1
   fi
-  printf '%s\n' "$(printf '%s' "$reason" | fm_linear_clean_line | fm_linear_bound_bytes 300)" \
-    | fmx_private_artifact_publish_stdin "$refused_dir" "$id.reason" 600 || true
+  printf '%s\n' "$clean_reason" | fmx_private_artifact_publish_stdin "$refused_dir" "$id.reason" 600 || true
   rm -f -- "$(fm_linear_attempts_dir "$STATE")/$id"
+  return 0
 }
 
 # GraphQL variable sigils, not shell expansions.
@@ -710,14 +719,20 @@ deliver_one_locked() {  # <delivery-id>
   # The record must still hash to its own filename, and the issue must still be
   # bound to the task. A tampered or orphaned record never reaches Linear.
   if [ "$(fm_linear_delivery_id "$task" "$issue" "$status" "$comment")" != "$id" ]; then
-    refuse_delivery "$id" 'the delivery record does not match its own derived identity'
-    printf 'fm-linear-sync: delivery %s failed its identity check and was quarantined\n' "$id" >&2
-    return 1
+    if refuse_delivery "$id" 'the delivery record does not match its own derived identity'; then
+      printf 'fm-linear-sync: delivery %s failed its identity check and was quarantined\n' "$id" >&2
+      return 1
+    fi
+    printf 'fm-linear-sync: delivery %s failed its identity check but could not be quarantined; it is preserved and still owed\n' "$id" >&2
+    return 3
   fi
   if [ "$marker" != "$(fm_linear_marker "$id")" ]; then
-    refuse_delivery "$id" 'the delivery record carries a marker that is not its own'
-    printf 'fm-linear-sync: delivery %s carries a forged marker and was quarantined\n' "$id" >&2
-    return 1
+    if refuse_delivery "$id" 'the delivery record carries a marker that is not its own'; then
+      printf 'fm-linear-sync: delivery %s carries a forged marker and was quarantined\n' "$id" >&2
+      return 1
+    fi
+    printf 'fm-linear-sync: delivery %s carries a forged marker but could not be quarantined; it is preserved and still owed\n' "$id" >&2
+    return 3
   fi
   if ! fm_linear_binding_issues "$STATE" "$task" | grep -Fxq -- "$issue"; then
     hold_delivery "$id" "issue $issue is no longer bound to task $task"
@@ -738,9 +753,12 @@ deliver_one_locked() {  # <delivery-id>
   case "$rc" in
     0) ;;
     1)
-      refuse_delivery "$id" "issue $issue is not reachable on this Linear workspace"
-      printf 'fm-linear-sync: Linear does not have issue %s; delivery %s is held for a decision\n' "$issue" "$id" >&2
-      return 1
+      if refuse_delivery "$id" "issue $issue is not reachable on this Linear workspace"; then
+        printf 'fm-linear-sync: Linear does not have issue %s; delivery %s is held for a decision\n' "$issue" "$id" >&2
+        return 1
+      fi
+      printf 'fm-linear-sync: Linear does not have issue %s and delivery %s could not be quarantined; it is preserved and still owed\n' "$issue" "$id" >&2
+      return 3
       ;;
     *)
       hold_delivery "$id" 'the issue read-back did not complete'
@@ -809,10 +827,14 @@ deliver_one_locked() {  # <delivery-id>
         '[.data.team.states.nodes[]? | select(.name == $n) | .id] | first // ""' \
         < "$response" 2>/dev/null)
       if [ -z "$state_id" ]; then
-        refuse_delivery "$id" "the team has no workflow state named '$status'"
-        printf 'fm-linear-sync: %s has no workflow state named "%s"; delivery %s is held for a decision\n' \
+        if refuse_delivery "$id" "the team has no workflow state named '$status'"; then
+          printf 'fm-linear-sync: %s has no workflow state named "%s"; delivery %s is held for a decision\n' \
+            "$issue" "$status" "$id" >&2
+          return 1
+        fi
+        printf 'fm-linear-sync: %s has no workflow state named "%s" and delivery %s could not be quarantined; it is preserved and still owed\n' \
           "$issue" "$status" "$id" >&2
-        return 1
+        return 3
       fi
       build_request "$request" "$LINEAR_STATUS_MUTATION" \
         "$(jq -n --arg id "$ISSUE_UUID" --arg stateId "$state_id" '{id:$id, stateId:$stateId}')" || return 3

--- a/bin/fm-linear-sync.sh
+++ b/bin/fm-linear-sync.sh
@@ -38,8 +38,9 @@
 #   1  a refusal: a missing or ambiguous target, an invalid argument, an
 #      unfinished handback found by guard-work, or a delivery Linear rejected
 #   2  usage
-#   3  a hold: Linear is not configured or not reachable, so the handback is
-#      preserved untouched and must be retried. Never a completion.
+#   3  a hold: Linear is not configured or not reachable, or a would-be refusal
+#      could not be recorded, so the handback is preserved untouched and must
+#      be retried. Never a completion.
 #
 # `hook` is the passive integration surface. It is scoped to a genuine firstmate
 # primary home (bin/fm-primary-scope-lib.sh) and prints nothing at all in an
@@ -537,6 +538,10 @@ hold_delivery() {  # <delivery-id> <reason>
   } | fmx_private_artifact_publish_stdin "$(fm_linear_attempts_dir "$STATE")" "$id" 600 || true
 }
 
+# refuse_delivery <delivery-id> <reason>: returns 0 once the refusal is durably
+# recorded (or there was nothing left to quarantine). Returns 1 when the
+# quarantine write itself failed - the caller must treat this as a hold, not a
+# refusal, since the record is neither delivered nor safely marked refused.
 refuse_delivery() {  # <delivery-id> <reason>
   local id=$1 reason=$2 outbox refused_dir clean_reason
   outbox="$(fm_linear_outbox_dir "$STATE")/$id.json"

--- a/bin/fm-linear-sync.sh
+++ b/bin/fm-linear-sync.sh
@@ -98,7 +98,7 @@ now_epoch() { date +%s; }
 
 require_jq() {
   command -v jq >/dev/null 2>&1 \
-    || hold_exit 'jq is required to build and read typed Linear records'
+    || hold_exit 'jq is required to queue and to deliver a typed Linear record'
 }
 
 # Every mutating verb runs in a genuine primary home. A crewmate/scout worktree
@@ -277,6 +277,17 @@ cmd_queue() {
     [ -f "$comment_file" ] || die "comment file not found: $comment_file"
     cat -- "$comment_file" > "$canonical"
   fi
+  # This check runs on the bytes as received, before the canonicalization below.
+  # That step reads the comment through a command substitution, which drops NUL
+  # bytes silently, so a NUL inspected afterwards would already be gone and the
+  # comment would reach Linear altered instead of refused.
+  # tr understands the octal escapes a portable grep does not, so the check is a
+  # byte comparison against the same text with control characters removed.
+  # Tab, newline, and carriage return are deliberately not in that set.
+  if ! LC_ALL=C cmp -s "$canonical" \
+      <(LC_ALL=C tr -d '\000-\010\013\014\016-\037\177' < "$canonical"); then
+    die 'the comment contains control characters; refusing'
+  fi
   # Canonicalize the trailing newline only. Everything else reaches Linear
   # byte-exact, because the comment is the captain's text, not a summary.
   trimmed=$(new_tmp) || die 'cannot create a temporary file'
@@ -287,13 +298,6 @@ cmd_queue() {
   [ -s "$canonical" ] || die 'the comment is empty; refusing to post nothing'
   if grep -Fq -- "$FM_LINEAR_MARKER_PREFIX" "$canonical"; then
     die "the comment contains the reserved marker prefix '$FM_LINEAR_MARKER_PREFIX'; refusing"
-  fi
-  # tr understands the octal escapes a portable grep does not, so the check is a
-  # byte comparison against the same text with control characters removed.
-  # Tab, newline, and carriage return are deliberately not in that set.
-  if ! LC_ALL=C cmp -s "$canonical" \
-      <(LC_ALL=C tr -d '\000-\010\013\014\016-\037\177' < "$canonical"); then
-    die 'the comment contains control characters; refusing'
   fi
   length=$(jq -Rs 'length' < "$canonical") || die 'cannot measure the comment'
   [ "$length" -le "$FM_LINEAR_COMMENT_MAX" ] \

--- a/bin/fm-linear-sync.sh
+++ b/bin/fm-linear-sync.sh
@@ -1,0 +1,910 @@
+#!/usr/bin/env bash
+# fm-linear-sync.sh - durable Linear synchronization for firstmate work.
+#
+# Enforces one captain rule mechanically: work is not complete until the
+# corresponding Linear issue is current. A task is explicitly BOUND to one or
+# more Linear issues; every handback is queued as a typed durable record; a
+# delivery is idempotent across retries, crashes, compaction, and restart; and
+# bin/fm-teardown.sh refuses to clean a task up while it still owes one.
+#
+# Nothing here ever infers a target. There is no transcript scraping and no
+# prose matching: an unbound task refuses, an ambiguous binding refuses, and a
+# comment is exactly the bytes the caller supplied.
+#
+# bin/fm-linear-lib.sh owns the gate order, the private layout, and the derived
+# delivery identity. This script owns the commands, flags, and the delivery
+# sequence that survives the lost-ack interval.
+#
+# Usage:
+#   fm-linear-sync.sh bind <task-id> <issue-ref>...
+#   fm-linear-sync.sh unbind <task-id> [<issue-ref>]
+#   fm-linear-sync.sh bindings [<task-id>]
+#   fm-linear-sync.sh queue <task-id> (--comment-file <path> | --comment-stdin)
+#                          [--issue <ref>] [--status <workflow-state-name>]
+#   fm-linear-sync.sh pending [<task-id>]
+#   fm-linear-sync.sh show <delivery-id>
+#   fm-linear-sync.sh deliver (<delivery-id> | --task <task-id> | --all)
+#   fm-linear-sync.sh guard-work <task-id>
+#   fm-linear-sync.sh discard <delivery-id> --reason <text> --yes
+#   fm-linear-sync.sh hook
+#   fm-linear-sync.sh status
+#
+# An <issue-ref> is the identifier a captain types (TEAM-123) or the API UUID.
+# A --status is a Linear workflow state NAME exactly as the team spells it
+# ("In Progress", "Done"); omit it to post a comment and change nothing else.
+#
+# Exit status:
+#   0  the command succeeded
+#   1  a refusal: a missing or ambiguous target, an invalid argument, an
+#      unfinished handback found by guard-work, or a delivery Linear rejected
+#   2  usage
+#   3  a hold: Linear is not configured or not reachable, so the handback is
+#      preserved untouched and must be retried. Never a completion.
+#
+# `hook` is the passive integration surface. It is scoped to a genuine firstmate
+# primary home (bin/fm-primary-scope-lib.sh) and prints nothing at all in an
+# ordinary project repo, in a crewmate/scout task worktree, or in a home with no
+# Linear bindings, so it is safe to wire into any harness lifecycle surface.
+# No harness hook file ships it enabled; docs/linear-sync.md owns why.
+#
+# Delivery sequence (the part that must survive a lost acknowledgement):
+#   1. an existing local receipt short-circuits;
+#   2. otherwise the issue's own comments are read back and searched for this
+#      delivery's marker, which is Linear's authoritative copy of the fact that
+#      the comment landed. A truncated read-back is treated as UNKNOWN and holds
+#      rather than posting, so a very long issue cannot produce a duplicate;
+#   3. only a proven absence posts the comment;
+#   4. an optional status change is applied only when the issue is not already
+#      in that state, and is confirmed by reading the state back;
+#   5. the receipt is written last. A crash anywhere before it converges on the
+#      next run through step 2, with no second comment and no second status
+#      change.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-$FM_ROOT}"
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+
+# shellcheck source=bin/fm-linear-lib.sh
+. "$SCRIPT_DIR/fm-linear-lib.sh"
+
+usage() {
+  awk '
+    NR == 1 { next }
+    /^#/ { sub(/^# ?/, ""); print; next }
+    { exit }
+  ' "$0" >&2
+}
+
+die() {
+  printf 'fm-linear-sync: %s\n' "$*" >&2
+  exit 1
+}
+
+usage_die() {
+  printf 'fm-linear-sync: %s\n' "$*" >&2
+  usage
+  exit 2
+}
+
+hold_exit() {
+  printf 'fm-linear-sync: %s\n' "$*" >&2
+  exit 3
+}
+
+now_epoch() { date +%s; }
+
+require_jq() {
+  command -v jq >/dev/null 2>&1 \
+    || hold_exit 'jq is required to build and read typed Linear records'
+}
+
+# Every mutating verb runs in a genuine primary home. A crewmate/scout worktree
+# and a plain project clone both refuse loudly here rather than creating state
+# in the wrong place; `hook` is the one caller that stays silent instead.
+require_primary_home() {
+  fm_linear_home_scoped "$FM_HOME" "$STATE" \
+    || die "$FM_HOME is not a firstmate primary home; Linear synchronization is inert here"
+}
+
+TMP_FILES=()
+cleanup_tmp() {
+  local f
+  for f in "${TMP_FILES[@]+"${TMP_FILES[@]}"}"; do
+    [ -z "$f" ] || rm -f -- "$f"
+  done
+}
+trap cleanup_tmp EXIT
+
+new_tmp() {
+  local f
+  f=$(umask 077; mktemp "${TMPDIR:-/tmp}/fm-linear.XXXXXX") || return 1
+  TMP_FILES+=("$f")
+  printf '%s\n' "$f"
+}
+
+# --- bind / unbind / bindings ----------------------------------------------
+
+cmd_bind() {
+  local task=${1-} issue dir file existing tmp
+  shift || true
+  [ -n "$task" ] || usage_die 'bind needs a task id'
+  [ "$#" -ge 1 ] || usage_die 'bind needs at least one issue reference'
+  fm_linear_slug_valid "$task" || die "not a usable task id: $task"
+  require_primary_home
+  for issue in "$@"; do
+    fm_linear_issue_ref_valid "$issue" \
+      || die "not a Linear issue reference: $issue (expected TEAM-123 or an API UUID)"
+  done
+
+  dir=$(fm_linear_bindings_dir "$STATE")
+  file="$dir/$task"
+  existing=$(fm_linear_binding_issues "$STATE" "$task")
+  tmp=$(new_tmp) || die 'cannot create a temporary file'
+  {
+    printf 'bound_at=%s\n' "$(now_epoch)"
+    {
+      [ -z "$existing" ] || printf '%s\n' "$existing"
+      printf '%s\n' "$@"
+    } | LC_ALL=C sort -u | while IFS= read -r issue; do
+      [ -n "$issue" ] || continue
+      printf 'issue=%s\n' "$issue"
+    done
+  } > "$tmp"
+  fmx_private_artifact_publish_stdin "$dir" "$task" 600 < "$tmp" \
+    || die "cannot record the binding at $file"
+  printf 'bound %s ->' "$task"
+  fm_linear_binding_issues "$STATE" "$task" | while IFS= read -r issue; do
+    printf ' %s' "$issue"
+  done
+  printf '\n'
+}
+
+cmd_unbind() {
+  local task=${1-} issue=${2-} dir file kept tmp
+  [ -n "$task" ] || usage_die 'unbind needs a task id'
+  fm_linear_slug_valid "$task" || die "not a usable task id: $task"
+  require_primary_home
+  dir=$(fm_linear_bindings_dir "$STATE")
+  file="$dir/$task"
+  [ -f "$file" ] && [ ! -L "$file" ] || die "task $task has no Linear binding"
+  if [ -n "$(fm_linear_pending_deliveries "$STATE" "$task")" ]; then
+    die "task $task still owes a Linear handback; deliver or discard it before unbinding"
+  fi
+  if [ -z "$issue" ]; then
+    rm -f -- "$file"
+    printf 'unbound %s\n' "$task"
+    return 0
+  fi
+  fm_linear_issue_ref_valid "$issue" || die "not a Linear issue reference: $issue"
+  kept=$(fm_linear_binding_issues "$STATE" "$task" | grep -Fxv -- "$issue" || true)
+  if [ -z "$kept" ]; then
+    rm -f -- "$file"
+    printf 'unbound %s\n' "$task"
+    return 0
+  fi
+  tmp=$(new_tmp) || die 'cannot create a temporary file'
+  {
+    printf 'bound_at=%s\n' "$(now_epoch)"
+    printf '%s\n' "$kept" | while IFS= read -r line; do
+      [ -n "$line" ] || continue
+      printf 'issue=%s\n' "$line"
+    done
+  } > "$tmp"
+  fmx_private_artifact_publish_stdin "$dir" "$task" 600 < "$tmp" \
+    || die "cannot rewrite the binding at $file"
+  printf 'unbound %s from %s\n' "$issue" "$task"
+}
+
+cmd_bindings() {
+  local task=${1-} t issues
+  fm_linear_present "$STATE" || return 0
+  if [ -n "$task" ]; then
+    fm_linear_slug_valid "$task" || die "not a usable task id: $task"
+    issues=$(fm_linear_binding_issues "$STATE" "$task")
+    [ -n "$issues" ] || return 0
+    printf '%s' "$task"
+    printf '%s\n' "$issues" | while IFS= read -r i; do printf ' %s' "$i"; done
+    printf '\n'
+    return 0
+  fi
+  while IFS= read -r t; do
+    [ -n "$t" ] || continue
+    cmd_bindings "$t"
+  done < <(fm_linear_bound_tasks "$STATE")
+}
+
+# --- queue ------------------------------------------------------------------
+
+# Resolve the one issue this handback targets. This is the refusal the whole
+# design rests on: no binding refuses, and more than one bound issue with no
+# explicit --issue refuses as ambiguous rather than picking the first.
+resolve_issue() {  # <task> <explicit-issue-or-empty>
+  local task=$1 explicit=$2 issues count
+  issues=$(fm_linear_binding_issues "$STATE" "$task")
+  if [ -z "$issues" ]; then
+    die "task $task has no Linear issue binding; bind it first with: $(basename "$0") bind $task <issue-ref>"
+  fi
+  if [ -n "$explicit" ]; then
+    fm_linear_issue_ref_valid "$explicit" || die "not a Linear issue reference: $explicit"
+    printf '%s\n' "$issues" | grep -Fxq -- "$explicit" \
+      || die "issue $explicit is not bound to task $task; bound: $(printf '%s' "$issues" | tr '\n' ' ')"
+    printf '%s\n' "$explicit"
+    return 0
+  fi
+  count=$(printf '%s\n' "$issues" | grep -c . || true)
+  if [ "$count" -ne 1 ]; then
+    die "task $task is bound to $count Linear issues; name one with --issue (bound: $(printf '%s' "$issues" | tr '\n' ' '))"
+  fi
+  printf '%s\n' "$issues"
+}
+
+cmd_queue() {
+  local task=${1-} comment_file='' comment_stdin=0 explicit_issue='' status=''
+  local issue canonical trimmed delivery_id record marker rc length
+  shift || true
+  [ -n "$task" ] || usage_die 'queue needs a task id'
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --comment-file) [ "$#" -gt 1 ] || usage_die '--comment-file needs a path'; comment_file=$2; shift 2 ;;
+      --comment-stdin) comment_stdin=1; shift ;;
+      --issue) [ "$#" -gt 1 ] || usage_die '--issue needs a reference'; explicit_issue=$2; shift 2 ;;
+      --status) [ "$#" -gt 1 ] || usage_die '--status needs a workflow state name'; status=$2; shift 2 ;;
+      *) usage_die "unknown queue option: $1" ;;
+    esac
+  done
+  fm_linear_slug_valid "$task" || die "not a usable task id: $task"
+  require_primary_home
+  require_jq
+  if [ -n "$comment_file" ] && [ "$comment_stdin" -eq 1 ]; then
+    usage_die 'use either --comment-file or --comment-stdin, not both'
+  fi
+  if [ -z "$comment_file" ] && [ "$comment_stdin" -eq 0 ]; then
+    usage_die 'queue needs --comment-file <path> or --comment-stdin'
+  fi
+  if [ -n "$status" ]; then
+    fm_linear_status_valid "$status" || die 'not a usable Linear workflow state name'
+  fi
+
+  issue=$(resolve_issue "$task" "$explicit_issue") || exit 1
+
+  canonical=$(new_tmp) || die 'cannot create a temporary file'
+  if [ "$comment_stdin" -eq 1 ]; then
+    cat > "$canonical"
+  else
+    [ -f "$comment_file" ] || die "comment file not found: $comment_file"
+    cat -- "$comment_file" > "$canonical"
+  fi
+  # Canonicalize the trailing newline only. Everything else reaches Linear
+  # byte-exact, because the comment is the captain's text, not a summary.
+  trimmed=$(new_tmp) || die 'cannot create a temporary file'
+  if ! printf '%s' "$(cat "$canonical")" > "$trimmed"; then
+    die 'cannot canonicalize the comment'
+  fi
+  mv -f "$trimmed" "$canonical" || die 'cannot canonicalize the comment'
+  [ -s "$canonical" ] || die 'the comment is empty; refusing to post nothing'
+  if grep -Fq -- "$FM_LINEAR_MARKER_PREFIX" "$canonical"; then
+    die "the comment contains the reserved marker prefix '$FM_LINEAR_MARKER_PREFIX'; refusing"
+  fi
+  # tr understands the octal escapes a portable grep does not, so the check is a
+  # byte comparison against the same text with control characters removed.
+  # Tab, newline, and carriage return are deliberately not in that set.
+  if ! LC_ALL=C cmp -s "$canonical" \
+      <(LC_ALL=C tr -d '\000-\010\013\014\016-\037\177' < "$canonical"); then
+    die 'the comment contains control characters; refusing'
+  fi
+  length=$(jq -Rs 'length' < "$canonical") || die 'cannot measure the comment'
+  [ "$length" -le "$FM_LINEAR_COMMENT_MAX" ] \
+    || die "the comment is $length characters, over the $FM_LINEAR_COMMENT_MAX limit"
+
+  delivery_id=$(fm_linear_delivery_id "$task" "$issue" "$status" "$canonical") \
+    || die 'cannot derive the delivery identity'
+  marker=$(fm_linear_marker "$delivery_id")
+
+  if fmx_private_artifact_file_valid "$(fm_linear_sent_dir "$STATE")" "$delivery_id" 600; then
+    printf 'already delivered: %s -> %s (%s)\n' "$task" "$issue" "$delivery_id"
+    return 0
+  fi
+  if fmx_private_artifact_file_valid "$(fm_linear_refused_dir "$STATE")" "$delivery_id.json" 600; then
+    printf 'already queued and refused by Linear: %s (see: %s show %s)\n' \
+      "$delivery_id" "$(basename "$0")" "$delivery_id" >&2
+    return 1
+  fi
+
+  record=$(new_tmp) || die 'cannot create a temporary file'
+  jq -n \
+    --arg schema "$FM_LINEAR_DELIVERY_SCHEMA" \
+    --arg delivery_id "$delivery_id" \
+    --arg task_id "$task" \
+    --arg issue "$issue" \
+    --rawfile comment "$canonical" \
+    --arg status "$status" \
+    --arg marker "$marker" \
+    --argjson queued_at "$(now_epoch)" \
+    '{schema:$schema, delivery_id:$delivery_id, task_id:$task_id, issue:$issue,
+      comment:$comment, status:(if $status == "" then null else $status end),
+      marker:$marker, queued_at:$queued_at}' > "$record" \
+    || die 'cannot build the typed delivery record'
+
+  fmx_private_artifact_publish_stdin_once \
+    "$(fm_linear_outbox_dir "$STATE")" "$delivery_id.json" 600 < "$record"
+  rc=$?
+  case "$rc" in
+    0) printf 'queued %s -> %s (%s)\n' "$task" "$issue" "$delivery_id" ;;
+    1) printf 'already queued %s -> %s (%s)\n' "$task" "$issue" "$delivery_id" ;;
+    *) die 'cannot record the delivery' ;;
+  esac
+}
+
+# --- pending / show / guard-work / hook / status ----------------------------
+
+pending_line() {  # <delivery-id>
+  local id=$1 outbox refused file task issue status state reason attempts next
+  outbox="$(fm_linear_outbox_dir "$STATE")/$id.json"
+  refused="$(fm_linear_refused_dir "$STATE")/$id.json"
+  if [ -f "$outbox" ] && [ ! -L "$outbox" ]; then
+    file=$outbox
+    state=queued
+  elif [ -f "$refused" ] && [ ! -L "$refused" ]; then
+    file=$refused
+    state=refused
+  else
+    return 1
+  fi
+  task=$(fm_linear_record_field "$file" task_id) || task='?'
+  issue=$(fm_linear_record_field "$file" issue) || issue='?'
+  status=$(fm_linear_record_field "$file" status) || status=
+  reason=
+  if [ "$state" = refused ]; then
+    reason=$(head -c 400 "$(fm_linear_refused_dir "$STATE")/$id.reason" 2>/dev/null | fm_linear_clean_line)
+  else
+    attempts="$(fm_linear_attempts_dir "$STATE")/$id"
+    if [ -f "$attempts" ] && [ ! -L "$attempts" ]; then
+      reason=$(grep -m1 '^reason=' "$attempts" 2>/dev/null | cut -d= -f2- | fm_linear_clean_line)
+      next=$(grep -m1 '^next_attempt=' "$attempts" 2>/dev/null | cut -d= -f2-)
+      [ -z "$next" ] || reason="$reason (retry after epoch $next)"
+    fi
+  fi
+  printf '%s  task=%s  issue=%s  status=%s  delivery=%s' \
+    "$state" "$task" "$issue" "${status:--}" "$id"
+  [ -z "$reason" ] || printf '  reason=%s' "$reason"
+  printf '\n'
+}
+
+cmd_pending() {
+  local task=${1-} id
+  fm_linear_present "$STATE" || return 0
+  [ -z "$task" ] || fm_linear_slug_valid "$task" || die "not a usable task id: $task"
+  while IFS= read -r id; do
+    [ -n "$id" ] || continue
+    pending_line "$id" || true
+  done < <(fm_linear_pending_deliveries "$STATE" "$task")
+}
+
+cmd_show() {
+  local id=${1-} file
+  [ -n "$id" ] || usage_die 'show needs a delivery id'
+  fm_linear_slug_valid "$id" || die "not a usable delivery id: $id"
+  for file in \
+    "$(fm_linear_outbox_dir "$STATE")/$id.json" \
+    "$(fm_linear_refused_dir "$STATE")/$id.json"; do
+    if [ -f "$file" ] && [ ! -L "$file" ]; then
+      cat -- "$file"
+      [ -f "${file%.json}.reason" ] && cat -- "${file%.json}.reason"
+      return 0
+    fi
+  done
+  for file in \
+    "$(fm_linear_sent_dir "$STATE")/$id" \
+    "$(fm_linear_discarded_dir "$STATE")/$id"; do
+    if [ -f "$file" ] && [ ! -L "$file" ]; then
+      cat -- "$file"
+      return 0
+    fi
+  done
+  die "no Linear delivery record for $id"
+}
+
+# guard-work is the completion gate bin/fm-teardown.sh calls. Exit 1 with the
+# blocking lines on stdout when this task still owes a handback; silent exit 0
+# otherwise. Costs one [ -d ] test in a home that never bound an issue.
+cmd_guard_work() {
+  local task=${1-} found=0 id
+  [ -n "$task" ] || usage_die 'guard-work needs a task id'
+  fm_linear_slug_valid "$task" || return 0
+  fm_linear_present "$STATE" || return 0
+  while IFS= read -r id; do
+    [ -n "$id" ] || continue
+    found=1
+    pending_line "$id" || true
+  done < <(fm_linear_pending_deliveries "$STATE" "$task")
+  [ "$found" -eq 0 ]
+}
+
+# The passive integration surface. Silent everywhere it does not apply.
+cmd_hook() {
+  local count
+  fm_linear_present "$STATE" || return 0
+  fm_linear_home_scoped "$FM_HOME" "$STATE" || return 0
+  fm_linear_has_pending "$STATE" || return 0
+  count=$(fm_linear_pending_deliveries "$STATE" | grep -c . || true)
+  printf 'Linear: %s handback(s) still owed; work bound to those issues is not complete.\n' "$count" >&2
+  printf 'Run %s/bin/fm-linear-sync.sh pending to see them, then deliver --all.\n' "$FM_ROOT" >&2
+}
+
+cmd_status() {
+  if ! fm_linear_home_scoped "$FM_HOME" "$STATE"; then
+    printf 'scope: inert (%s is not a firstmate primary home)\n' "$FM_HOME"
+    return 0
+  fi
+  printf 'scope: primary home %s\n' "$FM_HOME"
+  if ! fm_linear_present "$STATE"; then
+    printf 'bindings: none (no Linear state in this home)\n'
+    return 0
+  fi
+  printf 'bindings: %s task(s)\n' "$(fm_linear_bound_tasks "$STATE" | grep -c . || true)"
+  printf 'pending: %s handback(s)\n' "$(fm_linear_pending_deliveries "$STATE" | grep -c . || true)"
+  if fm_linear_config_load "$FM_HOME"; then
+    printf 'credential: present at %s\n' "$(fm_linear_config_file "$FM_HOME")"
+    printf 'endpoint: %s\n' "$FM_LINEAR_API_URL"
+  else
+    printf 'credential: unavailable - %s\n' "$FM_LINEAR_CONFIG_ERROR"
+  fi
+  printf 'transport: %s\n' "$(transport_path)"
+}
+
+# --- discard ----------------------------------------------------------------
+
+cmd_discard() {
+  local id=${1-} reason='' yes=0 file record
+  shift || true
+  [ -n "$id" ] || usage_die 'discard needs a delivery id'
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --reason) [ "$#" -gt 1 ] || usage_die '--reason needs text'; reason=$2; shift 2 ;;
+      --yes) yes=1; shift ;;
+      *) usage_die "unknown discard option: $1" ;;
+    esac
+  done
+  fm_linear_slug_valid "$id" || die "not a usable delivery id: $id"
+  require_primary_home
+  [ -n "$reason" ] || usage_die 'discard needs --reason "<why this handback is not owed>"'
+  [ "$yes" -eq 1 ] || die 'discard drops an owed Linear handback; pass --yes to confirm'
+  record=
+  for file in \
+    "$(fm_linear_outbox_dir "$STATE")/$id.json" \
+    "$(fm_linear_refused_dir "$STATE")/$id.json"; do
+    if [ -f "$file" ] && [ ! -L "$file" ]; then
+      record=$file
+      break
+    fi
+  done
+  [ -n "$record" ] || die "no pending Linear delivery $id"
+  {
+    printf 'discarded_at=%s\n' "$(now_epoch)"
+    printf 'task=%s\n' "$(fm_linear_record_field "$record" task_id)"
+    printf 'issue=%s\n' "$(fm_linear_record_field "$record" issue)"
+    printf 'reason=%s\n' "$(printf '%s' "$reason" | fm_linear_clean_line | fm_linear_bound_bytes 400)"
+  } | fmx_private_artifact_publish_stdin "$(fm_linear_discarded_dir "$STATE")" "$id" 600 \
+    || die 'cannot record the discard'
+  rm -f -- "$record" "${record%.json}.reason" "$(fm_linear_attempts_dir "$STATE")/$id"
+  printf 'discarded %s\n' "$id"
+}
+
+# --- delivery ---------------------------------------------------------------
+
+transport_path() {
+  if [ -n "${FM_LINEAR_TRANSPORT-}" ]; then
+    printf '%s\n' "$FM_LINEAR_TRANSPORT"
+  else
+    printf '%s\n' "$SCRIPT_DIR/fm-linear-transport.sh"
+  fi
+}
+
+# call_linear <query-file> <response-file>: run the configured transport and
+# print its HTTP code. Returns non-zero when the exchange did not complete.
+call_linear() {
+  local request=$1 response=$2 transport code
+  transport=$(transport_path)
+  [ -f "$transport" ] && [ -x "$transport" ] \
+    || { printf 'transport %s is not an executable file\n' "$transport" >&2; return 3; }
+  code=$("$transport" "$request" "$response") || return $?
+  printf '%s\n' "$code" | tr -d '[:space:]'
+}
+
+# graphql <response-file> <jq-filter>: read one value out of a GraphQL response.
+graphql() {
+  jq -r "$2" < "$1" 2>/dev/null
+}
+
+graphql_error() {  # <response-file>
+  jq -r 'if (.errors // empty) then (.errors[0].message // "unspecified GraphQL error") else empty end' \
+    < "$1" 2>/dev/null | fm_linear_clean_line | fm_linear_bound_bytes 300
+}
+
+build_request() {  # <out-file> <query> <variables-json>
+  jq -n --arg q "$2" --argjson v "$3" '{query:$q, variables:$v}' > "$1"
+}
+
+hold_delivery() {  # <delivery-id> <reason>
+  local id=$1 reason=$2 now
+  now=$(now_epoch)
+  {
+    printf 'last_attempt=%s\n' "$now"
+    printf 'next_attempt=%s\n' "$((now + FM_LINEAR_RETRY_BACKOFF_SECS))"
+    printf 'reason=%s\n' "$(printf '%s' "$reason" | fm_linear_clean_line | fm_linear_bound_bytes 300)"
+  } | fmx_private_artifact_publish_stdin "$(fm_linear_attempts_dir "$STATE")" "$id" 600 || true
+}
+
+refuse_delivery() {  # <delivery-id> <reason>
+  local id=$1 reason=$2 outbox refused_dir
+  outbox="$(fm_linear_outbox_dir "$STATE")/$id.json"
+  refused_dir=$(fm_linear_refused_dir "$STATE")
+  if [ -f "$outbox" ] && [ ! -L "$outbox" ]; then
+    fmx_private_artifact_publish_stdin "$refused_dir" "$id.json" 600 < "$outbox" || true
+    rm -f -- "$outbox"
+  fi
+  printf '%s\n' "$(printf '%s' "$reason" | fm_linear_clean_line | fm_linear_bound_bytes 300)" \
+    | fmx_private_artifact_publish_stdin "$refused_dir" "$id.reason" 600 || true
+  rm -f -- "$(fm_linear_attempts_dir "$STATE")/$id"
+}
+
+# GraphQL variable sigils, not shell expansions.
+# shellcheck disable=SC2016
+LINEAR_ISSUE_QUERY='query FmLinearIssue($id: String!, $first: Int!, $after: String) {
+  issue(id: $id) {
+    id
+    identifier
+    state { id name }
+    team { id }
+    comments(first: $first, after: $after) {
+      pageInfo { hasNextPage endCursor }
+      nodes { id body }
+    }
+  }
+}'
+
+# GraphQL variable sigils, not shell expansions.
+# shellcheck disable=SC2016
+LINEAR_STATES_QUERY='query FmLinearStates($teamId: String!) {
+  team(id: $teamId) { states(first: 100) { nodes { id name } } }
+}'
+
+# GraphQL variable sigils, not shell expansions.
+# shellcheck disable=SC2016
+LINEAR_COMMENT_MUTATION='mutation FmLinearComment($issueId: String!, $body: String!) {
+  commentCreate(input: { issueId: $issueId, body: $body }) { success comment { id } }
+}'
+
+# GraphQL variable sigils, not shell expansions.
+# shellcheck disable=SC2016
+LINEAR_STATUS_MUTATION='mutation FmLinearStatus($id: String!, $stateId: String!) {
+  issueUpdate(id: $id, input: { stateId: $stateId }) { success issue { id state { id name } } }
+}'
+
+# Resolved by read_back_issue for the current delivery.
+ISSUE_UUID=
+ISSUE_TEAM=
+ISSUE_STATE_NAME=
+FOUND_COMMENT_ID=
+
+# read_back_issue <issue-ref> <marker>: walk the issue's comments looking for
+# <marker>. Sets ISSUE_UUID/ISSUE_TEAM/ISSUE_STATE_NAME from the first page and
+# FOUND_COMMENT_ID when the marker is already on the issue. Returns:
+#   0 read-back completed (FOUND_COMMENT_ID tells you the answer)
+#   1 the issue does not exist (permanent)
+#   3 the read-back could not complete or was truncated (hold)
+read_back_issue() {
+  local issue=$1 marker=$2 request response after=null page=0 code err hit next
+  ISSUE_UUID=; ISSUE_TEAM=; ISSUE_STATE_NAME=; FOUND_COMMENT_ID=
+  request=$(new_tmp) || return 3
+  response=$(new_tmp) || return 3
+  while [ "$page" -lt "$FM_LINEAR_COMMENT_PAGE_MAX" ]; do
+    page=$((page + 1))
+    build_request "$request" "$LINEAR_ISSUE_QUERY" \
+      "$(jq -n --arg id "$issue" --argjson first "$FM_LINEAR_COMMENT_PAGE_SIZE" --argjson after "$after" \
+        '{id:$id, first:$first, after:$after}')" || return 3
+    code=$(call_linear "$request" "$response") || return 3
+    [ "$code" = 200 ] || { printf 'Linear returned HTTP %s\n' "$code" >&2; return 3; }
+    err=$(graphql_error "$response")
+    if [ -n "$err" ]; then
+      case "$err" in
+        *[Nn]ot\ found*|*does\ not\ exist*|*Entity\ not\ found*)
+          printf '%s\n' "$err" >&2
+          return 1
+          ;;
+      esac
+      printf '%s\n' "$err" >&2
+      return 3
+    fi
+    if [ "$(graphql "$response" '.data.issue // "null"')" = null ]; then
+      printf 'issue %s does not exist or is not visible to this credential\n' "$issue" >&2
+      return 1
+    fi
+    if [ -z "$ISSUE_UUID" ]; then
+      ISSUE_UUID=$(graphql "$response" '.data.issue.id // ""')
+      ISSUE_TEAM=$(graphql "$response" '.data.issue.team.id // ""')
+      ISSUE_STATE_NAME=$(graphql "$response" '.data.issue.state.name // ""')
+      [ -n "$ISSUE_UUID" ] || { printf 'Linear returned an issue with no id\n' >&2; return 3; }
+    fi
+    hit=$(jq -r --arg m "$marker" \
+      '[.data.issue.comments.nodes[]? | select((.body // "") | contains($m)) | .id] | first // ""' \
+      < "$response" 2>/dev/null)
+    if [ -n "$hit" ]; then
+      FOUND_COMMENT_ID=$hit
+      return 0
+    fi
+    if [ "$(graphql "$response" '.data.issue.comments.pageInfo.hasNextPage // false')" != true ]; then
+      return 0
+    fi
+    next=$(graphql "$response" '.data.issue.comments.pageInfo.endCursor // ""')
+    [ -n "$next" ] || return 0
+    after=$(jq -n --arg c "$next" '$c')
+  done
+  printf 'the issue has more comments than the %s-page read-back bound\n' "$FM_LINEAR_COMMENT_PAGE_MAX" >&2
+  return 3
+}
+
+# deliver_one serializes on a per-delivery lock directory. Two concurrent runs
+# would otherwise both complete a read-back before either posted, and both would
+# then see a proven absence and post - the one duplicate the read-back cannot
+# prevent on its own. An abandoned lock is taken over after
+# FM_LINEAR_LOCK_STALE_SECS, because a crashed delivery must stay retryable.
+deliver_one() {  # <delivery-id>
+  local id=$1 lockdir rc age
+  lockdir="$(fm_linear_root "$STATE")/.lock.$id"
+  if ! mkdir "$lockdir" 2>/dev/null; then
+    age=$(lock_age_secs "$lockdir")
+    if [ -n "$age" ] && [ "$age" -ge "$FM_LINEAR_LOCK_STALE_SECS" ]; then
+      rmdir "$lockdir" 2>/dev/null || true
+    fi
+    if ! mkdir "$lockdir" 2>/dev/null; then
+      printf 'fm-linear-sync: another delivery of %s is already in progress; it is still owed\n' "$id" >&2
+      return 3
+    fi
+  fi
+  deliver_one_locked "$id"
+  rc=$?
+  rmdir "$lockdir" 2>/dev/null || true
+  return "$rc"
+}
+
+lock_age_secs() {  # <path>
+  local mtime now
+  if [ "$(uname)" = Darwin ]; then
+    mtime=$(stat -f %m "$1" 2>/dev/null) || return 0
+  else
+    mtime=$(stat -c %Y "$1" 2>/dev/null) || return 0
+  fi
+  [ -n "$mtime" ] || return 0
+  now=$(now_epoch)
+  printf '%s\n' "$((now - mtime))"
+}
+
+deliver_one_locked() {  # <delivery-id>
+  local id=$1 record task issue status comment marker body request response
+  local rc code err comment_id proof state_id
+  record="$(fm_linear_outbox_dir "$STATE")/$id.json"
+  if fmx_private_artifact_file_valid "$(fm_linear_sent_dir "$STATE")" "$id" 600; then
+    rm -f -- "$record" "$(fm_linear_attempts_dir "$STATE")/$id"
+    printf 'already delivered: %s\n' "$id"
+    return 0
+  fi
+  if [ ! -f "$record" ] || [ -L "$record" ]; then
+    if fmx_private_artifact_file_valid "$(fm_linear_refused_dir "$STATE")" "$id.json" 600; then
+      printf 'fm-linear-sync: delivery %s was refused by Linear; inspect it with the show command, then re-queue or discard it\n' "$id" >&2
+      return 1
+    fi
+    printf 'fm-linear-sync: no pending Linear delivery %s\n' "$id" >&2
+    return 1
+  fi
+
+  task=$(jq -r '.task_id // ""' < "$record")
+  issue=$(jq -r '.issue // ""' < "$record")
+  status=$(jq -r '.status // ""' < "$record")
+  marker=$(jq -r '.marker // ""' < "$record")
+  comment=$(new_tmp) || return 3
+  jq -j '.comment // ""' < "$record" > "$comment" || return 3
+
+  # The record must still hash to its own filename, and the issue must still be
+  # bound to the task. A tampered or orphaned record never reaches Linear.
+  if [ "$(fm_linear_delivery_id "$task" "$issue" "$status" "$comment")" != "$id" ]; then
+    refuse_delivery "$id" 'the delivery record does not match its own derived identity'
+    printf 'fm-linear-sync: delivery %s failed its identity check and was quarantined\n' "$id" >&2
+    return 1
+  fi
+  if [ "$marker" != "$(fm_linear_marker "$id")" ]; then
+    refuse_delivery "$id" 'the delivery record carries a marker that is not its own'
+    printf 'fm-linear-sync: delivery %s carries a forged marker and was quarantined\n' "$id" >&2
+    return 1
+  fi
+  if ! fm_linear_binding_issues "$STATE" "$task" | grep -Fxq -- "$issue"; then
+    hold_delivery "$id" "issue $issue is no longer bound to task $task"
+    printf 'fm-linear-sync: issue %s is no longer bound to task %s; re-bind it or discard delivery %s\n' \
+      "$issue" "$task" "$id" >&2
+    return 3
+  fi
+
+  if ! fm_linear_config_load "$FM_HOME"; then
+    hold_delivery "$id" "$FM_LINEAR_CONFIG_ERROR"
+    printf 'fm-linear-sync: Linear is not connected (%s); handback for task %s on %s is preserved and still owed\n' \
+      "$FM_LINEAR_CONFIG_ERROR" "$task" "$issue" >&2
+    return 3
+  fi
+
+  read_back_issue "$issue" "$marker"
+  rc=$?
+  case "$rc" in
+    0) ;;
+    1)
+      refuse_delivery "$id" "issue $issue is not reachable on this Linear workspace"
+      printf 'fm-linear-sync: Linear does not have issue %s; delivery %s is held for a decision\n' "$issue" "$id" >&2
+      return 1
+      ;;
+    *)
+      hold_delivery "$id" 'the issue read-back did not complete'
+      printf 'fm-linear-sync: could not confirm the current state of %s; handback for task %s is preserved and still owed\n' \
+        "$issue" "$task" >&2
+      return 3
+      ;;
+  esac
+
+  if [ -n "$FOUND_COMMENT_ID" ]; then
+    comment_id=$FOUND_COMMENT_ID
+    proof=read-back
+  else
+    body=$(new_tmp) || return 3
+    { cat "$comment"; fm_linear_comment_body_suffix "$id"; } > "$body"
+    request=$(new_tmp) || return 3
+    response=$(new_tmp) || return 3
+    build_request "$request" "$LINEAR_COMMENT_MUTATION" \
+      "$(jq -n --arg issueId "$ISSUE_UUID" --rawfile body "$body" '{issueId:$issueId, body:$body}')" \
+      || return 3
+    code=$(call_linear "$request" "$response") || {
+      hold_delivery "$id" 'the comment request did not complete'
+      printf 'fm-linear-sync: could not reach Linear to post the handback for task %s on %s; it is preserved and still owed\n' \
+        "$task" "$issue" >&2
+      return 3
+    }
+    if [ "$code" != 200 ]; then
+      hold_delivery "$id" "Linear returned HTTP $code on comment create"
+      printf 'fm-linear-sync: Linear returned HTTP %s posting the handback for task %s on %s; it is preserved and still owed\n' \
+        "$code" "$task" "$issue" >&2
+      return 3
+    fi
+    err=$(graphql_error "$response")
+    if [ -n "$err" ]; then
+      hold_delivery "$id" "$err"
+      printf 'fm-linear-sync: Linear rejected the handback for task %s on %s (%s); it is preserved and still owed\n' \
+        "$task" "$issue" "$err" >&2
+      return 3
+    fi
+    if [ "$(graphql "$response" '.data.commentCreate.success // false')" != true ]; then
+      hold_delivery "$id" 'Linear reported the comment was not created'
+      printf 'fm-linear-sync: Linear did not accept the handback for task %s on %s; it is preserved and still owed\n' \
+        "$task" "$issue" >&2
+      return 3
+    fi
+    comment_id=$(graphql "$response" '.data.commentCreate.comment.id // ""')
+    proof=posted
+  fi
+
+  local status_applied=0
+  if [ -n "$status" ]; then
+    if [ "$ISSUE_STATE_NAME" = "$status" ]; then
+      status_applied=1
+    else
+      request=$(new_tmp) || return 3
+      response=$(new_tmp) || return 3
+      build_request "$request" "$LINEAR_STATES_QUERY" \
+        "$(jq -n --arg teamId "$ISSUE_TEAM" '{teamId:$teamId}')" || return 3
+      code=$(call_linear "$request" "$response") || {
+        hold_delivery "$id" 'the workflow-state lookup did not complete'
+        printf 'fm-linear-sync: the handback comment for task %s landed on %s, but its status change is still owed\n' \
+          "$task" "$issue" >&2
+        return 3
+      }
+      state_id=$(jq -r --arg n "$status" \
+        '[.data.team.states.nodes[]? | select(.name == $n) | .id] | first // ""' \
+        < "$response" 2>/dev/null)
+      if [ -z "$state_id" ]; then
+        refuse_delivery "$id" "the team has no workflow state named '$status'"
+        printf 'fm-linear-sync: %s has no workflow state named "%s"; delivery %s is held for a decision\n' \
+          "$issue" "$status" "$id" >&2
+        return 1
+      fi
+      build_request "$request" "$LINEAR_STATUS_MUTATION" \
+        "$(jq -n --arg id "$ISSUE_UUID" --arg stateId "$state_id" '{id:$id, stateId:$stateId}')" || return 3
+      code=$(call_linear "$request" "$response") || code=
+      if [ "$code" = 200 ] \
+        && [ "$(graphql "$response" '.data.issueUpdate.success // false')" = true ] \
+        && [ "$(graphql "$response" '.data.issueUpdate.issue.state.name // ""')" = "$status" ]; then
+        status_applied=1
+      else
+        hold_delivery "$id" "the status change to '$status' was not confirmed"
+        printf 'fm-linear-sync: the handback comment for task %s landed on %s, but its status change to "%s" is still owed\n' \
+          "$task" "$issue" "$status" >&2
+        return 3
+      fi
+    fi
+  fi
+
+  {
+    printf 'delivered_at=%s\n' "$(now_epoch)"
+    printf 'task=%s\n' "$task"
+    printf 'issue=%s\n' "$issue"
+    printf 'issue_id=%s\n' "$ISSUE_UUID"
+    printf 'comment_id=%s\n' "$comment_id"
+    printf 'marker=%s\n' "$marker"
+    printf 'status=%s\n' "$status"
+    printf 'status_applied=%s\n' "$status_applied"
+    printf 'proof=%s\n' "$proof"
+  } | fmx_private_artifact_publish_stdin_once "$(fm_linear_sent_dir "$STATE")" "$id" 600
+  case $? in
+    0|1) ;;
+    *)
+      hold_delivery "$id" 'the handback landed but its receipt could not be recorded'
+      printf 'fm-linear-sync: the handback for task %s landed on %s but its receipt could not be written\n' \
+        "$task" "$issue" >&2
+      return 3
+      ;;
+  esac
+  rm -f -- "$record" "$(fm_linear_attempts_dir "$STATE")/$id"
+  printf 'delivered %s -> %s (%s, %s)\n' "$task" "$issue" "$id" "$proof"
+}
+
+cmd_deliver() {
+  local target='' task='' all=0 id rc worst=0 any=0
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --task) [ "$#" -gt 1 ] || usage_die '--task needs a task id'; task=$2; shift 2 ;;
+      --all) all=1; shift ;;
+      -*) usage_die "unknown deliver option: $1" ;;
+      *) [ -z "$target" ] || usage_die 'deliver takes one delivery id'; target=$1; shift ;;
+    esac
+  done
+  require_primary_home
+  require_jq
+  if [ -n "$target" ]; then
+    [ "$all" -eq 0 ] && [ -z "$task" ] || usage_die 'deliver takes a delivery id OR --task OR --all'
+    fm_linear_slug_valid "$target" || die "not a usable delivery id: $target"
+    deliver_one "$target"
+    return $?
+  fi
+  [ "$all" -eq 1 ] || [ -n "$task" ] || usage_die 'deliver needs a delivery id, --task <id>, or --all'
+  [ -z "$task" ] || fm_linear_slug_valid "$task" || die "not a usable task id: $task"
+  fm_linear_present "$STATE" || return 0
+  while IFS= read -r id; do
+    [ -n "$id" ] || continue
+    # A refused delivery is reported by `pending`, never retried by a sweep.
+    [ -f "$(fm_linear_outbox_dir "$STATE")/$id.json" ] || continue
+    any=1
+    deliver_one "$id"
+    rc=$?
+    [ "$rc" -le "$worst" ] || worst=$rc
+  done < <(fm_linear_pending_deliveries "$STATE" "$task")
+  [ "$any" -eq 1 ] || printf 'no queued Linear handbacks\n'
+  return "$worst"
+}
+
+# --- dispatch ---------------------------------------------------------------
+
+VERB=${1-}
+shift || true
+case "$VERB" in
+  bind)       cmd_bind "$@" ;;
+  unbind)     cmd_unbind "$@" ;;
+  bindings)   cmd_bindings "$@" ;;
+  queue)      cmd_queue "$@" ;;
+  pending)    cmd_pending "$@" ;;
+  show)       cmd_show "$@" ;;
+  deliver)    cmd_deliver "$@" ;;
+  guard-work) cmd_guard_work "$@" ;;
+  discard)    cmd_discard "$@" ;;
+  hook)       cmd_hook "$@" ;;
+  status)     cmd_status "$@" ;;
+  -h|--help)  usage; exit 0 ;;
+  '')         usage; exit 2 ;;
+  *)          usage_die "unknown command: $VERB" ;;
+esac

--- a/bin/fm-linear-transport.sh
+++ b/bin/fm-linear-transport.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# fm-linear-transport.sh - the default Linear GraphQL transport.
+#
+# This is the ONLY place in firstmate that talks to Linear over the network, and
+# the only place a Linear credential is read for use. Splitting it out is what
+# makes the whole synchronization path testable with no credential and no
+# network: bin/fm-linear-sync.sh calls a transport through this exact contract,
+# and FM_LINEAR_TRANSPORT can point it at a hermetic fake instead.
+#
+# Usage:
+#   fm-linear-transport.sh <request-json-file> <response-body-out-file>
+#
+# Contract every transport must satisfy:
+#   - stdin is not read; the request body is the file at $1, a complete GraphQL
+#     document object: {"query": "...", "variables": {...}}
+#   - the response body is written to the file at $2
+#   - the HTTP status code is printed to stdout, alone, with no trailing text
+#   - exit 0 means the exchange completed and $2 plus the printed code are
+#     authoritative; a non-zero exit means the exchange did NOT complete and the
+#     caller must treat the delivery as still pending, never as failed-and-done
+#   - the request body never carries a credential, so it is safe to log
+#
+# Exit status:
+#   0  exchange completed (any HTTP code)
+#   3  local precondition failed: no curl, or no usable credential
+#   4  the request never completed (timeout, DNS, connection failure)
+#   2  usage
+#
+# Secret handling: the API key is written to a mode-0600 temp file as a complete
+# header line and handed to curl as `-H @file`. It never appears in argv, in an
+# environment variable curl inherits by name, in the request body, or in any
+# output this script produces. The temp file is removed on every exit path.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+FM_HOME="${FM_HOME:-$FM_ROOT}"
+
+# shellcheck source=bin/fm-linear-lib.sh
+. "$SCRIPT_DIR/fm-linear-lib.sh"
+
+usage() {
+  awk '
+    NR == 1 { next }
+    /^#/ { sub(/^# ?/, ""); print; next }
+    { exit }
+  ' "$0" >&2
+}
+
+case "${1-}" in
+  -h|--help) usage; exit 0 ;;
+esac
+
+[ "$#" -eq 2 ] || { usage; exit 2; }
+REQUEST=$1
+RESPONSE=$2
+
+[ -f "$REQUEST" ] && [ ! -L "$REQUEST" ] || {
+  echo "fm-linear-transport: request file is missing or not a plain file: $REQUEST" >&2
+  exit 2
+}
+
+command -v curl >/dev/null 2>&1 || {
+  echo "fm-linear-transport: curl is required to reach Linear" >&2
+  exit 3
+}
+
+if ! fm_linear_config_load "$FM_HOME"; then
+  printf 'fm-linear-transport: %s\n' "$FM_LINEAR_CONFIG_ERROR" >&2
+  exit 3
+fi
+
+AUTH_HEADER_FILE=
+cleanup() {
+  [ -z "$AUTH_HEADER_FILE" ] || rm -f -- "$AUTH_HEADER_FILE"
+}
+trap cleanup EXIT
+
+AUTH_HEADER_FILE=$(umask 077; mktemp "${TMPDIR:-/tmp}/fm-linear-auth.XXXXXX") || {
+  echo "fm-linear-transport: cannot create a private credential file" >&2
+  exit 3
+}
+chmod 600 "$AUTH_HEADER_FILE" 2>/dev/null || {
+  echo "fm-linear-transport: cannot secure the credential file" >&2
+  exit 3
+}
+# The credential is used verbatim as the Authorization value. Linear personal
+# API keys are sent bare and OAuth access tokens are sent as "Bearer <token>",
+# so an operator pastes whichever their workspace issued and this side never
+# has to guess which scheme it holds.
+printf 'Authorization: %s\n' "$FM_LINEAR_API_KEY" > "$AUTH_HEADER_FILE" || {
+  echo "fm-linear-transport: cannot write the credential file" >&2
+  exit 3
+}
+
+: > "$RESPONSE" 2>/dev/null || {
+  echo "fm-linear-transport: cannot write the response file: $RESPONSE" >&2
+  exit 2
+}
+
+CODE=$(curl -m "${FM_LINEAR_HTTP_TIMEOUT:-20}" -s -o "$RESPONSE" -w '%{http_code}' \
+  -X POST \
+  -H "@$AUTH_HEADER_FILE" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  --data-binary "@$REQUEST" \
+  "$FM_LINEAR_API_URL" 2>/dev/null) || {
+  echo "fm-linear-transport: the request to Linear did not complete" >&2
+  exit 4
+}
+
+case "$CODE" in
+  ''|*[!0-9]*)
+    echo "fm-linear-transport: the request to Linear did not complete" >&2
+    exit 4
+    ;;
+esac
+
+printf '%s\n' "$CODE"

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -329,6 +329,8 @@ PRIMARY_HARNESS=$("$SCRIPT_DIR/fm-harness.sh" 2>/dev/null || printf unknown)
 . "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
 # shellcheck source=bin/fm-public-followup-lib.sh
 . "$SCRIPT_DIR/fm-public-followup-lib.sh"
+# shellcheck source=bin/fm-linear-lib.sh
+. "$SCRIPT_DIR/fm-linear-lib.sh"
 # shellcheck source=bin/fm-trace-context-lib.sh
 . "$SCRIPT_DIR/fm-trace-context-lib.sh"
 # shellcheck source=bin/fm-wake-lib.sh
@@ -865,6 +867,23 @@ if fm_pf_relay_active "$FM_HOME" \
     printf 'Reconcile terminal results with %s/bin/fm-public-followup.sh consume, then deliver a ready one with\n' "$FM_ROOT"
     printf '%s/bin/fm-public-followup.sh deliver <id>. Hand a delivered loop on with rechain, or close it with\n' "$FM_ROOT"
     printf '%s/bin/fm-public-followup.sh retire <id> --reason "...". Load fmx-respond for the procedure.\n' "$FM_ROOT"
+  fi
+fi
+
+# Work bound to a Linear issue is not complete until that issue is current, so a
+# still-owed handback is surfaced from disk here rather than from conversation
+# memory. bin/fm-linear-lib.sh owns the gate: a home that never bound a Linear
+# issue runs one [ -d ] test, prints no subsection, and never reaches
+# bin/fm-linear-sync.sh.
+if fm_linear_present "$STATE" && fm_linear_has_pending "$STATE"; then
+  LINEAR_PENDING=$(FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" \
+    "$SCRIPT_DIR/fm-linear-sync.sh" pending 2>/dev/null) || LINEAR_PENDING=
+  if [ -n "$LINEAR_PENDING" ]; then
+    subsection "Linear issues awaiting synchronization"
+    printf '%s\n' "$LINEAR_PENDING"
+    printf '\nEach line is a handback a bound task still owes its Linear issue, and that task\n'
+    printf 'is not complete until it lands. Deliver them with\n'
+    printf '%s/bin/fm-linear-sync.sh deliver --all.\n' "$FM_ROOT"
   fi
 fi
 

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -164,6 +164,8 @@ SUB_HOME_PARENT_MARKER=".fm-secondmate-parent"
 . "$SCRIPT_DIR/fm-pr-lib.sh"
 # shellcheck source=bin/fm-public-followup-lib.sh
 . "$SCRIPT_DIR/fm-public-followup-lib.sh"
+# shellcheck source=bin/fm-linear-lib.sh
+. "$SCRIPT_DIR/fm-linear-lib.sh"
 # shellcheck source=bin/fm-secondmate-registry-lib.sh
 . "$SCRIPT_DIR/fm-secondmate-registry-lib.sh"
 # shellcheck source=bin/fm-secondmate-parent-lib.sh
@@ -2613,6 +2615,21 @@ fi
 X_REQUEST=$(grep '^x_request=' "$META" 2>/dev/null | tail -1 | cut -d= -f2- || true)
 if [ -n "$X_REQUEST" ]; then
   echo "warning: task $ID still carries an unreconciled Relay request link ($X_REQUEST) on its task record." >&2
+fi
+
+# The captain's rule: work bound to a Linear issue is not complete until that
+# issue is current. This cleanup removes the records that make the handback
+# deliverable, so it refuses while exactly this task still owes one. The gate is
+# bin/fm-linear-lib.sh's, so a home that never bound an issue runs one [ -d ]
+# test here and nothing else.
+if [ "$FORCE" != "--force" ] && fm_linear_present "$STATE"; then
+  if ! LINEAR_BLOCKING=$(FM_HOME="$FM_HOME" FM_STATE_OVERRIDE="$STATE" \
+      "$SCRIPT_DIR/fm-linear-sync.sh" guard-work "$ID" 2>/dev/null); then
+    echo "REFUSED: task $ID still owes its bound Linear issue a handback." >&2
+    printf '%s\n' "$LINEAR_BLOCKING" >&2
+    echo "Deliver it with bin/fm-linear-sync.sh deliver --task $ID, drop it with bin/fm-linear-sync.sh discard <delivery-id> --reason <why> --yes, or use --force after explicit discard approval." >&2
+    exit 1
+  fi
 fi
 
 if [ "$BACKEND" = orca ] && [ "$KIND" != scout ] && [ "$KIND" != secondmate ] && [ "$FORCE" != "--force" ]; then

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -211,6 +211,7 @@ family_for_basename() {
     fm-teardown-endpoint-safety.test.sh)
       printf '%s\n' backend-dispatch
       ;;
+    fm-linear-sync.test.sh|\
     fm-pr-check-security.test.sh|fm-pr-merge.test.sh|fm-review-diff.test.sh|\
     fm-teardown.test.sh|fm-x-mode.test.sh)
       printf '%s\n' pr-forge
@@ -982,6 +983,12 @@ families_for_changed_path() {
       printf '%s\n' pure-contract-unit
       printf '%s\n' secondmate
       printf '%s\n' watcher-wake-lock
+      ;;
+    bin/fm-linear-*)
+      # The completion gate lives in cleanup (pr-forge) and the owed-handback
+      # surfacing lives in session start, so a change to either re-selects both.
+      printf '%s\n' pr-forge
+      printf '%s\n' session-bootstrap
       ;;
     bin/fm-pr-*|bin/fm-merge-local.sh|bin/fm-teardown.sh|bin/fm-review-diff.sh|\
     bin/fm-x-*|bin/fm-check*)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -273,6 +273,20 @@ That path merges only after one live read of the merge request confirms it is op
 Teardown is fail-closed for ship worktrees: dirty worktrees refuse, and committed work must be landed before the worktree is returned.
 [`bin/fm-teardown.sh`](../bin/fm-teardown.sh)'s header owns the landed-work proofs, PR-discovery fallback, and stale-lock recovery procedure.
 
+## Linear issues are part of completion
+
+A firstmate home can hold one captain rule mechanically: work is not complete until the corresponding Linear issue is current.
+It is opt-in per home and per task - a gitignored `config/linear.env` credential plus an explicit task-to-issue binding - and a home that never binds one pays a single `[ -d ]` test and gains no state.
+
+The mechanism boundary is three files.
+`bin/fm-linear-lib.sh` owns the activation gates, the private `state/linear` layout, and the content-derived delivery identity that makes re-queueing idempotent.
+`bin/fm-linear-sync.sh` owns the commands and the delivery sequence, including the read-back that recovers a comment Linear committed but never acknowledged.
+`bin/fm-linear-transport.sh` is the only place that reaches Linear or reads the credential, and `FM_LINEAR_TRANSPORT` replaces it wholesale, which is the seam that makes the whole path testable with no credential and no network.
+
+Enforcement is deliberately harness-independent: the completion gate lives in `bin/fm-teardown.sh` and the owed-handback surfacing lives in the `bin/fm-session-start.sh` digest, so no primary-harness turn-end registration carries a second verdict alongside the continuity state machine in [`turnend-guard.md`](turnend-guard.md).
+`bin/fm-linear-sync.sh hook` is the optional passive surface for an operator who wants that nag, scoped by `bin/fm-primary-scope-lib.sh` so it is inert in a project repo or a task worktree.
+The [Linear synchronization reference](linear-sync.md) owns the operator contract and the reasoning behind that placement, [`configuration.md`](configuration.md#linear-synchronization-configlinearenv--statelinear) owns the two files you set, and [`verification/linear-sync.md`](verification/linear-sync.md) owns the current evidence.
+
 ## Optional Relay
 
 Relay is opt-in presence for the shared `@myfirstmate` bot on both public surfaces it supports, X and Discord.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -529,6 +529,27 @@ The session-start digest separately prints a "Public commitments" subsection fro
 `FM_PF_RETRY_BACKOFF_SECS` (default 900) sets the next-attempt time recorded with a retryable delivery error.
 See [verification/public-followup.md](verification/public-followup.md) for the current maintainer evidence behind restart recovery, retained-loop disposition, and the relay-disabled zero-overhead guarantee.
 
+## Linear synchronization (config/linear.env / state/linear)
+
+Firstmate can hold one rule mechanically: work is not complete until the corresponding Linear issue is current.
+[`linear-sync.md`](linear-sync.md) owns the operator contract, the setup steps, the guarantees, and the supported limits; `bin/fm-linear-sync.sh --help` owns the commands and flags.
+This section owns only the two files you set.
+
+`config/linear.env` is the single credential and configuration owner for a home, gitignored with the rest of `config/`.
+It accepts `LINEAR_API_KEY`, required and non-empty, and an optional `LINEAR_API_URL` that must be an `https://` endpoint and defaults to `https://api.linear.app/graphql`.
+The file is refused rather than used when it is a symlink, carries more than one hard link, is not mode 0600, or holds a key containing whitespace or control characters, so a world-readable paste fails loudly instead of leaking.
+The key never reaches a command line, an environment variable a child inherits by name, a request body, a durable record, or any output: `bin/fm-linear-transport.sh` writes it to a mode-0600 temp file as a complete header line, hands `curl` that file, and removes it on every exit path.
+`FM_LINEAR_API_KEY_OVERRIDE` and `FM_LINEAR_API_URL_OVERRIDE` let a direct invocation bypass the file, matching how every other firstmate client treats an explicit environment value.
+
+`state/linear` (mode 0700) is this home's private transport, created only by `bin/fm-linear-sync.sh bind`: `bindings/` for the durable task-to-issue binding, `outbox/` for typed pending deliveries, `sent/` for the receipt ledger, `attempts/` for a held delivery's retry state, `refused/` for a delivery Linear rejected with its one-line reason, `discarded/` for explicitly authorized drops, and a transient `.lock.<delivery-id>` while one is being delivered.
+A delivery's id is derived from its own content, so re-queueing an identical handback after a retry, a crash, or a restart resolves to the same record and changes nothing.
+`FM_LINEAR_LOCK_STALE_SECS` (default 300) is how long a per-delivery lock may sit before a later run treats it as abandoned, so a crashed delivery stays retryable.
+
+Activation is those two things and no third flag.
+A home that never bound a Linear issue has no `state/linear`, so `bin/fm-teardown.sh`'s completion gate and the session-start digest's owed-handback subsection each cost one `[ -d ]` test and produce no output and no file.
+No harness hook file registers any of this; [`linear-sync.md`](linear-sync.md) records why the harness-independent cleanup and session-start gates are the owner instead.
+See [verification/linear-sync.md](verification/linear-sync.md) for the current maintainer evidence.
+
 ## Process-to-event sources (state/procevent)
 
 A long-polling external process is registered as a *source* through its adapter, whose header and `--help` own the commands and flags.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -26,6 +26,7 @@
   "readmeSetupTargets": [
     "docs/configuration.md",
     "docs/wedge-alarm.md",
+    "docs/linear-sync.md",
     "docs/tmux-backend.md",
     "docs/herdr-backend.md",
     "docs/zellij-backend.md",
@@ -289,6 +290,10 @@
       "audience": "operator-current"
     },
     {
+      "path": "docs/linear-sync.md",
+      "audience": "operator-current"
+    },
+    {
       "path": "docs/orca-backend.md",
       "audience": "operator-current"
     },
@@ -354,6 +359,10 @@
     },
     {
       "path": "docs/verification/dispatch-auth.md",
+      "audience": "maintainer-verification"
+    },
+    {
+      "path": "docs/verification/linear-sync.md",
       "audience": "maintainer-verification"
     },
     {

--- a/docs/linear-sync.md
+++ b/docs/linear-sync.md
@@ -121,7 +121,8 @@ A refusal is an unfinished handback that needs a decision, not a discarded one.
 - One credential per home. Cross-workspace issues need separate homes.
 - An issue with more comment pages than `FM_LINEAR_COMMENT_PAGE_MAX` holds rather than posting, because an unproven absence is treated as unknown. Raise the bound for a very long issue.
 - Only the comment body and the workflow state are synchronized. Assignees, labels, estimates, relations, and attachments are not.
-- `jq` is required. Without it, every command that builds or reads a typed record holds rather than proceeding.
+- `jq` is required by `queue` and by `deliver`; without it both hold rather than proceeding.
+  Reading is deliberately `jq`-free, so `bind`, `bindings`, `pending`, `show`, `hook`, `discard`, and the cleanup gate all keep working on a home that lacks it, and that home still refuses to complete a task that owes a handback.
 - The GraphQL documents are written against Linear's published API and are exercised end to end only against the hermetic fake. They have not been run against the live service from this repository. If Linear's schema differs, a delivery holds with the API's own message and no handback is lost; correcting the documents is a one-file change in `bin/fm-linear-sync.sh`.
 
 See [verification/linear-sync.md](verification/linear-sync.md) for the current maintainer evidence.

--- a/docs/linear-sync.md
+++ b/docs/linear-sync.md
@@ -1,0 +1,127 @@
+# Linear synchronization
+
+Audience: operator, current behavior.
+
+Firstmate can hold one rule mechanically: work is not complete until the corresponding Linear issue is current.
+A task is explicitly bound to one or more Linear issues, every handback is a durable record, delivery is idempotent, and cleanup refuses while a bound task still owes one.
+
+It is off unless a home creates the credential file below and binds at least one task.
+A home that never binds a Linear issue gains no state, runs no extra command, and prints nothing.
+
+`bin/fm-linear-sync.sh --help` owns the exact commands and flags.
+`bin/fm-linear-transport.sh --help` owns the transport contract.
+
+## What it guarantees
+
+- **A target is established, never inferred.** There is no transcript scraping and no prose matching. A task with no binding refuses to queue anything, a task bound to more than one issue refuses until one is named, and a comment is exactly the bytes you supplied.
+- **Delivery is idempotent.** A delivery's identity is derived from its own content, so re-queueing the same handback after a retry, a crash, a context compaction, or a restart resolves to the same record and changes nothing.
+- **A lost acknowledgement cannot duplicate a comment.** Every posted comment carries a marker derived from that delivery. Before posting, the issue's own comments are read back and searched for it, so Linear's copy - not the local receipt - is what proves the comment landed. A local receipt alone would miss the interval where Linear commits the comment and the response never arrives.
+- **A disconnected Linear never becomes a completion.** With no credential, an unreachable API, or an unconfirmed status change, the handback is preserved untouched, one concise blocker is printed, and the command exits non-zero. Repeated runs converge with no duplicate comment and no second status change.
+- **Two deliveries cannot race into a duplicate.** A per-delivery lock serializes the read-then-post sequence, and an abandoned lock is taken over after `FM_LINEAR_LOCK_STALE_SECS` so a crashed delivery stays retryable rather than stranded.
+- **Cleanup enforces it.** `bin/fm-teardown.sh` refuses to clean up a task while exactly that task still owes a handback, unless `--force` carries explicit discard approval.
+
+## Setup
+
+1. Create a Linear API key. In Linear, open Settings, then Security & access, then Personal API keys, and create one scoped to the workspace whose issues firstmate should update. An OAuth access token works too; paste it as `Bearer <token>`.
+2. Write it into this firstmate home's gitignored credential file, which must be mode 0600:
+
+   ```sh
+   ( umask 077; printf 'LINEAR_API_KEY=%s\n' '<your-key>' > "$FM_HOME/config/linear.env" )
+   chmod 600 "$FM_HOME/config/linear.env"
+   ```
+
+3. Confirm the home can see it:
+
+   ```sh
+   bin/fm-linear-sync.sh status
+   ```
+
+`config/linear.env` is the single credential and configuration owner.
+It accepts `LINEAR_API_KEY` and an optional `LINEAR_API_URL` (an `https://` endpoint; the default is `https://api.linear.app/graphql`).
+The file is refused rather than used when it is a symlink, has more than one hard link, is not mode 0600, or holds a key with whitespace or control characters, so a world-readable paste fails loudly instead of leaking.
+`config/` is gitignored in full, so the key is never committed.
+
+The key never reaches a command line, a log, a request body, a durable record, or a report.
+`bin/fm-linear-transport.sh` writes it to a mode-0600 temp file as a complete header line, hands `curl` that file, and removes it on every exit path.
+
+## Using it
+
+```sh
+# Bind the work to its issue, once.
+bin/fm-linear-sync.sh bind <task-id> ENG-123
+
+# Queue the exact handback the issue should receive.
+bin/fm-linear-sync.sh queue <task-id> --comment-file handback.md --status Done
+
+# Deliver everything this home still owes.
+bin/fm-linear-sync.sh deliver --all
+
+# See what is still owed.
+bin/fm-linear-sync.sh pending
+```
+
+`--status` is a Linear workflow state name exactly as the team spells it, such as `In Progress` or `Done`.
+Omit it to post a comment and change nothing else.
+A status change is applied only when the issue is not already in that state, and it is confirmed by reading the state back.
+
+`bin/fm-linear-sync.sh guard-work <task-id>` is the completion gate cleanup calls.
+`bin/fm-linear-sync.sh hook` is the passive surface described below.
+`bin/fm-linear-sync.sh discard <delivery-id> --reason <why> --yes` is the only way to drop an owed handback without delivering it, and the discard itself is recorded.
+
+## Where it is enforced
+
+Two integration points, both independent of which harness the primary session runs.
+
+`bin/fm-teardown.sh` runs the completion gate before it removes anything.
+The refusal names the task, the issue, and the delivery, and preserves every record.
+
+The session-start digest prints a "Linear issues awaiting synchronization" subsection whenever, and only when, this home still owes a handback.
+It is read from disk, so a compaction or a restart is a non-event.
+
+Both gates start with one `[ -d ]` test on `state/linear`, so a home that never bound an issue pays nothing for either.
+
+No harness hook file registers Linear synchronization, and none needs to.
+Every supported primary harness turn-end surface (Claude and Codex `Stop`, OpenCode `session.idle`, Pi `agent_settled`, Grok `Stop`, Cursor `stop`) is already owned by a single continuation state machine documented in [`turnend-guard.md`](turnend-guard.md), whose job is watcher liveness and whose failure modes are per-harness.
+Adding a second, unrelated verdict to that boundary would put an unfinished Linear handback in a position to hold a turn open, on six separately-behaving surfaces, for no gain over the harness-independent gates above.
+`bin/fm-linear-sync.sh hook` exists for an operator who does want that nag: it is scoped to a genuine firstmate primary home, prints nothing in an ordinary project repo, a crewmate or scout task worktree, or a home with no owed handback, and never blocks.
+
+## Private state
+
+All of it lives under `state/linear` (mode 0700), created only by `bind`:
+
+| Path | What it holds |
+| --- | --- |
+| `bindings/<task-id>` | the durable task-to-issue binding |
+| `outbox/<delivery-id>.json` | typed pending deliveries, immutable once written |
+| `sent/<delivery-id>` | the receipt ledger for confirmed handbacks |
+| `attempts/<delivery-id>` | retry state for a held delivery, kept beside the record so its identity never moves |
+| `refused/<delivery-id>.json` and `.reason` | a delivery Linear rejected, preserved with a one-line reason |
+| `discarded/<delivery-id>` | explicitly authorized discards |
+| `.lock.<delivery-id>` | a delivery in progress, taken over after `FM_LINEAR_LOCK_STALE_SECS` |
+
+A refused delivery still blocks cleanup.
+A refusal is an unfinished handback that needs a decision, not a discarded one.
+
+## Tuning
+
+| Variable | Default | Effect |
+| --- | --- | --- |
+| `FM_LINEAR_COMMENT_MAX` | 6000 | maximum characters in one handback comment |
+| `FM_LINEAR_COMMENT_PAGE_SIZE` | 100 | comments fetched per read-back page |
+| `FM_LINEAR_COMMENT_PAGE_MAX` | 10 | read-back pages walked before the delivery holds instead of posting |
+| `FM_LINEAR_RETRY_BACKOFF_SECS` | 900 | recorded next-attempt spacing for a held delivery |
+| `FM_LINEAR_LOCK_STALE_SECS` | 300 | age at which a per-delivery lock is treated as abandoned and taken over |
+| `FM_LINEAR_HTTP_TIMEOUT` | 20 | per-request timeout in `bin/fm-linear-transport.sh` |
+| `FM_LINEAR_TRANSPORT` | `bin/fm-linear-transport.sh` | an executable satisfying the transport contract, used instead of the real one |
+
+`FM_LINEAR_TRANSPORT` is what makes the whole path testable with no credential and no network; `tests/fm-linear-sync.test.sh` points it at a hermetic fake workspace.
+
+## Supported limits
+
+- One credential per home. Cross-workspace issues need separate homes.
+- An issue with more comment pages than `FM_LINEAR_COMMENT_PAGE_MAX` holds rather than posting, because an unproven absence is treated as unknown. Raise the bound for a very long issue.
+- Only the comment body and the workflow state are synchronized. Assignees, labels, estimates, relations, and attachments are not.
+- `jq` is required. Without it, every command that builds or reads a typed record holds rather than proceeding.
+- The GraphQL documents are written against Linear's published API and are exercised end to end only against the hermetic fake. They have not been run against the live service from this repository. If Linear's schema differs, a delivery holds with the API's own message and no handback is lost; correcting the documents is a one-file change in `bin/fm-linear-sync.sh`.
+
+See [verification/linear-sync.md](verification/linear-sync.md) for the current maintainer evidence.

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -133,3 +133,6 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-voice-client.py`     | The laptop end of the spoken interface: capture, playback, and turn timing over SSH; audio devices unverified |
 | `fm_voice_frame.py`      | The wire format both machines share, copied to the laptop beside the client          |
 | `fm_voice_records.py`    | What a spoken answer may read, and the handover that queues real work                |
+| `fm-linear-lib.sh`       | Shared Linear activation gates, private transport paths, and derived delivery identity |
+| `fm-linear-sync.sh`      | Bind a task to its Linear issues, queue a typed handback, and deliver it idempotently |
+| `fm-linear-transport.sh` | Perform one Linear GraphQL exchange, passing the credential only by private file     |

--- a/docs/verification/linear-sync.md
+++ b/docs/verification/linear-sync.md
@@ -2,20 +2,22 @@
 
 Audience: maintainer verification.
 
-This record supports five active guarantees for firstmate's durable Linear synchronization:
+This record supports seven active guarantees for firstmate's durable Linear synchronization:
 
 1. A handback target is established, never inferred: a missing or ambiguous target refuses.
 2. A comment Linear committed but never acknowledged is recovered from Linear's own copy, so no retry, crash, or restart produces a duplicate comment or a second status change.
 3. Two concurrent deliveries cannot both post, and an abandoned lock never strands a handback.
 4. A disconnected, misconfigured, or unreachable Linear preserves the owed handback, surfaces one concise blocker, and never becomes a completion.
-5. A home that never bound a Linear issue pays nothing: no artifact, no output, no extra call.
+5. An owed handback is never dropped on the way to being set aside: when a permanent refusal cannot be written to quarantine, the delivery record survives and the task stays blocked.
+6. The comment reaches Linear as the captain's own bytes, so text that cannot survive that trip is refused rather than silently altered.
+7. A home that never bound a Linear issue pays nothing: no artifact, no output, no extra call.
 
 [`docs/linear-sync.md`](../linear-sync.md) owns the operator contract, [`docs/configuration.md`](../configuration.md#linear-synchronization-configlinearenv--statelinear) owns the two files an operator sets, and `bin/fm-linear-sync.sh --help` owns the commands and flags.
 Task chronology and delivery evidence stay outside this record.
 
 ## Environment
 
-Recorded 2026-08-20 on Darwin 25.5.0 (arm64, macOS 26.5.2) with GNU bash 3.2.57(1), jq 1.7.1-apple, git 2.50.1, curl 8.7.1, and ShellCheck 0.11.0 (the version `bin/fm-lint.sh` pins).
+Recorded 2026-08-25 on Darwin 25.5.0 (arm64, macOS 26.5.2) with GNU bash 3.2.57(1), jq 1.7.1-apple, git 2.50.1, curl 8.7.1, and ShellCheck 0.11.0 (the version `bin/fm-lint.sh` pins).
 
 Linear is a hermetic fake transport in every automated case, so no Linear mutation is ever made and no credential is ever needed.
 `FM_LINEAR_TRANSPORT` is the seam: `bin/fm-linear-sync.sh` reaches Linear only through the two-argument transport contract in `bin/fm-linear-transport.sh`, and the suite points that at a fake workspace held in a temp directory.
@@ -29,7 +31,7 @@ bash tests/fm-linear-sync.test.sh
 
 ```
 ok - an unbound task, an ambiguous binding, and a prose target all refuse instead of guessing
-ok - an empty comment, a forged marker, an oversized body, and a malformed status all refuse
+ok - an empty comment, a forged marker, an oversized body, a NUL byte, and a malformed status all refuse
 ok - a delivery posts one comment, applies the status once, and repeats as a no-op
 ok - re-queueing an identical handback resolves to one delivery, and a changed one is distinct
 ok - a delivery already under way holds, and an abandoned lock is taken over rather than stranding it
@@ -40,6 +42,7 @@ ok - a disconnected or misconfigured Linear preserves the handback and never cla
 ok - an unreachable Linear holds the handback and the later retry posts exactly once
 ok - a comment that landed without its status is completed on retry with no second comment
 ok - an issue Linear does not have is quarantined, keeps blocking, and clears only on an explicit discard
+ok - a refusal that cannot be quarantined preserves the outbox record and holds instead of discarding it
 ok - cleanup refuses while a Linear handback is owed and proceeds once the issue is current
 ok - the completion gate blocks only the task that owes the handback
 ok - session start surfaces an owed Linear handback from disk, and stays silent otherwise
@@ -49,6 +52,7 @@ ok - the credential never reaches a request body, a durable record, or any outpu
 ok - the real transport passes its credential by private file, never in argv or the environment
 ok - delivery records are typed, private, and refused when they no longer match their identity
 ok - comment text cannot forge the record fields the jq-free cleanup gate reads
+ok - a home without jq still reads its records and still refuses to complete an owed task
 ```
 
 The sixth case is the end-to-end proof for guarantee 2.
@@ -64,8 +68,21 @@ An absence that could not be proven is treated as unknown, never as new.
 The read-back cannot prevent one duplicate on its own: two concurrent deliveries would both prove absence before either posted.
 `a delivery already under way holds, and an abandoned lock is taken over rather than stranding it` covers both halves of the per-delivery lock that closes it, including the takeover that keeps a crashed delivery retryable rather than stranded.
 
+`a refusal that cannot be quarantined preserves the outbox record and holds instead of discarding it` covers guarantee 5, which is the one way the quarantine path could otherwise turn an owed handback into a silent discard.
+The case makes the refused directory unwritable, so a permanent refusal has nowhere to go.
+The delivery must then hold rather than proceed: it exits 3 saying the handback is preserved and still owed, the outbox record survives, no partial quarantine record is left behind, `pending` still lists the handback as queued rather than refused, and the completion gate still refuses the task.
+
+`an empty comment, a forged marker, an oversized body, a NUL byte, and a malformed status all refuse` covers guarantee 6.
+The comment is canonicalized in its trailing newline only and otherwise reaches Linear byte for byte, and that canonicalization reads the text through a command substitution, which drops NUL bytes silently.
+The control-character check therefore runs on the bytes as received rather than after canonicalization: a comment carrying a NUL refuses instead of posting an altered comment.
+The same case pins the other side of that boundary, since tab, carriage return, and newline are deliberately postable: a comment containing all three queues, and the stored record is asserted byte for byte against the captain's own text.
+
 `comment text cannot forge the record fields the jq-free cleanup gate reads` covers the one place a delivery record is parsed without `jq`, so that the cleanup gate keeps working on a home with no `jq`.
 A comment whose own text contains `"status":`, `"issue":`, and `"task_id":` lines must not change what that gate sees, in either direction: the gate must still block the task that owes the handback and must still pass the task named only inside the comment.
+
+`a home without jq still reads its records and still refuses to complete an owed task` proves that same boundary from the operator's side, on a PATH rebuilt from the real one with `jq` alone withheld.
+`bind`, `bindings`, `pending`, `show`, `hook`, and `discard` keep working on the typed records, and the completion gate still refuses the task that owes the handback and then passes once that handback is explicitly discarded; `queue` and `deliver` are the only two commands that hold, and both name `jq` and post nothing.
+Those two holds are also what keep the case from passing vacuously: a PATH that still resolved a `jq` would let them succeed instead of hold.
 
 ## Secret handling
 
@@ -98,7 +115,8 @@ fm-linear-sync: .../.treehouse/firstmate-7bab20/1/firstmate is not a firstmate p
 exit=1
 ```
 
-No `state/` directory came into existence in that worktree as a result.
+No `state/linear` came into existence in that worktree as a result, so nothing about a binding, an outbox, or a receipt was written outside the primary home.
+Re-observed on 2026-08-25 in the same worktree, with the same three verdicts.
 
 ## Harness surfaces inspected
 

--- a/docs/verification/linear-sync.md
+++ b/docs/verification/linear-sync.md
@@ -1,0 +1,131 @@
+# Linear synchronization verification
+
+Audience: maintainer verification.
+
+This record supports five active guarantees for firstmate's durable Linear synchronization:
+
+1. A handback target is established, never inferred: a missing or ambiguous target refuses.
+2. A comment Linear committed but never acknowledged is recovered from Linear's own copy, so no retry, crash, or restart produces a duplicate comment or a second status change.
+3. Two concurrent deliveries cannot both post, and an abandoned lock never strands a handback.
+4. A disconnected, misconfigured, or unreachable Linear preserves the owed handback, surfaces one concise blocker, and never becomes a completion.
+5. A home that never bound a Linear issue pays nothing: no artifact, no output, no extra call.
+
+[`docs/linear-sync.md`](../linear-sync.md) owns the operator contract, [`docs/configuration.md`](../configuration.md#linear-synchronization-configlinearenv--statelinear) owns the two files an operator sets, and `bin/fm-linear-sync.sh --help` owns the commands and flags.
+Task chronology and delivery evidence stay outside this record.
+
+## Environment
+
+Recorded 2026-08-20 on Darwin 25.5.0 (arm64, macOS 26.5.2) with GNU bash 3.2.57(1), jq 1.7.1-apple, git 2.50.1, curl 8.7.1, and ShellCheck 0.11.0 (the version `bin/fm-lint.sh` pins).
+
+Linear is a hermetic fake transport in every automated case, so no Linear mutation is ever made and no credential is ever needed.
+`FM_LINEAR_TRANSPORT` is the seam: `bin/fm-linear-sync.sh` reaches Linear only through the two-argument transport contract in `bin/fm-linear-transport.sh`, and the suite points that at a fake workspace held in a temp directory.
+The one case that exercises the real transport substitutes a fake `curl` and asserts local secret handling only.
+
+## Guarantees and regressions
+
+```sh
+bash tests/fm-linear-sync.test.sh
+```
+
+```
+ok - an unbound task, an ambiguous binding, and a prose target all refuse instead of guessing
+ok - an empty comment, a forged marker, an oversized body, and a malformed status all refuse
+ok - a delivery posts one comment, applies the status once, and repeats as a no-op
+ok - re-queueing an identical handback resolves to one delivery, and a changed one is distinct
+ok - a delivery already under way holds, and an abandoned lock is taken over rather than stranding it
+ok - a comment committed by Linear with a lost acknowledgement converges with no duplicate
+ok - a lost local receipt is recovered from Linear's own copy, never by reposting
+ok - a read-back that cannot be completed holds rather than risking a duplicate
+ok - a disconnected or misconfigured Linear preserves the handback and never claims completion
+ok - an unreachable Linear holds the handback and the later retry posts exactly once
+ok - a comment that landed without its status is completed on retry with no second comment
+ok - an issue Linear does not have is quarantined, keeps blocking, and clears only on an explicit discard
+ok - cleanup refuses while a Linear handback is owed and proceeds once the issue is current
+ok - the completion gate blocks only the task that owes the handback
+ok - session start surfaces an owed Linear handback from disk, and stays silent otherwise
+ok - a home that never bound a Linear issue gains no artifact and prints nothing
+ok - the hook is active in a primary and secondmate home and inert in a task worktree or project repo
+ok - the credential never reaches a request body, a durable record, or any output
+ok - the real transport passes its credential by private file, never in argv or the environment
+ok - delivery records are typed, private, and refused when they no longer match their identity
+ok - comment text cannot forge the record fields the jq-free cleanup gate reads
+```
+
+The sixth case is the end-to-end proof for guarantee 2.
+The fake commits the comment and then exits non-zero without answering, which is exactly the interval a local receipt cannot cover.
+The suite asserts the delivery holds with no receipt, the handback stays owed, and the retry finds the marker in Linear's own comment list, reports `read-back` as its proof, adds no second comment, and clears the pending set.
+
+The seventh case covers the same interval from the other side: a home restored from an older copy whose receipt is gone re-derives the same delivery identity from the same content and still converges without reposting.
+
+The eighth case pins the anti-duplicate rule that makes the read-back trustworthy.
+With `FM_LINEAR_COMMENT_PAGE_SIZE=2` and `FM_LINEAR_COMMENT_PAGE_MAX=2` against a twelve-comment issue, the read-back cannot complete, so the delivery holds and posts nothing; with the bound restored, the same delivery adds exactly one comment.
+An absence that could not be proven is treated as unknown, never as new.
+
+The read-back cannot prevent one duplicate on its own: two concurrent deliveries would both prove absence before either posted.
+`a delivery already under way holds, and an abandoned lock is taken over rather than stranding it` covers both halves of the per-delivery lock that closes it, including the takeover that keeps a crashed delivery retryable rather than stranded.
+
+`comment text cannot forge the record fields the jq-free cleanup gate reads` covers the one place a delivery record is parsed without `jq`, so that the cleanup gate keeps working on a home with no `jq`.
+A comment whose own text contains `"status":`, `"issue":`, and `"task_id":` lines must not change what that gate sees, in either direction: the gate must still block the task that owes the handback and must still pass the task named only inside the comment.
+
+## Secret handling
+
+Two cases cover it, because the credential can leak in two different places.
+
+`the credential never reaches a request body, a durable record, or any output` runs a full delivery with a distinctive key and then greps the fake transport's whole workspace (including every captured request body), the home's whole `state/` tree, and the command's stdout and stderr for that key.
+Any hit fails the case.
+The same case asserts the key is still present in `config/linear.env`, so the check cannot pass vacuously.
+
+`the real transport passes its credential by private file, never in argv or the environment` runs the real `bin/fm-linear-transport.sh` against a fake `curl` that records its full argv and its full environment.
+The key must be absent from argv, from the request body, and from the environment; must be present as a complete `Authorization:` line in the mode-0600 file that `curl` was pointed at with `-H @file`; and that file must no longer exist once the transport has exited.
+
+## Zero overhead and scope
+
+`a home that never bound a Linear issue gains no artifact and prints nothing` asserts that `hook`, `pending`, and `bindings` are all silent, that `guard-work` passes, and that neither `state/linear` nor `config/linear.env` comes into existence.
+
+`the hook is active in a primary and secondmate home and inert in a task worktree or project repo` builds the four real shapes rather than standing in for them: a plain non-worktree checkout with `AGENTS.md`, `bin/`, and `state/`; a genuine linked `git worktree` of that home, which is what `bin/fm-spawn.sh` hands a crewmate or scout; an ordinary project repo; and a linked worktree carrying the `.fm-secondmate-home` marker.
+Each child copy is given a populated `state/linear` first, so a passing inert verdict is a scope decision and not an empty-directory accident.
+Binding from inside the task worktree refuses with a named scope error rather than creating state in the wrong place.
+
+The same verdict was observed directly in a real crewmate worktree that `bin/fm-spawn.sh` had produced (a treehouse-leased linked worktree of the primary checkout), rather than only in the synthetic fixture:
+
+```
+$ bin/fm-linear-sync.sh hook ; echo "exit=$?"
+exit=0
+$ bin/fm-linear-sync.sh status
+scope: inert (.../.treehouse/firstmate-7bab20/1/firstmate is not a firstmate primary home)
+$ bin/fm-linear-sync.sh bind t1 ENG-1 ; echo "exit=$?"
+fm-linear-sync: .../.treehouse/firstmate-7bab20/1/firstmate is not a firstmate primary home; Linear synchronization is inert here
+exit=1
+```
+
+No `state/` directory came into existence in that worktree as a result.
+
+## Harness surfaces inspected
+
+The captain's rule is enforced at two harness-independent points - the cleanup completion gate in `bin/fm-teardown.sh` and the owed-handback subsection in `bin/fm-session-start.sh` - and no harness hook file was changed.
+That is a decision, so the alternative was inspected first.
+
+Every supported primary-harness turn-end registration was read: Claude's two `Stop` entries in `.claude/settings.json`, Codex's `Stop` entry in `.codex/hooks.json`, OpenCode's `session.idle` plugin in `.opencode/plugins/`, Pi's `agent_settled` extension in `.pi/extensions/`, Grok's `Stop` registration in `.grok/hooks/`, and Cursor's `stop` registration in `.cursor/hooks.json`.
+All six already delegate to one continuation state machine whose verdict is watcher liveness, whose blocking semantics differ per harness (Claude and Codex block on exit 2; OpenCode and Pi are passive and force one bounded follow-up; Grok selects natively from its payload; Cursor cannot block at all and parks instead), and whose per-harness loop bounds and fail-open tradeoffs are recorded in [`../turnend-guard.md`](../turnend-guard.md).
+Adding a second, unrelated verdict there would let an unfinished Linear handback hold a turn open on six separately-behaving surfaces, and would need six pieces of per-harness work, for no coverage the cleanup gate does not already provide with certainty.
+`.codex/hooks.json` therefore needs no new registration, and none was added.
+
+`bin/fm-linear-sync.sh hook` exists as the passive surface for an operator who does want that nag, and is inert by the scoping evidence above.
+Because nothing registers it, no real harness hook was changed and no scratch-project hook validation was required.
+
+## Lint
+
+```sh
+bin/fm-lint.sh bin/fm-linear-lib.sh bin/fm-linear-sync.sh bin/fm-linear-transport.sh tests/fm-linear-sync.test.sh
+```
+
+```
+fm-lint.sh: ShellCheck 0.11.0 (pinned 0.11.0)
+```
+
+## Not covered here
+
+The GraphQL documents in `bin/fm-linear-sync.sh` are written against Linear's published API and are exercised end to end only against the hermetic fake.
+They have not been run against the live Linear service from this repository, because no credential was available and the work was explicitly barred from making a live mutation.
+The failure mode of a schema mismatch is a hold carrying Linear's own message, with the handback preserved, which is the same path the transport-failure and HTTP-500 cases already pin.
+Refreshing this record against a live workspace needs a `config/linear.env` and a throwaway issue, and is the one claim above that a reader should not treat as live-verified.

--- a/tests/fm-gotmp.test.sh
+++ b/tests/fm-gotmp.test.sh
@@ -82,6 +82,12 @@ make_fake_root() {
   # teardown now requires.
   ln -s "$ROOT/bin/fm-public-followup-lib.sh" "$fake/bin/fm-public-followup-lib.sh"
   ln -s "$ROOT/bin/fm-x-lib.sh" "$fake/bin/fm-x-lib.sh"
+  # fm-linear-lib.sh (and the fm-primary-scope-lib.sh it sources): teardown
+  # sources it for the Linear completion gate. Neither does anything in this
+  # fixture, which has no state/linear, but both are real siblings teardown
+  # now requires.
+  ln -s "$ROOT/bin/fm-linear-lib.sh" "$fake/bin/fm-linear-lib.sh"
+  ln -s "$ROOT/bin/fm-primary-scope-lib.sh" "$fake/bin/fm-primary-scope-lib.sh"
   ln -s "$ROOT/bin/fm-secondmate-registry-lib.sh" "$fake/bin/fm-secondmate-registry-lib.sh"
   ln -s "$ROOT/bin/fm-secondmate-parent-lib.sh" "$fake/bin/fm-secondmate-parent-lib.sh"
   # Receiver-wake retirement sources the pending-reply library, which in turn
@@ -171,6 +177,12 @@ test_teardown_skips_gracefully_without_tasktmp() {
   # teardown now requires.
   ln -s "$ROOT/bin/fm-public-followup-lib.sh" "$fake/bin/fm-public-followup-lib.sh"
   ln -s "$ROOT/bin/fm-x-lib.sh" "$fake/bin/fm-x-lib.sh"
+  # fm-linear-lib.sh (and the fm-primary-scope-lib.sh it sources): teardown
+  # sources it for the Linear completion gate. Neither does anything in this
+  # fixture, which has no state/linear, but both are real siblings teardown
+  # now requires.
+  ln -s "$ROOT/bin/fm-linear-lib.sh" "$fake/bin/fm-linear-lib.sh"
+  ln -s "$ROOT/bin/fm-primary-scope-lib.sh" "$fake/bin/fm-primary-scope-lib.sh"
   ln -s "$ROOT/bin/fm-secondmate-registry-lib.sh" "$fake/bin/fm-secondmate-registry-lib.sh"
   ln -s "$ROOT/bin/fm-secondmate-parent-lib.sh" "$fake/bin/fm-secondmate-parent-lib.sh"
   ln -s "$ROOT/bin/fm-pending-reply-lib.sh" "$fake/bin/fm-pending-reply-lib.sh"

--- a/tests/fm-linear-sync.test.sh
+++ b/tests/fm-linear-sync.test.sh
@@ -201,6 +201,38 @@ run_sync() {  # <home> <args...>
     "$SYNC" "$@"
 }
 
+# A copy of $PATH with jq alone withheld. Any PATH directory that actually holds
+# a jq is mirrored without it rather than dropped, so the case proves a missing
+# jq and not a missing shell. Prints the new PATH.
+path_without_jq() {  # <shim-dir>
+  local shim=$1 dir entry name newpath=''
+  mkdir -p "$shim"
+  while IFS= read -r dir; do
+    [ -n "$dir" ] || continue
+    if [ -x "$dir/jq" ]; then
+      for entry in "$dir"/*; do
+        [ -e "$entry" ] || continue
+        name=${entry##*/}
+        [ "$name" = jq ] && continue
+        [ -e "$shim/$name" ] || ln -s "$entry" "$shim/$name" 2>/dev/null || true
+      done
+      newpath="${newpath:+$newpath:}$shim"
+    else
+      newpath="${newpath:+$newpath:}$dir"
+    fi
+  done < <(printf '%s\n' "$PATH" | tr ':' '\n')
+  printf '%s\n' "$newpath"
+}
+
+run_sync_nojq() {  # <home> <path> <args...>
+  local home=$1 path=$2
+  shift 2
+  PATH="$path" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    FM_LINEAR_TRANSPORT="$home/fake-linear.sh" \
+    FAKE_LINEAR_DIR="$(fake_dir "$home")" \
+    "$SYNC" "$@"
+}
+
 # A credential file exactly as docs/linear-sync.md tells an operator to create it.
 write_credential() {  # <home> [key]
   local home=$1 key=${2:-lin_api_TESTKEYqqq0000}
@@ -294,7 +326,7 @@ test_missing_and_ambiguous_targets_refuse() {
 }
 
 test_comment_content_is_validated() {
-  local home rc big
+  local home rc big id
   home=$(make_home content)
   run_sync "$home" bind task-a ENG-1 >/dev/null || fail "bind failed"
 
@@ -319,8 +351,32 @@ test_comment_content_is_validated() {
   queue_comment "$home" task-a 'bad status' --status "$(printf 'Done\001')" >/dev/null 2> "$home/e4" || rc=$?
   [ "$rc" -eq 1 ] || fail "a control character in the status must refuse"
 
+  # A NUL cannot survive the command substitution that canonicalizes the
+  # trailing newline, so a NUL inspected after that step is already gone and the
+  # comment would post silently altered rather than refuse. This pins the
+  # refusal on the bytes as received.
+  rc=0
+  printf 'hello\000world\n' > "$home/nul.md"
+  run_sync "$home" queue task-a --comment-file "$home/nul.md" >/dev/null 2> "$home/e5" || rc=$?
+  [ "$rc" -eq 1 ] || fail "a NUL byte must refuse, not be dropped into an altered comment"
+  assert_grep "control characters" "$home/e5" "the NUL refusal must name the cause"
+
   assert_absent "$home/state/linear/outbox" "no refused input may leave a delivery record"
-  pass "an empty comment, a forged marker, an oversized body, and a malformed status all refuse"
+
+  # The other half of that boundary: tab, newline, and carriage return are
+  # deliberately allowed, and the stored comment is the captain's bytes.
+  printf 'col1\tcol2\r\nline2\n' > "$home/tabs.md"
+  run_sync "$home" queue task-a --comment-file "$home/tabs.md" >/dev/null \
+    || fail "tab, CR, and newline must remain postable"
+  id=$(run_sync "$home" pending task-a | sed -n 's/.*delivery=\([0-9a-f][0-9a-f]*\).*/\1/p' | head -n1)
+  [ -n "$id" ] || fail "the queued handback must be listed"
+  # jq -r terminates its output with a newline; the record itself keeps none.
+  run_sync "$home" show "$id" | jq -r '.comment' > "$home/stored"
+  printf 'col1\tcol2\r\nline2\n' > "$home/expect"
+  cmp -s "$home/stored" "$home/expect" \
+    || fail "the stored comment must be the captain's bytes, trailing newline aside"
+
+  pass "an empty comment, a forged marker, an oversized body, a NUL byte, and a malformed status all refuse"
 }
 
 # --- 2. delivery, and its idempotence ---------------------------------------
@@ -910,6 +966,61 @@ test_comment_text_cannot_forge_record_fields() {
   pass "comment text cannot forge the record fields the jq-free cleanup gate reads"
 }
 
+# --- 6. reading without jq --------------------------------------------------
+
+# docs/linear-sync.md claims queue and deliver need jq and that everything else
+# reads the typed records without it. The point of keeping the reading path
+# jq-free is that a home missing jq still refuses to complete an owed task
+# rather than passing the gate by accident.
+test_a_home_without_jq_still_blocks_completion() {
+  local home shim nojq rc out id
+  home=$(make_home nojq)
+  shim="$home/nojq-bin"
+  nojq=$(path_without_jq "$shim")
+  ( PATH="$nojq"; command -v jq >/dev/null 2>&1 ) && fail "the jq-free PATH still resolves jq"
+  ( PATH="$nojq"; command -v grep >/dev/null 2>&1 ) || fail "the jq-free PATH lost grep"
+
+  run_sync "$home" bind task-a ENG-1 >/dev/null || fail "bind failed"
+  queue_comment "$home" task-a 'the handback' --status Done >/dev/null || fail "queue failed"
+
+  rc=0
+  run_sync_nojq "$home" "$nojq" guard-work task-a > "$home/gate.out" 2>&1 || rc=$?
+  [ "$rc" -eq 1 ] || fail "the completion gate must still block without jq (rc=$rc)"
+  assert_grep "ENG-1" "$home/gate.out" "the blocked gate must still name the issue without jq"
+
+  out=$(run_sync_nojq "$home" "$nojq" pending) || fail "pending must still read records without jq"
+  assert_contains "$out" "issue=ENG-1" "pending must still read the typed record without jq"
+  out=$(run_sync_nojq "$home" "$nojq" bindings) || fail "bindings must still read without jq"
+  assert_contains "$out" "ENG-1" "bindings must still read without jq"
+  out=$(run_sync_nojq "$home" "$nojq" hook 2>&1) || fail "the hook must stay usable without jq"
+  assert_contains "$out" "still owed" "the hook must still name the owed handback without jq"
+  id=$(one_id "$home/state/linear/outbox" .json) || fail "queue left no outbox record"
+  out=$(run_sync_nojq "$home" "$nojq" show "$id") || fail "show must still read a record without jq"
+  assert_contains "$out" "the handback" "show must still print the record without jq"
+
+  # The two that genuinely need jq must hold, not proceed and not claim success.
+  printf 'another handback\n' > "$home/c2.md"
+  rc=0
+  run_sync_nojq "$home" "$nojq" queue task-a --comment-file "$home/c2.md" \
+    >/dev/null 2> "$home/q.err" || rc=$?
+  [ "$rc" -eq 3 ] || fail "queue must hold without jq (rc=$rc)"
+  assert_grep "jq is required" "$home/q.err" "the queue hold must name jq"
+  rc=0
+  run_sync_nojq "$home" "$nojq" deliver --all >/dev/null 2> "$home/d.err" || rc=$?
+  [ "$rc" -eq 3 ] || fail "deliver must hold without jq (rc=$rc)"
+  assert_grep "jq is required" "$home/d.err" "the delivery hold must name jq"
+  [ "$(comment_count "$home" ENG-1)" -eq 0 ] || fail "a held delivery must post nothing"
+
+  # The explicit escape hatch is jq-free too, so a home missing jq is never
+  # stuck with a handback it cannot resolve one way or the other.
+  run_sync_nojq "$home" "$nojq" discard "$id" --reason 'no longer wanted' --yes >/dev/null \
+    || fail "discard must still work without jq"
+  run_sync_nojq "$home" "$nojq" guard-work task-a >/dev/null 2>&1 \
+    || fail "the gate must pass once the handback is explicitly discarded"
+
+  pass "a home without jq still reads its records and still refuses to complete an owed task"
+}
+
 test_missing_and_ambiguous_targets_refuse
 test_comment_content_is_validated
 test_delivery_posts_once_and_sets_status
@@ -932,3 +1043,4 @@ test_the_credential_never_leaves_its_file
 test_the_real_transport_keeps_the_credential_out_of_argv
 test_records_are_typed_and_bounded
 test_comment_text_cannot_forge_record_fields
+test_a_home_without_jq_still_blocks_completion

--- a/tests/fm-linear-sync.test.sh
+++ b/tests/fm-linear-sync.test.sh
@@ -573,6 +573,42 @@ test_an_unknown_issue_is_quarantined_and_still_blocks() {
   pass "an issue Linear does not have is quarantined, keeps blocking, and clears only on an explicit discard"
 }
 
+test_a_refusal_that_cannot_be_quarantined_holds_instead() {
+  local home rc out refused_dir id
+  home=$(make_home refusal-cannot-quarantine)
+  write_credential "$home"
+  run_sync "$home" bind ship-11 ENG-406 >/dev/null || fail "bind failed"
+  queue_comment "$home" ship-11 'nowhere to put this' >/dev/null || fail "queue failed"
+  id=$(one_id "$home/state/linear/outbox" .json) || fail "queue left no outbox record"
+
+  refused_dir="$home/state/linear/refused"
+  ( umask 077; mkdir -p "$refused_dir" ) || fail "cannot pre-create the refused dir"
+  chmod 500 "$refused_dir"
+
+  rc=0
+  run_sync "$home" deliver --all >/dev/null 2> "$home/r.err" || rc=$?
+  chmod 700 "$refused_dir"
+  [ "$rc" -eq 3 ] || fail "a refusal that cannot be quarantined must hold instead (rc=$rc)"
+  assert_grep "preserved and still owed" "$home/r.err" \
+    "the fallback must say the handback is still owed, not discarded"
+
+  assert_present "$home/state/linear/outbox/$id.json" \
+    "the outbox record must survive when the quarantine write fails"
+  assert_absent "$refused_dir/$id.json" \
+    "no partial quarantine record should be left behind when the copy could not be confirmed"
+
+  out=$(run_sync "$home" pending ship-11)
+  assert_contains "$out" "queued  task=ship-11" \
+    "pending must still show the handback as owed, not refused"
+
+  rc=$(expect_failure "an unquarantinable refusal still blocks completion" \
+    env FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    "$SYNC" guard-work ship-11)
+  [ "$rc" -eq 1 ] || fail "guard-work must still refuse while the handback is preserved"
+
+  pass "a refusal that cannot be quarantined preserves the outbox record and holds instead of discarding it"
+}
+
 # --- 5. the completion gate --------------------------------------------------
 
 test_cleanup_refuses_while_a_linear_handback_is_owed() {
@@ -886,6 +922,7 @@ test_disconnected_linear_preserves_the_handback
 test_transport_failure_holds_then_lands_once
 test_a_partial_delivery_completes_its_status_without_reposting
 test_an_unknown_issue_is_quarantined_and_still_blocks
+test_a_refusal_that_cannot_be_quarantined_holds_instead
 test_cleanup_refuses_while_a_linear_handback_is_owed
 test_cleanup_of_an_unbound_task_is_unaffected
 test_startup_surfaces_owed_handbacks_only_when_owed

--- a/tests/fm-linear-sync.test.sh
+++ b/tests/fm-linear-sync.test.sh
@@ -1,0 +1,897 @@
+#!/usr/bin/env bash
+# Behavior tests for firstmate's durable Linear synchronization.
+#
+# The rule this suite pins: work is not complete until the corresponding Linear
+# issue is current. Every case here is about one of the three ways that rule
+# breaks in practice - a target that was never established, an acknowledgement
+# lost between Linear committing a comment and firstmate recording it, and a
+# disconnected Linear quietly turning an owed handback into a claimed completion.
+#
+# Everything is hermetic. The Linear transport is a fake that keeps its whole
+# workspace in a temp directory, so no credential is needed, no network call is
+# made, and no Linear mutation ever happens. The one case that exercises the real
+# bin/fm-linear-transport.sh substitutes a fake `curl` and asserts only local
+# secret handling.
+set -u
+
+# shellcheck source=tests/lib.sh
+# shellcheck disable=SC1091
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SYNC="$ROOT/bin/fm-linear-sync.sh"
+TRANSPORT="$ROOT/bin/fm-linear-transport.sh"
+TEARDOWN="$ROOT/bin/fm-teardown.sh"
+SESSION_START="$ROOT/bin/fm-session-start.sh"
+TMP_ROOT=$(fm_test_tmproot fm-linear-sync)
+
+command -v jq >/dev/null 2>&1 || { echo "skip: jq not found"; exit 0; }
+
+# --- the hermetic fake Linear workspace -------------------------------------
+#
+# One executable satisfying bin/fm-linear-transport.sh's contract, backed by
+# plain files. It records every operation, so a test can prove exactly how many
+# comments were created and how many status changes were applied.
+#
+# FAKE_LINEAR_MODE injects the failures that matter:
+#   transport-fail  the exchange never completes (network down)
+#   http-500        Linear answers, unhappily
+#   issue-missing   the issue does not exist on this workspace
+#   drop-ack        the comment IS committed and the acknowledgement is lost -
+#                   the exact interval a local receipt cannot cover
+#   status-fail     the comment lands and the status change does not
+make_fake_linear() {  # <dir>
+  local path="$1/fake-linear.sh"
+  mkdir -p "$1"
+  cat > "$path" <<'SH'
+#!/usr/bin/env bash
+set -u
+req=$1
+resp=$2
+d=${FAKE_LINEAR_DIR:?}
+mode=${FAKE_LINEAR_MODE:-}
+op=$(jq -r '.query' < "$req" | grep -o 'FmLinear[A-Za-z]*' | head -n1)
+printf 'op=%s\n' "$op" >> "$d/log"
+cp "$req" "$d/last-request.json"
+cat "$req" >> "$d/requests.log"
+
+case "$mode" in
+  transport-fail) echo "fake-linear: no network" >&2; exit 4 ;;
+  http-500) printf '{}' > "$resp"; printf '500\n'; exit 0 ;;
+esac
+
+fail_json() {  # <message>
+  jq -n --arg m "$1" '{errors:[{message:$m}]}' > "$resp"
+  printf '200\n'
+  exit 0
+}
+
+case "$op" in
+  FmLinearIssue)
+    ref=$(jq -r '.variables.id' < "$req")
+    first=$(jq -r '.variables.first' < "$req")
+    after=$(jq -r '.variables.after // ""' < "$req")
+    meta="$d/issue.$ref"
+    if [ "$mode" = issue-missing ] || [ ! -f "$meta" ]; then
+      printf '{"data":{"issue":null}}' > "$resp"
+      printf '200\n'
+      exit 0
+    fi
+    # shellcheck disable=SC1090
+    . "$meta"
+    cfile="$d/comments.$ref"
+    [ -f "$cfile" ] || : > "$cfile"
+    total=$(grep -c . "$cfile" || true)
+    start=${after:-0}
+    [ -n "$start" ] || start=0
+    end=$((start + first))
+    [ "$end" -le "$total" ] || end=$total
+    nodes=$(sed -n "$((start + 1)),${end}p" "$cfile" | jq -s '.')
+    hasnext=false
+    [ "$end" -ge "$total" ] || hasnext=true
+    jq -n --arg id "$ISSUE_ID" --arg ident "$ref" --arg sid "$STATE_ID" \
+      --arg sname "$STATE_NAME" --arg team "$TEAM_ID" --argjson nodes "$nodes" \
+      --argjson hasnext "$hasnext" --arg cursor "$end" \
+      '{data:{issue:{id:$id, identifier:$ident, state:{id:$sid, name:$sname},
+        team:{id:$team},
+        comments:{pageInfo:{hasNextPage:$hasnext, endCursor:$cursor}, nodes:$nodes}}}}' \
+      > "$resp"
+    printf '200\n'
+    ;;
+  FmLinearStates)
+    team=$(jq -r '.variables.teamId' < "$req")
+    sfile="$d/states.$team"
+    [ -f "$sfile" ] || fail_json "no such team"
+    jq -s '{data:{team:{states:{nodes:.}}}}' < "$sfile" > "$resp"
+    printf '200\n'
+    ;;
+  FmLinearComment)
+    issue_id=$(jq -r '.variables.issueId' < "$req")
+    ref=$(cat "$d/byid.$issue_id" 2>/dev/null) || ref=
+    [ -n "$ref" ] || fail_json "unknown issue id"
+    cfile="$d/comments.$ref"
+    [ -f "$cfile" ] || : > "$cfile"
+    n=$(( $(grep -c . "$cfile" || true) + 1 ))
+    jq -cn --arg id "c$n" --rawfile body <(jq -j '.variables.body' < "$req") \
+      '{id:$id, body:$body}' >> "$cfile"
+    printf 'comment-created=%s\n' "$ref" >> "$d/log"
+    if [ "$mode" = drop-ack ]; then
+      echo "fake-linear: acknowledgement lost after commit" >&2
+      exit 4
+    fi
+    jq -n --arg id "c$n" '{data:{commentCreate:{success:true, comment:{id:$id}}}}' > "$resp"
+    printf '200\n'
+    ;;
+  FmLinearStatus)
+    issue_id=$(jq -r '.variables.id' < "$req")
+    state_id=$(jq -r '.variables.stateId' < "$req")
+    ref=$(cat "$d/byid.$issue_id" 2>/dev/null) || ref=
+    [ -n "$ref" ] || fail_json "unknown issue id"
+    if [ "$mode" = status-fail ]; then
+      printf 'status-refused=%s\n' "$ref" >> "$d/log"
+      fail_json "state change rejected"
+    fi
+    name=$(jq -r --arg i "$state_id" 'select(.id == $i) | .name' < "$d/states.$(grep '^TEAM_ID=' "$d/issue.$ref" | cut -d= -f2)" | head -n1)
+    sed -i.bak "s/^STATE_ID=.*/STATE_ID=$state_id/; s/^STATE_NAME=.*/STATE_NAME=$name/" "$d/issue.$ref"
+    rm -f "$d/issue.$ref.bak"
+    printf 'status-applied=%s=%s\n' "$ref" "$name" >> "$d/log"
+    jq -n --arg id "$issue_id" --arg n "$name" \
+      '{data:{issueUpdate:{success:true, issue:{id:$id, state:{id:"s", name:$n}}}}}' > "$resp"
+    printf '200\n'
+    ;;
+  *)
+    fail_json "unsupported operation"
+    ;;
+esac
+SH
+  chmod +x "$path"
+  printf '%s\n' "$path"
+}
+
+# seed_issue <fake-dir> <REF> <team-id> <current-state-name>
+# The API uuid comes from a per-workspace counter, not $RANDOM: two issues in one
+# fake workspace must never collide on the id the comment path resolves through.
+seed_issue() {
+  local d=$1 ref=$2 team=$3 state=$4 uuid seq
+  seq=$(( $(cat "$d/.issue-seq" 2>/dev/null || printf 0) + 1 ))
+  printf '%s\n' "$seq" > "$d/.issue-seq"
+  uuid="00000000-0000-4000-8000-$(printf '%012d' "$seq")"
+  cat > "$d/issue.$ref" <<EOF
+ISSUE_ID=$uuid
+TEAM_ID=$team
+STATE_ID=state-todo
+STATE_NAME=$state
+EOF
+  printf '%s\n' "$ref" > "$d/byid.$uuid"
+  : > "$d/comments.$ref"
+  cat > "$d/states.$team" <<'EOF'
+{"id":"state-todo","name":"Todo"}
+{"id":"state-progress","name":"In Progress"}
+{"id":"state-done","name":"Done"}
+EOF
+}
+
+# --- primary-shaped firstmate homes -----------------------------------------
+#
+# The scoping predicate (bin/fm-primary-scope-lib.sh) needs a plain, non-worktree
+# git checkout carrying AGENTS.md, bin/, and state/. Building the real shape here
+# is what lets the scoping cases below use genuine linked worktrees instead of a
+# stand-in.
+make_home() {  # <name>
+  local home="$TMP_ROOT/$1"
+  mkdir -p "$home/state" "$home/data" "$home/config" "$home/bin" "$home/projects"
+  git init -q "$home"
+  git -C "$home" commit -q --allow-empty -m init
+  : > "$home/AGENTS.md"
+  make_fake_linear "$home" >/dev/null
+  mkdir -p "$home/linear-fake"
+  printf '%s\n' "$home"
+}
+
+fake_dir() { printf '%s\n' "$1/linear-fake"; }
+
+run_sync() {  # <home> <args...>
+  local home=$1
+  shift
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    FM_LINEAR_TRANSPORT="$home/fake-linear.sh" \
+    FAKE_LINEAR_DIR="$(fake_dir "$home")" \
+    FAKE_LINEAR_MODE="${FAKE_LINEAR_MODE:-}" \
+    FM_LINEAR_COMMENT_PAGE_SIZE="${FM_LINEAR_COMMENT_PAGE_SIZE:-100}" \
+    FM_LINEAR_COMMENT_PAGE_MAX="${FM_LINEAR_COMMENT_PAGE_MAX:-10}" \
+    "$SYNC" "$@"
+}
+
+# A credential file exactly as docs/linear-sync.md tells an operator to create it.
+write_credential() {  # <home> [key]
+  local home=$1 key=${2:-lin_api_TESTKEYqqq0000}
+  ( umask 077; printf 'LINEAR_API_KEY=%s\n' "$key" > "$home/config/linear.env" )
+  chmod 600 "$home/config/linear.env"
+}
+
+queue_comment() {  # <home> <task> <text> [extra sync args...]
+  local home=$1 task=$2 text=$3
+  shift 3
+  printf '%s\n' "$text" > "$home/comment.md"
+  run_sync "$home" queue "$task" --comment-file "$home/comment.md" "$@"
+}
+
+# grep -c prints 0 and exits 1 on no match, so `|| true` (not `|| printf 0`) is
+# what keeps these to a single number.
+comment_count() {  # <home> <REF>
+  local f
+  f="$(fake_dir "$1")/comments.$2"
+  if [ -f "$f" ]; then grep -c . "$f" || true; else printf '0\n'; fi
+}
+
+log_count() {  # <home> <pattern>
+  local f
+  f="$(fake_dir "$1")/log"
+  if [ -f "$f" ]; then grep -c "$2" "$f" || true; else printf '0\n'; fi
+}
+
+# One entry name from a private record directory, with an optional suffix
+# trimmed. A glob rather than `ls` so an odd filename cannot be mis-split.
+one_id() {  # <dir> [suffix]
+  local dir=$1 suffix=${2-} entry name
+  for entry in "$dir"/*; do
+    [ -e "$entry" ] || continue
+    name=$(basename "$entry")
+    printf '%s\n' "${name%"$suffix"}"
+    return 0
+  done
+  return 1
+}
+
+file_mode() {  # <path>
+  if [ "$(uname)" = Darwin ]; then stat -f %Lp "$1"; else stat -c %a "$1"; fi
+}
+
+expect_failure() {  # <label> <cmd...>
+  local label=$1 rc=0
+  shift
+  "$@" > "$TMP_ROOT/expect.out" 2> "$TMP_ROOT/expect.err" || rc=$?
+  [ "$rc" -ne 0 ] || fail "$label: expected a refusal, got exit 0"
+  printf '%s\n' "$rc"
+}
+
+# --- 1. targets are established, never inferred ------------------------------
+
+test_missing_and_ambiguous_targets_refuse() {
+  local home rc out
+  home=$(make_home targets)
+  write_credential "$home"
+
+  rc=0
+  queue_comment "$home" unbound-task 'shipped it' > "$home/q.out" 2> "$home/q.err" || rc=$?
+  [ "$rc" -eq 1 ] || fail "an unbound task must refuse to queue (rc=$rc)"
+  assert_grep "has no Linear issue binding" "$home/q.err" \
+    "the refusal must name the missing binding, not guess a target"
+  assert_absent "$home/state/linear/outbox" "a refused queue must leave no delivery"
+
+  run_sync "$home" bind two-issue-task ENG-11 ENG-12 >/dev/null || fail "bind failed"
+  rc=0
+  queue_comment "$home" two-issue-task 'shipped it' > "$home/q2.out" 2> "$home/q2.err" || rc=$?
+  [ "$rc" -eq 1 ] || fail "an ambiguous binding must refuse (rc=$rc)"
+  assert_grep "bound to 2 Linear issues" "$home/q2.err" "the refusal must say why it is ambiguous"
+
+  rc=0
+  queue_comment "$home" two-issue-task 'shipped it' --issue ENG-99 \
+    > "$home/q3.out" 2> "$home/q3.err" || rc=$?
+  [ "$rc" -eq 1 ] || fail "an unbound issue must refuse even when named explicitly"
+  assert_grep "is not bound to task" "$home/q3.err" "naming an unbound issue must refuse"
+
+  queue_comment "$home" two-issue-task 'shipped it' --issue ENG-12 >/dev/null \
+    || fail "naming one bound issue must resolve the ambiguity"
+  out=$(run_sync "$home" pending two-issue-task)
+  assert_contains "$out" "issue=ENG-12" "the queued handback must target the named issue"
+
+  rc=0
+  run_sync "$home" bind bad-task 'not an issue' > /dev/null 2> "$home/q4.err" || rc=$?
+  [ "$rc" -eq 1 ] || fail "a prose target must refuse to bind"
+  assert_grep "not a Linear issue reference" "$home/q4.err" "binding must validate the reference shape"
+
+  pass "an unbound task, an ambiguous binding, and a prose target all refuse instead of guessing"
+}
+
+test_comment_content_is_validated() {
+  local home rc big
+  home=$(make_home content)
+  run_sync "$home" bind task-a ENG-1 >/dev/null || fail "bind failed"
+
+  rc=0
+  printf '' > "$home/empty.md"
+  run_sync "$home" queue task-a --comment-file "$home/empty.md" >/dev/null 2> "$home/e1" || rc=$?
+  [ "$rc" -eq 1 ] || fail "an empty comment must refuse"
+  assert_grep "refusing to post nothing" "$home/e1" "an empty comment must say so"
+
+  rc=0
+  queue_comment "$home" task-a 'sneaky fm-linear-sync:deadbeef' >/dev/null 2> "$home/e2" || rc=$?
+  [ "$rc" -eq 1 ] || fail "a comment carrying the reserved marker prefix must refuse"
+  assert_grep "reserved marker prefix" "$home/e2" "a forged marker must be named as such"
+
+  big=$(head -c 7000 /dev/zero | tr '\0' 'x')
+  rc=0
+  queue_comment "$home" task-a "$big" >/dev/null 2> "$home/e3" || rc=$?
+  [ "$rc" -eq 1 ] || fail "an oversized comment must refuse"
+  assert_grep "over the" "$home/e3" "the size refusal must name the limit"
+
+  rc=0
+  queue_comment "$home" task-a 'bad status' --status "$(printf 'Done\001')" >/dev/null 2> "$home/e4" || rc=$?
+  [ "$rc" -eq 1 ] || fail "a control character in the status must refuse"
+
+  assert_absent "$home/state/linear/outbox" "no refused input may leave a delivery record"
+  pass "an empty comment, a forged marker, an oversized body, and a malformed status all refuse"
+}
+
+# --- 2. delivery, and its idempotence ---------------------------------------
+
+test_delivery_posts_once_and_sets_status() {
+  local home out
+  home=$(make_home deliver)
+  write_credential "$home"
+  seed_issue "$(fake_dir "$home")" ENG-42 team-1 Todo
+  run_sync "$home" bind ship-1 ENG-42 >/dev/null || fail "bind failed"
+  queue_comment "$home" ship-1 'Landed: https://example.invalid/pr/7' --status Done >/dev/null \
+    || fail "queue failed"
+
+  run_sync "$home" deliver --all > "$home/d1.out" 2> "$home/d1.err" \
+    || fail "delivery failed: $(cat "$home/d1.err")"
+  assert_grep "delivered ship-1 -> ENG-42" "$home/d1.out" "delivery must report the issue it updated"
+  [ "$(comment_count "$home" ENG-42)" -eq 1 ] || fail "expected exactly one comment"
+  [ "$(log_count "$home" '^status-applied=ENG-42=Done$')" -eq 1 ] || fail "expected one status change"
+  assert_present "$home/state/linear/sent" "delivery must leave a receipt"
+  [ -z "$(run_sync "$home" pending)" ] || fail "a delivered handback must leave the pending set"
+
+  # The posted body carries the captain's text and the read-back marker, nothing else.
+  out=$(jq -r '.body' < <(head -n1 "$(fake_dir "$home")/comments.ENG-42"))
+  assert_contains "$out" "Landed: https://example.invalid/pr/7" "the comment must carry the exact text"
+  assert_contains "$out" "fm-linear-sync:" "the comment must carry its read-back marker"
+
+  # Delivering again is a no-op in every direction.
+  run_sync "$home" deliver --all >/dev/null 2>&1 || true
+  [ "$(comment_count "$home" ENG-42)" -eq 1 ] || fail "a repeated delivery must not post again"
+  [ "$(log_count "$home" '^status-applied=')" -eq 1 ] || fail "a repeated delivery must not restatus"
+  pass "a delivery posts one comment, applies the status once, and repeats as a no-op"
+}
+
+test_requeueing_the_same_handback_is_one_delivery() {
+  local home first second
+  home=$(make_home requeue)
+  run_sync "$home" bind ship-2 ENG-7 >/dev/null || fail "bind failed"
+  first=$(queue_comment "$home" ship-2 'same text' --status Done)
+  second=$(queue_comment "$home" ship-2 'same text' --status Done)
+  assert_contains "$first" "queued ship-2" "the first queue must create the delivery"
+  assert_contains "$second" "already queued ship-2" "the second must resolve to the same delivery"
+  [ "$(run_sync "$home" pending | grep -c .)" -eq 1 ] \
+    || fail "the same handback must never queue twice"
+
+  # A different status is a different handback, so it gets its own delivery.
+  queue_comment "$home" ship-2 'same text' --status "In Progress" >/dev/null || fail "queue failed"
+  [ "$(run_sync "$home" pending | grep -c .)" -eq 2 ] \
+    || fail "a different status must be a distinct handback"
+  pass "re-queueing an identical handback resolves to one delivery, and a changed one is distinct"
+}
+
+# --- 3. the lost-acknowledgement interval -----------------------------------
+
+test_lost_acknowledgement_converges_without_a_duplicate() {
+  local home rc
+  home=$(make_home lost-ack)
+  write_credential "$home"
+  seed_issue "$(fake_dir "$home")" ENG-50 team-1 Todo
+  run_sync "$home" bind ship-3 ENG-50 >/dev/null || fail "bind failed"
+  queue_comment "$home" ship-3 'the fix is on main' >/dev/null || fail "queue failed"
+
+  # Linear commits the comment and the acknowledgement never arrives. This is the
+  # exact interval a local receipt cannot cover.
+  rc=0
+  FAKE_LINEAR_MODE=drop-ack run_sync "$home" deliver --all >/dev/null 2> "$home/d.err" || rc=$?
+  [ "$rc" -eq 3 ] || fail "a lost acknowledgement must hold, not complete (rc=$rc)"
+  [ "$(comment_count "$home" ENG-50)" -eq 1 ] || fail "the fake must have committed the comment"
+  assert_absent "$home/state/linear/sent/$(one_id "$home/state/linear/outbox" .json)" \
+    "no receipt may exist for an unacknowledged post"
+  [ -n "$(run_sync "$home" pending ship-3)" ] || fail "the handback must still be owed"
+
+  # The retry must find Linear's own copy of the marker and converge.
+  run_sync "$home" deliver --all > "$home/d2.out" 2> "$home/d2.err" \
+    || fail "the retry must converge: $(cat "$home/d2.err")"
+  [ "$(comment_count "$home" ENG-50)" -eq 1 ] || fail "the retry must not post a second comment"
+  assert_grep "read-back" "$home/d2.out" "the retry must report that it converged from the read-back"
+  [ -z "$(run_sync "$home" pending)" ] || fail "the converged handback must leave the pending set"
+  pass "a comment committed by Linear with a lost acknowledgement converges with no duplicate"
+}
+
+test_a_destroyed_receipt_does_not_repost() {
+  local home id
+  home=$(make_home receipt-loss)
+  write_credential "$home"
+  seed_issue "$(fake_dir "$home")" ENG-51 team-1 Todo
+  run_sync "$home" bind ship-4 ENG-51 >/dev/null || fail "bind failed"
+  queue_comment "$home" ship-4 'done and dusted' --status Done >/dev/null || fail "queue failed"
+  run_sync "$home" deliver --all >/dev/null || fail "delivery failed"
+  id=$(one_id "$home/state/linear/sent")
+
+  # Simulate a home restored from an older copy: the receipt is gone and the
+  # handback is queued again by the same deterministic identity.
+  rm -f "$home/state/linear/sent/$id"
+  queue_comment "$home" ship-4 'done and dusted' --status Done >/dev/null || fail "re-queue failed"
+  run_sync "$home" deliver --all >/dev/null || fail "re-delivery failed"
+  [ "$(comment_count "$home" ENG-51)" -eq 1 ] || fail "a lost receipt must not produce a second comment"
+  [ "$(log_count "$home" '^status-applied=')" -eq 1 ] || fail "a lost receipt must not restatus"
+  pass "a lost local receipt is recovered from Linear's own copy, never by reposting"
+}
+
+test_truncated_read_back_refuses_to_post() {
+  local home rc i
+  home=$(make_home truncated)
+  write_credential "$home"
+  seed_issue "$(fake_dir "$home")" ENG-60 team-1 Todo
+  for i in $(seq 1 12); do
+    jq -cn --arg id "old$i" '{id:$id, body:"unrelated chatter"}' \
+      >> "$(fake_dir "$home")/comments.ENG-60"
+  done
+  run_sync "$home" bind ship-5 ENG-60 >/dev/null || fail "bind failed"
+  queue_comment "$home" ship-5 'a handback on a very long issue' >/dev/null || fail "queue failed"
+
+  rc=0
+  FM_LINEAR_COMMENT_PAGE_SIZE=2 FM_LINEAR_COMMENT_PAGE_MAX=2 \
+    run_sync "$home" deliver --all >/dev/null 2> "$home/t.err" || rc=$?
+  [ "$rc" -eq 3 ] || fail "a truncated read-back must hold, not post (rc=$rc)"
+  [ "$(comment_count "$home" ENG-60)" -eq 12 ] || fail "a truncated read-back must post nothing"
+  assert_grep "could not confirm the current state" "$home/t.err" \
+    "the hold must say the issue state was unconfirmed"
+  [ -n "$(run_sync "$home" pending ship-5)" ] || fail "the handback must still be owed"
+
+  # With a read-back that can complete, the same delivery proceeds exactly once.
+  run_sync "$home" deliver --all >/dev/null || fail "delivery failed once the read-back completes"
+  [ "$(comment_count "$home" ENG-60)" -eq 13 ] || fail "exactly one comment must be added"
+  pass "a read-back that cannot be completed holds rather than risking a duplicate"
+}
+
+# --- 4. disconnected Linear never becomes a completion ----------------------
+
+test_disconnected_linear_preserves_the_handback() {
+  local home rc out
+  home=$(make_home disconnected)
+  seed_issue "$(fake_dir "$home")" ENG-70 team-1 Todo
+  run_sync "$home" bind ship-6 ENG-70 >/dev/null || fail "bind failed"
+  queue_comment "$home" ship-6 'this must not be lost' --status Done >/dev/null || fail "queue failed"
+
+  # No credential at all: the disconnected case an operator hits before OAuth.
+  rc=0
+  run_sync "$home" deliver --all >/dev/null 2> "$home/c1.err" || rc=$?
+  [ "$rc" -eq 3 ] || fail "a disconnected Linear must hold, not fail-and-forget (rc=$rc)"
+  [ "$(grep -c . "$home/c1.err")" -le 2 ] || fail "the blocker must stay concise"
+  assert_grep "Linear is not connected" "$home/c1.err" "the blocker must name the actual problem"
+  assert_grep "still owed" "$home/c1.err" "the blocker must say the handback survives"
+  [ "$(comment_count "$home" ENG-70)" -eq 0 ] || fail "nothing may be posted while disconnected"
+
+  # Repeated runs converge: still exactly one owed handback, no duplicate record.
+  run_sync "$home" deliver --all >/dev/null 2>&1 || true
+  run_sync "$home" deliver --all >/dev/null 2>&1 || true
+  [ "$(run_sync "$home" pending | grep -c .)" -eq 1 ] \
+    || fail "repeated disconnected runs must not multiply the owed handback"
+  out=$(run_sync "$home" pending ship-6)
+  assert_contains "$out" "no Linear credential" "the pending line must carry the current reason"
+
+  # A malformed credential is refused rather than used.
+  printf 'LINEAR_API_KEY=has space\n' > "$home/config/linear.env"
+  chmod 600 "$home/config/linear.env"
+  rc=0
+  run_sync "$home" deliver --all >/dev/null 2> "$home/c2.err" || rc=$?
+  [ "$rc" -eq 3 ] || fail "a malformed credential must hold"
+  assert_grep "not a single-line credential" "$home/c2.err" "a malformed credential must be named"
+
+  # A world-readable credential is refused rather than used.
+  write_credential "$home"
+  chmod 644 "$home/config/linear.env"
+  rc=0
+  run_sync "$home" deliver --all >/dev/null 2> "$home/c3.err" || rc=$?
+  [ "$rc" -eq 3 ] || fail "a world-readable credential must hold"
+  assert_grep "must be mode 0600" "$home/c3.err" "the credential mode requirement must be explicit"
+
+  # Once connected, the preserved handback lands exactly once.
+  write_credential "$home"
+  run_sync "$home" deliver --all >/dev/null || fail "delivery must succeed once connected"
+  [ "$(comment_count "$home" ENG-70)" -eq 1 ] || fail "the preserved handback must land exactly once"
+  pass "a disconnected or misconfigured Linear preserves the handback and never claims completion"
+}
+
+test_transport_failure_holds_then_lands_once() {
+  local home rc
+  home=$(make_home transport-fail)
+  write_credential "$home"
+  seed_issue "$(fake_dir "$home")" ENG-80 team-1 Todo
+  run_sync "$home" bind ship-7 ENG-80 >/dev/null || fail "bind failed"
+  queue_comment "$home" ship-7 'retry me' >/dev/null || fail "queue failed"
+
+  rc=0
+  FAKE_LINEAR_MODE=transport-fail run_sync "$home" deliver --all >/dev/null 2> "$home/f1" || rc=$?
+  [ "$rc" -eq 3 ] || fail "an unreachable Linear must hold (rc=$rc)"
+  rc=0
+  FAKE_LINEAR_MODE=http-500 run_sync "$home" deliver --all >/dev/null 2> "$home/f2" || rc=$?
+  [ "$rc" -eq 3 ] || fail "an HTTP 500 must hold (rc=$rc)"
+  [ "$(comment_count "$home" ENG-80)" -eq 0 ] || fail "a failed exchange must post nothing"
+
+  run_sync "$home" deliver --all >/dev/null || fail "the retry must succeed"
+  [ "$(comment_count "$home" ENG-80)" -eq 1 ] || fail "the retry must post exactly once"
+  pass "an unreachable Linear holds the handback and the later retry posts exactly once"
+}
+
+test_a_partial_delivery_completes_its_status_without_reposting() {
+  local home rc
+  home=$(make_home partial)
+  write_credential "$home"
+  seed_issue "$(fake_dir "$home")" ENG-90 team-1 Todo
+  run_sync "$home" bind ship-8 ENG-90 >/dev/null || fail "bind failed"
+  queue_comment "$home" ship-8 'comment lands, status does not' --status Done >/dev/null \
+    || fail "queue failed"
+
+  rc=0
+  FAKE_LINEAR_MODE=status-fail run_sync "$home" deliver --all >/dev/null 2> "$home/p.err" || rc=$?
+  [ "$rc" -eq 3 ] || fail "an unapplied status must hold the delivery (rc=$rc)"
+  [ "$(comment_count "$home" ENG-90)" -eq 1 ] || fail "the comment must have landed"
+  assert_grep "status change" "$home/p.err" "the hold must name the status as the missing half"
+  [ -n "$(run_sync "$home" pending ship-8)" ] || fail "a half-applied handback is still owed"
+
+  run_sync "$home" deliver --all >/dev/null || fail "the retry must complete the status change"
+  [ "$(comment_count "$home" ENG-90)" -eq 1 ] || fail "the retry must not repost the comment"
+  [ "$(log_count "$home" '^status-applied=ENG-90=Done$')" -eq 1 ] || fail "the status must be applied once"
+  [ -z "$(run_sync "$home" pending)" ] || fail "the completed handback must leave the pending set"
+  pass "a comment that landed without its status is completed on retry with no second comment"
+}
+
+test_an_unknown_issue_is_quarantined_and_still_blocks() {
+  local home rc out
+  home=$(make_home unknown-issue)
+  write_credential "$home"
+  run_sync "$home" bind ship-9 ENG-404 >/dev/null || fail "bind failed"
+  queue_comment "$home" ship-9 'nowhere to put this' >/dev/null || fail "queue failed"
+
+  rc=0
+  run_sync "$home" deliver --all >/dev/null 2> "$home/u.err" || rc=$?
+  [ "$rc" -eq 1 ] || fail "an issue Linear does not have must refuse (rc=$rc)"
+  assert_grep "does not have issue ENG-404" "$home/u.err" "the refusal must name the issue"
+  out=$(run_sync "$home" pending ship-9)
+  assert_contains "$out" "refused" "a refused handback must stay visible as pending work"
+  rc=$(expect_failure "a refused handback still blocks completion" \
+    env FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    "$SYNC" guard-work ship-9)
+  [ "$rc" -eq 1 ] || fail "guard-work must refuse on a quarantined handback"
+
+  # Only an explicit, reasoned discard clears it.
+  set -- "$home/state/linear/refused"/*.json
+  rc=0
+  run_sync "$home" discard "$(basename "$1" .json)" --reason 'issue was deleted upstream' \
+    >/dev/null 2> "$home/u2.err" || rc=$?
+  [ "$rc" -eq 1 ] || fail "a discard without --yes must refuse"
+  run_sync "$home" discard "$(basename "$1" .json)" --reason 'issue was deleted upstream' --yes \
+    >/dev/null || fail "an explicit discard must succeed"
+  assert_present "$home/state/linear/discarded" "a discard must stay inspectable"
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    "$SYNC" guard-work ship-9 >/dev/null || fail "guard-work must pass after an explicit discard"
+  pass "an issue Linear does not have is quarantined, keeps blocking, and clears only on an explicit discard"
+}
+
+# --- 5. the completion gate --------------------------------------------------
+
+test_cleanup_refuses_while_a_linear_handback_is_owed() {
+  local home rc
+  home=$(make_home cleanup-gate)
+  write_credential "$home"
+  seed_issue "$(fake_dir "$home")" ENG-100 team-1 Todo
+  run_sync "$home" bind ship-task ENG-100 >/dev/null || fail "bind failed"
+  queue_comment "$home" ship-task 'PR merged' --status Done >/dev/null || fail "queue failed"
+  fm_write_meta "$home/state/ship-task.meta" \
+    "window=firstmate:fm-ship-task" \
+    "worktree=$home/projects/gone" \
+    "project=$home/projects/sample" \
+    "harness=codex" \
+    "kind=ship" \
+    "mode=no-mistakes"
+  fm_fake_exit0 "$(fm_fakebin "$home")" tmux treehouse no-mistakes gh gh-axi
+
+  rc=0
+  PATH="$home/fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_CONFIG_OVERRIDE="$home/config" "$TEARDOWN" ship-task \
+    > "$home/td.out" 2> "$home/td.err" || rc=$?
+  [ "$rc" -ne 0 ] || fail "cleanup must refuse while a Linear handback is owed"
+  assert_grep "still owes its bound Linear issue" "$home/td.err" "the refusal must be explicit"
+  assert_present "$home/state/ship-task.meta" "a refused cleanup must preserve the task record"
+
+  run_sync "$home" deliver --all >/dev/null || fail "delivery failed"
+  rc=0
+  PATH="$home/fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_CONFIG_OVERRIDE="$home/config" "$TEARDOWN" ship-task >/dev/null 2>&1 || rc=$?
+  [ "$rc" -eq 0 ] || fail "cleanup must proceed once the Linear issue is current (rc=$rc)"
+  pass "cleanup refuses while a Linear handback is owed and proceeds once the issue is current"
+}
+
+test_cleanup_of_an_unbound_task_is_unaffected() {
+  local home rc
+  home=$(make_home cleanup-unbound)
+  run_sync "$home" bind other-task ENG-111 >/dev/null || fail "bind failed"
+  queue_comment "$home" other-task 'unrelated' >/dev/null || fail "queue failed"
+  fm_write_meta "$home/state/free-task.meta" \
+    "window=firstmate:fm-free-task" \
+    "worktree=$home/projects/gone" \
+    "project=$home/projects/sample" \
+    "harness=codex" \
+    "kind=ship" \
+    "mode=no-mistakes"
+  fm_fake_exit0 "$(fm_fakebin "$home")" tmux treehouse no-mistakes gh gh-axi
+  rc=0
+  PATH="$home/fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_CONFIG_OVERRIDE="$home/config" "$TEARDOWN" free-task >/dev/null 2>&1 || rc=$?
+  [ "$rc" -eq 0 ] || fail "another task's owed handback must not block this cleanup (rc=$rc)"
+  pass "the completion gate blocks only the task that owes the handback"
+}
+
+# --- 6. surfacing across restart --------------------------------------------
+
+test_startup_surfaces_owed_handbacks_only_when_owed() {
+  local home out
+  home=$(make_home startup)
+  fm_fake_exit0 "$(fm_fakebin "$home")" tmux treehouse no-mistakes gh gh-axi tasks-axi
+  out=$(PATH="$home/fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_CONFIG_OVERRIDE="$home/config" FM_SESSION_START_NO_LOCK=1 \
+    "$SESSION_START" 2>/dev/null || true)
+  assert_not_contains "$out" "Linear issues awaiting synchronization" \
+    "a home with no Linear work must print no Linear subsection"
+
+  run_sync "$home" bind ship-x ENG-200 >/dev/null || fail "bind failed"
+  queue_comment "$home" ship-x 'survives a restart' >/dev/null || fail "queue failed"
+  out=$(PATH="$home/fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
+    FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
+    FM_CONFIG_OVERRIDE="$home/config" FM_SESSION_START_NO_LOCK=1 \
+    "$SESSION_START" 2>/dev/null || true)
+  assert_contains "$out" "Linear issues awaiting synchronization" \
+    "an owed handback must be surfaced from disk at session start"
+  assert_contains "$out" "issue=ENG-200" "the surfaced line must name the issue"
+  pass "session start surfaces an owed Linear handback from disk, and stays silent otherwise"
+}
+
+# --- 7. zero overhead and scope ----------------------------------------------
+
+test_a_home_with_no_linear_work_gains_nothing() {
+  local home out
+  home=$(make_home untouched)
+  out=$(run_sync "$home" hook 2>&1)
+  [ -z "$out" ] || fail "the hook must be silent in a home with no Linear work: $out"
+  out=$(run_sync "$home" pending 2>&1)
+  [ -z "$out" ] || fail "pending must be silent in a home with no Linear work"
+  out=$(run_sync "$home" bindings 2>&1)
+  [ -z "$out" ] || fail "bindings must be silent in a home with no Linear work"
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    "$SYNC" guard-work anything >/dev/null 2>&1 \
+    || fail "the completion gate must pass in a home with no Linear work"
+  assert_absent "$home/state/linear" "a home with no Linear work must gain no Linear state"
+  assert_absent "$home/config/linear.env" "a home with no Linear work must gain no credential file"
+  pass "a home that never bound a Linear issue gains no artifact and prints nothing"
+}
+
+test_scope_is_a_genuine_primary_home() {
+  local main worktree secondmate project out rc
+  main=$(make_home scope-main)
+  run_sync "$main" bind ship-s ENG-300 >/dev/null || fail "bind failed"
+  queue_comment "$main" ship-s 'owed' >/dev/null || fail "queue failed"
+  out=$(run_sync "$main" hook 2>&1)
+  assert_contains "$out" "handback(s) still owed" "a genuine primary home must surface owed work"
+
+  # A crewmate/scout task worktree: a genuine linked git worktree of the home.
+  worktree="$TMP_ROOT/scope-child"
+  git -C "$main" worktree add --quiet -b fm/linear-scope-test "$worktree"
+  mkdir -p "$worktree/state"
+  cp -R "$main/state/linear" "$worktree/state/linear"
+  : > "$worktree/AGENTS.md"
+  mkdir -p "$worktree/bin"
+  out=$(FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$worktree" FM_STATE_OVERRIDE="$worktree/state" \
+    "$SYNC" hook 2>&1)
+  [ -z "$out" ] || fail "the hook must be inert in a task worktree, printed: $out"
+  rc=0
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$worktree" FM_STATE_OVERRIDE="$worktree/state" \
+    "$SYNC" bind other ENG-1 >/dev/null 2> "$worktree/err" || rc=$?
+  [ "$rc" -eq 1 ] || fail "binding inside a task worktree must refuse"
+  assert_grep "is not a firstmate primary home" "$worktree/err" "the refusal must name the scope"
+
+  # An ordinary project repo is not a firstmate home at all.
+  project="$TMP_ROOT/scope-project"
+  fm_git_init_commit "$project"
+  mkdir -p "$project/state"
+  out=$(FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$project" FM_STATE_OVERRIDE="$project/state" \
+    "$SYNC" hook 2>&1)
+  [ -z "$out" ] || fail "the hook must be inert in an ordinary project repo"
+
+  # A marked secondmate home runs its own primary session and stays in scope.
+  secondmate="$TMP_ROOT/scope-secondmate"
+  git -C "$main" worktree add --quiet -b fm/linear-secondmate-home "$secondmate"
+  mkdir -p "$secondmate/state" "$secondmate/bin"
+  : > "$secondmate/AGENTS.md"
+  printf 'sm-linear-1\n' > "$secondmate/.fm-secondmate-home"
+  cp -R "$main/state/linear" "$secondmate/state/linear"
+  out=$(FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$secondmate" FM_STATE_OVERRIDE="$secondmate/state" \
+    "$SYNC" hook 2>&1)
+  assert_contains "$out" "handback(s) still owed" "a marked secondmate home must stay in scope"
+  pass "the hook is active in a primary and secondmate home and inert in a task worktree or project repo"
+}
+
+# --- 8. secret handling ------------------------------------------------------
+
+test_the_credential_never_leaves_its_file() {
+  local home key hit
+  home=$(make_home secrets)
+  key='lin_api_SUPERSECRETVALUE0001'
+  write_credential "$home" "$key"
+  seed_issue "$(fake_dir "$home")" ENG-400 team-1 Todo
+  run_sync "$home" bind ship-sec ENG-400 >/dev/null || fail "bind failed"
+  queue_comment "$home" ship-sec 'no secrets here' --status Done >/dev/null || fail "queue failed"
+  run_sync "$home" deliver --all > "$home/s.out" 2> "$home/s.err" || fail "delivery failed"
+
+  # Nothing the transport saw, nothing durable, and nothing printed may carry it.
+  hit=$(grep -rl "$key" "$(fake_dir "$home")" "$home/state" "$home/s.out" "$home/s.err" 2>/dev/null || true)
+  [ -z "$hit" ] || fail "the credential leaked into: $hit"
+  hit=$(grep -rl "$key" "$home/state/linear" 2>/dev/null || true)
+  [ -z "$hit" ] || fail "the credential leaked into a durable record: $hit"
+  # It is still exactly where it belongs.
+  assert_grep "$key" "$home/config/linear.env" "the credential must remain in its own file"
+  pass "the credential never reaches a request body, a durable record, or any output"
+}
+
+test_the_real_transport_keeps_the_credential_out_of_argv() {
+  local home fakebin argv key headerfile
+  home=$(make_home real-transport)
+  key='lin_api_ARGVCHECK00000002'
+  write_credential "$home" "$key"
+  fakebin=$(fm_fakebin "$home")
+  argv="$home/curl-argv.log"
+  cat > "$fakebin/curl" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$@" > "$argv"
+env > "$home/curl-env.log"
+for a in "\$@"; do
+  case "\$a" in
+    @*)
+      f=\${a#@}
+      case "\$f" in
+        *fm-linear-auth*)
+          printf '%s\n' "\$f" > "$home/curl-headerfile"
+          cat "\$f" > "$home/curl-headerfile-content"
+          ;;
+      esac
+      ;;
+  esac
+done
+printf '200'
+exit 0
+SH
+  chmod +x "$fakebin/curl"
+  jq -n '{query:"query FmLinearIssue { __typename }", variables:{}}' > "$home/req.json"
+
+  PATH="$fakebin:$PATH" FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" \
+    "$TRANSPORT" "$home/req.json" "$home/resp.json" >/dev/null \
+    || fail "the real transport must complete with a fake curl"
+
+  assert_no_grep "$key" "$argv" "the credential must never appear in curl's argv"
+  assert_no_grep "$key" "$home/req.json" "the credential must never appear in the request body"
+  assert_no_grep "$key" "$home/curl-env.log" "the credential must never be exported to curl's environment"
+  # The credential did travel - as a complete header line in a private file that
+  # curl was pointed at, and that file is gone as soon as the transport exits.
+  assert_grep "Authorization: $key" "$home/curl-headerfile-content" \
+    "the credential must reach curl as a header file"
+  headerfile=$(cat "$home/curl-headerfile")
+  assert_absent "$headerfile" "the private credential file must not outlive the transport"
+  pass "the real transport passes its credential by private file, never in argv or the environment"
+}
+
+# --- 9. records stay inspectable and typed ----------------------------------
+
+test_records_are_typed_and_bounded() {
+  local home id record mode
+  home=$(make_home records)
+  run_sync "$home" bind ship-r ENG-500 >/dev/null || fail "bind failed"
+  queue_comment "$home" ship-r 'a typed handback' --status Done >/dev/null || fail "queue failed"
+  id=$(one_id "$home/state/linear/outbox" .json)
+  record="$home/state/linear/outbox/$id.json"
+
+  [ "$(jq -r '.schema' < "$record")" = fm-linear-delivery-v1 ] || fail "the record must carry its schema"
+  [ "$(jq -r '.delivery_id' < "$record")" = "$id" ] || fail "the record must carry its own identity"
+  [ "$(jq -r '.task_id' < "$record")" = ship-r ] || fail "the record must name its task"
+  [ "$(jq -r '.issue' < "$record")" = ENG-500 ] || fail "the record must name its issue"
+  [ "$(jq -r '.status' < "$record")" = Done ] || fail "the record must carry its status"
+  [ "$(jq -r '.marker' < "$record")" = "fm-linear-sync:$id" ] || fail "the record must carry its marker"
+
+  mode=$(file_mode "$record")
+  [ "$mode" = 600 ] || fail "a delivery record must be private (found $mode)"
+  mode=$(file_mode "$home/state/linear")
+  [ "$mode" = 700 ] || fail "the Linear state root must be private (found $mode)"
+
+  # A record that no longer matches its own identity never reaches Linear.
+  write_credential "$home"
+  seed_issue "$(fake_dir "$home")" ENG-500 team-1 Todo
+  jq '.comment = "tampered"' < "$record" > "$record.tmp" && mv "$record.tmp" "$record"
+  chmod 600 "$record"
+  run_sync "$home" deliver "$id" >/dev/null 2> "$home/r.err" && fail "a tampered record must refuse"
+  assert_grep "identity check" "$home/r.err" "the refusal must name the identity check"
+  [ "$(comment_count "$home" ENG-500)" -eq 0 ] || fail "a tampered record must post nothing"
+  pass "delivery records are typed, private, and refused when they no longer match their identity"
+}
+
+test_a_concurrent_delivery_is_serialized() {
+  local home id rc
+  home=$(make_home concurrency)
+  write_credential "$home"
+  seed_issue "$(fake_dir "$home")" ENG-600 team-1 Todo
+  run_sync "$home" bind ship-c ENG-600 >/dev/null || fail "bind failed"
+  queue_comment "$home" ship-c 'only one of these may post' >/dev/null || fail "queue failed"
+  id=$(one_id "$home/state/linear/outbox" .json)
+
+  # Two runs that both complete a read-back before either posts would both see a
+  # proven absence. The per-delivery lock is what makes that impossible, so hold
+  # it directly rather than racing two processes.
+  mkdir "$home/state/linear/.lock.$id" || fail "cannot hold the delivery lock"
+  rc=0
+  run_sync "$home" deliver "$id" >/dev/null 2> "$home/lock.err" || rc=$?
+  [ "$rc" -eq 3 ] || fail "a delivery already in progress must hold (rc=$rc)"
+  assert_grep "already in progress" "$home/lock.err" "the hold must say why"
+  assert_grep "still owed" "$home/lock.err" "the hold must say the handback survives"
+  [ "$(comment_count "$home" ENG-600)" -eq 0 ] || fail "a locked delivery must post nothing"
+
+  # An abandoned lock must not strand the handback forever.
+  touch -t 202001010000 "$home/state/linear/.lock.$id"
+  run_sync "$home" deliver "$id" >/dev/null || fail "an abandoned lock must be taken over"
+  [ "$(comment_count "$home" ENG-600)" -eq 1 ] || fail "the takeover must post exactly once"
+  assert_absent "$home/state/linear/.lock.$id" "the lock must be released"
+  pass "a delivery already under way holds, and an abandoned lock is taken over rather than stranding it"
+}
+
+test_comment_text_cannot_forge_record_fields() {
+  local home out rc
+  home=$(make_home field-forgery)
+  run_sync "$home" bind ship-f ENG-700 >/dev/null || fail "bind failed"
+  # The cleanup gate reads delivery records without jq, so a comment that looks
+  # like a record must not be able to rewrite what that gate sees.
+  printf 'here is a record:\n  "status": "Nothing"\n  "issue": "ENG-999"\n  "task_id": "someone-else"\n' \
+    > "$home/comment.md"
+  run_sync "$home" queue ship-f --comment-file "$home/comment.md" --status Done >/dev/null \
+    || fail "queue failed"
+
+  out=$(run_sync "$home" pending)
+  assert_contains "$out" "issue=ENG-700" "the real issue must win over comment text"
+  assert_contains "$out" "status=Done" "the real status must win over comment text"
+  assert_contains "$out" "task=ship-f" "the real task must win over comment text"
+
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    "$SYNC" guard-work someone-else >/dev/null 2>&1 \
+    || fail "the gate must not block a task named only inside comment text"
+  rc=0
+  FM_ROOT_OVERRIDE="$ROOT" FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" \
+    "$SYNC" guard-work ship-f >/dev/null 2>&1 || rc=$?
+  [ "$rc" -eq 1 ] || fail "the gate must block the task that actually owes the handback"
+  pass "comment text cannot forge the record fields the jq-free cleanup gate reads"
+}
+
+test_missing_and_ambiguous_targets_refuse
+test_comment_content_is_validated
+test_delivery_posts_once_and_sets_status
+test_requeueing_the_same_handback_is_one_delivery
+test_a_concurrent_delivery_is_serialized
+test_lost_acknowledgement_converges_without_a_duplicate
+test_a_destroyed_receipt_does_not_repost
+test_truncated_read_back_refuses_to_post
+test_disconnected_linear_preserves_the_handback
+test_transport_failure_holds_then_lands_once
+test_a_partial_delivery_completes_its_status_without_reposting
+test_an_unknown_issue_is_quarantined_and_still_blocks
+test_cleanup_refuses_while_a_linear_handback_is_owed
+test_cleanup_of_an_unbound_task_is_unaffected
+test_startup_surfaces_owed_handbacks_only_when_owed
+test_a_home_with_no_linear_work_gains_nothing
+test_scope_is_a_genuine_primary_home
+test_the_credential_never_leaves_its_file
+test_the_real_transport_keeps_the_credential_out_of_argv
+test_records_are_typed_and_bounded
+test_comment_text_cannot_forge_record_fields


### PR DESCRIPTION
## Intent

Keep the captain's Linear issues continuously current by making a bound Linear issue part of a task's completion, so work can never be reported done while its issue is still stale.

## What Changed

- Add `bin/fm-linear-lib.sh`, `bin/fm-linear-sync.sh`, and `bin/fm-linear-transport.sh`, implementing `bind`/`queue`/`deliver`/`guard-work`/`discard`/`hook` commands with content-derived delivery IDs (idempotent re-queueing across retries/crashes), read-back reconciliation against Linear's own comments before posting, and a curl-based transport that keeps the API key out of argv, inherited env, request bodies, and output.
- Wire the completion gate into `bin/fm-teardown.sh` (refuses teardown while a bound task still owes a Linear handback) and `bin/fm-session-start.sh` (surfaces pending handbacks in the session digest), with matching test-family routing in `bin/fm-test-run.sh` and fixture updates in `tests/fm-gotmp.test.sh` plus the new `tests/fm-linear-sync.test.sh`.
- Harden delivery correctness: preserve an owed handback (hold instead of discard) when quarantining a refused delivery fails, refuse comments containing a NUL byte instead of silently dropping it during trailing-newline canonicalization, and document the exit-3/`refuse_delivery` return contract and the corrected jq requirement across `docs/linear-sync.md`, `docs/verification/linear-sync.md`, `docs/architecture.md`, `docs/configuration.md`, `AGENTS.md`, `README.md`, `docs/scripts.md`, and `docs/documentation-audiences.json`.

## Risk Assessment

✅ Low: All three previously-flagged issues (silent outbox loss when quarantine-write fails, overbroad jq-requirement doc claim, NUL byte silently stripped instead of refused) are durably fixed exactly per the required shape, each with a matching behavioral regression test through the public interface and updated verification evidence that was actually re-run (test count and doc's ok-lines both match 23). The feature closely matches its stated intent (a bound Linear issue's currency becomes part of task completion via bin/fm-teardown.sh's new gate) with strong idempotency, crash-safety, and jq-optional design, and the one new finding is a narrow, display-only parsing edge case with no data-loss, security, or completion-gate correctness impact.

## Testing

Ran the full targeted behavioral suite (tests/fm-linear-sync.test.sh, 23/23 passing, hermetic, no network) covering every guarantee including the two regressions from this change round, then independently verified the actual code for both fixes (quarantine-write-failure preservation in refuse_delivery, and pre-canonicalization NUL detection in cmd_queue) matches the required fix shape, and cross-checked the verification/config docs against the real test output and real jq call sites. Beyond the suite, I hand-drove the real CLI end-to-end against a fresh hermetic fake Linear workspace outside the test harness: bind → queue → guard-work refuses while stale (exit 1) → deliver → guard-work clears (exit 0), directly demonstrating the user intent — a bound Linear issue is part of task completion and completion cannot be reported while it's stale. bin/fm-teardown.sh itself was not invoked directly since it correctly self-refuses under this session's NO_MISTAKES_GATE (a gate-phase agent must not drive the fleet); guard-work is the exact gate primitive teardown calls internally, so this is a faithful substitute. No issues found; worktree left clean.

<details>
<summary>Evidence: tests/fm-linear-sync.test.sh full run (23/23 ok, exit 0)</summary>

```text
ok - an unbound task, an ambiguous binding, and a prose target all refuse instead of guessing
ok - an empty comment, a forged marker, an oversized body, a NUL byte, and a malformed status all refuse
ok - a delivery posts one comment, applies the status once, and repeats as a no-op
ok - re-queueing an identical handback resolves to one delivery, and a changed one is distinct
ok - a delivery already under way holds, and an abandoned lock is taken over rather than stranding it
ok - a comment committed by Linear with a lost acknowledgement converges with no duplicate
ok - a lost local receipt is recovered from Linear's own copy, never by reposting
ok - a read-back that cannot be completed holds rather than risking a duplicate
ok - a disconnected or misconfigured Linear preserves the handback and never claims completion
ok - an unreachable Linear holds the handback and the later retry posts exactly once
ok - a comment that landed without its status is completed on retry with no second comment
ok - an issue Linear does not have is quarantined, keeps blocking, and clears only on an explicit discard
ok - a refusal that cannot be quarantined preserves the outbox record and holds instead of discarding it
ok - cleanup refuses while a Linear handback is owed and proceeds once the issue is current
ok - the completion gate blocks only the task that owes the handback
ok - session start surfaces an owed Linear handback from disk, and stays silent otherwise
ok - a home that never bound a Linear issue gains no artifact and prints nothing
ok - the hook is active in a primary and secondmate home and inert in a task worktree or project repo
ok - the credential never reaches a request body, a durable record, or any output
ok - the real transport passes its credential by private file, never in argv or the environment
ok - delivery records are typed, private, and refused when they no longer match their identity
ok - comment text cannot forge the record fields the jq-free cleanup gate reads
ok - a home without jq still reads its records and still refuses to complete an owed task
```
</details>
<details>
<summary>Evidence: Independent manual CLI transcript: completion gate refuses while stale, clears after delivery</summary>

Source: [Independent manual CLI transcript: completion gate refuses while stale, clears after delivery](https://github.com/chadxgpt/firstmate/blob/f9da575e664ea0a27cd239761a971e54e76a7c87/.no-mistakes/evidence/fm/fm-linear-sync-hook-r1/guard-work-gate-cli-transcript.txt)

```text
=== 1. bind ship-900 to ENG-900 ===
bound ship-900 -> ENG-900

=== 2. queue a completion comment + Done status ===
queued ship-900 -> ENG-900 (2d171abd67de7f437d60b6078ae1bc2bee35f3f0beefb0b30afa3b86e0312b2f)

=== 3. write the task's meta record (as if ship-900 is ready to tear down) ===

=== 4. run the completion gate (fm-linear-sync.sh guard-work), the exact check
===    fm-teardown.sh's cleanup runs before it will tear down a task, BEFORE
===    delivering the handback ===
queued  task=ship-900  issue=ENG-900  status=Done  delivery=2d171abd67de7f437d60b6078ae1bc2bee35f3f0beefb0b30afa3b86e0312b2f
--> exit code: 1
PASS: the completion gate refused while ENG-900 was still stale

=== 5. deliver the queued handback to Linear (the fake workspace) ===
delivered ship-900 -> ENG-900 (2d171abd67de7f437d60b6078ae1bc2bee35f3f0beefb0b30afa3b86e0312b2f, posted)

=== 6. Linear issue state after delivery ===
ENG-900 state is now: Done
ENG-900 comments:
{"id":"c1","body":"Shipped in PR #42.\n\n<!-- fm-linear-sync:2d171abd67de7f437d60b6078ae1bc2bee35f3f0beefb0b30afa3b86e0312b2f -->"}

=== 7. re-run the completion gate AFTER delivering the handback ===
--> exit code: 0
PASS: the completion gate cleared once the Linear issue was made current

=== manual intent check complete ===

--- Context ---
Branch: fm/fm-linear-sync-hook-r1
Target commit: 54ea420f2e1399a9ff3ff5b23cfd354a98b0ee87
This is an independent, hand-driven CLI transcript (not a run of tests/fm-linear-sync.test.sh)
exercising bin/fm-linear-sync.sh directly against a hermetic fake Linear transport, following
the same fake-transport contract documented in docs/verification/linear-sync.md. It demonstrates
the user intent end-to-end: a task's completion gate (fm-linear-sync.sh guard-work, the exact
check bin/fm-teardown.sh's cleanup runs before tearing a task down) refuses while the bound
Linear issue is stale, and clears only after the handback (comment + status) is actually
delivered to Linear.

Note: bin/fm-teardown.sh itself was not invoked directly, because this session runs as the
test phase inside an active no-mistakes gate, and fm-teardown.sh correctly refuses to run
under that condition ("no-mistakes gate agent must not drive the fleet (NO_MISTAKES_GATE set)").
guard-work is the exact primitive fm-teardown.sh calls internally for this gate
(see bin/fm-teardown.sh's "The captain's rule" block), so this is a faithful, unmodified
exercise of the same gate logic.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"54ea420f2e1399a9ff3ff5b23cfd354a98b0ee87","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Rebase** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-teardown.sh` - merge conflict rebasing onto origin/main
- ⚠️ `docs/scripts.md` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `bin/fm-linear-lib.sh:247` - fm_linear_status_valid() in bin/fm-linear-lib.sh only rejects control characters, so a --status value containing a literal double quote (e.g. `queue task-a --comment-file x --status &#39;Foo&#34;Bar&#39;`) is accepted and stored correctly (jq-escaped) in the outbox/refused JSON record. But fm_linear_record_field(), the jq-free reader that `pending`/`guard-work`/`hook` rely on, extracts a field with `line=${line#\&#34;}; line=${line%%\&#34;*}`, which does not understand backslash-escaping and truncates at the first embedded quote. Verified directly: writing a record with status `Foo&#34;Bar` and reading it back via fm_linear_record_field yields `Foo\` instead of `Foo&#34;Bar`. Impact is narrow and display-only: cmd_show cats the raw JSON file (unaffected) and deliver_one_locked reads status via jq (unaffected), so only the human-readable status shown in `pending`/`guard-work` output is garbled.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-linear-sync.test.sh` (23/23 ok, exit 0) — the full hermetic behavioral suite for the feature, including the two regression tests added by this change: `a refusal that cannot be quarantined preserves the outbox record and holds instead of discarding it` and the NUL-byte case inside `an empty comment, a forged marker, an oversized body, a NUL byte, and a malformed status all refuse`</code>
- `Read bin/fm-linear-sync.sh refuse_delivery() (lines 549-569): confirmed it now validates the refused/<id>.json and .reason writes with fmx_private_artifact_file_valid before removing the outbox record, and falls back to hold_delivery() (preserving the outbox record, returning 3/hold) when the quarantine write fails — matching the required fix shape exactly`
- `Read bin/fm-linear-sync.sh cmd_queue() (lines 280-298): confirmed the control-character/NUL check now runs on the comment's original bytes before the command-substitution canonicalization step that would silently drop a NUL, so a NUL byte triggers the documented refusal instead of being silently stripped`
- `Diffed and read docs/verification/linear-sync.md and docs/linear-sync.md against the actual test output and actual jq call sites (require_jq only in cmd_queue/cmd_deliver): confirmed the verification record's recorded ok-line output and 5th/6th guarantee wording match the real, freshly-run suite output verbatim, and the jq requirement is now correctly scoped to queue/deliver rather than overstated`
- <code>Independent manual CLI transcript (not a re-run of the test file): bound a task to a fake Linear issue, queued a Done-status comment, ran `bin/fm-linear-sync.sh guard-work` (the exact primitive bin/fm-teardown.sh&#39;s completion gate calls) before delivery and confirmed it refuses (exit 1) while the issue is stale, delivered the handback, then re-ran guard-work and confirmed it clears (exit 0) with the fake Linear issue now showing the posted comment and Done state</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
