### PR TITLE
fix(afk): route claude+herdr away-mode launch through the terminal-backed path

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -24,17 +24,21 @@ batched digest rather than per-wake injections.
    The flag survives a firstmate restart, so recovery re-enters afk when it is present.
 
 2. **Ensure the sub-supervisor daemon is running as a tracked background process.**
-   Its hosting differs by harness.
+   Its hosting differs by harness AND backend.
    Pick the right path:
-   - **Harness WITH a native in-pane tracked-background tool** (e.g. claude's
-     background bash, grok's background tool): first run
+   - **Claude on the herdr backend: always use the terminal-backed path below, never `start-native`.**
+     A Claude Code background shell hosting the daemon in the captain's own pane leaves a `· 1 shell ·` token in that pane's rendered footer for as long as the daemon lives.
+     Herdr's own claude agent-detection ruleset maps that exact token to `agent_status = "working"` at a priority that beats the idle rule, so the away-mode busy guard reads the captain's pane as permanently busy and can never deliver an escalation into it for the life of the session - proven in `data/firstmate-afk-daemon-wedged-investigation/report.md` (2026-08-26), which found this in every claude+herdr away run since 2026-08-19.
+     Do not "fix" this by teaching the busy guard to subtract the daemon's own footer contribution; that couples firstmate to a private, versioned herdr ruleset that already changes without notice.
+   - **Harness WITH a native in-pane tracked-background tool, on any OTHER combination** (e.g. claude's
+     background bash on tmux, grok's background tool): first run
      `bin/fm-afk-launch.sh start-native`, then run
      `FM_AFK_STATE_PREPARED=1 bin/fm-afk-start.sh` through that native tool.
      This is a deliberate no-separate-terminal exception because the harness-hosted job creates no terminal or layout mutation, and a shell launcher cannot invoke a harness-native background tool.
      The launcher still owns lifecycle state and records the no-terminal mode, while the daemon inherits and auto-discovers the captain pane.
      If the native launch fails, run `bin/fm-afk-launch.sh stop` to roll back the prepared lifecycle.
      Do not wrap it in `nohup ... &` (Codex/herdr can reap fire-and-forget shell children after a tool call returns).
-   - **Harness WITHOUT one** (e.g. pi): run `bin/fm-afk-launch.sh start`. It is
+   - **Harness WITHOUT a native in-pane tool (e.g. pi), and claude on herdr per above**: run `bin/fm-afk-launch.sh start`. It is
      the single owner of the daemon terminal: it creates a NON-VISIBLE tracked
      terminal for the current backend (a herdr dedicated `--no-focus` workspace,
      a detached tmux session), records its exact id, and passes the captain pane

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -6,9 +6,15 @@
 # Why this exists (docs/herdr-backend.md "Away-mode daemon terminal launch"):
 # bin/fm-afk-start.sh execs the supervise daemon in the FOREGROUND of whatever
 # terminal it is already in. Harnesses with a native in-pane tracked-background
-# tool (claude, grok) run it there directly and it is fine. A harness with NO
-# native background mechanism (pi) has to manufacture a terminal, and doing that
-# by SPLITTING the captain's active pane visibly shrinks it - the regression this
+# tool (claude, grok) run it there directly on most backends and it is fine.
+# claude on the herdr backend is the proven exception, NOT fine: the in-pane
+# background job leaves a footer token that herdr's own claude agent-detection
+# ruleset misreads as "working" for the life of the session, so the away-mode
+# busy guard can never read that pane idle and the daemon can never deliver an
+# escalation into it (data/firstmate-afk-daemon-wedged-investigation/report.md,
+# 2026-08-26). A harness with NO native background mechanism (pi), and claude
+# on herdr per that exception, has to manufacture a terminal, and doing that by
+# SPLITTING the captain's active pane visibly shrinks it - the regression this
 # script fixes. Instead this creates a non-visible tracked terminal (a herdr tab/
 # workspace with --no-focus, or a detached tmux session) that never touches the
 # captain's active tab, and NEVER uses shell `&` (which herdr/codex can reap).

--- a/bin/fm-afk-start.sh
+++ b/bin/fm-afk-start.sh
@@ -20,13 +20,19 @@
 # This is the COMMON daemon entry for every backend. HOW it becomes a tracked
 # background process differs by harness/backend and is owned elsewhere:
 #   - Harnesses with a native in-pane tracked-background tool (e.g. claude, grok)
-#     run this directly via that tool, so the daemon inherits the captain pane's
-#     env and auto-discovers it.
-#   - Harnesses with NO native background mechanism (e.g. pi) run this THROUGH
-#     bin/fm-afk-launch.sh, which creates a non-visible tracked terminal per
-#     backend (herdr tab/workspace, tmux detached session) and passes the
-#     captain pane in as FM_SUPERVISOR_TARGET so injection targets it, not the
-#     daemon's own new pane.
+#     run this directly via that tool on most backends, so the daemon inherits
+#     the captain pane's env and auto-discovers it. EXCEPTION: claude on the
+#     herdr backend must NOT use this path - the in-pane background job leaves
+#     a footer token that herdr's own claude agent-detection ruleset misreads as
+#     "working" for the life of the session, structurally wedging the away-mode
+#     busy guard (data/firstmate-afk-daemon-wedged-investigation/report.md,
+#     2026-08-26; see .agents/skills/afk/SKILL.md for the routing rule).
+#   - Harnesses with NO native background mechanism (e.g. pi), and claude on
+#     herdr per the exception above, run this THROUGH bin/fm-afk-launch.sh,
+#     which creates a non-visible tracked terminal per backend (herdr tab/
+#     workspace, tmux detached session) and passes the captain pane in as
+#     FM_SUPERVISOR_TARGET so injection targets it, not the daemon's own new
+#     pane.
 # Do not wrap this in `nohup ... &`: Codex/herdr can reap fire-and-forget shell
 # children after the tool call returns, while a tracked background terminal stays
 # attached and has a real lifecycle.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -291,8 +291,10 @@ It refuses Zellij, Orca, and cmux as supervisor backends rather than applying th
 For Herdr, target existence, native state, capture, composer state, and verified submit all route through the shared backend dispatcher and the explicit named-session CLI owner.
 The pane-independent max-defer alert is configured in [`wedge-alarm.md`](wedge-alarm.md).
 
-Harnesses with native tracked background execution can run the daemon in their terminal.
-Pi has no such mechanism.
+Harnesses with native tracked background execution can run the daemon in their terminal, with one proven exception: Claude must not host the away daemon this way on Herdr.
+Claude renders a live background shell in its own pane footer, and Herdr's Claude agent-detection ruleset reads that footer token as the agent working, at a priority that beats its idle rule.
+The busy guard trusts that native state first, so it reads the daemon's own presence as the captain pane being busy and can never deliver an escalation into it for the life of the session (`data/firstmate-afk-daemon-wedged-investigation/report.md`, 2026-08-26).
+Pi has no native background mechanism at all, and Claude on Herdr is routed the same way for the reason above.
 `bin/fm-afk-launch.sh` therefore creates a dedicated unfocused Herdr workspace, runs the daemon there with an explicit supervisor target and backend, records the exact daemon pane, and closes only that pane on stop.
 It never splits the captain's active tab and never uses shell `&`.
 Recovery reconciles only the recorded exact id.


### PR DESCRIPTION
## What happened

Away mode delivered nothing for 95 minutes. One run logged 408 deferrals, every one carrying the identical reason `supervisor pane busy (agent mid-turn)`. The composer guard - the accurate one - was never reached.

## The mechanism

`bin/fm-afk-launch.sh start-native` runs the sub-supervisor daemon as a Claude Code background shell inside the captain's own pane. That leaves a `· 1 shell ·` token in the pane's rendered footer for as long as the daemon lives. Herdr's own claude agent-detection ruleset maps that exact footer token to `agent_status = "working"` at priority 965, which outranks the idle rule `live_prompt_box` at priority 950. The away-mode busy guard trusts herdr's native agent state first, so it reads the daemon's own presence as the pane being busy and defers - every time.

This is structurally self-wedging: for the life of the away session, that pane can never read idle, so the escalation can never be delivered. The same signature appears in every away run launched this way since 2026-08-19. A production A/B across seven prior runs confirms it: every `HERDR_ENV`-launched run (daemon in-pane) wedged repeatedly, while the one run launched through the terminal-backed `FM_SUPERVISOR_TARGET` path ran 2h22m with a single deferral and zero wedges.

Full diagnosis: `data/firstmate-afk-daemon-wedged-investigation/report.md` (private task evidence, not part of this diff).

## The fix

Route claude on the herdr backend through `bin/fm-afk-launch.sh start` (the existing non-visible tracked-terminal path, with the captain pane captured first and passed in as `FM_SUPERVISOR_TARGET`) instead of `start-native`. This is the same path already proven clean in the one successful control run above. Corrected the "the in-pane background job is harmless" belief recorded in three places: `bin/fm-afk-start.sh`, `bin/fm-afk-launch.sh` (header), and `.agents/skills/afk/SKILL.md`. Other harness/backend combinations are unaffected - only herdr's native `agent_status` path is implicated; tmux's rendered busy-fallback regex does not match the background-shell footer token, and grok on herdr is unproven either way, so both are left on the native path.

## What this deliberately does NOT do

Does not teach the busy guard to subtract the daemon's own footer contribution from what it reads. That would couple firstmate to a private, versioned herdr ruleset (`claude.toml`, carrying its own `updated_at`) that already changes without notice - the ruleset is not a stable contract to build safety logic against.

## What this does NOT fix

This cures the CAUSE (why the guard misread the pane), not the general problem (that a guard false-positive of any kind currently wedges silently for the life of a session). Bounding *any* future guard false-positive - by making the max-defer escape try a genuinely different path in rather than retrying the same failing guard - is a separate, sibling change (`firstmate-afk-escape-and-delivery-logging`) still in flight. Away mode is not yet safe against every possible guard false-positive after this PR; it is safe against this specific proven one.

## Note on delivery route

This PR comes from a fork (`NicholasACTran/firstmate`) rather than a branch pushed directly to this repository, because the authenticated account used for this task has no push access to the upstream repository. Every other `fm/` branch here is pushed directly; this one differs only for that credential reason.

## Status

Do not merge. Holding to land together with its sibling ticket.
