### PR TITLE
feat(specialists): add intentional-design checklists to pipeline packs

### DIFF
--- a/data/specialists/frontend.md
+++ b/data/specialists/frontend.md
@@ -1,0 +1,54 @@
+# Frontend specialist (general)
+
+Prefixes: `frontend-*`, `web-*`, and project aliases such as `forge-web-*`.
+
+ADR-001: production FE implements from approved intentional design — not a default visual-polish stage.
+
+## Entry gate
+
+- Linked approved design inputs when the surface is user-facing:
+  - Product plan (`<scope>.PRD.md`) ID or path
+  - Wire design doc with **component registry**
+  - Preview PR URL when wire preview ran for this scope
+- Path ownership, delivery mode, and out-of-scope paths explicit in the brief.
+- Load **`wire-design-workflow`** when implementing from an approved wire.
+- Stop with `blocked:` when user-facing work lacks wire approval.
+- **`product-visual-*`** is not required unless the brief or captain explicitly cites a visual polish pass.
+
+## Must produce
+
+- The **frontend surface named in the brief** (paths, framework, and test commands from brief + project `AGENTS.md`).
+- UI that implements the component registry without silent redesign.
+- PR (or local-only landing) with Summary, Test plan, and How to demo.
+- Full PR URL in `done:` when shipping.
+
+## Must not
+
+- Edit backend or deploy paths the brief marks out of scope.
+- Invent components, IA, or chrome not in the approved design doc.
+- Re-implement an API that only exists on an unmerged PR — wait for merge or use a brief-named shim.
+- Treat visual polish as an implied prerequisite — wire doc + preview (when required) are the default gates.
+- Use **`chrome-devtools-axi`** on **`pipeline-*`** firstmate work (scripts, skills, docs only).
+
+## Browser evidence
+
+**Required on project work:** invoke **`/fm-frontend`** and **`chrome-devtools-axi`** — smoke every changed user-visible route before `done:`.
+
+Record routes opened and what you observed in the PR Test plan.
+CI and project test commands must be green.
+
+**Not for:** `pipeline-*` on the firstmate repo.
+
+## Intentional-design checklist (FE ship)
+
+Before coding, attest in the brief or PR that:
+
+- [ ] Approved PRD and design doc linked (preview PR when preview was required)
+- [ ] Component registry rows accounted for or explicitly out of scope
+- [ ] Demo routes match the wire preview contract or updated design doc
+- [ ] No IA or registry change without a new wire scout
+
+## Handoff
+
+No silent expand into backend or deploy.
+Follow-ups are new tasks with the right specialist prefix.

--- a/data/specialists/product-wire-preview.md
+++ b/data/specialists/product-wire-preview.md
@@ -1,0 +1,36 @@
+# Wire preview specialist pack
+
+Load with `/fm-frontend` and `wire-design-workflow` on every `product-wire-preview-*` ship.
+
+ADR-001: live stub pages are the default design review surface — not a separate visual-polish scout.
+
+## Entry gate
+
+- **Wire design approved** for this scope.
+- Linked **`data/planning/<scope>/<scope>.design-doc.md`** and **`<scope>.preview-spec.md`** (or equivalent preview section).
+- Stop with `blocked:` if either doc is missing or wire approval is not recorded.
+
+## Must produce
+
+- **Preview routes** in the project `web/` per the preview contract — stub fixtures only.
+- PR with demo URLs and a Test plan listing every route opened.
+- Evidence that mapped components render without inventing registry entries.
+
+Route and fixture schemas: load **`wire-design-workflow`** preview-contract section.
+
+## Must not
+
+- Redesign IA, chrome, or the component registry — new `product-wire-*` instead.
+- Expand into full feature ship — production scope is a follow-up `forge-web-*` / `frontend-*` task.
+- Skip tests or demo commands the project `AGENTS.md` requires for FE PRs.
+- Dispatch **`product-visual-*`** as a routine follow-up — only when the captain explicitly requests polish beyond wire + preview.
+
+## Browser evidence
+
+**Required on project work:** invoke **`chrome-devtools-axi`** — open every preview route; capture layout notes for the PR Test plan.
+
+**Not for:** `pipeline-*` on the firstmate repo.
+
+## Gate
+
+**Wire design approved** (captain signed off doc + preview pages when preview was in scope) unlocks production FE ship for the same surfaces.

--- a/data/specialists/product-wire.md
+++ b/data/specialists/product-wire.md
@@ -1,0 +1,44 @@
+# Wire design specialist pack
+
+Load with `/fm-wire`, `wire-design-workflow`, and `planning-documents` on every `product-wire-*` scout.
+
+ADR-001: this stage owns **intentional deliberate design** — not a visual-polish pass.
+
+## Entry gate
+
+- **Product plan approved** for this scope.
+- Linked **`data/planning/<scope>/<scope>.PRD.md`** in the brief.
+- Stop with `blocked:` if the PRD is missing or not yet approved.
+
+## Must produce
+
+- Canonical **`data/planning/<scope>/<scope>.design-doc.md`** with component registry, state matrix, and interaction notes.
+- **Preview contract** — section in the design doc or sibling `<scope>.preview-spec.md` when live preview is in scope (default for user-facing surfaces unless brief says doc-only).
+- Optional `<scope>.review.html` for captain review (static wireframes and decision cards).
+
+Full section schemas and registry columns: load **`wire-design-workflow`** — do not duplicate them here.
+
+## Must not
+
+- Run `lavish-axi` or post session URLs.
+- Ship production or preview application code (`product-wire-preview-*` is a separate ship).
+- Replace or fork the PRD; revise the design doc in place per singularity rules.
+- Treat **`product-visual-*`** as the default next stage — live wire preview or production ship follows when approved.
+- Use **`chrome-devtools-axi`** — wire scouts publish docs and optional static HTML, not live routes.
+
+## Intentional-design checklist (G2)
+
+Before `done:`, confirm the design doc covers:
+
+- [ ] Scope and journeys from the linked PRD; out-of-scope explicit
+- [ ] IA and chrome (nav, reading order, breakpoints)
+- [ ] Artboard index with stable IDs for every screen/state
+- [ ] State matrix (empty, loading, error, success, degraded where relevant)
+- [ ] **Component registry** — every UI unit mapped; no orphan wire boxes
+- [ ] Accessibility notes per component (not deferred to ship)
+- [ ] Preview contract filled or marked out-of-scope with reason
+- [ ] Captain decisions plain-text; handoff lists what production must not redesign
+
+## Gate
+
+Captain approves **wire design approved** (design doc + preview spec when preview was in scope) before `product-wire-preview-*` or production FE ship.

--- a/data/specialists/product.md
+++ b/data/specialists/product.md
@@ -1,0 +1,43 @@
+# Product specialist pack
+
+Load with `/fm-product` and `planning-documents` on every `product-*` scout (not `product-wire-*` / `product-visual-*`).
+
+ADR-001: intentional design path — no default visual-polish stage.
+
+## Entry gate
+
+- Brief names scope and project; read that project's committed `AGENTS.md`.
+- Optional linked `research-*` lock when a tech choice is load-bearing.
+- Stop with `blocked:` if the brief asks for wireframes, design docs, or app code.
+
+## Must produce
+
+- Canonical **PRD** at `data/planning/<scope>/<scope>.PRD.md` — strategy, MVP, JTBD, surface inventory, discovery folded in (no separate discovery scout).
+- Optional `<scope>.review.html` for captain review (static; firstmate opens in browser).
+- Punch-list row update when the scope tracks completion in `<scope>.punch-list.md`.
+- Plain-text `needs-decision:` once if needed; `done:` links the PRD path.
+
+## Must not
+
+- Run `lavish-axi` or post session URLs.
+- Ship design docs, component registries, preview routes, or application code.
+- Dispatch or imply a default `product-visual-*` stage — wire design + live preview follow G1 (see `wire-design-workflow`).
+- Use **`chrome-devtools-axi`** — product scouts are planning docs, not browser work.
+
+## Intentional-design checklist (G1)
+
+Before `done:`, confirm the PRD covers:
+
+- [ ] Users and JTBD with a measurable success signal
+- [ ] MVP cut (in / out / later) with rationale
+- [ ] Surface inventory (routes or modules — names only)
+- [ ] Cross-cutting interaction rules (chrome, voice, accessibility patterns — not pixels)
+- [ ] Dependencies and optional research-lock references
+- [ ] Captain decisions numbered and plain-text
+- [ ] **Handoff to wire** — explicit list of surfaces needing a design doc
+
+Doc schemas and singularity rules: load **`planning-documents`**.
+
+## Gate
+
+Captain approves **product plan approved** before any `product-wire-*` scout for this scope.

--- a/docs/documentation-audiences.json
+++ b/docs/documentation-audiences.json
@@ -205,6 +205,22 @@
       "audience": "maintainer-architecture"
     },
     {
+      "path": "data/specialists/frontend.md",
+      "audience": "agent-runtime"
+    },
+    {
+      "path": "data/specialists/product-wire-preview.md",
+      "audience": "agent-runtime"
+    },
+    {
+      "path": "data/specialists/product-wire.md",
+      "audience": "agent-runtime"
+    },
+    {
+      "path": "data/specialists/product.md",
+      "audience": "agent-runtime"
+    },
+    {
       "path": "GROK_BOT.md",
       "audience": "public-product"
     },


### PR DESCRIPTION
## Summary

- Deepen `product`, `product-wire`, `product-wire-preview`, and `frontend` specialist packs with ADR-001 aligned intentional-design sections: entry gate, must produce, must not, and stage checklists.
- Register the four packs in `docs/documentation-audiences.json`.
- `chrome-devtools-axi` required only on frontend / wire-preview project work; explicitly excluded from pipeline tasks.

## Test plan

- [x] `bash tests/fm-documentation-audiences.test.sh` — all four checks pass