### PR TITLE
fix(watcher): repair blank monitor identity records

### DIFF
--- a/bin/fm-claude-stop-autoarm.sh
+++ b/bin/fm-claude-stop-autoarm.sh
@@ -37,10 +37,10 @@
 #     benign when a live identity-matched watcher still has a fresh beacon.
 #   - Failure handling: a typed failure is rechecked against the same live,
 #     fresh watcher predicate and retried a bounded number of times in this
-#     hook. Only an exhausted failure with no verified watcher emits one
-#     last-resort notice per failure episode; later consecutive failures still
-#     exit 2 to guarantee the next Stop-owned retry without repeating notice,
-#     until the synchronous guard has consumed its attended fail-open.
+#     hook. Only an exhausted failure with no verified watcher emits the full
+#     last-resort notice once per failure episode; later consecutive failures
+#     still exit 2 with a compact retry banner, until the synchronous guard has
+#     consumed its attended fail-open.
 #
 # The epoch ledger state/.claude-autoarm-epoch records the latest claim and
 # outcome so the synchronous Stop guard (bin/fm-turnend-guard.sh --claude) can
@@ -51,7 +51,8 @@
 # suppresses any later automatic continuation in that unresolved episode.
 #
 # This hook never blocks the Stop decision itself and never prints to stdout:
-# exit 0 is always silent, and exit 2 carries the rewake banner on stderr.
+# exit 0 is always silent, and exit 2 always carries a rewake or retry banner on
+# stderr.
 # On any uncertainty such as unresolvable ancestry, malformed lock state, or
 # lock contention, it exits 0 and leaves continuity to the synchronous guard and
 # the model.
@@ -178,6 +179,14 @@ write_epoch() {  # <outcome>
 
 write_epoch arming
 
+retry_banner() {  # <summary> [captured-arm-output]
+  local summary=$1 out=${2:-}
+  {
+    printf 'firstmate watcher auto-arm retry - %s\n' "$summary"
+    [ -n "$out" ] && grep -E '^(watcher:|signal:|stale:|check:|heartbeat)' "$out" 2>/dev/null | head -8
+  } >&2
+}
+
 # X mode cadence: source the generated config so an X instance polls at its
 # 30s cadence (fm-bootstrap.sh x_mode_setup contract).
 # shellcheck source=/dev/null
@@ -245,6 +254,7 @@ if [ "$HEALTHY" -eq 1 ]; then
   write_epoch failed-suppressed
   [ -z "$OUT" ] || rm -f "$OUT" 2>/dev/null || true
   [ -e "$FAILURE_ALARM" ] && exit 0
+  retry_banner "a live watcher was verified, but stale failure markers could not be cleared yet."
   exit 2
 fi
 
@@ -282,5 +292,6 @@ if [ ! -e "$FAILURE_NOTICE" ]; then
   exit 2
 fi
 write_epoch failed-suppressed
+[ -e "$FAILURE_NOTICE" ] && retry_banner "the prior automatic supervision failure episode remains unresolved after $attempt bounded attempts." "$OUT"
 [ -z "$OUT" ] || rm -f "$OUT" 2>/dev/null || true
 exit 2

--- a/bin/fm-turnend-guard.sh
+++ b/bin/fm-turnend-guard.sh
@@ -160,6 +160,11 @@ budget_reset() {
   fm_lock_release "$BUDGET_LOCK"
 }
 
+reset_retry_banner() {
+  [ "$CLAUDE_MODE" -eq 1 ] || return 0
+  printf '%s\n' 'firstmate watcher recovery retry - a live watcher was verified, but stale failure markers could not be cleared yet.' >&2
+}
+
 fm_supervision_status "$STATE" "$GRACE"
 if [ "$FM_SUP_NEEDED" = false ]; then
   [ -e "$FAILURE_NOTICE" ] || budget_reset
@@ -168,6 +173,7 @@ fi
 if fm_watcher_healthy "$STATE" "$WATCH" "$GRACE" "$FM_HOME"; then
   [ "$CLAUDE_MODE" -eq 1 ] || exit 0
   fm_failure_episode_reset "$STATE" && exit 0
+  reset_retry_banner
   exit 2
 fi
 
@@ -377,7 +383,7 @@ i=0
 while [ "$i" -lt $((SYNC_WAIT_MS / 100)) ]; do
   if autoarm_owns_recovery; then
     if fm_watcher_healthy "$STATE" "$WATCH" "$GRACE" "$FM_HOME"; then
-      fm_failure_episode_reset "$STATE" || exit 2
+      fm_failure_episode_reset "$STATE" || { reset_retry_banner; exit 2; }
     fi
     exit 0
   fi
@@ -386,7 +392,7 @@ while [ "$i" -lt $((SYNC_WAIT_MS / 100)) ]; do
 done
 if autoarm_owns_recovery; then
   if fm_watcher_healthy "$STATE" "$WATCH" "$GRACE" "$FM_HOME"; then
-    fm_failure_episode_reset "$STATE" || exit 2
+    fm_failure_episode_reset "$STATE" || { reset_retry_banner; exit 2; }
   fi
   exit 0
 fi

--- a/bin/fm-wake-lib.sh
+++ b/bin/fm-wake-lib.sh
@@ -19,6 +19,28 @@ fm_current_pid() {
   printf '%s\n' "${BASHPID:-$$}"
 }
 
+FM_LOCK_CURRENT_PID=
+FM_LOCK_CURRENT_TOKEN=
+fm_lock_current_owner_set() {
+  FM_LOCK_CURRENT_PID=${BASHPID:-$$}
+  FM_LOCK_CURRENT_TOKEN="$FM_LOCK_CURRENT_PID:${BASH_SUBSHELL:-0}"
+}
+
+fm_lock_owner_matches_current() {
+  local ownerdir=$1 pid token
+  fm_lock_current_owner_set
+  pid=$(cat "$ownerdir/pid" 2>/dev/null || true)
+  [ "$pid" = "$FM_LOCK_CURRENT_PID" ] || return 1
+  token=$(cat "$ownerdir/owner-token" 2>/dev/null || true)
+  if [ -n "$token" ]; then
+    [ "$token" = "$FM_LOCK_CURRENT_TOKEN" ]
+    return
+  fi
+  # Legacy locks recorded only $$ on Bash 3. In a subshell $$ still names the
+  # parent shell, so a child must not reclaim or release a parent-owned old lock.
+  [ -n "${BASHPID+x}" ] || [ "${BASH_SUBSHELL:-0}" = 0 ]
+}
+
 fm_pid_alive() {
   local pid=$1
   case "$pid" in
@@ -64,6 +86,34 @@ fm_pid_identity() {
   printf '%s\n' "$out" | sed 's/^[[:space:]]*//'
 }
 
+fm_pid_identity_retry() {  # <pid> [attempts] [delay-seconds]
+  local pid=$1 attempts=${2:-5} delay=${3:-0.05} identity i=0
+  while [ "$i" -lt "$attempts" ]; do
+    identity=$(fm_pid_identity "$pid" 2>/dev/null) && [ -n "$identity" ] && {
+      printf '%s\n' "$identity"
+      return 0
+    }
+    i=$((i + 1))
+    [ "$i" -lt "$attempts" ] || break
+    sleep "$delay" 2>/dev/null || sleep 1
+  done
+  return 1
+}
+
+fm_pid_identity_mentions_path() {  # <identity> <path>
+  local identity=$1 path=$2 path_hex
+  [ -n "$identity" ] && [ -n "$path" ] || return 1
+  case "$identity" in
+    *"$path"*) return 0 ;;
+  esac
+  path_hex=$(printf '%s' "$path" | od -An -v -tx1 2>/dev/null | tr -d '[:space:]') || return 1
+  [ -n "$path_hex" ] || return 1
+  case "$identity" in
+    *"cmdline-hex="*"$path_hex"*) return 0 ;;
+  esac
+  return 1
+}
+
 fm_path_mtime() {
   if [ "$_FM_UNAME" = Darwin ]; then
     stat -f %m "$1" 2>/dev/null
@@ -92,6 +142,53 @@ fm_watcher_lock_unheld() {
 }
 
 FM_WATCHER_MATCHED_IDENTITY=
+fm_watcher_lock_repair_blank_identity() {
+  local state=$1 watch_path=$2 pid=$3 home=${4:-$FM_HOME}
+  local lockdir repair_lock lock_pid lock_home lock_path lock_identity identity tmp back
+  lockdir="$state/.watch.lock"
+  repair_lock="$state/.watch.lock.identity-repair"
+  fm_lock_try_acquire "$repair_lock" || return 1
+  lock_pid=$(cat "$lockdir/pid" 2>/dev/null || true)
+  lock_home=$(cat "$lockdir/fm-home" 2>/dev/null || true)
+  lock_path=$(cat "$lockdir/watcher-path" 2>/dev/null || true)
+  lock_identity=$(cat "$lockdir/pid-identity" 2>/dev/null || true)
+  if [ "$lock_pid" != "$pid" ] || [ "$lock_home" != "$home" ] \
+    || [ "$lock_path" != "$watch_path" ] || [ -n "$lock_identity" ] \
+    || [ ! -f "$lockdir/pid-identity" ]; then
+    fm_lock_release "$repair_lock"
+    return 1
+  fi
+  identity=$(fm_pid_identity_retry "$pid") || {
+    fm_lock_release "$repair_lock"
+    return 1
+  }
+  if ! fm_pid_identity_mentions_path "$identity" "$watch_path"; then
+    fm_lock_release "$repair_lock"
+    return 1
+  fi
+  lock_pid=$(cat "$lockdir/pid" 2>/dev/null || true)
+  lock_home=$(cat "$lockdir/fm-home" 2>/dev/null || true)
+  lock_path=$(cat "$lockdir/watcher-path" 2>/dev/null || true)
+  lock_identity=$(cat "$lockdir/pid-identity" 2>/dev/null || true)
+  if [ "$lock_pid" != "$pid" ] || [ "$lock_home" != "$home" ] \
+    || [ "$lock_path" != "$watch_path" ] || [ -n "$lock_identity" ]; then
+    fm_lock_release "$repair_lock"
+    return 1
+  fi
+  tmp="$state/.watch.pid-identity.$$"
+  if ! printf '%s\n' "$identity" > "$tmp" 2>/dev/null \
+    || ! mv -f "$tmp" "$lockdir/pid-identity" 2>/dev/null; then
+    rm -f "$tmp" 2>/dev/null || true
+    fm_lock_release "$repair_lock"
+    return 1
+  fi
+  rm -f "$tmp" 2>/dev/null || true
+  back=$(cat "$lockdir/pid-identity" 2>/dev/null || true)
+  fm_lock_release "$repair_lock"
+  [ "$back" = "$identity" ] || return 1
+  printf '%s\n' "$identity"
+}
+
 fm_watcher_lock_matches_pid() {
   local state=$1 watch_path=$2 pid=$3 home=${4:-$FM_HOME} lockdir lock_home lock_path lock_identity current_identity
   FM_WATCHER_MATCHED_IDENTITY=
@@ -101,8 +198,10 @@ fm_watcher_lock_matches_pid() {
   lock_identity=$(cat "$lockdir/pid-identity" 2>/dev/null || true)
   [ "$lock_home" = "$home" ] || return 1
   [ "$lock_path" = "$watch_path" ] || return 1
-  [ -n "$lock_identity" ] || return 1
-  current_identity=$(fm_pid_identity "$pid") || return 1
+  if [ -z "$lock_identity" ]; then
+    lock_identity=$(fm_watcher_lock_repair_blank_identity "$state" "$watch_path" "$pid" "$home") || return 1
+  fi
+  current_identity=$(fm_pid_identity_retry "$pid") || return 1
   [ "$current_identity" = "$lock_identity" ] || return 1
   FM_WATCHER_MATCHED_IDENTITY=$lock_identity
 }
@@ -129,14 +228,17 @@ fm_watcher_healthy() {
 }
 
 # fm_watcher_healthy above is the PID-STRICT primitive: true only when a live,
-# identity-matched watcher PROCESS holds this home's lock with a fresh beacon. The
-# arm layer (bin/fm-watch-arm.sh, bin/fm-claude-stop-autoarm.sh) needs exactly
-# that - it decides whether to start, attach to, or replace a real watcher
-# process, so a leftover beacon must never satisfy it. bin/fm-turnend-guard.sh
-# also keeps this strict check because it fires at the turn boundary where the
-# auto-arm brings a fresh watcher up. The pull warning (bin/fm-guard.sh) fires
-# mid-turn, where the auto-arm model runs no watcher at all, so it wants a
-# different, model-aware question:
+# identity-matched watcher PROCESS holds this home's lock with a fresh beacon.
+# A blank pid-identity record is repaired only by capturing a real identity
+# whose command line names this watcher path, then writing and re-reading that
+# identity for the same live pid, fm-home, and watcher-path before the match is
+# accepted. The arm layer (bin/fm-watch-arm.sh,
+# bin/fm-claude-stop-autoarm.sh) needs exactly that - it decides whether to
+# start, attach to, or replace a real watcher process, so a leftover beacon must
+# never satisfy it. bin/fm-turnend-guard.sh also keeps this strict check because
+# it fires at the turn boundary where the auto-arm brings a fresh watcher up. The
+# pull warning (bin/fm-guard.sh) fires mid-turn, where the auto-arm model runs no
+# watcher at all, so it wants a different, model-aware question:
 
 # fm_supervision_model
 # Print the supervision model of this home's PRIMARY harness:
@@ -290,6 +392,7 @@ fm_lock_clean_known_files() {
   rm -f \
     "$lockdir/pid" \
     "$lockdir/fm-home" \
+    "$lockdir/owner-token" \
     "$lockdir/pid-identity" \
     "$lockdir/role" \
     "$lockdir/watcher-path" \
@@ -297,14 +400,12 @@ fm_lock_clean_known_files() {
 }
 
 fm_lock_set_role() {
-  local lockdir=$1 role=$2 current pid back
+  local lockdir=$1 role=$2 back
   case "$role" in
     autoarm|terminal-check) : ;;
     *) return 1 ;;
   esac
-  current=${BASHPID:-$$}
-  pid=$(cat "$lockdir/pid" 2>/dev/null || true)
-  [ "$pid" = "$current" ] || return 1
+  fm_lock_owner_matches_current "$lockdir" || return 1
   printf '%s\n' "$role" > "$lockdir/role" 2>/dev/null || return 1
   back=$(cat "$lockdir/role" 2>/dev/null || true)
   [ "$back" = "$role" ]
@@ -322,6 +423,30 @@ fm_lock_abs_path() {
   printf '%s/%s\n' "$dir" "$base"
 }
 
+fm_lock_normalize_owner_path() {
+  local ownerdir=$1 owner_parent owner_base
+  [ -n "$ownerdir" ] || return 1
+  owner_parent=$(dirname "$ownerdir")
+  owner_base=$(basename "$ownerdir")
+  owner_parent=$(cd "$owner_parent" 2>/dev/null && pwd -P) || return 1
+  printf '%s/%s\n' "$owner_parent" "$owner_base"
+}
+
+fm_lock_owner_dir_belongs_to_lock() {
+  local lockdir=$1 ownerdir=$2 lock_abs owner_abs
+  [ -n "$ownerdir" ] || return 1
+  lock_abs=$(fm_lock_abs_path "$lockdir") || return 1
+  case "$ownerdir" in
+    /*) owner_abs=$ownerdir ;;
+    *) owner_abs="$(dirname "$lockdir")/$ownerdir" ;;
+  esac
+  owner_abs=$(fm_lock_normalize_owner_path "$owner_abs") || return 1
+  case "$owner_abs" in
+    "$lock_abs".owner.*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 fm_lock_owner_dir() {
   local lockdir=$1 lock_abs
   lock_abs=$(fm_lock_abs_path "$lockdir") || return 1
@@ -329,11 +454,15 @@ fm_lock_owner_dir() {
 }
 
 fm_lock_prepare_owner() {
-  local ownerdir=$1 mypid back
-  mypid=${BASHPID:-$$}
+  local ownerdir=$1 mypid token back back_token
+  fm_lock_current_owner_set
+  mypid=$FM_LOCK_CURRENT_PID
+  token=$FM_LOCK_CURRENT_TOKEN
   printf '%s\n' "$mypid" > "$ownerdir/pid" 2>/dev/null || return 1
+  printf '%s\n' "$token" > "$ownerdir/owner-token" 2>/dev/null || return 1
   back=$(cat "$ownerdir/pid" 2>/dev/null || true)
-  [ "$back" = "$mypid" ]
+  back_token=$(cat "$ownerdir/owner-token" 2>/dev/null || true)
+  [ "$back" = "$mypid" ] && [ "$back_token" = "$token" ]
 }
 
 fm_lock_link_owner() {
@@ -346,6 +475,20 @@ fm_lock_link_owner() {
   esac
 }
 
+fm_lock_owner_dir_referenced() {
+  local lockdir=$1 ownerdir=$2 lock_abs parent path target owner_norm
+  lock_abs=$(fm_lock_abs_path "$lockdir") || return 1
+  owner_norm=$(fm_lock_normalize_owner_path "$ownerdir") || return 1
+  parent=$(dirname "$lock_abs")
+  for path in "$parent"/* "$parent"/.[!.]* "$parent"/..?*; do
+    [ -L "$path" ] || continue
+    target=$(fm_lock_link_owner "$path" 2>/dev/null || true)
+    target=$(fm_lock_normalize_owner_path "$target" 2>/dev/null) || continue
+    [ "$target" = "$owner_norm" ] && return 0
+  done
+  return 1
+}
+
 fm_lock_points_to_owner() {
   local lockdir=$1 ownerdir=$2 actual
   actual=$(readlink "$lockdir" 2>/dev/null) || return 1
@@ -353,10 +496,44 @@ fm_lock_points_to_owner() {
 }
 
 fm_lock_discard_owner() {
-  local ownerdir=$1
+  local ownerdir=$1 stray
   [ -n "$ownerdir" ] || return 0
+  for stray in "$ownerdir"/*.owner.* "$ownerdir"/.*.owner.*; do
+    [ -L "$stray" ] || continue
+    rm -f "$stray" 2>/dev/null || true
+  done
   fm_lock_clean_known_files "$ownerdir"
   rmdir "$ownerdir" 2>/dev/null || true
+}
+
+fm_lock_cleanup_orphan_owner_dirs() {
+  local lockdir=$1 lock_abs parent base current_owner current_owner_norm candidate stale_after age owner_pid
+  lock_abs=$(fm_lock_abs_path "$lockdir") || return 0
+  parent=$(dirname "$lock_abs")
+  base=$(basename "$lock_abs")
+  current_owner=
+  current_owner_norm=
+  if [ -L "$lockdir" ]; then
+    current_owner=$(fm_lock_link_owner "$lockdir" 2>/dev/null || true)
+    current_owner_norm=$(fm_lock_normalize_owner_path "$current_owner" 2>/dev/null || true)
+  fi
+  stale_after=${FM_LOCK_STALE_AFTER:-2}
+  case "$stale_after" in
+    ''|*[!0-9]*) stale_after=2 ;;
+  esac
+  [ "$stale_after" -lt 2 ] && stale_after=2
+  for candidate in "$parent/$base".owner.*; do
+    [ -d "$candidate" ] && [ ! -L "$candidate" ] || continue
+    fm_lock_owner_dir_belongs_to_lock "$lockdir" "$candidate" || continue
+    [ -z "$current_owner_norm" ] || [ "$(fm_lock_normalize_owner_path "$candidate" 2>/dev/null || true)" != "$current_owner_norm" ] || continue
+    fm_lock_owner_dir_referenced "$lockdir" "$candidate" && continue
+    owner_pid=$(cat "$candidate/pid" 2>/dev/null || true)
+    ! fm_pid_alive "$owner_pid" || continue
+    age=$(fm_path_age "$candidate")
+    [ "$age" -ge "$stale_after" ] || continue
+    fm_lock_discard_owner "$candidate"
+  done
+  return 0
 }
 
 fm_lock_remove_stray_owner_link() {
@@ -378,14 +555,21 @@ fm_lock_claim_blocked_by_steal() {
 }
 
 fm_lock_claim() {
-  local lockdir=$1 ownerdir=$2 allowed_steal_owner=${3:-} mypid back
-  mypid=${BASHPID:-$$}
+  local lockdir=$1 ownerdir=$2 allowed_steal_owner=${3:-} mypid token back back_token
+  fm_lock_current_owner_set
+  mypid=$FM_LOCK_CURRENT_PID
+  token=$FM_LOCK_CURRENT_TOKEN
   if ! { printf '%s\n' "$mypid" > "$ownerdir/pid"; } 2>/dev/null; then
     fm_lock_discard_owner "$ownerdir"
     return 1
   fi
+  if ! { printf '%s\n' "$token" > "$ownerdir/owner-token"; } 2>/dev/null; then
+    fm_lock_discard_owner "$ownerdir"
+    return 1
+  fi
   back=$(cat "$ownerdir/pid" 2>/dev/null || true)
-  if [ "$back" != "$mypid" ]; then
+  back_token=$(cat "$ownerdir/owner-token" 2>/dev/null || true)
+  if [ "$back" != "$mypid" ] || [ "$back_token" != "$token" ]; then
     fm_lock_discard_owner "$ownerdir"
     return 1
   fi
@@ -431,15 +615,20 @@ fm_lock_try_create() {
 }
 
 fm_lock_remove_path() {
-  local lockdir=$1 ownerdir
+  local lockdir=$1 ownerdir rc
   if [ -L "$lockdir" ]; then
     ownerdir=$(fm_lock_link_owner "$lockdir" 2>/dev/null || true)
     rm -f "$lockdir" 2>/dev/null || return 1
-    [ -n "$ownerdir" ] && fm_lock_discard_owner "$ownerdir"
+    [ -n "$ownerdir" ] && fm_lock_owner_dir_belongs_to_lock "$lockdir" "$ownerdir" \
+      && fm_lock_discard_owner "$ownerdir"
+    fm_lock_cleanup_orphan_owner_dirs "$lockdir" || true
     return 0
   fi
   fm_lock_clean_known_files "$lockdir"
   rmdir "$lockdir" 2>/dev/null
+  rc=$?
+  fm_lock_cleanup_orphan_owner_dirs "$lockdir" || true
+  return "$rc"
 }
 
 fm_lock_mid_acquire_is_fresh() {
@@ -792,10 +981,12 @@ fm_lock_try_acquire() {
     return 0
   fi
 
-  # Compare against ${BASHPID:-$$} inline, never via a command substitution:
-  # $() forks a subshell whose BASHPID is not this frame's pid.
+  # Compare against this shell frame, not a command substitution. On Bash 3, $$
+  # still names the parent shell inside a subshell, so the owner-token keeps a
+  # child from reclaiming its parent's live lock while preserving same-frame
+  # trap recovery.
   pid=$(cat "$lockdir/pid" 2>/dev/null || true)
-  if [ -n "$pid" ] && [ "$pid" = "${BASHPID:-$$}" ]; then
+  if [ -n "$pid" ] && fm_lock_owner_matches_current "$lockdir"; then
     # The recorded holder is THIS very process. Single-threaded bash can only
     # observe that when an interrupting trap abandoned the frame that held the
     # lock mid-critical-section (e.g. TERM inside a recovery-marker section,
@@ -891,22 +1082,28 @@ fm_lock_acquire_wait() {
 }
 
 fm_lock_release() {
-  local lockdir=$1 pid current ownerdir
-  current=${BASHPID:-$$}
+  local lockdir=$1 ownerdir
   if [ -L "$lockdir" ]; then
     ownerdir=$(fm_lock_link_owner "$lockdir" 2>/dev/null || true)
     [ -n "$ownerdir" ] || return 0
-    pid=$(cat "$ownerdir/pid" 2>/dev/null || true)
-    [ "$pid" = "$current" ] || return 0
+    if [ ! -e "$ownerdir" ]; then
+      fm_lock_owner_dir_belongs_to_lock "$lockdir" "$ownerdir" \
+        && rm -f "$lockdir" 2>/dev/null || true
+      fm_lock_cleanup_orphan_owner_dirs "$lockdir" || true
+      return 0
+    fi
+    fm_lock_owner_matches_current "$ownerdir" || return 0
     fm_lock_points_to_owner "$lockdir" "$ownerdir" || return 0
     rm -f "$lockdir" 2>/dev/null || return 0
-    fm_lock_discard_owner "$ownerdir"
+    fm_lock_owner_dir_belongs_to_lock "$lockdir" "$ownerdir" \
+      && fm_lock_discard_owner "$ownerdir"
+    fm_lock_cleanup_orphan_owner_dirs "$lockdir" || true
     return 0
   fi
-  pid=$(cat "$lockdir/pid" 2>/dev/null || true)
-  [ "$pid" = "$current" ] || return 0
+  fm_lock_owner_matches_current "$lockdir" || return 0
   fm_lock_clean_known_files "$lockdir"
   rmdir "$lockdir" 2>/dev/null || true
+  fm_lock_cleanup_orphan_owner_dirs "$lockdir" || true
 }
 
 fm_meta_lock_path() {
@@ -954,9 +1151,7 @@ fm_failure_episode_reset() {
       acquired=1
       ;;
     held)
-      current=${BASHPID:-$$}
-      pid=$(cat "$lock/pid" 2>/dev/null || true)
-      [ "$pid" = "$current" ] || return 1
+      fm_lock_owner_matches_current "$lock" || return 1
       ;;
     *) return 1 ;;
   esac
@@ -1046,18 +1241,18 @@ _fm_autoarm_epoch_field() {  # <epoch-file> <field>
 # identity file behind, so a partial write can never read as a mismatch against
 # its own live owner. Call it before publishing the auto-arm role.
 fm_autoarm_claim_record_identity() {  # <state-dir>
-  local state=$1 lock pid held identity back
+  local state=$1 lock pid identity back
   lock="$state/.claude-autoarm.lock"
-  # Resolve the pid into a variable FIRST: expanding ${BASHPID:-$$} inside the
-  # command substitution below would resolve it in that subshell, recording the
-  # identity of a process that exits immediately and leaving every later reader
-  # with a permanent mismatch against the real owner.
-  pid=${BASHPID:-$$}
+  # Resolve the pid into a variable FIRST in this shell frame: expanding a pid
+  # expression inside the command substitution below would resolve it in that
+  # subshell, recording the identity of a process that exits immediately and
+  # leaving every later reader with a permanent mismatch against the real owner.
+  fm_lock_current_owner_set
+  pid=$FM_LOCK_CURRENT_PID
   # The identity must describe the pid the lock publishes, so record it only for a
   # lock this process actually holds (the same ownership test as fm_lock_set_role).
-  held=$(cat "$lock/pid" 2>/dev/null || true)
-  [ "$held" = "$pid" ] || return 1
-  identity=$(fm_pid_identity "$pid" 2>/dev/null) || return 1
+  fm_lock_owner_matches_current "$lock" || return 1
+  identity=$(fm_pid_identity_retry "$pid") || return 1
   [ -n "$identity" ] || return 1
   if ! printf '%s\n' "$identity" > "$lock/pid-identity" 2>/dev/null; then
     rm -f "$lock/pid-identity" 2>/dev/null || true

--- a/bin/fm-watch-checkpoint.sh
+++ b/bin/fm-watch-checkpoint.sh
@@ -4,7 +4,10 @@
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bin/fm-wake-lib.sh
+. "$SCRIPT_DIR/fm-wake-lib.sh"
 SECONDS_ARG=${FM_CODEX_WATCH_CHECKPOINT:-180}
+TERM_GRACE=${FM_WATCH_CHECKPOINT_TERM_GRACE:-2}
 
 usage() {
   cat <<'EOF'
@@ -43,6 +46,10 @@ case "$SECONDS_ARG" in
   ''|*[!0-9]*) echo "error: --seconds must be a positive integer" >&2; exit 2 ;;
   0) echo "error: --seconds must be greater than zero" >&2; exit 2 ;;
 esac
+case "$TERM_GRACE" in
+  ''|*[!0-9]*) echo "error: FM_WATCH_CHECKPOINT_TERM_GRACE must be a positive integer" >&2; exit 2 ;;
+  0) echo "error: FM_WATCH_CHECKPOINT_TERM_GRACE must be greater than zero" >&2; exit 2 ;;
+esac
 
 OUT=$(mktemp "${TMPDIR:-/tmp}/fm-watch-checkpoint.out.XXXXXX") || exit 1
 ERR=$(mktemp "${TMPDIR:-/tmp}/fm-watch-checkpoint.err.XXXXXX") || {
@@ -54,6 +61,7 @@ trap 'rm -f "$OUT" "$ERR"' EXIT
 run_with_perl_timeout() {
   perl -e '
     my $seconds = shift;
+    my $term_grace = shift;
     my $pid = fork;
     die "fork failed\n" unless defined $pid;
     if (!$pid) {
@@ -63,14 +71,34 @@ run_with_perl_timeout() {
     }
     local $SIG{ALRM} = sub {
       kill "TERM", -$pid;
-      select undef, undef, undef, 0.2;
+      my $deadline = time + $term_grace;
+      while (time < $deadline) {
+        my $done = waitpid $pid, 1;
+        exit 124 if $done == $pid;
+        select undef, undef, undef, 0.05;
+      }
       kill "KILL", -$pid;
+      waitpid $pid, 0;
       exit 124;
     };
     alarm $seconds;
     waitpid $pid, 0;
     exit($? >> 8);
-  ' "$SECONDS_ARG" "$SCRIPT_DIR/fm-watch.sh"
+  ' "$SECONDS_ARG" "$TERM_GRACE" "$SCRIPT_DIR/fm-watch.sh"
+}
+
+cleanup_timed_out_watcher_lock() {
+  local lock pid lock_home lock_path
+  lock="$STATE/.watch.lock"
+  [ -e "$lock" ] || [ -L "$lock" ] || return 0
+  pid=$(cat "$lock/pid" 2>/dev/null || true)
+  [ -n "$pid" ] || return 0
+  fm_pid_alive "$pid" && return 0
+  lock_home=$(cat "$lock/fm-home" 2>/dev/null || true)
+  lock_path=$(cat "$lock/watcher-path" 2>/dev/null || true)
+  [ -z "$lock_home" ] || [ "$lock_home" = "$FM_HOME" ] || return 0
+  [ -z "$lock_path" ] || [ "$lock_path" = "$SCRIPT_DIR/fm-watch.sh" ] || return 0
+  fm_lock_remove_path "$lock" || true
 }
 
 set +e
@@ -100,6 +128,7 @@ if grep -E '^watcher: already running' "$OUT" "$ERR" >/dev/null 2>&1; then
 fi
 
 if [ "$RC" -eq 124 ]; then
+  cleanup_timed_out_watcher_lock
   printf 'checkpoint: no actionable wake within %ss\n' "$SECONDS_ARG"
   exit 124
 fi

--- a/bin/fm-watch.sh
+++ b/bin/fm-watch.sh
@@ -1079,12 +1079,23 @@ trap 'exit 1' HUP INT TERM
 # ${BASHPID:-$$} from this same main shell). Read directly, never via a command
 # substitution, so it matches the stored holder pid for the self-eviction check.
 WATCHER_PID=${BASHPID:-$$}
-printf '%s\n' "$FM_HOME" > "$WATCH_LOCK/fm-home" || true
-printf '%s\n' "$WATCH_PATH" > "$WATCH_LOCK/watcher-path" || true
+if ! printf '%s\n' "$FM_HOME" > "$WATCH_LOCK/fm-home" \
+  || ! printf '%s\n' "$WATCH_PATH" > "$WATCH_LOCK/watcher-path"; then
+  echo "watcher: could not publish watcher lock ownership metadata" >&2
+  exit 1
+fi
 # shellcheck disable=SC2034 # Consumed by wake() in the separately linted transition owner.
 FM_WATCH_DELIVERY_PID=$WATCHER_PID
-FM_WATCH_DELIVERY_IDENTITY=$(fm_pid_identity "$WATCHER_PID" 2>/dev/null || true)
-printf '%s\n' "$FM_WATCH_DELIVERY_IDENTITY" > "$WATCH_LOCK/pid-identity" 2>/dev/null || true
+if ! FM_WATCH_DELIVERY_IDENTITY=$(fm_pid_identity_retry "$WATCHER_PID"); then
+  echo "watcher: could not record pid identity for $WATCHER_PID; refusing to publish an invisible watcher lock" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$FM_WATCH_DELIVERY_IDENTITY" > "$WATCH_LOCK/pid-identity" 2>/dev/null \
+  || [ "$(cat "$WATCH_LOCK/pid-identity" 2>/dev/null || true)" != "$FM_WATCH_DELIVERY_IDENTITY" ]; then
+  rm -f "$WATCH_LOCK/pid-identity" 2>/dev/null || true
+  echo "watcher: could not verify watcher lock pid identity publication" >&2
+  exit 1
+fi
 
 [ -e "$STATE/.last-heartbeat" ] || touch "$STATE/.last-heartbeat"
 

--- a/tests/fm-claude-stop-autoarm.test.sh
+++ b/tests/fm-claude-stop-autoarm.test.sh
@@ -163,6 +163,22 @@ watcher_identity() {
   FM_STATE_OVERRIDE="$dir/state" bash -c '. "$1"; fm_pid_identity "$2"' _ "$dir/bin/fm-wake-lib.sh" "$pid"
 }
 
+start_path_named_watcher_holder() {
+  local dir=$1 script_path
+  STARTED_WATCHER_PID=
+  script_path=$(cd "$dir/bin" && pwd)/fm-watch.sh
+  cat > "$script_path" <<'SH'
+#!/usr/bin/env bash
+trap 'exit 0' TERM INT
+while :; do
+  sleep 1
+done
+SH
+  chmod +x "$script_path"
+  "$script_path" >/dev/null 2>&1 &
+  STARTED_WATCHER_PID=$!
+}
+
 record_watcher_lock() {
   local dir=$1 pid=$2 identity=$3 root bin_dir
   root=$dir
@@ -402,7 +418,8 @@ test_failed_cycles_notify_once_and_keep_retrying() {
   expect_code 2 "$status1" "the first exhausted failure must notify"
   expect_code 2 "$status2" "a consecutive exhausted failure must force another Stop-owned retry"
   [ -n "$out1" ] || fail "the first exhausted failure did not notify"
-  [ -z "$out2" ] || fail "consecutive exhausted failure repeated an operator notice: $out2"
+  assert_contains "$out2" "firstmate watcher auto-arm retry" "consecutive exhausted failure must carry a compact retry banner"
+  assert_not_contains "$out2" "automatic supervision mechanism is broken" "consecutive exhausted failure repeated the full operator notice"
   [ "$(wc -l < "$dir/state/arm-ran" | tr -d ' ')" -eq 4 ] || fail "each cycle must retain bounded automatic retries"
   assert_present "$dir/state/.claude-autoarm-failure-notified" "failure episode marker was not recorded"
   [ "$(epoch_outcome "$dir")" = failed-suppressed ] || fail "second failure must record failed-suppressed"
@@ -467,6 +484,39 @@ test_benign_cycle_end_with_live_watcher_is_silent() {
   pass "auto-arm: benign cycle end with a live watcher and fresh beacon stays silent across the next cycle"
 }
 
+test_blank_identity_live_watcher_clears_stuck_failure_episode() {
+  local dir out1 out2 status1 status2 pid repaired
+  dir=$(make_primary_dir "$TMP_ROOT/blank-identity-live")
+  : > "$dir/state/task.meta"
+  write_arm_fixture "$dir" benign-live
+  start_path_named_watcher_holder "$dir"
+  pid=$STARTED_WATCHER_PID
+  record_watcher_lock "$dir" "$pid" ""
+  : > "$dir/state/.watch.lock/pid-identity"
+  touch "$dir/state/.last-watcher-beat"
+  printf 'session=sess-autoarm\ncount=3\nepoch=9\n' > "$dir/state/.turnend-claude-blocks"
+  : > "$dir/state/.claude-autoarm-failure-notified"
+
+  out1=$(run_autoarm "$dir" 2>/dev/null); status1=$?
+  out2=$(run_autoarm "$dir" 2>/dev/null); status2=$?
+  repaired=$(cat "$dir/state/.watch.lock/pid-identity" 2>/dev/null || true)
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+
+  if [ "$status1" -eq 2 ] && [ -z "$out1" ] \
+    && [ "$status2" -eq 2 ] && [ -z "$out2" ]; then
+    fail "blank pid-identity incumbent reproduced a repeated blank exit-2 autoarm loop"
+  fi
+  expect_code 0 "$status1" "first autoarm turn must accept the matching live watcher and clear stale failure state"
+  expect_code 0 "$status2" "next autoarm turn must stay quiet after stale failure state is cleared"
+  [ -z "$out1" ] || fail "first healthy blank-identity autoarm produced output: $out1"
+  [ -z "$out2" ] || fail "next healthy blank-identity autoarm produced output: $out2"
+  [ -n "$repaired" ] || fail "healthy blank-identity autoarm did not repair the watcher pid identity"
+  assert_absent "$dir/state/.turnend-claude-blocks" "blank-identity recovery left the block budget"
+  assert_absent "$dir/state/.claude-autoarm-failure-notified" "blank-identity recovery left the failure notice marker"
+  pass "auto-arm: blank-identity live watcher clears stale failure state instead of looping with blank exit 2"
+}
+
 test_positive_recovery_budget_contention_preserves_episode() {
   local dir out status pid identity holder
   dir=$(make_primary_dir "$TMP_ROOT/recovery-budget-contention")
@@ -485,7 +535,8 @@ test_positive_recovery_budget_contention_preserves_episode() {
   printf '%s\n' "$holder" > "$dir/state/.turnend-claude-blocks.lock/pid"
   out=$(run_autoarm "$dir" 2>/dev/null); status=$?
   expect_code 2 "$status" "a healthy auto-arm must continue when the episode reset lock is busy"
-  [ -z "$out" ] || fail "recovery contention produced an operator notice: $out"
+  assert_contains "$out" "firstmate watcher auto-arm retry" "recovery contention must carry a compact retry banner"
+  assert_not_contains "$out" "automatic supervision mechanism is broken" "recovery contention repeated the full operator notice"
   [ "$(epoch_outcome "$dir")" = failed-suppressed ] || fail "recovery contention must not record ordinary clean recovery"
   assert_present "$dir/state/.turnend-claude-blocks" "recovery contention partially cleared the block budget"
   assert_present "$dir/state/.claude-autoarm-failure-notified" "recovery contention partially cleared the failure notice"
@@ -801,6 +852,7 @@ test_failed_cycles_notify_once_and_keep_retrying
 test_unverified_clean_close_exhausts_retries
 test_post_alarm_actionable_close_is_suppressed
 test_benign_cycle_end_with_live_watcher_is_silent
+test_blank_identity_live_watcher_clears_stuck_failure_episode
 test_positive_recovery_budget_contention_preserves_episode
 test_arms_for_x_mode_poll_need_without_inflight
 test_single_flight_admits_exactly_one_owner

--- a/tests/fm-turnend-guard.test.sh
+++ b/tests/fm-turnend-guard.test.sh
@@ -1415,7 +1415,8 @@ test_hook_claude_mode_integrated_monotonic_fail_open() {
   for i in 1 2 3 4; do
     out=$(run_integrated_autoarm "$dir"); status=$?
     expect_code 2 "$status" "failed epoch $i must retain the automatic retry handoff"
-    [ -z "$out" ] || fail "failed epoch $i repeated the operator notice: $out"
+    assert_contains "$out" "firstmate watcher auto-arm retry" "failed epoch $i must carry a compact retry banner"
+    assert_not_contains "$out" "automatic supervision mechanism is broken" "failed epoch $i repeated the full operator notice"
     guard_out=$(FM_CLAUDE_AUTOARM_SYNC_WAIT_MS=100 run_hook_claude "$dir" true); guard_status=$?
     if [ "$i" -lt 4 ]; then
       expect_code 2 "$guard_status" "failed epoch $i must consume a bounded blind-stop block"
@@ -1480,7 +1481,7 @@ test_hook_claude_mode_recovery_contention_is_not_ordinary_allow() {
   printf '%s\n' "$holder" > "$dir/state/.turnend-claude-blocks.lock/pid"
   out=$(run_hook_claude "$dir" false); status=$?
   expect_code 2 "$status" "a healthy guard must continue when the episode reset lock is busy"
-  [ -z "$out" ] || fail "guard recovery contention produced output: $out"
+  assert_contains "$out" "firstmate watcher recovery retry" "guard recovery contention must carry a compact retry banner"
   assert_present "$dir/state/.turnend-claude-blocks" "guard contention partially cleared the block budget"
   assert_present "$dir/state/.claude-autoarm-failure-notified" "guard contention partially cleared the failure notice"
   assert_present "$dir/state/.claude-autoarm-failure-alarmed" "guard contention partially cleared the attended alarm"

--- a/tests/fm-watch-arm.test.sh
+++ b/tests/fm-watch-arm.test.sh
@@ -241,6 +241,37 @@ test_attached_arm_still_fails_on_a_wake_it_did_not_deliver() {
   pass "watch-arm: a cycle that delivered no wake of its own still fails loudly"
 }
 
+test_restart_arm_survives_quiet_tracked_background_startup() {
+  local dir home state fakebin armout status watcher_pid
+  dir=$(make_case restart-arm-survival)
+  home="$dir/home"
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  armout="$dir/arm.out"
+  mkdir -p "$home/data"
+
+  start_rearm_arm "$home" "$state" "$fakebin" "$armout"
+  watcher_pid=$(sed -n 's/^watcher: started pid=\([0-9][0-9]*\).*$/\1/p' "$armout")
+  [ -n "$watcher_pid" ] \
+    || fail "tracked restart arm did not report its watcher pid: $(cat "$armout" 2>/dev/null || true)"
+
+  sleep 1.2
+  is_live_non_zombie "$ARM_PID" \
+    || fail "tracked restart arm completed immediately after startup: $(cat "$armout" 2>/dev/null || true)"
+  is_live_non_zombie "$watcher_pid" \
+    || fail "watcher child died while its tracked arm was still expected to own it"
+  [ "$(cat "$state/.watch.lock/pid" 2>/dev/null || true)" = "$watcher_pid" ] \
+    || fail "quiet restart arm lost its watcher lock before any wake"
+
+  printf 'done: tracked arm shutdown\n' > "$state/shutdown.status"
+  wait_for_exit "$ARM_PID" 80
+  status=$?
+  expect_code 0 "$status" "tracked restart arm must close on a real wake"
+  grep -F 'signal:' "$armout" >/dev/null \
+    || fail "tracked restart arm did not report its shutdown wake: $(cat "$armout")"
+  pass "watch-arm: tracked restart arm survives quiet startup until a real wake"
+}
+
 test_rearm_resurfaces_durable_queue_and_remote_open_decision() {
   local dir home state fakebin result armout drainout status watcher_pid sequence generation decision_recovery_arm decision_successor
   dir=$(make_case rearm-resurface)
@@ -287,16 +318,15 @@ test_rearm_resurfaces_durable_queue_and_remote_open_decision() {
   append_wake "$state" check startup-network 'check: startup-network'
 
   start_rearm_arm "$home" "$state" "$fakebin" "$armout"
-  sleep 0.25
-  if is_live_non_zombie "$ARM_PID"; then
+  wait_for_exit "$ARM_PID" 80
+  status=$?
+  if [ "$status" -eq 124 ]; then
     # End the fixture through an ordinary actionable status transition so this
     # failing pre-fix path leaves no child behind.
     printf 'done: fixture cleanup\n' > "$state/cleanup.status"
     wait_for_exit "$ARM_PID" 80 || true
-    fail "re-arm stayed live instead of surfacing durable wakes and the still-open remote decision"
+    fail "re-arm stayed live instead of surfacing durable wakes and the still-open remote decision; arm=$(tr '\n' '|' < "$armout" 2>/dev/null || true) marker=$(tr '\n' '|' < "$state/.watcher-down" 2>/dev/null || true) queue=$(tr '\n' '|' < "$state/.wake-queue" 2>/dev/null || true)"
   fi
-  wait "$ARM_PID"
-  status=$?
   expect_code 0 "$status" "re-arm re-surface wake must close successfully"
   grep -F 'check: rearm-resurface' "$armout" >/dev/null \
     || fail "re-arm did not report the durable recovery wake: $(cat "$armout")"
@@ -807,6 +837,7 @@ test_downtime_marker_does_not_follow_symlink() {
 test_attached_arm_reports_the_delivered_wake
 test_attached_arm_reports_the_delivered_wake_after_drain
 test_attached_arm_still_fails_on_a_wake_it_did_not_deliver
+test_restart_arm_survives_quiet_tracked_background_startup
 test_rearm_resurfaces_durable_queue_and_remote_open_decision
 test_marker_publish_failure_retains_recovery_evidence
 test_delivery_gap_wake_is_recovered_once

--- a/tests/fm-watch-checkpoint.test.sh
+++ b/tests/fm-watch-checkpoint.test.sh
@@ -15,6 +15,24 @@ make_home() {
   printf '%s\n' "$home"
 }
 
+install_empty_once_ps() {  # <fakebin> <stamp>
+  local fakebin=$1 stamp=$2 real_ps
+  real_ps=$(command -v ps) || fail "test host has no ps command"
+  cat > "$fakebin/ps" <<'SH'
+#!/usr/bin/env bash
+set -u
+stamp=${FM_FAKE_PS_EMPTY_ONCE:?FM_FAKE_PS_EMPTY_ONCE unset}
+real_ps=${FM_FAKE_REAL_PS:?FM_FAKE_REAL_PS unset}
+if [ ! -e "$stamp" ]; then
+  : > "$stamp"
+  exit 0
+fi
+exec "$real_ps" "$@"
+SH
+  chmod +x "$fakebin/ps"
+  printf '%s\n' "$real_ps" > "$fakebin/real-ps"
+}
+
 test_quiet_checkpoint_exits_124_cleanly() {
   local home out err status
   home=$(make_home quiet)
@@ -24,7 +42,7 @@ test_quiet_checkpoint_exits_124_cleanly() {
   FM_HOME="$home" FM_POLL=1 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 "$CHECKPOINT" --seconds 1 >"$out" 2>"$err" || status=$?
   expect_code 124 "$status" "quiet checkpoint exit"
   assert_contains "$(cat "$out")" "checkpoint: no actionable wake within 1s" "quiet checkpoint line missing"
-  assert_absent "$home/state/.watch.lock/pid" "watch lock pid survived quiet checkpoint timeout"
+  assert_absent "$home/state/.watch.lock/pid" "watch lock pid survived quiet checkpoint timeout; link=$(readlink "$home/state/.watch.lock" 2>/dev/null || true) pid=$(cat "$home/state/.watch.lock/pid" 2>/dev/null || true) token=$(cat "$home/state/.watch.lock/owner-token" 2>/dev/null || true) files=$(find "$home/state" -maxdepth 1 -name '.watch.lock*' -print 2>/dev/null | sort | tr '\n' '|') err=$(tr '\n' '|' < "$err" 2>/dev/null || true)"
   pass "quiet checkpoint exits 124 with a clean checkpoint line and no live lock"
 }
 
@@ -69,6 +87,54 @@ SH
   pass "checkpoint preserves watcher environment for registered custom checks"
 }
 
+test_checkpoint_retries_empty_identity_publication() {
+  local home fakebin stamp real_ps out err checkpoint_pid watcher_pid identity health health_status status i
+  home=$(make_home transient-identity)
+  fakebin=$(fm_fakebin "$home")
+  stamp="$home/ps-empty-once"
+  install_empty_once_ps "$fakebin" "$stamp"
+  real_ps=$(cat "$fakebin/real-ps")
+  out="$home/out.txt"
+  err="$home/err.txt"
+
+  PATH="$fakebin:$PATH" FM_HOME="$home" FM_PROC_ROOT_OVERRIDE="$home/no-proc" \
+    FM_FAKE_PS_EMPTY_ONCE="$stamp" FM_FAKE_REAL_PS="$real_ps" \
+    FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 \
+    "$CHECKPOINT" --seconds 8 >"$out" 2>"$err" &
+  checkpoint_pid=$!
+
+  i=0
+  while [ "$i" -lt 80 ]; do
+    watcher_pid=$(cat "$home/state/.watch.lock/pid" 2>/dev/null || true)
+    [ -n "$watcher_pid" ] && [ -e "$home/state/.watch.lock/pid-identity" ] && break
+    sleep 0.1
+    i=$((i + 1))
+  done
+  identity=$(cat "$home/state/.watch.lock/pid-identity" 2>/dev/null || true)
+  health=$(FM_HOME="$home" FM_STATE_OVERRIDE="$home/state" FM_PROC_ROOT_OVERRIDE="$home/no-proc" bash -c '
+    . "$1"
+    if fm_watcher_healthy "$2" "$3" 300 "$4"; then
+      printf "healthy pid=%s identity=%s\n" "$FM_WATCHER_HEALTHY_PID" "$FM_WATCHER_HEALTHY_IDENTITY"
+    else
+      printf "unhealthy\n"
+      exit 7
+    fi
+  ' _ "$ROOT/bin/fm-wake-lib.sh" "$home/state" "$ROOT/bin/fm-watch.sh" "$home" 2>&1); health_status=$?
+
+  printf 'done: synthetic wake\n' > "$home/state/transient.status"
+  wait "$checkpoint_pid" 2>/dev/null
+  status=$?
+
+  [ -e "$stamp" ] || fail "fixture ps did not force an initial empty identity read"
+  [ -n "$watcher_pid" ] || fail "checkpoint watcher never published its pid"
+  [ -n "$identity" ] || fail "checkpoint watcher published a blank pid-identity after an initial empty read"
+  expect_code 0 "$health_status" "checkpoint watcher with retried identity must pass strict health"
+  assert_contains "$health" "healthy pid=$watcher_pid" "strict health did not identify the checkpoint watcher"
+  expect_code 0 "$status" "signal checkpoint exit after transient identity publication"
+  assert_contains "$(cat "$out")" "signal:" "checkpoint did not pass through the cleanup signal"
+  pass "checkpoint watcher retries an initial empty pid identity before publishing the lock"
+}
+
 test_existing_singleton_watcher_is_not_success() {
   local home out err status
   home=$(make_home singleton)
@@ -90,4 +156,5 @@ test_existing_singleton_watcher_is_not_success() {
 test_quiet_checkpoint_exits_124_cleanly
 test_signal_passes_through_and_exits_zero
 test_registered_check_uses_preserved_watcher_environment
+test_checkpoint_retries_empty_identity_publication
 test_existing_singleton_watcher_is_not_success

--- a/tests/fm-watcher-lock.test.sh
+++ b/tests/fm-watcher-lock.test.sh
@@ -133,7 +133,7 @@ test_guard_warnings() {
   #       warning follows it, and the guidance is repair-after-drain (never the
   #       old conflicting "restart NOW first").
   #   (2) a fresh watcher and an empty queue: total silence.
-  local dir state err first banner_line queue_line pid identity
+  local dir state err first banner_line queue_line pid out i
   dir=$(make_case guard)
   state="$dir/state"
   err="$dir/guard.err"
@@ -178,21 +178,30 @@ test_guard_warnings() {
   dir=$(make_case guard-fresh)
   state="$dir/state"
   err="$dir/guard.err"
+  out="$dir/watch.out"
   printf 'project=x\n' > "$state/task.meta"
-  sleep 60 &
+  PATH="$dir/fakebin:$PATH" FM_HOME="$dir" FM_STATE_OVERRIDE="$state" \
+    FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 \
+    "$WATCH" > "$out" &
   pid=$!
-  identity=$(FM_STATE_OVERRIDE="$state" bash -c '. "$1"; fm_pid_identity "$2"' _ "$LIB" "$pid") || fail "could not identify fresh guard watcher"
-  mkdir -p "$state/.watch.lock"
-  printf '%s\n' "$pid" > "$state/.watch.lock/pid"
-  printf '%s\n' "$dir" > "$state/.watch.lock/fm-home"
-  printf '%s\n' "$WATCH" > "$state/.watch.lock/watcher-path"
-  printf '%s\n' "$identity" > "$state/.watch.lock/pid-identity"
-  touch "$state/.last-watcher-beat"
+  i=0
+  while [ "$i" -lt 80 ]; do
+    [ "$(cat "$state/.watch.lock/pid" 2>/dev/null || true)" = "$pid" ] \
+      && [ -s "$state/.watch.lock/pid-identity" ] \
+      && [ -e "$state/.last-watcher-beat" ] \
+      && break
+    sleep 0.1
+    i=$((i + 1))
+  done
+  [ "$(cat "$state/.watch.lock/pid" 2>/dev/null || true)" = "$pid" ] \
+    && [ -s "$state/.watch.lock/pid-identity" ] \
+    && [ -e "$state/.last-watcher-beat" ] \
+    || fail "fresh guard fixture watcher did not publish its lock: $(cat "$out" 2>/dev/null || true)"
   # Non-git FM_ROOT keeps the worktree-tangle check inert so "fresh watcher ->
   # total silence" stays a pure assertion about watcher state.
-  FM_ROOT_OVERRIDE="$dir" FM_STATE_OVERRIDE="$state" FM_GUARD_GRACE=300 "$ROOT/bin/fm-guard.sh" 2> "$err" >/dev/null || fail "guard failed"
-  kill "$pid" 2>/dev/null || true
-  wait "$pid" 2>/dev/null || true
+  FM_ROOT_OVERRIDE="$dir" FM_HOME="$dir" FM_STATE_OVERRIDE="$state" FM_GUARD_GRACE=300 "$ROOT/bin/fm-guard.sh" 2> "$err" >/dev/null || fail "guard failed"
+  printf 'done: fresh guard cleanup\n' > "$state/cleanup.status"
+  wait_for_exit "$pid" 80 || true
   [ ! -s "$err" ] || fail "guard warned with a live watcher and fresh beacon: $(cat "$err")"
   pass "guard banner leads when down with pending wakes (repair-after-drain) and stays silent when live and fresh"
 }
@@ -534,6 +543,138 @@ test_watcher_self_evicts_on_lock_takeover() {
   lock_pid=$(cat "$state/.watch.lock/pid" 2>/dev/null || true)
   [ "$lock_pid" = "$$" ] || fail "self-evicting watcher clobbered the new holder's lock (got '$lock_pid')"
   pass "watcher self-evicts when the lock pid no longer names it"
+}
+
+test_blank_identity_live_watcher_lock_is_repaired_before_health() {
+  local dir state fakebin pid out status repaired i
+  dir=$(make_case blank-identity-health)
+  state="$dir/state"
+  fakebin="$dir/fakebin"
+  PATH="$fakebin:$PATH" FM_HOME="$dir" FM_STATE_OVERRIDE="$state" \
+    FM_POLL=5 FM_SIGNAL_GRACE=1 FM_CHECK_INTERVAL=999999 FM_HEARTBEAT=999999 \
+    "$WATCH" > "$dir/watch.out" &
+  pid=$!
+  i=0
+  while [ "$i" -lt 80 ]; do
+    [ "$(cat "$state/.watch.lock/pid" 2>/dev/null || true)" = "$pid" ] \
+      && [ -s "$state/.watch.lock/pid-identity" ] \
+      && [ -e "$state/.last-watcher-beat" ] \
+      && break
+    sleep 0.1
+    i=$((i + 1))
+  done
+  [ "$(cat "$state/.watch.lock/pid" 2>/dev/null || true)" = "$pid" ] \
+    && [ -s "$state/.watch.lock/pid-identity" ] \
+    && [ -e "$state/.last-watcher-beat" ] \
+    || fail "blank-identity fixture watcher did not finish publishing its lock"
+  : > "$state/.watch.lock/pid-identity"
+
+  out=$(FM_HOME="$dir" FM_STATE_OVERRIDE="$state" bash -c '
+    . "$1"
+    if fm_watcher_healthy "$2" "$3" 300 "$4"; then
+      printf "healthy pid=%s identity=%s\n" "$FM_WATCHER_HEALTHY_PID" "$FM_WATCHER_HEALTHY_IDENTITY"
+    else
+      printf "unhealthy\n"
+      exit 7
+    fi
+  ' _ "$LIB" "$state" "$WATCH" "$dir" 2>&1); status=$?
+  repaired=$(cat "$state/.watch.lock/pid-identity" 2>/dev/null || true)
+  printf 'done: blank identity cleanup\n' > "$state/cleanup.status"
+  wait_for_exit "$pid" 80 || true
+
+  expect_code 0 "$status" "fresh live watcher with blank recorded identity must be repaired into strict health"
+  assert_contains "$out" "healthy pid=$pid" "blank-identity repair did not report the live watcher"
+  [ -n "$repaired" ] || fail "blank-identity repair left pid-identity empty"
+  pass "watcher health repairs a blank identity record before accepting the live lock holder"
+}
+
+test_blank_identity_live_nonwatcher_lock_is_not_repaired_into_health() {
+  local dir state pid out status repaired identity
+  dir=$(make_case blank-identity-nonwatcher)
+  state="$dir/state"
+  sleep 60 &
+  pid=$!
+  mkdir -p "$state/.watch.lock"
+  printf '%s\n' "$pid" > "$state/.watch.lock/pid"
+  printf '%s\n' "$dir" > "$state/.watch.lock/fm-home"
+  printf '%s\n' "$WATCH" > "$state/.watch.lock/watcher-path"
+  : > "$state/.watch.lock/pid-identity"
+  touch "$state/.last-watcher-beat"
+
+  out=$(FM_HOME="$dir" FM_STATE_OVERRIDE="$state" bash -c '
+    . "$1"
+    if fm_watcher_healthy "$2" "$3" 300 "$4"; then
+      printf "healthy pid=%s identity=%s\n" "$FM_WATCHER_HEALTHY_PID" "$FM_WATCHER_HEALTHY_IDENTITY"
+      exit 0
+    fi
+    printf "unhealthy\n"
+    exit 7
+  ' _ "$LIB" "$state" "$WATCH" "$dir" 2>&1); status=$?
+  repaired=$(cat "$state/.watch.lock/pid-identity" 2>/dev/null || true)
+  identity=$(FM_STATE_OVERRIDE="$state" bash -c '. "$1"; fm_pid_identity "$2"' _ "$LIB" "$pid" 2>/dev/null || true)
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+
+  expect_code 7 "$status" "blank-identity repair must not certify an unrelated live pid"
+  assert_contains "$out" "unhealthy" "unrelated live pid was not rejected"
+  [ -z "$repaired" ] || fail "unrelated live pid was repaired into a watcher identity: $repaired (actual $identity)"
+  pass "watcher health refuses to repair a blank identity from an unrelated live pid"
+}
+
+test_release_cleans_dangling_watch_lock_owner_after_spawn_guard_contention() {
+  local dir state lockdir foreign_lock referenced_link out status
+  dir=$(make_case guard-contention-dangling)
+  state="$dir/state"
+  lockdir="$state/.watch.lock"
+  foreign_lock="$state/.foreign-watch.lock"
+  referenced_link="$state/.watch.lock.owner-referenced-link"
+
+  out=$(FM_STATE_OVERRIDE="$state" bash -c '
+    . "$1"
+    orphan_empty="$2.owner.empty"
+    orphan_known="$2.owner.known"
+    referenced_owner="$2.owner.referenced"
+    other_state="$4/other-home/state"
+    foreign_owner="$other_state/.watch.lock.owner.foreign"
+    mkdir -p "$orphan_empty" "$orphan_known" "$referenced_owner" "$foreign_owner"
+    printf "99999999\n" > "$orphan_known/pid"
+    printf "%s\n" "$4" > "$orphan_known/fm-home"
+    printf "%s/bin/fm-watch.sh\n" "$4" > "$orphan_known/watcher-path"
+    printf "old identity\n" > "$orphan_known/pid-identity"
+    touch -t 200001010000 "$orphan_empty" "$orphan_known" "$referenced_owner" "$foreign_owner"
+    ln -s "$referenced_owner" "$5"
+
+    fm_lock_try_acquire "$2" || exit 10
+    owner=${FM_LOCK_OWNER_DIR:-}
+    [ -n "$owner" ] || exit 11
+    fm_lock_release "$2"
+    [ ! -e "$2" ] && [ ! -L "$2" ] || exit 12
+    [ ! -e "$owner" ] || exit 13
+    [ ! -e "$orphan_empty" ] || exit 14
+    [ ! -e "$orphan_known" ] || exit 15
+    [ -d "$referenced_owner" ] || exit 16
+    [ -d "$foreign_owner" ] || exit 17
+    rm -f "$5"
+    fm_lock_discard_owner "$referenced_owner"
+
+    fm_lock_try_acquire "$2" || exit 20
+    owner=${FM_LOCK_OWNER_DIR:-}
+    [ -n "$owner" ] || exit 21
+    fm_lock_discard_owner "$owner"
+    fm_lock_release "$2"
+    if [ -e "$2" ] || [ -L "$2" ]; then
+      printf "residue target=%s\n" "$(readlink "$2" 2>/dev/null || true)"
+      exit 22
+    fi
+
+    ln -s "$4/foreign-owner-missing" "$3"
+    fm_lock_release "$3"
+    [ -L "$3" ] || exit 23
+  ' _ "$LIB" "$lockdir" "$foreign_lock" "$dir" "$referenced_link" 2>&1); status=$?
+
+  expect_code 0 "$status" "self-eviction release must clear only exact-lock unowned watcher lock residue"
+  [ -z "$out" ] || fail "dangling symlink cleanup produced unexpected output: $out"
+  pass "watcher lock release removes exact-lock dangling and orphaned owner residue without crossing home boundaries"
 }
 
 test_arm_self_eviction_is_loud_without_successor() {
@@ -1140,6 +1281,9 @@ test_lock_paused_mid_acquire_claim_fails_during_steal
 test_watch_restart_rejects_reused_pid
 test_watch_restart_attaches_to_healthy_peer
 test_watcher_self_evicts_on_lock_takeover
+test_blank_identity_live_watcher_lock_is_repaired_before_health
+test_blank_identity_live_nonwatcher_lock_is_not_repaired_into_health
+test_release_cleans_dangling_watch_lock_owner_after_spawn_guard_contention
 test_arm_self_eviction_is_loud_without_successor
 test_arm_attaches_and_waits_for_live_fresh_watcher
 test_attached_arm_signal_is_recorded_in_cycle_ledger


### PR DESCRIPTION
## Summary
- Make watcher startup refuse blank pid-identity publication and retry identity capture before publishing the singleton lock.
- Preserve the PID-strict health contract by repairing legacy blank identity records only after proving the same live pid, fm-home, watcher-path, and captured command identity match the watcher path.
- Make Stop-owned autoarm and Claude turn-end guard exit 2 only with explanatory stderr, and reset stale failure episodes once any verified fresh watcher owns this home.
- Clean exact-lock dangling `.watch.lock` symlinks plus unreferenced `.watch.lock.owner.*` orphans without removing another home owner directory or foreign lock.
- Add a tracked-background arm survivability regression for `fm-watch-arm.sh --restart`.

## Fix Option
Chose option (a): make the watcher record a real, re-readable identity.

The live correction showed `fm_pid_identity` returns a full identity for the checkpoint-started watcher pid from a plain shell, so I treated the defect as the in-situ lock publication path rather than a ps compatibility failure. Requiring publication to retry, write, and re-read a nonblank identity preserves the documented PID-strict predicate. For already-written blank records, the health repair path still refuses to accept a blank fallback: it captures the identity for the same live pid and accepts the repair only if that command identity names the recorded watcher path.

## Tracked Background Arm Check
The patch does not add a broad process-detach change. It adds `watch-arm: tracked restart arm survives quiet startup until a real wake`, which passed focused and in the full suite. That proves `fm-watch-arm.sh --restart` itself keeps the arm and watcher child alive in the isolated tracked-background shape until an actual wake closes it. If the primary-home pid/ppid/pgid death still reproduces after this patch, that is likely a separate adapter/process-group invocation defect rather than the blank-identity health defect.

## Validation
Focused and lint checks passed:
- `tests/fm-claude-stop-autoarm.test.sh`
- `tests/fm-turnend-guard.test.sh`
- `tests/fm-watcher-lock.test.sh`
- `tests/fm-watch-arm.test.sh`
- `tests/fm-watch-checkpoint.test.sh`
- `tests/fm-wake-queue.test.sh`
- `bash -n` on edited scripts/tests
- `git diff --check`
- `PATH="$PWD/.tmp-actionlint-bin:$PATH" bin/fm-lint.sh`

Full suite result:
- `bin/fm-test-run.sh --all --json .tmp-fm-test-all-final3.json`
- `FM_TEST_SUMMARY total=161 failed=11 skipped_gate=37 duration_ms=6242802`
- Passed: 150
- Failed: 11
- `watcher-wake-lock`: count 18, failed 0

The 11 failing scripts also reproduced on clean main before this patch, so I am treating them as pre-existing:
- `tests/fm-backend-cmux.test.sh`
- `tests/fm-backend-orca.test.sh`
- `tests/fm-backlog-handoff.test.sh`
- `tests/fm-composer-lib.test.sh`
- `tests/fm-gotmp.test.sh`
- `tests/fm-muse-harness.test.sh`
- `tests/fm-pending-reply.test.sh`
- `tests/fm-public-followup.test.sh`
- `tests/fm-remote-secondmate-lifecycle-e2e.test.sh`
- `tests/fm-remote-secondmate-trace-context.test.sh`
- `tests/fm-teardown.test.sh`
