### PR TITLE
feat(bin): surface no-mistakes ask-user findings via ask_user_question

### DIFF
--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -418,8 +418,11 @@ When starting no-mistakes, make \`--intent\` preserve all relevant content from 
 Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.
 
 Two firstmate-specific rules layer on top of that guidance:
-- ask-user findings are never yours to answer: escalate to firstmate (rule 6) and stop.
-  Firstmate applies \`ask-user-authority\` and obtains any required captain decision.
+- ask-user findings are never yours to answer: present them, then escalate to firstmate (rule 6) and stop.
+  Call the \`ask_user_question\` extension tool to render the finding as a concise question with the finding's options as the tool's options.
+  Append a \`needs-decision [key=<finding-id>]: {one-line summary}\` status line so firstmate's watcher wakes firstmate.
+  The \`ask_user_question\` tool is the presentation mechanism, not a license to decide.
+  Firstmate applies \`ask-user-authority\` and obtains any required captain decision, so stop and wait rather than answering your own finding.
   When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
 - Avoid \`--yes\`: it would silently bypass firstmate's authority check and any required captain escalation.
 

--- a/bin/fm-brief.sh
+++ b/bin/fm-brief.sh
@@ -419,8 +419,8 @@ Do not hand-edit, commit, or fix findings yourself while a run is active - the p
 
 Two firstmate-specific rules layer on top of that guidance:
 - ask-user findings are never yours to answer: present them, then escalate to firstmate (rule 6) and stop.
-  Call the \`ask_user_question\` extension tool to render the finding as a concise question with the finding's options as the tool's options.
   Append a \`needs-decision [key=<finding-id>]: {one-line summary}\` status line so firstmate's watcher wakes firstmate.
+  Call the \`ask_user_question\` extension tool to render the finding as a concise question with the finding's options as the tool's options.
   The \`ask_user_question\` tool is the presentation mechanism, not a license to decide.
   Firstmate applies \`ask-user-authority\` and obtains any required captain decision, so stop and wait rather than answering your own finding.
   When the decision comes back, feed it to the gate with \`no-mistakes axi respond\` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -362,7 +362,7 @@ test_no_mistakes_dod_wording() {
 # in a status firstmate must relay. The boundary keeps the tool a presentation
 # mechanism, not a license to decide.
 test_no_mistakes_dod_ask_user_presentation() {
-  local home id brief
+  local home id brief wake_line ask_line
   home="$TMP_ROOT/ask-user-presentation-home"
   mkdir -p "$home/data"
   id="brief-askuser-e1"
@@ -389,6 +389,18 @@ test_no_mistakes_dod_ask_user_presentation() {
     "no-mistakes DOD lost the rule-6 escalation cross-reference"
   assert_grep "feed it to the gate with \`no-mistakes axi respond\`" "$brief" \
     "no-mistakes DOD lost the decision-feed-back step"
+  # ask_user_question blocks until answered, so the needs-decision wake line
+  # MUST be appended before the presentation call - otherwise firstmate's
+  # watcher never wakes and the escalation deadlocks. Assert the generated
+  # brief emits the wake line before the ask_user_question call.
+  # shellcheck disable=SC2016  # single quotes keep backticks/brackets literal for grep -F
+  wake_line=$(grep -n -F '`needs-decision [key=<finding-id>]: {one-line summary}`' "$brief" | head -1 | cut -d: -f1)
+  # shellcheck disable=SC2016
+  ask_line=$(grep -n -F 'Call the `ask_user_question` extension tool' "$brief" | head -1 | cut -d: -f1)
+  [ -n "$wake_line" ] || fail "no needs-decision wake line found in generated brief"
+  [ -n "$ask_line" ] || fail "no ask_user_question call line found in generated brief"
+  [ "$wake_line" -lt "$ask_line" ] \
+    || fail "no-mistakes DOD emits needs-decision wake line at line $wake_line but ask_user_question at line $ask_line; wake line must come first or ask_user_question blocks before firstmate wakes"
   pass "fm-brief.sh: no-mistakes ask-user findings present via ask_user_question while keeping the wake line and authority boundary"
 }
 

--- a/tests/fm-brief.test.sh
+++ b/tests/fm-brief.test.sh
@@ -354,6 +354,44 @@ test_no_mistakes_dod_wording() {
   pass "fm-brief.sh: no-mistakes DOD keeps its apostrophe prose, now parse-safe"
 }
 
+# A no-mistakes ask-user finding must be presented through the ask_user_question
+# extension tool AND still append the keyed needs-decision wake line, while the
+# ask-user-authority boundary (the worker never answers its own finding) is
+# preserved. Both halves matter: presentation without the wake line leaves
+# firstmate asleep, and the wake line without presentation buries the question
+# in a status firstmate must relay. The boundary keeps the tool a presentation
+# mechanism, not a license to decide.
+test_no_mistakes_dod_ask_user_presentation() {
+  local home id brief
+  home="$TMP_ROOT/ask-user-presentation-home"
+  mkdir -p "$home/data"
+  id="brief-askuser-e1"
+  FM_HOME="$home" "$ROOT/bin/fm-brief.sh" "$id" some-proj --mode no-mistakes >/dev/null 2>&1
+  brief="$home/data/$id/brief.md"
+  assert_present "$brief" "brief was not scaffolded"
+  assert_grep "Call the \`ask_user_question\` extension tool" "$brief" \
+    "no-mistakes DOD did not instruct the worker to present an ask-user finding via ask_user_question"
+  assert_grep "with the finding's options as the tool's options" "$brief" \
+    "no-mistakes DOD did not carry the finding's options into the ask_user_question options"
+  # shellcheck disable=SC2016  # single quotes are deliberate: the backticks and brackets must stay literal for the fixed-string grep
+  assert_grep '`needs-decision [key=<finding-id>]: {one-line summary}`' "$brief" \
+    "no-mistakes DOD did not keep the keyed needs-decision wake line alongside the presentation"
+  assert_grep "so firstmate's watcher wakes firstmate" "$brief" \
+    "no-mistakes DOD did not state the wake-line purpose"
+  assert_grep "presentation mechanism, not a license to decide" "$brief" \
+    "no-mistakes DOD dropped the ask-user-authority boundary on the presentation tool"
+  assert_grep "stop and wait rather than answering your own finding" "$brief" \
+    "no-mistakes DOD did not forbid the worker from answering its own finding"
+  # The status-line + keyed-decision + resolved contract that rule 6 owns must
+  # still be present unchanged, so the watcher and ask-user-authority paths keep
+  # working alongside the new presentation mechanism.
+  assert_grep "escalate to firstmate (rule 6) and stop" "$brief" \
+    "no-mistakes DOD lost the rule-6 escalation cross-reference"
+  assert_grep "feed it to the gate with \`no-mistakes axi respond\`" "$brief" \
+    "no-mistakes DOD lost the decision-feed-back step"
+  pass "fm-brief.sh: no-mistakes ask-user findings present via ask_user_question while keeping the wake line and authority boundary"
+}
+
 test_ship_project_memory_wording() {
   local home id brief
   home="$TMP_ROOT/project-memory-home"
@@ -760,6 +798,7 @@ test_ship_mode_is_explicit_not_registry
 test_delivery_flags_are_refused_where_they_do_not_apply
 test_faster_paths_use_configured_authority_without_stacked_review
 test_no_mistakes_dod_wording
+test_no_mistakes_dod_ask_user_presentation
 test_ship_project_memory_wording
 test_herdr_lab_contract_is_explicit_and_complete
 test_herdr_lab_contract_quotes_foreign_firstmate_path


### PR DESCRIPTION
## Intent

Fix the no-mistakes ask-user escalation path so a crewmate surfaces ask-user findings through the ask_user_question extension and wakes firstmate, instead of only appending a needs-decision status line. When a no-mistakes run parks on an ask-user finding, the crewmate must: (1) call the ask_user_question extension tool to present the finding as a concise question with the finding's options as the tool's options; (2) still append a needs-decision [key=<finding-id>] status line so firstmate's watcher wakes firstmate; (3) stop and wait rather than answering its own finding. The ask-user-authority boundary is preserved: ask_user_question is a presentation mechanism, not a license to decide; firstmate still owns the decision and a resolved [key=...] line still closes it. Scope is the crewmate instruction surface only: bin/fm-brief.sh no-mistakes definition-of-done block is the one owner of the new mechanism. Rule 6 keyed-decision and resolved contract unchanged. Scout and secondmate scaffolds untouched (scouts never run no-mistakes; secondmate charter carries no crewmate ask-user rule). Non-no-mistakes decisions (ordinary product choices, destructive actions) keep current behavior. Minimal change, one-owner, shellcheck-clean, extend the existing brief-scaffold test. Do not modify the no-mistakes skill, ask-user-authority skill, watcher, live global Pi extension files, or the captain ~/.pi config.

## What Changed

- The no-mistakes definition-of-done block in `bin/fm-brief.sh` now instructs a crewmate to present an ask-user finding through the `ask_user_question` extension tool (with the finding's options as the tool's options), while still appending the keyed `needs-decision [key=<finding-id>]` wake line so firstmate's watcher wakes firstmate.
- The crewmate must append the wake line before calling `ask_user_question` (which blocks until answered) and stop and wait, keeping `ask_user_question` a presentation mechanism and preserving the `ask-user-authority` boundary where firstmate still owns the decision.
- Extended `tests/fm-brief.test.sh` with a new assertion covering the presentation wording, the unchanged rule-6 escalation and decision-feed-back steps, and the wake-line-before-presentation ordering.

## Risk Assessment

✅ Low: Minimal, well-bounded reorder of prompt instruction text plus a generated-brief content/ordering test; the prior escalation deadlock is resolved by emitting the watcher-waking line before the blocking ask_user_question call, with no executable logic or shared state altered.

## Testing

Ran the targeted fm-brief behavior suite (all pass, including the new ask-user presentation test) and generated an actual no-mistakes brief to inspect the rendered DOD a crewmate receives: the needs-decision wake line precedes the ask_user_question call (72 before 73), avoiding the blocking deadlock the review decision mandated, with the authority boundary, rule-6 cross-ref, and axi-respond feed-back step intact. Confirmed the test is a real regression guard (red at base and at the interim call-before-append commit, green at target) and the change stays within the stated scope.

<details>
<summary>Evidence: Rendered no-mistakes brief ask-user DOD bullet (lines 71-77) with wake-line-before-call ordering</summary>

Source: [Rendered no-mistakes brief ask-user DOD bullet (lines 71-77) with wake-line-before-call ordering](https://github.com/aviralmansingka/firstmate/blob/da0b24802227dec99ac31915971e176516ba01aa/.no-mistakes/evidence/fm/nm-askuser-escalation/brief-askuser-rendered.md)

<code>71: ask-user findings are never yours to answer: present them, then escalate to firstmate (rule 6) and stop.&#10;72: Append a `needs-decision [key=&lt;finding-id&gt;]: {one-line summary}` status line so firstmate&#39;s watcher wakes firstmate.&#10;73: Call the `ask_user_question` extension tool to render the finding as a concise question with the finding&#39;s options as the tool&#39;s options.&#10;74: The `ask_user_question` tool is the presentation mechanism, not a license to decide.&#10;75: Firstmate applies `ask-user-authority` and obtains any required captain decision, so stop and wait rather than answering your own finding.&#10;76: When the decision comes back, feed it to the gate with `no-mistakes axi respond` ...&#10;ORDERING: wake line 72 &lt; ask_user_question call 73 -&gt; append-before-call (no deadlock)</code>

```text
You are a crewmate: an autonomous worker agent managed by firstmate. Work on your own; do not wait for a human.

# Task
{TASK}

# Herdr lifecycle declaration - NOT ENABLED
**HARD SAFETY GATE:** this scaffold cannot inspect the task text filled in above.
If the task will start, stop, delete, restart, profile, or otherwise drive Herdr lifecycle behavior, stop and regenerate the brief with `--herdr-lab` before dispatch.
Do not add Herdr lifecycle commands to this unguarded brief by hand.

# Setup
You are in a disposable git worktree of some-proj, at a detached HEAD on a clean default branch.

**Verify isolation before anything else.** Run `pwd -P` and `git rev-parse --show-toplevel`; both must resolve to the disposable task worktree you were launched in, such as a treehouse pool path or an Orca-managed worktree, not the primary checkout firstmate operates from.
The path check is authoritative: `git rev-parse --git-dir` and `git rev-parse --git-common-dir` can help inspect the repo, but they do not prove you are outside the primary checkout.
If the top-level path is the primary checkout or not the worktree you were launched in, STOP - do not branch or commit here - append `blocked: launched in primary checkout, not an isolated worktree` to the status file and stop.

1. First action: create your branch: `git checkout -b fm/brief-askuser-test`
2. Run `no-mistakes doctor`; if it reports the repo is not initialized here, run `no-mistakes init`.

# Rules
1. Never push to the default branch. Never merge a PR.
2. Stay inside this worktree; modify nothing outside it.
3. Use gh-axi for GitHub operations and chrome-devtools-axi for browser operations.
4. Report status by appending one line:
   `echo "{state}: {one short line}" >> '/var/folders/dn/m1fcqssd46758319qbfv5j5c0000gn/T/tmp.whk9RhGnkZ/state/brief-askuser-test.status'`
   States: working, needs-decision, blocked, paused, done, failed.
   Each append wakes firstmate, so report sparingly: only phase changes a supervisor
   would act on (setup done, bug reproduced, fix implemented, validation passed) and the
   needs-decision/blocked/paused/done/failed states. No step-by-step FYI progress lines;
   firstmate reads your pane for that.
   A mid-task `working:` line (including setup complete) is nonterminal: do not end the
   turn after it; continue the same stage until a defined `done:` gate under Definition of done.
   Use `paused: {why}` - distinct from `blocked:` - ONLY when you are deliberately idling on a
   known external wait you expect to clear on its own (an upstream release, a rate-limit reset,
   a scheduled window): firstmate then leaves your idle pane alone and rechecks it on a long
   cadence instead of treating it as a possible wedge. Use `blocked:` when you are stuck and need help.
5. If you hit the same obstacle twice, append `blocked: {why}` and stop; firstmate will help.
6. If a decision belongs above the implementation worker (product choices, destructive actions, ask-user findings),
   append `needs-decision: {summary of options}` and stop. Firstmate will reply with the decision.
   A decision or blocker you opened stays open until a `resolved` line carrying its exact key lands; a later `done:` or `working:` line never closes it, even when the answer is what started that work.
   Firstmate's reply normally writes that closing line at answer time; when a blocker or wait clears WITHOUT a firstmate reply, append `resolved: {how it cleared}` yourself (same `[key=<slug>]` if you opened it with one) as you resume.
7. Never stop, restart, or update the shared `no-mistakes` daemon - it is one instance serving
   every lane/home, so restarting it kills other lanes' in-flight pipeline runs. On ANY no-mistakes
   daemon error, append `blocked: {the daemon error}` and stop; only firstmate manages the daemon.

# Firstmate instruction inbox
Firstmate steers you through durable message files in '/var/folders/dn/m1fcqssd46758319qbfv5j5c0000gn/T/tmp.whk9RhGnkZ/state/brief-askuser-test.inbox'.
When a terminal message says an instruction is waiting there - and at any natural checkpoint when you are unsure - list '/var/folders/dn/m1fcqssd46758319qbfv5j5c0000gn/T/tmp.whk9RhGnkZ/state/brief-askuser-test.inbox'/*.msg, read and act on each message in numeric order, then acknowledge each handled message by moving it: `mv '/var/folders/dn/m1fcqssd46758319qbfv5j5c0000gn/T/tmp.whk9RhGnkZ/state/brief-askuser-test.inbox'/NNN.msg '/var/folders/dn/m1fcqssd46758319qbfv5j5c0000gn/T/tmp.whk9RhGnkZ/state/brief-askuser-test.inbox'/handled/`.
The move IS the acknowledgement: without it firstmate rings again and eventually treats you as stuck. An empty or absent inbox needs no action.

# Project memory
If `AGENTS.md` or `CLAUDE.md` already exists, or if this task produced durable project-intrinsic knowledge, run `/Users/aviral/.no-mistakes/worktrees/ed00a6ed041c/01M10556Q70TM9KZ4HYBC4QYGS/bin/fm-ensure-agents-md.sh .` in the worktree.
Record only project knowledge useful to almost every future session.
For anything the codebase already shows, prefer a pointer to the authoritative file, command, or doc over copying the detail.
If you touch a project `AGENTS.md` that lacks `## Maintaining this file`, add that short self-governance section from `/Users/aviral/.no-mistakes/worktrees/ed00a6ed041c/01M10556Q70TM9KZ4HYBC4QYGS/bin/fm-ensure-agents-md.sh` in the same pass.
Keep it proportionate: skip `AGENTS.md` edits for trivial tasks that produced no durable project knowledge.

# Definition of done
Delivery contract: mode=no-mistakes
The task is complete only when committed on your branch.
When you believe it is complete, append `done: {summary}` to the status file and stop.
Firstmate will then instruct you to run /no-mistakes to validate and ship a PR.

You drive no-mistakes by responding to its gates, not by implementing fixes.
Follow the guidance no-mistakes itself provides for the mechanics: it loads when you invoke /no-mistakes, and `no-mistakes axi run --help` plus the `help` lines in each `axi` response are authoritative and version-matched to the installed binary.
When starting no-mistakes, make `--intent` preserve all relevant content from this brief's `# Task` section plus every later accepted Firstmate requirement, clarification, constraint, exclusion, and supersession, carrying only each requirement's current accepted form; retain direct requirements instead of substituting a diff summary, and exclude generic operational, status, delivery, and other scaffold boilerplate unless it is task-specific.
Do not hand-edit, commit, or fix findings yourself while a run is active - the pipeline applies every fix.

Two firstmate-specific rules layer on top of that guidance:
- ask-user findings are never yours to answer: present them, then escalate to firstmate (rule 6) and stop.
  Append a `needs-decision [key=<finding-id>]: {one-line summary}` status line so firstmate's watcher wakes firstmate.
  Call the `ask_user_question` extension tool to render the finding as a concise question with the finding's options as the tool's options.
  The `ask_user_question` tool is the presentation mechanism, not a license to decide.
  Firstmate applies `ask-user-authority` and obtains any required captain decision, so stop and wait rather than answering your own finding.
  When the decision comes back, feed it to the gate with `no-mistakes axi respond` and let the pipeline apply it - do not route the question to "the user" or implement the fix yourself.
- Avoid `--yes`: it would silently bypass firstmate's authority check and any required captain escalation.

After /no-mistakes reports CI green (the CI-ready return point - do not wait for it to keep monitoring in the background until merge), append `done: PR {url} checks green` and stop. You are finished.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"723ff4b872befca47ed0aae274dc3a8ef5fab8a9","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bash tests/fm-brief.test.sh (full suite, incl. new test_no_mistakes_dod_ask_user_presentation)`
- `FM_HOME=$TMP bin/fm-brief.sh brief-askuser-test some-proj --mode no-mistakes -> generated brief, inspected rendered ask-user DOD bullet lines 71-77`
- `ordering assertion: grep -n -F needs-decision wake line (72) vs ask_user_question call line (73); 72<73 confirms append-before-call`
- `regression proof: git show 60bedde:bin/fm-brief.sh (no ask_user_question at all) and git show 75697a1 (call-before-append, deadlock) both fail the new test's presence+ordering assertions`
- `scope check: git diff --name-only 60bedde 723ff4b -> only bin/fm-brief.sh + tests/fm-brief.test.sh; rule 6 keyed-decision line byte-identical; scout/secondmate scaffolds untouched`
- `git status --porcelain clean (no transient artifacts left in worktree)`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
