### PR TITLE
ci: Pin GitHub Actions to immutable SHAs to prevent supply chain risks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
       - name: Install pinned ShellCheck
         run: |
           set -eu
@@ -38,7 +38,7 @@ jobs:
     name: Test coverage guard
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
       - name: Prove complete regression partition
         run: bin/fm-test-run.sh --check-coverage
 
@@ -51,7 +51,7 @@ jobs:
     # a hang tripwire with margin, not the expected healthy end of the lane.
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           fetch-depth: 0
       - name: Install pinned ShellCheck
@@ -77,7 +77,7 @@ jobs:
             --json "$RUNNER_TEMP/fm-test/fm-test-timing-portable-parallel-1.json"
       - name: Upload shard 1 timing artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: fm-test-timing-portable-parallel-1
           path: ${{ runner.temp }}/fm-test/fm-test-timing-portable-parallel-1.json
@@ -88,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           fetch-depth: 0
       - name: Install pinned ShellCheck
@@ -114,7 +114,7 @@ jobs:
             --json "$RUNNER_TEMP/fm-test/fm-test-timing-portable-parallel-2.json"
       - name: Upload shard 2 timing artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: fm-test-timing-portable-parallel-2
           path: ${{ runner.temp }}/fm-test/fm-test-timing-portable-parallel-2.json
@@ -139,7 +139,7 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           fetch-depth: 0
       - name: Install pinned ShellCheck
@@ -179,7 +179,7 @@ jobs:
             --json "$RUNNER_TEMP/fm-test/fm-test-timing-portable-serial-${FM_SERIAL_SHARD}.json"
       - name: Upload portable serial shard ${{ matrix.shard }} timing artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: fm-test-timing-portable-serial-${{ matrix.shard }}
           path: ${{ runner.temp }}/fm-test/fm-test-timing-portable-serial-${{ matrix.shard }}.json
@@ -198,7 +198,7 @@ jobs:
     # timing artifacts still uploaded (docs/fm-test-portable-shards.md).
     timeout-minutes: 75
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           fetch-depth: 0
       - name: Require tools for real Herdr
@@ -299,7 +299,7 @@ jobs:
           }
       - name: Upload Herdr timing and diagnostics
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: fm-test-timing-herdr
           path: |
@@ -319,9 +319,9 @@ jobs:
       - tests-herdr
     if: always()
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
       - name: Download lane timing artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           pattern: fm-test-timing-*
           path: ${{ runner.temp }}/fm-test-aggregate
@@ -341,7 +341,7 @@ jobs:
             "${inputs[@]}"
       - name: Upload aggregate timing artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: fm-test-timing-aggregate
           path: ${{ runner.temp }}/fm-test/fm-test-timing-aggregate.json
@@ -352,7 +352,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
       - name: Run snapshot consumers with stock Bash
         shell: /bin/bash {0}
         env:
@@ -394,7 +394,7 @@ jobs:
     name: Repo invariants
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
       - name: Compatibility pointers must stay intact
         run: |
           set -eu

--- a/.github/workflows/windows-herdr-spike.yml
+++ b/.github/workflows/windows-herdr-spike.yml
@@ -15,7 +15,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
 
       - name: Install Herdr Windows preview and jq
         shell: pwsh
@@ -427,7 +427,7 @@ jobs:
 
       - name: Upload measurement and diagnostics
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: windows-herdr-spike-${{ github.run_id }}
           path: |


### PR DESCRIPTION
Hey! 👋 I was exploring Firstmate (the fleet supervision architecture looks incredible!) and I ran the repository through a security and architecture scanner we are building called [VibeMass](https://vibemass.com). 

I noticed a minor supply-chain vulnerability in your CI/CD workflows, so I wanted to quickly patch it for you.

### 1. Security Fix: Mutable GitHub Action Tags
Workflows like `ci.yml` and `windows-herdr-spike.yml` were using mutable tags like `@v6` and `@v4`. If any of those upstream action repositories are ever compromised, an attacker could silently inject malware into your builds. 
**Fix:** I’ve pinned your GitHub Actions (`actions/checkout`, `actions/upload-artifact`, `actions/download-artifact`) to their exact 40-character commit SHAs to guarantee supply chain security.

### 2. Architecture Observations
As a side note, the scanner's Architecture agent flagged a few heavy "God Files" that might become bottlenecks:
- `tests/fm-voice-relay.test.sh` is quite massive (4700+ lines). The agent flagged that this could make test maintenance and debugging harder.
- `bin/backends/herdr.sh` was also flagged as a very large monolithic file (3300+ lines), which could increase cognitive load.
- `AGENTS.md` is becoming a monolithic instruction file. 

Just wanted to leave those as helpful architectural breadcrumbs! Keep up the great work on the project! 🚀
