### PR TITLE
feat(pi): add fixture-gated captain question dialog

### DIFF
--- a/.pi/extensions/fm-ask-user-question.ts
+++ b/.pi/extensions/fm-ask-user-question.ts
@@ -218,6 +218,7 @@ function deliverAdapter(params: QuestionParams, answer: string): Promise<Deliver
 }
 
 function normalize(params: QuestionParams): QuestionParams | undefined {
+  if (params.home.includes("\0")) return undefined;
   if (!/^[A-Za-z0-9._-]+$/.test(params.taskId) || !/^[A-Za-z0-9._-]+$/.test(params.decisionKey)) return undefined;
   if (!/^sha256:[0-9a-f]{64}$/.test(params.sourceGeneration)) return undefined;
   const question = cleanDisplay(params.question, 500);

--- a/.pi/extensions/fm-ask-user-question.ts
+++ b/.pi/extensions/fm-ask-user-question.ts
@@ -1,6 +1,8 @@
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
 import { realpathSync } from "node:fs";
 import { dirname, resolve } from "node:path";
+import { StringDecoder } from "node:string_decoder";
 import { fileURLToPath } from "node:url";
 import { StringEnum } from "@earendil-works/pi-ai";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
@@ -140,7 +142,7 @@ function cancelled(
   return { content: [{ type: "text" as const, text }], details };
 }
 
-function runAdapter(command: "validate" | "deliver", params: QuestionParams, answer?: string) {
+function adapterArgs(command: "validate" | "deliver", params: QuestionParams, answer?: string): string[] {
   const args = [
     command,
     "--home", params.home,
@@ -149,10 +151,69 @@ function runAdapter(command: "validate" | "deliver", params: QuestionParams, ans
     "--generation", params.sourceGeneration,
   ];
   if (answer !== undefined) args.push("--answer", answer);
-  return spawnSync(adapter, args, {
+  return args;
+}
+
+function validateAdapter(params: QuestionParams) {
+  return spawnSync(adapter, adapterArgs("validate", params), {
     encoding: "utf8",
     env: { ...process.env, FM_HOME: activeHome, FM_STATE_OVERRIDE: activeState },
-    ...(command === "validate" ? { timeout: 10_000 } : {}),
+    timeout: 10_000,
+  });
+}
+
+type DeliveryResult = {
+  status: number | null;
+  signal: NodeJS.Signals | null;
+  ownerEntered: boolean;
+  diagnostic: string;
+};
+
+function deliverAdapter(params: QuestionParams, answer: string): Promise<DeliveryResult> {
+  const marker = `fm-owner-entry-v1:${randomBytes(16).toString("hex")}`;
+  const child = spawn(adapter, adapterArgs("deliver", params, answer), {
+    env: {
+      ...process.env,
+      FM_HOME: activeHome,
+      FM_STATE_OVERRIDE: activeState,
+      FM_ASK_USER_QUESTION_OWNER_ENTRY_FD: "3",
+      FM_ASK_USER_QUESTION_OWNER_ENTRY_MARKER: marker,
+    },
+    stdio: ["ignore", "pipe", "pipe", "pipe"],
+  });
+
+  return new Promise((resolveDelivery) => {
+    let ownerEntered = false;
+    let ownerOutput = "";
+    let diagnostic = "";
+    const stdoutDecoder = new StringDecoder("utf8");
+    const stderrDecoder = new StringDecoder("utf8");
+    const appendDiagnostic = (value: string): void => {
+      const clean = value
+        .replace(/[\u0000-\u001f\u007f-\u009f]/g, " ")
+        .replace(/\s+/g, " ");
+      diagnostic = `${diagnostic}${clean}`.replace(/\s+/g, " ").trim().slice(-500);
+    };
+    const ownerEntry = child.stdio[3] as NodeJS.ReadableStream | null;
+
+    child.stdout?.on("data", (chunk: Buffer) => appendDiagnostic(stdoutDecoder.write(chunk)));
+    child.stdout?.on("end", () => appendDiagnostic(stdoutDecoder.end()));
+    child.stderr?.on("data", (chunk: Buffer) => appendDiagnostic(stderrDecoder.write(chunk)));
+    child.stderr?.on("end", () => appendDiagnostic(stderrDecoder.end()));
+    ownerEntry?.on("data", (chunk: Buffer) => {
+      if (ownerEntered) return;
+      ownerOutput = `${ownerOutput}${chunk.toString("utf8")}`.slice(0, marker.length + 1);
+      ownerEntered = ownerOutput === `${marker}\n`;
+    });
+    child.once("error", (error) => appendDiagnostic(error.message));
+    child.once("close", (status, signal) => {
+      resolveDelivery({
+        status,
+        signal,
+        ownerEntered,
+        diagnostic: diagnostic || `Firstmate delivery owner exited with ${signal ? `signal ${signal}` : `status ${status ?? "unknown"}`}.`,
+      });
+    });
   });
 }
 
@@ -179,17 +240,6 @@ function deliveryText(answers: AnswerItem[]): string {
     if (answer.type === "other") return `other: ${answer.text}`;
     return answer.text;
   }).join("; ");
-}
-
-function deliveryDiagnostic(delivery: ReturnType<typeof runAdapter>): string {
-  const output = [delivery.stderr, delivery.stdout, delivery.error?.message]
-    .filter(Boolean)
-    .map(String)
-    .join(" ")
-    .replace(/[\u0000-\u001f\u007f-\u009f]/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
-  return output.slice(-500) || `Firstmate delivery owner exited with status ${delivery.status ?? "unknown"}.`;
 }
 
 function showQuestion(params: QuestionParams, signal: AbortSignal, ctx: ExtensionContext) {
@@ -378,7 +428,7 @@ export default function askUserQuestion(pi: ExtensionAPI): void {
 
       return withPrimaryModal(async () => {
         if (abortSignal.aborted) return cancelled(params, "aborted", "Captain dialog was cancelled before display.");
-        const validation = runAdapter("validate", params);
+        const validation = validateAdapter(params);
         if (validation.status !== 0) return cancelled(params, "binding-mismatch", "Captain dialog source binding no longer matches.");
 
         let modal: ModalResult | undefined;
@@ -390,9 +440,8 @@ export default function askUserQuestion(pi: ExtensionAPI): void {
         if (!modal || modal.cancelled) return cancelled(params, modal?.reason || "ui-failure", "Captain left the decision open.");
         if (abortSignal.aborted) return cancelled(params, "aborted", "Captain dialog was cancelled before delivery.");
 
-        const delivery = runAdapter("deliver", params, deliveryText(modal.answers));
-        const deliveryWasAttempted = delivery.status === 4 || (delivery.status === null && delivery.pid > 0);
-        if (delivery.status !== 0 && !deliveryWasAttempted) {
+        const delivery = await deliverAdapter(params, deliveryText(modal.answers));
+        if (!delivery.ownerEntered) {
           return cancelled(
             params,
             "binding-mismatch",
@@ -408,7 +457,7 @@ export default function askUserQuestion(pi: ExtensionAPI): void {
             "Captain answer delivery could not be confirmed; the decision remains open. Do not resend automatically.",
             "unknown",
             modal.answers,
-            deliveryDiagnostic(delivery),
+            delivery.diagnostic,
           );
         }
         const details: AnswerDetails = {

--- a/.pi/extensions/fm-ask-user-question.ts
+++ b/.pi/extensions/fm-ask-user-question.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { realpathSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { StringEnum } from "@earendil-works/pi-ai";
@@ -82,6 +82,7 @@ type AnswerDetails = {
   answers: AnswerItem[];
   delivered: boolean | "unknown";
   reason?: "user" | "aborted" | "ui-unavailable" | "ui-failure" | "binding-mismatch" | "delivery-unknown";
+  diagnostic?: string;
 };
 
 type ModalResult = {
@@ -120,6 +121,8 @@ function cancelled(
   reason: AnswerDetails["reason"],
   text: string,
   delivered: false | "unknown" = false,
+  answers: AnswerItem[] = [],
+  diagnostic?: string,
 ) {
   const details: AnswerDetails = {
     schema: "fm-captain-answer.v1",
@@ -129,43 +132,12 @@ function cancelled(
     decisionKey: params.decisionKey,
     sourceGeneration: params.sourceGeneration,
     mode: params.mode,
-    answers: [],
+    answers,
     delivered,
     reason,
+    ...(diagnostic ? { diagnostic } : {}),
   };
   return { content: [{ type: "text" as const, text }], details };
-}
-
-function parentPid(pid: string): string {
-  const result = spawnSync("ps", ["-o", "ppid=", "-p", pid], { encoding: "utf8" });
-  return result.status === 0 ? result.stdout.trim() : "";
-}
-
-function ownsPrimaryLock(state: string): boolean {
-  let lockPid = "";
-  try {
-    lockPid = readFileSync(`${state}/.lock`, "utf8").trim();
-  } catch {
-    return false;
-  }
-  if (!/^[0-9]+$/.test(lockPid) || lockPid === "1") return false;
-  let pid = String(process.pid);
-  for (let depth = 0; depth < 8; depth += 1) {
-    if (pid === lockPid) return true;
-    pid = parentPid(pid);
-    if (!pid || pid === "1") return false;
-  }
-  return false;
-}
-
-function primaryBoundary(home: string): boolean {
-  try {
-    const canonicalHome = realpathSync(home);
-    const canonicalActive = realpathSync(activeHome);
-    return canonicalHome === canonicalActive && !existsSync(`${canonicalHome}/.fm-secondmate-home`) && ownsPrimaryLock(activeState);
-  } catch {
-    return false;
-  }
 }
 
 function runAdapter(command: "validate" | "deliver", params: QuestionParams, answer?: string) {
@@ -203,10 +175,18 @@ function normalize(params: QuestionParams): QuestionParams | undefined {
 
 function deliveryText(answers: AnswerItem[]): string {
   return answers.map((answer) => {
-    if (answer.type === "option") return `selected ${answer.id}: ${answer.text}`;
+    if (answer.type === "option") return `selected ${answer.id}`;
     if (answer.type === "other") return `other: ${answer.text}`;
     return answer.text;
   }).join("; ");
+}
+
+function deliveryDiagnostic(delivery: ReturnType<typeof runAdapter>): string {
+  const output = [delivery.stderr, delivery.stdout, delivery.error?.message]
+    .filter(Boolean)
+    .map(String)
+    .join(" ");
+  return cleanDisplay(output, 500) || `Firstmate delivery owner exited with status ${delivery.status ?? "unknown"}.`;
 }
 
 function showQuestion(params: QuestionParams, signal: AbortSignal, ctx: ExtensionContext) {
@@ -395,7 +375,6 @@ export default function askUserQuestion(pi: ExtensionAPI): void {
 
       return withPrimaryModal(async () => {
         if (abortSignal.aborted) return cancelled(params, "aborted", "Captain dialog was cancelled before display.");
-        if (!primaryBoundary(params.home)) return cancelled(params, "binding-mismatch", "Captain dialog primary binding no longer matches.");
         const validation = runAdapter("validate", params);
         if (validation.status !== 0) return cancelled(params, "binding-mismatch", "Captain dialog source binding no longer matches.");
 
@@ -407,7 +386,6 @@ export default function askUserQuestion(pi: ExtensionAPI): void {
         }
         if (!modal || modal.cancelled) return cancelled(params, modal?.reason || "ui-failure", "Captain left the decision open.");
         if (abortSignal.aborted) return cancelled(params, "aborted", "Captain dialog was cancelled before delivery.");
-        if (!primaryBoundary(params.home)) return cancelled(params, "binding-mismatch", "Captain dialog primary binding changed before delivery.");
 
         const delivery = runAdapter("deliver", params, deliveryText(modal.answers));
         if (delivery.status !== 0) {
@@ -416,6 +394,8 @@ export default function askUserQuestion(pi: ExtensionAPI): void {
             "delivery-unknown",
             "Captain answer delivery could not be confirmed; the decision remains open. Do not resend automatically.",
             "unknown",
+            modal.answers,
+            deliveryDiagnostic(delivery),
           );
         }
         const details: AnswerDetails = {

--- a/.pi/extensions/fm-ask-user-question.ts
+++ b/.pi/extensions/fm-ask-user-question.ts
@@ -1,0 +1,439 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import {
+  Editor,
+  type EditorTheme,
+  Key,
+  matchesKey,
+  Text,
+  truncateToWidth,
+  visibleWidth,
+  wrapTextWithAnsi,
+} from "@earendil-works/pi-tui";
+import { Type } from "typebox";
+
+const fixtureEnabled = process.env.FM_ASK_USER_QUESTION_FIXTURE === "1";
+const extensionFile = fileURLToPath(import.meta.url);
+const root = resolve(dirname(extensionFile), "../..");
+const activeHome = process.env.FM_HOME || process.env.FM_ROOT_OVERRIDE || root;
+const adapter = process.env.FM_ASK_USER_QUESTION_ADAPTER || `${root}/bin/fm-ask-user-question.sh`;
+
+const OptionSchema = Type.Object({
+  id: Type.String({ description: "Stable answer identifier" }),
+  label: Type.String({ description: "Captain-facing option label" }),
+  description: Type.Optional(Type.String({ description: "Short option explanation" })),
+});
+
+const ParamsSchema = Type.Object({
+  home: Type.String({ description: "Explicit Firstmate home that owns the task" }),
+  taskId: Type.String({ description: "Exact Firstmate task id" }),
+  decisionKey: Type.String({ description: "Exact open decision key" }),
+  sourceGeneration: Type.String({ description: "Generation returned by fm-ask-user-question.sh generation" }),
+  mode: Type.Union([Type.Literal("text"), Type.Literal("single"), Type.Literal("multi")]),
+  question: Type.String({ description: "Question shown to the captain" }),
+  details: Type.Optional(Type.String({ description: "Optional context shown below the question" })),
+  options: Type.Optional(Type.Array(OptionSchema, { description: "Options for single or multi mode" })),
+  allowOther: Type.Optional(Type.Boolean({ description: "Offer a free-text Other answer" })),
+});
+
+type QuestionOption = {
+  id: string;
+  label: string;
+  description?: string;
+};
+
+type QuestionParams = {
+  home: string;
+  taskId: string;
+  decisionKey: string;
+  sourceGeneration: string;
+  mode: "text" | "single" | "multi";
+  question: string;
+  details?: string;
+  options?: QuestionOption[];
+  allowOther?: boolean;
+};
+
+type AnswerItem = {
+  type: "text" | "option" | "other";
+  id?: string;
+  text: string;
+};
+
+type AnswerDetails = {
+  schema: "fm-captain-answer.v1";
+  status: "answered" | "cancelled";
+  home: string;
+  taskId: string;
+  decisionKey: string;
+  sourceGeneration: string;
+  mode: QuestionParams["mode"];
+  answers: AnswerItem[];
+  delivered: boolean | "unknown";
+  reason?: "user" | "aborted" | "ui-unavailable" | "ui-failure" | "binding-mismatch" | "delivery-unknown";
+};
+
+type ModalResult = {
+  cancelled: boolean;
+  reason?: "user" | "aborted";
+  answers: AnswerItem[];
+};
+
+let modalTail: Promise<void> = Promise.resolve();
+
+async function withPrimaryModal<T>(show: () => Promise<T>): Promise<T> {
+  const previous = modalTail.catch(() => undefined);
+  let release = (): void => undefined;
+  const gate = new Promise<void>((resolveGate) => {
+    release = resolveGate;
+  });
+  modalTail = previous.then(() => gate);
+  await previous;
+  try {
+    return await show();
+  } finally {
+    release();
+  }
+}
+
+function cleanDisplay(value: string, limit: number): string {
+  return value.replace(/[\u0000-\u001f\u007f-\u009f]/g, " ").replace(/\s+/g, " ").trim().slice(0, limit);
+}
+
+function cleanAnswer(value: string): string {
+  return cleanDisplay(value, 1000);
+}
+
+function cancelled(
+  params: QuestionParams,
+  reason: AnswerDetails["reason"],
+  text: string,
+  delivered: false | "unknown" = false,
+) {
+  const details: AnswerDetails = {
+    schema: "fm-captain-answer.v1",
+    status: "cancelled",
+    home: params.home,
+    taskId: params.taskId,
+    decisionKey: params.decisionKey,
+    sourceGeneration: params.sourceGeneration,
+    mode: params.mode,
+    answers: [],
+    delivered,
+    reason,
+  };
+  return { content: [{ type: "text" as const, text }], details };
+}
+
+function parentPid(pid: string): string {
+  const result = spawnSync("ps", ["-o", "ppid=", "-p", pid], { encoding: "utf8" });
+  return result.status === 0 ? result.stdout.trim() : "";
+}
+
+function ownsPrimaryLock(home: string): boolean {
+  let lockPid = "";
+  try {
+    lockPid = readFileSync(`${home}/state/.lock`, "utf8").trim();
+  } catch {
+    return false;
+  }
+  if (!/^[0-9]+$/.test(lockPid) || lockPid === "1") return false;
+  let pid = String(process.pid);
+  for (let depth = 0; depth < 8; depth += 1) {
+    if (pid === lockPid) return true;
+    pid = parentPid(pid);
+    if (!pid || pid === "1") return false;
+  }
+  return false;
+}
+
+function primaryBoundary(home: string): boolean {
+  try {
+    const canonicalHome = realpathSync(home);
+    const canonicalActive = realpathSync(activeHome);
+    return canonicalHome === canonicalActive && !existsSync(`${canonicalHome}/.fm-secondmate-home`) && ownsPrimaryLock(canonicalHome);
+  } catch {
+    return false;
+  }
+}
+
+function runAdapter(command: "validate" | "deliver", params: QuestionParams, answer?: string) {
+  const args = [
+    command,
+    "--home", params.home,
+    "--task", params.taskId,
+    "--key", params.decisionKey,
+    "--generation", params.sourceGeneration,
+  ];
+  if (answer !== undefined) args.push("--answer", answer);
+  return spawnSync(adapter, args, {
+    encoding: "utf8",
+    env: { ...process.env, FM_HOME: activeHome },
+    timeout: 10_000,
+  });
+}
+
+function normalize(params: QuestionParams): QuestionParams | undefined {
+  if (!/^[A-Za-z0-9._-]+$/.test(params.taskId) || !/^[A-Za-z0-9._-]+$/.test(params.decisionKey)) return undefined;
+  if (!/^sha256:[0-9a-f]{64}$/.test(params.sourceGeneration)) return undefined;
+  const question = cleanDisplay(params.question, 500);
+  const details = params.details ? cleanDisplay(params.details, 1000) : undefined;
+  const options = (params.options || []).slice(0, 12).map((option) => ({
+    id: cleanDisplay(option.id, 80),
+    label: cleanDisplay(option.label, 160),
+    description: option.description ? cleanDisplay(option.description, 300) : undefined,
+  }));
+  if (!question) return undefined;
+  if (new Set(options.map((option) => option.id)).size !== options.length) return undefined;
+  if (options.some((option) => !/^[A-Za-z0-9._-]+$/.test(option.id) || !option.label)) return undefined;
+  if (params.mode !== "text" && options.length === 0 && params.allowOther !== true) return undefined;
+  return { ...params, question, details, options };
+}
+
+function deliveryText(answers: AnswerItem[]): string {
+  return answers.map((answer) => {
+    if (answer.type === "option") return `selected ${answer.id}: ${answer.text}`;
+    if (answer.type === "other") return `other: ${answer.text}`;
+    return answer.text;
+  }).join("; ");
+}
+
+function showQuestion(params: QuestionParams, signal: AbortSignal, ctx: ExtensionContext) {
+  return ctx.ui.custom<ModalResult>((tui, theme, _keybindings, done) => {
+    const options = params.options || [];
+    const allowOther = params.allowOther === true;
+    const selected = new Set<string>();
+    let optionIndex = 0;
+    let editing = params.mode === "text";
+    let finished = false;
+    let cacheWidth = -1;
+    let cachedLines: string[] | undefined;
+    const editorTheme: EditorTheme = {
+      borderColor: (text) => theme.fg("accent", text),
+      selectList: {
+        selectedPrefix: (text) => theme.fg("accent", text),
+        selectedText: (text) => theme.fg("accent", text),
+        description: (text) => theme.fg("muted", text),
+        scrollInfo: (text) => theme.fg("dim", text),
+        noMatch: (text) => theme.fg("warning", text),
+      },
+    };
+    const editor = new Editor(tui, editorTheme);
+
+    const refresh = (): void => {
+      cachedLines = undefined;
+      tui.requestRender();
+    };
+    const finish = (result: ModalResult): void => {
+      if (finished) return;
+      finished = true;
+      signal.removeEventListener("abort", abort);
+      done(result);
+    };
+    const abort = (): void => finish({ cancelled: true, reason: "aborted", answers: [] });
+    signal.addEventListener("abort", abort, { once: true });
+    if (signal.aborted) abort();
+
+    const submitEditor = (value: string): void => {
+      const text = cleanAnswer(value);
+      if (!text) return;
+      if (params.mode === "text") {
+        finish({ cancelled: false, answers: [{ type: "text", text }] });
+        return;
+      }
+      if (params.mode === "single") {
+        finish({ cancelled: false, answers: [{ type: "other", text }] });
+        return;
+      }
+      editing = false;
+      editor.setText(text);
+      refresh();
+    };
+    editor.onSubmit = submitEditor;
+
+    const submitMulti = (): void => {
+      const answers: AnswerItem[] = options
+        .filter((option) => selected.has(option.id))
+        .map((option) => ({ type: "option", id: option.id, text: option.label }));
+      const other = cleanAnswer(editor.getText());
+      if (other) answers.push({ type: "other", text: other });
+      if (answers.length > 0) finish({ cancelled: false, answers });
+    };
+
+    const rowCount = (): number => options.length + (allowOther ? 1 : 0) + (params.mode === "multi" ? 1 : 0);
+
+    const handleInput = (data: string): void => {
+      if (finished) return;
+      if (matchesKey(data, Key.escape)) {
+        finish({ cancelled: true, reason: "user", answers: [] });
+        return;
+      }
+      if (editing) {
+        editor.handleInput(data);
+        refresh();
+        return;
+      }
+      if (matchesKey(data, Key.up)) {
+        optionIndex = Math.max(0, optionIndex - 1);
+        refresh();
+        return;
+      }
+      if (matchesKey(data, Key.down)) {
+        optionIndex = Math.min(Math.max(0, rowCount() - 1), optionIndex + 1);
+        refresh();
+        return;
+      }
+      if (!matchesKey(data, Key.enter)) return;
+      if (optionIndex < options.length) {
+        const option = options[optionIndex];
+        if (params.mode === "multi") {
+          if (selected.has(option.id)) selected.delete(option.id);
+          else selected.add(option.id);
+          refresh();
+        } else {
+          finish({ cancelled: false, answers: [{ type: "option", id: option.id, text: option.label }] });
+        }
+        return;
+      }
+      if (allowOther && optionIndex === options.length) {
+        editing = true;
+        editor.setText(params.mode === "multi" ? editor.getText() : "");
+        refresh();
+        return;
+      }
+      submitMulti();
+    };
+
+    const render = (width: number): string[] => {
+      const renderWidth = Math.max(1, width);
+      if (cachedLines && cacheWidth === renderWidth) return cachedLines;
+      cacheWidth = renderWidth;
+      const lines: string[] = [];
+      const add = (text: string): void => {
+        const wrapped = wrapTextWithAnsi(text, renderWidth);
+        lines.push(...(wrapped.length > 0 ? wrapped : [""]));
+      };
+      const addRow = (prefix: string, text: string): void => {
+        const prefixWidth = visibleWidth(prefix);
+        if (prefixWidth >= renderWidth) {
+          add(`${prefix}${text}`);
+          return;
+        }
+        const wrapped = wrapTextWithAnsi(text, renderWidth - prefixWidth);
+        wrapped.forEach((line, index) => lines.push(`${index === 0 ? prefix : " ".repeat(prefixWidth)}${line}`));
+      };
+
+      lines.push(theme.fg("accent", "─".repeat(renderWidth)));
+      addRow(" ", theme.fg("accent", theme.bold(`Captain decision · ${params.taskId} · ${params.decisionKey}`)));
+      addRow(" ", theme.fg("text", params.question));
+      if (params.details) addRow(" ", theme.fg("muted", params.details));
+      lines.push("");
+
+      if (editing) {
+        addRow(" ", theme.fg("muted", params.mode === "multi" ? "Other answer:" : "Your answer:"));
+        editor.render(Math.max(1, renderWidth - 2)).forEach((line) => lines.push(truncateToWidth(` ${line}`, renderWidth)));
+      } else {
+        options.forEach((option, index) => {
+          const cursor = index === optionIndex ? "> " : "  ";
+          const mark = params.mode === "multi" ? (selected.has(option.id) ? "[x] " : "[ ] ") : "";
+          addRow(cursor, theme.fg(index === optionIndex ? "accent" : "text", `${mark}${option.label}`));
+          if (option.description) addRow("      ", theme.fg("muted", option.description));
+        });
+        if (allowOther) {
+          const index = options.length;
+          const other = cleanAnswer(editor.getText());
+          addRow(index === optionIndex ? "> " : "  ", theme.fg(index === optionIndex ? "accent" : "text", other ? `Other: ${other}` : "Other..."));
+        }
+        if (params.mode === "multi") {
+          const index = options.length + (allowOther ? 1 : 0);
+          addRow(index === optionIndex ? "> " : "  ", theme.fg(index === optionIndex ? "accent" : "success", "Submit selected answers"));
+        }
+      }
+
+      lines.push("");
+      addRow(" ", theme.fg("dim", editing ? "Enter submits · Esc cancels" : "↑↓ navigate · Enter selects · Esc cancels"));
+      lines.push(theme.fg("accent", "─".repeat(renderWidth)));
+      cachedLines = lines.map((line) => truncateToWidth(line, renderWidth));
+      return cachedLines;
+    };
+
+    return {
+      render,
+      invalidate: refresh,
+      handleInput,
+      get focused() { return editor.focused; },
+      set focused(value: boolean) { editor.focused = value; },
+      dispose: () => signal.removeEventListener("abort", abort),
+    };
+  });
+}
+
+export default function askUserQuestion(pi: ExtensionAPI): void {
+  if (!fixtureEnabled) return;
+  pi.registerTool({
+    name: "fm_ask_user_question",
+    label: "Ask Captain",
+    description: "Fixture-stage primary-only dialog for one already-open keyed Firstmate decision.",
+    parameters: ParamsSchema,
+    executionMode: "sequential",
+    async execute(_toolCallId, rawParams, signal, _onUpdate, ctx) {
+      const params = normalize(rawParams as QuestionParams);
+      const abortSignal = signal || new AbortController().signal;
+      if (!params) return cancelled(rawParams as QuestionParams, "binding-mismatch", "Captain dialog rejected invalid input.");
+      if (ctx.mode !== "tui") return cancelled(params, "ui-unavailable", "Captain dialog requires the primary Pi TUI.");
+
+      return withPrimaryModal(async () => {
+        if (abortSignal.aborted) return cancelled(params, "aborted", "Captain dialog was cancelled before display.");
+        if (!primaryBoundary(params.home)) return cancelled(params, "binding-mismatch", "Captain dialog primary binding no longer matches.");
+        const validation = runAdapter("validate", params);
+        if (validation.status !== 0) return cancelled(params, "binding-mismatch", "Captain dialog source binding no longer matches.");
+
+        let modal: ModalResult | undefined;
+        try {
+          modal = await showQuestion(params, abortSignal, ctx);
+        } catch {
+          return cancelled(params, "ui-failure", "Captain dialog could not be displayed.");
+        }
+        if (!modal || modal.cancelled) return cancelled(params, modal?.reason || "ui-failure", "Captain left the decision open.");
+        if (abortSignal.aborted) return cancelled(params, "aborted", "Captain dialog was cancelled before delivery.");
+        if (!primaryBoundary(params.home)) return cancelled(params, "binding-mismatch", "Captain dialog primary binding changed before delivery.");
+
+        const delivery = runAdapter("deliver", params, deliveryText(modal.answers));
+        if (delivery.status !== 0) {
+          return cancelled(
+            params,
+            "delivery-unknown",
+            "Captain answer delivery could not be confirmed; the decision remains open. Do not resend automatically.",
+            "unknown",
+          );
+        }
+        const details: AnswerDetails = {
+          schema: "fm-captain-answer.v1",
+          status: "answered",
+          home: params.home,
+          taskId: params.taskId,
+          decisionKey: params.decisionKey,
+          sourceGeneration: params.sourceGeneration,
+          mode: params.mode,
+          answers: modal.answers,
+          delivered: true,
+        };
+        return { content: [{ type: "text" as const, text: "Captain answer delivered through Firstmate's keyed decision owner." }], details };
+      });
+    },
+    renderCall(args, theme) {
+      const task = typeof args.taskId === "string" ? cleanDisplay(args.taskId, 80) : "unknown";
+      const key = typeof args.decisionKey === "string" ? cleanDisplay(args.decisionKey, 80) : "unknown";
+      return new Text(theme.fg("toolTitle", theme.bold(`Ask Captain · ${task} · ${key}`)), 0, 0);
+    },
+    renderResult(result, _options, theme) {
+      const details = result.details as AnswerDetails | undefined;
+      if (!details) return new Text(theme.fg("warning", "Captain dialog returned no structured result."), 0, 0);
+      const text = details.status === "answered" ? "Captain answer delivered" : `Decision left open · ${details.reason || "cancelled"}`;
+      return new Text(theme.fg(details.status === "answered" ? "success" : "warning", text), 0, 0);
+    },
+  });
+}

--- a/.pi/extensions/fm-ask-user-question.ts
+++ b/.pi/extensions/fm-ask-user-question.ts
@@ -391,7 +391,8 @@ export default function askUserQuestion(pi: ExtensionAPI): void {
         if (abortSignal.aborted) return cancelled(params, "aborted", "Captain dialog was cancelled before delivery.");
 
         const delivery = runAdapter("deliver", params, deliveryText(modal.answers));
-        if (delivery.status === 3) {
+        const deliveryWasAttempted = delivery.status === 4 || (delivery.status === null && delivery.pid > 0);
+        if (delivery.status !== 0 && !deliveryWasAttempted) {
           return cancelled(
             params,
             "binding-mismatch",

--- a/.pi/extensions/fm-ask-user-question.ts
+++ b/.pi/extensions/fm-ask-user-question.ts
@@ -28,7 +28,6 @@ try {
   activeState = configuredState;
 }
 const adapter = process.env.FM_ASK_USER_QUESTION_ADAPTER || `${root}/bin/fm-ask-user-question.sh`;
-const adapterDeliveryUnknown = 4;
 
 const OptionSchema = Type.Object({
   id: Type.String({ description: "Stable answer identifier" }),
@@ -153,7 +152,7 @@ function runAdapter(command: "validate" | "deliver", params: QuestionParams, ans
   return spawnSync(adapter, args, {
     encoding: "utf8",
     env: { ...process.env, FM_HOME: activeHome, FM_STATE_OVERRIDE: activeState },
-    timeout: 10_000,
+    ...(command === "validate" ? { timeout: 10_000 } : {}),
   });
 }
 
@@ -392,7 +391,7 @@ export default function askUserQuestion(pi: ExtensionAPI): void {
         if (abortSignal.aborted) return cancelled(params, "aborted", "Captain dialog was cancelled before delivery.");
 
         const delivery = runAdapter("deliver", params, deliveryText(modal.answers));
-        if (delivery.status !== 0 && delivery.status !== adapterDeliveryUnknown) {
+        if (delivery.status === 3) {
           return cancelled(
             params,
             "binding-mismatch",
@@ -401,7 +400,7 @@ export default function askUserQuestion(pi: ExtensionAPI): void {
             modal.answers,
           );
         }
-        if (delivery.status === adapterDeliveryUnknown) {
+        if (delivery.status !== 0) {
           return cancelled(
             params,
             "delivery-unknown",

--- a/.pi/extensions/fm-ask-user-question.ts
+++ b/.pi/extensions/fm-ask-user-question.ts
@@ -420,6 +420,14 @@ export default function askUserQuestion(pi: ExtensionAPI): void {
     renderResult(result, _options, theme) {
       const details = result.details as AnswerDetails | undefined;
       if (!details) return new Text(theme.fg("warning", "Captain dialog returned no structured result."), 0, 0);
+      if (details.reason === "delivery-unknown") {
+        const diagnostic = cleanDisplay(details.diagnostic || "Firstmate delivery owner returned no diagnostic.", 500);
+        return new Text(
+          theme.fg("warning", `Decision left open · delivery-unknown\n${diagnostic}\nDo not resend automatically.`),
+          0,
+          0,
+        );
+      }
       const text = details.status === "answered" ? "Captain answer delivered" : `Decision left open · ${details.reason || "cancelled"}`;
       return new Text(theme.fg(details.status === "answered" ? "success" : "warning", text), 0, 0);
     },

--- a/.pi/extensions/fm-ask-user-question.ts
+++ b/.pi/extensions/fm-ask-user-question.ts
@@ -19,6 +19,13 @@ const fixtureEnabled = process.env.FM_ASK_USER_QUESTION_FIXTURE === "1";
 const extensionFile = fileURLToPath(import.meta.url);
 const root = resolve(dirname(extensionFile), "../..");
 const activeHome = process.env.FM_HOME || process.env.FM_ROOT_OVERRIDE || root;
+const configuredState = process.env.FM_STATE_OVERRIDE || `${activeHome}/state`;
+let activeState = configuredState;
+try {
+  activeState = realpathSync(configuredState);
+} catch {
+  activeState = configuredState;
+}
 const adapter = process.env.FM_ASK_USER_QUESTION_ADAPTER || `${root}/bin/fm-ask-user-question.sh`;
 
 const OptionSchema = Type.Object({
@@ -133,10 +140,10 @@ function parentPid(pid: string): string {
   return result.status === 0 ? result.stdout.trim() : "";
 }
 
-function ownsPrimaryLock(home: string): boolean {
+function ownsPrimaryLock(state: string): boolean {
   let lockPid = "";
   try {
-    lockPid = readFileSync(`${home}/state/.lock`, "utf8").trim();
+    lockPid = readFileSync(`${state}/.lock`, "utf8").trim();
   } catch {
     return false;
   }
@@ -154,7 +161,7 @@ function primaryBoundary(home: string): boolean {
   try {
     const canonicalHome = realpathSync(home);
     const canonicalActive = realpathSync(activeHome);
-    return canonicalHome === canonicalActive && !existsSync(`${canonicalHome}/.fm-secondmate-home`) && ownsPrimaryLock(canonicalHome);
+    return canonicalHome === canonicalActive && !existsSync(`${canonicalHome}/.fm-secondmate-home`) && ownsPrimaryLock(activeState);
   } catch {
     return false;
   }
@@ -171,7 +178,7 @@ function runAdapter(command: "validate" | "deliver", params: QuestionParams, ans
   if (answer !== undefined) args.push("--answer", answer);
   return spawnSync(adapter, args, {
     encoding: "utf8",
-    env: { ...process.env, FM_HOME: activeHome },
+    env: { ...process.env, FM_HOME: activeHome, FM_STATE_OVERRIDE: activeState },
     timeout: 10_000,
   });
 }

--- a/.pi/extensions/fm-ask-user-question.ts
+++ b/.pi/extensions/fm-ask-user-question.ts
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { StringEnum } from "@earendil-works/pi-ai";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import {
   Editor,
@@ -39,7 +40,7 @@ const ParamsSchema = Type.Object({
   taskId: Type.String({ description: "Exact Firstmate task id" }),
   decisionKey: Type.String({ description: "Exact open decision key" }),
   sourceGeneration: Type.String({ description: "Generation returned by fm-ask-user-question.sh generation" }),
-  mode: Type.Union([Type.Literal("text"), Type.Literal("single"), Type.Literal("multi")]),
+  mode: StringEnum(["text", "single", "multi"] as const),
   question: Type.String({ description: "Question shown to the captain" }),
   details: Type.Optional(Type.String({ description: "Optional context shown below the question" })),
   options: Type.Optional(Type.Array(OptionSchema, { description: "Options for single or multi mode" })),

--- a/.pi/extensions/fm-ask-user-question.ts
+++ b/.pi/extensions/fm-ask-user-question.ts
@@ -28,6 +28,7 @@ try {
   activeState = configuredState;
 }
 const adapter = process.env.FM_ASK_USER_QUESTION_ADAPTER || `${root}/bin/fm-ask-user-question.sh`;
+const adapterDeliveryUnknown = 4;
 
 const OptionSchema = Type.Object({
   id: Type.String({ description: "Stable answer identifier" }),
@@ -185,8 +186,11 @@ function deliveryDiagnostic(delivery: ReturnType<typeof runAdapter>): string {
   const output = [delivery.stderr, delivery.stdout, delivery.error?.message]
     .filter(Boolean)
     .map(String)
-    .join(" ");
-  return cleanDisplay(output, 500) || `Firstmate delivery owner exited with status ${delivery.status ?? "unknown"}.`;
+    .join(" ")
+    .replace(/[\u0000-\u001f\u007f-\u009f]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return output.slice(-500) || `Firstmate delivery owner exited with status ${delivery.status ?? "unknown"}.`;
 }
 
 function showQuestion(params: QuestionParams, signal: AbortSignal, ctx: ExtensionContext) {
@@ -388,7 +392,16 @@ export default function askUserQuestion(pi: ExtensionAPI): void {
         if (abortSignal.aborted) return cancelled(params, "aborted", "Captain dialog was cancelled before delivery.");
 
         const delivery = runAdapter("deliver", params, deliveryText(modal.answers));
-        if (delivery.status !== 0) {
+        if (delivery.status !== 0 && delivery.status !== adapterDeliveryUnknown) {
+          return cancelled(
+            params,
+            "binding-mismatch",
+            "Captain dialog source binding no longer matches.",
+            false,
+            modal.answers,
+          );
+        }
+        if (delivery.status === adapterDeliveryUnknown) {
           return cancelled(
             params,
             "delivery-unknown",

--- a/.pi/extensions/fm-calm.ts
+++ b/.pi/extensions/fm-calm.ts
@@ -454,6 +454,7 @@ export default function (pi: ExtensionAPI) {
         repaintCalmToolRows();
         ctx.ui.setStatus("firstmate-calm", undefined);
       }, 0);
+      return undefined;
     });
   });
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ GitHub Actions and Dependabot are exempt so their automation keeps working, but 
 
 6. Run `no-mistakes` to attach to the pipeline, watch findings, authorize auto-fixes, and review ask-user findings as needed.
    Follow the installed no-mistakes version's SKILL.md and live `axi` help for gate mechanics.
-7. Once the pipeline passes, it pushes the branch to your fork and opens the PR against the parent repo for you.
+7. Once the pipeline passes, it pushes the branch to your fork and opens the PR against the parent repo for you. Any later commit changes the PR head and requires another `git push no-mistakes` so the attestation binds to that new head.
 
 See the [no-mistakes quick start](https://kunchenguid.github.io/no-mistakes/start-here/quick-start/) for the full first-run walkthrough.
 

--- a/bin/fm-ask-user-question.sh
+++ b/bin/fm-ask-user-question.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# fm-ask-user-question.sh - fixture-stage source binding and delivery adapter
+# for the primary Pi ask-user-question prototype.
+#
+# Commands:
+#   fm-ask-user-question.sh generation --home <home> --task <id> --key <key>
+#   fm-ask-user-question.sh validate --home <home> --task <id> --key <key> --generation <sha256:...>
+#   fm-ask-user-question.sh deliver --home <home> --task <id> --key <key> --generation <sha256:...> --answer <text>
+#
+# This adapter owns no decision state.
+# It binds a presentation to the exact task metadata and status bytes, verifies
+# that the keyed decision is still open through fm-classify-lib.sh, and delegates
+# successful delivery to fm-send.sh --resolve-key.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=bin/fm-classify-lib.sh
+. "$ROOT/bin/fm-classify-lib.sh"
+
+die() {
+  printf 'fm-ask-user-question: %s\n' "$*" >&2
+  exit 2
+}
+
+hash_stream() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 | awk '{print $1}'
+  elif command -v sha256sum >/dev/null 2>&1; then
+    sha256sum | awk '{print $1}'
+  else
+    die 'shasum or sha256sum is required'
+  fi
+}
+
+canonical_dir() {
+  [ -d "$1" ] || return 1
+  (cd -- "$1" 2>/dev/null && pwd -P)
+}
+
+parse_binding() {
+  home=
+  task=
+  key=
+  generation=
+  answer=
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --home) [ "$#" -ge 2 ] || die '--home requires a value'; home=$2; shift 2 ;;
+      --task) [ "$#" -ge 2 ] || die '--task requires a value'; task=$2; shift 2 ;;
+      --key) [ "$#" -ge 2 ] || die '--key requires a value'; key=$2; shift 2 ;;
+      --generation) [ "$#" -ge 2 ] || die '--generation requires a value'; generation=$2; shift 2 ;;
+      --answer) [ "$#" -ge 2 ] || die '--answer requires a value'; answer=$2; shift 2 ;;
+      *) die "unknown argument: $1" ;;
+    esac
+  done
+}
+
+validate_identity() {
+  local active_home canonical_home canonical_active
+  [ -n "$home" ] || die '--home is required'
+  [ -n "$task" ] || die '--task is required'
+  [ -n "$key" ] || die '--key is required'
+  case "$task" in
+    *[!A-Za-z0-9._-]*|'') die 'invalid task id' ;;
+  esac
+  case "$key" in
+    *[!A-Za-z0-9._-]*|'') die 'invalid decision key' ;;
+  esac
+  active_home=${FM_HOME:-${FM_ROOT_OVERRIDE:-$ROOT}}
+  canonical_home=$(canonical_dir "$home") || die 'home does not exist'
+  canonical_active=$(canonical_dir "$active_home") || die 'active FM_HOME does not exist'
+  [ "$canonical_home" = "$canonical_active" ] || die 'supplied home is not the active FM_HOME'
+  [ ! -e "$canonical_home/.fm-secondmate-home" ] || die 'captain dialog is primary-only'
+  home=$canonical_home
+  meta="$home/state/$task.meta"
+  status="$home/state/$task.status"
+  [ -f "$meta" ] && [ -r "$meta" ] && [ ! -L "$meta" ] || die 'task metadata is missing or unsafe'
+  [ -f "$status" ] && [ -r "$status" ] && [ ! -L "$status" ] || die 'task status is missing or unsafe'
+}
+
+require_open_key() {
+  local open line found=0
+  open=$(status_open_decisions "$status")
+  while IFS= read -r line; do
+    case "$line" in
+      "$key"$'\t'*) found=1; break ;;
+    esac
+  done <<EOF
+$open
+EOF
+  [ "$found" -eq 1 ] || die 'keyed decision is no longer open for this task'
+}
+
+current_generation() {
+  local digest
+  digest=$({
+    printf 'home\0%s\0task\0%s\0key\0%s\0meta\0' "$home" "$task" "$key"
+    cat "$meta"
+    printf '\0status\0'
+    cat "$status"
+  } | hash_stream)
+  printf 'sha256:%s\n' "$digest"
+}
+
+validate_generation() {
+  local current
+  [[ "$generation" =~ ^sha256:[0-9a-f]{64}$ ]] || die 'invalid source generation'
+  current=$(current_generation)
+  [ "$generation" = "$current" ] || die 'source generation no longer matches the task'
+}
+
+command=${1:-}
+[ -n "$command" ] || die 'a command is required'
+shift
+parse_binding "$@"
+validate_identity
+require_open_key
+
+case "$command" in
+  generation)
+    [ -z "$generation" ] || die 'generation does not accept --generation'
+    [ -z "$answer" ] || die 'generation does not accept --answer'
+    current_generation
+    ;;
+  validate)
+    [ -n "$generation" ] || die '--generation is required'
+    [ -z "$answer" ] || die 'validate does not accept --answer'
+    validate_generation
+    printf 'valid\n'
+    ;;
+  deliver)
+    [ -n "$generation" ] || die '--generation is required'
+    [ -n "$answer" ] || die '--answer is required'
+    validate_generation
+    "$ROOT/bin/fm-send.sh" "$task" --resolve-key "$key" "Captain answer: $answer"
+    ;;
+  *) die "unknown command: $command" ;;
+esac

--- a/bin/fm-ask-user-question.sh
+++ b/bin/fm-ask-user-question.sh
@@ -16,6 +16,8 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck source=bin/fm-classify-lib.sh
 . "$ROOT/bin/fm-classify-lib.sh"
+# shellcheck source=bin/fm-session-lock-lib.sh
+. "$ROOT/bin/fm-session-lock-lib.sh"
 
 die() {
   printf 'fm-ask-user-question: %s\n' "$*" >&2
@@ -112,6 +114,10 @@ validate_generation() {
   [ "$generation" = "$current" ] || die 'source generation no longer matches the task'
 }
 
+require_primary_lock() {
+  fm_session_lock_owned_by_self "$state" || die 'active session does not own the primary lock'
+}
+
 command=${1:-}
 [ -n "$command" ] || die 'a command is required'
 shift
@@ -128,12 +134,14 @@ case "$command" in
   validate)
     [ -n "$generation" ] || die '--generation is required'
     [ -z "$answer" ] || die 'validate does not accept --answer'
+    require_primary_lock
     validate_generation
     printf 'valid\n'
     ;;
   deliver)
     [ -n "$generation" ] || die '--generation is required'
     [ -n "$answer" ] || die '--answer is required'
+    require_primary_lock
     validate_generation
     FM_HOME="$home" FM_STATE_OVERRIDE="$state" \
       "$ROOT/bin/fm-send.sh" "$task" --resolve-key "$key" "Captain answer: $answer"

--- a/bin/fm-ask-user-question.sh
+++ b/bin/fm-ask-user-question.sh
@@ -161,8 +161,6 @@ case "$command" in
     trap - ERR
     if [ -n "${FM_ASK_USER_QUESTION_OWNER_ENTRY_MARKER:-}" ]; then
       [ "${FM_ASK_USER_QUESTION_OWNER_ENTRY_FD:-}" = 3 ] || exit "$PREFLIGHT_FAILURE"
-      printf '%s\n' "$FM_ASK_USER_QUESTION_OWNER_ENTRY_MARKER" >&3 || exit "$PREFLIGHT_FAILURE"
-      exec 3>&-
     fi
     if FM_HOME="$home" FM_STATE_OVERRIDE="$state" \
       "$ROOT/bin/fm-send.sh" "$task" --resolve-key "$key" "Captain answer: $answer"; then

--- a/bin/fm-ask-user-question.sh
+++ b/bin/fm-ask-user-question.sh
@@ -127,7 +127,11 @@ command=${1:-}
 [ -n "$command" ] || die 'a command is required'
 case "$command" in
   generation|validate) ;;
-  deliver) failure_status=$PREFLIGHT_FAILURE ;;
+  deliver)
+    failure_status=$PREFLIGHT_FAILURE
+    set -E
+    trap 'exit "$PREFLIGHT_FAILURE"' ERR
+    ;;
   *) die "unknown command: $command" ;;
 esac
 shift
@@ -154,6 +158,7 @@ case "$command" in
     require_primary_lock
     validate_generation
     [ -x "$ROOT/bin/fm-send.sh" ] || die 'delivery owner is missing or not executable'
+    trap - ERR
     if FM_HOME="$home" FM_STATE_OVERRIDE="$state" \
       "$ROOT/bin/fm-send.sh" "$task" --resolve-key "$key" "Captain answer: $answer"; then
       :

--- a/bin/fm-ask-user-question.sh
+++ b/bin/fm-ask-user-question.sh
@@ -72,7 +72,8 @@ validate_identity() {
   canonical_home=$(canonical_dir "$home") || die 'home does not exist'
   canonical_active=$(canonical_dir "$active_home") || die 'active FM_HOME does not exist'
   [ "$canonical_home" = "$canonical_active" ] || die 'supplied home is not the active FM_HOME'
-  [ ! -e "$canonical_home/.fm-secondmate-home" ] || die 'captain dialog is primary-only'
+  [ ! -e "$canonical_home/.fm-secondmate-home" ] && [ ! -L "$canonical_home/.fm-secondmate-home" ] \
+    || die 'captain dialog is primary-only'
   home=$canonical_home
   active_state=${FM_STATE_OVERRIDE:-$home/state}
   canonical_state=$(canonical_dir "$active_state") || die 'active state dir does not exist'

--- a/bin/fm-ask-user-question.sh
+++ b/bin/fm-ask-user-question.sh
@@ -153,6 +153,7 @@ case "$command" in
     [ -n "$answer" ] || die '--answer is required'
     require_primary_lock
     validate_generation
+    [ -x "$ROOT/bin/fm-send.sh" ] || die 'delivery owner is missing or not executable'
     if FM_HOME="$home" FM_STATE_OVERRIDE="$state" \
       "$ROOT/bin/fm-send.sh" "$task" --resolve-key "$key" "Captain answer: $answer"; then
       :

--- a/bin/fm-ask-user-question.sh
+++ b/bin/fm-ask-user-question.sh
@@ -56,7 +56,7 @@ parse_binding() {
 }
 
 validate_identity() {
-  local active_home canonical_home canonical_active
+  local active_home active_state canonical_home canonical_active canonical_state
   [ -n "$home" ] || die '--home is required'
   [ -n "$task" ] || die '--task is required'
   [ -n "$key" ] || die '--key is required'
@@ -72,8 +72,11 @@ validate_identity() {
   [ "$canonical_home" = "$canonical_active" ] || die 'supplied home is not the active FM_HOME'
   [ ! -e "$canonical_home/.fm-secondmate-home" ] || die 'captain dialog is primary-only'
   home=$canonical_home
-  meta="$home/state/$task.meta"
-  status="$home/state/$task.status"
+  active_state=${FM_STATE_OVERRIDE:-$home/state}
+  canonical_state=$(canonical_dir "$active_state") || die 'active state dir does not exist'
+  state=$canonical_state
+  meta="$state/$task.meta"
+  status="$state/$task.status"
   [ -f "$meta" ] && [ -r "$meta" ] && [ ! -L "$meta" ] || die 'task metadata is missing or unsafe'
   [ -f "$status" ] && [ -r "$status" ] && [ ! -L "$status" ] || die 'task status is missing or unsafe'
 }
@@ -94,7 +97,7 @@ EOF
 current_generation() {
   local digest
   digest=$({
-    printf 'home\0%s\0task\0%s\0key\0%s\0meta\0' "$home" "$task" "$key"
+    printf 'home\0%s\0state\0%s\0task\0%s\0key\0%s\0meta\0' "$home" "$state" "$task" "$key"
     cat "$meta"
     printf '\0status\0'
     cat "$status"
@@ -132,7 +135,8 @@ case "$command" in
     [ -n "$generation" ] || die '--generation is required'
     [ -n "$answer" ] || die '--answer is required'
     validate_generation
-    "$ROOT/bin/fm-send.sh" "$task" --resolve-key "$key" "Captain answer: $answer"
+    FM_HOME="$home" FM_STATE_OVERRIDE="$state" \
+      "$ROOT/bin/fm-send.sh" "$task" --resolve-key "$key" "Captain answer: $answer"
     ;;
   *) die "unknown command: $command" ;;
 esac

--- a/bin/fm-ask-user-question.sh
+++ b/bin/fm-ask-user-question.sh
@@ -159,6 +159,10 @@ case "$command" in
     validate_generation
     [ -x "$ROOT/bin/fm-send.sh" ] || die 'delivery owner is missing or not executable'
     trap - ERR
+    if [ -n "${FM_ASK_USER_QUESTION_OWNER_ENTRY_MARKER:-}" ]; then
+      [ "${FM_ASK_USER_QUESTION_OWNER_ENTRY_FD:-}" = 3 ] || exit "$PREFLIGHT_FAILURE"
+      printf '%s\n' "$FM_ASK_USER_QUESTION_OWNER_ENTRY_MARKER" >&3 || exit "$PREFLIGHT_FAILURE"
+    fi
     if FM_HOME="$home" FM_STATE_OVERRIDE="$state" \
       "$ROOT/bin/fm-send.sh" "$task" --resolve-key "$key" "Captain answer: $answer"; then
       :

--- a/bin/fm-ask-user-question.sh
+++ b/bin/fm-ask-user-question.sh
@@ -13,6 +13,10 @@
 # successful delivery to fm-send.sh --resolve-key.
 set -euo pipefail
 
+PREFLIGHT_FAILURE=3
+DELIVERY_UNKNOWN=4
+failure_status=2
+
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck source=bin/fm-classify-lib.sh
 . "$ROOT/bin/fm-classify-lib.sh"
@@ -21,7 +25,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 die() {
   printf 'fm-ask-user-question: %s\n' "$*" >&2
-  exit 2
+  exit "$failure_status"
 }
 
 hash_stream() {
@@ -121,6 +125,11 @@ require_primary_lock() {
 
 command=${1:-}
 [ -n "$command" ] || die 'a command is required'
+case "$command" in
+  generation|validate) ;;
+  deliver) failure_status=$PREFLIGHT_FAILURE ;;
+  *) die "unknown command: $command" ;;
+esac
 shift
 parse_binding "$@"
 validate_identity
@@ -144,8 +153,12 @@ case "$command" in
     [ -n "$answer" ] || die '--answer is required'
     require_primary_lock
     validate_generation
-    FM_HOME="$home" FM_STATE_OVERRIDE="$state" \
-      "$ROOT/bin/fm-send.sh" "$task" --resolve-key "$key" "Captain answer: $answer"
+    if FM_HOME="$home" FM_STATE_OVERRIDE="$state" \
+      "$ROOT/bin/fm-send.sh" "$task" --resolve-key "$key" "Captain answer: $answer"; then
+      :
+    else
+      exit "$DELIVERY_UNKNOWN"
+    fi
     ;;
   *) die "unknown command: $command" ;;
 esac

--- a/bin/fm-ask-user-question.sh
+++ b/bin/fm-ask-user-question.sh
@@ -162,6 +162,7 @@ case "$command" in
     if [ -n "${FM_ASK_USER_QUESTION_OWNER_ENTRY_MARKER:-}" ]; then
       [ "${FM_ASK_USER_QUESTION_OWNER_ENTRY_FD:-}" = 3 ] || exit "$PREFLIGHT_FAILURE"
       printf '%s\n' "$FM_ASK_USER_QUESTION_OWNER_ENTRY_MARKER" >&3 || exit "$PREFLIGHT_FAILURE"
+      exec 3>&-
     fi
     if FM_HOME="$home" FM_STATE_OVERRIDE="$state" \
       "$ROOT/bin/fm-send.sh" "$task" --resolve-key "$key" "Captain answer: $answer"; then

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -175,6 +175,15 @@
 # path do not pay it.
 set -eu
 
+# Fixture-only acknowledgement: write this only after execution has entered the
+# delivery owner, then close it before any owner descendants can inherit it.
+if [ -n "${FM_ASK_USER_QUESTION_OWNER_ENTRY_MARKER:-}" ]; then
+  [ "${FM_ASK_USER_QUESTION_OWNER_ENTRY_FD:-}" = 3 ] || exit 1
+  printf '%s\n' "$FM_ASK_USER_QUESTION_OWNER_ENTRY_MARKER" >&3 || exit 1
+  exec 3>&-
+  unset FM_ASK_USER_QUESTION_OWNER_ENTRY_FD FM_ASK_USER_QUESTION_OWNER_ENTRY_MARKER
+fi
+
 FM_SEND_ORIGINAL_ARGS=("$@")
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FM_ROOT="${FM_ROOT_OVERRIDE:-$(cd "$SCRIPT_DIR/.." && pwd)}"

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -135,7 +135,7 @@ family_for_basename() {
     fm-arm-pretool-check.test.sh|fm-ask-user-authority.test.sh|\
     fm-bearings-board.test.sh|\
     fm-brief.test.sh|fm-vendor-auth-probe.test.sh|\
-    fm-calm-pi-extension.test.sh|fm-cd-pretool-check.test.sh|\
+    fm-calm-pi-extension.test.sh|fm-ask-user-question.test.sh|fm-cd-pretool-check.test.sh|\
     fm-classify-decision-key.test.sh|\
     fm-composer-ghost.test.sh|fm-composer-lib.test.sh|\
     fm-crew-state.test.sh|fm-captain-hold-lifecycle.test.sh|\
@@ -936,6 +936,9 @@ families_for_changed_path() {
     bin/fm-backend.sh|bin/fm-backend-hometag-lib.sh)
       printf '%s\n' backend-dispatch
       printf '%s\n' real-herdr-gated
+      ;;
+    bin/fm-ask-user-question.sh|.pi/extensions/fm-ask-user-question.ts)
+      printf '%s\n' pure-contract-unit
       ;;
     bin/fm-watch*|bin/fm-wake*|bin/fm-inactive-reconcile.sh|\
     bin/fm-classify-lib.sh|bin/fm-daemon*|bin/fm-turnend-guard*|bin/fm-guard.sh)

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -649,8 +649,8 @@ run_coverage_guard() {
     return 1
   fi
   cat "$tmp/s1" "$tmp/s2" | LC_ALL=C sort -u >"$tmp/shards_union"
-  missing=$(comm -23 "$tmp/proven" "$tmp/shards_union" || true)
-  extra=$(comm -13 "$tmp/proven" "$tmp/shards_union" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/proven" "$tmp/shards_union" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/proven" "$tmp/shards_union" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: portable shards must equal the proven-isolated set"
     [ -z "$missing" ] || { log "missing from shards:"; printf '%s\n' "$missing" >&2; }
@@ -694,8 +694,8 @@ run_coverage_guard() {
     return 1
   fi
   LC_ALL=C sort -u "$tmp/serial_shards_raw" >"$tmp/serial_shards"
-  missing=$(comm -23 "$tmp/serial" "$tmp/serial_shards" || true)
-  extra=$(comm -13 "$tmp/serial" "$tmp/serial_shards" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/serial" "$tmp/serial_shards" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/serial" "$tmp/serial_shards" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: portable serial shards must equal the portable serial lane"
     [ -z "$missing" ] || { log "missing from serial shards:"; printf '%s\n' "$missing" >&2; }
@@ -707,7 +707,7 @@ run_coverage_guard() {
   for pair in "shards_union:serial" "shards_union:herdr" "serial:herdr"; do
     a=${pair%%:*}
     b=${pair#*:}
-    comm -12 "$tmp/$a" "$tmp/$b" >"$tmp/overlap"
+    LC_ALL=C comm -12 "$tmp/$a" "$tmp/$b" >"$tmp/overlap"
     if [ -s "$tmp/overlap" ]; then
       log "coverage guard: overlap between $a and $b:"
       cat "$tmp/overlap" >&2
@@ -725,8 +725,8 @@ run_coverage_guard() {
     return 1
   fi
   LC_ALL=C sort -u "$tmp/union_raw" >"$tmp/union"
-  missing=$(comm -23 "$tmp/all" "$tmp/union" || true)
-  extra=$(comm -13 "$tmp/all" "$tmp/union" || true)
+  missing=$(LC_ALL=C comm -23 "$tmp/all" "$tmp/union" || true)
+  extra=$(LC_ALL=C comm -13 "$tmp/all" "$tmp/union" || true)
   if [ -n "$missing" ] || [ -n "$extra" ]; then
     log "coverage guard: union of portable shards + portable serial + Herdr must equal tests/*.test.sh"
     [ -z "$missing" ] || { log "missing from union:"; printf '%s\n' "$missing" >&2; }
@@ -739,7 +739,7 @@ run_coverage_guard() {
     "$ROOT/bin/fm-test-isolation-proof.sh" --list | LC_ALL=C sort -u >"$tmp/proof_list"
     if ! cmp -s "$tmp/proven" "$tmp/proof_list"; then
       log "coverage guard: embedded proven-isolated set diverges from bin/fm-test-isolation-proof.sh --list"
-      comm -3 "$tmp/proven" "$tmp/proof_list" >&2 || true
+      LC_ALL=C comm -3 "$tmp/proven" "$tmp/proof_list" >&2 || true
       rm -rf "$tmp"
       return 1
     fi

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -59,9 +59,9 @@ It registers the `fm_ask_user_question` tool only when Pi starts with `FM_ASK_US
 The tool supports free text, single selection, multiple selection with an optional Other value, terminal resize, and structured answered or cancelled results.
 Every call supplies the owning Firstmate home, task ID, decision key, and source generation explicitly.
 Generate that binding with `FM_HOME=/path/to/home bin/fm-ask-user-question.sh generation --home /path/to/home --task <task-id> --key <decision-key>` before invoking the tool in a fixture-enabled primary Pi session.
-The extension verifies the active primary home and session lock, serializes its own modal, validates the binding before display, and asks the adapter to validate it again immediately before delivery.
-Cancellation, missing UI, UI failure, and any binding mismatch return a structured cancelled result without closing the decision.
-A successful answer goes only through `bin/fm-ask-user-question.sh deliver`, which reuses `fm-classify-lib.sh`'s open-decision fold and delegates to `fm-send.sh --resolve-key`.
+The extension serializes its own modal and uses the adapter before display and during delivery to verify the active primary home, prove shared session-lock ownership, and validate the binding against one canonical active state directory.
+Cancellation, missing UI, UI failure, and any binding mismatch return a structured cancelled result without closing the decision; an unconfirmed delivery preserves the selected answer and a bounded owner diagnostic without retrying.
+A successful answer goes only through `bin/fm-ask-user-question.sh deliver`, which reuses `fm-classify-lib.sh`'s open-decision fold and delegates to `fm-send.sh --resolve-key`; selected option labels remain presentation data while delivery carries their stable IDs.
 The dialog never sends to a pane, rewrites Pi input, or creates durable state of its own.
 
 A turn-ended-only queue row omits its historical status annotation when that status file exactly matches the same seen marker.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,9 +58,10 @@ The tracked Pi extension `.pi/extensions/fm-ask-user-question.ts` is a fixture-s
 It registers the `fm_ask_user_question` tool only when Pi starts with `FM_ASK_USER_QUESTION_FIXTURE=1`, so ordinary Pi sessions retain their current behavior.
 The tool supports free text, single selection, multiple selection with an optional Other value, terminal resize, and structured answered or cancelled results.
 Every call supplies the owning Firstmate home, task ID, decision key, and source generation explicitly.
-Generate that binding with `FM_HOME=/path/to/home bin/fm-ask-user-question.sh generation --home /path/to/home --task <task-id> --key <decision-key>` before invoking the tool in a fixture-enabled primary Pi session.
+The `bin/fm-ask-user-question.sh` header owns the exact generation, validation, and delivery invocations used by fixture-enabled primary Pi sessions.
 The extension serializes its own modal and uses the adapter before display and during delivery to verify the active primary home, prove shared session-lock ownership, and validate the binding against one canonical active state directory.
-Cancellation, missing UI, UI failure, and any binding mismatch return a structured cancelled result without closing the decision; an unconfirmed delivery preserves the selected answer and a bounded owner diagnostic without retrying.
+Cancellation, missing UI, UI failure, and any binding mismatch return a structured cancelled result without closing the decision.
+An unconfirmed delivery also leaves the decision open, preserves the selected answer and a bounded owner diagnostic, and forbids automatic resend.
 A successful answer goes only through `bin/fm-ask-user-question.sh deliver`, which reuses `fm-classify-lib.sh`'s open-decision fold and delegates to `fm-send.sh --resolve-key`; selected option labels remain presentation data while delivery carries their stable IDs.
 The dialog never sends to a pane, rewrites Pi input, or creates durable state of its own.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,6 +51,19 @@ A third bounded section, RECORD DIVERGENCE, prints on the same drains for the op
 A failed read, output, or concurrent-replacement check prevents the snapshot cursor from advancing across uncertain bytes, and teardown retires a task's manifest row before that task ID can be reused.
 The explicit resolution is written by the actor that answers, not the busy worker: `fm-send`'s `--resolve-key` appends the closing `resolved` line to this home's own copy of the ledger at answer time, which covers crewmates, local secondmates, and remote secondmates identically because a remote mate's escalations reach that local copy through the parent-replies ingest and only the answer message itself crosses the transport.
 This home's answerer close, pending-reply escalation close, and captain-held transfer use the provenance-guarded append owned by `bin/fm-wake-lib.sh`, so they advance the watcher marker only across their own bytes when all earlier bytes were already announced; pending or interleaved foreign bytes fail toward an ordinary wake.
+
+### Pi captain-question prototype
+
+The tracked Pi extension `.pi/extensions/fm-ask-user-question.ts` is a fixture-stage primary-only presentation adapter for one already-open keyed decision.
+It registers the `fm_ask_user_question` tool only when Pi starts with `FM_ASK_USER_QUESTION_FIXTURE=1`, so ordinary Pi sessions retain their current behavior.
+The tool supports free text, single selection, multiple selection with an optional Other value, terminal resize, and structured answered or cancelled results.
+Every call supplies the owning Firstmate home, task ID, decision key, and source generation explicitly.
+Generate that binding with `FM_HOME=/path/to/home bin/fm-ask-user-question.sh generation --home /path/to/home --task <task-id> --key <decision-key>` before invoking the tool in a fixture-enabled primary Pi session.
+The extension verifies the active primary home and session lock, serializes its own modal, validates the binding before display, and asks the adapter to validate it again immediately before delivery.
+Cancellation, missing UI, UI failure, and any binding mismatch return a structured cancelled result without closing the decision.
+A successful answer goes only through `bin/fm-ask-user-question.sh deliver`, which reuses `fm-classify-lib.sh`'s open-decision fold and delegates to `fm-send.sh --resolve-key`.
+The dialog never sends to a pane, rewrites Pi input, or creates durable state of its own.
+
 A turn-ended-only queue row omits its historical status annotation when that status file exactly matches the same seen marker.
 Any direct or remaining historical annotation prints every status line unread at the presentation cursor instead of replaying only the latest line.
 `bin/fm-crew-state.sh <id>` is the cheap current-state read for an actionable heartbeat review: it attributes a no-mistakes run, active or terminal, only when it matches the crew's branch and current code identity, then keeps that run-step authoritative even if the pane has closed.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,7 +61,8 @@ Every call supplies the owning Firstmate home, task ID, decision key, and source
 The `bin/fm-ask-user-question.sh` header owns the exact generation, validation, and delivery invocations used by fixture-enabled primary Pi sessions.
 The extension serializes its own modal and uses the adapter before display and during delivery to verify the active primary home, prove shared session-lock ownership, and validate the binding against one canonical active state directory.
 Cancellation, missing UI, UI failure, and any binding mismatch return a structured cancelled result without closing the decision.
-An unconfirmed delivery also leaves the decision open, preserves the selected answer and a bounded owner diagnostic, and forbids automatic resend.
+Every failure before the adapter proves entry into `fm-send` is a `binding-mismatch`; only an indeterminate result after owner entry becomes `delivery-unknown`.
+A `delivery-unknown` result leaves the decision open, preserves the selected answer and a bounded owner diagnostic, and forbids automatic resend.
 A successful answer goes only through `bin/fm-ask-user-question.sh deliver`, which reuses `fm-classify-lib.sh`'s open-decision fold and delegates to `fm-send.sh --resolve-key`; selected option labels remain presentation data while delivery carries their stable IDs.
 The dialog never sends to a pane, rewrites Pi input, or creates durable state of its own.
 

--- a/tests/fm-ask-user-question.test.sh
+++ b/tests/fm-ask-user-question.test.sh
@@ -123,6 +123,108 @@ test_state_override_binding() {
   pass "ask-user adapter binds generation, validation, and delivery to one canonical state override"
 }
 
+test_pi_state_override_integration() {
+  local fixture generation out status canonical_state
+  if ! command -v node >/dev/null 2>&1 || [ ! -f "$PI_PACKAGE_DIR/package.json" ]; then
+    echo "skip: installed Pi package not found for ask-user-question state override integration test"
+    return 0
+  fi
+  fixture="$TMP_ROOT/pi-state-override"
+  make_adapter_fixture "$fixture"
+  mkdir -p "$fixture/root/.pi/extensions" "$fixture/root/node_modules/@earendil-works" \
+    "$fixture/active-state"
+  cp "$ROOT/.pi/extensions/fm-ask-user-question.ts" "$fixture/root/.pi/extensions/fm-ask-user-question.ts"
+  ln -s "$PI_PACKAGE_DIR" "$fixture/root/node_modules/@earendil-works/pi-coding-agent"
+  ln -s "$PI_PACKAGE_DIR/node_modules/@earendil-works/pi-ai" "$fixture/root/node_modules/@earendil-works/pi-ai"
+  ln -s "$PI_PACKAGE_DIR/node_modules/@earendil-works/pi-tui" "$fixture/root/node_modules/@earendil-works/pi-tui"
+  ln -s "$PI_PACKAGE_DIR/node_modules/typebox" "$fixture/root/node_modules/typebox"
+  printf '%s\n' '{"type":"module"}' > "$fixture/root/package.json"
+  cp "$fixture/home/state/alpha.meta" "$fixture/active-state/alpha.meta"
+  cp "$fixture/home/state/alpha.status" "$fixture/active-state/alpha.status"
+  printf 'resolved: [key=scope] default tree is closed\n' > "$fixture/home/state/alpha.status"
+  printf '%s\n' 1 > "$fixture/home/state/.lock"
+  printf '%s\n' "$$" > "$fixture/active-state/.lock"
+  canonical_state=$(cd "$fixture/active-state" && pwd -P)
+  generation=$(FM_HOME="$fixture/home" FM_STATE_OVERRIDE="$fixture/active-state" \
+    "$fixture/root/bin/fm-ask-user-question.sh" generation \
+      --home "$fixture/home" --task alpha --key scope) \
+    || fail "state override integration generation failed"
+
+  out=$(cd "$fixture/root" && \
+    FM_HOME="$fixture/home" \
+    FM_STATE_OVERRIDE="$fixture/active-state" \
+    FM_ASK_USER_QUESTION_FIXTURE=1 \
+    FM_SEND_LOG="$fixture/send.log" \
+    FM_SEND_STATE_LOG="$fixture/send-state.log" \
+    GENERATION="$generation" \
+    EXPECTED_STATE="$canonical_state" \
+    EXT="$fixture/root/.pi/extensions/fm-ask-user-question.ts" \
+    node --input-type=module 2>&1 <<'JS'
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const extension = await import(`${pathToFileURL(process.env.EXT).href}?fixture=${Date.now()}`);
+delete process.env.FM_STATE_OVERRIDE;
+let tool;
+extension.default({
+  registerTool(candidate) {
+    if (candidate.name === "fm_ask_user_question") tool = candidate;
+  },
+});
+if (!tool) throw new Error("fixture flag did not register the tool");
+
+const theme = {
+  fg(_color, text) { return text; },
+  bg(_color, text) { return text; },
+  bold(text) { return text; },
+};
+const ui = {
+  custom(factory) {
+    return new Promise((resolve, reject) => {
+      try {
+        const tui = { requestRender() {}, terminal: { rows: 40, columns: 80 } };
+        const component = factory(tui, theme, {}, resolve);
+        component.handleInput("\r");
+      } catch (error) {
+        reject(error);
+      }
+    });
+  },
+};
+const result = await tool.execute("call", {
+  home: process.env.FM_HOME,
+  taskId: "alpha",
+  decisionKey: "scope",
+  sourceGeneration: process.env.GENERATION,
+  mode: "single",
+  question: "Choose",
+  options: [{ id: "safe", label: "Safe" }],
+}, new AbortController().signal, undefined, { mode: "tui", ui });
+if (result.details.status !== "answered" || result.details.answers[0]?.id !== "safe") {
+  throw new Error(`override-backed question was not answered: ${JSON.stringify(result.details)}`);
+}
+const args = readFileSync(process.env.FM_SEND_LOG, "utf8").split("\0").filter(Boolean);
+const expectedArgs = [
+  "alpha",
+  "--resolve-key",
+  "scope",
+  "Captain answer: selected safe: Safe",
+];
+if (JSON.stringify(args) !== JSON.stringify(expectedArgs)) {
+  throw new Error(`fm-send received wrong calls: ${JSON.stringify(args)}`);
+}
+const states = readFileSync(process.env.FM_SEND_STATE_LOG, "utf8").trim().split("\n");
+if (states.length !== 1 || states[0] !== process.env.EXPECTED_STATE) {
+  throw new Error(`fm-send inherited wrong state: ${JSON.stringify(states)}`);
+}
+JS
+  )
+  status=$?
+  [ "$status" -eq 0 ] || fail "Pi state override integration failed: $out"
+  [ -z "$out" ] || fail "Pi state override integration printed output: $out"
+  pass "Pi ask-user tool keeps one canonical override through modal delivery"
+}
+
 test_pi_modal_contract() {
   local fixture out status
   if ! command -v node >/dev/null 2>&1 || [ ! -f "$PI_PACKAGE_DIR/package.json" ]; then
@@ -134,6 +236,7 @@ test_pi_modal_contract() {
     "$fixture/home/state" "$fixture/active-state"
   cp "$ROOT/.pi/extensions/fm-ask-user-question.ts" "$fixture/project/.pi/extensions/fm-ask-user-question.ts"
   ln -s "$PI_PACKAGE_DIR" "$fixture/project/node_modules/@earendil-works/pi-coding-agent"
+  ln -s "$PI_PACKAGE_DIR/node_modules/@earendil-works/pi-ai" "$fixture/project/node_modules/@earendil-works/pi-ai"
   ln -s "$PI_PACKAGE_DIR/node_modules/@earendil-works/pi-tui" "$fixture/project/node_modules/@earendil-works/pi-tui"
   ln -s "$PI_PACKAGE_DIR/node_modules/typebox" "$fixture/project/node_modules/typebox"
   printf '%s\n' '{"type":"module"}' > "$fixture/project/package.json"
@@ -366,6 +469,7 @@ test_fixture_gate() {
   mkdir -p "$fixture/project/.pi/extensions" "$fixture/project/node_modules/@earendil-works"
   cp "$ROOT/.pi/extensions/fm-ask-user-question.ts" "$fixture/project/.pi/extensions/fm-ask-user-question.ts"
   ln -s "$PI_PACKAGE_DIR" "$fixture/project/node_modules/@earendil-works/pi-coding-agent"
+  ln -s "$PI_PACKAGE_DIR/node_modules/@earendil-works/pi-ai" "$fixture/project/node_modules/@earendil-works/pi-ai"
   ln -s "$PI_PACKAGE_DIR/node_modules/@earendil-works/pi-tui" "$fixture/project/node_modules/@earendil-works/pi-tui"
   ln -s "$PI_PACKAGE_DIR/node_modules/typebox" "$fixture/project/node_modules/typebox"
   printf '%s\n' '{"type":"module"}' > "$fixture/project/package.json"
@@ -385,5 +489,6 @@ JS
 
 test_binding_and_delivery_adapter
 test_state_override_binding
+test_pi_state_override_integration
 test_pi_modal_contract
 test_fixture_gate

--- a/tests/fm-ask-user-question.test.sh
+++ b/tests/fm-ask-user-question.test.sh
@@ -14,6 +14,14 @@ make_adapter_fixture() {
   cp "$ROOT/bin/fm-ask-user-question.sh" "$fixture/root/bin/fm-ask-user-question.sh"
   cp "$ROOT/bin/fm-classify-lib.sh" "$fixture/root/bin/fm-classify-lib.sh"
   cp "$ROOT/bin/fm-timeout-lib.sh" "$fixture/root/bin/fm-timeout-lib.sh"
+  cat > "$fixture/root/bin/fm-session-lock-lib.sh" <<'SH'
+fm_session_lock_owned_by_self() {
+  if [ -n "${FM_LOCK_CHECK_LOG:-}" ]; then
+    printf '%s\n' "$1" >> "$FM_LOCK_CHECK_LOG"
+  fi
+  [ "$(cat "$1/.lock" 2>/dev/null)" = owned ]
+}
+SH
   cat > "$fixture/root/bin/fm-send.sh" <<'SH'
 #!/usr/bin/env bash
 printf '%s\0' "$@" >> "$FM_SEND_LOG"
@@ -26,11 +34,12 @@ SH
   printf 'needs-decision: [key=scope] choose scope\n' > "$fixture/home/state/alpha.status"
   printf 'task_id=beta\nbackend=tmux\n' > "$fixture/home/state/beta.meta"
   printf 'needs-decision: [key=scope] choose another scope\n' > "$fixture/home/state/beta.status"
+  printf 'owned\n' > "$fixture/home/state/.lock"
   : > "$fixture/send.log"
 }
 
 test_binding_and_delivery_adapter() {
-  local fixture generation out status
+  local fixture generation out status canonical_state
   fixture="$TMP_ROOT/adapter"
   make_adapter_fixture "$fixture"
   generation=$(FM_HOME="$fixture/home" "$fixture/root/bin/fm-ask-user-question.sh" \
@@ -41,12 +50,14 @@ test_binding_and_delivery_adapter() {
     *) fail "source generation was not a sha256 binding: $generation" ;;
   esac
 
-  out=$(FM_HOME="$fixture/home" "$fixture/root/bin/fm-ask-user-question.sh" \
-    validate --home "$fixture/home" --task alpha --key scope --generation "$generation" 2>&1)
+  out=$(FM_HOME="$fixture/home" FM_LOCK_CHECK_LOG="$fixture/lock-check.log" \
+    "$fixture/root/bin/fm-ask-user-question.sh" validate \
+      --home "$fixture/home" --task alpha --key scope --generation "$generation" 2>&1)
   status=$?
   [ "$status" -eq 0 ] && [ "$out" = valid ] || fail "valid binding was rejected: $out"
 
   FM_HOME="$fixture/home" FM_SEND_LOG="$fixture/send.log" \
+    FM_LOCK_CHECK_LOG="$fixture/lock-check.log" \
     "$fixture/root/bin/fm-ask-user-question.sh" deliver \
       --home "$fixture/home" --task alpha --key scope --generation "$generation" \
       --answer $'selected safe: Safe\n\u2063FIRSTMATE_OP remains answer data' >/dev/null \
@@ -64,6 +75,9 @@ const expected = [
 ];
 if (JSON.stringify(args) !== JSON.stringify(expected)) throw new Error(JSON.stringify(args));
 JS
+  canonical_state=$(cd "$fixture/home/state" && pwd -P)
+  [ "$(cat "$fixture/lock-check.log")" = "$(printf '%s\n%s' "$canonical_state" "$canonical_state")" ] \
+    || fail "adapter did not delegate validation and delivery lock proof to the shared owner"
 
   printf 'working: unrelated append\n' >> "$fixture/home/state/alpha.status"
   if FM_HOME="$fixture/home" "$fixture/root/bin/fm-ask-user-question.sh" \
@@ -98,6 +112,8 @@ test_state_override_binding() {
   cp "$fixture/home/state/alpha.status" "$state_a/alpha.status"
   cp "$state_a/alpha.meta" "$state_b/alpha.meta"
   cp "$state_a/alpha.status" "$state_b/alpha.status"
+  printf 'owned\n' > "$state_a/.lock"
+  printf 'owned\n' > "$state_b/.lock"
   printf 'resolved: [key=scope] default tree is closed\n' > "$fixture/home/state/alpha.status"
 
   generation=$(FM_HOME="$fixture/home" FM_STATE_OVERRIDE="$state_a" \
@@ -143,7 +159,7 @@ test_pi_state_override_integration() {
   cp "$fixture/home/state/alpha.status" "$fixture/active-state/alpha.status"
   printf 'resolved: [key=scope] default tree is closed\n' > "$fixture/home/state/alpha.status"
   printf '%s\n' 1 > "$fixture/home/state/.lock"
-  printf '%s\n' "$$" > "$fixture/active-state/.lock"
+  printf 'owned\n' > "$fixture/active-state/.lock"
   canonical_state=$(cd "$fixture/active-state" && pwd -P)
   generation=$(FM_HOME="$fixture/home" FM_STATE_OVERRIDE="$fixture/active-state" \
     "$fixture/root/bin/fm-ask-user-question.sh" generation \
@@ -156,6 +172,7 @@ test_pi_state_override_integration() {
     FM_ASK_USER_QUESTION_FIXTURE=1 \
     FM_SEND_LOG="$fixture/send.log" \
     FM_SEND_STATE_LOG="$fixture/send-state.log" \
+    FM_LOCK_CHECK_LOG="$fixture/lock-check.log" \
     GENERATION="$generation" \
     EXPECTED_STATE="$canonical_state" \
     EXT="$fixture/root/.pi/extensions/fm-ask-user-question.ts" \
@@ -208,7 +225,7 @@ const expectedArgs = [
   "alpha",
   "--resolve-key",
   "scope",
-  "Captain answer: selected safe: Safe",
+  "Captain answer: selected safe",
 ];
 if (JSON.stringify(args) !== JSON.stringify(expectedArgs)) {
   throw new Error(`fm-send received wrong calls: ${JSON.stringify(args)}`);
@@ -216,6 +233,10 @@ if (JSON.stringify(args) !== JSON.stringify(expectedArgs)) {
 const states = readFileSync(process.env.FM_SEND_STATE_LOG, "utf8").trim().split("\n");
 if (states.length !== 1 || states[0] !== process.env.EXPECTED_STATE) {
   throw new Error(`fm-send inherited wrong state: ${JSON.stringify(states)}`);
+}
+const lockChecks = readFileSync(process.env.FM_LOCK_CHECK_LOG, "utf8").trim().split("\n");
+if (lockChecks.length !== 2 || lockChecks.some((state) => state !== process.env.EXPECTED_STATE)) {
+  throw new Error(`shared lock owner received wrong state: ${JSON.stringify(lockChecks)}`);
 }
 JS
   )
@@ -241,7 +262,7 @@ test_pi_modal_contract() {
   ln -s "$PI_PACKAGE_DIR/node_modules/typebox" "$fixture/project/node_modules/typebox"
   printf '%s\n' '{"type":"module"}' > "$fixture/project/package.json"
   printf '%s\n' 1 > "$fixture/home/state/.lock"
-  printf '%s\n' "$$" > "$fixture/active-state/.lock"
+  printf 'owned\n' > "$fixture/active-state/.lock"
   cat > "$fixture/adapter.sh" <<'SH'
 #!/usr/bin/env bash
 printf '%s\0' "$@" >> "$FM_ASK_LOG"
@@ -256,9 +277,18 @@ while [ "$#" -gt 0 ]; do
     *) shift ;;
   esac
 done
+[ "$(cat "$FM_STATE_OVERRIDE/.lock" 2>/dev/null)" = owned ] || exit 2
 [ "$task" != wrong-task ] || exit 2
 [ "$key" != wrong-generation ] || exit 2
-[ "$command" != deliver ] || [ "$key" != stale-before-delivery ] || exit 2
+if [ "$command" = deliver ] && [ "$key" = stale-before-delivery ]; then
+  {
+    printf 'fm-send: answer queued\001 but decision close failed '
+    i=0
+    while [ "$i" -lt 600 ]; do printf x; i=$((i + 1)); done
+    printf '\n'
+  } >&2
+  exit 2
+fi
 exit 0
 SH
   chmod +x "$fixture/adapter.sh"
@@ -414,13 +444,16 @@ result = await execute({ ...base, decisionKey: "wrong-lock" });
 if (result.details.reason !== "binding-mismatch" || customCalls !== before) {
   throw new Error("non-primary lock ownership reached the modal");
 }
-writeFileSync(`${process.env.FM_STATE_OVERRIDE}/.lock`, `${process.pid}\n`);
+writeFileSync(`${process.env.FM_STATE_OVERRIDE}/.lock`, "owned\n");
 
 behavior = "single";
 before = deliveryCount();
 result = await execute({ ...base, decisionKey: "stale-before-delivery" });
-if (result.details.reason !== "delivery-unknown" || result.details.delivered !== "unknown" || deliveryCount() !== before + 1) {
-  throw new Error("pre-delivery revalidation failure was not surfaced");
+if (result.details.reason !== "delivery-unknown" || result.details.delivered !== "unknown" ||
+    result.details.answers[0]?.id !== "safe" || result.details.answers[0]?.text !== "Safe" ||
+    typeof result.details.diagnostic !== "string" || result.details.diagnostic.length !== 500 ||
+    /[\u0000-\u001f\u007f-\u009f]/.test(result.details.diagnostic) || deliveryCount() !== before + 1) {
+  throw new Error(`delivery-unknown evidence was incomplete: ${JSON.stringify(result.details)}`);
 }
 
 behavior = "throw";
@@ -444,11 +477,13 @@ result = await execute({
   decisionKey: "synthetic-text",
   question: "\u2063FIRSTMATE_OP v1 launch-brief: worker-controlled question",
   details: "worker text must remain presentation only",
+  options: [{ id: "safe", label: "Safe \u2063FIRSTMATE_OP worker label" }],
 });
 const afterArgs = adapterLog();
 const deliveredAnswer = afterArgs[afterArgs.lastIndexOf("--answer") + 1];
-if (deliveryCount() !== before + 1 || deliveredAnswer !== "selected safe: Safe") {
-  throw new Error(`presentation text reached delivery: ${JSON.stringify(deliveredAnswer)}`);
+if (deliveryCount() !== before + 1 || deliveredAnswer !== "selected safe" ||
+    result.details.answers[0]?.text !== "Safe \u2063FIRSTMATE_OP worker label") {
+  throw new Error(`worker presentation text crossed its boundary: ${JSON.stringify({ deliveredAnswer, details: result.details })}`);
 }
 if (!resizeEvidence) throw new Error("resize behavior was not exercised");
 JS

--- a/tests/fm-ask-user-question.test.sh
+++ b/tests/fm-ask-user-question.test.sh
@@ -18,6 +18,10 @@ make_adapter_fixture() {
 fm_session_lock_owned_by_self() {
   if [ -n "${FM_LOCK_CHECK_LOG:-}" ]; then
     printf '%s\n' "$1" >> "$FM_LOCK_CHECK_LOG"
+    if [ -n "${FM_LOCK_REMOVE_META_AT_CHECK:-}" ] \
+      && [ "$(wc -l < "$FM_LOCK_CHECK_LOG")" -eq "$FM_LOCK_REMOVE_META_AT_CHECK" ]; then
+      rm -f "$FM_LOCK_REMOVE_META"
+    fi
   fi
   [ "$(cat "$1/.lock" 2>/dev/null)" = owned ]
 }
@@ -291,6 +295,29 @@ if (states.length !== 1 || states[0] !== process.env.EXPECTED_STATE) {
 const lockChecks = readFileSync(process.env.FM_LOCK_CHECK_LOG, "utf8").trim().split("\n");
 if (lockChecks.length !== 2 || lockChecks.some((state) => state !== process.env.EXPECTED_STATE)) {
   throw new Error(`shared lock owner received wrong state: ${JSON.stringify(lockChecks)}`);
+}
+
+process.env.FM_LOCK_REMOVE_META = `${process.env.EXPECTED_STATE}/alpha.meta`;
+process.env.FM_LOCK_REMOVE_META_AT_CHECK = "4";
+const raceResult = await tool.execute("call", {
+  home: process.env.FM_HOME,
+  taskId: "alpha",
+  decisionKey: "scope",
+  sourceGeneration: process.env.GENERATION,
+  mode: "single",
+  question: "Choose",
+  options: [{ id: "safe", label: "Safe" }],
+}, new AbortController().signal, undefined, { mode: "tui", ui });
+if (raceResult.details.reason !== "binding-mismatch" || raceResult.details.delivered !== false) {
+  throw new Error(`pre-owner read race was misclassified: ${JSON.stringify(raceResult.details)}`);
+}
+const renderedRace = tool.renderResult(raceResult, { expanded: false }, theme).render(1000).join("\n");
+if (renderedRace.includes("Do not resend automatically.")) {
+  throw new Error(`pre-owner read race showed a no-resend warning: ${renderedRace}`);
+}
+const finalArgs = readFileSync(process.env.FM_SEND_LOG, "utf8").split("\0").filter(Boolean);
+if (JSON.stringify(finalArgs) !== JSON.stringify(expectedArgs)) {
+  throw new Error(`pre-owner read race reached fm-send: ${JSON.stringify(finalArgs)}`);
 }
 JS
   )

--- a/tests/fm-ask-user-question.test.sh
+++ b/tests/fm-ask-user-question.test.sh
@@ -28,6 +28,12 @@ printf '%s\0' "$@" >> "$FM_SEND_LOG"
 if [ -n "${FM_SEND_STATE_LOG:-}" ]; then
   printf '%s\n' "${FM_STATE_OVERRIDE:-}" >> "$FM_SEND_STATE_LOG"
 fi
+if [ "${FM_SEND_FAIL:-0}" = 1 ]; then
+  i=0
+  while [ "$i" -lt 600 ]; do printf x >&2; i=$((i + 1)); done
+  printf '\001fm-send: answer queued but decision close failed\n' >&2
+  exit 9
+fi
 SH
   chmod +x "$fixture/root/bin/fm-ask-user-question.sh" "$fixture/root/bin/fm-send.sh"
   printf 'task_id=alpha\nbackend=tmux\n' > "$fixture/home/state/alpha.meta"
@@ -79,6 +85,17 @@ JS
   [ "$(cat "$fixture/lock-check.log")" = "$(printf '%s\n%s' "$canonical_state" "$canonical_state")" ] \
     || fail "adapter did not delegate validation and delivery lock proof to the shared owner"
 
+  out=$(FM_HOME="$fixture/home" FM_SEND_LOG="$fixture/send.log" FM_SEND_FAIL=1 \
+    "$fixture/root/bin/fm-ask-user-question.sh" deliver \
+      --home "$fixture/home" --task alpha --key scope --generation "$generation" \
+      --answer uncertain 2>&1)
+  status=$?
+  [ "$status" -eq 4 ] || fail "owner failure was not reported as delivery unknown: $status $out"
+  case "$out" in
+    *"fm-send: answer queued but decision close failed") ;;
+    *) fail "owner failure diagnostic was lost: $out" ;;
+  esac
+
   cp "$fixture/send.log" "$fixture/send-before-marker.log"
   ln -s "$fixture/missing-secondmate-marker" "$fixture/home/.fm-secondmate-home"
   if FM_HOME="$fixture/home" "$fixture/root/bin/fm-ask-user-question.sh" \
@@ -100,6 +117,15 @@ JS
     validate --home "$fixture/home" --task alpha --key scope --generation "$generation" >/dev/null 2>&1; then
     fail "stale source generation was accepted"
   fi
+  cp "$fixture/send.log" "$fixture/send-before-preflight.log"
+  out=$(FM_HOME="$fixture/home" FM_SEND_LOG="$fixture/send.log" \
+    "$fixture/root/bin/fm-ask-user-question.sh" deliver \
+      --home "$fixture/home" --task alpha --key scope --generation "$generation" \
+      --answer blocked 2>&1)
+  status=$?
+  [ "$status" -eq 3 ] || fail "delivery preflight mismatch returned the wrong result: $status $out"
+  cmp -s "$fixture/send-before-preflight.log" "$fixture/send.log" \
+    || fail "delivery preflight mismatch reached fm-send"
   if FM_HOME="$fixture/home" "$fixture/root/bin/fm-ask-user-question.sh" \
     validate --home "$fixture/home" --task beta --key scope --generation "$generation" >/dev/null 2>&1; then
     fail "mismatched task was accepted"
@@ -296,19 +322,25 @@ done
 [ "$(cat "$FM_STATE_OVERRIDE/.lock" 2>/dev/null)" = owned ] || exit 2
 [ "$task" != wrong-task ] || exit 2
 [ "$key" != wrong-generation ] || exit 2
-if [ "$command" = deliver ] && [ "$key" = stale-before-delivery ]; then
-  {
-    printf 'fm-send: answer queued\001 but decision close failed '
-    i=0
-    while [ "$i" -lt 600 ]; do printf x; i=$((i + 1)); done
-    printf '\n'
-  } >&2
-  exit 2
+if [ "$command" = deliver ] && [ "$key" = preflight-mismatch ]; then
+  exit 3
+fi
+if [ "$command" = deliver ]; then
+  printf '%s\n' "$key" >> "$FM_OWNER_LOG"
+  if [ "$key" = owner-failure ]; then
+    {
+      i=0
+      while [ "$i" -lt 600 ]; do printf x; i=$((i + 1)); done
+      printf '\001fm-send: answer queued but decision close failed\n'
+    } >&2
+    exit 4
+  fi
 fi
 exit 0
 SH
   chmod +x "$fixture/adapter.sh"
   : > "$fixture/adapter.log"
+  : > "$fixture/owner.log"
 
   out=$(cd "$fixture/project" && \
     FM_HOME="$fixture/home" \
@@ -316,6 +348,7 @@ SH
     FM_ASK_USER_QUESTION_FIXTURE=1 \
     FM_ASK_USER_QUESTION_ADAPTER="$fixture/adapter.sh" \
     FM_ASK_LOG="$fixture/adapter.log" \
+    FM_OWNER_LOG="$fixture/owner.log" \
     EXT="$fixture/project/.pi/extensions/fm-ask-user-question.ts" \
     node --input-type=module 2>&1 <<'JS'
 import { readFileSync, writeFileSync } from "node:fs";
@@ -351,7 +384,7 @@ const base = {
   options: [{ id: "safe", label: "Safe" }],
 };
 const adapterLog = () => readFileSync(process.env.FM_ASK_LOG, "utf8").split("\0").filter(Boolean);
-const deliveryCount = () => adapterLog().filter((value) => value === "deliver").length;
+const deliveryCount = () => readFileSync(process.env.FM_OWNER_LOG, "utf8").split("\n").filter(Boolean).length;
 let customCalls = 0;
 let activeModals = 0;
 let maxActiveModals = 0;
@@ -464,7 +497,17 @@ writeFileSync(`${process.env.FM_STATE_OVERRIDE}/.lock`, "owned\n");
 
 behavior = "single";
 before = deliveryCount();
-result = await execute({ ...base, decisionKey: "stale-before-delivery" });
+result = await execute({ ...base, decisionKey: "preflight-mismatch" });
+if (result.details.reason !== "binding-mismatch" || result.details.delivered !== false ||
+    result.details.answers[0]?.id !== "safe" || deliveryCount() !== before) {
+  throw new Error(`preflight mismatch was misclassified: ${JSON.stringify(result.details)}`);
+}
+const renderedMismatch = tool.renderResult(result, { expanded: false }, theme).render(1000).join("\n");
+if (renderedMismatch.includes("Do not resend automatically.")) {
+  throw new Error(`preflight mismatch showed a no-resend warning: ${renderedMismatch}`);
+}
+
+result = await execute({ ...base, decisionKey: "owner-failure" });
 if (result.details.reason !== "delivery-unknown" || result.details.delivered !== "unknown" ||
     result.details.answers[0]?.id !== "safe" || result.details.answers[0]?.text !== "Safe" ||
     typeof result.details.diagnostic !== "string" || result.details.diagnostic.length !== 500 ||

--- a/tests/fm-ask-user-question.test.sh
+++ b/tests/fm-ask-user-question.test.sh
@@ -364,6 +364,9 @@ done
 if [ "$command" = deliver ] && [ "$key" = preflight-mismatch ]; then
   exit 3
 fi
+if [ "$command" = deliver ] && [ "$key" = known-status ]; then
+  exit 2
+fi
 if [ "$command" = deliver ]; then
   printf '%s\n' "$key" >> "$FM_OWNER_LOG"
   if [ "$key" = owner-failure ]; then
@@ -396,7 +399,7 @@ SH
     FM_OWNER_LOG="$fixture/owner.log" \
     EXT="$fixture/project/.pi/extensions/fm-ask-user-question.ts" \
     node --input-type=module 2>&1 <<'JS'
-import { readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, readFileSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 import { visibleWidth } from "@earendil-works/pi-tui";
 
@@ -459,7 +462,10 @@ const ui = {
         resizeEvidence = true;
         if (behavior === "throw") throw new Error("synthetic UI failure");
         if (behavior === "cancel") component.handleInput(ESCAPE);
-        else if (behavior === "single") {
+        else if (behavior === "launch-error") {
+          chmodSync(process.env.FM_ASK_USER_QUESTION_ADAPTER, 0o644);
+          component.handleInput(ENTER);
+        } else if (behavior === "single") {
           component.handleInput(ENTER);
           component.handleInput(ENTER);
         } else if (behavior === "text") {
@@ -550,6 +556,27 @@ if (result.details.reason !== "binding-mismatch" || result.details.delivered !==
 const renderedMismatch = tool.renderResult(result, { expanded: false }, theme).render(1000).join("\n");
 if (renderedMismatch.includes("Do not resend automatically.")) {
   throw new Error(`preflight mismatch showed a no-resend warning: ${renderedMismatch}`);
+}
+
+before = deliveryCount();
+result = await execute({ ...base, decisionKey: "known-status" });
+if (result.details.reason !== "binding-mismatch" || result.details.delivered !== false ||
+    result.details.answers[0]?.id !== "safe" || deliveryCount() !== before) {
+  throw new Error(`known adapter status was misclassified: ${JSON.stringify(result.details)}`);
+}
+
+behavior = "launch-error";
+before = deliveryCount();
+result = await execute({ ...base, decisionKey: "launch-error" });
+chmodSync(process.env.FM_ASK_USER_QUESTION_ADAPTER, 0o755);
+behavior = "single";
+if (result.details.reason !== "binding-mismatch" || result.details.delivered !== false ||
+    result.details.answers[0]?.id !== "safe" || deliveryCount() !== before) {
+  throw new Error(`adapter launch error was misclassified: ${JSON.stringify(result.details)}`);
+}
+const renderedLaunchError = tool.renderResult(result, { expanded: false }, theme).render(1000).join("\n");
+if (renderedLaunchError.includes("Do not resend automatically.")) {
+  throw new Error(`adapter launch error showed a no-resend warning: ${renderedLaunchError}`);
 }
 
 result = await execute({ ...base, decisionKey: "owner-failure" });

--- a/tests/fm-ask-user-question.test.sh
+++ b/tests/fm-ask-user-question.test.sh
@@ -540,6 +540,12 @@ if (result.details.reason !== "ui-unavailable" || customCalls !== before) {
 }
 
 before = customCalls;
+const adapterCalls = adapterLog().length;
+result = await execute({ ...base, home: `${base.home}\0invalid` });
+if (result.details.reason !== "binding-mismatch" || result.details.delivered !== false ||
+    customCalls !== before || adapterLog().length !== adapterCalls) {
+  throw new Error(`process-unsafe home did not resolve before spawn or UI: ${JSON.stringify(result.details)}`);
+}
 result = await execute({ ...base, taskId: "wrong-task" });
 if (result.details.reason !== "binding-mismatch" || customCalls !== before) {
   throw new Error("task mismatch reached the modal");

--- a/tests/fm-ask-user-question.test.sh
+++ b/tests/fm-ask-user-question.test.sh
@@ -17,6 +17,9 @@ make_adapter_fixture() {
   cat > "$fixture/root/bin/fm-send.sh" <<'SH'
 #!/usr/bin/env bash
 printf '%s\0' "$@" >> "$FM_SEND_LOG"
+if [ -n "${FM_SEND_STATE_LOG:-}" ]; then
+  printf '%s\n' "${FM_STATE_OVERRIDE:-}" >> "$FM_SEND_STATE_LOG"
+fi
 SH
   chmod +x "$fixture/root/bin/fm-ask-user-question.sh" "$fixture/root/bin/fm-send.sh"
   printf 'task_id=alpha\nbackend=tmux\n' > "$fixture/home/state/alpha.meta"
@@ -84,6 +87,42 @@ JS
   pass "ask-user adapter binds home, task, key, and generation and delegates one literal answer through fm-send"
 }
 
+test_state_override_binding() {
+  local fixture state_a state_b generation canonical_state
+  fixture="$TMP_ROOT/state-override"
+  make_adapter_fixture "$fixture"
+  state_a="$fixture/state-a"
+  state_b="$fixture/state-b"
+  mkdir -p "$state_a" "$state_b"
+  cp "$fixture/home/state/alpha.meta" "$state_a/alpha.meta"
+  cp "$fixture/home/state/alpha.status" "$state_a/alpha.status"
+  cp "$state_a/alpha.meta" "$state_b/alpha.meta"
+  cp "$state_a/alpha.status" "$state_b/alpha.status"
+  printf 'resolved: [key=scope] default tree is closed\n' > "$fixture/home/state/alpha.status"
+
+  generation=$(FM_HOME="$fixture/home" FM_STATE_OVERRIDE="$state_a" \
+    "$fixture/root/bin/fm-ask-user-question.sh" generation \
+      --home "$fixture/home" --task alpha --key scope) \
+    || fail "source generation ignored the active state override"
+
+  FM_HOME="$fixture/home" FM_STATE_OVERRIDE="$state_a" \
+    FM_SEND_LOG="$fixture/send.log" FM_SEND_STATE_LOG="$fixture/send-state.log" \
+    "$fixture/root/bin/fm-ask-user-question.sh" deliver \
+      --home "$fixture/home" --task alpha --key scope --generation "$generation" \
+      --answer Safe >/dev/null \
+    || fail "delivery did not use the active state override"
+  canonical_state=$(cd "$state_a" && pwd -P)
+  [ "$(cat "$fixture/send-state.log")" = "$canonical_state" ] \
+    || fail "fm-send did not inherit the canonical active state path"
+
+  if FM_HOME="$fixture/home" FM_STATE_OVERRIDE="$state_b" \
+    "$fixture/root/bin/fm-ask-user-question.sh" validate \
+      --home "$fixture/home" --task alpha --key scope --generation "$generation" >/dev/null 2>&1; then
+    fail "generation from a different canonical state tree was accepted"
+  fi
+  pass "ask-user adapter binds generation, validation, and delivery to one canonical state override"
+}
+
 test_pi_modal_contract() {
   local fixture out status
   if ! command -v node >/dev/null 2>&1 || [ ! -f "$PI_PACKAGE_DIR/package.json" ]; then
@@ -91,13 +130,15 @@ test_pi_modal_contract() {
     return 0
   fi
   fixture="$TMP_ROOT/pi"
-  mkdir -p "$fixture/project/.pi/extensions" "$fixture/project/node_modules/@earendil-works" "$fixture/home/state"
+  mkdir -p "$fixture/project/.pi/extensions" "$fixture/project/node_modules/@earendil-works" \
+    "$fixture/home/state" "$fixture/active-state"
   cp "$ROOT/.pi/extensions/fm-ask-user-question.ts" "$fixture/project/.pi/extensions/fm-ask-user-question.ts"
   ln -s "$PI_PACKAGE_DIR" "$fixture/project/node_modules/@earendil-works/pi-coding-agent"
   ln -s "$PI_PACKAGE_DIR/node_modules/@earendil-works/pi-tui" "$fixture/project/node_modules/@earendil-works/pi-tui"
   ln -s "$PI_PACKAGE_DIR/node_modules/typebox" "$fixture/project/node_modules/typebox"
   printf '%s\n' '{"type":"module"}' > "$fixture/project/package.json"
-  printf '%s\n' "$$" > "$fixture/home/state/.lock"
+  printf '%s\n' 1 > "$fixture/home/state/.lock"
+  printf '%s\n' "$$" > "$fixture/active-state/.lock"
   cat > "$fixture/adapter.sh" <<'SH'
 #!/usr/bin/env bash
 printf '%s\0' "$@" >> "$FM_ASK_LOG"
@@ -122,6 +163,7 @@ SH
 
   out=$(cd "$fixture/project" && \
     FM_HOME="$fixture/home" \
+    FM_STATE_OVERRIDE="$fixture/active-state" \
     FM_ASK_USER_QUESTION_FIXTURE=1 \
     FM_ASK_USER_QUESTION_ADAPTER="$fixture/adapter.sh" \
     FM_ASK_LOG="$fixture/adapter.log" \
@@ -264,12 +306,12 @@ result = await execute({ ...base, decisionKey: "wrong-generation" });
 if (result.details.reason !== "binding-mismatch" || customCalls !== before) {
   throw new Error("generation mismatch reached the modal");
 }
-writeFileSync(`${process.env.FM_HOME}/state/.lock`, "1\n");
+writeFileSync(`${process.env.FM_STATE_OVERRIDE}/.lock`, "1\n");
 result = await execute({ ...base, decisionKey: "wrong-lock" });
 if (result.details.reason !== "binding-mismatch" || customCalls !== before) {
   throw new Error("non-primary lock ownership reached the modal");
 }
-writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
+writeFileSync(`${process.env.FM_STATE_OVERRIDE}/.lock`, `${process.pid}\n`);
 
 behavior = "single";
 before = deliveryCount();
@@ -342,5 +384,6 @@ JS
 }
 
 test_binding_and_delivery_adapter
+test_state_override_binding
 test_pi_modal_contract
 test_fixture_gate

--- a/tests/fm-ask-user-question.test.sh
+++ b/tests/fm-ask-user-question.test.sh
@@ -96,6 +96,18 @@ JS
     *) fail "owner failure diagnostic was lost: $out" ;;
   esac
 
+  cp "$fixture/send.log" "$fixture/send-before-owner-missing.log"
+  chmod -x "$fixture/root/bin/fm-send.sh"
+  out=$(FM_HOME="$fixture/home" FM_SEND_LOG="$fixture/send.log" \
+    "$fixture/root/bin/fm-ask-user-question.sh" deliver \
+      --home "$fixture/home" --task alpha --key scope --generation "$generation" \
+      --answer blocked 2>&1)
+  status=$?
+  chmod +x "$fixture/root/bin/fm-send.sh"
+  [ "$status" -eq 3 ] || fail "missing delivery owner was not a preflight failure: $status $out"
+  cmp -s "$fixture/send-before-owner-missing.log" "$fixture/send.log" \
+    || fail "missing delivery owner changed the send log"
+
   cp "$fixture/send.log" "$fixture/send-before-marker.log"
   ln -s "$fixture/missing-secondmate-marker" "$fixture/home/.fm-secondmate-home"
   if FM_HOME="$fixture/home" "$fixture/root/bin/fm-ask-user-question.sh" \
@@ -335,6 +347,12 @@ if [ "$command" = deliver ]; then
     } >&2
     exit 4
   fi
+  if [ "$key" = owner-signal ]; then
+    kill -TERM "$$"
+  fi
+  if [ "$key" = slow-owner ]; then
+    sleep 11
+  fi
 fi
 exit 0
 SH
@@ -520,6 +538,20 @@ if (!renderedUnknown.includes("fm-send: answer queued but decision close failed"
     !renderedUnknown.includes("Do not resend automatically.") ||
     renderedUnknownLines.some((line) => /[\u0000-\u001f\u007f-\u009f]/.test(line))) {
   throw new Error(`delivery-unknown evidence was hidden or unsafe: ${JSON.stringify(renderedUnknownLines)}`);
+}
+
+before = deliveryCount();
+result = await execute({ ...base, decisionKey: "owner-signal" });
+if (result.details.reason !== "delivery-unknown" || result.details.delivered !== "unknown" ||
+    result.details.answers[0]?.id !== "safe" || deliveryCount() !== before + 1) {
+  throw new Error(`indeterminate owner result was misclassified: ${JSON.stringify(result.details)}`);
+}
+
+before = deliveryCount();
+result = await execute({ ...base, decisionKey: "slow-owner" });
+if (result.details.status !== "answered" || result.details.delivered !== true ||
+    deliveryCount() !== before + 1) {
+  throw new Error(`bounded owner delivery was killed externally: ${JSON.stringify(result.details)}`);
 }
 
 behavior = "throw";

--- a/tests/fm-ask-user-question.test.sh
+++ b/tests/fm-ask-user-question.test.sh
@@ -38,6 +38,9 @@ if [ "${FM_SEND_FAIL:-0}" = 1 ]; then
   printf '\001fm-send: answer queued but decision close failed\n' >&2
   exit 9
 fi
+if [ "${FM_SEND_BACKGROUND_DESCENDANT:-0}" = 1 ]; then
+  sleep 5 </dev/null >/dev/null 2>&1 &
+fi
 SH
   chmod +x "$fixture/root/bin/fm-ask-user-question.sh" "$fixture/root/bin/fm-send.sh"
   printf 'task_id=alpha\nbackend=tmux\n' > "$fixture/home/state/alpha.meta"
@@ -278,15 +281,15 @@ const result = await tool.execute("call", {
 if (result.details.status !== "answered" || result.details.answers[0]?.id !== "safe") {
   throw new Error(`override-backed question was not answered: ${JSON.stringify(result.details)}`);
 }
-const args = readFileSync(process.env.FM_SEND_LOG, "utf8").split("\0").filter(Boolean);
-const expectedArgs = [
+const expectedCall = [
   "alpha",
   "--resolve-key",
   "scope",
   "Captain answer: selected safe",
 ];
-if (JSON.stringify(args) !== JSON.stringify(expectedArgs)) {
-  throw new Error(`fm-send received wrong calls: ${JSON.stringify(args)}`);
+const sendCalls = () => readFileSync(process.env.FM_SEND_LOG, "utf8").split("\0").filter(Boolean);
+if (JSON.stringify(sendCalls()) !== JSON.stringify(expectedCall)) {
+  throw new Error(`fm-send received wrong calls: ${JSON.stringify(sendCalls())}`);
 }
 const states = readFileSync(process.env.FM_SEND_STATE_LOG, "utf8").trim().split("\n");
 if (states.length !== 1 || states[0] !== process.env.EXPECTED_STATE) {
@@ -297,8 +300,30 @@ if (lockChecks.length !== 2 || lockChecks.some((state) => state !== process.env.
   throw new Error(`shared lock owner received wrong state: ${JSON.stringify(lockChecks)}`);
 }
 
+process.env.FM_SEND_BACKGROUND_DESCENDANT = "1";
+const descendantResult = await Promise.race([
+  tool.execute("call", {
+    home: process.env.FM_HOME,
+    taskId: "alpha",
+    decisionKey: "scope",
+    sourceGeneration: process.env.GENERATION,
+    mode: "single",
+    question: "Choose",
+    options: [{ id: "safe", label: "Safe" }],
+  }, new AbortController().signal, undefined, { mode: "tui", ui }),
+  new Promise((_, reject) => setTimeout(() => reject(new Error("delivery waited for the owner's background descendant")), 1000)),
+]);
+delete process.env.FM_SEND_BACKGROUND_DESCENDANT;
+if (descendantResult.details.status !== "answered" || descendantResult.details.delivered !== true) {
+  throw new Error(`background-owner delivery was not answered: ${JSON.stringify(descendantResult.details)}`);
+}
+const expectedCalls = [...expectedCall, ...expectedCall];
+if (JSON.stringify(sendCalls()) !== JSON.stringify(expectedCalls)) {
+  throw new Error(`background-owner delivery was not exactly once: ${JSON.stringify(sendCalls())}`);
+}
+
 process.env.FM_LOCK_REMOVE_META = `${process.env.EXPECTED_STATE}/alpha.meta`;
-process.env.FM_LOCK_REMOVE_META_AT_CHECK = "4";
+process.env.FM_LOCK_REMOVE_META_AT_CHECK = "6";
 const raceResult = await tool.execute("call", {
   home: process.env.FM_HOME,
   taskId: "alpha",
@@ -316,7 +341,7 @@ if (renderedRace.includes("Do not resend automatically.")) {
   throw new Error(`pre-owner read race showed a no-resend warning: ${renderedRace}`);
 }
 const finalArgs = readFileSync(process.env.FM_SEND_LOG, "utf8").split("\0").filter(Boolean);
-if (JSON.stringify(finalArgs) !== JSON.stringify(expectedArgs)) {
+if (JSON.stringify(finalArgs) !== JSON.stringify(expectedCalls)) {
   throw new Error(`pre-owner read race reached fm-send: ${JSON.stringify(finalArgs)}`);
 }
 JS

--- a/tests/fm-ask-user-question.test.sh
+++ b/tests/fm-ask-user-question.test.sh
@@ -79,6 +79,22 @@ JS
   [ "$(cat "$fixture/lock-check.log")" = "$(printf '%s\n%s' "$canonical_state" "$canonical_state")" ] \
     || fail "adapter did not delegate validation and delivery lock proof to the shared owner"
 
+  cp "$fixture/send.log" "$fixture/send-before-marker.log"
+  ln -s "$fixture/missing-secondmate-marker" "$fixture/home/.fm-secondmate-home"
+  if FM_HOME="$fixture/home" "$fixture/root/bin/fm-ask-user-question.sh" \
+    validate --home "$fixture/home" --task alpha --key scope --generation "$generation" >/dev/null 2>&1; then
+    fail "dangling secondmate marker bypassed pre-display primary validation"
+  fi
+  if FM_HOME="$fixture/home" FM_SEND_LOG="$fixture/send.log" \
+    "$fixture/root/bin/fm-ask-user-question.sh" deliver \
+      --home "$fixture/home" --task alpha --key scope --generation "$generation" \
+      --answer blocked >/dev/null 2>&1; then
+    fail "dangling secondmate marker bypassed pre-delivery primary validation"
+  fi
+  cmp -s "$fixture/send-before-marker.log" "$fixture/send.log" \
+    || fail "dangling secondmate marker reached the delivery owner"
+  rm "$fixture/home/.fm-secondmate-home"
+
   printf 'working: unrelated append\n' >> "$fixture/home/state/alpha.status"
   if FM_HOME="$fixture/home" "$fixture/root/bin/fm-ask-user-question.sh" \
     validate --home "$fixture/home" --task alpha --key scope --generation "$generation" >/dev/null 2>&1; then
@@ -454,6 +470,13 @@ if (result.details.reason !== "delivery-unknown" || result.details.delivered !==
     typeof result.details.diagnostic !== "string" || result.details.diagnostic.length !== 500 ||
     /[\u0000-\u001f\u007f-\u009f]/.test(result.details.diagnostic) || deliveryCount() !== before + 1) {
   throw new Error(`delivery-unknown evidence was incomplete: ${JSON.stringify(result.details)}`);
+}
+const renderedUnknownLines = tool.renderResult(result, { expanded: false }, theme).render(1000);
+const renderedUnknown = renderedUnknownLines.join("\n");
+if (!renderedUnknown.includes("fm-send: answer queued but decision close failed") ||
+    !renderedUnknown.includes("Do not resend automatically.") ||
+    renderedUnknownLines.some((line) => /[\u0000-\u001f\u007f-\u009f]/.test(line))) {
+  throw new Error(`delivery-unknown evidence was hidden or unsafe: ${JSON.stringify(renderedUnknownLines)}`);
 }
 
 behavior = "throw";

--- a/tests/fm-ask-user-question.test.sh
+++ b/tests/fm-ask-user-question.test.sh
@@ -1,0 +1,346 @@
+#!/usr/bin/env bash
+# Focused source-binding, delivery, and Pi modal checks for ask-user-question.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-ask-user-question)
+PI_PACKAGE_DIR=${FM_PI_PACKAGE_DIR:-"$(npm root -g 2>/dev/null)/@earendil-works/pi-coding-agent"}
+
+make_adapter_fixture() {
+  local fixture=$1
+  mkdir -p "$fixture/root/bin" "$fixture/home/state"
+  cp "$ROOT/bin/fm-ask-user-question.sh" "$fixture/root/bin/fm-ask-user-question.sh"
+  cp "$ROOT/bin/fm-classify-lib.sh" "$fixture/root/bin/fm-classify-lib.sh"
+  cp "$ROOT/bin/fm-timeout-lib.sh" "$fixture/root/bin/fm-timeout-lib.sh"
+  cat > "$fixture/root/bin/fm-send.sh" <<'SH'
+#!/usr/bin/env bash
+printf '%s\0' "$@" >> "$FM_SEND_LOG"
+SH
+  chmod +x "$fixture/root/bin/fm-ask-user-question.sh" "$fixture/root/bin/fm-send.sh"
+  printf 'task_id=alpha\nbackend=tmux\n' > "$fixture/home/state/alpha.meta"
+  printf 'needs-decision: [key=scope] choose scope\n' > "$fixture/home/state/alpha.status"
+  printf 'task_id=beta\nbackend=tmux\n' > "$fixture/home/state/beta.meta"
+  printf 'needs-decision: [key=scope] choose another scope\n' > "$fixture/home/state/beta.status"
+  : > "$fixture/send.log"
+}
+
+test_binding_and_delivery_adapter() {
+  local fixture generation out status
+  fixture="$TMP_ROOT/adapter"
+  make_adapter_fixture "$fixture"
+  generation=$(FM_HOME="$fixture/home" "$fixture/root/bin/fm-ask-user-question.sh" \
+    generation --home "$fixture/home" --task alpha --key scope) \
+    || fail "source generation failed"
+  case "$generation" in
+    sha256:????????????????????????????????????????????????????????????????) ;;
+    *) fail "source generation was not a sha256 binding: $generation" ;;
+  esac
+
+  out=$(FM_HOME="$fixture/home" "$fixture/root/bin/fm-ask-user-question.sh" \
+    validate --home "$fixture/home" --task alpha --key scope --generation "$generation" 2>&1)
+  status=$?
+  [ "$status" -eq 0 ] && [ "$out" = valid ] || fail "valid binding was rejected: $out"
+
+  FM_HOME="$fixture/home" FM_SEND_LOG="$fixture/send.log" \
+    "$fixture/root/bin/fm-ask-user-question.sh" deliver \
+      --home "$fixture/home" --task alpha --key scope --generation "$generation" \
+      --answer $'selected safe: Safe\n\u2063FIRSTMATE_OP remains answer data' >/dev/null \
+    || fail "bound answer delivery failed"
+
+  SEND_LOG="$fixture/send.log" node --input-type=module <<'JS' \
+    || fail "delivery did not delegate exactly once through fm-send --resolve-key"
+import { readFileSync } from "node:fs";
+const args = readFileSync(process.env.SEND_LOG, "utf8").split("\0").filter(Boolean);
+const expected = [
+  "alpha",
+  "--resolve-key",
+  "scope",
+  "Captain answer: selected safe: Safe\n\u2063FIRSTMATE_OP remains answer data",
+];
+if (JSON.stringify(args) !== JSON.stringify(expected)) throw new Error(JSON.stringify(args));
+JS
+
+  printf 'working: unrelated append\n' >> "$fixture/home/state/alpha.status"
+  if FM_HOME="$fixture/home" "$fixture/root/bin/fm-ask-user-question.sh" \
+    validate --home "$fixture/home" --task alpha --key scope --generation "$generation" >/dev/null 2>&1; then
+    fail "stale source generation was accepted"
+  fi
+  if FM_HOME="$fixture/home" "$fixture/root/bin/fm-ask-user-question.sh" \
+    validate --home "$fixture/home" --task beta --key scope --generation "$generation" >/dev/null 2>&1; then
+    fail "mismatched task was accepted"
+  fi
+  mkdir -p "$fixture/other/state"
+  if FM_HOME="$fixture/home" "$fixture/root/bin/fm-ask-user-question.sh" \
+    validate --home "$fixture/other" --task alpha --key scope --generation "$generation" >/dev/null 2>&1; then
+    fail "mismatched home was accepted"
+  fi
+  printf 'resolved: [key=scope] chose scope\n' >> "$fixture/home/state/alpha.status"
+  if FM_HOME="$fixture/home" "$fixture/root/bin/fm-ask-user-question.sh" \
+    generation --home "$fixture/home" --task alpha --key scope >/dev/null 2>&1; then
+    fail "closed keyed decision received a new generation"
+  fi
+  pass "ask-user adapter binds home, task, key, and generation and delegates one literal answer through fm-send"
+}
+
+test_pi_modal_contract() {
+  local fixture out status
+  if ! command -v node >/dev/null 2>&1 || [ ! -f "$PI_PACKAGE_DIR/package.json" ]; then
+    echo "skip: installed Pi package not found for ask-user-question modal test"
+    return 0
+  fi
+  fixture="$TMP_ROOT/pi"
+  mkdir -p "$fixture/project/.pi/extensions" "$fixture/project/node_modules/@earendil-works" "$fixture/home/state"
+  cp "$ROOT/.pi/extensions/fm-ask-user-question.ts" "$fixture/project/.pi/extensions/fm-ask-user-question.ts"
+  ln -s "$PI_PACKAGE_DIR" "$fixture/project/node_modules/@earendil-works/pi-coding-agent"
+  ln -s "$PI_PACKAGE_DIR/node_modules/@earendil-works/pi-tui" "$fixture/project/node_modules/@earendil-works/pi-tui"
+  ln -s "$PI_PACKAGE_DIR/node_modules/typebox" "$fixture/project/node_modules/typebox"
+  printf '%s\n' '{"type":"module"}' > "$fixture/project/package.json"
+  printf '%s\n' "$$" > "$fixture/home/state/.lock"
+  cat > "$fixture/adapter.sh" <<'SH'
+#!/usr/bin/env bash
+printf '%s\0' "$@" >> "$FM_ASK_LOG"
+command=$1
+shift
+task=
+key=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --task) task=$2; shift 2 ;;
+    --key) key=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+[ "$task" != wrong-task ] || exit 2
+[ "$key" != wrong-generation ] || exit 2
+[ "$command" != deliver ] || [ "$key" != stale-before-delivery ] || exit 2
+exit 0
+SH
+  chmod +x "$fixture/adapter.sh"
+  : > "$fixture/adapter.log"
+
+  out=$(cd "$fixture/project" && \
+    FM_HOME="$fixture/home" \
+    FM_ASK_USER_QUESTION_FIXTURE=1 \
+    FM_ASK_USER_QUESTION_ADAPTER="$fixture/adapter.sh" \
+    FM_ASK_LOG="$fixture/adapter.log" \
+    EXT="$fixture/project/.pi/extensions/fm-ask-user-question.ts" \
+    node --input-type=module 2>&1 <<'JS'
+import { readFileSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import { visibleWidth } from "@earendil-works/pi-tui";
+
+const extension = await import(`${pathToFileURL(process.env.EXT).href}?fixture=${Date.now()}`);
+let tool;
+const pi = {
+  registerTool(candidate) {
+    if (candidate.name === "fm_ask_user_question") tool = candidate;
+  },
+};
+extension.default(pi);
+if (!tool) throw new Error("fixture flag did not register the tool");
+
+const theme = {
+  fg(_color, text) { return text; },
+  bg(_color, text) { return text; },
+  bold(text) { return text; },
+};
+const generation = `sha256:${"0".repeat(64)}`;
+const ENTER = "\r";
+const DOWN = "\x1b[B";
+const ESCAPE = "\x1b";
+const base = {
+  home: process.env.FM_HOME,
+  taskId: "alpha",
+  decisionKey: "scope",
+  sourceGeneration: generation,
+  mode: "single",
+  question: "Choose",
+  options: [{ id: "safe", label: "Safe" }],
+};
+const adapterLog = () => readFileSync(process.env.FM_ASK_LOG, "utf8").split("\0").filter(Boolean);
+const deliveryCount = () => adapterLog().filter((value) => value === "deliver").length;
+let customCalls = 0;
+let activeModals = 0;
+let maxActiveModals = 0;
+let behavior = "single";
+let resizeEvidence = false;
+
+const ui = {
+  custom(factory) {
+    customCalls += 1;
+    activeModals += 1;
+    maxActiveModals = Math.max(maxActiveModals, activeModals);
+    return new Promise((resolve, reject) => {
+      const tui = { requestRender() {}, terminal: { rows: 40, columns: 80 } };
+      const done = (result) => {
+        activeModals -= 1;
+        resolve(result);
+      };
+      let component;
+      try {
+        component = factory(tui, theme, {}, done);
+        component.focused = true;
+        const wide = component.render(72);
+        const narrow = component.render(17);
+        if (wide === narrow || narrow.some((line) => visibleWidth(line) > 17)) {
+          throw new Error("resize cache did not honor the new width");
+        }
+        resizeEvidence = true;
+        if (behavior === "throw") throw new Error("synthetic UI failure");
+        if (behavior === "cancel") component.handleInput(ESCAPE);
+        else if (behavior === "single") {
+          component.handleInput(ENTER);
+          component.handleInput(ENTER);
+        } else if (behavior === "text") {
+          for (const char of "free answer") component.handleInput(char);
+          component.handleInput(ENTER);
+        } else if (behavior === "multi") {
+          component.handleInput(ENTER);
+          component.handleInput(DOWN);
+          component.handleInput(DOWN);
+          component.handleInput(ENTER);
+          for (const char of "custom") component.handleInput(char);
+          component.handleInput(ENTER);
+          component.handleInput(DOWN);
+          component.handleInput(ENTER);
+        } else if (behavior === "delayed") {
+          setTimeout(() => component.handleInput(ENTER), 25);
+        }
+      } catch (error) {
+        activeModals -= 1;
+        reject(error);
+      }
+    });
+  },
+};
+const tuiContext = { mode: "tui", ui };
+const execute = (params, context = tuiContext) => tool.execute("call", params, new AbortController().signal, undefined, context);
+
+let before = deliveryCount();
+let result = await execute(base);
+if (result.details.status !== "answered" || result.details.answers[0].id !== "safe" || deliveryCount() !== before + 1) {
+  throw new Error("single-select did not deliver exactly one structured answer");
+}
+
+behavior = "text";
+result = await execute({ ...base, decisionKey: "text", mode: "text", options: undefined, question: "Free text" });
+if (result.details.answers[0]?.type !== "text" || result.details.answers[0]?.text !== "free answer") {
+  throw new Error(`free text answer was not structured: ${JSON.stringify(result.details)}`);
+}
+
+behavior = "multi";
+result = await execute({
+  ...base,
+  decisionKey: "multi",
+  mode: "multi",
+  allowOther: true,
+  options: [{ id: "one", label: "One" }, { id: "two", label: "Two" }],
+});
+if (result.details.answers.length !== 2 || result.details.answers[0].id !== "one" || result.details.answers[1].text !== "custom") {
+  throw new Error(`multi-select/Other result was wrong: ${JSON.stringify(result.details)}`);
+}
+
+behavior = "cancel";
+before = deliveryCount();
+result = await execute({ ...base, decisionKey: "cancel" });
+if (result.details.status !== "cancelled" || result.details.reason !== "user" || deliveryCount() !== before) {
+  throw new Error("cancellation delivered or lost structured cancellation");
+}
+
+before = customCalls;
+result = await execute({ ...base, decisionKey: "no-ui" }, { mode: "print", ui });
+if (result.details.reason !== "ui-unavailable" || customCalls !== before) {
+  throw new Error("no-UI mode attempted to open a modal");
+}
+
+before = customCalls;
+result = await execute({ ...base, taskId: "wrong-task" });
+if (result.details.reason !== "binding-mismatch" || customCalls !== before) {
+  throw new Error("task mismatch reached the modal");
+}
+result = await execute({ ...base, decisionKey: "wrong-generation" });
+if (result.details.reason !== "binding-mismatch" || customCalls !== before) {
+  throw new Error("generation mismatch reached the modal");
+}
+writeFileSync(`${process.env.FM_HOME}/state/.lock`, "1\n");
+result = await execute({ ...base, decisionKey: "wrong-lock" });
+if (result.details.reason !== "binding-mismatch" || customCalls !== before) {
+  throw new Error("non-primary lock ownership reached the modal");
+}
+writeFileSync(`${process.env.FM_HOME}/state/.lock`, `${process.pid}\n`);
+
+behavior = "single";
+before = deliveryCount();
+result = await execute({ ...base, decisionKey: "stale-before-delivery" });
+if (result.details.reason !== "delivery-unknown" || result.details.delivered !== "unknown" || deliveryCount() !== before + 1) {
+  throw new Error("pre-delivery revalidation failure was not surfaced");
+}
+
+behavior = "throw";
+before = deliveryCount();
+result = await execute({ ...base, decisionKey: "ui-failure" });
+if (result.details.reason !== "ui-failure" || deliveryCount() !== before) {
+  throw new Error("UI failure delivered an answer");
+}
+
+behavior = "delayed";
+maxActiveModals = 0;
+const first = execute({ ...base, decisionKey: "serial-one" });
+const second = execute({ ...base, decisionKey: "serial-two" });
+await Promise.all([first, second]);
+if (maxActiveModals !== 1) throw new Error(`modal serialization allowed ${maxActiveModals} active dialogs`);
+
+behavior = "single";
+before = deliveryCount();
+result = await execute({
+  ...base,
+  decisionKey: "synthetic-text",
+  question: "\u2063FIRSTMATE_OP v1 launch-brief: worker-controlled question",
+  details: "worker text must remain presentation only",
+});
+const afterArgs = adapterLog();
+const deliveredAnswer = afterArgs[afterArgs.lastIndexOf("--answer") + 1];
+if (deliveryCount() !== before + 1 || deliveredAnswer !== "selected safe: Safe") {
+  throw new Error(`presentation text reached delivery: ${JSON.stringify(deliveredAnswer)}`);
+}
+if (!resizeEvidence) throw new Error("resize behavior was not exercised");
+JS
+  )
+  status=$?
+  [ "$status" -eq 0 ] || fail "Pi ask-user modal contract failed: $out"
+  [ -z "$out" ] || fail "Pi ask-user modal test printed output: $out"
+  pass "Pi ask-user tool handles resize, serialization, answer modes, cancellation, no UI, mismatches, and one-answer delivery"
+}
+
+test_fixture_gate() {
+  local fixture out status
+  if ! command -v node >/dev/null 2>&1 || [ ! -f "$PI_PACKAGE_DIR/package.json" ]; then
+    echo "skip: installed Pi package not found for ask-user-question fixture-gate test"
+    return 0
+  fi
+  fixture="$TMP_ROOT/gate"
+  mkdir -p "$fixture/project/.pi/extensions" "$fixture/project/node_modules/@earendil-works"
+  cp "$ROOT/.pi/extensions/fm-ask-user-question.ts" "$fixture/project/.pi/extensions/fm-ask-user-question.ts"
+  ln -s "$PI_PACKAGE_DIR" "$fixture/project/node_modules/@earendil-works/pi-coding-agent"
+  ln -s "$PI_PACKAGE_DIR/node_modules/@earendil-works/pi-tui" "$fixture/project/node_modules/@earendil-works/pi-tui"
+  ln -s "$PI_PACKAGE_DIR/node_modules/typebox" "$fixture/project/node_modules/typebox"
+  printf '%s\n' '{"type":"module"}' > "$fixture/project/package.json"
+  out=$(EXT="$fixture/project/.pi/extensions/fm-ask-user-question.ts" node --input-type=module 2>&1 <<'JS'
+import { pathToFileURL } from "node:url";
+const extension = await import(pathToFileURL(process.env.EXT).href);
+let registered = false;
+extension.default({ registerTool() { registered = true; } });
+if (registered) throw new Error("tool registered without the fixture flag");
+JS
+  )
+  status=$?
+  [ "$status" -eq 0 ] || fail "fixture gate failed: $out"
+  [ -z "$out" ] || fail "fixture-gate test printed output: $out"
+  pass "ask-user-question leaves production Pi behavior unchanged without its fixture flag"
+}
+
+test_binding_and_delivery_adapter
+test_pi_modal_contract
+test_fixture_gate

--- a/tests/fm-ask-user-question.test.sh
+++ b/tests/fm-ask-user-question.test.sh
@@ -28,6 +28,11 @@ fm_session_lock_owned_by_self() {
 SH
   cat > "$fixture/root/bin/fm-send.sh" <<'SH'
 #!/usr/bin/env bash
+if [ -n "${FM_ASK_USER_QUESTION_OWNER_ENTRY_MARKER:-}" ]; then
+  [ "${FM_ASK_USER_QUESTION_OWNER_ENTRY_FD:-}" = 3 ] || exit 2
+  printf '%s\n' "$FM_ASK_USER_QUESTION_OWNER_ENTRY_MARKER" >&3 || exit 2
+  exec 3>&-
+fi
 printf '%s\0' "$@" >> "$FM_SEND_LOG"
 if [ -n "${FM_SEND_STATE_LOG:-}" ]; then
   printf '%s\n' "${FM_STATE_OVERRIDE:-}" >> "$FM_SEND_STATE_LOG"
@@ -216,6 +221,11 @@ test_pi_state_override_integration() {
   ln -s "$PI_PACKAGE_DIR/node_modules/@earendil-works/pi-tui" "$fixture/root/node_modules/@earendil-works/pi-tui"
   ln -s "$PI_PACKAGE_DIR/node_modules/typebox" "$fixture/root/node_modules/typebox"
   printf '%s\n' '{"type":"module"}' > "$fixture/root/package.json"
+  cat > "$fixture/kill-before-owner.bash" <<'SH'
+if [ "${1:-}" = deliver ]; then
+  trap 'if [[ ${BASH_COMMAND:-} == FM_HOME=*fm-send.sh* ]]; then kill -TERM "$$"; fi' DEBUG
+fi
+SH
   cp "$fixture/home/state/alpha.meta" "$fixture/active-state/alpha.meta"
   cp "$fixture/home/state/alpha.status" "$fixture/active-state/alpha.status"
   printf 'resolved: [key=scope] default tree is closed\n' > "$fixture/home/state/alpha.status"
@@ -322,8 +332,28 @@ if (JSON.stringify(sendCalls()) !== JSON.stringify(expectedCalls)) {
   throw new Error(`background-owner delivery was not exactly once: ${JSON.stringify(sendCalls())}`);
 }
 
+process.env.BASH_ENV = `${process.env.FM_HOME}/../kill-before-owner.bash`;
+const preOwnerTermination = await tool.execute("call", {
+  home: process.env.FM_HOME,
+  taskId: "alpha",
+  decisionKey: "scope",
+  sourceGeneration: process.env.GENERATION,
+  mode: "single",
+  question: "Choose",
+  options: [{ id: "safe", label: "Safe" }],
+}, new AbortController().signal, undefined, { mode: "tui", ui });
+delete process.env.BASH_ENV;
+if (preOwnerTermination.details.reason !== "binding-mismatch" ||
+    preOwnerTermination.details.delivered !== false ||
+    preOwnerTermination.details.answers[0]?.id !== "safe") {
+  throw new Error(`pre-owner termination was misclassified: ${JSON.stringify(preOwnerTermination.details)}`);
+}
+if (JSON.stringify(sendCalls()) !== JSON.stringify(expectedCalls)) {
+  throw new Error(`pre-owner termination reached fm-send: ${JSON.stringify(sendCalls())}`);
+}
+
 process.env.FM_LOCK_REMOVE_META = `${process.env.EXPECTED_STATE}/alpha.meta`;
-process.env.FM_LOCK_REMOVE_META_AT_CHECK = "6";
+process.env.FM_LOCK_REMOVE_META_AT_CHECK = "8";
 const raceResult = await tool.execute("call", {
   home: process.env.FM_HOME,
   taskId: "alpha",

--- a/tests/fm-ask-user-question.test.sh
+++ b/tests/fm-ask-user-question.test.sh
@@ -367,7 +367,13 @@ fi
 if [ "$command" = deliver ] && [ "$key" = known-status ]; then
   exit 2
 fi
+if [ "$command" = deliver ] && [ "$key" = pre-marker-signal ]; then
+  kill -TERM "$$"
+fi
 if [ "$command" = deliver ]; then
+  [ "${FM_ASK_USER_QUESTION_OWNER_ENTRY_FD:-}" = 3 ] || exit 2
+  [ -n "${FM_ASK_USER_QUESTION_OWNER_ENTRY_MARKER:-}" ] || exit 2
+  printf '%s\n' "$FM_ASK_USER_QUESTION_OWNER_ENTRY_MARKER" >&3
   printf '%s\n' "$key" >> "$FM_OWNER_LOG"
   if [ "$key" = owner-failure ]; then
     {
@@ -379,6 +385,9 @@ if [ "$command" = deliver ]; then
   fi
   if [ "$key" = owner-signal ]; then
     kill -TERM "$$"
+  fi
+  if [ "$key" = large-owner ]; then
+    node -e 'process.stderr.write("x".repeat(1200000))'
   fi
   if [ "$key" = slow-owner ]; then
     sleep 11
@@ -579,6 +588,17 @@ if (renderedLaunchError.includes("Do not resend automatically.")) {
   throw new Error(`adapter launch error showed a no-resend warning: ${renderedLaunchError}`);
 }
 
+before = deliveryCount();
+result = await execute({ ...base, decisionKey: "pre-marker-signal" });
+if (result.details.reason !== "binding-mismatch" || result.details.delivered !== false ||
+    result.details.answers[0]?.id !== "safe" || deliveryCount() !== before) {
+  throw new Error(`pre-marker signal was misclassified: ${JSON.stringify(result.details)}`);
+}
+const renderedPreMarkerSignal = tool.renderResult(result, { expanded: false }, theme).render(1000).join("\n");
+if (renderedPreMarkerSignal.includes("Do not resend automatically.")) {
+  throw new Error(`pre-marker signal showed a no-resend warning: ${renderedPreMarkerSignal}`);
+}
+
 result = await execute({ ...base, decisionKey: "owner-failure" });
 if (result.details.reason !== "delivery-unknown" || result.details.delivered !== "unknown" ||
     result.details.answers[0]?.id !== "safe" || result.details.answers[0]?.text !== "Safe" ||
@@ -599,6 +619,13 @@ result = await execute({ ...base, decisionKey: "owner-signal" });
 if (result.details.reason !== "delivery-unknown" || result.details.delivered !== "unknown" ||
     result.details.answers[0]?.id !== "safe" || deliveryCount() !== before + 1) {
   throw new Error(`indeterminate owner result was misclassified: ${JSON.stringify(result.details)}`);
+}
+
+before = deliveryCount();
+result = await execute({ ...base, decisionKey: "large-owner" });
+if (result.details.status !== "answered" || result.details.delivered !== true ||
+    deliveryCount() !== before + 1) {
+  throw new Error(`large owner output killed delivery: ${JSON.stringify(result.details)}`);
 }
 
 before = deliveryCount();

--- a/tests/fm-pi-primary-types.test.sh
+++ b/tests/fm-pi-primary-types.test.sh
@@ -31,6 +31,7 @@ cp "$ROOT/.pi/extensions/fm-branch-supervision.ts" "$TMP_ROOT/fm-branch-supervis
 cp "$ROOT/.pi/extensions/fm-calm.ts" "$TMP_ROOT/fm-calm.ts"
 cp "$ROOT/.pi/extensions/fm-primary-pi-watch.ts" "$TMP_ROOT/fm-primary-pi-watch.ts"
 cp "$ROOT/.pi/extensions/fm-primary-turnend-guard.ts" "$TMP_ROOT/fm-primary-turnend-guard.ts"
+cp "$ROOT/.pi/extensions/fm-ask-user-question.ts" "$TMP_ROOT/fm-ask-user-question.ts"
 cp "$ROOT/.pi/extensions/lib/fm-branch-dispatch.ts" "$TMP_ROOT/lib/fm-branch-dispatch.ts"
 cp "$ROOT/.pi/extensions/lib/fm-calm-assistant-layout.ts" "$TMP_ROOT/lib/fm-calm-assistant-layout.ts"
 cp "$ROOT/.pi/extensions/lib/fm-calm-operational-user-layout.ts" "$TMP_ROOT/lib/fm-calm-operational-user-layout.ts"

--- a/tests/fm-send-resolve-key.test.sh
+++ b/tests/fm-send-resolve-key.test.sh
@@ -139,6 +139,29 @@ test_answer_send_closes_open_decision() {
   pass "fm-send --resolve-key: the answer send itself closes the open decision"
 }
 
+test_owner_entry_acknowledges_inside_fm_send() {
+  local dir fb log home marker entry rc
+  dir="$TMP_ROOT/owner-entry"; mkdir -p "$dir"
+  fb=$(make_stubs "$dir"); log="$dir/send.log"; entry="$dir/owner-entry"
+  home=$(setup_home owner-entry)
+  marker='fm-owner-entry-v1:test'
+  fm_write_meta "$home/state/t0.meta" "window=sess:fm-t0" "kind=ship"
+  printf 'needs-decision [key=choice]: choose\n' > "$home/state/t0.status"
+
+  env PATH="$fb:$PATH" FM_ROOT_OVERRIDE="$home" FM_HOME="$home" \
+    FM_SEND_LOG="$log" FM_SEND_SETTLE=0 \
+    FM_ASK_USER_QUESTION_OWNER_ENTRY_FD=3 \
+    FM_ASK_USER_QUESTION_OWNER_ENTRY_MARKER="$marker" \
+    "$SEND" t0 --resolve-key choice "answer" 3>"$entry" 2>/dev/null
+  rc=$?
+  expect_code 0 "$rc" "owner-marked answer send should succeed"
+  [ "$(cat "$entry")" = "$marker" ] \
+    || fail "fm-send did not emit its exact owner-entry acknowledgement"
+  [ -f "$home/state/t0.inbox/001.msg" ] \
+    || fail "owner-marked answer did not reach the durable inbox"
+  pass "fm-send emits the opt-in owner-entry acknowledgement from inside its executable"
+}
+
 # The answerer's close is this home's own bookkeeping: it must not re-wake the
 # session that wrote it, while any other writer's later line on the same task
 # still must. Both directions are read through the production seen-signature
@@ -537,6 +560,7 @@ test_flag_misuse_refuses() {
 }
 
 test_answer_send_closes_open_decision
+test_owner_entry_acknowledges_inside_fm_send
 test_answer_close_is_self_announced
 test_colon_first_key_position_is_answerable
 test_answer_starts_work_never_orphans

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -25,8 +25,8 @@ test_list_all_exact_suite_coverage() {
     done | LC_ALL=C sort
   )
   [ -n "$listed" ] || fail "--list --all printed nothing"
-  missing=$(comm -23 <(printf '%s\n' "$expected") <(printf '%s\n' "$listed") || true)
-  extra=$(comm -13 <(printf '%s\n' "$expected") <(printf '%s\n' "$listed") || true)
+  missing=$(LC_ALL=C comm -23 <(printf '%s\n' "$expected") <(printf '%s\n' "$listed") || true)
+  extra=$(LC_ALL=C comm -13 <(printf '%s\n' "$expected") <(printf '%s\n' "$listed") || true)
   [ -z "$missing" ] || fail "--list --all missing scripts: $missing"
   [ -z "$extra" ] || fail "--list --all unexpected scripts: $extra"
   # No duplicates.
@@ -359,7 +359,7 @@ test_portable_shard_union_and_coverage_guard() {
   herdr=$("$RUNNER" --list --family real-herdr-gated)
   [ -n "$s1" ] && [ -n "$s2" ] || fail "portable parallel shards must be non-empty"
   # Shards disjoint.
-  overlap=$(comm -12 <(printf '%s\n' "$s1" | LC_ALL=C sort) <(printf '%s\n' "$s2" | LC_ALL=C sort) || true)
+  overlap=$(LC_ALL=C comm -12 <(printf '%s\n' "$s1" | LC_ALL=C sort) <(printf '%s\n' "$s2" | LC_ALL=C sort) || true)
   [ -z "$overlap" ] || fail "portable parallel shards overlap: $overlap"
   # Union of shards equals proven-isolated.
   [ "$(printf '%s\n' "$s1" "$s2" | LC_ALL=C sort -u)" = \


### PR DESCRIPTION
## Intent

Implement the captain-facing ask-user-question capability for Firstmate, deliberately ported from pi-config's reference to Firstmate's current Pi APIs and ownership model. Keep the captain in the primary Firstmate session with the smallest safe Stage 0/1 structured dialog or tool supporting free text, single select, multi-select with Other, cancellation, resize, and structured answered or cancelled results. Bind display to explicitly supplied task id, decision key, home, and source generation and revalidate before delivery; route answers only through the existing Firstmate decision/send owner, never directly to a pane, Herdr label, or worker; cancellation and UI failure must leave the durable decision open. Do not create a backend, registry, wake ledger, lifecycle authority, or prompt-snippets behavior. Preserve production behavior behind a safe fixture boundary because no live trigger exists. Add executable behavioral tests for resize, modal serialization, cancellation, no UI, generation and task mismatch, one-answer-only delivery, and isolation of synthetic operational input and worker text. Document only current behavior and the prototype entry point in the correct owner surface, avoid AGENTS.md unless a one-line trigger is required, use the no-mistakes pipeline with yolo off, do not modify pi-config or project clones, access connectors, or merge, and finish with a PR plus green validation. The existing fm-send owner solely governs delivery and its bounds; all pre-owner failures are binding mismatch, while an owner-invoked indeterminate result preserves the selected answer and bounded final diagnostic as delivery unknown with no automatic resend.

## What Changed

- Add a fixture-gated primary Pi dialog supporting free text, single select, multi-select with Other, cancellation, resize, modal serialization, and structured results.
- Bind questions to the active home, task, decision key, and source generation, routing answers exclusively through `fm-send --resolve-key` while preserving open decisions on failures or uncertain delivery.
- Add behavioral and type-check coverage plus architecture documentation for the prototype and its ownership boundaries.

## Risk Assessment

✅ Low: The feature is fixture-gated, delegates delivery to the existing owner, and the reviewed failure paths preserve the required binding and delivery classifications.

## Testing

The focused ask-user-question and fm-send owner tests passed, covering answer modes, resize, serialization, cancellation, UI absence/failure, binding mismatches, one-answer delivery, input isolation, durable decision closure, and failure preservation; executable rendered HTML and structured-result evidence confirm the end-user flow, and the worktree remained clean.

<details>
<summary>Evidence: Ask Captain rendered dialog and result evidence</summary>

Source: [Ask Captain rendered dialog and result evidence](https://github.com/aviralmansingka/firstmate/blob/0c5c6e37f543580b636401a1d8e866d25f87f971/.no-mistakes/evidence/feat/pi-ask-user-question/ask-user-question-ui.html)

```text
<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><title>Firstmate Ask Captain evidence</title><style>
:root{color-scheme:dark;font-family:ui-sans-serif,system-ui;background:#07111f;color:#dce8f8}body{margin:0;padding:36px;background:radial-gradient(circle at top right,#16345a,#07111f 45%)}main{max-width:1100px;margin:auto}h1{font-size:30px;margin:0 0 8px}.lede{color:#9eb2cd;margin:0 0 26px}.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(310px,1fr));gap:18px}.frame,.result{background:#0c192a;border:1px solid #294568;border-radius:12px;box-shadow:0 14px 35px #0008;overflow:hidden}.frame-title{padding:11px 14px;background:#11243b;color:#7fc4ff;font-weight:700}.frame-title span{float:right;color:#8098b6;font-weight:500}pre{margin:0;padding:16px;white-space:pre-wrap;color:#e9f2ff;font:14px/1.45 ui-monospace,SFMono-Regular,Consolas,monospace}.results{display:grid;grid-template-columns:repeat(auto-fit,minmax(270px,1fr));gap:18px;margin-top:18px}.result{padding:18px}.result h2{font-size:16px;margin:0 0 12px;color:#7fc4ff}.ok{color:#80e6af;font-weight:800}.cancel{color:#ffd082;font-weight:800}code{color:#dce8f8}.meta{margin-top:22px;color:#8098b6;font-size:13px}</style></head><body><main><h1>Ask Captain · executable UI evidence</h1><p class="lede">The tracked Pi extension rendered these modal states, handled resize and Other input, then returned structured results through the fixture-stage owner boundary.</p><div class="grid"><section class="frame"><div class="frame-title">Multi-select · wide terminal <span>72 cols</span></div><pre style="max-width:72ch">────────────────────────────────────────────────────────────────────────
 Captain decision · alpha · scope
 Which rollout should Firstmate use?
 Choose one or more safe paths. Worker text is presentation only.

&gt; [ ] Safe rollout
      Stage the change behind the fixture boundary.
  [ ] Fast rollout
      Use the smallest bounded rollout.
  Other...
  Submit selected answers

 ↑↓ navigate · Enter selects · Esc cancels
────────────────────────────────────────────────────────────────────────</pre></section>
<section class="frame"><div class="frame-title">Same dialog after terminal resize <span>30 cols</span></div><pre style="max-width:30ch">──────────────────────────────
 Captain decision · alpha ·
 scope
 Which rollout should
 Firstmate use?
 Choose one or more safe
 paths. Worker text is
 presentation only.

&gt; [ ] Safe rollout
      Stage the change behind
      the fixture boundary.
  [ ] Fast rollout
      Use the smallest bounded
      rollout.
  Other...
  Submit selected answers

 ↑↓ navigate · Enter selects ·
 Esc cancels
──────────────────────────────</pre></section>
<section class="frame"><div class="frame-title">Other free text in progress <span>72 cols</span></div><pre style="max-width:72ch">────────────────────────────────────────────────────────────────────────
 Captain decision · alpha · scope
 Which rollout should Firstmate use?
 Choose one or more safe paths. Worker text is presentation only.

 Other answer:
 ──────────────────────────────────────────────────────────────────────
 custom_pi:c[7m [0m                                                               
 ──────────────────────────────────────────────────────────────────────

 Enter submits · Esc cancels
────────────────────────────────────────────────────────────────────────</pre></section>
<section class="frame"><div class="frame-title">Ready to submit selected + Other <span>72 cols</span></div><pre style="max-width:72ch">────────────────────────────────────────────────────────────────────────
 Captain decision · alpha · scope
 Which rollout should Firstmate use?
 Choose one or more safe paths. Worker text is presentation only.

  [x] Safe rollout
      Stage the change behind the fixture boundary.
  [ ] Fast rollout
      Use the smallest bounded rollout.
  Other: custom
&gt; Submit selected answers

 ↑↓ navigate · Enter selects · Esc cancels
────────────────────────────────────────────────────────────────────────</pre></section>
<section class="frame"><div class="frame-title">Cancellation · decision remains open <span>72 cols</span></div><pre style="max-width:72ch">────────────────────────────────────────────────────────────────────────
 Captain decision · beta · cancel
 Which rollout should Firstmate use?
 Choose one or more safe paths. Worker text is presentation only.

&gt; Safe rollout
      Stage the change behind the fixture boundary.
  Fast rollout
      Use the smallest bounded rollout.

 ↑↓ navigate · Enter selects · Esc cancels
────────────────────────────────────────────────────────────────────────</pre></section></div><div class="results"><section class="result"><h2>Answered result</h2><div class="ok">answered · delivered=true</div><pre>{
  "schema": "fm-captain-answer.v1",
  "status": "answered",
  "home": "/tmp/no-mistakes-evidence/01M0Y6MJWQHG63XMF8R1DBMQH8/.ask-user-fixture/home",
  "taskId": "alpha",
  "decisionKey": "scope",
  "sourceGeneration": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
  "mode": "multi",
  "answers": [
    {
      "type": "option",
      "id": "safe",
      "text": "Safe rollout"
    },
    {
      "type": "other",
      "text": "custom"
    }
  ],
  "delivered": true
}</pre></section><section class="result"><h2>Cancelled result</h2><div class="cancel">cancelled · delivered=false</div><pre>{
  "schema": "fm-captain-answer.v1",
  "status": "cancelled",
  "home": "/tmp/no-mistakes-evidence/01M0Y6MJWQHG63XMF8R1DBMQH8/.ask-user-fixture/home",
  "taskId": "beta",
  "decisionKey": "cancel",
  "sourceGeneration": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
  "mode": "single",
  "answers": [],
  "delivered": false,
  "reason": "user"
}</pre></section><section class="result"><h2>Owner boundary</h2><div class="ok">Exactly one delivery</div><pre>scope	selected safe; other: custom</pre></section></div><div class="meta">Target 3bdc96944fd19bbb6e7f50447df60dc4ea63584f · executable source: .pi/extensions/fm-ask-user-question.ts</div></main></body></html>
```
</details>
<details>
<summary>Evidence: Structured answered, cancelled, resize-frame, and owner-delivery evidence</summary>

Source: [Structured answered, cancelled, resize-frame, and owner-delivery evidence](https://github.com/aviralmansingka/firstmate/blob/0c5c6e37f543580b636401a1d8e866d25f87f971/.no-mistakes/evidence/feat/pi-ask-user-question/ask-user-question-results.json)

```text
{
  "schema": "fm-ask-user-question-evidence.v1",
  "commit": "3bdc96944fd19bbb6e7f50447df60dc4ea63584f",
  "frames": [
    {
      "label": "Multi-select · wide terminal",
      "width": 72,
      "lines": [
        "────────────────────────────────────────────────────────────────────────",
        " Captain decision · alpha · scope",
        " Which rollout should Firstmate use?",
        " Choose one or more safe paths. Worker text is presentation only.",
        "",
        "> [ ] Safe rollout",
        "      Stage the change behind the fixture boundary.",
        "  [ ] Fast rollout",
        "      Use the smallest bounded rollout.",
        "  Other...",
        "  Submit selected answers",
        "",
        " ↑↓ navigate · Enter selects · Esc cancels",
        "────────────────────────────────────────────────────────────────────────"
      ]
    },
    {
      "label": "Same dialog after terminal resize",
      "width": 30,
      "lines": [
        "──────────────────────────────",
        " Captain decision · alpha ·",
        " scope",
        " Which rollout should",
        " Firstmate use?",
        " Choose one or more safe",
        " paths. Worker text is",
        " presentation only.",
        "",
        "> [ ] Safe rollout",
        "      Stage the change behind",
        "      the fixture boundary.",
        "  [ ] Fast rollout",
        "      Use the smallest bounded",
        "      rollout.",
        "  Other...",
        "  Submit selected answers",
        "",
        " ↑↓ navigate · Enter selects ·",
        " Esc cancels",
        "──────────────────────────────"
      ]
    },
    {
      "label": "Other free text in progress",
      "width": 72,
      "lines": [
        "────────────────────────────────────────────────────────────────────────",
        " Captain decision · alpha · scope",
        " Which rollout should Firstmate use?",
        " Choose one or more safe paths. Worker text is presentation only.",
        "",
        " Other answer:",
        " ──────────────────────────────────────────────────────────────────────",
        " custom\u001b_pi:c\u0007\u001b[7m \u001b[0m                                                               ",
        " ──────────────────────────────────────────────────────────────────────",
        "",
        " Enter submits · Esc cancels",
        "────────────────────────────────────────────────────────────────────────"
      ]
    },
    {
      "label": "Ready to submit selected + Other",
      "width": 72,
      "lines": [
        "────────────────────────────────────────────────────────────────────────",
        " Captain decision · alpha · scope",
        " Which rollout should Firstmate use?",
        " Choose one or more safe paths. Worker text is presentation only.",
        "",
        "  [x] Safe rollout",
        "      Stage the change behind the fixture boundary.",
        "  [ ] Fast rollout",
        "      Use the smallest bounded rollout.",
        "  Other: custom",
        "> Submit selected answers",
        "",
        " ↑↓ navigate · Enter selects · Esc cancels",
        "────────────────────────────────────────────────────────────────────────"
      ]
    },
    {
      "label": "Cancellation · decision remains open",
      "width": 72,
      "lines": [
        "────────────────────────────────────────────────────────────────────────",
        " Captain decision · beta · cancel",
        " Which rollout should Firstmate use?",
        " Choose one or more safe paths. Worker text is presentation only.",
        "",
        "> Safe rollout",
        "      Stage the change behind the fixture boundary.",
        "  Fast rollout",
        "      Use the smallest bounded rollout.",
        "",
        " ↑↓ navigate · Enter selects · Esc cancels",
        "────────────────────────────────────────────────────────────────────────"
      ]
    }
  ],
  "answered": {
    "schema": "fm-captain-answer.v1",
    "status": "answered",
    "home": "/tmp/no-mistakes-evidence/01M0Y6MJWQHG63XMF8R1DBMQH8/.ask-user-fixture/home",
    "taskId": "alpha",
    "decisionKey": "scope",
    "sourceGeneration": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
    "mode": "multi",
    "answers": [
      {
        "type": "option",
        "id": "safe",
        "text": "Safe rollout"
      },
      {
        "type": "other",
        "text": "custom"
      }
    ],
    "delivered": true
  },
  "cancelled": {
    "schema": "fm-captain-answer.v1",
    "status": "cancelled",
    "home": "/tmp/no-mistakes-evidence/01M0Y6MJWQHG63XMF8R1DBMQH8/.ask-user-fixture/home",
    "taskId": "beta",
    "decisionKey": "cancel",
    "sourceGeneration": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
    "mode": "single",
    "answers": [],
    "delivered": false,
    "reason": "user"
  },
  "ownerDeliveries": [
    "scope\tselected safe; other: custom"
  ]
}
```
</details>
<details>
<summary>Evidence: End-to-end evidence result</summary>

```text
answered=answered delivered=true; cancelled=cancelled reason=user delivered=false; owner_deliveries=1 payload=scope → selected safe; other: custom
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"313da9eb9172214c15fb1e7468eb649ba25974d9","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (3) ✅</summary>

- 🚨 `.pi/extensions/fm-ask-user-question.ts:394` - Intent requires “all pre-owner failures are binding mismatch” and only an owner-invoked indeterminate result to become delivery-unknown. Any successfully spawned adapter terminated before invoking fm-send returns status=null with a positive pid, so this condition incorrectly reports delivery-unknown and warns against resend even though nothing reached the owner. Have the adapter emit explicit evidence when it crosses the fm-send boundary rather than treating process creation as owner invocation.
- 🚨 `.pi/extensions/fm-ask-user-question.ts:152` - Intent requires that “the existing fm-send owner solely governs delivery and its bounds,” but spawnSync applies Node&#39;s finite default maxBuffer to delivery. Sufficient owner output therefore terminates fm-send outside its own bounds and converts the result to delivery-unknown. Stream and retain only the bounded diagnostic tail without imposing a parent-side delivery limit.

🔧 Fix: Stream owner delivery with explicit entry proof
1 error still open:
- 🚨 `.pi/extensions/fm-ask-user-question.ts:431` - The required “all pre-owner failures are binding mismatch” invariant is still violated. `home` accepts any string, so a payload containing `\u0000` passes `normalize`; Node then throws `ERR_INVALID_ARG_VALUE` from `spawnSync` before the adapter starts, and `execute` rejects instead of returning a structured binding-mismatch cancellation. Reject process-unsafe home values at the normalization boundary and cover this payload through the executable tool interface.

🔧 Fix: Reject process-unsafe ask-user homes
1 error still open:
- 🚨 `bin/fm-ask-user-question.sh:164` - The owner-entry pipe remains open while invoking fm-send, so FD 3 is inherited by all descendants. A supported Herdr send can background a long-lived server while ringing the durable inbox; that server redirects only FDs 0-2 and retains FD 3. Node then never emits the child `close` event, leaving the answered tool hung after delivery. Close FD 3 immediately after emitting the marker and before invoking fm-send, and cover a long-lived descendant retaining inherited descriptors.

🔧 Fix: Close owner marker descriptor before delivery
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `./bin/fm-test-run.sh tests/fm-ask-user-question.test.sh`
- `./bin/fm-test-run.sh tests/fm-send-resolve-key.test.sh`
- `Executed the tracked Pi extension through a fixture TUI, rendered wide and resized dialogs, entered multi-select plus Other, cancelled a second dialog, and verified exactly one owner delivery.`
- `Parsed the generated HTML and JSON evidence and verified the worktree remained clean with no transient build directories.`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
