### PR TITLE
fix(bin): gate the first spawn send on proven pane-shell readiness

### DIFF
--- a/bin/backends/herdr.sh
+++ b/bin/backends/herdr.sh
@@ -2532,8 +2532,10 @@ fm_backend_herdr_current_path() {  # <target>
 
 # fm_backend_herdr_send_text_line: send one line of TEXT then submit,
 # ATOMICALLY - mirrors tmux's `send-keys -t T text Enter`. Used for the fixed
-# spawn-time commands (treehouse get, the GOTMPDIR export). `pane run` types
-# the command and submits it in one call (verified).
+# spawn-time commands (treehouse get, the GOTMPDIR export, and the
+# shell-readiness probe fm-spawn.sh's spawn_await_shell_ready sends before each
+# of those two). `pane run` types the command and submits it in one call
+# (verified).
 fm_backend_herdr_send_text_line() {  # <target> <text>
   fm_backend_herdr_target_ready "$1" || return 1
   fm_backend_herdr_cli "$FM_BACKEND_HERDR_SESSION" pane run "$FM_BACKEND_HERDR_PANE" "$2" >/dev/null 2>&1

--- a/bin/backends/tmux.sh
+++ b/bin/backends/tmux.sh
@@ -106,9 +106,11 @@ fm_backend_tmux_current_path() {  # <target>
 }
 
 # fm_backend_tmux_send_text_line: send one line of TEXT then Enter, with no
-# composer verification - used for the fixed spawn-time commands
-# (`treehouse get`, the GOTMPDIR export) that already ran this exact sequence
-# inline in fm-spawn.sh. Mirrors `tmux send-keys -t "$T" "<text>" Enter`.
+# composer verification - used for the fixed spawn-time commands: `treehouse
+# get` and the GOTMPDIR export, which already ran this exact sequence inline in
+# fm-spawn.sh, plus the shell-readiness probe fm-spawn.sh's
+# spawn_await_shell_ready sends before each of those two.
+# Mirrors `tmux send-keys -t "$T" "<text>" Enter`.
 fm_backend_tmux_send_text_line() {  # <target> <text>
   tmux send-keys -t "$1" "$2" Enter
 }

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -165,7 +165,13 @@
 #   roughly doubles the number of send_text_line calls that can reach that
 #   pre-existing adapter path. Every gate refusal names the window and says
 #   whether it survives, and the gate removes nothing itself, so on every flat
-#   layout that pane is still there afterwards.
+#   layout that pane is still there afterwards. A refusal also speaks to the task
+#   record, because the second gate runs after that record is published and no
+#   refusal retracts it: on a fresh spawn the record is an orphan, so the refusal
+#   names $STATE/<id>.meta and the exact `bin/fm-teardown.sh <id>` that clears it;
+#   on a relaunch the record is the live task being adopted, so the refusal says
+#   teardown is NOT the remedy there and to fix the endpoint's shell and relaunch
+#   again.
 #   Known residuals on the herdr presentation-projection path: both gates run
 #   while this session's presentation-order lock is held, so an unresponsive pane
 #   can add up to two full poll budgets to that hold window; and the shared
@@ -2229,16 +2235,16 @@ spawn_send_key() {  # <target> <key>
 # repo drives the real fm-spawn.sh against a FAKE backend whose send channel has
 # no shell behind it at all, so no marker can ever appear there and the gate
 # would time out on fixtures that are not testing a shell. tests/lib.sh exports
-# the bypass for those, while the real-backend smoke suites - which do not source
-# it - exercise the gate for real, and tests/fm-spawn-first-send.test.sh strips
-# it to verify the gate itself. No portable CI lane proves the gate's premise
-# against a real shell: the tmux and herdr smoke suites never invoke this script
-# at all, and every suite that does either bypasses the gate or is classified
-# real-herdr-gated and excluded from those lanes. So "a live pane shell executes
-# the marker touch, and this script observes that marker" is unproven against any
-# real shell there; follow-up task spawn-ready-live-backend-evidence owns closing
-# that, and tests/fm-spawn-first-send.test.sh covers only the gate's logic against
-# a modelled byte-lossy shell.
+# the bypass for those, and tests/fm-spawn-first-send.test.sh strips it to verify
+# the gate itself. No portable CI lane proves the gate's premise against a real
+# shell: the tmux and herdr smoke suites never invoke this script at all, and
+# every suite that does either bypasses the gate or is classified real-herdr-gated
+# or live-harness-optin, which portable lanes exclude and which exit early anyway
+# without herdr, jq, treehouse, or cmux. So "a live pane shell executes the marker
+# touch, and this script observes that marker" is unproven against any real shell
+# there; follow-up task spawn-ready-live-backend-evidence owns closing that, and
+# tests/fm-spawn-first-send.test.sh covers only the gate's logic against a
+# modelled byte-lossy shell.
 
 # spawn_ready_probe_dir <root>: mktemp one probe directory under <root> and echo
 # it. Separate from the caller so the preferred root and the known-safe fallback
@@ -2273,10 +2279,15 @@ spawn_await_shell_ready() {  # <target> <what-the-caller-is-about-to-send>
     aftermath="inspect window $T, which survives this refusal and is left for you to clean up"
   fi
   # The second gate runs after the task record is published, and a refusal does
-  # not retract it, so the fleet would keep enumerating a task whose pane never
-  # got its launch command. Name the record and the command that clears it.
-  if [ -e "$STATE/$ID.meta" ] || [ -L "$STATE/$ID.meta" ]; then
-    aftermath="$aftermath; task record $STATE/$ID.meta is published and this refusal does not retract it, so clear the task with '$FM_ROOT/bin/fm-teardown.sh $ID'"
+  # not retract it. What that record MEANS differs by path, and so does the
+  # remedy: a fresh spawn leaves an orphan nothing will ever launch into, while a
+  # relaunch leaves the live task it was adopting. Teardown kills the endpoint and
+  # removes the worktree holding the work, so it is named only where the record is
+  # genuinely orphaned.
+  if [ "$RELAUNCH" -eq 1 ]; then
+    aftermath="$aftermath; task $ID is a LIVE adopted task and its record $STATE/$ID.meta stands, so do NOT run fm-teardown.sh here - that would kill the endpoint and remove the worktree holding this task's work; fix the endpoint's shell and run the relaunch again"
+  elif [ -e "$STATE/$ID.meta" ] || [ -L "$STATE/$ID.meta" ]; then
+    aftermath="$aftermath; task record $STATE/$ID.meta is published for a pane that never received its launch command, and this refusal does not retract it, so clear the orphaned task with '$FM_ROOT/bin/fm-teardown.sh $ID'"
   fi
   polls=${FM_SPAWN_READY_POLLS:-300}
   interval=${FM_SPAWN_READY_INTERVAL:-0.1}

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -165,13 +165,14 @@
 #   roughly doubles the number of send_text_line calls that can reach that
 #   pre-existing adapter path. Every gate refusal names the window and says
 #   whether it survives, and the gate removes nothing itself, so on every flat
-#   layout that pane is still there afterwards. A refusal also speaks to the task
+#   layout that pane is still there afterwards. A refusal also names the task
 #   record, because the second gate runs after that record is published and no
-#   refusal retracts it: on a fresh spawn the record is an orphan, so the refusal
-#   names $STATE/<id>.meta and the exact `bin/fm-teardown.sh <id>` that clears it;
-#   on a relaunch the record is the live task being adopted, so the refusal says
-#   teardown is NOT the remedy there and to fix the endpoint's shell and relaunch
-#   again.
+#   refusal retracts it: it names $STATE/<id>.meta and says the record stands,
+#   and it prescribes no remedy on any path, because whether that record is now
+#   orphaned or still describes a live task is not knowable here. Absence of
+#   --relaunch does not make it a fresh record: bin/fm-bootstrap.sh's secondmate
+#   liveness respawn and bin/fm-remote-secondmate-control.sh both re-launch over
+#   a pre-existing record without that flag.
 #   Known residuals on the herdr presentation-projection path: both gates run
 #   while this session's presentation-order lock is held, so an unresponsive pane
 #   can add up to two full poll budgets to that hold window; and the shared
@@ -2238,13 +2239,14 @@ spawn_send_key() {  # <target> <key>
 # the bypass for those, and tests/fm-spawn-first-send.test.sh strips it to verify
 # the gate itself. No portable CI lane proves the gate's premise against a real
 # shell: the tmux and herdr smoke suites never invoke this script at all, and
-# every suite that does either bypasses the gate or is classified real-herdr-gated
-# or live-harness-optin, which portable lanes exclude and which exit early anyway
-# without herdr, jq, treehouse, or cmux. So "a live pane shell executes the marker
-# touch, and this script observes that marker" is unproven against any real shell
-# there; follow-up task spawn-ready-live-backend-evidence owns closing that, and
-# tests/fm-spawn-first-send.test.sh covers only the gate's logic against a
-# modelled byte-lossy shell.
+# every suite that drives it unbypassed against a REAL backend is classified
+# real-herdr-gated or live-harness-optin, which portable lanes exclude and which
+# exit early anyway without herdr, jq, treehouse, or cmux. The one unbypassed
+# suite portable lanes do run is tests/fm-spawn-first-send.test.sh, whose backend
+# is a fake modelling a byte-lossy shell, so it covers the gate's logic and not
+# its premise. So "a live pane shell executes the marker touch, and this script
+# observes that marker" is unproven against any real shell there; follow-up task
+# spawn-ready-live-backend-evidence owns closing that.
 
 # spawn_ready_probe_dir <root>: mktemp one probe directory under <root> and echo
 # it. Separate from the caller so the preferred root and the known-safe fallback
@@ -2279,15 +2281,13 @@ spawn_await_shell_ready() {  # <target> <what-the-caller-is-about-to-send>
     aftermath="inspect window $T, which survives this refusal and is left for you to clean up"
   fi
   # The second gate runs after the task record is published, and a refusal does
-  # not retract it. What that record MEANS differs by path, and so does the
-  # remedy: a fresh spawn leaves an orphan nothing will ever launch into, while a
-  # relaunch leaves the live task it was adopting. Teardown kills the endpoint and
-  # removes the worktree holding the work, so it is named only where the record is
-  # genuinely orphaned.
-  if [ "$RELAUNCH" -eq 1 ]; then
-    aftermath="$aftermath; task $ID is a LIVE adopted task and its record $STATE/$ID.meta stands, so do NOT run fm-teardown.sh here - that would kill the endpoint and remove the worktree holding this task's work; fix the endpoint's shell and run the relaunch again"
-  elif [ -e "$STATE/$ID.meta" ] || [ -L "$STATE/$ID.meta" ]; then
-    aftermath="$aftermath; task record $STATE/$ID.meta is published for a pane that never received its launch command, and this refusal does not retract it, so clear the orphaned task with '$FM_ROOT/bin/fm-teardown.sh $ID'"
+  # not retract it. Whether that record is now orphaned or still describes a live
+  # task is not knowable here: --relaunch adopts an existing one, and both
+  # bin/fm-bootstrap.sh's secondmate liveness respawn and
+  # bin/fm-remote-secondmate-control.sh re-launch over a pre-existing one without
+  # that flag. So state the fact and prescribe nothing.
+  if [ -e "$STATE/$ID.meta" ] || [ -L "$STATE/$ID.meta" ]; then
+    aftermath="$aftermath; task $ID's record $STATE/$ID.meta is published and this refusal does not retract it"
   fi
   polls=${FM_SPAWN_READY_POLLS:-300}
   interval=${FM_SPAWN_READY_INTERVAL:-0.1}

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -160,9 +160,9 @@
 #   not interrupt-free end to end, though: the zellij and cmux send_text_line
 #   adapters clear their own failed submit with C-c, and gating both first sends
 #   roughly doubles the number of send_text_line calls that can reach that
-#   pre-existing adapter path. Every gate refusal names the window to inspect,
-#   and the gate removes nothing itself, so on every flat layout that pane is
-#   still there afterwards.
+#   pre-existing adapter path. Every gate refusal names the window and says
+#   whether it survives, and the gate removes nothing itself, so on every flat
+#   layout that pane is still there afterwards.
 #   Known residuals on the herdr presentation-projection path: both gates run
 #   while this session's presentation-order lock is held, so an unresponsive pane
 #   can add up to two full poll budgets to that hold window; and the shared
@@ -2191,41 +2191,36 @@ spawn_send_key() {  # <target> <key>
 }
 
 # Shell-readiness gate for the FIRST text line sent into a pane.
+# This script's header owns the contract: which sends are gated, the knobs and
+# their defaults, the refusal rules, and the bypass. What follows is only the
+# rationale a maintainer changing this code needs and cannot read off the header.
 #
-# A freshly created pane's shell can still be sourcing its rc files when that
-# first send lands, and a slow init eats the leading byte(s). Seen live on herdr
-# under load (2026-08-17): the leading 't' of `treehouse get` was swallowed three
-# times running, the pane ran `reehouse get`, and the worktree was never entered -
-# silently, with nothing on firstmate's side to notice. A sacrificial leading
-# space is only a mitigation: it buys exactly as many bytes as spaces are sent.
+# Seen live on herdr under load (2026-08-17): the leading 't' of `treehouse get`
+# was swallowed three times running, the pane ran `reehouse get`, and the
+# worktree was never entered - silently, with nothing on firstmate's side to
+# notice. A sacrificial leading space was rejected as only a mitigation: it buys
+# exactly as many bytes as spaces are sent.
 #
-# So prove readiness instead. The probe sends `touch <marker>` and polls the
-# filesystem for <marker>. The command word cannot survive ANY head truncation -
-# every prefix loss turns `touch` into some other word, the shell reports
-# command-not-found, and the marker stays absent - so the marker exists only
-# after one byte-exact line was received AND executed at a live prompt. That is
-# the same condition which makes the NEXT send safe, which is what makes this a
-# fix rather than padding.
+# `touch` is load-bearing, not incidental. The command word cannot survive ANY
+# head truncation - every prefix loss turns it into some other word, the shell
+# reports command-not-found, and the marker stays absent - so the marker exists
+# only after one byte-exact line was received AND executed at a live prompt. That
+# is the same condition which makes the NEXT send safe, which is what makes this
+# a fix rather than padding.
 #
 # The verdict comes from the filesystem, never from rendered pane output, so it
 # holds identically on every send-capable backend and carries no per-harness
 # assumption at all: the gate runs strictly before the launch command, so no
-# harness has started yet.
+# harness has started yet. That is why no new per-harness evidence is owed here.
 #
-# Bounded and loud: on exhaustion the spawn refuses with the endpoint named,
-# rather than sending into a pane that never proved it can read a line.
-# FM_SPAWN_READY_POLLS, FM_SPAWN_READY_INTERVAL, and FM_SPAWN_READY_RESEND_EVERY
-# tune the budget; the defaults cost a healthy pane one poll interval.
-#
-# TEST-FIXTURE ESCAPE HATCH (FM_SPAWN_READY_BYPASS=1), the same shape and the
-# same reasoning as bin/fm-gate-refuse-lib.sh's: nearly every suite in this repo
-# drives the real fm-spawn.sh against a FAKE backend whose send channel has no
-# shell behind it at all, so no marker can ever appear there and the gate would
-# time out on fixtures that are not testing a shell. tests/lib.sh exports the
-# bypass for those, while the real-backend smoke suites - which do not source it -
-# exercise the gate for real, and tests/fm-spawn-first-send.test.sh strips it to
-# verify the gate itself. It must never be set in a live home: a pane whose shell
-# is unproven is exactly what this gate exists to catch.
+# FM_SPAWN_READY_BYPASS takes the same shape and the same reasoning as
+# bin/fm-gate-refuse-lib.sh's FM_GATE_REFUSE_BYPASS: nearly every suite in this
+# repo drives the real fm-spawn.sh against a FAKE backend whose send channel has
+# no shell behind it at all, so no marker can ever appear there and the gate
+# would time out on fixtures that are not testing a shell. tests/lib.sh exports
+# the bypass for those, while the real-backend smoke suites - which do not source
+# it - exercise the gate for real, and tests/fm-spawn-first-send.test.sh strips
+# it to verify the gate itself.
 spawn_ready_cleanup() {
   [ -n "$SPAWN_READY_DIR" ] || return 0
   rm -rf "$SPAWN_READY_DIR" 2>/dev/null || true
@@ -2252,8 +2247,18 @@ spawn_ready_probe_dir() {  # <root>
 
 spawn_await_shell_ready() {  # <target> <what-the-caller-is-about-to-send>
   local target=$1 about=$2 marker polls interval resend_every root i=0 sends=0
-  local probe_rc=0 send_status=0 send_failures=0
+  local probe_rc=0 send_status=0 send_failures=0 aftermath
   [ "${FM_SPAWN_READY_BYPASS:-}" != 1 ] || return 0
+  # Every refusal below ends with the same clause, built once here so the three
+  # cannot drift apart. The gate itself removes nothing, but a refusal is a
+  # nonzero exit, and on the herdr presentation-projection path the shared
+  # spawn-abort cleanup then closes the exact projected task pane - so promise
+  # the pane is there to inspect only where it actually still is.
+  if [ "$HERDR_PROJECTION_ABORT_CLEANUP" = 1 ]; then
+    aftermath="window $T is closed by this spawn's abort cleanup, so it is not left behind for you to inspect"
+  else
+    aftermath="inspect window $T, which survives this refusal and is left for you to clean up"
+  fi
   polls=${FM_SPAWN_READY_POLLS:-300}
   interval=${FM_SPAWN_READY_INTERVAL:-0.1}
   resend_every=${FM_SPAWN_READY_RESEND_EVERY:-10}
@@ -2340,12 +2345,12 @@ spawn_await_shell_ready() {  # <target> <what-the-caller-is-about-to-send>
         send_failures=$((send_failures + 1))
         if [ "$send_status" -eq 2 ] && { [ "$BACKEND" = zellij ] || [ "$BACKEND" = cmux ]; }; then
           spawn_ready_cleanup
-          echo "error: shell-readiness probe input could not be cleared on $target for task $ID; refusing to send '$about' - inspect window $T, which survives this refusal and is left for you to clean up" >&2
+          echo "error: shell-readiness probe input could not be cleared on $target for task $ID; refusing to send '$about' - $aftermath" >&2
           return 1
         fi
         if [ "$send_failures" -ge 2 ]; then
           spawn_ready_cleanup
-          echo "error: the send channel for task $ID's endpoint $target failed the shell-readiness probe $send_failures times in a row (last status $send_status), so probes are no longer reaching the pane; refusing to send '$about' - the endpoint's send path is failing, not its shell; inspect window $T, which survives this refusal and is left for you to clean up" >&2
+          echo "error: the send channel for task $ID's endpoint $target failed the shell-readiness probe $send_failures times in a row (last status $send_status), so probes are no longer reaching the pane; refusing to send '$about' - the endpoint's send path is failing, not its shell; $aftermath" >&2
           return 1
         fi
       else
@@ -2360,7 +2365,7 @@ spawn_await_shell_ready() {  # <target> <what-the-caller-is-about-to-send>
     sleep "$interval"
   done
   spawn_ready_cleanup
-  echo "error: task $ID's pane shell never confirmed it can read a command line ($sends probes over $polls polls at ${interval}s on $target); refusing to send '$about' into a pane that may silently drop its leading bytes; inspect window $T, which survives this refusal and is left for you to clean up" >&2
+  echo "error: task $ID's pane shell never confirmed it can read a command line ($sends probes over $polls polls at ${interval}s on $target); refusing to send '$about' into a pane that may silently drop its leading bytes; $aftermath" >&2
   return 1
 }
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -151,28 +151,30 @@
 #   shell in a quote continuation, and discards its own stderr so that probes a
 #   blocked shell drains after the gate has already passed and removed the probe
 #   directory leave no failure debris on the pane ahead of the guarded command.
-#   The probe directory is created under TMPDIR
-#   when that yields a plain absolute marker path, and otherwise under the same
-#   fixed /tmp root TASK_TMP uses, with one stderr notice; only a /tmp that also
-#   cannot yield a plain path refuses the spawn. A probe the backend cannot even
-#   deliver refuses on the SEND CHANNEL rather than spending the poll budget and
-#   blaming the pane: two CONSECUTIVE send failures name the endpoint, a lone
-#   hiccup between delivered probes does not, and on zellij and cmux - the only
-#   adapters that define it - a reported uncleared input line is terminal on
-#   sight. The gate sends no interrupt of its own, on either gated path. It is
+#   The probe directory is created under TMPDIR when that root both accepts a
+#   temp directory and yields a plain absolute marker path, and otherwise under
+#   the same fixed /tmp root TASK_TMP uses, with one stderr notice naming which
+#   of the two it failed; only a /tmp that fails the same way refuses the spawn,
+#   before any probe is sent and naming that local fault rather than the pane.
+#   A probe the backend cannot even deliver refuses on the SEND CHANNEL rather
+#   than spending the poll budget and blaming the pane: two CONSECUTIVE send
+#   failures name the endpoint, a lone hiccup between delivered probes does not,
+#   and on zellij and cmux - the only adapters that define it - a reported
+#   uncleared input line is terminal on sight.
+#   The gate sends no interrupt of its own, on either gated path. It is
 #   not interrupt-free end to end, though: the zellij and cmux send_text_line
 #   adapters clear their own failed submit with C-c, and gating both first sends
 #   roughly doubles the number of send_text_line calls that can reach that
-#   pre-existing adapter path. Every gate refusal names the window and says
-#   whether it survives, and the gate removes nothing itself, so on every flat
-#   layout that pane is still there afterwards. A refusal also names the task
-#   record, because the second gate runs after that record is published and no
-#   refusal retracts it: it names $STATE/<id>.meta and says the record stands,
-#   and it prescribes no remedy on any path, because whether that record is now
-#   orphaned or still describes a live task is not knowable here. Absence of
-#   --relaunch does not make it a fresh record: bin/fm-bootstrap.sh's secondmate
-#   liveness respawn and bin/fm-remote-secondmate-control.sh both re-launch over
-#   a pre-existing record without that flag.
+#   pre-existing adapter path. Every refusal the probe loop itself raises names
+#   the window and says whether it survives, and the gate removes nothing itself,
+#   so on every flat layout that pane is still there afterwards. Such a refusal
+#   also names the task record, because the second gate runs after that record is
+#   published and no refusal retracts it: it names $STATE/<id>.meta and says the
+#   record stands, and it prescribes no remedy on any path, because whether that
+#   record is now orphaned or still describes a live task is not knowable here.
+#   Absence of --relaunch does not make it a fresh record: bin/fm-bootstrap.sh's
+#   secondmate liveness respawn and bin/fm-remote-secondmate-control.sh both
+#   re-launch over a pre-existing record without that flag.
 #   Known residuals on the herdr presentation-projection path: both gates run
 #   while this session's presentation-order lock is held, so an unresponsive pane
 #   can add up to two full poll budgets to that hold window; and the shared

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -148,7 +148,10 @@
 #   bricking every spawn; FM_SPAWN_READY_BYPASS=1 is a test-fixture escape hatch
 #   for suites whose fake backend has no shell behind it, never for a live home.
 #   The marker command is sent unquoted so no truncation can strand the pane's
-#   shell in a quote continuation. The probe directory is created under TMPDIR
+#   shell in a quote continuation, and discards its own stderr so that probes a
+#   blocked shell drains after the gate has already passed and removed the probe
+#   directory leave no failure debris on the pane ahead of the guarded command.
+#   The probe directory is created under TMPDIR
 #   when that yields a plain absolute marker path, and otherwise under the same
 #   fixed /tmp root TASK_TMP uses, with one stderr notice; only a /tmp that also
 #   cannot yield a plain path refuses the spawn. A probe the backend cannot even
@@ -728,6 +731,14 @@ parse_orca_worktree_result() {
   fi
 }
 
+# Sole owner of readiness-probe scratch removal, defined here so the EXIT trap
+# below can call it from any exit point in this script.
+spawn_ready_cleanup() {
+  [ -n "$SPAWN_READY_DIR" ] || return 0
+  rm -rf "$SPAWN_READY_DIR" 2>/dev/null || true
+  SPAWN_READY_DIR=
+}
+
 spawn_abort_cleanup() {
   local status=$?
   if [ "$RELAUNCH_REPLACEMENT_PENDING" = 1 ] \
@@ -817,7 +828,7 @@ spawn_abort_cleanup() {
     fm_lock_release "$SPAWN_CONTROL_LOCK" || true
   fi
   [ -z "$SPAWN_META_TMP" ] || rm -f "$SPAWN_META_TMP" 2>/dev/null || true
-  [ -z "$SPAWN_READY_DIR" ] || rm -rf "$SPAWN_READY_DIR" 2>/dev/null || true
+  spawn_ready_cleanup
   if [ "$CONFIG_INHERIT_LOCK_HELD" = 1 ]; then
     CONFIG_INHERIT_LOCK_HELD=0
     fm_lock_release "$CONFIG_INHERIT_LOCK" || true
@@ -2220,12 +2231,14 @@ spawn_send_key() {  # <target> <key>
 # would time out on fixtures that are not testing a shell. tests/lib.sh exports
 # the bypass for those, while the real-backend smoke suites - which do not source
 # it - exercise the gate for real, and tests/fm-spawn-first-send.test.sh strips
-# it to verify the gate itself.
-spawn_ready_cleanup() {
-  [ -n "$SPAWN_READY_DIR" ] || return 0
-  rm -rf "$SPAWN_READY_DIR" 2>/dev/null || true
-  SPAWN_READY_DIR=
-}
+# it to verify the gate itself. No portable CI lane proves the gate's premise
+# against a real shell: the tmux and herdr smoke suites never invoke this script
+# at all, and every suite that does either bypasses the gate or is classified
+# real-herdr-gated and excluded from those lanes. So "a live pane shell executes
+# the marker touch, and this script observes that marker" is unproven against any
+# real shell there; follow-up task spawn-ready-live-backend-evidence owns closing
+# that, and tests/fm-spawn-first-send.test.sh covers only the gate's logic against
+# a modelled byte-lossy shell.
 
 # spawn_ready_probe_dir <root>: mktemp one probe directory under <root> and echo
 # it. Separate from the caller so the preferred root and the known-safe fallback
@@ -2258,6 +2271,12 @@ spawn_await_shell_ready() {  # <target> <what-the-caller-is-about-to-send>
     aftermath="window $T is closed by this spawn's abort cleanup, so it is not left behind for you to inspect"
   else
     aftermath="inspect window $T, which survives this refusal and is left for you to clean up"
+  fi
+  # The second gate runs after the task record is published, and a refusal does
+  # not retract it, so the fleet would keep enumerating a task whose pane never
+  # got its launch command. Name the record and the command that clears it.
+  if [ -e "$STATE/$ID.meta" ] || [ -L "$STATE/$ID.meta" ]; then
+    aftermath="$aftermath; task record $STATE/$ID.meta is published and this refusal does not retract it, so clear the task with '$FM_ROOT/bin/fm-teardown.sh $ID'"
   fi
   polls=${FM_SPAWN_READY_POLLS:-300}
   interval=${FM_SPAWN_READY_INTERVAL:-0.1}
@@ -2312,9 +2331,10 @@ spawn_await_shell_ready() {  # <target> <what-the-caller-is-about-to-send>
       # pays it.
       #
       # Deliberately NOT C-c, even though a bare Enter cannot escape a PS2
-      # continuation. The probe line is unquoted and metacharacter-free, so no
-      # truncation of the gate's OWN line can produce a continuation, which was
-      # C-c's only justification. Against that, C-c is a real SIGINT to whatever
+      # continuation. The probe line is unquoted and carries no character that
+      # opens one - its only metacharacter is the trailing stderr redirect, whose
+      # target is /dev/null - so no truncation of the gate's OWN line can produce
+      # a continuation, which was C-c's only justification. Against that, C-c is a real SIGINT to whatever
       # holds the pane's foreground: `treehouse get` can still be running at the
       # second gate, because the settle loop below accepts a transiently settled
       # non-project path before the shell catches up with its cd, and a relaunch
@@ -2327,7 +2347,7 @@ spawn_await_shell_ready() {  # <target> <what-the-caller-is-about-to-send>
       # bounded budget still turns it into a loud refusal, never a corrupt spawn.
       [ "$sends" -eq 0 ] || spawn_send_key "$target" Enter || true
       send_status=0
-      spawn_send_text_line "$target" "touch $marker" || send_status=$?
+      spawn_send_text_line "$target" "touch $marker 2>/dev/null" || send_status=$?
       sends=$((sends + 1))
       # A send channel that reports failure is not a pane that will not answer,
       # and burning the whole budget would report the wrong cause. Only zellij

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -160,7 +160,13 @@
 #   not interrupt-free end to end, though: the zellij and cmux send_text_line
 #   adapters clear their own failed submit with C-c, and gating both first sends
 #   roughly doubles the number of send_text_line calls that can reach that
-#   pre-existing adapter path.
+#   pre-existing adapter path. Every gate refusal names the window to inspect and
+#   says the created pane survives, because nothing here removes it.
+#   Known residual: on the herdr presentation-projection path both gates run
+#   while this session's presentation-order lock is held, so an unresponsive pane
+#   can add up to two full poll budgets to that hold window. A concurrent herdr
+#   spawn that cannot acquire the lock meanwhile takes the same documented path it
+#   already does, warning once and falling back to the flat layout.
 #   Before a fresh ship or scout worker starts, its clean task worktree fetches
 #   origin, resolves the current remote default branch, and resets to its tip.
 #   An unreachable origin, unresolved default branch, or non-clean worktree
@@ -2330,12 +2336,12 @@ spawn_await_shell_ready() {  # <target> <what-the-caller-is-about-to-send>
         send_failures=$((send_failures + 1))
         if [ "$send_status" -eq 2 ] && { [ "$BACKEND" = zellij ] || [ "$BACKEND" = cmux ]; }; then
           spawn_ready_cleanup
-          echo "error: shell-readiness probe input could not be cleared on $target for task $ID; refusing to send '$about'" >&2
+          echo "error: shell-readiness probe input could not be cleared on $target for task $ID; refusing to send '$about' - inspect window $T, which survives this refusal and is left for you to clean up" >&2
           return 1
         fi
         if [ "$send_failures" -ge 2 ]; then
           spawn_ready_cleanup
-          echo "error: the send channel for task $ID's endpoint $target failed the shell-readiness probe $send_failures times in a row (last status $send_status), so probes are no longer reaching the pane; refusing to send '$about' - the endpoint's send path is failing, not its shell" >&2
+          echo "error: the send channel for task $ID's endpoint $target failed the shell-readiness probe $send_failures times in a row (last status $send_status), so probes are no longer reaching the pane; refusing to send '$about' - the endpoint's send path is failing, not its shell; inspect window $T, which survives this refusal and is left for you to clean up" >&2
           return 1
         fi
       else
@@ -2350,7 +2356,7 @@ spawn_await_shell_ready() {  # <target> <what-the-caller-is-about-to-send>
     sleep "$interval"
   done
   spawn_ready_cleanup
-  echo "error: task $ID's pane shell never confirmed it can read a command line ($sends probes over $polls polls at ${interval}s on $target); refusing to send '$about' into a pane that may silently drop its leading bytes" >&2
+  echo "error: task $ID's pane shell never confirmed it can read a command line ($sends probes over $polls polls at ${interval}s on $target); refusing to send '$about' into a pane that may silently drop its leading bytes; inspect window $T, which survives this refusal and is left for you to clean up" >&2
   return 1
 }
 

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -134,6 +134,18 @@
 #   default-branch commit when safe; skipped syncs warn and launch unchanged.
 #   Ship/scout spawns refuse to launch unless the resolved task path is a real
 #   git worktree root distinct from the primary project checkout.
+#   Before the first text line goes into a pane, the spawn proves that pane's
+#   shell is actually reading command lines: it sends a marker command and waits
+#   for the file only a byte-exact delivery can create, because a shell still
+#   sourcing its rc files silently eats the leading bytes of the first send. Both
+#   first-send points are gated - `treehouse get`, and the launch environment
+#   that follows treehouse's new subshell or opens a relaunch, secondmate, or
+#   Orca spawn - and a pane that never answers refuses the spawn rather than
+#   launching into a possibly corrupted command. FM_SPAWN_READY_POLLS (default
+#   300), FM_SPAWN_READY_INTERVAL (default 0.1s), and FM_SPAWN_READY_RESEND_EVERY
+#   (default every 10 polls) tune that budget; FM_SPAWN_READY_BYPASS=1 is a
+#   test-fixture escape hatch for suites whose fake backend has no shell behind
+#   it, never for a live home.
 #   Before a fresh ship or scout worker starts, its clean task worktree fetches
 #   origin, resolves the current remote default branch, and resets to its tip.
 #   An unreachable origin, unresolved default branch, or non-clean worktree
@@ -672,6 +684,7 @@ RELAUNCH_REPLACEMENT_STATE=
 RELAUNCH_REPLACEMENT_WT=
 CONFIG_INHERIT_LOCK=
 CONFIG_INHERIT_LOCK_HELD=0
+SPAWN_READY_DIR=
 
 parse_orca_worktree_result() {
   local raw=$1 rest
@@ -779,6 +792,7 @@ spawn_abort_cleanup() {
     fm_lock_release "$SPAWN_CONTROL_LOCK" || true
   fi
   [ -z "$SPAWN_META_TMP" ] || rm -f "$SPAWN_META_TMP" 2>/dev/null || true
+  [ -z "$SPAWN_READY_DIR" ] || rm -rf "$SPAWN_READY_DIR" 2>/dev/null || true
   if [ "$CONFIG_INHERIT_LOCK_HELD" = 1 ]; then
     CONFIG_INHERIT_LOCK_HELD=0
     fm_lock_release "$CONFIG_INHERIT_LOCK" || true
@@ -2151,6 +2165,91 @@ spawn_send_key() {  # <target> <key>
   esac
 }
 
+# Shell-readiness gate for the FIRST text line sent into a pane.
+#
+# A freshly created pane's shell can still be sourcing its rc files when that
+# first send lands, and a slow init eats the leading byte(s). Seen live on herdr
+# under load (2026-08-17): the leading 't' of `treehouse get` was swallowed three
+# times running, the pane ran `reehouse get`, and the worktree was never entered -
+# silently, with nothing on firstmate's side to notice. A sacrificial leading
+# space is only a mitigation: it buys exactly as many bytes as spaces are sent.
+#
+# So prove readiness instead. The probe sends `touch <marker>` and polls the
+# filesystem for <marker>. The command word cannot survive ANY head truncation -
+# every prefix loss turns `touch` into some other word, the shell reports
+# command-not-found, and the marker stays absent - so the marker exists only
+# after one byte-exact line was received AND executed at a live prompt. That is
+# the same condition which makes the NEXT send safe, which is what makes this a
+# fix rather than padding.
+#
+# The verdict comes from the filesystem, never from rendered pane output, so it
+# holds identically on every send-capable backend and carries no per-harness
+# assumption at all: the gate runs strictly before the launch command, so no
+# harness has started yet.
+#
+# Bounded and loud: on exhaustion the spawn refuses with the endpoint named,
+# rather than sending into a pane that never proved it can read a line.
+# FM_SPAWN_READY_POLLS, FM_SPAWN_READY_INTERVAL, and FM_SPAWN_READY_RESEND_EVERY
+# tune the budget; the defaults cost a healthy pane one poll interval.
+#
+# TEST-FIXTURE ESCAPE HATCH (FM_SPAWN_READY_BYPASS=1), the same shape and the
+# same reasoning as bin/fm-gate-refuse-lib.sh's: nearly every suite in this repo
+# drives the real fm-spawn.sh against a FAKE backend whose send channel has no
+# shell behind it at all, so no marker can ever appear there and the gate would
+# time out on fixtures that are not testing a shell. tests/lib.sh exports the
+# bypass for those, while the real-backend smoke suites - which do not source it -
+# exercise the gate for real, and tests/fm-spawn-first-send.test.sh strips it to
+# verify the gate itself. It must never be set in a live home: a pane whose shell
+# is unproven is exactly what this gate exists to catch.
+spawn_ready_cleanup() {
+  [ -n "$SPAWN_READY_DIR" ] || return 0
+  rm -rf "$SPAWN_READY_DIR" 2>/dev/null || true
+  SPAWN_READY_DIR=
+}
+
+spawn_await_shell_ready() {  # <target> <what-the-caller-is-about-to-send>
+  local target=$1 about=$2 marker polls interval resend_every i=0 sends=0
+  [ "${FM_SPAWN_READY_BYPASS:-}" != 1 ] || return 0
+  polls=${FM_SPAWN_READY_POLLS:-300}
+  interval=${FM_SPAWN_READY_INTERVAL:-0.1}
+  resend_every=${FM_SPAWN_READY_RESEND_EVERY:-10}
+  [ "$resend_every" -ge 1 ] 2>/dev/null || resend_every=1
+  SPAWN_READY_DIR=$(mktemp -d "${TMPDIR:-/tmp}/fm-spawn-ready.XXXXXX") || {
+    echo "error: could not create a shell-readiness probe directory for $W" >&2
+    return 1
+  }
+  marker="$SPAWN_READY_DIR/ready"
+  # The probe line carries the marker path single-quoted, which covers every
+  # path character except a single quote itself. Refuse rather than send a line
+  # whose quoting the pane's shell would parse differently than intended.
+  case "$marker" in
+    *\'*)
+      spawn_ready_cleanup
+      echo "error: shell-readiness probe path contains a single quote and cannot be sent safely: $marker" >&2
+      return 1
+      ;;
+  esac
+  while [ "$i" -lt "$polls" ]; do
+    if [ $((i % resend_every)) -eq 0 ]; then
+      # Every resend after the first submits a bare Enter first, so a prior
+      # attempt left half-typed on the input line is flushed as its own failing
+      # command instead of being concatenated onto this one.
+      [ "$sends" -eq 0 ] || spawn_send_key "$target" Enter || true
+      spawn_send_text_line "$target" "touch '$marker'" || true
+      sends=$((sends + 1))
+    fi
+    if [ -e "$marker" ]; then
+      spawn_ready_cleanup
+      return 0
+    fi
+    i=$((i + 1))
+    sleep "$interval"
+  done
+  spawn_ready_cleanup
+  echo "error: task $ID's pane shell never confirmed it can read a command line ($sends probes over $polls polls at ${interval}s on $target); refusing to send '$about' into a pane that may silently drop its leading bytes" >&2
+  return 1
+}
+
 kimi_capture() {
   fm_backend_capture "$BACKEND" "$T" 120 "$W" 2>/dev/null || true
 }
@@ -2227,6 +2326,7 @@ if [ "$RELAUNCH" -eq 1 ]; then
   fi
   [ "$KIND" = secondmate ] || validate_spawn_worktree "relaunch" "$T"
 elif [ "$KIND" != secondmate ] && [ "$BACKEND" != orca ]; then
+  spawn_await_shell_ready "$WT_TARGET" 'treehouse get' || exit 1
   spawn_send_text_line "$WT_TARGET" 'treehouse get'
 
   # Wait for the treehouse subshell: the pane's cwd moves from the project to the worktree.
@@ -2802,6 +2902,12 @@ spawn_record_traceparent() {
 # Export GOTMPDIR into the crewmate's pane shell so the agent and every child
 # process (go build, go test, ...) inherit it. Sent before the launch command so
 # the env is set when the agent starts; the brief sleep lets the export land.
+#
+# Gated again rather than once per spawn. On the ordinary path `treehouse get`
+# above handed the pane to a NEW subshell that sources its own rc files, so
+# readiness proven before that send says nothing about this one; on every other
+# path (relaunch, secondmate, orca) this line IS the spawn's first send.
+spawn_await_shell_ready "$T" 'the launch environment' || exit 1
 spawn_send_text_line "$T" "export GOTMPDIR=$TASK_TMP/gotmp"
 # Send through the exact channel that already ships GOTMPDIR, so every backend
 # and harness - ship, scout, and secondmate - gets it before launch. Skipped

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -153,10 +153,14 @@
 #   fixed /tmp root TASK_TMP uses, with one stderr notice; only a /tmp that also
 #   cannot yield a plain path refuses the spawn. A probe the backend cannot even
 #   deliver refuses on the SEND CHANNEL rather than spending the poll budget and
-#   blaming the pane: a cleared-input failure is terminal on sight, and any other
-#   send failure gets one bounded retry before the endpoint is named. The gate
-#   never sends an interrupt, so it cannot signal work already running in the
-#   pane.
+#   blaming the pane: two CONSECUTIVE send failures name the endpoint, a lone
+#   hiccup between delivered probes does not, and on zellij and cmux - the only
+#   adapters that define it - a reported uncleared input line is terminal on
+#   sight. The gate sends no interrupt of its own, on either gated path. It is
+#   not interrupt-free end to end, though: the zellij and cmux send_text_line
+#   adapters clear their own failed submit with C-c, and gating both first sends
+#   roughly doubles the number of send_text_line calls that can reach that
+#   pre-existing adapter path.
 #   Before a fresh ship or scout worker starts, its clean task worktree fetches
 #   origin, resolves the current remote default branch, and resets to its tip.
 #   An unreachable origin, unresolved default branch, or non-clean worktree
@@ -2311,22 +2315,31 @@ spawn_await_shell_ready() {  # <target> <what-the-caller-is-about-to-send>
       spawn_send_text_line "$target" "touch $marker" || send_status=$?
       sends=$((sends + 1))
       # A send channel that reports failure is not a pane that will not answer,
-      # and burning the whole budget would report the wrong cause. Status 2 is
-      # the adapters' distinct "input could not be cleared" verdict, terminal on
-      # sight exactly as at the TRACEPARENT send site. Any other failure gets one
-      # bounded retry on the next stride, then refuses naming the channel.
+      # and burning the whole budget would report the wrong cause. Only zellij
+      # and cmux define status 2 as "input could not be cleared" (orca returns 2
+      # for invalid JSON or an ok:false response, which says nothing about the
+      # input line), so that terminal reading is scoped to those two. Every other
+      # failure gets one bounded retry on the next stride.
+      #
+      # The count is CONSECUTIVE, reset by any successful send. A pane eating
+      # leading bytes for many strides is this gate's whole target scenario, and
+      # one transient channel hiccup at its start must not combine with an
+      # unrelated one much later into a send-channel abort - the refusal has to
+      # name the fault that is actually happening.
       if [ "$send_status" -ne 0 ]; then
         send_failures=$((send_failures + 1))
-        if [ "$send_status" -eq 2 ]; then
+        if [ "$send_status" -eq 2 ] && { [ "$BACKEND" = zellij ] || [ "$BACKEND" = cmux ]; }; then
           spawn_ready_cleanup
           echo "error: shell-readiness probe input could not be cleared on $target for task $ID; refusing to send '$about'" >&2
           return 1
         fi
         if [ "$send_failures" -ge 2 ]; then
           spawn_ready_cleanup
-          echo "error: the send channel for task $ID's endpoint $target failed the shell-readiness probe $send_failures times (last status $send_status), so no probe reached the pane; refusing to send '$about' - the endpoint's send path is broken, not its shell" >&2
+          echo "error: the send channel for task $ID's endpoint $target failed the shell-readiness probe $send_failures times in a row (last status $send_status), so probes are no longer reaching the pane; refusing to send '$about' - the endpoint's send path is failing, not its shell" >&2
           return 1
         fi
+      else
+        send_failures=0
       fi
     fi
     if [ -e "$marker" ]; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -151,7 +151,12 @@
 #   shell in a quote continuation. The probe directory is created under TMPDIR
 #   when that yields a plain absolute marker path, and otherwise under the same
 #   fixed /tmp root TASK_TMP uses, with one stderr notice; only a /tmp that also
-#   cannot yield a plain path refuses the spawn.
+#   cannot yield a plain path refuses the spawn. A probe the backend cannot even
+#   deliver refuses on the SEND CHANNEL rather than spending the poll budget and
+#   blaming the pane: a cleared-input failure is terminal on sight, and any other
+#   send failure gets one bounded retry before the endpoint is named. The gate
+#   never sends an interrupt, so it cannot signal work already running in the
+#   pane.
 #   Before a fresh ship or scout worker starts, its clean task worktree fetches
 #   origin, resolves the current remote default branch, and resets to its tip.
 #   An unreachable origin, unresolved default branch, or non-clean worktree
@@ -2214,16 +2219,18 @@ spawn_ready_cleanup() {
 }
 
 # spawn_ready_probe_dir <root>: mktemp one probe directory under <root> and echo
-# it, or return non-zero when that root cannot yield a marker path the probe line
-# can carry unquoted. Separate from the caller so the preferred root and the
-# known-safe fallback root run the exact same validation.
+# it. Separate from the caller so the preferred root and the known-safe fallback
+# root run the exact same validation. The two failure modes are distinct causes
+# an operator has to act on differently, so they get distinct statuses: 1 means
+# mktemp itself could not create a directory there (missing, read-only, full),
+# 2 means the path it produced cannot be carried by an unquoted probe line.
 spawn_ready_probe_dir() {  # <root>
   local dir
   dir=$(mktemp -d "$1/fm-spawn-ready.XXXXXX") || return 1
   case "$dir/ready" in
     [!/]*|*[!A-Za-z0-9._/+:@-]*)
       rm -rf "$dir" 2>/dev/null || true
-      return 1
+      return 2
       ;;
   esac
   printf '%s\n' "$dir"
@@ -2231,6 +2238,7 @@ spawn_ready_probe_dir() {  # <root>
 
 spawn_await_shell_ready() {  # <target> <what-the-caller-is-about-to-send>
   local target=$1 about=$2 marker polls interval resend_every root i=0 sends=0
+  local probe_rc=0 send_status=0 send_failures=0
   [ "${FM_SPAWN_READY_BYPASS:-}" != 1 ] || return 0
   polls=${FM_SPAWN_READY_POLLS:-300}
   interval=${FM_SPAWN_READY_INTERVAL:-0.1}
@@ -2258,28 +2266,68 @@ spawn_await_shell_ready() {  # <target> <what-the-caller-is-about-to-send>
   # TASK_TMP already uses rather than failing a spawn over the caller's
   # environment. Only a /tmp that also cannot yield a plain path refuses.
   root=${TMPDIR:-/tmp}
-  SPAWN_READY_DIR=$(spawn_ready_probe_dir "$root") || SPAWN_READY_DIR=
-  if [ -z "$SPAWN_READY_DIR" ] && [ "$root" != /tmp ]; then
-    echo "notice: shell-readiness probe root $root cannot yield a plain absolute marker path; falling back to /tmp for task $ID" >&2
-    SPAWN_READY_DIR=$(spawn_ready_probe_dir /tmp) || SPAWN_READY_DIR=
+  SPAWN_READY_DIR=$(spawn_ready_probe_dir "$root") || probe_rc=$?
+  if [ "$probe_rc" -ne 0 ] && [ "$root" != /tmp ]; then
+    if [ "$probe_rc" -eq 2 ]; then
+      echo "notice: shell-readiness probe root $root cannot yield a plain absolute marker path; falling back to /tmp for task $ID" >&2
+    else
+      echo "notice: shell-readiness probe root $root does not accept a temp directory; falling back to /tmp for task $ID" >&2
+    fi
+    probe_rc=0
+    SPAWN_READY_DIR=$(spawn_ready_probe_dir /tmp) || probe_rc=$?
   fi
-  if [ -z "$SPAWN_READY_DIR" ]; then
-    echo "error: no shell-readiness probe directory for task $ID: /tmp yielded no plain absolute marker path, so the probe line cannot be sent without shell quoting" >&2
+  if [ "$probe_rc" -ne 0 ] || [ -z "$SPAWN_READY_DIR" ]; then
+    if [ "$probe_rc" -eq 2 ]; then
+      echo "error: no shell-readiness probe directory for task $ID: /tmp yields no plain absolute marker path, so the probe line cannot be sent without shell quoting" >&2
+    else
+      echo "error: no shell-readiness probe directory for task $ID: mktemp could not create one under /tmp - check that it exists, is writable, and has free space" >&2
+    fi
     return 1
   fi
   marker="$SPAWN_READY_DIR/ready"
   while [ "$i" -lt "$polls" ]; do
     if [ $((i % resend_every)) -eq 0 ]; then
-      # Every resend after the first clears the input line with C-c first, so a
-      # prior attempt left half-typed - or any continuation state a partial line
-      # produced - is discarded instead of being concatenated onto this one. A
-      # bare Enter cannot escape a continuation prompt, C-c can. The tradeoff is
-      # that C-c can interrupt rc sourcing, which is acceptable only because a
-      # resend means the shell already failed to answer a whole probe window. A
-      # healthy first probe never pays it.
-      [ "$sends" -eq 0 ] || spawn_send_key "$target" C-c || true
-      spawn_send_text_line "$target" "touch $marker" || true
+      # Every resend after the first submits a bare Enter, so a prior attempt
+      # left half-typed on the input line is flushed as its own failing command
+      # instead of being concatenated onto this one. A healthy first probe never
+      # pays it.
+      #
+      # Deliberately NOT C-c, even though a bare Enter cannot escape a PS2
+      # continuation. The probe line is unquoted and metacharacter-free, so no
+      # truncation of the gate's OWN line can produce a continuation, which was
+      # C-c's only justification. Against that, C-c is a real SIGINT to whatever
+      # holds the pane's foreground: `treehouse get` can still be running at the
+      # second gate, because the settle loop below accepts a transiently settled
+      # non-project path before the shell catches up with its cd, and a relaunch
+      # endpoint is only required to be agent-free, not idle at a prompt.
+      # Interrupting either would let this gate pass over a half-created
+      # worktree - worse than the silent corruption it exists to prevent.
+      # Accepted residual: a genuinely partial line from some other cause can
+      # leave continuation state a bare Enter cannot clear. That rare liveness
+      # edge is traded away rather than risk signalling productive work, and the
+      # bounded budget still turns it into a loud refusal, never a corrupt spawn.
+      [ "$sends" -eq 0 ] || spawn_send_key "$target" Enter || true
+      send_status=0
+      spawn_send_text_line "$target" "touch $marker" || send_status=$?
       sends=$((sends + 1))
+      # A send channel that reports failure is not a pane that will not answer,
+      # and burning the whole budget would report the wrong cause. Status 2 is
+      # the adapters' distinct "input could not be cleared" verdict, terminal on
+      # sight exactly as at the TRACEPARENT send site. Any other failure gets one
+      # bounded retry on the next stride, then refuses naming the channel.
+      if [ "$send_status" -ne 0 ]; then
+        send_failures=$((send_failures + 1))
+        if [ "$send_status" -eq 2 ]; then
+          spawn_ready_cleanup
+          echo "error: shell-readiness probe input could not be cleared on $target for task $ID; refusing to send '$about'" >&2
+          return 1
+        fi
+        if [ "$send_failures" -ge 2 ]; then
+          spawn_ready_cleanup
+          echo "error: the send channel for task $ID's endpoint $target failed the shell-readiness probe $send_failures times (last status $send_status), so no probe reached the pane; refusing to send '$about' - the endpoint's send path is broken, not its shell" >&2
+          return 1
+        fi
+      fi
     fi
     if [ -e "$marker" ]; then
       spawn_ready_cleanup

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -160,13 +160,17 @@
 #   not interrupt-free end to end, though: the zellij and cmux send_text_line
 #   adapters clear their own failed submit with C-c, and gating both first sends
 #   roughly doubles the number of send_text_line calls that can reach that
-#   pre-existing adapter path. Every gate refusal names the window to inspect and
-#   says the created pane survives, because nothing here removes it.
-#   Known residual: on the herdr presentation-projection path both gates run
+#   pre-existing adapter path. Every gate refusal names the window to inspect,
+#   and the gate removes nothing itself, so on every flat layout that pane is
+#   still there afterwards.
+#   Known residuals on the herdr presentation-projection path: both gates run
 #   while this session's presentation-order lock is held, so an unresponsive pane
-#   can add up to two full poll budgets to that hold window. A concurrent herdr
-#   spawn that cannot acquire the lock meanwhile takes the same documented path it
-#   already does, warning once and falling back to the flat layout.
+#   can add up to two full poll budgets to that hold window; and the shared
+#   spawn-abort cleanup closes the exact projected task pane on any nonzero exit
+#   before the launch literal lands, this gate's refusal included, so there the
+#   named window is already gone rather than left for inspection. A concurrent
+#   herdr spawn that cannot acquire the lock meanwhile takes the same documented
+#   path it already does, warning once and falling back to the flat layout.
 #   Before a fresh ship or scout worker starts, its clean task worktree fetches
 #   origin, resolves the current remote default branch, and resets to its tip.
 #   An unreachable origin, unresolved default branch, or non-clean worktree

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -148,8 +148,10 @@
 #   bricking every spawn; FM_SPAWN_READY_BYPASS=1 is a test-fixture escape hatch
 #   for suites whose fake backend has no shell behind it, never for a live home.
 #   The marker command is sent unquoted so no truncation can strand the pane's
-#   shell in a quote continuation; a probe path that is not a plain absolute path
-#   of shell-inert characters therefore refuses the spawn rather than be sent.
+#   shell in a quote continuation. The probe directory is created under TMPDIR
+#   when that yields a plain absolute marker path, and otherwise under the same
+#   fixed /tmp root TASK_TMP uses, with one stderr notice; only a /tmp that also
+#   cannot yield a plain path refuses the spawn.
 #   Before a fresh ship or scout worker starts, its clean task worktree fetches
 #   origin, resolves the current remote default branch, and resets to its tip.
 #   An unreachable origin, unresolved default branch, or non-clean worktree
@@ -2211,8 +2213,24 @@ spawn_ready_cleanup() {
   SPAWN_READY_DIR=
 }
 
+# spawn_ready_probe_dir <root>: mktemp one probe directory under <root> and echo
+# it, or return non-zero when that root cannot yield a marker path the probe line
+# can carry unquoted. Separate from the caller so the preferred root and the
+# known-safe fallback root run the exact same validation.
+spawn_ready_probe_dir() {  # <root>
+  local dir
+  dir=$(mktemp -d "$1/fm-spawn-ready.XXXXXX") || return 1
+  case "$dir/ready" in
+    [!/]*|*[!A-Za-z0-9._/+:@-]*)
+      rm -rf "$dir" 2>/dev/null || true
+      return 1
+      ;;
+  esac
+  printf '%s\n' "$dir"
+}
+
 spawn_await_shell_ready() {  # <target> <what-the-caller-is-about-to-send>
-  local target=$1 about=$2 marker polls interval resend_every i=0 sends=0
+  local target=$1 about=$2 marker polls interval resend_every root i=0 sends=0
   [ "${FM_SPAWN_READY_BYPASS:-}" != 1 ] || return 0
   polls=${FM_SPAWN_READY_POLLS:-300}
   interval=${FM_SPAWN_READY_INTERVAL:-0.1}
@@ -2229,26 +2247,27 @@ spawn_await_shell_ready() {  # <target> <what-the-caller-is-about-to-send>
     *[1-9]*) : ;;
     *) interval=0.1 ;;
   esac
-  SPAWN_READY_DIR=$(mktemp -d "${TMPDIR:-/tmp}/fm-spawn-ready.XXXXXX") || {
-    echo "error: could not create a shell-readiness probe directory for $W" >&2
-    return 1
-  }
-  marker="$SPAWN_READY_DIR/ready"
   # The probe line carries the marker path UNQUOTED on purpose. A quoted line
   # can lose enough leading bytes to leave the pane's shell holding one
   # unbalanced quote, and from that PS2 continuation every later probe adds an
   # even number of quotes, so the parity never returns and no probe ever runs.
   # Unquoted, every head truncation still degrades to a word the shell cannot
   # run, which is the property this gate depends on. That only holds while the
-  # path needs no quoting, so refuse anything but a plain absolute path made of
-  # characters no shell reinterprets, exactly as the quote guard did before.
-  case "$marker" in
-    [!/]*|*[!A-Za-z0-9._/+:@-]*)
-      spawn_ready_cleanup
-      echo "error: shell-readiness probe path is not a plain absolute path and cannot be sent safely: $marker" >&2
-      return 1
-      ;;
-  esac
+  # path itself needs no quoting, and TMPDIR is inherited from whoever launched
+  # this spawn - so an unusable TMPDIR falls back to the same fixed /tmp root
+  # TASK_TMP already uses rather than failing a spawn over the caller's
+  # environment. Only a /tmp that also cannot yield a plain path refuses.
+  root=${TMPDIR:-/tmp}
+  SPAWN_READY_DIR=$(spawn_ready_probe_dir "$root") || SPAWN_READY_DIR=
+  if [ -z "$SPAWN_READY_DIR" ] && [ "$root" != /tmp ]; then
+    echo "notice: shell-readiness probe root $root cannot yield a plain absolute marker path; falling back to /tmp for task $ID" >&2
+    SPAWN_READY_DIR=$(spawn_ready_probe_dir /tmp) || SPAWN_READY_DIR=
+  fi
+  if [ -z "$SPAWN_READY_DIR" ]; then
+    echo "error: no shell-readiness probe directory for task $ID: /tmp yielded no plain absolute marker path, so the probe line cannot be sent without shell quoting" >&2
+    return 1
+  fi
+  marker="$SPAWN_READY_DIR/ready"
   while [ "$i" -lt "$polls" ]; do
     if [ $((i % resend_every)) -eq 0 ]; then
       # Every resend after the first clears the input line with C-c first, so a

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -143,9 +143,13 @@
 #   Orca spawn - and a pane that never answers refuses the spawn rather than
 #   launching into a possibly corrupted command. FM_SPAWN_READY_POLLS (default
 #   300), FM_SPAWN_READY_INTERVAL (default 0.1s), and FM_SPAWN_READY_RESEND_EVERY
-#   (default every 10 polls) tune that budget; FM_SPAWN_READY_BYPASS=1 is a
-#   test-fixture escape hatch for suites whose fake backend has no shell behind
-#   it, never for a live home.
+#   (default every 10 polls) tune that budget, and a zero or non-numeric value
+#   for any of the three falls back to that knob's own default rather than
+#   bricking every spawn; FM_SPAWN_READY_BYPASS=1 is a test-fixture escape hatch
+#   for suites whose fake backend has no shell behind it, never for a live home.
+#   The marker command is sent unquoted so no truncation can strand the pane's
+#   shell in a quote continuation; a probe path that is not a plain absolute path
+#   of shell-inert characters therefore refuses the spawn rather than be sent.
 #   Before a fresh ship or scout worker starts, its clean task worktree fetches
 #   origin, resolves the current remote default branch, and resets to its tip.
 #   An unreachable origin, unresolved default branch, or non-clean worktree
@@ -2213,29 +2217,49 @@ spawn_await_shell_ready() {  # <target> <what-the-caller-is-about-to-send>
   polls=${FM_SPAWN_READY_POLLS:-300}
   interval=${FM_SPAWN_READY_INTERVAL:-0.1}
   resend_every=${FM_SPAWN_READY_RESEND_EVERY:-10}
-  [ "$resend_every" -ge 1 ] 2>/dev/null || resend_every=1
+  # Fail closed on a misconfigured knob rather than let one brick spawning: a
+  # zero or non-numeric poll count would refuse every spawn without sending a
+  # single probe while the message blamed the pane, a zero resend stride would
+  # divide by zero, and a non-numeric interval would kill sleep. Each falls back
+  # to its own documented default.
+  [ "$polls" -ge 1 ] 2>/dev/null || polls=300
+  [ "$resend_every" -ge 1 ] 2>/dev/null || resend_every=10
+  case "$interval" in
+    ''|.|*[!0-9.]*|*.*.*) interval=0.1 ;;
+    *[1-9]*) : ;;
+    *) interval=0.1 ;;
+  esac
   SPAWN_READY_DIR=$(mktemp -d "${TMPDIR:-/tmp}/fm-spawn-ready.XXXXXX") || {
     echo "error: could not create a shell-readiness probe directory for $W" >&2
     return 1
   }
   marker="$SPAWN_READY_DIR/ready"
-  # The probe line carries the marker path single-quoted, which covers every
-  # path character except a single quote itself. Refuse rather than send a line
-  # whose quoting the pane's shell would parse differently than intended.
+  # The probe line carries the marker path UNQUOTED on purpose. A quoted line
+  # can lose enough leading bytes to leave the pane's shell holding one
+  # unbalanced quote, and from that PS2 continuation every later probe adds an
+  # even number of quotes, so the parity never returns and no probe ever runs.
+  # Unquoted, every head truncation still degrades to a word the shell cannot
+  # run, which is the property this gate depends on. That only holds while the
+  # path needs no quoting, so refuse anything but a plain absolute path made of
+  # characters no shell reinterprets, exactly as the quote guard did before.
   case "$marker" in
-    *\'*)
+    [!/]*|*[!A-Za-z0-9._/+:@-]*)
       spawn_ready_cleanup
-      echo "error: shell-readiness probe path contains a single quote and cannot be sent safely: $marker" >&2
+      echo "error: shell-readiness probe path is not a plain absolute path and cannot be sent safely: $marker" >&2
       return 1
       ;;
   esac
   while [ "$i" -lt "$polls" ]; do
     if [ $((i % resend_every)) -eq 0 ]; then
-      # Every resend after the first submits a bare Enter first, so a prior
-      # attempt left half-typed on the input line is flushed as its own failing
-      # command instead of being concatenated onto this one.
-      [ "$sends" -eq 0 ] || spawn_send_key "$target" Enter || true
-      spawn_send_text_line "$target" "touch '$marker'" || true
+      # Every resend after the first clears the input line with C-c first, so a
+      # prior attempt left half-typed - or any continuation state a partial line
+      # produced - is discarded instead of being concatenated onto this one. A
+      # bare Enter cannot escape a continuation prompt, C-c can. The tradeoff is
+      # that C-c can interrupt rc sourcing, which is acceptable only because a
+      # resend means the shell already failed to answer a whole probe window. A
+      # healthy first probe never pays it.
+      [ "$sends" -eq 0 ] || spawn_send_key "$target" C-c || true
+      spawn_send_text_line "$target" "touch $marker" || true
       sends=$((sends + 1))
     fi
     if [ -e "$marker" ]; then

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -206,7 +206,7 @@ family_for_basename() {
     fm-control.test.sh|fm-control-relaunch.test.sh|\
     fm-herdr-session-cleanup.test.sh|fm-send-resolve-key.test.sh|fm-send-strict.test.sh|\
     fm-send-inbox.test.sh|fm-spawn-batch.test.sh|\
-    fm-spawn-dispatch-profile.test.sh|\
+    fm-spawn-dispatch-profile.test.sh|fm-spawn-first-send.test.sh|\
     fm-trace-context-spawn.test.sh|fm-spawn-worktree-settle.test.sh|\
     fm-teardown-endpoint-safety.test.sh)
       printf '%s\n' backend-dispatch

--- a/docs/agent-control.md
+++ b/docs/agent-control.md
@@ -99,6 +99,8 @@ Switching harness is therefore one ordinary relaunch rather than a separate mech
 - An ambiguous or unreadable endpoint state refuses.
   Only a positively classified state acts.
 - `fm-spawn --relaunch` independently refuses unless the recorded endpoint is positively agent-free and its shell is sitting in the recorded worktree, so a replacement can never join a live agent or start outside the copy holding the work.
+- `fm-spawn.sh` then refuses again unless that pane's shell proves it is reading command lines, because a shell that silently drops the leading bytes of the first send would launch a corrupted command instead of failing.
+  [`bin/fm-spawn.sh`](../bin/fm-spawn.sh)'s header owns which sends are gated, the poll budget knobs, and the exact refusal wording.
 
 ## Capability matrix
 

--- a/tests/fm-spawn-first-send.test.sh
+++ b/tests/fm-spawn-first-send.test.sh
@@ -51,6 +51,7 @@ log_delivery() {
   case "$line" in
     touch\ /*)
       path=${line#touch }
+      path=${path% 2>/dev/null}
       : > "$path"
       ;;
   esac
@@ -302,13 +303,14 @@ assert_not_delivered_prefix() {
 # the intact text - `treehouse get` would arrive as `reehouse get` and no
 # prefix-anchored check on the intact form could ever fire. A probe line is an
 # intact `touch <marker>` or one of its head-truncated forms, and every marker
-# lives under a `fm-spawn-ready.` directory and is named `ready`, so anything
-# else on the wire is a leak whichever way it arrived.
+# lives under a `fm-spawn-ready.` directory and is named `ready` before the
+# probe's own stderr redirect, so anything else on the wire is a leak whichever
+# way it arrived.
 assert_only_probes_delivered() {
   local stray
   stray=$(awk '
     /^key / { next }
-    index($0, "fm-spawn-ready.") > 0 && /\/ready$/ { next }
+    index($0, "fm-spawn-ready.") > 0 && /\/ready( 2>\/dev\/null)?$/ { next }
     { print }
   ' "$DELIVERED" 2>/dev/null)
   [ -z "$stray" ] || fail \

--- a/tests/fm-spawn-first-send.test.sh
+++ b/tests/fm-spawn-first-send.test.sh
@@ -181,6 +181,11 @@ EOF
 run_spawn() {
   local id=$1 from=$2 upto=$3
   shift 3
+  # SPAWN_BACKEND selects an explicit backend for the one case that needs a
+  # non-reference adapter; unset keeps every other case on the fake tmux.
+  local -a spawn_args
+  spawn_args=("$id" "$PROJ_DIR" --mode no-mistakes --yolo off)
+  [ -z "${SPAWN_BACKEND:-}" ] || spawn_args+=(--backend "$SPAWN_BACKEND")
   # -u FM_SPAWN_READY_BYPASS: tests/lib.sh exports that bypass for every
   # fixture-based suite, and this is the suite whose whole subject is the gate.
   env -u FM_SPAWN_READY_BYPASS "$@" \
@@ -196,7 +201,65 @@ run_spawn() {
     FM_SPAWN_READY_INTERVAL=0.05 FM_SPAWN_READY_RESEND_EVERY=1 \
     TMPDIR="$CASE_TMP" \
     PATH="$FAKEBIN_DIR:$PATH" \
-    "$SPAWN" "$id" "$PROJ_DIR" --mode no-mistakes --yolo off 2>&1
+    FM_FAKE_CMUX_STATE="${CMUX_STATE:-}" \
+    "$SPAWN" "${spawn_args[@]}" 2>&1
+}
+
+# install_cmux_fake <fakebin-dir> adds a `cmux` CLI stub keyed on COMMAND SHAPE,
+# not on an ordered response queue, so the number of readiness probes a case
+# provokes cannot desynchronize it.
+#
+# It models exactly the calls a cmux ship spawn makes before the first gate, plus
+# one failure mode: every `send-key` fails. That is what makes the real adapter
+# return status 2 - fm_backend_cmux_send_text_line types the line, fails to
+# submit it with Enter, then fails to clear it with C-c, which is the "input
+# could not be cleared" condition only zellij and cmux define.
+install_cmux_fake() {
+  local fakebin=$1
+  cat > "$fakebin/cmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+STATE="${FM_FAKE_CMUX_STATE:?FM_FAKE_CMUX_STATE unset}"
+case "${1:-}" in
+  version) printf 'cmux 0.64.17 (97) [abcdef1]\n'; exit 0 ;;
+  ping) printf 'PONG\n'; exit 0 ;;
+  new-workspace)
+    shift
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --name) printf '%s\n' "${2:-}" > "$STATE/title"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    exit 0
+    ;;
+  workspace)
+    if [ "${2:-}" = list ]; then
+      if [ -f "$STATE/title" ]; then
+        printf '{"workspaces":[{"id":"ws-1","title":"%s"}]}\n' "$(cat "$STATE/title")"
+      else
+        printf '{"workspaces":[]}\n'
+      fi
+      exit 0
+    fi
+    exit 0
+    ;;
+  list-panes)
+    printf '{"panes":[{"selected_surface_id":"sf-1","surface_ids":["sf-1"]}]}\n'
+    exit 0
+    ;;
+  send)
+    printf 'literal %s\n' "${!#}" >> "${FM_FAKE_DELIVERED:?}"
+    exit 0
+    ;;
+  send-key)
+    printf 'key %s\n' "${!#}" >> "${FM_FAKE_DELIVERED:?}"
+    exit 1
+    ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/cmux"
 }
 
 # delivered_line_count <exact-line>
@@ -452,6 +515,38 @@ test_status_2_is_not_read_as_uncleared_input_on_tmux() {
   pass "status 2 is read as uncleared input only on the adapters that define it"
 }
 
+# The other half of the same contract, on a backend that really does define
+# status 2 as "input could not be cleared". There the typed `touch <marker>` is
+# sitting on the pane's input line with no way to clear it, so retrying would
+# concatenate the next probe onto it: the refusal has to fire on sight and say
+# what the adapter actually reported.
+test_uncleared_probe_input_is_terminal_on_cmux() {
+  local rec id out status
+  id=first-send-cmux-uncleared-p4
+  rec=$(make_case cmux-uncleared "$id")
+  read_case "$rec"
+  install_cmux_fake "$FAKEBIN_DIR"
+  CMUX_STATE="$CASE_TMP/cmux"
+  mkdir -p "$CMUX_STATE"
+
+  out=$(SPAWN_BACKEND=cmux run_spawn "$id" 1 0)
+  status=$?
+  CMUX_STATE=
+  [ "$status" -ne 0 ] || fail "a cmux endpoint whose input could not be cleared still spawned"
+  assert_contains "$out" "probe input could not be cleared" \
+    "the refusal did not report the uncleared input line the cmux adapter signalled"
+  assert_not_contains "$out" "send path is failing" \
+    "an uncleared-input failure fell through to the retryable send-channel path"
+  assert_not_contains "$out" "never confirmed it can read a command line" \
+    "an uncleared-input failure was reported with the pane-shell timeout message"
+  assert_not_contains "$out" "spawned $id" "spawn reported success despite uncleared pane input"
+  # Terminal on sight: exactly one probe was typed, so no second probe could be
+  # concatenated onto the line the adapter could not clear.
+  [ "$(delivered_prefix_count 'literal touch ')" = 1 ] \
+    || fail "the gate typed $(delivered_prefix_count 'literal touch ') probes into a pane whose input it could not clear, instead of refusing on sight"
+  pass "an uncleared-input send failure is terminal on sight on the adapters that define it"
+}
+
 # The bounded retry must count CONSECUTIVE failures. This is the gate's own target
 # scenario: a pane eating every probe's leading bytes while the channel itself is
 # merely intermittent. Two hiccups separated by delivered probes must still be
@@ -549,6 +644,7 @@ test_healthy_shell_pays_one_probe_per_gate
 test_misconfigured_budget_knob_falls_back_to_its_default
 test_broken_send_channel_refuses_on_the_channel_not_the_pane
 test_status_2_is_not_read_as_uncleared_input_on_tmux
+test_uncleared_probe_input_is_terminal_on_cmux
 test_intermittent_send_hiccups_still_refuse_on_the_pane
 test_unusable_tmpdir_falls_back_instead_of_refusing
 test_fixture_bypass_is_explicit

--- a/tests/fm-spawn-first-send.test.sh
+++ b/tests/fm-spawn-first-send.test.sh
@@ -12,7 +12,7 @@
 #
 # The fake tmux below is a byte-lossy shell: it drops the leading character of
 # every delivery in a configurable window, records what the pane actually
-# received, and executes a delivered `touch '<path>'` for real. That makes the
+# received, and executes a delivered `touch <path>` for real. That makes the
 # gate's own readiness signal - a marker file only a byte-exact line can create -
 # observable end to end, and lets each case assert on the exact bytes the pane
 # saw rather than on the script's source.
@@ -30,8 +30,9 @@ TMP_ROOT=$(fm_test_tmproot fm-spawn-first-send)
 # FM_FAKE_SWALLOW_FROM..FM_FAKE_SWALLOW_UNTIL inclusive lose their leading
 # character, exactly like the live incident; every delivery (corrupted or not) is
 # appended to FM_FAKE_DELIVERED so a case can assert what the pane received. A
-# delivered line of the form `touch '<path>'` is then executed for real, which is
-# the only way the readiness marker can ever appear.
+# delivered line of the form `touch <path>` is then executed for real, which is
+# the only way the readiness marker can ever appear - and, exactly like a real
+# shell, a head-truncated form is not that shape and creates nothing.
 make_lossy_fakebin() {
   local dir=$1 fakebin
   fakebin=$(fm_fakebin "$dir")
@@ -42,9 +43,8 @@ log_delivery() {
   local line=$1 path
   printf '%s\n' "$line" >> "${FM_FAKE_DELIVERED:?FM_FAKE_DELIVERED unset}"
   case "$line" in
-    touch\ \'*\')
-      path=${line#touch \'}
-      path=${path%\'}
+    touch\ /*)
+      path=${line#touch }
       : > "$path"
       ;;
   esac
@@ -73,7 +73,7 @@ case "${1:-}" in
       exit 0
     fi
     if [ "${#args[@]}" -eq 1 ]; then
-      # A bare key: the gate's pre-clear Enter, or the launch submit.
+      # A bare key: the gate's retry pre-clear C-c, or the launch submit.
       printf 'key %s\n' "${args[0]}" >> "${FM_FAKE_DELIVERED:?}"
       exit 0
     fi
@@ -259,6 +259,10 @@ test_unready_shell_fails_loudly() {
   assert_not_contains "$out" "spawned $id" "spawn reported success despite an unready shell"
   assert_not_delivered_prefix "treehouse get" \
     "treehouse get reached the pane after the readiness gate had given up"
+  # Each resend must be able to escape a continuation prompt a partial line left
+  # behind. A bare Enter cannot; C-c can, which is why the pre-clear is a C-c.
+  [ "$(delivered_line_count 'key C-c')" -ge 1 ] \
+    || fail "the gate's resends never cleared the input line, so a stranded continuation prompt would swallow every later probe"
   pass "an unready pane shell refuses the spawn loudly instead of sending into it"
 }
 
@@ -280,30 +284,70 @@ test_healthy_shell_pays_one_probe_per_gate() {
   assert_contains "$out" "spawned $id" "spawn did not report success"
   first_line=$(sed -n '1p' "$DELIVERED")
   case "$first_line" in
-    touch\ \'*) : ;;
+    touch\ /*) : ;;
     *) fail "the readiness probe did not precede the first task command (first delivery: '$first_line')" ;;
   esac
+  [ "$(delivered_line_count 'key C-c')" = 0 ] \
+    || fail "a healthy shell should never pay the gate's retry pre-clear C-c"
   [ "$(delivered_line_count 'key Enter')" = 1 ] \
-    || fail "a healthy shell should need no pre-clear Enter retry, only the launch submit"
+    || fail "a healthy spawn should send exactly one bare Enter, the launch submit"
   [ "$elapsed" -le 8 ] || fail "a healthy spawn took ${elapsed}s - the gate is charging retries it should not need"
   pass "a healthy pane answers the first probe, and the probe precedes the command it guards"
 }
 
 # The probe directory is scratch: it must never survive the spawn, on the
 # success path or the refusal path.
+#
+# The refusal half runs against its own fully scaffolded fixture rather than a
+# made-up id on the success fixture. An id with no brief dies at fm-spawn's
+# brief check, long before a pane or a probe directory exists, so the cleanup
+# assertion would pass vacuously. The case therefore proves the refusal actually
+# came from the readiness gate before it trusts what the gate left behind.
 test_probe_scratch_is_cleaned_up() {
-  local rec id before after
+  local rec id out status before after
+  before=$(count_probe_scratch)
+
   id=first-send-scratch-e5
   rec=$(make_case scratch "$id")
   read_case "$rec"
+  out=$(run_spawn "$id" 1 0)
+  status=$?
+  expect_code 0 "$status" "the success half of the cleanup case never spawned"
+  assert_contains "$out" "spawned $id" "the success half of the cleanup case never spawned"
 
-  before=$(count_probe_scratch)
-  run_spawn "$id" 1 0 >/dev/null 2>&1
-  run_spawn "$id-refused" 1 100000 FM_SPAWN_READY_POLLS=2 >/dev/null 2>&1 || true
+  id=first-send-scratch-refused-g7
+  rec=$(make_case scratch-refused "$id")
+  read_case "$rec"
+  out=$(run_spawn "$id" 1 100000 FM_SPAWN_READY_POLLS=2)
+  status=$?
+  [ "$status" -ne 0 ] || fail "the refusal half of the cleanup case did not refuse"
+  assert_contains "$out" "never confirmed it can read a command line" \
+    "the refusal half never reached the readiness gate, so its cleanup is unproven"
+
   after=$(count_probe_scratch)
   [ "$after" -le "$before" ] \
     || fail "readiness probe scratch directories leaked (before=$before after=$after)"
   pass "readiness probe scratch is removed on both the success and refusal paths"
+}
+
+# A misconfigured budget knob must not brick spawning. A zero poll count would
+# otherwise skip the probe loop entirely and refuse every spawn with a message
+# blaming a pane that was never asked anything, so it falls back to the default.
+test_misconfigured_budget_knob_falls_back_to_its_default() {
+  local rec id out status
+  id=first-send-bad-knob-h8
+  rec=$(make_case bad-knob "$id")
+  read_case "$rec"
+
+  out=$(run_spawn "$id" 1 0 FM_SPAWN_READY_POLLS=0)
+  status=$?
+  expect_code 0 "$status" "a zero poll count refused a spawn a healthy pane should have passed"
+  assert_contains "$out" "spawned $id" "spawn did not report success"
+  assert_not_contains "$out" "never confirmed it can read a command line" \
+    "a zero poll count made the gate blame the pane instead of falling back to its default"
+  assert_delivered_prefix "treehouse get" \
+    "the pane never received an intact treehouse get"
+  pass "a zero budget knob falls back to its default instead of refusing every spawn"
 }
 
 # The fixture escape hatch has to be explicit, and it has to be the ONLY thing
@@ -329,6 +373,7 @@ test_swallowed_leading_bytes_never_corrupt_the_first_command
 test_second_gate_protects_the_launch_environment
 test_unready_shell_fails_loudly
 test_healthy_shell_pays_one_probe_per_gate
+test_misconfigured_budget_knob_falls_back_to_its_default
 test_fixture_bypass_is_explicit
 test_probe_scratch_is_cleaned_up
 

--- a/tests/fm-spawn-first-send.test.sh
+++ b/tests/fm-spawn-first-send.test.sh
@@ -33,6 +33,10 @@ TMP_ROOT=$(fm_test_tmproot fm-spawn-first-send)
 # delivered line of the form `touch <path>` is then executed for real, which is
 # the only way the readiness marker can ever appear - and, exactly like a real
 # shell, a head-truncated form is not that shape and creates nothing.
+#
+# FM_FAKE_SEND_FAIL_STATUS models the other failure mode: a send channel that
+# reports the given exit status and delivers nothing at all, which is what a
+# closed or renumbered pane looks like to the adapters.
 make_lossy_fakebin() {
   local dir=$1 fakebin
   fakebin=$(fm_fakebin "$dir")
@@ -73,11 +77,17 @@ case "${1:-}" in
       exit 0
     fi
     if [ "${#args[@]}" -eq 1 ]; then
-      # A bare key: the gate's retry pre-clear C-c, or the launch submit.
+      # A bare key: the gate's retry pre-clear Enter, or the launch submit.
       printf 'key %s\n' "${args[0]}" >> "${FM_FAKE_DELIVERED:?}"
       exit 0
     fi
     text=${args[0]}
+    if [ -n "${FM_FAKE_SEND_FAIL_STATUS:-}" ]; then
+      # A send channel that reports failure and delivers nothing. The attempt is
+      # still recorded so a case can count how many the caller made.
+      printf 'send-failed %s\n' "$FM_FAKE_SEND_FAIL_STATUS" >> "${FM_FAKE_DELIVERED:?}"
+      exit "$FM_FAKE_SEND_FAIL_STATUS"
+    fi
     countfile="${FM_FAKE_DELIVERY_COUNTFILE:?FM_FAKE_DELIVERY_COUNTFILE unset}"
     seenfile="$countfile.post-treehouse"
     n=0
@@ -289,10 +299,13 @@ test_unready_shell_fails_loudly() {
   assert_not_contains "$out" "spawned $id" "spawn reported success despite an unready shell"
   assert_only_probes_delivered \
     "a task command reached the pane after the readiness gate had given up"
-  # Each resend must be able to escape a continuation prompt a partial line left
-  # behind. A bare Enter cannot; C-c can, which is why the pre-clear is a C-c.
-  [ "$(delivered_line_count 'key C-c')" -ge 1 ] \
-    || fail "the gate's resends never cleared the input line, so a stranded continuation prompt would swallow every later probe"
+  # Each resend flushes whatever a prior attempt left half-typed, so it cannot be
+  # concatenated onto the next probe. It must be a bare Enter and never an
+  # interrupt: the pane may still be running productive work at this point.
+  [ "$(delivered_line_count 'key Enter')" -ge 1 ] \
+    || fail "the gate's resends never flushed the input line, so a half-typed probe would be concatenated onto the next one"
+  [ "$(delivered_line_count 'key C-c')" = 0 ] \
+    || fail "the gate sent an interrupt into the pane, which can signal foreground work such as treehouse get"
   pass "an unready pane shell refuses the spawn loudly instead of sending into it"
 }
 
@@ -317,8 +330,13 @@ test_healthy_shell_pays_one_probe_per_gate() {
     touch\ /*) : ;;
     *) fail "the readiness probe did not precede the first task command (first delivery: '$first_line')" ;;
   esac
-  [ "$(delivered_line_count 'key C-c')" = 0 ] \
-    || fail "a healthy shell should never pay the gate's retry pre-clear C-c"
+  # The count the case name claims, pinned exactly. The fake shell creates the
+  # marker synchronously inside the send, so a healthy gate's very next marker
+  # check succeeds and each of the two gates owes exactly one probe. A regression
+  # that re-probed on the next stride before checking would slide under the 8s
+  # bound and leave every other assertion here true.
+  [ "$(delivered_prefix_count 'touch ')" = 2 ] \
+    || fail "a healthy spawn sent $(delivered_prefix_count 'touch ') readiness probes, not one per gate"
   [ "$(delivered_line_count 'key Enter')" = 1 ] \
     || fail "a healthy spawn should send exactly one bare Enter, the launch submit"
   [ "$elapsed" -le 8 ] || fail "a healthy spawn took ${elapsed}s - the gate is charging retries it should not need"
@@ -358,6 +376,59 @@ test_probe_scratch_is_cleaned_up() {
   [ "$(count_probe_scratch)" = 0 ] \
     || fail "readiness probe scratch survived a refused spawn ($(count_probe_scratch) left in $CASE_TMP)"
   pass "readiness probe scratch is removed on both the success and refusal paths"
+}
+
+# A send channel that reports failure is not a pane refusing to answer, and the
+# refusal has to say so. Before the gate existed, a non-zero send aborted the
+# spawn at once under set -eu; swallowing the status would instead spend the whole
+# poll budget and then blame the pane's shell for a probe that never left the box.
+test_broken_send_channel_refuses_on_the_channel_not_the_pane() {
+  local rec id out status start end elapsed
+  id=first-send-dead-channel-k1
+  rec=$(make_case dead-channel "$id")
+  read_case "$rec"
+
+  start=$(date +%s)
+  out=$(run_spawn "$id" 1 0 FM_FAKE_SEND_FAIL_STATUS=1)
+  status=$?
+  end=$(date +%s)
+  elapsed=$((end - start))
+  [ "$status" -ne 0 ] || fail "a send channel that delivered no probe at all still spawned"
+  assert_contains "$out" "send path is broken, not its shell" \
+    "the refusal did not attribute the failure to the send channel"
+  assert_not_contains "$out" "never confirmed it can read a command line" \
+    "a send-channel failure was reported with the pane-shell timeout message"
+  assert_not_contains "$out" "spawned $id" "spawn reported success despite a dead send channel"
+  # One bounded retry, then refuse - not the whole poll budget. run_spawn's
+  # 300 polls at 0.05s would be 15s if the status were swallowed.
+  [ "$(delivered_line_count 'send-failed 1')" = 2 ] \
+    || fail "the gate made $(delivered_line_count 'send-failed 1') probe attempts, not one bounded retry"
+  [ "$elapsed" -le 8 ] \
+    || fail "a dead send channel cost ${elapsed}s - the gate spent its poll budget instead of refusing on the send error"
+  pass "a failing send channel refuses promptly and names the channel, not the pane"
+}
+
+# Status 2 is the adapters' distinct "input could not be cleared" verdict, which
+# fm-spawn already treats as terminal at the TRACEPARENT send site. It must not be
+# collapsed into the retryable case: a pane whose input cannot be cleared would
+# concatenate the probe onto whatever is already on the line.
+test_uncleared_probe_input_is_terminal() {
+  local rec id out status
+  id=first-send-uncleared-m2
+  rec=$(make_case uncleared "$id")
+  read_case "$rec"
+
+  out=$(run_spawn "$id" 1 0 FM_FAKE_SEND_FAIL_STATUS=2)
+  status=$?
+  [ "$status" -ne 0 ] || fail "an uncleared-input send failure still spawned"
+  assert_contains "$out" "probe input could not be cleared" \
+    "the refusal did not name the uncleared input as the cause"
+  assert_not_contains "$out" "never confirmed it can read a command line" \
+    "an uncleared-input failure was reported with the pane-shell timeout message"
+  assert_not_contains "$out" "spawned $id" "spawn reported success despite uncleared pane input"
+  [ "$(delivered_line_count 'send-failed 2')" = 1 ] \
+    || fail "an uncleared-input failure was retried $(delivered_line_count 'send-failed 2') times instead of being terminal on sight"
+  pass "an uncleared-input send failure is terminal on sight rather than retried"
 }
 
 # The probe root is derived from an INHERITED TMPDIR, so a TMPDIR that cannot
@@ -430,6 +501,8 @@ test_second_gate_protects_the_launch_environment
 test_unready_shell_fails_loudly
 test_healthy_shell_pays_one_probe_per_gate
 test_misconfigured_budget_knob_falls_back_to_its_default
+test_broken_send_channel_refuses_on_the_channel_not_the_pane
+test_uncleared_probe_input_is_terminal
 test_unusable_tmpdir_falls_back_instead_of_refusing
 test_fixture_bypass_is_explicit
 test_probe_scratch_is_cleaned_up

--- a/tests/fm-spawn-first-send.test.sh
+++ b/tests/fm-spawn-first-send.test.sh
@@ -1,0 +1,335 @@
+#!/usr/bin/env bash
+# Regression test for fm-spawn.sh's shell-readiness gate on the first text line
+# sent into a pane (bin/fm-spawn.sh, spawn_await_shell_ready).
+#
+# A freshly created pane's shell can still be sourcing its rc files when the
+# first send lands, and a slow init eats the leading byte(s). Seen live on herdr
+# under load (2026-08-17): the leading 't' of `treehouse get` was swallowed three
+# times running, the pane ran `reehouse get`, and the worktree was never entered -
+# with nothing on firstmate's side to notice. The gate proves the shell is
+# reading command lines before trusting a send, so a corrupted first line can no
+# longer reach the pane silently.
+#
+# The fake tmux below is a byte-lossy shell: it drops the leading character of
+# every delivery in a configurable window, records what the pane actually
+# received, and executes a delivered `touch '<path>'` for real. That makes the
+# gate's own readiness signal - a marker file only a byte-exact line can create -
+# observable end to end, and lets each case assert on the exact bytes the pane
+# saw rather than on the script's source.
+set -u
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+SPAWN="$ROOT/bin/fm-spawn.sh"
+TMP_ROOT=$(fm_test_tmproot fm-spawn-first-send)
+
+# make_lossy_fakebin <dir> builds a fake tmux that models the pane's shell.
+#
+# Every `send-keys -t <target> <text> Enter` is one delivery. Deliveries numbered
+# FM_FAKE_SWALLOW_FROM..FM_FAKE_SWALLOW_UNTIL inclusive lose their leading
+# character, exactly like the live incident; every delivery (corrupted or not) is
+# appended to FM_FAKE_DELIVERED so a case can assert what the pane received. A
+# delivered line of the form `touch '<path>'` is then executed for real, which is
+# the only way the readiness marker can ever appear.
+make_lossy_fakebin() {
+  local dir=$1 fakebin
+  fakebin=$(fm_fakebin "$dir")
+  cat > "$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -u
+log_delivery() {
+  local line=$1 path
+  printf '%s\n' "$line" >> "${FM_FAKE_DELIVERED:?FM_FAKE_DELIVERED unset}"
+  case "$line" in
+    touch\ \'*\')
+      path=${line#touch \'}
+      path=${path%\'}
+      : > "$path"
+      ;;
+  esac
+}
+case "$*" in
+  *'#{pane_current_path}'*)
+    printf '%s\n' "${FM_FAKE_PANE_PATH:-}"
+    exit 0
+    ;;
+esac
+case "${1:-}" in
+  send-keys)
+    shift
+    literal=0
+    args=()
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        -t) shift 2 ;;
+        -l) literal=1; shift ;;
+        *) args+=("$1"); shift ;;
+      esac
+    done
+    if [ "$literal" = 1 ]; then
+      # A literal send types without submitting, so it is not a delivery yet.
+      printf 'literal %s\n' "${args[0]:-}" >> "${FM_FAKE_DELIVERED:?}"
+      exit 0
+    fi
+    if [ "${#args[@]}" -eq 1 ]; then
+      # A bare key: the gate's pre-clear Enter, or the launch submit.
+      printf 'key %s\n' "${args[0]}" >> "${FM_FAKE_DELIVERED:?}"
+      exit 0
+    fi
+    text=${args[0]}
+    countfile="${FM_FAKE_DELIVERY_COUNTFILE:?FM_FAKE_DELIVERY_COUNTFILE unset}"
+    seenfile="$countfile.post-treehouse"
+    n=0
+    [ -f "$countfile" ] && n=$(cat "$countfile")
+    n=$((n + 1))
+    printf '%s\n' "$n" > "$countfile"
+    if [ "$n" -ge "${FM_FAKE_SWALLOW_FROM:-1}" ] \
+       && [ "$n" -le "${FM_FAKE_SWALLOW_UNTIL:-0}" ]; then
+      text=${text:1}
+    elif [ -f "$seenfile" ]; then
+      used=$(cat "$seenfile")
+      if [ "$used" -lt "${FM_FAKE_SWALLOW_AFTER_TREEHOUSE:-0}" ]; then
+        text=${text:1}
+        printf '%s\n' "$((used + 1))" > "$seenfile"
+      fi
+    fi
+    # Opening the post-treehouse window on the delivery CONTENT, not on a
+    # delivery number, keeps the case independent of how many probes the
+    # implementation sends - so it still corrupts the launch environment when the
+    # gate is absent, which is what makes the case non-vacuous.
+    if [ "$text" = 'treehouse get' ] && [ ! -f "$seenfile" ]; then
+      printf '0\n' > "$seenfile"
+    fi
+    log_delivery "$text"
+    exit 0
+    ;;
+  display-message) printf 'firstmate\n'; exit 0 ;;
+  list-windows) exit 0 ;;
+  has-session|new-session|new-window|kill-window) exit 0 ;;
+esac
+exit 0
+SH
+  chmod +x "$fakebin/tmux"
+  fm_fake_exit0 "$fakebin" treehouse
+  printf '%s\n' "$fakebin"
+}
+
+# make_case <name> <id> builds a home plus a real project/worktree pair, and
+# echoes the per-case paths the run helper needs.
+make_case() {
+  local name=$1 id=$2 case_dir home proj wt fakebin
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  proj="$case_dir/project"
+  wt="$case_dir/wt"
+  fakebin=$(make_lossy_fakebin "$case_dir/fake")
+  mkdir -p "$home/data" "$home/projects" "$home/state" "$home/config"
+  printf 'codex\n' > "$home/config/crew-harness"
+  fm_git_worktree "$proj" "$wt" "wt-$name"
+  mkdir -p "$home/data/$id"
+  printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
+  touch "$home/state/.last-watcher-beat"
+  printf '%s|%s|%s|%s|%s|%s\n' \
+    "$home" "$proj" "$wt" "$fakebin" "$case_dir/delivered" "$case_dir/delivery-count"
+}
+
+read_case() {
+  IFS='|' read -r HOME_DIR PROJ_DIR WT_DIR FAKEBIN_DIR DELIVERED COUNTFILE <<EOF
+$1
+EOF
+}
+
+# run_spawn <id> <swallow-from> <swallow-until> [extra KEY=VAL ...]
+run_spawn() {
+  local id=$1 from=$2 upto=$3
+  shift 3
+  # -u FM_SPAWN_READY_BYPASS: tests/lib.sh exports that bypass for every
+  # fixture-based suite, and this is the suite whose whole subject is the gate.
+  env -u FM_SPAWN_READY_BYPASS "$@" \
+    FM_ROOT_OVERRIDE='' FM_HOME="$HOME_DIR" \
+    FM_STATE_OVERRIDE="$HOME_DIR/state" FM_DATA_OVERRIDE="$HOME_DIR/data" \
+    FM_PROJECTS_OVERRIDE="$HOME_DIR/projects" FM_CONFIG_OVERRIDE="$HOME_DIR/config" \
+    FM_SPAWN_NO_GUARD=1 TMUX="fake,1,0" \
+    FM_FAKE_PANE_PATH="$WT_DIR" \
+    FM_FAKE_DELIVERED="$DELIVERED" \
+    FM_FAKE_DELIVERY_COUNTFILE="$COUNTFILE" \
+    FM_FAKE_SWALLOW_FROM="$from" FM_FAKE_SWALLOW_UNTIL="$upto" \
+    FM_FAKE_SWALLOW_AFTER_TREEHOUSE="${FM_FAKE_SWALLOW_AFTER_TREEHOUSE:-0}" \
+    FM_SPAWN_READY_INTERVAL=0.05 FM_SPAWN_READY_RESEND_EVERY=1 \
+    PATH="$FAKEBIN_DIR:$PATH" \
+    "$SPAWN" "$id" "$PROJ_DIR" --mode no-mistakes --yolo off 2>&1
+}
+
+# delivered_line_count <exact-line>
+delivered_line_count() {
+  grep -c -x -F -- "$1" "$DELIVERED" 2>/dev/null || true
+}
+
+# count_probe_scratch: how many readiness probe directories exist right now.
+count_probe_scratch() {
+  find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'fm-spawn-ready.*' 2>/dev/null | wc -l | tr -d ' '
+}
+
+# delivered_prefix_count <prefix>: delivered lines that START with <prefix>.
+# Anchored on purpose: every truncated form this suite must catch is a substring
+# of its intact form (`reehouse get` sits inside `treehouse get`), so an
+# unanchored match cannot tell the two apart.
+delivered_prefix_count() {
+  awk -v want="$1" 'index($0, want) == 1 { n++ } END { print n + 0 }' \
+    "$DELIVERED" 2>/dev/null || printf '0\n'
+}
+
+# assert_delivered_prefix <prefix> <msg>
+assert_delivered_prefix() {
+  [ "$(delivered_prefix_count "$1")" -gt 0 ] || fail \
+    "$2 (no delivered line starts with '$1')"$'\n'"--- delivered ---"$'\n'"$(cat "$DELIVERED" 2>/dev/null)"
+}
+
+# assert_not_delivered_prefix <prefix> <msg>
+assert_not_delivered_prefix() {
+  [ "$(delivered_prefix_count "$1")" -eq 0 ] || fail \
+    "$2 (a delivered line starts with '$1')"$'\n'"--- delivered ---"$'\n'"$(cat "$DELIVERED" 2>/dev/null)"
+}
+
+# The live incident: the first three deliveries lose their leading byte. The
+# gate must absorb all three on its own probe and hand the pane an intact
+# `treehouse get`, never the truncated `reehouse get` that reached it before.
+test_swallowed_leading_bytes_never_corrupt_the_first_command() {
+  local rec id out status
+  id=first-send-swallow-three-a1
+  rec=$(make_case swallow-three "$id")
+  read_case "$rec"
+
+  out=$(run_spawn "$id" 1 3)
+  status=$?
+  expect_code 0 "$status" "spawn should succeed once the gate absorbs the lossy window"
+  assert_contains "$out" "spawned $id" "spawn did not report success"
+  assert_delivered_prefix "treehouse get" \
+    "the pane never received an intact treehouse get"
+  assert_not_delivered_prefix "reehouse get" \
+    "the pane received a head-truncated treehouse get - the gate did not absorb the loss"
+  [ "$(delivered_line_count 'treehouse get')" = 1 ] \
+    || fail "treehouse get was not delivered exactly once"
+  pass "a lossy shell init cannot corrupt the first command line"
+}
+
+# The loss window opens only AFTER treehouse get, so the second gate - the one
+# covering the launch environment sent into treehouse's new subshell - is the one
+# that has to absorb it. That send is the path a leading-space mitigation on the
+# treehouse line alone leaves unprotected.
+test_second_gate_protects_the_launch_environment() {
+  local rec id out status
+  id=first-send-swallow-later-b2
+  rec=$(make_case swallow-later "$id")
+  read_case "$rec"
+
+  # The lossy window opens on the delivery AFTER treehouse get lands, so it
+  # corrupts only the post-subshell sends however many probes precede them.
+  out=$(FM_FAKE_SWALLOW_AFTER_TREEHOUSE=3 run_spawn "$id" 1 0)
+  status=$?
+  expect_code 0 "$status" "spawn should succeed once the second gate absorbs the lossy window"
+  assert_contains "$out" "spawned $id" "spawn did not report success"
+  assert_delivered_prefix "treehouse get" \
+    "the pane never received an intact treehouse get"
+  assert_delivered_prefix "export GOTMPDIR=" \
+    "the pane never received an intact launch environment"
+  assert_not_delivered_prefix "xport GOTMPDIR=" \
+    "the pane received a head-truncated launch environment - that send was unguarded"
+  pass "the launch-environment send is guarded too, not only treehouse get"
+}
+
+# A shell that never accepts a line must stop the spawn loudly. Silently
+# proceeding is the exact failure this change exists to remove, so the refusal
+# has to be an error exit that names the send it refused - and no task command
+# may reach the pane after it.
+test_unready_shell_fails_loudly() {
+  local rec id out status
+  id=first-send-never-ready-c3
+  rec=$(make_case never-ready "$id")
+  read_case "$rec"
+
+  out=$(run_spawn "$id" 1 100000 FM_SPAWN_READY_POLLS=3)
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn exited 0 with a shell that never accepted a command line"
+  assert_contains "$out" "never confirmed it can read a command line" \
+    "the refusal did not explain that the pane shell was never proven ready"
+  assert_contains "$out" "treehouse get" \
+    "the refusal did not name the send it refused"
+  assert_not_contains "$out" "spawned $id" "spawn reported success despite an unready shell"
+  assert_not_delivered_prefix "treehouse get" \
+    "treehouse get reached the pane after the readiness gate had given up"
+  pass "an unready pane shell refuses the spawn loudly instead of sending into it"
+}
+
+# The gate must not tax a healthy spawn: a shell that answers the first probe
+# costs one poll interval per gated send, not a retry cycle. It must also run
+# BEFORE the command it protects, which the delivery order proves.
+test_healthy_shell_pays_one_probe_per_gate() {
+  local rec id out status start end elapsed first_line
+  id=first-send-healthy-d4
+  rec=$(make_case healthy "$id")
+  read_case "$rec"
+
+  start=$(date +%s)
+  out=$(run_spawn "$id" 1 0)
+  status=$?
+  end=$(date +%s)
+  elapsed=$((end - start))
+  expect_code 0 "$status" "spawn should succeed against a healthy shell"
+  assert_contains "$out" "spawned $id" "spawn did not report success"
+  first_line=$(sed -n '1p' "$DELIVERED")
+  case "$first_line" in
+    touch\ \'*) : ;;
+    *) fail "the readiness probe did not precede the first task command (first delivery: '$first_line')" ;;
+  esac
+  [ "$(delivered_line_count 'key Enter')" = 1 ] \
+    || fail "a healthy shell should need no pre-clear Enter retry, only the launch submit"
+  [ "$elapsed" -le 8 ] || fail "a healthy spawn took ${elapsed}s - the gate is charging retries it should not need"
+  pass "a healthy pane answers the first probe, and the probe precedes the command it guards"
+}
+
+# The probe directory is scratch: it must never survive the spawn, on the
+# success path or the refusal path.
+test_probe_scratch_is_cleaned_up() {
+  local rec id before after
+  id=first-send-scratch-e5
+  rec=$(make_case scratch "$id")
+  read_case "$rec"
+
+  before=$(count_probe_scratch)
+  run_spawn "$id" 1 0 >/dev/null 2>&1
+  run_spawn "$id-refused" 1 100000 FM_SPAWN_READY_POLLS=2 >/dev/null 2>&1 || true
+  after=$(count_probe_scratch)
+  [ "$after" -le "$before" ] \
+    || fail "readiness probe scratch directories leaked (before=$before after=$after)"
+  pass "readiness probe scratch is removed on both the success and refusal paths"
+}
+
+# The fixture escape hatch has to be explicit, and it has to be the ONLY thing
+# that stands the gate down: the same never-ready pane that refuses above must
+# spawn when FM_SPAWN_READY_BYPASS=1 is set, and only then. Pinning both halves
+# keeps a future change from quietly turning the gate into a no-op by default.
+test_fixture_bypass_is_explicit() {
+  local rec id out status
+  id=first-send-bypass-f6
+  rec=$(make_case bypass "$id")
+  read_case "$rec"
+
+  out=$(run_spawn "$id" 1 100000 FM_SPAWN_READY_POLLS=3 FM_SPAWN_READY_BYPASS=1)
+  status=$?
+  expect_code 0 "$status" "an explicitly bypassed gate should not stop a fixture spawn"
+  assert_contains "$out" "spawned $id" "the bypassed spawn did not report success"
+  assert_not_contains "$out" "never confirmed it can read a command line" \
+    "the gate still refused despite an explicit bypass"
+  pass "the gate stands down only for an explicit fixture bypass"
+}
+
+test_swallowed_leading_bytes_never_corrupt_the_first_command
+test_second_gate_protects_the_launch_environment
+test_unready_shell_fails_loudly
+test_healthy_shell_pays_one_probe_per_gate
+test_fixture_bypass_is_explicit
+test_probe_scratch_is_cleaned_up
+
+echo "# all fm-spawn-first-send tests passed"

--- a/tests/fm-spawn-first-send.test.sh
+++ b/tests/fm-spawn-first-send.test.sh
@@ -36,7 +36,9 @@ TMP_ROOT=$(fm_test_tmproot fm-spawn-first-send)
 #
 # FM_FAKE_SEND_FAIL_STATUS models the other failure mode: a send channel that
 # reports the given exit status and delivers nothing at all, which is what a
-# closed or renumbered pane looks like to the adapters.
+# closed or renumbered pane looks like to the adapters. FM_FAKE_SEND_FAIL_ATTEMPTS
+# narrows that to a list of attempt numbers, which models a channel that hiccups
+# and then recovers rather than one that is simply dead.
 make_lossy_fakebin() {
   local dir=$1 fakebin
   fakebin=$(fm_fakebin "$dir")
@@ -83,10 +85,28 @@ case "${1:-}" in
     fi
     text=${args[0]}
     if [ -n "${FM_FAKE_SEND_FAIL_STATUS:-}" ]; then
-      # A send channel that reports failure and delivers nothing. The attempt is
-      # still recorded so a case can count how many the caller made.
-      printf 'send-failed %s\n' "$FM_FAKE_SEND_FAIL_STATUS" >> "${FM_FAKE_DELIVERED:?}"
-      exit "$FM_FAKE_SEND_FAIL_STATUS"
+      # A send channel that reports failure and delivers nothing. Attempts are
+      # numbered on their own counter, so a failed send never advances the
+      # delivery numbering the loss window keys on. With no attempt list every
+      # attempt fails; with one, only the listed attempt numbers do, which is how
+      # a case models a channel that hiccups between delivered probes. The
+      # attempt is recorded either way so a case can count what the caller made.
+      attemptfile="${FM_FAKE_DELIVERY_COUNTFILE:?}.send-attempts"
+      a=0
+      [ -f "$attemptfile" ] && a=$(cat "$attemptfile")
+      a=$((a + 1))
+      printf '%s\n' "$a" > "$attemptfile"
+      fail_this=1
+      if [ -n "${FM_FAKE_SEND_FAIL_ATTEMPTS:-}" ]; then
+        fail_this=0
+        for want in ${FM_FAKE_SEND_FAIL_ATTEMPTS}; do
+          [ "$want" = "$a" ] && fail_this=1
+        done
+      fi
+      if [ "$fail_this" = 1 ]; then
+        printf 'send-failed %s\n' "$FM_FAKE_SEND_FAIL_STATUS" >> "${FM_FAKE_DELIVERED:?}"
+        exit "$FM_FAKE_SEND_FAIL_STATUS"
+      fi
     fi
     countfile="${FM_FAKE_DELIVERY_COUNTFILE:?FM_FAKE_DELIVERY_COUNTFILE unset}"
     seenfile="$countfile.post-treehouse"
@@ -394,7 +414,7 @@ test_broken_send_channel_refuses_on_the_channel_not_the_pane() {
   end=$(date +%s)
   elapsed=$((end - start))
   [ "$status" -ne 0 ] || fail "a send channel that delivered no probe at all still spawned"
-  assert_contains "$out" "send path is broken, not its shell" \
+  assert_contains "$out" "send path is failing, not its shell" \
     "the refusal did not attribute the failure to the send channel"
   assert_not_contains "$out" "never confirmed it can read a command line" \
     "a send-channel failure was reported with the pane-shell timeout message"
@@ -408,27 +428,53 @@ test_broken_send_channel_refuses_on_the_channel_not_the_pane() {
   pass "a failing send channel refuses promptly and names the channel, not the pane"
 }
 
-# Status 2 is the adapters' distinct "input could not be cleared" verdict, which
-# fm-spawn already treats as terminal at the TRACEPARENT send site. It must not be
-# collapsed into the retryable case: a pane whose input cannot be cleared would
-# concatenate the probe onto whatever is already on the line.
-test_uncleared_probe_input_is_terminal() {
+# Status 2 means "input could not be cleared" only on zellij and cmux, which are
+# the adapters that define it. This suite drives the reference tmux backend, where
+# 2 carries no such meaning - orca, for instance, returns it for invalid JSON or an
+# ok:false response - so it must get the ordinary bounded retry and a refusal that
+# does not name a cause the backend never reported.
+test_status_2_is_not_read_as_uncleared_input_on_tmux() {
   local rec id out status
-  id=first-send-uncleared-m2
-  rec=$(make_case uncleared "$id")
+  id=first-send-status2-m2
+  rec=$(make_case status2 "$id")
   read_case "$rec"
 
   out=$(run_spawn "$id" 1 0 FM_FAKE_SEND_FAIL_STATUS=2)
   status=$?
-  [ "$status" -ne 0 ] || fail "an uncleared-input send failure still spawned"
-  assert_contains "$out" "probe input could not be cleared" \
-    "the refusal did not name the uncleared input as the cause"
-  assert_not_contains "$out" "never confirmed it can read a command line" \
-    "an uncleared-input failure was reported with the pane-shell timeout message"
-  assert_not_contains "$out" "spawned $id" "spawn reported success despite uncleared pane input"
-  [ "$(delivered_line_count 'send-failed 2')" = 1 ] \
-    || fail "an uncleared-input failure was retried $(delivered_line_count 'send-failed 2') times instead of being terminal on sight"
-  pass "an uncleared-input send failure is terminal on sight rather than retried"
+  [ "$status" -ne 0 ] || fail "a send channel returning status 2 still spawned"
+  assert_not_contains "$out" "probe input could not be cleared" \
+    "a tmux send failure was blamed on an uncleared input line, which tmux never reports"
+  assert_contains "$out" "send path is failing" \
+    "the refusal did not attribute the failure to the send channel"
+  assert_not_contains "$out" "spawned $id" "spawn reported success despite a failing send channel"
+  [ "$(delivered_line_count 'send-failed 2')" = 2 ] \
+    || fail "status 2 skipped the bounded retry every other backend gets ($(delivered_line_count 'send-failed 2') attempts)"
+  pass "status 2 is read as uncleared input only on the adapters that define it"
+}
+
+# The bounded retry must count CONSECUTIVE failures. This is the gate's own target
+# scenario: a pane eating every probe's leading bytes while the channel itself is
+# merely intermittent. Two hiccups separated by delivered probes must still be
+# refused as a pane-shell timeout, because that is what actually happened - a
+# cumulative counter would abort on the send channel and name the wrong fault.
+test_intermittent_send_hiccups_still_refuse_on_the_pane() {
+  local rec id out status
+  id=first-send-hiccup-n3
+  rec=$(make_case hiccup "$id")
+  read_case "$rec"
+
+  out=$(run_spawn "$id" 1 100000 FM_SPAWN_READY_POLLS=6 \
+    FM_FAKE_SEND_FAIL_STATUS=1 FM_FAKE_SEND_FAIL_ATTEMPTS='1 3')
+  status=$?
+  [ "$status" -ne 0 ] || fail "a pane that never answered a probe still spawned"
+  assert_contains "$out" "never confirmed it can read a command line" \
+    "two non-consecutive send hiccups were reported as a broken send channel instead of an unready pane"
+  assert_not_contains "$out" "send path is failing" \
+    "a channel that delivered probes between two hiccups was declared broken"
+  # Both hiccups really happened, so the case is exercising the path it claims.
+  [ "$(delivered_line_count 'send-failed 1')" = 2 ] \
+    || fail "the fixture produced $(delivered_line_count 'send-failed 1') send hiccups, not the two this case needs"
+  pass "intermittent send hiccups do not turn an unready pane into a send-channel abort"
 }
 
 # The probe root is derived from an INHERITED TMPDIR, so a TMPDIR that cannot
@@ -502,7 +548,8 @@ test_unready_shell_fails_loudly
 test_healthy_shell_pays_one_probe_per_gate
 test_misconfigured_budget_knob_falls_back_to_its_default
 test_broken_send_channel_refuses_on_the_channel_not_the_pane
-test_uncleared_probe_input_is_terminal
+test_status_2_is_not_read_as_uncleared_input_on_tmux
+test_intermittent_send_hiccups_still_refuse_on_the_pane
 test_unusable_tmpdir_falls_back_instead_of_refusing
 test_fixture_bypass_is_explicit
 test_probe_scratch_is_cleaned_up

--- a/tests/fm-spawn-first-send.test.sh
+++ b/tests/fm-spawn-first-send.test.sh
@@ -117,6 +117,12 @@ SH
 
 # make_case <name> <id> builds a home plus a real project/worktree pair, and
 # echoes the per-case paths the run helper needs.
+#
+# Each case also gets its own empty TMPDIR. The gate derives its probe directory
+# from TMPDIR, so a case-private root is what makes the leak assertion hermetic:
+# the real-backend smoke suites in this same family run the gate unbypassed and
+# would otherwise be writing identically named directories into the shared
+# ambient TMPDIR while this suite counted them.
 make_case() {
   local name=$1 id=$2 case_dir home proj wt fakebin
   case_dir="$TMP_ROOT/$name"
@@ -124,18 +130,19 @@ make_case() {
   proj="$case_dir/project"
   wt="$case_dir/wt"
   fakebin=$(make_lossy_fakebin "$case_dir/fake")
-  mkdir -p "$home/data" "$home/projects" "$home/state" "$home/config"
+  mkdir -p "$home/data" "$home/projects" "$home/state" "$home/config" "$case_dir/tmp"
   printf 'codex\n' > "$home/config/crew-harness"
   fm_git_worktree "$proj" "$wt" "wt-$name"
   mkdir -p "$home/data/$id"
   printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
   touch "$home/state/.last-watcher-beat"
-  printf '%s|%s|%s|%s|%s|%s\n' \
-    "$home" "$proj" "$wt" "$fakebin" "$case_dir/delivered" "$case_dir/delivery-count"
+  printf '%s|%s|%s|%s|%s|%s|%s\n' \
+    "$home" "$proj" "$wt" "$fakebin" "$case_dir/delivered" "$case_dir/delivery-count" \
+    "$case_dir/tmp"
 }
 
 read_case() {
-  IFS='|' read -r HOME_DIR PROJ_DIR WT_DIR FAKEBIN_DIR DELIVERED COUNTFILE <<EOF
+  IFS='|' read -r HOME_DIR PROJ_DIR WT_DIR FAKEBIN_DIR DELIVERED COUNTFILE CASE_TMP <<EOF
 $1
 EOF
 }
@@ -157,6 +164,7 @@ run_spawn() {
     FM_FAKE_SWALLOW_FROM="$from" FM_FAKE_SWALLOW_UNTIL="$upto" \
     FM_FAKE_SWALLOW_AFTER_TREEHOUSE="${FM_FAKE_SWALLOW_AFTER_TREEHOUSE:-0}" \
     FM_SPAWN_READY_INTERVAL=0.05 FM_SPAWN_READY_RESEND_EVERY=1 \
+    TMPDIR="$CASE_TMP" \
     PATH="$FAKEBIN_DIR:$PATH" \
     "$SPAWN" "$id" "$PROJ_DIR" --mode no-mistakes --yolo off 2>&1
 }
@@ -166,9 +174,10 @@ delivered_line_count() {
   grep -c -x -F -- "$1" "$DELIVERED" 2>/dev/null || true
 }
 
-# count_probe_scratch: how many readiness probe directories exist right now.
+# count_probe_scratch: probe directories left in THIS case's private probe root.
+# Scoped to the case so no concurrent spawn elsewhere can decide the verdict.
 count_probe_scratch() {
-  find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'fm-spawn-ready.*' 2>/dev/null | wc -l | tr -d ' '
+  find "$CASE_TMP" -maxdepth 1 -name 'fm-spawn-ready.*' 2>/dev/null | wc -l | tr -d ' '
 }
 
 # delivered_prefix_count <prefix>: delivered lines that START with <prefix>.
@@ -190,6 +199,27 @@ assert_delivered_prefix() {
 assert_not_delivered_prefix() {
   [ "$(delivered_prefix_count "$1")" -eq 0 ] || fail \
     "$2 (a delivered line starts with '$1')"$'\n'"--- delivered ---"$'\n'"$(cat "$DELIVERED" 2>/dev/null)"
+}
+
+# assert_only_probes_delivered <msg>: nothing but readiness probes and the
+# gate's own bookkeeping keys ever reached the pane.
+#
+# Stated as a whole-file invariant rather than as a list of forbidden spellings
+# on purpose. A case that truncates EVERY delivery cannot detect a leaked send by
+# the intact text - `treehouse get` would arrive as `reehouse get` and no
+# prefix-anchored check on the intact form could ever fire. A probe line is an
+# intact `touch <marker>` or one of its head-truncated forms, and every marker
+# lives under a `fm-spawn-ready.` directory and is named `ready`, so anything
+# else on the wire is a leak whichever way it arrived.
+assert_only_probes_delivered() {
+  local stray
+  stray=$(awk '
+    /^key / { next }
+    index($0, "fm-spawn-ready.") > 0 && /\/ready$/ { next }
+    { print }
+  ' "$DELIVERED" 2>/dev/null)
+  [ -z "$stray" ] || fail \
+    "$1"$'\n'"--- non-probe deliveries ---"$'\n'"$stray"
 }
 
 # The live incident: the first three deliveries lose their leading byte. The
@@ -257,8 +287,8 @@ test_unready_shell_fails_loudly() {
   assert_contains "$out" "treehouse get" \
     "the refusal did not name the send it refused"
   assert_not_contains "$out" "spawned $id" "spawn reported success despite an unready shell"
-  assert_not_delivered_prefix "treehouse get" \
-    "treehouse get reached the pane after the readiness gate had given up"
+  assert_only_probes_delivered \
+    "a task command reached the pane after the readiness gate had given up"
   # Each resend must be able to escape a continuation prompt a partial line left
   # behind. A bare Enter cannot; C-c can, which is why the pre-clear is a C-c.
   [ "$(delivered_line_count 'key C-c')" -ge 1 ] \
@@ -298,15 +328,15 @@ test_healthy_shell_pays_one_probe_per_gate() {
 # The probe directory is scratch: it must never survive the spawn, on the
 # success path or the refusal path.
 #
-# The refusal half runs against its own fully scaffolded fixture rather than a
-# made-up id on the success fixture. An id with no brief dies at fm-spawn's
-# brief check, long before a pane or a probe directory exists, so the cleanup
-# assertion would pass vacuously. The case therefore proves the refusal actually
-# came from the readiness gate before it trusts what the gate left behind.
+# Each half runs against its own fully scaffolded fixture with its own empty
+# probe root, so the count is an absolute zero attributable to that one spawn
+# rather than a before/after diff of state anything else can write. The refusal
+# half needs a real brief: an id without one dies at fm-spawn's brief check long
+# before a pane or a probe directory exists, so its cleanup assertion would pass
+# vacuously. The case therefore proves the refusal came from the readiness gate
+# before it trusts what that gate left behind.
 test_probe_scratch_is_cleaned_up() {
-  local rec id out status before after
-  before=$(count_probe_scratch)
-
+  local rec id out status
   id=first-send-scratch-e5
   rec=$(make_case scratch "$id")
   read_case "$rec"
@@ -314,6 +344,8 @@ test_probe_scratch_is_cleaned_up() {
   status=$?
   expect_code 0 "$status" "the success half of the cleanup case never spawned"
   assert_contains "$out" "spawned $id" "the success half of the cleanup case never spawned"
+  [ "$(count_probe_scratch)" = 0 ] \
+    || fail "readiness probe scratch survived a successful spawn ($(count_probe_scratch) left in $CASE_TMP)"
 
   id=first-send-scratch-refused-g7
   rec=$(make_case scratch-refused "$id")
@@ -323,11 +355,35 @@ test_probe_scratch_is_cleaned_up() {
   [ "$status" -ne 0 ] || fail "the refusal half of the cleanup case did not refuse"
   assert_contains "$out" "never confirmed it can read a command line" \
     "the refusal half never reached the readiness gate, so its cleanup is unproven"
-
-  after=$(count_probe_scratch)
-  [ "$after" -le "$before" ] \
-    || fail "readiness probe scratch directories leaked (before=$before after=$after)"
+  [ "$(count_probe_scratch)" = 0 ] \
+    || fail "readiness probe scratch survived a refused spawn ($(count_probe_scratch) left in $CASE_TMP)"
   pass "readiness probe scratch is removed on both the success and refusal paths"
+}
+
+# The probe root is derived from an INHERITED TMPDIR, so a TMPDIR that cannot
+# carry an unquoted probe line must not fail the spawn. fm-spawn worked in such
+# an environment before this gate existed, and the pane is not at fault, so the
+# probe falls back to the fixed /tmp root and says so once instead of refusing.
+test_unusable_tmpdir_falls_back_instead_of_refusing() {
+  local rec id out status
+  id=first-send-odd-tmpdir-j9
+  rec=$(make_case odd-tmpdir "$id")
+  read_case "$rec"
+  mkdir -p "$CASE_TMP/has space"
+  CASE_TMP="$CASE_TMP/has space"
+
+  out=$(run_spawn "$id" 1 0)
+  status=$?
+  expect_code 0 "$status" \
+    "a TMPDIR that cannot carry an unquoted probe line refused the spawn instead of falling back"
+  assert_contains "$out" "spawned $id" "spawn did not report success"
+  assert_contains "$out" "falling back to /tmp" \
+    "the probe root fallback was silent, so the condition is invisible to the captain"
+  assert_delivered_prefix "treehouse get" \
+    "the pane never received an intact treehouse get, so the fallback probe never proved readiness"
+  [ "$(count_probe_scratch)" = 0 ] \
+    || fail "a probe directory was created under the unusable root instead of the fallback"
+  pass "an unusable TMPDIR falls back to /tmp with a notice instead of failing the spawn"
 }
 
 # A misconfigured budget knob must not brick spawning. A zero poll count would
@@ -374,6 +430,7 @@ test_second_gate_protects_the_launch_environment
 test_unready_shell_fails_loudly
 test_healthy_shell_pays_one_probe_per_gate
 test_misconfigured_budget_knob_falls_back_to_its_default
+test_unusable_tmpdir_falls_back_instead_of_refusing
 test_fixture_bypass_is_explicit
 test_probe_scratch_is_cleaned_up
 

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -40,9 +40,13 @@ export FM_GATE_REFUSE_BYPASS=1
 # pane itself must create; nearly every suite here drives the real fm-spawn.sh
 # against a FAKE backend whose send channel has no shell behind it, so the marker
 # can never appear and the gate would time out on fixtures that are not testing a
-# shell at all. The real-backend smoke suites deliberately do NOT source this
-# library, so they still exercise the gate against a real shell, and
-# tests/fm-spawn-first-send.test.sh strips this bypass to verify the gate itself.
+# shell at all. tests/fm-spawn-first-send.test.sh strips this bypass to verify the
+# gate itself against a modelled byte-lossy shell. No portable CI lane proves the
+# gate against a real shell: the tmux and herdr smoke suites never invoke
+# bin/fm-spawn.sh at all, and every suite that drives it unbypassed is classified
+# real-herdr-gated or live-harness-optin, which portable lanes exclude and which
+# exit early anyway without herdr, jq, treehouse, or cmux. Follow-up task
+# spawn-ready-live-backend-evidence owns closing that gap.
 export FM_SPAWN_READY_BYPASS=1
 
 # Resolve the repo root from this library's own location. Consumed by sourcing

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -43,10 +43,11 @@ export FM_GATE_REFUSE_BYPASS=1
 # shell at all. tests/fm-spawn-first-send.test.sh strips this bypass to verify the
 # gate itself against a modelled byte-lossy shell. No portable CI lane proves the
 # gate against a real shell: the tmux and herdr smoke suites never invoke
-# bin/fm-spawn.sh at all, and every suite that drives it unbypassed is classified
-# real-herdr-gated or live-harness-optin, which portable lanes exclude and which
-# exit early anyway without herdr, jq, treehouse, or cmux. Follow-up task
-# spawn-ready-live-backend-evidence owns closing that gap.
+# bin/fm-spawn.sh at all, and every suite that drives it unbypassed against a REAL
+# backend is classified real-herdr-gated or live-harness-optin, which portable
+# lanes exclude and which exit early anyway without herdr, jq, treehouse, or cmux.
+# The one unbypassed suite portable lanes do run is the fake-backend suite named
+# above. Follow-up task spawn-ready-live-backend-evidence owns closing that gap.
 export FM_SPAWN_READY_BYPASS=1
 
 # Resolve the repo root from this library's own location. Consumed by sourcing

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -41,13 +41,10 @@ export FM_GATE_REFUSE_BYPASS=1
 # against a FAKE backend whose send channel has no shell behind it, so the marker
 # can never appear and the gate would time out on fixtures that are not testing a
 # shell at all. tests/fm-spawn-first-send.test.sh strips this bypass to verify the
-# gate itself against a modelled byte-lossy shell. No portable CI lane proves the
-# gate against a real shell: the tmux and herdr smoke suites never invoke
-# bin/fm-spawn.sh at all, and every suite that drives it unbypassed against a REAL
-# backend is classified real-herdr-gated or live-harness-optin, which portable
-# lanes exclude and which exit early anyway without herdr, jq, treehouse, or cmux.
-# The one unbypassed suite portable lanes do run is the fake-backend suite named
-# above. Follow-up task spawn-ready-live-backend-evidence owns closing that gap.
+# gate itself against a modelled byte-lossy shell. spawn_await_shell_ready's own
+# comment owns what this bypass therefore leaves unproven in portable CI lanes
+# and which follow-up closes it; do not restate that analysis here, because two
+# copies drift the moment only one is edited.
 export FM_SPAWN_READY_BYPASS=1
 
 # Resolve the repo root from this library's own location. Consumed by sourcing

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -34,6 +34,17 @@ FM_TEST_LIB_SOURCED=1
 # strips this to verify real refusal.
 export FM_GATE_REFUSE_BYPASS=1
 
+# Exempt firstmate's own fixture-based suites from fm-spawn.sh's first-send
+# shell-readiness gate (bin/fm-spawn.sh, spawn_await_shell_ready). That gate
+# proves a pane's shell is reading command lines by waiting for a marker file the
+# pane itself must create; nearly every suite here drives the real fm-spawn.sh
+# against a FAKE backend whose send channel has no shell behind it, so the marker
+# can never appear and the gate would time out on fixtures that are not testing a
+# shell at all. The real-backend smoke suites deliberately do NOT source this
+# library, so they still exercise the gate against a real shell, and
+# tests/fm-spawn-first-send.test.sh strips this bypass to verify the gate itself.
+export FM_SPAWN_READY_BYPASS=1
+
 # Resolve the repo root from this library's own location. Consumed by sourcing
 # test files, not by this library, so it reads as "unused" here.
 # shellcheck disable=SC2034

--- a/tests/remote-herdr-fixture.sh
+++ b/tests/remote-herdr-fixture.sh
@@ -126,6 +126,7 @@ case "${1:-} ${2:-}" in
     case "${4:-}" in
       "touch /"*)
         delivered=${4#touch }
+        delivered=${delivered% 2>/dev/null}
         : > "$delivered" 2>/dev/null || true
         ;;
     esac

--- a/tests/remote-herdr-fixture.sh
+++ b/tests/remote-herdr-fixture.sh
@@ -120,9 +120,8 @@ case "${1:-} ${2:-}" in
     # the marker file that line creates appears. Strictly additive - no fixture
     # state changes here, so every other assertion in these suites is unaffected.
     case "${4:-}" in
-      "touch '"*"'")
-        delivered=${4#touch \'}
-        delivered=${delivered%\'}
+      "touch /"*)
+        delivered=${4#touch }
         : > "$delivered" 2>/dev/null || true
         ;;
     esac

--- a/tests/remote-herdr-fixture.sh
+++ b/tests/remote-herdr-fixture.sh
@@ -16,6 +16,10 @@
 # registered agent once anything has been typed into it, and submitting starts
 # one turn: the next agent read reports working and the pane settles back to
 # idle, which is the native transition the adapter confirms a submit with.
+
+# It also models just enough of the pane's SHELL for `pane run` to execute the
+# marker command fm-spawn's first-send readiness gate waits on; without that the
+# remote launch would stall on a pane that can never answer.
 #
 # Usage:
 #   . "$(dirname "${BASH_SOURCE[0]}")/remote-herdr-fixture.sh"
@@ -108,6 +112,20 @@ case "${1:-} ${2:-}" in
     else
       printf '{"error":{"code":"agent_not_found","message":"%s"}}\n' "$pane"
     fi
+    ;;
+  "pane run")
+    # Model the pane's SHELL for the one command shape fm-spawn's first-send
+    # readiness gate turns on (bin/fm-spawn.sh, spawn_await_shell_ready): a real
+    # pane executes the delivered line, and the gate's entire verdict is whether
+    # the marker file that line creates appears. Strictly additive - no fixture
+    # state changes here, so every other assertion in these suites is unaffected.
+    case "${4:-}" in
+      "touch '"*"'")
+        delivered=${4#touch \'}
+        delivered=${delivered%\'}
+        : > "$delivered" 2>/dev/null || true
+        ;;
+    esac
     ;;
   "session list"*)
     printf '{"sessions":[{"name":"default","running":true,"socket_path":"%s"},{"name":"fm-remote","running":true,"socket_path":"%s"}]}\n' "$SOCKET" "$SOCKET" ;;

--- a/tests/remote-herdr-fixture.sh
+++ b/tests/remote-herdr-fixture.sh
@@ -119,6 +119,10 @@ case "${1:-} ${2:-}" in
     # pane executes the delivered line, and the gate's entire verdict is whether
     # the marker file that line creates appears. Strictly additive - no fixture
     # state changes here, so every other assertion in these suites is unaffected.
+    # This is a pane WRITE, so it honours the send-fail flag exactly as pane
+    # send-text and pane send-keys do; an endpoint a test has made unreachable
+    # must not answer the readiness probe.
+    [ ! -f "$SEND_FAIL" ] || exit 1
     case "${4:-}" in
       "touch /"*)
         delivered=${4#touch }


### PR DESCRIPTION
## Intent

Harden the first spawn-time send in bin/fm-spawn.sh against shell-init keystroke loss, and land it properly with a regression test.

THE BUG. After a fresh pane is created, fm-spawn.sh sends `treehouse get` as its first text line. The pane's shell can still be sourcing its rc files when that send lands, and a slow init eats the first byte(s). Observed live on herdr under load on 2026-08-17: the leading 't' was swallowed three times in a row, so the pane received `reehouse get` and the worktree was never entered. The failure is silent from firstmate's side - the spawn appears to proceed.

PRIOR ART THAT HAD TO BE RECONCILED, NOT COPIED. An uncommitted hand hotfix sits in the primary checkout (not in this worktree) adding a sacrificial leading space: `spawn_send_text_line "$WT_TARGET" ' treehouse get'`. It was explicitly rejected as-is for three reasons given to me: its comment block and call lost their two-space indentation inside the enclosing if block; it was applied to only one send path even though the same first-send hazard exists on the others; and a leading space is a mitigation, not a fix - it buys exactly as many bytes as spaces you send.

WHAT I WAS ASKED TO DECIDE AND BUILD. Choose between (a) a readiness-verified send that probes the pane's shell is actually accepting input before the first text line goes out, and (b) the sacrificial-prefix approach done properly on every first-send path with the rationale and byte budget stated. I was told to prefer (a) if I could make it deterministic and bounded, that it must fail loudly on timeout rather than silently proceeding, that it must not add meaningful latency to a healthy spawn, to fall back to (b) only if (a) could not be made reliable across the supported backends, and to say plainly in the PR body which I chose and why. Whichever I picked, EVERY first-send path after pane creation had to be covered, not only the relaunch branch.

ACCEPTANCE CRITERIA I WAS GIVEN. Every post-pane-creation first send in bin/fm-spawn.sh is protected by the chosen mechanism, with no path left on the bare unguarded send. A colocated regression test proves the protection is in place and, where the mechanism allows, that a delayed or slow shell init does not corrupt the command. shellcheck clean per this repo's style rules. The relaunch-path indentation is correct - the hotfix's broken indentation must not survive into the PR. If I chose (a), a timeout is a loud failure with a clear message, never a silent continue.

CONSTRAINTS I WAS GIVEN. Load and follow the firstmate-coding-guidelines skill because this changes firstmate's shared tracked material: one-owner rule for contracts, script header ownership, one sentence per line in tracked Markdown, plain dash never an em dash, shellcheck-clean bin scripts, colocated tests named <subject>.test.sh extending the existing runner, tests must exercise behavior through an executable or public interface and must never assert implementation-source bytes, and maintainer-verification evidence where a guarantee changes. bin/fm-spawn.sh's own header owns its launch-flag and validation contract, so if behavior changes the header changes with it. Do NOT add a Co-Authored-By trailer to any commit - this repo forbids it. PR base is the default branch main; no retargeting. The captain's home has config/backend=herdr, which is where the failure was observed, but the fix must stay backend-agnostic with tmux as the reference backend. I do not answer my own ask-user findings; they are escalated.

WHAT I CHOSE, AND WHY. I implemented (a). spawn_await_shell_ready sends `touch '<marker>'` into the pane and polls the filesystem for that marker. The load-bearing property is that the command word `touch` cannot survive ANY head truncation: every prefix loss turns it into some other word, the shell reports command-not-found, and the marker stays absent. So the marker exists only after one byte-exact line was received AND executed at a live prompt, which is exactly the condition that also makes the next send safe - that is what makes this a fix rather than padding. The verdict comes from the filesystem, never from rendered pane output, so it is backend-agnostic and carries no per-harness assumption at all; the gate runs strictly before any launch command, so no harness has started yet.

DELIBERATE DESIGN DECISIONS A REVIEWER READING ONLY THE DIFF WOULD NOT KNOW.

1. Both first-send points are gated and the gate is deliberately NOT memoized per spawn. On the ordinary path `treehouse get` hands the pane to a NEW subshell that sources its own rc files, so readiness proven before that send says nothing about the launch-environment send that follows it; and on the relaunch, secondmate, and Orca paths that launch-environment line IS the spawn's first send. Two probes cost about 0.2s total on a healthy spawn. I verified by inspection that these are the only two send call sites reached after pane creation.

2. Relaunch is gated too even though an adopted endpoint is not strictly post-pane-creation. A relaunch already requires a positively agent-free endpoint, so a pane that cannot execute a command line would fail the launch anyway; failing loudly at the probe is better than launching into it.

3. FM_SPAWN_READY_BYPASS=1 is an intentional test-fixture escape hatch, with the same shape and the same reasoning as the existing bin/fm-gate-refuse-lib.sh FM_GATE_REFUSE_BYPASS precedent. Nearly every suite in this repo drives the real fm-spawn.sh against a FAKE backend whose send channel has no shell behind it at all, so no marker can ever appear there and the gate would time out on fixtures that are not testing a shell. tests/lib.sh exports it for those suites; the real-backend smoke suites deliberately do not source tests/lib.sh, so they keep exercising the gate for real; and tests/fm-spawn-first-send.test.sh strips it to verify the gate itself. A dedicated test case pins both halves so a future change cannot quietly turn the gate into a default no-op. This is a deliberate, documented fail-open surface, not an oversight.

4. tests/remote-herdr-fixture.sh gained a pane shell for that one command shape instead of the env knob crossing the remote boundary. The remote job worker composes every child with `env -i` and a small allowlist, so no test env var can cross it - by design. My change genuinely regressed tests/fm-remote-secondmate-parent-binding.test.sh, and I fixed it by teaching that fixture's fake `herdr pane run` to execute a delivered `touch '<path>'`, which is strictly additive and changes no fixture state. I deliberately did NOT widen the remote worker's security-relevant env allowlist to carry a test-only knob. That suite is green again.

5. Two small fail-closed guards were added on purpose: a floor of 1 on FM_SPAWN_READY_RESEND_EVERY so a zero value cannot divide by zero, and a refusal if the probe path contains a single quote rather than sending a line whose quoting the pane's shell would parse differently than intended.

6. Each retry after the first submits a bare Enter before re-probing, so a prior attempt left half-typed on the input line is flushed as its own failing command instead of being concatenated onto the next one. A healthy shell never pays this.

7. I deliberately did NOT update docs/verification/runtime-backends.md, and this is a judgment call worth reviewing rather than an omission. The firstmate-coding-guidelines rule for harness-dependent checks applies when a verdict comes from vendor-emitted output - a process name, rendered output, a glyph, a banner. This verdict comes from the filesystem. The gate also introduces no new backend command: it reuses send_text_line and send_key Enter, both already recorded in that doc's per-backend matrices. So no new live-harness guard and no new dated per-harness evidence is owed.

8. Knowledge placement followed the guidelines' decision tree: the env knobs and mechanics are exact flags and commands, so they live in bin/fm-spawn.sh's own header rather than in AGENTS.md, a skill, or a second documentation owner. No AGENTS.md change - nothing here is needed by every session or every turn.

TEST DESIGN, INCLUDING ONE VACUOUSNESS BUG I FOUND AND FIXED. tests/fm-spawn-first-send.test.sh drives the real fm-spawn.sh against a fake tmux that models a byte-lossy shell: it drops the leading character of every delivery in a configurable window, records what the pane actually received, and executes a delivered `touch '<path>'` for real so the gate's own readiness signal is observable end to end. Assertions are on the exact bytes the pane saw, never on the script's source. Two details matter. First, the truncated forms are substrings of the intact ones - `reehouse get` sits inside `treehouse get`, `xport GOTMPDIR=` inside `export GOTMPDIR=` - so unanchored matching cannot tell them apart; the helpers anchor on line prefix. Second, my initial second-gate case keyed its loss window on a delivery NUMBER and therefore passed without the fix, which made it vacuous; I re-keyed it on delivery CONTENT (the window opens on the delivery after `treehouse get` lands) so it stays non-vacuous however many probes precede it. I verified case by case that removing the gate makes the four substantive cases fail, reproducing the incident verbatim as `reehouse get` and `xport GOTMPDIR=`.

VERIFICATION PERFORMED, AND ITS LIMITS. bin/fm-lint.sh is clean (pinned ShellCheck 0.11.0 and actionlint 1.7.12; actionlint was absent on this machine and I installed the pinned version). The new suite's 6 cases pass and is registered in the backend-dispatch family; the coverage guard accepts it. The whole backend-dispatch family is green: 15 suites, 0 failures. The secondmate and session-bootstrap families show 4 failures, and I reproduced every one of them on HEAD~1 - fm-remote-doctor in the same four-suite order, fm-remote-secondmate-lifecycle-e2e, fm-remote-secondmate-trace-context, and fm-gotmp. fm-kimi-harness, fm-muse-harness, and fm-composer-lib are also pre-existing failures on this machine. What I could NOT verify: no real-shell backend run. tmux, zellij, orca, and cmux are not installed here, and herdr 0.7.4 is installed but exercising it would drive Herdr lifecycle, which my task's own safety gate forbade without a --herdr-lab scaffold. Real-backend coverage therefore rests on the herdr and tmux smoke suites in CI, which now run the gate unbypassed.

## What Changed

- `bin/fm-spawn.sh` gains `spawn_await_shell_ready`, a readiness gate that sends a `touch <marker>` line into a freshly created pane and polls the filesystem for that marker before any text line the spawn depends on. The command word `touch` cannot survive head truncation, so the marker appears only after one byte-exact line executed at a live prompt - the same condition that makes the next send safe. This replaces the rejected sacrificial-leading-space mitigation, which buys only as many bytes as spaces sent. Both post-pane-creation first sends are gated - `treehouse get` and the launch-environment `export GOTMPDIR=...` that follows treehouse's new subshell or opens a relaunch, secondmate, or Orca spawn - and the gate is deliberately not memoized, since readiness proven before `treehouse get` says nothing about the subshell that sources its own rc files. A pane that never answers refuses the spawn with a message naming the window, whether it survives, and the published task record, rather than launching into a possibly corrupted command. `FM_SPAWN_READY_POLLS`, `FM_SPAWN_READY_INTERVAL`, and `FM_SPAWN_READY_RESEND_EVERY` tune the budget and fall back to their own defaults on a zero or non-numeric value; the probe root falls back from `TMPDIR` to `/tmp` with a notice; consecutive undeliverable probes refuse on the send channel rather than blaming the pane. `bin/fm-spawn.sh`'s header, which owns the launch-flag and validation contract, documents the gated sends, knobs, refusal rules, and bypass.
- `FM_SPAWN_READY_BYPASS=1` is a documented test-fixture escape hatch modelled on `bin/fm-gate-refuse-lib.sh`'s `FM_GATE_REFUSE_BYPASS`, exported from `tests/lib.sh` because nearly every suite drives the real `fm-spawn.sh` against a fake backend with no shell behind its send channel. Real-backend smoke suites do not source `tests/lib.sh`, so they keep exercising the gate unbypassed. `tests/remote-herdr-fixture.sh`'s fake `herdr pane run` now executes a delivered `touch '<path>'` - strictly additive, honouring the existing send-fail flag - instead of widening the remote worker's `env -i` allowlist to carry a test-only knob.
- New `tests/fm-spawn-first-send.test.sh` drives the real `fm-spawn.sh` against a fake tmux modelling a byte-lossy shell: it drops the leading character of deliveries in a configurable window, records what the pane received, and executes delivered `touch` lines for real. Cases assert on the exact bytes the pane saw with line-prefix anchoring (the truncated `reehouse get` and `xport GOTMPDIR=` are substrings of the intact forms), and cover both gated sends, loud refusal on timeout, probe-scratch cleanup on success and refusal, send-channel and uncleared-input failure modes, `TMPDIR` fallback, zero-knob fallback, and that the gate stands down only for the explicit bypass. The suite is registered in the backend-dispatch family in `bin/fm-test-run.sh`; `bin/backends/tmux.sh`, `bin/backends/herdr.sh`, and `docs/agent-control.md` record the gate's use of the existing `send_text_line` channel.

## Risk Assessment

✅ Low: The gate is additive, bounded, and fail-loud; every prior round's prescribed fix is verifiably applied in the current source, the coverage-honesty comments now match the suite/family classification I independently enumerated, and the colocated suite proves the protection with non-vacuous before/after cases.

## Testing

<code>Ran the new colocated suite tests/fm-spawn-first-send.test.sh (12 cases, all pass) and then proved it is not vacuous by reverting bin/fm-spawn.sh to the base commit and running each case individually: 10 of 12 fail pre-fix, the two exceptions being the guard-rail halves that assert a spawn succeeds. For product-level evidence I drove the real fm-spawn.sh against the suite&#39;s byte-lossy fake shell and captured the exact bytes the pane received before and after the fix: pre-fix the pane runs `reehouse get` and `xport GOTMPDIR=` while fm-spawn.sh reports `spawned &lt;id&gt;` and exits 0, post-fix the probe absorbs the same three byte losses and both `treehouse get` and `export GOTMPDIR=` arrive intact, each preceded by its own gate. A never-ready pane exits 1 with a refusal that names the send it refused, delivers no task command, and leaves no probe scratch. I also verified the gate&#39;s load-bearing premise against real sh, bash and zsh - only the byte-exact probe line creates the marker, every truncation is command-not-found - which is the one thing the fake models rather than proves. Neighbouring suites (fm-remote-secondmate-parent-binding, fm-test-run, and the three other backend-dispatch spawn suites) are green, the new suite is registered in the backend-dispatch family, and the runner&#39;s coverage guard accepts it. No visual evidence applies: this change is a shell-level spawn guard with no rendered surface, so the reviewer-visible artifacts are CLI transcripts of what a pane&#39;s shell actually received. One limit, already documented in the code with an owned follow-up task: no delivery through a real multiplexer into a shell mid-rc-sourcing, because tmux, zellij, cmux and orca are not installed here and herdr is excluded by this task&#39;s safety gate. All temporary drivers and the reverted source were removed; the worktree is clean.</code>

<details>
<summary>Evidence: Pane transcript: incident reproduced pre-fix, fixed post-fix (exact bytes the pane&#39;s shell received)</summary>

Source: [Pane transcript: incident reproduced pre-fix, fixed post-fix (exact bytes the pane&#39;s shell received)](https://github.com/adriantoczydlowski/firstmate/blob/32fa40ac424202f6924e98617cf127bd080c0bfd/.no-mistakes/evidence/fm/fm-spawn-first-send-hardening/pane-transcript.txt)

<code>== PRE-FIX (bin/fm-spawn.sh at base 6a2cd6c) ==&#10;--- fm-spawn.sh exit status: 0&#10;spawned incident-repro harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-incident-repro ...&#10;--- what the pane&#39;s shell actually received (in order) ---&#10;reehouse get&#10;xport GOTMPDIR=/tmp/fm-incident-repro/gotmp&#10;literal env -u CURSOR_AGENT ... codex ...&#10;key Enter&#10;&#10;== POST-FIX (bin/fm-spawn.sh at fa5aafc) ==&#10;--- fm-spawn.sh exit status: 0&#10;spawned incident-repro harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-incident-repro ...&#10;--- what the pane&#39;s shell actually received (in order) ---&#10;ouch &lt;TMPDIR&gt;/fm-spawn-ready.QXasDn/ready 2&gt;/dev/null&#10;key Enter&#10;ouch &lt;TMPDIR&gt;/fm-spawn-ready.QXasDn/ready 2&gt;/dev/null&#10;key Enter&#10;ouch &lt;TMPDIR&gt;/fm-spawn-ready.QXasDn/ready 2&gt;/dev/null&#10;key Enter&#10;touch &lt;TMPDIR&gt;/fm-spawn-ready.QXasDn/ready 2&gt;/dev/null&#10;treehouse get&#10;touch &lt;TMPDIR&gt;/fm-spawn-ready.R6S4Hh/ready 2&gt;/dev/null&#10;export GOTMPDIR=/tmp/fm-incident-repro/gotmp&#10;literal env -u CURSOR_AGENT ... codex ...&#10;key Enter</code>

```text
== PRE-FIX (bin/fm-spawn.sh at base 6a2cd6c) ==
--- fm-spawn.sh exit status: 0
--- fm-spawn.sh stdout/stderr (tail) ---
warning: /var/folders/wg/l58p0r3s0f90qy6rt44vnh_00000gn/T//fm-spawn-first-send.pkwcRE/incident/home/data/incident-repro/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
spawned incident-repro harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-incident-repro worktree=/var/folders/wg/l58p0r3s0f90qy6rt44vnh_00000gn/T//fm-spawn-first-send.pkwcRE/incident/wt
--- what the pane's shell actually received (in order) ---
reehouse get
xport GOTMPDIR=/tmp/fm-incident-repro/gotmp
literal env -u CURSOR_AGENT -u CURSOR_INVOKED_AS codex --dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch '/private/var/folders/wg/l58p0r3s0f90qy6rt44vnh_00000gn/T/fm-spawn-first-send.pkwcRE/incident/home/state/incident-repro.turn-ended'\"]" "$('<REPO>/bin/fm-operational-input.sh' encode launch-brief < '<HOME>/data/incident-repro/brief.md')"
key Enter

== POST-FIX (bin/fm-spawn.sh at fa5aafc) ==
--- fm-spawn.sh exit status: 0
--- fm-spawn.sh stdout/stderr (tail) ---
warning: /var/folders/wg/l58p0r3s0f90qy6rt44vnh_00000gn/T//fm-spawn-first-send.TrswN0/incident/home/data/incident-repro/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
spawned incident-repro harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-incident-repro worktree=/var/folders/wg/l58p0r3s0f90qy6rt44vnh_00000gn/T//fm-spawn-first-send.TrswN0/incident/wt
--- what the pane's shell actually received (in order) ---
ouch <TMPDIR>/fm-spawn-ready.QXasDn/ready 2>/dev/null
key Enter
ouch <TMPDIR>/fm-spawn-ready.QXasDn/ready 2>/dev/null
key Enter
ouch <TMPDIR>/fm-spawn-ready.QXasDn/ready 2>/dev/null
key Enter
touch <TMPDIR>/fm-spawn-ready.QXasDn/ready 2>/dev/null
treehouse get
touch <TMPDIR>/fm-spawn-ready.R6S4Hh/ready 2>/dev/null
export GOTMPDIR=/tmp/fm-incident-repro/gotmp
literal env -u CURSOR_AGENT -u CURSOR_INVOKED_AS codex --dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch '/private/var/folders/wg/l58p0r3s0f90qy6rt44vnh_00000gn/T/fm-spawn-first-send.TrswN0/incident/home/state/incident-repro.turn-ended'\"]" "$('<REPO>/bin/fm-operational-input.sh' encode launch-brief < '<HOME>/data/incident-repro/brief.md')"
key Enter
```
</details>
<details>
<summary>Evidence: Loud refusal: a pane that never accepts a command line stops the spawn</summary>

Source: [Loud refusal: a pane that never accepts a command line stops the spawn](https://github.com/adriantoczydlowski/firstmate/blob/32fa40ac424202f6924e98617cf127bd080c0bfd/.no-mistakes/evidence/fm/fm-spawn-first-send-hardening/loud-refusal.txt)

<code>--- fm-spawn.sh exit status: 1&#10;error: task never-ready-repro&#39;s pane shell never confirmed it can read a command line (5 probes over 5 polls at 0.05s on firstmate:fm-never-ready-repro); refusing to send &#39;treehouse get&#39; into a pane that may silently drop its leading bytes; inspect window firstmate:fm-never-ready-repro, which survives this refusal and is left for you to clean up&#10;--- what the pane&#39;s shell received (only probes; no task command) ---&#10;ouch &lt;TMPDIR&gt;/fm-spawn-ready.sqeZt4/ready 2&gt;/dev/null&#10;key Enter&#10;... (5 probes, 4 bare Enters, no C-c, no task command)&#10;--- probe scratch left behind under &lt;TMPDIR&gt; ---&#10;0 directories</code>

```text
--- fm-spawn.sh exit status: 1
--- captain-visible output (last 3 lines) ---
warning: <HOME>/data/never-ready-repro/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
error: task never-ready-repro's pane shell never confirmed it can read a command line (5 probes over 5 polls at 0.05s on firstmate:fm-never-ready-repro); refusing to send 'treehouse get' into a pane that may silently drop its leading bytes; inspect window firstmate:fm-never-ready-repro, which survives this refusal and is left for you to clean up
--- what the pane's shell received (only probes; no task command) ---
ouch <TMPDIR>/fm-spawn-ready.sqeZt4/ready 2>/dev/null
key Enter
ouch <TMPDIR>/fm-spawn-ready.sqeZt4/ready 2>/dev/null
key Enter
ouch <TMPDIR>/fm-spawn-ready.sqeZt4/ready 2>/dev/null
key Enter
ouch <TMPDIR>/fm-spawn-ready.sqeZt4/ready 2>/dev/null
key Enter
ouch <TMPDIR>/fm-spawn-ready.sqeZt4/ready 2>/dev/null
--- probe scratch left behind under <TMPDIR> ---
0 directories
```
</details>
<details>
<summary>Evidence: Non-vacuousness: each case run individually against pre-fix bin/fm-spawn.sh (10 of 12 fail)</summary>

Source: [Non-vacuousness: each case run individually against pre-fix bin/fm-spawn.sh (10 of 12 fail)](https://github.com/adriantoczydlowski/firstmate/blob/32fa40ac424202f6924e98617cf127bd080c0bfd/.no-mistakes/evidence/fm/fm-spawn-first-send-hardening/pre-fix-per-case.txt)

<code>not ok - the pane never received an intact treehouse get (no delivered line starts with &#39;treehouse get&#39;)&#10;not ok - the pane never received an intact launch environment (no delivered line starts with &#39;export GOTMPDIR=&#39;)&#10;not ok - spawn exited 0 with a shell that never accepted a command line&#10;not ok - the readiness probe did not precede the first task command (first delivery: &#39;treehouse get&#39;)&#10;ok - a zero budget knob falls back to its default instead of refusing every spawn [asserts success; passes without the gate by construction]&#10;not ok - the refusal did not attribute the failure to the send channel&#10;not ok - the refusal did not attribute the failure to the send channel (status 2 on tmux)&#10;not ok - the refusal did not report the uncleared input line the cmux adapter signalled&#10;not ok - two non-consecutive send hiccups were reported as a broken send channel instead of an unready pane&#10;not ok - the probe root fallback was silent, so the condition is invisible to the captain&#10;ok - the gate stands down only for an explicit fixture bypass [asserts success; passes without the gate by construction]&#10;not ok - the refusal half of the cleanup case did not refuse</code>

```text
### bin/fm-spawn.sh reverted to base commit 6a2cd6c (pre-fix); tests/fm-spawn-first-send.test.sh run one case at a time

=== test_swallowed_leading_bytes_never_corrupt_the_first_command ===
not ok - the pane never received an intact treehouse get (no delivered line starts with 'treehouse get')
--- delivered ---
reehouse get
xport GOTMPDIR=/tmp/fm-first-send-swallow-three-a1/gotmp
literal env -u CURSOR_AGENT -u CURSOR_INVOKED_AS codex --dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch '/private/var/folders/wg/l58p0r3s0f90qy6rt44vnh_00000gn/T/fm-spawn-first-send.F916SA/swallow-three/home/state/first-send-swallow-three-a1.turn-ended'\"]" "$('/Users/adriantoczydlowski/.no-mistakes/worktrees/b0d3d72ad777/01M0VZE71XBW5ZGWMQR44P3XBZ/bin/fm-operational-input.sh' encode launch-brief < '/var/folders/wg/l58p0r3s0f90qy6rt44vnh_00000gn/T//fm-spawn-first-send.F916SA/swallow-three/home/data/first-send-swallow-three-a1/brief.md')"
key Enter
[case exited nonzero]

=== test_second_gate_protects_the_launch_environment ===
not ok - the pane never received an intact launch environment (no delivered line starts with 'export GOTMPDIR=')
--- delivered ---
treehouse get
xport GOTMPDIR=/tmp/fm-first-send-swallow-later-b2/gotmp
literal env -u CURSOR_AGENT -u CURSOR_INVOKED_AS codex --dangerously-bypass-approvals-and-sandbox -c "notify=[\"bash\",\"-c\",\"touch '/private/var/folders/wg/l58p0r3s0f90qy6rt44vnh_00000gn/T/fm-spawn-first-send.RsYhqy/swallow-later/home/state/first-send-swallow-later-b2.turn-ended'\"]" "$('/Users/adriantoczydlowski/.no-mistakes/worktrees/b0d3d72ad777/01M0VZE71XBW5ZGWMQR44P3XBZ/bin/fm-operational-input.sh' encode launch-brief < '/var/folders/wg/l58p0r3s0f90qy6rt44vnh_00000gn/T//fm-spawn-first-send.RsYhqy/swallow-later/home/data/first-send-swallow-later-b2/brief.md')"
key Enter
[case exited nonzero]

=== test_unready_shell_fails_loudly ===
not ok - spawn exited 0 with a shell that never accepted a command line
[case exited nonzero]

=== test_healthy_shell_pays_one_probe_per_gate ===
not ok - the readiness probe did not precede the first task command (first delivery: 'treehouse get')
[case exited nonzero]

=== test_misconfigured_budget_knob_falls_back_to_its_default ===
ok - a zero budget knob falls back to its default instead of refusing every spawn

=== test_broken_send_channel_refuses_on_the_channel_not_the_pane ===
not ok - the refusal did not attribute the failure to the send channel (missing: 'send path is failing, not its shell')
--- output ---
warning: /var/folders/wg/l58p0r3s0f90qy6rt44vnh_00000gn/T//fm-spawn-first-send.MTabpi/dead-channel/home/data/first-send-dead-channel-k1/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
[case exited nonzero]

=== test_status_2_is_not_read_as_uncleared_input_on_tmux ===
not ok - the refusal did not attribute the failure to the send channel (missing: 'send path is failing')
--- output ---
warning: /var/folders/wg/l58p0r3s0f90qy6rt44vnh_00000gn/T//fm-spawn-first-send.2s5TVW/status2/home/data/first-send-status2-m2/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
[case exited nonzero]

=== test_uncleared_probe_input_is_terminal_on_cmux ===
not ok - the refusal did not report the uncleared input line the cmux adapter signalled (missing: 'probe input could not be cleared')
--- output ---
warning: /var/folders/wg/l58p0r3s0f90qy6rt44vnh_00000gn/T//fm-spawn-first-send.FSKQrV/cmux-uncleared/home/data/first-send-cmux-uncleared-p4/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
[case exited nonzero]

=== test_intermittent_send_hiccups_still_refuse_on_the_pane ===
not ok - two non-consecutive send hiccups were reported as a broken send channel instead of an unready pane (missing: 'never confirmed it can read a command line')
--- output ---
warning: /var/folders/wg/l58p0r3s0f90qy6rt44vnh_00000gn/T//fm-spawn-first-send.r2ZPF4/hiccup/home/data/first-send-hiccup-n3/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
[case exited nonzero]

=== test_unusable_tmpdir_falls_back_instead_of_refusing ===
not ok - the probe root fallback was silent, so the condition is invisible to the captain (missing: 'falling back to /tmp')
--- output ---
warning: /var/folders/wg/l58p0r3s0f90qy6rt44vnh_00000gn/T//fm-spawn-first-send.7LLaN2/odd-tmpdir/home/data/first-send-odd-tmpdir-j9/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
spawned first-send-odd-tmpdir-j9 harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-first-send-odd-tmpdir-j9 worktree=/var/folders/wg/l58p0r3s0f90qy6rt44vnh_00000gn/T//fm-spawn-first-send.7LLaN2/odd-tmpdir/wt
[case exited nonzero]

=== test_fixture_bypass_is_explicit ===
ok - the gate stands down only for an explicit fixture bypass

=== test_probe_scratch_is_cleaned_up ===
not ok - the refusal half of the cleanup case did not refuse
[case exited nonzero]
```
</details>
<details>
<summary>Evidence: Gate premise against real shells: only a byte-exact probe line creates the marker</summary>

Source: [Gate premise against real shells: only a byte-exact probe line creates the marker](https://github.com/adriantoczydlowski/firstmate/blob/32fa40ac424202f6924e98617cf127bd080c0bfd/.no-mistakes/evidence/fm/fm-spawn-first-send-hardening/real-shell-premise.txt)

<code>SHELL LOST COMMAND WORD RECEIVED MARKER WHAT THE SHELL WOULD SAY (redirect removed)&#10;sh 0 touch CREATED &lt;silent, succeeded&gt;&#10;sh 1 ouch absent /bin/sh: ouch: command not found&#10;sh 2 uch absent /bin/sh: uch: command not found&#10;bash 0 touch CREATED &lt;silent, succeeded&gt;&#10;bash 1 ouch absent /bin/bash: ouch: command not found&#10;zsh 0 touch CREATED &lt;silent, succeeded&gt;&#10;zsh 1 ouch absent zsh:1: command not found: ouch&#10;(4 truncation depths per shell; every prefix loss leaves the marker absent)</code>

```text
The gate's load-bearing premise, checked against REAL shells on this machine
(sh, bash, zsh). No multiplexer is needed for this half of the claim.

Probe line the gate sends:  touch <marker> 2>/dev/null
Claim: the marker appears ONLY on a byte-exact delivery; every head
truncation degrades the command word into something the shell cannot run.

SHELL      LOST   COMMAND WORD RECEIVED    MARKER           WHAT THE SHELL WOULD SAY (redirect removed)
sh         0      touch                    CREATED          <silent, succeeded>
sh         1      ouch                     absent           /bin/sh: ouch: command not found
sh         2      uch                      absent           /bin/sh: uch: command not found
sh         3      ch                       absent           /bin/sh: ch: command not found
sh         4      h                        absent           /bin/sh: h: command not found
bash       0      touch                    CREATED          <silent, succeeded>
bash       1      ouch                     absent           /bin/bash: ouch: command not found
bash       2      uch                      absent           /bin/bash: uch: command not found
bash       3      ch                       absent           /bin/bash: ch: command not found
bash       4      h                        absent           /bin/bash: h: command not found
zsh        0      touch                    CREATED          <silent, succeeded>
zsh        1      ouch                     absent           zsh:1: command not found: ouch
zsh        2      uch                      absent           zsh:1: command not found: uch
zsh        3      ch                       absent           zsh:1: command not found: ch
zsh        4      h                        absent           zsh:1: command not found: h
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"83ab8d1d112ba29b8bc466e369b999d372ea5783","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `bin/fm-test-run.sh` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `bin/fm-spawn.sh:2343` - All three gate refusal messages (lines 2343, 2348, 2363) end with the unconditional claim &#34;inspect window $T, which survives this refusal and is left for you to clean up&#34;, but on the herdr presentation-projection path the pane does not survive. HERDR_PROJECTION_ABORT_CLEANUP is set to 1 at bin/fm-spawn.sh:2046 (or :1990 on reclaim) and is only cleared at :3046, i.e. after BOTH gate call sites (:2443 and :3024). So a gate refusal exits nonzero with the flag still 1, the EXIT trap runs fm_backend_herdr_projection_cleanup_exact (:766-771), and the exact projected task pane is closed - then the operator is told to go inspect it. Concrete path: config/backend=herdr with presentation enabled (fm_backend_herdr_presentation_enabled, :1955) -&gt; projected task pane created -&gt; pane shell slow to init -&gt; gate at :2443 or :3024 exhausts its budget -&gt; message points at a window that no longer exists. This is the exact backend and layout where the original incident was observed. The header documents this as a known residual (:166-173), so it is a deliberate accepted gap rather than an oversight, but the operator sees the stderr message during the failure, not --help. Suggested fix: make the survival clause conditional on HERDR_PROJECTION_ABORT_CLEANUP (and factor the shared suffix into one local so all three refusals stay in step).
- ℹ️ `bin/fm-spawn.sh:3024` - On the herdr projected path the presentation-order lock is held from pane creation (:2046) through :3048, so it now also spans both gates. At the defaults that adds up to 2 x 30s to the hold window for an unresponsive pane. spawn_herdr_presentation_order_lock_acquire only waits 50 x 0.1s (:832-847), so a concurrent herdr spawn during that window warns and silently degrades to the flat layout. The failure mode this gate targets is &#34;herdr under load&#34;, which is precisely when concurrent spawns are most likely, so the degraded-layout path will be hit more often than before. The header documents this residual explicitly (:166-169) and it is bounded and non-corrupting, so I am flagging it as an acknowledged tradeoff rather than a defect.
- ℹ️ `bin/fm-spawn.sh:137` - The gate&#39;s contract is now stated in full twice in the same file: the --help header block at :137-176 (~40 lines) and the function comment at :2193-2228 (~36 lines) both cover the incident, the truncation property, the three knobs, the FM_SPAWN_READY_BYPASS rationale, the send-channel/status-2 rules, and the no-interrupt reasoning - with a third partial restatement in the body&#39;s inline comments (:2261-2265, :2271-2280, :2327-2337). The firstmate-coding-guidelines one-owner rule states a contract in full exactly once and makes every other mention a one-line cross-reference, precisely because two copies drift once only one is edited. The survival-claim drift in the previous finding is already a symptom of that: the header carries the corrected &#34;on every flat layout&#34; qualifier while the message it describes does not. Tier 7 of the placement tree puts the exact flags and knob defaults in the header/--help, which suggests the header is the owner and the function comment should shrink to the maintainer-only rationale plus a pointer. This is a documentation-structure judgment on deliberately authored prose, so it needs the author&#39;s call rather than a mechanical edit.

🔧 Fix: scope gate refusal survival claim, fold contract to header
4 issues (2 warnings, 2 infos) still open:
- ⚠️ `tests/lib.sh:46` - The new gate is a mandatory hard-fail on every spawn path, and nothing in a portable CI lane exercises it against a real shell. tests/lib.sh:46 exports FM_SPAWN_READY_BYPASS=1 for every fixture suite, and the two suites named as the real-backend fallback do NOT compensate: tests/fm-backend-tmux-smoke.test.sh mentions fm-spawn.sh only in comments (lines 69 and 108) and tests/fm-backend-herdr-smoke.test.sh only at line 332 - neither ever invokes bin/fm-spawn.sh, so neither can run the gate at all, bypassed or not. Enumerating every suite that actually executes bin/fm-spawn.sh without the bypass on its source path gives exactly five: fm-backend-autodetect-smoke, fm-backend-herdr-launcher-workspace-e2e, fm-backend-herdr-presentation-e2e, fm-backend-herdr-workspace-per-home-e2e (all four classified real-herdr-gated at bin/fm-test-run.sh:164-171) and fm-cmux-claude-composer-live-e2e (live opt-in). bin/fm-test-run.sh:33 states portable CI lanes exclude real-herdr-gated, and each of those suites exits 0 early when herdr/jq/treehouse or cmux is absent. Net effect: on a portable lane the gate&#39;s real-shell behavior is never executed, and there is no coverage whatsoever on tmux even though tmux is the declared reference backend. tests/fm-spawn-first-send.test.sh proves the gate against a modelled byte-lossy shell, which is real coverage of the LOGIC but not of the assumption that a live pane shell executes `touch &lt;marker&gt;` and that the marker becomes visible to fm-spawn - the one assumption whose failure refuses every spawn on that backend. Worth deciding explicitly whether to accept that (the intent already records &#34;no real-shell backend run&#34; as a limit) or to add a real-tmux case that drives bin/fm-spawn.sh unbypassed, since tmux is installable in CI where herdr is not.
- ⚠️ `bin/fm-spawn.sh:3029` - The second gate runs after the task record is already published, so its refusal leaves a phantom task and the refusal text points the operator at the wrong thing. On the ordinary path SPAWN_META_PATH is &#34;$STATE/$ID.meta&#34; (bin/fm-spawn.sh:2858) and the record is written directly there at :2923; on relaunch it is mv&#39;d into place at :2931. The gate call is at :3029, after both. spawn_abort_cleanup (:731-825) never removes a published meta - it only unwinds a relaunch&#39;s pending replacement wiring and the temp file. So the concrete sequence is: slow pane shell at the second gate (the exact scenario this gate exists for) -&gt; spawn_await_shell_ready exhausts its budget -&gt; exit 1 -&gt; $STATE/$ID.meta remains, recording window, worktree, harness and backend for a task whose pane never received the launch command. The task is then enumerable by the fleet as live while its pane sits at a bare shell. Meanwhile the refusal&#39;s cleanup clause built at :2260 says only &#34;inspect window $T, which survives this refusal and is left for you to clean up&#34; - it names the window, not the record, so an operator who closes the pane leaves the meta behind. Two mitigating facts, which is why I am not calling this an error: the message prefix does name &#34;task $ID&#34;, and the pre-existing trace-context refusal at :3041 sits at the same point with the same consequence and no cleanup guidance at all, so this is an existing hole rather than a new one. What the change does is turn it from a rare send-channel failure into the gate&#39;s documented common outcome. Your call whether that warrants naming the teardown in the refusal, or moving nothing at all.
- ℹ️ `bin/fm-spawn.sh:820` - bin/fm-spawn.sh:820 open-codes `[ -z &#34;$SPAWN_READY_DIR&#34; ] || rm -rf &#34;$SPAWN_READY_DIR&#34; 2&gt;/dev/null || true`, which is exactly what spawn_ready_cleanup (:2224-2228) already owns, minus the SPAWN_READY_DIR reset. Bash resolves function calls at runtime, so spawn_abort_cleanup can call spawn_ready_cleanup despite being defined earlier in the file, and the two copies then cannot drift on the removal semantics. Purely mechanical; no behavior change either way.
- ℹ️ `bin/fm-spawn.sh:2361` - Deferred probes can spray `touch: No such file or directory` into the crewmate&#39;s pane just before the guarded command. The gate submits one probe per resend stride (bin/fm-spawn.sh:2330) but removes the probe directory the instant the marker appears (:2361). A pane whose shell is blocked for most of the budget has every queued probe sitting unread in the tty; when the shell finally comes up it drains them in order, the first creates the marker, the gate returns and rm -rf&#39;s the directory, and each remaining queued `touch` then fails visibly. At the defaults that is bounded by 30 probes, so a shell that comes up around poll 250 leaves roughly two dozen error lines in the pane immediately ahead of `treehouse get` or the launch environment. Purely cosmetic - terminal input is a FIFO, so ordering is preserved and nothing the gate protects is affected - but it is operator-visible noise in exactly the degraded case an operator would be inspecting. Redirecting the probe&#39;s stderr would silence it at the cost of putting a metacharacter into a line the header currently documents as metacharacter-free, so it is a tradeoff rather than a clear fix.

🔧 Fix: name published record in gate refusal, silence probe stderr
3 issues (2 warnings, 1 info) still open:
- ⚠️ `bin/fm-spawn.sh:2279` - The new published-record clause fires on the relaunch path, where fm-teardown.sh is the wrong and destructive remedy. The condition is `[ -e &#34;$STATE/$ID.meta&#34; ] || [ -L ... ]` evaluated at gate entry (bin/fm-spawn.sh:2278). At the second gate (:3049) with RELAUNCH=1 that is unconditionally true: the task record existed before this spawn (relaunch adopts an existing task) and is re-published at :2941 via `mv -f &#34;$SPAWN_META_TMP&#34; &#34;$STATE/$ID.meta&#34;`. So the concrete sequence is: relaunch a task whose adopted endpoint&#39;s shell cannot execute a command line -&gt; spawn_await_shell_ready exhausts its budget at :3049 -&gt; the refusal appends &#34;task record $STATE/$ID.meta is published and this refusal does not retract it, so clear the task with &#39;&lt;root&gt;/bin/fm-teardown.sh &lt;id&gt;&#39;&#34;. But on relaunch the record is not a phantom - it is a live task the operator was trying to hand a fresh agent - and fm-teardown.sh&#39;s own header (bin/fm-teardown.sh:1-10) states it returns/hard-resets/removes the worktree and kills the recorded endpoint. The correct remedy there is fixing the pane and retrying the relaunch. Teardown&#39;s unlanded-work refusal limits the blast radius but does not make the guidance right: a relaunch of a task whose work has already landed would be torn down on the first try. Also worth noting while you are here: no case in tests/fm-spawn-first-send.test.sh produces a second-gate refusal (test_second_gate_protects_the_launch_environment succeeds; both refusal cases refuse at the first gate, before publication), so neither branch of this clause is executed by any test. Suggested scope: gate the clause on `[ &#34;$RELAUNCH&#34; -ne 1 ]`, or give the relaunch case its own wording that names retry rather than teardown.
- ⚠️ `bin/fm-spawn.sh:2232` - The round-3 honesty statement was appended without removing the claim it contradicts, and the identical claim in tests/lib.sh was left untouched. bin/fm-spawn.sh:2232-2233 says &#34;tests/lib.sh exports the bypass for those, while the real-backend smoke suites - which do not source it - exercise the gate for real&#34;, and :2236-2237 then says &#34;the tmux and herdr smoke suites never invoke this script at all&#34;. The second statement is the accurate one: tests/fm-backend-tmux-smoke.test.sh mentions fm-spawn.sh only in comments (lines 69, 108) and tests/fm-backend-herdr-smoke.test.sh only at line 332 - neither ever executes it, so neither can run the gate. tests/lib.sh:43-44 carries the same unqualified overclaim with no correction at all: &#34;The real-backend smoke suites deliberately do NOT source this library, so they still exercise the gate against a real shell.&#34; Round 2&#39;s instruction for this exact text was &#34;state plainly that the gate premise ... is unproven against any real shell in portable CI lanes ... Do not soften that statement and do not claim coverage that does not exist.&#34; The surviving clause claims coverage that does not exist and is the softening that instruction forbade. The only suites that really do drive bin/fm-spawn.sh unbypassed are the herdr-gated e2e suites plus fm-backend-autodetect-smoke, all of which exit 0 early without herdr/jq/treehouse - name those, or drop the clause and let the corrected sentence stand alone.
- ℹ️ `bin/fm-spawn.sh:166` - The --help header block was made the single owner of the gate contract in round 1, and usage() emits it verbatim (bin/fm-spawn.sh:241-246), but it was not updated when round 3 added a new refusal element. Line 166-168 still describes the refusal as only &#34;Every gate refusal names the window and says whether it survives, and the gate removes nothing itself&#34; - a refusal now also names the published task record at $STATE/$ID.meta and prescribes a concrete `fm-teardown.sh &lt;id&gt;` command (:2278-2280). That is exactly the kind of exact-command detail the placement rule puts in the header, and it is the one part of the refusal an operator acts on. One sentence in the header block closes the gap.

🔧 Fix: split relaunch refusal from orphan-record teardown advice
2 issues (1 warning, 1 info) still open:
- ⚠️ `bin/fm-spawn.sh:2289` - The round-3 split keys the record wording on RELAUNCH alone, but relaunch is not the only non-orphan path, so the destructive teardown guidance is still reachable. Concrete sequence: bin/fm-bootstrap.sh&#39;s liveness sweep respawns an existing secondmate whose agent is dead/missing with `fm-spawn.sh &#34;$id&#34; --secondmate` (bin/fm-bootstrap.sh:752 and :789). That runs with RELAUNCH=0 and a pre-existing $STATE/$ID.meta - bootstrap just read that same meta for backend/target, and fm-spawn re-resolves the home from it at bin/fm-spawn.sh:1646 (`[ -z &#34;$FIRSTMATE_HOME&#34; ] &amp;&amp; [ -f &#34;$STATE/$ID.meta&#34; ]`). A new pane is created, the record is re-published, and the second gate at :3060 refuses if that pane&#39;s shell is slow - the gate&#39;s whole target scenario. The RELAUNCH branch at :2287 is false, so the elif at :2289 fires and the refusal says the record &#39;is published for a pane that never received its launch command&#39; and to &#39;clear the orphaned task with &lt;root&gt;/bin/fm-teardown.sh &lt;id&gt;&#39;. That record is not orphaned: it is a live secondmate. bin/fm-teardown.sh on kind=secondmate refuses only while the home has in-flight CHILD meta files (:2545-2555); an idle secondmate passes that check and is then destroyed by remove_firstmate_home at :2795, which removes the home, releases its treehouse lease, and drops the registry entry. The same shape recurs on the remote launch path, where bin/fm-remote-secondmate-control.sh:154-177 re-launches over an existing meta with RELAUNCH=0 and additionally under FM_STATE_OVERRIDE, so the printed `fm-teardown.sh &lt;id&gt;` would not even address the record the message names. The code&#39;s own stated invariant at :2282-2286 is &#39;named only where the record is genuinely orphaned&#39;, and the header at :170 restates it as &#39;on a fresh spawn the record is an orphan&#39; - both are violated by these paths. Earliest shared boundary: decide the wording from whether THIS spawn created the record rather than from RELAUNCH - capture a flag once where $STATE/$ID.meta is first consulted (before publication, e.g. near :1646/:1016) and branch the aftermath on that, which covers relaunch, secondmate respawn, and the remote launch with one condition. The header sentence at :170 needs the same correction since it is the contract owner.
- ℹ️ `tests/lib.sh:46` - The coverage-honesty statement&#39;s supporting enumeration is contradicted by the sentence two lines above it. tests/lib.sh:44 correctly says tests/fm-spawn-first-send.test.sh strips the bypass; tests/lib.sh:46-47 then says &#39;every suite that drives it unbypassed is classified real-herdr-gated or live-harness-optin&#39;. fm-spawn-first-send.test.sh drives bin/fm-spawn.sh unbypassed (env -u FM_SPAWN_READY_BYPASS at tests/fm-spawn-first-send.test.sh:190) and is classified backend-dispatch (bin/fm-test-run.sh:209), which portable lanes DO run. bin/fm-spawn.sh:2241 carries the same over-broad enumeration (&#39;every suite that does either bypasses the gate or is classified real-herdr-gated or live-harness-optin&#39;). The headline claim - unproven against a REAL shell - is accurate; only the enumeration is wrong, because it omits the fake-shell suite it just named. Round 3&#39;s instruction was to stop leaving two sentences that disagree a few lines apart, so qualifying the enumeration (&#39;every suite that drives it against a real backend&#39;) or excepting fm-spawn-first-send explicitly finishes that correction.

🔧 Fix: drop remedy from gate record refusal, fix coverage claims
1 info still open:
- ℹ️ `bin/fm-spawn.sh:158` - The gate re-derives its probe root on each of the two entries per spawn, so an unusable TMPDIR emits the fallback notice twice (bin/fm-spawn.sh:2317-2325 runs once at :2476 and again at :3060), while the header at :158-160 describes the fallback as happening &#34;with one stderr notice&#34;. The fallback itself is correct on both entries and the scratch is cleaned each time, so this is operator-visible duplication of a diagnostic rather than a defect; recording it only so the header wording is not mistaken for a per-spawn guarantee.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-spawn-first-send.test.sh` - all 12 cases pass on the target commit (~27s)</code>
- <code>Non-vacuousness: `git checkout 6a2cd6c -- bin/fm-spawn.sh`, then ran each of the 12 test functions individually via a throwaway driver; 10 fail pre-fix, including `test_swallowed_leading_bytes_never_corrupt_the_first_command`, `test_second_gate_protects_the_launch_environment`, `test_unready_shell_fails_loudly` and `test_healthy_shell_pays_one_probe_per_gate`. Restored with `git checkout fa5aafc -- bin/fm-spawn.sh`.</code>
- <code>Incident reproduction / fix transcript: drove the suite&#39;s own fixture with the loss window on deliveries 1-3 and dumped the exact bytes the pane&#39;s shell received, once with pre-fix and once with post-fix `bin/fm-spawn.sh`</code>
- <code>Loud-refusal check: same fixture with a pane that truncates every delivery and `FM_SPAWN_READY_POLLS=5` - captured exit status, the captain-visible refusal text, the full pane delivery log, and the probe-scratch count</code>
- <code>Real-shell premise check: delivered `touch &lt;marker&gt; 2&gt;/dev/null` and its 1-4 byte head truncations to `/bin/sh`, `/bin/bash` and `/bin/zsh`, recording marker existence and the shell&#39;s own diagnostic</code>
- <code>`grep -n &#39;spawn_send_text_line|spawn_await_shell_ready|spawn_send_key &#39; bin/fm-spawn.sh` - confirmed only two post-pane-creation first sends (2480, 3061), both gated at 2479/3060</code>
- <code>`bash tests/fm-remote-secondmate-parent-binding.test.sh` - the suite the fixture change was needed for; ALL TESTS PASSED</code>
- <code>`bash tests/fm-test-run.test.sh` - passed</code>
- <code>`bash tests/fm-spawn-dispatch-profile.test.sh`, `bash tests/fm-trace-context-spawn.test.sh`, `bash tests/fm-spawn-worktree-settle.test.sh` - same family, all passed</code>
- <code>`bash bin/fm-test-run.sh --list --family backend-dispatch` (new suite listed) and `bash bin/fm-test-run.sh --check-coverage` (`FM_TEST_COVERAGE ok total=162`)</code>

</details>

<details>
<summary>⚠️ **Document** - 2 issues (1 warning, 1 info)</summary>

- ⚠️ `docs/fm-test-portable-shards.md:84` - docs/fm-test-portable-shards.md&#39;s portable-serial shard table is stale and this change adds to the drift. It documents 29/28/30/30 scripts (117 total); the lane actually resolves to 30/32/32/32 (126) after this change, and already resolved to 30/31/32/32 (125) at the base commit. The doc&#39;s own instruction is to refresh the weight hints and this table whenever the serial lane gains scripts, but doing that correctly requires per-shard timing artifacts from a green CI run, which are not reachable from this worktree; recomputing only the counts would leave the Estimated duration and imbalance columns inconsistent with them. Left unchanged and proposed as a follow-up: download the fm-test-timing-portable-serial-* artifacts from a green run, replace portable_serial_weight_hints in bin/fm-test-run.sh, and regenerate the table. Coverage is unaffected either way - the guard keeps the partition complete and disjoint whatever the hints say - so the cost is shard balance only.
- ℹ️ `docs/verification/runtime-backends.md` - Judgment call the author flagged for review: docs/verification/runtime-backends.md was deliberately not updated for the readiness gate. I checked it and concur, so I made no change. The gate introduces no new backend command - it reuses send_text_line and send_key Enter, both already recorded in every per-backend matrix in that doc - and its verdict comes from a marker file on the filesystem rather than from anything the vendor emits (process name, rendered output, glyph, banner), so the firstmate-coding-guidelines rule for harness-dependent checks does not fire and no new live-harness guard or dated per-harness evidence is owed. Recording it here because it is a deliberate omission a reviewer would otherwise have to re-derive.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
