### PR TITLE
feat: add role-scoped reusable callsigns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,11 +4,12 @@ You are the first mate.
 The user is the captain.
 This file is your entire job description.
 
-Address the user as "captain" at least once in every response.
-This is mandatory respectful address, not performance: it applies even when delivering bad news or relaying serious findings, such as "Captain, the build broke - ...".
+Address the user as "Senchō" at least once in every response.
+This is mandatory respectful address, not performance: it applies even when delivering bad news or relaying serious findings.
 Do not force it into every sentence, but never send a response with zero direct address.
-Use light nautical seasoning only when it fits: the occasional "aye", "on deck", "shipshape", "under way", or "ahoy" may land naturally.
-Keep that seasoning optional and never let it obscure technical content; never use it in commits, briefs, PRs, or anything crewmates or other tools read; drop the playful flavor entirely when delivering bad news or relaying serious findings.
+Use natural, lively, One Piece-inspired crew energy when it fits: direct, warm, adventurous, and occasional nautical banter.
+Use "Ryōkai" instead of "aye".
+Do not imitate exact character dialogue, force role-play, or obscure technical outcomes; never use themed language in commits, briefs, PRs, or anything crewmates or other tools read.
 For captain-facing escalation style and outcome phrasing, see section 9.
 
 ## 1. Identity and prime directives

--- a/bin/fm-control.sh
+++ b/bin/fm-control.sh
@@ -126,6 +126,8 @@ DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
 
 # shellcheck source=bin/fm-backend.sh
 . "$SCRIPT_DIR/fm-backend.sh"
+# shellcheck source=bin/fm-identity-lib.sh
+. "$SCRIPT_DIR/fm-identity-lib.sh"
 # shellcheck source=bin/fm-busy-lib.sh
 . "$SCRIPT_DIR/fm-busy-lib.sh"
 # shellcheck source=bin/fm-control-lib.sh
@@ -247,15 +249,18 @@ case "$NEW_EFFORT" in
   *) die "--effort must be one of low, medium, high, xhigh, max" ;;
 esac
 
-# --- exact task-id resolution ----------------------------------------------
+# --- exact task identity resolution ----------------------------------------
 
 case "$RAW_ID" in
   *:*) die "'$RAW_ID' is an explicit backend endpoint; fm-control accepts an exact task id only, so a lifecycle command can never land on an endpoint this home does not own" ;;
 esac
-if ! fm_task_id_creation_valid "$RAW_ID"; then
-  die "'$RAW_ID' is not a valid task id"
+if fm_task_id_creation_valid "$RAW_ID" && [ -f "$STATE/$RAW_ID.meta" ] \
+  && [ ! -f "$(fm_identity_task_record "$RAW_ID")" ]; then
+  fm_identity_ensure_task_from_meta "$STATE/$RAW_ID.meta" "$RAW_ID" >/dev/null \
+    || die "task '$RAW_ID' could not receive a persistent callsign"
 fi
-ID=$RAW_ID
+ID=$(fm_identity_resolve_selector "$STATE" "$RAW_ID") \
+  || die "'$RAW_ID' is not a live task id or callsign in $STATE"
 # Supervision lease guard: lifecycle control is overlap territory between the
 # two Pi supervision actors; refuse while the OTHER actor holds this task's
 # live lease (contract: bin/fm-lease-lib.sh; no-op in homes without leases).

--- a/bin/fm-crew-state.sh
+++ b/bin/fm-crew-state.sh
@@ -67,6 +67,8 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 . "$SCRIPT_DIR/fm-tmux-lib.sh"
 # shellcheck source=bin/fm-backend.sh
 . "$SCRIPT_DIR/fm-backend.sh"
+# shellcheck source=bin/fm-identity-lib.sh
+. "$SCRIPT_DIR/fm-identity-lib.sh"
 # shellcheck source=bin/fm-classify-lib.sh
 . "$SCRIPT_DIR/fm-classify-lib.sh"
 # shellcheck source=bin/fm-busy-lib.sh
@@ -76,6 +78,8 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 
 ID=${1:-}
 [ -n "$ID" ] || { echo "usage: fm-crew-state.sh <id>" >&2; exit 2; }
+resolved_id=$(fm_identity_resolve_selector "$STATE" "$ID" 2>/dev/null || true)
+[ -z "$resolved_id" ] || ID=$resolved_id
 
 META="$STATE/$ID.meta"
 LOG="$STATE/$ID.status"

--- a/bin/fm-identity-lib.sh
+++ b/bin/fm-identity-lib.sh
@@ -1,0 +1,391 @@
+#!/usr/bin/env bash
+# Persistent Firstmate home and task identities.
+#
+# Current callsigns are the only names that reserve a pool entry. Archived
+# records and retired_callsign history are retained as evidence but ignored by
+# allocation and selector resolution.
+
+FM_IDENTITY_DATA=${FM_IDENTITY_DATA:-${FM_DATA_OVERRIDE:-${DATA:-${FM_HOME:-.}/data}}}
+FM_IDENTITY_STATE=${FM_IDENTITY_STATE:-${FM_STATE_OVERRIDE:-${STATE:-${FM_HOME:-.}/state}}}
+FM_IDENTITY_HOME_POOL="Rayleigh Beckman Zoro Killer Marco King Shiryu Lafitte Daz Gin Mohji Cabaji Jango Pearl Sarquiss"
+FM_IDENTITY_SECOND_MATE_POOL="Jinbei Katakuri Sabo Law Vivi Yamato Hancock Mihawk Crocodile Dragon Shanks Kuma Ace Smoker Fujitora Garp Sengoku Tsuru Kuzan Kizaru Ryokugyu Magellan Hannyabal Kyros Neptune Momonosuke Kinemon Denjiro Inuarashi Nekomamushi Bonney Urouge Capone Hawkins Drake Apoo"
+FM_IDENTITY_CREWMATE_POOL="Franky Robin Nami Sanji Usopp Brook Chopper Koby Tashigi Perona Reiju Pudding Carrot Bepo Penguin Shachi Heat Wire Bartolomeo Cavendish Rebecca Viola Leo Sai Ideo Hajrudin Orlumbus Chinjao Bellamy BonClay Galdino Baby5 Koala Hack Inazuma Karasu Lindbergh Morley BeloBetty Helmeppo Hina Fullbody Sentomaru Momonga Doberman Onigumo Bastille Bogard Raizo Kikunojo Ashura Kawamatsu Izo Shinobu Tama Toko Hiyori Mansherry Dellinger SenorPink Pica Diamante Trebol Sugar Ichiji Niji Yonji Pekoms Tamago Chiffon Lola Praline Brulee Cracker Smoothie Oven Daifuku Perospero Nojiko Genzo Zeff Patty Carne Kaya Merry Makino Laboon Crocus Dorry Brogy Dalton Kureha GanFall Conis Wyper Aisa Paulie Iceburg Kokoro Chimney Camie Hachi Duval Shirahoshi Fukaboshi Ryuboshi Manboshi Otohime Aladine Shaka Lilith Pythagoras Atlas York"
+FM_IDENTITY_RESERVED_NAMES="luffy roger captain firstmate first-mate mate crew crewmate secondmate second-mate scout ship default unknown unnamed archived active provisioning"
+
+fm_identity_error() {
+  echo "error: $*" >&2
+}
+
+fm_identity_fold() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+fm_identity_task_record() {
+  printf '%s/crew-identities/%s.identity\n' "$FM_IDENTITY_DATA" "$1"
+}
+
+fm_identity_record_value() {
+  local record=$1 key=$2
+  sed -n "s/^${key}=//p" "$record" | head -1
+}
+
+fm_identity_meta_value() {
+  fm_identity_record_value "$1" "$2"
+}
+
+fm_identity_name_valid() {
+  [[ "$1" =~ ^[A-Za-z][A-Za-z0-9-]{1,31}$ ]]
+}
+
+fm_identity_task_id_valid() {
+  [[ "$1" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]]
+}
+
+fm_identity_value_safe() {
+  case "$1" in *$'\n'*|*$'\r'*|*$'\t'*) return 1 ;; esac
+}
+
+fm_identity_validate_name() {
+  local folded
+  fm_identity_name_valid "$1" || {
+    fm_identity_error "callsign '$1' must be 2-32 characters, start with a letter, and contain only letters, digits, or hyphens"
+    return 1
+  }
+  fm_identity_value_safe "$1" || return 1
+  folded=$(fm_identity_fold "$1")
+  case " $FM_IDENTITY_RESERVED_NAMES " in *" $folded "*)
+    fm_identity_error "callsign '$1' is reserved"
+    return 1
+    ;;
+  esac
+}
+
+fm_identity_prepare_dirs() {
+  mkdir -p "$FM_IDENTITY_DATA/crew-identities" "$FM_IDENTITY_STATE"
+}
+
+fm_identity_lock_acquire() {
+  local lock="$FM_IDENTITY_DATA/.identity.lock" tries=0
+  mkdir -p "$FM_IDENTITY_DATA"
+  while ! mkdir "$lock" 2>/dev/null; do
+    tries=$((tries + 1))
+    [ "$tries" -lt 500 ] || return 1
+    sleep 0.01
+  done
+}
+
+fm_identity_lock_release() {
+  rmdir "$FM_IDENTITY_DATA/.identity.lock" 2>/dev/null || true
+}
+
+fm_identity_checksum() {
+  local value=$1 sum=0 byte i
+  LC_ALL=C
+  for ((i=0; i<${#value}; i++)); do
+    printf -v byte '%d' "'${value:i:1}"
+    sum=$(((sum * 33 + byte) & 2147483647))
+  done
+  printf '%s\n' "$sum"
+}
+
+fm_identity_pool_for_kind() {
+  case "${1:-ship}" in
+    firstmate|home|firstmate-home) printf '%s\n' "$FM_IDENTITY_HOME_POOL" ;;
+    secondmate) printf '%s\n' "$FM_IDENTITY_SECOND_MATE_POOL" ;;
+    *) printf '%s\n' "$FM_IDENTITY_CREWMATE_POOL" ;;
+  esac
+}
+
+fm_identity_pool_item() {
+  local pool=$1 wanted=$2 item index=0
+  for item in $pool; do
+    [ "$index" -eq "$wanted" ] && { printf '%s\n' "$item"; return 0; }
+    index=$((index + 1))
+  done
+  return 1
+}
+
+fm_identity_pool_size() {
+  local pool=$1 item count=0
+  for item in $pool; do count=$((count + 1)); done
+  printf '%s\n' "$count"
+}
+
+fm_identity_status_live() {
+  case "$1" in provisioning|active) return 0 ;; *) return 1 ;; esac
+}
+
+fm_identity_live_names() {
+  local home_record="$FM_IDENTITY_DATA/firstmate.identity" record records=()
+  [ -f "$home_record" ] && records+=("$home_record")
+  for record in "$FM_IDENTITY_DATA"/crew-identities/*.identity; do
+    [ -f "$record" ] && records+=("$record")
+  done
+  [ "${#records[@]}" -gt 0 ] || return 0
+  awk -F= '
+    FILENAME ~ /firstmate\.identity$/ && $1 == "name" { home=$2 }
+    FILENAME ~ /crew-identities\/.*\.identity$/ {
+      file=FILENAME
+      sub(/^.*\//, "", file)
+      sub(/\.identity$/, "", file)
+      if ($1 == "status") status[file]=tolower($2)
+      if ($1 == "callsign") callsign[file]=$2
+    }
+    END {
+      if (home != "") print home "\t"
+      for (file in status) {
+        if (status[file] == "active" || status[file] == "provisioning")
+          print callsign[file] "\t" file
+      }
+    }
+  ' "${records[@]}"
+}
+
+fm_identity_live_name_in_list() {
+  local wanted=$1 names=$2 ignore=${3:-} name id wanted_fold
+  wanted_fold=$(fm_identity_fold "$wanted")
+  while IFS=$'\t' read -r name id; do
+    [ "$id" = "$ignore" ] && continue
+    [ "$(fm_identity_fold "$name")" = "$wanted_fold" ] && return 0
+    [ "$(fm_identity_fold "$id")" = "$wanted_fold" ] && return 0
+  done <<< "$names"
+  return 1
+}
+
+fm_identity_name_in_use() {
+  local wanted=$1 ignore=${2:-} wanted_fold names
+  wanted_fold=$(fm_identity_fold "$wanted")
+  [ "$wanted_fold" != luffy ] || return 0
+  [ "$wanted_fold" != roger ] || return 0
+  names=$(fm_identity_live_names)
+  fm_identity_live_name_in_list "$wanted" "$names" "$ignore"
+}
+
+fm_identity_choose_fresh_callsign() {
+  local id=$1 kind=${2:-ship} pool size checksum start offset base suffix candidate live_names
+  pool=$(fm_identity_pool_for_kind "$kind")
+  size=$(fm_identity_pool_size "$pool")
+  [ "$size" -gt 0 ] || return 1
+  checksum=$(fm_identity_checksum "$id")
+  start=$((checksum % size))
+  live_names=$(fm_identity_live_names)
+  for ((offset=0; offset<size; offset++)); do
+    base=$(fm_identity_pool_item "$pool" "$(((start + offset) % size))")
+    fm_identity_live_name_in_list "$base" "$live_names" || { printf '%s\n' "$base"; return 0; }
+  done
+  base=$(fm_identity_pool_item "$pool" "$start")
+  suffix=2
+  while :; do
+    candidate="$base-$suffix"
+    fm_identity_live_name_in_list "$candidate" "$live_names" || { printf '%s\n' "$candidate"; return 0; }
+    suffix=$((suffix + 1))
+  done
+}
+
+fm_identity_legacy_callsign() {
+  fm_identity_choose_fresh_callsign "$1" "${2:-ship}"
+}
+
+fm_identity_write_task_record() {
+  local record=$1 id=$2 callsign=$3 status=$4 meta=${5:-} created=${6:-} old=${7:-} tmp
+  fm_identity_task_id_valid "$id" && fm_identity_validate_name "$callsign" >/dev/null
+  fm_identity_value_safe "$id" && fm_identity_value_safe "$meta" || return 1
+  [ -n "$created" ] || created=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+  tmp="$record.tmp.${BASHPID:-$$}"
+  {
+    printf 'schema=fm-crew-identity.v1\n'
+    printf 'home=%s\n' "$(cd "$FM_IDENTITY_DATA/.." && pwd -P)"
+    printf 'task_id=%s\n' "$id"
+    printf 'callsign=%s\n' "$callsign"
+    printf 'status=%s\n' "$status"
+    [ -z "$meta" ] || {
+      printf 'worktree=%s\n' "$(fm_identity_meta_value "$meta" worktree)"
+      printf 'backend=%s\n' "$(fm_identity_meta_value "$meta" backend)"
+      printf 'endpoint=%s\n' "$(fm_identity_meta_value "$meta" window)"
+      printf 'endpoint_session_id=%s\n' "$(fm_identity_meta_value "$meta" herdr_session)"
+      printf 'harness_session_id=%s\n' "$(fm_identity_meta_value "$meta" codex_session_id)"
+      printf 'spawn_gen=%s\n' "$(fm_identity_meta_value "$meta" spawn_gen)"
+    }
+    printf 'created_at=%s\nupdated_at=%s\n' "$created" "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    [ -z "$old" ] || printf 'retired_callsign=%s\n' "$old"
+  } > "$tmp"
+  mv -f -- "$tmp" "$record"
+}
+
+fm_identity_reserve_fresh_task() {
+  local id=$1 kind=${2:-ship} record callsign status
+  fm_identity_prepare_dirs
+  fm_identity_task_id_valid "$id" || return 1
+  fm_identity_lock_acquire || return 1
+  record=$(fm_identity_task_record "$id")
+  if [ -f "$record" ]; then
+    status=$(fm_identity_record_value "$record" status)
+    callsign=$(fm_identity_record_value "$record" callsign)
+    if [ "$status" = provisioning ] && [ ! -f "$FM_IDENTITY_STATE/$id.meta" ]; then
+      fm_identity_lock_release
+      printf '%s\n' "$callsign"
+      return 0
+    fi
+    fm_identity_lock_release
+    fm_identity_error "task id '$id' already has a $status identity; refusing a fresh assignment"
+    return 1
+  fi
+  if ! callsign=$(fm_identity_choose_fresh_callsign "$id" "$kind"); then
+    fm_identity_lock_release
+    return 1
+  fi
+  if ! fm_identity_write_task_record "$record" "$id" "$callsign" provisioning; then
+    fm_identity_lock_release
+    return 1
+  fi
+  fm_identity_lock_release
+  printf '%s\n' "$callsign"
+}
+
+fm_identity_activate_reserved_task_from_meta() {
+  local meta=$1 id=$2 record callsign status created
+  record=$(fm_identity_task_record "$id")
+  [ -f "$record" ] || return 1
+  status=$(fm_identity_record_value "$record" status)
+  [ "$status" = provisioning ] || return 1
+  callsign=$(fm_identity_record_value "$record" callsign)
+  created=$(fm_identity_record_value "$record" created_at)
+  fm_identity_write_task_record "$record" "$id" "$callsign" active "$meta" "$created"
+  printf '%s\n' "$callsign"
+}
+
+fm_identity_ensure_task_from_meta() {
+  local meta=$1 id=$2 record callsign status created kind
+  [ -f "$meta" ] || return 1
+  fm_identity_prepare_dirs
+  record=$(fm_identity_task_record "$id")
+  if [ -f "$record" ]; then
+    status=$(fm_identity_record_value "$record" status)
+    callsign=$(fm_identity_record_value "$record" callsign)
+    [ "$status" != archived ] || return 1
+    created=$(fm_identity_record_value "$record" created_at)
+    fm_identity_write_task_record "$record" "$id" "$callsign" active "$meta" "$created"
+    printf '%s\n' "$callsign"
+    return 0
+  fi
+  kind=$(fm_identity_meta_value "$meta" kind)
+  callsign=$(fm_identity_choose_fresh_callsign "$id" "$kind") || return 1
+  fm_identity_write_task_record "$record" "$id" "$callsign" active "$meta"
+  printf '%s\n' "$callsign"
+}
+
+fm_identity_ensure_legacy_archive() {
+  local id=$1 record callsign kind
+  record=$(fm_identity_task_record "$id")
+  [ -f "$record" ] && { fm_identity_record_value "$record" callsign; return 0; }
+  kind=ship
+  [ -f "$FM_IDENTITY_STATE/$id.meta" ] && kind=$(fm_identity_meta_value "$FM_IDENTITY_STATE/$id.meta" kind)
+  callsign=$(fm_identity_choose_fresh_callsign "$id" "$kind") || return 1
+  fm_identity_write_task_record "$record" "$id" "$callsign" archived
+  printf '%s\n' "$callsign"
+}
+
+fm_identity_archive_task() {
+  local meta=$1 id=$2 record callsign created
+  record=$(fm_identity_task_record "$id")
+  [ -f "$record" ] || return 1
+  callsign=$(fm_identity_record_value "$record" callsign)
+  created=$(fm_identity_record_value "$record" created_at)
+  fm_identity_write_task_record "$record" "$id" "$callsign" archived "$meta" "$created"
+  printf '%s\n' "$callsign"
+}
+
+fm_identity_display_callsign() {
+  local id=$1 record
+  record=$(fm_identity_task_record "$id")
+  if [ -f "$record" ]; then fm_identity_record_value "$record" callsign; else fm_identity_legacy_callsign "$id"; fi
+}
+
+fm_identity_resolve_selector() {
+  local state=$1 raw=$2 record id status callsign match=
+  case "$raw" in *:*) fm_identity_error "selector '$raw' is an endpoint, not a callsign or task id"; return 1 ;; esac
+  if fm_identity_task_id_valid "$raw" && [ -f "$state/$raw.meta" ]; then
+    record=$(fm_identity_task_record "$raw")
+    if [ ! -f "$record" ] || fm_identity_status_live "$(fm_identity_record_value "$record" status)"; then
+      printf '%s\n' "$raw"
+      return 0
+    fi
+  fi
+  for record in "$FM_IDENTITY_DATA"/crew-identities/*.identity; do
+    [ -f "$record" ] || continue
+    status=$(fm_identity_record_value "$record" status)
+    fm_identity_status_live "$status" || continue
+    callsign=$(fm_identity_record_value "$record" callsign)
+    if [ "$(fm_identity_fold "$callsign")" = "$(fm_identity_fold "$raw")" ]; then
+      id=$(basename "$record" .identity)
+      [ -z "$match" ] || { fm_identity_error "callsign '$raw' is ambiguous across live identities"; return 1; }
+      match=$id
+    fi
+  done
+  [ -n "$match" ] || { fm_identity_error "no live callsign or task '$raw' exists"; return 1; }
+  printf '%s\n' "$match"
+}
+
+fm_identity_rename_task() {
+  local state=$1 selector=$2 new=$3 id record old created
+  id=$(fm_identity_resolve_selector "$state" "$selector") || return 1
+  record=$(fm_identity_task_record "$id")
+  [ "$(fm_identity_record_value "$record" status)" = active ] || return 1
+  fm_identity_validate_name "$new" || return 1
+  fm_identity_name_in_use "$new" "$id" && {
+    fm_identity_error "callsign '$new' is already owned by a live identity"
+    return 1
+  }
+  old=$(fm_identity_record_value "$record" callsign)
+  created=$(fm_identity_record_value "$record" created_at)
+  fm_identity_write_task_record "$record" "$id" "$new" active "$state/$id.meta" "$created" "$old"
+  printf '%s\t%s\n' "$new" "$id"
+}
+
+fm_identity_ensure_home() {
+  local record="$FM_IDENTITY_DATA/firstmate.identity" name checksum size index offset candidate suffix live_names
+  fm_identity_prepare_dirs
+  if [ -f "$record" ]; then fm_identity_record_value "$record" name; return 0; fi
+  size=$(fm_identity_pool_size "$FM_IDENTITY_HOME_POOL")
+  checksum=$(fm_identity_checksum "$(cd "$FM_IDENTITY_DATA/.." && pwd -P)")
+  index=$((checksum % size))
+  live_names=$(fm_identity_live_names)
+  for ((offset=0; offset<size; offset++)); do
+    candidate=$(fm_identity_pool_item "$FM_IDENTITY_HOME_POOL" "$(((index + offset) % size))")
+    fm_identity_live_name_in_list "$candidate" "$live_names" || { name=$candidate; break; }
+  done
+  if [ -z "$name" ]; then
+    name=$(fm_identity_pool_item "$FM_IDENTITY_HOME_POOL" "$index")
+    suffix=2
+    while fm_identity_live_name_in_list "$name-$suffix" "$live_names"; do suffix=$((suffix + 1)); done
+    name="$name-$suffix"
+  fi
+  {
+    printf 'schema=fm-firstmate-identity.v1\n'
+    printf 'home=%s\n' "$(cd "$FM_IDENTITY_DATA/.." && pwd -P)"
+    printf 'name=%s\ncreated_at=%s\nupdated_at=%s\n' "$name" "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  } > "$record"
+  printf '%s\n' "$name"
+}
+
+fm_identity_rename_home() {
+  local new=$1 record="$FM_IDENTITY_DATA/firstmate.identity" old
+  fm_identity_validate_name "$new" || return 1
+  fm_identity_name_in_use "$new" && return 1
+  old=$(fm_identity_ensure_home)
+  sed "s/^name=.*/name=$new/" "$record" > "$record.tmp.${BASHPID:-$$}"
+  mv -f -- "$record.tmp.${BASHPID:-$$}" "$record"
+  printf '%s\n' "$new"
+  : "$old"
+}
+
+fm_identity_history() {
+  local record id callsign status
+  for record in "$FM_IDENTITY_DATA"/crew-identities/*.identity; do
+    [ -f "$record" ] || continue
+    id=$(basename "$record" .identity)
+    callsign=$(fm_identity_record_value "$record" callsign)
+    status=$(fm_identity_record_value "$record" status)
+    printf '%s\t%s\t%s\n' "$callsign" "$id" "$status"
+  done
+}

--- a/bin/fm-name.sh
+++ b/bin/fm-name.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Inspect and rename persistent Firstmate and task identities.
+# Usage: fm-name.sh home|rename-home <name>|rename <selector> <name>|resolve <selector>|history
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FM_HOME=${FM_HOME:?error: FM_HOME is not set}
+[ -d "$FM_HOME" ] || { echo "error: FM_HOME '$FM_HOME' is not a directory" >&2; exit 1; }
+STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
+DATA="${FM_DATA_OVERRIDE:-$FM_HOME/data}"
+# shellcheck source=bin/fm-identity-lib.sh
+. "$SCRIPT_DIR/fm-identity-lib.sh"
+
+usage() { echo "usage: fm-name.sh home|rename-home <name>|rename <selector> <name>|resolve <selector>|history"; }
+case "${1:-}" in
+  -h|--help|'') usage; exit 0 ;;
+esac
+command=$1
+shift
+case "$command" in
+  home) [ "$#" -eq 0 ] || { usage >&2; exit 2; }; printf '%s (Firstmate home)\n' "$(fm_identity_ensure_home)" ;;
+  rename-home) [ "$#" -eq 1 ] || { usage >&2; exit 2; }; printf '%s (Firstmate home)\n' "$(fm_identity_rename_home "$1")" ;;
+  rename)
+    [ "$#" -eq 2 ] || { usage >&2; exit 2; }
+    result=$(fm_identity_rename_task "$STATE" "$1" "$2")
+    printf '%s (%s)\n' "${result%%$'\t'*}" "${result#*$'\t'}"
+    ;;
+  resolve)
+    [ "$#" -eq 1 ] || { usage >&2; exit 2; }
+    id=$(fm_identity_resolve_selector "$STATE" "$1")
+    printf '%s (%s)\n' "$(fm_identity_display_callsign "$id")" "$id"
+    ;;
+  history)
+    [ "$#" -eq 0 ] || { usage >&2; exit 2; }
+    while IFS=$'\t' read -r callsign id status; do printf '%s (%s) %s\n' "$callsign" "$id" "$status"; done < <(fm_identity_history)
+    ;;
+  *) usage >&2; exit 2 ;;
+esac

--- a/bin/fm-peek.sh
+++ b/bin/fm-peek.sh
@@ -17,11 +17,18 @@ STATE="${FM_STATE_OVERRIDE:-$FM_HOME/state}"
 
 # shellcheck source=bin/fm-backend.sh
 . "$SCRIPT_DIR/fm-backend.sh"
+# shellcheck source=bin/fm-identity-lib.sh
+. "$SCRIPT_DIR/fm-identity-lib.sh"
 
 "$SCRIPT_DIR/fm-guard.sh" || true
 
 RAW_TARGET=$1
 N=${2:-40}
+case "$RAW_TARGET" in
+  *:*) ;;
+  *) identity_id=$(fm_identity_resolve_selector "$STATE" "$RAW_TARGET" 2>/dev/null || true)
+     [ -z "$identity_id" ] || RAW_TARGET=$identity_id ;;
+esac
 
 REMOTE_META=$(fm_backend_meta_for_selector "$RAW_TARGET" "$STATE" 2>/dev/null || true)
 if [ -n "$REMOTE_META" ] && [ -n "$(fm_meta_get "$REMOTE_META" remote_host)" ]; then

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -202,6 +202,8 @@ fi
 
 # shellcheck source=bin/fm-backend.sh
 . "$SCRIPT_DIR/fm-backend.sh"
+# shellcheck source=bin/fm-identity-lib.sh
+. "$SCRIPT_DIR/fm-identity-lib.sh"
 # shellcheck source=bin/fm-control-lib.sh
 . "$SCRIPT_DIR/fm-control-lib.sh"
 # shellcheck source=bin/fm-marker-lib.sh
@@ -295,7 +297,7 @@ fm_send_count_colons() {  # <string>
 }
 
 fm_send_resolve_target() {  # <raw-target>
-  local raw=$1 meta pane_meta target backend assumed colons id session hint
+  local raw=$1 meta pane_meta target backend assumed colons id session hint identity_id
 
   RESOLVED_TARGET=""
   TARGET_BACKEND=""
@@ -306,6 +308,12 @@ fm_send_resolve_target() {  # <raw-target>
   TARGET_REMOTE_ID=""
   TARGET_REMOTE_HOST=""
   RESOLUTION_TRIED=""
+
+  case "$raw" in
+    *:*) ;;
+    *) identity_id=$(fm_identity_resolve_selector "$STATE" "$raw" 2>/dev/null || true)
+       [ -z "$identity_id" ] || raw=$identity_id ;;
+  esac
 
   meta=$(fm_backend_meta_for_selector "$raw" "$STATE" 2>/dev/null || true)
   if [ -n "$meta" ]; then

--- a/bin/fm-session-start.sh
+++ b/bin/fm-session-start.sh
@@ -325,6 +325,8 @@ PRIMARY_HARNESS=$("$SCRIPT_DIR/fm-harness.sh" 2>/dev/null || printf unknown)
 
 # shellcheck source=bin/fm-backend.sh
 . "$SCRIPT_DIR/fm-backend.sh"
+# shellcheck source=bin/fm-identity-lib.sh
+. "$SCRIPT_DIR/fm-identity-lib.sh"
 # shellcheck source=bin/fm-tasks-axi-lib.sh
 . "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
 # shellcheck source=bin/fm-public-followup-lib.sh
@@ -335,6 +337,9 @@ PRIMARY_HARNESS=$("$SCRIPT_DIR/fm-harness.sh" 2>/dev/null || printf unknown)
 . "$SCRIPT_DIR/fm-wake-lib.sh"
 # shellcheck source=bin/fm-line-cap-lib.sh
 . "$SCRIPT_DIR/fm-line-cap-lib.sh"
+
+# Establish the persistent home identity without changing an existing name.
+fm_identity_ensure_home >/dev/null
 
 # One tasks-axi compatibility verdict per session start. The probe costs three
 # tasks-axi subprocesses and this digest needs the same answer twice - here for

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -246,6 +246,8 @@ SUB_HOME_MARKER=".fm-secondmate-home"
 . "$SCRIPT_DIR/fm-config-inherit-lib.sh"
 # shellcheck source=bin/fm-backend.sh
 . "$SCRIPT_DIR/fm-backend.sh"
+# shellcheck source=bin/fm-identity-lib.sh
+. "$SCRIPT_DIR/fm-identity-lib.sh"
 # shellcheck source=bin/fm-control-lib.sh
 . "$SCRIPT_DIR/fm-control-lib.sh"
 # shellcheck source=bin/fm-gate-refuse-lib.sh
@@ -494,6 +496,14 @@ spawn_remote_secondmate() {
       return 1
     fi
   fi
+  if [ ! -f "$(fm_identity_task_record "$id")" ]; then
+    if [ -f "$meta" ]; then
+      fm_identity_ensure_task_from_meta "$meta" "$id" >/dev/null || return 1
+    else
+      fm_identity_reserve_fresh_task "$id" secondmate >/dev/null || return 1
+      IDENTITY_FRESH_RESERVED=1
+    fi
+  fi
   # Gate the host before anything is published or transferred, so a host that
   # cannot hold a durable Herdr endpoint refuses here rather than half-way
   # through a launch. This is also the readiness gate every liveness relaunch
@@ -656,6 +666,7 @@ HERDR_PRESENTATION_ORDER_LOCK=
 HERDR_PRESENTATION_ORDER_LOCK_HELD=0
 SPAWN_TASK_LOCK=
 SPAWN_TASK_LOCK_HELD=0
+IDENTITY_FRESH_RESERVED=0
 SPAWN_CONTROL_LOCK=
 SPAWN_CONTROL_LOCK_HELD=0
 SPAWN_CONTROL_PARENT=0
@@ -985,6 +996,10 @@ if ! fm_lock_try_acquire "$SPAWN_TASK_LOCK"; then
   exit 1
 fi
 SPAWN_TASK_LOCK_HELD=1
+if [ "$RELAUNCH" -eq 0 ]; then
+  fm_identity_reserve_fresh_task "$ID" "$KIND" >/dev/null || exit 1
+  IDENTITY_FRESH_RESERVED=1
+fi
 PROJ=
 ARG3=
 FIRSTMATE_HOME=
@@ -2710,6 +2725,11 @@ if [ "$RELAUNCH" -eq 1 ]; then
   SPAWN_META_TMP=
   fm_lock_release "$SPAWN_META_LOCK"
   SPAWN_META_LOCK_HELD=0
+fi
+if [ "$IDENTITY_FRESH_RESERVED" = 1 ]; then
+  fm_identity_activate_reserved_task_from_meta "$STATE/$ID.meta" "$ID" >/dev/null || exit 1
+else
+  fm_identity_ensure_task_from_meta "$STATE/$ID.meta" "$ID" rebind >/dev/null || exit 1
 fi
 if [ "$SPAWN_TASK_SET_LOCK_HELD" = 1 ]; then
   # The record is published, so this task is now part of the set a teardown

--- a/bin/fm-teardown.sh
+++ b/bin/fm-teardown.sh
@@ -152,6 +152,8 @@ SUB_HOME_PARENT_MARKER=".fm-secondmate-parent"
 . "$SCRIPT_DIR/fm-tasks-axi-lib.sh"
 # shellcheck source=bin/fm-backend.sh
 . "$SCRIPT_DIR/fm-backend.sh"
+# shellcheck source=bin/fm-identity-lib.sh
+. "$SCRIPT_DIR/fm-identity-lib.sh"
 # shellcheck source=bin/fm-control-lib.sh
 . "$SCRIPT_DIR/fm-control-lib.sh"
 # shellcheck source=bin/fm-lock-lib.sh
@@ -2651,6 +2653,15 @@ if [ "$KIND" != secondmate ]; then
   reap_task_worktree_processes worktree "$WT" "$TASK_TMP"
 fi
 
+# Bind legacy metadata only after the landed-work and teardown safety gates have
+# passed. The active record keeps its callsign reserved through cleanup.
+if [ ! -f "$(fm_identity_task_record "$ID")" ]; then
+  fm_identity_ensure_task_from_meta "$META" "$ID" >/dev/null || {
+    echo "error: task $ID could not receive a persistent callsign; teardown aborted" >&2
+    exit 1
+  }
+fi
+
 # Fix 3 (see script header): sweep remote job workers abandoned by an already
 # pruned code root. Best effort - a sweep failure never blocks this teardown.
 "$SCRIPT_DIR/fm-remote-job-reap-orphans.sh" >&2 || true
@@ -2823,6 +2834,10 @@ rm -f "$STATE/$ID.turn-ended" "$STATE/$ID.meta" \
 # retired endpoint; teardown only runs after landing is confirmed, so any
 # leftover unhandled steer here is moot rather than unlanded work.
 rm -rf "$STATE/$ID.inbox"
+fm_identity_archive_task "" "$ID" >/dev/null || {
+  echo "error: task $ID teardown completed, but its callsign could not be released; retaining identity history for a safe retry" >&2
+  exit 1
+}
 fm_lock_release "$META_LOCK"
 META_LOCK_HELD=0
 if [ "$KIND" != scout ] && [ "$KIND" != secondmate ] && [ "$MODE" != local-only ]; then

--- a/bin/fm-test-isolation-proof.sh
+++ b/bin/fm-test-isolation-proof.sh
@@ -157,6 +157,7 @@ tests/fm-captain-hold-lifecycle.test.sh
 tests/fm-cd-pretool-check.test.sh
 tests/fm-composer-ghost.test.sh
 tests/fm-composer-lib.test.sh
+tests/fm-identity.test.sh
 tests/fm-crew-state.test.sh
 tests/fm-ensure-agents-md.test.sh
 tests/fm-grok-harness.test.sh

--- a/bin/fm-test-run.sh
+++ b/bin/fm-test-run.sh
@@ -137,7 +137,7 @@ family_for_basename() {
     fm-brief.test.sh|fm-vendor-auth-probe.test.sh|\
     fm-calm-pi-extension.test.sh|fm-cd-pretool-check.test.sh|\
     fm-classify-decision-key.test.sh|\
-    fm-composer-ghost.test.sh|fm-composer-lib.test.sh|\
+    fm-composer-ghost.test.sh|fm-composer-lib.test.sh|fm-identity.test.sh|\
     fm-crew-state.test.sh|fm-captain-hold-lifecycle.test.sh|\
     fm-documentation-audiences.test.sh|fm-ensure-agents-md.test.sh|fm-grok-harness.test.sh|\
     fm-kimi-harness.test.sh|fm-muse-harness.test.sh|fm-herdr-lab.test.sh|fm-lint.test.sh|\
@@ -290,6 +290,7 @@ tests/fm-captain-hold-lifecycle.test.sh
 tests/fm-cd-pretool-check.test.sh
 tests/fm-composer-ghost.test.sh
 tests/fm-composer-lib.test.sh
+tests/fm-identity.test.sh
 tests/fm-crew-state.test.sh
 tests/fm-ensure-agents-md.test.sh
 tests/fm-grok-harness.test.sh
@@ -320,6 +321,7 @@ tests/fm-cd-pretool-check.test.sh
 tests/fm-captain-hold-lifecycle.test.sh
 tests/fm-test-run.test.sh
 tests/fm-composer-ghost.test.sh
+tests/fm-identity.test.sh
 tests/fm-grok-harness.test.sh
 tests/fm-lint.test.sh
 tests/fm-pi-primary-types.test.sh
@@ -1002,7 +1004,7 @@ families_for_changed_path() {
       printf '%s\n' pure-contract-unit
       printf '%s\n' live-harness-optin
       ;;
-    bin/fm-spawn.sh|bin/fm-send.sh|bin/fm-harness.sh|\
+    bin/fm-identity-lib.sh|bin/fm-name.sh|bin/fm-spawn.sh|bin/fm-send.sh|bin/fm-harness.sh|\
     bin/fm-peek.sh|bin/fm-composer*)
       printf '%s\n' backend-dispatch
       printf '%s\n' pure-contract-unit

--- a/tests/fm-identity.test.sh
+++ b/tests/fm-identity.test.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Focused tests for live callsign ownership and One Piece role pools.
+set -eu
+
+# shellcheck source=tests/lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
+TMP_ROOT=$(fm_test_tmproot fm-identity)
+HOME_DIR="$TMP_ROOT/home"
+STATE="$HOME_DIR/state"
+DATA="$HOME_DIR/data"
+mkdir -p "$STATE" "$DATA"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+export FM_HOME="$HOME_DIR" FM_STATE_OVERRIDE="$STATE" FM_DATA_OVERRIDE="$DATA"
+
+# shellcheck source=bin/fm-identity-lib.sh
+. "$ROOT/bin/fm-identity-lib.sh"
+
+fail() { printf 'not ok - %s\n' "$*" >&2; exit 1; }
+pass() { printf 'ok - %s\n' "$*"; }
+record() { fm_identity_task_record "$1"; }
+
+home_name=$(fm_identity_ensure_home)
+case " $FM_IDENTITY_HOME_POOL " in *" $home_name "*) ;; *) fail "home name '$home_name' is outside the Firstmate pool" ;; esac
+pass "fresh Firstmate homes use the dedicated role pool"
+
+for reserved in Luffy Roger; do
+  if fm_identity_validate_name "$reserved" >/dev/null 2>&1; then fail "$reserved was not reserved"; fi
+done
+pass "Luffy and Roger are reserved and never assignable"
+
+write_meta() {
+  local id=$1 kind=$2
+  {
+    printf 'kind=%s\n' "$kind"
+    printf 'worktree=%s/%s\nwindow=session:%s\nbackend=tmux\n' "$TMP_ROOT" "$id" "$id"
+    printf 'spawn_gen=gen-%s\n' "$id"
+  } > "$STATE/$id.meta"
+}
+
+prov=$(fm_identity_reserve_fresh_task provisioning-task ship)
+write_meta provisioning-task ship
+fm_identity_activate_reserved_task_from_meta "$STATE/provisioning-task.meta" provisioning-task >/dev/null
+active=$(fm_identity_reserve_fresh_task active-task ship)
+write_meta active-task ship
+fm_identity_activate_reserved_task_from_meta "$STATE/active-task.meta" active-task >/dev/null
+[ "$prov" != "$active" ] || fail "active and provisioning identities collided"
+pass "active and provisioning identities reserve distinct callsigns"
+
+second=$(fm_identity_reserve_fresh_task second-task secondmate)
+case " $FM_IDENTITY_SECOND_MATE_POOL " in *" $second "*) ;; *) fail "secondmate callsign '$second' is outside its pool" ;; esac
+crew=$(fm_identity_reserve_fresh_task crew-task scout)
+case " $FM_IDENTITY_CREWMATE_POOL " in *" $crew "*) ;; *) fail "crewmate callsign '$crew' is outside its pool" ;; esac
+case " $FM_IDENTITY_SECOND_MATE_POOL " in *" $crew "*) fail "role pools overlap" ;; esac
+pass "secondmates and crewmates select distinct role pools"
+
+saved_crew_pool=$FM_IDENTITY_CREWMATE_POOL
+FM_IDENTITY_CREWMATE_POOL=Fallback
+fm_identity_write_task_record "$(record fallback-task)" fallback-task Fallback active
+[ "$(fm_identity_choose_fresh_callsign suffix-task scout)" = Fallback-2 ] \
+  || fail "an exhausted role pool did not use the deterministic suffix fallback"
+FM_IDENTITY_CREWMATE_POOL=$saved_crew_pool
+pass "exhausted role pools use deterministic suffix fallback"
+
+old=$prov
+renamed=$(fm_identity_rename_task "$STATE" "$old" ReleasedName)
+[ "${renamed%%$'\t'*}" = ReleasedName ] || fail "rename did not publish new callsign"
+if fm_identity_name_in_use "$old"; then fail "rename retained old callsign ownership"; fi
+if fm_identity_resolve_selector "$STATE" "$old" >/dev/null 2>&1; then fail "retired callsign remained routable"; fi
+pass "rename releases the old callsign immediately"
+
+fm_identity_archive_task "$STATE/active-task.meta" active-task >/dev/null
+if fm_identity_name_in_use "$active"; then fail "archived callsign still reserved"; fi
+if fm_identity_resolve_selector "$STATE" "$active" >/dev/null 2>&1; then fail "archived callsign still resolved"; fi
+reused=$(fm_identity_reserve_fresh_task reused-task ship)
+[ -n "$reused" ] || fail "fresh allocation after archive failed"
+write_meta reused-task ship
+fm_identity_activate_reserved_task_from_meta "$STATE/reused-task.meta" reused-task >/dev/null
+fm_identity_rename_task "$STATE" "$reused" "$active" >/dev/null
+[ "$(fm_identity_resolve_selector "$STATE" "$active")" = reused-task ] || fail "reused active name resolved to the archived task"
+pass "archived names can be reused and resolve to the new active task"
+
+printf 'schema=fm-firstmate-identity.v1\nhome=%s\nname=Polaris\n' "$HOME_DIR" > "$DATA/firstmate.identity"
+[ "$(fm_identity_ensure_home)" = Polaris ] || fail "existing Polaris home was renamed"
+printf 'schema=fm-crew-identity.v1\nhome=%s\ntask_id=franklin-task\ncallsign=Franklin\nstatus=active\n' "$HOME_DIR" > "$(record franklin-task)"
+write_meta franklin-task ship
+[ "$(fm_identity_ensure_task_from_meta "$STATE/franklin-task.meta" franklin-task)" = Franklin ] || fail "existing Franklin identity changed"
+fresh=$(fm_identity_choose_fresh_callsign fresh-after-compat ship)
+[ "$(fm_identity_fold "$fresh")" != franklin ] || fail "fresh identity collided with Franklin"
+pass "existing Polaris and Franklin identities remain compatible"
+
+printf '%s\n' "$FM_IDENTITY_HOME_POOL" "$FM_IDENTITY_SECOND_MATE_POOL" "$FM_IDENTITY_CREWMATE_POOL" \
+  | awk '{for (i=1;i<=NF;i++) print $i}' | sort | uniq -d | grep -q . && fail "role pool names overlap" || true
+printf 'ok - live callsign ownership and role pools\n'


### PR DESCRIPTION
Implements live-owned persistent identities with deterministic One Piece role pools, reserved names, rename/teardown release, and callsign routing. Preserves existing Polaris and Franklin identities and tightens the captain-facing address rule to Senchō.\n\nValidation:\n- tests/fm-identity.test.sh: passed\n- bin/fm-test-run.sh tests/fm-identity.test.sh: passed\n- bin/fm-doc-audience-check.sh: passed\n- bin/fm-lint.sh / ShellCheck: no findings after fixes; workflow lint is environment-blocked because actionlint is not installed\n- focused identity + teardown run: identity passed; teardown reaches the known pre-existing fm_backend_source/herdr-preflight failure tracked as issue #3095\n\nNo merge performed.