### PR TITLE
feat(skills): add slack-announcements drafting skill and forward claude proxy env

### DIFF
--- a/.agents/skills/harness-adapters/SKILL.md
+++ b/.agents/skills/harness-adapters/SKILL.md
@@ -193,6 +193,10 @@ First launch in a fresh worktree, or first ever on a machine, may show a trust o
 After every spawn, peek the pane within about 20 seconds.
 If such a dialog is showing, accept it from an active firstmate session using `FM_HOME=<this-firstmate-home> bin/fm-send.sh <window> --key Enter`, or the choice the dialog requires, unless `FM_HOME` is already set to the active firstmate home; verify the brief started processing.
 
+Crewmate and secondmate panes are created by a long-lived backend daemon that does not inherit firstmate's own environment, so every claude launch forwards firstmate's `CLAUDE_CONFIG_DIR` and `ANTHROPIC_BASE_URL` when they are set (`bin/fm-spawn.sh`).
+Forwarding `CLAUDE_CONFIG_DIR` keeps the worker on the same credential and config store firstmate is authenticated with, and forwarding `ANTHROPIC_BASE_URL` keeps it routed through the same local proxy in front of the model API, for example one the captain uses for cost tracking.
+An unset value is the default (single store, direct API) and adds no prefix, and neither variable is forwarded onto a non-claude harness.
+
 Claude renders a predicted-next-prompt suggestion as dim/faint text inside an otherwise-empty composer after a turn completes.
 A plain `tmux capture-pane` cannot tell that ghost text apart from typed text.
 Firstmate launches every claude crewmate and secondmate with `CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false`, scoped to firstmate-launched agents through `bin/fm-spawn.sh`, so it never touches the captain's global config.

--- a/.agents/skills/slack-announcements/SKILL.md
+++ b/.agents/skills/slack-announcements/SKILL.md
@@ -18,6 +18,8 @@ Every cut was prose, none was structure, so treat these as rules rather than pre
 ## Scope
 
 Use this for any message the captain will post to a channel: a new page or tool, a capability launch, a brownbag, a process change, a broadcast status note.
+This skill produces a draft and nothing else: the captain posts it.
+Never send, schedule, or otherwise publish the announcement yourself, through any channel or tool.
 
 Do not use it for captain-facing chat, PR bodies, commit messages, or project documentation.
 Several rules here are the opposite of what those surfaces need, and applying them there deletes detail those readers depend on.
@@ -33,6 +35,11 @@ Draft, then cut to roughly half, and expect to find nothing missing.
 Three or four bold section headers, each answering a question the reader actually has: what this is plus the link, what it counts or does, what makes it trustworthy, what it is not.
 That outline survived verbatim through the cut.
 Edit inside the sections, never the outline.
+
+The announcement itself uses no markdown emphasis or heading syntax at all: no double-asterisk bold, no hash headings, no underscores for italics, no markdown links, and no backtick code spans.
+Slack does not parse markdown and renders every one of those literally.
+Section headers stay bold through Slack's own mrkdwn form instead, a single asterisk on each side of the header text, written as `*What this is*`.
+A single-asterisk pair is only ever a bold section header, never inline emphasis on a word or a phrase, and the announcement carries no hash title.
 
 ## One clause per bullet
 
@@ -109,8 +116,9 @@ An announcement carries no captain attribution.
 
 Run this pass in order before handing the draft over, applying the rules above rather than overriding them:
 
-1. Cut the second sentence of every bullet: it is almost always the cut, so keep it only when it passes the prevent-a-wrong-action test above.
-2. Cut every defensive clause beginning "never", "rather than", or "not a", keeping the "what it is not" section's own content and any clause that passes that same test.
+1. Cut the second sentence of every bullet: it is almost always the cut, so keep it only when it is a load-bearing reason that prevents a wrong action, never when it restates or illustrates the first sentence, as the worked example's cut second sentence does.
+2. Cut every clause that defends a claim or pre-empts an objection nobody raised, measured against the quoted phrases in the no-defence rule above rather than against any fixed opener, so a clause reading "that's honest data, not a gap in the page", "and the page says so itself", or "Nothing else sneaks in." is caught exactly as one opening "never", "rather than", or "not a" is.
+   Keep the "what it is not" section's own content and any clause that passes that same load-bearing test.
 3. Replace every em dash with a colon or a full stop, or restructure the sentence, and never remove a clause separator in a way that leaves a run-on.
 4. Cut every sentence about how the thing is built or refreshed.
 

--- a/.agents/skills/slack-announcements/SKILL.md
+++ b/.agents/skills/slack-announcements/SKILL.md
@@ -37,6 +37,7 @@ Edit inside the sections, never the outline.
 ## One clause per bullet
 
 A bullet is an index entry, not a paragraph.
+Keep every capability list brief, and prefer one sentence per bullet wherever the announcement lists bullet points.
 If a bullet has a second sentence, that sentence is almost always the cut.
 
 Before:
@@ -91,6 +92,7 @@ A reader who needs that detail is already past the announcement.
 ## Link plainly
 
 Bare domain and path on its own line, no scheme and no label text.
+Keep the scheme when the host is not one Slack will auto-link, such as an internal or non-public-suffix hostname.
 
 This does not relax `AGENTS.md` section 9's requirement for a full `https://` URL in captain-facing chat about a PR.
 Different audience, different rule: nothing here is a general relaxation of that requirement.
@@ -105,11 +107,11 @@ An announcement carries no captain attribution.
 
 ## Final deletion pass
 
-Run this pass in order before handing the draft over:
+Run this pass in order before handing the draft over, applying the rules above rather than overriding them:
 
-1. Delete every second sentence of every bullet.
-2. Delete every clause beginning "never", "rather than", or "not a".
-3. Delete every em dash.
-4. Delete every sentence about how the thing is built or refreshed.
+1. Cut the second sentence of every bullet: it is almost always the cut, so keep it only when it passes the prevent-a-wrong-action test above.
+2. Cut every defensive clause beginning "never", "rather than", or "not a", keeping the "what it is not" section's own content and any clause that passes that same test.
+3. Replace every em dash with a colon or a full stop, or restructure the sentence, and never remove a clause separator in a way that leaves a run-on.
+4. Cut every sentence about how the thing is built or refreshed.
 
 Then confirm the outline still stands.

--- a/.agents/skills/slack-announcements/SKILL.md
+++ b/.agents/skills/slack-announcements/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: slack-announcements
+description: >-
+  Agent-only style contract for drafting a Slack announcement the captain will post to a channel.
+  Load before drafting a new-page, new-tool, capability-launch, brownbag, process-change, or broadcast status message.
+  Owns the length target, the section skeleton, the one-clause bullet rule, the no-defence rule, punctuation and formatting limits, and the final deletion pass.
+user-invocable: false
+metadata:
+  internal: true
+---
+
+# Slack announcement style
+
+This skill is the single owner of how firstmate drafts a message the captain will post to a channel.
+The rules below come from one measured case: a draft announcing a new internal page went from 323 words to 144 before posting, and the captain's section outline survived untouched.
+Every cut was prose, none was structure, so treat these as rules rather than preferences.
+
+## Scope
+
+Use this for any message the captain will post to a channel: a new page or tool, a capability launch, a brownbag, a process change, a broadcast status note.
+
+Do not use it for captain-facing chat, PR bodies, commit messages, or project documentation.
+Several rules here are the opposite of what those surfaces need, and applying them there deletes detail those readers depend on.
+
+## Assume the first draft is twice as long as it should be
+
+The measured case cut 55% of the words with the outline unchanged.
+The excess is explanation, not content.
+Draft, then cut to roughly half, and expect to find nothing missing.
+
+## Keep the skeleton, cut the prose
+
+Three or four bold section headers, each answering a question the reader actually has: what this is plus the link, what it counts or does, what makes it trustworthy, what it is not.
+That outline survived verbatim through the cut.
+Edit inside the sections, never the outline.
+
+## One clause per bullet
+
+A bullet is an index entry, not a paragraph.
+If a bullet has a second sentence, that sentence is almost always the cut.
+
+Before:
+
+- "A completion is credited to whoever held the ticket the moment it moved to Done, replayed from the ticket's own history, not whoever it happens to be assigned to today. Work finished in July and reassigned in August still credits July's owner."
+
+After:
+
+- "A completion is credited to whoever held the ticket the moment it moved to Done."
+
+## Never defend the claim
+
+This was the single largest source of cut words.
+Delete every phrase that pre-empts an objection nobody raised.
+These are the phrases the captain cut from the real case, and the pattern is easier to recognise from them than from a definition:
+
+- "never guessed at, and never handed to whoever filed them"
+- "that's honest data, not a gap in the page"
+- "rather than being fuzzy-matched into a plausible pod"
+- "and the page says so itself"
+- "Nothing else sneaks in."
+
+A reader who doubts a claim clicks the link.
+A reader who does not is being argued with for no reason.
+
+## Keep a reason only when it changes how the thing is used
+
+Not all reasoning is padding.
+This sentence survived in full: "Weeks run Thursday to Thursday UTC, deliberately matching the release week, so an activity week and a release cover the same seven days."
+A reader comparing the page against a release would otherwise misread it.
+
+The test: does the reason prevent a wrong action, or does it defend the work's credibility?
+Keep the first, cut the second.
+
+## No em dashes
+
+Use a colon, a full stop, or restructure the sentence.
+In the real case both em dashes that introduced a definition became colons, and the rest of those sentences were split or dropped.
+
+## No intensifiers, no hedges, numerals for numbers
+
+"genuinely went through AgentOS" became "went through AgentOS".
+"Nineteen weeks of history so far" became "19 weeks of history".
+An adverb survives only when it carries meaning: "what's actually moving through AgentOS" stayed, because it distinguishes real throughput from noise.
+
+## Leave out how it works
+
+An entire closing paragraph covering refresh cadence, credential handling, and build-time embedding was cut wholesale.
+Refresh schedules, security posture, generator scripts, and file layout belong on the page or in the repo, never in the announcement.
+A reader who needs that detail is already past the announcement.
+
+## Link plainly
+
+Bare domain and path on its own line, no scheme and no label text.
+
+This does not relax `AGENTS.md` section 9's requirement for a full `https://` URL in captain-facing chat about a PR.
+Different audience, different rule: nothing here is a general relaxation of that requirement.
+
+## No pipe characters
+
+That rules out markdown tables, because Slack renders them as noise.
+
+## Never name the captain
+
+An announcement carries no captain attribution.
+
+## Final deletion pass
+
+Run this pass in order before handing the draft over:
+
+1. Delete every second sentence of every bullet.
+2. Delete every clause beginning "never", "rather than", or "not a".
+3. Delete every em dash.
+4. Delete every sentence about how the thing is built or refreshed.
+
+Then confirm the outline still stands.

--- a/.agents/skills/slack-announcements/SKILL.md
+++ b/.agents/skills/slack-announcements/SKILL.md
@@ -45,8 +45,8 @@ A single-asterisk pair is only ever a bold section header, never inline emphasis
 ## One clause per bullet
 
 A bullet is an index entry, not a paragraph.
-One clause per bullet is the target that binds, and one sentence per bullet is only the floor beneath it, so a bullet trailing a second clause inside a single sentence still fails the rule.
-Keep every capability list brief, and hold every bullet in it to that same ladder wherever the announcement lists bullet points.
+One claim per bullet is what binds: cut a second sentence, and cut a trailing clause that adds a second claim, restates the first, or defends it, while keeping a subordinate clause the claim's meaning depends on.
+Keep every capability list brief, and hold every bullet in it to that same one-claim rule wherever the announcement lists bullet points.
 If a bullet has a second sentence, that sentence is almost always the cut.
 
 Before:
@@ -123,5 +123,8 @@ Run this pass in order before handing the draft over, applying the rules above r
    Keep only the "what it is not" section's plain statements of what the thing is not, plus any clause that passes that same load-bearing test, so a defensive clause is still cut wherever it sits, including inside that section.
 3. Replace every em dash with a colon or a full stop, or restructure the sentence, and never remove a clause separator in a way that leaves a run-on.
 4. Cut every sentence about how the thing is built or refreshed.
+5. Replace every markdown emphasis or heading form with plain text or a single-asterisk bold section header: no double-asterisk bold, no hash headings, no markdown links, no underscore italics, and no backtick code spans, and a single-asterisk pair only ever wraps a section header.
+6. Cut every pipe character, and rewrite whatever table it carried as bullets or a sentence.
+7. Cut every mention of the captain, because the announcement carries no captain attribution.
 
 Then confirm the outline still stands.

--- a/.agents/skills/slack-announcements/SKILL.md
+++ b/.agents/skills/slack-announcements/SKILL.md
@@ -37,14 +37,16 @@ That outline survived verbatim through the cut.
 Edit inside the sections, never the outline.
 
 The announcement itself uses no markdown emphasis or heading syntax at all: no double-asterisk bold, no hash headings, no underscores for italics, no markdown links, and no backtick code spans.
-Slack does not parse markdown and renders every one of those literally.
+Slack uses its own mrkdwn rather than markdown, so the markdown-only forms among those, double-asterisk bold, hash headings, and markdown link syntax, show up as literal punctuation.
+The forms Slack does share, underscore italics and backtick code spans, are banned as a style choice, because plain unstyled text scans better in an announcement.
 Section headers stay bold through Slack's own mrkdwn form instead, a single asterisk on each side of the header text, written as `*What this is*`.
 A single-asterisk pair is only ever a bold section header, never inline emphasis on a word or a phrase, and the announcement carries no hash title.
 
 ## One clause per bullet
 
 A bullet is an index entry, not a paragraph.
-Keep every capability list brief, and prefer one sentence per bullet wherever the announcement lists bullet points.
+One clause per bullet is the target that binds, and one sentence per bullet is only the floor beneath it, so a bullet trailing a second clause inside a single sentence still fails the rule.
+Keep every capability list brief, and hold every bullet in it to that same ladder wherever the announcement lists bullet points.
 If a bullet has a second sentence, that sentence is almost always the cut.
 
 Before:
@@ -118,7 +120,7 @@ Run this pass in order before handing the draft over, applying the rules above r
 
 1. Cut the second sentence of every bullet: it is almost always the cut, so keep it only when it is a load-bearing reason that prevents a wrong action, never when it restates or illustrates the first sentence, as the worked example's cut second sentence does.
 2. Cut every clause that defends a claim or pre-empts an objection nobody raised, measured against the quoted phrases in the no-defence rule above rather than against any fixed opener, so a clause reading "that's honest data, not a gap in the page", "and the page says so itself", or "Nothing else sneaks in." is caught exactly as one opening "never", "rather than", or "not a" is.
-   Keep the "what it is not" section's own content and any clause that passes that same load-bearing test.
+   Keep only the "what it is not" section's plain statements of what the thing is not, plus any clause that passes that same load-bearing test, so a defensive clause is still cut wherever it sits, including inside that section.
 3. Replace every em dash with a colon or a full stop, or restructure the sentence, and never remove a clause separator in a way that leaves a run-on.
 4. Cut every sentence about how the thing is built or refreshed.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -549,6 +549,7 @@ These skills are not captain-invocable; load them only at their precise triggers
   Never run a registered source's blocking command yourself in a conversational turn.
 - `fmx-respond` - load on an `x-mention <request_id>` `check:` wake to handle the mention, on an `x-mode-error ...` `check:` wake to report the Relay configuration blocker, on a `public-followup ...` `check:` wake or a startup-surfaced public commitment, and on any milestone or terminal wake for a Relay-linked task before posting its completion follow-up; relevant only when Relay is on.
 - `firstmate-codexapp` - load before coordinating a visible Codex Desktop thread, evaluating a Codex App backend request, or reconciling Codex Desktop host-tool smoke evidence for Firstmate work.
+- `slack-announcements` - load before drafting a Slack announcement or any other message the captain will post to a channel.
 - `firstmate-coding-guidelines` - load before changing firstmate's shared, tracked material, as defined by section 1's list, whether editing directly or briefing a crewmate for a firstmate-repo task.
 
 ## 14. Relay

--- a/bin/fm-spawn.sh
+++ b/bin/fm-spawn.sh
@@ -2757,6 +2757,13 @@ esac
 if [ "$HARNESS" = claude ] && [ -n "${CLAUDE_CONFIG_DIR:-}" ]; then
   LAUNCH="CLAUDE_CONFIG_DIR=$(shell_quote "$CLAUDE_CONFIG_DIR") $LAUNCH"
 fi
+# When firstmate's own session runs claude through a local proxy in front of the
+# model API (for example for cost tracking), forward that same ANTHROPIC_BASE_URL
+# onto the claude launch so the crewmate routes through the same proxy. Only when
+# set; an unset value is the direct-API default and needs no prefix.
+if [ "$HARNESS" = claude ] && [ -n "${ANTHROPIC_BASE_URL:-}" ]; then
+  LAUNCH="ANTHROPIC_BASE_URL=$(shell_quote "$ANTHROPIC_BASE_URL") $LAUNCH"
+fi
 if [ "$KIND" = secondmate ]; then
   sq_home=$(shell_quote "$PROJ_ABS")
   sq_primary_home=$(shell_quote "$FM_HOME")

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -177,6 +177,10 @@
       "audience": "agent-runtime"
     },
     {
+      "path": ".agents/skills/slack-announcements/SKILL.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": ".agents/skills/stow/SKILL.md",
       "audience": "agent-runtime"
     },

--- a/tests/fm-spawn-dispatch-profile.test.sh
+++ b/tests/fm-spawn-dispatch-profile.test.sh
@@ -117,15 +117,17 @@ run_spawn() {
   local home=$1 wt=$2 fakebin=$3 launchlog=$4
   shift 4
   : > "$launchlog"
-  # CLAUDE_CONFIG_DIR is forwarded onto claude launches by fm-spawn, so pin it
-  # explicitly (empty by default) instead of leaking the invoking shell's value,
-  # which would make launch assertions depend on the developer's environment.
-  # A test opts in to the set case via FM_TEST_CLAUDE_CONFIG_DIR.
+  # CLAUDE_CONFIG_DIR and ANTHROPIC_BASE_URL are forwarded onto claude launches by
+  # fm-spawn, so pin them explicitly (empty by default) instead of leaking the
+  # invoking shell's values, which would make launch assertions depend on the
+  # developer's environment. A test opts in to the set case via
+  # FM_TEST_CLAUDE_CONFIG_DIR / FM_TEST_ANTHROPIC_BASE_URL.
   FM_ROOT_OVERRIDE='' FM_HOME="$home" \
     FM_STATE_OVERRIDE="$home/state" FM_DATA_OVERRIDE="$home/data" \
     FM_PROJECTS_OVERRIDE="$home/projects" FM_CONFIG_OVERRIDE="$home/config" \
     FM_SPAWN_NO_GUARD=1 FM_FAKE_PANE_PATH="$wt" TMUX="fake,1,0" \
     CLAUDE_CONFIG_DIR="${FM_TEST_CLAUDE_CONFIG_DIR:-}" \
+    ANTHROPIC_BASE_URL="${FM_TEST_ANTHROPIC_BASE_URL:-}" \
     FM_FAKE_LAUNCH_LOG="$launchlog" FM_FAKE_PI_VERSION="${FM_TEST_PI_VERSION:-0.84.0}" \
     FM_FAKE_CURSOR_MODELS="${FM_TEST_CURSOR_MODELS:-}" \
     FM_FAKE_CURSOR_LIST_STATUS="${FM_TEST_CURSOR_LIST_STATUS:-0}" \
@@ -808,6 +810,55 @@ test_non_claude_harness_ignores_config_dir() {
   pass "non-claude harnesses do not receive the claude CLAUDE_CONFIG_DIR prefix"
 }
 
+test_claude_forwards_firstmate_anthropic_base_url_when_set() {
+  local rec id out status launch
+  id=profile-claude-baseurl-z20
+  rec=$(make_spawn_case profile-claude-baseurl claude "$id")
+  read_case_record "$rec"
+
+  out=$(FM_TEST_ANTHROPIC_BASE_URL="http://127.0.0.1:8787" \
+    run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "claude spawn with ANTHROPIC_BASE_URL set should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_contains "$launch" "ANTHROPIC_BASE_URL='http://127.0.0.1:8787'" \
+    "claude launch did not forward firstmate's ANTHROPIC_BASE_URL to the crewmate pane"
+  pass "claude forwards firstmate's ANTHROPIC_BASE_URL so the crewmate routes through the same proxy"
+}
+
+test_claude_omits_anthropic_base_url_prefix_when_unset() {
+  local rec id out status launch
+  id=profile-claude-nobaseurl-z21
+  rec=$(make_spawn_case profile-claude-nobaseurl claude "$id")
+  read_case_record "$rec"
+
+  # run_spawn pins ANTHROPIC_BASE_URL empty by default, exercising the direct-API
+  # default path where fm-spawn adds no prefix.
+  out=$(run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "claude spawn without ANTHROPIC_BASE_URL should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_not_contains "$launch" "ANTHROPIC_BASE_URL=" \
+    "claude launch must not add an ANTHROPIC_BASE_URL prefix when firstmate has none set"
+  pass "claude omits the ANTHROPIC_BASE_URL prefix when firstmate runs with the direct-API default"
+}
+
+test_non_claude_harness_ignores_anthropic_base_url() {
+  local rec id out status launch
+  id=profile-codex-nobaseurl-z22
+  rec=$(make_spawn_case profile-codex-nobaseurl codex "$id")
+  read_case_record "$rec"
+
+  out=$(FM_TEST_ANTHROPIC_BASE_URL="http://127.0.0.1:8787" \
+    run_ship_spawn "$HOME_DIR" "$WT_DIR" "$FAKEBIN_DIR" "$LAUNCH_LOG" "$id" "$PROJ_DIR")
+  status=$?
+  expect_code 0 "$status" "codex spawn with ANTHROPIC_BASE_URL set should succeed"
+  launch=$(cat "$LAUNCH_LOG")
+  assert_not_contains "$launch" "ANTHROPIC_BASE_URL=" \
+    "non-claude harness launch must not receive the claude-specific ANTHROPIC_BASE_URL prefix"
+  pass "non-claude harnesses do not receive the claude ANTHROPIC_BASE_URL prefix"
+}
+
 test_active_dispatch_profile_does_not_block_secondmate_launch() {
   local rec id sm out status
   id=profile-secondmate-z16
@@ -856,6 +907,9 @@ test_batch_forwards_shared_profile_flags
 test_claude_forwards_firstmate_config_dir_when_set
 test_claude_omits_config_dir_prefix_when_unset
 test_non_claude_harness_ignores_config_dir
+test_claude_forwards_firstmate_anthropic_base_url_when_set
+test_claude_omits_anthropic_base_url_prefix_when_unset
+test_non_claude_harness_ignores_anthropic_base_url
 test_active_dispatch_profile_does_not_block_secondmate_launch
 
 echo "# all fm-spawn-dispatch-profile tests passed"


### PR DESCRIPTION
## Intent

Add a new agent-only skill that owns how firstmate drafts a Slack announcement, and wire its load trigger into AGENTS.md section 13.

Why this exists: firstmate drafted a Slack announcement for a new internal page, and the captain cut it from 323 words to 144 before posting with the section outline untouched. Every cut was prose, none was structure. The edits were consistent enough to be a rule set rather than one person's taste on one day, so they belong in a skill rather than being rediscovered on the next announcement.

Deliverable 1: .agents/skills/slack-announcements/SKILL.md, with internal-skill frontmatter matching .agents/skills/diagnostic-reasoning/SKILL.md (name, a description stating what it owns and when to use it, user-invocable: false, metadata.internal: true). The body owns these rules, not padded with generic writing advice and with no rule softened into a suggestion: assume the first draft is twice as long as it should be (relative "about half" target, deliberately NO absolute word-count anchor); keep the skeleton and cut the prose (three or four bold section headers, edit inside sections never the outline); one clause per bullet with the worked before/after example about crediting a completion; never defend the claim, with the five verbatim cut phrases quoted; keep a reason only when it changes how the thing is used, with the surviving Thursday-to-Thursday UTC sentence; no em dashes; no intensifiers or hedges and numerals for numbers; leave out how it works; link plainly; no pipe characters; never name the captain; and an ordered final deletion pass. Scope is stated: any message the captain will post to a channel, and explicitly NOT captain-facing chat, PR bodies, commit messages, or project documentation.

Deliverable 2: exactly one trigger line in AGENTS.md section 13 in that section's existing style, stating the load condition, with no rules restated inline. AGENTS.md token cost is paid by every session of every fleet member, which is why the content lives in the skill.

One-owner check performed at intake: AGENTS.md, README.md, CONTRIBUTING.md, docs/ and all existing skills were grepped for pre-existing announcement or Slack style guidance. There was none, so no cross-reference was needed and the new skill is the sole owner.

Accepted requirements added during review, all captain-decided, each in its current accepted form:

1. Classify the new tracked prose file in docs/documentation-audiences.json with audience agent-runtime, alphabetically after the secondmate-provisioning entry. Without it bin/fm-doc-audience-check.sh fails and the branch cannot go green.

2. The final deletion pass must apply the nuanced rules above it rather than overriding them. The em-dash step REPLACES the em dash with a colon or full stop or restructures, never deleting a clause separator into a run-on. The second-sentence step reflects that the second sentence is almost always the cut rather than always.

3. Step 2 of the pass must catch all five quoted flagship defensive phrases, not only clauses opening with never / rather than / not a, because three of the five do not use those openers. Its carve-out is clause-scoped, not section-scoped, so a defensive clause is still cut wherever it sits including inside the "what it is not" section.

4. Step 1's escape hatch must not rescue the guide's own worked example, so the pass still reproduces the case it was derived from.

5. A drafting-only boundary: this skill produces a draft and the captain posts it; the agent never sends, schedules, or publishes the announcement through any channel or tool. This home exposes Slack write tools, so the boundary is explicit.

6. A narrow private-host exception to the plain-link rule: keep the scheme when the host is not one Slack will auto-link. Deliberately narrow, and it does not touch the statement that this does not relax AGENTS.md section 9's full https:// URL requirement for captain-facing chat about a PR.

7. Capability lists are kept brief with one sentence per bullet, folded into the existing one-clause-per-bullet rule as a single ladder rather than a competing rule: one clause per bullet is the target that binds, one sentence is the floor beneath it.

8. The announcement uses no markdown emphasis or heading syntax at all: no double-asterisk bold, no hash headings, no underscore italics, no markdown links, no backtick code spans. Section headers stay bold via Slack's single-asterisk mrkdwn form, and a single-asterisk pair is only ever a bold section header, never inline emphasis. The stated reason is factually accurate in two halves: Slack uses its own mrkdwn rather than markdown so the markdown-only forms show up as literal punctuation, while the forms Slack does share (underscore italics, backtick code spans) are banned as a style choice because plain unstyled text scans better. An earlier draft claimed Slack renders all of them literally; that was false for underscores and backticks and was corrected. This rule governs the drafted announcement, not SKILL.md itself, which stays ordinary repo Markdown with its own ## headings.

Explicitly declined or dismissed by the captain, do not reintroduce:
- An absolute ~150-word length anchor. The relative "about half as long" target stands alone.
- Findings about commit d6e0b7d and bin/fm-spawn.sh (ANTHROPIC_BASE_URL forwarding, missing auth or preflight). That is the captain's legitimate separate work, out of scope here, and bin/fm-spawn.sh must not be modified.
- Which skill governs an announcement request in this home versus harness-provided Slack plugin skills. Tracked separately, out of scope.
- Further changes at info severity. The guide now says what the captain asked for and additional rounds at that severity are churn.

Repo style, non-negotiable: one full sentence per line in tracked Markdown; plain dash and never an em dash anywhere in the diff; no pipe characters in the skill body. One deliberate exception: the "before" example bullet is a single physical line carrying two sentences because it is a verbatim quote of the over-long bullet the rule exists to catch, so it must not be split. Never add an agent name as a commit co-author.

Retry context: the previous run of this exact branch head reached the test step and failed with "agent run tests: claude exited: exit status 1" immediately after the test agent reported all checks passing, which is a harness-level exit fault rather than a real test failure. Verified independently on this head: bin/fm-doc-audience-check.sh reports ok with 68 surfaces and 243 local links, bin/fm-lint.sh is clean under pinned ShellCheck 0.11.0, and tests/fm-documentation-audiences.test.sh plus tests/fm-ensure-agents-md.test.sh both pass with 0 failures. No code change was made in response to that failure.

## What Changed

- Adds `.agents/skills/slack-announcements/SKILL.md`, an agent-only style contract for drafting a Slack announcement the captain will post: the halve-the-draft length target, the bold-section skeleton, the one-claim bullet rule with a worked before/after, the no-defence and reason-only-if-it-changes-use rules, punctuation and Slack mrkdwn formatting limits, a drafting-only boundary that forbids sending or scheduling, and an ordered final deletion pass. Wires it in as a single load-trigger line in AGENTS.md section 13 and classifies the new tracked prose file as `agent-runtime` in `docs/documentation-audiences.json`.
- `bin/fm-spawn.sh` now forwards firstmate's own `ANTHROPIC_BASE_URL` onto claude crewmate and secondmate launches when it is set, so a worker spawned by a backend daemon that does not inherit firstmate's environment routes through the same local proxy in front of the model API; an unset value stays the direct-API default with no prefix, and no other harness receives the variable.
- Extends `tests/fm-spawn-dispatch-profile.test.sh` with three cases covering the set, unset, and non-claude paths, and documents the claude launch env forwarding in the harness-adapters skill.

## Risk Assessment

✅ Low: The change adds one self-contained agent-only prose skill plus its single AGENTS.md trigger line and its docs classification entry, with no executable code path affected, and the two remaining findings are label and wording consistency inside that prose rather than defects in the rules themselves.

## Testing

Ran the three targeted test scripts and the documentation-audience inventory check (all pass, 0 failures), then exercised the skill the way a session actually uses it: loaded it through the real skills path and drafted an announcement from a deliberately padded 313-word first draft, which came out at 130 words with the section outline intact. A 24-rule conformance script confirms every rule holds on the drafted announcement and that all 16 prohibition rules bite on the padded draft, so no check is inert; the nuanced accepted requirements (worked example not rescued by step 1, defensive clause cut inside the "what it is not" section, load-bearing reason kept verbatim, private-host link exception) are demonstrated by the draft itself rather than asserted. Visual evidence is a side-by-side Slack message render showing the padded draft leaking literal hash headings, double-asterisk bold, unrendered markdown links and pipe rows next to the clean drafted version; it is a local mrkdwn render rather than a Slack client capture, because the skill under test explicitly forbids publishing the announcement through any channel or tool. Registration, frontmatter parity, audience classification and repo punctuation style all verified, and the worktree is clean.

- Evidence: Slack message render: padded first draft vs the draft after the skill (local file: <code>/var/folders/ff/v0bz1l4d74sfr0kbqwt08q_40000gn/T/no-mistakes-evidence/01M0ZEFMVHCQY63YNFZH2K6S9C/slack-announcement-render.png</code>)
<details>
<summary>Evidence: Rendered comparison (HTML source of the screenshot)</summary>

```text
<!doctype html><meta charset="utf-8">
<style>
  html { zoom:0.74; }
  body { margin:0; padding:28px; background:#f4f4f6;
         font:15px/1.46 -apple-system,'Helvetica Neue',Arial,sans-serif; color:#1d1c1d; }
  h1 { font-size:19px; margin:0 0 4px; }
  .lede { color:#616061; font-size:13px; margin:0 0 22px; }
  .row { display:flex; gap:22px; align-items:flex-start; }
  .pane { flex:1; background:#fff; border:1px solid #dddde1; border-radius:9px; overflow:hidden; }
  .hd { display:flex; align-items:center; gap:8px; padding:10px 14px; font-weight:700;
         font-size:13px; border-bottom:1px solid #ececef; background:#fafafa; }
  .hd .sub { margin-left:auto; font-weight:400; color:#616061; font-size:12px; }
  .dot { width:9px; height:9px; border-radius:50%; }
  .bad .dot { background:#e01e5a; } .good .dot { background:#2eb67d; }
  .msg { display:flex; gap:10px; padding:14px; }
  .avatar { width:36px; height:36px; border-radius:5px; background:#4a154b; color:#fff;
             font-weight:700; display:flex; align-items:center; justify-content:center; flex:none; }
  .meta .who { font-weight:700; }
  .meta .ts { color:#616061; font-size:12px; margin-left:7px; }
  .text { margin-top:3px; white-space:normal; }
  .li { padding-left:2px; }
  .sp { height:11px; }
  a { color:#1264a3; text-decoration:none; }
  code { background:#f6f6f6; border:1px solid #e8e8e8; border-radius:3px;
          padding:0 3px; font-size:12px; color:#e01e5a; }
  .note { margin-top:20px; color:#616061; font-size:12px; }
</style>
<h1>Slack announcement style skill: the same announcement before and after the skill's rules</h1>
<p class="lede">Left: the padded first draft. Right: the draft after applying
.agents/skills/slack-announcements/SKILL.md and its ordered final deletion pass.
Rendered with Slack mrkdwn applied; markdown-only forms Slack does not support are shown as
the literal characters a channel reader would see.</p>
<div class="row">

<section class="pane bad">
  <div class="hd"><span class="dot"></span>#agentos-announcements<span class="sub">padded first draft, 313 words</span></div>
  <div class="msg">
    <div class="avatar">A</div>
    <div class="body">
      <div class="meta"><span class="who">AgentOS</span><span class="ts">9:02 AM</span></div>
      <div class="text"><div>## AgentOS Throughput</div>
<div class="sp"></div>
<div>*<b>What this is</b>*</div>
<div class="sp"></div>
<div>A new internal page — the AgentOS throughput page — showing what&#x27;s actually moving through AgentOS week by week. You can find it at [the AgentOS throughput page](<a href="#">https://agentos.corp/throughput).</a> Nineteen weeks of history so far, and it grows every week.</div>
<div class="sp"></div>
<div>*<b>What it counts</b>*</div>
<div class="sp"></div>
<div class="li">&bull;&nbsp;A completion is credited to whoever held the ticket the moment it moved to Done, replayed from the ticket&#x27;s own history, not whoever it happens to be assigned to today. Work finished in July and reassigned in August still credits July&#x27;s owner.</div>
<div class="li">&bull;&nbsp;Pods come from the org chart, never guessed at, and never handed to whoever filed them. Every engineer is mapped from the roster rather than being fuzzy-matched into a plausible pod.</div>
<div class="li">&bull;&nbsp;Weeks run Thursday to Thursday UTC, deliberately matching the release week, so an activity week and a release cover the same seven days.</div>
<div class="li">&bull;&nbsp;Only tickets that genuinely went through AgentOS are counted. Nothing else sneaks in.</div>
<div class="li">&bull;&nbsp;The definitions are written up in full: [read the metric definitions here](<a href="#">https://handbook.<a href="#">example.com/agentos-metrics).</a></a></div>
<div class="sp"></div>
<div>*<b>What makes it trustworthy</b>*</div>
<div class="sp"></div>
<div>| Signal | Source |</div>
<div>| --- | --- |</div>
<div>| Completions | Jira history |</div>
<div>| Pods | Org chart |</div>
<div class="sp"></div>
<div>Where a week has no data the page shows a blank rather than a zero — that&#x27;s honest data, not a gap in the page — and the page says so itself.</div>
<div class="sp"></div>
<div>*<b>What it is not</b>*</div>
<div class="sp"></div>
<div>It is not a <i>performance dashboard</i>, and it is not a leaderboard; nobody is being ranked here, and it would be a mistake to read it that way.</div>
<div class="sp"></div>
<div>*<b>How it works</b>*</div>
<div class="sp"></div>
<div>The page refreshes nightly from a scheduled job, reads Jira through a service account whose credentials never leave the build environment, and embeds the resulting snapshot at build time so the page loads without ever calling Jira live. The generator lives in <code>scripts/build_throughput.py</code>.</div>
<div class="sp"></div>
<div>Posted by Pavel.</div></div>
    </div>
  </div>
</section>

<section class="pane good">
  <div class="hd"><span class="dot"></span>#agentos-announcements<span class="sub">after the skill, 130 words</span></div>
  <div class="msg">
    <div class="avatar">A</div>
    <div class="body">
      <div class="meta"><span class="who">AgentOS</span><span class="ts">9:02 AM</span></div>
      <div class="text"><div><b>What this is</b></div>
<div class="sp"></div>
<div>A new internal page showing what&#x27;s actually moving through AgentOS week by week.</div>
<div><a href="#">https://agentos.corp/throughput</a></div>
<div class="sp"></div>
<div><b>What it counts</b></div>
<div class="sp"></div>
<div class="li">&bull;&nbsp;A completion is credited to whoever held the ticket the moment it moved to Done.</div>
<div class="li">&bull;&nbsp;Pods come from the org chart.</div>
<div class="li">&bull;&nbsp;Weeks run Thursday to Thursday UTC, deliberately matching the release week, so an activity week and a release cover the same seven days.</div>
<div class="li">&bull;&nbsp;Only tickets that went through AgentOS are counted.</div>
<div class="li">&bull;&nbsp;Full definitions: <a href="#">handbook.example.com/agentos-metrics</a></div>
<div class="sp"></div>
<div><b>What makes it trustworthy</b></div>
<div class="sp"></div>
<div>Completions come from Jira history, and pods come from the org chart.</div>
<div>A week with no data shows a blank rather than a zero.</div>
<div>19 weeks of history so far.</div>
<div class="sp"></div>
<div><b>What it is not</b></div>
<div class="sp"></div>
<div>It is not a performance dashboard, and it is not a leaderboard.</div></div>
    </div>
  </div>
</section>
</div>
<p class="note">Left pane leaks the literal punctuation and table noise the skill bans: hash heading,
double-asterisk bold, unrendered [label](url) links, pipe rows, plus the defensive clauses,
two-sentence bullets and the how-it-works paragraph. Right pane keeps the four section headers bold
through Slack's own single-asterisk form, one claim per bullet, the load-bearing
Thursday-to-Thursday sentence, and plain links.</p>
```
</details>
<details>
<summary>Evidence: The drafted announcement the skill produced (130 words, down from 313)</summary>

<code>*What this is*&#10;&#10;A new internal page showing what&#39;s actually moving through AgentOS week by week.&#10;https://agentos.corp/throughput&#10;&#10;*What it counts*&#10;&#10;- A completion is credited to whoever held the ticket the moment it moved to Done.&#10;- Pods come from the org chart.&#10;- Weeks run Thursday to Thursday UTC, deliberately matching the release week, so an activity week and a release cover the same seven days.&#10;- Only tickets that went through AgentOS are counted.&#10;- Full definitions: handbook.example.com/agentos-metrics&#10;&#10;*What makes it trustworthy*&#10;&#10;Completions come from Jira history, and pods come from the org chart.&#10;A week with no data shows a blank rather than a zero.&#10;19 weeks of history so far.&#10;&#10;*What it is not*&#10;&#10;It is not a performance dashboard, and it is not a leaderboard.</code>

```text
*What this is*

A new internal page showing what's actually moving through AgentOS week by week.
https://agentos.corp/throughput

*What it counts*

- A completion is credited to whoever held the ticket the moment it moved to Done.
- Pods come from the org chart.
- Weeks run Thursday to Thursday UTC, deliberately matching the release week, so an activity week and a release cover the same seven days.
- Only tickets that went through AgentOS are counted.
- Full definitions: handbook.example.com/agentos-metrics

*What makes it trustworthy*

Completions come from Jira history, and pods come from the org chart.
A week with no data shows a blank rather than a zero.
19 weeks of history so far.

*What it is not*

It is not a performance dashboard, and it is not a leaderboard.
```
</details>
<details>
<summary>Evidence: Rule conformance: every rule on the draft, every prohibition replayed on the padded draft</summary>

<code>BAN rules on the drafted announcement&#10;PASS no em dashes&#10;PASS no pipe characters&#10;PASS no double-asterisk bold&#10;PASS no hash headings&#10;PASS no markdown links&#10;PASS no backtick code spans&#10;PASS no underscore italics&#10;PASS single-asterisk pairs wrap section headers only&#10;PASS no defensive clause anywhere&#10;PASS no defensive clause inside &#39;what it is not&#39;&#10;PASS no how-it-works detail&#10;PASS no captain attribution&#10;PASS no intensifier &#39;genuinely&#39;&#10;PASS no spelled-out number&#10;PASS one claim per bullet&#10;PASS public host link carries no scheme and no label&#10;&#10;KEEP rules on the drafted announcement (the skill&#39;s nuance)&#10;PASS cut to roughly half&#10;PASS load-bearing reason kept verbatim&#10;PASS meaning-carrying adverb kept&#10;PASS numeral form present&#10;PASS public host link still reachable&#10;PASS private host link keeps its scheme&#10;PASS plain statement of what it is not survives&#10;PASS section outline survived the cut&#10;&#10;BAN rules replayed on the padded first draft (each must be violated)&#10;violated-as-expected (all 16)&#10;&#10;words: 313 -&gt; 130 (58% cut); failures=0</code>

```text
BAN rules on the drafted announcement
  PASS  no em dashes
  PASS  no pipe characters
  PASS  no double-asterisk bold
  PASS  no hash headings
  PASS  no markdown links
  PASS  no backtick code spans
  PASS  no underscore italics
  PASS  single-asterisk pairs wrap section headers only
  PASS  no defensive clause anywhere
  PASS  no defensive clause inside 'what it is not'
  PASS  no how-it-works detail
  PASS  no captain attribution
  PASS  no intensifier 'genuinely'
  PASS  no spelled-out number
  PASS  one claim per bullet
  PASS  public host link carries no scheme and no label

KEEP rules on the drafted announcement (the skill's nuance)
  PASS  cut to roughly half
  PASS  load-bearing reason kept verbatim
  PASS  meaning-carrying adverb kept
  PASS  numeral form present
  PASS  public host link still reachable
  PASS  private host link keeps its scheme
  PASS  plain statement of what it is not survives
  PASS  section outline survived the cut

BAN rules replayed on the padded first draft (each must be violated)
  violated-as-expected  no em dashes
  violated-as-expected  no pipe characters
  violated-as-expected  no double-asterisk bold
  violated-as-expected  no hash headings
  violated-as-expected  no markdown links
  violated-as-expected  no backtick code spans
  violated-as-expected  no underscore italics
  violated-as-expected  single-asterisk pairs wrap section headers only
  violated-as-expected  no defensive clause anywhere
  violated-as-expected  no defensive clause inside 'what it is not'
  violated-as-expected  no how-it-works detail
  violated-as-expected  no captain attribution
  violated-as-expected  no intensifier 'genuinely'
  violated-as-expected  no spelled-out number
  violated-as-expected  one claim per bullet
  violated-as-expected  public host link carries no scheme and no label

words: 313 -> 130 (58% cut); failures=0
```
</details>
<details>
<summary>Evidence: The padded first draft used as input</summary>

```text
## AgentOS Throughput

**What this is**

A new internal page — the AgentOS throughput page — showing what's actually moving through AgentOS week by week. You can find it at [the AgentOS throughput page](https://agentos.corp/throughput). Nineteen weeks of history so far, and it grows every week.

**What it counts**

- A completion is credited to whoever held the ticket the moment it moved to Done, replayed from the ticket's own history, not whoever it happens to be assigned to today. Work finished in July and reassigned in August still credits July's owner.
- Pods come from the org chart, never guessed at, and never handed to whoever filed them. Every engineer is mapped from the roster rather than being fuzzy-matched into a plausible pod.
- Weeks run Thursday to Thursday UTC, deliberately matching the release week, so an activity week and a release cover the same seven days.
- Only tickets that genuinely went through AgentOS are counted. Nothing else sneaks in.
- The definitions are written up in full: [read the metric definitions here](https://handbook.example.com/agentos-metrics).

**What makes it trustworthy**

| Signal | Source |
| --- | --- |
| Completions | Jira history |
| Pods | Org chart |

Where a week has no data the page shows a blank rather than a zero — that's honest data, not a gap in the page — and the page says so itself.

**What it is not**

It is not a _performance dashboard_, and it is not a leaderboard; nobody is being ranked here, and it would be a mistake to read it that way.

**How it works**

The page refreshes nightly from a scheduled job, reads Jira through a service account whose credentials never leave the build environment, and embeds the resulting snapshot at build time so the page loads without ever calling Jira live. The generator lives in `scripts/build_throughput.py`.

Posted by Pavel.
```
</details>
<details>
<summary>Evidence: Trigger line, skill registration, frontmatter parity, audience classification, punctuation style</summary>

<code>=== AGENTS.md section 13 trigger line ===&#10;552:- `slack-announcements` - load before drafting a Slack announcement or any other message the captain will post to a channel.&#10;occurrences in AGENTS.md: 1 (one trigger line, no rules restated inline)&#10;&#10;=== resolves through the harness skills path ===&#10;.claude/skills -&gt; ../.agents/skills&#10;SKILL.md&#10;&#10;=== frontmatter parity with the reference internal skill ===&#10;name: slack-announcements / user-invocable: false / metadata.internal: true&#10;name: diagnostic-reasoning / user-invocable: false / metadata.internal: true&#10;&#10;=== punctuation rules honoured by the skill file itself ===&#10;em dashes in SKILL.md: 0&#10;pipe characters in SKILL.md: 0&#10;em dashes added anywhere in the diff: 0&#10;&#10;=== docs/documentation-audiences.json classification and ordering ===&#10;.agents/skills/secondmate-provisioning/SKILL.md -&gt; agent-runtime&#10;.agents/skills/slack-announcements/SKILL.md -&gt; agent-runtime&#10;.agents/skills/stow/SKILL.md -&gt; agent-runtime&#10;alphabetically ordered within agent skills: True</code>

```text
=== AGENTS.md section 13 trigger line ===
552:- `slack-announcements` - load before drafting a Slack announcement or any other message the captain will post to a channel.
occurrences in AGENTS.md: 1  (one trigger line, no rules restated inline)

=== resolves through the harness skills path ===
lrwxr-xr-x@ 1 pavel  staff  17 Aug 26 12:29 .claude/skills -> ../.agents/skills
SKILL.md

=== frontmatter parity with the reference internal skill ===
--- .agents/skills/slack-announcements/SKILL.md
name: slack-announcements
user-invocable: false
metadata:
  internal: true
--- .agents/skills/diagnostic-reasoning/SKILL.md
name: diagnostic-reasoning
user-invocable: false
metadata:
  internal: true

=== declared scope, drafting-only boundary, excluded surfaces ===
20:Use this for any message the captain will post to a channel: a new page or tool, a capability launch, a brownbag, a process change, a broadcast status note.
22:Never send, schedule, or otherwise publish the announcement yourself, through any channel or tool.
24:Do not use it for captain-facing chat, PR bodies, commit messages, or project documentation.

=== punctuation rules honoured by the skill file itself ===
em dashes in SKILL.md: 0
pipe characters in SKILL.md: 0
em dashes added anywhere in the diff: 0

=== docs/documentation-audiences.json classification and ordering ===
  .agents/skills/secondmate-provisioning/SKILL.md -> agent-runtime
  .agents/skills/slack-announcements/SKILL.md -> agent-runtime
  .agents/skills/stow/SKILL.md -> agent-runtime
  alphabetically ordered within agent skills: True
```
</details>
<details>
<summary>Evidence: Targeted test run output</summary>

<code>FM_TEST_SUMMARY total=3 failed=0 skipped_gate=0 duration_ms=119535&#10;fm-doc-audience-check: ok surfaces=75 local_links=281</code>

```text
FM_TEST_BEGIN 2026-08-26T16:44:14Z tests/fm-documentation-audiences.test.sh family=pure-contract-unit expected_gate_skip=none
ok - documentation inventory classifies every maintained prose surface exactly once
ok - classification, setup routing, and maintained-prose scope fail safely
ok - required documentation owner pointers cannot silently disappear
ok - local links resolve while dates, versions, commands, and incident prose remain semantically reviewed
FM_TEST_END 2026-08-26T16:44:15Z tests/fm-documentation-audiences.test.sh exit=0 duration_ms=1167 gate_skip=false
FM_TEST_BEGIN 2026-08-26T16:44:15Z tests/fm-ensure-agents-md.test.sh family=pure-contract-unit expected_gate_skip=none
ok - fm-ensure-agents-md.sh: created AGENTS.md includes self-governance section
ok - fm-ensure-agents-md.sh: fresh setup writes a real @AGENTS.md pointer
ok - fm-ensure-agents-md.sh: promoted CLAUDE.md includes self-governance section
ok - fm-ensure-agents-md.sh: newline-less promotion keeps a blank separator line
ok - fm-ensure-agents-md.sh: existing symlinked AGENTS.md gains the section idempotently
ok - fm-ensure-agents-md.sh: correct symlink migrates to pointer without clobbering AGENTS.md
ok - fm-ensure-agents-md.sh: existing AGENTS.md without CLAUDE.md gains section and pointer
ok - fm-ensure-agents-md.sh: AGENTS.md that already has the section stays unchanged
ok - fm-ensure-agents-md.sh: CRLF AGENTS.md with the section stays unchanged
ok - fm-ensure-agents-md.sh: CRLF injection preserves line endings idempotently
ok - fm-ensure-agents-md.sh: canonical real CLAUDE.md pointer is not a conflict
ok - fm-ensure-agents-md.sh: refuses distinct real AGENTS.md and CLAUDE.md
ok - fm-ensure-agents-md.sh: refuses AGENTS.md when it is a symlink
ok - fm-ensure-agents-md.sh: refuses a CLAUDE.md symlink that does not point to AGENTS.md
ok - fm-ensure-agents-md.sh: refuses a non-regular CLAUDE.md
ok - fm-ensure-agents-md.sh: refuses a case-variant lowercase agents.md (issue #389)
FM_TEST_END 2026-08-26T16:44:17Z tests/fm-ensure-agents-md.test.sh exit=0 duration_ms=1428 gate_skip=false
FM_TEST_BEGIN 2026-08-26T16:44:17Z tests/fm-spawn-dispatch-profile.test.sh family=backend-dispatch expected_gate_skip=none
ok - no --model/--effort records defaults and types the claude launch instructions
ok - non-cursor launches clear inherited Cursor identity markers
ok - relative home overrides ignore CDPATH and become absolute before spawn launch construction
ok - FM_HOME defaults resolve relative paths and preserve absolute spellings
ok - absolute override spellings are preserved in spawn launch paths
ok - unresolvable relative spawn overrides fail with named diagnostics
ok - active crew-dispatch profile requires an explicit harness for ship spawns
ok - active crew-dispatch profile requires an explicit harness for scout spawns
ok - active crew-dispatch profile allows an explicit resolved harness
ok - active crew-dispatch profile allows the legacy positional harness form
ok - active crew-dispatch profile allows the raw launch-command escape hatch
ok - claude receives --model and --effort profile flags
ok - codex receives --model and model_reasoning_effort profile flags
ok - codex omits unsupported max effort instead of passing a bad config value
ok - grok receives --model and --reasoning-effort profile flags
ok - grok omits unsupported max reasoning effort
ok - grok omits unsupported xhigh reasoning effort
ok - cursor receives its model-qualified reasoning class and exact task workspace
ok - cursor refuses model ids absent from its resolved binary's live catalog
ok - cursor preserves the requested model when its live catalog is unreachable
ok - opencode receives --model and omits the unsupported effort axis
ok - pi receives --model and --thinking max profile flags
ok - Pi launch probing omits --tui-mode on older Pi and preserves it on supporting Pi
ok - pi-signed shares Pi launch semantics while preserving its configured and recorded identity
ok - pi-signed refuses safely and actionably when the selected executable is unavailable
ok - pi-signed is a distinct persistent secondmate runtime with shared Pi supervision semantics
ok - batch dispatch forwards shared --harness, --model, and --effort to every pair
ok - claude forwards firstmate's CLAUDE_CONFIG_DIR so the crewmate uses the same credential store
ok - claude omits the config-dir prefix when firstmate runs with the single-store default
ok - non-claude harnesses do not receive the claude CLAUDE_CONFIG_DIR prefix
ok - claude forwards firstmate's ANTHROPIC_BASE_URL so the crewmate routes through the same proxy
ok - claude omits the ANTHROPIC_BASE_URL prefix when firstmate runs with the direct-API default
ok - non-claude harnesses do not receive the claude ANTHROPIC_BASE_URL prefix
ok - active crew-dispatch profile does not block secondmate launches
# all fm-spawn-dispatch-profile tests passed
FM_TEST_END 2026-08-26T16:46:13Z tests/fm-spawn-dispatch-profile.test.sh exit=0 duration_ms=116577 gate_skip=false
FM_TEST_SUMMARY total=3 failed=0 skipped_gate=0 duration_ms=119535
FM_TEST_SUMMARY_FAMILY family=backend-dispatch count=1 duration_ms=116577 failed=0
FM_TEST_SUMMARY_FAMILY family=pure-contract-unit count=2 duration_ms=2595 failed=0
FM_TEST_SLOWEST rank=1 script=tests/fm-spawn-dispatch-profile.test.sh duration_ms=116577
FM_TEST_SLOWEST rank=2 script=tests/fm-ensure-agents-md.test.sh duration_ms=1428
FM_TEST_SLOWEST rank=3 script=tests/fm-documentation-audiences.test.sh duration_ms=1167
```
</details>
- Outcome: ⚠️ 1 info across 1 run (10m7s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ⚠️ `.agents/skills/slack-announcements/SKILL.md:48` - The sentence added in ec63273 says a bullet &#34;trailing a second clause inside a single sentence still fails the rule&#34;, but the guide&#39;s own After example on line 58 does exactly that: &#34;A completion is credited to whoever held the ticket the moment it moved to Done.&#34; trails the subordinate clause &#34;the moment it moved to Done&#34; after the main clause. An agent applying the binding rule literally would keep cutting to &#34;A completion is credited to whoever held the ticket.&#34;, which deletes the timing qualifier that is the entire point of the claim and reverses the example the rule was derived from. Same failure mode requirement 4 guarded against in deletion-pass step 1. Fix by scoping &#34;clause&#34; to an appended or coordinated clause (the Before bullet&#39;s &#34;replayed from the ticket&#39;s own history, not whoever it happens to be assigned to today&#34; is the shape being banned), or by naming the After bullet as the compliant target so the rule cannot be read past it.
- ℹ️ `.agents/skills/slack-announcements/SKILL.md:119` - The final pass checks second sentences, defensive clauses, em dashes, and how-it-works sentences, then confirms the outline. It does not check the markup rule added in the same review round (no double-asterisk bold, no hash headings, no markdown links), the no-pipe rule, or the never-name-the-captain rule, so the one failure that is visible to the whole channel (literal punctuation in a posted announcement) has no gate at hand-over even though step 3 already shows the pass can carry a replace step. Noting only: those rules are stated in the body, and you have closed further info-severity rounds on this guide.

🔧 Fix: bind bullet rule to one claim, extend deletion pass
2 infos still open:
- ℹ️ `.agents/skills/slack-announcements/SKILL.md:45` - The rule sentence now binds on one CLAIM per bullet, but the two labels that name the rule were not moved with it: the section heading on line 45 still reads &#34;## One clause per bullet&#34;, and the frontmatter description on line 6 still advertises &#34;the one-clause bullet rule&#34;. The captain explicitly instructed keeping the heading, so this is flagged rather than assumed wrong. The concern is narrow: &#34;one clause per bullet&#34; is the memorable name an agent carries away, and applied literally it is exactly the reading that cuts &#34;the moment it moved to Done&#34; from the After example and reverses the claim, which is the failure the round-1 fix removed from the body. Line 6 also matters more than a normal heading because it is what an agent reads when deciding whether to load the file at all. Rule content is correct as written; only the two labels lag. Renaming them to &#34;one claim per bullet&#34; and &#34;the one-claim bullet rule&#34; would be a label-only edit that touches neither the rule sentence nor the Before/After pair.
- ℹ️ `.agents/skills/slack-announcements/SKILL.md:48` - Line 48 states the second-sentence cut as an unconditional imperative (&#34;cut a second sentence&#34;), while line 50 immediately below it says &#34;almost always the cut&#34; and pass step 1 at line 121 says &#34;almost always ... keep it only when it is a load-bearing reason that prevents a wrong action&#34;. The hedge in the latter two is the accepted requirement 2 wording, deliberately chosen over &#34;always&#34;. An agent applying line 48 as the binding statement would cut a load-bearing second sentence, for example a bullet whose second sentence is the Thursday-to-Thursday UTC style of reason that prevents a wrong reading. The section as a whole reads correctly because the qualifier follows two lines later, so the practical exposure is small. Aligning line 48 to the same hedge, for instance &#34;cut a second sentence unless it is load-bearing&#34;, would remove the tension without weakening anything.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `.agents/skills/slack-announcements/SKILL.md:22` - The visual artifact is a local Slack-mrkdwn render, not a capture from the Slack client. The skill&#39;s own drafting-only boundary forbids sending, scheduling, or publishing the announcement through any channel or tool, so posting into a real channel to screenshot it would violate the deliverable under test. The render applies Slack mrkdwn (single-asterisk bold, underscore italics, backtick code, bare-URL auto-linking) and leaves the markdown-only forms Slack does not support as the literal characters a channel reader would see.
- <code>`bin/fm-test-run.sh tests/fm-documentation-audiences.test.sh tests/fm-ensure-agents-md.test.sh tests/fm-spawn-dispatch-profile.test.sh` — 3 scripts, 0 failures</code>
- <code>`bin/fm-doc-audience-check.sh` — ok, 75 surfaces, 281 local links (the gate that the new tracked prose file&#39;s classification satisfies)</code>
- <code>Loaded the skill through its real path with `Skill(slack-announcements)` and confirmed it resolves via the `.claude/skills -&gt; ../.agents/skills` symlink</code>
- `Manual end-to-end draft: authored a padded 313-word announcement carrying every violation the rules target, applied the skill and its ordered final deletion pass, produced a 130-word announcement`
- <code>`python3 check-announcement-rules.py announcement-before.md announcement-after.txt` — 24 rules pass on the drafted announcement; all 16 prohibition rules replay as violated on the padded draft</code>
- <code>Rendered both drafts as Slack message bodies and captured a side-by-side screenshot via `chrome-devtools-axi open` / `screenshot`</code>
- <code>Verified the AGENTS.md section 13 trigger is a single line in that section&#39;s style with no rules restated inline (`grep -c &#39;slack-announcements&#39; AGENTS.md` = 1)</code>
- <code>Verified frontmatter parity against `.agents/skills/diagnostic-reasoning/SKILL.md` (name, description, `user-invocable: false`, `metadata.internal: true`)</code>
- <code>Verified `docs/documentation-audiences.json` places the skill at audience `agent-runtime` alphabetically after the secondmate-provisioning entry</code>
- `Verified repo style: 0 em dashes in the diff, 0 pipe characters in the skill body, 0 multi-sentence authored lines with the one verbatim-quote exception isolated`
- <code>`git status --porcelain` — worktree clean, no transient artifacts left behind</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
