### PR TITLE
fix(spawn): fail closed when task metadata cannot be written

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2701,7 +2701,12 @@ preserve_relaunch_meta() {
   if [ "$SPAWN_CONTROL_PARENT" = 1 ] && [ -n "${FM_CONTROL_RELAUNCH_TX:-}" ]; then
     echo "control_relaunch_tx=$FM_CONTROL_RELAUNCH_TX"
   fi
-} > "$SPAWN_META_PATH"
+} > "$SPAWN_META_PATH" || {
+  # Bash 3.2 does not abort on a failed grouped redirect even with set -e, so a
+  # directory or other unwritable metadata path would otherwise launch anyway.
+  echo "error: could not write task metadata for $ID" >&2
+  exit 1
+}
 if [ "$RELAUNCH" -eq 1 ]; then
   SPAWN_META_PUBLISH_STARTED=1
   mv -f "$SPAWN_META_TMP" "$STATE/$ID.meta"

--- a/tests/fm-backend-orca.test.sh
+++ b/tests/fm-backend-orca.test.sh
@@ -705,6 +705,7 @@ test_spawn_releases_orca_resources_when_metadata_write_fails() {
   status=$?
   [ "$status" -ne 0 ] || fail "Orca spawn should fail when metadata cannot be written"
   assert_contains "$out" "Is a directory" "spawn should fail at metadata publication"
+  assert_not_contains "$out" "spawned $id" "metadata-write refusal should not launch the harness"
   assert_contains "$(cat "$LOG")" $'orca\x1f''terminal'$'\x1f''close'$'\x1f''--terminal'$'\x1f''term-meta-fail'$'\x1f''--json' \
     "Orca spawn should close the recorded terminal when a later abort occurs"
   assert_contains "$(cat "$LOG")" $'orca\x1f''worktree'$'\x1f''rm'$'\x1f''--worktree'$'\x1f''id:wt-meta-fail'$'\x1f''--force'$'\x1f''--json' \


### PR DESCRIPTION
## Summary

Orca spawn on Bash 3.2 continued after a failed metadata write, launched the harness, and skipped abort cleanup.

The grouped redirect `{ ... } > "$SPAWN_META_PATH"` returns non-zero when the path is a directory, but Bash 3.2 does not honor `set -e` for that form. Spawn then cleared `ORCA_ABORT_CLEANUP` and reported success.

This makes that write fail closed so spawn exits before launch and the existing abort trap can release the terminal and worktree.

## Reproduction

On `9a01dea` (current `origin/main`), `tests/fm-backend-orca.test.sh` failed at "Orca spawn should fail when metadata cannot be written." Repeatable 3/3.

- Expected: non-zero spawn, no harness launch, terminal close + worktree rm.
- Observed: `Is a directory` printed, then `spawned ...`, exit 0, no cleanup.
- Trigger: metadata publication to an unwritable path.
- Mask: Bash 3.2 grouped-redirect `set -e` hole.
- Proven path: a writable metadata file still launches and records Orca metadata.
- Counterfactual: `} > path || exit 1` restores refusal and cleanup.

## Validation

- `bin/fm-test-run.sh --family orca` pass
- `bin/fm-lint.sh` pass
- `bin/fm-test-run.sh --check-coverage` pass
- `bin/fm-test-run.sh --all` still has unrelated host failures that also fail on unmodified `9a01dea` (composer-lib, gotmp, kimi, muse, teardown herdr-preflight, fixture-cleanup). This PR does not change those.

## Test plan

- [x] Isolated Orca metadata-write abort now fails closed and cleans up
- [x] Successful Orca spawn still writes metadata and launches
