### PR TITLE
fix(bin): reconcile markerless remote secondmates safely

### DIFF
--- a/bin/fm-bearings-snapshot.sh
+++ b/bin/fm-bearings-snapshot.sh
@@ -113,7 +113,7 @@ Default is LOCAL-ONLY (no network); --include-prs is the only path that fetches.
 
 Default fields: schema, home, generated, prs, in_flight{id,kind,state,doing},
   secondmates{id,state,doing,provenance,freshness,age_seconds,contradiction,reason},
-  secondmate_reconcile{id,spawn_gen,kind,ids},
+  secondmate_reconcile{id,spawn_gen,host,kind,ids},
   decisions_open{id,key,verb,summary,owner}, landed{id,what,artifact,owner},
   gates{id,title,blocked_by,reason,owner}, reports{id,path}, recorded_prs{id,url},
   unhealthy_endpoints{...} (only when non-empty), omitted{surface,reveal}.
@@ -454,7 +454,7 @@ MODEL=$(printf '%s' "$SNAP" | jq \
       secondmates: (if $all_secondmates == 1 then $secondmates_all else $secondmates_all[:$secondmates_n] end),
       secondmate_reconcile: [ (.secondmate_current.records // [])[]
         | select(.reconcile_inventory != null)
-        | {id, spawn_gen:(.spawn_gen // null), kind:(.reconcile_inventory.kind // null), ids:((.reconcile_inventory.ids // []) | map(select(type == "string")) | sort)} ],
+        | {id, spawn_gen:(.spawn_gen // null), host:(.host // null), kind:(.reconcile_inventory.kind // null), ids:((.reconcile_inventory.ids // []) | map(select(type == "string")) | sort)} ],
       decisions_open: (if $all_decisions == 1 then $decisions_all else $decisions_all[:$decisions_n] end),
       landed: ($done | map({id, what:(.title | trunc(70)),
                             artifact:(.pr_url // .report_path // .local_note // "-"),owner:.home_id})),

--- a/bin/fm-secondmate-reconcile.sh
+++ b/bin/fm-secondmate-reconcile.sh
@@ -37,18 +37,15 @@
 #
 # Lock acquisition is non-blocking. A busy reconcile, lifecycle-control, or
 # metadata lock skips that home without starting its cooldown, so a later recap
-# can retry. The sampled spawn generation is revalidated before delivery and
-# before the cooldown commit so a retired endpoint is never nudged or allowed to
-# silence its replacement.
+# can retry. The sampled endpoint identity is revalidated before delivery, by
+# fm-send under its final route lock, and before the cooldown commit so a retired
+# endpoint is never nudged or allowed to silence its replacement.
 #
-# A persistent REMOTE secondmate's parent-side metadata never carries spawn_gen:
-# bin/fm-spawn.sh's spawn_remote_secondmate() is its sole writer and that
-# incarnation identity does not apply to a remote route (docs/remote-secondmates.md).
-# Such a row is legitimate and markerless by construction, not corrupt, so it is
-# revalidated on its recorded remote_host instead: a row with no sampled spawn_gen
-# is accepted only when it also carries a sampled host, and is nudged only while
-# the current metadata still has no spawn_gen and the same remote_host. A row with
-# neither a spawn_gen nor a host cannot be identified at all and fails loudly.
+# A persistent REMOTE secondmate's parent-side metadata intentionally has no
+# spawn_gen (docs/remote-secondmates.md). Such a row is legitimate and markerless
+# by construction, not corrupt, so it uses its sampled remote_host as the separate
+# identity guard. The current metadata must still have no spawn_gen and must still
+# name that host. A row with neither identity fails loudly.
 #
 # Exit status: 0 when no delivery or cooldown-recording failure is known,
 # including when a home was skipped for lock contention or a stale endpoint;

--- a/bin/fm-secondmate-reconcile.sh
+++ b/bin/fm-secondmate-reconcile.sh
@@ -241,7 +241,7 @@ cmd_notify() {
     | [.id, .spawn_gen, .host, $kind]
     | join($sep)')
 
-  local id sampled_spawn_gen sampled_host kind path last age now delivered_at reconcile_lock control_lock meta meta_lock did send_rc
+  local id sampled_spawn_gen sampled_host expected_remote_host kind path last age now delivered_at reconcile_lock control_lock meta meta_lock did send_rc
   while IFS=$'\037' read -r id sampled_spawn_gen sampled_host kind; do
     [ -n "${id:-}" ] || continue
     path=$(nudge_path "$id")
@@ -299,9 +299,12 @@ cmd_notify() {
       release_active_locks
       continue
     }
+    expected_remote_host=
+    [ -n "$sampled_spawn_gen" ] || expected_remote_host=$sampled_host
     release_active_locks
     send_rc=0
     FM_TASK_INBOX_LOCK_WAIT_SECS=0 FM_SEND_EXPECTED_SPAWN_GEN="$sampled_spawn_gen" \
+      FM_SEND_EXPECTED_REMOTE_HOST="$expected_remote_host" \
       "$SCRIPT_DIR/fm-send.sh" "$id" --fire-and-forget "$did" \
       "$(reconcile_text)" >/dev/null 2>&1 || send_rc=$?
     # exit 3 is "typed but unconfirmed": the mate may already hold the ask, so

--- a/bin/fm-secondmate-reconcile.sh
+++ b/bin/fm-secondmate-reconcile.sh
@@ -41,6 +41,15 @@
 # before the cooldown commit so a retired endpoint is never nudged or allowed to
 # silence its replacement.
 #
+# A persistent REMOTE secondmate's parent-side metadata never carries spawn_gen:
+# bin/fm-spawn.sh's spawn_remote_secondmate() is its sole writer and that
+# incarnation identity does not apply to a remote route (docs/remote-secondmates.md).
+# Such a row is legitimate and markerless by construction, not corrupt, so it is
+# revalidated on its recorded remote_host instead: a row with no sampled spawn_gen
+# is accepted only when it also carries a sampled host, and is nudged only while
+# the current metadata still has no spawn_gen and the same remote_host. A row with
+# neither a spawn_gen nor a host cannot be identified at all and fails loudly.
+#
 # Exit status: 0 when no delivery or cooldown-recording failure is known,
 # including when a home was skipped for lock contention or a stale endpoint;
 # 1 when at least one due send failed or its cooldown could not be recorded.
@@ -103,8 +112,43 @@ nudge_path() {  # <mate-id>
   printf '%s/%s.reconcile-nudged\n' "$STATE" "$1"
 }
 
+meta_field() {  # <meta-file> <key>
+  grep "^$2=" "$1" 2>/dev/null | tail -1 | cut -d= -f2- || true
+}
+
 meta_spawn_gen() {
-  grep '^spawn_gen=' "$1" 2>/dev/null | tail -1 | cut -d= -f2- || true
+  meta_field "$1" spawn_gen
+}
+
+meta_remote_host() {
+  meta_field "$1" remote_host
+}
+
+# revalidate_identity <meta> <sampled_spawn_gen> <sampled_host>
+# Confirms the row's sampled identity still matches the mate's current
+# metadata. When a spawn generation was sampled, that generation alone is the
+# identity, exactly as before. When none was sampled - the only legitimate
+# case is a persistent remote secondmate, whose parent metadata never carries
+# one - the sampled host substitutes, and the metadata must still carry no
+# spawn_gen of its own or the row's assumed identity model no longer holds.
+# Sets REVALIDATE_REASON to "no-identity" (nothing here can be safely
+# identified; report failed) or "stale" (identified, but changed; report
+# stale) on any non-zero return.
+revalidate_identity() {  # <meta> <sampled_spawn_gen> <sampled_host>
+  local meta=$1 sampled_gen=$2 sampled_host=$3 cur_gen='' cur_host=''
+  if [ -f "$meta" ] && [ ! -L "$meta" ]; then
+    cur_gen=$(meta_spawn_gen "$meta")
+    cur_host=$(meta_remote_host "$meta")
+  fi
+  if [ -n "$sampled_gen" ]; then
+    if [ -z "$cur_gen" ]; then REVALIDATE_REASON=no-identity; return 1; fi
+    if [ "$cur_gen" != "$sampled_gen" ]; then REVALIDATE_REASON=stale; return 1; fi
+    return 0
+  fi
+  if [ -z "$sampled_host" ]; then REVALIDATE_REASON=no-identity; return 1; fi
+  if [ -n "$cur_gen" ]; then REVALIDATE_REASON=stale; return 1; fi
+  if [ -z "$cur_host" ] || [ "$cur_host" != "$sampled_host" ]; then REVALIDATE_REASON=stale; return 1; fi
+  return 0
 }
 
 cmd_nudged() {
@@ -143,7 +187,7 @@ EOF
 }
 
 cmd_notify() {
-  local snapshot_src="" snapshot rows rc=0 now
+  local snapshot_src="" snapshot rows rc=0 now row_sep
   while [ "$#" -gt 0 ]; do
     case "$1" in
       --snapshot) [ "$#" -ge 2 ] || fail "--snapshot needs a value"; snapshot_src=$2; shift 2 ;;
@@ -167,24 +211,38 @@ cmd_notify() {
 
   # Only a real inventory mismatch is a books problem the mate can fix; every
   # other invalidity is either unreadable state or nothing to reconcile.
-  rows=$(printf '%s' "$snapshot" | jq -r '
+  # spawn_gen is empty only for a persistent remote secondmate, whose parent
+  # metadata never carries one (bin/fm-spawn.sh's spawn_remote_secondmate());
+  # host is its substitute identity there and is otherwise unused. Both are
+  # still character-restricted so a malformed sample cannot masquerade as
+  # either a live incarnation token or a live host.
+  #
+  # Rows join on ASCII unit separator (0x1F), not @tsv: bash's IFS-whitespace
+  # `read` collapses consecutive tabs, which would silently drop a
+  # legitimately empty spawn_gen or host field instead of preserving it. 0x1F
+  # is a control character, so the host filter below already excludes it from
+  # every field; it is passed in via --arg rather than written literally so no
+  # raw control byte sits in this source file.
+  row_sep=$(printf '\037')
+  rows=$(printf '%s' "$snapshot" | jq -r --arg sep "$row_sep" '
     (if .schema == "fm-bearings.v1" then
        (.secondmate_reconcile // [])[]
-       | {id, spawn_gen:(.spawn_gen // ""), kind:(.kind // ""), ids:(.ids // [])}
+       | {id, spawn_gen:(.spawn_gen // ""), host:(.host // ""), kind:(.kind // ""), ids:(.ids // [])}
      else
        (.secondmate_current.records // [])[]
        | select(.reconcile_inventory != null)
-       | {id, spawn_gen:(.spawn_gen // ""), kind:(.reconcile_inventory.kind // ""), ids:(.reconcile_inventory.ids // [])}
+       | {id, spawn_gen:(.spawn_gen // ""), host:(.host // ""), kind:(.reconcile_inventory.kind // ""), ids:(.reconcile_inventory.ids // [])}
      end)
     | select((.id | type) == "string" and (.id | test("^[A-Za-z0-9._-]+$")))
-    | select((.spawn_gen | type) == "string" and (.spawn_gen | test("^[A-Za-z0-9._-]+$")))
+    | select((.spawn_gen | type) == "string" and (.spawn_gen | test("^[A-Za-z0-9._-]*$")))
+    | select((.host | type) == "string" and (.host | test("[[:cntrl:]]") | not))
     | .kind as $kind
     | select(["orphan_in_flight","unowned_current","terminal_in_flight"] | index($kind))
-    | [.id, .spawn_gen, $kind]
-    | @tsv')
+    | [.id, .spawn_gen, .host, $kind]
+    | join($sep)')
 
-  local id sampled_spawn_gen kind path last age now delivered_at reconcile_lock control_lock meta meta_lock current_spawn_gen did send_rc
-  while IFS=$'\t' read -r id sampled_spawn_gen kind; do
+  local id sampled_spawn_gen sampled_host kind path last age now delivered_at reconcile_lock control_lock meta meta_lock did send_rc
+  while IFS=$'\037' read -r id sampled_spawn_gen sampled_host kind; do
     [ -n "${id:-}" ] || continue
     path=$(nudge_path "$id")
     reconcile_lock="$STATE/.$id.reconcile.lock"
@@ -225,18 +283,13 @@ cmd_notify() {
       continue
     fi
     ACTIVE_META_LOCK=$meta_lock
-    current_spawn_gen=
-    if [ -f "$meta" ] && [ ! -L "$meta" ]; then
-      current_spawn_gen=$(meta_spawn_gen "$meta")
-    fi
-    if [ -z "$current_spawn_gen" ]; then
-      printf 'failed: %s %s\n' "$id" "$kind"
-      rc=1
-      release_active_locks
-      continue
-    fi
-    if [ "$current_spawn_gen" != "$sampled_spawn_gen" ]; then
-      printf 'stale: %s %s\n' "$id" "$kind"
+    if ! revalidate_identity "$meta" "$sampled_spawn_gen" "$sampled_host"; then
+      if [ "$REVALIDATE_REASON" = stale ]; then
+        printf 'stale: %s %s\n' "$id" "$kind"
+      else
+        printf 'failed: %s %s\n' "$id" "$kind"
+        rc=1
+      fi
       release_active_locks
       continue
     fi
@@ -279,15 +332,11 @@ cmd_notify() {
       continue
     fi
     ACTIVE_META_LOCK=$meta_lock
-    current_spawn_gen=
-    if [ -f "$meta" ] && [ ! -L "$meta" ]; then
-      current_spawn_gen=$(meta_spawn_gen "$meta")
-    fi
     last=
     if [ -f "$path" ] && [ ! -L "$path" ]; then last=$(cat "$path" 2>/dev/null || true); fi
     case "$last" in ''|*[!0-9]*) last= ;; esac
     if [ -n "$last" ] && [ "$last" -gt "$delivered_at" ]; then delivered_at=$last; fi
-    if [ "$current_spawn_gen" = "$sampled_spawn_gen" ] \
+    if revalidate_identity "$meta" "$sampled_spawn_gen" "$sampled_host" \
       && (umask 077; printf '%s\n' "$delivered_at" > "$path.tmp") \
       && mv -f -- "$path.tmp" "$path"; then
       printf 'sent: %s %s\n' "$id" "$kind"

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -134,7 +134,11 @@
 # retry. The remote host runs no re-ring ladder of its own: a swallowed ordinary
 # doorbell surfaces through the parent's pending-reply recovery and escalation,
 # whose recovery request re-rings the remote doorbell when it is enqueued;
-# fire-and-forget delivery deliberately arms neither mechanism.
+# fire-and-forget delivery deliberately arms neither mechanism. Internal
+# semantic callers may set FM_SEND_EXPECTED_SPAWN_GEN or
+# FM_SEND_EXPECTED_REMOTE_HOST to require that sampled identity to still match
+# during the final locked remote-route validation; unset or empty guards do not
+# change ordinary sends.
 #
 # Decision closure (answerer-closes): pass --resolve-key <key> (repeatable,
 # before the message) when this send answers an open keyed needs-decision: or

--- a/bin/fm-send.sh
+++ b/bin/fm-send.sh
@@ -762,6 +762,8 @@ else
     if [ "$CURRENT_REMOTE_ID" != "$TARGET_REMOTE_ID" ] \
       || { [ -n "${FM_SEND_EXPECTED_SPAWN_GEN:-}" ] \
         && [ "$CURRENT_REMOTE_SPAWN_GEN" != "$FM_SEND_EXPECTED_SPAWN_GEN" ]; } \
+      || { [ -n "${FM_SEND_EXPECTED_REMOTE_HOST:-}" ] \
+        && [ "$CURRENT_REMOTE_HOST" != "$FM_SEND_EXPECTED_REMOTE_HOST" ]; } \
       || [ -z "$CURRENT_REMOTE_HOST" ] \
       || [ "$CURRENT_REMOTE_HOST" != "$TARGET_REMOTE_HOST" ]; then
       fm_lock_release "$REMOTE_META_LOCK"

--- a/docs/remote-secondmates.md
+++ b/docs/remote-secondmates.md
@@ -162,6 +162,9 @@ Backends that already refuse secondmate launch, currently Orca and cmux, remain 
 
 Startup liveness recovery relaunches a dead or missing remote second mate through this same command, so recovery passes the same readiness gate rather than a weaker one.
 
+A persistent remote route's parent metadata intentionally has no local spawn-generation marker and identifies the route by its recorded host instead.
+The Bearings inventory-reconcile hook therefore accepts these markerless routes, revalidates the sampled host at delivery, and refuses a route that changed hosts; [`fm-secondmate-reconcile.sh`](../bin/fm-secondmate-reconcile.sh) owns the exact cooldown, identity, and reporting contract.
+
 Send routed requests normally:
 
 ```sh
@@ -243,6 +246,7 @@ The lifecycle test covers seeding a registered project that this machine has nev
 ```sh
 bin/fm-test-run.sh tests/fm-on.test.sh
 bin/fm-test-run.sh tests/fm-send-remote-delivery.test.sh
+bin/fm-test-run.sh tests/fm-secondmate-reconcile.test.sh
 bin/fm-test-run.sh tests/fm-peek-remote.test.sh
 bin/fm-test-run.sh tests/fm-crew-state.test.sh
 bin/fm-test-run.sh tests/fm-remote-job.test.sh

--- a/tests/fm-secondmate-reconcile.test.sh
+++ b/tests/fm-secondmate-reconcile.test.sh
@@ -52,6 +52,111 @@ write_snapshot() {  # <path> <mate-id> <invalidity-json> [state]
       provenance:{selected:"structured-home", trust:"partial-structured"}}]}}' > "$1"
 }
 
+# The same shape, but for a persistent REMOTE secondmate: no spawn_gen (its
+# parent metadata never carries one), host instead.
+write_remote_snapshot() {  # <path> <mate-id> <host> <invalidity-json> [state]
+  jq -n --arg id "$2" --arg host "$3" --argjson inv "$4" --arg state "${5:-captain_decision}" '{
+    schema:"fm-fleet-snapshot.v1", generated:"2026-08-26T00:00:00Z",
+    secondmate_current:{records:[{
+      id:$id, home:("/tmp/" + $id), host:$host, spawn_gen:null,
+      current:{state:$state, reason:null},
+      invalidity:$inv, reconcile_inventory:($inv // {kind:null,ids:[]}),
+      provenance:{selected:"structured-home", trust:"partial-structured"}}]}}' > "$1"
+}
+
+# A fake ssh that decodes fm-on.sh's base64 remote-home/argv payload and
+# EXECUTES the real host-local leg (fm-remote-secondmate-control.sh) against a
+# genuinely seeded remote-home fixture, exactly like the ssh stub proven in
+# tests/fm-send-remote-delivery.test.sh.
+make_remote_ssh_stub() {  # <dir> -> echoes fakebin dir
+  local dir=$1 fb="$1/fakebin"
+  mkdir -p "$fb"
+  cat > "$fb/fake-ssh" <<'SH'
+#!/usr/bin/env bash
+set -u
+cat > /dev/null
+while [ "$#" -gt 0 ]; do
+  case "$1" in -o) shift 2 ;; --) shift; break ;; *) exit 90 ;; esac
+done
+shift 2  # host, fm-remote-entrypoint.sh
+home_b64=$3
+argv_b64=$4
+remote_home=$(perl -MMIME::Base64=decode_base64 -e 'print decode_base64($ARGV[0])' "$home_b64")
+rargs=()
+while IFS= read -r -d '' a; do rargs+=("$a"); done \
+  < <(perl -MMIME::Base64=decode_base64 -e 'print decode_base64($ARGV[0])' "$argv_b64")
+cmd=${rargs[0]}
+rc=0
+env FM_HOME="$remote_home" FM_ROOT_OVERRIDE="$FM_REMOTE_CODE_ROOT" \
+  "$FM_REMOTE_CODE_ROOT/bin/$cmd" "${rargs[@]:1}" || rc=$?
+exit "$rc"
+SH
+  chmod +x "$fb/fake-ssh"
+  printf '%s\n' "$fb"
+}
+
+# A seeded remote secondmate home the real host-local leg validates and writes
+# into (identity marker, Firstmate-checkout shape, parent-route endpoint meta).
+make_remote_secondmate_home() {  # <name> -> echoes remote home dir
+  local rh="$TMP_ROOT/$1-rhome"
+  mkdir -p "$rh/state/parent-route" "$rh/bin"
+  printf '%s\n' "$1" > "$rh/.fm-secondmate-home"
+  printf '# remote secondmate home fixture\n' > "$rh/AGENTS.md"
+  cat > "$rh/state/parent-route/$1.meta" <<META
+window=fm-remote:p1
+worktree=-
+project=-
+backend=herdr
+endpoint_task_id=$1
+harness=claude
+herdr_session=fm-remote
+herdr_workspace_id=w1
+herdr_tab_id=t1
+herdr_pane_id=p1
+META
+  printf '%s\n' "$rh"
+}
+
+# A parent home whose secondmate is a persistent REMOTE route (as
+# spawn_remote_secondmate() writes it: no spawn_gen, remote_host instead).
+make_remote_parent_home() {  # <name> <mate-id> <remote-home> <host> -> echoes home dir
+  local home="$TMP_ROOT/$1" id=$2 rhome host=$4
+  mkdir -p "$home/data" "$home/state"
+  # Canonicalize: fm-on.sh's registry route parser rejects an empty path
+  # component, and $TMP_ROOT can carry one (a raw mktemp base under a
+  # trailing-slash TMPDIR), same as make_main_home's $abs above.
+  rhome=$(cd "$3" && pwd -P)
+  cat > "$home/state/$id.meta" <<META
+window=remote:$id
+endpoint_task_id=$id
+harness=claude
+kind=secondmate
+mode=secondmate
+yolo=off
+remote_host=$host
+remote_root=/remote/root
+remote_backend=herdr
+remote_herdr_session=fm-remote
+remote_target=fm-remote:p1
+META
+  cat > "$home/data/secondmates.md" <<EOF
+- $id - remote fixture domain (host: $host; root: /remote/root; home: $rhome; scope: remote fixture; projects: sample; added 2026-08-26)
+EOF
+  printf '%s\n' "$home"
+}
+
+remote_inbox_records() {  # <remote-home> <mate-id>
+  find "$1/state/parent-route/$2.inbox" -maxdepth 1 -type f -name '*.msg' 2>/dev/null
+}
+
+run_remote_notify() {  # <home> <fakebin> <snapshot>
+  local home=$1 fakebin=$2 snap=$3
+  FM_SSH_BIN="$fakebin/fake-ssh" FM_REMOTE_CODE_ROOT="$ROOT" \
+    PATH="$fakebin:$PATH" FM_HOME="$home" FM_ROOT_OVERRIDE="$ROOT" \
+    FM_STATE_OVERRIDE="$home/state" \
+    "$RECONCILE" notify --snapshot "$snap"
+}
+
 # Age the home's cooldown record so the next run sees the window as elapsed.
 age_cooldown() {  # <state-dir> <mate-id> <seconds-ago>
   printf '%s\n' "$(( $(date +%s) - $3 ))" > "$1/$2.reconcile-nudged"
@@ -453,6 +558,90 @@ META
   pass "teardown retires the cooldown before a replacement can inherit it"
 }
 
+# A persistent REMOTE secondmate's parent metadata never carries spawn_gen
+# (bin/fm-spawn.sh's spawn_remote_secondmate() never writes one). This is the
+# proven marker-bearing path's counterpart: same durable fire-and-forget
+# delivery and cooldown behavior, driven end to end through the real remote
+# transport, for a mate that legitimately has no generation marker at all.
+test_a_markerless_remote_secondmate_is_nudged_once_per_window() {
+  local home rhome fakebin snap out
+  fakebin=$(make_remote_ssh_stub "$TMP_ROOT/remote-once")
+  rhome=$(make_remote_secondmate_home remote-once-mate)
+  home=$(make_remote_parent_home remote-once remote-once-mate "$rhome" remote-once-host)
+  snap="$home/snapshot.json"
+  write_remote_snapshot "$snap" remote-once-mate remote-once-host \
+    '{"kind":"orphan_in_flight","ids":["stale-scout"]}'
+
+  out=$(run_remote_notify "$home" "$fakebin" "$snap") \
+    || fail "the first markerless reconcile ask failed: $out"
+  assert_contains "$out" "sent: remote-once-mate orphan_in_flight" \
+    "a legitimately markerless remote mate got no ask: $out"
+  [ -n "$(remote_inbox_records "$rhome" remote-once-mate)" ] \
+    || fail "the ask did not land as a durable record in the remote steering inbox"
+  [ -f "$home/state/remote-once-mate.reconcile-nudged" ] \
+    || fail "a successful markerless ask did not start the cooldown"
+
+  out=$(run_remote_notify "$home" "$fakebin" "$snap") \
+    || fail "the repeat markerless run failed: $out"
+  assert_contains "$out" "cooldown: remote-once-mate" \
+    "a repeated markerless snapshot did not report the cooldown: $out"
+  [ "$(remote_inbox_records "$rhome" remote-once-mate | grep -c . || true)" -eq 1 ] \
+    || fail "repeated markerless snapshots asked the mate more than once inside the cooldown"
+  pass "a legitimately markerless persistent remote secondmate is nudged once per window"
+}
+
+# The safety boundary the spawn_gen check protects for local mates has a
+# host-keyed counterpart for markerless remote mates: a snapshot sampled
+# before the route moved to a different host must never reach the new host's
+# mate or arm its cooldown.
+test_a_stale_remote_route_is_refused() {
+  local home rhome fakebin snap out
+  fakebin=$(make_remote_ssh_stub "$TMP_ROOT/remote-stale")
+  rhome=$(make_remote_secondmate_home remote-stale-mate)
+  home=$(make_remote_parent_home remote-stale remote-stale-mate "$rhome" old-host)
+  snap="$home/snapshot.json"
+  write_remote_snapshot "$snap" remote-stale-mate old-host \
+    '{"kind":"orphan_in_flight","ids":["old-ghost"]}'
+  # The route was re-seeded to a different host since the snapshot was taken.
+  sed -i.bak 's/^remote_host=.*/remote_host=new-host/' "$home/state/remote-stale-mate.meta" \
+    && rm -f "$home/state/remote-stale-mate.meta.bak"
+
+  out=$(run_remote_notify "$home" "$fakebin" "$snap") \
+    || fail "a stale remote-route snapshot made reconcile fail: $out"
+  assert_contains "$out" "stale: remote-stale-mate orphan_in_flight" \
+    "a snapshot sampled from a retired remote route was not identified: $out"
+  [ -z "$(remote_inbox_records "$rhome" remote-stale-mate)" ] \
+    || fail "a replacement remote route received its predecessor's reconcile ask"
+  assert_absent "$home/state/remote-stale-mate.reconcile-nudged" \
+    "a replacement remote route inherited cooldown from a stale snapshot"
+  pass "a stale remote-route snapshot cannot ask or silence a replacement mate"
+}
+
+# A row with neither a spawn generation nor a host carries no safe identity at
+# all - the markerless path must not swallow that case the way the original
+# bug swallowed every markerless row.
+test_a_row_with_no_identity_at_all_fails_loudly() {
+  local home rhome fakebin snap out
+  fakebin=$(make_remote_ssh_stub "$TMP_ROOT/remote-noid")
+  rhome=$(make_remote_secondmate_home remote-noid-mate)
+  home=$(make_remote_parent_home remote-noid remote-noid-mate "$rhome" remote-noid-host)
+  snap="$home/snapshot.json"
+  write_remote_snapshot "$snap" remote-noid-mate "" \
+    '{"kind":"orphan_in_flight","ids":["ghost"]}'
+
+  set +e
+  out=$(run_remote_notify "$home" "$fakebin" "$snap"); rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "a row with no sampled identity at all reported success: $out"
+  assert_contains "$out" "failed: remote-noid-mate orphan_in_flight" \
+    "an unidentifiable row was not reported as failed: $out"
+  [ -z "$(remote_inbox_records "$rhome" remote-noid-mate)" ] \
+    || fail "an unidentifiable row still received a reconcile ask"
+  assert_absent "$home/state/remote-noid-mate.reconcile-nudged" \
+    "an unidentifiable row started a cooldown"
+  pass "a row with neither a spawn generation nor a host fails loudly instead of vanishing"
+}
+
 test_an_inventory_mismatch_asks_the_mate_once_per_window
 test_a_mismatch_still_there_after_the_window_earns_one_more_nudge
 test_the_cooldown_starts_when_delivery_finishes
@@ -467,3 +656,6 @@ test_concurrent_recaps_send_one_instruction
 test_a_delayed_snapshot_never_prescribes_a_stale_repair
 test_a_stale_snapshot_never_targets_a_replacement_mate
 test_teardown_cannot_leave_its_replacement_in_cooldown
+test_a_markerless_remote_secondmate_is_nudged_once_per_window
+test_a_stale_remote_route_is_refused
+test_a_row_with_no_identity_at_all_fails_loudly

--- a/tests/fm-secondmate-reconcile.test.sh
+++ b/tests/fm-secondmate-reconcile.test.sh
@@ -617,6 +617,66 @@ test_a_stale_remote_route_is_refused() {
   pass "a stale remote-route snapshot cannot ask or silence a replacement mate"
 }
 
+test_route_replacement_during_send_is_refused() {
+  local home rhome fakebin snap signal release out rc notify_pid
+  fakebin=$(make_remote_ssh_stub "$TMP_ROOT/remote-send-race")
+  rhome=$(make_remote_secondmate_home remote-send-race-mate)
+  home=$(make_remote_parent_home remote-send-race remote-send-race-mate "$rhome" old-host)
+  snap="$home/snapshot.json"
+  signal="$home/fm-send-started"
+  release="$home/release-fm-send"
+  write_remote_snapshot "$snap" remote-send-race-mate old-host \
+    '{"kind":"orphan_in_flight","ids":["old-ghost"]}'
+  cat > "$fakebin/dirname" <<'SH'
+#!/usr/bin/env bash
+set -u
+case "${1:-}" in
+  */fm-send.sh)
+    : > "$FM_RECONCILE_RACE_SIGNAL"
+    while [ ! -f "$FM_RECONCILE_RACE_RELEASE" ]; do sleep 0.01; done
+    ;;
+esac
+case "${1:-}" in
+  */*) printf '%s\n' "${1%/*}" ;;
+  *) printf '.\n' ;;
+esac
+SH
+  chmod +x "$fakebin/dirname"
+
+  rc=0
+  FM_RECONCILE_RACE_SIGNAL="$signal" FM_RECONCILE_RACE_RELEASE="$release" \
+    run_remote_notify "$home" "$fakebin" "$snap" > "$home/notify.out" 2>&1 &
+  notify_pid=$!
+  while [ ! -f "$signal" ]; do
+    kill -0 "$notify_pid" 2>/dev/null || fail "reconcile exited before entering fm-send"
+    sleep 0.01
+  done
+
+  . "$ROOT/bin/fm-wake-lib.sh"
+  fm_lock_acquire_wait "$home/state/.control-remote-send-race-mate.lock"
+  fm_lock_acquire_wait "$home/state/.meta-remote-send-race-mate.lock"
+  sed 's/^remote_host=.*/remote_host=new-host/' \
+    "$home/state/remote-send-race-mate.meta" > "$home/state/remote-send-race-mate.meta.tmp"
+  mv "$home/state/remote-send-race-mate.meta.tmp" "$home/state/remote-send-race-mate.meta"
+  sed 's/host: old-host/host: new-host/' \
+    "$home/data/secondmates.md" > "$home/data/secondmates.md.tmp"
+  mv "$home/data/secondmates.md.tmp" "$home/data/secondmates.md"
+  fm_lock_release "$home/state/.meta-remote-send-race-mate.lock"
+  fm_lock_release "$home/state/.control-remote-send-race-mate.lock"
+  : > "$release"
+  wait "$notify_pid" || rc=$?
+  out=$(cat "$home/notify.out")
+
+  [ "$rc" -ne 0 ] || fail "a route replacement during send reported success: $out"
+  assert_contains "$out" "failed: remote-send-race-mate orphan_in_flight" \
+    "a route replacement during send was not refused: $out"
+  [ -z "$(remote_inbox_records "$rhome" remote-send-race-mate)" ] \
+    || fail "a replacement route received its predecessor's reconcile ask"
+  assert_absent "$home/state/remote-send-race-mate.reconcile-nudged" \
+    "a refused route replacement started the cooldown"
+  pass "a route replacement between reconcile and fm-send cannot receive a stale ask"
+}
+
 # A row with neither a spawn generation nor a host carries no safe identity at
 # all - the markerless path must not swallow that case the way the original
 # bug swallowed every markerless row.
@@ -658,4 +718,5 @@ test_a_stale_snapshot_never_targets_a_replacement_mate
 test_teardown_cannot_leave_its_replacement_in_cooldown
 test_a_markerless_remote_secondmate_is_nudged_once_per_window
 test_a_stale_remote_route_is_refused
+test_route_replacement_during_send_is_refused
 test_a_row_with_no_identity_at_all_fails_loudly

--- a/tests/fm-send-remote-delivery.test.sh
+++ b/tests/fm-send-remote-delivery.test.sh
@@ -459,6 +459,36 @@ test_remote_send_revalidates_parent_route_after_retirement_lock() {
   pass "fm-send remote: enqueue revalidates the parent route under its metadata lock"
 }
 
+test_remote_expected_host_revalidates_final_route() {
+  local dir fb ssh_log home rhome rc err count
+  dir="$TMP_ROOT/remote-expected-host"; mkdir -p "$dir"
+  fb=$(make_stubs "$dir"); ssh_log="$dir/ssh.log"; : > "$ssh_log"
+  rhome=$(setup_remote_secondmate_home remote-expected-host)
+  home=$(setup_remote_parent_home remote-expected-host "$rhome")
+
+  rc=0
+  send_env "$fb" "$home" "$ssh_log" \
+    FM_SEND_EXPECTED_SPAWN_GEN="" FM_SEND_EXPECTED_REMOTE_HOST=remote-mac \
+    "$SEND" rsm --fire-and-forget 1111111111111111 "matching expected host" \
+    >"$dir/match.out" 2>"$dir/match.err" || rc=$?
+  expect_code 0 "$rc" "a matching expected remote host must allow delivery"
+  count=$(remote_inbox_records "$rhome" | grep -c . || true)
+  [ "$count" = 1 ] || fail "a matching expected remote host did not deliver exactly once"
+
+  rc=0
+  send_env "$fb" "$home" "$ssh_log" \
+    FM_SEND_EXPECTED_SPAWN_GEN="" FM_SEND_EXPECTED_REMOTE_HOST=retired-mac \
+    "$SEND" rsm --fire-and-forget 2222222222222222 "stale expected host" \
+    >"$dir/mismatch.out" 2>"$dir/mismatch.err" || rc=$?
+  [ "$rc" -ne 0 ] || fail "a mismatched expected remote host reported delivery"
+  err=$(cat "$dir/mismatch.err")
+  assert_contains "$err" "retired or changed route" \
+    "a mismatched expected remote host did not report the route replacement: $err"
+  count=$(remote_inbox_records "$rhome" | grep -c . || true)
+  [ "$count" = 1 ] || fail "a mismatched expected remote host reached the remote inbox"
+  pass "fm-send remote: expected host is enforced by final route validation"
+}
+
 test_remote_resolve_key_closes_at_enqueue() {
   local dir fb ssh_log home rhome rc out
   dir="$TMP_ROOT/remote-key"; mkdir -p "$dir"
@@ -657,6 +687,7 @@ test_remote_retry_failure_preserves_ambiguous_expectation
 test_remote_fire_and_forget_never_arms_reply_recovery
 test_remote_send_revalidates_after_retirement_lock
 test_remote_send_revalidates_parent_route_after_retirement_lock
+test_remote_expected_host_revalidates_final_route
 test_remote_resolve_key_closes_at_enqueue
 test_remote_slash_rides_inbox
 test_remote_real_failure_still_fails


### PR DESCRIPTION
## Intent

Fix reconciliation nudges silently SKIPPING persistent remote secondmates that lack a spawn-generation marker, so Bearings stops omitting valid work the mate should have reconciled.

Root cause: bin/fm-secondmate-reconcile.sh's row filter required a non-empty spawn_gen matching an identifier regex before a row would even enter the per-row loop. A persistent REMOTE secondmate's parent-side state/<id>.meta legitimately and permanently never carries spawn_gen (bin/fm-spawn.sh's spawn_remote_secondmate() is its sole writer and never writes one - that incarnation-generation identity model does not apply to a remote route). So every markerless remote-secondmate row was silently dropped before ever reaching the sent/stale/failed reporting logic: no output line, no cooldown record, nothing sent, and no visibility into why. This was confirmed via real end-to-end reproduction (a synthetic fm-fleet-snapshot.v1 document with spawn_gen=null piped through 'fm-secondmate-reconcile.sh notify --snapshot -' produced zero output and no state/<id>.reconcile-nudged file), by tracing fm-spawn.sh's spawn_remote_secondmate() to confirm it never writes spawn_gen by design, and by comparing against the proven local-secondmate path where spawn_gen IS always present.

Constraint from the captain: do NOT weaken the existing stale/replacement-endpoint safety check (the spawn_gen revalidation that protects against sending a reconcile ask sampled from a retired/replaced worker onto its unrelated replacement) for rows that DO have a spawn_gen. Define a SEPARATE safe identity path for persistent remote secondmates that legitimately lack spawn_gen.

Fix implemented:
- bin/fm-secondmate-reconcile.sh: the row-selection jq now admits an empty spawn_gen (relaxed the regex from one-or-more to zero-or-more characters) instead of filtering the row out entirely, and threads a new 'host' field through the row projection for both the fm-fleet-snapshot.v1 and fm-bearings.v1 input schemas (host was already present in fm-fleet-snapshot.sh's secondmate_current records but not previously read here). A new revalidate_identity() function replaces the old current_spawn_gen equality check in both the pre-send validation and the post-send cooldown-commit check: when a spawn generation WAS sampled, that generation alone remains the identity exactly as before (unchanged behavior, no weakening); when NO spawn generation was sampled, the sampled host substitutes as the identity, but ONLY if a host was actually sampled (a row with neither a spawn_gen nor a host has no safe identity at all and is reported as 'failed', preserving visibility instead of silently vanishing) AND the current metadata still carries no spawn_gen of its own (guards against the row's assumed identity model changing) AND the current metadata's remote_host still matches the sampled host (a route re-seeded to a different host between the snapshot and reconcile is correctly treated as stale/retired, mirroring the exact protection spawn_gen provides for local secondmates).
- Also fixed a latent bug discovered while implementing this: the row-joining format changed from @tsv to the ASCII unit separator (0x1F, passed via jq --arg rather than embedded as a literal control byte in the script source) because bash's 'IFS=$'\t' read' collapses consecutive tab delimiters (tab is an IFS-whitespace character), which would have silently dropped a legitimately empty spawn_gen or host field exactly the way the original bug dropped rows - this was caught by writing the new end-to-end tests, which failed until this was fixed.
- bin/fm-bearings-snapshot.sh: threaded the same 'host' field through the secondmate_reconcile projection (previously only id/spawn_gen/kind/ids) so the fm-bearings.v1 schema - the one the bearings SKILL.md's documented reconcile-hook invocation actually feeds to fm-secondmate-reconcile.sh - carries the substitute identity too, not just the raw fm-fleet-snapshot.v1 schema.
- tests/fm-secondmate-reconcile.test.sh: added three new end-to-end tests exercising the REAL remote transport (fm-on.sh + fm-remote-secondmate-control.sh against a genuinely seeded remote-home fixture, using the same proven fake-ssh-executes-the-real-host-local-leg pattern already established in tests/fm-send-remote-delivery.test.sh) rather than mocking fm-send.sh: (1) a legitimately markerless persistent remote secondmate is nudged exactly once per cooldown window and its durable fire-and-forget instruction lands as a real record in the remote steering inbox, matching the existing proven marker-bearing local-secondmate test; (2) a stale/replaced remote route (the parent metadata's remote_host changed since the snapshot was sampled) is refused exactly like the existing local spawn_gen-mismatch case, receiving no ask and starting no cooldown - this is the disconfirming-evidence test proving the safety boundary was not weakened; (3) a row with neither a spawn_gen nor a host fails loudly rather than vanishing, proving the original bug's silent-drop failure mode cannot recur even for a genuinely unidentifiable row.

All existing tests in tests/fm-secondmate-reconcile.test.sh (14 pre-existing) and tests/fm-bearings-snapshot.test.sh (42 tests) pass unchanged, confirming no regression to the local-secondmate path or the bearings projection. bin/fm-lint.sh (shellcheck + actionlint) passes clean. Kept bash 3.2 compatible: no arrays, no [[ ]], no bash4+ features in the touched bin/*.sh scripts.

## What Changed
- Preserve remote hosts in Bearings reconciliation snapshots and admit markerless remote secondmate rows without losing empty fields during parsing.
- Revalidate markerless routes by sampled host before delivery, during the final locked send, and before cooldown commit, while retaining spawn-generation checks for marked routes and failing rows with no identity.
- Add end-to-end coverage for remote delivery, cooldowns, stale route rejection, send-time replacement races, and missing identities; document the host-based identity contract.

## Risk Assessment

✅ Low: The additive host guard closes the markerless remote-route race under fm-send's final metadata lock while preserving spawn-generation checks and existing caller behavior.

## Testing

Targeted reconcile, remote-delivery, and Bearings projection suites passed; manual end-to-end verification showed a markerless remote mate receives one durable nudge, cooldown suppresses repeats, and a replaced route rejects the stale snapshot without delivery.

<details>
<summary>Evidence: Markerless remote reconcile end-to-end transcript</summary>

Source: [Markerless remote reconcile end-to-end transcript](https://github.com/kunchenguid/firstmate/blob/2012f3564ac711d398ced34b1e1bda9682cf526a/.no-mistakes/evidence/fm/fm-secondmate-reconcile-missing-spawn-gen-r1/markerless-remote-reconcile-transcript.txt)

```text
$ fm-secondmate-reconcile.sh notify --snapshot markerless-remote.json
sent: evidence-mate orphan_in_flight

$ persisted remote steering inbox record
record=state/parent-route/evidence-mate.inbox/001.msg
schema=fm-task-inbox.v1
at=2026-08-26T23:03:20Z
delivery=fire-and-forget
--
[fm-from-firstmate]⁣delivery=cfbbb8e0630b0bc7 A fleet snapshot found that your home's backlog and task metadata disagreed.

Please check your current books and, if they still disagree, reconcile them to match reality. Nothing outside your home has been changed, and no reply is expected.cooldown_record=1787785400

$ repeat notify inside cooldown
cooldown: evidence-mate 0

$ notify from old snapshot after route replacement
stale: evidence-mate orphan_in_flight
remote_inbox_record_count=1 (unchanged; replacement received nothing)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"0c80eab36a48be374ab8b803021e1843cd7318bb","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `bin/fm-secondmate-reconcile.sh:304` - Intent requires “do NOT weaken the existing stale/replacement-endpoint safety check” and a separate safe identity path, but the changed hunk releases the identity locks and passes only FM_SEND_EXPECTED_SPAWN_GEN to fm-send. For a markerless row: snapshot samples host A, pre-send validation sees A, locks are released at line 302, lifecycle replaces the route with host B, and fm-send resolves and delivers to B because the expected generation is empty; the post-send host check can only report sent-unrecorded after the replacement already received the stale ask. Pass the sampled host into fm-send and enforce it in fm-send’s final locked remote-route validation, analogous to FM_SEND_EXPECTED_SPAWN_GEN.

🔧 Fix: Enforce markerless remote host identity during final delivery
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-secondmate-reconcile.test.sh`
- `bash tests/fm-send-remote-delivery.test.sh`
- `bash tests/fm-bearings-snapshot.test.sh`
- `Manual end-to-end remote fixture: notified a markerless mate, inspected its durable inbox record and cooldown, repeated within cooldown, then replaced the route and verified the stale snapshot was refused without another inbox record.`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
