### PR TITLE
docs(agents): address the user as Raj instead of mandatory captain

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -52,7 +52,7 @@ batched digest rather than per-wake injections.
 3. **Do not separately arm `fm-watch.sh`.** The daemon manages the watcher as
    its child; the singleton lock no-ops a stray arm harmlessly.
 
-4. **Acknowledge** in `AGENTS.md` section 9 language: "Captain, away mode is active; I will batch routine updates and surface only decisions, failures, credentials, or review-ready work until you return."
+4. **Acknowledge** in `AGENTS.md` section 9 language: "Raj, away mode is active; I will batch routine updates and surface only decisions, failures, credentials, or review-ready work until you return."
 
 ## How to exit afk
 

--- a/.agents/skills/bearings/SKILL.md
+++ b/.agents/skills/bearings/SKILL.md
@@ -128,7 +128,6 @@ Rules that keep the contract unambiguous:
 - The strict boundary keeps action-free items OUT of Captain's Call: a working or validating task, a queued item blocked on another task or a date, landed work, a completed scout's report pointer, a declared `paused:` external wait, and a bare recorded PR with no merge-ready signal each belong to one of the other three sections, never Captain's Call.
 - A secondmate's own row appears Underway only for `active_child_work`; `externally_held` belongs in Charted Next, and `unknown` belongs there as an unavailable-state gate unless its reason requires the captain's action.
 - Do not suppress separately projected decisions, landed records, or gates from a `partial-structured` home merely because that secondmate's own row is `unknown`.
-- Include the required direct address to the captain inside one item or empty-state sentence.
 - Every PR appears as the full `https://...` URL; a shorthand `#number` is fine only as a back-reference after the full URL has already appeared in the same digest.
 - The chat follows `AGENTS.md` section 9 and carries one scannable line per item.
 - Detailed decisions, plans, full gate reasons, and evidence stay out of chat; file mode puts them in the report, while lavish mode puts only its payload-backed interactive detail on the board.

--- a/.agents/skills/updatefirstmate/SKILL.md
+++ b/.agents/skills/updatefirstmate/SKILL.md
@@ -49,7 +49,7 @@ This touches only the firstmate repo and its own worktrees, never anything under
 
 4. **Report to the captain in plain outcomes.**
    Summarize what landed under `AGENTS.md` section 9 without firstmate's internal vocabulary: which parts of the fleet are now on the latest, and which were left as-is and why.
-   For example: "Captain, firstmate and both second mates are now on the latest."
+   For example: "Raj, firstmate and both second mates are now on the latest."
    Surface any skipped target whose reason needs the captain's attention - for instance a home with its own un-landed changes (diverged) or local edits (dirty), which were left untouched on purpose.
 
 ## Safety

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,7 @@ You are the first mate.
 The user is the captain.
 This file is your entire job description.
 
-Address the user as "captain" at least once in every response.
-This is mandatory respectful address, not performance: it applies even when delivering bad news or relaying serious findings, such as "Captain, the build broke - ...".
-Do not force it into every sentence, but never send a response with zero direct address.
+Address the user as "Raj", the way you would address any user by name.
 Use light nautical seasoning only when it fits: the occasional "aye", "on deck", "shipshape", "under way", or "ahoy" may land naturally.
 Keep that seasoning optional and never let it obscure technical content; never use it in commits, briefs, PRs, or anything crewmates or other tools read; drop the playful flavor entirely when delivering bad news or relaying serious findings.
 For captain-facing escalation style and outcome phrasing, see section 9.
@@ -481,7 +479,7 @@ Reach the captain immediately for:
 - A needed credential or login.
 
 Do not surface automatic fixes, retries, routine progress, or internal supervision mechanics.
-When a routine operational update's specific event requires no action but a response must be sent, reply exactly `Captain, shipshape.` without characterizing the visible session's unrelated decisions.
+When a routine operational update's specific event requires no action but a response must be sent, reply exactly `Raj, shipshape.` without characterizing the visible session's unrelated decisions.
 Batch non-urgent updates into the next natural reply.
 Use plain chat for a yes-or-no decision and `lavish-axi` only when several options or a structured report benefit from a visual surface.
 Whenever a PR is mentioned, include its full `https://...` URL before any shorthand reference.


### PR DESCRIPTION
## Intent

In AGENTS.md's preamble (section 1, Identity and prime directives), remove the mandatory requirement to address the user as 'captain' at least once in every response, and replace it with an instruction to address the user as 'Raj' instead, used naturally like addressing any user by name, with no mandatory-every-response requirement. Keep the rest of the identity/nautical-seasoning guidance intact. Leave every other use of the word 'captain' as general role terminology (e.g. 'the user is the captain', 'captain-approved', 'captain-facing', 'captain instruction precedence') unchanged; only change wording that concerns how firstmate directly addresses the user in conversation. GROK_BOT.md's separate mandatory-captain-address convention is confirmed out of scope and stays untouched (captain decision). Keep the diff minimal and targeted to the direct-address mandate and any place that directly conflicts with removing it (such as section 9's scripted exact reply that literally addresses the user as 'Captain').

## What Changed
- AGENTS.md section 1: replaced the mandatory "address the user as captain at least once in every response" rule with an instruction to address the user as "Raj," used naturally like any user's name, dropping the never-send-zero-direct-address mandate.
- AGENTS.md section 9: updated the scripted exact reply from `Captain, shipshape.` to `Raj, shipshape.` to match the new direct-address convention.
- Updated the example acknowledgment strings in `.agents/skills/afk/SKILL.md` and `.agents/skills/updatefirstmate/SKILL.md` from "Captain, ..." to "Raj, ..." to stay consistent with the new address convention.
- Removed the now-obsolete "Include the required direct address to the captain" rule from `.agents/skills/bearings/SKILL.md`.

## Risk Assessment

✅ Low: Documentation-only wording change, fully scoped to the direct-address mandate and its dependent scripted examples, with no code, logic, or test surface touched.

## Testing

This is a pure natural-language instruction change to AGENTS.md and three skill docs (afk, bearings, updatefirstmate) with no executable consumer in this repo, so per the test-quality rule no grep/parse-based automated test would constitute real evidence, and live-LLM behavioral evaluation of the prompt text is explicitly out of scope for deterministic CI/test phase; I confirmed via targeted repo search that no existing test asserts on this content, then manually reviewed the full diff for correctness: the mandatory "address as captain every response" directive is fully removed and replaced with a natural "Address the user as \"Raj\"" instruction, the scripted section 9 reply and all three skill-doc example strings were updated in lockstep from "Captain, ..." to "Raj, ...", bearings/SKILL.md's now-obsolete "required direct address" checklist line was cleanly dropped, all other "captain" role-terminology usages (captain-approved, captain-facing, etc.) were left untouched, and GROK_BOT.md remains untouched per the already-declined decision. No test failures, no setup issues, nothing to fix; working tree is clean with no transient artifacts to remove.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"5e2cffc04c60f549a9e3deac40accdc47ab59b7a","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff 6a2cd6c..5e2cffc -- AGENTS.md .agents/skills/afk/SKILL.md .agents/skills/bearings/SKILL.md .agents/skills/updatefirstmate/SKILL.md (manual review of the full diff)`
- `grep -n 'captain" at least once|mandatory respectful address|^Address the user' AGENTS.md (confirms the mandatory-address sentence is gone and replaced by the single natural-address line)`
- `grep -rn 'shipshape|address the user as|Captain, away mode|Captain, firstmate|captain' tests/ to confirm no test asserts on this AGENTS.md/skill prose (only unrelated fixture strings in tests/fm-x-mode.test.sh)`
- `grep -rl 'AGENTS.md' tests/ then spot-checked fm-session-start.test.sh, fm-brief.test.sh, fm-ensure-agents-md.test.sh for any content assertion on the changed wording (none found)`
- `confirmed GROK_BOT.md is absent from the diff, matching the recorded captain decision that it stays out of scope`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
