### PR TITLE
fix(bin): forbid agent attribution in generated crewmate briefs

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -57,6 +57,14 @@
 # it carries the AGENTS.md authoring bar (widely useful knowledge only, pointers
 # over copied detail) and has the crewmate add the fm-ensure-agents-md.sh
 # self-governance section when a touched project AGENTS.md lacks it.
+# The commit-producing scaffolds (ship and scout) carry a rule forbidding agent
+# attribution in a commit message - no `Co-Authored-By:` agent trailer and no
+# agent session line such as `Claude-Session:` - stated to override whatever the
+# worker's own harness or tooling would add by default, because a crewmate works
+# in a project checkout and never reads firstmate's AGENTS.md.
+# The secondmate charter deliberately omits that rule: a secondmate operates under
+# its own home's AGENTS.md, which already owns it, and its project commits are made
+# by crewmates that receive this same scaffold.
 # Refuses to overwrite an existing brief.
 set -eu
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -355,6 +355,9 @@ The report is the only thing that survives, so anything worth keeping must be in
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+8. Put no agent attribution in a commit message: no \`Co-Authored-By:\` trailer naming an agent
+   or tool and no agent session line such as \`Claude-Session:\`, whatever your harness or tooling
+   would add by default - that default must be overridden.
 
 $INBOX_SECTION
 
@@ -474,6 +477,9 @@ $RULE1
 7. Never stop, restart, or update the shared \`no-mistakes\` daemon - it is one instance serving
    every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
    daemon error, append \`blocked: {the daemon error}\` and stop; only firstmate manages the daemon.
+8. Put no agent attribution in a commit message: no \`Co-Authored-By:\` trailer naming an agent
+   or tool and no agent session line such as \`Claude-Session:\`, whatever your harness or tooling
+   would add by default - that default must be overridden.
 
 $INBOX_SECTION
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -747,8 +747,39 @@ test_scout_and_secondmate_scaffold() {
   pass "fm-brief: scout and secondmate code paths still scaffold well-formed briefs"
 }
 
+# AGENTS.md section 1 forbids an agent co-author on a commit, but crewmates work
+# inside a project checkout and never read firstmate's AGENTS.md - the brief is
+# the only instruction surface they see. Every variant that can produce commits
+# must therefore carry the prohibition itself, and it must override the harness
+# default (Claude Code appends both trailers unless told otherwise).
+test_commit_variants_forbid_agent_attribution() {
+  local home id brief spec args
+  home="$TMP_ROOT/coauthor-home"
+  mkdir -p "$home/data"
+  for spec in "brief-ca-nm:--mode no-mistakes" "brief-ca-dp:--mode direct-PR" \
+              "brief-ca-lo:--mode local-only" "brief-ca-scout:--scout"; do
+    id=${spec%%:*}
+    args=${spec#*:}
+    # shellcheck disable=SC2086  # deliberate word splitting of the flag fixture
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj $args >/dev/null 2>&1 \
+      || fail "$id: fm-brief.sh exited non-zero"
+    brief="$home/data/$id/brief.md"
+    assert_present "$brief" "$id: brief was not scaffolded"
+    assert_grep "no agent attribution in a commit message" "$brief" \
+      "$id: brief does not forbid agent attribution in commit messages"
+    assert_grep "Co-Authored-By:" "$brief" \
+      "$id: brief does not name the Co-Authored-By agent trailer"
+    assert_grep "Claude-Session:" "$brief" \
+      "$id: brief does not name the agent session line"
+    assert_grep "whatever your harness or tooling" "$brief" \
+      "$id: brief does not override the harness default"
+  done
+  pass "fm-brief.sh: commit-producing briefs forbid agent co-author trailers"
+}
+
 test_script_parses
 test_no_heredoc_in_command_substitution
+test_commit_variants_forbid_agent_attribution
 test_help_includes_entire_header
 test_ship_modes_generate_clean_briefs
 test_ship_mode_is_required_and_closed_set


### PR DESCRIPTION
## Intent

Firstmate's AGENTS.md section 1 says 'Never add an agent name as a commit co-author', but the crewmate worker agents that firstmate spawns work inside a project checkout and never read firstmate's AGENTS.md - their only instruction surface is the brief generated by bin/fm-brief.sh. That scaffold did not carry the prohibition, so workers fell back to their harness default: Claude Code appended 'Co-Authored-By: Claude ...' and a 'Claude-Session:' line to every commit (observed live on both commits of a task branch). Goal: put the rule where the workers it governs can actually see it.

Required change: add the prohibition to the generated brief's '# Rules' block so every dispatched worker receives it. fm-brief.sh has more than one rules block (scout variant and ship variant); every generated variant that can produce commits must carry the rule, and the secondmate charter variant had to be checked too.

Accepted decisions and constraints:
- Wording must be an explicit instruction about what NOT to put in a commit message, naming both the 'Co-Authored-By:' agent trailer and the 'Claude-Session:' line, and must make clear it applies regardless of any default the worker's own harness or tooling would otherwise apply - overriding that default is the whole point. It deliberately does not name only one vendor's trailer format, because workers run on several different harnesses (claude, codex, opencode, pi, grok, kimi, cursor, muse).
- Deliberately kept to the minimum text that does the job: ONE rule line, not a paragraph. AGENTS.md's token cost is paid by every session and the brief's by every dispatched worker, so brevity here is an explicit requirement, not an oversight. Do not expand it into prose.
- Implemented as rule 8 appended after the existing rule 7 in both the scout and the ship rules blocks.
- The secondmate charter variant was checked and deliberately left unchanged: a secondmate is a firstmate in its own isolated home whose local AGENTS.md (which already carries the rule) is its job description, and its project commits are made by its own crewmates, who receive this same scaffolded brief. Adding a third copy there would duplicate a contract that already has an owner, which firstmate-coding-guidelines' one-owner rule forbids. Absence of the rule in the charter is intentional, not a missed variant.

Test requirement (explicit): extend the EXISTING tests/fm-brief.test.sh - do not add a new test file or a new runner. Assert through the executable interface by generating briefs and checking their content. Asserting against bin/fm-brief.sh's own source bytes is explicitly forbidden by firstmate-coding-guidelines. The added test generates all three ship delivery modes (no-mistakes, direct-PR, local-only) plus a scout brief and asserts each carries the prohibition, names both trailer forms, and carries the harness-default override clause. It was verified to fail when the rule line is removed from the scaffold.

This task changes firstmate's own shared tracked material, so firstmate-coding-guidelines applies: one sentence per line in tracked Markdown, plain dash never an em dash, bin/*.sh shellcheck-clean, tests colocated in tests/ extending the existing script. bin/fm-lint.sh passes.

Final constraint on this work's own commits: because the task is about not putting agent co-author trailers in commits, the commits produced here must themselves carry no 'Co-Authored-By:' agent trailer and no 'Claude-Session:' line, whatever the tooling would add by default. This applies to any pipeline fix-commits made during validation as well.

## What Changed

- `bin/fm-brief.sh` appends a rule 8 to both commit-producing rules blocks (ship and scout): a commit message must carry no `Co-Authored-By:` agent/tool trailer and no agent session line such as `Claude-Session:`, explicitly overriding whatever the worker's harness or tooling adds by default.
- The script header documents why the rule lives in the scaffold - a crewmate works in a project checkout and never reads firstmate's `AGENTS.md` - and why the secondmate charter variant deliberately omits it (its own home's `AGENTS.md` already owns the rule).
- `tests/fm-brief.test.sh` gains `test_commit_variants_forbid_agent_attribution`, which generates briefs for all three ship delivery modes (`no-mistakes`, `direct-PR`, `local-only`) plus a scout brief and asserts each generated brief carries the prohibition, names both trailer forms, and includes the harness-default override clause.

## Risk Assessment

✅ Low: Additive three-line prose rule appended to the two brief variants that can produce commits, with no control-flow, argument-parsing, or byte-stability impact, plus a colocated test that exercises the real generator across all four affected variants.

## Testing

Ran the existing fm-brief test script, which passes end to end with the new case included, then went past pass/fail by exercising the real CLI: every commit-producing brief variant (the three ship delivery modes plus scout) was generated and the emitted Rules block shows the new rule 8 naming both the Co-Authored-By trailer and the Claude-Session line along with the harness-default override clause, while the secondmate charter contains neither, as the intent deliberately specifies. I also confirmed the new test is a genuine regression guard by stripping the rule from a throwaway copy of the scaffold and watching the test fail, and verified this branch's own two commits carry no agent trailers. The user-facing surface here is a generated text brief delivered to a worker agent rather than a rendered UI, so the captured brief output is the product-level artifact; no screenshot applies.

<details>
<summary>Evidence: Generated brief Rules block for all commit-producing variants (plus charter absence)</summary>

Source: [Generated brief Rules block for all commit-producing variants (plus charter absence)](https://github.com/triplehamburger/firstmate/blob/ce2cf61e00e129ca808ffdd54fdd1893084d2ba6/.no-mistakes/evidence/fm/brief-no-agent-coauthor/generated-brief-rule8.txt)

<code>$ fm-brief.sh ship-no-mistakes some-proj --mode no-mistakes&#10;8. Put no agent attribution in a commit message: no `Co-Authored-By:` trailer naming an agent&#10;or tool and no agent session line such as `Claude-Session:`, whatever your harness or tooling&#10;would add by default - that default must be overridden.&#10;&#10;(identical block emitted for --mode direct-PR, --mode local-only, and --scout)&#10;&#10;$ fm-brief.sh secondmate-charter some-proj --secondmate # charter variant - rule deliberately absent&#10;grep -cE &#34;Co-Authored-By|Claude-Session&#34; charter brief =&gt; 0</code>

```text
Generated crewmate briefs - the "# Rules" line each dispatched worker actually receives
(bin/fm-brief.sh, FM_HOME=<tmp>, project "some-proj")

$ fm-brief.sh ship-no-mistakes some-proj --mode no-mistakes
8. Put no agent attribution in a commit message: no `Co-Authored-By:` trailer naming an agent
   or tool and no agent session line such as `Claude-Session:`, whatever your harness or tooling
   would add by default - that default must be overridden.

$ fm-brief.sh ship-direct-PR some-proj --mode direct-PR
8. Put no agent attribution in a commit message: no `Co-Authored-By:` trailer naming an agent
   or tool and no agent session line such as `Claude-Session:`, whatever your harness or tooling
   would add by default - that default must be overridden.

$ fm-brief.sh ship-local-only some-proj --mode local-only
8. Put no agent attribution in a commit message: no `Co-Authored-By:` trailer naming an agent
   or tool and no agent session line such as `Claude-Session:`, whatever your harness or tooling
   would add by default - that default must be overridden.

$ fm-brief.sh scout some-proj --scout
8. Put no agent attribution in a commit message: no `Co-Authored-By:` trailer naming an agent
   or tool and no agent session line such as `Claude-Session:`, whatever your harness or tooling
   would add by default - that default must be overridden.

$ fm-brief.sh secondmate-charter some-proj --secondmate   # charter variant - rule deliberately absent
grep -cE "Co-Authored-By|Claude-Session" charter brief => 0
```
</details>
<details>
<summary>Evidence: Regression proof: new test fails without the rule, passes with it</summary>

Source: [Regression proof: new test fails without the rule, passes with it](https://github.com/triplehamburger/firstmate/blob/ce2cf61e00e129ca808ffdd54fdd1893084d2ba6/.no-mistakes/evidence/fm/brief-no-agent-coauthor/regression-fails-without-rule.txt)

<code>== bin/fm-brief.sh with rule 8 stripped from both Rules blocks (copy in a temp dir) ==&#10;$ bash tests/fm-brief.test.sh&#10;not ok - brief-ca-nm: brief does not forbid agent attribution in commit messages&#10;&#10;== bin/fm-brief.sh as committed at d84f28c ==&#10;$ bash tests/fm-brief.test.sh&#10;ok - fm-brief.sh: commit-producing briefs forbid agent co-author trailers</code>

```text
Regression proof for tests/fm-brief.test.sh::test_commit_variants_forbid_agent_attribution

== bin/fm-brief.sh with rule 8 stripped from both Rules blocks (copy in a temp dir) ==
$ bash tests/fm-brief.test.sh
not ok - brief-ca-nm: brief does not forbid agent attribution in commit messages

== bin/fm-brief.sh as committed at d84f28c ==
$ bash tests/fm-brief.test.sh
ok - fm-brief.sh: commit-producing briefs forbid agent co-author trailers
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"538d944bdceabfe404d52a59e111ad9ce677971c","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-brief.test.sh` - the full existing brief suite including the new `test_commit_variants_forbid_agent_attribution`; every check passes</code>
- <code>Generated briefs through the CLI for each commit-producing variant: `FM_HOME=&lt;tmp&gt; ./bin/fm-brief.sh &lt;id&gt; some-proj --mode no-mistakes` / `--mode direct-PR` / `--mode local-only` / `--scout`, then read the emitted `# Rules` block out of `$FM_HOME/data/&lt;id&gt;/brief.md`</code>
- <code>Confirmed rule 8 in each generated brief names both `Co-Authored-By:` and `Claude-Session:` and carries the harness-default override clause</code>
- <code>Charter check: `FM_HOME=&lt;tmp&gt; ./bin/fm-brief.sh secondmate-charter some-proj --secondmate` then `grep -cE &#39;Co-Authored-By|Claude-Session&#39;` on the generated charter, which returns 0, matching the intent&#39;s deliberate no-copy decision</code>
- <code>Regression proof: copied bin/ and tests/ into a temp dir, stripped the rule-8 lines from the copied bin/fm-brief.sh, re-ran `bash tests/fm-brief.test.sh` and observed `not ok - brief-ca-nm: brief does not forbid agent attribution in commit messages`</code>
- <code>Verified both `# Rules` blocks in bin/fm-brief.sh carry the rule, so no commit-producing variant was missed</code>
- <code>Checked the branch&#39;s own commits for the forbidden trailers: `git log --format=&#39;%H%n%B&#39; 9a01dea..d84f28c` piped through a case-insensitive grep for Co-Authored-By and Claude-Session, which matched nothing</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
