### PR TITLE
fix(herdr): fail closed on unsafe long typed sends

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -117,6 +117,11 @@ FM_BACKEND_HERDR_MIN_WORKSPACE_MOVE_PROTOCOL=16
 # both fixes reaches 19, and the pre-fix builds top out at 17.
 FM_BACKEND_HERDR_MIN_PRESENTATION_PROTOCOL=19
 FM_BACKEND_HERDR_MIN_PRESENTATION_VERSION=0.8.0
+# Herdr's atomic agent-prompt route is required for long typed input.  Claude's
+# terminal composer can lose the head of a large literal PTY paste, while the
+# agent-prompt API submits the text as one bracketed-paste operation.
+FM_BACKEND_HERDR_MIN_AGENT_PROMPT_PROTOCOL=19
+FM_BACKEND_HERDR_LONG_TEXT_BYTES=800
 # One-warning-per-release dedupe marker prefix, under the state dir. The
 # projection decision is remade on every spawn, so an undeduplicated
 # below-floor warning would repeat on every crewmate; the key is the detected
@@ -2548,6 +2553,32 @@ fm_backend_herdr_send_literal() {  # <target> <text>
   fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane send-text "$FM_BACKEND_HERDR_PANE" "$2" >/dev/null 2>&1
 }
 
+# fm_backend_herdr_agent_prompt_capable: return 0 only when both the client and
+# selected server advertise the atomic agent-prompt protocol.  Unknown release
+# data is deliberately not treated as capable because long input must never
+# fall back to a truncating PTY paste.
+fm_backend_herdr_agent_prompt_capable() {  # <session>
+  local session=$1 status running client_protocol server_protocol
+  status=$(fm_backend_herdr_cli "$session" status --json 2>/dev/null) || return 2
+  client_protocol=$(printf '%s' "$status" | jq -r '.client.protocol // empty' 2>/dev/null) || return 2
+  case "$client_protocol" in
+    ''|*[!0-9]*) return 2 ;;
+  esac
+  running=$(printf '%s' "$status" | jq -r 'if .server.running == true then "true" elif .server.running == false then "false" else "unknown" end' 2>/dev/null) || return 2
+  case "$running" in
+    false) [ "$client_protocol" -ge "$FM_BACKEND_HERDR_MIN_AGENT_PROMPT_PROTOCOL" ] ;;
+    true)
+      server_protocol=$(printf '%s' "$status" | jq -r '.server.protocol // empty' 2>/dev/null) || return 2
+      case "$server_protocol" in
+        ''|*[!0-9]*) return 2 ;;
+      esac
+      [ "$client_protocol" -ge "$FM_BACKEND_HERDR_MIN_AGENT_PROMPT_PROTOCOL" ] \
+        && [ "$server_protocol" -ge "$FM_BACKEND_HERDR_MIN_AGENT_PROMPT_PROTOCOL" ]
+      ;;
+    *) return 2 ;;
+  esac
+}
+
 # fm_backend_herdr_normalize_key: map firstmate's key vocabulary (Enter,
 # Escape, C-c, as used by fm-send.sh --key and stuck-crewmate-recovery) onto
 # herdr's `pane send-keys` names. Verified empirically: enter, escape/esc, and
@@ -2782,8 +2813,30 @@ fm_backend_herdr_queued_enter_busy() {  # <target> <allow-rendered>
 
 fm_backend_herdr_send_text_submit() {  # <target> <text> <retries> <enter-sleep> <settle>
   local target=$1 text=$2 retries=$3 sleep_s=$4 settle=$5 i=0 verdict baseline confirm_sleep
+  local text_bytes agent_prompt_capable
   local raw_status footer_baseline='' allow_rendered=0 enter_sent=0
   fm_backend_herdr_parse_target "$target" || { printf 'unknown'; return 0; }
+
+  # Herdr's literal PTY route is unsafe for large composer pastes: a Claude
+  # terminal can accept the tail while dropping the marker and leading text.
+  # Protocol 19's agent-prompt API is atomic and includes submission, so use it
+  # for long messages; older or unreadable releases fail closed before typing.
+  text_bytes=$(LC_ALL=C printf '%s' "$text" | wc -c | tr -d '[:space:]')
+  if [ "$text_bytes" -gt "$FM_BACKEND_HERDR_LONG_TEXT_BYTES" ]; then
+    agent_prompt_capable=0
+    fm_backend_herdr_agent_prompt_capable "$FM_BACKEND_HERDR_SESSION" || agent_prompt_capable=$?
+    if [ "$agent_prompt_capable" -ne 0 ]; then
+      echo "error: refusing unsafe Herdr long send (${text_bytes} bytes); atomic agent prompt requires protocol ${FM_BACKEND_HERDR_MIN_AGENT_PROMPT_PROTOCOL}" >&2
+      printf 'send-failed'
+      return 0
+    fi
+    if fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" agent prompt "$FM_BACKEND_HERDR_PANE" "$text" >/dev/null 2>&1; then
+      printf 'empty'
+    else
+      printf 'send-failed'
+    fi
+    return 0
+  fi
   fm_backend_herdr_send_literal "$target" "$text" || { printf 'send-failed'; return 0; }
   sleep "$settle"
   raw_status=$(fm_backend_herdr_agent_status_raw "$FM_BACKEND_HERDR_SESSION" "$FM_BACKEND_HERDR_PANE")

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2558,15 +2558,34 @@ fm_backend_herdr_send_text_line() {  # <target> <text>
 # Long text fails closed here rather than falling back to the atomic
 # agent-prompt route: that route submits as part of the call, which would
 # break this function's unsubmitted contract, and it targets a running
-# agent's composer - not available for pre-launch shell sends (e.g. the
-# spawn LAUNCH command), which is this primitive's only long-text caller.
+# agent's composer - not available for pre-launch shell sends.
 fm_backend_herdr_send_literal() {  # <target> <text>
+  fm_backend_herdr_send_literal_impl "$1" "$2" 0
+}
+
+# fm_backend_herdr_send_literal_command: like fm_backend_herdr_send_literal,
+# but exempt from the long-text guard. Reserved for fm-spawn.sh's fixed,
+# code-constructed LAUNCH command line, sent to a bare pre-agent shell prompt
+# before any agent is running - not the agent composer widget the documented
+# head-loss failure mode was reproduced against - and whose length tracks
+# path/env lengths rather than arbitrary long user-authored content. The
+# submit step for that send must stay a separate, later call (never folded
+# into an atomic type+submit primitive): fm-spawn.sh's herdr presentation
+# order lock is released in the window between typing and Enter, and an
+# atomic primitive would collapse that window.
+fm_backend_herdr_send_literal_command() {  # <target> <text>
+  fm_backend_herdr_send_literal_impl "$1" "$2" 1
+}
+
+fm_backend_herdr_send_literal_impl() {  # <target> <text> <allow-long>
   local text_bytes
   fm_backend_herdr_target_ready "$1" || return 1
-  text_bytes=$(LC_ALL=C printf '%s' "$2" | wc -c | tr -d '[:space:]')
-  if [ "$text_bytes" -gt "$FM_BACKEND_HERDR_LONG_TEXT_BYTES" ]; then
-    echo "error: refusing unsafe Herdr literal send (${text_bytes} bytes); Herdr's PTY paste can silently drop the head of long input and no atomic unsubmitted primitive exists" >&2
-    return 1
+  if [ "$3" -ne 1 ]; then
+    text_bytes=$(LC_ALL=C printf '%s' "$2" | wc -c | tr -d '[:space:]')
+    if [ "$text_bytes" -gt "$FM_BACKEND_HERDR_LONG_TEXT_BYTES" ]; then
+      echo "error: refusing unsafe Herdr literal send (${text_bytes} bytes); Herdr's PTY paste can silently drop the head of long input and no atomic unsubmitted primitive exists" >&2
+      return 1
+    fi
   fi
   fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane send-text "$FM_BACKEND_HERDR_PANE" "$2" >/dev/null 2>&1
 }

--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -121,7 +121,13 @@ FM_BACKEND_HERDR_MIN_PRESENTATION_VERSION=0.8.0
 # terminal composer can lose the head of a large literal PTY paste, while the
 # agent-prompt API submits the text as one bracketed-paste operation.
 FM_BACKEND_HERDR_MIN_AGENT_PROMPT_PROTOCOL=19
-FM_BACKEND_HERDR_LONG_TEXT_BYTES=800
+# Live verification only reproduced the legacy path as safe for a short
+# (~43-byte) marker-bearing message and confirmed the atomic route for
+# 2,000+ bytes; the true onset of head/marker loss between those points is
+# unproven. Kept deliberately far below the smallest untested point so the
+# legacy literal route is only ever used for messages close in size to what
+# was actually verified safe.
+FM_BACKEND_HERDR_LONG_TEXT_BYTES=200
 # One-warning-per-release dedupe marker prefix, under the state dir. The
 # projection decision is remade on every spawn, so an undeduplicated
 # below-floor warning would repeat on every crewmate; the key is the detected
@@ -2548,8 +2554,20 @@ fm_backend_herdr_send_text_line() {  # <target> <text>
 # caller sends Enter separately. Mirrors tmux's `send-keys -t T -l text`.
 # Verified: `pane send-text` does NOT auto-submit (contrary to the addendum's
 # original guess); it behaves exactly like tmux's `-l` literal send.
+#
+# Long text fails closed here rather than falling back to the atomic
+# agent-prompt route: that route submits as part of the call, which would
+# break this function's unsubmitted contract, and it targets a running
+# agent's composer - not available for pre-launch shell sends (e.g. the
+# spawn LAUNCH command), which is this primitive's only long-text caller.
 fm_backend_herdr_send_literal() {  # <target> <text>
+  local text_bytes
   fm_backend_herdr_target_ready "$1" || return 1
+  text_bytes=$(LC_ALL=C printf '%s' "$2" | wc -c | tr -d '[:space:]')
+  if [ "$text_bytes" -gt "$FM_BACKEND_HERDR_LONG_TEXT_BYTES" ]; then
+    echo "error: refusing unsafe Herdr literal send (${text_bytes} bytes); Herdr's PTY paste can silently drop the head of long input and no atomic unsubmitted primitive exists" >&2
+    return 1
+  fi
   fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane send-text "$FM_BACKEND_HERDR_PANE" "$2" >/dev/null 2>&1
 }
 
@@ -2816,6 +2834,11 @@ fm_backend_herdr_send_text_submit() {  # <target> <text> <retries> <enter-sleep>
   local text_bytes agent_prompt_capable
   local raw_status footer_baseline='' allow_rendered=0 enter_sent=0
   fm_backend_herdr_parse_target "$target" || { printf 'unknown'; return 0; }
+  # fm_backend_herdr_send_literal below auto-starts the server via
+  # fm_backend_herdr_target_ready; the atomic agent-prompt branch calls
+  # fm_backend_herdr_cli directly instead, which has no bootstrap logic of
+  # its own, so ensure the server here for both branches alike.
+  fm_backend_herdr_server_ensure "$FM_BACKEND_HERDR_SESSION" || { printf 'send-failed'; return 0; }
 
   # Herdr's literal PTY route is unsafe for large composer pastes: a Claude
   # terminal can accept the tail while dropping the marker and leading text.

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2135,7 +2135,7 @@ spawn_current_path() {  # <target>
 spawn_send_literal() {  # <target> <text>
   case "$BACKEND" in
     tmux) fm_backend_tmux_send_literal "$1" "$2" ;;
-    herdr) fm_backend_herdr_send_literal "$1" "$2" ;;
+    herdr) fm_backend_herdr_send_literal_command "$1" "$2" ;;
     zellij) fm_backend_zellij_send_literal "$1" "$2" "$W" ;;
     orca) fm_backend_orca_send_literal "$1" "$2" ;;
     cmux) fm_backend_cmux_send_literal "$1" "$2" "$W" ;;

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -210,7 +210,7 @@ Literal text and Enter are separate operations on `fm-send.sh`'s typed plane; or
 Typed Herdr messages larger than 200 bytes use the atomic `agent prompt` operation on protocol 19 or newer, which submits the complete text and Enter together.
 On older or unreadable Herdr releases, a long typed message fails closed before any text is inserted rather than risking silent prefix loss.
 The adapter submit function is the authoritative transport boundary for both secondmate and ordinary explicit-target typed sends, while durable inbox sends remain lossless and unchanged.
-The unsubmitted literal-send primitive used by spawn-time commands, such as the crewmate and secondmate launch line, fails closed over the same byte threshold instead of risking the same silent prefix loss, since it has no atomic unsubmitted equivalent to fall back to.
+The crewmate and secondmate LAUNCH command line is exempt from that byte threshold: it targets a bare pre-agent shell prompt rather than the agent composer widget the documented head-loss failure mode was reproduced against, and its length tracks fixed path and env content rather than arbitrary long user-authored text.
 Spawn-time fixed commands may use Herdr's atomic run primitive.
 Enter, Escape, and Ctrl-C are supported.
 Typed-plane slash input, and dollar-prefixed skill input for Codex, uses the shared harness-aware settle before the first Enter so a completion popup cannot consume it.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -207,9 +207,10 @@ Every Herdr invocation goes through `fm_backend_herdr_cli`, which sets the envir
 An environment variable alone is not reliable when another Herdr server is running.
 
 Literal text and Enter are separate operations on `fm-send.sh`'s typed plane; ordinary local text steers instead use the durable steering inbox and send only its best-effort constant doorbell through this adapter.
-Typed Herdr messages larger than 800 bytes use the atomic `agent prompt` operation on protocol 19 or newer, which submits the complete text and Enter together.
+Typed Herdr messages larger than 200 bytes use the atomic `agent prompt` operation on protocol 19 or newer, which submits the complete text and Enter together.
 On older or unreadable Herdr releases, a long typed message fails closed before any text is inserted rather than risking silent prefix loss.
 The adapter submit function is the authoritative transport boundary for both secondmate and ordinary explicit-target typed sends, while durable inbox sends remain lossless and unchanged.
+The unsubmitted literal-send primitive used by spawn-time commands, such as the crewmate and secondmate launch line, fails closed over the same byte threshold instead of risking the same silent prefix loss, since it has no atomic unsubmitted equivalent to fall back to.
 Spawn-time fixed commands may use Herdr's atomic run primitive.
 Enter, Escape, and Ctrl-C are supported.
 Typed-plane slash input, and dollar-prefixed skill input for Codex, uses the shared harness-aware settle before the first Enter so a completion popup cannot consume it.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -207,6 +207,9 @@ Every Herdr invocation goes through `fm_backend_herdr_cli`, which sets the envir
 An environment variable alone is not reliable when another Herdr server is running.
 
 Literal text and Enter are separate operations on `fm-send.sh`'s typed plane; ordinary local text steers instead use the durable steering inbox and send only its best-effort constant doorbell through this adapter.
+Typed Herdr messages larger than 800 bytes use the atomic `agent prompt` operation on protocol 19 or newer, which submits the complete text and Enter together.
+On older or unreadable Herdr releases, a long typed message fails closed before any text is inserted rather than risking silent prefix loss.
+The adapter submit function is the authoritative transport boundary for both secondmate and ordinary explicit-target typed sends, while durable inbox sends remain lossless and unchanged.
 Spawn-time fixed commands may use Herdr's atomic run primitive.
 Enter, Escape, and Ctrl-C are supported.
 Typed-plane slash input, and dollar-prefixed skill input for Codex, uses the shared harness-aware settle before the first Enter so a completion popup cannot consume it.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -904,7 +904,7 @@ A throwaway scout was spawned through `bin/fm-spawn.sh --scout --backend tmux` o
 Long typed-input safety was reverified on Herdr 0.8.0 client and server, protocol 19, using the operational `[fm-from-firstmate]` marker and correlation prefix.
 The live Claude path reproduced the failure signature with a literal PTY paste: the tail arrived while the marker and beginning disappeared, while a shorter resend arrived intact.
 The smallest counterfactual used `herdr agent prompt` and preserved marker, correlation prefix, and tail for 2,000, 8,000, and 16,000-byte messages.
-The regression `tests/fm-herdr-long-send.test.sh` verifies the atomic route, protocol-below-19 fail-closed behavior, and the short literal resend boundary through the adapter submit interface.
+The regression `tests/fm-herdr-long-send.test.sh` verifies the atomic route, protocol-below-19 fail-closed behavior, and the short literal resend boundary through the adapter submit interface, plus the spawn-time LAUNCH command's exemption from that boundary through `fm_backend_herdr_send_literal_command`.
 
 The tmux run above is the reference; this section is the separate Herdr proof, produced on 2026-08-12 against Herdr 0.8.0 (client and server, protocol 19) and the same signed `cursor-agent` 2026.08.11-e8db854 on macOS 26.5.2 arm64.
 Every step ran inside an isolated `fm-lab-` session provisioned by `bin/fm-herdr-lab.sh`, launched from a neutral parent outside any Herdr pane, with the live default session's pane count checked before, during, and after; it stayed at 7 throughout.

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -901,6 +901,11 @@ A throwaway scout was spawned through `bin/fm-spawn.sh --scout --backend tmux` o
 
 ### Herdr backend
 
+Long typed-input safety was reverified on Herdr 0.8.0 client and server, protocol 19, using the operational `[fm-from-firstmate]` marker and correlation prefix.
+The live Claude path reproduced the failure signature with a literal PTY paste: the tail arrived while the marker and beginning disappeared, while a shorter resend arrived intact.
+The smallest counterfactual used `herdr agent prompt` and preserved marker, correlation prefix, and tail for 2,000, 8,000, and 16,000-byte messages.
+The regression `tests/fm-herdr-long-send.test.sh` verifies the atomic route, protocol-below-19 fail-closed behavior, and the short literal resend boundary through the adapter submit interface.
+
 The tmux run above is the reference; this section is the separate Herdr proof, produced on 2026-08-12 against Herdr 0.8.0 (client and server, protocol 19) and the same signed `cursor-agent` 2026.08.11-e8db854 on macOS 26.5.2 arm64.
 Every step ran inside an isolated `fm-lab-` session provisioned by `bin/fm-herdr-lab.sh`, launched from a neutral parent outside any Herdr pane, with the live default session's pane count checked before, during, and after; it stayed at 7 throughout.
 

--- a/tests/fm-herdr-long-send.test.sh
+++ b/tests/fm-herdr-long-send.test.sh
@@ -33,6 +33,8 @@ run() {
 out=$(run "$long")
 [ "$out" = empty ] || { echo "long send was not confirmed: $out" >&2; exit 1; }
 grep -F 'agent prompt w1:p2' "$FM_FAKE_HERDR_LOG" >/dev/null
+grep -F '[fm-from-firstmate]' "$FM_FAKE_HERDR_LOG" >/dev/null
+grep -F $'\u2063' "$FM_FAKE_HERDR_LOG" >/dev/null
 grep -F 'TAIL' "$FM_FAKE_HERDR_LOG" >/dev/null
 ! grep -F 'pane send-text' "$FM_FAKE_HERDR_LOG" >/dev/null
 

--- a/tests/fm-herdr-long-send.test.sh
+++ b/tests/fm-herdr-long-send.test.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/bin"
+cat > "$TMP/bin/herdr" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+log=${FM_FAKE_HERDR_LOG:?}
+args=("$@")
+printf '%s\n' "${args[*]}" >> "$log"
+if [ "${args[0]:-}" = status ] && [ "${args[1]:-}" = --json ]; then
+  protocol=${FM_FAKE_HERDR_PROTOCOL:-19}
+  printf '{"client":{"protocol":%s},"server":{"running":true,"protocol":%s}}\n' "$protocol" "$protocol"
+fi
+EOF
+chmod +x "$TMP/bin/herdr"
+export PATH="$TMP/bin:$PATH"
+export FM_FAKE_HERDR_LOG="$TMP/herdr.log"
+
+long='[fm-from-firstmate]'$'\u2063''corr=test '
+long+=$(printf 'x%.0s' $(seq 1 1000))
+long+=TAIL
+short='[fm-from-firstmate]'$'\u2063''corr=short SHORT-TAIL'
+
+run() {
+  FM_BACKEND_HERDR_SESSION=default FM_BACKEND_HERDR_PANE=w1:p2 \
+    bash -c '. "$1/bin/backends/herdr.sh"; fm_backend_herdr_send_text_submit "default:w1:p2" "$2" 2 0.01 0.01' _ "$ROOT" "$1"
+}
+
+out=$(run "$long")
+[ "$out" = empty ] || { echo "long send was not confirmed: $out" >&2; exit 1; }
+grep -F 'agent prompt w1:p2' "$FM_FAKE_HERDR_LOG" >/dev/null
+grep -F 'TAIL' "$FM_FAKE_HERDR_LOG" >/dev/null
+! grep -F 'pane send-text' "$FM_FAKE_HERDR_LOG" >/dev/null
+
+: > "$FM_FAKE_HERDR_LOG"
+export FM_FAKE_HERDR_PROTOCOL=16
+out=$(run "$long")
+[ "$out" = send-failed ] || { echo "old Herdr release was not failed closed: $out" >&2; exit 1; }
+! grep -F 'pane send-text' "$FM_FAKE_HERDR_LOG" >/dev/null
+
+: > "$FM_FAKE_HERDR_LOG"
+short_out=$(FM_BACKEND_HERDR_SESSION=default FM_BACKEND_HERDR_PANE=w1:p2 \
+  bash -c '. "$1/bin/backends/herdr.sh";
+    fm_backend_herdr_target_ready() { return 0; }
+    fm_backend_herdr_send_literal() { printf "pane send-text %s\\n" "$2" >> "$FM_FAKE_HERDR_LOG"; }
+    fm_backend_herdr_send_key() { return 0; }
+    fm_backend_herdr_agent_status_raw() { printf idle; }
+    fm_backend_herdr_wait_for_working() { printf busy; }
+    fm_backend_herdr_composer_state() { printf empty; }
+    fm_backend_herdr_send_text_submit "default:w1:p2" "$2" 2 0.01 0.01' _ "$ROOT" "$short")
+[ "$short_out" = empty ] || { echo "short resend was not confirmed: $short_out" >&2; exit 1; }
+grep -F 'SHORT-TAIL' "$FM_FAKE_HERDR_LOG" >/dev/null
+grep -F $'\u2063' "$FM_FAKE_HERDR_LOG" >/dev/null
+
+echo 'ok: Herdr long sends use atomic agent prompt without literal PTY insertion'

--- a/tests/fm-herdr-long-send.test.sh
+++ b/tests/fm-herdr-long-send.test.sh
@@ -58,4 +58,19 @@ short_out=$(FM_BACKEND_HERDR_SESSION=default FM_BACKEND_HERDR_PANE=w1:p2 \
 grep -F 'SHORT-TAIL' "$FM_FAKE_HERDR_LOG" >/dev/null
 grep -F $'\u2063' "$FM_FAKE_HERDR_LOG" >/dev/null
 
+: > "$FM_FAKE_HERDR_LOG"
+launch_like=$(printf 'x%.0s' $(seq 1 600))
+if FM_BACKEND_HERDR_SESSION=default FM_BACKEND_HERDR_PANE=w1:p2 \
+  bash -c '. "$1/bin/backends/herdr.sh"; fm_backend_herdr_send_literal "default:w1:p2" "$2"' _ "$ROOT" "$launch_like"; then
+  echo "general literal send was not failed closed for a realistic LAUNCH-sized (600 byte) message" >&2
+  exit 1
+fi
+! grep -F 'pane send-text' "$FM_FAKE_HERDR_LOG" >/dev/null
+
+: > "$FM_FAKE_HERDR_LOG"
+FM_BACKEND_HERDR_SESSION=default FM_BACKEND_HERDR_PANE=w1:p2 \
+  bash -c '. "$1/bin/backends/herdr.sh"; fm_backend_herdr_send_literal_command "default:w1:p2" "$2"' _ "$ROOT" "$launch_like"
+grep -F 'pane send-text w1:p2' "$FM_FAKE_HERDR_LOG" >/dev/null
+grep -F "$launch_like" "$FM_FAKE_HERDR_LOG" >/dev/null
+
 echo 'ok: Herdr long sends use atomic agent prompt without literal PTY insertion'


### PR DESCRIPTION
## Summary
- Reproduce and document Herdr Claude composer truncation where the tail arrived without the operational marker and beginning.
- Route long typed Herdr sends through atomic agent prompt on protocol 19+ and fail closed on unsupported releases.
- Keep pre-launch commands on the dedicated command primitive, and cover secondmate, ordinary typed sends, marker preservation, and shorter resend behavior.

## Validation
- bin/fm-lint.sh with pinned ShellCheck 0.11.0 and actionlint 1.7.12.
- Focused Herdr long-send, Herdr backend, and secondmate marker tests.
- Complete Firstmate validation suite passed locally.
- Herdr lab and live Claude counterfactuals preserved 2,000, 8,000, and 16,000-byte marker-bearing prompts atomically.

The no-mistakes review, test, and document gates passed; its configured upstream push was unavailable, so this branch was pushed to the authenticated fork for this PR.