### PR TITLE
fix(afk): stop the away daemon from self-injecting on claude+herdr

### DIFF
--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -24,17 +24,21 @@ batched digest rather than per-wake injections.
    The flag survives a firstmate restart, so recovery re-enters afk when it is present.
 
 2. **Ensure the sub-supervisor daemon is running as a tracked background process.**
-   Its hosting differs by harness.
+   Its hosting differs by harness AND backend.
    Pick the right path:
-   - **Harness WITH a native in-pane tracked-background tool** (e.g. claude's
-     background bash, grok's background tool): first run
+   - **Claude on the herdr backend: always use the terminal-backed path below, never `start-native`.**
+     A Claude Code background shell hosting the daemon in the captain's own pane leaves a `· 1 shell ·` token in that pane's rendered footer for as long as the daemon lives.
+     Herdr's own claude agent-detection ruleset maps that exact token to `agent_status = "working"` at a priority that beats the idle rule, so the away-mode busy guard reads the captain's pane as permanently busy and can never deliver an escalation into it for the life of the session - proven in `data/firstmate-afk-daemon-wedged-investigation/report.md` (2026-08-26), which found this in every claude+herdr away run since 2026-08-19.
+     Do not "fix" this by teaching the busy guard to subtract the daemon's own footer contribution; that couples firstmate to a private, versioned herdr ruleset that already changes without notice.
+   - **Harness WITH a native in-pane tracked-background tool, on any OTHER combination** (e.g. claude's
+     background bash on tmux, grok's background tool): first run
      `bin/fm-afk-launch.sh start-native`, then run
      `FM_AFK_STATE_PREPARED=1 bin/fm-afk-start.sh` through that native tool.
      This is a deliberate no-separate-terminal exception because the harness-hosted job creates no terminal or layout mutation, and a shell launcher cannot invoke a harness-native background tool.
      The launcher still owns lifecycle state and records the no-terminal mode, while the daemon inherits and auto-discovers the captain pane.
      If the native launch fails, run `bin/fm-afk-launch.sh stop` to roll back the prepared lifecycle.
      Do not wrap it in `nohup ... &` (Codex/herdr can reap fire-and-forget shell children after a tool call returns).
-   - **Harness WITHOUT one** (e.g. pi): run `bin/fm-afk-launch.sh start`. It is
+   - **Harness WITHOUT a native in-pane tool (e.g. pi), and claude on herdr per above**: run `bin/fm-afk-launch.sh start`. It is
      the single owner of the daemon terminal: it creates a NON-VISIBLE tracked
      terminal for the current backend (a herdr dedicated `--no-focus` workspace,
      a detached tmux session), records its exact id, and passes the captain pane

--- a/.agents/skills/afk/SKILL.md
+++ b/.agents/skills/afk/SKILL.md
@@ -30,6 +30,7 @@ batched digest rather than per-wake injections.
      A Claude Code background shell hosting the daemon in the captain's own pane leaves a `· 1 shell ·` token in that pane's rendered footer for as long as the daemon lives.
      Herdr's own claude agent-detection ruleset maps that exact token to `agent_status = "working"` at a priority that beats the idle rule, so the away-mode busy guard reads the captain's pane as permanently busy and can never deliver an escalation into it for the life of the session - proven in `data/firstmate-afk-daemon-wedged-investigation/report.md` (2026-08-26), which found this in every claude+herdr away run since 2026-08-19.
      Do not "fix" this by teaching the busy guard to subtract the daemon's own footer contribution; that couples firstmate to a private, versioned herdr ruleset that already changes without notice.
+     `bin/fm-afk-launch.sh start-native` enforces this rule itself: on claude+herdr it refuses before writing any lifecycle state, so a refusal there is the guard working and there is nothing to roll back - re-enter with `bin/fm-afk-launch.sh start`.
    - **Harness WITH a native in-pane tracked-background tool, on any OTHER combination** (e.g. claude's
      background bash on tmux, grok's background tool): first run
      `bin/fm-afk-launch.sh start-native`, then run

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -6,9 +6,15 @@
 # Why this exists (docs/herdr-backend.md "Away-mode daemon terminal launch"):
 # bin/fm-afk-start.sh execs the supervise daemon in the FOREGROUND of whatever
 # terminal it is already in. Harnesses with a native in-pane tracked-background
-# tool (claude, grok) run it there directly and it is fine. A harness with NO
-# native background mechanism (pi) has to manufacture a terminal, and doing that
-# by SPLITTING the captain's active pane visibly shrinks it - the regression this
+# tool (claude, grok) run it there directly on most backends and it is fine.
+# claude on the herdr backend is the proven exception, NOT fine: the in-pane
+# background job leaves a footer token that herdr's own claude agent-detection
+# ruleset misreads as "working" for the life of the session, so the away-mode
+# busy guard can never read that pane idle and the daemon can never deliver an
+# escalation into it (data/firstmate-afk-daemon-wedged-investigation/report.md,
+# 2026-08-26). A harness with NO native background mechanism (pi), and claude
+# on herdr per that exception, has to manufacture a terminal, and doing that by
+# SPLITTING the captain's active pane visibly shrinks it - the regression this
 # script fixes. Instead this creates a non-visible tracked terminal (a herdr tab/
 # workspace with --no-focus, or a detached tmux session) that never touches the
 # captain's active tab, and NEVER uses shell `&` (which herdr/codex can reap).

--- a/bin/fm-afk-launch.sh
+++ b/bin/fm-afk-launch.sh
@@ -35,6 +35,8 @@
 #   fm-afk-launch.sh start-native
 #                              Prepare lifecycle state for a harness-native
 #                              background job and record that no terminal exists.
+#                              Refuses on claude+herdr (the exception above) and
+#                              points at `start`, before writing any state.
 #   fm-afk-launch.sh stop      Correct-ordered exit: SIGTERM the daemon so its
 #                              cleanup flushes WHILE state/.afk is still present,
 #                              wait for it, close the recorded terminal by exact
@@ -533,8 +535,30 @@ fm_afk_launch_start() {
   return "$result"
 }
 
+# The claude+herdr exception, enforced rather than merely documented. A claude
+# in-pane background job renders a shell token in the captain pane's footer for
+# as long as the daemon lives; herdr's own claude agent-detection ruleset maps
+# that token to "working" above its idle rule, so the away-mode busy guard reads
+# the captain pane busy forever and no escalation is ever delivered. Refuse this
+# ONE combination and name the terminal-backed path; every other harness/backend
+# pair keeps the native exception.
+fm_afk_launch_native_refused() {
+  local harness backend
+  backend=$(discover_supervisor_backend) || true
+  [ "$backend" = herdr ] || return 1
+  harness=$("$FM_AFK_LAUNCH_DIR/fm-harness.sh" 2>/dev/null) || harness=unknown
+  [ "$harness" = claude ] || return 1
+  return 0
+}
+
 fm_afk_launch_start_native() {
   local backup artifact had_afk=0 result=0
+  # Refuse BEFORE touching lifecycle state, so a refusal leaves nothing to undo.
+  if fm_afk_launch_native_refused; then
+    fm_afk_launch_log "refusing start-native on claude+herdr: a claude background shell renders in the captain pane's footer, herdr reads that as the agent working, so the away daemon defers forever and away mode silently delivers nothing"
+    fm_afk_launch_log "use 'bin/fm-afk-launch.sh start' instead (non-visible daemon terminal)"
+    return 1
+  fi
   mkdir -p "$FM_AFK_LAUNCH_STATE" || return 1
   if [ -e "$FM_AFK_LAUNCH_STATE/.afk-return-catchup" ]; then
     fm_afk_launch_log "return catch-up is still pending; run bin/fm-afk-return.sh check before re-entering away mode"

--- a/bin/fm-afk-start.sh
+++ b/bin/fm-afk-start.sh
@@ -20,13 +20,19 @@
 # This is the COMMON daemon entry for every backend. HOW it becomes a tracked
 # background process differs by harness/backend and is owned elsewhere:
 #   - Harnesses with a native in-pane tracked-background tool (e.g. claude, grok)
-#     run this directly via that tool, so the daemon inherits the captain pane's
-#     env and auto-discovers it.
-#   - Harnesses with NO native background mechanism (e.g. pi) run this THROUGH
-#     bin/fm-afk-launch.sh, which creates a non-visible tracked terminal per
-#     backend (herdr tab/workspace, tmux detached session) and passes the
-#     captain pane in as FM_SUPERVISOR_TARGET so injection targets it, not the
-#     daemon's own new pane.
+#     run this directly via that tool on most backends, so the daemon inherits
+#     the captain pane's env and auto-discovers it. EXCEPTION: claude on the
+#     herdr backend must NOT use this path - the in-pane background job leaves
+#     a footer token that herdr's own claude agent-detection ruleset misreads as
+#     "working" for the life of the session, structurally wedging the away-mode
+#     busy guard (data/firstmate-afk-daemon-wedged-investigation/report.md,
+#     2026-08-26; see .agents/skills/afk/SKILL.md for the routing rule).
+#   - Harnesses with NO native background mechanism (e.g. pi), and claude on
+#     herdr per the exception above, run this THROUGH bin/fm-afk-launch.sh,
+#     which creates a non-visible tracked terminal per backend (herdr tab/
+#     workspace, tmux detached session) and passes the captain pane in as
+#     FM_SUPERVISOR_TARGET so injection targets it, not the daemon's own new
+#     pane.
 # Do not wrap this in `nohup ... &`: Codex/herdr can reap fire-and-forget shell
 # children after the tool call returns, while a tracked background terminal stays
 # attached and has a real lifecycle.

--- a/bin/fm-afk-start.sh
+++ b/bin/fm-afk-start.sh
@@ -107,22 +107,22 @@ fm_afk_start_native_refused() {
   harness=$("$FM_AFK_START_DIR/fm-harness.sh" 2>/dev/null) || harness=unknown
   [ "$harness" = claude ] || return 1
 
-  own_backend=$(fm_afk_start_own_backend) || own_backend=''
-  own_pane=$(fm_afk_start_own_pane) || own_pane=''
-  # Deliberate: an unresolvable side means the guard cannot check itself, so it
-  # permits rather than blocks on unknown state, and says so out loud instead of
-  # permitting silently.
-  if [ -z "$own_backend" ] || [ -z "$own_pane" ]; then
-    echo "afk: cannot resolve this process's own pane (no TMUX_PANE, no HERDR_ENV+HERDR_PANE_ID), so the claude+herdr self-injection guard cannot check itself; permitting this start rather than blocking on unknown state" >&2
-    return 1
-  fi
+  # Resolve backend FIRST and narrow the "cannot check myself" diagnostic to
+  # when it is actually true: herdr provably absent (no TMUX_PANE, no
+  # HERDR_ENV+HERDR_PANE_ID) or resolved to a different backend is not
+  # ambiguity, it is proof there is nothing to warn about - permit silently.
+  own_backend=$(fm_afk_start_own_backend) || return 1
   [ "$own_backend" = herdr ] || return 1
 
-  target=$(discover_supervisor_target) || target=''
-  if [ -z "$target" ]; then
+  own_pane=$(fm_afk_start_own_pane) || {
+    echo "afk: resolved this process's own backend as herdr but could not resolve its own pane, so the claude+herdr self-injection guard cannot check itself; permitting this start rather than blocking on unknown state" >&2
+    return 1
+  }
+
+  target=$(discover_supervisor_target) || {
     echo "afk: cannot resolve the escalation injection target, so the claude+herdr self-injection guard cannot check itself; permitting this start rather than blocking on unknown state" >&2
     return 1
-  fi
+  }
 
   [ "$own_pane" = "$target" ] || return 1
   return 0
@@ -212,6 +212,17 @@ fm_afk_flag_write() {  # <state-dir>
   return 1
 }
 
+# Write (or verify) the lifecycle flag on the path that has decided to proceed.
+# Shared by the refresh and fresh branches of fm_afk_start_main so neither
+# writes it before that decision is made.
+fm_afk_start_ensure_flag() {
+  if [ "${FM_AFK_STATE_PREPARED:-0}" = 1 ]; then
+    [ -f "$FM_AFK_STATE/.afk" ] || { echo "afk: launcher-prepared state is missing" >&2; return 1; }
+  else
+    fm_afk_flag_write "$FM_AFK_STATE" || { echo "afk: failed to write away-mode flag" >&2; return 1; }
+  fi
+}
+
 fm_afk_start_main() {
   case "${1:-}" in
     '' ) ;;
@@ -219,35 +230,26 @@ fm_afk_start_main() {
     * ) echo "usage: $(basename "${BASH_SOURCE[1]:-fm-afk-start.sh}")" >&2; return 2 ;;
   esac
 
-  local had_flag=0
-  [ ! -e "$FM_AFK_STATE/.afk" ] || had_flag=1
-
   mkdir -p "$FM_AFK_STATE"
-  if [ "${FM_AFK_STATE_PREPARED:-0}" = 1 ]; then
-    [ -f "$FM_AFK_STATE/.afk" ] || { echo "afk: launcher-prepared state is missing" >&2; return 1; }
-  else
-    fm_afk_flag_write "$FM_AFK_STATE" || { echo "afk: failed to write away-mode flag" >&2; return 1; }
-  fi
 
   local pid
   pid=$(daemon_lock_pid 2>/dev/null || true)
   if daemon_lock_held_by_live_daemon; then
+    fm_afk_start_ensure_flag || return 1
     echo "afk: daemon already running pid=$pid"
     return 0
   fi
 
-  # Only a genuine FRESH start reaches the guard: a refresh of an already-live,
-  # already-safely-hosted daemon returned above untouched. Roll the away flag
-  # back when this invocation is the one that wrote it, so a refusal leaves the
-  # lifecycle exactly as it found it.
+  # Only a genuine FRESH start reaches here (a refresh of an already-live,
+  # already-safely-hosted daemon returned above, untouched). Decide BEFORE
+  # writing any lifecycle state, so a refusal leaves nothing to roll back.
   if fm_afk_start_native_refused; then
-    if [ "${FM_AFK_STATE_PREPARED:-0}" != 1 ] && [ "$had_flag" -eq 0 ]; then
-      rm -f "$FM_AFK_STATE/.afk" 2>/dev/null || true
-    fi
     echo "afk: refusing to host the away daemon in the same pane it injects into on claude+herdr: a claude background shell renders in that pane's footer, herdr reads that as the agent working, so the away daemon defers forever and away mode silently delivers nothing" >&2
     echo "afk: use 'bin/fm-afk-launch.sh start' instead (non-visible daemon terminal)" >&2
     return 1
   fi
+
+  fm_afk_start_ensure_flag || return 1
 
   if fm_pid_alive "$pid" && [ -n "$pid" ]; then
     fm_lock_remove_path "$FM_AFK_LOCK" 2>/dev/null || true

--- a/bin/fm-afk-start.sh
+++ b/bin/fm-afk-start.sh
@@ -47,9 +47,33 @@ FM_AFK_DAEMON="$FM_AFK_START_DIR/fm-supervise-daemon.sh"
 
 # shellcheck source=bin/fm-wake-lib.sh
 . "$FM_AFK_START_DIR/fm-wake-lib.sh"
+# shellcheck source=bin/fm-supervisor-target-lib.sh
+. "$FM_AFK_START_DIR/fm-supervisor-target-lib.sh"
 
 fm_afk_start_usage() {
   sed -n '2,14p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+# The claude+herdr exception, enforced here too: bin/fm-afk-launch.sh's own
+# start-native guard only covers entry THROUGH the launcher. This script is
+# also a documented direct entry point (the second half of the native two-step,
+# and a bare direct call), so the same wedge is reachable by skipping the
+# launcher entirely. Key the refusal on HOSTING MODE, not on harness+backend
+# alone: the launcher's own terminal-backed path also execs this script, but
+# does so in its OWN separate pane and always passes FM_SUPERVISOR_TARGET
+# explicitly so the daemon injects into the captain pane rather than
+# discovering its own - that explicit target is what marks a launcher-hosted,
+# already-safe invocation. Its absence means this process will auto-discover
+# ITS OWN pane as the target, i.e. it IS the pane being hosted in - the exact
+# in-pane case that wedges herdr's claude detection.
+fm_afk_start_native_refused() {
+  local harness backend
+  [ -z "${FM_SUPERVISOR_TARGET:-}" ] || return 1
+  backend=$(discover_supervisor_backend) || true
+  [ "$backend" = herdr ] || return 1
+  harness=$("$FM_AFK_START_DIR/fm-harness.sh" 2>/dev/null) || harness=unknown
+  [ "$harness" = claude ] || return 1
+  return 0
 }
 
 # fm_afk_clear_stale_artifacts: on a FRESH away-session entry (the daemon is not
@@ -142,6 +166,14 @@ fm_afk_start_main() {
     -h|--help) fm_afk_start_usage; return 0 ;;
     * ) echo "usage: $(basename "${BASH_SOURCE[1]:-fm-afk-start.sh}")" >&2; return 2 ;;
   esac
+
+  # Refuse BEFORE touching lifecycle state (before mkdir/flag-write), so a
+  # refusal leaves nothing to roll back.
+  if fm_afk_start_native_refused; then
+    echo "afk: refusing to host the away daemon in this pane on claude+herdr: a claude background shell renders in the captain pane's footer, herdr reads that as the agent working, so the away daemon defers forever and away mode silently delivers nothing" >&2
+    echo "afk: use 'bin/fm-afk-launch.sh start' instead (non-visible daemon terminal)" >&2
+    return 1
+  fi
 
   mkdir -p "$FM_AFK_STATE"
   if [ "${FM_AFK_STATE_PREPARED:-0}" = 1 ]; then

--- a/bin/fm-afk-start.sh
+++ b/bin/fm-afk-start.sh
@@ -58,21 +58,73 @@ fm_afk_start_usage() {
 # start-native guard only covers entry THROUGH the launcher. This script is
 # also a documented direct entry point (the second half of the native two-step,
 # and a bare direct call), so the same wedge is reachable by skipping the
-# launcher entirely. Key the refusal on HOSTING MODE, not on harness+backend
-# alone: the launcher's own terminal-backed path also execs this script, but
-# does so in its OWN separate pane and always passes FM_SUPERVISOR_TARGET
-# explicitly so the daemon injects into the captain pane rather than
-# discovering its own - that explicit target is what marks a launcher-hosted,
-# already-safe invocation. Its absence means this process will auto-discover
-# ITS OWN pane as the target, i.e. it IS the pane being hosted in - the exact
-# in-pane case that wedges herdr's claude detection.
+# launcher entirely.
+#
+# The hazard is PHYSICAL: the daemon hosting itself in the very pane it will
+# inject escalations into (self-injection). On claude+herdr that pane's footer
+# then carries the background-shell token for the life of the session, herdr's
+# claude detection reads it as "the agent is working", and every escalation
+# defers forever. So the signal is a same-pane comparison, not the presence of
+# any environment knob: fm_afk_start_own_pane resolves where THIS process is
+# actually running (raw $TMUX_PANE / $HERDR_ENV+$HERDR_PANE_ID, deliberately
+# ignoring the FM_SUPERVISOR_TARGET override), while discover_supervisor_target
+# resolves where injection will actually land (override first, exactly as
+# inject_msg does). The launcher's terminal-backed path stays permitted because
+# it runs in its OWN separate pane and targets the captain's - different panes,
+# no self-injection.
+#
+# fm_afk_start_own_backend / fm_afk_start_own_pane: this process's RAW identity.
+# Distinct from discover_supervisor_backend/discover_supervisor_target on
+# purpose - those answer "where do escalations go", which an operator may
+# override; these answer "where am I", which nothing may override. Both return
+# non-zero when this process is in no pane at all.
+fm_afk_start_own_backend() {
+  if [ -n "${TMUX_PANE:-}" ]; then
+    printf 'tmux'
+    return 0
+  fi
+  if [ "${HERDR_ENV:-}" = "1" ] && [ -n "${HERDR_PANE_ID:-}" ]; then
+    printf 'herdr'
+    return 0
+  fi
+  return 1
+}
+
+fm_afk_start_own_pane() {
+  if [ -n "${TMUX_PANE:-}" ]; then
+    printf '%s' "$TMUX_PANE"
+    return 0
+  fi
+  if [ "${HERDR_ENV:-}" = "1" ] && [ -n "${HERDR_PANE_ID:-}" ]; then
+    printf '%s:%s' "${HERDR_SESSION:-default}" "$HERDR_PANE_ID"
+    return 0
+  fi
+  return 1
+}
+
 fm_afk_start_native_refused() {
-  local harness backend
-  [ -z "${FM_SUPERVISOR_TARGET:-}" ] || return 1
-  backend=$(discover_supervisor_backend) || true
-  [ "$backend" = herdr ] || return 1
+  local harness own_backend own_pane target
   harness=$("$FM_AFK_START_DIR/fm-harness.sh" 2>/dev/null) || harness=unknown
   [ "$harness" = claude ] || return 1
+
+  own_backend=$(fm_afk_start_own_backend) || own_backend=''
+  own_pane=$(fm_afk_start_own_pane) || own_pane=''
+  # Deliberate: an unresolvable side means the guard cannot check itself, so it
+  # permits rather than blocks on unknown state, and says so out loud instead of
+  # permitting silently.
+  if [ -z "$own_backend" ] || [ -z "$own_pane" ]; then
+    echo "afk: cannot resolve this process's own pane (no TMUX_PANE, no HERDR_ENV+HERDR_PANE_ID), so the claude+herdr self-injection guard cannot check itself; permitting this start rather than blocking on unknown state" >&2
+    return 1
+  fi
+  [ "$own_backend" = herdr ] || return 1
+
+  target=$(discover_supervisor_target) || target=''
+  if [ -z "$target" ]; then
+    echo "afk: cannot resolve the escalation injection target, so the claude+herdr self-injection guard cannot check itself; permitting this start rather than blocking on unknown state" >&2
+    return 1
+  fi
+
+  [ "$own_pane" = "$target" ] || return 1
   return 0
 }
 
@@ -167,13 +219,8 @@ fm_afk_start_main() {
     * ) echo "usage: $(basename "${BASH_SOURCE[1]:-fm-afk-start.sh}")" >&2; return 2 ;;
   esac
 
-  # Refuse BEFORE touching lifecycle state (before mkdir/flag-write), so a
-  # refusal leaves nothing to roll back.
-  if fm_afk_start_native_refused; then
-    echo "afk: refusing to host the away daemon in this pane on claude+herdr: a claude background shell renders in the captain pane's footer, herdr reads that as the agent working, so the away daemon defers forever and away mode silently delivers nothing" >&2
-    echo "afk: use 'bin/fm-afk-launch.sh start' instead (non-visible daemon terminal)" >&2
-    return 1
-  fi
+  local had_flag=0
+  [ ! -e "$FM_AFK_STATE/.afk" ] || had_flag=1
 
   mkdir -p "$FM_AFK_STATE"
   if [ "${FM_AFK_STATE_PREPARED:-0}" = 1 ]; then
@@ -187,6 +234,19 @@ fm_afk_start_main() {
   if daemon_lock_held_by_live_daemon; then
     echo "afk: daemon already running pid=$pid"
     return 0
+  fi
+
+  # Only a genuine FRESH start reaches the guard: a refresh of an already-live,
+  # already-safely-hosted daemon returned above untouched. Roll the away flag
+  # back when this invocation is the one that wrote it, so a refusal leaves the
+  # lifecycle exactly as it found it.
+  if fm_afk_start_native_refused; then
+    if [ "${FM_AFK_STATE_PREPARED:-0}" != 1 ] && [ "$had_flag" -eq 0 ]; then
+      rm -f "$FM_AFK_STATE/.afk" 2>/dev/null || true
+    fi
+    echo "afk: refusing to host the away daemon in the same pane it injects into on claude+herdr: a claude background shell renders in that pane's footer, herdr reads that as the agent working, so the away daemon defers forever and away mode silently delivers nothing" >&2
+    echo "afk: use 'bin/fm-afk-launch.sh start' instead (non-visible daemon terminal)" >&2
+    return 1
   fi
 
   if fm_pid_alive "$pid" && [ -n "$pid" ]; then

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -295,6 +295,7 @@ Harnesses with native tracked background execution can run the daemon in their t
 Claude renders a live background shell in its own pane footer, and Herdr's Claude agent-detection ruleset reads that footer token as the agent working, at a priority that beats its idle rule.
 The busy guard trusts that native state first, so it reads the daemon's own presence as the captain pane being busy and can never deliver an escalation into it for the life of the session (`data/firstmate-afk-daemon-wedged-investigation/report.md`, 2026-08-26).
 Pi has no native background mechanism at all, and Claude on Herdr is routed the same way for the reason above.
+`bin/fm-afk-launch.sh start-native` enforces that routing rather than relying on the caller having read it: it refuses the Claude-on-Herdr pair before writing any lifecycle state and names `start` instead, covered by `tests/fm-afk-launch.test.sh`.
 `bin/fm-afk-launch.sh` therefore creates a dedicated unfocused Herdr workspace, runs the daemon there with an explicit supervisor target and backend, records the exact daemon pane, and closes only that pane on stop.
 It never splits the captain's active tab and never uses shell `&`.
 Recovery reconciles only the recorded exact id.

--- a/docs/herdr-backend.md
+++ b/docs/herdr-backend.md
@@ -291,8 +291,10 @@ It refuses Zellij, Orca, and cmux as supervisor backends rather than applying th
 For Herdr, target existence, native state, capture, composer state, and verified submit all route through the shared backend dispatcher and the explicit named-session CLI owner.
 The pane-independent max-defer alert is configured in [`wedge-alarm.md`](wedge-alarm.md).
 
-Harnesses with native tracked background execution can run the daemon in their terminal.
-Pi has no such mechanism.
+Harnesses with native tracked background execution can run the daemon in their terminal, with one proven exception: Claude must not host the away daemon this way on Herdr.
+Claude renders a live background shell in its own pane footer, and Herdr's Claude agent-detection ruleset reads that footer token as the agent working, at a priority that beats its idle rule.
+The busy guard trusts that native state first, so it reads the daemon's own presence as the captain pane being busy and can never deliver an escalation into it for the life of the session (`data/firstmate-afk-daemon-wedged-investigation/report.md`, 2026-08-26).
+Pi has no native background mechanism at all, and Claude on Herdr is routed the same way for the reason above.
 `bin/fm-afk-launch.sh` therefore creates a dedicated unfocused Herdr workspace, runs the daemon there with an explicit supervisor target and backend, records the exact daemon pane, and closes only that pane on stop.
 It never splits the captain's active tab and never uses shell `&`.
 Recovery reconciles only the recorded exact id.

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -683,18 +683,19 @@ unit_start_refuses_self_injecting_claude_on_herdr() {
   esac
   rm -rf "$st"
 
-  # (6) neither side resolvable -> permitted, but the guard says out loud that
-  # it could not check itself rather than permitting silently.
+  # (6) herdr provably absent (no TMUX_PANE, no HERDR_ENV+HERDR_PANE_ID) is not
+  # ambiguity - there is nothing the guard could have failed to check, so it
+  # permits SILENTLY rather than crying wolf on every plain claude terminal.
   st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-start-guard.XXXXXX")
   mkdir -p "$st/state"
   out=$(start_guard_run "$st" CLAUDECODE=1)
   case "$out" in
-    *'starting supervise daemon'*) pass "start guard: an unresolvable pane permits rather than blocks" ;;
-    *) fail "start guard: an unresolvable pane was refused ($out)" ;;
+    *'starting supervise daemon'*) pass "start guard: herdr provably absent permits rather than blocks" ;;
+    *) fail "start guard: herdr provably absent was refused ($out)" ;;
   esac
   case "$out" in
-    *"cannot resolve this process's own pane"*) pass "start guard: unresolvable state emits the could-not-check diagnostic" ;;
-    *) fail "start guard: unresolvable state permitted silently ($out)" ;;
+    *"cannot resolve"*) fail "start guard: herdr provably absent still emitted the could-not-check diagnostic ($out)" ;;
+    *) pass "start guard: herdr provably absent permits without the could-not-check diagnostic" ;;
   esac
   rm -rf "$st"
 }

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -705,6 +705,7 @@ unit_native_entry_preserves_prepared_state() {
   mkdir -p "$st/state"
   : > "$st/state/.afk"
   : > "$st/state/.subsuper-escalations"
+  # shellcheck disable=SC2016 # $1 is bash -c's own positional param.
   "${START_GUARD_CLEAN_ENV[@]}" FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" \
     FM_AFK_STATE_PREPARED=1 bash -c '
     . "$1"

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -558,6 +558,68 @@ unit_native_refuses_claude_on_herdr() {
   rm -rf "$st"
 }
 
+# ---------------------------------------------------------------------------
+# UNIT: bin/fm-afk-start.sh is ALSO a documented direct entry point (the
+# native two-step's second half, and a bare direct call), so the launcher's
+# own start-native guard above does not cover it - the same wedge is reachable
+# by skipping the launcher entirely. This guard is keyed on HOSTING MODE, not
+# harness+backend alone: the launcher's terminal-backed path also execs this
+# script, but always passes FM_SUPERVISOR_TARGET explicitly (a separate pane
+# injecting into the captain's), so its presence proves a safe, already-hosted
+# invocation and must stay permitted even on claude+herdr.
+# ---------------------------------------------------------------------------
+unit_start_refuses_direct_claude_on_herdr() {
+  local st out refused=0
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-start-guard.XXXXXX")
+  mkdir -p "$st/state"
+  out=$(env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u PI_CODING_AGENT -u GROK_AGENT -u TMUX_PANE \
+    -u FM_SUPERVISOR_TARGET -u FM_SUPERVISOR_BACKEND \
+    CLAUDECODE=1 HERDR_ENV=1 HERDR_PANE_ID=pane-1 FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" \
+    "$START" 2>&1) || refused=1
+  if [ "$refused" -eq 1 ] && [ ! -e "$st/state/.afk" ]; then
+    pass "start guard: direct claude+herdr entry is refused with no lifecycle state written"
+  else
+    fail "start guard: direct claude+herdr entry was accepted"
+  fi
+  case "$out" in
+    *'bin/fm-afk-launch.sh start'*) pass "start guard: refusal names the terminal-backed path" ;;
+    *) fail "start guard: refusal did not name the terminal-backed path" ;;
+  esac
+  rm -rf "$st"
+
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-start-guard.XXXXXX")
+  mkdir -p "$st/state"
+  # shellcheck disable=SC2016 # $1 is bash -c's own positional param, not this shell's.
+  out=$(env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u PI_CODING_AGENT -u GROK_AGENT -u TMUX_PANE \
+    CLAUDECODE=1 HERDR_ENV=1 HERDR_PANE_ID=pane-1 FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" \
+    FM_SUPERVISOR_TARGET=captain FM_SUPERVISOR_BACKEND=herdr bash -c '
+      . "$1"
+      FM_AFK_DAEMON=/bin/true
+      fm_afk_start_main
+    ' _ "$START" 2>&1)
+  case "$out" in
+    *'starting supervise daemon'*) pass "start guard: claude+herdr is still permitted when launcher-hosted (FM_SUPERVISOR_TARGET set)" ;;
+    *) fail "start guard: claude+herdr launcher-hosted entry was refused ($out)" ;;
+  esac
+  rm -rf "$st"
+
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-start-guard.XXXXXX")
+  mkdir -p "$st/state"
+  # shellcheck disable=SC2016 # $1 is bash -c's own positional param, not this shell's.
+  out=$(env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u CLAUDECODE -u GROK_AGENT -u TMUX_PANE \
+    -u FM_SUPERVISOR_TARGET -u FM_SUPERVISOR_BACKEND \
+    PI_CODING_AGENT=true HERDR_ENV=1 HERDR_PANE_ID=pane-1 FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" bash -c '
+      . "$1"
+      FM_AFK_DAEMON=/bin/true
+      fm_afk_start_main
+    ' _ "$START" 2>&1)
+  case "$out" in
+    *'starting supervise daemon'*) pass "start guard: a non-claude harness on herdr direct entry is still permitted" ;;
+    *) fail "start guard: a non-claude harness on herdr direct entry was refused ($out)" ;;
+  esac
+  rm -rf "$st"
+}
+
 unit_native_entry_preserves_prepared_state() {
   local st
   st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-native-entry.XXXXXX")
@@ -994,6 +1056,7 @@ unit_readiness_failure_preserves_unconfirmed_record
 unit_tmux_absence_distinguishes_probe_failure
 unit_native_lifecycle
 unit_native_refuses_claude_on_herdr
+unit_start_refuses_direct_claude_on_herdr
 unit_native_entry_preserves_prepared_state
 unit_close_failure_preserves_record
 unit_record_publication_atomic

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -488,7 +488,8 @@ unit_native_lifecycle() {
   st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-native.XXXXXX")
   mkdir -p "$st/state"
   : > "$st/state/.subsuper-escalations"
-  if FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" "$LAUNCH" start-native >/dev/null 2>&1 \
+  if FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" FM_SUPERVISOR_BACKEND=tmux \
+    "$LAUNCH" start-native >/dev/null 2>&1 \
     && [ "$(cut -f1 "$st/state/.afk-daemon-terminal")" = none ] \
     && [ -e "$st/state/.afk" ] \
     && [ ! -e "$st/state/.subsuper-escalations" ]; then
@@ -501,6 +502,58 @@ unit_native_lifecycle() {
     pass "native lifecycle: uniform stop clears state without closing a terminal"
   else
     fail "native lifecycle: uniform stop retained state"
+  fi
+  rm -rf "$st"
+}
+
+# Regression for the 95-minute wedged away session: claude hosting the daemon in
+# its own pane on herdr leaves a footer shell token that herdr reports as
+# "working", so the busy guard never sees the captain pane idle. The launcher
+# must refuse exactly that pair, write no lifecycle state when it does, and keep
+# permitting every neighbouring pair.
+unit_native_refuses_claude_on_herdr() {
+  local st out refused=0
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-native-guard.XXXXXX")
+  mkdir -p "$st/state"
+
+  out=$(env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u PI_CODING_AGENT -u GROK_AGENT \
+    CLAUDECODE=1 FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" \
+    FM_SUPERVISOR_TARGET=captain FM_SUPERVISOR_BACKEND=herdr \
+    "$LAUNCH" start-native 2>&1) || refused=1
+  if [ "$refused" -eq 1 ] && [ ! -e "$st/state/.afk" ] && [ ! -e "$st/state/.afk-daemon-terminal" ]; then
+    pass "native guard: claude+herdr is refused with no lifecycle state written"
+  else
+    fail "native guard: claude+herdr native launch was accepted"
+  fi
+  case "$out" in
+    *'bin/fm-afk-launch.sh start'*) pass "native guard: refusal names the terminal-backed path" ;;
+    *) fail "native guard: refusal did not name the terminal-backed path" ;;
+  esac
+
+  rm -rf "$st"
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-native-guard.XXXXXX")
+  mkdir -p "$st/state"
+  if env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u PI_CODING_AGENT -u GROK_AGENT \
+    CLAUDECODE=1 FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" \
+    FM_SUPERVISOR_TARGET=captain FM_SUPERVISOR_BACKEND=tmux \
+    "$LAUNCH" start-native >/dev/null 2>&1 \
+    && [ "$(cut -f1 "$st/state/.afk-daemon-terminal")" = none ]; then
+    pass "native guard: claude on a non-herdr backend is still permitted"
+  else
+    fail "native guard: claude on a non-herdr backend was refused"
+  fi
+
+  rm -rf "$st"
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-native-guard.XXXXXX")
+  mkdir -p "$st/state"
+  if env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u CLAUDECODE -u GROK_AGENT \
+    PI_CODING_AGENT=true FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" \
+    FM_SUPERVISOR_TARGET=captain FM_SUPERVISOR_BACKEND=herdr \
+    "$LAUNCH" start-native >/dev/null 2>&1 \
+    && [ "$(cut -f1 "$st/state/.afk-daemon-terminal")" = none ]; then
+    pass "native guard: a non-claude harness on herdr is still permitted"
+  else
+    fail "native guard: a non-claude harness on herdr was refused"
   fi
   rm -rf "$st"
 }
@@ -759,7 +812,7 @@ unit_clear_failure_aborts_entry() {
   st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-clear-fail.XXXXXX")
   mkdir -p "$st/state"
   : > "$st/state/.subsuper-escalations"
-  if FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" bash -c '
+  if FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" FM_SUPERVISOR_BACKEND=tmux bash -c '
     . "$1"
     fm_afk_launch_reconcile() { return 0; }
     fm_afk_clear_stale_artifacts() { return 1; }
@@ -812,7 +865,7 @@ unit_flag_write_failure_aborts() {
   local st
   st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-flag-fail.XXXXXX")
   mkdir -p "$st/state"
-  FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" bash -c '
+  FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" FM_SUPERVISOR_BACKEND=tmux bash -c '
     . "$1"
     fm_afk_launch_flag_write() { return 1; }
     ! fm_afk_launch_start_native
@@ -940,6 +993,7 @@ unit_readiness_failure_rolls_back_terminal
 unit_readiness_failure_preserves_unconfirmed_record
 unit_tmux_absence_distinguishes_probe_failure
 unit_native_lifecycle
+unit_native_refuses_claude_on_herdr
 unit_native_entry_preserves_prepared_state
 unit_close_failure_preserves_record
 unit_record_publication_atomic

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -40,6 +40,14 @@ GLOBAL_CLEANUP() {
 }
 trap GLOBAL_CLEANUP EXIT
 
+# bin/fm-afk-start.sh refuses a start that would host the away daemon in the very
+# pane it injects into. Every test below that runs its main is about something
+# else, so they pin a neutral identity - no harness marker, no pane manager -
+# instead of inheriting the test runner's real captain session.
+START_GUARD_CLEAN_ENV=(env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u CLAUDECODE -u PI_CODING_AGENT
+  -u GROK_AGENT -u TMUX_PANE -u FM_SUPERVISOR_TARGET -u FM_SUPERVISOR_BACKEND
+  -u HERDR_ENV -u HERDR_PANE_ID -u HERDR_SESSION)
+
 # ---------------------------------------------------------------------------
 # UNIT 1: fm_afk_clear_stale_artifacts removes exactly the three stale artifacts.
 # ---------------------------------------------------------------------------
@@ -136,7 +144,7 @@ unit_fresh_vs_refresh() {
   mkdir -p "$lock"
   printf '%s' "$sleep_pid" > "$lock/pid"
   ( . "$ROOT/bin/fm-wake-lib.sh"; fm_pid_identity "$sleep_pid" > "$lock/pid-identity" 2>/dev/null ) || true
-  FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" "$START" >/dev/null 2>&1
+  "${START_GUARD_CLEAN_ENV[@]}" FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" "$START" >/dev/null 2>&1
   if [ -e "$st/state/.subsuper-escalations" ] && [ -e "$st/state/.subsuper-inject-wedged" ]; then
     pass "refresh: daemon already alive - stale artifacts preserved (current session's buffer kept)"
   else
@@ -572,9 +580,6 @@ unit_native_refuses_claude_on_herdr() {
 # comparison is where-am-I vs where-does-injection-land, never the mere
 # presence of a documented env knob.
 # ---------------------------------------------------------------------------
-START_GUARD_CLEAN_ENV=(env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u CLAUDECODE -u PI_CODING_AGENT
-  -u GROK_AGENT -u TMUX_PANE -u FM_SUPERVISOR_TARGET -u FM_SUPERVISOR_BACKEND
-  -u HERDR_ENV -u HERDR_PANE_ID -u HERDR_SESSION)
 
 # Run fm_afk_start_main in a child shell with a harmless daemon stand-in, so a
 # PERMITTED start is observable as its own announcement rather than by execing
@@ -700,7 +705,8 @@ unit_native_entry_preserves_prepared_state() {
   mkdir -p "$st/state"
   : > "$st/state/.afk"
   : > "$st/state/.subsuper-escalations"
-  FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" FM_AFK_STATE_PREPARED=1 bash -c '
+  "${START_GUARD_CLEAN_ENV[@]}" FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" \
+    FM_AFK_STATE_PREPARED=1 bash -c '
     . "$1"
     FM_AFK_DAEMON=/bin/true
     fm_afk_start_main

--- a/tests/fm-afk-launch.test.sh
+++ b/tests/fm-afk-launch.test.sh
@@ -562,60 +562,134 @@ unit_native_refuses_claude_on_herdr() {
 # UNIT: bin/fm-afk-start.sh is ALSO a documented direct entry point (the
 # native two-step's second half, and a bare direct call), so the launcher's
 # own start-native guard above does not cover it - the same wedge is reachable
-# by skipping the launcher entirely. This guard is keyed on HOSTING MODE, not
-# harness+backend alone: the launcher's terminal-backed path also execs this
-# script, but always passes FM_SUPERVISOR_TARGET explicitly (a separate pane
-# injecting into the captain's), so its presence proves a safe, already-hosted
-# invocation and must stay permitted even on claude+herdr.
+# by skipping the launcher entirely. The signal is PHYSICAL: refuse only when
+# this process's OWN pane (raw $TMUX_PANE / $HERDR_ENV+$HERDR_PANE_ID) is the
+# very pane escalations will be injected into (discover_supervisor_target,
+# which honours the FM_SUPERVISOR_TARGET override). Same pane on claude+herdr
+# means the daemon hosts itself in the pane it drives - the wedge. Different
+# panes (the launcher's own separate terminal targeting the captain's) stay
+# permitted, and so does an operator override pointing somewhere else: the
+# comparison is where-am-I vs where-does-injection-land, never the mere
+# presence of a documented env knob.
 # ---------------------------------------------------------------------------
-unit_start_refuses_direct_claude_on_herdr() {
-  local st out refused=0
+START_GUARD_CLEAN_ENV=(env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u CLAUDECODE -u PI_CODING_AGENT
+  -u GROK_AGENT -u TMUX_PANE -u FM_SUPERVISOR_TARGET -u FM_SUPERVISOR_BACKEND
+  -u HERDR_ENV -u HERDR_PANE_ID -u HERDR_SESSION)
+
+# Run fm_afk_start_main in a child shell with a harmless daemon stand-in, so a
+# PERMITTED start is observable as its own announcement rather than by execing
+# the real daemon. Prints combined output; returns the real exit status.
+start_guard_run() {  # <state-dir> <env assignment>...
+  local st=$1; shift
+  # shellcheck disable=SC2016 # $1 is bash -c's own positional param.
+  "${START_GUARD_CLEAN_ENV[@]}" FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" "$@" bash -c '
+    . "$1"
+    FM_AFK_DAEMON=/bin/true
+    fm_afk_start_main
+  ' _ "$START" 2>&1
+}
+
+unit_start_refuses_self_injecting_claude_on_herdr() {
+  local st out status
+
+  # (1) claude+herdr, own pane IS the injection target -> refused, and no
+  # lifecycle state left behind.
   st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-start-guard.XXXXXX")
   mkdir -p "$st/state"
-  out=$(env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u PI_CODING_AGENT -u GROK_AGENT -u TMUX_PANE \
-    -u FM_SUPERVISOR_TARGET -u FM_SUPERVISOR_BACKEND \
-    CLAUDECODE=1 HERDR_ENV=1 HERDR_PANE_ID=pane-1 FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" \
-    "$START" 2>&1) || refused=1
-  if [ "$refused" -eq 1 ] && [ ! -e "$st/state/.afk" ]; then
-    pass "start guard: direct claude+herdr entry is refused with no lifecycle state written"
+  status=0
+  out=$(start_guard_run "$st" CLAUDECODE=1 HERDR_ENV=1 HERDR_PANE_ID=pane-1) || status=$?
+  if [ "$status" -ne 0 ] && [ ! -e "$st/state/.afk" ]; then
+    pass "start guard: claude+herdr self-injection is refused with no lifecycle state left behind"
   else
-    fail "start guard: direct claude+herdr entry was accepted"
+    fail "start guard: claude+herdr self-injection was accepted ($out)"
   fi
   case "$out" in
     *'bin/fm-afk-launch.sh start'*) pass "start guard: refusal names the terminal-backed path" ;;
-    *) fail "start guard: refusal did not name the terminal-backed path" ;;
+    *) fail "start guard: refusal did not name the terminal-backed path ($out)" ;;
   esac
   rm -rf "$st"
 
+  # (2) claude+herdr, launcher-placed separate terminal: own pane differs from
+  # the captain pane it injects into -> permitted (not a blanket block).
   st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-start-guard.XXXXXX")
   mkdir -p "$st/state"
-  # shellcheck disable=SC2016 # $1 is bash -c's own positional param, not this shell's.
-  out=$(env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u PI_CODING_AGENT -u GROK_AGENT -u TMUX_PANE \
-    CLAUDECODE=1 HERDR_ENV=1 HERDR_PANE_ID=pane-1 FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" \
-    FM_SUPERVISOR_TARGET=captain FM_SUPERVISOR_BACKEND=herdr bash -c '
-      . "$1"
-      FM_AFK_DAEMON=/bin/true
-      fm_afk_start_main
-    ' _ "$START" 2>&1)
+  out=$(start_guard_run "$st" CLAUDECODE=1 HERDR_ENV=1 HERDR_PANE_ID=daemon-pane \
+    FM_SUPERVISOR_TARGET=default:captain-pane FM_SUPERVISOR_BACKEND=herdr)
   case "$out" in
-    *'starting supervise daemon'*) pass "start guard: claude+herdr is still permitted when launcher-hosted (FM_SUPERVISOR_TARGET set)" ;;
-    *) fail "start guard: claude+herdr launcher-hosted entry was refused ($out)" ;;
+    *'starting supervise daemon'*) pass "start guard: claude+herdr in the launcher's own separate pane is permitted" ;;
+    *) fail "start guard: launcher-hosted claude+herdr entry was refused ($out)" ;;
   esac
   rm -rf "$st"
 
+  # (3) claude+herdr with a hand-set FM_SUPERVISOR_TARGET pointing at a pane
+  # this process is NOT running in -> permitted: no self-injection.
   st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-start-guard.XXXXXX")
   mkdir -p "$st/state"
-  # shellcheck disable=SC2016 # $1 is bash -c's own positional param, not this shell's.
-  out=$(env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u CLAUDECODE -u GROK_AGENT -u TMUX_PANE \
-    -u FM_SUPERVISOR_TARGET -u FM_SUPERVISOR_BACKEND \
-    PI_CODING_AGENT=true HERDR_ENV=1 HERDR_PANE_ID=pane-1 FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" bash -c '
+  out=$(start_guard_run "$st" CLAUDECODE=1 HERDR_ENV=1 HERDR_PANE_ID=pane-1 \
+    FM_SUPERVISOR_TARGET=default:some-other-pane)
+  case "$out" in
+    *'starting supervise daemon'*) pass "start guard: an override naming a different pane is permitted" ;;
+    *) fail "start guard: an override naming a different pane was refused ($out)" ;;
+  esac
+  rm -rf "$st"
+
+  # (3b) the same documented override pointed AT this process's own pane is
+  # still refused: the comparison is physical, not override-presence-based.
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-start-guard.XXXXXX")
+  mkdir -p "$st/state"
+  status=0
+  out=$(start_guard_run "$st" CLAUDECODE=1 HERDR_ENV=1 HERDR_PANE_ID=pane-1 \
+    FM_SUPERVISOR_TARGET=default:pane-1 FM_SUPERVISOR_BACKEND=herdr) || status=$?
+  if [ "$status" -ne 0 ] && [ ! -e "$st/state/.afk" ]; then
+    pass "start guard: an override naming this process's own pane is still refused"
+  else
+    fail "start guard: an operator-set override reopened the self-injection wedge ($out)"
+  fi
+  rm -rf "$st"
+
+  # (4) a non-claude primary in the same pane -> permitted: only claude's
+  # footer token wedges herdr's detection.
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-start-guard.XXXXXX")
+  mkdir -p "$st/state"
+  out=$(start_guard_run "$st" PI_CODING_AGENT=true HERDR_ENV=1 HERDR_PANE_ID=pane-1)
+  case "$out" in
+    *'starting supervise daemon'*) pass "start guard: a non-claude harness in the same pane is permitted" ;;
+    *) fail "start guard: a non-claude harness in the same pane was refused ($out)" ;;
+  esac
+  rm -rf "$st"
+
+  # (5) a refresh of an already-live daemon takes the existing refresh path
+  # untouched: nothing is being started, so nothing is refused.
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-start-guard.XXXXXX")
+  mkdir -p "$st/state"
+  status=0
+  # shellcheck disable=SC2016 # $1 is bash -c's own positional param.
+  out=$("${START_GUARD_CLEAN_ENV[@]}" CLAUDECODE=1 HERDR_ENV=1 HERDR_PANE_ID=pane-1 \
+    FM_HOME="$st" FM_STATE_OVERRIDE="$st/state" bash -c '
       . "$1"
       FM_AFK_DAEMON=/bin/true
+      daemon_lock_pid() { echo 4242; }
+      daemon_lock_held_by_live_daemon() { return 0; }
       fm_afk_start_main
-    ' _ "$START" 2>&1)
+    ' _ "$START" 2>&1) || status=$?
+  case "$status:$out" in
+    0*'daemon already running pid=4242'*) pass "start guard: a refresh of a live daemon takes the refresh path, not the refusal" ;;
+    *) fail "start guard: a refresh of a live daemon was refused (status=$status) ($out)" ;;
+  esac
+  rm -rf "$st"
+
+  # (6) neither side resolvable -> permitted, but the guard says out loud that
+  # it could not check itself rather than permitting silently.
+  st=$(mktemp -d "${TMPDIR:-/tmp}/fm-afk-start-guard.XXXXXX")
+  mkdir -p "$st/state"
+  out=$(start_guard_run "$st" CLAUDECODE=1)
   case "$out" in
-    *'starting supervise daemon'*) pass "start guard: a non-claude harness on herdr direct entry is still permitted" ;;
-    *) fail "start guard: a non-claude harness on herdr direct entry was refused ($out)" ;;
+    *'starting supervise daemon'*) pass "start guard: an unresolvable pane permits rather than blocks" ;;
+    *) fail "start guard: an unresolvable pane was refused ($out)" ;;
+  esac
+  case "$out" in
+    *"cannot resolve this process's own pane"*) pass "start guard: unresolvable state emits the could-not-check diagnostic" ;;
+    *) fail "start guard: unresolvable state permitted silently ($out)" ;;
   esac
   rm -rf "$st"
 }
@@ -1056,7 +1130,7 @@ unit_readiness_failure_preserves_unconfirmed_record
 unit_tmux_absence_distinguishes_probe_failure
 unit_native_lifecycle
 unit_native_refuses_claude_on_herdr
-unit_start_refuses_direct_claude_on_herdr
+unit_start_refuses_self_injecting_claude_on_herdr
 unit_native_entry_preserves_prepared_state
 unit_close_failure_preserves_record
 unit_record_publication_atomic

--- a/tests/fm-afk-return.test.sh
+++ b/tests/fm-afk-return.test.sh
@@ -241,7 +241,8 @@ test_away_reentry_refuses_pending_return_gate() {
   mkdir -p "$dir/home/state" "$dir/home/data" "$dir/home/config"
   printf 'schema\tfm-afk-return.v1\nphase\tblocked\n' > "$dir/home/state/.afk-return-catchup"
   set +e
-  out=$(FM_HOME="$dir/home" FM_STATE_OVERRIDE="$dir/home/state" "$ROOT/bin/fm-afk-launch.sh" start-native 2>&1)
+  out=$(FM_HOME="$dir/home" FM_STATE_OVERRIDE="$dir/home/state" FM_SUPERVISOR_BACKEND=tmux \
+    "$ROOT/bin/fm-afk-launch.sh" start-native 2>&1)
   rc=$?
   set -e
   [ "$rc" -ne 0 ] || fail "away re-entry succeeded while return catch-up was pending"

--- a/tests/fm-daemon.test.sh
+++ b/tests/fm-daemon.test.sh
@@ -12,6 +12,14 @@ set -u
 
 DAEMON="$ROOT/bin/fm-supervise-daemon.sh"
 AFK_START="$ROOT/bin/fm-afk-start.sh"
+# fm-afk-start.sh reads the AMBIENT pane and harness environment to decide whether
+# a start would host the daemon in the pane it injects into. These tests are about
+# lock/pidfile reclamation, not that guard, so pin a neutral identity: no harness
+# marker and no pane manager, which the test runner would otherwise inherit from a
+# real captain session.
+AFK_START_ENV=(env -u CURSOR_AGENT -u CURSOR_INVOKED_AS -u CLAUDECODE -u PI_CODING_AGENT
+  -u GROK_AGENT -u TMUX_PANE -u HERDR_ENV -u HERDR_PANE_ID -u HERDR_SESSION
+  -u FM_SUPERVISOR_TARGET)
 # Source the daemon's pure functions once. Its main loop is skipped under sourcing
 # via a BASH_SOURCE guard, so only classify_*/housekeeping/escalate_*/afk_* and the
 # pane/submit helpers become defined.
@@ -31,7 +39,7 @@ test_afk_start_refuses_when_flag_cannot_be_written() {
   state="$dir/state"
   mkdir -p "$state/.afk"
 
-  out=$(FM_STATE_OVERRIDE="$state" FM_SUPERVISOR_BACKEND=unsupported "$AFK_START" 2>&1)
+  out=$("${AFK_START_ENV[@]}" FM_STATE_OVERRIDE="$state" FM_SUPERVISOR_BACKEND=unsupported "$AFK_START" 2>&1)
   status=$?
 
   [ "$status" -ne 0 ] || fail "fm-afk-start.sh should fail when state/.afk cannot be written"
@@ -46,7 +54,7 @@ test_afk_start_ignores_stale_pidfile_without_lock() {
   state="$dir/state"
   printf '%s\n' "$$" > "$state/.supervise-daemon.pid"
 
-  out=$(FM_STATE_OVERRIDE="$state" FM_SUPERVISOR_BACKEND=unsupported "$AFK_START" 2>&1)
+  out=$("${AFK_START_ENV[@]}" FM_STATE_OVERRIDE="$state" FM_SUPERVISOR_BACKEND=unsupported "$AFK_START" 2>&1)
   status=$?
 
   [ "$status" -ne 0 ] || fail "fm-afk-start.sh should attempt daemon startup instead of trusting a pidfile-only live pid"
@@ -66,7 +74,7 @@ test_afk_start_reclaims_stale_daemon_lock_reused_pid() {
   printf '%s\n' "$$" > "$lock/pid"
   printf '%s\n' "stale daemon identity" > "$lock/pid-identity"
 
-  out=$(FM_STATE_OVERRIDE="$state" FM_SUPERVISOR_BACKEND=unsupported "$AFK_START" 2>&1)
+  out=$("${AFK_START_ENV[@]}" FM_STATE_OVERRIDE="$state" FM_SUPERVISOR_BACKEND=unsupported "$AFK_START" 2>&1)
   status=$?
 
   [ "$status" -ne 0 ] || fail "fm-afk-start.sh should attempt daemon startup after rejecting a reused-pid lock"


### PR DESCRIPTION
## Intent

Fix a real bug where a Claude-primary + herdr away-mode setup silently never runs the away-mode daemon. The invariant: the daemon must never inject escalations into the very pane it is itself hosted in, on a claude primary under herdr - that self-injection is the wedge (a claude background shell renders a footer token herdr's claude-detection reads as 'the agent is working', so escalations defer forever). The fix (1) routes claude+herdr through the terminal-backed launcher in .agents/skills/afk/SKILL.md, (2) updates docs/herdr-backend.md to state the exception in its own voice, (3) enforces a guard in bin/fm-afk-launch.sh's start-native path refusing claude+herdr entirely (that path is always same-pane by definition), and (4) enforces a second guard in bin/fm-afk-start.sh's own direct entry point - since that script is also a documented direct entry point the launcher's guard alone does not cover - keyed on comparing this process's own raw pane (ignoring the FM_SUPERVISOR_TARGET override) against the actual injection target (which does honor that override): same pane on claude+herdr is refused, different panes (the launcher's own separate terminal, or an operator override pointing elsewhere) stay permitted. A direct claude+herdr entry that manually sets FM_SUPERVISOR_TARGET to a pane other than where it is actually running is deliberately PERMITTED - that is the case distinguishing this design from a simpler 'is FM_SUPERVISOR_TARGET set' signal, which review proved could be fooled in both directions. The guard decides before writing any lifecycle state (so a refusal leaves nothing to roll back) and stays silent when herdr is provably absent (only warns when herdr is confirmed present and the pane comparison itself cannot be completed). CI cannot run on this PR: GitHub holds workflow runs from a first-time fork contributor at action_required until a repo maintainer approves them, which is expected and accepted on this repo - the finish line is PR open, correct, and carrying the no-mistakes attestation over the actual current head, not green CI. PR 3100 is already open on this branch against https://github.com/kunchenguid/firstmate, pushed via the fork https://github.com/NicholasACTran/firstmate.git (captain-approved via no-mistakes init --fork-url, since this machine's GitHub account is pull-only on origin).

## What Changed

- Route claude on the herdr backend away from the harness-native in-pane daemon path: `.agents/skills/afk/SKILL.md` now sends that pair to the terminal-backed `bin/fm-afk-launch.sh start`, and `docs/herdr-backend.md` states the exception and its enforcement in its own voice. A claude background shell leaves a footer token that herdr's claude agent-detection ruleset reads as "the agent is working", so the away-mode busy guard defers every escalation for the life of the session.
- Enforce that routing in code rather than in prose. `bin/fm-afk-launch.sh start_native` refuses the claude+herdr pair outright (that path is same-pane by definition), and `bin/fm-afk-start.sh` adds a second guard for its own direct entry point, keyed on comparing this process's raw pane (`fm_afk_start_own_backend`/`fm_afk_start_own_pane`, which ignore `FM_SUPERVISOR_TARGET`) against the real injection target from `discover_supervisor_target` (which honors it). Same pane on claude+herdr is refused; the launcher's separate pane and an override naming a different pane stay permitted. Both guards decide before any lifecycle state is written, and the start guard stays silent unless herdr is confirmed present but the pane comparison cannot complete.
- Split lifecycle-flag writing into `fm_afk_start_ensure_flag` so the refresh and fresh-start branches each write it only after deciding to proceed, and extend `tests/fm-afk-launch.test.sh` with cases covering refusal-with-no-state-written, the refusal message naming `start`, claude on non-herdr, non-claude on herdr, launcher-hosted entry, and both override directions; `tests/fm-afk-return.test.sh` and `tests/fm-daemon.test.sh` pin backend/pane env at affected call sites so the new guards do not fire on ambient environment.

## Risk Assessment

✅ Low: The change adds a narrowly-keyed same-pane refusal at the single exec chokepoint for the away daemon, correctly permits every launcher-hosted and non-claude/non-herdr path I traced, writes no lifecycle state on refusal, and is covered by behavior-executing tests whose ambient-environment pinning is load-bearing on the right variables; the three remaining findings are informational (dead diagnostic branches, an over-stated comment on the refresh carve-out, and a knob-honoring launcher guard whose residue is recoverable via `stop`).

## Testing

I ran the three test files the change touches (fm-afk-launch, fm-afk-return, fm-daemon) and all pass, then proved the two new guard tests are real regressions by running the new test file against the base commit, where the claude+herdr refusal assertions fail exactly as the bug describes. For product-level evidence I drove the actual user scenario on a live herdr session: as a Claude captain in a real herdr pane, `bin/fm-afk-launch.sh start-native` and a direct `bin/fm-afk-start.sh` both refuse with the wedge explanation and point at `bin/fm-afk-launch.sh start`, leaving the state directory completely empty (nothing to roll back), while the prescribed `start` path succeeds and places the daemon in a separate non-visible workspace (workspaces 1 to 2, captain tab pane count unchanged at 1, daemon tab w2:t1 vs captain tab w1:t1), and running `bin/fm-afk-start.sh` from that daemon pane is permitted since it is a different pane from the injection target. `stop` restores the original topology and clears state. This is a shell/CLI surface with no rendered UI, so the evidence is a CLI transcript rather than a screenshot.

<details>
<summary>Evidence: Claude captain on a real herdr session: refusal at both entry points, then successful terminal-backed away-mode entry</summary>

Source: [Claude captain on a real herdr session: refusal at both entry points, then successful terminal-backed away-mode entry](https://github.com/NicholasACTran/firstmate/blob/fbaecf6ff91eab28eeec64bce7307add312bed60/.no-mistakes/evidence/fm/firstmate-afk-launch-fix-land-locally-v2/claude-herdr-away-mode-e2e.md)

```text
# Real herdr session: Claude captain enters away mode

Live herdr lab session `fm-lab-afk-evidence-17389`; captain pane `w1:p1` (workspace w1).
The shell below runs AS the captain: HERDR_ENV=1, HERDR_PANE_ID=w1:p1, CLAUDECODE=1.

## Step 1 - the old native two-step is now refused
`` `
$ bin/fm-afk-launch.sh start-native
fm-afk-launch: refusing start-native on claude+herdr: a claude background shell renders in the captain pane's footer, herdr reads that as the agent working, so the away daemon defers forever and away mode silently delivers nothing
fm-afk-launch: use 'bin/fm-afk-launch.sh start' instead (non-visible daemon terminal)
exit=1
$ ls -A state/
(empty - no lifecycle state written)
`` `

## Step 2 - the direct daemon entry point refuses the same self-injection
`` `
$ FM_AFK_STATE_PREPARED=1 bin/fm-afk-start.sh
afk: refusing to host the away daemon in the same pane it injects into on claude+herdr: a claude background shell renders in that pane's footer, herdr reads that as the agent working, so the away daemon defers forever and away mode silently delivers nothing
afk: use 'bin/fm-afk-launch.sh start' instead (non-visible daemon terminal)
exit=1
$ ls -A state/
(still empty - away mode never half-entered)
`` `

## Step 3 - the prescribed path: bin/fm-afk-launch.sh start
`` `
$ bin/fm-afk-launch.sh start
fm-afk-launch: daemon launched in non-visible herdr workspace w2 (pane fm-lab-afk-evidence-17389:w2:p1), supervising fm-lab-afk-evidence-17389:w1:p1
exit=0
$ cat state/.afk-daemon-terminal
herdr	fm-lab-afk-evidence-17389:w2:p1	w2
$ ls -A state/
.afk
.afk-daemon-terminal
`` `

| observation | before | after start |
| --- | --- | --- |
| herdr workspaces in session | 1 | 2 |
| panes in the captain's tab | 1 | 1 |

Daemon terminal: `fm-lab-afk-evidence-17389:w2:p1` in tab `w2:t1`; captain tab is `w1:t1` - a different tab, so the daemon is NOT hosted in the pane it injects into.

## Step 4 - the daemon pane itself may run fm-afk-start.sh (different pane, permitted)
`` `
$ FM_AFK_STATE_PREPARED=1 bin/fm-afk-start.sh   # run from the daemon pane
afk: starting supervise daemon in foreground; keep this command as a tracked background session
exit=0
`` `

## Step 5 - stop restores the topology
`` `
$ bin/fm-afk-launch.sh stop
fm-afk-launch: away mode stopped; daemon terminal torn down and .afk cleared
exit=0
`` `

After stop: workspaces=1 (was 1), captain tab panes=1 (was 1), state/ = 
```
</details>
<details>
<summary>Evidence: Guard assertions fail on base 07bf0c8, pass on target b1cd4ec</summary>

```text
# base 07bf0c8 (pre-fix), new tests/fm-afk-launch.test.sh
not ok - native guard: claude+herdr native launch was accepted
not ok - native guard: refusal did not name the terminal-backed path
not ok - start guard: claude+herdr self-injection was accepted (afk: starting supervise daemon in foreground; ...)
not ok - start guard: refusal did not name the terminal-backed path
not ok - start guard: an operator-set override reopened the self-injection wedge

# target b1cd4ec
ok - native guard: claude+herdr is refused with no lifecycle state written
ok - native guard: refusal names the terminal-backed path
ok - native guard: claude on a non-herdr backend is still permitted
ok - native guard: a non-claude harness on herdr is still permitted
ok - start guard: claude+herdr self-injection is refused with no lifecycle state left behind
ok - start guard: refusal names the terminal-backed path
ok - start guard: claude+herdr in the launcher's own separate pane is permitted
ok - start guard: an override naming a different pane is permitted
ok - start guard: an override naming this process's own pane is still refused
ok - start guard: a non-claude harness in the same pane is permitted
ok - start guard: a refresh of a live daemon takes the refresh path, not the refusal
ok - start guard: herdr provably absent permits rather than blocks
ok - start guard: herdr provably absent permits without the could-not-check diagnostic
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"b1cd4ecf71e9dde587fc61840b4b00f733fe39c5","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 3 infos</summary>

- ℹ️ `bin/fm-afk-start.sh:117` - Both &#34;cannot check itself&#34; diagnostics in fm_afk_start_native_refused are unreachable, so the guard can never warn. Control reaches line 117 only when own_backend == herdr, which by fm_afk_start_own_backend (lines 81-91) requires TMUX_PANE empty AND HERDR_ENV=1 AND HERDR_PANE_ID non-empty. fm_afk_start_own_pane (lines 93-103) tests the identical two conditions, so it always takes its herdr branch and returns 0 - the line 118 message is dead. discover_supervisor_target under the same state returns 0 via the override branch or the HERDR_ENV+HERDR_PANE_ID compose branch, so the line 123 message is dead too (round 3 already noted this one as no-op). Net effect on the intent&#39;s phrase &#34;only warns when herdr is confirmed present and the pane comparison itself cannot be completed&#34;: that warning never fires, and the one genuinely ambiguous state - HERDR_ENV=1 with HERDR_PANE_ID unset or empty - is classified by fm_afk_start_own_backend as &#34;herdr provably absent&#34; and permitted silently at line 114. Since own_backend and own_pane branch on identical predicates, fm_afk_start_own_backend plus the line 117-120 block could collapse into a single own_pane resolve. Noted so a future reader does not treat either message as a live failure mode; the user has already ruled twice on this diagnostic surface.
- ℹ️ `bin/fm-afk-start.sh:243` - The comment at line 243 asserts the refresh branch above it returned &#34;a refresh of an already-live, already-safely-hosted daemon&#34;. The &#34;already-safely-hosted&#34; half is not established by anything the code checks: daemon_lock_held_by_live_daemon only proves a live daemon owns the lock, not where it is hosted. Concrete state - the exact one on the machine this fix targets - a claude+herdr captain that entered away mode before this change and is running the self-hosted, wedged in-pane daemon right now. Re-running /afk takes bin/fm-afk-launch.sh start, whose own refresh branch (bin/fm-afk-launch.sh:483-491) also returns 0 with &#34;daemon already running; refreshed away-mode flag&#34;; a bare bin/fm-afk-start.sh returns 0 at line 239. Neither guard fires, so the wedged daemon survives and away mode keeps silently delivering nothing until it dies. Refusing the refresh would not unwedge it either, so this is not obviously the wrong behavior - but the fix only takes effect on a genuinely fresh start, meaning verifying it on the reporting machine requires bin/fm-afk-launch.sh stop before bin/fm-afk-launch.sh start. Worth knowing before the fix is validated live; the comment&#39;s premise should not be read as a checked invariant.
- ℹ️ `bin/fm-afk-launch.sh:547` - fm_afk_launch_native_refused keys on discover_supervisor_backend, which honors the FM_SUPERVISOR_BACKEND override, while the sibling guard in bin/fm-afk-start.sh:114 deliberately reads the raw HERDR_ENV/HERDR_PANE_ID identity precisely because review proved an env-knob signal can be fooled in both directions. Concrete path on a real claude+herdr captain: `FM_SUPERVISOR_BACKEND=tmux bin/fm-afk-launch.sh start-native` resolves backend=tmux, is permitted, and proceeds to clear stale artifacts, write state/.afk, and write a `none\t-\tnative` terminal record - and tests/fm-afk-launch.test.sh:544-553 pins that permit as correct. The wedge itself stays unreachable because the second step (fm-afk-start.sh) ignores that override and refuses on the raw same-pane comparison, so this is not a hole in the invariant. The residue is that the operator is left holding prepared lifecycle state and a terminal record for a daemon that can never start, requiring bin/fm-afk-launch.sh stop to roll back, where a raw-identity keying in the launcher would have refused before writing anything. Requires an unusual manual override, so low practical exposure.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-afk-launch.test.sh` (65 assertions, includes the new `unit_native_refuses_claude_on_herdr` and `unit_start_refuses_self_injecting_claude_on_herdr`, plus the real-herdr and real-tmux topology e2e blocks)</code>
- <code>`bash tests/fm-afk-return.test.sh` (pinned-env re-entry gate call site)</code>
- <code>`bash tests/fm-daemon.test.sh` (103 assertions; the two lock-reclamation call sites re-pinned with `AFK_START_ENV`)</code>
- <code>Regression proof: exported base commit 07bf0c8 to a temp dir, copied in the new `tests/fm-afk-launch.test.sh`, and confirmed the guard assertions fail there (`native guard: claude+herdr native launch was accepted`, `start guard: claude+herdr self-injection was accepted`, `start guard: an operator-set override reopened the self-injection wedge`) and pass on b1cd4ec</code>
- <code>Manual end-to-end on a live herdr lab session: created a captain workspace, ran `bin/fm-afk-launch.sh start-native`, `bin/fm-afk-start.sh`, `bin/fm-afk-launch.sh start`, `bin/fm-afk-start.sh` from the daemon pane, and `bin/fm-afk-launch.sh stop` as a CLAUDECODE=1 / HERDR_ENV=1 captain, capturing the transcript and herdr workspace/pane counts</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
