### PR TITLE
fix(bin): name the stale submodule pin behind a pooled slot refusal

### DIFF
--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -138,6 +138,9 @@
 #   origin, resolves the current remote default branch, and resets to its tip.
 #   An unreachable origin, unresolved default branch, or non-clean worktree
 #   refuses the spawn rather than risking a PR based on stale history.
+#   A slot whose only deviation is a stale submodule gitlink is refused by that
+#   same clean check, but is reported as a stale checkout naming each submodule,
+#   both pins, and the command that clears it; nothing is converged or removed.
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
@@ -1742,6 +1745,31 @@ validate_spawn_worktree() {  # <source> <inspect-target>
   fi
 }
 
+# A pooled slot whose only deviation is a submodule gitlink is stale, not dirty:
+# an earlier refresh moved the superproject and left the submodule checkout on
+# the pin the previous base recorded. The refusal still stands and this gate
+# never touches the slot; it only names the cause, because "is not clean" while
+# the operator's own `git status` reads clean gives neither a cause nor a remedy.
+# Returns 1 unless EVERY reported entry is exactly that, so a submodule holding
+# real work is still reported as uncommitted work and never called stale.
+describe_stale_submodule_pins() {  # <worktree> <status>
+  local worktree=$1 status=$2 line path want have found=0
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    case $line in ' M '*) path=${line#' M '} ;; *) return 1 ;; esac
+    [ "$(git -C "$worktree" ls-files --stage -- "$path" 2>/dev/null | cut -c1-6)" = 160000 ] || return 1
+    [ -z "$(git -C "$worktree/$path" status --porcelain 2>/dev/null)" ] || return 1
+    want=$(git -C "$worktree" rev-parse --verify --quiet "HEAD:$path" 2>/dev/null) || return 1
+    have=$(git -C "$worktree/$path" rev-parse --verify --quiet HEAD 2>/dev/null) || return 1
+    [ "$want" != "$have" ] || return 1
+    echo "error: submodule '$path' is checked out at $have, but this base records $want" >&2
+    found=1
+  done <<EOF
+$status
+EOF
+  [ "$found" = 1 ]
+}
+
 freshen_spawn_worktree_base() {  # <worktree>
   local worktree=$1 default target expected actual status
   if ! git -C "$worktree" fetch --quiet origin; then
@@ -1765,12 +1793,17 @@ freshen_spawn_worktree_base() {  # <worktree>
     echo "error: '$target' is not a commit for pooled worktree '$worktree'; refusing to launch from a potentially stale base" >&2
     return 1
   }
-  status=$(git -C "$worktree" status --porcelain) || {
+  status=$(git -C "$worktree" -c core.quotePath=false status --porcelain) || {
     echo "error: could not inspect pooled worktree '$worktree' before refreshing its base" >&2
     return 1
   }
   if [ -n "$status" ]; then
-    echo "error: pooled worktree '$worktree' is not clean; refusing to discard uncommitted work while refreshing its base" >&2
+    if describe_stale_submodule_pins "$worktree" "$status"; then
+      echo "error: pooled worktree '$worktree' has a stale submodule checkout, not uncommitted work; refusing to launch and leaving it untouched" >&2
+      echo "error: clear it with: git -C '$worktree' submodule update --checkout" >&2
+    else
+      echo "error: pooled worktree '$worktree' is not clean; refusing to discard uncommitted work while refreshing its base" >&2
+    fi
     return 1
   fi
   if ! git -C "$worktree" reset --hard "$target" >/dev/null; then

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -1782,7 +1782,7 @@ describe_stale_submodule_pins() {  # <worktree> <status>
     want=$(git -C "$worktree" rev-parse --verify --quiet "HEAD:$path" 2>/dev/null) || return 1
     have=$(git -C "$worktree/$path" rev-parse --verify --quiet HEAD 2>/dev/null) || return 1
     [ "$want" != "$have" ] || return 1
-    unpushed=$(git -C "$worktree/$path" log --format=%H "$have" --not --remotes -- 2>/dev/null) || return 1
+    unpushed=$(git -C "$worktree/$path" log --format=%H --max-count=1 "$have" --not --remotes -- 2>/dev/null) || return 1
     [ -z "$unpushed" ] || return 1
     lines+="error: submodule '$path' is checked out at $have, but this base records $want"$'\n'
   done <<EOF

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -139,11 +139,14 @@
 #   An unreachable origin, unresolved default branch, or non-clean worktree
 #   refuses the spawn rather than risking a PR based on stale history.
 #   A slot whose only deviation is a stale submodule gitlink is refused by that
-#   same clean check, but is reported as a stale checkout naming each submodule,
-#   both pins, and the command that clears it; nothing is converged or removed.
+#   same clean check, but is reported as a stale checkout naming each submodule
+#   and both pins; nothing is converged or removed, and no remedy is suggested.
 #   That report is only reached when each submodule's checked-out commit is
 #   already contained in one of its remotes, so a submodule carrying an unpushed
-#   commit keeps the conservative uncommitted-work refusal instead.
+#   commit keeps the conservative uncommitted-work refusal instead. That
+#   containment test reads local refs only and never fetches, so this gate stays
+#   usable offline; a stale remote-tracking ref can therefore make an unpushed
+#   commit look contained, which is exactly why no remedy command is printed.
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
@@ -1753,13 +1756,22 @@ validate_spawn_worktree() {  # <source> <inspect-target>
 # the pin the previous base recorded. The refusal still stands and this gate
 # never touches the slot; it only names the cause, because "is not clean" while
 # the operator's own `git status` reads clean gives neither a cause nor a remedy.
-# A pin is only stale when the commit the slot holds is already contained in one
-# of the submodule's remotes, so the `submodule update --checkout` this refusal
-# prints can never orphan unlanded work. Anything that cannot be proven contained
-# - an unpushed commit, a submodule with no remote, a git error - falls through to
-# the conservative uncommitted-work refusal, as does any entry that is not exactly
-# a clean submodule sitting on a different pin. The diagnosis is buffered and only
-# emitted once every entry qualifies, so it can never contradict the verdict.
+# A pin is only reported as stale when the commit the slot holds is already
+# contained in one of the submodule's remotes. Anything that cannot be proven
+# contained - an unpushed commit, a submodule with no remote, a git error - falls
+# through to the conservative uncommitted-work refusal, as does any entry that is
+# not exactly a clean submodule sitting on a different pin. The diagnosis is
+# buffered and only emitted once every entry qualifies, so it can never
+# contradict the verdict.
+#
+# No remedy command is printed, deliberately. That containment check reads local
+# refs only and never fetches, because this gate has to stay usable offline. A
+# remote-tracking ref that has gone stale - its upstream branch deleted or
+# force-pushed, and never pruned - therefore still reads as containment, so a
+# commit that is really unpushed can look contained. Naming the submodule and both
+# pins is what the operator actually needs; printing a checkout command on a
+# judgement that can be fooled could cost them that commit, so the remedy is left
+# to the operator, who can see the whole picture.
 describe_stale_submodule_pins() {  # <worktree> <status>
   local worktree=$1 status=$2 line path want have unpushed lines=
   while IFS= read -r line; do
@@ -1810,7 +1822,6 @@ freshen_spawn_worktree_base() {  # <worktree>
   if [ -n "$status" ]; then
     if describe_stale_submodule_pins "$worktree" "$status"; then
       echo "error: pooled worktree '$worktree' has a stale submodule checkout, not uncommitted work; refusing to launch and leaving it untouched" >&2
-      echo "error: clear it with: git -C '$worktree' submodule update --checkout" >&2
     else
       echo "error: pooled worktree '$worktree' is not clean; refusing to discard uncommitted work while refreshing its base" >&2
     fi

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -141,6 +141,9 @@
 #   A slot whose only deviation is a stale submodule gitlink is refused by that
 #   same clean check, but is reported as a stale checkout naming each submodule,
 #   both pins, and the command that clears it; nothing is converged or removed.
+#   That report is only reached when each submodule's checked-out commit is
+#   already contained in one of its remotes, so a submodule carrying an unpushed
+#   commit keeps the conservative uncommitted-work refusal instead.
 # Batch dispatch: pass one or more `id=repo` pairs instead of a single <id> <project>, e.g.
 #     fm-spawn.sh fix-a-k3=projects/foo add-b-q7=projects/bar [--scout]
 #   Each pair re-execs this script in single-task mode, so the single path stays the only
@@ -1750,10 +1753,15 @@ validate_spawn_worktree() {  # <source> <inspect-target>
 # the pin the previous base recorded. The refusal still stands and this gate
 # never touches the slot; it only names the cause, because "is not clean" while
 # the operator's own `git status` reads clean gives neither a cause nor a remedy.
-# Returns 1 unless EVERY reported entry is exactly that, so a submodule holding
-# real work is still reported as uncommitted work and never called stale.
+# A pin is only stale when the commit the slot holds is already contained in one
+# of the submodule's remotes, so the `submodule update --checkout` this refusal
+# prints can never orphan unlanded work. Anything that cannot be proven contained
+# - an unpushed commit, a submodule with no remote, a git error - falls through to
+# the conservative uncommitted-work refusal, as does any entry that is not exactly
+# a clean submodule sitting on a different pin. The diagnosis is buffered and only
+# emitted once every entry qualifies, so it can never contradict the verdict.
 describe_stale_submodule_pins() {  # <worktree> <status>
-  local worktree=$1 status=$2 line path want have found=0
+  local worktree=$1 status=$2 line path want have unpushed lines=
   while IFS= read -r line; do
     [ -n "$line" ] || continue
     case $line in ' M '*) path=${line#' M '} ;; *) return 1 ;; esac
@@ -1762,12 +1770,14 @@ describe_stale_submodule_pins() {  # <worktree> <status>
     want=$(git -C "$worktree" rev-parse --verify --quiet "HEAD:$path" 2>/dev/null) || return 1
     have=$(git -C "$worktree/$path" rev-parse --verify --quiet HEAD 2>/dev/null) || return 1
     [ "$want" != "$have" ] || return 1
-    echo "error: submodule '$path' is checked out at $have, but this base records $want" >&2
-    found=1
+    unpushed=$(git -C "$worktree/$path" log --format=%H "$have" --not --remotes -- 2>/dev/null) || return 1
+    [ -z "$unpushed" ] || return 1
+    lines+="error: submodule '$path' is checked out at $have, but this base records $want"$'\n'
   done <<EOF
 $status
 EOF
-  [ "$found" = 1 ]
+  [ -n "$lines" ] || return 1
+  printf '%s' "$lines" >&2
 }
 
 freshen_spawn_worktree_base() {  # <worktree>

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -322,7 +322,11 @@ test_stale_submodule_pin_explains_itself() {
   assert_contains "$out" "submodule 'ui'" "refusal did not name the submodule"
   assert_contains "$out" "$SUBPIN1" "refusal did not report the pin the slot actually has"
   assert_contains "$out" "$SUBPIN2" "refusal did not report the pin the base records"
-  assert_contains "$out" "submodule update --checkout" "refusal did not print the command that clears it"
+  # No remedy is printed on purpose: the containment check reads local refs only,
+  # so a stale remote-tracking ref can make an unpushed commit look contained, and
+  # a checkout command on that judgement could cost the operator a commit.
+  assert_not_contains "$out" "submodule update --checkout" \
+    "refusal printed a remedy command the containment check cannot stand behind"
   assert_not_contains "$out" "refusing to discard uncommitted work" \
     "a stale pin was misreported as uncommitted work"
   [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$before" ] \
@@ -332,7 +336,7 @@ test_stale_submodule_pin_explains_itself() {
   if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
     printf '# observed stale-pin refusal: %s\n' "$(printf '%s\n' "$out" | grep 'submodule' | head -n 1)"
   fi
-  pass "two consecutive spawns across a moved submodule pin end in a refusal naming both pins and the remedy"
+  pass "two consecutive spawns across a moved submodule pin end in a refusal naming both pins and no remedy"
 }
 
 test_unpushed_submodule_commit_is_still_uncommitted_work() {
@@ -342,9 +346,9 @@ test_unpushed_submodule_commit_is_still_uncommitted_work() {
   read_submodule_case "$rec"
   strand_submodule_pin_via_spawn 'pool-sub-unpushed-seed-r10'
   # A commit made inside the submodule and never pushed leaves the submodule work
-  # tree clean and the pins different - the same two facts a stale pin shows. The
-  # printed `submodule update --checkout` would move HEAD off this commit and
-  # orphan it, so this case must keep the conservative refusal.
+  # tree clean and the pins different - the same two facts a stale pin shows. Any
+  # checkout of the recorded pin would move HEAD off this commit and leave it
+  # unreferenced, so this case must keep the conservative refusal.
   printf 'unlanded submodule work\n' > "$POOL_DIR/ui/unlanded.txt"
   git -C "$POOL_DIR/ui" add unlanded.txt
   git -C "$POOL_DIR/ui" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' \
@@ -406,7 +410,7 @@ test_stale_pin_carrying_real_work_is_not_called_stale() {
   rec=$(make_submodule_case sub-both "$id")
   read_submodule_case "$rec"
   strand_submodule_pin_via_spawn 'pool-sub-both-seed-r9'
-  # Stale pin AND real work inside it: the remedy command would be wrong here, so
+  # Stale pin AND real work inside it: calling this merely stale would be wrong, so
   # the refusal must stay the conservative one.
   printf 'work that must survive\n' > "$POOL_DIR/ui/keep-me.txt"
 

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -228,9 +228,11 @@ test_unresolved_remote_default_refuses_pool() {
 }
 
 # A slot left on a stale submodule pin is the field failure this diagnosis exists
-# for: the previous refresh moved the superproject and left the submodule behind,
-# so the refusal fires a spawn later, on a slot whose own `git status` looks clean
-# to the operator. Nothing here is converged - the gate only has to say why.
+# for: a refresh moved the superproject and left the submodule behind, so the
+# refusal fires a spawn later, on a slot whose own `git status` looks clean to the
+# operator. Nothing here is converged - the gate only has to say why. The fixture
+# only builds the repositories; the residue itself is produced by a real spawn, so
+# these tests cover the reset that actually strands the submodule.
 make_submodule_case() {  # <name> <id>
   local name=$1 id=$2 case_dir home project origin pool publisher fakebin sub subpin1 subpin2 advanced
   case_dir="$TMP_ROOT/$name"
@@ -276,17 +278,31 @@ make_submodule_case() {  # <name> <id>
   git -C "$publisher" push --quiet origin main
   advanced=$(git -C "$publisher" rev-parse HEAD)
 
-  # Reproduce the residue a previous spawn left: superproject moved, submodule not.
-  git -C "$pool" fetch --quiet origin
-  git -C "$pool" reset --hard --quiet "$advanced" >/dev/null
-
-  printf '%s\n' "$case_dir|$home|$project|$pool|$fakebin|$subpin1|$subpin2"
+  printf '%s\n' "$case_dir|$home|$project|$pool|$fakebin|$subpin1|$subpin2|$advanced"
 }
 
 read_submodule_case() {
-  IFS='|' read -r CASE_DIR HOME_DIR PROJECT_DIR POOL_DIR FAKEBIN_DIR SUBPIN1 SUBPIN2 <<EOF
+  IFS='|' read -r CASE_DIR HOME_DIR PROJECT_DIR POOL_DIR FAKEBIN_DIR SUBPIN1 SUBPIN2 ADVANCED_SHA <<EOF
 $1
 EOF
+}
+
+# The first of two consecutive spawns: it succeeds, resets the superproject onto
+# the base that moved the pin, and leaves the submodule checkout on the pin the
+# old base recorded. That reset is what strands the slot, so every case below
+# starts from residue this code path actually produced rather than a hand-built one.
+strand_submodule_pin_via_spawn() {  # <seed-id>
+  local id=$1 out status
+  mkdir -p "$HOME_DIR/data/$id"
+  printf 'brief for %s\n' "$id" > "$HOME_DIR/data/$id/brief.md"
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off)
+  status=$?
+  expect_code 0 "$status" "the spawn that moves the submodule pin should succeed"
+  assert_contains "$out" "spawned $id" "the spawn that moves the submodule pin did not report success"
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$ADVANCED_SHA" ] \
+    || fail "the first spawn did not move the pooled base across the moved submodule pin"
+  [ "$(git -C "$POOL_DIR/ui" rev-parse HEAD)" = "$SUBPIN1" ] \
+    || fail "the first spawn did not strand the submodule on the pin the old base recorded"
 }
 
 test_stale_submodule_pin_explains_itself() {
@@ -294,13 +310,13 @@ test_stale_submodule_pin_explains_itself() {
   id='pool-stale-pin-r7'
   rec=$(make_submodule_case stale-pin "$id")
   read_submodule_case "$rec"
+  strand_submodule_pin_via_spawn 'pool-stale-pin-seed-r7'
   before=$(git -C "$POOL_DIR" rev-parse HEAD)
   before_sub=$(git -C "$POOL_DIR/ui" rev-parse HEAD)
-  [ "$before_sub" = "$SUBPIN1" ] || fail "fixture did not leave the submodule on the old pin"
 
   out=$(run_spawn "$id" --mode no-mistakes --yolo off)
   status=$?
-  [ "$status" -ne 0 ] || fail "spawn launched from a slot carrying a stale submodule pin"
+  [ "$status" -ne 0 ] || fail "the second spawn launched from a slot carrying a stale submodule pin"
   assert_contains "$out" "stale submodule checkout" \
     "refusal did not name the cause as a stale submodule checkout"
   assert_contains "$out" "submodule 'ui'" "refusal did not name the submodule"
@@ -316,7 +332,49 @@ test_stale_submodule_pin_explains_itself() {
   if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
     printf '# observed stale-pin refusal: %s\n' "$(printf '%s\n' "$out" | grep 'submodule' | head -n 1)"
   fi
-  pass "a stale submodule pin is refused with the submodule, both pins, and the remedy named"
+  pass "two consecutive spawns across a moved submodule pin end in a refusal naming both pins and the remedy"
+}
+
+test_unpushed_submodule_commit_is_still_uncommitted_work() {
+  local rec id out status unpushed before before_sub
+  id='pool-sub-unpushed-r10'
+  rec=$(make_submodule_case sub-unpushed "$id")
+  read_submodule_case "$rec"
+  strand_submodule_pin_via_spawn 'pool-sub-unpushed-seed-r10'
+  # A commit made inside the submodule and never pushed leaves the submodule work
+  # tree clean and the pins different - the same two facts a stale pin shows. The
+  # printed `submodule update --checkout` would move HEAD off this commit and
+  # orphan it, so this case must keep the conservative refusal.
+  printf 'unlanded submodule work\n' > "$POOL_DIR/ui/unlanded.txt"
+  git -C "$POOL_DIR/ui" add unlanded.txt
+  git -C "$POOL_DIR/ui" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' \
+    commit -qm unlanded-submodule-work
+  unpushed=$(git -C "$POOL_DIR/ui" rev-parse HEAD)
+  [ -z "$(git -C "$POOL_DIR/ui" status --porcelain)" ] \
+    || fail "fixture did not leave the submodule work tree clean"
+  [ "$unpushed" != "$(git -C "$POOL_DIR" rev-parse "HEAD:ui")" ] \
+    || fail "fixture did not leave the recorded pin different from what is checked out"
+  before=$(git -C "$POOL_DIR" rev-parse HEAD)
+  before_sub=$unpushed
+
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn launched from a slot holding an unpushed submodule commit"
+  assert_contains "$out" "refusing to discard uncommitted work" \
+    "an unpushed submodule commit was not refused as uncommitted work"
+  assert_not_contains "$out" "stale submodule checkout" \
+    "an unpushed submodule commit was misreported as a stale pin"
+  assert_not_contains "$out" "is checked out at" \
+    "an unpushed submodule commit still drew the stale-pin diagnosis"
+  [ "$(git -C "$POOL_DIR/ui" rev-parse HEAD)" = "$before_sub" ] \
+    || fail "spawn moved the submodule off its unpushed commit"
+  git -C "$POOL_DIR/ui" cat-file -e "$unpushed^{commit}" \
+    || fail "the unpushed submodule commit did not survive the refusal"
+  assert_grep 'unlanded submodule work' "$POOL_DIR/ui/unlanded.txt" \
+    "spawn discarded the unpushed submodule work while refusing the pool"
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$before" ] \
+    || fail "spawn moved HEAD while refusing a slot holding an unpushed submodule commit"
+  pass "an unpushed submodule commit keeps the uncommitted-work refusal and survives it"
 }
 
 test_work_inside_submodule_is_still_uncommitted_work() {
@@ -324,6 +382,7 @@ test_work_inside_submodule_is_still_uncommitted_work() {
   id='pool-sub-work-r8'
   rec=$(make_submodule_case sub-work "$id")
   read_submodule_case "$rec"
+  strand_submodule_pin_via_spawn 'pool-sub-work-seed-r8'
   # Put the submodule back on the pin the base records, so the ONLY deviation is
   # real work inside it. This must never be softened into a stale-pin diagnosis.
   git -C "$POOL_DIR/ui" checkout --quiet "$SUBPIN2"
@@ -346,6 +405,7 @@ test_stale_pin_carrying_real_work_is_not_called_stale() {
   id='pool-sub-both-r9'
   rec=$(make_submodule_case sub-both "$id")
   read_submodule_case "$rec"
+  strand_submodule_pin_via_spawn 'pool-sub-both-seed-r9'
   # Stale pin AND real work inside it: the remedy command would be wrong here, so
   # the refusal must stay the conservative one.
   printf 'work that must survive\n' > "$POOL_DIR/ui/keep-me.txt"
@@ -362,6 +422,30 @@ test_stale_pin_carrying_real_work_is_not_called_stale() {
   pass "a stale pin carrying real work is refused conservatively, never called stale"
 }
 
+test_stale_pin_beside_other_dirt_reports_one_verdict() {
+  local rec id out status
+  id='pool-sub-mixed-r11'
+  rec=$(make_submodule_case sub-mixed "$id")
+  read_submodule_case "$rec"
+  strand_submodule_pin_via_spawn 'pool-sub-mixed-seed-r11'
+  # Git sorts status paths, so the stale 'ui' entry is scanned before this file.
+  # The conservative verdict must not arrive contradicted by a stale-pin line.
+  printf 'notes the operator still wants\n' > "$POOL_DIR/zz-notes.txt"
+
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn launched from a slot with a stale pin beside an untracked file"
+  assert_contains "$out" "refusing to discard uncommitted work" \
+    "a stale pin beside an untracked file was not refused as uncommitted work"
+  assert_not_contains "$out" "stale submodule checkout" \
+    "a slot carrying more than a stale pin was reported as merely stale"
+  assert_not_contains "$out" "is checked out at" \
+    "the stale-pin diagnosis was printed alongside the conservative refusal"
+  assert_grep 'notes the operator still wants' "$POOL_DIR/zz-notes.txt" \
+    "spawn discarded the untracked file while refusing the pool"
+  pass "a stale pin beside other dirt yields the conservative refusal alone, with no stale-pin line"
+}
+
 test_stale_pool_base_refreshes_before_branching
 test_non_main_default_branch_refreshes_before_branching
 test_direct_pr_and_scout_refresh_before_launch
@@ -369,7 +453,9 @@ test_dirty_pool_refuses_without_discarding_work
 test_unresolved_remote_default_refuses_pool
 test_unreachable_origin_refuses_stale_pool_base
 test_stale_submodule_pin_explains_itself
+test_unpushed_submodule_commit_is_still_uncommitted_work
 test_work_inside_submodule_is_still_uncommitted_work
 test_stale_pin_carrying_real_work_is_not_called_stale
+test_stale_pin_beside_other_dirt_reports_one_verdict
 
 echo "# all fm-spawn-pool-base-freshen tests passed"

--- a/tests/fm-spawn-pool-base-freshen.test.sh
+++ b/tests/fm-spawn-pool-base-freshen.test.sh
@@ -227,11 +227,149 @@ test_unresolved_remote_default_refuses_pool() {
   pass "an unresolved remote default branch refuses the pooled worktree"
 }
 
+# A slot left on a stale submodule pin is the field failure this diagnosis exists
+# for: the previous refresh moved the superproject and left the submodule behind,
+# so the refusal fires a spawn later, on a slot whose own `git status` looks clean
+# to the operator. Nothing here is converged - the gate only has to say why.
+make_submodule_case() {  # <name> <id>
+  local name=$1 id=$2 case_dir home project origin pool publisher fakebin sub subpin1 subpin2 advanced
+  case_dir="$TMP_ROOT/$name"
+  home="$case_dir/home"
+  project="$case_dir/project"
+  origin="$case_dir/origin.git"
+  pool="$case_dir/pool"
+  publisher="$case_dir/publisher"
+  sub="$case_dir/sub-origin"
+  fakebin=$(make_spawn_fakebin "$case_dir/fake")
+
+  mkdir -p "$home/data/$id" "$home/projects" "$home/state" "$home/config"
+  printf 'codex\n' > "$home/config/crew-harness"
+  printf 'brief for %s\n' "$id" > "$home/data/$id/brief.md"
+  touch "$home/state/.last-watcher-beat"
+
+  git init --quiet -b main "$sub"
+  printf 'pin one\n' > "$sub/lib.txt"
+  git -C "$sub" add lib.txt
+  git -C "$sub" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm sub-one
+  subpin1=$(git -C "$sub" rev-parse HEAD)
+  printf 'pin two\n' > "$sub/lib.txt"
+  git -C "$sub" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qam sub-two
+  subpin2=$(git -C "$sub" rev-parse HEAD)
+  git -C "$sub" checkout --quiet "$subpin1"
+
+  git init --quiet -b main "$project"
+  printf 'base\n' > "$project/README.md"
+  git -C "$project" add README.md
+  git -C "$project" -c protocol.file.allow=always -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' \
+    submodule --quiet add "file://$sub" ui
+  git -C "$project" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qm initial
+  git clone --quiet --bare "$project" "$origin"
+  git -C "$project" remote add origin "file://$origin"
+  git -C "$project" worktree add --quiet --detach "$pool" HEAD
+  git -C "$pool" -c protocol.file.allow=always submodule --quiet update --init
+
+  # Advance origin and move the submodule pin, exactly as the field incident did.
+  git clone --quiet "file://$origin" "$publisher"
+  git -C "$publisher" -c protocol.file.allow=always submodule --quiet update --init
+  git -C "$publisher/ui" checkout --quiet "$subpin2"
+  git -C "$publisher" -c user.name='Firstmate Tests' -c user.email='tests@example.invalid' commit -qam advance-pin
+  git -C "$publisher" push --quiet origin main
+  advanced=$(git -C "$publisher" rev-parse HEAD)
+
+  # Reproduce the residue a previous spawn left: superproject moved, submodule not.
+  git -C "$pool" fetch --quiet origin
+  git -C "$pool" reset --hard --quiet "$advanced" >/dev/null
+
+  printf '%s\n' "$case_dir|$home|$project|$pool|$fakebin|$subpin1|$subpin2"
+}
+
+read_submodule_case() {
+  IFS='|' read -r CASE_DIR HOME_DIR PROJECT_DIR POOL_DIR FAKEBIN_DIR SUBPIN1 SUBPIN2 <<EOF
+$1
+EOF
+}
+
+test_stale_submodule_pin_explains_itself() {
+  local rec id out status before before_sub
+  id='pool-stale-pin-r7'
+  rec=$(make_submodule_case stale-pin "$id")
+  read_submodule_case "$rec"
+  before=$(git -C "$POOL_DIR" rev-parse HEAD)
+  before_sub=$(git -C "$POOL_DIR/ui" rev-parse HEAD)
+  [ "$before_sub" = "$SUBPIN1" ] || fail "fixture did not leave the submodule on the old pin"
+
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn launched from a slot carrying a stale submodule pin"
+  assert_contains "$out" "stale submodule checkout" \
+    "refusal did not name the cause as a stale submodule checkout"
+  assert_contains "$out" "submodule 'ui'" "refusal did not name the submodule"
+  assert_contains "$out" "$SUBPIN1" "refusal did not report the pin the slot actually has"
+  assert_contains "$out" "$SUBPIN2" "refusal did not report the pin the base records"
+  assert_contains "$out" "submodule update --checkout" "refusal did not print the command that clears it"
+  assert_not_contains "$out" "refusing to discard uncommitted work" \
+    "a stale pin was misreported as uncommitted work"
+  [ "$(git -C "$POOL_DIR" rev-parse HEAD)" = "$before" ] \
+    || fail "spawn moved HEAD while refusing a stale submodule pin"
+  [ "$(git -C "$POOL_DIR/ui" rev-parse HEAD)" = "$before_sub" ] \
+    || fail "spawn converged the submodule; this gate must never touch the slot"
+  if [ "${FM_TEST_EVIDENCE:-0}" = 1 ]; then
+    printf '# observed stale-pin refusal: %s\n' "$(printf '%s\n' "$out" | grep 'submodule' | head -n 1)"
+  fi
+  pass "a stale submodule pin is refused with the submodule, both pins, and the remedy named"
+}
+
+test_work_inside_submodule_is_still_uncommitted_work() {
+  local rec id out status
+  id='pool-sub-work-r8'
+  rec=$(make_submodule_case sub-work "$id")
+  read_submodule_case "$rec"
+  # Put the submodule back on the pin the base records, so the ONLY deviation is
+  # real work inside it. This must never be softened into a stale-pin diagnosis.
+  git -C "$POOL_DIR/ui" checkout --quiet "$SUBPIN2"
+  printf 'work that must survive\n' > "$POOL_DIR/ui/keep-me.txt"
+
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn launched from a slot holding work inside a submodule"
+  assert_contains "$out" "refusing to discard uncommitted work" \
+    "work inside a submodule was not refused as uncommitted work"
+  assert_not_contains "$out" "stale submodule checkout" \
+    "real work inside a submodule was misreported as a stale pin"
+  assert_grep 'work that must survive' "$POOL_DIR/ui/keep-me.txt" \
+    "spawn discarded work inside the submodule while refusing the pool"
+  pass "work inside a submodule is still refused as uncommitted work, not called stale"
+}
+
+test_stale_pin_carrying_real_work_is_not_called_stale() {
+  local rec id out status
+  id='pool-sub-both-r9'
+  rec=$(make_submodule_case sub-both "$id")
+  read_submodule_case "$rec"
+  # Stale pin AND real work inside it: the remedy command would be wrong here, so
+  # the refusal must stay the conservative one.
+  printf 'work that must survive\n' > "$POOL_DIR/ui/keep-me.txt"
+
+  out=$(run_spawn "$id" --mode no-mistakes --yolo off)
+  status=$?
+  [ "$status" -ne 0 ] || fail "spawn launched from a slot with a stale pin and work inside it"
+  assert_contains "$out" "refusing to discard uncommitted work" \
+    "a stale pin carrying real work was not refused as uncommitted work"
+  assert_not_contains "$out" "stale submodule checkout" \
+    "a submodule holding real work was reported as merely stale"
+  assert_grep 'work that must survive' "$POOL_DIR/ui/keep-me.txt" \
+    "spawn discarded work inside the submodule while refusing the pool"
+  pass "a stale pin carrying real work is refused conservatively, never called stale"
+}
+
 test_stale_pool_base_refreshes_before_branching
 test_non_main_default_branch_refreshes_before_branching
 test_direct_pr_and_scout_refresh_before_launch
 test_dirty_pool_refuses_without_discarding_work
 test_unresolved_remote_default_refuses_pool
 test_unreachable_origin_refuses_stale_pool_base
+test_stale_submodule_pin_explains_itself
+test_work_inside_submodule_is_still_uncommitted_work
+test_stale_pin_carrying_real_work_is_not_called_stale
 
 echo "# all fm-spawn-pool-base-freshen tests passed"


### PR DESCRIPTION
## Intent

Fix a bug in firstmate's bin/fm-spawn.sh pool-slot refresh path: when a pooled worktree's base is reset to the new default-branch head, submodules are never synced, so the superproject moves while the submodule stays pinned to the old commit, leaving " M <submodule>" residue that makes the NEXT spawn refuse the slot as possibly holding unpushed work. Observed in the field on 2026-08-24 when the inscada `ui` pin moved and three pooled slots jammed in a row; cleared by hand, but it recurs every time the pin moves. The refusal always lands one spawn late: the spawn that creates the residue succeeds and the following task pays for it.

Measured root cause: the refresh path checks cleanliness with `git status --porcelain` BEFORE the reset, then runs `git reset --hard origin/<default>`, and never syncs submodules.

The goal is that a pooled slot stays clean after its base is refreshed and its submodule pin matches that base, so the residue never forms - explicitly WITHOUT weakening protection: genuinely unpushed work must still be refused, hard rule 3 (never tear down unlanded work) stays intact, repos with no submodule must behave identically, and real modifications INSIDE a submodule (not merely a pointer difference) must still be refused. That last point had to be measured, not assumed.

Three measurements were required before choosing the fix's shape, with anything unmeasurable written down as "not measured" rather than guessed:
1. Where linked worktrees keep submodule checkouts (per-worktree .git/worktrees/<name>/modules/ vs shared .git/modules/), since a shared checkout would mean two slots cannot hold different pins at once and would force stopping scope there.
2. Whether the cleanliness check belongs before the reset, after it, or both.
3. The actual behavior when there are real changes inside the submodule.

Acceptance required red-first tests: two consecutive spawns across a moving submodule pin failing before the fix, plus tests proving real unpushed work is still refused (including changes inside a submodule), that no-submodule repos are unchanged, and that concurrent pooled slots do not collide - or, if they do collide, saying so and stopping scope there.

Accepted delivered shape: rather than silently resyncing a pin, the slot explains a stale-submodule refusal instead of reporting it as merely unclean, and requires remote containment before calling a submodule pin stale, so no remedy is printed that the containment check cannot stand behind. The cleanliness gate was TIGHTENED, not loosened, using --ignore-submodules=none. Delivered on branch fm/pool-submodule-drift as changes to bin/fm-spawn.sh plus a 302-line colocated test file, 6 tests of which 2 are red-before-the-fix.

This work touches firstmate's shared tracked material, so firstmate-coding-guidelines applies. Commit trailers must not carry Co-Authored-By.

Current delivery state: this is published externally as PR #3121 against kunchenguid/firstmate. Upstream has reviewed it, approved the substance as class corrective and aligned on all seven vision points, and approved the CI workflow runs. They are withholding merge for exactly one reason: the PR body carries no no-mistakes-pipeline-attestation:v1 matching the current head, so the "Require no-mistakes" check fails. The remaining objective is to run the pipeline so the structured attestation lands on the PR body for the CURRENT head and that check turns green. Nothing about the code is in question; the shape is settled, so do not narrow or redesign it.

## What Changed

- `freshen_spawn_worktree_base` now distinguishes a stale submodule checkout from uncommitted work: when a slot's only deviation is a submodule gitlink, the refusal reports it as a stale checkout naming the submodule and both pins instead of the generic "is not clean" message. The refusal itself still stands and the slot is left untouched — nothing is converged, reset, or removed.
- Added `describe_stale_submodule_pins`, which only reaches that diagnosis when every status entry is a clean submodule sitting on a different pin *and* the checked-out commit is already contained in one of the submodule's remotes (`git log ... --not --remotes`, capped at one commit). Anything unprovable — an unpushed commit, a submodule with no remote, a git error, or any non-submodule entry — falls through to the conservative uncommitted-work refusal. The diagnosis is buffered and emitted only after every entry qualifies, so it can never contradict the verdict. No remedy command is printed, since the containment probe reads local refs only and never fetches; the header comment documents that trade-off.
- The pre-reset status call now runs with `-c core.quotePath=false` so paths parse reliably, and the colocated test file gains five cases covering: two consecutive spawns across a moved submodule pin (residue produced by a real spawn, not hand-built), an unpushed submodule commit, work inside a submodule, a stale pin carrying real work, and a stale pin beside unrelated dirt.

## Risk Assessment

✅ Low: The change is a refuse-only diagnostic refinement on a path that already refused: every guard in the new classifier degrades to the pre-existing conservative message, no new write or reset path is introduced, the review-round fix (`--max-count=1`) is verdict-preserving, and the only gap is a missing acceptance test for a concurrent-slot property I independently verified holds in git 2.43.

## Testing

I ran the colocated suite `tests/fm-spawn-pool-base-freshen.test.sh` at the target commit (all 11 pass) and confirmed no other test file depends on the changed refusal text, then went past pass/fail to demonstrate the intent as an operator sees it. Using throwaway copies of the tree with `bin/fm-spawn.sh` swapped to the base and to the intermediate review commit, I verified both red-first claims: the stale-pin diagnosis test fails at base b0ca8f5, and the unpushed-commit test fails at 3c9f27c, where the pre-containment code printed a `git submodule update --checkout` remedy at a slot holding an unpushed submodule commit. I then captured a real before/after CLI transcript of the actual field sequence — spawn one succeeds and strands the submodule, leaving ` M ui`; spawn two refuses. At base the operator gets "is not clean; refusing to discard uncommitted work" while their own `git status` shows only a pointer difference; at head they get the submodule name, both pins, and "has a stale submodule checkout, not uncommitted work", with no remedy printed and HEAD plus the submodule pin unmoved. I also measured the two open questions the intent flagged: linked worktrees keep submodule checkouts per-worktree, and a spawn refused in one pooled slot left a second slot's differing pin untouched, so concurrent slots do not collide. One thing did not check out: the intent says the cleanliness gate was tightened with `--ignore-submodules=none`, but that flag is nowhere in the code, and a slot whose `.gitmodules` ships `ignore = all` is still accepted with a tracked edit and an untracked file inside the submodule. Base behaves identically, so this is pre-existing rather than a regression from this change, and I left the code alone since the shape is settled — but it contradicts the stated delivered shape and needs the author's call.

<details>
<summary>Evidence: CLI transcript — two consecutive spawns across a moved submodule pin, AFTER the fix (head e7d2849)</summary>

<code>=== SPAWN 1 of 2 (fm-spawn.sh ship-ui-copy-seed &lt;project&gt;) ===&#10;spawned ship-ui-copy-seed harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-ship-ui-copy-seed worktree=.../demo/pool&#10;[exit 0]&#10;&#10;--- pooled slot AFTER spawn 1 (this is the residue) ---&#10;$ git -C &lt;pool&gt; rev-parse --short HEAD -&gt; d9a165e (base moved)&#10;$ git -C &lt;pool&gt;/ui rev-parse --short HEAD -&gt; 4ca2884 (submodule left behind)&#10;$ git -C &lt;pool&gt; status --short&#10;M ui&#10;&#10;=== SPAWN 2 of 2 (the next task pays for it) ===&#10;error: submodule &#39;ui&#39; is checked out at 4ca2884b919922bb347389ec64457945c9b713a6, but this base records aef27f14851884b44a3cd2775a9dc8bb3fbdb39f&#10;error: pooled worktree &#39;.../demo/pool&#39; has a stale submodule checkout, not uncommitted work; refusing to launch and leaving it untouched&#10;[exit 1]&#10;&#10;--- slot after the refusal (must be untouched) ---&#10;$ git -C &lt;pool&gt; rev-parse --short HEAD -&gt; d9a165e&#10;$ git -C &lt;pool&gt;/ui rev-parse --short HEAD -&gt; 4ca2884</code>

```text
############################################################
# AFTER THE FIX   (head e7d2849)
# fm-spawn.sh under test: /tmp/no-mistakes-evidence/01M0ZR39QB0TVBZ7XFNZKD01FX/transcript-after-fix/bin/fm-spawn.sh
############################################################

--- pooled slot before any spawn (operator view) ---
$ git -C <pool> status --short          # (empty = clean)
$ git -C <pool> rev-parse --short HEAD  -> 9a886c9
$ git -C <pool>/ui rev-parse --short HEAD -> 0d0dba4
  origin/main has since moved to 7c6a18f, which moves the 'ui' pin to 7279d9a

=== SPAWN 1 of 2  (fm-spawn.sh ship-ui-copy-seed <project>) ===
spawned ship-ui-copy-seed harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-ship-ui-copy-seed worktree=/tmp/fm-spawn-pool-base-freshen.LHid0G/demo/pool
[exit 0]

--- pooled slot AFTER spawn 1 (this is the residue) ---
$ git -C <pool> rev-parse --short HEAD    -> 7c6a18f  (base moved)
$ git -C <pool>/ui rev-parse --short HEAD -> 0d0dba4  (submodule left behind)
$ git -C <pool> status --short
 M ui

=== SPAWN 2 of 2  (the next task pays for it) ===
error: submodule 'ui' is checked out at 0d0dba46ec30ece43c34098ec07adebdf2af3f24, but this base records 7279d9a012945c08ab7bce5a1252357be6862ca1
error: pooled worktree '/tmp/fm-spawn-pool-base-freshen.LHid0G/demo/pool' has a stale submodule checkout, not uncommitted work; refusing to launch and leaving it untouched
[exit 1]

--- slot after the refusal (must be untouched) ---
$ git -C <pool> rev-parse --short HEAD    -> 7c6a18f
$ git -C <pool>/ui rev-parse --short HEAD -> 0d0dba4
```
</details>
<details>
<summary>Evidence: CLI transcript — same sequence BEFORE the fix (base b0ca8f5): the misleading verdict</summary>

<code>--- pooled slot AFTER spawn 1 (this is the residue) ---&#10;$ git -C &lt;pool&gt; status --short&#10;M ui&#10;&#10;=== SPAWN 2 of 2 (the next task pays for it) ===&#10;error: pooled worktree &#39;.../demo/pool&#39; is not clean; refusing to discard uncommitted work while refreshing its base&#10;[exit 1]</code>

```text
############################################################
# BEFORE THE FIX  (base b0ca8f5)
# fm-spawn.sh under test: /tmp/no-mistakes-evidence/01M0ZR39QB0TVBZ7XFNZKD01FX/transcript-before-fix/bin/fm-spawn.sh
############################################################

--- pooled slot before any spawn (operator view) ---
$ git -C <pool> status --short          # (empty = clean)
$ git -C <pool> rev-parse --short HEAD  -> 934ecc8
$ git -C <pool>/ui rev-parse --short HEAD -> b1633b9
  origin/main has since moved to df26c27, which moves the 'ui' pin to 4ce5d10

=== SPAWN 1 of 2  (fm-spawn.sh ship-ui-copy-seed <project>) ===
spawned ship-ui-copy-seed harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-ship-ui-copy-seed worktree=/tmp/fm-spawn-pool-base-freshen.uG0i3N/demo/pool
[exit 0]

--- pooled slot AFTER spawn 1 (this is the residue) ---
$ git -C <pool> rev-parse --short HEAD    -> df26c27  (base moved)
$ git -C <pool>/ui rev-parse --short HEAD -> b1633b9  (submodule left behind)
$ git -C <pool> status --short
 M ui

=== SPAWN 2 of 2  (the next task pays for it) ===
error: pooled worktree '/tmp/fm-spawn-pool-base-freshen.uG0i3N/demo/pool' is not clean; refusing to discard uncommitted work while refreshing its base
[exit 1]

--- slot after the refusal (must be untouched) ---
$ git -C <pool> rev-parse --short HEAD    -> df26c27
$ git -C <pool>/ui rev-parse --short HEAD -> b1633b9
```
</details>
<details>
<summary>Evidence: Red-first proof #1 — new tests run against the pre-fix bin/fm-spawn.sh (b0ca8f5)</summary>

<code>=== test_stale_submodule_pin_explains_itself (against pre-fix bin/fm-spawn.sh @ b0ca8f5) ===&#10;not ok - refusal did not name the cause as a stale submodule checkout (missing: &#39;stale submodule checkout&#39;)&#10;--- output ---&#10;error: pooled worktree &#39;.../stale-pin/pool&#39; is not clean; refusing to discard uncommitted work while refreshing its base&#10;exit=1</code>

```text
=== test_stale_submodule_pin_explains_itself (against pre-fix bin/fm-spawn.sh @ b0ca8f5) ===
not ok - refusal did not name the cause as a stale submodule checkout (missing: 'stale submodule checkout')
--- output ---
warning: /tmp/fm-spawn-pool-base-freshen.TnrH0x/stale-pin/home/data/pool-stale-pin-r7/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
error: pooled worktree '/tmp/fm-spawn-pool-base-freshen.TnrH0x/stale-pin/pool' is not clean; refusing to discard uncommitted work while refreshing its base
exit=1

=== test_unpushed_submodule_commit_is_still_uncommitted_work (against pre-fix bin/fm-spawn.sh @ b0ca8f5) ===
ok - an unpushed submodule commit keeps the uncommitted-work refusal and survives it
# all fm-spawn-pool-base-freshen tests passed
exit=0

=== test_work_inside_submodule_is_still_uncommitted_work (against pre-fix bin/fm-spawn.sh @ b0ca8f5) ===
ok - work inside a submodule is still refused as uncommitted work, not called stale
# all fm-spawn-pool-base-freshen tests passed
exit=0

=== test_stale_pin_carrying_real_work_is_not_called_stale (against pre-fix bin/fm-spawn.sh @ b0ca8f5) ===
ok - a stale pin carrying real work is refused conservatively, never called stale
# all fm-spawn-pool-base-freshen tests passed
exit=0

=== test_stale_pin_beside_other_dirt_reports_one_verdict (against pre-fix bin/fm-spawn.sh @ b0ca8f5) ===
ok - a stale pin beside other dirt yields the conservative refusal alone, with no stale-pin line
# all fm-spawn-pool-base-freshen tests passed
exit=0
```
</details>
<details>
<summary>Evidence: Red-first proof #2 — containment test against the pre-containment commit (3c9f27c), where a destructive remedy was printed at an unpushed commit</summary>

<code>=== test_unpushed_submodule_commit_is_still_uncommitted_work against pre-containment bin/fm-spawn.sh @ 3c9f27c ===&#10;not ok - an unpushed submodule commit was not refused as uncommitted work (missing: &#39;refusing to discard uncommitted work&#39;)&#10;--- output ---&#10;error: submodule &#39;ui&#39; is checked out at a7a728a6..., but this base records 0a14f9ad...&#10;error: pooled worktree &#39;.../sub-unpushed/pool&#39; has a stale submodule checkout, not uncommitted work; refusing to launch and leaving it untouched&#10;error: clear it with: git -C &#39;.../sub-unpushed/pool&#39; submodule update --checkout&#10;exit=1</code>

```text
=== test_unpushed_submodule_commit_is_still_uncommitted_work against pre-containment bin/fm-spawn.sh @ 3c9f27c ===
not ok - an unpushed submodule commit was not refused as uncommitted work (missing: 'refusing to discard uncommitted work')
--- output ---
warning: /tmp/fm-spawn-pool-base-freshen.L3FopH/sub-unpushed/home/data/pool-sub-unpushed-r10/brief.md records no delivery contract line (scaffolded before ship briefs recorded one); launching on the explicit --mode no-mistakes - confirm its definition of done matches
error: submodule 'ui' is checked out at a7a728a64b7256c58295d3d026487d6ee3190451, but this base records 0a14f9ad0c665f4bf6f148b5014140d117076f6b
error: pooled worktree '/tmp/fm-spawn-pool-base-freshen.L3FopH/sub-unpushed/pool' has a stale submodule checkout, not uncommitted work; refusing to launch and leaving it untouched
error: clear it with: git -C '/tmp/fm-spawn-pool-base-freshen.L3FopH/sub-unpushed/pool' submodule update --checkout
exit=1
```
</details>
<details>
<summary>Evidence: Measurements — per-worktree submodule storage and concurrent pooled slots</summary>

<code>slot A gitdir for &#39;ui&#39;: &lt;case&gt;/project/.git/worktrees/pool/modules/ui&#10;slot B gitdir for &#39;ui&#39;: &lt;case&gt;/project/.git/worktrees/pool2/modules/ui&#10;=&gt; PER-WORKTREE submodule git dir&#10;&#10;slot A ui HEAD = ffb1560 slot A status: []&#10;slot B ui HEAD = 4adeb0b slot B status: [ M ui;]&#10;&#10;Now spawn into slot B while slot A holds the other pin:&#10;error: submodule &#39;ui&#39; is checked out at 4adeb0b9..., but this base records ffb1560c...&#10;error: pooled worktree &#39;.../m1/pool2&#39; has a stale submodule checkout, not uncommitted work; refusing to launch and leaving it untouched&#10;[exit 1]&#10;slot A ui HEAD after slot B&#39;s spawn = ffb1560 (was ffb1560)&#10;=&gt; no collision: slot A&#39;s submodule pin untouched by slot B&#39;s spawn</code>

```text
==========================================================
MEASUREMENT 1: where a linked worktree keeps its submodule
               checkout, and whether two pooled slots on
               different pins collide
==========================================================
slot A gitdir for 'ui': <case>/project/.git/worktrees/pool/modules/ui
slot B gitdir for 'ui': <case>/project/.git/worktrees/pool2/modules/ui
=> PER-WORKTREE submodule git dir

Put the two slots on DIFFERENT pins and read each slot's status:
slot A ui HEAD = ffb1560   slot A status: []
slot B ui HEAD = 4adeb0b   slot B status: [ M ui;]

Now spawn into slot B while slot A holds the other pin:
error: submodule 'ui' is checked out at 4adeb0b933c7d080ca52f1c0f647eb1783ece04f, but this base records ffb1560c5136c5072c451befb11da8c11e95963b
error: pooled worktree '/tmp/fm-spawn-pool-base-freshen.6LemFO/m1/pool2' has a stale submodule checkout, not uncommitted work; refusing to launch and leaving it untouched
[exit 1]
slot A ui HEAD after slot B's spawn = ffb1560 (was ffb1560)
=> no collision: slot A's submodule pin untouched by slot B's spawn

==========================================================
MEASUREMENT 2: does the cleanliness gate still see real
               work inside a submodule when .gitmodules
               sets submodule.<name>.ignore = all ?
==========================================================
$ git -C <pool> status --porcelain            -> []
$ git -C <pool> status --porcelain --ignore-submodules=none -> [ M ui;]
spawned measure-c3 harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-measure-c3 worktree=/tmp/fm-spawn-pool-base-freshen.6LemFO/m2/pool
[exit 0]  (0 = spawn ACCEPTED the slot)
pool HEAD: 492a35f -> b20cfec
submodule work still present? lib.txt tail: [tracked edit inside the submodule]  keep-me.txt: [work that must survive]
```
</details>
<details>
<summary>Evidence: Gap measurement — `.gitmodules` ignore = all defeats the cleanliness gate identically on base and head</summary>

<code>### BASE b0ca8f5&#10;.gitmodules ships: submodule.ui.ignore=all&#10;real work inside the submodule: tracked edit to ui/lib.txt + untracked ui/keep-me.txt&#10;git status --porcelain -&gt; []&#10;git status --porcelain --ignore-submodules=none -&gt; [ M ui;]&#10;spawned gm-ignore-d4 ... worktree=.../m3/pool&#10;[exit 0] -&gt; slot ACCEPTED and handed to a new task, despite real work inside the submodule&#10;&#10;### HEAD e7d2849&#10;.gitmodules ships: submodule.ui.ignore=all&#10;git status --porcelain -&gt; []&#10;git status --porcelain --ignore-submodules=none -&gt; [ M ui;]&#10;spawned gm-ignore-d4 ... worktree=.../m3/pool&#10;[exit 0] -&gt; slot ACCEPTED and handed to a new task, despite real work inside the submodule</code>

```text
### BASE b0ca8f5   (fm-spawn.sh = /tmp/no-mistakes-evidence/01M0ZR39QB0TVBZ7XFNZKD01FX/transcript-before-fix/bin/fm-spawn.sh)
  .gitmodules ships: submodule.ui.ignore=all
  real work inside the submodule: tracked edit to ui/lib.txt + untracked ui/keep-me.txt
  git status --porcelain                          -> []
  git status --porcelain --ignore-submodules=none  -> [ M ui;]
  spawned gm-ignore-d4 harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-gm-ignore-d4 worktree=/tmp/fm-spawn-pool-base-freshen.YYMi8K/m3/pool
  [exit 0] -> slot ACCEPTED and handed to a new task, despite real work inside the submodule
  pool HEAD 628212f -> 628212f

### HEAD e7d2849   (fm-spawn.sh = /tmp/no-mistakes-evidence/01M0ZR39QB0TVBZ7XFNZKD01FX/transcript-after-fix/bin/fm-spawn.sh)
  .gitmodules ships: submodule.ui.ignore=all
  real work inside the submodule: tracked edit to ui/lib.txt + untracked ui/keep-me.txt
  git status --porcelain                          -> []
  git status --porcelain --ignore-submodules=none  -> [ M ui;]
  spawned gm-ignore-d4 harness=codex kind=ship mode=no-mistakes yolo=off window=firstmate:fm-gm-ignore-d4 worktree=/tmp/fm-spawn-pool-base-freshen.P1FsAU/m3/pool
  [exit 0] -> slot ACCEPTED and handed to a new task, despite real work inside the submodule
  pool HEAD 1db7b1e -> 1db7b1e
```
</details>
<details>
<summary>Evidence: Targeted suite at head e7d2849</summary>

<code>ok - two consecutive spawns across a moved submodule pin end in a refusal naming both pins and no remedy&#10;ok - an unpushed submodule commit keeps the uncommitted-work refusal and survives it&#10;ok - work inside a submodule is still refused as uncommitted work, not called stale&#10;ok - a stale pin carrying real work is refused conservatively, never called stale&#10;ok - a stale pin beside other dirt yields the conservative refusal alone, with no stale-pin line&#10;# all fm-spawn-pool-base-freshen tests passed</code>

```text
ok - a stale pooled worktree refreshes to current origin/main before a crew branch is created
ok - a stale pooled worktree resolves and refreshes a non-main default branch
ok - direct-PR ships and scouts both refresh stale pooled worktrees before launch
ok - a dirty pooled worktree is refused without discarding its local work
ok - an unresolved remote default branch refuses the pooled worktree
ok - an unreachable origin refuses a potentially stale pooled worktree
ok - two consecutive spawns across a moved submodule pin end in a refusal naming both pins and no remedy
ok - an unpushed submodule commit keeps the uncommitted-work refusal and survives it
ok - work inside a submodule is still refused as uncommitted work, not called stale
ok - a stale pin carrying real work is refused conservatively, never called stale
ok - a stale pin beside other dirt yields the conservative refusal alone, with no stale-pin line
# all fm-spawn-pool-base-freshen tests passed
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (6m21s)

## Neighbouring issues, named but not absorbed

**Pre-existing and out of scope.** A project that sets `submodule.<name>.ignore = all` can hide real uncommitted work inside a submodule from this cleanliness gate, letting the slot be refreshed anyway. This is equally true on `main` today, whose gate is a plain `git status --porcelain` with no `--ignore-submodules`, so this branch is at parity and does not introduce the exposure. Flagging it here so it can be weighed on its own rather than folded into this change.

**Measurement on record.** Linked worktrees each get their own submodule gitdir at `.git/worktrees/<slot>/modules/<name>` rather than sharing `.git/modules` (measured on git 2.43.0: two slots held different submodule HEADs at once, and only the drifted slot reported ` M <submodule>`). Concurrent pooled slots therefore cannot collide over a submodule checkout, so the conditional acceptance item covering a *shared* checkout does not apply and no two-slot regression test was added.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"e7d2849f3fd3921584ed721ed0d1d047613eb32a","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

- 🚨 `bin/fm-spawn.sh:1818` - Acceptance criteria state &#34;The cleanliness gate was TIGHTENED, not loosened, using --ignore-submodules=none&#34;, but that flag is absent from the branch: the gate reads `status=$(git -C &#34;$worktree&#34; -c core.quotePath=false status --porcelain)` and `--ignore-submodules` appears nowhere in the repo (`grep -rn ignore-submodules --include=*.sh` returns nothing). Without it, `git status` honors `submodule.&lt;name&gt;.ignore` from `.gitmodules`/`.git/config` and `diff.ignoreSubmodules`. A superproject that ships `ignore = all` for its submodule (a setting a team plausibly adds precisely to silence the &#39; M &lt;submodule&gt;&#39; residue this bug produces) makes status report clean, so the gate proceeds straight to `git reset --hard` on line 1830 and launches a task from a slot that holds real uncommitted modifications inside the submodule - directly contradicting the criterion &#34;real modifications INSIDE a submodule (not merely a pointer difference) must still be refused&#34;. `ignore = dirty` hides the same work-tree modifications while still surfacing the pin difference, which would additionally route a slot carrying real submodule work into the softer &#34;stale submodule checkout&#34; diagnosis. The inner check on line 1781 (`git -C &#34;$worktree/$path&#34; status --porcelain`) has the same exposure for a submodule that itself configures nested-submodule ignores. Adding `--ignore-submodules=none` to both status calls is what the criteria describe; because it changes which slots are refused and which message they get, it is your call rather than mine.
- ℹ️ `bin/fm-spawn.sh:1785` - The containment probe only tests emptiness, but `git log --format=%H &#34;$have&#34; --not --remotes --` enumerates every non-contained commit into a shell variable. In the two cases that matter most - a submodule with no remote-tracking refs at all, or one whose refs were never fetched - `--not --remotes` excludes nothing, so this walks and materializes the submodule&#39;s entire history on a path that runs before every pooled spawn. Adding `--max-count=1` bounds it to the first commit found without changing the verdict.
- ℹ️ `bin/fm-spawn.sh:1830` - Noting the accepted tradeoff, not asking for a change: the `reset --hard` on this line is unchanged and still never syncs submodules, so each time the pin moves the residue re-forms, and the affected slot now refuses every subsequent spawn until an operator repairs it by hand - the pool loses that slot rather than self-healing. The intent authorizes exactly this shape (&#34;rather than silently resyncing a pin, the slot explains a stale-submodule refusal&#34;), and the diagnosis does make the manual repair actionable by naming the submodule and both pins, so no action is required here.

🔧 Fix: bound submodule containment probe to first commit
1 warning still open:
- ⚠️ `tests/fm-spawn-pool-base-freshen.test.sh:463` - The acceptance criteria require tests &#34;that concurrent pooled slots do not collide - or, if they do collide, saying so and stopping scope there.&#34; Neither exists on the branch: all five new tests (lines 459-463) build exactly one pool worktree via `make_submodule_case`, which does a single `git worktree add ... &#34;$pool&#34;` plus one `submodule update --init`, and nothing in bin/fm-spawn.sh or the test file records the measurement either way. This matters specifically for the new code because `describe_stale_submodule_pins` reads the slot&#39;s submodule through `git -C &#34;$worktree/$path&#34;` (bin/fm-spawn.sh:1781,1783,1785); if slots shared one submodule gitdir, `core.worktree` would point at whichever slot initialized last and the diagnosis would report another slot&#39;s state - and the field incident this change is for involved three pooled slots at once. I probed the underlying behavior read-only (git 2.43): a linked worktree gets its OWN submodule gitdir at `.git/worktrees/&lt;slot&gt;/modules/&lt;name&gt;` with its own `core.worktree` and its own `refs/remotes`, and two slots held different submodule HEADs with only the drifted slot reporting ` M ui`. So the property holds and there is no defect here - this is a missing regression test (and missing recorded measurement) for an explicitly required acceptance item, not a broken behavior. Adding a second `git worktree add` slot to a case and asserting each slot&#39;s diagnosis names only its own pin would close it; because it is an acceptance-scope decision, it is the author&#39;s call.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `bin/fm-spawn.sh:1818` - The intent states the cleanliness gate was tightened &#34;using --ignore-submodules=none&#34;, but that flag does not appear anywhere in the delivered code (bin/fm-spawn.sh:1818 runs plain `git status --porcelain`, and a repo-wide grep for `ignore-submodules` returns nothing). Measured consequence: with `submodule.ui.ignore = all` shipped in .gitmodules, a pooled slot holding a tracked edit to ui/lib.txt plus an untracked ui/keep-me.txt reads clean to the gate, and the spawn ACCEPTS the slot and hands it to a new task — the intent&#39;s required constraint that real modifications inside a submodule must still be refused. The base commit b0ca8f5 behaves identically, so this is pre-existing and NOT a regression introduced by this change, and I did not touch the code because the delivery state says the shape is settled. But the delivered code does not match the delivered-shape description in the intent, and the one-flag change that would close it also affects the conservative refusal path, so it is the author&#39;s call whether to add `--ignore-submodules=none` now or correct the claim. Evidence: /tmp/no-mistakes-evidence/01M0ZR39QB0TVBZ7XFNZKD01FX/measure-gitmodules-ignore.txt
- <code>`bash tests/fm-spawn-pool-base-freshen.test.sh` at head e7d2849 — all 11 tests pass (6 pre-existing, 5 new)</code>
- <code>Red-first vs base: each of the 5 new tests run individually against `git show b0ca8f5:bin/fm-spawn.sh` in a throwaway copy — `test_stale_submodule_pin_explains_itself` fails as claimed</code>
- <code>Red-first vs intermediate: `test_unpushed_submodule_commit_is_still_uncommitted_work` run against `git show 3c9f27c:bin/fm-spawn.sh` — fails, and the pre-containment code printed `git submodule update --checkout` at a slot holding an unpushed submodule commit</code>
- <code>Manual end-user CLI transcript: two consecutive `fm-spawn.sh &lt;id&gt; &lt;project&gt; --mode no-mistakes --yolo off` runs over a real superproject+submodule fixture whose origin advanced the `ui` pin, captured under both base and head</code>
- <code>Manual measurement: `git -C &lt;pool&gt;/ui rev-parse --git-dir` in two linked worktrees of the same project (per-worktree vs shared submodule storage)</code>
- `Manual measurement: spawn into pooled slot B while slot A holds a different submodule pin, asserting slot A's pin is unmoved (concurrent-slot collision check)`
- <code>Manual measurement: slot with `submodule.ui.ignore = all` in `.gitmodules` plus a tracked edit and an untracked file inside the submodule, spawned under both base b0ca8f5 and head e7d2849</code>
- <code>`grep -rn &#39;is not clean; refusing to discard&#39; tests/ bin/` and `grep -rln &#39;freshen_spawn_worktree_base|pooled worktree&#39; tests/` to confirm no other test file asserts the changed refusal text</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `bin/fm-spawn.sh:1754` - describe_stale_submodule_pins compares each pooled slot&#39;s own submodule HEAD against that slot&#39;s recorded pin, which is only meaningful because linked worktrees keep independent submodule checkouts. I measured this rather than assume it: under git 2.43.0 each linked worktree gets its own .git/worktrees/&lt;name&gt;/modules/&lt;path&gt; (gitdir pointers ../../super/.git/worktrees/wt1/modules/ui and .../wt2/modules/ui), and two worktrees of one superproject held two different pins at the same time, so concurrent pooled slots do not collide. That external constraint is written down nowhere - not in the function comment, not in the script header - and no test in tests/fm-spawn-pool-base-freshen.test.sh exercises two slots at once, so a future git layout change or a shared-checkout configuration would silently make the per-slot comparison wrong with nothing failing. Recording it is an addition rather than a stale-fact fix, and the test is executable work, so both sit outside this documentation phase. Follow-up: add the measured constraint as one clause in that function&#39;s existing comment block (code comments own external constraints under the placement policy) and back it with a concurrent-slot regression case.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 1)

🔧 Fix: lint clean at current head, no changes needed
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

