### PR TITLE
test(bin): isolate directly invoked suites from the ambient fleet environment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,7 @@ tmp=$(mktemp -d) && printf 'done: smoke\n' > "$tmp/smoke.status" && FM_STATE_OVE
 `bin/fm-test-run.sh` is the single owner of behavior-suite selection, portable CI lane composition, optional local `--jobs` for the proven-isolated set only, per-script timing markers, family totals, the coverage guard, and the optional JSON timing artifact.
 Its header and `--help` own the flags, family labels, lanes, and changed-file map; this section only documents the entry points.
 `bin/fm-test-isolation-proof.sh` remains the single owner of the Phase 2 concurrent isolation proof and the exact proven candidate set; see `docs/fm-test-isolation-proof.md`.
+Both runners clear the ambient fleet environment once per run through `bin/fm-test-env-lib.sh`, the single owner of that pointer list, so no run path can hand a test the live firstmate home and no test has to clear the pointers itself; a runner that cannot clear them refuses to run.
 Portable shard balance evidence lives in `docs/fm-test-portable-shards.md`.
 Local no-mistakes Test stays intent-targeted and must not wire `commands.test` to `--all` or a `tests/*.test.sh` walk.
 Family selection is the ordinary local path; `--all` is deliberate full regression only.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ tmp=$(mktemp -d) && printf 'done: smoke\n' > "$tmp/smoke.status" && FM_STATE_OVE
 `bin/fm-test-run.sh` is the single owner of behavior-suite selection, portable CI lane composition, optional local `--jobs` for the proven-isolated set only, per-script timing markers, family totals, the coverage guard, and the optional JSON timing artifact.
 Its header and `--help` own the flags, family labels, lanes, and changed-file map; this section only documents the entry points.
 `bin/fm-test-isolation-proof.sh` remains the single owner of the Phase 2 concurrent isolation proof and the exact proven candidate set; see `docs/fm-test-isolation-proof.md`.
-Both runners clear the ambient fleet environment once per run through `bin/fm-test-env-lib.sh`, the single owner of that pointer list, and `tests/lib.sh` calls the same owner so a suite invoked directly with `bash tests/<file>.test.sh` is isolated too; no run path can hand a test the live firstmate home, no test has to clear the pointers itself, and a caller that cannot clear them refuses to run.
+Both runners clear the ambient fleet environment once per run through `bin/fm-test-env-lib.sh`, the single owner of that pointer list, and `tests/lib.sh` calls the same owner, so a suite that sources `tests/lib.sh` is also isolated when you invoke it directly with `bash tests/<file>.test.sh`; a suite covered by that owner does not clear the pointers itself, and a caller that cannot clear them refuses to run.
 Portable shard balance evidence lives in `docs/fm-test-portable-shards.md`.
 Local no-mistakes Test stays intent-targeted and must not wire `commands.test` to `--all` or a `tests/*.test.sh` walk.
 Family selection is the ordinary local path; `--all` is deliberate full regression only.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ tmp=$(mktemp -d) && printf 'done: smoke\n' > "$tmp/smoke.status" && FM_STATE_OVE
 `bin/fm-test-run.sh` is the single owner of behavior-suite selection, portable CI lane composition, optional local `--jobs` for the proven-isolated set only, per-script timing markers, family totals, the coverage guard, and the optional JSON timing artifact.
 Its header and `--help` own the flags, family labels, lanes, and changed-file map; this section only documents the entry points.
 `bin/fm-test-isolation-proof.sh` remains the single owner of the Phase 2 concurrent isolation proof and the exact proven candidate set; see `docs/fm-test-isolation-proof.md`.
-Both runners clear the ambient fleet environment once per run through `bin/fm-test-env-lib.sh`, the single owner of that pointer list, so no run path can hand a test the live firstmate home and no test has to clear the pointers itself; a runner that cannot clear them refuses to run.
+Both runners clear the ambient fleet environment once per run through `bin/fm-test-env-lib.sh`, the single owner of that pointer list, and `tests/lib.sh` calls the same owner so a suite invoked directly with `bash tests/<file>.test.sh` is isolated too; no run path can hand a test the live firstmate home, no test has to clear the pointers itself, and a caller that cannot clear them refuses to run.
 Portable shard balance evidence lives in `docs/fm-test-portable-shards.md`.
 Local no-mistakes Test stays intent-targeted and must not wire `commands.test` to `--all` or a `tests/*.test.sh` walk.
 Family selection is the ordinary local path; `--all` is deliberate full regression only.

--- a/bin/fm-test-env-lib.sh
+++ b/bin/fm-test-env-lib.sh
@@ -11,21 +11,22 @@
 # fm_test_env_isolate clears those pointers in the CALLING process. A runner
 # calls it once, before it starts any test script, so every child inherits the
 # cleared environment whichever path the run takes: serial, a --jobs worker, or
-# an isolation-proof worker. Isolation therefore cannot depend on a flag, and no
-# runner keeps its own copy of the list - two copies drift apart the moment one
-# of them is edited.
+# an isolation-proof worker. tests/lib.sh calls it too, for its own process, so
+# a suite invoked directly rather than through a runner is isolated as well.
+# Isolation therefore cannot depend on a flag, and no caller keeps its own copy
+# of the list - two copies drift apart the moment one of them is edited.
 #
 # Usage (source, then call once, early):
 #   . "$ROOT/bin/fm-test-env-lib.sh"
 #   fm_test_env_isolate || exit 2
 #
-# It returns non-zero if any pointer survives, so a runner that cannot isolate
+# It returns non-zero if any pointer survives, so a caller that cannot isolate
 # refuses instead of running the suite against the live home.
 
 # Every environment variable a live Firstmate session puts into a worker's
 # environment and a Firstmate script then consults: the home and its durable
 # records, plus the runtime control variables a session start creates. Extend
-# this list, not a runner, whenever Firstmate starts exporting another one.
+# this list, not a caller, whenever Firstmate starts exporting another one.
 #
 # The second class is every runtime control variable a live session exports to
 # tell a child what it already is or already decided, because a Firstmate script

--- a/bin/fm-test-env-lib.sh
+++ b/bin/fm-test-env-lib.sh
@@ -22,8 +22,16 @@
 # It returns non-zero if any pointer survives, so a runner that cannot isolate
 # refuses instead of running the suite against the live home.
 
-# Every environment variable a Firstmate script consults to locate a home or its
-# durable records. Extend this list, not a runner.
+# Every environment variable a live Firstmate session puts into a worker's
+# environment and a Firstmate script then consults: the home and its durable
+# records, plus the runtime control variables a session start creates. Extend
+# this list, not a runner, whenever Firstmate starts exporting another one.
+#
+# FM_SESSION_START_STAGE_FILE is in the second class and matters as much as the
+# home pointers: bin/fm-session-start.sh treats its presence as "I am already
+# the bounded child" and skips its own runtime bound, so a leaked one removes
+# the bound a test is asserting and the suite hangs on the fixture instead of
+# failing.
 FM_TEST_ENV_FLEET_POINTERS="\
 FM_HOME \
 FM_ROOT \
@@ -36,7 +44,8 @@ FM_PENDING_REPLY_DIR_OVERRIDE \
 FM_PUBLIC_FOLLOWUP_PRIMARY_HOME \
 FM_WAKE_QUEUE \
 FM_WAKE_QUEUE_LOCK \
-FM_BACKEND"
+FM_BACKEND \
+FM_SESSION_START_STAGE_FILE"
 
 fm_test_env_isolate() {
   local name rc=0

--- a/bin/fm-test-env-lib.sh
+++ b/bin/fm-test-env-lib.sh
@@ -27,11 +27,23 @@
 # records, plus the runtime control variables a session start creates. Extend
 # this list, not a runner, whenever Firstmate starts exporting another one.
 #
-# FM_SESSION_START_STAGE_FILE is in the second class and matters as much as the
-# home pointers: bin/fm-session-start.sh treats its presence as "I am already
-# the bounded child" and skips its own runtime bound, so a leaked one removes
-# the bound a test is asserting and the suite hangs on the fixture instead of
-# failing.
+# The second class is every runtime control variable a live session exports to
+# tell a child what it already is or already decided, because a Firstmate script
+# then honors it ahead of its own detection - so a leaked one silently replaces
+# the very thing a test asserts:
+#   FM_SESSION_START_STAGE_FILE  bin/fm-session-start.sh treats its presence as
+#     "I am already the bounded child" and skips its own runtime bound, so a
+#     leaked one removes the bound a test is asserting and the suite hangs on
+#     the fixture instead of failing.
+#   FM_SUPERVISION_MODEL  bin/fm-wake-lib.sh returns it verbatim instead of
+#     detecting the harness, so a leaked autoarm from a secondmate worker makes
+#     the watcher verdict short-circuit and a supervision-health assertion pass
+#     without ever checking watcher health.
+#   FM_TRACE_CONTEXT  bin/fm-trace-context-lib.sh lets a non-empty value beat
+#     config/trace-context, so a leaked one decides the capability a test set
+#     that file to control.
+# bin/fm-spawn.sh exports both of the latter on the same secondmate launch line
+# that carries FM_HOME and FM_PUBLIC_FOLLOWUP_PRIMARY_HOME.
 FM_TEST_ENV_FLEET_POINTERS="\
 FM_HOME \
 FM_ROOT \
@@ -45,7 +57,9 @@ FM_PUBLIC_FOLLOWUP_PRIMARY_HOME \
 FM_WAKE_QUEUE \
 FM_WAKE_QUEUE_LOCK \
 FM_BACKEND \
-FM_SESSION_START_STAGE_FILE"
+FM_SESSION_START_STAGE_FILE \
+FM_SUPERVISION_MODEL \
+FM_TRACE_CONTEXT"
 
 fm_test_env_isolate() {
   local name rc=0

--- a/bin/fm-test-env-lib.sh
+++ b/bin/fm-test-env-lib.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# fm-test-env-lib.sh - single owner of the ambient fleet environment that
+# Firstmate's behavior-test processes must not inherit.
+#
+# Firstmate launches a worker with the live home exported (bin/fm-spawn.sh sets
+# FM_HOME=<home> in the launch command), so a suite started from inside a worker
+# carries pointers at the real fleet home. Any test that resolves a home the
+# ordinary way - bin/fm-wake-lib.sh and friends read these variables - would then
+# read and write the live locks, wake queue, and task records.
+#
+# fm_test_env_isolate clears those pointers in the CALLING process. A runner
+# calls it once, before it starts any test script, so every child inherits the
+# cleared environment whichever path the run takes: serial, a --jobs worker, or
+# an isolation-proof worker. Isolation therefore cannot depend on a flag, and no
+# runner keeps its own copy of the list - two copies drift apart the moment one
+# of them is edited.
+#
+# Usage (source, then call once, early):
+#   . "$ROOT/bin/fm-test-env-lib.sh"
+#   fm_test_env_isolate || exit 2
+#
+# It returns non-zero if any pointer survives, so a runner that cannot isolate
+# refuses instead of running the suite against the live home.
+
+# Every environment variable a Firstmate script consults to locate a home or its
+# durable records. Extend this list, not a runner.
+FM_TEST_ENV_FLEET_POINTERS="\
+FM_HOME \
+FM_ROOT \
+FM_ROOT_OVERRIDE \
+FM_STATE_OVERRIDE \
+FM_DATA_OVERRIDE \
+FM_PROJECTS_OVERRIDE \
+FM_CONFIG_OVERRIDE \
+FM_PENDING_REPLY_DIR_OVERRIDE \
+FM_PUBLIC_FOLLOWUP_PRIMARY_HOME \
+FM_WAKE_QUEUE \
+FM_WAKE_QUEUE_LOCK \
+FM_BACKEND"
+
+fm_test_env_isolate() {
+  local name rc=0
+  for name in $FM_TEST_ENV_FLEET_POINTERS; do
+    unset "$name" 2>/dev/null || true
+  done
+  for name in $FM_TEST_ENV_FLEET_POINTERS; do
+    if [ -n "${!name:-}" ]; then
+      printf 'fm-test-env: could not clear %s from the environment\n' "$name" >&2
+      rc=1
+    fi
+  done
+  return "$rc"
+}

--- a/bin/fm-test-isolation-proof.sh
+++ b/bin/fm-test-isolation-proof.sh
@@ -29,7 +29,8 @@
 # Isolation contract for each concurrent worker:
 #   - distinct mode-0700 temporary root under a proof-owned parent
 #   - TMPDIR/TMP point only at that root so mktemp/fm_test_tmproot stay private
-#   - ambient FM_HOME / FM_*_OVERRIDE cleared so no shared home is reused
+#   - the ambient fleet environment cleared once for this process, so no worker
+#     can reach a live home (bin/fm-test-env-lib.sh owns that pointer list)
 #   - no global git config mutation (snapshot before/after)
 #   - no production sharding and no retry-until-green
 #
@@ -47,6 +48,16 @@ set -eu
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT" || exit 1
+
+# Clear the ambient fleet environment once here, so every candidate worker
+# inherits it and no candidate can share a live home.
+# bin/fm-test-env-lib.sh owns the pointer list.
+# shellcheck source=bin/fm-test-env-lib.sh
+. "$ROOT/bin/fm-test-env-lib.sh"
+fm_test_env_isolate || {
+  printf 'fm-isolation-proof: refusing to run: the live fleet home is still reachable\n' >&2
+  exit 2
+}
 
 JOBS=4
 JSON_PATH=
@@ -424,9 +435,6 @@ for script in "${CANDIDATES[@]}"; do
     set +e
     export TMPDIR="$work/tmp"
     export TMP="$work/tmp"
-    # Clear ambient fleet overrides so candidates cannot share a live home.
-    unset FM_HOME FM_STATE_OVERRIDE FM_DATA_OVERRIDE FM_ROOT_OVERRIDE \
-      FM_PROJECTS_OVERRIDE FM_CONFIG_OVERRIDE FM_BACKEND 2>/dev/null || true
     cd "$ROOT" || exit 1
     begin_ms=$(now_ms)
     bash "$script" >"$work/out/stdout" 2>"$work/out/stderr"

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -925,7 +925,17 @@ families_for_changed_path() {
       # resolution in the caller; emit a marker family of __script__
       printf '%s\n' "__script__:$(basename "$path")"
       ;;
-    bin/fm-test-run.sh|bin/fm-test-isolation-proof.sh|bin/fm-test-env-lib.sh)
+    bin/fm-test-env-lib.sh)
+      # tests/lib.sh is a caller too, so this file's pointer list shapes the
+      # environment of every suite that sources the shared library, not just
+      # the runner's own contract tests. Select through the same reference scan
+      # tests/lib.sh gets, so a pointer edit here selects the suites it can
+      # break rather than only pure-contract-unit.
+      printf '%s\n' pure-contract-unit
+      families_for_test_reference lib.sh \
+        || printf '%s\n' "__unmapped__:$path"
+      ;;
+    bin/fm-test-run.sh|bin/fm-test-isolation-proof.sh)
       printf '%s\n' pure-contract-unit
       ;;
     bin/backends/herdr*|bin/fm-herdr-lab.sh|tests/herdr-test-safety.sh)

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -895,15 +895,49 @@ select_family() {
   [ "$found" -eq 1 ] || die "no tests mapped to family '$want'"
 }
 
+# Every name a suite could spell to reach $1: the needle itself, plus each
+# shared tests/ helper that SOURCES a name already in the set, to a fixed
+# point. tests/fm-watch-arm.test.sh sources tests/wake-helpers.sh and never
+# spells "lib.sh", so a lib.sh edit reaches it only through this expansion.
+#
+# The edge is a source line, not any mention: a mention carries no direction,
+# and tests/lib.sh names its own consumers in comments, so treating those as
+# edges would walk backwards from any helper to the library.
+expand_test_reference_needles() {
+  local needles=$1 h base n n_re added=1
+  while [ "$added" -eq 1 ]; do
+    added=0
+    for h in tests/*.sh; do
+      case "$h" in *.test.sh) continue ;; esac
+      [ -f "$h" ] || continue
+      base=$(basename "$h")
+      case " $needles " in *" $base "*) continue ;; esac
+      for n in $needles; do
+        n_re=${n//./\\.}
+        if grep -Eq "^[[:space:]]*(\.|source)[[:space:]].*${n_re}" "$h"; then
+          needles="$needles $base"
+          added=1
+          break
+        fi
+      done
+    done
+  done
+  printf '%s\n' "$needles"
+}
+
 families_for_test_reference() {
-  local needle=$1 s
+  local needle=$1 s n needles
   local found=0
+  needles=$(expand_test_reference_needles "$needle")
   while IFS= read -r s; do
     [ -n "$s" ] || continue
-    if grep -Fq "$needle" "$s"; then
-      family_for_basename "$(basename "$s")"
-      found=1
-    fi
+    for n in $needles; do
+      if grep -Fq "$n" "$s"; then
+        family_for_basename "$(basename "$s")"
+        found=1
+        break
+      fi
+    done
   done < <(all_repo_tests)
   [ "$found" -eq 1 ]
 }
@@ -930,9 +964,9 @@ families_for_changed_path() {
       # environment of every suite that sources the shared library, not just
       # the runner's own contract tests. Select through the same reference scan
       # tests/lib.sh gets, so a pointer edit here selects the suites it can
-      # break rather than only pure-contract-unit. Selection expands each
-      # emitted family to all of its suites, so reasoning about which suites a
-      # needle matches, rather than which families, gives the wrong answer.
+      # break rather than only pure-contract-unit. That scan follows shared
+      # tests/ helpers, so suites that reach the library only through one are
+      # selected too rather than left to a sibling's family pulling them in.
       printf '%s\n' pure-contract-unit
       families_for_test_reference lib.sh \
         || printf '%s\n' "__unmapped__:$path"

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -895,15 +895,66 @@ select_family() {
   [ "$found" -eq 1 ] || die "no tests mapped to family '$want'"
 }
 
+# Shared, non-suite scripts under tests/. A suite reaches tests/lib.sh either
+# directly or through one of these, so a reference scan that reads only the
+# suites misses every indirect consumer.
+tests_helper_scripts() {
+  local f
+  for f in tests/*.sh; do
+    case "$f" in
+      *.test.sh) continue ;;
+    esac
+    [ -f "$f" ] || continue
+    printf '%s\n' "$f"
+  done | LC_ALL=C sort
+}
+
+# Grow a reference needle into every name a suite could spell to reach it: the
+# needle itself, plus each shared helper that SOURCES one of the names already
+# in the set, to a fixed point. tests/fm-watch-arm.test.sh sources
+# tests/wake-helpers.sh and never spells "lib.sh", so a lib.sh edit reaches it
+# only through this expansion.
+#
+# The edge is a source line rather than any mention, because a mention carries
+# no direction: tests/lib.sh names wake-helpers.sh in a comment about its own
+# consumers, and treating that as an edge would walk backwards from any helper
+# to the library and select the complete suite for every helper edit.
+expand_test_reference_needles() {
+  local needles=$1 h base n n_re added=1
+  while [ "$added" -eq 1 ]; do
+    added=0
+    while IFS= read -r h; do
+      [ -n "$h" ] || continue
+      base=$(basename "$h")
+      case " $needles " in
+        *" $base "*) continue ;;
+      esac
+      for n in $needles; do
+        n_re=${n//./\\.}
+        if grep -Eq "^[[:space:]]*(\.|source)[[:space:]].*${n_re}" "$h"; then
+          needles="$needles $base"
+          added=1
+          break
+        fi
+      done
+    done < <(tests_helper_scripts)
+  done
+  printf '%s\n' "$needles"
+}
+
 families_for_test_reference() {
-  local needle=$1 s
+  local needle=$1 s n needles
   local found=0
+  needles=$(expand_test_reference_needles "$needle")
   while IFS= read -r s; do
     [ -n "$s" ] || continue
-    if grep -Fq "$needle" "$s"; then
-      family_for_basename "$(basename "$s")"
-      found=1
-    fi
+    for n in $needles; do
+      if grep -Fq "$n" "$s"; then
+        family_for_basename "$(basename "$s")"
+        found=1
+        break
+      fi
+    done
   done < <(all_repo_tests)
   [ "$found" -eq 1 ]
 }

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -68,10 +68,25 @@
 # configured shard count is refused, so a CI matrix cannot silently drop a shard.
 # --changed is conservative: it over-selects related families rather than
 # under-selecting, and never expands to the complete suite unless --all.
+#
+# Every run, by every path, clears the ambient fleet environment before it starts
+# a script, so a suite started from inside a worker cannot reach the live home.
+# bin/fm-test-env-lib.sh owns that contract.
 set -eu
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT" || exit 1
+
+# Clear the ambient fleet environment once, in this process, before anything can
+# start a test script. Every selected script - serial or --jobs worker - is a
+# child of this process, so no run path can hand a test the live home and no
+# caller has to remember a flag. bin/fm-test-env-lib.sh owns the pointer list.
+# shellcheck source=bin/fm-test-env-lib.sh
+. "$ROOT/bin/fm-test-env-lib.sh"
+fm_test_env_isolate || {
+  printf 'fm-test-run: refusing to run: the live fleet home is still reachable\n' >&2
+  exit 2
+}
 
 MODE=
 LIST_ONLY=0
@@ -910,7 +925,7 @@ families_for_changed_path() {
       # resolution in the caller; emit a marker family of __script__
       printf '%s\n' "__script__:$(basename "$path")"
       ;;
-    bin/fm-test-run.sh|bin/fm-test-isolation-proof.sh)
+    bin/fm-test-run.sh|bin/fm-test-isolation-proof.sh|bin/fm-test-env-lib.sh)
       printf '%s\n' pure-contract-unit
       ;;
     bin/backends/herdr*|bin/fm-herdr-lab.sh|tests/herdr-test-safety.sh)
@@ -1630,8 +1645,10 @@ if [ "$JOBS" -eq 1 ]; then
   done
 else
   # Bounded concurrent execution for proven-isolated scripts only. Each worker
-  # gets a private mode-0700 TMPDIR so mktemp roots cannot collide. Retries are
-  # never used as a green strategy.
+  # gets a private mode-0700 TMPDIR so mktemp roots cannot collide - that is
+  # collision avoidance between concurrent workers; fleet-home isolation is
+  # already inherited from this process. Retries are never used as a green
+  # strategy.
   declare -a WORKER_PIDS=()
   declare -a WORKER_IDX=()
   declare -a WORKER_SCRIPTS=()
@@ -1713,8 +1730,6 @@ else
       set +e
       export TMPDIR="$work/tmp"
       export TMP="$work/tmp"
-      unset FM_HOME FM_STATE_OVERRIDE FM_DATA_OVERRIDE FM_ROOT_OVERRIDE \
-        FM_PROJECTS_OVERRIDE FM_CONFIG_OVERRIDE FM_BACKEND 2>/dev/null || true
       cd "$ROOT" || exit 1
       begin_ms=$(now_ms)
       bash "$script" >"$work/output" 2>&1

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -895,49 +895,15 @@ select_family() {
   [ "$found" -eq 1 ] || die "no tests mapped to family '$want'"
 }
 
-# Every name a suite could spell to reach $1: the needle itself, plus each
-# shared tests/ helper that SOURCES a name already in the set, to a fixed
-# point. tests/fm-watch-arm.test.sh sources tests/wake-helpers.sh and never
-# spells "lib.sh", so a lib.sh edit reaches it only through this expansion.
-#
-# The edge is a source line, not any mention: a mention carries no direction,
-# and tests/lib.sh names its own consumers in comments, so treating those as
-# edges would walk backwards from any helper to the library.
-expand_test_reference_needles() {
-  local needles=$1 h base n n_re added=1
-  while [ "$added" -eq 1 ]; do
-    added=0
-    for h in tests/*.sh; do
-      case "$h" in *.test.sh) continue ;; esac
-      [ -f "$h" ] || continue
-      base=$(basename "$h")
-      case " $needles " in *" $base "*) continue ;; esac
-      for n in $needles; do
-        n_re=${n//./\\.}
-        if grep -Eq "^[[:space:]]*(\.|source)[[:space:]].*${n_re}" "$h"; then
-          needles="$needles $base"
-          added=1
-          break
-        fi
-      done
-    done
-  done
-  printf '%s\n' "$needles"
-}
-
 families_for_test_reference() {
-  local needle=$1 s n needles
+  local needle=$1 s
   local found=0
-  needles=$(expand_test_reference_needles "$needle")
   while IFS= read -r s; do
     [ -n "$s" ] || continue
-    for n in $needles; do
-      if grep -Fq "$n" "$s"; then
-        family_for_basename "$(basename "$s")"
-        found=1
-        break
-      fi
-    done
+    if grep -Fq "$needle" "$s"; then
+      family_for_basename "$(basename "$s")"
+      found=1
+    fi
   done < <(all_repo_tests)
   [ "$found" -eq 1 ]
 }
@@ -964,9 +930,9 @@ families_for_changed_path() {
       # environment of every suite that sources the shared library, not just
       # the runner's own contract tests. Select through the same reference scan
       # tests/lib.sh gets, so a pointer edit here selects the suites it can
-      # break rather than only pure-contract-unit. That scan follows shared
-      # tests/ helpers, so suites that reach the library only through one are
-      # selected too rather than left to a sibling's family pulling them in.
+      # break rather than only pure-contract-unit. Selection expands each
+      # emitted family to all of its suites, so reasoning about which suites a
+      # needle matches, rather than which families, gives the wrong answer.
       printf '%s\n' pure-contract-unit
       families_for_test_reference lib.sh \
         || printf '%s\n' "__unmapped__:$path"

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -895,66 +895,15 @@ select_family() {
   [ "$found" -eq 1 ] || die "no tests mapped to family '$want'"
 }
 
-# Shared, non-suite scripts under tests/. A suite reaches tests/lib.sh either
-# directly or through one of these, so a reference scan that reads only the
-# suites misses every indirect consumer.
-tests_helper_scripts() {
-  local f
-  for f in tests/*.sh; do
-    case "$f" in
-      *.test.sh) continue ;;
-    esac
-    [ -f "$f" ] || continue
-    printf '%s\n' "$f"
-  done | LC_ALL=C sort
-}
-
-# Grow a reference needle into every name a suite could spell to reach it: the
-# needle itself, plus each shared helper that SOURCES one of the names already
-# in the set, to a fixed point. tests/fm-watch-arm.test.sh sources
-# tests/wake-helpers.sh and never spells "lib.sh", so a lib.sh edit reaches it
-# only through this expansion.
-#
-# The edge is a source line rather than any mention, because a mention carries
-# no direction: tests/lib.sh names wake-helpers.sh in a comment about its own
-# consumers, and treating that as an edge would walk backwards from any helper
-# to the library and select the complete suite for every helper edit.
-expand_test_reference_needles() {
-  local needles=$1 h base n n_re added=1
-  while [ "$added" -eq 1 ]; do
-    added=0
-    while IFS= read -r h; do
-      [ -n "$h" ] || continue
-      base=$(basename "$h")
-      case " $needles " in
-        *" $base "*) continue ;;
-      esac
-      for n in $needles; do
-        n_re=${n//./\\.}
-        if grep -Eq "^[[:space:]]*(\.|source)[[:space:]].*${n_re}" "$h"; then
-          needles="$needles $base"
-          added=1
-          break
-        fi
-      done
-    done < <(tests_helper_scripts)
-  done
-  printf '%s\n' "$needles"
-}
-
 families_for_test_reference() {
-  local needle=$1 s n needles
+  local needle=$1 s
   local found=0
-  needles=$(expand_test_reference_needles "$needle")
   while IFS= read -r s; do
     [ -n "$s" ] || continue
-    for n in $needles; do
-      if grep -Fq "$n" "$s"; then
-        family_for_basename "$(basename "$s")"
-        found=1
-        break
-      fi
-    done
+    if grep -Fq "$needle" "$s"; then
+      family_for_basename "$(basename "$s")"
+      found=1
+    fi
   done < <(all_repo_tests)
   [ "$found" -eq 1 ]
 }
@@ -981,7 +930,9 @@ families_for_changed_path() {
       # environment of every suite that sources the shared library, not just
       # the runner's own contract tests. Select through the same reference scan
       # tests/lib.sh gets, so a pointer edit here selects the suites it can
-      # break rather than only pure-contract-unit.
+      # break rather than only pure-contract-unit. Selection expands each
+      # emitted family to all of its suites, so reasoning about which suites a
+      # needle matches, rather than which families, gives the wrong answer.
       printf '%s\n' pure-contract-unit
       families_for_test_reference lib.sh \
         || printf '%s\n' "__unmapped__:$path"

--- a/docs/fm-test-isolation-proof.md
+++ b/docs/fm-test-isolation-proof.md
@@ -79,7 +79,8 @@ This record is the concurrent isolation proof for the portable parallel candidat
 ## Scope
 
 Each worker used a separate mode-`0700` temporary root and private `TMPDIR` and `TMP`.
-The harness cleared ambient `FM_HOME` and `FM_*_OVERRIDE` values for every worker and verified that global Git configuration was unchanged.
+The harness clears the ambient fleet environment once for the whole run, so every worker inherits an environment with no pointer at a live home (`bin/fm-test-env-lib.sh` owns that pointer list).
+The proof run also verified that global Git configuration was unchanged.
 A candidate failure fails the aggregate run and requires investigation rather than a retry.
 
 ## Re-run

--- a/docs/fm-test-isolation-proof.md
+++ b/docs/fm-test-isolation-proof.md
@@ -79,7 +79,6 @@ This record is the concurrent isolation proof for the portable parallel candidat
 ## Scope
 
 Each worker used a separate mode-`0700` temporary root and private `TMPDIR` and `TMP`.
-The harness clears the ambient fleet environment once for the whole run, so every worker inherits an environment with no pointer at a live home (`bin/fm-test-env-lib.sh` owns that pointer list).
 The proof run also verified that global Git configuration was unchanged.
 A candidate failure fails the aggregate run and requires investigation rather than a retry.
 

--- a/docs/fm-test-isolation-proof.md
+++ b/docs/fm-test-isolation-proof.md
@@ -79,7 +79,7 @@ This record is the concurrent isolation proof for the portable parallel candidat
 ## Scope
 
 Each worker used a separate mode-`0700` temporary root and private `TMPDIR` and `TMP`.
-The proof run also verified that global Git configuration was unchanged.
+The harness cleared ambient `FM_HOME` and `FM_*_OVERRIDE` values for every worker and verified that global Git configuration was unchanged.
 A candidate failure fails the aggregate run and requires investigation rather than a retry.
 
 ## Re-run

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -36,6 +36,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-herdr-ci-cleanup.sh` | Snapshot and tear down only job-owned `fm-lab-*` sessions in the Herdr CI lane       |
 | `fm-test-run.sh`         | Behavior-test runner: selection, portable lanes, proven-isolated `--jobs`, coverage guard, timing/JSON |
 | `fm-test-isolation-proof.sh` | Concurrent isolation proof and proven-isolated candidate set owner |
+| `fm-test-env-lib.sh`     | Single owner of the ambient fleet environment a behavior-test process must not inherit; both test runners clear it once per run |
 | `fm-ensure-agents-md.sh` | Ensure a project's real `AGENTS.md`, its `CLAUDE.md` `@AGENTS.md` pointer, and the canonical self-governance section |
 | `fm-guard.sh`            | Warn on primary-checkout tangles, pending queued wakes, and unhealthy supervision    |
 | `fm-primary-scope-lib.sh` | Shared marker-or-plain-checkout primary-home predicate for tracked hooks             |

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -36,7 +36,7 @@ The shared no-mistakes gate refusal for fleet lifecycle entrypoints is summarize
 | `fm-herdr-ci-cleanup.sh` | Snapshot and tear down only job-owned `fm-lab-*` sessions in the Herdr CI lane       |
 | `fm-test-run.sh`         | Behavior-test runner: selection, portable lanes, proven-isolated `--jobs`, coverage guard, timing/JSON |
 | `fm-test-isolation-proof.sh` | Concurrent isolation proof and proven-isolated candidate set owner |
-| `fm-test-env-lib.sh`     | Single owner of the ambient fleet environment a behavior-test process must not inherit; both test runners clear it once per run |
+| `fm-test-env-lib.sh`     | Single owner of the ambient fleet environment a behavior-test process must not inherit; both test runners and `tests/lib.sh` clear it once per process |
 | `fm-ensure-agents-md.sh` | Ensure a project's real `AGENTS.md`, its `CLAUDE.md` `@AGENTS.md` pointer, and the canonical self-governance section |
 | `fm-guard.sh`            | Warn on primary-checkout tangles, pending queued wakes, and unhealthy supervision    |
 | `fm-primary-scope-lib.sh` | Shared marker-or-plain-checkout primary-home predicate for tracked hooks             |

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -115,6 +115,15 @@ init_changed_fixture_repo() {
     chmod +x "$repo/tests/$script"
   done
   : >"$repo/tests/lib.sh"
+  # A suite that reaches tests/lib.sh only through a shared helper and never
+  # spells the library's own name - tests/fm-watch-arm.test.sh is the real one.
+  # It is deliberately the sole member of its family here, so a reference scan
+  # that reads only the suites cannot be rescued by family expansion pulling it
+  # in behind some sibling that does name the library.
+  printf '#!/usr/bin/env bash\n. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"\n' \
+    >"$repo/tests/wake-helpers.sh"
+  printf '#!/usr/bin/env bash\n# tests/wake-helpers.sh\n' \
+    >"$repo/tests/fm-backend-orca.test.sh"
   : >"$repo/tests/fm-backend-herdr-eventwait.test.py"
   : >"$repo/bin/fm-supervisor-target-lib.sh"
   : >"$repo/bin/unmapped-source.sh"
@@ -143,8 +152,20 @@ test_changed_dependency_selection_and_unmapped_failure() {
   assert_contains "$listed" "tests/fm-pr-merge.test.sh" "shared helper selects pr-forge dependents"
   assert_contains "$listed" "tests/fm-secondmate-safety.test.sh" "shared helper selects secondmate dependents"
   assert_contains "$listed" "tests/fm-bearings-snapshot.test.sh" "shared helper selects snapshot dependents"
+  assert_contains "$listed" "tests/fm-backend-orca.test.sh" \
+    "shared helper selects a suite that reaches it only through another helper"
   git -C "$repo" add tests/lib.sh
   git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm helper-change
+
+  # The env library shapes every suite that sources tests/lib.sh, so it must
+  # reach the indirect consumers through the same scan.
+  printf '\n' >>"$repo/bin/fm-test-env-lib.sh"
+  listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)
+  assert_contains "$listed" "tests/fm-pr-merge.test.sh" "env library selects direct lib.sh consumers"
+  assert_contains "$listed" "tests/fm-backend-orca.test.sh" \
+    "env library selects a suite that reaches lib.sh only through another helper"
+  git -C "$repo" add bin/fm-test-env-lib.sh
+  git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm env-lib-change
 
   printf '\n' >>"$repo/tests/fm-backend-herdr-eventwait.test.py"
   listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -731,6 +731,7 @@ set -u
 fm_wake_append check live-home-probe probe >/dev/null 2>&1 || true
 printf 'PROBE_HOME=%s\n' "$FM_HOME"
 printf 'PROBE_STATE=%s\n' "$STATE"
+printf 'PROBE_STAGE_FILE=%s\n' "${FM_SESSION_START_STAGE_FILE:-none}"
 echo "ok - probe"
 SH
   chmod +x "$repo/bin/fm-test-run.sh" "$repo/$probe"
@@ -746,6 +747,10 @@ SH
     export FM_STATE_OVERRIDE="$sentinel/state"
     export FM_DATA_OVERRIDE="$sentinel/data"
     export FM_ROOT="$sentinel"
+    # A live session start leaves this behind in a worker's environment, and
+    # bin/fm-session-start.sh reads its presence as "the runtime bound is
+    # already applied", so a test that inherits one loses the bound it asserts.
+    export FM_SESSION_START_STAGE_FILE="$sentinel/stage"
     bin/fm-test-run.sh "$probe"
   ) >"$tmp/out" 2>"$tmp/err"
   rc=$?
@@ -759,6 +764,8 @@ SH
     || fail "probe resolved a home outside its own repo: $(grep PROBE_ "$tmp/out")"
   grep -Fq "PROBE_STATE=$repo/state" "$tmp/out" \
     || fail "probe resolved a state directory outside its own repo: $(grep PROBE_ "$tmp/out")"
+  grep -Fq "PROBE_STAGE_FILE=none" "$tmp/out" \
+    || fail "a live session's control variable reached a test script: $(grep PROBE_STAGE "$tmp/out")"
 
   [ "$(cat "$sentinel/state/.wake-queue")" = "sentinel" ] \
     || fail "a test script wrote to the live home's durable queue"
@@ -781,11 +788,11 @@ test_env_isolation_helper_clears_every_pointer() {
     FM_PUBLIC_FOLLOWUP_PRIMARY_HOME=/live \
     FM_WAKE_QUEUE=/live/state/.wake-queue \
     FM_WAKE_QUEUE_LOCK=/live/state/.wake-queue.lock \
-    FM_BACKEND=tmux \
+    FM_BACKEND=tmux FM_SESSION_START_STAGE_FILE=/live/stage \
     bash -c '. "$1/bin/fm-test-env-lib.sh"; fm_test_env_isolate || exit 1; env' \
     _ "$ROOT"
   ) || fail "fm_test_env_isolate refused with a clearable environment"
-  survivors=$(printf '%s\n' "$out" | grep -E '^(FM_HOME|FM_ROOT|FM_ROOT_OVERRIDE|FM_STATE_OVERRIDE|FM_DATA_OVERRIDE|FM_PROJECTS_OVERRIDE|FM_CONFIG_OVERRIDE|FM_PENDING_REPLY_DIR_OVERRIDE|FM_PUBLIC_FOLLOWUP_PRIMARY_HOME|FM_WAKE_QUEUE|FM_WAKE_QUEUE_LOCK|FM_BACKEND)=' || true)
+  survivors=$(printf '%s\n' "$out" | grep -E '^(FM_HOME|FM_ROOT|FM_ROOT_OVERRIDE|FM_STATE_OVERRIDE|FM_DATA_OVERRIDE|FM_PROJECTS_OVERRIDE|FM_CONFIG_OVERRIDE|FM_PENDING_REPLY_DIR_OVERRIDE|FM_PUBLIC_FOLLOWUP_PRIMARY_HOME|FM_WAKE_QUEUE|FM_WAKE_QUEUE_LOCK|FM_BACKEND|FM_SESSION_START_STAGE_FILE)=' || true)
   [ -z "$survivors" ] || fail "fleet pointers survived isolation: $survivors"
   pass "the shared isolation helper clears every fleet pointer it owns"
 }

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -115,16 +115,6 @@ init_changed_fixture_repo() {
     chmod +x "$repo/tests/$script"
   done
   : >"$repo/tests/lib.sh"
-  # A suite that reaches tests/lib.sh only through a shared helper and never
-  # spells the library's own name - tests/fm-watch-arm.test.sh is the real one.
-  # It is deliberately the sole member of its family here, so a reference scan
-  # that reads only the suites cannot be rescued by family expansion pulling it
-  # in behind some sibling that does name the library.
-  # shellcheck disable=SC2016 # The fixture helper, not this test shell, expands the source path.
-  printf '#!/usr/bin/env bash\n. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"\n' \
-    >"$repo/tests/wake-helpers.sh"
-  printf '#!/usr/bin/env bash\n# tests/wake-helpers.sh\n' \
-    >"$repo/tests/fm-backend-orca.test.sh"
   : >"$repo/tests/fm-backend-herdr-eventwait.test.py"
   : >"$repo/bin/fm-supervisor-target-lib.sh"
   : >"$repo/bin/unmapped-source.sh"
@@ -153,8 +143,6 @@ test_changed_dependency_selection_and_unmapped_failure() {
   assert_contains "$listed" "tests/fm-pr-merge.test.sh" "shared helper selects pr-forge dependents"
   assert_contains "$listed" "tests/fm-secondmate-safety.test.sh" "shared helper selects secondmate dependents"
   assert_contains "$listed" "tests/fm-bearings-snapshot.test.sh" "shared helper selects snapshot dependents"
-  assert_contains "$listed" "tests/fm-backend-orca.test.sh" \
-    "shared helper selects a suite that reaches it only through another helper"
   git -C "$repo" add tests/lib.sh
   git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm helper-change
 
@@ -164,8 +152,6 @@ test_changed_dependency_selection_and_unmapped_failure() {
   listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)
   assert_contains "$listed" "tests/fm-pr-merge.test.sh" "env library selects direct lib.sh consumers"
   assert_contains "$listed" "tests/fm-secondmate-safety.test.sh" "env library selects every lib.sh dependent family"
-  assert_contains "$listed" "tests/fm-backend-orca.test.sh" \
-    "env library selects a suite that reaches lib.sh only through another helper"
   git -C "$repo" add bin/fm-test-env-lib.sh
   git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm env-lib-change
 

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -120,6 +120,7 @@ init_changed_fixture_repo() {
   # It is deliberately the sole member of its family here, so a reference scan
   # that reads only the suites cannot be rescued by family expansion pulling it
   # in behind some sibling that does name the library.
+  # shellcheck disable=SC2016 # The fixture helper, not this test shell, expands the source path.
   printf '#!/usr/bin/env bash\n. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"\n' \
     >"$repo/tests/wake-helpers.sh"
   printf '#!/usr/bin/env bash\n# tests/wake-helpers.sh\n' \

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -777,22 +777,23 @@ SH
 }
 
 test_env_isolation_helper_clears_every_pointer() {
-  local out survivors
+  local out survivors name pattern
+  # Drive the assertion from the lib's own list, so a pointer added there is
+  # exported and asserted here without a second copy to keep in step.
+  . "$ROOT/bin/fm-test-env-lib.sh"
+  [ -n "${FM_TEST_ENV_FLEET_POINTERS:-}" ] \
+    || fail "the shared library published no fleet pointer list"
   # The helper is what both runners call; drive it directly with every pointer
   # exported and confirm nothing survives into a child process.
   out=$(
-    FM_HOME=/live FM_ROOT=/live FM_ROOT_OVERRIDE=/live \
-    FM_STATE_OVERRIDE=/live/state FM_DATA_OVERRIDE=/live/data \
-    FM_PROJECTS_OVERRIDE=/live/projects FM_CONFIG_OVERRIDE=/live/config \
-    FM_PENDING_REPLY_DIR_OVERRIDE=/live/state/pending-replies \
-    FM_PUBLIC_FOLLOWUP_PRIMARY_HOME=/live \
-    FM_WAKE_QUEUE=/live/state/.wake-queue \
-    FM_WAKE_QUEUE_LOCK=/live/state/.wake-queue.lock \
-    FM_BACKEND=tmux FM_SESSION_START_STAGE_FILE=/live/stage \
+    for name in $FM_TEST_ENV_FLEET_POINTERS; do
+      export "$name=/live-sentinel"
+    done
     bash -c '. "$1/bin/fm-test-env-lib.sh"; fm_test_env_isolate || exit 1; env' \
-    _ "$ROOT"
+      _ "$ROOT"
   ) || fail "fm_test_env_isolate refused with a clearable environment"
-  survivors=$(printf '%s\n' "$out" | grep -E '^(FM_HOME|FM_ROOT|FM_ROOT_OVERRIDE|FM_STATE_OVERRIDE|FM_DATA_OVERRIDE|FM_PROJECTS_OVERRIDE|FM_CONFIG_OVERRIDE|FM_PENDING_REPLY_DIR_OVERRIDE|FM_PUBLIC_FOLLOWUP_PRIMARY_HOME|FM_WAKE_QUEUE|FM_WAKE_QUEUE_LOCK|FM_BACKEND|FM_SESSION_START_STAGE_FILE)=' || true)
+  pattern=$(printf '%s\n' $FM_TEST_ENV_FLEET_POINTERS | paste -sd'|' -)
+  survivors=$(printf '%s\n' "$out" | grep -E "^($pattern)=" || true)
   [ -z "$survivors" ] || fail "fleet pointers survived isolation: $survivors"
   pass "the shared isolation helper clears every fleet pointer it owns"
 }

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -92,6 +92,7 @@ init_changed_fixture_repo() {
   local repo=$1 script
   mkdir -p "$repo/bin" "$repo/tests"
   cp "$RUNNER" "$repo/bin/fm-test-run.sh"
+  cp "$ROOT/bin/fm-test-env-lib.sh" "$repo/bin/fm-test-env-lib.sh"
   chmod +x "$repo/bin/fm-test-run.sh"
   for script in \
     fm-brief.test.sh \
@@ -507,6 +508,7 @@ test_jobs_parallel_scheduler_and_failure_propagation() {
   d=tests/fm-supervision-instructions.test.sh
   mkdir -p "$repo/bin" "$repo/tests" "$evidence" "$fake_bin"
   cp "$RUNNER" "$runner"
+  cp "$ROOT/bin/fm-test-env-lib.sh" "$repo/bin/fm-test-env-lib.sh"
   cat >"$fake_bin/stat" <<'SH'
 #!/usr/bin/env bash
 if [ "$1" = "-c" ] && [ "$2" = "%a" ]; then
@@ -703,6 +705,91 @@ assert len(doc["scripts"])==3
   pass "aggregate-json merges lane timing artifacts"
 }
 
+test_run_cannot_reach_the_live_home() {
+  local tmp repo sentinel probe out rc leaked
+  tmp=$(fm_test_tmproot fm-test-run-live-home)
+  repo="$tmp/repo"
+  sentinel="$tmp/live-home"
+  probe=tests/fm-live-home-probe.test.sh
+
+  # A home-shaped sentinel with one durable record already in it, so both a new
+  # write and a modified byte count are visible afterwards.
+  mkdir -p "$sentinel/state" "$sentinel/data"
+  printf 'sentinel\n' >"$sentinel/state/.wake-queue"
+
+  mkdir -p "$repo/bin" "$repo/tests"
+  cp "$RUNNER" "$repo/bin/fm-test-run.sh"
+  cp "$ROOT/bin/fm-test-env-lib.sh" "$repo/bin/fm-test-env-lib.sh"
+  cp "$ROOT/bin/fm-wake-lib.sh" "$repo/bin/fm-wake-lib.sh"
+  # The probe resolves its home the way every Firstmate script does, through the
+  # real shared library, and then writes a durable record there.
+  cat >"$repo/$probe" <<'SH'
+#!/usr/bin/env bash
+set -u
+# shellcheck source=/dev/null
+. "$(cd "$(dirname "$0")/../bin" && pwd)/fm-wake-lib.sh"
+fm_wake_append check live-home-probe probe >/dev/null 2>&1 || true
+printf 'PROBE_HOME=%s\n' "$FM_HOME"
+printf 'PROBE_STATE=%s\n' "$STATE"
+echo "ok - probe"
+SH
+  chmod +x "$repo/bin/fm-test-run.sh" "$repo/$probe"
+  # The probe reports a resolved path, so compare against a resolved one.
+  repo=$(cd "$repo" && pwd -P)
+
+  find "$sentinel" | LC_ALL=C sort >"$tmp/sentinel-before"
+
+  set +e
+  (
+    cd "$repo" || exit 1
+    export FM_HOME="$sentinel"
+    export FM_STATE_OVERRIDE="$sentinel/state"
+    export FM_DATA_OVERRIDE="$sentinel/data"
+    export FM_ROOT="$sentinel"
+    bin/fm-test-run.sh "$probe"
+  ) >"$tmp/out" 2>"$tmp/err"
+  rc=$?
+  set -e
+  [ "$rc" -eq 0 ] || fail "probe run failed ($rc): $(cat "$tmp/err")"
+
+  # Positive assertion, not "anywhere but the sentinel": a partial fix that
+  # cleared only FM_HOME would still resolve the state directory from an
+  # inherited override, and that must not read as a pass.
+  grep -Fq "PROBE_HOME=$repo" "$tmp/out" \
+    || fail "probe resolved a home outside its own repo: $(grep PROBE_ "$tmp/out")"
+  grep -Fq "PROBE_STATE=$repo/state" "$tmp/out" \
+    || fail "probe resolved a state directory outside its own repo: $(grep PROBE_ "$tmp/out")"
+
+  [ "$(cat "$sentinel/state/.wake-queue")" = "sentinel" ] \
+    || fail "a test script wrote to the live home's durable queue"
+  find "$sentinel" | LC_ALL=C sort >"$tmp/sentinel-after"
+  leaked=$(comm -13 "$tmp/sentinel-before" "$tmp/sentinel-after" || true)
+  [ -z "$leaked" ] || fail "a test script created entries in the live home: $leaked"
+
+  pass "no run path hands a test script the live fleet home"
+}
+
+test_env_isolation_helper_clears_every_pointer() {
+  local out survivors
+  # The helper is what both runners call; drive it directly with every pointer
+  # exported and confirm nothing survives into a child process.
+  out=$(
+    FM_HOME=/live FM_ROOT=/live FM_ROOT_OVERRIDE=/live \
+    FM_STATE_OVERRIDE=/live/state FM_DATA_OVERRIDE=/live/data \
+    FM_PROJECTS_OVERRIDE=/live/projects FM_CONFIG_OVERRIDE=/live/config \
+    FM_PENDING_REPLY_DIR_OVERRIDE=/live/state/pending-replies \
+    FM_PUBLIC_FOLLOWUP_PRIMARY_HOME=/live \
+    FM_WAKE_QUEUE=/live/state/.wake-queue \
+    FM_WAKE_QUEUE_LOCK=/live/state/.wake-queue.lock \
+    FM_BACKEND=tmux \
+    bash -c '. "$1/bin/fm-test-env-lib.sh"; fm_test_env_isolate || exit 1; env' \
+    _ "$ROOT"
+  ) || fail "fm_test_env_isolate refused with a clearable environment"
+  survivors=$(printf '%s\n' "$out" | grep -E '^(FM_HOME|FM_ROOT|FM_ROOT_OVERRIDE|FM_STATE_OVERRIDE|FM_DATA_OVERRIDE|FM_PROJECTS_OVERRIDE|FM_CONFIG_OVERRIDE|FM_PENDING_REPLY_DIR_OVERRIDE|FM_PUBLIC_FOLLOWUP_PRIMARY_HOME|FM_WAKE_QUEUE|FM_WAKE_QUEUE_LOCK|FM_BACKEND)=' || true)
+  [ -z "$survivors" ] || fail "fleet pointers survived isolation: $survivors"
+  pass "the shared isolation helper clears every fleet pointer it owns"
+}
+
 test_list_all_exact_suite_coverage
 test_family_selection
 test_single_script_selection
@@ -721,3 +808,5 @@ test_jobs_requires_proven_isolated
 test_jobs_parallel_scheduler_and_failure_propagation
 test_herdr_ci_family_run_has_a_step_timeout
 test_aggregate_json
+test_run_cannot_reach_the_live_home
+test_env_isolation_helper_clears_every_pointer

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -819,7 +819,7 @@ test_shared_test_library_isolates_a_direct_invocation() {
   ) || fail "sourcing tests/lib.sh refused with a clearable environment"
   read -r -a pointers <<<"$FM_TEST_ENV_FLEET_POINTERS"
   pattern=$(IFS='|'; printf '%s' "${pointers[*]}")
-  survivors=$(printf '%s\n' "$out" | grep -E "^($pattern)=/live-sentinel$" || true)
+  survivors=$(printf '%s\n' "$out" | grep -E "^($pattern)=" || true)
   [ -z "$survivors" ] || fail "fleet pointers survived a direct suite invocation: $survivors"
   # The sentinel must actually reach a child that does NOT source the library,
   # so the assertion above cannot pass merely because the export did nothing.

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -115,16 +115,6 @@ init_changed_fixture_repo() {
     chmod +x "$repo/tests/$script"
   done
   : >"$repo/tests/lib.sh"
-  # A suite that reaches tests/lib.sh only through a shared helper and never
-  # spells the library's own name - tests/fm-watch-arm.test.sh is the real one.
-  # It is deliberately the sole member of its family here, so a reference scan
-  # that reads only the suites cannot be rescued by family expansion pulling it
-  # in behind some sibling that does name the library.
-  # shellcheck disable=SC2016 # The fixture helper, not this test shell, expands the source path.
-  printf '#!/usr/bin/env bash\n. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"\n' \
-    >"$repo/tests/wake-helpers.sh"
-  printf '#!/usr/bin/env bash\n# tests/wake-helpers.sh\n' \
-    >"$repo/tests/fm-backend-orca.test.sh"
   : >"$repo/tests/fm-backend-herdr-eventwait.test.py"
   : >"$repo/bin/fm-supervisor-target-lib.sh"
   : >"$repo/bin/unmapped-source.sh"
@@ -153,18 +143,15 @@ test_changed_dependency_selection_and_unmapped_failure() {
   assert_contains "$listed" "tests/fm-pr-merge.test.sh" "shared helper selects pr-forge dependents"
   assert_contains "$listed" "tests/fm-secondmate-safety.test.sh" "shared helper selects secondmate dependents"
   assert_contains "$listed" "tests/fm-bearings-snapshot.test.sh" "shared helper selects snapshot dependents"
-  assert_contains "$listed" "tests/fm-backend-orca.test.sh" \
-    "shared helper selects a suite that reaches it only through another helper"
   git -C "$repo" add tests/lib.sh
   git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm helper-change
 
   # The env library shapes every suite that sources tests/lib.sh, so it must
-  # reach the indirect consumers through the same scan.
+  # select them through the same scan rather than the runner's own family alone.
   printf '\n' >>"$repo/bin/fm-test-env-lib.sh"
   listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)
   assert_contains "$listed" "tests/fm-pr-merge.test.sh" "env library selects direct lib.sh consumers"
-  assert_contains "$listed" "tests/fm-backend-orca.test.sh" \
-    "env library selects a suite that reaches lib.sh only through another helper"
+  assert_contains "$listed" "tests/fm-secondmate-safety.test.sh" "env library selects every lib.sh dependent family"
   git -C "$repo" add bin/fm-test-env-lib.sh
   git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm env-lib-change
 

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -115,6 +115,16 @@ init_changed_fixture_repo() {
     chmod +x "$repo/tests/$script"
   done
   : >"$repo/tests/lib.sh"
+  # A suite that reaches tests/lib.sh only through a shared helper and never
+  # spells the library's own name - tests/fm-watch-arm.test.sh is the real one.
+  # It is deliberately the sole member of its family here, so a reference scan
+  # that reads only the suites cannot be rescued by family expansion pulling it
+  # in behind some sibling that does name the library.
+  # shellcheck disable=SC2016 # The fixture helper, not this test shell, expands the source path.
+  printf '#!/usr/bin/env bash\n. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"\n' \
+    >"$repo/tests/wake-helpers.sh"
+  printf '#!/usr/bin/env bash\n# tests/wake-helpers.sh\n' \
+    >"$repo/tests/fm-backend-orca.test.sh"
   : >"$repo/tests/fm-backend-herdr-eventwait.test.py"
   : >"$repo/bin/fm-supervisor-target-lib.sh"
   : >"$repo/bin/unmapped-source.sh"
@@ -143,6 +153,8 @@ test_changed_dependency_selection_and_unmapped_failure() {
   assert_contains "$listed" "tests/fm-pr-merge.test.sh" "shared helper selects pr-forge dependents"
   assert_contains "$listed" "tests/fm-secondmate-safety.test.sh" "shared helper selects secondmate dependents"
   assert_contains "$listed" "tests/fm-bearings-snapshot.test.sh" "shared helper selects snapshot dependents"
+  assert_contains "$listed" "tests/fm-backend-orca.test.sh" \
+    "shared helper selects a suite that reaches it only through another helper"
   git -C "$repo" add tests/lib.sh
   git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm helper-change
 
@@ -152,6 +164,8 @@ test_changed_dependency_selection_and_unmapped_failure() {
   listed=$(cd "$repo" && bin/fm-test-run.sh --list --changed --base HEAD)
   assert_contains "$listed" "tests/fm-pr-merge.test.sh" "env library selects direct lib.sh consumers"
   assert_contains "$listed" "tests/fm-secondmate-safety.test.sh" "env library selects every lib.sh dependent family"
+  assert_contains "$listed" "tests/fm-backend-orca.test.sh" \
+    "env library selects a suite that reaches lib.sh only through another helper"
   git -C "$repo" add bin/fm-test-env-lib.sh
   git -C "$repo" -c user.name=test -c user.email=test@example.invalid commit -qm env-lib-change
 

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -778,6 +778,7 @@ SH
 
 test_env_isolation_helper_clears_every_pointer() {
   local out survivors name pattern
+  local -a pointers
   # Drive the assertion from the lib's own list, so a pointer added there is
   # exported and asserted here without a second copy to keep in step.
   . "$ROOT/bin/fm-test-env-lib.sh"
@@ -792,7 +793,8 @@ test_env_isolation_helper_clears_every_pointer() {
     bash -c '. "$1/bin/fm-test-env-lib.sh"; fm_test_env_isolate || exit 1; env' \
       _ "$ROOT"
   ) || fail "fm_test_env_isolate refused with a clearable environment"
-  pattern=$(printf '%s\n' $FM_TEST_ENV_FLEET_POINTERS | paste -sd'|' -)
+  read -r -a pointers <<<"$FM_TEST_ENV_FLEET_POINTERS"
+  pattern=$(IFS='|'; printf '%s' "${pointers[*]}")
   survivors=$(printf '%s\n' "$out" | grep -E "^($pattern)=" || true)
   [ -z "$survivors" ] || fail "fleet pointers survived isolation: $survivors"
   pass "the shared isolation helper clears every fleet pointer it owns"

--- a/tests/fm-test-run.test.sh
+++ b/tests/fm-test-run.test.sh
@@ -800,6 +800,36 @@ test_env_isolation_helper_clears_every_pointer() {
   pass "the shared isolation helper clears every fleet pointer it owns"
 }
 
+test_shared_test_library_isolates_a_direct_invocation() {
+  local out survivors name pattern
+  local -a pointers
+  # The runner covers every suite it starts, but a suite run directly - `bash
+  # tests/<file>.test.sh` from a firstmate worker - never passes through it, and
+  # the pointers reach the production scripts that suite drives. Sourcing
+  # tests/lib.sh must therefore isolate too. Driven from the lib's own list so a
+  # pointer added there is asserted here without a second copy.
+  . "$ROOT/bin/fm-test-env-lib.sh"
+  [ -n "${FM_TEST_ENV_FLEET_POINTERS:-}" ] \
+    || fail "the shared library published no fleet pointer list"
+  out=$(
+    for name in $FM_TEST_ENV_FLEET_POINTERS; do
+      export "$name=/live-sentinel"
+    done
+    bash -c '. "$1/tests/lib.sh"; env' _ "$ROOT"
+  ) || fail "sourcing tests/lib.sh refused with a clearable environment"
+  read -r -a pointers <<<"$FM_TEST_ENV_FLEET_POINTERS"
+  pattern=$(IFS='|'; printf '%s' "${pointers[*]}")
+  survivors=$(printf '%s\n' "$out" | grep -E "^($pattern)=/live-sentinel$" || true)
+  [ -z "$survivors" ] || fail "fleet pointers survived a direct suite invocation: $survivors"
+  # The sentinel must actually reach a child that does NOT source the library,
+  # so the assertion above cannot pass merely because the export did nothing.
+  # shellcheck disable=SC2016 # Expands in the probe child, not in this shell.
+  out=$(env FM_HOME=/live-sentinel bash -c 'printf "%s\n" "${FM_HOME:-none}"')
+  [ "$out" = /live-sentinel ] \
+    || fail "fixture setup wrong: the sentinel never reached an unisolated child"
+  pass "sourcing tests/lib.sh isolates a directly invoked suite"
+}
+
 test_list_all_exact_suite_coverage
 test_family_selection
 test_single_script_selection
@@ -820,3 +850,4 @@ test_herdr_ci_family_run_has_a_step_timeout
 test_aggregate_json
 test_run_cannot_reach_the_live_home
 test_env_isolation_helper_clears_every_pointer
+test_shared_test_library_isolates_a_direct_invocation

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -23,7 +23,6 @@
 if [ -n "${FM_TEST_LIB_SOURCED:-}" ]; then
   return 0
 fi
-FM_TEST_LIB_SOURCED=1
 
 # Exempt firstmate's own test suite from the gate-lifecycle refusal
 # (bin/fm-gate-refuse-lib.sh). The no-mistakes gate runs this suite FROM a gate
@@ -48,9 +47,19 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # the rest aimed at the live home, and a suite asserting a bound can lose the
 # bound it is asserting. bin/fm-test-env-lib.sh owns the pointer list; this is a
 # second CALLER of that one owner, never a second copy of the list.
+#
+# A failed isolate refuses the whole process, the same way both runners do,
+# rather than returning to a suite that would then build fixtures over the live
+# home. The sourced guard is latched only after this succeeds, so a refusal can
+# never leave a half-initialised library behind for a second source to accept.
 # shellcheck source=bin/fm-test-env-lib.sh
 . "$ROOT/bin/fm-test-env-lib.sh"
-fm_test_env_isolate || return 1
+if ! fm_test_env_isolate; then
+  printf 'tests/lib.sh: refusing to run a suite against the live fleet home\n' >&2
+  exit 2
+fi
+
+FM_TEST_LIB_SOURCED=1
 
 # --- reporters --------------------------------------------------------------
 

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -39,6 +39,19 @@ export FM_GATE_REFUSE_BYPASS=1
 # shellcheck disable=SC2034
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
+# Isolate the process from the ambient fleet environment before any fixture is
+# built. bin/fm-test-run.sh already does this for every suite it starts, so a
+# run through the runner is covered; a suite invoked directly - `bash
+# tests/<file>.test.sh` from a firstmate worker - is not, and inherits the live
+# home. That is not a cosmetic gap: the pointers reach the production scripts a
+# suite drives, so a fixture that exports only the subset it cares about leaves
+# the rest aimed at the live home, and a suite asserting a bound can lose the
+# bound it is asserting. bin/fm-test-env-lib.sh owns the pointer list; this is a
+# second CALLER of that one owner, never a second copy of the list.
+# shellcheck source=bin/fm-test-env-lib.sh
+. "$ROOT/bin/fm-test-env-lib.sh"
+fm_test_env_isolate || return 1
+
 # --- reporters --------------------------------------------------------------
 
 fail() {


### PR DESCRIPTION
## Intent

Diagnose and fix the failing unmarked-crewmate-send case in tests/fm-pending-reply.test.sh.

Evidence given at intake: that case fails on the clean default branch, independent of locale, reproduced on a clean tree on 2026-08-25. It is not an environment problem and not caused by an unrelated away-mode change landed the same day. Keep it distinct from two findings reported at the same time that are NOT defects: tests/fm-afk-inject-e2e.test.sh and tests/fm-composer-lib.test.sh fail only under LC_ALL=C on multi-byte fixture comparisons and pass under UTF-8; that is locale sensitivity in the fixtures, already recorded as environment sensitivity rather than a defect, and must be left alone.

Required approach: reproduce it first on a clean base and confirm independently that it fails regardless of locale; do not take the reported evidence on trust. Establish whether the TEST is wrong or the SEND PATH is wrong before fixing, because these have opposite correct fixes. Fix the actual cause.

Absolute constraint: do not weaken, skip, relax, delete or mark-flaky the test to get green. If the test is genuinely wrong, prove it before changing it, ideally with a disconfirming experiment showing the assertion still fails when the behaviour it claims to protect is removed. A suite made green by weakening it is worse than a red one.

Scope: fix this one case. If the diagnosis showed a larger defect in the pending-reply machinery, stop and report it with evidence rather than building the larger change.

What the diagnosis established. The test's fixture is wrong, not its assertion and not the send path. A firstmate worker's environment carries the live home's pointers. FM_STATE_OVERRIDE outranks FM_HOME/state in every script that reads it (docs/configuration.md "FM_HOME"). The fixture sets its own FM_HOME but inherits the rest, so bin/fm-send.sh resolved state/<id>.meta under the live fleet home, could not find the fixture's target, and refused with exit 1 - the correct refusal for the environment it was actually given. Four sibling fm-send suites fail the same way for the same reason. With the inherited pointers cleared, the whole suite passes untouched.

The chosen fix and why it is placed where it is. bin/fm-test-run.sh already isolates every suite it starts, so a run through the runner is green and only a direct `bash tests/<file>.test.sh` sees this. tests/lib.sh now sources bin/fm-test-env-lib.sh and calls fm_test_env_isolate, so the direct-invocation path is isolated too. This is deliberately a second CALLER of that single owner, never a second copy of its pointer list: bin/fm-test-env-lib.sh states that no runner keeps its own copy because two copies drift. That rule is load-bearing here rather than stylistic. An earlier attempt on this task did duplicate the list, on a branch cut below the landed owner, and that copy was already missing FM_SESSION_START_STAGE_FILE - which is exactly the drift the rule predicts, and it left a real symptom in place: bin/fm-session-start.sh treats that variable's presence as "the runtime bound is already applied", so tests/fm-session-start.test.sh lost the bound it asserts and hung on its fixture instead of being truncated. That earlier commit was rebuilt from scratch on top of the landed owner rather than carried forward.

Accepted requirement from supervision: the unbounded session-start suite is NOT a separate defect to track. It is the same missing isolation on the direct-invocation path, and this change closes it.

The send path is deliberately unchanged. Its precedence is the documented one, and the failing case still catches a real regression: removing the kind=secondmate condition that keeps crewmate steers unmarked turns it red again.

Regression coverage added to tests/fm-test-run.test.sh, which already owns the runner-path and helper-level isolation cases; the direct-invocation path was the gap. The new case is driven from the library's own published pointer list so no second copy is introduced, and it asserts the sentinel genuinely reaches an unisolated child so it cannot pass vacuously.

Verified locally with the live worker environment still present: tests/fm-pending-reply.test.sh and the sibling fm-send suites pass where they previously refused at the first send; tests/fm-session-start.test.sh completes in 188s where it previously ran past a 420s kill; the portable-parallel-1 lane is 11 suites with 0 failures; the proven-isolated set is 24 suites with only the known composer-lib locale case, which is present on pristine main too; bin/fm-lint.sh and bin/fm-doc-audience-check.sh pass. Removing the fix turns both the reported case and the new regression test red again.

Delivery constraints for this run: the push step targets an upstream repository where this account has no write access, so an HTTP 403 there is correct behaviour rather than a credential fault; pushing to the fork remote https://github.com/AgardnerAU/firstmate is pre-authorised, naming the remote on the push itself. Do not change the pipeline's push target, do not edit remotes in the primary checkout, do not touch credentials, and never force. The pull request must be opened against kunchenguid/firstmate with base main, head AgardnerAU:<branch> into base kunchenguid:main; a fork-internal pull request reaches nobody. CI will not run on the fork pull request because it waits on an upstream maintainer to release workflow runs, so it must never be called green. This worker does not merge.

RUN PURPOSE, accepted after the previous run: take this pipeline to COMPLETION so the pull request body carries a parseable no-mistakes v1 attestation bound to its FINAL head. The upstream repository's "Require no-mistakes" check requires that attestation to bind to the current head and report review, test and document completed; the previous run was cancelled at CI attempt 2 of 3, before it was emitted, which is why the check cannot pass as things stand. Do not cancel early this time. Once the attestation is verified bound to the head, waiting further on CI is pointless: this is a fork pull request on a repository that holds contributor workflow runs, so those checks are held rather than red and no amount of waiting produces them.

BRANCH REBUILD, done deliberately before this run: the branch was rebuilt on top of the CURRENT head of its dependency pull request kunchenguid/firstmate#3026 (038da15bdbb24d999b355185c820adf0ec84d50c), by replaying this change's own five commits onto it. Verified afterwards that 038da15b is an ancestor of this branch, so the two pull requests now share the SAME dependency commits rather than this one carrying rewritten copies of them. That is the honest improvement available; fully unstacking is NOT possible yet, because bin/fm-test-env-lib.sh does not exist on upstream main and GitHub compares a pull request from its merge base, so any branch carrying this fix must also carry the dependency until #3026 merges. Do not attempt to remove the dependency commits, and never invent history to make the diff look smaller. Never merge - the upstream maintainer merges. Never force-push to work around a guard; if the push step refuses, stop and report the exact refusal rather than working around it.

RUN PURPOSE: emit a no-mistakes v1 attestation bound to this branch's FINAL head. The previous attestation went stale because an automated CI round pushed a commit after the pr step had already emitted it. This run must reach the emitting step against the current head. The attestation must never be hand-written.

STANDING DECISION, already made and NOT open for re-debate: expand_test_reference_needles must NOT exist on this branch. It was removed on measurement - neutralising it leaves the --changed selection byte-for-byte identical, 165 of 165 suites with tests/fm-watch-arm.test.sh and tests/fm-watch-recovery-loop.test.sh selected either way - because selection here is family-expanded, so a needle-level refinement is inert and those suites arrive with family watcher-wake-lock, which contains direct tests/lib.sh sourcers. An automated round reinstated it while chasing a review verdict that had already reversed to pass; that commit has been reverted. Do NOT reinstate the closure, its fixture, or its assertion. If review raises it again, the answer is this measurement, not a fresh debate. Keep the bin/fm-test-env-lib.sh map routing, which is the part that genuinely changed behaviour from 32 of 162 to full selection, and keep the comment recording that selection expands each emitted family to all of its suites.

## What Changed

- Adds `bin/fm-test-env-lib.sh` as the single owner of the ambient fleet pointer list (`FM_HOME`, the `FM_*_OVERRIDE` set, wake-queue pointers, and the runtime control variables `FM_SESSION_START_STAGE_FILE`, `FM_SUPERVISION_MODEL`, `FM_TRACE_CONTEXT`). Its `fm_test_env_isolate` clears them in the calling process and returns non-zero if any survives.
- Makes `bin/fm-test-run.sh`, `bin/fm-test-isolation-proof.sh`, and `tests/lib.sh` all call that one owner once per process and refuse with exit 2 if isolation fails; the two runners drop their own inline `unset` lists, and `tests/lib.sh` latches `FM_TEST_LIB_SOURCED` only after a successful isolate. This closes the direct `bash tests/<file>.test.sh` path, which previously inherited a live worker's pointers.
- Routes changed-file selection for `bin/fm-test-env-lib.sh` through the same reference scan `tests/lib.sh` gets (plus `pure-contract-unit`), and adds three cases to `tests/fm-test-run.test.sh` covering the runner path, the helper itself, and direct invocation - each driven from the library's published pointer list, with a sentinel check so the direct-invocation case cannot pass vacuously. `CONTRIBUTING.md` and `docs/scripts.md` record the new owner and its callers.

## Risk Assessment

✅ Low: The change is a well-bounded test-harness fix that introduces a single shared owner for the fleet-pointer list with three consistent callers, all fixture copy sites were updated, no suite exports a pointer before sourcing tests/lib.sh, and every intent constraint (no needle closure, byte-identical proof record, narrowed CONTRIBUTING claim) is satisfied; the only issue found is a stale invariant comment.

## Testing

I drove the change through the exact end-user command that was reported broken - `bash tests/fm-pending-reply.test.sh` from a firstmate-worker-shaped environment - against a scratch export of the base commit and against this worktree. The unmarked-crewmate-send case fails on base under both C and UTF-8 locales and passes on target with the test file untouched, and a disconfirming mutation that strips the `kind=secondmate` guard from bin/fm-send.sh turns it red again, so the suite was fixed rather than weakened. Four sibling fm-send suites and tests/fm-session-start.test.sh show the same base-fails / target-passes transition on the direct path, and the new regression case in tests/fm-test-run.test.sh fails when the tests/lib.sh fix is reverted, so it is not vacuous. I also confirmed the standing decisions hold: the needle closure is gone, the dated proof record is byte-identical to base, and the env-lib changed-map routing still selects the full 165-suite set. No UI surface is involved, so the evidence is a CLI transcript rather than a screenshot. Everything ran green and no findings are actionable; the only caveat is that my scratch trees under /tmp could not be deleted because the sandbox declined every `rm -rf`, and the worktree itself is clean including untracked files.

<details>
<summary>Evidence: Direct-invocation isolation CLI transcript (base vs target, disconfirming mutation, sibling suites, selection)</summary>

Source: [Direct-invocation isolation CLI transcript (base vs target, disconfirming mutation, sibling suites, selection)](https://github.com/AgardnerAU/firstmate/blob/9228a8e03a06789f97c883ecc955a5bbfa3d60b4/.no-mistakes/evidence/fm/fm-test-lib-isolates-direct-invocation/direct-invocation-isolation-transcript.txt)

<code>--- 1. BASE 5953e9b: bash tests/fm-pending-reply.test.sh ---&#10;not ok - unmarked crewmate send should succeed: expected exit 0, got 1&#10;exit status: 1&#10;&#10;--- 2. BASE, locale independence ---&#10;[LC_ALL=C] not ok - unmarked crewmate send should succeed: expected exit 0, got 1&#10;[LC_ALL=en_AU.UTF-8] not ok - unmarked crewmate send should succeed: expected exit 0, got 1&#10;&#10;--- 3. TARGET 910b96a: same command, same ambient environment ---&#10;ok - all pending-reply tests passed&#10;exit status: 0&#10;&#10;--- 4. Disconfirming experiment: remove the kind=secondmate guard in bin/fm-send.sh ---&#10;not ok - crewmate steer should be recorded unmarked&#10;exit status: 1 -- the case still protects the behaviour it claims to&#10;&#10;--- 7. New regression coverage ---&#10;target tree:&#10;ok - sourcing tests/lib.sh isolates a directly invoked suite&#10;with the fix removed:&#10;not ok - fleet pointers survived a direct suite invocation: FM_PROJECTS_OVERRIDE=/live-sentinel</code>

```text
== direct-invocation isolation: end-user transcript ==
Ambient environment simulates a firstmate worker: FM_HOME / FM_STATE_OVERRIDE / FM_DATA_OVERRIDE / FM_ROOT aimed at a fake live home.

--- 1. BASE 5953e9b: bash tests/fm-pending-reply.test.sh (reported failing case) ---
not ok - unmarked crewmate send should succeed: expected exit 0, got 1
exit status: 1

--- 2. BASE, locale independence ---
[LC_ALL=C]            not ok - unmarked crewmate send should succeed: expected exit 0, got 1
[LC_ALL=en_AU.UTF-8]  not ok - unmarked crewmate send should succeed: expected exit 0, got 1

--- 3. TARGET 910b96a: same command, same ambient environment ---
ok - all pending-reply tests passed
exit status: 0

--- 4. Disconfirming experiment: remove the kind=secondmate guard in bin/fm-send.sh on the fixed tree ---
not ok - crewmate steer should be recorded unmarked
exit status: 1 -- the case still protects the behaviour it claims to; it was not weakened.

--- 5. Sibling fm-send suites, direct invocation, base vs target (count of "not ok") ---
fm-send-inbox              base=1  target=0
fm-send-strict             base=1  target=0
fm-send-resolve-key        base=1  target=0
fm-send-secondmate-marker  base=1  target=0

--- 6. tests/fm-session-start.test.sh, direct invocation with a leaked FM_SESSION_START_STAGE_FILE ---
BASE   : exit=1 after 10s -- not ok - read-only banner missing on lock refusal (missing: 'READ-ONLY SESSION')
TARGET : exit=0 after 228s -- # fm-session-start.test.sh: all assertions passed

--- 7. New regression coverage in tests/fm-test-run.test.sh ---
target tree:
ok - no run path hands a test script the live fleet home
ok - the shared isolation helper clears every fleet pointer it owns
ok - sourcing tests/lib.sh isolates a directly invoked suite

same suite with tests/lib.sh reverted to base (fix removed):
ok - the shared isolation helper clears every fleet pointer it owns
not ok - fleet pointers survived a direct suite invocation: FM_PROJECTS_OVERRIDE=/live-sentinel

--- 8. Changed-file map routing for bin/fm-test-env-lib.sh (scratch clone, one line appended and committed) ---
$ bin/fm-test-run.sh --list --changed --base HEAD~1
selected = 165 of 165 suites
  tests/fm-pending-reply.test.sh
  tests/fm-watch-arm.test.sh
  tests/fm-watch-recovery-loop.test.sh
Matches the recorded standing measurement; expand_test_reference_needles is absent from bin/ and tests/.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"910b96a499f5343b6ad228a28c0153c5f8cb8c60","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `bin/fm-test-run.sh:911` - The map&#39;s contract comment (`# Conservative path → family map. Over-selects rather than under-selects. / # Never expands to the complete suite.`, line 911, restated at line 70 as &#34;never expands to the complete suite unless --all&#34;) is contradicted by the new `bin/fm-test-env-lib.sh` entry added at line 928. That entry calls `families_for_test_reference lib.sh`, whose `grep -Fq &#34;lib.sh&#34;` matches essentially every suite in the repository (almost all of them reference some `*-lib.sh`), so by the intent&#39;s own measurement a one-line edit to `bin/fm-test-env-lib.sh` selects 165 of 165 suites - the complete suite, without `--all`. The full expansion is deliberate and correct here; the defect is the stale absolute claim two lines above it, which now tells a maintainer the opposite of what the code does. Nothing fails as a result: `test_changed_file_selection_is_conservative` (tests/fm-test-run.test.sh:80) only asserts `listed_count -le all_count`, so the assertion still passes at exactly full selection. Narrow both sentences to what still holds - the map over-selects related families rather than under-selecting, and a path may legitimately expand to every family when its blast radius is that wide.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-pending-reply.test.sh` on a scratch export of base 5953e9b with FM_HOME/FM_STATE_OVERRIDE/FM_DATA_OVERRIDE/FM_ROOT aimed at a fake live home - reproduced `not ok - unmarked crewmate send should succeed: expected exit 0, got 1`</code>
- <code>Same base command under `LC_ALL=C` and `LC_ALL=en_AU.UTF-8` - identical failure, so it is not locale sensitivity</code>
- <code>`bash tests/fm-pending-reply.test.sh` in this worktree with the same ambient environment - exit 0, whole suite green</code>
- <code>Disconfirming mutation: removed the `kind=secondmate` condition at bin/fm-send.sh:500 in a scratch copy of the target tree and re-ran the suite - `not ok - crewmate steer should be recorded unmarked`</code>
- <code>`bash tests/fm-send-inbox.test.sh`, `bash tests/fm-send-strict.test.sh`, `bash tests/fm-send-resolve-key.test.sh`, `bash tests/fm-send-secondmate-marker.test.sh` on base vs target with the same ambient pointers - one failure each on base, zero on target</code>
- <code>`bash tests/fm-session-start.test.sh` with a leaked `FM_SESSION_START_STAGE_FILE` - base exits 1 at 10s, target passes in 228s</code>
- <code>`bash tests/fm-test-run.test.sh` on the target tree - the three isolation cases pass, including `sourcing tests/lib.sh isolates a directly invoked suite`</code>
- <code>Same suite with `tests/lib.sh` reverted to the base version - `not ok - fleet pointers survived a direct suite invocation: FM_PROJECTS_OVERRIDE=/live-sentinel`, confirming fail-before/pass-after</code>
- <code>`bin/fm-test-run.sh --list --changed --base HEAD~1` in a scratch clone after appending a line to bin/fm-test-env-lib.sh - 165 of 165 suites selected, including tests/fm-watch-arm.test.sh and tests/fm-watch-recovery-loop.test.sh</code>
- <code>`grep -rn &#39;expand_test_reference_needles|tests_helper_scripts&#39; bin tests` - no matches; `git diff 5953e9b 910b96a -- docs/fm-test-isolation-proof.md` - empty</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
