### PR TITLE
fix(bin): refuse to steer an endpoint whose agent has exited

### DIFF
--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -57,7 +57,13 @@
 # type the literal
 # text through the target backend's verified submit core: typed ONCE, then
 # Enter retried (never retyped) until the backend confirms a submit or reports
-# an inconclusive send. Typed-plane exit contract: 0 = submit confirmed;
+# an inconclusive send. Before ANY of that the endpoint must not be a proven
+# dead one: a task's endpoint outlives the agent inside it, and typing into the
+# login shell an exited agent falls back to would hand the steer to that shell
+# instead of losing it visibly. fm_backend_agent_state (bin/fm-backend.sh) owns
+# that verdict fleet-wide and only its positive `dead` refuses, so an idle,
+# ghost-text, or busy composer is never blocked. Typed-plane exit contract:
+# 0 = submit confirmed;
 # 3 = the text was typed into the live endpoint and
 # Enter was sent, but the submit read-back stayed unconfirmed (verify the pane
 # before any resend, and never re-type blindly; a marked request's
@@ -862,6 +868,27 @@ else
       2) echo "fm-send: doorbell did not reach $T; the steer is durably recorded at $INBOX_RECORD and the watcher will re-ring" >&2 ;;
     esac
     exit 0
+  fi
+  # Refuse a dead endpoint BEFORE typing anything into it.
+  # The typed plane hands its text to whatever owns the terminal, and a task's
+  # endpoint outlives the agent inside it: once the agent exits, the pane falls
+  # back to the login shell that launched it. Typing there hands the steer to
+  # that SHELL, which runs the first token and discards the rest, so the
+  # instruction is gone while the endpoint still looks perfectly alive.
+  # The question "does this endpoint still hold an agent" already has one
+  # fleet-wide owner - fm_backend_agent_state (bin/fm-backend.sh) - so this
+  # consults it instead of adding a second classifier. Only its positive `dead`
+  # verdict refuses: `dead` means the endpoint exists and its foreground process
+  # group is confidently nothing but shells, which no live agent can produce
+  # (an agent running a child process reads `ambiguous`, never `dead`).
+  # `missing`, `ambiguous`, `unreadable`, and `unverified` all proceed exactly as
+  # before, because a false refusal here is as harmful as a false success: every
+  # supervision decision that assumes a steer landed is built on this exit.
+  if [ "$(fm_backend_agent_state "$TARGET_BACKEND" "$T")" = dead ]; then
+    fm_send_known_undelivered_cleanup || \
+      echo "error: known-undelivered pending-reply state could not be reset for $TARGET_TASK_ID" >&2
+    echo "error: text not sent to $T: the agent there is gone and the endpoint is now a bare shell, so nothing was typed (tried $RESOLUTION_TRIED). Relaunch the agent before re-sending; typing into the shell would run the message as a command and lose it." >&2
+    exit 1
   fi
   # Slash commands open a completion popup in some TUIs (verified on codex);
   # submitting too fast selects nothing, so give the popup time to settle before

--- a/docs/verification/runtime-backends.md
+++ b/docs/verification/runtime-backends.md
@@ -623,6 +623,22 @@ ok - real herdr: an agent that does not stop fails closed instead of being repor
 The registry read through `herdr pane report-agent` is the same source `fm_backend_herdr_agent_state` classifies, so registering and not registering an agent on a plain shell pane exercises exactly the gate every lifecycle verb depends on, with no real agent launched.
 That command is the guard that refreshes this record; run it after every Herdr upgrade rather than trusting the version above.
 
+### Steering a dead endpoint
+
+`bin/fm-send.sh`'s typed plane refuses an endpoint `fm_backend_agent_state` classifies `dead`, so that verdict is a delivery guarantee and not only a recovery one.
+Measured 2026-08-26 on Herdr 0.7.4 with Claude Code 2.1.246, in an isolated `fm-lab-` session, by launching claude in a pane, exiting it with `/exit`, and steering the pane in each state.
+
+| Pane state | `herdr agent get <pane>` | `fm_backend_agent_state` | `fm-send.sh <target> "<text>"` |
+| --- | --- | --- | --- |
+| Shell, no agent ever launched | `{"error":{"code":"agent_not_found",...}}` | `dead` | refused, exit 1, nothing typed |
+| Live idle claude | `{"agent":"claude","agent_status":"idle"}` | `alive` | delivered, exit 0 |
+| Claude mid-turn running a child process | `{"agent":"claude","agent_status":"working"}` | `alive` | delivered, exit 0 |
+| Shell after the agent exits | `{"error":{"code":"agent_not_found",...}}` | `dead` | refused, exit 1, nothing typed |
+
+Before the refusal existed, the fourth row typed the message into the login shell, which ran its first token and discarded the rest, leaving `zsh: no matches found: (3 findings: review-1 auto-fix, review-2 and review-3 ask-user).` in the pane and no instruction anywhere.
+`herdr pane process-info` shows why the agent-registry read is trustworthy here rather than a rendered one: an exited pane's foreground process is the pane's own `shell_pid`, while a mid-turn agent's foreground child carries a different pid, so a busy agent can never present as an agent-less pane.
+The portable regressions are `tests/fm-backend-herdr.test.sh` (the four `agent get` shapes) and `tests/fm-send-strict.test.sh` (the refusal, that nothing is typed, and that idle, busy, natively blocked, and unclassifiable endpoints are all still steered).
+
 ### Away-mode transport
 
 The Pi/Herdr return and injection path was reverified on Herdr 0.7.3 and Pi 0.80.7:

--- a/tests/fm-backend-herdr.test.sh
+++ b/tests/fm-backend-herdr.test.sh
@@ -4459,6 +4459,73 @@ test_create_task_refuses_duplicate_label_when_agent_live
 test_create_task_refuses_when_any_duplicate_label_is_live
 test_create_task_closes_and_replaces_dead_pane_husk
 test_create_task_closes_and_replaces_no_agent_husk
+
+# --- agent_state: the endpoint-liveness verdict fm-send steers on -----------
+#
+# bin/fm-send.sh refuses to type into an endpoint fm_backend_agent_state calls
+# `dead`, because a pane whose agent has exited falls back to the login shell
+# that launched it and would run the steer as a command instead of receiving it.
+# That makes these four verdicts a delivery contract, not just a recovery one:
+# `dead` must be reachable for a really-exited agent, and must be unreachable
+# for every registered agent_status a live pane can report - including the
+# `blocked` a Cursor pane reports in EVERY state, which a stricter rule would
+# misread as gone and refuse forever. The shapes below are the real responses
+# captured from herdr 0.7.4: an exited agent leaves the pane present and
+# answers `agent get` with agent_not_found.
+test_agent_state_classifies_an_exited_agent_dead() {
+  local dir log resp fb out
+  dir="$TMP_ROOT/agent-state-dead"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  # 1: pane get - the pane itself is still very much alive
+  # 2: agent get - but nothing is registered in it any more
+  printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/1.out"
+  printf '{"error":{"code":"agent_not_found","message":"agent target w1:p2 not found"}}\n' > "$resp/2.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_agent_state default:w1:p2' "$ROOT" )
+  [ "$out" = dead ] || fail "a present pane whose agent has exited must classify dead, got '$out'"
+  pass "fm_backend_herdr_agent_state: a live pane whose agent has exited classifies dead"
+}
+
+test_agent_state_never_calls_a_registered_agent_dead() {
+  local dir log resp fb out status
+  for status in idle working blocked 'done'; do
+    dir="$TMP_ROOT/agent-state-$status"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+    printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/1.out"
+    printf '{"result":{"agent":{"agent_status":"%s"}}}\n' "$status" > "$resp/2.out"
+    fb=$(make_herdr_fakebin "$dir")
+    out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+      bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_agent_state default:w1:p2' "$ROOT" )
+    [ "$out" = alive ] || fail "a registered agent reporting '$status' must classify alive, got '$out'"
+  done
+  pass "fm_backend_herdr_agent_state: every registered agent_status (idle, working, blocked, done) classifies alive"
+}
+
+test_agent_state_unreadable_reads_never_claim_dead() {
+  local dir log resp fb out
+  # An unparseable agent get is ambiguity, not proof the agent left. Claiming
+  # `dead` here would make fm-send refuse a healthy worker on a bad read.
+  dir="$TMP_ROOT/agent-state-garbage"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '{"result":{"pane":{"pane_id":"w1:p2"}}}\n' > "$resp/1.out"
+  printf 'not json at all\n' > "$resp/2.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_agent_state default:w1:p2' "$ROOT" )
+  [ "$out" = unreadable ] || fail "an unparseable agent read must stay unreadable, got '$out'"
+
+  # A pane that is genuinely gone is `missing`, which is a different fault from
+  # an agent-less pane and must not be folded into the dead-endpoint refusal.
+  dir="$TMP_ROOT/agent-state-gone"; mkdir -p "$dir/responses"; log="$dir/log"; resp="$dir/responses"; : > "$log"
+  printf '{"error":{"code":"pane_not_found","message":"pane w1:p2 not found"}}\n' > "$resp/1.out"
+  fb=$(make_herdr_fakebin "$dir")
+  out=$( PATH="$fb:$PATH" FM_HERDR_LOG="$log" FM_HERDR_RESPONSES="$resp" \
+    bash -c '. "$0/bin/backends/herdr.sh"; fm_backend_herdr_agent_state default:w1:p2' "$ROOT" )
+  [ "$out" = missing ] || fail "a pane that no longer exists must classify missing, got '$out'"
+  pass "fm_backend_herdr_agent_state: unreadable and missing endpoints never masquerade as dead"
+}
+
+test_agent_state_classifies_an_exited_agent_dead
+test_agent_state_never_calls_a_registered_agent_dead
+test_agent_state_unreadable_reads_never_claim_dead
 test_create_task_closes_all_duplicate_husks_after_replacement
 test_create_task_refuses_when_preexisting_husk_tab_remains
 test_create_task_refuses_when_agent_state_ambiguous

--- a/tests/fm-composer-lib.test.sh
+++ b/tests/fm-composer-lib.test.sh
@@ -625,6 +625,32 @@ test_matrix_claude_inside_zellij_ansi_dump
 test_strict_blank_row_divergence
 test_bare_wrap_region_classifies
 test_contiguous_transcript_reanchors_on_live_prompt
+# An exited agent leaves a login-shell prompt whose glyph is NOT leading: the
+# real macOS zsh default is "<user>@<host> <dir> %". Every glyph rule here is
+# leading-anchored, so that row carries no container proof at all and must read
+# `unknown`. This case exists because the classifier is the FIRST place someone
+# will reach for after a steer lands in a dead shell, and reclassifying this row
+# as `empty` to "identify the shell" would hand the away-mode injector a live
+# injection target. The shell-ness of the endpoint is a process fact, owned by
+# fm_backend_agent_state (bin/fm-backend.sh); the screen alone must never claim
+# it. The composer shapes a live agent draws are pinned beside it, because a
+# refusal built on this verdict would be as harmful as the swallow it prevents.
+test_exited_agent_shell_prompt_row_is_unknown() {
+  local prompt idle ghost busy
+  prompt=$'transcript from the finished turn\n\nkhyle@host scratchpad % '
+  assert_screen "macOS zsh prompt after /exit on herdr" unknown "$CAPS_STYLED" "$prompt"
+  assert_screen "macOS zsh prompt after /exit on zellij" unknown "$CAPS_STYLED_NOID" "$prompt"
+  assert_screen "macOS zsh prompt after /exit on cmux/orca" unknown "$CAPS_PLAIN" "$prompt"
+
+  idle=$'transcript\n╭────────╮\n│        │\n╰────────╯'
+  assert_screen "idle bordered composer stays empty" empty "$CAPS_STYLED" "$idle"
+  ghost=$'transcript\n\n  ❯ \033[2mTry "fix the bug"\033[0m'
+  assert_screen "ghost-text composer stays empty" empty "$CAPS_STYLED" "$(printf '%b' "$ghost")"
+  busy=$'transcript\n╭────────╮\n│ hello  │\n╰────────╯'
+  assert_screen "composer holding real text stays pending" pending "$CAPS_STYLED" "$busy"
+  pass "fm_composer_classify_screen: an exited agent's shell prompt row reads unknown while live composer shapes keep their verdicts"
+}
+test_exited_agent_shell_prompt_row_is_unknown
 test_lower_dead_shell_invalidates_cursorless_candidate
 test_cursorless_bare_wrap_region_classifies
 test_cursorless_container_rejects_contiguous_lower_activity

--- a/tests/fm-send-strict.test.sh
+++ b/tests/fm-send-strict.test.sh
@@ -74,7 +74,19 @@ case "${1:-} ${2:-}" in
   "status --json") printf '{"client":{"version":"0.7.5","protocol":16},"server":{"running":true}}\n' ;;
   "pane get") printf '{"result":{"pane":{"pane_id":"%s"}}}\n' "${3:-}" ;;
   "pane send-keys") : ;;
+  # FM_FAKE_HERDR_AGENT drives the pane's registered agent: "absent" is the
+  # agent_not_found real herdr returns once the agent has exited to a shell,
+  # any other non-empty value is that live agent_status, and leaving it unset
+  # keeps the historical silent response every pre-existing case relies on.
+  "agent get")
+    case "${FM_FAKE_HERDR_AGENT:-}" in
+      "") : ;;
+      absent) printf '{"error":{"code":"agent_not_found","message":"agent target %s not found"}}\n' "${3:-}" ;;
+      *) printf '{"result":{"agent":{"agent_status":"%s"}}}\n' "$FM_FAKE_HERDR_AGENT" ;;
+    esac ;;
+  "pane read") printf '%s' "${FM_FAKE_HERDR_COMPOSER:-}" ;;
 esac
+exit 0
 SH
   chmod +x "$fb/herdr"
   cat > "$fb/sleep" <<'SH'
@@ -231,8 +243,85 @@ test_key_send_exit_status_follows_delivery() {
   pass "fm-send --key: exit status follows delivery, and an undelivered key never reports success"
 }
 
+# --- the typed plane must not hand a steer to a dead endpoint's shell --------
+#
+# A task's endpoint outlives the agent inside it: when the agent exits, the pane
+# falls back to the login shell that launched it and stays perfectly alive. The
+# typed plane used to type straight into that shell, which ran the first token
+# and discarded the rest - observed live on herdr as
+# `zsh: no matches found: (3 findings: ...)` - so the instruction was gone while
+# the send reported nothing a supervisor could act on. The message below carries
+# the same shell-metacharacter shape on purpose.
+#
+# The refusal is deliberately narrow. It fires only on fm_backend_agent_state's
+# positive `dead`, so the cases underneath it pin the other direction just as
+# hard: an idle agent, a busy agent, a natively `blocked` one (Cursor reads
+# blocked in every state), and an endpoint whose agent cannot be classified at
+# all must every one of them still be typed into exactly as before. A false
+# refusal here is as harmful as the swallow it prevents, because every
+# supervision decision that assumes a steer landed is built on this exit status.
+DEAD_SHELL_MESSAGE='please decide the pipeline gate (3 findings: review-1 auto-fix, review-2 and review-3 ask-user).'
+# A bare claude composer glyph: an empty agent composer, so a send that is
+# allowed through reaches its confirmed-delivery verdict.
+IDLE_COMPOSER=$(printf 'transcript\n\n  \xe2\x9d\xaf ')
+
+test_dead_endpoint_refuses_and_types_nothing() {
+  local dir fb home err herdr_log rc
+  dir="$TMP_ROOT/dead-agent"; mkdir -p "$dir"
+  fb=$(make_stubs "$dir"); home=$(setup_home deadagent); err="$dir/send.err"
+  herdr_log="$dir/herdr.log"; : > "$herdr_log"
+
+  PATH="$fb:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$home" FM_HERDR_LOG="$herdr_log" \
+    FM_TMUX_LOG="$dir/tmux.log" FM_SEND_SETTLE=0 FM_FAKE_HERDR_AGENT=absent \
+    "$SEND" default:w1:p2 "$DEAD_SHELL_MESSAGE" >/dev/null 2>"$err"; rc=$?
+  [ "$rc" -ne 0 ] || fail "a steer typed into a dead endpoint's shell reported success"
+  assert_contains "$(cat "$err")" "the agent there is gone" \
+    "the refusal should say the agent is gone, not that delivery was merely unconfirmed"
+  assert_contains "$(cat "$err")" "nothing was typed" "the refusal should state that nothing was sent"
+  assert_not_contains "$(cat "$herdr_log")" "pane send-text" \
+    "the dead endpoint was still typed into"$'\n'"$(cat "$herdr_log")"
+  assert_not_contains "$(cat "$herdr_log")" "pane send-keys" \
+    "the dead endpoint still received a submit key"$'\n'"$(cat "$herdr_log")"
+  # Non-vacuousness: the same stub, same target, same message DOES type when the
+  # pane still holds an agent, so the assertions above cannot pass by accident.
+  : > "$herdr_log"
+  PATH="$fb:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$home" FM_HERDR_LOG="$herdr_log" \
+    FM_TMUX_LOG="$dir/tmux.log" FM_SEND_SETTLE=0 FM_FAKE_HERDR_AGENT=idle \
+    FM_FAKE_HERDR_COMPOSER="$IDLE_COMPOSER" \
+    "$SEND" default:w1:p2 "$DEAD_SHELL_MESSAGE" >/dev/null 2>"$err"; rc=$?
+  expect_code 0 "$rc" "the identical send to a live agent must still succeed"
+  assert_contains "$(cat "$herdr_log")" "pane send-text" \
+    "the live-agent control case never typed, so the dead-endpoint case proves nothing"
+  pass "fm-send typed plane: a dead endpoint is refused with nothing typed, while the same send to a live agent still lands"
+}
+
+test_live_agent_states_are_never_refused() {
+  local dir fb home err herdr_log rc state
+  dir="$TMP_ROOT/live-agent"; mkdir -p "$dir"
+  fb=$(make_stubs "$dir"); home=$(setup_home liveagent); err="$dir/send.err"
+  herdr_log="$dir/herdr.log"
+  # idle: an ordinary waiting composer. working: a busy agent mid-turn. blocked:
+  # a natively always-blocked pane (Cursor). unset: an endpoint whose agent the
+  # backend cannot classify at all, which must fail open, never closed.
+  for state in idle working blocked ''; do
+    : > "$herdr_log"
+    PATH="$fb:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$home" FM_HERDR_LOG="$herdr_log" \
+      FM_TMUX_LOG="$dir/tmux.log" FM_SEND_SETTLE=0 FM_FAKE_HERDR_AGENT="$state" \
+      FM_FAKE_HERDR_COMPOSER="$IDLE_COMPOSER" \
+      "$SEND" default:w1:p2 "$DEAD_SHELL_MESSAGE" >/dev/null 2>"$err"; rc=$?
+    expect_code 0 "$rc" "agent_status '${state:-<unclassifiable>}' must still be steered"
+    assert_contains "$(cat "$herdr_log")" "pane send-text" \
+      "agent_status '${state:-<unclassifiable>}' was not typed into"
+    assert_not_contains "$(cat "$err")" "the agent there is gone" \
+      "agent_status '${state:-<unclassifiable>}' was wrongly refused as a dead endpoint"
+  done
+  pass "fm-send typed plane: idle, busy, natively blocked, and unclassifiable endpoints are all still steered"
+}
+
 test_exact_lane_id_send_still_works
 test_key_send_exit_status_follows_delivery
+test_dead_endpoint_refuses_and_types_nothing
+test_live_agent_states_are_never_refused
 test_unset_fm_home_fails
 test_unresolvable_target_does_not_tmux_fallback
 test_prefixless_herdr_pane_id_fails


### PR DESCRIPTION
## The fault

A terminal endpoint outlives the agent inside it. When an agent exits, its pane
does not close: it falls back to the login shell that launched it, and every
presence check still reports a perfectly healthy endpoint.

`bin/fm-send.sh`'s typed plane went on typing the steer into that shell. zsh ran
the first token and choked on the rest, leaving this in the pane and the
instruction nowhere:

```
zsh: no matches found: (3 findings: review-1 auto-fix, review-2 and review-3 ask-user).
```

The send did fail, but only as `delivery unconfirmed; verdict=unknown`, which
reads as "it may well have landed" rather than "the agent is gone". Worse, the
text had already been handed to the shell and executed before that verdict was
computed, because the submit core types first and inspects afterwards.

## Reproduction

On Herdr 0.7.4 with Claude Code 2.1.246, in an isolated `fm-lab-` session:

1. Create a workspace, launch `claude` in its pane, and let it reach an idle
   composer.
2. `/exit` the agent, so the pane falls back to a bare zsh prompt.
3. `bin/fm-send.sh <session>:<pane> 'please decide the pipeline gate (3 findings:
   review-1 auto-fix, review-2 and review-3 ask-user).'`

Before this change the pane showed the message echoed at the shell prompt
followed by the `zsh: no matches found:` line above. After it, the pane shows
only its prompt and the send is refused.

## Which of the two possible root causes it actually is

Two candidates were on the table, and they need opposite fixes, so this was
settled with measurements rather than reasoning.

**The composer classifier is correct.** `fm_composer_classify_screen` returns
`unknown` for a dead shell, exactly as `bin/fm-composer-lib.sh` documents.
Verified both against the live pane and directly against the classifier: the
real macOS default zsh prompt (`user@host dir %`) carries no container proof at
all, since every glyph rule is leading-anchored, so it cannot be mistaken for an
empty composer. Reclassifying it would have been the wrong fix, and would have
handed the away-mode injector a live injection target.

**The send path consulted no liveness signal before typing.** That is the whole
defect. Note also that `unknown` could not have carried the refusal even if it
were consulted here: a live, idle Claude pane on this Herdr version *also*
classified `unknown`, so refusing on `unknown` would have blocked healthy
workers.

The signal that does answer the question already exists and already has one
fleet-wide owner: `fm_backend_agent_state` (`bin/fm-backend.sh`), which prints
`alive` / `dead` / `missing` / `ambiguous` / `unreadable` / `unverified`. Its
`dead` means the endpoint exists and its foreground process group is confidently
nothing but shells. Measured across four pane states:

| Pane state | `herdr agent get` | `fm_backend_agent_state` |
| --- | --- | --- |
| Shell, no agent ever launched | `agent_not_found` | `dead` |
| Live idle claude | `agent_status: idle` | `alive` |
| Claude mid-turn running a child process | `agent_status: working` | `alive` |
| Shell after the agent exits | `agent_not_found` | `dead` |

`herdr pane process-info` shows why this is trustworthy rather than a rendering
guess: an agent-less pane's foreground process *is* the pane's own `shell_pid`,
while a mid-turn agent's foreground child carries a different pid. A busy agent
can therefore never present as an agent-less pane.

## The change

`bin/fm-send.sh`'s typed plane now consults `fm_backend_agent_state` before
typing anything, and refuses a `dead` endpoint: non-zero exit, an error that
says the agent is gone and that nothing was typed, and no keystrokes sent.

The refusal is deliberately narrow, because a false refusal is as harmful as a
false success here - every supervision decision that assumes a steer landed is
built on this exit status. Only the positive `dead` verdict refuses. `missing`,
`ambiguous`, `unreadable`, and `unverified` all proceed exactly as before.

No second classifier was added. The backend classifiers, the composer classifier,
and the submit cores are untouched; the send path simply asks the owner that
already answers this question.

The durable-inbox plane is intentionally left alone. There the recorded message
*is* the delivery, so a swallowed doorbell loses nothing and the existing
re-ring ladder owns recovery. Only the typed plane can lose a steer this way.

## What the regression tests now cover

`tests/fm-send-strict.test.sh`
- A dead endpoint is refused, the error names the gone agent, and the backend log
  contains no `pane send-text` and no `pane send-keys` - nothing was typed.
- The same send, same stub, same target lands normally when the pane still holds
  an agent, so the assertions above cannot pass vacuously.
- Idle, busy (`working`), natively `blocked` (a Cursor pane reads blocked in
  every state), and endpoints whose agent cannot be classified at all are every
  one of them still steered, exit 0, text typed.

`tests/fm-backend-herdr.test.sh`
- A present pane whose `agent get` answers `agent_not_found` classifies `dead`.
- Every registered `agent_status` - idle, working, blocked, done - classifies
  `alive`.
- An unparseable read stays `unreadable` and a vanished pane stays `missing`;
  neither masquerades as `dead`.

`tests/fm-composer-lib.test.sh`
- An exited agent's real shell prompt row reads `unknown`, pinning the
  classifier against being "fixed" in the wrong direction, with an idle bordered
  composer, a ghost/placeholder composer, and a composer holding real text
  asserted alongside it to keep their existing verdicts.

`docs/verification/runtime-backends.md` records the dated live measurement and
points at both portable regressions as the commands that refresh it.

## Validation

- `bin/fm-lint.sh` clean (ShellCheck 0.11.0, actionlint 1.7.12).
- `tests/fm-send-strict.test.sh`, `tests/fm-send-inbox.test.sh`,
  `tests/fm-send-settle.test.sh`, `tests/fm-send-popup-settle.test.sh`,
  `tests/fm-send-resolve-key.test.sh`, `tests/fm-send-secondmate-marker.test.sh`,
  `tests/fm-send-remote-delivery.test.sh`, `tests/fm-backend-herdr.test.sh` (184
  cases), `tests/fm-composer-ghost.test.sh`, `tests/fm-control.test.sh`,
  `tests/fm-backend-tmux-smoke.test.sh`, and
  `tests/fm-documentation-audiences.test.sh` all pass.
- `tests/fm-composer-lib.test.sh` passes apart from one pre-existing case,
  `test_matrix_herdr_halfblock_rule_bounds_bare_wrap`, which fails identically on
  an unmodified checkout here because it uses `$'▀'` and this machine's
  `bash` is 3.2 (the escape needs 4.2). `tests/fm-backend.test.sh` likewise has
  one pre-existing unrelated failure on an unmodified checkout. Both were
  confirmed against a clean tree; neither is touched by this change.
