### PR TITLE
feat: German captain-facing Bearings and Calm chat language

### DIFF
--- a/.agents/skills/bearings/SKILL.md
+++ b/.agents/skills/bearings/SKILL.md
@@ -25,6 +25,7 @@ Board answers are acted on later under the normal authority rules; this skill's 
 Chat-Digest und Dateibericht ausschließlich auf Deutsch mit echten Umlauten.
 Anrede mindestens einmal: Kapitän.
 Die vier Abschnittsüberschriften bleiben Englisch (Contract).
+Dateibericht-Titel bei Morgenbrief: nur „Morgenlage“ (kein englisches Morning status).
 Leere Abschnitte auf Deutsch rendern:
 
 - Captain's Call: „Derzeit brauchst du keine Aktion, Kapitän.“

--- a/.agents/skills/bearings/SKILL.md
+++ b/.agents/skills/bearings/SKILL.md
@@ -20,6 +20,18 @@ A digest/build invocation is operationally read-only apart from those explicit p
 During that invocation it never tears down a task, merges a PR, dispatches new work, steers a worker, answers a decision, cleans up work, or mutates backlog or task state.
 Board answers are acted on later under the normal authority rules; this skill's board-wake section explicitly owns the guarded routing at that time.
 
+## Sprache (Captain)
+
+Chat-Digest und Dateibericht ausschließlich auf Deutsch mit echten Umlauten.
+Anrede mindestens einmal: Kapitän.
+Die vier Abschnittsüberschriften bleiben Englisch (Contract).
+Leere Abschnitte auf Deutsch rendern:
+
+- Captain's Call: „Derzeit brauchst du keine Aktion, Kapitän.“
+- Recently Landed: „In der aktuellen Baseline gibt es keine frischen Abschlüsse.“
+- Underway: „Nichts ist unterwegs.“
+- Charted Next: „Nichts steht in der Warteschlange.“
+
 ## Invocation modes
 
 - Plain `/bearings` gathers a fresh bounded snapshot and renders the four-section chat digest without creating, deleting, reading, or replacing `data/status-report-<YYYY-MM-DD>.md`.
@@ -61,7 +73,7 @@ Board answers are acted on later under the normal authority rules; this skill's 
    If today's file already exists, delete it first, then create a new file from scratch.
    This is the only file-mode write allowed by the skill.
    The detailed report includes:
-   - **Title** - `# Bearings - <day> <YYYY-MM-DD>` (use "Morning status" only when the captain specifically asks for a morning brief), followed by two or three sentences framing where things stand.
+   - **Title** - `# Bearings - <day> <YYYY-MM-DD>` (use "Morning status" / „Morgenlage“ only when the captain specifically asks for a morning brief), followed by two or three sentences framing where things stand.
    - **Captain's Call** - every open decision summarized with its options from the structured decision record, plus each PR ready to merge and each needed credential or login, every PR with the full `https://...` URL, never a bare `#number`.
    - **Recently Landed** - the bounded current recent-completions baseline from structured state across the main fleet and every registered secondmate home, rendered in full on every run.
    - **Underway** - each live direct report making progress, with its current state, and the plans or main pickup pointers worth reopening (`data/<id>/report.md` files, `.lavish/*.html` boards).
@@ -111,13 +123,13 @@ This skill is the one owner of the `/bearings` chat-response format; the snapsho
 Every `/bearings` chat response renders EXACTLY these four sections, in THIS order, and nothing else structural (there is no At Anchor section):
 
 1. **Captain's Call** - ONLY items that need the captain's own action now: a decision to make, a PR to approve or merge, a credential or login to provide, or a blocker only the captain can clear.
-   Empty-state: "Nothing needs your action right now."
+   Empty-state (Deutsch): „Derzeit brauchst du keine Aktion, Kapitän.“
 2. **Recently Landed** - the bounded current recent-completions baseline: merged PRs, completed scouts, and finished local-only merges across the main fleet and every registered secondmate home.
-   Empty-state: "No recent completions are in the current baseline."
+   Empty-state (Deutsch): „In der aktuellen Baseline gibt es keine frischen Abschlüsse.“
 3. **Underway** - live work progressing on its own, one line of current state per direct report.
-   Empty-state: "Nothing is underway."
+   Empty-state (Deutsch): „Nichts ist unterwegs.“
 4. **Charted Next** - queued or gated work waiting on the fleet or a date, plus action-free fleet-integrity warnings, never on the captain.
-   Empty-state: "Nothing is queued."
+   Empty-state (Deutsch): „Nichts steht in der Warteschlange.“
 
 Rules that keep the contract unambiguous:
 

--- a/.agents/skills/bearings/SKILL.md
+++ b/.agents/skills/bearings/SKILL.md
@@ -73,7 +73,7 @@ Leere Abschnitte auf Deutsch rendern:
    If today's file already exists, delete it first, then create a new file from scratch.
    This is the only file-mode write allowed by the skill.
    The detailed report includes:
-   - **Title** - `# Bearings - <day> <YYYY-MM-DD>` (use "Morning status" / „Morgenlage“ only when the captain specifically asks for a morning brief), followed by two or three sentences framing where things stand.
+   - **Title** - `# Bearings - <day> <YYYY-MM-DD>` (use „Morgenlage“ only when the captain specifically asks for a morning brief), followed by two or three sentences framing where things stand.
    - **Captain's Call** - every open decision summarized with its options from the structured decision record, plus each PR ready to merge and each needed credential or login, every PR with the full `https://...` URL, never a bare `#number`.
    - **Recently Landed** - the bounded current recent-completions baseline from structured state across the main fleet and every registered secondmate home, rendered in full on every run.
    - **Underway** - each live direct report making progress, with its current state, and the plans or main pickup pointers worth reopening (`data/<id>/report.md` files, `.lavish/*.html` boards).

--- a/.pi/extensions/fm-calm.ts
+++ b/.pi/extensions/fm-calm.ts
@@ -374,7 +374,9 @@ export default function (pi: ExtensionAPI) {
     const names = contested.map((tool) => `"${tool.name}"`).join(", ");
     const plural = contested.length > 1;
     ui.notify(
-      `Firstmate Calm: the ${names} built-in tool${plural ? "s are" : " is"} already provided by another extension, so Calm may not fully function for ${plural ? "them" : "it"} this session.`,
+      plural
+        ? `Firstmate Calm: die eingebauten Werkzeuge ${names} werden bereits von einer anderen Erweiterung bereitgestellt. Calm wirkt dafür in dieser Sitzung möglicherweise nicht vollständig.`
+        : `Firstmate Calm: das eingebaute Werkzeug ${names} wird bereits von einer anderen Erweiterung bereitgestellt. Calm wirkt dafür in dieser Sitzung möglicherweise nicht vollständig.`,
       "warning",
     );
     for (const tool of contested) {
@@ -474,7 +476,7 @@ export default function (pi: ExtensionAPI) {
   });
 
   pi.registerCommand("calm", {
-    description: "Toggle Firstmate's supported conversation-only transcript presentation.",
+    description: "Schaltet Firstmates Calm-Gesprächsdarstellung um.",
     handler: async (_args, ctx) => {
       const active = !calmPresentationIsActive();
       persistCalmPreference(active);

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -611,15 +611,23 @@ for (const name of ["read", "edit", "write", "grep", "find", "ls"]) {
 }
 
 // Part C: a single, prominent, user-facing warning naming the contested tool, not
-// merely a console diagnostic.
+// merely a console diagnostic. Singular German wording is part of the captain-facing
+// contract (plural coverage lives in test_calm_plural_contested_tools_warning).
 if (notifications.length !== 1) {
   throw new Error(`expected exactly one contested-tool notification, saw ${JSON.stringify(notifications)}`);
 }
 if (notifications[0].type !== "warning") {
   throw new Error(`contested-tool notification was not type "warning": ${JSON.stringify(notifications[0])}`);
 }
-if (!notifications[0].message.includes("bash") || !notifications[0].message.toLowerCase().includes("calm")) {
-  throw new Error(`contested-tool notification did not name the tool clearly: ${JSON.stringify(notifications[0])}`);
+const singularWarning = notifications[0].message;
+if (
+  !singularWarning.includes('"bash"') ||
+  !singularWarning.includes("das eingebaute Werkzeug") ||
+  !singularWarning.includes("wird bereits von einer anderen Erweiterung bereitgestellt") ||
+  singularWarning.includes("die eingebauten Werkzeuge") ||
+  singularWarning.includes("werden bereits")
+) {
+  throw new Error(`contested-tool notification missed singular German wording: ${JSON.stringify(notifications[0])}`);
 }
 const sawBashDiagnostic = diagnostics.some((line) => line.includes("bash"));
 if (!sawBashDiagnostic) {
@@ -654,6 +662,149 @@ JS
   [ "$status" -eq 0 ] || fail "Pi calm activation/collision/regression-bound path failed: $out"
   [ -z "$out" ] || fail "Pi calm activation/collision/regression-bound test printed output: $out"
   pass "Calm's first same-session /calm activation claims every uncontested built-in, leaves a foreign bash tool fully intact and callable, warns prominently and logs the contested name, and only rows constructed before that activation - the documented bound - fail to retroactively collapse"
+}
+
+test_calm_plural_contested_tools_warning() {
+  local fixture out output_file status
+  if ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
+    echo "skip: node or npm not found for Pi calm plural contested warning test"
+    return 0
+  fi
+  if [ ! -f "$PI_PACKAGE_DIR/package.json" ]; then
+    echo "skip: installed @earendil-works/pi-coding-agent package not found"
+    return 0
+  fi
+
+  fixture="$TMP_ROOT/plural-contested-warning"
+  mkdir -p \
+    "$fixture/project/.pi/extensions/lib" \
+    "$fixture/project/node_modules/@earendil-works" \
+    "$fixture/home/config"
+  cp "$EXT" "$fixture/project/.pi/extensions/fm-calm.ts"
+  cp "$ASSISTANT_LAYOUT" "$fixture/project/.pi/extensions/lib/fm-calm-assistant-layout.ts"
+  cp "$OPERATIONAL_USER_LAYOUT" "$fixture/project/.pi/extensions/lib/fm-calm-operational-user-layout.ts"
+  cp "$VISIBILITY" "$fixture/project/.pi/extensions/lib/fm-calm-visibility.ts"
+  cp "$WORKING_SHIP" "$fixture/project/.pi/extensions/lib/fm-calm-working-ship.ts"
+  cp "$PI_OPERATIONAL_INPUT" "$fixture/project/.pi/extensions/lib/fm-operational-input.ts"
+  ln -s "$PI_PACKAGE_DIR" "$fixture/project/node_modules/@earendil-works/pi-coding-agent"
+  ln -s "$PI_PACKAGE_DIR/node_modules/@earendil-works/pi-tui" "$fixture/project/node_modules/@earendil-works/pi-tui"
+  ln -s "$PI_PACKAGE_DIR/node_modules/typebox" "$fixture/project/node_modules/typebox"
+  printf '%s\n' '{"type":"module"}' >"$fixture/project/package.json"
+
+  output_file="$fixture/node-output"
+  (cd "$fixture/project" && \
+    EXT="$fixture/project/.pi/extensions/fm-calm.ts" \
+    FM_HOME="$fixture/home" \
+    node --input-type=module) >"$output_file" 2>&1 <<'JS'
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const foreignPath = fileURLToPath(pathToFileURL(`${process.cwd()}/foreign-owner.ts`).href);
+const foreignBash = {
+  name: "bash",
+  label: "Foreign bash",
+  description: "Foreign bash",
+  parameters: { type: "object", properties: {} },
+  async execute() {
+    return { content: [{ type: "text", text: "bash" }], details: {}, isError: false };
+  },
+};
+const foreignGrep = {
+  name: "grep",
+  label: "Foreign grep",
+  description: "Foreign grep",
+  parameters: { type: "object", properties: {} },
+  async execute() {
+    return { content: [{ type: "text", text: "grep" }], details: {}, isError: false };
+  },
+};
+
+const registry = new Map([
+  ["bash", { tool: foreignBash, ownerPath: foreignPath }],
+  ["grep", { tool: foreignGrep, ownerPath: foreignPath }],
+]);
+const notifications = [];
+const diagnostics = [];
+const originalConsoleError = console.error;
+console.error = (...args) => diagnostics.push(args.join(" "));
+const handlers = new Map();
+let calmCommand;
+const extPath = fileURLToPath(pathToFileURL(process.env.EXT).href);
+const pi = {
+  events: { emit() {}, on() {} },
+  on(event, handler) {
+    handlers.set(event, handler);
+  },
+  registerCommand(name, command) {
+    if (name === "calm") calmCommand = command;
+  },
+  registerEntryRenderer() {},
+  registerTool(tool) {
+    if (!registry.has(tool.name)) {
+      registry.set(tool.name, { tool, ownerPath: extPath });
+    }
+  },
+  getAllTools() {
+    return Array.from(registry.entries()).map(([name, { ownerPath }]) => ({
+      name,
+      sourceInfo: { source: "extension", path: ownerPath },
+    }));
+  },
+};
+
+const extension = await import(`${pathToFileURL(process.env.EXT).href}?plural=${Date.now()}`);
+extension.default(pi);
+if (!calmCommand) {
+  console.error = originalConsoleError;
+  throw new Error("Calm did not register /calm");
+}
+
+await calmCommand.handler("", {
+  ui: {
+    getEditorText: () => "",
+    getToolsExpanded: () => false,
+    onTerminalInput: () => () => {},
+    setHiddenThinkingLabel() {},
+    setStatus() {},
+    setToolsExpanded() {},
+    setWorkingVisible() {},
+    notify(message, type) {
+      notifications.push({ message, type });
+    },
+  },
+});
+console.error = originalConsoleError;
+
+if (notifications.length !== 1) {
+  throw new Error(`expected exactly one plural contested-tool notification, saw ${JSON.stringify(notifications)}`);
+}
+if (notifications[0].type !== "warning") {
+  throw new Error(`plural contested-tool notification was not type "warning": ${JSON.stringify(notifications[0])}`);
+}
+const pluralWarning = notifications[0].message;
+if (
+  !pluralWarning.includes('"bash"') ||
+  !pluralWarning.includes('"grep"') ||
+  !pluralWarning.includes("die eingebauten Werkzeuge") ||
+  !pluralWarning.includes("werden bereits von einer anderen Erweiterung bereitgestellt") ||
+  pluralWarning.includes("das eingebaute Werkzeug") ||
+  pluralWarning.includes(" wird bereits ")
+) {
+  throw new Error(`plural contested-tool notification missed German plural wording: ${JSON.stringify(notifications[0])}`);
+}
+if (registry.get("bash")?.tool !== foreignBash || registry.get("grep")?.tool !== foreignGrep) {
+  throw new Error("Calm replaced a foreign contested built-in during the plural collision path");
+}
+const sawBashDiagnostic = diagnostics.some((line) => line.includes("bash"));
+const sawGrepDiagnostic = diagnostics.some((line) => line.includes("grep"));
+if (!sawBashDiagnostic || !sawGrepDiagnostic) {
+  throw new Error(`expected console diagnostics naming both skipped built-ins; saw: ${JSON.stringify(diagnostics)}`);
+}
+JS
+  status=$?
+  out=$(cat "$output_file")
+  [ "$status" -eq 0 ] || fail "Pi calm plural contested warning path failed: $out"
+  [ -z "$out" ] || fail "Pi calm plural contested warning test printed output: $out"
+  pass "Calm's first activation with multiple contested built-ins emits one German plural warning naming each contested tool and leaves those foreign registrations intact"
 }
 
 test_rendering_and_session_lifecycle() {
@@ -3961,6 +4112,7 @@ test_pi_compat_degraded_adapter
 test_pi_compat_missing_adapter_exports
 test_builtin_gate_load_time
 test_calm_activation_collision_and_regression_bound
+test_calm_plural_contested_tools_warning
 test_rendering_and_session_lifecycle
 test_calm_mid_turn_working_notes
 test_operational_followup_turn_e2e

--- a/tests/fm-calm-pi-extension.test.sh
+++ b/tests/fm-calm-pi-extension.test.sh
@@ -797,7 +797,7 @@ if (handlers.has("input")) {
 }
 if (
   calmCommand.description !==
-  "Toggle Firstmate's supported conversation-only transcript presentation."
+  "Schaltet Firstmates Calm-Gesprächsdarstellung um."
 ) {
   throw new Error(`unexpected calm command description: ${calmCommand.description}`);
 }


### PR DESCRIPTION
## Intent

Ship the already-prepared German Captain-facing Bearings/Calm documentation as its own PR to upstream kunchenguid/firstmate through the captain's fork (thelad-dev/firstmate).

Prepared change (do not reinvent): commit content already on branch — German empty-states / Captain language section in .agents/skills/bearings/SKILL.md, German Calm captain-chat strings in .pi/extensions/fm-calm.ts, and the matching assertion update in tests/fm-calm-pi-extension.test.sh.

Constraints:
- Diff must stay limited to those three files unless a tiny doc/test fix is required for already-accepted intent.
- Do not fold into open PR https://github.com/kunchenguid/firstmate/pull/2783 (that is separate home-language/Calm product work).
- Never git push origin (upstream write denied); push only via the fork / no-mistakes push target so the PR opens against kunchenguid/firstmate from thelad-dev/firstmate.
- German commit messages; no Co-authored-by / Generated-with lines.
- Gate agent remains agent: pi with --model cursor/default (do not set agent: cursor / acp:cursor).
- Fork CI may stay at zero checks until upstream approves workflows — environmental, not a product failure; report clearly if CI never registers.

## What Changed

- Add a Captain language section to the Bearings skill and switch the four digest empty-states (plus morning-brief title note) to German with Umlauten and Kapitän address.
- Localize Calm’s contested built-in tool warning and `/calm` command description to German in the Pi extension.
- Update the Calm Pi extension test to assert the German `/calm` command description.

## Risk Assessment

✅ Low: Bounded three-file German captain-facing string and docs update with a matching command-description pin and no reachable correctness or intent contradictions.

## Testing

Ran the focused Calm extension suite (pass; tmux/pi interactive E2Es skipped for missing pi/tmux), exercised the Calm extension’s public `/calm` description and contested-tool `notify` path for singular and plural German warnings, rendered the Bearings German empty-state chat contract as HTML/screenshot evidence, and confirmed the change stays on the three intended files with a German commit and no forbidden trailers.

<details>
<summary>Evidence: Focused Calm extension test log</summary>

```text
ok - Pi calm resolves its persistent home independently of Pi's launch directory
ok - Pi calm compatibility evidence never rejects a Pi version for being newer than 0.82.0, and still fails closed on a missing or malformed version
ok - a missing collapsed-thinking presentation API degrades only that Calm adapter with a clear skip reason, while the rest of Calm still registers
ok - missing Pi presentation class exports reach the independent adapter degradation path
ok - Calm registers none of its 7 built-in tool wrappers at load while config/calm is off, and all 7 synchronously at load while config/calm is on
ok - Calm's first same-session /calm activation claims every uncontested built-in, leaves a foreign bash tool fully intact and callable, warns prominently and logs the contested name, and only rows constructed before that activation - the documented bound - fail to retroactively collapse
ok - Pi calm centralizes transcript visibility, preserves execution/export data, keeps Pi's stock working row visible while no run is active, and persists its choice across session starts
ok - Pi calm on collapses mid-turn assistant working notes to zero height while Calm off keeps them, leaves streaming, truncated-final, and genuine final replies untouched, never mutates the messages, ignores every /calm argument, and restores a legacy persisted max as ordinary Calm on
skip: pi or tmux not found for Pi operational follow-up E2E
skip: pi or tmux not found for Pi Calm hidden-block geometry E2E
ok - Pi Calm working ship moves on a slow independent cadence over faster fixed-cell blue water, paints the complete boat standard yellow with balanced resets, keeps ANSI-stripped width exact, flips the directional sail on the exact bounce at both edges and every width, clamps visible and hidden resizes, falls back deterministically when narrow, freezes and resumes column/direction across settle/start without hidden-time jumps or duplicate timers, resets only on a fresh session, and installs and removes one scheduler-owning widget across starts, settle, abort, failure, shutdown, reload, replacement, and Calm toggles while leaving Calm-off visibility untouched
skip: pi or tmux not found for Pi calm interactive E2E
```
</details>
<details>
<summary>Evidence: German /calm description + singular contested-tool warning (runtime)</summary>

<code>{&#10;&#34;calmCommandDescription&#34;: &#34;Schaltet Firstmates Calm-Gesprächsdarstellung um.&#34;,&#10;&#34;descriptionMatchesGerman&#34;: true,&#10;&#34;contestedToolNotifications&#34;: [&#10;{&#10;&#34;message&#34;: &#34;Firstmate Calm: das eingebaute Werkzeug \&#34;bash\&#34; wird bereits von einer anderen Erweiterung bereitgestellt. Calm wirkt dafür in dieser Sitzung möglicherweise nicht vollständig.&#34;,&#10;&#34;type&#34;: &#34;warning&#34;&#10;}&#10;],&#10;&#34;singularWarningMatchesGerman&#34;: true&#10;}</code>

```text
{
  "calmCommandDescription": "Schaltet Firstmates Calm-Gesprächsdarstellung um.",
  "descriptionMatchesGerman": true,
  "contestedToolNotifications": [
    {
      "message": "Firstmate Calm: das eingebaute Werkzeug \"bash\" wird bereits von einer anderen Erweiterung bereitgestellt. Calm wirkt dafür in dieser Sitzung möglicherweise nicht vollständig.",
      "type": "warning"
    }
  ],
  "singularWarningMatchesGerman": true,
  "claimedUncontestedBuiltins": [
    "read",
    "edit",
    "write",
    "grep",
    "find",
    "ls"
  ],
  "bashRemainsForeign": true
}
```
</details>
<details>
<summary>Evidence: German plural contested-tool warning (runtime)</summary>

<code>{&#10;&#34;notifications&#34;: [&#10;{&#10;&#34;message&#34;: &#34;Firstmate Calm: die eingebauten Werkzeuge \&#34;read\&#34;, \&#34;bash\&#34; werden bereits von einer anderen Erweiterung bereitgestellt. Calm wirkt dafür in dieser Sitzung möglicherweise nicht vollständig.&#34;,&#10;&#34;type&#34;: &#34;warning&#34;&#10;}&#10;],&#10;&#34;usesGermanPluralWording&#34;: true&#10;}</code>

```text
{
  "notifications": [
    {
      "message": "Firstmate Calm: die eingebauten Werkzeuge \"read\", \"bash\" werden bereits von einer anderen Erweiterung bereitgestellt. Calm wirkt dafür in dieser Sitzung möglicherweise nicht vollständig.",
      "type": "warning"
    }
  ],
  "usesGermanPluralWording": true
}
```
</details>
- Evidence: Bearings empty-fleet digest with German empty-states (local file: <code>/tmp/no-mistakes-evidence/01M0YN1V73BXP7NP37JX0NQ3DB/bearings-empty-states-de.png</code>)
<details>
<summary>Evidence: Bearings empty-states rendered HTML</summary>

```text
<!DOCTYPE html>
<html lang="de"><head><meta charset="utf-8"><title>Bearings empty states (DE)</title>
<style>
  body { font-family: "IBM Plex Sans", "Segoe UI", sans-serif; max-width: 42rem; margin: 2rem auto; padding: 0 1.25rem; line-height: 1.45; color: #1a1a1a; background: linear-gradient(180deg,#f7f3ea,#efe8d8); }
  h1 { font-size: 1.35rem; }
  h2 { margin-top: 1.5rem; font-size: 1.05rem; border-bottom: 1px solid #cfc6b3; padding-bottom: .25rem; }
  p { margin: .4rem 0 0; }
</style></head><body>
<h1>Bearings chat digest — empty fleet (Captain-facing German empty-states)</h1>

<p>Rendered per `.agents/skills/bearings/SKILL.md` section &quot;Sprache (Captain)&quot; / chat-response format.</p>

<h2>Captain&#x27;s Call</h2>

<p>Derzeit brauchst du keine Aktion, Kapitän.</p>

<h2>Recently Landed</h2>

<p>In der aktuellen Baseline gibt es keine frischen Abschlüsse.</p>

<h2>Underway</h2>

<p>Nichts ist unterwegs.</p>

<h2>Charted Next</h2>

<p>Nichts steht in der Warteschlange.</p>
</body></html>
```
</details>
<details>
<summary>Evidence: Bearings empty-states markdown digest</summary>

```text
# Bearings chat digest — empty fleet (Captain-facing German empty-states)

Rendered per `.agents/skills/bearings/SKILL.md` section "Sprache (Captain)" / chat-response format.

## Captain's Call

Derzeit brauchst du keine Aktion, Kapitän.

## Recently Landed

In der aktuellen Baseline gibt es keine frischen Abschlüsse.

## Underway

Nichts ist unterwegs.

## Charted Next

Nichts steht in der Warteschlange.
```
</details>
<details>
<summary>Evidence: Diff scope and German commit metadata</summary>

<code>files_changed:&#10;.agents/skills/bearings/SKILL.md&#10;.pi/extensions/fm-calm.ts&#10;tests/fm-calm-pi-extension.test.sh&#10;&#10;commit_subject:&#10;doc: Bearings und Calm auf Deutsch für den Captain-Chat ausrichten.&#10;&#10;forbidden_trailers:&#10;(none)</code>

```text
files_changed:
.agents/skills/bearings/SKILL.md
.pi/extensions/fm-calm.ts
tests/fm-calm-pi-extension.test.sh

commit_subject:
doc: Bearings und Calm auf Deutsch für den Captain-Chat ausrichten.

forbidden_trailers:
(none)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)
<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"3cca4ce1cae0eb09cf1f7b28ede0a198314ffc10","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"completed"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash tests/fm-calm-pi-extension.test.sh` (focused Calm extension suite; asserts German `/calm` command description)</code>
- <code>Executable Calm probe: load `.pi/extensions/fm-calm.ts`, read `registerCommand(&#39;calm&#39;).description`, activate with foreign `bash` ownership, capture `ui.notify` singular German warning → `/tmp/no-mistakes-evidence/01M0YN1V73BXP7NP37JX0NQ3DB/calm-german-runtime.json`</code>
- <code>Executable Calm probe: same path with foreign `bash`+`read`, capture plural German warning → `/tmp/no-mistakes-evidence/01M0YN1V73BXP7NP37JX0NQ3DB/calm-german-plural-warning.json`</code>
- `Manual Bearings empty-fleet digest render from skill empty-states (DE) → markdown/HTML + Playwright screenshot`
- <code>`git diff --name-only` / commit subject / trailer check for three-file scope and German commit without Co-authored-by/Generated-with</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>



