### PR TITLE
feat(brief): let firstmate declare a project's checks dormant

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -517,7 +517,7 @@ Keep additions task-specific rather than repeating lifecycle instructions, and a
 Every ship brief must retain the worktree-isolation assertion and stop if launched in the primary checkout.
 If a ship task touches firstmate's shared tracked material, explicitly require `firstmate-coding-guidelines` before editing.
 If a task will drive Herdr lifecycle behavior, scaffold with `--herdr-lab`; if that need appears after an unguarded scaffold, stop and regenerate rather than adding commands by hand.
-The generated Herdr contract must use a named non-`default` isolated lab and its guarded helper for every lifecycle action.
+If the project's automated checks cannot currently run, scaffold with `--checks-dormant <why>`: the worker follows the pipeline's own waiting step, so only the regenerated instruction stops it waiting for a result that cannot arrive.
 
 Load `secondmate-provisioning` before creating or using a charter brief and preserve its idle-by-default and marked-return-channel contracts.
 Status appends are sparse supervisor-actionable events, not routine progress; `bin/fm-classify-lib.sh` owns keyed open and resolved semantics.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -364,7 +364,7 @@ The worker reports the PR when CI first becomes green rather than waiting for me
 
 ### PR ready, landing, and teardown
 
-For PR-based ship tasks, the ready signal depends on mode: `no-mistakes` reports `done: PR <url> checks green` after CI is green, while `direct-PR` reports `done: PR <url>` after opening the PR.
+For PR-based ship tasks, the ready signal depends on mode: `no-mistakes` reports `done: PR <url> checks green` after CI is green, `direct-PR` reports `done: PR <url>` after opening the PR, and a task briefed with `--checks-dormant` reports `done: PR <url> - automated checks did not run, verified locally` in either mode - equally ready, so arm the PR check as usual.
 Run `bin/fm-pr-check.sh <id> <PR url>` - it records `pr=` and the forge's `pr_head=` when available in the task's meta and arms the watcher's merge poll.
 Tell the captain the PR's full URL, always the complete `https://...` link rather than a bare `#number`, a concise outcome summary, and the no-mistakes risk level when applicable.
 A captain instruction to merge is explicit authority; `yolo` is the only standing routine merge authority.

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -418,8 +418,8 @@ CHECKS_DORMANT_SECTION=""
 if [ -n "$CHECKS_DORMANT" ]; then
   if [ "$MODE" = no-mistakes ]; then
     DORMANT_WAIT="Never wait for, poll, or re-run checks at any point, including when the pipeline reaches its own CI step: that step is what does the waiting, and you are the one who must not sit on it."
-    DORMANT_STEP="If the pipeline can finish or move on without check results, let it; if it can only sit waiting for them, leave it there and complete the two obligations below."
-    DORMANT_PR_WRITE="The pipeline's generated description knows none of this, so add it yourself with \`gh-axi\` once the run is no longer active."
+    DORMANT_STEP="Your finish line is the pipeline having done everything it can: once it has pushed and the PR exists, you are at it and the two obligations below are all that remain. Its CI step may still be sitting on check results then - that is expected here, not a reason to wait, and not something you have to end."
+    DORMANT_PR_WRITE="The pipeline's generated description knows none of this, so add it yourself with \`gh-axi\` as soon as the PR exists; writing a PR description is not hand-editing code or fixing findings, so an active run is no reason to hold it back."
     DORMANT_INTENT=$'\n'"Carry this dormancy statement into your \`--intent\` as well, so the pipeline is not left inferring that a missing check is a defect in your change."
   else
     DORMANT_WAIT="Never wait for, poll, or re-run checks after you push."
@@ -492,7 +492,7 @@ EOF
       IFS= read -r -d '' DOD_TAIL <<EOF || true
 $CHECKS_DORMANT_SECTION
 
-When the PR exists and its description carries that statement, append \`done: PR {url} - automated checks did not run, verified locally\` to the status file and stop. You are finished.
+Once the pipeline has pushed, the PR exists, and its description carries that statement, append \`done: PR {url} - automated checks did not run, verified locally\` to the status file and stop. You are finished, whether or not the run is still sitting on its CI step.
 EOF
     else
       IFS= read -r -d '' DOD_TAIL <<'EOF' || true

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -6,7 +6,8 @@
 # description, acceptance criteria, and context, and may adjust other sections
 # when the task genuinely deviates (e.g. working an existing external PR instead
 # of shipping a new one).
-# Usage: fm-brief.sh <task-id> <repo-name> --mode <no-mistakes|direct-PR|local-only> [--herdr-lab]
+# Usage: fm-brief.sh <task-id> <repo-name> --mode <no-mistakes|direct-PR|local-only>
+#          [--checks-dormant <why>] [--herdr-lab]
 #        fm-brief.sh <task-id> <repo-name> --scout [--herdr-lab]
 #        fm-brief.sh <task-id> --secondmate {<project>...|--no-projects}
 #   --scout writes the scout contract instead: the deliverable is a report at
@@ -43,6 +44,17 @@
 # Ship briefs begin with a worktree-isolation assertion before the branch step.
 # --mode is refused on scout and secondmate scaffolds: a scout's deliverable is a
 # report rather than a merge, and a charter is not a delivery contract.
+# --checks-dormant <why> is firstmate's declaration that this project's automated
+# checks cannot currently run, and <why> is the one-line reason (for example
+# "GitHub Actions minutes exhausted until 1 September"). This script never probes
+# for that condition: firstmate knows it, and a wrong automatic answer would tell
+# a worker to skip real checks on a healthy project. The declaration replaces the
+# generated finish line - which otherwise ends at a check result the worker would
+# wait forever for - with the action to take instead: stop waiting, verify
+# locally, and state in the PR that the checks did not run and what replaced them.
+# It applies only to a ship task that publishes a PR, so scout, secondmate, and
+# local-only scaffolds refuse it rather than accept a declaration that changes
+# nothing.
 # There is no --yolo flag here. The worker never owns merge decisions, so yolo is
 # a spawn-time and firstmate-side input only (AGENTS.md section 7).
 # Every scaffold's status protocol distinguishes the configured
@@ -109,6 +121,8 @@ HERDR_LAB=0
 NO_PROJECTS=0
 MODE=
 MODE_SET=0
+CHECKS_DORMANT=
+CHECKS_DORMANT_SET=0
 POS=()
 want_value=
 for a in "$@"; do
@@ -118,6 +132,7 @@ for a in "$@"; do
     esac
     case "$want_value" in
       mode) MODE=$a; MODE_SET=1 ;;
+      checks-dormant) CHECKS_DORMANT=$a; CHECKS_DORMANT_SET=1 ;;
       *) echo "error: internal parser state for --$want_value" >&2; exit 1 ;;
     esac
     want_value=
@@ -130,6 +145,8 @@ for a in "$@"; do
     --no-projects) NO_PROJECTS=1 ;;
     --mode) want_value=mode ;;
     --mode=*) MODE=${a#--mode=}; MODE_SET=1 ;;
+    --checks-dormant) want_value=checks-dormant ;;
+    --checks-dormant=*) CHECKS_DORMANT=${a#--checks-dormant=}; CHECKS_DORMANT_SET=1 ;;
     # yolo never reaches the worker: it is firstmate's merge authority, not a
     # brief input. Refuse it loudly so it is never silently dropped here and then
     # believed to have been recorded.
@@ -156,6 +173,29 @@ if [ "$KIND" = ship ]; then
 elif [ "$MODE_SET" -eq 1 ]; then
   echo "error: --mode applies only to ship briefs; a scout delivers a report and a secondmate charter is not a delivery contract" >&2
   exit 1
+fi
+
+# A dormant-checks declaration only has somewhere to land on a ship task that
+# publishes a PR: it rewrites the check-shaped finish line and requires the PR to
+# say the checks did not run. Anywhere else it would be accepted and silently
+# change nothing, which is exactly the failure this flag exists to prevent.
+if [ "$CHECKS_DORMANT_SET" -eq 1 ]; then
+  if [ "$KIND" != ship ]; then
+    echo "error: --checks-dormant applies only to ship briefs; a scout raises no PR and a secondmate charter is not a delivery contract" >&2
+    exit 1
+  fi
+  if [ "$MODE" = local-only ]; then
+    echo "error: --checks-dormant does not apply to local-only, which never pushes and so never waits on checks" >&2
+    exit 1
+  fi
+  case "$CHECKS_DORMANT" in
+    '')
+      echo "error: --checks-dormant requires the one-line reason the checks cannot run, e.g. --checks-dormant 'GitHub Actions minutes exhausted until 1 September'" >&2
+      exit 1 ;;
+    *$'\n'*)
+      echo "error: --checks-dormant takes a single line; give the reason in one sentence" >&2
+      exit 1 ;;
+  esac
 fi
 ID=${POS[0]}
 
@@ -370,6 +410,43 @@ echo "scaffolded: $BRIEF (scout; replace {TASK})"
 exit 0
 fi
 
+# A declared dormant-checks state is composed into the delivery mode's own
+# finish line rather than added as one more warning sentence: the pipeline, not
+# the worker's reading, is what drives waiting on a check result, so only
+# replacing the instruction changes what the worker does.
+CHECKS_DORMANT_SECTION=""
+if [ -n "$CHECKS_DORMANT" ]; then
+  if [ "$MODE" = no-mistakes ]; then
+    DORMANT_WAIT="Never wait for, poll, or re-run checks at any point, including when the pipeline reaches its own CI step: that step is what does the waiting, and you are the one who must not sit on it."
+    DORMANT_STEP="If the pipeline can finish or move on without check results, let it; if it can only sit waiting for them, leave it there and complete the two obligations below."
+    DORMANT_PR_WRITE="The pipeline's generated description knows none of this, so add it yourself with \`gh-axi\` once the run is no longer active."
+    DORMANT_INTENT=$'\n'"Carry this dormancy statement into your \`--intent\` as well, so the pipeline is not left inferring that a missing check is a defect in your change."
+  else
+    DORMANT_WAIT="Never wait for, poll, or re-run checks after you push."
+    DORMANT_STEP="There is nothing to watch once the PR is up; complete the two obligations below and report."
+    DORMANT_PR_WRITE="Write that statement into the PR description yourself when you open the PR."
+    DORMANT_INTENT=""
+  fi
+  IFS= read -r -d '' CHECKS_DORMANT_SECTION <<EOF || true
+## Automated checks are dormant on this project
+Firstmate has established that this project's automated checks cannot run: $CHECKS_DORMANT.
+Runs may still be created and then die within seconds with no runner, no logs, and no steps; that is the dormancy, not a flake worth retrying.
+Take this as given: do not verify it, investigate the checks, or try to make them run.
+
+Your finish line here is NOT a green check, because no green can arrive.
+$DORMANT_WAIT
+This is not a declared external wait either, so never park on it with \`$PAUSED_VERB:\`: waiting delivers nothing.
+$DORMANT_STEP
+
+Local evidence is what replaces the checks, and a dormant check is never permission to ship unverified work.
+Run this project's own tests, lint, and build yourself, record the exact commands and their results, and fix a local failure before you report done.
+The PR description MUST state plainly, in its own section, that the automated checks did NOT run, why, which commands you ran in their place, and their results.
+$DORMANT_PR_WRITE
+A PR that quietly omits it is not done.$DORMANT_INTENT
+EOF
+  CHECKS_DORMANT_SECTION=${CHECKS_DORMANT_SECTION%$'\n'}
+fi
+
 # Ship task: shape Setup / Rule 1 / Definition of done by this task's explicit
 # delivery mode, validated above. The generated DOD opens with the fixed
 # "Delivery contract: mode=<mode>" line that bin/fm-spawn.sh checks against its own
@@ -378,13 +455,20 @@ case "$MODE" in
   direct-PR)
     SETUP2=""
     RULE1='1. Never push to the default branch (push only your `fm/'"$ID"'` branch). Never merge a PR.'
+    if [ -n "$CHECKS_DORMANT" ]; then
+      DIRECT_DONE='done: PR {url} - automated checks did not run, verified locally'
+      DORMANT_APPENDIX=$'\n\n'"$CHECKS_DORMANT_SECTION"
+    else
+      DIRECT_DONE='done: PR {url}'
+      DORMANT_APPENDIX=""
+    fi
     IFS= read -r -d '' DOD <<EOF || true
 # Definition of done
 Delivery contract: mode=direct-PR
 This task ships **direct-PR**: you raise the PR yourself, without the no-mistakes pipeline.
 The task is complete only when committed on your branch.
-When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`done: PR {url}\` to the status file and stop.
-Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.
+When it is implemented and committed, push your branch and open a PR with \`gh-axi\`, then append \`$DIRECT_DONE\` to the status file and stop.
+Do NOT run /no-mistakes. The configured merge authority decides whether to merge the PR; firstmate relays the outcome.$DORMANT_APPENDIX
 EOF
     ;;
   local-only)
@@ -404,6 +488,18 @@ EOF
     SETUP2="
 2. Run \`no-mistakes doctor\`; if it reports the repo is not initialized here, run \`no-mistakes init\`."
     RULE1='1. Never push to the default branch. Never merge a PR.'
+    if [ -n "$CHECKS_DORMANT" ]; then
+      IFS= read -r -d '' DOD_TAIL <<EOF || true
+$CHECKS_DORMANT_SECTION
+
+When the PR exists and its description carries that statement, append \`done: PR {url} - automated checks did not run, verified locally\` to the status file and stop. You are finished.
+EOF
+    else
+      IFS= read -r -d '' DOD_TAIL <<'EOF' || true
+After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
+EOF
+    fi
+    DOD_TAIL=${DOD_TAIL%$'\n'}
     IFS= read -r -d '' DOD <<EOF || true
 # Definition of done
 Delivery contract: mode=no-mistakes
@@ -422,7 +518,7 @@ Two firstmate-specific rules layer on top of that guidance:
   When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
 - Avoid \`--yes\`: it would silently bypass firstmate's authority check and any required captain escalation.
 
-After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished.
+$DOD_TAIL
 EOF
     ;;
 esac

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -778,6 +778,19 @@ test_dormant_checks_replace_the_check_shaped_finish_line() {
     "dormant brief re-gated the finish line on the pipeline run going inactive"
   assert_grep "whether or not the run is still sitting on its CI step" "$brief" \
     "dormant brief did not free the done report from the run's own state"
+
+  # The forbidden park verb is the configured declared-external-wait verb, not a
+  # hardcoded "paused": a home that renames it would otherwise be told to avoid a
+  # verb it does not use while the one it does use stays open as an idle trap.
+  FM_HOME="$home" FM_CLASSIFY_PAUSED_VERB=awaiting "$ROOT/bin/fm-brief.sh" \
+    brief-dormant-verb some-proj --mode no-mistakes --checks-dormant 'runner minutes exhausted' >/dev/null 2>&1 \
+    || fail "dormant brief should scaffold under a renamed pause verb"
+  brief="$home/data/brief-dormant-verb/brief.md"
+  assert_grep "never park on it with \`awaiting:\`" "$brief" \
+    "dormant brief did not forbid parking with the configured pause verb"
+  # shellcheck disable=SC2016 # the default verb must not survive the override
+  assert_no_grep 'park on it with `paused:`' "$brief" \
+    "dormant brief hardcoded the default pause verb"
   pass "fm-brief.sh: a dormant-checks declaration replaces the check-shaped finish line"
 }
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -770,6 +770,14 @@ test_dormant_checks_replace_the_check_shaped_finish_line() {
     "dormant brief did not give the worker a reachable finish line"
   assert_grep "never park on it with \`paused:\`" "$brief" \
     "dormant brief let the worker park on the dormancy as a self-clearing external wait"
+  # The replacement finish line must itself be reachable: no-mistakes' ci step
+  # stays running for the whole CI-monitor phase on a captain-merge repo, so a
+  # done gate that waits for the run to end or go inactive is the same unbounded
+  # wait one level up.
+  assert_no_grep "no longer active" "$brief" \
+    "dormant brief re-gated the finish line on the pipeline run going inactive"
+  assert_grep "whether or not the run is still sitting on its CI step" "$brief" \
+    "dormant brief did not free the done report from the run's own state"
   pass "fm-brief.sh: a dormant-checks declaration replaces the check-shaped finish line"
 }
 
@@ -797,7 +805,7 @@ test_dormant_checks_require_local_evidence_and_pr_disclosure() {
   done
 
   # Only the pipeline-driven mode carries the pipeline-specific instructions.
-  assert_grep "add it yourself with \`gh-axi\` once the run is no longer active" \
+  assert_grep "add it yourself with \`gh-axi\` as soon as the PR exists" \
     "$home/data/brief-dormant-say-no-mistakes/brief.md" \
     "no-mistakes dormant brief must say how the disclosure reaches a pipeline-generated PR description"
   assert_grep "Carry this dormancy statement into your \`--intent\`" \

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -747,6 +747,128 @@ test_scout_and_secondmate_scaffold() {
   pass "fm-brief: scout and secondmate code paths still scaffold well-formed briefs"
 }
 
+# The dormant-checks declaration must change what the worker DOES, not merely
+# restate a fact. The regression this guards: a brief that carried "CI cannot
+# run" as prose while the pipeline still drove the worker into an unbounded
+# wait for a check result that could never arrive.
+test_dormant_checks_replace_the_check_shaped_finish_line() {
+  local home brief
+  home="$TMP_ROOT/dormant-home"
+  mkdir -p "$home/data"
+
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-dormant-nm some-proj \
+    --mode no-mistakes --checks-dormant 'GitHub Actions minutes exhausted until 1 September' >/dev/null 2>&1 \
+    || fail "no-mistakes brief with a dormant-checks declaration should scaffold"
+  brief="$home/data/brief-dormant-nm/brief.md"
+  assert_grep "cannot run: GitHub Actions minutes exhausted until 1 September" "$brief" \
+    "dormant brief lost firstmate's declared reason"
+  assert_grep "Never wait for, poll, or re-run checks at any point, including when the pipeline reaches its own CI step" "$brief" \
+    "dormant no-mistakes brief did not tell the worker to stop waiting on the pipeline's CI step"
+  assert_no_grep "After /no-mistakes reports CI green" "$brief" \
+    "dormant brief kept the check-shaped finish line the worker would wait forever for"
+  assert_grep "done: PR {url} - automated checks did not run, verified locally" "$brief" \
+    "dormant brief did not give the worker a reachable finish line"
+  assert_grep "never park on it with \`paused:\`" "$brief" \
+    "dormant brief let the worker park on the dormancy as a self-clearing external wait"
+  pass "fm-brief.sh: a dormant-checks declaration replaces the check-shaped finish line"
+}
+
+# The counterweight: skipping checks is only safe if the PR says so. A brief that
+# stops the waiting without demanding that disclosure would trade an unbounded
+# wait for a PR that looks verified and is not.
+test_dormant_checks_require_local_evidence_and_pr_disclosure() {
+  local home brief mode id
+  home="$TMP_ROOT/dormant-disclosure-home"
+  mkdir -p "$home/data"
+  for mode in no-mistakes direct-PR; do
+    id="brief-dormant-say-${mode}"
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj \
+      --mode "$mode" --checks-dormant 'runner minutes exhausted' >/dev/null 2>&1 \
+      || fail "$mode: dormant brief should scaffold"
+    brief="$home/data/$id/brief.md"
+    assert_grep "The PR description MUST state plainly, in its own section, that the automated checks did NOT run, why, which commands you ran in their place, and their results." "$brief" \
+      "$mode: dormant brief did not require the PR to say the checks did not run and what replaced them"
+    assert_grep "A PR that quietly omits it is not done." "$brief" \
+      "$mode: dormant brief left the PR disclosure optional"
+    assert_grep "a dormant check is never permission to ship unverified work" "$brief" \
+      "$mode: dormant brief lost the counterweight against shipping unverified work"
+    assert_grep "Run this project's own tests, lint, and build yourself, record the exact commands and their results" "$brief" \
+      "$mode: dormant brief did not require local evidence in place of the checks"
+  done
+
+  # Only the pipeline-driven mode carries the pipeline-specific instructions.
+  assert_grep "add it yourself with \`gh-axi\` once the run is no longer active" \
+    "$home/data/brief-dormant-say-no-mistakes/brief.md" \
+    "no-mistakes dormant brief must say how the disclosure reaches a pipeline-generated PR description"
+  assert_grep "Carry this dormancy statement into your \`--intent\`" \
+    "$home/data/brief-dormant-say-no-mistakes/brief.md" \
+    "no-mistakes dormant brief must carry the dormancy into the pipeline's intent"
+  assert_no_grep "the pipeline reaches its own CI step" \
+    "$home/data/brief-dormant-say-direct-PR/brief.md" \
+    "direct-PR dormant brief must not reference a pipeline it never runs"
+  assert_grep "done: PR {url} - automated checks did not run, verified locally" \
+    "$home/data/brief-dormant-say-direct-PR/brief.md" \
+    "direct-PR dormant brief did not carry the dormancy into its done report"
+  pass "fm-brief.sh: dormant briefs demand local evidence and an explicit PR disclosure"
+}
+
+# Without the declaration nothing changes: the ordinary briefs must keep their
+# check-shaped finish line and carry no dormancy wording at all.
+test_briefs_without_the_dormant_declaration_are_unchanged() {
+  local home brief mode id
+  home="$TMP_ROOT/plain-brief-home"
+  mkdir -p "$home/data"
+  for mode in no-mistakes direct-PR local-only; do
+    id="brief-plain-${mode}"
+    FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode "$mode" >/dev/null 2>&1 \
+      || fail "$mode: plain brief should scaffold"
+    brief="$home/data/$id/brief.md"
+    assert_no_grep "dormant" "$brief" "$mode: plain brief leaked dormant-checks wording"
+    assert_no_grep "automated checks did not run" "$brief" \
+      "$mode: plain brief leaked the dormant done report"
+  done
+  assert_grep "After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append \`done: PR {url} checks green\` and stop. You are finished." \
+    "$home/data/brief-plain-no-mistakes/brief.md" \
+    "plain no-mistakes brief lost its CI-green finish line"
+  # shellcheck disable=SC2016  # single quotes are deliberate: the backticks must stay literal
+  assert_grep 'append `done: PR {url}` to the status file and stop' \
+    "$home/data/brief-plain-direct-PR/brief.md" \
+    "plain direct-PR brief lost its unqualified done report"
+  pass "fm-brief.sh: briefs without the declaration keep their ordinary finish lines"
+}
+
+# firstmate declares dormancy; the scaffold never infers it. A declaration with
+# nowhere to land, or with no reason, must refuse rather than be accepted and
+# generate nothing - a silently dropped declaration is the same failure again.
+test_dormant_checks_declaration_is_refused_where_it_cannot_land() {
+  local home out status label args expect
+  home="$TMP_ROOT/dormant-refused-home"
+  mkdir -p "$home/data"
+  while IFS='|' read -r label args expect; do
+    [ -n "$label" ] || continue
+    # shellcheck disable=SC2086  # args is an intentional word-split arg list
+    out=$(FM_HOME="$home" "$ROOT/bin/fm-brief.sh" $args 2>&1)
+    status=$?
+    [ "$status" -ne 0 ] || fail "$label: expected a non-zero exit"
+    assert_contains "$out" "$expect" "$label: refusal did not explain why"
+  done <<'ROWS'
+scout brief|brief-dormant-r1 some-proj --scout --checks-dormant reason|--checks-dormant applies only to ship briefs
+secondmate charter|brief-dormant-r2 --secondmate --no-projects --checks-dormant reason|--checks-dormant applies only to ship briefs
+local-only ship|brief-dormant-r3 some-proj --mode local-only --checks-dormant reason|--checks-dormant does not apply to local-only
+missing reason|brief-dormant-r4 some-proj --mode no-mistakes --checks-dormant|requires a value
+empty reason|brief-dormant-r5 some-proj --mode no-mistakes --checks-dormant=|requires the one-line reason
+ROWS
+
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-dormant-r6 some-proj --mode no-mistakes \
+    --checks-dormant 'minutes exhausted
+until 1 September' 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "multi-line reason: expected a non-zero exit"
+  assert_contains "$out" "takes a single line" "multi-line reason: refusal did not explain the contract"
+  assert_absent "$home/data/brief-dormant-r6/brief.md" "multi-line reason: refused scaffold still wrote a brief"
+  pass "fm-brief.sh: a dormant-checks declaration that cannot land is refused, never dropped"
+}
+
 test_script_parses
 test_no_heredoc_in_command_substitution
 test_help_includes_entire_header
@@ -768,3 +890,7 @@ test_secondmate_directory_paths_are_absolute_and_output_is_stable
 test_pause_verb_override_renders_all_brief_scaffolds
 test_scout_and_secondmate_load_decision_hold_policy
 test_scout_and_secondmate_scaffold
+test_dormant_checks_replace_the_check_shaped_finish_line
+test_dormant_checks_require_local_evidence_and_pr_disclosure
+test_briefs_without_the_dormant_declaration_are_unchanged
+test_dormant_checks_declaration_is_refused_where_it_cannot_land


### PR DESCRIPTION
## Problem

When a project's automated checks cannot run — for example GitHub Actions with no minutes left — jobs are still created and then die within seconds with no runner, no logs, and no steps. The validation pipeline's CI step then waits for a green that can never arrive, and the worker waits with it.

Stating the fact in the brief does not fix this. In the case that prompted the change, the generated brief already carried "CI cannot run — minutes exhausted", and the worker still waited: the pipeline drives the polling, not the worker's reading. Only replacing the instruction changes what the worker does.

## Change

`bin/fm-brief.sh` gains `--checks-dormant <why>` on the ship scaffold. It is a declaration by firstmate, not a detection: the script never probes for the condition, calls GitHub, or reads billing. A wrong automatic answer would be worse than the problem, since it would tell a worker to skip real checks on a healthy project.

When declared, the generated brief replaces the check-shaped finish line with the action to take instead:

- stop waiting — do not poll, re-run, or park on the pipeline's CI step;
- verify locally — run the project's own tests, lint, and build, and record the exact commands and results;
- disclose — the PR description must state in its own section that the automated checks did not run, why, which commands were run in their place, and their results.

The wording composes into each delivery mode's own finish line rather than being appended as another warning. The done signal becomes `done: PR <url> - automated checks did not run, verified locally`.

Skipping checks is dangerous, so the disclosure is not optional in the generated wording: a PR that quietly omits it is not done.

## Scope

The flag is refused where it would be accepted and silently change nothing — scout briefs, secondmate charters, and `local-only`, which never pushes. An empty or multi-line reason is refused rather than dropped.

`AGENTS.md` gains one pointer to the flag and the updated ready signal, paid for by pruning a line that the scaffold itself already enforces, so the file stays within its size ceiling.

## Verification

`tests/fm-brief.test.sh` — 25 tests pass, including four new ones covering the replaced finish line, the demanded local evidence and PR disclosure, the unchanged output when the declaration is absent, and the refusals above.
