### PR TITLE
Add --stage flag to fm-brief.sh for design-workflow scaffolds

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -6,8 +6,8 @@
 # description, acceptance criteria, and context, and may adjust other sections
 # when the task genuinely deviates (e.g. working an existing external PR instead
 # of shipping a new one).
-# Usage: fm-brief.sh <task-id> <repo-name> --mode <no-mistakes|direct-PR|local-only> [--herdr-lab]
-#        fm-brief.sh <task-id> <repo-name> --scout [--herdr-lab]
+# Usage: fm-brief.sh <task-id> <repo-name> --mode <no-mistakes|direct-PR|local-only> [--stage <name>] [--herdr-lab]
+#        fm-brief.sh <task-id> <repo-name> --scout [--stage <name>] [--herdr-lab]
 #        fm-brief.sh <task-id> --secondmate {<project>...|--no-projects}
 #   --scout writes the scout contract instead: the deliverable is a report at
 #   data/<task-id>/report.md (no branch, no push, no PR) and the worktree is scratch.
@@ -22,6 +22,12 @@
 #   omitting both still fails loudly so an accidental omission is never silent.
 #   Set FM_SECONDMATE_CHARTER='<charter>' to fill the charter text.
 #   Set FM_SECONDMATE_SCOPE='<scope>' to write a routing scope distinct from the charter text.
+#   --stage injects a stage-specific design-workflow block into ship and scout briefs.
+#   Allowed values: product, wire, wire-preview, pipeline. Omitted means no stage block.
+#   product      PRD or product-plan acceptance; link data/planning/<scope>/; forbid wire/FE scope.
+#   wire         design-doc plus component-registry checklist; requires an approved PRD named in the brief.
+#   wire-preview preview-spec plus demo-route expectations; browser-smoke note for FE work.
+#   pipeline     firstmate-coding-guidelines plus a no-chrome-devtools tools rule for firstmate-repo work.
 #   --herdr-lab is mandatory when the task will issue Herdr lifecycle commands.
 #   It adds the hard isolation contract backed by bin/fm-herdr-lab.sh.
 #   The flag must be explicit because {TASK} is filled after scaffolding and the
@@ -109,6 +115,8 @@ HERDR_LAB=0
 NO_PROJECTS=0
 MODE=
 MODE_SET=0
+STAGE=
+STAGE_SET=0
 POS=()
 want_value=
 for a in "$@"; do
@@ -118,6 +126,7 @@ for a in "$@"; do
     esac
     case "$want_value" in
       mode) MODE=$a; MODE_SET=1 ;;
+      stage) STAGE=$a; STAGE_SET=1 ;;
       *) echo "error: internal parser state for --$want_value" >&2; exit 1 ;;
     esac
     want_value=
@@ -130,6 +139,8 @@ for a in "$@"; do
     --no-projects) NO_PROJECTS=1 ;;
     --mode) want_value=mode ;;
     --mode=*) MODE=${a#--mode=}; MODE_SET=1 ;;
+    --stage) want_value=stage ;;
+    --stage=*) STAGE=${a#--stage=}; STAGE_SET=1 ;;
     # yolo never reaches the worker: it is firstmate's merge authority, not a
     # brief input. Refuse it loudly so it is never silently dropped here and then
     # believed to have been recorded.
@@ -155,6 +166,16 @@ if [ "$KIND" = ship ]; then
   esac
 elif [ "$MODE_SET" -eq 1 ]; then
   echo "error: --mode applies only to ship briefs; a scout delivers a report and a secondmate charter is not a delivery contract" >&2
+  exit 1
+fi
+if [ "$STAGE_SET" -eq 1 ]; then
+  case "$STAGE" in
+    product|wire|wire-preview|pipeline) ;;
+    *) echo "error: --stage must be one of product, wire, wire-preview, pipeline (got '$STAGE')" >&2; exit 1 ;;
+  esac
+fi
+if [ "$STAGE_SET" -eq 1 ] && [ "$KIND" = secondmate ]; then
+  echo "error: --stage applies only to ship and scout briefs; a secondmate charter is not a design-workflow scaffold" >&2
   exit 1
 fi
 ID=${POS[0]}
@@ -194,6 +215,62 @@ When a terminal message says an instruction is waiting there - and at any natura
 The move IS the acknowledgement: without it firstmate rings again and eventually treats you as stuck. An empty or absent inbox needs no action.
 EOF
 INBOX_SECTION=${INBOX_SECTION%$'\n'}
+
+TOOLS_RULE='3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.'
+STAGE_SECTION=
+if [ "$STAGE_SET" -eq 1 ]; then
+  case "$STAGE" in
+    product)
+      IFS= read -r -d '' STAGE_SECTION <<'EOF' || true
+# Stage contract
+**Stage:** product
+
+Deliver a PRD or product plan for captain acceptance.
+Store durable planning artifacts under `data/planning/<scope>/` in the firstmate home (replace `<scope>` with the project or feature slug named in the task).
+Load the `fm-product` skill before starting.
+
+**Out of scope for this stage:** wireframes, visual design, frontend implementation, and browser smoke tests.
+Do not start wire or FE work until the captain approves the product plan.
+EOF
+      ;;
+    wire)
+      IFS= read -r -d '' STAGE_SECTION <<'EOF' || true
+# Stage contract
+**Stage:** wire
+
+Deliver a design doc and complete the component registry checklist for the surfaces named in the task.
+Load the `fm-wire` skill before starting.
+
+**Prerequisite:** an approved PRD or product plan must be named and linked in the `# Task` section above.
+If no approved PRD is named, append `blocked: no approved PRD named in brief` to the status file and stop.
+EOF
+      ;;
+    wire-preview)
+      IFS= read -r -d '' STAGE_SECTION <<'EOF' || true
+# Stage contract
+**Stage:** wire-preview
+
+Deliver a preview spec with demo route expectations for the surfaces named in the task.
+Use chrome-devtools-axi for browser smoke when validating preview routes or frontend behavior.
+
+Wireframes or an approved design doc for this surface should already exist; name them in the task when they are not obvious from context.
+EOF
+      ;;
+    pipeline)
+      TOOLS_RULE='3. Use gh-axi for GitHub operations. Do **not** use chrome-devtools-axi (pipeline task).'
+      IFS= read -r -d '' STAGE_SECTION <<'EOF' || true
+# Stage contract
+**Stage:** pipeline
+
+Load **`firstmate-coding-guidelines`** before editing shared tracked material in the firstmate repo.
+
+This is a pipeline-engineering task: use gh-axi for GitHub operations only.
+Do **not** use chrome-devtools-axi.
+EOF
+      ;;
+  esac
+  STAGE_SECTION=${STAGE_SECTION%$'\n'}
+fi
 
 if [ "$KIND" = secondmate ]; then
 SECONDMATE_PROJECTS=""
@@ -327,6 +404,8 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 {TASK}
 
 $HERDR_SECTION
+${STAGE_SECTION:+
+$STAGE_SECTION}
 
 # Setup
 You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.
@@ -337,7 +416,7 @@ The report is the only thing that survives, so anything worth keeping must be in
 # Rules
 1. Never push to any remote and never open a PR.
 2. Stay inside this worktree; the only files you may write outside it are the report and the status file below.
-3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
+$TOOLS_RULE
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.
@@ -440,6 +519,8 @@ You are a crewmate: an autonomous worker agent managed by firstmate. Work on you
 {TASK}
 
 $HERDR_SECTION
+${STAGE_SECTION:+
+$STAGE_SECTION}
 
 # Setup
 You are in a disposable git worktree of $REPO, at a detached HEAD on a clean default branch.
@@ -453,7 +534,7 @@ If the top-level path is the primary checkout or not the worktree you were launc
 # Rules
 $RULE1
 2. Stay inside this worktree; modify nothing outside it.
-3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
+$TOOLS_RULE
 4. Report status by appending one line:
    \`echo "{state}: {one short line}" >> $STATUS_FILE\`
    States: working, needs-decision, blocked, $PAUSED_VERB, done, failed.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -174,6 +174,10 @@ test_help_includes_entire_header() {
   local help
   help=$("$ROOT/bin/fm-brief.sh" --help)
   assert_contains "$help" "Refuses to overwrite an existing brief." "fm-brief.sh --help omitted its header terminator"
+  assert_contains "$help" "--stage injects a stage-specific design-workflow block" \
+    "fm-brief.sh --help omitted --stage documentation"
+  assert_contains "$help" "product, wire, wire-preview, pipeline" \
+    "fm-brief.sh --help omitted --stage allowed values"
   pass "fm-brief.sh: --help renders the complete header"
 }
 
@@ -288,6 +292,84 @@ mode on a scout brief|brief-refused-b3 some-proj --scout --mode direct-PR|--mode
 mode on a secondmate charter|brief-refused-b4 --secondmate --no-projects --mode no-mistakes|--mode applies only to ship briefs
 ROWS
   pass "fm-brief.sh: --yolo and scout/secondmate --mode are refused, never silently dropped"
+}
+
+test_stage_pipeline_injects_contract_and_tools_rule() {
+  local home id brief out status
+  home="$TMP_ROOT/stage-pipeline-home"
+  mkdir -p "$home/data"
+  id="brief-stage-pipeline-e1"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" firstmate --mode no-mistakes --stage pipeline >/dev/null 2>&1
+  status=$?
+  expect_code 0 "$status" "ship brief with --stage pipeline should exit 0"
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "pipeline stage brief was not scaffolded"
+  assert_grep "**Stage:** pipeline" "$brief" \
+    "pipeline stage brief missing stage header"
+  # shellcheck disable=SC2016  # backticks must stay literal in the grep pattern
+  assert_grep 'Load **`firstmate-coding-guidelines`** before editing shared tracked material' "$brief" \
+    "pipeline stage brief missing firstmate-coding-guidelines load instruction"
+  assert_grep "Do **not** use chrome-devtools-axi (pipeline task)." "$brief" \
+    "pipeline stage brief missing the no-chrome-devtools tools rule"
+  assert_no_grep "chrome-devtools-axi for browser operations" "$brief" \
+    "pipeline stage brief retained the default browser-tools rule"
+
+  id="brief-stage-pipeline-scout-e2"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" firstmate --scout --stage pipeline >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_grep "**Stage:** pipeline" "$brief" \
+    "scout pipeline stage brief missing stage header"
+  assert_grep "Do **not** use chrome-devtools-axi (pipeline task)." "$brief" \
+    "scout pipeline stage brief missing the no-chrome-devtools tools rule"
+  pass "fm-brief.sh: --stage pipeline injects the stage contract and tools rule"
+}
+
+test_stage_product_injects_planning_contract() {
+  local home id brief
+  home="$TMP_ROOT/stage-product-home"
+  mkdir -p "$home/data"
+  id="brief-stage-product-e3"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --scout --stage product >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_grep "**Stage:** product" "$brief" \
+    "product stage brief missing stage header"
+  assert_grep 'data/planning/<scope>/' "$brief" \
+    "product stage brief missing planning path guidance"
+  assert_grep "Do not start wire or FE work until the captain approves the product plan." "$brief" \
+    "product stage brief missing wire/FE scope prohibition"
+  pass "fm-brief.sh: --stage product injects PRD acceptance and scope limits"
+}
+
+test_stage_is_closed_set_and_refused_on_secondmate() {
+  local home out status
+  home="$TMP_ROOT/stage-refused-home"
+  mkdir -p "$home/data"
+  out=$(FM_HOME="$home" "$ROOT/bin/fm-brief.sh" brief-stage-bad some-proj --mode no-mistakes --stage nope 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "unknown --stage value should fail"
+  assert_contains "$out" "must be one of product, wire, wire-preview, pipeline" \
+    "unknown --stage refusal did not explain the closed set"
+  out=$(FM_HOME="$home" FM_SECONDMATE_CHARTER=x \
+    "$ROOT/bin/fm-brief.sh" brief-stage-sm --secondmate --no-projects --stage pipeline 2>&1)
+  status=$?
+  [ "$status" -ne 0 ] || fail "--stage on secondmate should fail"
+  assert_contains "$out" "--stage applies only to ship and scout briefs" \
+    "secondmate --stage refusal did not explain the contract"
+  pass "fm-brief.sh: --stage is closed-set validated and refused on secondmate charters"
+}
+
+test_stage_absent_leaves_brief_unchanged() {
+  local home id brief
+  home="$TMP_ROOT/stage-absent-home"
+  mkdir -p "$home/data"
+  id="brief-stage-absent-e4"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_no_grep "# Stage contract" "$brief" \
+    "brief without --stage should not inject a stage block"
+  assert_grep "chrome-devtools-axi for browser operations" "$brief" \
+    "brief without --stage should keep the default browser-tools rule"
+  pass "fm-brief.sh: omitting --stage leaves the default brief shape"
 }
 
 test_faster_paths_use_configured_authority_without_stacked_review() {
@@ -758,6 +840,10 @@ test_ship_modes_generate_clean_briefs
 test_ship_mode_is_required_and_closed_set
 test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply
+test_stage_pipeline_injects_contract_and_tools_rule
+test_stage_product_injects_planning_contract
+test_stage_is_closed_set_and_refused_on_secondmate
+test_stage_absent_leaves_brief_unchanged
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
 test_ship_project_memory_wording


### PR DESCRIPTION
## Summary
- Add `bin/fm-brief.sh --stage <name>` for ship and scout briefs to inject stage-specific design-workflow blocks.
- Supported stages: `product`, `wire`, `wire-preview`, and `pipeline` (each with scoped deliverables, prerequisites, and tool constraints).
- Extend `tests/fm-brief.test.sh` with stage coverage; all existing fm-brief tests pass.

## Test plan
- [x] `tests/fm-brief.test.sh` (25 tests, all passing)
- [x] `bash -n bin/fm-brief.sh`